### PR TITLE
github: cancel previous builds

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -1,0 +1,12 @@
+name: Cancel
+on: [push]
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.3.1
+        with:
+          workflow_id: 864446 
+          access_token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
GitHub actions does not have a first party feature of cancelling
workflows that are CI related when a new commit is pushed to an open
pull request.

This puts a lot of load on our queue that is processing effectively
stale requests. To ease the pain integrate with a 3rd party action
to see if we can get the desired effect.

If successful the action will be forked and hosted on snapcore/*, to
ensure we are in control.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
