### PR TITLE
github: always run the "Discard spread workers" step, even if the job fails

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,8 +85,8 @@ jobs:
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: /tmp/spread -abend google-unstable:${{ matrix.system }}:tests/...
-      # TODO: move this to a reliable post() action.
     - name: Discard spread workers
+      if: always()
       run: |
         shopt -s nullglob;
         for r in .spread-reuse.*.yaml; do


### PR DESCRIPTION
At present, the final step of the `spread` job, responsible for discarding Spread workers, will not run if the Spread tests fail.

There is a TODO comment talking about moving this to a post() action.  However, we should be able to achieve this without writing a new action.

By default, steps have the conditional `if: success()` attached, so they will only run if the job is currently considered to be successful.  By changing this to `if: always()`, we can force a step to run even if the job has failed.