### PR TITLE
errtracker: add missing mocks

### DIFF
--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -124,6 +124,9 @@ bugs		: very yes
 	s.AddCleanup(errtracker.MockProcSelfExe(mockSelfExe))
 	s.AddCleanup(errtracker.MockProcSelfCwd(mockSelfCwd))
 	s.AddCleanup(testutil.MockCommand(c, "journalctl", "echo "+someJournalEntry).Restore)
+
+	mockCmd := testutil.MockCommand(c, "systemctl", "echo enabled; exit 0")
+	s.AddCleanup(mockCmd.Restore)
 }
 
 func (s *ErrtrackerTestSuite) TestReport(c *C) {


### PR DESCRIPTION
The errtracker checks if whopsie is enabled. This check is not
properly mocked so this fails on systems where this is disabled.

This commit fixes the missing mock.
