### PR TITLE
interfaces: work around apparmor_parser slowness affecting uio

### DIFF
--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -41,9 +41,9 @@ type Specification struct {
 	// of the application or hook.
 	snippets map[string][]string
 
-	// dedupSnippets are just like snippets but are expensive to de-duplicate
-	// in apparmor_parser and are explicitly de-duplicated in the specification
-	// and backend system.
+	// dedupSnippets are just like snippets but are added only once to the
+	// resulting policy in an effort to avoid certain expensive to de-duplicate
+	// rules by apparmor_parser.
 	dedupSnippets map[string]*strutil.OrderedSet
 
 	// updateNS describe parts of apparmor policy for snap-update-ns executing
@@ -98,10 +98,13 @@ func (spec *Specification) AddSnippet(snippet string) {
 
 // AddDeduplicatedSnippet adds a new apparmor snippet to all applications and hooks using the interface.
 //
-// Multiple identical snippets may be computationally expensive to de-duplicate
-// in apparmor_parser. Using this function allows snapd to de-duplicate them at
-// the cost of somewhat more complex auditing process of the text of generated
-// apparmor profile.
+// Certain combinations of snippets may be computationally expensive for
+// apparmor_parser in its de-duplication step. This function lets snapd
+// perform de-duplication of identical rules at the potential cost of a
+// somewhat more complex auditing process of the text of generated
+// apparmor profile. Identical mount rules should typically use this, but
+// this function can also be used to avoid repeated rules that inhibit
+// auditability.
 func (spec *Specification) AddDeduplicatedSnippet(snippet string) {
 	if len(spec.securityTags) == 0 {
 		return

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -153,6 +153,25 @@ func (s *specSuite) TestAddDeduplicatedSnippet(c *C) {
 	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.command", "snap.demo.service"})
 }
 
+// Both AddSnippet and AddDeduplicatedSnippet work correctly together.
+func (s *specSuite) TestAddSnippetAndAddDeduplicatedSnippet(c *C) {
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})
+	defer restore()
+
+	// Add two snippets in the context we are in.
+	s.spec.AddSnippet("normal")
+	s.spec.AddDeduplicatedSnippet("dedup")
+
+	// The snippets were recorded correctly.
+	c.Assert(s.spec.UpdateNS(), HasLen, 0)
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
+		"snap.demo.command": {"normal", "dedup"},
+		"snap.demo.service": {"normal", "dedup"},
+	})
+	c.Assert(s.spec.SnippetForTag("snap.demo.command"), Equals, "normal\ndedup")
+	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.command", "snap.demo.service"})
+}
+
 // AddUpdateNS adds a snippet for the snap-update-ns profile for a given snap.
 func (s *specSuite) TestAddUpdateNS(c *C) {
 	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -132,6 +132,27 @@ func (s *specSuite) TestAddSnippet(c *C) {
 	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.command", "snap.demo.service"})
 }
 
+// AddDeduplicatedSnippet adds a snippet for the given security tag.
+func (s *specSuite) TestAddDeduplicatedSnippet(c *C) {
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})
+	defer restore()
+
+	// Add two snippets in the context we are in.
+	s.spec.AddDeduplicatedSnippet("dedup snippet 1")
+	s.spec.AddDeduplicatedSnippet("dedup snippet 1")
+	s.spec.AddDeduplicatedSnippet("dedup snippet 2")
+	s.spec.AddDeduplicatedSnippet("dedup snippet 2")
+
+	// The snippets were recorded correctly.
+	c.Assert(s.spec.UpdateNS(), HasLen, 0)
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
+		"snap.demo.command": {"dedup snippet 1", "dedup snippet 2"},
+		"snap.demo.service": {"dedup snippet 1", "dedup snippet 2"},
+	})
+	c.Assert(s.spec.SnippetForTag("snap.demo.command"), Equals, "dedup snippet 1\ndedup snippet 2")
+	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.command", "snap.demo.service"})
+}
+
 // AddUpdateNS adds a snippet for the snap-update-ns profile for a given snap.
 func (s *specSuite) TestAddUpdateNS(c *C) {
 	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})

--- a/interfaces/builtin/uio.go
+++ b/interfaces/builtin/uio.go
@@ -99,7 +99,7 @@ func (iface *uioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	// sysfs files and control writable access to the specific
 	// device node in /dev. Use AddDeduplicatedSnippet() for clarity
 	// in the resulting rules.
-	spec.AddDeduplicatedSnippet("/sys/devices/platform/**/uio/uio[0-9]** r,")
+	spec.AddDeduplicatedSnippet("/sys/devices/platform/**/uio/uio[0-9]** r,  # common rule for all uio connections")
 	return nil
 }
 

