### PR TITLE
boot/bootstate20: add EnvRefExtractedKernelBootloader bootstate20 implementation

### DIFF
--- a/boot/boot_robustness_test.go
+++ b/boot/boot_robustness_test.go
@@ -293,7 +293,7 @@ func (s *bootenv20Suite) TestHappySetNextBoot20KernelUpgradeUnexpectedReboots(c 
 			coreDev,
 			setNextFunc,
 			t.rebootBeforeFunc,
-			t.expBlKernel,
+			t.expBootKernel,
 			t.expModeenvKernels,
 			t.expBlKernel,
 			t.comment,

--- a/boot/boot_robustness_test.go
+++ b/boot/boot_robustness_test.go
@@ -205,29 +205,29 @@ func (s *bootenv20Suite) TestHappyMarkBootSuccessful20KernelUpgradeUnexpectedReb
 		{
 			"",                        // don't do any reboots for the happy path
 			s.kern2,                   // we should boot the new kernel
-			[]snap.PlaceInfo{s.kern2}, // expected kernel is new one
-			s.kern2,                   // the expected kernel is the new one
+			[]snap.PlaceInfo{s.kern2}, // expected modeenv kernel is new one
+			s.kern2,                   // after reboot, current kernel on bl is new one
 			"happy path",
 		},
 		{
 			"SetBootVars",             // reboot right before SetBootVars
 			s.kern1,                   // we should boot the old kernel
-			[]snap.PlaceInfo{s.kern1}, // expected kernel is old one
-			s.kern1,                   // the expected kernel is the old one
+			[]snap.PlaceInfo{s.kern1}, // expected modeenv kernel is old one
+			s.kern1,                   // after reboot, current kernel on bl is old one
 			"reboot before SetBootVars results in old kernel",
 		},
 		{
 			"EnableKernel",            // reboot right before EnableKernel
 			s.kern1,                   // we should boot the old kernel
-			[]snap.PlaceInfo{s.kern1}, // expected kernel is old one
-			s.kern1,                   // the expected kernel is the old one
+			[]snap.PlaceInfo{s.kern1}, // expected modeenv kernel is old one
+			s.kern1,                   // after reboot, current kernel on bl is old one
 			"reboot before EnableKernel results in old kernel",
 		},
 		{
 			"DisableTryKernel",        // reboot right before DisableTryKernel
 			s.kern2,                   // we should boot the new kernel
-			[]snap.PlaceInfo{s.kern2}, // expected kernel is new one
-			s.kern2,                   // the expected kernel is the new one
+			[]snap.PlaceInfo{s.kern2}, // expected modeenv kernel is new one
+			s.kern2,                   // after reboot, current kernel on bl is new one
 			"reboot before DisableTryKernel results in new kernel",
 		},
 	}
@@ -269,22 +269,22 @@ func (s *bootenv20Suite) TestHappySetNextBoot20KernelUpgradeUnexpectedReboots(c 
 		{
 			"",                        // don't do any reboots for the happy path
 			s.kern2,                   // we should boot the new kernel
-			[]snap.PlaceInfo{s.kern2}, // expected kernel is new one
-			s.kern1,                   // the expected kernel is the old one
+			[]snap.PlaceInfo{s.kern2}, // final expected modeenv kernel is new one
+			s.kern1,                   // after reboot, current kernel on bl is old one
 			"happy path",
 		},
 		{
 			"EnableTryKernel",         // reboot right before EnableTryKernel
 			s.kern1,                   // we should boot the old kernel
-			[]snap.PlaceInfo{s.kern1}, // expected kernel is old one
-			s.kern1,                   // the expected kernel is the old one
+			[]snap.PlaceInfo{s.kern1}, // final expected modeenv kernel is old one
+			s.kern1,                   // after reboot, current kernel on bl is old one
 			"reboot before EnableTryKernel results in old kernel",
 		},
 		{
 			"SetBootVars",             // reboot right before SetBootVars
 			s.kern1,                   // we should boot the old kernel
-			[]snap.PlaceInfo{s.kern1}, // expected kernel is old one
-			s.kern1,                   // the expected kernel is the old one
+			[]snap.PlaceInfo{s.kern1}, // final expected modeenv kernel is old one
+			s.kern1,                   // after reboot, current kernel on bl is old one
 			"reboot before SetBootVars results in old kernel",
 		},
 	}

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -186,11 +186,7 @@ type bootenv20Setup struct {
 	kernStatus string
 }
 
