### PR TITLE
boot: write current_kernels in bootstate20, makebootable

### DIFF
--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -51,7 +50,7 @@ func (bsm *bootState20Modeenv) loadModeenv() error {
 	if bsm.modeenv != nil {
 		return nil
 	}
-	modeenv, err := ReadModeenv(dirs.GlobalRootDir)
+	modeenv, err := ReadModeenv("")
 	if err != nil {
 		return fmt.Errorf("cannot get snap revision: unable to read modeenv: %v", err)
 	}
@@ -273,7 +272,7 @@ func (bs20 *bootState20Base) loadModeenv() error {
 	if bs20.modeenv != nil {
 		return nil
 	}
-	modeenv, err := ReadModeenv(dirs.GlobalRootDir)
+	modeenv, err := ReadModeenv("")
 	if err != nil {
 		return fmt.Errorf("cannot get snap revision: unable to read modeenv: %v", err)
 	}

--- a/boot/boottest/modeenv.go
+++ b/boot/boottest/modeenv.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/dirs"
 )
 
 // ForceModeenv forces ReadModeenv to always return a specific Modeenv for a
@@ -30,7 +31,7 @@ import (
 // If rootdir is empty, then all invocations return the specified modeenv
 func ForceModeenv(rootdir string, m *boot.Modeenv) (restore func()) {
 	mock := func(callerrootdir string) (*boot.Modeenv, error) {
-		if rootdir == "" || callerrootdir == rootdir {
+		if rootdir == "" || rootdir == dirs.GlobalRootDir || callerrootdir == rootdir {
 			return m, nil
 		}
 

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -22,6 +22,7 @@ package boot_test
 import (
 	"errors"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -167,6 +168,15 @@ func (s *coreBootSetSuite) TestSetNextBoot20ForKernel(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
+	// default modeenv state
+	m := &boot.Modeenv{
+		Base:           "core20_1.snap",
+		CurrentKernels: []string{"pc-kernel_1.snap"},
+	}
+	err := m.Write("")
+	c.Assert(err, IsNil)
+	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
+
 	// setup current kernel
 	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
 	c.Assert(err, IsNil)
@@ -202,6 +212,11 @@ func (s *coreBootSetSuite) TestSetNextBoot20ForKernel(c *C) {
 	// check that SetNextBoot asked the bootloader for a kernel
 	_, nKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("Kernel")
 	c.Assert(nKernelCalls, Equals, 1)
+
+	// and that the modeenv now has this kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{"pc-kernel_1.snap", "pc-kernel_2.snap"})
 }
 
 func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
@@ -230,6 +245,15 @@ func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 func (s *coreBootSetSuite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	// default modeenv state
+	m := &boot.Modeenv{
+		Base:           "core20_1.snap",
+		CurrentKernels: []string{"pc-kernel_1.snap"},
+	}
+	err := m.Write("")
+	c.Assert(err, IsNil)
+	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// setup current kernel
 	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
@@ -262,6 +286,11 @@ func (s *coreBootSetSuite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 	// check that SetNextBoot asked the bootloader for a kernel
 	_, nKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("Kernel")
 	c.Assert(nKernelCalls, Equals, 1)
+
+	// and that the modeenv now has this kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{"pc-kernel_1.snap"})
 }
 
 func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C) {
@@ -295,6 +324,15 @@ func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C)
 func (s *coreBootSetSuite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	// default modeenv state
+	m := &boot.Modeenv{
+		Base:           "core20_1.snap",
+		CurrentKernels: []string{"pc-kernel_1.snap"},
+	}
+	err := m.Write("")
+	c.Assert(err, IsNil)
+	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// setup current kernel
 	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
@@ -332,6 +370,11 @@ func (s *coreBootSetSuite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *
 	// check that SetNextBoot asked the bootloader for a kernel
 	_, nKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("Kernel")
 	c.Assert(nKernelCalls, Equals, 1)
+
+	// and that the modeenv didn't change
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, m.CurrentKernels)
 }
 
 // ubootBootSetSuite tests the uboot specific code in the bootloader handling

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -211,6 +211,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		Mode:           "run",
 		RecoverySystem: filepath.Base(bootWith.RecoverySystemDir),
 		Base:           filepath.Base(bootWith.BasePath),
+		CurrentKernels: []string{filepath.Base(bootWith.Kernel.MountFile())},
 	}
 	if err := modeenv.Write(filepath.Join(runMnt, "ubuntu-data", "system-data")); err != nil {
 		return fmt.Errorf("cannot write modeenv: %v", err)

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -211,7 +211,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		Mode:           "run",
 		RecoverySystem: filepath.Base(bootWith.RecoverySystemDir),
 		Base:           filepath.Base(bootWith.BasePath),
-		CurrentKernels: []string{filepath.Base(bootWith.Kernel.MountFile())},
+		CurrentKernels: []string{bootWith.Kernel.Filename()},
 	}
 	if err := modeenv.Write(filepath.Join(runMnt, "ubuntu-data", "system-data")); err != nil {
 		return fmt.Errorf("cannot write modeenv: %v", err)

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -356,5 +356,6 @@ version: 5.0
 	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, `mode=run
 recovery_system=20191216
 base=core20_3.snap
+current_kernels=pc-kernel_5.snap
 `)
 }


### PR DESCRIPTION
This change implements adding the next kernel snap to the list in the modeenv, so that the initramfs trusts the new kernel snap and loads the kernel modules from the new kernel snap when we reboot.

It also implements removing the old kernel snap from the modeenv when we successfully boot a kernel snap, so that there is only 2 kernel snaps during the specific reboot cycle between trying a new kernel snap and switching state to the new one after we reboot. All other times it should only contain the current, active kernel snap specified by the kernel.efi symlink on ubuntu-boot.

It also adds to current_kernels the current kernel from the seed when we are transitioning to run mode.