### PR TITLE
features: enable "parallel-installs" by default

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -76,7 +76,8 @@ var featureNames = map[SnapdFeature]string{
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
 var featuresEnabledWhenUnset = map[SnapdFeature]bool{
-	Layouts: true,
+	Layouts:           true,
+	ParallelInstances: true,
 }
 
 // featuresExported contains a set of features that are exported outside of snapd.


### PR DESCRIPTION
The parallel-installs feature is available as an experimental
feature for some time now and it is time to enable it by default.

Because it changes the way that classic snaps works there is a
regression risk here so we need to carefully monitor bugreports
and revert if needed.
