### PR TITLE
tests/lib/assertions/developer1-pi-uc20.model: use 20/edge for kernel and gadget

### DIFF
--- a/tests/lib/assertions/developer1-pi-uc20.model.json
+++ b/tests/lib/assertions/developer1-pi-uc20.model.json
@@ -10,12 +10,12 @@
     "base": "core20",
     "snaps": [
         {
-            "default-channel": "20-pi/edge",
+            "default-channel": "20/edge",
             "id": "YbGa9O3dAXl88YLI6Y1bGG74pwBxZyKg",
             "name": "pi",
             "type": "gadget"
         }, {
-            "default-channel": "20-pi3/edge",
+            "default-channel": "20/edge",
             "id": "jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ",
             "name": "pi-kernel",
             "type": "kernel"


### PR DESCRIPTION
The ubuntu-core-20-pi-arm64.model is using 20/edge for kernel (pi-kernel) and
gadget (pi). Update the test model to use the same.