### PR TITLE
cmd/snap-bootstrap: create a new parser instance

### DIFF
--- a/cmd/snap-bootstrap/cmd_create_partitions.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions.go
@@ -20,6 +20,8 @@
 package main
 
 import (
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 )
 
@@ -31,9 +33,11 @@ func init() {
 		long  = ""
 	)
 
-	if _, err := parser.AddCommand("create-partitions", short, long, &cmdCreatePartitions{}); err != nil {
-		panic(err)
-	}
+	addCommandBuilder(func(parser *flags.Parser) {
+		if _, err := parser.AddCommand("create-partitions", short, long, &cmdCreatePartitions{}); err != nil {
+			panic(err)
+		}
+	})
 }
 
 type cmdCreatePartitions struct {

--- a/cmd/snap-bootstrap/cmd_create_partitions_test.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions_test.go
@@ -36,7 +36,7 @@ func (s *cmdSuite) TestCreatePartitionsHappy(c *C) {
 	})
 	defer restore()
 
-	rest, err := main.Parser.ParseArgs([]string{"create-partitions", "gadget-dir", "device"})
+	rest, err := main.Parser().ParseArgs([]string{"create-partitions", "gadget-dir", "device"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Assert(n, Equals, 1)
@@ -53,7 +53,7 @@ func (s *cmdSuite) TestCreatePartitionsMount(c *C) {
 	})
 	defer restore()
 
-	rest, err := main.Parser.ParseArgs([]string{"create-partitions", "--mount", "gadget-dir", "device"})
+	rest, err := main.Parser().ParseArgs([]string{"create-partitions", "--mount", "gadget-dir", "device"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Assert(n, Equals, 1)
@@ -71,7 +71,7 @@ func (s *cmdSuite) TestCreatePartitionsWithEncryption(c *C) {
 	})
 	defer restore()
 
-	rest, err := main.Parser.ParseArgs([]string{"create-partitions", "--encrypt", "--key-file", "keyfile", "gadget-dir", "device"})
+	rest, err := main.Parser().ParseArgs([]string{"create-partitions", "--encrypt", "--key-file", "keyfile", "gadget-dir", "device"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Assert(n, Equals, 1)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
@@ -40,9 +42,11 @@ func init() {
 		long  = "Generate mount tuples for the initramfs until nothing more can be done"
 	)
 
-	if _, err := parser.AddCommand("initramfs-mounts", short, long, &cmdInitramfsMounts{}); err != nil {
-		panic(err)
-	}
+	addCommandBuilder(func(parser *flags.Parser) {
+		if _, err := parser.AddCommand("initramfs-mounts", short, long, &cmdInitramfsMounts{}); err != nil {
+			panic(err)
+		}
+	})
 
 	snap.SanitizePlugsSlots = func(*snap.Info) {}
 }

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -121,14 +121,14 @@ func (s *initramfsMountsSuite) mockProcCmdlineContent(c *C, newContent string) {
 func (s *initramfsMountsSuite) TestInitramfsMountsNoModeError(c *C) {
 	s.mockProcCmdlineContent(c, "nothing-to-see")
 
-	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err := main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, ErrorMatches, "cannot detect mode nor recovery system to use")
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsUnknownMode(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install-foo")
 
-	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err := main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, ErrorMatches, `cannot use unknown mode "install-foo"`)
 }
 
@@ -147,7 +147,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep1(c *C) {
 	})
 	defer restore()
 
-	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err := main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 1)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf("/dev/disk/by-label/ubuntu-seed %s/ubuntu-seed\n", s.runMnt))
@@ -180,7 +180,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep2(c *C) {
 	})
 	defer restore()
 
-	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err := main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 5)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/snaps/snapd_1.snap %[2]s/snapd
@@ -217,7 +217,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep4(c *C) {
 	})
 	defer restore()
 
-	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err := main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 5)
 	c.Check(s.Stdout.String(), Equals, "")
@@ -248,7 +248,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1(c *C) {
 	})
 	defer restore()
 
-	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err := main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 3)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`/dev/disk/by-label/ubuntu-seed %[1]s/ubuntu-seed
@@ -302,7 +302,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
 	r := bloader.SetRunKernelImageEnabledKernel(kernel)
 	defer r()
 
-	_, err = main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 5)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/core20_123.snap %[1]s/base
@@ -354,7 +354,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeFailsHap
 	c.Assert(err, IsNil)
 	defer os.Remove(tryBaseSnap)
 
-	_, err = main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 5)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/core20_123.snap %[1]s/base
@@ -404,7 +404,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseEmptyHapp
 	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
-	_, err = main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 5)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/core20_123.snap %[1]s/base
@@ -461,7 +461,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeHappy(c 
 	c.Assert(err, IsNil)
 	defer os.Remove(tryBaseSnap)
 
-	_, err = main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 5)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/core20_124.snap %[1]s/base
@@ -507,7 +507,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvBaseEmptyUnhappy
 	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
-	_, err = main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, ErrorMatches, "modeenv corrupt: missing base setting")
 	c.Assert(n, Equals, 4)
 	c.Check(s.Stdout.String(), Equals, "")
@@ -550,7 +550,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseNotExists
 	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
-	_, err = main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 5)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/core20_123.snap %[1]s/base
@@ -624,7 +624,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeKernelSnapUpgradeHappy(
 	r = bloader.SetRunKernelImageEnabledTryKernel(tryKernel)
 	defer r()
 
-	_, err = main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 5)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/pc-kernel_2.snap %[1]s/kernel

--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -32,8 +32,8 @@ snap-bootstrap is a tool to bootstrap Ubuntu Core from ephemeral systems
 such as initramfs.
 `
 
-	opts   struct{}
-	parser *flags.Parser = flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash|flags.PassAfterNonOption)
+	opts            struct{}
+	commandBuilders []func(*flags.Parser)
 )
 
 func main() {
@@ -53,9 +53,22 @@ func run(args []string) error {
 }
 
 func parseArgs(args []string) error {
-	parser.ShortDescription = shortHelp
-	parser.LongDescription = longHelp
+	p := parser()
 
-	_, err := parser.ParseArgs(args)
+	_, err := p.ParseArgs(args)
 	return err
+}
+
+func parser() *flags.Parser {
+	p := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash|flags.PassAfterNonOption)
+	p.ShortDescription = shortHelp
+	p.LongDescription = longHelp
+	for _, builder := range commandBuilders {
+		builder(p)
+	}
+	return p
+}
+
+func addCommandBuilder(builder func(*flags.Parser)) {
+	commandBuilders = append(commandBuilders, builder)
 }

--- a/cmd/snap-bootstrap/main_test.go
+++ b/cmd/snap-bootstrap/main_test.go
@@ -35,6 +35,6 @@ type cmdSuite struct{}
 var _ = Suite(&cmdSuite{})
 
 func (s *cmdSuite) TestNoArgsErrors(c *C) {
-	_, err := main.Parser.ParseArgs(nil)
+	_, err := main.Parser().ParseArgs(nil)
 	c.Assert(err, ErrorMatches, "Please specify .*")
 }


### PR DESCRIPTION
Refactor the command to create a parser on demand rather than reuse a global
object. This stops passed command --flags from leaking between tests, by making
sure that each test runs with a new parser and a new commander.