### PR TITLE
many: allow using ~/.snapdata instead of ~/snap

### DIFF
--- a/cmd/libsnap-confine-private/feature-test.c
+++ b/cmd/libsnap-confine-private/feature-test.c
@@ -89,6 +89,20 @@ static void test_feature_parallel_instances(void)
 	g_assert(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
 }
 
+static void test_feature_hidden_snap_folder(void)
+{
+	const char *d = sc_testdir();
+	sc_mock_feature_flag_dir(d);
+
+	g_assert(!sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
+
+	char pname[PATH_MAX];
+	sc_must_snprintf(pname, sizeof pname, "%s/hidden-snap-folder", d);
+	g_file_set_contents(pname, "", -1, NULL);
+
+	g_assert(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
+}
+
 static void __attribute__((constructor)) init(void)
 {
 	g_test_add_func("/feature/missing_dir",
@@ -99,4 +113,6 @@ static void __attribute__((constructor)) init(void)
 			test_feature_enabled__present_file);
 	g_test_add_func("/feature/parallel_instances",
 			test_feature_parallel_instances);
+	g_test_add_func("/feature/hidden_snap_folder",
+			test_feature_hidden_snap_folder);
 }

--- a/cmd/libsnap-confine-private/feature.c
+++ b/cmd/libsnap-confine-private/feature.c
@@ -43,6 +43,9 @@ bool sc_feature_enabled(sc_feature_flag flag)
 	case SC_FEATURE_PARALLEL_INSTANCES:
 		file_name = "parallel-instances";
 		break;
+	case SC_FEATURE_HIDDEN_SNAP_FOLDER:
+		file_name = "hidden-snap-folder";
+		break;
 	default:
 		die("unknown feature flag code %d", flag);
 	}

--- a/cmd/libsnap-confine-private/feature.h
+++ b/cmd/libsnap-confine-private/feature.h
@@ -24,6 +24,7 @@ typedef enum sc_feature_flag {
 	SC_FEATURE_PER_USER_MOUNT_NAMESPACE = 1 << 0,
 	SC_FEATURE_REFRESH_APP_AWARENESS = 1 << 1,
 	SC_FEATURE_PARALLEL_INSTANCES = 1 << 2,
+	SC_FEATURE_HIDDEN_SNAP_FOLDER = 1 << 3,
 } sc_feature_flag;
 
 /**

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -347,7 +347,7 @@
     # These should both have 'owner' match but due to LP: #1466234, we can't
     # yet
     @{HOME}/ r,
-    @{HOME}/snap/{,*/,*/*/} rw,
+    @{HOME}/{snap,.snapdata}/{,*/,*/*/} rw,
 
     # Special case for *classic* snaps that are used by users with existing dirs
     # in /var/lib/. Like jenkins, postgresql, mysql, puppet, ...

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -445,7 +445,7 @@ int main(int argc, char **argv)
 	// of the calling user (by using real user and group identifiers). This
 	// allows the creation of directories inside ~/ on NFS with root_squash
 	// attribute.
-	setup_user_data();
+	setup_user_data(invocation.snap_instance);
 #if 0
 	setup_user_xdg_runtime_dir();
 #endif

--- a/cmd/snap-confine/user-support.c
+++ b/cmd/snap-confine/user-support.c
@@ -21,25 +21,106 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/feature.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
-#include "../libsnap-confine-private/feature.h"
+
+static void sc_migrate_to_dot_snapdata(const char *real_home)
+{
+	struct stat fi;
+	int hfd SC_CLEANUP(sc_cleanup_close) = -1;
+	hfd = open(real_home, O_PATH | O_DIRECTORY | O_NOFOLLOW);
+	if (hfd < 0) {
+		die("cannot open path %s", real_home);
+	}
+	/* If ~/.snapdata exists then there is nothing to do. */
+	if (fstatat(hfd, ".snapdata", &fi, AT_SYMLINK_NOFOLLOW) < 0) {
+		if (errno != ENOENT) {
+			die("cannot stat ~/.snapdata");
+		}
+	} else {
+		return;
+	}
+
+	/* If ~/snap doesn't exist then there is nothing to do. */
+	if (fstatat(hfd, "snap", &fi, AT_SYMLINK_NOFOLLOW) < 0) {
+		if (errno == ENOENT) {
+			return;
+		}
+		die("cannot stat ~/snap");
+	}
+	/* If ~/snap is a symlink then don't perform the rename! */
+	if ((fi.st_mode & S_IFMT) == S_IFLNK) {
+		return;
+	}
+
+	/* Rename ~/snap to ~/.snapdata making sure not to clobber ~/.snapdata. */
+	if (renameat2(hfd, "snap", hfd, ".snapdata", RENAME_NOREPLACE) < 0) {
+		if (errno == EEXIST) {
+			return;
+		}
+		die("cannot migrate ~/snap to ~/.snapdata");
+	}
+}
+
+static void sc_migrate_to_snap(const char *real_home)
+{
+	struct stat fi;
+	int hfd SC_CLEANUP(sc_cleanup_close) = -1;
+	hfd = open(real_home, O_PATH | O_DIRECTORY | O_NOFOLLOW);
+	if (hfd < 0) {
+		die("cannot open path %s", real_home);
+	}
+	/* If ~/snap exists then there is nothing to do. */
+	if (fstatat(hfd, "snap", &fi, AT_SYMLINK_NOFOLLOW) < 0) {
+		if (errno != ENOENT) {
+			die("cannot stat ~/snap");
+		}
+	} else {
+		return;
+	}
+
+	/* If ~/.snapdata doesn't exist then there is nothing to do. */
+	if (fstatat(hfd, ".snapdata", &fi, AT_SYMLINK_NOFOLLOW) < 0) {
+		if (errno == ENOENT) {
+			return;
+		}
+		die("cannot stat ~/.snapdata");
+	}
+	/* If ~/.snapdata is a symlink then don't perform the rename! */
+	if ((fi.st_mode & S_IFMT) == S_IFLNK) {
+		return;
+	}
+
+	/* Rename ~/.snapdata to ~/snap making sure not to clobber ~/snap. */
+	if (renameat2(hfd, ".snapdata", hfd, "snap", RENAME_NOREPLACE) < 0) {
+		if (errno == EEXIST) {
+			return;
+		}
+		die("cannot migrate ~/.snapdata to ~/snap");
+	}
+}
 
 void setup_user_data(const char *snap_instance)
 {
 	const char *user_data = getenv("SNAP_USER_DATA");
+	const char *real_home = getenv("SNAP_REAL_HOME");
 
-	if (user_data == NULL)
+	if (user_data == NULL) {
 		return;
+	}
+	if (real_home == NULL) {
+		die("cannot remap snap folder, SNAP_REAL_HOME is not set");
+	}
 
 	if (sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER)) {
 		char buf[PATH_MAX + 1];
-		const char *real_home = getenv("SNAP_REAL_HOME");
 		const char *revision = getenv("SNAP_REVISION");
-		if (real_home == NULL) {
-			die("cannot remap snap folder, SNAP_REAL_HOME is not set");
-		}
 		if (revision == NULL) {
 			die("cannot remap snap folder, SNAP_REVISION is not set");
 		}
@@ -50,8 +131,11 @@ void setup_user_data(const char *snap_instance)
 		sc_must_snprintf(buf, sizeof buf, "%s/.snapdata/%s/common",
 				 real_home, snap_instance);
 		setenv("SNAP_USER_COMMON", buf, 1);
-
 		user_data = getenv("SNAP_USER_DATA");
+
+		sc_migrate_to_dot_snapdata(real_home);
+	} else {
+		sc_migrate_to_snap(real_home);
 	}
 	// Only support absolute paths.
 	if (user_data[0] != '/') {

--- a/cmd/snap-confine/user-support.h
+++ b/cmd/snap-confine/user-support.h
@@ -18,7 +18,7 @@
 #ifndef SNAP_CONFINE_USER_SUPPORT_H
 #define SNAP_CONFINE_USER_SUPPORT_H
 
-void setup_user_data(void);
+void setup_user_data(const char *snap_name);
 void setup_user_xdg_runtime_dir(void);
 void mkpath(const char *const path);
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -39,6 +39,7 @@ var (
 	SnapBlobDir               string
 	SnapDataDir               string
 	SnapDataHomeGlob          string
+	SnapAltDataHomeGlob       string
 	SnapDownloadCacheDir      string
 	SnapAppArmorDir           string
 	SnapAppArmorAdditionalDir string
@@ -131,7 +132,8 @@ const (
 	CoreSnapMountDir = "/snap"
 
 	// Directory with snap data inside user's home
-	UserHomeSnapDir = "snap"
+	UserHomeSnapDir    = "snap"
+	UserHomeAltSnapDir = ".snapdata"
 
 	// LocalInstallBlobTempPrefix is used by local install code:
 	// * in daemon to spool the snap file to <SnapBlobDir>/<LocalInstallBlobTempPrefix>*
@@ -274,6 +276,7 @@ func SetRootDir(rootdir string) {
 
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/", UserHomeSnapDir)
+	SnapAltDataHomeGlob = filepath.Join(rootdir, "/home/*/", UserHomeAltSnapDir)
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	SnapConfineAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "snap-confine")
 	SnapAppArmorAdditionalDir = filepath.Join(rootdir, snappyDir, "apparmor", "additional")

--- a/features/features.go
+++ b/features/features.go
@@ -47,6 +47,8 @@ const (
 	ClassicPreservesXdgRuntimeDir
 	// RobustMountNamespaceUpdates controls how snap-update-ns updates existing mount namespaces.
 	RobustMountNamespaceUpdates
+	// HiddenSnapFolder moves ~/snap to ~/.snapdata.
+	HiddenSnapFolder
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
 )
@@ -72,6 +74,7 @@ var featureNames = map[SnapdFeature]string{
 
 	ClassicPreservesXdgRuntimeDir: "classic-preserves-xdg-runtime-dir",
 	RobustMountNamespaceUpdates:   "robust-mount-namespace-updates",
+	HiddenSnapFolder:              "hidden-snap-folder",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
@@ -88,6 +91,7 @@ var featuresExported = map[SnapdFeature]bool{
 
 	ClassicPreservesXdgRuntimeDir: true,
 	RobustMountNamespaceUpdates:   true,
+	HiddenSnapFolder:              true,
 }
 
 // String returns the name of a snapd feature.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -47,6 +47,7 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.RefreshAppAwareness.String(), Equals, "refresh-app-awareness")
 	c.Check(features.ClassicPreservesXdgRuntimeDir.String(), Equals, "classic-preserves-xdg-runtime-dir")
 	c.Check(features.RobustMountNamespaceUpdates.String(), Equals, "robust-mount-namespace-updates")
+	c.Check(features.HiddenSnapFolder.String(), Equals, "hidden-snap-folder")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 
@@ -68,6 +69,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	c.Check(features.PerUserMountNamespace.IsExported(), Equals, true)
 	c.Check(features.RefreshAppAwareness.IsExported(), Equals, true)
 	c.Check(features.ClassicPreservesXdgRuntimeDir.IsExported(), Equals, true)
+	c.Check(features.HiddenSnapFolder.IsExported(), Equals, true)
 }
 
 func (*featureSuite) TestIsEnabled(c *C) {
@@ -98,6 +100,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.RefreshAppAwareness.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.ClassicPreservesXdgRuntimeDir.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.RobustMountNamespaceUpdates.IsEnabledWhenUnset(), Equals, true)
+	c.Check(features.HiddenSnapFolder.IsEnabledWhenUnset(), Equals, false)
 }
 
 func (*featureSuite) TestControlFile(c *C) {
@@ -105,6 +108,7 @@ func (*featureSuite) TestControlFile(c *C) {
 	c.Check(features.RefreshAppAwareness.ControlFile(), Equals, "/var/lib/snapd/features/refresh-app-awareness")
 	c.Check(features.ParallelInstances.ControlFile(), Equals, "/var/lib/snapd/features/parallel-instances")
 	c.Check(features.RobustMountNamespaceUpdates.ControlFile(), Equals, "/var/lib/snapd/features/robust-mount-namespace-updates")
+	c.Check(features.HiddenSnapFolder.ControlFile(), Equals, "/var/lib/snapd/features/hidden-snap-folder")
 	// Features that are not exported don't have a control file.
 	c.Check(features.Layouts.ControlFile, PanicMatches, `cannot compute the control file of feature "layouts" because that feature is not exported`)
 }

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -318,13 +318,13 @@ var templateCommon = `
 
   # Read-only home area for other versions
   # bind mount *not* used here (see 'parallel installs', above)
-  owner @{HOME}/snap/@{SNAP_INSTANCE_NAME}/                  r,
-  owner @{HOME}/snap/@{SNAP_INSTANCE_NAME}/**                mrkix,
+  owner @{HOME}/{snap,.snapdata}/@{SNAP_INSTANCE_NAME}/                  r,
+  owner @{HOME}/{snap,.snapdata}/@{SNAP_INSTANCE_NAME}/**                mrkix,
 
   # Writable home area for this version.
   # bind mount *not* used here (see 'parallel installs', above)
-  owner @{HOME}/snap/@{SNAP_INSTANCE_NAME}/@{SNAP_REVISION}/** wl,
-  owner @{HOME}/snap/@{SNAP_INSTANCE_NAME}/common/** wl,
+  owner @{HOME}/{snap,.snapdata}/@{SNAP_INSTANCE_NAME}/@{SNAP_REVISION}/** wl,
+  owner @{HOME}/{snap,.snapdata}/@{SNAP_INSTANCE_NAME}/common/** wl,
 
   # Read-only system area for other versions
   # bind mount used here (see 'parallel installs', above)

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -64,11 +64,11 @@ owner @{HOME}/snap[^/]**          rwkl###HOME_IX###,
 # Allow creating a few files not caught above
 owner @{HOME}/{s,sn,sna}{,/} rwkl###HOME_IX###,
 
-# Allow access to @{HOME}/snap/ to allow directory traversals from
-# @{HOME}/snap/@{SNAP_INSTANCE_NAME} through @{HOME}/snap to @{HOME}.
-# While this leaks snap names, it fixes usability issues for snaps
+# Allow access to @{HOME}/{snap,.snapdata}/ to allow directory traversals from
+# @{HOME}/{snap,.snapdata}/@{SNAP_INSTANCE_NAME} through @{HOME}/snap to
+# @{HOME}. While this leaks snap names, it fixes usability issues for snaps
 # that require this transitional interface.
-owner @{HOME}/snap/ r,
+owner @{HOME}/{snap,.snapdata}/ r,
 
 # Allow access to gvfs mounts for files owned by the user (including hidden
 # files; only allow writes to files, not the mount point).

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -201,6 +201,7 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 	}
 
 	for _, usr := range users {
+		// TODO: Add support for si.UserAltDataDir
 		if err := addDirToZip(ctx, snapshot, w, usr.Username, userArchiveName(usr), si.UserDataDir(usr.HomeDir)); err != nil {
 			return nil, err
 		}

--- a/overlord/snapshotstate/backend/helpers.go
+++ b/overlord/snapshotstate/backend/helpers.go
@@ -128,6 +128,7 @@ func usersForUsernames(usernames []string) ([]*user.User, error) {
 }
 
 func allUsers() ([]*user.User, error) {
+	// TODO: support dirs.SnapAltDataHomeGlob
 	ds, err := filepath.Glob(dirs.SnapDataHomeGlob)
 	if err != nil {
 		// can't happen?

--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -227,6 +227,7 @@ func (r *Reader) Restore(ctx context.Context, current snap.Revision, usernames [
 				continue
 			}
 
+			// TODO: Add support for si.UserAltDataDir
 			dest = si.UserDataDir(usr.HomeDir)
 			fi, err := os.Stat(usr.HomeDir)
 			if err != nil {

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -100,12 +100,20 @@ func removeDirs(dirs []string) error {
 // snapDataDirs returns the list of data directories for the given snap version
 func snapDataDirs(snap *snap.Info) ([]string, error) {
 	// collect the directories, homes first
-	found, err := filepath.Glob(snap.DataHomeDir())
+	foundPri, err := filepath.Glob(snap.DataHomeDir())
 	if err != nil {
 		return nil, err
 	}
+	foundAlt, err := filepath.Glob(snap.AltDataHomeDir())
+	if err != nil {
+		return nil, err
+	}
+	var found []string
+	found = append(found, foundPri...)
+	found = append(found, foundAlt...)
 	// then the /root user (including GlobalRootDir for tests)
 	found = append(found, snap.UserDataDir(filepath.Join(dirs.GlobalRootDir, "/root/")))
+	found = append(found, snap.UserAltDataDir(filepath.Join(dirs.GlobalRootDir, "/root/")))
 	// then system data
 	found = append(found, snap.DataDir())
 
@@ -115,10 +123,17 @@ func snapDataDirs(snap *snap.Info) ([]string, error) {
 // snapCommonDataDirs returns the list of data directories common between versions of the given snap
 func snapCommonDataDirs(snap *snap.Info) ([]string, error) {
 	// collect the directories, homes first
-	found, err := filepath.Glob(snap.CommonDataHomeDir())
+	foundPri, err := filepath.Glob(snap.CommonDataHomeDir())
 	if err != nil {
 		return nil, err
 	}
+	foundAlt, err := filepath.Glob(snap.CommonAltDataHomeDir())
+	if err != nil {
+		return nil, err
+	}
+	var found []string
+	found = append(found, foundPri...)
+	found = append(found, foundAlt...)
 
 	// then XDG_RUNTIME_DIRs for the users
 	foundXdg, err := filepath.Glob(snap.XdgRuntimeDirs())

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,9 @@
+snapd (2.45~snapdata1) UNRELEASED; urgency=medium
+
+  * Add experimental support for using ~/.snapdata instead of ~/snap
+
+ -- Zygmunt Bazyli Krynicki <me@zygoon.pl>  Mon, 27 Apr 2020 14:19:41 +0200
+
 snapd (2.45~pre1) xenial; urgency=medium
 
   * New upstream release, LP: #1875071

--- a/snap/info.go
+++ b/snap/info.go
@@ -71,6 +71,9 @@ type PlaceInfo interface {
 	// UserDataDir returns the per user data directory of the snap.
 	UserDataDir(home string) string
 
+	// UserAltDataDir returns the per user, alternative data directory of the snap.
+	UserAltDataDir(home string) string
+
 	// CommonDataDir returns the data directory common across revisions of the
 	// snap.
 	CommonDataDir() string
@@ -79,16 +82,28 @@ type PlaceInfo interface {
 	// revisions of the snap.
 	UserCommonDataDir(home string) string
 
+	// UserCommonAltDataDir returns the alternative, per user data directory common across
+	// revisions of the snap.
+	UserCommonAltDataDir(home string) string
+
 	// UserXdgRuntimeDir returns the per user XDG_RUNTIME_DIR directory
 	UserXdgRuntimeDir(userID sys.UserID) string
 
-	// DataHomeDir returns the a glob that matches all per user data directories
+	// DataHomeDir returns a glob that matches all per user data directories
 	// of a snap.
 	DataHomeDir() string
+
+	// AltDataHomeDir returns a glob that matches all alternative, per user data
+	// directories of a snap.
+	AltDataHomeDir() string
 
 	// CommonDataHomeDir returns a glob that matches all per user data
 	// directories common across revisions of the snap.
 	CommonDataHomeDir() string
+
+	// AltCommonDataHomeDir returns a glob that matches all alternative, per user
+	// data directories common across revisions of the snap.
+	CommonAltDataHomeDir() string
 
 	// XdgRuntimeDirs returns a glob that matches all XDG_RUNTIME_DIR
 	// directories for all users of the snap.
@@ -203,16 +218,35 @@ func UserDataDir(home string, name string, revision Revision) string {
 	return filepath.Join(home, dirs.UserHomeSnapDir, name, revision.String())
 }
 
+// UserAltDataDir returns the user-specific, alternative data directory for
+// given snap name. The name can be either a snap name or snap instance name.
+func UserAltDataDir(home string, name string, revision Revision) string {
+	return filepath.Join(home, dirs.UserHomeAltSnapDir, name, revision.String())
+}
+
 // UserCommonDataDir returns the user-specific common data directory for given
 // snap name. The name can be either a snap name or snap instance name.
 func UserCommonDataDir(home string, name string) string {
 	return filepath.Join(home, dirs.UserHomeSnapDir, name, "common")
 }
 
+// UserCommonAltDataDir returns the user-specific, alternative common data
+// directory for given snap name. The name can be either a snap name or snap
+// instance name.
+func UserCommonAltDataDir(home string, name string) string {
+	return filepath.Join(home, dirs.UserHomeAltSnapDir, name, "common")
+}
+
 // UserSnapDir returns the user-specific directory for given
 // snap name. The name can be either a snap name or snap instance name.
 func UserSnapDir(home string, name string) string {
 	return filepath.Join(home, dirs.UserHomeSnapDir, name)
+}
+
+// UserSnapAltDir returns the user-specific, alternative directory for given
+// snap name. The name can be either a snap name or snap instance name.
+func UserSnapAltDir(home string, name string) string {
+	return filepath.Join(home, dirs.UserHomeAltSnapDir, name)
 }
 
 // UserXdgRuntimeDir returns the user-specific XDG_RUNTIME_DIR directory for
@@ -467,10 +501,21 @@ func (s *Info) UserDataDir(home string) string {
 	return UserDataDir(home, s.InstanceName(), s.Revision)
 }
 
+// UserAltDataDir returns the user-specific, alternative data directory of the snap.
+func (s *Info) UserAltDataDir(home string) string {
+	return UserAltDataDir(home, s.InstanceName(), s.Revision)
+}
+
 // UserCommonDataDir returns the user-specific data directory common across
 // revision of the snap.
 func (s *Info) UserCommonDataDir(home string) string {
 	return UserCommonDataDir(home, s.InstanceName())
+}
+
+// UserCommonAltDataDir returns the user-specific, alternative data directory
+// common across revision of the snap.
+func (s *Info) UserCommonAltDataDir(home string) string {
+	return UserCommonAltDataDir(home, s.InstanceName())
 }
 
 // CommonDataDir returns the data directory common across revisions of the snap.
@@ -483,10 +528,21 @@ func (s *Info) DataHomeDir() string {
 	return filepath.Join(dirs.SnapDataHomeGlob, s.InstanceName(), s.Revision.String())
 }
 
+// AltDataHomeDir returns the per user, alternative data directory of the snap.
+func (s *Info) AltDataHomeDir() string {
+	return filepath.Join(dirs.SnapAltDataHomeGlob, s.InstanceName(), s.Revision.String())
+}
+
 // CommonDataHomeDir returns the per user data directory common across revisions
 // of the snap.
 func (s *Info) CommonDataHomeDir() string {
 	return filepath.Join(dirs.SnapDataHomeGlob, s.InstanceName(), "common")
+}
+
+// CommonAltDataHomeDir returns the per user data directory common across revisions
+// of the snap.
+func (s *Info) CommonAltDataHomeDir() string {
+	return filepath.Join(dirs.SnapAltDataHomeGlob, s.InstanceName(), "common")
 }
 
 // UserXdgRuntimeDir returns the XDG_RUNTIME_DIR directory of the snap for a

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1009,12 +1009,16 @@ func (s *infoSuite) testDirAndFileMethods(c *C, info snap.PlaceInfo) {
 	c.Check(info.HooksDir(), Equals, fmt.Sprintf("%s/name/1/meta/hooks", dirs.SnapMountDir))
 	c.Check(info.DataDir(), Equals, "/var/snap/name/1")
 	c.Check(info.UserDataDir("/home/bob"), Equals, "/home/bob/snap/name/1")
+	c.Check(info.UserAltDataDir("/home/bob"), Equals, "/home/bob/.snapdata/name/1")
 	c.Check(info.UserCommonDataDir("/home/bob"), Equals, "/home/bob/snap/name/common")
+	c.Check(info.UserCommonAltDataDir("/home/bob"), Equals, "/home/bob/.snapdata/name/common")
 	c.Check(info.CommonDataDir(), Equals, "/var/snap/name/common")
 	c.Check(info.UserXdgRuntimeDir(12345), Equals, "/run/user/12345/snap.name")
 	// XXX: Those are actually a globs, not directories
 	c.Check(info.DataHomeDir(), Equals, "/home/*/snap/name/1")
+	c.Check(info.AltDataHomeDir(), Equals, "/home/*/.snapdata/name/1")
 	c.Check(info.CommonDataHomeDir(), Equals, "/home/*/snap/name/common")
+	c.Check(info.CommonAltDataHomeDir(), Equals, "/home/*/.snapdata/name/common")
 	c.Check(info.XdgRuntimeDirs(), Equals, "/run/user/*/snap.name")
 }
 

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -118,5 +118,7 @@ func userEnv(info *snap.Info, home string) osutil.Environment {
 		env["HOME"] = info.UserDataDir(home)
 		env["XDG_RUNTIME_DIR"] = info.UserXdgRuntimeDir(sys.Geteuid())
 	}
+	// Provide the location of the real home directory.
+	env["SNAP_REAL_HOME"] = home
 	return env
 }

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -103,6 +103,7 @@ func (ts *HTestSuite) TestUser(c *C) {
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
 		"HOME":             "/root/snap/foo/17",
 		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
+		"SNAP_REAL_HOME":   "/root",
 	})
 }
 
@@ -119,6 +120,7 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
 		"XDG_RUNTIME_DIR":  fmt.Sprintf(dirs.GlobalRootDir+"/run/user/%d/snap.foo", sys.Geteuid()),
+		"SNAP_REAL_HOME":   "/root",
 	})
 
 	// With the classic-preserves-xdg-runtime-dir feature enabled the snap
@@ -130,6 +132,7 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 		// NOTE: Both HOME and XDG_RUNTIME_DIR are not defined here.
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
+		"SNAP_REAL_HOME":   "/root",
 	})
 }
 
@@ -166,6 +169,7 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 			"SNAP_USER_DATA":     fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
 			"HOME":               fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
 			"XDG_RUNTIME_DIR":    fmt.Sprintf("/run/user/%d/snap.snapname", sys.Geteuid()),
+			"SNAP_REAL_HOME":     usr.HomeDir,
 		})
 	}
 }
@@ -210,6 +214,7 @@ func (s *HTestSuite) TestParallelInstallSnapRunSnapExecEnv(c *C) {
 			"SNAP_USER_DATA":   fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
 			"HOME":             fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
 			"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.snapname_foo", sys.Geteuid()),
+			"SNAP_REAL_HOME":   usr.HomeDir,
 		})
 	}
 }
@@ -224,6 +229,7 @@ func (ts *HTestSuite) TestParallelInstallUser(c *C) {
 		"SNAP_USER_DATA":   "/root/snap/foo_bar/17",
 		"HOME":             "/root/snap/foo_bar/17",
 		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo_bar", sys.Geteuid()),
+		"SNAP_REAL_HOME":   "/root",
 	})
 }
 
@@ -242,6 +248,7 @@ func (ts *HTestSuite) TestParallelInstallUserForClassicConfinement(c *C) {
 		"SNAP_USER_COMMON": "/root/snap/foo_bar/common",
 		"SNAP_USER_DATA":   "/root/snap/foo_bar/17",
 		"XDG_RUNTIME_DIR":  fmt.Sprintf(dirs.GlobalRootDir+"/run/user/%d/snap.foo_bar", sys.Geteuid()),
+		"SNAP_REAL_HOME":   "/root",
 	})
 
 	// With the classic-preserves-xdg-runtime-dir feature enabled the snap
@@ -253,6 +260,7 @@ func (ts *HTestSuite) TestParallelInstallUserForClassicConfinement(c *C) {
 		// NOTE, Both HOME and XDG_RUNTIME_DIR are not defined here.
 		"SNAP_USER_COMMON": "/root/snap/foo_bar/common",
 		"SNAP_USER_DATA":   "/root/snap/foo_bar/17",
+		"SNAP_REAL_HOME":   "/root",
 	})
 }
 


### PR DESCRIPTION
Disclaimer: this is still work in progress!

Missing features:
 - snapshots do not handle `~/.snapdata` yet
 - maintenance scripts do not know about `~/.snapdata` yet

Missing patches:
 - integration tests for data migration
 - unit tests for `snapstate` and others

Missing design:
 - agreement on `~/.snapdata` name

Usage instructions:
 - build a package out of this branch
 - install the snapd package
 - quit all running snap apps
 - `sudo snap set core experimental.hidden-snap-folder=true`
 - run your snaps as before

To stop using this feature:
 - quit all running snap apps
 - `sudo snap set core experimental.hidden-snap-folder=false`
 - run your snaps as before
 - you may reinstall the version from the archive
