### PR TITLE
tests: backport partition fixes to 2.44

### DIFF
--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -1,9 +1,7 @@
 summary: Integration tests for the snap-bootstrap binary
 
-# testing on 19.10/20.04 is enough, its a very specialized test
-# TODO:UC20: remove 19.10-64 system once ubuntu-20.04-64 becomes available
-#            inside spread
-systems: [ubuntu-19.10-64, ubuntu-20.04-64]
+# use the same system and tooling as uc20
+systems: [ubuntu-20.04-64]
 
 debug: |
     cat /proc/partitions

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -49,6 +49,6 @@ execute: |
 
     echo "And check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'
-    sfdisk -l "$LOOP" | MATCH '3G Linux filesystem'
+    sfdisk -l "$LOOP" | MATCH '1G Linux filesystem'
     file -s "${LOOP}p3" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-boot"'
     file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -1,7 +1,7 @@
 summary: Integration tests for the snap-bootstrap binary autodetect
 
-# one system is enough, its a very specialized test for now
-systems: [ubuntu-19.10-64]
+# use the same system and tooling as uc20
+systems: [ubuntu-20.04-64]
 
 debug: |
     cat /proc/partitions


### PR DESCRIPTION
This backport selected partition test fixes from master to 2.44 to unbreak the tests.