### PR TITLE
tests: rewrite timeserver-control test

### DIFF
--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -4,74 +4,80 @@ details: |
     This test makes sure that a snap using the timeserver-control interface
     can access timeserver information and update it.
 
-# Debian sid is skipped because "timedatectl set-ntp" fails with the error:
-# "Failed to set ntp: Message recipient disconnected from message bus without replying"
-# A workaround is to make "systemctl enable --now systemd-timesyncd.service" instead
-systems: [-debian-sid-*]
-
 prepare: |
-    # shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
+    truncate --size=0 defer.sh
+    chmod +x defer.sh
+
+    # This test requires busctl but on 14.04 we don't have one.
+    # Let's pick the one from the core snap in such case.
+    if [ -z "$(command -v busctl 2>/dev/null)" ]; then
+        ln -s /snap/core/current/usr/bin/busctl /usr/local/bin/busctl
+        hash -r
+        echo "rm -f /usr/local/bin/busctl" >> defer.sh
+    fi
+
+    # Technically the interface may be implemented by many things but in
+    # practice systemd implementation has a working SetNTP while others do not.
+    # On such systems, install systemd-timesyncd to get the implementation we
+    # can test. On other systems remember the current setting of the NTP
+    # property and restore it later.
+    case "$SPREAD_SYSTEM" in
+        debian-sid-*)
+            apt-get remove -y ntp
+            echo 'apt-get install -y ntp' >> defer.sh
+            ;;
+        ubuntu-19.10-*)
+            apt-get remove -y chrony
+            echo 'apt-get install -y chrony' >> defer.sh
+            ;;
+        *)
+            case "$(busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP)" in
+                "b true")
+                    echo "busctl call org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 SetNTP bb true false" >> defer.sh
+                    ;;
+                "b false")
+                    echo "busctl call org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 SetNTP bb false false" >> defer.sh
+                    ;;
+                *)
+                    echo "Unexpected value of NTP property"
+                    exit 1
+                    ;;
+            esac
+            ;;
+    esac
 
     # Install a snap declaring a plug on timeserver-control
+    # shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local test-snapd-timedate-control-consumer
-
-    if [[ "$SPREAD_SYSTEM" == ubuntu-19.10-* ]] || [[ "$SPREAD_SYSTEM" == ubuntu-20.04-* ]]; then
-        # ensure chrony is not installed as it interferes with
-        # the systemd-timesyncd.service
-        apt remove -y chrony
-        systemctl restart systemd-timesyncd.service
-    fi
+    echo "snap remove --purge test-snapd-timedate-control-consumer" >> defer.sh
 
 restore: |
-    if [[ "$SPREAD_SYSTEM" == ubuntu-19.10-* ]] || [[ "$SPREAD_SYSTEM" == ubuntu-20.04-* ]]; then
-        # bring it back
-        apt install -y chrony
-        systemctl restart systemd-timesyncd.service
-    fi
-
-    # Restore the initial timeserver
-    if [ -s timeserver.txt ]; then
-        timedatectl set-ntp "$(cat timeserver.txt)"
-    fi
+    # Restore system to the previous state by running deferred commands in
+    # reverse order.
+    tac defer.sh > refed.sh
+    sh -xe refed.sh && rm -f {defer,refed}.sh
 
 execute: |
+    # If we cannot use network time protocol then the test is meaningless.
+    if [ "$(busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 CanNTP)" != "b true" ]; then
+        echo "This system cannot use NTP, test precondition failed"
+        exit 1
+    fi
+
     echo "The interface is disconnected by default"
     snap interfaces -i timeserver-control | MATCH -- '- +test-snapd-timedate-control-consumer:timeserver-control'
 
     echo "When the interface is connected"
     snap connect test-snapd-timedate-control-consumer:timeserver-control
 
-    # Save the default timeserver to be restored at the end
-    test-snapd-timedate-control-consumer.timedatectl-timeserver status | grep -oP '(Network time on|systemd-timesyncd.service active): \K(.*)' > timeserver.txt
-
-    get_ntp_status() {
-        test-snapd-timedate-control-consumer.timedatectl-timeserver status | \
-            grep -oP '(Network time on|System clock synchronized): \K(.*)'
-    }
-
-    # NOTE: with systemd >= 239, switching the ntp setting it takes a while for
-    # it to become visible
-
-    # Set the ntp value and check the status
-    test-snapd-timedate-control-consumer.timedatectl-timeserver set-ntp yes
-    for _ in $(seq 10); do
-        if [ "$(get_ntp_status)" = "yes" ] ; then
-            break
-        fi
-        sleep 1
+    # Set NTP and check that the setting was propagated.
+    for value in true false true; do
+        test-snapd-timedate-control-consumer.timedatectl-timeserver set-ntp "$value"
+        # Starting or stopping NTP takes non-zero time so give it some time to take effect.
+        # shellcheck disable=SC2016
+        retry-tool --wait 5 sh -c 'test "$(busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP)" = "b '"$value"'"'
     done
-    [ "$(get_ntp_status)" = "yes" ]
-
-    # Set the ntp value and check the status
-    test-snapd-timedate-control-consumer.timedatectl-timeserver set-ntp no
-    for _ in $(seq 10); do
-        if [ "$(get_ntp_status)" = "no" ]; then
-            break
-        fi
-        sleep 1
-    done
-    [ "$(get_ntp_status)" = "no" ]
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0


### PR DESCRIPTION
The test was somewhat flaky and was constantly failing on master.
There are several changes here:

1) The test now handles changing to systemd-timesyncd from either ntp
(on Debian) or from chrony (on Ubuntu 19.10 only). This also enables the
test on work and pass on Debian.

2) The means of querying timesyncd was changed to busctl. This abstracts
away the problem of what the current provider is (those vary across
Ubuntu 14.04 to 20.04) and what specific version of timedatectl can do.

3) The test no longer measures NTPSynchronized, instead it measures NTP,
the actual setting we allow to set via the timeserver-control interface.
This also detaches the test from the racy process of establishing NTP
synchronization which we don't care about.

4) The restore logic now follows the defer-like style to avoid repeating
conditionals and being somewhat easier to follow.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
