### PR TITLE
tests/mount-ns: update to reflect new UEFI boot mode

### DIFF
--- a/tests/main/mount-ns/google.ubuntu-18.04-64/HOST.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/HOST.expected.txt
@@ -1,4 +1,4 @@
-0:0 / / rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
 +0:+1 / /boot/efi rw,relatime shared:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:-1 / /dev rw,nosuid,relatime shared:+1 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime shared:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
@@ -7,18 +7,18 @@
 +0:+1 / /dev/shm rw,nosuid,nodev shared:+1 - tmpfs tmpfs rw
 +0:+1 / /proc rw,nosuid,nodev,noexec,relatime shared:+1 - proc proc rw
 +0:+1 / /proc/fs/nfsd rw,relatime shared:+1 - nfsd nfsd rw
-+0:+1 / /proc/sys/fs/binfmt_misc rw,relatime shared:+1 - binfmt_misc binfmt_misc rw
 +0:+1 / /proc/sys/fs/binfmt_misc rw,relatime shared:+1 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
 +0:+1 / /run rw,nosuid,noexec,relatime shared:+1 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /run/lock rw,nosuid,nodev,noexec,relatime shared:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /run/rpc_pipefs rw,relatime shared:+1 - rpc_pipefs sunrpc rw
 +0:+1 / /run/user/0 rw,nosuid,nodev,relatime shared:+1 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-+1:-12 / /snap/core/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop0 ro
++1:-11 / /snap/core/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop0 ro
 +0:+1 / /snap/core18/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop1 ro
 +0:+1 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop2 ro
 +0:+1 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop3 ro
 +0:+1 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop4 ro
--1:+9 / /sys rw,nosuid,nodev,noexec,relatime shared:+1 - sysfs sysfs rw
+-1:+8 / /sys rw,nosuid,nodev,noexec,relatime shared:+1 - sysfs sysfs rw
++0:+1 / /sys/firmware/efi/efivars rw,nosuid,nodev,noexec,relatime shared:+1 - efivarfs efivarfs rw
 +0:+1 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:+1 - tmpfs tmpfs ro,mode=755
 +0:+1 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:+1 - cgroup cgroup rw,blkio
 +0:+1 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:+1 - cgroup cgroup rw,cpu,cpuacct

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
@@ -1,36 +1,37 @@
-2:0 / / ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
--1:+0 / /dev rw,nosuid,relatime master:-13 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:0 / / ro,nodev,relatime master:15 - squashfs /dev/loop0 ro
+-1:+0 / /dev rw,nosuid,relatime master:-12 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime master:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
 +0:+1 / /dev/mqueue rw,relatime master:+1 - mqueue mqueue rw
 +0:+31 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
 +0:-30 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
 +0:+30 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
 +0:-29 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
--1:-4 /etc /etc rw,relatime master:-6 - ext4 /dev/sda1 rw,data=ordered
-+2:+0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:+15 - squashfs /dev/loop0 ro
+-1:-4 /etc /etc rw,relatime master:-6 - ext4 /dev/sda1 rw
++2:+0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:+14 - squashfs /dev/loop0 ro
 +0:+0 /etc/ssl /etc/ssl ro,nodev,relatime master:+0 - squashfs /dev/loop0 ro
--2:+0 /home /home rw,relatime master:-15 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /lib/modules /lib/modules rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+-2:+0 /home /home rw,relatime master:-14 - ext4 /dev/sda1 rw
++0:+0 /lib/firmware /lib/firmware rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /lib/modules /lib/modules rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw
++0:+0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw
 +1:+5 / /proc rw,nosuid,nodev,noexec,relatime master:+7 - proc proc rw
 +0:+1 / /proc/fs/nfsd rw,relatime master:+1 - nfsd nfsd rw
-+0:+1 / /proc/sys/fs/binfmt_misc rw,relatime master:+1 - binfmt_misc binfmt_misc rw
 +0:+1 / /proc/sys/fs/binfmt_misc rw,relatime master:+1 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
