### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: support EnvRefExtractedKernelBootloader's

### DIFF
--- a/boot/boottest/bootenv.go
+++ b/boot/boottest/bootenv.go
@@ -29,18 +29,28 @@ import (
 // Bootenv16 implements manipulating a UC16/18 boot env for testing.
 type Bootenv16 struct {
 	*bootloadertest.MockBootloader
+	statusVar string
 }
 
 // MockUC16Bootenv wraps a mock bootloader for UC16/18 boot env
 // manipulation.
 func MockUC16Bootenv(b *bootloadertest.MockBootloader) *Bootenv16 {
-	return &Bootenv16{b}
+	return &Bootenv16{
+		MockBootloader: b,
+		statusVar:      "snap_mode",
+	}
 }
 
 // SetBootKernel sets the current boot kernel string. Should be
 // something like "pc-kernel_1234.snap".
 func (b16 Bootenv16) SetBootKernel(kernel string) {
 	b16.SetBootVars(map[string]string{"snap_kernel": kernel})
+}
+
+// SetBootTryKernel sets the try boot kernel string. Should be
+// something like "pc-kernel_1235.snap".
+func (b16 Bootenv16) SetBootTryKernel(kernel string) {
+	b16.SetBootVars(map[string]string{"snap_try_kernel": kernel})
 }
 
 // SetBootBase sets the current boot base string. Should be something
@@ -52,10 +62,10 @@ func (b16 Bootenv16) SetBootBase(base string) {
 // SetTryingDuringReboot indicates that new kernel or base are being tried
 // same as done by bootloader config.
 func (b16 Bootenv16) SetTryingDuringReboot(which []snap.Type) error {
-	if b16.BootVars["snap_mode"] != "try" {
+	if b16.BootVars[b16.statusVar] != "try" {
 		return fmt.Errorf("bootloader must be in 'try' mode")
 	}
-	b16.BootVars["snap_mode"] = "trying"
+	b16.BootVars[b16.statusVar] = "trying"
 	return nil
 }
 
@@ -85,7 +95,7 @@ func exactlyType(which []snap.Type, t snap.Type) bool {
 // in "snap_{core,kernel}" will be used. which indicates whether rollback
 // applies to kernel, base or both.
 func (b16 Bootenv16) SetRollbackAcrossReboot(which []snap.Type) error {
-	if b16.BootVars["snap_mode"] != "try" {
+	if b16.BootVars[b16.statusVar] != "try" {
 		return fmt.Errorf("rollback can only be simulated in 'try' mode")
 	}
 	rollbackBase := includesType(which, snap.TypeBase)
@@ -99,8 +109,8 @@ func (b16 Bootenv16) SetRollbackAcrossReboot(which []snap.Type) error {
 	if rollbackKernel && b16.BootVars["snap_kernel"] == "" {
 		return fmt.Errorf("kernel rollback can only be simulated if snap_kernel is set")
 	}
-	// clean try bootvars and snap_mode
-	b16.BootVars["snap_mode"] = ""
+	// clean try bootvars and statusVar
+	b16.BootVars[b16.statusVar] = ""
 	if rollbackBase {
 		b16.BootVars["snap_try_core"] = ""
 	}
@@ -110,10 +120,19 @@ func (b16 Bootenv16) SetRollbackAcrossReboot(which []snap.Type) error {
 	return nil
 }
 
-// RunBootenv16 implements manipulating a UC20 run-mode boot env for
+// RunBootenv20 implements manipulating a UC20 run-mode boot env for
 // testing.
 type RunBootenv20 struct {
 	*bootloadertest.MockExtractedRunKernelImageBootloader
+}
+
+// MockUC20EnvRefExtractedKernelRunBootenv wraps a mock bootloader for UC20 run-mode boot
+// env manipulation.
+func MockUC20EnvRefExtractedKernelRunBootenv(b *bootloadertest.MockBootloader) *Bootenv16 {
+	return &Bootenv16{
+		MockBootloader: b,
+		statusVar:      "kernel_status",
+	}
 }
 
 // MockUC20RunBootenv wraps a mock bootloader for UC20 run-mode boot

--- a/boot/boottest/bootenv.go
+++ b/boot/boottest/bootenv.go
@@ -129,6 +129,8 @@ type RunBootenv20 struct {
 // MockUC20EnvRefExtractedKernelRunBootenv wraps a mock bootloader for UC20 run-mode boot
 // env manipulation.
 func MockUC20EnvRefExtractedKernelRunBootenv(b *bootloadertest.MockBootloader) *Bootenv16 {
+	// TODO:UC20: implement this w/o returning Bootenv16 because that doesn't
+	//            make a lot of sense to the caller
 	return &Bootenv16{
 		MockBootloader: b,
 		statusVar:      "kernel_status",

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -326,62 +326,6 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2LegacyKernelBootstate(c *C) {
-	n := 0
-	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
-
-	restore := main.MockOsutilIsMounted(func(path string) (bool, error) {
-		n++
-		switch n {
-		case 1:
-			c.Check(path, Equals, boot.InitramfsUbuntuSeedDir)
-			return true, nil
-		case 2:
-			c.Check(path, Equals, boot.InitramfsUbuntuBootDir)
-			return true, nil
-		case 3:
-			c.Check(path, Equals, boot.InitramfsUbuntuDataDir)
-			return true, nil
-		case 4:
-			c.Check(path, Equals, filepath.Join(boot.InitramfsRunMntDir, "base"))
-			return false, nil
-		case 5:
-			c.Check(path, Equals, filepath.Join(boot.InitramfsRunMntDir, "kernel"))
-			return false, nil
-		case 6:
-			c.Check(path, Equals, filepath.Join(boot.InitramfsRunMntDir, "snapd"))
-			return false, nil
-		}
-		return false, fmt.Errorf("unexpected number of calls: %v", n)
-	})
-	defer restore()
-
-	// write modeenv
-	modeEnv := boot.Modeenv{
-		RecoverySystem: "20191118",
-		Base:           "core20_123.snap",
-		CurrentKernels: []string{"pc-kernel_1.snap"},
-	}
-	err := modeEnv.WriteTo(boot.InitramfsWritableDir)
-	c.Assert(err, IsNil)
-
-	// mock a bootloader
-	bloader := boottest.MockUC20EnvRefExtractedKernelRunBootenv(bootloadertest.Mock("mock", c.MkDir()))
-	bootloader.Force(bloader)
-	defer bootloader.Force(nil)
-
-	// set the current kernel
-	bloader.SetBootKernel("pc-kernel_1.snap")
-
-	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, 6)
-	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/core20_123.snap %[1]s/base
-%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/pc-kernel_1.snap %[1]s/kernel
-%[1]s/ubuntu-seed/snaps/snapd_1.snap %[1]s/snapd
-`, boot.InitramfsRunMntDir))
-}
-
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2BaseSnapUpgradeFailsHappy(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
@@ -884,7 +828,63 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2KernelStatusTrying
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2LegacyKernelBootstateKernelSnapUpgradeHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstate(c *C) {
+	n := 0
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
+
+	restore := main.MockOsutilIsMounted(func(path string) (bool, error) {
+		n++
+		switch n {
+		case 1:
+			c.Check(path, Equals, boot.InitramfsUbuntuSeedDir)
+			return true, nil
+		case 2:
+			c.Check(path, Equals, boot.InitramfsUbuntuBootDir)
+			return true, nil
+		case 3:
+			c.Check(path, Equals, boot.InitramfsUbuntuDataDir)
+			return true, nil
+		case 4:
+			c.Check(path, Equals, filepath.Join(boot.InitramfsRunMntDir, "base"))
+			return false, nil
+		case 5:
+			c.Check(path, Equals, filepath.Join(boot.InitramfsRunMntDir, "kernel"))
+			return false, nil
+		case 6:
+			c.Check(path, Equals, filepath.Join(boot.InitramfsRunMntDir, "snapd"))
+			return false, nil
+		}
+		return false, fmt.Errorf("unexpected number of calls: %v", n)
+	})
+	defer restore()
+
+	// write modeenv
+	modeEnv := boot.Modeenv{
+		RecoverySystem: "20191118",
+		Base:           "core20_123.snap",
+		CurrentKernels: []string{"pc-kernel_1.snap"},
+	}
+	err := modeEnv.WriteTo(boot.InitramfsWritableDir)
+	c.Assert(err, IsNil)
+
+	// mock a bootloader
+	bloader := boottest.MockUC20EnvRefExtractedKernelRunBootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+
+	// set the current kernel
+	bloader.SetBootKernel("pc-kernel_1.snap")
+
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 6)
+	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/core20_123.snap %[1]s/base
+%[1]s/ubuntu-data/system-data/var/lib/snapd/snaps/pc-kernel_1.snap %[1]s/kernel
+%[1]s/ubuntu-seed/snaps/snapd_1.snap %[1]s/snapd
+`, boot.InitramfsRunMntDir))
+}
+
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstateKernelSnapUpgradeHappy(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -947,7 +947,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2LegacyKernelBootst
 // TODO:UC20: in this case snap-bootstrap should request a reboot, since we
 //            already booted the try snap, so mounting the fallback kernel will
 //            not match in some cases
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2LegacyKernelBootstateUntrustedKernelSnap(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstateUntrustedKernelSnap(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -998,7 +998,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2LegacyKernelBootst
 // TODO:UC20: in this case snap-bootstrap should request a reboot, since we
 //            already booted the try snap, so mounting the fallback kernel will
 //            not match in some cases
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2LegacyKernelBootstateUntrustedTryKernelSnapFallsBack(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstateUntrustedTryKernelSnapFallsBack(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -1056,7 +1056,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2LegacyKernelBootst
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2LegacyKernelBootstateKernelStatusTryingNoTryKernel(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstateKernelStatusTryingNoTryKernel(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -326,7 +326,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeFailsHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2BaseSnapUpgradeFailsHappy(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -385,7 +385,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeFailsHap
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseEmptyHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2ModeenvTryBaseEmptyHappy(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -434,7 +434,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseEmptyHapp
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2BaseSnapUpgradeHappy(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -491,7 +491,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBaseSnapUpgradeHappy(c 
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvBaseEmptyUnhappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2ModeenvBaseEmptyUnhappy(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -529,7 +529,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvBaseEmptyUnhappy
 	c.Check(s.Stdout.String(), Equals, "")
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseNotExistsHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2ModeenvTryBaseNotExistsHappy(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -580,7 +580,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeModeenvTryBaseNotExists
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeKernelSnapUpgradeHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2KernelSnapUpgradeHappy(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -651,7 +651,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeKernelSnapUpgradeHappy(
 // TODO:UC20: in this case snap-bootstrap should request a reboot, since we
 //            already booted the try snap, so mounting the fallback kernel will
 //            not match in some cases
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUntrustedKernelSnap(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2UntrustedKernelSnap(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -705,7 +705,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUntrustedKernelSnap(c *
 // TODO:UC20: in this case snap-bootstrap should request a reboot, since we
 //            already booted the try snap, so mounting the fallback kernel will
 //            not match in some cases
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUntrustedTryKernelSnapFallsBack(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2UntrustedTryKernelSnapFallsBack(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
@@ -767,7 +767,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUntrustedTryKernelSnapF
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeKernelStatusTryingNoTryKernel(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2KernelStatusTryingNoTryKernel(c *C) {
 	n := 0
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 


### PR DESCRIPTION
This is necessary to support i.e. u-boot on the Raspberry Pi 4. 

All of this logic should eventually move to the boot pkg as a part of https://github.com/snapcore/snapd/pull/8340, but since just supporting UC20 on the Raspberry Pi 4 is high-priority, we should do this first and clean up where it goes later. At that point I also think we can delete the duplicative tests here since the boot pkg will be in a much better place to test the additional dimension we are adding here. 