### PR TITLE
cmd/snap-update-ns: handle EBUSY when unlinking files

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -447,7 +447,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 				//
 				// In an ideal world we would model this better and could do
 				// without this edge case.
-				if kind == "" && err == syscall.EBUSY {
+				if (kind == "" || kind == "file") && err == syscall.EBUSY {
 					logger.Debugf("cannot remove busy mount point %q", path)
 					return nil
 				}

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -49,6 +49,8 @@ var _ = Suite(&changeSuite{})
 
 func (s *changeSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	// This isolates us from host's experimental settings.
+	dirs.SetRootDir(c.MkDir())
 	// Mock and record system interactions.
 	s.sys = &testutil.SyscallRecorder{}
 	s.BaseTest.AddCleanup(update.MockSystemCalls(s.sys))
@@ -58,6 +60,7 @@ func (s *changeSuite) SetUpTest(c *C) {
 func (s *changeSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 	s.sys.CheckForStrayDescriptors(c)
+	dirs.SetRootDir("")
 }
 
 func (s *changeSuite) disableRobustMountNamespaceUpdates(c *C) {


### PR DESCRIPTION
The idea behind robust mount namespace updates is to reduce the
complexity by changing the problem of updating an exiting mount
namespace to the problem of tearing down any namespace and constructing
any desired namespace, which is arguably easier.

As we developed that logic we ran into an issue where snap-update-ns
would fail where there was one layout "shadowing" another, for example
/usr /usr/foo. If you tried to remove /usr/foo you would not be able to
because /usr was still an active mount point. We handled that EBUSY
error and all was good.

The problem is that we made that correction specific to bind mounts of
directories. The snap layout system also supports file bind mounts where
the empty placeholder we remove is a file, not a directory.  This patch
extends that correction to file bind mounts as the have the exact same
limitations. If /usr/foo from the example above were a file, not a
directory, we would still try to remove it and we would still have
failed the exact same way.

This fixes microk8s as a strictly confined snap.

Fixes: https://bugs.launchpad.net/snapd/+bug/1871189
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>