### PR TITLE
tests: work around journald bug in core16

### DIFF
--- a/tests/main/core-persistent-journal/task.yaml
+++ b/tests/main/core-persistent-journal/task.yaml
@@ -33,7 +33,7 @@ execute: |
     # configuration specified in snapd.service. Other services may not be so
     # lucky and just decide to die and stay dead.
     #
-    # This is bug upstream bug https://bugs.freedesktop.org/show_bug.cgi?id=84923
+    # This is upstream bug https://bugs.freedesktop.org/show_bug.cgi?id=84923
     #
     # It has been fixed in the version of systemd on core18+ but core16 makes
     # configuring the journal entirely unreliable as it leaves us with the

--- a/tests/main/core-persistent-journal/task.yaml
+++ b/tests/main/core-persistent-journal/task.yaml
@@ -26,7 +26,27 @@ execute: |
     not test -e /var/log/journal
 
     echo "Check that persistent journal can be enabled"
-    snap set core journal.persistent=true
+    # FIXME: any time we manipulate the journal on core16 systems, with the
+    # systemd version used there, systemd-journald closes the pipes it uses to
+    # communicate with services, resulting in SIGPIPE. This also means that
+    # snapd is killed with SIGPIPE and restarts on failure, due to the
+    # configuration specified in snapd.service. Other services may not be so
+    # lucky and just decide to die and stay dead.
+    #
+    # This is bug upstream bug https://bugs.freedesktop.org/show_bug.cgi?id=84923
+    #
+    # It has been fixed in the version of systemd on core18+ but core16 makes
+    # configuring the journal entirely unreliable as it leaves us with the
+    # following alternatives:
+    #
+    # 1) Die in the middle of the hook, because journal is restarting.
+    #    We can polish this so that snapd can die "cleanly", with enough
+    #    effort, perhaps.
+    #
+    # 2) Ignore SIGPIPE and not log anything from snapd following the restart.
+    #
+    # Note that this also affects *all* services on the system, not just snapd.
+    retry-tool -n 10 --wait 3 snap set core journal.persistent=true
     test -e /var/log/journal/
     test -e /var/log/journal/.snapd-created
 
@@ -36,12 +56,14 @@ execute: |
     retry-tool -n30 --wait 1 test -e "/var/log/journal/$MACHINE_ID"
 
     echo "Check that persistent journal can be disabled"
-    snap set core journal.persistent=false
+    # FIXME: see the longer comment above.
+    retry-tool -n 10 --wait 3 snap set core journal.persistent=false
     not test -e /var/log/journal
 
     echo "Check that journal log is not removed if managed manually"
     mkdir /var/log/journal
-    snap set core journal.persistent=true
+    # FIXME: see the longer comment above.
+    retry-tool -n 10 --wait 3 snap set core journal.persistent=true
     not test -e /var/log/journal/.snapd-created
     snap set core journal.persistent=false 2>&1 | MATCH "the /var/log/journal directory was not created by snapd"
     # the journal dir was not removed

--- a/tests/main/core-persistent-journal/task.yaml
+++ b/tests/main/core-persistent-journal/task.yaml
@@ -46,7 +46,14 @@ execute: |
     # 2) Ignore SIGPIPE and not log anything from snapd following the restart.
     #
     # Note that this also affects *all* services on the system, not just snapd.
-    retry-tool -n 10 --wait 3 snap set core journal.persistent=true
+    case "$SPREAD_SYSTEM" in
+        ubuntu-core-16-*)
+            retry-tool -n 10 --wait 3 snap set core journal.persistent=true
+            ;;
+        *)
+            snap set core journal.persistent=true
+            ;;
+    esac
     test -e /var/log/journal/
     test -e /var/log/journal/.snapd-created
 
@@ -57,14 +64,29 @@ execute: |
 
     echo "Check that persistent journal can be disabled"
     # FIXME: see the longer comment above.
-    retry-tool -n 10 --wait 3 snap set core journal.persistent=false
+    case "$SPREAD_SYSTEM" in
+        ubuntu-core-16-*)
+            retry-tool -n 10 --wait 3 snap set core journal.persistent=false
+            ;;
+        *)
+            snap set core journal.persistent=false
+            ;;
+    esac
     not test -e /var/log/journal
 
     echo "Check that journal log is not removed if managed manually"
     mkdir /var/log/journal
     # FIXME: see the longer comment above.
-    retry-tool -n 10 --wait 3 snap set core journal.persistent=true
+    case "$SPREAD_SYSTEM" in
+        ubuntu-core-16-*)
+            retry-tool -n 10 --wait 3 snap set core journal.persistent=true
+            ;;
+        *)
+            snap set core journal.persistent=true
+            ;;
+    esac
     not test -e /var/log/journal/.snapd-created
+    # NOTE: Since this is failing early, before we do anything to the journal, there is no need to use retry-tool.
     snap set core journal.persistent=false 2>&1 | MATCH "the /var/log/journal directory was not created by snapd"
     # the journal dir was not removed
     test -e /var/log/journal/


### PR DESCRIPTION
Restarting or reconfiguring journald on the version of systemd used in
core16 sends SIGPIPE to *all* services, as the journal is closing all
the pipes used for logging.

While this is disastrous for other reasons (all services are affected,
no good solution as outlined in the comment in the test) we don't want
to see random test failures that plague master.

This patch puts a retry loop around the journal manipulation test logic.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
