### PR TITLE
boot: store model model and grade information in modeenv

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -246,7 +246,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		RecoverySystem: filepath.Base(bootWith.RecoverySystemDir),
 		Base:           filepath.Base(bootWith.BasePath),
 		CurrentKernels: []string{bootWith.Kernel.Filename()},
-		Brand:          model.BrandID(),
+		BrandID:        model.BrandID(),
 		Model:          model.Model(),
 		Grade:          string(model.Grade()),
 	}

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -245,6 +245,9 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		RecoverySystem: filepath.Base(bootWith.RecoverySystemDir),
 		Base:           filepath.Base(bootWith.BasePath),
 		CurrentKernels: []string{bootWith.Kernel.Filename()},
+		Brand:          model.BrandID(),
+		Model:          model.Model(),
+		Grade:          string(model.Grade()),
 	}
 	if err := modeenv.WriteTo(InitramfsWritableDir); err != nil {
 		return fmt.Errorf("cannot write modeenv: %v", err)

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -584,5 +584,7 @@ version: 5.0
 recovery_system=20191216
 base=core20_3.snap
 current_kernels=arm-kernel_5.snap
+model=my-brand/my-model-uc20
+grade=dangerous
 `)
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -416,6 +416,8 @@ version: 5.0
 recovery_system=20191216
 base=core20_3.snap
 current_kernels=pc-kernel_5.snap
+model=my-brand/my-model-uc20
+grade=dangerous
 `)
 }
 

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -41,6 +41,9 @@ type Modeenv struct {
 	TryBase        string
 	BaseStatus     string
 	CurrentKernels []string
+	Model          string
+	Brand          string
+	Grade          string
 
 	// read is set to true when a modenv was read successfully
 	read bool
@@ -87,6 +90,18 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 		}
 		kernels = nonEmptyKernels
 	}
+	brand := ""
+	model := ""
+	brandSlashModel, _ := cfg.Get("", "model")
+	if bsmSplit := strings.SplitN(brandSlashModel, "/", 2); len(bsmSplit) == 2 {
+		if bsmSplit[0] != "" && bsmSplit[1] != "" {
+			brand = bsmSplit[0]
+			model = bsmSplit[1]
+		}
+	}
+	// expect the caller to validate the grade
+	grade, _ := cfg.Get("", "grade")
+
 	return &Modeenv{
 		Mode:           mode,
 		RecoverySystem: recoverySystem,
@@ -94,6 +109,9 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 		TryBase:        tryBase,
 		BaseStatus:     baseStatus,
 		CurrentKernels: kernels,
+		Brand:          brand,
+		Grade:          grade,
+		Model:          model,
 		read:           true,
 		originRootdir:  rootdir,
 	}, nil
@@ -133,6 +151,18 @@ func (m *Modeenv) WriteTo(rootdir string) error {
 	}
 	if len(m.CurrentKernels) != 0 {
 		fmt.Fprintf(buf, "current_kernels=%s\n", strings.Join(m.CurrentKernels, ","))
+	}
+	if m.Model != "" || m.Grade != "" {
+		if m.Model == "" {
+			return fmt.Errorf("internal error: model is unset")
+		}
+		if m.Brand == "" {
+			return fmt.Errorf("internal error: brand is unset")
+		}
+		fmt.Fprintf(buf, "model=%s/%s\n", m.Brand, m.Model)
+	}
+	if m.Grade != "" {
+		fmt.Fprintf(buf, "grade=%s\n", m.Grade)
 	}
 
 	if err := osutil.AtomicWriteFile(modeenvPath, buf.Bytes(), 0644, 0); err != nil {

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -42,7 +42,7 @@ type Modeenv struct {
 	BaseStatus     string
 	CurrentKernels []string
 	Model          string
-	Brand          string
+	BrandID        string
 	Grade          string
 
 	// read is set to true when a modenv was read successfully
@@ -109,7 +109,7 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 		TryBase:        tryBase,
 		BaseStatus:     baseStatus,
 		CurrentKernels: kernels,
-		Brand:          brand,
+		BrandID:        brand,
 		Grade:          grade,
 		Model:          model,
 		read:           true,
@@ -156,10 +156,10 @@ func (m *Modeenv) WriteTo(rootdir string) error {
 		if m.Model == "" {
 			return fmt.Errorf("internal error: model is unset")
 		}
-		if m.Brand == "" {
+		if m.BrandID == "" {
 			return fmt.Errorf("internal error: brand is unset")
 		}
-		fmt.Fprintf(buf, "model=%s/%s\n", m.Brand, m.Model)
+		fmt.Fprintf(buf, "model=%s/%s\n", m.BrandID, m.Model)
 	}
 	if m.Grade != "" {
 		fmt.Fprintf(buf, "grade=%s\n", m.Grade)

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -113,6 +113,59 @@ base_status=try
 	c.Check(modeenv.BaseStatus, Equals, boot.TryStatus)
 }
 
+func (s *modeenvSuite) TestReadModeWithGrade(c *C) {
+	s.makeMockModeenvFile(c, `mode=run
+grade=dangerous
+`)
+	modeenv, err := boot.ReadModeenv(s.tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(modeenv.Mode, Equals, "run")
+	c.Check(modeenv.Grade, Equals, "dangerous")
+
+	s.makeMockModeenvFile(c, `mode=run
+grade=some-random-grade-string
+`)
+	modeenv, err = boot.ReadModeenv(s.tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(modeenv.Mode, Equals, "run")
+	c.Check(modeenv.Grade, Equals, "some-random-grade-string")
+}
+
+func (s *modeenvSuite) TestReadModeWithModel(c *C) {
+	tt := []struct {
+		entry        string
+		model, brand string
+	}{
+		{
+			entry: "my-brand/my-model",
+			brand: "my-brand",
+			model: "my-model",
+		}, {
+			entry: "my-brand/",
+		}, {
+			entry: "my-model/",
+		}, {
+			entry: "foobar",
+		}, {
+			entry: "/",
+		}, {
+			entry: ",",
+		}, {
+			entry: "",
+		},
+	}
+
+	for _, t := range tt {
+		s.makeMockModeenvFile(c, `mode=run
+model=`+t.entry+"\n")
+		modeenv, err := boot.ReadModeenv(s.tmpdir)
+		c.Assert(err, IsNil)
+		c.Check(modeenv.Mode, Equals, "run")
+		c.Check(modeenv.Model, Equals, t.model)
+		c.Check(modeenv.Brand, Equals, t.brand)
+	}
+}
+
 func (s *modeenvSuite) TestReadModeWithCurrentKernels(c *C) {
 
 	tt := []struct {

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -162,7 +162,7 @@ model=`+t.entry+"\n")
 		c.Assert(err, IsNil)
 		c.Check(modeenv.Mode, Equals, "run")
 		c.Check(modeenv.Model, Equals, t.model)
-		c.Check(modeenv.Brand, Equals, t.brand)
+		c.Check(modeenv.BrandID, Equals, t.brand)
 	}
 }
 


### PR DESCRIPTION
Add support for storing brand/model and model grade information inside the
modeenv for later use.
