### PR TITLE
github: run C unit tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Quick Go unit tests
+name: Unit Tests
 on:
   push:
     branches: [ master ]
@@ -7,7 +7,8 @@ on:
 jobs:
   # TODO: run static checks before we run unit tests
   # TODO: run spread tests, in a matrix, after we run unit tests
-  go-unit-tests:
+  # TODO: port static checks as well
+  unit-tests:
     runs-on: ubuntu-latest
     env:
       GOPATH: ${{ github.workspace }}
@@ -19,17 +20,10 @@ jobs:
         # NOTE: checkout the code in a fixed location, even for forks, as this
         # is relevant for go's import system.
         path: ./src/github.com/snapcore/snapd
-    - name: Cache go's .cache directory (used by govendor)
-      id: cache-go-govendor
-      uses: actions/cache@v1
-      with:
-        path: ${{ github.workspace }}/.cache/govendor
-        key: go-govendor-{{ hashFiles('**/vendor.json') }}
     - name: Set up go 1.9
       uses: actions/setup-go@v1
       with:
         go-version: 1.9
-      id: go  # XXX: what is this for?
     - name: Install govendor
       run: go get -u github.com/kardianos/govendor
     # This dominates the duration of the test. Can we get a smaller set that is
@@ -42,9 +36,22 @@ jobs:
       run: |
           cd ${{ github.workspace }}/src/github.com/snapcore/snapd
           ${{ github.workspace }}/bin/govendor sync
-    - name: Build
+    - name: Cache go's .cache directory (used by govendor)
+      id: cache-go-govendor
+      uses: actions/cache@v1
+      with:
+        path: ${{ github.workspace }}/.cache/govendor
+        key: go-govendor-{{ hashFiles('**/vendor.json') }}
+    - name: Build C
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/
+          ./autogen.sh
+          make -j2
+    - name: Build Go
       run: go build github.com/snapcore/snapd/...
-    - name: Run Go unit tests
+    - name: Test C
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/
+          make check
+    - name: Test Go
       run: go test github.com/snapcore/snapd/...
-      # XXX: those are just Go unit tests, there are more tests missing that
-      # need to be ported from run-checks.


### PR DESCRIPTION
This expands the github action to cover both Go and C unit tests.
In addition some steps were renamed to give them nicer look on the
website.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
