### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: copy auth.json and macaroon-key in recover

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -109,6 +109,9 @@ func copyUbuntuDataAuth(src, dst string) error {
 		"system-data/var/lib/extrausers/*",
 		"system-data/etc/ssh/*",
 		"user-data/*/.ssh/*",
+		// this ensures we get proper authentication to snapd from "snap"
+		// commands in recover mode
+		"user-data/*/.snap/auth.json",
 		// this ensures we also get non-ssh enabled accounts copied
 		"user-data/*/.profile",
 		// so that users have proper perms, i.e. console-conf added users are
@@ -150,7 +153,7 @@ func copyUbuntuDataAuth(src, dst string) error {
 	// ensure the user state is transferred as well
 	srcState := filepath.Join(src, "system-data/var/lib/snapd/state.json")
 	dstState := filepath.Join(dst, "system-data/var/lib/snapd/state.json")
-	err := state.CopyState(srcState, dstState, []string{"auth.users"})
+	err := state.CopyState(srcState, dstState, []string{"auth.users", "auth.macaroon-key", "auth.last-id"})
 	if err != nil && err != state.ErrNoState {
 		return fmt.Errorf("cannot copy user state: %v", err)
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1173,7 +1173,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep3Encrypted(c *C
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, fmt.Sprintf("%s-model-measured", s.sysLabel)), testutil.FilePresent)
 }
 
-var mockStateContent = `{"data":{"auth":{"users":[{"name":"mvo"}]}},"some":{"other":"stuff"}}`
+var mockStateContent = `{"data":{"auth":{"users":[{"id":1,"name":"mvo"}],"macaroon-key":"not-a-cookie","last-id":1}},"some":{"other":"stuff"}}`
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=recover snapd_recovery_system="+s.sysLabel)
@@ -1208,6 +1208,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 		// user ssh
 		"user-data/user1/.ssh/authorized_keys",
 		"user-data/user2/.ssh/authorized_keys",
+		// user snap authentication
+		"user-data/user1/.snap/auth.json",
 		// sudoers
 		"system-data/etc/sudoers.d/create-user-test",
 	}
@@ -1216,6 +1218,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 		"system-data/etc/passwd",
 		"user-data/user1/some-random-data",
 		"user-data/user2/other-random-data",
+		"user-data/user2/.snap/sneaky-not-auth.json",
 	}
 	for _, mockAuthFile := range append(mockAuthFiles, mockUnrelatedFiles...) {
 		p := filepath.Join(hostUbuntuData, mockAuthFile)
@@ -1256,7 +1259,7 @@ recovery_system=20191118
 		c.Check(fiParent.Mode(), Equals, os.FileMode(os.ModeDir|0750))
 	}
 
-	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"users":[{"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0}`)
+	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0}`)
 }
 
 func (s *initramfsMountsSuite) testInitramfsMountsInstallRecoverModeStep1Measure(c *C, mode string) {


### PR DESCRIPTION
These are necessary so that the "snap" commands work without using sudo in recover mode.

The "last-id" is necessary so that if a new user is created in recover mode, it doesn't have the same id as the ones we copied from the run system.