### PR TITLE
cmd/libsnap, tests: fix C unit tests failing as non-root

### DIFF
--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -68,6 +68,11 @@ static const char *sc_test_use_fake_lock_dir(void)
 // Check that locking a namespace actually flock's the mutex with LOCK_EX
 static void test_sc_lock_unlock(void)
 {
+	if (geteuid() != 0) {
+		g_test_skip("this test only runs as root");
+		return;
+	}
+
 	const char *lock_dir = sc_test_use_fake_lock_dir();
 	int fd = sc_lock_generic("foo", 123);
 	// Construct the name of the lock file
@@ -95,6 +100,11 @@ static void test_sc_lock_unlock(void)
 // Check that holding a lock is properly detected.
 static void test_sc_verify_snap_lock__locked(void)
 {
+	if (geteuid() != 0) {
+		g_test_skip("this test only runs as root");
+		return;
+	}
+
 	(void)sc_test_use_fake_lock_dir();
 	int fd = sc_lock_snap("foo");
 	sc_verify_snap_lock("foo");
@@ -104,6 +114,11 @@ static void test_sc_verify_snap_lock__locked(void)
 // Check that holding a lock is properly detected.
 static void test_sc_verify_snap_lock__unlocked(void)
 {
+	if (geteuid() != 0) {
+		g_test_skip("this test only runs as root");
+		return;
+	}
+
 	(void)sc_test_use_fake_lock_dir();
 	if (g_test_subprocess()) {
 		sc_verify_snap_lock("foo");
@@ -117,6 +132,11 @@ static void test_sc_verify_snap_lock__unlocked(void)
 
 static void test_sc_enable_sanity_timeout(void)
 {
+	if (geteuid() != 0) {
+		g_test_skip("this test only runs as root");
+		return;
+	}
+
 	if (g_test_subprocess()) {
 		sc_enable_sanity_timeout();
 		debug("waiting...");

--- a/tests/unit/c-unit-tests-clang/task.yaml
+++ b/tests/unit/c-unit-tests-clang/task.yaml
@@ -27,5 +27,7 @@ execute: |
     build_dir="$SPREAD_PATH/cmd/autogarbage"
     BUILD_DIR=$build_dir CC=clang ./autogen.sh
     cd "$build_dir"
-    # Build and run unit tests
+    # Build and run unit tests as root and as a user
     make check
+    chown -R test.test "$build_dir"
+    su test -c 'make check'

--- a/tests/unit/c-unit-tests-gcc/task.yaml
+++ b/tests/unit/c-unit-tests-gcc/task.yaml
@@ -27,5 +27,7 @@ execute: |
     build_dir="$SPREAD_PATH/cmd/autogarbage"
     BUILD_DIR=$build_dir ./autogen.sh
     cd "$build_dir"
-    # Build and run unit tests
+    # Build and run unit tests as root and as a user
     make check
+    chown -R test.test "$build_dir"
+    su test -c 'make check'


### PR DESCRIPTION
I'm guilty of not running unit tests as my user.

I grew so reliant on spread and I grew to hate the output of the C unit tests
so much that I just stopped looking there. This has caused havok in the
launchpad builders which, apparently, do run our test suite as a user.

This branch contains the necessary fix and a correction to the spread task
which runs the unit tests, so that they run as both root (for completness) and
as the test user (to avoid this from happening again).
