### PR TITLE
o/devicestate: StartOfOperationTime helper for Prune (1/2)

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -562,6 +562,9 @@ var timeNow = time.Now
 // or current time otherwise.
 func (m *DeviceManager) StartOfOperationTime() (time.Time, error) {
 	var opTime time.Time
+	if m.preseed {
+		return opTime, fmt.Errorf("internal error: unexpected call to StartOfOperationTime in preseed-mode")
+	}
 	err := m.state.Get("start-of-operation-time", &opTime)
 	if err == nil {
 		return opTime, nil

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -556,12 +556,13 @@ func (m *DeviceManager) ensureInstalled() error {
 
 var timeNow = time.Now
 
-// OperationalTime returns the time when snapd became operational, and sets it
-// in the state when called for the first time. The operational time is
-// seed-time if available, or current time otherwise.
-func (m *DeviceManager) OperationalTime() (time.Time, error) {
+// StartOfOperationTime returns the time when snapd started operating,
+// and sets it in the state when called for the first time.
+// The StartOfOperationTime time is seed-time if available,
+// or current time otherwise.
+func (m *DeviceManager) StartOfOperationTime() (time.Time, error) {
 	var opTime time.Time
-	err := m.state.Get("operational-time", &opTime)
+	err := m.state.Get("start-of-operation-time", &opTime)
 	if err == nil {
 		return opTime, nil
 	}
@@ -569,7 +570,7 @@ func (m *DeviceManager) OperationalTime() (time.Time, error) {
 		return opTime, err
 	}
 
-	// operational-time not set yet
+	// start-of-operation-time not set yet, use seed-time if available
 	var seedTime time.Time
 	err = m.state.Get("seed-time", &seedTime)
 	if err != nil && err != state.ErrNoState {
@@ -580,7 +581,7 @@ func (m *DeviceManager) OperationalTime() (time.Time, error) {
 	} else {
 		opTime = timeNow()
 	}
-	m.state.Set("operational-time", opTime)
+	m.state.Set("start-of-operation-time", opTime)
 	return opTime, nil
 }
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -563,7 +563,7 @@ var timeNow = time.Now
 func (m *DeviceManager) StartOfOperationTime() (time.Time, error) {
 	var opTime time.Time
 	if m.preseed {
-		return opTime, fmt.Errorf("internal error: unexpected call to StartOfOperationTime in preseed-mode")
+		return opTime, fmt.Errorf("internal error: unexpected call to StartOfOperationTime in preseed mode")
 	}
 	err := m.state.Get("start-of-operation-time", &opTime)
 	if err == nil {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1136,3 +1136,48 @@ func (s *deviceMgrSuite) TestDeviceManagerEmptyOperatingModeRun(c *C) {
 	// empty is returned as "run"
 	c.Check(s.mgr.OperatingMode(), Equals, "run")
 }
+
+func (s *deviceMgrSuite) TestOperationalTimeFromSeedTime(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	seedTime := time.Now().AddDate(0, -1, 0)
+	st.Set("seed-time", seedTime)
+
+	operationalTime, err := s.mgr.OperationalTime()
+	c.Assert(err, IsNil)
+	c.Check(operationalTime, Equals, seedTime)
+
+	var op time.Time
+	st.Get("operational-time", &op)
+	c.Check(op, Equals, operationalTime)
+}
+
+func (s *deviceMgrSuite) TestOperationalTimeAlreadySet(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	op := time.Now().AddDate(0, -1, 0)
+	st.Set("operational-time", op)
+
+	operationalTime, err := s.mgr.OperationalTime()
+	c.Assert(err, IsNil)
+	c.Check(operationalTime, Equals, op)
+}
+
+func (s *deviceMgrSuite) TestOperationalTimeNoSeedTime(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	now := time.Now()
+	devicestate.MockTimeNow(func() time.Time {
+		return now
+	})
+
+	operationalTime, err := s.mgr.OperationalTime()
+	c.Assert(err, IsNil)
+	c.Check(operationalTime, Equals, now)
+}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1188,3 +1188,18 @@ func (s *deviceMgrSuite) TestStartOfOperationTimeNoSeedTime(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(operationTime.Equal(prev), Equals, true)
 }
+
+func (s *deviceMgrSuite) TestStartOfOperationErrorIfPreseed(c *C) {
+	restore := release.MockPreseedMode(func() bool { return true })
+	defer restore()
+
+	st := s.state
+
+	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), s.newStore)
+	c.Assert(err, IsNil)
+
+	st.Lock()
+	defer st.Unlock()
+	_, err = mgr.StartOfOperationTime()
+	c.Assert(err, ErrorMatches, `internal error: unexpected call to StartOfOperationTime in preseed-mode`)
+}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1147,11 +1147,11 @@ func (s *deviceMgrSuite) TestOperationalTimeFromSeedTime(c *C) {
 
 	operationalTime, err := s.mgr.OperationalTime()
 	c.Assert(err, IsNil)
-	c.Check(operationalTime, Equals, seedTime)
+	c.Check(operationalTime.Equal(seedTime), Equals, true)
 
 	var op time.Time
 	st.Get("operational-time", &op)
-	c.Check(op, Equals, operationalTime)
+	c.Check(op.Equal(operationalTime), Equals, true)
 }
 
 func (s *deviceMgrSuite) TestOperationalTimeAlreadySet(c *C) {
@@ -1164,7 +1164,7 @@ func (s *deviceMgrSuite) TestOperationalTimeAlreadySet(c *C) {
 
 	operationalTime, err := s.mgr.OperationalTime()
 	c.Assert(err, IsNil)
-	c.Check(operationalTime, Equals, op)
+	c.Check(operationalTime.Equal(op), Equals, true)
 }
 
 func (s *deviceMgrSuite) TestOperationalTimeNoSeedTime(c *C) {
@@ -1172,12 +1172,19 @@ func (s *deviceMgrSuite) TestOperationalTimeNoSeedTime(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	now := time.Now()
+	now := time.Now().Add(-1 * time.Second)
 	devicestate.MockTimeNow(func() time.Time {
 		return now
 	})
 
 	operationalTime, err := s.mgr.OperationalTime()
 	c.Assert(err, IsNil)
-	c.Check(operationalTime, Equals, now)
+	c.Check(operationalTime.Equal(now), Equals, true)
+
+	// repeated call returns already set time
+	prev := now
+	now = time.Now().Add(-10 * time.Hour)
+	operationalTime, err = s.mgr.OperationalTime()
+	c.Assert(err, IsNil)
+	c.Check(operationalTime.Equal(prev), Equals, true)
 }

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1201,5 +1201,5 @@ func (s *deviceMgrSuite) TestStartOfOperationErrorIfPreseed(c *C) {
 	st.Lock()
 	defer st.Unlock()
 	_, err = mgr.StartOfOperationTime()
-	c.Assert(err, ErrorMatches, `internal error: unexpected call to StartOfOperationTime in preseed-mode`)
+	c.Assert(err, ErrorMatches, `internal error: unexpected call to StartOfOperationTime in preseed mode`)
 }

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1137,7 +1137,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEmptyOperatingModeRun(c *C) {
 	c.Check(s.mgr.OperatingMode(), Equals, "run")
 }
 
-func (s *deviceMgrSuite) TestOperationalTimeFromSeedTime(c *C) {
+func (s *deviceMgrSuite) TestStartOfOperationTimeFromSeedTime(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -1145,29 +1145,29 @@ func (s *deviceMgrSuite) TestOperationalTimeFromSeedTime(c *C) {
 	seedTime := time.Now().AddDate(0, -1, 0)
 	st.Set("seed-time", seedTime)
 
-	operationalTime, err := s.mgr.OperationalTime()
+	operationTime, err := s.mgr.StartOfOperationTime()
 	c.Assert(err, IsNil)
-	c.Check(operationalTime.Equal(seedTime), Equals, true)
+	c.Check(operationTime.Equal(seedTime), Equals, true)
 
 	var op time.Time
-	st.Get("operational-time", &op)
-	c.Check(op.Equal(operationalTime), Equals, true)
+	st.Get("start-of-operation-time", &op)
+	c.Check(op.Equal(operationTime), Equals, true)
 }
 
-func (s *deviceMgrSuite) TestOperationalTimeAlreadySet(c *C) {
+func (s *deviceMgrSuite) TestStartOfOperationTimeAlreadySet(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
 
 	op := time.Now().AddDate(0, -1, 0)
-	st.Set("operational-time", op)
+	st.Set("start-of-operation-time", op)
 
-	operationalTime, err := s.mgr.OperationalTime()
+	operationTime, err := s.mgr.StartOfOperationTime()
 	c.Assert(err, IsNil)
-	c.Check(operationalTime.Equal(op), Equals, true)
+	c.Check(operationTime.Equal(op), Equals, true)
 }
 
-func (s *deviceMgrSuite) TestOperationalTimeNoSeedTime(c *C) {
+func (s *deviceMgrSuite) TestStartOfOperationTimeNoSeedTime(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -1177,14 +1177,14 @@ func (s *deviceMgrSuite) TestOperationalTimeNoSeedTime(c *C) {
 		return now
 	})
 
-	operationalTime, err := s.mgr.OperationalTime()
+	operationTime, err := s.mgr.StartOfOperationTime()
 	c.Assert(err, IsNil)
-	c.Check(operationalTime.Equal(now), Equals, true)
+	c.Check(operationTime.Equal(now), Equals, true)
 
 	// repeated call returns already set time
 	prev := now
 	now = time.Now().Add(-10 * time.Hour)
-	operationalTime, err = s.mgr.OperationalTime()
+	operationTime, err = s.mgr.StartOfOperationTime()
 	c.Assert(err, IsNil)
-	c.Check(operationalTime.Equal(prev), Equals, true)
+	c.Check(operationTime.Equal(prev), Equals, true)
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -70,6 +70,14 @@ func MockMaxTentatives(max int) (restore func()) {
 	}
 }
 
+func MockTimeNow(f func() time.Time) (restore func()) {
+	old := timeNow
+	timeNow = f
+	return func() {
+		timeNow = old
+	}
+}
+
 func KeypairManager(m *DeviceManager) asserts.KeypairManager {
 	return m.keypairMgr
 }


### PR DESCRIPTION
Implement the `StartOfOperationTime()` helper for devicemgr, to be used with `Prune(...)`. 

StartOfOperationTime is set on first use from seed-time (if available), or otherwise from current time. It then remains unchanged for the entire lifetime of snapd. The idea is to pass this time to `Prune` method from overlord to aid in the decision regarding aborting of past changes, with the aim to fix a potential problem of aborting of changes with old SpawnTime on preseeded image.
