### PR TITLE
tests: disable special-home-can-run-classic-snaps due to jenkins repo issue

### DIFF
--- a/tests/main/special-home-can-run-classic-snaps/task.yaml
+++ b/tests/main/special-home-can-run-classic-snaps/task.yaml
@@ -1,6 +1,10 @@
 summary: Check that users with homes in /var/lib can run *classic* snaps
 
 systems: [ubuntu-16.04-64]
+
+# XXX: disabled for now due to an issue with jenkins repo auth key
+manual: true
+
 environment:
     SPECIAL_USER_NAME/jenkins: jenkins
     SPECIAL_USER_NAME/postgres: postgres


### PR DESCRIPTION
The test seems to be failing right now due to an upstream issue with their repo key. Will propose a PR to re-enable once this lands.
