### PR TITLE
client, daemon, overlord/devicestate: request system action API and stubs

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -109,6 +109,7 @@ var api = []*Command{
 	cohortsCmd,
 	serialModelCmd,
 	systemsCmd,
+	systemsActionCmd,
 }
 
 var (

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -125,7 +125,9 @@ func postSystemsAction(c *Command, r *http.Request, user *auth.UserState) Respon
 		if os.IsNotExist(err) {
 			return NotFound("requested seed system %q does not exist", systemLabel)
 		}
-		// distinguish bad action?
+		if err == devicestate.ErrUnsupportedAction {
+			return BadRequest("requested action is not supported by system %q", systemLabel)
+		}
 		return InternalError(err.Error())
 	}
 	return SyncResponse(nil, nil)

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -810,10 +810,10 @@ func (m *DeviceManager) Systems() ([]*System, error) {
 	return systems, nil
 }
 
-// RequestSystemModel request provided system to be run in a given mode. A
+// RequestSystemAction request provided system to be run in a given mode. A
 // system reboot will be requested when the request can be successfully carried
 // out.
-func (m *DeviceManager) RequestSystemMode(systemLabel, action string) error {
+func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAction) error {
 	systemSeedDir := filepath.Join(dirs.SnapSeedDir, "systems", systemLabel)
 	if _, err := os.Stat(systemSeedDir); err != nil {
 		return err
@@ -825,14 +825,14 @@ func (m *DeviceManager) RequestSystemMode(systemLabel, action string) error {
 
 	var sysAction *SystemAction
 	for _, act := range system.Actions {
-		if action == act.Mode {
+		if action.Mode == act.Mode {
 			sysAction = &act
 			break
 		}
 	}
 	if sysAction == nil {
-		return fmt.Errorf("cannot request mode %q unsupported by system %q",
-			action, systemLabel)
+		return fmt.Errorf("cannot request unsupported mode %q for system %q",
+			action.Mode, systemLabel)
 	}
 
 	// TODO:UC20 request action

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -810,6 +810,8 @@ func (m *DeviceManager) Systems() ([]*System, error) {
 	return systems, nil
 }
 
+var ErrUnsupportedAction = errors.New("unsupported action")
+
 // RequestSystemAction request provided system to be run in a given mode. A
 // system reboot will be requested when the request can be successfully carried
 // out.
@@ -831,11 +833,10 @@ func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAct
 		}
 	}
 	if sysAction == nil {
-		return fmt.Errorf("cannot request unsupported mode %q for system %q",
-			action.Mode, systemLabel)
+		return ErrUnsupportedAction
 	}
 
-	// TODO:UC20 request action
+	// TODO:UC20 update boot environment and schedule a reboot
 	return nil
 }
 

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -244,20 +244,20 @@ func (s *deviceMgrSystemsSuite) TestBrokenSeedSystems(c *C) {
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeHappy(c *C) {
-	err := s.mgr.RequestSystemMode("20191119", "install")
+	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, IsNil)
 	// TODO:UC20 verify bootenv
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeNotFound(c *C) {
-	err := s.mgr.RequestSystemMode("not-found", "install")
+	err := s.mgr.RequestSystemAction("not-found", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, NotNil)
 	c.Assert(os.IsNotExist(err), Equals, true)
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeBadMode(c *C) {
-	err := s.mgr.RequestSystemMode("20191119", "unknown-mode")
-	c.Assert(err, ErrorMatches, `cannot request mode "unknown-mode" unsupported by system "20191119"`)
+	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "unknown-mode"})
+	c.Assert(err, ErrorMatches, `cannot request unsupported mode "unknown-mode" for system "20191119"`)
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeBroken(c *C) {
@@ -265,6 +265,6 @@ func (s *deviceMgrSystemsSuite) TestRequestModeBroken(c *C) {
 	err := os.Remove(filepath.Join(dirs.SnapSeedDir, "systems", s.mockedSystemSeeds[0].label, "model"))
 	c.Assert(err, IsNil)
 
-	err = s.mgr.RequestSystemMode("20191119", "install")
+	err = s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, "cannot load seed system: cannot load assertions: .*")
 }

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -257,7 +257,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeNotFound(c *C) {
 
 func (s *deviceMgrSystemsSuite) TestRequestModeBadMode(c *C) {
 	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "unknown-mode"})
-	c.Assert(err, ErrorMatches, `cannot request unsupported mode "unknown-mode" for system "20191119"`)
+	c.Assert(err, Equals, devicestate.ErrUnsupportedAction)
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeBroken(c *C) {

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -190,25 +190,33 @@ func (s *deviceMgrSystemsSuite) TestListSystemsNotPossible(c *C) {
 	c.Assert(systems, HasLen, 0)
 }
 
+// TODO:UC20 update once we can list actions
+var defaultActions []devicestate.SystemAction = []devicestate.SystemAction{
+	{Title: "reinstall", Mode: "install"},
+}
+
 func (s *deviceMgrSystemsSuite) TestListSeedSystems(c *C) {
 	systems, err := s.mgr.Systems()
 	c.Assert(err, IsNil)
 	c.Assert(systems, HasLen, 3)
-	c.Check(systems, DeepEquals, []devicestate.System{{
+	c.Check(systems, DeepEquals, []*devicestate.System{{
 		Current: false,
 		Label:   s.mockedSystemSeeds[0].label,
 		Model:   s.mockedSystemSeeds[0].model,
 		Brand:   s.mockedSystemSeeds[0].brand,
+		Actions: defaultActions,
 	}, {
 		Current: false,
 		Label:   s.mockedSystemSeeds[1].label,
 		Model:   s.mockedSystemSeeds[1].model,
 		Brand:   s.mockedSystemSeeds[1].brand,
+		Actions: defaultActions,
 	}, {
 		Current: false,
 		Label:   s.mockedSystemSeeds[2].label,
 		Model:   s.mockedSystemSeeds[2].model,
 		Brand:   s.mockedSystemSeeds[2].brand,
+		Actions: defaultActions,
 	}})
 }
 
@@ -220,15 +228,43 @@ func (s *deviceMgrSystemsSuite) TestBrokenSeedSystems(c *C) {
 	systems, err := s.mgr.Systems()
 	c.Assert(err, IsNil)
 	c.Assert(systems, HasLen, 2)
-	c.Check(systems, DeepEquals, []devicestate.System{{
+	c.Check(systems, DeepEquals, []*devicestate.System{{
 		Current: false,
 		Label:   s.mockedSystemSeeds[1].label,
 		Model:   s.mockedSystemSeeds[1].model,
 		Brand:   s.mockedSystemSeeds[1].brand,
+		Actions: defaultActions,
 	}, {
 		Current: false,
 		Label:   s.mockedSystemSeeds[2].label,
 		Model:   s.mockedSystemSeeds[2].model,
 		Brand:   s.mockedSystemSeeds[2].brand,
+		Actions: defaultActions,
 	}})
+}
+
+func (s *deviceMgrSystemsSuite) TestRequestModeHappy(c *C) {
+	err := s.mgr.RequestSystemMode("20191119", "install")
+	c.Assert(err, IsNil)
+	// TODO:UC20 verify bootenv
+}
+
+func (s *deviceMgrSystemsSuite) TestRequestModeNotFound(c *C) {
+	err := s.mgr.RequestSystemMode("not-found", "install")
+	c.Assert(err, NotNil)
+	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+func (s *deviceMgrSystemsSuite) TestRequestModeBadMode(c *C) {
+	err := s.mgr.RequestSystemMode("20191119", "unknown-mode")
+	c.Assert(err, ErrorMatches, `cannot request mode "unknown-mode" unsupported by system "20191119"`)
+}
+
+func (s *deviceMgrSystemsSuite) TestRequestModeBroken(c *C) {
+	// break the first seed
+	err := os.Remove(filepath.Join(dirs.SnapSeedDir, "systems", s.mockedSystemSeeds[0].label, "model"))
+	c.Assert(err, IsNil)
+
+	err = s.mgr.RequestSystemMode("20191119", "install")
+	c.Assert(err, ErrorMatches, "cannot load seed system: cannot load assertions: .*")
 }


### PR DESCRIPTION
The PR adds the API support for requesting system action. The devicemgr bit is mostly a stub that performs basic checks