### PR TITLE
tests: setup portals before starting user session

### DIFF
--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -20,15 +20,13 @@ description: |
 systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 prepare: |
-    session-tool -u test --prepare
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
+    session-tool -u test --prepare
 
 restore: |
     session-tool -u test --restore
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -15,11 +15,10 @@ environment:
     EDITOR_HISTORY: /tmp/editor-history.txt
 
 prepare: |
-    session-tool -u test --prepare
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
+    session-tool -u test --prepare
 
     # Configure fake web browser
     session-tool -u test mkdir -p ~test/.local/share/applications
@@ -39,7 +38,6 @@ prepare: |
 
 restore: |
     session-tool -u test --restore
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -12,11 +12,10 @@ environment:
     BROWSER_HISTORY: /tmp/browser-history.txt
 
 prepare: |
-    session-tool -u test --prepare
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
+    session-tool -u test --prepare
 
     # Configure fake web browser
     session-tool -u test mkdir -p ~test/.local/share/applications
@@ -36,7 +35,6 @@ prepare: |
 
 restore: |
     session-tool -u test --restore
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -23,15 +23,13 @@ description: |
 systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 prepare: |
-    session-tool -u test --prepare
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
+    session-tool -u test --prepare
 
 restore: |
     session-tool -u test --restore
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals

--- a/tests/main/xdg-open-portal/task.yaml
+++ b/tests/main/xdg-open-portal/task.yaml
@@ -21,11 +21,10 @@ environment:
     EDITOR_HISTORY: /tmp/editor-history.txt
 
 prepare: |
-    session-tool -u test --prepare
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     setup_portals
+    session-tool -u test --prepare
 
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
@@ -67,7 +66,6 @@ prepare: |
 
 restore: |
     session-tool -u test --restore
-
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals


### PR DESCRIPTION
The portals contain session level services. We need to prepare them
*ahead* of starting the session or we risk running the real
implementation.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
