### PR TITLE
snap/container.go: don't import snapdir, squashfs; use register format w/ init()

### DIFF
--- a/snap/container.go
+++ b/snap/container.go
@@ -20,17 +20,11 @@
 package snap
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/snap/snapdir"
-	"github.com/snapcore/snapd/snap/squashfs"
 )
 
 // Container is the interface to interact with the low-level snap files.
@@ -64,47 +58,30 @@ type Container interface {
 
 // backend implements a specific snap format
 type snapFormat struct {
-	magic []byte
-	open  func(fn string) (Container, error)
+	magicIdentFunc IdentifyMagicFunc
+	open           OpenFunc
 }
 
+type OpenFunc func(string) (Container, error)
+
+type IdentifyMagicFunc func(string) bool
+
 // formatHandlers is the registry of known formats, squashfs is the only one atm.
-var formatHandlers = []snapFormat{
-	{squashfs.Magic, func(p string) (Container, error) {
-		return squashfs.New(p), nil
-	}},
+var formatHandlers = []snapFormat{}
+
+func RegisterContainerFormatHandler(magicBytes IdentifyMagicFunc, openFunc OpenFunc) {
+	formatHandlers = append(formatHandlers, snapFormat{magicBytes, openFunc})
 }
 
 // Open opens a given snap file with the right backend.
 func Open(path string) (Container, error) {
-
-	if osutil.IsDirectory(path) {
-		if osutil.FileExists(filepath.Join(path, "meta", "snap.yaml")) {
-			return snapdir.New(path), nil
-		}
-
-		return nil, NotSnapError{Path: path}
-	}
-
-	// open the file and check magic
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("cannot open snap: %v", err)
-	}
-	defer f.Close()
-
-	header := make([]byte, 20)
-	if _, err := f.ReadAt(header, 0); err != nil {
-		return nil, fmt.Errorf("cannot read snap: %v", err)
-	}
-
 	for _, h := range formatHandlers {
-		if bytes.HasPrefix(header, h.magic) {
+		if h.magicIdentFunc(path) {
 			return h.open(path)
 		}
 	}
 
-	return nil, fmt.Errorf("cannot open snap: unknown header: %q", header)
+	return nil, NotSnapError{Path: path}
 }
 
 var (

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -25,7 +25,26 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
+
+func isSnapDir(path string) bool {
+	if osutil.IsDirectory(path) {
+		if osutil.FileExists(filepath.Join(path, "meta", "snap.yaml")) {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	snap.RegisterContainerFormatHandler(
+		isSnapDir,
+		func(fn string) (snap.Container, error) { return New(fn), nil },
+	)
+}
 
 // SnapDir is the snapdir based snap.
 type SnapDir struct {


### PR DESCRIPTION
Here we disentangle snap/container.go from importing snapdir and squashfs so that in a followup PR we can add an option struct to Install() that then is used in snapdir / squashfs implementations of Install().

We do this by having container.go export a register format function that is called during init() by the snapdir and squashfs packages. This required some refactoring to make snapdir work with a magic identifying function the way that squashfs currently does.

This is needed by https://github.com/snapcore/snapd/pull/8711 so that I can add an InstallOptions to Install() and use it to enforce that we don't ever create symlinks in some situations (like in run mode on uc20).