### PR TITLE
tests: update snap-preseed --reset logic to acommodate for 2.44 change

### DIFF
--- a/cmd/snap-preseed/reset.go
+++ b/cmd/snap-preseed/reset.go
@@ -63,6 +63,7 @@ func resetPreseededChroot(preseedChroot string) error {
 		filepath.Join(dirs.SnapDataDir, "*"),
 		filepath.Join(dirs.SnapCacheDir, "*"),
 		filepath.Join(apparmor_sandbox.CacheDir, "*"),
+		filepath.Join(dirs.SnapDesktopFilesDir, "*"),
 	}
 
 	for _, gl := range globs {
@@ -82,7 +83,6 @@ func resetPreseededChroot(preseedChroot string) error {
 	paths := []string{
 		dirs.SnapAssertsDBDir,
 		dirs.FeaturesDir,
-		dirs.SnapDesktopFilesDir,
 		dirs.SnapDesktopIconsDir,
 		dirs.SnapDeviceDir,
 		dirs.SnapCookieDir,

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -26,7 +26,13 @@ restore: |
 
 execute: |
   find_files() {
-    find "$IMAGE_MOUNTPOINT/etc/" "$IMAGE_MOUNTPOINT/usr/" "$IMAGE_MOUNTPOINT/var/"
+    # ubuntu-19.10 doesn't have new snapd deb yet, so exclude applications dir for now
+    # TODO: remove after 2.44 is there.
+    if [[ "$SPREAD_SYSTEM" = ubuntu-19.10-64 ]]; then
+      find "$IMAGE_MOUNTPOINT/etc/" "$IMAGE_MOUNTPOINT/usr/" "$IMAGE_MOUNTPOINT/var/" | grep -v "/var/lib/snapd/desktop/applications"
+    else
+      find "$IMAGE_MOUNTPOINT/etc/" "$IMAGE_MOUNTPOINT/usr/" "$IMAGE_MOUNTPOINT/var/"
+    fi
   }
 
   #shellcheck source=tests/lib/preseed.sh


### PR DESCRIPTION
This should fix snap-preseed spread test failure on master. Note, the test also hangs in case of failure, but I'm still investigating this. This should fix the reason of the failure though and unblock master.

The 2.44 deb now includes an empty /var/lib/snapd/desktop/applications directory, which causes preseed-reset spread test failure when diffing the filesystem before and after reset (because with current reset implementation the directory is removed completely, when it should be left empty).

