### PR TITLE
github: run non-canary if label is present

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,6 +97,7 @@ jobs:
           spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
         done
   spread-stable:
+    if: "contains(github.event.pull_request.labels.*.name, 'Run spread')"
     needs: [unit-tests, spread-canary]
     runs-on: self-hosted
     strategy:
@@ -141,6 +142,7 @@ jobs:
           spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
         done
   spread-unstable:
+    if: "contains(github.event.pull_request.labels.*.name, 'Run spread')"
     needs: [unit-tests, spread-stable]
     runs-on: self-hosted
     strategy:


### PR DESCRIPTION
This will let us save resources when we just push new code to a
work-in-progress branch. We will still run unit tests and canary spread
but that has much lower cost.

Due to the [required] checks for all stable spread targets no pull request
can be merged before the "Run spread" label is set.

This logic will allow us to open pull requests in "half draft" mode, where some
basic checks will run quickly but more expensive and extensive checks are
only started once the label is assigned.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
