### PR TITLE
tests: improve debugging of user session agent tests

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -55,6 +55,12 @@ create_test_user(){
                 echo "ERROR: system $SPREAD_SYSTEM not yet supported!"
                 exit 1
         esac
+
+        # Allow the test user to access systemd journal.
+        if getent group systemd-journal >/dev/null; then
+            usermod -G systemd-journal -a test
+            id test | MATCH systemd-journal
+        fi
     fi
 
     owner=$( stat -c "%U:%G" /home/test )

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -29,7 +29,7 @@ disable_journald_rate_limiting() {
     # Disable journald rate limiting
     mkdir -p /etc/systemd/journald.conf.d
     # The RateLimitIntervalSec key is not supported on some systemd versions causing
-    # the journal rate limit could be considered as not valid and discarded in concecuence.
+    # the journal rate limit could be considered as not valid and discarded in consequence.
     # RateLimitInterval key is supported in old systemd versions and in new ones as well,
     # maintaining backward compatibility.
     cat <<-EOF > /etc/systemd/journald.conf.d/no-rate-limit.conf

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -614,6 +614,10 @@ EOF
         MATCH "^ubuntu:" </mnt/system-data/var/lib/extrausers/"$f"
     done
 
+    # Make sure systemd-journal group has the "test" user as a member. Due to the way we copy that from the host
+    # and merge it from the core snap this is done explicitly as a second step.
+    sed -r -i -e 's/^systemd-journal:x:([0-9]+):$/systemd-journal:x:\1:test/' /mnt/system-data/root/test-etc/group
+
     # ensure spread -reuse works in the core image as well
     if [ -e /.spread.yaml ]; then
         cp -av /.spread.yaml /mnt/system-data

--- a/tests/main/snap-user-service-restart-on-upgrade/task.yaml
+++ b/tests/main/snap-user-service-restart-on-upgrade/task.yaml
@@ -56,3 +56,4 @@ execute: |
 debug: |
     session-tool --dump
     session-tool -u test systemctl --user status snapd.session-agent.service || true
+    session-tool -u test journalctl --user || true

--- a/tests/main/snap-user-service-socket-activation/task.yaml
+++ b/tests/main/snap-user-service-socket-activation/task.yaml
@@ -41,3 +41,4 @@ execute: |
 debug: |
     session-tool --dump
     session-tool -u test systemctl --user status snapd.session-agent.service || true
+    session-tool -u test journalctl --user || true

--- a/tests/main/snap-user-service-start-on-install/task.yaml
+++ b/tests/main/snap-user-service-start-on-install/task.yaml
@@ -56,3 +56,4 @@ execute: |
 debug: |
     session-tool --dump
     session-tool -u test systemctl --user status snapd.session-agent.service || true
+    session-tool -u test journalctl --user || true

--- a/tests/main/snap-user-service-upgrade-failure/task.yaml
+++ b/tests/main/snap-user-service-upgrade-failure/task.yaml
@@ -63,4 +63,4 @@ execute: |
 debug: |
     session-tool --dump
     session-tool -u test systemctl --user status snapd.session-agent.service || true
-
+    session-tool -u test journalctl --user || true

--- a/tests/main/snap-user-service/task.yaml
+++ b/tests/main/snap-user-service/task.yaml
@@ -33,3 +33,4 @@ execute: |
 debug: |
     session-tool --dump
     session-tool -u test systemctl --user status snapd.session-agent.service || true
+    session-tool -u test journalctl --user || true


### PR DESCRIPTION
This branch contains two principal patches that allow us to see session-level
journal logs in case one of the user session agent test fails. I also squeezed in
a typo that I fixed along the way.