### PR TITLE
tests: port selinux-clean to session-tool

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -274,10 +274,14 @@ chmod +x "$tmp_dir/exec"
 # We want to provide a SELinuxContext but systemd in older SELinux-using distributions
 # does not recognize this attribute. See https://github.com/systemd/systemd/blob/master/NEWS#L6402
 # The typical user context as reported by id -Z is: unconfined_u:unconfined_r:unconfined_t:s0
-selinux_context_arg="SELinuxContext s unconfined_u:unconfined_r:unconfined_t:s0"
-if [ "$(systemctl --version | head -n 1 | awk '{ print $2 }')" -le 219 ]; then
-	selinux_context_arg=
-fi
+selinux_context_arg=
+case $SPREAD_SYSTEM in
+	fedora-*|centos-*)
+		if [ "$(systemctl --version | head -n 1 | awk '{ print $2 }')" -gt 219 ]; then
+			selinux_context_arg="SELinuxContext s unconfined_u:unconfined_r:unconfined_t:s0"
+		fi
+		;;
+esac
 
 # NOTE: This shellcheck directive is for the $selinux_context_arg expansion below.
 # shellcheck disable=SC2086

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -273,6 +273,7 @@ chmod +x "$tmp_dir/exec"
 
 # We want to provide a SELinuxContext but systemd in older SELinux-using distributions
 # does not recognize this attribute. See https://github.com/systemd/systemd/blob/master/NEWS#L6402
+# The typical user context as reported by id -Z is: unconfined_u:unconfined_r:unconfined_t:s0
 selinux_context_arg="SELinuxContext s unconfined_u:unconfined_r:unconfined_t:s0"
 if [ "$(systemctl --version | head -n 1 | awk '{ print $2 }')" -le 219 ]; then
 	selinux_context_arg=

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -108,6 +108,8 @@ case "$action" in
 				echo "StateDirectory=systemd/linger"
 			) > /etc/systemd/system/systemd-logind.service.d/linger.conf
 			mkdir -p /var/lib/systemd/linger
+			test "$(command -v restorecon)" != "" && restorecon /var/lib/systemd/linger
+
 			systemctl daemon-reload
 			systemctl restart systemd-logind.service
 
@@ -269,6 +271,15 @@ cat_stderr_pid=$!
 )>"$tmp_dir/exec"
 chmod +x "$tmp_dir/exec"
 
+# We want to provide a SELinuxContext but systemd in older SELinux-using distributions
+# does not recognize this attribute. See https://github.com/systemd/systemd/blob/master/NEWS#L6402
+selinux_context_arg="SELinuxContext s unconfined_u:unconfined_r:unconfined_t:s0"
+if [ "$(systemctl --version | head -n 1 | awk '{ print $2 }')" -le 219 ]; then
+	selinux_context_arg=
+fi
+
+# NOTE: This shellcheck directive is for the $selinux_context_arg expansion below.
+# shellcheck disable=SC2086
 busctl \
 	--allow-interactive-authorization=no --quiet \
 	--system \
@@ -278,10 +289,11 @@ busctl \
 	/org/freedesktop/systemd1 \
 	 org.freedesktop.systemd1.Manager \
 	StartTransientUnit "ssa(sv)a(sa(sv))" \
-	"$unit_name" fail 4 \
+	"$unit_name" fail $(( 4 + $(test -n "$selinux_context_arg" && echo 1 || echo 0))) \
 		Description s "session-tool running $* as $user" \
 		Type s oneshot \
 		Environment as 1 TERM=xterm-256color \
+		$selinux_context_arg \
 		ExecStart "a(sasb)" 1 \
 			"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \
 	0

--- a/tests/lib/snaps/test-snapd-desktop/bin/sh
+++ b/tests/lib/snaps/test-snapd-desktop/bin/sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+PS1='$ '
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-desktop/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-desktop/meta/snap.yaml
@@ -13,3 +13,6 @@ apps:
     cmd:
         command: bin/cmd
         plugs: [desktop]
+    sh:
+        command: bin/sh
+        plugs: [desktop]

--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -17,36 +17,31 @@ prepare: |
 
     getenforce > enforcing.mode
 
+    # NOTE: Enable linger (what effectively happens in session-tool --prepare)
+    # before we enable enforcing mode, as otherwise the remote ssh session
+    # won't have access to this.
+    session-tool -u test --prepare
+
     # Enable enforcing mode, our policy is already marked as permissive, so we
     # will get audit entries but the program will not be stopped by SELinux
     setenforce 1
     ausearch --checkpoint stamp -m AVC || true
 
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-
-    start_user_session
-
 restore: |
     setenforce "$(cat enforcing.mode)"
     rm -f stamp enforcing.mode
 
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
-
-    stop_user_session
-    purge_user_session_data
+    session-tool -u test --restore
 
 execute: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
-    #shellcheck source=tests/lib/user.sh
-    . "$TESTSLIB/user.sh"
 
     install_local test-snapd-desktop
-    test-snapd-desktop.cmd sh -c echo 'hello world'
-    as_user test-snapd-desktop.cmd "sh -c 'echo hello world'"
-    as_user test-snapd-desktop.cmd "sh -c 'mkdir \$HOME/foo && echo foo > \$HOME/foo/bar'"
+    test-snapd-desktop.sh -c echo 'hello world'
+    session-tool -u test test-snapd-desktop.sh -c 'echo hello world'
+    session-tool -u test test-snapd-desktop.sh -c 'mkdir /home/test/foo'
+    session-tool -u test test-snapd-desktop.sh -c 'echo foo >/home/test/foo/bar'
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
     # another revision triggers copy of snap data
     install_local test-snapd-desktop
@@ -87,7 +82,7 @@ execute: |
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
     # we are likely running without a display, so this will likely fail,
     # hopefully triggering enough of earlier setup to catch any relevant denials
-    as_user snap run snap-store || true
+    session-tool -u test snap run snap-store || true
     # removal triggers cleanups
     snap remove snap-store
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'


### PR DESCRIPTION
When running interactively I noticed this test fails to run "cmd"
correctly, resulting in this error:

    /snap/test-snapd-desktop/x1/bin/cmd: 4: exec: sh -c 'echo hello world': not found

I rewrote that fragment to be less mysterious around quoting.

This patch also contains a pair of fixes for session-tool related to SELinux.
The first issue is incorrect context on the directory
/var/lib/systemd/linger created to work around a systemd bug.
The second issue is the incorrect service context that we get from
StartTransientScope, that is not representative of the context a user
would get in a session.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
