### PR TITLE
tests: run "lxd" test again (reverts PR#8381)

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -16,9 +16,6 @@ kill-timeout: 25m
 # Start before anything else as it can take a really long time.
 priority: 1000
 
-# Skip the test until it is fixed upstream lp:1869661
-manual: true
-
 prepare: |
     # using apt here is ok because this test only runs on ubuntu
     echo "Remove any installed debs (some images carry them) to ensure we test the snap"


### PR DESCRIPTION
This commit enables the lxd test again now that LP: 1869661 is
fixed.

Blocked until the test is *actually* fixed by an updated and here as a reminder that we need to re-enable this test ASAP.