### PR TITLE
cmd/snap-bootstrap: no error when not input devices are found

### DIFF
--- a/cmd/snap-bootstrap/cmd_recovery_chooser_trigger.go
+++ b/cmd/snap-bootstrap/cmd_recovery_chooser_trigger.go
@@ -88,11 +88,16 @@ func (c *cmdRecoveryChooserTrigger) Execute(args []string) error {
 
 	err = triggerwatchWait(timeout)
 	if err != nil {
-		if err == triggerwatch.ErrTriggerNotDetected {
+		switch err {
+		case triggerwatch.ErrTriggerNotDetected:
 			logger.Noticef("trigger not detected")
 			return nil
+		case triggerwatch.ErrNoMatchingInputDevices:
+			logger.Noticef("no matching input devices")
+			return nil
+		default:
+			return err
 		}
-		return err
 	}
 
 	// got the trigger, try to create the marker file

--- a/cmd/snap-bootstrap/cmd_recovery_chooser_trigger_test.go
+++ b/cmd/snap-bootstrap/cmd_recovery_chooser_trigger_test.go
@@ -143,3 +143,23 @@ func (s *cmdSuite) TestRecoveryChooserTriggerBadDurationFallback(c *C) {
 	c.Check(n, Equals, 1)
 	c.Check(passedTimeout, Equals, main.DefaultTimeout)
 }
+
+func (s *cmdSuite) TestRecoveryChooserTriggerNoInputDevsNoError(c *C) {
+	n := 0
+	marker := filepath.Join(c.MkDir(), "marker")
+
+	restore := main.MockDefaultMarkerFile(marker)
+	defer restore()
+	restore = main.MockTriggerwatchWait(func(_ time.Duration) error {
+		n++
+		// no input devices
+		return triggerwatch.ErrNoMatchingInputDevices
+	})
+	defer restore()
+
+	_, err := main.Parser().ParseArgs([]string{"recovery-chooser-trigger"})
+	// does not trigger an error
+	c.Assert(err, IsNil)
+	c.Check(n, Equals, 1)
+	c.Check(marker, testutil.FileAbsent)
+}

--- a/cmd/snap-bootstrap/triggerwatch/triggerwatch.go
+++ b/cmd/snap-bootstrap/triggerwatch/triggerwatch.go
@@ -44,7 +44,8 @@ var (
 	// wait for '1' to be pressed
 	triggerFilter = triggerEventFilter{Key: "KEY_1"}
 
-	ErrTriggerNotDetected = errors.New("trigger not detected")
+	ErrTriggerNotDetected     = errors.New("trigger not detected")
+	ErrNoMatchingInputDevices = errors.New("no matching input devices")
 )
 
 // Wait waits for a trigger on the available trigger devices for a given amount
@@ -60,14 +61,12 @@ func Wait(timeout time.Duration) error {
 		return fmt.Errorf("cannot list trigger devices: %v", err)
 	}
 	if devices == nil {
-		return fmt.Errorf("cannot find matching devices")
+		return ErrNoMatchingInputDevices
 	}
 
 	logger.Noticef("waiting for trigger key: %v", triggerFilter.Key)
 
-	// wait for a couple of second for the key
 	detectKeyCh := make(chan keyEvent, len(devices))
-
 	for _, dev := range devices {
 		go dev.WaitForTrigger(detectKeyCh)
 		defer dev.Close()

--- a/cmd/snap-bootstrap/triggerwatch/triggerwatch_test.go
+++ b/cmd/snap-bootstrap/triggerwatch/triggerwatch_test.go
@@ -109,7 +109,7 @@ func (s *triggerwatchSuite) TestNoDevsWaitNoMatching(c *C) {
 	defer restore()
 
 	err := triggerwatch.Wait(testTriggerTimeout)
-	c.Assert(err, ErrorMatches, "cannot find matching devices")
+	c.Assert(err, Equals, triggerwatch.ErrNoMatchingInputDevices)
 }
 
 func (s *triggerwatchSuite) TestNoDevsWaitMatchingError(c *C) {

--- a/data/systemd/snapd.recovery-chooser-trigger.service.in
+++ b/data/systemd/snapd.recovery-chooser-trigger.service.in
@@ -3,6 +3,8 @@ Description=Wait for the Ubuntu Core chooser trigger
 Before=snapd.service
 # don't run on classic or uc16/uc18
 ConditionKernelCommandLine=snapd_recovery_mode
+# only run when there are input devices
+ConditionPathExistsGlob=/dev/input/event*
 
 [Service]
 # blocks the service startup until a trigger is detected or a timeout is hit


### PR DESCRIPTION
Do not error out when no matching input devices are present. Also, tweak the snapd.recovery-chooser-trigger.service to start only when there are input devices at `/dev/input/event*`.

Related: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1870212

cc @xnox 