### PR TITLE
travis.yml: run unit tests on arm64 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,29 @@ matrix:
         - set -e
         - ./run-checks --static
         - ./run-checks --short-unit
+    # slightly sad that the arm64 section duplicates most of the amd64
+    # section above. But it looks like doing "arch: [amd64, arm64]"
+    # does not work for some reason so this duplication is necessary.
+    - stage: quick
+      name: ARM64 unit tests
+      os: linux
+      arch: arm64
+      dist: xenial
+      # go1.10 here because that is what we use to build arm64 snaps/debs
+      go: "1.10.x"
+      before_install:
+        # no "deb-src" entries in the lxd arm64 container so we need to add
+        # it here
+        - echo "deb-src http://ports.ubuntu.com/ubuntu-ports xenial-updates main" | sudo tee -a /etc/apt/sources.list
+        - sudo apt --quiet -o Dpkg::Progress-Fancy=false update
+      install:
+        - sudo apt --quiet -o Dpkg::Progress-Fancy=false build-dep snapd
+        - ./get-deps.sh
+      script:
+        - set -e
+        - ./run-checks --static
+        - ./run-checks --short-unit
+
     - stage: quick
       go: "1.10.x"
       name: OSX build and minimal runtime sanity check

--- a/usersession/client/client_test.go
+++ b/usersession/client/client_test.go
@@ -120,7 +120,7 @@ func (s *clientSuite) TestAgentTimeout(c *C) {
 }`))
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
 	defer cancel()
 	si, err := s.cli.SessionInfo(ctx)
 

--- a/usersession/userd/ui/kdialog_test.go
+++ b/usersession/userd/ui/kdialog_test.go
@@ -69,7 +69,7 @@ func (s *kdialogSuite) TestYesNoSimpleFooter(c *C) {
 }
 
 func (s *kdialogSuite) TestYesNoSimpleTimeout(c *C) {
-	mock := testutil.MockCommand(c, "kdialog", "sleep 9999999")
+	mock := testutil.MockCommand(c, "kdialog", "sleep 30")
 	defer mock.Restore()
 
 	z := &ui.KDialog{}


### PR DESCRIPTION
This will run go1.10 based tests on arm64 too so that we catch unit test failures on arm64 early.