### PR TITLE
snap/naming: add validator for snap security tag

### DIFF
--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -21,6 +21,7 @@
 package naming
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -173,4 +174,46 @@ func ValidateSnapID(id string) error {
 		return fmt.Errorf("invalid snap-id: %q", id)
 	}
 	return nil
+}
+
+var errInvalidSecurityTag = errors.New("invalid security tag")
+
+// ValidateSecurityTag validates known variants of snap security tag.
+//
+// Two forms are recognised, one for apps and one for hooks. Other forms
+// are possible but are not handled here.
+//
+// TODO: handle the weird udev variant.
+func ValidateSecurityTag(tag string) error {
+	parts := strings.Split(tag, ".")
+	switch len(parts) {
+	case 3:
+		snapLiteral, snapName, appName := parts[0], parts[1], parts[2]
+		if snapLiteral != "snap" {
+			return errInvalidSecurityTag
+		}
+		if err := ValidateInstance(snapName); err != nil {
+			return errInvalidSecurityTag
+		}
+		if err := ValidateApp(appName); err != nil {
+			return errInvalidSecurityTag
+		}
+		return nil
+	case 4:
+		snapLiteral, snapName, hookLiteral, hookName := parts[0], parts[1], parts[2], parts[3]
+		if snapLiteral != "snap" {
+			return errInvalidSecurityTag
+		}
+		if err := ValidateInstance(snapName); err != nil {
+			return errInvalidSecurityTag
+		}
+		if hookLiteral != "hook" {
+			return errInvalidSecurityTag
+		}
+		if err := ValidateHook(hookName); err != nil {
+			return errInvalidSecurityTag
+		}
+		return nil
+	}
+	return errInvalidSecurityTag
 }

