### PR TITLE
Add libnvidia-opticalflow as Nvidia library

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -112,6 +112,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-ifr.so*",
 	"libnvidia-ml.so*",
 	"libnvidia-opencl.so*",
+	"libnvidia-opticalflow.so.*",
 	"libnvidia-ptxjitcompiler.so*",
 	"libnvidia-rtcore.so*",
 	"libnvidia-tls.so*",

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -112,7 +112,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-ifr.so*",
 	"libnvidia-ml.so*",
 	"libnvidia-opencl.so*",
-	"libnvidia-opticalflow.so.*",
+	"libnvidia-opticalflow.so*",
 	"libnvidia-ptxjitcompiler.so*",
 	"libnvidia-rtcore.so*",
 	"libnvidia-tls.so*",


### PR DESCRIPTION
Following on from https://github.com/snapcore/snapd/pull/8419, there's also need for this lib.