### PR TITLE
seed: add Info() method for seed.Snap

### DIFF
--- a/seed/seed.go
+++ b/seed/seed.go
@@ -61,7 +61,8 @@ func (s *Snap) ID() string {
 	return s.SideInfo.SnapID
 }
 
-func (s *Snap) Info() snap.PlaceInfo {
+// PlaceInfo returns a PlaceInfo for the seed snap.
+func (s *Snap) PlaceInfo() snap.PlaceInfo {
 	return &snap.Info{SideInfo: *s.SideInfo}
 }
 

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -61,6 +61,10 @@ func (s *Snap) ID() string {
 	return s.SideInfo.SnapID
 }
 
+func (s *Snap) Info() snap.PlaceInfo {
+	return &snap.Info{SideInfo: *s.SideInfo}
+}
+
 // Seed supports loading assertions and seed snaps' metadata.
 type Seed interface {
 	// LoadAssertions loads all assertions from the seed with

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -495,6 +495,14 @@ func (s *seed16Suite) TestLoadMetaCore16(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(runSnaps, HasLen, 1)
 
+	// check that PlaceInfo method works
+	pi := essSnaps[0].PlaceInfo()
+	c.Check(pi.Filename(), Equals, "core_1.snap")
+	pi = essSnaps[1].PlaceInfo()
+	c.Check(pi.Filename(), Equals, "pc-kernel_1.snap")
+	pi = essSnaps[2].PlaceInfo()
+	c.Check(pi.Filename(), Equals, "pc_1.snap")
+
 	c.Check(runSnaps, DeepEquals, []*seed.Snap{
 		{
 			Path:     s.expectedPath("required"),

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -168,6 +168,16 @@ func (s *seed20Suite) TestLoadMetaCore20Minimal(c *C) {
 		},
 	})
 
+	// check that PlaceInfo method works
+	pi := essSnaps[0].PlaceInfo()
+	c.Check(pi.Filename(), Equals, "snapd_1.snap")
+	pi = essSnaps[1].PlaceInfo()
+	c.Check(pi.Filename(), Equals, "pc-kernel_1.snap")
+	pi = essSnaps[2].PlaceInfo()
+	c.Check(pi.Filename(), Equals, "core20_1.snap")
+	pi = essSnaps[3].PlaceInfo()
+	c.Check(pi.Filename(), Equals, "pc_1.snap")
+
 	runSnaps, err := seed20.ModeSnaps("run")
 	c.Assert(err, IsNil)
 	c.Check(runSnaps, HasLen, 0)


### PR DESCRIPTION
This is a bit of a hack, but let's us easily turn a seed.Snap into a snap.Info, which is nicer to work with when returning error messages from snap-bootstrap for example.