### PR TITLE
tests: port interfaces-desktop-* to session-tool

### DIFF
--- a/tests/main/interfaces-desktop-host-fonts/task.yaml
+++ b/tests/main/interfaces-desktop-host-fonts/task.yaml
@@ -5,17 +5,24 @@ details: |
     covering the user's spoken language, the host system's fonts are
     bind mounted into the sandbox.
 
-systems: [-ubuntu-core-*]
+systems:
+    - -amazon-linux-2-*
+    - -centos-7-*
+    - -ubuntu-14.04-*
+    - -ubuntu-core-*
 
 restore: |
+    session-tool -u test --restore
     rm -f /usr/share/fonts/dist-font.txt
     rm -f /usr/local/share/fonts/local-font.txt
-    rm -f "$HOME"/.fonts/user-font1.txt
-    rm -f "$HOME"/.local/share/fonts/user-font2.txt
+    rm -f /home/test/.fonts/user-font1.txt
+    rm -f /home/test/.local/share/fonts/user-font2.txt
     rm -f /var/cache/fontconfig/cache.txt
     rm -f /usr/lib/fontconfig/cache/cache.txt
 
-execute: |
+prepare: |
+    session-tool -u test --prepare
+
     echo "Distribution font" > /usr/share/fonts/dist-font.txt
     # this may not exist across all distributions
     mkdir -p /usr/local/share/fonts
@@ -30,38 +37,40 @@ execute: |
     mkdir -p "$cache_dir"
     echo "Cache file" > "$cache_dir"/cache.txt
 
-    mkdir -p "$HOME"/.fonts
-    echo "User font 1" > "$HOME"/.fonts/user-font1.txt
+    # User directories created via session-tool for correct ownership and SELinux context.
+    session-tool -u test mkdir -p /home/test/.fonts
+    echo "User font 1" | session-tool -u test tee /home/test/.fonts/user-font1.txt
 
-    mkdir -p "$HOME"/.local/share/fonts
-    echo "User font 2" > "$HOME"/.local/share/fonts/user-font2.txt
+    session-tool -u test mkdir -p /home/test/.local/share/fonts
+    echo "User font 2" | session-tool -u test tee /home/test/.local/share/fonts/user-font2.txt
 
     echo "Install the test-snapd-desktop snap"
     snap try "$TESTSLIB"/snaps/test-snapd-desktop
 
+execute: |
     echo "The plug is connected by default"
     snap interfaces -i desktop | MATCH ":desktop .*test-snapd-desktop"
 
     echo "Checking access to host /usr/share/fonts"
-    test-snapd-desktop.check-files /usr/share/fonts/dist-font.txt | MATCH "Distribution font"
+    session-tool -u test test-snapd-desktop.check-files /usr/share/fonts/dist-font.txt | MATCH "Distribution font"
 
     echo "Checking access to host /usr/local/share/fonts"
-    test-snapd-desktop.check-files /usr/local/share/fonts/local-font.txt | MATCH "Local font"
+    session-tool -u test test-snapd-desktop.check-files /usr/local/share/fonts/local-font.txt | MATCH "Local font"
 
-    echo "Checking access to host $cache_dir"
+    echo "Checking access to host cache dir"
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*|amazon-linux-*|arch-linux-*)
             # system fonts cache is inaccessible due to
             # https://bugs.launchpad.net/snapd/+bug/1877109
-            test-snapd-desktop.sh -c "test ! -e $cache_dir/cache.txt"
+            session-tool -u test test-snapd-desktop.sh -c "test ! -e /usr/lib/fontconfig/cache/cache.txt"
             ;;
         *)
-            test-snapd-desktop.check-files "$cache_dir"/cache.txt | MATCH "Cache file"
+            session-tool -u test test-snapd-desktop.check-files /var/cache/fontconfig/cache.txt | MATCH "Cache file"
             ;;
     esac
 
     echo "Checking access to host ~/.fonts"
-    test-snapd-desktop.check-files "$HOME"/.fonts/user-font1.txt | MATCH "User font 1"
+    session-tool -u test test-snapd-desktop.check-files /home/test/.fonts/user-font1.txt | MATCH "User font 1"
 
     echo "Checking access to host ~/.local/share/fonts"
-    test-snapd-desktop.check-files "$HOME"/.local/share/fonts/user-font2.txt | MATCH "User font 2"
+    session-tool -u test test-snapd-desktop.check-files /home/test/.local/share/fonts/user-font2.txt | MATCH "User font 2"

--- a/tests/main/interfaces-desktop/task.yaml
+++ b/tests/main/interfaces-desktop/task.yaml
@@ -6,11 +6,19 @@ details: |
     The test-snapd-desktop snap checks files and dirs are accessible through the
     desktop interface.
 
-systems: [-ubuntu-core-*]
+systems:
+    - -amazon-linux-2-*
+    - -centos-7-*
+    - -ubuntu-14.04-*
+    - -ubuntu-core-*
 
 prepare: |
     echo "Given the desktop snap is installed"
     snap try "$TESTSLIB"/snaps/test-snapd-desktop
+    session-tool -u test --prepare
+
+restore: |
+    session-tool -u test --restore
 
 execute: |
     dirs="/var/cache/fontconfig /usr/share/icons /usr/share/pixmaps"
@@ -21,9 +29,9 @@ execute: |
 
     echo "Then the snap is able to desktop files and directories"
     # shellcheck disable=SC2086
-    test-snapd-desktop.check-files $files
+    session-tool -u test test-snapd-desktop.check-files $files
     # shellcheck disable=SC2086
-    test-snapd-desktop.check-dirs $dirs
+    session-tool -u test test-snapd-desktop.check-dirs $dirs
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
@@ -34,7 +42,7 @@ execute: |
 
     echo "Then the snap is not able to access the desktop files"
     for file in $files; do
-        if test-snapd-desktop.check-files "$file" 2> call.error; then
+        if session-tool -u test test-snapd-desktop.check-files "$file" 2> call.error; then
             echo "Expected permission error calling desktop with disconnected plug"
             exit 1
         fi
@@ -43,7 +51,7 @@ execute: |
 
     echo "Then the snap is not able to access the desktop dirs"
     for dir in $dirs; do
-        if test-snapd-desktop.check-dirs "$dir" 2> call.error; then
+        if session-tool -u test test-snapd-desktop.check-dirs "$dir" 2> call.error; then
             echo "Expected permission error calling desktop with disconnected plug"
             exit 1
         fi


### PR DESCRIPTION
Those test were leaking the dbus-daemon process as they were running as
root and caused the root user to socket-activate dbus-daemon responsible
for the session-bus.

The usage of "session-tool -u test" ensures we have a session bus and
more importantly that it gets shut down at the end of the test.

This was detected with invariant-tool.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
