### PR TITLE
many: introduce naming.WellKnownSnapID

### DIFF
--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/snapcore/snapd/snap/naming"
 )
 
 // AttrMatchContext has contextual helpers for evaluating attribute constraints.
@@ -594,15 +596,14 @@ func (nc *NameConstraints) Check(whichName, name string, special map[string]stri
 var (
 	validSnapType  = regexp.MustCompile("^(?:core|kernel|gadget|app)$")
 	validDistro    = regexp.MustCompile("^[-0-9a-z._]+$")
-	validSnapID    = regexp.MustCompile("^[a-z0-9A-Z]{32}$")                                        // snap-ids look like this
 	validPublisher = regexp.MustCompile("^(?:[a-z0-9A-Z]{32}|[-a-z0-9]{2,28}|\\$[A-Z][A-Z0-9_]*)$") // account ids look like snap-ids or are nice identifiers, support our own special markers $MARKER
 
 	validIDConstraints = map[string]*regexp.Regexp{
 		"slot-snap-type":    validSnapType,
-		"slot-snap-id":      validSnapID,
+		"slot-snap-id":      naming.ValidSnapID,
 		"slot-publisher-id": validPublisher,
 		"plug-snap-type":    validSnapType,
-		"plug-snap-id":      validSnapID,
+		"plug-snap-id":      naming.ValidSnapID,
 		"plug-publisher-id": validPublisher,
 	}
 )

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -661,6 +661,11 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 			// the assumption is that base names are very stable
 			// essentially fixed
 			modSnaps.base = baseSnap
+			snapID := naming.WellKnownSnapID(modSnaps.base.Name)
+			if snapID == "" && grade != ModelDangerous {
+				return nil, fmt.Errorf(`cannot specify not well-known base %q without a corresponding "snaps" header entry`, modSnaps.base.Name)
+			}
+			modSnaps.base.SnapID = snapID
 			modSnaps.base.Modes = essentialSnapModes
 			modSnaps.base.DefaultChannel = "latest/stable"
 		}

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -203,7 +203,7 @@ func checkModelSnap(snap map[string]interface{}, grade ModelGrade) (*ModelSnap, 
 	_, ok := snap["id"]
 	if ok {
 		var err error
-		snapID, err = checkStringMatchesWhat(snap, "id", what, validSnapID)
+		snapID, err = checkStringMatchesWhat(snap, "id", what, naming.ValidSnapID)
 		if err != nil {
 			return nil, err
 		}

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -27,6 +27,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/snap/naming"
 )
 
 type modelSuite struct {
@@ -607,6 +608,7 @@ func (mods *modelSuite) TestCore20DecodeOK(c *C) {
 	c.Check(model.Base(), Equals, "core20")
 	c.Check(model.BaseSnap(), DeepEquals, &asserts.ModelSnap{
 		Name:           "core20",
+		SnapID:         naming.WellKnownSnapID("core20"),
 		SnapType:       "base",
 		Modes:          []string{"run", "ephemeral"},
 		DefaultChannel: "latest/stable",
@@ -764,6 +766,7 @@ func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"base: core20\n", "", `"base" header is mandatory`},
+		{"base: core20\n", "base: alt-base\n", `cannot specify not well-known base "alt-base" without a corresponding "snaps" header entry`},
 		{"OTHER", "classic: true\n", `cannot use extended snaps header for a classic model \(yet\)`},
 		{snapsStanza, "snaps: snap\n", `"snaps" header must be a list of maps`},
 		{snapsStanza, "snaps:\n  - snap\n", `"snaps" header must be a list of maps`},

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -123,8 +123,9 @@ type VolumeStructure struct {
 	// For backwards compatibility type 'mbr' is also accepted, and the
 	// structure is treated as if it is of role 'mbr'.
 	Type string `yaml:"type"`
-	// Role describes the role of given structure, can be one of 'mbr',
-	// 'system-data', 'system-boot', 'bootimg', 'bootselect'. Structures of type 'mbr', must have a
+	// Role describes the role of given structure, can be one of
+	// 'mbr', 'system-data', 'system-boot', 'system-boot-image',
+	// 'system-boot-select'. Structures of type 'mbr', must have a
 	// size of 446 bytes and must start at 0 offset.
 	Role string `yaml:"role"`
 	// ID is the GPT partition ID

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -36,11 +36,9 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/strutil"
 )
-
-// The fixed length of valid snap IDs.
-const validSnapIDLength = 32
 
 const (
 	// MBR identifies a Master Boot Record partitioning schema, or an MBR like role
@@ -284,7 +282,7 @@ func parseSnapIDColonName(s string) (snapID, name string, err error) {
 }
 
 func systemOrSnapID(s string) bool {
-	if s != "system" && len(s) != validSnapIDLength {
+	if s != "system" && naming.ValidateSnapID(s) != nil {
 		return false
 	}
 	return true

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -594,7 +594,7 @@ func (s *imageSuite) TestSetupSeed(c *C) {
 		})
 		// sanity
 		if name == "core" {
-			c.Check(essSnaps[i].SideInfo.SnapID, Equals, "coreidididididididididididididid")
+			c.Check(essSnaps[i].SideInfo.SnapID, Equals, s.AssertedSnapID("core"))
 		}
 	}
 	c.Check(runSnaps[0], DeepEquals, &seed.Snap{
@@ -893,7 +893,7 @@ func (s *imageSuite) TestSetupSeedWithBase(c *C) {
 			case "core18_18.snap":
 				info = &snap.Info{
 					SideInfo: snap.SideInfo{
-						SnapID:   "core18ididididididididididididid",
+						SnapID:   s.AssertedSnapID("core18"),
 						RealName: "core18",
 						Revision: snap.R("18"),
 					},
@@ -1054,7 +1054,7 @@ func (s *imageSuite) TestSetupSeedWithBaseLegacySnap(c *C) {
 			case "core18_18.snap":
 				info = &snap.Info{
 					SideInfo: snap.SideInfo{
-						SnapID:   "core18ididididididididididididid",
+						SnapID:   s.AssertedSnapID("core18"),
 						RealName: "core18",
 						Revision: snap.R("18"),
 					},

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -140,7 +140,7 @@ type: gadget
 `
 	var mockGadgetYaml = []byte(`
 defaults:
-  test-snap-ididididididididididid:
+  testsnapidididididididididididid:
       bar: baz
       num: 1.305
 
@@ -178,7 +178,7 @@ hooks:
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
-			{RealName: "test-snap", Revision: snap.R(11), SnapID: "test-snap-ididididididididididid"},
+			{RealName: "test-snap", Revision: snap.R(11), SnapID: "testsnapidididididididididididid"},
 		},
 		Current:  snap.R(11),
 		SnapType: "app",
@@ -190,7 +190,7 @@ hooks:
 	s.context.Set("use-defaults", true)
 	s.context.Unlock()
 
-	c.Check(s.handler.Before(), IsNil)
+	c.Assert(s.handler.Before(), IsNil)
 
 	s.context.Lock()
 	tr := configstate.ContextTransaction(s.context)
@@ -214,7 +214,7 @@ type: gadget
 `
 	var mockGadgetYaml = []byte(`
 defaults:
-  test-snap-ididididididididididid:
+  testsnapidididididididididididid:
       bar: baz
       num: 1.305
 
@@ -245,7 +245,7 @@ volumes:
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
-			{RealName: "test-snap", Revision: snap.R(11), SnapID: "test-snap-ididididididididididid"},
+			{RealName: "test-snap", Revision: snap.R(11), SnapID: "testsnapidididididididididididid"},
 		},
 		Current:  snap.R(11),
 		SnapType: "app",

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -759,7 +759,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedConfigureHappy(c *C) {
 defaults:
     foodidididididididididididididid:
        foo-cfg: foo.
-    coreidididididididididididididid:
+    99T7MUlRhtI3U0QFgl5mXXESAiSwt776:
        core-cfg: core_cfg_defl
     pckernelidididididididididididid:
        pc-kernel-cfg: pc-kernel_cfg_defl

--- a/overlord/patch/patch6_2_test.go
+++ b/overlord/patch/patch6_2_test.go
@@ -35,8 +35,9 @@ type patch62Suite struct{}
 
 var _ = Suite(&patch62Suite{})
 
-// State with snapd snap marked as 'app' (to be converted to 'snapd' type) and a regular 'other' snap,
-// plus three tasks - two of them need to have their SnapSetup migrated to 'snapd' type.
+// State with snapd snap marked as 'app' (to be converted to 'snapd'
+// type) and a regular 'other' snap, plus three tasks - two of them
+// need to have their SnapSetup migrated to 'snapd' type.
 var statePatch6_2JSON = []byte(`
 {
 	"data": {
@@ -47,7 +48,7 @@ var statePatch6_2JSON = []byte(`
 			"sequence": [
 			  {
 				"name": "snapd",
-				"snap-id": "snapd-snap-id",
+				"snap-id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
 				"revision": "2"
 			  }
 			],
@@ -130,7 +131,7 @@ var statePatch6_2JSON = []byte(`
 				},
 				"side-info": {
 				  "name": "snapd",
-				  "snap-id": "snapd-snap-id",
+				  "snap-id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
 				  "revision": "1",
 				  "channel": "stable",
 				  "title": "snapd"
@@ -173,7 +174,7 @@ var statePatch6_2JSON = []byte(`
 				"snap-path": "/path",
 				"side-info": {
 				  "name": "snapd",
-				  "snap-id": "snapd-snap-id",
+				  "snap-id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
 				  "revision": "1",
 				  "channel": "stable",
 				  "title": "snapd"
@@ -194,7 +195,7 @@ var statePatch6_2JSON = []byte(`
 				"snap-path": "/path",
 				"side-info": {
 				  "name": "snapd",
-				  "snap-id": "snapd-snap-id",
+				  "snap-id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
 				  "revision": "1",
 				  "channel": "stable",
 				  "title": "snapd"
@@ -208,8 +209,9 @@ var statePatch6_2JSON = []byte(`
 	}
 }`)
 
-// State with 'snapd' snap with proper snap type, and an extra 'other' snap
-// with snapd-snap-id but improper 'app' type.
+// State with 'snapd' snap with proper snap type, and an extra 'other'
+// snap with snapd snap-id (PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4) but
+// improper 'app' type.
 var statePatch6_2JSONWithSnapd = []byte(`
 {
 	"data": {
@@ -220,7 +222,7 @@ var statePatch6_2JSONWithSnapd = []byte(`
 			"sequence": [
 			  {
 				"name": "snapd",
-				"snap-id": "snapd-snap-id",
+				"snap-id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
 				"revision": "2"
 			  }
 			],
@@ -233,7 +235,7 @@ var statePatch6_2JSONWithSnapd = []byte(`
 			"sequence": [
 			  {
 				"name": "other",
-				"snap-id": "snapd-snap-id",
+				"snap-id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
 				"revision": "1"
 			  }
 			],
@@ -249,7 +251,8 @@ var statePatch6_2JSONWithSnapd = []byte(`
 	}
 }`)
 
-// State with two snaps with snapd-snap-id and improper snap types
+// State with two snaps with snapd snap-id
+// (PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4) and improper snap types
 var statePatch6_2JSONWithSnapd2 = []byte(`
 {
 	"data": {
@@ -260,7 +263,7 @@ var statePatch6_2JSONWithSnapd2 = []byte(`
 			"sequence": [
 			  {
 				"name": "snapd",
-				"snap-id": "snapd-snap-id",
+				"snap-id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
 				"revision": "2"
 			  }
 			],
@@ -273,7 +276,7 @@ var statePatch6_2JSONWithSnapd2 = []byte(`
 			"sequence": [
 			  {
 				"name": "other",
-				"snap-id": "snapd-snap-id",
+				"snap-id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
 				"revision": "1"
 			  }
 			],
@@ -297,9 +300,6 @@ func (s *patch62Suite) SetUpTest(c *C) {
 func (s *patch62Suite) TestPatch62(c *C) {
 	restore1 := patch.MockLevel(6, 2)
 	defer restore1()
-
-	restore2 := snap.MockSnapdSnapID("snapd-snap-id")
-	defer restore2()
 
 	r := bytes.NewReader(statePatch6_2JSON)
 	st, err := state.ReadState(nil, r)
@@ -353,9 +353,6 @@ func (s *patch62Suite) TestPatch62(c *C) {
 func (s *patch62Suite) TestPatch62StopsAfterFirstSnapd(c *C) {
 	restore1 := patch.MockLevel(6, 2)
 	defer restore1()
-
-	restore2 := snap.MockSnapdSnapID("snapd-snap-id")
-	defer restore2()
 
 	r := bytes.NewReader(statePatch6_2JSONWithSnapd2)
 	st, err := state.ReadState(nil, r)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -308,8 +308,9 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		name = "snap-content-plug"
 	case "snap-content-slot-id":
 		name = "snap-content-slot"
-	case "snapd-id":
+	case "snapd-snap-id":
 		name = "snapd"
+		typ = snap.TypeSnapd
 	case "kernel-id":
 		name = "kernel"
 		typ = snap.TypeKernel
@@ -732,6 +733,8 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 		info.SnapType = snap.TypeGadget
 	case "core":
 		info.SnapType = snap.TypeOS
+	case "snapd":
+		info.SnapType = snap.TypeSnapd
 	case "services-snap":
 		var err error
 		// fix services after/before so that there is only one solution

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -72,7 +72,6 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 	s.setup(c, s.stateBackend)
 
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
-	s.AddCleanup(snap.MockSnapdSnapID("snapd-snap-id"))
 }
 
 func checkHasCookieForSnap(c *C, st *state.State, instanceName string) {
@@ -480,6 +479,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdRestartsOnCoreWithBase(c *C) {
 	t := s.state.NewTask("link-snap", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
 		SideInfo: si,
+		Type:     snap.TypeSnapd,
 	})
 	s.state.NewChange("dummy", "...").AddTask(t)
 
@@ -556,6 +556,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdRestartsOnClassic(c *C) {
 	t := s.state.NewTask("link-snap", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
 		SideInfo: si,
+		Type:     snap.TypeSnapd,
 	})
 	s.state.NewChange("dummy", "...").AddTask(t)
 
@@ -593,6 +594,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessCoreAndSnapdNoCoreRestart(c *C) {
 		Sequence: []*snap.SideInfo{siSnapd},
 		Current:  siSnapd.Revision,
 		Active:   true,
+		SnapType: "snapd",
 	})
 
 	si := &snap.SideInfo{
@@ -1136,6 +1138,7 @@ func (s *linkSnapSuite) TestUndoLinkSnapdNthInstall(c *C) {
 		Sequence: []*snap.SideInfo{&siOld},
 		Current:  siOld.Revision,
 		Active:   true,
+		SnapType: "snapd",
 	})
 	chg := s.state.NewChange("dummy", "...")
 	t := s.state.NewTask("link-snap", "test")

--- a/overlord/snapstate/handlers_test.go
+++ b/overlord/snapstate/handlers_test.go
@@ -39,7 +39,6 @@ func (s *handlersSuite) SetUpTest(c *C) {
 	s.setup(c, s.stateBackend)
 
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
-	s.AddCleanup(snap.MockSnapdSnapID("snapd-snap-id"))
 }
 
 func (s *handlersSuite) TestSetTaskSnapSetupFirstTask(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12644,7 +12644,7 @@ func tasksWithKind(ts *state.TaskSet, kind string) []*state.Task {
 
 var gadgetYaml = `
 defaults:
-    some-snap-ididididididididididid:
+    somesnapidididididididididididid:
         key: value
 
 volumes:
@@ -12709,7 +12709,7 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
-			{RealName: "some-snap", Revision: snap.R(11), SnapID: "some-snap-ididididididididididid"},
+			{RealName: "some-snap", Revision: snap.R(11), SnapID: "somesnapidididididididididididid"},
 		},
 		Current:  snap.R(11),
 		SnapType: "app",
@@ -12769,7 +12769,7 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSmokeUC20(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
-			{RealName: "some-snap", Revision: snap.R(11), SnapID: "some-snap-ididididididididididid"},
+			{RealName: "some-snap", Revision: snap.R(11), SnapID: "somesnapidididididididididididid"},
 		},
 		Current:  snap.R(11),
 		SnapType: "app",
@@ -12796,7 +12796,7 @@ func (s *snapmgrTestSuite) TestConfigDefaultsNoGadget(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
-			{RealName: "some-snap", Revision: snap.R(11), SnapID: "some-snap-ididididididididididid"},
+			{RealName: "some-snap", Revision: snap.R(11), SnapID: "somesnapidididididididididididid"},
 		},
 		Current:  snap.R(11),
 		SnapType: "app",
@@ -12903,7 +12903,7 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSystemConflictsCoreSnapId(c *C) {
 defaults:
     system:
         foo: bar
-    the-core-snapidididididididididi:
+    thecoresnapididididididididididi:
         foo: other-bar
         other-key: other-key-default
 `)
@@ -12913,7 +12913,7 @@ defaults:
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
-			{RealName: "core", SnapID: "the-core-snapidididididididididi", Revision: snap.R(1)},
+			{RealName: "core", SnapID: "thecoresnapididididididididididi", Revision: snap.R(1)},
 		},
 		Current:  snap.R(1),
 		SnapType: "os",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -679,9 +679,6 @@ version: 1.0
 }
 
 func (s *snapmgrTestSuite) TestInstallSnapdSnapType(c *C) {
-	restore := snap.MockSnapdSnapID("snapd-id") // id provided by fakeStore
-	defer restore()
-
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1368,9 +1365,6 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC18(c *C) {
 	r := snapstatetest.MockDeviceModel(ModelWithBase("core18"))
 	defer r()
 
-	restore := snap.MockSnapdSnapID("snapd-id")
-	defer restore()
-
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1395,7 +1389,7 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC18(c *C) {
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
-			{RealName: "snapd", SnapID: "snapd-id", Revision: snap.R(1)},
+			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)},
 		},
 		Current:  snap.R(1),
 		SnapType: "app",
@@ -9229,7 +9223,7 @@ func (s *snapmgrTestSuite) TestRevertWithBaseRunThrough(c *C) {
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
-			{RealName: "snapd", SnapID: "snapd-id", Revision: snap.R(1)},
+			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)},
 		},
 		Current:  snap.R(1),
 		SnapType: "app",
@@ -15573,9 +15567,6 @@ func (s *snapmgrTestSuite) TestNoConfigureForSnapdSnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	restore := snap.MockSnapdSnapID("snapd-id")
-	defer restore()
-
 	// snapd cannot be installed unless the model uses a base snap
 	r := snapstatetest.MockDeviceModel(ModelWithBase("core18"))
 	defer r()
@@ -15589,7 +15580,7 @@ func (s *snapmgrTestSuite) TestNoConfigureForSnapdSnap(c *C) {
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "snapd", SnapID: "snapd-id", Revision: snap.R(1)}},
+		Sequence:        []*snap.SideInfo{{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)}},
 		Current:         snap.R(1),
 		SnapType:        "app",
 	})

--- a/seed/internal/helpers.go
+++ b/seed/internal/helpers.go
@@ -21,13 +21,13 @@ package internal
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/snap/naming"
 )
 
 func MakeSystemSnap(snapName string, defaultChannel string, modes []string) *asserts.ModelSnap {
-	// TODO: set SnapID too
-	// introduce some kind of asserts|/snapsserts WellKnownSnapID(name)
 	return &asserts.ModelSnap{
 		Name:           snapName,
+		SnapID:         naming.WellKnownSnapID(snapName),
 		SnapType:       snapName, // same as snapName for core, snapd
 		Modes:          modes,
 		DefaultChannel: defaultChannel,

--- a/seed/internal/options20.go
+++ b/seed/internal/options20.go
@@ -87,7 +87,11 @@ func ReadOptions20(optionsFn string) (*Options20, error) {
 		if sn.SnapID == "" && sn.Channel == "" && sn.Unasserted == "" {
 			return nil, fmt.Errorf("%s: at least one of id, channel or unasserted must be set for snap %q", errPrefix, sn.Name)
 		}
-		// TODO|XXX: sanity check SnapID if not empty as well
+		if sn.SnapID != "" {
+			if err := naming.ValidateSnapID(sn.SnapID); err != nil {
+				return nil, fmt.Errorf("%s: %v", errPrefix, err)
+			}
+		}
 		if sn.Channel != "" {
 			if _, err := channel.Parse(sn.Channel, ""); err != nil {
 				return nil, fmt.Errorf("%s: %v", errPrefix, err)

--- a/seed/internal/options20_test.go
+++ b/seed/internal/options20_test.go
@@ -35,7 +35,7 @@ var _ = Suite(&options20Suite{})
 var mockOptions20 = []byte(`
 snaps:
  - name: foo
-   id: snapidsnapidsnapid
+   id: snapidsnapidsnapidsnapidsnapidsn
    channel: edge
  - name: local
    unasserted: local_v1.snap
@@ -51,7 +51,7 @@ func (s *options20Suite) TestSimple(c *C) {
 	c.Assert(options20.Snaps, HasLen, 2)
 	c.Assert(options20.Snaps[0], DeepEquals, &internal.Snap20{
 		Name:    "foo",
-		SnapID:  "snapidsnapidsnapid",
+		SnapID:  "snapidsnapidsnapidsnapidsnapidsn",
 		Channel: "edge",
 	})
 	c.Assert(options20.Snaps[1], DeepEquals, &internal.Snap20{
@@ -111,6 +111,19 @@ snaps:
 
 	_, err = internal.ReadOptions20(fn)
 	c.Assert(err, ErrorMatches, `cannot read grade dangerous options yaml: invalid risk in channel name: invalid/channel/`)
+}
+
+func (s *options20Suite) TestValidateSnapIDUnhappy(c *C) {
+	fn := filepath.Join(c.MkDir(), "options.yaml")
+	err := ioutil.WriteFile(fn, []byte(`
+snaps:
+ - name: foo
+   id: foo
+`), 0644)
+	c.Assert(err, IsNil)
+
+	_, err = internal.ReadOptions20(fn)
+	c.Assert(err, ErrorMatches, `cannot read grade dangerous options yaml: invalid snap-id: "foo"`)
 }
 
 func (s *options20Suite) TestValidateNameUnhappy(c *C) {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -264,7 +264,7 @@ func (s *seed20) lookupVerifiedRevision(snapRef naming.SnapRef, snapsDir string)
 			return "", nil, nil, &NoSnapDeclarationError{snapRef}
 		}
 	} else {
-		if s.model.Grade() != asserts.ModelDangerous && snapRef.SnapName() != "snapd" && snapRef.SnapName() != s.model.Base() /* TODO: use snap-id for snapd*/ {
+		if s.model.Grade() != asserts.ModelDangerous {
 			return "", nil, nil, fmt.Errorf("all system snaps must be identified by snap-id, missing for %q", snapRef.SnapName())
 		}
 		snapName := snapRef.SnapName()

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -315,7 +315,7 @@ func (s *seed20Suite) TestLoadAssertionsMultiSnapRev(c *C) {
 	seed20, err := seed.Open(s.SeedDir, sysLabel)
 	c.Assert(err, IsNil)
 	err = seed20.LoadAssertions(s.db, s.commitTo)
-	c.Check(err, ErrorMatches, `cannot have multiple snap-revisions for the same snap-id: core20ididididididididididididid`)
+	c.Check(err, ErrorMatches, `cannot have multiple snap-revisions for the same snap-id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q`)
 }
 
 func (s *seed20Suite) TestLoadAssertionsMultiSnapDecl(c *C) {
@@ -359,7 +359,38 @@ func (s *seed20Suite) TestLoadAssertionsMultiSnapDecl(c *C) {
 
 func (s *seed20Suite) TestLoadMetaMissingSnapDeclByName(c *C) {
 	sysLabel := "20191031"
-	sysDir := s.makeCore20MinimalSeed(c, sysLabel)
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name": "core20",
+				// no id
+				"type": "base",
+			}},
+	}, nil)
+
+	sysDir := filepath.Join(s.SeedDir, "systems", sysLabel)
 
 	wrongDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
 		"series":       "16",

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
@@ -54,6 +55,10 @@ func (ss *SeedSnaps) SetupAssertSigning(storeBrandID string) {
 }
 
 func (ss *SeedSnaps) AssertedSnapID(snapName string) string {
+	snapID := naming.WellKnownSnapID(snapName)
+	if snapID != "" {
+		return snapID
+	}
 	return snaptest.AssertedSnapID(snapName)
 }
 

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -2274,6 +2274,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ChannelOverrides(c *C) {
 	c.Check(options20.Snaps, DeepEquals, []*seedwriter.InternalSnap20{
 		{
 			Name:    "snapd",
+			SnapID:  s.AssertedSnapID("snapd"), // inferred
 			Channel: "latest/candidate",
 		},
 		{
@@ -2283,6 +2284,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ChannelOverrides(c *C) {
 		},
 		{
 			Name:    "core20",
+			SnapID:  s.AssertedSnapID("core20"), // inferred
 			Channel: "latest/candidate",
 		},
 		{

--- a/snap/helpers.go
+++ b/snap/helpers.go
@@ -20,24 +20,9 @@
 package snap
 
 import (
-	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/snap/naming"
 )
 
-var snapIDsSnapd = []string{
-	// production
-	"PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
-	// staging
-	"Z44rtQD1v4r1LXGPCDZAJO3AOw1EDGqy",
-}
-
 func IsSnapd(snapID string) bool {
-	return strutil.ListContains(snapIDsSnapd, snapID)
-}
-
-func MockSnapdSnapID(snapID string) (restore func()) {
-	old := snapIDsSnapd
-	snapIDsSnapd = append(snapIDsSnapd, snapID)
-	return func() {
-		snapIDsSnapd = old
-	}
+	return snapID == naming.WellKnownSnapID("snapd")
 }

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1555,15 +1555,12 @@ func (s *infoSuite) TestIsActive(c *C) {
 }
 
 func (s *infoSuite) TestGetTypeSnapdBackwardCompatibility(c *C) {
-	restore := snap.MockSnapdSnapID("snapd-id")
-	defer restore()
-
 	const snapdYaml = `
 name: snapd
 type: app
 version: 1
 `
-	snapInfo := snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{Revision: snap.R(1), SnapID: "snapd-id"})
+	snapInfo := snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{Revision: snap.R(1), SnapID: "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"})
 	c.Check(snapInfo.GetType(), Equals, snap.TypeSnapd)
 }
 

--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -160,6 +160,17 @@ func ValidateApp(n string) error {
 func ValidateSocket(name string) error {
 	if !isValidName(name) {
 		return fmt.Errorf("invalid socket name: %q", name)
+	}
+	return nil
+}
+
+// ValidSnapID is a regular expression describing a valid snapd-id
+var ValidSnapID = regexp.MustCompile("^[a-z0-9A-Z]{32}$")
+
+// ValidateSnapID checks whether the string is a valid snap-id.
+func ValidateSnapID(id string) error {
+	if !ValidSnapID.MatchString(id) {
+		return fmt.Errorf("invalid snap-id: %q", id)
 	}
 	return nil
 }

--- a/snap/naming/validate_test.go
+++ b/snap/naming/validate_test.go
@@ -20,6 +20,7 @@
 package naming_test
 
 import (
+	"fmt"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/snap/naming"
@@ -280,5 +281,20 @@ func (s *ValidateSuite) TestValidateSlotPlugInterfaceName(c *C) {
 		c.Assert(err, ErrorMatches, `invalid plug name: ".*"`)
 		err = naming.ValidateInterface(name)
 		c.Assert(err, ErrorMatches, `invalid interface name: ".*"`)
+	}
+}
+
+func (s *ValidateSuite) TestValidateSnapID(c *C) {
+	c.Check(naming.ValidateSnapID("buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ"), IsNil)
+
+	invalid := []string{
+		"",
+		"buPKUD3TKqC",
+		"buPKUD3TKqCOgLE-jHx5kSiCpIs5cMuQ",
+		"buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQxxx",
+	}
+	for _, id := range invalid {
+		err := naming.ValidateSnapID(id)
+		c.Check(err, ErrorMatches, fmt.Sprintf("invalid snap-id: %q", id))
 	}
 }

--- a/snap/naming/wellknown.go
+++ b/snap/naming/wellknown.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package naming
+
+import (
+	"github.com/snapcore/snapd/snapdenv"
+)
+
+var (
+	prodWellKnownSnapIDs = map[string]string{
+		"core":   "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
+		"snapd":  "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+		"core18": "CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6",
+		"core20": "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q",
+	}
+
+	stagingWellKnownSnapIDs = map[string]string{
+		"core":   "xMNMpEm0COPZy7jq9YRwWVLCD9q5peow",
+		"snapd":  "Z44rtQD1v4r1LXGPCDZAJO3AOw1EDGqy",
+		"core18": "NhSvwckvNdvgdiVGlsO1vYmi3FPdTZ9U",
+		// XXX no core20 uploaded to staging yet
+		"core20": "",
+	}
+)
+
+var wellKnownSnapIDs = prodWellKnownSnapIDs
+
+func init() {
+	if snapdenv.UseStagingStore() {
+		wellKnownSnapIDs = stagingWellKnownSnapIDs
+	}
+}
+
+// WellKnownSnapID returns the snap-id of well-known snaps (snapd, core*)
+// given the snap name or the empty string otherwise.
+func WellKnownSnapID(snapName string) string {
+	return wellKnownSnapIDs[snapName]
+}
+
+func UseStagingIDs(staging bool) (restore func()) {
+	old := wellKnownSnapIDs
+	if staging {
+		wellKnownSnapIDs = stagingWellKnownSnapIDs
+	} else {
+		wellKnownSnapIDs = prodWellKnownSnapIDs
+	}
+	return func() {
+		wellKnownSnapIDs = old
+	}
+}

--- a/snap/naming/wellknown_test.go
+++ b/snap/naming/wellknown_test.go
@@ -1,0 +1,53 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package naming_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/snap/naming"
+)
+
+type wellKnownSuite struct{}
+
+var _ = Suite(&wellKnownSuite{})
+
+func (s wellKnownSuite) TestWellKwownSnapID(c *C) {
+	c.Check(naming.WellKnownSnapID("foo"), Equals, "")
+
+	c.Check(naming.WellKnownSnapID("snapd"), Equals, "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4")
+
+	c.Check(naming.WellKnownSnapID("core"), Equals, "99T7MUlRhtI3U0QFgl5mXXESAiSwt776")
+	c.Check(naming.WellKnownSnapID("core18"), Equals, "CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6")
+	c.Check(naming.WellKnownSnapID("core20"), Equals, "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q")
+}
+
+func (s wellKnownSuite) TestWellKwownSnapIDStaging(c *C) {
+	defer naming.UseStagingIDs(true)()
+
+	c.Check(naming.WellKnownSnapID("baz"), Equals, "")
+
+	c.Check(naming.WellKnownSnapID("snapd"), Equals, "Z44rtQD1v4r1LXGPCDZAJO3AOw1EDGqy")
+
+	c.Check(naming.WellKnownSnapID("core"), Equals, "xMNMpEm0COPZy7jq9YRwWVLCD9q5peow")
+	c.Check(naming.WellKnownSnapID("core18"), Equals, "NhSvwckvNdvgdiVGlsO1vYmi3FPdTZ9U")
+	// XXX no core20 uploaded to staging yet
+	c.Check(naming.WellKnownSnapID("core20"), Equals, "")
+}

--- a/snap/naming/wellknown_test.go
+++ b/snap/naming/wellknown_test.go
@@ -29,7 +29,7 @@ type wellKnownSuite struct{}
 
 var _ = Suite(&wellKnownSuite{})
 
-func (s wellKnownSuite) TestWellKwownSnapID(c *C) {
+func (s wellKnownSuite) TestWellKnownSnapID(c *C) {
 	c.Check(naming.WellKnownSnapID("foo"), Equals, "")
 
 	c.Check(naming.WellKnownSnapID("snapd"), Equals, "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4")
@@ -39,7 +39,7 @@ func (s wellKnownSuite) TestWellKwownSnapID(c *C) {
 	c.Check(naming.WellKnownSnapID("core20"), Equals, "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q")
 }
 
-func (s wellKnownSuite) TestWellKwownSnapIDStaging(c *C) {
+func (s wellKnownSuite) TestWellKnownSnapIDStaging(c *C) {
 	defer naming.UseStagingIDs(true)()
 
 	c.Check(naming.WellKnownSnapID("baz"), Equals, "")

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -38,9 +38,6 @@ import (
 	"github.com/snapcore/snapd/timeutil"
 )
 
-// The fixed length of valid snap IDs.
-const validSnapIDLength = 32
-
 // ValidateInstanceName checks if a string can be used as a snap instance name.
 func ValidateInstanceName(instanceName string) error {
 	return naming.ValidateInstance(instanceName)


### PR DESCRIPTION
This is a function that can return the snap-id given the name for well-known snaps (snapd and core*).

Use it for:

* inferring/filling in the base snap-id when parsing UC20 model assertions that have a base header without a "snaps" stanza entry
* inferring/filling in snapd snap-id when reading UC20 seeds where it's implicit
* defining snap.IsSnapd

It can probably be used also in code that handles gadget defaults.

This also adds naming.ValidateSnapID/ValidSnapID and use them where relevant.
