### PR TITLE
tests: new test user is used for external backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -410,40 +410,40 @@ backends:
             ADDRESS $SPREAD_EXTERNAL_ADDRESS
         systems:
             - ubuntu-core-16-64:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-16-32:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-16-arm-64:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-16-arm-32:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-18-64:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-18-32:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-18-arm-64:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-18-arm-32:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-20-64:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-20-32:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-20-arm-64:
-                username: test
+                username: external
                 password: ubuntu
             - ubuntu-core-20-arm-32:
-                username: test
+                username: external
                 password: ubuntu
 
 path: /home/gopath/src/github.com/snapcore/snapd

--- a/tests/lib/external/prepare-ssh.sh
+++ b/tests/lib/external/prepare-ssh.sh
@@ -10,6 +10,10 @@ execute_remote(){
     ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p "$INSTANCE_PORT" "$USER@$INSTANCE_IP" "$@"
 }
 
-execute_remote "sudo adduser --extrausers --quiet --disabled-password --gecos '' test"
+execute_remote "sudo adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test"
 execute_remote "echo test:ubuntu | sudo chpasswd"
 execute_remote "echo 'test ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-test"
+
+execute_remote "sudo adduser --extrausers --quiet --disabled-password --gecos '' external"
+execute_remote "echo external:ubuntu | sudo chpasswd"
+execute_remote "echo 'external ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-external"


### PR DESCRIPTION
The problem with external backend is that we are using the same test
user also for connecting to the external ip and when session-tool
restores the environment it is breaking the connection and we get EOF.

Also the test tests/main/snap-session-agent-service-control is waiting
to have the test user with id 12345 and the user for external tests does
not have it. This produces that the connection fails when we do
        -D- -X POST -H "Content-Type: application/json" \
        -d '{"action": "daemon-reload"}' \
        http://localhost/v1/service-control
