### PR TITLE
snap,many: mv Open to snapfile pkg to support add'l options to Container methods

### DIFF
--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -542,7 +543,7 @@ func (s *ubootSuite) TestExtractKernelAssetsAndRemoveOnUboot(c *C) {
 			Revision: snap.R(42),
 		}
 		fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-		snapf, err := snap.Open(fn)
+		snapf, err := snapfile.Open(fn)
 		c.Assert(err, IsNil)
 
 		info, err := snap.ReadInfoFromSnapFile(snapf, si)
@@ -626,7 +627,7 @@ func (s *grubSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
@@ -657,7 +658,7 @@ func (s *grubSuite) TestExtractKernelForceWorks(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 )
 
 // BootableSet represents the boot snaps of a system to be made bootable.
@@ -125,7 +126,7 @@ func makeBootable16(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	setBoot("snap_core", bootWith.BasePath)
 
 	// kernel
-	kernelf, err := snap.Open(bootWith.KernelPath)
+	kernelf, err := snapfile.Open(bootWith.KernelPath)
 	if err != nil {
 		return err
 	}
@@ -190,7 +191,7 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	// the recovery system
 	erkbl, ok := bl.(bootloader.ExtractedRecoveryKernelImageBootloader)
 	if ok {
-		kernelf, err := snap.Open(bootWith.KernelPath)
+		kernelf, err := snapfile.Open(bootWith.KernelPath)
 		if err != nil {
 			return err
 		}
@@ -271,7 +272,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 	}
 
 	// extract the kernel first and mark kernel_status ready
-	kernelf, err := snap.Open(bootWith.KernelPath)
+	kernelf, err := snapfile.Open(bootWith.KernelPath)
 	if err != nil {
 		return err
 	}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/ubootenv"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -64,7 +65,7 @@ func makeSnapWithFiles(c *C, name, yaml string, revno snap.Revision, files [][]s
 		Revision: revno,
 	}
 	fn = snaptest.MakeTestSnapWithFiles(c, yaml, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 	info, err = snap.ReadInfoFromSnapFile(snapf, si)
 	c.Assert(err, IsNil)

--- a/bootloader/androidboot_test.go
+++ b/bootloader/androidboot_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
@@ -80,7 +81,7 @@ func (s *androidBootTestSuite) TestExtractKernelAssetsNoUnpacksKernel(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -169,7 +170,7 @@ func (s *grubTestSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
@@ -200,7 +201,7 @@ func (s *grubTestSuite) TestExtractKernelForceWorks(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
@@ -491,7 +492,7 @@ func (s *grubTestSuite) TestKernelExtractionRunImageKernel(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
@@ -533,7 +534,7 @@ func (s *grubTestSuite) TestKernelExtractionRunImageKernelNoSlashBoot(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)

--- a/bootloader/lk_test.go
+++ b/bootloader/lk_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/lkenv"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
@@ -100,7 +101,7 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksBootimgImageBuilding(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
@@ -151,7 +152,7 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksCustomBootimgImageBuilding(c
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
@@ -194,7 +195,7 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksAndRemoveInRuntimeMode(c *C)
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)

--- a/bootloader/uboot_test.go
+++ b/bootloader/uboot_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/ubootenv"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -149,7 +150,7 @@ func (s *ubootTestSuite) TestExtractKernelAssetsAndRemove(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
@@ -194,7 +195,7 @@ func (s *ubootTestSuite) TestExtractRecoveryKernelAssets(c *C) {
 		Revision: snap.R(42),
 	}
 	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
-	snapf, err := snap.Open(fn)
+	snapf, err := snapfile.Open(fn)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -112,7 +113,7 @@ func (iw *infoWriter) maybePrintHealth() {
 }
 
 func clientSnapFromPath(path string) (*client.Snap, error) {
-	snapf, err := snap.Open(path)
+	snapf, err := snapfile.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -70,6 +70,7 @@ import (
 	"github.com/snapcore/snapd/sandbox"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
@@ -1545,7 +1546,7 @@ out:
 
 func unsafeReadSnapInfoImpl(snapPath string) (*snap.Info, error) {
 	// Condider using DeriveSideInfo before falling back to this!
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	if err != nil {
 		return nil, err
 	}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
@@ -1765,7 +1765,7 @@ version: 1.0
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlFromSnapFileMissing(c *C) {
 	snapPath := snaptest.MakeTestSnapWithFiles(c, string(mockSnapYaml), nil)
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	// if constraints are nil, we allow a missing gadget.yaml
@@ -1786,7 +1786,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlFromSnapFileValid(c *C) {
 	snapPath := snaptest.MakeTestSnapWithFiles(c, mockSnapYaml, [][]string{
 		{"meta/gadget.yaml", string(minimalMockGadgetYaml)},
 	})
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	ginfo, err := gadget.ReadInfoFromSnapFile(snapf, nil)

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -261,7 +262,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 			return err
 		}
 
-		snapFile, err := snap.Open(sn.Path)
+		snapFile, err := snapfile.Open(sn.Path)
 		if err != nil {
 			return err
 		}

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store/storetest"
 )
@@ -1042,7 +1043,7 @@ volumes:
 	// so that we get a directory
 	currInfo := snaptest.MockSnapWithFiles(c, currentSnapYaml, siCurrent, nil)
 	info := snaptest.MockSnapWithFiles(c, remodelSnapYaml, &snap.SideInfo{Revision: snap.R(1)}, nil)
-	snapf, err := snap.Open(info.MountDir())
+	snapf, err := snapfile.Open(info.MountDir())
 	c.Assert(err, IsNil)
 
 	s.setupBrands(c)
@@ -1173,7 +1174,7 @@ version: 123
 	info := snaptest.MockSnapWithFiles(c, remodelSnapYaml, &snap.SideInfo{Revision: snap.R(1)}, [][]string{
 		{"meta/gadget.yaml", newGadgetYaml},
 	})
-	snapf, err := snap.Open(info.MountDir())
+	snapf, err := snapfile.Open(info.MountDir())
 	c.Assert(err, IsNil)
 
 	s.setupBrands(c)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -70,6 +70,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/systemd"
@@ -665,7 +666,7 @@ func (s *baseMgrsSuite) newestThatCanRead(name string, epoch snap.Epoch) (info *
 	rev = s.serveRevision[name]
 	path := s.serveSnapPath[name]
 	for {
-		snapf, err := snap.Open(path)
+		snapf, err := snapfile.Open(path)
 		if err != nil {
 			panic(err)
 		}
@@ -880,7 +881,7 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 // serveSnap starts serving the snap at snapPath, moving the current
 // one onto the list of previous ones if already set.
 func (s *baseMgrsSuite) serveSnap(snapPath, revno string) {
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	if err != nil {
 		panic(err)
 	}
@@ -2318,7 +2319,7 @@ func (s *mgrsSuite) installLocalTestSnap(c *C, snapYamlContent string) *snap.Inf
 	st := s.o.State()
 
 	snapPath := makeTestSnap(c, snapYamlContent)
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 	info, err := snap.ReadInfoFromSnapFile(snapf, nil)
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/backend/backend.go
+++ b/overlord/snapstate/backend/backend.go
@@ -22,6 +22,7 @@ package backend
 
 import (
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 )
 
 // Backend exposes all the low-level primitives to manage snaps and their installation on disk.
@@ -39,7 +40,7 @@ func (b Backend) CurrentInfo(*snap.Info) {}
 // with sideInfo (if not nil) and a corresponding snap.Container.
 // Assumes the file was verified beforehand or the user asked for --dangerous.
 func OpenSnapFile(snapPath string, sideInfo *snap.SideInfo) (*snap.Info, snap.Container, error) {
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/storetest"
 	"github.com/snapcore/snapd/strutil"
@@ -667,7 +668,7 @@ func (f *fakeSnappyBackend) OpenSnapFile(snapFilePath string, si *snap.SideInfo)
 		}
 	} else {
 		// for snap try only
-		snapf, err := snap.Open(snapFilePath)
+		snapf, err := snapfile.Open(snapFilePath)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 )
 
 var trusted = sysdb.Trusted()
@@ -94,7 +95,7 @@ func readAsserts(batch *asserts.Batch, fn string) ([]*asserts.Ref, error) {
 }
 
 func readInfo(snapPath string, si *snap.SideInfo) (*snap.Info, error) {
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	if err != nil {
 		return nil, err
 	}

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
@@ -267,7 +268,7 @@ func (s *TestingSeed20) MakeSeed(c *C, label, brandID, modelID string, modelHead
 		if !asserts.IsNotFound(err) {
 			c.Assert(err, IsNil)
 		}
-		f, err := snap.Open(sn.Path)
+		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, si)
 		c.Assert(err, IsNil)

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -989,7 +990,7 @@ func (s *writerSuite) TestLocalSnapsCore18FullUse(c *C) {
 		if !asserts.IsNotFound(err) {
 			c.Assert(err, IsNil)
 		}
-		f, err := snap.Open(sn.Path)
+		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, si)
 		c.Assert(err, IsNil)
@@ -1259,7 +1260,7 @@ func (s *writerSuite) TestInfoDerivedRepeatedLocalSnap(c *C) {
 	c.Check(localSnaps, HasLen, 4)
 
 	for _, sn := range localSnaps {
-		f, err := snap.Open(sn.Path)
+		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, nil)
 		c.Assert(err, IsNil)
@@ -1303,7 +1304,7 @@ func (s *writerSuite) TestInfoDerivedInconsistentChannel(c *C) {
 	c.Check(localSnaps, HasLen, 3)
 
 	for _, sn := range localSnaps {
-		f, err := snap.Open(sn.Path)
+		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, nil)
 		c.Assert(err, IsNil)
@@ -1341,7 +1342,7 @@ func (s *writerSuite) TestSetRedirectChannelLocalError(c *C) {
 	c.Check(localSnaps, HasLen, 1)
 
 	sn := localSnaps[0]
-	f, err := snap.Open(sn.Path)
+	f, err := snapfile.Open(sn.Path)
 	c.Assert(err, IsNil)
 	info, err := snap.ReadInfoFromSnapFile(f, nil)
 	c.Assert(err, IsNil)
@@ -1644,7 +1645,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
 		if !asserts.IsNotFound(err) {
 			c.Assert(err, IsNil)
 		}
-		f, err := snap.Open(sn.Path)
+		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, si)
 		c.Assert(err, IsNil)
@@ -2179,7 +2180,7 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
 				if !asserts.IsNotFound(err) {
 					c.Assert(err, IsNil)
 				}
-				f, err := snap.Open(sn.Path)
+				f, err := snapfile.Open(sn.Path)
 				c.Assert(err, IsNil)
 				info, err := snap.ReadInfoFromSnapFile(f, si)
 				c.Assert(err, IsNil)
@@ -2260,7 +2261,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalSnaps(c *C) {
 	for _, sn := range localSnaps {
 		_, _, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
 		c.Assert(asserts.IsNotFound(err), Equals, true)
-		f, err := snap.Open(sn.Path)
+		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, nil)
 		c.Assert(err, IsNil)
@@ -2641,7 +2642,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 	for _, sn := range localSnaps {
 		_, _, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
 		c.Assert(asserts.IsNotFound(err), Equals, true)
-		f, err := snap.Open(sn.Path)
+		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, nil)
 		c.Assert(err, IsNil)
@@ -2813,7 +2814,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalAssertedSnaps(c *C) {
 	for _, sn := range localSnaps {
 		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
 		c.Assert(err, IsNil)
-		f, err := snap.Open(sn.Path)
+		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, si)
 		c.Assert(err, IsNil)

--- a/seed/validate.go
+++ b/seed/validate.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -114,7 +115,7 @@ func ValidateFromYaml(seedYamlFile string) error {
 	// read the snap infos
 	snapInfos := make([]*snap.Info, 0, seed16.NumSnaps())
 	seed16.Iter(func(sn *Snap) error {
-		snapf, err := snap.Open(sn.Path)
+		snapf, err := snapfile.Open(sn.Path)
 		if err != nil {
 			ve.addErr("", err)
 		} else {

--- a/snap/container.go
+++ b/snap/container.go
@@ -20,17 +20,11 @@
 package snap
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/snap/snapdir"
-	"github.com/snapcore/snapd/snap/squashfs"
 )
 
 // Container is the interface to interact with the low-level snap files.
@@ -60,51 +54,6 @@ type Container interface {
 
 	// Unpack unpacks the src parts to the dst directory
 	Unpack(src, dst string) error
-}
-
-// backend implements a specific snap format
-type snapFormat struct {
-	magic []byte
-	open  func(fn string) (Container, error)
-}
-
-// formatHandlers is the registry of known formats, squashfs is the only one atm.
-var formatHandlers = []snapFormat{
-	{squashfs.Magic, func(p string) (Container, error) {
-		return squashfs.New(p), nil
-	}},
-}
-
-// Open opens a given snap file with the right backend.
-func Open(path string) (Container, error) {
-
-	if osutil.IsDirectory(path) {
-		if osutil.FileExists(filepath.Join(path, "meta", "snap.yaml")) {
-			return snapdir.New(path), nil
-		}
-
-		return nil, NotSnapError{Path: path}
-	}
-
-	// open the file and check magic
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("cannot open snap: %v", err)
-	}
-	defer f.Close()
-
-	header := make([]byte, 20)
-	if _, err := f.ReadAt(header, 0); err != nil {
-		return nil, fmt.Errorf("cannot read snap: %v", err)
-	}
-
-	for _, h := range formatHandlers {
-		if bytes.HasPrefix(header, h.magic) {
-			return h.open(path)
-		}
-	}
-
-	return nil, fmt.Errorf("cannot open snap: unknown header: %q", header)
 }
 
 var (

--- a/snap/container_test.go
+++ b/snap/container_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
-	"github.com/snapcore/snapd/snap/snapfile"
 
 	"github.com/snapcore/snapd/testutil"
 )
@@ -37,25 +36,6 @@ import (
 type FileSuite struct{}
 
 var _ = Suite(&FileSuite{})
-
-func (s *FileSuite) TestFileOpenForSnapDir(c *C) {
-	sd := c.MkDir()
-	snapYaml := filepath.Join(sd, "meta", "snap.yaml")
-	err := os.MkdirAll(filepath.Dir(snapYaml), 0755)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(snapYaml, []byte(`name: foo`), 0644)
-	c.Assert(err, IsNil)
-
-	f, err := snapfile.Open(sd)
-	c.Assert(err, IsNil)
-	c.Assert(f, FitsTypeOf, &snapdir.SnapDir{})
-}
-
-func (s *FileSuite) TestFileOpenForSnapDirErrors(c *C) {
-	_, err := snapfile.Open(c.MkDir())
-	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
-	c.Assert(err, ErrorMatches, `"/.*" is not a snap or snapdir`)
-}
 
 type validateSuite struct {
 	testutil.BaseTest

--- a/snap/container_test.go
+++ b/snap/container_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
+	"github.com/snapcore/snapd/snap/snapfile"
 
 	"github.com/snapcore/snapd/testutil"
 )
@@ -45,13 +46,13 @@ func (s *FileSuite) TestFileOpenForSnapDir(c *C) {
 	err = ioutil.WriteFile(snapYaml, []byte(`name: foo`), 0644)
 	c.Assert(err, IsNil)
 
-	f, err := snap.Open(sd)
+	f, err := snapfile.Open(sd)
 	c.Assert(err, IsNil)
 	c.Assert(f, FitsTypeOf, &snapdir.SnapDir{})
 }
 
 func (s *FileSuite) TestFileOpenForSnapDirErrors(c *C) {
-	_, err := snap.Open(c.MkDir())
+	_, err := snapfile.Open(c.MkDir())
 	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
 	c.Assert(err, ErrorMatches, `"/.*" is not a snap or snapdir`)
 }

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/testutil"
@@ -395,7 +396,7 @@ epoch: 1*
 confinement: devmode`
 	snapPath := snaptest.MakeTestSnapWithFiles(c, yaml, nil)
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, nil)
@@ -417,7 +418,7 @@ type: app
 confinement: classic`
 	snapPath := snaptest.MakeTestSnapWithFiles(c, yaml, nil)
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, nil)
@@ -437,7 +438,7 @@ version: 1.0
 type: app`
 	snapPath := snaptest.MakeTestSnapWithFiles(c, yaml, nil)
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, nil)
@@ -457,7 +458,7 @@ version: 1.0
 type: app`
 	snapPath := snaptest.MakeTestSnapWithFiles(c, yaml, nil)
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, &snap.SideInfo{
@@ -477,7 +478,7 @@ version: 1.0
 type: app`
 	snapPath := makeTestSnap(c, yaml)
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
@@ -490,7 +491,7 @@ version: 1.0
 type: foo`
 	snapPath := makeTestSnap(c, yaml)
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
@@ -503,7 +504,7 @@ version: 1.0
 confinement: foo`
 	snapPath := makeTestSnap(c, yaml)
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
@@ -651,7 +652,7 @@ hooks:
   123abc:`
 	snapPath := makeTestSnap(c, yaml)
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
@@ -663,7 +664,7 @@ func (s *infoSuite) TestReadInfoFromSnapFileCatchesInvalidImplicitHook(c *C) {
 version: 1.0`
 	snapPath := snaptest.MakeTestSnapWithFiles(c, yaml, emptyHooks("123abc"))
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
@@ -681,7 +682,7 @@ func (s *infoSuite) checkInstalledSnapAndSnapFile(c *C, instanceName, yaml strin
 
 	// Now check snap file
 	snapPath := snaptest.MakeTestSnapWithFiles(c, yaml, emptyHooks(hooks...))
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 	info, err = snap.ReadInfoFromSnapFile(snapf, nil)
 	c.Check(err, IsNil)
@@ -1124,7 +1125,7 @@ plugs:
 func (s *infoSuite) TestReadInfoFromSnapFileRenamesCorePlus(c *C) {
 	snapPath := snaptest.MakeTestSnapWithFiles(c, coreSnapYaml, nil)
 
-	snapf, err := snap.Open(snapPath)
+	snapf, err := snapfile.Open(snapPath)
 	c.Assert(err, IsNil)
 
 	info, err := snap.ReadInfoFromSnapFile(snapf, nil)

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -25,7 +25,18 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/snapcore/snapd/osutil"
 )
+
+func IsSnapDir(path string) bool {
+	if osutil.IsDirectory(path) {
+		if osutil.FileExists(filepath.Join(path, "meta", "snap.yaml")) {
+			return true
+		}
+	}
+	return false
+}
 
 // SnapDir is the snapdir based snap.
 type SnapDir struct {

--- a/snap/snapfile/snapfile.go
+++ b/snap/snapfile/snapfile.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapfile
+
+import (
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapdir"
+	"github.com/snapcore/snapd/snap/squashfs"
+)
+
+// backend implements a specific snap format
+type snapFormat struct {
+	matches func(string) bool
+	open    func(string) (snap.Container, error)
+}
+
+// formatHandlers is the registry of known formats that work with Open
+var formatHandlers = []snapFormat{
+	// standard squashfs snap file format
+	{
+		squashfs.FileHasSquashfsHeader,
+		func(fn string) (snap.Container, error) { return squashfs.New(fn), nil },
+	},
+	// snap directory format, i.e. snap try <dir>
+	{
+		snapdir.IsSnapDir,
+		func(fn string) (snap.Container, error) { return snapdir.New(fn), nil },
+	},
+}
+
+// Open opens a given snap file with the right backend.
+func Open(path string) (snap.Container, error) {
+	for _, h := range formatHandlers {
+		if h.matches(path) {
+			return h.open(path)
+		}
+	}
+
+	return nil, snap.NotSnapError{Path: path}
+}

--- a/snap/snapfile/snapfile_test.go
+++ b/snap/snapfile/snapfile_test.go
@@ -139,3 +139,10 @@ func (s *snapFileTestSuite) TestOpenSnapdirFileNoExists(c *C) {
 	_, err := snapfile.Open(filepath.Join(dir, "garbage"))
 	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
 }
+
+func (s *snapFileTestSuite) TestFileOpenForSnapDirErrors(c *C) {
+	// no snap.yaml file
+	_, err := snapfile.Open(c.MkDir())
+	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
+	c.Assert(err, ErrorMatches, `"/.*" is not a snap or snapdir`)
+}

--- a/snap/snapfile/snapfile_test.go
+++ b/snap/snapfile/snapfile_test.go
@@ -1,0 +1,141 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapfile_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
+	"github.com/snapcore/snapd/snap/squashfs"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func TestSnapfileTest(t *testing.T) { TestingT(t) }
+
+type snapFileTestSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&snapFileTestSuite{})
+
+func (s *snapFileTestSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+
+	restore := osutil.MockMountInfo("")
+	s.AddCleanup(restore)
+}
+
+func (s *snapFileTestSuite) TestOpenSquashfs(c *C) {
+	// make a squashfs snap and try to open it with just the filename, then
+	// install it somewhere
+	tmp := c.MkDir()
+	err := os.MkdirAll(filepath.Join(tmp, "meta"), 0755)
+	c.Assert(err, IsNil)
+
+	// our regular snap.yaml
+	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "snap.yaml"), []byte("name: foo"), 0644)
+	c.Assert(err, IsNil)
+
+	// build it
+	dir := c.MkDir()
+	snFilename := filepath.Join(dir, "foo.snap")
+	buildSn := squashfs.New(snFilename)
+	err = buildSn.Build(tmp, &squashfs.BuildOpts{SnapType: "app"})
+	c.Assert(err, IsNil)
+
+	sn, err := snapfile.Open(snFilename)
+	c.Assert(err, IsNil)
+
+	targetPath := filepath.Join(c.MkDir(), "target.snap")
+	mountDir := c.MkDir()
+	// we should have copied it
+	didNothing, err := sn.Install(targetPath, mountDir)
+	c.Assert(err, IsNil)
+	c.Assert(didNothing, Equals, false)
+	c.Check(osutil.FileExists(targetPath), Equals, true)
+
+	r, err := sn.RandomAccessFile("meta/snap.yaml")
+	c.Assert(err, IsNil)
+	defer r.Close()
+
+	b := make([]byte, 5)
+	n, err := r.ReadAt(b, 4)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 5)
+	c.Check(string(b), Equals, ": foo")
+}
+
+func (s *snapFileTestSuite) TestOpenSnapdir(c *C) {
+	// make a snapdir snap and try to open it with just the filename, then
+	// install it somewhere
+	tmp := c.MkDir()
+	err := os.MkdirAll(filepath.Join(tmp, "meta"), 0755)
+	c.Assert(err, IsNil)
+
+	// our regular snap.yaml
+	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "snap.yaml"), []byte("name: foo"), 0644)
+	c.Assert(err, IsNil)
+
+	sn, err := snapfile.Open(tmp)
+	c.Assert(err, IsNil)
+
+	targetPath := filepath.Join(c.MkDir(), "target.snap")
+	mountDir := c.MkDir()
+	// we should have copied it
+	didNothing, err := sn.Install(targetPath, mountDir)
+	c.Assert(err, IsNil)
+	c.Assert(didNothing, Equals, false)
+	c.Check(osutil.FileExists(targetPath), Equals, true)
+
+	r, err := sn.RandomAccessFile("meta/snap.yaml")
+	c.Assert(err, IsNil)
+	defer r.Close()
+
+	b := make([]byte, 5)
+	n, err := r.ReadAt(b, 4)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 5)
+	c.Check(string(b), Equals, ": foo")
+}
+
+func (s *snapFileTestSuite) TestOpenSnapdirUnsupportedFormat(c *C) {
+	// make a file with garbage data
+	tmp := c.MkDir()
+	fn := filepath.Join(tmp, "some-format")
+	err := ioutil.WriteFile(fn, []byte("not-a-real-header"), 0644)
+	c.Assert(err, IsNil)
+
+	_, err = snapfile.Open(fn)
+	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
+}
+
+func (s *snapFileTestSuite) TestOpenSnapdirFileNoExists(c *C) {
+	dir := c.MkDir()
+	_, err := snapfile.Open(filepath.Join(dir, "garbage"))
+	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
+}

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -42,12 +42,27 @@ import (
 )
 
 var (
-	// Magic is the magic prefix of squashfs snap files.
-	Magic = []byte{'h', 's', 'q', 's'}
+	// magic is the magic prefix of squashfs snap files.
+	magic = []byte{'h', 's', 'q', 's'}
 
 	// for testing
 	isRootWritableOverlay = osutil.IsRootWritableOverlay
 )
+
+func FileHasSquashfsHeader(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	header := make([]byte, 20)
+	if _, err := f.ReadAt(header, 0); err != nil {
+		return false
+	}
+
+	return bytes.HasPrefix(header, magic)
+}
 
 // Snap is the squashfs based snap.
 type Snap struct {

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/asserts/systestkeys"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 )
@@ -177,7 +178,7 @@ type essentialInfo struct {
 var errInfo = errors.New("cannot get info")
 
 func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Backstore) (*essentialInfo, error) {
-	snapFile, err := snap.Open(fn)
+	file, err := snapfile.Open(fn)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("cannot read: %v: %v", fn, err), 400)
 		return nil, errInfo
@@ -186,7 +187,7 @@ func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Back
 	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 	defer restoreSanitize()
 
-	info, err := snap.ReadInfoFromSnapFile(snapFile, nil)
+	info, err := snap.ReadInfoFromSnapFile(file, nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("cannot get info for: %v: %v", fn, err), 400)
 		return nil, errInfo
@@ -324,7 +325,7 @@ func (s *Store) collectSnaps() (map[string]string, error) {
 	defer restoreSanitize()
 
 	for _, fn := range snapFns {
-		snapFile, err := snap.Open(fn)
+		snapFile, err := snapfile.Open(fn)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -178,7 +178,7 @@ type essentialInfo struct {
 var errInfo = errors.New("cannot get info")
 
 func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Backstore) (*essentialInfo, error) {
-	file, err := snapfile.Open(fn)
+	f, err := snapfile.Open(fn)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("cannot read: %v: %v", fn, err), 400)
 		return nil, errInfo
@@ -187,7 +187,7 @@ func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Back
 	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 	defer restoreSanitize()
 
-	info, err := snap.ReadInfoFromSnapFile(file, nil)
+	info, err := snap.ReadInfoFromSnapFile(f, nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("cannot get info for: %v: %v", fn, err), 400)
 		return nil, errInfo
@@ -325,11 +325,11 @@ func (s *Store) collectSnaps() (map[string]string, error) {
 	defer restoreSanitize()
 
 	for _, fn := range snapFns {
-		snapFile, err := snapfile.Open(fn)
+		f, err := snapfile.Open(fn)
 		if err != nil {
 			return nil, err
 		}
-		info, err := snap.ReadInfoFromSnapFile(snapFile, nil)
+		info, err := snap.ReadInfoFromSnapFile(f, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We want to eventually expand Container to take an options struct to Install() for example, which means that the squashfs and snapdir implementations need to import "snap" pkg to understand that option struct, but this would lead to an import cycle since the "snap" pkg also imports squashfs and snapdir packages directly.

The solution is to make "snap" pkg not import the squashfs and snapdir packages and instead have Open and the formats listing live in another package so that the formats will always get loaded by just using Open() directly. The new snapfile package is where Open lives and it imports "snap", the squashfs and snapdir packages without import cycles.

This requires numerous changes across the codebase to use snapfile.Open now.

This is needed to unblock https://github.com/snapcore/snapd/pull/8711.