### PR TITLE
tests: improve oom-vitality tests

### DIFF
--- a/tests/core/gadget-config-defaults-vitality/task.yaml
+++ b/tests/core/gadget-config-defaults-vitality/task.yaml
@@ -28,6 +28,12 @@ prepare: |
         MODEL=developer1-pc-18-w-config.model
     fi
 
+    # Stop snapd and remove existing state, modify and repack gadget
+    # snap and provide developer assertions in order to force first
+    # boot again.
+    #
+    # TODO: find common pattern and extract code from the various tests
+    #       that use similar code to simulate a first-boot
     systemctl stop snapd.service snapd.socket
     rm -rf /var/lib/snapd/assertions/*
     rm -rf /var/lib/snapd/device

--- a/tests/core/gadget-config-defaults-vitality/task.yaml
+++ b/tests/core/gadget-config-defaults-vitality/task.yaml
@@ -48,7 +48,7 @@ prepare: |
     cat <<EOF >> squashfs-root/service
     #!/bin/sh
     echo other service
-    sleep infinity
+    exec sleep infinity
     EOF
     chmod +x squashfs-root/service
 

--- a/tests/lib/snaps/test-snapd-with-configure-core18/service
+++ b/tests/lib/snaps/test-snapd-with-configure-core18/service
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "service running"
-sleep infinity
+exec sleep infinity

--- a/tests/lib/snaps/test-snapd-with-configure/service
+++ b/tests/lib/snaps/test-snapd-with-configure/service
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "service running"
-sleep infinity
+exec sleep infinity


### PR DESCRIPTION
This is a small followup for https://github.com/snapcore/snapd/pull/8351 to address some of the comments. Some more comments will addressed in followup (e.g. service refactor) or in need dedicated branches (extraction of the first-boot-simulate prepare/restore).