### PR TITLE
progress: fix progress bar with multibyte duration units

### DIFF
--- a/progress/ansimeter_test.go
+++ b/progress/ansimeter_test.go
@@ -108,7 +108,7 @@ func (ansiSuite) TestSetLayout(c *check.C) {
 	msg := "0123456789"
 	ticker := time.NewTicker(time.Millisecond)
 	defer ticker.Stop()
-	p.Start(msg, 1E300)
+	p.Start(msg, 1e300)
 	for i := 1; i <= 80; i++ {
 		desc := check.Commentf("width %d", i)
 		width = i
@@ -129,6 +129,31 @@ func (ansiSuite) TestSetLayout(c *check.C) {
 		default:
 			c.Check(out, check.Matches, fmt.Sprintf("\r%*s   0%%  [ 0-9]{4}B/s ages!", -(i-20), msg), desc)
 		}
+	}
+}
+
+func (ansiSuite) TestSetLayoutMultibyte(c *check.C) {
+	var buf bytes.Buffer
+	var duration string
+	var msg = "0123456789"
+	defer progress.MockStdout(&buf)()
+	defer progress.MockEmptyEscapes()()
+	defer progress.MockTermWidth(func() int { return 80 })()
+	defer progress.MockFormatDuration(func(_ float64) string {
+		return duration
+	})()
+
+	for _, dstr := range []string{"м", "語"} {
+		duration = dstr
+		buf.Reset()
+
+		p := &progress.ANSIMeter{}
+		p.Start(msg, 1e300)
+		p.Set(0.99 * 1e300)
+		out := buf.String()
+		c.Check([]rune(out), check.HasLen, 80+1, check.Commentf("unexpected length: %v", len(out)))
+		c.Check(out, check.Matches,
+			fmt.Sprintf("\r0123456789 \\s+  99%% 9\\.22EB/s %s", dstr))
 	}
 }
 
@@ -198,7 +223,7 @@ func (ansiSuite) TestNotify(c *check.C) {
 	defer progress.MockTermWidth(func() int { return width })()
 
 	p := &progress.ANSIMeter{}
-	p.Start("working", 1E300)
+	p.Start("working", 1e300)
 
 	width = 10
 	p.Set(0)

--- a/progress/export_test.go
+++ b/progress/export_test.go
@@ -96,6 +96,14 @@ func MockStdout(w io.Writer) func() {
 	}
 }
 
+func MockFormatDuration(m func(f float64) string) (restore func()) {
+	old := formatDuration
+	formatDuration = m
+	return func() {
+		formatDuration = old
+	}
+}
+
 var (
 	Norm    = norm
 	Spinner = spinner


### PR DESCRIPTION
Some languages may use multibyte characters for duration. In such case, the
width of the progress bar would be incorrectly calculated, making the displayed
label too short.

At runtime this would randomly cause a panic with the translation used a
multibyte characters:
```
panic: runtime error: slice bounds out of range [80:79] [recovered]
 panic: runtime error: slice bounds out of range [80:79]

goroutine 1 [running]:
main.main.func1()
 github.com/snapcore/snapd/cmd/snap/main.go:477 +0x95
panic(0x561d5f7fac80, 0xc000144280)
 runtime/panic.go:679 +0x1b6
github.com/snapcore/snapd/progress.(*ANSIMeter).Set(0xc000214eb0, 0x41a891a000000000)
 github.com/snapcore/snapd/progress/ansimeter.go:152 +0xa1b
main.waitMixin.wait(0xc0002e42a0, 0x561d5f3e0000, 0xc0001e4488, 0x2, 0x0, 0x0, 0x0)
 github.com/snapcore/snapd/cmd/snap/wait.go:130 +0x700
main.(*cmdInstall).installOne(0xc000359040, 0x7ffcf44c33e4, 0xb, 0x0, 0x0, 0xc00036cba0, 0x561d5f805060, 0x561d5f8693a0)
 github.com/snapcore/snapd/cmd/snap/cmd_snap_op.go:491 +0x316
main.(*cmdInstall).Execute(0xc000359040, 0xc0003787a0, 0x0, 0x2, 0xc000359040, 0x1)
 github.com/snapcore/snapd/cmd/snap/cmd_snap_op.go:596 +0x3d7
github.com/snapcore/snapd/vendor/github.com/jessevdk/go-flags.(*Parser).ParseArgs(0xc000316bd0, 0xc000032190, 0x2, 0x2, 0xc000330330, 0xc0002a5cd0, 0x561d5ee49fbd, 0x561d5f7d08a0, 0xc000330330)
 github.com/snapcore/snapd/vendor/github.com/jessevdk/go-flags/parser.go:333 +0x8e7
github.com/snapcore/snapd/vendor/github.com/jessevdk/go-flags.(*Parser).Parse(...)
 github.com/snapcore/snapd/vendor/github.com/jessevdk/go-flags/parser.go:190
main.run(0xc0002a5de0, 0xe)
 github.com/snapcore/snapd/cmd/snap/main.go:515 +0xa7
main.main()
 github.com/snapcore/snapd/cmd/snap/main.go:482 +0x371
```

Since we are assuming that terminal can display up to the column number of
runes, fix the length calculation to use slices of runes for all
components (keep in mind that len(string) >= len([]rune)).

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1876583