### PR TITLE
httputil: increase testRetryStrategy max timelimit to 5s

### DIFF
--- a/httputil/retry_test.go
+++ b/httputil/retry_test.go
@@ -46,7 +46,7 @@ func (s *retrySuite) SetUpTest(c *C) {
 func (s *retrySuite) TearDownTest(c *C) {
 }
 
-var testRetryStrategy = retry.LimitCount(5, retry.LimitTime(1*time.Second,
+var testRetryStrategy = retry.LimitCount(5, retry.LimitTime(5*time.Second,
 	retry.Exponential{
 		Initial: 1 * time.Millisecond,
 		Factor:  1,


### PR DESCRIPTION
On the (very slow) armhf builder one unit test failed with:
```
FAIL: retry_test.go:359: retrySuite.TestRetryRequestTimeoutHandling

retry_test.go:411:
    // check that we exhausted all retries (as defined by mocked retry strategy)
    c.Assert(permanentlyBrokenSrvCalls.Count(), Equals, 5)
... obtained int = 4
... expected int = 5
```
This is caused by the retry stragey limit of 1s. The timeout of
the retry to increased to 100ms recently and it looks like this
can sometimes cause the test to go over the 1s retry strategy
limit now. This commit increases this timeout to make this much
less likely.

This has no impact on the test time as this retry max limit is never hit
under normal circumstances.