### PR TITLE
data/selinux: allow snapd to remove/create the its socket

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -206,8 +206,8 @@ storage_getattr_fuse_dev(snappy_t)
 miscfiles_read_localization(snappy_t)
 
 # Allow snapd to read its run files, those files are managed elsewhere
-read_files_pattern(snappy_t, snappy_var_run_t, snappy_var_run_t)
-getattr_files_pattern(snappy_t, snappy_var_run_t, snappy_var_run_t)
+manage_files_pattern(snappy_t, snappy_var_run_t, snappy_var_run_t)
+manage_sock_files_pattern(snappy_t, snappy_var_run_t, snappy_var_run_t)
 
 gen_require(`
 	type user_tmp_t;

--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -34,6 +34,9 @@ restore: |
     session-tool -u test --restore
 
 execute: |
+    systemctl restart snapd.socket
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
 


### PR DESCRIPTION
It has been observed that snapd may remove and create the socket when being
restarted by systemd right after the package update, what causes the following
SELinux denials:

```
time->Tue May 26 08:40:07 2020
type=AVC msg=audit(1590475207.721:397): avc:  denied  { write } for  pid=3490 comm="snapd" name="snapd.socket" dev="tmpfs" ino=21816 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:snappy_var_run_t:s0 tclass=sock_file permissive=1
----
time->Tue May 26 08:40:07 2020
type=AVC msg=audit(1590475207.721:398): avc:  denied  { write } for  pid=3490 comm="snapd" name="/" dev="tmpfs" ino=13932 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=dir permissive=1
----
time->Tue May 26 08:40:07 2020
type=AVC msg=audit(1590475207.721:399): avc:  denied  { remove_name } for  pid=3490 comm="snapd" name="snapd.socket" dev="tmpfs" ino=21816 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=dir permissive=1
----
time->Tue May 26 08:40:07 2020
type=AVC msg=audit(1590475207.721:400): avc:  denied  { unlink } for  pid=3490 comm="snapd" name="snapd.socket" dev="tmpfs" ino=21816 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:snappy_var_run_t:s0 tclass=sock_file permissive=1
----
time->Tue May 26 08:40:07 2020
type=AVC msg=audit(1590475207.721:401): avc:  denied  { add_name } for  pid=3490 comm="snapd" name="snapd.socket" scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=dir permissive=1
----
time->Tue May 26 08:40:07 2020
type=AVC msg=audit(1590475207.721:402): avc:  denied  { create } for  pid=3490 comm="snapd" name="snapd.socket" scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=sock_file permissive=1
```

Update the policy to allow that.