### PR TITLE
interfaces/docker-support: make containerd abstract socket more generic

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -82,8 +82,8 @@ const dockerSupportConnectedPlugAppArmor = `
 /run/ipam-state/k8s-** rw,
 /run/ipam-state/k8s-*/lock k,
 
-# Socket for docker-container-shim
-unix (bind,listen) type=stream addr="@/containerd-shim/**/shim.sock\x00",
+# Socket for docker-containerd-shim
+unix (bind,listen) type=stream addr="@/containerd-shim/**.sock\x00",
 
 /{,var/}run/mount/utab r,
 


### PR DESCRIPTION
Recent k8s updates changed the socket name again and despite our recent
efforts to make it future-proof, we need to update the path again to
make it even more generic to handle this (decoded) denial:

  `addr="@/containerd-shim/...<long hex string>....sock`