### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: cosmetic changes in prep for future work

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -409,7 +409,6 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 			} else {
 				logger.Noticef("try-base snap is empty, but \"base_status\" is \"trying\"")
 			}
-			// TODO:UC20: log a message if try_base is unset here?
 		} else if modeEnv.BaseStatus == boot.TryingStatus {
 			// snapd failed to start with the base snap update, so we need to
 			// fallback to the old base snap and clear base_status
@@ -523,8 +522,6 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 		fmt.Fprintf(stdout, "%s %s\n", kernelPath, filepath.Join(boot.InitramfsRunMntDir, "kernel"))
 	}
 
-	// TODO:UC20: Make RecoverySystem empty after successful first boot
-	// somewhere in devicestate
 	// 4.7. Maybe mount the snapd snap on first boot of run-mode
 	if modeEnv.RecoverySystem != "" {
 		isSnapdMounted, err := mst.IsMounted(filepath.Join(boot.InitramfsRunMntDir, "snapd"))

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -62,10 +62,13 @@ func (c *cmdInitramfsMounts) Execute(args []string) error {
 	return generateInitramfsMounts()
 }
 
-// XXX: move all var () to the top, it's very spread out right now
 var (
 	// Stdout - can be overridden in tests
 	stdout io.Writer = os.Stdout
+
+	secbootMeasureSnapSystemEpochWhenPossible = secboot.MeasureSnapSystemEpochWhenPossible
+	secbootMeasureSnapModelWhenPossible       = secboot.MeasureSnapModelWhenPossible
+	secbootUnlockVolumeIfEncrypted            = secboot.UnlockVolumeIfEncrypted
 )
 
 // generateMountsMode* is called multiple times from initramfs until it
@@ -207,12 +210,6 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 	//      with mounting stuff
 	return nil
 }
