### PR TITLE
tests: port interfaces-autopilot-introspection to session-tool

### DIFF
--- a/tests/main/interfaces-autopilot-introspection/task.yaml
+++ b/tests/main/interfaces-autopilot-introspection/task.yaml
@@ -1,62 +1,48 @@
 summary: Ensure that the autopilot-introspection interface works
 
 details: |
-    The autopilot-intrspection interface allows an application to be introspected
+    The autopilot-introspection interface allows an application to be introspected
     and export its ui status over DBus.
 
-    The test uses an snap that declares a plug on autopilot-intrsopection, it
+    The test uses an snap that declares a plug on autopilot-introspection, it
     needs to request a dbus name on start so that its state can be queried.
 
-systems: [-ubuntu-core-*]
+systems:
+    - -ubuntu-14.04-*  # no session-tool
+    - -ubuntu-core-*  # no session bus (except for core20+)
+    - -amazon-linux-2-*  # no session bus
+    - -centos-7-*  # no session bus
 
 prepare: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB/dirs.sh"
-
-    echo "Given a snap declaring an autopilot-intrspection plug in installed"
+    echo "Given a snap declaring an autopilot-introspection plug in installed"
     snap install --edge test-snapd-autopilot-consumer
 
+    session-tool -u test --prepare
+
     echo "And the provider dbus loop is started"
-    #shellcheck source=tests/lib/dbus.sh
-    . "$TESTSLIB/dbus.sh"
-    start_dbus_unit $SNAP_MOUNT_DIR/bin/test-snapd-autopilot-consumer.provider
+    # XXX: The test snap doesn't run as a service so we must do it ourselves.
+    # The app requires a session bus connection to operate. The interface is
+    # defined for session bus only.
+    session-tool -u test systemd-run --user --unit test-snapd-autopilot-consumer-provider.service test-snapd-autopilot-consumer.provider
 
 restore: |
-    #shellcheck source=tests/lib/dbus.sh
-    . "$TESTSLIB/dbus.sh"
-    stop_dbus_unit
+    session-tool -u test systemctl --user stop test-snapd-autopilot-consumer-provider.service
+    session-tool -u test --restore
 
 execute: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB/dirs.sh"
-
-    dbus_send(){
-        local method="$1"
-        dbus-send --print-reply --dest=com.canonical.Autopilot.Introspection /com/canonical/Autopilot/Introspection "com.canonical.Autopilot.Introspection.${method}"
-    }
-
-    #shellcheck disable=SC2046
-    export $(cat dbus.env)
-
     echo "Then the plug is disconnected by default"
     snap interfaces -i autopilot-introspection | MATCH '^\- +test-snapd-autopilot-consumer:autopilot-introspection'
 
     echo "When the plug is connected"
     snap connect test-snapd-autopilot-consumer:autopilot-introspection
 
-    echo "Then the dbus name is properly reserved and the snap app version can be introspected"
+    echo "Then the dbus name is properly reserved and the snap app version can be introspectd"
 
-    for _ in $(seq 10); do
-        if ! dbus_send GetVersion | MATCH "my-ap-version"; then
-            sleep 1
-        else
-            break
-        fi
-    done
-    $SNAP_MOUNT_DIR/bin/test-snapd-autopilot-consumer.consumer GetVersion | MATCH "my-ap-version"
+    retry-tool -n 10 --wait 1 sh -c 'session-tool -u test dbus-send --print-reply --dest=com.canonical.Autopilot.Introspection /com/canonical/Autopilot/Introspection com.canonical.Autopilot.Introspection.GetVersion | MATCH "my-ap-version"'
+    session-tool -u test test-snapd-autopilot-consumer.consumer GetVersion | MATCH "my-ap-version"
 
-    echo "And the snap app state can be intrsopected"
-    $SNAP_MOUNT_DIR/bin/test-snapd-autopilot-consumer.consumer GetState | MATCH "my-ap-state"
+    echo "And the snap app state can be introspected"
+    session-tool -u test test-snapd-autopilot-consumer.consumer GetState | MATCH "my-ap-state"
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
@@ -66,14 +52,14 @@ execute: |
     snap disconnect test-snapd-autopilot-consumer:autopilot-introspection
 
     echo "Then the snap version is not introspectable"
-    if $SNAP_MOUNT_DIR/bin/test-snapd-autopilot-consumer.consumer GetVersion 2> getversion.error ; then
+    if session-tool -u test test-snapd-autopilot-consumer.consumer GetVersion 2> getversion.error ; then
         echo "Expected permission error trying to introspect version with disconnected plug"
         exit 1
     fi
     MATCH "Permission denied" < getversion.error
 
     echo "And the snap state is not introspectable"
-    if $SNAP_MOUNT_DIR/bin/test-snapd-autopilot-consumer.consumer GetState 2> getstate.error; then
+    if session-tool -u test test-snapd-autopilot-consumer.consumer GetState 2> getstate.error; then
         echo "Expected permission error trying to introspect state with disconnected plug"
         exit 1
     fi


### PR DESCRIPTION
This completes the transition of tests that relied on dbus.sh, which
leaks a dbus-daemon process that sticks around and looks weird.
The test was also slightly modernized to use retry-tool

I also fixed a typo that occurred throughout the test.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
