### PR TITLE
usersession: extend timerange in TestExitOnIdle

### DIFF
--- a/usersession/agent/session_agent_test.go
+++ b/usersession/agent/session_agent_test.go
@@ -135,7 +135,7 @@ func (s *sessionAgentSuite) TestExitOnIdle(c *C) {
 		c.Fatal("agent did not exit after idle timeout expired")
 	}
 	elapsed := time.Since(startTime)
-	if elapsed < 175*time.Millisecond || elapsed > 250*time.Millisecond {
+	if elapsed < 175*time.Millisecond || elapsed > 450*time.Millisecond {
 		// The idle timeout should have been extended when we
 		// issued a second request after 25ms.
 		c.Errorf("Expected ellaped time close to 175 ms, but got %v", elapsed)


### PR DESCRIPTION
The TestExitOnIdle test checks that the idle time is extended
when making a second request. It checks both a lower and a upper
bound but the upper bound is too low for slow (overcommitted)
machines and it fails sometimes during a PPA build. This commit
increases the uppper limit. This should be fine because this
is mostly about not exiting too early.

Maybe @jhenstridge can have a look and see if we could do it
differently. I looked at bit at it but nothing super obvious occured
to me. The assumption must be that machines that run this are
incredible slow.