### PR TITLE
github: run spread tests on PRs only

### DIFF
--- a/.github/workflows/sprd.yaml
+++ b/.github/workflows/sprd.yaml
@@ -1,9 +1,7 @@
 name: Spread
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ "master", "release/**" ]
 jobs:
   unstable:
     runs-on: [self-hosted]


### PR DESCRIPTION
Instead of running spread on PRs and on pushes to master we are now
going to run it only on PRs to master or release branches. Release
branch logic can be further tweaked if we happen to cherry pick and push
directly more than propose a pull request. IIRC we only push to release
branches because waiting on travis is so depressing so we try to avoid
it.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
