### PR TITLE
data, packaging: Add sudoers snippet to allow snaps to be run with sudo

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -5,3 +5,4 @@ all install clean:
 	$(MAKE) -C dbus $@
 	$(MAKE) -C env $@
 	$(MAKE) -C desktop $@
+	$(MAKE) -C sudo $@

--- a/data/sudo/99-snapd.conf.in
+++ b/data/sudo/99-snapd.conf.in
@@ -1,0 +1,3 @@
+# Allow snap-provided applications to work with sudo
+
+Defaults    secure_path += @SNAP_MOUNT_DIR@/bin

--- a/data/sudo/Makefile
+++ b/data/sudo/Makefile
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2020 Neal Gompa <ngompa13@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+SNAP_MOUNT_DIR := /snap
+SUDOERD := /etc/sudoers.d
+
+%.conf: %.conf.in
+	sed   < $< > $@ \
+		s:@SNAP_MOUNT_DIR@:${SNAP_MOUNT_DIR}:g
+
+GENERATED = 99-snapd.conf
+
+all: ${GENERATED}
+.PHONY: all
+
+install: ${GENERATED}
+	# NOTE: old (e.g. 14.04) GNU coreutils doesn't -D with -t
+	install -d -m 0755 ${DESTDIR}/${SUDOERD}
+	install -m 0644 -t ${DESTDIR}/${SUDOERD} $^
+.PHONY: install
+
+clean:
+	$(RM) ${GENERATED}
+.PHONY: clean

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -540,6 +540,7 @@ install -d -p %{buildroot}%{_systemd_system_env_generator_dir}
 install -d -p %{buildroot}%{_unitdir}
 install -d -p %{buildroot}%{_sysconfdir}/profile.d
 install -d -p %{buildroot}%{_sysconfdir}/sysconfig
+install -d -p %{buildroot}%{_sysconfdir}/sudoers.d
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/assertions
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/cookie
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/desktop/applications
@@ -724,6 +725,7 @@ popd
 %{_libexecdir}/snapd/etelpmoc.sh
 %{_libexecdir}/snapd/snapd.run-from-snap
 %{_sysconfdir}/profile.d/snapd.sh
+%{_sysconfdir}/sudoers.d/99-snapd.conf
 %{_mandir}/man8/snapd-env-generator.8*
 %{_systemd_system_env_generator_dir}/snapd-env-generator
 %{_unitdir}/snapd.socket

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -338,6 +338,7 @@ fi
 %config %{_sysconfdir}/permissions.d/snapd
 %config %{_sysconfdir}/permissions.d/snapd.paranoid
 %config %{_sysconfdir}/profile.d/snapd.sh
+%config %{_sysconfdir}/sudoers.d/99-snapd.conf
 
 # Directories
 %dir %attr(0111,root,root) %{_sharedstatedir}/snapd/void


### PR DESCRIPTION
Generally speaking, applications provided as snaps should behave in all the same ways that native packages should, and that includes being usable with `sudo(8)`. In order for this to work, we need to configure `sudo` to add the snap binary directory to the search path.

Resolves: [RH#1691996](https://bugzilla.redhat.com/1691996)

Signed-off-by: Neal Gompa <ngompa13@gmail.com>