### PR TITLE
interfaces/{desktop-legacy,unity7}: adjust for new ibus socket location

### DIFF
--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -125,6 +125,15 @@ unix (connect, receive, send)
     type=stream
     peer=(addr="@/tmp/ibus/dbus-*"),
 
+# abstract path in ibus >= 1.5.22 uses $XDG_CACHE_HOME (ie, @{HOME}/.cache)
+# This should use this, but due to LP: #1856738 we cannot
+#unix (connect, receive, send)
+#    type=stream
+#    peer=(addr="@@{HOME}/.cache/ibus/dbus-*"),
+unix (connect, receive, send)
+     type=stream
+     peer=(addr="@/home/*/.cache/ibus/dbus-*"),
+
 
 # mozc
 # allow communicating with mozc server

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -135,6 +135,15 @@ unix (connect, receive, send)
      type=stream
      peer=(addr="@/tmp/ibus/dbus-*"),
 
+# abstract path in ibus >= 1.5.22 uses $XDG_CACHE_HOME (ie, @{HOME}/.cache)
+# This should use this, but due to LP: #1856738 we cannot
+#unix (connect, receive, send)
+#    type=stream
+#    peer=(addr="@@{HOME}/.cache/ibus/dbus-*"),
+unix (connect, receive, send)
+     type=stream
+     peer=(addr="@/home/*/.cache/ibus/dbus-*"),
+
 
 # input methods (mozc)
 # allow communicating with mozc server (TODO: investigate if allows sniffing)


### PR DESCRIPTION
IBus 1.5.22 changed the abstract socket path. This version is currently
in Ubuntu 20.04 and while the apparmor ibus abstraction in 20.04 was
adjusted for this path, snapd uses a subset of that abstraction and
needs a corresponding update. This provides that update.

References:
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1580463/comments/37