### PR TITLE
tests: skip "/etc/machine-id" in "writablepaths" test

### DIFF
--- a/tests/core/writablepaths/task.yaml
+++ b/tests/core/writablepaths/task.yaml
@@ -8,8 +8,17 @@ execute: |
         if [ -z "$line" ]; then
             continue;
         fi
+
         # a writable-path may be either a file or a directory
         dir_or_file=$(echo "$line"|cut -f1 -d' ')
+
+        # fun! systemd is playing tricks with /etc/machine-id
+        # and mounts a RO tmpfs on top of the writable one which
+        # means we cannot touch this file
+        if [ "$dir_or_file" = "/etc/machine-id" ]; then
+            continue;
+        fi
+
         if [ ! -e "$dir_or_file" ]; then
             echo "$dir_or_file" >> missing
         elif [ -f "$dir_or_file" ]; then


### PR DESCRIPTION
When systemd is booting it's playing tricks with /etc/machine-id
on firstboot. I.e. it is creating a RO tmpfs on top of the real
machine-id file:
```
google:ubuntu-core-20-64 .../tests/core/writablepaths# findmnt /etc/machine-id
TARGET        SOURCE                                             FSTYPE OPTIONS
/etc/machine-id
              /dev/mapper/ubuntu-data[/system-data/etc/machine-id]
                                                                 ext4   rw,rela
/etc/machine-id
              tmpfs[/machine-id]                                 tmpfs  ro,size

```
This causes the test to fail for this particular file. This commit
skips the test for /etc/machine-id.

This should unbreak master.