### PR TITLE
snapcraft.yaml: add python3-apt, tzdata as build-deps for the snapd snap

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
 
   Start with 'snap list' to see installed snaps.
 adopt-info: snapd
-# build-base is needed here for snapcraft to build this snap as with "modern" 
+# build-base is needed here for snapcraft to build this snap as with "modern"
 # snapcraft
 build-base: core
 grade: stable
@@ -108,6 +108,7 @@ parts:
   # the version in Ubuntu 16.04 (cache v6)
   fontconfig-xenial:
     plugin: nil
+    build-packages: [python3-apt]
     source: https://github.com/snapcore/fc-cache-static-builder.git
     override-build: |
       ./build-from-security.py xenial
@@ -118,6 +119,7 @@ parts:
   # the version in Ubuntu 18.04 (cache v7)
   fontconfig-bionic:
     plugin: nil
+    build-packages: [python3-apt]
     source: https://github.com/snapcore/fc-cache-static-builder.git
     override-build: |
       ./build-from-security.py bionic

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -31,6 +31,12 @@ parts:
     plugin: nil
     source: .
     build-snaps: [go/1.10/stable]
+    # this is needed because the base image doesn't have tzdata so when this pkg
+    # gets pulled in, for some reason the build-dep command in override-pull
+    # doesn't obey DEBIAN_FRONTEND=noninteractive, so instead have snapcraft
+    # install the build-package for us, as snapcraft can successfully trick apt
+    # somehow
+    build-packages: [tzdata]
     override-pull: |
       snapcraftctl pull
       # install build dependencies


### PR DESCRIPTION
I think this should fix the snapd snap being built on LP, which currently is failing. See https://pastebin.ubuntu.com/p/C4W39znCfk/ for example build log.

However I wasn't able to confirm that this builds on LP because remote-build doesn't use the snapcraft from candidate so that fails like this https://pastebin.ubuntu.com/p/mvJDDshqbY/ which is fixed in snapcraft 3.10 which is in candidate channel right now.

If I hear back from the snapcraft team on how this could be tested against LP with remote-build, I will comment back on how to test this, I was just doing `snapcraft remote-build --build-on=amd64` with candidate channel of snapcraft. 