### PR TITLE
tests: ignore user@12345.service hierarchy

### DIFF
--- a/tests/main/snap-confine-undesired-mode-group/task.yaml
+++ b/tests/main/snap-confine-undesired-mode-group/task.yaml
@@ -17,8 +17,9 @@ execute: |
     # snap-confine (which includes snap-update-ns and snap-discard-ns) ran as
     # the group of the calling user and did not manage that properly.
     for dname in /run/snapd /sys/fs/cgroup /tmp/snap.*; do
-        find "$dname" -user test >> wrong-user.txt
-        find "$dname" -group test >> wrong-group.txt
+        # Filter out cgroups that are expected to be owned by the test user.
+        find "$dname" -user test ! -path '*/user@12345.service/*' >> wrong-user.txt
+        find "$dname" -group test ! -path '*/user@12345.service/*' >> wrong-group.txt
         # Filter out the following elements:
         # - sockets, we don't create any and there are some that are 777
         # - symbolic links, those are always 777


### PR DESCRIPTION
A test that looks for files made by snap-confine or the tools it invokes
sometimes reports false positives when a set of cgroup hierarchies
related to the test user session is still around. Filter those out.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
