### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: verify the seed snap matches bootloader env

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -187,14 +187,14 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	// on e.g. ARM we need to extract the kernel assets on the recovery
 	// system as well, but the bootloader does not load any environment from
 	// the recovery system
-	ekrbl, ok := bl.(bootloader.ExtractedRecoveryKernelImageBootloader)
+	erkbl, ok := bl.(bootloader.ExtractedRecoveryKernelImageBootloader)
 	if ok {
 		kernelf, err := snap.Open(bootWith.KernelPath)
 		if err != nil {
 			return err
 		}
 
-		err = ekrbl.ExtractRecoveryKernelAssets(
+		err = erkbl.ExtractRecoveryKernelAssets(
 			bootWith.RecoverySystemDir,
 			bootWith.Kernel,
 			kernelf,

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -158,7 +158,8 @@ func generateMountsModeInstall(recoverySystem string) error {
 		return err
 	}
 	if !isMounted {
-		// TODO:UC20: is there a better way?
+		// this relies on the-tool taking our stdout and piping it directly to
+		// systemd-mount
 		fmt.Fprintf(stdout, "--type=tmpfs tmpfs /run/mnt/ubuntu-data\n")
 		return nil
 	}


### PR DESCRIPTION
The recovery system has a boot env which contains what specific kernel should be run/mounted in the snapd_recovery_kernel env var and this is supposedly what kernel was booted to get us to install mode, but we should verify this matches. Also add unit tests for the happy path and common unhappy paths.

This includes https://github.com/snapcore/snapd/pull/8365

Also some drive-bys:
* delete the cross-check TODO, as recoverySystemEssentialSnaps already is verifying the snap's signatures are valid and this is probably sufficient checks for install mode.
* fix variable name in makebootable to match what it stands for
* add an Info() method to seed.Snap (if this is controversial I can back this out)
* delete unnecessary TODO, there isn't a better way to mount ubuntu-data as tmpfs without specifying the options to systemd-mount here right now