### PR TITLE
tests: fix racy pulseaudio tests (2.44)

### DIFF
--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -9,6 +9,14 @@ environment:
     EXFAIL: "ubuntu-1[468]"
 
 prepare: |
+    # FIXME: This test is broken and should be ported to session-tool, systemd
+    # --user starts pulseaudio for us so we are always racing with it (whoever
+    # acquires the socket file wins).
+    #
+    # To prevent this from breaking this test mask pulseaudio.{socket,service}
+    # in all user sessions.
+    systemctl --user --global mask pulseaudio.{socket,service}
+
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh
     snap install --edge test-snapd-audio-record
@@ -36,6 +44,7 @@ restore: |
         rm -rf /home/test/.config
         mv /home/test/.config.spread /home/test/.config
     fi
+    systemctl --user --global unmask pulseaudio.{socket,service}
 
 execute: |
     # we need -p so that XDG_RUNTIME_DIR is honored, but that preserves HOME,

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -10,6 +10,14 @@ environment:
     PA_TEST_LOG: /home/test/pulseaudio.log
 
 prepare: |
+    # FIXME: This test is broken and should be ported to session-tool, systemd
+    # --user starts pulseaudio for us so we are always racing with it (whoever
+    # acquires the socket file wins).
+    #
+    # To prevent this from breaking this test mask pulseaudio.{socket,service}
+    # in all user sessions.
+    systemctl --user --global mask pulseaudio.{socket,service}
+
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh
     snap install --edge test-snapd-pulseaudio
@@ -56,6 +64,8 @@ restore: |
     rm -f /home/test/pulse-test.pa
     rm -f /run/user/12345/pulse/native
     rm -f $PA_TEST_LOG
+
+    systemctl --user --global unmask pulseaudio.{socket,service}
 
 debug: |
     if [ -f $PA_TEST_LOG ]; then


### PR DESCRIPTION
Both tests start pulseaudo manually inside a user session created by the
virtue of using "su -l". Inside the same session, PAM starts systemd
--user which starts pulseaudio.{socket,service}.

In the case that systemd acquires pulseaudio.socket and then starts to
start pulseaudio.service (ironically because pulseaudio connects to that
socket on startup), it will fail in the following way:

	Apr 10 14:15:45 apr101317-837037 systemd[21320]: Starting Sound Service...
	Apr 10 14:15:46 apr101317-837037 pulseaudio[21345]: E: [pulseaudio] pid.c: Daemon already running.
	Apr 10 14:15:46 apr101317-837037 pulseaudio[21345]: E: [pulseaudio] main.c: pa_pid_file_create() failed.
	Apr 10 14:15:46 apr101317-837037 systemd[21320]: pulseaudio.service: Main process exited, code=exited, status=1/FAILURE
	Apr 10 14:15:46 apr101317-837037 systemd[21320]: pulseaudio.service: Failed with result 'exit-code'.
	Apr 10 14:15:46 apr101317-837037 systemd[21320]: Failed to start Sound Service.
	Apr 10 14:15:46 apr101317-837037 systemd[21320]: pulseaudio.service: Service RestartSec=100ms expired, scheduling restart.
	Apr 10 14:15:46 apr101317-837037 systemd[21320]: pulseaudio.service: Scheduled restart job, restart counter is at 2.
	Apr 10 14:15:46 apr101317-837037 systemd[21320]: Stopped Sound Service.

This can be also seen as the status of failed units in the user systemd:

	  UNIT               LOAD   ACTIVE SUB    DESCRIPTION
	● pulseaudio.service loaded failed failed Sound Service
	● pulseaudio.socket  loaded failed failed Sound System

Strace of the pulseaudio started by the test, explicitly shows:

	socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0) = 14
	fcntl(14, F_GETFD)                = 0x1 (flags FD_CLOEXEC)
	connect(14, {sa_family=AF_UNIX, sun_path="/run/user/12345/pulse/native"}, 110) = 0
	close(14)                         = 0
	socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0) = 14
	fcntl(14, F_GETFD)                = 0x1 (flags FD_CLOEXEC)
	setsockopt(14, SOL_SOCKET, SO_PRIORITY, [6], 4) = 0
	bind(14, {sa_family=AF_UNIX, sun_path="/run/user/12345/pulse/native"}, 30) = -1 EADDRINUSE (Address already in use)

As one can see, we connect to the pulse socket, this triggers socket
activation of the pulseaudio.service, from the socket earlier acquired
by systemd.

After masking both units pulseaudio explicitly started by the test works normally:

	socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0) = 14
	fcntl(14, F_GETFD)                = 0x1 (flags FD_CLOEXEC)
	connect(14, {sa_family=AF_UNIX, sun_path="/run/user/12345/pulse/native"}, 110) = -1 ECONNREFUSED (Connection refused)
	close(14)                         = 0
	unlink("/run/user/12345/pulse/native") = 0
	socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0) = 14
	fcntl(14, F_GETFD)                = 0x1 (flags FD_CLOEXEC)
	setsockopt(14, SOL_SOCKET, SO_PRIORITY, [6], 4) = 0
	bind(14, {sa_family=AF_UNIX, sun_path="/run/user/12345/pulse/native"}, 30) = 0

IMO in the long term all user.sh code should be removed and replaced by
the use of session-tool, which not only more accurately represents real
session interaction but is less error prone to use correctly.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>