### PR TITLE
interfaces/udisks2: also allow Introspection on /org/freedesktop/UDisks/**

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -179,7 +179,7 @@ dbus (receive, send)
 # do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
-    path=/org/freedesktop/UDisks2
+    path=/org/freedesktop/UDisks2{,/**}
     interface=org.freedesktop.DBus.Introspectable
     member=Introspect,
 `


### PR DESCRIPTION
References:
https://forum.snapcraft.io/t/interfaces-for-raspberry-pi-imager/15822/13
