### PR TITLE
tests: port interfaces-wayland to session-tool

### DIFF
--- a/tests/main/interfaces-wayland/task.yaml
+++ b/tests/main/interfaces-wayland/task.yaml
@@ -1,16 +1,22 @@
 summary: Ensure that the wayland interface works
 
 # Only test on classic Ubuntu amd64 systems that have wayland
-systems: [ ubuntu-1*-*64 ]
+# TODO: Expand this to Fedora and other systems.
+systems:
+    - ubuntu-16.04-64
+    - ubuntu-18.04-64
+    - ubuntu-20.04-64
 
 prepare: |
-    #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB"/pkgdb.sh
     snap install --edge test-snapd-wayland
+    session-tool -u test --prepare
+    session-tool -u test systemd-run --user --unit headless-weston.service weston --backend=headless-backend.so
+    retry-tool -n 10 --wait 1 test -S /run/user/12345/wayland-0
 
 restore: |
-    echo "Stop weston compositor"
-    pkill -SIGKILL weston || true
+    snap remove test-snapd-wayland
+    session-tool -u test systemctl --user stop headless-weston.service
+    session-tool -u test --restore
 
 execute: |
     echo "The interface is connected by default"
@@ -23,38 +29,14 @@ execute: |
         exit 0
     fi
 
-    echo "Create XDG_RUNTIME_DIR=/run/user/12345"
-    mkdir -p /run/user/12345 || true
-    chmod 700 /run/user/12345
-    chown test:test /run/user/12345
-
-    echo "Start weston compositor under test user"
-    XDG_RUNTIME_DIR=/run/user/12345 su -p -c "weston --backend=headless-backend.so" test &
-
-    echo "Then wait for the socket to show up"
-    count=0
-    while sleep 1 && [ ! -S /run/user/12345/wayland-0 ]; do
-        echo $count
-        count=$((count+1))
-        if [ "$count" -gt 10 ]; then
-           echo "Could not find wayland socket"
-           exit 1
-        fi
-    done
-
     echo "Then the snap command under the test user is able connect to the wayland socket"
-    XDG_RUNTIME_DIR=/run/user/12345 su -p -l -c test-snapd-wayland test | MATCH wl_compositor
+    session-tool -u test test-snapd-wayland | MATCH wl_compositor
 
     echo "When the plug is disconnected"
     snap disconnect test-snapd-wayland:wayland
 
     echo "Then the snap command is not able to connect to the wayland socket"
-    if XDG_RUNTIME_DIR=/run/user/12345 su -p -l -c test-snapd-wayland test; then
+    if session-tool -u test test-snapd-wayland; then
         echo "Expected error with plug disconnected"
         exit 1
     fi
-
-    # If this is in 'restore', execute doesn't exit and spread must timeout
-    # the test.
-    echo "Stop weston compositor"
-    pkill -SIGKILL weston || true


### PR DESCRIPTION
This test was evil as it started a user session via su -l, leaving behind
assorted processes. It was both modernized and simplified with session
and retry tools.

The test might pass on more systems but I didn't focus on expanding
coverage at this time.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
