### PR TITLE
overlord/configstate: add backlight option

### DIFF
--- a/overlord/configstate/configcore/backlight.go
+++ b/overlord/configstate/configcore/backlight.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/systemd"
+)
+
+func init() {
+	// add supported configuration of this module
+	supportedConfigurations["core.system.disable-backlight-service"] = true
+}
+
+func validateBacklightServiceSettings(tr config.Conf) error {
+	return validateBoolFlag(tr, "system.disable-backlight-service")
+}
+
+type backlightSysdLogger struct{}
+
+func (l *backlightSysdLogger) Notify(status string) {
+	fmt.Fprintf(Stderr, "sysd: %s\n", status)
+}
+
+// systemd-backlight service has no installation config. It's started when needed via udev.
+// So, systemctl enable/disable/start/stop are invalid commands. After masking/unmasking
+// the service, rebooting is required for making new setting work
+func handleBacklightServiceConfiguration(tr config.Conf) error {
+	var serviceName string = "systemd-backlight@.service"
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, &backlightSysdLogger{})
+	output, err := coreCfg(tr, "system.disable-backlight-service")
+	if err != nil {
+		return nil
+	}
+	if output != "" {
+		switch output {
+		case "true":
+			return sysd.Mask(serviceName)
+		case "false":
+			return sysd.Unmask(serviceName)
+		default:
+			return fmt.Errorf("unsupported disable-backlight-service option: %q", output)
+		}
+	}
+	return nil
+}

--- a/overlord/configstate/configcore/backlight_test.go
+++ b/overlord/configstate/configcore/backlight_test.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/release"
+)
+
+type backlightSuite struct {
+	configcoreSuite
+}
+
+var _ = Suite(&backlightSuite{})
+
+func (s *backlightSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
+	c.Assert(err, IsNil)
+}
+
+func (s *backlightSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *backlightSuite) TestConfigureBacklightServiceMaskIntegration(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.systemctlArgs = nil
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.disable-backlight-service": true,
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.systemctlArgs, DeepEquals, [][]string{
+		{"--root", dirs.GlobalRootDir, "mask", "systemd-backlight@.service"},
+	})
+}
+
+func (s *backlightSuite) TestConfigureBacklightServiceUnmaskIntegration(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.systemctlArgs = nil
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.disable-backlight-service": false,
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.systemctlArgs, DeepEquals, [][]string{
+		{"--root", dirs.GlobalRootDir, "unmask", "systemd-backlight@.service"},
+	})
+}

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -88,6 +88,9 @@ func Run(tr config.Conf) error {
 	if err := validateNetworkSettings(tr); err != nil {
 		return err
 	}
+	if err := validateBacklightServiceSettings(tr); err != nil {
+		return err
+	}
 	if err := validateAutomaticSnapshotsExpiration(tr); err != nil {
 		return err
 	}
@@ -134,6 +137,10 @@ func Run(tr config.Conf) error {
 	}
 	// network.disable-ipv6
 	if err := handleNetworkConfiguration(tr); err != nil {
+		return err
+	}
+	// system.disable-backlight-service
+	if err := handleBacklightServiceConfiguration(tr); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Add an option to mask/unmask backlight service.
See systemd-backlight@.service for more information.

Both of core and core18 snap have /lib/systemd/system/systemd-backlight@.service