### PR TITLE
interfaces/greengrass-support: add new 1.9 access (2.44)

### DIFF
--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -280,6 +280,9 @@ owner /{var/,}run/greengrassd.pid rw,
 # Additionally see LP bug #1791711 for apparmor resolving file accesses after
 # a pivot_root
 
+# for IPC communication via lambda helpers
+/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]/upper/greengrass_ipc.sock rw,
+
 # for child container lambda certificates
 /certs/ r,
 /certs/** r,


### PR DESCRIPTION
This is needed for newer versions of AWS IoT Greengrass 1.9+.

This is #8273 for 2.44