### PR TITLE
tests: inject snapd from edge into seeds of the image in manual preseed test

### DIFF
--- a/tests/lib/preseed.sh
+++ b/tests/lib/preseed.sh
@@ -38,3 +38,25 @@ umount_ubuntu_image() {
     # reporting it's still in use.
     retry-tool -n 5 --wait 1 qemu-nbd -d /dev/nbd0
 }
+
+# inject latest snapd snap from edge into seed/snaps of the cloud image
+# and make it unasserted.
+# this is needed if snapd from the deb is newer than snapd in seeds as
+# otherwise 
+inject_snapd_into_seeds() {
+    local IMAGE_MOUNTPOINT=$1
+    local SNAP_IMAGE
+
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+
+    SNAP_IMAGE=$(find "$IMAGE_MOUNTPOINT/var/lib/snapd/seed/snaps/" -name "snapd_*.snap")
+    if [ -e "$SNAP_IMAGE" ]; then
+        snap download --edge snapd
+        SNAPD_EDGE=$(ls snapd_*.snap)
+        rm -f "$IMAGE_MOUNTPOINT"/var/lib/snapd/seed/snaps/snapd_*.snap
+        mv "$SNAPD_EDGE" "$IMAGE_MOUNTPOINT"/var/lib/snapd/seed/snaps/
+        sed -i "$IMAGE_MOUNTPOINT/var/lib/snapd/seed/seed.yaml" -E -e "s/^(\\s+)name: snapd/\\1name: snapd\\n\\1unasserted: true/"
+        sed -i "$IMAGE_MOUNTPOINT/var/lib/snapd/seed/seed.yaml" -E -e "s/^(\\s+)file: snapd.*/\\1file: $SNAPD_EDGE\\n/"
+    fi
+}

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -13,12 +13,20 @@ environment:
 prepare: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
+  dpkg -i "$SPREAD_PATH"/../snapd_*.deb
   create_nested_classic_vm
   mkdir -p "$IMAGE_MOUNTPOINT"
   #shellcheck source=tests/lib/preseed.sh
   . "$TESTSLIB/preseed.sh"
   CLOUD_IMAGE=$(get_nested_classic_image_path)
   mount_ubuntu_image "$CLOUD_IMAGE" "$IMAGE_MOUNTPOINT"
+
+  # on 20.04 snapd from the deb is newer than snapd from seeds;
+  # this is not a sensible scenario for preseeding but since
+  # we're cheating and preseeding images that were not meant to be
+  # preseeded in their current state, we need to inject newer snapd
+  # into seeds/ to make snap-preseed and the test happy.
+  inject_snapd_into_seeds "$IMAGE_MOUNTPOINT"
 
 restore: |
   #shellcheck source=tests/lib/nested.sh


### PR DESCRIPTION
Inject snapd snap from edge into seeds/ of the preseeded image. Otherwise the test fails on 20.04 because snapd from the deb is newer than the one from seeds, so we don't reexec on first boot and therefore system-key that was generated during preseeding gets re-generated on first boot, making the check of system-key fail. The check of system-key in the test is there to validate that snapd from seeds/ was used for preseeding.

This is fine since we're kinda abusing existing images for preseeding while they are not quite ready for that (snapd deb shouldn't be newer than seeded snapd).

I'll also propose a followup that makes snap-preseed fail in such case.