### PR TITLE
seed: make Brand() part of the Seed interface

### DIFF
--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -216,6 +216,17 @@ func (fs *Fake16Seed) Model() (*asserts.Model, error) {
 	return fs.AssertsModel, nil
 }
 
+func (fs *Fake16Seed) Brand() (*asserts.Account, error) {
+	headers := map[string]interface{}{
+		"type":         "account",
+		"account-id":   "brand",
+		"display-name": "fake brand",
+		"username":     "brand",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}
+	return assertstest.FakeAssertion(headers, nil).(*asserts.Account), nil
+}
+
 func (fs *Fake16Seed) LoadMeta(tm timings.Measurer) error {
 	return fs.LoadMetaErr
 }

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -139,3 +139,17 @@ func essentialSnapTypesToModelFilter(essentialTypes []snap.Type) func(modSnap *a
 		return m[modSnap.SnapType]
 	}
 }
+
+func findBrand(seed Seed, db asserts.RODatabase) (*asserts.Account, error) {
+	model, err := seed.Model()
+	if err != nil {
+		return nil, err
+	}
+	a, err := db.Find(asserts.AccountType, map[string]string{
+		"account-id": model.BrandID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("internal error: %v", err)
+	}
+	return a.(*asserts.Account), nil
+}

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -77,6 +77,10 @@ type Seed interface {
 	// error to call Model before LoadAssertions.
 	Model() (*asserts.Model, error)
 
+	// Brand returns the brand information of the seed. It is an
+	// error to call Brand before LoadAssertions.
+	Brand() (*asserts.Account, error)
+
 	// LoadMeta loads the seed and seed's snaps metadata while
 	// verifying the underlying snaps against assertions. It can
 	// return ErrNoMeta if there is no metadata nor snaps in the

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -113,16 +113,7 @@ func (s *seed16) Model() (*asserts.Model, error) {
 }
 
 func (s *seed16) Brand() (*asserts.Account, error) {
-	if s.model == nil {
-		return nil, fmt.Errorf("internal error: cannot query brand with model assertion unset")
-	}
-	a, err := s.db.Find(asserts.AccountType, map[string]string{
-		"account-id": s.model.BrandID(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot find brand account assertion: %v", err)
-	}
-	return a.(*asserts.Account), nil
+	return findBrand(s, s.db)
 }
 
 func (s *seed16) addSnap(sn *internal.Snap16, pinnedTrack string, tm timings.Measurer) (*Snap, error) {

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -204,7 +204,7 @@ func (s *seed16Suite) TestSkippedLoadAssertion(c *C) {
 	c.Check(err, ErrorMatches, "internal error: model assertion unset")
 
 	_, err = s.seed16.Brand()
-	c.Check(err, ErrorMatches, "internal error: brand account assertion unset")
+	c.Check(err, ErrorMatches, "internal error: cannot query brand with model assertion unset")
 }
 
 func (s *seed16Suite) TestLoadMetaNoMeta(c *C) {

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -189,6 +189,11 @@ func (s *seed16Suite) TestLoadAssertionsModelTempDBHappy(c *C) {
 	model, err := s.seed16.Model()
 	c.Assert(err, IsNil)
 	c.Check(model.Model(), Equals, "my-model")
+
+	brand, err := s.seed16.Brand()
+	c.Assert(err, IsNil)
+	c.Check(brand.AccountID(), Equals, "my-brand")
+	c.Check(brand.DisplayName(), Equals, "My-brand")
 }
 
 func (s *seed16Suite) TestSkippedLoadAssertion(c *C) {
@@ -197,6 +202,9 @@ func (s *seed16Suite) TestSkippedLoadAssertion(c *C) {
 
 	err = s.seed16.LoadMeta(s.perfTimings)
 	c.Check(err, ErrorMatches, "internal error: model assertion unset")
+
+	_, err = s.seed16.Brand()
+	c.Check(err, ErrorMatches, "internal error: brand account assertion unset")
 }
 
 func (s *seed16Suite) TestLoadMetaNoMeta(c *C) {

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -204,7 +204,7 @@ func (s *seed16Suite) TestSkippedLoadAssertion(c *C) {
 	c.Check(err, ErrorMatches, "internal error: model assertion unset")
 
 	_, err = s.seed16.Brand()
-	c.Check(err, ErrorMatches, "internal error: cannot query brand with model assertion unset")
+	c.Check(err, ErrorMatches, "internal error: model assertion unset")
 }
 
 func (s *seed16Suite) TestLoadMetaNoMeta(c *C) {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -185,16 +185,7 @@ func (s *seed20) Model() (*asserts.Model, error) {
 }
 
 func (s *seed20) Brand() (*asserts.Account, error) {
-	if s.model == nil {
-		return nil, fmt.Errorf("internal error: cannot query brand with model assertion unset")
-	}
-	a, err := s.db.Find(asserts.AccountType, map[string]string{
-		"account-id": s.model.BrandID(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot find brand account assertion: %v", err)
-	}
-	return a.(*asserts.Account), nil
+	return findBrand(s, s.db)
 }
 
 func (s *seed20) UsesSnapdSnap() bool {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -52,7 +52,6 @@ type seed20 struct {
 	db asserts.RODatabase
 
 	model *asserts.Model
-	brand *asserts.Account
 
 	snapDeclsByID   map[string]*asserts.SnapDeclaration
 	snapDeclsByName map[string]*asserts.SnapDeclaration
@@ -84,7 +83,6 @@ func (s *seed20) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Ba
 	// collect assertions that are not the model
 	var declRefs []*asserts.Ref
 	var revRefs []*asserts.Ref
-	var acctRefs []*asserts.Ref
 	checkAssertion := func(ref *asserts.Ref) error {
 		switch ref.Type {
 		case asserts.ModelType:
@@ -93,8 +91,6 @@ func (s *seed20) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Ba
 			declRefs = append(declRefs, ref)
 		case asserts.SnapRevisionType:
 			revRefs = append(revRefs, ref)
-		case asserts.AccountType:
-			acctRefs = append(acctRefs, ref)
 		}
 		return nil
 	}
@@ -170,24 +166,10 @@ func (s *seed20) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Ba
 		}
 	}
 
-	var brandAssertion *asserts.Account
-	for _, acctRef := range acctRefs {
-		a, err := find(acctRef)
-		if err != nil {
-			return err
-		}
-		acctAssertion := a.(*asserts.Account)
-		if acctAssertion.AccountID() == modelAssertion.BrandID() {
-			brandAssertion = acctAssertion
-			break
-		}
-	}
-
 	// remember db for later use
 	s.db = db
 	// remember
 	s.model = modelAssertion
-	s.brand = brandAssertion
 	s.snapDeclsByID = snapDeclsByID
 	s.snapDeclsByName = snapDeclsByName
 	s.snapRevsByID = snapRevsByID
@@ -203,10 +185,16 @@ func (s *seed20) Model() (*asserts.Model, error) {
 }
 
 func (s *seed20) Brand() (*asserts.Account, error) {
-	if s.brand == nil {
-		return nil, fmt.Errorf("internal error: brand account assertion unset")
+	if s.model == nil {
+		return nil, fmt.Errorf("internal error: cannot query brand with model assertion unset")
 	}
-	return s.brand, nil
+	a, err := s.db.Find(asserts.AccountType, map[string]string{
+		"account-id": s.model.BrandID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot find brand account assertion: %v", err)
+	}
+	return a.(*asserts.Account), nil
 }
 
 func (s *seed20) UsesSnapdSnap() bool {

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -217,6 +217,11 @@ func (s *seed20Suite) TestLoadAssertionsModelTempDBHappy(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(model.Model(), Equals, "my-model")
 	c.Check(model.Base(), Equals, "core20")
+
+	brand, err := seed20.Brand()
+	c.Assert(err, IsNil)
+	c.Check(brand.AccountID(), Equals, "my-brand")
+	c.Check(brand.DisplayName(), Equals, "My-brand")
 }
 
 func (s *seed20Suite) TestLoadAssertionsMultiModels(c *C) {


### PR DESCRIPTION
In preparation for returning the list of seed systems from device manager, extend the seed.Seed interface to return the brand information of the model.
