### PR TITLE
tests: ignore user-12345 slice and service

### DIFF
--- a/tests/main/snap-confine-undesired-mode-group/task.yaml
+++ b/tests/main/snap-confine-undesired-mode-group/task.yaml
@@ -18,8 +18,8 @@ execute: |
     # the group of the calling user and did not manage that properly.
     for dname in /run/snapd /sys/fs/cgroup /tmp/snap.*; do
         # Filter out cgroups that are expected to be owned by the test user.
-        find "$dname" -user test ! -path '*/user@12345.service/*' >> wrong-user.txt
-        find "$dname" -group test ! -path '*/user@12345.service/*' >> wrong-group.txt
+        find "$dname" -user test ! -path '*/user@12345.service*' ! -path '*/user-12345.slice*' >> wrong-user.txt
+        find "$dname" -group test ! -path '*/user@12345.service*' ! -path '*/user-12345.slice*' >> wrong-group.txt
         # Filter out the following elements:
         # - sockets, we don't create any and there are some that are 777
         # - symbolic links, those are always 777


### PR DESCRIPTION
The tests/main/snap-confine/undesired-user-mode-group test is randomly
picking up the legitimate user session cgroup left-overs that should not
be measured here.

The interesting finding of this patch is that there are two general
forms, the one we already captured, with the user@12345.service earlier
in the chain and then the one where user-12345.slice is the parent of
the user@12345.service, oh well, systemd just changing things along the
way.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
