### PR TITLE
opensuse: zypper --replacefiles

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -287,7 +287,7 @@ distro_install_package() {
             # --allow-downgrade will make the installation proceed
 
             # shellcheck disable=SC2086
-            quiet zypper install -y --allow-downgrade --force-resolution $ZYPPER_FLAGS "${pkg_names[@]}"
+            quiet zypper install -y --allow-downgrade --force-resolution --replacefiles $ZYPPER_FLAGS "${pkg_names[@]}"
             ;;
         arch-*)
             # shellcheck disable=SC2086


### PR DESCRIPTION
I don't quite know why opensuse has a conflict between go 12 and 13 but
the alternative is probably the alternative system. Oh well, this fixes
master.

We should update all the images and remove this hack.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
