### PR TITLE
interfaces/many: miscellaneous policy updates xliv

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -373,6 +373,7 @@ var defaultTemplate = `
   @{PROC}/sys/kernel/hostname r,
   @{PROC}/sys/kernel/osrelease r,
   @{PROC}/sys/kernel/ostype r,
+  @{PROC}/sys/kernel/pid_max r,
   @{PROC}/sys/kernel/yama/ptrace_scope r,
   @{PROC}/sys/kernel/shmmax r,
   @{PROC}/sys/fs/file-max r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -127,6 +127,20 @@ var defaultTemplate = `
   /run/systemd/users/[0-9]* r,
   /etc/default/nss r,
 
+  # libnss-systemd (subset from nameservice abstraction)
+  #
+  #   https://systemd.io/USER_GROUP_API/
+  #   https://systemd.io/USER_RECORD/
+  #   https://www.freedesktop.org/software/systemd/man/nss-systemd.html
+  #
+  # Allow User/Group lookups via common VarLink socket APIs. Applications need
+  # to either consult all of them or the io.systemd.Multiplexer frontend.
+  /run/systemd/userdb/ r,
+  /run/systemd/userdb/io.systemd.Multiplexer rw,
+  /run/systemd/userdb/io.systemd.DynamicUser rw,        # systemd-exec users
+  /run/systemd/userdb/io.systemd.Home rw,               # systemd-home dirs
+  /run/systemd/userdb/io.systemd.NameServiceSwitch rw,  # UNIX/glibc NSS
+
   /etc/libnl-3/{classid,pktloc} r,      # apps that use libnl
   /etc/profile r,
   /etc/environment r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -356,7 +356,7 @@ var defaultTemplate = `
   /etc/{,writable/}localtime r,
   /etc/{,writable/}mailname r,
   /etc/{,writable/}timezone r,
-  owner @{PROC}/@{pid}/cgroup r,
+  owner @{PROC}/@{pid}/cgroup rk,
   @{PROC}/@{pid}/io r,
   owner @{PROC}/@{pid}/limits r,
   owner @{PROC}/@{pid}/loginuid r,

--- a/interfaces/builtin/appstream_metadata.go
+++ b/interfaces/builtin/appstream_metadata.go
@@ -46,8 +46,8 @@ const appstreamMetadataConnectedPlugAppArmor = `
 # Description: Allow access to AppStream metadata from the host system
 
 # Allow access to AppStream upstream metadata files
-/usr/share/metainfo/** r,
-/usr/share/appdata/** r,
+/usr/share/metainfo/{,**} r,
+/usr/share/appdata/{,**} r,
 
 # Allow access to AppStream collection metadata
 /usr/share/app-info/** r,

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -56,6 +56,8 @@ dbus (send)
 owner @{HOME}/.local/share/fonts/{,**} r,
 /var/cache/fontconfig/   r,
 /var/cache/fontconfig/** mr,
+# some applications are known to mmap fonts
+/usr/{,local/}share/fonts/** m,
 
 # subset of gnome abstraction
 /etc/gtk-3.0/settings.ini r,

--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -35,7 +35,7 @@ const firewallControlConnectedPlugAppArmor = `
 # privileged access to networking and should only be used with trusted apps.
 
 #include <abstractions/nameservice>
-/run/systemd/resolve/stub-resolv.conf r,
+/run/systemd/resolve/stub-resolv.conf rk,
 
 # systemd-resolved (not yet included in nameservice abstraction)
 #

--- a/interfaces/builtin/hostname_control.go
+++ b/interfaces/builtin/hostname_control.go
@@ -63,8 +63,7 @@ dbus(receive, send)
     bus=system
     path=/org/freedesktop/hostname1
     interface=org.freedesktop.hostname1
-    member=Set{,Pretty,Static}Hostname
-    peer=(label=unconfined),
+    member=Set{,Pretty,Static}Hostname,
 
 # Needed to use 'sethostname' and 'hostnamectl set-hostname'. See man 7
 # capabilities

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -121,7 +121,9 @@ deny ptrace (trace) peer=unconfined,
 @{PROC}/[0-9]*/attr/ r,
 @{PROC}/[0-9]*/fdinfo/ r,
 @{PROC}/[0-9]*/map_files/ r,
