### PR TITLE
tests: port snap-routine-portal-info to session-tool

### DIFF
--- a/tests/main/snap-routine-portal-info/task.yaml
+++ b/tests/main/snap-routine-portal-info/task.yaml
@@ -1,29 +1,29 @@
 summary: The portal-info command provides information about a confined process
 
-# TODO: fedora-31: uses cgroupv2, which does not have a separate freezer
-# controller hierarchy
-systems: [ -fedora-31-*]
+systems:
+    - -ubuntu-14.04-*
+    - -fedora-31-*  # TODO: add support for cgroupv2 based tracking
+    - -fedora-32-*
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-desktop
+    session-tool -u test --prepare
 
 restore: |
     rm -f output.txt
+    session-tool -u test systemctl --user stop test-snapd-desktop-sleep.service
+    session-tool -u test --restore
 
 execute: |
     # Start a "sleep" process in the background
     #shellcheck disable=SC2016
-    test-snapd-desktop.cmd sh -c 'touch $SNAP_DATA/1.stamp && exec sleep 1h' &
-    pid1=$!
-    trap 'kill "$pid1" || true' EXIT
+    session-tool -u test systemd-run --user --unit test-snapd-desktop-sleep.service test-snapd-desktop.cmd sh -c 'touch $SNAP_USER_DATA/1.stamp && exec sleep 1h'
     # Ensure that snap-confine has finished its task and that the snap process
     # is active. Note that we don't want to wait forever either.
-    for _ in $(seq 30); do
-        test -e /var/snap/test-snapd-desktop/current/1.stamp && break
-        sleep 0.1
-    done
+    retry-tool -n 30 --wait 0.1 test -e /home/test/snap/test-snapd-desktop/current/1.stamp
+    pid1="$(session-tool -u test systemctl --user show --property=MainPID test-snapd-desktop-sleep.service | cut -d = -f 2)"
 
     snap routine portal-info "$pid1" > output.txt
     diff -u output.txt - << \EOF
@@ -33,6 +33,3 @@ execute: |
     DesktopFile=test-snapd-desktop_cmd.desktop
     HasNetworkStatus=false
     EOF
-
-    kill "$pid1"
-    wait "$pid1" || true

--- a/tests/main/snap-routine-portal-info/task.yaml
+++ b/tests/main/snap-routine-portal-info/task.yaml
@@ -4,6 +4,8 @@ systems:
     - -ubuntu-14.04-*
     - -fedora-31-*  # TODO: add support for cgroupv2 based tracking
     - -fedora-32-*
+    - -amazon-linux-*
+    - -centos-7-*
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh


### PR DESCRIPTION
This test is rather straightforward. The only interesting highlight is
the use of user session service to run the "sleep 1h" command and a
rather non-trivial way to extract the PID of the sleep process, due to
the stack of a snap command and session-tool (we just ask systemd). This
method of running background tasks is more resilient as they are
properly shut down by session-tool --restore -u test *and* they don't
hang spread *and* this also kills any helper processes that may have
been started.

This change removes one more leaking dbus-daemon, namely that from
test-snapd-desktop.cmd which causes desktop portal activation.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
