### PR TITLE
github: give jobs shorter names

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
 jobs:
   # TODO: port CLA check
   unit-tests:
+    name: "Static & Unit"
     runs-on: ubuntu-16.04
     env:
       GOPATH: ${{ github.workspace }}
@@ -67,7 +68,8 @@ jobs:
       run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/ && make check
     - name: Test Go
       run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --unit
-  spread-canary:
+  canary:
+    name: "Canary"
     needs: unit-tests
     runs-on: ubuntu-latest
     strategy:
@@ -97,8 +99,9 @@ jobs:
         for r in .spread-reuse.*.yaml; do
           /tmp/spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
         done
-  spread-stable:
-    needs: [unit-tests, spread-canary]
+  stable:
+    name: "Stable"
+    needs: [unit-tests, canary]
     runs-on: ubuntu-latest
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
@@ -144,8 +147,9 @@ jobs:
         for r in .spread-reuse.*.yaml; do
           /tmp/spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
         done
-  spread-unstable:
-    needs: [unit-tests, spread-stable]
+  unstable:
+    name: "Unstable"
+    needs: [unit-tests, stable]
     runs-on: ubuntu-latest
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,19 +113,19 @@ jobs:
       fail-fast: false
       matrix:
         system:
-        - ubuntu-14.04-64
-        - ubuntu-18.04-64
-        - ubuntu-19.10-64
-        - ubuntu-20.04-64
-        - ubuntu-core-18-64
-        - ubuntu-core-20-64
-        - debian-9-64
-        - debian-sid-64
-        - fedora-30-64
-        - fedora-31-64
-        - arch-linux-64
-        - amazon-linux-2-64
-        - centos-7-64
+        - ubuntu-14.04
+        - ubuntu-18.04
+        - ubuntu-19.10
+        - ubuntu-20.04
+        - ubuntu-core-18
+        - ubuntu-core-20
+        - debian-9
+        - debian-sid
+        - fedora-30
+        - fedora-31
+        - arch-linux
+        - amazon-linux-2
+        - centos-7
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -139,7 +139,7 @@ jobs:
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-      run: /tmp/spread google:${{ matrix.system }}:tests/...
+      run: /tmp/spread google:${{ matrix.system }}-64:tests/...
     - name: Discard spread workers
       if: always()
       run: |
@@ -156,9 +156,9 @@ jobs:
       fail-fast: false
       matrix:
         system:
-        - centos-8-64
-        - opensuse-15.1-64
-        - opensuse-tumbleweed-64
+        - centos-8
+        - opensuse-15.1
+        - opensuse-tumbleweed
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -172,7 +172,7 @@ jobs:
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-      run: /tmp/spread -abend google-unstable:${{ matrix.system }}:tests/...
+      run: /tmp/spread -abend google-unstable:${{ matrix.system }}-64:tests/...
     - name: Discard spread workers
       if: always()
       run: |


### PR DESCRIPTION
GitHub actions constructs a line out of workflow name, job name and
matrix configuration. At some point the line length limit is exceeded
and we loose the tail of the line, which holds the duration of the run.

In order to get the duration to be visible, use shorter terms.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
