### PR TITLE
spread: move centos to stable systems

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -349,7 +349,7 @@ if [ -n "$SPREAD" ]; then
             ;;
         unstable)
             # check if we have any systems first
-            if spread -list "google-unstable:" 2>&1 | grep -q -E 'no systems specified for backend'; then
+            if spread -list "google-unstable:" 2>&1 | grep -q -E 'nothing matches'; then
                 echo "No unstable systems to run the tests on"
             else
                 spread "google-unstable:"

--- a/run-checks
+++ b/run-checks
@@ -348,7 +348,12 @@ if [ -n "$SPREAD" ]; then
             spread "google:[^u]...:tests/..."
             ;;
         unstable)
-            spread "google-unstable:"
+            # check if we have any systems first
+            if spread -list "google-unstable:" 2>&1 | grep -q -E 'no systems specified for backend'; then
+                echo "No unstable systems to run the tests on"
+            else
+                spread "google-unstable:"
+            fi
             ;;
         *)
             echo "Spread parameter $SPREAD not supported"

--- a/spread.yaml
+++ b/spread.yaml
@@ -110,15 +110,16 @@ backends:
                 workers: 6
                 storage: preserve-size
 
+            - centos-7-64:
+                workers: 6
+                image: centos-7-64
+
     google-unstable:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
         location: computeengine/us-east1-b
         halt-timeout: 2h
         systems:
-            - centos-7-64:
-                workers: 6
-                image: centos-7-64
 
     google-tpm:
         type: google

--- a/spread.yaml
+++ b/spread.yaml
@@ -114,12 +114,16 @@ backends:
                 workers: 6
                 image: centos-7-64
 
-    google-unstable:
-        type: google
-        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: computeengine/us-east1-b
-        halt-timeout: 2h
-        systems:
+    # TODO: spread is really unhappy when it sees a backend without any systems,
+    # so this block is intentially kept commented out, until we need to add
+    # systems to it
+    #
+    # google-unstable:
+    #     type: google
+    #     key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+    #     location: computeengine/us-east1-b
+    #     halt-timeout: 2h
+    #     systems:
 
     google-tpm:
         type: google


### PR DESCRIPTION
Looks like https://bugs.centos.org/view.php?id=16441 is fixed. The test
suite can complete on CentOS 7.6 without errors now.
