### PR TITLE
systemd: improve is-active check for 'failed' services

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -496,10 +496,16 @@ func (s *systemd) IsActive(serviceName string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	// "systemctl is-active <name>" prints `inactive\n` to stderr and returns exit code 1 for inactive services
+	// "systemctl is-active <name>" returns exit code 3 for inactive
+	// services, the stderr output may be `inactive\n` for services that are
+	// inactive (or not found), or `failed\n` for services that are in a
+	// failed state; nevertheless make sure to check any non-0 exit code
 	sysdErr, ok := err.(*Error)
-	if ok && sysdErr.exitCode > 0 && strings.TrimSpace(string(sysdErr.msg)) == "inactive" {
-		return false, nil
+	if ok {
+		switch strings.TrimSpace(string(sysdErr.msg)) {
+		case "inactive", "failed":
+			return false, nil
+		}
 	}
 	return false, err
 }


### PR DESCRIPTION
The following failure was seen in the wild:

```
+ echo 'Installing a new snapd snap'
Installing a new snapd snap
+ snap install --dangerous /var/lib/snapd/snaps/snapd_x1.snap
error: cannot perform the following tasks:
- Make current revision for snap "snapd" unavailable ([--root / is-active snapd.core-fixup.service] failed with exit status 3: failed
)
- Make snap "snapd" (unset) available to the system ([--root / is-active snapd.core-fixup.service] failed with exit status 3: failed
)
```

When a service is in failed state, `systemctl is-active`, returns 3 and prints
out `failed\n` to stderr. Extend the current checks to cover this case.

Document that `systemctl is-active` check for non-active service exits with
error code 3, but we check any non-0 exit status.

