### PR TITLE
gadget: make ext4 filesystems with or without metadata checksum (master)

### DIFF
--- a/gadget/filesystemimage.go
+++ b/gadget/filesystemimage.go
@@ -33,7 +33,7 @@ type MkfsFunc func(imgFile, label, contentsRootDir string) error
 var (
 	mkfsHandlers = map[string]MkfsFunc{
 		"vfat": MkfsVfat,
-		"ext4": MkfsExt4WithoutMetadataChecksum,
+		"ext4": MkfsExt4,
 	}
 )
 

--- a/gadget/filesystemimage.go
+++ b/gadget/filesystemimage.go
@@ -33,7 +33,7 @@ type MkfsFunc func(imgFile, label, contentsRootDir string) error
 var (
 	mkfsHandlers = map[string]MkfsFunc{
 		"vfat": MkfsVfat,
-		"ext4": MkfsExt4,
+		"ext4": MkfsExt4WithoutMetadataChecksum,
 	}
 )
 

--- a/gadget/mkfs.go
+++ b/gadget/mkfs.go
@@ -33,26 +33,15 @@ import (
 // filesystem label, and populates it with the contents of provided root
 // directory.
 func MkfsExt4(img, label, contentsRootDir string) error {
-	return mkfsExt4(img, label, contentsRootDir)
-}
-
-// mkfsExt4WithoutMetadataChecksum also creates an EXT4 filesystem in given image
-// file, but using checksum protection for block group descriptors instead of
-// metadata checksum.
-func MkfsExt4WithoutMetadataChecksum(img, label, contentsRootDir string) error {
-	// disable metadata checksum, which were unsupported in Ubuntu 16.04 and
-	// Ubuntu Core 16 systems and would lead to a boot failure if enabled
-	return mkfsExt4(img, label, contentsRootDir, "-O", "-metadata_csum", "-O", "uninit_bg")
-}
-
-func mkfsExt4(img, label, contentsRootDir string, options ...string) error {
 	// taken from ubuntu-image
-	mkfsArgs := append([]string{
+	// Filesystem creation is used only in snap-bootstrap for uc20 install.
+	// See https://github.com/snapcore/snapd/pull/6997#discussion_r293967140
+	// and https://bugs.launchpad.net/snappy/+bug/1878374
+	mkfsArgs := []string{
 		"mkfs.ext4",
 		// default usage type
 		"-T", "default",
-	}, options...)
-
+	}
 	if contentsRootDir != "" {
 		// mkfs.ext4 can populate the filesystem with contents of given
 		// root directory

--- a/gadget/mkfs.go
+++ b/gadget/mkfs.go
@@ -33,10 +33,10 @@ import (
 // filesystem label, and populates it with the contents of provided root
 // directory.
 func MkfsExt4(img, label, contentsRootDir string) error {
-	// taken from ubuntu-image
-	// Filesystem creation is used only in snap-bootstrap for uc20 install.
-	// See https://github.com/snapcore/snapd/pull/6997#discussion_r293967140
-	// and https://bugs.launchpad.net/snappy/+bug/1878374
+	// Originally taken from ubuntu-image
+	// Switched to use mkfs defaults for https://bugs.launchpad.net/snappy/+bug/1878374
+	// For caveats/requirements in case we need support for older systems:
+	// https://github.com/snapcore/snapd/pull/6997#discussion_r293967140
 	mkfsArgs := []string{
 		"mkfs.ext4",
 		// default usage type

--- a/gadget/mkfs.go
+++ b/gadget/mkfs.go
@@ -33,18 +33,26 @@ import (
 // filesystem label, and populates it with the contents of provided root
 // directory.
 func MkfsExt4(img, label, contentsRootDir string) error {
+	return mkfsExt4(img, label, contentsRootDir)
+}
+
+// mkfsExt4WithoutMetadataChecksum also creates an EXT4 filesystem in given image
+// file, but using checksum protection for block group descriptors instead of
+// metadata checksum.
+func MkfsExt4WithoutMetadataChecksum(img, label, contentsRootDir string) error {
+	// disable metadata checksum, which were unsupported in Ubuntu 16.04 and
+	// Ubuntu Core 16 systems and would lead to a boot failure if enabled
+	return mkfsExt4(img, label, contentsRootDir, "-O", "-metadata_csum", "-O", "uninit_bg")
+}
+
+func mkfsExt4(img, label, contentsRootDir string, options ...string) error {
 	// taken from ubuntu-image
-	mkfsArgs := []string{
+	mkfsArgs := append([]string{
 		"mkfs.ext4",
 		// default usage type
 		"-T", "default",
-		// disable metadata checksum, which were unsupported in Ubuntu
-		// 16.04 and Ubuntu Core 16 systems and would lead to a boot
-		// failure if enabled
-		"-O", "-metadata_csum",
-		// allow uninitialized block groups
-		"-O", "uninit_bg",
-	}
+	}, options...)
+
 	if contentsRootDir != "" {
 		// mkfs.ext4 can populate the filesystem with contents of given
 		// root directory

--- a/gadget/mkfs_test.go
+++ b/gadget/mkfs_test.go
@@ -102,61 +102,6 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 
 }
 
-func (m *mkfsSuite) TestMkfsExt4WithoutMetadataChecksumHappy(c *C) {
-	cmd := testutil.MockCommand(c, "fakeroot", "")
-	defer cmd.Restore()
-
-	err := gadget.MkfsExt4WithoutMetadataChecksum("foo.img", "my-label", "contents")
-	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-T", "default",
-			"-O", "-metadata_csum",
-			"-O", "uninit_bg",
-			"-d", "contents",
-			"-L", "my-label",
-			"foo.img",
-		},
-	})
-
-	cmd.ForgetCalls()
-
-	// empty label
-	err = gadget.MkfsExt4WithoutMetadataChecksum("foo.img", "", "contents")
-	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-T", "default",
-			"-O", "-metadata_csum",
-			"-O", "uninit_bg",
-			"-d", "contents",
-			"foo.img",
-		},
-	})
-
-	cmd.ForgetCalls()
-
-	// no content
-	err = gadget.MkfsExt4WithoutMetadataChecksum("foo.img", "my-label", "")
-	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-T", "default",
-			"-O", "-metadata_csum",
-			"-O", "uninit_bg",
-			"-L", "my-label",
-			"foo.img",
-		},
-	})
-
-}
-
 func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
 	cmd := testutil.MockCommand(c, "fakeroot", "echo 'command failed'; exit 1")
 	defer cmd.Restore()

