### PR TITLE
devicestate: disable cloud-init by default on uc20

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -65,8 +66,6 @@ var (
 )
 
 var (
-	runMnt = "/run/mnt"
-
 	osutilIsMounted = osutil.IsMounted
 )
 
@@ -98,7 +97,7 @@ func recoverySystemEssentialSnaps(seedDir, recoverySystem string, essentialTypes
 // generateMountsMode* is called multiple times from initramfs until it
 // no longer generates more mount points and just returns an empty output.
 func generateMountsModeInstall(recoverySystem string) error {
-	seedDir := filepath.Join(runMnt, "ubuntu-seed")
+	seedDir := filepath.Join(dirs.RunMnt, "ubuntu-seed")
 
 	// 1. always ensure seed partition is mounted
 	isMounted, err := osutilIsMounted(seedDir)
@@ -111,15 +110,15 @@ func generateMountsModeInstall(recoverySystem string) error {
 	}
 
 	// 2. (auto) select recovery system for now
-	isBaseMounted, err := osutilIsMounted(filepath.Join(runMnt, "base"))
+	isBaseMounted, err := osutilIsMounted(filepath.Join(dirs.RunMnt, "base"))
 	if err != nil {
 		return err
 	}
-	isKernelMounted, err := osutilIsMounted(filepath.Join(runMnt, "kernel"))
+	isKernelMounted, err := osutilIsMounted(filepath.Join(dirs.RunMnt, "kernel"))
 	if err != nil {
 		return err
 	}
-	isSnapdMounted, err := osutilIsMounted(filepath.Join(runMnt, "snapd"))
+	isSnapdMounted, err := osutilIsMounted(filepath.Join(dirs.RunMnt, "snapd"))
 	if err != nil {
 		return err
 	}
@@ -145,18 +144,18 @@ func generateMountsModeInstall(recoverySystem string) error {
 		for _, essentialSnap := range essSnaps {
 			switch essentialSnap.EssentialType {
 			case snap.TypeBase:
-				fmt.Fprintf(stdout, "%s %s\n", essentialSnap.Path, filepath.Join(runMnt, "base"))
+				fmt.Fprintf(stdout, "%s %s\n", essentialSnap.Path, filepath.Join(dirs.RunMnt, "base"))
 			case snap.TypeKernel:
 				// TODO:UC20: we need to cross-check the kernel path with snapd_recovery_kernel used by grub
-				fmt.Fprintf(stdout, "%s %s\n", essentialSnap.Path, filepath.Join(runMnt, "kernel"))
+				fmt.Fprintf(stdout, "%s %s\n", essentialSnap.Path, filepath.Join(dirs.RunMnt, "kernel"))
 			case snap.TypeSnapd:
-				fmt.Fprintf(stdout, "%s %s\n", essentialSnap.Path, filepath.Join(runMnt, "snapd"))
+				fmt.Fprintf(stdout, "%s %s\n", essentialSnap.Path, filepath.Join(dirs.RunMnt, "snapd"))
 			}
 		}
 	}
 
 	// 3. mount "ubuntu-data" on a tmpfs
-	isMounted, err = osutilIsMounted(filepath.Join(runMnt, "ubuntu-data"))
+	isMounted, err = osutilIsMounted(filepath.Join(dirs.RunMnt, "ubuntu-data"))
 	if err != nil {
 		return err
 	}
@@ -172,7 +171,11 @@ func generateMountsModeInstall(recoverySystem string) error {
 		Mode:           "install",
 		RecoverySystem: recoverySystem,
 	}
-	if err := modeEnv.Write(filepath.Join(runMnt, "ubuntu-data", "system-data")); err != nil {
+	if err := modeEnv.Write(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data")); err != nil {
+		return err
+	}
+	// and disable cloud-init in install mode
+	if err := sysconfig.DisableCloudInit(); err != nil {
 		return err
 	}
 
@@ -186,9 +189,9 @@ func generateMountsModeRecover(recoverySystem string) error {
 }
 
 func generateMountsModeRun() error {
-	seedDir := filepath.Join(runMnt, "ubuntu-seed")
-	bootDir := filepath.Join(runMnt, "ubuntu-boot")
-	dataDir := filepath.Join(runMnt, "ubuntu-data")
+	seedDir := filepath.Join(dirs.RunMnt, "ubuntu-seed")
+	bootDir := filepath.Join(dirs.RunMnt, "ubuntu-boot")
+	dataDir := filepath.Join(dirs.RunMnt, "ubuntu-data")
 
 	// 1.1 always ensure basic partitions are mounted
 	for _, d := range []string{seedDir, bootDir} {
@@ -224,7 +227,7 @@ func generateMountsModeRun() error {
 	}
 
 	// 2.2.1 check if base is mounted
-	isBaseMounted, err := osutilIsMounted(filepath.Join(runMnt, "base"))
+	isBaseMounted, err := osutilIsMounted(filepath.Join(dirs.RunMnt, "base"))
 	if err != nil {
 		return err
 	}
@@ -263,11 +266,11 @@ func generateMountsModeRun() error {
 		}
 
 		baseSnapPath := filepath.Join(dataDir, "system-data", dirs.SnapBlobDir, base)
-		fmt.Fprintf(stdout, "%s %s\n", baseSnapPath, filepath.Join(runMnt, "base"))
+		fmt.Fprintf(stdout, "%s %s\n", baseSnapPath, filepath.Join(dirs.RunMnt, "base"))
 	}
 
 	// 2.3.1 check if the kernel is mounted
-	isKernelMounted, err := osutilIsMounted(filepath.Join(runMnt, "kernel"))
+	isKernelMounted, err := osutilIsMounted(filepath.Join(dirs.RunMnt, "kernel"))
 	if err != nil {
 		return err
 	}
@@ -338,14 +341,14 @@ func generateMountsModeRun() error {
 		}
 
 		kernelPath := filepath.Join(dataDir, "system-data", dirs.SnapBlobDir, kernelFile)
-		fmt.Fprintf(stdout, "%s %s\n", kernelPath, filepath.Join(runMnt, "kernel"))
+		fmt.Fprintf(stdout, "%s %s\n", kernelPath, filepath.Join(dirs.RunMnt, "kernel"))
 	}
 
 	// 3.1 Maybe mount the snapd snap on first boot of run-mode
 	// TODO:UC20: Make RecoverySystem empty after successful first boot
 	// somewhere in devicestate
 	if modeEnv.RecoverySystem != "" {
-		isSnapdMounted, err := osutilIsMounted(filepath.Join(runMnt, "snapd"))
+		isSnapdMounted, err := osutilIsMounted(filepath.Join(dirs.RunMnt, "snapd"))
 		if err != nil {
 			return err
 		}
@@ -356,7 +359,7 @@ func generateMountsModeRun() error {
 			if err != nil {
 				return fmt.Errorf("cannot load metadata and verify snapd snap: %v", err)
 			}
-			fmt.Fprintf(stdout, "%s %s\n", essSnaps[0].Path, filepath.Join(runMnt, "snapd"))
+			fmt.Fprintf(stdout, "%s %s\n", essSnaps[0].Path, filepath.Join(dirs.RunMnt, "snapd"))
 		}
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -226,6 +226,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep4(c *C) {
 	c.Check(modeEnv, testutil.FileEquals, `mode=install
 recovery_system=20191118
 `)
+	cloudInitDisable := filepath.Join(s.runMnt, "/ubuntu-data/system-data/etc/cloud/cloud-init.disabled")
+	c.Check(cloudInitDisable, testutil.FilePresent)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1(c *C) {

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
+	"github.com/snapcore/snapd/dirs"
 )
 
 var (
@@ -55,10 +56,10 @@ func MockOsutilIsMounted(f func(path string) (bool, error)) (restore func()) {
 }
 
 func MockRunMnt(newRunMnt string) (restore func()) {
-	oldRunMnt := runMnt
-	runMnt = newRunMnt
+	oldRunMnt := dirs.RunMnt
+	dirs.RunMnt = newRunMnt
 	return func() {
-		runMnt = oldRunMnt
+		dirs.RunMnt = oldRunMnt
 	}
 }
 

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -364,6 +364,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
 		configureRunSystemCalls++
 		return nil
 	})
+	defer restore()
 
 	devicestate.SetOperatingMode(s.mgr, "install")
 	devicestate.SetRecoverySystem(s.mgr, "20191218")

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -360,7 +360,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
 	defer restore()
 
 	configureRunSystemCalls := 0
-	restore = devicestate.MockSysconfigConfigureRunSystem(func(opts sysconfig.Opts) error {
+	restore = devicestate.MockSysconfigConfigureRunSystem(func(opts *sysconfig.Options) error {
 		configureRunSystemCalls++
 		return nil
 	})
@@ -402,7 +402,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfigErr(c *C) {
 	defer restore()
 
 	configureRunSystemCalls := 0
-	restore = devicestate.MockSysconfigConfigureRunSystem(func(opts sysconfig.Opts) error {
+	restore = devicestate.MockSysconfigConfigureRunSystem(func(opts *sysconfig.Options) error {
 		configureRunSystemCalls++
 		return fmt.Errorf("error from sysconfig.ConfigureRunSystem")
 	})

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -341,3 +341,39 @@ func (s *deviceMgrInstallModeSuite) TestInstallSecuredBypassEncryption(c *C) {
 	err := s.doRunChangeTestWithEncryption(c, "secured", encTestCase{tpm: false, bypass: true, encrypt: false})
 	c.Assert(err, ErrorMatches, "(?s).*cannot encrypt secured device: TPM not available.*")
 }
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeDisablesCloudInit(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockSnapBootstrapCmd := testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), "")
+	defer mockSnapBootstrapCmd.Restore()
+
+	s.state.Lock()
+	s.makeMockInstalledPcGadget(c, "dangerous")
+	s.state.Unlock()
+
+	restore = devicestate.MockBootMakeBootable(func(model *asserts.Model, rootdir string, bootWith *boot.BootableSet) error {
+		return nil
+	})
+	defer restore()
+
+	devicestate.SetOperatingMode(s.mgr, "install")
+	devicestate.SetRecoverySystem(s.mgr, "20191218")
+
+	s.settle(c)
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// the install-system change is created
+	installSystem := s.findInstallSystem()
+	c.Assert(installSystem, NotNil)
+
+	// and was run successfully
+	c.Check(installSystem.Err(), IsNil)
+	c.Check(installSystem.Status(), Equals, state.DoneStatus)
+
+	// and cloud init is disabled
+	ubuntuDataCloudDisabled := filepath.Join(dirs.RunMnt, "ubuntu-data/system-data/etc/cloud/cloud-init.disabled/")
+	c.Check(ubuntuDataCloudDisabled, testutil.FilePresent)
+}

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
+	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -225,5 +226,13 @@ func MockHttputilNewHTTPClient(f func(opts *httputil.ClientOptions) *http.Client
 	httputilNewHTTPClient = f
 	return func() {
 		httputilNewHTTPClient = old
+	}
+}
+
+func MockSysconfigConfigureRunSystem(f func(opts sysconfig.Opts) error) (restore func()) {
+	old := sysconfigConfigureRunSystem
+	sysconfigConfigureRunSystem = f
+	return func() {
+		sysconfigConfigureRunSystem = old
 	}
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -229,7 +229,7 @@ func MockHttputilNewHTTPClient(f func(opts *httputil.ClientOptions) *http.Client
 	}
 }
 
-func MockSysconfigConfigureRunSystem(f func(opts sysconfig.Opts) error) (restore func()) {
+func MockSysconfigConfigureRunSystem(f func(opts *sysconfig.Options) error) (restore func()) {
 	old := sysconfigConfigureRunSystem
 	sysconfigConfigureRunSystem = f
 	return func() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -89,6 +89,12 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("cannot create partitions: %v", osutil.OutputErr(output, err))
 	}
 
+	// configure the run system
+	if err := configureRunSystem(); err != nil {
+		return err
+	}
+
+	// make it bootable
 	kernelInfo, err := snapstate.KernelInfo(st, deviceCtx)
 	if err != nil {
 		return fmt.Errorf("cannot get gadget info: %v", err)
@@ -98,7 +104,6 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		return fmt.Errorf("cannot get boot base info: %v", err)
 	}
-
 	recoverySystemDir := filepath.Join("/systems", m.modeEnv.RecoverySystem)
 	bootWith := &boot.BootableSet{
 		Base:              bootBaseInfo,
@@ -107,21 +112,9 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		KernelPath:        kernelInfo.MountFile(),
 		RecoverySystemDir: recoverySystemDir,
 	}
-
 	rootdir := dirs.GlobalRootDir
 	if err := bootMakeBootable(deviceCtx.Model(), rootdir, bootWith); err != nil {
 		return fmt.Errorf("cannot make run system bootable: %v", err)
-	}
-
-	// disable cloud-init by default (as it's not confined)
-	// TODO:UC20: 1. allow drop-in cloud.cfg.d/* in mode dangerous
-	//            2. allow gadget cloud.cfg.d/* (with whitelisted keys?)
-	ubuntuDataCloud := filepath.Join(dirs.RunMnt, "ubuntu-data/system-data/etc/cloud/")
-	if err := os.MkdirAll(ubuntuDataCloud, 0755); err != nil {
-		return fmt.Errorf("cannot make cloud config dir: %v", err)
-	}
-	if err := ioutil.WriteFile(filepath.Join(ubuntuDataCloud, "cloud-init.disabled"), nil, 0644); err != nil {
-		return fmt.Errorf("cannot disable cloud-init: %v", err)
 	}
 
 	// request a restart as the last action after a successful install
@@ -156,4 +149,22 @@ func checkEncryption(model *asserts.Model) (res bool, err error) {
 	}
 
 	return true, nil
+}
+
+// configureRunSystem configures the ubuntu-data partition with any
+// configuration needed from e.g. the gadget or for cloud-init
+func configureRunSystem() error {
+	// disable cloud-init by default (as it's not confined)
+	// TODO:UC20: 1. allow drop-in cloud.cfg.d/* in mode dangerous
+	//            2. allow gadget cloud.cfg.d/* (with whitelisted keys?)
+	//            3. allow cloud.cfg.d (with whitelisted keys) for non
+	//               grade dangerous systems
+	ubuntuDataCloud := filepath.Join(dirs.RunMnt, "ubuntu-data/system-data/etc/cloud/")
+	if err := os.MkdirAll(ubuntuDataCloud, 0755); err != nil {
+		return fmt.Errorf("cannot make cloud config dir: %v", err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(ubuntuDataCloud, "cloud-init.disabled"), nil, 0644); err != nil {
+		return fmt.Errorf("cannot disable cloud-init: %v", err)
+	}
+	return nil
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -92,7 +92,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// configure the run system
-	if err := sysconfigConfigureRunSystem(sysconfig.Opts{}); err != nil {
+	if err := sysconfigConfigureRunSystem(&sysconfig.Options{}); err != nil {
 		return err
 	}
 

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sysconfig
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+func disableCloudInit() error {
+	ubuntuDataCloud := filepath.Join(dirs.RunMnt, "ubuntu-data/system-data/etc/cloud/")
+	if err := os.MkdirAll(ubuntuDataCloud, 0755); err != nil {
+		return fmt.Errorf("cannot make cloud config dir: %v", err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(ubuntuDataCloud, "cloud-init.disabled"), nil, 0644); err != nil {
+		return fmt.Errorf("cannot disable cloud-init: %v", err)
+	}
+
+	return nil
+}
+
+func installCloudInitCfg(src string) error {
+	return fmt.Errorf("installCloudInitCfg not implemented yet")
+}
+
+// disable cloud-init by default (as it's not confined)
+// TODO:UC20: 1. allow drop-in cloud.cfg.d/* in mode dangerous
+//            2. allow gadget cloud.cfg.d/* (with whitelisted keys?)
+//            3. allow cloud.cfg.d (with whitelisted keys) for non
+//               grade dangerous systems
+func configureCloudInit(opts Opts) (err error) {
+	switch opts.CloudInitSrcDir {
+	case "":
+		err = disableCloudInit()
+	default:
+		err = installCloudInitCfg(opts.CloudInitSrcDir)
+	}
+	return err
+}

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -28,7 +28,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 )
 
-func disableCloudInit() error {
+func DisableCloudInit() error {
 	ubuntuDataCloud := filepath.Join(dirs.RunMnt, "ubuntu-data/system-data/etc/cloud/")
 	if err := os.MkdirAll(ubuntuDataCloud, 0755); err != nil {
 		return fmt.Errorf("cannot make cloud config dir: %v", err)
@@ -52,7 +52,7 @@ func installCloudInitCfg(src string) error {
 func configureCloudInit(opts Opts) (err error) {
 	switch opts.CloudInitSrcDir {
 	case "":
-		err = disableCloudInit()
+		err = DisableCloudInit()
 	default:
 		err = installCloudInitCfg(opts.CloudInitSrcDir)
 	}

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -49,7 +49,7 @@ func installCloudInitCfg(src string) error {
 //            2. allow gadget cloud.cfg.d/* (with whitelisted keys?)
 //            3. allow cloud.cfg.d (with whitelisted keys) for non
 //               grade dangerous systems
-func configureCloudInit(opts Opts) (err error) {
+func configureCloudInit(opts *Options) (err error) {
 	switch opts.CloudInitSrcDir {
 	case "":
 		err = DisableCloudInit()

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -1,0 +1,65 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sysconfig_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/sysconfig"
+	"github.com/snapcore/snapd/testutil"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type sysconfigSuite struct {
+	testutil.BaseTest
+
+	tmpdir string
+}
+
+var _ = Suite(&sysconfigSuite{})
+
+func (s *sysconfigSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.tmpdir = c.MkDir()
+	dirs.SetRootDir(s.tmpdir)
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+}
+
+func (s *sysconfigSuite) TestCloudInitDisablesByDefault(c *C) {
+	err := sysconfig.ConfigureRunSystem(sysconfig.Opts{})
+	c.Assert(err, IsNil)
+
+	ubuntuDataCloudDisabled := filepath.Join(dirs.RunMnt, "ubuntu-data/system-data/etc/cloud/cloud-init.disabled/")
+	c.Check(ubuntuDataCloudDisabled, testutil.FilePresent)
+}
+
+func (s *sysconfigSuite) TestCloudInitInstalls(c *C) {
+	err := sysconfig.ConfigureRunSystem(sysconfig.Opts{
+		CloudInitSrcDir: "some-dir",
+	})
+	c.Assert(err, ErrorMatches, "installCloudInitCfg not implemented yet")
+}

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -50,7 +50,7 @@ func (s *sysconfigSuite) SetUpTest(c *C) {
 }
 
 func (s *sysconfigSuite) TestCloudInitDisablesByDefault(c *C) {
-	err := sysconfig.ConfigureRunSystem(sysconfig.Opts{})
+	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{})
 	c.Assert(err, IsNil)
 
 	ubuntuDataCloudDisabled := filepath.Join(dirs.RunMnt, "ubuntu-data/system-data/etc/cloud/cloud-init.disabled/")
@@ -58,7 +58,7 @@ func (s *sysconfigSuite) TestCloudInitDisablesByDefault(c *C) {
 }
 
 func (s *sysconfigSuite) TestCloudInitInstalls(c *C) {
-	err := sysconfig.ConfigureRunSystem(sysconfig.Opts{
+	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
 		CloudInitSrcDir: "some-dir",
 	})
 	c.Assert(err, ErrorMatches, "installCloudInitCfg not implemented yet")

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -19,13 +19,15 @@
 
 package sysconfig
 
-type Opts struct {
+type Options struct {
+	// TODO: do we really want this kind of specific dir pointers
+	// or more general ones?
 	CloudInitSrcDir string
 }
 
 // ConfigureRunSystem configures the ubuntu-data partition with any
-// Configuration needed from e.g. the gadget or for cloud-init
-func ConfigureRunSystem(opts Opts) error {
+// configuration needed from e.g. the gadget or for cloud-init.
+func ConfigureRunSystem(opts *Options) error {
 	if err := configureCloudInit(opts); err != nil {
 		return err
 	}

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sysconfig
+
+type Opts struct {
+	CloudInitSrcDir string
+}
+
+// ConfigureRunSystem configures the ubuntu-data partition with any
+// Configuration needed from e.g. the gadget or for cloud-init
+func ConfigureRunSystem(opts Opts) error {
+	if err := configureCloudInit(opts); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -17,8 +17,11 @@ execute: |
     if [[ ! -e /run/cloud-init/instance-data.json ]]; then
         echo "cloud-init instance data is required to execute the test"
 
-        if [[ "$SPREAD_SYSTEM" == ubuntu-* && "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
-            # we expect the test to run on all Ubuntu images, excluding 14.04
+        if [[ "$SPREAD_SYSTEM" == ubuntu-* &&
+              "$SPREAD_SYSTEM" != ubuntu-14.04-* &&
+              "$SPREAD_SYSTEM" != ubuntu-core-20-* ]]; then
+            # we expect the test to run on all Ubuntu images,
+            # excluding 14.04/core20
             echo "the test expected to run on $SPREAD_SYSTEM"
             exit 1
         fi


### PR DESCRIPTION
This commit disables cloud-init by default on UC20 but leaves a
TODO:UC20: to enable it for:

  1. allow drop-in cloud.cfg.d/* in mode dangerous
  2. allow gadget cloud.cfg.d/* (with whitelisted keys?)

which will happen in followup PRs.

This should unblock https://github.com/snapcore/snapd/pull/8234