### PR TITLE
devicestate: do not use snap-boostrap in devicestate to install

### DIFF
--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nosecboot
 
 /*
  * Copyright (C) 2019-2020 Canonical Ltd
@@ -33,23 +34,6 @@ const (
 	ubuntuDataLabel = "ubuntu-data"
 )
 
-type Options struct {
-	// Also mount the filesystems after creation
-	Mount bool
-	// Encrypt the data partition
-	Encrypt bool
-	// KeyFile is the location where the encryption key is written to
-	KeyFile string
-	// RecoveryKeyFile is the location where the recovery key is written to
-	RecoveryKeyFile string
-	// TPMLockoutAuthFile is the location where the TPM lockout authorization is written to
-	TPMLockoutAuthFile string
-	// PolicyUpdateDataFile is the location where the authorization policy update data is written to
-	PolicyUpdateDataFile string
-	// KernelPath is the path to the kernel to seal the keyfile to
-	KernelPath string
-}
-
 func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err error) {
 	for _, vs := range lv.LaidOutStructure {
 		// XXX: this part of the finding maybe should be a
@@ -65,6 +49,8 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 	return "", fmt.Errorf("cannot find role %s in gadget", role)
 }
 
+// Run bootstraps the partitions of a device, by either creating
+// missing ones or recreating installed ones.
 func Run(gadgetRoot, device string, options Options) error {
 	if options.Encrypt && (options.KeyFile == "" || options.RecoveryKeyFile == "") {
 		return fmt.Errorf("key file and recovery key file must be specified when encrypting")

--- a/cmd/snap-bootstrap/bootstrap/bootstrap_dummy.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap_dummy.go
@@ -1,8 +1,8 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-// +build !nosecboot
+// +build nosecboot
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,7 +20,10 @@
 
 package bootstrap
 
-var (
-	EnsureLayoutCompatibility = ensureLayoutCompatibility
-	DeviceFromRole            = deviceFromRole
+import (
+	"fmt"
 )
+
+func Run(gadgetRoot, device string, options Options) error {
+	return fmt.Errorf("build without secboot support")
+}

--- a/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nosecboot
 
 /*
  * Copyright (C) 2019 Canonical Ltd

--- a/cmd/snap-bootstrap/bootstrap/options.go
+++ b/cmd/snap-bootstrap/bootstrap/options.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package bootstrap
+
+type Options struct {
+	// Also mount the filesystems after creation
+	Mount bool
+	// Encrypt the data partition
+	Encrypt bool
+	// KeyFile is the location where the encryption key is written to
+	KeyFile string
+	// RecoveryKeyFile is the location where the recovery key is written to
+	RecoveryKeyFile string
+	// TPMLockoutAuthFile is the location where the TPM lockout authorization is written to
+	TPMLockoutAuthFile string
+	// PolicyUpdateDataFile is the location where the authorization policy update data is written to
+	PolicyUpdateDataFile string
+	// KernelPath is the path to the kernel to seal the keyfile to
+	KernelPath string
+}

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/sysconfig"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type deviceMgrInstallModeSuite struct {

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
-	// XXX: move bootstrap pkg elsewhere
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -176,6 +175,10 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	var brOpts bootstrap.Options
 	var bootstrapRunCalled int
 	restore = devicestate.MockBootstrapRun(func(gadgetRoot, device string, options bootstrap.Options) error {
+		// ensure we can grab the lock here, i.e. that it's not taken
+		s.state.Lock()
+		defer s.state.Unlock()
+
 		brGadgetRoot = gadgetRoot
 		brDevice = device
 		brOpts = options

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -177,7 +177,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	restore = devicestate.MockBootstrapRun(func(gadgetRoot, device string, options bootstrap.Options) error {
 		// ensure we can grab the lock here, i.e. that it's not taken
 		s.state.Lock()
-		defer s.state.Unlock()
+		s.state.Unlock()
 
 		brGadgetRoot = gadgetRoot
 		brDevice = device

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	// XXX: move bootstrap pkg elsewhere
+	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -232,5 +234,13 @@ func MockSysconfigConfigureRunSystem(f func(opts *sysconfig.Options) error) (res
 	sysconfigConfigureRunSystem = f
 	return func() {
 		sysconfigConfigureRunSystem = old
+	}
+}
+
+func MockBootstrapRun(f func(gadgetRoot, device string, options bootstrap.Options) error) (restore func()) {
+	old := bootstrapRun
+	bootstrapRun = f
+	return func() {
+		bootstrapRun = old
 	}
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
-	// XXX: move bootstrap pkg elsewhere
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/httputil"

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -21,6 +21,7 @@ package devicestate
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/tomb.v2"

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -26,7 +26,9 @@ import (
 
 	"gopkg.in/tomb.v2"
 
-	// XXX: move bootstrap pkg elsewhere
+	// TODO:UC20 look into merging
+	// snap-bootstrap/bootstrap|partition into gadget or
+	// supackages there cleanly
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 
 	"github.com/snapcore/snapd/asserts"

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -21,11 +21,12 @@ package devicestate
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"path/filepath"
 
 	"gopkg.in/tomb.v2"
+
+	// XXX: move bootstrap pkg elsewhere
+	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
@@ -41,6 +42,7 @@ import (
 var (
 	bootMakeBootable            = boot.MakeBootable
 	sysconfigConfigureRunSystem = sysconfig.ConfigureRunSystem
+	bootstrapRun                = bootstrap.Run
 )
 
 func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
@@ -68,45 +70,31 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 	kernelDir := kernelInfo.MountDir()
 
-	args := []string{
-		// create partitions missing from the device
-		"create-partitions",
-		// mount filesystems after they're created
-		"--mount",
+	// bootstrap
+	bopts := bootstrap.Options{
+		Mount: true,
 	}
-
 	useEncryption, err := checkEncryption(deviceCtx.Model())
 	if err != nil {
 		return err
 	}
 	if useEncryption {
 		fdeDir := "var/lib/snapd/device/fde"
-		args = append(args,
-			// enable data encryption
-			"--encrypt",
-			// location to store the keyfile
-			"--key-file", filepath.Join(boot.InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
-			// location to store the recovery keyfile
-			"--recovery-key-file", filepath.Join(boot.InitramfsWritableDir, fdeDir, "recovery.key"),
-			// location to store the recovery keyfile
-			"--tpm-lockout-auth", filepath.Join(boot.InitramfsWritableDir, fdeDir, "tpm-lockout-auth"),
-			// location to store the authorization policy update data
-			"--policy-update-data-file", filepath.Join(boot.InitramfsWritableDir, fdeDir, "policy-update-data"),
-			// path to the kernel to install
-			"--kernel", filepath.Join(kernelDir, "kernel.efi"),
-		)
+		bopts.Encrypt = true
+		bopts.KeyFile = filepath.Join(boot.InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key")
+		bopts.RecoveryKeyFile = filepath.Join(boot.InitramfsWritableDir, fdeDir, "recovery.key")
+		bopts.TPMLockoutAuthFile = filepath.Join(boot.InitramfsWritableDir, fdeDir, "tpm-lockout-auth")
+		bopts.PolicyUpdateDataFile = filepath.Join(boot.InitramfsWritableDir, fdeDir, "policy-update-data")
+		bopts.KernelPath = filepath.Join(kernelDir, "kernel.efi")
 	}
-	args = append(args, gadgetDir)
 
 	// run the create partition code
 	logger.Noticef("create and deploy partitions")
 	st.Unlock()
-	cmd := exec.Command(filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), args...)
-	cmd.Stderr = os.Stderr
-	output, err := cmd.Output()
+	err = bootstrapRun(gadgetDir, "", bopts)
 	st.Lock()
 	if err != nil {
-		return fmt.Errorf("cannot create partitions: %v", osutil.OutputErr(output, err))
+		return fmt.Errorf("cannot create partitions: %v", err)
 	}
 
 	// configure the run system

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -28,7 +28,7 @@ import (
 
 	// TODO:UC20 look into merging
 	// snap-bootstrap/bootstrap|partition into gadget or
-	// supackages there cleanly
+	// subpackages there cleanly
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 
 	"github.com/snapcore/snapd/asserts"

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -102,9 +102,11 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 
 	// run the create partition code
 	logger.Noticef("create and deploy partitions")
-	st.Unlock()
-	err = bootstrapRun(gadgetDir, "", bopts)
-	st.Lock()
+	func() {
+		st.Unlock()
+		defer st.Lock()
+		err = bootstrapRun(gadgetDir, "", bopts)
+	}()
 	if err != nil {
 		return fmt.Errorf("cannot create partitions: %v", err)
 	}

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -140,7 +140,7 @@ override_dh_auto_build:
 	mkdir -p _build/src/$(DH_GOPKG)/cmd/snap/test-data
 	cp -a cmd/snap/test-data/*.gpg _build/src/$(DH_GOPKG)/cmd/snap/test-data/
 	# exclude certain parts that won't be used by debian
-	rm -rf _build/src/$(DH_GOPKG)/cmd/snap-bootstrap
+	find _build/src/$(DH_GOPKG)/cmd/snap-bootstrap -name "*.go" | grep -vE '(bootstrap_dummy\.go|options\.go)'| xargs rm -f
 	# XXX: once dh-golang understands go build tags this would not be needed
 	find _build/src/$(DH_GOPKG)/secboot/ -name "*.go" | grep -Ev '(secboot_dummy\.go|secboot\.go)' | xargs rm -f
 	# and build


### PR DESCRIPTION
This commit changes the way that devicestate creates the
partitions. Instead of calling the snap-bootstrap binary
directly it will import the "bootstrap" package and run it
from inside the code.

This is the minimal PR, in a followup we can remove the
`snap-boostrap create-partitions` command. But this requires
that the spread tests are updated first.
