### PR TITLE
tests: not fail when boot dir cannot be determined

### DIFF
--- a/tests/lib/boot.sh
+++ b/tests/lib/boot.sh
@@ -42,7 +42,7 @@ bootenv_unset() {
 }
 
 get_boot_path() {
-    if [ -f /boot/uboot/uboot.env -o -f /boot/uboot/uboot.sel ]; then
+    if [ -f /boot/uboot/uboot.env ] || [ -f /boot/uboot/uboot.sel ]; then
         # uc16/uc18 have /boot/uboot/uboot.env
         # uc20 has /boot/uboot/uboot.sel
         echo "/boot/uboot/"

--- a/tests/lib/boot.sh
+++ b/tests/lib/boot.sh
@@ -47,9 +47,7 @@ get_boot_path() {
     elif [ -f /boot/grub/grubenv ]; then
         echo "/boot/grub/"
     else
-        echo "Cannot determine boot path"
-        ls -alR /boot
-        exit 1
+        echo "/boot/"
     fi
 }
 

--- a/tests/lib/boot.sh
+++ b/tests/lib/boot.sh
@@ -42,12 +42,16 @@ bootenv_unset() {
 }
 
 get_boot_path() {
-    if [ -f /boot/uboot/uboot.env ]; then
+    if [ -f /boot/uboot/uboot.env -o -f /boot/uboot/uboot.sel ]; then
+        # uc16/uc18 have /boot/uboot/uboot.env
+        # uc20 has /boot/uboot/uboot.sel
         echo "/boot/uboot/"
     elif [ -f /boot/grub/grubenv ]; then
         echo "/boot/grub/"
     else
-        echo "/boot/"
+        echo "Cannot determine boot path"
+        ls -alR /boot
+        exit 1
     fi
 }
 


### PR DESCRIPTION
This is to support scenarios like uc20 on pi3 where uboot and grub are
not used.

Tests passing in jenkins with this change: https://paste.ubuntu.com/p/Kzr4XgThdv/ 