### PR TITLE
tests: ensure session agent service is ready in prepare

### DIFF
--- a/tests/main/snap-session-agent-service-control/task.yaml
+++ b/tests/main/snap-session-agent-service-control/task.yaml
@@ -33,6 +33,9 @@ prepare: |
         snap alias test-snapd-curl.curl curl
     fi
 
+    echo "Ensure session agent service is ready to reply"
+    retry-tool curl --unix-socket "${USER_RUNTIME_DIR}/snapd-session-agent.socket" http://localhost/v1/service-control
+
 restore: |
     snap remove test-snapd-curl
     systemctl stop "user@${TEST_UID}.service"


### PR DESCRIPTION
The snap-session-agent-service-control test sometimes fails with
the following error:
```
+ curl --unix-socket /run/user/12345/snapd-session-agent.socket -D- -X POST -H 'Content-Type: application/json' -d '{"action": "daemon-reload"}' http://localhost/v1/service-control
curl: (7) Couldn't connect to server
```
This indicates the curl command is run before systemd is fully ready.
Arguable this is a systemd bug, i.e. when "systemctl enable" returns
the service should be activatable. This commit works around this by
adding a small retry (for just 3 x 1s) to ensure the service is really
available before continuing.
