### PR TITLE
boot/bootstate20: small changes to markSuccessful

### DIFF
--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -79,10 +79,10 @@ type bootloaderKernelState20 interface {
 	setCommitStatus(status string)
 	// setNextKernel marks the kernel as the next, if it's not the currently
 	// booted kernel, then the specified kernel is setup as a try-kernel
-	setNextKernel(kernelSnap snap.PlaceInfo) error
-	// markSuccessful marks the specified kernel as having booted successfully,
-	// whether that kernel is the current kernel or the try-kernel
-	markSuccessful(kernelSnap snap.PlaceInfo) error
+	setNextKernel(sn snap.PlaceInfo) error
+	// markSuccessfulKernel marks the specified kernel as having booted
+	// successfully, whether that kernel is the current kernel or the try-kernel
+	markSuccessfulKernel(sn snap.PlaceInfo) error
 }
 
 // extractedRunKernelImageBootloaderKernelState implements bootloaderKernelState20 for
@@ -138,7 +138,7 @@ func (bks *extractedRunKernelImageBootloaderKernelState) setCommitStatus(status 
 	bks.commitKernelStatus = status
 }
 
-func (bks *extractedRunKernelImageBootloaderKernelState) markSuccessful(sn snap.PlaceInfo) error {
+func (bks *extractedRunKernelImageBootloaderKernelState) markSuccessfulKernel(sn snap.PlaceInfo) error {
 	// set the boot vars first, then enable the successful kernel, then disable
 	// the old try-kernel, see the comment in bootState20MarkSuccessful.commit()
 	// for details
@@ -645,7 +645,7 @@ func (bsmark *bootState20MarkSuccessful) commit() error {
 		// try kernel before we actually set it up to boot from the new try
 		// kernel - that would brick us because we wouldn't trust the new kernel
 		// but the bootloader still thinks it should boot from the old kernel
-		err := bsmark.bks.markSuccessful(bsmark.bootedKernelSnap)
+		err := bsmark.bks.markSuccessfulKernel(bsmark.bootedKernelSnap)
 		if err != nil {
 			return err
 		}

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -143,13 +143,49 @@ func (bks *extractedRunKernelImageBootloaderKernelState) markSuccessful(sn snap.
 	// the old try-kernel, see the comment in bootState20MarkSuccessful.commit()
 	// for details
 
-	// always set the kernel_status to default "" when marking successful, but
-	// only call SetBootVars if needed
-	// this has the useful side-effect of cleaning up if we happen to have
-	// kernel_status = "trying" but don't have a try-kernel set
-	if bks.commitKernelStatus != DefaultStatus {
+	// the ordering here is very important for boot reliability!
+
+	// If we have successfully just booted from a try-kernel and are
+	// marking it successful (this implies that snap_kernel=="trying" as set
+	// by the boot script), we need to do the following in order (since we
+	// have the added complexity of moving the kernel symlink):
+	// 1. Update kernel_status to ""
+	// 2. Move kernel symlink to point to the new try kernel
+	// 3. Remove try-kernel symlink
+	// 4. Remove old kernel from modeenv (this happens one level up from this
+	//    function)
+	//
+	// If we got rebooted after step 1, then the bootloader is booting the wrong
+	// kernel, but is at least booting a known good kernel and snapd in
+	// user-space would be able to figure out the inconsistency.
+	// If we got rebooted after step 2, the bootloader would boot from the new
+	// try-kernel which is okay because we were in the middle of committing
+	// that new kernel as good and all that's left is for snapd to cleanup
+	// the left-over try-kernel symlink.
+	//
+	// If instead we had moved the kernel symlink first to point to the new try
+	// kernel, and got rebooted before the kernel_status was updated, we would
+	// have kernel_status="trying" which would cause the bootloader to think
+	// the boot failed, and revert to booting using the kernel symlink, but that
+	// now points to the new kernel we were trying and we did not successfully
+	// boot from that kernel to know we should trust it.
+	//
+	// Removing the old kernel from the modeenv needs to happen after it is
+	// impossible for the bootloader to boot from that kernel, otherwise we
+	// could end up in a state where the bootloader doesn't want to boot the
+	// new kernel, but the initramfs doesn't trust the old kernel and we are
+	// stuck. As such, do this last, after the symlink no longer exists.
+	//
+	// The try-kernel symlink removal should happen last because it will not
+	// affect anything, except that if it was removed before updating
+	// kernel_status to "", the bootloader will think that the try kernel failed
+	// to boot and fall back to booting the old kernel which is safe.
+
+	// always set the boot vars first before mutating any of the kernel symlinks
+	// etc.
+	if bks.commitKernelStatus != bks.currentKernelStatus {
 		m := map[string]string{
-			"kernel_status": DefaultStatus,
+			"kernel_status": bks.commitKernelStatus,
 		}
 
 		// set the boot variables
@@ -292,6 +328,11 @@ func (ks20 *bootState20Kernel) markSuccessful(update bootStateUpdate) (bootState
 
 	// u should always be non-nil if err is nil
 	u.bootedKernelSnap = sn
+
+	// always set the commit status on the bks on the bootStateUpdate we return
+	// to be empty
+	u.bks.setCommitStatus(DefaultStatus)
+
 	return u, nil
 }
 
@@ -588,50 +629,22 @@ func (bsmark *bootState20MarkSuccessful) commit() error {
 	// issue a single write at the end if something changed
 	modeenvChanged := false
 
+	// for full explanation of the robustness and ordering, see the comments
+	// on the implementations of bks.markSuccessful
+
 	// kernel snap first, slightly higher priority
-
-	// the ordering here is very important for boot reliability!
-
-	// If we have successfully just booted from a try-kernel and are
-	// marking it successful (this implies that snap_kernel=="trying" as set
-	// by the boot script), we need to do the following in order (since we
-	// have the added complexity of moving the kernel symlink):
-	// 1. Update kernel_status to ""
-	// 2. Move kernel symlink to point to the new try kernel
-	// 3. Remove try-kernel symlink
-	// 4. Remove old kernel from modeenv
-	//
-	// If we got rebooted after step 1, then the bootloader is booting the wrong
-	// kernel, but is at least booting a known good kernel and snapd in
-	// user-space would be able to figure out the inconsistency.
-	// If we got rebooted after step 2, the bootloader would boot from the new
-	// try-kernel which is okay because we were in the middle of committing
-	// that new kernel as good and all that's left is for snapd to cleanup
-	// the left-over try-kernel symlink.
-	//
-	// If instead we had moved the kernel symlink first to point to the new try
-	// kernel, and got rebooted before the kernel_status was updated, we would
-	// have kernel_status="trying" which would cause the bootloader to think
-	// the boot failed, and revert to booting using the kernel symlink, but that
-	// now points to the new kernel we were trying and we did not successfully
-	// boot from that kernel to know we should trust it.
-	//
-	// Removing the old kernel from the modeenv needs to happen after it is
-	// impossible for the bootloader to boot from that kernel, otherwise we
-	// could end up in a state where the bootloader doesn't want to boot the
-	// new kernel, but the initramfs doesn't trust the old kernel and we are
-	// stuck. As such, do this last, after the symlink no longer exists.
-	//
-	// The try-kernel symlink removal should happen last because it will not
-	// affect anything, except that if it was removed before updating
-	// kernel_status to "", the bootloader will think that the try kernel failed
-	// to boot and fall back to booting the old kernel which is safe.
 
 	// bootedKernelSnap will only ever be non-nil if we aren't marking a kernel
 	// snap successful, i.e. we are only marking a base snap successful
 	// this shouldn't happen except in tests, but let's be robust against it
 	// just in case
 	if bsmark.bootedKernelSnap != nil {
+		// always mark the kernel snap successful _before_ any other state
+		// mutating that may happen in bks.markSuccessful, because what we don't
+		// want to happen is to remove the old kernel and only trust the new
+		// try kernel before we actually set it up to boot from the new try
+		// kernel - that would brick us because we wouldn't trust the new kernel
+		// but the bootloader still thinks it should boot from the old kernel
 		err := bsmark.bks.markSuccessful(bsmark.bootedKernelSnap)
 		if err != nil {
 			return err

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -74,15 +74,12 @@ type bootloaderKernelState20 interface {
 	// kernel returns the current try kernel if it exists on the bootloader
 	tryKernel() (snap.PlaceInfo, error)
 
-	// setCommitStatus will save the kernel status to be committed during either
-	// setNextKernel or markSuccessful
-	setCommitStatus(status string)
 	// setNextKernel marks the kernel as the next, if it's not the currently
 	// booted kernel, then the specified kernel is setup as a try-kernel
-	setNextKernel(sn snap.PlaceInfo) error
+	setNextKernel(sn snap.PlaceInfo, status string) error
 	// markSuccessfulKernel marks the specified kernel as having booted
 	// successfully, whether that kernel is the current kernel or the try-kernel
-	markSuccessfulKernel(sn snap.PlaceInfo) error
+	markSuccessfulKernel(sn snap.PlaceInfo, status string) error
 }
 
 // extractedRunKernelImageBootloaderKernelState implements bootloaderKernelState20 for
@@ -92,9 +89,6 @@ type extractedRunKernelImageBootloaderKernelState struct {
 	ebl bootloader.ExtractedRunKernelImageBootloader
 	// the current kernel status as read by the bootloader's bootenv
 	currentKernelStatus string
-	// what the kernel status should be committed as during one of the
-	// committing methods, setNextKernel or markSuccessful
-	commitKernelStatus string
 	// the current kernel on the bootloader (not the try-kernel)
 	currentKernel snap.PlaceInfo
 }
@@ -107,8 +101,6 @@ func (bks *extractedRunKernelImageBootloaderKernelState) load() error {
 	}
 
 	bks.currentKernelStatus = m["kernel_status"]
-	// the default kernel status to commit is the current state
-	bks.commitKernelStatus = bks.currentKernelStatus
 
 	// get the current kernel for this bootloader to compare during commit() for
 	// markSuccessful() if we booted the current kernel or not
@@ -134,11 +126,7 @@ func (bks *extractedRunKernelImageBootloaderKernelState) kernelStatus() string {
 	return bks.currentKernelStatus
 }
 
-func (bks *extractedRunKernelImageBootloaderKernelState) setCommitStatus(status string) {
-	bks.commitKernelStatus = status
-}
-
-func (bks *extractedRunKernelImageBootloaderKernelState) markSuccessfulKernel(sn snap.PlaceInfo) error {
+func (bks *extractedRunKernelImageBootloaderKernelState) markSuccessfulKernel(sn snap.PlaceInfo, status string) error {
 	// set the boot vars first, then enable the successful kernel, then disable
 	// the old try-kernel, see the comment in bootState20MarkSuccessful.commit()
 	// for details
@@ -183,9 +171,9 @@ func (bks *extractedRunKernelImageBootloaderKernelState) markSuccessfulKernel(sn
 
 	// always set the boot vars first before mutating any of the kernel symlinks
 	// etc.
-	if bks.commitKernelStatus != bks.currentKernelStatus {
+	if status != bks.currentKernelStatus {
 		m := map[string]string{
-			"kernel_status": bks.commitKernelStatus,
+			"kernel_status": status,
 		}
 
 		// set the boot variables
@@ -214,7 +202,7 @@ func (bks *extractedRunKernelImageBootloaderKernelState) markSuccessfulKernel(sn
 	return nil
 }
 
-func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernel(sn snap.PlaceInfo) error {
+func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernel(sn snap.PlaceInfo, status string) error {
 	// always enable the try-kernel first, if we did the reverse and got
 	// rebooted after setting the boot vars but before enabling the try-kernel
 	// we could get stuck where the bootloader can't find the try-kernel and
@@ -229,9 +217,9 @@ func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernel(sn snap.P
 
 	// only if the new kernel status is different from what we read should we
 	// run SetBootVars() to minimize wear/corruption possibility on the bootenv
-	if bks.commitKernelStatus != bks.currentKernelStatus {
+	if status != bks.currentKernelStatus {
 		m := map[string]string{
-			"kernel_status": bks.commitKernelStatus,
+			"kernel_status": status,
 		}
 
 		// set the boot variables
@@ -257,6 +245,9 @@ type bootState20Kernel struct {
 
 	// the kernel snap to try for setNext()
 	nextKernelSnap snap.PlaceInfo
+
+	// the kernel_status to commit during commit()
+	commitKernelStatus string
 
 	// don't embed this struct - it will conflict with embedding
 	// bootState20Modeenv in bootState20Base when both bootState20Base and
@@ -329,9 +320,10 @@ func (ks20 *bootState20Kernel) markSuccessful(update bootStateUpdate) (bootState
 	// u should always be non-nil if err is nil
 	u.bootedKernelSnap = sn
 
-	// always set the commit status on the bks on the bootStateUpdate we return
-	// to be empty
-	u.bks.setCommitStatus(DefaultStatus)
+	// always set the commit status to be Default because we need to finish this
+	// "boot"
+	// TODO:UC20: should this really be hard-coded in commit instead?
+	u.commitKernelStatus = DefaultStatus
 
 	return u, nil
 }
@@ -354,7 +346,7 @@ func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo) (rebootRequired bool
 	if nextStatus == TryStatus {
 		rebootRequired = true
 	}
-	ks20.bks.setCommitStatus(nextStatus)
+	ks20.commitKernelStatus = nextStatus
 
 	// any state changes done so far are consumed in commit()
 
@@ -400,7 +392,7 @@ func (ks20 *bootState20Kernel) commit() error {
 		}
 	}
 
-	err := ks20.bks.setNextKernel(ks20.nextKernelSnap)
+	err := ks20.bks.setNextKernel(ks20.nextKernelSnap, ks20.commitKernelStatus)
 	if err != nil {
 		return err
 	}
@@ -645,7 +637,7 @@ func (bsmark *bootState20MarkSuccessful) commit() error {
 		// try kernel before we actually set it up to boot from the new try
 		// kernel - that would brick us because we wouldn't trust the new kernel
 		// but the bootloader still thinks it should boot from the old kernel
-		err := bsmark.bks.markSuccessfulKernel(bsmark.bootedKernelSnap)
+		err := bsmark.bks.markSuccessfulKernel(bsmark.bootedKernelSnap, bsmark.commitKernelStatus)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This might seem like it is a behavioral change, but it is not. It is just slightly moving some things around to be "less clearly unclear". 

Specifically, no matter the implementation of bootloaderKernelState20, we want to always set the status to DefaultStatus when we are marking successful, so if we do that in the bootState markSuccessful, then markSuccessfulKernel (renamed) doesn't need to know to do that and just needs to track what status should be committed and then commit it, so we are moving the decision about that to a method which is more clearly associated with making that decision IMHO.

The name markSuccessful on bootloaderKernelState20 kept confusing me with markSuccessful on bootstate, so making these separate is useful while coding if nothing else, but I will concede the full name is now repetitive.

Also move the big comment to where it's applicable, it won't be applicable in the new implementation of bootloaderKernelState20 I'll be adding soon for u-boot and lk and friends.