### PR TITLE
tests: remove gnome-online-accounts we install

### DIFF
--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -33,6 +33,7 @@ prepare: |
 restore: |
     session-tool -u test --restore
 
+    apt-get remove -y --purge gnome-online-accounts
     apt-get autoremove --purge -y
 
     # Ensure the file we are expecting to remove is there. This ought to catch


### PR DESCRIPTION
This was added as a comment to the original review on
https://github.com/snapcore/snapd/pull/8681 but was lost before merging.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
