### PR TITLE
daemon: Allow clients to call /v2/logout via Polkit

### DIFF
--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -48,8 +48,9 @@ var (
 	}
 
 	logoutCmd = &Command{
-		Path: "/v2/logout",
-		POST: logoutUser,
+		Path:     "/v2/logout",
+		POST:     logoutUser,
+		PolkitOK: "io.snapcraft.snapd.login",
 	}
 
 	// backwards compat; to-be-deprecated


### PR DESCRIPTION
/v2/logout was added in e35c869d, but doesn't have allow Polkit access like
/v2/login does. This change gives it the same access as a client that is
allowed to login should also be allowed to logout.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
