### PR TITLE
overlord: update tests to work with latest go

### DIFF
--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -259,5 +259,5 @@ func (s *watchdogSuite) TestFilesystemOnlyApplyValidationFails(c *C) {
 	})
 
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf), ErrorMatches, `cannot parse "foo": time: invalid duration foo`)
+	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf), ErrorMatches, `cannot parse "foo": time: invalid duration \"?foo\"?`)
 }

--- a/overlord/state/warning_test.go
+++ b/overlord/state/warning_test.go
@@ -117,8 +117,8 @@ func (stateSuite) TestUnmarshalErrors(c *check.C) {
 		// some bogus values
 		{`{"message": " ", "first-added": "2006-01-02T15:04:05Z", "expire-after": "1h", "repeat-after": "1h"}`, "malformed warning message"},
 		{`{"message": "x", "first-added": "2006",                 "expire-after": "1h", "repeat-after": "1h"}`, "parsing time .* cannot parse .*"},
-		{`{"message": "x", "first-added": "2006-01-02T15:04:05Z", "expire-after": "1d", "repeat-after": "1h"}`, ".* unknown unit d .*"},
-		{`{"message": "x", "first-added": "2006-01-02T15:04:05Z", "expire-after": "1h", "repeat-after": "1d"}`, ".* unknown unit d .*"},
+		{`{"message": "x", "first-added": "2006-01-02T15:04:05Z", "expire-after": "1d", "repeat-after": "1h"}`, ".* unknown unit \"?d\"? .*"},
+		{`{"message": "x", "first-added": "2006-01-02T15:04:05Z", "expire-after": "1h", "repeat-after": "1d"}`, ".* unknown unit \"?d\"? .*"},
 	} {
 		var w state.Warning
 		c.Check(json.Unmarshal([]byte(t.b), &w), check.ErrorMatches, t.e)


### PR DESCRIPTION
The error messages from the latest go master changed slightly
and our tests need to be adjusted to work with the latest go.
