### PR TITLE
snap: do not hardlink on overlayfs

### DIFF
--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -77,3 +77,11 @@ func Alike(a, b os.FileInfo, c *check.C, comment check.CommentInterface) {
 	bm := b.ModTime().UTC().Truncate(time.Minute)
 	c.Check(am.Equal(bm), check.Equals, true, check.Commentf("%s != %s (%s)", am, bm, comment))
 }
+
+func MockIsRootWritableOverlay(new func() (string, error)) (restore func()) {
+	old := isRootWritableOverlay
+	isRootWritableOverlay = new
+	return func() {
+		isRootWritableOverlay = old
+	}
+}

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -36,12 +36,18 @@ import (
 
 	"github.com/snapcore/snapd/cmd/cmdutil"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
 )
 
-// Magic is the magic prefix of squashfs snap files.
-var Magic = []byte{'h', 's', 'q', 's'}
+var (
+	// Magic is the magic prefix of squashfs snap files.
+	Magic = []byte{'h', 's', 'q', 's'}
+
+	// for testing
+	isRootWritableOverlay = osutil.IsRootWritableOverlay
+)
 
 // Snap is the squashfs based snap.
 type Snap struct {
@@ -87,14 +93,20 @@ func (s *Snap) Install(targetPath, mountDir string) (bool, error) {
 		return didNothing, nil
 	}
 
-	// try to (hard)link the file, but go on to trying to copy it
-	// if it fails for whatever reason
-	//
-	// link(2) returns EPERM on filesystems that don't support
-	// hard links (like vfat), so checking the error here doesn't
-	// make sense vs just trying to copy it.
-	if err := osLink(s.path, targetPath); err == nil {
-		return false, nil
+	overlayRoot, err := isRootWritableOverlay()
+	if err != nil {
+		logger.Noticef("cannot determine if root filesystem on overlay: %v", err)
+	}
+	if overlayRoot == "" {
+		// try to (hard)link the file, but go on to trying to copy it
+		// if it fails for whatever reason
+		//
+		// link(2) returns EPERM on filesystems that don't support
+		// hard links (like vfat), so checking the error here doesn't
+		// make sense vs just trying to copy it.
+		if err := osLink(s.path, targetPath); err == nil {
+			return false, nil
+		}
 	}
 
 	// if the file is a seed, but the hardlink failed, symlinking it

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -152,6 +152,40 @@ exec /bin/cp "$@"
 	c.Check(cmd.Calls(), HasLen, 0)
 }
 
+func (s *SquashfsTestSuite) TestInstallSimpleOnOverlayfs(c *C) {
+	cmd := testutil.MockCommand(c, "cp", "")
+	defer cmd.Restore()
+
+	// mock link but still link
+	linked := 0
+	r := squashfs.MockLink(func(a, b string) error {
+		linked++
+		return os.Link(a, b)
+	})
+	defer r()
+
+	// pretend we are on overlayfs
+	restore := squashfs.MockIsRootWritableOverlay(func() (string, error) {
+		return "/upper", nil
+	})
+	defer restore()
+
+	c.Assert(os.MkdirAll(dirs.SnapSeedDir, 0755), IsNil)
+	snap := makeSnapInDir(c, dirs.SnapSeedDir, "name: test2", "")
+	targetPath := filepath.Join(c.MkDir(), "target.snap")
+	_, err := os.Lstat(targetPath)
+	c.Check(os.IsNotExist(err), Equals, true)
+
+	didNothing, err := snap.Install(targetPath, c.MkDir())
+	c.Assert(err, IsNil)
+	c.Assert(didNothing, Equals, false)
+	// symlink in place
+	c.Check(osutil.IsSymlink(targetPath), Equals, true)
+	// no link / no cp
+	c.Check(linked, Equals, 0)
+	c.Check(cmd.Calls(), HasLen, 0)
+}
+
 func noLink() func() {
 	return squashfs.MockLink(func(string, string) error { return errors.New("no.") })
 }


### PR DESCRIPTION
We currently try to hardlink a snap on install first. However this
will cause a lot of memory usage on an overlayfs based system like
the ubuntu live-cd.

To avoid this extra memory, this commit detects an overlayfs and
uses a symlink in this case instead of a hardlink.  This saves
~400Mb on the 20.04 livecd.

We could potentially just reverse the order of the hardlink/symlink
but that is a more risky change.

This should fix LP:1867415
