### PR TITLE
secboot,cmd/snap-bootstrap: add model to pcr protection profile

### DIFF
--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -27,10 +27,8 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/partition"
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/secboot"
-	"github.com/snapcore/snapd/seed"
 )
 
 const (
@@ -227,12 +225,9 @@ func tpmSealKey(key partition.EncryptionKey, rkey partition.RecoveryKey, options
 	}
 	tpm.SetKernelCmdlines(kernelCmdlines)
 
-	model, err := getModel(options.SystemLabel)
-	if err != nil {
-		return err
+	if options.Model != nil {
+		tpm.SetModels([]*asserts.Model{options.Model})
 	}
-
-	tpm.SetModels([]*asserts.Model{model})
 
 	// Provision the TPM as late as possible
 	// TODO:UC20: ideally we should ask the firmware to clear the TPM and then reboot
@@ -308,22 +303,4 @@ func isCompatibleSchema(gadgetSchema, diskSchema string) bool {
 	default:
 		return false
 	}
-}
-
-func getModel(sysLabel string) (*asserts.Model, error) {
-	s, err := seed.Open(dirs.SnapSeedDir, sysLabel)
-	if err != nil {
-		return nil, fmt.Errorf("cannot open seed with label %q: %v", sysLabel, err)
-	}
-
-	if err := s.LoadAssertions(nil, nil); err != nil {
-		return nil, fmt.Errorf("cannot load assertions: %v", err)
-	}
-
-	model, err := s.Model()
-	if err != nil {
-		return nil, fmt.Errorf("cannot obtain model from seed: %v", err)
-	}
-
-	return model, nil
 }

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -51,6 +51,8 @@ type Options struct {
 	PolicyUpdateDataFile string
 	// KernelPath is the path to the kernel to seal the keyfile to
 	KernelPath string
+	// SystemLabel is the label of the system to be installed
+	SystemLabel string
 }
 
 func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err error) {
@@ -241,7 +243,7 @@ func tpmSealKey(key partition.EncryptionKey, rkey partition.RecoveryKey, options
 	}
 	tpm.SetKernelCmdlines(kernelCmdlines)
 
-	model, err := getModel()
+	model, err := getModel(options.SystemLabel)
 	if err != nil {
 		return err
 	}
@@ -320,13 +322,7 @@ func isCompatibleSchema(gadgetSchema, diskSchema string) bool {
 	}
 }
 
