### PR TITLE
interfaces/{docker,kubernetes}-support: updates for lastest k8s

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -83,8 +83,7 @@ const dockerSupportConnectedPlugAppArmor = `
 /run/ipam-state/k8s-*/lock k,
 
 # Socket for docker-container-shim
-unix (bind,listen) type=stream addr="@/containerd-shim/moby/*/shim.sock\x00",
-unix (bind,listen) type=stream addr="@/containerd-shim/k8s.io/*/shim.sock\x00",
+unix (bind,listen) type=stream addr="@/containerd-shim/**/shim.sock\x00",
 
 /{,var/}run/mount/utab r,
 

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -154,6 +154,12 @@ const kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun = `
   # For mounting volume subPaths
   mount /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
   mount options=(rw, remount, bind) -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
+  # nvme0-99, 1-63 partitions with 1-63 optional namespaces
+  mount /dev/nvme{[0-9],[1-9][0-9]}n{[1-9],[1-5][0-9],6[0-3]}{,p{[1-9],[1-5][0-9],6[0-3]}} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
+  # SCSI sda-sdiv, 1-15 partitions
+  mount /dev/sd{[a-z],[a-h][a-z],i[a-v]}{[1-9],1[0-5]} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
+  # virtio vda-vdz, 1-63 partitions
+  mount /dev/vd[a-z]{[1-9],[1-5][0-9],6[0-3]} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
   umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
   # When mounting a volume subPath, kubelet binds mounts on an open fd (eg,
   # /proc/.../fd/N) which triggers a ptrace 'trace' denial on the parent

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -64,6 +64,7 @@ capability sys_resource,
 capability dac_override,
 
 /usr/bin/systemd-run Cxr -> systemd_run,
+/run/systemd/private r,
 profile systemd_run (attach_disconnected,mediate_deleted) {
   # Common rules for kubernetes use of systemd_run
   #include <abstractions/base>


### PR DESCRIPTION
* kubernetes-support: update for /run/systemd/private read by kubelet
* kubernetes-support: allow mounts of certain block devices for kubelet
* docker-support: future proof socket with @/containerd-shim/**/shim.sock\x00

Note: there is an additional rule that is needed that will be in a followup PR once I am done investigating it.