### PR TITLE
tests: fix raciness in pulseaudio test

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -4,7 +4,8 @@ if [ $# -eq 0 ]; then
 	echo "usage: session-tool --prepare | --restore [-u USER | -u USER1,USER2,...]"
 	echo "usage: session-tool --kill-leaked"
 	echo "usage: session-tool --dump"
-	echo "usage: session-tool --has-systemd-and-dbus [-u USER]"
+	echo "usage: session-tool --has-system-systemd-and-dbus"
+	echo "usage: session-tool --has-session-systemd-and-dbus"
 	exit 1
 fi
 if [ "$(id -u)" -ne 0 ]; then
@@ -44,8 +45,12 @@ while [ $# -gt 0 ]; do
 			action=dump
 			shift
 			;;
-		--has-systemd-and-dbus)
-			action=has-systemd-and-dbus
+		--has-system-systemd-and-dbus)
+			action=has-system-systemd-and-dbus
+			shift
+			;;
+		--has-session-systemd-and-dbus)
+			action=has-session-systemd-and-dbus
 			shift
 			;;
 		-u)
@@ -122,7 +127,13 @@ case "$action" in
 			# We've enabled linger, now let's explicitly start the
 			# default.target. This ensures that test code does not need to pay
 			# extra attention to synchronization.
-			session-tool -u "$u" systemctl --user start default.target
+			#
+			# Because some systems do not support systemd --user (see
+			# tests/main/session-tool-support for details), check if this is
+			# expected to work ahead of trying.
+			if session-tool --has-session-systemd-and-dbus >/dev/null; then
+				session-tool -u "$u" systemctl --user start default.target
+			fi
 		done
 
 		exit 0
@@ -189,24 +200,25 @@ case "$action" in
 		done
 		exit 0
 		;;
-	has-systemd-and-dbus)
-		# Older systems don't have support for modern sessions
-		# There are two known issues:
-		#  - CentOS 7 and derivatives disabled systemd --user
-		#    https://bugs.centos.org/view.php?id=8767
-		#  - Ubuntu 14.04 with deputy systemd does not connect to DBus
-		#    and systemd-shim is really responding to "systemd" requests.
+	has-system-systemd-and-dbus)
+		#  Ubuntu 14.04 with deputy systemd does not connect to DBus
+		#  and systemd-shim is really responding to "systemd" requests.
 		test -n "$(command -v busctl)"         			|| ( echo "no busctl"; exit 1 )
