### PR TITLE
tests: fix the issue where all the tests were executed on secboot system

### DIFF
--- a/.github/workflows/test-go1.13.yaml
+++ b/.github/workflows/test-go1.13.yaml
@@ -92,7 +92,7 @@ jobs:
         system:
         - ubuntu-19.10-64
         - ubuntu-20.04-64
-        - ubuntu-20.04-64-secboot
+        - ubuntu-secboot-20.04-64
         - ubuntu-core-20-64
         - debian-sid-64
         - fedora-30-64

--- a/spread.yaml
+++ b/spread.yaml
@@ -101,15 +101,18 @@ backends:
                 workers: 6
             - fedora-31-64:
                 workers: 6
+
             - opensuse-15.0-64:
                 workers: 6
                 manual: true
+
             - arch-linux-64:
                 workers: 6
 
             - amazon-linux-2-64:
                 workers: 6
                 storage: preserve-size
+
             - centos-7-64:
                 workers: 6
                 storage: preserve-size

--- a/spread.yaml
+++ b/spread.yaml
@@ -81,7 +81,7 @@ backends:
                 image: ubuntu-2004-64-virt-enabled
                 workers: 6
                 storage: 20G
-            - ubuntu-20.04-64-secboot:
+            - ubuntu-secboot-20.04-64:
                 image: ubuntu-20.04-64
                 workers: 1
                 secureboot: true
@@ -690,6 +690,7 @@ suites:
     # All other tests run now and will heavily modify the system.
     tests/main/:
         summary: Full-system tests for snapd
+        systems: [-ubuntu-secboot-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -717,7 +718,7 @@ suites:
     tests/completion/:
         summary: completion tests
         # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-        systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
+        systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -ubuntu-secboot-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -744,6 +745,7 @@ suites:
 
     tests/regression/:
         summary: Regression tests for snapd
+        systems: [-ubuntu-secboot-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -758,7 +760,7 @@ suites:
         # Test cases are not yet ported to openSUSE that is why we keep
         # it disabled. A later PR will enable most tests and
         # drop this blacklist.
-        systems: [-ubuntu-core-*, -opensuse-*]
+        systems: [-ubuntu-core-*, -opensuse-*, -ubuntu-secboot-*]
         prepare-each: |
             # FIXME: this should really use prepare-restore.sh --prepare-suite-each
             # like other suites, needs more investigation
@@ -791,7 +793,7 @@ suites:
         # Test cases are not yet ported to Fedora/openSUSE/Arch that is why
         # we keep them disabled. A later PR will enable most tests and
         # drop this blacklist.
-        systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
+        systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -ubuntu-secboot-*]
         # unittests are run as part of the autopkgtest build already
         backends: [-autopkgtest]
         environment:

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -72,8 +72,8 @@ execute: |
     LOOP="$(cat loop.txt)"
 
     echo "Run the snap-bootstrap tool"
-    go get ../../../lib/create-partitions
-    create-partitions \
+    go get ../../lib/uc20-create-partitions
+    uc20-create-partitions \
         --encrypt --key-file keyfile \
         --recovery-key-file recovery-key \
         --policy-update-data-file policy-update-data \
@@ -82,7 +82,7 @@ execute: |
         ./gadget-dir "$LOOP"
 
     echo "Check that the key file was created"
-    test "$(stat --printf=%s ./keyfile)" = 1095
+    test "$(stat --printf=%s ./keyfile)" -ge 1000
 
     echo "Check that the partitions are created"
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -1,7 +1,7 @@
 summary: Integration tests for the snap-bootstrap binary
 
 # use the same system and tooling as uc20
-systems: [ubuntu-20.04-64-secboot]
+systems: [ubuntu-secboot-20.04-64]
 
 environment:
     # an empty $topsrcdir/tests/go.mod seems to break importing or building go

--- a/tests/regression/lp-1813365/task.yaml
+++ b/tests/regression/lp-1813365/task.yaml
@@ -1,5 +1,5 @@
 summary: Regression check for https://bugs.launchpad.net/snapd/+bug/1813365
-systems: [ubuntu-*, ubuntu-core-*, debian-*]
+systems: [ubuntu-1*, ubuntu-2*, ubuntu-core-*, debian-*]
 prepare: |
     mount --bind logger "$(command -v adduser)"
     mount --bind logger "$(command -v passwd)"


### PR DESCRIPTION
The idea is to run in ubuntu with secure-boot enabled the smoke tests and the tests just tagged to be executed on a secure-boot