### PR TITLE
spread.yaml: add ps aux to debug section

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -506,6 +506,8 @@ debug-each: |
         echo '# mounts'
         # use ascii output to prevent travis from messing up the encoding
         findmnt --ascii -o+PROPAGATION || true
+        echo "# processes"
+        ps aux
     fi
 
 rename:


### PR DESCRIPTION
When some tests fail it would be really useful to see what kind of
processes are around in the system. We already show the mount table and
disk usage so hopefully this won't be too long.

In particular this should help to sheld some light on some rare
failures.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
