### PR TITLE
configcore,tests: fix setting watchdog options on UC18/20

### DIFF
--- a/overlord/configstate/configcore/watchdog.go
+++ b/overlord/configstate/configcore/watchdog.go
@@ -21,6 +21,7 @@ package configcore
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -51,6 +52,10 @@ func updateWatchdogConfig(config map[string]uint, opts *fsOnlyContext) error {
 		}
 	}
 	if len(configStr) > 0 {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+
 		// We order the variables to have predictable output
 		sort.Strings(configStr)
 		content := "[Manager]\n" + strings.Join(configStr, "")

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -125,6 +125,28 @@ func (s *watchdogSuite) TestConfigureWatchdogAll(c *C) {
 		fmt.Sprintf("ShutdownWatchdogSec=%d\n", times[1]))
 }
 
+func (s *watchdogSuite) TestConfigureWatchdogAllMkdir(c *C) {
+	// remove the .conf.d directory, it will be created
+	err := os.Remove(dirs.SnapSystemdConfDir)
+	c.Assert(err, IsNil)
+
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	times := []int{10, 100}
+	err = configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"watchdog.runtime-timeout":  fmt.Sprintf("%ds", times[0]),
+			"watchdog.shutdown-timeout": fmt.Sprintf("%ds", times[1]),
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.mockEtcEnvironment, testutil.FileEquals, "[Manager]\n"+
+		fmt.Sprintf("RuntimeWatchdogSec=%d\n", times[0])+
+		fmt.Sprintf("ShutdownWatchdogSec=%d\n", times[1]))
+}
+
 func (s *watchdogSuite) TestConfigureWatchdogBadFormat(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()

--- a/tests/core/watchdog/task.yaml
+++ b/tests/core/watchdog/task.yaml
@@ -3,9 +3,6 @@ summary: Check that the core.watchdog settings work
 environment:
     WATCHDOG_FILE: /etc/systemd/system.conf.d/10-snapd-watchdog.conf
 
-# TODO:UC20: enable for uc20/uc18
-systems: [ubuntu-core-16-*]
-
 prepare: |
     if [ -f "$WATCHDOG_FILE" ]; then
         echo "Watchdog file already present, testbed not clean"


### PR DESCRIPTION
the issue was that /etc/systemd/sytemd.conf.d doesn't exist there and needs to be created
