### PR TITLE
cmd/snap-bootstrap/partition: add Disk, methods to cross-check mountpounts

### DIFF
--- a/cmd/snap-bootstrap/partition/disks.go
+++ b/cmd/snap-bootstrap/partition/disks.go
@@ -1,0 +1,499 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package partition
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+var (
+	diskFromMountPoint = diskFromMountPointImplWrapper
+	mockedMountPoints  = make(map[string]*mockDisk)
+	isSnapdTest        = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test")
+
+	luksUUIDPatternRe = regexp.MustCompile(`(?m)CRYPT-LUKS2-([0-9a-f]{32})`)
+
+	totalMockedDisks = 0
+)
+
+// Options is a set of options used when querying information about
+// partition and disk devices.
+type Options struct {
+	IsDecryptedDevice bool
+}
+
+// Disk is a single physical disk device that contains partitions.
+type Disk interface {
+	// FindMatchingPartitionUUID finds the partition uuid for a partition matching
+	// the specified label on the disk. Note that for non-ascii labels like
+	// "Some label", the label should be encoded using \x<hex> for potentially
+	// non-safe characters like in "Some\x20Label".
+	FindMatchingPartitionUUID(string) (string, error)
+
+	// MountPointIsFromDisk returns whether the specified mountpoint corresponds
+	// to a partition on the disk.
+	MountPointIsFromDisk(string, *Options) (bool, error)
+
+	// String returns a representation of the disk that may not be unique, it
+	// is meant for testing/debugging.
+	String() string
+}
+
+type partition struct {
+	major    int
+	minor    int
+	label    string
+	partuuid string
+	path     string
+}
+
+type disk struct {
+	major      int
+	minor      int
+	partitions []*partition
+}
+
+func parseDeviceMajorMinor(s string) (int, int, error) {
+	errMsg := fmt.Errorf("invalid device number format: (expected <int>:<int>)")
+	devNums := strings.SplitN(s, ":", 2)
+	if len(devNums) != 2 {
+		return 0, 0, errMsg
+	}
+	maj, err := strconv.Atoi(devNums[0])
+	if err != nil {
+		return 0, 0, errMsg
+	}
+	min, err := strconv.Atoi(devNums[1])
+	if err != nil {
+		return 0, 0, errMsg
+	}
+	return maj, min, nil
+}
+
+var udevProperties = func(device string) (map[string]string, error) {
+	// now we have the partition for this mountpoint, we need to tie that back
+	// to a disk with a major minor, so query udev with the mount source path
+	// of the mountpoint for properties
+	cmd := exec.Command("udevadm", "info", "--name", device, "--query", "property")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, osutil.OutputErr(out, err)
+	}
+	r := bytes.NewBuffer(out)
+
+	return parseUdevProperties(r)
+}
+
+func parseUdevProperties(r io.Reader) (map[string]string, error) {
+	m := make(map[string]string)
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		strs := strings.SplitN(scanner.Text(), "=", 2)
+		if len(strs) != 2 {
+			// bad udev output?
+			continue
+		}
+		m[strs[0]] = strs[1]
+	}
+
+	return m, scanner.Err()
+}
+
+// DiskFromMountPoint finds a matching Disk for the specified mount point.
+func DiskFromMountPoint(mountpoint string, opts *Options) (Disk, error) {
+	// call the unexported version that may be mocked by tests
+	return diskFromMountPoint(mountpoint, opts)
+}
+
+// the wrapper function just calls the implementation, but has the right
+// signature that returns a Disk, such that diskFromMountPointImplWrapper can
+// be assigned to diskFromMountPoint
+// the main reason we do this is so that we can call diskFromMountPointImpl from
+// other functions without type casting anything
+func diskFromMountPointImplWrapper(mountpoint string, opts *Options) (Disk, error) {
+	return diskFromMountPointImpl(mountpoint, opts)
+}
+
+func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
+	// first get the mount entry for the mountpoint
+	mounts, err := osutil.LoadMountInfo()
+	if err != nil {
+		return nil, err
+	}
+	found := false
+	d := &disk{}
+	mountpointPart := partition{}
+	for _, mount := range mounts {
+		if mount.MountDir == mountpoint {
+			mountpointPart.major = mount.DevMajor
+			mountpointPart.minor = mount.DevMinor
+			mountpointPart.path = mount.MountSource
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("cannot find mountpoint %q", mountpoint)
+	}
+
+	majorMinor := fmt.Sprintf("%d:%d", mountpointPart.major, mountpointPart.minor)
+
+	if opts != nil && opts.IsDecryptedDevice {
+		// if the device is an decrypted device, the partition we got will be a
+		// virtual partition and a dm device, so we need to map that back to the
+		// actual encrypted physical partition, then find the disk for that
+		// partition
+
+		// first we use the major minor for the mount point we got and verify
+		// that there is a "dm" subdir in the sysfs dev/block entry for the disk
+		// and in the dm subdir there are "uuid" and "name" files as we need
+		// those to properly match the partition id contained in the dm uuid
+
+		dmNameFile := filepath.Join(dirs.SysfsDir, "dev/block/", majorMinor, "dm/name")
+		dmName, err := ioutil.ReadFile(dmNameFile)
+		if err != nil && os.IsNotExist(err) {
+			// not a dm device
+			return nil, fmt.Errorf("disk %s is not a decrypted device", majorMinor)
+		} else if err != nil {
+			return nil, fmt.Errorf("cannot read dm name for disk %s: %v", majorMinor, err)
+		}
+
+		dmUUIDFile := filepath.Join(dirs.SysfsDir, "dev/block/", majorMinor, "dm/uuid")
+		dmUUID, err := ioutil.ReadFile(dmUUIDFile)
+		if err != nil && os.IsNotExist(err) {
+			// not a dm device
+			return nil, fmt.Errorf("disk %s is not a decrypted device", majorMinor)
+		} else if err != nil {
+			return nil, fmt.Errorf("cannot read dm uuid for disk %s: %v", majorMinor, err)
+		}
+
+		// trim the suffix of the dm name from the dm uuid to safely match the
+		// regex - the dm uuid contains the dm name, and the dm name is user
+		// controlled, so we want to remove that and just use the luks pattern
+		// to match the device uuid
+		// we are extra safe here since the dm name could be hypothetically user
+		// controlled via an external USB disk with LVM partition names, etc.
+		dmUUIDSafe := bytes.TrimSuffix(
+			bytes.TrimSpace(dmUUID),
+			append([]byte("-"), bytes.TrimSpace(dmName)...),
+		)
+		matches := luksUUIDPatternRe.FindSubmatch(dmUUIDSafe)
+		if len(matches) != 2 {
+			// the format of the uuid is different - new luks version maybe?
+			return nil, fmt.Errorf(
+				"cannot verify disk: partition %s does not have a valid luks uuid format",
+				majorMinor,
+			)
+		}
+
+		// the uuid is the first and only submatch, but it is not in the same
+		// format exactly as we want to use, namely it is missing all of the "-"
+		// characters in a typical uuid, i.e. it is of the form:
+		// ae6e79de00a9406f80ee64ba7c1966bb but we want it to be like:
+		// ae6e79de-00a9-406f-80ee-64ba7c1966bb so we need to add in 4 "-"
+		// characters
+		fullUUID := string(matches[1])
+		realUUID := fmt.Sprintf(
+			"%s-%s-%s-%s-%s",
+			fullUUID[0:8],
+			fullUUID[8:12],
+			fullUUID[12:16],
+			fullUUID[16:20],
+			fullUUID[20:],
+		)
+
+		// now finally, we need to use this uuid, which is the device uuid of
+		// the actual physical encrypted partition to get the path, which will
+		// be something like /dev/vda4, etc.
+		props, err := udevProperties(filepath.Join("/dev/disk/by-uuid", realUUID))
+		if err != nil {
+			return nil, fmt.Errorf("cannot verify partition with uuid %s: %v", realUUID, err)
+		}
+
+		path, ok := props["DEVNAME"]
+		if !ok {
+			return nil, fmt.Errorf("cannot verify partition with uuid %s: incomplete udev information", realUUID)
+		}
+
+		// save it in the mountpointPart for the rest of the function to operate
+		// normally on
+		mountpointPart.path = path
+	}
+
+	// now we have the partition for this mountpoint, we need to tie that back
+	// to a disk with a major minor, so query udev with the mount source path
+	// of the mountpoint for properties
+	props, err := udevProperties(mountpointPart.path)
+	if err != nil && props == nil {
+		// only fail here if props is nil, if it's available we validate it
+		// below
+		return nil, fmt.Errorf("cannot find disk for partition %s: %v", mountpointPart.path, err)
+	}
+
+	// ID_PART_ENTRY_DISK will give us the major and minor of the disk that this
+	// partition originated from
+	if majorMinor, ok := props["ID_PART_ENTRY_DISK"]; ok {
+		maj, min, err := parseDeviceMajorMinor(majorMinor)
+		if err != nil {
+			// bad udev output?
+			return nil, fmt.Errorf("cannot find disk for partition %s, bad udev output: %v", mountpointPart.path, err)
+		}
+		d.major = maj
+		d.minor = min
+	} else {
+		// didn't find the property we need
+		return nil, fmt.Errorf("cannot find disk for partition %s, incomplete udev output", mountpointPart.path)
+	}
+
+	// now we have the major and minor of the disk, and thus now have the
+	// arduous task to identify all partitions that come from this disk using
+	// sysfs
+	// step 1. find all devices with a matching major number
+	// step 2. start at the major + minor device for the disk, and iterate over
+	//         all devices that have a partition attribute, starting with the
+	//         device with major same as disk and minor equal to disk minor + 1
+	// step 3. if we hit a device that does not have a partition attribute, then
+	//         we hit another disk, and shall stop searching
+
+	// TODO: are there devices that have structures on them that show up as
+	//       contiguous devices but are _not_ partitions, i.e. some littlekernel
+	//       devices?
+
+	pattern := fmt.Sprintf("%s/dev/block/%d:*", dirs.SysfsDir, d.major)
+	allDevices, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: %v", err)
+	}
+
+	// glob does not guarantee a sort, but we need our list of devices sorted
+	sort.Strings(allDevices)
+
+	// populate all the partitions from our candidate devices
+	for _, dev := range allDevices {
+		base := filepath.Base(dev)
+		maj, min, err := parseDeviceMajorMinor(base)
+		if err != nil {
+			continue
+		}
+
+		// ignore any devices that have minor numbers less than the disk itself
+		// the disk will have the same minor so ignore that too
+		if min <= d.minor {
+			continue
+		}
+
+		// now if there is a partition file, this is a partition for our disk
+		if osutil.FileExists(filepath.Join(dev, "partition")) {
+			// read the uevent file for this partition to get the devname
+			p := &partition{
+				major: maj,
+				minor: min,
+			}
+			f, err := os.Open(filepath.Join(dev, "uevent"))
+			if err != nil {
+				continue
+			}
+
+			// now get the full set of udev properties for this partition
+			eventProps, err := parseUdevProperties(f)
+			if err != nil {
+				continue
+			}
+
+			// get the name of the device path to call udevadm
+			// note that here DEVNAME is coming from sysfs's uevent, and for
+			// whatever reason it is just the basename a la vda3, but DEVNAME
+			// when  requested from udevadm proper is the full path a la
+			// /dev/vda3
+			if name, ok := eventProps["DEVNAME"]; ok {
+				p.path = filepath.Join("/dev", name)
+			} else {
+				continue
+			}
+
+			props, err := udevProperties(p.path)
+			if err != nil && props == nil {
+				// only error here if we didn't get a map, we validate the map
+				// in the next steps
+				continue
+			}
+
+			// get the label
+			if labelEncoded, ok := props["ID_FS_LABEL_ENC"]; ok {
+				p.label = labelEncoded
+			} else {
+				continue
+			}
+
+			// finally get the partition uuid
+			if partuuid, ok := props["ID_PART_ENTRY_UUID"]; ok {
+				p.partuuid = partuuid
+			} else {
+				continue
+			}
+
+			d.partitions = append(d.partitions, p)
+		} else {
+			// if there was not a partition file, we hit another disk and must
+			// stop searching (the disk we are looking at will be ignored with
+			// the minor number <= check above)
+			break
+		}
+	}
+
+	// if we didn't find any partitions from above then return an error
+	if len(d.partitions) == 0 {
+		return nil, fmt.Errorf("no partitions found for disk %s", majorMinor)
+	}
+
+	return d, nil
+}
+
+func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
+	// iterate over the partitions looking for the specified label
+	for _, part := range d.partitions {
+		if part.label == label {
+			return part.partuuid, nil
+		}
+	}
+
+	return "", fmt.Errorf("couldn't find label %q", label)
+}
+
+func (d *disk) MountPointIsFromDisk(mountpoint string, opts *Options) (bool, error) {
+	d2, err := diskFromMountPointImpl(mountpoint, opts)
+	if err != nil {
+		return false, err
+	}
+
+	// compare if the major/minor devices are the same
+	return d.major == d2.major && d.minor == d2.minor, nil
+}
+
+func (d *disk) String() string {
+	return fmt.Sprintf("%d:%d", d.major, d.minor)
+}
+
+// mockDisk is an implementation of Disk for mocking purposes, it is exported
+// so that other packages can easily mock a specific disk layout without
+// needing to mock the mount setup, sysfs, and udevadm commands just to test
+// high level logic.
+type mockDisk struct {
+	s                string
+	allMockedDisks   map[string]map[string]string
+	mountpoint       string
+	labelsToPartUUID map[string]string
+}
+
+func (d *mockDisk) FindMatchingPartitionUUID(label string) (string, error) {
+	return d.labelsToPartUUID[label], nil
+}
+
+func (d *mockDisk) MountPointIsFromDisk(mountpoint string, opts *Options) (bool, error) {
+	// TODO:UC20: support options here
+	if otherPartitionsDisk, ok := d.allMockedDisks[mountpoint]; ok {
+		// compare that the map of partitions between the two Disk's matches
+		// as that's the only unique info that would be included in mocked tests
+		for k, v := range d.labelsToPartUUID {
+			if v2, ok := otherPartitionsDisk[k]; !ok || v2 != v {
+				return false, nil
+			}
+		}
+		for k, v := range otherPartitionsDisk {
+			if v1, ok := d.labelsToPartUUID[k]; !ok || v1 != v {
+				return false, nil
+			}
+		}
+		return true, nil
+
+	}
+	return false, fmt.Errorf("mountpoint %s not mocked", mountpoint)
+}
+
+func (d *mockDisk) Equals(other Disk) bool {
+	switch d2 := other.(type) {
+	case *mockDisk:
+		// compare that the map of partitions between the two Disk's matches
+		// as that's the only unique info that would be included in mocked tests
+		for k, v := range d.labelsToPartUUID {
+			if v2, ok := d2.labelsToPartUUID[k]; !ok || v2 != v {
+				return false
+			}
+		}
+		for k, v := range d2.labelsToPartUUID {
+			if v1, ok := d.labelsToPartUUID[k]; !ok || v1 != v {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *mockDisk) String() string {
+	return d.s
+}
+
+// MockMountPointDisksToPartionMapping will mock DiskFromMountPoint such that
+// the specified mapping is returned/used. Specifically, keys in the provided
+// map are mountpoints, and the values for those keys are the partitions that
+// are used to identify the disk.
+func MockMountPointDisksToPartionMapping(mockedMountPoints map[string]map[string]string) (restore func()) {
+	// only to be used in tests!!!!
+	if !isSnapdTest {
+		panic("mocking functions only to be used in tests!")
+	}
+
+	old := diskFromMountPoint
+
+	mockedDiskNum := totalMockedDisks
+	totalMockedDisks++
+
+	diskFromMountPoint = func(mountpoint string, opts *Options) (Disk, error) {
+		// TODO:UC20: support options here
+		if partitions, ok := mockedMountPoints[mountpoint]; ok {
+			return &mockDisk{
+				s:                fmt.Sprintf("mocked-disk-%d", mockedDiskNum),
+				allMockedDisks:   mockedMountPoints, // for MountPointIsFromDisk
+				mountpoint:       mountpoint,
+				labelsToPartUUID: partitions,
+			}, nil
+		}
+		return nil, fmt.Errorf("mountpoint %s not mocked", mountpoint)
+	}
+	return func() {
+		diskFromMountPoint = old
+	}
+}

--- a/cmd/snap-bootstrap/partition/disks_test.go
+++ b/cmd/snap-bootstrap/partition/disks_test.go
@@ -1,0 +1,440 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package partition_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/cmd/snap-bootstrap/partition"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type diskSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&diskSuite{})
+
+func (s *diskSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+type partitionDevice struct {
+	majMin  string
+	devName string
+	symlink string
+}
+
+func makePart(majMin string, devName string) partitionDevice {
+	return partitionDevice{
+		majMin:  majMin,
+		devName: devName,
+	}
+}
+
+func makePartWithSym(majMin string, devName string, symlink string) partitionDevice {
+	return partitionDevice{
+		majMin:  majMin,
+		devName: devName,
+		symlink: symlink,
+	}
+}
+
+type mockSysfsUdevDisk struct {
+	diskMajMin string
+	partitions map[partitionDevice]map[string]string
+}
+
+// used to mock all the things in sysfs and udev that we need to identify/find
+// disks
+func mockSysfsUdevDiskLayout(c *C, disks ...mockSysfsUdevDisk) (restore func()) {
+
+	udevPropsMap := make(map[string]map[string]string)
+	for _, d := range disks {
+		// make a list of relevant dev numbers to mock inside /sys/dev/block
+		// devNums := []string{d.diskMajMin}
+
+		// major disk device first
+		err := os.MkdirAll(filepath.Join(dirs.SysfsDir, "dev/block", d.diskMajMin), 0755)
+		c.Assert(err, IsNil)
+
+		// make the partitions
+		for part, udevProps := range d.partitions {
+			dev := filepath.Join("/dev", part.devName)
+
+			// make major:minor dir
+			err := os.MkdirAll(filepath.Join(dirs.SysfsDir, "dev/block", part.majMin), 0755)
+			c.Assert(err, IsNil)
+
+			partitionFile := filepath.Join(dirs.SysfsDir, "dev/block", part.majMin, "partition")
+			// the data in the partition file is the partition number, but it
+			// doesn't really matter for our purposes, we just check for the
+			// partition file existence
+			err = ioutil.WriteFile(partitionFile, []byte("1"), 0644)
+			c.Assert(err, IsNil)
+
+			// finally make a uevent file for the partition too
+			// the only relevant udev props we use from uevent is DEVNAME, then
+			// we get the rest from udev directly
+			ueventFile := filepath.Join(dirs.SysfsDir, "dev/block", part.majMin, "uevent")
+			content := fmt.Sprintf("DEVNAME=%s", part.devName)
+			err = ioutil.WriteFile(ueventFile, []byte(content), 0644)
+			c.Assert(err, IsNil)
+
+			// also save this devname -> udev map props to put in the mocked
+			// udev props function at the end
+			udevPropsMap[dev] = udevProps
+
+			// always add the DEVNAME to the udev props, note that when
+			// requested from udevadm proper, DEVNAME is a full path, but when
+			// requested via sysfs uevent, it's just the basename
+			udevPropsMap[dev]["DEVNAME"] = dev
+
+			//always add the ID_PART_ENTRY_DISK property too which just
+			// back-references the major disk major:minor
+			udevPropsMap[dev]["ID_PART_ENTRY_DISK"] = d.diskMajMin
+
+			// if the partition has symlinks, add those too
+			if part.symlink != "" {
+				udevPropsMap["/dev/"+part.symlink] = udevPropsMap[dev]
+			}
+		}
+	}
+
+	// mock the udev properties function with all the devices we got with
+	// udev property maps
+	restore = partition.MockUdevPropertiesForDevice(func(dev string) (map[string]string, error) {
+		if devProps, ok := udevPropsMap[dev]; ok {
+			return devProps, nil
+		} else {
+			c.Logf("unexpected udev device properties requested: %s", dev)
+			c.Fail()
+			return nil, fmt.Errorf("unexpected udev device")
+		}
+	})
+
+	return restore
+}
+
+func (s *diskSuite) TestDiskFromMountPointUnhappyMissingMountpoint(c *C) {
+	// no mount points
+	restore := osutil.MockMountInfo(``)
+	defer restore()
+
+	_, err := partition.DiskFromMountPoint("/run/mnt/blah", nil)
+	c.Assert(err, ErrorMatches, "cannot find mountpoint \"/run/mnt/blah\"")
+}
+
+func (s *diskSuite) TestDiskFromMountPointUnhappyMissingUdevProps(c *C) {
+	restore := osutil.MockMountInfo(`130 30 42:1 / /run/mnt/point rw,relatime shared:54 - ext4 /dev/vda4 rw
+`)
+	defer restore()
+
+	restore = partition.MockUdevPropertiesForDevice(func(dev string) (map[string]string, error) {
+		c.Assert(dev, Equals, "/dev/vda4")
+		return map[string]string{
+			"prop": "hello",
+		}, nil
+	})
+	defer restore()
+
+	_, err := partition.DiskFromMountPoint("/run/mnt/point", nil)
+	c.Assert(err, ErrorMatches, "cannot find disk for partition /dev/vda4, incomplete udev output")
+}
+
+func (s *diskSuite) TestDiskFromMountPointUnhappyBadUdevPropsMountpointPartition(c *C) {
+	restore := osutil.MockMountInfo(`130 30 42:1 / /run/mnt/point rw,relatime shared:54 - ext4 /dev/vda4 rw
+`)
+	defer restore()
+
+	restore = partition.MockUdevPropertiesForDevice(func(dev string) (map[string]string, error) {
+		c.Assert(dev, Equals, "/dev/vda4")
+		return map[string]string{
+			"ID_PART_ENTRY_DISK": "not-a-number",
+		}, nil
+	})
+	defer restore()
+
+	_, err := partition.DiskFromMountPoint("/run/mnt/point", nil)
+	c.Assert(err, ErrorMatches, `cannot find disk for partition /dev/vda4, bad udev output: invalid device number format: \(expected <int>:<int>\)`)
+}
+
+func (s *diskSuite) TestDiskFromMountPointUnhappyNoPartitions(c *C) {
+	restore := osutil.MockMountInfo(`130 30 42:1 / /run/mnt/point rw,relatime shared:54 - ext4 /dev/vda4 rw
+`)
+	defer restore()
+
+	// mock just the partition's disk major minor in udev, but no actual
+	// partitions
+	restore = partition.MockUdevPropertiesForDevice(func(dev string) (map[string]string, error) {
+		switch dev {
+		case "/dev/vda4":
+			return map[string]string{
+				"ID_PART_ENTRY_DISK": "42:0",
+			}, nil
+		default:
+			c.Logf("unexpected udev device properties requested: %s", dev)
+			c.Fail()
+			return nil, fmt.Errorf("unexpected udev device")
+
+		}
+	})
+	defer restore()
+
+	_, err := partition.DiskFromMountPoint("/run/mnt/point", nil)
+	c.Assert(err, ErrorMatches, `no partitions found for disk 42:1`)
+}
+
+func (s *diskSuite) TestDiskFromMountPointHappyOnePartition(c *C) {
+	// this test ensures that we still get a Disk, even if we don't find any
+	// other partitions for the current disk
+	restore := osutil.MockMountInfo(`130 30 42:1 / /run/mnt/point rw,relatime shared:54 - ext4 /dev/vda1 rw
+`)
+	defer restore()
+
+	ourDisk := mockSysfsUdevDisk{
+		diskMajMin: "42:0",
+		partitions: map[partitionDevice]map[string]string{
+			makePart("42:1", "vda1"): {
+				"ID_PART_ENTRY_UUID": "bios-boot-partuuid",
+				"ID_FS_LABEL_ENC":    "bios",
+			},
+		},
+	}
+
+	unrelatedAdjacentDisk := mockSysfsUdevDisk{
+		diskMajMin: "42:5",
+		partitions: map[partitionDevice]map[string]string{
+			makePart("42:6", "sda"): {
+				"ID_PART_ENTRY_UUID": "some-unrelated-partuuid",
+				"ID_FS_LABEL_ENC":    "unrelated-adjacent-disk-partition",
+			},
+		},
+	}
+
+	unrelatedDisk1 := mockSysfsUdevDisk{diskMajMin: "46:0"}
+	unrelatedDisk2 := mockSysfsUdevDisk{diskMajMin: "41:0"}
+
+	restore = mockSysfsUdevDiskLayout(c, ourDisk, unrelatedAdjacentDisk, unrelatedDisk1, unrelatedDisk2)
+	defer restore()
+
+	d, err := partition.DiskFromMountPoint("/run/mnt/point", nil)
+	c.Assert(err, IsNil)
+	c.Assert(d.String(), Equals, "42:0")
+}
+
+func (s *diskSuite) TestDiskFromMountPointHappy(c *C) {
+	restore := osutil.MockMountInfo(`130 30 42:4 / /run/mnt/data rw,relatime shared:54 - ext4 /dev/vda4 rw
+130 30 42:4 / /run/mnt/ubuntu-boot rw,relatime shared:54 - ext4 /dev/vda3 rw
+`)
+	defer restore()
+
+	ourDisk := mockSysfsUdevDisk{
+		diskMajMin: "42:0",
+		partitions: map[partitionDevice]map[string]string{
+			makePart("42:1", "vda1"): {
+				"ID_PART_ENTRY_UUID": "bios-boot-partuuid",
+				"ID_FS_LABEL_ENC":    "bios-boot",
+			},
+			makePart("42:2", "vda2"): {
+				"ID_PART_ENTRY_UUID": "ubuntu-seed-partuuid",
+				"ID_FS_LABEL_ENC":    "ubuntu-seed",
+			},
+			makePart("42:3", "vda3"): {
+				"ID_PART_ENTRY_UUID": "ubuntu-boot-partuuid",
+				"ID_FS_LABEL_ENC":    "ubuntu-boot",
+			},
+			makePart("42:4", "vda4"): {
+				"ID_PART_ENTRY_UUID": "ubuntu-data-partuuid",
+				"ID_FS_LABEL_ENC":    "ubuntu-data",
+			},
+		},
+	}
+
+	unrelatedAdjacentDisk := mockSysfsUdevDisk{
+		diskMajMin: "42:5",
+		partitions: map[partitionDevice]map[string]string{
+			makePart("42:6", "sda"): {
+				"ID_PART_ENTRY_UUID": "some-unrelated-partuuid",
+				"ID_FS_LABEL_ENC":    "unrelated-adjacent-disk-partition",
+			},
+		},
+	}
+
+	unrelatedDisk1 := mockSysfsUdevDisk{diskMajMin: "46:0"}
+	unrelatedDisk2 := mockSysfsUdevDisk{diskMajMin: "41:0"}
+
+	restore = mockSysfsUdevDiskLayout(c, ourDisk, unrelatedAdjacentDisk, unrelatedDisk1, unrelatedDisk2)
+	defer restore()
+
+	ubuntuDataDisk, err := partition.DiskFromMountPoint("/run/mnt/data", nil)
+	c.Assert(err, IsNil)
+	c.Assert(ubuntuDataDisk, Not(IsNil))
+	c.Assert(ubuntuDataDisk.String(), Equals, "42:0")
+
+	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
+	for _, label := range []string{"bios-boot", "ubuntu-seed", "ubuntu-boot", "ubuntu-data"} {
+		id, err := ubuntuDataDisk.FindMatchingPartitionUUID(label)
+		c.Assert(err, IsNil)
+		c.Assert(id, Equals, label+"-partuuid")
+	}
+
+	// and the mountpoint for ubuntu-boot at /run/mnt/ubuntu-boot matches the
+	// same disk
+	matches, err := ubuntuDataDisk.MountPointIsFromDisk("/run/mnt/ubuntu-boot", nil)
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, true)
+
+	// and we can find the partition for ubuntu-boot first and then match
+	// that with ubuntu-data too
+	ubuntuBootDisk, err := partition.DiskFromMountPoint("/run/mnt/ubuntu-boot", nil)
+	c.Assert(err, IsNil)
+	c.Assert(ubuntuBootDisk, Not(IsNil))
+	c.Assert(ubuntuBootDisk.String(), Equals, "42:0")
+
+	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
+	for _, label := range []string{"bios-boot", "ubuntu-seed", "ubuntu-boot", "ubuntu-data"} {
+		id, err := ubuntuBootDisk.FindMatchingPartitionUUID(label)
+		c.Assert(err, IsNil)
+		c.Assert(id, Equals, label+"-partuuid")
+	}
+
+	// and the mountpoint for ubuntu-boot at /run/mnt/ubuntu-boot matches the
+	// same disk
+	matches, err = ubuntuBootDisk.MountPointIsFromDisk("/run/mnt/data", nil)
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, true)
+}
+
+func (s *diskSuite) TestDiskFromMountPointDecryptedDeviceHappy(c *C) {
+	restore := osutil.MockMountInfo(`130 30 253:0 / /run/mnt/data rw,relatime shared:55 - ext4 /dev/mapper/ubuntu-data-64512768-5509-4c2c-b014-2549b97f3ed6 rw
+130 30 42:4 / /run/mnt/ubuntu-boot rw,relatime shared:54 - ext4 /dev/vda3 rw
+`)
+	defer restore()
+
+	ourDisk := mockSysfsUdevDisk{
+		diskMajMin: "42:0",
+		partitions: map[partitionDevice]map[string]string{
+			makePart("42:1", "vda1"): {
+				"ID_PART_ENTRY_UUID": "bios-boot-partuuid",
+				"ID_FS_LABEL_ENC":    "bios-boot",
+			},
+			makePart("42:2", "vda2"): {
+				"ID_PART_ENTRY_UUID": "ubuntu-seed-partuuid",
+				"ID_FS_LABEL_ENC":    "ubuntu-seed",
+			},
+			makePart("42:3", "vda3"): {
+				"ID_PART_ENTRY_UUID": "ubuntu-boot-partuuid",
+				"ID_FS_LABEL_ENC":    "ubuntu-boot",
+			},
+			// since ubuntu-data is a mapper device, it will have the backing
+			// encrypted device referenced by uuid, so we need this symlink too
+			makePartWithSym("42:4", "vda4", "disk/by-uuid/60040aef-c34d-4d54-ad04-89d92e7b8d00"): {
+				"ID_PART_ENTRY_UUID": "ubuntu-data-enc-partuuid",
+				"ID_FS_LABEL_ENC":    "ubuntu-data-enc",
+			},
+		},
+	}
+
+	unrelatedAdjacentDisk := mockSysfsUdevDisk{
+		diskMajMin: "42:5",
+		partitions: map[partitionDevice]map[string]string{
+			makePart("42:6", "sda"): {
+				"ID_PART_ENTRY_UUID": "some-unrelated-partuuid",
+				"ID_FS_LABEL_ENC":    "unrelated-adjacent-disk-partition",
+			},
+		},
+	}
+
+	decryptedMapperDisk := mockSysfsUdevDisk{
+		diskMajMin: "253:0",
+		partitions: map[partitionDevice]map[string]string{
+			makePart("42:6", "sda"): {
+				"ID_PART_ENTRY_UUID": "some-unrelated-partuuid",
+				"ID_FS_LABEL_ENC":    "unrelated-adjacent-disk-partition",
+			},
+		},
+	}
+
+	unrelatedDisk1 := mockSysfsUdevDisk{diskMajMin: "46:0"}
+	unrelatedDisk2 := mockSysfsUdevDisk{diskMajMin: "41:0"}
+
+	restore = mockSysfsUdevDiskLayout(c, ourDisk, decryptedMapperDisk, unrelatedAdjacentDisk, unrelatedDisk1, unrelatedDisk2)
+	defer restore()
+
+	// also mock the dm device for ubuntu-data-<uuid>
+	dmDeviceSyfsDir := filepath.Join(dirs.SysfsDir, "dev/block", "253:0", "dm")
+	err := os.MkdirAll(dmDeviceSyfsDir, 0755)
+	c.Assert(err, IsNil)
+
+	// the dm name is the mapper name
+	err = ioutil.WriteFile(filepath.Join(dmDeviceSyfsDir, "name"), []byte("ubuntu-data-64512768-5509-4c2c-b014-2549b97f3ed6"), 0644)
+	c.Assert(err, IsNil)
+
+	// the uuid is of the form CRYPT-LUKS2-$UUID-$DM_NAME
+	// for this test UUID => 60040aef-c34d-4d54-ad04-89d92e7b8d00
+	err = ioutil.WriteFile(filepath.Join(dmDeviceSyfsDir, "uuid"), []byte("CRYPT-LUKS2-60040aefc34d4d54ad0489d92e7b8d00-ubuntu-data-4d4dc28c-c319-4841-bc84-71a3f9b68902"), 0644)
+	c.Assert(err, IsNil)
+
+	ubuntuDataDisk, err := partition.DiskFromMountPoint("/run/mnt/data", &partition.Options{IsDecryptedDevice: true})
+	c.Assert(err, IsNil)
+	c.Assert(ubuntuDataDisk, Not(IsNil))
+	c.Assert(ubuntuDataDisk.String(), Equals, "42:0")
+
+	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
+	for _, label := range []string{"bios-boot", "ubuntu-seed", "ubuntu-boot", "ubuntu-data-enc"} {
+		id, err := ubuntuDataDisk.FindMatchingPartitionUUID(label)
+		c.Assert(err, IsNil)
+		c.Assert(id, Equals, label+"-partuuid")
+	}
+
+	// and the mountpoint for ubuntu-boot at /run/mnt/ubuntu-boot matches the
+	// same disk
+	matches, err := ubuntuDataDisk.MountPointIsFromDisk("/run/mnt/ubuntu-boot", nil)
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, true)
+
+	// and we can find the partition for ubuntu-boot first and then match
+	// that with ubuntu-data via the decrypted device too
+	ubuntuBootDisk, err := partition.DiskFromMountPoint("/run/mnt/ubuntu-boot", nil)
+	c.Assert(err, IsNil)
+	c.Assert(ubuntuBootDisk, Not(IsNil))
+	c.Assert(ubuntuBootDisk.String(), Equals, "42:0")
+
+	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data-enc partition labels
+	for _, label := range []string{"bios-boot", "ubuntu-seed", "ubuntu-boot", "ubuntu-data-enc"} {
+		id, err := ubuntuBootDisk.FindMatchingPartitionUUID(label)
+		c.Assert(err, IsNil)
+		c.Assert(id, Equals, label+"-partuuid")
+	}
+
+	// and the mountpoint for ubuntu-boot at /run/mnt/ubuntu-boot matches the
+	// same disk
+	matches, err = ubuntuBootDisk.MountPointIsFromDisk("/run/mnt/data", &partition.Options{IsDecryptedDevice: true})
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, true)
+}

--- a/cmd/snap-bootstrap/partition/export_test.go
+++ b/cmd/snap-bootstrap/partition/export_test.go
@@ -68,3 +68,11 @@ func MockEnsureNodesExist(f func(ds []DeviceStructure, timeout time.Duration) er
 		ensureNodesExist = old
 	}
 }
+
+func MockUdevPropertiesForDevice(new func(string) (map[string]string, error)) (restore func()) {
+	old := udevProperties
+	udevProperties = new
+	return func() {
+		udevProperties = old
+	}
+}


### PR DESCRIPTION
These methods are meant to be used by snap-bootstrap, primarily to take an already mounted partition, and use that to find the underlying disk, then to find an unmounted partition from the same disk, with the specified label so that we can mount that one.

We also have the use case that a given mountpoint might be a decrypted mapper device, in which case we need some special logic to dig through sysfs and udev to find the underlying encrypted device that the decrypted mapper device maps to.