### PR TITLE
tests: port snap-session-agent-* to session-tool

### DIFF
--- a/tests/main/snap-session-agent-service-control/task.yaml
+++ b/tests/main/snap-session-agent-service-control/task.yaml
@@ -19,26 +19,21 @@ prepare: |
         touch agent-was-enabled
     fi
 
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-    start_user_session
-    # Wait for sockets.target to finish starting so the session agent
-    # socket is available.
-    as_user systemctl --user start sockets.target
-
     # ensure curl is available (needed for e.g. core18)
     if ! command -v curl; then
         snap install --devmode --edge test-snapd-curl
         snap alias test-snapd-curl.curl curl
     fi
 
-restore: |
-    snap remove --purge test-snapd-curl
+    session-tool -u test --prepare
+    # Wait for sockets.target to finish starting so the session agent
+    # socket is available.
+    # XXX: I strongly believe this is not required anymore.
+    session-tool -u test systemctl --user start sockets.target
 
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-    stop_user_session
-    purge_user_session_data
+restore: |
+    session-tool -u test --restore
+    snap remove --purge test-snapd-curl
 
     if [ -f agent-was-enabled ]; then
         systemctl --user --global disable snapd.session-agent.socket
@@ -46,12 +41,6 @@ restore: |
     rm -f /etc/systemd/user/snap.test-service.service
 
 execute: |
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-    systemctl_user() {
-        as_user systemctl --user "$@"
-    }
-
     echo "Create a user mode service"
     cat << \EOF > /etc/systemd/user/snap.test-service.service
     [Unit]
@@ -62,29 +51,25 @@ execute: |
     EOF
 
     echo "The session agent can reload the user mode systemd instance"
-    curl --unix-socket "${USER_RUNTIME_DIR}/snapd-session-agent.socket" \
+    curl --unix-socket /run/user/12345/snapd-session-agent.socket \
         -D- -X POST -H "Content-Type: application/json" \
         -d '{"action": "daemon-reload"}' \
         http://localhost/v1/service-control | MATCH "HTTP/1.1 200 OK"
 
     echo "The service is now visible but not active"
-    systemctl_user show --property=LoadState snap.test-service.service |
-        MATCH LoadState=loaded
-    systemctl_user show --property=ActiveState snap.test-service.service |
-        MATCH ActiveState=inactive
+    session-tool -u test systemctl --user show --property=LoadState snap.test-service.service | MATCH LoadState=loaded
+    session-tool -u test systemctl --user show --property=ActiveState snap.test-service.service | MATCH ActiveState=inactive
 
     echo "The session agent can start user mode services"
-    curl --unix-socket "${USER_RUNTIME_DIR}/snapd-session-agent.socket" \
+    curl --unix-socket /run/user/12345/snapd-session-agent.socket \
         -D- -X POST -H "Content-Type: application/json" \
         -d '{"action": "start", "services": ["snap.test-service.service"]}' \
         http://localhost/v1/service-control | MATCH "HTTP/1.1 200 OK"
-    systemctl_user show --property=ActiveState snap.test-service.service |
-        MATCH ActiveState=active
+    session-tool -u test systemctl --user show --property=ActiveState snap.test-service.service | MATCH ActiveState=active
 
     echo "The session agent can stop user mode services"
-    curl --unix-socket "${USER_RUNTIME_DIR}/snapd-session-agent.socket" \
+    curl --unix-socket /run/user/12345/snapd-session-agent.socket \
         -D- -X POST -H "Content-Type: application/json" \
         -d '{"action": "stop", "services": ["snap.test-service.service"]}' \
         http://localhost/v1/service-control | MATCH "HTTP/1.1 200 OK"
-    systemctl_user show --property=ActiveState snap.test-service.service |
-        MATCH ActiveState=inactive
+    session-tool -u test systemctl --user show --property=ActiveState snap.test-service.service | MATCH ActiveState=inactive

--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -19,26 +19,20 @@ prepare: |
         touch agent-was-enabled
     fi
 
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-    start_user_session
-    # Wait for sockets.target to finish starting so the session agent
-    # socket is available.
-    as_user systemctl --user start sockets.target
-
     # ensure curl is available (needed for e.g. core18)
     if ! command -v curl; then
         snap install --devmode --edge test-snapd-curl
         snap alias test-snapd-curl.curl curl
     fi
 
-restore: |
-    snap remove test-snapd-curl
+    session-tool -u test --prepare
+    # Wait for sockets.target to finish starting so the session agent
+    # socket is available.
+    session-tool -u test systemctl --user start sockets.target
 
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-    stop_user_session
-    purge_user_session_data
+restore: |
+    session-tool -u test --restore
+    snap remove test-snapd-curl
 
     if [ -f agent-was-enabled ]; then
         systemctl --user --global disable snapd.session-agent.socket
