### PR TITLE
tests: fix passing stdin via session-tool

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -302,7 +302,9 @@ cat "$tmp_dir/ready.pipe" >/dev/null
 # and redirects to capture output. Sadly busctl doesn't support passing file
 # descriptors https://github.com/systemd/systemd/issues/14954 As a workaround
 # we pass a set of pipes. This is good for non-interactive work.
-cat >"$tmp_dir/stdin.pipe" &
+# NOTE: /dev/stdin is provided explicitly to trigger special behavior in bash,
+# as otherwise background tasks are started with /dev/null for stdin.
+cat </dev/stdin >"$tmp_dir/stdin.pipe" &
 cat_stdin_pid=$!
 cat <"$tmp_dir/stdout.pipe" >&1 &
 cat_stdout_pid=$!

--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -34,6 +34,9 @@ prepare: |
     # Prepare for using sessions as the given user
     session-tool --prepare -u "$USER"
 execute: |
+    # Check that stdin is forwarded correctly.
+    echo "it-works" | session-tool -u "$USER" cat | MATCH "it-works"
+
     for n in $(seq 300); do
         echo "ITERATION $(date) $n"
         session-tool -u "$USER" id -u  2>/tmp/session-tool.log | MATCH "$(id -u "$USER")"


### PR DESCRIPTION
While trying to use stdin via session-tool I realised that it doesn't
work at all. The reason is this bit of documentation of bash:

       If a command is followed by a & and job control is not active,
       the default standard input for the command is the empty file
       /dev/null. Otherwise, the invoked command  inherits the file
       descriptors of the calling shell as modified by redirections.

By using an explicit redirect from /dev/stdin, we trigger two
operations: first bash handles /dev/stdin specially, duplicating file
descriptor zero, in addition the explicitly redirected descriptor is now
inherited by "cat" that we invoke.

This is coupled with an integration test.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
