### PR TITLE
tests: use Filename() instead of filepath.Base(sn.MountFile())

### DIFF
--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -102,14 +102,14 @@ func (s *makeBootableSuite) TestMakeBootable(c *C) {
 type: base
 version: 4.0
 `, snap.R(3))
-	baseInSeed := filepath.Join(seedSnapsDirs, filepath.Base(baseInfo.MountFile()))
+	baseInSeed := filepath.Join(seedSnapsDirs, baseInfo.Filename())
 	err = os.Rename(baseFn, baseInSeed)
 	c.Assert(err, IsNil)
 	kernelFn, kernelInfo := s.makeSnap(c, "pc-kernel", `name: pc-kernel
 type: kernel
 version: 4.0
 `, snap.R(5))
-	kernelInSeed := filepath.Join(seedSnapsDirs, filepath.Base(kernelInfo.MountFile()))
+	kernelInSeed := filepath.Join(seedSnapsDirs, kernelInfo.Filename())
 	err = os.Rename(kernelFn, kernelInSeed)
 	c.Assert(err, IsNil)
 
@@ -135,14 +135,14 @@ version: 4.0
 	c.Check(s.bootloader.ExtractKernelAssetsCalls, DeepEquals, []snap.PlaceInfo{kernelInfo})
 
 	// check symlinks from snap blob dir
-	kernelBlob := filepath.Join(dirs.SnapBlobDirUnder(rootdir), filepath.Base(kernelInfo.MountFile()))
-	dst, err := os.Readlink(filepath.Join(dirs.SnapBlobDirUnder(rootdir), filepath.Base(kernelInfo.MountFile())))
+	kernelBlob := filepath.Join(dirs.SnapBlobDirUnder(rootdir), kernelInfo.Filename())
+	dst, err := os.Readlink(filepath.Join(dirs.SnapBlobDirUnder(rootdir), kernelInfo.Filename()))
 	c.Assert(err, IsNil)
 	c.Check(dst, Equals, "../seed/snaps/pc-kernel_5.snap")
 	c.Check(kernelBlob, testutil.FilePresent)
 
-	baseBlob := filepath.Join(dirs.SnapBlobDirUnder(rootdir), filepath.Base(baseInfo.MountFile()))
-	dst, err = os.Readlink(filepath.Join(dirs.SnapBlobDirUnder(rootdir), filepath.Base(baseInfo.MountFile())))
+	baseBlob := filepath.Join(dirs.SnapBlobDirUnder(rootdir), baseInfo.Filename())
+	dst, err = os.Readlink(filepath.Join(dirs.SnapBlobDirUnder(rootdir), baseInfo.Filename()))
 	c.Assert(err, IsNil)
 	c.Check(dst, Equals, "../seed/snaps/core18_3.snap")
 	c.Check(baseBlob, testutil.FilePresent)
@@ -202,7 +202,7 @@ func (s *makeBootableSuite) TestMakeBootable20(c *C) {
 type: base
 version: 5.0
 `, snap.R(3))
-	baseInSeed := filepath.Join(seedSnapsDirs, filepath.Base(baseInfo.MountFile()))
+	baseInSeed := filepath.Join(seedSnapsDirs, baseInfo.Filename())
 	err = os.Rename(baseFn, baseInSeed)
 	c.Assert(err, IsNil)
 	kernelFn, kernelInfo := s.makeSnapWithFiles(c, "pc-kernel", `name: pc-kernel
@@ -211,7 +211,7 @@ version: 5.0
 `, snap.R(5), [][]string{
 		{"kernel.efi", "I'm a kernel.efi"},
 	})
-	kernelInSeed := filepath.Join(seedSnapsDirs, filepath.Base(kernelInfo.MountFile()))
+	kernelInSeed := filepath.Join(seedSnapsDirs, kernelInfo.Filename())
 	err = os.Rename(kernelFn, kernelInSeed)
 	c.Assert(err, IsNil)
 
