### PR TITLE
tests: add 32 bit machine to GH actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,7 @@ jobs:
       matrix:
         system:
         - ubuntu-16.04-64
+        - ubuntu-16.04-32
         - ubuntu-core-16-64
     steps:
     - name: Checkout code

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -583,7 +583,6 @@ pkg_dependencies_ubuntu_classic(){
         fontconfig
         gnome-keyring
         jq
-        libc6-dev-i386
         man
         nfs-kernel-server
         printer-driver-cups-pdf
@@ -660,6 +659,7 @@ pkg_dependencies_ubuntu_classic(){
                 eatmydata
                 evolution-data-server
                 fwupd
+                libc6-dev-i386
                 net-tools
                 packagekit
                 sbuild

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,10 +7,16 @@
 			"revision": ""
 		},
 		{
-			"checksumSHA1": "9knAF4MuJlL6JI1jM3i/AS4ACbY=",
+			"checksumSHA1": "vdoEbcZanhiMfNOmqdCoizz3CRI=",
 			"path": "github.com/chrisccoulson/go-tpm2",
-			"revision": "e6887e32e4a513099aedbc8fc313d369a889131e",
-			"revisionTime": "2020-03-06T09:45:16Z"
+			"revision": "c9680171bd57ce6028ecd5c895a54abe6bccc1d6",
+			"revisionTime": "2020-04-06T19:53:07Z"
+		},
+		{
+			"checksumSHA1": "gG7bzHZcHChchuLFW6XY/ojB/k8=",
+			"path": "github.com/chrisccoulson/go-tpm2/internal/crypto",
+			"revision": "c9680171bd57ce6028ecd5c895a54abe6bccc1d6",
+			"revisionTime": "2020-04-06T19:53:07Z"
 		},
 		{
 			"checksumSHA1": "eDjzake0GpHm9kfTH7FMUWX8zVA=",
@@ -111,10 +117,10 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "dJIqi7bVE6Lwzib0oGkCEQeEcxY=",
+			"checksumSHA1": "rg++Of1pqZF7emKLOV0LoDL1WvU=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "49613a072d9413ec09a5e98f6791a6f93e2571b9",
-			"revisionTime": "2020-03-30T08:14:49Z"
+			"revision": "1bdd70d66dc41c1b6b138ee0204ea1e7d188d307",
+			"revisionTime": "2020-04-08T11:02:26Z"
 		},
 		{
 			"checksumSHA1": "3AmEm18mKj8XxBuru/ix4OOpRkE=",


### PR DESCRIPTION
We currently have no 32 bit machine running tests in GH actions.
This is important to catch issues like int overflows that happend
recently in the secboot code.
