### PR TITLE
configcore: show better error when disabling services

### DIFF
--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -63,16 +63,14 @@ func switchDisableSSHService(sysd systemd.Systemd, serviceName string, disabled 
 
 	sshCanary := filepath.Join(rootDir, "/etc/ssh/sshd_not_to_be_run")
 
-	switch disabled {
-	case true:
+	if disabled {
 		if err := ioutil.WriteFile(sshCanary, []byte("SSH has been disabled by snapd system configuration\n"), 0644); err != nil {
 			return err
 		}
 		if opts == nil {
 			return sysd.Stop(serviceName, 5*time.Minute)
 		}
-		return nil
-	case false:
+	} else {
 		err := os.Remove(sshCanary)
 		if err != nil && !os.IsNotExist(err) {
 			return err
@@ -85,10 +83,8 @@ func switchDisableSSHService(sysd systemd.Systemd, serviceName string, disabled 
 		if opts == nil {
 			return sysd.Start(serviceName)
 		}
-		return nil
-	default:
-		panic("internal error: go violates the law of noncontradition")
 	}
+	return nil
 }
 
 // switchDisableConsoleConfService handles the special case of disabling/enabling
@@ -134,16 +130,14 @@ func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName string, d
 		return sysd.RestartAll("console-conf@*")
 	}
 
-	switch disabled {
-	case true:
+	if disabled {
 		if err := ioutil.WriteFile(consoleConfCanary, []byte("console-conf has been disabled by snapd system configuration\n"), 0644); err != nil {
 			return err
 		}
 		if opts == nil {
 			return restartServicesOnTTYs()
 		}
-		return nil
-	case false:
+	} else {
 		err := os.Remove(consoleConfCanary)
 		if err != nil {
 			if !os.IsNotExist(err) {
@@ -155,10 +149,8 @@ func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName string, d
 		if opts == nil {
 			return restartServicesOnTTYs()
 		}
-		return nil
-	default:
-		panic("internal error: go violates the law of noncontradition")
 	}
+	return nil
 }
 
 // switchDisableTypicalService switches a service in/out of disabled state
@@ -179,8 +171,7 @@ func switchDisableService(serviceName string, disabled bool, opts *fsOnlyContext
 		return switchDisableConsoleConfService(sysd, serviceName, disabled, opts)
 	}
 
-	switch disabled {
-	case true:
+	if disabled {
 		if opts == nil {
 			if err := sysd.Disable(serviceName); err != nil {
 				return err
@@ -192,8 +183,7 @@ func switchDisableService(serviceName string, disabled bool, opts *fsOnlyContext
 		if opts == nil {
 			return sysd.Stop(serviceName, 5*time.Minute)
 		}
-		return nil
-	case false:
+	} else {
 		if err := sysd.Unmask(serviceName); err != nil {
 			return err
 		}
@@ -205,10 +195,8 @@ func switchDisableService(serviceName string, disabled bool, opts *fsOnlyContext
 		if opts == nil {
 			return sysd.Start(serviceName)
 		}
-		return nil
-	default:
-		panic("internal error: go violates the law of noncontradition")
 	}
+	return nil
 }
 
 // services that can be disabled

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -52,7 +52,7 @@ func (l *sysdLogger) Notify(status string) {
 
 // switchDisableSSHService handles the special case of disabling/enabling ssh
 // service on core devices.
-func switchDisableSSHService(sysd systemd.Systemd, serviceName, value string, opts *fsOnlyContext) error {
+func switchDisableSSHService(sysd systemd.Systemd, serviceName string, disabled bool, opts *fsOnlyContext) error {
 	rootDir := dirs.GlobalRootDir
 	if opts != nil {
 		rootDir = opts.RootDir
@@ -63,8 +63,8 @@ func switchDisableSSHService(sysd systemd.Systemd, serviceName, value string, op
 
 	sshCanary := filepath.Join(rootDir, "/etc/ssh/sshd_not_to_be_run")
 
-	switch value {
-	case "true":
+	switch disabled {
+	case true:
 		if err := ioutil.WriteFile(sshCanary, []byte("SSH has been disabled by snapd system configuration\n"), 0644); err != nil {
 			return err
 		}
@@ -72,7 +72,7 @@ func switchDisableSSHService(sysd systemd.Systemd, serviceName, value string, op
 			return sysd.Stop(serviceName, 5*time.Minute)
 		}
 		return nil
-	case "false":
+	case false:
 		err := os.Remove(sshCanary)
 		if err != nil && !os.IsNotExist(err) {
 			return err
@@ -87,7 +87,7 @@ func switchDisableSSHService(sysd systemd.Systemd, serviceName, value string, op
 		}
 		return nil
 	default:
-		return fmt.Errorf("option %q has invalid value %q", serviceName, value)
+		panic("internal error: go violates the law of noncontradition")
 	}
 }
 
@@ -102,9 +102,9 @@ func switchDisableSSHService(sysd systemd.Systemd, serviceName, value string, op
 //     systemctl restart 'serial-console-conf@*' --all
 //     systemctl restart 'console-conf@*' --all
 //
-// This restart all active getty and console-conf instances, even ones that were
-// started on-demand (eg. on tty2)
-func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName, value string, opts *fsOnlyContext) error {
+// This restarts all active getty and console-conf instances, even
+// ones that were started on-demand (eg. on tty2)
+func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName string, disabled bool, opts *fsOnlyContext) error {
 	rootDir := dirs.GlobalRootDir
 	if opts != nil {
 		rootDir = opts.RootDir
@@ -134,8 +134,8 @@ func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName, value st
 		return sysd.RestartAll("console-conf@*")
 	}
 
-	switch value {
-	case "true":
+	switch disabled {
+	case true:
 		if err := ioutil.WriteFile(consoleConfCanary, []byte("console-conf has been disabled by snapd system configuration\n"), 0644); err != nil {
 			return err
 		}
@@ -143,7 +143,7 @@ func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName, value st
 			return restartServicesOnTTYs()
 		}
 		return nil
-	case "false":
+	case false:
 		err := os.Remove(consoleConfCanary)
 		if err != nil {
 			if !os.IsNotExist(err) {
@@ -157,13 +157,13 @@ func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName, value st
 		}
 		return nil
 	default:
-		return fmt.Errorf("option %q has invalid value %q", serviceName, value)
+		panic("internal error: go violates the law of noncontradition")
 	}
 }
 
 // switchDisableTypicalService switches a service in/out of disabled state
 // where "true" means disabled and "false" means enabled.
-func switchDisableService(serviceName, value string, opts *fsOnlyContext) error {
+func switchDisableService(serviceName string, disabled bool, opts *fsOnlyContext) error {
 	var sysd systemd.Systemd
 	if opts != nil {
 		sysd = systemd.NewEmulationMode(opts.RootDir)
@@ -174,13 +174,13 @@ func switchDisableService(serviceName, value string, opts *fsOnlyContext) error 
 	// some services are special
 	switch serviceName {
 	case "ssh.service":
-		return switchDisableSSHService(sysd, serviceName, value, opts)
+		return switchDisableSSHService(sysd, serviceName, disabled, opts)
 	case "console-conf@*":
-		return switchDisableConsoleConfService(sysd, serviceName, value, opts)
+		return switchDisableConsoleConfService(sysd, serviceName, disabled, opts)
 	}
 
-	switch value {
-	case "true":
+	switch disabled {
+	case true:
 		if opts == nil {
 			if err := sysd.Disable(serviceName); err != nil {
 				return err
@@ -193,7 +193,7 @@ func switchDisableService(serviceName, value string, opts *fsOnlyContext) error 
 			return sysd.Stop(serviceName, 5*time.Minute)
 		}
 		return nil
-	case "false":
+	case false:
 		if err := sysd.Unmask(serviceName); err != nil {
 			return err
 		}
@@ -207,19 +207,30 @@ func switchDisableService(serviceName, value string, opts *fsOnlyContext) error 
 		}
 		return nil
 	default:
-		return fmt.Errorf("option %q has invalid value %q", serviceName, value)
+		panic("internal error: go violates the law of noncontradition")
 	}
 }
 
 // services that can be disabled
 func handleServiceDisableConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
 	for _, service := range services {
-		output, err := coreCfg(tr, fmt.Sprintf("service.%s.disable", service.configName))
+		optionName := fmt.Sprintf("service.%s.disable", service.configName)
+		outputStr, err := coreCfg(tr, optionName)
 		if err != nil {
 			return err
 		}
-		if output != "" {
-			if err := switchDisableService(service.systemdName, output, opts); err != nil {
+		if outputStr != "" {
+			var disabled bool
+			switch outputStr {
+			case "true":
+				disabled = true
+			case "false":
+				disabled = false
+			default:
+				return fmt.Errorf("option %q has invalid value %q", optionName, outputStr)
+			}
+
+			if err := switchDisableService(service.systemdName, disabled, opts); err != nil {
 				return err
 			}
 		}

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -56,12 +56,20 @@ func (s *servicesSuite) TearDownTest(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureServiceInvalidValue(c *C) {
-	err := configcore.SwitchDisableService("ssh.service", "xxx", nil)
-	c.Check(err, ErrorMatches, `option "ssh.service" has invalid value "xxx"`)
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		changes: map[string]interface{}{
+			"service.ssh.disable": "xxx",
+		},
+	})
+	c.Check(err, ErrorMatches, `option "service.ssh.disable" has invalid value "xxx"`)
 }
 
 func (s *servicesSuite) TestConfigureServiceNotDisabled(c *C) {
-	err := configcore.SwitchDisableService("sshd.service", "false", nil)
+	err := configcore.SwitchDisableService("sshd.service", false, nil)
 	c.Assert(err, IsNil)
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
 		{"--root", dirs.GlobalRootDir, "unmask", "sshd.service"},
@@ -71,7 +79,7 @@ func (s *servicesSuite) TestConfigureServiceNotDisabled(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureServiceDisabled(c *C) {
-	err := configcore.SwitchDisableService("sshd.service", "true", nil)
+	err := configcore.SwitchDisableService("sshd.service", true, nil)
 	c.Assert(err, IsNil)
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
 		{"--root", dirs.GlobalRootDir, "disable", "sshd.service"},


### PR DESCRIPTION
When an invalid value is passed when trying to disable a service
the current code gives an incorrect error message. It will print
the name of the service (like "ssh.service") as the option name.

This commit fixes this and instead prints the correct option
name.

Small followup from https://github.com/snapcore/snapd/pull/8661#discussion_r430288410