### PR TITLE
tests: port user-mounts test to session-tool

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -86,7 +86,7 @@ case "$action" in
 	prepare)
 		# Make /var/lib/systemd writable so that we can get linger enabled.
 		# This only applies to Ubuntu Core 16 where individual directories were
-		# writable. In Core 18 and beyod all of /var/lib/systemd is writable.
+		# writable. In Core 18 and beyond all of /var/lib/systemd is writable.
 		case "$SPREAD_SYSTEM" in
 			ubuntu-core-16-*)
 				mount tmpfs -t tmpfs /var/lib/systemd/

--- a/tests/lib/snaps/test-snapd-desktop/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-desktop/meta/snap.yaml
@@ -1,7 +1,7 @@
 name: test-snapd-desktop
 version: 1.0
 summary: Basic desktop interface test snap
-description: A basic snap to access dektop interface
+description: A basic snap to access desktop interface
 
 apps:
     check-files:

--- a/tests/main/user-mounts/task.yaml
+++ b/tests/main/user-mounts/task.yaml
@@ -9,45 +9,35 @@ details: |
 # This test makes use of the user mount provided by the desktop
 # interface.  When we have an interface providing user mounts that is
 # available on core, we can switch to that.
-systems: [-ubuntu-core-*]
+systems:
+    - -ubuntu-core-*   # see above
+    - -ubuntu-14.04-*  # no session-tool
 
 prepare: |
-    snap try "$TESTSLIB"/snaps/test-snapd-desktop
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local test-snapd-desktop
     snap disconnect test-snapd-desktop:desktop
 
+    session-tool -u test --prepare
 restore: |
-    rm -rf /run/user/12345/*
-    rm -f /tmp/check-user-mount.sh
+    session-tool -u test --restore
 
 execute: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-
-    echo "Create XDG_RUNTIME_DIR for test user"
-    USER_RUNTIME_DIR=/run/user/"$(id -u test)"
-    mkdir -p "$USER_RUNTIME_DIR" || true
-    #shellcheck disable=SC2115
-    rm -rf "$USER_RUNTIME_DIR"/*
-    chmod u=rwX,go= "$USER_RUNTIME_DIR"
-    chown test:test "$USER_RUNTIME_DIR"
-
     echo "Without desktop interface connected, there is no user-fstab file"
-    [ ! -f /var/lib/snapd/mount/snap.test-snapd-desktop.user-fstab ]
+    test ! -e /var/lib/snapd/mount/snap.test-snapd-desktop.user-fstab
 
     echo "With desktop interface connected, it is created"
     snap connect test-snapd-desktop:desktop
-    [ -f /var/lib/snapd/mount/snap.test-snapd-desktop.user-fstab ]
+    test -f /var/lib/snapd/mount/snap.test-snapd-desktop.user-fstab
     diff -u /var/lib/snapd/mount/snap.test-snapd-desktop.user-fstab - << \EOF
     $XDG_RUNTIME_DIR/doc/by-app/snap.test-snapd-desktop $XDG_RUNTIME_DIR/doc none bind,rw,x-snapd.ignore-missing 0 0
     EOF
 
-    "$LIBEXECDIR"/snapd/snap-discard-ns test-snapd-sh
+    snap-tool snap-discard-ns test-snapd-sh
 
     echo "The user-fstab file is used to prepare the confinement sandbox"
-    cat << \EOF > /tmp/check-user-mount.sh
-    mkdir -p /run/user/12345/doc/by-app/snap.test-snapd-desktop
-    touch /run/user/12345/doc/by-app/snap.test-snapd-desktop/in-source
-    touch /run/user/12345/doc/in-target
-    test-snapd-desktop.check-dirs /run/user/12345/doc
-    EOF
-    su -l -c "sh /tmp/check-user-mount.sh" test | MATCH in-source
+    session-tool -u test mkdir -p /run/user/12345/doc/by-app/snap.test-snapd-desktop
+    session-tool -u test touch /run/user/12345/doc/by-app/snap.test-snapd-desktop/in-source
+    session-tool -u test touch /run/user/12345/doc/in-target
+    session-tool -u test test-snapd-desktop.check-dirs /run/user/12345/doc | MATCH in-source


### PR DESCRIPTION
This test was failing for me recently so I decided to take a look and
*oh my*, so much stuff that can be simplified:

 - hand-coded "run as user" code replaced with session-tool
 - snap-discard-ns invoked with snap-tool
 - test snap installed with install_local rather than with snap try

In addition I made some stylistic changes, assertions that use "[ ... ]"
were changed to "test ..." as that form is more natural outside of an if
statement. The helper script that was hand-crafted is gone and the four
lines it invoked now run via session-tool, so that on failure we could
see exactly which line failed and why.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
