### PR TITLE
bootloader: make uboot a RecoveryAwareBootloader

### DIFF
--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -43,7 +43,7 @@ func MockAndroidBootFile(c *C, rootdir string, mode os.FileMode) {
 	c.Assert(err, IsNil)
 }
 
-func NewUboot(rootdir string) Bootloader {
+func NewUboot(rootdir string) RecoveryAwareBootloader {
 	return newUboot(rootdir)
 }
 


### PR DESCRIPTION
This commit adds support for uboot to be used as a
RecoveryAwareBootloader. It works similar to what we do in grub,
i.e. it will write a recovery system specific config into the
recovery system specific dir.

Uboot has the "env import" comamnd which will be used to get
this data.
