### PR TITLE
data/selinux, tests/main/selinux: cleanup tmpfs operations in the policy, updates

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -388,6 +388,14 @@ allow snappy_t self:key { search write };
 # runuser logs to audit
 logging_send_audit_msgs(snappy_t)
 
+# allow snapd to remove snap specific user's data under
+# /run/user/<uid>/snap.<snap> on snap remove;
+# also desktop-helpers do cp -a on user-dirs.locale, what creates a config_home_t
+# file inside ~/snap, which would normally be snappy_home_t
+gnome_manage_home_config(snappy_t)
+gnome_manage_home_config_dirs(snappy_t)
+userdom_manage_user_tmp_symlinks(snappy_t)
+
 ########################################
 #
 # snap-update-ns, snap-dicsard-ns local policy
@@ -400,6 +408,20 @@ admin_pattern(snappy_mount_t, snappy_var_run_t)
 files_pid_filetrans(snappy_mount_t, snappy_var_run_t, {file dir})
 
 # layouts are built using tmpfs
+fs_manage_tmpfs_files(snappy_mount_t)
+fs_manage_tmpfs_dirs(snappy_mount_t)
+fs_manage_tmpfs_symlinks(snappy_mount_t)
+fs_mount_tmpfs(snappy_mount_t)
+fs_unmount_tmpfs(snappy_mount_t)
+fs_remount_tmpfs(snappy_mount_t)
+fs_getattr_tmpfs(snappy_mount_t)
+# this only gives mounton on directories
+fs_mounton_tmpfs(snappy_mount_t)
+# layouts may need to mount on files
+allow snappy_mount_t tmpfs_t:file mounton;
+# or (re)create symlinks
+fs_manage_tmpfs_symlinks(snappy_mount_t)
+
 # any tmp_t files or directories get snappy_tmp_t
 files_tmp_filetrans(snappy_mount_t, snappy_tmp_t, { file dir })
 userdom_user_tmp_filetrans(snappy_mount_t, snappy_tmp_t, { file dir})
@@ -430,18 +452,18 @@ allow snappy_mount_t self:capability { sys_chroot sys_admin setgid };
 
 manage_files_pattern(snappy_mount_t, snappy_snap_t, snappy_snap_t)
 manage_dirs_pattern(snappy_mount_t, snappy_snap_t, snappy_snap_t)
+manage_lnk_files_pattern(snappy_mount_t, snappy_snap_t, snappy_snap_t)
 
 read_files_pattern(snappy_mount_t, snappy_var_lib_t, snappy_var_lib_t)
 getattr_files_pattern(snappy_mount_t, snappy_var_lib_t, snappy_var_lib_t)
 read_lnk_files_pattern(snappy_mount_t, snappy_var_lib_t, snappy_var_lib_t)
+list_dirs_pattern(snappy_mount_t, snappy_var_lib_t, snappy_var_lib_t)
 
 fs_getattr_all_fs(snappy_mount_t)
-fs_getattr_tmpfs(snappy_mount_t)
 fs_getattr_xattr_fs(snappy_mount_t)
 # snap-discard-ns pokes, reads and unmounts the mount ns captured at <snap>.mnt
 fs_read_nsfs_files(snappy_mount_t)
 fs_unmount_nsfs(snappy_mount_t)
-fs_unmount_tmpfs(snappy_mount_t)
 
 # due to mounting /usr/libexec/snapd
 allow snappy_mount_t bin_t:dir mounton;
@@ -462,14 +484,11 @@ allow snappy_mount_t lib_t:dir mounton;
 # mount and unmount on top of snaps
 allow snappy_mount_t snappy_snap_t:dir mounton;
 allow snappy_mount_t snappy_snap_t:file mounton;
-allow snappy_mount_t snappy_snap_t:filesystem unmount;
+allow snappy_mount_t snappy_snap_t:filesystem { unmount remount };
 
 # freezer
 fs_manage_cgroup_dirs(snappy_mount_t)
 fs_manage_cgroup_files(snappy_mount_t)
