### PR TITLE
tests: install dependencies with apt using --no-install-recommends

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -167,7 +167,7 @@ distro_install_local_package() {
             eatmydata apt-get -f install -y
             ;;
         ubuntu-*)
-            flags="-y"
+            flags="-y --no-intsall-recommends"
             if [ "$allow_downgrades" = "true" ]; then
                 flags="$flags --allow-downgrades"
             fi

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -167,7 +167,7 @@ distro_install_local_package() {
             eatmydata apt-get -f install -y
             ;;
         ubuntu-*)
-            flags="-y --no-intsall-recommends"
+            flags="-y --no-install-recommends"
             if [ "$allow_downgrades" = "true" ]; then
                 flags="$flags --allow-downgrades"
             fi


### PR DESCRIPTION
This is to prevent gdm3 and ubuntu-desktop is installed when installing
evolution-data-server
