### PR TITLE
many: comment or avoid cryptic snap-ids in tests

### DIFF
--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -759,7 +759,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedConfigureHappy(c *C) {
 defaults:
     foodidididididididididididididid:
        foo-cfg: foo.
-    99T7MUlRhtI3U0QFgl5mXXESAiSwt776:
+    99T7MUlRhtI3U0QFgl5mXXESAiSwt776:  # core
        core-cfg: core_cfg_defl
     pckernelidididididididididididid:
        pc-kernel-cfg: pc-kernel_cfg_defl

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -326,7 +326,7 @@ func (s *seed20Suite) TestLoadAssertionsMultiSnapRev(c *C) {
 	seed20, err := seed.Open(s.SeedDir, sysLabel)
 	c.Assert(err, IsNil)
 	err = seed20.LoadAssertions(s.db, s.commitTo)
-	c.Check(err, ErrorMatches, `cannot have multiple snap-revisions for the same snap-id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q`)
+	c.Check(err, ErrorMatches, fmt.Sprintf(`cannot have multiple snap-revisions for the same snap-id: %s`, s.AssertedSnapID("core20")))
 }
 
 func (s *seed20Suite) TestLoadAssertionsMultiSnapDecl(c *C) {


### PR DESCRIPTION
This is a follow up for @mvo5 comments to #8335.