### PR TITLE
spread.yaml: make qemu ubuntu-core-20-64 use ubuntu-20.04-64

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -201,7 +201,7 @@ backends:
                 username: ubuntu
                 password: ubuntu
             - ubuntu-core-20-64:
-                image: ubuntu-18.04-64
+                image: ubuntu-20.04-64
                 username: ubuntu
                 password: ubuntu
                 flags: [virtio]


### PR DESCRIPTION
We are using ubuntu-20.04-64 to build the ubuntu-core-20 images
for google since a while. This commit updates the qemu part of
spread.yaml to do the same.
