### PR TITLE
cmd/snap-bootstrap,seed: verify only in-play snaps

### DIFF
--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -117,3 +117,25 @@ func snapTypeFromModel(modSnap *asserts.ModelSnap) snap.Type {
 		return snap.TypeApp
 	}
 }
+
+func essentialSnapTypesToModelFilter(essentialTypes []snap.Type) func(modSnap *asserts.ModelSnap) bool {
+	m := make(map[string]bool, len(essentialTypes))
+	for _, t := range essentialTypes {
+		switch t {
+		case snap.TypeBase:
+			m["base"] = true
+		case snap.TypeOS:
+			m["core"] = true
+		case snap.TypeGadget:
+			m["gadget"] = true
+		case snap.TypeKernel:
+			m["kernel"] = true
+		case snap.TypeSnapd:
+			m["snapd"] = true
+		}
+	}
+
+	return func(modSnap *asserts.ModelSnap) bool {
+		return m[modSnap.SnapType]
+	}
+}

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -77,7 +77,8 @@ type Seed interface {
 	// error to call Model before LoadAssertions.
 	Model() (*asserts.Model, error)
 
-	// LoadMeta loads the seed and seed's snaps metadata. It can
+	// LoadMeta loads the seed and seed's snaps metadata while
+	// verifying the underlying snaps against assertions. It can
 	// return ErrNoMeta if there is no metadata nor snaps in the
 	// seed, this is legitimate only on classic. It is an error to
 	// call LoadMeta before LoadAssertions.
@@ -94,6 +95,20 @@ type Seed interface {
 	// ModeSnaps returns the snaps that should be available
 	// in the given mode as defined by the seed, after LoadMeta.
 	ModeSnaps(mode string) ([]*Snap, error)
+}
+
+// EssentialMetaLoaderSeed is a Seed that can be asked to load and verify
+// only a subset of the essential model snaps via LoadEssentialMeta.
+type EssentialMetaLoaderSeed interface {
+	Seed
+
+	// LoadEssentialMeta loads the seed's snaps metadata for the
+	// essential snaps with types in the essentialTypes set while
+	// verifying them against assertions. It can return ErrNoMeta
+	// if there is no metadata nor snaps in the seed, this is
+	// legitimate only on classic. It is an error to call LoadMeta
+	// before LoadAssertions or to mix it with LoadMeta.
+	LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error
 }
 
 // Open returns a Seed implementation for the seed at seedDir.

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -405,7 +405,7 @@ func (s *seed20) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measur
 	}
 
 	if s.essentialSnapsNum != len(essentialTypes) {
-		// did not found all the explicitly asked essential types
+		// did not find all the explicitly asked essential types
 		return fmt.Errorf("model does not specify all the requested essential snaps: %v", essentialTypes)
 	}
 

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -31,6 +31,7 @@ package seed
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -352,8 +353,13 @@ func (s *seed20) addSnap(snapRef naming.SnapRef, optSnap *internal.Snap20, modes
 	return seedSnap, nil
 }
 
