### PR TITLE
cmd/snap: make the portal-info command search for the network-status interface

### DIFF
--- a/cmd/snap/cmd_routine_portal_info.go
+++ b/cmd/snap/cmd_routine_portal_info.go
@@ -102,12 +102,12 @@ func (x *cmdRoutinePortalInfo) Execute(args []string) error {
 		desktopFile = filepath.Base(app.DesktopFile)
 	}
 
-	// Determine whether the snap has access to the network
+	// Determine whether the snap has access to the network status
 	// TODO: use direct API for asking about interface being connected if
 	// that becomes available
 	connections, err := x.client.Connections(&client.ConnectionOptions{
 		Snap:      snap.Name,
-		Interface: "network",
+		Interface: "network-status",
 	})
 	if err != nil {
 		return fmt.Errorf("cannot get connections for snap %q: %v", snap.Name, err)
@@ -117,12 +117,7 @@ func (x *cmdRoutinePortalInfo) Execute(args []string) error {
 	// network despite the 'network' interface being disconnected
 	var hasNetworkStatus bool
 	for _, conn := range connections.Established {
-		// TODO: this should check for network-status plugs
-		// instead, but that interface is not currently in a
-		// usable state (not usable on classic systems, likely
-		// never worked with indicator-network).  This can be
-		// changed when the interface is fixed.
-		if conn.Plug.Snap == snap.Name && conn.Interface == "network" {
+		if conn.Plug.Snap == snap.Name && conn.Interface == "network-status" {
 			hasNetworkStatus = true
 			break
 		}

--- a/cmd/snap/cmd_routine_portal_info_test.go
+++ b/cmd/snap/cmd_routine_portal_info_test.go
@@ -104,20 +104,20 @@ func (s *SnapSuite) TestPortalInfo(c *C) {
 			c.Check(r.URL.Path, Equals, "/v2/connections")
 			c.Check(r.URL.Query(), DeepEquals, url.Values{
 				"snap":      []string{"hello"},
-				"interface": []string{"network"},
+				"interface": []string{"network-status"},
 			})
 			result := client.Connections{
 				Established: []client.Connection{
 					{
 						Slot: client.SlotRef{
 							Snap: "core",
-							Name: "network",
+							Name: "network-status",
 						},
 						Plug: client.PlugRef{
 							Snap: "hello",
-							Name: "network",
+							Name: "network-status",
 						},
-						Interface: "network",
+						Interface: "network-status",
 					},
 				},
 			}
@@ -164,7 +164,7 @@ func (s *SnapSuite) TestPortalInfoNoAppInfo(c *C) {
 			c.Check(r.URL.Path, Equals, "/v2/connections")
 			c.Check(r.URL.Query(), DeepEquals, url.Values{
 				"snap":      []string{"hello"},
-				"interface": []string{"network"},
+				"interface": []string{"network-status"},
 			})
 			result := client.Connections{}
 			EncodeResponseBody(c, w, map[string]interface{}{


### PR DESCRIPTION
This is a followup to #7588, modifying the "portal-info" command to instead check for the `network-status` interface now that it has been updated to be implicit on classic.