### PR TITLE
tests/session-tool: add session-tool --dump

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -1,4 +1,11 @@
 #!/bin/bash -e
+if [ $# -eq 0 ]; then
+	echo "usage: session-tool [-u USER] [-p PID_FILE] [--] <CMD>"
+	echo "usage: session-tool --prepare | --restore [-u USER]"
+	echo "usage: session-tool --kill-leaked"
+	echo "usage: session-tool --dump"
+	exit 1
+fi
 if [ "$(id -u)" -ne 0 ]; then
     echo "session-tool needs to be invoked as root" >&2
     exit 1
@@ -6,12 +13,6 @@ fi
 if [ -z "$(command -v busctl)" ]; then
     echo "session-tool requires busctl" >&2
     exit 1
-fi
-if [ $# -eq 0 ]; then
-	echo "usage: session-tool [-u USER] [-p PID_FILE] [--] <CMD>"
-	echo "usage: session-tool --prepare | --restore [-u USER]"
-	echo "usage: session-tool --kill-leaked"
-	exit 1
 fi
 user=root
 pid_file=
@@ -40,6 +41,10 @@ while [ $# -gt 0 ]; do
 			;;
 		--restore)
 			action=restore
+			shift
+			;;
+		--dump)
+			action=dump
 			shift
 			;;
 		-u)
@@ -112,7 +117,7 @@ case "$action" in
 		loginctl enable-linger "$user"
 
 		exit 0
-	;;
+		;;
 	restore)
 		# Disable linger for the selected user.
 		loginctl disable-linger "$user"
@@ -135,7 +140,15 @@ case "$action" in
 		fi
 
 		exit 0
-	;;
+		;;
+	dump)
+		echo "Active sessions:"
+		for session_id in $(loginctl list-sessions --no-legend | awk '{ print($1) }'); do
+			echo "Details of session $session_id"
+			loginctl show-session "$session_id"
+		done
+		exit 0
+		;;
 esac
 
 # This fixes a bug in some older Debian systems where /root/.profile contains

--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -7,6 +7,7 @@ environment:
 prepare: |
     truncate --size=0 defer.sh
     chmod +x defer.sh
+
     # Prevent anacron/cron from interfering with their background sessions, grr!
     for unit in cron.service crond.service anacron.timer anacron.service; do
         if [ "$(systemctl is-active "$unit")" = active ]; then
@@ -18,13 +19,7 @@ prepare: |
     session-tool --kill-leaked
 
     # Remember details of sessions before we start.
-    (
-        echo "Active sessions:"
-        for session_id in $(loginctl list-sessions --no-legend | awk '{ print($1) }'); do
-            echo "Details of session $session_id"
-            loginctl show-session "$session_id"
-        done
-    ) > before.debug.txt
+    session-tool --dump > before.debug.txt
 
     # Brief version of existing sessions to measure during "restore".
     loginctl list-sessions > before.txt
@@ -66,18 +61,10 @@ restore: |
     rm -f {before,after}.txt
 
     # Restart background stuff we stopped.
-    sh defer.sh && rm -f defer.sh
+    sh -xe defer.sh && rm -f defer.sh
 
 debug: |
-    (
-        echo "Active sessions:"
-        for session_id in $(loginctl list-sessions --no-legend | awk '{ print($1) }'); do
-            echo "Details of session $session_id"
-            loginctl show-session "$session_id"
-        done
-    ) > after.debug.txt
-
+    session-tool --dump > after.debug.txt
     diff -u before.debug.txt after.debug.txt
-
     echo "Active timers"
     systemctl list-timers


### PR DESCRIPTION
Pawel suggested that the duplicated debug code should be put into a
helper. After looking at it quickly it's most natural to put the
duplicated code into session-tool itself.

With session-tool --debug we get a dump of all the sessions logind knows
about. The corresponding code was removed from the test.

This patch also moves the help message earlier and fixes some
spaces/tabs.

Maciek suggested that the "defer.sh" script be invoked with -x, I also
added -e to maintain the fail-fast semantics.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>