### PR TITLE
snap/squashfs: also symlink snap Install with uc20 seed snap dir layout

### DIFF
--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -21,6 +21,7 @@ package devicestate_test
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -30,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -216,6 +218,15 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv
 		err = snapstate.Get(state, reqName, &snapst)
 		c.Assert(err, IsNil)
 		c.Assert(snapst.Required, Equals, true, Commentf("required not set for %v", reqName))
+
+		if m.Mode == "run" {
+			// also ensure that in run mode none of the snaps are installed as
+			// symlinks, they must be copied onto ubuntu-data
+			files, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, reqName+"_*.snap"))
+			c.Assert(err, IsNil)
+			c.Assert(files, HasLen, 1)
+			c.Assert(osutil.IsSymlink(files[0]), Equals, false)
+		}
 	}
 
 	// the right systemd commands were run

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -74,10 +74,10 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 		}
 	}
 
-	// in uc20 run mode, all snaps must be copied when installing
+	// in uc20 run mode, all snaps must be on the same device
 	opts := &snap.InstallOptions{}
 	if dev.HasModeenv() && dev.RunMode() {
-		opts.MustCopy = true
+		opts.MustNotCrossDevices = true
 	}
 
 	var didNothing bool

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -74,8 +74,14 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 		}
 	}
 
+	// in uc20 run mode, all snaps must be copied when installing
+	opts := &snap.InstallOptions{}
+	if dev.HasModeenv() && dev.RunMode() {
+		opts.MustCopy = true
+	}
+
 	var didNothing bool
-	if didNothing, err = snapf.Install(s.MountFile(), instdir, nil); err != nil {
+	if didNothing, err = snapf.Install(s.MountFile(), instdir, opts); err != nil {
 		return snapType, nil, err
 	}
 

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -75,7 +75,7 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 	}
 
 	var didNothing bool
