### PR TITLE
 Adds missing paths to desktop, solves lp:1876804

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -74,6 +74,18 @@ owner @{HOME}/.config/gtk-3.0/bookmarks r,
 /usr/share/thumbnailer/icons/**            r,
 /usr/share/themes/**                       r,
 
+# Allows read from hostfs.
+/var/lib/snapd/hostfs/usr/share/pixmaps/   r,
+/var/lib/snapd/hostfs/usr/share/pixmaps/** r,
+/var/lib/snapd/hostfs/usr/share/icons/**   r,
+/var/lib/snapd/hostfs/usr/share/fonts/     r,
+/var/lib/snapd/hostfs/usr/share/fonts/**   r,
+/var/lib/snapd/hostfs/usr/share/mime/      r,
+/var/lib/snapd/hostfs/usr/share/mime/**    r,
+/var/lib/snapd/hostfs/usr/share/gdm/       r,
+/var/lib/snapd/hostfs/usr/share/gdm/**     r,
+/var/lib/snapd/hostfs/usr/share/icons/*/index.theme rk,
+
 # The snapcraft desktop part may look for schema files in various locations, so
 # allow reading system installed schemas.
 /usr/share/glib*/schemas/{,*}              r,
@@ -86,6 +98,9 @@ owner @{HOME}/.config/user-dirs.* r,
 
 /etc/xdg/user-dirs.conf r,
 /etc/xdg/user-dirs.defaults r,
+
+# Desktop applications
+/etc/gnome/defaults.list r,
 
 # gmenu
 dbus (send)


### PR DESCRIPTION
Solves.

> The second line definitely belongs in another interface, perhaps the desktop interface?

From #8601

https://bugs.launchpad.net/snapd/+bug/1876804

When I launch the Ubuntu snap store from my favorites, the following lines appear in dmesg.

[38514.879381] audit: type=1400 audit(1588562964.269:5985): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/mime.cache" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879402] audit: type=1400 audit(1588562964.269:5986): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/globs2" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879426] audit: type=1400 audit(1588562964.269:5987): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/magic" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879443] audit: type=1400 audit(1588562964.269:5988): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/aliases" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879459] audit: type=1400 audit(1588562964.269:5989): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/subclasses" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879474] audit: type=1400 audit(1588562964.269:5990): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/icons" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.879488] audit: type=1400 audit(1588562964.269:5991): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/generic-icons" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.880255] audit: type=1400 audit(1588562964.269:5992): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/etc/gnome/defaults.list" pid=17441 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.961031] audit: type=1400 audit(1588562964.349:5993): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/mime.cache" pid=2467 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
[38514.961038] audit: type=1400 audit(1588562964.349:5994): apparmor="DENIED" operation="open" profile="snap.snap-store.ubuntu-software" name="/var/lib/snapd/hostfs/usr/share/mime/globs2" pid=2467 comm="snap-store" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0

Adding these lines:

/var/lib/snapd/hostfs/usr/share/mime/* r,
/etc/gnome/defaults.list r,

to /var/lib/snapd/apparmor/profiles/snap.snap-store.ubuntu-software

made the messages go away.

Further notes. https://ubuntuforums.org/showthread.php?t=2442426
