### PR TITLE
tests: reload root's systemd --user after snapd tests

### DIFF
--- a/tests/core/core-to-snapd-failover16/task.yaml
+++ b/tests/core/core-to-snapd-failover16/task.yaml
@@ -12,6 +12,7 @@ restore: |
   rm -f /etc/systemd/user/snapd.session-agent.service
   rm -f /etc/systemd/user/snapd.session-agent.socket
   rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
+  systemctl --user daemon-reload
 
 execute: |
   # shellcheck source=tests/lib/journalctl.sh

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -50,6 +50,7 @@ restore: |
         rm -f /etc/systemd/user/snapd.session-agent.service
         rm -f /etc/systemd/user/snapd.session-agent.socket
         rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
+        systemctl --user daemon-reload
     fi
 
 execute: |

--- a/tests/core/snapd16/task.yaml
+++ b/tests/core/snapd16/task.yaml
@@ -70,3 +70,4 @@ restore: |
     rm -f /etc/systemd/user/snapd.session-agent.service
     rm -f /etc/systemd/user/snapd.session-agent.socket
     rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
+    systemctl --user daemon-reload


### PR DESCRIPTION
Recently we realized that some tests leave systemd/user configuration
files in /etc that are normally not cleaned up by snapd under any
circumstances. Despite this we still, occasionally, see some failures
related to session-agent tests.

With extra debugging we understand that the problem is caused by the
fact that loaded units stay in systemd --user's memory (for the root
user) between tests. Unlike the session of the test user, we are not
performing a full cleanup, as that would nuke our SSH connection from
spread.

This patch fixes the affected tests to reload systemd --user running for
root, in the appropriate restore sections.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