--1:-8 /root /root rw,relatime master:-10 - ext4 /dev/sda1 rw,data=ordered
-+1:+9 / /run rw,nosuid,noexec,relatime master:+11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+-1:-7 /root /root rw,relatime master:-9 - ext4 /dev/sda1 rw
++1:+8 / /run rw,nosuid,noexec,relatime master:+10 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
-+0:-1 /netns /run/netns rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+2 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
++0:-1 /netns /run/netns rw,nosuid,noexec,relatime shared:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
++0:+2 / /run/rpc_pipefs rw,relatime master:13 - rpc_pipefs sunrpc rw
 +0:-2 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+3 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
--1:-12 /snap /snap rw,relatime master:-14 - ext4 /dev/sda1 rw,data=ordered
-+2:+0 / /snap/core/1 ro,nodev,relatime master:+15 - squashfs /dev/loop0 ro
++0:+3 / /run/user/0 rw,nosuid,nodev,relatime master:14 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+-1:-11 /snap /snap rw,relatime master:-13 - ext4 /dev/sda1 rw
++2:+0 / /snap/core/1 ro,nodev,relatime master:+14 - squashfs /dev/loop0 ro
 +0:+1 / /snap/core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop1 ro
 +0:+1 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:+1 - squashfs /dev/loop2 ro
 +0:+1 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:+1 - squashfs /dev/loop3 ro
 +0:+1 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop4 ro
--1:+9 / /sys rw,nosuid,nodev,noexec,relatime master:+1 - sysfs sysfs rw
+-1:+8 / /sys rw,nosuid,nodev,noexec,relatime master:+1 - sysfs sysfs rw
++0:+1 / /sys/firmware/efi/efivars rw,nosuid,nodev,noexec,relatime master:+1 - efivarfs efivarfs rw
 +0:+1 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:+1 - tmpfs tmpfs ro,mode=755
 +0:+1 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:+1 - cgroup cgroup rw,blkio
 +0:+1 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:+1 - cgroup cgroup rw,cpu,cpuacct
@@ -50,27 +51,27 @@
 +0:+1 / /sys/kernel/config rw,relatime master:+1 - configfs configfs rw
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
--1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
+-1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw
++0:+0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
 +1:+34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-+1:-34 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
++1:-34 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:15 - squashfs /dev/loop0 ro
 -1:+35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
--1:-35 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/dhcp /var/lib/dhcp rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 / /var/lib/snapd/hostfs rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
+-1:-35 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw
++0:+0 /var/lib/dhcp /var/lib/dhcp rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 / /var/lib/snapd/hostfs rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw
 +0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-+1:+8 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+10 - tmpfs tmpfs rw,size=VARIABLE,mode=755
++1:+7 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+9 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:+1 - rpc_pipefs sunrpc rw
 +0:-2 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+3 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-+1:-12 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:+1 - squashfs /dev/loop0 ro
++0:+3 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:14 - tmpfs tmpfs rw,size=VARIABLE,mode=700
++1:-11 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:+1 - squashfs /dev/loop0 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop1 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:+1 - squashfs /dev/loop2 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:+1 - squashfs /dev/loop3 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop4 ro
--2:-4 /var/log /var/log rw,relatime master:-19 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/snap /var/snap rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/tmp /var/tmp rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
+-2:-4 /var/log /var/log rw,relatime master:-18 - ext4 /dev/sda1 rw
++0:+0 /var/snap /var/snap rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/tmp /var/tmp rw,relatime master:+0 - ext4 /dev/sda1 rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
@@ -1,36 +1,37 @@
-2:1 / / ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
--1:-1 / /dev rw,nosuid,relatime master:-14 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / / ro,nodev,relatime master:16 - squashfs /dev/loop1 ro
+-1:-1 / /dev rw,nosuid,relatime master:-13 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime master:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
 +0:+1 / /dev/mqueue rw,relatime master:+1 - mqueue mqueue rw
 +0:+31 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
 +0:-30 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
 +0:+30 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
 +0:-29 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
