### PR TITLE
dirs: manjaro-arm is like manjaro

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -240,7 +240,7 @@ func SetRootDir(rootdir string) {
 	GlobalRootDir = rootdir
 
 	isInsideBase, _ := isInsideBaseSnap()
-	if !isInsideBase && release.DistroLike("fedora", "arch", "archlinux", "manjaro", "antergos") {
+	if !isInsideBase && release.DistroLike("fedora", "arch", "archlinux", "manjaro", "manjaro-arm", "antergos") {
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)


### PR DESCRIPTION
Manjaro-arm is the aarch64 build of Manjaro and should behave the same.
The distributor did not choose to use ID_LIKE=manjaro and while that
decision may happen over time, this patch fixes snaps in that
environment.

Forum: https://forum.snapcraft.io/t/15242
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
