### PR TITLE
github: disable fail-fast as spread cannot be interrupted

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,6 +101,13 @@ jobs:
     needs: [unit-tests, spread-canary]
     runs-on: ubuntu-latest
     strategy:
+      # FIXME: enable fail-fast mode once spread can cancel an executing job.
+      #
+      # Disable fail-fast mode as it doesn't function with spread. It seems
+      # that cancelling tasks requires short, interruptible actions and
+      # interrupting spread, notably, does not work today. As such disable
+      # fail-fast while we tackle that problem upstream.
+      fail-fast: false
       matrix:
         system:
         - ubuntu-14.04-64
@@ -141,6 +148,8 @@ jobs:
     needs: [unit-tests, spread-stable]
     runs-on: ubuntu-latest
     strategy:
+      # FIXME: enable fail-fast mode once spread can cancel an executing job.
+      fail-fast: false
       matrix:
         system:
         - centos-8-64


### PR DESCRIPTION
Spread doesn't respond to interrupt requests. In effect actions cannot
cancel a running job normally and nukes the whole runner.

We should fix this upstream in spread, so that it can shut down
(quickly) on an interrupt signal.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>