### PR TITLE
github: register the problem matcher in a separate step to running spread

### DIFF
--- a/.github/workflows/test-go-latest.yaml
+++ b/.github/workflows/test-go-latest.yaml
@@ -91,13 +91,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Register problem matcher
+      run: echo "::add-matcher::.github/spread-problem-matcher.json"
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
           spread -abend google-unstable:${{ matrix.system }}:tests/...
     - name: Discard spread workers
       if: always()

--- a/.github/workflows/test-go1.10.yaml
+++ b/.github/workflows/test-go1.10.yaml
@@ -98,13 +98,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Register problem matcher
+      run: echo "::add-matcher::.github/spread-problem-matcher.json"
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
           spread google:${{ matrix.system }}:tests/...
     - name: Discard spread workers
       if: always()

--- a/.github/workflows/test-go1.13.yaml
+++ b/.github/workflows/test-go1.13.yaml
@@ -99,13 +99,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Register problem matcher
+      run: echo "::add-matcher::.github/spread-problem-matcher.json"
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
           spread google:${{ matrix.system }}:tests/...
     - name: Discard spread workers
       if: always()

--- a/.github/workflows/test-go1.9.yaml
+++ b/.github/workflows/test-go1.9.yaml
@@ -88,13 +88,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Register problem matcher
+      run: echo "::add-matcher::.github/spread-problem-matcher.json"
     - name: Run spread tests
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
           spread -abend google:${{ matrix.system }}:tests/...
     - name: Discard spread workers
       if: always()


### PR DESCRIPTION
With the reorganisation of the CI jobs, Github stopped providing a summary of the failures in the web UI.  It would still mention counts in the emails at the end, which indicates that the problem matcher was active though.

The main change I can see is that previously the problem matcher was registered in an earlier step prior to running Spread, while now it is part of the same step.  This PR splits the problem matcher registration out into an independent step to see if that gets the old behaviour (assuming I actually manage to hit a failure).