### PR TITLE
cmd/snap: do not hide debug boot-vars on core

### DIFF
--- a/cmd/snap/cmd_debug_bootvars.go
+++ b/cmd/snap/cmd_debug_bootvars.go
@@ -20,9 +20,12 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/release"
 )
 
 type cmdBootvars struct{}
@@ -34,9 +37,14 @@ func init() {
 		func() flags.Commander {
 			return &cmdBootvars{}
 		}, nil, nil)
-	cmd.hidden = true
+	if release.OnClassic {
+		cmd.hidden = true
+	}
 }
 
 func (x *cmdBootvars) Execute(args []string) error {
+	if release.OnClassic {
+		return errors.New(`the "boot-vars" command is not available on classic systems`)
+	}
 	return boot.DumpBootVars(Stdout)
 }

--- a/cmd/snap/cmd_debug_bootvars_test.go
+++ b/cmd/snap/cmd_debug_bootvars_test.go
@@ -25,9 +25,12 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/release"
 )
 
 func (s *SnapSuite) TestDebugBootvars(c *check.C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	bloader.BootVars = map[string]string{
@@ -49,4 +52,11 @@ snap_kernel=pc-kernel_3.snap
 snap_try_kernel=pc-kernel_4.snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestDebugBootvarsNotOnClassic(c *check.C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "boot-vars"})
+	c.Assert(err, check.ErrorMatches, `the "boot-vars" command is not available on classic systems`)
 }


### PR DESCRIPTION
When working with a UC20 system, I noticed that boot-vars is not listed in debug
commands. Tweak the code to hide the command only on classic systems and return
an error if called in such environment.
