### PR TITLE
configcore: add nomanagers buildtag for conditional build

### DIFF
--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nomanagers
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/overlord/configstate/configcore/cloud.go
+++ b/overlord/configstate/configcore/cloud.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nomanagers
 
 /*
  * Copyright (C) 2018 Canonical Ltd

--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nomanagers
 
 /*
  * Copyright (C) 2017 Canonical Ltd

--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nomanagers
 
 /*
  * Copyright (C) 2017-2018 Canonical Ltd

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nomanagers
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/overlord/configstate/configcore/snapshots.go
+++ b/overlord/configstate/configcore/snapshots.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nomanagers
 
 /*
  * Copyright (C) 2019 Canonical Ltd

--- a/tests/main/snap-cli-no-managers/task.yaml
+++ b/tests/main/snap-cli-no-managers/task.yaml
@@ -1,0 +1,12 @@
+summary: Check that snap binary does not inadvertently import snapstate.
+description: |
+  This test checks that snap binary does not import snapstate when built
+  with -tags nomanagers.
+
+execute: |
+  # XXX: just check /usr/bin/snap when packaging handles 'nomanagers' tag.
+  go build -tags nomanagers -o snap-test github.com/snapcore/snapd/cmd/snap
+  if strings snap-test | MATCH "overlord/snapstate"; then
+    echo "snap binary should not import overlord/snapstate"
+    exit 1
+  fi

--- a/tests/main/snap-cli-no-managers/task.yaml
+++ b/tests/main/snap-cli-no-managers/task.yaml
@@ -3,6 +3,9 @@ description: |
   This test checks that snap binary does not import snapstate when built
   with -tags nomanagers.
 
+# XXX: enable on all systems once nomanagers tag is applied during packaging.
+systems: [ubuntu-1*, ubuntu-2*]
+
 execute: |
   # XXX: just check /usr/bin/snap when packaging handles 'nomanagers' tag.
   go build -tags nomanagers -o snap-test github.com/snapcore/snapd/cmd/snap


### PR DESCRIPTION
Add !nomanagers tag to some configcore files to allow building of snap command without any managers. Checking for overlord/snapstate imports on the snap binary acts as a simple sanity check of the effect of this tag.

This PR will be followed by packaging changes PR.

