### PR TITLE
 tests: repack the initramfs + kernel snap for UC20 spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -77,7 +77,7 @@ backends:
                 image: ubuntu-16.04-64
                 workers: 6
             - ubuntu-core-20-64:
-                image: ubuntu-1804-64-uefi-enabled
+                image: ubuntu-2004-64-virt-uefi-enabled
                 workers: 6
                 storage: 20G
 

--- a/tests/core20/basic/task.yaml
+++ b/tests/core20/basic/task.yaml
@@ -28,3 +28,7 @@ execute: |
     # TODO:UC20: also check for /boot/grub/kernel.efi symlink once it's there
     echo "Check that we have an extracted kernel"
     test -e /boot/grub/pc-kernel*/kernel.efi
+
+    # ensure that our the-tool (and thus our snap-bootstrap ran)
+    echo "Check that we booted with the rebuilt initramfs in the kernel snap"
+    test -e /writable/system-data/the-tool-ran

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -833,6 +833,8 @@ EOF
         setup_core_for_testing_by_modify_writable "$UNPACK_DIR"
     fi
 
+    umount /mnt
+
     # the reflash magic
     # FIXME: ideally in initrd, but this is good enough for now
     cat > "$IMAGE_HOME/reflash.sh" << EOF

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -637,8 +637,6 @@ EOF
 
     (cd /tmp ; unsquashfs -no-progress -v  /var/lib/snapd/snaps/"$core_name"_*.snap etc/systemd/system)
     cp -avr /tmp/squashfs-root/etc/systemd/system /mnt/system-data/etc/systemd/
