### PR TITLE
interfaces: don't use the owner modifier for files shared via document portal

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -203,9 +203,13 @@ dbus (send)
     member={Check,Get,Set}
     peer=(label=unconfined),
 
-## Allow access to xdg-document-portal file system.  Access control is
-## handled by bind mounting a snap-specific sub-tree to this location.
-owner /run/user/[0-9]*/doc/{,*} r,
+# Allow access to xdg-document-portal file system.  Access control is
+# handled by bind mounting a snap-specific sub-tree to this location
+# (ie, this is /run/user/<uid>/doc/by-app/snap.@{SNAP_INSTANCE_NAME}
+# on the host).
+owner /run/user/[0-9]*/doc/{,*/} r,
+# Allow rw access without owner match to the documents themselves since
+# the user guided the access and can specify anything DAC allows.
 /run/user/[0-9]*/doc/*/** rw,
 
 # Allow access to xdg-desktop-portal and xdg-document-portal

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -205,8 +205,8 @@ dbus (send)
 
 ## Allow access to xdg-document-portal file system.  Access control is
 ## handled by bind mounting a snap-specific sub-tree to this location.
-owner /run/user/[0-9]*/doc/ r,
-owner /run/user/[0-9]*/doc/** rw,
+owner /run/user/[0-9]*/doc/{,*} r,
+/run/user/[0-9]*/doc/*/** rw,
 
 # Allow access to xdg-desktop-portal and xdg-document-portal
 dbus (receive, send)


### PR DESCRIPTION
The document portal does not alter the stat information of the files it shares.  For example, if a user tries to open some documentation in /usr/share/doc via a portal file chooser, the proxied file under $XDG_RUNTIME_DIR/doc will be owned by root.

As the document portal is a FUSE filesystem, there are kernel level restrictions to prevent other users accessing the file system (even root).  So this shouldn't result in any effective change in access.