### PR TITLE
tests: 16.04 and 18.04 now have mediating pulseaudio (again)

### DIFF
--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -5,8 +5,8 @@ systems: [ ubuntu-1*-*64, ubuntu-2*-*64 ]
 
 environment:
     PLAY_FILE: "/snap/test-snapd-audio-record/current/usr/share/sounds/alsa/Noise.wav"
-    # today, only 19.10 has a mediating pulseaudio
-    EXFAIL: "ubuntu-1[468]"
+    # today, 16.04 and higher have a mediating pulseaudio
+    EXFAIL: "ubuntu-14"
 
 prepare: |
     # FIXME: This test is broken and should be ported to session-tool, systemd


### PR DESCRIPTION
References:
- https://bugs.launchpad.net/ubuntu/+source/pulseaudio/+bug/1781428