### PR TITLE
snap-bootstrap,secboot: clear tpm if provisioning fails

### DIFF
--- a/secboot/tpm.go
+++ b/secboot/tpm.go
@@ -35,6 +35,10 @@ const (
 	pinHandle = 0x01800000
 )
 
+func RequestTPMClearInNextBoot() error {
+	return sb.RequestTPMClearUsingPPI()
+}
+
 type tpmSupport struct {
 	// Connection to the TPM device
 	tconn *sb.TPMConnection


### PR DESCRIPTION
If provisioning fails, ask the firmware to clear the TPM on the
next reboot, and reboot the system.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
