### PR TITLE
o/snapstate: tweak "waiting for restart" message

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -429,7 +429,7 @@ var CheckHealthHook = func(st *state.State, snapName string, rev snap.Revision) 
 func WaitRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 	if ok, _ := task.State().Restarting(); ok {
 		// don't continue until we are in the restarted snapd
-		task.Logf("Waiting for restart...")
+		task.Logf("Waiting for automatic snapd restart...")
 		return &state.Retry{}
 	}
 


### PR DESCRIPTION
Tweak "Waiting for restart..." log message to provide more info as it might be confusing for users if it appears on the terminal.
Fixes https://bugs.launchpad.net/snappy/+bug/1873452

