### PR TITLE
image,cmd/snap,tests: add support for store-wide cohort keys

### DIFF
--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -111,7 +111,9 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 		opts.SnapChannels = snapChannels
 	}
 
-	opts.CohortKey = os.Getenv("UBUNTU_STORE_COHORT_KEY")
+	// store-wide cohort key via env, see image/options.go
+	opts.WideCohortKey = os.Getenv("UBUNTU_STORE_COHORT_KEY")
+
 	opts.PrepareDir = x.Positional.TargetDir
 	opts.Classic = x.Classic
 

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 
 	"github.com/jessevdk/go-flags"
@@ -110,6 +111,7 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 		opts.SnapChannels = snapChannels
 	}
 
+	opts.CohortKey = os.Getenv("UBUNTU_STORE_COHORT_KEY")
 	opts.PrepareDir = x.Positional.TargetDir
 	opts.Classic = x.Classic
 

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -109,10 +109,10 @@ func (s *SnapPrepareImageSuite) TestPrepareImageClassicWideCohort(c *C) {
 	c.Assert(rest, DeepEquals, []string{})
 
 	c.Check(opts, DeepEquals, &image.Options{
-		Classic:    true,
-		WideCohortKey:  "is-six-centuries",
-		ModelFile:  "model",
-		PrepareDir: "prepare-dir",
+		Classic:       true,
+		WideCohortKey: "is-six-centuries",
+		ModelFile:     "model",
+		PrepareDir:    "prepare-dir",
 	})
 
 	os.Unsetenv("UBUNTU_STORE_COHORT_KEY")

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -93,7 +93,7 @@ func (s *SnapPrepareImageSuite) TestPrepareImageClassicArch(c *C) {
 	})
 }
 
-func (s *SnapPrepareImageSuite) TestPrepareImageClassicCohort(c *C) {
+func (s *SnapPrepareImageSuite) TestPrepareImageClassicWideCohort(c *C) {
 	var opts *image.Options
 	prep := func(o *image.Options) error {
 		opts = o
@@ -110,7 +110,7 @@ func (s *SnapPrepareImageSuite) TestPrepareImageClassicCohort(c *C) {
 
 	c.Check(opts, DeepEquals, &image.Options{
 		Classic:    true,
-		CohortKey:  "is-six-centuries",
+		WideCohortKey:  "is-six-centuries",
 		ModelFile:  "model",
 		PrepareDir: "prepare-dir",
 	})

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -21,6 +21,7 @@ package main_test
 
 import (
 	. "gopkg.in/check.v1"
+	"os"
 
 	snap "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/image"
@@ -90,6 +91,31 @@ func (s *SnapPrepareImageSuite) TestPrepareImageClassicArch(c *C) {
 		ModelFile:    "model",
 		PrepareDir:   "prepare-dir",
 	})
+}
+
+func (s *SnapPrepareImageSuite) TestPrepareImageClassicCohort(c *C) {
+	var opts *image.Options
+	prep := func(o *image.Options) error {
+		opts = o
+		return nil
+	}
+	r := snap.MockImagePrepare(prep)
+	defer r()
+
+	os.Setenv("UBUNTU_STORE_COHORT_KEY", "is-six-centuries")
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"prepare-image", "--classic", "model", "prepare-dir"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+
+	c.Check(opts, DeepEquals, &image.Options{
+		Classic:    true,
+		CohortKey:  "is-six-centuries",
+		ModelFile:  "model",
+		PrepareDir: "prepare-dir",
+	})
+
+	os.Unsetenv("UBUNTU_STORE_COHORT_KEY")
 }
 
 func (s *SnapPrepareImageSuite) TestPrepareImageExtraSnaps(c *C) {

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -299,7 +299,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 			dlOpts := DownloadOptions{
 				TargetPathFunc: targetPathFunc,
 				Channel:        sn.Channel,
-				CohortKey:      opts.CohortKey,
+				CohortKey:      opts.WideCohortKey,
 			}
 			fn, info, redirectChannel, err := tsto.DownloadSnap(sn.SnapName(), dlOpts) // TODO|XXX make this take the SnapRef really
 			if err != nil {

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -299,6 +299,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 			dlOpts := DownloadOptions{
 				TargetPathFunc: targetPathFunc,
 				Channel:        sn.Channel,
+				CohortKey:      opts.CohortKey,
 			}
 			fn, info, redirectChannel, err := tsto.DownloadSnap(sn.SnapName(), dlOpts) // TODO|XXX make this take the SnapRef really
 			if err != nil {

--- a/image/options.go
+++ b/image/options.go
@@ -28,7 +28,11 @@ type Options struct {
 	// TODO: use OptionsSnap directly here?
 	Snaps        []string
 	SnapChannels map[string]string
-	CohortKey    string
+
+	// WideCohortKey can be used to supply a cohort covering all
+	// the snaps in the image, there is no generally suppported API
+	// to create such a cohort key.
+	WideCohortKey string
 
 	PrepareDir string
 

--- a/image/options.go
+++ b/image/options.go
@@ -28,6 +28,7 @@ type Options struct {
 	// TODO: use OptionsSnap directly here?
 	Snaps        []string
 	SnapChannels map[string]string
+	CohortKey    string
 
 	PrepareDir string
 


### PR DESCRIPTION
image,cmd/snap,tests: add support for store-wide cohort keys

Add hidden UBUNTU_STORE_COHORT_KEY environment variable to
prepare-image, which works like the --cohort option in the download
command. This is to be used by livecd-rootfs during classic image
building with the store-wide any-snap cohort keys. This is required to
move livecd-rootfs from using download, to using prepare-image.