### PR TITLE
tests: adding more workers for ubuntu 20.04

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -69,7 +69,7 @@ backends:
             - ubuntu-19.10-64:
                 workers: 6
             - ubuntu-20.04-64:
-                workers: 6
+                workers: 8
             - ubuntu-core-16-64:
                 image: ubuntu-16.04-64
                 workers: 6


### PR DESCRIPTION
It is being researched why ubuntu-20.04 is taking more time to run the
tests than other systems. As travis is reaching the 50m job limit the
idea is to increase the number of workers until we can determine the
reason

spread -list google:ubuntu-18.04-64 | wc -l
481
spread -list google:ubuntu-19.10-64 | wc -l
459
spread -list google:ubuntu-20.04-64 | wc -l
452

spread -list google:ubuntu-core-18-64 | wc -l
349
spread -list google:ubuntu-core-20-64 | wc -l
309

error: https://travis-ci.org/github/snapcore/snapd/jobs/667131846