### PR TITLE
tests: reload systemd after removing pulseaudio

### DIFF
--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -16,6 +16,10 @@ prepare: |
     # Install pulseaudio.
     apt-get update
     apt-get install -y pulseaudio pulseaudio-utils
+    # Remove the package and reload systemd later, when we are restoring. This
+    # is important because of rtkit-daemon.service that gets pulled by
+    # pulseaudio and that is subsequently removed.
+    echo "systemctl daemon-reload" >>defer.sh
     echo "apt-get autoremove --purge -y pulseaudio pulseaudio-utils" >>defer.sh
 
     # Make sure the socket and the server is available in the user session.

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -14,6 +14,10 @@ prepare: |
     # Install pulseaudio.
     apt-get update
     apt-get install -y pulseaudio pulseaudio-utils
+    # Remove the package and reload systemd later, when we are restoring. This
+    # is important because of rtkit-daemon.service that gets pulled by
+    # pulseaudio and that is subsequently removed.
+    echo "systemctl daemon-reload" >>defer.sh
     echo "apt-get autoremove --purge -y pulseaudio pulseaudio-utils" >>defer.sh
 
     # Make sure the socket and the server is available in the user session.


### PR DESCRIPTION
Pulseaudio pulls in rtkit-daemon.service, the real-time management
stack that can be asked to make a non-privileged process scheduled with
real-time class.

The test removes that package and this leaves the rtkit-daemon.service
in memory.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

