### PR TITLE
devicestate, sysconfig: revert support for cloud.cfg.d/ in the gadget

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -511,7 +511,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeNoCloudInitForSigned(c *C) {
 	})
 }
 
-func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitFromGadget(c *C) {
+// TODO: convert test to "cloud.conf" support
+func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitFromGadgetNotSupported(c *C) {
 	// XXX: this is slightly magic - in mockInstallModeChange() we create
 	//      a mock pc gadget snap with revno 1. This is why we can set
 	//      set gadget dir here
@@ -529,12 +530,13 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitFromGadget(c
 	// cloud init config from gadget works for signed models too
 	s.mockInstallModeChange(c, "signed")
 
-	// and did tell sysconfig about the cloud-init files
-	c.Assert(s.configureRunSystemOptsPassed, DeepEquals, []*sysconfig.Options{
-		{
-			CloudInitSrcDir: filepath.Join(gadgetDir, "cloud.cfg.d"),
-			TargetRootDir:   boot.InstallHostWritableDir,
-		},
+	// nothing about cloud-init got passed to sysconf, we don't
+	// support cloud.cfg.d anymore
+	c.Assert(s.configureRunSystemOptsPassed, HasLen, 1)
+	c.Assert(s.configureRunSystemOptsPassed[0], DeepEquals, &sysconfig.Options{
+		TargetRootDir: boot.InstallHostWritableDir,
+		// not set
+		CloudInitSrcDir: "",
 	})
 }
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -50,7 +50,7 @@ var (
 
 func setSysconfigCloudOptions(opts *sysconfig.Options, gadgetDir string, model *asserts.Model) {
 	// TODO: add support for a single cloud-init `cloud.conf` file
-	//       that is then pased to sysconfig
+	//       that is then passed to sysconfig
 
 	// check cloud.cfg.d on the ubuntu-seed partition
 	//

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -49,24 +49,16 @@ var (
 )
 
 func setSysconfigCloudOptions(opts *sysconfig.Options, gadgetDir string, model *asserts.Model) {
-	// TODO: Decide what to do when both gadget and ubuntu-seed have
-	//       cloud.cfg.d/ directories.
+	// TODO: add support for a single cloud-init `cloud.conf` file
+	//       that is then pased to sysconfig
 
-	// 1. check cloud.cfg.d in the gadget snap, this is always ok regardless
-	//    of grade
-	cloudCfg := filepath.Join(gadgetDir, "cloud.cfg.d")
-	if osutil.IsDirectory(cloudCfg) {
-		opts.CloudInitSrcDir = cloudCfg
-		return
-	}
-
-	// 2. check cloud.cfg.d on the ubuntu-seed partition
+	// check cloud.cfg.d on the ubuntu-seed partition
 	//
 	// Support custom cloud.cfg.d/*.cfg files on the ubuntu-seed partition
 	// during install when in grade "dangerous".
 	//
 	// XXX: maybe move policy decision into configureRunSystem later?
-	cloudCfg = filepath.Join(boot.InitramfsUbuntuSeedDir, "data/etc/cloud/cloud.cfg.d")
+	cloudCfg := filepath.Join(boot.InitramfsUbuntuSeedDir, "data/etc/cloud/cloud.cfg.d")
 	if osutil.IsDirectory(cloudCfg) && model.Grade() == asserts.ModelDangerous {
 		opts.CloudInitSrcDir = cloudCfg
 		return

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -66,9 +66,8 @@ func installCloudInitCfg(src, targetdir string) error {
 	return nil
 }
 
-// disable cloud-init by default (as it's not confined)
-// TODO:UC20: - allow cloud.cfg.d (with whitelisted keys) for non
-//              grade dangerous systems
+// TODO:UC20: - allow cloud.conf coming from the gadget
+//            - think about if/what cloud-init means on "secured" models
 func configureCloudInit(opts *Options) (err error) {
 	if opts.TargetRootDir == "" {
 		return fmt.Errorf("unable to configure cloud-init, missing target dir")
@@ -76,6 +75,7 @@ func configureCloudInit(opts *Options) (err error) {
 
 	switch opts.CloudInitSrcDir {
 	case "":
+		// disable cloud-init by default (as it's not confined)
 		err = DisableCloudInit(opts.TargetRootDir)
 	default:
 		err = installCloudInitCfg(opts.CloudInitSrcDir, opts.TargetRootDir)


### PR DESCRIPTION
This reverts parts of https://github.com/snapcore/snapd/pull/8541
and stops support for cloud.cfg.d/ files in the gadget snap.

We will eventually support a single cloud.conf in the gadget but
that will come later.
