### PR TITLE
github: partition the github action workflows

### DIFF
--- a/.github/workflows/test-go-latest.yaml
+++ b/.github/workflows/test-go-latest.yaml
@@ -1,0 +1,108 @@
+name: Tests go-latest
+on:
+  pull_request:
+    branches: [ "master", "release/**" ]
+jobs:
+  unit-tests-go-latest:
+    runs-on: ubuntu-18.04
+    env:
+      GOPATH: ${{ github.workspace }}
+      GO111MODULE: off
+      # Set PATH to ignore the load of magic binaries from /usr/local/bin And
+      # to use the go snap automatically. Note that we install go from the
+      # snap in a step below. Without this we get the GitHub-controlled latest
+      # version of go.
+      PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
+      GOROOT: ""
+      # skip format checks on 1.13+
+      SKIP_GOFMT: 1
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        # NOTE: checkout the code in a fixed location, even for forks, as this
+        # is relevant for go's import system.
+        path: ./src/github.com/snapcore/snapd
+    - name: Make /var/cache/apt owned by current user
+      run: sudo chown -R $(id -u) /var/cache/apt
+    - name: Cache Debian dependencies
+      id: cache-deb-downloads
+      uses: actions/cache@v1
+      with:
+        path: /var/cache/apt
+        key: var-cache-apt-{{ hashFiles('**/debian/control') }}
+    - name: Run "apt update"
+      run: |
+          sudo apt update
+    - name: Download Debian dependencies
+      if: steps.cache-deb-downloads.outputs.cache-hit != 'true'
+      run: |
+          sudo apt clean
+          sudo apt build-dep -d -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+    # Work around caching files owned by root https://github.com/actions/cache/issues/133
+    - name: Install Debian dependencies
+      run: sudo apt build-dep -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+    # golang latest ensures things work on the edge
+    - name: Install the go snap
+      run: |
+          sudo snap install --classic --channel=latest/edge go
+    - name: Install ShellCheck as a snap
+      run: |
+          sudo apt-get remove --purge shellcheck
+          sudo snap install shellcheck
+    - name: Make /var/cache/apt owned by current user
+      run: sudo chown -R $(id -u) /var/cache/apt
+    - name: Install govendor
+      run: go get -u github.com/kardianos/govendor
+    - name: Cache Go dependencies
+      id: cache-go-govendor
+      uses: actions/cache@v1
+      with:
+        path: ${{ github.workspace }}/.cache/govendor
+        key: go-govendor-{{ hashFiles('**/vendor.json') }}
+    - name: Get Go dependencies
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ${{ github.workspace }}/bin/govendor sync
+    - name: Run static checks
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --static
+    - name: Build C
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/
+          ./autogen.sh
+          make -j2
+    - name: Build Go
+      run: go build github.com/snapcore/snapd/...
+    - name: Test C
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/ && make check
+    - name: Test Go
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --unit
+
+  spread-unstable:
+    needs: [unit-tests-go-latest]
+    runs-on: self-hosted
+    strategy:
+      # FIXME: enable fail-fast mode once spread can cancel an executing job.
+      fail-fast: false
+      matrix:
+        system:
+        - centos-8-64
+        - opensuse-15.1-64
+        - opensuse-tumbleweed-64
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run spread tests
+      env:
+          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
+      if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
+      run: |
+          # Register a problem matcher to highlight spread failures
+          echo "::add-matcher::.github/spread-problem-matcher.json"
+          spread -abend google-unstable:${{ matrix.system }}:tests/...
+    - name: Discard spread workers
+      if: always()
+      run: |
+        shopt -s nullglob;
+        for r in .spread-reuse.*.yaml; do
+          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+        done

