### PR TITLE
 progress: tweak multibyte label unit test data 

### DIFF
--- a/progress/ansimeter_test.go
+++ b/progress/ansimeter_test.go
@@ -150,7 +150,7 @@ func (ansiSuite) TestSetLayoutMultibyte(c *check.C) {
 		out := buf.String()
 		c.Check([]rune(out), check.HasLen, 80+1, check.Commentf("unexpected length: %v", len(out)))
 		c.Check(out, check.Matches,
-			fmt.Sprintf("\r0123456789 \\s+  99%% [0-9]+(\\.[0-9]+)?[kMGTPEZY]?B/s %s", dstr))
+			fmt.Sprintf("\r0123456789 \\s+  99%% +[0-9]+(\\.[0-9]+)?[kMGTPEZY]?B/s %s", dstr))
 	}
 }
 

--- a/progress/ansimeter_test.go
+++ b/progress/ansimeter_test.go
@@ -22,7 +22,6 @@ package progress_test
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -31,9 +30,7 @@ import (
 	"github.com/snapcore/snapd/progress"
 )
 
-type ansiSuite struct {
-	stdout *os.File
-}
+type ansiSuite struct{}
 
 var _ = check.Suite(ansiSuite{})
 

--- a/progress/ansimeter_test.go
+++ b/progress/ansimeter_test.go
@@ -153,7 +153,7 @@ func (ansiSuite) TestSetLayoutMultibyte(c *check.C) {
 		out := buf.String()
 		c.Check([]rune(out), check.HasLen, 80+1, check.Commentf("unexpected length: %v", len(out)))
 		c.Check(out, check.Matches,
-			fmt.Sprintf("\r0123456789 \\s+  99%% 9\\.22EB/s %s", dstr))
+			fmt.Sprintf("\r0123456789 \\s+  99%% [0-9]+(\\.[0-9]+)?[kMGTPEZY]?B/s %s", dstr))
 	}
 }
 


### PR DESCRIPTION
Since the progress bar calculates speed based on actual time, any
flakyness/delay in test execution may influence the reported value. Account for
that in the regex.
