### PR TITLE
selinux: export MockIsEnforcing; systemd: use in tests

### DIFF
--- a/sandbox/selinux/export_test.go
+++ b/sandbox/selinux/export_test.go
@@ -43,11 +43,3 @@ func MockMountInfo(c *check.C, text string) (where string, restore func()) {
 	}
 	return procSelfMountInfo, restore
 }
-
-func MockSELinuxIsEnforcing(isEnforcing func() (bool, error)) (restore func()) {
-	old := selinuxIsEnforcing
-	selinuxIsEnforcing = isEnforcing
-	return func() {
-		selinuxIsEnforcing = old
-	}
-}

--- a/sandbox/selinux/selinux.go
+++ b/sandbox/selinux/selinux.go
@@ -85,3 +85,13 @@ func MockIsEnabled(isEnabled func() (bool, error)) (restore func()) {
 		selinuxIsEnabled = old
 	}
 }
+
+// MockIsEnforcing makes the system believe the current SELinux is currently
+// enforcing
+func MockIsEnforcing(isEnforcing func() (bool, error)) (restore func()) {
+	old := selinuxIsEnforcing
+	selinuxIsEnforcing = isEnforcing
+	return func() {
+		selinuxIsEnforcing = old
+	}
+}

--- a/sandbox/selinux/selinux_test.go
+++ b/sandbox/selinux/selinux_test.go
@@ -46,7 +46,7 @@ func (s *selinuxBasicSuite) TestProbeNone(c *C) {
 func (s *selinuxBasicSuite) TestProbeEnforcingHappy(c *C) {
 	restore := selinux.MockIsEnabled(func() (bool, error) { return true, nil })
 	defer restore()
-	restore = selinux.MockSELinuxIsEnforcing(func() (bool, error) { return true, nil })
+	restore = selinux.MockIsEnforcing(func() (bool, error) { return true, nil })
 	defer restore()
 
 	level, status := selinux.ProbeSELinux()
@@ -72,7 +72,7 @@ func (s *selinuxBasicSuite) TestProbeEnabledError(c *C) {
 func (s *selinuxBasicSuite) TestProbeEnforcingError(c *C) {
 	restore := selinux.MockIsEnabled(func() (bool, error) { return true, nil })
 	defer restore()
-	restore = selinux.MockSELinuxIsEnforcing(func() (bool, error) { return true, errors.New("so much fail") })
+	restore = selinux.MockIsEnforcing(func() (bool, error) { return true, errors.New("so much fail") })
 	defer restore()
 
 	level, status := selinux.ProbeSELinux()
@@ -86,7 +86,7 @@ func (s *selinuxBasicSuite) TestProbeEnforcingError(c *C) {
 func (s *selinuxBasicSuite) TestProbePermissive(c *C) {
 	restore := selinux.MockIsEnabled(func() (bool, error) { return true, nil })
 	defer restore()
-	restore = selinux.MockSELinuxIsEnforcing(func() (bool, error) { return false, nil })
+	restore = selinux.MockIsEnforcing(func() (bool, error) { return false, nil })
 	defer restore()
 
 	level, status := selinux.ProbeSELinux()

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -575,6 +575,8 @@ WantedBy=multi-user.target
 func (s *SystemdTestSuite) TestWriteSELinuxMountUnit(c *C) {
 	restore := selinux.MockIsEnabled(func() (bool, error) { return true, nil })
 	defer restore()
+	restore = selinux.MockIsEnforcing(func() (bool, error) { return true, nil })
+	defer restore()
 	restore = squashfs.MockNeedsFuse(false)
 	defer restore()
 


### PR DESCRIPTION
Not exporting this means that the systemd tests would now need to actually mock selinux mountinfo details.