### PR TITLE
tests: enable degraded test on uc20

### DIFF
--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -1,9 +1,5 @@
 summary: Check that the system is not in "degraded" state
 
-# TODO:UC20: e2scrub_reap.service is failing on uc20 as of 20200109, enable
-#            once foundations fixes it
-systems: [-ubuntu-core-20-*]
-
 # run this early to ensure no test created failed units yet
 priority: 500
 


### PR DESCRIPTION
The failing unit on uc20 is now fixed.
