### PR TITLE
tests/session-tool: stop anacron.service in prepare

### DIFF
--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -8,7 +8,7 @@ prepare: |
     truncate --size=0 defer.sh
     chmod +x defer.sh
     # Prevent anacron/cron from interfering with their background sessions, grr!
-    for unit in cron.service crond.service anacron.timer; do
+    for unit in cron.service crond.service anacron.timer anacron.service; do
         if [ "$(systemctl is-active "$unit")" = active ]; then
             systemctl stop "$unit"
             echo "systemctl start \"$unit\"" >> defer.sh


### PR DESCRIPTION
We stopped anacron.timer but not the service. We could still have the
service running while we were starting the test, then stop mid way. This
would show up as a session that was there to begin with but was gone in
the end.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
