### PR TITLE
cmd/snap: Implement a "snap routine file-access" command

### DIFF
--- a/cmd/snap/cmd_routine_file_access.go
+++ b/cmd/snap/cmd_routine_file_access.go
@@ -1,0 +1,215 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+)
+
+type cmdRoutineFileAccess struct {
+	clientMixin
+	FileAccessOptions struct {
+		Snap installedSnapName
+		Path flags.Filename
+	} `positional-args:"true" required:"true"`
+}
+
+var shortRoutineFileAccessHelp = i18n.G("Return information about file access by a snap")
+var longRoutineFileAccessHelp = i18n.G(`
+The file-access command returns information about a snap's file system access.
+
+This command is used by the xdg-document-portal service to identify
+files that do not need to be proxied to provide access within
+confinement.
+
+File paths are interpreted as host file system paths.  The tool may
+return false negatives (e.g. report that a file path is unreadable,
+despite being readable under a different path).  It also does not
+check if file system permissions would render a file unreadable.
+`)
+
+func init() {
+	addRoutineCommand("file-access", shortRoutineFileAccessHelp, longRoutineFileAccessHelp, func() flags.Commander {
+		return &cmdRoutineFileAccess{}
+	}, nil, []argDesc{
+		{
+			// TRANSLATORS: This needs to begin with < and end with >
+			name: i18n.G("<snap>"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			desc: i18n.G("Snap name"),
+		},
+		{
+			// TRANSLATORS: This needs to begin with < and end with >
+			name: i18n.G("<path>"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			desc: i18n.G("File path"),
+		},
+	})
+}
+
+func (x *cmdRoutineFileAccess) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	snapName := string(x.FileAccessOptions.Snap)
+	path := string(x.FileAccessOptions.Path)
+
+	snap, _, err := x.client.Snap(snapName)
+	if err != nil {
+		return fmt.Errorf("cannot retrieve info for snap %q: %v", snapName, err)
+	}
+
+	// Check whether the snap has home or removable-media plugs connected
+	connections, err := x.client.Connections(&client.ConnectionOptions{
+		Snap: snap.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("cannot get connections for snap %q: %v", snap.Name, err)
+	}
+	var hasHome, hasRemovableMedia bool
+	for _, conn := range connections.Established {
+		if conn.Plug.Snap != snap.Name {
+			continue
+		}
+		switch conn.Interface {
+		case "home":
+			hasHome = true
+		case "removable-media":
+			hasRemovableMedia = true
+		}
+	}
+
+	access, err := x.checkAccess(snap, hasHome, hasRemovableMedia, path)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(Stdout, access)
+	return nil
+}
+
+type FileAccess string
+
+const (
+	FileAccessHidden    FileAccess = "hidden"
+	FileAccessReadOnly  FileAccess = "read-only"
+	FileAccessReadWrite FileAccess = "read-write"
+)
+
+func splitPath(path string) ([]string, error) {
+	// Abs also cleans the path, removing any ".." components
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	// Ignore the component before the first slash
+	return strings.Split(path, string(os.PathSeparator))[1:], nil
+}
+
+func pathHasPrefix(path, prefix []string) bool {
+	if len(path) < len(prefix) {
+		return false
+	}
+	for i := range prefix {
+		if path[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (x *cmdRoutineFileAccess) checkAccess(snap *client.Snap, hasHome, hasRemovableMedia bool, path string) (FileAccess, error) {
+	// Classic confinement snaps run in the host system namespace,
+	// so can see everything.
+	if snap.Confinement == client.ClassicConfinement {
+		return FileAccessReadWrite, nil
+	}
+
+	pathParts, err := splitPath(path)
+	if err != nil {
+		return "", err
+	}
+
+	// Snaps have access to $SNAP_DATA and $SNAP_COMMON
+	if pathHasPrefix(pathParts, []string{"var", "snap", snap.Name}) {
+		if len(pathParts) == 3 {
+			return FileAccessReadOnly, nil
+		}
+		switch pathParts[3] {
+		case "common", "current", snap.Revision.String():
+			return FileAccessReadWrite, nil
+		default:
+			return FileAccessReadOnly, nil
+		}
+	}
+
+	// Snaps with removable-media plugged can access removable
+	// media mount points.
+	if hasRemovableMedia {
+		if pathHasPrefix(pathParts, []string{"mnt"}) || pathHasPrefix(pathParts, []string{"media"}) || pathHasPrefix(pathParts, []string{"run", "media"}) {
+			return FileAccessReadWrite, nil
+		}
+	}
+
+	usr, err := userCurrent()
+	if err != nil {
+		return "", fmt.Errorf("cannot get the current user: %v", err)
+	}
+
+	home, err := splitPath(usr.HomeDir)
+	if err != nil {
+		return "", err
+	}
+	if pathHasPrefix(pathParts, home) {
+		pathInHome := pathParts[len(home):]
+		// Snaps have access to $SNAP_USER_DATA and $SNAP_USER_COMMON
+		if pathHasPrefix(pathInHome, []string{"snap"}) {
+			if !pathHasPrefix(pathInHome, []string{"snap", snap.Name}) {
+				return FileAccessHidden, nil
+			}
+			if len(pathInHome) < 3 {
+				return FileAccessReadOnly, nil
+			}
+			switch pathInHome[2] {
+			case "common", "current", snap.Revision.String():
+				return FileAccessReadWrite, nil
+			default:
+				return FileAccessReadOnly, nil
+			}
+		}
+		// If the home interface is connected, the snap has
+		// access to non-dot files.
+		if hasHome {
+			if len(pathInHome) == 0 || !strings.HasPrefix(pathInHome[0], ".") {
+				return FileAccessReadWrite, nil
+			}
+		}
+	}
+
+	return FileAccessHidden, nil
+}

--- a/cmd/snap/cmd_routine_file_access.go
+++ b/cmd/snap/cmd_routine_file_access.go
@@ -121,13 +121,13 @@ const (
 	FileAccessReadWrite FileAccess = "read-write"
 )
 
-func splitPath(path string) ([]string, error) {
+func splitPathAbs(path string) ([]string, error) {
 	// Abs also cleans the path, removing any ".." components
 	path, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
 	}
-	// Ignore the component before the first slash
+	// Ignore the empty component before the first slash
 	return strings.Split(path, string(os.PathSeparator))[1:], nil
 }
 
@@ -150,7 +150,7 @@ func (x *cmdRoutineFileAccess) checkAccess(snap *client.Snap, hasHome, hasRemova
 		return FileAccessReadWrite, nil
 	}
 
-	pathParts, err := splitPath(path)
+	pathParts, err := splitPathAbs(path)
 	if err != nil {
 		return "", err
 	}
@@ -181,7 +181,7 @@ func (x *cmdRoutineFileAccess) checkAccess(snap *client.Snap, hasHome, hasRemova
 		return "", fmt.Errorf("cannot get the current user: %v", err)
 	}
 
-	home, err := splitPath(usr.HomeDir)
+	home, err := splitPathAbs(usr.HomeDir)
 	if err != nil {
 		return "", err
 	}
@@ -203,7 +203,8 @@ func (x *cmdRoutineFileAccess) checkAccess(snap *client.Snap, hasHome, hasRemova
 			}
 		}
 		// If the home interface is connected, the snap has
-		// access to non-dot files.
+		// access to other files in home, except top-level dot
+		// files.
 		if hasHome {
 			if len(pathInHome) == 0 || !strings.HasPrefix(pathInHome[0], ".") {
 				return FileAccessReadWrite, nil

--- a/cmd/snap/cmd_routine_file_access_test.go
+++ b/cmd/snap/cmd_routine_file_access_test.go
@@ -1,0 +1,184 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/client"
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+type SnapRoutineFileAccessSuite struct {
+	BaseSnapSuite
+
+	fakeHome string
+}
+
+var _ = Suite(&SnapRoutineFileAccessSuite{})
+
+func (s *SnapRoutineFileAccessSuite) SetUpTest(c *C) {
+	s.BaseSnapSuite.SetUpTest(c)
+
+	s.fakeHome = c.MkDir()
+	u, err := user.Current()
+	c.Assert(err, IsNil)
+	s.AddCleanup(snap.MockUserCurrent(func() (*user.User, error) {
+		return &user.User{Uid: u.Uid, HomeDir: s.fakeHome}, nil
+	}))
+}
+
+func (s *SnapRoutineFileAccessSuite) setUpClient(c *C, isClassic, hasHome, hasRemovableMedia bool) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/snaps/hello":
+			c.Check(r.Method, Equals, "GET")
+			response := mockInfoJSONNoLicense
+			if isClassic {
+				response = strings.Replace(response, `"confinement": "strict"`, `"confinement": "classic"`, 1)
+			}
+			fmt.Fprintln(w, response)
+		case "/v2/connections":
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/v2/connections")
+			c.Check(r.URL.Query(), DeepEquals, url.Values{
+				"snap": []string{"hello"},
+			})
+			connections := []client.Connection{}
+			if hasHome {
+				connections = append(connections, client.Connection{
+					Slot: client.SlotRef{
+						Snap: "core",
+						Name: "home",
+					},
+					Plug: client.PlugRef{
+						Snap: "hello",
+						Name: "home",
+					},
+					Interface: "home",
+				})
+			}
+			if hasRemovableMedia {
+				connections = append(connections, client.Connection{
+					Slot: client.SlotRef{
+						Snap: "core",
+						Name: "removable-media",
+					},
+					Plug: client.PlugRef{
+						Snap: "hello",
+						Name: "removable-media",
+					},
+					Interface: "removable-media",
+				})
+			}
+			result := client.Connections{Established: connections}
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		default:
+			c.Fatalf("unexpected request: %v", r)
+		}
+	})
+}
+
+func (s *SnapRoutineFileAccessSuite) checkAccess(c *C, path, access string) {
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"routine", "file-access", "hello", path})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, access)
+	c.Check(s.Stderr(), Equals, "")
+	s.ResetStdStreams()
+}
+
+func (s *SnapRoutineFileAccessSuite) checkBasicAccess(c *C) {
+	// Check access to SNAP_DATA and SNAP_COMMON
+	s.checkAccess(c, "/var/snap", "hidden\n")
+	s.checkAccess(c, "/var/snap/other-snap", "hidden\n")
+	s.checkAccess(c, "/var/snap/hello", "read-only\n")
+	s.checkAccess(c, "/var/snap/hello/common", "read-write\n")
+	s.checkAccess(c, "/var/snap/hello/current", "read-write\n")
+	s.checkAccess(c, "/var/snap/hello/100", "read-write\n")
+	s.checkAccess(c, "/var/snap/hello/99", "read-only\n")
+
+	// Check access to SNAP_USER_DATA and SNAP_USER_COMMON
+	s.checkAccess(c, filepath.Join(s.fakeHome, "snap"), "hidden\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "snap/other-snap"), "hidden\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "snap/hello"), "read-only\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "snap/hello/common"), "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "snap/hello/current"), "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "snap/hello/100"), "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "snap/hello/99"), "read-only\n")
+}
+
+func (s *SnapRoutineFileAccessSuite) TestAccessDefault(c *C) {
+	s.setUpClient(c, false, false, false)
+	s.checkBasicAccess(c)
+
+	// No access to root
+	s.checkAccess(c, "/", "hidden\n")
+	s.checkAccess(c, "/usr/lib/libfoo.so", "hidden\n")
+	// No access to removable media
+	s.checkAccess(c, "/media/foo", "hidden\n")
+	// No access to home directory
+	s.checkAccess(c, s.fakeHome, "hidden\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "Documents"), "hidden\n")
+}
+
+func (s *SnapRoutineFileAccessSuite) TestAccessClassicConfinement(c *C) {
+	s.setUpClient(c, true, false, false)
+
+	// Classic confinement snaps run in the host file system
+	// namespace, so have access to everything.
+	s.checkAccess(c, "/", "read-write\n")
+	s.checkAccess(c, "/usr/lib/libfoo.so", "read-write\n")
+	s.checkAccess(c, "/", "read-write\n")
+	s.checkAccess(c, s.fakeHome, "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "snap/other-snap"), "read-write\n")
+}
+
+func (s *SnapRoutineFileAccessSuite) TestAccessHomeInterface(c *C) {
+	s.setUpClient(c, false, true, false)
+	s.checkBasicAccess(c)
+
+	// Access to non-hidden files in the home directory
+	s.checkAccess(c, s.fakeHome, "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "Documents/foo.txt"), "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "Documents/.hidden"), "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, ".config"), "hidden\n")
+}
+
+func (s *SnapRoutineFileAccessSuite) TestAccessRemovableMedia(c *C) {
+	s.setUpClient(c, false, false, true)
+	s.checkBasicAccess(c)
+
+	s.checkAccess(c, "/mnt", "read-write\n")
+	s.checkAccess(c, "/mnt/path/file.txt", "read-write\n")
+	s.checkAccess(c, "/media", "read-write\n")
+	s.checkAccess(c, "/media/path/file.txt", "read-write\n")
+	s.checkAccess(c, "/run/media", "read-write\n")
+	s.checkAccess(c, "/run/media/path/file.txt", "read-write\n")
+}

--- a/cmd/snap/cmd_routine_file_access_test.go
+++ b/cmd/snap/cmd_routine_file_access_test.go
@@ -57,6 +57,7 @@ func (s *SnapRoutineFileAccessSuite) setUpClient(c *C, isClassic, hasHome, hasRe
 		switch r.URL.Path {
 		case "/v2/snaps/hello":
 			c.Check(r.Method, Equals, "GET")
+			// snap hello at revision 100
 			response := mockInfoJSONNoLicense
 			if isClassic {
 				response = strings.Replace(response, `"confinement": "strict"`, `"confinement": "classic"`, 1)

--- a/tests/main/snap-routine-file-access/task.yaml
+++ b/tests/main/snap-routine-file-access/task.yaml
@@ -29,6 +29,24 @@ prepare: |
     snap disconnect test-snapd-file-access:home
     snap disconnect test-snapd-file-access:removable-media
 
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+    case "$SPREAD_SYSTEM" in
+        fedora-*|arch-*|centos-*)
+            # although classic snaps do not work out of the box on fedora,
+            # we still want to verify if the basics do work if the user
+            # symlinks /snap to $SNAP_MOUNT_DIR themselves
+            ln -sf $SNAP_MOUNT_DIR /snap
+            ;;
+    esac
+
+restore: |
+    case "$SPREAD_SYSTEM" in
+        fedora-*|arch-*|centos-*)
+            rm -f /snap
+            ;;
+    esac
+
 execute: |
     access() {
         snap routine file-access test-snapd-file-access "$@"

--- a/tests/main/snap-routine-file-access/task.yaml
+++ b/tests/main/snap-routine-file-access/task.yaml
@@ -64,28 +64,28 @@ execute: |
     access /var/snap/other-snap/common | MATCH hidden
 
     # The snap has access to $SNAP_USER_DATA and $SNAP_USER_COMMON
-    access $HOME/snap/test-snapd-file-access/common | MATCH read-write
-    access $HOME/snap/test-snapd-file-access/current | MATCH read-write
-    access $HOME/snap/test-snapd-file-access/x1 | MATCH read-write
+    access "$HOME"/snap/test-snapd-file-access/common | MATCH read-write
+    access "$HOME"/snap/test-snapd-file-access/current | MATCH read-write
+    access "$HOME"/snap/test-snapd-file-access/x1 | MATCH read-write
     # It has read-only access to $SNAP_USER_DATA for other revisions
-    access $HOME/snap/test-snapd-file-access/42 | MATCH read-only
+    access "$HOME"/snap/test-snapd-file-access/42 | MATCH read-only
     # Access to other snap's data is blocked
-    access $HOME/snap/other-snap/common | MATCH hidden
+    access "$HOME"/snap/other-snap/common | MATCH hidden
 
     # Access to other user's snap data is blocked
     TEST_HOME=$(getent passwd test | cut -d: -f 6)
-    access $TEST_HOME/snap/test-snapd-file-access/common | MATCH hidden
+    access "$TEST_HOME"/snap/test-snapd-file-access/common | MATCH hidden
 
     # Without interfaces connected, the snap does not have access to
     # rest of the home directory or removable media
-    access $HOME/Documents/foo.txt | MATCH hidden
+    access "$HOME"/Documents/foo.txt | MATCH hidden
     access /media/volume/foo.txt | MATCH hidden
 
     # With the home interface connected, the snap can access the home
     # directory (but not data owned by other snaps)
     snap connect test-snapd-file-access:home
-    access $HOME/Documents/foo.txt | MATCH read-write
-    access $HOME/snap/other-snap/common | MATCH hidden
+    access "$HOME"/Documents/foo.txt | MATCH read-write
+    access "$HOME"/snap/other-snap/common | MATCH hidden
 
     # With the removable-media interface connected, the snap can
     # access removable media

--- a/tests/main/snap-routine-file-access/task.yaml
+++ b/tests/main/snap-routine-file-access/task.yaml
@@ -1,0 +1,89 @@
+summary: The file-access command provides information about access to file paths
+description: |
+    The "snap routine file-access" command is intended to be a helper for
+    xdg-document-portal.  When xdg-document-portal is asked to make a
+    file available to a snap, we would like to avoid proxying files
+    that the snap can access directly.
+
+    The command reports whether a particular file path represents the
+    same file in both the host and sandbox mount namespaces, and
+    whether it is readable or writable inside the snap sandbox.  When
+    used with the SaveFile portal API, it may be asked about file
+    paths that don't yet exist.
+
+    False negatives are not considered to be a problem: if file-access
+    reports that a path is hidden, then it will just result in the
+    document portal proxying a file that it didn't need to.
+
+    The command may also report greater access than unix file
+    permissions actually allow.  This is acceptable since there is
+    nothing the document portal can do to increase the level of
+    access.
+
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local test-snapd-file-access
+
+    # Ensure interfaces are disconnected
+    snap disconnect test-snapd-file-access:home
+    snap disconnect test-snapd-file-access:removable-media
+
+execute: |
+    access() {
+        snap routine file-access test-snapd-file-access "$@"
+    }
+    # The root directory for strict confined snaps is hidden
+    access / | MATCH hidden
+
+    # The snap has access to its $SNAP_DATA and $SNAP_COMMON directories
+    access /var/snap/test-snapd-file-access/common | MATCH read-write
+    access /var/snap/test-snapd-file-access/current | MATCH read-write
+    access /var/snap/test-snapd-file-access/x1 | MATCH read-write
+    # It has read-only access to $SNAP_DATA for other revisions
+    access /var/snap/test-snapd-file-access/42 | MATCH read-only
+    # Access to other snap's data is blocked
+    access /var/snap/other-snap/common | MATCH hidden
+
+    # The snap has access to $SNAP_USER_DATA and $SNAP_USER_COMMON
+    access $HOME/snap/test-snapd-file-access/common | MATCH read-write
+    access $HOME/snap/test-snapd-file-access/current | MATCH read-write
+    access $HOME/snap/test-snapd-file-access/x1 | MATCH read-write
+    # It has read-only access to $SNAP_USER_DATA for other revisions
+    access $HOME/snap/test-snapd-file-access/42 | MATCH read-only
+    # Access to other snap's data is blocked
+    access $HOME/snap/other-snap/common | MATCH hidden
+
+    # Access to other user's snap data is blocked
+    TEST_HOME=$(getent passwd test | cut -d: -f 6)
+    access $TEST_HOME/snap/test-snapd-file-access/common | MATCH hidden
+
+    # Without interfaces connected, the snap does not have access to
+    # rest of the home directory or removable media
+    access $HOME/Documents/foo.txt | MATCH hidden
+    access /media/volume/foo.txt | MATCH hidden
+
+    # With the home interface connected, the snap can access the home
+    # directory (but not data owned by other snaps)
+    snap connect test-snapd-file-access:home
+    access $HOME/Documents/foo.txt | MATCH read-write
+    access $HOME/snap/other-snap/common | MATCH hidden
+
+    # With the removable-media interface connected, the snap can
+    # access removable media
+    snap connect test-snapd-file-access:removable-media
+    access /media/volume/foo.txt | MATCH read-write
+
+    # File access checks for unknown snaps fail
+    not snap routine file-access no-such-snap /
+
+    # Classic confinement snaps run in the host system's mount
+    # namespace, so there are no restrictions on it's file access.
+    if [[ "$SPREAD_SYSTEM" = ubuntu-core-* ]]; then
+        exit 0
+    fi
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local test-snapd-classic-confinement --classic
+
+    snap routine file-access test-snapd-classic-confinement / | MATCH read-write

--- a/tests/main/snap-routine-file-access/test-snapd-file-access/bin/sh
+++ b/tests/main/snap-routine-file-access/test-snapd-file-access/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/snap-routine-file-access/test-snapd-file-access/meta/snap.yaml
+++ b/tests/main/snap-routine-file-access/test-snapd-file-access/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: test-snapd-file-access
+summary: A no-strings-attached, no-fuss shell for writing tests
+version: 1.0
+
+apps:
+    sh:
+        command: bin/sh
+        plugs:
+          - home
+          - removable-media


### PR DESCRIPTION
This is intended for use by xdg-document-portal to let it make decisions
about whether certain paths are safe to pass to a confined process
without being proxied.

As such, false negatives are not a big problem: it just means a file may
end up being proxied when it doesn't need to be.

The command also only cares about sandbox imposed restrictions.  So it
might report that a regular user has "read-write" access to $SNAP_DATA
when file permissions mean otherwise.  xdg-document-portal can not do
anything about this, so it is best to treat the path as if it is
read/write.