### PR TITLE
Adds missing paths to apparmor, solves lp:1876804

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -279,6 +279,8 @@ var templateCommon = `
   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
   /sys/module/apparmor/parameters/enabled r,
   /{,usr/}lib/ r,
+  /var/lib/snapd/hostfs/usr/share/mime/* r,
+  /etc/gnome/defaults.list r,
 
   # Reads of oom_adj and oom_score_adj are safe
   owner @{PROC}/@{pid}/oom_{,score_}adj r,


### PR DESCRIPTION
https://bugs.launchpad.net/snapd/+bug/1876804

When I launch the Ubuntu snap store from my favorites, the following lines appear in dmesg.

[38514.879381] audit: type=1400 audit(1588562964.269:5985): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/mime.cache" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879402] audit: type=1400 audit(1588562964.269:5986): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/globs2" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879426] audit: type=1400 audit(1588562964.269:5987): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/magic" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879443] audit: type=1400 audit(1588562964.269:5988): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/aliases" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879459] audit: type=1400 audit(1588562964.269:5989): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/subclasses" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879474] audit: type=1400 audit(1588562964.269:5990): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/icons" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879488] audit: type=1400 audit(1588562964.269:5991): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/generic-icons" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.880255] audit: type=1400 audit(1588562964.269:5992): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/etc/gnome/defaults.list" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.961031] audit: type=1400 audit(1588562964.349:5993): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/mime.cache" pid=2467 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.961038] audit: type=1400 audit(1588562964.349:5994): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/globs2" pid=2467 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0

Adding these lines:

  /var/lib/snapd/hostfs/usr/share/mime/* r,
  /etc/gnome/defaults.list r,

to /var/lib/snapd/apparmor/profiles/snap.snap-store.ubuntu-software

made the messages go away.

Further notes. https://ubuntuforums.org/showthread.php?t=2442426
