### PR TITLE
interfaces/seccomp: allow passing an address to setgroups

### DIFF
--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -765,7 +765,7 @@ apps:
 		"\n# - create_module, init_module, finit_module, delete_module (kernel modules)\n",
 		"\nopen\n",
 		"\ngetuid\n",
-		"\nsetgroups 0 0\n",
+		"\nsetgroups 0 -\n",
 		// and a few randomly picked lines from root syscalls
 		// with extra \n checks to ensure we have the right
 		// "paragraphs" in the generated output

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -605,9 +605,13 @@ var rootSetUidGidSyscalls = `
 # filtering. AppArmor has corresponding CAP_SETUID, CAP_SETGID and CAP_CHOWN
 # rules.
 
-# allow use of setgroups(0, NULL)
-setgroups 0 0
-setgroups32 0 0
+# allow use of setgroups(0, ...). Note: while the setgroups() man page states
+# that 'setgroups(0, NULL) should be used to clear all supplementary groups,
+# the kernel will not consult the group list when size is '0', so we allow it
+# to be anything for compatibility with (arguably buggy) programs that expect
+# to clear the groups with 'setgroups(0, <non-null>).
+setgroups 0 -
+setgroups32 0 -
 
 # allow setgid to root
 setgid g:root


### PR DESCRIPTION
It turns out that some programs use setgroups(0, &addr) to drop groups
instead of setgroups(0, NULL). For instance, dnsmasq:
http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=blob;f=src/dnsmasq.c;h=10f19ead62f791568532115e871a0dd7ab3527bc;hb=HEAD#l701
This might be due to compatibility reasons with BSDs. Allow this,
because if the size is 0, the second argument is not used anyway.