### PR TITLE
testutil/exec.go: set PATH after running shellcheck

### DIFF
--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -110,6 +110,7 @@ var selfLock = `if [ "${FLOCKER}" != "$0" ]; then exec env FLOCKER="$0" flock -e
 func mockCommand(c *check.C, basename, script, template string) *MockCmd {
 	var wholeScript bytes.Buffer
 	var binDir, exeFile, logFile string
+	var newpath string
 	if filepath.IsAbs(basename) {
 		binDir = filepath.Dir(basename)
 		err := os.MkdirAll(binDir, 0755)
@@ -122,7 +123,7 @@ func mockCommand(c *check.C, basename, script, template string) *MockCmd {
 		binDir = c.MkDir()
 		exeFile = path.Join(binDir, basename)
 		logFile = path.Join(binDir, basename+".log")
-		os.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+		newpath = binDir + ":" + os.Getenv("PATH")
 	}
 	fmt.Fprintf(&wholeScript, template, logFile, script)
 	err := ioutil.WriteFile(exeFile, wholeScript.Bytes(), 0700)
@@ -131,6 +132,10 @@ func mockCommand(c *check.C, basename, script, template string) *MockCmd {
 	}
 
 	maybeShellcheck(c, script, &wholeScript)
+
+	if newpath != "" {
+		os.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	}
 
 	return &MockCmd{binDir: binDir, exeFile: exeFile, logFile: logFile}
 }

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -147,7 +147,7 @@ func MockCommand(c *check.C, basename, script string) *MockCmd {
 	return mockCommand(c, basename, script, strings.Replace(scriptTpl, "###LOCK###", "", 1))
 }
 
-// MockLockCommand is the same as MockCommand(), but the script uses flock to
+// MockLockedCommand is the same as MockCommand(), but the script uses flock to
 // enforce exclusive locking, preventing the call tracking from being corrupted.
 // Thus it is safe to be called in parallel.
 func MockLockedCommand(c *check.C, basename, script string) *MockCmd {


### PR DESCRIPTION
If we set this before calling shellcheck, if shellcheck is a snap, then we could have issues mocking specifically systemctl, where shellcheck as a snap tries to use `systemctl is-system-running` if there is a system key mismatch, and this will call our mocked systemctl which leads to undesirable and very confusing unit test failures.

Longer term we may want to consider not setting PATH in this manner as there have been other similar bugs where some system tool is a snap and it affects unit tests in a confusing way.
