### PR TITLE
tests: make session tool way more robust

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -217,9 +217,11 @@ busctl \
 	/org/freedesktop/systemd1 \
 	 org.freedesktop.systemd1.Manager \
 	StartTransientUnit "ssa(sv)a(sa(sv))" \
-	"$unit_name" fail 4 \
+	"$unit_name" fail 6 \
 		Description s "session-tool running $* as $user" \
 		Type s oneshot \
+		RemainAfterExit b false \
+		CollectMode s inactive-or-failed \
 		Environment as 1 TERM=xterm-256color \
 		ExecStart "a(sasb)" 1 \
 			"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 if [ "$(id -u)" -ne 0 ]; then
     echo "session-tool needs to be invoked as root" >&2
     exit 1
@@ -8,15 +8,34 @@ if [ -z "$(command -v busctl)" ]; then
     exit 1
 fi
 if [ $# -eq 0 ]; then
-	echo "usage: session-tool [-u USER] [--] <CMD>"
+	echo "usage: session-tool [-u USER] [-p PID_FILE] [ -i SESSION_ID_FILE] [--] <CMD>"
+	echo "usage: session-tool --prepare | --restore [-u USER]"
 	exit 1
 fi
 user=root
+pid_file=
+action=
 while [ $# -gt 0 ]; do
 	case "$1" in
 		--)
 			shift
 			break
+			;;
+		-p)
+			if [ $# -eq 1 ]; then
+				echo "session-tool: option -p requires an argument" >&2
+				exit 1
+			fi
+			pid_file="$2"
+			shift 2
+			;;
+		--prepare)
+			action=prepare
+			shift
+			;;
+		--restore)
+			action=restore
+			shift
 			;;
 		-u)
 			if [ $# -eq 1 ]; then
@@ -35,6 +54,68 @@ while [ $# -gt 0 ]; do
 			;;
 	esac
 done
+
+case "$action" in
+	prepare)
+		# Make /var/lib/systemd writable so that we can get linger enabled.
+		# This only applies to Ubuntu Core 16 where individual directories were
+		# writable. In Core 18 and beyod all of /var/lib/systemd is writable.
+		case "$SPREAD_SYSTEM" in
+			ubuntu-core-16-*)
+				mount tmpfs -t tmpfs /var/lib/systemd/
+				mkdir /var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill}
+				touch /var/lib/systemd/random-seed
+				mount --bind /writable/system-data/var/lib/systemd/rfkill /var/lib/systemd/rfkill
+				mount --bind /writable/system-data/var/lib/systemd/random-seed /var/lib/systemd/random-seed
+
+				touch /run/session-tool-core16.workaround
+				;;
+		esac
+
+		# Work around https://github.com/systemd/systemd/issues/12401 fixed
+		# in systemd v243.
+		if systemctl cat systemd-logind.service | not grep -q StateDirectory; then
+			mkdir -p /etc/systemd/system/systemd-logind.service.d
+			(
+				echo "[Service]"
+				echo "StateDirectory=systemd/linger"
+			) > /etc/systemd/system/systemd-logind.service.d/linger.conf
+			mkdir -p /var/lib/systemd/linger
+			systemctl daemon-reload
+			systemctl restart systemd-logind.service
+
+			touch /run/session-tool-systemd-issue-12401.workaround
+		fi
+
+		# Enable linger for the selected user.
+		loginctl enable-linger "$user"
+
+		exit 0
+	;;
+	restore)
+		# Disable linger for the selected user.
+		loginctl disable-linger "$user"
+
+		if [ -e /run/session-tool-core16.workaround ]; then
+			rm  /run/session-tool-core16.workaround;
+			# Undo changes to make /var/lib/systemd/ writable.
+			umount -l /var/lib/systemd
+		fi
+
+		if [ -e /run/session-tool-systemd-issue-12401.workaround ]; then
+			rm /run/session-tool-systemd-issue-12401.workaround
+
+			# Remove the logind customizations we (may have) done above.
+			rm -rf /etc/systemd/system/systemd-logind.service.d
+
+			# Reload systemd and restart logind.
+			systemctl daemon-reload
+			systemctl restart systemd-logind.service
+		fi
+
+		exit 0
+	;;
+esac
 
 # This fixes a bug in some older Debian systems where /root/.profile contains
 # unconditional invocation of mesg, which on non-tty shells prints "mesg
