### PR TITLE
test: session-tool cli tweaks 

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -12,10 +12,6 @@ if [ $# -eq 0 ]; then
 	show_help
 	exit 1
 fi
-if [ "$(id -u)" -ne 0 ]; then
-    echo "session-tool needs to be invoked as root" >&2
-    exit 1
-fi
 user=root
 pid_file=
 action=
@@ -79,6 +75,11 @@ while [ $# -gt 0 ]; do
 			;;
 	esac
 done
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "session-tool needs to be invoked as root" >&2
+    exit 1
+fi
 
 case "$action" in
 	kill-leaked)

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -1,11 +1,15 @@
 #!/bin/bash -e
-if [ $# -eq 0 ]; then
+show_help() {
 	echo "usage: session-tool [-u USER] [-p PID_FILE] [--] <CMD>"
 	echo "usage: session-tool --prepare | --restore [-u USER | -u USER1,USER2,...]"
 	echo "usage: session-tool --kill-leaked"
 	echo "usage: session-tool --dump"
 	echo "usage: session-tool --has-system-systemd-and-dbus"
 	echo "usage: session-tool --has-session-systemd-and-dbus"
+}
+
+if [ $# -eq 0 ]; then
+	show_help
 	exit 1
 fi
 if [ "$(id -u)" -ne 0 ]; then
@@ -17,9 +21,10 @@ pid_file=
 action=
 while [ $# -gt 0 ]; do
 	case "$1" in
-		--)
+		-h)
 			shift
-			break
+			show_help
+			exit 0
 			;;
 		-p)
 			if [ $# -eq 1 ]; then
@@ -28,6 +33,10 @@ while [ $# -gt 0 ]; do
 			fi
 			pid_file="$2"
 			shift 2
+			;;
+		--)
+			shift
+			break
 			;;
 		--kill-leaked)
 			action=kill-leaked

--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -1,11 +1,11 @@
 #!/bin/bash -e
 show_help() {
-	echo "usage: session-tool [-u USER] [-p PID_FILE] [--] <CMD>"
-	echo "usage: session-tool --prepare | --restore [-u USER | -u USER1,USER2,...]"
-	echo "usage: session-tool --kill-leaked"
-	echo "usage: session-tool --dump"
-	echo "usage: session-tool --has-system-systemd-and-dbus"
-	echo "usage: session-tool --has-session-systemd-and-dbus"
+	echo "usage: session-tool exec [-u USER] [-p PID_FILE] [--] <CMD>"
+	echo "usage: session-tool prepare | restore [-u USER | -u USER1,USER2,...]"
+	echo "usage: session-tool kill-leaked"
+	echo "usage: session-tool dump"
+	echo "usage: session-tool has-system-systemd-and-dbus"
+	echo "usage: session-tool has-session-systemd-and-dbus"
 }
 
 if [ $# -eq 0 ]; then
@@ -34,27 +34,27 @@ while [ $# -gt 0 ]; do
 			shift
 			break
 			;;
-		--kill-leaked)
+		kill-leaked|--kill-leaked)
 			action=kill-leaked
 			shift
 			;;
-		--prepare)
+		prepare|--prepare)
 			action=prepare
 			shift
 			;;
-		--restore)
+		restore|--restore)
 			action=restore
 			shift
 			;;
-		--dump)
+		dump|--dump)
 			action=dump
 			shift
 			;;
-		--has-system-systemd-and-dbus)
+		has-system-systemd-and-dbus|--has-system-systemd-and-dbus)
 			action=has-system-systemd-and-dbus
 			shift
 			;;
-		--has-session-systemd-and-dbus)
+		has-session-systemd-and-dbus|--has-session-systemd-and-dbus)
 			action=has-session-systemd-and-dbus
 			shift
 			;;
@@ -70,7 +70,13 @@ while [ $# -gt 0 ]; do
 			echo "session-tool: unsupported argument $1" >&2
 			exit 1
 			;;
+		exec)
+			shift
+			action="exec"
+			break
+			;;
 		*)
+			action="exec"
 			break
 			;;
 	esac

