### PR TITLE
packaging: add the inhibit directory

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -152,6 +152,7 @@ purge() {
     rm -rf /var/lib/snapd/mount/*
     rm -rf /var/lib/snapd/sequence/*
     rm -rf /var/lib/snapd/apparmor/*
+    rm -rf /var/lib/snapd/inhibit/*
     rm -f /var/lib/snapd/state.json
     rm -f /var/lib/snapd/system-key
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -165,6 +165,7 @@ package() {
   install -dm755 "$pkgdir/var/lib/snapd/seccomp/bpf"
   install -dm755 "$pkgdir/var/lib/snapd/snap/bin"
   install -dm755 "$pkgdir/var/lib/snapd/snaps"
+  install -dm755 "$pkgdir/var/lib/snapd/inhibit"
   install -dm755 "$pkgdir/var/lib/snapd/lib/gl"
   install -dm755 "$pkgdir/var/lib/snapd/lib/gl32"
   install -dm755 "$pkgdir/var/lib/snapd/lib/vulkan"

--- a/packaging/debian-sid/snapd.dirs
+++ b/packaging/debian-sid/snapd.dirs
@@ -6,6 +6,7 @@ var/lib/snapd/auto-import
 var/lib/snapd/desktop
 var/lib/snapd/environment
 var/lib/snapd/firstboot
+var/lib/snapd/inhibit
 var/lib/snapd/lib/gl
 var/lib/snapd/lib/gl32
 var/lib/snapd/lib/vulkan

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -562,6 +562,7 @@ install -d -p %{buildroot}%{_sharedstatedir}/snapd/cookie
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/desktop/applications
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/device
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/hostfs
+install -d -p %{buildroot}%{_sharedstatedir}/snapd/inhibit
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/gl
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/gl32
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/glvnd
@@ -768,6 +769,7 @@ popd
 %dir %{_sharedstatedir}/snapd/desktop/applications
 %dir %{_sharedstatedir}/snapd/device
 %dir %{_sharedstatedir}/snapd/hostfs
+%dir %{_sharedstatedir}/snapd/inhibit
 %dir %{_sharedstatedir}/snapd/lib
 %dir %{_sharedstatedir}/snapd/lib/gl
 %dir %{_sharedstatedir}/snapd/lib/gl32

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -362,6 +362,7 @@ fi
 %dir %{_sharedstatedir}/snapd/desktop/applications
 %dir %{_sharedstatedir}/snapd/device
 %dir %{_sharedstatedir}/snapd/hostfs
+%dir %{_sharedstatedir}/snapd/inhibit
 %dir %{_sharedstatedir}/snapd/lib
 %dir %{_sharedstatedir}/snapd/lib/gl
 %dir %{_sharedstatedir}/snapd/lib/gl32

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -107,6 +107,7 @@ install::
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/desktop/applications
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/device
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/hostfs
+	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/inhibit
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/lib/gl
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/lib/gl32
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/lib/glvnd

--- a/packaging/ubuntu-14.04/snapd.dirs
+++ b/packaging/ubuntu-14.04/snapd.dirs
@@ -7,6 +7,7 @@ var/lib/snapd/auto-import
 var/lib/snapd/desktop
 var/lib/snapd/environment
 var/lib/snapd/firstboot
+var/lib/snapd/inhibit
 var/lib/snapd/lib/gl
 var/lib/snapd/lib/gl32
 var/lib/snapd/lib/glvnd

--- a/packaging/ubuntu-16.04/snapd.dirs
+++ b/packaging/ubuntu-16.04/snapd.dirs
@@ -7,6 +7,7 @@ var/lib/snapd/auto-import
 var/lib/snapd/desktop
 var/lib/snapd/environment
 var/lib/snapd/firstboot
+var/lib/snapd/inhibit
 var/lib/snapd/lib/gl
 var/lib/snapd/lib/gl32
 var/lib/snapd/lib/glvnd


### PR DESCRIPTION
The management script and various packaging helpers now handle the
inhibit directory.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