--1:-4 /etc /etc rw,relatime master:-6 - ext4 /dev/sda1 rw,data=ordered
-+2:+1 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:+16 - squashfs /dev/loop1 ro
+-1:-4 /etc /etc rw,relatime master:-6 - ext4 /dev/sda1 rw
++2:+1 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:+15 - squashfs /dev/loop1 ro
 +0:+0 /etc/ssl /etc/ssl ro,nodev,relatime master:+0 - squashfs /dev/loop1 ro
--2:-1 /home /home rw,relatime master:-16 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /lib/modules /lib/modules rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+-2:-1 /home /home rw,relatime master:-15 - ext4 /dev/sda1 rw
++0:+0 /lib/firmware /lib/firmware rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /lib/modules /lib/modules rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw
++0:+0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw
 +1:+5 / /proc rw,nosuid,nodev,noexec,relatime master:+7 - proc proc rw
 +0:+1 / /proc/fs/nfsd rw,relatime master:+1 - nfsd nfsd rw
-+0:+1 / /proc/sys/fs/binfmt_misc rw,relatime master:+1 - binfmt_misc binfmt_misc rw
 +0:+1 / /proc/sys/fs/binfmt_misc rw,relatime master:+1 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
--1:-8 /root /root rw,relatime master:-10 - ext4 /dev/sda1 rw,data=ordered
-+1:+9 / /run rw,nosuid,noexec,relatime master:+11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+-1:-7 /root /root rw,relatime master:-9 - ext4 /dev/sda1 rw
++1:+8 / /run rw,nosuid,noexec,relatime master:+10 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
-+0:-1 /netns /run/netns rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+2 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
++0:-1 /netns /run/netns rw,nosuid,noexec,relatime shared:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
++0:+2 / /run/rpc_pipefs rw,relatime master:13 - rpc_pipefs sunrpc rw
 +0:-2 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+3 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
--1:-12 /snap /snap rw,relatime master:-14 - ext4 /dev/sda1 rw,data=ordered
-+2:+0 / /snap/core/1 ro,nodev,relatime master:+15 - squashfs /dev/loop0 ro
++0:+3 / /run/user/0 rw,nosuid,nodev,relatime master:14 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+-1:-11 /snap /snap rw,relatime master:-13 - ext4 /dev/sda1 rw
++2:+0 / /snap/core/1 ro,nodev,relatime master:+14 - squashfs /dev/loop0 ro
 +0:+1 / /snap/core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop1 ro
 +0:+1 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:+1 - squashfs /dev/loop2 ro
 +0:+1 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:+1 - squashfs /dev/loop3 ro
 +0:+1 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop4 ro
--1:+9 / /sys rw,nosuid,nodev,noexec,relatime master:+1 - sysfs sysfs rw
+-1:+8 / /sys rw,nosuid,nodev,noexec,relatime master:+1 - sysfs sysfs rw
++0:+1 / /sys/firmware/efi/efivars rw,nosuid,nodev,noexec,relatime master:+1 - efivarfs efivarfs rw
 +0:+1 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:+1 - tmpfs tmpfs ro,mode=755
 +0:+1 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:+1 - cgroup cgroup rw,blkio
 +0:+1 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:+1 - cgroup cgroup rw,cpu,cpuacct
@@ -50,28 +51,28 @@
 +0:+1 / /sys/kernel/config rw,relatime master:+1 - configfs configfs rw
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
--1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-+2:+0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+-1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw
++0:+0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
++2:+0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:15 - squashfs /dev/loop0 ro
 -1:+34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-+1:-33 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
++1:-33 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop1 ro
 -1:+34 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
--1:-35 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/dhcp /var/lib/dhcp rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 / /var/lib/snapd/hostfs rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
+-1:-35 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw
++0:+0 /var/lib/dhcp /var/lib/dhcp rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 / /var/lib/snapd/hostfs rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw
 +0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-+1:+8 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+10 - tmpfs tmpfs rw,size=VARIABLE,mode=755
++1:+7 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+9 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:+1 - rpc_pipefs sunrpc rw
 +0:-2 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+3 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-+1:-12 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:+1 - squashfs /dev/loop0 ro