@@ -112,6 +193,17 @@ cat "$tmp_dir/ready.pipe" >/dev/null
 cat >"$tmp_dir/stdin.pipe" &
 cat <"$tmp_dir/stdout.pipe" >&1 &
 cat <"$tmp_dir/stderr.pipe" >&2 &
+(
+	echo "#!/bin/sh"
+	test -n "$pid_file" && echo "echo \$$ >\"$pid_file\""
+	printf "exec "
+	for arg in "$@"; do
+		printf '%q ' "$arg"
+	done
+	echo
+)>"$tmp_dir/exec"
+chmod +x "$tmp_dir/exec"
+
 busctl \
 	--allow-interactive-authorization=no --quiet \
 	--system \
@@ -126,7 +218,7 @@ busctl \
 		Type s oneshot \
 		Environment as 1 TERM=xterm-256color \
 		ExecStart "a(sasb)" 1 \
-			/bin/sh 3 /bin/sh -c "exec runuser -l $user - -c \"$*\" <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \
+			"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \
 	0
 # FIXME: ^ the line above invokes runuser via sh has broken quoting.
 # This is done so that we can configure file redirects. Once Ubuntu 16.04 is no
@@ -152,7 +244,7 @@ trap - INT TERM QUIT
 # Kill dbus-monitor that otherwise runs until it notices the pipe is no longer
 # connected, which happens after a longer while.
 kill $dbus_monitor_pid || true
-wait $dbus_monitor_pid || true
+wait $dbus_monitor_pid 2>/dev/null || true
 wait $awk_pid
 
 case "$result" in

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -224,7 +224,6 @@ busctl \
 		ExecStart "a(sasb)" 1 \
 			"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \
 	0
-# FIXME: ^ the line above invokes runuser via sh has broken quoting.
 # This is done so that we can configure file redirects. Once Ubuntu 16.04 is no
 # longer supported we can use Standard{Input,Output,Error}=file:path property
 # of systemd, or perhaps even StandardInputFileDescriptor and pass a file

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -97,13 +97,13 @@ case "$action" in
 		loginctl disable-linger "$user"
 
 		if [ -e /run/session-tool-core16.workaround ]; then
-			rm  /run/session-tool-core16.workaround;
+			rm  /run/session-tool-core16.workaround
 			# Undo changes to make /var/lib/systemd/ writable.
 			umount -l /var/lib/systemd
 		fi
 
 		if [ -e /run/session-tool-systemd-issue-12401.workaround ]; then
-			rm /run/session-tool-systemd-issue-12401.workaround
+			rm  /run/session-tool-systemd-issue-12401.workaround
 
 			# Remove the logind customizations we (may have) done above.
 			rm -rf /etc/systemd/system/systemd-logind.service.d

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -191,8 +191,12 @@ cat "$tmp_dir/ready.pipe" >/dev/null
 # descriptors https://github.com/systemd/systemd/issues/14954 As a workaround
 # we pass a set of pipes. This is good for non-interactive work.
 cat >"$tmp_dir/stdin.pipe" &
+cat_stdin_pid=$!
 cat <"$tmp_dir/stdout.pipe" >&1 &
+cat_stdout_pid=$!
 cat <"$tmp_dir/stderr.pipe" >&2 &
