### PR TITLE
tests: update snap-preseed --reset logic to acommodate for 2.44 change (2.44)

### DIFF
--- a/cmd/snap-preseed/reset.go
+++ b/cmd/snap-preseed/reset.go
@@ -62,6 +62,7 @@ func resetPreseededChroot(preseedChroot string) error {
 		filepath.Join(dirs.SnapDataDir, "*"),
 		filepath.Join(dirs.SnapCacheDir, "*"),
 		filepath.Join(dirs.AppArmorCacheDir, "*"),
+		filepath.Join(dirs.SnapDesktopFilesDir, "*"),
 	}
 
 	for _, gl := range globs {
@@ -81,7 +82,6 @@ func resetPreseededChroot(preseedChroot string) error {
 	paths := []string{
 		dirs.SnapAssertsDBDir,
 		dirs.FeaturesDir,
-		dirs.SnapDesktopFilesDir,
 		dirs.SnapDesktopIconsDir,
 		dirs.SnapDeviceDir,
 		dirs.SnapCookieDir,

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -115,14 +115,11 @@ and environment.
 // isStopping returns true if the system is shutting down.
 func isStopping() (bool, error) {
 	// Make sure, just in case, that systemd doesn't localize the output string.
-	env, err := osutil.OSEnvironment()
-	if err != nil {
-		return false, err
-	}
-	env["LC_MESSAGES"] = "C"
+	env := os.Environ()
+	env = append(env, "LC_MESSAGES=C")
 	// Check if systemd is stopping (shutting down or rebooting).
 	cmd := exec.Command("systemctl", "is-system-running")
-	cmd.Env = env.ForExec()
+	cmd.Env = env
 	stdout, err := cmd.Output()
 	// systemctl is-system-running returns non-zero for outcomes other than "running"
 	// As such, ignore any ExitError and just process the stdout buffer.

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -26,7 +26,13 @@ restore: |
 
 execute: |
   find_files() {
-    find "$IMAGE_MOUNTPOINT/etc/" "$IMAGE_MOUNTPOINT/usr/" "$IMAGE_MOUNTPOINT/var/"
+    # ubuntu-19.10 doesn't have new snapd deb yet, so exclude applications dir for now
+    # TODO: remove after 2.44 is there.
+    if [[ "$SPREAD_SYSTEM" = ubuntu-19.10-64 ]]; then
+      find "$IMAGE_MOUNTPOINT/etc/" "$IMAGE_MOUNTPOINT/usr/" "$IMAGE_MOUNTPOINT/var/" | grep -v "/var/lib/snapd/desktop/applications"
+    else
+      find "$IMAGE_MOUNTPOINT/etc/" "$IMAGE_MOUNTPOINT/usr/" "$IMAGE_MOUNTPOINT/var/"
+    fi
   }
 
   #shellcheck source=tests/lib/preseed.sh


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/8465 for 2.44