### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: mount ubuntu-seed first, other misc changes

### DIFF
--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -171,7 +171,7 @@ func Run(gadgetRoot, device string, options Options) error {
 // TODO:UC20: get cmdline definition from bootloaders
 var kernelCmdlines = []string{
 	// run mode
-	"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 rd.systemd.unit=basic.target snapd_recovery_mode=run",
+	"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
 }
 
 func tpmSealKey(key partition.EncryptionKey, rkey partition.RecoveryKey, options Options) error {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -305,13 +305,16 @@ func generateMountsCommonInstallRecover(recoverySystem string) (allMounted bool,
 
 func generateMountsModeRun() error {
 	// 1.1 always ensure basic partitions are mounted
-	for _, d := range []string{boot.InitramfsUbuntuSeedDir, boot.InitramfsUbuntuBootDir} {
+	for _, d := range []string{boot.InitramfsUbuntuBootDir, boot.InitramfsUbuntuSeedDir} {
 		isMounted, err := osutilIsMounted(d)
 		if err != nil {
 			return err
 		}
 		if !isMounted {
+			// we need ubuntu-seed to be mounted before we can continue to
+			// check ubuntu-data, so return if we need something mounted
 			fmt.Fprintf(stdout, "/dev/disk/by-label/%s %s\n", filepath.Base(d), d)
+			return nil
 		}
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -72,6 +72,10 @@ var (
 	osutilIsMounted = osutil.IsMounted
 )
 
+var (
+	diskByLabel = "/dev/disk/by-label"
+)
+
 func recoverySystemEssentialSnaps(seedDir, recoverySystem string, essentialTypes []snap.Type) ([]*seed.Snap, error) {
 	systemSeed, err := seed.Open(seedDir, recoverySystem)
 	if err != nil {
@@ -516,7 +520,7 @@ func generateInitramfsMounts() error {
 }
 
 func unlockIfEncrypted(name string) (string, error) {
-	device := filepath.Join("/dev/disk/by-label", name)
+	device := filepath.Join(diskByLabel, name)
 	encdev := device + "-enc"
 	if osutil.FileExists(encdev) {
 		// TODO:UC20: snap-bootstrap should validate that <name>-enc is what

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -73,6 +73,7 @@ var (
 )
 
 var (
+	// for mocking by tests
 	devDiskByLabelDir = "/dev/disk/by-label"
 )
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -73,7 +73,7 @@ var (
 )
 
 var (
-	diskByLabel = "/dev/disk/by-label"
+	devDiskByLabelDir = "/dev/disk/by-label"
 )
 
 func recoverySystemEssentialSnaps(seedDir, recoverySystem string, essentialTypes []snap.Type) ([]*seed.Snap, error) {
@@ -523,8 +523,8 @@ func generateInitramfsMounts() error {
 }
 
 func unlockIfEncrypted(name string) (string, error) {
-	device := filepath.Join(diskByLabel, name)
-	encdev := device + "-enc"
+	device := filepath.Join(devDiskByLabelDir, name)
+	encdev := filepath.Join(devDiskByLabelDir, name+"-enc")
 	if osutil.FileExists(encdev) {
 		// TODO:UC20: snap-bootstrap should validate that <name>-enc is what
 		//            we expect (and not e.g. an external disk), and also that

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -322,7 +322,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1EncryptedData(c *C
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(ubuntuDataEnc, nil, 0644)
 	c.Assert(err, IsNil)
-	restore := main.MockDevDiskByLabel(mockDevDiskByLabel)
+	restore := main.MockDevDiskByLabelDir(mockDevDiskByLabel)
 	defer restore()
 
 	// setup a fake tpm

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -100,3 +100,11 @@ func MockSecbootActivateVolumeWithTPMSealedKey(f func(tpm *secboot.TPMConnection
 		secbootActivateVolumeWithTPMSealedKey = oldSecbootActivateVolumeWithTPMSealedKey
 	}
 }
+
+func MockDevDiskByLabel(new string) (restore func()) {
+	old := diskByLabel
+	diskByLabel = new
+	return func() {
+		diskByLabel = old
+	}
+}

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -101,10 +101,10 @@ func MockSecbootActivateVolumeWithTPMSealedKey(f func(tpm *secboot.TPMConnection
 	}
 }
 
-func MockDevDiskByLabel(new string) (restore func()) {
-	old := diskByLabel
-	diskByLabel = new
+func MockDevDiskByLabelDir(new string) (restore func()) {
+	old := devDiskByLabelDir
+	devDiskByLabelDir = new
 	return func() {
-		diskByLabel = old
+		devDiskByLabelDir = old
 	}
 }


### PR DESCRIPTION
This is necessary because ubuntu-data-enc needs the keyfile on ubuntu-seed, so we need to return to let "the-tool" mount that before trying to decrypt ubuntu-data-enc.

* Mount ubuntu-boot first in preparation for the eventual cross-check with partitions mounted that match the booted kernel
* Also add test for decrypting ubuntu-data-enc
* Update the kernel cmdline to match https://github.com/snapcore/pc-amd64-gadget/pull/43