### PR TITLE
spread.yaml,tests/many: use global env var for lxd channel

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -28,6 +28,8 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     MANAGED_DEVICE: "false"
+    # TODO: change back to latest/stable when 4.0 is fixed
+    LXD_SNAP_CHANNEL: "3.23/stable"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -8,7 +8,7 @@ execute: |
     apt autoremove -y lxd
 
     echo "Install lxd"
-    snap install --candidate lxd
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
 
     echo "Create a trivial container using the lxd snap"
     snap set lxd waitready.timeout=240

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -14,7 +14,7 @@ execute: |
     apt autoremove -y squashfuse
 
     echo "Install lxd"
-    snap install --candidate lxd
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
 
     echo "Create a trivial container using the lxd snap"
     snap set lxd waitready.timeout=240

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -10,9 +10,6 @@ systems: [ubuntu-16.04*64, ubuntu-18.04*, ubuntu-2*, ubuntu-core-1*]
 # with the distro
 backends: [-autopkgtest]
 
-environment:
-    LXD_CHANNEL: candidate
-
 # lxd downloads can be quite slow
 kill-timeout: 25m
 
@@ -53,7 +50,7 @@ execute: |
     fi
 
     echo "Install lxd"
-    snap install --channel=${LXD_CHANNEL} lxd
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
 
     echo "Create a trivial container using the lxd snap"
     snap set lxd waitready.timeout=240
@@ -138,7 +135,7 @@ execute: |
 
     echo "Ensure we can use lxd as a snap inside lxd"
     lxd.lxc exec my-nesting-ubuntu -- apt autoremove -y lxd
-    lxd.lxc exec my-nesting-ubuntu -- snap install --channel=${LXD_CHANNEL} lxd
+    lxd.lxc exec my-nesting-ubuntu -- snap install lxd --channel="$LXD_SNAP_CHANNEL"
     echo "And we can run lxd containers inside the lxd container"
     lxd.lxc exec my-nesting-ubuntu -- snap set lxd waitready.timeout=240
     lxd.lxc exec my-nesting-ubuntu -- lxd waitready

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -38,7 +38,7 @@ debug: |
     fi
 
 execute: |
-    snap install lxd
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
 
     echo "Create a trivial container using the lxd snap"

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -8,7 +8,7 @@ prepare: |
     test "$(find "$GOHOME" -name 'snapd_*.deb' | wc -l)" -ne 0
 
     # Install LXD snap and set it up.
-    snap install lxd
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
     snap set lxd waitready.timeout=240
     lxd waitready
     lxd init --auto

--- a/tests/regression/lp-1867193/task.yaml
+++ b/tests/regression/lp-1867193/task.yaml
@@ -1,7 +1,7 @@
 summary: certain refresh sequence on the maas snap breaks the layout system
 systems: [ubuntu-18.04-64] # tight coupling with container guest
 prepare: |
-    snap install --candidate lxd
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
     snap set lxd waitready.timeout=240
     lxd waitready
     lxd init --auto

--- a/tests/regression/lp-1867752/task.yaml
+++ b/tests/regression/lp-1867752/task.yaml
@@ -1,7 +1,7 @@
 summary: certain layout configuration prevents snapd from removing a snap
 systems: [ubuntu-18.04-64] # tight coupling with container guest
 prepare: |
-    snap install --candidate lxd
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
     snap set lxd waitready.timeout=240
     lxd waitready
     lxd init --auto

--- a/tests/regression/lp-1871652/task.yaml
+++ b/tests/regression/lp-1871652/task.yaml
@@ -2,7 +2,7 @@ summary: system key mismatch is ignored on reboot/shutdown
 # Run on a system matching the guest container.
 systems: [ubuntu-18.04-64]
 prepare: |
-    snap install lxd
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
     lxd init --auto
     lxc launch ubuntu:18.04 bionic
     # Install snapd inside the container and then install the core snap so that
@@ -20,7 +20,7 @@ prepare: |
     # by running a lxc command. When lxd service shuts down systemd runs a
     # "snap run ... " command related to it, which will is where the problem
     # originates (we will observe a system key mismatch).
-    lxc exec bionic -- snap install lxd
+    lxc exec bionic -- snap install lxd --channel="$LXD_SNAP_CHANNEL"
     lxc exec bionic -- lxc info >/dev/null
 
     # Overwrite the snap binary inside the container with the one from this


### PR DESCRIPTION
This will make it easy to switch between channels if there is something broken on the stable lxd channel (like there is right now) and not have random lxd-related tests fail.