### PR TITLE
tests: remove generated session-agent units

### DIFF
--- a/tests/core/core-to-snapd-failover16/task.yaml
+++ b/tests/core/core-to-snapd-failover16/task.yaml
@@ -8,6 +8,11 @@ prepare: |
   . "$TESTSLIB/snaps.sh"
   repack_core_snap_into_snapd_snap
 
+restore: |
+  rm -f /etc/systemd/user/snapd.session-agent.service
+  rm -f /etc/systemd/user/snapd.session-agent.socket
+  rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
+
 execute: |
   # shellcheck source=tests/lib/journalctl.sh
   . "$TESTSLIB/journalctl.sh"

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -48,6 +48,9 @@ restore: |
         # cleanup the snapd-from-core snap we built
         rm -f snapd-from-core.snap
     fi
+    rm -f /etc/systemd/user/snapd.session-agent.service
+    rm -f /etc/systemd/user/snapd.session-agent.socket
+    rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
 
 execute: |
     # shellcheck source=tests/lib/journalctl.sh

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -47,10 +47,10 @@ restore: |
         not test -d /snap/snapd
         # cleanup the snapd-from-core snap we built
         rm -f snapd-from-core.snap
+        rm -f /etc/systemd/user/snapd.session-agent.service
+        rm -f /etc/systemd/user/snapd.session-agent.socket
+        rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
     fi
-    rm -f /etc/systemd/user/snapd.session-agent.service
-    rm -f /etc/systemd/user/snapd.session-agent.socket
-    rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
 
 execute: |
     # shellcheck source=tests/lib/journalctl.sh

--- a/tests/core/snapd16/task.yaml
+++ b/tests/core/snapd16/task.yaml
@@ -67,3 +67,6 @@ execute: |
     rsync --help
 restore: |
     not test -d /snap/snapd
+    rm -f /etc/systemd/user/snapd.session-agent.service
+    rm -f /etc/systemd/user/snapd.session-agent.socket
+    rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket


### PR DESCRIPTION
Some tests install snapd snap and trigger generation of session agent
systemd units. Currently nothing is performing the cleanup of this code
when snapd snap is removed in snapd proper, apart from snapd management
script and from package purge script.

Test helpers are not properly recovering from this situation so resort
to explicit cleanup in all tests that install core.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
