### PR TITLE
tests: reload systemd after editing /etc/fstab

### DIFF
--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -8,6 +8,9 @@ restore: |
     echo "Restore fstab copy"
     cp /tmp/fstab.save /etc/fstab
     rm -f /tmp/fstab.save
+    # Systemd detects changes to fstab and complains that the -.mount unit has
+    # changed on disk.
+    systemctl daemon-reload
 
 execute: |
     stop_snapd() {


### PR DESCRIPTION
The snap-system-key test was found to upset the -.mount unit, aka the
mount unit for the root filesystem. It seems this is happening because
the test is editing /etc/fstab.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>