### PR TITLE
seed: clearer errors for missing essential snapd or core snap

### DIFF
--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -244,11 +244,11 @@ func (s *seed20) loadAuxInfos() error {
 	return nil
 }
 
-type NoSnapDeclarationError struct {
+type noSnapDeclarationError struct {
 	snapRef naming.SnapRef
 }
 
-func (e *NoSnapDeclarationError) Error() string {
+func (e *noSnapDeclarationError) Error() string {
 	snapID := e.snapRef.ID()
 	if snapID != "" {
 		return fmt.Sprintf("cannot find snap-declaration for snap-id: %s", snapID)
@@ -261,7 +261,7 @@ func (s *seed20) lookupVerifiedRevision(snapRef naming.SnapRef, snapsDir string)
 	if snapID != "" {
 		snapDecl = s.snapDeclsByID[snapID]
 		if snapDecl == nil {
-			return "", nil, nil, &NoSnapDeclarationError{snapRef}
+			return "", nil, nil, &noSnapDeclarationError{snapRef}
 		}
 	} else {
 		if s.model.Grade() != asserts.ModelDangerous {
@@ -270,7 +270,7 @@ func (s *seed20) lookupVerifiedRevision(snapRef naming.SnapRef, snapsDir string)
 		snapName := snapRef.SnapName()
 		snapDecl = s.snapDeclsByName[snapName]
 		if snapDecl == nil {
-			return "", nil, nil, &NoSnapDeclarationError{snapRef}
+			return "", nil, nil, &noSnapDeclarationError{snapRef}
 		}
 		snapID = snapDecl.SnapID()
 	}
@@ -455,7 +455,7 @@ func (s *seed20) loadModelMeta(filterEssential func(*asserts.ModelSnap) bool, tm
 			if err == errFiltered {
 				continue
 			}
-			if _, ok := err.(*NoSnapDeclarationError); ok && modelSnap.Presence == "optional" {
+			if _, ok := err.(*noSnapDeclarationError); ok && modelSnap.Presence == "optional" {
 				// skipped optional snap is ok
 				continue
 			}

--- a/seed/validate.go
+++ b/seed/validate.go
@@ -97,6 +97,13 @@ func ValidateFromYaml(seedYamlFile string) error {
 
 	tm := timings.New(nil)
 	if err := seed.LoadMeta(tm); err != nil {
+		if missingErr, ok := err.(*essentialSnapMissingError); ok {
+			// Model always succeed after LoadAssertions
+			mod, _ := seed.Model()
+			if mod.Classic() && missingErr.SnapName == "core" {
+				err = fmt.Errorf("essential snap core or snapd must be part of the seed")
+			}
+		}
 		return newValidationError("", err)
 	}
 


### PR DESCRIPTION
improve errors related to missing snapd or core snap

one is really fixing a regression in clarity since we switched
validation to use Seed, this was noted/reported by Robert C Jennings
