### PR TITLE
store,asserts,many: support the new action fetch-assertions

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -152,6 +152,24 @@ var formatAnalyzer = map[*AssertionType]func(headers map[string]interface{}, bod
 	SnapDeclarationType: snapDeclarationFormatAnalyze,
 }
 
+// MaxSupportedFormats returns a mapping between assertion type names
+// and corresponding max supported format if it is >= min. Typical
+// usage passes 1 or 0 for min.
+func MaxSupportedFormats(min int) (maxFormats map[string]int) {
+	if min == 0 {
+		maxFormats = make(map[string]int, len(typeRegistry))
+	} else {
+		maxFormats = make(map[string]int)
+	}
+	for name := range typeRegistry {
+		m := maxSupportedFormat[name]
+		if m >= min {
+			maxFormats[name] = m
+		}
+	}
+	return maxFormats
+}
+
 // SuggestFormat returns a minimum format that supports the features that would be used by an assertion with the given components.
 func SuggestFormat(assertType *AssertionType, headers map[string]interface{}, body []byte) (formatnum int, err error) {
 	analyzer := formatAnalyzer[assertType]

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -237,6 +237,23 @@ func (ref *Ref) Resolve(find func(assertType *AssertionType, headers map[string]
 	return find(ref.Type, headers)
 }
 
+const RevisionNotKnown = -1
+
+// AtRevision represents an assertion at a given revision, possibly
+// not known (RevisionNotKnown).
+type AtRevision struct {
+	Ref
+	Revision int
+}
+
+func (at *AtRevision) String() string {
+	s := at.Ref.String()
+	if at.Revision == RevisionNotKnown {
+		return s
+	}
+	return fmt.Sprintf("%s at revision %d", s, at.Revision)
+}
+
 // Assertion represents an assertion through its general elements.
 type Assertion interface {
 	// Type returns the type of this assertion

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -71,6 +71,23 @@ func (as *assertsSuite) TestTypeNames(c *C) {
 	})
 }
 
+func (as *assertsSuite) TestMaxSupportedFormats(c *C) {
+	snapDeclMaxFormat := asserts.SnapDeclarationType.MaxSupportedFormat()
+	// sanity
+	c.Check(snapDeclMaxFormat >= 4, Equals, true)
+	c.Check(asserts.MaxSupportedFormats(1), DeepEquals, map[string]int{
+		"snap-declaration": snapDeclMaxFormat,
+		"test-only":        1,
+	})
+
+	// all
+	maxFormats := asserts.MaxSupportedFormats(0)
+	c.Assert(maxFormats, HasLen, len(asserts.TypeNames()))
+	c.Check(maxFormats["test-only"], Equals, 1)
+	c.Check(maxFormats["test-only-2"], Equals, 0)
+	c.Check(maxFormats["snap-declaration"], Equals, snapDeclMaxFormat)
+}
+
 func (as *assertsSuite) TestSuggestFormat(c *C) {
 	fmtnum, err := asserts.SuggestFormat(asserts.Type("test-only-2"), nil, nil)
 	c.Assert(err, IsNil)

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -163,6 +163,24 @@ func (as *assertsSuite) TestRefResolveError(c *C) {
 	c.Check(err, ErrorMatches, `"test-only-2" assertion reference primary key has the wrong length \(expected \[pk1 pk2\]\): \[abc\]`)
 }
 
+func (as *assertsSuite) TestAtRevisionString(c *C) {
+	ref := asserts.Ref{
+		Type:       asserts.AccountType,
+		PrimaryKey: []string{"canonical"},
+	}
+
+	at := &asserts.AtRevision{
+		Ref: ref,
+	}
+	c.Check(at.String(), Equals, "account (canonical) at revision 0")
+
+	at = &asserts.AtRevision{
+		Ref:      ref,
+		Revision: asserts.RevisionNotKnown,
+	}
+	c.Check(at.String(), Equals, "account (canonical)")
+}
+
 const exKeyID = "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"
 
 const exampleEmptyBodyAllDefaults = "type: test-only\n" +

--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+// A Grouping identifies opaquely a grouping of assertions.
+// TODO: add details to this comment when this is actually used.
+type Grouping string

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -125,7 +125,7 @@ func streamOneSnap(c *Command, action snapDownloadAction, user *auth.UserState) 
 			CohortKey:    action.CohortKey,
 			Channel:      action.Channel,
 		}}
-		results, err := theStore.SnapAction(context.TODO(), nil, actions, user, nil)
+		results, _, err := theStore.SnapAction(context.TODO(), nil, actions, nil, user, nil)
 		if err != nil {
 			return errToResponse(err, []string{action.SnapName}, InternalError, "cannot download snap: %v")
 		}

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -125,7 +125,10 @@ var storeSnaps = map[string]*snap.Info{
 	},
 }
 
