### PR TITLE
github: allow cached debian downloads to restore

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,8 @@ jobs:
         # NOTE: checkout the code in a fixed location, even for forks, as this
         # is relevant for go's import system.
         path: ./src/github.com/snapcore/snapd
+    - name: Make /var/cache/apt owned by current user
+      run: sudo chown -R $(id -u) /var/cache/apt
     - name: Cache Debian dependencies
       id: cache-deb-downloads
       uses: actions/cache@v1


### PR DESCRIPTION
Cache action fails to restore the contents to /var/cache/apt

    /bin/tar: ./archives/lib32mpx0_5.5.0-12ubuntu1~16.04_amd64.deb: Cannot open: Permission denied
    Run actions/cache@v1
    Cache Size: ~112 MB (117373280 B)
    /bin/tar -xz -f /home/runner/work/_temp/91fec82d-1028-40cc-9c4e-3b4a63bfb9e6/cache.tgz -C /var/cache/apt
    /bin/tar: ./apt-fast: Cannot utime: Operation not permitted

This is because at the time the action runs, the permissions are
typical. We solved it for the "cache" case but not for the "restore
cache" case,  this should fix that.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
