### PR TITLE
osutil: expand FileLock to support shared locks and more

### DIFF
--- a/osutil/flock.go
+++ b/osutil/flock.go
@@ -32,15 +32,20 @@ type FileLock struct {
 
 var ErrAlreadyLocked = errors.New("cannot acquire lock, already locked")
 
-// NewFileLock creates and opens the lock file given by "path"
-func NewFileLock(path string) (*FileLock, error) {
-	mode := syscall.O_RDWR | syscall.O_CREAT | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
-	file, err := os.OpenFile(path, mode, os.FileMode(0600))
+// NewFileModeLock creates and opens the lock file given by "path" with the given mode.
+func NewFileModeLock(path string, mode os.FileMode) (*FileLock, error) {
+	flag := syscall.O_RDWR | syscall.O_CREAT | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
+	file, err := os.OpenFile(path, flag, mode)
 	if err != nil {
 		return nil, err
 	}
 	l := &FileLock{file: file}
 	return l, nil
+}
+
+// NewFileLock creates and opens the lock file given by "path" with mode 0600.
+func NewFileLock(path string) (*FileLock, error) {
+	return NewFileModeLock(path, 0600)
 }
 
 // Path returns the path of the lock file.

--- a/osutil/flock.go
+++ b/osutil/flock.go
@@ -53,6 +53,11 @@ func (l *FileLock) Path() string {
 	return l.file.Name()
 }
 
+// File returns the underlying file.
+func (l *FileLock) File() *os.File {
+	return l.file
+}
+
 // Close closes the lock, unlocking it automatically if needed.
 func (l *FileLock) Close() error {
 	return l.file.Close()

--- a/osutil/flock.go
+++ b/osutil/flock.go
@@ -59,8 +59,19 @@ func (l *FileLock) Close() error {
 }
 
 // Lock acquires an exclusive lock and blocks until the lock is free.
+//
+// Only one process can acquire an exclusive lock at a given time, preventing
+// shared or exclusive locks from being acquired.
 func (l *FileLock) Lock() error {
 	return syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX)
+}
+
+// Lock acquires an shared lock and blocks until the lock is free.
+//
+// Multiple processes can acquire a shared lock at the same time, unless an
+// exclusive lock is held.
+func (l *FileLock) ReadLock() error {
+	return syscall.Flock(int(l.file.Fd()), syscall.LOCK_SH)
 }
 
 // TryLock acquires an exclusive lock and errors if the lock cannot be acquired.

--- a/osutil/flock_test.go
+++ b/osutil/flock_test.go
@@ -58,6 +58,18 @@ func (s *flockSuite) TestNewFileLock(c *C) {
 	c.Assert(fi.Mode().Perm(), Equals, os.FileMode(0600))
 }
 
+// Test that we can access the underlying open file.
+func (s *flockSuite) TestFile(c *C) {
+	fname := filepath.Join(c.MkDir(), "name")
+	lock, err := osutil.NewFileLock(fname)
+	c.Assert(err, IsNil)
+	defer lock.Close()
+
+	f := lock.File()
+	c.Assert(f, NotNil)
+	c.Check(f.Name(), Equals, fname)
+}
+
 func flockSupportsConflictExitCodeSwitch(c *C) bool {
 	output, err := exec.Command("flock", "--help").CombinedOutput()
 	c.Assert(err, IsNil)

--- a/osutil/flock_test.go
+++ b/osutil/flock_test.go
@@ -36,14 +36,26 @@ type flockSuite struct{}
 
 var _ = Suite(&flockSuite{})
 
+// Test that opening and closing a lock works as expected, and that the mode is right.
+func (s *flockSuite) TestNewFileModeLock(c *C) {
+	lock, err := osutil.NewFileModeLock(filepath.Join(c.MkDir(), "name"), 0644)
+	c.Assert(err, IsNil)
+	defer lock.Close()
+
+	fi, err := os.Stat(lock.Path())
+	c.Assert(err, IsNil)
+	c.Assert(fi.Mode().Perm(), Equals, os.FileMode(0644))
+}
+
 // Test that opening and closing a lock works as expected.
 func (s *flockSuite) TestNewFileLock(c *C) {
 	lock, err := osutil.NewFileLock(filepath.Join(c.MkDir(), "name"))
 	c.Assert(err, IsNil)
 	defer lock.Close()
 
-	_, err = os.Stat(lock.Path())
+	fi, err := os.Stat(lock.Path())
 	c.Assert(err, IsNil)
+	c.Assert(fi.Mode().Perm(), Equals, os.FileMode(0600))
 }
 
 func flockSupportsConflictExitCodeSwitch(c *C) bool {

--- a/osutil/flock_test.go
+++ b/osutil/flock_test.go
@@ -101,6 +101,50 @@ func (s *flockSuite) TestLockUnlockWorks(c *C) {
 	c.Assert(cmd.Run(), IsNil)
 }
 
+// Test that ReadLock and Unlock work as expected.
+func (s *flockSuite) TestReadLockUnlockWorks(c *C) {
+	if os.Getenv("TRAVIS_BUILD_NUMBER") != "" {
+		c.Skip("Cannot use this under travis")
+		return
+	}
+	if !flockSupportsConflictExitCodeSwitch(c) {
+		c.Skip("flock too old for this test")
+	}
+
+	lock, err := osutil.NewFileLock(filepath.Join(c.MkDir(), "name"))
+	c.Assert(err, IsNil)
+	defer lock.Close()
+
+	// Run a flock command in another process, it should succeed because it can
+	// lock the lock as we didn't do it yet.
+	cmd := exec.Command("flock", "--exclusive", "--nonblock", lock.Path(), "true")
+	c.Assert(cmd.Run(), IsNil)
+
+	// Grab a shared lock.
+	c.Assert(lock.ReadLock(), IsNil)
+
+	// Run a flock command in another process, it should fail with the distinct
+	// error code because we hold a shared lock already and we asked it not to block.
+	cmd = exec.Command("flock", "--exclusive", "--nonblock",
+		"--conflict-exit-code", "2", lock.Path(), "true")
+	c.Assert(cmd.Run(), ErrorMatches, "exit status 2")
+
+	// Run a flock command in another process, it should succeed because we
+	// hold a shared lock and those do not prevent others from acquiring a
+	// shared lock.
+	cmd = exec.Command("flock", "--shared", "--nonblock",
+		"--conflict-exit-code", "2", lock.Path(), "true")
+	c.Assert(cmd.Run(), IsNil)
+
+	// Unlock the lock.
+	c.Assert(lock.Unlock(), IsNil)
+
+	// Run a flock command in another process, it should succeed because it can
+	// grab the lock again now.
+	cmd = exec.Command("flock", "--exclusive", "--nonblock", lock.Path(), "true")
+	c.Assert(cmd.Run(), IsNil)
+}
+
 // Test that locking a locked lock does nothing.
 func (s *flockSuite) TestLockLocked(c *C) {
 	lock, err := osutil.NewFileLock(filepath.Join(c.MkDir(), "name"))


### PR DESCRIPTION
This branch contains three patches that expand `FileLock` with several new
features:

 - we can now open lock files with mode other than 0600
 - we can now acquire shared locks
 - we can now access the `*os.File` of the underlying lock

Those three are all used to implement the _run inhibition lock_ mechanism
coming up in another branch shortly.
