### PR TITLE
tests: fix a typo in nested.sh helper

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -198,7 +198,7 @@ create_nested_core_vm(){
         if [ -d "${PWD}/extra-snaps" ]; then
             while IFS= read -r mysnap; do
                 EXTRA_SNAPS="$EXTRA_SNAPS --snap $mysnap"
-            done <   <(find extra-snaps -name '*.snaps')
+            done <   <(find extra-snaps -name '*.snap')
         fi
 
         local NESTED_MODEL=""


### PR DESCRIPTION
Fix a typo in file pattern of the nested vm tests helpers.