### PR TITLE
github: use "continue-on-error" for the spread-unstable systems

### DIFF
--- a/.github/workflows/test-go-latest.yaml
+++ b/.github/workflows/test-go-latest.yaml
@@ -95,6 +95,7 @@ jobs:
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
+      continue-on-error: true
       run: |
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"


### PR DESCRIPTION
This should make the overview page green when spread fails.

Let's see if it is ok or if it goes too far by marking too much green.