### PR TITLE
interfaces-ssh-keys: Support reading /etc/ssh/ssh_config.d/

### DIFF
--- a/interfaces/builtin/ssh_keys.go
+++ b/interfaces/builtin/ssh_keys.go
@@ -35,6 +35,7 @@ const sshKeysConnectedPlugAppArmor = `
 
 /usr/bin/ssh ixr,
 /etc/ssh/ssh_config r,
+/etc/ssh/ssh_config.d/{,**} r,
 owner @{HOME}/.ssh/{,**} r,
 `
 

--- a/interfaces/builtin/ssh_keys_test.go
+++ b/interfaces/builtin/ssh_keys_test.go
@@ -76,6 +76,7 @@ func (s *SshKeysInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/etc/ssh/ssh_config.d/{,**} r,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner @{HOME}/.ssh/{,**} r,`)
 }
 

--- a/tests/main/interfaces-ssh-keys/task.yaml
+++ b/tests/main/interfaces-ssh-keys/task.yaml
@@ -7,6 +7,7 @@ details: |
 environment:
     KEYSDIR: "/$HOME/.ssh"
     TESTKEY: "$HOME/.ssh/testkey"
+    CONFDIR: "/etc/ssh/ssh_config.d/"
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
@@ -21,10 +22,21 @@ prepare: |
     echo "testkey" > "$TESTKEY"
     echo "testkey.pub" > "$TESTKEY".pub
 
+    if [ ! -d "$CONFDIR" ]; then
+        mkdir -p "$CONFDIR"
+        touch "$CONFDIR/.spread-created"
+    fi
+    touch "$CONFDIR/test.conf"
+
 restore: |
     rm -rf "$KEYSDIR"
     if [ -d "$KEYSDIR".old ]; then
         mv "$KEYSDIR".old "$KEYSDIR"
+    fi
+
+    rm -f "$CONFDIR/test.conf"
+    if [ -f "$CONFDIR/.spread-created" ]; then
+        rm -rf "$CONFDIR"
     fi
 
 execute: |
@@ -41,6 +53,7 @@ execute: |
     test-snapd-sh.with-ssh-keys-plug -c "cat $TESTKEY"
     test-snapd-sh.with-ssh-keys-plug -c "cat $TESTKEY.pub"
     test-snapd-sh.with-ssh-keys-plug -c "cat /etc/ssh/ssh_config"
+    test-snapd-sh.with-ssh-keys-plug -c "cat /etc/ssh/ssh_config.d/test.conf"
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0


### PR DESCRIPTION
By default on Ubuntu 20.04, `/etc/ssh/ssh_config` contains:

    Include /etc/ssh/ssh_config.d/*.conf

This is added by a Debian patch:

https://git.launchpad.net/ubuntu/+source/openssh/tree/debian/patches/debian-config.patch?h=ubuntu/focal

