### PR TITLE
snap-bootstrap: remove sealed key file on reinstall

### DIFF
--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -22,6 +22,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/snapcore/snapd/asserts"
@@ -91,6 +92,15 @@ func Run(gadgetRoot, device string, options Options) error {
 	// remove partitions added during a previous (failed) install attempt
 	if err := diskLayout.RemoveCreated(); err != nil {
 		return fmt.Errorf("cannot remove partitions from previous install: %v", err)
+	}
+	// at this point we removed any existing partition, nuke any of the
+	// existing keyfiles too (LP: #1879338)
+	for _, p := range []string{options.KeyFile, options.PolicyUpdateDataFile} {
+		if p != "" {
+			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("cannot cleanup obsolete key file: %v", p)
+			}
+		}
 	}
 
 	created, err := diskLayout.CreateMissing(lv)

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -93,14 +93,13 @@ func Run(gadgetRoot, device string, options Options) error {
 	if err := diskLayout.RemoveCreated(); err != nil {
 		return fmt.Errorf("cannot remove partitions from previous install: %v", err)
 	}
-	// at this point we removed any existing partition, nuke any of the
-	// existing keyfiles too (LP: #1879338)
-	for _, p := range []string{options.KeyFile, options.PolicyUpdateDataFile} {
-		if p != "" {
-			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("cannot cleanup obsolete key file: %v", p)
-			}
+	// existing sealed key files placed outside of the encrypted
+	// partitions (LP: #1879338)
+	if options.KeyFile != "" {
+		if err := os.Remove(options.KeyFile); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("cannot cleanup obsolete key file: %v", options.KeyFile)
 		}
+
 	}
 
 	created, err := diskLayout.CreateMissing(lv)

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -93,8 +93,9 @@ func Run(gadgetRoot, device string, options Options) error {
 	if err := diskLayout.RemoveCreated(); err != nil {
 		return fmt.Errorf("cannot remove partitions from previous install: %v", err)
 	}
-	// existing sealed key files placed outside of the encrypted
-	// partitions (LP: #1879338)
+	// at this point we removed any existing partition, nuke any
+	// of the existing sealed key files placed outside of the
+	// encrypted partitions (LP: #1879338)
 	if options.KeyFile != "" {
 		if err := os.Remove(options.KeyFile); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("cannot cleanup obsolete key file: %v", options.KeyFile)

--- a/cmd/snap-bootstrap/partition/encrypt.go
+++ b/cmd/snap-bootstrap/partition/encrypt.go
@@ -163,6 +163,9 @@ func cryptsetupClose(name string) error {
 func cryptsetupAddKey(key EncryptionKey, rkey RecoveryKey, node string) error {
 	// create a named pipe to pass the recovery key
 	fpath := filepath.Join(dirs.SnapRunDir, "tmp-rkey")
+	if err := os.MkdirAll(dirs.SnapRunDir, 0755); err != nil {
+		return err
+	}
 	if err := syscall.Mkfifo(fpath, 0600); err != nil {
 		return fmt.Errorf("cannot create named pipe: %v", err)
 	}

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -37,7 +37,7 @@ prepare: |
     apt install -y cryptsetup
 
     echo "Setup the image as a block device"
-    # use a script here as we will need this code on the next boot
+    # use a script here as this code needs to be run on the next boot
     cat > losetup.sh <<'EOF'
     #!/bin/sh -e
     echo "Setting up loop"
@@ -67,7 +67,7 @@ prepare: |
     unsquashfs -d gadget-dir pc_*.snap
 
 execute: |
-    # this test simulates a reinstall, to clean the TPM this requires
+    # this test simulates a reinstall, to clear the TPM this requires
     # a reboot so the losetup has to be redone
     if [ "$SPREAD_REBOOT" = 1 ]; then
         ./losetup.sh
@@ -127,7 +127,7 @@ execute: |
     # Can't test the keyfile because it's now sealed to the TPM
     mkdir -p ./mnt
     echo "Ensure that we can open the encrypted device using the recovery key"
-    cryptsetup open --key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key "${LOOP}p4" test-recovery
+    cryptsetup open --key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde/recovery-key "${LOOP}p4" test-recovery
     mount /dev/mapper/test-recovery ./mnt
     umount ./mnt
     cryptsetup close /dev/mapper/test-recovery

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -91,9 +91,9 @@ execute: |
     go get ../../lib/uc20-create-partitions
     uc20-create-partitions \
         --encrypt --key-file /run/mnt/ubuntu-seed/keyfile \
-        --recovery-key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key \
-        --policy-update-data-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data \
-        --tpm-lockout-auth /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth \
+        --recovery-key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde/recovery-key \
+        --policy-update-data-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde/policy-update-data \
+        --tpm-lockout-auth /run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde/tpm-lockout-auth \
         --model <(snap model --assertion) \
         ./gadget-dir "$LOOP"
     # keep for later
@@ -119,8 +119,8 @@ execute: |
     cryptsetup close /dev/mapper/ubuntu-data
 
     echo "Check the policy update data and TPM lockout authorization files"
-    ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data
-    ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth
+    ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde/policy-update-data
+    ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde/tpm-lockout-auth
 
     # Test the recovery key
 

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -36,8 +36,20 @@ prepare: |
     apt install -y cryptsetup
 
     echo "Setup the image as a block device"
+    cat > prepare.sh <<'EOF'
+    #!/bin/sh -e
+    echo "Setting up loop"
     losetup -fP fake.img
     losetup -a |grep fake.img|cut -f1 -d: > loop.txt
+
+    echo "Install EFI binaries"
+    bootdir=/run/mnt/ubuntu-boot/EFI/boot
+    mkdir -p "$bootdir"
+    cp /usr/lib/shim/shimx64.efi.signed "$bootdir"/bootx64.efi
+    cp /usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed "$bootdir"/grubx64.efi
+    EOF
+    chmod +x ./prepare.sh
+    ./prepare.sh
     LOOP="$(cat loop.txt)"
 
     echo "Create a partition that looks like a uc20 image"
@@ -58,58 +70,75 @@ prepare: |
     snap download --channel=20/edge pc
     unsquashfs -d gadget-dir pc_*.snap
 
-    echo "Install EFI binaries"
-    bootdir=/run/mnt/ubuntu-boot/EFI/boot
-    mkdir -p "$bootdir"
-    cp /usr/lib/shim/shimx64.efi.signed "$bootdir"/bootx64.efi
-    cp /usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed "$bootdir"/grubx64.efi
-
 execute: |
-    bootdir=/run/mnt/ubuntu-boot/EFI/boot
-    ls -l "$bootdir"
-    sbverify --list "$bootdir"/bootx64.efi
-    sbverify --list "$bootdir"/grubx64.efi
-    LOOP="$(cat loop.txt)"
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        bootdir=/run/mnt/ubuntu-boot/EFI/boot
+        ls -l "$bootdir"
+        sbverify --list "$bootdir"/bootx64.efi
+        sbverify --list "$bootdir"/grubx64.efi
+        LOOP="$(cat loop.txt)"
 
-    echo "Run the snap-bootstrap tool"
-    go get ../../lib/uc20-create-partitions
-    uc20-create-partitions \
-        --encrypt --key-file keyfile \
-        --recovery-key-file recovery-key \
-        --policy-update-data-file policy-update-data \
-        --tpm-lockout-auth tpm-lockout-auth \
-        --model <(snap model --assertion) \
-        ./gadget-dir "$LOOP"
+        echo "Run the snap-bootstrap tool"
+        go get ../../lib/uc20-create-partitions
+        uc20-create-partitions \
+            --encrypt --key-file keyfile \
+            --recovery-key-file recovery-key \
+            --policy-update-data-file policy-update-data \
+            --tpm-lockout-auth tpm-lockout-auth \
+            --model <(snap model --assertion) \
+            ./gadget-dir "$LOOP"
 
-    echo "Check that the key file was created"
-    test "$(stat --printf=%s ./keyfile)" -ge 1000
+        echo "Check that the key file was created"
+        test "$(stat --printf=%s ./keyfile)" -ge 1000
 
-    echo "Check that the partitions are created"
-    sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
-    sfdisk -d "$LOOP" | MATCH "^${LOOP}p2 .*size=\s*2457600, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B,.*ubuntu-seed"
-    sfdisk -d "$LOOP" | MATCH "^${LOOP}p3 .*size=\s*1536000, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-boot"
-    sfdisk -d "$LOOP" | MATCH "^${LOOP}p4 .*size=\s*15533521, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-data"
+        echo "Check that the partitions are created"
+        sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
+        sfdisk -d "$LOOP" | MATCH "^${LOOP}p2 .*size=\s*2457600, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B,.*ubuntu-seed"
+        sfdisk -d "$LOOP" | MATCH "^${LOOP}p3 .*size=\s*1536000, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-boot"
+        sfdisk -d "$LOOP" | MATCH "^${LOOP}p4 .*size=\s*15533521, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-data"
 
-    not cryptsetup isLuks "${LOOP}p1"
-    not cryptsetup isLuks "${LOOP}p2"
-    not cryptsetup isLuks "${LOOP}p3"
-    cryptsetup isLuks "${LOOP}p4"
+        not cryptsetup isLuks "${LOOP}p1"
+        not cryptsetup isLuks "${LOOP}p2"
+        not cryptsetup isLuks "${LOOP}p3"
+        cryptsetup isLuks "${LOOP}p4"
 
-    cryptsetup luksDump "${LOOP}p4" | MATCH 'Label:\s*ubuntu-data-enc'
-    POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
+        cryptsetup luksDump "${LOOP}p4" | MATCH 'Label:\s*ubuntu-data-enc'
+        POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
 
-    cryptsetup close /dev/mapper/ubuntu-data
+        cryptsetup close /dev/mapper/ubuntu-data
 
-    echo "Check the policy update data and TPM lockout authorization files"
-    ls -l policy-update-data
-    ls -l tpm-lockout-auth
+        echo "Check the policy update data and TPM lockout authorization files"
+        ls -l policy-update-data
+        ls -l tpm-lockout-auth
 
-    # Test the recovery key
+        # Test the recovery key
 
-    # Can't test the keyfile because it's now sealed to the TPM
-    mkdir -p ./mnt
-    echo "Ensure that we can open the encrypted device using the recovery key"
-    cryptsetup open --key-file recovery-key "${LOOP}p4" test-recovery
-    mount /dev/mapper/test-recovery ./mnt
-    umount ./mnt
-    cryptsetup close /dev/mapper/test-recovery
+        # Can't test the keyfile because it's now sealed to the TPM
+        mkdir -p ./mnt
+        echo "Ensure that we can open the encrypted device using the recovery key"
+        cryptsetup open --key-file recovery-key "${LOOP}p4" test-recovery
+        mount /dev/mapper/test-recovery ./mnt
+        umount ./mnt
+        cryptsetup close /dev/mapper/test-recovery
+
+        # clear tpm for the reinstall test
+        echo 5 > /sys/class/tpm/tpm0/ppi/request
+        REBOOT
+    fi
+
+    # simulate reinstall: i.e. validate that partitions can be created
+    # again without failure
+    if [ "$SPREAD_REBOOT" = 1 ]; then
+        # run prepare again after the reboot
+        ./prepare.sh
+        LOOP="$(cat loop.txt)"
+
+        # and simulate a reinstall
+        uc20-create-partitions \
+            --encrypt --key-file keyfile \
+            --recovery-key-file recovery-key \
+            --policy-update-data-file policy-update-data \
+            --tpm-lockout-auth tpm-lockout-auth \
+            --model <(snap model --assertion) \
+            ./gadget-dir "$LOOP"
+    fi

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -97,7 +97,7 @@ execute: |
         --model <(snap model --assertion) \
         ./gadget-dir "$LOOP"
     # keep for later
-    cp -a /run/mnt/ubuntu-seed/keyfile /run/mnt/ubuntu-seed/keyfile.$SPREAD_REBOOT
+    cp -a /run/mnt/ubuntu-seed/keyfile "/run/mnt/ubuntu-seed/keyfile.$SPREAD_REBOOT"
 
     echo "Check that the key file was created"
     test "$(stat --printf=%s /run/mnt/ubuntu-seed/keyfile)" -ge 1000

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -16,6 +16,7 @@ restore: |
     if [[ -d ./mnt ]]; then
         umount ./mnt || true
     fi
+    umount /run/mnt/ubuntu-seed || true
     umount /dev/mapper/ubuntu-data || true
     umount /dev/mapper/test-udata || true
 
@@ -36,11 +37,15 @@ prepare: |
     apt install -y cryptsetup
 
     echo "Setup the image as a block device"
+    # use a script here as we will need this code on the next boot
     cat > prepare.sh <<'EOF'
     #!/bin/sh -e
     echo "Setting up loop"
     losetup -fP fake.img
     losetup -a |grep fake.img|cut -f1 -d: > loop.txt
+
+    echo "Setup dirs"
+    mkdir -p /run/mnt/ubuntu-seed
 
     echo "Install EFI binaries"
     bootdir=/run/mnt/ubuntu-boot/EFI/boot
@@ -77,19 +82,20 @@ execute: |
         sbverify --list "$bootdir"/bootx64.efi
         sbverify --list "$bootdir"/grubx64.efi
         LOOP="$(cat loop.txt)"
+        mount "${LOOP}"p2 /run/mnt/ubuntu-seed
 
         echo "Run the snap-bootstrap tool"
         go get ../../lib/uc20-create-partitions
         uc20-create-partitions \
-            --encrypt --key-file keyfile \
-            --recovery-key-file recovery-key \
-            --policy-update-data-file policy-update-data \
-            --tpm-lockout-auth tpm-lockout-auth \
+            --encrypt --key-file /run/mnt/ubuntu-seed/keyfile \
+            --recovery-key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key \
+            --policy-update-data-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data \
+            --tpm-lockout-auth /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth \
             --model <(snap model --assertion) \
             ./gadget-dir "$LOOP"
 
         echo "Check that the key file was created"
-        test "$(stat --printf=%s ./keyfile)" -ge 1000
+        test "$(stat --printf=%s /run/mnt/ubuntu-seed/keyfile)" -ge 1000
 
         echo "Check that the partitions are created"
         sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
@@ -108,15 +114,15 @@ execute: |
         cryptsetup close /dev/mapper/ubuntu-data
 
         echo "Check the policy update data and TPM lockout authorization files"
-        ls -l policy-update-data
-        ls -l tpm-lockout-auth
+        ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data
+        ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth
 
         # Test the recovery key
 
         # Can't test the keyfile because it's now sealed to the TPM
         mkdir -p ./mnt
         echo "Ensure that we can open the encrypted device using the recovery key"
-        cryptsetup open --key-file recovery-key "${LOOP}p4" test-recovery
+        cryptsetup open --key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key "${LOOP}p4" test-recovery
         mount /dev/mapper/test-recovery ./mnt
         umount ./mnt
         cryptsetup close /dev/mapper/test-recovery
@@ -132,13 +138,15 @@ execute: |
         # run prepare again after the reboot
         ./prepare.sh
         LOOP="$(cat loop.txt)"
+        # a real uc20 has the ubuntu-seed partition mounted on reinstall
+        mount "${LOOP}"p2 /run/mnt/ubuntu-seed
 
         # and simulate a reinstall
         uc20-create-partitions \
-            --encrypt --key-file keyfile \
-            --recovery-key-file recovery-key \
-            --policy-update-data-file policy-update-data \
-            --tpm-lockout-auth tpm-lockout-auth \
+            --encrypt --key-file /run/mnt/ubuntu-seed/keyfile \
+            --recovery-key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key \
+            --policy-update-data-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data \
+            --tpm-lockout-auth /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth \
             --model <(snap model --assertion) \
             ./gadget-dir "$LOOP"
     fi

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -26,7 +26,7 @@ restore: |
     if [ -f loop.txt ]; then
         losetup -d "$(cat loop.txt)"
     fi
-    apt remove -y cryptsetup
+    apt autoremove -y cryptsetup
 
     rm -Rf /run/mnt
 
@@ -38,23 +38,14 @@ prepare: |
 
     echo "Setup the image as a block device"
     # use a script here as we will need this code on the next boot
-    cat > prepare.sh <<'EOF'
+    cat > losetup.sh <<'EOF'
     #!/bin/sh -e
     echo "Setting up loop"
     losetup -fP fake.img
     losetup -a |grep fake.img|cut -f1 -d: > loop.txt
-
-    echo "Setup dirs"
-    mkdir -p /run/mnt/ubuntu-seed
-
-    echo "Install EFI binaries"
-    bootdir=/run/mnt/ubuntu-boot/EFI/boot
-    mkdir -p "$bootdir"
-    cp /usr/lib/shim/shimx64.efi.signed "$bootdir"/bootx64.efi
-    cp /usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed "$bootdir"/grubx64.efi
     EOF
-    chmod +x ./prepare.sh
-    ./prepare.sh
+    chmod +x ./losetup.sh
+    ./losetup.sh
     LOOP="$(cat loop.txt)"
 
     echo "Create a partition that looks like a uc20 image"
@@ -76,77 +67,80 @@ prepare: |
     unsquashfs -d gadget-dir pc_*.snap
 
 execute: |
+    # this test simulates a reinstall, to clean the TPM this requires
+    # a reboot so the losetup has to be redone
+    if [ "$SPREAD_REBOOT" = 1 ]; then
+        ./losetup.sh
+    fi
+    LOOP="$(cat loop.txt)"
+
+    echo "Setup simulated ubuntu-seed mount"
+    mkdir -p /run/mnt/ubuntu-seed
+    mount "${LOOP}"p2 /run/mnt/ubuntu-seed
+
+    echo "Install EFI binaries"
+    bootdir=/run/mnt/ubuntu-boot/EFI/boot
+    mkdir -p "$bootdir"
+    cp /usr/lib/shim/shimx64.efi.signed "$bootdir"/bootx64.efi
+    cp /usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed "$bootdir"/grubx64.efi
+    ls -l "$bootdir"
+    sbverify --list "$bootdir"/bootx64.efi
+    sbverify --list "$bootdir"/grubx64.efi
+
+    echo "Run the snap-bootstrap tool"
+    go get ../../lib/uc20-create-partitions
+    uc20-create-partitions \
+        --encrypt --key-file /run/mnt/ubuntu-seed/keyfile \
+        --recovery-key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key \
+        --policy-update-data-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data \
+        --tpm-lockout-auth /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth \
+        --model <(snap model --assertion) \
+        ./gadget-dir "$LOOP"
+    # keep for later
+    cp -a /run/mnt/ubuntu-seed/keyfile /run/mnt/ubuntu-seed/keyfile.$SPREAD_REBOOT
+
+    echo "Check that the key file was created"
+    test "$(stat --printf=%s /run/mnt/ubuntu-seed/keyfile)" -ge 1000
+
+    echo "Check that the partitions are created"
+    sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
+    sfdisk -d "$LOOP" | MATCH "^${LOOP}p2 .*size=\s*2457600, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B,.*ubuntu-seed"
+    sfdisk -d "$LOOP" | MATCH "^${LOOP}p3 .*size=\s*1536000, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-boot"
+    sfdisk -d "$LOOP" | MATCH "^${LOOP}p4 .*size=\s*15533521, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-data"
+
+    not cryptsetup isLuks "${LOOP}p1"
+    not cryptsetup isLuks "${LOOP}p2"
+    not cryptsetup isLuks "${LOOP}p3"
+    cryptsetup isLuks "${LOOP}p4"
+
+    cryptsetup luksDump "${LOOP}p4" | MATCH 'Label:\s*ubuntu-data-enc'
+    POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
+
+    cryptsetup close /dev/mapper/ubuntu-data
+
+    echo "Check the policy update data and TPM lockout authorization files"
+    ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data
+    ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth
+
+    # Test the recovery key
+
+    # Can't test the keyfile because it's now sealed to the TPM
+    mkdir -p ./mnt
+    echo "Ensure that we can open the encrypted device using the recovery key"
+    cryptsetup open --key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key "${LOOP}p4" test-recovery
+    mount /dev/mapper/test-recovery ./mnt
+    umount ./mnt
+    cryptsetup close /dev/mapper/test-recovery
+
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        bootdir=/run/mnt/ubuntu-boot/EFI/boot
-        ls -l "$bootdir"
-        sbverify --list "$bootdir"/bootx64.efi
-        sbverify --list "$bootdir"/grubx64.efi
-        LOOP="$(cat loop.txt)"
-        mount "${LOOP}"p2 /run/mnt/ubuntu-seed
-
-        echo "Run the snap-bootstrap tool"
-        go get ../../lib/uc20-create-partitions
-        uc20-create-partitions \
-            --encrypt --key-file /run/mnt/ubuntu-seed/keyfile \
-            --recovery-key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key \
-            --policy-update-data-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data \
-            --tpm-lockout-auth /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth \
-            --model <(snap model --assertion) \
-            ./gadget-dir "$LOOP"
-
-        echo "Check that the key file was created"
-        test "$(stat --printf=%s /run/mnt/ubuntu-seed/keyfile)" -ge 1000
-
-        echo "Check that the partitions are created"
-        sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
-        sfdisk -d "$LOOP" | MATCH "^${LOOP}p2 .*size=\s*2457600, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B,.*ubuntu-seed"
-        sfdisk -d "$LOOP" | MATCH "^${LOOP}p3 .*size=\s*1536000, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-boot"
-        sfdisk -d "$LOOP" | MATCH "^${LOOP}p4 .*size=\s*15533521, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-data"
-
-        not cryptsetup isLuks "${LOOP}p1"
-        not cryptsetup isLuks "${LOOP}p2"
-        not cryptsetup isLuks "${LOOP}p3"
-        cryptsetup isLuks "${LOOP}p4"
-
-        cryptsetup luksDump "${LOOP}p4" | MATCH 'Label:\s*ubuntu-data-enc'
-        POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
-
-        cryptsetup close /dev/mapper/ubuntu-data
-
-        echo "Check the policy update data and TPM lockout authorization files"
-        ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data
-        ls -l /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth
-
-        # Test the recovery key
-
-        # Can't test the keyfile because it's now sealed to the TPM
-        mkdir -p ./mnt
-        echo "Ensure that we can open the encrypted device using the recovery key"
-        cryptsetup open --key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key "${LOOP}p4" test-recovery
-        mount /dev/mapper/test-recovery ./mnt
-        umount ./mnt
-        cryptsetup close /dev/mapper/test-recovery
-
         # clear tpm for the reinstall test
         echo 5 > /sys/class/tpm/tpm0/ppi/request
         REBOOT
     fi
 
-    # simulate reinstall: i.e. validate that partitions can be created
-    # again without failure
+    echo "Ensure the keys are different"
     if [ "$SPREAD_REBOOT" = 1 ]; then
-        # run prepare again after the reboot
-        ./prepare.sh
-        LOOP="$(cat loop.txt)"
-        # a real uc20 has the ubuntu-seed partition mounted on reinstall
-        mount "${LOOP}"p2 /run/mnt/ubuntu-seed
-
-        # and simulate a reinstall
-        uc20-create-partitions \
-            --encrypt --key-file /run/mnt/ubuntu-seed/keyfile \
-            --recovery-key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/recovery-key \
-            --policy-update-data-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/policy-update-data \
-            --tpm-lockout-auth /run/mnt/ubuntu-data/system-data/var/lib/snapd/fde/tpm-lockout-auth \
-            --model <(snap model --assertion) \
-            ./gadget-dir "$LOOP"
+        test -e /run/mnt/ubuntu-seed/keyfile.0
+        test -e /run/mnt/ubuntu-seed/keyfile.1
+        not cmp /run/mnt/ubuntu-seed/keyfile.0 /run/mnt/ubuntu-seed/keyfile.1
     fi


### PR DESCRIPTION
If a device gets reinstalled the existing encrypted partitions are
removed. Also remove to keyfile to ensure
that a reinstall is actually possible.

LP: 1879338
