### PR TITLE
[wip] boot: move initramfs-mounts logic to boot pkg

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -168,6 +168,10 @@ type bootState interface {
 	// revisions retrieves the revisions of the current snap and
 	// the try snap (only the latter might not be set), and
 	// the status of the trying snap.
+	// Note that the error could be ErrorKindTrySnap, in which case curSnap may
+	// still be non-nil and valid. Callers concerned with robustness should
+	// always inspect a non-nil error with IsTrySnapError, and use curSnap
+	// instead if the error is only for the trySnap or tryingStatus.
 	revisions() (curSnap, trySnap snap.PlaceInfo, tryingStatus string, err error)
 
 	// setNext lazily implements setting the next boot target for

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -163,8 +163,9 @@ func applicable(s snap.PlaceInfo, t snap.Type, dev Device) bool {
 	return true
 }
 
-// bootState exposes the boot state for a type of boot snap.
-type bootState interface {
+// runningBootState exposes the boot state for a type of boot snap during
+// normal running state, i.e. after the pivot_root and after the initramfs.
+type runningBootState interface {
 	// revisions retrieves the revisions of the current snap and
 	// the try snap (only the latter might not be set), and
 	// the status of the trying snap.
@@ -176,7 +177,7 @@ type bootState interface {
 
 	// setNext lazily implements setting the next boot target for
 	// the type's boot snap. actually committing the update
-	// is done via the returned bootStateUpdate's commit.
+	// is done via the returned bootStateUpdate's commit method.
 	setNext(s snap.PlaceInfo) (rebootRequired bool, u bootStateUpdate, err error)
 
 	// markSuccessful lazily implements marking the boot
@@ -188,7 +189,7 @@ type bootState interface {
 
 // bootStateFor finds the right bootState implementation of the given
 // snap type and Device, if applicable.
-func bootStateFor(typ snap.Type, dev Device) (s bootState, err error) {
+func bootStateFor(typ snap.Type, dev Device) (s runningBootState, err error) {
 	if !dev.RunMode() {
 		return nil, fmt.Errorf("internal error: no boot state handling for ephemeral modes")
 	}

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -163,6 +163,18 @@ func applicable(s snap.PlaceInfo, t snap.Type, dev Device) bool {
 	return true
 }
 
+// earlyBootState exposes the boot state for a type of boot snap during the
+// early boot, i.e. during the initramfs or, strictly for testing purposes, the
+// bootloader stages.
+type earlyBootState interface {
+	// chooseSnapInitramfsMount chooses which snap should be mounted during the
+	// early boot sequence, i.e. the initramfs. actually committing the choice
+	// is done via the returned bootStateUpdate's commit method. Note that there
+	// may or may not actually be anything to commit, for example the kernel
+	// snap does not have anything to commit during the initramfs
+	chooseSnapInitramfsMount(bootStateUpdate) (sn snap.PlaceInfo, choices bootStateUpdate, err error)
+}
+
 // runningBootState exposes the boot state for a type of boot snap during
 // normal running state, i.e. after the pivot_root and after the initramfs.
 type runningBootState interface {

--- a/boot/bootstate16.go
+++ b/boot/bootstate16.go
@@ -31,7 +31,7 @@ type bootState16 struct {
 	errName   string
 }
 
-func newBootState16(typ snap.Type) bootState {
+func newBootState16(typ snap.Type) runningBootState {
 	var varSuffix, errName string
 	switch typ {
 	case snap.TypeKernel:

--- a/boot/bootstate16.go
+++ b/boot/bootstate16.go
@@ -74,6 +74,7 @@ func (s16 *bootState16) revisions() (s, tryS snap.PlaceInfo, status string, err 
 		if vName == "snap_mode" {
 			status = v
 		} else {
+			// TODO: use trySnapErrorf() here somehow?
 			if v == "" {
 				return nil, nil, "", fmt.Errorf("cannot get name and revision of %s (%s): boot variable unset", s16.errName, vName)
 			}

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -26,7 +26,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-func newBootState20(typ snap.Type) bootState {
+func newBootState20(typ snap.Type) runningBootState {
 	switch typ {
 	case snap.TypeBase:
 		return &bootState20Base{}
@@ -381,7 +381,7 @@ func (bs20 *bootState20Base) commit() error {
 // genericSetNext implements the generic logic for setting up a snap to be tried
 // for boot and works for both kernel and base snaps (though not
 // simultaneously).
-func genericSetNext(b bootState, next snap.PlaceInfo) (setStatus string, err error) {
+func genericSetNext(b runningBootState, next snap.PlaceInfo) (setStatus string, err error) {
 	// get the current snap
 	current, _, _, err := b.revisions()
 	if err != nil {
@@ -445,7 +445,7 @@ func threadBootState20MarkSuccessful(update bootStateUpdate) (*bootState20MarkSu
 // genericMarkSuccessful sets the necessary boot variables, etc. to mark the
 // given boot snap as successful and a valid rollback target. If err is nil,
 // then the first return value is guaranteed to always be non-nil.
-func genericMarkSuccessful(b bootState, update bootStateUpdate) (bsmark *bootState20MarkSuccessful, trySnap snap.PlaceInfo, err error) {
+func genericMarkSuccessful(b runningBootState, update bootStateUpdate) (bsmark *bootState20MarkSuccessful, trySnap snap.PlaceInfo, err error) {
 	// create a new object or combine the existing one with this type
 	bsmark, err = threadBootState20MarkSuccessful(update)
 	if err != nil {

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -137,8 +137,9 @@ func (ks20 *bootState20Kernel) revisions() (curSnap, trySnap snap.PlaceInfo, try
 	}
 
 	tryKernel, err := ks20.ebl.TryKernel()
+	// if err is ErrNoTryKernelRef, then we will just return nil as the trySnap
 	if err != nil && err != bootloader.ErrNoTryKernelRef {
-		return nil, nil, "", fmt.Errorf("cannot identify try kernel snap with bootloader %s: %v", ks20.ebl.Name(), err)
+		return bootSn, nil, "", trySnapErrorf("cannot identify try kernel snap with bootloader %s: %v", ks20.ebl.Name(), err)
 	}
 
 	if err == nil {
@@ -305,7 +306,7 @@ func (bs20 *bootState20Base) revisions() (curSnap, trySnap snap.PlaceInfo, tryin
 	if bs20.modeenv.BaseStatus == TryingStatus && bs20.modeenv.TryBase != "" {
 		tryBootSn, err = snap.ParsePlaceInfoFromSnapFileName(bs20.modeenv.TryBase)
 		if err != nil {
-			return nil, nil, "", fmt.Errorf("cannot get snap revision: modeenv try base boot variable is invalid: %v", err)
+			return bootSn, nil, "", trySnapErrorf("cannot get snap revision: modeenv try base boot variable is invalid: %v", err)
 		}
 	}
 

--- a/boot/errors.go
+++ b/boot/errors.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import "fmt"
+
+// SnapRevError is an error dealing with boot snap revisions, specifically used
+// with revisions() in the bootState interface for example.
+type SnapRevError struct {
+	Kind    string
+	Message string
+}
+
+func (sre *SnapRevError) Error() string {
+	return sre.Message
+}
+
+const (
+	// ErrorKindTrySnap is when an error is only for the try snap and can be
+	// ignored if a caller is not working with or doesn't need the try snap.
+	ErrorKindTrySnap = "try-snap"
+)
+
+// trySnapErrorf is a helper for creating a SnapRevError with kind
+// ErrorKindTrySnap.
+func trySnapErrorf(s string, args ...interface{}) error {
+	return &SnapRevError{
+		Kind:    ErrorKindTrySnap,
+		Message: fmt.Sprintf(s, args...),
+	}
+}
+
+// IsTrySnapError returns true if the given error is an error resulting from
+// accessing information about the try snap or the trying status.
+func IsTrySnapError(err error) bool {
+	switch e := err.(type) {
+	case *SnapRevError:
+		return e.Kind == ErrorKindTrySnap
+	}
+	return false
+}

--- a/boot/initramfs.go
+++ b/boot/initramfs.go
@@ -1,0 +1,87 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/timings"
+)
+
+// TODO:UC20: add install mode mounts code too
+
+// InitramfsRunModeSnapsToMount returns a map of the snap paths to mount for the
+// specified snap types.
+func InitramfsRunModeSnapsToMount(typs []snap.Type) (map[snap.Type]string, error) {
+	var choices bootStateUpdate
+	var sn snap.PlaceInfo
+	var err error
+	m := make(map[snap.Type]string)
+	for _, typ := range typs {
+		ebs := newEarlyBootState20(typ)
+		sn, choices, err = ebs.chooseSnapInitramfsMount(choices)
+		if err != nil {
+			return nil, err
+		}
+
+		snapPath := filepath.Join(dirs.EarlyBootUbuntuData, "system-data", dirs.SnapBlobDir, sn.Filename())
+		m[typ] = snapPath
+	}
+
+	// if we have something to actually commit, then commit it
+	if choices != nil {
+		err = choices.commit()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return m, nil
+}
+
+// TODO: move this into it's own file?
+func recoverySystemEssentialSnaps(seedDir, recoverySystem string, essentialTypes []snap.Type) ([]*seed.Snap, error) {
+	systemSeed, err := seed.Open(seedDir, recoverySystem)
+	if err != nil {
+		return nil, err
+	}
+
+	seed20, ok := systemSeed.(seed.EssentialMetaLoaderSeed)
+	if !ok {
+		return nil, fmt.Errorf("internal error: UC20 seed must implement EssentialMetaLoaderSeed")
+	}
+
+	// load assertions into a temporary database
+	if err := systemSeed.LoadAssertions(nil, nil); err != nil {
+		return nil, err
+	}
+
+	// load and verify metadata only for the relevant essential snaps
+	perf := timings.New(nil)
+	if err := seed20.LoadEssentialMeta(essentialTypes, perf); err != nil {
+		return nil, err
+	}
+
+	return seed20.EssentialSnaps(), nil
+}

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -28,7 +28,7 @@ import (
 
 type coreBootParticipant struct {
 	s  snap.PlaceInfo
-	bs bootState
+	bs runningBootState
 }
 
 // ensure coreBootParticipant is a BootParticipant

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -125,6 +125,10 @@ var (
 	FeaturesDir string
 
 	RunMnt string
+
+	EarlyBootUbuntuData string
+	EarlyBootUbuntuBoot string
+	EarlyBootUbuntuSeed string
 )
 
 const (
@@ -381,6 +385,9 @@ func SetRootDir(rootdir string) {
 	FeaturesDir = filepath.Join(rootdir, snappyDir, "features")
 
 	RunMnt = filepath.Join(rootdir, "/run/mnt")
+	EarlyBootUbuntuData = filepath.Join(RunMnt, "ubuntu-data")
+	EarlyBootUbuntuBoot = filepath.Join(RunMnt, "ubuntu-boot")
+	EarlyBootUbuntuSeed = filepath.Join(RunMnt, "ubuntu-seed")
 }
 
 // what inside a (non-classic) snap is /usr/lib/snapd, outside can come from different places


### PR DESCRIPTION
This is a wip, but opening now to make sure my thinking isn't too far off here before I go and fix up a bunch of unit tests and write other things around all this...

1. I thought it would be cool to move as much logic for boot state into bootstate20.go but perhaps I have overstepped and something simpler would have been better. thoughts?
1. The name InitramfsRunModeSnapsToMount is not the best, but I managed to convince myself that at least internally to the boot package returning a bootStateUpdate and calling it a choice makes it more clear that you are mutating something, so maybe this should be renamed to something like ChooseAndCommitInitramfsRunModeSnapsToMount :astonished: ?
1. I looked into it a bit and I didn't find any obvious reason why having boot import the seed package doesn't make sense, but I'm not sure about this. If so, then we can still probably have most of this, just that we will need to keep picking the snapd snap using logic not in the boot pkg, and we will need to somehow share the modeenv between the boot pkg and the snap-bootstrap binary, or we can probably just read it multiple times and it's fine
1. there is currently an unfortunate side effect that we read the modeenv multiple times when we run `chooseSnapInitramfsMount` with multiple `earlyBootState` implementations, I think I have an idea to fix this by sharing the modeenv inside the bootStateUpdate instead of in the objects themselves, but it's a little clever, and perhaps too clever. Maybe it's not a bad thing to read the modeenv multiple times?
1. I need to update many unit tests, that's known...
1. If this is +1'd and I update the unit tests here, then the next thing to do would be to write robustness tests for the base snap updating and we can use the `InitramfsRunModeSnapsToMount` function here from those tests to run the actual logic there
1. I was hoping to find a way where I could transparently fit in the fake kernel snap try process in a way that "just worked" with the earlyBootState interface, but I couldn't find a way, so I think that will just need to be it's own function living in boottest no matter what, but I could at least integrate that with `InitramfsRunModeSnapsToMount` to make a nice helper which does both kernel and base snap upgrade logic.
1. The `EarlyBootUbuntu{Data,Boot,Seed}` vars I thought would be nice to have, but I can remove those if that's not desirable or doesn't make sense