### PR TITLE
github: run spread via github actions

### DIFF
--- a/.github/workflows/sprd.yaml
+++ b/.github/workflows/sprd.yaml
@@ -1,0 +1,31 @@
+name: Spread 
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  GCE:
+    runs-on: [self-hosted]
+    strategy:
+      matrix:
+        system:
+        - ubuntu-14.04-64
+        - ubuntu-16.04-64
+        - ubuntu-18.04-64
+        - ubuntu-20.04-64
+        - ubuntu-core-16-64
+        - ubuntu-core-18-64
+        - ubuntu-core-20-64
+        - debian-9-64
+        - debian-sid-64
+        - fedora-30-64
+        - fedora-31-64
+        - arch-linux-64
+        - amazon-linux-2-64
+        - centos-7-64
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run spread tests
+      run: spread -v google:${{ matrix.system }}:tests/...

--- a/.github/workflows/sprd.yaml
+++ b/.github/workflows/sprd.yaml
@@ -1,4 +1,4 @@
-name: Spread 
+name: Spread
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/sprd.yaml
+++ b/.github/workflows/sprd.yaml
@@ -13,6 +13,7 @@ jobs:
         - ubuntu-14.04-64
         - ubuntu-16.04-64
         - ubuntu-18.04-64
+        - ubuntu-19.10-64
         - ubuntu-20.04-64
         - ubuntu-core-16-64
         - ubuntu-core-18-64

--- a/.github/workflows/sprd.yaml
+++ b/.github/workflows/sprd.yaml
@@ -5,37 +5,6 @@ on:
   pull_request:
     branches: [ master ]
 jobs:
-  stable:
-    runs-on: [self-hosted]
-    strategy:
-      matrix:
-        system:
-        - ubuntu-14.04-64
-        - ubuntu-16.04-64
-        - ubuntu-18.04-64
-        - ubuntu-19.10-64
-        - ubuntu-20.04-64
-        - ubuntu-core-16-64
-        - ubuntu-core-18-64
-        - ubuntu-core-20-64
-        - debian-9-64
-        - debian-sid-64
-        - fedora-30-64
-        - fedora-31-64
-        - arch-linux-64
-        - amazon-linux-2-64
-        - centos-7-64
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Run spread tests
-      run: spread -v google:${{ matrix.system }}:tests/...
-    - name: Discard spread workers
-      run: |
-        shopt -s nullglob;
-        for r in .spread-reuse.*.yaml; do
-          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
-        done
   unstable:
     runs-on: [self-hosted]
     strategy:

--- a/.github/workflows/sprd.yaml
+++ b/.github/workflows/sprd.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ master ]
 jobs:
-  GCE:
+  stable:
     runs-on: [self-hosted]
     strategy:
       matrix:
@@ -30,6 +30,25 @@ jobs:
       uses: actions/checkout@v2
     - name: Run spread tests
       run: spread -v google:${{ matrix.system }}:tests/...
+    - name: Discard spread workers
+      run: |
+        shopt -s nullglob;
+        for r in .spread-reuse.*.yaml; do
+          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+        done
+  unstable:
+    runs-on: [self-hosted]
+    strategy:
+      matrix:
+        system:
+        - centos-8-64
+        - opensuse-15.1-64
+        - opensuse-tumbleweed-64
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run spread tests
+      run: spread -v google-unstable:${{ matrix.system }}:tests/...
     - name: Discard spread workers
       run: |
         shopt -s nullglob;

--- a/.github/workflows/sprd.yaml
+++ b/.github/workflows/sprd.yaml
@@ -29,3 +29,9 @@ jobs:
       uses: actions/checkout@v2
     - name: Run spread tests
       run: spread -v google:${{ matrix.system }}:tests/...
+    - name: Discard spread workers
+      run: |
+        shopt -s nullglob;
+        for r in .spread-reuse.*.yaml; do
+          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+        done

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,30 +65,6 @@ matrix:
         - git fetch --unshallow
         - ./tests/lib/cla_check.py
     - stage: integration
