### PR TITLE
config, features: move and rename config.GetFeatureFlag helper to features.Flag

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -143,3 +143,25 @@ func (f SnapdFeature) IsEnabled() bool {
 	}
 	return osutil.FileExists(f.ControlFile())
 }
+
+type confGetter interface {
+	GetMaybe(snapName, key string, result interface{}) error
+}
+
+// Flag returns the value of a given feature flag.
+func Flag(tr confGetter, feature SnapdFeature) (bool, error) {
+	var isEnabled interface{}
+	snapName, confName := feature.ConfigOption()
+	if err := tr.GetMaybe(snapName, confName, &isEnabled); err != nil {
+		return false, err
+	}
+	switch isEnabled {
+	case true, "true":
+		return true, nil
+	case false, "false":
+		return false, nil
+	case nil, "":
+		return feature.IsEnabledWhenUnset(), nil
+	}
+	return false, fmt.Errorf("%s can only be set to 'true' or 'false', got %q", feature, isEnabled)
+}

--- a/features/features.go
+++ b/features/features.go
@@ -148,7 +148,7 @@ type confGetter interface {
 	GetMaybe(snapName, key string, result interface{}) error
 }
 
-// Flag returns the value of a given feature flag.
+// Flag returns whether the given feature flag is enabled.
 func Flag(tr confGetter, feature SnapdFeature) (bool, error) {
 	var isEnabled interface{}
 	snapName, confName := feature.ConfigOption()

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1027,14 +1027,21 @@ func flatten(path string, cfg interface{}, out map[string]interface{}) {
 	}
 }
 
