### PR TITLE
many: support immediate reboot

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -905,7 +905,7 @@ func (s *daemonSuite) testRestartSystemWiring(c *check.C, restartKind state.Rest
 	c.Check(delays, check.HasLen, 2)
 	if restartKind == state.RestartSystem {
 		c.Check(delays[1], check.DeepEquals, 1*time.Minute)
-	} else if restartKind == state.RestartSystemImmediate {
+	} else if restartKind == state.RestartSystemNow {
 		c.Check(delays[1], check.DeepEquals, time.Duration(0))
 	}
 
@@ -920,7 +920,7 @@ func (s *daemonSuite) testRestartSystemWiring(c *check.C, restartKind state.Rest
 	if restartKind == state.RestartSystem {
 		approxAt := now.Add(time.Minute)
 		c.Check(rebootAt.After(approxAt) || rebootAt.Equal(approxAt), check.Equals, true)
-	} else if restartKind == state.RestartSystemImmediate {
+	} else if restartKind == state.RestartSystemNow {
 		// should be good enough
 		c.Check(rebootAt.Before(now.Add(10*time.Second)), check.Equals, true)
 	}
@@ -931,7 +931,7 @@ func (s *daemonSuite) TestRestartSystemGracefulWiring(c *check.C) {
 }
 
 func (s *daemonSuite) TestRestartSystemImmediateWiring(c *check.C) {
-	s.testRestartSystemWiring(c, state.RestartSystemImmediate)
+	s.testRestartSystemWiring(c, state.RestartSystemNow)
 }
 
 func (s *daemonSuite) TestRebootHelper(c *check.C) {

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -244,7 +244,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 		})
 	}
 	c.Assert(bootMakeBootableCalled, Equals, 1)
-	c.Assert(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystem})
+	c.Assert(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemImmediate})
 
 	return nil
 }

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -244,7 +244,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 		})
 	}
 	c.Assert(bootMakeBootableCalled, Equals, 1)
-	c.Assert(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemImmediate})
+	c.Assert(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
 
 	return nil
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -134,7 +134,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// request a restart as the last action after a successful install
-	st.RequestRestart(state.RestartSystem)
+	st.RequestRestart(state.RestartSystemImmediate)
 
 	return nil
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -134,7 +134,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// request a restart as the last action after a successful install
-	st.RequestRestart(state.RestartSystemImmediate)
+	st.RequestRestart(state.RestartSystemNow)
 
 	return nil
 }

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -80,6 +80,9 @@ const (
 	RestartUnset RestartType = iota
 	RestartDaemon
 	RestartSystem
+	// RestartSystemImmediate is like RestartSystem but action is immediate,
+	// without unnecessary delay
+	RestartSystemImmediate
 	// RestartSocket will restart the daemon so that it goes into
 	// socket activation mode.
 	RestartSocket
@@ -261,7 +264,7 @@ func (s *State) EnsureBefore(d time.Duration) {
 // The state needs to be locked to request a RestartSystem.
 func (s *State) RequestRestart(t RestartType) {
 	if s.backend != nil {
-		if t == RestartSystem {
+		if t == RestartSystem || t == RestartSystemImmediate {
 			if s.bootID == "" {
 				panic("internal error: cannot request a system restart if current boot ID was not provided via VerifyReboot")
 			}

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -80,9 +80,8 @@ const (
 	RestartUnset RestartType = iota
 	RestartDaemon
 	RestartSystem
-	// RestartSystemImmediate is like RestartSystem but action is immediate,
-	// without unnecessary delay
-	RestartSystemImmediate
+	// RestartSystemNow is like RestartSystem but action is immediate
+	RestartSystemNow
 	// RestartSocket will restart the daemon so that it goes into
 	// socket activation mode.
 	RestartSocket
@@ -264,7 +263,7 @@ func (s *State) EnsureBefore(d time.Duration) {
 // The state needs to be locked to request a RestartSystem.
 func (s *State) RequestRestart(t RestartType) {
 	if s.backend != nil {
-		if t == RestartSystem || t == RestartSystemImmediate {
+		if t == RestartSystem || t == RestartSystemNow {
 			if s.bootID == "" {
 				panic("internal error: cannot request a system restart if current boot ID was not provided via VerifyReboot")
 			}


### PR DESCRIPTION
Our reboot process adds a minimum of 1 minute delay from the request to when the reboot actually happens. This is undesirable in a number of scenarios, specifically when a UC20 install is finished, and when we reboot into a recovery system (once #8369 lands).

The PR introduces a new restart type and hooks up the install mode to use the type. Testing this locally in a VM makes the install process feel much faster.
