### PR TITLE
tests: cleanup security-private-tmp properly

### DIFF
--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -20,7 +20,7 @@ prepare: |
     snap install --dangerous not-test-snapd-sh_1.0_all.snap
 
 restore: |
-    rm -rf "$SNAP_INSTALL_DIR" /tmp/foo /tmp/snap.not-test-snapd-sh
+    rm -rf "$SNAP_INSTALL_DIR" /tmp/foo /tmp/snap.not-test-snapd-sh /tmp/snap.test-snapd-sh/
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh


### PR DESCRIPTION
The "snap-confine-undesired-mode-group" test sometimes fails. It
turns out this is because the "security-private-tmp" test leaves
a file that is not root owned in /tmp.

The snap-confine-undesired-mode-group is arguable testing too
much/the wrong thing. But the "security-private-tmp" is also
not properly cleaning up after itself so this commit fixes this
missing cleanup.
