### PR TITLE
tests: disable mount-ns test

### DIFF
--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -11,6 +11,7 @@ systems: [ubuntu-18.04-64]
 # The test is sensitive to backend type, which designates the used image.
 # Backends are enabled one-by-one along with the matching data set.
 backends: [google]
+manual: true
 details: |
     This test measures the mount table of the host, of the mount namespace for
     a simple core16-based snap for the per-user mount namespace of a simple


### PR DESCRIPTION
This is until the test is fixed for next update of the bionic image.

