### PR TITLE
snap: improve TestWaitRecovers test

### DIFF
--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -140,8 +140,6 @@ func (s *SnapOpSuite) TestWait(c *check.C) {
 func (s *SnapOpSuite) TestWaitRecovers(c *check.C) {
 	meter := &progresstest.Meter{}
 	defer progress.MockMeter(meter)()
-	restore := snap.MockMaxGoneTime(time.Millisecond)
-	defer restore()
 
 	nah := true
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
@@ -155,7 +153,7 @@ func (s *SnapOpSuite) TestWaitRecovers(c *check.C) {
 	cli := snap.Client()
 	chg, err := snap.Wait(cli, "x")
 	// we got the change
-	c.Assert(chg, check.NotNil)
+	c.Check(chg, check.NotNil)
 	c.Assert(err, check.IsNil)
 
 	// but only after recovering


### PR DESCRIPTION
The SnapOpSuite.TestWaitRecovers test recently failed during the
package build. It seems to be some sort of race, the failure is:
```
----------------------------------------------------------------------
FAIL: cmd_snap_op_test.go:140: SnapOpSuite.TestWaitRecovers

cmd_snap_op_test.go:158:
    // we got the change
    c.Assert(chg, check.NotNil)
... value *client.Change = (*client.Change)(nil)
```

This commit improves the test slightly by making the error visible
instead of hidding it. It also removes snap.MockMaxGoneTime()
because that is not really useful in this test - the test is about
reconnecting after an error and setting this value looks more like
cargo-culting as it will not play a role here.