++0:+3 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:14 - tmpfs tmpfs rw,size=VARIABLE,mode=700
++1:-11 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:+1 - squashfs /dev/loop0 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop1 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:+1 - squashfs /dev/loop2 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:+1 - squashfs /dev/loop3 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop4 ro
--2:-4 /var/log /var/log rw,relatime master:-19 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/snap /var/snap rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/tmp /var/tmp rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
+-2:-4 /var/log /var/log rw,relatime master:-18 - ext4 /dev/sda1 rw
++0:+0 /var/snap /var/snap rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/tmp /var/tmp rw,relatime master:+0 - ext4 /dev/sda1 rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-C7.expected.txt
@@ -1,4 +1,4 @@
-0:0 / / rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
 +0:+1 / /boot/efi rw,relatime shared:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:-1 / /dev rw,nosuid,relatime shared:+1 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime shared:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
@@ -7,18 +7,18 @@
 +0:+1 / /dev/shm rw,nosuid,nodev shared:+1 - tmpfs tmpfs rw
 +0:+1 / /proc rw,nosuid,nodev,noexec,relatime shared:+1 - proc proc rw
 +0:+1 / /proc/fs/nfsd rw,relatime shared:+1 - nfsd nfsd rw
-+0:+1 / /proc/sys/fs/binfmt_misc rw,relatime shared:+1 - binfmt_misc binfmt_misc rw
 +0:+1 / /proc/sys/fs/binfmt_misc rw,relatime shared:+1 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
 +0:+1 / /run rw,nosuid,noexec,relatime shared:+1 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /run/lock rw,nosuid,nodev,noexec,relatime shared:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /run/rpc_pipefs rw,relatime shared:+1 - rpc_pipefs sunrpc rw
 +0:+1 / /run/user/0 rw,nosuid,nodev,relatime shared:+1 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-+1:-12 / /snap/core/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop0 ro
++1:-11 / /snap/core/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop0 ro
 +0:+1 / /snap/core18/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop1 ro
 +0:+1 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop2 ro
 +0:+1 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop3 ro
 +0:+1 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop4 ro
--1:+9 / /sys rw,nosuid,nodev,noexec,relatime shared:+1 - sysfs sysfs rw
+-1:+8 / /sys rw,nosuid,nodev,noexec,relatime shared:+1 - sysfs sysfs rw
++0:+1 / /sys/firmware/efi/efivars rw,nosuid,nodev,noexec,relatime shared:+1 - efivarfs efivarfs rw
 +0:+1 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:+1 - tmpfs tmpfs ro,mode=755
 +0:+1 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:+1 - cgroup cgroup rw,blkio
 +0:+1 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:+1 - cgroup cgroup rw,cpu,cpuacct

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
@@ -1,36 +1,37 @@
-2:0 / / ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
--1:+0 / /dev rw,nosuid,relatime master:-13 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:0 / / ro,nodev,relatime master:15 - squashfs /dev/loop0 ro
+-1:+0 / /dev rw,nosuid,relatime master:-12 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime master:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
 +0:+1 / /dev/mqueue rw,relatime master:+1 - mqueue mqueue rw
 +0:+31 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
 +0:-30 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
 +0:+30 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
 +0:-29 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
--1:-4 /etc /etc rw,relatime master:-6 - ext4 /dev/sda1 rw,data=ordered
-+2:+0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:+15 - squashfs /dev/loop0 ro
+-1:-4 /etc /etc rw,relatime master:-6 - ext4 /dev/sda1 rw
++2:+0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:+14 - squashfs /dev/loop0 ro
 +0:+0 /etc/ssl /etc/ssl ro,nodev,relatime master:+0 - squashfs /dev/loop0 ro
--2:+0 /home /home rw,relatime master:-15 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /lib/modules /lib/modules rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+-2:+0 /home /home rw,relatime master:-14 - ext4 /dev/sda1 rw
++0:+0 /lib/firmware /lib/firmware rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /lib/modules /lib/modules rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw
++0:+0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw
 +1:+5 / /proc rw,nosuid,nodev,noexec,relatime master:+7 - proc proc rw
 +0:+1 / /proc/fs/nfsd rw,relatime master:+1 - nfsd nfsd rw