-		if [ "$user" = "root" ]; then
-			# 		/lib										   /usr/lib									   (if present) dbus-broker.service variant
-			test -f /lib/systemd/system/default.target	|| test -f /usr/lib/systemd/system/default.target	|| ( echo "no system default.target"; exit 1 )
-			test -f /lib/systemd/system/dbus.socket  	|| test -f /usr/lib/systemd/system/dbus.socket		|| ( echo "no system dbus.socket"; exit 1 )
-			test -f /lib/systemd/system/dbus.service	|| test -f /usr/lib/systemd/system/dbus.service		|| test -f /lib/systemd/system/dbus-broker.service || ( echo "no system dbus{,-broker}.service"; exit 1 )
-		else
-			test -f /lib/systemd/user/default.target 	|| test -f /usr/lib/systemd/user/default.target		|| ( echo "no user default.target"; exit 1)
-			test -f /lib/systemd/user/dbus.socket 		|| test -f /usr/lib/systemd/user/dbus.socket 		|| ( echo "no user dbus.socket"; exit 1 )
-			test -f /lib/systemd/user/dbus.service		|| test -f /usr/lib/systemd/user/dbus.service		|| test -f /lib/systemd/user/dbus-broker.service || ( echo "no system dbus{,-broker}.service"; exit 1 )
-		fi
+		# 		/lib										   /usr/lib									   (if present) dbus-broker.service variant
+		test -f /lib/systemd/system/default.target	|| test -f /usr/lib/systemd/system/default.target	|| ( echo "no system default.target"; exit 1 )
+		test -f /lib/systemd/system/dbus.socket  	|| test -f /usr/lib/systemd/system/dbus.socket		|| ( echo "no system dbus.socket"; exit 1 )
+		test -f /lib/systemd/system/dbus.service	|| test -f /usr/lib/systemd/system/dbus.service		|| test -f /lib/systemd/system/dbus-broker.service || ( echo "no system dbus{,-broker}.service"; exit 1 )
+		echo "ok"
+		exit 0
+		;;
+	has-session-systemd-and-dbus)
+		#  CentOS 7 and derivatives disabled systemd --user
+		#  https://bugs.centos.org/view.php?id=8767
+		test -n "$(command -v busctl)"         			|| ( echo "no busctl"; exit 1 )
+		# 		/lib										   /usr/lib									   (if present) dbus-broker.service variant
+		test -f /lib/systemd/user/default.target 	|| test -f /usr/lib/systemd/user/default.target		|| ( echo "no user default.target"; exit 1)
+		test -f /lib/systemd/user/dbus.socket 		|| test -f /usr/lib/systemd/user/dbus.socket 		|| ( echo "no user dbus.socket"; exit 1 )
+		test -f /lib/systemd/user/dbus.service		|| test -f /usr/lib/systemd/user/dbus.service		|| test -f /lib/systemd/user/dbus-broker.service || ( echo "no system dbus{,-broker}.service"; exit 1 )
 		echo "ok"
 		exit 0
 		;;

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -120,9 +120,9 @@ case "$action" in
 		for u in $(echo "$user" | tr ',' ' '); do
 			loginctl enable-linger "$u"
 			# We've enabled linger, now let's explicitly start the
-			# default.target and sockets.target. This ensures that test code
-			# does not need to pay extra attention to synchronization.
-			session-tool -u "$u" systemctl --user start default.target sockets.target
+			# default.target. This ensures that test code does not need to pay
+			# extra attention to synchronization.
+			session-tool -u "$u" systemctl --user start default.target
 		done
 
 		exit 0

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -119,6 +119,10 @@ case "$action" in
 		# Enable linger for the selected user(s).
 		for u in $(echo "$user" | tr ',' ' '); do
 			loginctl enable-linger "$u"
+			# We've enabled linger, now let's explicitly start the
+			# default.target and sockets.target. This ensures that test code
+			# does not need to pay extra attention to synchronization.
+			session-tool -u "$u" systemctl --user start default.target sockets.target
 		done
 
 		exit 0

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -35,6 +35,14 @@ prepare: |
     session-tool -u test --prepare
     echo "session-tool -u test --restore" >>defer.sh
 
+    # Ensure that the socket is active but do not check the service.  For some
+    # reason, pulseaudio quits as soon as it is not needed and this means that
+    # it works when we use paplay but shuts down relatively quickly after
+    # playback. We use to run "pulseaudio --check" but this only worked when
+    # pulse was still running, just before quitting, after the session was
+    # prepared a split second before.
+    session-tool -u test systemctl --user is-active pulseaudio.socket | MATCH active
+
 restore: |
     # Restore system to the previous state by running deferred commands in
     # reverse order.
@@ -42,12 +50,6 @@ restore: |
     sh -xe refed.sh && rm -f {defer,refed}.sh
 
 execute: |
-    echo "ensure that we have a pulse socket"
-    retry-tool test -S /run/user/12345/pulse/native
-
-    echo "Check that the daemon is running"
-    retry-tool session-tool -u test pulseaudio --check
-
     echo "The unconfined user can play audio"
     session-tool -u test /usr/bin/paplay "$PLAY_FILE"
 

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -35,12 +35,13 @@ prepare: |
     session-tool -u test --prepare
     echo "session-tool -u test --restore" >>defer.sh
 
