### PR TITLE
overlord/snapstate, wrappers: manpages!

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -84,6 +84,7 @@ var (
 	SnapAuxStoreInfoDir string
 
 	SnapBinariesDir     string
+	SnapManpagesDir     string
 	SnapServicesDir     string
 	SnapUserServicesDir string
 	SnapSystemdConfDir  string
@@ -298,6 +299,7 @@ func SetRootDir(rootdir string) {
 	SnapRollbackDir = filepath.Join(rootdir, snappyDir, "rollback")
 
 	SnapBinariesDir = filepath.Join(SnapMountDir, "bin")
+	SnapManpagesDir = filepath.Join(SnapMountDir, "man")
 	SnapServicesDir = filepath.Join(rootdir, "/etc/systemd/system")
 	SnapUserServicesDir = filepath.Join(rootdir, "/etc/systemd/user")
 	SnapSystemdConfDir = filepath.Join(rootdir, "/etc/systemd/system.conf.d")

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -160,6 +160,11 @@ func generateWrappers(s *snap.Info, disabledSvcs []string) error {
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapBinaries)
 
+	if err = wrappers.AddSnapManpages(s); err != nil {
+		return err
+	}
+	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapManpages)
+
 	// add the daemons from the snap.yaml
 	if err = wrappers.AddSnapServices(s, disabledSvcs, progress.Null); err != nil {
 		return err
@@ -204,7 +209,12 @@ func removeGeneratedWrappers(s *snap.Info, meter progress.Meter) error {
 		logger.Noticef("Cannot remove desktop icons for %q: %v", s.InstanceName(), err4)
 	}
 
-	return firstErr(err1, err2, err3, err4)
+	err5 := wrappers.RemoveSnapManpages(s)
+	if err5 != nil {
+		logger.Noticef("Cannot remove manpages for %q: %v", s.InstanceName(), err5)
+	}
+
+	return firstErr(err1, err2, err3, err4, err5)
 }
 
 // UnlinkSnap makes the snap unavailable to the system removing wrappers and symlinks.

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -463,6 +463,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 // StartUp implements StateStarterUp.Startup.
 func (m *SnapManager) StartUp() error {
 	writeSnapReadme()
+	// TODO: writeSnapManpageRreadme
 
 	m.state.Lock()
 	defer m.state.Unlock()

--- a/wrappers/manpages.go
+++ b/wrappers/manpages.go
@@ -1,0 +1,104 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package wrappers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/snap"
+	"syscall"
+)
+
+func AddSnapManpages(s *snap.Info) error {
+	snapManRoot := filepath.Join(s.MountDir(), "meta", "man")
+	inSnapPrefix := s.SnapName() + "."
+	onDiskPrefix := s.InstanceName() + "."
+	return filepath.Walk(snapManRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			// TODO: support in-snap symlinks
+			return nil
+		}
+		dir, base := filepath.Split(path[len(snapManRoot):])
+		if !strings.HasPrefix(base, inSnapPrefix) {
+			return nil
+		}
+		targetDir := filepath.Join(dirs.SnapManpagesDir, dir)
+		if err := os.MkdirAll(targetDir, 0755); err != nil {
+			return err
+		}
+		target := filepath.Join(targetDir, onDiskPrefix+base[len(inSnapPrefix):])
+		err = os.Symlink(path, target)
+		if os.IsExist(err) {
+			// can happen during a Retry of LinkSnap
+			err = os.Remove(target)
+			if err == nil {
+				err = os.Symlink(path, target)
+			}
+		}
+		return err
+	})
+}
+
+// removeUp removes the file at the given path and all directories above it
+// until "stop" is reached, bailing at first error. "stop" is not removed.
+//
+// if the error is because a directory being removed is not empty, return nil,
+// otherwise return the error
+//
+// TODO: move to osutil? wrap error in os.PathError?
+// XXX: TEST ME MORE
+func removeUp(path, stop string) error {
+	err := syscall.Unlink(path)
+	for err == nil {
+		path = filepath.Dir(path)
+		if path == stop {
+			break
+		}
+		err = syscall.Rmdir(path)
+	}
+	if err == syscall.ENOTEMPTY {
+		return nil
+	}
+	return err
+}
+
+func RemoveSnapManpages(s *snap.Info) error {
+	pfx := s.MountDir()
+	return filepath.Walk(dirs.SnapManpagesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// ignore walk errors
+			return nil
+		}
+		str, err := os.Readlink(path)
+		if err != nil {
+			return nil
+		}
+		if strings.HasPrefix(str, pfx) {
+			return removeUp(path, dirs.SnapManpagesDir)
+		}
+		return nil
+	})
+}

