### PR TITLE
tests/session-tool: kill leaking closing session

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -255,6 +255,18 @@ wait "$cat_stdin_pid"
 wait "$cat_stdout_pid"
 wait "$cat_stderr_pid"
 
+# Work around a bug in older versions of logind that leak closing session
+# without a process inhabiting it anymore. In the case we've observed there's a
+# session that is being closed with a missing process.
+for session_id in $(loginctl --no-legend | awk '{ print $1 }'); do
+	if [ "$(loginctl show-session "$session_id" --property=State --value)" = closing ]; then
+		leader=$(loginctl show-session "$session_id" --property=Leader --value)
+		if [ ! -e "/proc/$leader" ]; then
+			loginctl kill-session "$session_id"
+		fi
+	fi
+done
+
 case "$result" in
 	'"done"') exit 0; ;;
 	'"failed"') exit 1; ;;


### PR DESCRIPTION
Systemd v219, present at least in Amazon Linux 2, exhibits a bug where a
session is stuck in the state "closing" even when the leading process
has already terminated. In our tests we've seen this with the crond
process.

This patch adds extra logic that terminates such sessions, if they are
detected.

Related: https://github.com/systemd/systemd/issues/8672
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
