### PR TITLE
[RFC] overlord: show what manager throws a state ensure error

### DIFF
--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -147,7 +147,7 @@ func (se *StateEngine) Ensure() error {
 	for _, m := range se.managers {
 		err := m.Ensure()
 		if err != nil {
-			logger.Noticef("state ensure error: %v", err)
+			logger.Noticef("state ensure error from %T: %v", m, err)
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
When we install UC20 we get a lot of state.ErrNoState errors. In
general the state engine error reporting can be unhelpful if the
errors generic. To improve the situation a bit this commit adds
information about what manager is throwing the error. Eventually
we should ensure we don't return "naked" ErrNoState or similar
generic errors all the way up without decorating them with more
information.

I tested this on a UC20 install and the output is (slightly) more useful
this way. More to come.