### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: add sudoers to dirs to copy as well

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -119,6 +119,9 @@ func copyUbuntuDataAuth(src, dst string) error {
 		"user-data/*/.ssh/*",
 		// this ensures we also get non-ssh enabled accounts copied
 		"user-data/*/.profile",
+		// so that users have proper perms, i.e. console-conf added users are
+		// sudoers
+		"system-data/etc/sudoers.d/*",
 	} {
 		matches, err := filepath.Glob(filepath.Join(src, globEx))
 		if err != nil {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1433,6 +1433,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 		// user ssh
 		"user-data/user1/.ssh/authorized_keys",
 		"user-data/user2/.ssh/authorized_keys",
+		// sudoers
+		"system-data/etc/sudoers.d/create-user-test",
 	}
 	mockUnrelatedFiles := []string{
 		"system-data/var/lib/foo",


### PR DESCRIPTION
This means that when users are created via i.e. console-conf, they can 
actually login to recover mode and do something, without this the users
just login and can't do anything because they are not sudoers, and there
also is not a root login for them to use instead.

Signed-off-by: Ian Johnson <ian.johnson@canonical.com>
