### PR TITLE
cmd/snap-bootstrap: switch to a 64-byte key for unlocking

### DIFF
--- a/cmd/snap-bootstrap/partition/encrypt.go
+++ b/cmd/snap-bootstrap/partition/encrypt.go
@@ -40,7 +40,7 @@ var (
 const (
 	// The encryption key size is set so it has the same entropy as the derived
 	// key. The recovery key is shorter and goes through KDF iterations.
-	encryptionKeySize = 32
+	encryptionKeySize = 64
 	recoveryKeySize   = 16
 )
 
@@ -134,6 +134,8 @@ func cryptsetupFormat(key EncryptionKey, label, node string) error {
 		"--type", "luks2",
 		// read key from stdin
 		"--key-file", "-",
+		// use AES-256 with XTS block cipher mode (XTS requires 2 keys)
+		"--cipher", "aes-xts-plain64", "--key-size", "512",
 		// use --iter-time 1 with the default KDF argon2i so
 		// to do virtually no derivation, here key is a random
 		// key with good entropy, not a passphrase, so

--- a/cmd/snap-bootstrap/partition/encrypt_test.go
+++ b/cmd/snap-bootstrap/partition/encrypt_test.go
@@ -71,7 +71,8 @@ func (s *encryptSuite) TestEncryptHappy(c *C) {
 	c.Assert(s.mockCryptsetup.Calls(), DeepEquals, [][]string{
 		{
 			"cryptsetup", "-q", "luksFormat", "--type", "luks2", "--key-file", "-",
-			"--pbkdf", "argon2i", "--iter-time", "1", "--label", "some-label-enc", "/dev/node1",
+			"--cipher", "aes-xts-plain64", "--key-size", "512", "--pbkdf", "argon2i",
+			"--iter-time", "1", "--label", "some-label-enc", "/dev/node1",
 		},
 		{
 			"cryptsetup", "open", "--key-file", "-", "/dev/node1", "some-label",
@@ -116,7 +117,8 @@ func (s *encryptSuite) TestEncryptAddKey(c *C) {
 	c.Assert(s.mockCryptsetup.Calls(), DeepEquals, [][]string{
 		{
 			"cryptsetup", "-q", "luksFormat", "--type", "luks2", "--key-file", "-",
-			"--pbkdf", "argon2i", "--iter-time", "1", "--label", "some-label-enc", "/dev/node1",
+			"--cipher", "aes-xts-plain64", "--key-size", "512", "--pbkdf", "argon2i",
+			"--iter-time", "1", "--label", "some-label-enc", "/dev/node1",
 		},
 		{
 			"cryptsetup", "open", "--key-file", "-", "/dev/node1", "some-label",

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -59,7 +59,7 @@ execute: |
         ./gadget-dir "$LOOP"
 
     echo "Check that the key file was created"
-    test "$(stat --printf="%s" ./keyfile)" = 32
+    test "$(stat --printf="%s" ./keyfile)" = 64
 
     echo "Check that the partitions are created"
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"


### PR DESCRIPTION
AES-256 with XTS block cipher uses 2 keys, so the key size is
512-bits. As the derived key is the same size as this, and we
require the derived key and unlocking key to have the same
entropy, increase the size of the unlocking key to 512-bits too.

As the size of the unlocking key is hardcoded in snap-bootstrap,
keep everything in sync by specifying the cipher and key size
when creating the LUKS2 container.
