### PR TITLE
run-checks: SKIP_GMFMT really skips formatting checks

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -155,22 +155,18 @@ if [ "$STATIC" = 1 ]; then
         ./check-pr-title.py "$TRAVIS_PULL_REQUEST"
     fi
 
-    echo Checking formatting
-    fmt=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
-        s="$(${GOFMT:-gofmt} -s -l -d "$dir" | grep -v /vendor/ || true)"
-        if [ -n "$s" ]; then
-            fmt="$s\\n$fmt"
-        fi
-    done
-
-    if [ -n "$fmt" ]; then
-        echo "Formatting wrong in following files:"
-        echo "$fmt" | sed -e 's/\\n/\n/g'
-        if [ -z "${SKIP_GOFMT:-}" ]; then
-            exit 1
-        else
-            echo "Ignoring gofmt errors as requested"
+    if [ -z "${SKIP_GOFMT:-}" ]; then
+        echo Checking formatting
+        fmt=""
+        for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
+            s="$(${GOFMT:-gofmt} -s -l -d "$dir" | grep -v /vendor/ || true)"
+            if [ -n "$s" ]; then
+                fmt="$s\\n$fmt"
+            fi
+        done
+        if [ -n "$fmt" ]; then
+            echo "Formatting wrong in following files:"
+            echo "$fmt" | sed -e 's/\\n/\n/g'
         fi
     fi
 


### PR DESCRIPTION
Previously setting SKIP_GOFMT would run the check, producing loads of
output on specific version of go, even in an otherwise pristine tree and
then IGNORE the "failure" and carry on with other checks.

This may have been useful once but it no longer is, since master has
drifted far from the "proper", fronzen-in-time version we verify
against.

We lost some time looking for the real failure (which was a unit test
error that was burried beneath the gofmt noise) and I promised I would
look at changing this today. Setting SKIP_GOFMT to a non-empty value
skips the whole formatting check.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
