### PR TITLE
packaging,tests: ensure debian-sid builds without vendor/

### DIFF
--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -139,6 +139,9 @@ override_dh_auto_build:
 	# Build golang bits
 	mkdir -p _build/src/$(DH_GOPKG)/cmd/snap/test-data
 	cp -a cmd/snap/test-data/*.gpg _build/src/$(DH_GOPKG)/cmd/snap/test-data/
+	# exclude certain parts that won't be used by debian
+	rm -rf _build/src/$(DH_GOPKG)/cmd/snap-bootstrap
+	# and build
 	dh_auto_build -- $(BUILDFLAGS) $(TAGS) $(GCCGOFLAGS)
 
 	# (static linking on powerpc with cgo is broken)

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -74,6 +74,11 @@ build_deb(){
     # Use fake version to ensure we are always bigger than anything else
     dch --newversion "1337.$(dpkg-parsechangelog --show-field Version)" "testing build"
 
+    if [[ "$SPREAD_SYSTEM" == debian-sid-* ]]; then
+        # ensure we really build without vendored packages
+        rm -rf vendor/*/*
+    fi
+
     su -l -c "cd $PWD && DEB_BUILD_OPTIONS='nocheck testkeys' dpkg-buildpackage -tc -b -Zgzip" test
     # put our debs to a safe place
     cp ../*.deb "$GOHOME"


### PR DESCRIPTION
The debian-sid packaging does not currently build in a pristine
sbuild environment. The nightly suite did catch this but we did
not pay attention.

This commit fixes the first issue and removes the vendor/ content
when building the debian package in debian-sid. It also updates
the packaging to exclude the "snap-bootstrap" binary which contains
code that needs a vendored package. But snap-bootstrap is not used
in debian (and never will be) so that's fine.
