### PR TITLE
devicestate: generate warning if seeding fails

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -665,12 +665,19 @@ func (e *ensureError) Error() string {
 	return strings.Join(parts, "\n - ")
 }
 
+// no \n allowed in warnings
+var seedFailureFmt = `seeding failed with: %v. This indicates an error in your distribution, please see https://forum.snapcraft.io/t/16341 for more information.`
+
 // Ensure implements StateManager.Ensure.
 func (m *DeviceManager) Ensure() error {
 	var errs []error
 
 	if err := m.ensureSeeded(); err != nil {
-		errs = append(errs, err)
+		// XXX: avoid duplicated warnings?
+		m.state.Lock()
+		m.state.Warnf(seedFailureFmt, err)
+		m.state.Unlock()
+		errs = append(errs, fmt.Errorf("cannot seed: %v", err))
 	}
 
 	if !m.preseed {

--- a/tests/main/broken-seeding/task.yaml
+++ b/tests/main/broken-seeding/task.yaml
@@ -1,0 +1,60 @@
+summary: Check that broken seeding generates an error
+
+systems: [-ubuntu-core-*]
+
+environment:
+    SEED_DIR: /var/lib/snapd/seed
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    snap pack "$TESTSLIB/snaps/basic18"
+    snap download "--$CORE_CHANNEL" core
+
+    "$TESTSLIB/reset.sh" --keep-stopped
+    mkdir -p "$SEED_DIR/snaps"
+    mkdir -p "$SEED_DIR/assertions"
+    # Break the seed by not providing a model assertion and using
+    # a base18 snap that needs a core18 base but not providing one.
+    # XXX: Another common failure is to not provide some assertions
+    #      in the seed, provide a test for this too?
+    cat > "$SEED_DIR/seed.yaml" <<EOF
+    snaps:
+      - name: core
+        channel: $CORE_CHANNEL
+        file: core.snap
+      - name: basic18
+        unasserted: true
+        file: basic18.snap
+    EOF
+    echo Copy the needed assertions to /var/lib/snapd/
+    cp core_*.assert "$SEED_DIR/assertions"
+    echo "Copy the needed snaps to $SEED_DIR/snaps"
+    cp ./core_*.snap "$SEED_DIR/snaps/core.snap"
+    cp ./basic18_1.0_all.snap "$SEED_DIR/snaps/basic.snap"
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    rm -rf "$SEED_DIR"
+    rm -f -- *.snap
+    rm -f -- *.assert
+    systemctl start snapd.socket snapd.service
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    echo "Start the daemon with an empty state"
+    systemctl start snapd.service
+
+    echo "Ensure we get a warning message"
+    retry-tool -n 30 sh -c 'snap warnings | MATCH "seeding failed "'


### PR DESCRIPTION
We got reports that seeding did not work when the focal release
had an incorrect seed.yaml. This was mostly invisible for the
user. This commit makes it more explicit.

This should help with LP: #1868706 to make it more visible at least.