### PR TITLE
[RFC] cmd/snap-recovery-chooser: add a recovery chooser

### DIFF
--- a/cmd/snap-recovery-chooser/action.go
+++ b/cmd/snap-recovery-chooser/action.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+// executeMenuAction performs the action
+func executeMenuAction(action string) error {
+	// TODO:UC20: replace with actual actions
+
+	if action == "normal-start" {
+		return cleanupTriggerMarker()
+	}
+	return nil
+}

--- a/cmd/snap-recovery-chooser/action_test.go
+++ b/cmd/snap-recovery-chooser/action_test.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	main "github.com/snapcore/snapd/cmd/snap-recovery-chooser"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type actionSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&actionSuite{})
+
+func (s *actionSuite) TestActionNormalStart(c *C) {
+	mf := filepath.Join(c.MkDir(), "marker")
+	err := ioutil.WriteFile(mf, nil, 0644)
+	c.Assert(err, IsNil)
+
+	r := main.MockDefaultMarkerFile(mf)
+	defer r()
+
+	err = main.ExecuteMenuAction("normal-start")
+	c.Assert(err, IsNil)
+
+	c.Assert(mf, testutil.FileAbsent)
+}

--- a/cmd/snap-recovery-chooser/demo.go
+++ b/cmd/snap-recovery-chooser/demo.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+// demoUI outputs the skeleton of a demo UI based on the spec
+func demoUI() *Menu {
+	// TODO:UC20: talk to snapd to build the list of options
+
+	prevVersionMenu := Menu{
+		Description: "Start into a previous version:",
+		Entries: []Entry{
+			{
+				ID:   "20190917",
+				Text: "20190917 (last used 2019-09-17 21:07)",
+			}, {
+				ID:   "20190901",
+				Text: "20190917 (never used)",
+			},
+		},
+	}
+	reinstallMenu := Menu{
+		Header:      "! Reinstalling will start immediately and will delete all data on this device.",
+		Description: "Reinstall the system using version:",
+		Entries: []Entry{
+			{
+				ID:   "20190917",
+				Text: "20190917 (last used 2019-09-17 21:07)",
+			}, {
+				ID:   "20190901",
+				Text: "20190917 (never used)",
+			},
+		},
+	}
+	shellMenu := Menu{
+		Description: "Enter shell using version",
+		Entries: []Entry{
+			{
+				ID:   "20190917",
+				Text: "20190917 (last used 2019-09-17 21:07)",
+			}, {
+				ID:   "20190901",
+				Text: "20190917 (never used)",
+			},
+		},
+	}
+	menu := Menu{
+		Header:      "Ubuntu Core for YoyoDyne Retro Encabulator 550",
+		Description: "Use arrow/number keys then Enter, or volume buttons then power button",
+		Entries: []Entry{
+			{
+				ID:   "normal-start",
+				Text: "Start normally",
+			}, {
+				ID:      "prev-version",
+				Text:    "Start into a previous version",
+				Submenu: &prevVersionMenu,
+			}, {
+				ID:   "self-test",
+				Text: "Self-test",
+			}, {
+				ID:      "enter-shell",
+				Text:    "Enter shell",
+				Submenu: &shellMenu,
+			}, {
+				ID:      "reinstall",
+				Text:    "Reinstall",
+				Submenu: &reinstallMenu,
+			},
+		},
+	}
+	return ResolveMenu(&menu)
+}
+
+// demoUITool returns a hardcoded path to the demo tool
+func demoUITool() (string, error) {
+	return filepath.Join(dirs.DistroLibExecDir, "snap-chooser-ui-demo"), nil
+}

