### PR TITLE
cmd/snap-failure,tests: try to make snap-failure more robust

### DIFF
--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
@@ -106,6 +107,11 @@ func runCmd(prog string, args []string, env []string) *exec.Cmd {
 	return cmd
 }
 
+var (
+	sampleForActiveInterval = 5 * time.Second
+	restartSnapdCoolOffWait = 12500 * time.Millisecond
+)
+
 // FIXME: also do error reporting via errtracker
 func (c *cmdSnapd) Execute(args []string) error {
 	var snapdPath string
@@ -141,6 +147,23 @@ func (c *cmdSnapd) Execute(args []string) error {
 		return fmt.Errorf("snapd failed: %v", err)
 	}
 
+	isFailedCmd := runCmd("systemctl", []string{"is-failed", "snapd.socket", "snapd.service"}, nil)
+	if err := isFailedCmd.Run(); err != nil {
+		// seems not to be failed anymore, sample for sanely
+		// active for 5 * 5s
+		for i := 0; i < 5; i++ {
+			if i != 0 {
+				time.Sleep(sampleForActiveInterval)
+			}
+			isActiveCmd := runCmd("systemctl", []string{"is-active", "snapd.socket", "snapd.service"}, nil)
+			err := isActiveCmd.Run()
+			if err == nil && osutil.FileExists(dirs.SnapdSocket) && osutil.FileExists(dirs.SnapSocket) {
+				logger.Noticef("snapd is active again, sockets are available, nothing more to do")
+				return nil
+			}
+		}
+	}
+
 	logger.Noticef("restarting snapd socket")
 	// we need to reset the failure state to be able to restart again
 	resetCmd := runCmd("systemctl", []string{"reset-failed", "snapd.socket", "snapd.service"}, nil)
@@ -158,14 +181,24 @@ func (c *cmdSnapd) Execute(args []string) error {
 	// before restarting, otherwise the restart command will fail because the
 	// systemd can't create the file
 	// always remove to avoid TOCTOU issues but don't complain about ENOENT
-	err = os.Remove(dirs.SnapdSocket)
-	if err != nil && !os.IsNotExist(err) {
-		logger.Noticef("snapd socket still exists before restarting socket service, but unable to remove: %v", err)
+	for _, fn := range []string{dirs.SnapdSocket, dirs.SnapSocket} {
+		err = os.Remove(fn)
+		if err != nil && !os.IsNotExist(err) {
+			logger.Noticef("snapd socket %s still exists before restarting socket service, but unable to remove: %v", fn, err)
+		}
 	}
 
 	restartCmd := runCmd("systemctl", []string{"restart", "snapd.socket"}, nil)
 	if err := restartCmd.Run(); err != nil {
 		logger.Noticef("failed to restart snapd.socket: %v", err)
+		// fallback to try snapd itself
+		// wait  more than DefaultStartLimitIntervalSec
+		time.Sleep(restartSnapdCoolOffWait)
+		logger.Noticef("fallback, restarting snapd itself")
+		restartCmd := runCmd("systemctl", []string{"restart", "snapd.service"}, nil)
+		if err := restartCmd.Run(); err != nil {
+			logger.Noticef("failed to restart snapd: %v", err)
+		}
 	}
 
 	return nil

--- a/cmd/snap-failure/export_test.go
+++ b/cmd/snap-failure/export_test.go
@@ -19,7 +19,20 @@
 
 package main
 
+import "time"
+
 var (
 	Run       = run
 	ParseArgs = parseArgs
 )
+
+func MockWaitTimes(sampleForActive, restartSnapdCoolOff time.Duration) (restore func()) {
+	oldSampleForActive := sampleForActiveInterval
+	oldRestartSnapdCoolOff := restartSnapdCoolOffWait
+	sampleForActiveInterval = sampleForActive
+	restartSnapdCoolOffWait = restartSnapdCoolOff
+	return func() {
+		sampleForActiveInterval = oldSampleForActive
+		restartSnapdCoolOffWait = oldRestartSnapdCoolOff
+	}
+}

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -117,10 +117,13 @@ execute: |
             # just because snapd.failure.service is active doesn't mean that we are 
             # fully ready; we should wait until the snap command shows up again
             echo "And verify that snap commands still work and snapd is reverted"
-            retry-tool -n 30 --wait 1 bash -c "snap list | MATCH '^snapd .* $current .*'"
+            retry-tool --maxmins 5.5 bash -c "snap list | MATCH '^snapd .* $current .*'"
 
             echo "Verify we got the expected error message"
             snap change --last=install|MATCH "there was a snapd rollback across the restart"
+
+            echo "Double check the status of snapd.socket"
+            systemctl is-active snapd.socket
 
             echo "restart snapd and ensure we can still talk to it"
             systemctl restart snapd.socket snapd.service

--- a/tests/lib/bin/retry-tool
+++ b/tests/lib/bin/retry-tool
@@ -2,6 +2,7 @@
 from __future__ import print_function, absolute_import, unicode_literals
 
 import argparse
+import itertools
 import subprocess
 import sys
 import time
@@ -41,6 +42,13 @@ attempt. On failure the exit code from the final attempt is returned.
         help="grace period between attempts (default %(default)ss)",
     )
     parser.add_argument(
+        "--maxmins",
+        metavar="MINUTES",
+        type=float,
+        default=0,
+        help="number of minutes after which to give up (no default, if set attempts is ignored)",
+    )
+    parser.add_argument(
         "--quiet",
         dest="verbose",
         action="store_false",
@@ -53,32 +61,46 @@ attempt. On failure the exit code from the final attempt is returned.
     return parser
 
 
-def run_cmd(cmd, n, wait, verbose):
-    # type: (List[Text], int, float, bool) -> int
+def run_cmd(cmd, n, wait, maxmins, verbose):
+    # type: (List[Text], int, float, float, bool) -> int
+    if maxmins != 0:
+        attempts = itertools.count(1)
+        t0 = time.time()
+        after = "{} minutes".format(maxmins)
+        of = ""
+    else:
+        attempts = range(1, n + 1)
+        after = "{} attempts".format(n)
+        of = " of {}".format(n)
     retcode = 0
-    for i in range(1, n + 1):
+    i = 0
+    for i in attempts:
         retcode = subprocess.call(cmd)
         if retcode == 0:
-            break
+            return 0
         if verbose:
             print(
                 "retry: command {} failed with code {}".format(" ".join(cmd), retcode),
                 file=sys.stderr,
             )
-        if i < n:
+        if maxmins != 0:
+            elapsed = (time.time()-t0)/60
+            if elapsed > maxmins:
+                break
+        if i < n or maxmins != 0:
             if verbose:
                 print(
-                    "retry: next attempt in {} second(s) (attempt {} of {})".format(
-                        wait, i, n
+                    "retry: next attempt in {} second(s) (attempt {}{})".format(
+                        wait, i, of
                     ),
                     file=sys.stderr,
                 )
             time.sleep(wait)
-    else:
-        if verbose and n > 1:
-            print(
-                "retry: command {} keeps failing after {} attempts".format(
-                    " ".join(cmd), n
+
+    if verbose and i > 1:
+        print(
+            "retry: command {} keeps failing after {}".format(
+                " ".join(cmd), after
                 ),
                 file=sys.stderr,
             )
@@ -95,7 +117,7 @@ def main():
         parser.exit(0)
     # Return the last exit code as the exit code of this process.
     try:
-        retcode = run_cmd(ns.cmd, ns.attempts, ns.wait, ns.verbose)
+        retcode = run_cmd(ns.cmd, ns.attempts, ns.wait, ns.maxmins, ns.verbose)
     except OSError as exc:
         if ns.verbose:
             print(


### PR DESCRIPTION
AFAICT at least on core 18 the running of the ephemeral SNAPD_REVERT_TO_REV snapd ends with snapd.socket and snapd.service both active (though I have seen at least once them in active, respectively activating state instead), but the sockets unlinked at exit of the ephemeral snapd.

All the rest of snap-failure tries to fix this state, though at least on core 18 reset-failed is a nop, and so removing the sockets.

(I see a recent commit comment that says that the sockets can be around but afaict if that's the case they would come from a managed by systemd snapd.socket/snapd, there is also this comment that says that restarting snapd.socket fails if there are sockets around, that's not the behavior I see, anyway at this point removing the removal code is something we can try later)

Restarting snapd.socket should recreate the sockets and fix the state, but sometimes it fails with:

    snapd.socket: Socket service snapd.service already active, refusing.
    Failed to listen on Socket activation for snappy daemon.

The closest thing I found is: https://github.com/systemd/systemd/issues/13271
but notice there they were trying to restart both service and socket.

Also because from systemd POV snapd.socket is active, restarting snapd.service alone first does not help to fix state.

From my trying it seems though once we are in this snapd.socket failed state again, restarting snapd.service itself restarts snapd.socket and fixes things. So here I added such fallback code to snap-failure.

In a follow-up I want to try to avoid the ephemeral snapd creating the sockets at all. That's why I added code that checks for a healthy state and exits snap-failure earlier, as far as I know that code won't be triggered by older snapd.

TODO: there will still be a race between the ending of ephemeral
snapd and the restarted by it snapd, they are reading/writing the
same state for a bit, we should fix that as soon as possible. We
also want to limit as much as possible any unrelated work by the
ephemeral snapd. In the follow-up I will add TODOs in the code
about these.

TODO: there's also the question of what to do if OnFailure is invoked in a case that is not during a snapd refresh...