### PR TITLE
overlord/devicestate: fix preseed unit tests on systems not using /snap

### DIFF
--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -508,7 +508,7 @@ func (s *preseedModeSuite) TestDoMarkPreseeded(c *C) {
 
 	// core snap was "manually" unmounted
 	c.Check(s.cmdUmount.Calls(), DeepEquals, [][]string{
-		{"umount", "-d", "-l", filepath.Join(dirs.GlobalRootDir, "/snap/test-snap/3")},
+		{"umount", "-d", "-l", filepath.Join(dirs.SnapMountDir, "test-snap/3")},
 	})
 
 	// and snapd stop was requested


### PR DESCRIPTION
Got this on Arch:

```
----------------------------------------------------------------------
FAIL: handlers_test.go:487: preseedModeSuite.TestDoMarkPreseeded

handlers_test.go:510:
    // core snap was "manually" unmounted
    c.Check(s.cmdUmount.Calls(), DeepEquals, [][]string{
        {"umount", "-d", "-l", filepath.Join(dirs.GlobalRootDir, "/snap/test-snap/3")},
    })
... obtained [][]string = [][]string{[]string{"umount", "-d", "-l", "/tmp/check-3259763683045511571/0/var/lib/snapd/snap/test-snap/3"}}
... expected [][]string = [][]string{[]string{"umount", "-d", "-l", "/tmp/check-3259763683045511571/0/snap/test-snap/3"}}
... Difference:
...     [0][3]: "/tmp/check-3259763683045511571/0/var/lib/snapd/snap/test-snap/3" != "/tmp/check-3259763683045511571/0/snap/test-snap/3"
```

Fix unit tests on systems not using /snap as snap mount directory.

