### PR TITLE
tests: add dependency needed for next upgrade of bionic

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -579,6 +579,7 @@ pkg_dependencies_ubuntu_classic(){
     echo "
         avahi-daemon
         cups
+        dbus-user-session
         dbus-x11
         fontconfig
         gnome-keyring

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -76,6 +76,6 @@ debug: |
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
 
-    ls -la "/run/user/$TEST_UID/" || true
+    ls -la "/run/user/$(id -u test)" || true
     #shellcheck disable=SC2009
     ps -ef | grep xdg || true

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -73,6 +73,6 @@ debug: |
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
 
-    ls -la "/run/user/$TEST_UID/" || true
+    ls -la "/run/user/$(id -u test)" || true
     #shellcheck disable=SC2009
     ps -ef | grep xdg || true

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -63,6 +63,6 @@ debug: |
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
 
-    ls -la "/run/user/$TEST_UID/" || true
+    ls -la "/run/user/$(id -u test)" || true
     #shellcheck disable=SC2009
     ps -ef | grep xdg || true

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -53,6 +53,6 @@ debug: |
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
 
-    ls -la "/run/user/$TEST_UID/" || true
+    ls -la "/run/user/$(id -u test)" || true
     #shellcheck disable=SC2009
     ps -ef | grep xdg || true


### PR DESCRIPTION
Issue fixed by installing the dbus-user-session package which is removed after the bionic upgrade
Tests that were failing:
    - google:ubuntu-18.04-64:tests/main/desktop-portal-filechooser
    - google:ubuntu-18.04-64:tests/main/desktop-portal-open-file
    - google:ubuntu-18.04-64:tests/main/desktop-portal-open-uri
    - google:ubuntu-18.04-64:tests/main/desktop-portal-screenshot
    - google:ubuntu-18.04-64:tests/main/session-tool-support:test
    - google:ubuntu-18.04-64:tests/main/xdg-open-portal

There was compared the dependncies installed in the current bionic version (which we use currently in gce) and the next one (which is the current + apt upgrade) and I detected the dbus-user-session was not installed in the upgraded version.  

Also this fix includes some small fixes for debug section on desktop portal tests.

