### PR TITLE
tests: fix retry network test after image update

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -656,6 +656,7 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         debian-*)
             echo "
+                dnsutils
                 eatmydata
                 evolution-data-server
                 fwupd
@@ -689,6 +690,7 @@ pkg_dependencies_ubuntu_core(){
 
 pkg_dependencies_fedora(){
     echo "
+        bind-utils
         clang
         curl
         dbus-x11
@@ -721,6 +723,7 @@ pkg_dependencies_fedora(){
 
 pkg_dependencies_amazon(){
     echo "
+        bind-utils
         curl
         dbus-x11
         expect
@@ -781,6 +784,7 @@ pkg_dependencies_arch(){
     bash-completion
     clang
     curl
+    dnsutils
     evolution-data-server
     expect
     fontconfig

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -656,7 +656,6 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         debian-*)
             echo "
-                dnsutils
                 eatmydata
                 evolution-data-server
                 fwupd
@@ -690,7 +689,6 @@ pkg_dependencies_ubuntu_core(){
 
 pkg_dependencies_fedora(){
     echo "
-        bind-utils
         clang
         curl
         dbus-x11
@@ -723,7 +721,6 @@ pkg_dependencies_fedora(){
 
 pkg_dependencies_amazon(){
     echo "
-        bind-utils
         curl
         dbus-x11
         expect
@@ -784,7 +781,6 @@ pkg_dependencies_arch(){
     bash-completion
     clang
     curl
-    dnsutils
     evolution-data-server
     expect
     fontconfig

--- a/tests/main/retry-network/task.yaml
+++ b/tests/main/retry-network/task.yaml
@@ -37,7 +37,7 @@ execute: |
     MATCH "(Temporary failure in name resolution|network is unreachable)" < stderr
 
     echo "Now without DNS resolver"
-    UBUNTU_IP="$(nslookup www.ubuntu.com | grep 'Server:' | awk '{print $2 }')"
+    UBUNTU_IP="$(getent ahostsv4 www.ubuntu.com | awk '{print $1}' | head -n1)"
     SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry "http://$UBUNTU_IP" > output.txt 2>stderr
     # XXX: ShouldRetryError is slightly misbehaving, see comment above
     MATCH "ShouldRetryError: true" < output.txt

--- a/tests/main/retry-network/task.yaml
+++ b/tests/main/retry-network/task.yaml
@@ -25,13 +25,7 @@ execute: |
     echo "Add totally unconnected network namespace"
     ip netns add testns
 
-    for _ in $(seq 10); do
-        nsenter --net=/var/run/netns/testns ./detect-retry http://www.ubuntu.com > output.txt
-        if MATCH "NoNetwork: true" < output.txt; then
-            break
-        fi
-        sleep 1
-    done
+    retry-tool -n 10 --wait 1 bash -c 'nsenter --net=/var/run/netns/testns ./detect-retry http://www.ubuntu.com | tee output.txt | MATCH "NoNetwork: true"'
 
     SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry http://www.ubuntu.com > output.txt 2>stderr
     # XXX: ShouldRetryError is slightly misbehaving, if we know we don't have

--- a/tests/main/retry-network/task.yaml
+++ b/tests/main/retry-network/task.yaml
@@ -24,6 +24,15 @@ debug: |
 execute: |
     echo "Add totally unconnected network namespace"
     ip netns add testns
+
+    for _ in $(seq 10); do
+        nsenter --net=/var/run/netns/testns ./detect-retry http://www.ubuntu.com > output.txt
+        if MATCH "NoNetwork: true" < output.txt; then
+            break
+        fi
+        sleep 1
+    done
+
     SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry http://www.ubuntu.com > output.txt 2>stderr
     # XXX: ShouldRetryError is slightly misbehaving, if we know we don't have
     #      a network connection we should not retry. However we keep it as
@@ -34,7 +43,7 @@ execute: |
     MATCH "(Temporary failure in name resolution|network is unreachable)" < stderr
 
     echo "Now without DNS resolver"
-    UBUNTU_IP="$(getent hosts www.ubuntu.com|awk '{print $1 }' | head -n1)"
+    UBUNTU_IP="$(nslookup www.ubuntu.com | grep 'Server:' | awk '{print $2 }')"
     SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry "http://$UBUNTU_IP" > output.txt 2>stderr
     # XXX: ShouldRetryError is slightly misbehaving, see comment above
     MATCH "ShouldRetryError: true" < output.txt


### PR DESCRIPTION
Two fixes have been applied to retry-network test:
    1. Timing issue, after addin a totally unconnected network namespace
it is needed a short time to get NoNetwork: true.
    2. ipv6 issue: the command 'getent hosts www.ubuntu.com' is
returning the ipv6 which is making the validation fail.
