### PR TITLE
usersession/userd: add "zoommtg" to the white list of URL schemes handled by xdg-open

### DIFF
--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -91,6 +91,7 @@ execute: |
     ensure_xdg_open_output "snap://snapcraft"
     ensure_xdg_open_output "help:snapcraft"
     ensure_xdg_open_output "apt:snapcraft"
+    ensure_xdg_open_output "zoommtg://snapcraft.io"
     # Ensure XDG_DATA_DIRS was prefixed with snap specific location
     test "$(tail -1 /tmp/xdg-open-output)" = "XDG_DATA_DIRS=$SNAP_MOUNT_DIR/test-snapd-desktop/current/usr/share:/usr/share"
 

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -57,7 +57,7 @@ const launcherIntrospectionXML = `
 </interface>`
 
 var (
-	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help", "apt"}
+	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg"}
 )
 
 // Launcher implements the 'io.snapcraft.Launcher' DBus interface.

--- a/usersession/userd/launcher_test.go
+++ b/usersession/userd/launcher_test.go
@@ -75,7 +75,7 @@ func (s *launcherSuite) TestOpenURLWithNotAllowedScheme(c *C) {
 }
 
 func (s *launcherSuite) TestOpenURLWithAllowedSchemeHappy(c *C) {
-	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt"} {
+	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg"} {
 		err := s.launcher.OpenURL(schema+"://snapcraft.io", ":some-dbus-sender")
 		c.Assert(err, IsNil)
 		c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{


### PR DESCRIPTION
This will allow apps (namely Chromium) to launch the Zoom video conferencing app directly (instead of silently failing to launch).