### PR TITLE
tests/boot: refactor to make it easier for new bootloaderKernelState20 impl

### DIFF
--- a/boot/boot_robustness_test.go
+++ b/boot/boot_robustness_test.go
@@ -219,7 +219,7 @@ func (s *bootenv20Suite) TestHappyMarkBootSuccessful20KernelUpgradeUnexpectedReb
 
 	for _, t := range tt {
 		// setup the bootloader per test
-		restore := setupUC20Bloader(
+		restore := setupUC20Bootenv(
 			c,
 			s.bootloader,
 			s.normalTryingKernelState,
@@ -269,7 +269,7 @@ func (s *bootenv20Suite) TestHappySetNextBoot20KernelUpgradeUnexpectedReboots(c 
 
 	for _, t := range tt {
 		// setup the bootloader per test
-		restore := setupUC20Bloader(
+		restore := setupUC20Bootenv(
 			c,
 			s.bootloader,
 			s.normalDefaultState,

--- a/boot/boot_robustness_test.go
+++ b/boot/boot_robustness_test.go
@@ -1,0 +1,302 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package boot_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/boot/boottest"
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/snap"
+)
+
+// TODO:UC20: move this to bootloadertest package and use from i.e. managers_test.go ?
+func runBootloaderLogic(c *C, bl bootloader.Bootloader) (snap.PlaceInfo, error) {
+	// switch on which kind of bootloader we have
+	ebl, ok := bl.(bootloader.ExtractedRunKernelImageBootloader)
+	if ok {
+		return extractedRunKernelImageBootloaderLogic(c, ebl)
+	}
+
+	return pureenvBootloaderLogic(c, "kernel_status", bl)
+}
+
+// runBootloaderLogic implements the logic from the gadget snap bootloader,
+// namely that we transition kernel_status "try" -> "trying" and "trying" -> ""
+// and use try-kernel.efi when kernel_status is "try" and kernel.efi in all
+// other situations
+func extractedRunKernelImageBootloaderLogic(c *C, ebl bootloader.ExtractedRunKernelImageBootloader) (snap.PlaceInfo, error) {
+	m, err := ebl.GetBootVars("kernel_status")
+	c.Assert(err, IsNil)
+	kernStatus := m["kernel_status"]
+
+	kern, err := ebl.Kernel()
+	c.Assert(err, IsNil)
+	c.Assert(kern, Not(IsNil))
+
+	switch kernStatus {
+	case boot.DefaultStatus:
+	case boot.TryStatus:
+		// move to trying, use the try-kernel
+		m["kernel_status"] = boot.TryingStatus
+
+		// ensure that the try-kernel exists
+		tryKern, err := ebl.TryKernel()
+		c.Assert(err, IsNil)
+		c.Assert(tryKern, Not(IsNil))
+		kern = tryKern
+
+	case boot.TryingStatus:
+		// boot failed, move back to default
+		m["kernel_status"] = boot.DefaultStatus
+	}
+
+	err = ebl.SetBootVars(m)
+	c.Assert(err, IsNil)
+
+	return kern, nil
+}
+
+func pureenvBootloaderLogic(c *C, modeVar string, bl bootloader.Bootloader) (snap.PlaceInfo, error) {
+	m, err := bl.GetBootVars(modeVar, "snap_kernel", "snap_try_kernel")
+	c.Assert(err, IsNil)
+	var kern snap.PlaceInfo
+
+	kernStatus := m[modeVar]
+
+	kern, err = snap.ParsePlaceInfoFromSnapFileName(m["snap_kernel"])
+	c.Assert(err, IsNil)
+	c.Assert(kern, Not(IsNil))
+
+	switch kernStatus {
+	case boot.DefaultStatus:
+		// nothing to do, use normal kernel
+
+	case boot.TryStatus:
+		// move to trying, use the try-kernel
+		m[modeVar] = boot.TryingStatus
+
+		tryKern, err := snap.ParsePlaceInfoFromSnapFileName(m["snap_try_kernel"])
+		c.Assert(err, IsNil)
+		c.Assert(tryKern, Not(IsNil))
+		kern = tryKern
+
+	case boot.TryingStatus:
+		// boot failed, move back to default status
+		m[modeVar] = boot.DefaultStatus
+
+	}
+
+	err = bl.SetBootVars(m)
+	c.Assert(err, IsNil)
+
+	return kern, nil
+}
+
+// note: this could be implemented just as a function which takes a bootloader
+// as an argument and then inspect the type of MockBootloader that was passed
+// in, but the gains are little, since we don't need to use this function for
+// the non-ExtractedRunKernelImageBootloader implementations, as those
+// implementations just have one critical function to run which is just
+// SetBootVars
+func (s *bootenv20Suite) checkBootStateAfterUnexpectedRebootAndCleanup(
+	c *C,
+	dev boot.Device,
+	bootFunc func(boot.Device) error,
+	panicFunc string,
+	expectedBootedKernel snap.PlaceInfo,
+	expectedModeenvCurrentKernels []snap.PlaceInfo,
+	finalBlKernel snap.PlaceInfo,
+	comment string,
+) {
+	// setup a panic during the given bootloader function
+	restoreBootloaderPanic := s.bootloader.SetRunKernelImagePanic(panicFunc)
+
+	// run the boot function that will now panic
+	c.Assert(
+		func() { bootFunc(dev) },
+		PanicMatches,
+		fmt.Sprintf("mocked reboot panic in %s", panicFunc),
+		Commentf(comment),
+	)
+
+	// don't panic anymore
+	restoreBootloaderPanic()
+
+	// do the bootloader kernel failover logic handling
+	nextBootingKernel, err := runBootloaderLogic(c, s.bootloader)
+	c.Assert(err, IsNil, Commentf(comment))
+
+	// check that the kernel we booted now is expected
+	c.Assert(nextBootingKernel, Equals, expectedBootedKernel)
+
+	// mark the boot successful like we were rebooted
+	err = boot.MarkBootSuccessful(dev)
+	c.Assert(err, IsNil, Commentf(comment))
+
+	// the boot vars should be empty now too
+	afterVars, err := s.bootloader.GetBootVars("kernel_status")
+	c.Assert(err, IsNil, Commentf(comment))
+	c.Assert(afterVars["kernel_status"], DeepEquals, boot.DefaultStatus, Commentf(comment))
+
+	// the modeenv's setting for CurrentKernels also matches
+	m, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil, Commentf(comment))
+	// it's nicer to pass in just the snap.PlaceInfo's, but to compare we need
+	// the string filenames
+	currentKernels := make([]string, len(expectedModeenvCurrentKernels))
+	for i, sn := range expectedModeenvCurrentKernels {
+		currentKernels[i] = sn.Filename()
+	}
+	c.Assert(m.CurrentKernels, DeepEquals, currentKernels, Commentf(comment))
+
+	// if we have a final bootloader kernel set, the bootloader should be a
+	// ExtractedRunKernelImageBootloader that we can check the kernel and try
+	// kernel on directly
+	if finalBlKernel != nil {
+		afterKernel, err := s.bootloader.Kernel()
+		c.Assert(err, IsNil, Commentf(comment))
+		c.Assert(afterKernel, DeepEquals, finalBlKernel, Commentf(comment))
+
+		// we should never have a leftover try kernel
+		_, err = s.bootloader.TryKernel()
+		c.Assert(err, Equals, bootloader.ErrNoTryKernelRef, Commentf(comment))
+	}
+}
+
+func (s *bootenv20Suite) TestHappyMarkBootSuccessful20KernelUpgradeUnexpectedReboots(c *C) {
+	coreDev := boottest.MockUC20Device("some-snap")
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	tt := []struct {
+		rebootBeforeFunc  string
+		expBootKernel     snap.PlaceInfo
+		expModeenvKernels []snap.PlaceInfo
+		expBlKernel       snap.PlaceInfo
+		comment           string
+	}{
+		{
+			"SetBootVars",             // reboot right before SetBootVars
+			s.kern1,                   // we should boot the old kernel
+			[]snap.PlaceInfo{s.kern1}, // expected kernel is old one
+			s.kern1,                   // the expected kernel is just the old one
+			"reboot before SetBootVars results in old kernel",
+		},
+		{
+			"EnableKernel",            // reboot right before EnableKernel
+			s.kern1,                   // we should boot the old kernel
+			[]snap.PlaceInfo{s.kern1}, // expected kernel is old one
+			s.kern1,                   // the expected kernel is just the old one
+			"reboot before EnableKernel results in old kernel",
+		},
+		{
+			"DisableTryKernel",        // reboot right before DisableTryKernel
+			s.kern2,                   // we should boot the new kernel
+			[]snap.PlaceInfo{s.kern2}, // expected kernel is new one
+			s.kern2,                   // the expected kernel is the new one
+			"reboot before DisableTryKernel results in new kernel",
+		},
+	}
+
+	for _, t := range tt {
+		// setup the bootloader per test
+		restore := setupUC20Bloader(
+			c,
+			s.bootloader,
+			s.normalTryingKernelState,
+		)
+
+		s.checkBootStateAfterUnexpectedRebootAndCleanup(
+			c,
+			coreDev,
+			boot.MarkBootSuccessful,
+			t.rebootBeforeFunc,
+			t.expBlKernel,
+			t.expModeenvKernels,
+			t.expBlKernel,
+			t.comment,
+		)
+
+		restore()
+	}
+}
+
+func (s *bootenv20Suite) TestHappySetNextBoot20KernelUpgradeUnexpectedReboots(c *C) {
+	coreDev := boottest.MockUC20Device("pc-kernel")
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	tt := []struct {
+		rebootBeforeFunc  string
+		expBootKernel     snap.PlaceInfo
+		expModeenvKernels []snap.PlaceInfo
+		expBlKernel       snap.PlaceInfo
+		comment           string
+	}{
+		{
+			"EnableTryKernel",         // reboot right before EnableTryKernel
+			s.kern1,                   // we should boot the old kernel
+			[]snap.PlaceInfo{s.kern1}, // expected kernel is old one
+			s.kern1,                   // the expected kernel is the old one
+			"reboot before EnableTryKernel results in old kernel",
+		},
+		{
+			"SetBootVars",             // reboot right before SetBootVars
+			s.kern1,                   // we should boot the old kernel
+			[]snap.PlaceInfo{s.kern1}, // expected kernel is old one
+			s.kern1,                   // the expected kernel is the old one
+			"reboot before SetBootVars results in old kernel",
+		},
+	}
+
+	for _, t := range tt {
+		// setup the bootloader per test
+		restore := setupUC20Bloader(
+			c,
+			s.bootloader,
+			s.normalDefaultState,
+		)
+
+		// get the boot kernel participant from our new kernel snap
+		bootKern := boot.Participant(s.kern2, snap.TypeKernel, coreDev)
+		// make sure it's not a trivial boot participant
+		c.Assert(bootKern.IsTrivial(), Equals, false)
+
+		setNextFunc := func(boot.Device) error {
+			// we don't care about the reboot required logic here
+			_, err := bootKern.SetNextBoot()
+			return err
+		}
+
+		s.checkBootStateAfterUnexpectedRebootAndCleanup(
+			c,
+			coreDev,
+			setNextFunc,
+			t.rebootBeforeFunc,
+			t.expBlKernel,
+			t.expModeenvKernels,
+			t.expBlKernel,
+			t.comment,
+		)
+
+		restore()
+	}
+}

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -85,8 +85,8 @@ type baseBootenv20Suite struct {
 	base1 snap.PlaceInfo
 	base2 snap.PlaceInfo
 
-	normalDefaultState      *uc20bootStateSetupOpts
-	normalTryingKernelState *uc20bootStateSetupOpts
+	normalDefaultState      *bootenv20Setup
+	normalTryingKernelState *bootenv20Setup
 }
 
 func (s *baseBootenv20Suite) SetUpTest(c *C) {
@@ -104,7 +104,7 @@ func (s *baseBootenv20Suite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// default boot state for robustness tests, etc.
-	s.normalDefaultState = &uc20bootStateSetupOpts{
+	s.normalDefaultState = &bootenv20Setup{
 		modeenv: &boot.Modeenv{
 			// base is base1
 			Base: s.base1.Filename(),
@@ -128,7 +128,7 @@ func (s *baseBootenv20Suite) SetUpTest(c *C) {
 	}
 
 	// state for after trying a new kernel for robustness tests, etc.
-	s.normalTryingKernelState = &uc20bootStateSetupOpts{
+	s.normalTryingKernelState = &bootenv20Setup{
 		modeenv: &boot.Modeenv{
 			// base is base1
 			Base: s.base1.Filename(),
@@ -165,17 +165,17 @@ func (s *bootenv20Suite) SetUpTest(c *C) {
 	s.forceBootloader(s.bootloader)
 }
 
-type uc20bootStateSetupOpts struct {
+type bootenv20Setup struct {
 	modeenv    *boot.Modeenv
 	kern       snap.PlaceInfo
 	tryKern    snap.PlaceInfo
 	kernStatus string
 }
 
-func setupUC20Bloader(
+func setupUC20Bootenv(
 	c *C,
 	bl bootloader.Bootloader,
-	opts *uc20bootStateSetupOpts,
+	opts *bootenv20Setup,
 ) (restore func()) {
 	var cleanups []func()
 
@@ -367,7 +367,7 @@ func (s *bootenv20Suite) TestCurrentBoot20NameAndRevision(c *C) {
 	coreDev := boottest.MockUC20Device("some-snap")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
 		s.normalDefaultState,
@@ -551,7 +551,7 @@ func (s *bootenv20Suite) TestCoreKernel20(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
 		s.normalDefaultState,
@@ -586,7 +586,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
 		s.normalDefaultState,
@@ -629,7 +629,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
 		s.normalDefaultState,
@@ -669,10 +669,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapC
 
 	// set all the same vars as if we were doing trying, except don't set a try
 	// kernel
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
-		&uc20bootStateSetupOpts{
+		&bootenv20Setup{
 			modeenv: &boot.Modeenv{
 				Mode:           "run",
 				Base:           s.base1.Filename(),
@@ -728,10 +728,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseStatusTryingNoTryBaseSnapCl
 		// no TryBase set
 		BaseStatus: boot.TryingStatus,
 	}
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
-		&uc20bootStateSetupOpts{
+		&bootenv20Setup{
 			modeenv: m,
 			// no kernel setup necessary
 		},
@@ -771,10 +771,10 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameBaseSnap(c *C) {
 		Mode: "run",
 		Base: s.base1.Filename(),
 	}
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
-		&uc20bootStateSetupOpts{
+		&bootenv20Setup{
 			modeenv: m,
 			// no kernel setup necessary
 		},
@@ -810,10 +810,10 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnap(c *C) {
 		Mode: "run",
 		Base: s.base1.Filename(),
 	}
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
-		&uc20bootStateSetupOpts{
+		&bootenv20Setup{
 			modeenv: m,
 			// no kernel setup necessary
 		},
@@ -876,10 +876,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
 		BaseStatus:     boot.TryingStatus,
 		CurrentKernels: []string{s.kern1.Filename(), s.kern2.Filename()},
 	}
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
-		&uc20bootStateSetupOpts{
+		&bootenv20Setup{
 			modeenv:    m,
 			kern:       s.kern1,
 			tryKern:    s.kern2,
@@ -979,10 +979,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename(), s.kern2.Filename()},
 	}
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
-		&uc20bootStateSetupOpts{
+		&bootenv20Setup{
 			modeenv:    m,
 			kern:       s.kern1,
 			tryKern:    s.kern2,
@@ -1039,10 +1039,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseUpdate(c *C) {
 		BaseStatus:     boot.TryingStatus,
 		CurrentKernels: []string{s.kern1.Filename()},
 	}
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
-		&uc20bootStateSetupOpts{
+		&bootenv20Setup{
 			modeenv:    m,
 			kern:       s.kern1,
 			kernStatus: boot.DefaultStatus,

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -77,19 +77,181 @@ func (s *bootenvSuite) SetUpTest(c *C) {
 	s.forceBootloader(s.bootloader)
 }
 
-type bootenv20Suite struct {
+type baseBootenv20Suite struct {
 	baseBootenvSuite
+
+	kern1 snap.PlaceInfo
+	kern2 snap.PlaceInfo
+	base1 snap.PlaceInfo
+	base2 snap.PlaceInfo
+
+	normalDefaultState      *uc20bootStateSetupOpts
+	normalTryingKernelState *uc20bootStateSetupOpts
+}
+
+func (s *baseBootenv20Suite) SetUpTest(c *C) {
+	s.baseBootenvSuite.SetUpTest(c)
+
+	var err error
+	s.kern1, err = snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
+	c.Assert(err, IsNil)
+	s.kern2, err = snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
+	c.Assert(err, IsNil)
+
+	s.base1, err = snap.ParsePlaceInfoFromSnapFileName("core20_1.snap")
+	c.Assert(err, IsNil)
+	s.base2, err = snap.ParsePlaceInfoFromSnapFileName("core20_2.snap")
+	c.Assert(err, IsNil)
+
+	// default boot state for robustness tests, etc.
+	s.normalDefaultState = &uc20bootStateSetupOpts{
+		modeenv: &boot.Modeenv{
+			// base is base1
+			Base: s.base1.Filename(),
+			// no try base
+			TryBase: "",
+			// base status is default
+			BaseStatus: boot.DefaultStatus,
+			// current kernels is just kern1
+			CurrentKernels: []string{s.kern1.Filename()},
+			// operating mode is run
+			Mode: "run",
+			// RecoverySystem is unset, as it should be during run mode
+			RecoverySystem: "",
+		},
+		// enabled kernel is kern1
+		kern: s.kern1,
+		// no try kernel enabled
+		tryKern: nil,
+		// kernel status is default
+		kernStatus: boot.DefaultStatus,
+	}
+
+	// state for after trying a new kernel for robustness tests, etc.
+	s.normalTryingKernelState = &uc20bootStateSetupOpts{
+		modeenv: &boot.Modeenv{
+			// base is base1
+			Base: s.base1.Filename(),
+			// no try base
+			TryBase: "",
+			// base status is default
+			BaseStatus: boot.DefaultStatus,
+			// current kernels is kern1 + kern2
+			CurrentKernels: []string{s.kern1.Filename(), s.kern2.Filename()},
+		},
+		// enabled kernel is kern1
+		kern: s.kern1,
+		// try kernel is kern2
+		tryKern: s.kern2,
+		// kernel status is trying
+		kernStatus: boot.TryingStatus,
+	}
+}
+
+type bootenv20Suite struct {
+	baseBootenv20Suite
 
 	bootloader *bootloadertest.MockExtractedRunKernelImageBootloader
 }
 
+
+var defaultUC20BootEnv = map[string]string{"kernel_status": boot.DefaultStatus}
+
 var _ = Suite(&bootenv20Suite{})
 
 func (s *bootenv20Suite) SetUpTest(c *C) {
-	s.baseBootenvSuite.SetUpTest(c)
+	s.baseBootenv20Suite.SetUpTest(c)
 
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir()).WithExtractedRunKernelImage()
 	s.forceBootloader(s.bootloader)
+}
+
+
+type uc20bootStateSetupOpts struct {
+	modeenv    *boot.Modeenv
+	kern       snap.PlaceInfo
+	tryKern    snap.PlaceInfo
+	kernStatus string
+}
+
+func setupUC20Bloader(
+	c *C,
+	bl bootloader.Bootloader,
+	opts *uc20bootStateSetupOpts,
+) (restore func()) {
+	var cleanups []func()
+
+	// write the modeenv
+	if opts.modeenv != nil {
+		c.Assert(opts.modeenv.WriteTo(""), IsNil)
+		// this isn't strictly necessary since the modeenv will be written to
+		// the test's private dir anyways, but it's nice to have so we can write
+		// multiple modeenvs from a single test and just call the restore
+		// function in between the parts of the test that use different modeenvs
+		r := func() {
+			emptyModeenv := &boot.Modeenv{}
+			c.Assert(emptyModeenv.WriteTo(""), IsNil)
+		}
+		cleanups = append(cleanups, r)
+	}
+
+	// check what kind of real mock bootloader we have to use different methods
+	// to set the kernel snaps are if they're non-nil
+	switch vbl := bl.(type) {
+	case *bootloadertest.MockExtractedRunKernelImageBootloader:
+		// then we can use the advanced methods on it
+		if opts.kern != nil {
+			r := vbl.SetRunKernelImageEnabledKernel(opts.kern)
+			cleanups = append(cleanups, r)
+		}
+
+		if opts.tryKern != nil {
+			r := vbl.SetRunKernelImageEnabledTryKernel(opts.tryKern)
+			cleanups = append(cleanups, r)
+		}
+
+	case *bootloadertest.MockBootloader:
+		// then we need to use the bootenv to set the current kernels
+		origEnv, err := vbl.GetBootVars("snap_kernel", "snap_try_kernel")
+		c.Assert(err, IsNil)
+		m := make(map[string]string, 2)
+		if opts.kern != nil {
+			m["snap_kernel"] = opts.kern.Filename()
+		} else {
+			m["snap_kernel"] = ""
+		}
+
+		if opts.tryKern != nil {
+			m["snap_try_kernel"] = opts.tryKern.Filename()
+		} else {
+			m["snap_try_kernel"] = ""
+		}
+
+		err = bl.SetBootVars(m)
+		c.Assert(err, IsNil)
+
+		cleanups = append(cleanups, func() {
+			err := bl.SetBootVars(origEnv)
+			c.Assert(err, IsNil)
+		})
+	}
+
+	// set the status
+	origEnv, err := bl.GetBootVars("kernel_status")
+	c.Assert(err, IsNil)
+
+	err = bl.SetBootVars(map[string]string{"kernel_status": opts.kernStatus})
+	c.Assert(err, IsNil)
+	cleanups = append(cleanups, func() {
+		err := bl.SetBootVars(origEnv)
+		c.Assert(err, IsNil)
+	})
+
+	return func() {
+		for _, r := range cleanups {
+			r()
+		}
+	}
 }
 
 func (s *bootenvSuite) TestInUseClassic(c *C) {
@@ -198,26 +360,21 @@ func (s *bootenv20Suite) TestCurrentBoot20NameAndRevision(c *C) {
 	coreDev := boottest.MockUC20Device("some-snap")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	m := &boot.Modeenv{
-		Mode:           "run",
-		RecoverySystem: "20191018",
-		Base:           "core20_1.snap",
-	}
-	c.Assert(m.WriteTo(""), IsNil)
-
-	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
 	defer r()
 
 	current, err := boot.GetCurrentBoot(snap.TypeBase, coreDev)
 	c.Check(err, IsNil)
-	c.Check(current.SnapName(), Equals, "core20")
+	c.Check(current.SnapName(), Equals, s.base1.SnapName())
 	c.Check(current.SnapRevision(), Equals, snap.R(1))
 
 	current, err = boot.GetCurrentBoot(snap.TypeKernel, coreDev)
 	c.Check(err, IsNil)
-	c.Check(current.SnapName(), Equals, "pc-kernel")
+	c.Check(current.SnapName(), Equals, s.kern1.SnapName())
 	c.Check(current.SnapRevision(), Equals, snap.R(1))
 
 	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
@@ -387,11 +544,15 @@ func (s *bootenv20Suite) TestCoreKernel20(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
-	c.Assert(err, IsNil)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
+	defer r()
 
 	// get the boot kernel from our kernel snap
-	bootKern := boot.Kernel(kernel, snap.TypeKernel, coreDev)
+	bootKern := boot.Kernel(s.kern1, snap.TypeKernel, coreDev)
 	// can't use FitsTypeOf with coreKernel here, cause that causes an import
 	// loop as boottest imports boot and coreKernel is unexported
 	c.Assert(bootKern.IsTrivial(), Equals, false)
@@ -400,42 +561,34 @@ func (s *bootenv20Suite) TestCoreKernel20(c *C) {
 	// the container here doesn't really matter since it's just being passed
 	// to the mock bootloader method anyways
 	kernelContainer := snaptest.MockContainer(c, nil)
-	err = bootKern.ExtractKernelAssets(kernelContainer)
+	err := bootKern.ExtractKernelAssets(kernelContainer)
 	c.Assert(err, IsNil)
 
 	// make sure that the bootloader was told to extract some assets
-	c.Assert(s.bootloader.ExtractKernelAssetsCalls, DeepEquals, []snap.PlaceInfo{kernel})
+	c.Assert(s.bootloader.ExtractKernelAssetsCalls, DeepEquals, []snap.PlaceInfo{s.kern1})
 
 	// now remove the kernel assets and ensure that we get those calls
 	err = bootKern.RemoveKernelAssets()
 	c.Assert(err, IsNil)
 
 	// make sure that the bootloader was told to remove assets
-	c.Assert(s.bootloader.RemoveKernelAssetsCalls, DeepEquals, []snap.PlaceInfo{kernel})
+	c.Assert(s.bootloader.RemoveKernelAssetsCalls, DeepEquals, []snap.PlaceInfo{s.kern1})
 }
 
 func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	// default modeenv state
-	m := &boot.Modeenv{
-		Base:           "core20_1.snap",
-		CurrentKernels: []string{"pc-kernel_1.snap"},
-	}
-	c.Assert(m.WriteTo(""), IsNil)
-
-	// set the current kernel
-	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
 	defer r()
 
-	// default state
-	s.bootloader.BootVars["kernel_status"] = boot.DefaultStatus
-
 	// get the boot kernel participant from our kernel snap
-	bootKern := boot.Participant(kernel, snap.TypeKernel, coreDev)
+	bootKern := boot.Participant(s.kern1, snap.TypeKernel, coreDev)
+
 	// make sure it's not a trivial boot participant
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
@@ -458,7 +611,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	// the modeenv is still the same as well
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Assert(m2.CurrentKernels, DeepEquals, []string{"pc-kernel_1.snap"})
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
 
 	// finally we didn't call SetBootVars on the bootloader because nothing
 	// changed
@@ -469,28 +622,15 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	// default modeenv state
-	m := &boot.Modeenv{
-		Base:           "core20_1.snap",
-		CurrentKernels: []string{"pc-kernel_1.snap"},
-	}
-	c.Assert(m.WriteTo(""), IsNil)
-
-	// set the current kernel
-	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
 	defer r()
 
-	// make a new kernel
-	kernel2, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
-	c.Assert(err, IsNil)
-
-	// default state
-	s.bootloader.BootVars["kernel_status"] = boot.DefaultStatus
-
 	// get the boot kernel participant from our new kernel snap
-	bootKern := boot.Participant(kernel2, snap.TypeKernel, coreDev)
+	bootKern := boot.Participant(s.kern2, snap.TypeKernel, coreDev)
 	// make sure it's not a trivial boot participant
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
@@ -508,37 +648,38 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 
 	// and we were asked to enable kernel2 as the try kernel
 	actual, _ := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableTryKernel")
-	c.Assert(actual, DeepEquals, []snap.PlaceInfo{kernel2})
+	c.Assert(actual, DeepEquals, []snap.PlaceInfo{s.kern2})
 
 	// and that the modeenv now has this kernel listed
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Assert(m2.CurrentKernels, DeepEquals, []string{"pc-kernel_1.snap", "pc-kernel_2.snap"})
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename(), s.kern2.Filename()})
 }
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapCleansUp(c *C) {
-	m := &boot.Modeenv{
-		Mode:           "run",
-		RecoverySystem: "20191018",
-		Base:           "core20_1.snap",
-		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
-	}
-	c.Assert(m.WriteTo(""), IsNil)
-
 	coreDev := boottest.MockUC20Device("some-snap")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	// set kernel_status as trying, but don't set a try kernel snap
-	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
-
-	// set the current Kernel
-	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel1)
+	// set all the same vars as if we were doing trying, except don't set a try
+	// kernel
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		&uc20bootStateSetupOpts{
+			modeenv: &boot.Modeenv{
+				Mode:           "run",
+				Base:           s.base1.Filename(),
+				CurrentKernels: []string{s.kern1.Filename(), s.kern2.Filename()},
+			},
+			kern: s.kern1,
+			// no try-kernel
+			kernStatus: boot.TryingStatus,
+		},
+	)
 	defer r()
 
 	// mark successful
-	err = boot.MarkBootSuccessful(coreDev)
+	err := boot.MarkBootSuccessful(coreDev)
 	c.Assert(err, IsNil)
 
 	// check that the bootloader variable was cleaned
@@ -570,18 +711,25 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapC
 	// check that the modeenv re-wrote the CurrentKernels
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Assert(m2.CurrentKernels, DeepEquals, []string{kernel1.Filename()})
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
 }
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20BaseStatusTryingNoTryBaseSnapCleansUp(c *C) {
-	// try_base is missing from modeenv
 	m := &boot.Modeenv{
-		Mode:           "run",
-		RecoverySystem: "20191018",
-		Base:           "core20_1.snap",
-		BaseStatus:     boot.TryingStatus,
+		Mode: "run",
+		Base: s.base1.Filename(),
+		// no TryBase set
+		BaseStatus: boot.TryingStatus,
 	}
-	c.Assert(m.WriteTo(""), IsNil)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		&uc20bootStateSetupOpts{
+			modeenv: m,
+			// no kernel setup necessary
+		},
+	)
+	defer r()
 
 	coreDev := boottest.MockUC20Device("core20")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
@@ -612,19 +760,22 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameBaseSnap(c *C) {
 	coreDev := boottest.MockUC20Device("core20")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	// make a new base snap
-	base, err := snap.ParsePlaceInfoFromSnapFileName("core20_1.snap")
-	c.Assert(err, IsNil)
-
-	// default state
 	m := &boot.Modeenv{
-		Base: "core20_1.snap",
+		Mode: "run",
+		Base: s.base1.Filename(),
 	}
-	err = m.WriteTo("")
-	c.Assert(err, IsNil)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		&uc20bootStateSetupOpts{
+			modeenv: m,
+			// no kernel setup necessary
+		},
+	)
+	defer r()
 
 	// get the boot base participant from our base snap
-	bootBase := boot.Participant(base, snap.TypeBase, coreDev)
+	bootBase := boot.Participant(s.base1, snap.TypeBase, coreDev)
 	// make sure it's not a trivial boot participant
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
@@ -647,19 +798,23 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnap(c *C) {
 	coreDev := boottest.MockUC20Device("core20")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	// make a new base snap to update to
-	base2, err := snap.ParsePlaceInfoFromSnapFileName("core20_2.snap")
-	c.Assert(err, IsNil)
-
 	// default state
 	m := &boot.Modeenv{
-		Base: "core20_1.snap",
+		Mode: "run",
+		Base: s.base1.Filename(),
 	}
-	err = m.WriteTo("")
-	c.Assert(err, IsNil)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		&uc20bootStateSetupOpts{
+			modeenv: m,
+			// no kernel setup necessary
+		},
+	)
+	defer r()
 
 	// get the boot base participant from our new base snap
-	bootBase := boot.Participant(base2, snap.TypeBase, coreDev)
+	bootBase := boot.Participant(s.base2, snap.TypeBase, coreDev)
 	// make sure it's not a trivial boot participant
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
@@ -673,7 +828,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnap(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(m2.Base, Equals, m.Base)
 	c.Assert(m2.BaseStatus, Equals, boot.TryStatus)
-	c.Assert(m2.TryBase, Equals, "core20_2.snap")
+	c.Assert(m2.TryBase, Equals, s.base2.Filename())
 }
 
 func (s *bootenvSuite) TestMarkBootSuccessfulAllSnap(c *C) {
@@ -706,30 +861,27 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
 	coreDev := boottest.MockUC20Device("some-snap")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	// we were trying a base snap
+	// bonus points: we were trying both a base snap and a kernel snap
 	m := &boot.Modeenv{
-		Base:           "core20_1.snap",
-		TryBase:        "core20_2.snap",
+		Mode:           "run",
+		Base:           s.base1.Filename(),
+		TryBase:        s.base2.Filename(),
 		BaseStatus:     boot.TryingStatus,
-		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
+		CurrentKernels: []string{s.kern1.Filename(), s.kern2.Filename()},
 	}
-	c.Assert(m.WriteTo(""), IsNil)
-
-	// set the current kernel
-	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel1)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		&uc20bootStateSetupOpts{
+			modeenv:    m,
+			kern:       s.kern1,
+			tryKern:    s.kern2,
+			kernStatus: boot.TryingStatus,
+		},
+	)
 	defer r()
 
-	// set the current try kernel
-	kernel2, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
-	c.Assert(err, IsNil)
-	r = s.bootloader.SetRunKernelImageEnabledTryKernel(kernel2)
-	defer r()
-
-	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
-
-	err = boot.MarkBootSuccessful(coreDev)
+	err := boot.MarkBootSuccessful(coreDev)
 	c.Assert(err, IsNil)
 
 	// check the bootloader variables
@@ -741,7 +893,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
 
 	// check that we called EnableKernel() on the try-kernel
 	actual, _ := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
-	c.Assert(actual, DeepEquals, []snap.PlaceInfo{kernel2})
+	c.Assert(actual, DeepEquals, []snap.PlaceInfo{s.kern2})
 
 	// and that we disabled a try kernel
 	_, nDisableTryCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("DisableTryKernel")
@@ -750,10 +902,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
 	// also check that the modeenv was updated
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Assert(m2.Base, Equals, "core20_2.snap")
+	c.Assert(m2.Base, Equals, s.base2.Filename())
 	c.Assert(m2.TryBase, Equals, "")
 	c.Assert(m2.BaseStatus, Equals, boot.DefaultStatus)
-	c.Assert(m2.CurrentKernels, DeepEquals, []string{"pc-kernel_2.snap"})
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern2.Filename()})
 
 	// do it again, verify its still valid
 	err = boot.MarkBootSuccessful(coreDev)
@@ -762,7 +914,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
 
 	// no new enabled kernels
 	actual, _ = s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
-	c.Assert(actual, DeepEquals, []snap.PlaceInfo{kernel2})
+	c.Assert(actual, DeepEquals, []snap.PlaceInfo{s.kern2})
 	// we always disable the try kernel as a cleanup operation, so there's one
 	// more call here
 	_, nDisableTryCalls = s.bootloader.GetRunKernelImageFunctionSnapCalls("DisableTryKernel")
@@ -814,33 +966,29 @@ func (s *bootenvSuite) TestMarkBootSuccessfulBaseUpdate(c *C) {
 }
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
-	// default modeenv
+	// trying a kernel snap
 	m := &boot.Modeenv{
-		Base:           "core20_1.snap",
-		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
+		Mode:           "run",
+		Base:           s.base1.Filename(),
+		CurrentKernels: []string{s.kern1.Filename(), s.kern2.Filename()},
 	}
-	c.Assert(m.WriteTo(""), IsNil)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		&uc20bootStateSetupOpts{
+			modeenv:    m,
+			kern:       s.kern1,
+			tryKern:    s.kern2,
+			kernStatus: boot.TryingStatus,
+		},
+	)
+	defer r()
 
 	coreDev := boottest.MockUC20Device("some-snap")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	// set bootloader variables
-	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
-
-	// set the current Kernel
-	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel1)
-	defer r()
-
-	// set the current try kernel
-	kernel2, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
-	c.Assert(err, IsNil)
-	r = s.bootloader.SetRunKernelImageEnabledTryKernel(kernel2)
-	defer r()
-
 	// mark successful
-	err = boot.MarkBootSuccessful(coreDev)
+	err := boot.MarkBootSuccessful(coreDev)
 	c.Assert(err, IsNil)
 
 	// check the bootloader variables
@@ -849,7 +997,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 
 	// check that MarkBootSuccessful enabled the try kernel
 	actual, _ := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
-	c.Assert(actual, DeepEquals, []snap.PlaceInfo{kernel2})
+	c.Assert(actual, DeepEquals, []snap.PlaceInfo{s.kern2})
 
 	// and that we disabled a try kernel
 	_, nDisableTryCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("DisableTryKernel")
@@ -858,7 +1006,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 	// check that the new kernel is the only one in modeenv
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Assert(m2.CurrentKernels, DeepEquals, []string{"pc-kernel_2.snap"})
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern2.Filename()})
 
 	// do it again, verify its still valid
 	err = boot.MarkBootSuccessful(coreDev)
@@ -867,7 +1015,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 
 	// no new bootloader calls
 	actual, _ = s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
-	c.Assert(actual, DeepEquals, []snap.PlaceInfo{kernel2})
+	c.Assert(actual, DeepEquals, []snap.PlaceInfo{s.kern2})
 
 	// we did disable the kernel again because we always do this to cleanup in
 	// case there were leftovers
@@ -878,11 +1026,22 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 func (s *bootenv20Suite) TestMarkBootSuccessful20BaseUpdate(c *C) {
 	// we were trying a base snap
 	m := &boot.Modeenv{
-		Base:       "core20_1.snap",
-		TryBase:    "core20_2.snap",
-		BaseStatus: boot.TryingStatus,
+		Mode:           "run",
+		Base:           s.base1.Filename(),
+		TryBase:        s.base2.Filename(),
+		BaseStatus:     boot.TryingStatus,
+		CurrentKernels: []string{s.kern1.Filename()},
 	}
-	c.Assert(m.WriteTo(""), IsNil)
+	r := setupUC20Bloader(
+		c,
+		s.bootloader,
+		&uc20bootStateSetupOpts{
+			modeenv:    m,
+			kern:       s.kern1,
+			kernStatus: boot.DefaultStatus,
+		},
+	)
+	defer r()
 
 	coreDev := boottest.MockUC20Device("some-snap")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
@@ -894,7 +1053,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseUpdate(c *C) {
 	// check the modeenv
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Assert(m2.Base, Equals, "core20_2.snap")
+	c.Assert(m2.Base, Equals, s.base2.Filename())
 	c.Assert(m2.TryBase, Equals, "")
 	c.Assert(m2.BaseStatus, Equals, "")
 
@@ -905,449 +1064,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseUpdate(c *C) {
 	// check the modeenv again
 	m3, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Assert(m3.Base, Equals, "core20_2.snap")
+	c.Assert(m3.Base, Equals, s.base2.Filename())
 	c.Assert(m3.TryBase, Equals, "")
 	c.Assert(m3.BaseStatus, Equals, "")
-}
-
-// TestHappyMarkBootSuccessfulKernelRebootBeforeSetBootVars
-// emulates a reboot during SetBootVars, for the kernel snap when we
-// commit the boot state during MarkBootSuccessful
-func (s *bootenv20Suite) TestHappyMarkBootSuccessfulKernelUpgradeRebootBeforeSetBootVars(c *C) {
-	m := &boot.Modeenv{
-		Mode:           "run",
-		RecoverySystem: "20191018",
-		Base:           "core20_1.snap",
-	}
-	c.Assert(m.WriteTo(""), IsNil)
-
-	coreDev := boottest.MockUC20Device("some-snap")
-	c.Assert(coreDev.HasModeenv(), Equals, true)
-
-	// we are trying a new kernel snap
-	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
-
-	// set the current Kernel
-	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel1)
-	defer r()
-
-	// set the current try kernel
-	kernel2, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
-	c.Assert(err, IsNil)
-	r = s.bootloader.SetRunKernelImageEnabledTryKernel(kernel2)
-	defer r()
-
-	// we will panic during the next SetBootVars, which is the first step, so
-	// essentially we reboot before anything is committed
-	restoreBootloaderPanic := s.bootloader.SetRunKernelImagePanic("SetBootVars")
-
-	// attempt mark successful, expecting a panic in SetBootVars
-	c.Check(
-		func() { boot.MarkBootSuccessful(coreDev) },
-		PanicMatches,
-		"mocked reboot panic in SetBootVars",
-	)
-
-	// don't panic anymore
-	restoreBootloaderPanic()
-
-	// do the bootloader kernel failover logic handling
-	nextBootingKernel, err := runBootloaderLogic(c, s.bootloader)
-	c.Assert(err, IsNil)
-
-	// the next kernel we boot from should be kernel1, because we didn't
-	// actually commit anything
-	c.Assert(nextBootingKernel, Equals, kernel1)
-
-	// kernel_status should still be default
-	vars, err := s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-
-	// try again, should complete now
-	err = boot.MarkBootSuccessful(coreDev)
-	c.Assert(err, IsNil)
-
-	// after running now, we should still have Kernel() == pc-kernel_1.snap
-	// because the try failed
-
-	afterKernel, err := s.bootloader.Kernel()
-	c.Assert(err, IsNil)
-	c.Assert(afterKernel, DeepEquals, kernel1)
-
-	vars, err = s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-
-	// we no longer have a TryKernel() because we cleaned it up in the
-	// successful MarkBootSuccessful
-	_, err = s.bootloader.TryKernel()
-	c.Assert(err, Equals, bootloader.ErrNoTryKernelRef)
-}
-
-// TestHappyMarkBootSuccessfulKernelUpgradeRebootBeforeEnableKernel
-// emulates a reboot during EnableKernel, for the kernel snap when we
-// commit the boot state during MarkBootSuccessful
-func (s *bootenv20Suite) TestHappyMarkBootSuccessfulKernelUpgradeRebootBeforeEnableKernel(c *C) {
-	m := &boot.Modeenv{
-		Mode:           "run",
-		RecoverySystem: "20191018",
-		Base:           "core20_1.snap",
-	}
-	c.Assert(m.WriteTo(""), IsNil)
-
-	coreDev := boottest.MockUC20Device("some-snap")
-	c.Assert(coreDev.HasModeenv(), Equals, true)
-
-	// we are trying a new kernel snap
-	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
-
-	// set the current Kernel
-	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel1)
-	defer r()
-
-	// set the current try kernel
-	kernel2, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
-	c.Assert(err, IsNil)
-	r = s.bootloader.SetRunKernelImageEnabledTryKernel(kernel2)
-	defer r()
-
-	// we will panic during the next EnableKernel
-	restoreBootloaderPanic := s.bootloader.SetRunKernelImagePanic("EnableKernel")
-
-	// attempt mark successful, expecting a panic in EnableKernel
-	c.Check(
-		func() { boot.MarkBootSuccessful(coreDev) },
-		PanicMatches,
-		"mocked reboot panic in EnableKernel",
-	)
-
-	// don't panic anymore
-	restoreBootloaderPanic()
-
-	// do the bootloader kernel failover logic handling
-	nextBootingKernel, err := runBootloaderLogic(c, s.bootloader)
-	c.Assert(err, IsNil)
-
-	// the next kernel we boot from should be kernel1, because we are now in
-	// default status
-	c.Assert(nextBootingKernel, Equals, kernel1)
-
-	// we should now at least have kernel_status in default state because
-	// SetBootVars completed successfully
-	vars, err := s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-
-	// try again, should complete now
-	err = boot.MarkBootSuccessful(coreDev)
-	c.Assert(err, IsNil)
-
-	// after running now, we should still have Kernel() == pc-kernel_1.snap
-	// because the try failed
-
-	afterKernel, err := s.bootloader.Kernel()
-	c.Assert(err, IsNil)
-	c.Assert(afterKernel, DeepEquals, kernel1)
-
-	// kernel_status is still default as well
-	vars, err = s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-
-	// we no longer have a TryKernel() because we cleaned it up in the
-	// successful MarkBootSuccessful
-	_, err = s.bootloader.TryKernel()
-	c.Assert(err, Equals, bootloader.ErrNoTryKernelRef)
-}
-
-// TestHappyMarkBootSuccessfulKernelUpgradeRebootBeforeDisableTryKernel
-// emulates a reboot during DisableTryKernel, for the kernel snap when
-// we commit the boot state during MarkBootSuccessful
-func (s *bootenv20Suite) TestHappyMarkBootSuccessfulKernelUpgradeRebootBeforeDisableTryKernel(c *C) {
-	m := &boot.Modeenv{
-		Mode:           "run",
-		RecoverySystem: "20191018",
-		Base:           "core20_1.snap",
-	}
-	c.Assert(m.WriteTo(""), IsNil)
-
-	coreDev := boottest.MockUC20Device("some-snap")
-	c.Assert(coreDev.HasModeenv(), Equals, true)
-
-	// we are trying a new kernel snap
-	s.bootloader.BootVars["kernel_status"] = boot.TryingStatus
-
-	// set the current Kernel
-	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel1)
-	defer r()
-
-	// set the current try kernel
-	kernel2, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
-	c.Assert(err, IsNil)
-	r = s.bootloader.SetRunKernelImageEnabledTryKernel(kernel2)
-	defer r()
-
-	// we will panic during the next DisableTryKernel
-	restoreBootloaderPanic := s.bootloader.SetRunKernelImagePanic("DisableTryKernel")
-
-	// attempt mark successful, expecting a panic in DisableTryKernel
-	c.Check(
-		func() { boot.MarkBootSuccessful(coreDev) },
-		PanicMatches,
-		"mocked reboot panic in DisableTryKernel",
-	)
-
-	// don't panic anymore
-	restoreBootloaderPanic()
-
-	// do the bootloader kernel failover logic handling
-	nextBootingKernel, err := runBootloaderLogic(c, s.bootloader)
-	c.Assert(err, IsNil)
-
-	// the next kernel we boot from should be kernel2, because we reset
-	// kernel_status and moved the kernel.efi symlink
-	c.Assert(nextBootingKernel, Equals, kernel2)
-
-	// we should now at least have kernel_status in default state because
-	// SetBootVars completed successfully
-	vars, err := s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-
-	// try again, should complete now
-	err = boot.MarkBootSuccessful(coreDev)
-	c.Assert(err, IsNil)
-
-	// after running now, we should still have Kernel() == pc-kernel_2.snap
-	// because we moved the kernel.efi symlink
-
-	afterKernel, err := s.bootloader.Kernel()
-	c.Assert(err, IsNil)
-	c.Assert(afterKernel, DeepEquals, kernel2)
-
-	// kernel_status is still default as well
-	vars, err = s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-
-	// we no longer have a TryKernel() because we cleaned it up in the
-	// successful MarkBootSuccessful
-	_, err = s.bootloader.TryKernel()
-	c.Assert(err, Equals, bootloader.ErrNoTryKernelRef)
-}
-
-// TestHappyCoreParticipant20SetNextKernelSnapRebootBeforeEnableTryKernel
-// emulates a reboot during EnableTryKernel, for the kernel snap when
-// we commit the boot state during SetNextBoot to prepare to try a new
-// kernel snap
-func (s *bootenv20Suite) TestHappyCoreParticipant20SetNextKernelSnapRebootBeforeEnableTryKernel(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
-	c.Assert(coreDev.HasModeenv(), Equals, true)
-
-	// default modeenv state
-	m := &boot.Modeenv{
-		Base:           "core20_1.snap",
-		CurrentKernels: []string{"pc-kernel_1.snap"},
-	}
-	c.Assert(m.WriteTo(""), IsNil)
-
-	// set the current kernel
-	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel)
-	defer r()
-
-	// make a new kernel
-	kernel2, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
-	c.Assert(err, IsNil)
-
-	// default state
-	s.bootloader.BootVars["kernel_status"] = boot.DefaultStatus
-
-	// get the boot kernel participant from our new kernel snap
-	bootKern := boot.Participant(kernel2, snap.TypeKernel, coreDev)
-	// make sure it's not a trivial boot participant
-	c.Assert(bootKern.IsTrivial(), Equals, false)
-
-	// we will panic during EnableTryKernel
-	restoreBootloaderPanic := s.bootloader.SetRunKernelImagePanic("EnableTryKernel")
-
-	// attempt set next, expecting a panic in EnableTryKernel
-	c.Check(
-		func() { bootKern.SetNextBoot() },
-		PanicMatches,
-		"mocked reboot panic in EnableTryKernel",
-	)
-
-	// don't panic anymore
-	restoreBootloaderPanic()
-
-	// do the bootloader kernel failover logic handling
-	nextBootingKernel, err := runBootloaderLogic(c, s.bootloader)
-	c.Assert(err, IsNil)
-
-	// the next kernel we boot from should be kernel, because we didn't change
-	// the kernel_status, nor did we actually create a symlink
-	c.Assert(nextBootingKernel, Equals, kernel)
-
-	// kernel_status should still be in the default state
-	vars, err := s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-
-	// the modeenv now has this kernel listed
-	m2, err := boot.ReadModeenv("")
-	c.Assert(err, IsNil)
-	c.Assert(m2.CurrentKernels, DeepEquals, []string{"pc-kernel_1.snap", "pc-kernel_2.snap"})
-
-	// now, after a reboot running MarkBootSuccessful should work
-	err = boot.MarkBootSuccessful(coreDev)
-	c.Assert(err, IsNil)
-
-	// after running now, we should still have Kernel() == pc-kernel_1.snap
-	// because nothing was committed
-	afterKernel, err := s.bootloader.Kernel()
-	c.Assert(err, IsNil)
-	c.Assert(afterKernel, DeepEquals, kernel)
-
-	// kernel_status is still default as well
-	vars, err = s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-}
-
-// TestHappyCoreParticipant20SetNextKernelSnapRebootBeforeSetBootVars
-// emulates a reboot during SetBootVars, for the kernel snap when we
-// commit the boot state during SetNextBoot to prepare to try a new
-// kernel snap
-func (s *bootenv20Suite) TestHappyCoreParticipant20SetNextKernelSnapRebootBeforeSetBootVars(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
-	c.Assert(coreDev.HasModeenv(), Equals, true)
-
-	// default modeenv state
-	m := &boot.Modeenv{
-		Base:           "core20_1.snap",
-		CurrentKernels: []string{"pc-kernel_1.snap"},
-	}
-	c.Assert(m.WriteTo(""), IsNil)
-
-	// set the current kernel
-	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
-	c.Assert(err, IsNil)
-	r := s.bootloader.SetRunKernelImageEnabledKernel(kernel)
-	defer r()
-
-	// make a new kernel
-	kernel2, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
-	c.Assert(err, IsNil)
-
-	// default state
-	s.bootloader.BootVars["kernel_status"] = boot.DefaultStatus
-
-	// get the boot kernel participant from our new kernel snap
-	bootKern := boot.Participant(kernel2, snap.TypeKernel, coreDev)
-	// make sure it's not a trivial boot participant
-	c.Assert(bootKern.IsTrivial(), Equals, false)
-
-	// we will panic during SetBootVars
-	restoreBootloaderPanic := s.bootloader.SetRunKernelImagePanic("SetBootVars")
-
-	// attempt set next, expecting a panic in SetBootVars
-	c.Check(
-		func() { bootKern.SetNextBoot() },
-		PanicMatches,
-		"mocked reboot panic in SetBootVars",
-	)
-
-	// don't panic anymore
-	restoreBootloaderPanic()
-
-	// do the bootloader kernel failover logic handling
-	nextBootingKernel, err := runBootloaderLogic(c, s.bootloader)
-	c.Assert(err, IsNil)
-
-	// the next kernel we boot from should be kernel, because we didn't change
-	// the kernel_status
-	c.Assert(nextBootingKernel, Equals, kernel)
-
-	// we should now at least have kernel_status in default state because
-	// SetBootVars completed successfully
-	vars, err := s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-
-	// the modeenv now has this kernel listed however
-	m2, err := boot.ReadModeenv("")
-	c.Assert(err, IsNil)
-	c.Assert(m2.CurrentKernels, DeepEquals, []string{"pc-kernel_1.snap", "pc-kernel_2.snap"})
-
-	// now, after a reboot running MarkBootSuccessful should work
-	err = boot.MarkBootSuccessful(coreDev)
-	c.Assert(err, IsNil)
-
-	// after running now, we should still have Kernel() == pc-kernel_1.snap
-	// because nothing was committed
-	afterKernel, err := s.bootloader.Kernel()
-	c.Assert(err, IsNil)
-	c.Assert(afterKernel, DeepEquals, kernel)
-
-	// kernel_status is still default as well
-	vars, err = s.bootloader.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	c.Assert(vars, DeepEquals, map[string]string{"kernel_status": boot.DefaultStatus})
-
-	// we no longer have a TryKernel() because we cleaned it up in the
-	// successful MarkBootSuccessful
-	_, err = s.bootloader.TryKernel()
-	c.Assert(err, Equals, bootloader.ErrNoTryKernelRef)
-}
-
-// runBootloaderLogic implements the logic from the gadget snap bootloader,
-// namely that we transition kernel_status "try" -> "trying" and "trying" -> ""
-// and use try-kernel.efi when kernel_status is "try" and kernel.efi in all
-// other situations
-func runBootloaderLogic(c *C, ebl bootloader.ExtractedRunKernelImageBootloader) (snap.PlaceInfo, error) {
-	m, err := ebl.GetBootVars("kernel_status")
-	c.Assert(err, IsNil)
-	kernStatus := m["kernel_status"]
-
-	changed := false
-
-	kern, err := ebl.Kernel()
-	c.Assert(err, IsNil)
-	c.Assert(kern, Not(IsNil))
-
-	switch kernStatus {
-	case boot.DefaultStatus:
-	case boot.TryStatus:
-		// move to trying, use the try-kernel
-		m["kernel_status"] = boot.TryingStatus
-		changed = true
-
-		// ensure that the try-kernel exists
-		tryKern, err := ebl.TryKernel()
-		c.Assert(err, IsNil)
-		c.Assert(tryKern, Not(IsNil))
-		kern = tryKern
-
-	case boot.TryingStatus:
-		// boot failed, move back to default
-		m["kernel_status"] = boot.DefaultStatus
-		changed = true
-	}
-
-	if changed {
-		err = ebl.SetBootVars(m)
-		c.Assert(err, IsNil)
-	}
-	return kern, nil
 }
 
 type recoveryBootenv20Suite struct {

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -149,7 +149,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
 		s.normalDefaultState,
@@ -215,7 +215,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
 		s.normalDefaultState,
@@ -288,10 +288,10 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C)
 
 	// set all the same vars as if we were doing trying, except don't set a try
 	// kernel
-	r := setupUC20Bloader(
+	r := setupUC20Bootenv(
 		c,
 		s.bootloader,
-		&uc20bootStateSetupOpts{
+		&bootenv20Setup{
 			modeenv: &boot.Modeenv{
 				Mode:           "run",
 				Base:           s.base1.Filename(),


### PR DESCRIPTION
This is stacked on top of https://github.com/snapcore/snapd/pull/8510, but there are no behavioral changes contained here, it's all in test refactoring. As such, I would recommend waiting until that is merged to review this...

* Add a new file boot_robustness_test.go which houses all of the tests about functions being robust against getting rebooted during the middle of executing
* Add new helper about setting up boot state as pre-reqs for testing things and use this setupUC20Bloader helper everywhere. setupUC20Bloader is generic such that it can works with bootloadertest.MockExtractedRunKernelImageBootloader like we currently test, and with future bootstate20 implementations that will just use bootloadertest.MockBootloader and just manipulate the environment.
* Add common constants for common kernel and base snaps that are used in tests.
* Add common setup option sets to be shared across different tests.
