### PR TITLE
tests: port portals test to session-tool, fix portal tests on sid

### DIFF
--- a/tests/lib/desktop-portal.sh
+++ b/tests/lib/desktop-portal.sh
@@ -3,9 +3,6 @@
 #shellcheck source=tests/lib/pkgdb.sh
 . "$TESTSLIB"/pkgdb.sh
 
-#shellcheck source=tests/lib/user.sh
-. "$TESTSLIB"/user.sh
-
 setup_portals() {
     # Install xdg-desktop-portal and configure service activation for
     # fake portal UI.

--- a/tests/lib/desktop-portal.sh
+++ b/tests/lib/desktop-portal.sh
@@ -39,13 +39,10 @@ Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.S
 UseIn=spread
 EOF
 
-    start_user_session
-    as_user systemctl --user set-environment XDG_CURRENT_DESKTOP=spread
+    session-tool -u test systemctl --user set-environment XDG_CURRENT_DESKTOP=spread
 }
 
 teardown_portals() {
-    stop_user_session
-
     rm -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
     rm -f /usr/lib/systemd/user/spread-portal-ui.service
     rm -f /usr/share/xdg-desktop-portal/portals/spread.portal
@@ -59,6 +56,4 @@ teardown_portals() {
 
     distro_purge_package xdg-desktop-portal
     distro_auto_remove_packages
-
-    purge_user_session_data
 }

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -663,6 +663,7 @@ pkg_dependencies_ubuntu_classic(){
                 net-tools
                 packagekit
                 sbuild
+                dbus-user-session
                 "
             ;;
     esac

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -20,11 +20,15 @@ description: |
 systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 prepare: |
+    session-tool -u test --prepare
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
 
 restore: |
+    session-tool -u test --restore
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals
@@ -32,9 +36,6 @@ restore: |
     rm -f /tmp/file-to-write.txt
 
 execute: |
-    #shellcheck source=tests/lib/desktop-portal.sh
-    . "$TESTSLIB"/desktop-portal.sh
-
     echo "Install the portals test client"
     snap install --edge test-snapd-portal-client
 
@@ -43,7 +44,7 @@ execute: |
     # file ownership is exposed through the document portal, and our
     # AppArmor policy uses the @owner restriction.
     chown test:test /tmp/file-to-read.txt
-    as_user test-snapd-portal-client open-file | MATCH "from-host-system"
+    session-tool -u test test-snapd-portal-client open-file | MATCH "from-host-system"
 
     echo "The confined application can write files via the portal"
     [ ! -f /tmp/file-to-write.txt ]
@@ -58,7 +59,7 @@ execute: |
     touch /tmp/file-to-write.txt
     chown test:test /tmp/file-to-write.txt
 
-    as_user test-snapd-portal-client save-file "from-sandbox"
+    session-tool -u test test-snapd-portal-client save-file "from-sandbox"
 
     # TODO: another workaround for testing on 18.04
     # Retry checking until the file contains the written text. In particular on

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -15,6 +15,8 @@ environment:
     EDITOR_HISTORY: /tmp/editor-history.txt
 
 prepare: |
+    session-tool -u test --prepare
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
@@ -35,6 +37,8 @@ prepare: |
     EOF
 
 restore: |
+    session-tool -u test --restore
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals
@@ -44,8 +48,6 @@ restore: |
     rm -f "$EDITOR_HISTORY"
 
 execute: |
-    #shellcheck source=tests/lib/desktop-portal.sh
-    . "$TESTSLIB"/desktop-portal.sh
     #shellcheck source=tests/lib/files.sh
     . "$TESTSLIB"/files.sh
 
@@ -60,7 +62,7 @@ execute: |
     chown -R test:test ~test/snap
 
     echo "The confined application can open URLs in the default browser"
-    as_user test-snapd-portal-client launch-file "$testfile"
+    session-tool -u test test-snapd-portal-client launch-file "$testfile"
 
     echo "The test-browser process was invoked with the URL"
     wait_for_file "$EDITOR_HISTORY" 4 .5

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -12,6 +12,8 @@ environment:
     BROWSER_HISTORY: /tmp/browser-history.txt
 
 prepare: |
+    session-tool -u test --prepare
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
@@ -32,6 +34,8 @@ prepare: |
     EOF
 
 restore: |
+    session-tool -u test --restore
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals
@@ -41,8 +45,6 @@ restore: |
     rm -f "$BROWSER_HISTORY"
 
 execute: |
-    #shellcheck source=tests/lib/desktop-portal.sh
-    . "$TESTSLIB"/desktop-portal.sh
     #shellcheck source=tests/lib/files.sh
     . "$TESTSLIB"/files.sh
 
@@ -50,7 +52,7 @@ execute: |
     snap install --edge test-snapd-portal-client
 
     echo "The confined application can open URLs in the default browser"
-    as_user test-snapd-portal-client open-uri http://www.example.org
+    session-tool -u test test-snapd-portal-client open-uri http://www.example.org
 
     echo "The test-browser process was invoked with the URL"
     wait_for_file "$BROWSER_HISTORY" 4 .5

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -23,20 +23,21 @@ description: |
 systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 prepare: |
+    session-tool -u test --prepare
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
 
 restore: |
+    session-tool -u test --restore
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals
     rm -f /tmp/screenshot.txt
 
 execute: |
-    #shellcheck source=tests/lib/desktop-portal.sh
-    . "$TESTSLIB"/desktop-portal.sh
-
     echo "Install the portals test client"
     snap install --edge test-snapd-portal-client
 
@@ -46,7 +47,7 @@ execute: |
     # file ownership is exposed through the document portal, and our
     # AppArmor policy uses the @owner restriction.
     chown test:test /tmp/screenshot.txt
-    as_user test-snapd-portal-client screenshot | MATCH "my screenshot"
+    session-tool -u test test-snapd-portal-client screenshot | MATCH "my screenshot"
 
 debug: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/session-tool-support/task.yaml
+++ b/tests/main/session-tool-support/task.yaml
@@ -12,13 +12,6 @@ execute: |
             session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no user dbus.socket'
             not session-tool -u "$USER" --has-systemd-and-dbus
             ;;
-        debian-sid-*/test)
-            # Debian packages support session DBus into a separate, optional
-            # package dbus-user-session. It is not installed by default
-            # on sid (XXX: why is it in debian-10 though?).
-            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no user dbus.socket'
-            not session-tool -u "$USER" --has-systemd-and-dbus
-            ;;
         ubuntu-14.04-*)
             # Ubuntu 14.04 does not use systemd. 
             session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no busctl'

