### PR TITLE
packaging: fix build on Centos8 to support BUILDTAGS

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -72,6 +72,11 @@
 %define gobuild_static(o:) go build -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags -static'" -a -v -x %{?**};
 %endif
 
+# These macros are missing BUILDTAGS in RHEL 8
+%if 0%{?rhel} == 8
+%define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
+%endif
+
 # These macros are not defined in RHEL 7
 %if 0%{?rhel} == 7
 %define gobuild(o:) go build -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags'" -a -v -x %{?**};


### PR DESCRIPTION
We switched to use the "BUILDTAGS" definition in the snapd.spec
file. Unfortunately the rpm macro in centos8/RHEL8 do not support
this yet. This commit updates the macro to include BUILDTAGS
support.