--- a/interfaces/builtin/uio.go
+++ b/interfaces/builtin/uio.go
@@ -82,7 +82,15 @@ func (iface *uioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	//  - $sysfs_base/portio/port[0-9]+/{name,start,size,porttype}
 	// The expression below matches them all as they all may be required for
 	// userspace drivers to operate.
-	spec.AddSnippet(fmt.Sprintf("/sys/devices/platform/**/uio/%s/** r,", strings.TrimPrefix(path, "/dev/")))
+	//
+	// NOTE: This is a constant string to avoid apparmor_parser efficiency
+	// issue. This is detailed in the (private) bug LP: #1866349
+	//
+	// The workaround grants read only access to all uio sysfs files and
+	// control writable access to the specific device node. In addition the
+	// snippet added here is de-duplicated by the system before handing the
+	// text to compile in apparmor_parser.
+	spec.AddDeduplicatedSnippet("/sys/devices/platform/**/uio/uio[0-9]** r,")
 	return nil
 }
 

--- a/interfaces/builtin/uio.go
+++ b/interfaces/builtin/uio.go
@@ -97,7 +97,7 @@ func (iface *uioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	// which are computationally difficult to de-duplicate provided
 	// large enough N. Instead, grant read only access to all uio
 	// sysfs files and control writable access to the specific
-	// device node in /dev. Use AddDeduplicatedSnippet() for clariry
+	// device node in /dev. Use AddDeduplicatedSnippet() for clarity
 	// in the resulting rules.
 	spec.AddDeduplicatedSnippet("/sys/devices/platform/**/uio/uio[0-9]** r,")
 	return nil

--- a/interfaces/builtin/uio_test.go
+++ b/interfaces/builtin/uio_test.go
@@ -113,7 +113,7 @@ func (s *uioInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
 		"/dev/uio0 rw,\n"+
 		"/dev/uio1 rw,\n"+
-		"/sys/devices/platform/**/uio/uio[0-9]** r,")
+		"/sys/devices/platform/**/uio/uio[0-9]** r,  # common rule for all uio connections")
 }
 
 func (s *uioInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/uio_test.go
+++ b/interfaces/builtin/uio_test.go
@@ -33,11 +33,13 @@ import (
 
 type uioInterfaceSuite struct {
 	testutil.BaseTest
-	iface          interfaces.Interface
-	slotGadgetInfo *snap.SlotInfo
-	slotGadget     *interfaces.ConnectedSlot
-	plugInfo       *snap.PlugInfo
-	plug           *interfaces.ConnectedPlug
+	iface           interfaces.Interface
+	slotGadgetInfo0 *snap.SlotInfo
+	slotGadgetInfo1 *snap.SlotInfo
+	slotGadget0     *interfaces.ConnectedSlot
+	slotGadget1     *interfaces.ConnectedSlot
+	plugInfo        *snap.PlugInfo
+	plug            *interfaces.ConnectedPlug
 }
 
 var _ = Suite(&uioInterfaceSuite{
@@ -53,9 +55,14 @@ slots:
   uio-0:
     interface: uio
     path: /dev/uio0
+  uio-1:
+    interface: uio
+    path: /dev/uio1
 `, nil)
-	s.slotGadgetInfo = info.Slots["uio-0"]
-	s.slotGadget = interfaces.NewConnectedSlot(s.slotGadgetInfo, nil, nil)
+	s.slotGadgetInfo0 = info.Slots["uio-0"]
+	s.slotGadgetInfo1 = info.Slots["uio-1"]
+	s.slotGadget0 = interfaces.NewConnectedSlot(s.slotGadgetInfo0, nil, nil)
+	s.slotGadget1 = interfaces.NewConnectedSlot(s.slotGadgetInfo1, nil, nil)
 
 	info = snaptest.MockInfo(c, `
 name: consumer
@@ -76,7 +83,7 @@ func (s *uioInterfaceSuite) TestName(c *C) {
 }
 
 func (s *uioInterfaceSuite) TestSanitizeSlot(c *C) {
-	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotGadgetInfo), IsNil)
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotGadgetInfo0), IsNil)
 	brokenSlot := snaptest.MockInfo(c, `
 name: broken-gadget
 version: 1
@@ -90,7 +97,7 @@ slots:
 
 func (s *uioInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slotGadget), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slotGadget0), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# uio
 SUBSYSTEM=="uio", KERNEL=="uio0", TAG+="snap_consumer_app"`)
@@ -99,11 +106,14 @@ SUBSYSTEM=="uio", KERNEL=="uio0", TAG+="snap_consumer_app"`)
 
 func (s *uioInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slotGadget), IsNil)
+	// Simulate two UIO connections.
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slotGadget0), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slotGadget1), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
 		"/dev/uio0 rw,\n"+
-		"/sys/devices/platform/**/uio/uio0/** r,")
+		"/dev/uio1 rw,\n"+
+		"/sys/devices/platform/**/uio/uio[0-9]** r,")
 }
 
 func (s *uioInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
This branch contains two new patches: a way to add apparmor snippets that are
de-duplicated by snapd and a modification of uio interface to avoid a
performance regression when using multiple uio interfaces.

Fixes: https://launchpad.net/bugs/1866349
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
