### PR TITLE
tests: port interfaces-audio-playback-record to session-tool

### DIFF
--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the audio-playback/record interface works
 
-# Only classic Ubuntu has the pulseaudio mediation patches
-systems: [ ubuntu-1*-*64, ubuntu-2*-*64 ]
+# Only classic Ubuntu has the pulseaudio mediation patches. Ubuntu 14.04 is unsupported on the desktop.
+systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 environment:
     PLAY_FILE: "/snap/test-snapd-audio-record/current/usr/share/sounds/alsa/Noise.wav"
@@ -9,60 +9,50 @@ environment:
     EXFAIL: "ubuntu-14"
 
 prepare: |
-    # FIXME: This test is broken and should be ported to session-tool, systemd
-    # --user starts pulseaudio for us so we are always racing with it (whoever
-    # acquires the socket file wins).
-    #
-    # To prevent this from breaking this test mask pulseaudio.{socket,service}
-    # in all user sessions.
-    systemctl --user --global mask pulseaudio.{socket,service}
+    truncate --size=0 defer.sh
+    chmod +x defer.sh
 
-    #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB"/pkgdb.sh
-    snap install --edge test-snapd-audio-record
-
+    # Install pulseaudio.
     apt-get update
     apt-get install -y pulseaudio pulseaudio-utils
+    echo "apt-get autoremove --purge -y pulseaudio pulseaudio-utils" >>defer.sh
 
-    echo "Create XDG_RUNTIME_DIR=/run/user/12345"
-    # shellcheck disable=SC2174
-    mkdir -m 700 -p /run/user/12345 || true
-    chown test:test /run/user/12345
+    # Make sure the socket and the server is available in the user session.
+    if [ "$(systemctl --user --global is-enabled pulseaudio.socket)" != enabled ]; then
+        systemctl --user --global enable pulseaudio.socket
+        echo "systemctl --user --global disable pulseaudio.socket" >>defer.sh
+    fi
+    if [ "$(systemctl --user --global is-enabled pulseaudio.service)" != enabled ]; then
+        systemctl --user --global enable pulseaudio.service
+        echo "systemctl --user --global disable pulseaudio.service" >>defer.sh
+    fi
 
-    # ensure we have a clean pulse directory
-    test -d /home/test/.config && mv /home/test/.config /home/test/.config.spread
-    mkdir -m 700 /home/test/.config
-    mkdir -m 700 /home/test/.config/pulse
-    chown test:test /home/test/.config /home/test/.config/pulse
+    # Install a snap that uses the pulseaudio interface.
+    snap install --edge test-snapd-audio-record
+    echo "snap remove --purge test-snapd-audio-record" >>defer.sh
+
+    # Prepare a session for the user.
+    session-tool -u test --prepare
+    echo "session-tool -u test --restore" >>defer.sh
 
 restore: |
-    HOME=/home/test XDG_RUNTIME_DIR=/run/user/12345 su -p -c "pulseaudio --kill" test || true
-    snap remove --purge test-snapd-audio-record
-    apt-get autoremove --purge -y pulseaudio pulseaudio-utils
-    rm -rf /run/user/12345 /home/test/.config/pulse
-    if [ -d /home/test/.config.spread ]; then
-        rm -rf /home/test/.config
-        mv /home/test/.config.spread /home/test/.config
-    fi
-    systemctl --user --global unmask pulseaudio.{socket,service}
+    # Restore system to the previous state by running deferred commands in
+    # reverse order.
+    tac defer.sh > refed.sh
+    sh -xe refed.sh && rm -f {defer,refed}.sh
 
 execute: |
-    # we need -p so that XDG_RUNTIME_DIR is honored, but that preserves HOME,
-    # so specify it too since pulseaudio fails to start otherwise
-    echo "Start pulseaudio"
-    HOME=/home/test XDG_RUNTIME_DIR=/run/user/12345 su -p -c "pulseaudio --exit-idle-time=30" test &
+    echo "ensure that we have a pulse socket"
+    retry-tool test -S /run/user/12345/pulse/native
 
