### PR TITLE
overlord/devicestate: preserve the current model inside ubuntu-boot

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -20,6 +20,7 @@
 package devicestate_test
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -215,6 +216,9 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	c.Assert(modeenv.WriteTo(""), IsNil)
 	devicestate.SetSystemMode(s.mgr, "install")
 
+	err := os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755)
+	c.Assert(err, IsNil)
+
 	s.settle(c)
 
 	// the install-system change is created
@@ -368,7 +372,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallSecuredBypassEncryption(c *C) {
 	c.Assert(err, ErrorMatches, "(?s).*cannot encrypt secured device: TPM not available.*")
 }
 
-func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade string) {
+func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade string) *asserts.Model {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
@@ -392,7 +396,12 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade strin
 	c.Assert(modeenv.WriteTo(""), IsNil)
 	devicestate.SetSystemMode(s.mgr, "install")
 
+	err := os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755)
+	c.Assert(err, IsNil)
+
 	s.settle(c)
+
+	return mockModel
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
@@ -470,4 +479,25 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeNoCloudInitForSigned(c *C) {
 	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
 		{TargetRootDir: boot.InitramfsWritableDir},
 	})
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeWritesModel(c *C) {
+	// pretend we have a cloud-init config on the seed partition
+	model := s.mockInstallModeChange(c, "dangerous")
+
+	var buf bytes.Buffer
+	err := asserts.NewEncoder(&buf).Encode(model)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	installSystem := s.findInstallSystem()
+	c.Assert(installSystem, NotNil)
+
+	// and was run successfully
+	c.Check(installSystem.Err(), IsNil)
+	c.Check(installSystem.Status(), Equals, state.DoneStatus)
+
+	c.Check(filepath.Join(boot.InitramfsUbuntuBootDir, "model"), testutil.FileEquals, buf.String())
 }

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -216,6 +216,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	c.Assert(modeenv.WriteTo(""), IsNil)
 	devicestate.SetSystemMode(s.mgr, "install")
 
+	// normally done by snap-bootstrap
 	err := os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755)
 	c.Assert(err, IsNil)
 
@@ -396,6 +397,7 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade strin
 	c.Assert(modeenv.WriteTo(""), IsNil)
 	devicestate.SetSystemMode(s.mgr, "install")
 
+	// normally done by snap-bootstrap
 	err := os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755)
 	c.Assert(err, IsNil)
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -43,7 +43,7 @@ var (
 	sysconfigConfigureRunSystem = sysconfig.ConfigureRunSystem
 )
 
-func storeModel(model *asserts.Model, where string) error {
+func writeModel(model *asserts.Model, where string) error {
 	f, err := os.OpenFile(where, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// keep track of the model we installed
-	err = storeModel(deviceCtx.Model(), filepath.Join(boot.InitramfsUbuntuBootDir, "model"))
+	err = writeModel(deviceCtx.Model(), filepath.Join(boot.InitramfsUbuntuBootDir, "model"))
 	if err != nil {
 		return fmt.Errorf("cannot store the model: %v", err)
 	}


### PR DESCRIPTION
Preserve the installed model inside ubuntu-boot partition. We will need to
measure the model attributes in initramfs, this change enables that.
