### PR TITLE
netlink: fix/support stopping goroutines reading netlink raw sockets

### DIFF
--- a/osutil/udev/netlink/conn.go
+++ b/osutil/udev/netlink/conn.go
@@ -153,7 +153,7 @@ func (c *UEventConn) Monitor(queue chan UEvent, errors chan error, matcher Match
 				// for some reason we get here after
 				// readableOrStop but the read would
 				// block anyway
-				if err == syscall.EAGAIN || err == syscall.EWOULDBLOCK {
+				if errno, ok := err.(syscall.Errno); ok && errno.Temporary() {
 					continue EventReading
 				}
 				if err != nil {

--- a/osutil/udev/netlink/conn_test.go
+++ b/osutil/udev/netlink/conn_test.go
@@ -2,6 +2,7 @@ package netlink
 
 import (
 	"testing"
+	"time"
 )
 
 func TestConnect(t *testing.T) {
@@ -17,4 +18,18 @@ func TestConnect(t *testing.T) {
 		t.Fatal("can't subscribing a second time to netlink socket with PID", conn2.Addr.Pid)
 	}
 	defer conn2.Close()
+}
+
+func TestMonitorStop(t *testing.T) {
+	conn := new(UEventConn)
+	if err := conn.Connect(UdevEvent); err != nil {
+		t.Fatal("unable to subscribe to netlink uevent, err:", err)
+	}
+	defer conn.Close()
+
+	stop := conn.Monitor(nil, nil, nil)
+	ok := stop(200 * time.Millisecond)
+	if !ok {
+		t.Fatal("stop timed out instead of working")
+	}
 }

--- a/osutil/udev/netlink/rawsockstop.go
+++ b/osutil/udev/netlink/rawsockstop.go
@@ -1,0 +1,60 @@
+package netlink
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// RawSockStopper returns a pair of functions to manage stopping code
+// reading from a raw socket, readableOrStop blocks until
+// fd is readable or stop was called.
+// TODO: with go 1.11+ it should be possible to just switch to setting
+// fd to non-blocking and then wrapping the socket via os.NewFile and
+// use Closeq to force a read to stop.
+// c.f. https://github.com/golang/go/commit/ea5825b0b64e1a017a76eac0ad734e11ff557c8e
+func RawSockStopper(fd int) (readableOrStop func() (bool, error), stop func(), err error) {
+	stopR, stopW, err := os.Pipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	stopFd := int(stopR.Fd())
+
+	readableOrStop = func() (bool, error) {
+		return stopperSelectReadable(fd, stopFd)
+	}
+	stop = func() {
+		stopW.Write([]byte{0})
+	}
+	return readableOrStop, stop, nil
+}
+
+var stopperSelectTimeout *syscall.Timeval
+
+func stopperSelectReadable(fd, stopFd int) (bool, error) {
+	maxFd := fd
+	if maxFd < stopFd {
+		maxFd = stopFd
+	}
+	if maxFd >= 1024 {
+		return false, fmt.Errorf("fd too high for syscall.Select")
+	}
+	fdIdx := fd / 64
+	fdBits := int64(1 << (uint(fd) % 64))
+	readable := false
+	for {
+		var r syscall.FdSet
+		r.Bits[fdIdx] = fdBits
+		r.Bits[stopFd/64] |= 1 << (uint(stopFd) % 64)
+		_, err := syscall.Select(maxFd+1, &r, nil, nil, stopperSelectTimeout)
+		if err == syscall.EINTR {
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		readable = (r.Bits[fdIdx] & fdBits) != 0
+		break
+	}
+	return readable, nil
+}

--- a/osutil/udev/netlink/rawsockstop.go
+++ b/osutil/udev/netlink/rawsockstop.go
@@ -56,7 +56,7 @@ func stopperSelectReadable(fd, stopFd int) (bool, error) {
 		r.Bits[fdIdx] = 1 << fdShift
 		r.Bits[stopFdIdx] |= 1 << stopFdShift
 		_, err := syscall.Select(maxFd+1, &r, nil, nil, stopperSelectTimeout)
-		if err == syscall.EINTR {
+		if errno, ok := err.(syscall.Errno); ok && errno.Temporary() {
 			continue
 		}
 		if err != nil {

--- a/osutil/udev/netlink/rawsockstop_test.go
+++ b/osutil/udev/netlink/rawsockstop_test.go
@@ -1,0 +1,65 @@
+package netlink
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestRawSockStopperReadable(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot make test pipe: %v", err)
+	}
+
+	stopperSelectTimeout = &syscall.Timeval{
+		Usec: 50 * 1000, // 50ms
+	}
+	defer func() {
+		stopperSelectTimeout = nil
+	}()
+
+	readableOrStop, _, err := RawSockStopper(int(r.Fd()))
+	if err != nil {
+		t.Fatalf("rawSockStopper: %v", err)
+	}
+
+	readable, err := readableOrStop()
+	if err != nil {
+		t.Fatalf("readableOrStop should timeout without error: %v", err)
+	}
+	if readable {
+		t.Fatal("readableOrStop: expected nothing to read yet")
+	}
+
+	w.Write([]byte{1})
+	readable, err = readableOrStop()
+	if err != nil {
+		t.Fatalf("readableOrStop should succeed without error: %v", err)
+	}
+	if !readable {
+		t.Fatal("readableOrStop: expected something to read")
+	}
+}
+
+func TestRawSockStopperStop(t *testing.T) {
+	r, _, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot make test pipe: %v", err)
+	}
+
+	readableOrStop, stop, err := RawSockStopper(int(r.Fd()))
+	if err != nil {
+		t.Fatalf("rawSockStopper: %v", err)
+	}
+
+	stop()
+	readable, err := readableOrStop()
+	if err != nil {
+		t.Fatalf("readableOrStop should return without error: %v", err)
+	}
+	if readable {
+		t.Fatal("readableOrStop: expected nothing to read, just stopped")
+	}
+
+}

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -311,7 +311,6 @@ func (m *InterfaceManager) initUDevMonitor() error {
 		return err
 	}
 	if err := mon.Run(); err != nil {
-		mon.Disconnect()
 		return err
 	}
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -5961,21 +5961,16 @@ func (s *interfaceManagerSuite) TestSnapstateOpConflictWithDisconnect(c *C) {
 }
 
 type udevMonitorMock struct {
-	ConnectError, RunError                             error
-	ConnectCalls, RunCalls, StopCalls, DisconnectCalls int
-	AddDevice                                          udevmonitor.DeviceAddedFunc
-	RemoveDevice                                       udevmonitor.DeviceRemovedFunc
-	EnumerationDone                                    udevmonitor.EnumerationDoneFunc
+	ConnectError, RunError            error
+	ConnectCalls, RunCalls, StopCalls int
+	AddDevice                         udevmonitor.DeviceAddedFunc
+	RemoveDevice                      udevmonitor.DeviceRemovedFunc
+	EnumerationDone                   udevmonitor.EnumerationDoneFunc
 }
 
 func (u *udevMonitorMock) Connect() error {
 	u.ConnectCalls++
 	return u.ConnectError
-}
-
-func (u *udevMonitorMock) Disconnect() error {
-	u.DisconnectCalls++
-	return nil
 }
 
 func (u *udevMonitorMock) Run() error {
@@ -6066,7 +6061,6 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitErrors(c *C) {
 	c.Assert(u.ConnectCalls, Equals, 2)
 	c.Assert(u.RunCalls, Equals, 1)
 	c.Assert(u.StopCalls, Equals, 0)
-	c.Assert(u.DisconnectCalls, Equals, 1)
 
 	u.RunError = nil
 	c.Assert(s.se.Ensure(), IsNil)


### PR DESCRIPTION
During the review of PR#8085 we discoverd that the netlink socket
reads will block for an arbitrary long time which means that stoping
a udev monitor is not reliable. This PR (by Samuele) fixes this by
using a new netlink.RawSockStopper().

Note that from go-1.11 onwards we can simplify this by just setting
the netlink fd to non-blocking and then wrapping it with os.NewFile.
With that the regular os.File.Close() will work as expected.
