### PR TITLE
secboot: append uuid to ubuntu-data when decrypting

### DIFF
--- a/randutil/crypto.go
+++ b/randutil/crypto.go
@@ -55,7 +55,7 @@ func CryptoToken(nbytes int) (string, error) {
 func RandomKernelUUID() string {
 	b, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
 	if err != nil {
-		panic("cannot read kernel uuid")
+		panic("cannot read kernel generated uuid")
 	}
 	return strings.TrimSpace(string(b))
 }

--- a/randutil/crypto.go
+++ b/randutil/crypto.go
@@ -23,6 +23,8 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
+	"strings"
 )
 
 // CryptoTokenBytes returns a crypthographically secure token of
@@ -31,7 +33,7 @@ func CryptoTokenBytes(nbytes int) ([]byte, error) {
 	b := make([]byte, nbytes)
 	_, err := cryptorand.Read(b)
 	if err != nil {
-		return nil, fmt.Errorf("canot obtain %d crypto random bytes: %v", nbytes, err)
+		return nil, fmt.Errorf("cannot obtain %d crypto random bytes: %v", nbytes, err)
 	}
 	return b, nil
 }
@@ -45,4 +47,15 @@ func CryptoToken(nbytes int) (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// RandomKernelUUID will return a UUID from the kernel's procfs API at
+// /proc/sys/kernel/random/uuid. Only to be used in very specific uses, most
+// random code should use CryptoToken(Bytes) instead.
+func RandomKernelUUID() string {
+	b, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
+	if err != nil {
+		panic("cannot read kernel uuid")
+	}
+	return strings.TrimSpace(string(b))
 }

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -118,3 +118,11 @@ func MockDevDiskByLabelDir(new string) (restore func()) {
 		devDiskByLabelDir = old
 	}
 }
+
+func MockRandomKernelUUID(new func() string) (restore func()) {
+	old := randutilRandomKernelUUID
+	randutilRandomKernelUUID = new
+	return func() {
+		randutilRandomKernelUUID = old
+	}
+}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader/efi"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/randutil"
 )
 
 var (
@@ -146,13 +147,15 @@ func MeasureSnapModelWhenPossible(findModel func() (*asserts.Model, error)) erro
 	return nil
 }
 
+var (
+	randutilRandomKernelUUID = randutil.RandomKernelUUID
+)
+
 // UnlockVolumeIfEncrypted verifies whether an encrypted volume with the specified
 // name exists and unlocks it. With lockKeysOnFinish set, access to the sealed
 // keys will be locked when this function completes. The path to the unencrypted
 // device node is returned.
 func UnlockVolumeIfEncrypted(name string, lockKeysOnFinish bool) (string, error) {
-	device := filepath.Join(devDiskByLabelDir, name)
-
 	// TODO:UC20: use sb.SecureConnectToDefaultTPM() if we decide there's benefit in doing that or
 	//            we have a hard requirement for a valid EK cert chain for every boot (ie, panic
 	//            if there isn't one). But we can't do that as long as we need to download
@@ -165,6 +168,7 @@ func UnlockVolumeIfEncrypted(name string, lockKeysOnFinish bool) (string, error)
 	}
 
 	var lockErr error
+	var mapperName string
 	err := func() error {
 		defer func() {
 			// TODO:UC20: we might want some better error handling here - eg, if tpmErr is a
@@ -195,7 +199,8 @@ func UnlockVolumeIfEncrypted(name string, lockKeysOnFinish bool) (string, error)
 		//            <name> is from <name>-enc and not an unencrypted partition
 		//            with the same name (LP #1863886)
 		sealedKeyPath := filepath.Join(boot.InitramfsEncryptionKeyDir, name+".sealed-key")
-		return unlockEncryptedPartition(tpm, name, encdev, sealedKeyPath, "", lockKeysOnFinish)
+		mapperName = name + "-" + randutilRandomKernelUUID()
+		return unlockEncryptedPartition(tpm, mapperName, encdev, sealedKeyPath, "", lockKeysOnFinish)
 	}()
 	if err != nil {
 		return "", err
@@ -204,7 +209,17 @@ func UnlockVolumeIfEncrypted(name string, lockKeysOnFinish bool) (string, error)
 		return "", fmt.Errorf("cannot lock access to sealed keys: %v", lockErr)
 	}
 
-	return device, nil
+	// return the encrypted device if the device we are maybe unlocked is an
+	// encrypted device
+	if mapperName != "" {
+		return filepath.Join("/dev/mapper", mapperName), nil
+	}
+
+	// otherwise use the device from /dev/disk/by-label
+	// TODO:UC20: we want to always determine the ubuntu-data partition by
+	//            referencing the ubuntu-boot or ubuntu-seed partitions and not
+	//            by using labels
+	return filepath.Join(devDiskByLabelDir, name), nil
 }
 
 // UnlockEncryptedPartition unseals the keyfile and opens an encrypted device.

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -209,7 +209,7 @@ func UnlockVolumeIfEncrypted(name string, lockKeysOnFinish bool) (string, error)
 		return "", fmt.Errorf("cannot lock access to sealed keys: %v", lockErr)
 	}
 
-	// return the encrypted device if the device we are maybe unlocked is an
+	// return the encrypted device if the device we are maybe unlocking is an
 	// encrypted device
 	if mapperName != "" {
 		return filepath.Join("/dev/mapper", mapperName), nil


### PR DESCRIPTION
This is a forward-port of https://github.com/snapcore/snapd/pull/8644 to master.

This will cause systemd-cryptsetup to mount ubuntu-data-enc at a mostly unpredictable location in /dev/mapper. Then requesting that we mount this node in /dev/mapper/ as the filesystem will prevent an attacker from attaching a disk with an unencrypted partition named ubuntu-data to the system and having snap-bootstrap mistakenly unlock the real ubuntu-data-enc but mount the attacker's unencrypted ubuntu-data partition as the real rootfs.

Also add a function to randutil to read from the kernel a cryptographically random UUID. In the 2.45 PR this was embedded into cmd_initramfs_mounts.go in the interest of time.