### PR TITLE
many: make sure ephemeral failover snapd does not open sockets

### DIFF
--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -147,6 +147,7 @@ func (c *cmdSnapd) Execute(args []string) error {
 		return fmt.Errorf("snapd failed: %v", err)
 	}
 
+	logger.Noticef("checking is-failed status of snapd.socket, snapd.service")
 	isFailedCmd := runCmd("systemctl", []string{"is-failed", "snapd.socket", "snapd.service"}, nil)
 	if err := isFailedCmd.Run(); err != nil {
 		// seems not to be failed anymore, sample for sanely
@@ -155,6 +156,7 @@ func (c *cmdSnapd) Execute(args []string) error {
 			if i != 0 {
 				time.Sleep(sampleForActiveInterval)
 			}
+			logger.Noticef("sampling is-active status of snapd.socket, snapd.service")
 			isActiveCmd := runCmd("systemctl", []string{"is-active", "snapd.socket", "snapd.service"}, nil)
 			err := isActiveCmd.Run()
 			if err == nil && osutil.FileExists(dirs.SnapdSocket) && osutil.FileExists(dirs.SnapSocket) {

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -422,6 +422,15 @@ func (o *Overlord) Loop() {
 		for {
 			// TODO: pass a proper context into Ensure
 			o.ensureTimerReset()
+
+			// TODO: in the case of a snapd failover
+			// revert (see cmd/snap-failure) make sure we
+			// only do what is strictly necessary in terms
+			// of:
+			//  * ensure logic
+			//  * run only the lane with the revert, not
+			//    other changes
+
 			// in case of errors engine logs them,
 			// continue to the next Ensure() try for now
 			err := o.stateEng.Ensure()

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -930,6 +930,14 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	// mark as active again
 	Set(st, snapsup.InstanceName(), snapst)
 
+	// TODO: consider setting Status to UndoStatus to avoid reruns while
+	// here
+
+	// TODO: in the case of a snapd failover revert (see
+	// cmd/snap-failure) make sure we have saved state
+	// before we start the reverted snapd, we might need some form
+	// of CommitAndExit on state
+
 	// if we just put back a previous a core snap, request a restart
 	// so that we switch executing its snapd
 	m.maybeRestart(t, oldInfo, reboot, deviceCtx)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"time"
 
@@ -45,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -433,7 +433,7 @@ func WaitRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 		return &state.Retry{}
 	}
 
-	if snapsup.Type == snap.TypeSnapd && os.Getenv("SNAPD_REVERT_TO_REV") != "" {
+	if snapsup.Type == snap.TypeSnapd && snapdenv.FailoverSnapdReverting() != "" {
 		return fmt.Errorf("there was a snapd rollback across the restart")
 	}
 

--- a/snapdenv/snapdenv.go
+++ b/snapdenv/snapdenv.go
@@ -92,3 +92,24 @@ func MockPreseeding(preseeding bool) (restore func()) {
 		mockPreseeding = old
 	}
 }
+
+var mockSnapdRevertToRev *string
+
+// FailoverSnapdReverting returns a string representing the revision
+// to revert to if snapd is being ephemerally run to revert to a
+// previous revision for failover.
+func FailoverSnapdReverting() (rev string) {
+	if mockSnapdRevertToRev != nil {
+		return *mockSnapdRevertToRev
+	}
+
+	return os.Getenv("SNAPD_REVERT_TO_REV")
+}
+
+func MockFailoverSnapdReverting(snapdRevertToRev string) (restore func()) {
+	old := mockSnapdRevertToRev
+	mockSnapdRevertToRev = &snapdRevertToRev
+	return func() {
+		mockSnapdRevertToRev = old
+	}
+}

--- a/snapdenv/snapdenv_test.go
+++ b/snapdenv/snapdenv_test.go
@@ -144,3 +144,37 @@ func (s *snapdenvSuite) TestMockPreseeding(c *C) {
 	snapdenv.MockPreseeding(false)
 	c.Check(snapdenv.Preseeding(), Equals, false)
 }
+
+func (s *snapdenvSuite) TestFailoverSnapdReverting(c *C) {
+	oldSnapdRevertToRev := os.Getenv("SNAPD_REVERT_TO_REV")
+	defer func() {
+		if oldSnapdRevertToRev == "" {
+			os.Unsetenv("SNAPD_REVERT_TO_REV")
+		} else {
+			os.Setenv("SNAPD_REVERT_TO_REV", oldSnapdRevertToRev)
+		}
+	}()
+
+	os.Setenv("SNAPD_REVERT_TO_REV", "33")
+	c.Check(snapdenv.FailoverSnapdReverting(), Equals, "33")
+
+	os.Unsetenv("SNAPD_REVERT_TO_REV")
+	c.Check(snapdenv.FailoverSnapdReverting(), Equals, "")
+}
+
+func (s *snapdenvSuite) TestMockFailoverSnapdReverting(c *C) {
+	oldSnapdRevertToRev := os.Getenv("SNAPD_REVERT_TO_REV")
+	defer func() {
+		if oldSnapdRevertToRev == "" {
+			os.Unsetenv("SNAPD_REVERT_TO_REV")
+		} else {
+			os.Setenv("SNAPD_REVERT_TO_REV", oldSnapdRevertToRev)
+		}
+	}()
+	os.Unsetenv("SNAPD_REVERT_TO_REV")
+
+	r := snapdenv.MockFailoverSnapdReverting("66")
+	defer r()
+
+	c.Check(snapdenv.FailoverSnapdReverting(), Equals, "66")
+}

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timeout"
 )
@@ -265,7 +266,9 @@ func AddSnapdSnapServices(s *snap.Info, inter interacter) error {
 	}
 	// and finally start snapd.service (it will stop by itself and gets
 	// started by systemd then)
+	logger.Debugf("starting snapd.service [failover revert? %s]", snapdenv.FailoverSnapdReverting())
 	if err := sysd.Start("snapd.service"); err != nil {
+		logger.Debugf("error starting snapd.service: %v", err)
 		return err
 	}
 	if err := sysd.StartNoBlock("snapd.seeded.service"); err != nil {


### PR DESCRIPTION
Follow-up to #8314 

* more debug logging as well
* TODOs

Open questions:

* I had a bug in this originally that made the ephemeral snapd do only one thing, the logs got really confused,  one question, the doc are unclear, is to which extent an OnFailure handling service should respect start limits of the handled service?
* given that the sockets of the properly restarted snapd are not removed after a short bit maybe this makes the raciness between the ephemeral snapd and it possibly worse, so should we fix that 
before landing this?