-      name: Ubuntu 14.04, 16.04, 18.04, 18.10, 19.10, Core 16, Core 18, Core 20
-      dist: xenial
-      addons:
-        apt:
-          packages:
-          - xdelta3
-      install:
-        # override the default install for language:go
-        - true
-      script:
-        - ./run-checks --spread-ubuntu
-    - stage: integration
-      name: Debian, Fedora, CentOS, Amazon Linux 2, openSUSE, Arch
-      dist: xenial
-      addons:
-        apt:
-          packages:
-          - xdelta3
-      install:
-        # override the default install for language:go
-        - true
-      script:
-        - ./run-checks --spread-no-ubuntu
-    - stage: integration
       name: Unstable systems
       dist: xenial
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,30 @@ matrix:
       script:
         - git fetch --unshallow
         - ./tests/lib/cla_check.py
+    - stage: integration
+      name: Ubuntu 14.04, 16.04, 18.04, 18.10, 19.10, Core 16, Core 18, Core 20
+      dist: xenial
+      addons:
+        apt:
+          packages:
+          - xdelta3
+      install:
+        # override the default install for language:go
+        - true
+      script:
+        - ./run-checks --spread-ubuntu
+    - stage: integration
+      name: Debian, Fedora, CentOS, Amazon Linux 2, openSUSE, Arch
+      dist: xenial
+      addons:
+        apt:
+          packages:
+          - xdelta3
+      install:
+        # override the default install for language:go
+        - true
+      script:
+        - ./run-checks --spread-no-ubuntu
   global:
     # SPREAD_LINODE_KEY
     - secure: "bzALrfNSLwM0bjceal1PU5rFErvqVhi00Sygx8jruo6htpZay3hrC2sHCKCQKPn1kvCfHidrHX1vnomg5N+B9o25GZEYSjKSGxuvdNDfCZYqPNjMbz5y7xXYfKWgyo+xtrKRM85Nqy121SfRz3KLDvrOLwwreb+pZv8DG1WraFTd7D6rK7nLnnYNUyw665XBMFVnM8ue3Zu9496Ih/TfQXhnNpsZY8xFWte4+cH7JvVCVTs8snjoGVZi3972PzinNkfBgJa24cUzxFMfiN/AwSBXJQKdVv+FsbB4uRgXAqTNwuus7PptiPNxpWWojuhm1Qgbk0XhGIdJxyUYkmNA4UrZ3C29nIRWbuAiHJ6ZWd1ur3dqphqOcgFInltSHkpfEdlL3YK4dCa2SmJESzotUGnyowCUUCXkWdDaZmFTwyK0Y6He9oyXDK5f+/U7SFlPvok0caJCvB9HbTQR1kYdh048I/R+Ht5QrFOZPk21DYWDOYhn7SzthBDZLsaL6n5gX7Y547SsL4B35YVbpaeHzccG6Mox8rI4bqlGFvP1U5i8uXD4uQjJChlVxpmozUEMok9T5RVediJs540p5uc8DQl48Nke02tXzC/XpGAvpnXT7eiiRNW67zOj2QcIV+ni3lBj3HvZeB9cgjzLNrZSl/t9vseqnNwQWpl3V6nd/bU="

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,20 +64,6 @@ matrix:
       script:
         - git fetch --unshallow
         - ./tests/lib/cla_check.py
