### PR TITLE
tests/session-tool: reset failed session-tool units

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -217,10 +217,9 @@ busctl \
 	/org/freedesktop/systemd1 \
 	 org.freedesktop.systemd1.Manager \
 	StartTransientUnit "ssa(sv)a(sa(sv))" \
-	"$unit_name" fail 5 \
+	"$unit_name" fail 4 \
 		Description s "session-tool running $* as $user" \
 		Type s oneshot \
-		RemainAfterExit b false \
 		Environment as 1 TERM=xterm-256color \
 		ExecStart "a(sasb)" 1 \
 			"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \
@@ -254,6 +253,12 @@ wait $awk_pid
 wait "$cat_stdin_pid"
 wait "$cat_stdout_pid"
 wait "$cat_stderr_pid"
+
+# Prevent accumulation of failed sessions.
+
+if [ "$result" != '"done"' ]; then
+	systemctl reset-failed "$unit_name"
+fi
 
 case "$result" in
 	'"done"') exit 0; ;;


### PR DESCRIPTION
This prevents accumulation of failed units that make systemd slower,
well at 1K units.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>