### PR TITLE
snap: whitelist lzo as support compression for snap pack

### DIFF
--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -120,7 +120,7 @@ printf "hello world"
 func (s *SnapSuite) TestPackPacksASnapWithCompressionHappy(c *check.C) {
 	snapDir := makeSnapDirForPack(c, "name: hello\nversion: 1.0")
 
-	for _, comp := range []string{"xz"} {
+	for _, comp := range []string{"xz", "lzo"} {
 		_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", "--compression", comp, snapDir, snapDir})
 		c.Assert(err, check.IsNil)
 
@@ -135,7 +135,7 @@ func (s *SnapSuite) TestPackPacksASnapWithCompressionHappy(c *check.C) {
 func (s *SnapSuite) TestPackPacksASnapWithCompressionUnhappy(c *check.C) {
 	snapDir := makeSnapDirForPack(c, "name: hello\nversion: 1.0")
 
-	for _, comp := range []string{"gzip", "lzo", "zstd", "silly"} {
+	for _, comp := range []string{"gzip", "zstd", "silly"} {
 		_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", "--compression", comp, snapDir, snapDir})
 		c.Assert(err, check.ErrorMatches, fmt.Sprintf(`cannot pack "/.*": cannot use compression %q`, comp))
 	}

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -200,7 +200,7 @@ func Snap(sourceDir string, opts *Options) (string, error) {
 		opts = &Options{}
 	}
 	switch opts.Compression {
-	case "xz", "":
+	case "xz", "lzo", "":
 		// fine
 	default:
 		return "", fmt.Errorf("cannot use compression %q", opts.Compression)

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -331,7 +331,7 @@ volumes:
 func (s *packSuite) TestPackWithCompressionHappy(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 
-	for _, comp := range []string{"", "xz"} {
+	for _, comp := range []string{"", "xz", "lzo"} {
 		snapfile, err := pack.Snap(sourceDir, &pack.Options{
 			TargetDir:   c.MkDir(),
 			Compression: comp,
@@ -344,7 +344,7 @@ func (s *packSuite) TestPackWithCompressionHappy(c *C) {
 func (s *packSuite) TestPackWithCompressionUnhappy(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 
-	for _, comp := range []string{"gzip", "lzo", "zstd", "silly"} {
+	for _, comp := range []string{"gzip", "zstd", "silly"} {
 		snapfile, err := pack.Snap(sourceDir, &pack.Options{
 			TargetDir:   c.MkDir(),
 			Compression: comp,

--- a/tests/main/snap-pack/task.yaml
+++ b/tests/main/snap-pack/task.yaml
@@ -23,3 +23,9 @@ execute: |
     not su test -c "snap pack "$SNAP_MOUNT_DIR/core18/current" . --filename core18-as-user.snap" 2> stderr.log
     MATCH 'error: cannot pack ".*core18.*": cannot access the following locations in the snap source directory:' < stderr.log
     MATCH -- '- etc.* \(owner .* mode .*\)' < stderr.log
+
+    echo "Packing a simple snap with lzo works"
+    snap pack --compression=lzo "$TESTSLIB/snaps/test-snapd-sh" . --filename test-snapd-sh-lzo.snap
+    test -e test-snapd-sh-lzo.snap
+    unsquashfs -l test-snapd-sh-lzo.snap
+    unsquashfs -s test-snapd-sh-lzo.snap | MATCH "Compression lzo"


### PR DESCRIPTION
This will allow to use `snap pack --compression=lzo`.
