### PR TITLE
interfaces/desktop: silence more /var/lib/snapd/desktop/icons denials - 2.44

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -202,7 +202,7 @@ dbus (receive, send)
 
 # These accesses are noisy and applications can't do anything with the found
 # icon files, so explicitly deny to silence the denials
-deny /var/lib/snapd/desktop/icons/ r,
+deny /var/lib/snapd/desktop/icons/{,**/} r,
 `
 
 type desktopInterface struct {


### PR DESCRIPTION
The rule added in 4fc4777506 was found to be insufficient now that apps
are starting to ship icon sets. Eg, with the remmina snap installed, the
following are created:

 /var/lib/snapd/desktop/icons/hicolor/\*/apps/snap.remmina....
 /var/lib/snapd/desktop/icons/hicolor/\*/actions/snap.remmina....
 /var/lib/snapd/desktop/icons/hicolor/\*/emblems/snap.remmina....
 /var/lib/snapd/desktop/icons/hicolor/\*/panel/snap.remmina....

This results in denials like the following:

 apparmor="DENIED" operation="open" profile="snap.firefox.firefox"
 name="/var/lib/snapd/desktop/icons/hicolor/32x32/apps/" pid=62224
 comm="firefox-bin" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0

Update the rule to also deny access to subdirectories of
/var/lib/snapd/desktop/icons
