### PR TITLE
cmd/snap: fix the order of positional parameters in help output

### DIFF
--- a/cmd/snap/cmd_snapshot.go
+++ b/cmd/snap/cmd_snapshot.go
@@ -338,13 +338,13 @@ func init() {
 			"users": i18n.G("Restore data of only specific users (comma-separated) (default: all users)"),
 		}), []argDesc{
 			{
-				name: "<snap>",
-				// TRANSLATORS: This should not start with a lowercase letter.
-				desc: i18n.G("The snap for which data will be restored"),
-			}, {
 				name: "<id>",
 				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("Set id of snapshot to restore (see 'snap help saved')"),
+			}, {
+				name: "<snap>",
+				// TRANSLATORS: This should not start with a lowercase letter.
+				desc: i18n.G("The snap for which data will be restored"),
 			},
 		})
 


### PR DESCRIPTION
The order of parameters expected in the code for restore (and other snapshot
related commands) is <id> <snap>. However, the order of id/snap was reversed in
`snap restore --help` output. Originally reported in the forum [1].

1. https://forum.snapcraft.io/t/17291
