### PR TITLE
tests: run core/snap-set-core-config on uc20 too

### DIFF
--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -1,7 +1,6 @@
 summary: Ensure "snap set core" works
 
-# TODO:UC20: enable for UC20
-systems: [ubuntu-core-1*]
+systems: [ubuntu-core-*]
 
 # TODO: use `snap set system` instead of `snap set core`
 


### PR DESCRIPTION
This test should work fine now on uc20.