-# TODO: further tweaks may be needed for layouts
-# reading tmpfs symlinks, eg. /etc/os-release
-fs_read_tmpfs_symlinks(snappy_mount_t)
 
 # because /run/snapd/ns/*.mnt gets a label of the process context
 gen_require(`
@@ -488,6 +507,10 @@ dev_read_sysfs(snappy_mount_t)
 # mount ns and may try to read/mmap cache files inside
 fs_read_tmpfs_files(snappy_mount_t)
 mmap_read_files_pattern(snappy_mount_t, tmpfs_t, tmpfs_t)
+
+# with robust mount namespace update snap-update-ns can remount filesystems that
+# were mounted from the host when updating the ns
+fs_remount_xattr_fs(snappy_mount_t)
 
 ########################################
 #

--- a/tests/lib/user.sh
+++ b/tests/lib/user.sh
@@ -58,11 +58,11 @@ as_user() {
 }
 
 as_user_simple() {
-    su -l -c "$*" "$TEST_USER"
+    su -l -c "$@" "$TEST_USER"
 }
 
 as_given_user() {
     local user="$1"
     shift
-    su -l -c "$*" "$user"
+    su -l -c "$@" "$user"
 }

--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -22,18 +22,31 @@ prepare: |
     setenforce 1
     ausearch --checkpoint stamp -m AVC || true
 
+    #shellcheck source=tests/lib/user.sh
+    . "$TESTSLIB/user.sh"
+
+    start_user_session
+
 restore: |
     setenforce "$(cat enforcing.mode)"
     rm -f stamp enforcing.mode
 
+    #shellcheck source=tests/lib/user.sh
+    . "$TESTSLIB/user.sh"
+
+    stop_user_session
+    purge_user_session_data
+
 execute: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
+    #shellcheck source=tests/lib/user.sh
+    . "$TESTSLIB/user.sh"
 
     install_local test-snapd-desktop
     test-snapd-desktop.cmd sh -c echo 'hello world'
-    su test -c "test-snapd-desktop.cmd sh -c 'echo hello world'"
-    su test -c "test-snapd-desktop.cmd sh -c 'mkdir \$HOME/foo && echo foo > \$HOME/foo/bar'"
+    as_user test-snapd-desktop.cmd "sh -c 'echo hello world'"
+    as_user test-snapd-desktop.cmd "sh -c 'mkdir \$HOME/foo && echo foo > \$HOME/foo/bar'"
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
     # another revision triggers copy of snap data
     install_local test-snapd-desktop
@@ -68,4 +81,13 @@ execute: |
     install_local test-snapd-snapctl-core18
     snap restart test-snapd-snapctl-core18
     snap remove test-snapd-snapctl-core18
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+
+    snap install snap-store
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+    # we are likely running without a display, so this will likely fail,
+    # hopefully triggering enough of earlier setup to catch any relevant denials
+    as_user snap run snap-store || true
+    # removal triggers cleanups
+    snap remove snap-store
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'


### PR DESCRIPTION
- allow snap-update-ns to operate more widely on tmpfs that's used for
  constructing layouts
- allow snapd to clean up files in /run/user/<uid>/snap.<snap> (labeled as
  user_tmp_t)
- same but for files with config_home_t (eg. user-dirs.locale cp -a'ed by
  desktop-helpers to ~/snap/<snap>/.. on startup)
- allow snap-update-ns to list dirs /var/lib/snapd
- allow snap-update-ns to work with symlinks in mounted snaps
- allow snap-update-ns to remount snaps when recreating layouts
- allow snap-update-ns to remount xattr capable fs when recreating
  layouts (needed when we pull in directories from the host, eg. fonts, cache)

Fixes from this PR are needed for #8089 

cc @Conan-Kudo 