### PR TITLE
dirs: don't depend on osutil anymore, mv apparmor vars to apparmor pkg

### DIFF
--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/cmd/snap-preseed"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -417,7 +418,7 @@ func (s *startPreseedSuite) TestReset(c *C) {
 		{filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants", "snap-foo.mount"), ""},
 		{filepath.Join(dirs.SnapDataDir, "foo", "bar"), ""},
 		{filepath.Join(dirs.SnapCacheDir, "foocache", "bar"), ""},
-		{filepath.Join(dirs.AppArmorCacheDir, "foo", "bar"), ""},
+		{filepath.Join(apparmor_sandbox.CacheDir, "foo", "bar"), ""},
 		{filepath.Join(dirs.SnapAppArmorDir, "foo"), ""},
 		{filepath.Join(dirs.SnapAssertsDBDir, "foo"), ""},
 		{filepath.Join(dirs.FeaturesDir, "foo"), ""},

--- a/cmd/snap-preseed/reset.go
+++ b/cmd/snap-preseed/reset.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 )
 
 func resetPreseededChroot(preseedChroot string) error {
@@ -61,7 +62,7 @@ func resetPreseededChroot(preseedChroot string) error {
 	globs = []string{
 		filepath.Join(dirs.SnapDataDir, "*"),
 		filepath.Join(dirs.SnapCacheDir, "*"),
-		filepath.Join(dirs.AppArmorCacheDir, "*"),
+		filepath.Join(apparmor_sandbox.CacheDir, "*"),
 	}
 
 	for _, gl := range globs {

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 )
 
@@ -42,7 +41,6 @@ var (
 	SnapDataHomeGlob          string
 	SnapDownloadCacheDir      string
 	SnapAppArmorDir           string
-	AppArmorCacheDir          string
 	SnapAppArmorAdditionalDir string
 	SnapConfineAppArmorDir    string
 	SnapSeccompBase           string
@@ -95,9 +93,6 @@ var (
 	SnapBusPolicyDir    string
 
 	SnapModeenvFile string
-
-	SystemApparmorDir      string
-	SystemApparmorCacheDir string
 
 	CloudMetaDataFile     string
 	CloudInstanceDataFile string
@@ -280,7 +275,6 @@ func SetRootDir(rootdir string) {
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/", UserHomeSnapDir)
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	SnapConfineAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "snap-confine")
-	AppArmorCacheDir = filepath.Join(rootdir, "/var/cache/apparmor")
 	SnapAppArmorAdditionalDir = filepath.Join(rootdir, snappyDir, "apparmor", "additional")
 	SnapDownloadCacheDir = filepath.Join(rootdir, snappyDir, "cache")
 	SnapSeccompBase = filepath.Join(rootdir, snappyDir, "seccomp")
@@ -335,15 +329,6 @@ func SetRootDir(rootdir string) {
 	SnapUserServicesDir = filepath.Join(rootdir, "/etc/systemd/user")
 	SnapSystemdConfDir = SnapSystemdConfDirUnder(rootdir)
 	SnapBusPolicyDir = filepath.Join(rootdir, "/etc/dbus-1/system.d")
-
-	SystemApparmorDir = filepath.Join(rootdir, "/etc/apparmor.d")
-	SystemApparmorCacheDir = filepath.Join(rootdir, "/etc/apparmor.d/cache")
-	exists, isDir, _ := osutil.DirExists(SystemApparmorCacheDir)
-	if !exists || !isDir {
-		// some systems use a single cache dir instead of splitting
-		// out the system cache
-		SystemApparmorCacheDir = AppArmorCacheDir
-	}
 
 	CloudMetaDataFile = filepath.Join(rootdir, "/var/lib/cloud/seed/nocloud-net/meta-data")
 	CloudInstanceDataFile = filepath.Join(rootdir, "/run/cloud-init/instance-data.json")

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -161,7 +161,7 @@ func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
 	// that is the more recent name we use.
 	var profilePath string
 	for _, profileFname := range []string{"usr.lib.snapd.snap-confine.real", "usr.lib.snapd.snap-confine"} {
-		profilePath = filepath.Join(dirs.SystemApparmorDir, profileFname)
+		profilePath = filepath.Join(apparmor_sandbox.ConfDir, profileFname)
 		if _, err := os.Stat(profilePath); err != nil {
 			if os.IsNotExist(err) {
 				continue
@@ -180,7 +180,7 @@ func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
 	}
 
 	// We are not using apparmor.LoadProfiles() because it uses other cache.
-	if err := loadProfiles([]string{profilePath}, dirs.SystemApparmorCacheDir, aaFlags); err != nil {
+	if err := loadProfiles([]string{profilePath}, apparmor_sandbox.SystemCacheDir, aaFlags); err != nil {
 		// When we cannot reload the profile then let's remove the generated
 		// policy. Maybe we have caused the problem so it's better to let other
 		// things work.
@@ -244,7 +244,7 @@ func (b *Backend) setupSnapConfineReexec(info *snap.Info) error {
 		return fmt.Errorf("cannot create snap-confine policy directory: %s", err)
 	}
 	dir, glob, content, err := snapConfineFromSnapProfile(info)
-	cache := dirs.AppArmorCacheDir
+	cache := apparmor_sandbox.CacheDir
 	if err != nil {
 		return fmt.Errorf("cannot compute snap-confine profile: %s", err)
 	}
@@ -369,7 +369,7 @@ func (b *Backend) prepareProfiles(snapInfo *snap.Info, opts interfaces.Confineme
 	// https://forum.snapcraft.io/t/core-snap-revert-issues-on-core-devices/
 	//
 	if (snapInfo.GetType() == snap.TypeOS || snapInfo.GetType() == snap.TypeSnapd) && !release.OnClassic {
-		if li, err := filepath.Glob(filepath.Join(dirs.SystemApparmorCacheDir, "*")); err == nil {
+		if li, err := filepath.Glob(filepath.Join(apparmor_sandbox.SystemCacheDir, "*")); err == nil {
 			for _, p := range li {
 				if st, err := os.Stat(p); err == nil && st.Mode().IsRegular() && profileIsRemovableOnCoreSetup(p) {
 					if err := os.Remove(p); err != nil {
@@ -443,7 +443,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		aaFlags |= skipKernelLoad
 	}
 	timings.Run(tm, "load-profiles[changed]", fmt.Sprintf("load changed security profiles of snap %q", snapInfo.InstanceName()), func(nesttm timings.Measurer) {
-		errReloadChanged = loadProfiles(prof.changed, dirs.AppArmorCacheDir, aaFlags)
+		errReloadChanged = loadProfiles(prof.changed, apparmor_sandbox.CacheDir, aaFlags)
 	})
 
 	// Load all unchanged profiles anyway. This ensures those are correct in
@@ -455,9 +455,9 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		aaFlags |= skipKernelLoad
 	}
 	timings.Run(tm, "load-profiles[unchanged]", fmt.Sprintf("load unchanged security profiles of snap %q", snapInfo.InstanceName()), func(nesttm timings.Measurer) {
-		errReloadOther = loadProfiles(prof.unchanged, dirs.AppArmorCacheDir, aaFlags)
+		errReloadOther = loadProfiles(prof.unchanged, apparmor_sandbox.CacheDir, aaFlags)
 	})
-	errUnload := unloadProfiles(prof.removed, dirs.AppArmorCacheDir)
+	errUnload := unloadProfiles(prof.removed, apparmor_sandbox.CacheDir)
 	if errReloadChanged != nil {
 		return errReloadChanged
 	}
@@ -496,7 +496,7 @@ func (b *Backend) SetupMany(snaps []*snap.Info, confinement func(snapName string
 		}
 		var errReloadChanged error
 		timings.Run(tm, "load-profiles[changed-many]", fmt.Sprintf("load changed security profiles of %d snaps", len(snaps)), func(nesttm timings.Measurer) {
-			errReloadChanged = loadProfiles(allChangedPaths, dirs.AppArmorCacheDir, aaFlags)
+			errReloadChanged = loadProfiles(allChangedPaths, apparmor_sandbox.CacheDir, aaFlags)
 		})
 
 		aaFlags = conserveCPU
@@ -505,10 +505,10 @@ func (b *Backend) SetupMany(snaps []*snap.Info, confinement func(snapName string
 		}
 		var errReloadOther error
 		timings.Run(tm, "load-profiles[unchanged-many]", fmt.Sprintf("load unchanged security profiles %d snaps", len(snaps)), func(nesttm timings.Measurer) {
-			errReloadOther = loadProfiles(allUnchangedPaths, dirs.AppArmorCacheDir, aaFlags)
+			errReloadOther = loadProfiles(allUnchangedPaths, apparmor_sandbox.CacheDir, aaFlags)
 		})
 
-		errUnload := unloadProfiles(allRemovedPaths, dirs.AppArmorCacheDir)
+		errUnload := unloadProfiles(allRemovedPaths, apparmor_sandbox.CacheDir)
 		if errReloadChanged != nil {
 			logger.Noticef("failed to batch-reload changed profiles: %s", errReloadChanged)
 			fallback = true
@@ -540,7 +540,7 @@ func (b *Backend) SetupMany(snaps []*snap.Info, confinement func(snapName string
 func (b *Backend) Remove(snapName string) error {
 	dir := dirs.SnapAppArmorDir
 	globs := profileGlobs(snapName)
-	cache := dirs.AppArmorCacheDir
+	cache := apparmor_sandbox.CacheDir
 	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dir, globs, nil)
 	errUnload := unloadProfiles(removed, cache)
 	if errEnsure != nil {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -161,7 +161,7 @@ func (s *backendSuite) SetUpTest(c *C) {
 	s.perf = timings.New(nil)
 	s.meas = s.perf.StartSpan("", "")
 
-	err := os.MkdirAll(dirs.AppArmorCacheDir, 0700)
+	err := os.MkdirAll(apparmor_sandbox.CacheDir, 0700)
 	c.Assert(err, IsNil)
 	// Mock away any real apparmor interaction
 	s.parserCmd = testutil.MockCommand(c, "apparmor_parser", fakeAppArmorParser)
@@ -308,7 +308,7 @@ func (s *backendSuite) TestRemovingSnapRemovesAndUnloadsProfiles(c *C) {
 		_, err := os.Stat(profile)
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor cache file was removed
-		cache := filepath.Join(dirs.AppArmorCacheDir, "snap.samba.smbd")
+		cache := filepath.Join(apparmor_sandbox.CacheDir, "snap.samba.smbd")
 		_, err = os.Stat(cache)
 		c.Check(os.IsNotExist(err), Equals, true)
 	}
@@ -324,7 +324,7 @@ func (s *backendSuite) TestRemovingSnapWithHookRemovesAndUnloadsProfiles(c *C) {
 		_, err := os.Stat(profile)
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor cache file was removed
-		cache := filepath.Join(dirs.AppArmorCacheDir, "snap.foo.hook.configure")
+		cache := filepath.Join(apparmor_sandbox.CacheDir, "snap.foo.hook.configure")
 		_, err = os.Stat(cache)
 		c.Check(os.IsNotExist(err), Equals, true)
 	}
@@ -1138,7 +1138,7 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 `, dirs.SnapMountDir))
 
 	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s", dirs.AppArmorCacheDir), "--quiet", newAA[0]},
+		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s", apparmor_sandbox.CacheDir), "--quiet", newAA[0]},
 	})
 
 	// snap-confine directory was created
@@ -1162,47 +1162,47 @@ func (s *backendSuite) testCoreOrSnapdOnCoreCleansApparmorCache(c *C, coreOrSnap
 	restorer := release.MockOnClassic(false)
 	defer restorer()
 
-	err := os.MkdirAll(dirs.SystemApparmorCacheDir, 0755)
+	err := os.MkdirAll(apparmor_sandbox.SystemCacheDir, 0755)
 	c.Assert(err, IsNil)
 	// the canary file in the cache will be removed
-	canaryPath := filepath.Join(dirs.SystemApparmorCacheDir, "meep")
+	canaryPath := filepath.Join(apparmor_sandbox.SystemCacheDir, "meep")
 	err = ioutil.WriteFile(canaryPath, nil, 0644)
 	c.Assert(err, IsNil)
 	// and the snap-confine profiles are removed
-	scCanaryPath := filepath.Join(dirs.SystemApparmorCacheDir, "usr.lib.snapd.snap-confine.real")
+	scCanaryPath := filepath.Join(apparmor_sandbox.SystemCacheDir, "usr.lib.snapd.snap-confine.real")
 	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
-	scCanaryPath = filepath.Join(dirs.SystemApparmorCacheDir, "usr.lib.snapd.snap-confine")
+	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "usr.lib.snapd.snap-confine")
 	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
-	scCanaryPath = filepath.Join(dirs.SystemApparmorCacheDir, "snap-confine.core.6405")
+	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "snap-confine.core.6405")
 	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
-	scCanaryPath = filepath.Join(dirs.SystemApparmorCacheDir, "snap-confine.snapd.6405")
+	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "snap-confine.snapd.6405")
 	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
-	scCanaryPath = filepath.Join(dirs.SystemApparmorCacheDir, "snap.core.4938.usr.lib.snapd.snap-confine")
+	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "snap.core.4938.usr.lib.snapd.snap-confine")
 	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
-	scCanaryPath = filepath.Join(dirs.SystemApparmorCacheDir, "var.lib.snapd.snap.core.1234.usr.lib.snapd.snap-confine")
+	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "var.lib.snapd.snap.core.1234.usr.lib.snapd.snap-confine")
 	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
 	// but non-regular entries in the cache dir are kept
-	dirsAreKept := filepath.Join(dirs.SystemApparmorCacheDir, "dir")
+	dirsAreKept := filepath.Join(apparmor_sandbox.SystemCacheDir, "dir")
 	err = os.MkdirAll(dirsAreKept, 0755)
 	c.Assert(err, IsNil)
-	symlinksAreKept := filepath.Join(dirs.SystemApparmorCacheDir, "symlink")
+	symlinksAreKept := filepath.Join(apparmor_sandbox.SystemCacheDir, "symlink")
 	err = os.Symlink("some-sylink-target", symlinksAreKept)
 	c.Assert(err, IsNil)
 	// and the snap profiles are kept
-	snapCanaryKept := filepath.Join(dirs.SystemApparmorCacheDir, "snap.canary.meep")
+	snapCanaryKept := filepath.Join(apparmor_sandbox.SystemCacheDir, "snap.canary.meep")
 	err = ioutil.WriteFile(snapCanaryKept, nil, 0644)
 	c.Assert(err, IsNil)
-	sunCanaryKept := filepath.Join(dirs.SystemApparmorCacheDir, "snap-update-ns.canary")
+	sunCanaryKept := filepath.Join(apparmor_sandbox.SystemCacheDir, "snap-update-ns.canary")
 	err = ioutil.WriteFile(sunCanaryKept, nil, 0644)
 	c.Assert(err, IsNil)
 	// and the .features file is kept
-	dotKept := filepath.Join(dirs.SystemApparmorCacheDir, ".features")
+	dotKept := filepath.Join(apparmor_sandbox.SystemCacheDir, ".features")
 	err = ioutil.WriteFile(dotKept, nil, 0644)
 	c.Assert(err, IsNil)
 
@@ -1210,7 +1210,7 @@ func (s *backendSuite) testCoreOrSnapdOnCoreCleansApparmorCache(c *C, coreOrSnap
 	// for this snap-confine on core
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", coreOrSnapdYaml, 111)
 
-	l, err := filepath.Glob(filepath.Join(dirs.SystemApparmorCacheDir, "*"))
+	l, err := filepath.Glob(filepath.Join(apparmor_sandbox.SystemCacheDir, "*"))
 	c.Assert(err, IsNil)
 	// canary is gone, extra stuff is kept
 	c.Check(l, DeepEquals, []string{dotKept, dirsAreKept, sunCanaryKept, snapCanaryKept, symlinksAreKept})
@@ -1279,11 +1279,11 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithNFS(c *C, profileF
 	restore = apparmor.MockProcSelfExe(fakeExe)
 	defer restore()
 
-	profilePath := filepath.Join(dirs.SystemApparmorDir, profileFname)
+	profilePath := filepath.Join(apparmor_sandbox.ConfDir, profileFname)
 
 	// Create the directory where system apparmor profiles are stored and write
 	// the system apparmor profile of snap-confine.
-	c.Assert(os.MkdirAll(dirs.SystemApparmorDir, 0755), IsNil)
+	c.Assert(os.MkdirAll(apparmor_sandbox.ConfDir, 0755), IsNil)
 	c.Assert(ioutil.WriteFile(profilePath, []byte(""), 0644), IsNil)
 
 	// Setup generated policy for snap-confine.
@@ -1309,7 +1309,7 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithNFS(c *C, profileF
 		"apparmor_parser", "--replace",
 		"--write-cache",
 		"-O", "no-expr-simplify",
-		"--cache-loc=" + dirs.SystemApparmorCacheDir,
+		"--cache-loc=" + apparmor_sandbox.SystemCacheDir,
 		"--skip-read-cache",
 		"--quiet",
 		profilePath,
@@ -1457,8 +1457,8 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyError3(c *C) {
 
 	// Create the directory where system apparmor profiles are stored and Write
 	// the system apparmor profile of snap-confine.
-	c.Assert(os.MkdirAll(dirs.SystemApparmorDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SystemApparmorDir, "usr.lib.snapd.snap-confine"), []byte(""), 0644), IsNil)
+	c.Assert(os.MkdirAll(apparmor_sandbox.ConfDir, 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(apparmor_sandbox.ConfDir, "usr.lib.snapd.snap-confine"), []byte(""), 0644), IsNil)
 
 	// Setup generated policy for snap-confine.
 	err = (&apparmor.Backend{}).Initialize(nil)
@@ -1601,11 +1601,11 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithOverlay(c *C, prof
 	restore = apparmor.MockProcSelfExe(fakeExe)
 	defer restore()
 
-	profilePath := filepath.Join(dirs.SystemApparmorDir, profileFname)
+	profilePath := filepath.Join(apparmor_sandbox.ConfDir, profileFname)
 
 	// Create the directory where system apparmor profiles are stored and write
 	// the system apparmor profile of snap-confine.
-	c.Assert(os.MkdirAll(dirs.SystemApparmorDir, 0755), IsNil)
+	c.Assert(os.MkdirAll(apparmor_sandbox.ConfDir, 0755), IsNil)
 	c.Assert(ioutil.WriteFile(profilePath, []byte(""), 0644), IsNil)
 
 	// Setup generated policy for snap-confine.
@@ -1631,7 +1631,7 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithOverlay(c *C, prof
 		"apparmor_parser", "--replace",
 		"--write-cache",
 		"-O", "no-expr-simplify",
-		"--cache-loc=" + dirs.SystemApparmorCacheDir,
+		"--cache-loc=" + apparmor_sandbox.SystemCacheDir,
 		"--skip-read-cache",
 		"--quiet",
 		profilePath,

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -49,6 +51,30 @@ const (
 	Partial
 	// Full indicates that all features are supported.
 	Full
+)
+
+func setupConfCacheDirs(newrootdir string) {
+	ConfDir = filepath.Join(newrootdir, "/etc/apparmor.d")
+	CacheDir = filepath.Join(newrootdir, "/var/cache/apparmor")
+
+	SystemCacheDir = filepath.Join(ConfDir, "cache")
+	exists, isDir, _ := osutil.DirExists(SystemCacheDir)
+	if !exists || !isDir {
+		// some systems use a single cache dir instead of splitting
+		// out the system cache
+		SystemCacheDir = CacheDir
+	}
+}
+
+func init() {
+	dirs.AddRootDirCallback(setupConfCacheDirs)
+	setupConfCacheDirs(dirs.GlobalRootDir)
+}
+
+var (
+	ConfDir        string
+	CacheDir       string
+	SystemCacheDir string
 )
 
 func (level LevelType) String() string {

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -62,6 +62,7 @@ func setupConfCacheDirs(newrootdir string) {
 	if !exists || !isDir {
 		// some systems use a single cache dir instead of splitting
 		// out the system cache
+		// TODO: it seems Solus has a different setup too, investigate this
 		SystemCacheDir = CacheDir
 	}
 }


### PR DESCRIPTION
This is not critical for anything, but is a nice to have to reduce the dependencies of the dirs package. Things that care about where apparmor dirs are should probably be asking the apparmor package. 