### PR TITLE
gadget: fix fallback device lookup for 'mbr' type structures

### DIFF
--- a/gadget/device_linux.go
+++ b/gadget/device_linux.go
@@ -126,7 +126,7 @@ func FindDeviceForStructureWithFallback(ps *LaidOutStructure) (dev string, offs 
 		// error out on other errors
 		return "", 0, err
 	}
-	if err == ErrDeviceNotFound && ps.Type != "bare" && ps.Name != "" {
+	if err == ErrDeviceNotFound && ps.IsPartition() && ps.Name != "" {
 		// structures with partition table entry and a name must have
 		// been located already
 		return "", 0, err

--- a/gadget/device_test.go
+++ b/gadget/device_test.go
@@ -354,16 +354,27 @@ func (d *deviceSuite) TestDeviceFindFallbackHappyWritable(c *C) {
 		},
 		StartOffset: 123,
 	}
+	psMBR := &gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Type: "mbr",
+			Name: "mbr",
+		},
+		StartOffset: 0,
+	}
 	psNoName := &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{},
 		StartOffset:     123,
 	}
 
-	for _, ps := range []*gadget.LaidOutStructure{psJustBare, psBareWithName, psNoName} {
+	for _, ps := range []*gadget.LaidOutStructure{psJustBare, psBareWithName, psNoName, psMBR} {
 		found, offs, err := gadget.FindDeviceForStructureWithFallback(ps)
 		c.Check(err, IsNil)
 		c.Check(found, Equals, filepath.Join(d.dir, "/dev/fakedevice0"))
-		c.Check(offs, Equals, gadget.Size(123))
+		if ps.Type != "mbr" {
+			c.Check(offs, Equals, gadget.Size(123))
+		} else {
+			c.Check(offs, Equals, gadget.Size(0))
+		}
 	}
 }
 


### PR DESCRIPTION
A structure without a partition can explicitly specify its type as 'bare', or
use the legacy type 'mbr' (with some limitations). Fix the fallback
structure-to-device lookup for 'mbr' type structures.


