### PR TITLE
 boot: enable makeBootable20RunMode for EnvRefExtractedKernel bootloaders

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -172,11 +172,12 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 		return fmt.Errorf("internal error: cannot find bootloader: %v", err)
 	}
 
-	// record which recovery system is to be used on the bootloader, note that
-	// this goes on the main bootloader, and not on the recovery system
-	// bootloader, for example for grub bootloader, this env var is set on
-	// the ubuntu-seed root grubenv, and not on the recovery system grubenv in
-	// the systems/20200314/ subdir on ubuntu-seed
+	// record which recovery system is to be used on the bootloader, note
+	// that this goes on the main bootloader environment, and not on the
+	// recovery system bootloader environment, for example for grub
+	// bootloader, this env var is set on the ubuntu-seed root grubenv, and
+	// not on the recovery system grubenv in the systems/20200314/ subdir on
+	// ubuntu-seed
 	blVars := map[string]string{
 		"snapd_recovery_system": bootWith.RecoverySystemLabel,
 	}
@@ -250,13 +251,12 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		return fmt.Errorf("cannot write modeenv: %v", err)
 	}
 
-	// get the ubuntu-boot grub and extract the kernel there
+	// get the ubuntu-boot bootloader and extract the kernel there
 	opts := &bootloader.Options{
 		// At this point the run mode bootloader is under the native
 		// layout, no /boot mount.
 		NoSlashBoot: true,
-
-		// extract efi kernel assets to the ubuntu-boot partition
+		// Bootloader that supports kernel asset extraction
 		ExtractedRunKernelImage: true,
 	}
 	bl, err := bootloader.Find(InitramfsUbuntuBootDir, opts)
@@ -264,9 +264,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		return fmt.Errorf("internal error: cannot find run system bootloader: %v", err)
 	}
 
