### PR TITLE
interfaces: work around apparmor_parser slowness affecting uio (2.44)

### DIFF
--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -40,6 +40,12 @@ type Specification struct {
 	// for snap application and hook processes. The security tag encodes the identity
 	// of the application or hook.
 	snippets map[string][]string
+
+	// dedupSnippets are just like snippets but are added only once to the
+	// resulting policy in an effort to avoid certain expensive to de-duplicate
+	// rules by apparmor_parser.
+	dedupSnippets map[string]*strutil.OrderedSet
+
 	// updateNS describe parts of apparmor policy for snap-update-ns executing
 	// on behalf of a given snap.
 	updateNS strutil.OrderedSet
@@ -87,6 +93,32 @@ func (spec *Specification) AddSnippet(snippet string) {
 	for _, tag := range spec.securityTags {
 		spec.snippets[tag] = append(spec.snippets[tag], snippet)
 		sort.Strings(spec.snippets[tag])
+	}
+}
+
+// AddDeduplicatedSnippet adds a new apparmor snippet to all applications and hooks using the interface.
+//
+// Certain combinations of snippets may be computationally expensive for
+// apparmor_parser in its de-duplication step. This function lets snapd
+// perform de-duplication of identical rules at the potential cost of a
+// somewhat more complex auditing process of the text of generated
+// apparmor profile. Identical mount rules should typically use this, but
+// this function can also be used to avoid repeated rules that inhibit
+// auditability.
+func (spec *Specification) AddDeduplicatedSnippet(snippet string) {
+	if len(spec.securityTags) == 0 {
+		return
+	}
+	if spec.dedupSnippets == nil {
+		spec.dedupSnippets = make(map[string]*strutil.OrderedSet)
+	}
+	for _, tag := range spec.securityTags {
+		bag := spec.dedupSnippets[tag]
+		if bag == nil {
+			bag = &strutil.OrderedSet{}
+			spec.dedupSnippets[tag] = bag
+		}
+		bag.Put(snippet)
 	}
 }
 
@@ -334,21 +366,38 @@ func parent(path string) string {
 
 // Snippets returns a deep copy of all the added application snippets.
 func (spec *Specification) Snippets() map[string][]string {
-	return copySnippets(spec.snippets)
+	snippets := copySnippets(spec.snippets)
+	for tag, bag := range spec.dedupSnippets {
+		if bag != nil {
+			snippets[tag] = append(snippets[tag], bag.Items()...)
+		}
+	}
+	return snippets
 }
 
 // SnippetForTag returns a combined snippet for given security tag with
 // individual snippets joined with the newline character. Empty string is
 // returned for non-existing security tag.
 func (spec *Specification) SnippetForTag(tag string) string {
-	return strings.Join(spec.snippets[tag], "\n")
+	snippets := append([]string(nil), spec.snippets[tag]...)
+	if bag := spec.dedupSnippets[tag]; bag != nil {
+		snippets = append(snippets, bag.Items()...)
+	}
+	return strings.Join(snippets, "\n")
 }
 
 // SecurityTags returns a list of security tags which have a snippet.
 func (spec *Specification) SecurityTags() []string {
 	var tags []string
+	seen := make(map[string]bool, len(spec.snippets))
 	for t := range spec.snippets {
 		tags = append(tags, t)
+		seen[t] = true
+	}
+	for t := range spec.dedupSnippets {
+		if !seen[t] {
+			tags = append(tags, t)
+		}
 	}
 	sort.Strings(tags)
 	return tags

--- a/interfaces/builtin/uio.go
+++ b/interfaces/builtin/uio.go
@@ -82,7 +82,24 @@ func (iface *uioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	//  - $sysfs_base/portio/port[0-9]+/{name,start,size,porttype}
 	// The expression below matches them all as they all may be required for
 	// userspace drivers to operate.
-	spec.AddSnippet(fmt.Sprintf("/sys/devices/platform/**/uio/%s/** r,", strings.TrimPrefix(path, "/dev/")))
+	//
+	// While it is more accurate to use:
+	//
+	//   "/sys/devices/platform/**/uio/%s/** r,", strings.TrimPrefix(path, "/dev/")
+	//
+	// multiple interface connections will result in overlapping deep
+	// globs of the form:
+	//
+	//   /sys/devices/platform/**/uio/uio1/** r,
+	//   /sys/devices/platform/**/uio/uio2/** r,
+	//   /sys/devices/platform/**/uio/uioN/** r,
+	//
+	// which are computationally difficult to de-duplicate provided
+	// large enough N. Instead, grant read only access to all uio
+	// sysfs files and control writable access to the specific
+	// device node in /dev. Use AddDeduplicatedSnippet() for clarity
+	// in the resulting rules.
+	spec.AddDeduplicatedSnippet("/sys/devices/platform/**/uio/uio[0-9]** r,  # common rule for all uio connections")
 	return nil
 }
 


### PR DESCRIPTION
This branch contains two new patches: a way to add apparmor snippets that are
de-duplicated by snapd and a modification of uio interface to avoid a
performance regression when using multiple uio interfaces.

Fixes: https://launchpad.net/bugs/1866349