### PR TITLE
store: detect if server does not support http range headers

### DIFF
--- a/store/download_test.go
+++ b/store/download_test.go
@@ -362,8 +362,8 @@ func (s *downloadSuite) TestActualDownloadServerNoResumeHandeled(c *C) {
 		switch n {
 		case 1:
 			c.Check(r.Header["Range"], HasLen, 1)
-		case 2:
-			c.Check(r.Header["Range"], IsNil)
+		default:
+			c.Fatal("only one request expected")
 		}
 		// server does not do partial content and sends full data instead
 		w.WriteHeader(200)
@@ -381,7 +381,7 @@ func (s *downloadSuite) TestActualDownloadServerNoResumeHandeled(c *C) {
 	err := store.Download(context.TODO(), "foo", sha3, mockServer.URL, nil, theStore, buf, int64(len("some ")), nil, nil)
 	c.Check(err, IsNil)
 	c.Check(buf.String(), Equals, "some data")
-	c.Check(n, Equals, 2)
+	c.Check(n, Equals, 1)
 }
 
 func (s *downloadSuite) TestUseDeltas(c *C) {

--- a/store/store.go
+++ b/store/store.go
@@ -1534,7 +1534,13 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 			}
 			break
 		}
-
+		if resume > 0 && resp.StatusCode != 206 {
+			logger.Debugf("server does not support resume")
+			resp.Body.Close()
+			w.Seek(0, os.SEEK_SET)
+			resume = 0
+			continue
+		}
 		if httputil.ShouldRetryHttpResponse(attempt, resp) {
 			resp.Body.Close()
 			continue

--- a/store/store.go
+++ b/store/store.go
@@ -1536,10 +1536,11 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 		}
 		if resume > 0 && resp.StatusCode != 206 {
 			logger.Debugf("server does not support resume")
-			resp.Body.Close()
-			w.Seek(0, os.SEEK_SET)
+			if _, err := w.Seek(0, os.SEEK_SET); err != nil {
+				return err
+			}
+			h = crypto.SHA3_384.New()
 			resume = 0
-			continue
 		}
 		if httputil.ShouldRetryHttpResponse(attempt, resp) {
 			resp.Body.Close()

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -678,6 +678,43 @@ func (s *storeTestSuite) TestResumeOfCompletedRetriedOnHashFailure(c *C) {
 	c.Assert(s.logbuf.String(), Matches, "(?s).*sha3-384 mismatch.*")
 }
 
+func (s *storeTestSuite) TestResumeOfTooMuchDataWorks(c *C) {
+	var mockServer *httptest.Server
+
+	// our mock download content
+	snapContent := "snap-content"
+	// the partial file has too much data
+	tooMuchLocalData := "way-way-way-too-much-snap-content"
+
+	h := crypto.SHA3_384.New()
+	io.Copy(h, bytes.NewBufferString(snapContent))
+
+	n := 0
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		w.Write([]byte(snapContent))
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	snap := &snap.Info{}
+	snap.RealName = "foo"
+	snap.AnonDownloadURL = mockServer.URL
+	snap.DownloadURL = "AUTH-URL"
+	snap.Sha3_384 = fmt.Sprintf("%x", h.Sum(nil))
+	snap.Size = int64(len(snapContent))
+
+	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
+	c.Assert(ioutil.WriteFile(targetFn+".partial", []byte(tooMuchLocalData), 0644), IsNil)
+	err := s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 1)
+
+	c.Assert(targetFn, testutil.FileEquals, snapContent)
+
+	c.Assert(s.logbuf.String(), Matches, "(?s).*sha3-384 mismatch.*")
+}
+
 func (s *storeTestSuite) TestDownloadRetryHashErrorIsFullyRetriedOnlyOnce(c *C) {
 	n := 0
 	var mockServer *httptest.Server

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -572,6 +572,9 @@ func (s *storeTestSuite) TestDownloadEOFHandlesResumeHashCorrectly(c *C) {
 			mockServer.CloseClientConnections()
 			return
 		}
+		if len(r.Header["Range"]) > 0 {
+			w.WriteHeader(206)
+		}
 		w.Write(buf[len(buf)-5:])
 	}))
 


### PR DESCRIPTION
When the server replies with a 200 instead of 206 for a range
request we need to re-download the full thing. Deal with this
correctly.