-    umount /mnt
-    kpartx -d  "$IMAGE_HOME/$IMAGE"
 }
 
 setup_reflash_magic() {
@@ -842,7 +840,9 @@ EOF
         setup_core_for_testing_by_modify_writable "$UNPACK_DIR"
     fi
 
+    # unmount the partition we just modified and delete the image's loop devices
     umount /mnt
+    kpartx -d "$IMAGE_HOME/$IMAGE"
 
     # the reflash magic
     # FIXME: ideally in initrd, but this is good enough for now

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -819,14 +819,18 @@ fi
 EOF
     chmod +x "$IMAGE_HOME/reflash.sh"
 
+    DEVPREFIX=""
+    if is_core20_system; then
+        DEVPREFIX="/boot"
+    fi
     # extract ROOT from /proc/cmdline
     ROOT=$(sed -e 's/^.*root=//' -e 's/ .*$//' /proc/cmdline)
     cat >/boot/grub/grub.cfg <<EOF
 set default=0
 set timeout=2
 menuentry 'flash-all-snaps' {
-linux /vmlinuz root=$ROOT ro init=$IMAGE_HOME/reflash.sh console=ttyS0
-initrd /initrd.img
+linux $DEVPREFIX/vmlinuz root=$ROOT ro init=$IMAGE_HOME/reflash.sh console=ttyS0
+initrd $DEVPREFIX/initrd.img
 }
 EOF
 }

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -434,117 +434,50 @@ EOF
 
 
 uc20_build_initramfs_kernel_snap() {
-    # first create a debootstrap'd focal chroot 
-    CHROOT_DIR=$1/focal-chroot
-    debootstrap --variant=minbase focal "$CHROOT_DIR"
+    local TARGET="$1"
+    # kernel snap is huge, unpacking to current dir
+    unsquashfs -d repacked-kernel pc-kernel_*.snap
 
-    # first fix the sources.list, for some reason the minimal one doesn't have
-    # all the sources we need
-    cat << EOF > "$CHROOT_DIR/etc/apt/sources.list"
-deb http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu focal-updates main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
-deb http://security.ubuntu.com/ubuntu focal-security main restricted universe multiverse
-EOF
+    local SNAPD_UNPACK_DIR="/tmp/snapd-unpack"
+    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$SNAPD_UNPACK_DIR"
 
-    # mount proc and sys on the chroot otherwise installing packages like dmraid
-    # and other initramfs related things fail in weird ways
-	mount --bind /proc "$CHROOT_DIR/proc"
-	mount --bind /sys "$CHROOT_DIR/sys"
+    # repack initrd magic, beware
+    # assumptions: initrd is compressed with LZ4, cpio block size 512, microcode
+    # at the beginning of initrd image
+    (
+        apt install liblz4-tool -y
 
-    # update packages
-    chroot "$CHROOT_DIR" apt update -y -qq
-    chroot "$CHROOT_DIR" apt upgrade -y -qq
+        cd repacked-kernel
+        objcopy -j .initrd -O binary kernel.efi initrd
+        # find out the size of the microcode bit
+        # this may be flaky, we're assuming 512 block size
+        blocks=$(cpio -t < initrd 2>&1 >/dev/null| tail -1 | cut -f1 -d' ')
 
-    # install our snapd into the focal chroot
-    cp "$GOHOME"/snapd_*.deb "$CHROOT_DIR"
-    # careful with the quoting here
-    chroot "$CHROOT_DIR" bash -c 'apt install -y -qq /snapd*.deb'
+        # this works on 20.04 but not on 18.04
+        # $ unmkinitramfs initrd unpacked-initrd
+        # on 18.04 perform each step manually
+        mkdir unpacked-initrd
+        (
+            cd unpacked-initrd
+            # extract to current dir
+            dd if=../initrd skip="$blocks" | unlz4 | cpio -iv
+        )
+        # replace snap-boostrap
+        cp -a "$SNAPD_UNPACK_DIR/usr/lib/snapd/snap-bootstrap" unpacked-initrd/usr/lib/snapd/snap-bootstrap
+        # see mkinitramfs for reference
+        compress="lz4 -l -9"
+        (cd "unpacked-initrd/" && \
+             find . | LC_ALL=C sort | cpio --quiet -R 0:0 -o -H newc | $compress ) > repacked-initrd-main
+        # extract the early part
+        dd if=initrd bs=512 count="$blocks" > repacked-initrd
+        cat repacked-initrd-main >> repacked-initrd
+        objcopy --update-section .initrd="repacked-initrd" kernel.efi
+        # clean up
+        rm -f repacked-initrd repacked-initrd-main initrd
+        rm -rf unpacked-initrd
+    )
 
-    # all of the below needs to be run from inside the chroot, so just put it 
-    # into a script in the chroot to make it easier to run
-    # TLDR this script will create a kernel snap using the makefile from the 
-    # canonical-kernel-snaps git repo, w/o snapcraft - the snapcraft.yaml for 
-    # the kernel snap currently just uses this makefile, so this is equivalent
-    cat << "EOF2" > "$CHROOT_DIR/make-kernel-snap.sh"
-#!/bin/bash -ex
-
-# install packages
-# * linux-image-generic is for the linux kernel
-# * build-essential and git are for building the kernel snap
-# * debootstrap and lsb-release are also used by the kernel snap build
-apt update -qq
-apt upgrade -y -qq
-apt install -y -qq linux-image-generic build-essential git debootstrap lsb-release
-
-# get the version of the linux image package we have installed
-# the nasty sed expr at the end is to change the 3rd "." in the package version number
-# into a "-" as that's what the kernel makefile expects for some reason I don't
-# understand, i.e. 11.22.33.44.55 -> 11.22.33-44.55
-SNAPCRAFT_PROJECT_VERSION=$(apt list --installed linux-image-generic 2>/dev/null | grep -Po 'linux-image-generic/focal,now \K[^ ]+' | sed -e 's/^\([[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\)\./\1-/g')
-export SNAPCRAFT_PROJECT_VERSION
-
-# get kernel snap makefile from kernel-snaps-uc20 git repo
-if [ ! -d kernel-snaps-uc20 ]; then
-    # TODO:UC20: should we pin this to a specific commit? currently this will 
-    # follow master...
-    git clone https://git.launchpad.net/~canonical-kernel-snaps/+git/kernel-snaps-uc20
-fi
-cd kernel-snaps-uc20
-
-rm -rf pc-kernel
-mkdir -p pc-kernel/meta
-
-# create the snap.yaml for the kernel snap
-cat << EOF > pc-kernel/meta/snap.yaml
-name: pc-kernel
-version: $SNAPCRAFT_PROJECT_VERSION-snapd-tests
-summary: generic linux kernel
-description: The generic Ubuntu kernel package as a snap
-type: kernel
-architectures:
-- amd64
-confinement: strict
-grade: stable
-EOF
-
-# make the kernel snap assets - note this will create an initramfs, but that one
-# will be wrong as it will contain snap-bootstrap from the ubuntu-core-initramfs
-# package, not ours
-# TODO:UC20: when should we stop using focal-proposed here?
-make KERNEL=linux-pc-image PROPOSED=true MIRROR=archive.ubuntu.com/ubuntu
-
-# get the kernel version from inside the chroot that the kernel Makefile creates
-# to pass to ubuntu-core-initramfs
-KERNEL_VERSION=$(chroot chroot apt-cache depends linux-image-generic | grep -Po "Depends: linux-image-\K.*")
-
-# install our snap-bootstrap into the ubuntu-core-initramfs files and 
-# re-generate the initrd and subsequent initramfs
-cp /usr/lib/snapd/snap-bootstrap chroot/lib/ubuntu-core-initramfs/main/usr/lib/snapd/snap-bootstrap
-chroot chroot ubuntu-core-initramfs create-initrd --kernelver "$KERNEL_VERSION"
-chroot chroot ubuntu-core-initramfs create-efi --kernelver "$KERNEL_VERSION"
-
-# make "the-tool" be "the-verbose-tool"
-sed -i -e 's/set -e/set -ex/' chroot/lib/ubuntu-core-initramfs/main/usr/lib/the-tool
-
-# install the kernel snap files to pc-kernel - this just copies files from 
-# /boot/... so it will pick up the changes we made above
-# TODO:UC20: when should we stop using focal-proposed here?
-make KERNEL=linux-pc-image PROPOSED=true MIRROR=archive.ubuntu.com/ubuntu install DESTDIR="$(pwd)/pc-kernel"
-
-# pack the kernel snap
-snap pack pc-kernel
-
-mv pc-kernel*.snap /pc-kernel_snapd-tests.snap
-EOF2
-
-    chmod +x "$CHROOT_DIR/make-kernel-snap.sh"
-
-    # build the snap
-    chroot "$CHROOT_DIR" /make-kernel-snap.sh
-    
-    # copy the built snap into the specified target directory
-    cp "$CHROOT_DIR/pc-kernel_snapd-tests.snap" "$2"
+     snap pack repacked-kernel "$TARGET"
 }
 
 
