### PR TITLE
daemon: do a forceful server shutdown if we hit a deadline

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -580,9 +580,9 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	err := d.tomb.Wait()
 	if err != nil {
 		if err == context.DeadlineExceeded {
-			logger.Noticef("WARNING: cannot gracefully shut down the snapd API: %v", err)
+			logger.Noticef("WARNING: cannot gracefully shut down in-flight snapd API activity within: %v", shutdownTimeout)
 			// the process is shutting down anyway, so we may just
-			// as well close he connections right now
+			// as well close the active connections right now
 			d.serve.Close()
 		} else {
 			// do not stop the shutdown even if the tomb errors

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -637,7 +637,6 @@ func (s *daemonSuite) TestGracefulStop(c *check.C) {
 		} else {
 			w.Write([]byte("Gone"))
 		}
-		return
 	})
 
 	// mark as already seeded
@@ -718,6 +717,98 @@ func (s *daemonSuite) TestGracefulStop(c *check.C) {
 	select {
 	case <-alright:
 	case <-time.After(2 * time.Second):
+		c.Fatal("never got proper response")
+	}
+}
+
+func (s *daemonSuite) TestGracefulStopHasLimits(c *check.C) {
+	d := newTestDaemon(c)
+
+	// mark as already seeded
+	s.markSeeded(d)
+
+	restore := MockShutdownTimeout(time.Second)
+	defer restore()
+
+	responding := make(chan struct{})
+	doRespond := make(chan bool, 1)
+
+	d.router.HandleFunc("/endp", func(w http.ResponseWriter, r *http.Request) {
+		close(responding)
+		if <-doRespond {
+			for {
+				// write in a loop to keep the handler running
+				if _, err := w.Write([]byte("OKOK")); err != nil {
+					break
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+		} else {
+			w.Write([]byte("Gone"))
+		}
+	})
+
+	snapdL, err := net.Listen("tcp", "127.0.0.1:0")
+	c.Assert(err, check.IsNil)
+
+	snapL, err := net.Listen("tcp", "127.0.0.1:0")
+	c.Assert(err, check.IsNil)
+
+	snapdAccept := make(chan struct{})
+	snapdClosed := make(chan struct{})
+	d.snapdListener = &witnessAcceptListener{Listener: snapdL, accept: snapdAccept, closed: snapdClosed}
+
+	snapAccept := make(chan struct{})
+	d.snapListener = &witnessAcceptListener{Listener: snapL, accept: snapAccept}
+
+	c.Assert(d.Start(), check.IsNil)
+
+	snapdAccepting := make(chan struct{})
+	go func() {
+		select {
+		case <-snapdAccept:
+		case <-time.After(2 * time.Second):
+			c.Fatal("snapd accept was not called")
+		}
+		close(snapdAccepting)
+	}()
+
+	snapAccepting := make(chan struct{})
+	go func() {
+		select {
+		case <-snapAccept:
+		case <-time.After(2 * time.Second):
+			c.Fatal("snapd accept was not called")
+		}
+		close(snapAccepting)
+	}()
+
+	<-snapdAccepting
+	<-snapAccepting
+
+	clientErr := make(chan error)
+
+	go func() {
+		_, err := http.Get(fmt.Sprintf("http://%s/endp", snapdL.Addr()))
+		c.Assert(err, check.NotNil)
+		clientErr <- err
+		close(clientErr)
+	}()
+	go func() {
+		<-snapdClosed
+		time.Sleep(200 * time.Millisecond)
+		doRespond <- true
+	}()
+
+	<-responding
+	err = d.Stop(nil)
+	doRespond <- false
+	c.Check(err, check.IsNil)
+
+	select {
+	case cErr := <-clientErr:
+		c.Check(cErr, check.ErrorMatches, ".*: EOF")
+	case <-time.After(5 * time.Second):
 		c.Fatal("never got proper response")
 	}
 }

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/snapcore/snapd/overlord"
 )
@@ -49,5 +50,13 @@ func MockBuildID(mock string) (restore func()) {
 	buildID = mock
 	return func() {
 		buildID = old
+	}
+}
+
+func MockShutdownTimeout(tm time.Duration) (restore func()) {
+	old := shutdownTimeout
+	shutdownTimeout = tm
+	return func() {
+		shutdownTimeout = old
 	}
 }


### PR DESCRIPTION
When the daemon is shutting down, and a slow client is keeping the socket
connection alive, we can hit a timeout. In such case, try to swallow up the
error and force-close the server.

Related: https://bugs.launchpad.net/snapd/+bug/1867616
