### PR TITLE
tests: detect stray dbus-daemon

### DIFF
--- a/tests/lib/tools/invariant-tool
+++ b/tests/lib/tools/invariant-tool
@@ -7,6 +7,7 @@ show_help() {
 	echo "    root-files-in-home: most of /home/* does not contain root-owned files"
 	echo "    crashed-snap-confine: /tmp/snap.rootfs_* does not exist"
 	echo "    lxcfs-mounted: /var/lib/lxcfs is a mount point"
+	echo "    stray-dbus-daemon: at most one dbus-daemon is running"
 }
 
 if [ $# -eq 0 ]; then
@@ -74,6 +75,34 @@ check_lxcfs_mounted() {
 	fi
 }
 
+check_stray_dbus_daemon() {
+	n="$1" # invariant name
+	(
+		skipped_system=0
+		for pid in $(pgrep dbus-daemon); do
+			cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline")"
+			# Ignore one dbus-daemon responsible for the system bus.
+			if echo "$cmdline" | grep -q 'dbus-daemon --system' && [ "$skipped_system" -eq 0 ]; then
+				skipped_system=1
+				continue
+			fi
+			# Ignore dbus-daemon running the session of the "external" user.
+			# This may happen when testing a core device using the ad-hoc
+			# backend. This user is never used by tests explicitly.
+			if [ "$(stat -c %U "/proc/$pid")" = "external" ]; then
+				continue
+			fi
+			# Report stray dbus-daemon.
+			echo "pid:$pid cmdline:$cmdline"
+		done
+	) > "/tmp/invariant-tool.$n"
+	if [ -s "/tmp/invariant-tool.$n" ]; then
+		echo "invariant-tool: more than one dbus-daemon running" >&2
+		cat "/tmp/invariant-tool.$n" >&2
+		return 1
+	fi
+}
+
 check_invariant() {
 	case "$1" in
 		root-files-in-home)
@@ -85,6 +114,9 @@ check_invariant() {
 		lxcfs-mounted)
 			check_lxcfs_mounted "$1"
 			;;
+		stray-dbus-daemon)
+			check_stray_dbus_daemon "$1"
+			;;
 		*)
 			echo "invariant-tool: unknown invariant $1" >&2
 			exit 1
@@ -92,7 +124,7 @@ check_invariant() {
 	esac
 }
 
-ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted"
+ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted stray-dbus-daemon"
 
 case "$action" in
 	check)

--- a/tests/lib/tools/suite/invariant-tool/task.yaml
+++ b/tests/lib/tools/suite/invariant-tool/task.yaml
@@ -57,3 +57,14 @@ execute: |
     invariant-tool check crashed-snap-confine 2>&1 | MATCH 'invariant-tool: crashed-snap-confine not-ok'
     invariant-tool check crashed-snap-confine 2>&1 | MATCH 'invariant-tool: it seems snap-confine has crashed'
     rmdir /tmp/snap.rootfs_invariant-tool
+
+    # This filters out 14.04 and ubuntu-core, respectively.
+    if [ "$(command -v systemd-run)" != "" ] && [ "$(command -v dbus-launch)" != "" ]; then
+        # Invariant tool detects leaked dbus-daemon.
+        systemd-run --service-type=forking --unit superfluous-dbus.service dbus-launch --sh-syntax
+        # shellcheck disable=SC2016
+        retry sh -c 'test "$(systemctl is-active superfluous-dbus.service)" = active'
+        invariant-tool check stray-dbus-daemon 2>&1 | MATCH 'invariant-tool: stray-dbus-daemon not-ok'
+        systemctl stop superfluous-dbus.service
+        invariant-tool check stray-dbus-daemon 2>&1 | MATCH 'invariant-tool: stray-dbus-daemon ok'
+    fi

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -51,4 +51,6 @@ execute: |
     MATCH 'The "fuse" filesystem is required' < err.txt
 
 restore: |
+    lxc delete --force my-ubuntu
+    snap remove ---purge lxd
     lxd-tool undo-lxd-mount-changes

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -4,6 +4,8 @@ summary: Check snapfuse works
 systems: [ubuntu-18.04-64]
 
 restore: |
+    lxc delete --force my-ubuntu
+    snap remove ---purge lxd
     lxd-tool undo-lxd-mount-changes
 
 execute: |


### PR DESCRIPTION
The DBus specification contains the unfortunate instructions on how to
launch a new DBus session bus if one is not already availalbe. All of
our tests should now run with session-managed DBus and should not run a
DBus daemon themselves. To avoid weird bugs, detect the case where more
than one "dbus-dameon" process is running. Note that this check is
performed before preparation and after restoring, so well-behaved tests
should no longer have anything around.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
