### PR TITLE
data/systemd: improve the description

### DIFF
--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Snappy daemon
+Description=Snap Daemon
 Requires=snapd.socket
 OnFailure=snapd.failure.service
 # This is handled by snapd


### PR DESCRIPTION
While the code may have references to "snappy" we have long ago
not exposed that name. Fix the service description so that the
"Snappy" reference is not seen on system startup nor shutdown.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
