### PR TITLE
tests: mock prune ticker in overlord tests to reduce wait times (2.44)

### DIFF
--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -52,6 +52,14 @@ func MockPruneInterval(prunei, prunew, abortw time.Duration) (restore func()) {
 	}
 }
 
+func MockPruneTicker(f func(t *time.Ticker) <-chan time.Time) (restore func()) {
+	old := pruneTickerC
+	pruneTickerC = f
+	return func() {
+		pruneTickerC = old
+	}
+}
+
 // MockEnsureNext sets o.ensureNext for tests.
 func MockEnsureNext(o *Overlord, t time.Time) {
 	o.ensureNext = t

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -68,6 +68,10 @@ var (
 	configstateInit = configstate.Init
 )
 
+var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
+	return t.C
+}
+
 // Overlord is the central manager of a snappy system, keeping
 // track of all available state managers and related helpers.
 type Overlord struct {
@@ -430,11 +434,12 @@ func (o *Overlord) Loop() {
 				preseedExitWithError(err)
 			}
 			o.ensureDidRun()
+			pruneC := pruneTickerC(o.pruneTicker)
 			select {
 			case <-o.loopTomb.Dying():
 				return nil
 			case <-o.ensureTimer.C:
-			case <-o.pruneTicker.C:
+			case <-pruneC:
 				if preseed {
 					// in preseed mode avoid setting StartOfOperationTime (it's
 					// an error), and don't Prune.


### PR DESCRIPTION
Mock prune ticker in overlord tests to reduce wait times.

This is https://github.com/snapcore/snapd/pull/8201  for 2.44