-    # Ensure that the socket is active but do not check the service.  For some
-    # reason, pulseaudio quits as soon as it is not needed and this means that
-    # it works when we use paplay but shuts down relatively quickly after
-    # playback. We use to run "pulseaudio --check" but this only worked when
-    # pulse was still running, just before quitting, after the session was
-    # prepared a split second before.
+    # Ensure that the socket is active but do not check the service. In user
+    # mode pulseaudio is documented to quit when there are no active logind
+    # sessions.
+    #
+    # User session services do not posses a logind session session so
+    # pulseaudio immediately quits, and remains inactive outside of the moments
+    # we execute paplay through session-tool.
     session-tool -u test systemctl --user is-active pulseaudio.socket | MATCH active
 
 restore: |

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -31,6 +31,11 @@ prepare: |
     snap install --edge test-snapd-audio-record
     echo "snap remove --purge test-snapd-audio-record" >>defer.sh
 
+    # TODO: move this to the test that is responsible for creating this data.
+    # Remove potentially large go build cache that makes the debug section more
+    # verbose.
+    rm -rf ~test/.cache/go-build
+
     # Prepare a session for the user.
     session-tool -u test --prepare
     echo "session-tool -u test --restore" >>defer.sh
@@ -49,7 +54,8 @@ prepare: |
     # with cookie file being available.
     if not session-tool -u test systemctl --user start pulseaudio.service; then
         echo "cannot start pulseaudio server"
-        session-tool -u test systemctl --user status pulseaudio.service
+        session-tool -u test systemctl --user status pulseaudio.service || true
+        session-tool -u test journalctl --user -u pulseaudio.service || true
         exit 1
     fi
 
@@ -60,6 +66,8 @@ prepare: |
 debug: |
     echo "Files present in the test user's home directory"
     test -d /home/test && find /home/test
+    echo "Files present in the test user's home directory, that are owned by root"
+    test -d /home/test && find /home/test -user root
     echo "Files present in the test user's runtime directory"
     test -d /home/user/12345 && find /run/user/12345
     echo "Processes running as the test user"

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -47,11 +47,23 @@ prepare: |
     # Start pulseaudio to give it a chance to write the pulseaudio cookie file.
     # Otherwise paplay invocation will race with pulse startup, and will race
     # with cookie file being available.
-    session-tool -u test systemctl --user start pulseaudio.service
+    if not session-tool -u test systemctl --user start pulseaudio.service; then
+        echo "cannot start pulseaudio server"
+        session-tool -u test systemctl --user status pulseaudio.service
+        exit 1
+    fi
 
     # Ensure, that the cookie file is present.
     test -e ~test/.config/pulse/cookie || test -e ~test/.config/pulse/.pulse-cookie
     echo "rm -rf ~test/.config/pulse" >>defer.sh
+
+debug: |
+    echo "Files present in the test user's home directory"
+    test -d /home/test && find /home/test
+    echo "Files present in the test user's runtime directory"
+    test -d /home/user/12345 && find /run/user/12345
+    echo "Processes running as the test user"
+    ps -u test
 
 restore: |
     # Restore system to the previous state by running deferred commands in

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -44,6 +44,15 @@ prepare: |
     # we execute paplay through session-tool.
     session-tool -u test systemctl --user is-active pulseaudio.socket | MATCH active
 
+    # Start pulseaudio to give it a chance to write the pulseaudio cookie file.
+    # Otherwise paplay invocation will race with pulse startup, and will race
+    # with cookie file being available.
+    session-tool -u test systemctl --user start pulseaudio.service
+
+    # Ensure, that the cookie file is present.
+    test -e ~test/.config/pulse/cookie || test -e ~test/.config/pulse/.pulse-cookie
+    echo "rm -rf ~test/.config/pulse" >>defer.sh
+
 restore: |
     # Restore system to the previous state by running deferred commands in
     # reverse order.

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -36,6 +36,10 @@ prepare: |
     # verbose.
     rm -rf ~test/.cache/go-build
 
