### PR TITLE
Add libnvidia-rtcore as Nvidia library

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -113,6 +113,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-ml.so*",
 	"libnvidia-opencl.so*",
 	"libnvidia-ptxjitcompiler.so*",
+	"libnvidia-rtcore.so*",
 	"libnvidia-tls.so*",
 	"libnvoptix.so*",
 	"tls/libnvidia-tls.so*",


### PR DESCRIPTION
Following on from https://github.com/snapcore/snapd/pull/8397.  There is a need for this library too.
