### PR TITLE
tests: fix cross build tests when installing dependencies

### DIFF
--- a/tests/cross/go-build/task.yaml
+++ b/tests/cross/go-build/task.yaml
@@ -53,7 +53,7 @@ prepare: |
     EOF
     dpkg --add-architecture "$X_DEBARCH"
     apt --quiet -o Dpkg::Progress-Fancy=false update
-    apt --yes --quiet -o Dpkg::Progress-Fancy=false install "$X_GCC" libseccomp-dev:"$X_DEBARCH"
+    apt --yes --quiet -o Dpkg::Progress-Fancy=false install "$X_GCC" libseccomp2:"$X_DEBARCH" libseccomp-dev:"$X_DEBARCH"
 
 execute: |
     cd /tmp/cross-build/src/github.com/snapcore/snapd


### PR DESCRIPTION
This change is to fix the following dependencies issue which happens
when the bionic image is upgraded.

+ apt --yes --quiet -o Dpkg::Progress-Fancy=false install
gcc-s390x-linux-gnu libseccomp-dev:s390x
WARNING: apt does not have a stable CLI interface. Use with caution in
scripts.
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
The following packages have unmet dependencies:
libseccomp-dev:s390x : Depends: libseccomp2:s390x (=
2.4.1-0ubuntu0.18.04.2) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