+    # TODO: fix the test causing this. Some test is making ~test/.config root-owned,
+    # making it impossible for pulseaudio to start and write the secure cookie file.
+    chown -R test ~test
+
     # Prepare a session for the user.
     session-tool -u test --prepare
     echo "session-tool -u test --restore" >>defer.sh

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -34,6 +34,10 @@ prepare: |
     # verbose.
     rm -rf ~test/.cache/go-build
 
+    # TODO: fix the test causing this. Some test is making ~test/.config root-owned,
+    # making it impossible for pulseaudio to start and write the secure cookie file.
+    chown -R test ~test
+
     # Prepare a session for the user.
     session-tool -u test --prepare
     echo "session-tool -u test --restore" >>defer.sh

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -33,12 +33,13 @@ prepare: |
     session-tool -u test --prepare
     echo "session-tool -u test --restore" >>defer.sh
 
-    # Ensure that the socket is active but do not check the service.  For some
-    # reason, pulseaudio quits as soon as it is not needed and this means that
-    # it works when we use paplay but shuts down relatively quickly after
-    # playback. We use to run "pulseaudio --check" but this only worked when
-    # pulse was still running, just before quitting, after the session was
-    # prepared a split second before.
+    # Ensure that the socket is active but do not check the service. In user
+    # mode pulseaudio is documented to quit when there are no active logind
+    # sessions.
+    #
+    # User session services do not posses a logind session session so
+    # pulseaudio immediately quits, and remains inactive outside of the moments
+    # we execute paplay through session-tool.
     session-tool -u test systemctl --user is-active pulseaudio.socket | MATCH active
 
 restore: |

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -45,11 +45,23 @@ prepare: |
     # Start pulseaudio to give it a chance to write the pulseaudio cookie file.
     # Otherwise paplay invocation will race with pulse startup, and will race
     # with cookie file being available.
-    session-tool -u test systemctl --user start pulseaudio.service
+    if not session-tool -u test systemctl --user start pulseaudio.service; then
+        echo "cannot start pulseaudio server"
+        session-tool -u test systemctl --user status pulseaudio.service
+        exit 1
+    fi
 
     # Ensure, that the cookie file is present.
     test -e ~test/.config/pulse/cookie || test -e ~test/.config/pulse/.pulse-cookie
     echo "rm -rf ~test/.config/pulse" >>defer.sh
+
+debug: |
+    echo "Files present in the test user's home directory"
+    test -d /home/test && find /home/test
+    echo "Files present in the test user's runtime directory"
+    test -d /home/user/12345 && find /run/user/12345
+    echo "Processes running as the test user"
+    ps -u test
 
 restore: |
     # Restore system to the previous state by running deferred commands in

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -29,6 +29,11 @@ prepare: |
     snap install --edge test-snapd-pulseaudio
     echo "snap remove --purge test-snapd-pulseaudio" >>defer.sh
 
+    # TODO: move this to the test that is responsible for creating this data.
+    # Remove potentially large go build cache that makes the debug section more
+    # verbose.
+    rm -rf ~test/.cache/go-build
+
     # Prepare a session for the user.
     session-tool -u test --prepare
     echo "session-tool -u test --restore" >>defer.sh
@@ -47,7 +52,8 @@ prepare: |
     # with cookie file being available.
     if not session-tool -u test systemctl --user start pulseaudio.service; then
         echo "cannot start pulseaudio server"
-        session-tool -u test systemctl --user status pulseaudio.service
+        session-tool -u test systemctl --user status pulseaudio.service || true
+        session-tool -u test journalctl --user -u pulseaudio.service || true
         exit 1
     fi
 
@@ -58,6 +64,8 @@ prepare: |
 debug: |
     echo "Files present in the test user's home directory"
     test -d /home/test && find /home/test
+    echo "Files present in the test user's home directory, that are owned by root"
+    test -d /home/test && find /home/test -user root
     echo "Files present in the test user's runtime directory"
     test -d /home/user/12345 && find /run/user/12345
     echo "Processes running as the test user"

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -33,6 +33,14 @@ prepare: |
     session-tool -u test --prepare
     echo "session-tool -u test --restore" >>defer.sh
 
