### PR TITLE
daemon: fix error message from `snap remove-user foo` on classic

### DIFF
--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -221,7 +221,7 @@ const noUserAdmin = "system user administration via snapd is not allowed on this
 
 func postUsers(c *Command, r *http.Request, user *auth.UserState) Response {
 	if !hasUserAdmin {
-		return MethodNotAllowed(noUserAdmin, r.Method)
+		return MethodNotAllowed(noUserAdmin)
 	}
 
 	var postData postUserData

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -191,7 +191,7 @@ func (s *userSuite) testNoUserAdmin(c *check.C, endpoint string) {
 	switch endpoint {
 	case "/v2/users":
 		rsp := postUsers(usersCmd, req, nil).(*resp)
-		c.Check(rsp, check.DeepEquals, MethodNotAllowed(noUserAdmin, "POST"))
+		c.Check(rsp, check.DeepEquals, MethodNotAllowed(noUserAdmin))
 	case "/v2/create-user":
 		rsp := postCreateUser(createUserCmd, req, nil).(*resp)
 		c.Check(rsp, check.DeepEquals, Forbidden(noUserAdmin))


### PR DESCRIPTION
Currently we output on classic:
```
$ sudo snap remove-user foo
error: system user administration via snapd is not allowed on this
       system%!(EXTRA string=POST)
```

This commit fixes this.
