### PR TITLE
github: move spread to self-hosted workers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,7 @@ jobs:
 
   spread-canary:
     needs: unit-tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -79,27 +79,23 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Install spread
-      run: |
-          cd /tmp
-          curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz
-          tar xzvf spread-amd64.tar.gz
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-      run: /tmp/spread -abend google:${{ matrix.system }}:tests/...
+      run: |
+          # Register a problem matcher to highlight spread failures
+          echo "::add-matcher::.github/spread-problem-matcher.json"
+          spread -abend google:${{ matrix.system }}:tests/...
     - name: Discard spread workers
       if: always()
       run: |
         shopt -s nullglob;
         for r in .spread-reuse.*.yaml; do
-          /tmp/spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
         done
   spread-stable:
     needs: [unit-tests, spread-canary]
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       #
@@ -126,27 +122,23 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Install spread
-      run: |
-          cd /tmp
-          curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz
-          tar xzvf spread-amd64.tar.gz
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-      run: /tmp/spread google:${{ matrix.system }}:tests/...
+      run: |
+          # Register a problem matcher to highlight spread failures
+          echo "::add-matcher::.github/spread-problem-matcher.json"
+          spread google:${{ matrix.system }}:tests/...
     - name: Discard spread workers
       if: always()
       run: |
         shopt -s nullglob;
         for r in .spread-reuse.*.yaml; do
-          /tmp/spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
         done
   spread-unstable:
     needs: [unit-tests, spread-stable]
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       fail-fast: false
@@ -158,21 +150,17 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Install spread
-      run: |
-          cd /tmp
-          curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz
-          tar xzvf spread-amd64.tar.gz
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-      run: /tmp/spread -abend google-unstable:${{ matrix.system }}:tests/...
+      run: |
+          # Register a problem matcher to highlight spread failures
+          echo "::add-matcher::.github/spread-problem-matcher.json"
+          spread -abend google-unstable:${{ matrix.system }}:tests/...
     - name: Discard spread workers
       if: always()
       run: |
         shopt -s nullglob;
         for r in .spread-reuse.*.yaml; do
-          /tmp/spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
         done


### PR DESCRIPTION
We're hitting saturation of github free workers quota. We'd rather keep
that quota for quick unit tests and allocate self-hosted workers for the
long running spread tests.

The workers are deployed in Canonistack by Sergio.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
