### PR TITLE
o/devicestate: cleanup system actions supported by recover mode

### DIFF
--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -349,9 +349,10 @@ func (s *apiSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		},
 		{
 			// from recover mode -> recover mode is no-op
-			currentMode: "recover",
-			actionMode:  "recover",
-			comment:     "recover mode to recover mode",
+			currentMode:    "recover",
+			actionMode:     "recover",
+			expUnsupported: true,
+			comment:        "recover mode to recover mode",
 		},
 		{
 			// from install mode -> install mode is no-no

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/strutil"
 )
 
 type mockedSystemSeed struct {
@@ -323,7 +324,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeInstallHappyForAny(c *C) {
 	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
 }
 
-func (s *deviceMgrSystemsSuite) TestRequestRunToRun(c *C) {
+func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystem(c *C) {
 	s.state.Lock()
 	s.state.Set("seeded-systems", []devicestate.SeededSystem{
 		{
@@ -335,30 +336,44 @@ func (s *deviceMgrSystemsSuite) TestRequestRunToRun(c *C) {
 	s.state.Unlock()
 
 	label := s.mockedSystemSeeds[0].label
-	// non run modes use modeenv
-	modeenv := boot.Modeenv{
-		Mode: "run",
-	}
-	err := modeenv.WriteTo("")
-	c.Assert(err, IsNil)
 
-	devicestate.SetSystemMode(s.mgr, "run")
-	err = s.bootloader.SetBootVars(map[string]string{
-		"snapd_recovery_mode":   "",
-		"snapd_recovery_system": "",
-	})
-	c.Assert(err, IsNil)
-	err = s.mgr.RequestSystemAction(label, devicestate.SystemAction{Mode: "run"})
-	c.Assert(err, IsNil)
-	// bootloader vars shouldn't change
-	m, err := s.bootloader.GetBootVars("snapd_recovery_mode", "snapd_recovery_system")
-	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]string{
-		"snapd_recovery_mode":   "",
-		"snapd_recovery_system": "",
-	})
-	// should never restart
-	c.Check(s.restartRequests, HasLen, 0)
+	happyModes := []string{"run"}
+	sadModes := []string{"install", "recover"}
+
+	for _, mode := range append(happyModes, sadModes...) {
+		c.Logf("checking mode: %q", mode)
+		// non run modes use modeenv
+		modeenv := boot.Modeenv{
+			Mode: mode,
+		}
+		if mode != "run" {
+			modeenv.RecoverySystem = s.mockedSystemSeeds[0].label
+		}
+		err := modeenv.WriteTo("")
+		c.Assert(err, IsNil)
+
+		devicestate.SetSystemMode(s.mgr, mode)
+		err = s.bootloader.SetBootVars(map[string]string{
+			"snapd_recovery_mode":   mode,
+			"snapd_recovery_system": label,
+		})
+		c.Assert(err, IsNil)
+		err = s.mgr.RequestSystemAction(label, devicestate.SystemAction{Mode: mode})
+		if strutil.ListContains(sadModes, mode) {
+			c.Assert(err, Equals, devicestate.ErrUnsupportedAction)
+		} else {
+			c.Assert(err, IsNil)
+		}
+		// bootloader vars shouldn't change
+		m, err := s.bootloader.GetBootVars("snapd_recovery_mode", "snapd_recovery_system")
+		c.Assert(err, IsNil)
+		c.Check(m, DeepEquals, map[string]string{
+			"snapd_recovery_mode":   mode,
+			"snapd_recovery_system": label,
+		})
+		// should never restart
+		c.Check(s.restartRequests, HasLen, 0)
+	}
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestNotYetSeeded(c *C) {

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -42,7 +42,7 @@ execute: |
       test -n "$label"
       # make sure that the seed exists
       test -d "/var/lib/snapd/seed/systems/$label"
-      jq -r .result.systems[0].actions[].mode < systems.json | MATCH 'recover'
+      jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install recover run'
 
       # keep a copy of the systems dump for later reference
       cp systems.json /writable/systems.json.run
@@ -95,8 +95,8 @@ execute: |
       test -e /host/ubuntu-data/systems.json.run
 
       test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
-      # systems list should be identical
-      diff -up /host/ubuntu-data/systems.json.run systems.json
+      jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install run'
+
       label="$(cat /host/ubuntu-data/systems.label)"
       test -n "$label"
       # seed in mounted in recover mode too

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -14,6 +14,9 @@ debug: |
   if [ -e systems.json ]; then
       cat systems.json
   fi
+  if [ -e system-info ]; then
+      cat system-info
+  fi
   if [ -e /tmp/mock-shutdown.calls ]; then
       cat /tmp/mock-shutdown.calls
   fi
@@ -86,8 +89,7 @@ execute: |
       MATCH 'snapd_recovery_mode=recover' < /proc/cmdline
       # verify we are in recovery mode via the API
       test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
-      jq -r '.result["system-mode"]' < system-info | not MATCH 'recover'
-      jq -r '.result["system-mode"]' < system-info | MATCH 'run'
+      jq -r '.result["system-mode"]' < system-info | MATCH 'recover'
 
       # host data should be accessible
       test -e /host/ubuntu-data/systems.json.run

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -86,7 +86,8 @@ execute: |
       MATCH 'snapd_recovery_mode=recover' < /proc/cmdline
       # verify we are in recovery mode via the API
       test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
-      jq -r '.result["system-mode"]' < system-info | MATCH 'recover'
+      jq -r '.result["system-mode"]' < system-info | not MATCH 'recover'
+      jq -r '.result["system-mode"]' < system-info | MATCH 'run'
 
       # host data should be accessible
       test -e /host/ubuntu-data/systems.json.run


### PR DESCRIPTION
It does not make sense for recover mode to go boot into recover mode again.

This is stacked on top of #8672 
