### PR TITLE
cmd/snap,seed: validate full seeds (UC 16/18)

### DIFF
--- a/cmd/snap/cmd_debug_validate_seed_test.go
+++ b/cmd/snap/cmd_debug_validate_seed_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -28,7 +28,7 @@ import (
 	snap "github.com/snapcore/snapd/cmd/snap"
 )
 
-func (s *SnapSuite) TestDebugValidateSeedRegressionLp1825437(c *C) {
+func (s *SnapSuite) TestDebugValidateCannotValidate(c *C) {
 	tmpf := filepath.Join(c.MkDir(), "seed.yaml")
 	err := ioutil.WriteFile(tmpf, []byte(`
 snaps:
@@ -36,29 +36,10 @@ snaps:
    name: core
    channel: stable
    file: core_6673.snap
- -
- -
-   name: gnome-foo
-   channel: stable/ubuntu-19.04
-   file: gtk-common-themes_1198.snap
 `), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "validate-seed", tmpf})
-	c.Assert(err, ErrorMatches, "cannot read seed yaml: empty element in seed")
-}
-
-func (s *SnapSuite) TestDebugValidateSeedDuplicatedSnap(c *C) {
-	tmpf := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(tmpf, []byte(`
-snaps:
- - name: foo
-   file: foo.snap
- - name: foo
-   file: bar.snap
-`), 0644)
-	c.Assert(err, IsNil)
-
-	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "validate-seed", tmpf})
-	c.Assert(err, ErrorMatches, `cannot read seed yaml: snap name "foo" must be unique`)
+	c.Assert(err, ErrorMatches, `cannot validate seed:
+ - no seed assertions`)
 }

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -306,4 +306,17 @@ func (s *seed16) ModeSnaps(mode string) ([]*Snap, error) {
 		return nil, fmt.Errorf("internal error: Core 16/18 have only run mode, got: %s", mode)
 	}
 	return s.snaps[s.essentialSnapsNum:], nil
