### PR TITLE
tests: detect signs of crashed snap-confine

### DIFF
--- a/tests/lib/bin/invariant-tool
+++ b/tests/lib/bin/invariant-tool
@@ -5,6 +5,7 @@ show_help() {
 	echo
 	echo "Supported invariants:"
 	echo "    root-files-in-home: most of /home/* does not contain root-owned files"
+	echo "    crashed-snap-confine: /tmp/snap.rootfs_* does not exist"
 }
 
 if [ $# -eq 0 ]; then
@@ -51,10 +52,24 @@ check_root_files_in_home() {
 	fi
 }
 
+check_crashed_snap_confine() {
+	n="$1" # invariant name
+	find /tmp -name 'snap.rootfs_*' > "/tmp/invariant-tool.$n"
+	# NOTE: it may be a mount point but we are not checking that here.
+	if [ -s "/tmp/invariant-tool.$n" ]; then
+		echo "invariant-tool: it seems snap-confine has crashed" >&2
+		cat "/tmp/invariant-tool.$n" >&2
+		return 1
+	fi
+}
+
 check_invariant() {
 	case "$1" in
 		root-files-in-home)
 			check_root_files_in_home "$1"
+			;;
+		crashed-snap-confine)
+			check_crashed_snap_confine "$1"
 			;;
 		*)
 			echo "invariant-tool: unknown invariant $1" >&2
@@ -63,7 +78,7 @@ check_invariant() {
 	esac
 }
 
-ALL_INVARIANTS="root-files-in-home"
+ALL_INVARIANTS="root-files-in-home crashed-snap-confine"
 
 case "$action" in
 	check)

--- a/tests/main/invariant-tool/task.yaml
+++ b/tests/main/invariant-tool/task.yaml
@@ -51,3 +51,9 @@ execute: |
         chown root /home/ubuntu
     fi
     invariant-tool check root-files-in-home | MATCH 'invariant-tool: root-files-in-home ok'
+
+    # Invariant tool detects leftovers from crashed snap-confine.
+    mkdir /tmp/snap.rootfs_invariant-tool
+    invariant-tool check crashed-snap-confine 2>&1 | MATCH 'invariant-tool: crashed-snap-confine not-ok'
+    invariant-tool check crashed-snap-confine 2>&1 | MATCH 'invariant-tool: it seems snap-confine has crashed'
+    rmdir /tmp/snap.rootfs_invariant-tool


### PR DESCRIPTION
During a specific phase of the construction of the mount namespace,
snap-confine creates a directory matching /tmp/snap.rootfs_*. Normally
by the time snap-confine passes the baton to snap-exec, this directory
is gone. It can only stay behind if snap-confine crashes at a particular
point.

Detecting this directory may shed some light on a particular test
failure, where /tmp/snap.rootfs_* was a mount point (which is expected)
and was failed to be removed by the test prepare/restore logic.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