-	if didNothing, err = snapf.Install(s.MountFile(), instdir); err != nil {
+	if didNothing, err = snapf.Install(s.MountFile(), instdir, nil); err != nil {
 		return snapType, nil, err
 	}
 

--- a/snap/container.go
+++ b/snap/container.go
@@ -61,9 +61,12 @@ type Container interface {
 // on a system with tmpfs mounted as writable or with full disk encryption and
 // graded secured on UC20.
 type InstallOptions struct {
-	// MustCopy indicates that the snap file must be copied as-is, and cannot be
-	// linked either through a hard-link or a symlink.
-	MustCopy bool
+	// MustNotCrossDevices indicates that the snap file when installed to the
+	// target must not cross devices. For example, installing a snap file from
+	// the ubuntu-seed partition onto the ubuntu-data partition must result in
+	// an installation on ubuntu-data that does not depend or reference
+	// ubuntu-seed at all.
+	MustNotCrossDevices bool
 }
 
 var (

--- a/snap/container.go
+++ b/snap/container.go
@@ -50,10 +50,20 @@ type Container interface {
 
 	// Install copies the snap file to targetPath (and possibly unpacks it to mountDir).
 	// The bool return value indicates if the backend had nothing to do on install.
-	Install(targetPath, mountDir string) (bool, error)
+	Install(targetPath, mountDir string, opts *InstallOptions) (bool, error)
 
 	// Unpack unpacks the src parts to the dst directory
 	Unpack(src, dst string) error
+}
+
+// InstallOptions is for customizing the behavior of Install() from a higher
+// level function, i.e. from overlord customizing how a snap file is installed
+// on a system with tmpfs mounted as writable or with full disk encryption and
+// graded secured on UC20.
+type InstallOptions struct {
+	// MustCopy indicates that the snap file must be copied as-is, and cannot be
+	// linked either through a hard-link or a symlink.
+	MustCopy bool
 }
 
 var (

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -67,7 +67,7 @@ func (s *SnapDir) Size() (size int64, err error) {
 
 func (s *SnapDir) Install(targetPath, mountDir string, opts *snap.InstallOptions) (bool, error) {
 	// if we need to copy by policy, do that
-	if opts != nil && opts.MustCopy {
+	if opts != nil && opts.MustNotCrossDevices {
 		return false, osutil.CopyFile(s.path, targetPath, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
 	}
 

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -66,10 +66,7 @@ func (s *SnapDir) Size() (size int64, err error) {
 }
 
 func (s *SnapDir) Install(targetPath, mountDir string, opts *snap.InstallOptions) (bool, error) {
-	// if we need to copy by policy, do that
-	if opts != nil && opts.MustNotCrossDevices {
-		return false, osutil.CopyFile(s.path, targetPath, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
-	}
+	// TODO:UC20: support MustNotCrossDevices somehow here
 
 	return false, os.Symlink(s.path, targetPath)
 }

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
 
 func IsSnapDir(path string) bool {
@@ -64,7 +65,12 @@ func (s *SnapDir) Size() (size int64, err error) {
 	return totalSize, nil
 }
 
-func (s *SnapDir) Install(targetPath, mountDir string) (bool, error) {
+func (s *SnapDir) Install(targetPath, mountDir string, opts *snap.InstallOptions) (bool, error) {
+	// if we need to copy by policy, do that
+	if opts != nil && opts.MustCopy {
+		return false, osutil.CopyFile(s.path, targetPath, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
+	}
+
 	return false, os.Symlink(s.path, targetPath)
 }
 

--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -114,7 +114,9 @@ func (s *SnapdirTestSuite) TestInstallMustNotCrossDevices(c *C) {
 	didNothing, err := sn.Install(targetPath, "unused-mount-dir", &snap.InstallOptions{MustNotCrossDevices: true})
 	c.Assert(err, IsNil)
 	c.Check(didNothing, Equals, false)
-	c.Check(osutil.IsSymlink(targetPath), Equals, false)
+	// TODO:UC20: fix this test when snapdir Install() understands/does
+	//            something with opts.MustNotCrossDevices
+	c.Check(osutil.IsSymlink(targetPath), Equals, true)
 }
 
 func walkEqual(tryBaseDir, sub string, c *C) {

--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
 
 	. "gopkg.in/check.v1"
@@ -47,8 +49,8 @@ func (s *SnapdirTestSuite) TestReadFile(c *C) {
 	err := ioutil.WriteFile(filepath.Join(d, "foo"), needle, 0644)
 	c.Assert(err, IsNil)
 
-	snap := snapdir.New(d)
-	content, err := snap.ReadFile("foo")
+	sn := snapdir.New(d)
+	content, err := sn.ReadFile("foo")
 	c.Assert(err, IsNil)
 	c.Assert(content, DeepEquals, needle)
 }
@@ -59,8 +61,8 @@ func (s *SnapdirTestSuite) TestRandomAccessFile(c *C) {
 	err := ioutil.WriteFile(filepath.Join(d, "foo"), needle, 0644)
 	c.Assert(err, IsNil)
 
-	snap := snapdir.New(d)
-	r, err := snap.RandomAccessFile("foo")
+	sn := snapdir.New(d)
+	r, err := sn.RandomAccessFile("foo")
 	c.Assert(err, IsNil)
 	defer r.Close()
 
@@ -81,8 +83,8 @@ func (s *SnapdirTestSuite) TestListDir(c *C) {
 	err = ioutil.WriteFile(filepath.Join(d, "test", "test2"), nil, 0644)
 	c.Assert(err, IsNil)
 
-	snap := snapdir.New(d)
-	fileNames, err := snap.ListDir("test")
+	sn := snapdir.New(d)
+	fileNames, err := sn.ListDir("test")
 	c.Assert(err, IsNil)
 	c.Assert(fileNames, HasLen, 2)
 	c.Check(fileNames[0], Equals, "test1")
@@ -91,16 +93,28 @@ func (s *SnapdirTestSuite) TestListDir(c *C) {
 
 func (s *SnapdirTestSuite) TestInstall(c *C) {
 	tryBaseDir := c.MkDir()
-	snap := snapdir.New(tryBaseDir)
+	sn := snapdir.New(tryBaseDir)
 
 	varLibSnapd := c.MkDir()
 	targetPath := filepath.Join(varLibSnapd, "foo_1.0.snap")
-	didNothing, err := snap.Install(targetPath, "unused-mount-dir")
+	didNothing, err := sn.Install(targetPath, "unused-mount-dir", nil)
 	c.Assert(err, IsNil)
 	c.Check(didNothing, Equals, false)
 	symlinkTarget, err := filepath.EvalSymlinks(targetPath)
 	c.Assert(err, IsNil)
 	c.Assert(symlinkTarget, Equals, tryBaseDir)
+}
+
+func (s *SnapdirTestSuite) TestInstallMustCopy(c *C) {
+	tryBaseDir := c.MkDir()
+	sn := snapdir.New(tryBaseDir)
+
+	varLibSnapd := c.MkDir()
+	targetPath := filepath.Join(varLibSnapd, "foo_1.0.snap")
+	didNothing, err := sn.Install(targetPath, "unused-mount-dir", &snap.InstallOptions{MustCopy: true})
+	c.Assert(err, IsNil)
+	c.Check(didNothing, Equals, false)
+	c.Check(osutil.IsSymlink(targetPath), Equals, false)
 }
 
 func walkEqual(tryBaseDir, sub string, c *C) {
@@ -118,8 +132,8 @@ func walkEqual(tryBaseDir, sub string, c *C) {
 	})
 
 	sdw := map[string]os.FileInfo{}
-	snap := snapdir.New(tryBaseDir)
-	snap.Walk(sub, func(path string, info os.FileInfo, err error) error {
+	sn := snapdir.New(tryBaseDir)
+	sn.Walk(sub, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -105,13 +105,13 @@ func (s *SnapdirTestSuite) TestInstall(c *C) {
 	c.Assert(symlinkTarget, Equals, tryBaseDir)
 }
 
-func (s *SnapdirTestSuite) TestInstallMustCopy(c *C) {
+func (s *SnapdirTestSuite) TestInstallMustNotCrossDevices(c *C) {
 	tryBaseDir := c.MkDir()
 	sn := snapdir.New(tryBaseDir)
 
 	varLibSnapd := c.MkDir()
 	targetPath := filepath.Join(varLibSnapd, "foo_1.0.snap")
-	didNothing, err := sn.Install(targetPath, "unused-mount-dir", &snap.InstallOptions{MustCopy: true})
+	didNothing, err := sn.Install(targetPath, "unused-mount-dir", &snap.InstallOptions{MustNotCrossDevices: true})
 	c.Assert(err, IsNil)
 	c.Check(didNothing, Equals, false)
 	c.Check(osutil.IsSymlink(targetPath), Equals, false)

--- a/snap/snapfile/snapfile_test.go
+++ b/snap/snapfile/snapfile_test.go
@@ -74,7 +74,7 @@ func (s *snapFileTestSuite) TestOpenSquashfs(c *C) {
 	targetPath := filepath.Join(c.MkDir(), "target.snap")
 	mountDir := c.MkDir()
 	// we should have copied it
-	didNothing, err := sn.Install(targetPath, mountDir)
+	didNothing, err := sn.Install(targetPath, mountDir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(didNothing, Equals, false)
 	c.Check(osutil.FileExists(targetPath), Equals, true)
@@ -107,7 +107,7 @@ func (s *snapFileTestSuite) TestOpenSnapdir(c *C) {
 	targetPath := filepath.Join(c.MkDir(), "target.snap")
 	mountDir := c.MkDir()
 	// we should have copied it
-	didNothing, err := sn.Install(targetPath, mountDir)
+	didNothing, err := sn.Install(targetPath, mountDir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(didNothing, Equals, false)
 	c.Check(osutil.FileExists(targetPath), Equals, true)

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -133,11 +133,6 @@ func (s *Snap) Install(targetPath, mountDir string, opts *snap.InstallOptions) (
 	// if the installation must not cross devices, then we should not use
 	// symlinks and instead must copy the file entirely, this is the case
 	// during seeding on uc20 in run mode for example
-
-	// TODO:UC20: we might still have some situation where
-	//            opts.MustNotCrossDevice is true, but we can safely symlink
-	//            from the source to the destination, but this requires knowing
-	//            what device the source and target would be on
 	if opts == nil || !opts.MustNotCrossDevices {
 		// if the source snap file is in seed, but the hardlink failed, symlinking
 		// it saves the copy (which in livecd is expensive) so try that next

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -128,9 +128,14 @@ func (s *Snap) Install(targetPath, mountDir string) (bool, error) {
 		}
 	}
 
-	// if the file is a seed, but the hardlink failed, symlinking it
-	// saves the copy (which in livecd is expensive) so try that next
-	if filepath.Dir(s.path) == dirs.SnapSeedDir && os.Symlink(s.path, targetPath) == nil {
+	// if the source snap file is in seed, but the hardlink failed, symlinking
+	// it saves the copy (which in livecd is expensive) so try that next
+	// note that on UC20, the snap file could be in a deep subdir of
+	// SnapSeedDir, i.e. /var/lib/snapd/seed/systems/20200521/snaps/<name>.snap
+	// so we need to check if it has the prefix of the seed dir
+	cleanSrc := filepath.Clean(s.path)
+	if strings.HasPrefix(cleanSrc, dirs.SnapSeedDir) &&
+		os.Symlink(s.path, targetPath) == nil {
 		return false, nil
 	}
 

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/testutil"
@@ -98,11 +99,11 @@ func makeSnapInDir(c *C, dir, manifest, data string) *squashfs.Snap {
 
 	tmp := makeSnapContents(c, manifest, data)
 	// build it
-	snap := squashfs.New(filepath.Join(dir, "foo.snap"))
-	err := snap.Build(tmp, &squashfs.BuildOpts{SnapType: snapType})
+	sn := squashfs.New(filepath.Join(dir, "foo.snap"))
+	err := sn.Build(tmp, &squashfs.BuildOpts{SnapType: snapType})
 	c.Assert(err, IsNil)
 
-	return snap
+	return sn
 }
 
 func (s *SquashfsTestSuite) SetUpTest(c *C) {
@@ -145,10 +146,10 @@ exec /bin/cp "$@"
 	})
 	defer r()
 
-	snap := makeSnap(c, "name: test", "")
+	sn := makeSnap(c, "name: test", "")
 	targetPath := filepath.Join(c.MkDir(), "target.snap")
 	mountDir := c.MkDir()
-	didNothing, err := snap.Install(targetPath, mountDir)
+	didNothing, err := sn.Install(targetPath, mountDir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(didNothing, Equals, false)
 	c.Check(osutil.FileExists(targetPath), Equals, true)
@@ -175,12 +176,12 @@ func (s *SquashfsTestSuite) TestInstallSimpleOnOverlayfs(c *C) {
 	defer restore()
 
 	c.Assert(os.MkdirAll(dirs.SnapSeedDir, 0755), IsNil)
-	snap := makeSnapInDir(c, dirs.SnapSeedDir, "name: test2", "")
+	sn := makeSnapInDir(c, dirs.SnapSeedDir, "name: test2", "")
 	targetPath := filepath.Join(c.MkDir(), "target.snap")
 	_, err := os.Lstat(targetPath)
 	c.Check(os.IsNotExist(err), Equals, true)
 
-	didNothing, err := snap.Install(targetPath, c.MkDir())
+	didNothing, err := sn.Install(targetPath, c.MkDir(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(didNothing, Equals, false)
 	// symlink in place
@@ -204,15 +205,15 @@ exec /bin/cp "$@"
 `)
 	defer cmd.Restore()
 
-	snap := makeSnap(c, "name: test2", "")
+	sn := makeSnap(c, "name: test2", "")
 	targetPath := filepath.Join(c.MkDir(), "target.snap")
 	mountDir := c.MkDir()
-	didNothing, err := snap.Install(targetPath, mountDir)
+	didNothing, err := sn.Install(targetPath, mountDir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(didNothing, Equals, false)
 	c.Check(cmd.Calls(), HasLen, 1)
 
-	didNothing, err = snap.Install(targetPath, mountDir)
+	didNothing, err = sn.Install(targetPath, mountDir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(didNothing, Equals, true)
 	c.Check(cmd.Calls(), HasLen, 1) // and not 2 \o/
@@ -222,12 +223,12 @@ func (s *SquashfsTestSuite) TestInstallSeedNoLink(c *C) {
 	defer noLink()()
 
 	c.Assert(os.MkdirAll(dirs.SnapSeedDir, 0755), IsNil)
-	snap := makeSnapInDir(c, dirs.SnapSeedDir, "name: test2", "")
+	sn := makeSnapInDir(c, dirs.SnapSeedDir, "name: test2", "")
 	targetPath := filepath.Join(c.MkDir(), "target.snap")
 	_, err := os.Lstat(targetPath)
 	c.Check(os.IsNotExist(err), Equals, true)
 
-	didNothing, err := snap.Install(targetPath, c.MkDir())
+	didNothing, err := sn.Install(targetPath, c.MkDir(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(didNothing, Equals, false)
 	c.Check(osutil.IsSymlink(targetPath), Equals, true) // \o/
@@ -243,33 +244,48 @@ func (s *SquashfsTestSuite) TestInstallUC20SeedNoLink(c *C) {
 	_, err := os.Lstat(targetPath)
 	c.Check(os.IsNotExist(err), Equals, true)
 
-	didNothing, err := snap.Install(targetPath, c.MkDir())
+	didNothing, err := snap.Install(targetPath, c.MkDir(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(didNothing, Equals, false)
 	c.Check(osutil.IsSymlink(targetPath), Equals, true) // \o/
 }
 
+func (s *SquashfsTestSuite) TestInstallMustCopy(c *C) {
+	defer noLink()()
+
+	c.Assert(os.MkdirAll(dirs.SnapSeedDir, 0755), IsNil)
+	sn := makeSnapInDir(c, dirs.SnapSeedDir, "name: test2", "")
+	targetPath := filepath.Join(c.MkDir(), "target.snap")
+	_, err := os.Lstat(targetPath)
+	c.Check(os.IsNotExist(err), Equals, true)
+
+	didNothing, err := sn.Install(targetPath, c.MkDir(), &snap.InstallOptions{MustCopy: true})
+	c.Assert(err, IsNil)
+	c.Assert(didNothing, Equals, false)
+	c.Check(osutil.IsSymlink(targetPath), Equals, false)
+}
+
 func (s *SquashfsTestSuite) TestInstallNothingToDo(c *C) {
-	snap := makeSnap(c, "name: test2", "")
+	sn := makeSnap(c, "name: test2", "")
 
 	targetPath := filepath.Join(c.MkDir(), "foo.snap")
-	c.Assert(os.Symlink(snap.Path(), targetPath), IsNil)
+	c.Assert(os.Symlink(sn.Path(), targetPath), IsNil)
 
-	didNothing, err := snap.Install(targetPath, c.MkDir())
+	didNothing, err := sn.Install(targetPath, c.MkDir(), nil)
 	c.Assert(err, IsNil)
 	c.Check(didNothing, Equals, true)
 }
 
 func (s *SquashfsTestSuite) TestPath(c *C) {
 	p := "/path/to/foo.snap"
-	snap := squashfs.New("/path/to/foo.snap")
-	c.Assert(snap.Path(), Equals, p)
+	sn := squashfs.New("/path/to/foo.snap")
+	c.Assert(sn.Path(), Equals, p)
 }
 
 func (s *SquashfsTestSuite) TestReadFile(c *C) {
-	snap := makeSnap(c, "name: foo", "")
+	sn := makeSnap(c, "name: foo", "")
 
-	content, err := snap.ReadFile("meta/snap.yaml")
+	content, err := sn.ReadFile("meta/snap.yaml")
 	c.Assert(err, IsNil)
 	c.Assert(string(content), Equals, "name: foo")
 }
@@ -278,15 +294,15 @@ func (s *SquashfsTestSuite) TestReadFileFail(c *C) {
 	mockUnsquashfs := testutil.MockCommand(c, "unsquashfs", `echo boom; exit 1`)
 	defer mockUnsquashfs.Restore()
 
-	snap := makeSnap(c, "name: foo", "")
-	_, err := snap.ReadFile("meta/snap.yaml")
+	sn := makeSnap(c, "name: foo", "")
+	_, err := sn.ReadFile("meta/snap.yaml")
 	c.Assert(err, ErrorMatches, "cannot run unsquashfs: boom")
 }
 
 func (s *SquashfsTestSuite) TestRandomAccessFile(c *C) {
-	snap := makeSnap(c, "name: foo", "")
+	sn := makeSnap(c, "name: foo", "")
 
-	r, err := snap.RandomAccessFile("meta/snap.yaml")
+	r, err := sn.RandomAccessFile("meta/snap.yaml")
 	c.Assert(err, IsNil)
 	defer r.Close()
 
@@ -298,9 +314,9 @@ func (s *SquashfsTestSuite) TestRandomAccessFile(c *C) {
 }
 
 func (s *SquashfsTestSuite) TestListDir(c *C) {
-	snap := makeSnap(c, "name: foo", "")
+	sn := makeSnap(c, "name: foo", "")
 
-	fileNames, err := snap.ListDir("meta/hooks")
+	fileNames, err := sn.ListDir("meta/hooks")
 	c.Assert(err, IsNil)
 	c.Assert(len(fileNames), Equals, 3)
 	c.Check(fileNames[0], Equals, "bar-hook")
@@ -310,9 +326,9 @@ func (s *SquashfsTestSuite) TestListDir(c *C) {
 
 func (s *SquashfsTestSuite) TestWalk(c *C) {
 	sub := "."
-	snap := makeSnap(c, "name: foo", "")
+	sn := makeSnap(c, "name: foo", "")
 	sqw := map[string]os.FileInfo{}
-	snap.Walk(sub, func(path string, info os.FileInfo, err error) error {
+	sn.Walk(sub, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -324,7 +340,7 @@ func (s *SquashfsTestSuite) TestWalk(c *C) {
 	})
 
 	base := c.MkDir()
-	c.Assert(snap.Unpack("*", base), IsNil)
+	c.Assert(sn.Unpack("*", base), IsNil)
 
 	sdw := map[string]os.FileInfo{}
 	snapdir.New(base).Walk(sub, func(path string, info os.FileInfo, err error) error {
@@ -374,10 +390,10 @@ func (s *SquashfsTestSuite) TestWalk(c *C) {
 // TestUnpackGlob tests the internal unpack
 func (s *SquashfsTestSuite) TestUnpackGlob(c *C) {
 	data := "some random data"
-	snap := makeSnap(c, "", data)
+	sn := makeSnap(c, "", data)
 
 	outputDir := c.MkDir()
-	err := snap.Unpack("data*", outputDir)
+	err := sn.Unpack("data*", outputDir)
 	c.Assert(err, IsNil)
 
 	// this is the file we expect
@@ -432,8 +448,8 @@ EOF
 	defer mockUnsquashfs.Restore()
 
 	data := "mock kernel snap"
-	snap := makeSnap(c, "", data)
-	err := snap.Unpack("*", "some-output-dir")
+	sn := makeSnap(c, "", data)
+	err := sn.Unpack("*", "some-output-dir")
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, `cannot extract "*" to "some-output-dir": failed: "Failed to write /tmp/1/modules/4.4.0-112-generic/modules.symbols, skipping", "Write on output file failed because No space left on device", "writer: failed to write data block 0", "Failed to write /tmp/1/modules/4.4.0-112-generic/modules.symbols.bin, skipping", and 15 more`)
 }
@@ -448,14 +464,14 @@ func (s *SquashfsTestSuite) TestBuild(c *C) {
 	err = ioutil.WriteFile(filepath.Join(buildDir, "random", "data.bin"), []byte("more data"), 0644)
 	c.Assert(err, IsNil)
 
-	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err = snap.Build(buildDir, &squashfs.BuildOpts{SnapType: "app"})
+	sn := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
+	err = sn.Build(buildDir, &squashfs.BuildOpts{SnapType: "app"})
 	c.Assert(err, IsNil)
 
 	// unsquashfs writes a funny header like:
 	//     "Parallel unsquashfs: Using 1 processor"
 	//     "1 inodes (1 blocks) to write"
-	outputWithHeader, err := exec.Command("unsquashfs", "-n", "-l", snap.Path()).Output()
+	outputWithHeader, err := exec.Command("unsquashfs", "-n", "-l", sn.Path()).Output()
 	c.Assert(err, IsNil)
 	split := strings.Split(string(outputWithHeader), "\n")
 	output := strings.Join(split[3:], "\n")
@@ -489,14 +505,14 @@ data.bin
 `), 0644)
 	c.Assert(err, IsNil)
 
-	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err = snap.Build(buildDir, &squashfs.BuildOpts{
+	sn := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
+	err = sn.Build(buildDir, &squashfs.BuildOpts{
 		SnapType:     "app",
 		ExcludeFiles: []string{excludesFilename},
 	})
 	c.Assert(err, IsNil)
 
-	outputWithHeader, err := exec.Command("unsquashfs", "-n", "-l", snap.Path()).Output()
+	outputWithHeader, err := exec.Command("unsquashfs", "-n", "-l", sn.Path()).Output()
 	c.Assert(err, IsNil)
 	split := strings.Split(string(outputWithHeader), "\n")
 	output := strings.Join(split[3:], "\n")
@@ -517,8 +533,8 @@ func (s *SquashfsTestSuite) TestBuildSupportsMultipleExcludesWithOnlyOneWildcard
 	defer mksq.Restore()
 
 	snapPath := filepath.Join(c.MkDir(), "foo.snap")
-	snap := squashfs.New(snapPath)
-	err := snap.Build(c.MkDir(), &squashfs.BuildOpts{
+	sn := squashfs.New(snapPath)
+	err := sn.Build(c.MkDir(), &squashfs.BuildOpts{
 		SnapType:     "core",
 		ExcludeFiles: []string{"exclude1", "exclude2", "exclude3"},
 	})
@@ -545,8 +561,8 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromCoreIfAvailable(c *C) {
 
 	buildDir := c.MkDir()
 
-	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err := snap.Build(buildDir, nil)
+	sn := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
+	err := sn.Build(buildDir, nil)
 	c.Assert(err, IsNil)
 	c.Check(usedFromCore, Equals, true)
 	c.Check(mksq.Calls(), HasLen, 0)
@@ -564,8 +580,8 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromClassicIfCoreUnavailable(
 
 	buildDir := c.MkDir()
 
-	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err := snap.Build(buildDir, nil)
+	sn := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
+	err := sn.Build(buildDir, nil)
 	c.Assert(err, IsNil)
 	c.Check(triedFromCore, Equals, true)
 	c.Check(mksq.Calls(), HasLen, 1)
@@ -583,8 +599,8 @@ func (s *SquashfsTestSuite) TestBuildFailsIfNoMksquashfs(c *C) {
 
 	buildDir := c.MkDir()
 
-	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err := snap.Build(buildDir, nil)
+	sn := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
+	err := sn.Build(buildDir, nil)
 	c.Assert(err, ErrorMatches, "mksquashfs call failed:.*")
 	c.Check(triedFromCore, Equals, true)
 	c.Check(mksq.Calls(), HasLen, 1)
@@ -638,8 +654,8 @@ exit 1
 
 	data := "mock kernel snap"
 	dir := makeSnapContents(c, "", data)
-	snap := squashfs.New("foo.snap")
-	c.Check(snap.Build(dir, &squashfs.BuildOpts{SnapType: "kernel"}), ErrorMatches, `mksquashfs call failed: Yeah, nah.`)
+	sn := squashfs.New("foo.snap")
+	c.Check(sn.Build(dir, &squashfs.BuildOpts{SnapType: "kernel"}), ErrorMatches, `mksquashfs call failed: Yeah, nah.`)
 }
 
 func (s *SquashfsTestSuite) TestUnsquashfsStderrWriter(c *C) {
@@ -701,11 +717,11 @@ func (s *SquashfsTestSuite) TestBuildDate(c *C) {
 	c.Assert(os.Chtimes(d, then, then), IsNil)
 	// make a snap using this directory
 	filename := filepath.Join(c.MkDir(), "foo.snap")
-	snap := squashfs.New(filename)
-	c.Assert(snap.Build(d, nil), IsNil)
+	sn := squashfs.New(filename)
+	c.Assert(sn.Build(d, nil), IsNil)
 	// and see it's BuildDate is _now_, not _then_.
-	c.Check(squashfs.BuildDate(filename), Equals, snap.BuildDate())
-	c.Check(math.Abs(now.Sub(snap.BuildDate()).Seconds()) <= 61, Equals, true, Commentf("Unexpected build date %s", snap.BuildDate()))
+	c.Check(squashfs.BuildDate(filename), Equals, sn.BuildDate())
+	c.Check(math.Abs(now.Sub(sn.BuildDate()).Seconds()) <= 61, Equals, true, Commentf("Unexpected build date %s", sn.BuildDate()))
 }
 
 func (s *SquashfsTestSuite) TestBuildChecksReadDifferentFiles(c *C) {
@@ -733,8 +749,8 @@ func (s *SquashfsTestSuite) TestBuildChecksReadDifferentFiles(c *C) {
 	c.Assert(err, IsNil)
 
 	filename := filepath.Join(c.MkDir(), "foo.snap")
-	snap := squashfs.New(filename)
-	err = snap.Build(d, nil)
+	sn := squashfs.New(filename)
+	err = sn.Build(d, nil)
 	c.Assert(err, ErrorMatches, `(?s)cannot access the following locations in the snap source directory:
 - ro-(file|dir) \(owner [0-9]+:[0-9]+ mode 000\)
 - ro-(file|dir) \(owner [0-9]+:[0-9]+ mode 000\)
@@ -758,8 +774,8 @@ func (s *SquashfsTestSuite) TestBuildChecksReadErrorLimit(c *C) {
 		c.Assert(err, IsNil)
 	}
 	filename := filepath.Join(c.MkDir(), "foo.snap")
-	snap := squashfs.New(filename)
-	err := snap.Build(d, nil)
+	sn := squashfs.New(filename)
+	err := sn.Build(d, nil)
 	c.Assert(err, ErrorMatches, `(?s)cannot access the following locations in the snap source directory:
 (- [0-9]+ \(owner [0-9]+:[0-9]+ mode 000.*\).){10}- too many errors, listing first 10 entries
 `)
@@ -767,8 +783,8 @@ func (s *SquashfsTestSuite) TestBuildChecksReadErrorLimit(c *C) {
 
 func (s *SquashfsTestSuite) TestBuildBadSource(c *C) {
 	filename := filepath.Join(c.MkDir(), "foo.snap")
-	snap := squashfs.New(filename)
-	err := snap.Build("does-not-exist", nil)
+	sn := squashfs.New(filename)
+	err := sn.Build("does-not-exist", nil)
 	c.Assert(err, ErrorMatches, ".*does-not-exist/: no such file or directory")
 }
 
@@ -779,14 +795,14 @@ func (s *SquashfsTestSuite) TestBuildWithCompressionHappy(c *C) {
 
 	defaultComp := "xz"
 	for _, comp := range []string{"", "xz", "gzip", "lzo"} {
-		snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-		err = snap.Build(buildDir, &squashfs.BuildOpts{
+		sn := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
+		err = sn.Build(buildDir, &squashfs.BuildOpts{
 			Compression: comp,
 		})
 		c.Assert(err, IsNil)
 
 		// check compression
-		outputWithHeader, err := exec.Command("unsquashfs", "-n", "-s", snap.Path()).CombinedOutput()
+		outputWithHeader, err := exec.Command("unsquashfs", "-n", "-s", sn.Path()).CombinedOutput()
 		c.Assert(err, IsNil)
 		// ensure default is xz
 		if comp == "" {
@@ -801,8 +817,8 @@ func (s *SquashfsTestSuite) TestBuildWithCompressionUnhappy(c *C) {
 	err := os.MkdirAll(filepath.Join(buildDir, "/random/dir"), 0755)
 	c.Assert(err, IsNil)
 
-	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err = snap.Build(buildDir, &squashfs.BuildOpts{
+	sn := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
+	err = sn.Build(buildDir, &squashfs.BuildOpts{
 		Compression: "silly",
 	})
 	c.Assert(err, ErrorMatches, "(?m)^mksquashfs call failed: ")

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -233,6 +233,22 @@ func (s *SquashfsTestSuite) TestInstallSeedNoLink(c *C) {
 	c.Check(osutil.IsSymlink(targetPath), Equals, true) // \o/
 }
 
+func (s *SquashfsTestSuite) TestInstallUC20SeedNoLink(c *C) {
+	defer noLink()()
+
+	systemSnapsDir := filepath.Join(dirs.SnapSeedDir, "systems", "20200521", "snaps")
+	c.Assert(os.MkdirAll(systemSnapsDir, 0755), IsNil)
+	snap := makeSnapInDir(c, systemSnapsDir, "name: test2", "")
+	targetPath := filepath.Join(c.MkDir(), "target.snap")
+	_, err := os.Lstat(targetPath)
+	c.Check(os.IsNotExist(err), Equals, true)
+
+	didNothing, err := snap.Install(targetPath, c.MkDir())
+	c.Assert(err, IsNil)
+	c.Assert(didNothing, Equals, false)
+	c.Check(osutil.IsSymlink(targetPath), Equals, true) // \o/
+}
+
 func (s *SquashfsTestSuite) TestInstallNothingToDo(c *C) {
 	snap := makeSnap(c, "name: test2", "")
 

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -250,7 +250,7 @@ func (s *SquashfsTestSuite) TestInstallUC20SeedNoLink(c *C) {
 	c.Check(osutil.IsSymlink(targetPath), Equals, true) // \o/
 }
 
-func (s *SquashfsTestSuite) TestInstallMustCopy(c *C) {
+func (s *SquashfsTestSuite) TestInstallMustNotCrossDevices(c *C) {
 	defer noLink()()
 
 	c.Assert(os.MkdirAll(dirs.SnapSeedDir, 0755), IsNil)
@@ -259,7 +259,7 @@ func (s *SquashfsTestSuite) TestInstallMustCopy(c *C) {
 	_, err := os.Lstat(targetPath)
 	c.Check(os.IsNotExist(err), Equals, true)
 
-	didNothing, err := sn.Install(targetPath, c.MkDir(), &snap.InstallOptions{MustCopy: true})
+	didNothing, err := sn.Install(targetPath, c.MkDir(), &snap.InstallOptions{MustNotCrossDevices: true})
 	c.Assert(err, IsNil)
 	c.Assert(didNothing, Equals, false)
 	c.Check(osutil.IsSymlink(targetPath), Equals, false)

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -41,6 +41,15 @@ execute: |
     #    extra config will be merged
     test -e /writable/system-data/etc/cloud/cloud-init.disabled || [ "$(find /writable/system-data/etc/cloud/cloud.cfg.d/ | wc -l)" -gt "$(find /snap/core20/current/etc/cloud/cloud.cfg.d/ | wc -l)" ]
 
+    # ensure that we have no symlinks from /var/lib/snapd/snaps to 
+    # /var/lib/snapd/seed
+    for f in $(ls /var/lib/snapd/snaps/); do
+        if [[ -L /var/lib/snapd/snaps/$f ]]; then
+            echo "snap /var/lib/snapd/snaps/$f is a symlink but should not be"
+            exit 1
+        fi
+    done
+
     # TODO:UC20: move to the nested test
     #if [ -e /dev/tpm0 ]; then
     #    echo "The recovery key is available"

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -41,11 +41,11 @@ execute: |
     #    extra config will be merged
     test -e /writable/system-data/etc/cloud/cloud-init.disabled || [ "$(find /writable/system-data/etc/cloud/cloud.cfg.d/ | wc -l)" -gt "$(find /snap/core20/current/etc/cloud/cloud.cfg.d/ | wc -l)" ]
 
-    # ensure that we have no symlinks from /var/lib/snapd/snaps to 
+    # ensure that we have no symlinks from /var/lib/snapd/snaps to
     # /var/lib/snapd/seed
-    for f in $(ls /var/lib/snapd/snaps/); do
-        if [[ -L /var/lib/snapd/snaps/$f ]]; then
-            echo "snap /var/lib/snapd/snaps/$f is a symlink but should not be"
+    for sn in /var/lib/snapd/snaps/*.snap ; do
+        if [[ -L $sn ]]; then
+            echo "snap $sn is a symlink but should not be"
             exit 1
         fi
     done

--- a/tests/core/seed-base-symlinks/task.yaml
+++ b/tests/core/seed-base-symlinks/task.yaml
@@ -1,8 +1,9 @@
 summary: Check that the seed symlinks work
 
-# TODO:UC20: update for symlinks from ubuntu-data/var/lib/snapd/snaps to
-#            ubuntu-seed and enable for UC20
-systems: [ubuntu-core-1*]
+# We explicitly don't want symlinks from /var/lib/snapd/snaps to
+# /var/lib/snapd/seed in UC20 run mode because /var/lib/snapd/seed snaps are
+# essentially untrusted
+systems: [-ubuntu-core-20]
 
 execute: |
     # shellcheck source=tests/lib/systems.sh

--- a/tests/core/seed-base-symlinks/task.yaml
+++ b/tests/core/seed-base-symlinks/task.yaml
@@ -3,7 +3,7 @@ summary: Check that the seed symlinks work
 # We explicitly don't want symlinks from /var/lib/snapd/snaps to
 # /var/lib/snapd/seed in UC20 run mode because /var/lib/snapd/seed snaps are
 # essentially untrusted
-systems: [-ubuntu-core-20]
+systems: [-ubuntu-core-20-*]
 
 execute: |
     # shellcheck source=tests/lib/systems.sh


### PR DESCRIPTION
This ensures that during install/recover mode we use symlinks in /var/lib/snapd/snaps to /var/lib/snapd/seed/systems/<label>/snaps, and that makebootable will still copy the full snap file to /run/mnt/ubuntu-data/... such that the initramfs and run mode see a normal snap file. Note that we specifically don't want the initramfs to use symlinks from ubuntu-data to ubuntu-seed because this is not trusted.

This was prompted by https://bugs.launchpad.net/snapd/+bug/1878647 because there, the tmpfs we mount for ubuntu-data/writable is only 205M, and all the kernel and base snaps are over 205M and so the install runs out of space to copy the snap files onto the tmpfs and eventually snapd tries to uninstall itself during first-boot. 

This fixes https://bugs.launchpad.net/snapd/+bug/1878647