### PR TITLE
client: increase timeout in client tests to 100ms

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -75,7 +75,7 @@ func (cs *clientSuite) SetUpTest(c *C) {
 
 	dirs.SetRootDir(c.MkDir())
 
-	cs.restore = client.MockDoTimings(time.Millisecond, 10*time.Millisecond)
+	cs.restore = client.MockDoTimings(time.Millisecond, 100*time.Millisecond)
 }
 
 func (cs *clientSuite) TearDownTest(c *C) {


### PR DESCRIPTION
The default timeout in our client tests is currently 10ms. This
is problematic on very loaded cloud instances like during PPA
builds where 10ms is sometimes not enough for the machine to
respond. Increasing this timeout decreases the risk of hitting
this by at least ~10x.

It does make the whole testsuite slower because we have 10 tests
that hit this timeout so this add 1s to the execution. Fixing this
is a good idea but more work.