@@ -295,7 +295,7 @@ func (s *makeBootableSuite) TestMakeBootable20RunMode(c *C) {
 type: base
 version: 5.0
 `, snap.R(3))
-	baseInSeed := filepath.Join(seedSnapsDirs, filepath.Base(baseInfo.MountFile()))
+	baseInSeed := filepath.Join(seedSnapsDirs, baseInfo.Filename())
 	err = os.Rename(baseFn, baseInSeed)
 	c.Assert(err, IsNil)
 	kernelFn, kernelInfo := s.makeSnapWithFiles(c, "pc-kernel", `name: pc-kernel
@@ -306,7 +306,7 @@ version: 5.0
 			{"kernel.efi", "I'm a kernel.efi"},
 		},
 	)
-	kernelInSeed := filepath.Join(seedSnapsDirs, filepath.Base(kernelInfo.MountFile()))
+	kernelInSeed := filepath.Join(seedSnapsDirs, kernelInfo.Filename())
 	err = os.Rename(kernelFn, kernelInSeed)
 	c.Assert(err, IsNil)
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -578,7 +578,7 @@ func (s *imageSuite) TestSetupSeed(c *C) {
 	// check the files are in place
 	for i, name := range []string{"core", "pc-kernel", "pc"} {
 		info := s.AssertedSnapInfo(name)
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(seedsnapsdir, fn)
 		c.Check(p, testutil.FilePresent)
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
@@ -597,7 +597,7 @@ func (s *imageSuite) TestSetupSeed(c *C) {
 		}
 	}
 	c.Check(runSnaps[0], DeepEquals, &seed.Snap{
-		Path: filepath.Join(seedsnapsdir, filepath.Base(s.AssertedSnapInfo("required-snap1").MountFile())),
+		Path: filepath.Join(seedsnapsdir, s.AssertedSnapInfo("required-snap1").Filename()),
 
 		SideInfo: &s.AssertedSnapInfo("required-snap1").SideInfo,
 
@@ -637,13 +637,13 @@ func (s *imageSuite) TestSetupSeed(c *C) {
 	// check symlinks from snap blob dir
 	kernelInfo := s.AssertedSnapInfo("pc-kernel")
 	coreInfo := s.AssertedSnapInfo("core")
-	kernelBlob := filepath.Join(blobdir, filepath.Base(kernelInfo.MountFile()))
+	kernelBlob := filepath.Join(blobdir, kernelInfo.Filename())
 	dst, err := os.Readlink(kernelBlob)
 	c.Assert(err, IsNil)
 	c.Check(dst, Equals, "../seed/snaps/pc-kernel_2.snap")
 	c.Check(kernelBlob, testutil.FilePresent)
 
-	coreBlob := filepath.Join(blobdir, filepath.Base(coreInfo.MountFile()))
+	coreBlob := filepath.Join(blobdir, coreInfo.Filename())
 	dst, err = os.Readlink(coreBlob)
 	c.Assert(err, IsNil)
 	c.Check(dst, Equals, "../seed/snaps/core_3.snap")
@@ -720,7 +720,7 @@ func (s *imageSuite) TestSetupSeedLocalCoreBrandKernel(c *C) {
 			sideInfo = &info.SideInfo
 		}
 
-		fn := filepath.Base(pinfo.MountFile())
+		fn := pinfo.Filename()
 		p := filepath.Join(seedsnapsdir, fn)
 		c.Check(p, testutil.FilePresent)
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
@@ -792,7 +792,7 @@ func (s *imageSuite) TestSetupSeedDevmodeSnap(c *C) {
 	for i, name := range []string{"core", "pc-kernel", "pc"} {
 		info := s.AssertedSnapInfo(name)
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
-			Path:      filepath.Join(seedsnapsdir, filepath.Base(info.MountFile())),
+			Path:      filepath.Join(seedsnapsdir, info.Filename()),
 			SideInfo:  &info.SideInfo,
 			Essential: true,
 			Required:  true,
@@ -895,7 +895,7 @@ func (s *imageSuite) TestSetupSeedWithBase(c *C) {
 			}
 		}
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(seedsnapsdir, fn)
 		c.Check(p, testutil.FilePresent)
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
@@ -928,13 +928,13 @@ func (s *imageSuite) TestSetupSeedWithBase(c *C) {
 	// check symlinks from snap blob dir
 	kernelInfo := s.AssertedSnapInfo("pc-kernel")
 	baseInfo := s.AssertedSnapInfo("core18")
-	kernelBlob := filepath.Join(blobdir, filepath.Base(kernelInfo.MountFile()))
+	kernelBlob := filepath.Join(blobdir, kernelInfo.Filename())
 	dst, err := os.Readlink(kernelBlob)
 	c.Assert(err, IsNil)
 	c.Check(dst, Equals, "../seed/snaps/pc-kernel_2.snap")
 	c.Check(kernelBlob, testutil.FilePresent)
 
-	baseBlob := filepath.Join(blobdir, filepath.Base(baseInfo.MountFile()))
+	baseBlob := filepath.Join(blobdir, baseInfo.Filename())
 	dst, err = os.Readlink(baseBlob)
 	c.Assert(err, IsNil)
 	c.Check(dst, Equals, "../seed/snaps/core18_18.snap")
@@ -1054,7 +1054,7 @@ func (s *imageSuite) TestSetupSeedWithBaseLegacySnap(c *C) {
 			}
 		}
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(seedsnapsdir, fn)
 		c.Check(p, testutil.FilePresent)
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
@@ -1066,14 +1066,14 @@ func (s *imageSuite) TestSetupSeedWithBaseLegacySnap(c *C) {
 		})
 	}
 	c.Check(runSnaps[0], DeepEquals, &seed.Snap{
-		Path:     filepath.Join(seedsnapsdir, filepath.Base(s.AssertedSnapInfo("core").MountFile())),
+		Path:     filepath.Join(seedsnapsdir, s.AssertedSnapInfo("core").Filename()),
 		SideInfo: &s.AssertedSnapInfo("core").SideInfo,
 		Required: false, // strange but expected
 		Channel:  stableChannel,
 	})
 	c.Check(runSnaps[0].Path, testutil.FilePresent)
 	c.Check(runSnaps[1], DeepEquals, &seed.Snap{
-		Path:     filepath.Join(seedsnapsdir, filepath.Base(s.AssertedSnapInfo("required-snap1").MountFile())),
+		Path:     filepath.Join(seedsnapsdir, s.AssertedSnapInfo("required-snap1").Filename()),
 		SideInfo: &s.AssertedSnapInfo("required-snap1").SideInfo,
 		Required: true,
 		Channel:  stableChannel,
@@ -1219,7 +1219,7 @@ func (s *imageSuite) TestSetupSeedLocalSnapsWithStoreAsserts(c *C) {
 			}
 		}
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(seedsnapsdir, fn)
 		c.Check(p, testutil.FilePresent)
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
@@ -1314,7 +1314,7 @@ func (s *imageSuite) TestSetupSeedLocalSnapsWithChannels(c *C) {
 			}
 		}
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(seedsnapsdir, fn)
 		c.Check(p, testutil.FilePresent)
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
@@ -2162,7 +2162,7 @@ func (s *imageSuite) TestSetupSeedClassicSnapdOnly(c *C) {
 	for i, name := range []string{"snapd", "classic-gadget18", "core18"} {
 		info := s.AssertedSnapInfo(name)
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(seedsnapsdir, fn)
 		c.Check(p, testutil.FilePresent)
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
@@ -2386,7 +2386,7 @@ func (s *imageSuite) TestSetupSeedCore20(c *C) {
 			channel = "20"
 		}
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(seedsnapsdir, fn)
 		c.Check(p, testutil.FilePresent)
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -92,7 +92,7 @@ func (s *seed20Suite) makeSnap(c *C, yamlKey, publisher string) {
 }
 
 func (s *seed20Suite) expectedPath(snapName string) string {
-	return filepath.Join(s.SeedDir, "snaps", filepath.Base(s.AssertedSnapInfo(snapName).MountFile()))
+	return filepath.Join(s.SeedDir, "snaps", s.AssertedSnapInfo(snapName).Filename())
 }
 
 func (s *seed20Suite) TestLoadMetaCore20Minimal(c *C) {

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -195,7 +195,7 @@ func (s *writerSuite) doFillMetaDownloadedSnap(c *C, w *seedwriter.Writer, sn *s
 func (s *writerSuite) fillDownloadedSnap(c *C, w *seedwriter.Writer, sn *seedwriter.SeedSnap) {
 	info := s.doFillMetaDownloadedSnap(c, w, sn)
 
-	c.Assert(sn.Path, Equals, filepath.Join(s.opts.SeedDir, "snaps", filepath.Base(info.MountFile())))
+	c.Assert(sn.Path, Equals, filepath.Join(s.opts.SeedDir, "snaps", info.Filename()))
 	err := os.Rename(s.AssertedSnap(sn.SnapName()), sn.Path)
 	c.Assert(err, IsNil)
 }
@@ -809,7 +809,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 	for i, name := range []string{"snapd", "pc-kernel", "core18", "pc", "cont-consumer", "cont-producer"} {
 		info := s.AssertedSnapInfo(name)
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
 		c.Check(p, testutil.FilePresent)
 
@@ -1044,7 +1044,7 @@ func (s *writerSuite) TestLocalSnapsCore18FullUse(c *C) {
 			assertedNum++
 		}
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
 		c.Check(p, testutil.FilePresent)
 
@@ -1258,7 +1258,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicWithCore(c *C) {
 	for i, name := range []string{"core", "classic-gadget", "required"} {
 		info := s.AssertedSnapInfo(name)
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
 		c.Check(p, testutil.FilePresent)
 
@@ -1314,7 +1314,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicSnapdOnly(c *C) {
 	for i, name := range []string{"snapd", "core18", "classic-gadget18", "required18"} {
 		info := s.AssertedSnapInfo(name)
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
 		c.Check(p, testutil.FilePresent)
 
@@ -1423,7 +1423,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaExtraSnaps(c *C) {
 	for i, name := range []string{"snapd", "core", "pc-kernel", "core18", "pc", "cont-consumer", "cont-producer", "required"} {
 		info := s.AssertedSnapInfo(name)
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
 		c.Check(osutil.FileExists(p), Equals, true)
 
@@ -1575,7 +1575,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
 			unasserted = true
 		}
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
 		c.Check(osutil.FileExists(p), Equals, true)
 
@@ -1709,7 +1709,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20(c *C) {
 	for _, name := range []string{"snapd", "pc-kernel", "core20", "pc", "core18", "cont-consumer", "cont-producer"} {
 		info := s.AssertedSnapInfo(name)
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
 		c.Check(p, testutil.FilePresent)
 	}
@@ -2376,7 +2376,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ModelOverrideSnapd(c *C) {
 	for _, name := range []string{"snapd", "pc-kernel", "core20", "pc"} {
 		info := s.AssertedSnapInfo(name)
 
-		fn := filepath.Base(info.MountFile())
+		fn := info.Filename()
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
 		c.Check(p, testutil.FilePresent)
 	}
@@ -2544,7 +2544,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 
 		info := s.doFillMetaDownloadedSnap(c, w, sn)
 
-		c.Assert(sn.Path, Equals, filepath.Join(s.opts.SeedDir, "systems", s.opts.Label, "snaps", filepath.Base(info.MountFile())))
+		c.Assert(sn.Path, Equals, filepath.Join(s.opts.SeedDir, "systems", s.opts.Label, "snaps", info.Filename()))
 		err := os.Rename(s.AssertedSnap(sn.SnapName()), sn.Path)
 		c.Assert(err, IsNil)
 	}


### PR DESCRIPTION
These were missed in the initial implementation of Filename() because I wasn't searching the *test.go files for this pattern.