### PR TITLE
cmd/snap-confine/mount-support-nvidia.c: add libnvoptix as nvidia library

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -114,6 +114,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-opencl.so*",
 	"libnvidia-ptxjitcompiler.so*",
 	"libnvidia-tls.so*",
+	"libnvoptix.so*",
 	"tls/libnvidia-tls.so*",
 	"vdpau/libvdpau_nvidia.so*",
 };

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -38,6 +38,7 @@ const openglConnectedPlugAppArmor = `
 # Bi-arch distribution nvidia support
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcuda*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvidia*.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvoptix*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}tls/libnvidia*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvcuvid.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}lib{GL,GLESv1_CM,GLESv2,EGL}*nvidia.so{,.*} rm,


### PR DESCRIPTION
This came about from a kubernetes container running from inside the snap that needs this library.