+cat_stderr_pid=$!
+
 (
 	echo "#!/bin/sh"
 	test -n "$pid_file" && echo "echo \$$ >\"$pid_file\""
@@ -246,6 +250,10 @@ trap - INT TERM QUIT
 kill $dbus_monitor_pid || true
 wait $dbus_monitor_pid 2>/dev/null || true
 wait $awk_pid
+
+wait "$cat_stdin_pid"
+wait "$cat_stdout_pid"
+wait "$cat_stderr_pid"
 
 case "$result" in
 	'"done"') exit 0; ;;

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -217,11 +217,10 @@ busctl \
 	/org/freedesktop/systemd1 \
 	 org.freedesktop.systemd1.Manager \
 	StartTransientUnit "ssa(sv)a(sa(sv))" \
-	"$unit_name" fail 6 \
+	"$unit_name" fail 5 \
 		Description s "session-tool running $* as $user" \
 		Type s oneshot \
 		RemainAfterExit b false \
-		CollectMode s inactive-or-failed \
 		Environment as 1 TERM=xterm-256color \
 		ExecStart "a(sasb)" 1 \
 			"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -227,10 +227,10 @@ busctl \
 # This is done so that we can configure file redirects. Once Ubuntu 16.04 is no
 # longer supported we can use Standard{Input,Output,Error}=file:path property
 # of systemd, or perhaps even StandardInputFileDescriptor and pass a file
-# descriptor to the fifos we open in the script above.
+# descriptor to the FIFOs we open in the script above.
 
 # Wait for the service to terminate. The trigger is a successful read
-# from the result fifo. In case we are signaled in one of the familiar
+# from the result FIFO. In case we are signaled in one of the familiar
 # ways, kill the started service with the same signal. The reading occurs
 # in a loop as the signal will first interrupt the read process, which will
 # fail and return nothing.

--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -6,7 +6,7 @@ environment:
     USER/test: test
 prepare: |
     # Check which sessions we have before running the test
-    loginctl list-sessions --no-legend > before.txt
+    loginctl list-sessions > before.txt
     # Prepare for using sessions as the given user
     session-tool --prepare -u "$USER"
 execute: |
@@ -15,7 +15,7 @@ execute: |
         session-tool -u "$USER" id -u  2>/tmp/session-tool.log | MATCH "$(id -u "$USER")"
         session-tool -u "$USER" env    2>/tmp/session-tool.log | MATCH "XDG_RUNTIME_DIR=/run/user/$(id -u "$USER")"
         # We get a logind session
-        session-tool -u "$USER" loginctl list-sessions --no-legend | grep "$USER"
+        session-tool -u "$USER" loginctl list-sessions | grep "$USER"
         # Exit code is forwarded
         session-tool -u "$USER" true
         not session-tool -u "$USER" false
@@ -30,4 +30,4 @@ restore: |
     session-tool --restore -u "$USER"
     # When we are done the sessions are exactly what we started with but this
     # can take a moment as the termination process is asnychronous.
-    retry-tool --wait 1 sh -c 'loginctl list-sessions --no-legend > after.txt && diff -u before.txt after.txt'
+    retry-tool -n 10 --wait 1 sh -c 'loginctl list-sessions > after.txt && diff -u before.txt after.txt'

--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -1,23 +1,33 @@
 summary: tests for session-tool
 # Session-tool depends on busctl and doesn't work on 14.04
 systems: [-ubuntu-14.04-*]
-kill-timeout: 1m
+environment:
+    USER/root: root
+    USER/test: test
+prepare: |
+    # Check which sessions we have before running the test
+    loginctl list-sessions --no-legend > before.txt
+    # Prepare for using sessions as the given user
+    session-tool --prepare -u "$USER"
 execute: |
