### PR TITLE
o/devicestate,cmd/snap-bootstrap: seal to recover mode cmdline

### DIFF
--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -223,7 +223,7 @@ func tpmSealKey(key partition.EncryptionKey, rkey partition.RecoveryKey, options
 		// run mode
 		"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
 		// recover mode
-		fmt.Sprintf("snapd_recovery_mode=run snapd_recovery_system=%s console=ttyS0 console=tty1 panic=-1", options.SystemLabel),
+		fmt.Sprintf("snapd_recovery_mode=recover snapd_recovery_system=%s console=ttyS0 console=tty1 panic=-1", options.SystemLabel),
 	}
 
 	tpm.SetKernelCmdlines(kernelCmdlines)

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -155,12 +155,6 @@ func Run(gadgetRoot, device string, options Options) error {
 	return nil
 }
 
-// TODO:UC20: get cmdline definition from bootloaders
-var kernelCmdlines = []string{
-	// run mode
-	"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
-}
-
 func tpmSealKey(key partition.EncryptionKey, rkey partition.RecoveryKey, options Options) error {
 	if err := rkey.Store(options.RecoveryKeyFile); err != nil {
 		return fmt.Errorf("cannot store recovery key: %v", err)
@@ -223,6 +217,15 @@ func tpmSealKey(key partition.EncryptionKey, rkey partition.RecoveryKey, options
 			return err
 		}
 	}
+
+	// TODO:UC20: get cmdline definition from bootloaders
+	kernelCmdlines := []string{
+		// run mode
+		"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+		// recover mode
+		fmt.Sprintf("snapd_recovery_mode=run snapd_recovery_system=%s console=ttyS0 console=tty1 panic=-1", options.SystemLabel),
+	}
+
 	tpm.SetKernelCmdlines(kernelCmdlines)
 
 	if options.Model != nil {

--- a/cmd/snap-bootstrap/bootstrap/options.go
+++ b/cmd/snap-bootstrap/bootstrap/options.go
@@ -40,4 +40,6 @@ type Options struct {
 	KernelPath string
 	// Model is the device model to seal the keyfile to
 	Model *asserts.Model
+	// SystemLabel is the recover system label to seal the keyfile to
+	SystemLabel string
 }

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -178,8 +178,14 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 		return err
 	}
 	if !isRecoverDataMounted {
-		// TODO:UC20: data may need to be unlocked
-		fmt.Fprintf(stdout, "/dev/disk/by-label/ubuntu-data %s\n", boot.InitramfsHostUbuntuDataDir)
+		// TODO: do we do this in recover mode too ?
+		const lockKeysForLast = true
+		device, err := unlockIfEncrypted("ubuntu-data", lockKeysForLast)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(stdout, "%s %s\n", device, boot.InitramfsHostUbuntuDataDir)
 		return nil
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -178,7 +178,6 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 		return err
 	}
 	if !isRecoverDataMounted {
-		// TODO: do we do this in recover mode too ?
 		const lockKeysForLast = true
 		device, err := unlockIfEncrypted("ubuntu-data", lockKeysForLast)
 		if err != nil {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1395,6 +1395,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep3Encrypted(c *C
 	c.Check(measuredModel, DeepEquals, s.model)
 
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "secboot-epoch-measured"), testutil.FilePresent)
+	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, fmt.Sprintf("%s-model-measured", s.sysLabel)), testutil.FilePresent)
 }
 
 var mockStateContent = `{"data":{"auth":{"users":[{"name":"mvo"}]}},"some":{"other":"stuff"}}`

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -188,8 +188,10 @@ type (
 func (m mounted) size() int                                            { return len(m) }
 func (m mounted) dirAndIsMounted(callNum int) (dir string, state bool) { return m[callNum], true }
 
-func (n notYetMounted) size() int                                            { return len(n) }
-func (n notYetMounted) dirAndIsMounted(callNum int) (dir string, state bool) { return n[callNum], false }
+func (n notYetMounted) size() int { return len(n) }
+func (n notYetMounted) dirAndIsMounted(callNum int) (dir string, state bool) {
+	return n[callNum], false
+}
 
 func (s *initramfsMountsSuite) mockExpectedMountChecks(c *C, expectedDirs ...expectedMountDirs) *int {
 	var n int // call counter
@@ -1309,6 +1311,90 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep3(c *C) {
 	c.Assert(*n, Equals, 6)
 	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`/dev/disk/by-label/ubuntu-data %s/host/ubuntu-data
 `, boot.InitramfsRunMntDir))
+}
+
+func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep3Encrypted(c *C) {
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=recover snapd_recovery_system="+s.sysLabel)
+
+	// setup ubuntu-data-enc
+	devDiskByLabel, restore := mockDevDiskByLabel(c)
+	defer restore()
+
+	ubuntuDataEnc := filepath.Join(devDiskByLabel, "ubuntu-data-enc")
+	err := ioutil.WriteFile(ubuntuDataEnc, nil, 0644)
+	c.Assert(err, IsNil)
+
+	// setup a fake tpm
+	mockTPM, restore := mockSecbootTPM(c)
+	defer restore()
+
+	activated := false
+	// setup activating the fake tpm
+	restore = main.MockSecbootActivateVolumeWithTPMSealedKey(func(tpm *secboot.TPMConnection, volumeName, sourceDevicePath,
+		keyPath string, pinReader io.Reader, options *secboot.ActivateWithTPMSealedKeyOptions) (bool, error) {
+		c.Assert(tpm, Equals, mockTPM)
+		c.Assert(volumeName, Equals, "ubuntu-data")
+		c.Assert(sourceDevicePath, Equals, ubuntuDataEnc)
+		// the keyfile will be on ubuntu-seed as ubuntu-data.sealed-key
+		c.Assert(keyPath, Equals, filepath.Join(boot.InitramfsUbuntuSeedDir, "device/fde", "ubuntu-data.sealed-key"))
+		c.Assert(*options, DeepEquals, secboot.ActivateWithTPMSealedKeyOptions{
+			PINTries:            1,
+			RecoveryKeyTries:    3,
+			LockSealedKeyAccess: true,
+		})
+		activated = true
+		return true, nil
+	})
+	defer restore()
+
+	n := s.mockExpectedMountChecks(c,
+		mounted{
+			boot.InitramfsUbuntuSeedDir,
+			filepath.Join(boot.InitramfsRunMntDir, "base"),
+			filepath.Join(boot.InitramfsRunMntDir, "kernel"),
+			filepath.Join(boot.InitramfsRunMntDir, "snapd"),
+			filepath.Join(boot.InitramfsRunMntDir, "data"),
+		},
+		notYetMounted{filepath.Join(boot.InitramfsRunMntDir, "host/ubuntu-data")},
+	)
+
+	sealedKeysLocked := false
+	restore = main.MockSecbootLockAccessToSealedKeys(func(tpm *secboot.TPMConnection) error {
+		sealedKeysLocked = true
+		return nil
+	})
+	defer restore()
+
+	epochPCR := -1
+	modelPCR := -1
+	restore = main.MockSecbootMeasureSnapSystemEpochToTPM(func(tpm *secboot.TPMConnection, pcrIndex int) error {
+		epochPCR = pcrIndex
+		return nil
+	})
+	defer restore()
+
+	var measuredModel *asserts.Model
+	restore = main.MockSecbootMeasureSnapModelToTPM(func(tpm *secboot.TPMConnection, pcrIndex int, model *asserts.Model) error {
+		modelPCR = pcrIndex
+		measuredModel = model
+		return nil
+	})
+	defer restore()
+
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+	c.Assert(err, IsNil)
+	c.Assert(*n, Equals, 6)
+	c.Check(s.Stdout.String(), Equals, fmt.Sprintf(`%[1]s/ubuntu-data %[2]s/host/ubuntu-data
+`, devDiskByLabel, boot.InitramfsRunMntDir))
+
+	c.Check(activated, Equals, true)
+	c.Check(sealedKeysLocked, Equals, true)
+	c.Check(epochPCR, Equals, 12)
+	c.Check(modelPCR, Equals, 12)
+	c.Check(measuredModel, NotNil)
+	c.Check(measuredModel, DeepEquals, s.model)
+
+	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "secboot-epoch-measured"), testutil.FilePresent)
 }
 
 var mockStateContent = `{"data":{"auth":{"users":[{"name":"mvo"}]}},"some":{"other":"stuff"}}`

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -264,6 +264,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 			PolicyUpdateDataFile: filepath.Join(boot.InstallHostWritableDir, "var/lib/snapd/device/fde/policy-update-data"),
 			KernelPath:           filepath.Join(dirs.SnapMountDir, "pc-kernel/1/kernel.efi"),
 			Model:                mockModel,
+			SystemLabel:          "20191218",
 		})
 
 		// directories were ensured
@@ -291,6 +292,9 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 		return fmt.Errorf("The horror, The horror")
 	})
 	defer restore()
+
+	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"), nil, 0644)
+	c.Assert(err, IsNil)
 
 	s.state.Lock()
 	s.makeMockInstalledPcGadget(c, "dangerous")


### PR DESCRIPTION
Also seal the encryption key to the recover mode kernel command line. This is an interim implementation: kernel command lines should be retrieved from bootloaders, and the mechanism to set command lines will be refactored when moving TPM support to snapd/secboot.
