### PR TITLE
snap/snapfile,squashfs: followups from 8729

### DIFF
--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -43,6 +43,22 @@ type SnapdirTestSuite struct {
 
 var _ = Suite(&SnapdirTestSuite{})
 
+func (s *SnapdirTestSuite) TestIsSnapDir(c *C) {
+	d := c.MkDir()
+	err := os.MkdirAll(filepath.Join(d, "meta"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(d, "meta/snap.yaml"), nil, 0644)
+	c.Assert(err, IsNil)
+
+	c.Check(snapdir.IsSnapDir(d), Equals, true)
+}
+
+func (s *SnapdirTestSuite) TestNotIsSnapDir(c *C) {
+	c.Check(snapdir.IsSnapDir("/not-existent"), Equals, false)
+	c.Check(snapdir.IsSnapDir("/dev/null"), Equals, false)
+	c.Check(snapdir.IsSnapDir(c.MkDir()), Equals, false)
+}
+
 func (s *SnapdirTestSuite) TestReadFile(c *C) {
 	d := c.MkDir()
 	needle := []byte(`stuff`)

--- a/snap/snapfile/snapfile.go
+++ b/snap/snapfile/snapfile.go
@@ -36,12 +36,12 @@ var formatHandlers = []snapFormat{
 	// standard squashfs snap file format
 	{
 		squashfs.FileHasSquashfsHeader,
-		func(f string) (snap.Container, error) { return squashfs.New(f), nil },
+		func(p string) (snap.Container, error) { return squashfs.New(p), nil },
 	},
 	// snap directory format, i.e. snap try <dir>
 	{
 		snapdir.IsSnapDir,
-		func(f string) (snap.Container, error) { return snapdir.New(f), nil },
+		func(p string) (snap.Container, error) { return snapdir.New(p), nil },
 	},
 }
 

--- a/snap/snapfile/snapfile.go
+++ b/snap/snapfile/snapfile.go
@@ -36,12 +36,12 @@ var formatHandlers = []snapFormat{
 	// standard squashfs snap file format
 	{
 		squashfs.FileHasSquashfsHeader,
-		func(fn string) (snap.Container, error) { return squashfs.New(fn), nil },
+		func(f string) (snap.Container, error) { return squashfs.New(f), nil },
 	},
 	// snap directory format, i.e. snap try <dir>
 	{
 		snapdir.IsSnapDir,
-		func(fn string) (snap.Container, error) { return snapdir.New(fn), nil },
+		func(f string) (snap.Container, error) { return snapdir.New(f), nil },
 	},
 }
 

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -32,7 +32,10 @@ var (
 	NewUnsquashfsStderrWriter = newUnsquashfsStderrWriter
 )
 
-const MaxErrPaths = maxErrPaths
+const (
+	SuperblockSize = superblockSize
+	MaxErrPaths    = maxErrPaths
+)
 
 func (s stat) User() string  { return s.user }
 func (s stat) Group() string { return s.group }

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -57,7 +57,7 @@ func FileHasSquashfsHeader(path string) bool {
 	}
 	defer f.Close()
 
-	header := make([]byte, 20)
+	header := make([]byte, len(magic)+1)
 	if _, err := f.ReadAt(header, 0); err != nil {
 		return false
 	}

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -42,6 +42,11 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
+const (
+	// https://github.com/plougher/squashfs-tools/blob/master/squashfs-tools/squashfs_fs.h#L289
+	superblockSize = 96
+)
+
 var (
 	// magic is the magic prefix of squashfs snap files.
 	magic = []byte{'h', 's', 'q', 's'}
@@ -57,7 +62,8 @@ func FileHasSquashfsHeader(path string) bool {
 	}
 	defer f.Close()
 
-	header := make([]byte, len(magic)+1)
+	// a squashfs file would contain at least the superblock + some data
+	header := make([]byte, superblockSize+1)
 	if _, err := f.ReadAt(header, 0); err != nil {
 		return false
 	}


### PR DESCRIPTION
Some tweaks/improvements on top of #8729 now that format detection has moved into squashfs and snapdir themselves.