### PR TITLE
packaging/fedora: disable FIPS compliant crypto for static binaries

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -488,9 +488,17 @@ sed -e "s:github.com/snapcore/bolt:github.com/boltdb/bolt:g" -i advisor/*.go err
 
 # To ensure things work correctly with base snaps,
 # snap-exec, snap-update-ns, and snapctl need to be built statically
-%gobuild_static -o bin/snap-exec $GOFLAGS %{import_path}/cmd/snap-exec
-%gobuild_static -o bin/snap-update-ns $GOFLAGS %{import_path}/cmd/snap-update-ns
-%gobuild_static -o bin/snapctl $GOFLAGS %{import_path}/cmd/snapctl
+(
+%if 0%{?rhel} >= 8
+    # since 1.12.1, the go-toolset module is built with FIPS compliance that
+    # defaults to using libcrypto.so which gets loaded at runtime via dlopen(),
+    # disable that functionality for statically built binaries
+    BUILDTAGS="${BUILDTAGS} no_openssl"
+%endif
+    %gobuild_static -o bin/snap-exec $GOFLAGS %{import_path}/cmd/snap-exec
+    %gobuild_static -o bin/snap-update-ns $GOFLAGS %{import_path}/cmd/snap-update-ns
+    %gobuild_static -o bin/snapctl $GOFLAGS %{import_path}/cmd/snapctl
+)
 
 %if 0%{?rhel}
 # There's no static link library for libseccomp in RHEL/CentOS...


### PR DESCRIPTION
Since 1.12.1-1, the Go toolchain available in go-toolset module for RHEL8
defaults to the FIPS compliant boringcrypto implementation. This functionality
dynamically loads libcrypto.so via dlopen(). This breaks statically built
binaries, since the dlopen() call is sill included, so even though the binary is
static, it stil tries to load libcrypto.so at runtime.

Disable the boringcrypto FIPS tweaks for static binaries on RHEL 8+.

[1]. https://developers.redhat.com/blog/2019/06/24/go-and-fips-140-2-on-red-hat-enterprise-linux/

With this change, #8574 should no longer be needed.

cc @Conan-Kudo 
