### PR TITLE
travis.yml: run unit tests on master as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,21 @@ matrix:
         - set -e
         - ./run-checks --static
         - ./run-checks --short-unit
+    # XXX: why does travis not support go: ["1.9.x", "master"] here?
+    #      this would avoid this ugly copy
+    - stage: quick
+      name: go master/xenial static and unit test suites
+      dist: xenial
+      go: "master"
+      before_install:
+        - sudo apt --quiet -o Dpkg::Progress-Fancy=false update
+      install:
+        - sudo apt --quiet -o Dpkg::Progress-Fancy=false build-dep snapd
+        - ./get-deps.sh
+      script:
+        - set -e
+        - ./run-checks --static
+        - ./run-checks --short-unit
     - stage: quick
       go: "1.10.x"
       name: OSX build and minimal runtime sanity check

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -103,7 +103,7 @@ func (cs *clientSuite) Do(req *http.Request) (*http.Response, error) {
 func (cs *clientSuite) TestNewPanics(c *C) {
 	c.Assert(func() {
 		client.New(&client.Config{BaseURL: ":"})
-	}, PanicMatches, `cannot parse server base URL: ":" \(parse :: missing protocol scheme\)`)
+	}, PanicMatches, `cannot parse server base URL: ":" \(parse \"?:\"?: missing protocol scheme\)`)
 }
 
 func (cs *clientSuite) TestClientDoReportsErrors(c *C) {

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -2824,7 +2824,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithAvoidedTrespassing(c *C) {
 
 // Change.Perform handles unknown actions.
 func (s *changeSuite) TestPerformUnknownAction(c *C) {
-	chg := &update.Change{Action: update.Action(42)}
+	chg := &update.Change{Action: update.Action("42")}
 	synth, err := chg.Perform(s.as)
 	c.Assert(err, ErrorMatches, `cannot process mount change: unknown action: .*`)
 	c.Assert(synth, HasLen, 0)

--- a/httputil/retry_test.go
+++ b/httputil/retry_test.go
@@ -144,7 +144,7 @@ func (s *retrySuite) TestRetryRequestFailWithEOF(c *C) {
 
 	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
 	c.Assert(err, NotNil)
-	c.Check(err, ErrorMatches, `^Get http://127.0.0.1:.*?: EOF$`)
+	c.Check(err, ErrorMatches, `^Get \"?http://127.0.0.1:.*?\"?: EOF$`)
 
 	c.Check(failure, Equals, false)
 	c.Assert(n.Count(), Equals, 5)

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -1535,7 +1535,7 @@ func (s *deviceMgrSerialSuite) TestNewEnoughProxy(c *C) {
 	defer os.Unsetenv("SNAPD_DEBUG")
 
 	expecteds := []string{
-		`Head http://\S+: EOF`,
+		`Head \"?http://\S+\"?: EOF`,
 		`Head request returned 403 Forbidden.`,
 		`Bogus Snap-Store-Version header "5pre1".`,
 		``,

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -114,7 +114,7 @@ func (suite *configTestSuite) TestSetBaseURLStoreURLBadEnviron(c *C) {
 
 	cfg := store.DefaultConfig()
 	err := cfg.SetBaseURL(store.ApiURL())
-	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_API_URL: parse ://example.com: missing protocol scheme")
+	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_API_URL: parse \"?://example.com\"?: missing protocol scheme")
 }
 
 func (suite *configTestSuite) TestSetBaseURLAssertsOverrides(c *C) {
@@ -135,7 +135,7 @@ func (suite *configTestSuite) TestSetBaseURLAssertsURLBadEnviron(c *C) {
 
 	cfg := store.DefaultConfig()
 	err := cfg.SetBaseURL(store.ApiURL())
-	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_SAS_URL: parse ://example.com: missing protocol scheme")
+	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_SAS_URL: parse \"?://example.com\"?: missing protocol scheme")
 }
 
 const (
@@ -3518,14 +3518,14 @@ func (s *storeTestSuite) TestStoreURLBadEnvironAPI(c *C) {
 	c.Assert(os.Setenv("SNAPPY_FORCE_API_URL", "://force-api.local/"), IsNil)
 	defer os.Setenv("SNAPPY_FORCE_API_URL", "")
 	_, err := store.StoreURL(store.ApiURL())
-	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_API_URL: parse ://force-api.local/: missing protocol scheme")
+	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_API_URL: parse \"?://force-api.local/\"?: missing protocol scheme")
 }
 
 func (s *storeTestSuite) TestStoreURLBadEnvironCPI(c *C) {
 	c.Assert(os.Setenv("SNAPPY_FORCE_CPI_URL", "://force-cpi.local/api/v1/"), IsNil)
 	defer os.Setenv("SNAPPY_FORCE_CPI_URL", "")
 	_, err := store.StoreURL(store.ApiURL())
-	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_CPI_URL: parse ://force-cpi.local/: missing protocol scheme")
+	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_CPI_URL: parse \"?://force-cpi.local/\"?: missing protocol scheme")
 }
 
 func (s *storeTestSuite) TestStoreDeveloperURLDependsOnEnviron(c *C) {

--- a/usersession/agent/session_agent_test.go
+++ b/usersession/agent/session_agent_test.go
@@ -158,7 +158,7 @@ func (s *sessionAgentSuite) TestConnectFromOtherUser(c *C) {
 
 	_, err = s.client.Get("http://localhost/v1/session-info")
 	// This could be an EOF error or a failed read, depending on timing
-	c.Assert(err, ErrorMatches, "Get http://localhost/v1/session-info: .*")
+	c.Assert(err, ErrorMatches, "Get \"?http://localhost/v1/session-info\"?: .*")
 	logger.WithLoggerLock(func() {
 		c.Check(logbuf.String(), testutil.Contains, "Blocking request from user ID")
 	})
@@ -200,7 +200,7 @@ func (s *sessionAgentSuite) TestConnectWithFailedPeerCredentials(c *C) {
 	defer sa.Stop()
 
 	_, err = s.client.Get("http://localhost/v1/session-info")
-	c.Assert(err, ErrorMatches, "Get http://localhost/v1/session-info: .*")
+	c.Assert(err, ErrorMatches, "Get \"?http://localhost/v1/session-info\"?: .*")
 	logger.WithLoggerLock(func() {
 		c.Check(logbuf.String(), testutil.Contains, "Failed to retrieve peer credentials: SO_PEERCRED failed")
 	})

--- a/usersession/client/client_test.go
+++ b/usersession/client/client_test.go
@@ -126,7 +126,7 @@ func (s *clientSuite) TestAgentTimeout(c *C) {
 
 	// An error is reported, and we receive information about the
 	// agent that replied on time.
-	c.Assert(err, ErrorMatches, `Get http://1000/v1/session-info: context deadline exceeded`)
+	c.Assert(err, ErrorMatches, `Get \"?http://1000/v1/session-info\"?: context deadline exceeded`)
 	c.Check(si, DeepEquals, map[int]client.SessionInfo{
 		42: {Version: "42"},
 	})


### PR DESCRIPTION
The unit tests of snapd are broken currently for golang-1.14. This
was observed on debian-sid. We did not catch this. To ensure we
get an early warning about failures with the latest go this PR
adds "master" to the go versions to run the unit tests against.

This commit also fixes the broken tests with 1.14
