### PR TITLE
cmd/snap-confine: detect base transitions on core16

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -453,16 +453,15 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 			value = SC_DISCARD_SHOULD;
 			value_str = "should";
 
-			// The namespace is stale so also check if we must discard it due to the
-			// base snap changing. If the base snap changed, we must discard since even
-			// though currently running processes from this snap will continue to see
-			// the old base, we want new processes to use the new base. See LP:
-			// #1819875 for details.
-			if (is_base_transition(inv)) {
-				// The base snap has changed. We must discard ...
-				value = SC_DISCARD_MUST;
-				value_str = "must";
-			}
+		}
+		// If the base snap changed, we must discard the mount namespace and
+		// start over to allow the newly started process to see the requested
+		// base snap. Due to the TODO above always perform explicit transition
+		// check to protect against LP:#1819875 and LP:#1861901
+		if (is_base_transition(inv)) {
+			// The base snap has changed. We must discard ...
+			value = SC_DISCARD_MUST;
+			value_str = "must";
 		}
 		// Send this back to the parent: 3 - force discard 2 - prefer discard, 1 - keep.
 		// Note that we cannot just use 0 and 1 because of the semantics of eventfd(2).

--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -1,4 +1,7 @@
 summary: A snap migrates from base "core" to "core18"
+environment:
+    DIRECTION/forward: forward
+    DIRECTION/back: back
 
 prepare: |
   snap install core18
@@ -6,51 +9,102 @@ prepare: |
   snap pack "$TESTSLIB/snaps/test-snapd-core-migration.base-core18"
 
 execute: |
-  # When we install a snap that is using (implicitly) base: core, then that
-  # snap runs on top of the core16 runtime environment. This can be seen by
-  # looking at the os-release file which will match that of ubuntu core 16.
-  snap install --dangerous test-snapd-core-migration_1_all.snap
-  su test -c 'snap run test-snapd-core-migration.sh -c "cat /usr/lib/os-release"' | MATCH 'VERSION_ID="16"'
+  case "$DIRECTION" in
+    forward)
+      # When we install a snap that is using (implicitly) base: core, then that
+      # snap runs on top of the core16 runtime environment. This can be seen by
+      # looking at the os-release file which will match that of ubuntu core 16.
+      snap install --dangerous test-snapd-core-migration_1_all.snap
+      su test -c 'snap run test-snapd-core-migration.sh -c "cat /usr/lib/os-release"' | MATCH 'VERSION_ID="16"'
 
-  # The mount namespace information file is owned by root.root and has mode 0644
-  # even though the user invoking the snap command was non-root.
-  MATCH 'base-snap-name=core' < /run/snapd/ns/snap.test-snapd-core-migration.info
-  test "$(stat -c '%u.%g' /run/snapd/ns/snap.test-snapd-core-migration.info)" = 0.0
-  test "$(stat -c '%a'    /run/snapd/ns/snap.test-snapd-core-migration.info)" = 644
+      # The mount namespace information file is owned by root.root and has mode 0644
+      # even though the user invoking the snap command was non-root.
+      MATCH 'base-snap-name=core' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      test "$(stat -c '%u.%g' /run/snapd/ns/snap.test-snapd-core-migration.info)" = 0.0
+      test "$(stat -c '%a'    /run/snapd/ns/snap.test-snapd-core-migration.info)" = 644
 
-  # When said snap is refreshed to use "base: core18" then, because there are
-  # no active processes in that snap, the base will change correctly to core18.
-  # This can be again observed by looking at the os-release file.
-  snap install --dangerous test-snapd-core-migration_2_all.snap
-  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
-  MATCH 'base-snap-name=core18' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      # When said snap is refreshed to use "base: core18" then, because there are
+      # no active processes in that snap, the base will change correctly to core18.
+      # This can be again observed by looking at the os-release file.
+      snap install --dangerous test-snapd-core-migration_2_all.snap
+      test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
+      MATCH 'base-snap-name=core18' < /run/snapd/ns/snap.test-snapd-core-migration.info
 
