### PR TITLE
cmd/snap: coldplug auto-import assertions from all removable devices

### DIFF
--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -187,8 +187,10 @@ func autoImportFromAllMounts(cli *client.Client) (int, error) {
 	return added, nil
 }
 
+var ioutilTempDir = ioutil.TempDir
+
 func tryMount(deviceName string) (string, error) {
-	tmpMountTarget, err := ioutil.TempDir("", "snapd-auto-import-mount-")
+	tmpMountTarget, err := ioutilTempDir("", "snapd-auto-import-mount-")
 	if err != nil {
 		err = fmt.Errorf("cannot create temporary mount point: %v", err)
 		logger.Noticef("error: %v", err)
@@ -210,8 +212,10 @@ func tryMount(deviceName string) (string, error) {
 	return tmpMountTarget, nil
 }
 
+var syscallUnmount = syscall.Unmount
+
 func doUmount(mp string) error {
-	if err := syscall.Unmount(mp, 0); err != nil {
+	if err := syscallUnmount(mp, 0); err != nil {
 		return err
 	}
 	return os.Remove(mp)
@@ -263,7 +267,44 @@ func (x *cmdAutoImport) autoAddUsers() error {
 	return cmd.Execute(nil)
 }
 
-var procCmdline = "/proc/cmdline"
+func removableBlockDevices() (removableDevices []string) {
+	// eg. /sys/block/sda/removable
+	removable, err := filepath.Glob(filepath.Join(dirs.GlobalRootDir, "/sys/block/*/removable"))
+	if err != nil {
+		return nil
+	}
+	for _, removableAttr := range removable {
+		val, err := ioutil.ReadFile(removableAttr)
+		if err != nil || string(val) != "1\n" {
+			// non removable
+			continue
+		}
+		// let's see if it has partitions
+		dev := filepath.Base(filepath.Dir(removableAttr))
+
+		pattern := fmt.Sprintf(filepath.Join(dirs.GlobalRootDir, "/sys/block/%s/%s*/partition"), dev, dev)
+		// eg. /sys/block/sda/sda1/partition
+		partitionAttrs, _ := filepath.Glob(pattern)
+
+		if len(partitionAttrs) == 0 {
+			// not partitioned? try to use the main device
+			removableDevices = append(removableDevices, fmt.Sprintf("/dev/%s", dev))
+			continue
+		}
+
+		for _, partAttr := range partitionAttrs {
+			val, err := ioutil.ReadFile(partAttr)
+			if err != nil || string(val) != "1\n" {
+				// non partition?
+				continue
+			}
+			pdev := filepath.Base(filepath.Dir(partAttr))
+			removableDevices = append(removableDevices, fmt.Sprintf("/dev/%s", pdev))
+			// hasPartitions = true
+		}
+	}
+	return removableDevices
+}
 
 // inInstallmode returns true if it's UC20 system in install mode
 func inInstallMode() bool {
@@ -289,7 +330,13 @@ func (x *cmdAutoImport) Execute(args []string) error {
 		return nil
 	}
 
-	for _, path := range x.Mount {
+	devices := x.Mount
+	if len(devices) == 0 {
+		// coldplug scenario, try all removable devices
+		devices = removableBlockDevices()
+	}
+
+	for _, path := range devices {
 		// udev adds new /dev/loopX devices on the fly when a
 		// loop mount happens and there is no loop device left.
 		//

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 
@@ -303,6 +304,7 @@ func removableBlockDevices() (removableDevices []string) {
 			// hasPartitions = true
 		}
 	}
+	sort.Strings(removableDevices)
 	return removableDevices
 }
 

--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func makeMockMountInfo(c *C, content string) string {
@@ -320,4 +322,112 @@ func (s *SnapSuite) TestAutoImportUnhappyInInstallMode(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "auto-import is disabled in install-mode\n")
+}
+
+var mountStatic = []string{"mount", "-t", "ext4,vfat", "-o", "ro", "--make-private"}
+
+func (s *SnapSuite) TestAutoImportFromRemovable(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	_, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	rootdir := c.MkDir()
+	dirs.SetRootDir(rootdir)
+
+	var umounts []string
+	restore = snap.MockSyscallUmount(func(p string, _ int) error {
+		umounts = append(umounts, p)
+		return nil
+	})
+	defer restore()
+
+	var tmpdirIdx int
+	restore = snap.MockIoutilTempDir(func(where string, p string) (string, error) {
+		c.Check(where, Equals, "")
+		tmpdirIdx++
+		return filepath.Join(rootdir, fmt.Sprintf("/tmp/%s%d", p, tmpdirIdx)), nil
+	})
+	defer restore()
+
+	mountCmd := testutil.MockCommand(c, "mount", "")
+	defer mountCmd.Restore()
+
+	snaptest.PopulateDir(rootdir, [][]string{
+		// removable without partitions
+		{"sys/block/sdremovable/removable", "1\n"},
+		// fixed disk
+		{"sys/block/sdfixed/removable", "0\n"},
+		// removable with partitions
+		{"sys/block/sdpart/removable", "1\n"},
+		{"sys/block/sdpart/sdpart1/partition", "1\n"},
+		{"sys/block/sdpart/sdpart2/partition", "0\n"},
+		{"sys/block/sdpart/sdpart3/partition", "1\n"},
+		// removable but subdevices are not partitions?
+		{"sys/block/sdother/removable", "1\n"},
+		{"sys/block/sdother/sdother1/partition", "0\n"},
+	})
+
+	// do not mock mountinfo contents, we just want to observe whether we
+	// try to mount and umount the right stuff
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, "")
+	c.Check(s.Stderr(), Equals, "")
+	c.Check(mountCmd.Calls(), DeepEquals, [][]string{
+		append(mountStatic, "/dev/sdpart1", filepath.Join(rootdir, "/tmp/snapd-auto-import-mount-1")),
+		append(mountStatic, "/dev/sdpart3", filepath.Join(rootdir, "/tmp/snapd-auto-import-mount-2")),
+		append(mountStatic, "/dev/sdremovable", filepath.Join(rootdir, "/tmp/snapd-auto-import-mount-3")),
+	})
+	c.Check(umounts, DeepEquals, []string{
+		filepath.Join(rootdir, "/tmp/snapd-auto-import-mount-3"),
+		filepath.Join(rootdir, "/tmp/snapd-auto-import-mount-2"),
+		filepath.Join(rootdir, "/tmp/snapd-auto-import-mount-1"),
+	})
+}
+
+func (s *SnapSuite) TestAutoImportFromMount(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	_, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	mountCmd := testutil.MockCommand(c, "mount", "")
+
+	rootdir := c.MkDir()
+	dirs.SetRootDir(rootdir)
+
+	var umounts []string
+	restore = snap.MockSyscallUmount(func(p string, _ int) error {
+		c.Assert(umounts, HasLen, 0)
+		umounts = append(umounts, p)
+		return nil
+	})
+	defer restore()
+
+	var tmpdircalls int
+	restore = snap.MockIoutilTempDir(func(where string, p string) (string, error) {
+		c.Check(where, Equals, "")
+		c.Assert(tmpdircalls, Equals, 0)
+		tmpdircalls++
+		return filepath.Join(rootdir, fmt.Sprintf("/tmp/%s1", p)), nil
+	})
+	defer restore()
+
+	// do not mock mountinfo contents, we just want to observe whether we
+	// try to mount and umount the right stuff
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import", "--mount", "/dev/foobar"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, "")
+	c.Check(s.Stderr(), Equals, "")
+	c.Check(mountCmd.Calls(), DeepEquals, [][]string{
+		append(mountStatic, "/dev/foobar", filepath.Join(rootdir, "/tmp/snapd-auto-import-mount-1")),
+	})
+	c.Check(umounts, DeepEquals, []string{
+		filepath.Join(rootdir, "/tmp/snapd-auto-import-mount-1"),
+	})
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -341,3 +341,19 @@ func MockCgroupSnapNameFromPid(f func(pid int) (string, error)) (restore func())
 		cgroupSnapNameFromPid = old
 	}
 }
+
+func MockSyscallUmount(f func(string, int) error) (restore func()) {
+	old := syscallUnmount
+	syscallUnmount = f
+	return func() {
+		syscallUnmount = old
+	}
+}
+
+func MockIoutilTempDir(f func(string, string) (string, error)) (restore func()) {
+	old := ioutilTempDir
+	ioutilTempDir = f
+	return func() {
+		ioutilTempDir = old
+	}
+}


### PR DESCRIPTION
Add support for importing assertions from all removable devices in coldplug
scenario. The snap auto-import --mount invocations from udev triggers that run
before snapd is seeded in first boot will fail because snap command is not yet
available. The coldplug scenario allows us to import assertions from all
removable devices when snap.auto-import is explicitly started.