--- a/.github/workflows/test-go1.10.yaml
+++ b/.github/workflows/test-go1.10.yaml
@@ -1,0 +1,115 @@
+name: Tests go1.10
+on:
+  pull_request:
+    branches: [ "master", "release/**" ]
+jobs:
+  unit-tests-1_10:
+    runs-on: ubuntu-16.04
+    env:
+      GOPATH: ${{ github.workspace }}
+      GO111MODULE: off
+      # Set PATH to ignore the load of magic binaries from /usr/local/bin And
+      # to use the go snap automatically. Note that we install go from the
+      # snap in a step below. Without this we get the GitHub-controlled latest
+      # version of go.
+      PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
+      GOROOT: ""
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        # NOTE: checkout the code in a fixed location, even for forks, as this
+        # is relevant for go's import system.
+        path: ./src/github.com/snapcore/snapd
+    - name: Make /var/cache/apt owned by current user
+      run: sudo chown -R $(id -u) /var/cache/apt
+    - name: Cache Debian dependencies
+      id: cache-deb-downloads
+      uses: actions/cache@v1
+      with:
+        path: /var/cache/apt
+        key: var-cache-apt-{{ hashFiles('**/debian/control') }}
+    - name: Run "apt update"
+      run: |
+          sudo apt update
+    - name: Download Debian dependencies
+      if: steps.cache-deb-downloads.outputs.cache-hit != 'true'
+      run: |
+          sudo apt clean
+          sudo apt build-dep -d -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+    # Work around caching files owned by root https://github.com/actions/cache/issues/133
+    - name: Install Debian dependencies
+      run: sudo apt build-dep -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+    # golang 1.10 is used on 14.04/16.04/18.04
+    - name: Install the go snap
+      run: |
+          sudo snap install --classic --channel=1.10 go
+    - name: Install ShellCheck as a snap
+      run: |
+          sudo apt-get remove --purge shellcheck
+          sudo snap install shellcheck
+    - name: Make /var/cache/apt owned by current user
+      run: sudo chown -R $(id -u) /var/cache/apt
+    - name: Install govendor
+      run: go get -u github.com/kardianos/govendor
+    - name: Cache Go dependencies
+      id: cache-go-govendor
+      uses: actions/cache@v1
+      with:
+        path: ${{ github.workspace }}/.cache/govendor
+        key: go-govendor-{{ hashFiles('**/vendor.json') }}
+    - name: Get Go dependencies
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ${{ github.workspace }}/bin/govendor sync
+    - name: Run static checks
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --static
+    - name: Build C
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/
+          ./autogen.sh
+          make -j2
+    - name: Build Go
+      run: go build github.com/snapcore/snapd/...
+    - name: Test C
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/ && make check
+    - name: Test Go
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --unit
+
+  spread:
+    needs: [unit-tests-1_10]
+    runs-on: self-hosted
+    strategy:
+      # FIXME: enable fail-fast mode once spread can cancel an executing job.
+      #
+      # Disable fail-fast mode as it doesn't function with spread. It seems
+      # that cancelling tasks requires short, interruptible actions and
+      # interrupting spread, notably, does not work today. As such disable
+      # fail-fast while we tackle that problem upstream.
+      fail-fast: false
+      matrix:
+        system:
+        - ubuntu-14.04-64
+        - ubuntu-18.04-64
+        - ubuntu-core-18-64
+        - debian-9-64
+        - arch-linux-64
+        - amazon-linux-2-64
+        - centos-7-64
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run spread tests
+      env:
+          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
+      if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
+      run: |
+          # Register a problem matcher to highlight spread failures
+          echo "::add-matcher::.github/spread-problem-matcher.json"
+          spread google:${{ matrix.system }}:tests/...
+    - name: Discard spread workers
+      if: always()
+      run: |
+        shopt -s nullglob;
+        for r in .spread-reuse.*.yaml; do
+          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+        done

--- a/.github/workflows/test-go1.13.yaml
+++ b/.github/workflows/test-go1.13.yaml
@@ -1,19 +1,21 @@
-name: Tests
+name: Tests go1.13
 on:
   pull_request:
     branches: [ "master", "release/**" ]
 jobs:
-  unit-tests:
-    runs-on: ubuntu-16.04
+  unit-tests-1_13:
+    runs-on: ubuntu-18.04
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: off
       # Set PATH to ignore the load of magic binaries from /usr/local/bin And
-      # to use the go-1.10 automatically. Note that we install go 1.10 from the
-      # archive in a step below. Without this we get the GitHub-controlled latest
+      # to use the go snap automatically. Note that we install go from the
+      # snap in a step below. Without this we get the GitHub-controlled latest
       # version of go.
