### PR TITLE
interfaces/greengrass-support: add /dev/null -> /proc/latency_stats mount

### DIFF
--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -251,6 +251,10 @@ mount options=(rw, bind) /dev/null -> /proc/kcore,
 mount options=(rw, bind) /dev/null -> /proc/sched_debug,
 mount options=(rw, bind) /dev/null -> /proc/timer_stats,
 
+# greengrass will also mount over /proc/latency_stats when running on
+# kernels configured with CONFIG_LATENCYTOP set
+mount options=(rw, bind) /dev/null -> /proc/latency_stats,
+
 # umounts for tearing down containers
 umount /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/*/**,
 


### PR DESCRIPTION
[Bug-1862007](https://bugs.launchpad.net/snapd/+bug/1862007): 'aws-iot-greengrass' snap fails to start due to apparmor deny on mounting of "/proc/latency_stats". [interface/greengrass-support]

**Problem Summary**

'aws-iot-greengrass' snap fails to start. I am not sure why nobody has reported this problem so far.

**Fix Summary**

Added a mount rule to allow runc/libcontainer to mask path '/proc/latency_stats' by allowing to mount '/dev/null' onto it.

**Error**

Lambda container fails to start. I think the error is originating from runc/libcontainer

    $ sudo tail /var/snap/aws-iot-greengrass/current/ggc-writable/var/log/system/runtime.log

    Runtime execution error: unable to start lambda container: failed to run container sandbox: container_linux.go:344: starting container process caused "process_linux.go:424: container init caused \"mask path /proc/latency_stats: permission denied\""

**Root Cause**

Snap's apparmor profile doesn't allow mask mounting the path `/proc/latency_stat`

    $ sudo journalctl --system -k | grep apparmor

    localhost kernel: audit: type=1400 audit(1580900786.074:19): apparmor="DENIED" operation="mount" info="failed flags match" error=-13 profile="snap.aws-iot-greengrass.greengrassd" name="/proc/latency_stats" pid=1309 comm="runc:[2:INIT]" srcname="/dev/null" flags="rw, bind"

**System Information**

Ubuntu

    $ uname -a

    Linux localhost 4.15.0-1054-raspi2 #58-Ubuntu SMP PREEMPT Wed Jan 15 19:28:59 UTC 2020 armv7l armv7l armv7l GNU/Linux

Snap

    $ snap --version

    snap 2.42.5
    snapd 2.42.5
    series 16
    kernel 4.15.0-1054-raspi2

AWS IoT Greengrass Snap

    $ snap info aws-iot-greengrass

    name: aws-iot-greengrass
    services:
      aws-iot-greengrass.greengrassd: forking, enabled, active
    snap-id: SRDuhPJGj4XPxFNNZQKOTvURAp0wxKnd
    tracking: stable
    refresh-date: yesterday at 10:28 UTC
    channels:
      stable: 1.8.0 2019-04-01 (3) 167MB -
      candidate: 1.8.0 2019-03-29 (3) 167MB -
      beta: 1.8.0 2019-03-29 (3) 167MB -
      edge: 1.8.0 2019-03-29 (3) 167MB -
    installed: 1.8.0 (3) 167MB -

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
