### PR TITLE
github: check pull request title

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,21 @@
+name: 'Check PR Title'
+on:
+  pull_request:
+    types:
+      # Check title when opened.
+      - opened
+      # Check title when new commits are pushed.
+      # Required to use as a status check.
+      - synchronize
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dylanvann/check-pull-request-title@v0.1.14
+        with:
+          # package: foo
+          # package, otherpackage/subpackage: this is a title
+          # tests/regression/lp-12341234: foo
+          # [RFC] foo: bar
+          pattern: '[a-zA-Z0-9_\-/,. \[\]{}]+: .*'


### PR DESCRIPTION
Instead of porting the check-pr-title.py script we can use a 3rd party
action. The action itself is extremely simple and is reproduced below in
its entirety:

    import * as core from '@actions/core'
    import * as github from '@actions/github'

    function run() {
      const pattern = core.getInput('pattern')
      const regex = new RegExp(pattern)
      const title =
	github.context.payload &&
	github.context.payload.pull_request &&
	github.context.payload.pull_request.title
      core.info(title)
      const isValid = regex.test(title)
      if (!isValid) {
	core.setFailed(
	  `Pull request title "${title}" does not match regex pattern "${pattern}".`,
	)
      }
    }

    run()

The action code is available under MIT license.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
