### PR TITLE
asserts: it should be possible to omit many snap-ids if allowed, fix

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -210,10 +210,10 @@ func checkModelSnap(snap map[string]interface{}, grade ModelGrade) (*ModelSnap, 
 			return nil, err
 		}
 	} else {
-		// snap ids are optional with grade unstable to allow working
+		// snap ids are optional with grade dangerous to allow working
 		// with local/not pushed yet to the store snaps
 		if grade != ModelDangerous {
-			return nil, fmt.Errorf(`"id" %s is mandatory for stable model`, what)
+			return nil, fmt.Errorf(`"id" %s is mandatory for %s grade model`, what, grade)
 		}
 	}
 

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -123,13 +123,15 @@ func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade
 		if seen[modelSnap.Name] {
 			return nil, fmt.Errorf("cannot list the same snap %q multiple times", modelSnap.Name)
 		}
+		seen[modelSnap.Name] = true
 		// at this time we do not support parallel installing
 		// from model/seed
-		if underName := seenIDs[modelSnap.SnapID]; underName != "" {
-			return nil, fmt.Errorf("cannot specify the same snap id %q multiple times, specified for snaps %q and %q", modelSnap.SnapID, underName, modelSnap.Name)
+		if snapID := modelSnap.SnapID; snapID != "" {
+			if underName := seenIDs[snapID]; underName != "" {
+				return nil, fmt.Errorf("cannot specify the same snap id %q multiple times, specified for snaps %q and %q", snapID, underName, modelSnap.Name)
+			}
+			seenIDs[snapID] = modelSnap.Name
 		}
-		seen[modelSnap.Name] = true
-		seenIDs[modelSnap.SnapID] = modelSnap.Name
 
 		essential := false
 		switch {

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -769,6 +769,7 @@ func (mods *modelSuite) TestCore20GradeDangerous(c *C) {
 	// snap ids are optional with grade dangerous to allow working
 	// with local/not pushed yet to the store snaps
 	encoded = strings.Replace(encoded, "    id: myappdididididididididididididid\n", "", 1)
+	encoded = strings.Replace(encoded, "    id: brandgadgetdidididididididididid\n", "", 1)
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.ModelType)

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -799,7 +799,7 @@ func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 		{"name: myapp\n", "other: 1\n", `"name" of snap is mandatory`},
 		{"name: myapp\n", "name: myapp_2\n", `invalid snap name "myapp_2"`},
 		{"id: myappdididididididididididididid\n", "id: 2\n", `"id" of snap "myapp" contains invalid characters: "2"`},
-		{"    id: myappdididididididididididididid\n", "", `"id" of snap "myapp" is mandatory for stable model`},
+		{"    id: myappdididididididididididididid\n", "", `"id" of snap "myapp" is mandatory for secured grade model`},
 		{"type: gadget\n", "type:\n      - g\n", `"type" of snap "brand-gadget" must be a string`},
 		{"type: app\n", "type: thing\n", `"type" of snap "myappopt" must be one of must be one of app|base|gadget|kernel|core|snapd`},
 		{"modes:\n      - run\n", "modes: run\n", `"modes" of snap "other-base" must be a list of strings`},


### PR DESCRIPTION
We were checking for snap id reuse even for the empty/omitted
snap-ids, those are allowed in grade dangerous for any snap.

Also use the new naming/terminology in the mandatory ids check code.

