### PR TITLE
tests: preserve size for centos images on spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -107,6 +107,7 @@ backends:
                 storage: preserve-size
             - centos-7-64:
                 workers: 6
+                storage: preserve-size
                 image: centos-7-64
 
     # TODO: spread is really unhappy when it sees a backend without any systems,
@@ -125,6 +126,7 @@ backends:
                 workers: 6
             - centos-8-64:
                 workers: 4
+                storage: preserve-size
                 image: centos-8-64
 
     google-sru:


### PR DESCRIPTION
New Centos base images have changed their size going to 20GB and spread
by default uses 10GB. So we need to use the option preserve-size because
otherwise spread fails to start it.

See error:
2020-04-14 02:38:44 Cannot allocate google:centos-7-64-base: cannot
allocate new Google server for centos-7-64-base: invalid value for field
'resource.disks[0].initializeParams.diskSizeGb': '10'. Requested disk
size cannot be smaller than the image size (20 GB)
