### PR TITLE
interfaces: add case for rootWritableOverlay + NFS

### DIFF
--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -52,6 +52,16 @@ func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
 	}
 }
 
+// MockIsRootWritableOverlay mocks the real implementation of
+// osutil.IsRootWritableOverlay
+func MockIsRootWritableOverlay(new func() (string, error)) (restore func()) {
+	old := isRootWritableOverlay
+	isRootWritableOverlay = new
+	return func() {
+		isRootWritableOverlay = old
+	}
+}
+
 func MockReadBuildID(mock func(p string) (string, error)) (restore func()) {
 	old := readBuildID
 	readBuildID = mock

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -82,8 +82,9 @@ type systemKey struct {
 const systemKeyVersion = 10
 
 var (
-	isHomeUsingNFS  = osutil.IsHomeUsingNFS
-	mockedSystemKey *systemKey
+	isHomeUsingNFS        = osutil.IsHomeUsingNFS
+	isRootWritableOverlay = osutil.IsRootWritableOverlay
+	mockedSystemKey       *systemKey
 
 	readBuildID = osutil.ReadBuildID
 )
@@ -129,7 +130,7 @@ func generateSystemKey() (*systemKey, error) {
 
 	// Add if '/' is on overlayfs so we can add AppArmor rules for
 	// upperdir such that if this changes, we change our profile.
-	sk.OverlayRoot, err = osutil.IsRootWritableOverlay()
+	sk.OverlayRoot, err = isRootWritableOverlay()
 	if err != nil {
 		// just log the error here
 		logger.Noticef("cannot determine root filesystem on overlay in generateSystemKey: %v", err)


### PR DESCRIPTION
This is incredibly unlikely to actually happen, but is good to mock because otherwise we need to mock the mountinfo directly for these things, and that ends up being a lot of work (as I discovered in a followup to this PR). This is simpler and matches other places where we need to mock IsRootWritableOverlay.