### PR TITLE
spread.yaml: mv opensuse 15.1 to unstable

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -99,8 +99,6 @@ backends:
             - opensuse-15.0-64:
                 workers: 6
                 manual: true
-            - opensuse-15.1-64:
-                workers: 6
             - opensuse-tumbleweed-64:
                 workers: 6
             - arch-linux-64:
@@ -118,12 +116,15 @@ backends:
     # so this block is intentially kept commented out, until we need to add
     # systems to it
     #
-    # google-unstable:
-    #    type: google
-    #    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    #    location: computeengine/us-east1-b
-    #    halt-timeout: 2h
-    #    systems:
+    google-unstable:
+       type: google
+       key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+       location: computeengine/us-east1-b
+       halt-timeout: 2h
+       systems:
+            - opensuse-15.1-64:
+                workers: 6
+
 
     google-tpm:
         type: google

--- a/spread.yaml
+++ b/spread.yaml
@@ -99,8 +99,6 @@ backends:
             - opensuse-15.0-64:
                 workers: 6
                 manual: true
-            - opensuse-tumbleweed-64:
-                workers: 6
             - arch-linux-64:
                 manual: true
                 workers: 6
@@ -123,6 +121,8 @@ backends:
        halt-timeout: 2h
        systems:
             - opensuse-15.1-64:
+                workers: 6
+            - opensuse-tumbleweed-64:
                 workers: 6
 
 


### PR DESCRIPTION
The repos are currently failing to fetch like this:
```
+ zypper ref
Repository 'openSUSE-Leap-15.1-Non-Oss' is up to date.
Repository 'openSUSE-Leap-15.1-Oss' is up to date.
Problem retrieving files from 'openSUSE-Leap-15.1-Update'.
Download (curl) error for 'http://download.opensuse.org/update/leap/15.1/oss/repodata/repomd.xml':
Error code: Connection failed
Error message: Could not resolve host: download.opensuse.org

Please see the above error message for a hint.
Skipping repository 'openSUSE-Leap-15.1-Update' because of the above error.
Retrieving repository 'openSUSE-Leap-Cloud-Tools' metadata [.......done]
Building repository 'openSUSE-Leap-Cloud-Tools' cache [....done]
Problem retrieving files from 'openSUSE-Leap-15.1-Update'.
```
We will move back when the repos are stable again.