### PR TITLE
httputil: increase httpclient timeout in TestRetryRequestTimeoutHandling

### DIFF
--- a/httputil/retry_test.go
+++ b/httputil/retry_test.go
@@ -383,7 +383,7 @@ func (s *retrySuite) TestRetryRequestTimeoutHandling(c *C) {
 	defer close(finished)
 
 	cli := httputil.NewHTTPClient(&httputil.ClientOptions{
-		Timeout: 25 * time.Millisecond,
+		Timeout: 100 * time.Millisecond,
 	})
 
 	url := ""


### PR DESCRIPTION
The test uses a short 25ms connect timeout. Slow (overcommitted)
systems may fail because they are unable to reply in this time.

This commit changes the timeout to 100ms which makes it at least
4x less likely to hit this condition. It also makes the test
slower unfortunately (by ~400ms).

This was observed by Ian in https://github.com/snapcore/snapd/pull/8410#issuecomment-608093868 and I also saw it in various PPA build failures.