### PR TITLE
tests: add regression test for MAAS refresh bug

### DIFF
--- a/tests/regression/lp-1867193/task.yaml
+++ b/tests/regression/lp-1867193/task.yaml
@@ -1,0 +1,24 @@
+summary: certain refresh sequence on the maas snap breaks the layout system
+systems: [ubuntu-18.04-64] # tight coupling with container guest
+prepare: |
+    snap install --candidate lxd
+    snap set lxd waitready.timeout=240
+    lxd waitready
+    lxd init --auto
+    lxc launch --quiet "ubuntu:18.04" bionic
+    lxc exec bionic -- apt autoremove --purge -y snapd ubuntu-core-launcher
+    lxc exec bionic -- apt update
+    lxc exec bionic -- mkdir -p "$GOHOME"
+    lxc file push --quiet "$GOHOME"/snapd_*.deb "bionic/$GOHOME/"
+    lxc exec bionic -- apt install -y "$GOHOME"/snapd_*.deb
+    lxc exec bionic -- snap set core experimental.robust-mount-namespace-updates=true
+execute: |
+    # first command is done twice due to https://bugs.launchpad.net/snapd/+bug/1865503
+    lxc exec bionic -- snap install maas --channel=2.7/edge
+    lxc exec bionic -- snap install maas --channel=2.7/edge
+    lxc exec bionic -- snap refresh maas --channel=edge
+restore: |
+    lxc stop --force bionic
+    lxc delete bionic
+    snap remove --purge lxd
+    lxd-tool undo-lxd-mount-changes


### PR DESCRIPTION
This test fails and shows how some interaction between lxd and maas
content system breaks snap-update-ns. This test also passes when robust
mount namespace updates are enabled inside the LXD container.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>