### PR TITLE
features: enable robust mount ns updates

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -76,7 +76,8 @@ var featureNames = map[SnapdFeature]string{
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
 var featuresEnabledWhenUnset = map[SnapdFeature]bool{
-	Layouts: true,
+	Layouts:                     true,
+	RobustMountNamespaceUpdates: true,
 }
 
 // featuresExported contains a set of features that are exported outside of snapd.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -95,7 +95,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.PerUserMountNamespace.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.RefreshAppAwareness.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.ClassicPreservesXdgRuntimeDir.IsEnabledWhenUnset(), Equals, false)
-	c.Check(features.RobustMountNamespaceUpdates.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.RobustMountNamespaceUpdates.IsEnabledWhenUnset(), Equals, true)
 }
 
 func (*featureSuite) TestControlFile(c *C) {


### PR DESCRIPTION
A while ago we enabled this for select customers. We should enable this
globally now as this feature genuinely improves robustness for a certain
class of mount namespace operations.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