-    - stage: integration
-      name: Unstable systems
-      dist: xenial
-      addons:
-        apt:
-          packages:
-          - xdelta3
-      install:
-        # override the default install for language:go
-        - true
-      script:
-        - ./run-checks --spread-unstable
-  allow_failures:
-    - name: Unstable systems
   global:
     # SPREAD_LINODE_KEY
     - secure: "bzALrfNSLwM0bjceal1PU5rFErvqVhi00Sygx8jruo6htpZay3hrC2sHCKCQKPn1kvCfHidrHX1vnomg5N+B9o25GZEYSjKSGxuvdNDfCZYqPNjMbz5y7xXYfKWgyo+xtrKRM85Nqy121SfRz3KLDvrOLwwreb+pZv8DG1WraFTd7D6rK7nLnnYNUyw665XBMFVnM8ue3Zu9496Ih/TfQXhnNpsZY8xFWte4+cH7JvVCVTs8snjoGVZi3972PzinNkfBgJa24cUzxFMfiN/AwSBXJQKdVv+FsbB4uRgXAqTNwuus7PptiPNxpWWojuhm1Qgbk0XhGIdJxyUYkmNA4UrZ3C29nIRWbuAiHJ6ZWd1ur3dqphqOcgFInltSHkpfEdlL3YK4dCa2SmJESzotUGnyowCUUCXkWdDaZmFTwyK0Y6He9oyXDK5f+/U7SFlPvok0caJCvB9HbTQR1kYdh048I/R+Ht5QrFOZPk21DYWDOYhn7SzthBDZLsaL6n5gX7Y547SsL4B35YVbpaeHzccG6Mox8rI4bqlGFvP1U5i8uXD4uQjJChlVxpmozUEMok9T5RVediJs540p5uc8DQl48Nke02tXzC/XpGAvpnXT7eiiRNW67zOj2QcIV+ni3lBj3HvZeB9cgjzLNrZSl/t9vseqnNwQWpl3V6nd/bU="

--- a/spread.yaml
+++ b/spread.yaml
@@ -35,7 +35,7 @@ environment:
     SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-edge}")'
     REMOTE_STORE: '$(HOST: echo "${SPREAD_REMOTE_STORE:-production}")'
     SNAPPY_USE_STAGING_STORE: '$(HOST: if [ "$SPREAD_REMOTE_STORE" = staging ]; then echo 1; else echo 0; fi)'
-    DELTA_REF: 2.42
+    DELTA_REF: 2.44
     DELTA_PREFIX: snapd-$DELTA_REF/
     SNAPD_PUBLISHED_VERSION: '$(HOST: echo "$SPREAD_SNAPD_PUBLISHED_VERSION")'
     HTTP_PROXY: '$(HOST: echo "$SPREAD_HTTP_PROXY")'


### PR DESCRIPTION
This patch runs adds a github actions workflow for running spread
tests. I've used a matrix build, one per system, so that logs are
shorter and any error patterns are easier to spot.

Earlier test runs indicate that each system takes about 30 minutes to
complete. The fastest system is ubuntu-14.06-64 at around 28 minutes.
The slowest systems are ubuntu-core-20-64 and ubuntu-20.04-64 (classic)
at over 47 minutes. While the slowness of core-20 setup is well-known
the slowness of classic is surprising.

Tests are powered by a pool of 32 self-hosted runners. The matrix uses
14 systems per pull request. This means we can instantly start up to two
pull requests and process them in about 40 minutes. The extra workers 
are spare capacity in case something is restarted. Self-hosted workers
do not cost anything and do not take any concurrency slots in github
actions.

Our free plan gives us 20 slots that are used to run unit tests. This
means that up to 20 pull requests are instantly, concurrently tested
(unit tests) and then processed one-by-one by the spread worker pool.

Matrix workers have a fail-fast semantics by default, so any run that
fails will cancel all the peers. We could explore some more ideas that
run a canary run (e.g. ubuntu-16.04-64) and only run the remaining
combinations if the canary succeeds.

We could also explore building snapd.deb and re-packaging snapd.snap and
core.snap once, offering those as downloadable items (in each pull
request). This would allow us to remove a good chunk of constant delay
that is otherwise incurred by each test (and fix some build bugs we
currently have in repackaging, e.g. when building on fedora). This might
offset the cost of the pipeline, cutting the total time as well.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
