### PR TITLE
state: log task errors in the journal too

### DIFF
--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -267,6 +267,8 @@ func (r *TaskRunner) run(t *Task) {
 			r.abortLanes(t.Change(), t.Lanes())
 			t.SetStatus(ErrorStatus)
 			t.Errorf("%s", err)
+			// ensure the error is available in the global log too
+			logger.Noticef("[change %s %q task] failed: %v", t.Change().ID(), t.Summary(), err)
 			if r.taskErrorCallback != nil {
 				r.taskErrorCallback(err)
 			}


### PR DESCRIPTION
When we see failures in snapd operations like installing a UC20
system or installing a single snap we need to ask for two logs
currently. The journal of snapd and the snap changes output with
the details for the failed change.

This commit tries to improve this situation by logging task
errors into the snapd journal as well. This allows users to just
sent the `journalctl -u snapd` output for bugreports in most
cases.
