### PR TITLE
tests: set StartLimitInterval in snapd failover test

### DIFF
--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -133,6 +133,10 @@ func (c *cmdSnapd) Execute(args []string) error {
 	}
 
 	logger.Noticef("restarting snapd socket")
+	// we need to reset the failure state to be able to restart again
+	if output, err := exec.Command("systemctl", "reset-failed", "snapd.socket").CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
 	// at this point our manually started snapd stopped and
 	// removed the /run/snap* sockets (this is a feature of
 	// golang) - we need to restart snapd.socket to make them

--- a/cmd/snap-failure/cmd_snapd_test.go
+++ b/cmd/snap-failure/cmd_snapd_test.go
@@ -89,6 +89,7 @@ func (r *failureSuite) TestCallPrevSnapdFromSnap(c *C) {
 	})
 	c.Check(systemctlCmd.Calls(), DeepEquals, [][]string{
 		{"systemctl", "stop", "snapd.socket"},
+		{"systemctl", "reset-failed", "snapd.socket"},
 		{"systemctl", "restart", "snapd.socket"},
 	})
 }
@@ -120,6 +121,7 @@ func (r *failureSuite) TestCallPrevSnapdFromCore(c *C) {
 	})
 	c.Check(systemctlCmd.Calls(), DeepEquals, [][]string{
 		{"systemctl", "stop", "snapd.socket"},
+		{"systemctl", "reset-failed", "snapd.socket"},
 		{"systemctl", "restart", "snapd.socket"},
 	})
 }

--- a/spread.yaml
+++ b/spread.yaml
@@ -107,10 +107,6 @@ backends:
                 manual: true
                 workers: 6
 
-            - amazon-linux-2-64:
-                workers: 6
-                storage: preserve-size
-
             - centos-7-64:
                 workers: 6
                 image: centos-7-64
@@ -119,12 +115,16 @@ backends:
     # so this block is intentially kept commented out, until we need to add
     # systems to it
     #
-    # google-unstable:
-    #     type: google
-    #     key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    #     location: computeengine/us-east1-b
-    #     halt-timeout: 2h
-    #     systems:
+    google-unstable:
+        type: google
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+        location: computeengine/us-east1-b
+        halt-timeout: 2h
+        systems:
+            - amazon-linux-2-64:
+                workers: 6
+                storage: preserve-size
+
 
     google-tpm:
         type: google

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -12,11 +12,18 @@ debug: |
     journalctl -u snapd.socket || true
     ls -l /snap/snapd/
 
+prepare: |
+    cp -a /etc/systemd/system/snapd.service.d/local.conf local.conf.bak
+    sed -i 's/^StartLimitInterval=0/StartLimitInterval=10s/g' /etc/systemd/system/snapd.service.d/local.conf
+    systemctl daemon-reload
+
 restore: |
     # Stop snapd.failure.service in case it is active
     if systemctl is-active snapd.failure.service | MATCH active; then
         systemctl stop snapd.failure.service
     fi
+    cp -a local.conf.bak /etc/systemd/system/snapd.service.d/local.conf
+    systemctl daemon-reload
 
 execute: |
     echo "Testing failover handling of the snapd snap"


### PR DESCRIPTION
With the most recent version of systemd in bionic [0] systemd
will not start the OnFailure unit until the StartLimitInterval
is reached. This is set to "0" in our tests so this needs to
be adjusted for this test. This commit is doing this.

[0] https://launchpad.net/ubuntu/+source/systemd/237-3ubuntu10.39
