### PR TITLE
client: use Assert when checking for error

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -307,7 +307,7 @@ func (cs *clientSuite) TestSnapdClientIntegration(c *C) {
 
 	cli := client.New(nil)
 	si, err := cli.SysInfo()
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 	c.Check(si.Series, Equals, "42")
 }
 


### PR DESCRIPTION
This should fix a panic caused by test failure:

PANIC: client_test.go:287: clientSuite.TestSnapdClientIntegration

    client_test.go:310:
	c.Check(err, IsNil)
    ... value *errors.errorString = &errors.errorString{s:"cannot obtain system details: cannot communicate with server: timeout exceeded while waiting for response"} ("cannot obtain system details: cannot communicate with server: timeout exceeded while waiting for response")

    ... Panic: runtime error: invalid memory address or nil pointer dereference (PC=0x453FEB)

    /usr/lib/go-1.10/src/runtime/panic.go:502
      in gopanic
    /usr/lib/go-1.10/src/runtime/panic.go:63
      in panicmem
    /usr/lib/go-1.10/src/runtime/signal_unix.go:388
      in sigpanic
    client_test.go:311
      in clientSuite.TestSnapdClientIntegration
    /usr/lib/go-1.10/src/reflect/value.go:308
      in Value.Call
    /usr/lib/go-1.10/src/runtime/asm_arm64.s:1037
      in goexit
    OOPS: 180 passed, 1 PANICKED

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
