### PR TITLE
tests/session-tool: stop cron/anacron from meddling

### DIFF
--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -5,6 +5,15 @@ environment:
     USER/root: root
     USER/test: test
 prepare: |
+    truncate --size=0 defer.sh
+    chmod +x defer.sh
+    # Prevent anacron/cron from interfering with their background sessions, grr!
+    for unit in cron.service crond.service anacron.timer; do
+        if [ "$(systemctl is-active "$unit")" = active ]; then
+            systemctl stop "$unit"
+            echo "systemctl start \"$unit\"" >> defer.sh
+        fi
+    done
     # Kill sessions that systemd has leaked earlier.
     session-tool --kill-leaked
     # Check which sessions we have before running the test
@@ -44,3 +53,14 @@ restore: |
     # Remove files we've created
     rm -f /tmp/{inner,outer}.pid
     rm -f {before,after}.txt
+
+    # Restart background stuff we stopped.
+    sh defer.sh && rm -f defer.sh
+debug: |
+    echo "Active sessions:"
+    for session_id in $(loginctl list-sessions --no-legend | awk '{ print($1) }'); do
+        echo "Details of session $session_id"
+        loginctl show-session "$session_id"
+    done
+    echo "Active timers"
+    systemctl list-timers


### PR DESCRIPTION
I've seen active cron sessions interfering with this test. As such,
disable crond (service) and anacron (timer) for the duration of the
test.

In addition, to collect extra information in case this happens again, on
failure collect the state of each session.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
