### PR TITLE
tests: silence stderr from dbus-monitor

### DIFF
--- a/tests/lib/bin/session-tool
+++ b/tests/lib/bin/session-tool
@@ -246,7 +246,7 @@ trap 'rm -rf $tmp_dir' EXIT
 # Run dbus-monitor waiting for systemd JobRemoved signal. Process the output
 # with awk, forwarding the result of the service to a fifo.
 monitor_expr="type='signal', sender='org.freedesktop.systemd1', interface='org.freedesktop.systemd1.Manager', path='/org/freedesktop/systemd1', member='JobRemoved'"
-stdbuf -oL dbus-monitor --system --monitor "$monitor_expr" > "$tmp_dir/dbus-monitor.pipe" &
+stdbuf -oL dbus-monitor --system --monitor "$monitor_expr" > "$tmp_dir/dbus-monitor.pipe" 2>/dev/null &
 dbus_monitor_pid=$!
 
 awk_expr="


### PR DESCRIPTION
On some systemd dbus-monitor complains that it cannot establish
"new-style monitoring" and that it is falling back to eavesdropping
mode, like this:

    dbus-monitor: unable to enable new-style monitoring:
    org.freedesktop.DBus.Error.MatchRuleInvalid: "Invalid match rule". Falling back to eavesdropping.

This is harmless *but* leaks to stderr output of session-tool that may
confuse a test particularly careful about stderr.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>