### PR TITLE
spread.yaml: switch back to latest/candidate for lxd snap

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -28,8 +28,7 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     MANAGED_DEVICE: "false"
-    # TODO: change back to latest/stable when 4.0 is fixed
-    LXD_SNAP_CHANNEL: "3.23/stable"
+    LXD_SNAP_CHANNEL: "latest/candidate"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'


### PR DESCRIPTION
Merge this after lxd latest snap is fixed to address the file push issue that https://github.com/lxc/lxd/pull/7198 fixes.

The specific error we were seeing was:

```
google:ubuntu-18.04-64 .../tests/regression/lp-1871652# lxc file push /usr/bin/snap bionic/usr/bin/snap
Error: open /snap/snapd/current/usr/bin/snap: no such file or directory
```

when that works again we can merge this. The issue happened because the core18 snap (which is what 4.0 lxd snap uses) has this symlink:

```
13:21:58 stgraber> root@sateda:~# nsenter --mount=/run/snapd/ns/lxd.mnt  -- ls -lh /usr/bin/snap 
13:22:00 stgraber> lrwxrwxrwx 1 root root 32 Mar 11 05:46 /usr/bin/snap -> /snap/snapd/current/usr/bin/snap
```

whereas core (which is what 3.23 lxd snap uses) has this:

```
13:23:14 stgraber> root@sateda:~# nsenter --mount=/run/snapd/ns/lxd.mnt  -- ls -lh /var/lib/snapd/hostfs/usr/bin/snap
13:23:16 stgraber> -rwxr-xr-x 1 root root 14M Oct 30 12:17 /var/lib/snapd/hostfs/usr/bin/snap
```

Note this is not necessarily a regression in the core18 snap, since snaps shouldn't be able to access /usr/bin/snap in the snap's namespace anyways, but lxd is erm special :-)