### PR TITLE
tests/lib/reset: workaround unicode dot in systemctl output

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -63,7 +63,7 @@ reset_classic() {
 
     # systemd retains the failed state of service units, even after they are
     # removed, we need to reset their 'failed state'
-    systemctl --failed --no-legend --full | awk '/^snap\..*\.service +(error|not-found) +failed/ {print $1}' | while read -r unit; do
+    systemctl --plain --failed --no-legend --full | awk '/^ *snap\..*\.service +(error|not-found) +failed/ {print $1}' | while read -r unit; do
         systemctl reset-failed "$unit" || true
     done
 


### PR DESCRIPTION
The newer versions of systemd seem to insist on printing out a huge colorful dot
in the output of `systemctl --failed` command:

●snap.test-snapd-service-stop-timeout.svc.service not-found failed failed snap.test-snapd-service-stop-timeout.svc.service

The dot is printed even when the output is piped to another program. Make sure
we pass --plain to avoid this. The dot is then replaced by whitespace. Adjust
the pattern to handle that.