### PR TITLE
tests: cleanup various uc20 boot tests from previous PR

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -150,6 +150,11 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	if len(recoverySystems) > 1 {
 		return fmt.Errorf("cannot make multiple recovery systems bootable yet")
 	}
+
+	if bootWith.RecoverySystemLabel == "" {
+		return fmt.Errorf("internal error: recovery system label unset")
+	}
+
 	opts := &bootloader.Options{
 		PrepareImageTime: true,
 		// setup the recovery bootloader
@@ -167,10 +172,6 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 		return fmt.Errorf("internal error: cannot find bootloader: %v", err)
 	}
 
-	if bootWith.RecoverySystemLabel == "" {
-		return fmt.Errorf("internal error: recovery system label unset")
-	}
-
 	// record which recovery system is to be used on the bootloader, note that
 	// this goes on the main bootloader, and not on the recovery system 
 	// bootloader, for example for grub bootloader, this env var is set on 
@@ -180,7 +181,7 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 		"snapd_recovery_system": bootWith.RecoverySystemLabel,
 	}
 	if err := bl.SetBootVars(blVars); err != nil {
-		return fmt.Errorf("cannot set system environment: %v", err)
+		return fmt.Errorf("cannot set recovery environment: %v", err)
 	}
 
 	// on e.g. ARM we need to extract the kernel assets on the recovery
@@ -202,9 +203,6 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 			return fmt.Errorf("cannot extract recovery system kernel assets: %v", err)
 		}
 
-		if err := bl.SetBootVars(blVars); err != nil {
-			return fmt.Errorf("cannot set system environment: %v", err)
-		}
 		return nil
 	}
 
@@ -315,7 +313,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		"snapd_recovery_mode": "run",
 	}
 	if err := bl.SetBootVars(blVars); err != nil {
-		return fmt.Errorf("cannot set recovery system environment: %v", err)
+		return fmt.Errorf("cannot set recovery environment: %v", err)
 	}
 	return nil
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -157,12 +157,26 @@ type makeBootable20Suite struct {
 	bootloader *bootloadertest.MockRecoveryAwareBootloader
 }
 
+type makeBootable20UbootSuite struct {
+	baseBootenvSuite
+
+	bootloader *bootloadertest.MockExtractedRecoveryKernelImageBootloader
+}
+
 var _ = Suite(&makeBootable20Suite{})
+var _ = Suite(&makeBootable20UbootSuite{})
 
 func (s *makeBootable20Suite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir()).RecoveryAware()
+	s.forceBootloader(s.bootloader)
+}
+
+func (s *makeBootable20UbootSuite) SetUpTest(c *C) {
+	s.baseBootenvSuite.SetUpTest(c)
+
+	s.bootloader = bootloadertest.Mock("mock", c.MkDir()).ExtractedRecoveryKernelImage()
 	s.forceBootloader(s.bootloader)
 }
 
