### PR TITLE
tests: add LXD_CHANNEL environment

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -10,6 +10,9 @@ systems: [ubuntu-16.04*64, ubuntu-18.04*, ubuntu-2*, ubuntu-core-1*]
 # with the distro
 backends: [-autopkgtest]
 
+environment:
+    LXD_CHANNEL: candidate
+
 # lxd downloads can be quite slow
 kill-timeout: 25m
 
@@ -50,7 +53,7 @@ execute: |
     fi
 
     echo "Install lxd"
-    snap install --candidate lxd
+    snap install --channel=${LXD_CHANNEL} lxd
 
     echo "Create a trivial container using the lxd snap"
     snap set lxd waitready.timeout=240
@@ -135,7 +138,7 @@ execute: |
 
     echo "Ensure we can use lxd as a snap inside lxd"
     lxd.lxc exec my-nesting-ubuntu -- apt autoremove -y lxd
-    lxd.lxc exec my-nesting-ubuntu -- snap install lxd
+    lxd.lxc exec my-nesting-ubuntu -- snap install --channel=${LXD_CHANNEL} lxd
     echo "And we can run lxd containers inside the lxd container"
     lxd.lxc exec my-nesting-ubuntu -- snap set lxd waitready.timeout=240
     lxd.lxc exec my-nesting-ubuntu -- lxd waitready


### PR DESCRIPTION
During the review of the lxd test I noticed that we are a bit
inconsistent about the channel in the inner and outer lxd.

This commit fixes this by moving the channel to the environment.
