### PR TITLE
github: don't fail-fast

### DIFF
--- a/.github/workflows/sprd.yaml
+++ b/.github/workflows/sprd.yaml
@@ -8,6 +8,7 @@ jobs:
   unstable:
     runs-on: [self-hosted]
     strategy:
+      fail-fast: false
       matrix:
         system:
         - centos-8-64


### PR DESCRIPTION
This cancels spread execution, including the step that cleans up
runners. Before we check how to run cleanup steps let's not cancel
anything.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
