### PR TITLE
snap-bootstrap: add creationSupported predicate for partition types

### DIFF
--- a/cmd/snap-bootstrap/partition/sfdisk.go
+++ b/cmd/snap-bootstrap/partition/sfdisk.go
@@ -48,6 +48,13 @@ var createdPartitionGUID = []string{
 	"0657FD6D-A4AB-43C4-84E5-0933C84B4F4F", // Linux swap partition
 }
 
+// creationSupported returns whether we support and expect to create partitions
+// of the given type, it also means we are ready to remove them for re-installation
+// or retried installation if they are appropriately marked with createdPartitionAttr.
+func creationSupported(ptype string) bool {
+	return strutil.ListContains(createdPartitionGUID, strings.ToUpper(ptype))
+}
+
 // sfdiskDeviceDump represents the sfdisk --dump JSON output format.
 type sfdiskDeviceDump struct {
 	PartitionTable sfdiskPartitionTable `json:"partitiontable"`
@@ -371,13 +378,6 @@ func listCreatedPartitions(dl *DeviceLayout) []string {
 		}
 	}
 	return created
-}
-
-// creationSupported returns whether we support and expect to create partitions
-// of the given type, it also means we are ready to remove them for re-installation
-// or retried installation if they are appropriately marked with createdPartitionAttr.
-func creationSupported(ptype string) bool {
-	return strutil.ListContains(createdPartitionGUID, strings.ToUpper(ptype))
 }
 
 // udevTrigger triggers udev for the specified device and waits until


### PR DESCRIPTION
Add a small helper function that tells us whether partition creation
or removal is supported for a given partition type. This is a follow-up
to PR #8159.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>