### PR TITLE
tests: session-tool --restore -u stops user-$UID.slice

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -138,7 +138,7 @@ case "$action" in
 				uid="$(id -u "$u")"
 				# See user@.service(5) for discussion about user-UID.slice and
 				# user@UID.service and why both are used. Here we stop the
-				# slice as that encompasses both user@UID.scope and any
+				# slice as that encompasses both user@UID.service and any
 				# existing sessions of that user.
 				systemctl stop "user-$uid.slice"
 

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -127,6 +127,25 @@ case "$action" in
 		# Disable linger for the selected user(s).
 		for u in $(echo "$user" | tr ',' ' '); do
 			loginctl disable-linger "$u"
+			# If the user is not root, also stop their user slice and ensure
+			# their XDG_RUNTIME_DIR goes away. Currently doing this for root is
+			# impossible, because spread logs into a test system over ssh and
+			# gets a root user slice, at minimum.
+			#
+			# If spread ever changes, so that the tests are executed as system
+			# services, then there this condition could be removed.
+			if [ "$u" != root ]; then
+				uid="$(id -u "$u")"
+				# See user@.service(5) for discussion about user-UID.slice and
+				# user@UID.service and why both are used. Here we stop the
+				# slice as that encompasses both user@UID.scope and any
+				# existing sessions of that user.
+				systemctl stop "user-$uid.slice"
+				if [ -e "/run/user/$uid" ]; then
+					echo "session-tool: /run/user/$uid still exists" >&2
+					exit 1
+				fi
+			fi
 		done
 
 		if [ -e /run/session-tool-core16.workaround ]; then

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -141,6 +141,16 @@ case "$action" in
 				# slice as that encompasses both user@UID.scope and any
 				# existing sessions of that user.
 				systemctl stop "user-$uid.slice"
+
+				# On Ubuntu 16.04 and Debian 9 stopping the slice above is
+				# insufficient to stop the service responsible for
+				# /run/user/UID *immediately*. This seems to be related to
+				# *absence* of user-session-dir@.service (template service)
+				# which is responsible for this operation later on (and where
+				# it works more reliably).
+				#
+				# Give the system some time to clean things up.
+				retry-tool -n 3 --wait 3 test ! -e "/run/user/$uid"
 				if [ -e "/run/user/$uid" ]; then
 					echo "session-tool: /run/user/$uid still exists" >&2
 					exit 1


### PR DESCRIPTION
This patch expands session-tool to perform a more extensive restore
operation for non-root users. The primary motivation is porting of
tests/main/user-mounts, with an added check that the XDG_RUNTIME_DIR
directory is no longer present after a call to session-tool --restore,
where it was observed that, at least on Ubuntu 19.10 the directory would
not be removed, (since it is a mount point, it would also remain
mounted.

For unknown reasons systemd --user remains running after a call to
"loginctl disable-linger" on that system, this does not happen on Ubuntu
20.04 anymore, though, suggesting it is just another bug that was
fixed.

With this patch, when restoring a non-root user, see the code comment
for the rationale of this exception, we stop the user-UID.slice as well.
The aforementioned slice contains user@UID.session as well as any
session-NNN.scope units belonging to the user.

In addition, as a sanity check, session-tool --restore fails immediately
if the XDG_RUNTIME_DIR directory exists after the slice is stopped.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>