-	// extract the kernel first, then mark kernel_status ready, then make the
-	// symlink and finally transition to run-mode in case we get rebooted in
-	// between anywhere here
+	// extract the kernel first and mark kernel_status ready
 	kernelf, err := snap.Open(bootWith.KernelPath)
 	if err != nil {
 		return err
@@ -283,8 +281,12 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 
 	ebl, ok := bl.(bootloader.ExtractedRunKernelImageBootloader)
 	if ok {
-		// we can use ebl, so just set the EnableKernel after setting
-		// kernel_status
+		// the bootloader supports additional extracted kernel handling
+
+		// make the symlink and finally transition to run-mode in case
+		// we get rebooted in between anywhere here
+
+		// just set the EnableKernel after setting kernel_status
 		if err := bl.SetBootVars(blVars); err != nil {
 			return fmt.Errorf("cannot set run system environment: %v", err)
 		}
@@ -298,8 +300,9 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		//            ExtractedRunKernelImageBootloader the same way we do with
 		//            ExtractedRecoveryKernelImageBootloader?
 
-		// we don't have an ExtractedRunKernelImageBootloader, so just set the
-		// legacy variables for snap_kernel and move on
+		// the bootloader does not support additional handling of
+		// extracted kernel images, we must name the kernel to be used
+		// explicitly in bootloader variables
 		blVars["snap_kernel"] = bootWith.Kernel.Filename()
 
 		if err := bl.SetBootVars(blVars); err != nil {
@@ -307,17 +310,11 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		}
 	}
 
-	// LAST step: update recovery grub's grubenv to indicate that
-	// we transition to run mode now
-
-	// TODO:UC20: this "just works" on accident with bootloaders like uboot and
-	//            lk, but should we make this more explicit? currently they
-	//            don't see or care about the Recovery option, so we in effect
-	//            end up writing the bootenv to the normal bootenv on
-	//            ubuntu-seed, which is what we wanted for these bootloaders
-	//            anyways?
+	// LAST step: update recovery bootloader environment to indicate that we
+	// transition to run mode now
 	opts = &bootloader.Options{
-		// setup the recovery bootloader
+		// let the bootloader know we will be touching the recovery
+		// partition
 		Recovery: true,
 	}
 	bl, err = bootloader.Find(InitramfsUbuntuSeedDir, opts)

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -505,8 +505,7 @@ func (s *makeBootable20UbootSuite) TestUbootMakeBootable20RunMode(c *C) {
 	c.Assert(err, IsNil)
 
 	// uboot on ubuntu-seed
-	mockSeedUbootDir := filepath.Join(boot.InitramfsUbuntuSeedDir, "boot", "uboot")
-	mockSeedUbootEnv := filepath.Join(mockSeedUbootDir, "uboot.env")
+	mockSeedUbootEnv := filepath.Join(boot.InitramfsUbuntuSeedDir, "uboot.env")
 	err = os.MkdirAll(filepath.Dir(mockSeedUbootEnv), 0755)
 	c.Assert(err, IsNil)
 	// this is taken from the pi gadget uboot.conf
@@ -515,8 +514,7 @@ func (s *makeBootable20UbootSuite) TestUbootMakeBootable20RunMode(c *C) {
 	c.Assert(env.Save(), IsNil)
 
 	// uboot on ubuntu-boot
-	mockBootUbootDir := filepath.Join(boot.InitramfsUbuntuBootDir, "boot", "uboot")
-	mockBootUbootEnv := filepath.Join(mockBootUbootDir, "uboot.env")
+	mockBootUbootEnv := filepath.Join(boot.InitramfsUbuntuBootDir, "uboot.env")
 	err = os.MkdirAll(filepath.Dir(mockBootUbootEnv), 0755)
 	c.Assert(err, IsNil)
 	// this is taken from the pi gadget uboot.conf
@@ -562,13 +560,13 @@ version: 5.0
 	c.Check(filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), "arm-kernel_5.snap"), testutil.FilePresent)
 
 	// ensure the bootvars on ubuntu-seed got updated the right way
-	mockSeedUbootenv := filepath.Join(mockSeedUbootDir, "uboot.env")
+	mockSeedUbootenv := filepath.Join(boot.InitramfsUbuntuSeedDir, "uboot.env")
 	uenvSeed, err := ubootenv.Open(mockSeedUbootenv)
 	c.Assert(err, IsNil)
 	c.Assert(uenvSeed.Get("snapd_recovery_mode"), Equals, "run")
 
 	// now check ubuntu-boot uboot.env
-	mockBootUbootenv := filepath.Join(mockBootUbootDir, "uboot.env")
+	mockBootUbootenv := filepath.Join(boot.InitramfsUbuntuBootDir, "uboot.env")
 	uenvBoot, err := ubootenv.Open(mockBootUbootenv)
 	c.Assert(err, IsNil)
 	c.Assert(uenvBoot.Get("snap_try_kernel"), Equals, "")
@@ -579,7 +577,7 @@ version: 5.0
 	// old uc16/uc18 location
 	for _, file := range kernelSnapFiles {
 		fName := file[0]
-		c.Check(filepath.Join(mockBootUbootDir, "arm-kernel_5.snap", fName), testutil.FilePresent)
+		c.Check(filepath.Join(boot.InitramfsUbuntuBootDir, "arm-kernel_5.snap", fName), testutil.FilePresent)
 	}
 
 	// ensure modeenv looks correct

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -391,8 +391,6 @@ version: 5.0
 	mockSeedGrubenv := filepath.Join(mockSeedGrubDir, "grubenv")
 	c.Check(mockSeedGrubenv, testutil.FilePresent)
 	c.Check(mockSeedGrubenv, testutil.FileContains, "snapd_recovery_mode=run")
-	// TODO:UC20: update once we write the static UC20 kernels and stop
-	// using the UC16 bootmode
 	mockBootGrubenv := filepath.Join(mockBootGrubDir, "grubenv")
 	c.Check(mockBootGrubenv, testutil.FilePresent)
 

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
+	"github.com/snapcore/snapd/bootloader/ubootenv"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -492,4 +493,102 @@ version: 5.0
 			S:                 kernelInfo,
 		}},
 	)
