### PR TITLE
devicestate: add support for cloud.cfg.d config from the gadget

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -471,3 +471,30 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeNoCloudInitForSigned(c *C) {
 		{TargetRootDir: boot.InitramfsWritableDir},
 	})
 }
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitFromGadget(c *C) {
+	// XXX: this is slightly magic - in mockInstallModeChange() we create
+	//      a mock pc gadget snap with revno 1. This is why we can set
+	//      set gadget dir here
+	gadgetDir := filepath.Join(dirs.SnapMountDir, "pc/1/")
+
+	// pretend we have a cloud-init config in our gadget
+	cloudCfg := filepath.Join(gadgetDir, "cloud.cfg.d")
+	err := os.MkdirAll(cloudCfg, 0755)
+	c.Assert(err, IsNil)
+	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {
+		err = ioutil.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	// cloud init config from gadget works for signed models too
+	s.mockInstallModeChange(c, "signed")
+
+	// and did tell sysconfig about the cloud-init files
+	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
+		{
+			CloudInitSrcDir: filepath.Join(gadgetDir, "cloud.cfg.d"),
+			TargetRootDir:   boot.InitramfsWritableDir,
+		},
+	})
+}

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -63,9 +63,8 @@ func installCloudInitCfg(src, targetdir string) error {
 }
 
 // disable cloud-init by default (as it's not confined)
-// TODO:UC20: - allow gadget cloud.cfg.d/* (with whitelisted keys?)
-//            - allow cloud.cfg.d (with whitelisted keys) for non
-//               grade dangerous systems
+// TODO:UC20: - allow cloud.cfg.d (with whitelisted keys) for non
+//              grade dangerous systems
 func configureCloudInit(opts *Options) (err error) {
 	if opts.TargetRootDir == "" {
 		return fmt.Errorf("unable to configure cloud-init, missing target dir")


### PR DESCRIPTION
This commit adds support for cloud init data from the gadget. If
the gadget snap has a dir `cloud.cfg.d` all the content of that
dir is copied to the `ubuntu-data` partition during the install
phase.

