### PR TITLE
tests: don't create root-owned things in ~test

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -302,7 +302,9 @@ cat "$tmp_dir/ready.pipe" >/dev/null
 # and redirects to capture output. Sadly busctl doesn't support passing file
 # descriptors https://github.com/systemd/systemd/issues/14954 As a workaround
 # we pass a set of pipes. This is good for non-interactive work.
-cat >"$tmp_dir/stdin.pipe" &
+# NOTE: /dev/stdin is provided explicitly to trigger special behavior in bash,
+# as otherwise background tasks are started with /dev/null for stdin.
+cat </dev/stdin >"$tmp_dir/stdin.pipe" &
 cat_stdin_pid=$!
 cat <"$tmp_dir/stdout.pipe" >&1 &
 cat_stdout_pid=$!

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -22,16 +22,17 @@ prepare: |
     setup_portals
 
     # Configure fake web browser
-    mkdir -p ~test/.local/share/applications
-    cat << EOF > ~test/.local/share/applications/test-editor.desktop
+    session-tool -u test mkdir -p ~test/.local/share/applications
+    session-tool -u test sh -c 'cat > ~test/.local/share/applications/test-editor.desktop' << EOF
     [Desktop Entry]
     Type=Application
     Name=Test Editor
     Exec=$(pwd)/editor.sh %f $EDITOR_HISTORY
     MimeType=text/plain;
     EOF
-    mkdir -p ~test/.config
-    cat << EOF > ~test/.config/mimeapps.list
+
+    session-tool -u test mkdir -p ~test/.config
+    session-tool -u test sh -c 'cat > ~test/.config/mimeapps.list' << EOF
     [Default Applications]
     text/plain=test-editor.desktop
     EOF

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -19,16 +19,17 @@ prepare: |
     setup_portals
 
     # Configure fake web browser
-    mkdir -p ~test/.local/share/applications
-    cat << EOF > ~test/.local/share/applications/test-browser.desktop
+    session-tool -u test mkdir -p ~test/.local/share/applications
+    session-tool -u test sh -c 'cat > ~test/.local/share/applications/test-browser.desktop' << EOF
     [Desktop Entry]
     Type=Application
     Name=Test Web Browser
     Exec=$(pwd)/web-browser.sh %u $BROWSER_HISTORY
     MimeType=x-scheme-handler/http;
     EOF
-    mkdir -p ~test/.config
-    cat << EOF > ~test/.config/mimeapps.list
+
+    session-tool -u test mkdir -p ~test/.config
+    session-tool -u test sh -c 'cat  > ~test/.config/mimeapps.list' << EOF
     [Default Applications]
     x-scheme-handler/http=test-browser.desktop
     EOF

--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -34,6 +34,9 @@ prepare: |
     # Prepare for using sessions as the given user
     session-tool --prepare -u "$USER"
 execute: |
+    # Check that stdin is forwarded correctly.
+    echo "it-works" | session-tool -u "$USER" cat | MATCH "it-works"
+
     for n in $(seq 300); do
         echo "ITERATION $(date) $n"
         session-tool -u "$USER" id -u  2>/tmp/session-tool.log | MATCH "$(id -u "$USER")"

--- a/tests/main/xdg-open-portal/task.yaml
+++ b/tests/main/xdg-open-portal/task.yaml
@@ -33,8 +33,8 @@ prepare: |
     install_local test-snapd-desktop
 
     # Configure fake web browser
-    mkdir -p ~test/.local/share/applications
-    cat << EOF > ~test/.local/share/applications/test-browser.desktop
+    session-tool -u test mkdir -p ~test/.local/share/applications
+    session-tool -u test sh -c 'cat > ~test/.local/share/applications/test-browser.desktop' << EOF
     [Desktop Entry]
     Type=Application
     Name=Test Web Browser
@@ -43,7 +43,7 @@ prepare: |
     EOF
 
     # Configure a fake editor
-    cat << EOF > ~test/.local/share/applications/test-editor.desktop
+    session-tool -u test sh -c 'cat > ~test/.local/share/applications/test-editor.desktop' << EOF
     [Desktop Entry]
     Type=Application
     Name=Test Editor
@@ -52,19 +52,18 @@ prepare: |
     EOF
 
     # Set up file type handlers
-    mkdir -p ~test/.config
-    cat << EOF > ~test/.config/mimeapps.list
+    session-tool -u test mkdir -p ~test/.config
+    session-tool -u test sh -c 'cat > ~test/.config/mimeapps.list' << EOF
     [Default Applications]
     x-scheme-handler/http=test-browser.desktop
     text/plain=test-editor.desktop
     EOF
 
     # Prepare test data for editor
-    commondir=~test/snap/test-snapd-desktop/common
-    testfile="$commondir/test.txt"
-    mkdir -p "$commondir"
-    echo "Hello World" > "$testfile"
-    chown -R test:test ~test/snap
+    session-tool -u test mkdir -p ~test/snap/test-snapd-desktop/common
+    session-tool -u test sh -c 'cat > ~test/snap/test-snapd-desktop/common/test.txt' << EOF
+    Hello World
+    EOF
 
 restore: |
     session-tool -u test --restore


### PR DESCRIPTION
This branch contains three patches for the tests that create root-owned
files in the ~test home directory. This is the immediate cause of the
random failures of the pulseaudio tests.

I chose to just use sesssion-tool to perform those operations as this
handles both the ownership and the SELinux context of the files.
