### PR TITLE
o/configstate: add backlight option for core config

### DIFF
--- a/overlord/configstate/configcore/backlight.go
+++ b/overlord/configstate/configcore/backlight.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/systemd"
+)
+
+func init() {
+	// add supported configuration of this module
+	supportedConfigurations["core.system.disable-backlight-service"] = true
+}
+
+func validateBacklightServiceSettings(tr config.Conf) error {
+	return validateBoolFlag(tr, "system.disable-backlight-service")
+}
+
+type backlightSysdLogger struct{}
+
+func (l *backlightSysdLogger) Notify(status string) {
+	fmt.Fprintf(Stderr, "sysd: %s\n", status)
+}
+
+// systemd-backlight service has no installation config. It's started when needed via udev.
+// So, systemctl enable/disable/start/stop are invalid commands. After masking/unmasking
+// the service, rebooting is required for making new setting work
+func handleBacklightServiceConfiguration(tr config.Conf) error {
+	var serviceName string = "systemd-backlight@.service"
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, &backlightSysdLogger{})
+	output, err := coreCfg(tr, "system.disable-backlight-service")
+	if err != nil {
+		return nil
+	}
+	if output != "" {
+		switch output {
+		case "true":
+			return sysd.Mask(serviceName)
+		case "false":
+			return sysd.Unmask(serviceName)
+		default:
+			return fmt.Errorf("unsupported disable-backlight-service option: %q", output)
+		}
+	}
+	return nil
+}

--- a/overlord/configstate/configcore/backlight_test.go
+++ b/overlord/configstate/configcore/backlight_test.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/release"
+)
+
+type backlightSuite struct {
+	configcoreSuite
+}
+
+var _ = Suite(&backlightSuite{})
+
+func (s *backlightSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
+	c.Assert(err, IsNil)
+}
+
+func (s *backlightSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *backlightSuite) TestConfigureBacklightServiceMaskIntegration(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.systemctlArgs = nil
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.disable-backlight-service": true,
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.systemctlArgs, DeepEquals, [][]string{
+		{"--root", dirs.GlobalRootDir, "mask", "systemd-backlight@.service"},
+	})
+}
+
+func (s *backlightSuite) TestConfigureBacklightServiceUnmaskIntegration(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.systemctlArgs = nil
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.disable-backlight-service": false,
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.systemctlArgs, DeepEquals, [][]string{
+		{"--root", dirs.GlobalRootDir, "unmask", "systemd-backlight@.service"},
+	})
+}

--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -75,6 +75,9 @@ func init() {
 
 	// pi-config.*
 	addFSOnlyHandler(nil, handlePiConfiguration, coreOnly)
+
+	// system.disable-backlight-service
+	addFSOnlyHandler(validateBacklightServiceSettings, handleBacklightServiceConfiguration, coreOnly)
 }
 
 // addFSOnlyHandler registers functions to validate and handle a subset of

--- a/tests/main/core-backlight/task.yaml
+++ b/tests/main/core-backlight/task.yaml
@@ -1,0 +1,22 @@
+summary: Test system.disable-backlight-service core config option
+
+systems: [ubuntu-core-*]
+
+environment:
+    MASKFILE: /etc/systemd/system/systemd-backlight@.service
+
+execute: |
+    echo "Backlight is not masked by default"
+    systemctl status systemd-backlight@foo | MATCH "Loaded: loaded"
+
+    echo "Check that backlight service can be disabled"
+    snap set core system.disable-backlight-service=true
+
+    systemctl status systemd-backlight@foo | MATCH "Loaded: masked"
+    test -L "$MASKFILE"
+        
+    echo "Check that backlight service can be enabled"
+    snap set core system.disable-backlight-service=false
+
+    systemctl status systemd-backlight@foo | MATCH "Loaded: loaded"
+    ! test -L "$MASKFILE"

--- a/tests/main/core-backlight/task.yaml
+++ b/tests/main/core-backlight/task.yaml
@@ -14,6 +14,7 @@ execute: |
 
     systemctl status systemd-backlight@foo | MATCH "Loaded: masked"
     test -L "$MASKFILE"
+    [ "$(readlink $MASKFILE)" = "/dev/null" ]
         
     echo "Check that backlight service can be enabled"
     snap set core system.disable-backlight-service=false

--- a/tests/main/core-backlight/task.yaml
+++ b/tests/main/core-backlight/task.yaml
@@ -19,4 +19,4 @@ execute: |
     snap set core system.disable-backlight-service=false
 
     systemctl status systemd-backlight@foo | MATCH "Loaded: loaded"
-    ! test -L "$MASKFILE"
+    not test -e "$MASKFILE"


### PR DESCRIPTION
Added core config option for masking/unmasking systemd-backlight@.service via system.disable-backlight-service flag.

Based on https://github.com/snapcore/snapd/pull/8160 (many thanks to @EthanHsieh for the actual implementation!).
