### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: mount the snapd snap in run-mode too

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -130,7 +130,7 @@ func generateMountsModeInstall(recoverySystem string) error {
 				}
 			case snap.TypeKernel:
 				if !isKernelMounted {
-					// XXX: we need to cross-check the kernel path with snapd_recovery_kernel used by grub
+					// TODO:UC20: we need to cross-check the kernel path with snapd_recovery_kernel used by grub
 					fmt.Fprintf(stdout, "%s %s\n", essentialSnap.Path, filepath.Join(runMnt, "kernel"))
 				}
 			case snap.TypeSnapd:

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -309,21 +309,23 @@ func generateMountsModeRun() error {
 		}
 
 		if !isSnapdMounted {
+			// TODO:UC20: refactor to combine this code with the install mode
+			// bit in generateMountsModeInstall
 			// load the recovery system  and generate mounts for kernel/base
 			systemSeed, err := seed.Open(seedDir, modeEnv.RecoverySystem)
 			if err != nil {
-				return fmt.Errorf("cannot open seed: %v", err)
+				return err
 			}
 			// load assertions into a temporary database
 			if err := systemSeed.LoadAssertions(nil, nil); err != nil {
-				return fmt.Errorf("cannot load assertions from seed %s: %v", modeEnv.RecoverySystem, err)
+				return err
 			}
 			perf := timings.New(nil)
 			// TODO:UC20: LoadMeta will verify all the snaps in the
 			// seed, that is probably too much. We can expose more
 			// dedicated helpers for this later.
 			if err := systemSeed.LoadMeta(perf); err != nil {
-				return fmt.Errorf("cannot load metadata from seed %s: %v", modeEnv.RecoverySystem, err)
+				return err
 			}
 			// TODO:UC20: do we need more cross checks here?
 			snapdSnapPath := ""

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -279,6 +279,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
 		case 5:
 			c.Check(path, Equals, filepath.Join(s.runMnt, "kernel"))
 			return false, nil
+		case 6:
+			c.Check(path, Equals, filepath.Join(s.runMnt, "snapd"))
+			return false, nil
 		}
 		return false, fmt.Errorf("unexpected number of calls: %v", n)
 	})
@@ -286,7 +289,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
 
 	// write modeenv
 	modeEnv := boot.Modeenv{
-		Base: "core20_123.snap",
+		RecoverySystem: "20191118",
+		Base:           "core20_123.snap",
 	}
 	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
@@ -304,9 +308,10 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
-	c.Assert(n, Equals, 5)
+	c.Assert(n, Equals, 6)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/core20_123.snap %[1]s/base
 %[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/pc-kernel_1.snap %[1]s/kernel
+%[1]s/ubuntu-seed/snaps/snapd_1.snap %[1]s/snapd
 `, s.runMnt))
 }
 


### PR DESCRIPTION
To mount the snapd snap during run mode, we need to read the seed from the recovery system stored in the modeenv. This also means that we end up validating all of the seeds on every run-mode boot, but we will stop doing this when modeEnv is empty.