### PR TITLE
tests: skip interfaces-openvswitch for centos 8 in nightly suite

### DIFF
--- a/tests/nightly/interfaces-openvswitch/task.yaml
+++ b/tests/nightly/interfaces-openvswitch/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the openvswitch interface works.
 
 # Openvswitch getting stuck during installation sporadically on ubuntu-14.04-64
 # Openvswitch service not available on the following systems
-systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -arch-linux-*, -centos-7-*, -ubuntu-14.04-64]
+systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -arch-linux-*, -centos-*, -ubuntu-14.04-64]
 
 details: |
     The openvswitch interface allows to task to the openvswitch socket (rw mode).


### PR DESCRIPTION
The openvswitch package is not available in centos 8

This is making the nightly test suite to fail:

quiet: dnf -y --refresh install --setopt=install_weak_deps=False
openvswitch
quiet: exit status 1. Output follows:
CentOS-8 - AppStream                             13 kB/s | 4.3 kB
00:00
CentOS-8 - Base                                  12 kB/s | 3.9 kB
00:00
CentOS-8 - Extras                               3.1 kB/s | 1.5 kB
00:00
CentOS-8 - PowerTools                            15 kB/s | 4.3 kB
00:00
Extra Packages for Enterprise Linux Modular 8 - 131 kB/s |  19 kB
00:00
Extra Packages for Enterprise Linux 8 - x86_64  161 kB/s |  20 kB
00:00
Google Compute Engine                           1.2 kB/s | 454  B
00:00
Google Cloud SDK                                854  B/s | 454  B
00:00
No match for argument: openvswitch
Error: Unable to find a match: openvswitch
quiet: end of output.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
