### PR TITLE
tests: port interfaces-dbus to session-tool

### DIFF
--- a/tests/main/interfaces-dbus/task.yaml
+++ b/tests/main/interfaces-dbus/task.yaml
@@ -1,46 +1,45 @@
-summary: Ensure that the dbus interface works
+summary: Ensure that the DBus interface works
 
 details: |
-    The dbus interface allows owning a name on DBus public bus.
+    The DBus interface allows owning a name on DBus public bus.
 
-    The test uses two snaps, a provider declaring a dbus slot and a consumer
+    The test uses two snaps, a provider declaring a DBus slot and a consumer
     with a plug with the same attributes as the slot. The provider requests
-    a dbus name and, when the plug is connected, the consumer can call the
+    a DBus name and, when the plug is connected, the consumer can call the
     method exposed by the provider.
 
-environment:
-    DISPLAY: :0
-
-systems: [-ubuntu-core-*]
+systems:
+    - -ubuntu-14.04-*  # no session-tool support
+    - -ubuntu-core-*  # dbus interface disallows unconfined access on core,
+                      # in addition, up until core20 session bus was not supported
+    - -amazon-linux-2-* # session bus is not supported
+    - -centos-7-*       # session bus is not supported
 
 prepare: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB/dirs.sh"
-
     echo "Give a snap declaring a dbus slot in installed"
     snap install --beta test-snapd-dbus-provider
 
     echo "And a snap declaring a matching dbus plug is installed"
     snap install --beta test-snapd-dbus-consumer
 
+    session-tool -u test --prepare
+
+    # XXX: The pair of snaps in this test communicate over the session bus but
+    # are normal applications that require starting. Instead of using
+    # run-in-the-background hack, use systemd-run to start a session service
+    # wrapping the application. This ensures it has access to the session bus
+    # and that if it forks off any unexpected processes, those are cleaned up
+    # on shutdown.
     echo "And the provider dbus loop is started"
-    #shellcheck source=tests/lib/dbus.sh
-    . "$TESTSLIB/dbus.sh"
-    start_dbus_unit $SNAP_MOUNT_DIR/bin/test-snapd-dbus-provider.provider
+    session-tool -u test systemd-run --user --unit dbus-provider.service test-snapd-dbus-provider.provider
 
 restore: |
-    #shellcheck source=tests/lib/dbus.sh
-    . "$TESTSLIB/dbus.sh"
-    stop_dbus_unit || true
+    session-tool -u test systemctl --user stop dbus-provider.service
+    session-tool -u test --restore
 
 execute: |
-    #shellcheck disable=SC2046
-    export $(cat dbus.env)
-
     echo "Then the dbus name is properly reserved by the provider and the method is accessible"
-    while ! dbus-send --print-reply --dest=com.dbustest.HelloWorld /com/dbustest/HelloWorld com.dbustest.HelloWorld.SayHello | MATCH "hello world"; do
-        sleep 1
-    done
+    retry-tool -n 5 --wait 1 sh -c 'session-tool -u test dbus-send --print-reply --dest=com.dbustest.HelloWorld /com/dbustest/HelloWorld com.dbustest.HelloWorld.SayHello | MATCH "hello world"'
 
     echo "And plug is disconnected by default"
     snap interfaces -i dbus | MATCH '^- +test-snapd-dbus-consumer:dbus-test'
@@ -49,7 +48,7 @@ execute: |
     snap connect test-snapd-dbus-consumer:dbus-test test-snapd-dbus-provider:dbus-test
 
     echo "Then the consumer is able to call the provided method"
-    test-snapd-dbus-consumer.dbus-consumer | MATCH "hello world"
+    session-tool -u test test-snapd-dbus-consumer.dbus-consumer | MATCH "hello world"
 
     if [ "$(snap debug confinement)" = partial ]; then
         exit 0
@@ -59,7 +58,7 @@ execute: |
     snap disconnect test-snapd-dbus-consumer:dbus-test test-snapd-dbus-provider:dbus-test
 
     echo "The consumer is not able to access the provided method"
-    if test-snapd-dbus-consumer.dbus-consumer 2> call.error; then
+    if session-tool -u test test-snapd-dbus-consumer.dbus-consumer 2> call.error; then
         echo "Expected permission error calling dbus method with disconnected plug"
         exit 1
     fi


### PR DESCRIPTION
This test did some weird hacks that I removed:
 - it faked a session bus on systems where it is unsupported
 - it spawned DBus and left it running
   - dbus.sh always leaks a process behind
 - it faked an X11 server to cause python to spawn spawn another bus!
 - it used an endless loop hoping for the service to respond
   - replaced with retry-tool

With this patch the test prepare/restore logic is more straightforward
and cannot leak anything behind as session-tool terminates all the
entire user slice.

In addition, this test could pass on core20 if we exclude the first
interaction, which uses unconfined user to check if the service is
"alive". On core systems the DBus interface does not allow unconfined
bus access so this check would always fail. I chose not to change that
for now.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

