### PR TITLE
[RFC] o/devicestate: don't prune tasks immediediately

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -146,26 +146,13 @@ func (m *DeviceManager) CanStandby() bool {
 	return seeded
 }
 
-var canPruneDelay = 1 * time.Hour
-
 func (m *DeviceManager) CanPrune() bool {
+	// XXX: this is the same as CanStandby above.
 	var seeded bool
-	if err := m.state.Get("seeded", &seeded); err != nil || !seeded {
+	if err := m.state.Get("seeded", &seeded); err != nil {
 		return false
 	}
-
-	// we are seeded. check if "seed" change is still
-	// in state and at least canPruneDelay passed since it has became ready.
-	for _, chg := range m.state.Changes() {
-		// block pruning for 1h from seeding
-		if chg.IsReady() && chg.Kind() == "seed" {
-			return time.Now().After(chg.ReadyTime().Add(canPruneDelay))
-		}
-	}
-
-	// seed change not found, so it was pruned already, don't
-	// prevent pruning anymore.
-	return true
+	return seeded
 }
 
 func (m *DeviceManager) confirmRegistered() error {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -146,6 +146,28 @@ func (m *DeviceManager) CanStandby() bool {
 	return seeded
 }
 
+var canPruneDelay = 1 * time.Hour
+
+func (m *DeviceManager) CanPrune() bool {
+	var seeded bool
+	if err := m.state.Get("seeded", &seeded); err != nil || !seeded {
+		return false
+	}
+
+	// we are seeded. check if "seed" change is still
+	// in state and at least canPruneDelay passed since it has became ready.
+	for _, chg := range m.state.Changes() {
+		// block pruning for 1h from seeding
+		if chg.IsReady() && chg.Kind() == "seed" {
+			return time.Now().After(chg.ReadyTime().Add(canPruneDelay))
+		}
+	}
+
+	// seed change not found, so it was pruned already, don't
+	// prevent pruning anymore.
+	return true
+}
+
 func (m *DeviceManager) confirmRegistered() error {
 	m.state.Lock()
 	defer m.state.Unlock()

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -403,6 +403,8 @@ func (o *Overlord) Loop() {
 			case <-o.pruneTicker.C:
 				st := o.State()
 				st.Lock()
+				// account for deviceMgr == nil as it's not always present in
+				// tests.
 				if o.deviceMgr == nil || o.deviceMgr.CanPrune() {
 					st.Prune(pruneWait, abortWait, pruneMaxChanges)
 				}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -403,7 +403,9 @@ func (o *Overlord) Loop() {
 			case <-o.pruneTicker.C:
 				st := o.State()
 				st.Lock()
-				st.Prune(pruneWait, abortWait, pruneMaxChanges)
+				if o.deviceMgr == nil || o.deviceMgr.CanPrune() {
+					st.Prune(pruneWait, abortWait, pruneMaxChanges)
+				}
 				st.Unlock()
 			}
 		}

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -450,7 +450,7 @@ func (s *State) tasksIn(tids []string) []*Task {
 //
 //  * it removes expired warnings.
 func (s *State) Prune(pruneWait, abortWait time.Duration, maxReadyChanges int) {
-	now := time.Now()
+	now := timeNow()
 	pruneLimit := now.Add(-pruneWait)
 	abortLimit := now.Add(-abortWait)
 

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -450,7 +450,7 @@ func (s *State) tasksIn(tids []string) []*Task {
 //
 //  * it removes expired warnings.
 func (s *State) Prune(pruneWait, abortWait time.Duration, maxReadyChanges int) {
-	now := timeNow()
+	now := time.Now()
 	pruneLimit := now.Add(-pruneWait)
 	abortLimit := now.Add(-abortWait)
 


### PR DESCRIPTION
I think that preseeded image may potentially have an issue with task/change pruning on first boot, because the "seed" change in the state (that's is partially done, and partially carried over on first boot) has tasks with spawn times in the past, and if more than 24hrs passed since spawn time, the change may get aborted. There is a 10-minute window defined before pruneTicker will kick in and Prune(), so theoretically it wouldn't happen, but I think it's better to explicitly prevent it until 'seeded' is true.
