### PR TITLE
tests: ensure $cache_dir is actually available

### DIFF
--- a/tests/main/interfaces-desktop-host-fonts/task.yaml
+++ b/tests/main/interfaces-desktop-host-fonts/task.yaml
@@ -27,6 +27,7 @@ execute: |
             cache_dir=/usr/lib/fontconfig/cache
             ;;
     esac
+    mkdir -p "$cache_dir"
     echo "Cache file" > "$cache_dir"/cache.txt
 
     mkdir -p "$HOME"/.fonts


### PR DESCRIPTION
This commit ensures that the test that uses the $cache_dir
actually has the cachedir available for testing. This fixes
the current test failures we see with amazon-linux.
