### PR TITLE
packaging: work around review-tools and snap-confine

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -247,6 +247,8 @@ override_dh_install:
 	mv debian/snapd/etc/profile.d/snapd.sh debian/snapd/etc/profile.d/apps-bin-path.sh
 
 	$(MAKE) -C cmd install DESTDIR=$(CURDIR)/debian/tmp
+	# FIXME: remove the chmod once review tools accept non-setgid-root snap-confine
+	chmod 6755 $(CURDIR)/debian/tmp/usr/lib/snapd/snap-confine
 
 	# Rename the apparmor profile, see dh_apparmor call above for an explanation.
 	mv $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine.real

--- a/tests/main/snap-confine-undesired-mode-group/task.yaml
+++ b/tests/main/snap-confine-undesired-mode-group/task.yaml
@@ -8,7 +8,8 @@ prepare: |
     snap connect test-snapd-app:opengl
     snap connect test-snapd-app:joystick
     # Remove any stale temp file left over by other runs.
-    rm -rf /tmp/snap.test-snapd-app
+    # TODO: move this to generic restore code.
+    rm -rf /tmp/snap.*
 execute: |
     # Run the snap as a non-root user.
     su test -c 'snap run test-snapd-app.sh -c /bin/true'


### PR DESCRIPTION
The review tools that automatically scan all snaps uploaded to the store
have a fixed set of permissions that involve setuid bits. After
snap-confine has dropped the g+s bit, neither snapd nor core snaps pass
automatic review. This will be fixed early this week. Meanwhile,
Pedronis and Jamie both agreed we shoud restore g+s in packaging to
unblock publishing to edge.

This patch does just that.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
