### PR TITLE
tests: add session-tool --has-systemd-and-dbus

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -4,14 +4,11 @@ if [ $# -eq 0 ]; then
 	echo "usage: session-tool --prepare | --restore [-u USER]"
 	echo "usage: session-tool --kill-leaked"
 	echo "usage: session-tool --dump"
+	echo "usage: session-tool --has-systemd-and-dbus [-u USER]"
 	exit 1
 fi
 if [ "$(id -u)" -ne 0 ]; then
     echo "session-tool needs to be invoked as root" >&2
-    exit 1
-fi
-if [ -z "$(command -v busctl)" ]; then
-    echo "session-tool requires busctl" >&2
     exit 1
 fi
 user=root
@@ -45,6 +42,10 @@ while [ $# -gt 0 ]; do
 			;;
 		--dump)
 			action=dump
+			shift
+			;;
+		--has-systemd-and-dbus)
+			action=has-systemd-and-dbus
 			shift
 			;;
 		-u)
@@ -149,7 +150,33 @@ case "$action" in
 		done
 		exit 0
 		;;
+	has-systemd-and-dbus)
+		# Older systems don't have support for modern sessions
+		# There are two known issues:
+		#  - CentOS 7 and derivatives disabled systemd --user
+		#    https://bugs.centos.org/view.php?id=8767
+		#  - Ubuntu 14.04 with deputy systemd does not connect to DBus
+		#    and systemd-shim is really responding to "systemd" requests.
+		test -n "$(command -v busctl)"         			|| ( echo "no busctl"; exit 1 )
+		if [ "$user" = "root" ]; then
+			# 		/lib										   /usr/lib									   (if present) dbus-broker.service variant
+			test -f /lib/systemd/system/default.target	|| test -f /usr/lib/systemd/system/default.target	|| ( echo "no system default.target"; exit 1 )
+			test -f /lib/systemd/system/dbus.socket  	|| test -f /usr/lib/systemd/system/dbus.socket		|| ( echo "no system dbus.socket"; exit 1 )
+			test -f /lib/systemd/system/dbus.service	|| test -f /usr/lib/systemd/system/dbus.service		|| test -f /lib/systemd/system/dbus-broker.service || ( echo "no system dbus{,-broker}.service"; exit 1 )
+		else
+			test -f /lib/systemd/user/default.target 	|| test -f /usr/lib/systemd/user/default.target		|| ( echo "no user default.target"; exit 1)
+			test -f /lib/systemd/user/dbus.socket 		|| test -f /usr/lib/systemd/user/dbus.socket 		|| ( echo "no user dbus.socket"; exit 1 )
+			test -f /lib/systemd/user/dbus.service		|| test -f /usr/lib/systemd/user/dbus.service		|| test -f /lib/systemd/user/dbus-broker.service || ( echo "no system dbus{,-broker}.service"; exit 1 )
+		fi
+		echo "ok"
+		exit 0
+		;;
 esac
+
+if [ -z "$(command -v busctl)" ]; then
+    echo "session-tool requires busctl" >&2
+    exit 1
+fi
 
 # This fixes a bug in some older Debian systems where /root/.profile contains
 # unconditional invocation of mesg, which on non-tty shells prints "mesg

--- a/tests/main/session-tool-support/task.yaml
+++ b/tests/main/session-tool-support/task.yaml
@@ -1,0 +1,45 @@
+summary: check the session support status of various distributions
+environment:
+    USER/root: root
+    USER/test: test
+execute: |
+    case "$SPREAD_SYSTEM/$USER" in
+        amazon-linux-2-*/test|centos-7-*/test)
+            # Amazon Linux 2 which is based on CentOS 7 both disable user
+            # session features of systemd as, at the time, this was a feature
+            # that was not certain to stay in systemd, and RedHat did not want
+            # to commit to supporting it.
+            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no user dbus.socket'
+            not session-tool -u "$USER" --has-systemd-and-dbus
+            ;;
+        debian-sid-*/test)
+            # Debian packages support session DBus into a separate, optional
+            # package dbus-user-session. It is not installed by default
+            # on sid (XXX: why is it in debian-10 though?).
+            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no user dbus.socket'
+            not session-tool -u "$USER" --has-systemd-and-dbus
+            ;;
+        ubuntu-14.04-*)
+            # Ubuntu 14.04 does not use systemd. 
+            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no busctl'
+            not session-tool -u "$USER" --has-systemd-and-dbus
+            ;;
+        ubuntu-16.04-*/test)
+            # Ubuntu 16.04 does not use systemd for user sessions.
+            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no user dbus.socket'
+            not session-tool -u "$USER" --has-systemd-and-dbus
+            ;;
+        ubuntu-core-1[68]-*/test)
+            # Ubuntu Core 16 and Ubuntu Core 18 did not support user sessions.
+            # Note that Ubuntu Core 20 is in the default case down below, and
+            # does support this feature.
+            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no user dbus.socket'
+            not session-tool -u "$USER" --has-systemd-and-dbus
+            ;;
+        *)
+            # The list above contains just the exceptions. By default
+            # everything should work.
+            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'ok'
+            session-tool -u "$USER" --has-systemd-and-dbus
+            ;;
+    esac


### PR DESCRIPTION
Instead of encoding where a specific test can pass and where it cannot
based on a snapshot of the knowledge, we now can ask session-tool for an
opinion.

The check performed looks for systemd support and dbus socket and
service, as a minimal "this looks like a session" baseline.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