-func (s *seed20) addModelSnap(modelSnap *asserts.ModelSnap, essential bool, tm timings.Measurer) (*Snap, error) {
+var errFiltered = errors.New("filtered out")
+
+func (s *seed20) addModelSnap(modelSnap *asserts.ModelSnap, essential bool, filter func(*asserts.ModelSnap) bool, tm timings.Measurer) (*Snap, error) {
 	optSnap, _ := s.nextOptSnap(modelSnap)
+	if !filter(modelSnap) {
+		return nil, errFiltered
+	}
 	seedSnap, err := s.addSnap(modelSnap, optSnap, modelSnap.Modes, modelSnap.DefaultChannel, "../../snaps", tm)
 	if err != nil {
 		return nil, err
@@ -370,6 +376,44 @@ func (s *seed20) addModelSnap(modelSnap *asserts.ModelSnap, essential bool, tm t
 }
 
 func (s *seed20) LoadMeta(tm timings.Measurer) error {
+	if err := s.loadModelMeta(nil, tm); err != nil {
+		return err
+	}
+
+	// extra snaps
+	runMode := []string{"run"}
+	for {
+		optSnap, done := s.nextOptSnap(nil)
+		if done {
+			break
+		}
+
+		_, err := s.addSnap(optSnap, optSnap, runMode, "latest/stable", "snaps", tm)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *seed20) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error {
+	filterEssential := essentialSnapTypesToModelFilter(essentialTypes)
+	expectedEssentialSnapsNum := len(essentialTypes)
+
+	if err := s.loadModelMeta(filterEssential, tm); err != nil {
+		return err
+	}
+
+	if s.essentialSnapsNum == expectedEssentialSnapsNum {
+		// found all the explicitly asked essential types
+		return nil
+	}
+
+	return fmt.Errorf("model does not specify all the requested essential snaps: %v", essentialTypes)
+}
+
+func (s *seed20) loadModelMeta(filterEssential func(*asserts.ModelSnap) bool, tm timings.Measurer) error {
 	model, err := s.Model()
 	if err != nil {
 		return err
@@ -383,19 +427,31 @@ func (s *seed20) LoadMeta(tm timings.Measurer) error {
 		return err
 	}
 
+	essentialOnly := filterEssential != nil
+	filter := filterEssential
+	if !essentialOnly {
+		// no filtering
+		filter = func(*asserts.ModelSnap) bool {
+			return true
+		}
+	}
+
 	allSnaps := model.AllSnaps()
 	// an explicit snapd is the first of all of snaps
 	if allSnaps[0].SnapType != "snapd" {
 		snapdSnap := internal.MakeSystemSnap("snapd", "latest/stable", []string{"run", "ephemeral"})
-		if _, err := s.addModelSnap(snapdSnap, true, tm); err != nil {
+		if _, err := s.addModelSnap(snapdSnap, true, filter, tm); err != nil && err != errFiltered {
 			return err
 		}
 	}
 
 	essential := true
 	for _, modelSnap := range allSnaps {
-		seedSnap, err := s.addModelSnap(modelSnap, essential, tm)
+		seedSnap, err := s.addModelSnap(modelSnap, essential, filter, tm)
 		if err != nil {
+			if err == errFiltered {
+				continue
+			}
 			if _, ok := err.(*NoSnapDeclarationError); ok && modelSnap.Presence == "optional" {
 				// skipped optional snap is ok
 				continue
@@ -416,20 +472,10 @@ func (s *seed20) LoadMeta(tm timings.Measurer) error {
 
 			// done with essential snaps
 			essential = false
-		}
-	}
-
-	// extra snaps
-	runMode := []string{"run"}
-	for {
-		optSnap, done := s.nextOptSnap(nil)
-		if done {
-			break
-		}
-
-		_, err := s.addSnap(optSnap, optSnap, runMode, "latest/stable", "snaps", tm)
-		if err != nil {
-			return err
+			if essentialOnly {
+				// will not find more
+				break
+			}
 		}
 	}
 

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -399,18 +399,17 @@ func (s *seed20) LoadMeta(tm timings.Measurer) error {
 
 func (s *seed20) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error {
 	filterEssential := essentialSnapTypesToModelFilter(essentialTypes)
-	expectedEssentialSnapsNum := len(essentialTypes)
 
 	if err := s.loadModelMeta(filterEssential, tm); err != nil {
 		return err
 	}
 
-	if s.essentialSnapsNum == expectedEssentialSnapsNum {
-		// found all the explicitly asked essential types
-		return nil
+	if s.essentialSnapsNum != len(essentialTypes) {
+		// did not found all the explicitly asked essential types
+		return fmt.Errorf("model does not specify all the requested essential snaps: %v", essentialTypes)
 	}
 
-	return fmt.Errorf("model does not specify all the requested essential snaps: %v", essentialTypes)
+	return nil
 }
 
 func (s *seed20) loadModelMeta(filterEssential func(*asserts.ModelSnap) bool, tm timings.Measurer) error {
@@ -470,7 +469,7 @@ func (s *seed20) loadModelMeta(filterEssential func(*asserts.ModelSnap) bool, tm
 			// TODO: when we allow extend models for classic
 			// we need to add the gadget base here
 
-			// done with essential snaps
+			// done with essential snaps, gadget is the last one
 			essential = false
 			if essentialOnly {
 				// will not find more

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -629,6 +629,144 @@ func (s *seed20Suite) TestLoadMetaCore20(c *C) {
 	c.Check(installSnaps, HasLen, 0)
 }
 
+func hideSnaps(c *C, all []*seed.Snap, keepTypes []snap.Type) (unhide func()) {
+	var hidden [][]string
+Hiding:
+	for _, sn := range all {
+		for _, t := range keepTypes {
+			if sn.EssentialType == t {
+				continue Hiding
+			}
+		}
+		origFn := sn.Path
+		hiddenFn := sn.Path + ".hidden"
+		err := os.Rename(origFn, hiddenFn)
+		c.Assert(err, IsNil)
+		hidden = append(hidden, []string{origFn, hiddenFn})
+	}
+	return func() {
+		for _, h := range hidden {
+			err := os.Rename(h[1], h[0])
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
+func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "required20", "developerid")
+
+	sysLabel := "20191018"
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name": "required20",
+				"id":   s.AssertedSnapID("required20"),
+			}},
+	}, nil)
+
+	snapdSnap := &seed.Snap{
+		Path:          s.expectedPath("snapd"),
+		SideInfo:      &s.AssertedSnapInfo("snapd").SideInfo,
+		EssentialType: snap.TypeSnapd,
+		Essential:     true,
+		Required:      true,
+		Channel:       "latest/stable",
+	}
+	pcKernelSnap := &seed.Snap{
+		Path:          s.expectedPath("pc-kernel"),
+		SideInfo:      &s.AssertedSnapInfo("pc-kernel").SideInfo,
+		EssentialType: snap.TypeKernel,
+		Essential:     true,
+		Required:      true,
+		Channel:       "20",
+	}
+	core20Snap := &seed.Snap{Path: s.expectedPath("core20"),
+		SideInfo:      &s.AssertedSnapInfo("core20").SideInfo,
+		EssentialType: snap.TypeBase,
+		Essential:     true,
+		Required:      true,
+		Channel:       "latest/stable",
+	}
+	pcSnap := &seed.Snap{
+		Path:          s.expectedPath("pc"),
+		SideInfo:      &s.AssertedSnapInfo("pc").SideInfo,
+		EssentialType: snap.TypeGadget,
+		Essential:     true,
+		Required:      true,
+		Channel:       "20",
+	}
+	required20Snap := &seed.Snap{
+		Path: s.expectedPath("required20"),
+	}
+
+	all := []*seed.Snap{snapdSnap, pcKernelSnap, core20Snap, pcSnap, required20Snap}
+
+	tests := []struct {
+		onlyTypes []snap.Type
+		expected  []*seed.Snap
+	}{
+		{[]snap.Type{snap.TypeSnapd}, []*seed.Snap{snapdSnap}},
+		{[]snap.Type{snap.TypeKernel}, []*seed.Snap{pcKernelSnap}},
+		{[]snap.Type{snap.TypeBase}, []*seed.Snap{core20Snap}},
+		{[]snap.Type{snap.TypeGadget}, []*seed.Snap{pcSnap}},
+		{[]snap.Type{snap.TypeSnapd, snap.TypeKernel, snap.TypeBase}, []*seed.Snap{snapdSnap, pcKernelSnap, core20Snap}},
+		// the order in essentialTypes is not relevant
+		{[]snap.Type{snap.TypeGadget, snap.TypeKernel}, []*seed.Snap{pcKernelSnap, pcSnap}},
+		// degenerate case
+		{[]snap.Type{}, []*seed.Snap(nil)},
+	}
+
+	for _, t := range tests {
+		// hide the non-requested snaps to make sure they are not
+		// accessed
+		unhide := hideSnaps(c, all, t.onlyTypes)
+
+		seed20, err := seed.Open(s.SeedDir, sysLabel)
+		c.Assert(err, IsNil)
+
+		essSeed20, ok := seed20.(seed.EssentialMetaLoaderSeed)
+		c.Assert(ok, Equals, true)
+
+		err = essSeed20.LoadAssertions(s.db, s.commitTo)
+		c.Assert(err, IsNil)
+
+		err = essSeed20.LoadEssentialMeta(t.onlyTypes, s.perfTimings)
+		c.Assert(err, IsNil)
+
+		c.Check(essSeed20.UsesSnapdSnap(), Equals, true)
+
+		essSnaps := essSeed20.EssentialSnaps()
+		c.Check(essSnaps, HasLen, len(t.expected))
+
+		c.Check(essSnaps, DeepEquals, t.expected)
+
+		runSnaps, err := essSeed20.ModeSnaps("run")
+		c.Assert(err, IsNil)
+		c.Check(runSnaps, HasLen, 0)
+
+		unhide()
+	}
+}
+
 func (s *seed20Suite) makeLocalSnap(c *C, yamlKey string) (fname string) {
 	return snaptest.MakeTestSnapWithFiles(c, snapYaml[yamlKey], nil)
 }


### PR DESCRIPTION
add seed.EssentialMetaLoaderSeed exposing LoadEssentialMeta implemented by
seed20

use it to verify only the relevant/in-play snaps in snap-bootstrap
