### PR TITLE
tests: remove google-tpm backend from spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -127,22 +127,6 @@ backends:
                 workers: 4
                 image: centos-8-64
 
-    google-tpm:
-        type: google
-        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: computeengine/us-east1-b
-        halt-timeout: 2h
-        systems:
-            - ubuntu-18.04-64:
-                workers: 1
-                image: ubuntu-1804-64-tpm-enabled
-            - ubuntu-19.10-64:
-                workers: 1
-                image: ubuntu-1910-64-tpm-enabled
-            - ubuntu-20.04-64:
-                workers: 1
-                image: ubuntu-2004-64-tpm-enabled
-
     google-sru:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'


### PR DESCRIPTION
This is because the cloud team is shealding by default all the ubuntu
images on gce