-+0:+1 / /proc/sys/fs/binfmt_misc rw,relatime master:+1 - binfmt_misc binfmt_misc rw
 +0:+1 / /proc/sys/fs/binfmt_misc rw,relatime master:+1 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
--1:-8 /root /root rw,relatime master:-10 - ext4 /dev/sda1 rw,data=ordered
-+1:+9 / /run rw,nosuid,noexec,relatime master:+11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+-1:-7 /root /root rw,relatime master:-9 - ext4 /dev/sda1 rw
++1:+8 / /run rw,nosuid,noexec,relatime master:+10 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
-+0:-1 /netns /run/netns rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+2 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
++0:-1 /netns /run/netns rw,nosuid,noexec,relatime shared:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
++0:+2 / /run/rpc_pipefs rw,relatime master:13 - rpc_pipefs sunrpc rw
 +0:-2 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+3 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
--1:-12 /snap /snap rw,relatime master:-14 - ext4 /dev/sda1 rw,data=ordered
-+2:+0 / /snap/core/1 ro,nodev,relatime master:+15 - squashfs /dev/loop0 ro
++0:+3 / /run/user/0 rw,nosuid,nodev,relatime master:14 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+-1:-11 /snap /snap rw,relatime master:-13 - ext4 /dev/sda1 rw
++2:+0 / /snap/core/1 ro,nodev,relatime master:+14 - squashfs /dev/loop0 ro
 +0:+1 / /snap/core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop1 ro
 +0:+1 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:+1 - squashfs /dev/loop2 ro
 +0:+1 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:+1 - squashfs /dev/loop3 ro
 +0:+1 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop4 ro
--1:+9 / /sys rw,nosuid,nodev,noexec,relatime master:+1 - sysfs sysfs rw
+-1:+8 / /sys rw,nosuid,nodev,noexec,relatime master:+1 - sysfs sysfs rw
++0:+1 / /sys/firmware/efi/efivars rw,nosuid,nodev,noexec,relatime master:+1 - efivarfs efivarfs rw
 +0:+1 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:+1 - tmpfs tmpfs ro,mode=755
 +0:+1 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:+1 - cgroup cgroup rw,blkio
 +0:+1 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:+1 - cgroup cgroup rw,cpu,cpuacct
@@ -50,27 +51,27 @@
 +0:+1 / /sys/kernel/config rw,relatime master:+1 - configfs configfs rw
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
--1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
+-1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw
++0:+0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
 +1:+34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-+1:-34 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
++1:-34 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:15 - squashfs /dev/loop0 ro
 -1:+35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
--1:-35 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/dhcp /var/lib/dhcp rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-+0:+0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+-1:-35 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw
++0:+0 /var/lib/dhcp /var/lib/dhcp rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw
++0:+0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw
 +0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-+1:+8 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+10 - tmpfs tmpfs rw,size=VARIABLE,mode=755
++1:+7 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+9 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:+1 - rpc_pipefs sunrpc rw
 +0:-2 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+3 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-+1:-12 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:+1 - squashfs /dev/loop0 ro
++0:+3 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:14 - tmpfs tmpfs rw,size=VARIABLE,mode=700
++1:-11 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:+1 - squashfs /dev/loop0 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop1 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:+1 - squashfs /dev/loop2 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:+1 - squashfs /dev/loop3 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop4 ro
--2:-4 /var/log /var/log rw,relatime master:-19 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/snap /var/snap rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/tmp /var/tmp rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
+-2:-4 /var/log /var/log rw,relatime master:-18 - ext4 /dev/sda1 rw
++0:+0 /var/snap /var/snap rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/tmp /var/tmp rw,relatime master:+0 - ext4 /dev/sda1 rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
@@ -1,36 +1,37 @@
-2:1 / / ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
--1:-1 / /dev rw,nosuid,relatime master:-14 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / / ro,nodev,relatime master:16 - squashfs /dev/loop1 ro
+-1:-1 / /dev rw,nosuid,relatime master:-13 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime master:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
 +0:+1 / /dev/mqueue rw,relatime master:+1 - mqueue mqueue rw
 +0:+31 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
 +0:-30 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
 +0:+30 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
 +0:-29 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
