### PR TITLE
tests: update statx test to run on all LTS releases

### DIFF
--- a/tests/main/seccomp-statx/task.yaml
+++ b/tests/main/seccomp-statx/task.yaml
@@ -5,10 +5,9 @@ details: |
     available on each kernel but should not be blocked by seccomp
     when the kernel implements it
 
-# This test will only pass on Ubuntu 18.10 and on other systems with seccomp
-# 2.3.3 or newer. Eventually with some tricks we should be able to support all
-# systems but for the purpose of snapd 2.36 this is the best we can do.
-systems: [ubuntu-19.10-*, ubuntu-20.04-*]
+# This test will only pass on systems with seccomp 2.3.3 or newer which
+# is avaialble on all Ubuntu LTS releases.
+systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-2*]
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/seccomp-statx/task.yaml
+++ b/tests/main/seccomp-statx/task.yaml
@@ -6,7 +6,7 @@ details: |
     when the kernel implements it
 
 # This test will only pass on systems with seccomp 2.3.3 or newer which
-# is avaialble on all Ubuntu LTS releases.
+# is available on all Ubuntu LTS releases.
 systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-2*]
 
 prepare: |


### PR DESCRIPTION
The statx test can now run on all LTS releases because libseccomp
got updated via a security update everywhere.