-
-var (
-	secbootMeasureSnapSystemEpochWhenPossible = secboot.MeasureSnapSystemEpochWhenPossible
-	secbootMeasureSnapModelWhenPossible       = secboot.MeasureSnapModelWhenPossible
-	secbootUnlockVolumeIfEncrypted            = secboot.UnlockVolumeIfEncrypted
-)
 
 func generateMountsCommonInstallRecover(mst *initramfsMountsState, recoverySystem string) (allMounted bool, err error) {
 	// 1. always ensure seed partition is mounted

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -228,7 +228,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep2(c *C) {
 `, s.seedDir, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep4(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep3(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install snapd_recovery_system="+s.sysLabel)
 
 	n := s.mockExpectedMountChecks(c,
@@ -252,7 +252,7 @@ recovery_system=20191118
 	c.Check(cloudInitDisable, testutil.FilePresent)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1Boot(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -266,7 +266,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1Boot(c *C) {
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1Seed(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -281,7 +281,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1Seed(c *C) {
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1Data(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep3(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -299,7 +299,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1Data(c *C) {
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1EncryptedData(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep3EncryptedData(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	// write the installed model like makebootable does it
@@ -362,19 +362,19 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep1EncryptedData(c *C
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "run-model-measured"), testutil.FilePresent)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsStep1EncryptedNoModelRun(c *C) {
-	s.testInitramfsMountsStep1EncryptedNoModel(c, "run", "")
+func (s *initramfsMountsSuite) TestInitramfsMountsStep3EncryptedNoModelRun(c *C) {
+	s.testInitramfsMountsStep3EncryptedNoModel(c, "run", "")
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsStep1EncryptedNoModelInstall(c *C) {
-	s.testInitramfsMountsStep1EncryptedNoModel(c, "install", s.sysLabel)
+func (s *initramfsMountsSuite) TestInitramfsMountsStep3EncryptedNoModelInstall(c *C) {
+	s.testInitramfsMountsStep3EncryptedNoModel(c, "install", s.sysLabel)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsStep1EncryptedNoModelRecovery(c *C) {
-	s.testInitramfsMountsStep1EncryptedNoModel(c, "recover", s.sysLabel)
+	s.testInitramfsMountsStep3EncryptedNoModel(c, "recover", s.sysLabel)
 }
 
-func (s *initramfsMountsSuite) testInitramfsMountsStep1EncryptedNoModel(c *C, mode, label string) {
+func (s *initramfsMountsSuite) testInitramfsMountsStep3EncryptedNoModel(c *C, mode, label string) {
 	s.mockProcCmdlineContent(c, fmt.Sprintf("snapd_recovery_mode=%s", mode))
 	if label != "" {
 		s.mockProcCmdlineContent(c,
@@ -421,7 +421,7 @@ func (s *initramfsMountsSuite) testInitramfsMountsStep1EncryptedNoModel(c *C, mo
 	c.Assert(gl, HasLen, 0)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -466,7 +466,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2(c *C) {
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2BaseSnapUpgradeFailsHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4BaseSnapUpgradeFailsHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -511,7 +511,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2BaseSnapUpgradeFai
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2ModeenvTryBaseEmptyHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4ModeenvTryBaseEmptyHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -546,7 +546,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2ModeenvTryBaseEmpt
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2BaseSnapUpgradeHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4BaseSnapUpgradeHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -589,7 +589,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2BaseSnapUpgradeHap
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2ModeenvBaseEmptyUnhappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4ModeenvBaseEmptyUnhappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -613,7 +613,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2ModeenvBaseEmptyUn
 	c.Check(s.Stdout.String(), Equals, "")
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2ModeenvTryBaseNotExistsHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4ModeenvTryBaseNotExistsHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -650,7 +650,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2ModeenvTryBaseNotE
 	c.Assert(newModeenv.Base, DeepEquals, modeEnv.Base)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2KernelSnapUpgradeHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4KernelSnapUpgradeHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -707,7 +707,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2KernelSnapUpgradeH
 // TODO:UC20: in this case snap-bootstrap should request a reboot, since we
 //            already booted the try snap, so mounting the fallback kernel will
 //            not match in some cases
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2UntrustedKernelSnap(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4UntrustedKernelSnap(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -747,7 +747,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2UntrustedKernelSna
 // TODO:UC20: in this case snap-bootstrap should request a reboot, since we
 //            already booted the try snap, so mounting the fallback kernel will
 //            not match in some cases
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2UntrustedTryKernelSnapFallsBack(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4UntrustedTryKernelSnapFallsBack(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -795,7 +795,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2UntrustedTryKernel
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2KernelStatusTryingNoTryKernel(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4KernelStatusTryingNoTryKernel(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -842,7 +842,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2KernelStatusTrying
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstate(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4EnvRefKernelBootstate(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -884,7 +884,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootst
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstateKernelSnapUpgradeHappy(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4EnvRefKernelBootstateKernelSnapUpgradeHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -933,7 +933,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootst
 // TODO:UC20: in this case snap-bootstrap should request a reboot, since we
 //            already booted the try snap, so mounting the fallback kernel will
 //            not match in some cases
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstateUntrustedKernelSnap(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4EnvRefKernelBootstateUntrustedKernelSnap(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -970,7 +970,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootst
 // TODO:UC20: in this case snap-bootstrap should request a reboot, since we
 //            already booted the try snap, so mounting the fallback kernel will
 //            not match in some cases
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstateUntrustedTryKernelSnapFallsBack(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4EnvRefKernelBootstateUntrustedTryKernelSnapFallsBack(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -1014,7 +1014,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootst
 `, boot.InitramfsRunMntDir))
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep2EnvRefKernelBootstateKernelStatusTryingNoTryKernel(c *C) {
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeStep4EnvRefKernelBootstateKernelStatusTryingNoTryKernel(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	n := s.mockExpectedMountChecks(c,
@@ -1259,7 +1259,7 @@ recovery_system=20191118
 	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"users":[{"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0}`)
 }
 
-func (s *initramfsMountsSuite) testInitramfsMountsInstallRecoverModeStep1Measure(c *C, mode string) {
+func (s *initramfsMountsSuite) testInitramfsMountsInstallRecoverModeStep2Measure(c *C, mode string) {
 	s.mockProcCmdlineContent(c, fmt.Sprintf("snapd_recovery_mode=%s snapd_recovery_system=%s", mode, s.sysLabel))
 
 	n := s.mockExpectedMountChecks(c,
@@ -1308,10 +1308,10 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallRecoverModeStep1Measure
 	c.Check(*n, Equals, 5)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep1Measure(c *C) {
-	s.testInitramfsMountsInstallRecoverModeStep1Measure(c, "")
+func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep2Measure(c *C) {
+	s.testInitramfsMountsInstallRecoverModeStep2Measure(c, "")
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep1Measure(c *C) {
-	s.testInitramfsMountsInstallRecoverModeStep1Measure(c, "recover")
+func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep2Measure(c *C) {
+	s.testInitramfsMountsInstallRecoverModeStep2Measure(c, "recover")
 }


### PR DESCRIPTION
This is a pure code re-org / comment updating branch which will make it easier for me to open followup PR's with simpler diffs. I also moved some of the code around without changing anything so it's in a more logical (to me at least) ordering. Also deleted some already done todos

I also took the opportunity to re-number the steps so it makes more sense to explain it, in essence now we have:

### Install mode
1. Mount ubuntu-seed, return
2. Measure model from ubuntu-seed, mount snaps from ubuntu-seed, mount data as tmpfs, return
3. Write modeenv, cloud-init disable to data, return

### Run Mode
1. Mount ubuntu-boot, return 
2. Mount ubuntu-seed, return
3. Measure model from ubuntu-boot, mount ubuntu-data, return
4. Mount snaps from ubuntu-data, and update modeenv, return

### Recover mode
1. Mount ubuntu-seed, return
2. Measure model from ubuntu-seed, mount snaps from ubuntu-seed, mount data as tmpfs, return
3. Mount ubuntu-data as /host/ubuntu-data, return
4. Copy relevant data files from ubuntu-data, write modeenv, disable cloud-init, return