### PR TITLE
packaging: use debian/not-installed to ignore snap-preseed

### DIFF
--- a/packaging/debian-sid/not-installed
+++ b/packaging/debian-sid/not-installed
@@ -3,3 +3,4 @@ usr/bin/snap-failure
 usr/lib/snapd/system-shutdown
 usr/bin/snap-bootstrap
 usr/bin/snap-recovery-chooser
+usr/bin/snap-preseed

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -255,13 +255,6 @@ override_dh_install-arch:
 	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.system-shutdown.service
 	rm $(CURDIR)/debian/snapd/usr/lib/snapd/snapd.run-from-snap
 
-	# snap-preseed is currently only useful on ubuntu and tailored for preseeding
-	# of ubuntu cloud images due to certain assumptions about runtime environment
-	# of the host and of the preseeded image.
-ifneq ($(shell dpkg-vendor --query Vendor),Ubuntu)
-	rm -f ${CURDIR}/debian/tmp/usr/bin/snap-preseed
-endif
-
 	dh_install
 
 override_dh_auto_install: snap.8


### PR DESCRIPTION
The debian build failed because snap-preseed was not removed
in the "_dh_install-indep" target. This made it fail during
the amd64 build on Debian. Instead of removing the file in
both the "_dh_install-{arch,indep}" target this commit uses
debian/not-installed to avoid the duplication.

This should have been caught in the nightly sbuild-* test
but the test fails there since forever due to an incorrect
setup.

In related news: packaging is hard :)