### PR TITLE
interfaces/serial-port: add NXP SC16IS7xx (ttySCX) to allowed devices

### DIFF
--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -72,7 +72,8 @@ func (iface *serialPortInterface) String() string {
 //  - ttySX (UART serial ports)
 //  - ttyOX (UART serial ports on ARM)
 //  - ttymxcX (serial ports on i.mx6UL)
-var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(mxc|USB|ACM|AMA|XRUSB|S|O)[0-9]+$")
+//  - ttySCX (NXP SC16IS7xx serial devices)
+var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(mxc|USB|ACM|AMA|XRUSB|S|O|SC)[0-9]+$")
 
 // Pattern that is considered valid for the udev symlink to the serial device,
 // path attributes will be compared to this for validity when usb vid and pid


### PR DESCRIPTION
This PR is to support NXP SC16IS7xx serial device. Its driver uses 'ttySC' as the node name prefix.

I've built a testing version on [launchpad](https://code.launchpad.net/~robertliu/+snap/snapd+ttysc) and verified it on an armhf platform with this device.