--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -204,10 +204,10 @@ func ValidateSecurityTag(tag string) error {
 		if snapLiteral != "snap" {
 			return errInvalidSecurityTag
 		}
-		if err := ValidateInstance(snapName); err != nil {
+		if hookLiteral != "hook" {
 			return errInvalidSecurityTag
 		}
-		if hookLiteral != "hook" {
+		if err := ValidateInstance(snapName); err != nil {
 			return errInvalidSecurityTag
 		}
 		if err := ValidateHook(hookName); err != nil {

--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -185,7 +185,9 @@ var errInvalidSecurityTag = errors.New("invalid security tag")
 //
 // TODO: handle the weird udev variant.
 func ValidateSecurityTag(tag string) error {
-	parts := strings.SplitN(tag, ".", 4)
+	// We expect at most four parts. Split with up to five parts so that the
+	// len(parts) test catches invalid format tags very early.
+	parts := strings.SplitN(tag, ".", 5)
 	switch len(parts) {
 	case 3:
 		snapLiteral, snapName, appName := parts[0], parts[1], parts[2]

--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -185,7 +185,7 @@ var errInvalidSecurityTag = errors.New("invalid security tag")
 //
 // TODO: handle the weird udev variant.
 func ValidateSecurityTag(tag string) error {
-	parts := strings.Split(tag, ".")
+	parts := strings.SplitN(tag, ".", 4)
 	switch len(parts) {
 	case 3:
 		snapLiteral, snapName, appName := parts[0], parts[1], parts[2]

--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -188,28 +188,30 @@ func ValidateSecurityTag(tag string) error {
 	// We expect at most four parts. Split with up to five parts so that the
 	// len(parts) test catches invalid format tags very early.
 	parts := strings.SplitN(tag, ".", 5)
+	// We expect either three or four components.
+	if len(parts) != 3 && len(parts) != 4 {
+		return errInvalidSecurityTag
+	}
+	// We expect "snap" and the snap instance name as first two fields.
+	snapLiteral, snapName := parts[0], parts[1]
+	if snapLiteral != "snap" {
+		return errInvalidSecurityTag
+	}
+	if err := ValidateInstance(snapName); err != nil {
+		return errInvalidSecurityTag
+	}
+	// Depending on the type of the tag we either expect application name or
+	// the "hook" literal and the hook name.
 	switch len(parts) {
 	case 3:
-		snapLiteral, snapName, appName := parts[0], parts[1], parts[2]
-		if snapLiteral != "snap" {
-			return errInvalidSecurityTag
-		}
-		if err := ValidateInstance(snapName); err != nil {
-			return errInvalidSecurityTag
-		}
+		appName := parts[2]
 		if err := ValidateApp(appName); err != nil {
 			return errInvalidSecurityTag
 		}
 		return nil
 	case 4:
-		snapLiteral, snapName, hookLiteral, hookName := parts[0], parts[1], parts[2], parts[3]
-		if snapLiteral != "snap" {
-			return errInvalidSecurityTag
-		}
+		hookLiteral, hookName := parts[2], parts[3]
 		if hookLiteral != "hook" {
-			return errInvalidSecurityTag
-		}
-		if err := ValidateInstance(snapName); err != nil {
 			return errInvalidSecurityTag
 		}
 		if err := ValidateHook(hookName); err != nil {

--- a/snap/naming/validate_test.go
+++ b/snap/naming/validate_test.go
@@ -316,7 +316,7 @@ func (s *ValidateSuite) TestValidateSecurityTag(c *C) {
 	// invalid number of components are rejected.
 	c.Check(naming.ValidateSecurityTag("snap.pkg.hook.surprise."), ErrorMatches, "invalid security tag")
 	c.Check(naming.ValidateSecurityTag("snap.pkg.hook."), ErrorMatches, "invalid security tag")
-	c.Check(naming.ValidateSecurityTag("snap.pkg.hook"), IsNil) // surprise, it is a valid app name!
+	c.Check(naming.ValidateSecurityTag("snap.pkg.hook"), IsNil) // Perhaps somewhat unexpectedly, this tag is valid.
 	c.Check(naming.ValidateSecurityTag("snap.pkg.app.surprise"), ErrorMatches, "invalid security tag")
 	c.Check(naming.ValidateSecurityTag("snap.pkg."), ErrorMatches, "invalid security tag")
 	c.Check(naming.ValidateSecurityTag("snap.pkg"), ErrorMatches, "invalid security tag")

--- a/snap/naming/validate_test.go
+++ b/snap/naming/validate_test.go
@@ -298,3 +298,28 @@ func (s *ValidateSuite) TestValidateSnapID(c *C) {
 		c.Check(err, ErrorMatches, fmt.Sprintf("invalid snap-id: %q", id))
 	}
 }
+
+func (s *ValidateSuite) TestValidateSecurityTag(c *C) {
+	// valid snap names, snap instances, app names and hook names are accepted.
+	c.Check(naming.ValidateSecurityTag("snap.pkg.app"), IsNil)
+	c.Check(naming.ValidateSecurityTag("snap.pkg.hook.configure"), IsNil)
+	c.Check(naming.ValidateSecurityTag("snap.pkg_key.app"), IsNil)
+	c.Check(naming.ValidateSecurityTag("snap.pkg_key.hook.configure"), IsNil)
+
+	c.Check(naming.ValidateSecurityTag("snap.pkg_key.app.surprise"), ErrorMatches, "invalid security tag")
+	c.Check(naming.ValidateSecurityTag("snap.pkg_key.hook.configure.surprise"), ErrorMatches, "invalid security tag")
+
+	// invalid snap and app names are rejected.
+	c.Check(naming.ValidateSecurityTag("snap._.app"), ErrorMatches, "invalid security tag")
+	c.Check(naming.ValidateSecurityTag("snap.pkg._"), ErrorMatches, "invalid security tag")
+
+	// invalid number of components are rejected.
+	c.Check(naming.ValidateSecurityTag("snap.pkg.hook.surprise."), ErrorMatches, "invalid security tag")
+	c.Check(naming.ValidateSecurityTag("snap.pkg.hook."), ErrorMatches, "invalid security tag")
+	c.Check(naming.ValidateSecurityTag("snap.pkg.hook"), IsNil) // surprise, it is a valid app name!
+	c.Check(naming.ValidateSecurityTag("snap.pkg.app.surprise"), ErrorMatches, "invalid security tag")
+	c.Check(naming.ValidateSecurityTag("snap.pkg."), ErrorMatches, "invalid security tag")
+	c.Check(naming.ValidateSecurityTag("snap.pkg"), ErrorMatches, "invalid security tag")
+	c.Check(naming.ValidateSecurityTag("snap."), ErrorMatches, "invalid security tag")
+	c.Check(naming.ValidateSecurityTag("snap"), ErrorMatches, "invalid security tag")
+}


### PR DESCRIPTION
Security tags were only created by snapd, never read from external
sources. With the upcoming refresh app awareness patches we will have to
parse and validate security tags that are embedded in cgroup names.

This patch provides the validator. It was cherry-picked from the main
feature branch.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