--1:-4 /etc /etc rw,relatime master:-6 - ext4 /dev/sda1 rw,data=ordered
-+2:+1 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:+16 - squashfs /dev/loop1 ro
+-1:-4 /etc /etc rw,relatime master:-6 - ext4 /dev/sda1 rw
++2:+1 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:+15 - squashfs /dev/loop1 ro
 +0:+0 /etc/ssl /etc/ssl ro,nodev,relatime master:+0 - squashfs /dev/loop1 ro
--2:-1 /home /home rw,relatime master:-16 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /lib/modules /lib/modules rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+-2:-1 /home /home rw,relatime master:-15 - ext4 /dev/sda1 rw
++0:+0 /lib/firmware /lib/firmware rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /lib/modules /lib/modules rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw
++0:+0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw
 +1:+5 / /proc rw,nosuid,nodev,noexec,relatime master:+7 - proc proc rw
 +0:+1 / /proc/fs/nfsd rw,relatime master:+1 - nfsd nfsd rw
-+0:+1 / /proc/sys/fs/binfmt_misc rw,relatime master:+1 - binfmt_misc binfmt_misc rw
 +0:+1 / /proc/sys/fs/binfmt_misc rw,relatime master:+1 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
--1:-8 /root /root rw,relatime master:-10 - ext4 /dev/sda1 rw,data=ordered
-+1:+9 / /run rw,nosuid,noexec,relatime master:+11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+-1:-7 /root /root rw,relatime master:-9 - ext4 /dev/sda1 rw
++1:+8 / /run rw,nosuid,noexec,relatime master:+10 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
-+0:-1 /netns /run/netns rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+2 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
++0:-1 /netns /run/netns rw,nosuid,noexec,relatime shared:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
++0:+2 / /run/rpc_pipefs rw,relatime master:13 - rpc_pipefs sunrpc rw
 +0:-2 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+3 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
--1:-12 /snap /snap rw,relatime master:-14 - ext4 /dev/sda1 rw,data=ordered
-+2:+0 / /snap/core/1 ro,nodev,relatime master:+15 - squashfs /dev/loop0 ro
++0:+3 / /run/user/0 rw,nosuid,nodev,relatime master:14 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+-1:-11 /snap /snap rw,relatime master:-13 - ext4 /dev/sda1 rw
++2:+0 / /snap/core/1 ro,nodev,relatime master:+14 - squashfs /dev/loop0 ro
 +0:+1 / /snap/core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop1 ro
 +0:+1 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:+1 - squashfs /dev/loop2 ro
 +0:+1 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:+1 - squashfs /dev/loop3 ro
 +0:+1 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop4 ro
--1:+9 / /sys rw,nosuid,nodev,noexec,relatime master:+1 - sysfs sysfs rw
+-1:+8 / /sys rw,nosuid,nodev,noexec,relatime master:+1 - sysfs sysfs rw
++0:+1 / /sys/firmware/efi/efivars rw,nosuid,nodev,noexec,relatime master:+1 - efivarfs efivarfs rw
 +0:+1 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:+1 - tmpfs tmpfs ro,mode=755
 +0:+1 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:+1 - cgroup cgroup rw,blkio
 +0:+1 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:+1 - cgroup cgroup rw,cpu,cpuacct
@@ -50,28 +51,28 @@
 +0:+1 / /sys/kernel/config rw,relatime master:+1 - configfs configfs rw
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
--1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-+2:+0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+-1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw
++0:+0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
++2:+0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:15 - squashfs /dev/loop0 ro
 -1:+34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-+1:-33 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
++1:-33 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop1 ro
 -1:+34 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
--1:-35 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/dhcp /var/lib/dhcp rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-+0:+0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+-1:-35 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw
++0:+0 /var/lib/dhcp /var/lib/dhcp rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw
++0:+0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw
 +0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-+1:+8 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+10 - tmpfs tmpfs rw,size=VARIABLE,mode=755