-      PATH: /usr/lib/go-1.10/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/snap/bin
+      PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
       GOROOT: ""
+      # skip format checks on 1.13+
+      SKIP_GOFMT: 1
 
     steps:
     - name: Checkout code
@@ -30,15 +32,21 @@ jobs:
       with:
         path: /var/cache/apt
         key: var-cache-apt-{{ hashFiles('**/debian/control') }}
+    - name: Run "apt update"
+      run: |
+          sudo apt update
     - name: Download Debian dependencies
       if: steps.cache-deb-downloads.outputs.cache-hit != 'true'
       run: |
           sudo apt clean
-          sudo apt update
           sudo apt build-dep -d -y ${{ github.workspace }}/src/github.com/snapcore/snapd
     # Work around caching files owned by root https://github.com/actions/cache/issues/133
     - name: Install Debian dependencies
       run: sudo apt build-dep -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+    # golang 1.13 is used on 20.04
+    - name: Install the go snap
+      run: |
+          sudo snap install --classic --channel=1.13 go
     - name: Install ShellCheck as a snap
       run: |
           sudo apt-get remove --purge shellcheck
@@ -69,36 +77,8 @@ jobs:
     - name: Test Go
       run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --unit
 
-  spread-canary:
-    needs: unit-tests
-    runs-on: self-hosted
-    strategy:
-      fail-fast: false
-      matrix:
-        system:
-        - ubuntu-16.04-64
-        - ubuntu-16.04-32
-        - ubuntu-core-16-64
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Run spread tests
-      env:
-          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-      if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
-      run: |
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
-          spread -abend google:${{ matrix.system }}:tests/...
-    - name: Discard spread workers
-      if: always()
-      run: |
-        shopt -s nullglob;
-        for r in .spread-reuse.*.yaml; do
-          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
-        done
-  spread-stable:
-    needs: [unit-tests, spread-canary]
+  spread:
+    needs: [unit-tests-1_13]
     runs-on: self-hosted
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
@@ -110,19 +90,12 @@ jobs:
       fail-fast: false
       matrix:
         system:
-        - ubuntu-14.04-64
-        - ubuntu-18.04-64
         - ubuntu-19.10-64
         - ubuntu-20.04-64
-        - ubuntu-core-18-64
         - ubuntu-core-20-64
-        - debian-9-64
         - debian-sid-64
         - fedora-30-64
         - fedora-31-64
-        - arch-linux-64
-        - amazon-linux-2-64
-        - centos-7-64
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -134,35 +107,6 @@ jobs:
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"
           spread google:${{ matrix.system }}:tests/...
-    - name: Discard spread workers
-      if: always()
-      run: |
-        shopt -s nullglob;
-        for r in .spread-reuse.*.yaml; do
-          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
-        done
-  spread-unstable:
-    needs: [unit-tests, spread-stable]
-    runs-on: self-hosted
-    strategy:
-      # FIXME: enable fail-fast mode once spread can cancel an executing job.
-      fail-fast: false
-      matrix:
-        system:
-        - centos-8-64
-        - opensuse-15.1-64
-        - opensuse-tumbleweed-64
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Run spread tests
-      env:
-          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-      if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
-      run: |
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
-          spread -abend google-unstable:${{ matrix.system }}:tests/...
     - name: Discard spread workers
       if: always()
       run: |

