### PR TITLE
tests/session-tool: kill cron session, if any

### DIFF
--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -15,6 +15,13 @@ prepare: |
             echo "systemctl start \"$unit\"" >> defer.sh
         fi
     done
+
+    # For whatever reason (what spawns it!?!) cron may be running in session 2.
+    # To remove any background activity, get rid of it.
+    if loginctl show-session 2 >/dev/null 2>&1 && loginctl show-session 2 | grep -q Service=crond; then
+        loginctl kill-session 2
+    fi
+
     # Kill sessions that systemd has leaked earlier.
     session-tool --kill-leaked
 
@@ -45,6 +52,11 @@ execute: |
 restore: |
     # Restore after using sessions as the given user
     session-tool --restore -u "$USER"
+
+    # Kill cron if it is running (check prepare for details).
+    if loginctl show-session 2 >/dev/null 2>&1 && loginctl show-session 2 | grep -q Service=crond; then
+        loginctl kill-session 2
+    fi
 
     # Kill sessions that systemd has leaked over time.
     session-tool --kill-leaked


### PR DESCRIPTION
Despite stopping cron*.service, cron may still be running in a session
when we commence or finish the test. While I have no insight into what
is starting it, we can kill it to avoid any background activity.

This was observed with a session such as:

    Id=2
    User=0
    Name=root
    Timestamp=Wed 2020-04-08 10:01:01 UTC
    TimestampMonotonic=90474701
    VTNr=0
    Remote=no
    Service=crond
    Scope=session-2.scope
    Leader=1659
    Audit=2
    Type=unspecified
    Class=background
    Active=yes
    State=active
    IdleHint=no
    IdleSinceHint=0
    IdleSinceHintMonotonic=0
    LockedHint=no

The session was started at close to 10AM, so perhaps there's some other
source of temporary activities?

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
