### PR TITLE
tests: retry mounting the udisk2 device due to timing issue

### DIFF
--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -4,8 +4,8 @@ details: |
     The udisks2 interface allows operating as or interacting with the UDisks2 service
 
 # Interfaces not defined for ubuntu core systems
-# FIXME: fails in debian-sid for unknown reasons
-systems: [-ubuntu-core-*, -debian-sid-*]
+# FIXME: fails in debian-sid and ubuntu-20.04 for unknown reasons
+systems: [-ubuntu-core-*, -debian-sid-*, -ubuntu-20.04-*]
 
 prepare: |
     snap install test-snapd-udisks2

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -42,7 +42,7 @@ execute: |
     device="$(losetup -j "$FS_PATH" | cut -d: -f1)"
 
     # We retry because there is a race with the device becoming
-    # registered by udisks2. The issue can be easy reproduced in ubuntu-20.04
+    # registered by udisks2. The issue can be easily reproduced on ubuntu-20.04
     retry-tool -n 3 --wait 1 sh -c "test-snapd-udisks2.udisksctl mount -b \"$device\" -t ext4 | MATCH 'Mounted /dev/'"
     test-snapd-udisks2.udisksctl unmount -b "$device" | MATCH "Unmounted /dev/"
 

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -4,8 +4,8 @@ details: |
     The udisks2 interface allows operating as or interacting with the UDisks2 service
 
 # Interfaces not defined for ubuntu core systems
-# FIXME: fails in debian-sid and ubuntu-20.04 for unknown reasons
-systems: [-ubuntu-core-*, -debian-sid-*, -ubuntu-20.04-*]
+# FIXME: fails in debian-sid for unknown reasons
+systems: [-ubuntu-core-*, -debian-sid-*]
 
 prepare: |
     snap install test-snapd-udisks2
@@ -41,7 +41,9 @@ execute: |
 
     device="$(losetup -j "$FS_PATH" | cut -d: -f1)"
 
-    test-snapd-udisks2.udisksctl mount -b "$device" -t ext4 | MATCH "Mounted /dev/"
+    # We retry because there is a race with the device becoming
+    # registered by udisks2. The issue can be easy reproduced in ubuntu-20.04
+    retry-tool -n 3 --wait 1 test-snapd-udisks2.udisksctl mount -b "$device" -t ext4 | MATCH "Mounted /dev/"
     test-snapd-udisks2.udisksctl unmount -b "$device" | MATCH "Unmounted /dev/"
 
     if [ "$(snap debug confinement)" = partial ] ; then

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -43,7 +43,7 @@ execute: |
 
     # We retry because there is a race with the device becoming
     # registered by udisks2. The issue can be easy reproduced in ubuntu-20.04
-    retry-tool -n 3 --wait 1 test-snapd-udisks2.udisksctl mount -b "$device" -t ext4 | MATCH "Mounted /dev/"
+    retry-tool -n 3 --wait 1 sh -c "test-snapd-udisks2.udisksctl mount -b \"$device\" -t ext4 | MATCH 'Mounted /dev/'"
     test-snapd-udisks2.udisksctl unmount -b "$device" | MATCH "Unmounted /dev/"
 
     if [ "$(snap debug confinement)" = partial ] ; then


### PR DESCRIPTION
The test fails due to a timing issue (with a sleep before the mount the
error is not reproduced anymore).

error: https://travis-ci.org/snapcore/snapd/jobs/645851946#L12371
