### PR TITLE
interfaces: miscellaneous policy updates

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -364,8 +364,12 @@ var defaultTemplate = `
   @{PROC}/sys/fs/file-max r,
   @{PROC}/sys/fs/inotify/max_* r,
   @{PROC}/sys/kernel/pid_max r,
-  @{PROC}/sys/kernel/random/uuid r,
   @{PROC}/sys/kernel/random/boot_id r,
+  @{PROC}/sys/kernel/random/uuid r,
+  # Allow access to the uuidd daemon (this daemon is a thin wrapper around
+  # time and getrandom()/{,u}random and, when available, runs under an
+  # unprivilged, dedicated user).
+  /run/uuidd/request r,
   /sys/devices/virtual/tty/{console,tty*}/active r,
   /sys/fs/cgroup/memory/memory.limit_in_bytes r,
   /sys/fs/cgroup/memory/snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.limit_in_bytes r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -464,6 +464,17 @@ var defaultTemplate = `
   # from the snap base runtime.
   /usr/share/dbus-1/services/{,*} r,
   /usr/share/dbus-1/system-services/{,*} r,
+  # Allow apps to perform DBus introspection on org.freedesktop.DBus for both
+  # the system and session buses.
+  # Note: this does not grant access to the DBus sockets of these buses, but
+  # we grant it here since it is missing from the dbus abstractions
+  # (LP: #1866168)
+  dbus (send)
+      bus={session,system}
+      path=/org/freedesktop/DBus
+      interface=org.freedesktop.DBus.Introspectable
+      member=Introspect
+      peer=(label=unconfined),
 
   # Allow apps from the same package to signal each other via signals
   signal peer=snap.@{SNAP_INSTANCE_NAME}.*,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -257,6 +257,24 @@ owner /{dev,run}/shm/shmfd-* mrw,
 # other snaps and the system, so it is limited to snaps that specify:
 # allow-sandbox: true.
 owner @{PROC}/@{pid}/clear_refs w,
+
+# Allow setting realtime priorities. Clients require RLIMIT_RTTIME in the first
+# place and client authorization is done via PolicyKit. Note that setrlimit()
+# is allowed by default seccomp policy but requires 'capability sys_resource',
+# which we deny be default.
+# http://git.0pointer.net/rtkit.git/tree/README
+dbus (send)
+    bus=system
+    path=/org/freedesktop/RealtimeKit1
+    interface=org.freedesktop.DBus.Properties
+    member=Get
+    peer=(name=org.freedesktop.RealtimeKit1, label=unconfined),
+dbus (send)
+    bus=system
+    path=/org/freedesktop/RealtimeKit1
+    interface=org.freedesktop.RealtimeKit1
+    member=MakeThread{HighPriority,Realtime}
+    peer=(name=org.freedesktop.RealtimeKit1, label=unconfined),
 `
 
 const browserSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -97,6 +97,7 @@ dbus (receive)
     interface=org.freedesktop.DBus.Properties
     path=/org/mpris/MediaPlayer2
     peer=(label=###PLUG_SECURITY_TAGS###),
+
 dbus (receive)
     bus=session
     interface=org.freedesktop.DBus.Introspectable
@@ -106,6 +107,13 @@ dbus (receive)
     bus=session
     interface="org.mpris.MediaPlayer2{,.*}"
     path=/org/mpris/MediaPlayer2
+    peer=(label=###PLUG_SECURITY_TAGS###),
+
+dbus (send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/mpris/MediaPlayer2
+    member=PropertiesChanged
     peer=(label=###PLUG_SECURITY_TAGS###),
 `
 

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -78,6 +78,13 @@ ptrace (read),
 /var/lib/snapd/hostfs/etc/os-release rk,
 /var/lib/snapd/hostfs/usr/lib/os-release rk,
 
+# Allow discovering system-wide CFS Bandwidth Control information
+# https://www.kernel.org/doc/html/latest/scheduler/sched-bwc.html
+/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us r,
+/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us r,
+/sys/fs/cgroup/cpu,cpuacct/cpu.shares r,
+/sys/fs/cgroup/cpu,cpuacct/cpu.stat r,
+
 #include <abstractions/dbus-strict>
 
 # do not use peer=(label=unconfined) here since this is DBus activated

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -259,15 +259,19 @@ munmap
 
 nanosleep
 
+# Argument filtering with gt/ge/lt/le does not work properly with
+# libseccomp < 2.4 or golang-seccomp < 0.9.1. See:
+# - https://bugs.launchpad.net/snapd/+bug/1825052/comments/9
+# - https://github.com/seccomp/libseccomp/issues/69
+# Eventually we want to use >=0, but we need libseccomp and golang-seccomp to
+# be updated everywhere first. In the meantime, use <=19 and rely on the fact
+# that AppArmor mediates CAP_SYS_NICE (and for systems without AppArmor, we
+# ignore this lack of mediation since snaps are not meaningfully confined).
+#
 # Allow using nice() with default or lower priority
-# FIXME: https://github.com/seccomp/libseccomp/issues/69 which means we
-# currently have to use <=19. When that bug is fixed, use >=0
 nice <=19
 # Allow using setpriority to set the priority of the calling process to default
 # or lower priority (eg, 'nice -n 9 <command>')
-# default or lower priority.
-# FIXME: https://github.com/seccomp/libseccomp/issues/69 which means we
-# currently have to use <=19. When that bug is fixed, use >=0
 setpriority PRIO_PROCESS 0 <=19
 
 # LP: #1446748 - support syscall arg filtering for mode_t with O_CREAT


### PR DESCRIPTION
* interfaces/seccomp: cleanup comment surrounding setpriority rule
* interfaces/browser-support: allow RealtimeKit APIs with allow-sandbox: true
* apparmor: also /run/uuidd/request in default template
* interfaces/system-observe: allow reading CFS items from cpu,cpuacct
* interfaces/mpris: allow provider to send PropertiesChanged to the consumer
* apparmor: allow introspection of dbus-daemon (with accompanying connections)

See individual commits for more information. 