### PR TITLE
many: fix loading apparmor profiles on Ubuntu 20.04 with ZFS

### DIFF
--- a/data/systemd/snapd.apparmor.service.in
+++ b/data/systemd/snapd.apparmor.service.in
@@ -11,6 +11,7 @@ Before=sysinit.target
 # This dependency is meant to ensure that apparmor initialization (whatever that might entail) is complete.
 After=apparmor.service
 ConditionSecurity=apparmor
+RequiresMountsFor=/var/cache/apparmor /var/lib/snapd/apparmor/profiles
 
 [Service]
 Type=oneshot

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -252,10 +252,6 @@ override_dh_install:
 	# Rename the apparmor profile, see dh_apparmor call above for an explanation.
 	mv $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine.real
 
-	# On Ubuntu and Debian we don't need to install the apparmor helper service.
-	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.apparmor.service
-	rm $(CURDIR)/debian/tmp/usr/lib/snapd/snapd-apparmor
-
 	dh_install
 
 override_dh_auto_install: snap.8

--- a/packaging/ubuntu-16.04/snapd.install
+++ b/packaging/ubuntu-16.04/snapd.install
@@ -45,3 +45,6 @@ vendor/github.com/snapcore/squashfuse/src/snapfuse usr/bin
 usr/lib/systemd/system-environment-generators
 # but system generators end up in lib
 lib/systemd/system-generators
+
+# service for loading apparmor profiles for snap applications
+usr/lib/snapd/snapd-apparmor

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -596,7 +596,7 @@ WantedBy={{.ServicesTarget}}
 		KillSignal:         appInfo.StopMode.KillSignal(),
 
 		Before: genServiceNames(appInfo.Snap, appInfo.Before),
-		After:  genServiceNames(appInfo.Snap, appInfo.After),
+		After:  append(genServiceNames(appInfo.Snap, appInfo.After), "snapd.apparmor.service"),
 
 		// systemd runs as PID 1 so %h will not work.
 		Home: "/root",

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -49,7 +49,7 @@ const expectedServiceFmt = `[Unit]
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
 Wants=network.target
-After=%s-snap-44.mount network.target
+After=%s-snap-44.mount network.target snapd.apparmor.service
 X-Snappy=yes
 
 [Service]
@@ -84,7 +84,7 @@ var (
 Description=Service for snap application xkcd-webserver.xkcd-webserver
 Requires=%s-xkcd\x2dwebserver-44.mount
 Wants=network.target
-After=%s-xkcd\x2dwebserver-44.mount network.target
+After=%s-xkcd\x2dwebserver-44.mount network.target snapd.apparmor.service
 X-Snappy=yes
 
 [Service]
@@ -359,7 +359,7 @@ func (s *servicesWrapperGenSuite) TestServiceAfterBefore(c *C) {
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
 Wants=network.target
-After=%s-snap-44.mount network.target %s
+After=%s-snap-44.mount network.target %s snapd.apparmor.service
 Before=%s
 X-Snappy=yes
 
@@ -508,7 +508,7 @@ func (s *servicesWrapperGenSuite) TestServiceTimerServiceUnit(c *C) {
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
 Wants=network.target
-After=%s-snap-44.mount network.target
+After=%s-snap-44.mount network.target snapd.apparmor.service
 X-Snappy=yes
 
 [Service]
@@ -709,7 +709,7 @@ func (s *servicesWrapperGenSuite) TestKillModeSig(c *C) {
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
 Wants=network.target
-After=%s-snap-44.mount network.target
+After=%s-snap-44.mount network.target snapd.apparmor.service
 X-Snappy=yes
 
 [Service]
@@ -750,7 +750,7 @@ func (s *servicesWrapperGenSuite) TestRestartDelay(c *C) {
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
 Wants=network.target
-After=%s-snap-44.mount network.target
+After=%s-snap-44.mount network.target snapd.apparmor.service
 X-Snappy=yes
 
 [Service]


### PR DESCRIPTION
This branch contains three patches that collectively address the problem
where, on Ubuntu 20.04 with experimental ZFS root filesystem, apparmor
profiles are not loaded early during the boot process due to a collection
of related problems.

Fixes: https://bugs.launchpad.net/apparmor/+bug/1871148
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>