### PR TITLE
tests/lib/prepare-restore: Revert "Continue on errors updating or installing dependencies"

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -270,9 +270,7 @@ prepare_project() {
 
     create_test_user
 
-    if ! distro_update_package_db; then
-        echo "Error updating the package db, continue with the system preparation"
-    fi
+    distro_update_package_db
 
     if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
         # perform system upgrade on Arch so that we run with most recent kernel
@@ -376,9 +374,7 @@ prepare_project() {
             ;;
     esac
 
-    if ! install_pkg_dependencies; then
-        echo "Error installing test dependencies, continue with the system preparation"
-    fi
+    install_pkg_dependencies
 
     # We take a special case for Debian/Ubuntu where we install additional build deps
     # base on the packaging. In Fedora/Suse this is handled via mock/osc


### PR DESCRIPTION
This reverts commit 121e5770be21afb8ba74d7a7c9e411e03f7c4eff.

Now that we can move distros with flaky repositories to unstable systems, this
should no longer be needed. As a side effect, we might have missed some errors
in project prepare.

