### PR TITLE
wrappers: add mount unit dependency for snapd services on core devices 

### DIFF
--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -295,11 +295,11 @@ type: snapd
 `
 	snapdUnits := [][]string{
 		// system services
-		{"lib/systemd/system/snapd.service", "[Unit]\nExecStart=/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start"},
+		{"lib/systemd/system/snapd.service", "[Unit]\n[Service]\nExecStart=/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start"},
 		{"lib/systemd/system/snapd.socket", "[Unit]\n[Socket]\nListenStream=/run/snapd.socket"},
 		{"lib/systemd/system/snapd.snap-repair.timer", "[Unit]\n[Timer]\nOnCalendar=*-*-* 5,11,17,23:00"},
 		// user services
-		{"usr/lib/systemd/user/snapd.session-agent.service", "[Unit]\nExecStart=/usr/bin/snap session-agent"},
+		{"usr/lib/systemd/user/snapd.session-agent.service", "[Unit]\n[Service]\nExecStart=/usr/bin/snap session-agent"},
 		{"usr/lib/systemd/user/snapd.session-agent.socket", "[Unit]\n[Socket]\nListenStream=%t/snap-session.socket"},
 	}
 	info := snaptest.MockSnapWithFiles(c, yaml, &snap.SideInfo{Revision: snap.R(11)}, snapdUnits)
@@ -322,15 +322,15 @@ func (s *linkSuite) TestLinkSnapdSnapOnCore(c *C) {
 	c.Assert(reboot, Equals, false)
 
 	// system services
-	c.Check(filepath.Join(dirs.SnapServicesDir, "snapd.service"), testutil.FileEquals,
-		fmt.Sprintf("[Unit]\nExecStart=%s/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start", info.MountDir()))
+	c.Check(filepath.Join(dirs.SnapServicesDir, "snapd.service"), testutil.FileContains,
+		fmt.Sprintf("[Service]\nExecStart=%s/usr/lib/snapd/snapd\n", info.MountDir()))
 	c.Check(filepath.Join(dirs.SnapServicesDir, "snapd.socket"), testutil.FileEquals,
 		"[Unit]\n[Socket]\nListenStream=/run/snapd.socket")
 	c.Check(filepath.Join(dirs.SnapServicesDir, "snapd.snap-repair.timer"), testutil.FileEquals,
 		"[Unit]\n[Timer]\nOnCalendar=*-*-* 5,11,17,23:00")
 	// user services
-	c.Check(filepath.Join(dirs.SnapUserServicesDir, "snapd.session-agent.service"), testutil.FileEquals,
-		fmt.Sprintf("[Unit]\nExecStart=%s/usr/bin/snap session-agent", info.MountDir()))
+	c.Check(filepath.Join(dirs.SnapUserServicesDir, "snapd.session-agent.service"), testutil.FileContains,
+		fmt.Sprintf("[Service]\nExecStart=%s/usr/bin/snap session-agent", info.MountDir()))
 	c.Check(filepath.Join(dirs.SnapUserServicesDir, "snapd.session-agent.socket"), testutil.FileEquals,
 		"[Unit]\n[Socket]\nListenStream=%t/snap-session.socket")
 	// auxiliary mount unit
@@ -628,8 +628,8 @@ func (s *snapdOnCoreUnlinkSuite) TestUndoGeneratedWrappers(c *C) {
 	c.Assert(reboot, Equals, false)
 
 	// sanity checks
-	c.Check(filepath.Join(dirs.SnapServicesDir, "snapd.service"), testutil.FileEquals,
-		fmt.Sprintf("[Unit]\nExecStart=%s/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start", info.MountDir()))
+	c.Check(filepath.Join(dirs.SnapServicesDir, "snapd.service"), testutil.FileContains,
+		fmt.Sprintf("[Service]\nExecStart=%s/usr/lib/snapd/snapd\n", info.MountDir()))
 	// expecting all generated untis to be present
 	for _, entry := range generatedSnapdUnits {
 		c.Check(toEtcUnitPath(entry[0]), testutil.FilePresent)

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -168,7 +168,13 @@ func AddSnapdSnapServices(s *snap.Info, inter interacter) error {
 		if err != nil {
 			return err
 		}
-		content = execStartRe.ReplaceAll(content, []byte(fmt.Sprintf(`ExecStart=%s$1`, s.MountDir())))
+		if execStartRe.Match(content) {
+			content = execStartRe.ReplaceAll(content, []byte(fmt.Sprintf("ExecStart=%s$1", s.MountDir())))
+			// when the service executes a command from the snapd snap, make
+			// sure the exec path points to the mount dir, and that the
+			// mount happens before the unit is started
+			content = append(content, []byte(fmt.Sprintf("\n[Unit]\nRequiresMountsFor=%s\n", s.MountDir()))...)
+		}
 
 		snapdUnits[filepath.Base(unit)] = &osutil.MemoryFileState{
 			Content: content,
@@ -394,7 +400,13 @@ func writeSnapdUserServicesOnCore(s *snap.Info, inter interacter) error {
 		if err != nil {
 			return err
 		}
-		content = execStartRe.ReplaceAll(content, []byte(fmt.Sprintf(`ExecStart=%s$1`, s.MountDir())))
+		if execStartRe.Match(content) {
+			content = execStartRe.ReplaceAll(content, []byte(fmt.Sprintf("ExecStart=%s$1", s.MountDir())))
+			// when the service executes a command from the snapd snap, make
+			// sure the exec path points to the mount dir, and that the
+			// mount happens before the unit is started
+			content = append(content, []byte(fmt.Sprintf("\n[Unit]\nRequiresMountsFor=%s\n", s.MountDir()))...)
+		}
 
 		snapdUnits[filepath.Base(unit)] = &osutil.MemoryFileState{
 			Content: content,

--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -45,13 +45,13 @@ func makeMockSnapdSnap(c *C) *snap.Info {
 
 	info := snaptest.MockSnapWithFiles(c, snapdYaml, &snap.SideInfo{Revision: snap.R(1)}, [][]string{
 		// system services
-		{"lib/systemd/system/snapd.service", "[Unit]\nExecStart=/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start"},
-		{"lib/systemd/system/snapd.system-shutdown.service", "[Unit]\nExecStart=/bin/umount --everything\n# X-Snapd-Snap: do-not-start"},
-		{"lib/systemd/system/snapd.autoimport.service", "[Unit]\nExecStart=/usr/bin/snap auto-import"},
+		{"lib/systemd/system/snapd.service", "[Unit]\n[Service]\nExecStart=/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start"},
+		{"lib/systemd/system/snapd.system-shutdown.service", "[Unit]\n[Service]\nExecStart=/bin/umount --everything\n# X-Snapd-Snap: do-not-start"},
+		{"lib/systemd/system/snapd.autoimport.service", "[Unit]\n[Service]\nExecStart=/usr/bin/snap auto-import"},
 		{"lib/systemd/system/snapd.socket", "[Unit]\n[Socket]\nListenStream=/run/snapd.socket"},
 		{"lib/systemd/system/snapd.snap-repair.timer", "[Unit]\n[Timer]\nOnCalendar=*-*-* 5,11,17,23:00"},
 		// user services
-		{"usr/lib/systemd/user/snapd.session-agent.service", "[Unit]\nExecStart=/usr/bin/snap session-agent"},
+		{"usr/lib/systemd/user/snapd.session-agent.service", "[Unit]\n[Service]\nExecStart=/usr/bin/snap session-agent"},
 		{"usr/lib/systemd/user/snapd.session-agent.socket", "[Unit]\n[Socket]\nListenStream=%t/snap-session.socket"},
 	})
 
@@ -124,17 +124,17 @@ WantedBy=snapd.service
 		// check that snapd.service is created
 		filepath.Join(dirs.SnapServicesDir, "snapd.service"),
 		// and paths get re-written
-		fmt.Sprintf("[Unit]\nExecStart=%s/snapd/1/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start", dirs.SnapMountDir),
+		fmt.Sprintf("[Unit]\n[Service]\nExecStart=%[1]s/snapd/1/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start\n[Unit]\nRequiresMountsFor=%[1]s/snapd/1\n", dirs.SnapMountDir),
 	}, {
 		// check that snapd.autoimport.service is created
 		filepath.Join(dirs.SnapServicesDir, "snapd.autoimport.service"),
 		// and paths get re-written
-		fmt.Sprintf("[Unit]\nExecStart=%s/snapd/1/usr/bin/snap auto-import", dirs.SnapMountDir),
+		fmt.Sprintf("[Unit]\n[Service]\nExecStart=%[1]s/snapd/1/usr/bin/snap auto-import\n[Unit]\nRequiresMountsFor=%[1]s/snapd/1\n", dirs.SnapMountDir),
 	}, {
 		// check that snapd.system-shutdown.service is created
 		filepath.Join(dirs.SnapServicesDir, "snapd.system-shutdown.service"),
 		// and paths *do not* get re-written
-		"[Unit]\nExecStart=/bin/umount --everything\n# X-Snapd-Snap: do-not-start",
+		"[Unit]\n[Service]\nExecStart=/bin/umount --everything\n# X-Snapd-Snap: do-not-start",
 	}, {
 		// check that usr-lib-snapd.mount is created
 		filepath.Join(dirs.SnapServicesDir, "usr-lib-snapd.mount"),
@@ -143,7 +143,7 @@ WantedBy=snapd.service
 		// check that snapd.session-agent.service is created
 		filepath.Join(dirs.SnapUserServicesDir, "snapd.session-agent.service"),
 		// and paths get re-written
-		fmt.Sprintf("[Unit]\nExecStart=%s/snapd/1/usr/bin/snap session-agent", dirs.SnapMountDir),
+		fmt.Sprintf("[Unit]\n[Service]\nExecStart=%[1]s/snapd/1/usr/bin/snap session-agent\n[Unit]\nRequiresMountsFor=%[1]s/snapd/1\n", dirs.SnapMountDir),
 	}, {
 		// check that snapd.session-agent.socket is created
 		filepath.Join(dirs.SnapUserServicesDir, "snapd.session-agent.socket"),


### PR DESCRIPTION
Snapd services on core devices are executed directly from the mounted snapd
snap. For this reason need to ensure that the snap is mounted. This is done by
adding a RequiresMountsFor=<snap-mount-path> when updating the service's
ExecStart line.