### PR TITLE
packaging/arch: update PKGBUILD to match one in AUR

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -112,7 +112,7 @@ check() {
 
   # make sure the binaries that need to be built statically really are
   for binary in snap-exec snap-update-ns snapctl; do
-      ldd "$srcdir/go/bin/$binary" 2>&1 | grep 'not a dynamic executable'
+      LC_ALL=C ldd "$srcdir/go/bin/$binary" 2>&1 | grep -q 'not a dynamic executable'
   done
 
   SKIP_UNCLEAN=1 ./run-checks --unit

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -8,12 +8,12 @@
 
 pkgname=snapd
 pkgdesc="Service and tools for management of snap packages."
-depends=('squashfs-tools' 'libseccomp' 'libsystemd')
+depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
-            'zsh: zsh completion support')
+            'xdg-desktop-portal: desktop integration')
 pkgver=2.45
 pkgrel=1
-arch=('x86_64')
+arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"
 license=('GPL3')
 makedepends=('git' 'go' 'go-tools' 'libseccomp' 'libcap' 'systemd' 'xfsprogs' 'python-docutils' 'apparmor')
@@ -54,6 +54,8 @@ build() {
   if [[ "$WITH_TEST_KEYS" == 1 ]]; then
       GOFLAGS="$GOFLAGS -tags withtestkeys"
   fi
+  # snapd does not support modules yet, explicitly disable Go modules
+  export GO111MODULE=off
 
   export CGO_ENABLED="1"
   export CGO_CFLAGS="${CFLAGS}"
@@ -68,17 +70,20 @@ build() {
   cd "$srcdir/go/src/${_gourl}"
   XDG_CONFIG_HOME="$srcdir" ./get-deps.sh
 
-  gobuild="go build -x -v -buildmode=pie"
-  gobuild_static="go build -x -v -buildmode=pie -ldflags=-extldflags=-static"
+  # because argument expansion with quoting in bash is hard, and -ldflags=-extldflags='-foo'
+  # is not exactly the same as -ldflags "-extldflags '-foo'" use the array trick
+  # to pass exactly what we want
+  flags=(-buildmode=pie -ldflags "-s -extldflags '$LDFLAGS'")
+  staticflags=(-buildmode=pie -ldflags "-s -extldflags '$LDFLAGS -static'")
   # Build/install snap and snapd
-  $gobuild -o $srcdir/go/bin/snap $GOFLAGS "${_gourl}/cmd/snap"
-  $gobuild -o $srcdir/go/bin/snapd $GOFLAGS "${_gourl}/cmd/snapd"
-  $gobuild -o $srcdir/go/bin/snap-seccomp $GOFLAGS "${_gourl}/cmd/snap-seccomp"
-  $gobuild -o $srcdir/go/bin/snap-failure $GOFLAGS "${_gourl}/cmd/snap-failure"
+  go build "${flags[@]}" -o "$srcdir/go/bin/snap" $GOFLAGS "${_gourl}/cmd/snap"
+  go build "${flags[@]}" -o "$srcdir/go/bin/snapd" $GOFLAGS "${_gourl}/cmd/snapd"
+  go build "${flags[@]}" -o "$srcdir/go/bin/snap-seccomp" $GOFLAGS "${_gourl}/cmd/snap-seccomp"
+  go build "${flags[@]}" -o "$srcdir/go/bin/snap-failure" $GOFLAGS "${_gourl}/cmd/snap-failure"
   # build snap-exec and snap-update-ns completely static for base snaps
-  $gobuild_static -o $srcdir/go/bin/snap-update-ns $GOFLAGS "${_gourl}/cmd/snap-update-ns"
-  $gobuild_static -o $srcdir/go/bin/snap-exec $GOFLAGS "${_gourl}/cmd/snap-exec"
-  $gobuild_static -o $srcdir/go/bin/snapctl $GOFLAGS "${_gourl}/cmd/snapctl"
+  go build "${staticflags[@]}" -o "$srcdir/go/bin/snap-update-ns" $GOFLAGS "${_gourl}/cmd/snap-update-ns"
+  go build "${staticflags[@]}" -o "$srcdir/go/bin/snap-exec" $GOFLAGS "${_gourl}/cmd/snap-exec"
+  go build "${staticflags[@]}" -o "$srcdir/go/bin/snapctl" $GOFLAGS "${_gourl}/cmd/snapctl"
 
   # Generate data files such as real systemd units, dbus service, environment
   # setup helpers out of the available templates
@@ -104,6 +109,11 @@ build() {
 check() {
   export GOPATH="$srcdir/go"
   cd "$srcdir/go/src/${_gourl}"
+
+  # make sure the binaries that need to be built statically really are
+  for binary in snap-exec snap-update-ns snapctl; do
+      ldd "$srcdir/go/bin/$binary" 2>&1 | grep 'not a dynamic executable'
+  done
 
   SKIP_UNCLEAN=1 ./run-checks --unit
   # XXX: Static checks choke on autotools generated cruft. Let's not run them
@@ -137,6 +147,8 @@ package() {
      SYSTEMDSYSTEMUNITDIR=/usr/lib/systemd/system \
      SNAP_MOUNT_DIR=/var/lib/snapd/snap \
      DESTDIR="$pkgdir"
+  # no tweaks for sudo are needed
+  rm -rfv "$pkgdir/etc/sudoers.d"
 
   # Install polkit policy
   install -Dm644 data/polkit/io.snapcraft.snapd.policy \
@@ -144,14 +156,14 @@ package() {
 
   # Install executables
   install -Dm755 "$srcdir/go/bin/snap" "$pkgdir/usr/bin/snap"
+  install -Dm755 "$srcdir/go/bin/snapctl" "$pkgdir/usr/lib/snapd/snapctl"
   install -Dm755 "$srcdir/go/bin/snapd" "$pkgdir/usr/lib/snapd/snapd"
   install -Dm755 "$srcdir/go/bin/snap-seccomp" "$pkgdir/usr/lib/snapd/snap-seccomp"
   install -Dm755 "$srcdir/go/bin/snap-failure" "$pkgdir/usr/lib/snapd/snap-failure"
   install -Dm755 "$srcdir/go/bin/snap-update-ns" "$pkgdir/usr/lib/snapd/snap-update-ns"
   install -Dm755 "$srcdir/go/bin/snap-exec" "$pkgdir/usr/lib/snapd/snap-exec"
   # Ensure /usr/bin/snapctl is a symlink to /usr/libexec/snapd/snapctl
-  install -Dm755 "$srcdir/go/bin/snapctl" "$pkgdir/usr/lib/snapd/snapctl"
-  ln -s  ../lib/snapd/snapctl  "$pkgdir/usr/bin/snapctl"
+  ln -s /usr/lib/snapd/snapctl "$pkgdir/usr/bin/snapctl"
 
   # pre-create directories
   install -dm755 "$pkgdir/var/lib/snapd/snap"

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -99,6 +99,7 @@ reset_classic() {
                 EXTRA_NC_ARGS=""
                 ;;
         esac
+        # shellcheck disable=SC2086
         while ! printf 'GET / HTTP/1.0\r\n\r\n' | nc -U $EXTRA_NC_ARGS /run/snapd.socket; do sleep 0.5; done
     fi
 }


### PR DESCRIPTION
Update the PKGBUILD to match what is currently available in AUR.

The changes are mostly minor or cosmetic. A larger tweak for the go flags makes
sure that quoting is corrrect when passing nested flags eg.
`-ldflags "-extldflags='-flag -flag'"`.

Adopt a check for static binaries we already have in the RPM packaging.

