### PR TITLE
tests: port interfaces-password-manager-service to session-tool

### DIFF
--- a/tests/main/interfaces-password-manager-service/task.yaml
+++ b/tests/main/interfaces-password-manager-service/task.yaml
@@ -1,28 +1,20 @@
 summary: Ensure that the password-manager-service interface works
 
-# Only test on classic systems with AppArmor DBus mediation
-systems: [ ubuntu-1* ]
+systems:
+    - ubuntu-16.04-*
+    - ubuntu-18.04-*
+    - ubuntu-20.04-*
 
 prepare: |
-    #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB"/pkgdb.sh
     echo "Ensure we have a working gnome-keyring"
     snap install --edge test-snapd-password-manager-consumer
 
+    session-tool -u test --prepare
+
 restore: |
-    #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB"/pkgdb.sh
-    if [ -f dbus-launch.pid ]; then
-        kill "$(cat dbus-launch.pid)"
-    fi
+    session-tool -u test --restore
 
 execute: |
-    echo "Ensure things run"
-    eval "$(dbus-launch --sh-syntax)"
-    eval "$(printf password|gnome-keyring-daemon --login)"
-    eval "$(gnome-keyring-daemon --start)"
-    echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid
-
     echo "The interface is disconnected by default"
     snap interfaces -i password-manager-service | MATCH -- '- +test-snapd-password-manager-consumer:password-manager-service'
 
@@ -30,7 +22,7 @@ execute: |
     snap connect test-snapd-password-manager-consumer:password-manager-service
 
     echo "Then the snap command is able use the libsecret service"
-    test-snapd-password-manager-consumer.secret-tool clear foo bar
+    session-tool -u test test-snapd-password-manager-consumer.secret-tool clear foo bar
 
     if [ "$(snap debug confinement)" = "partial" ] ; then
         exit 0
@@ -40,7 +32,7 @@ execute: |
     snap disconnect test-snapd-password-manager-consumer:password-manager-service
 
     echo "Then the snap command is not able to use the secret-tool"
-    if test-snapd-password-manager-consumer.secret-tool clear foo bar; then
+    if session-tool -u test test-snapd-password-manager-consumer.secret-tool clear foo bar; then
         echo "Expected error with plug disconnected"
         exit 1
     fi


### PR DESCRIPTION
Similar story as with the interfaces-accounts-service test, all the
cruft just flies away and test coverage is extended to all Ubuntu LTS
systems. And we do not leak another dbus-daemon process.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
