### PR TITLE
managers_test: add uc20 kernel snap update happy and panic tests

### DIFF
--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -38,6 +38,8 @@ type MockBootloader struct {
 	name    string
 	bootdir string
 
+	RebootStatusVar string
+
 	ExtractKernelAssetsCalls []snap.PlaceInfo
 	RemoveKernelAssetsCalls  []snap.PlaceInfo
 
@@ -73,6 +75,10 @@ func Mock(name, bootdir string) *MockBootloader {
 		panicMethods:                 make(map[string]bool),
 		runKernelImageMockedErrs:     make(map[string]error),
 		runKernelImageMockedNumCalls: make(map[string]int),
+
+		// this is for UC16/UC18 boot var for reboot
+		// for UC20, set to "kernel_status"
+		RebootStatusVar: "snap_mode",
 	}
 }
 
@@ -131,10 +137,10 @@ func (b *MockBootloader) SetBootBase(base string) {
 }
 
 func (b *MockBootloader) SetTryingDuringReboot() error {
-	if b.BootVars["snap_mode"] != "try" {
+	if b.BootVars[b.RebootStatusVar] != "try" {
 		return fmt.Errorf("bootloader must be in 'try' mode")
 	}
-	b.BootVars["snap_mode"] = "trying"
+	b.BootVars[b.RebootStatusVar] = "trying"
 	return nil
 }
 

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -226,6 +226,8 @@ func (b *MockBootloader) GetRunKernelImageFunctionSnapCalls(f string) ([]snap.Pl
 // EnableKernel enables the kernel; part of ExtractedRunKernelImageBootloader.
 func (b *MockBootloader) EnableKernel(s snap.PlaceInfo) error {
 	b.runKernelImageEnableKernelCalls = append(b.runKernelImageEnableKernelCalls, s)
+
+	b.runKernelImageEnabledKernel = s
 	return b.runKernelImageMockedErrs["EnableKernel"]
 }
 
@@ -233,6 +235,7 @@ func (b *MockBootloader) EnableKernel(s snap.PlaceInfo) error {
 // ExtractedRunKernelImageBootloader.
 func (b *MockBootloader) EnableTryKernel(s snap.PlaceInfo) error {
 	b.runKernelImageEnableTryKernelCalls = append(b.runKernelImageEnableTryKernelCalls, s)
+	b.runKernelImageEnabledTryKernel = s
 	return b.runKernelImageMockedErrs["EnableTryKernel"]
 }
 

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -120,7 +120,8 @@ func (t *firstBootBaseTest) startOverlord(c *C) {
 	c.Assert(ovld.StartUp(), IsNil)
 
 	// don't actually try to talk to the store on snapstate.Ensure
-	// needs doing after the call to devicestate.Manager (which happens in overlord.New)
+	// needs doing after the call to devicestate.Manager (which happens in
+	// overlord.New)
 	snapstate.CanAutoRefresh = nil
 }
 


### PR DESCRIPTION
The happy test here is working, but the panic'ing test is not working because the panic happens out-of-band from the Settle. I had an earlier prototype of this test working properly in just the devicestate tests, but there's something different about the managers test here that is making the panic happen sooner (or maybe I was just luckier with the devicestate test and this test happens to be slower than that one).