### PR TITLE
many: fix packages having mistakenly their copyright as doc

### DIFF
--- a/cmd/cmdutil/cmdutil.go
+++ b/cmd/cmdutil/cmdutil.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package cmdutil
 
 import (

--- a/cmd/cmdutil/version.go
+++ b/cmd/cmdutil/version.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package cmdutil
 
 import (

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package bootstrap
 
 import (

--- a/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package bootstrap_test
 
 import (

--- a/cmd/snap-bootstrap/bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/bootstrap/export_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package bootstrap
 
 var (

--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package main
 
 import (

--- a/cmd/snap-bootstrap/partition/deploy.go
+++ b/cmd/snap-bootstrap/partition/deploy.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition
 
 import (

--- a/cmd/snap-bootstrap/partition/deploy_test.go
+++ b/cmd/snap-bootstrap/partition/deploy_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition_test
 
 import (

--- a/cmd/snap-bootstrap/partition/encrypt.go
+++ b/cmd/snap-bootstrap/partition/encrypt.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition
 
 import (

--- a/cmd/snap-bootstrap/partition/encrypt_test.go
+++ b/cmd/snap-bootstrap/partition/encrypt_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition_test
 
 import (

--- a/cmd/snap-bootstrap/partition/export_test.go
+++ b/cmd/snap-bootstrap/partition/export_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition
 
 import (

--- a/cmd/snap-bootstrap/partition/mkfs.go
+++ b/cmd/snap-bootstrap/partition/mkfs.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition
 
 import (

--- a/cmd/snap-bootstrap/partition/mkfs_test.go
+++ b/cmd/snap-bootstrap/partition/mkfs_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition_test
 
 import (

--- a/cmd/snap-bootstrap/partition/partition_test.go
+++ b/cmd/snap-bootstrap/partition/partition_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition_test
 
 import (

--- a/cmd/snap-bootstrap/partition/sfdisk.go
+++ b/cmd/snap-bootstrap/partition/sfdisk.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition
 
 import (

--- a/cmd/snap-bootstrap/partition/sfdisk_test.go
+++ b/cmd/snap-bootstrap/partition/sfdisk_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package partition_test
 
 import (

--- a/gadget/device_darwin.go
+++ b/gadget/device_darwin.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/device_linux.go
+++ b/gadget/device_linux.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/filesystemimage.go
+++ b/gadget/filesystemimage.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/filesystemimage_test.go
+++ b/gadget/filesystemimage_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget_test
 
 import (

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/mkfs.go
+++ b/gadget/mkfs.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget_test
 
 import (

--- a/gadget/offset.go
+++ b/gadget/offset.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/partition.go
+++ b/gadget/partition.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/raw.go
+++ b/gadget/raw.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/raw_test.go
+++ b/gadget/raw_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget_test
 
 import (

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package gadget
 
 import (

--- a/osutil/fshelpers.go
+++ b/osutil/fshelpers.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package osutil
 
 import (

--- a/sandbox/seccomp/compiler.go
+++ b/sandbox/seccomp/compiler.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package seccomp
 
 import (

--- a/sandbox/seccomp/compiler_test.go
+++ b/sandbox/seccomp/compiler_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package seccomp_test
 
 import (

--- a/sandbox/selinux/export_test.go
+++ b/sandbox/selinux/export_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package selinux
 
 import (

--- a/sandbox/selinux/label.go
+++ b/sandbox/selinux/label.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package selinux
 
 // RestoreMode configures how default path context is restored

--- a/sandbox/selinux/label_darwin.go
+++ b/sandbox/selinux/label_darwin.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package selinux
 
 // VerifyPathContext checks whether a given path is labeled according to its default

--- a/sandbox/selinux/label_linux.go
+++ b/sandbox/selinux/label_linux.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package selinux
 
 import (

--- a/sandbox/selinux/label_linux_test.go
+++ b/sandbox/selinux/label_linux_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package selinux_test
 
 import (

--- a/sandbox/selinux/selinux_darwin.go
+++ b/sandbox/selinux/selinux_darwin.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package selinux
 
 // IsEnabled checks whether SELinux is enabled

--- a/sandbox/selinux/selinux_linux.go
+++ b/sandbox/selinux/selinux_linux.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package selinux
 
 import (

--- a/sandbox/selinux/selinux_linux_test.go
+++ b/sandbox/selinux/selinux_linux_test.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package selinux_test
 
 import (


### PR DESCRIPTION
If there's no proper doc comment or blank lines between copyright's
comment block and the package clause we get the copyright as package
doc comment, we do not want that.