### PR TITLE
ovelord/snapstate: update only system wide fonts cache

### DIFF
--- a/overlord/snapstate/backend/fontconfig.go
+++ b/overlord/snapstate/backend/fontconfig.go
@@ -32,7 +32,7 @@ var commandFromSystemSnap = cmdutil.CommandFromSystemSnap
 // updateFontconfigCaches always update the fontconfig caches
 func updateFontconfigCachesImpl() error {
 	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7"} {
-		cmd, err := commandFromSystemSnap("/bin/" + fc)
+		cmd, err := commandFromSystemSnap("/bin/"+fc, "--system-only")
 		if err != nil {
 			return fmt.Errorf("cannot get %s from core: %v", fc, err)
 		}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -523,8 +523,12 @@ type: os
 	c.Check(oldCmdV6.Calls(), HasLen, 0)
 	c.Check(oldCmdV7.Calls(), HasLen, 0)
 
-	c.Check(newCmdV6.Calls(), HasLen, 1)
-	c.Check(newCmdV7.Calls(), HasLen, 1)
+	c.Check(newCmdV6.Calls(), DeepEquals, [][]string{
+		{"fc-cache-v6", "--system-only"},
+	})
+	c.Check(newCmdV7.Calls(), DeepEquals, [][]string{
+		{"fc-cache-v7", "--system-only"},
+	})
 }
 
 func (s *linkCleanupSuite) testLinkCleanupFailedSnapdSnapOnCorePastWrappers(c *C, firstInstall bool) {


### PR DESCRIPTION
Snapd is running as root, make sure that the fontconfig cache is rebuilt only for
system wide locations, omitting the user's home (/root in this case).

@jhenstridge  can you take a look as well?