### PR TITLE
seed: validate UC20 seed system label

### DIFF
--- a/seed/export_test.go
+++ b/seed/export_test.go
@@ -27,4 +27,6 @@ type InternalSnap16 = internal.Snap16
 
 var (
 	LoadAssertions = loadAssertions
+
+	ValidateUC20SeedSystemLabel = validateUC20SeedSystemLabel
 )

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -119,6 +119,9 @@ type EssentialMetaLoaderSeed interface {
 // label if not empty is used to identify a Core 20 recovery system seed.
 func Open(seedDir, label string) (Seed, error) {
 	if label != "" {
+		if err := validateUC20SeedSystemLabel(label); err != nil {
+			return nil, err
+		}
 		return &seed20{systemDir: filepath.Join(seedDir, "systems", label)}, nil
 	}
 	// TODO: consider if systems is present to open the Core 20

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -20,6 +20,7 @@
 package seed_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1799,4 +1800,19 @@ func (s *seed20Suite) TestLoadMetaCore20LocalAssertedSnaps(c *C) {
 			Channel:  "latest/stable",
 		},
 	})
+}
+
+func (s *seed20Suite) TestOpenInvalidLabel(c *C) {
+	invalid := []string{
+		// empty string not included, as it's not a UC20 seed
+		"/bin",
+		"../../bin/bar",
+		":invalid:",
+		"日本語",
+	}
+	for _, label := range invalid {
+		seed20, err := seed.Open(s.SeedDir, label)
+		c.Assert(err, ErrorMatches, fmt.Sprintf("invalid seed system label: %q", label))
+		c.Assert(seed20, IsNil)
+	}
 }

--- a/seed/validate.go
+++ b/seed/validate.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"regexp"
 
 	"github.com/snapcore/snapd/seed/internal"
 	"github.com/snapcore/snapd/snap"
@@ -76,5 +77,16 @@ func ValidateFromYaml(seedYamlFile string) error {
 		return fmt.Errorf("cannot validate seed:%s", buf.Bytes())
 	}
 
+	return nil
+}
+
+var validSeedSystemLabel = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9-]+$")
+
+// validateSeedSystemLabel checks whether the string is a valid UC20 seed system
+// label.
+func validateUC20SeedSystemLabel(label string) error {
+	if !validSeedSystemLabel.MatchString(label) {
+		return fmt.Errorf("invalid seed system label: %q", label)
+	}
 	return nil
 }

--- a/seed/validate.go
+++ b/seed/validate.go
@@ -80,7 +80,7 @@ func ValidateFromYaml(seedYamlFile string) error {
 	return nil
 }
 
-var validSeedSystemLabel = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9-]+$")
+var validSeedSystemLabel = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])+$")
 
 // validateSeedSystemLabel checks whether the string is a valid UC20 seed system
 // label.

--- a/seed/validate_test.go
+++ b/seed/validate_test.go
@@ -265,6 +265,7 @@ snaps:
 
 func (s *validateSuite) TestValidateSeedSystemLabel(c *C) {
 	valid := []string{
+		"ab",
 		"20191119",
 		"foobar",
 		"MYSYSTEM",
@@ -280,10 +281,13 @@ func (s *validateSuite) TestValidateSeedSystemLabel(c *C) {
 
 	invalid := []string{
 		"",
+		"a", // too short
 		"/bin",
 		"../../bin/bar",
 		":invalid:",
 		"日本語",
+		"-invalid",
+		"invalid-",
 	}
 	for _, label := range invalid {
 		c.Logf("trying invalid label: %q", label)

--- a/seed/validate_test.go
+++ b/seed/validate_test.go
@@ -262,3 +262,32 @@ snaps:
 	c.Assert(err, ErrorMatches, `cannot validate seed:
 - cannot use snap /.*/snaps/some-snap-invalid-yaml_1.snap: invalid snap version: cannot be empty`)
 }
+
+func (s *validateSuite) TestValidateSeedSystemLabel(c *C) {
+	valid := []string{
+		"20191119",
+		"foobar",
+		"MYSYSTEM",
+		"mySystem",
+		"my-system",
+		"brand-system-date-1234",
+	}
+	for _, label := range valid {
+		c.Logf("trying valid label: %q", label)
+		err := seed.ValidateUC20SeedSystemLabel(label)
+		c.Check(err, IsNil)
+	}
+
+	invalid := []string{
+		"",
+		"/bin",
+		"../../bin/bar",
+		":invalid:",
+		"日本語",
+	}
+	for _, label := range invalid {
+		c.Logf("trying invalid label: %q", label)
+		err := seed.ValidateUC20SeedSystemLabel(label)
+		c.Check(err, ErrorMatches, fmt.Sprintf("invalid seed system label: %q", label))
+	}
+}


### PR DESCRIPTION
When opening the UC20 seed we add the label to the path without any validation.
The patch adds basic validation of the system labels.
