### PR TITLE
tests: update encrypted partition creation test

### DIFF
--- a/.github/workflows/test-go1.13.yaml
+++ b/.github/workflows/test-go1.13.yaml
@@ -92,6 +92,7 @@ jobs:
         system:
         - ubuntu-19.10-64
         - ubuntu-20.04-64
+        - ubuntu-20.04-64-secboot
         - ubuntu-core-20-64
         - debian-sid-64
         - fedora-30-64

--- a/spread.yaml
+++ b/spread.yaml
@@ -82,6 +82,7 @@ backends:
                 workers: 6
                 storage: 20G
             - ubuntu-20.04-64-secboot:
+                image: ubuntu-20.04-64
                 workers: 1
                 secureboot: true
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -145,6 +145,16 @@ backends:
             - ubuntu-19.10-64:
                 workers: 6
 
+    google-tpm:
+        type: google
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+        location: computeengine/us-east1-b
+        halt-timeout: 2h
+        systems:
+            - ubuntu-20.04-64:
+                workers: 6
+                secureboot: true
+
     google-nested:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'

--- a/spread.yaml
+++ b/spread.yaml
@@ -81,6 +81,9 @@ backends:
                 image: ubuntu-2004-64-virt-enabled
                 workers: 6
                 storage: 20G
+            - ubuntu-20.04-64-secboot:
+                workers: 1
+                secureboot: true
 
             - debian-9-64:
                 workers: 6
@@ -144,16 +147,6 @@ backends:
                 workers: 6
             - ubuntu-19.10-64:
                 workers: 6
-
-    google-tpm:
-        type: google
-        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: computeengine/us-east1-b
-        halt-timeout: 2h
-        systems:
-            - ubuntu-20.04-64:
-                workers: 6
-                secureboot: true
 
     google-nested:
         type: google

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -3,6 +3,9 @@ summary: Integration tests for the snap-bootstrap binary
 # use the same system and tooling as uc20
 systems: [ubuntu-20.04-64]
 
+# we need secure boot and TPM enabled for this test
+backends: [google-tpm]
+
 debug: |
     cat /proc/partitions
 
@@ -20,6 +23,8 @@ restore: |
         losetup -d "$(cat loop.txt)"
     fi
     apt remove -y cryptsetup
+
+    rm -Rf /run/mnt
 
 prepare: |
     echo "Create a fake block device image that looks like an image from u-i"
@@ -50,16 +55,26 @@ prepare: |
     snap download --channel=20/edge pc
     unsquashfs -d gadget-dir pc_*.snap
 
+    echo "Install EFI binaries"
+    bootdir=/run/mnt/ubuntu-boot/EFI/boot
+    mkdir -p "$bootdir"
+    cp /usr/lib/shim/shimx64.efi.signed "$bootdir"/bootx64.efi
+    cp /usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed "$bootdir"/grubx64.efi
+
 execute: |
+    bootdir=/run/mnt/ubuntu-boot/EFI/boot
+    ls -l "$bootdir"
+    sbverify --list "$bootdir"/bootx64.efi
+    sbverify --list "$bootdir"/grubx64.efi
     LOOP="$(cat loop.txt)"
     echo "Run the snap-bootstrap tool"
-    /usr/lib/snapd/snap-bootstrap create-partitions --mount \
+    /usr/lib/snapd/snap-bootstrap create-partitions \
         --encrypt --key-file keyfile \
-        --recovery-key-file /run/mnt/ubuntu-data/system-data/recovery-key \
+        --recovery-key-file recovery-key \
         ./gadget-dir "$LOOP"
 
     echo "Check that the key file was created"
-    test "$(stat --printf="%s" ./keyfile)" = 64
+    test "$(stat --printf="%s" ./keyfile)" = 1095
 
     echo "Check that the partitions are created"
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
@@ -73,33 +88,15 @@ execute: |
     cryptsetup isLuks "${LOOP}p4"
 
     cryptsetup luksDump "${LOOP}p4" | MATCH 'Label:\s*ubuntu-data-enc'
-
-    # we used "lsblk --fs" here but it was unreliable
-    df -T "${LOOP}p3" | MATCH ext4
     file -s "${LOOP}p3" | MATCH 'volume name "ubuntu-boot"'
-
-    df -T /dev/mapper/ubuntu-data | MATCH ext4
     POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
 
-    echo "Check that the filesystem content was deployed"
-    ls /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
-    ls /run/mnt/ubuntu-boot/EFI/boot/bootx64.efi
-    ls /run/mnt/ubuntu-boot/EFI/ubuntu/grub.cfg
-
-    umount /run/mnt/ubuntu-boot
-    umount /run/mnt/ubuntu-data
     cryptsetup close /dev/mapper/ubuntu-data
 
-    echo "Ensure that we can open the encrypted device using the key"
-    mkdir -p ./mnt
-    cryptsetup open --key-file keyfile "${LOOP}p4" test-udata
-    mount /dev/mapper/test-udata ./mnt
-    echo "Check that the recovery key was stored"
-    test "$(stat --printf="%s" ./mnt/system-data/recovery-key)" = 16
-    cp ./mnt/system-data/recovery-key .
-    umount ./mnt
-    cryptsetup close /dev/mapper/test-udata
+    # Can't test keyfile because it's now sealed to the TPM
 
+    # Test the recovery key
+    mkdir -p ./mnt
     echo "Ensure that we can open the encrypted device using the recovery key"
     cryptsetup open --key-file recovery-key "${LOOP}p4" test-recovery
     mount /dev/mapper/test-recovery ./mnt

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -1,10 +1,7 @@
 summary: Integration tests for the snap-bootstrap binary
 
 # use the same system and tooling as uc20
-systems: [ubuntu-20.04-64]
-
-# we need secure boot and TPM enabled for this test
-backends: [google-tpm]
+systems: [ubuntu-20.04-64-secboot]
 
 debug: |
     cat /proc/partitions


### PR DESCRIPTION
Update the create-partitions-encrypted test to handle sealed keys. This
test requires a spread back-end that supports TPM and secure boot (thanks
Sergio!).

Note: this also requires a spread binary that supports systems with the
secureboot attribute (https://github.com/snapcore/spread/pull/104).

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>