### PR TITLE
devicestate: do not report "ErrNoState" for seeded up

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -547,7 +547,7 @@ func (m *DeviceManager) ensureInstalled() error {
 
 	var seeded bool
 	err := m.state.Get("seeded", &seeded)
-	if err != nil {
+	if err != nil && err != state.ErrNoState {
 		return err
 	}
 	if !seeded {


### PR DESCRIPTION
When seeding a device it's not an error if the "seeded" property
is not (yet) set in the state. No need to report this error up
and spam the logs.
