### PR TITLE
image: stub implementation of image.Prepare for darwin

### DIFF
--- a/image/image_darwin.go
+++ b/image/image_darwin.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package image
+
+import (
+	"github.com/snapcore/snapd/osutil"
+)
+
+func Prepare(opts *Options) error {
+	return osutil.ErrDarwin
+}

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -46,23 +46,6 @@ var (
 	Stderr io.Writer = os.Stderr
 )
 
-type Options struct {
-	ModelFile string
-	Classic   bool
-
-	Channel string
-
-	// TODO: use OptionsSnap directly here?
-	Snaps        []string
-	SnapChannels map[string]string
-
-	PrepareDir string
-
-	// Architecture to use if none is specified by the model,
-	// useful only for classic mode. If set must match the model otherwise.
-	Architecture string
-}
-
 // classicHasSnaps returns whether the model or options specify any snaps for the classic case
 func classicHasSnaps(model *asserts.Model, opts *Options) bool {
 	return model.Gadget() != "" || len(model.RequiredNoEssentialSnaps()) != 0 || len(opts.Snaps) != 0

--- a/image/options.go
+++ b/image/options.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package image
+
+type Options struct {
+	ModelFile string
+	Classic   bool
+
+	Channel string
+
+	// TODO: use OptionsSnap directly here?
+	Snaps        []string
+	SnapChannels map[string]string
+
+	PrepareDir string
+
+	// Architecture to use if none is specified by the model,
+	// useful only for classic mode. If set must match the model otherwise.
+	Architecture string
+}


### PR DESCRIPTION
Stub method for prepare.Image for darwin. This is needed to make the existing test of minimal build of snap binary on OSX happy in #8533. It fails in 8533  once gadget is imported because of various unimplemented methods that bubble up via bootstrap / secboot / tpm.
