### PR TITLE
o/devicestate: change how current system is reported for different modes

### DIFF
--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -398,7 +398,10 @@ func (s *apiSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
 		assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
 		s.mockModel(c, st, model)
-		st.Set("seeded-systems", currentSystem)
+		if tc.currentMode == "run" {
+			// only set in run mode
+			st.Set("seeded-systems", currentSystem)
+		}
 		st.Unlock()
 
 		body := map[string]string{

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -106,7 +106,13 @@ func (s *apiSuite) mockSystemSeeds(c *check.C) (restore func()) {
 	return restore
 }
 
-func (s *apiSuite) TestGetSystemsSome(c *check.C) {
+func (s *apiSuite) TestSystemsGetSome(c *check.C) {
+	m := boot.Modeenv{
+		Mode: "run",
+	}
+	err := m.WriteTo("")
+	c.Assert(err, check.IsNil)
+
 	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.overlord.State(), d.overlord.TaskRunner())
 	c.Assert(err, check.IsNil)
@@ -175,7 +181,13 @@ func (s *apiSuite) TestGetSystemsSome(c *check.C) {
 		}})
 }
 
-func (s *apiSuite) TestGetSystemsNone(c *check.C) {
+func (s *apiSuite) TestSystemsGetNone(c *check.C) {
+	m := boot.Modeenv{
+		Mode: "run",
+	}
+	err := m.WriteTo("")
+	c.Assert(err, check.IsNil)
+
 	// model assertion setup
 	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.overlord.State(), d.overlord.TaskRunner())
@@ -365,11 +377,15 @@ func (s *apiSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 	}
 	s.vars = map[string]string{"label": "20191119"}
 
-	for _, t := range tt {
+	for _, tc := range tt {
+		c.Logf("tc: %v", tc.comment)
 		// daemon setup - need to do this per-test because we need to re-read
 		// the modeenv during devicemgr startup
 		m := boot.Modeenv{
-			Mode: t.currentMode,
+			Mode: tc.currentMode,
+		}
+		if tc.currentMode != "run" {
+			m.RecoverySystem = "20191119"
 		}
 		err := m.WriteTo("")
 		c.Assert(err, check.IsNil)
@@ -387,29 +403,29 @@ func (s *apiSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 
 		body := map[string]string{
 			"action": "do",
-			"mode":   t.actionMode,
+			"mode":   tc.actionMode,
 		}
 		b, err := json.Marshal(body)
-		c.Assert(err, check.IsNil, check.Commentf(t.comment))
+		c.Assert(err, check.IsNil, check.Commentf(tc.comment))
 		buf := bytes.NewBuffer(b)
 		req, err := http.NewRequest("POST", "/v2/systems/20191119", buf)
-		c.Assert(err, check.IsNil, check.Commentf(t.comment))
+		c.Assert(err, check.IsNil, check.Commentf(tc.comment))
 		// as root
 		req.RemoteAddr = "pid=100;uid=0;socket=;"
 		rec := httptest.NewRecorder()
 		systemsActionCmd.ServeHTTP(rec, req)
-		if t.expUnsupported {
-			c.Check(rec.Code, check.Equals, 400, check.Commentf(t.comment))
+		if tc.expUnsupported {
+			c.Check(rec.Code, check.Equals, 400, check.Commentf(tc.comment))
 		} else {
-			c.Check(rec.Code, check.Equals, 200, check.Commentf(t.comment))
+			c.Check(rec.Code, check.Equals, 200, check.Commentf(tc.comment))
 		}
 
 		var rspBody map[string]interface{}
 		err = json.Unmarshal(rec.Body.Bytes(), &rspBody)
-		c.Assert(err, check.IsNil, check.Commentf(t.comment))
+		c.Assert(err, check.IsNil, check.Commentf(tc.comment))
 
 		var expResp map[string]interface{}
-		if t.expUnsupported {
+		if tc.expUnsupported {
 			expResp = map[string]interface{}{
 				"result": map[string]interface{}{
 					"message": fmt.Sprintf("requested action is not supported by system %q", "20191119"),
@@ -425,7 +441,7 @@ func (s *apiSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 				"status-code": 200.0,
 				"type":        "sync",
 			}
-			if t.expRestart {
+			if tc.expRestart {
 				expResp["maintenance"] = map[string]interface{}{
 					"kind":    "system-restart",
 					"message": "system is restarting",
@@ -434,17 +450,17 @@ func (s *apiSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 				// daemon is not started, only check whether reboot was scheduled as expected
 
 				// reboot flag
-				c.Check(d.restartSystem, check.Equals, state.RestartSystemNow, check.Commentf(t.comment))
+				c.Check(d.restartSystem, check.Equals, state.RestartSystemNow, check.Commentf(tc.comment))
 				// slow reboot schedule
 				c.Check(cmd.Calls(), check.DeepEquals, [][]string{
 					{"shutdown", "-r", "+10", "reboot scheduled to update the system"},
 				},
-					check.Commentf(t.comment),
+					check.Commentf(tc.comment),
 				)
 			}
 		}
 
-		c.Assert(rspBody, check.DeepEquals, expResp, check.Commentf(t.comment))
+		c.Assert(rspBody, check.DeepEquals, expResp, check.Commentf(tc.comment))
 
 		cmd.ForgetCalls()
 		s.d = nil

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -547,7 +547,7 @@ func (m *DeviceManager) ensureInstalled() error {
 
 	var seeded bool
 	err := m.state.Get("seeded", &seeded)
-	if err != nil {
+	if err != nil && err != state.ErrNoState {
 		return err
 	}
 	if !seeded {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -773,7 +773,7 @@ var currentSystemActions = []SystemAction{
 	{Title: "Run normally", Mode: "run"},
 }
 
-func systemFromSeed(label string, current *seededSystem) (*System, error) {
+func systemFromSeed(label string) (*System, error) {
 	s, err := seed.Open(dirs.SnapSeedDir, label)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open: %v", err)
@@ -828,7 +828,7 @@ func seededSystemFromModeenv() (*seededSystem, error) {
 		return nil, fmt.Errorf("internal error: recovery system is unset")
 	}
 
-	system, err := systemFromSeed(modeEnv.RecoverySystem, nil)
+	system, err := systemFromSeed(modeEnv.RecoverySystem)
 	if err != nil {
 		return nil, err
 	}
@@ -882,7 +882,7 @@ func (m *DeviceManager) Systems() ([]*System, error) {
 	var systems []*System
 	for _, fpLabel := range systemLabels {
 		label := filepath.Base(fpLabel)
-		system, err := systemFromSeed(label, currentSys)
+		system, err := systemFromSeed(label)
 		if err != nil {
 			// TODO:UC20 add a Broken field to the seed system like
 			// we do for snap.Info
@@ -910,7 +910,7 @@ func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAct
 	if _, err := os.Stat(systemSeedDir); err != nil {
 		return err
 	}
-	system, err := systemFromSeed(systemLabel, currentSys)
+	system, err := systemFromSeed(systemLabel)
 	if err != nil {
 		return fmt.Errorf("cannot load seed system: %v", err)
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -91,7 +91,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 		preseed:    snapdenv.Preseeding(),
 	}
 
-	modeEnv, err := m.maybeReadModeenv()
+	modeEnv, err := maybeReadModeenv()
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	return m, nil
 }
 
-func (m *DeviceManager) maybeReadModeenv() (*boot.Modeenv, error) {
+func maybeReadModeenv() (*boot.Modeenv, error) {
 	modeEnv, err := boot.ReadModeenv("")
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("cannot read modeenv: %v", err)
@@ -453,7 +453,7 @@ func (m *DeviceManager) ensureSeeded() error {
 	if m.preseed {
 		opts = &populateStateFromSeedOptions{Preseed: true}
 	} else {
-		modeEnv, err := m.maybeReadModeenv()
+		modeEnv, err := maybeReadModeenv()
 		if err != nil {
 			return err
 		}
@@ -797,14 +797,51 @@ func systemFromSeed(label string, current *seededSystem) (*System, error) {
 		Brand:   brand,
 		Actions: defaultSystemActions,
 	}
-	if current != nil && isCurrentSystem(current, &system) {
-		system.Current = true
-		system.Actions = currentSystemActions
-	}
 	return &system, nil
 }
 
 var ErrNoSystems = errors.New("no systems seeds")
+
+func currentSystemForMode(st *state.State, mode string) (*seededSystem, error) {
+	switch mode {
+	case "run":
+		return currentSeedSystem(st)
+	case "install":
+		// there is no current system for install mode
+		return nil, nil
+	case "recover":
+		// recover mode uses modeenv for reference
+		return seededSystemFromModeenv()
+	}
+	return nil, fmt.Errorf("internal error: cannot identify current system for unsupported mode %q", mode)
+}
+
+func seededSystemFromModeenv() (*seededSystem, error) {
+	modeEnv, err := maybeReadModeenv()
+	if err != nil {
+		return nil, err
+	}
+	if modeEnv == nil {
+		return nil, fmt.Errorf("internal error: modeenv does not exist")
+	}
+	if modeEnv.RecoverySystem == "" {
+		return nil, fmt.Errorf("internal error: recovery system is unset")
+	}
+
+	system, err := systemFromSeed(modeEnv.RecoverySystem, nil)
+	if err != nil {
+		return nil, err
+	}
+	seededSys := &seededSystem{
+		System:    modeEnv.RecoverySystem,
+		Model:     system.Model.Model(),
+		BrandID:   system.Model.BrandID(),
+		Revision:  system.Model.Revision(),
+		Timestamp: system.Model.Timestamp(),
+		// SeedTime is intentionally left unset
+	}
+	return seededSys, nil
+}
 
 func currentSeedSystem(st *state.State) (*seededSystem, error) {
 	st.Lock()
@@ -831,7 +868,7 @@ func isCurrentSystem(current *seededSystem, other *System) bool {
 // systems, ErrNoSystems when no systems seeds were found or other error.
 func (m *DeviceManager) Systems() ([]*System, error) {
 	// it's tough luck when we cannot determine the current system seed
-	currentSys, _ := currentSeedSystem(m.state)
+	currentSys, _ := currentSystemForMode(m.state, m.systemMode)
 
 	systemLabels, err := filepath.Glob(filepath.Join(dirs.SnapSeedDir, "systems", "*"))
 	if err != nil && !os.IsNotExist(err) {
@@ -852,6 +889,10 @@ func (m *DeviceManager) Systems() ([]*System, error) {
 			logger.Noticef("cannot load system %q seed: %v", label, err)
 			continue
 		}
+		if currentSys != nil && isCurrentSystem(currentSys, system) {
+			system.Current = true
+			system.Actions = currentSystemActions
+		}
 		systems = append(systems, system)
 	}
 	return systems, nil
@@ -863,7 +904,7 @@ var ErrUnsupportedAction = errors.New("unsupported action")
 // system reboot will be requested when the request can be successfully carried
 // out.
 func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAction) error {
-	currentSys, _ := currentSeedSystem(m.state)
+	currentSys, _ := currentSystemForMode(m.state, m.systemMode)
 
 	systemSeedDir := filepath.Join(dirs.SnapSeedDir, "systems", systemLabel)
 	if _, err := os.Stat(systemSeedDir); err != nil {
@@ -872,6 +913,10 @@ func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAct
 	system, err := systemFromSeed(systemLabel, currentSys)
 	if err != nil {
 		return fmt.Errorf("cannot load seed system: %v", err)
+	}
+	if currentSys != nil && isCurrentSystem(currentSys, system) {
+		system.Current = true
+		system.Actions = currentSystemActions
 	}
 
 	var sysAction *SystemAction

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -117,12 +117,8 @@ volumes:
 	}, nil)
 }
 
-func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
-	m := boot.Modeenv{
-		Mode:           "run",
-		RecoverySystem: "20191018",
-		Base:           "core20_1.snap",
-	}
+func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv) {
+	c.Assert(m, NotNil, Commentf("missing modeenv test data"))
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
@@ -137,7 +133,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 	})
 	defer systemctlRestorer()
 
-	sysLabel := "20191018"
+	sysLabel := m.RecoverySystem
 	model := s.setupCore20Seed(c, sysLabel)
 
 	bloader := bootloadertest.Mock("mock", c.MkDir()).WithExtractedRunKernelImage()
@@ -154,7 +150,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 
 	opts := devicestate.PopulateStateFromSeedOptions{
 		Label: sysLabel,
-		Mode:  "run",
+		Mode:  m.Mode,
 	}
 
 	// run the firstboot stuff
@@ -240,7 +236,13 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 	// check that we removed recovery_system from modeenv
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Assert(m2.RecoverySystem, Equals, "")
+	if m.Mode == "run" {
+		// recovery system is cleared in run mode
+		c.Assert(m2.RecoverySystem, Equals, "")
+	} else {
+		// but kept intact in other modes
+		c.Assert(m2.RecoverySystem, Equals, m.RecoverySystem)
+	}
 	c.Assert(m2.Base, Equals, m.Base)
 	c.Assert(m2.Mode, Equals, m.Mode)
 	// Note that we don't check CurrentKernels in the modeenv, even though in a
@@ -257,14 +259,17 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 	// already booted from, we should only have checked what the current kernel
 	// is
 
-	// the 3 calls here are :
-	// * 1 from MarkBootSuccessful() from ensureBootOk() before we restart
-	// * 1 from boot.SetNextBoot() from LinkSnap() from doInstall() from InstallPath() from
-	//     installSeedSnap() after restart
-	// * 1 from boot.GetCurrentBoot() from WaitRestart after restart
-	_, numKernelCalls := bloader.GetRunKernelImageFunctionSnapCalls("Kernel")
-	c.Assert(numKernelCalls, Equals, 3)
+	if m.Mode == "run" {
+		// only relevant in run mode
 
+		// the 3 calls here are :
+		// * 1 from MarkBootSuccessful() from ensureBootOk() before we restart
+		// * 1 from boot.SetNextBoot() from LinkSnap() from doInstall() from InstallPath() from
+		//     installSeedSnap() after restart
+		// * 1 from boot.GetCurrentBoot() from WaitRestart after restart
+		_, numKernelCalls := bloader.GetRunKernelImageFunctionSnapCalls("Kernel")
+		c.Assert(numKernelCalls, Equals, 3)
+	}
 	actual, _ := bloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
 	c.Assert(actual, HasLen, 0)
 	actual, _ = bloader.GetRunKernelImageFunctionSnapCalls("DisableTryKernel")
@@ -274,13 +279,44 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 
 	var whatseeded []devicestate.SeededSystem
 	err = state.Get("seeded-systems", &whatseeded)
-	c.Assert(err, IsNil)
-	c.Assert(whatseeded, DeepEquals, []devicestate.SeededSystem{{
-		System:    "20191018",
-		Model:     "my-model",
-		BrandID:   "my-brand",
-		Revision:  model.Revision(),
-		Timestamp: model.Timestamp(),
-		SeedTime:  seedTime,
-	}})
+	if m.Mode == "run" {
+		c.Assert(err, IsNil)
+		c.Assert(whatseeded, DeepEquals, []devicestate.SeededSystem{{
+			System:    m.RecoverySystem,
+			Model:     "my-model",
+			BrandID:   "my-brand",
+			Revision:  model.Revision(),
+			Timestamp: model.Timestamp(),
+			SeedTime:  seedTime,
+		}})
+	} else {
+		c.Assert(err, NotNil)
+	}
+}
+
+func (s *firstBoot20Suite) TestPopulateFromSeedCore20RunMode(c *C) {
+	m := boot.Modeenv{
+		Mode:           "run",
+		RecoverySystem: "20191018",
+		Base:           "core20_1.snap",
+	}
+	s.testPopulateFromSeedCore20Happy(c, &m)
+}
+
+func (s *firstBoot20Suite) TestPopulateFromSeedCore20InstallMode(c *C) {
+	m := boot.Modeenv{
+		Mode:           "install",
+		RecoverySystem: "20191019",
+		Base:           "core20_1.snap",
+	}
+	s.testPopulateFromSeedCore20Happy(c, &m)
+}
+
+func (s *firstBoot20Suite) TestPopulateFromSeedCore20RecoverMode(c *C) {
+	m := boot.Modeenv{
+		Mode:           "recover",
+		RecoverySystem: "20191020",
+		Base:           "core20_1.snap",
+	}
+	s.testPopulateFromSeedCore20Happy(c, &m)
 }

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -131,7 +131,7 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if deviceCtx.HasModeenv() && deviceCtx.RunMode() {
-		modeEnv, err := m.maybeReadModeenv()
+		modeEnv, err := maybeReadModeenv()
 		if err != nil {
 			return err
 		}
@@ -152,6 +152,8 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 	if whatSeeded != nil && deviceCtx.RunMode() {
+		// record what seeded in the state only when in run mode
+
 		whatSeeded.SeedTime = now
 		// TODO:UC20 what about remodels?
 		if err := m.recordSeededSystem(st, whatSeeded); err != nil {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -151,7 +151,7 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	if err := t.Get("seed-system", &whatSeeded); err != nil && err != state.ErrNoState {
 		return err
 	}
-	if whatSeeded != nil {
+	if whatSeeded != nil && deviceCtx.RunMode() {
 		whatSeeded.SeedTime = now
 		// TODO:UC20 what about remodels?
 		if err := m.recordSeededSystem(st, whatSeeded); err != nil {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -107,7 +107,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 	kernelDir := kernelInfo.MountDir()
 
-	modeEnv, err := m.maybeReadModeenv()
+	modeEnv, err := maybeReadModeenv()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Change how current system is determined in different modes. In run mode, we use the seeded-systems information that is updated in mark seeded task.

In recover and install modes, we are effectively seeding an ephemeral system, so no such information is recorded. Use the modeenv to identify that recovery system that booted and use it as the current system. However, in install mode, report nothing for now.
