### PR TITLE
cmd/snap-update-ns: ignore EROFS from rmdir/unlink

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -379,6 +379,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			defer sysClose(fd)
 
 			// Don't attempt to remove anything from squashfs.
+			// Note that this is not a perfect check and we also handle EROFS below.
 			var statfsBuf syscall.Statfs_t
 			err = sysFstatfs(fd, &statfsBuf)
 			if err != nil {
@@ -409,6 +410,23 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			// Unpack the low-level error that osRemove wraps into PathError.
 			if packed, ok := err.(*os.PathError); ok {
 				err = packed.Err
+			}
+			if err == syscall.EROFS {
+				// If the underlying medium is read-only then ignore the error.
+				// Instead of checking up front we just try to remove because
+				// of https://bugs.launchpad.net/snapd/+bug/1867752 which showed us
+				// two important properties:
+				// 1) inside containers we cannot detect squashfs reliably and
+				//    will always see FUSE instead. The problem is that there's no
+				//    indication as to what is really mounted via statfs(2) and
+				//    we would have to deduce that from mountinfo, trusting
+				//    that fuse.<name> is not spoofed (as in, the name is not
+				//    spoofed).
+				// 2) rmdir of a bind mount (from a normal writable filesystem like ext4)
+				//    over a read-only filesystem also yields EROFS without any indication
+				//    that this is to be expected.
+				logger.Debugf("cannot mount point on read-only filesystem %q", path)
+				return nil
 			}
 			// If we were removing a directory but it was not empty then just
 			// ignore the error. This is the equivalent of the non-empty file

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -425,7 +425,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 				// 2) rmdir of a bind mount (from a normal writable filesystem like ext4)
 				//    over a read-only filesystem also yields EROFS without any indication
 				//    that this is to be expected.
-				logger.Debugf("cannot mount point on read-only filesystem %q", path)
+				logger.Debugf("cannot remove a mount point on read-only filesystem %q", path)
 				return nil
 			}
 			// If we were removing a directory but it was not empty then just

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -2818,6 +2818,39 @@ func (s *changeSuite) TestPerformCreateSymlinkWithAvoidedTrespassing(c *C) {
 	})
 }
 
+// Change.Perform wants to remove a directory which is a bind mount of ext4 from onto squashfs.
+func (s *changeSuite) TestPerformRmdirOnExt4OnSquashfs(c *C) {
+	defer s.as.MockUnrestrictedPaths("/tmp/")() // Allow writing to /tmp
+
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	// Pretend that /root is an ext4 bind mount from somewhere.
+	s.sys.InsertFstatfsResult(`fstatfs 4 <ptr>`, syscall.Statfs_t{Type: update.Ext4Magic})
+	// Pretend that removing /root returns EROFS (it really can!).
+	s.sys.InsertFault(`remove "/root"`, syscall.EROFS)
+
+	// This is the change we want to perform:
+	// - unmount a layout from /root
+	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "unused", Dir: "/root", Options: []string{"x-snapd.origin=layout"}}}
+	synth, err := chg.Perform(s.as)
+	// The change succeeded even though we were unable to remove the /root
+	// directory because it is backed by a squashfs, which is not modelled by
+	// this test but is modelled by the integration test.
+	c.Check(err, IsNil)
+	c.Check(synth, HasLen, 0)
+
+	// And this is exactly how we made that happen:
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `unmount "/root" UMOUNT_NOFOLLOW`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "root" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `fstatfs 4 <ptr>`, R: syscall.Statfs_t{Type: update.Ext4Magic}},
+		{C: `remove "/root"`, E: syscall.EROFS},
+		{C: `close 4`},
+	})
+}
+
 // ###########
 // Topic: misc
 // ###########

--- a/tests/regression/lp-1867752/task.yaml
+++ b/tests/regression/lp-1867752/task.yaml
@@ -1,0 +1,26 @@
+summary: certain layout configuration prevents snapd from removing a snap
+systems: [ubuntu-18.04-64] # tight coupling with container guest
+prepare: |
+    snap install --candidate lxd
+    snap set lxd waitready.timeout=240
+    lxd waitready
+    lxd init --auto
+    lxc launch --quiet "ubuntu:18.04" bionic
+    lxc exec bionic -- apt autoremove --purge -y snapd ubuntu-core-launcher
+    lxc exec bionic -- apt update
+    lxc exec bionic -- mkdir -p "$GOHOME"
+    lxc file push --quiet "$GOHOME"/snapd_*.deb "bionic/$GOHOME/"
+    lxc exec bionic -- apt install -y "$GOHOME"/snapd_*.deb
+    lxc exec bionic -- snap set core experimental.robust-mount-namespace-updates=true
+execute: |
+    # first command is done twice due to https://bugs.launchpad.net/snapd/+bug/1865503
+    lxc exec bionic -- snap install maas --channel=2.7/edge
+    lxc exec bionic -- snap install maas --channel=2.7/edge
+    lxc exec bionic -- snap remove maas
+restore: |
+    lxc stop --force bionic
+    lxc delete bionic
+    snap remove --purge lxd
+    lxd-tool undo-lxd-mount-changes
+debug: |
+    lxc exec bionic -- bash -c "SNAPD_DEBUG=1 /usr/lib/snapd/snap-update-ns maas"


### PR DESCRIPTION
Surprisingly, unlink/remove can return EROFS when the file being removed
is a bind mount from writable filesystem onto a read-only filesystem.
This was not handled by snap-update-ns logic before.

The case was reported by the MAAS team, many thanks for their reliable
reproduction instructions.

Fixes: https://bugs.launchpad.net/snapd/+bug/1867752
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
