### PR TITLE
snap: introduce Container.RandomAccessFile

### DIFF
--- a/snap/container.go
+++ b/snap/container.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,13 @@ import (
 type Container interface {
 	// Size returns the size of the snap in bytes.
 	Size() (int64, error)
+
+	// RandomAccessFile returns an implementation to read at any
+	// given location for a single file inside the snap.
+	RandomAccessFile(relative string) (interface {
+		io.ReaderAt
+		io.Closer
+	}, error)
 
 	// ReadFile returns the content of a single file from the snap.
 	ReadFile(relative string) ([]byte, error)

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -57,6 +57,13 @@ func (s *SnapDir) Install(targetPath, mountDir string) (bool, error) {
 	return false, os.Symlink(s.path, targetPath)
 }
 
+func (s *SnapDir) RandomAccessFile(file string) (interface {
+	io.ReaderAt
+	io.Closer
+}, error) {
+	return os.Open(filepath.Join(s.path, file))
+}
+
 func (s *SnapDir) ReadFile(file string) (content []byte, err error) {
 	return ioutil.ReadFile(filepath.Join(s.path, file))
 }

--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -53,6 +53,24 @@ func (s *SnapdirTestSuite) TestReadFile(c *C) {
 	c.Assert(content, DeepEquals, needle)
 }
 
+func (s *SnapdirTestSuite) TestRandomAccessFile(c *C) {
+	d := c.MkDir()
+	needle := []byte(`stuff`)
+	err := ioutil.WriteFile(filepath.Join(d, "foo"), needle, 0644)
+	c.Assert(err, IsNil)
+
+	snap := snapdir.New(d)
+	r, err := snap.RandomAccessFile("foo")
+	c.Assert(err, IsNil)
+	defer r.Close()
+
+	b := make([]byte, 2)
+	n, err := r.ReadAt(b, 2)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 2)
+	c.Check(string(b), Equals, "uf")
+}
+
 func (s *SnapdirTestSuite) TestListDir(c *C) {
 	d := c.MkDir()
 

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -229,6 +229,20 @@ func (s *SquashfsTestSuite) TestReadFileFail(c *C) {
 	c.Assert(err, ErrorMatches, "cannot run unsquashfs: boom")
 }
 
+func (s *SquashfsTestSuite) TestRandomAccessFile(c *C) {
+	snap := makeSnap(c, "name: foo", "")
+
+	r, err := snap.RandomAccessFile("meta/snap.yaml")
+	c.Assert(err, IsNil)
+	defer r.Close()
+
+	b := make([]byte, 4)
+	n, err := r.ReadAt(b, 4)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 4)
+	c.Check(string(b), Equals, ": fo")
+}
+
 func (s *SquashfsTestSuite) TestListDir(c *C) {
 	snap := makeSnap(c, "name: foo", "")
 


### PR DESCRIPTION
this is meant to return an io.ReaderAt+io.Closer
