### PR TITLE
tests: when restoring chrony do not restart systemd-timesyncd

### DIFF
--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -27,7 +27,6 @@ restore: |
     if [[ "$SPREAD_SYSTEM" == ubuntu-19.10-* ]] || [[ "$SPREAD_SYSTEM" == ubuntu-20.04-* ]]; then
         # bring it back
         apt install -y chrony
-        systemctl restart systemd-timesyncd.service
     fi
 
     # Restore the initial timeserver


### PR DESCRIPTION
There is no need to restart the service, on 20.04 it will get
removed so a restart will always fail.
