### PR TITLE
overlord/devicestate: support for recover and run modes

### DIFF
--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -165,6 +165,8 @@ func (s *apiSuite) TestGetSystemsSome(c *check.C) {
 				},
 				Actions: []client.SystemAction{
 					{Title: "reinstall", Mode: "install"},
+					{Title: "recover", Mode: "recover"},
+					{Title: "run normally", Mode: "run"},
 				},
 			},
 		}})

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -147,7 +147,7 @@ func (s *apiSuite) TestGetSystemsSome(c *check.C) {
 					Validation:  "unproven",
 				},
 				Actions: []client.SystemAction{
-					{Title: "reinstall", Mode: "install"},
+					{Title: "Install", Mode: "install"},
 				},
 			}, {
 				Current: true,
@@ -164,9 +164,9 @@ func (s *apiSuite) TestGetSystemsSome(c *check.C) {
 					Validation:  "unproven",
 				},
 				Actions: []client.SystemAction{
-					{Title: "reinstall", Mode: "install"},
-					{Title: "recover", Mode: "recover"},
-					{Title: "run normally", Mode: "run"},
+					{Title: "Reinstall", Mode: "install"},
+					{Title: "Recover", Mode: "recover"},
+					{Title: "Run normally", Mode: "run"},
 				},
 			},
 		}})

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -476,8 +476,7 @@ func (m *DeviceManager) ensureSeeded() error {
 		return nil
 	}
 
-	msg := fmt.Sprintf("Initialize system state")
-	chg := m.state.NewChange("seed", msg)
+	chg := m.state.NewChange("seed", "Initialize system state")
 	for _, ts := range tsAll {
 		chg.AddAll(ts)
 	}

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -363,6 +363,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeInstallRecoverForCurrent(c *C) {
 		})
 		c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
 		s.restartRequests = nil
+		s.bootloader.BootVars = map[string]string{}
 	}
 }
 

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -213,12 +213,13 @@ func (s *deviceMgrSystemsSuite) TestListSystemsNotPossible(c *C) {
 
 // TODO:UC20 update once we can list actions
 var defaultSystemActions []devicestate.SystemAction = []devicestate.SystemAction{
-	{Title: "reinstall", Mode: "install"},
+	{Title: "Install", Mode: "install"},
 }
-var currentSystemActions []devicestate.SystemAction = append(defaultSystemActions,
-	devicestate.SystemAction{Title: "recover", Mode: "recover"},
-	devicestate.SystemAction{Title: "run normally", Mode: "run"},
-)
+var currentSystemActions []devicestate.SystemAction = []devicestate.SystemAction{
+	{Title: "Reinstall", Mode: "install"},
+	{Title: "Recover", Mode: "recover"},
+	{Title: "Run normally", Mode: "run"},
+}
 
 func (s *deviceMgrSystemsSuite) TestListSeedSystemsNoCurrent(c *C) {
 	systems, err := s.mgr.Systems()


### PR DESCRIPTION
The PR adds the `recover` and `run` modes to the current system's actions list. Requesting a `run` mode is effectively a noop.

We still need #8010 and related PRs to be able to do anything useful in the recovery mode, but the chooser bits allow us to boot into the mode at least.