### PR TITLE
cmd/snap-confine: deny snap-confine to load nss libs

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -28,6 +28,11 @@
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_files-[0-9]*.so* mr,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_mymachines.[0-9]*.so* mr,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_systemd.[0-9]*.so* mr,
+    /etc/nsswitch.conf r,
+    /etc/passwd r,
     # normal libs in order
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -28,11 +28,13 @@
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
-    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_files-[0-9]*.so* mr,
-    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_mymachines.[0-9]*.so* mr,
-    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_systemd.[0-9]*.so* mr,
-    /etc/nsswitch.conf r,
-    /etc/passwd r,
+    # Explicitly deny these accesses which show up on Arch to silence the
+    # denials for this unneeded access.
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_files-[0-9]*.so* mr,
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_mymachines.[0-9]*.so* mr,
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_systemd.[0-9]*.so* mr,
+    deny /etc/nsswitch.conf r,
+    deny /etc/passwd r,
     # normal libs in order
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -28,13 +28,6 @@
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
-    # Explicitly deny these accesses which show up on Arch to silence the
-    # denials for this unneeded access.
-    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_files-[0-9]*.so* mr,
-    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_mymachines.[0-9]*.so* mr,
-    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_systemd.[0-9]*.so* mr,
-    deny /etc/nsswitch.conf r,
-    deny /etc/passwd r,
     # normal libs in order
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,
@@ -572,4 +565,12 @@
     # silence noisy denials breaks nested lxd. Until the cause is determined,
     # do not use an explicit deny for unix. (LP: #1855355)
     #deny unix,
+
+    # Explicitly deny these accesses which show up on Arch to silence the
+    # denials for this unneeded access.
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_files-[0-9]*.so* mr,
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_mymachines.[0-9]*.so* mr,
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_systemd.[0-9]*.so* mr,
+    deny /etc/nsswitch.conf r,
+    deny /etc/passwd r,
 }


### PR DESCRIPTION
On Arch using snap-confine, during the device assignment process when we
shell out to snap-device-helper, we see several denials. For now deny them
as we don't want to open up the Pandora's box of NSS and confinement.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
