### PR TITLE
tests: fix/improve failing spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -108,9 +108,6 @@ backends:
             - centos-7-64:
                 workers: 6
                 image: centos-7-64
-            - centos-8-64:
-                workers: 4
-                image: centos-8-64
 
     # TODO: spread is really unhappy when it sees a backend without any systems,
     # so this block is intentially kept commented out, until we need to add
@@ -126,7 +123,9 @@ backends:
                 workers: 6
             - opensuse-tumbleweed-64:
                 workers: 6
-
+            - centos-8-64:
+                workers: 4
+                image: centos-8-64
 
     google-tpm:
         type: google

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -3,7 +3,8 @@ summary: Ensure that lxd works
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
 # TODO:UC20: enable for UC20
-systems: [ubuntu-16*, ubuntu-18.04*, ubuntu-2*, ubuntu-core-1*]
+# TODO: enable for ubuntu-16-32 again
+systems: [ubuntu-16.04*64, ubuntu-18.04*, ubuntu-2*, ubuntu-core-1*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -58,4 +58,8 @@ execute: |
         systemctl reset-failed snap.test-snapd-service.test-snapd-service-refuses-to-stop.service
     fi
 
-    systemctl --no-legend --full | not MATCH "snap\..*\.(service|timer|socket)"
+    systemctl --no-legend --full > output.txt
+    if grep -E "snap\..*\.(service|timer|socket)" < output.txt; then
+        echo "found unexpected leftovers"
+        exit 1
+    fi

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -58,6 +58,8 @@ execute: |
         systemctl reset-failed snap.test-snapd-service.test-snapd-service-refuses-to-stop.service
     fi
 
+    # XXX: use retry-tool instead
+    sleep 5
     systemctl --no-legend --full > output.txt
     if grep -E "snap\..*\.(service|timer|socket)" < output.txt; then
         echo "found unexpected leftovers"

--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -6,6 +6,8 @@ systems:
     # Systemd on CentOS 7/Amazon Linux 2 does not have the user@uid unit
     - -amazon-linux-2-*
     - -centos-7-*
+    # fails regularly with "curl: Recv failure: connection reset by peer"
+    - -ubuntu-core-16-*
 
 environment:
     TEST_UID: $(id -u test)

--- a/tests/regression/lp-1805838/task.yaml
+++ b/tests/regression/lp-1805838/task.yaml
@@ -41,7 +41,7 @@ restore: |
 execute: |
     systemctl stop snapd.socket snapd.service
     systemctl start snapd.socket snapd.service
-    journalctl -u snapd | MATCH 'cannot regenerate seccomp profiles'
-    journalctl -u snapd | MATCH 'cannot compile /var/lib/snapd/seccomp/bpf/snap.network-consumer.network-consumer.src: exit status 1'
+    retry-tool -n10 sh -c "journalctl -u snapd | MATCH 'cannot regenerate seccomp profiles'"
+    retry-tool -n10 sh -c "journalctl -u snapd | MATCH 'cannot compile /var/lib/snapd/seccomp/bpf/snap.network-consumer.network-consumer.src: exit status 1'"
     snap list | MATCH "(core|snapd)"
     test ! -e /var/lib/snapd/system-key


### PR DESCRIPTION
This test constantly fails right now so disable it. It seems like
the 32 bit image is having network problems right now.
