### PR TITLE
tests/main/user-session-env: stop the user session before deleting the test-zsh user

### DIFF
--- a/tests/lib/user.sh
+++ b/tests/lib/user.sh
@@ -28,6 +28,9 @@ stop_user_session() {
     fi
 
     systemctl stop "user@${TEST_UID}.service"
+    # The user-runtime-dir@.service unit did not exist before systemd
+    # 239, so ignore errors.
+    systemctl stop "user-runtime-dir@${TEST_UID}.service" || true
 }
 
 purge_user_session_data() {

--- a/tests/main/user-session-env/task.yaml
+++ b/tests/main/user-session-env/task.yaml
@@ -35,16 +35,19 @@ prepare: |
     done
 
 restore: |
-    userdel -f -r "$TEST_ZSH_USER"
-
-    rm -f test-profile-env test-profile-zsh-env test-session-env test-zsh-session-env
-
     if [ -e has-sessions ]; then
         for uid in $(id -u test) $(id -u "$TEST_ZSH_USER"); do
             systemctl stop "user@$uid.service"
+            # The user-runtime-dir@.service unit did not exist before
+            # Systemd 239, so ignore errors.
+            systemctl stop "user-runtime-dir@$uid.service" || true
         done
     fi
     rm -f ./has-sessions
+
+    userdel -f -r "$TEST_ZSH_USER"
+
+    rm -f test-profile-env test-profile-zsh-env test-session-env test-zsh-session-env
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh


### PR DESCRIPTION
The restore script for the `tests/main/user-session-env` spread test fails to properly clean up the user session for the `test-zsh` user it creates.

It first deletes the `test-zsh` user account, and then tries to get the user ID for `test-zsh` in order to stop the associated `user@uid.service` systemd unit.  Due to the way the script is structured, this "use after free" bug just results in it never trying to stop the user session rather than triggering an error.

This leaves us with a running user instance of systemd with an inaccessible home directory.  Furthermore, it has an `XDG_RUNTIME_DIR` with a `snapd-session-agent.socket`, so causes problems for tests that involve the session agent.