### PR TITLE
cmd/snap-bootstrap: measure epoch and model before unlocking encrypted data

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -578,7 +578,7 @@ func isDeviceEncrypted(name string) bool {
 }
 
 // unlockIfEncrypted verifies whether an encrypted volume with the specified
-// name exists and unlocks it. With lockKeyOnFinish set, access to the sealed
+// name exists and unlocks it. With lockKeysOnFinish set, access to the sealed
 // keys will be locked when this function completes. The path to the unencrypted
 // device node is returned.
 func unlockIfEncrypted(name string, lockKeysOnFinish bool) (string, error) {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -597,9 +597,12 @@ var (
 	secbootLockAccessToSealedKeys = secboot.LockAccessToSealedKeys
 )
 
-func isDeviceEncrypted(name string) bool {
-	encdev := filepath.Join(devDiskByLabelDir, name+"-enc")
-	return osutil.FileExists(encdev)
+func isDeviceEncrypted(name string) (ok bool, encdev string) {
+	encdev = filepath.Join(devDiskByLabelDir, name+"-enc")
+	if osutil.FileExists(encdev) {
+		return true, encdev
+	}
+	return false, ""
 }
 
 // unlockIfEncrypted verifies whether an encrypted volume with the specified
@@ -638,10 +641,11 @@ func unlockIfEncrypted(name string, lockKeysOnFinish bool) (string, error) {
 			}
 		}()
 
-		if !isDeviceEncrypted(name) {
+		ok, encdev := isDeviceEncrypted(name)
+		if !ok {
 			return nil
 		}
-		encdev := filepath.Join(devDiskByLabelDir, name+"-enc")
+
 		if tpmErr != nil {
 			return fmt.Errorf("cannot unlock encrypted device %q: %v", name, tpmErr)
 		}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -40,8 +40,6 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/state"
-	// XXX: remove "ssb"
-	ssb "github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/sysconfig"
@@ -595,8 +593,6 @@ func generateMountsModeRun() error {
 	// 4.1 Write the modeenv out again
 	return modeEnv.Write()
 }
-
-var ssbCheckKeySealingSupported = ssb.CheckKeySealingSupported
 
 func stampedAction(stamp string, action func() error) error {
 	stampFile := filepath.Join(dirs.SnapBootstrapRunDir, stamp)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -255,9 +255,10 @@ func generateMountsCommonInstallRecover(recoverySystem string) (allMounted bool,
 	// 1a. measure model
 	err = stampedAction("recovery-model-measure", func() error {
 		return measureWhenPossible(func(tpm *secboot.TPMConnection) error {
+			// TODO:UC20: consider doing the measurement later and
+			// getting the model from opened system seed
 			model, err := loadModelFrom(filepath.Join(boot.InitramfsUbuntuSeedDir,
-				recoverySystem,
-				"model"))
+				"systems", recoverySystem, "model"))
 			if err != nil {
 				return fmt.Errorf("cannot load recovery system model: %v", err)
 			}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -251,7 +251,7 @@ func generateMountsCommonInstallRecover(recoverySystem string) (allMounted bool,
 	}
 
 	// 1a. measure model
-	err = stampedAction(fmt.Sprintf("%s-model-measure", recoverySystem), func() error {
+	err = stampedAction(fmt.Sprintf("%s-model-measured", recoverySystem), func() error {
 		return measureWhenPossible(func(tpm *secboot.TPMConnection) error {
 			// TODO:UC20: consider doing the measurement later and
 			// getting the model from opened system seed

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -454,8 +454,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1EncryptedData(c *C
 	c.Check(measuredModel, NotNil)
 	c.Check(measuredModel, DeepEquals, s.model)
 
-	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "initial-measure"), testutil.FilePresent)
-	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "boot-model-measure"), testutil.FilePresent)
+	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "secboot-epoch-measured"), testutil.FilePresent)
+	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "run-model-measured"), testutil.FilePresent)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsStep1EncryptedNoModelRun(c *C) {
@@ -527,12 +527,10 @@ func (s *initramfsMountsSuite) testInitramfsMountsStep1EncryptedNoModel(c *C, mo
 		fmt.Sprintf("cannot load (run mode|recovery system) model: open .*%s: no such file or directory", where))
 	c.Assert(measureEpochCalls, Equals, 1)
 	c.Assert(measureModelCalls, Equals, 0)
-	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "initial-measure"), testutil.FilePresent)
-	whichStamp := "boot-model-measure"
-	if mode != "run" {
-		whichStamp = "seed-model-measure"
-	}
-	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, whichStamp), testutil.FileAbsent)
+	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "secboot-epoch-measured"), testutil.FilePresent)
+	gl, err := filepath.Glob(filepath.Join(dirs.SnapBootstrapRunDir, "*-model-measured"))
+	c.Assert(err, IsNil)
+	c.Assert(gl, HasLen, 0)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -475,6 +475,9 @@ func (s *initramfsMountsSuite) testInitramfsMountsStep1EncryptedNoModel(c *C, mo
 	if label != "" {
 		s.mockProcCmdlineContent(c,
 			fmt.Sprintf("snapd_recovery_mode=%s snapd_recovery_system=%s", mode, label))
+		// break the seed
+		err := os.Remove(filepath.Join(s.seedDir, "systems", label, "model"))
+		c.Assert(err, IsNil)
 	}
 	restore := main.MockSsbCheckKeySealingSupported(func() error {
 		return nil
@@ -518,7 +521,7 @@ func (s *initramfsMountsSuite) testInitramfsMountsStep1EncryptedNoModel(c *C, mo
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	where := "/run/mnt/ubuntu-boot/model"
 	if mode != "run" {
-		where = fmt.Sprintf("/run/mnt/ubuntu-seed/%s/model", label)
+		where = fmt.Sprintf("/run/mnt/ubuntu-seed/systems/%s/model", label)
 	}
 	c.Assert(err, ErrorMatches,
 		fmt.Sprintf("cannot load (run mode|recovery system) model: open .*%s: no such file or directory", where))

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -505,7 +505,7 @@ func (s *initramfsMountsSuite) testInitramfsMountsStep1EncryptedNoModel(c *C, mo
 		where = fmt.Sprintf("/run/mnt/ubuntu-seed/systems/%s/model", label)
 	}
 	c.Assert(err, ErrorMatches,
-		fmt.Sprintf("cannot load (run mode|recovery system) model: open .*%s: no such file or directory", where))
+		fmt.Sprintf("cannot read model assertion: open .*%s: no such file or directory", where))
 	c.Assert(measureEpochCalls, Equals, 1)
 	c.Assert(measureModelCalls, Equals, 0)
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "secboot-epoch-measured"), testutil.FilePresent)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -132,12 +132,6 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 			}},
 	}, nil)
 
