### PR TITLE
tests: run ubuntu-20.04-* tests on all ubuntu-2* releases

### DIFF
--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure apt hooks work
 
 # apt hook only available on 18.04+ and aws-cli only for amd64
-systems: [ubuntu-18.04-64, ubuntu-19.10-64, ubuntu-20.04-64]
+systems: [ubuntu-18.04-64, ubuntu-19.10-64, ubuntu-2*-64]
 
 manual: true
 

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -17,7 +17,7 @@ description: |
 # Expand as needed.
 # ubuntu-18.04-*: Ships xdg-desktop-portal 0.11
 # ubuntu-19.10-*: Ships xdg-desktop-portal 1.2.0
-systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
+systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-2*]
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -9,7 +9,7 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
+systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-2*]
 
 environment:
     EDITOR_HISTORY: /tmp/editor-history.txt

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -6,7 +6,7 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
+systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-2*]
 
 environment:
     BROWSER_HISTORY: /tmp/browser-history.txt

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -20,7 +20,7 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
+systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-2*]
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -6,7 +6,7 @@ summary: Ensure that the accounts-service interface works
 systems:
     - ubuntu-16.04-*
     - ubuntu-18.04-*
-    - ubuntu-20.04-*
+    - ubuntu-2*
 
 prepare: |
     # Not all the images have the same packages pre-installed.

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the audio-playback/record interface works
 
 # Only classic Ubuntu has the pulseaudio mediation patches. Ubuntu 14.04 is unsupported on the desktop.
 # TODO: extend session-tool and run this test on 14.04 as well.
-systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
+systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-2*]
 
 environment:
     PLAY_FILE: "/snap/test-snapd-audio-record/current/usr/share/sounds/alsa/Noise.wav"

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -9,7 +9,7 @@ summary: Ensure that the calendar-service interface works
 # arch-linux: test-snapd-eds is incompatible with eds version shipped with the distro
 # fedora-31: test-snapd-eds is incompatible with eds version shipped with the distro
 # fedora-32: test-snapd-eds is incompatible with eds version shipped with the distro
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*, -ubuntu-19.10-*, -ubuntu-20.04-*, -arch-linux-*, -debian-sid-*, -fedora-31-*, -fedora-32-*]
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*, -ubuntu-19.10-*, -ubuntu-2*, -arch-linux-*, -debian-sid-*, -fedora-31-*, -fedora-32-*]
 
 # fails in the autopkgtest env with:
 # [Wed Aug 15 16:34:12 2018] audit: type=1400

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -12,7 +12,7 @@ systems:
     - -opensuse-tumbleweed-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -ubuntu-14.04-*  # no session-tool support, eds is too old
     - -ubuntu-19.10-*  # test-snapd-eds is incompatible with eds shipped with the distro
-    - -ubuntu-20.04-*
+    - -ubuntu-2*
     - -ubuntu-core-*  # EDS is unsupported on core systems
 
 # fails in autopkgtest environment with:

--- a/tests/main/interfaces-password-manager-service/task.yaml
+++ b/tests/main/interfaces-password-manager-service/task.yaml
@@ -3,7 +3,7 @@ summary: Ensure that the password-manager-service interface works
 systems:
     - ubuntu-16.04-*
     - ubuntu-18.04-*
-    - ubuntu-20.04-*
+    - ubuntu-2*
 
 prepare: |
     echo "Ensure we have a working gnome-keyring"

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the pulseaudio interface works
 
 # Only classic Ubuntu has the pulseaudio mediation patches. Ubuntu 14.04 is unsupported on the desktop.
 # TODO: extend session-tool and run this test on 14.04 as well.
-systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
+systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-2*]
 
 environment:
     PLAY_FILE: "/snap/test-snapd-pulseaudio/current/usr/share/sounds/alsa/Noise.wav"

--- a/tests/main/interfaces-wayland/task.yaml
+++ b/tests/main/interfaces-wayland/task.yaml
@@ -5,7 +5,7 @@ summary: Ensure that the wayland interface works
 systems:
     - ubuntu-16.04-64
     - ubuntu-18.04-64
-    - ubuntu-20.04-64
+    - ubuntu-2*-64
 
 prepare: |
     snap install --edge test-snapd-wayland

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -3,8 +3,7 @@ description: |
   This test checks that preseeding of Ubuntu cloud images with snap-preseed
   can be undone with --reset flag.
 
-# TODO: reenable for ubuntu-20.04-*, that now uses the snapd snap
-systems: [ubuntu-19.10-*, ubuntu-20.04-*]
+systems: [ubuntu-19.10-*, ubuntu-2*]
 
 environment:
   IMAGE_MOUNTPOINT: /mnt/cloudimg

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -4,7 +4,7 @@ description: |
   command works, up to the point where the image is ready to be booted.
   The test assumes cloud image with a core and lxd snaps in its seeds/.
 
-systems: [ubuntu-19.10-*, ubuntu-20.04-*]
+systems: [ubuntu-19.10-*, ubuntu-2*]
 
 environment:
   IMAGE_MOUNTPOINT: /mnt/cloudimg

--- a/tests/main/xdg-open-portal/task.yaml
+++ b/tests/main/xdg-open-portal/task.yaml
@@ -14,7 +14,7 @@ systems:
   - opensuse-tumbleweed-*
   - ubuntu-18.04-*
   - ubuntu-19.10-*
-  - ubuntu-20.04-*
+  - ubuntu-2*
 
 environment:
     BROWSER_HISTORY: /tmp/browser-history.txt

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -5,7 +5,7 @@ description: |
   command works, and the resulting image boots and finalizes seeding.
   The test assumes cloud image with a core and lxd snaps in its seeds/.
 
-systems: [ubuntu-19.10-*, ubuntu-20.04-*]
+systems: [ubuntu-19.10-*, ubuntu-2*]
 
 environment:
   IMAGE_MOUNTPOINT: /mnt/cloudimg


### PR DESCRIPTION
This commit changes all `ubuntu-20.04-*` tests to also run on
all future Ubuntu releases in the 2020-2029 timeframe. This
will ensure tests run on e.g. groovy and if the distro changes
in an incompatile way we learn about it early.