-    # User switching really works
-    session-tool -u test id -u | MATCH 12345
-    # We get XDG_RUNTIME_DIR
-    session-tool -u test env | MATCH XDG_RUNTIME_DIR=/run/user/12345
-    # We get a logind session
-    session-tool -u test loginctl show-user test | MATCH State=active
-    # Exit code is forwarded
-    session-tool -u test true
-    not session-tool -u test false
+    for n in $(seq 300); do
+        echo "ITERATION $(date) $n"
+        session-tool -u "$USER" id -u  2>/tmp/session-tool.log | MATCH "$(id -u "$USER")"
+        session-tool -u "$USER" env    2>/tmp/session-tool.log | MATCH "XDG_RUNTIME_DIR=/run/user/$(id -u "$USER")"
+        # We get a logind session
+        session-tool -u "$USER" loginctl list-sessions --no-legend | grep "$USER"
+        # Exit code is forwarded
+        session-tool -u "$USER" true
+        not session-tool -u "$USER" false
+        # The -p option can be used to know the PID of the started program.
+        # This is different from the pid of session-tool as there's a session
+        # manager overlooking the termination of PAM stack (internally we use runuser).
+        session-tool -u "$USER" -p /tmp/outer.pid "$(command -v any-python)" -c 'from __future__ import print_function; import os; print(os.getpid())' >/tmp/inner.pid
+        test "$(cat /tmp/outer.pid)" = "$(cat /tmp/inner.pid)"
+    done
 restore: |
-    # Session termination runs asynchronously. Session services are
-    # automatically terminated when the session is shutting down but this is
-    # not synchronized with the execution of the main test program.
-    #
-    # Notably kills: dbus-daemon, systemd --user.
-    # On desktop systems this might also kill: pulseaudio, bluetoothd, gpg
-    # daemon, apt daemon and more.
-    loginctl kill-user test || :
+    # Restore after using sessions as the given user
+    session-tool --restore -u "$USER"
+    # When we are done the sessions are exactly what we started with but this
+    # can take a moment as the termination process is asnychronous.
+    retry-tool --wait 1 sh -c 'loginctl list-sessions --no-legend > after.txt && diff -u before.txt after.txt'

--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -31,3 +31,6 @@ restore: |
     # When we are done the sessions are exactly what we started with but this
     # can take a moment as the termination process is asnychronous.
     retry-tool -n 10 --wait 1 sh -c 'loginctl list-sessions > after.txt && diff -u before.txt after.txt'
+    # Remove files we've created
+    rm -f /tmp/{inner,outer}.pid
+    rm -f {before,after}.txt

--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -28,6 +28,11 @@ execute: |
 restore: |
     # Restore after using sessions as the given user
     session-tool --restore -u "$USER"
+
+    # NOTE: This part of the test is very flaky if you restart systemd-logind
+    # It *seems* that all new systems (Debian Sid, Arch, Tumbleweed and Ubuntu 20.04)
+    # Forget about the root session that was there to begin with.
+
     # When we are done the sessions are exactly what we started with but this
     # can take a moment as the termination process is asnychronous.
     retry-tool -n 10 --wait 1 sh -c 'loginctl list-sessions > after.txt && diff -u before.txt after.txt'


### PR DESCRIPTION
This patch greatly improves the robustness of session-tool.  After
debugging the failure we've seen for several weeks I got to the smoking
gun: in the failing case, the session that was being started by session
tool was interrupted by asynchronous shutdown of the session started
just a moment before. This is because the test was using session-tool to
run several commands, one after another.

    Failed to create session: Start job for unit user-12345.slice failed with 'canceled'

This has lead to the failure in pam_systemd.so, which effectively
resulted in failure to spawn a session in logind, which resulted in no
an error message, rather than the message that was carrying the value of
XDG_RUNTIME_DIR (returned by logind in response to a request from
pam_systemd.so).

There are two new options to `session-tool`, namely `--prepare` and
`--restore`, both of which also take `-u USER` as an option (defaulting
to root if omitted). Those two options can be used to allow a persistent
session-tool to provide a session for the given user. Internally this
enables lingering, as described by loginctl(1), which means the session
will no longer be constructed and torn down by each execution of
session-tool, avoiding the entire race problem.

In addition, --prepare and --restore work around bugs in systemd-logind,
that prevent lingering from really working. In addition, on core-16
systems where /var/lib/systemd is not writable, /var/lib/systemd/linger
is constructed, for the duration of the test, using a writable mimic.

The test exercising this script has been expanded to run several
hundred iterations, in order to give more confidence that the result is
no longer racy.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
