### PR TITLE
overlord/devicestate,boot: do not hold to the originally read modeenv

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -36,3 +36,7 @@ func NewCoreKernel(s snap.PlaceInfo, d Device) *coreKernel {
 }
 
 type Trivial = trivial
+
+func (m *Modeenv) WasRead() bool {
+	return m.read
+}

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -115,11 +115,6 @@ func readModeenvImpl(rootdir string) (*Modeenv, error) {
 	}, nil
 }
 
-// Unset returns true if no modeenv file was read (yet)
-func (m *Modeenv) Unset() bool {
-	return !m.read
-}
-
 // Write outputs the modeenv to the file where it was read, only valid on
 // modeenv that has been read.
 func (m *Modeenv) Write() error {

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -46,11 +46,6 @@ func (s *modeenvSuite) SetUpTest(c *C) {
 	s.mockModeenvPath = filepath.Join(s.tmpdir, dirs.SnapModeenvFile)
 }
 
-func (s *modeenvSuite) TestUnset(c *C) {
-	modeenv := &boot.Modeenv{}
-	c.Check(modeenv.Unset(), Equals, true)
-}
-
 func (s *modeenvSuite) TestReadEmptyErrors(c *C) {
 	modeenv, err := boot.ReadModeenv("/no/such/file")
 	c.Assert(os.IsNotExist(err), Equals, true)
@@ -64,6 +59,11 @@ func (s *modeenvSuite) makeMockModeenvFile(c *C, content string) {
 	c.Assert(err, IsNil)
 }
 
+func (s *modeenvSuite) TestWasReadSanity(c *C) {
+	modeenv := &boot.Modeenv{}
+	c.Check(modeenv.WasRead(), Equals, false)
+}
+
 func (s *modeenvSuite) TestReadEmpty(c *C) {
 	s.makeMockModeenvFile(c, "")
 
@@ -72,7 +72,7 @@ func (s *modeenvSuite) TestReadEmpty(c *C) {
 	c.Check(modeenv.Mode, Equals, "")
 	c.Check(modeenv.RecoverySystem, Equals, "")
 	// an empty modeenv still means the modeenv was set
-	c.Check(modeenv.Unset(), Equals, false)
+	c.Check(modeenv.WasRead(), Equals, true)
 }
 
 func (s *modeenvSuite) TestReadMode(c *C) {

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -203,8 +203,12 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	})
 	defer restore()
 
+	modeenv := boot.Modeenv{
+		Mode:           "install",
+		RecoverySystem: "20191218",
+	}
+	c.Assert(modeenv.WriteTo(""), IsNil)
 	devicestate.SetOperatingMode(s.mgr, "install")
-	devicestate.SetRecoverySystem(s.mgr, "20191218")
 
 	s.settle(c)
 
@@ -372,8 +376,12 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade strin
 	})
 	defer restore()
 
+	modeenv := boot.Modeenv{
+		Mode:           "install",
+		RecoverySystem: "20191218",
+	}
+	c.Assert(modeenv.WriteTo(""), IsNil)
 	devicestate.SetOperatingMode(s.mgr, "install")
-	devicestate.SetRecoverySystem(s.mgr, "20191218")
 
 	s.settle(c)
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -96,10 +96,7 @@ func SetLastBecomeOperationalAttempt(m *DeviceManager, t time.Time) {
 }
 
 func SetOperatingMode(m *DeviceManager, mode string) {
-	m.modeEnv.Mode = mode
-}
-func SetRecoverySystem(m *DeviceManager, d string) {
-	m.modeEnv.RecoverySystem = d
+	m.systemMode = mode
 }
 
 func MockRepeatRequestSerial(label string) (restore func()) {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -25,7 +25,6 @@ import (
 
 	"gopkg.in/tomb.v2"
 
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -107,9 +106,12 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if deviceCtx.HasModeenv() && deviceCtx.RunMode() {
-		modeEnv, err := boot.ReadModeenv("")
+		modeEnv, err := m.readMaybeModeenv()
 		if err != nil {
-			return fmt.Errorf("cannot read modeenv: %v", err)
+			return err
+		}
+		if modeEnv == nil {
+			return fmt.Errorf("missing modeenv, cannot proceed")
 		}
 		// unset recovery_system because that is only needed during install mode
 		modeEnv.RecoverySystem = ""

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -115,7 +115,14 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		return fmt.Errorf("cannot get boot base info: %v", err)
 	}
-	recoverySystemDir := filepath.Join("/systems", m.modeEnv.RecoverySystem)
+	modeEnv, err := m.readMaybeModeenv()
+	if err != nil {
+		return err
+	}
+	if modeEnv == nil {
+		return fmt.Errorf("missing modeenv, cannot proceed")
+	}
+	recoverySystemDir := filepath.Join("/systems", modeEnv.RecoverySystem)
 	bootWith := &boot.BootableSet{
 		Base:              bootBaseInfo,
 		BasePath:          bootBaseInfo.MountFile(),


### PR DESCRIPTION
Bits might have changed and overwriting from the original is potentially risky.

Drop Modeenv.Unset, there's no clear use case for it anymore.