### PR TITLE
tests/lib/prepare.sh: use only initrd from the kernel snap

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -77,7 +77,7 @@ backends:
                 image: ubuntu-16.04-64
                 workers: 6
             - ubuntu-core-20-64:
-                image: ubuntu-2004-64-virt-uefi-enabled
+                image: ubuntu-2004-64-virt-enabled
                 workers: 6
                 storage: 20G
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -456,8 +456,11 @@ uc20_build_initramfs_kernel_snap() {
         # this works on 20.04 but not on 18.04
         unmkinitramfs initrd unpacked-initrd
 
-        # use distro skeleton
-        cp -ar /usr/lib/ubuntu-core-initramfs skeleton
+        # use only the initrd we got from the kernel snap to inject our changes
+        # we don't use the distro package because the distro package may be 
+        # different systemd version, etc. in the initrd from the one in the 
+        # kernel and we don't want to test that, just test our snap-bootstrap
+        cp -ar unpacked-initrd skeleton
         # all the skeleton edits go to a local copy of distro directory
         skeletondir=$PWD/skeleton
         cp -a /usr/lib/snapd/snap-bootstrap "$skeletondir/main/usr/lib/snapd/snap-bootstrap"


### PR DESCRIPTION
This should unbreak master, which currently is broken because the gadget snap needs to be updated to reflect new systemd in the initrd. Regardless of that though, this is the right change because we don't want to be testing whatever version of ubuntu-core-initramfs that's in the distro package, we only want to change the kernel snap's snap-bootstrap. Everything else should be the same.

~~However, this may not unbreak master as locally I still see issues where after a successful install mode, the system just hangs in the initrd, never progressing to switch root to the final running system.~~ - this was a problem with unencrypting ubuntu-data, but if I boot with `.force-unencrypted` then that problem goes away, so that's probably an independent issue