### PR TITLE
data/systemd: do not run snapd.system-shutdown if finalrd is available

### DIFF
--- a/data/systemd/snapd.system-shutdown.service.in
+++ b/data/systemd/snapd.system-shutdown.service.in
@@ -5,6 +5,7 @@ DefaultDependencies=false
 # don't run on classic
 ConditionKernelCommandLine=|snap_core
 ConditionKernelCommandLine=|snapd_recovery_mode
+ConditionPathExists=!/usr/bin/finalrd
 # don't run if system-shutdown isn't there
 ConditionPathExists=@libexecdir@/snapd/system-shutdown
 # X-Snapd-Snap: do-not-start


### PR DESCRIPTION
finalrd is superior implementation, is available on core20 and is
being evaluated for backport to core18.
