### PR TITLE
tests/core: add swapfiles test

### DIFF
--- a/tests/core/swapfiles/task.yaml
+++ b/tests/core/swapfiles/task.yaml
@@ -1,0 +1,30 @@
+summary: Ensure that we can create swapfiles
+
+prepare: |
+  cp /etc/default/swapfile swapfile.bk
+
+restore: |
+  if [ -f swapfile.bk ]; then 
+    cp swapfile.bk /etc/default/swapfile
+
+    # enabling the service now again will set swap to 0 because SIZE=0 means 
+    # don't create a swap file
+    systemctl enable --now swapfile.service || true
+  fi
+
+execute: |
+  echo "Set swapfile to 200"
+  # don't use sed -i because /etc/default is not writable and this will fail
+  sed -e "s/SIZE=0/SIZE=200/" /etc/default/swapfile > /tmp/swapfile
+  cat /tmp/swapfile > /etc/default/swapfile
+
+  echo "Turn on the swap service" 
+  systemctl enable --now swapfile.service
+
+  # source the file so that we can grep for the location of the swap file as
+  # configured
+  # shellcheck disable=SC1091
+  . /etc/default/swapfile
+
+  echo "Check that the swap file exists"
+  retry-tool -n 60 --wait 1 bash -c "cat /proc/swaps | MATCH '$FILE\s+file\s+204796'"


### PR DESCRIPTION
This ensures that we can create swap files on UC with the documented process at https://snapcraft.io/docs/t/enabling-swap-on-ubuntu-core/5440.