### PR TITLE
github: port CLA check to Github Actions

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,0 +1,22 @@
+name: cla-check
+on:
+  # Only run on pull requests: not pushes
+  pull_request:
+    branches: [ "master", "release/**" ]
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install python-launchpadlib
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # The cla_check script reads git commit history, so can't
+          # use a shallow checkout.
+          fetch-depth: 0
+      - name: CLA check
+        run: ./tests/lib/cla_check.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,24 +67,6 @@ jobs:
     - name: Test Go
       run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --unit
 
-  cla-check:
-    # TODO: as this job only runs for pull requests, we can't make it
-    # a prerequisite for the spread tests.
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-16.04
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install python-launchpadlib
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          # The cla_check script reads git commit history
-          fetch-depth: 0
-      - name: CLA check
-        run: ./tests/lib/cla_check.py
-
   spread-canary:
     needs: unit-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches: [ "master", "release/**" ]
 jobs:
-  # TODO: port CLA check
   unit-tests:
     runs-on: ubuntu-16.04
     env:
@@ -67,6 +66,25 @@ jobs:
       run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/ && make check
     - name: Test Go
       run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --unit
+
+  cla-check:
+    # TODO: as this job only runs for pull requests, we can't make it
+    # a prerequisite for the spread tests.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install python-launchpadlib
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # The cla_check script reads git commit history
+          fetch-depth: 0
+      - name: CLA check
+        run: ./tests/lib/cla_check.py
+
   spread-canary:
     needs: unit-tests
     runs-on: ubuntu-latest

--- a/tests/lib/cla_check.py
+++ b/tests/lib/cla_check.py
@@ -18,12 +18,35 @@ except ImportError:
 shortlog_email_rx = re.compile("^\s*\d+\s+.*<(\S+)>$", re.M)
 
 
+is_travis = os.getenv("TRAVIS", "") == "true"
+is_github_actions = os.getenv("GITHUB_ACTIONS", "") == "true"
+
+
+def get_commit_range():
+    # Sanity check to ensure we are running from a pull request check job
+    if is_travis:
+        if os.getenv("TRAVIS_PULL_REQUEST", "false") == "false":
+            raise RuntimeError("called from a non-pull request Travis job")
+    elif is_github_actions:
+        if os.getenv("GITHUB_EVENT_NAME", "") != "pull_request":
+            raise RuntimeError("called from a non-pull request Github Actions job")
+    else:
+        raise RuntimeError("Unknown CI system.")
+
+    # The head revision is a synthesised merge commit, merging the
+    # proposed branch into the destination branch.  So the first
+    # parent is our destination, and the second is our proposal.
+    dest = check_output(["git", "rev-parse", "@^1"]).strip()
+    proposed = check_output(["git", "rev-parse", "@^2"]).strip()
+    return dest, proposed
+
+
 def get_emails_for_range(r):
     output = check_output(["git", "shortlog", "-se", r])
     return set(m.group(1) for m in shortlog_email_rx.finditer(output))
 
 
-if sys.stdout.isatty():
+if sys.stdout.isatty() or is_travis or is_github_actions:
     green = "\033[32;1m"
     red = "\033[31;1m"
     yellow = "\033[33;1m"
@@ -35,6 +58,17 @@ else:
     yellow = ""
     reset = ""
     clear = ""
+
+if is_travis:
+    fold_start = 'travis_fold:start:{{tag}}\r{}{}{{message}}{}'.format(
+        clear, yellow, reset)
+    fold_end = 'travis_fold:end:{{tag}}\r{}'.format(clear)
+elif is_github_actions:
+    fold_start = '::group::{message}'
+    fold_end = '::endgroup::'
+else:
+    fold_start = '{}{{message}}{}'.format(yellow, reset)
+    fold_end = ''
 
 
 def static_email_check(email, master_emails, width):
@@ -85,9 +119,7 @@ def lp_email_check(email, lp, cla_folks, width):
 
 def print_checkout_info(travis_commit_range):
     # This is just to have information in case things go wrong
-    if clear:
-        print("travis_fold:start:checkout_info\r" + clear, end="")
-    print("{}Debug information{}".format(yellow, reset))
+    print(fold_start.format(tag="checkout_info", message="Debug information"))
     print("Commit range:", travis_commit_range)
     print("Remotes:")
     sys.stdout.flush()
@@ -96,22 +128,22 @@ def print_checkout_info(travis_commit_range):
     sys.stdout.flush()
     check_call(["git", "branch", "-v"])
     sys.stdout.flush()
-    if clear:
-        print("travis_fold:end:checkout_info\r" + clear)
+    print(fold_end.format(tag="checkout_info"))
 
 
 def main():
-    travis_commit_range = os.getenv("TRAVIS_COMMIT_RANGE", "")
-    print_checkout_info(travis_commit_range)
+    try:
+        master, proposed = get_commit_range()
+    except Exception, exc:
+        sys.exit("Could not determine commit range: {}".format(exc))
+    commit_range = "{}..{}".format(master, proposed)
+    print_checkout_info(commit_range)
 
-    if travis_commit_range == "":
-        sys.exit("No TRAVIS_COMMIT_RANGE set.")
-
-    emails = get_emails_for_range(travis_commit_range)
+    emails = get_emails_for_range(commit_range)
     if len(emails) == 0:
         sys.exit("No emails found in in the given commit range.")
 
-    master_emails = get_emails_for_range("master")
+    master_emails = get_emails_for_range(master)
 
     width = max(map(len, emails))
     lp = None


### PR DESCRIPTION
Port the CLA check from Travis over to Github Actions.

I've removed the use of the `TRAVIS_COMMIT_RANGE` environment variable in the Python script: it turns out we can determine the new commits based on the synthetic merge commit we're asked to test (first parent is the destination branch head, second parent is the proposed branch head).

This PR doesn't make the new job a prerequisite for the spread jobs, since that would prevent those jobs from running when it is skipped (or at least once the workflow is enabled for push events).

I've left the Travis CLA check job enabled for now, to allow comparison of the output.