+}
+
+func (s *seed16) NumSnaps() int {
+	return len(s.snaps)
+}
+
+func (s *seed16) Iter(f func(sn *Snap) error) error {
+	for _, sn := range s.snaps {
+		if err := f(sn); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/seed/validate.go
+++ b/seed/validate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -24,61 +24,114 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 
-	"github.com/snapcore/snapd/seed/internal"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/timings"
 )
+
+type ValidationError struct {
+	// SystemErrors maps system labels ("" for UC16/18) to their validation errors.
+	SystemErrors map[string][]error
+}
+
+func newValidationError(label string, err error) *ValidationError {
+	return &ValidationError{SystemErrors: map[string][]error{
+		label: {err},
+	}}
+}
+
+func (e *ValidationError) addErr(label string, errs ...error) {
+	if e.SystemErrors == nil {
+		e.SystemErrors = make(map[string][]error)
+	}
+	for _, err := range errs {
+		e.SystemErrors[label] = append(e.SystemErrors[label], err)
+	}
+}
+
+func (e ValidationError) hasErrors() bool {
+	return len(e.SystemErrors) != 0
+}
+
+func (e *ValidationError) Error() string {
+	systems := make([]string, 0, len(e.SystemErrors))
+	for s := range e.SystemErrors {
+		systems = append(systems, s)
+	}
+	sort.Strings(systems)
+	var buf bytes.Buffer
+	first := true
+	for _, s := range systems {
+		if first {
+			if s == "" {
+				fmt.Fprintf(&buf, "cannot validate seed:")
+			} else {
+				fmt.Fprintf(&buf, "cannot validate seed system %q:", s)
+			}
+		} else {
+			fmt.Fprintf(&buf, "\nand seed system %q:", s)
+		}
+		for _, err := range e.SystemErrors[s] {
+			fmt.Fprintf(&buf, "\n - %s", err)
+		}
+	}
+	return buf.String()
+}
 
 // ValidateFromYaml validates the given seed.yaml file and surrounding seed.
 func ValidateFromYaml(seedYamlFile string) error {
-	seed, err := internal.ReadSeedYaml(seedYamlFile)
+	// TODO:UC20: support validating also one or multiple UC20 seed systems
+	// introduce ListSystems ?
+	// What about full empty seed dir?
+	seedDir := filepath.Dir(seedYamlFile)
+
+	seed, err := Open(seedDir, "")
 	if err != nil {
-		return err
+		return newValidationError("", err)
 	}
 
-	var errs []error
-	var haveCore, haveSnapd bool
+	if err := seed.LoadAssertions(nil, nil); err != nil {
+		return newValidationError("", err)
+	}
+
+	tm := timings.New(nil)
+	if err := seed.LoadMeta(tm); err != nil {
+		return newValidationError("", err)
+	}
+
+	// TODO:UC20: make the NumSnaps/Iter part of Seed
+	seed16 := seed.(*seed16)
+
+	ve := &ValidationError{}
 	// read the snap infos
-	snapInfos := make([]*snap.Info, 0, len(seed.Snaps))
-	for _, seedSnap := range seed.Snaps {
-		fn := filepath.Join(filepath.Dir(seedYamlFile), "snaps", seedSnap.File)
-		snapf, err := snap.Open(fn)
+	snapInfos := make([]*snap.Info, 0, seed16.NumSnaps())
+	seed16.Iter(func(sn *Snap) error {
+		snapf, err := snap.Open(sn.Path)
 		if err != nil {
-			errs = append(errs, err)
+			ve.addErr("", err)
 		} else {
-			info, err := snap.ReadInfoFromSnapFile(snapf, nil)
+			info, err := snap.ReadInfoFromSnapFile(snapf, sn.SideInfo)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("cannot use snap %s: %v", fn, err))
+				ve.addErr("", fmt.Errorf("cannot use snap %q: %v", sn.Path, err))
 			} else {
-				switch info.InstanceName() {
-				case "core":
-					haveCore = true
-				case "snapd":
-					haveSnapd = true
-				}
 				snapInfos = append(snapInfos, info)
 			}
 		}
-	}
-
-	// ensure we have either "core" or "snapd"
-	if !(haveCore || haveSnapd) {
-		errs = append(errs, fmt.Errorf("the core or snapd snap must be part of the seed"))
-	}
+		return nil
+	})
 
 	if errs2 := snap.ValidateBasesAndProviders(snapInfos); errs2 != nil {
-		errs = append(errs, errs2...)
+		ve.addErr("", errs2...)
 	}
-	if errs != nil {
-		var buf bytes.Buffer
-		for _, err := range errs {
-			fmt.Fprintf(&buf, "\n- %s", err)
-		}
-		return fmt.Errorf("cannot validate seed:%s", buf.Bytes())
+	if ve.hasErrors() {
+		return ve
 	}
 
 	return nil
 }
+
+// TODO:UC20: move these to internal, use also in seedwriter
 
 var validSeedSystemLabel = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])+$")
 

--- a/seed/validate_test.go
+++ b/seed/validate_test.go
@@ -336,6 +336,50 @@ snaps:
 
 }
 