-	// No KeySealing by default for most tests
-	restore = main.MockSsbCheckKeySealingSupported(func() error {
-		return fmt.Errorf("no key sealing support in this test")
-	})
-	s.AddCleanup(restore)
-
 	mockTPM, restoreTPM := mockSecbootTPM(c)
 	s.AddCleanup(restoreTPM)
 	s.mockTPM = mockTPM
@@ -351,10 +345,6 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1Data(c *C) {
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1EncryptedData(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
-	restore := main.MockSsbCheckKeySealingSupported(func() error {
-		return nil
-	})
-	defer restore()
 
 	// write the installed model like makebootable does it
 	err := os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755)
@@ -437,11 +427,6 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1EncryptedData(c *C
 	})
 	defer restore()
 
-	restore = main.MockSsbCheckKeySealingSupported(func() error {
-		return nil
-	})
-	defer restore()
-
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 	c.Check(n, Equals, 3)
@@ -479,10 +464,6 @@ func (s *initramfsMountsSuite) testInitramfsMountsStep1EncryptedNoModel(c *C, mo
 		err := os.Remove(filepath.Join(s.seedDir, "systems", label, "model"))
 		c.Assert(err, IsNil)
 	}
-	restore := main.MockSsbCheckKeySealingSupported(func() error {
-		return nil
-	})
-	defer restore()
 
 	// setup ubuntu-data-enc
 	devDiskByLabel, restore := mockDevDiskByLabel(c)

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/snapcore/secboot"
+	"github.com/snapcore/snapd/asserts"
 
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 )
@@ -116,5 +117,21 @@ func MockDevDiskByLabelDir(new string) (restore func()) {
 	devDiskByLabelDir = new
 	return func() {
 		devDiskByLabelDir = old
+	}
+}
+
+func MockSecbootMeasureSnapSystemEpochToTPM(f func(tpm *secboot.TPMConnection, pcrIndex int) error) (restore func()) {
+	old := secbootMeasureSnapSystemEpochToTPM
+	secbootMeasureSnapSystemEpochToTPM = f
+	return func() {
+		secbootMeasureSnapSystemEpochToTPM = old
+	}
+}
+
+func MockSecbootMeasureSnapModelToTPM(f func(tpm *secboot.TPMConnection, pcrIndex int, model *asserts.Model) error) (restore func()) {
+	old := secbootMeasureSnapModelToTPM
+	secbootMeasureSnapModelToTPM = f
+	return func() {
+		secbootMeasureSnapModelToTPM = old
 	}
 }

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -135,3 +135,11 @@ func MockSecbootMeasureSnapModelToTPM(f func(tpm *secboot.TPMConnection, pcrInde
 		secbootMeasureSnapModelToTPM = old
 	}
 }
