### PR TITLE
boot,many: add modeenv.WriteTo, make Write take no args

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -21,7 +21,6 @@ package boot_test
 
 import (
 	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -422,9 +421,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
-	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// set the current kernel
 	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
@@ -475,9 +473,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
-	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// set the current kernel
 	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
@@ -575,7 +572,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseStatusTryingNoBaseSnapClean
 		Base:           "core20_1.snap",
 		BaseStatus:     boot.TryingStatus,
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
 	coreDev := boottest.MockUC20Device("core20")
@@ -615,7 +612,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameBaseSnap(c *C) {
 	m := &boot.Modeenv{
 		Base: "core20_1.snap",
 	}
-	err = m.Write()
+	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
 	// get the boot base participant from our base snap
@@ -650,7 +647,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnap(c *C) {
 	m := &boot.Modeenv{
 		Base: "core20_1.snap",
 	}
-	err = m.Write()
+	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
 	// get the boot base participant from our new base snap
@@ -708,7 +705,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
 		BaseStatus:     boot.TryingStatus,
 		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
 	// set the current kernel
@@ -813,7 +810,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
 	coreDev := boottest.MockUC20Device("some-snap")
@@ -874,7 +871,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseUpdate(c *C) {
 		TryBase:    "core20_2.snap",
 		BaseStatus: boot.TryingStatus,
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
 	coreDev := boottest.MockUC20Device("some-snap")
@@ -1158,9 +1155,8 @@ func (s *bootenv20Suite) TestHappyCoreParticipant20SetNextKernelSnapRebootBefore
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
-	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// set the current kernel
 	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
@@ -1240,9 +1236,8 @@ func (s *bootenv20Suite) TestHappyCoreParticipant20SetNextKernelSnapRebootBefore
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
-	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// set the current kernel
 	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -422,7 +422,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
@@ -475,7 +475,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
@@ -575,7 +575,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseStatusTryingNoBaseSnapClean
 		Base:           "core20_1.snap",
 		BaseStatus:     boot.TryingStatus,
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 
 	coreDev := boottest.MockUC20Device("core20")
@@ -615,7 +615,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameBaseSnap(c *C) {
 	m := &boot.Modeenv{
 		Base: "core20_1.snap",
 	}
-	err = m.Write("")
+	err = m.Write()
 	c.Assert(err, IsNil)
 
 	// get the boot base participant from our base snap
@@ -650,7 +650,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnap(c *C) {
 	m := &boot.Modeenv{
 		Base: "core20_1.snap",
 	}
-	err = m.Write("")
+	err = m.Write()
 	c.Assert(err, IsNil)
 
 	// get the boot base participant from our new base snap
@@ -708,7 +708,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
 		BaseStatus:     boot.TryingStatus,
 		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 
 	// set the current kernel
@@ -813,7 +813,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 
 	coreDev := boottest.MockUC20Device("some-snap")
@@ -874,7 +874,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseUpdate(c *C) {
 		TryBase:    "core20_2.snap",
 		BaseStatus: boot.TryingStatus,
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 
 	coreDev := boottest.MockUC20Device("some-snap")
@@ -1158,7 +1158,7 @@ func (s *bootenv20Suite) TestHappyCoreParticipant20SetNextKernelSnapRebootBefore
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
@@ -1240,7 +1240,7 @@ func (s *bootenv20Suite) TestHappyCoreParticipant20SetNextKernelSnapRebootBefore
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -219,7 +219,7 @@ func (ks20 *bootState20Kernel) commit() error {
 			ks20.kModeenv.modeenv.CurrentKernels,
 			ks20.tryKernelSnap.Filename(),
 		)
-		err := ks20.kModeenv.modeenv.Write("")
+		err := ks20.kModeenv.modeenv.Write()
 		if err != nil {
 			return err
 		}
@@ -368,7 +368,7 @@ func (bs20 *bootState20Base) commit() error {
 
 	// only write the modeenv if we actually changed it
 	if changed {
-		return bs20.modeenv.Write("")
+		return bs20.modeenv.Write()
 	}
 	return nil
 }
@@ -582,7 +582,7 @@ func (bsmark *bootState20MarkSuccessful) commit() error {
 
 	// write the modeenv
 	if modeenvChanged {
-		return bsmark.modeenv.Write("")
+		return bsmark.modeenv.Write()
 	}
 
 	return nil

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -155,7 +155,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
@@ -233,7 +233,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
@@ -312,7 +312,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C)
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -22,7 +22,6 @@ package boot_test
 import (
 	"errors"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -155,9 +154,8 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
-	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// setup current kernel
 	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
@@ -233,9 +231,8 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
-	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// setup current kernel
 	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
@@ -312,9 +309,8 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C)
 		Base:           "core20_1.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
-	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// setup current kernel
 	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -250,7 +250,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		Base:           filepath.Base(bootWith.BasePath),
 		CurrentKernels: []string{bootWith.Kernel.Filename()},
 	}
-	if err := modeenv.Write(filepath.Join(runMnt, "ubuntu-data", "system-data")); err != nil {
+	if err := modeenv.WriteTo(filepath.Join(runMnt, "ubuntu-data", "system-data")); err != nil {
 		return fmt.Errorf("cannot write modeenv: %v", err)
 	}
 

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -45,9 +45,9 @@ type Modeenv struct {
 	// read is set to true when a modenv was read successfully
 	read bool
 
-	// origindir is set to the location where the modeenv was read from, and
-	// where it will be written back to
-	origindir string
+	// originRootdir is set to the root whence the modeenv was
+	// read from, and where it will be written back to
+	originRootdir string
 }
 
 var readModeenv = readModeenvImpl
@@ -111,7 +111,7 @@ func readModeenvImpl(rootdir string) (*Modeenv, error) {
 		BaseStatus:     baseStatus,
 		CurrentKernels: kernels,
 		read:           true,
-		origindir:      rootdir,
+		originRootdir:  rootdir,
 	}, nil
 }
 
@@ -121,13 +121,12 @@ func (m *Modeenv) Unset() bool {
 }
 
 // Write outputs the modeenv to the file where it was read, only valid on
-// modeenv that has been read
+// modeenv that has been read.
 func (m *Modeenv) Write() error {
 	if m.read {
-		return m.WriteTo(m.origindir)
+		return m.WriteTo(m.originRootdir)
 	}
-	// use default dir
-	return m.WriteTo("")
+	return fmt.Errorf("internal error: must use WriteTo with modeenv not read from disk")
 }
 
 // WriteTo outputs the modeenv to the file at <rootdir>/var/lib/snapd/modeenv.

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -44,6 +44,10 @@ type Modeenv struct {
 
 	// read is set to true when a modenv was read successfully
 	read bool
+
+	// origindir is set to the location where the modeenv was read from, and
+	// where it will be written back to
+	origindir string
 }
 
 var readModeenv = readModeenvImpl
@@ -107,6 +111,7 @@ func readModeenvImpl(rootdir string) (*Modeenv, error) {
 		BaseStatus:     baseStatus,
 		CurrentKernels: kernels,
 		read:           true,
+		origindir:      rootdir,
 	}, nil
 }
 
@@ -115,8 +120,18 @@ func (m *Modeenv) Unset() bool {
 	return !m.read
 }
 
-// Write outputs the modeenv to the file at <rootdir>/var/lib/snapd/modeenv.
-func (m *Modeenv) Write(rootdir string) error {
+// Write outputs the modeenv to the file where it was read, only valid on
+// modeenv that has been read
+func (m *Modeenv) Write() error {
+	if m.read {
+		return m.WriteTo(m.origindir)
+	}
+	// use default dir
+	return m.WriteTo("")
+}
+
+// WriteTo outputs the modeenv to the file at <rootdir>/var/lib/snapd/modeenv.
+func (m *Modeenv) WriteTo(rootdir string) error {
 	modeenvPath := modeenvFile(rootdir)
 
 	if err := os.MkdirAll(filepath.Dir(modeenvPath), 0755); err != nil {

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -156,7 +156,7 @@ current_kernels=`+t.kernelString+"\n")
 	}
 }
 
-func (s *modeenvSuite) TestWriteNonExisting(c *C) {
+func (s *modeenvSuite) TestWriteToNonExisting(c *C) {
 	c.Assert(s.mockModeenvPath, testutil.FileAbsent)
 
 	modeenv := &boot.Modeenv{Mode: "run"}
@@ -166,7 +166,7 @@ func (s *modeenvSuite) TestWriteNonExisting(c *C) {
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, "mode=run\n")
 }
 
-func (s *modeenvSuite) TestWriteExisting(c *C) {
+func (s *modeenvSuite) TestWriteToExisting(c *C) {
 	s.makeMockModeenvFile(c, "mode=run")
 
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
@@ -178,7 +178,26 @@ func (s *modeenvSuite) TestWriteExisting(c *C) {
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, "mode=recovery\n")
 }
 
-func (s *modeenvSuite) TestWriteNonExistingFull(c *C) {
+func (s *modeenvSuite) TestWriteExisting(c *C) {
+	s.makeMockModeenvFile(c, "mode=run")
+
+	modeenv, err := boot.ReadModeenv(s.tmpdir)
+	c.Assert(err, IsNil)
+	modeenv.Mode = "recovery"
+	err = modeenv.Write()
+	c.Assert(err, IsNil)
+
+	c.Assert(s.mockModeenvPath, testutil.FileEquals, "mode=recovery\n")
+}
+
+func (s *modeenvSuite) TestWriteFreshError(c *C) {
+	modeenv := &boot.Modeenv{Mode: "recovery"}
+
+	err := modeenv.Write()
+	c.Assert(err, ErrorMatches, `internal error: must use WriteTo with modeenv not read from disk`)
+}
+
+func (s *modeenvSuite) TestWriteToNonExistingFull(c *C) {
 	c.Assert(s.mockModeenvPath, testutil.FileAbsent)
 
 	modeenv := &boot.Modeenv{

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -160,7 +160,7 @@ func (s *modeenvSuite) TestWriteNonExisting(c *C) {
 	c.Assert(s.mockModeenvPath, testutil.FileAbsent)
 
 	modeenv := &boot.Modeenv{Mode: "run"}
-	err := modeenv.Write(s.tmpdir)
+	err := modeenv.WriteTo(s.tmpdir)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, "mode=run\n")
@@ -172,7 +172,7 @@ func (s *modeenvSuite) TestWriteExisting(c *C) {
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
 	c.Assert(err, IsNil)
 	modeenv.Mode = "recovery"
-	err = modeenv.Write(s.tmpdir)
+	err = modeenv.WriteTo(s.tmpdir)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, "mode=recovery\n")
@@ -189,7 +189,7 @@ func (s *modeenvSuite) TestWriteNonExistingFull(c *C) {
 		BaseStatus:     boot.TryStatus,
 		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
 	}
-	err := modeenv.Write(s.tmpdir)
+	err := modeenv.WriteTo(s.tmpdir)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, `mode=run

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -171,7 +171,7 @@ func generateMountsModeInstall(recoverySystem string) error {
 		Mode:           "install",
 		RecoverySystem: recoverySystem,
 	}
-	if err := modeEnv.Write(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data")); err != nil {
+	if err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data")); err != nil {
 		return err
 	}
 	// and disable cloud-init in install mode
@@ -364,7 +364,7 @@ func generateMountsModeRun() error {
 	}
 
 	// 4.1 Write the modeenv out again
-	return modeEnv.Write(filepath.Join(dataDir, "system-data"))
+	return modeEnv.Write()
 }
 
 func generateInitramfsMounts() error {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -296,7 +296,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
 		Base:           "core20_123.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	// mock a bootloader
@@ -353,7 +353,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeFailsHap
 		TryBase:    "core20_124.snap",
 		BaseStatus: boot.TryingStatus,
 	}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	tryBaseSnap := filepath.Join(s.runMnt, "ubuntu-data", "system-data", dirs.SnapBlobDir, "core20_124.snap")
@@ -410,7 +410,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseEmptyHapp
 		Base:       "core20_123.snap",
 		BaseStatus: boot.TryStatus,
 	}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
@@ -460,7 +460,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeHappy(c 
 		TryBase:    "core20_124.snap",
 		BaseStatus: boot.TryStatus,
 	}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	tryBaseSnap := filepath.Join(s.runMnt, "ubuntu-data", "system-data", dirs.SnapBlobDir, "core20_124.snap")
@@ -513,7 +513,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvBaseEmptyUnhappy
 
 	// write an empty modeenv
 	modeEnv := &boot.Modeenv{}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
@@ -556,7 +556,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseNotExists
 		TryBase:    "core20_124.snap",
 		BaseStatus: boot.TryStatus,
 	}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
@@ -605,7 +605,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeKernelSnapUpgradeHappy(
 		Base:           "core20_123.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
 	}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	tryBaseSnap := filepath.Join(s.runMnt, "ubuntu-data", "system-data", dirs.SnapBlobDir, "core20_124.snap")
@@ -673,7 +673,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUntrustedKernelSnap(c *
 		Base:           "core20_123.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	// mock a bootloader
@@ -724,7 +724,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUntrustedTryKernelSnapF
 		Base:           "core20_123.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	// mock a bootloader
@@ -786,7 +786,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeKernelStatusTryingNoTry
 		Base:           "core20_123.snap",
 		CurrentKernels: []string{"pc-kernel_1.snap"},
 	}
-	err := modeEnv.Write(filepath.Join(s.runMnt, "ubuntu-data", "system-data"))
+	err := modeEnv.WriteTo(filepath.Join(dirs.RunMnt, "ubuntu-data", "system-data"))
 	c.Assert(err, IsNil)
 
 	// mock a bootloader

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -367,7 +367,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureSeededHappyWithModeenv(c *C) {
 		Mode:           "install",
 		RecoverySystem: "20191127",
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 
 	// re-create manager so that modeenv file is-read
@@ -1121,7 +1121,7 @@ func (s *deviceMgrSuite) TestDevicemgrCanStandby(c *C) {
 
 func (s *deviceMgrSuite) TestDeviceManagerReadsModeenv(c *C) {
 	modeEnv := &boot.Modeenv{Mode: "install"}
-	err := modeEnv.Write("")
+	err := modeEnv.Write()
 	c.Assert(err, IsNil)
 
 	runner := s.o.TaskRunner()

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -367,7 +367,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureSeededHappyWithModeenv(c *C) {
 		Mode:           "install",
 		RecoverySystem: "20191127",
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
 	// re-create manager so that modeenv file is-read
@@ -1121,7 +1121,7 @@ func (s *deviceMgrSuite) TestDevicemgrCanStandby(c *C) {
 
 func (s *deviceMgrSuite) TestDeviceManagerReadsModeenv(c *C) {
 	modeEnv := &boot.Modeenv{Mode: "install"}
-	err := modeEnv.Write()
+	err := modeEnv.WriteTo("")
 	c.Assert(err, IsNil)
 
 	runner := s.o.TaskRunner()

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -122,9 +122,8 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 		RecoverySystem: "20191018",
 		Base:           "core20_1.snap",
 	}
-	err := m.Write()
+	err := m.WriteTo("")
 	c.Assert(err, IsNil)
-	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 
 	// restart overlord to pick up the modeenv
 	s.startOverlord(c)

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -122,7 +122,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 		RecoverySystem: "20191018",
 		Base:           "core20_1.snap",
 	}
-	err := m.Write("")
+	err := m.Write()
 	c.Assert(err, IsNil)
 	defer os.Remove(dirs.SnapModeenvFileUnder(dirs.GlobalRootDir))
 

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -108,7 +108,7 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	if deviceCtx.HasModeenv() && deviceCtx.RunMode() {
 		// unset recovery_system because that is only needed during install mode
 		m.modeEnv.RecoverySystem = ""
-		err := m.modeEnv.Write("")
+		err := m.modeEnv.Write()
 		if err != nil {
 			return err
 		}

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -25,6 +25,7 @@ import (
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -106,9 +107,13 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if deviceCtx.HasModeenv() && deviceCtx.RunMode() {
+		modeEnv, err := boot.ReadModeenv("")
+		if err != nil {
+			return fmt.Errorf("cannot read modeenv: %v", err)
+		}
 		// unset recovery_system because that is only needed during install mode
-		m.modeEnv.RecoverySystem = ""
-		err := m.modeEnv.Write()
+		modeEnv.RecoverySystem = ""
+		err = modeEnv.Write()
 		if err != nil {
 			return err
 		}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -2015,7 +2015,7 @@ type: kernel`
 		RecoverySystem: "20191127",
 		Base:           "core20_1.snap",
 	}
-	err = m.Write("")
+	err = m.Write()
 	c.Assert(err, IsNil)
 
 	st := s.o.State()
@@ -2174,7 +2174,7 @@ type: kernel`
 		RecoverySystem: "20191127",
 		Base:           "core20_1.snap",
 	}
-	err = m.Write("")
+	err = m.Write()
 	c.Assert(err, IsNil)
 
 	st := s.o.State()

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -2015,7 +2015,7 @@ type: kernel`
 		RecoverySystem: "20191127",
 		Base:           "core20_1.snap",
 	}
-	err = m.Write()
+	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
 	st := s.o.State()
@@ -2174,7 +2174,7 @@ type: kernel`
 		RecoverySystem: "20191127",
 		Base:           "core20_1.snap",
 	}
-	err = m.Write()
+	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
 	st := s.o.State()


### PR DESCRIPTION
This is helpful in situations where we don't want to carry around a directory of where to write the modeenv when we are mutating it.

Also make some changes of s.runmnt to dirs.RunMnt in preparation for another PR which eliminates s.runmnt in favor of using dirs.RunMnt everywhere. Making this change here eliminates the likelihood of merge conflicts with that followup PR.