### PR TITLE
tests: disable archlinux system

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -104,6 +104,7 @@ backends:
             - opensuse-tumbleweed-64:
                 workers: 6
             - arch-linux-64:
+                manual: true
                 workers: 6
 
             - amazon-linux-2-64:


### PR DESCRIPTION
Arch linux system needs to be set as manual until a new brand new image
is created. 

There is a security issue associated to this image so it is going to be deleted.

