### PR TITLE
snap-seccomp: allow mprotect() to unblock the tests

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -249,6 +249,8 @@ readlinkat
 faccessat
 # i386 from amd64
 restart_syscall
+# libc6 2.31
+mprotect
 `
 	bpfPath := filepath.Join(c.MkDir(), "bpf")
 	err := main.Compile([]byte(common+seccompWhitelist), bpfPath)


### PR DESCRIPTION
This will unblock the tests but there is more to come to fully
understand the issue.
