### PR TITLE
tests, selinux: update SELinux rule affecting snap-update-ns on centos 8

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -512,6 +512,9 @@ mmap_read_files_pattern(snappy_mount_t, tmpfs_t, tmpfs_t)
 # were mounted from the host when updating the ns
 fs_remount_xattr_fs(snappy_mount_t)
 
+# for centos 8: statically linked snap-update-ns loads libcrypto.so.
+allow snappy_mount_t snappy_snap_t:file { execute map };
+
 ########################################
 #
 # snap-confine local policy


### PR DESCRIPTION
selinux-lxd spread test is currently failing on centos 8 because of new denials:

```
type=AVC msg=audit(04/28/20 12:25:06.213:553) : avc:  denied  { execute } for  pid=12059 comm=snap-update-ns path=/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 dev="loop1" ino=5726 scontext=system_u:system_r:snappy_mount_t:s0 tcontext=system_u:object_r:snappy_snap_t:s0 tclass=file permissive=1 
type=AVC msg=audit(04/28/20 12:25:06.213:553) : avc:  denied  { map } for  pid=12059 comm=snap-update-ns path=/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 dev="loop1" ino=5726 scontext=system_u:system_r:snappy_mount_t:s0 tcontext=system_u:object_r:snappy_snap_t:s0 tclass=file permissive=1 
```

This is because statically linked snap-update-ns opens libcrypto, which is most likely caused by a change to go toolchain in redhat (see https://kupczynski.info/2019/12/15/fips-golang.html).
