### PR TITLE
cmd/snap-preseed: improve mountpoint checks of the preseeded chroot (1/3)

### DIFF
--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -67,7 +67,10 @@ func testParser(c *C) *flags.Parser {
 	return parser
 }
 
-func mockChrootDirs(c *C, rootDir string) func() {
+func mockChrootDirs(c *C, rootDir string, apparmorDir bool) func() {
+	if apparmorDir {
+		c.Assert(os.MkdirAll(filepath.Join(rootDir, "/sys/kernel/security/apparmor"), 0755), IsNil)
+	}
 	mockMountInfo := `912 920 0:57 / ${rootDir}/proc rw,nosuid,nodev,noexec,relatime - proc proc rw
 914 913 0:7 / ${rootDir}/sys/kernel/security rw,nosuid,nodev,noexec,relatime master:8 - securityfs securityfs rw
 915 920 0:58 / ${rootDir}/dev rw,relatime - tmpfs none rw,size=492k,mode=755,uid=100000,gid=100000
@@ -108,9 +111,21 @@ func (s *startPreseedSuite) TestChrootValidationUnhappy(c *C) {
 	defer restore()
 
 	tmpDir := c.MkDir()
+	defer osutil.MockMountInfo("")()
 
 	parser := testParser(c)
-	c.Check(main.Run(parser, []string{tmpDir}), ErrorMatches, `cannot preseed without access to ".*/dev" \(not a mountpoint\)`)
+	c.Check(main.Run(parser, []string{tmpDir}), ErrorMatches, "cannot preseed without the following mountpoints:\n - .*/dev\n - .*/proc\n - .*/sys/kernel/security")
+}
+
+func (s *startPreseedSuite) TestChrootValidationUnhappyNoApparmor(c *C) {
+	restore := main.MockOsGetuid(func() int { return 0 })
+	defer restore()
+
+	tmpDir := c.MkDir()
+	defer mockChrootDirs(c, tmpDir, false)()
+
+	parser := testParser(c)
+	c.Check(main.Run(parser, []string{tmpDir}), ErrorMatches, `cannot preseed without access to ".*sys/kernel/security/apparmor"`)
 }
 
 func (s *startPreseedSuite) TestChrootValidationAlreadyPreseeded(c *C) {
@@ -136,7 +151,7 @@ func (s *startPreseedSuite) TestChrootFailure(c *C) {
 	defer restoreSyscallChroot()
 
 	tmpDir := c.MkDir()
-	mockChrootDirs(c, tmpDir)
+	defer mockChrootDirs(c, tmpDir, true)()
 
 	parser := testParser(c)
 	c.Check(main.Run(parser, []string{tmpDir}), ErrorMatches, fmt.Sprintf("cannot chroot into %s: FAIL: %s", tmpDir, tmpDir))
@@ -145,7 +160,7 @@ func (s *startPreseedSuite) TestChrootFailure(c *C) {
 func (s *startPreseedSuite) TestRunPreseedHappy(c *C) {
 	tmpDir := c.MkDir()
 	dirs.SetRootDir(tmpDir)
-	mockChrootDirs(c, tmpDir)
+	defer mockChrootDirs(c, tmpDir, true)()
 
 	restoreOsGuid := main.MockOsGetuid(func() int { return 0 })
 	defer restoreOsGuid()
@@ -345,7 +360,7 @@ func (s *startPreseedSuite) TestClassicRequired(c *C) {
 func (s *startPreseedSuite) TestRunPreseedUnsupportedVersion(c *C) {
 	tmpDir := c.MkDir()
 	dirs.SetRootDir(tmpDir)
-	mockChrootDirs(c, tmpDir)
+	defer mockChrootDirs(c, tmpDir, true)()
 
 	restoreOsGuid := main.MockOsGetuid(func() int { return 0 })
 	defer restoreOsGuid()

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"syscall"
 
 	"github.com/snapcore/snapd/cmd/cmdutil"
@@ -59,12 +60,29 @@ func checkChroot(preseedChroot string) error {
 		return fmt.Errorf("the system at %q appears to be preseeded, pass --reset flag to clean it up", preseedChroot)
 	}
 
-	// sanity checks of the critical mountpoints inside chroot directory
-	for _, p := range []string{"/sys/kernel/security/apparmor", "/proc/self", "/dev/mem"} {
-		path := filepath.Join(preseedChroot, p)
-		if exists := osutil.FileExists(path); !exists {
-			return fmt.Errorf("cannot pre-seed without access to %q", path)
+	// sanity checks of the critical mountpoints inside chroot directory.
+	required := map[string]bool{}
+	// required mountpoints are relative to the preseed chroot
+	for _, p := range []string{"/sys/kernel/security", "/proc", "/dev"} {
+		required[filepath.Join(preseedChroot, p)] = true
+	}
+	entries, err := osutil.LoadMountInfo()
+	if err != nil {
+		return fmt.Errorf("cannot parse mount info: %v", err)
+	}
+	for _, ent := range entries {
+		if _, ok := required[ent.MountDir]; ok {
+			delete(required, ent.MountDir)
 		}
+	}
+	// non empty required indicates missing mountpoint(s), print just one.
+	if len(required) > 0 {
+		sorted := []string{}
+		for path := range required {
+			sorted = append(sorted, path)
+		}
+		sort.Strings(sorted)
+		return fmt.Errorf("cannot preseed without access to %q (not a mountpoint)", sorted[0])
 	}
 
 	return nil


### PR DESCRIPTION
Fix and improve mountpoint checks in snap-preseed: check actual mount points with help from osutil.LoadMountInfo(). Don't require /dev/kmem - it was an incorrect requirement that just acted as a simple canary for non-empty /dev.

This is the first of the fixes that should make preseeding work in lxd containers.

