### PR TITLE
o/devicestate: support doing system action reboots from recover mode

### DIFF
--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -20,7 +20,9 @@
 package daemon
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -30,6 +32,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/client"
@@ -261,8 +264,6 @@ func (s *apiSuite) TestSystemActionRequestHappy(c *check.C) {
 	cmd := testutil.MockCommand(c, "shutdown", "")
 	defer cmd.Restore()
 
-	d := s.daemon(c)
-
 	restore := s.mockSystemSeeds(c)
 	defer restore()
 
@@ -287,48 +288,167 @@ func (s *apiSuite) TestSystemActionRequestHappy(c *check.C) {
 		},
 	})
 
-	st := d.overlord.State()
-	st.Lock()
-	// devicemgr needs boot id to request a reboot
-	st.VerifyReboot("boot-id-0")
-	// device model
-	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
-	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
-	s.mockModel(c, st, model)
-	st.Unlock()
+	currentSystem := []map[string]interface{}{{
+		"system": "20191119", "model": "my-model", "brand-id": "my-brand",
+		"revision": 2, "timestamp": "2009-11-10T23:00:00Z",
+		"seed-time": "2009-11-10T23:00:00Z",
+	}}
 
-	s.vars = map[string]string{"label": "20191119"}
-	body := `{"action":"do","title":"reinstall","mode":"install"}`
-	req, err := http.NewRequest("POST", "/v2/systems/20191119", strings.NewReader(body))
-	c.Assert(err, check.IsNil)
-	// as root
-	req.RemoteAddr = "pid=100;uid=0;socket=;"
-	rec := httptest.NewRecorder()
-	systemsActionCmd.ServeHTTP(rec, req)
-	c.Assert(rec.Code, check.Equals, 200)
-
-	var rspBody map[string]interface{}
-	err = json.Unmarshal(rec.Body.Bytes(), &rspBody)
-	c.Check(err, check.IsNil)
-	c.Check(rspBody, check.DeepEquals, map[string]interface{}{
-		"result":      nil,
-		"status":      "OK",
-		"status-code": 200.0,
-		"type":        "sync",
-		"maintenance": map[string]interface{}{
-			"kind":    "system-restart",
-			"message": "system is restarting",
+	tt := []struct {
+		currentMode    string
+		actionMode     string
+		expUnsupported bool
+		expRestart     bool
+		comment        string
+	}{
+		{
+			// from run mode -> install mode works to reinstall the system
+			currentMode: "run",
+			actionMode:  "install",
+			expRestart:  true,
+			comment:     "run mode to install mode",
 		},
-	})
+		{
+			// from run mode -> recover mode works to recover the system
+			currentMode: "run",
+			actionMode:  "recover",
+			expRestart:  true,
+			comment:     "run mode to recover mode",
+		},
+		{
+			// from run mode -> run mode is no-op
+			currentMode: "run",
+			actionMode:  "run",
+			comment:     "run mode to run mode",
+		},
+		{
+			// from recover mode -> run mode works to stop recovering and "restore" the system to normal
+			currentMode: "recover",
+			actionMode:  "run",
+			expRestart:  true,
+			comment:     "recover mode to run mode",
+		},
+		{
+			// from recover mode -> install mode works to stop recovering and reinstall the system if all is lost
+			currentMode: "recover",
+			actionMode:  "install",
+			expRestart:  true,
+			comment:     "recover mode to install mode",
+		},
+		{
+			// from recover mode -> recover mode is no-op
+			currentMode: "recover",
+			actionMode:  "recover",
+			comment:     "recover mode to recover mode",
+		},
+		{
+			// from install mode -> install mode is no-op
+			currentMode: "install",
+			actionMode:  "install",
+			comment:     "install mode to install mode",
+		},
+		{
+			// from install mode -> run mode is no-no
+			currentMode:    "install",
+			actionMode:     "run",
+			expUnsupported: true,
+			comment:        "install mode to run mode not supported",
+		},
+		{
+			// from install mode -> recover mode is no-no
+			currentMode:    "install",
+			actionMode:     "recover",
+			expUnsupported: true,
+			comment:        "install mode to recover mode not supported",
+		},
+	}
+	s.vars = map[string]string{"label": "20191119"}
 
-	// daemon is not started, only check whether reboot was scheduled as expected
+	for _, t := range tt {
+		// daemon setup - need to do this per-test because we need to re-read
+		// the modeenv during devicemgr startup
+		m := boot.Modeenv{
+			Mode: t.currentMode,
+		}
+		err := m.WriteTo("")
+		c.Assert(err, check.IsNil)
+		d := s.daemon(c)
+		st := d.overlord.State()
+		st.Lock()
+		// devicemgr needs boot id to request a reboot
+		st.VerifyReboot("boot-id-0")
+		// device model
+		assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
+		assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+		s.mockModel(c, st, model)
+		st.Set("seeded-systems", currentSystem)
+		st.Unlock()
 
-	// reboot flag
-	c.Check(d.restartSystem, check.Equals, state.RestartSystemNow)
-	// slow reboot schedule
-	c.Check(cmd.Calls(), check.DeepEquals, [][]string{
-		{"shutdown", "-r", "+10", "reboot scheduled to update the system"},
-	})
+		body := map[string]string{
+			"action": "do",
+			"mode":   t.actionMode,
+		}
+		b, err := json.Marshal(body)
+		c.Assert(err, check.IsNil, check.Commentf(t.comment))
+		buf := bytes.NewBuffer(b)
+		req, err := http.NewRequest("POST", "/v2/systems/20191119", buf)
+		c.Assert(err, check.IsNil, check.Commentf(t.comment))
+		// as root
+		req.RemoteAddr = "pid=100;uid=0;socket=;"
+		rec := httptest.NewRecorder()
+		systemsActionCmd.ServeHTTP(rec, req)
+		if t.expUnsupported {
+			c.Check(rec.Code, check.Equals, 400, check.Commentf(t.comment))
+		} else {
+			c.Check(rec.Code, check.Equals, 200, check.Commentf(t.comment))
+		}
+
+		var rspBody map[string]interface{}
+		err = json.Unmarshal(rec.Body.Bytes(), &rspBody)
+		c.Assert(err, check.IsNil, check.Commentf(t.comment))
+
+		expResp := make(map[string]interface{})
+		if t.expUnsupported {
+			expResp = map[string]interface{}{
+				"result": map[string]interface{}{
+					"message": fmt.Sprintf("requested action is not supported by system %q", "20191119"),
+				},
+				"status":      "Bad Request",
+				"status-code": 400.0,
+				"type":        "error",
+			}
+		} else {
+			expResp = map[string]interface{}{
+				"result":      nil,
+				"status":      "OK",
+				"status-code": 200.0,
+				"type":        "sync",
+			}
+			if t.expRestart {
+				expResp["maintenance"] = map[string]interface{}{
+					"kind":    "system-restart",
+					"message": "system is restarting",
+				}
+
+				// daemon is not started, only check whether reboot was scheduled as expected
+
+				// reboot flag
+				c.Check(d.restartSystem, check.Equals, state.RestartSystemNow, check.Commentf(t.comment))
+				// slow reboot schedule
+				c.Check(cmd.Calls(), check.DeepEquals, [][]string{
+					{"shutdown", "-r", "+10", "reboot scheduled to update the system"},
+				},
+					check.Commentf(t.comment),
+				)
+			}
+		}
+
+		c.Assert(rspBody, check.DeepEquals, expResp, check.Commentf(t.comment))
+
+		cmd.ForgetCalls()
+		s.d = nil
+	}
+
 }
 
 func (s *apiSuite) TestSystemActionBrokenSeed(c *check.C) {

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -407,7 +407,7 @@ func (s *apiSuite) TestSystemActionRequestHappy(c *check.C) {
 		err = json.Unmarshal(rec.Body.Bytes(), &rspBody)
 		c.Assert(err, check.IsNil, check.Commentf(t.comment))
 
-		expResp := make(map[string]interface{})
+		var expResp map[string]interface{}
 		if t.expUnsupported {
 			expResp = map[string]interface{}{
 				"result": map[string]interface{}{

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -256,7 +256,7 @@ func (s *apiSuite) TestSystemActionRequestErrors(c *check.C) {
 	}
 }
 
-func (s *apiSuite) TestSystemActionRequestHappy(c *check.C) {
+func (s *apiSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 	bt := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bt)
 	defer func() { bootloader.Force(nil) }()
@@ -342,10 +342,11 @@ func (s *apiSuite) TestSystemActionRequestHappy(c *check.C) {
 			comment:     "recover mode to recover mode",
 		},
 		{
-			// from install mode -> install mode is no-op
-			currentMode: "install",
-			actionMode:  "install",
-			comment:     "install mode to install mode",
+			// from install mode -> install mode is no-no
+			currentMode:    "install",
+			actionMode:     "install",
+			expUnsupported: true,
+			comment:        "install mode to install mode not supported",
 		},
 		{
 			// from install mode -> run mode is no-no

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -904,10 +904,10 @@ func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAct
 		// installed
 		// TODO:UC20: maybe factory hooks will be able to something like this?
 		return ErrUnsupportedAction
-	case "":
+	default:
 		// probably test device manager mocking problem, or also potentially
 		// missing modeenv
-		return fmt.Errorf("internal error: no manager system mode set")
+		return fmt.Errorf("internal error: unexpected manager system mode %q", m.systemMode)
 	}
 
 	m.state.Lock()

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -885,6 +885,9 @@ func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAct
 		return ErrUnsupportedAction
 	}
 
+	// XXX: requested mode is valid; only current system has 'run' and
+	// recover 'actions'
+
 	switch m.systemMode {
 	case "recover", "run":
 		// if going from recover to recover or from run to run and the systems
@@ -893,17 +896,10 @@ func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAct
 			return nil
 		}
 	case "install":
-		// unclear why we should support requesting the system to go into
-		// install mode when it's already in install mode, but sure why not?
-		if sysAction.Mode == "install" && systemLabel == currentSys.System {
-			return nil
-		}
-		// anything else doesn't make sense, we should let install mode finish
-		// before we can realistically "run" or "recover" anything
-		// it's also unclear that we want something to be able to request
-		// installing a different system while the current one is being
-		// installed
-		// TODO:UC20: maybe factory hooks will be able to something like this?
+		// requesting system actions in install mode does not make sense atm
+		//
+		// TODO:UC20: maybe factory hooks will be able to something like
+		// this?
 		return ErrUnsupportedAction
 	default:
 		// probably test device manager mocking problem, or also potentially

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -887,8 +887,9 @@ func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAct
 
 	switch m.systemMode {
 	case "recover", "run":
-		// if going from recover to recover or from run to run, do nothing
-		if m.systemMode == sysAction.Mode {
+		// if going from recover to recover or from run to run and the systems
+		// are the same do nothing
+		if m.systemMode == sysAction.Mode && systemLabel == currentSys.System {
 			return nil
 		}
 	case "install":

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -180,6 +180,9 @@ func (s *deviceMgrSystemsSuite) SetUpTest(c *C) {
 		brand: otherBrandAcc,
 	}}
 
+	// all tests should be in run mode by default, if they need to be in
+	// different modes they should set that individually
+	s.AddCleanup(s.mgr.SetManagerSystemMode("run"))
 }
 
 func (s *deviceMgrSystemsSuite) TestListNoSystems(c *C) {

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -356,7 +356,7 @@ func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystemDoesNothing(c *C) {
 	}
 }
 
-func (s *deviceMgrSystemsSuite) TestRequestModeRunInstallForRun(c *C) {
+func (s *deviceMgrSystemsSuite) TestRequestModeRunInstallForRecover(c *C) {
 	// we are in recover mode here
 	devicestate.SetSystemMode(s.mgr, "recover")
 	s.state.Lock()

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -182,7 +182,7 @@ func (s *deviceMgrSystemsSuite) SetUpTest(c *C) {
 
 	// all tests should be in run mode by default, if they need to be in
 	// different modes they should set that individually
-	s.AddCleanup(s.mgr.SetManagerSystemMode("run"))
+	devicestate.SetSystemMode(s.mgr, "run")
 }
 
 func (s *deviceMgrSystemsSuite) TestListNoSystems(c *C) {
@@ -336,7 +336,7 @@ func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystemDoesNothing(c *C) {
 	label := s.mockedSystemSeeds[0].label
 
 	for _, mode := range []string{"run", "install", "recover"} {
-		s.mgr.SetManagerSystemMode(mode)
+		devicestate.SetSystemMode(s.mgr, mode)
 		err := s.bootloader.SetBootVars(map[string]string{
 			"snapd_recovery_mode":   mode,
 			"snapd_recovery_system": label,
@@ -358,7 +358,7 @@ func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystemDoesNothing(c *C) {
 
 func (s *deviceMgrSystemsSuite) TestRequestModeRunInstallForRun(c *C) {
 	// we are in recover mode here
-	s.mgr.SetManagerSystemMode("recover")
+	devicestate.SetSystemMode(s.mgr, "recover")
 	s.state.Lock()
 	s.state.Set("seeded-systems", []devicestate.SeededSystem{
 		{

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -164,14 +164,6 @@ func RemodelDeviceBackend(remodCtx remodelContext) storecontext.DeviceBackend {
 	}).deviceBackend()
 }
 
-func (mgr *DeviceManager) SetManagerSystemMode(mode string) (restore func()) {
-	old := mgr.systemMode
-	mgr.systemMode = mode
-	return func() {
-		mgr.systemMode = old
-	}
-}
-
 var (
 	ImportAssertionsFromSeed     = importAssertionsFromSeed
 	CheckGadgetOrKernel          = checkGadgetOrKernel

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -164,6 +164,14 @@ func RemodelDeviceBackend(remodCtx remodelContext) storecontext.DeviceBackend {
 	}).deviceBackend()
 }
 
+func (mgr *DeviceManager) SetManagerSystemMode(mode string) (restore func()) {
+	old := mgr.systemMode
+	mgr.systemMode = mode
+	return func() {
+		mgr.systemMode = old
+	}
+}
+
 var (
 	ImportAssertionsFromSeed     = importAssertionsFromSeed
 	CheckGadgetOrKernel          = checkGadgetOrKernel


### PR DESCRIPTION
We want to be able to both re-install and go back to normal run mode when we are in recover mode, so we need some logic about the current system and the requested system. Specifically, we support going from run and recover to any other mode, but only support going from install to install (which is a no-op iff the system matches the currently installing system).

I will propose a recover mode spread test in a different PR, it's a bit more complicated and I think we want this sooner rather than later