--- a/wrappers/manpages_test.go
+++ b/wrappers/manpages_test.go
@@ -1,0 +1,131 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package wrappers_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/wrappers"
+)
+
+type manpagesTestSuite struct {
+	testutil.BaseTest
+	tempdir string
+}
+
+var _ = Suite(&manpagesTestSuite{})
+
+func (s *manpagesTestSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+	s.tempdir = c.MkDir()
+	dirs.SetRootDir(s.tempdir)
+}
+
+func (s *manpagesTestSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *manpagesTestSuite) TestAddSnapManpages(c *C) {
+	// fake the thing
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(11)})
+	manpage := filepath.Join(info.MountDir(), "meta", "man", "fr.UTF-8", "man1", "hello-snap.foo.1.gz")
+	c.Assert(os.MkdirAll(filepath.Dir(manpage), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(manpage, []byte("canary"), 0644), IsNil)
+	manpageFile := filepath.Join(dirs.SnapManpagesDir, "fr.UTF-8", "man1", "hello-snap.foo.1.gz")
+
+	// sanity check
+	c.Check(manpageFile, symlinkAbsent)
+
+	// the actual test
+	c.Assert(wrappers.AddSnapManpages(info), IsNil)
+	c.Check(manpageFile, symlinkPresent)
+	c.Check(manpageFile, testutil.FileEquals, "canary")
+}
+
+func (s *manpagesTestSuite) TestRemoveSnapManpages(c *C) {
+	// fake the thing
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(11)})
+	manpageFile := filepath.Join(dirs.SnapManpagesDir, "fr.UTF-8", "man1", "hello-snap.foo.1.gz")
+	c.Assert(os.MkdirAll(filepath.Dir(manpageFile), 0755), IsNil)
+	c.Assert(os.Symlink(filepath.Join(info.MountDir(), "meta", "man", "foo"), manpageFile), IsNil)
+
+	// sanity check
+	c.Check(manpageFile, symlinkPresent)
+
+	// the actual test
+	c.Assert(wrappers.RemoveSnapManpages(info), IsNil)
+	c.Check(manpageFile, symlinkAbsent)
+}
+
+// helper things, find a good name and put it in testutil or sth
+type symlinkPresentChecker struct{ *CheckerInfo }
+
+var symlinkPresent Checker = &symlinkPresentChecker{CheckerInfo: &CheckerInfo{Name: "symlinkPresent", Params: []string{"filename"}}}
+
+func (c *symlinkPresentChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	filename, ok := params[0].(string)
+	if !ok {
+		return false, "filename must be a string"
+	}
+	info, err := os.Lstat(filename)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Sprintf("cannot lstat %q: %v", filename, err)
+		}
+		return false, fmt.Sprintf("%q does not exist", filename)
+	}
+	if (info.Mode() & os.ModeSymlink) == 0 {
+		return false, fmt.Sprintf("%q exists but is not a symlink", filename)
+	}
+	return true, ""
+}
+
+type symlinkAbsentChecker struct{ *CheckerInfo }
+
+var symlinkAbsent Checker = &symlinkAbsentChecker{CheckerInfo: &CheckerInfo{Name: "symlinkAbsent", Params: []string{"filename"}}}
+
+func (c *symlinkAbsentChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	filename, ok := params[0].(string)
+	if !ok {
+		return false, "filename must be a string"
+	}
+	info, err := os.Lstat(filename)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Sprintf("cannot lstat %q: %v", filename, err)
+		}
+		return true, ""
+	}
+	if (info.Mode() & os.ModeSymlink) == 0 {
+		return false, fmt.Sprintf("%q exists (not as a symlink)", filename)
+	}
+	return false, fmt.Sprintf("%q exists (as a symlink)", filename)
+}


### PR DESCRIPTION
This is a rough draft of a first pass at manpages support.

This works by creating a `man` directory next to the snappy `bin`
directory (i.e. a `/snap/man` to go with `/snap/bin`, in Ubuntu); if
the latter is on your `$PATH`, then man will pick up manpages that are
in the former.

Right now it only sets things up for files that start with the snap
name. A second pass would be to add also support for aliases. Also it
only considers files, whereas often manpages will be symlinks. We
should support manpages symlinking to other things as long as they are
in the same snap, at least.

---

It works! But needs a few things before being production-ready:

* more and better unit tests
* a spread test

but I'm stopping here. Hopefully this is enough...
