### PR TITLE
interfaces/audio_playback: Fix pulseaudio config access

### DIFF
--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -69,7 +69,7 @@ const audioPlaybackConnectedPlugAppArmorDesktop = `
 # to read available client side configuration settings. On an Ubuntu Core
 # device those things will be stored inside the snap directory.
 /etc/pulse/ r,
-/etc/pulse/* r,
+/etc/pulse/** r,
 owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
 owner /{,var/}run/user/*/pulse/ rwk,


### PR DESCRIPTION
The `audio_playback` interface permission for `/etc/pulse` was incomplete in comparison with old `pulseadio` interface and causes regressions when it tries to read config from subdirs like `/etc/pulse/client.conf.d`. which is denied.

See https://bugs.launchpad.net/snapd/+bug/1865282