### PR TITLE
tests: update test to make snapd snap fixed twice

### DIFF
--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -63,4 +63,6 @@ execute: |
         echo "restart snapd and ensure we can still talk to it"
         systemctl restart snapd.socket snapd.service
         snap list | MATCH "^snapd .* $current .*"
+
+        rm -rf ./snapd-broken
     done

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -42,23 +42,25 @@ execute: |
     echo "Snap list is working still"
     snap list | MATCH "^snapd .* $current .*"
 
-    echo "Break snapd"
-    unsquashfs -d ./snapd-broken "$SNAPD_SNAP"
-    echo "" > ./snapd-broken/usr/lib/snapd/snapd
-    (cd ./snapd-broken && snap pack .)
-    echo "Now install the broken snapd"
-    if snap install --dangerous ./snapd-broken/snapd_*.snap; then
-        echo "installing a broken snapd should not work, test broken"
-        exit 1
-    fi
+    for _ in $(seq 2); do
+        echo "Break snapd"
+        unsquashfs -d ./snapd-broken "$SNAPD_SNAP"
+        echo "" > ./snapd-broken/usr/lib/snapd/snapd
+        (cd ./snapd-broken && snap pack .)
+        echo "Now install the broken snapd"
+        if snap install --dangerous ./snapd-broken/snapd_*.snap; then
+            echo "installing a broken snapd should not work, test broken"
+            exit 1
+        fi
 
-    echo "And verify that snap commands still work and snapd is reverted"
-    retry-tool -n 30 --wait 5 systemctl is-active snapd.failure.service
-    snap list | MATCH "^snapd .* $current .*"
+        echo "And verify that snap commands still work and snapd is reverted"
+        retry-tool -n 30 --wait 5 systemctl is-active snapd.failure.service
+        snap list | MATCH "^snapd .* $current .*"
 
-    echo "Verify we got the expected error message"
-    snap change --last=install|MATCH "there was a snapd rollback across the restart"
+        echo "Verify we got the expected error message"
+        snap change --last=install|MATCH "there was a snapd rollback across the restart"
 
-    echo "restart snapd and ensure we can still talk to it"
-    systemctl restart snapd.socket snapd.service
-    snap list | MATCH "^snapd .* $current .*"
+        echo "restart snapd and ensure we can still talk to it"
+        systemctl restart snapd.socket snapd.service
+        snap list | MATCH "^snapd .* $current .*"
+    done

--- a/tests/core/snapd-failover16/task.yaml
+++ b/tests/core/snapd-failover16/task.yaml
@@ -11,6 +11,13 @@ prepare: |
     EOF
     systemctl daemon-reload
 
+restore: |
+    # snapd.failure service should not exist in uc16
+    systemctl stop snapd.failure.service
+    systemctl disable snapd.failure.service
+    rm -rf /etc/systemd/system/snapd.failure.service.d
+    systemctl daemon-reload
+
 execute: |
     snap download snapd
 
@@ -21,19 +28,23 @@ execute: |
     cp -a /usr/lib/snapd/snap-failure ./snapd-broken/usr/lib/snapd/snap-failure
     (cd ./snapd-broken && snap pack .)
     echo "Now install the broken snapd"
-    if snap install --dangerous ./snapd-broken/snapd_*.snap; then
-        echo "installing a broken snapd should not work, test broken"
-        exit 1
-    fi
 
-    echo "And verify that snap commands still work and snapd is reverted"
-    retry-tool -n 30 --wait 5 systemctl is-active snapd.failure.service
+    for _ in $(seq 2); do
+        if snap install --dangerous ./snapd-broken/snapd_*.snap; then
+            echo "installing a broken snapd should not work, test broken"
+            exit 1
+        fi
 
-    echo "Verify we got the expected error message"
-    snap change --last=install|MATCH "there was a snapd rollback across the restart"
-    echo "No snapd snap is installed"
-    not snap list snapd
+        echo "And verify that snap commands still work and snapd is reverted"
+        retry-tool -n 30 --wait 5 systemctl is-active snapd.failure.service
 
-    test ! -e /etc/systemd/system/snapd.service
-    test ! -e /etc/systemd/system/usr-lib-snapd.mount
-    test ! -e /snap/snapd/x1
+        echo "Verify we got the expected error message"
+        snap change --last=install|MATCH "there was a snapd rollback across the restart"
+        echo "No snapd snap is installed"
+        not snap list snapd
+
+        test ! -e /etc/systemd/system/snapd.service
+        test ! -e /etc/systemd/system/usr-lib-snapd.mount
+        test ! -e /snap/snapd/x1
+    done
+


### PR DESCRIPTION
I see a bahaviour that snapd.failure fails when it needs to fix snapd
twice.
The first time it fixes correctly the snapd snap but the second one it
fails not giving much information about what failed.

