### PR TITLE
tests/main/uc20-snap-recovery: unbreak, rename to uc20-create-partitions

### DIFF
--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -1,4 +1,4 @@
-summary: Integration tests for the snap-bootstrap binary
+summary: Integration tests for the snap-bootstrap create-partitions
 
 # one system is enough, its a very specialized test for now
 systems: [ubuntu-20.04-64]
@@ -81,6 +81,7 @@ execute: |
     df -T "${LOOP}p4" | MATCH ext4
     umount ./mnt
     file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
+    # TODO: verify that partition was automatically expanded
 
     echo "Check that the filesystem content was deployed"
     mkdir -p ./mnt

--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -104,7 +104,7 @@ execute: |
     sfdisk -l "$LOOP" | MATCH "${LOOP}p1 .* 1M\s* BIOS boot"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p2 .* 1.2G\s* EFI System"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p3 .* 750M\s* Linux filesystem"
-    sfdisk -l "$LOOP" | MATCH "${LOOP}p4 .* 3G\s* Linux filesystem"
+    sfdisk -l "$LOOP" | MATCH "${LOOP}p4 .* 1G\s* Linux filesystem"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p5 .* 110M\s* Linux filesystem"
 
     echo "check that the filesystems are created and mounted"

--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -1,7 +1,7 @@
 summary: Integration tests for the snap-bootstrap binary
 
 # one system is enough, its a very specialized test for now
-systems: [ubuntu-19.10-64]
+systems: [ubuntu-20.04-64]
 
 debug: |
     cat /proc/partitions


### PR DESCRIPTION
The test is using the 'pc' gadget from 20/edge, which is back to using 1G size
for `ubuntu-data` as introduced in commit
https://github.com/snapcore/pc-amd64-gadget/commit/a0eb11c6f6945d9395a858aaf396f3f3c0c609cf

While at it, the test got renamed to `uc20-create-partitions`. I left a TODO which will be done in a follow up PR.