-  # If we rewind and do the update again, this time allowing one of the apps
-  # from the core16 world to keep running. Normally this would hold the update
-  # of the base snap, as seen by the processes of the application snap. This
-  # ensures that all processes in a given snap see a consistent view of the
-  # filesystem.
-  snap remove --purge test-snapd-core-migration
-  snap install --dangerous test-snapd-core-migration_1_all.snap
-  test-snapd-core-migration.sh -c "exec sleep 1h" &
-  pid=$!
-  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
-  MATCH 'base-snap-name=core' < /run/snapd/ns/snap.test-snapd-core-migration.info
-  snap install --dangerous test-snapd-core-migration_2_all.snap
-  # With core -> core18 migration this doesn't work however, as now
-  # applications that were expecting to use core18 libraries would be forced to
-  # run on top of core16.
-  #
-  # Therefore, to ensure compatibility, even before the background process
-  # terminates we are now using the new base snap, processes across base snaps
-  # see different mount namespaces.
-  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
-  MATCH 'base-snap-name=core18' < /run/snapd/ns/snap.test-snapd-core-migration.info
-  kill "$pid"
-  wait "$pid" || true  # wait returns the exit code and we kill the process
-  # Nothing changes after the background app terminates.
-  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
-  MATCH 'base-snap-name=core18' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      # If we rewind and do the update again, this time allowing one of the apps
+      # from the core16 world to keep running. Normally this would hold the update
+      # of the base snap, as seen by the processes of the application snap. This
+      # ensures that all processes in a given snap see a consistent view of the
+      # filesystem.
+      snap remove --purge test-snapd-core-migration
+      snap install --dangerous test-snapd-core-migration_1_all.snap
+      test-snapd-core-migration.sh -c "exec sleep 1h" &
+      pid=$!
+      test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
+      MATCH 'base-snap-name=core' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      snap install --dangerous test-snapd-core-migration_2_all.snap
+      # With core -> core18 migration this doesn't work however, as now
+      # applications that were expecting to use core18 libraries would be forced to
+      # run on top of core16.
+      #
+      # Therefore, to ensure compatibility, even before the background process
+      # terminates we are now using the new base snap, processes across base snaps
+      # see different mount namespaces.
+      test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
+      MATCH 'base-snap-name=core18' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      kill "$pid"
+      wait "$pid" || true  # wait returns the exit code and we kill the process
+      # Nothing changes after the background app terminates.
+      test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
+      MATCH 'base-snap-name=core18' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      ;;
+    back)
+      # When we install a snap that is using (explicitly) base: core18, then that
+      # snap runs on top of the core18 runtime environment. This can be seen by
+      # looking at the os-release file which will match that of ubuntu core 18.
+      snap install --dangerous test-snapd-core-migration_2_all.snap
+      su test -c 'snap run test-snapd-core-migration.sh -c "cat /usr/lib/os-release"' | MATCH 'VERSION_ID="18"'
+
+      # The mount namespace information file is owned by root.root and has mode 0644
+      # even though the user invoking the snap command was non-root.
+      MATCH 'base-snap-name=core18' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      test "$(stat -c '%u.%g' /run/snapd/ns/snap.test-snapd-core-migration.info)" = 0.0
+      test "$(stat -c '%a'    /run/snapd/ns/snap.test-snapd-core-migration.info)" = 644
+
+      # When said snap is refreshed to use core (implicitly) then, because there are
+      # no active processes in that snap, the base will change correctly to core.
+      # This can be again observed by looking at the os-release file.
+      snap install --dangerous test-snapd-core-migration_1_all.snap
+      test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
+      MATCH 'base-snap-name=core' < /run/snapd/ns/snap.test-snapd-core-migration.info
+
+      # If we rewind and do the update again, this time allowing one of the apps
+      # from the core18 world to keep running. Normally this would hold the update
+      # of the base snap, as seen by the processes of the application snap. This
+      # ensures that all processes in a given snap see a consistent view of the
+      # filesystem.
+      snap remove --purge test-snapd-core-migration
+      snap install --dangerous test-snapd-core-migration_2_all.snap
+      test-snapd-core-migration.sh -c "exec sleep 1h" &
+      pid=$!
+      test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
+      MATCH 'base-snap-name=core18' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      snap install --dangerous test-snapd-core-migration_1_all.snap
+      # With core18 -> core migration this doesn't work however, as now
+      # applications that were expecting to use core libraries would be forced to
+      # run on top of core18.
+      #
+      # Therefore, to ensure compatibility, even before the background process
+      # terminates we are now using the new base snap, processes across base snaps
+      # see different mount namespaces.
+      test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
+      MATCH 'base-snap-name=core' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      kill "$pid"
+      wait "$pid" || true  # wait returns the exit code and we kill the process
+      # Nothing changes after the background app terminates.
+      test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
+      MATCH 'base-snap-name=core' < /run/snapd/ns/snap.test-snapd-core-migration.info
+      ;;
+  esac
 
 restore: |
 


### PR DESCRIPTION
The base staleness detector is not supported on core16 and while this
patch does not change that we now have another tool in our arsenal: base
transition detector. That detector is much simpler and can only detect
"big" changes, such as going from one base to another (but not between
revisions of the same base). Fortunately it is sufficient to address
this problem.

The same patch generalizes an existing test to verify base snap
migration in both directions, forward as well as back (back correctly
reproduces the issue reported).

Fixes: https://bugs.launchpad.net/snapd/+bug/1861901
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
