### PR TITLE
tests: disable "searching" test

### DIFF
--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -2,6 +2,8 @@ summary: Check snap search
 
 # s390x,ppc64el have nothing featured
 systems: [-ubuntu-*-ppc64el, -ubuntu-*-s390x]
+# The store is under load from 20.04 release.
+manual: true
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro


### PR DESCRIPTION
The store is under load and fails to respond.

    error: cannot get snap sections: cannot sections: got unexpected HTTP status code 403 via GET to "https://api.snapcraft.io/api/v1/snaps/sections"

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
