### PR TITLE
tests: update proxy-no-core to match latest CDN changes

### DIFF
--- a/tests/main/proxy-no-core/task.yaml
+++ b/tests/main/proxy-no-core/task.yaml
@@ -52,4 +52,4 @@ execute: |
 
     # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
-    check_journalctl_log 'CONNECT .*.cdn.snapcraft.io' -u tinyproxy
+    check_journalctl_log 'CONNECT (.*.cdn.snapcraft.io|.*.cdn.snapcraftcontent.com)' -u tinyproxy


### PR DESCRIPTION
The CDN domain has changed and that breaks our tinyproxy
test. This commit updates the code to match the new CDN
location.