++1:+7 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+9 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:+1 - rpc_pipefs sunrpc rw
 +0:-2 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-+0:+3 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-+1:-12 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:+1 - squashfs /dev/loop0 ro
++0:+3 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:14 - tmpfs tmpfs rw,size=VARIABLE,mode=700
++1:-11 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:+1 - squashfs /dev/loop0 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop1 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:+1 - squashfs /dev/loop2 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:+1 - squashfs /dev/loop3 ro
 +0:+1 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:+1 - squashfs /dev/loop4 ro
--2:-4 /var/log /var/log rw,relatime master:-19 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/snap /var/snap rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /var/tmp /var/tmp rw,relatime master:+0 - ext4 /dev/sda1 rw,data=ordered
+-2:-4 /var/log /var/log rw,relatime master:-18 - ext4 /dev/sda1 rw
++0:+0 /var/snap /var/snap rw,relatime master:+0 - ext4 /dev/sda1 rw
++0:+0 /var/tmp /var/tmp rw,relatime master:+0 - ext4 /dev/sda1 rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-C7.expected.txt
@@ -1,4 +1,4 @@
-0:0 / / rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
 +0:+1 / /boot/efi rw,relatime shared:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:-1 / /dev rw,nosuid,relatime shared:+1 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime shared:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
@@ -7,18 +7,18 @@
 +0:+1 / /dev/shm rw,nosuid,nodev shared:+1 - tmpfs tmpfs rw
 +0:+1 / /proc rw,nosuid,nodev,noexec,relatime shared:+1 - proc proc rw
 +0:+1 / /proc/fs/nfsd rw,relatime shared:+1 - nfsd nfsd rw
-+0:+1 / /proc/sys/fs/binfmt_misc rw,relatime shared:+1 - binfmt_misc binfmt_misc rw
 +0:+1 / /proc/sys/fs/binfmt_misc rw,relatime shared:+1 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
 +0:+1 / /run rw,nosuid,noexec,relatime shared:+1 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /run/lock rw,nosuid,nodev,noexec,relatime shared:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /run/rpc_pipefs rw,relatime shared:+1 - rpc_pipefs sunrpc rw
 +0:+1 / /run/user/0 rw,nosuid,nodev,relatime shared:+1 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-+1:-12 / /snap/core/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop0 ro
++1:-11 / /snap/core/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop0 ro
 +0:+1 / /snap/core18/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop1 ro
 +0:+1 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop2 ro
 +0:+1 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop3 ro
 +0:+1 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:+1 - squashfs /dev/loop4 ro
--1:+9 / /sys rw,nosuid,nodev,noexec,relatime shared:+1 - sysfs sysfs rw
+-1:+8 / /sys rw,nosuid,nodev,noexec,relatime shared:+1 - sysfs sysfs rw
++0:+1 / /sys/firmware/efi/efivars rw,nosuid,nodev,noexec,relatime shared:+1 - efivarfs efivarfs rw
 +0:+1 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:+1 - tmpfs tmpfs ro,mode=755
 +0:+1 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:+1 - cgroup cgroup rw,blkio
 +0:+1 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:+1 - cgroup cgroup rw,cpu,cpuacct

--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -11,7 +11,6 @@ systems: [ubuntu-18.04-64]
 # The test is sensitive to backend type, which designates the used image.
 # Backends are enabled one-by-one along with the matching data set.
 backends: [google]
-manual: true
 details: |
     This test measures the mount table of the host, of the mount namespace for
     a simple core16-based snap for the per-user mount namespace of a simple


### PR DESCRIPTION
Our latest Bionic image is using UEFI boot mode, and this introduces
the new mount point: /sys/firmware/efi/efivars, as expected.

Some unexpected delta is present as well:
 - the root filesystem is no longer mounted with "data=ordered"
 - binfmt_misc is no longer mounted, it's only auto-mounted

I suspect those two changes are related to a systemd update but since
they look totally harmless, I did not investigate this in more detail.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>