### PR TITLE
snapstate: do not restart in undoLinkSnap unless on first install

### DIFF
--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -126,6 +126,7 @@ func (c *cmdSnapd) Execute(args []string) error {
 	cmd := exec.Command(snapdPath)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "SNAPD_REVERT_TO_REV="+prevRev)
+	cmd.Env = append(cmd.Env, "SNAPD_DEBUG=1")
 	cmd.Stdout = Stdout
 	cmd.Stderr = Stderr
 	if err = cmd.Run(); err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1622,7 +1622,9 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	if newInfo.GetType() == snap.TypeSnapd {
+	// only restart here if snapd was the installed and needs to
+	// get uninstalled again
+	if linkCtx.FirstInstall && newInfo.GetType() == snap.TypeSnapd {
 		// only way to get
 		deviceCtx, err := DeviceCtx(st, t, nil)
 		if err != nil {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -1184,12 +1184,12 @@ func (s *linkSnapSuite) TestUndoLinkSnapdNthInstall(c *C) {
 	c.Check(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Check(s.fakeBackend.ops, DeepEquals, expected)
 
-	// 2 restarts, one from link snap, another one from undo
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon, state.RestartDaemon})
-	c.Check(t.Log(), HasLen, 3)
+	// 1 restarts, one from link snap, the other restart happens
+	// in undoUnlinkCurrentSnap (not tested here)
+	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon})
+	c.Check(t.Log(), HasLen, 2)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
 	c.Check(t.Log()[1], Matches, `.*INFO unlink`)
-	c.Check(t.Log()[2], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
 }
 
 func (s *linkSnapSuite) TestDoUnlinkSnapRefreshAwarenessHardCheck(c *C) {

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -11,6 +11,9 @@ debug: |
     journalctl -u snapd.failure.service
     journalctl -u snapd.socket || true
     ls -l /snap/snapd/
+    cat /etc/systemd/system/snapd.service
+    /snap/snapd/x1/usr/bin/snap debug state /var/lib/snapd/state.json || true
+    /snap/snapd/x1/usr/bin/snap debug state --change="$(snap debug state /var/lib/snapd/state.json|tail -n1|awk '{print $1}')" /var/lib/snapd/state.json || true
 
 prepare: |
     cp -a /etc/systemd/system/snapd.service.d/local.conf local.conf.bak

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -12,6 +12,7 @@ debug: |
     journalctl -u snapd.socket || true
     ls -l /snap/snapd/
     cat /etc/systemd/system/snapd.service
+    cat /etc/systemd/system/usr-lib-snapd.mount
     /snap/snapd/x1/usr/bin/snap debug state /var/lib/snapd/state.json || true
     /snap/snapd/x1/usr/bin/snap debug state --change="$(snap debug state /var/lib/snapd/state.json|tail -n1|awk '{print $1}')" /var/lib/snapd/state.json || true
 


### PR DESCRIPTION
This commit does not restart snapd when undoing a snapd snap
that is not a first-install. Undoing at this point for regular
snapd failures causes the failover handling to break. The reason
is that the snapd snap is restarted before the fixed snapd.service
unit is written.