+
+func MockSsbCheckKeySealingSupported(f func() error) (restore func()) {
+	old := ssbCheckKeySealingSupported
+	ssbCheckKeySealingSupported = f
+	return func() {
+		ssbCheckKeySealingSupported = old
+	}
+}

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -135,11 +135,3 @@ func MockSecbootMeasureSnapModelToTPM(f func(tpm *secboot.TPMConnection, pcrInde
 		secbootMeasureSnapModelToTPM = old
 	}
 }
-
-func MockSsbCheckKeySealingSupported(f func() error) (restore func()) {
-	old := ssbCheckKeySealingSupported
-	ssbCheckKeySealingSupported = f
-	return func() {
-		ssbCheckKeySealingSupported = old
-	}
-}

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -40,12 +40,15 @@ type initramfsMountsState interface {
 	Model() (*asserts.Model, error)
 
 	// RecoverySystemEssentialSnaps returns the verified essential
-	// snaps from the recoverySystem, if that is "" the implied one
-	// will be used (only for modes other than run).
+	// snaps from the recoverySystem. If recoverySystem is "" the
+	// implied one will be used (only for modes other than run).
 	RecoverySystemEssentialSnaps(recoverySystem string, essentialTypes []snap.Type) ([]*seed.Snap, error)
 
-	// UnverifiedBootModel returns the unverified model from the boot
-	// partition for run mode.
+	// UnverifiedBootModel returns the unverified model from the
+	// boot partition for run mode. The current and only use case
+	// is measuring the model for run mode. Otherwise no decisions
+	// should be based on an unverified model. Note that the model
+	// is verified at the time the key auth policy is computed.
 	UnverifiedBootModel() (*asserts.Model, error)
 }
 