--- a/tests/main/xdg-open-portal/task.yaml
+++ b/tests/main/xdg-open-portal/task.yaml
@@ -20,6 +20,8 @@ environment:
     EDITOR_HISTORY: /tmp/editor-history.txt
 
 prepare: |
+    session-tool -u test --prepare
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
@@ -64,6 +66,8 @@ prepare: |
     chown -R test:test ~test/snap
 
 restore: |
+    session-tool -u test --restore
+
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals
@@ -81,20 +85,20 @@ execute: |
     . "$TESTSLIB"/files.sh
 
     echo "Request is forwarded to the default browser"
-    as_user test-snapd-desktop.cmd xdg-open http://www.example.org
+    session-tool -u test test-snapd-desktop.cmd xdg-open http://www.example.org
 
     echo "The test-browser process was invoked with the URL"
     wait_for_file "$BROWSER_HISTORY" 4 .5
     MATCH http://www.example.org < "$BROWSER_HISTORY"
 
     echo "Access the file via URI handler"
-    as_user test-snapd-desktop.cmd xdg-open file:///home/test/snap/test-snapd-desktop/common/test.txt
+    session-tool -u test test-snapd-desktop.cmd xdg-open file:///home/test/snap/test-snapd-desktop/common/test.txt
     wait_for_file "$EDITOR_HISTORY" 4 .5
     MATCH /home/test/snap/test-snapd-desktop/common/test.txt < "$EDITOR_HISTORY"
     rm -f "$EDITOR_HISTORY"
 
     echo "Access the file directly"
-    as_user test-snapd-desktop.cmd xdg-open /home/test/snap/test-snapd-desktop/common/test.txt
+    session-tool -u test test-snapd-desktop.cmd xdg-open /home/test/snap/test-snapd-desktop/common/test.txt
     wait_for_file "$EDITOR_HISTORY" 4 .5
     MATCH /home/test/snap/test-snapd-desktop/common/test.txt < "$EDITOR_HISTORY"
 


### PR DESCRIPTION
A bunch of patches that ports our portal tests to session-tool. The PR includes a fix for debian-sid that pulls in `dbus-user-session` which isn't installed in the spread images.