### PR TITLE
cmd/snap: the model command needs just a client, no waitMixin

### DIFF
--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -76,7 +76,7 @@ model assertion.
 )
 
 type cmdModel struct {
-	waitMixin
+	clientMixin
 	timeMixin
 	colorMixin
 
@@ -91,7 +91,7 @@ func init() {
 		longModelHelp,
 		func() flags.Commander {
 			return &cmdModel{}
-		}, colorDescs.also(timeDescs).also(waitDescs).also(map[string]string{
+		}, colorDescs.also(timeDescs).also(map[string]string{
 			"assertion": i18n.G("Print the raw assertion."),
 			"verbose":   i18n.G("Print all specific assertion fields."),
 			"serial": i18n.G(


### PR DESCRIPTION
just noticed that model sports a --no-wait option that is not relevant
to it, it is synchronous after all, the reason was the use of the
waitMixin, switch it out in favor of just clientMixin

