### PR TITLE
cmd/snap-bootstrap: tweak recovery trigger log messages

### DIFF
--- a/cmd/snap-bootstrap/cmd_recovery_chooser_trigger.go
+++ b/cmd/snap-bootstrap/cmd_recovery_chooser_trigger.go
@@ -77,7 +77,7 @@ func (c *cmdRecoveryChooserTrigger) Execute(args []string) error {
 	if c.MarkerFile != "" {
 		markerFile = c.MarkerFile
 	}
-	logger.Noticef("trigger timeout %v", timeout)
+	logger.Noticef("trigger wait timeout %v", timeout)
 	logger.Noticef("marker file %v", markerFile)
 
 	_, err := os.Stat(markerFile)

--- a/cmd/snap-bootstrap/triggerwatch/evdev.go
+++ b/cmd/snap-bootstrap/triggerwatch/evdev.go
@@ -88,7 +88,7 @@ func (e *evdevKeyboardInputDevice) probeKeyState() (bool, error) {
 }
 
 func (e *evdevKeyboardInputDevice) WaitForTrigger(ch chan keyEvent) {
-	logger.Noticef("%s: starting wait", e)
+	logger.Noticef("%s: starting wait, %s hold to trigger", e, holdToTrigger)
 
 	// XXX: do not mess with setting the key repeat rate, as it's cumbersome
 	// and golang-evdev SetRepeatRate() parameter order is actually reversed

--- a/cmd/snap-bootstrap/triggerwatch/evdev.go
+++ b/cmd/snap-bootstrap/triggerwatch/evdev.go
@@ -88,7 +88,7 @@ func (e *evdevKeyboardInputDevice) probeKeyState() (bool, error) {
 }
 
 func (e *evdevKeyboardInputDevice) WaitForTrigger(ch chan keyEvent) {
-	logger.Noticef("%s: starting wait, %s hold to trigger", e, holdToTrigger)
+	logger.Noticef("%s: starting wait, hold %s to trigger", e, holdToTrigger)
 
 	// XXX: do not mess with setting the key repeat rate, as it's cumbersome
 	// and golang-evdev SetRepeatRate() parameter order is actually reversed


### PR DESCRIPTION
The messages logged from recovery chooser trigger are slightly confusing. Tweak
them a little to make it more obvious.
