### PR TITLE
tests/session-tool: collect information about services on startup

### DIFF
--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -16,8 +16,19 @@ prepare: |
     done
     # Kill sessions that systemd has leaked earlier.
     session-tool --kill-leaked
-    # Check which sessions we have before running the test
+
+    # Remember details of sessions before we start.
+    (
+        echo "Active sessions:"
+        for session_id in $(loginctl list-sessions --no-legend | awk '{ print($1) }'); do
+            echo "Details of session $session_id"
+            loginctl show-session "$session_id"
+        done
+    ) > before.debug.txt
+
+    # Brief version of existing sessions to measure during "restore".
     loginctl list-sessions > before.txt
+
     # Prepare for using sessions as the given user
     session-tool --prepare -u "$USER"
 execute: |
@@ -56,11 +67,17 @@ restore: |
 
     # Restart background stuff we stopped.
     sh defer.sh && rm -f defer.sh
+
 debug: |
-    echo "Active sessions:"
-    for session_id in $(loginctl list-sessions --no-legend | awk '{ print($1) }'); do
-        echo "Details of session $session_id"
-        loginctl show-session "$session_id"
-    done
+    (
+        echo "Active sessions:"
+        for session_id in $(loginctl list-sessions --no-legend | awk '{ print($1) }'); do
+            echo "Details of session $session_id"
+            loginctl show-session "$session_id"
+        done
+    ) > after.debug.txt
+
+    diff -u before.debug.txt after.debug.txt
+
     echo "Active timers"
     systemctl list-timers


### PR DESCRIPTION
Expand the debug sections to show details of the sessions that were
before and after the tests.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>