### PR TITLE
randutil: ask for less entropy during boot 

### DIFF
--- a/randutil/rand.go
+++ b/randutil/rand.go
@@ -23,21 +23,23 @@
 package randutil
 
 import (
-	cryptorand "crypto/rand"
-	"fmt"
-	"math"
-	"math/big"
+	//cryptorand "crypto/rand"
+	//"fmt"
+	//"math"
+	//"math/big"
 	"math/rand"
+	"os"
 	"time"
 )
 
 func init() {
 	// golang does not init Seed() itself
-	bigSeed, err := cryptorand.Int(cryptorand.Reader, big.NewInt(math.MaxInt64))
+	/*bigSeed, err := cryptorand.Int(cryptorand.Reader, big.NewInt(math.MaxInt64))
 	if err != nil {
 		panic(fmt.Sprintf("cannot obtain random seed: %v", err))
 	}
-	rand.Seed(bigSeed.Int64())
+	rand.Seed(bigSeed.Int64())*/
+	rand.Seed(time.Now().UnixNano() + int64(os.Getpid()))
 }
 
 const letters = "BCDFGHJKLMNPQRSTVWXYbcdfghjklmnpqrstvwxy0123456789"

--- a/randutil/rand_test.go
+++ b/randutil/rand_test.go
@@ -47,6 +47,10 @@ func (s *randutilSuite) TestRandomString(c *C) {
 }
 
 func (s *randutilSuite) TestRandomDuration(c *C) {
+	// ensure higherEntropySeed is done
+	d := randutil.RandomDuration(time.Hour)
+	c.Check(d < time.Hour, Equals, true)
+
 	// for our tests
 	rand.Seed(1)
 


### PR DESCRIPTION
This PR changes randutils to use less entropy during early boot. It now requires only 8 bytes which should be enough to keep all machines from hanging during early boot. 

We may also get a kernel fix, bug filed in https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1868227 but that would be orthogonal.