+}
+
+func (s *makeBootable20UbootSuite) TestUbootMakeBootable20RunMode(c *C) {
+	dirs.SetRootDir("")
+	bootloader.Force(nil)
+
+	model := makeMockUC20Model()
+	rootdir := c.MkDir()
+	dirs.SetRootDir(rootdir)
+	seedSnapsDirs := filepath.Join(rootdir, "/snaps")
+	err := os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
+
+	// uboot on ubuntu-seed
+	mockSeedUbootDir := filepath.Join(boot.InitramfsUbuntuSeedDir, "boot", "uboot")
+	mockSeedUbootEnv := filepath.Join(mockSeedUbootDir, "uboot.env")
+	err = os.MkdirAll(filepath.Dir(mockSeedUbootEnv), 0755)
+	c.Assert(err, IsNil)
+	// this is taken from the pi gadget uboot.conf
+	env, err := ubootenv.Create(mockSeedUbootEnv, 131072)
+	c.Assert(err, IsNil)
+	c.Assert(env.Save(), IsNil)
+
+	// uboot on ubuntu-boot
+	mockBootUbootDir := filepath.Join(boot.InitramfsUbuntuBootDir, "boot", "uboot")
+	mockBootUbootEnv := filepath.Join(mockBootUbootDir, "uboot.env")
+	err = os.MkdirAll(filepath.Dir(mockBootUbootEnv), 0755)
+	c.Assert(err, IsNil)
+	// this is taken from the pi gadget uboot.conf
+	env, err = ubootenv.Create(mockBootUbootEnv, 131072)
+	c.Assert(err, IsNil)
+	c.Assert(env.Save(), IsNil)
+
+	baseFn, baseInfo := makeSnap(c, "core20", `name: core20
+type: base
+version: 5.0
+`, snap.R(3))
+	baseInSeed := filepath.Join(seedSnapsDirs, baseInfo.Filename())
+	err = os.Rename(baseFn, baseInSeed)
+	c.Assert(err, IsNil)
+	kernelSnapFiles := [][]string{
+		{"kernel.img", "I'm a kernel"},
+		{"initrd.img", "...and I'm an initrd"},
+		{"dtbs/foo.dtb", "foo dtb"},
+		{"dtbs/bar.dto", "bar dtbo"},
+	}
+	kernelFn, kernelInfo := makeSnapWithFiles(c, "arm-kernel", `name: arm-kernel
+type: kernel
+version: 5.0
+`, snap.R(5), kernelSnapFiles)
+	kernelInSeed := filepath.Join(seedSnapsDirs, kernelInfo.Filename())
+	err = os.Rename(kernelFn, kernelInSeed)
+	c.Assert(err, IsNil)
+
+	bootWith := &boot.BootableSet{
+		RecoverySystemDir: "20191216",
+		BasePath:          baseInSeed,
+		Base:              baseInfo,
+		KernelPath:        kernelInSeed,
+		Kernel:            kernelInfo,
+		Recovery:          false,
+	}
+
+	err = boot.MakeBootable(model, rootdir, bootWith)
+	c.Assert(err, IsNil)
+
+	// ensure base/kernel got copied to /var/lib/snapd/snaps
+	c.Check(filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), "core20_3.snap"), testutil.FilePresent)
+	c.Check(filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), "arm-kernel_5.snap"), testutil.FilePresent)
+
+	// ensure the bootvars on ubuntu-seed got updated the right way
+	mockSeedUbootenv := filepath.Join(mockSeedUbootDir, "uboot.env")
+	uenvSeed, err := ubootenv.Open(mockSeedUbootenv)
+	c.Assert(err, IsNil)
+	c.Assert(uenvSeed.Get("snapd_recovery_mode"), Equals, "run")
+
+	// now check ubuntu-boot uboot.env
+	mockBootUbootenv := filepath.Join(mockBootUbootDir, "uboot.env")
+	uenvBoot, err := ubootenv.Open(mockBootUbootenv)
+	c.Assert(err, IsNil)
+	c.Assert(uenvBoot.Get("snap_try_kernel"), Equals, "")
+	c.Assert(uenvBoot.Get("snap_kernel"), Equals, "arm-kernel_5.snap")
+	c.Assert(uenvBoot.Get("kernel_status"), Equals, boot.DefaultStatus)
+
+	// check that we have the extracted kernel in the right places, in the
+	// old uc16/uc18 location
+	for _, file := range kernelSnapFiles {
+		fName := file[0]
+		c.Check(filepath.Join(mockBootUbootDir, "arm-kernel_5.snap", fName), testutil.FilePresent)
+	}
+
+	// ensure modeenv looks correct
+	ubuntuDataModeEnvPath := filepath.Join(rootdir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/modeenv")
+	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, `mode=run
+recovery_system=20191216
+base=core20_3.snap
+current_kernels=arm-kernel_5.snap
+`)
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -470,13 +470,9 @@ version: 5.0
 	err = boot.MakeBootable(model, rootdir, bootWith)
 	c.Assert(err, IsNil)
 
-	// ensure only a single file got copied (the uboot.env)
-	files, err := filepath.Glob(filepath.Join(rootdir, "boot/uboot/*"))
-	c.Assert(err, IsNil)
-	c.Check(files, HasLen, 1)
 	// check that the recovery bootloader configuration was copied with
 	// the correct content
