### PR TITLE
cmd/snap/model: support store, system-user-authority keys in --verbose

### DIFF
--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -54,8 +54,8 @@ model assertion.
 	errNoVerboseAssertion = errors.New(i18n.G("cannot use --verbose with --assertion"))
 
 	// this list is a "nice" "human" "readable" "ordering" of headers to print
-	// off, sorted in lexographical order with meta headers and primary key
-	// headers removed, and big nasty keys such as device-key-sha3-384 and
+	// off, sorted in lexical order with meta headers and primary key headers
+	// removed, and big nasty keys such as device-key-sha3-384 and
 	// device-key at the bottom
 	// it also contains both serial and model assertion headers, but we
 	// follow the same code path for both assertion types and some of the
@@ -68,6 +68,8 @@ model assertion.
 		"gadget",
 		"kernel",
 		"revision",
+		"store",
+		"system-user-authority",
 		"timestamp",
 		"required-snaps",
 		"device-key-sha3-384",
@@ -241,7 +243,7 @@ func (x *cmdModel) Execute(args []string) error {
 			// switch on which header it is to handle some special cases
 			switch headerName {
 			// list of scalars
-			case "required-snaps":
+			case "required-snaps", "system-user-authority":
 				headerIfaceList, ok := headerValue.([]interface{})
 				if !ok {
 					return invalidTypeErr

--- a/cmd/snap/cmd_model_test.go
+++ b/cmd/snap/cmd_model_test.go
@@ -37,6 +37,10 @@ architecture: amd64
 base: core18
 gadget: pc=18
 kernel: pc-kernel=18
+store: mememestore
+system-user-authority:
+  - youyouyou
+  - mememe
 required-snaps:
   - core
   - hello-world
@@ -65,6 +69,10 @@ display-name: Model Name
 base: core18
 gadget: pc=18
 kernel: pc-kernel=18
+store: mememestore
+system-user-authority:
+  - youyouyou
+  - mememe
 required-snaps:
   - core
   - hello-world
@@ -314,13 +322,17 @@ func (s *SnapSuite) TestModelVerbose(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `
-brand-id:        mememe
-model:           test-model
-serial:          serialserial
-architecture:    amd64
-base:            core18
-gadget:          pc=18
-kernel:          pc-kernel=18
+brand-id:               mememe
+model:                  test-model
+serial:                 serialserial
+architecture:           amd64
+base:                   core18
+gadget:                 pc=18
+kernel:                 pc-kernel=18
+store:                  mememestore
+system-user-authority:  
+  - youyouyou
+  - mememe
 timestamp:       2017-07-27T00:00:00Z
 required-snaps:  
   - core
@@ -341,14 +353,18 @@ func (s *SnapSuite) TestModelVerboseDisplayName(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `
-brand-id:        mememe
-model:           test-model
-serial:          serialserial
-architecture:    amd64
-base:            core18
-display-name:    Model Name
-gadget:          pc=18
-kernel:          pc-kernel=18
+brand-id:               mememe
+model:                  test-model
+serial:                 serialserial
+architecture:           amd64
+base:                   core18
+display-name:           Model Name
+gadget:                 pc=18
+kernel:                 pc-kernel=18
+store:                  mememestore
+system-user-authority:  
+  - youyouyou
+  - mememe
 timestamp:       2017-07-27T00:00:00Z
 required-snaps:  
   - core
@@ -369,13 +385,17 @@ func (s *SnapSuite) TestModelVerboseNoSerialYet(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `
-brand-id:        mememe
-model:           test-model
-serial:          -- (device not registered yet)
-architecture:    amd64
-base:            core18
-gadget:          pc=18
-kernel:          pc-kernel=18
+brand-id:               mememe
+model:                  test-model
+serial:                 -- (device not registered yet)
+architecture:           amd64
+base:                   core18
+gadget:                 pc=18
+kernel:                 pc-kernel=18
+store:                  mememestore
+system-user-authority:  
+  - youyouyou
+  - mememe
 timestamp:       2017-07-27T00:00:00Z
 required-snaps:  
   - core


### PR DESCRIPTION
These fields are only seen on devices hooked up to brand stores, but are quite helpful in administrators debugging or getting info about the devices.

Fixes: https://bugs.launchpad.net/snapd/+bug/1879947