-    echo "Then wait for the socket to show up"
-    retry-tool -n 10 test -S /run/user/12345/pulse/native
-
-    echo "Check pulseaudio"
-    HOME=/home/test XDG_RUNTIME_DIR=/run/user/12345 retry-tool -n 10 su -p -c "pulseaudio --check" test
+    echo "Check that the daemon is running"
+    retry-tool session-tool -u test pulseaudio --check
 
     echo "The unconfined user can play audio"
-    HOME=/home/test XDG_RUNTIME_DIR=/run/user/12345 su -p -c "/usr/bin/paplay $PLAY_FILE" test
+    session-tool -u test /usr/bin/paplay "$PLAY_FILE"
 
     echo "The unconfined user can record audio"
-    HOME=/home/test XDG_RUNTIME_DIR=/run/user/12345 su -p -c "/snap/test-snapd-audio-record/current/bin/parec-simple" test
+    session-tool -u test /snap/test-snapd-audio-record/current/bin/parec-simple
 
     echo "The audio-playback interface is connected by default"
     snap connections test-snapd-audio-record | MATCH "audio-playback +test-snapd-audio-record:audio-playback +:audio-playback +-"
@@ -74,13 +64,13 @@ execute: |
     snap connect test-snapd-audio-record:audio-playback
 
     echo "Then the snap can play audio"
-    su -l -c "test-snapd-audio-record.play $PLAY_FILE" test
+    session-tool -u test test-snapd-audio-record.play "$PLAY_FILE"
 
     echo "When the audio-record plug is connected"
     snap connect test-snapd-audio-record:audio-record
 
     echo "Then the snap can record audio"
-    su -l -c "test-snapd-audio-record.recsimple" test
+    session-tool -u test test-snapd-audio-record.recsimple
 
     echo "When the audio-record plug is disconnected"
     snap disconnect test-snapd-audio-record:audio-record
@@ -91,10 +81,10 @@ execute: |
     fi
 
     echo "Then the snap command is not able to record audio"
-    if [ "$mediating_pa" = "no" ] && ! su -l -c "test-snapd-audio-record.recsimple" test ; then
+    if [ "$mediating_pa" = "no" ] && ! session-tool -u test test-snapd-audio-record.recsimple; then
         echo "Could not record audio. Does '$SPREAD_SYSTEM' have mediation patches?"
         exit 1
-    elif [ "$mediating_pa" = "yes" ] && su -l -c "test-snapd-audio-record.recsimple" test ; then
+    elif [ "$mediating_pa" = "yes" ] && session-tool -u test test-snapd-audio-record.recsimple; then
         echo "Could record audio even though '$SPREAD_SYSTEM' should have mediation patches"
         exit 1
     fi
@@ -107,7 +97,7 @@ execute: |
     snap disconnect test-snapd-audio-record:audio-playback
 
     echo "Then the snap command is not able to connect to the pulseaudio socket"
-    if su -l -c "test-snapd-audio-record.play $PLAY_FILE" test ; then
+    if session-tool -u test test-snapd-audio-record.play "$PLAY_FILE"; then
         echo "Expected error with plug disconnected"
         exit 1
     fi

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -1,10 +1,7 @@
 summary: Ensure that the pulseaudio interface works
 
-# Classic Ubuntu is sufficient to test the feature,
-# except Ubuntu 14.04 where systemd is not supported.
-systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20-*]
-
-kill-timeout: 3m
+# Only classic Ubuntu has the pulseaudio mediation patches. Ubuntu 14.04 is unsupported on the desktop.
+systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 environment:
     PLAY_FILE: "/snap/test-snapd-pulseaudio/current/usr/share/sounds/alsa/Noise.wav"
@@ -65,10 +62,7 @@ execute: |
     session-tool -u test test-snapd-pulseaudio.play "$PLAY_FILE"
 
     echo "Then the snap can record audio"
-    if ! session-tool -u test test-snapd-pulseaudio.recsimple; then
-        echo "Could not record audio"
-        exit 1
-    fi
+    session-tool -u test test-snapd-pulseaudio.recsimple
 
     if [ "$(snap debug confinement)" = "partial" ] ; then
         exit 0


### PR DESCRIPTION
This branch ports the other "audio" test to session-tool and makes the two tests more similar.
This test is one of the last tests that manipulate "session" things by hand.