### PR TITLE
data/selinux: update policy to allow forked processes to call getpw*()

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -261,8 +261,10 @@ allow snappy_t usr_t:lnk_file { create unlink };
 # Allow snapd to use ssh-keygen
 ssh_exec_keygen(snappy_t)
 
-# Allow snapd to access passwd file for lookup
+# Allow snapd to access passwd file for trivial user lookup
 auth_read_passwd(snappy_t)
+# also via nsswitch if called via libc
+auth_use_nsswitch(snappy_t)
 
 # because /run/snapd/ns/*.mnt gets a label of the process context
 gen_require(` type unconfined_t; ')
@@ -280,7 +282,7 @@ allow snappy_t self:netlink_route_socket create_netlink_socket_perms;
 allow snappy_t self:unix_stream_socket create_stream_socket_perms;
 allow snappy_t self:tcp_socket create_stream_socket_perms;
 allow snappy_t self:udp_socket create_stream_socket_perms;
-allow snappy_t self:unix_dgram_socket create_socket_perms;
+allow snappy_t self:unix_dgram_socket { create_socket_perms sendto };
 allow snappy_t self:capability2 block_suspend;
 
 # snapd needs to check for ipv6 support


### PR DESCRIPTION
When a process forked by snapd (eg. unsquashfs) calls getpw*() it may eventually
go through NSS. Depending on host configuration, it is possible that it will hit
nss-systemd and poke systemd-userdb.service. With current policy this triggers
the following denials:

```
type=AVC msg=audit(05/22/20 03:37:54.119:665) : avc: denied { read } for
         pid=27932 comm=unsquashfs name=userdb dev="tmpfs"
         ino=13308 scontext=system_u:system_r:snappy_t:s0
         tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0
         tclass=dir permissive=1

type=AVC msg=audit(05/22/20 03:37:54.119:666) : avc: denied { write } for
         pid=27932 comm=unsquashfs name=io.systemd.DynamicUser
         dev="tmpfs" ino=63792 scontext=system_u:system_r:snappy_t:s0
         tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0
         tclass=sock_file permissive=1

type=AVC msg=audit(05/22/20 03:37:54.120:667) : avc: denied { sendto } for
         pid=27932 comm=unsquashfs path=userdb-0f2255de09b5cbb97ed30ae81eda322e
         scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:system_r:snappy_t:s0
         tclass=unix_dgram_socket permissive=1
```

Update the policy to allow use of nss.

This unblocks the SELinux related tests in https://github.com/snapcore/snapd/pull/8693