-@{PROC}/[0-9]*/ns/ r,
+@{PROC}/[0-9]*/ns/{,*} r,
+# dac_read_search needed for lstat'ing non-root owned ns/* files
+capability dac_read_search,
 
 # kubernetes will verify and set panic and panic_on_oops to values it considers
 # sane

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -54,6 +54,16 @@ dbus send
      member="Resolve{Address,Hostname,Record,Service}"
      peer=(name="org.freedesktop.resolve1"),
 
+# libnss-systemd (D-Bus portion from nameservice abstraction)
+# Also allow lookups for systemd-exec's DynamicUsers via D-Bus
+#   https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+dbus send
+     bus=system
+     path="/org/freedesktop/systemd1"
+     interface="org.freedesktop.systemd1.Manager"
+     member="{GetDynamicUsers,LookupDynamicUserByName,LookupDynamicUserByUID}"
+     peer=(name="org.freedesktop.systemd1"),
+
 #include <abstractions/ssl_certs>
 
 @{PROC}/sys/net/core/somaxconn r,

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -32,7 +32,7 @@ const networkBaseDeclarationSlots = `
 const networkConnectedPlugAppArmor = `
 # Description: Can access the network as a client.
 #include <abstractions/nameservice>
-/run/systemd/resolve/stub-resolv.conf r,
+/run/systemd/resolve/stub-resolv.conf rk,
 /etc/mdns.allow r,  # not yet include in mdns abstraction
 
 # systemd-resolved (not yet included in nameservice abstraction)

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -33,6 +33,7 @@ const networkConnectedPlugAppArmor = `
 # Description: Can access the network as a client.
 #include <abstractions/nameservice>
 /run/systemd/resolve/stub-resolv.conf r,
+/etc/mdns.allow r,  # not yet include in mdns abstraction
 
 # systemd-resolved (not yet included in nameservice abstraction)
 #

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -32,7 +32,7 @@ const networkBindBaseDeclarationSlots = `
 const networkBindConnectedPlugAppArmor = `
 # Description: Can access the network as a server.
 #include <abstractions/nameservice>
-/run/systemd/resolve/stub-resolv.conf r,
+/run/systemd/resolve/stub-resolv.conf rk,
 
 # systemd-resolved (not yet included in nameservice abstraction)
 #

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -36,7 +36,7 @@ const networkControlConnectedPlugAppArmor = `
 # trusted apps.
 
 #include <abstractions/nameservice>
-/run/systemd/resolve/stub-resolv.conf r,
+/run/systemd/resolve/stub-resolv.conf rk,
 
 # systemd-resolved (not yet included in nameservice abstraction)
 #

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -119,7 +119,7 @@ network inet6 raw,
 /etc/rpc r,
 
 # network devices
-/sys/devices/**/net/** r,
+/sys/devices/**/net/** rk,
 
 # for receiving kobject_uevent() net messages from the kernel
 network netlink raw,


### PR DESCRIPTION
* interfaces/appstream-metadata: allow read on metainfo and appdata dirs
* interfaces/network: allow read of /etc/mdns.allow
* template/network: updates for libnss-systemd
* interfaces/kubernetes-support: allow probing /proc/*/ns/* files
* apparmor: allow read on /proc/sys/kernel/pid_max by default
* interfaces/many: allow 'k' on various read-only files
* interfaces/desktop: allow 'm'map of fonts in /usr/{,local/}share/fonts
* interfaces/hostname-control: drop peer label to allow activation

See individual commit messages for more information.