### PR TITLE
[RFC] config: add system.certs.[a-zA-Z0-9] support

### DIFF
--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -1,0 +1,80 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+)
+
+func handleCertConfiguration(tr config.Conf) error {
+	for _, name := range tr.Changes() {
+		nameWithoutSnap := strings.SplitN(name, ".", 2)[1]
+		cert, err := coreCfg(tr, nameWithoutSnap)
+		if err != nil {
+			return fmt.Errorf("internal error: cannot get data for %s: %v", nameWithoutSnap, err)
+		}
+		optionName := strings.SplitN(name, ".", 3)[2]
+		certPath := filepath.Join(dirs.SnapdStoreSSLCertsDir, optionName+".pem")
+		switch cert {
+		case "":
+			// remove
+			if err := os.Remove(certPath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("cannot remove cert: %v", err)
+			}
+		default:
+			if err := os.MkdirAll(dirs.SnapdStoreSSLCertsDir, 0755); err != nil {
+				return fmt.Errorf("cannot create store ssl certs dir: %v", err)
+			}
+			if err := ioutil.WriteFile(certPath, []byte(cert), 0644); err != nil {
+				return fmt.Errorf("cannot write extra cert: %v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateCertSettings(tr config.Conf) error {
+	for _, name := range tr.Changes() {
+		nameWithoutSnap := strings.SplitN(name, ".", 2)[1]
+		cert, err := coreCfg(tr, nameWithoutSnap)
+		if err != nil {
+			return fmt.Errorf("internal error: cannot get data for %s: %v", nameWithoutSnap, err)
+		}
+		if cert != "" {
+			optionName := strings.SplitN(name, ".", 3)[2]
+			block, rest := pem.Decode([]byte(cert))
+			if block == nil || block.Type != "CERTIFICATE" || len(rest) > 0 {
+				return fmt.Errorf("cannot decode pem certificate %q", optionName)
+			}
+			// XXX: add more validations?
+		}
+	}
+
+	return nil
+}

--- a/overlord/configstate/configcore/certs_test.go
+++ b/overlord/configstate/configcore/certs_test.go
@@ -1,0 +1,104 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type certsSuite struct {
+	configcoreSuite
+}
+
+var _ = Suite(&certsSuite{})
+
+func (s *certsSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *certsSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *certsSuite) TestConfigureCertsUnhappyName(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		changes: map[string]interface{}{
+			"certs.cert!": "xxx",
+		},
+	})
+	c.Assert(err, ErrorMatches, `cannot set "core.certs.cert!": name must be alphanumerical`)
+}
+
+func (s *certsSuite) TestConfigureCertsUnhappyContent(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		changes: map[string]interface{}{
+			"certs.cert1": "xxx",
+		},
+	})
+	c.Assert(err, ErrorMatches, `cannot decode pem certificate "cert1"`)
+}
+
+var mockCert = `-----BEGIN CERTIFICATE-----
+MIIEIDCCAwigAwIBAgIQNE7VVyDV7exJ9C/ON9srbTANBgkqhkiG9w0BAQUFADCB
+qTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEoMCYGA1UECxMf
+Q2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYGA1UECxMvKGMpIDIw
+MDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxHzAdBgNV
+BAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwHhcNMDYxMTE3MDAwMDAwWhcNMzYw
+NzE2MjM1OTU5WjCBqTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5j
+LjEoMCYGA1UECxMfQ2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYG
+A1UECxMvKGMpIDIwMDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNl
+IG9ubHkxHzAdBgNVBAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCsoPD7gFnUnMekz52hWXMJEEUMDSxuaPFs
+W0hoSVk3/AszGcJ3f8wQLZU0HObrTQmnHNK4yZc2AreJ1CRfBsDMRJSUjQJib+ta
+3RGNKJpchJAQeg29dGYvajig4tVUROsdB58Hum/u6f1OCyn1PoSgAfGcq/gcfomk
+6KHYcWUNo1F77rzSImANuVud37r8UVsLr5iy6S7pBOhih94ryNdOwUxkHt3Ph1i6
+Sk/KaAcdHJ1KxtUvkcx8cXIcxcBn6zL9yZJclNqFwJu/U30rCfSMnZEfl2pSy94J
+NqR32HuHUETVPm4pafs5SSYeCaWAe0At6+gnhcn+Yf1+5nyXHdWdAgMBAAGjQjBA
+MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBR7W0XP
+r87Lev0xkhpqtvNG61dIUDANBgkqhkiG9w0BAQUFAAOCAQEAeRHAS7ORtvzw6WfU
+DW5FvlXok9LOAz/t2iWwHVfLHjp2oEzsUHboZHIMpKnxuIvW1oeEuzLlQRHAd9mz
+YJ3rG9XRbkREqaYB7FViHXe4XI5ISXycO1cRrK1zN44veFyQaEfZYGDm/Ac9IiAX
+xPcW6cTYcvnIc3zfFi8VqT79aie2oetaupgf1eNNZAqdE8hhuvU5HIe6uL17In/2
+/qxAeeWsEG89jxt5dovEN7MhGITlNgDrYyCZuen+MwS7QcjBAvlEYyCegc5C09Y/
+LHbTY5xZ3Y+m4Q6gLkH3LpVHz7z9M/P2C2F+fpErgUfCJzDupxBdN49cOSvkBPB7
+jVaMaA==
+-----END CERTIFICATE-----
+`
+
+func (s *certsSuite) TestConfigureCertsHappy(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		changes: map[string]interface{}{
+			"certs.cert1": mockCert,
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Assert(filepath.Join(dirs.SnapdStoreSSLCertsDir, "cert1.pem"), testutil.FileEquals, mockCert)
+}


### PR DESCRIPTION
This option allows adding pem encoded ssl certificates
to the snapd config that will then be used by snapd.

Certs are added via:
```
$ sudo snap set system certs.extra1="$(cat mykey.pem)"
```
and removed via:
```
$ sudo snap unset system 'certs.extra1'
```

The certs are written to /var/lib/snapd/ssl/certs
and picked up by the httputil.NewHTTPClient(). This
means that they will be picked up by snap-repair as
well automatically.

Snapd on classic will also honor the ssl config but
it's less useful here because there are distro mechanisms
already to add certs.

One downside of this PR as is is that the certs end up in the
state. To fix this we will need some more work in the config
system AFAICT.
