### PR TITLE
.github: register a problem matcher to detect spread failures

### DIFF
--- a/.github/spread-problem-matcher.json
+++ b/.github/spread-problem-matcher.json
@@ -1,0 +1,14 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "spread-error",
+            "pattern": [
+                {
+                    "regexp": "^\\d+-\\d+-\\d+ \\d+:\\d+:\\d+ ((Error) (preparing|executing|restoring) .+) : .*$",
+                    "message": 1,
+                    "severity": 2
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,6 +81,8 @@ jobs:
           cd /tmp
           curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz
           tar xzvf spread-amd64.tar.gz
+          # Register a problem matcher to highlight spread failures
+          echo "::add-matcher::.github/spread-problem-matcher.json"
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}


### PR DESCRIPTION
Register a [problem matcher][1] to highlight failures in the Github Actions log files.

This should allow us to easily skip between failures rather than having to manually search through the log.  It probably won't generate annotations in the PR, since we don't have a file name to attach the error to.

[1]: https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md 