### PR TITLE
wrappers: tweak the  order of restoring, use client timeout in services test teardown

### DIFF
--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -20,7 +20,6 @@
 package wrappers_test
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -43,7 +42,6 @@ import (
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 	"github.com/snapcore/snapd/usersession/agent"
-	"github.com/snapcore/snapd/usersession/client"
 	"github.com/snapcore/snapd/wrappers"
 )
 
@@ -83,16 +81,7 @@ func (s *servicesTestSuite) SetUpTest(c *C) {
 
 func (s *servicesTestSuite) TearDownTest(c *C) {
 	if s.agent != nil {
-		// Try sending a message to the session agent before
-		// shutting it down to see if that helps with the hang
-		// in gracefully shutting down the agent.
-		cli := client.New()
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_, err := cli.SessionInfo(ctx)
-		c.Check(err, IsNil)
-
-		err = s.agent.Stop()
+		err := s.agent.Stop()
 		c.Check(err, IsNil)
 	}
 	s.delaysRestorer()

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -82,20 +82,22 @@ func (s *servicesTestSuite) SetUpTest(c *C) {
 }
 
 func (s *servicesTestSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("")
-	s.systemctlRestorer()
-	s.delaysRestorer()
 	if s.agent != nil {
 		// Try sending a message to the session agent before
 		// shutting it down to see if that helps with the hang
 		// in gracefully shutting down the agent.
 		cli := client.New()
-		_, err := cli.SessionInfo(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := cli.SessionInfo(ctx)
 		c.Check(err, IsNil)
 
 		err = s.agent.Stop()
 		c.Check(err, IsNil)
 	}
+	s.delaysRestorer()
+	s.systemctlRestorer()
+	dirs.SetRootDir("")
 }
 
 func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {


### PR DESCRIPTION
Restore mocks in the reverse order they were created. Make sure that the rootdir
is restored last so that we do not hit the actual session agent. Set the timeout
for the session agent quests during tear down, so that it does not block.
