### PR TITLE
tests/session-tool: session ordering is non-deterministic

### DIFF
--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -27,7 +27,7 @@ prepare: |
     ) > before.debug.txt
 
     # Brief version of existing sessions to measure during "restore".
-    loginctl list-sessions > before.txt
+    loginctl --no-legend list-sessions | sort > before.txt
 
     # Prepare for using sessions as the given user
     session-tool --prepare -u "$USER"
@@ -60,7 +60,7 @@ restore: |
 
     # When we are done the sessions are exactly what we started with but this
     # can take a moment as the termination process is asnychronous.
-    retry-tool -n 10 --wait 1 sh -c 'loginctl list-sessions > after.txt && diff -u before.txt after.txt'
+    retry-tool -n 10 --wait 1 sh -c 'loginctl --no-legend list-sessions | sort > after.txt && diff -u before.txt after.txt'
     # Remove files we've created
     rm -f /tmp/{inner,outer}.pid
     rm -f {before,after}.txt


### PR DESCRIPTION
The session-tool test failed with:

    --- before.txt	2020-04-07 19:02:19.552178634 +0000
    +++ after.txt	2020-04-07 19:05:21.061081801 +0000
    @@ -1,5 +1,5 @@
	SESSION        UID USER             SEAT
    -         2          0 root
	      1          0 root
    +         2          0 root

     2 sessions listed.

Fortunately we had additional information this time:

    --- before.debug.txt	2020-04-07 19:02:19.548178262 +0000
    +++ after.debug.txt	2020-04-07 19:05:21.202094929 +0000
    @@ -1,24 +1,4 @@
     Active sessions:
    -Details of session 2
    -Id=2
    -User=0
    -Name=root
    -Timestamp=Tue 2020-04-07 19:01:01 UTC
    -TimestampMonotonic=1383105892
    -VTNr=0
    -Remote=no
    -Service=crond
    -Scope=session-2.scope
    -Leader=28528
    -Audit=2
    -Type=unspecified
    -Class=background
    -Active=yes
    -State=active
    -IdleHint=no
    -IdleSinceHint=0
    -IdleSinceHintMonotonic=0
    -LockedHint=no
     Details of session 1
     Id=1
     User=0
    @@ -37,6 +17,26 @@
     Active=yes
     State=active
     IdleHint=no
    +IdleSinceHint=0
    +IdleSinceHintMonotonic=0
    +LockedHint=no
    +Details of session 2
    +Id=2
    +User=0
    +Name=root
    +Timestamp=Tue 2020-04-07 19:01:01 UTC
    +TimestampMonotonic=1383105892
    +VTNr=0
    +Remote=no
    +Service=crond
    +Scope=session-2.scope
    +Leader=28528
    +Audit=2
    +Type=unspecified
    +Class=background
    +Active=yes
    +State=active
    +IdleHint=no
     IdleSinceHint=0
     IdleSinceHintMonotonic=0
     LockedHint=no

As we can see, session 2 is really identical before and after the test.
Perhaps reloading older versions of logind can cause sessions to change
order in the internal data structures?

In either case, sort the before/after lists to avoid this problem.
To make sorting work pass --no-legend to strip the header/footer lines.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
