### PR TITLE
devicestate,sysconfig: support "cloud.cfg.d" in uc20 for grade: dangerous

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -394,7 +394,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
 
 	// and sysconfig.ConfigureRunSystem was run exactly once
 	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
-		&sysconfig.Options{},
+		{},
 	})
 }
 
@@ -411,7 +411,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfigErr(c *C) {
 - Setup system for run mode \(error from sysconfig.ConfigureRunSystem\)`)
 	// and sysconfig.ConfigureRunSystem was run exactly once
 	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
-		&sysconfig.Options{},
+		{},
 	})
 }
 
@@ -429,7 +429,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitInDangerous(
 
 	// and did tell sysconfig about the cloud-init files
 	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
-		&sysconfig.Options{CloudInitSrcDir: filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")},
+		{CloudInitSrcDir: filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")},
 	})
 }
 
@@ -448,6 +448,6 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeNoCloudInitForSigned(c *C) {
 
 	// so no cloud-init src dir is passed
 	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
-		&sysconfig.Options{},
+		{},
 	})
 }

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -417,7 +417,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfigErr(c *C) {
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitInDangerous(c *C) {
 	// pretend we have a cloud-init config on the seed partition
-	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")
+	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/data/etc/cloud/cloud.cfg.d")
 	err := os.MkdirAll(cloudCfg, 0755)
 	c.Assert(err, IsNil)
 	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {
@@ -429,13 +429,13 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitInDangerous(
 
 	// and did tell sysconfig about the cloud-init files
 	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
-		{CloudInitSrcDir: filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")},
+		{CloudInitSrcDir: filepath.Join(dirs.RunMnt, "ubuntu-seed/data/etc/cloud/cloud.cfg.d")},
 	})
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeNoCloudInitForSigned(c *C) {
 	// pretend we have a cloud-init config on the seed partition
-	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")
+	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/data/etc/cloud/cloud.cfg.d")
 	err := os.MkdirAll(cloudCfg, 0755)
 	c.Assert(err, IsNil)
 	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -21,6 +21,7 @@ package devicestate_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -43,6 +44,9 @@ import (
 
 type deviceMgrInstallModeSuite struct {
 	deviceMgrBaseSuite
+
+	configureRunSystemOptsPassed []*sysconfig.Options
+	configureRunSystemErr        error
 }
 
 var _ = Suite(&deviceMgrInstallModeSuite{})
@@ -58,6 +62,14 @@ func (s *deviceMgrInstallModeSuite) findInstallSystem() *state.Change {
 
 func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 	s.deviceMgrBaseSuite.SetUpTest(c)
+
+	s.configureRunSystemOptsPassed = nil
+	s.configureRunSystemErr = nil
+	restore := devicestate.MockSysconfigConfigureRunSystem(func(opts *sysconfig.Options) error {
+		s.configureRunSystemOptsPassed = append(s.configureRunSystemOptsPassed, opts)
+		return s.configureRunSystemErr
+	})
+	s.AddCleanup(restore)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -343,7 +355,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallSecuredBypassEncryption(c *C) {
 	c.Assert(err, ErrorMatches, "(?s).*cannot encrypt secured device: TPM not available.*")
 }
 
-func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
+func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade string) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
@@ -351,17 +363,11 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
 	defer mockSnapBootstrapCmd.Restore()
 
 	s.state.Lock()
-	s.makeMockInstalledPcGadget(c, "dangerous")
+	mockModel := s.makeMockInstalledPcGadget(c, modelGrade)
 	s.state.Unlock()
+	c.Check(mockModel.Grade(), Equals, asserts.ModelGrade(modelGrade))
 
 	restore = devicestate.MockBootMakeBootable(func(model *asserts.Model, rootdir string, bootWith *boot.BootableSet) error {
-		return nil
-	})
-	defer restore()
-
-	configureRunSystemCalls := 0
-	restore = devicestate.MockSysconfigConfigureRunSystem(func(opts *sysconfig.Options) error {
-		configureRunSystemCalls++
 		return nil
 	})
 	defer restore()
@@ -370,6 +376,11 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
 	devicestate.SetRecoverySystem(s.mgr, "20191218")
 
 	s.settle(c)
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
+	s.mockInstallModeChange(c, "dangerous")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -382,36 +393,15 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
 	c.Check(installSystem.Status(), Equals, state.DoneStatus)
 
 	// and sysconfig.ConfigureRunSystem was run exactly once
-	c.Assert(configureRunSystemCalls, Equals, 1)
+	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
+		&sysconfig.Options{},
+	})
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfigErr(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
+	s.configureRunSystemErr = fmt.Errorf("error from sysconfig.ConfigureRunSystem")
+	s.mockInstallModeChange(c, "dangerous")
 
-	mockSnapBootstrapCmd := testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), "")
-	defer mockSnapBootstrapCmd.Restore()
-
-	s.state.Lock()
-	s.makeMockInstalledPcGadget(c, "dangerous")
-	s.state.Unlock()
-
-	restore = devicestate.MockBootMakeBootable(func(model *asserts.Model, rootdir string, bootWith *boot.BootableSet) error {
-		return nil
-	})
-	defer restore()
-
-	configureRunSystemCalls := 0
-	restore = devicestate.MockSysconfigConfigureRunSystem(func(opts *sysconfig.Options) error {
-		configureRunSystemCalls++
-		return fmt.Errorf("error from sysconfig.ConfigureRunSystem")
-	})
-	defer restore()
-
-	devicestate.SetOperatingMode(s.mgr, "install")
-	devicestate.SetRecoverySystem(s.mgr, "20191218")
-
-	s.settle(c)
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -420,5 +410,44 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfigErr(c *C) {
 	c.Check(installSystem.Err(), ErrorMatches, `(?ms)cannot perform the following tasks:
 - Setup system for run mode \(error from sysconfig.ConfigureRunSystem\)`)
 	// and sysconfig.ConfigureRunSystem was run exactly once
-	c.Assert(configureRunSystemCalls, Equals, 1)
+	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
+		&sysconfig.Options{},
+	})
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitInDangerous(c *C) {
+	// pretend we have a cloud-init config on the seed partition
+	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")
+	err := os.MkdirAll(cloudCfg, 0755)
+	c.Assert(err, IsNil)
+	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {
+		err = ioutil.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	s.mockInstallModeChange(c, "dangerous")
+
+	// and did tell sysconfig about the cloud-init files
+	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
+		&sysconfig.Options{CloudInitSrcDir: filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")},
+	})
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeNoCloudInitForSigned(c *C) {
+	// pretend we have a cloud-init config on the seed partition
+	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")
+	err := os.MkdirAll(cloudCfg, 0755)
+	c.Assert(err, IsNil)
+	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {
+		err = ioutil.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	// but it is signed
+	s.mockInstallModeChange(c, "signed")
+
+	// so no cloud-init src dir is passed
+	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
+		&sysconfig.Options{},
+	})
 }

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -57,12 +57,15 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store/storetest"
+	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
 
 func TestDeviceManager(t *testing.T) { TestingT(t) }
 
 type deviceMgrBaseSuite struct {
+	testutil.BaseTest
+
 	o       *overlord.Overlord
 	state   *state.State
 	se      *overlord.StateEngine
@@ -118,6 +121,8 @@ var (
 )
 
 func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
 	dirs.SetRootDir(c.MkDir())
 	os.MkdirAll(dirs.SnapRunDir, 0755)
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -93,7 +93,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 
 	// configure the run system
 	opts := &sysconfig.Options{}
-	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")
+	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/data/etc/cloud/cloud.cfg.d")
 	// Support custom cloud.cfg.d/*.cfg files on the ubuntu-seed partition
 	// during install when in grade "dangerous". We will support configs
 	// from the gadget later too, see sysconfig/cloudinit.go

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -94,6 +94,11 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	// configure the run system
 	opts := &sysconfig.Options{}
 	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")
+	// Support custom cloud.cfg.d/*.cfg files on the ubuntu-seed partition
+	// during install when in grade "dangerous". We will support configs
+	// from the gadget later too, see sysconfig/cloudinit.go
+	//
+	// XXX: maybe move policy decision into configureRunSystem later?
 	if osutil.IsDirectory(cloudCfg) && deviceCtx.Model().Grade() == asserts.ModelDangerous {
 		opts.CloudInitSrcDir = cloudCfg
 	}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -92,7 +92,12 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// configure the run system
-	if err := sysconfigConfigureRunSystem(&sysconfig.Options{}); err != nil {
+	opts := &sysconfig.Options{}
+	cloudCfg := filepath.Join(dirs.RunMnt, "ubuntu-seed/cloud.cfg.d")
+	if osutil.IsDirectory(cloudCfg) && deviceCtx.Model().Grade() == asserts.ModelDangerous {
+		opts.CloudInitSrcDir = cloudCfg
+	}
+	if err := sysconfigConfigureRunSystem(opts); err != nil {
 		return err
 	}
 

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 )
 
 func DisableCloudInit() error {
@@ -41,13 +42,30 @@ func DisableCloudInit() error {
 }
 
 func installCloudInitCfg(src string) error {
-	return fmt.Errorf("installCloudInitCfg not implemented yet")
+	ccl, err := filepath.Glob(filepath.Join(src, "*.cfg"))
+	if err != nil {
+		return err
+	}
+	if len(ccl) == 0 {
+		return nil
+	}
+
+	ubuntuDataCloudCfgDir := filepath.Join(dirs.RunMnt, "ubuntu-data/system-data/etc/cloud/cloud.cfg.d/")
+	if err := os.MkdirAll(ubuntuDataCloudCfgDir, 0755); err != nil {
+		return fmt.Errorf("cannot make cloud config dir: %v", err)
+	}
+
+	for _, cc := range ccl {
+		if err := osutil.CopyFile(cc, filepath.Join(ubuntuDataCloudCfgDir, filepath.Base(cc)), 0); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // disable cloud-init by default (as it's not confined)
-// TODO:UC20: 1. allow drop-in cloud.cfg.d/* in mode dangerous
-//            2. allow gadget cloud.cfg.d/* (with whitelisted keys?)
-//            3. allow cloud.cfg.d (with whitelisted keys) for non
+// TODO:UC20: - allow gadget cloud.cfg.d/* (with whitelisted keys?)
+//            - allow cloud.cfg.d (with whitelisted keys) for non
 //               grade dangerous systems
 func configureCloudInit(opts *Options) (err error) {
 	switch opts.CloudInitSrcDir {


### PR DESCRIPTION
This commit adds support for dropping a cloud.cfg.d data into
the ubuntu-seed partition and have the install mode pick it up
and put it into the right place on the ubuntu-data partition.

Note that this will only work in "grade: dangerous" right now.

This is essentially https://github.com/snapcore/snapd/pull/8234 just
using latest sysconfig.