### PR TITLE
packaging: detect/disable broken seed in the postinst

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -673,7 +673,6 @@ func (m *DeviceManager) Ensure() error {
 	var errs []error
 
 	if err := m.ensureSeeded(); err != nil {
-		// XXX: avoid duplicated warnings?
 		m.state.Lock()
 		m.state.Warnf(seedFailureFmt, err)
 		m.state.Unlock()

--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -51,6 +51,20 @@ case "$1" in
 
         # Ensure that the void directory has correct permissions.
         chmod 111 /var/lib/snapd/void
+
+        # Ubuntu 20.04 had a incorrect seed directory during development.
+        #
+        # This was causing hangs in the postinst when systemctl tries to
+        # start snapd.seeded.service which will wait for snapd to finish
+        # seeding (which will never happen because seeding is broken).
+        # See LP: 1868706
+        # This snippet detect this incorrect seed and disables it.
+        if [ -e /var/lib/snapd/seed/seed.yaml ] && [ "$(snap debug state --is-seeded /var/lib/snapd/state.json)" = "false" ]; then
+            if ! snap debug validate-seed /var/lib/snapd/seed/seed.yaml; then
+                echo "Found incorrect seed, disabling it"
+                mv /var/lib/snapd/seed /var/lib/snapd/seed.disabled
+            fi
+        fi
 esac
 
 #DEBHELPER#

--- a/tests/main/broken-seeding/task.yaml
+++ b/tests/main/broken-seeding/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that broken seeding generates an error
 
-systems: [-ubuntu-core-*]
+# not running on 14.04 as we have no real systemd here
+systems: [-ubuntu-core-*, -ubuntu-14.04-*]
 
 environment:
     SEED_DIR: /var/lib/snapd/seed
@@ -58,3 +59,19 @@ execute: |
 
     echo "Ensure we get a warning message"
     retry-tool -n 30 sh -c 'snap warnings | MATCH "seeding failed "'
+
+    # the ubuntu postinst will fix broken seeds, see LP: 1868706
+    if [[ "$SPREAD_SYSTEM" == ubuntu-* ]]; then
+        # XXX: why is this needed?
+        mkdir -p /var/lib/snapd/void
+        # during a pkg upgrade snapd is stopped
+        DPKG_MAINTSCRIPT_NAME=prerm DPKG_MAINTSCRIPT_PACKAGE=snapd /var/lib/dpkg/info/snapd.prerm upgrade 2.44
+        # run the postinst
+        DPKG_MAINTSCRIPT_NAME=postinst DPKG_MAINTSCRIPT_PACKAGE=snapd /var/lib/dpkg/info/snapd.postinst configure | MATCH "Found incorrect seed"
+        echo "Check that the seed dir got renamed"
+        test -d /var/lib/snapd/seed.disabled
+        if test -d /var/lib/snapd/seed/seed; then
+            echo "The seed dir should be renamed, test broken"
+            exit 1
+        fi
+    fi


### PR DESCRIPTION
Ubuntu 20.04 had a incorrect seed directory during development.
It contained some snaps published by publisher-id
EH9A6Xg1QtCjYt4v3QlBVTPLAHDvEIn6 but this assertion was missing
and the snaps should have been published by canonical aynway.

This will cause hangs in the postinst when systemctl tries to
start snapd.seeded.service which will wait for snapd to finish
seeding (which will never happen because seeding is broken).

See LP: 1868706

This commit detect incorrect seeds and wil automatically disable
the seed dir if such a seed is found. This should fix the hangs
and also ensure that no broken classic images with broken seeds
will be produced.

