### PR TITLE
tests: add missing dependencies needed for sbuild test on debian

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -659,6 +659,8 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         debian-*)
             echo "
+                autopkgtest
+                debootstrap
                 dbus-user-session
                 eatmydata
                 evolution-data-server

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -659,6 +659,7 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         debian-*)
             echo "
+                dbus-user-session
                 eatmydata
                 evolution-data-server
                 fwupd
@@ -668,7 +669,7 @@ pkg_dependencies_ubuntu_classic(){
                 net-tools
                 packagekit
                 sbuild
-                dbus-user-session
+                schroot
                 "
             ;;
     esac


### PR DESCRIPTION
Adding all the needed dependencies on debian to run the sbuild test