### PR TITLE
tests: rm -rf /tmp/snap.* in restore

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -50,6 +50,7 @@ reset_classic() {
         ls -lR "$SNAP_MOUNT_DIR"/ /var/snap/
         exit 1
     fi
+    rm -rf /tmp/snap.*
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*)
@@ -160,6 +161,7 @@ reset_all_snap() {
     systemctl stop snapd.service snapd.socket
     restore_snapd_state
     rm -rf /root/.snap
+    rm -rf /tmp/snap.*
     if [ "$1" != "--keep-stopped" ]; then
         systemctl start snapd.service snapd.socket
     fi

--- a/tests/main/snap-confine-undesired-mode-group/task.yaml
+++ b/tests/main/snap-confine-undesired-mode-group/task.yaml
@@ -7,9 +7,6 @@ prepare: |
     snap install --dangerous ./test-snapd-app_1.0_all.snap
     snap connect test-snapd-app:opengl
     snap connect test-snapd-app:joystick
-    # Remove any stale temp file left over by other runs.
-    # TODO: move this to generic restore code.
-    rm -rf /tmp/snap.*
 execute: |
     # Run the snap as a non-root user.
     su test -c 'snap run test-snapd-app.sh -c /bin/true'


### PR DESCRIPTION
Running snaps leaves behind their private /tmp directories. Up until now
none of the tests were sensitive to it and we casually left behind data
from one execution to another.

With the snap-confine-undesired-mode-group test we started picking up
leftover files from prior executions on the same machine. This patch
fixes that by removing per-snap tmp directory in the automatic test rest
code.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
