### PR TITLE
bootloader/uboot: use secondary ubootenv file boot.sel for uc20

### DIFF
--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -385,7 +385,11 @@ func (ks20 *bootState20Kernel) loadBootenv() error {
 
 	// find the bootloader and ensure it's an extracted run kernel image
 	// bootloader
-	bl, err := bootloader.Find("", nil)
+	opts := &bootloader.Options{
+		// we want extracted run kernel images for uc20
+		ExtractedRunKernelImage: true,
+	}
+	bl, err := bootloader.Find("", opts)
 	if err != nil {
 		return err
 	}

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -457,7 +457,7 @@ func (s *ubootSuite) forceUbootBootloader(c *C) {
 	bootloader.Force(nil)
 
 	mockGadgetDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(mockGadgetDir, "uboot.conf"), nil, 0644)
+	err := ioutil.WriteFile(filepath.Join(mockGadgetDir, "uboot.conf"), []byte{1}, 0644)
 	c.Assert(err, IsNil)
 	err = bootloader.InstallBootConfig(mockGadgetDir, dirs.GlobalRootDir, nil)
 	c.Assert(err, IsNil)

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -188,14 +188,14 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	// on e.g. ARM we need to extract the kernel assets on the recovery
 	// system as well, but the bootloader does not load any environment from
 	// the recovery system
-	ekrbl, ok := bl.(bootloader.ExtractedRecoveryKernelImageBootloader)
+	erkbl, ok := bl.(bootloader.ExtractedRecoveryKernelImageBootloader)
 	if ok {
 		kernelf, err := snap.Open(bootWith.KernelPath)
 		if err != nil {
 			return err
 		}
 
-		err = ekrbl.ExtractRecoveryKernelAssets(
+		err = erkbl.ExtractRecoveryKernelAssets(
 			bootWith.RecoverySystemDir,
 			bootWith.Kernel,
 			kernelf,

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -96,21 +95,31 @@ func (s *bootenvTestSuite) TestInstallBootloaderConfigNoConfig(c *C) {
 
 func (s *bootenvTestSuite) TestInstallBootloaderConfig(c *C) {
 	for _, t := range []struct {
-		gadgetFile, systemFile string
-		opts                   *bootloader.Options
+		name           string
+		gFile, sysFile string
+		gFileContent   []byte
+		opts           *bootloader.Options
 	}{
-		{"grub.conf", "/boot/grub/grub.cfg", nil},
-		{"uboot.conf", "/boot/uboot/uboot.env", nil},
-		{"androidboot.conf", "/boot/androidboot/androidboot.env", nil},
-		{"lk.conf", "/boot/lk/snapbootsel.bin", nil},
-		{"grub-recovery.conf", "/EFI/ubuntu/grub.cfg", &bootloader.Options{Recovery: true}},
+		{name: "grub", gFile: "grub.conf", sysFile: "/boot/grub/grub.cfg"},
+		// traditional uboot.env - the uboot.env file needs to be non-empty
+		{name: "uboot.env", gFile: "uboot.conf", sysFile: "/boot/uboot/uboot.env", gFileContent: []byte{1}},
+		// boot.scr in place of uboot.env means we create the boot.sel file
+		{
+			name:    "uboot boot.scr",
+			gFile:   "uboot.conf",
+			sysFile: "/uboot/ubuntu/boot.sel",
+			opts:    &bootloader.Options{NoSlashBoot: true},
+		},
+		{name: "androidboot", gFile: "androidboot.conf", sysFile: "/boot/androidboot/androidboot.env"},
+		{name: "lk", gFile: "lk.conf", sysFile: "/boot/lk/snapbootsel.bin"},
+		{name: "grub recovery", gFile: "grub-recovery.conf", sysFile: "/EFI/ubuntu/grub.cfg", opts: &bootloader.Options{Recovery: true}},
 	} {
 		mockGadgetDir := c.MkDir()
-		err := ioutil.WriteFile(filepath.Join(mockGadgetDir, t.gadgetFile), nil, 0644)
+		err := ioutil.WriteFile(filepath.Join(mockGadgetDir, t.gFile), t.gFileContent, 0644)
 		c.Assert(err, IsNil)
 		err = bootloader.InstallBootConfig(mockGadgetDir, s.rootdir, t.opts)
-		c.Assert(err, IsNil)
-		fn := filepath.Join(s.rootdir, t.systemFile)
-		c.Check(osutil.FileExists(fn), Equals, true, Commentf("boot config missing for %s", t.gadgetFile))
+		c.Assert(err, IsNil, Commentf("installing boot config for %s", t.name))
+		fn := filepath.Join(s.rootdir, t.sysFile)
+		c.Assert(fn, testutil.FilePresent, Commentf("boot config missing for %s at %s", t.name, t.sysFile))
 	}
 }

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -43,12 +43,14 @@ func MockAndroidBootFile(c *C, rootdir string, mode os.FileMode) {
 	c.Assert(err, IsNil)
 }
 
-func NewUboot(rootdir string) ExtractedRecoveryKernelImageBootloader {
-	return newUboot(rootdir, nil)
+func NewUboot(rootdir string, blOpts *Options) ExtractedRecoveryKernelImageBootloader {
+	return newUboot(rootdir, blOpts)
 }
 
-func MockUbootFiles(c *C, rootdir string) {
+func MockUbootFiles(c *C, rootdir string, blOpts *Options) {
 	u := &uboot{rootdir: rootdir}
+	u.setDefaults()
+	u.processBlOpts(blOpts)
 	err := os.MkdirAll(u.dir(), 0755)
 	c.Assert(err, IsNil)
 

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -21,6 +21,7 @@ package bootloader
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/snapcore/snapd/bootloader/ubootenv"
@@ -29,8 +30,32 @@ import (
 )
 
 type uboot struct {
-	rootdir     string
-	noslashboot bool
+	rootdir string
+	basedir string
+
+	ubootEnvFileName string
+}
+
+func (u *uboot) setDefaults() {
+	u.basedir = "/boot/uboot/"
+	u.ubootEnvFileName = "uboot.env"
+}
+
+func (u *uboot) processBlOpts(blOpts *Options) {
+	if blOpts != nil {
+		switch {
+		case blOpts.NoSlashBoot, blOpts.Recovery:
+			// Recovery or NoSlashBoot imply we use the "boot.sel" simple text
+			// format file in /uboot/ubuntu as it exists on the partition
+			// directly
+			u.basedir = "/uboot/ubuntu/"
+			fallthrough
+		case blOpts.ExtractedRunKernelImage:
+			// if just ExtractedRunKernelImage is defined, we expect to find
+			// /boot/uboot/boot.sel
+			u.ubootEnvFileName = "boot.sel"
+		}
+	}
 }
 
 // newUboot create a new Uboot bootloader object
@@ -38,9 +63,9 @@ func newUboot(rootdir string, blOpts *Options) ExtractedRecoveryKernelImageBootl
 	u := &uboot{
 		rootdir: rootdir,
 	}
-	if blOpts != nil && (blOpts.NoSlashBoot || blOpts.Recovery) {
-		u.noslashboot = true
-	}
+	u.setDefaults()
+	u.processBlOpts(blOpts)
+
 	if !osutil.FileExists(u.envFile()) {
 		return nil
 	}
@@ -60,18 +85,57 @@ func (u *uboot) dir() string {
 	if u.rootdir == "" {
 		panic("internal error: unset rootdir")
 	}
-	if u.noslashboot {
-		return u.rootdir
-	}
-	return filepath.Join(u.rootdir, "/boot/uboot")
+	return filepath.Join(u.rootdir, u.basedir)
 }
 
-func (u *uboot) InstallBootConfig(gadgetDir string, opts *Options) (bool, error) {
+func (u *uboot) InstallBootConfig(gadgetDir string, blOpts *Options) (bool, error) {
 	gadgetFile := filepath.Join(gadgetDir, u.Name()+".conf")
-	systemFile := u.ConfigFile()
-	if opts != nil && opts.Recovery {
-		systemFile = filepath.Join(u.rootdir, "uboot.env")
+	// if the gadget file is empty, then we don't install anything
+	// this is because there are some gadgets, namely the 20 pi gadget right
+	// now, that don't use a uboot.env to boot and instead use a boot.scr, and
+	// installing a uboot.env file of any form in the root directory will break
+	// the boot.scr, so for these setups we just don't install anything
+	// TODO:UC20: how can we do this better? maybe parse the file to get the
+	//            actual format?
+	st, err := os.Stat(gadgetFile)
+	if err != nil {
+		return false, err
 	}
+	if st.Size() == 0 {
+		// we have an empty uboot.conf, and hence a uboot bootloader in the
+		// gadget, but nothing to copy in this case and instead just install our
+		// own boot.sel file
+		u.processBlOpts(blOpts)
+
+		err := os.MkdirAll(filepath.Dir(u.envFile()), 0755)
+		if err != nil {
+			return false, err
+		}
+
+		// TODO:UC20: what's a reasonable size for this file?
+		env, err := ubootenv.Create(u.envFile(), 4096)
+		if err != nil {
+			return false, err
+		}
+
+		if err := env.Save(); err != nil {
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	// InstallBootConfig gets called on a uboot that does not come from newUboot
+	// so we need to apply the defaults here
+	u.setDefaults()
+
+	if blOpts != nil && blOpts.Recovery {
+		// not supported yet, this is traditional uboot.env from gadget
+		// TODO:UC20: support this use-case
+		return false, fmt.Errorf("non-empty uboot.env not supported on UC20 yet")
+	}
+
+	systemFile := u.ConfigFile()
 	return genericInstallBootConfig(gadgetFile, systemFile)
 }
 
@@ -80,7 +144,7 @@ func (u *uboot) ConfigFile() string {
 }
 
 func (u *uboot) envFile() string {
-	return filepath.Join(u.dir(), "uboot.env")
+	return filepath.Join(u.dir(), u.ubootEnvFileName)
 }
 
 func (u *uboot) SetBootVars(values map[string]string) error {

--- a/bootloader/uboot_test.go
+++ b/bootloader/uboot_test.go
@@ -41,20 +41,20 @@ type ubootTestSuite struct {
 var _ = Suite(&ubootTestSuite{})
 
 func (s *ubootTestSuite) TestNewUbootNoUbootReturnsNil(c *C) {
-	u := bootloader.NewUboot(s.rootdir)
+	u := bootloader.NewUboot(s.rootdir, nil)
 	c.Assert(u, IsNil)
 }
 
 func (s *ubootTestSuite) TestNewUboot(c *C) {
-	bootloader.MockUbootFiles(c, s.rootdir)
-	u := bootloader.NewUboot(s.rootdir)
+	bootloader.MockUbootFiles(c, s.rootdir, nil)
+	u := bootloader.NewUboot(s.rootdir, nil)
 	c.Assert(u, NotNil)
 	c.Assert(u.Name(), Equals, "uboot")
 }
 
 func (s *ubootTestSuite) TestUbootGetEnvVar(c *C) {
-	bootloader.MockUbootFiles(c, s.rootdir)
-	u := bootloader.NewUboot(s.rootdir)
+	bootloader.MockUbootFiles(c, s.rootdir, nil)
+	u := bootloader.NewUboot(s.rootdir, nil)
 	c.Assert(u, NotNil)
 	err := u.SetBootVars(map[string]string{
 		"snap_mode": "",
@@ -71,7 +71,7 @@ func (s *ubootTestSuite) TestUbootGetEnvVar(c *C) {
 }
 
 func (s *ubootTestSuite) TestGetBootloaderWithUboot(c *C) {
-	bootloader.MockUbootFiles(c, s.rootdir)
+	bootloader.MockUbootFiles(c, s.rootdir, nil)
 
 	bootloader, err := bootloader.Find(s.rootdir, nil)
 	c.Assert(err, IsNil)
@@ -79,8 +79,8 @@ func (s *ubootTestSuite) TestGetBootloaderWithUboot(c *C) {
 }
 
 func (s *ubootTestSuite) TestUbootSetEnvNoUselessWrites(c *C) {
-	bootloader.MockUbootFiles(c, s.rootdir)
-	u := bootloader.NewUboot(s.rootdir)
+	bootloader.MockUbootFiles(c, s.rootdir, nil)
+	u := bootloader.NewUboot(s.rootdir, nil)
 	c.Assert(u, NotNil)
 
 	envFile := u.ConfigFile()
@@ -109,8 +109,8 @@ func (s *ubootTestSuite) TestUbootSetEnvNoUselessWrites(c *C) {
 }
 
 func (s *ubootTestSuite) TestUbootSetBootVarFwEnv(c *C) {
-	bootloader.MockUbootFiles(c, s.rootdir)
-	u := bootloader.NewUboot(s.rootdir)
+	bootloader.MockUbootFiles(c, s.rootdir, nil)
+	u := bootloader.NewUboot(s.rootdir, nil)
 
 	err := u.SetBootVars(map[string]string{"key": "value"})
 	c.Assert(err, IsNil)
@@ -121,8 +121,8 @@ func (s *ubootTestSuite) TestUbootSetBootVarFwEnv(c *C) {
 }
 
 func (s *ubootTestSuite) TestUbootGetBootVarFwEnv(c *C) {
-	bootloader.MockUbootFiles(c, s.rootdir)
-	u := bootloader.NewUboot(s.rootdir)
+	bootloader.MockUbootFiles(c, s.rootdir, nil)
+	u := bootloader.NewUboot(s.rootdir, nil)
 
 	err := u.SetBootVars(map[string]string{"key2": "value2"})
 	c.Assert(err, IsNil)
@@ -133,8 +133,8 @@ func (s *ubootTestSuite) TestUbootGetBootVarFwEnv(c *C) {
 }
 
 func (s *ubootTestSuite) TestExtractKernelAssetsAndRemove(c *C) {
-	bootloader.MockUbootFiles(c, s.rootdir)
-	u := bootloader.NewUboot(s.rootdir)
+	bootloader.MockUbootFiles(c, s.rootdir, nil)
+	u := bootloader.NewUboot(s.rootdir, nil)
 
 	files := [][]string{
 		{"kernel.img", "I'm a kernel"},
@@ -178,8 +178,8 @@ func (s *ubootTestSuite) TestExtractKernelAssetsAndRemove(c *C) {
 }
 
 func (s *ubootTestSuite) TestExtractRecoveryKernelAssets(c *C) {
-	bootloader.MockUbootFiles(c, s.rootdir)
-	u := bootloader.NewUboot(s.rootdir)
+	bootloader.MockUbootFiles(c, s.rootdir, nil)
+	u := bootloader.NewUboot(s.rootdir, nil)
 
 	files := [][]string{
 		{"kernel.img", "I'm a kernel"},
@@ -218,5 +218,49 @@ func (s *ubootTestSuite) TestExtractRecoveryKernelAssets(c *C) {
 
 		fullFn := filepath.Join(kernelAssetsDir, def[0])
 		c.Check(fullFn, testutil.FileEquals, def[1])
+	}
+}
+
+func (s *ubootTestSuite) TestUbootUC20OptsFormat(c *C) {
+	tt := []struct {
+		blOpts  *bootloader.Options
+		expEnv  string
+		comment string
+	}{
+		{
+			nil,
+			"/boot/uboot/uboot.env",
+			"traditional uboot.env",
+		},
+		{
+			&bootloader.Options{NoSlashBoot: true},
+			"/uboot/ubuntu/boot.sel",
+			"uc20 install mode boot.sel",
+		},
+		{
+			&bootloader.Options{ExtractedRunKernelImage: true},
+			"/boot/uboot/boot.sel",
+			"uc20 run mode boot.sel",
+		},
+		{
+			&bootloader.Options{Recovery: true},
+			"/uboot/ubuntu/boot.sel",
+			"uc20 recovery boot.sel",
+		},
+	}
+
+	for _, t := range tt {
+		dir := c.MkDir()
+		bootloader.MockUbootFiles(c, dir, t.blOpts)
+		u := bootloader.NewUboot(dir, t.blOpts)
+		c.Assert(u, NotNil, Commentf(t.comment))
+		c.Assert(u.ConfigFile(), Equals, filepath.Join(dir, t.expEnv), Commentf(t.comment))
+
+		// if we set boot vars on the uboot, we can open the config file and
+		// get the same variables
+		c.Assert(u.SetBootVars(map[string]string{"hello": "there"}), IsNil)
+		env, err := ubootenv.Open(filepath.Join(dir, t.expEnv))
+		c.Assert(err, IsNil)
+		c.Assert(env.Get("hello"), Equals, "there")
 	}
 }

--- a/tests/main/prepare-image-uboot-uc20/task.yaml
+++ b/tests/main/prepare-image-uboot-uc20/task.yaml
@@ -54,27 +54,30 @@ execute: |
     # have snap use the fakestore for assertions (but nothing else)
     export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
 
-    # TODO:UC20 remove when pi gadget is published to 20-pi/edge
-    curl -L -O https://launchpad.net/~canonical-foundations/+snap/pi-arm64-20/+build/862694/+files/pi_20-1_arm64.snap
-    mv pi_20-1_arm64.snap "$ROOT"
+    # for now we need to fix the pi-gadget's uboot.conf manually until 
+    # https://github.com/snapcore/pi-gadget/pull/41 is merged
+    # TODO:UC20: when the PR is merged let prepare-image download the snap
+    UBUNTU_STORE_ARCH=arm64 snap download pi --channel=20/edge --basename=pi-gadget-upstream
+    unsquashfs -d pi-gadget pi-gadget-upstream.snap
+    truncate -s 0 pi-gadget/uboot.conf
+    snap pack pi-gadget --filename=pi-gadget.snap
 
     echo Running prepare-image as a user
-    # TODO:UC20: remove --snap pi_20 once the gadget has been published
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap $ROOT/pi_20-1_arm64.snap $ROOT/model.assertion $ROOT" test
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap pi-gadget.snap $ROOT/model.assertion $ROOT" test
 
     systemid="$(date +%Y%m%d)"
 
     echo Verifying the result
     find "$ROOT/system-seed/" -ls
 
-    test -e "$ROOT/system-seed/uboot.env"
+    test -e "$ROOT/system-seed/uboot/ubuntu/boot.sel"
 
     test -e "$ROOT/system-seed/systems/$systemid/model"
     test -e "$ROOT/system-seed/systems/$systemid/kernel/initrd.img"
     test -e "$ROOT/system-seed/systems/$systemid/kernel/kernel.img"
     test "$(find "$ROOT/system-seed/systems/$systemid/kernel/dtbs/" | wc -l)" -gt 0
 
-    strings "$ROOT/system-seed/uboot.env" | MATCH "snapd_recovery_system=$systemid"
+    strings "$ROOT/system-seed/uboot/ubuntu/boot.sel" | MATCH "snapd_recovery_system=$systemid"
 
     test -e "$ROOT"/system-seed/snaps/core20_*.snap
     test -e "$ROOT"/system-seed/snaps/pi-kernel_*.snap


### PR DESCRIPTION
This is a simpler and probably more robust implementation of https://github.com/snapcore/snapd/pull/8550, which instead of using the text format for boot.sel, just uses the standard native uboot format instead. This will give us more reliable and robust writes to the file and will remove the need to introduce another ubootenv format to the codebase.

Also a couple of related changes that are also needed. 

This in conjunction with https://github.com/snapcore/pi-gadget/pull/41/files and https://code.launchpad.net/~anonymouse67/ubuntu-core-initramfs/+git/ubuntu-core-initramfs/+merge/382701 and an update to the boot.scr in flash-kernel pkg from the snappy-dev image PPA will enable UC20 for arm64 on the Raspberry Pi 4 finally.