### PR TITLE
tests: disable some problematic tests for 2.44

### DIFF
--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -7,7 +7,8 @@ details: |
 # Debian sid is skipped because "timedatectl set-ntp" fails with the error:
 # "Failed to set ntp: Message recipient disconnected from message bus without replying"
 # A workaround is to make "systemctl enable --now systemd-timesyncd.service" instead
-systems: [-debian-sid-*]
+# XXX: 20.04: fails with `Failed to restart systemd-timesyncd.service: Unit systemd-timesyncd.service is masked.` - needs further investigation, looks like a packaging issue in 20.04
+systems: [-debian-sid-*, -ubuntu-20.04-*]
 
 prepare: |
     # shellcheck source=tests/lib/snaps.sh

--- a/tests/main/snap-confine-undesired-mode-group/task.yaml
+++ b/tests/main/snap-confine-undesired-mode-group/task.yaml
@@ -1,4 +1,7 @@
 summary: the snap-{run,confine,exec} chain does not create files with undesired properties.
+
+manual: true
+
 prepare: |
     # Install a snap with opengl and joystick plugs.
     # This gives us all of the usual snap-confine configuration, along with all


### PR DESCRIPTION
This commit disables:

* tests/main/interfaces-time-control: fails with `Failed to restart
systemd-timesyncd.service: Unit systemd-timesyncd.service is masked.`

* tests/main/snap-confine-undesired-mode-group: fails because other
tests leak, this is fixed in master

The interfaces-time-control is also broken in master we need to do something about it (but I can't anymore tonight)