### PR TITLE
overlord: have a variant of Mock that can take a state.State

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -136,7 +136,7 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	s.restoreOnClassic = release.MockOnClassic(false)
 
 	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
-	s.o = overlord.MockWithRestartHandler(func(req state.RestartType) {
+	s.o = overlord.MockWithStateAndRestartHandler(nil, func(req state.RestartType) {
 		s.restartRequests = append(s.restartRequests, req)
 	})
 	s.state = s.o.State()

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -622,20 +622,22 @@ func (o *Overlord) SnapshotManager() *snapshotstate.SnapshotManager {
 // Mock creates an Overlord without any managers and with a backend
 // not using disk. Managers can be added with AddManager. For testing.
 func Mock() *Overlord {
-	return MockWithRestartHandler(nil)
+	return MockWithStateAndRestartHandler(nil, nil)
 }
 
-// MockWithRestartHandler creates an Overlord without any managers and
-// with a backend not using disk. It will use the given handler on
-// restart requests. Managers can be added with AddManager. For
-// testing.
-func MockWithRestartHandler(handleRestart func(state.RestartType)) *Overlord {
+// MockWithStateAndRestartHandler creates an Overlord with the given state
+// unless it is nil in which case it uses a state backend not using
+// disk. It will use the given handler on restart requests. Managers
+// can be added with AddManager. For testing.
+func MockWithStateAndRestartHandler(s *state.State, handleRestart func(state.RestartType)) *Overlord {
 	o := &Overlord{
 		loopTomb:        new(tomb.Tomb),
 		inited:          false,
 		restartBehavior: mockRestartBehavior(handleRestart),
 	}
-	s := state.New(mockBackend{o: o})
+	if s == nil {
+		s = state.New(mockBackend{o: o})
+	}
 	o.stateEng = NewStateEngine(s)
 	o.runner = state.NewTaskRunner(s)
 


### PR DESCRIPTION
extend and rename MockWithRestartHandler for this

this is not used in the code base itself but is useful to write
prototype or testing code that requires only subsets of the whole
Overlord

