### PR TITLE
packaging: add README.source for debian

### DIFF
--- a/packaging/debian-sid/README.Source
+++ b/packaging/debian-sid/README.Source
@@ -2,7 +2,7 @@
 
 The packaging is maintained in the upstream git repo at
 
-   github.com/snapcore/snapd:packaging/debian-sid
+github.com/snapcore/snapd in the packaging/debian-sid dir
 
 Please push any debian changes back there to make packaging
 easier.

--- a/packaging/debian-sid/README.Source
+++ b/packaging/debian-sid/README.Source
@@ -1,0 +1,35 @@
+# Overview
+
+The packaging is maintained in the upstream git repo at
+
+   github.com/snapcore/snapd:packaging/debian-sid
+
+Please push any debian changes back there to make packaging
+easier.
+
+## Release a new version
+
+To release a new upstream version the following steps are
+recommended:
+
+    # one time setup
+    $ git clone git@salsa.debian.org:debian/snapd
+    $ cd snapd
+    $ git remote add upstream https://github.com/snapcore/snapd
+
+    # releasing a new version
+    $ git fetch upstream
+    $ git merge upstream/<tag> # e.g. upstream/2.44
+    $ cp -ar packaging/debian-sid/* debian/
+    # ensure to git add any new files
+    # set debian/changelog to UNRELEASED
+    $ git commit -a -m 'debian: sync packaging changes from upstream'
+    # update changelog
+    $ debcommit -ar
+    $ gbp buildpackage -S -d
+    # testbuild
+    $ pbuilder-dist sid update
+    $ pbuilder-dist sid build  ../build-area/snapd_<version>.dsc
+    $ dput ftp-master ../build-area/snapd_<version>_source.changes
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>, Wed, 18 Mar 2020 13:11:03 +0100


### PR DESCRIPTION
This commit describes the workflow of building the debian packages
from the upstream git repo.
