### PR TITLE
tests: port interfaces-network-status-classic to session-tool

### DIFF
--- a/tests/main/interfaces-network-status-classic/task.yaml
+++ b/tests/main/interfaces-network-status-classic/task.yaml
@@ -17,21 +17,17 @@ systems:
   - -amazon-linux-2-*
 
 prepare: |
-    #shellcheck source=tests/lib/dbus.sh
-    . "$TESTSLIB/dbus.sh"
-
     echo "Start the stub xdg-desktop-portal NetworkMonitor provider"
-    start_dbus_unit ./fake-portal-network-monitor.py
+    # The network-status interface is defined to operate on a session
+    # bus so for most realism, invoke it as the test user.
+    session-tool -u test --prepare
+    session-tool -u test systemd-run --user --unit test-snapd-network-monitor.service "$(pwd)/fake-portal-network-monitor.py"
 
 restore: |
-    #shellcheck source=tests/lib/dbus.sh
-    . "$TESTSLIB/dbus.sh"
-    stop_dbus_unit
+    session-tool -u test systemctl --user stop test-snapd-network-monitor.service
+    session-tool -u test --restore
 
 execute: |
-    #shellcheck disable=SC2046
-    export $(cat dbus.env)
-
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
 
@@ -42,7 +38,7 @@ execute: |
     snap connections test-snapd-network-status-client | MATCH "network-status +test-snapd-network-status-client:network-status +:network-status +-"
 
     echo "The snap can access connectivity status"
-    test-snapd-network-status-client.connectivity | MATCH "uint32 4"
+    session-tool -u test test-snapd-network-status-client.connectivity | MATCH "uint32 4"
 
     if ! snap debug sandbox-features --required apparmor:kernel:dbus; then
         exit 0
@@ -52,4 +48,4 @@ execute: |
     snap disconnect test-snapd-network-status-client:network-status
 
     echo "The connectivity status can no longer be accessed"
-    not test-snapd-network-status-client.connectivity
+    not session-tool -u test test-snapd-network-status-client.connectivity


### PR DESCRIPTION
The port is straightforward. The only change worth mentioning is that
the entire test now runs as the test user, as the interface is designed
to work with the session bus, and it felt more natural to use.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>