### PR TITLE
travis.yml: disable unit tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,6 @@ git:
 matrix:
   include:
     - stage: quick
-      name: go 1.9/xenial static and unit test suites
-      dist: xenial
-      go: "1.9.x"
-      before_install:
-        - sudo apt --quiet -o Dpkg::Progress-Fancy=false update
-      install:
-        - sudo apt --quiet -o Dpkg::Progress-Fancy=false build-dep snapd
-        - ./get-deps.sh
-      script:
-        - set -e
-        - ./run-checks --static
-        - ./run-checks --short-unit
-    # XXX: why does travis not support go: ["1.9.x", "master"] here?
-    #      this would avoid this ugly copy
-    - stage: quick
       name: go master/xenial static and unit test suites
       dist: xenial
       go: "master"


### PR DESCRIPTION
We already run our unit tests as a github action and also run them
as part of the spread "tests/unit/go/" testing. So this commit
removes them from running on travis.
