### PR TITLE
config: add new Transaction.GetPristine{,Maybe}() function

### DIFF
--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -275,6 +275,7 @@ func DeleteSnapConfig(st *state.State, snapName string) error {
 type Conf interface {
 	Get(snapName, key string, result interface{}) error
 	GetMaybe(snapName, key string, result interface{}) error
+	GetPristine(snapName, key string, result interface{}) error
 	Set(snapName, key string, value interface{}) error
 	Changes() []string
 	State() *state.State

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -211,7 +211,7 @@ func (t *Transaction) GetPristine(snapName, key string, result interface{}) erro
 	return getFromConfig(snapName, subkeys, 0, t.pristine[snapName], result)
 }
 
-// GetPristine unmarshals the cached pristine (before applying any
+// GetPristineMaybe unmarshals the cached pristine (before applying any
 // changes) value of the provided snap's configuration key into
 // result.
 //

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -194,6 +194,36 @@ func (t *Transaction) GetMaybe(instanceName, key string, result interface{}) err
 	return nil
 }
 
+// GetPristine unmarshals the cached pristine (before applying any
+// changes) value of the provided snap's configuration key into
+// result.
+//
+// If the key does not exist, an error of type *NoOptionError is returned.
+func (t *Transaction) GetPristine(snapName, key string, result interface{}) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	subkeys, err := ParseKey(key)
+	if err != nil {
+		return err
+	}
+
+	return getFromConfig(snapName, subkeys, 0, t.pristine[snapName], result)
+}
+
+// GetPristine unmarshals the cached pristine (before applying any
+// changes) value of the provided snap's configuration key into
+// result.
+//
+// If the key does not exist, no error is returned.
+func (t *Transaction) GetPristineMaybe(instanceName, key string, result interface{}) error {
+	err := t.GetPristine(instanceName, key, result)
+	if err != nil && !IsNoOption(err) {
+		return err
+	}
+	return nil
+}
+
 func getFromConfig(instanceName string, subkeys []string, pos int, config map[string]*json.RawMessage, result interface{}) error {
 	// special case - get root document
 	if len(subkeys) == 0 {

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -68,6 +68,29 @@ func (cfg *mockConf) GetMaybe(snapName, key string, result interface{}) error {
 	return nil
 }
 
+func (cfg *mockConf) GetPristine(snapName, key string, result interface{}) error {
+	if snapName != "core" {
+		return fmt.Errorf("mockConf only knows about core")
+	}
+
+	var value interface{}
+	value = cfg.conf[key]
+	if value != nil {
+		v1 := reflect.ValueOf(result)
+		v2 := reflect.Indirect(v1)
+		v2.Set(reflect.ValueOf(value))
+	}
+	return cfg.err
+}
+
+func (cfg *mockConf) GetPristineMaybe(snapName, key string, result interface{}) error {
+	err := cfg.GetPristine(snapName, key, result)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	return nil
+}
+
 func (cfg *mockConf) Set(snapName, key string, v interface{}) error {
 	if snapName != "core" {
 		return fmt.Errorf("mockConf only knows about core")


### PR DESCRIPTION
This function will give the pristine value of the given config
option before any changes are applied. This is useful to figure
out the delta between a config option change and this will be
used in the "reslience.vitality-hint" config option PR (#8351).

Split out from #8351 for easier review.