@@ -65,7 +68,9 @@ type initramfsMountsStateImpl struct {
 
 var errRunModeNoImpliedRecoverySystem = errors.New("internal error: no implied recovery system in run mode")
 
-// loadSeed open the seed and reads assertions once, setting mst.seed
+// loadSeed opens the seed and reads its assertions; it does not
+// re-open or re-read the seed when called multiple times.
+// The opened seed is available is mst.seed
 func (mst *initramfsMountsStateImpl) loadSeed(recoverySystem string) error {
 	if mst.seed != nil {
 		return nil
@@ -95,7 +100,6 @@ func (mst *initramfsMountsStateImpl) loadSeed(recoverySystem string) error {
 
 	mst.seed = seed20
 	return nil
-
 }
 
 func (mst *initramfsMountsStateImpl) Model() (*asserts.Model, error) {

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -1,0 +1,144 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/timings"
+)
+
+// initramfsMountsState helps tracking the state and progress
+// of the mounting driving process.
+type initramfsMountsState interface {
+	// Model returns the verified model from the seed (only for
+	// modes other than run).
+	Model() (*asserts.Model, error)
+
+	// RecoverySystemEssentialSnaps returns the verified essential
+	// snaps from the recoverySystem, if that is "" the implied one
+	// will be used (only for modes other than run).
+	RecoverySystemEssentialSnaps(recoverySystem string, essentialTypes []snap.Type) ([]*seed.Snap, error)
+
+	// UnverifiedBootModel returns the unverified model from the boot
+	// partition for run mode.
+	UnverifiedBootModel() (*asserts.Model, error)
+}
+
+var newInitramfsMountsState = func(mode, recoverySystem string) initramfsMountsState {
+	return &initramfsMountsStateImpl{
+		mode:           mode,
+		recoverySystem: recoverySystem,
+	}
+}
+
+type initramfsMountsStateImpl struct {
+	mode           string
+	recoverySystem string
+
+	seed seed.EssentialMetaLoaderSeed
+}
+
+var errRunModeNoImpliedRecoverySystem = errors.New("internal error: no implied recovery system in run mode")
+
+// loadSeed open the seed and reads assertions once, setting mst.seed
+func (mst *initramfsMountsStateImpl) loadSeed(recoverySystem string) error {
+	if mst.seed != nil {
+		return nil
+	}
+
+	if recoverySystem == "" {
+		if mst.mode == "run" {
+			return errRunModeNoImpliedRecoverySystem
+		}
+		recoverySystem = mst.recoverySystem
+	}
+
+	systemSeed, err := seed.Open(boot.InitramfsUbuntuSeedDir, recoverySystem)
+	if err != nil {
+		return err
+	}
+
+	seed20, ok := systemSeed.(seed.EssentialMetaLoaderSeed)
+	if !ok {
+		return fmt.Errorf("internal error: UC20 seed must implement EssentialMetaLoaderSeed")
+	}
+
+	// load assertions into a temporary database
+	if err := seed20.LoadAssertions(nil, nil); err != nil {
+		return err
+	}
+
+	mst.seed = seed20
+	return nil
+
+}
+
+func (mst *initramfsMountsStateImpl) Model() (*asserts.Model, error) {
+	if mst.mode == "run" {
+		return nil, errRunModeNoImpliedRecoverySystem
+	}
+	if err := mst.loadSeed(""); err != nil {
+		return nil, err
+	}
+	mod, _ := mst.seed.Model()
+	return mod, nil
+}
+
+func (mst *initramfsMountsStateImpl) RecoverySystemEssentialSnaps(recoverySystem string, essentialTypes []snap.Type) ([]*seed.Snap, error) {
+	if err := mst.loadSeed(recoverySystem); err != nil {
+		return nil, err
+	}
+
+	// load and verify metadata only for the relevant essential snaps
+	perf := timings.New(nil)
+	if err := mst.seed.LoadEssentialMeta(essentialTypes, perf); err != nil {
+		return nil, err
+	}
+
+	return mst.seed.EssentialSnaps(), nil
+}
+
+func (mst *initramfsMountsStateImpl) UnverifiedBootModel() (*asserts.Model, error) {
+	if mst.mode != "run" {
+		return nil, fmt.Errorf("internal error: unverified boot model access is for limited run mode use")
+	}
+
+	mf, err := os.Open(filepath.Join(boot.InitramfsUbuntuBootDir, "model"))
+	if err != nil {
+		return nil, fmt.Errorf("cannot read model assertion: %v", err)
+	}
+	defer mf.Close()
+	ma, err := asserts.NewDecoder(mf).Decode()
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode assertion: %v", err)
+	}
+	if ma.Type() != asserts.ModelType {
+		return nil, fmt.Errorf("unexpected assertion: %q", ma.Type().Name)
+	}
+	return ma.(*asserts.Model), nil
+}

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -55,6 +55,7 @@ var (
 	SnapRunDir                string
 	SnapRunNsDir              string
 	SnapRunLockDir            string
+	SnapBootstrapRunDir       string
 
 	SnapdStoreSSLCertsDir string
 
@@ -290,6 +291,8 @@ func SetRootDir(rootdir string) {
 	SnapRunDir = filepath.Join(rootdir, "/run/snapd")
 	SnapRunNsDir = filepath.Join(SnapRunDir, "/ns")
 	SnapRunLockDir = filepath.Join(SnapRunDir, "/lock")
+
+	SnapBootstrapRunDir = filepath.Join(SnapRunDir, "snap-bootstrap")
 
 	SnapdStoreSSLCertsDir = filepath.Join(rootdir, snappyDir, "ssl/store-certs")
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -365,7 +365,7 @@ start_nested_core_vm(){
         if [ "$ENABLE_SECURE_BOOT" = "true" ]; then
             cp -f /usr/share/OVMF/OVMF_VARS.snakeoil.fd "$WORK_DIR/image/OVMF_VARS.snakeoil.fd"
             PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE.secboot.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=$WORK_DIR/image/OVMF_VARS.snakeoil.fd,if=pflash,format=raw,unit=1"
-            PARAM_MACHINE="-machine ubuntu-q35,accel=kvm -global ICH9-LPC.disable_s3=1 -global ICH9-LPC.disable_s4=1"
+            PARAM_MACHINE="-machine ubuntu-q35,accel=kvm -global ICH9-LPC.disable_s3=1 -global ICH9-LPC.disable_s4=1 -cpu host"
         fi
 
         if [ "$ENABLE_TPM" = "true" ]; then
@@ -451,7 +451,7 @@ start_nested_classic_vm(){
     if [ "$ENABLE_SECURE_BOOT" = "true" ] && is_focal_system; then
         cp -f /usr/share/OVMF/OVMF_VARS.snakeoil.fd "$WORK_DIR/image/OVMF_VARS.snakeoil.fd"
         PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE.secboot.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=$WORK_DIR/image/OVMF_VARS.snakeoil.fd,if=pflash,format=raw,unit=1"
-        PARAM_MACHINE="-machine ubuntu-q35,accel=kvm -global ICH9-LPC.disable_s3=1 -global ICH9-LPC.disable_s4=1"
+        PARAM_MACHINE="-machine ubuntu-q35,accel=kvm -global ICH9-LPC.disable_s3=1 -global ICH9-LPC.disable_s4=1 -cpu host"
     fi
 
     systemd_create_and_start_unit "$NESTED_VM" "${QEMU}  \

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -31,13 +31,6 @@
 			"revisionTime": "2018-05-11T13:34:05Z"
 		},
 		{
-			"checksumSHA1": "wHGa5uteRxMMSHJLQZtcBpIIUcw=",
-			"origin": "github.com/chrisccoulson/pkcs7",
-			"path": "github.com/fullsailor/pkcs7",
-			"revision": "9d98ea9f9bc8b4feee8f0d7c5ef8179f85f0e237",
-			"revisionTime": "2019-09-06T18:49:57Z"
-		},
-		{
 			"checksumSHA1": "qwK75TRXmR/k8CiegYaeqaCDek4=",
 			"path": "github.com/godbus/dbus",
 			"revision": "4481cbc300e2df0c0b3cecc18b6c16c6c0bb885d",
@@ -117,10 +110,10 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "WAeGpLSmxzsvaPLq7CTVjm+qvqE=",
+			"checksumSHA1": "c2bOBuITu1Zxobb14iqfp7+UwtQ=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "dd1d2c4169dcd173a0397a63d569d6e15e5f7644",
-			"revisionTime": "2020-04-16T07:09:07Z"
+			"revision": "599a99325f1f87aed32be5f7d1e47508c77734a1",
+			"revisionTime": "2020-04-22T19:11:46Z"
 		},
 		{
 			"checksumSHA1": "3AmEm18mKj8XxBuru/ix4OOpRkE=",
@@ -128,6 +121,12 @@
 			"revision": "319f6d41a0419465a55d9dcb848d2408b97764f9",
 			"revisionTime": "2017-12-20T16:53:23Z",
 			"tree": true
+		},
+		{
+			"checksumSHA1": "/mphxOFx5uIoQCnt6YtFmmPDBao=",
+			"path": "go.mozilla.org/pkcs7",
+			"revision": "432b2356ecb18209c1cec25680b8a23632794f21",
+			"revisionTime": "2020-01-28T12:03:23Z"
 		},
 		{
 			"checksumSHA1": "TT1rac6kpQp2vz24m5yDGUNQ/QQ=",
@@ -202,7 +201,7 @@
 			"revisionTime": "2017-06-28T23:42:41Z"
 		},
 		{
-			"checksumSHA1": "U4ZQCRcFfuKZvLIUmB1kXgWSd9U=",
+			"checksumSHA1": "kohbRG3D0CRhcgwH6z7YQ6uq1xo=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "e3b113bbe6a423737ae98f42118ce9366e112e12",
 			"revisionTime": "2020-04-06T14:27:27Z"


### PR DESCRIPTION
Measure the epoch and system model before attempting to unlock ubuntu-data partition.