+    # Ensure that the socket is active but do not check the service.  For some
+    # reason, pulseaudio quits as soon as it is not needed and this means that
+    # it works when we use paplay but shuts down relatively quickly after
+    # playback. We use to run "pulseaudio --check" but this only worked when
+    # pulse was still running, just before quitting, after the session was
+    # prepared a split second before.
+    session-tool -u test systemctl --user is-active pulseaudio.socket | MATCH active
+
 restore: |
     # Restore system to the previous state by running deferred commands in
     # reverse order.
@@ -40,12 +48,6 @@ restore: |
     sh -xe refed.sh && rm -f {defer,refed}.sh
 
 execute: |
-    echo "ensure that we have a pulse socket"
-    retry-tool test -S /run/user/12345/pulse/native
-
-    echo "Check that the daemon is running"
-    retry-tool session-tool -u test pulseaudio --check
-
     echo "The unconfined user can play audio"
     session-tool -u test /usr/bin/paplay "$PLAY_FILE"
 

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -42,6 +42,15 @@ prepare: |
     # we execute paplay through session-tool.
     session-tool -u test systemctl --user is-active pulseaudio.socket | MATCH active
 
+    # Start pulseaudio to give it a chance to write the pulseaudio cookie file.
+    # Otherwise paplay invocation will race with pulse startup, and will race
+    # with cookie file being available.
+    session-tool -u test systemctl --user start pulseaudio.service
+
+    # Ensure, that the cookie file is present.
+    test -e ~test/.config/pulse/cookie || test -e ~test/.config/pulse/.pulse-cookie
+    echo "rm -rf ~test/.config/pulse" >>defer.sh
+
 restore: |
     # Restore system to the previous state by running deferred commands in
     # reverse order.

--- a/tests/main/session-tool-support/task.yaml
+++ b/tests/main/session-tool-support/task.yaml
@@ -1,38 +1,50 @@
 summary: check the session support status of various distributions
-environment:
-    USER/root: root
-    USER/test: test
 execute: |
     case "$SPREAD_SYSTEM/$USER" in
-        amazon-linux-2-*/test|centos-7-*/test)
+        amazon-linux-2-*|centos-7-*)
+            session-tool --has-system-systemd-and-dbus | MATCH 'ok'
+            session-tool --has-system-systemd-and-dbus
             # Amazon Linux 2 which is based on CentOS 7 both disable user
             # session features of systemd as, at the time, this was a feature
             # that was not certain to stay in systemd, and RedHat did not want
             # to commit to supporting it.
-            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no user dbus.socket'
-            not session-tool -u "$USER" --has-systemd-and-dbus
+            session-tool --has-session-systemd-and-dbus | MATCH 'no user dbus.socket'
+            not session-tool --has-session-systemd-and-dbus
             ;;
         ubuntu-14.04-*)
             # Ubuntu 14.04 does not use systemd. 
-            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no busctl'
-            not session-tool -u "$USER" --has-systemd-and-dbus
+            session-tool --has-system-systemd-and-dbus | MATCH 'no busctl'
+            not session-tool --has-system-systemd-and-dbus
+            session-tool --has-session-systemd-and-dbus | MATCH 'no busctl'
+            not session-tool --has-session-systemd-and-dbus
             ;;
-        ubuntu-16.04-*/test)
-            # Ubuntu 16.04 does not use systemd for user sessions.
-            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no user dbus.socket'
-            not session-tool -u "$USER" --has-systemd-and-dbus
+        ubuntu-16.04-*)
+            session-tool --has-system-systemd-and-dbus | MATCH 'ok'
+            session-tool --has-system-systemd-and-dbus
+            # Ubuntu 16.04 does not use systemd for user sessions, and does not
+            # ship the package providing dbus.socket in systemd --user by
+            # default.
+            #
+            # NOTE: For some tests we manually install/remove the missing
+            # package to expand test coverage.
+            session-tool --has-session-systemd-and-dbus | MATCH 'no user dbus.socket'
+            not session-tool --has-session-systemd-and-dbus
             ;;
