### PR TITLE
httputil: add NoNetwork(err) helper, spread test and use in serial acquire

### DIFF
--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -102,7 +102,7 @@ func ShouldRetryAttempt(attempt *retry.Attempt, err error) bool {
 // the remote side returns a connection reset and it's sensible to rety
 // after a short time.
 //
-// XXX: Note that currently also NoNetwork(err) errors are repoarted
+// XXX: Note that currently also NoNetwork(err) errors are reported
 // with true here.
 func ShouldRetryError(err error) bool {
 	if err == nil {

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -104,11 +104,13 @@ func ShouldRetryAttempt(attempt *retry.Attempt, err error) bool {
 //
 // XXX: Note that currently also NoNetwork(err) errors are reported
 // with true here.
-func ShouldRetryError(err error) bool {
+func ShouldRetryError(err error) (b bool) {
 	if err == nil {
 		return false
 	}
-	logger.Debugf("ShouldRetryError: %v %T", err, err)
+	defer func() {
+		logger.Debugf("ShouldRetryError: %v %T -> %v", err, err, b)
+	}()
 
 	if urlErr, ok := err.(*url.Error); ok {
 		err = urlErr.Err
@@ -187,8 +189,10 @@ func ShouldRetryError(err error) bool {
 
 // NoNetwork returns true if the error indicates that there is no network
 // connection available, i.e. network unreachable or down or DNS unavailable.
-func NoNetwork(err error) bool {
-	logger.Debugf("NoNetwork: %v %T", err, err)
+func NoNetwork(err error) (b bool) {
+	defer func() {
+		logger.Debugf("NoNetwork: %v %T -> %v", err, err, b)
+	}()
 
 	return isNetworkDown(err) || isDnsUnavailable(err)
 }

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -99,6 +99,11 @@ func ShouldRetryAttempt(attempt *retry.Attempt, err error) bool {
 }
 
 func ShouldRetryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	logger.Debugf("ShouldRetryError: %v %T", err, err)
+
 	if urlErr, ok := err.(*url.Error); ok {
 		err = urlErr.Err
 	}
@@ -174,7 +179,18 @@ func ShouldRetryError(err error) bool {
 	return false
 }
 
+// NoNetwork returns true if the error indicates that there is no network
+// connection available, i.e. network unreachable or down or DNS unavailable.
+func NoNetwork(err error) bool {
+	logger.Debugf("NoNetwork: %v %T", err, err)
+
+	return isNetworkDown(err) || isDnsUnavailable(err)
+}
+
 func isNetworkDown(err error) bool {
+	if err == nil {
+		return false
+	}
 	urlErr, ok := err.(*url.Error)
 	if !ok {
 		return false
@@ -199,6 +215,10 @@ func isNetworkDown(err error) bool {
 }
 
 func isDnsUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	urlErr, ok := err.(*url.Error)
 	if !ok {
 		return false

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -98,6 +98,12 @@ func ShouldRetryAttempt(attempt *retry.Attempt, err error) bool {
 	return ShouldRetryError(err)
 }
 
+// ShouldRetryError returns true for transient network errors like when
+// the remote side returns a connection reset and it's sensible to rety
+// after a short time.
+//
+// XXX: Note that currently also NoNetwork(err) errors are repoarted
+// with true here.
 func ShouldRetryError(err error) bool {
 	if err == nil {
 		return false

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -99,7 +99,7 @@ func ShouldRetryAttempt(attempt *retry.Attempt, err error) bool {
 }
 
 // ShouldRetryError returns true for transient network errors like when
-// the remote side returns a connection reset and it's sensible to rety
+// the remote side returns a connection reset and it's sensible to retry
 // after a short time.
 //
 // XXX: Note that currently also NoNetwork(err) errors are reported

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -21,11 +21,13 @@ package devicestate
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
@@ -199,5 +201,13 @@ func MockBootMakeBootable(f func(model *asserts.Model, rootdir string, bootWith 
 	bootMakeBootable = f
 	return func() {
 		bootMakeBootable = old
+	}
+}
+
+func MockHttputilNewHTTPClient(f func(opts *httputil.ClientOptions) *http.Client) (restore func()) {
+	old := httputilNewHTTPClient
+	httputilNewHTTPClient = f
+	return func() {
+		httputilNewHTTPClient = old
 	}
 }

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -331,7 +331,7 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 	resp, err := client.Do(req)
 	if err != nil {
 		if !httputil.ShouldRetryError(err) {
-			// a non temporary net error errors out and do full
+			// a non temporary net error fully errors out and triggers a retry
 			// retries
 			return "", fmt.Errorf("cannot retrieve request-id for making a request for a serial: %v", err)
 		}

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -331,13 +331,17 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 	resp, err := client.Do(req)
 	if err != nil {
 		if !httputil.ShouldRetryError(err) {
-			// a non temporary net error, like a DNS no
-			// host, error out and do full retries
+			// a non temporary net error errors out and do full
+			// retries
 			return "", fmt.Errorf("cannot retrieve request-id for making a request for a serial: %v", err)
 		}
 		if httputil.NoNetwork(err) {
-			noNetwrokRetryIntervall := 30 * time.Second
-			return "", &state.Retry{After: noNetwrokRetryIntervall}
+			// Retry quickly if there is no network
+			// (yet). This ensures that we try to get a serial
+			// as soon as the user configured the network of the
+			// device
+			noNetworkRetryInterval := 30 * time.Second
+			return "", &state.Retry{After: noNetworkRetryInterval}
 		}
 
 		return "", retryErr(t, nTentatives, "cannot retrieve request-id for making a request for a serial: %v", err)

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -335,6 +335,11 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 			// host, error out and do full retries
 			return "", fmt.Errorf("cannot retrieve request-id for making a request for a serial: %v", err)
 		}
+		if httputil.NoNetwork(err) {
+			noNetwrokRetryIntervall := 30 * time.Second
+			return "", &state.Retry{After: noNetwrokRetryIntervall}
+		}
+
 		return "", retryErr(t, nTentatives, "cannot retrieve request-id for making a request for a serial: %v", err)
 	}
 	defer resp.Body.Close()

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -343,9 +343,8 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 			// and it replies with something we need to retry
 			// we will not because nTentatives is way over the
 			// limit.
-			nTentatives--
 			st.Lock()
-			t.Set("pre-poll-tentatives", nTentatives)
+			t.Set("pre-poll-tentatives", 0)
 			st.Unlock()
 			// Retry quickly if there is no network
 			// (yet). This ensures that we try to get a serial

--- a/tests/main/retry-network/detect-retry.go
+++ b/tests/main/retry-network/detect-retry.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/snapcore/snapd/httputil"
+	"github.com/snapcore/snapd/logger"
+)
+
+func main() {
+	logger.SimpleSetup()
+	if len(os.Args) < 2 {
+		fmt.Println("need url as first argument")
+		os.Exit(1)
+	}
+
+	_, err := http.Get(os.Args[1])
+	fmt.Printf("ShouldRetryError: %v\n", httputil.ShouldRetryError(err))
+	fmt.Printf("NoNetwork: %v\n", httputil.NoNetwork(err))
+}

--- a/tests/main/retry-network/task.yaml
+++ b/tests/main/retry-network/task.yaml
@@ -1,0 +1,30 @@
+summary: Test httputil/retry.go ShouldRetryError(err)/NoNetwork(err)
+
+# ubuntu-core: no go-compiler
+systems: [-ubuntu-core-*]
+
+environment:
+    # an empty $topsrcdir/tests/go.mod seems to break importing or building go
+    # packages referenced by their import paths while under the tests directory,
+    # need to disable go modules supportfor this test
+    GO111MODULE: off
+
+prepare: |
+    go build -o detect-retry ./detect-retry.go
+
+restore: |
+    ip netns delete testns || true
+    umount /run/netns || true
+
+execute: |
+    echo "Add totally unconnected network namespace"
+    ip netns add testns
+    SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry http://www.ubuntu.com > output.txt
+    #MATCH "ShouldRetryError: false" < output.txt
+    MATCH "NoNetwork: true" < output.txt
+
+    echo "Now without DNS resolver"
+    UBUNTU_IP="$(getent hosts www.ubuntu.com|awk '{print $1 }' | head -n1)"
+    SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry "http://$UBUNTU_IP" > output.txt
+    #MATCH "ShouldRetryError: false" < output.txt
+    MATCH "NoNetwork: true" < output.txt

--- a/tests/main/retry-network/task.yaml
+++ b/tests/main/retry-network/task.yaml
@@ -1,7 +1,8 @@
 summary: Test httputil/retry.go ShouldRetryError(err)/NoNetwork(err)
 
 # ubuntu-core: no go-compiler
-systems: [-ubuntu-core-*]
+# ubuntu-14.04: no nsenter
+systems: [-ubuntu-core-*, -ubuntu-14.04-*]
 
 environment:
     # an empty $topsrcdir/tests/go.mod seems to break importing or building go
@@ -16,15 +17,27 @@ restore: |
     ip netns delete testns || true
     umount /run/netns || true
 
+debug: |
+   cat output.txt || true
+   cat stderr || true
+
 execute: |
     echo "Add totally unconnected network namespace"
     ip netns add testns
-    SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry http://www.ubuntu.com > output.txt
-    #MATCH "ShouldRetryError: false" < output.txt
+    SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry http://www.ubuntu.com > output.txt 2>stderr
+    # XXX: ShouldRetryError is slightly misbehaving, if we know we don't have
+    #      a network connection we should not retry. However we keep it as
+    #      it is for now to be sure we don't add regressions.
+    MATCH "ShouldRetryError: true" < output.txt
     MATCH "NoNetwork: true" < output.txt
+    # be paranoid and look at the low-level go error as well
+    MATCH "(Temporary failure in name resolution|network is unreachable)" < stderr
 
     echo "Now without DNS resolver"
     UBUNTU_IP="$(getent hosts www.ubuntu.com|awk '{print $1 }' | head -n1)"
-    SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry "http://$UBUNTU_IP" > output.txt
-    #MATCH "ShouldRetryError: false" < output.txt
+    SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry "http://$UBUNTU_IP" > output.txt 2>stderr
+    # XXX: ShouldRetryError is slightly misbehaving, see comment above
+    MATCH "ShouldRetryError: true" < output.txt
     MATCH "NoNetwork: true" < output.txt
+    # be paranoid and look at the low-level go error as well
+    MATCH "network is unreachable" < stderr

--- a/tests/main/retry-network/task.yaml
+++ b/tests/main/retry-network/task.yaml
@@ -7,7 +7,7 @@ systems: [-ubuntu-core-*, -ubuntu-14.04-*]
 environment:
     # an empty $topsrcdir/tests/go.mod seems to break importing or building go
     # packages referenced by their import paths while under the tests directory,
-    # need to disable go modules supportfor this test
+    # need to disable go modules support for this test
     GO111MODULE: off
 
 prepare: |


### PR DESCRIPTION
This adds a new helper NoNetwork(err) and a spread test that
ensures that the errors behave sanely on all our tested systems.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
