### PR TITLE
run-checks: tweak formatting checks

### DIFF
--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -750,14 +750,14 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 	// connecting with these interfaces needs to be allowed on
 	// case-by-case basis
 	noconnect := map[string]bool{
-		"content":                   true,
-		"docker":                    true,
-		"fwupd":                     true,
-		"location-control":          true,
-		"location-observe":          true,
-		"lxd":                       true,
-		"maliit":                    true,
-		"mir":                       true,
+		"content":          true,
+		"docker":           true,
+		"fwupd":            true,
+		"location-control": true,
+		"location-observe": true,
+		"lxd":              true,
+		"maliit":           true,
+		"mir":              true,
 		"online-accounts-service":   true,
 		"raw-volume":                true,
 		"storage-framework-service": true,

--- a/run-checks
+++ b/run-checks
@@ -158,8 +158,10 @@ if [ "$STATIC" = 1 ]; then
     if [ -z "${SKIP_GOFMT:-}" ]; then
         echo Checking formatting
         fmt=""
-        for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
-            s="$(${GOFMT:-gofmt} -s -l -d "$dir" | grep -v /vendor/ || true)"
+        for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' | grep -E 'snapd/[A-Za-z0-9_]+$' ); do
+            # skip vendor packages
+            # skip subpackages of packages under snapd, gofmt already inspects them
+            s="$(${GOFMT:-gofmt} -s -l -d "$dir" || true)"
             if [ -n "$s" ]; then
                 fmt="$s\\n$fmt"
             fi

--- a/run-checks
+++ b/run-checks
@@ -169,6 +169,7 @@ if [ "$STATIC" = 1 ]; then
         if [ -n "$fmt" ]; then
             echo "Formatting wrong in following files:"
             echo "$fmt" | sed -e 's/\\n/\n/g'
+            exit 1
         fi
     fi
 


### PR DESCRIPTION
Gofmt already traverses the subpackages inside the package it was called for.
Thus, when a formatting issue is present in a nested package, the error output
we show will contain multiple copies of the same 'diff' section, because the
formatting got reported at each nesting level.

Also, restore error exit when code is not formatted correctly.