### PR TITLE
wrappers: import /etc/environment in all services

### DIFF
--- a/tests/regression/lp-1866095/task.yaml
+++ b/tests/regression/lp-1866095/task.yaml
@@ -1,0 +1,14 @@
+summary: sevices see proxy settings
+# Proxy settings are only honored on core systems.
+systems: [ubuntu-core-*]
+prepare: |
+    snap set system proxy.http=http://example.com/
+    MATCH http_proxy=http://example.com/ < /etc/environment
+    snap pack test-snapd-service
+    snap install --dangerous test-snapd-service_1_all.snap
+execute: |
+    MATCH http_proxy=http://example.com/ < /var/snap/test-snapd-service/common/env
+restore: |
+    snap remove test-snapd-service
+    rm -f test-snapd-service_1_all.snap
+    snap unset system proxy.http

--- a/tests/regression/lp-1866095/test-snapd-service/bin/test-snapd-service
+++ b/tests/regression/lp-1866095/test-snapd-service/bin/test-snapd-service
@@ -1,0 +1,2 @@
+#!/bin/sh -xe
+env > "$SNAP_COMMON/env"

--- a/tests/regression/lp-1866095/test-snapd-service/meta/snap.yaml
+++ b/tests/regression/lp-1866095/test-snapd-service/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-service
+version: 1
+architectures: [all]
+apps:
+    test-snapd-service:
+        daemon: oneshot
+        command: bin/test-snapd-service

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -486,6 +486,7 @@ Before={{ stringsJoin .Before " "}}
 X-Snappy=yes
 
 [Service]
+EnvironmentFile=-/etc/environment
 ExecStart={{.App.LauncherCommand}}
 SyslogIdentifier={{.App.Snap.InstanceName}}.{{.App.Name}}
 Restart={{.Restart}}

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -53,6 +53,7 @@ After=%s-snap-44.mount network.target
 X-Snappy=yes
 
 [Service]
+EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run snap.app
 SyslogIdentifier=snap.app
 Restart=%s
@@ -87,6 +88,7 @@ After=%s-xkcd\x2dwebserver-44.mount network.target
 X-Snappy=yes
 
 [Service]
+EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run xkcd-webserver
 SyslogIdentifier=xkcd-webserver.xkcd-webserver
 Restart=on-failure
@@ -362,6 +364,7 @@ Before=%s
 X-Snappy=yes
 
 [Service]
+EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run snap.app
 SyslogIdentifier=snap.app
 Restart=%s
@@ -509,6 +512,7 @@ After=%s-snap-44.mount network.target
 X-Snappy=yes
 
 [Service]
+EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run --timer="10:00-12:00,,mon,23:00~01:00/2" snap.app
 SyslogIdentifier=snap.app
 Restart=%s
@@ -700,6 +704,7 @@ After=%s-snap-44.mount network.target
 X-Snappy=yes
 
 [Service]
+EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run snap.app
 SyslogIdentifier=snap.app
 Restart=on-failure
@@ -740,6 +745,7 @@ After=%s-snap-44.mount network.target
 X-Snappy=yes
 
 [Service]
+EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run snap.app
 SyslogIdentifier=snap.app
 Restart=on-failure


### PR DESCRIPTION
We were alerted that setting a http proxy in the system is not actually
allowing snap services to see the appropriate value. On core systems
proxy settings are written to /etc/environment but systemd service units
that start all snap-installed services do not load that file. This patch
fixes that.

Fixes: https://bugs.launchpad.net/snapd/+bug/1866095
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
