### PR TITLE
seccomp: add get_tls, io_pg* and *time64/*64 variants for existing syscalls

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -260,8 +260,11 @@ chown
 chown32
 chroot
 clock_getres
+clock_getres_time64
 clock_gettime
+clock_gettime64
 clock_nanosleep
+clock_nanosleep_time64
 clone
 close
 connect
@@ -313,6 +316,7 @@ fsync
 ftruncate
 ftruncate64
 futex
+futex_time64
 futimesat
 getcpu
 getcwd
@@ -345,6 +349,7 @@ getsid
 getsockname
 getsockopt
 get_thread_area
+get_tls
 gettid
 gettimeofday
 getuid
@@ -401,7 +406,9 @@ mq_getsetattr
 mq_notify
 mq_open
 mq_timedreceive
+mq_timedreceive_time64
 mq_timedsend
+mq_timedsend_time64
 mq_unlink
 mremap
 msgctl
@@ -424,6 +431,7 @@ pipe
 pipe2
 poll
 ppoll
+ppoll_time64
 prctl
 pread64
 preadv
@@ -431,6 +439,7 @@ prlimit64
 process_vm_readv
 process_vm_writev
 pselect6
+pselect6_time64
 pwrite64
 pwritev
 read
@@ -442,6 +451,7 @@ reboot
 recv
 recvfrom
 recvmmsg
+recvmmsg_time64
 recvmsg
 remap_file_pages
 removexattr
@@ -457,6 +467,7 @@ rt_sigqueueinfo
 rt_sigreturn
 rt_sigsuspend
 rt_sigtimedwait
+rt_sigtimedwait_time64
 rt_tgsigqueueinfo
 s390_pci_mmio_read
 s390_pci_mmio_write
@@ -468,6 +479,7 @@ sched_get_priority_max
 sched_get_priority_min
 sched_getscheduler
 sched_rr_get_interval
+sched_rr_get_interval_time64
 sched_setaffinity
 sched_setattr
 sched_setparam
@@ -479,6 +491,7 @@ semctl
 semget
 semop
 semtimedop
+semtimedop_time64
 send
 sendfile
 sendfile64
@@ -550,10 +563,14 @@ timer_create
 timer_delete
 timerfd_create
 timerfd_gettime
+timerfd_gettime64
 timerfd_settime
+timerfd_settime64
 timer_getoverrun
 timer_gettime
+timer_gettime64
 timer_settime
+timer_settime64
 times
 tkill
 truncate
@@ -568,6 +585,7 @@ unlinkat
 unshare
 utime
 utimensat
+utimensat_time64
 utimes
 vfork
 vhangup

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -49,6 +49,7 @@ brk
 # ARM private syscalls
 breakpoint
 cacheflush
+get_tls
 set_tls
 usr26
 usr32
@@ -95,8 +96,11 @@ lchown - -1 g:root
 lchown32 - -1 g:root
 
 clock_getres
+clock_getres_time64
 clock_gettime
+clock_gettime64
 clock_nanosleep
+clock_nanosleep_time64
 clone
 close
 
@@ -135,6 +139,7 @@ flock
 fork
 ftime
 futex
+futex_time64
 get_mempolicy
 get_robust_list
 get_thread_area
@@ -188,6 +193,8 @@ ioctl - !TIOCSTI
 io_cancel
 io_destroy
 io_getevents
+io_pgetevents
+io_pgetevents_time64
 io_setup
 io_submit
 ioprio_get
@@ -244,7 +251,9 @@ mprotect
 #mq_notify
 #mq_open
 #mq_timedreceive
+#mq_timedreceive_time64
 #mq_timedsend
+#mq_timedsend_time64
 #mq_unlink
 
 mremap
@@ -284,6 +293,7 @@ pipe
 pipe2
 poll
 ppoll
+ppoll_time64
 
 # LP: #1446748 - support syscall arg filtering
 prctl
@@ -305,6 +315,7 @@ recv
 recvfrom
 recvmsg
 recvmmsg
+recvmmsg_time64
 
 remap_file_pages
 
@@ -328,6 +339,7 @@ rt_sigqueueinfo
 rt_sigreturn
 rt_sigsuspend
 rt_sigtimedwait
+rt_sigtimedwait_time64
 rt_tgsigqueueinfo
 sched_getaffinity
 sched_getattr
@@ -336,6 +348,7 @@ sched_get_priority_max
 sched_get_priority_min
 sched_getscheduler
 sched_rr_get_interval
+sched_rr_get_interval_time64
 # enforce pid_t is 0 so the app may only change its own scheduler and affinity.
 # Use process-control interface for controlling other pids.
 sched_setaffinity 0 - -
@@ -357,6 +370,7 @@ select
 _newselect
 pselect
 pselect6
+pselect6_time64
 
 # Allow use of SysV semaphores. Note that allocated resources are not freed by
 # OOM which can lead to global kernel resource leakage.
@@ -364,6 +378,7 @@ semctl
 semget
 semop
 semtimedop
+semtimedop_time64
 
 # allow sending to sockets
 send
@@ -516,11 +531,15 @@ timer_create
 timer_delete
 timer_getoverrun
 timer_gettime
+timer_gettime64
 timer_settime
+timer_settime64
 timerfd
 timerfd_create
 timerfd_gettime
+timerfd_gettime64
 timerfd_settime
+timerfd_settime64
 times
 tkill
 
@@ -540,6 +559,7 @@ unlinkat
 
 utime
 utimensat
+utimensat_time64
 utimes
 futimesat
 


### PR DESCRIPTION
https://github.com/snapcore/core20/issues/48#issuecomment-618000806 lists new syscalls since 4.13, but this PR doesn't add all of them. This PR adds:
* get_tls
* io_pgetevents
* *time64 and *64 variants for existing syscalls

I'll review the others for the next batch of policy updates.

References:
- https://github.com/snapcore/core20/issues/48