@@ -46,37 +40,27 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-    systemctl_user() {
-        as_user systemctl --user "$@"
-    }
-
     echo "Initially snap session-agent is not running"
-    if systemctl_user is-active snapd.session-agent.service; then
-        exit 1
-    fi
+    not session-tool -u test systemctl --user is-active snapd.session-agent.service
 
     echo "However its REST API socket exists"
-    test -S "${USER_RUNTIME_DIR}/snapd-session-agent.socket"
+    test -S /run/user/12345/snapd-session-agent.socket
 
     echo "We can issue queries to the socket as root"
-    curl --unix-socket "${USER_RUNTIME_DIR}/snapd-session-agent.socket" \
+    curl --unix-socket /run/user/12345/snapd-session-agent.socket \
         -D- http://localhost/v1/session-info | MATCH "HTTP/1.1 200 OK"
 
     echo "Now snap session-agent is running"
-    systemctl_user is-active snapd.session-agent.service
+    session-tool -u test systemctl --user is-active snapd.session-agent.service
 
     echo "If we stop session-agent, it can be restarted via socket activation"
-    systemctl_user stop snapd.session-agent.service
-    if systemctl_user is-active snapd.session-agent.service; then
-        exit 1
-    fi
+    session-tool -u test systemctl --user stop snapd.session-agent.service
+    not session-tool -u test systemctl --user is-active snapd.session-agent.service
 
-    curl --unix-socket "${USER_RUNTIME_DIR}/snapd-session-agent.socket" \
+    curl --unix-socket /run/user/12345/snapd-session-agent.socket \
         -D- http://localhost/v1/session-info | MATCH "HTTP/1.1 200 OK"
-    systemctl_user is-active snapd.session-agent.service
+    session-tool -u test systemctl --user is-active snapd.session-agent.service
 
     echo "The user running the session agent can also communicate with it"
-    su -l -c "curl --unix-socket \"${USER_RUNTIME_DIR}/snapd-session-agent.socket\" \
-        -D- http://localhost/v1/session-info" test | MATCH "HTTP/1.1 200 OK"
+    session-tool -u test curl --unix-socket /run/user/12345/snapd-session-agent.socket \
+        -D- http://localhost/v1/session-info | MATCH "HTTP/1.1 200 OK"

--- a/tests/main/snap-session-agent-unavailable-to-snaps/task.yaml
+++ b/tests/main/snap-session-agent-unavailable-to-snaps/task.yaml
@@ -17,44 +17,36 @@ prepare: |
         touch agent-was-enabled
     fi
 
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-    start_user_session
+    echo "Install the curl snap as a confined example client"
+    snap install --edge test-snapd-curl
+
+    session-tool -u test --prepare
     # Wait for sockets.target to finish starting so the session agent
     # socket is available.
-    as_user systemctl --user start sockets.target
+    session-tool -u test systemctl --user start sockets.target
 
 restore: |
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-    stop_user_session
-    purge_user_session_data
-
+    session-tool -u test --restore
+    snap remove test-snapd-curl
     if [ -f agent-was-enabled ]; then
         systemctl --user --global disable snapd.session-agent.socket
         rm agent-was-enabled
     fi
 
 execute: |
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-
     if [ "$(snap debug confinement)" != strict ]; then
         exit 0
     fi
 
-    echo "Install the curl snap as a confined example client"
-    snap install --edge test-snapd-curl
-
     echo "The snap session agent REST API socket exists"
-    test -S "${USER_RUNTIME_DIR}/snapd-session-agent.socket"
+    test -S "/run/user/12345/snapd-session-agent.socket"
 
     echo "But confined applications can not access it"
-    not su -l -c "test-snapd-curl.curl \
-        --unix-socket \"${USER_RUNTIME_DIR}/snapd-session-agent.socket\" \
-        -D- http://localhost/v1/session-info" test
+    not session-tool -u test test-snapd-curl.curl \
+        --unix-socket /run/user/12345/snapd-session-agent.socket \
+        -D- http://localhost/v1/session-info
 
     echo "Confined apps running as root also can not access it"
     not test-snapd-curl.curl \
-        --unix-socket "${USER_RUNTIME_DIR}/snapd-session-agent.socket" \
+        --unix-socket /run/user/12345/snapd-session-agent.socket \
         -D- http://localhost/v1/session-info


### PR DESCRIPTION
We've seen leftover user sessions, presumably from the use of user.sh
exercised by those test, affect and break other tests. With the maturing
process of session tool, port the three session-agent tests to use
session-tool.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
