### PR TITLE
build: enable type: snapd

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: snapd
-# TODO: enable this when the store is ready
-# type: snapd
+type: snapd
 summary: Daemon and tooling that enable snap packages
 description: |
   Install, configure, refresh and remove snap packages. Snaps are


### PR DESCRIPTION
The store is almost ready to enable the snapd type. This PR preapres
this and once we get green light from the store it can be merged.
