### PR TITLE
gadget: SystemDefaults helper for FilesystemOnlyApply (2/N)

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -41,6 +41,8 @@ var (
 	UpdaterForStructure = updaterForStructure
 
 	EnsureVolumeConsistency = ensureVolumeConsistency
+
+	Flatten = flatten
 )
 
 func MockEvalSymlinks(mock func(path string) (string, error)) (restore func()) {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1012,3 +1012,29 @@ func PositionedVolumeFromGadget(gadgetRoot string) (*LaidOutVolume, error) {
 	}
 	return nil, fmt.Errorf("internal error in PositionedVolumeFromGadget: this line cannot be reached")
 }
+
+func flatten(path string, cfg interface{}, out map[string]interface{}) {
+	if cfgMap, ok := cfg.(map[string]interface{}); ok {
+		for k, v := range cfgMap {
+			p := k
+			if path != "" {
+				p = path + "." + k
+			}
+			flatten(p, v, out)
+		}
+	} else {
+		out[path] = cfg
+	}
+}
+
+// SystemDefaults returns default system configuration from gadget defaults.
+func SystemDefaults(gadgetDefaults map[string]map[string]interface{}) map[string]interface{} {
+	for _, systemSnap := range []string{"system", naming.WellKnownSnapID("core")} {
+		if defaults, ok := gadgetDefaults[systemSnap]; ok {
+			coreDefaults := map[string]interface{}{}
+			flatten("", defaults, coreDefaults)
+			return coreDefaults
+		}
+	}
+	return nil
+}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -124,6 +124,13 @@ defaults:
       bar: baz
 `)
 
+var mockClassicGadgetCoreDefaultsYaml = []byte(`
+defaults:
+  99T7MUlRhtI3U0QFgl5mXXESAiSwt776:
+    ssh:
+      disable: true
+`)
+
 var mockClassicGadgetMultilineDefaultsYaml = []byte(`
 defaults:
   system:
@@ -358,6 +365,58 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOnylDefaultsIsValid(c *
 			// realign this, thus breaking our gofmt 1.9 checks
 			"otheridididididididididididididi": {"foo": map[string]interface{}{"bar": "baz"}},
 		},
+	})
+}
+
+func (s *gadgetYamlTestSuite) TestFlatten(c *C) {
+	cfg := map[string]interface{}{
+		"foo":         "bar",
+		"some.option": true,
+		"sub": map[string]interface{}{
+			"option1": true,
+			"option2": map[string]interface{}{
+				"deep": "2",
+			},
+		},
+	}
+	out := map[string]interface{}{}
+	gadget.Flatten("", cfg, out)
+	c.Check(out, DeepEquals, map[string]interface{}{
+		"foo":              "bar",
+		"some.option":      true,
+		"sub.option1":      true,
+		"sub.option2.deep": "2",
+	})
+}
+
+func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
+	err := ioutil.WriteFile(s.gadgetYamlPath, mockClassicGadgetCoreDefaultsYaml, 0644)
+	c.Assert(err, IsNil)
+
+	ginfo, err := gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
+	c.Assert(err, IsNil)
+	defaults := gadget.SystemDefaults(ginfo.Defaults)
+	c.Check(defaults, DeepEquals, map[string]interface{}{
+		"ssh.disable": true,
+	})
+
+	yaml := string(mockClassicGadgetCoreDefaultsYaml) + `
+  system:
+    something: true
+    some:
+      nested:
+        option: foo
+`
+
+	err = ioutil.WriteFile(s.gadgetYamlPath, []byte(yaml), 0644)
+	c.Assert(err, IsNil)
+	ginfo, err = gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
+	c.Assert(err, IsNil)
+
+	defaults = gadget.SystemDefaults(ginfo.Defaults)
+	c.Check(defaults, DeepEquals, map[string]interface{}{
+		"something":          true,
+		"some.nested.option": "foo",
 	})
 }
 


### PR DESCRIPTION
`SystemDefaults` helper function to convert system defaults config into a flattened map suitable for `FilesystemOnlyApply`.