@@ -737,23 +670,25 @@ EOF
 
     EXTRA_FUNDAMENTAL=
     IMAGE_CHANNEL=edge
-    if is_core20_system; then
-        # build the initramfs with our snapd assets into the kernel snap
-        uc20_build_initramfs_kernel_snap "$IMAGE_HOME" "$PWD"
+    if [ "$KERNEL_CHANNEL" = "$GADGET_CHANNEL" ]; then
+        IMAGE_CHANNEL="$KERNEL_CHANNEL"
+    else
+        # download pc-kernel snap for the specified channel and set
+        # ubuntu-image channel to that of the gadget, so that we don't
+        # need to download it
+        snap download --channel="$KERNEL_CHANNEL" pc-kernel
+
         EXTRA_FUNDAMENTAL="--extra-snaps $PWD/pc-kernel_*.snap"
         IMAGE_CHANNEL="$GADGET_CHANNEL"
-    else 
-        if [ "$KERNEL_CHANNEL" = "$GADGET_CHANNEL" ]; then
-            IMAGE_CHANNEL="$KERNEL_CHANNEL"
-        else
-            # download pc-kernel snap for the specified channel and set
-            # ubuntu-image channel to that of the gadget, so that we don't
-            # need to download it
-            snap download --channel="$KERNEL_CHANNEL" pc-kernel
+    fi
 
-            EXTRA_FUNDAMENTAL="--extra-snaps $PWD/pc-kernel_*.snap"
-            IMAGE_CHANNEL="$GADGET_CHANNEL"
-        fi
+    if is_core20_system; then
+        snap download --channel="20/$KERNEL_CHANNEL" pc-kernel
+        # make sure we have the snap
+        test -e pc-kernel_*.snap
+        # build the initramfs with our snapd assets into the kernel snap
+        uc20_build_initramfs_kernel_snap "$IMAGE_HOME"
+        EXTRA_FUNDAMENTAL="--extra-snaps $IMAGE_HOME/pc-kernel_*.snap"
     fi
 
     # 'snap pack' creates snaps 0644, and ubuntu-image just copies those in

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -390,7 +390,7 @@ if [ -e /root/spread-setup-done ]; then
 fi
 
 # extract data from previous stage