-        ubuntu-core-1[68]-*/test)
+        ubuntu-core-1[68]-*)
+            session-tool --has-system-systemd-and-dbus | MATCH 'ok'
+            session-tool --has-system-systemd-and-dbus
             # Ubuntu Core 16 and Ubuntu Core 18 did not support user sessions.
             # Note that Ubuntu Core 20 is in the default case down below, and
             # does support this feature.
-            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'no user dbus.socket'
-            not session-tool -u "$USER" --has-systemd-and-dbus
+            session-tool --has-session-systemd-and-dbus | MATCH 'no user dbus.socket'
+            not session-tool --has-session-systemd-and-dbus
             ;;
         *)
-            # The list above contains just the exceptions. By default
-            # everything should work.
-            session-tool -u "$USER" --has-systemd-and-dbus | MATCH 'ok'
-            session-tool -u "$USER" --has-systemd-and-dbus
+            # The list above contains just the exceptions.
+            # By default everything should work.
+            session-tool --has-system-systemd-and-dbus | MATCH 'ok'
+            session-tool --has-system-systemd-and-dbus
+            session-tool --has-session-systemd-and-dbus | MATCH 'ok'
+            session-tool --has-session-systemd-and-dbus
             ;;
     esac

--- a/tests/main/snap-session-agent-service-control/task.yaml
+++ b/tests/main/snap-session-agent-service-control/task.yaml
@@ -26,10 +26,6 @@ prepare: |
     fi
 
     session-tool -u test --prepare
-    # Wait for sockets.target to finish starting so the session agent
-    # socket is available.
-    # XXX: I strongly believe this is not required anymore.
-    session-tool -u test systemctl --user start sockets.target
 
 restore: |
     session-tool -u test --restore

--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -26,9 +26,6 @@ prepare: |
     fi
 
     session-tool -u test --prepare
-    # Wait for sockets.target to finish starting so the session agent
-    # socket is available.
-    session-tool -u test systemctl --user start sockets.target
 
 restore: |
     session-tool -u test --restore

--- a/tests/main/snap-session-agent-unavailable-to-snaps/task.yaml
+++ b/tests/main/snap-session-agent-unavailable-to-snaps/task.yaml
@@ -21,9 +21,6 @@ prepare: |
     snap install --edge test-snapd-curl
 
     session-tool -u test --prepare
-    # Wait for sockets.target to finish starting so the session agent
-    # socket is available.
-    session-tool -u test systemctl --user start sockets.target
 
 restore: |
     session-tool -u test --restore

--- a/tests/main/user-session-env/task.yaml
+++ b/tests/main/user-session-env/task.yaml
@@ -29,7 +29,7 @@ execute: |
 
     for user in test "$TEST_ZSH_USER"; do
         # Dump the environment set up by the user session manager
-        if session-tool -u "$user" --has-systemd-and-dbus; then
+        if session-tool --has-session-systemd-and-dbus; then
             session-tool -u "$user" systemctl --user show-environment > "${user}-session-env"
         fi
         session-tool -u "$user" env > "${user}-profile-env"


### PR DESCRIPTION
The test code contained "pulseaudio --check" which looks for the
pulseaudio PID in /run/user/$UID/pulse/pid and then checks if that
process is alive.

This only worked because we ran "session-tool -u test --prepare"
immediately before, and pulse has just started (asynchronously),
so it was still running while we looked.

For reasons I did not investigate, in our test session, pulse stops as
soon as it is idle, which is immediately after we start the session.
Subsequent use of paplay and other test executables cause socket
activation, so in actual testing pulse *is* working.

This fixes random failures related to those two tests.

There are more things fixed in this test but the description
does not fit in this textarea, please read commit messages.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