-func getModel() (*asserts.Model, error) {
-	modeenv, err := boot.ReadModeenv("")
-	if err != nil {
-		return nil, fmt.Errorf("cannot read modeenv: %v", err)
-	}
-	sysLabel := modeenv.RecoverySystem
-
+func getModel(sysLabel string) (*asserts.Model, error) {
 	s, err := seed.Open(dirs.SnapSeedDir, sysLabel)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open seed with label %q: %v", sysLabel, err)

--- a/cmd/snap-bootstrap/bootstrap/options.go
+++ b/cmd/snap-bootstrap/bootstrap/options.go
@@ -19,6 +19,10 @@
 
 package bootstrap
 
+import (
+	"github.com/snapcore/snapd/asserts"
+)
+
 type Options struct {
 	// Also mount the filesystems after creation
 	Mount bool
@@ -34,4 +38,6 @@ type Options struct {
 	PolicyUpdateDataFile string
 	// KernelPath is the path to the kernel to seal the keyfile to
 	KernelPath string
+	// Model is the device model to seal the keyfile to
+	Model *asserts.Model
 }

--- a/cmd/snap-bootstrap/cmd_create_partitions.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions.go
@@ -48,6 +48,7 @@ type cmdCreatePartitions struct {
 	TPMLockoutAuthFile   string `long:"tpm-lockout-auth" value-name:"filename" descrition:"Where the TPM lockout authorization data file will be stored"`
 	PolicyUpdateDataFile string `long:"policy-update-data-file" value-name:"filename" description:"Where the authorization policy update data file will be stored"`
 	KernelPath           string `long:"kernel" value-name:"path" description:"Path to the kernel to be installed"`
+	SystemLabel          string `long:"system-label" value-name:"label" description:"The label of the system to be installed"`
 
 	Positional struct {
 		GadgetRoot string `positional-arg-name:"<gadget-root>"`
@@ -64,6 +65,7 @@ func (c *cmdCreatePartitions) Execute(args []string) error {
 		TPMLockoutAuthFile:   c.TPMLockoutAuthFile,
 		PolicyUpdateDataFile: c.PolicyUpdateDataFile,
 		KernelPath:           c.KernelPath,
+		SystemLabel:          c.SystemLabel,
 	}
 
 	return bootstrapRun(c.Positional.GadgetRoot, c.Positional.Device, options)

--- a/cmd/snap-bootstrap/cmd_create_partitions.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions.go
@@ -64,7 +64,7 @@ func (c *cmdCreatePartitions) Execute(args []string) error {
 	var model *asserts.Model
 	if c.ModelPath != "" {
 		var err error
-		model, err = loadModel(c.ModelPath)
+		model, err = readModel(c.ModelPath)
 		if err != nil {
 			return fmt.Errorf("cannot load model: %v", err)
 		}
@@ -84,7 +84,7 @@ func (c *cmdCreatePartitions) Execute(args []string) error {
 	return bootstrapRun(c.Positional.GadgetRoot, c.Positional.Device, options)
 }
 
-func loadModel(modelPath string) (*asserts.Model, error) {
+func readModel(modelPath string) (*asserts.Model, error) {
 	f, err := os.Open(modelPath)
 	if err != nil {
 		return nil, err

--- a/cmd/snap-bootstrap/cmd_create_partitions_test.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions_test.go
@@ -70,6 +70,7 @@ func (s *cmdSuite) TestCreatePartitionsWithEncryption(c *C) {
 		c.Check(opts.TPMLockoutAuthFile, Equals, "lockout")
 		c.Check(opts.PolicyUpdateDataFile, Equals, "update")
 		c.Check(opts.KernelPath, Equals, "kernel")
+		c.Check(opts.SystemLabel, Equals, "20041020")
 		n++
 		return nil
 	})
@@ -83,6 +84,7 @@ func (s *cmdSuite) TestCreatePartitionsWithEncryption(c *C) {
 		"--tpm-lockout-auth", "lockout",
 		"--policy-update-data-file", "update",
 		"--kernel", "kernel",
+		"--system-label", "20041020",
 		"gadget-dir",
 		"device",
 	})

--- a/cmd/snap-bootstrap/cmd_create_partitions_test.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions_test.go
@@ -20,6 +20,9 @@
 package main_test
 
 import (
+	"io/ioutil"
+	"path/filepath"
+
 	. "gopkg.in/check.v1"
 
 	main "github.com/snapcore/snapd/cmd/snap-bootstrap"
@@ -59,6 +62,37 @@ func (s *cmdSuite) TestCreatePartitionsMount(c *C) {
 	c.Assert(n, Equals, 1)
 }
 
+var testModel = `type: model
+authority-id: brand-id1
+series: 16
+brand-id: brand-id1
+model: baz-3000
+display-name: Baz 3000
+architecture: amd64
+system-user-authority: *
+base: core20
+store: brand-store
+snaps:
+  -
+    name: baz-linux
+    id: bazlinuxidididididididididididid
+    type: kernel
+    default-channel: 20
+  -
+    name: brand-gadget
+    id: brandgadgetdidididididididididid
+    type: gadget
+  -
+    name: other-base
+    id: otherbasedididididididididididid
+    type: base
+grade: secured
+body-length: 0
+timestamp: 2002-10-02T10:00:00-05:00
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw==`
+
 func (s *cmdSuite) TestCreatePartitionsWithEncryption(c *C) {
 	n := 0
 	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts bootstrap.Options) error {
@@ -70,11 +104,15 @@ func (s *cmdSuite) TestCreatePartitionsWithEncryption(c *C) {
 		c.Check(opts.TPMLockoutAuthFile, Equals, "lockout")
 		c.Check(opts.PolicyUpdateDataFile, Equals, "update")
 		c.Check(opts.KernelPath, Equals, "kernel")
-		c.Check(opts.SystemLabel, Equals, "20041020")
+		c.Check(opts.Model.Model(), Equals, "baz-3000")
 		n++
 		return nil
 	})
 	defer restore()
+
+	mockModelPath := filepath.Join(c.MkDir(), "model")
+	err := ioutil.WriteFile(mockModelPath, []byte(testModel), 0644)
+	c.Assert(err, IsNil)
 
 	rest, err := main.Parser().ParseArgs([]string{
 		"create-partitions",
@@ -84,7 +122,7 @@ func (s *cmdSuite) TestCreatePartitionsWithEncryption(c *C) {
 		"--tpm-lockout-auth", "lockout",
 		"--policy-update-data-file", "update",
 		"--kernel", "kernel",
-		"--system-label", "20041020",
+		"--model", mockModelPath,
 		"gadget-dir",
 		"device",
 	})

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -262,6 +262,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 			TPMLockoutAuthFile:   filepath.Join(boot.InitramfsWritableDir, "var/lib/snapd/device/fde/tpm-lockout-auth"),
 			PolicyUpdateDataFile: filepath.Join(boot.InitramfsWritableDir, "var/lib/snapd/device/fde/policy-update-data"),
 			KernelPath:           filepath.Join(dirs.SnapMountDir, "pc-kernel/1/kernel.efi"),
+			Model:                mockModel,
 		})
 	} else {
 		c.Assert(brGadgetRoot, Equals, filepath.Join(dirs.SnapMountDir, "/pc/1"))
@@ -286,9 +287,6 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	})
 	defer restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"), nil, 0644)
-	c.Assert(err, IsNil)
-
 	s.state.Lock()
 	s.makeMockInstalledPcGadget(c, "dangerous")
 	devicestate.SetSystemMode(s.mgr, "install")
@@ -302,30 +300,6 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	installSystem := s.findInstallSystem()
 	c.Check(installSystem.Err(), ErrorMatches, `(?ms)cannot perform the following tasks:
 - Setup system for run mode \(cannot create partitions: The horror, The horror\)`)
-	// no restart request on failure
-	c.Check(s.restartRequests, HasLen, 0)
-}
-
-func (s *deviceMgrInstallModeSuite) TestInstallTaskErrorsNoModeenv(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
-	mockSnapBootstrapCmd := testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), `echo "The horror, The horror"; exit 1`)
-	defer mockSnapBootstrapCmd.Restore()
-
-	s.state.Lock()
-	s.makeMockInstalledPcGadget(c, "dangerous")
-	devicestate.SetSystemMode(s.mgr, "install")
-	s.state.Unlock()
-
-	s.settle(c)
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	installSystem := s.findInstallSystem()
-	c.Check(installSystem.Err(), ErrorMatches, `(?ms)cannot perform the following tasks:
-- Setup system for run mode \(missing modeenv, cannot proceed\)`)
 	// no restart request on failure
 	c.Check(s.restartRequests, HasLen, 0)
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -98,6 +98,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		bopts.TPMLockoutAuthFile = filepath.Join(boot.InitramfsWritableDir, fdeDir, "tpm-lockout-auth")
 		bopts.PolicyUpdateDataFile = filepath.Join(boot.InitramfsWritableDir, fdeDir, "policy-update-data")
 		bopts.KernelPath = filepath.Join(kernelDir, "kernel.efi")
+		bopts.Model = deviceCtx.Model()
 	}
 
 	// run the create partition code
@@ -137,6 +138,13 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	bootBaseInfo, err := snapstate.BootBaseInfo(st, deviceCtx)
 	if err != nil {
 		return fmt.Errorf("cannot get boot base info: %v", err)
+	}
+	modeEnv, err := m.maybeReadModeenv()
+	if err != nil {
+		return err
+	}
+	if modeEnv == nil {
+		return fmt.Errorf("missing modeenv, cannot proceed")
 	}
 	recoverySystemDir := filepath.Join("/systems", modeEnv.RecoverySystem)
 	bootWith := &boot.BootableSet{

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -58,6 +58,14 @@ func MockSbAddSystemdEFIStubProfile(f func(profile *sb.PCRProtectionProfile, par
 	}
 }
 
+func MockSbAddSnapModelProfile(f func(profile *sb.PCRProtectionProfile, params *sb.SnapModelProfileParams) error) (restore func()) {
+	old := sbAddSnapModelProfile
+	sbAddSnapModelProfile = f
+	return func() {
+		sbAddSnapModelProfile = old
+	}
+}
+
 func MockSbSealKeyToTPM(f func(tpm *sb.TPMConnection, key []byte, keyPath, policyUpdatePath string, params *sb.KeyCreationParams) error) (restore func()) {
 	old := sbSealKeyToTPM
 	sbSealKeyToTPM = f

--- a/secboot/tpm.go
+++ b/secboot/tpm.go
@@ -206,13 +206,15 @@ func (t *tpmSupport) Seal(key []byte, keyPath, policyUpdatePath string) error {
 	}
 
 	// Add snap model profile
-	snapModelParams := sb.SnapModelProfileParams{
-		PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-		PCRIndex:     12,
-		Models:       t.models,
-	}
-	if err := sbAddSnapModelProfile(pcrProfile, &snapModelParams); err != nil {
-		return fmt.Errorf("cannot add snap model profile: %v", err)
+	if len(t.models) != 0 {
+		snapModelParams := sb.SnapModelProfileParams{
+			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
+			PCRIndex:     12,
+			Models:       t.models,
+		}
+		if err := sbAddSnapModelProfile(pcrProfile, &snapModelParams); err != nil {
+			return fmt.Errorf("cannot add snap model profile: %v", err)
+		}
 	}
 
 	// Seal key to the TPM

--- a/secboot/tpm.go
+++ b/secboot/tpm.go
@@ -27,6 +27,7 @@ import (
 	"github.com/canonical/go-tpm2"
 	sb "github.com/snapcore/secboot"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/osutil"
 )
 
@@ -48,6 +49,8 @@ type tpmSupport struct {
 	kernelFiles []string
 	// Kernel command lines
 	kernelCmdlines []string
+	// Snap models
+	models []*asserts.Model
 }
 
 func NewTPMSupport() (*tpmSupport, error) {
@@ -139,10 +142,15 @@ func (t *tpmSupport) SetKernelCmdlines(cmdlines []string) {
 	t.kernelCmdlines = cmdlines
 }
 
+func (t *tpmSupport) SetModels(models []*asserts.Model) {
+	t.models = models
+}
+
 var (
 	sbSealKeyToTPM                  = sb.SealKeyToTPM
 	sbAddEFISecureBootPolicyProfile = sb.AddEFISecureBootPolicyProfile
 	sbAddSystemdEFIStubProfile      = sb.AddSystemdEFIStubProfile
+	sbAddSnapModelProfile           = sb.AddSnapModelProfile
 )
 
 // Seal seals the given key to the TPM and writes the sealed object to a file at the
@@ -195,6 +203,16 @@ func (t *tpmSupport) Seal(key []byte, keyPath, policyUpdatePath string) error {
 	}
 	if err := sbAddSystemdEFIStubProfile(pcrProfile, &systemdStubParams); err != nil {
 		return fmt.Errorf("cannot add systemd EFI stub profile: %v", err)
+	}
+
+	// Add snap model profile
+	snapModelParams := sb.SnapModelProfileParams{
+		PCRAlgorithm: tpm2.HashAlgorithmSHA256,
+		PCRIndex:     12,
+		Models:       t.models,
+	}
+	if err := sbAddSnapModelProfile(pcrProfile, &snapModelParams); err != nil {
+		return fmt.Errorf("cannot add snap model profile: %v", err)
 	}
 
 	// Seal key to the TPM

--- a/secboot/tpm_test.go
+++ b/secboot/tpm_test.go
@@ -192,7 +192,7 @@ func (s *secbootTPMSuite) TestSeal(c *C) {
 	defer stubRestore()
 
 	var sbAddSnapModelProfileCalled int
-	modelRestore := secboot.MockSbAddSnapModelProfile(func(profile *sb.PCRProtectionProfile, params *sb.SnapModelProfileParams) error {
+	modelProfileRestore := secboot.MockSbAddSnapModelProfile(func(profile *sb.PCRProtectionProfile, params *sb.SnapModelProfileParams) error {
 		c.Assert(*params, DeepEquals, sb.SnapModelProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
 			PCRIndex:     12,
@@ -201,7 +201,7 @@ func (s *secbootTPMSuite) TestSeal(c *C) {
 		sbAddSnapModelProfileCalled++
 		return nil
 	})
-	defer modelRestore()
+	defer modelProfileRestore()
 
 	var sbSealKeyToTPMCalled int
 	sealRestore := secboot.MockSbSealKeyToTPM(func(tpm *sb.TPMConnection, key []byte, keyPath, policyUpdatePath string, params *sb.KeyCreationParams) error {

--- a/secboot/tpm_test.go
+++ b/secboot/tpm_test.go
@@ -66,7 +66,6 @@ func (s *secbootTPMSuite) TestProvision(c *C) {
 }
 
 func (s *secbootTPMSuite) TestSeal(c *C) {
-	n := 0
 	myKey := []byte("528491")
 	myKeyPath := "keyFilename"
 	myPolicyUpdatePath := "policyUpdateFilename"
@@ -192,29 +191,33 @@ func (s *secbootTPMSuite) TestSeal(c *C) {
 	})
 	defer stubRestore()
 
+	var sbAddSnapModelProfileCalled int
 	modelRestore := secboot.MockSbAddSnapModelProfile(func(profile *sb.PCRProtectionProfile, params *sb.SnapModelProfileParams) error {
 		c.Assert(*params, DeepEquals, sb.SnapModelProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
 			PCRIndex:     12,
 			Models:       models,
 		})
+		sbAddSnapModelProfileCalled++
 		return nil
 	})
 	defer modelRestore()
 
+	var sbSealKeyToTPMCalled int
 	sealRestore := secboot.MockSbSealKeyToTPM(func(tpm *sb.TPMConnection, key []byte, keyPath, policyUpdatePath string, params *sb.KeyCreationParams) error {
 		c.Assert(key, DeepEquals, myKey)
 		c.Assert(keyPath, Equals, myKeyPath)
 		c.Assert(policyUpdatePath, Equals, policyUpdatePath)
 		c.Assert(params.PINHandle, Equals, tpm2.Handle(0x01800000))
-		n++
+		sbSealKeyToTPMCalled++
 		return nil
 	})
 	defer sealRestore()
 
 	err := t.Seal(myKey, myKeyPath, myPolicyUpdatePath)
 	c.Assert(err, IsNil)
-	c.Assert(n, Equals, 1)
+	c.Assert(sbSealKeyToTPMCalled, Equals, 1)
+	c.Assert(sbAddSnapModelProfileCalled, Equals, 1)
 }
 
 func (s *secbootTPMSuite) TestSetFiles(c *C) {

--- a/secboot/tpm_test.go
+++ b/secboot/tpm_test.go
@@ -98,7 +98,7 @@ func (s *secbootTPMSuite) TestSeal(c *C) {
 	cmdlines := []string{"cmdline1", "cmdline2"}
 	t.SetKernelCmdlines(cmdlines)
 
-	models := []*asserts.Model{&asserts.Model{}, &asserts.Model{}}
+	models := []*asserts.Model{{}, {}}
 	t.SetModels(models)
 
 	loadSequences := []*sb.EFIImageLoadEvent{

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -117,10 +117,10 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "WAeGpLSmxzsvaPLq7CTVjm+qvqE=",
+			"checksumSHA1": "pPDMOcvX+Q7GZTgallPBTIqN7Vg=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "dd1d2c4169dcd173a0397a63d569d6e15e5f7644",
-			"revisionTime": "2020-04-16T07:09:07Z"
+			"revision": "89c7bad3c8960ffb522a20b4732b0f14875ceff8",
+			"revisionTime": "2020-04-17T19:51:42Z"
 		},
 		{
 			"checksumSHA1": "3AmEm18mKj8XxBuru/ix4OOpRkE=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -202,7 +202,7 @@
 			"revisionTime": "2017-06-28T23:42:41Z"
 		},
 		{
-			"checksumSHA1": "U4ZQCRcFfuKZvLIUmB1kXgWSd9U=",
+			"checksumSHA1": "kohbRG3D0CRhcgwH6z7YQ6uq1xo=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "e3b113bbe6a423737ae98f42118ce9366e112e12",
 			"revisionTime": "2020-04-06T14:27:27Z"


### PR DESCRIPTION
Add the snap model profile to the PCR protection profile in order to
seal to a specific set of device models.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>