### PR TITLE
interfaces/desktop-legacy: ibus socket path has moved in focal

### DIFF
--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -124,6 +124,9 @@ owner @{HOME}/.config/ibus/bus/* r,
 unix (connect, receive, send)
     type=stream
     peer=(addr="@/tmp/ibus/dbus-*"),
+unix (connect, receive, send)
+    type=stream
+    peer=(addr="@/home/*/.cache/ibus/dbus-*"),
 
 
 # mozc


### PR DESCRIPTION
See https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1863255

Signed-off-by: Alex Murray <alex.murray@canonical.com>
