### PR TITLE
many: introduce snapdenv to present common snapd env options

### DIFF
--- a/asserts/sysdb/generic.go
+++ b/asserts/sysdb/generic.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 const (
@@ -152,7 +152,7 @@ func init() {
 // Generic returns a copy of the current set of predefined assertions for the 'generic' authority as used by Open.
 func Generic() []asserts.Assertion {
 	generic := []asserts.Assertion(nil)
-	if !osutil.GetenvBool("SNAPPY_USE_STAGING_STORE") {
+	if !snapdenv.UseStagingStore() {
 		generic = append(generic, genericAssertions...)
 	} else {
 		generic = append(generic, genericStagingAssertions...)
@@ -179,7 +179,7 @@ func GenericClassicModel() *asserts.Model {
 	if genericClassicModelOverride != nil {
 		return genericClassicModelOverride
 	}
-	if !osutil.GetenvBool("SNAPPY_USE_STAGING_STORE") {
+	if !snapdenv.UseStagingStore() {
 		return genericClassicModel
 	} else {
 		return genericStagingClassicModel

--- a/asserts/sysdb/trusted.go
+++ b/asserts/sysdb/trusted.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 const (
@@ -130,7 +130,7 @@ func init() {
 // Trusted returns a copy of the current set of trusted assertions as used by Open.
 func Trusted() []asserts.Assertion {
 	trusted := []asserts.Assertion(nil)
-	if !osutil.GetenvBool("SNAPPY_USE_STAGING_STORE") {
+	if !snapdenv.UseStagingStore() {
 		trusted = append(trusted, trustedAssertions...)
 	} else {
 		if len(trustedStagingAssertions) == 0 {

--- a/cmd/snap-repair/cmd_run.go
+++ b/cmd/snap-repair/cmd_run.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 func init() {
@@ -47,7 +48,7 @@ var baseURL *url.URL
 
 func init() {
 	var baseurl string
-	if osutil.GetenvBool("SNAPPY_USE_STAGING_STORE") {
+	if snapdenv.UseStagingStore() {
 		baseurl = "https://api.staging.snapcraft.io/v2/"
 	} else {
 		baseurl = "https://api.snapcraft.io/v2/"

--- a/cmd/snap-repair/main.go
+++ b/cmd/snap-repair/main.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -28,9 +28,9 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/cmd"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 var (
@@ -76,7 +76,7 @@ func run() error {
 	if osGetuid() != 0 {
 		return fmt.Errorf("must be run as root")
 	}
-	httputil.SetUserAgentFromVersion(cmd.Version, "snap-repair")
+	snapdenv.SetUserAgentFromVersion(cmd.Version, "snap-repair")
 
 	if err := parseArgs(os.Args[1:]); err != nil {
 		return err

--- a/cmd/snap-repair/main_test.go
+++ b/cmd/snap-repair/main_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -27,8 +27,8 @@ import (
 
 	repair "github.com/snapcore/snapd/cmd/snap-repair"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -49,7 +49,7 @@ type repairSuite struct {
 
 func (r *repairSuite) SetUpSuite(c *C) {
 	r.baseRunnerSuite.SetUpSuite(c)
-	r.restore = httputil.SetUserAgentFromVersion("", "")
+	r.restore = snapdenv.SetUserAgentFromVersion("", "")
 }
 
 func (r *repairSuite) TearDownSuite(c *C) {

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -282,7 +283,8 @@ func NewRunner() *Runner {
 		sequenceNext: make(map[string]int),
 	}
 	opts := httputil.ClientOptions{
-		MayLogBody: false,
+		MayLogBody:         false,
+		ProxyConnectHeader: http.Header{"User-Agent": []string{snapdenv.UserAgent()}},
 		TLSConfig: &tls.Config{
 			Time: run.now,
 		},
@@ -335,7 +337,7 @@ func (run *Runner) Fetch(brandID string, repairID int, revision int) (*asserts.R
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("User-Agent", httputil.UserAgent())
+		req.Header.Set("User-Agent", snapdenv.UserAgent())
 		req.Header.Set("Accept", "application/x.ubuntu.assertion")
 		if revision >= 0 {
 			req.Header.Set("If-None-Match", fmt.Sprintf(`"%d"`, revision))
@@ -440,7 +442,7 @@ func (run *Runner) Peek(brandID string, repairID int) (headers map[string]interf
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("User-Agent", httputil.UserAgent())
+		req.Header.Set("User-Agent", snapdenv.UserAgent())
 		req.Header.Set("Accept", "application/json")
 		return run.cli.Do(req)
 	}, func(resp *http.Response) error {

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -43,9 +43,9 @@ import (
 	"github.com/snapcore/snapd/asserts/sysdb"
 	repair "github.com/snapcore/snapd/cmd/snap-repair"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -170,7 +170,7 @@ type runnerSuite struct {
 
 func (s *runnerSuite) SetUpSuite(c *C) {
 	s.baseRunnerSuite.SetUpSuite(c)
-	s.restore = httputil.SetUserAgentFromVersion("1", "snap-repair")
+	s.restore = snapdenv.SetUserAgentFromVersion("1", "snap-repair")
 }
 
 func (s *runnerSuite) TearDownSuite(c *C) {

--- a/cmd/snap-repair/staging.go
+++ b/cmd/snap-repair/staging.go
@@ -2,7 +2,7 @@
 // +build withtestkeys withstagingkeys
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -24,7 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 const (
@@ -75,7 +75,7 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("cannot decode trusted account-key: %v", err))
 	}
-	if osutil.GetenvBool("SNAPPY_USE_STAGING_STORE") {
+	if snapdenv.UseStagingStore() {
 		trustedRepairRootKeys = append(trustedRepairRootKeys, repairRootAccountKey.(*asserts.AccountKey))
 	}
 }

--- a/cmd/snap-repair/trusted.go
+++ b/cmd/snap-repair/trusted.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 const (
@@ -83,7 +83,7 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("cannot decode trusted account-key: %v", err))
 	}
-	if !osutil.GetenvBool("SNAPPY_USE_STAGING_STORE") {
+	if !snapdenv.UseStagingStore() {
 		trustedRepairRootKeys = append(trustedRepairRootKeys, repairRootAccountKey.(*asserts.AccountKey))
 	}
 }

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2016 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 const autoImportsName = "auto-import.assert"
@@ -56,6 +57,8 @@ func autoImportCandidates() ([]string, error) {
 		return nil, err
 	}
 	defer f.Close()
+
+	isTesting := snapdenv.Testing()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -86,7 +89,7 @@ func autoImportCandidates() ([]string, error) {
 			continue
 		}
 		// skip all ram disks (unless in tests)
-		if !osutil.GetenvBool("SNAPPY_TESTING") && strings.HasPrefix(mountSrc, "/dev/ram") {
+		if !isTesting && strings.HasPrefix(mountSrc, "/dev/ram") {
 			continue
 		}
 

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -37,19 +37,19 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 func init() {
 	// set User-Agent for when 'snap' talks to the store directly (snap download etc...)
-	httputil.SetUserAgentFromVersion(cmd.Version, "snap")
+	snapdenv.SetUserAgentFromVersion(cmd.Version, "snap")
 
-	if osutil.GetenvBool("SNAPD_DEBUG") || osutil.GetenvBool("SNAPPY_TESTING") {
+	if osutil.GetenvBool("SNAPD_DEBUG") || snapdenv.Testing() {
 		// in tests or when debugging, enforce the "tidy" lint checks
 		noticef = logger.Panicf
 	}
@@ -387,7 +387,7 @@ func mkClient() *client.Client {
 	cfg := &ClientConfig
 	// Set client user-agent when talking to the snapd daemon to the
 	// same value as when talking to the store.
-	cfg.UserAgent = httputil.UserAgent()
+	cfg.UserAgent = snapdenv.UserAgent()
 
 	cli := client.New(cfg)
 	goos := runtime.GOOS

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -29,11 +29,11 @@ import (
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/errtracker"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sanity"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -109,7 +109,7 @@ var checkRunningConditionsRetryDelay = 300 * time.Second
 
 func run(ch chan os.Signal) error {
 	t0 := time.Now().Truncate(time.Millisecond)
-	httputil.SetUserAgentFromVersion(cmd.Version)
+	snapdenv.SetUserAgentFromVersion(cmd.Version)
 
 	d, err := daemon.New()
 	if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2016 Canonical Ltd
+ * Copyright (C) 2015-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -37,7 +37,6 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/netutil"
@@ -47,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/standby"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/polkit"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/systemd"
 )
@@ -340,7 +340,7 @@ func (d *Daemon) Init() error {
 
 	d.addRoutes()
 
-	logger.Noticef("started %v.", httputil.UserAgent())
+	logger.Noticef("started %v.", snapdenv.UserAgent())
 
 	return nil
 }

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -38,10 +38,10 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 var (
@@ -481,7 +481,7 @@ func report(errMsg, dupSig string, extra map[string]string) (string, error) {
 	}
 
 	// see if we run in testing mode
-	if osutil.GetenvBool("SNAPPY_TESTING") {
+	if snapdenv.Testing() {
 		logger.Noticef("errtracker.Report is *not* sent because SNAPPY_TESTING is set")
 		logger.Noticef("report: %v", report)
 		return "oops-not-sent", nil
@@ -498,7 +498,7 @@ func report(errMsg, dupSig string, extra map[string]string) (string, error) {
 		return "", err
 	}
 	req.Header.Add("Content-Type", "application/octet-stream")
-	req.Header.Add("X-Whoopsie-Version", httputil.UserAgent())
+	req.Header.Add("X-Whoopsie-Version", snapdenv.UserAgent())
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/errtracker"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -232,8 +233,7 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 }
 
 func (s *ErrtrackerTestSuite) TestReportUnderTesting(c *C) {
-	os.Setenv("SNAPPY_TESTING", "1")
-	defer os.Unsetenv("SNAPPY_TESTING")
+	defer snapdenv.MockTesting(true)()
 
 	n := 0
 	prev := errtracker.SnapdVersion

--- a/httputil/client.go
+++ b/httputil/client.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -141,10 +141,13 @@ func (d *dialTLS) addLocalSSLCertificates() (err error) {
 }
 
 type ClientOptions struct {
-	Timeout       time.Duration
-	TLSConfig     *tls.Config
-	MayLogBody    bool
-	Proxy         func(*http.Request) (*url.URL, error)
+	Timeout    time.Duration
+	TLSConfig  *tls.Config
+	MayLogBody bool
+
+	Proxy              func(*http.Request) (*url.URL, error)
+	ProxyConnectHeader http.Header
+
 	ExtraSSLCerts ExtraSSLCerts
 }
 
@@ -159,7 +162,7 @@ func NewHTTPClient(opts *ClientOptions) *http.Client {
 	if opts.Proxy != nil {
 		transport.Proxy = opts.Proxy
 	}
-	transport.ProxyConnectHeader = http.Header{"User-Agent": []string{UserAgent()}}
+	transport.ProxyConnectHeader = opts.ProxyConnectHeader
 	// Remember the original ClientOptions.TLSConfig when making
 	// tls connection.
 	// Note that we only set TLSClientConfig here because it's extracted

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -79,10 +79,8 @@ func (s *clientSuite) TestClientOptionsWithProxy(c *check.C) {
 	c.Check(url.String(), check.Equals, "http://some-proxy:3128")
 }
 
-func (s *clientSuite) TestClientProxySetsUserAgent(c *check.C) {
+func (s *clientSuite) TestClientProxyTakesUserAgent(c *check.C) {
 	myUserAgent := "snapd yadda yadda"
-
-	defer httputil.MockUserAgent(myUserAgent)()
 
 	called := false
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -94,6 +92,7 @@ func (s *clientSuite) TestClientProxySetsUserAgent(c *check.C) {
 		Proxy: func(*http.Request) (*url.URL, error) {
 			return mustParse(c, proxyServer.URL), nil
 		},
+		ProxyConnectHeader: http.Header{"User-Agent": []string{myUserAgent}},
 	})
 	_, err := cli.Get("https://localhost:9999")
 	c.Check(err, check.NotNil) // because we didn't do anything in the handler

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -127,7 +128,7 @@ func parseAuthFile(authFn string, data []byte) (*authData, error) {
 }
 
 func snapcraftLoginSection() string {
-	if osutil.GetenvBool("SNAPPY_USE_STAGING_STORE") {
+	if snapdenv.UseStagingStore() {
 		return "login.staging.ubuntu.com"
 	}
 	return "login.ubuntu.com"

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -754,6 +755,7 @@ func (s *deviceMgrSerialSuite) testDoRequestSerialKeepsRetrying(c *C, rt http.Ro
 	defer restore()
 
 	restore = devicestate.MockHttputilNewHTTPClient(func(opts *httputil.ClientOptions) *http.Client {
+		c.Check(opts.ProxyConnectHeader, NotNil)
 		return &http.Client{Transport: rt}
 	})
 	defer restore()
@@ -1526,7 +1528,7 @@ func (s *deviceMgrSerialSuite) TestNewEnoughProxy(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	expectedUserAgent := httputil.UserAgent()
+	expectedUserAgent := snapdenv.UserAgent()
 	log, restore := logger.MockLogger()
 	defer restore()
 	os.Setenv("SNAPD_DEBUG", "1")

--- a/overlord/devicestate/devicestatetest/devicesvc.go
+++ b/overlord/devicestate/devicestatetest/devicesvc.go
@@ -31,7 +31,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/httputil"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 type DeviceServiceBehavior struct {
@@ -61,7 +61,7 @@ const (
 )
 
 func MockDeviceService(c *C, bhv *DeviceServiceBehavior) *httptest.Server {
-	expectedUserAgent := httputil.UserAgent()
+	expectedUserAgent := snapdenv.UserAgent()
 
 	// default URL paths
 	if bhv.RequestIDURLPath == "" {

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/proxyconf"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -135,7 +136,7 @@ func newEnoughProxy(st *state.State, proxyURL *url.URL, client *http.Client) boo
 		logger.Debugf(prefix+": %v", err)
 		return false
 	}
-	req.Header.Set("User-Agent", httputil.UserAgent())
+	req.Header.Set("User-Agent", snapdenv.UserAgent())
 	resp, err := client.Do(req)
 	if err != nil {
 		// some sort of network or protocol error
@@ -325,7 +326,7 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 	if err != nil {
 		return "", fmt.Errorf("internal error: cannot create request-id request %q", cfg.requestIDURL)
 	}
-	req.Header.Set("User-Agent", httputil.UserAgent())
+	req.Header.Set("User-Agent", snapdenv.UserAgent())
 	cfg.applyHeaders(req)
 
 	resp, err := client.Do(req)
@@ -420,7 +421,7 @@ func submitSerialRequest(t *state.Task, serialRequest string, client *http.Clien
 	if err != nil {
 		return nil, nil, fmt.Errorf("internal error: cannot create serial-request request %q", cfg.serialRequestURL)
 	}
-	req.Header.Set("User-Agent", httputil.UserAgent())
+	req.Header.Set("User-Agent", snapdenv.UserAgent())
 	req.Header.Set("Snap-Device-Capabilities", strings.Join(registrationCapabilities, " "))
 	cfg.applyHeaders(req)
 	req.Header.Set("Content-Type", asserts.MediaType)
@@ -495,9 +496,10 @@ func getSerial(t *state.Task, regCtx registrationContext, privKey asserts.Privat
 	st := t.State()
 	proxyConf := proxyconf.New(st)
 	client := httputilNewHTTPClient(&httputil.ClientOptions{
-		Timeout:    30 * time.Second,
-		MayLogBody: true,
-		Proxy:      proxyConf.Conf,
+		Timeout:            30 * time.Second,
+		MayLogBody:         true,
+		Proxy:              proxyConf.Conf,
+		ProxyConnectHeader: http.Header{"User-Agent": []string{snapdenv.UserAgent()}},
 	})
 
 	cfg, err := getSerialRequestConfig(t, regCtx, client)

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -36,7 +36,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -47,12 +46,8 @@ import (
 	"github.com/snapcore/snapd/timings"
 )
 
-func useStaging() bool {
-	return osutil.GetenvBool("SNAPPY_USE_STAGING_STORE")
-}
-
 func baseURL() *url.URL {
-	if useStaging() {
+	if snapdenv.UseStagingStore() {
 		return mustParse("https://api.staging.snapcraft.io/")
 	}
 	return mustParse("https://api.snapcraft.io/")

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -236,7 +237,7 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 	return snapshot, nil
 }
 
-var isTesting = osutil.GetenvBool("SNAPPY_TESTING")
+var isTesting = snapdenv.Testing()
 
 func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, username string, entry, dir string) error {
 	parent, revdir := filepath.Split(dir)

--- a/snapdenv/export_test.go
+++ b/snapdenv/export_test.go
@@ -17,8 +17,17 @@
  *
  */
 
-package httputil
+package snapdenv
 
 var (
-	GetFlags = (*LoggedTransport).getFlags
+	StripUnsafeRunes      = stripUnsafeRunes
+	SanitizeKernelVersion = sanitizeKernelVersion
 )
+
+func MockUserAgent(mock string) (restore func()) {
+	old := userAgent
+	userAgent = mock
+	return func() {
+		userAgent = old
+	}
+}

--- a/snapdenv/snapdenv.go
+++ b/snapdenv/snapdenv.go
@@ -55,3 +55,21 @@ func MockTesting(testing bool) (restore func()) {
 		mockTesting = old
 	}
 }
+
+var mockUseStagingStore *bool
+
+// UseStagingStore returns whether snapd compontents should use the staging store.
+func UseStagingStore() bool {
+	if mockUseStagingStore != nil {
+		return *mockUseStagingStore
+	}
+	return osutil.GetenvBool("SNAPPY_USE_STAGING_STORE")
+}
+
+func MockUseStagingStore(testing bool) (restore func()) {
+	old := mockUseStagingStore
+	mockUseStagingStore = &testing
+	return func() {
+		mockUseStagingStore = old
+	}
+}

--- a/snapdenv/snapdenv.go
+++ b/snapdenv/snapdenv.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package snapdenv presents common environment (and related) options
+// for snapd components.
+package snapdenv
+
+import (
+	"os"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+var mockTesting *bool
+
+// is this a testing binary? (see withtestkeys.go)
+var testingBinary = false
+
+// Testing returns whether snapd compontents are under testing.
+func Testing() bool {
+	if mockTesting != nil {
+		return *mockTesting
+	}
+	ok := osutil.GetenvBool("SNAPPY_TESTING")
+	if !ok {
+		// assume testing if we are a testing binary and the
+		// env is not set explicitly to the contrary
+		if testingBinary && os.Getenv("SNAPPY_TESTING") == "" {
+			return true
+		}
+	}
+	return ok
+}
+
+func MockTesting(testing bool) (restore func()) {
+	old := mockTesting
+	mockTesting = &testing
+	return func() {
+		mockTesting = old
+	}
+}

--- a/snapdenv/snapdenv_test.go
+++ b/snapdenv/snapdenv_test.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapdenv_test
+
+import (
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/snapdenv"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type snapdenvSuite struct{}
+
+var _ = Suite(&snapdenvSuite{})
+
+func (s *snapdenvSuite) TestTesting(c *C) {
+	oldTesting := os.Getenv("SNAPPY_TESTING")
+	defer func() {
+		if oldTesting == "" {
+			os.Unsetenv("SNAPPY_TESTING")
+		} else {
+			os.Setenv("SNAPPY_TESTING", oldTesting)
+		}
+	}()
+
+	os.Setenv("SNAPPY_TESTING", "1")
+	c.Check(snapdenv.Testing(), Equals, true)
+
+	os.Unsetenv("SNAPPY_TESTING")
+	c.Check(snapdenv.Testing(), Equals, false)
+}
+
+func (s *snapdenvSuite) TestMockTesting(c *C) {
+	oldTesting := os.Getenv("SNAPPY_TESTING")
+	defer func() {
+		if oldTesting == "" {
+			os.Unsetenv("SNAPPY_TESTING")
+		} else {
+			os.Setenv("SNAPPY_TESTING", oldTesting)
+		}
+	}()
+	os.Unsetenv("SNAPPY_TESTING")
+
+	r := snapdenv.MockTesting(true)
+	defer r()
+
+	c.Check(snapdenv.Testing(), Equals, true)
+
+	snapdenv.MockTesting(false)
+	c.Check(snapdenv.Testing(), Equals, false)
+}

--- a/snapdenv/snapdenv_test.go
+++ b/snapdenv/snapdenv_test.go
@@ -70,3 +70,40 @@ func (s *snapdenvSuite) TestMockTesting(c *C) {
 	snapdenv.MockTesting(false)
 	c.Check(snapdenv.Testing(), Equals, false)
 }
+
+func (s *snapdenvSuite) TestUseStagingStore(c *C) {
+	oldUseStagingStore := os.Getenv("SNAPPY_USE_STAGING_STORE")
+	defer func() {
+		if oldUseStagingStore == "" {
+			os.Unsetenv("SNAPPY_USE_STAGING_STORE")
+		} else {
+			os.Setenv("SNAPPY_USE_STAGING_STORE", oldUseStagingStore)
+		}
+	}()
+
+	os.Setenv("SNAPPY_USE_STAGING_STORE", "1")
+	c.Check(snapdenv.UseStagingStore(), Equals, true)
+
+	os.Unsetenv("SNAPPY_USE_STAGING_STORE")
+	c.Check(snapdenv.UseStagingStore(), Equals, false)
+}
+
+func (s *snapdenvSuite) TestMockUseStagingStore(c *C) {
+	oldUseStagingStore := os.Getenv("SNAPPY_USE_STAGING_STORE")
+	defer func() {
+		if oldUseStagingStore == "" {
+			os.Unsetenv("SNAPPY_USE_STAGING_STORE")
+		} else {
+			os.Setenv("SNAPPY_USE_STAGING_STORE", oldUseStagingStore)
+		}
+	}()
+	os.Unsetenv("SNAPPY_USE_STAGING_STORE")
+
+	r := snapdenv.MockUseStagingStore(true)
+	defer r()
+
+	c.Check(snapdenv.UseStagingStore(), Equals, true)
+
+	snapdenv.MockUseStagingStore(false)
+	c.Check(snapdenv.UseStagingStore(), Equals, false)
+}

--- a/snapdenv/useragent.go
+++ b/snapdenv/useragent.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
  *
  */
 
-package httputil
+package snapdenv
 
 import (
 	"fmt"
@@ -29,16 +29,7 @@ import (
 )
 
 // UserAgent to send
-// TODO: this should actually be set per client request, and include the client user agent
 var userAgent = "unset"
-
-var isTesting bool
-
-func init() {
-	if osutil.GetenvBool("SNAPPY_TESTING") {
-		isTesting = true
-	}
-}
 
 // SetUserAgentFromVersion sets up a user-agent string.
 func SetUserAgentFromVersion(version string, extraProds ...string) (restore func()) {
@@ -50,7 +41,7 @@ func SetUserAgentFromVersion(version string, extraProds ...string) (restore func
 	if release.ReleaseInfo.ForceDevMode() {
 		extras = append(extras, "devmode")
 	}
-	if isTesting {
+	if Testing() {
 		extras = append(extras, "testing")
 	}
 	extraProdStr := ""

--- a/snapdenv/useragent_test.go
+++ b/snapdenv/useragent_test.go
@@ -17,14 +17,14 @@
  *
  */
 
-package httputil_test
+package snapdenv_test
 
 import (
 	"strings"
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/httputil"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 type UASuite struct {
@@ -34,7 +34,7 @@ type UASuite struct {
 var _ = Suite(&UASuite{})
 
 func (s *UASuite) SetUpTest(c *C) {
-	s.restore = httputil.MockUserAgent("-")
+	s.restore = snapdenv.MockUserAgent("-")
 }
 
 func (s *UASuite) TearDownTest(c *C) {
@@ -42,12 +42,12 @@ func (s *UASuite) TearDownTest(c *C) {
 }
 
 func (s *UASuite) TestUserAgent(c *C) {
-	httputil.SetUserAgentFromVersion("10")
-	ua := httputil.UserAgent()
+	snapdenv.SetUserAgentFromVersion("10")
+	ua := snapdenv.UserAgent()
 	c.Check(strings.HasPrefix(ua, "snapd/10 "), Equals, true)
 
-	httputil.SetUserAgentFromVersion("10", "extraProd")
-	ua = httputil.UserAgent()
+	snapdenv.SetUserAgentFromVersion("10", "extraProd")
+	ua = snapdenv.UserAgent()
 	c.Check(strings.Contains(ua, "extraProd"), Equals, true)
 }
 
@@ -59,13 +59,13 @@ func (s *UASuite) TestStripUnsafeRunes(c *C) {
 		"4.4.0-62-generic",
 		"4.8.6-x86_64-linode78",
 	} {
-		c.Check(httputil.StripUnsafeRunes(unchanged), Equals, unchanged, Commentf("%q", unchanged))
+		c.Check(snapdenv.StripUnsafeRunes(unchanged), Equals, unchanged, Commentf("%q", unchanged))
 	}
 	for _, t := range []struct{ orig, changed string }{
 		{"space bar", "spacebar"},
 		{"~;+()[]", ""}, // most punctuation goes away
 	} {
-		c.Check(httputil.StripUnsafeRunes(t.orig), Equals, t.changed)
+		c.Check(snapdenv.StripUnsafeRunes(t.orig), Equals, t.changed)
 	}
 
 }
@@ -74,6 +74,6 @@ func (s *UASuite) TestSanitizeKernelVersion(c *C) {
 	// Ensure that it is not too long (at most 25 runes)
 	const in = "this-is-a-very-long-thing-that-pretends-to-be-a-kernel-version-string"
 	const out = "this-is-a-very-long-thing"
-	c.Check(httputil.SanitizeKernelVersion(in), Equals, out)
+	c.Check(snapdenv.SanitizeKernelVersion(in), Equals, out)
 
 }

--- a/snapdenv/withtestkeys.go
+++ b/snapdenv/withtestkeys.go
@@ -2,7 +2,7 @@
 // +build withtestkeys
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -18,9 +18,9 @@
  *
  */
 
-package httputil
+package snapdenv
 
 func init() {
 	// mark as testing if we carry testing keys
-	isTesting = true
+	testingBinary = true
 }

--- a/store/auth.go
+++ b/store/auth.go
@@ -30,6 +30,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/snapcore/snapd/httputil"
+	"github.com/snapcore/snapd/snapdenv"
 )
 
 var (
@@ -140,7 +141,7 @@ func requestStoreMacaroon(httpClient *http.Client) (string, error) {
 	}
 
 	headers := map[string]string{
-		"User-Agent":   httputil.UserAgent(),
+		"User-Agent":   snapdenv.UserAgent(),
 		"Accept":       "application/json",
 		"Content-Type": "application/json",
 	}
@@ -175,7 +176,7 @@ func requestDischargeMacaroon(httpClient *http.Client, endpoint string, data map
 	var msg ssoMsg
 
 	headers := map[string]string{
-		"User-Agent":   httputil.UserAgent(),
+		"User-Agent":   snapdenv.UserAgent(),
 		"Accept":       "application/json",
 		"Content-Type": "application/json",
 	}
@@ -247,7 +248,7 @@ func requestStoreDeviceNonce(httpClient *http.Client, deviceNonceEndpoint string
 	}
 
 	headers := map[string]string{
-		"User-Agent": httputil.UserAgent(),
+		"User-Agent": snapdenv.UserAgent(),
 		"Accept":     "application/json",
 	}
 	resp, err := retryPostRequestDecodeJSON(httpClient, deviceNonceEndpoint, headers, nil, &responseData, nil)
@@ -292,7 +293,7 @@ func requestDeviceSession(httpClient *http.Client, deviceSessionEndpoint string,
 	}
 
 	headers := map[string]string{
-		"User-Agent":   httputil.UserAgent(),
+		"User-Agent":   snapdenv.UserAgent(),
 		"Accept":       "application/json",
 		"Content-Type": "application/json",
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -207,10 +207,6 @@ func useDeltas() bool {
 	return osutil.GetenvBool("SNAPD_USE_DELTAS_EXPERIMENTAL", true)
 }
 
-func useStaging() bool {
-	return osutil.GetenvBool("SNAPPY_USE_STAGING_STORE")
-}
-
 // endpointURL clones a base URL and updates it with optional path and query.
 func endpointURL(base *url.URL, path string, query url.Values) *url.URL {
 	u := *base
@@ -227,7 +223,7 @@ func endpointURL(base *url.URL, path string, query url.Values) *url.URL {
 // apiURL returns the system default base API URL.
 func apiURL() *url.URL {
 	s := "https://api.snapcraft.io/"
-	if useStaging() {
+	if snapdenv.UseStagingStore() {
 		s = "https://api.staging.snapcraft.io/"
 	}
 	u, _ := url.Parse(s)
@@ -274,7 +270,7 @@ func assertsURL() (*url.URL, error) {
 }
 
 func authLocation() string {
-	if useStaging() {
+	if snapdenv.UseStagingStore() {
 		return "login.staging.ubuntu.com"
 	}
 	return "login.ubuntu.com"
@@ -290,7 +286,7 @@ func authURL() string {
 var defaultStoreDeveloperURL = "https://dashboard.snapcraft.io/"
 
 func storeDeveloperURL() string {
-	if useStaging() {
+	if snapdenv.UseStagingStore() {
 		return "https://dashboard.staging.snapcraft.io/"
 	}
 	return defaultStoreDeveloperURL

--- a/store/store.go
+++ b/store/store.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2018 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -57,6 +57,7 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -172,7 +173,11 @@ type Store struct {
 	suggestedCurrency string
 
 	cacher downloadCache
-	proxy  func(*http.Request) (*url.URL, error)
+
+	proxy              func(*http.Request) (*url.URL, error)
+	proxyConnectHeader http.Header
+
+	userAgent string
 }
 
 var ErrTooManyRequests = errors.New("too many requests")
@@ -361,27 +366,27 @@ func New(cfg *Config, dauthCtx DeviceAndAuthContext) *Store {
 		deltaFormat = defaultSupportedDeltaFormat
 	}
 
-	store := &Store{
-		cfg:             cfg,
-		series:          series,
-		architecture:    architecture,
-		noCDN:           osutil.GetenvBool("SNAPPY_STORE_NO_CDN"),
-		fallbackStoreID: cfg.StoreID,
-		detailFields:    detailFields,
-		infoFields:      infoFields,
-		dauthCtx:        dauthCtx,
-		deltaFormat:     deltaFormat,
-		proxy:           cfg.Proxy,
+	userAgent := snapdenv.UserAgent()
+	proxyConnectHeader := http.Header{"User-Agent": []string{userAgent}}
 
-		client: httputil.NewHTTPClient(&httputil.ClientOptions{
-			Timeout:    10 * time.Second,
-			MayLogBody: true,
-			Proxy:      cfg.Proxy,
-			ExtraSSLCerts: &httputil.ExtraSSLCertsFromDir{
-				Dir: dirs.SnapdStoreSSLCertsDir,
-			},
-		}),
+	store := &Store{
+		cfg:                cfg,
+		series:             series,
+		architecture:       architecture,
+		noCDN:              osutil.GetenvBool("SNAPPY_STORE_NO_CDN"),
+		fallbackStoreID:    cfg.StoreID,
+		detailFields:       detailFields,
+		infoFields:         infoFields,
+		dauthCtx:           dauthCtx,
+		deltaFormat:        deltaFormat,
+		proxy:              cfg.Proxy,
+		proxyConnectHeader: proxyConnectHeader,
+		userAgent:          userAgent,
 	}
+	store.client = store.newHTTPClient(&httputil.ClientOptions{
+		Timeout:    10 * time.Second,
+		MayLogBody: true,
+	})
 	store.SetCacheDownloads(cfg.CacheDownloads)
 
 	return store
@@ -411,6 +416,18 @@ const (
 
 	assertionsPath = "api/v1/snaps/assertions"
 )
+
+func (s *Store) newHTTPClient(opts *httputil.ClientOptions) *http.Client {
+	if opts == nil {
+		opts = &httputil.ClientOptions{}
+	}
+	opts.Proxy = s.cfg.Proxy
+	opts.ProxyConnectHeader = s.proxyConnectHeader
+	opts.ExtraSSLCerts = &httputil.ExtraSSLCertsFromDir{
+		Dir: dirs.SnapdStoreSSLCertsDir,
+	}
+	return httputil.NewHTTPClient(opts)
+}
 
 func (s *Store) defaultSnapQuery() url.Values {
 	q := url.Values{}
@@ -927,7 +944,7 @@ func (s *Store) newRequest(ctx context.Context, reqOptions *requestOptions, user
 		authenticateUser(req, user)
 	}
 
-	req.Header.Set("User-Agent", httputil.UserAgent())
+	req.Header.Set("User-Agent", s.userAgent)
 	req.Header.Set("Accept", reqOptions.Accept)
 	req.Header.Set(hdrSnapDeviceArchitecture[reqOptions.APILevel], s.architecture)
 	req.Header.Set(hdrSnapDeviceSeries[reqOptions.APILevel], s.series)
@@ -1295,13 +1312,9 @@ func (s *Store) WriteCatalogs(ctx context.Context, names io.Writer, adder SnapAd
 	}
 
 	// do not log body for catalog updates (its huge)
-	client := httputil.NewHTTPClient(&httputil.ClientOptions{
+	client := s.newHTTPClient(&httputil.ClientOptions{
 		MayLogBody: false,
 		Timeout:    10 * time.Second,
-		Proxy:      s.proxy,
-		ExtraSSLCerts: &httputil.ExtraSSLCertsFromDir{
-			Dir: dirs.SnapdStoreSSLCertsDir,
-		},
 	})
 	doRequest := func() (*http.Response, error) {
 		return s.doRequest(ctx, client, reqOptions, nil)
@@ -1529,12 +1542,7 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 			return fmt.Errorf("The download has been cancelled: %s", ctx.Err())
 		}
 		var resp *http.Response
-		cli := httputil.NewHTTPClient(&httputil.ClientOptions{
-			Proxy: s.proxy,
-			ExtraSSLCerts: &httputil.ExtraSSLCertsFromDir{
-				Dir: dirs.SnapdStoreSSLCertsDir,
-			},
-		})
+		cli := s.newHTTPClient(nil)
 		resp, finalErr = s.doRequest(ctx, cli, reqOptions, user)
 
 		if cancelled(ctx) {
@@ -1677,12 +1685,7 @@ func doDownloadReqImpl(ctx context.Context, storeURL *url.URL, cdnHeader string,
 	if resume > 0 {
 		reqOptions.ExtraHeaders["Range"] = fmt.Sprintf("bytes=%d-", resume)
 	}
-	cli := httputil.NewHTTPClient(&httputil.ClientOptions{
-		Proxy: s.proxy,
-		ExtraSSLCerts: &httputil.ExtraSSLCertsFromDir{
-			Dir: dirs.SnapdStoreSSLCertsDir,
-		},
-	})
+	cli := s.newHTTPClient(nil)
 	return s.doRequest(ctx, cli, reqOptions, user)
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -58,6 +57,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -1247,7 +1247,7 @@ func (s *storeTestSuite) TestApplyDelta(c *C) {
 }
 
 var (
-	userAgent = httputil.UserAgent()
+	userAgent = snapdenv.UserAgent()
 )
 
 func (s *storeTestSuite) TestDoRequestSetsAuth(c *C) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3458,33 +3458,30 @@ func (s *storeTestSuite) TestFindClientUserAgent(c *C) {
 }
 
 func (s *storeTestSuite) TestAuthLocationDependsOnEnviron(c *C) {
-	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
+	defer snapdenv.MockUseStagingStore(false)()
 	before := store.AuthLocation()
 
-	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", "1"), IsNil)
-	defer os.Setenv("SNAPPY_USE_STAGING_STORE", "")
+	snapdenv.MockUseStagingStore(true)
 	after := store.AuthLocation()
 
 	c.Check(before, Not(Equals), after)
 }
 
 func (s *storeTestSuite) TestAuthURLDependsOnEnviron(c *C) {
-	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
+	defer snapdenv.MockUseStagingStore(false)()
 	before := store.AuthURL()
 
-	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", "1"), IsNil)
-	defer os.Setenv("SNAPPY_USE_STAGING_STORE", "")
+	snapdenv.MockUseStagingStore(true)
 	after := store.AuthURL()
 
 	c.Check(before, Not(Equals), after)
 }
 
 func (s *storeTestSuite) TestApiURLDependsOnEnviron(c *C) {
-	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
+	defer snapdenv.MockUseStagingStore(false)()
 	before := store.ApiURL()
 
-	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", "1"), IsNil)
-	defer os.Setenv("SNAPPY_USE_STAGING_STORE", "")
+	snapdenv.MockUseStagingStore(true)
 	after := store.ApiURL()
 
 	c.Check(before, Not(Equals), after)
@@ -3532,11 +3529,10 @@ func (s *storeTestSuite) TestStoreURLBadEnvironCPI(c *C) {
 }
 
 func (s *storeTestSuite) TestStoreDeveloperURLDependsOnEnviron(c *C) {
-	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
+	defer snapdenv.MockUseStagingStore(false)()
 	before := store.StoreDeveloperURL()
 
-	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", "1"), IsNil)
-	defer os.Setenv("SNAPPY_USE_STAGING_STORE", "")
+	snapdenv.MockUseStagingStore(true)
 	after := store.StoreDeveloperURL()
 
 	c.Check(before, Not(Equals), after)

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -36,9 +36,9 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/asserts/systestkeys"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -72,7 +72,7 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 	mux := http.NewServeMux()
 	var sto *store.Store
 	if assertFallback {
-		httputil.SetUserAgentFromVersion("unknown", "fakestore")
+		snapdenv.SetUserAgentFromVersion("unknown", "fakestore")
 		sto = store.New(nil, nil)
 	}
 	store := &Store{

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -36,7 +36,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/asserts/systestkeys"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
@@ -391,7 +390,7 @@ func (s *Store) bulkEndpoint(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var remoteStore string
-	if osutil.GetenvBool("SNAPPY_USE_STAGING_STORE") {
+	if snapdenv.UseStagingStore() {
 		remoteStore = "staging"
 	} else {
 		remoteStore = "production"
@@ -556,7 +555,7 @@ func (s *Store) snapActionEndpoint(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var remoteStore string
-	if osutil.GetenvBool("SNAPPY_USE_STAGING_STORE") {
+	if snapdenv.UseStagingStore() {
 		remoteStore = "staging"
 	} else {
 		remoteStore = "production"


### PR DESCRIPTION
This introduces a new package snapdenv to present the common env options for snapd components.

First it adds snadpenv.Testing exposing SNAPPY_TESTING.

It doesn't make sense for *util packages to use snapdenv directly, as a consequence this moves (Set)UserAgent from httputil to snapdenv.

Second this adds UseStagingStore

TODO for follow-ups: 
 * snapdenv.PreseedMode
 * SNAPD_DEBUG*