--- a/cmd/snap-recovery-chooser/export_test.go
+++ b/cmd/snap-recovery-chooser/export_test.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"io"
+)
+
+var (
+	OutputUI          = outputUI
+	RunUI             = runUI
+	Chooser           = chooser
+	ExecuteMenuAction = executeMenuAction
+)
+
+func MockStdStreams(stdout, stderr io.Writer) (restore func()) {
+	oldStdout, oldStderr := Stdout, Stderr
+	Stdout, Stderr = stdout, stderr
+	return func() {
+		Stdout, Stderr = oldStdout, oldStderr
+	}
+}
+
+func MockToolPath(f func() (string, error)) (restore func()) {
+	oldToolPath := toolPath
+	toolPath = f
+	return func() {
+		toolPath = oldToolPath
+	}
+}
+
+func MockExecuteAction(f func(action string) error) (restore func()) {
+	oldExecuteAction := f
+	executeAction = f
+	return func() {
+		executeAction = oldExecuteAction
+	}
+}
+
+func MockDefaultMarkerFile(p string) (restore func()) {
+	old := defaultMarkerFile
+	defaultMarkerFile = p
+	return func() {
+		defaultMarkerFile = old
+	}
+}

--- a/cmd/snap-recovery-chooser/main.go
+++ b/cmd/snap-recovery-chooser/main.go
@@ -1,0 +1,154 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/snapcore/snapd/logger"
+)
+
+var (
+	// default marker file location
+	defaultMarkerFile = "/run/snapd-recovery-chooser-triggered"
+
+	Stdout io.Writer = os.Stdout
+	Stderr io.Writer = os.Stderr
+
+	// TODO:UC20: hardcoded to use the demo UI tool
+	toolPath = demoUITool
+
+	executeAction = executeMenuAction
+)
+
+func outputUI(out io.Writer, menu *Menu) error {
+	enc := json.NewEncoder(out)
+	if err := enc.Encode(menu); err != nil {
+		return fmt.Errorf("cannot serialize menu structure: %v", err)
+	}
+	return nil
+}
+
+// Response is sent by the UI tool and contains the choice made by the user
+type Response struct {
+	// ID of menu entry selected
+	ID string
+}
+
+func runUI(uiTool string, menu *Menu) (action string, err error) {
+	var menuAsBytes bytes.Buffer
+	if err := outputUI(&menuAsBytes, menu); err != nil {
+		return "", err
+	}
+
+	logger.Noticef("spawning UI")
+	// the UI uses the same tty as current process
+	cmd := exec.Command(uiTool)
+	cmd.Stdin = &menuAsBytes
+	// reuse stderr
+	cmd.Stderr = os.Stderr
+	// the chooser may be invoked via console-conf service which uses
+	// KillMethod=process, so make sure the UI process dies when we die
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("cannot obtain output of the UI process: %v", err)
+	}
+
+	logger.Noticef("UI completed")
+
+	var resp Response
+	dec := json.NewDecoder(bytes.NewBuffer(out))
+	if err := dec.Decode(&resp); err != nil {
+		return "", fmt.Errorf("cannot decode response: %v", err)
+	}
+	return resp.ID, nil
+}
+
+func cleanupTriggerMarker() error {
+	err := os.Remove(defaultMarkerFile)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func chooser() error {
+	// TODO:UC20: build actual UI by querying snapd for available actions
+	menu := demoUI()
+
+	// for local testing
+	if os.Getenv("USE_STDOUT") != "" {
+		if err := outputUI(Stdout, menu); err != nil {
+			return fmt.Errorf("cannot serialize UI to stdout: %v", err)
+		}
+		return nil
+	}
+
+	uiTool, err := toolPath()
+	if err != nil {
+		return fmt.Errorf("cannot obtain chooser UI tool: %v", err)
+	}
+
+	if _, err := os.Stat(uiTool); err != nil {
+		if os.IsNotExist(err) {
+			logger.Noticef("chooser UI tool %q not found in the system", uiTool)
+			// UI tool not found, cleanup the marker, nothing to do
+			return cleanupTriggerMarker()
+		}
+
+		return fmt.Errorf("cannot stat UI tool binary: %v", err)
+	}
+
+	action, err := runUI(uiTool, menu)
+	if err != nil {
+		return fmt.Errorf("UI process failed: %v", err)
+
+	}
+
+	logger.Noticef("got response: %+v", action)
+
+	// TODO:UC20 trigger corresponding action in snapd
+	if err := executeAction(action); err != nil {
+		return fmt.Errorf("cannot execute action %q: %v", action, err)
+	}
+
+	return nil
+}
+
+func main() {
+	if err := logger.SimpleSetup(); err != nil {
+		fmt.Fprintf(Stderr, "cannot initialize logger: %v\n", err)
+		os.Exit(1)
+	}
+	if err := chooser(); err != nil {
+		fmt.Fprintf(Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/snap-recovery-chooser/main_test.go
+++ b/cmd/snap-recovery-chooser/main_test.go
@@ -1,0 +1,233 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	main "github.com/snapcore/snapd/cmd/snap-recovery-chooser"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/testutil"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type cmdSuite struct {
+	testutil.BaseTest
+
+	stdout, stderr bytes.Buffer
+}
+
+var _ = Suite(&cmdSuite{})
+
+func (s *cmdSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	_, r := logger.MockLogger()
+	s.AddCleanup(r)
+	r = main.MockStdStreams(&s.stdout, &s.stderr)
+	s.AddCleanup(r)
+}
+
+func (s *cmdSuite) TestRunUIHappy(c *C) {
+	mockCmd := testutil.MockCommand(c, "tool", `
+echo '{"id": "previous/20190917"}'
+`)
+	defer mockCmd.Restore()
+
+	m := &main.Menu{
+		Description: "Start into a previous version:",
+		Entries: []main.Entry{
+			{
+				ID:   "previous/20190917",
+				Text: "20190917 (last used 2019-09-17 21:07)",
+			}, {
+				ID:   "previous/20190901",
+				Text: "20190917 (never used)",
+			},
+		},
+	}
+
+	action, err := main.RunUI(mockCmd.Exe(), m)
+	c.Assert(err, IsNil)
+	c.Assert(action, Equals, "previous/20190917")
+}
+
+func (s *cmdSuite) TestRunUIBadJSON(c *C) {
+	mockCmd := testutil.MockCommand(c, "tool", `
+echo 'garbage'
+`)
+	defer mockCmd.Restore()
+
+	m := &main.Menu{
+		Description: "Start into a previous version:",
+		Entries: []main.Entry{
+			{
+				ID:   "something",
+				Text: "else",
+			},
+		},
+	}
+
+	action, err := main.RunUI(mockCmd.Exe(), m)
+	c.Assert(err, ErrorMatches, "cannot decode response: .*")
+	c.Assert(action, Equals, "")
+}
+
+func (s *cmdSuite) TestRunUIToolErr(c *C) {
+	mockCmd := testutil.MockCommand(c, "tool", `
+echo foo
+exit 22
+`)
+	defer mockCmd.Restore()
+
+	m := &main.Menu{
+		Description: "Start into a previous version:",
+		Entries: []main.Entry{
+			{
+				ID:   "something",
+				Text: "else",
+			},
+		},
+	}
+
+	_, err := main.RunUI(mockCmd.Exe(), m)
+	c.Assert(err, ErrorMatches, "cannot obtain output of the UI process: exit status 22")
+}
+
+func (s *cmdSuite) TestRunUIInputJSON(c *C) {
+	d := c.MkDir()
+	tf := filepath.Join(d, "json-input")
+	mockCmd := testutil.MockCommand(c, "tool", fmt.Sprintf(`
+cat > %s
+echo '{"id": "something"}'
+`, tf))
+	defer mockCmd.Restore()
+
+	m := &main.Menu{
+		Description: "Start into a previous version:",
+		Entries: []main.Entry{
+			{
+				ID:   "something",
+				Text: "else",
+			}, {
+				ID:   "nested",
+				Text: "nested menu",
+				Submenu: &main.Menu{
+					Entries: []main.Entry{
+						{
+							ID:   "nested/something",
+							Text: "nested else",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := main.RunUI(mockCmd.Exe(), m)
+	c.Assert(err, IsNil)
+
+	data, err := ioutil.ReadFile(tf)
+	c.Assert(err, IsNil)
+	var input *main.Menu
+	err = json.Unmarshal(data, &input)
+	c.Assert(err, IsNil)
+
+	c.Assert(input, DeepEquals, m)
+}
+
+func (s *cmdSuite) TestStdoutUI(c *C) {
+	m := &main.Menu{
+		Description: "Start into a previous version:",
+		Entries: []main.Entry{
+			{
+				ID:   "20190917",
+				Text: "20190917 (last used 2019-09-17 21:07)",
+			}, {
+				ID:   "20190901",
+				Text: "20190917 (never used)",
+			},
+		},
+	}
+	var buf bytes.Buffer
+	err := main.OutputUI(&buf, m)
+	c.Assert(err, IsNil)
+
+	var out *main.Menu
+
+	err = json.Unmarshal(buf.Bytes(), &out)
+	c.Assert(err, IsNil)
+	c.Assert(out, DeepEquals, m)
+}
+
+func (s *cmdSuite) TestMainChooserWithTool(c *C) {
+	var action string
+
+	mockCmd := testutil.MockCommand(c, "tool", `
+echo '{"id": "self-test"}'
+`)
+	defer mockCmd.Restore()
+	r := main.MockToolPath(func() (string, error) {
+		return mockCmd.Exe(), nil
+	})
+	defer r()
+	r = main.MockExecuteAction(func(act string) error {
+		action = act
+		return nil
+	})
+	defer r()
+
+	err := main.Chooser()
+	c.Assert(err, IsNil)
+	c.Assert(action, Equals, "self-test")
+}
+
+func (s *cmdSuite) TestMainChooserToolNotFound(c *C) {
+	d := c.MkDir()
+	mf := filepath.Join(d, "marker")
+	err := ioutil.WriteFile(mf, nil, 0644)
+	c.Assert(err, IsNil)
+
+	notATool := filepath.Join(d, "not-a-tool")
+
+	r := main.MockDefaultMarkerFile(mf)
+	defer r()
+	r = main.MockToolPath(func() (string, error) {
+		return notATool, nil
+	})
+	defer r()
+	r = main.MockExecuteAction(func(_ string) error {
+		return fmt.Errorf("unexpected call")
+	})
+	defer r()
+
+	err = main.Chooser()
+	c.Assert(err, IsNil)
+
+	c.Assert(mf, testutil.FileAbsent)
+}

--- a/cmd/snap-recovery-chooser/menu.go
+++ b/cmd/snap-recovery-chooser/menu.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"strings"
+)
+
+// Menu describes a menu with multiple entries
+type Menu struct {
+	Description string
+	Header      string
+	// Entries of the menu
+	Entries []Entry
+}
+
+// Entry describes a menu entry
+type Entry struct {
+	// ID is a unique ID of given entry inside the whole menu (parent and submenus)
+	ID string
+	// Entry text
+	Text string
+	// Submenu if any
+	Submenu *Menu `json:",omitempty"`
+}
+
+func fixupEntryID(e *Entry, parentID string) {
+	if parentID != "" {
+		prefix := parentID + "/"
+		if !strings.HasPrefix(e.ID, prefix) {
+			e.ID = prefix + e.ID
+		}
+	}
+	if e.Submenu != nil {
+		fixupSumbenuIDs(e.Submenu, e.ID)
+	}
+}
+
+func fixupSumbenuIDs(m *Menu, parentID string) {
+	for i := range m.Entries {
+		fixupEntryID(&m.Entries[i], parentID)
+	}
+}
+
+// ResolveMenu ensured that all menu entries have properly constructed IDs
+func ResolveMenu(looseMenu *Menu) *Menu {
+	fixupSumbenuIDs(looseMenu, "")
+	return looseMenu
+}

--- a/cmd/snap-recovery-chooser/menu_test.go
+++ b/cmd/snap-recovery-chooser/menu_test.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	main "github.com/snapcore/snapd/cmd/snap-recovery-chooser"
+)
+
+type menuSuite struct{}
+
+var _ = Suite(&menuSuite{})
+
+func (s *menuSuite) TestResolve(c *C) {
+	m := &main.Menu{
+		Description: "Start into a previous version:",
+		Entries: []main.Entry{
+			{
+				ID:   "something",
+				Text: "else",
+			}, {
+				ID:   "nested",
+				Text: "nested menu",
+				Submenu: &main.Menu{
+					Entries: []main.Entry{
+						{
+							ID:   "no-nested-prefix",
+							Text: "nested this",
+						}, {
+							ID:   "nested/has-nested-prefix",
+							Text: "nested that",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resolved := main.ResolveMenu(m)
+	expected := &main.Menu{
+		Description: "Start into a previous version:",
+		Entries: []main.Entry{
+			{
+				ID:   "something",
+				Text: "else",
+			}, {
+				ID:   "nested",
+				Text: "nested menu",
+				Submenu: &main.Menu{
+					Entries: []main.Entry{
+						{
+							ID:   "nested/no-nested-prefix",
+							Text: "nested this",
+						}, {
+							ID:   "nested/has-nested-prefix",
+							Text: "nested that",
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Assert(resolved, DeepEquals, expected)
+}

--- a/packaging/debian-sid/not-installed
+++ b/packaging/debian-sid/not-installed
@@ -2,3 +2,4 @@ usr/bin/snap-repair
 usr/bin/snap-failure
 usr/lib/snapd/system-shutdown
 usr/bin/snap-bootstrap
+usr/bin/snap-recovery-chooser

--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -172,6 +172,8 @@ override_dh_install:
 	rm -f ${CURDIR}/debian/tmp/usr/bin/snappy
 	# snap-bootstrap is only useful on core (and we don't have a 14.04 core)
 	rm -f ${CURDIR}/debian/tmp/usr/bin/snap-bootstrap
+	# same goes for snap-recovery-chooser
+	rm -f ${CURDIR}/debian/tmp/usr/bin/snap-recovery-chooser
 	# i18n stuff
 	mkdir -p debian/snapd/usr/share
 	if [ -d share/locale ]; then \

--- a/packaging/ubuntu-16.04/snapd.install
+++ b/packaging/ubuntu-16.04/snapd.install
@@ -9,6 +9,7 @@ usr/bin/snapd /usr/lib/snapd/
 usr/bin/snap-seccomp /usr/lib/snapd/
 usr/bin/snap-bootstrap /usr/lib/snapd/
 usr/bin/snap-preseed /usr/lib/snapd/
+usr/bin/snap-recovery-chooser /usr/lib/snapd/
 
 # bash completion
 data/completion/snap /usr/share/bash-completion/completions


### PR DESCRIPTION
Add a recovery chooser. The chooser does not implement the UI components, but rather calls a UI tool that can be part of snapd or some hook in the gadget (TBD?).

It is expected that once we have the API bits in snapd, the chooser will be able to decide what options are available in the system, pass that to the UI and expect a reasonable response.

The communication with the UI process is done over stdin/stdout. The choices are represented by a `Menu`, serialized to JSON and passed in stdin of the UI process. The UI comes back with a response containing the ID of a given action.

At this moment, there's an external `snap-chooser-ui-demo` tool that does the UI bits over a terminal, and is not part of this PR. Should the chooser be invoked, and the UI tool be missing from the system, the marker will be cleaned up and the process exits. With console-conf integration, this terminates the console-conf service which will restarts and presents the usual configure dialog or jumps to getty.

