### PR TITLE
github: fix order of go get caches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,16 +43,16 @@ jobs:
         go-version: 1.9
     - name: Install govendor
       run: go get -u github.com/kardianos/govendor
-    - name: Get Go dependencies
-      run: |
-          cd ${{ github.workspace }}/src/github.com/snapcore/snapd
-          ${{ github.workspace }}/bin/govendor sync
     - name: Cache Go dependencies
       id: cache-go-govendor
       uses: actions/cache@v1
       with:
         path: ${{ github.workspace }}/.cache/govendor
         key: go-govendor-{{ hashFiles('**/vendor.json') }}
+    - name: Get Go dependencies
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd
+          ${{ github.workspace }}/bin/govendor sync
     - name: Build C
       run: |
           cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/


### PR DESCRIPTION
Cache is an _action_, it has a step that runs early and a step that runs
late. The ordering of our code was such, that we fetched go dependencies
and then restored the cache. The author of said ordering apologizes and
offers a patch.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
