### PR TITLE
boot: use constants for boot status values

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -27,6 +27,19 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+const (
+	// DefaultStatus is the value of a status boot variable when nothing is
+	// being tried
+	DefaultStatus = ""
+	// TryStatus is the value of a status boot variable when something is about
+	// to be tried
+	TryStatus = "try"
+	// TryingStatus is the value of a status boot variable after we have
+	// attempted a boot with a try snap - this status is only set in the early
+	// boot sequence (bootloader, initramfs, etc.)
+	TryingStatus = "trying"
+)
+
 // A BootParticipant handles the boot process details for a snap involved in it.
 type BootParticipant interface {
 	// SetNextBoot will schedule the snap to be used in the next boot. For

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -176,7 +176,7 @@ func (s *bootSetSuite) TestCurrentBootNameAndRevision(c *C) {
 	c.Check(current.SnapName(), Equals, "canonical-pc-linux")
 	c.Check(current.SnapRevision(), Equals, snap.R(2))
 
-	s.bootloader.BootVars["snap_mode"] = "trying"
+	s.bootloader.BootVars["snap_mode"] = boot.TryingStatus
 	_, err = boot.GetCurrentBoot(snap.TypeKernel, coreDev)
 	c.Check(err, Equals, boot.ErrBootNameAndRevisionNotReady)
 }
@@ -207,7 +207,7 @@ func (s *bootSetSuite) TestCurrentBoot20NameAndRevision(c *C) {
 	c.Check(current.SnapName(), Equals, "pc-kernel")
 	c.Check(current.SnapRevision(), Equals, snap.R(1))
 
-	s.bootloader.BootVars["kernel_status"] = "trying"
+	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
 	_, err = boot.GetCurrentBoot(snap.TypeKernel, coreDev)
 	c.Check(err, Equals, boot.ErrBootNameAndRevisionNotReady)
 }
@@ -412,7 +412,7 @@ func (s *bootSetSuite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	defer r()
 
 	// default state
-	s.bootloader.BootVars["kernel_status"] = ""
+	s.bootloader.BootVars["kernel_status"] = boot.DefaultStatus
 
 	// get the boot kernel participant from our kernel snap
 	bootKern := boot.Participant(kernel, snap.TypeKernel, coreDev)
@@ -429,7 +429,7 @@ func (s *bootSetSuite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	c.Assert(nKernelCalls, Equals, 1)
 
 	// ensure that kernel_status is still empty
-	c.Assert(s.bootloader.BootVars["kernel_status"], Equals, "")
+	c.Assert(s.bootloader.BootVars["kernel_status"], Equals, boot.DefaultStatus)
 
 	// there was no attempt to enable a kernel
 	_, enableKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableTryKernel")
@@ -451,7 +451,7 @@ func (s *bootSetSuite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 	c.Assert(err, IsNil)
 
 	// default state
-	s.bootloader.BootVars["kernel_status"] = ""
+	s.bootloader.BootVars["kernel_status"] = boot.DefaultStatus
 
 	// get the boot kernel participant from our new kernel snap
 	bootKern := boot.Participant(kernel2, snap.TypeKernel, coreDev)
@@ -468,7 +468,7 @@ func (s *bootSetSuite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 	c.Assert(nKernelCalls, Equals, 1)
 
 	// ensure that kernel_status is now try
-	c.Assert(s.bootloader.BootVars["kernel_status"], Equals, "try")
+	c.Assert(s.bootloader.BootVars["kernel_status"], Equals, boot.TryStatus)
 
 	// and we were asked to enable kernel2 as the try kernel
 	actual, _ := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableTryKernel")
@@ -478,7 +478,7 @@ func (s *bootSetSuite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 func (s *bootSetSuite) TestMarkBootSuccessfulAllSnap(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
-	s.bootloader.BootVars["snap_mode"] = "trying"
+	s.bootloader.BootVars["snap_mode"] = boot.TryingStatus
 	s.bootloader.BootVars["snap_try_core"] = "os1"
 	s.bootloader.BootVars["snap_try_kernel"] = "k1"
 	err := boot.MarkBootSuccessful(coreDev)
@@ -486,7 +486,7 @@ func (s *bootSetSuite) TestMarkBootSuccessfulAllSnap(c *C) {
 
 	expected := map[string]string{
 		// cleared
-		"snap_mode":       "",
+		"snap_mode":       boot.DefaultStatus,
 		"snap_try_kernel": "",
 		"snap_try_core":   "",
 		// updated
@@ -514,19 +514,19 @@ func (s *bootSetSuite) TestMarkBootSuccessful20AllSnap(c *C) {
 	r := s.bootloader.SetRunKernelImageEnabledTryKernel(kernel2)
 	defer r()
 
-	s.bootloader.BootVars["kernel_status"] = "trying"
+	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
+
 	err = boot.MarkBootSuccessful(coreDev)
 	c.Assert(err, IsNil)
 
 	// check the bootloader variables
 	expected := map[string]string{
 		// cleared
-		"kernel_status": "",
+		"kernel_status": boot.DefaultStatus,
 	}
 	c.Assert(s.bootloader.BootVars, DeepEquals, expected)
 
-	// check that no bootloader EnableKernel() calls were made, since setNext()
-	// wasn't called
+	// check that we called EnableKernel() on the try-kernel
 	actual, _ := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
 	c.Assert(actual, DeepEquals, []snap.PlaceInfo{kernel2})
 
@@ -543,7 +543,7 @@ func (s *bootSetSuite) TestMarkBootSuccessful20AllSnap(c *C) {
 func (s *bootSetSuite) TestMarkBootSuccessfulKernelUpdate(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
-	s.bootloader.BootVars["snap_mode"] = "trying"
+	s.bootloader.BootVars["snap_mode"] = boot.TryingStatus
 	s.bootloader.BootVars["snap_core"] = "os1"
 	s.bootloader.BootVars["snap_kernel"] = "k1"
 	s.bootloader.BootVars["snap_try_core"] = ""
@@ -552,7 +552,7 @@ func (s *bootSetSuite) TestMarkBootSuccessfulKernelUpdate(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.bootloader.BootVars, DeepEquals, map[string]string{
 		// cleared
-		"snap_mode":       "",
+		"snap_mode":       boot.DefaultStatus,
 		"snap_try_kernel": "",
 		"snap_try_core":   "",
 		// unchanged
@@ -561,10 +561,11 @@ func (s *bootSetSuite) TestMarkBootSuccessfulKernelUpdate(c *C) {
 		"snap_kernel": "k2",
 	})
 }
+
 func (s *bootSetSuite) TestMarkBootSuccessfulBaseUpdate(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
-	s.bootloader.BootVars["snap_mode"] = "trying"
+	s.bootloader.BootVars["snap_mode"] = boot.TryingStatus
 	s.bootloader.BootVars["snap_core"] = "os1"
 	s.bootloader.BootVars["snap_kernel"] = "k1"
 	s.bootloader.BootVars["snap_try_core"] = "os2"
@@ -573,7 +574,7 @@ func (s *bootSetSuite) TestMarkBootSuccessfulBaseUpdate(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.bootloader.BootVars, DeepEquals, map[string]string{
 		// cleared
-		"snap_mode":     "",
+		"snap_mode":     boot.DefaultStatus,
 		"snap_try_core": "",
 		// unchanged
 		"snap_kernel":     "k1",
@@ -589,7 +590,7 @@ func (s *bootSetSuite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// set bootloader variables
-	s.bootloader.BootVars["kernel_status"] = "trying"
+	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
 
 	// set the current Kernel
 	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
@@ -608,10 +609,10 @@ func (s *bootSetSuite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 	c.Assert(err, IsNil)
 
 	// check the bootloader variables
-	expected := map[string]string{"kernel_status": ""}
+	expected := map[string]string{"kernel_status": boot.DefaultStatus}
 	c.Assert(s.bootloader.BootVars, DeepEquals, expected)
 
-	// check that MarkBootSuccessful enabled the kernel
+	// check that MarkBootSuccessful enabled the try kernel
 	actual, _ := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
 	c.Assert(actual, DeepEquals, []snap.PlaceInfo{kernel2})
 
@@ -624,10 +625,9 @@ func (s *bootSetSuite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.bootloader.BootVars, DeepEquals, expected)
 
-	// we shouldn't have enabled any more kernels than before
+	// no new bootloader calls
 	actual, _ = s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
 	c.Assert(actual, DeepEquals, []snap.PlaceInfo{kernel2})
-
 	_, nDisableTryCalls = s.bootloader.GetRunKernelImageFunctionSnapCalls("DisableTryKernel")
 	c.Assert(nDisableTryCalls, Equals, 1)
 }

--- a/boot/bootstate16.go
+++ b/boot/bootstate16.go
@@ -139,7 +139,7 @@ func (s16 *bootState16) markSuccessful(update bootStateUpdate) (bootStateUpdate,
 
 	// snap_mode goes from "" -> "try" -> "trying" -> ""
 	// so if we are not in "trying" mode, nothing to do here
-	if env["snap_mode"] != "trying" {
+	if env["snap_mode"] != TryingStatus {
 		return u16, nil
 	}
 
@@ -150,7 +150,7 @@ func (s16 *bootState16) markSuccessful(update bootStateUpdate) (bootStateUpdate,
 		toCommit[bootVar] = env[tryBootVar]
 		toCommit[tryBootVar] = ""
 	}
-	toCommit["snap_mode"] = ""
+	toCommit["snap_mode"] = DefaultStatus
 
 	return u16, nil
 }
@@ -169,19 +169,19 @@ func (s16 *bootState16) setNext(s snap.PlaceInfo) (rebootRequired bool, u bootSt
 	env := u16.env
 	toCommit := u16.toCommit
 
-	snapMode := "try"
+	snapMode := TryStatus
 	rebootRequired = true
 	if env[goodBootVar] == nextBoot {
 		// If we were in anything but default ("") mode before
 		// and switched to the good core/kernel again, make
 		// sure to clean the snap_mode here. This also
 		// mitigates https://forum.snapcraft.io/t/5253
-		if env["snap_mode"] == "" {
+		if env["snap_mode"] == DefaultStatus {
 			// already clean
 			return false, nil, nil
 		}
 		// clean
-		snapMode = ""
+		snapMode = DefaultStatus
 		nextBoot = ""
 		rebootRequired = false
 	}

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -101,7 +101,7 @@ func (s *coreBootSetSuite) TestSetNextBootForCore(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
 		"snap_try_core": "core_100.snap",
-		"snap_mode":     "try",
+		"snap_mode":     boot.TryStatus,
 	})
 
 	c.Check(reboot, Equals, true)
@@ -123,7 +123,7 @@ func (s *coreBootSetSuite) TestSetNextBootWithBaseForCore(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
 		"snap_try_core": "core18_1818.snap",
-		"snap_mode":     "try",
+		"snap_mode":     boot.TryStatus,
 	})
 
 	c.Check(reboot, Equals, true)
@@ -145,7 +145,7 @@ func (s *coreBootSetSuite) TestSetNextBootForKernel(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
 		"snap_try_kernel": "krnl_42.snap",
-		"snap_mode":       "try",
+		"snap_mode":       boot.TryStatus,
 	})
 
 	bootVars := map[string]string{
@@ -186,7 +186,7 @@ func (s *coreBootSetSuite) TestSetNextBoot20ForKernel(c *C) {
 	v, err := s.bootloader.GetBootVars("kernel_status")
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
-		"kernel_status": "try",
+		"kernel_status": boot.TryStatus,
 	})
 
 	c.Check(reboot, Equals, true)
@@ -246,7 +246,7 @@ func (s *coreBootSetSuite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 	v, err := s.bootloader.GetBootVars("kernel_status")
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
-		"kernel_status": "",
+		"kernel_status": boot.DefaultStatus,
 	})
 
 	c.Check(reboot, Equals, false)
@@ -275,7 +275,7 @@ func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C)
 	bootVars := map[string]string{
 		"snap_kernel":     "krnl_40.snap",
 		"snap_try_kernel": "krnl_99.snap",
-		"snap_mode":       "try"}
+		"snap_mode":       boot.TryStatus}
 	s.bootloader.SetBootVars(bootVars)
 
 	reboot, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot()
@@ -286,7 +286,7 @@ func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C)
 	c.Assert(v, DeepEquals, map[string]string{
 		"snap_kernel":     "krnl_40.snap",
 		"snap_try_kernel": "",
-		"snap_mode":       "",
+		"snap_mode":       boot.DefaultStatus,
 	})
 
 	c.Check(reboot, Equals, false)
@@ -303,7 +303,8 @@ func (s *coreBootSetSuite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *
 	defer r()
 
 	bootVars := map[string]string{
-		"kernel_status": "try"}
+		"kernel_status": boot.TryStatus,
+	}
 	s.bootloader.SetBootVars(bootVars)
 
 	bs := boot.NewCoreBootParticipant(kernel1, snap.TypeKernel, coreDev)
@@ -315,7 +316,7 @@ func (s *coreBootSetSuite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *
 	v, err := s.bootloader.GetBootVars("kernel_status")
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
-		"kernel_status": "",
+		"kernel_status": boot.DefaultStatus,
 	})
 
 	c.Check(reboot, Equals, false)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -341,7 +341,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeHappy(c 
 	modeEnv := &boot.Modeenv{
 		Base:       "core20_123.snap",
 		TryBase:    "core20_124.snap",
-		BaseStatus: "try",
+		BaseStatus: boot.TryStatus,
 	}
 	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
@@ -362,7 +362,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeHappy(c 
 	// check that the modeenv was re-written
 	newModeenv, err := boot.ReadModeenv(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
-	c.Assert(newModeenv.BaseStatus, DeepEquals, "trying")
+	c.Assert(newModeenv.BaseStatus, DeepEquals, boot.TryingStatus)
 	c.Assert(newModeenv.TryBase, DeepEquals, modeEnv.TryBase)
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
@@ -399,7 +399,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeFailsHap
 	modeEnv := &boot.Modeenv{
 		Base:       "core20_123.snap",
 		TryBase:    "core20_124.snap",
-		BaseStatus: "trying",
+		BaseStatus: boot.TryingStatus,
 	}
 	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
@@ -421,7 +421,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeFailsHap
 	newModeenv, err := boot.ReadModeenv(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 	// BaseStatus was re-set to empty
-	c.Assert(newModeenv.BaseStatus, DeepEquals, "")
+	c.Assert(newModeenv.BaseStatus, DeepEquals, boot.DefaultStatus)
 	c.Assert(newModeenv.TryBase, DeepEquals, modeEnv.TryBase)
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
@@ -456,7 +456,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseEmptyHapp
 	// write a modeenv with no try_base so we fall back to using base
 	modeEnv := &boot.Modeenv{
 		Base:       "core20_123.snap",
-		BaseStatus: "try",
+		BaseStatus: boot.TryStatus,
 	}
 	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
@@ -540,11 +540,12 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseNotExists
 	})
 	defer restore()
 
-	// write a modeenv with no try_base so we fall back to using base
+	// write a modeenv with try_base not existing on disk so we fall back to
+	// using the normal base
 	modeEnv := &boot.Modeenv{
 		Base:       "core20_123.snap",
 		TryBase:    "core20_124.snap",
-		BaseStatus: "try",
+		BaseStatus: boot.TryStatus,
 	}
 	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
@@ -609,7 +610,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeKernelSnapUpgradeHappy(
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
 
-	bloader.BootVars["kernel_status"] = "trying"
+	bloader.BootVars["kernel_status"] = boot.TryingStatus
 
 	// set the current kernel
 	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")


### PR DESCRIPTION
These variables all follow the same pattern "" -> "try" -> "trying" -> "", and are the same across UC16/UC18 and UC20, so this makes us less susceptible to typos.

Split out as per https://github.com/snapcore/snapd/pull/8077#discussion_r377080178