### PR TITLE
tests: bump sleep time of the new overlord tests

### DIFF
--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -682,7 +682,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneDoesntAbortShortlyAfterStartOfOpera
 
 	// start the loop that runs the prune ticker
 	o.Loop()
-	time.Sleep(1000 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	c.Assert(o.Stop(), IsNil)
 
 	st.Lock()
@@ -732,7 +732,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneAbortsOld(c *C) {
 
 	// start the loop that runs the prune ticker
 	o.Loop()
-	time.Sleep(1000 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	c.Assert(o.Stop(), IsNil)
 
 	st.Lock()
@@ -783,7 +783,7 @@ func (ovs *overlordSuite) TestEnsureLoopNoPruneWhenPreseed(c *C) {
 	st.Unlock()
 	// start the loop that runs the prune ticker
 	o.Loop()
-	time.Sleep(1000 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	c.Assert(o.Stop(), IsNil)
 
 	st.Lock()


### PR DESCRIPTION
The new overlord prune tests that I landed yesterday just failed with:
```
=== RUN   TestOverlord

----------------------------------------------------------------------
FAIL: overlord_test.go:694: overlordSuite.TestEnsureLoopPruneAbortsOld

overlord_test.go:748:
    // change was aborted
    c.Check(chg.Status(), Equals, state.HoldStatus)
... obtained state.Status = 3 ("Doing")
... expected state.Status = 1 ("Hold")

OOPS: 97 passed, 1 FAILED
--- FAIL: TestOverlord (23.85s)
```

This PR bumps the wait time in the test from 1000ms to 1500ms - this is the value used by existing tests that tests the same area (I used 1000 in a hope it was enough).

I'll work on a proper and more involved fix in a followup, hopefully this PR fixes flakiness until the better fix is ready.