-(cd / && tar xvf /run/mnt/ubuntu-seed/run-mode-overlay-data.tar.gz)
+(cd / && tar xf /run/mnt/ubuntu-seed/run-mode-overlay-data.tar.gz)
 
 # user db - it's complicated
 for f in group gshadow passwd shadow; do

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -442,8 +442,6 @@ uc20_build_initramfs_kernel_snap() {
     # kernel snap is huge, unpacking to current dir
     unsquashfs -d repacked-kernel pc-kernel_*.snap
 
-    local SNAPD_UNPACK_DIR="/tmp/snapd-unpack"
-    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$SNAPD_UNPACK_DIR"
 
     # repack initrd magic, beware
     # assumptions: initrd is compressed with LZ4, cpio block size 512, microcode
@@ -462,14 +460,14 @@ uc20_build_initramfs_kernel_snap() {
         unmkinitramfs initrd unpacked-initrd
         # XXX: this does not produce the same result as using distro's
         # /usr/lib/ubuntu-core-initramfs skeleton
-        cp -ar /usr/lib/ubuntu-core-initramfs skeleton
+        skeletondir=/usr/lib/ubuntu-core-initramfs/
+        cp -ar "$skeletondir" skeleton
         # replace the main bits
         rm -rf skeleton/main
         cp -ar unpacked-initrd/main skeleton/
 
         # all the skeleton edits go to the distro directory
-        skeletondir=/usr/lib/ubuntu-core-initramfs/
-        cp -a "$SNAPD_UNPACK_DIR/usr/lib/snapd/snap-bootstrap" "$skeletondir/main/usr/lib/snapd/snap-bootstrap"
+        cp -a /usr/lib/snapd/snap-bootstrap "$skeletondir/main/usr/lib/snapd/snap-bootstrap"
         # modify the-tool to verify that our version is used when booting - this
         # is verified in the tests/core20/basic spread test
         sed -i -e 's/set -e/set -ex/' "$skeletondir/main/usr/lib/the-tool"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -511,10 +511,10 @@ uc20_build_initramfs_kernel_snap() {
         cd repacked-kernel
         rm -rf firmware/*
 
-        # XXX: the code below drops the modules that are not loaded on the
+        # the code below drops the modules that are not loaded on the
         # current host, this should work for most cases, since the image will be
         # running on the same host
-        # enable when ready
+        # TODO:UC20: enable when ready
         exit 0
 
         # drop unnecessary modules

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -880,7 +880,7 @@ initrd $DEVPREFIX/initrd.img
 EOF
 }
 
-# prepare_ubuntu_core will prepare ubuntu-core 16 and 18
+# prepare_ubuntu_core will prepare ubuntu-core 16+
 prepare_ubuntu_core() {
     # we are still a "classic" image, prepare the surgery
     if [ -e /var/lib/dpkg/status ]; then

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -438,10 +438,11 @@ uc20_build_initramfs_kernel_snap() {
     add-apt-repository ppa:snappy-dev/image -y
     apt install ubuntu-core-initramfs -y
 
-    local TARGET="$1"
+    local ORIG_SNAP="$1"
+    local TARGET="$2"
+    
     # kernel snap is huge, unpacking to current dir
-    unsquashfs -d repacked-kernel pc-kernel_*.snap
-
+    unsquashfs -d repacked-kernel "$ORIG_SNAP"
 
     # repack initrd magic, beware
     # assumptions: initrd is compressed with LZ4, cpio block size 512, microcode
@@ -743,11 +744,11 @@ EOF
     fi
 
     if is_core20_system; then
-        snap download --channel="20/$KERNEL_CHANNEL" pc-kernel
+        snap download --basename=pc-kernel --channel="20/$KERNEL_CHANNEL" pc-kernel
         # make sure we have the snap
-        test -e pc-kernel_*.snap
+        test -e pc-kernel.snap
         # build the initramfs with our snapd assets into the kernel snap
-        uc20_build_initramfs_kernel_snap "$IMAGE_HOME"
+        uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$IMAGE_HOME"
         EXTRA_FUNDAMENTAL="--extra-snaps $IMAGE_HOME/pc-kernel_*.snap"
     fi
 

--- a/tests/main/ubuntu-core-apt/task.yaml
+++ b/tests/main/ubuntu-core-apt/task.yaml
@@ -1,4 +1,4 @@
-summary: Ensure that the apt output on ubuntu-core is correct
+summary: Ensure that the apt output on UC16 is correct
 
 systems: [ubuntu-core-16-*]
 

--- a/tests/main/ubuntu-core-netplan/task.yaml
+++ b/tests/main/ubuntu-core-netplan/task.yaml
@@ -1,9 +1,5 @@
 summary: Ensure that netplan works on Ubuntu Core with network-setup-{control,observe}
 
-#TODO:UC20: enable, fails right now with: "The permission of the
-#           setuid helper is not correct"
-systems: [-ubuntu-core-20-*]
-
 details: |
     Netplan apply is used to apply network configuration to the system
 
@@ -11,7 +7,8 @@ environment:
     NETPLAN: io.netplan.Netplan
 
 # the test is only meaningful on core devices
-# TODO:UC20: enable for UC20
+# TODO:UC20: enable, fails right now with: "The permission of the
+#            setuid helper is not correct"
 systems: [ubuntu-core-1*]
 
 prepare: |


### PR DESCRIPTION
Contains patches from #8069 and a workaround for `ubuntu-core-image`. Also, we use 20.04 to boostrap an `ubuntu-core-20-64` system.