### PR TITLE
many: introduce snapdenv.Preseeding instead of release.PreseedMode

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/errtracker"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sanity"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
@@ -52,9 +51,9 @@ func init() {
 }
 
 func main() {
-	// In preseed mode re-exec is not used
-	if release.PreseedMode() {
-		logger.Noticef("running in preseed mode")
+	// When preseeding re-exec is not used
+	if snapdenv.Preseeding() {
+		logger.Noticef("running for preseeding")
 	} else {
 		cmd.ExecInSnapdOrCoreSnap()
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -83,8 +84,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 		keypairMgr: keypairMgr,
 		newStore:   newStore,
 		reg:        make(chan struct{}),
-		// TODO: handle here via devicestate, similar to DeviceContext.
-		preseed: release.PreseedMode(),
+		preseed:    snapdenv.Preseeding(),
 	}
 
 	modeEnv, err := boot.ReadModeenv("")

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store/storetest"
 	"github.com/snapcore/snapd/timings"
 )
@@ -1229,7 +1230,7 @@ func (s *startOfOperationTimeSuite) TestStartOfOperationTimeNoSeedTime(c *C) {
 }
 
 func (s *startOfOperationTimeSuite) TestStartOfOperationErrorIfPreseed(c *C) {
-	restore := release.MockPreseedMode(func() bool { return true })
+	restore := snapdenv.MockPreseeding(true)
 	defer restore()
 
 	mgr := s.manager(c)

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -216,7 +217,7 @@ func (s *firstbootPreseed16Suite) SetUpTest(c *C) {
 }
 
 func (s *firstbootPreseed16Suite) TestPreseedHappy(c *C) {
-	restore := release.MockPreseedMode(func() bool { return true })
+	restore := snapdenv.MockPreseeding(true)
 	defer restore()
 
 	mockMountCmd := testutil.MockCommand(c, "mount", "")
@@ -247,7 +248,7 @@ func (s *firstbootPreseed16Suite) TestPreseedHappy(c *C) {
 }
 
 func (s *firstbootPreseed16Suite) TestPreseedOnClassicHappy(c *C) {
-	restore := release.MockPreseedMode(func() bool { return true })
+	restore := snapdenv.MockPreseeding(true)
 	defer restore()
 
 	restoreRelease := release.MockOnClassic(true)
@@ -333,7 +334,7 @@ snaps:
 }
 
 func (s *firstbootPreseed16Suite) TestPreseedClassicWithSnapdOnlyHappy(c *C) {
-	restorePreseedMode := release.MockPreseedMode(func() bool { return true })
+	restorePreseedMode := snapdenv.MockPreseeding(true)
 	defer restorePreseedMode()
 
 	restore := release.MockOnClassic(true)

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -35,9 +35,9 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
@@ -433,13 +433,19 @@ func (s *deviceMgrSuite) TestDoPrepareRemodeling(c *C) {
 
 type preseedBaseSuite struct {
 	deviceMgrBaseSuite
-	restorePreseedMode func()
-	cmdUmount          *testutil.MockCmd
-	cmdSystemctl       *testutil.MockCmd
+
+	// TODO: use this in deviceMgrBaseSuite itself
+	testutil.BaseTest
+
+	cmdUmount    *testutil.MockCmd
+	cmdSystemctl *testutil.MockCmd
 }
 
 func (s *preseedBaseSuite) SetUpTest(c *C, preseed bool) {
-	s.restorePreseedMode = release.MockPreseedMode(func() bool { return preseed })
+	s.BaseTest.SetUpTest(c)
+
+	s.AddCleanup(snapdenv.MockPreseeding(preseed))
+
 	// preseed mode helper needs to be mocked before setting up
 	// deviceMgrBaseSuite due to device Manager init.
 	s.deviceMgrBaseSuite.SetUpTest(c)
@@ -474,6 +480,9 @@ func (s *preseedBaseSuite) TearDownTest(c *C) {
 	s.cmdSystemctl.Restore()
 }
 
+// TODO: rename preesed mode to just preseeding as much as possible,
+// preseed mode souns like a UC20 system mode but is just a snapd mode
+// but preseed snapd mode is a mouthful
 type preseedModeSuite struct {
 	preseedBaseSuite
 }

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -31,8 +31,8 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -85,7 +85,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 		// extras
 		extraInterfaces: extraInterfaces,
 		extraBackends:   extraBackends,
-		preseed:         release.PreseedMode(),
+		preseed:         snapdenv.Preseeding(),
 	}
 
 	taskKinds := map[string]bool{}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -54,6 +54,7 @@ import (
 	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
@@ -8007,7 +8008,7 @@ plugs:
 }
 
 func (s *interfaceManagerSuite) TestPreseedAutoConnectErrorWithInterfaceHooks(c *C) {
-	restore := release.MockPreseedMode(func() bool { return true })
+	restore := snapdenv.MockPreseeding(true)
 	defer restore()
 
 	s.MockModel(c, nil)

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -50,7 +50,7 @@ import (
 	_ "github.com/snapcore/snapd/overlord/snapstate/policy"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
-	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/timings"
 )
@@ -316,7 +316,7 @@ func (o *Overlord) StartUp() error {
 
 	// account for deviceMgr == nil as it's not always present in
 	// the tests.
-	if o.deviceMgr != nil && !release.PreseedMode() {
+	if o.deviceMgr != nil && !snapdenv.Preseeding() {
 		var err error
 		st := o.State()
 		st.Lock()
@@ -414,7 +414,7 @@ var preseedExitWithError = func(err error) {
 // Loop runs a loop in a goroutine to ensure the current state regularly through StateEngine Ensure.
 func (o *Overlord) Loop() {
 	o.ensureTimerSetup()
-	preseed := release.PreseedMode()
+	preseed := snapdenv.Preseeding()
 	if preseed {
 		o.runner.OnTaskError(preseedExitWithError)
 	}

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -44,8 +44,8 @@ import (
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -793,7 +793,7 @@ func (ovs *overlordSuite) TestEnsureLoopNoPruneWhenPreseed(c *C) {
 	restoreIntv := overlord.MockPruneInterval(1*time.Millisecond, 1000*time.Millisecond, 1*time.Hour)
 	defer restoreIntv()
 
-	restore := release.MockPreseedMode(func() bool { return true })
+	restore := snapdenv.MockPreseeding(true)
 	defer restore()
 
 	restorePreseedExitWithErr := overlord.MockPreseedExitWithError(func(err error) {})
@@ -1084,7 +1084,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 }
 
 func (ovs *overlordSuite) TestEnsureErrorWhenPreseeding(c *C) {
-	restore := release.MockPreseedMode(func() bool { return true })
+	restore := snapdenv.MockPreseeding(true)
 	defer restore()
 
 	restoreIntv := overlord.MockEnsureInterval(1 * time.Millisecond)

--- a/overlord/patch/patch5.go
+++ b/overlord/patch/patch5.go
@@ -71,7 +71,7 @@ func patch5(st *state.State) error {
 			return err
 		}
 
-		err = wrappers.AddSnapServices(info, nil, log)
+		err = wrappers.AddSnapServices(info, nil, nil, log)
 		if err != nil {
 			return err
 		}

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -95,7 +95,7 @@ func (b Backend) LinkSnap(info *snap.Info, dev boot.Device, linkCtx LinkContext,
 
 	var err error
 	timings.Run(tm, "generate-wrappers", fmt.Sprintf("generate wrappers for snap %s", info.InstanceName()), func(timings.Measurer) {
-		err = generateWrappers(info, linkCtx.PrevDisabledServices)
+		err = b.generateWrappers(info, linkCtx.PrevDisabledServices)
 	})
 	if err != nil {
 		return false, err
@@ -154,7 +154,7 @@ func (b Backend) StopServices(apps []*snap.AppInfo, reason snap.ServiceStopReaso
 	return wrappers.StopServices(apps, reason, meter, tm)
 }
 
-func generateWrappers(s *snap.Info, disabledSvcs []string) error {
+func (b Backend) generateWrappers(s *snap.Info, disabledSvcs []string) error {
 	var err error
 	var cleanupFuncs []func(*snap.Info) error
 	defer func() {
@@ -177,7 +177,8 @@ func generateWrappers(s *snap.Info, disabledSvcs []string) error {
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapBinaries)
 
 	// add the daemons from the snap.yaml
-	if err = wrappers.AddSnapServices(s, disabledSvcs, progress.Null); err != nil {
+	opts := &wrappers.AddSnapServicesOptions{Preseeding: b.preseed}
+	if err = wrappers.AddSnapServices(s, disabledSvcs, opts, progress.Null); err != nil {
 		return err
 	}
 	cleanupFuncs = append(cleanupFuncs, func(s *snap.Info) error {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -391,7 +392,7 @@ func Store(st *state.State, deviceCtx DeviceContext) StoreService {
 
 // Manager returns a new snap manager.
 func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
-	preseed := release.PreseedMode()
+	preseed := snapdenv.Preseeding()
 	m := &SnapManager{
 		state:          st,
 		autoRefresh:    newAutoRefresh(st),

--- a/release/release.go
+++ b/release/release.go
@@ -135,14 +135,6 @@ func isWSL() bool {
 	return false
 }
 
-// PreseedMode states whether snapd is running in a presseding mode
-// to perform a partial first boot and touch only filesystem state
-// inside a chroot.
-// TODO: handle via devicestate, similar to DeviceContext.
-var PreseedMode = func() bool {
-	return os.Getenv("SNAPD_PRESEED") != ""
-}
-
 // OnClassic states whether the process is running inside a
 // classic Ubuntu system or a native Ubuntu Core image.
 var OnClassic bool
@@ -160,13 +152,6 @@ func init() {
 	OnClassic = (ReleaseInfo.ID != "ubuntu-core")
 
 	OnWSL = isWSL()
-}
-
-// MockPreseedMode fakes preseed mode.
-func MockPreseedMode(preseedMode func() bool) (restore func()) {
-	old := PreseedMode
-	PreseedMode = preseedMode
-	return func() { PreseedMode = old }
 }
 
 // MockOnClassic forces the process to appear inside a classic

--- a/snapdenv/snapdenv.go
+++ b/snapdenv/snapdenv.go
@@ -66,9 +66,9 @@ func UseStagingStore() bool {
 	return osutil.GetenvBool("SNAPPY_USE_STAGING_STORE")
 }
 
-func MockUseStagingStore(testing bool) (restore func()) {
+func MockUseStagingStore(useStaging bool) (restore func()) {
 	old := mockUseStagingStore
-	mockUseStagingStore = &testing
+	mockUseStagingStore = &useStaging
 	return func() {
 		mockUseStagingStore = old
 	}

--- a/snapdenv/snapdenv.go
+++ b/snapdenv/snapdenv.go
@@ -73,3 +73,22 @@ func MockUseStagingStore(useStaging bool) (restore func()) {
 		mockUseStagingStore = old
 	}
 }
+
+var mockPreseeding *bool
+
+// Preseeding returns whether snapd is preseeding, i.e. performing a
+// partial first boot updating only filesystem state inside a chroot.
+func Preseeding() bool {
+	if mockPreseeding != nil {
+		return *mockPreseeding
+	}
+	return osutil.GetenvBool("SNAPD_PRESEED")
+}
+
+func MockPreseeding(preseeding bool) (restore func()) {
+	old := mockPreseeding
+	mockPreseeding = &preseeding
+	return func() {
+		mockPreseeding = old
+	}
+}

--- a/snapdenv/snapdenv_test.go
+++ b/snapdenv/snapdenv_test.go
@@ -107,3 +107,40 @@ func (s *snapdenvSuite) TestMockUseStagingStore(c *C) {
 	snapdenv.MockUseStagingStore(false)
 	c.Check(snapdenv.UseStagingStore(), Equals, false)
 }
+
+func (s *snapdenvSuite) TestPreseeding(c *C) {
+	oldPreseeding := os.Getenv("SNAPD_PRESEED")
+	defer func() {
+		if oldPreseeding == "" {
+			os.Unsetenv("SNAPD_PRESEED")
+		} else {
+			os.Setenv("SNAPD_PRESEED", oldPreseeding)
+		}
+	}()
+
+	os.Setenv("SNAPD_PRESEED", "1")
+	c.Check(snapdenv.Preseeding(), Equals, true)
+
+	os.Unsetenv("SNAPD_PRESEED")
+	c.Check(snapdenv.Preseeding(), Equals, false)
+}
+
+func (s *snapdenvSuite) TestMockPreseeding(c *C) {
+	oldPreseeding := os.Getenv("SNAPD_PRESEED")
+	defer func() {
+		if oldPreseeding == "" {
+			os.Unsetenv("SNAPD_PRESEED")
+		} else {
+			os.Setenv("SNAPD_PRESEED", oldPreseeding)
+		}
+	}()
+	os.Unsetenv("SNAPD_PRESEED")
+
+	r := snapdenv.MockPreseeding(true)
+	defer r()
+
+	c.Check(snapdenv.Preseeding(), Equals, true)
+
+	snapdenv.MockPreseeding(false)
+	c.Check(snapdenv.Preseeding(), Equals, false)
+}


### PR DESCRIPTION
TODO: preseed mode sounds a UC20 system mode but is not, we should probably just use preseed(ing) instead around the code and messages.
