### PR TITLE
github: skip spread jobs when corresponding label is set

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,6 @@ jobs:
   spread-canary:
     needs: unit-tests
     runs-on: self-hosted
-    if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
     strategy:
       fail-fast: false
       matrix:
@@ -83,6 +82,7 @@ jobs:
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
+      if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"
@@ -97,7 +97,6 @@ jobs:
   spread-stable:
     needs: [unit-tests, spread-canary]
     runs-on: self-hosted
-    if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       #
@@ -127,6 +126,7 @@ jobs:
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
+      if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"
@@ -141,7 +141,6 @@ jobs:
   spread-unstable:
     needs: [unit-tests, spread-stable]
     runs-on: self-hosted
-    if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       fail-fast: false
@@ -156,6 +155,7 @@ jobs:
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
+      if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,6 +70,7 @@ jobs:
   spread-canary:
     needs: unit-tests
     runs-on: self-hosted
+    if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
     strategy:
       fail-fast: false
       matrix:
@@ -96,6 +97,7 @@ jobs:
   spread-stable:
     needs: [unit-tests, spread-canary]
     runs-on: self-hosted
+    if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       #
@@ -139,6 +141,7 @@ jobs:
   spread-unstable:
     needs: [unit-tests, spread-stable]
     runs-on: self-hosted
+    if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       fail-fast: false


### PR DESCRIPTION
Port the skip-spread thing to github actions.
