### PR TITLE
netlink: fix panic on arm64 with the new rawsockstop code

### DIFF
--- a/osutil/udev/netlink/conn_test.go
+++ b/osutil/udev/netlink/conn_test.go
@@ -1,6 +1,7 @@
 package netlink
 
 import (
+	"syscall"
 	"testing"
 	"time"
 )
@@ -31,5 +32,35 @@ func TestMonitorStop(t *testing.T) {
 	ok := stop(200 * time.Millisecond)
 	if !ok {
 		t.Fatal("stop timed out instead of working")
+	}
+}
+
+func TestMonitorSelectTimeoutIsHarmless(t *testing.T) {
+	conn := new(UEventConn)
+	if err := conn.Connect(UdevEvent); err != nil {
+		t.Fatal("unable to subscribe to netlink uevent, err:", err)
+	}
+	defer conn.Close()
+
+	selectCalled := 0
+	oldStopperSelectTimeout := stopperSelectTimeout
+	stopperSelectTimeout = func() *syscall.Timeval {
+		selectCalled += 1
+		return &syscall.Timeval{
+			Usec: 10 * 1000, // 10ms
+		}
+	}
+	defer func() {
+		stopperSelectTimeout = oldStopperSelectTimeout
+	}()
+
+	stop := conn.Monitor(nil, nil, nil)
+	time.Sleep(100 * time.Millisecond)
+	ok := stop(200 * time.Millisecond)
+	if !ok {
+		t.Fatal("stop timed out instead of working")
+	}
+	if selectCalled <= 1 {
+		t.Fatal("select->read->select should have been exercised at least once")
 	}
 }

--- a/osutil/udev/netlink/rawsockstop.go
+++ b/osutil/udev/netlink/rawsockstop.go
@@ -36,8 +36,6 @@ func RawSockStopper(fd int) (readableOrStop func() (bool, error), stop func(), e
 	return readableOrStop, stop, nil
 }
 
-var stopperSelectTimeout *syscall.Timeval
-
 func stopperSelectReadable(fd, stopFd int) (bool, error) {
 	maxFd := fd
 	if maxFd < stopFd {

--- a/osutil/udev/netlink/rawsockstop.go
+++ b/osutil/udev/netlink/rawsockstop.go
@@ -49,11 +49,12 @@ func stopperSelectReadable(fd, stopFd int) (bool, error) {
 	stopFdIdx := stopFd / bits.UintSize
 	stopFdShift := uint(stopFd) % bits.UintSize
 	readable := false
+	tout := stopperSelectTimeout()
 	for {
 		var r syscall.FdSet
 		r.Bits[fdIdx] = 1 << fdShift
 		r.Bits[stopFdIdx] |= 1 << stopFdShift
-		_, err := syscall.Select(maxFd+1, &r, nil, nil, stopperSelectTimeout)
+		_, err := syscall.Select(maxFd+1, &r, nil, nil, tout)
 		if errno, ok := err.(syscall.Errno); ok && errno.Temporary() {
 			continue
 		}

--- a/osutil/udev/netlink/rawsockstop_arm64.go
+++ b/osutil/udev/netlink/rawsockstop_arm64.go
@@ -1,0 +1,12 @@
+package netlink
+
+import (
+	"math"
+	"syscall"
+)
+
+// workaround a bug in go1.10 where syscall.Select() with nil Timeval
+// panics (c.f. https://github.com/golang/go/issues/24189)
+var stopperSelectTimeout *syscall.Timeval = &syscall.Timeval{
+	Sec: math.MaxInt64,
+}

--- a/osutil/udev/netlink/rawsockstop_arm64.go
+++ b/osutil/udev/netlink/rawsockstop_arm64.go
@@ -7,6 +7,8 @@ import (
 
 // workaround a bug in go1.10 where syscall.Select() with nil Timeval
 // panics (c.f. https://github.com/golang/go/issues/24189)
-var stopperSelectTimeout *syscall.Timeval = &syscall.Timeval{
-	Sec: math.MaxInt64,
+var stopperSelectTimeout = func() *syscall.Timeval {
+	return &syscall.Timeval{
+		Sec: math.MaxInt64,
+	}
 }

--- a/osutil/udev/netlink/rawsockstop_other.go
+++ b/osutil/udev/netlink/rawsockstop_other.go
@@ -1,0 +1,7 @@
+// + build !arm64
+package netlink
+
+// once we use something other than go1.10 we can move this back into
+// rawsocketstop.go and remove rawsocketstop_arm64.go, see
+// rawsocketstop_arm64.go for details
+var stopperSelectTimeout *syscall.Timeval

--- a/osutil/udev/netlink/rawsockstop_other.go
+++ b/osutil/udev/netlink/rawsockstop_other.go
@@ -1,5 +1,6 @@
 // +build !arm64
-// don't remove the whitespace below!
+// don't remove the newline between the above statement and the package statement
+// or else the build constraint will be ignored and assumed to be part of the package comment!
 
 package netlink
 

--- a/osutil/udev/netlink/rawsockstop_other.go
+++ b/osutil/udev/netlink/rawsockstop_other.go
@@ -1,7 +1,11 @@
 // + build !arm64
 package netlink
 
+import "syscall"
+
 // once we use something other than go1.10 we can move this back into
 // rawsocketstop.go and remove rawsocketstop_arm64.go, see
 // rawsocketstop_arm64.go for details
-var stopperSelectTimeout *syscall.Timeval
+var stopperSelectTimeout = func() *syscall.Timeval {
+	return nil
+}

--- a/osutil/udev/netlink/rawsockstop_other.go
+++ b/osutil/udev/netlink/rawsockstop_other.go
@@ -1,4 +1,6 @@
-// + build !arm64
+// +build !arm64
+// don't remove the whitespace below!
+
 package netlink
 
 import "syscall"

--- a/osutil/udev/netlink/rawsockstop_test.go
+++ b/osutil/udev/netlink/rawsockstop_test.go
@@ -12,11 +12,14 @@ func TestRawSockStopperReadable(t *testing.T) {
 		t.Fatalf("cannot make test pipe: %v", err)
 	}
 
-	stopperSelectTimeout = &syscall.Timeval{
-		Usec: 50 * 1000, // 50ms
+	oldStopperSelectTimeout := stopperSelectTimeout
+	stopperSelectTimeout = func() *syscall.Timeval {
+		return &syscall.Timeval{
+			Usec: 50 * 1000, // 50ms
+		}
 	}
 	defer func() {
-		stopperSelectTimeout = nil
+		stopperSelectTimeout = oldStopperSelectTimeout
 	}()
 
 	readableOrStop, _, err := RawSockStopper(int(r.Fd()))


### PR DESCRIPTION
This is a workaround for a bug in go1.10 where syscall.Select()
with a nil Timeval panics. See the upstream bug about this at:
 https://github.com/golang/go/issues/24189

Once we move off from go-1.10 we can revert this change again.