--- a/gadget/mkfs_test.go
+++ b/gadget/mkfs_test.go
@@ -64,8 +64,6 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 			"fakeroot",
 			"mkfs.ext4",
 			"-T", "default",
-			"-O", "-metadata_csum",
-			"-O", "uninit_bg",
 			"-d", "contents",
 			"-L", "my-label",
 			"foo.img",
@@ -82,6 +80,57 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 			"fakeroot",
 			"mkfs.ext4",
 			"-T", "default",
+			"-d", "contents",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
+	// no content
+	err = gadget.MkfsExt4("foo.img", "my-label", "")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-T", "default",
+			"-L", "my-label",
+			"foo.img",
+		},
+	})
+
+}
+
+func (m *mkfsSuite) TestMkfsExt4WithoutMetadataChecksumHappy(c *C) {
+	cmd := testutil.MockCommand(c, "fakeroot", "")
+	defer cmd.Restore()
+
+	err := gadget.MkfsExt4WithoutMetadataChecksum("foo.img", "my-label", "contents")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-T", "default",
+			"-O", "-metadata_csum",
+			"-O", "uninit_bg",
+			"-d", "contents",
+			"-L", "my-label",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
+	// empty label
+	err = gadget.MkfsExt4WithoutMetadataChecksum("foo.img", "", "contents")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-T", "default",
 			"-O", "-metadata_csum",
 			"-O", "uninit_bg",
 			"-d", "contents",
@@ -92,7 +141,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd.ForgetCalls()
 
 	// no content
-	err = gadget.MkfsExt4("foo.img", "my-label", "")
+	err = gadget.MkfsExt4WithoutMetadataChecksum("foo.img", "my-label", "")
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -82,12 +82,16 @@ execute: |
     df -T "${LOOP}p3" | MATCH ext4
     umount ./mnt
     file -s "${LOOP}p3" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-boot"'
+    # check metadata_csum
+    tune2fs -l "${LOOP}p3" | MATCH '^Filesystem features:.*metadata_csum'
 
     mkdir -p ./mnt
     mount "${LOOP}p4" ./mnt
     df -T "${LOOP}p4" | MATCH ext4
     umount ./mnt
     file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
+    # check metadata_csum
+    tune2fs -l "${LOOP}p3" | MATCH '^Filesystem features:.*metadata_csum'
     # size is reported in 512 blocks
     sz="$(udevadm info -q property "${LOOP}p4" |grep "^ID_PART_ENTRY_SIZE=" | cut -f2 -d=)"
     # the disk size is 20GB, 1GB in 512 blocks is 2097152, with auto grow, the


### PR DESCRIPTION
Creating ext4 filesystems without metadata checksum was needed in
xenial/uc16 because e2fsprogs 1.42 didn't support it (metadata_csum
was added in 1.43 used in bionic). However, creating such a filesystem
fails in uc20 when installing on the Intel 600P NVMe stick, so we
should enable it in this case.

This is #8763 for master.