### PR TITLE
interfaces: allow raw access to USB printers

### DIFF
--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -37,6 +37,9 @@ const rawusbConnectedPlugAppArmor = `
 # Allow access to all ttyUSB devices too
 /dev/tty{USB,ACM}[0-9]* rwk,
 
+# Allow raw access to USB printers (i.e. for receipt printers in POS systems)
+/dev/usb/lp[0-9]* rwk,
+
 # Allow detection of usb devices. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,
 /sys/devices/pci**/usb[0-9]** r,

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -37,7 +37,7 @@ const rawusbConnectedPlugAppArmor = `
 # Allow access to all ttyUSB devices too
 /dev/tty{USB,ACM}[0-9]* rwk,
 
-# Allow raw access to USB printers (i.e. for receipt printers in POS systems)
+# Allow raw access to USB printers (i.e. for receipt printers in POS systems).
 /dev/usb/lp[0-9]* rwk,
 
 # Allow detection of usb devices. Leaks plugged in USB device info


### PR DESCRIPTION
For Point of sale systems (and some medical devices) that write raw text into a USB printer port to a receipt printer, direct rw access to /dev/usb/lp[0-9] is needed. 

This PR extends the raw-usb interface to allow such access.
