### PR TITLE
packaging: stop depending on python-docutils

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -103,7 +103,6 @@ BuildRequires:  libuuid-devel
 BuildRequires:  make
 BuildRequires:  openssh
 BuildRequires:  pkg-config
-BuildRequires:  python-docutils
 BuildRequires:  python3-docutils
 BuildRequires:  squashfs
 # Due to: rpm -q --whatprovides /usr/share/pkgconfig/systemd.pc


### PR DESCRIPTION
We used to need python-docutils for the rst2man executable required to
build one of the manual pages. Over time this has drifted to
python3-docutils and we were depending on a entirely pointless package.
As the Python 3 transition was marching ahead, Python 2.x packages were
successively removed from the distribution. It seems that now
python-docutils (note the lack of "3") is gone, breaking openSUSE
builds.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