-	c.Check(filepath.Join(rootdir, "boot/uboot/uboot.env"), testutil.FileEquals, ubootEnv)
+	c.Check(filepath.Join(rootdir, "uboot.env"), testutil.FileEquals, ubootEnv)
 
 	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
 		"snapd_recovery_system": label,

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -187,7 +187,7 @@ func Find(rootdir string, opts *Options) (Bootloader, error) {
 	}
 
 	// try uboot
-	if uboot := newUboot(rootdir); uboot != nil {
+	if uboot := newUboot(rootdir, opts); uboot != nil {
 		return uboot, nil
 	}
 

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -44,7 +44,7 @@ func MockAndroidBootFile(c *C, rootdir string, mode os.FileMode) {
 }
 
 func NewUboot(rootdir string) ExtractedRecoveryKernelImageBootloader {
-	return newUboot(rootdir)
+	return newUboot(rootdir, nil)
 }
 
 func MockUbootFiles(c *C, rootdir string) {

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -69,6 +69,9 @@ func (u *uboot) dir() string {
 func (u *uboot) InstallBootConfig(gadgetDir string, opts *Options) (bool, error) {
 	gadgetFile := filepath.Join(gadgetDir, u.Name()+".conf")
 	systemFile := u.ConfigFile()
+	if opts != nil && opts.Recovery {
+		systemFile = filepath.Join(u.rootdir, "uboot.env")
+	}
 	return genericInstallBootConfig(gadgetFile, systemFile)
 }
 

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -29,12 +29,18 @@ import (
 )
 
 type uboot struct {
-	rootdir string
+	rootdir     string
+	noslashboot bool
 }
 
 // newUboot create a new Uboot bootloader object
-func newUboot(rootdir string) ExtractedRecoveryKernelImageBootloader {
-	u := &uboot{rootdir: rootdir}
+func newUboot(rootdir string, blOpts *Options) ExtractedRecoveryKernelImageBootloader {
+	u := &uboot{
+		rootdir: rootdir,
+	}
+	if blOpts != nil && (blOpts.NoSlashBoot || blOpts.Recovery) {
+		u.noslashboot = true
+	}
 	if !osutil.FileExists(u.envFile()) {
 		return nil
 	}
@@ -53,6 +59,9 @@ func (u *uboot) setRootDir(rootdir string) {
 func (u *uboot) dir() string {
 	if u.rootdir == "" {
 		panic("internal error: unset rootdir")
+	}
+	if u.noslashboot {
+		return u.rootdir
 	}
 	return filepath.Join(u.rootdir, "/boot/uboot")
 }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2643,7 +2643,7 @@ func (s *imageSuite) TestSetupSeedCore20UBoot(c *C) {
 	c.Check(l, HasLen, 4)
 
 	// check boot config
-	ubootCfg := filepath.Join(prepareDir, "system-seed", "boot/uboot/uboot.env")
+	ubootCfg := filepath.Join(prepareDir, "system-seed", "uboot.env")
 	c.Check(ubootCfg, testutil.FileEquals, "uboot env content")
 
 	expectedLabel := image.MakeLabel(time.Now())

--- a/tests/main/prepare-image-uboot-uc20/task.yaml
+++ b/tests/main/prepare-image-uboot-uc20/task.yaml
@@ -67,15 +67,14 @@ execute: |
     echo Verifying the result
     find "$ROOT/system-seed/" -ls
 
-    # TODO:UC20: refine the checks
-    test -e "$ROOT/system-seed/boot/uboot/uboot.env"
+    test -e "$ROOT/system-seed/uboot.env"
 
     test -e "$ROOT/system-seed/systems/$systemid/model"
     test -e "$ROOT/system-seed/systems/$systemid/kernel/initrd.img"
     test -e "$ROOT/system-seed/systems/$systemid/kernel/kernel.img"
     test "$(find "$ROOT/system-seed/systems/$systemid/kernel/dtbs/" | wc -l)" -gt 0
 
-    strings "$ROOT/system-seed/boot/uboot/uboot.env" | MATCH "snapd_recovery_system=$systemid"
+    strings "$ROOT/system-seed/uboot.env" | MATCH "snapd_recovery_system=$systemid"
 
     test -e "$ROOT"/system-seed/snaps/core20_*.snap
     test -e "$ROOT"/system-seed/snaps/pi-kernel_*.snap


### PR DESCRIPTION
This enables finishing install mode for i.e. u-boot and lk bootloaders where we will not have a full ExtractedRunKernelImageBootloader implementation.

This also is needed to enable UC20 for the Raspberry Pi 4.