### PR TITLE
overlord/snapstate: warn of refresh/postpone events

### DIFF
--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -652,3 +652,47 @@ func (s *autoRefreshTestSuite) TestRefreshOnMeteredConnNotMetered(c *C) {
 	c.Check(err, IsNil)
 	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
 }
+
+func (s *autoRefreshTestSuite) TestInhibitRefreshWithinInhibitWindow(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
+	info := &snap.Info{SideInfo: *si}
+	snapst := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+	}
+	err := snapstate.InhibitRefresh(s.state, snapst, info, func(si *snap.Info) error {
+		return &snapstate.BusySnapError{SnapName: "pkg"}
+	})
+	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks`)
+
+	pending, _ := s.state.PendingWarnings()
+	c.Assert(pending, HasLen, 1)
+	c.Check(pending[0].String(), Equals, `snap "pkg" is currently in use. Its refresh will be postponed for up to 7 days to wait for the snap to no longer be in use.`)
+}
+
+func (s *autoRefreshTestSuite) TestInhibitRefreshWarnsAndRefreshesWhenOverdue(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	instant := time.Now()
+	pastInstant := instant.Add(-snapstate.MaxInhibition * 2)
+
+	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
+	info := &snap.Info{SideInfo: *si}
+	snapst := &snapstate.SnapState{
+		Sequence:             []*snap.SideInfo{si},
+		Current:              si.Revision,
+		RefreshInhibitedTime: &pastInstant,
+	}
+	err := snapstate.InhibitRefresh(s.state, snapst, info, func(si *snap.Info) error {
+		return &snapstate.BusySnapError{SnapName: "pkg"}
+	})
+	c.Assert(err, IsNil)
+
+	pending, _ := s.state.PendingWarnings()
+	c.Assert(pending, HasLen, 1)
+	c.Check(pending[0].String(), Equals, `snap "pkg" has been running for the maximum allowable 7 days since its refresh was postponed. It will now be refreshed.`)
+}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -224,3 +224,9 @@ var (
 func (m *SnapManager) MaybeUndoRemodelBootChanges(t *state.Task) error {
 	return m.maybeUndoRemodelBootChanges(t)
 }
+
+// autorefresh
+var (
+	InhibitRefresh = inhibitRefresh
+	MaxInhibition  = maxInhibition
+)

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -93,7 +93,7 @@ func genericRefreshCheck(info *snap.Info, canAppRunDuringRefresh func(app *snap.
 	sort.Strings(busyHookNames)
 	sort.Ints(busyPIDs)
 	return &BusySnapError{
-		snapName:      info.SnapName(),
+		SnapName:      info.SnapName(),
 		busyAppNames:  busyAppNames,
 		busyHookNames: busyHookNames,
 		pids:          busyPIDs,
@@ -137,7 +137,7 @@ func HardNothingRunningRefreshCheck(info *snap.Info) error {
 
 // BusySnapError indicates that snap has apps or hooks running and cannot refresh.
 type BusySnapError struct {
-	snapName      string
+	SnapName      string
 	pids          []int
 	busyAppNames  []string
 	busyHookNames []string
@@ -148,15 +148,15 @@ func (err *BusySnapError) Error() string {
 	switch {
 	case len(err.busyAppNames) > 0 && len(err.busyHookNames) > 0:
 		return fmt.Sprintf("snap %q has running apps (%s) and hooks (%s)",
-			err.snapName, strings.Join(err.busyAppNames, ", "), strings.Join(err.busyHookNames, ", "))
+			err.SnapName, strings.Join(err.busyAppNames, ", "), strings.Join(err.busyHookNames, ", "))
 	case len(err.busyAppNames) > 0:
 		return fmt.Sprintf("snap %q has running apps (%s)",
-			err.snapName, strings.Join(err.busyAppNames, ", "))
+			err.SnapName, strings.Join(err.busyAppNames, ", "))
 	case len(err.busyHookNames) > 0:
 		return fmt.Sprintf("snap %q has running hooks (%s)",
-			err.snapName, strings.Join(err.busyHookNames, ", "))
+			err.SnapName, strings.Join(err.busyHookNames, ", "))
 	default:
-		return fmt.Sprintf("snap %q has running apps or hooks", err.snapName)
+		return fmt.Sprintf("snap %q has running apps or hooks", err.SnapName)
 	}
 }
 


### PR DESCRIPTION
When refresh-app-awareness, aka tracking of active applications, first
prevents a snap from refreshing a warning is issued to alert the user
that the snap will refresh forcibly after a week.

When the time elapses and force-refresh is issued a second warning
alerts the user of this behavior.

This is done in the hope that the desktop session will eventually
surface those messages, allowing the users to act accordingly. In
addition, the presence of the second warning may assist in debugging of
data-loss like situations during a forced refresh.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
