### PR TITLE
store: rely on CommandFromSystemSnap to find xdelta3

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1695,13 +1695,10 @@ func (s *Store) downloadDelta(deltaName string, downloadInfo *snap.DownloadInfo,
 }
 
 func getXdelta3Cmd(args ...string) (*exec.Cmd, error) {
-	switch {
-	case osutil.ExecutableExists("xdelta3"):
+	if osutil.ExecutableExists("xdelta3") {
 		return exec.Command("xdelta3", args...), nil
-	case osutil.FileExists(filepath.Join(dirs.SnapMountDir, "/core/current/usr/bin/xdelta3")):
-		return cmdutil.CommandFromSystemSnap("/usr/bin/xdelta3", args...)
 	}
-	return nil, fmt.Errorf("cannot find xdelta3 binary in PATH or core snap")
+	return cmdutil.CommandFromSystemSnap("/usr/bin/xdelta3", args...)
 }
 
 // applyDelta generates a target snap from a previously downloaded snap and a downloaded delta.


### PR DESCRIPTION
We had code that runs xdelta3 form the system snap but that logic was
conditional on ... the presence of the core snap. As more systems have
core18 and snapd, using core as the condition is wrong.

Fixes: https://bugs.launchpad.net/snapd/+bug/1864096
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
