### PR TITLE
packaging: update sid packaging to match 16.04+

### DIFF
--- a/packaging/debian-sid/snapd.postrm
+++ b/packaging/debian-sid/snapd.postrm
@@ -109,11 +109,7 @@ if [ "$1" = "purge" ]; then
                 rm -f "$mnt"
             done
         fi
-        if [ "$(find /run/snapd/ns/ -name "*.fstab" | wc -l)" -gt 0 ]; then
-            for fstab in /run/snapd/ns/*.fstab; do
-                rm -f "$fstab"
-            done
-        fi
+        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' -o -name '*.info' \) -delete
         umount -l /run/snapd/ns/ || true
     fi
 


### PR DESCRIPTION
There's some more delta there but I think this part is safe. It entails
to /run/snapd/ns mount information files we are creating.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
