### PR TITLE
tests: run smoke test with different bases

### DIFF
--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -55,8 +55,14 @@ execute: |
 
     echo "Ensure different bases work"
     for base in core18 core20; do
+        # no core20 snap for i386
+        if [ "$base" = "core20" ] && [ "$(uname -m)" = i686 ]; then
+            continue
+        fi
+
         snap install test-snapd-sh-${base}
         test-snapd-sh-${base}.sh -c "echo hello $base" | MATCH "hello $base"
+        # shellcheck disable=SC2016
         test-snapd-sh-${base}.sh -c 'touch $SNAP_COMMON/test'
         test -f /var/snap/test-snapd-sh-${base}/common/test
     done

--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -52,3 +52,11 @@ execute: |
 
     echo "Ensure a change was generated for the install"
     snap changes | MATCH 'Install "test-snapd-sh" snap'
+
+    echo "Ensure different bases work"
+    for base in core18 core20; do
+        snap install test-snapd-sh-${base}
+        test-snapd-sh-${base}.sh -c "echo hello $base" | MATCH "hello $base"
+        test-snapd-sh-${base}.sh -c 'touch $SNAP_COMMON/test'
+        test -f /var/snap/test-snapd-sh-${base}/common/test
+    done


### PR DESCRIPTION
The smoke suite should also run a simple echo test on
different bases. This should catch the error we had
on armhf where with kernel 5.4 certain syscalls are
not available. See:
https://github.com/snapcore/core20/issues/48

Because the smoke suite is run with autopkgtest on
all clasic ubuntu architectures a smoke test like
this would have found the issue.

