### PR TITLE
asserts: introduce ModelGrade.Code

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -342,7 +342,7 @@ const (
 var validModelGrades = []string{string(ModelSecured), string(ModelSigned), string(ModelDangerous)}
 
 // gradeToCode encodes grades into 32 bits, trying to be slightly future-proof:
-// * lower 16 bits are reversed
+// * lower 16 bits are reserved
 // * in the higher bits use the sequence 1, 8, 16 to have some space
 //   to possibly add new grades in between
 var gradeToCode = map[ModelGrade]uint32{
@@ -352,7 +352,8 @@ var gradeToCode = map[ModelGrade]uint32{
 	ModelSecured:    0x100000,
 }
 
-// Code returns a bit representation of the grade.
+// Code returns a bit representation of the grade, for example for
+// measuring it in a full disk encryption implementation.
 func (mg ModelGrade) Code() uint32 {
 	code, ok := gradeToCode[mg]
 	if !ok {

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -341,6 +341,26 @@ const (
 
 var validModelGrades = []string{string(ModelSecured), string(ModelSigned), string(ModelDangerous)}
 
+// gradeToCode encodes grades into 32 bits, trying to be slightly future-proof:
+// * lower 16 bits are reversed
+// * in the higher bits use the sequence 1, 8, 16 to have some space
+//   to possibly add new grades in between
+var gradeToCode = map[ModelGrade]uint32{
+	ModelGradeUnset: 0,
+	ModelDangerous:  0x10000,
+	ModelSigned:     0x80000,
+	ModelSecured:    0x100000,
+}
+
+// Code returns a bit representation of the grade.
+func (mg ModelGrade) Code() uint32 {
+	code, ok := gradeToCode[mg]
+	if !ok {
+		panic(fmt.Sprintf("unknown model grade: %s", mg))
+	}
+	return code
+}
+
 // Model holds a model assertion, which is a statement by a brand
 // about the properties of a device model.
 type Model struct {

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -762,6 +762,23 @@ func (mods *modelSuite) TestCore20ValidGrades(c *C) {
 	}
 }
 
+func (mods *modelSuite) TestModelGradeCode(c *C) {
+	for i, grade := range []asserts.ModelGrade{asserts.ModelGradeUnset, asserts.ModelDangerous, asserts.ModelSigned, asserts.ModelSecured} {
+		// unset is represented as zero
+		code := 0
+		if i > 0 {
+			// have some space between grades to add new ones
+			n := (i - 1) * 8
+			if n == 0 {
+				n = 1 // dangerous
+			}
+			// lower 16 bits are reserved
+			code = n << 16
+		}
+		c.Check(grade.Code(), Equals, uint32(code))
+	}
+}
+
 func (mods *modelSuite) TestCore20GradeDangerous(c *C) {
 	encoded := strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1)
 	encoded = strings.Replace(encoded, "OTHER", "", 1)

--- a/tests/lib/preseed.sh
+++ b/tests/lib/preseed.sh
@@ -44,6 +44,7 @@ setup_preseeding() {
     local IMAGE_MOUNTPOINT=$1
     local CORE_IMAGE
 
+    # TODO: on 20.04 there is no core_*.snap anymore, just snapd
     CORE_IMAGE=$(find "$IMAGE_MOUNTPOINT/var/lib/snapd/seed/snaps/" -name "core_*.snap")
     unsquashfs "$CORE_IMAGE"
     cp /usr/lib/snapd/snapd squashfs-root/usr/lib/snapd/snapd

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -3,7 +3,8 @@ description: |
   This test checks that preseeding of Ubuntu cloud images with snap-preseed
   can be undone with --reset flag.
 
-systems: [ubuntu-19.10-*,ubuntu-20.04-*]
+# TODO: reenable for ubuntu-20.04-*, that now uses the snapd snap
+systems: [ubuntu-19.10-*]
 
 environment:
   IMAGE_MOUNTPOINT: /mnt/cloudimg

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -4,7 +4,8 @@ description: |
   command works, up to the point where the image is ready to be booted.
   The test assumes cloud image with a core and lxd snaps in its seeds/.
 
-systems: [ubuntu-19.10-*,ubuntu-20.04-*]
+# TODO: reenable for ubuntu-20.04-*, that now uses the snapd snap
+systems: [ubuntu-19.10-*]
 
 environment:
   IMAGE_MOUNTPOINT: /mnt/cloudimg


### PR DESCRIPTION
the use case is having a fixed size bit representation of grades for measuring in secboot code

