### PR TITLE
boot/bootstate20: fix bug in try-kernel cleanup

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -550,9 +550,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapC
 	_, nEnableCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
 	c.Assert(nEnableCalls, Equals, 0)
 
-	// we also didn't disable a try kernel (because it didn't exist)
+	// we will always end up disabling a try-kernel though as cleanup
 	_, nDisableTryCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("DisableTryKernel")
-	c.Assert(nDisableTryCalls, Equals, 0)
+	c.Assert(nDisableTryCalls, Equals, 1)
 
 	// do it again, verify it's still okay
 	err = boot.MarkBootSuccessful(coreDev)
@@ -563,10 +563,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapC
 	_, nEnableCalls = s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
 	c.Assert(nEnableCalls, Equals, 0)
 
-	// we did disable a try kernel here though because we always do that as a
-	// cleanup operation
+	// again we will always disable try-kernels as cleanup
 	_, nDisableTryCalls = s.bootloader.GetRunKernelImageFunctionSnapCalls("DisableTryKernel")
-	c.Assert(nDisableTryCalls, Equals, 1)
+	c.Assert(nDisableTryCalls, Equals, 2)
 
 	// check that the modeenv re-wrote the CurrentKernels
 	m2, err := boot.ReadModeenv("")

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -456,7 +456,7 @@ func selectSuccessfulBootSnap(b bootState, update bootStateUpdate) (
 	// kernel_status and base_status go from "" -> "try" (set by snapd), to
 	// "try" -> "trying" (set by the boot script)
 	// so if we are in "trying" mode, then we should choose the try snap
-	if status == TryingStatus {
+	if status == TryingStatus && trySnap != nil {
 		return bsmark, trySnap, nil
 	}
 


### PR DESCRIPTION
We should have always been disabling the try-kernel in MarkBootSuccessful here, but we weren't because in this specific test scenario, trySnap was nil, because TryKernel() didn't return a real snap, but the status was TryingStatus, so we chose the try-kernel (which was nil) as the snap to use as the booted snap.

The code in commit() for bootState20MarkSuccessful was robust enough though that it didn't panic, because it's written in such a way that if the booted kernel snap was nil, it will just skip some of the cleanup there. That's so that we can call MarkSuccessful on just a single snap type, such as base or kernel only, but in reality we will always call it on both snaps from boot.MarkBootSuccessful.