### PR TITLE
tests: enable snapd-failover on uc20

### DIFF
--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -1,10 +1,8 @@
 summary: Check that snapd failure handling works
 
-# TODO:UC20: enable for UC20, currently snapd.failure.service does not work on
-#            UC20, it currently isn't activated for some reason
 # UC16 still uses the core snap rather than the snapd snap, so disable this test
 # for UC16
-systems: [-ubuntu-core-20-*, -ubuntu-core-16-*]
+systems: [-ubuntu-core-16-*]
 
 debug: |
     # dump failure data


### PR DESCRIPTION
With the recent fix for the snapd failover handling this test
now works on uc20 too.
