### PR TITLE
boot: add current_kernels to modeenv

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -103,13 +103,13 @@ func generateMountsModeInstall(recoverySystem string) error {
 			return err
 		}
 		perf := timings.New(nil)
-		// XXX: LoadMeta will verify all the snaps in the
+		// TODO:UC20: LoadMeta will verify all the snaps in the
 		// seed, that is probably too much. We can expose more
 		// dedicated helpers for this later.
 		if err := systemSeed.LoadMeta(perf); err != nil {
 			return err
 		}
-		// XXX: do we need more cross checks here?
+		// TODO:UC20: do we need more cross checks here?
 		for _, essentialSnap := range systemSeed.EssentialSnaps() {
 			snapf, err := snap.Open(essentialSnap.Path)
 			if err != nil {


### PR DESCRIPTION
This will be used in a followup PR to verify that the kernel snap specified by the symlink on ubuntu-boot is indeed a trusted kernel snap we should have the initramfs mount modules from. 

It's expected that current_kernels has 3 possible states:
- no kernels, this is true during install mode
- 1 kernel snap, this is expected during run mode when we are not trying a kernel snap
- 2 kernel snaps, this is expected during run mode when we are trying a new kernel snap

I opened just this change to hopefully clarify any naming things before I open up the followups where we write this and use it. 