### PR TITLE
systemd: rename actualFsTypeAndMountOptions to hostFsTypeAndMountOptions

### DIFF
--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -103,7 +103,7 @@ func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype str
 		return "", fmt.Errorf("bind-mounted directory is not supported in emulation mode")
 	}
 
-	// In emulation mode actualFsType is the fs we want to use to manually mount
+	// In emulation mode hostFsType is the fs we want to use to manually mount
 	// the snap below, but fstype is used for the created mount unit.
 	// This means that when preseeding in a lxd container, the snap will be
 	// mounted with fuse, but mount unit will use squashfs.
@@ -113,10 +113,10 @@ func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype str
 		return "", err
 	}
 
-	actualFsType, actualOptions := actualFsTypeAndMountOptions(fstype)
-	cmd := exec.Command("mount", "-t", actualFsType, what, where, "-o", strings.Join(actualOptions, ","))
+	hostFsType, actualOptions := hostFsTypeAndMountOptions(fstype)
+	cmd := exec.Command("mount", "-t", hostFsType, what, where, "-o", strings.Join(actualOptions, ","))
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("cannot mount %s (%s) at %s in preseed mode: %s; %s", what, actualFsType, where, err, string(out))
+		return "", fmt.Errorf("cannot mount %s (%s) at %s in preseed mode: %s; %s", what, hostFsType, where, err, string(out))
 	}
 
 	multiUserTargetWantsDir := filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants")

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -780,30 +780,30 @@ func fsMountOptions(fstype string) []string {
 	return options
 }
 
-// actualFsTypeAndMountOptions returns filesystem type and options to actually
+// hostFsTypeAndMountOptions returns filesystem type and options to actually
 // mount the given fstype at runtime, i.e. it determines if fuse should be used
 // for squashfs.
-func actualFsTypeAndMountOptions(fstype string) (actualFsType string, options []string) {
+func hostFsTypeAndMountOptions(fstype string) (hostFsType string, options []string) {
 	options = fsMountOptions(fstype)
-	actualFsType = fstype
+	hostFsType = fstype
 	if fstype == "squashfs" {
 		newFsType, newOptions := squashfsFsType()
 		options = append(options, newOptions...)
-		actualFsType = newFsType
+		hostFsType = newFsType
 	}
-	return actualFsType, options
+	return hostFsType, options
 }
 
 func (s *systemd) AddMountUnitFile(snapName, revision, what, where, fstype string) (string, error) {
 	daemonReloadLock.Lock()
 	defer daemonReloadLock.Unlock()
 
-	actualFsType, options := actualFsTypeAndMountOptions(fstype)
+	hostFsType, options := hostFsTypeAndMountOptions(fstype)
 	if osutil.IsDirectory(what) {
 		options = append(options, "bind")
-		actualFsType = "none"
+		hostFsType = "none"
 	}
-	mountUnitName, err := writeMountUnitFile(snapName, revision, what, where, actualFsType, options)
+	mountUnitName, err := writeMountUnitFile(snapName, revision, what, where, hostFsType, options)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Follow up to already landed preseeding fix where @bboozzoo suggested hostFsTypeAndMountOptions name and I liked it, this PR renames it.
