### PR TITLE
snapcraft.yaml: add comments, rename snapd part to snapd-deb

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ description: |
   cloud, servers, desktops and the internet of things.
 
   Start with 'snap list' to see installed snaps.
-adopt-info: snapd
+adopt-info: snapd-deb
 # build-base is needed here for snapcraft to build this snap as with "modern"
 # snapcraft
 build-base: core
@@ -27,7 +27,7 @@ license: GPL-3.0
 # See the comments from jdstrand in
 # https://forum.snapcraft.io/t/5547/10
 parts:
-  snapd:
+  snapd-deb:
     plugin: nil
     source: .
     build-snaps: [go/1.10/stable]
@@ -45,7 +45,7 @@ parts:
       sudo apt-get build-dep -y ./
       ./get-deps.sh --skip-unused-check
       # set version after installing dependencies so we have all the tools here
-      snapcraftctl set-version $(./mkversion.sh --output-only)
+      snapcraftctl set-version "$(./mkversion.sh --output-only)"
     override-build: |
       # unset the LD_FLAGS and LD_LIBRARY_PATH vars that snapcraft sets for us
       # as those will point to the $SNAPCRAFT_STAGE which on re-builds will 
@@ -54,7 +54,8 @@ parts:
       # TODO: should we unset $PATH to not include $SNAPCRAFT_STAGE too?
       unset LD_FLAGS
       unset LD_LIBRARY_PATH
-      # if we are root, disable tests
+      # if we are root, disable tests because a number of them fail when run as
+      # root
       if [ "$(id -u)" = "0" ]; then
         DEB_BUILD_OPTIONS=nocheck
         export DEB_BUILD_OPTIONS


### PR DESCRIPTION
This makes it more clear where the info is adopted from, as there's also the special magic value of `type: snapd`, so it's not clear looking at this if `adopt-info: snapd` is also a magic value. Using snapd-deb makes this more clear.

Also fix a shellcheck warning on the override-pull snippet, and elaborate on the comment about not running tests as root (because they fail).