### PR TITLE
tests: use ipv4 in retry-network to unblock failing master

### DIFF
--- a/tests/main/retry-network/task.yaml
+++ b/tests/main/retry-network/task.yaml
@@ -33,11 +33,13 @@ execute: |
     # be paranoid and look at the low-level go error as well
     MATCH "(Temporary failure in name resolution|network is unreachable)" < stderr
 
-    echo "Now without DNS resolver"
-    UBUNTU_IP="$(getent hosts www.ubuntu.com|awk '{print $1 }' | head -n1)"
+    echo "Now without DNS resolver with ipv4"
+    UBUNTU_IP="$(getent ahostsv4 www.ubuntu.com|awk '{print $1 }' | head -n1)"
     SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry "http://$UBUNTU_IP" > output.txt 2>stderr
     # XXX: ShouldRetryError is slightly misbehaving, see comment above
     MATCH "ShouldRetryError: true" < output.txt
     MATCH "NoNetwork: true" < output.txt
     # be paranoid and look at the low-level go error as well
     MATCH "network is unreachable" < stderr
+
+    # XXX: also test with ipv6


### PR DESCRIPTION
This commit unblocks master. Most recently "getenv hosts" returns
ipv6 addresses. But when those are passed to the script they are
not put inside [] so the "http://2001::01:123" style confuses
go ang things fail. I'm also working on a followup that will
use ipv6. Unfortunately this is more work as right now we get
a very different error in the network namespace and it's not
quite clear yet if the network namespace is just not configured
right or if it's a real error we should handle.