--- a/tests/main/session-tool/task.yaml
+++ b/tests/main/session-tool/task.yaml
@@ -23,38 +23,38 @@ prepare: |
     fi
 
     # Kill sessions that systemd has leaked earlier.
-    session-tool --kill-leaked
+    session-tool kill-leaked
 
     # Remember details of sessions before we start.
-    session-tool --dump > before.debug.txt
+    session-tool dump > before.debug.txt
 
     # Brief version of existing sessions to measure during "restore".
     loginctl --no-legend list-sessions | sort > before.txt
 
     # Prepare for using sessions as the given user
-    session-tool --prepare -u "$USER"
+    session-tool prepare -u "$USER"
 execute: |
     # Check that stdin is forwarded correctly.
-    echo "it-works" | session-tool -u "$USER" cat | MATCH "it-works"
+    echo "it-works" | session-tool -u "$USER" exec cat | MATCH "it-works"
 
     for n in $(seq 300); do
         echo "ITERATION $(date) $n"
-        session-tool -u "$USER" id -u  2>/tmp/session-tool.log | MATCH "$(id -u "$USER")"
-        session-tool -u "$USER" env    2>/tmp/session-tool.log | MATCH "XDG_RUNTIME_DIR=/run/user/$(id -u "$USER")"
+        session-tool -u "$USER" exec id -u 2>/tmp/session-tool.log | MATCH "$(id -u "$USER")"
+        session-tool -u "$USER" exec env   2>/tmp/session-tool.log | MATCH "XDG_RUNTIME_DIR=/run/user/$(id -u "$USER")"
         # We get a logind session
-        session-tool -u "$USER" loginctl list-sessions | grep "$USER"
+        session-tool -u "$USER" exec loginctl list-sessions | grep "$USER"
         # Exit code is forwarded
-        session-tool -u "$USER" true
-        not session-tool -u "$USER" false
+        session-tool -u "$USER" exec true
+        not session-tool -u "$USER" exec false
         # The -p option can be used to know the PID of the started program.
         # This is different from the pid of session-tool as there's a session
         # manager overlooking the termination of PAM stack (internally we use runuser).
-        session-tool -u "$USER" -p /tmp/outer.pid "$(command -v any-python)" -c 'from __future__ import print_function; import os; print(os.getpid())' >/tmp/inner.pid
+        session-tool -u "$USER" -p /tmp/outer.pid exec "$(command -v any-python)" -c 'from __future__ import print_function; import os; print(os.getpid())' >/tmp/inner.pid
         test "$(cat /tmp/outer.pid)" = "$(cat /tmp/inner.pid)"
     done
 restore: |
     # Restore after using sessions as the given user
-    session-tool --restore -u "$USER"
+    session-tool restore -u "$USER"
 
     # Kill cron if it is running (check prepare for details).
     if loginctl show-session 2 >/dev/null 2>&1 && loginctl show-session 2 | grep -q Service=crond; then
@@ -62,7 +62,7 @@ restore: |
     fi
 
     # Kill sessions that systemd has leaked over time.
-    session-tool --kill-leaked
+    session-tool kill-leaked
 
     # NOTE: This part of the test is very flaky if you restart systemd-logind
     # It *seems* that all new systems (Debian Sid, Arch, Tumbleweed and Ubuntu 20.04)
@@ -79,7 +79,7 @@ restore: |
     sh -xe defer.sh && rm -f defer.sh
 
 debug: |
-    session-tool --dump > after.debug.txt
+    session-tool dump > after.debug.txt
     diff -u before.debug.txt after.debug.txt
     echo "Active timers"
     systemctl list-timers


### PR DESCRIPTION
This branch contains two main changes:
 - session-tool now responds to -h
 - session-tool now supports the new {prepare,exec,restore} interface

I didn't attempt to rename it to the new naming scheme yet as that is under discussion
and will be more invasive. This just sets the stage so that we can use `session-tool exec`
everywhere.

Please check each patch commit message for details. I specifically did not change the
bulk of the tests so that the new logic is shown to be backwards compatible.