-// SystemDefaults returns default system configuration from gadget defaults.
-func SystemDefaults(gadgetDefaults map[string]map[string]interface{}) map[string]interface{} {
-	for _, systemSnap := range []string{"system", naming.WellKnownSnapID("core")} {
-		if defaults, ok := gadgetDefaults[systemSnap]; ok {
-			coreDefaults := map[string]interface{}{}
-			flatten("", defaults, coreDefaults)
-			return coreDefaults
+// CoreDefaults returns default system (or core) configuration from gadget defaults.
+func CoreDefaults(gadgetDefaults map[string]map[string]interface{}, coreSnapID string) (map[string]interface{}, error) {
+	coreDefaults := map[string]interface{}{}
+	if defaults, ok := gadgetDefaults["system"]; ok {
+		flatten("", defaults, coreDefaults)
+		return coreDefaults, nil
+	}
+	if defaults, ok := gadgetDefaults[coreSnapID]; ok {
+		if values, ok := defaults["core"]; ok {
+			if _, ok := values.(map[string]interface{}); ok {
+				flatten("", values, coreDefaults)
+				return coreDefaults, nil
+			}
+			return nil, fmt.Errorf("invalid structure of core defaults")
 		}
 	}
-	return nil
+	return nil, nil
 }

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1027,8 +1027,8 @@ func flatten(path string, cfg interface{}, out map[string]interface{}) {
 	}
 }
 
-// CoreDefaults returns default system (or core) configuration from gadget defaults.
-func CoreDefaults(gadgetDefaults map[string]map[string]interface{}, coreSnapID string) map[string]interface{} {
+// SystemDefaults returns default system configuration from gadget defaults.
+func SystemDefaults(gadgetDefaults map[string]map[string]interface{}, coreSnapID string) map[string]interface{} {
 	for _, systemSnap := range []string{"system", coreSnapID} {
 		if defaults, ok := gadgetDefaults[systemSnap]; ok {
 			coreDefaults := map[string]interface{}{}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1028,20 +1028,13 @@ func flatten(path string, cfg interface{}, out map[string]interface{}) {
 }
 
 // CoreDefaults returns default system (or core) configuration from gadget defaults.
-func CoreDefaults(gadgetDefaults map[string]map[string]interface{}, coreSnapID string) (map[string]interface{}, error) {
-	coreDefaults := map[string]interface{}{}
-	if defaults, ok := gadgetDefaults["system"]; ok {
-		flatten("", defaults, coreDefaults)
-		return coreDefaults, nil
-	}
-	if defaults, ok := gadgetDefaults[coreSnapID]; ok {
-		if values, ok := defaults["core"]; ok {
-			if _, ok := values.(map[string]interface{}); ok {
-				flatten("", values, coreDefaults)
-				return coreDefaults, nil
-			}
-			return nil, fmt.Errorf("invalid structure of core defaults")
+func CoreDefaults(gadgetDefaults map[string]map[string]interface{}, coreSnapID string) map[string]interface{} {
+	for _, systemSnap := range []string{"system", coreSnapID} {
+		if defaults, ok := gadgetDefaults[systemSnap]; ok {
+			coreDefaults := map[string]interface{}{}
+			flatten("", defaults, coreDefaults)
+			return coreDefaults
 		}
 	}
-	return nil, nil
+	return nil
 }

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1028,8 +1028,8 @@ func flatten(path string, cfg interface{}, out map[string]interface{}) {
 }
 
 // SystemDefaults returns default system configuration from gadget defaults.
-func SystemDefaults(gadgetDefaults map[string]map[string]interface{}, coreSnapID string) map[string]interface{} {
-	for _, systemSnap := range []string{"system", coreSnapID} {
+func SystemDefaults(gadgetDefaults map[string]map[string]interface{}) map[string]interface{} {
+	for _, systemSnap := range []string{"system", naming.WellKnownSnapID("core")} {
 		if defaults, ok := gadgetDefaults[systemSnap]; ok {
 			coreDefaults := map[string]interface{}{}
 			flatten("", defaults, coreDefaults)

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -126,9 +126,10 @@ defaults:
 
 var mockClassicGadgetCoreDefaultsYaml = []byte(`
 defaults:
-  99T7MUlRhtI3U0QFgl5mXXESAiSwt776:
-    ssh:
-      disable: true
+  otheridididididididididididididi:
+    core:
+      ssh:
+        disable: true
 `)
 
 var mockClassicGadgetMultilineDefaultsYaml = []byte(`
@@ -395,7 +396,8 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 
 	ginfo, err := gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
-	defaults := gadget.SystemDefaults(ginfo.Defaults)
+	defaults, err := gadget.CoreDefaults(ginfo.Defaults, "otheridididididididididididididi")
+	c.Assert(err, IsNil)
 	c.Check(defaults, DeepEquals, map[string]interface{}{
 		"ssh.disable": true,
 	})
@@ -403,9 +405,6 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 	yaml := string(mockClassicGadgetCoreDefaultsYaml) + `
   system:
     something: true
-    some:
-      nested:
-        option: foo
 `
 
 	err = ioutil.WriteFile(s.gadgetYamlPath, []byte(yaml), 0644)
@@ -413,10 +412,10 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 	ginfo, err = gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
 
-	defaults = gadget.SystemDefaults(ginfo.Defaults)
+	defaults, err = gadget.CoreDefaults(ginfo.Defaults, "otheridididididididididididididi")
+	c.Assert(err, IsNil)
 	c.Check(defaults, DeepEquals, map[string]interface{}{
-		"something":          true,
-		"some.nested.option": "foo",
+		"something": true,
 	})
 }
 

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -126,7 +126,7 @@ defaults:
 
 var mockClassicGadgetCoreDefaultsYaml = []byte(`
 defaults:
-  otheridididididididididididididi:
+  99T7MUlRhtI3U0QFgl5mXXESAiSwt776:
     ssh:
       disable: true
 `)
@@ -395,7 +395,7 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 
 	ginfo, err := gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
-	defaults := gadget.SystemDefaults(ginfo.Defaults, "otheridididididididididididididi")
+	defaults := gadget.SystemDefaults(ginfo.Defaults)
 	c.Check(defaults, DeepEquals, map[string]interface{}{
 		"ssh.disable": true,
 	})
@@ -410,7 +410,7 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 	ginfo, err = gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
 
-	defaults = gadget.SystemDefaults(ginfo.Defaults, "otheridididididididididididididi")
+	defaults = gadget.SystemDefaults(ginfo.Defaults)
 	c.Check(defaults, DeepEquals, map[string]interface{}{
 		"something": true,
 	})

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -127,9 +127,8 @@ defaults:
 var mockClassicGadgetCoreDefaultsYaml = []byte(`
 defaults:
   otheridididididididididididididi:
-    core:
-      ssh:
-        disable: true
+    ssh:
+      disable: true
 `)
 
 var mockClassicGadgetMultilineDefaultsYaml = []byte(`
@@ -396,8 +395,7 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 
 	ginfo, err := gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
-	defaults, err := gadget.CoreDefaults(ginfo.Defaults, "otheridididididididididididididi")
-	c.Assert(err, IsNil)
+	defaults := gadget.CoreDefaults(ginfo.Defaults, "otheridididididididididididididi")
 	c.Check(defaults, DeepEquals, map[string]interface{}{
 		"ssh.disable": true,
 	})
@@ -412,8 +410,7 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 	ginfo, err = gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
 
-	defaults, err = gadget.CoreDefaults(ginfo.Defaults, "otheridididididididididididididi")
-	c.Assert(err, IsNil)
+	defaults = gadget.CoreDefaults(ginfo.Defaults, "otheridididididididididididididi")
 	c.Check(defaults, DeepEquals, map[string]interface{}{
 		"something": true,
 	})

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -395,7 +395,7 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 
 	ginfo, err := gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
-	defaults := gadget.CoreDefaults(ginfo.Defaults, "otheridididididididididididididi")
+	defaults := gadget.SystemDefaults(ginfo.Defaults, "otheridididididididididididididi")
 	c.Check(defaults, DeepEquals, map[string]interface{}{
 		"ssh.disable": true,
 	})
@@ -410,7 +410,7 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 	ginfo, err = gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
 
-	defaults = gadget.CoreDefaults(ginfo.Defaults, "otheridididididididididididididi")
+	defaults = gadget.SystemDefaults(ginfo.Defaults, "otheridididididididididididididi")
 	c.Check(defaults, DeepEquals, map[string]interface{}{
 		"something": true,
 	})

--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -26,7 +26,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -285,22 +284,4 @@ type Conf interface {
 type ConfGetter interface {
 	Get(snapName, key string, result interface{}) error
 	GetMaybe(snapName, key string, result interface{}) error
-}
-
-// GetFeatureFlag returns the value of a given feature flag.
-func GetFeatureFlag(tr ConfGetter, feature features.SnapdFeature) (bool, error) {
-	var isEnabled interface{}
-	snapName, confName := feature.ConfigOption()
-	if err := tr.GetMaybe(snapName, confName, &isEnabled); err != nil {
-		return false, err
-	}
-	switch isEnabled {
-	case true, "true":
-		return true, nil
-	case false, "false":
-		return false, nil
-	case nil, "":
-		return feature.IsEnabledWhenUnset(), nil
-	}
-	return false, fmt.Errorf("%s can only be set to 'true' or 'false', got %q", feature, isEnabled)
 }

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -25,7 +25,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/state"
@@ -174,34 +173,6 @@ func (s *configHelpersSuite) TestSnapConfig(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(rawCfg, IsNil)
 	}
-}
-
-func (s *configHelpersSuite) TestGetFeatureFlag(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	tr := config.NewTransaction(s.state)
-
-	// Feature flags have a value even if unset.
-	flag, err := config.GetFeatureFlag(tr, features.Layouts)
-	c.Assert(err, IsNil)
-	c.Check(flag, Equals, true)
-
-	// Feature flags can be disabled.
-	c.Assert(tr.Set("core", "experimental.layouts", "false"), IsNil)
-	flag, err = config.GetFeatureFlag(tr, features.Layouts)
-	c.Assert(err, IsNil)
-	c.Check(flag, Equals, false)
-
-	// Feature flags can be enabled.
-	c.Assert(tr.Set("core", "experimental.layouts", "true"), IsNil)
-	flag, err = config.GetFeatureFlag(tr, features.Layouts)
-	c.Assert(err, IsNil)
-	c.Check(flag, Equals, true)
-
-	// Feature flags must have a well-known value.
-	c.Assert(tr.Set("core", "experimental.layouts", "banana"), IsNil)
-	_, err = config.GetFeatureFlag(tr, features.Layouts)
-	c.Assert(err, ErrorMatches, `layouts can only be set to 'true' or 'false', got "banana"`)
 }
 
 func (s *configHelpersSuite) TestPatchInvalidConfig(c *C) {

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -58,13 +58,13 @@ func doExportExperimentalFlags(tr config.ConfGetter, opts *fsOnlyContext) error 
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
-	features := features.KnownFeatures()
-	content := make(map[string]osutil.FileState, len(features))
-	for _, feature := range features {
+	feat := features.KnownFeatures()
+	content := make(map[string]osutil.FileState, len(feat))
+	for _, feature := range feat {
 		if !feature.IsExported() {
 			continue
 		}
-		isEnabled, err := config.GetFeatureFlag(tr, feature)
+		isEnabled, err := features.Flag(tr, feature)
 		if err != nil {
 			return err
 		}

--- a/overlord/ifacestate/hotplug.go
+++ b/overlord/ifacestate/hotplug.go
@@ -330,7 +330,7 @@ func (m *InterfaceManager) hotplugEnumerationDone() {
 
 func (m *InterfaceManager) hotplugEnabled() (bool, error) {
 	tr := config.NewTransaction(m.state)
-	return config.GetFeatureFlag(tr, features.Hotplug)
+	return features.Flag(tr, features.Hotplug)
 }
 
 // ensureUniqueName modifies proposedName so that it's unique according to isUnique predicate.

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -846,7 +846,7 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	)
 
 	tr := config.NewTransaction(st)
-	experimentalRefreshAppAwareness, err := config.GetFeatureFlag(tr, features.RefreshAppAwareness)
+	experimentalRefreshAppAwareness, err := features.Flag(tr, features.RefreshAppAwareness)
 	if err != nil && !config.IsNoOption(err) {
 		return err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -82,7 +82,7 @@ func isParallelInstallable(snapsup *SnapSetup) error {
 
 func optedIntoSnapdSnap(st *state.State) (bool, error) {
 	tr := config.NewTransaction(st)
-	experimentalAllowSnapd, err := config.GetFeatureFlag(tr, features.SnapdSnap)
+	experimentalAllowSnapd, err := features.Flag(tr, features.SnapdSnap)
 	if err != nil && !config.IsNoOption(err) {
 		return false, err
 	}
@@ -94,7 +94,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	// here, the resulting effects/changes were not pleasant at
 	// one point
 	tr := config.NewTransaction(st)
-	experimentalRefreshAppAwareness, err := config.GetFeatureFlag(tr, features.RefreshAppAwareness)
+	experimentalRefreshAppAwareness, err := features.Flag(tr, features.RefreshAppAwareness)
 	if err != nil && !config.IsNoOption(err) {
 		return nil, err
 	}
@@ -545,7 +545,7 @@ func validateFeatureFlags(st *state.State, info *snap.Info) error {
 	tr := config.NewTransaction(st)
 
 	if len(info.Layout) > 0 {
-		flag, err := config.GetFeatureFlag(tr, features.Layouts)
+		flag, err := features.Flag(tr, features.Layouts)
 		if err != nil {
 			return err
 		}
@@ -555,7 +555,7 @@ func validateFeatureFlags(st *state.State, info *snap.Info) error {
 	}
 
 	if info.InstanceKey != "" {
-		flag, err := config.GetFeatureFlag(tr, features.ParallelInstances)
+		flag, err := features.Flag(tr, features.ParallelInstances)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Move and rename config.GetFeatureFlag helper to features package, and rename it to Flag. This was suggested for a followup in #8309. Based on #8332 