### PR TITLE
tests: umount partitions which are not umounted after remount gadget

### DIFF
--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -8,7 +8,10 @@ debug: |
 
 restore: |
     if [ -f loop.txt ]; then
-        losetup -d "$(cat loop.txt)"
+        LOOP="$(cat loop.txt)"
+        losetup -d "$LOOP"
+        umount "${LOOP}p3"
+        umount "${LOOP}p4"
     fi
 
 prepare: |
@@ -112,4 +115,3 @@ execute: |
 
     echo "Make sure the filesystem was redeployed"
     ls /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
-


### PR DESCRIPTION
Currently when the gadget modified is mounted the partitions
/dev/loop1p3 and /dev/loop1p4 are mounted as well and need to be
removed.

See the message:

/usr/lib/snapd/snap-bootstrap create-partitions --mount ./gadget-dir "$LOOP"
2020/03/20 13:33:03.849540 sfdisk.go:178: partitions to remove:
[/dev/loop1p3 /dev/loop1p4]

Otherwise when re run 2 tests like this the second fails because the
/dev/loop1 is still in use and loop.txt file contains 2 devices:

/dev/loop1
/dev/loop2

Steps to reproduce the error:
spread2 -debug -order -workers 1
google:ubuntu-19.10-64:tests/main/interfaces-desktop-document-portal
google:ubuntu-19.10-64:tests/main/uc20-snap-recovery-autodetect


