### PR TITLE
many: fix a pair of ineffectual assignments

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -207,11 +207,10 @@ func wrapGeneric(out io.Writer, text []rune, indent, indent2 string, termWidth i
 	width := termWidth - indentWidth
 
 	// establish the indent of the whole block
-	idx := 0
 	var err error
 	for len(text) > width && err == nil {
 		// find a good place to chop the text
-		idx = runesLastIndexSpace(text[:width+1])
+		idx := runesLastIndexSpace(text[:width+1])
 		if idx < 0 {
 			// there's no whitespace; just chop at line width
 			idx = width

--- a/interfaces/policy/policy_test.go
+++ b/interfaces/policy/policy_test.go
@@ -2469,7 +2469,7 @@ func (s *policySuite) TestNameConstraintsAutoConnection(c *C) {
 		if t.ok {
 			c.Check(err, IsNil, Commentf("%s:%s", t.plug, t.slot))
 		} else {
-			expected := ""
+			var expected string
 			if cand.Plug.Interface() == "plugs-name-bound" {
 				expected = `auto-connection not allowed by plug rule of interface "plugs-name-bound".*`
 			} else {


### PR DESCRIPTION
This branch removes two ineffectual assignments spotted while running tests.