--- a/.github/workflows/test-go1.9.yaml
+++ b/.github/workflows/test-go1.9.yaml
@@ -1,0 +1,105 @@
+name: Tests go1.9
+on:
+  pull_request:
+    branches: [ "master", "release/**" ]
+jobs:
+  unit-tests-1_9:
+    runs-on: ubuntu-16.04
+    env:
+      GOPATH: ${{ github.workspace }}
+      GO111MODULE: off
+      # Set PATH to ignore the load of magic binaries from /usr/local/bin And
+      # to use the go snap automatically. Note that we install go from the
+      # snap in a step below. Without this we get the GitHub-controlled latest
+      # version of go.
+      PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
+      GOROOT: ""
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        # NOTE: checkout the code in a fixed location, even for forks, as this
+        # is relevant for go's import system.
+        path: ./src/github.com/snapcore/snapd
+    - name: Make /var/cache/apt owned by current user
+      run: sudo chown -R $(id -u) /var/cache/apt
+    - name: Cache Debian dependencies
+      id: cache-deb-downloads
+      uses: actions/cache@v1
+      with:
+        path: /var/cache/apt
+        key: var-cache-apt-{{ hashFiles('**/debian/control') }}
+    - name: Run "apt update"
+      run: |
+          sudo apt update
+    - name: Download Debian dependencies
+      if: steps.cache-deb-downloads.outputs.cache-hit != 'true'
+      run: |
+          sudo apt clean
+          sudo apt build-dep -d -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+    # Work around caching files owned by root https://github.com/actions/cache/issues/133
+    - name: Install Debian dependencies
+      run: sudo apt build-dep -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+    # golang 1.9 is used on centos-7 so we need to support it
+    - name: Install the go snap
+      run: |
+          sudo snap install --classic --channel=1.9 go
+    - name: Install ShellCheck as a snap
+      run: |
+          sudo apt-get remove --purge shellcheck
+          sudo snap install shellcheck
+    - name: Make /var/cache/apt owned by current user
+      run: sudo chown -R $(id -u) /var/cache/apt
+    - name: Install govendor
+      run: go get -u github.com/kardianos/govendor
+    - name: Cache Go dependencies
+      id: cache-go-govendor
+      uses: actions/cache@v1
+      with:
+        path: ${{ github.workspace }}/.cache/govendor
+        key: go-govendor-{{ hashFiles('**/vendor.json') }}
+    - name: Get Go dependencies
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ${{ github.workspace }}/bin/govendor sync
+    - name: Run static checks
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --static
+    - name: Build C
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/
+          ./autogen.sh
+          make -j2
+    - name: Build Go
+      run: go build github.com/snapcore/snapd/...
+    - name: Test C
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/ && make check
+    - name: Test Go
+      run: cd ${{ github.workspace }}/src/github.com/snapcore/snapd && ./run-checks --unit
+
+  spread:
+    needs: [ unit-tests-1_9 ]
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        system:
+        - ubuntu-16.04-64
+        - ubuntu-16.04-32
+        - ubuntu-core-16-64
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run spread tests
+      env:
+          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
+      if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
+      run: |
+          # Register a problem matcher to highlight spread failures
+          echo "::add-matcher::.github/spread-problem-matcher.json"
+          spread -abend google:${{ matrix.system }}:tests/...
+    - name: Discard spread workers
+      if: always()
+      run: |
+        shopt -s nullglob;
+        for r in .spread-reuse.*.yaml; do
+          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+        done

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,6 @@ git:
 matrix:
   include:
     - stage: quick
-      name: go master/xenial static and unit test suites
-      dist: xenial
-      go: "master"
-      before_install:
-        - sudo apt --quiet -o Dpkg::Progress-Fancy=false update
-      install:
-        - sudo apt --quiet -o Dpkg::Progress-Fancy=false build-dep snapd
-        - ./get-deps.sh
-      script:
-        - set -e
-        - SKIP_GOFMT=1 ./run-checks --static
-        - ./run-checks --short-unit
-    - stage: quick
       go: "1.10.x"
       name: OSX build and minimal runtime sanity check
       os: osx

--- a/run-checks
+++ b/run-checks
@@ -16,8 +16,8 @@ else
 fi
 COVERMODE=${COVERMODE:-atomic}
 
-if [ -z "${TRAVIS_BUILD_ID:-}" ]; then
-    # when *not* running inside travis, ensure we use go-1.10 by default
+if [ -z "${TRAVIS_BUILD_ID:-}" ] && [ -z "${GITHUB_WORKFLOW:-}" ]; then
+    # when *not* running inside travis/gh, ensure we use go-1.10 by default
     export PATH=/usr/lib/go-1.10/bin:${PATH}
 fi
 
@@ -283,6 +283,10 @@ fi
 
 if [ "$UNIT" = 1 ]; then
     ./get-deps.sh
+
+    echo "Show go version"
+    command -v go
+    go version
 
     echo Building
     go build -v github.com/snapcore/snapd/...


### PR DESCRIPTION
This commit partitions the spread systems into multiple actions
that are each unit tested with a different go version. This
allows independent restarts.
