### PR TITLE
tests: just remove user when the system is not managed on create-user-2 test (2.44)

### DIFF
--- a/tests/core/create-user-2/task.yaml
+++ b/tests/core/create-user-2/task.yaml
@@ -8,7 +8,9 @@ environment:
     USER_NAME: mvo
 
 restore: |
-    snap remove-user "$USER_NAME"
+    if [ "$(snap managed)" = "false" ]; then
+        snap remove-user "$USER_NAME"
+    fi
 
 execute: |
     echo "snap create-user -- ensure failure when run as non-root user without sudo"

--- a/tests/core/create-user-2/task.yaml
+++ b/tests/core/create-user-2/task.yaml
@@ -8,16 +8,17 @@ environment:
     USER_NAME: mvo
 
 restore: |
-    if [ "$(snap managed)" = "false" ]; then
-        snap remove-user "$USER_NAME"
+    if [ -e managed.device ]; then
+        exit 0
     fi
+    snap remove-user "$USER_NAME"
 
 execute: |
     echo "snap create-user -- ensure failure when run as non-root user without sudo"
     expected="error: while creating user: access denied"
     if obtained=$(su - test /bin/sh -c "snap create-user $USER_EMAIL 2>&1"); then
         echo "create-user command should have failed"
-    fi
+    fi 
     [[ "$obtained" =~ $expected ]]
 
     if [ "$(snap managed)" = "true" ]; then
@@ -27,6 +28,10 @@ execute: |
             exit 1
         fi
         MATCH "cannot create user: device already managed" < create.error
+
+        # Leave a file indicating the device was initially managed
+        touch managed.device
+
         exit 0
     fi
 

--- a/tests/core/create-user/task.yaml
+++ b/tests/core/create-user/task.yaml
@@ -4,21 +4,27 @@ summary: Ensure that snap create-user works in ubuntu-core
 # TODO:UC20: enable for UC20
 systems: [ubuntu-core-1*]
 
+environment:
+    USER_EMAIL: mvo@ubuntu.com
+    USER_NAME: mvo
+
 restore: |
-    # FIXME: use deluser here now that it supports --extrausers
-    sed -i '/^mvo/d' /var/lib/extrausers/passwd
-    sed -i '/^mvo/d' /var/lib/extrausers/shadow
-    sed -i '/^mvo/d' /var/lib/extrausers/group
-    rm -rf /home/mvo
-    rm -f create.error
+    if [ -e managed.device ]; then
+        exit 0
+    fi
+    snap remove-user "$USER_NAME"
 
 execute: |
     if [ "$MANAGED_DEVICE" = "true" ]; then
-        if snap create-user --sudoer mvo@ubuntu.com 2>create.error; then
+        if snap create-user --sudoer "$USER_EMAIL" 2>create.error; then
             echo "Did not get expected error creating user in managed device"
             exit 1
         fi
         MATCH "cannot create user: device already managed" < create.error
+
+        # Leave a file indicating the device was initially managed
+        touch managed.device
+
         exit 0
     fi
     echo "Adding invalid user"
@@ -30,23 +36,23 @@ execute: |
     MATCH "$expected" <<<"$output"
 
     echo "Adding valid user"
-    expected='created user "mvo"'
-    output=$(snap create-user --sudoer mvo@ubuntu.com)
+    expected='created user "$USER_NAME"'
+    output=$(snap create-user --sudoer "$USER_EMAIL")
     if [ "$output" != "$expected" ]; then
         echo "Unexpected output $output"
         exit 1
     fi
     echo "Ensure there are ssh keys imported"
-    MATCH ssh-rsa < /home/mvo/.ssh/authorized_keys
+    MATCH ssh-rsa < /home/"$USER_NAME"/.ssh/authorized_keys
 
     echo "Ensure the user is a sudo user"
-    sudo -u mvo sudo true
+    sudo -u "$USER_NAME" sudo true
 
     echo "ensure the user's home directory exists"
-    test -d /home/mvo
+    test -d /home/"$USER_NAME"
 
     echo "ensure ~/.snap/auth.json was created"
-    test -f /home/mvo/.snap/auth.json
+    test -f /home/"$USER_NAME"/.snap/auth.json
 
     echo "ensure user's email was stored in ~/.snap/auth.json"
-    MATCH '"email":"mvo@ubuntu.com"' < /home/mvo/.snap/auth.json
+    MATCH '"email":""$USER_EMAIL""' < /home/"$USER_NAME"/.snap/auth.json

--- a/tests/core/create-user/task.yaml
+++ b/tests/core/create-user/task.yaml
@@ -36,7 +36,7 @@ execute: |
     MATCH "$expected" <<<"$output"
 
     echo "Adding valid user"
-    expected="created user \"$USER_EMAIL\""
+    expected="created user \"$USER_NAME\""
     output=$(snap create-user --sudoer "$USER_EMAIL")
     if [ "$output" != "$expected" ]; then
         echo "Unexpected output $output"

--- a/tests/core/create-user/task.yaml
+++ b/tests/core/create-user/task.yaml
@@ -36,7 +36,7 @@ execute: |
     MATCH "$expected" <<<"$output"
 
     echo "Adding valid user"
-    expected='created user "$USER_NAME"'
+    expected="created user \"$USER_EMAIL\""
     output=$(snap create-user --sudoer "$USER_EMAIL")
     if [ "$output" != "$expected" ]; then
         echo "Unexpected output $output"
@@ -55,4 +55,4 @@ execute: |
     test -f /home/"$USER_NAME"/.snap/auth.json
 
     echo "ensure user's email was stored in ~/.snap/auth.json"
-    MATCH '"email":""$USER_EMAIL""' < /home/"$USER_NAME"/.snap/auth.json
+    MATCH "\"email\":\"$USER_EMAIL\"" < /home/"$USER_NAME"/.snap/auth.json

--- a/tests/main/remove-user/task.yaml
+++ b/tests/main/remove-user/task.yaml
@@ -9,18 +9,32 @@ environment:
     USER_NAME: mvo
 
 prepare: |
+    # Note: make this test work with the user already created in the device
+    if [ "$(snap managed)" = "true" ]; then
+        # Leave a file indicating the device was initially managed
+        touch managed.device
+
+        exit 0
+    fi
     snap create-user --sudoer "$USER_EMAIL"
 
 restore: |
+    if [ -e managed.device ]; then
+        exit 0
+    fi
     userdel --extrausers -r "$USER_NAME" || true
     rm -rf "/etc/sudoers.d/create-user-$USER_NAME"
 
 execute: |
+    if [ -e managed.device ]; then
+        exit 0
+    fi
+
     echo "sanity check: user in passwd"
     id "$USER_NAME"
     echo "sanity check: has sudoer file"
     test -f "/etc/sudoers.d/create-user-$USER_NAME"
-    echo "sanity check: user has a home"
+    echo "sanity check: user has a home" 
     test -d "/home/$USER_NAME"
 
     echo "snap remove-user fails when run as non-root user without sudo"


### PR DESCRIPTION
This is #8205 for 2.44