### PR TITLE
tests: remove tmp dir for snap not-test-snapd-sh on security-private-tmp test

### DIFF
--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -20,7 +20,7 @@ prepare: |
     snap install --dangerous not-test-snapd-sh_1.0_all.snap
 
 restore: |
-    rm -rf "$SNAP_INSTALL_DIR" /tmp/foo
+    rm -rf "$SNAP_INSTALL_DIR" /tmp/foo /tmp/snap.not-test-snapd-sh
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh


### PR DESCRIPTION
The test security-private-tmp is leaving trash on /tmp and this is
making snap-confine-undesired-mode-group test fail when trying to check
permissions on /tmp for the installed snaps.

error: https://paste.ubuntu.com/p/8rpsjh84kR/

Note: It is needed a general solution to clean up /tmp