@@ -373,4 +387,73 @@ recovery_system=20191216
 base=core20_3.snap
 current_kernels=pc-kernel_5.snap
 `)
+}
+
+func (s *makeBootable20UbootSuite) TestUbootMakeBootable20(c *C) {
+	dirs.SetRootDir("")
+
+	model := makeMockUC20Model()
+
+	unpackedGadgetDir := c.MkDir()
+	ubootEnv := []byte("#uboot env")
+	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), ubootEnv, 0644)
+	c.Assert(err, IsNil)
+
+	rootdir := c.MkDir()
+	// on uc20 the seed layout if different
+	seedSnapsDirs := filepath.Join(rootdir, "/snaps")
+	err = os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
+
+	baseFn, baseInfo := makeSnap(c, "core20", `name: core20
+type: base
+version: 5.0
+`, snap.R(3))
+	baseInSeed := filepath.Join(seedSnapsDirs, baseInfo.Filename())
+	err = os.Rename(baseFn, baseInSeed)
+	c.Assert(err, IsNil)
+	kernelFn, kernelInfo := makeSnapWithFiles(c, "arm-kernel", `name: arm-kernel
+type: kernel
+version: 5.0
+`, snap.R(5), [][]string{
+		{"kernel.img", "I'm a kernel"},
+		{"initrd.img", "...and I'm an initrd"},
+		{"dtbs/foo.dtb", "foo dtb"},
+		{"dtbs/bar.dto", "bar dtbo"},
+	})
+	kernelInSeed := filepath.Join(seedSnapsDirs, kernelInfo.Filename())
+	err = os.Rename(kernelFn, kernelInSeed)
+	c.Assert(err, IsNil)
+
+	recoverySystemDir := "/systems/20191209"
+	bootWith := &boot.BootableSet{
+		Base:              baseInfo,
+		BasePath:          baseInSeed,
+		Kernel:            kernelInfo,
+		KernelPath:        kernelInSeed,
+		RecoverySystemDir: recoverySystemDir,
+		UnpackedGadgetDir: unpackedGadgetDir,
+		Recovery:          true,
+	}
+
+	err = boot.MakeBootable(model, rootdir, bootWith)
+	c.Assert(err, IsNil)
+
+	// ensure only a single file got copied (the uboot.env)
+	files, err := filepath.Glob(filepath.Join(rootdir, "boot/uboot/*"))
+	c.Assert(err, IsNil)
+	c.Check(files, HasLen, 1)
+	// check that the recovery bootloader configuration was copied with
+	// the correct content
+	c.Check(filepath.Join(rootdir, "boot/uboot/uboot.env"), testutil.FileEquals, ubootEnv)
+
+	// ensure the correct recovery system configuration was set
+	c.Check(
+		s.bootloader.ExtractRecoveryKernelAssetsCalls,
+		DeepEquals,
+		[]bootloadertest.ExtractedRecoveryKernelCall{{
+			RecoverySystemDir: recoverySystemDir,
+			S:                 kernelInfo,
+		}},
+	)
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -281,7 +281,7 @@ version: 5.0
 	})
 }
 
-func (s *makeBootable20Suite) TestMakeBootable20MultipleRecoverySystemsError(c *C) {
+func (s *makeBootable20Suite) TestMakeBootable20UnsetRecoverySystemLabelError(c *C) {
 	dirs.SetRootDir("")
 
 	model := makeMockUC20Model()
@@ -308,7 +308,7 @@ func (s *makeBootable20Suite) TestMakeBootable20MultipleRecoverySystemsError(c *
 	c.Assert(err, ErrorMatches, "internal error: recovery system label unset")
 }
 
-func (s *makeBootable20Suite) TestMakeBootable20UnsetRecoverySystemLabelError(c *C) {
+func (s *makeBootable20Suite) TestMakeBootable20MultipleRecoverySystemsError(c *C) {
 	dirs.SetRootDir("")
 
 	model := makeMockUC20Model()
@@ -480,6 +480,10 @@ version: 5.0
 	// check that the recovery bootloader configuration was copied with
 	// the correct content
 	c.Check(filepath.Join(rootdir, "boot/uboot/uboot.env"), testutil.FileEquals, ubootEnv)
+
+	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
+		"snapd_recovery_system": label,
+	})
 
 	// ensure the correct recovery system configuration was set
 	c.Check(

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -244,15 +244,17 @@ version: 5.0
 	err = os.Rename(kernelFn, kernelInSeed)
 	c.Assert(err, IsNil)
 
-	recoverySystemDir := "/systems/20191209"
+	label := "20191209"
+	recoverySystemDir := filepath.Join("/systems", label)
 	bootWith := &boot.BootableSet{
-		Base:              baseInfo,
-		BasePath:          baseInSeed,
-		Kernel:            kernelInfo,
-		KernelPath:        kernelInSeed,
-		RecoverySystemDir: recoverySystemDir,
-		UnpackedGadgetDir: unpackedGadgetDir,
-		Recovery:          true,
+		Base:                baseInfo,
+		BasePath:            baseInSeed,
+		Kernel:              kernelInfo,
+		KernelPath:          kernelInSeed,
+		RecoverySystemDir:   recoverySystemDir,
+		RecoverySystemLabel: label,
+		UnpackedGadgetDir:   unpackedGadgetDir,
+		Recovery:            true,
 	}
 
 	err = boot.MakeBootable(model, rootdir, bootWith)
@@ -274,9 +276,39 @@ version: 5.0
 	c.Check(s.bootloader.RecoverySystemBootVars, DeepEquals, map[string]string{
 		"snapd_recovery_kernel": "/snaps/pc-kernel_5.snap",
 	})
+	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
+		"snapd_recovery_system": label,
+	})
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20MultipleRecoverySystemsError(c *C) {
+	dirs.SetRootDir("")
+
+	model := makeMockUC20Model()
+
+	unpackedGadgetDir := c.MkDir()
+	grubRecoveryCfg := []byte("#grub-recovery cfg")
+	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub-recovery.conf"), grubRecoveryCfg, 0644)
+	c.Assert(err, IsNil)
+	grubCfg := []byte("#grub cfg")
+	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
+	c.Assert(err, IsNil)
+
+	rootdir := c.MkDir()
+
+	label := "20191209"
+	recoverySystemDir := filepath.Join("/systems", label)
+	bootWith := &boot.BootableSet{
+		RecoverySystemDir: recoverySystemDir,
+		UnpackedGadgetDir: unpackedGadgetDir,
+		Recovery:          true,
+	}
+
+	err = boot.MakeBootable(model, rootdir, bootWith)
+	c.Assert(err, ErrorMatches, "internal error: recovery system label unset")
+}
+
+func (s *makeBootable20Suite) TestMakeBootable20UnsetRecoverySystemLabelError(c *C) {
 	dirs.SetRootDir("")
 
 	model := makeMockUC20Model()
@@ -425,15 +457,17 @@ version: 5.0
 	err = os.Rename(kernelFn, kernelInSeed)
 	c.Assert(err, IsNil)
 
-	recoverySystemDir := "/systems/20191209"
+	label := "20191209"
+	recoverySystemDir := filepath.Join("/systems", label)
 	bootWith := &boot.BootableSet{
-		Base:              baseInfo,
-		BasePath:          baseInSeed,
-		Kernel:            kernelInfo,
-		KernelPath:        kernelInSeed,
-		RecoverySystemDir: recoverySystemDir,
-		UnpackedGadgetDir: unpackedGadgetDir,
-		Recovery:          true,
+		Base:                baseInfo,
+		BasePath:            baseInSeed,
+		Kernel:              kernelInfo,
+		KernelPath:          kernelInSeed,
+		RecoverySystemDir:   recoverySystemDir,
+		RecoverySystemLabel: label,
+		UnpackedGadgetDir:   unpackedGadgetDir,
+		Recovery:            true,
 	}
 
 	err = boot.MakeBootable(model, rootdir, bootWith)

--- a/data/systemd/snapd.core-fixup.sh
+++ b/data/systemd/snapd.core-fixup.sh
@@ -11,7 +11,7 @@ if ! grep -q "ID=ubuntu-core" /etc/os-release; then
     exit 0
 fi
 
-# No fixe-ups yet on UC20
+# No fix-ups yet on UC20
 if grep -q snapd_recovery_mode= /proc/cmdline; then
     exit 0
 fi

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2458,6 +2458,9 @@ func (s *imageSuite) TestSetupSeedCore20(c *C) {
 	c.Check(bl.RecoverySystemBootVars, DeepEquals, map[string]string{
 		"snapd_recovery_kernel": "/snaps/pc-kernel_1.snap",
 	})
+	c.Check(bl.BootVars, DeepEquals, map[string]string{
+		"snapd_recovery_system": filepath.Base(systems[0]),
+	})
 
 	// check the downloads
 	c.Check(s.storeActions, HasLen, 5)

--- a/tests/main/prepare-image-uboot-uc20/task.yaml
+++ b/tests/main/prepare-image-uboot-uc20/task.yaml
@@ -60,7 +60,7 @@ execute: |
 
     echo Running prepare-image as a user
     # TODO:UC20: remove --snap pi_20 once the gadget has been published
-    session-tool -u test "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap $ROOT/pi_20-1_arm64.snap $ROOT/model.assertion $ROOT"
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap $ROOT/pi_20-1_arm64.snap $ROOT/model.assertion $ROOT" test
 
     systemid="$(date +%Y%m%d)"
 

--- a/tests/main/prepare-image-uboot-uc20/task.yaml
+++ b/tests/main/prepare-image-uboot-uc20/task.yaml
@@ -60,7 +60,7 @@ execute: |
 
     echo Running prepare-image as a user
     # TODO:UC20: remove --snap pi_20 once the gadget has been published
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap $ROOT/pi_20-1_arm64.snap $ROOT/model.assertion $ROOT" test
+    session-tool -u test "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap $ROOT/pi_20-1_arm64.snap $ROOT/model.assertion $ROOT"
 
     systemid="$(date +%Y%m%d)"
 


### PR DESCRIPTION
This adds a unit test requested in https://github.com/snapcore/snapd/pull/8228 and refactors how the uc20 uboot image test mocks a uboot bootloader by using bootloader types in bootloadertest to match what we are doing for the other types of mock bootloader.

Also fix a typo.