### PR TITLE
tests/degrated: ignore failure in systemd-vconsole-setup.service

### DIFF
--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -22,6 +22,13 @@ execute: |
     . "$TESTSLIB"/systemd.sh
     wait_for_service "multi-user.target"
 
+    case "$SPREAD_SYSTEM" in
+        opensuse-tumbleweed-*)
+            systemctl mask systemd-vconsole-setup.service
+            systemctl reset-failed systemd-vconsole-setup.service
+            ;;
+    esac
+
     if systemctl status | grep "State: [d]egraded"; then
         echo "systemctl reports the system is in degraded mode"
         # add debug output


### PR DESCRIPTION
On openSUSE tumbleweed this service constantly fails. The intention of
the test is to catch snapd-induced failures so ignoring it explicitly is
acceptable.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