-func setupUC20Bootenv(
-	c *C,
-	bl bootloader.Bootloader,
-	opts *bootenv20Setup,
-) (restore func()) {
+func setupUC20Bootenv(c *C, bl bootloader.Bootloader, opts *bootenv20Setup) (restore func()) {
 	var cleanups []func()
 
 	// write the modeenv

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -154,7 +154,7 @@ type bootenv20Suite struct {
 	bootloader *bootloadertest.MockExtractedRunKernelImageBootloader
 }
 
-type bootenv20LegacyKernelSuite struct {
+type bootenv20EnvRefKernelSuite struct {
 	baseBootenv20Suite
 
 	bootloader *bootloadertest.MockBootloader
@@ -163,7 +163,7 @@ type bootenv20LegacyKernelSuite struct {
 var defaultUC20BootEnv = map[string]string{"kernel_status": boot.DefaultStatus}
 
 var _ = Suite(&bootenv20Suite{})
-var _ = Suite(&bootenv20LegacyKernelSuite{})
+var _ = Suite(&bootenv20EnvRefKernelSuite{})
 
 func (s *bootenv20Suite) SetUpTest(c *C) {
 	s.baseBootenv20Suite.SetUpTest(c)
@@ -172,7 +172,7 @@ func (s *bootenv20Suite) SetUpTest(c *C) {
 	s.forceBootloader(s.bootloader)
 }
 
-func (s *bootenv20LegacyKernelSuite) SetUpTest(c *C) {
+func (s *bootenv20EnvRefKernelSuite) SetUpTest(c *C) {
 	s.baseBootenv20Suite.SetUpTest(c)
 
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
@@ -398,7 +398,7 @@ func (s *bootenv20Suite) TestCurrentBoot20NameAndRevision(c *C) {
 
 // only difference between this test and TestCurrentBoot20NameAndRevision is the
 // base bootloader which doesn't support ExtractedRunKernelImageBootloader.
-func (s *bootenv20LegacyKernelSuite) TestCurrentBoot20NameAndRevision(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestCurrentBoot20NameAndRevision(c *C) {
 	coreDev := boottest.MockUC20Device("some-snap")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
@@ -651,7 +651,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	c.Assert(s.bootloader.SetBootVarsCalls, Equals, 0)
 }
 
-func (s *bootenv20LegacyKernelSuite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
@@ -730,7 +730,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename(), s.kern2.Filename()})
 }
 
-func (s *bootenv20LegacyKernelSuite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
@@ -823,7 +823,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapC
 	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
 }
 
-func (s *bootenv20LegacyKernelSuite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapCleansUp(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapCleansUp(c *C) {
 	coreDev := boottest.MockUC20Device("some-snap")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
@@ -1076,7 +1076,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
 	c.Assert(nDisableTryCalls, Equals, 2)
 }
 
-func (s *bootenv20LegacyKernelSuite) TestMarkBootSuccessful20AllSnap(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestMarkBootSuccessful20AllSnap(c *C) {
 	coreDev := boottest.MockUC20Device("some-snap")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
@@ -1229,7 +1229,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 	c.Assert(nDisableTryCalls, Equals, 2)
 }
 
-func (s *bootenv20LegacyKernelSuite) TestMarkBootSuccessful20KernelUpdate(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 	// trying a kernel snap
 	m := &boot.Modeenv{
 		Mode:           "run",

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -233,10 +233,10 @@ func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernel(sn snap.P
 	return nil
 }
 
-// pureEnvironmentBootloaderKernelState implements bootloaderKernelState20 for
+// envRefExtractedKernelBootloaderKernelState implements bootloaderKernelState20 for
 // bootloaders that only support using bootenv and i.e. don't support
 // ExtractedRunKernelImageBootloader
-type pureEnvironmentBootloaderKernelState struct {
+type envRefExtractedKernelBootloaderKernelState struct {
 	// the bootloader
 	bl bootloader.Bootloader
 
@@ -250,7 +250,7 @@ type pureEnvironmentBootloaderKernelState struct {
 	kern snap.PlaceInfo
 }
 
-func (envbks *pureEnvironmentBootloaderKernelState) load() error {
+func (envbks *envRefExtractedKernelBootloaderKernelState) load() error {
 	// for uc20, we only care about kernel_status, snap_kernel, and
 	// snap_try_kernel
 	m, err := envbks.bl.GetBootVars("kernel_status", "snap_kernel", "snap_try_kernel")
@@ -277,11 +277,11 @@ func (envbks *pureEnvironmentBootloaderKernelState) load() error {
 	return nil
 }
 
-func (envbks *pureEnvironmentBootloaderKernelState) kernel() snap.PlaceInfo {
+func (envbks *envRefExtractedKernelBootloaderKernelState) kernel() snap.PlaceInfo {
 	return envbks.kern
 }
 
-func (envbks *pureEnvironmentBootloaderKernelState) tryKernel() (snap.PlaceInfo, error) {
+func (envbks *envRefExtractedKernelBootloaderKernelState) tryKernel() (snap.PlaceInfo, error) {
 	// empty snap_try_kernel is special case
 	if envbks.env["snap_try_kernel"] == "" {
 		return nil, bootloader.ErrNoTryKernelRef
@@ -294,11 +294,11 @@ func (envbks *pureEnvironmentBootloaderKernelState) tryKernel() (snap.PlaceInfo,
 	return sn, nil
 }
 
-func (envbks *pureEnvironmentBootloaderKernelState) kernelStatus() string {
+func (envbks *envRefExtractedKernelBootloaderKernelState) kernelStatus() string {
 	return envbks.env["kernel_status"]
 }
 
-func (envbks *pureEnvironmentBootloaderKernelState) commonStateCommitUpdate(sn snap.PlaceInfo, bootvar string) bool {
+func (envbks *envRefExtractedKernelBootloaderKernelState) commonStateCommitUpdate(sn snap.PlaceInfo, bootvar string) bool {
 	bootenvChanged := false
 
 	// check kernel_status
@@ -315,7 +315,7 @@ func (envbks *pureEnvironmentBootloaderKernelState) commonStateCommitUpdate(sn s
 	return bootenvChanged
 }
 
-func (envbks *pureEnvironmentBootloaderKernelState) markSuccessfulKernel(sn snap.PlaceInfo) error {
+func (envbks *envRefExtractedKernelBootloaderKernelState) markSuccessfulKernel(sn snap.PlaceInfo) error {
 	// the ordering here doesn't matter, as the only actual state we mutate is
 	// writing the boot vars/bootenv, so just do that once at the end after
 	// processing all the changes
@@ -339,7 +339,7 @@ func (envbks *pureEnvironmentBootloaderKernelState) markSuccessfulKernel(sn snap
 	return nil
 }
 
-func (envbks *pureEnvironmentBootloaderKernelState) setNextKernel(sn snap.PlaceInfo, status string) error {
+func (envbks *envRefExtractedKernelBootloaderKernelState) setNextKernel(sn snap.PlaceInfo, status string) error {
 	envbks.toCommit["kernel_status"] = status
 	bootenvChanged := envbks.commonStateCommitUpdate(sn, "snap_try_kernel")
 
@@ -395,7 +395,7 @@ func (ks20 *bootState20Kernel) loadBootenv() error {
 		ks20.bks = &extractedRunKernelImageBootloaderKernelState{ebl: ebl}
 	} else {
 		// use fallback pure bootenv implementation
-		ks20.bks = &pureEnvironmentBootloaderKernelState{bl: bl}
+		ks20.bks = &envRefExtractedKernelBootloaderKernelState{bl: bl}
 	}
 
 	// setup the bootloaderKernelState20

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -188,6 +188,37 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
 	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename(), s.kern2.Filename()})
 }
 
+func (s *bootenv20LegacyKernelSuite) TestSetNextBoot20ForKernel(c *C) {
+	coreDev := boottest.MockUC20Device("pc-kernel")
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
+	defer r()
+
+	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
+	c.Assert(bs.IsTrivial(), Equals, false)
+	reboot, err := bs.SetNextBoot()
+	c.Assert(err, IsNil)
+
+	m := s.bootloader.BootVars
+	c.Assert(m, DeepEquals, map[string]string{
+		"kernel_status":   boot.TryStatus,
+		"snap_try_kernel": s.kern2.Filename(),
+		"snap_kernel":     s.kern1.Filename(),
+	})
+
+	c.Check(reboot, Equals, true)
+
+	// and that the modeenv now has this kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename(), s.kern2.Filename()})
+}
+
 func (s *bootenvSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 	coreDev := boottest.MockDevice("krnl")
 
@@ -247,6 +278,38 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 	// check that SetNextBoot asked the bootloader for a kernel
 	_, nKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("Kernel")
 	c.Assert(nKernelCalls, Equals, 1)
+
+	// and that the modeenv now has this kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
+}
+
+func (s *bootenv20LegacyKernelSuite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
+	coreDev := boottest.MockUC20Device("pc-kernel")
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
+	defer r()
+
+	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
+	c.Assert(bs.IsTrivial(), Equals, false)
+	reboot, err := bs.SetNextBoot()
+	c.Assert(err, IsNil)
+
+	// check that kernel_status is cleared
+	m := s.bootloader.BootVars
+	c.Assert(m, DeepEquals, map[string]string{
+		"kernel_status":   boot.DefaultStatus,
+		"snap_kernel":     s.kern1.Filename(),
+		"snap_try_kernel": "",
+	})
+
+	c.Check(reboot, Equals, false)
 
 	// and that the modeenv now has this kernel listed
 	m2, err := boot.ReadModeenv("")
@@ -329,6 +392,49 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C)
 	// check that SetNextBoot asked the bootloader for a kernel
 	_, nKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("Kernel")
 	c.Assert(nKernelCalls, Equals, 1)
+
+	// and that the modeenv didn't change
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
+}
+
+func (s *bootenv20LegacyKernelSuite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C) {
+	coreDev := boottest.MockUC20Device("pc-kernel")
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	// set all the same vars as if we were doing trying, except don't set a try
+	// kernel
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		&bootenv20Setup{
+			modeenv: &boot.Modeenv{
+				Mode:           "run",
+				Base:           s.base1.Filename(),
+				CurrentKernels: []string{s.kern1.Filename()},
+			},
+			kern: s.kern1,
+			// no try-kernel
+			kernStatus: boot.TryStatus,
+		},
+	)
+	defer r()
+
+	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
+	c.Assert(bs.IsTrivial(), Equals, false)
+	reboot, err := bs.SetNextBoot()
+	c.Assert(err, IsNil)
+
+	// check that kernel_status is cleared
+	m := s.bootloader.BootVars
+	c.Assert(m, DeepEquals, map[string]string{
+		"kernel_status":   boot.DefaultStatus,
+		"snap_kernel":     s.kern1.Filename(),
+		"snap_try_kernel": "",
+	})
+
+	c.Check(reboot, Equals, false)
 
 	// and that the modeenv didn't change
 	m2, err := boot.ReadModeenv("")

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -188,7 +188,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
 	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename(), s.kern2.Filename()})
 }
 
-func (s *bootenv20LegacyKernelSuite) TestSetNextBoot20ForKernel(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernel(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
@@ -285,7 +285,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
 }
 
-func (s *bootenv20LegacyKernelSuite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
@@ -399,7 +399,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C)
 	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
 }
 
-func (s *bootenv20LegacyKernelSuite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C) {
 	coreDev := boottest.MockUC20Device("pc-kernel")
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 


### PR DESCRIPTION
This implements bootstate20 updates for bootloaders which do not implement ExtractedRunKernelImageBootloader, such as u-boot and lk. The tests here are mainly just slight modifications to the existing ones that exercise extractedRunKernelImageBootloaderKernelState. I didn't write robustness tests here because there's only one critical operation, but I could write that if folks really want me to. 