+func (s *validateSuite) TestValidateFromYamlDuplicatedSnap(c *C) {
+	s.makeSnapInSeed(c, coreYaml)
+	s.makeSnapInSeed(c, `name: gtk-common-themes
+version: 19.04`)
+	seedFn := s.makeSeedYaml(c, `
+snaps:
+ - name: core
+   channel: stable
+   file: core_1.snap
+ - name: gtk-common-themes
+   channel: stable/ubuntu-19.04
+   file: gtk-common-themes_1.snap
+ - name: gtk-common-themes
+   channel: stable/ubuntu-19.04
+   file: gtk-common-themes_1.snap
+`)
+
+	err := seed.ValidateFromYaml(seedFn)
+	c.Assert(err, ErrorMatches, `cannot validate seed:
+ - cannot read seed yaml: snap name "gtk-common-themes" must be unique`)
+}
+
+func (s *validateSuite) TestValidateFromYamlRegressionLP1825437(c *C) {
+	s.makeSnapInSeed(c, coreYaml)
+	s.makeSnapInSeed(c, `name: gtk-common-themes
+version: 19.04`)
+	seedFn := s.makeSeedYaml(c, `
+snaps:
+ -
+   name: core
+   channel: stable
+   file: core_1.snap
+ -
+ -
+   name: gtk-common-themes
+   channel: stable/ubuntu-19.04
+   file: gtk-common-themes_1.snap
+`)
+
+	err := seed.ValidateFromYaml(seedFn)
+	c.Assert(err, ErrorMatches, `cannot validate seed:
+ - cannot read seed yaml: empty element in seed`)
+}
+
 func (s *validateSuite) TestValidateSeedSystemLabel(c *C) {
 	valid := []string{
 		"ab",

--- a/seed/validate_test.go
+++ b/seed/validate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -27,16 +27,18 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type validateSuite struct {
 	testutil.BaseTest
-	root string
+
+	*seedtest.TestingSeed16
 }
 
 var _ = Suite(&validateSuite{})
@@ -61,23 +63,40 @@ func (s *validateSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
-	s.root = c.MkDir()
+	s.TestingSeed16 = &seedtest.TestingSeed16{}
+	s.SetupAssertSigning("canonical")
+	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+		"verification": "verified",
+	})
 
-	err := os.MkdirAll(filepath.Join(s.root, "snaps"), 0755)
+	s.SeedDir = c.MkDir()
+
+	s.AddCleanup(seed.MockTrusted(s.StoreSigning.Trusted))
+
+	err := os.MkdirAll(s.SnapsDir(), 0755)
 	c.Assert(err, IsNil)
+	err = os.Mkdir(s.AssertsDir(), 0755)
+	c.Assert(err, IsNil)
+
+	modelChain := s.MakeModelAssertionChain("my-brand", "my-model", map[string]interface{}{
+		"classic": "true",
+	})
+	s.WriteAssertions("model.asserts", modelChain...)
 }
 
 func (s *validateSuite) makeSnapInSeed(c *C, snapYaml string) {
-	info, err := snap.InfoFromSnapYaml([]byte(snapYaml))
+	publisher := "canonical"
+	fname, decl, rev := s.MakeAssertedSnap(c, snapYaml, nil, snap.R(1), publisher)
+	err := os.Rename(filepath.Join(s.SnapsDir(), fname), filepath.Join(s.SnapsDir(), fmt.Sprintf("%s_%s.snap", decl.SnapName(), snap.R(1))))
 	c.Assert(err, IsNil)
 
-	src := snaptest.MakeTestSnapWithFiles(c, snapYaml, nil)
-	dst := filepath.Join(s.root, "snaps", fmt.Sprintf("%s_%s.snap", info.SnapName(), snap.R(1)))
-	c.Assert(os.Rename(src, dst), IsNil)
+	acct, err := s.StoreSigning.Find(asserts.AccountType, map[string]string{"account-id": publisher})
+	c.Assert(err, IsNil)
+	s.WriteAssertions(fmt.Sprintf("%s.asserts", decl.SnapName()), rev, decl, acct)
 }
 
 func (s *validateSuite) makeSeedYaml(c *C, seedYaml string) string {
-	tmpf := filepath.Join(s.root, "seed.yaml")
+	tmpf := filepath.Join(s.SeedDir, "seed.yaml")
 	err := ioutil.WriteFile(tmpf, []byte(seedYaml), 0644)
 	c.Assert(err, IsNil)
 	return tmpf
@@ -116,7 +135,7 @@ snaps:
 
 	err := seed.ValidateFromYaml(seedFn)
 	c.Assert(err, ErrorMatches, `cannot validate seed:
-- cannot use snap "need-base": base "some-base" is missing`)
+ - cannot use snap "need-base": base "some-base" is missing`)
 }
 
 func (s *validateSuite) TestValidateFromYamlSnapMissingDefaultProvider(c *C) {
@@ -138,7 +157,7 @@ snaps:
 
 	err := seed.ValidateFromYaml(seedFn)
 	c.Assert(err, ErrorMatches, `cannot validate seed:
-- cannot use snap "need-df": default provider "gtk-common-themes" is missing`)
+ - cannot use snap "need-df": default provider "gtk-common-themes" is missing`)
 }
 
 func (s *validateSuite) TestValidateFromYamlSnapSnapdHappy(c *C) {
@@ -176,7 +195,7 @@ snaps:
 
 	err := seed.ValidateFromYaml(seedFn)
 	c.Assert(err, ErrorMatches, `cannot validate seed:
-- cannot use snap "some-snap": required snap "core" missing`)
+ - cannot use snap "some-snap": required snap "core" missing`)
 }
 
 func (s *validateSuite) TestValidateFromYamlSnapMissingSnapdAndCore(c *C) {
@@ -194,22 +213,86 @@ snaps:
 
 	err := seed.ValidateFromYaml(seedFn)
 	c.Assert(err, ErrorMatches, `cannot validate seed:
-- the core or snapd snap must be part of the seed`)
+ - essential snap "core" required by the model is missing in the seed`)
+}
+
+func (s *validateSuite) makeBrokenSnap(c *C, snapYaml string) (snapPath string) {
+	snapBuildDir := c.MkDir()
+	metaSnapYaml := filepath.Join(snapBuildDir, "meta", "snap.yaml")
+	err := os.MkdirAll(filepath.Dir(metaSnapYaml), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(metaSnapYaml, []byte(snapYaml), 0644)
+	c.Assert(err, IsNil)
+
+	// need to build the snap "manually" pack.Snap() will do validation
+	snapPath = filepath.Join(c.MkDir(), "broken.snap")
+	d := squashfs.New(snapPath)
+	err = d.Build(snapBuildDir, nil)
+	c.Assert(err, IsNil)
+
+	return snapPath
+}
+
+func (s *validateSuite) TestValidateFromYamlSnapSnapInvalid(c *C) {
+	s.makeSnapInSeed(c, coreYaml)
+
+	// "version" is missing in this yaml
+	snapYaml := `name: some-snap-invalid-yaml`
+	snapPath := s.makeBrokenSnap(c, snapYaml)
+
+	// put the broken snap in place
+	dst := filepath.Join(s.SnapsDir(), "some-snap-invalid-yaml_1.snap")
+	err := os.Rename(snapPath, dst)
+	c.Assert(err, IsNil)
+
+	seedFn := s.makeSeedYaml(c, `
+snaps:
+ - name: core
+   file: core_1.snap
+ - name: some-snap-invalid-yaml
+   unasserted: true
+   file: some-snap-invalid-yaml_1.snap
+`)
+
+	err = seed.ValidateFromYaml(seedFn)
+	c.Assert(err, ErrorMatches, `cannot validate seed:
+ - cannot use snap "/.*/snaps/some-snap-invalid-yaml_1.snap": invalid snap version: cannot be empty`)
 }
 
 func (s *validateSuite) TestValidateFromYamlSnapMultipleErrors(c *C) {
-	s.makeSnapInSeed(c, `name: some-snap
-version: 1.0`)
-	seedFn := s.makeSeedYaml(c, `
-snaps:
- - name: some-snap
-   file: some-snap_1.snap
+	s.makeSnapInSeed(c, coreYaml)
+	s.makeSnapInSeed(c, `name: need-df
+version: 1.0
+plugs:
+ gtk-3-themes:
+  interface: content
+  default-provider: gtk-common-themes
 `)
 
-	err := seed.ValidateFromYaml(seedFn)
+	// "version" is missing in this yaml
+	snapYaml := `name: some-snap-invalid-yaml`
+	snapPath := s.makeBrokenSnap(c, snapYaml)
+
+	// put the broken snap in place
+	dst := filepath.Join(s.SnapsDir(), "some-snap-invalid-yaml_1.snap")
+	err := os.Rename(snapPath, dst)
+	c.Assert(err, IsNil)
+
+	seedFn := s.makeSeedYaml(c, `
+snaps:
+ - name: core
+   file: core_1.snap
+ - name: need-df
+   file: need-df_1.snap
+ - name: some-snap-invalid-yaml
+   unasserted: true
+   file: some-snap-invalid-yaml_1.snap
+`)
+
+	err = seed.ValidateFromYaml(seedFn)
 	c.Assert(err, ErrorMatches, `cannot validate seed:
-- the core or snapd snap must be part of the seed
-- cannot use snap "some-snap": required snap "core" missing`)
+ - cannot use snap "/.*/snaps/some-snap-invalid-yaml_1.snap": invalid snap version: cannot be empty
+ - cannot use snap "need-df": default provider "gtk-common-themes" is missing`)
 }
 
 func (s *validateSuite) TestValidateFromYamlSnapSnapMissing(c *C) {
@@ -224,43 +307,33 @@ snaps:
 
 	err := seed.ValidateFromYaml(seedFn)
 	c.Assert(err, ErrorMatches, `cannot validate seed:
-- cannot open snap: open /.*/snaps/some-snap_1.snap: no such file or directory`)
+ - cannot compute snap "/.*/snaps/some-snap_1.snap" digest:.* no such file or directory`)
 }
 
-func (s *validateSuite) TestValidateFromYamlSnapSnapInvalid(c *C) {
-	s.makeSnapInSeed(c, coreYaml)
-
-	// "version" is missing in this yaml
-	snapBuildDir := c.MkDir()
-	snapYaml := `name: some-snap-invalid-yaml`
-	metaSnapYaml := filepath.Join(snapBuildDir, "meta", "snap.yaml")
-	err := os.MkdirAll(filepath.Dir(metaSnapYaml), 0755)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(metaSnapYaml, []byte(snapYaml), 0644)
-	c.Assert(err, IsNil)
-
-	// need to build the snap "manually" pack.Snap() will do validation
-	snapFilePath := filepath.Join(c.MkDir(), "some-snap-invalid-yaml_1.snap")
-	d := squashfs.New(snapFilePath)
-	err = d.Build(snapBuildDir, nil)
-	c.Assert(err, IsNil)
-
-	// put the broken snap in place
-	dst := filepath.Join(s.root, "snaps", "some-snap-invalid-yaml_1.snap")
-	err = os.Rename(snapFilePath, dst)
-	c.Assert(err, IsNil)
-
+func (s *validateSuite) TestValidateFromYamlSnapMissingAssertions(c *C) {
+	s.makeSnapInSeed(c, snapdYaml)
+	s.makeSnapInSeed(c, packageCore18)
+	s.makeSnapInSeed(c, `name: some-snap
+version: 1.0
+base: core18
+`)
 	seedFn := s.makeSeedYaml(c, `
 snaps:
- - name: core
-   file: core_1.snap
- - name: some-snap-invalid-yaml
-   file: some-snap-invalid-yaml_1.snap
+ - name: snapd
+   file: snapd_1.snap
+ - name: some-snap
+   file: some-snap_1.snap
+ - name: core18
+   file: core18_1.snap
 `)
+
+	err := os.Remove(filepath.Join(s.AssertsDir(), "some-snap.asserts"))
+	c.Assert(err, IsNil)
 
 	err = seed.ValidateFromYaml(seedFn)
 	c.Assert(err, ErrorMatches, `cannot validate seed:
-- cannot use snap /.*/snaps/some-snap-invalid-yaml_1.snap: invalid snap version: cannot be empty`)
+ - cannot find signatures with metadata for snap "some-snap" .*`)
+
 }
 
 func (s *validateSuite) TestValidateSeedSystemLabel(c *C) {


### PR DESCRIPTION
This switches ValidateFromYaml to actually use seed.Open/seed.Seed so that the validation is closer to how first boot code works now, and assertions are validated too.

Bunch of TODOs to extend this to UC20 in follow ups.

This also moves current validate-seed tests from cmd/snap to seed because now they need much more extensive setup. It replaces them with a minimal unhappy case test.
