### PR TITLE
overlord/devicestate, daemon: record the seed current system was installed from

### DIFF
--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -103,6 +103,13 @@ func (s *apiSuite) TestGetSystemsSome(c *check.C) {
 	c.Assert(err, check.IsNil)
 	d.overlord.AddManager(mgr)
 
+	st := d.overlord.State()
+	st.Lock()
+	st.Set("seeded-systems", []map[string]string{
+		{"system": "20200318", "model": "my-model-2", "brand-id": "my-brand"},
+	})
+	st.Unlock()
+
 	restore := s.mockSystemSeeds(c)
 	defer restore()
 
@@ -133,7 +140,7 @@ func (s *apiSuite) TestGetSystemsSome(c *check.C) {
 					{Title: "reinstall", Mode: "install"},
 				},
 			}, {
-				Current: false,
+				Current: true,
 				Label:   "20200318",
 				Model: client.SystemModelData{
 					Model:       "my-model-2",

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -105,9 +105,11 @@ func (s *apiSuite) TestGetSystemsSome(c *check.C) {
 
 	st := d.overlord.State()
 	st.Lock()
-	st.Set("seeded-systems", []map[string]string{
-		{"system": "20200318", "model": "my-model-2", "brand-id": "my-brand"},
-	})
+	st.Set("seeded-systems", []map[string]interface{}{{
+		"system": "20200318", "model": "my-model-2", "brand-id": "my-brand",
+		"revision": 2, "timestamp": "2009-11-10T23:00:00Z",
+		"seed-time": "2009-11-10T23:00:00Z",
+	}})
 	st.Unlock()
 
 	restore := s.mockSystemSeeds(c)

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -150,6 +150,7 @@ func SetBootOkRan(m *DeviceManager, b bool) {
 type (
 	RegistrationContext = registrationContext
 	RemodelContext      = remodelContext
+	SeededSystem        = seededSystem
 )
 
 func RegistrationCtx(m *DeviceManager, t *state.Task) (registrationContext, error) {

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -282,9 +282,11 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 		markSeeded.WaitFor(preseedDoneTask)
 	}
 	whatSeeds := &seededSystem{
-		System:  sysLabel,
-		Model:   model.Model(),
-		BrandID: model.BrandID(),
+		System:    sysLabel,
+		Model:     model.Model(),
+		BrandID:   model.BrandID(),
+		Revision:  model.Revision(),
+		Timestamp: model.Timestamp(),
 	}
 	markSeeded.Set("seed-system", whatSeeds)
 

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -117,9 +117,10 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 		return nil, err
 	}
 
+	var model *asserts.Model
 	// ack all initial assertions
 	timings.Run(tm, "import-assertions", "import assertions from seed", func(nested timings.Measurer) {
-		_, err = importAssertionsFromSeed(st, deviceSeed)
+		model, err = importAssertionsFromSeed(st, deviceSeed)
 	})
 	if err != nil && err != errNothingToDo {
 		return nil, err
@@ -280,6 +281,12 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 		endTs.AddTask(preseedDoneTask)
 		markSeeded.WaitFor(preseedDoneTask)
 	}
+	whatSeeds := &seededSystem{
+		System:  sysLabel,
+		Model:   model.Model(),
+		BrandID: model.BrandID(),
+	}
+	markSeeded.Set("seed-system", whatSeeds)
 
 	markSeeded.WaitAll(ts)
 	endTs.AddTask(markSeeded)

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -268,4 +268,11 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 	c.Assert(actual, HasLen, 0)
 	actual, _ = bloader.GetRunKernelImageFunctionSnapCalls("EnableTryKernel")
 	c.Assert(actual, HasLen, 0)
+
+	var whatseeded []devicestate.SeededSystem
+	err = state.Get("seeded-systems", &whatseeded)
+	c.Assert(err, IsNil)
+	c.Assert(whatseeded, DeepEquals, []devicestate.SeededSystem{
+		{System: "20191018", Model: "my-model", BrandID: "my-brand"},
+	})
 }

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -235,7 +235,7 @@ func (s *firstbootPreseed16Suite) TestPreseedHappy(c *C) {
 	s.startOverlord(c)
 	st := s.overlord.State()
 	opts := &devicestate.PopulateStateFromSeedOptions{Preseed: true}
-	chg := s.makeSeedChange(c, st, opts, checkPreseedTasks, checkPreseedOrder)
+	chg, _ := s.makeSeedChange(c, st, opts, checkPreseedTasks, checkPreseedOrder)
 	err := s.overlord.Settle(settleTimeout)
 
 	st.Lock()

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -602,6 +602,13 @@ func (s *firstBoot16Suite) TestPopulateFromSeedHappy(c *C) {
 	err = state.Get("seed-time", &seedTime)
 	c.Assert(err, IsNil)
 	c.Check(seedTime.IsZero(), Equals, false)
+
+	var whatseeded []devicestate.SeededSystem
+	err = state.Get("seeded-systems", &whatseeded)
+	c.Assert(err, IsNil)
+	c.Assert(whatseeded, DeepEquals, []devicestate.SeededSystem{
+		{System: "", Model: "my-model", BrandID: "my-brand"},
+	})
 }
 
 func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -98,6 +98,12 @@ type seededSystem struct {
 	Model  string `json:"model"`
 	// BrandID is the brand account ID
 	BrandID string `json:"brand-id"`
+	// Revision of the model assertion
+	Revision int `json:"revision"`
+	// Timestamp of model assertion
+	Timestamp time.Time `json:"timestamp"`
+	// SeedTime holds the timestamp when the system was seeded
+	SeedTime time.Time `json:"seed-time"`
 }
 
 func (m *DeviceManager) recordSeededSystem(st *state.State, whatSeeded *seededSystem) error {
@@ -140,17 +146,19 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
+	now := time.Now()
 	var whatSeeded *seededSystem
 	if err := t.Get("seed-system", &whatSeeded); err != nil && err != state.ErrNoState {
 		return err
 	}
 	if whatSeeded != nil {
+		whatSeeded.SeedTime = now
 		// TODO:UC20 what about remodels?
 		if err := m.recordSeededSystem(st, whatSeeded); err != nil {
 			return fmt.Errorf("cannot record the seeded system: %v", err)
 		}
 	}
-	st.Set("seed-time", time.Now())
+	st.Set("seed-time", now)
 	st.Set("seeded", true)
 	// make sure we setup a fallback model/consider the next phase
 	// (registration) timely


### PR DESCRIPTION
The PR adds support for recording which seed was used for installing the current system. This allows snapd to properly indicate the *current* recovery system when returning a list over `/v2/systems` endpoint.

Needed for the chooser
