### PR TITLE
tests/main/static: ldd in glibc 2.31 logs to stderr now

### DIFF
--- a/tests/main/static/task.yaml
+++ b/tests/main/static/task.yaml
@@ -12,4 +12,4 @@ environment:
 
 execute: |
     CGO_ENABLED=0 go build -o snapd.static github.com/snapcore/snapd/cmd/snapd
-    ldd snapd.static | MATCH 'not a dynamic executable'
+    ldd snapd.static 2>&1 | MATCH 'not a dynamic executable'


### PR DESCRIPTION
With update of glibc to 2.31, ldd logs to stderr instead of stdout.