-func (s *snapDownloadSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (s *snapDownloadSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
 	if len(actions) != 1 {
 		panic(fmt.Sprintf("unexpected amount of actions: %v", len(actions)))
 	}
@@ -135,7 +138,7 @@ func (s *snapDownloadSuite) SnapAction(ctx context.Context, currentSnaps []*stor
 	}
 	info, ok := storeSnaps[action.InstanceName]
 	if !ok {
-		return nil, store.ErrSnapNotFound
+		return nil, nil, store.ErrSnapNotFound
 	}
 	if action.Channel != info.Channel {
 		panic(fmt.Sprintf("unexpected channel %q for %v snap", action.Channel, action.InstanceName))
@@ -143,7 +146,7 @@ func (s *snapDownloadSuite) SnapAction(ctx context.Context, currentSnaps []*stor
 	if !action.Revision.Unset() && action.Revision != info.Revision {
 		panic(fmt.Sprintf("unexpected revision %q for %s snap", action.Revision, action.InstanceName))
 	}
-	return []store.SnapActionResult{{Info: info}}, nil
+	return []store.SnapActionResult{{Info: info}}, nil, nil
 }
 
 func (s *snapDownloadSuite) DownloadStream(ctx context.Context, name string, downloadInfo *snap.DownloadInfo, resume int64, user *auth.UserState) (io.ReadCloser, int, error) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2018 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -153,8 +153,11 @@ func (s *apiBaseSuite) Find(ctx context.Context, search *store.Search, user *aut
 	return s.rsnaps, s.err
 }
 
-func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
 	s.pokeStateLock()
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
 
 	if ctx == nil {
 		panic("context required")
@@ -167,7 +170,7 @@ func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.Cur
 	for i, rsnap := range s.rsnaps {
 		sars[i] = store.SnapActionResult{Info: rsnap}
 	}
-	return sars, s.err
+	return sars, nil, s.err
 }
 
 func (s *apiBaseSuite) SuggestedCurrency() string {

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -53,7 +53,7 @@ import (
 
 // A Store can find metadata on snaps, download snaps and fetch assertions.
 type Store interface {
-	SnapAction(context.Context, []*store.CurrentSnap, []*store.SnapAction, *auth.UserState, *store.RefreshOptions) ([]store.SnapActionResult, error)
+	SnapAction(context.Context, []*store.CurrentSnap, []*store.SnapAction, store.AssertionQuery, *auth.UserState, *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error)
 	Download(ctx context.Context, name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState, dlOpts *store.DownloadOptions) error
 
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
@@ -294,7 +294,7 @@ func (tsto *ToolingStore) DownloadSnap(name string, opts DownloadOptions) (targe
 		Channel:      opts.Channel,
 	}}
 
-	sars, err := sto.SnapAction(context.TODO(), nil, actions, tsto.user, nil)
+	sars, _, err := sto.SnapAction(context.TODO(), nil, actions, nil, tsto.user, nil)
 	if err != nil {
 		// err will be 'cannot download snap "foo": <reasons>'
 		return "", nil, "", err

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -126,17 +126,21 @@ func (s *imageSuite) TearDownTest(c *C) {
 }
 
 // interface for the store
-func (s *imageSuite) SnapAction(_ context.Context, _ []*store.CurrentSnap, actions []*store.SnapAction, _ *auth.UserState, _ *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (s *imageSuite) SnapAction(_ context.Context, _ []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, _ *auth.UserState, _ *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	if assertQuery != nil {
+		return nil, nil, fmt.Errorf("unexpected assertion query")
+	}
+
 	if len(actions) != 1 {
-		return nil, fmt.Errorf("expected 1 action, got %d", len(actions))
+		return nil, nil, fmt.Errorf("expected 1 action, got %d", len(actions))
 	}
 
 	if actions[0].Action != "download" {
-		return nil, fmt.Errorf("unexpected action %q", actions[0].Action)
+		return nil, nil, fmt.Errorf("unexpected action %q", actions[0].Action)
 	}
 
 	if _, instanceKey := snap.SplitInstanceName(actions[0].InstanceName); instanceKey != "" {
-		return nil, fmt.Errorf("unexpected instance key in %q", actions[0].InstanceName)
+		return nil, nil, fmt.Errorf("unexpected instance key in %q", actions[0].InstanceName)
 	}
 	// record
 	s.storeActions = append(s.storeActions, actions[0])
@@ -150,9 +154,9 @@ func (s *imageSuite) SnapAction(_ context.Context, _ []*store.CurrentSnap, actio
 			redirectChannel = channel
 		}
 		info1.Channel = channel
-		return []store.SnapActionResult{{Info: &info1, RedirectChannel: redirectChannel}}, nil
+		return []store.SnapActionResult{{Info: &info1, RedirectChannel: redirectChannel}}, nil, nil
 	}
-	return nil, fmt.Errorf("no %q in the fake store", actions[0].InstanceName)
+	return nil, nil, fmt.Errorf("no %q in the fake store", actions[0].InstanceName)
 }
 
 func (s *imageSuite) Download(ctx context.Context, name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState, dlOpts *store.DownloadOptions) error {

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -48,7 +48,10 @@ type fakeStore struct {
 	storetest.Store
 }
 
-func (f *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (f *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
 	if actions[0].Action == "install" {
 		installs := make([]store.SnapActionResult, 0, len(actions))
 		for _, a := range actions {
@@ -66,7 +69,7 @@ func (f *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.CurrentS
 			}})
 		}
 
-		return installs, nil
+		return installs, nil, nil
 	}
 
 	snaps := []store.SnapActionResult{{Info: &snap.Info{
@@ -84,7 +87,7 @@ func (f *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.CurrentS
 		},
 		Architectures: []string{"all"},
 	}}}
-	return snaps, nil
+	return snaps, nil, nil
 }
 
 type servicectlSuite struct {

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -50,7 +50,10 @@ type autoRefreshStore struct {
 	err error
 }
 
-func (r *autoRefreshStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (r *autoRefreshStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
 	if !opts.IsAutoRefresh {
 		panic("AutoRefresh snap action did not set IsAutoRefresh flag")
 	}
@@ -67,7 +70,7 @@ func (r *autoRefreshStore) SnapAction(ctx context.Context, currentSnaps []*store
 		}
 	}
 	r.ops = append(r.ops, "list-refresh")
-	return nil, r.err
+	return nil, nil, r.err
 }
 
 type autoRefreshTestSuite struct {

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -41,7 +41,7 @@ type StoreService interface {
 	SnapInfo(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
 	Find(ctx context.Context, search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 
-	SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error)
+	SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error)
 
 	Sections(ctx context.Context, user *auth.UserState) ([]string, error)
 	WriteCatalogs(ctx context.Context, names io.Writer, adder store.SnapAdder) error

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -387,14 +387,17 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	return nil, store.ErrNoUpdateAvailable
 }
 
-func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
 	if ctx == nil {
 		panic("context required")
 	}
 	f.pokeStateLock()
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
 
 	if len(currentSnaps) == 0 && len(actions) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if len(actions) > 4 {
 		panic("fake SnapAction unexpectedly called with more than 3 actions")
@@ -404,7 +407,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 	curSnaps := make(byName, len(currentSnaps))
 	for i, cur := range currentSnaps {
 		if cur.InstanceName == "" || cur.SnapID == "" || cur.Revision.Unset() {
-			return nil, fmt.Errorf("internal error: incomplete current snap info")
+			return nil, nil, fmt.Errorf("internal error: incomplete current snap info")
 		}
 		curByInstanceName[cur.InstanceName] = cur
 		curSnaps[i] = *cur
@@ -444,7 +447,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 			panic("not supported")
 		}
 		if a.InstanceName == "" {
-			return nil, fmt.Errorf("internal error: action without instance name")
+			return nil, nil, fmt.Errorf("internal error: action without instance name")
 		}
 
 		snapName, instanceKey := snap.SplitInstanceName(a.InstanceName)
@@ -483,7 +486,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 
 		cur := curByInstanceName[a.InstanceName]
 		if cur == nil {
-			return nil, fmt.Errorf("internal error: no matching current snap for %q", a.InstanceName)
+			return nil, nil, fmt.Errorf("internal error: no matching current snap for %q", a.InstanceName)
 		}
 		channel := a.Channel
 		if channel == "" {
@@ -521,7 +524,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 			continue
 		}
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !a.Revision.Unset() {
 			info.Channel = ""
@@ -537,14 +540,14 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 		if len(installErrors) == 0 {
 			installErrors = nil
 		}
-		return res, &store.SnapActionError{
+		return res, nil, &store.SnapActionError{
 			NoResults: len(refreshErrors)+len(installErrors)+len(res) == 0,
 			Refresh:   refreshErrors,
 			Install:   installErrors,
 		}
 	}
 
-	return res, nil
+	return res, nil, nil
 }
 
 func (f *fakeStore) SuggestedCurrency() string {

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -40,7 +40,10 @@ type recordingStore struct {
 	ops []string
 }
 
-func (r *recordingStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (r *recordingStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
 	if ctx == nil || !auth.IsEnsureContext(ctx) {
 		panic("Ensure marked context required")
 	}
@@ -53,7 +56,7 @@ func (r *recordingStore) SnapAction(ctx context.Context, currentSnaps []*store.C
 		}
 	}
 	r.ops = append(r.ops, "list-refresh")
-	return nil, nil
+	return nil, nil, nil
 }
 
 type refreshHintsTestSuite struct {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2124,7 +2124,7 @@ type sneakyStore struct {
 	state *state.State
 }
 
-func (s sneakyStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (s sneakyStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
 	s.state.Lock()
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -2134,7 +2134,7 @@ func (s sneakyStore) SnapAction(ctx context.Context, currentSnaps []*store.Curre
 		SnapType:        "app",
 	})
 	s.state.Unlock()
-	return s.fakeStore.SnapAction(ctx, currentSnaps, actions, user, opts)
+	return s.fakeStore.SnapAction(ctx, currentSnaps, actions, assertQuery, user, opts)
 }
 
 func (s *snapmgrTestSuite) TestInstallStateConflict(c *C) {
@@ -6086,8 +6086,11 @@ type noResultsStore struct {
 	*fakeStore
 }
 
-func (n noResultsStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
-	return nil, &store.SnapActionError{NoResults: true}
+func (n noResultsStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
+	return nil, nil, &store.SnapActionError{NoResults: true}
 }
 
 func (s *snapmgrTestSuite) TestUpdateNoStoreResults(c *C) {
@@ -13768,9 +13771,12 @@ type unhappyStore struct {
 	*fakeStore
 }
 
-func (s unhappyStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (s unhappyStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
 
-	return nil, fmt.Errorf("a grumpy store")
+	return nil, nil, fmt.Errorf("a grumpy store")
 }
 
 func (s *snapmgrTestSuite) TestTransitionSnapdSnapError(c *C) {
@@ -14556,7 +14562,11 @@ type behindYourBackStore struct {
 	chg                  *state.Change
 }
 
-func (s behindYourBackStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (s behindYourBackStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
+
 	if len(actions) == 1 && actions[0].Action == "install" && actions[0].InstanceName == "core" {
 		s.state.Lock()
 		if !s.coreInstallRequested {
@@ -14591,7 +14601,7 @@ func (s behindYourBackStore) SnapAction(ctx context.Context, currentSnaps []*sto
 		s.state.Unlock()
 	}
 
-	return s.fakeStore.SnapAction(ctx, currentSnaps, actions, user, opts)
+	return s.fakeStore.SnapAction(ctx, currentSnaps, actions, nil, user, opts)
 }
 
 // this test the scenario that some-snap gets installed and during the
@@ -14682,10 +14692,10 @@ type contentStore struct {
 	state *state.State
 }
 
-func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
-	sars, err := s.fakeStore.SnapAction(ctx, currentSnaps, actions, user, opts)
+func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	sars, _, err := s.fakeStore.SnapAction(ctx, currentSnaps, actions, assertQuery, user, opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(sars) != 1 {
 		panic("expected to be queried for install of only one snap at a time")
@@ -14773,7 +14783,7 @@ func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.Curr
 		}
 	}
 
-	return []store.SnapActionResult{{Info: info}}, err
+	return []store.SnapActionResult{{Info: info}}, nil, err
 }
 
 func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -118,7 +118,7 @@ func installInfo(ctx context.Context, st *state.State, name string, revOpts *Rev
 
 	theStore := Store(st, deviceCtx)
 	st.Unlock() // calls to the store should be done without holding the state lock
-	res, err := theStore.SnapAction(ctx, curSnaps, []*store.SnapAction{action}, user, opts)
+	res, _, err := theStore.SnapAction(ctx, curSnaps, []*store.SnapAction{action}, nil, user, opts)
 	st.Lock()
 
 	return singleActionResult(name, action.Action, res, err)
@@ -164,7 +164,7 @@ func updateInfo(st *state.State, snapst *SnapState, opts *RevisionOptions, userI
 
 	theStore := Store(st, deviceCtx)
 	st.Unlock() // calls to the store should be done without holding the state lock
-	res, err := theStore.SnapAction(context.TODO(), curSnaps, []*store.SnapAction{action}, user, refreshOpts)
+	res, _, err := theStore.SnapAction(context.TODO(), curSnaps, []*store.SnapAction{action}, nil, user, refreshOpts)
 	st.Lock()
 
 	sar, err := singleActionResult(curInfo.InstanceName(), action.Action, res, err)
@@ -255,7 +255,7 @@ func updateToRevisionInfo(st *state.State, snapst *SnapState, revision snap.Revi
 
 	theStore := Store(st, deviceCtx)
 	st.Unlock() // calls to the store should be done without holding the state lock
-	res, err := theStore.SnapAction(context.TODO(), curSnaps, []*store.SnapAction{action}, user, opts)
+	res, _, err := theStore.SnapAction(context.TODO(), curSnaps, []*store.SnapAction{action}, nil, user, opts)
 	st.Lock()
 
 	sar, err := singleActionResult(curInfo.InstanceName(), action.Action, res, err)
@@ -427,7 +427,7 @@ func refreshCandidates(ctx context.Context, st *state.State, names []string, use
 	updates := make([]*snap.Info, 0, nCands)
 	for u, actions := range actionsForUser {
 		st.Unlock()
-		sarsForUser, err := theStore.SnapAction(ctx, curSnaps, actions, u, opts)
+		sarsForUser, _, err := theStore.SnapAction(ctx, curSnaps, actions, nil, u, opts)
 		st.Lock()
 		if err != nil {
 			saErr, ok := err.(*store.SnapActionError)
@@ -471,5 +471,6 @@ func installCandidates(st *state.State, names []string, channel string, user *au
 	theStore := Store(st, nil)
 	st.Unlock() // calls to the store should be done without holding the state lock
 	defer st.Lock()
-	return theStore.SnapAction(context.TODO(), curSnaps, actions, user, opts)
+	results, _, err := theStore.SnapAction(context.TODO(), curSnaps, actions, nil, user, opts)
+	return results, err
 }

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -177,6 +177,9 @@ var snapActionFields = jsonutil.StructFields((*storeSnap)(nil))
 // current installed snaps in currentSnaps. If the request was overall
 // successul (200) but there were reported errors it will return both
 // the snap infos and an SnapActionError.
+// Orthogonally and at the same time it can be used to fetch or update
+// assertions by passing an AssertionQuery whose ToResolve specifies
+// the assertions and revisions to consider.
 func (s *Store) SnapAction(ctx context.Context, currentSnaps []*CurrentSnap, actions []*SnapAction, assertQuery AssertionQuery, user *auth.UserState, opts *RefreshOptions) ([]SnapActionResult, []AssertionResult, error) {
 	if opts == nil {
 		opts = &RefreshOptions{}

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -230,11 +230,6 @@ type SnapActionResult struct {
 }
 
 func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, actions []*SnapAction, user *auth.UserState, opts *RefreshOptions) ([]SnapActionResult, error) {
-
-	// TODO: the store already requires instance-key but doesn't
-	// yet support repeating in context or sending actions for the
-	// same snap-id, for now we keep instance-key handling internal
-
 	requestSalt := ""
 	if opts != nil {
 		requestSalt = opts.PrivacyKey

--- a/store/store_action_fetch_assertions_test.go
+++ b/store/store_action_fetch_assertions_test.go
@@ -62,6 +62,8 @@ func (s *storeActionFetchAssertionsSuite) TestFetch(c *C) {
 		var req struct {
 			Context []map[string]interface{} `json:"context"`
 			Actions []map[string]interface{} `json:"actions"`
+
+			AssertionMaxFormats map[string]int `json:"assertion-max-formats"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -83,6 +85,8 @@ func (s *storeActionFetchAssertionsSuite) TestFetch(c *C) {
 			},
 		}
 		c.Assert(req.Actions[0], DeepEquals, expectedAction)
+
+		c.Assert(req.AssertionMaxFormats, DeepEquals, asserts.MaxSupportedFormats(1))
 
 		fmt.Fprintf(w, `{
   "results": [{
@@ -146,6 +150,8 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateIfNewerThan(c *C) {
 		var req struct {
 			Context []map[string]interface{} `json:"context"`
 			Actions []map[string]interface{} `json:"actions"`
+
+			AssertionMaxFormats map[string]int `json:"assertion-max-formats"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -186,6 +192,8 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateIfNewerThan(c *C) {
 			expectedActions = []map[string]interface{}{expectedAction2, expectedAction1}
 		}
 		c.Assert(req.Actions, DeepEquals, expectedActions)
+
+		c.Assert(req.AssertionMaxFormats, DeepEquals, asserts.MaxSupportedFormats(1))
 
 		fmt.Fprintf(w, `{
   "results": [{

--- a/store/store_action_fetch_assertions_test.go
+++ b/store/store_action_fetch_assertions_test.go
@@ -1,0 +1,260 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/store"
+)
+
+type storeActionFetchAssertionsSuite struct {
+	baseStoreSuite
+}
+
+var _ = Suite(&storeActionFetchAssertionsSuite{})
+
+type testAssertQuery struct {
+	toResolve map[asserts.Grouping][]*asserts.AtRevision
+}
+
+func (q *testAssertQuery) ToResolve() (map[asserts.Grouping][]*asserts.AtRevision, error) {
+	return q.toResolve, nil
+}
+
+func (s *storeActionFetchAssertionsSuite) TestFetch(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 0)
+		c.Assert(req.Actions, HasLen, 1)
+		expectedAction := map[string]interface{}{
+			"action": "fetch-assertions",
+			"key":    "g1",
+			"assertions": []interface{}{
+				map[string]interface{}{
+					"type": "snap-declaration",
+					"primary-key": []interface{}{
+						"16",
+						"iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
+					},
+				},
+			},
+		}
+		c.Assert(req.Actions[0], DeepEquals, expectedAction)
+
+		fmt.Fprintf(w, `{
+  "results": [{
+     "result": "fetch-assertions",
+     "key": "g1",
+     "assertion-stream-urls": [
+        "https://api.snapcraft.io/api/v1/snaps/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5"
+      ]
+     }
+   ]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+	}
+	dauthCtx := &testDauthContext{c: c, device: s.device}
+	sto := store.New(&cfg, dauthCtx)
+
+	assertq := &testAssertQuery{
+		toResolve: map[asserts.Grouping][]*asserts.AtRevision{
+			asserts.Grouping("g1"): {{
+				Ref: asserts.Ref{
+					Type: asserts.SnapDeclarationType,
+					PrimaryKey: []string{
+						"16",
+						"iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
+					},
+				},
+				Revision: asserts.RevisionNotKnown,
+			}},
+		},
+	}
+
+	results, aresults, err := sto.SnapAction(s.ctx, nil,
+		nil, assertq, nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(results, HasLen, 0)
+	c.Check(aresults, HasLen, 1)
+	c.Check(aresults[0].Grouping, Equals, asserts.Grouping("g1"))
+	c.Check(aresults[0].StreamURLs, DeepEquals, []string{
+		"https://api.snapcraft.io/api/v1/snaps/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
+	})
+}
+
+func (s *storeActionFetchAssertionsSuite) TestUpdateIfNewerThan(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 0)
+		c.Assert(req.Actions, HasLen, 2)
+		expectedAction1 := map[string]interface{}{
+			"action": "fetch-assertions",
+			"key":    "g1",
+			"assertions": []interface{}{
+				map[string]interface{}{
+					"type": "snap-declaration",
+					"primary-key": []interface{}{
+						"16",
+						"iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
+					},
+					"if-newer-than": float64(0),
+				},
+			},
+		}
+		expectedAction2 := map[string]interface{}{
+			"action": "fetch-assertions",
+			"key":    "g2",
+			"assertions": []interface{}{
+				map[string]interface{}{
+					"type": "snap-declaration",
+					"primary-key": []interface{}{
+						"16",
+						"CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6",
+					},
+					"if-newer-than": float64(1),
+				},
+			},
+		}
+		expectedActions := []map[string]interface{}{expectedAction1, expectedAction2}
+		if req.Actions[0]["key"] != "g1" {
+			expectedActions = []map[string]interface{}{expectedAction2, expectedAction1}
+		}
+		c.Assert(req.Actions, DeepEquals, expectedActions)
+
+		fmt.Fprintf(w, `{
+  "results": [{
+     "result": "fetch-assertions",
+     "key": "g1",
+     "assertion-stream-urls": [
+        "https://api.snapcraft.io/api/v1/snaps/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5"
+      ]
+     }, {
+     "result": "fetch-assertions",
+     "key": "g2",
+     "assertion-stream-urls": []
+     }
+   ]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+	}
+	dauthCtx := &testDauthContext{c: c, device: s.device}
+	sto := store.New(&cfg, dauthCtx)
+
+	assertq := &testAssertQuery{
+		toResolve: map[asserts.Grouping][]*asserts.AtRevision{
+			asserts.Grouping("g1"): {{
+				Ref: asserts.Ref{
+					Type: asserts.SnapDeclarationType,
+					PrimaryKey: []string{
+						"16",
+						"iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
+					},
+				},
+				Revision: 0,
+			}},
+			asserts.Grouping("g2"): {{
+				Ref: asserts.Ref{
+					Type: asserts.SnapDeclarationType,
+					PrimaryKey: []string{
+						"16",
+						"CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6",
+					},
+				},
+				Revision: 1,
+			}},
+		},
+	}
+
+	results, aresults, err := sto.SnapAction(s.ctx, nil,
+		nil, assertq, nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(results, HasLen, 0)
+	c.Check(aresults, HasLen, 2)
+	seen := 0
+	for _, aresult := range aresults {
+		if aresult.Grouping == asserts.Grouping("g1") {
+			seen++
+			c.Check(aresult.StreamURLs, DeepEquals, []string{
+				"https://api.snapcraft.io/api/v1/snaps/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
+			})
+		} else {
+			seen++
+			c.Check(aresult.Grouping, Equals, asserts.Grouping("g2"))
+			c.Check(aresult.StreamURLs, HasLen, 0)
+		}
+	}
+	c.Check(seen, Equals, 2)
+}

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -154,7 +154,7 @@ func (s *storeActionSuite) TestSnapAction(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, aresults, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -169,8 +169,9 @@ func (s *storeActionSuite) TestSnapAction(c *C) {
 			InstanceName: "hello-world",
 			CohortKey:    helloCohortKey,
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, IsNil)
+	c.Assert(aresults, HasLen, 0)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
 	c.Assert(results[0].Revision, Equals, snap.R(26))
@@ -263,7 +264,7 @@ func (s *storeActionSuite) TestSnapActionNonZeroEpochAndEpochBump(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -278,7 +279,7 @@ func (s *storeActionSuite) TestSnapActionNonZeroEpochAndEpochBump(c *C) {
 			SnapID:       helloWorldSnapID,
 			InstanceName: "hello-world",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -336,7 +337,7 @@ func (s *storeActionSuite) TestSnapActionNoResults(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -344,12 +345,12 @@ func (s *storeActionSuite) TestSnapActionNoResults(c *C) {
 			Revision:        snap.R(1),
 			RefreshedDate:   helloRefreshedDate,
 		},
-	}, nil, nil, nil)
+	}, nil, nil, nil, nil)
 	c.Check(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{NoResults: true})
 
 	// local no-op
-	results, err = sto.SnapAction(s.ctx, nil, nil, nil, nil)
+	results, _, err = sto.SnapAction(s.ctx, nil, nil, nil, nil, nil)
 	c.Check(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{NoResults: true})
 
@@ -400,14 +401,14 @@ func (s *storeActionSuite) TestSnapActionRefreshedDateIsOptional(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
 			TrackingChannel: "beta",
 			Revision:        snap.R(1),
 		},
-	}, nil, nil, nil)
+	}, nil, nil, nil, nil)
 	c.Check(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{NoResults: true})
 }
@@ -476,7 +477,7 @@ func (s *storeActionSuite) TestSnapActionSkipBlocked(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -492,7 +493,7 @@ func (s *storeActionSuite) TestSnapActionSkipBlocked(c *C) {
 			InstanceName: "hello-world",
 			Channel:      "stable",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{
 		Refresh: map[string]error{
@@ -565,7 +566,7 @@ func (s *storeActionSuite) TestSnapActionSkipCurrent(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -580,7 +581,7 @@ func (s *storeActionSuite) TestSnapActionSkipCurrent(c *C) {
 			InstanceName: "hello-world",
 			Channel:      "stable",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{
 		Refresh: map[string]error{
@@ -641,7 +642,7 @@ func (s *storeActionSuite) TestSnapActionRetryOnEOF(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -655,7 +656,7 @@ func (s *storeActionSuite) TestSnapActionRetryOnEOF(c *C) {
 			InstanceName: "hello-world",
 			Channel:      "stable",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
 	c.Assert(results, HasLen, 1)
@@ -728,7 +729,7 @@ func (s *storeActionSuite) TestSnapActionIgnoreValidation(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:     "hello-world",
 			SnapID:           helloWorldSnapID,
@@ -745,7 +746,7 @@ func (s *storeActionSuite) TestSnapActionIgnoreValidation(c *C) {
 			Channel:      "stable",
 			Flags:        store.SnapActionEnforceValidation,
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -795,7 +796,7 @@ func (s *storeActionSuite) TestSnapActionAutoRefresh(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -809,7 +810,7 @@ func (s *storeActionSuite) TestSnapActionAutoRefresh(c *C) {
 			SnapID:       helloWorldSnapID,
 			InstanceName: "hello-world",
 		},
-	}, nil, &store.RefreshOptions{IsAutoRefresh: true})
+	}, nil, nil, &store.RefreshOptions{IsAutoRefresh: true})
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 }
@@ -877,7 +878,7 @@ func (s *storeActionSuite) TestInstallFallbackChannelIsStable(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:  "hello-world",
 			SnapID:        helloWorldSnapID,
@@ -890,7 +891,7 @@ func (s *storeActionSuite) TestInstallFallbackChannelIsStable(c *C) {
 			SnapID:       helloWorldSnapID,
 			InstanceName: "hello-world",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -973,7 +974,7 @@ func (s *storeActionSuite) TestSnapActionNonDefaultsHeaders(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -987,7 +988,7 @@ func (s *storeActionSuite) TestSnapActionNonDefaultsHeaders(c *C) {
 			SnapID:       helloWorldSnapID,
 			InstanceName: "hello-world",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -1066,7 +1067,7 @@ func (s *storeActionSuite) TestSnapActionWithDeltas(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -1080,7 +1081,7 @@ func (s *storeActionSuite) TestSnapActionWithDeltas(c *C) {
 			SnapID:       helloWorldSnapID,
 			InstanceName: "hello-world",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -1153,7 +1154,7 @@ func (s *storeActionSuite) TestSnapActionOptions(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -1168,7 +1169,7 @@ func (s *storeActionSuite) TestSnapActionOptions(c *C) {
 			InstanceName: "hello-world",
 			Channel:      "stable",
 		},
-	}, nil, &store.RefreshOptions{RefreshManaged: true})
+	}, nil, nil, &store.RefreshOptions{RefreshManaged: true})
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -1270,7 +1271,7 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, nil,
+	results, _, err := sto.SnapAction(s.ctx, nil,
 		[]*store.SnapAction{
 			{
 				Action:       action,
@@ -1278,7 +1279,7 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 				Channel:      "beta",
 				CohortKey:    cohort,
 			},
-		}, nil, nil)
+		}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -1364,7 +1365,7 @@ func (s *storeActionSuite) TestSnapActionInstallAmend(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, nil,
+	results, _, err := sto.SnapAction(s.ctx, nil,
 		[]*store.SnapAction{
 			{
 				Action:       "install",
@@ -1372,7 +1373,7 @@ func (s *storeActionSuite) TestSnapActionInstallAmend(c *C) {
 				Channel:      "beta",
 				Epoch:        snap.E("1*"),
 			},
-		}, nil, nil)
+		}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -1418,7 +1419,7 @@ func (s *storeActionSuite) TestSnapActionWithClientUserAgent(c *C) {
 	c.Assert(err, IsNil)
 	ctx := store.WithClientUserAgent(s.ctx, r)
 
-	results, err := sto.SnapAction(ctx, nil, []*store.SnapAction{{Action: "install", InstanceName: "some-snap"}}, nil, nil)
+	results, _, err := sto.SnapAction(ctx, nil, []*store.SnapAction{{Action: "install", InstanceName: "some-snap"}}, nil, nil, nil)
 	c.Check(serverCalls, Equals, 1)
 	c.Check(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{NoResults: true})
@@ -1443,14 +1444,14 @@ func (s *storeActionSuite) TestSnapActionDownloadParallelInstanceKey(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	_, err := sto.SnapAction(s.ctx, nil,
+	_, _, err := sto.SnapAction(s.ctx, nil,
 		[]*store.SnapAction{
 			{
 				Action:       "download",
 				InstanceName: "hello-world_foo",
 				Channel:      "beta",
 			},
-		}, nil, nil)
+		}, nil, nil, nil)
 	c.Assert(err, ErrorMatches, `internal error: unsupported download with instance name "hello-world_foo"`)
 }
 
@@ -1533,14 +1534,14 @@ func (s *storeActionSuite) testSnapActionGetWithRevision(action string, c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, nil,
+	results, _, err := sto.SnapAction(s.ctx, nil,
 		[]*store.SnapAction{
 			{
 				Action:       action,
 				InstanceName: "hello-world",
 				Revision:     snap.R(28),
 			},
-		}, nil, nil)
+		}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -1668,7 +1669,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailable(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -1702,7 +1703,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			InstanceName: "bar",
 			Revision:     snap.R(42),
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{
 		Refresh: map[string]error{
@@ -1820,7 +1821,7 @@ func (s *storeActionSuite) TestSnapActionSnapNotFound(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -1843,7 +1844,7 @@ func (s *storeActionSuite) TestSnapActionSnapNotFound(c *C) {
 			InstanceName: "bar",
 			Revision:     snap.R(42),
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{
 		Refresh: map[string]error{
@@ -1908,13 +1909,13 @@ func (s *storeActionSuite) TestSnapActionOtherErrors(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, nil, []*store.SnapAction{
+	results, _, err := sto.SnapAction(s.ctx, nil, []*store.SnapAction{
 		{
 			Action:       "install",
 			InstanceName: "foo",
 			Channel:      "stable",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{
 		Other: []error{
@@ -1942,13 +1943,13 @@ func (s *storeActionSuite) TestSnapActionUnknownAction(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, nil,
+	results, _, err := sto.SnapAction(s.ctx, nil,
 		[]*store.SnapAction{
 			{
 				Action:       "something unexpected",
 				InstanceName: "hello-world",
 			},
-		}, nil, nil)
+		}, nil, nil, nil)
 	c.Assert(err, ErrorMatches, `.* unsupported action .*`)
 	c.Assert(results, IsNil)
 }
@@ -2249,7 +2250,7 @@ func (s *storeActionSuite) TestSnapActionRefreshesBothAuths(c *C) {
 		StoreBaseURL: mockServerURL,
 	}, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -2263,7 +2264,7 @@ func (s *storeActionSuite) TestSnapActionRefreshesBothAuths(c *C) {
 			SnapID:       helloWorldSnapID,
 			InstanceName: "hello-world",
 		},
-	}, s.user, nil)
+	}, nil, s.user, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
@@ -2344,7 +2345,7 @@ func (s *storeActionSuite) TestSnapActionRefreshParallelInstall(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -2365,7 +2366,7 @@ func (s *storeActionSuite) TestSnapActionRefreshParallelInstall(c *C) {
 			Channel:      "stable",
 			InstanceName: "hello-world_foo",
 		},
-	}, nil, &store.RefreshOptions{PrivacyKey: "123"})
+	}, nil, nil, &store.RefreshOptions{PrivacyKey: "123"})
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].SnapName(), Equals, "hello-world")
@@ -2473,7 +2474,7 @@ func (s *storeActionSuite) TestSnapActionRefreshStableInstanceKey(c *C) {
 			InstanceName: "hello-world_foo",
 		},
 	}
-	results, err := sto.SnapAction(s.ctx, currentSnaps, action, nil, opts)
+	results, _, err := sto.SnapAction(s.ctx, currentSnaps, action, nil, nil, opts)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].SnapName(), Equals, "hello-world")
@@ -2481,7 +2482,7 @@ func (s *storeActionSuite) TestSnapActionRefreshStableInstanceKey(c *C) {
 	c.Assert(results[0].Revision, Equals, snap.R(26))
 
 	// another request with the same seed, gives same result
-	resultsAgain, err := sto.SnapAction(s.ctx, currentSnaps, action, nil, opts)
+	resultsAgain, _, err := sto.SnapAction(s.ctx, currentSnaps, action, nil, nil, opts)
 	c.Assert(err, IsNil)
 	c.Assert(resultsAgain, DeepEquals, results)
 }
@@ -2581,7 +2582,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -2610,7 +2611,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *
 			InstanceName: "other_foo",
 			Channel:      "stable",
 		},
-	}, nil, &store.RefreshOptions{PrivacyKey: "123"})
+	}, nil, nil, &store.RefreshOptions{PrivacyKey: "123"})
 	c.Assert(results, HasLen, 0)
 	c.Check(err, DeepEquals, &store.SnapActionError{
 		Refresh: map[string]error{
@@ -2697,7 +2698,7 @@ func (s *storeActionSuite) TestSnapActionInstallParallelInstall(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -2711,7 +2712,7 @@ func (s *storeActionSuite) TestSnapActionInstallParallelInstall(c *C) {
 			InstanceName: "hello-world_foo",
 			Channel:      "stable",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].InstanceName(), Equals, "hello-world_foo")
@@ -2728,7 +2729,7 @@ func (s *storeActionSuite) TestSnapActionErrorsWhenNoInstanceName(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&store.Config{}, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -2741,7 +2742,7 @@ func (s *storeActionSuite) TestSnapActionErrorsWhenNoInstanceName(c *C) {
 			Action:  "install",
 			Channel: "stable",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, ErrorMatches, "internal error: action without instance name")
 	c.Assert(results, IsNil)
 }
@@ -2811,7 +2812,7 @@ func (s *storeActionSuite) TestSnapActionInstallUnexpectedInstallKey(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -2825,7 +2826,7 @@ func (s *storeActionSuite) TestSnapActionInstallUnexpectedInstallKey(c *C) {
 			InstanceName: "hello-world_foo",
 			Channel:      "stable",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, ErrorMatches, `unexpected invalid install/refresh API result: unexpected instance-key "foo-2"`)
 	c.Assert(results, IsNil)
 }
@@ -2894,7 +2895,7 @@ func (s *storeActionSuite) TestSnapActionRefreshUnexpectedInstanceKey(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -2909,7 +2910,7 @@ func (s *storeActionSuite) TestSnapActionRefreshUnexpectedInstanceKey(c *C) {
 			Channel:      "stable",
 			InstanceName: "hello-world",
 		},
-	}, nil, nil)
+	}, nil, nil, nil)
 	c.Assert(err, ErrorMatches, `unexpected invalid install/refresh API result: unexpected refresh`)
 	c.Assert(results, IsNil)
 }
@@ -2996,7 +2997,7 @@ func (s *storeActionSuite) TestSnapActionUnexpectedErrorKey(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	results, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
+	results, _, err := sto.SnapAction(s.ctx, []*store.CurrentSnap{
 		{
 			InstanceName:    "hello-world",
 			SnapID:          helloWorldSnapID,
@@ -3015,7 +3016,7 @@ func (s *storeActionSuite) TestSnapActionUnexpectedErrorKey(c *C) {
 			Action:       "install",
 			InstanceName: "foo-2",
 		},
-	}, nil, &store.RefreshOptions{PrivacyKey: "123"})
+	}, nil, nil, &store.RefreshOptions{PrivacyKey: "123"})
 	c.Assert(err, DeepEquals, &store.SnapActionError{
 		Other: []error{fmt.Errorf(`snap "hello-world_foo": The Snap is present more than once in the request.`)},
 	})

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -53,7 +53,7 @@ func (Store) Find(context.Context, *store.Search, *auth.UserState) ([]*snap.Info
 	panic("Store.Find not expected")
 }
 
-func (Store) SnapAction(context.Context, []*store.CurrentSnap, []*store.SnapAction, *auth.UserState, *store.RefreshOptions) ([]store.SnapActionResult, error) {
+func (Store) SnapAction(context.Context, []*store.CurrentSnap, []*store.SnapAction, store.AssertionQuery, *auth.UserState, *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
 	panic("Store.SnapAction not expected")
 }
 


### PR DESCRIPTION
This is meant for fetching or updating assertions.

Given that fetching assertions can be combined with but is orthogonal to snaps operations and that assertions have prerequisites constituting a DAG (let's ignore trusted assertions), and that fetch-assertions results point to streams of assertions which are not required to match one by one the requested assertions, this uses more free-form mechanisms than what we did for snaps to declare the assertions to fetch and to return the result stream lists. The idea is that an object implementing the AssertionQuery interface will be used to track resolved and to be resolved assertions across the possibly more than one store request needed to fetch some assertions and their prerequisites. That will be defined in asserts/pool.go that here just have an intermediate definition of Grouping.

Parsing error-lists will be done in an immediate follow up.
