### PR TITLE
snap: (small) refactor of `snap download` code for testing/extending

### DIFF
--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -71,7 +71,7 @@ func init() {
 	}})
 }
 
-func fetchSnapAssertions(tsto *image.ToolingStore, snapPath string, snapInfo *snap.Info) (string, error) {
+func fetchSnapAssertionsDirect(tsto *image.ToolingStore, snapPath string, snapInfo *snap.Info) (string, error) {
 	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
 		Backstore: asserts.NewMemoryBackstore(),
 		Trusted:   sysdb.Trusted(),
@@ -113,6 +113,40 @@ func printInstallHint(assertPath, snapPath string) {
 `), assertPath, snapPath)
 }
 
+// for testing
+var downloadDirect = downloadDirectImpl
+
+func downloadDirectImpl(snapName string, revision snap.Revision, dlOpts image.DownloadOptions) error {
+	tsto, err := image.NewToolingStore()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(Stdout, i18n.G("Fetching snap %q\n"), snapName)
+	snapPath, snapInfo, _, err := tsto.DownloadSnap(snapName, dlOpts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(Stdout, i18n.G("Fetching assertions for %q\n"), snapName)
+	assertPath, err := fetchSnapAssertionsDirect(tsto, snapPath, snapInfo)
+	printInstallHint(assertPath, snapPath)
+	return err
+}
+
+func (x *cmdDownload) downloadFromStore(snapName string, revision snap.Revision) error {
+	dlOpts := image.DownloadOptions{
+		TargetDir: x.TargetDir,
+		Basename:  x.Basename,
+		Channel:   x.Channel,
+		CohortKey: x.CohortKey,
+		Revision:  revision,
+		// if something goes wrong, don't force it to start over again
+		LeavePartialOnError: true,
+	}
+	return downloadDirect(snapName, revision, dlOpts)
+}
+
 func (x *cmdDownload) Execute(args []string) error {
 	if strings.ContainsRune(x.Basename, filepath.Separator) {
 		return fmt.Errorf(i18n.G("cannot specify a path in basename (use --target-dir for that)"))
@@ -143,33 +177,7 @@ func (x *cmdDownload) Execute(args []string) error {
 	}
 
 	snapName := string(x.Positional.Snap)
-
-	tsto, err := image.NewToolingStore()
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(Stdout, i18n.G("Fetching snap %q\n"), snapName)
-	dlOpts := image.DownloadOptions{
-		TargetDir: x.TargetDir,
-		Basename:  x.Basename,
-		Channel:   x.Channel,
-		CohortKey: x.CohortKey,
-		Revision:  revision,
-		// if something goes wrong, don't force it to start over again
-		LeavePartialOnError: true,
-	}
-	snapPath, snapInfo, _, err := tsto.DownloadSnap(snapName, dlOpts)
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(Stdout, i18n.G("Fetching assertions for %q\n"), snapName)
-	assertPath, err := fetchSnapAssertions(tsto, snapPath, snapInfo)
-	if err != nil {
-		return err
-	}
-	printInstallHint(assertPath, snapPath)
+	x.downloadFromStore(snapName, revision)
 
 	return nil
 }

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -130,8 +130,11 @@ func downloadDirectImpl(snapName string, revision snap.Revision, dlOpts image.Do
 
 	fmt.Fprintf(Stdout, i18n.G("Fetching assertions for %q\n"), snapName)
 	assertPath, err := fetchSnapAssertionsDirect(tsto, snapPath, snapInfo)
+	if err != nil {
+		return err
+	}
 	printInstallHint(assertPath, snapPath)
-	return err
+	return nil
 }
 
 func (x *cmdDownload) downloadFromStore(snapName string, revision snap.Revision) error {
@@ -177,7 +180,5 @@ func (x *cmdDownload) Execute(args []string) error {
 	}
 
 	snapName := string(x.Positional.Snap)
-	x.downloadFromStore(snapName, revision)
-
-	return nil
+	return x.downloadFromStore(snapName, revision)
 }

--- a/cmd/snap/cmd_download_test.go
+++ b/cmd/snap/cmd_download_test.go
@@ -25,14 +25,16 @@ import (
 
 	"gopkg.in/check.v1"
 
-	snap "github.com/snapcore/snapd/cmd/snap"
+	snapCmd "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/image"
+	"github.com/snapcore/snapd/snap"
 )
 
 // these only cover errors that happen before hitting the network,
 // because we're not (yet!) mocking the tooling store
 
 func (s *SnapSuite) TestDownloadBadBasename(c *check.C) {
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{
+	_, err := snapCmd.Parser(snapCmd.Client()).ParseArgs([]string{
 		"download", "--basename=/foo", "a-snap",
 	})
 
@@ -40,7 +42,7 @@ func (s *SnapSuite) TestDownloadBadBasename(c *check.C) {
 }
 
 func (s *SnapSuite) TestDownloadBadChannelCombo(c *check.C) {
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{
+	_, err := snapCmd.Parser(snapCmd.Client()).ParseArgs([]string{
 		"download", "--beta", "--channel=foo", "a-snap",
 	})
 
@@ -48,7 +50,7 @@ func (s *SnapSuite) TestDownloadBadChannelCombo(c *check.C) {
 }
 
 func (s *SnapSuite) TestDownloadCohortAndRevision(c *check.C) {
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{
+	_, err := snapCmd.Parser(snapCmd.Client()).ParseArgs([]string{
 		"download", "--cohort=what", "--revision=1234", "a-snap",
 	})
 
@@ -56,7 +58,7 @@ func (s *SnapSuite) TestDownloadCohortAndRevision(c *check.C) {
 }
 
 func (s *SnapSuite) TestDownloadChannelAndRevision(c *check.C) {
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{
+	_, err := snapCmd.Parser(snapCmd.Client()).ParseArgs([]string{
 		"download", "--beta", "--revision=1234", "a-snap",
 	})
 
@@ -64,7 +66,7 @@ func (s *SnapSuite) TestDownloadChannelAndRevision(c *check.C) {
 }
 
 func (s *SnapSuite) TestPrintInstalHint(c *check.C) {
-	snap.PrintInstallHint("foo_1.assert", "foo_1.snap")
+	snapCmd.PrintInstallHint("foo_1.assert", "foo_1.snap")
 	c.Check(s.Stdout(), check.Equals, `Install the snap with:
    snap ack foo_1.assert
    snap install foo_1.snap
@@ -75,10 +77,36 @@ func (s *SnapSuite) TestPrintInstalHint(c *check.C) {
 	c.Assert(err, check.IsNil)
 	as := filepath.Join(cwd, "some-dir/foo_1.assert")
 	sn := filepath.Join(cwd, "some-dir/foo_1.snap")
-	snap.PrintInstallHint(as, sn)
+	snapCmd.PrintInstallHint(as, sn)
 	c.Check(s.Stdout(), check.Equals, `Install the snap with:
    snap ack some-dir/foo_1.assert
    snap install some-dir/foo_1.snap
 `)
+}
 
+func (s *SnapSuite) TestDownloadDirect(c *check.C) {
+	var n int
+	restore := snapCmd.MockDownloadDirect(func(snapName string, revision snap.Revision, dlOpts image.DownloadOptions) error {
+		c.Check(snapName, check.Equals, "a-snap")
+		c.Check(revision, check.Equals, snap.R(0))
+		c.Check(dlOpts.Basename, check.Equals, "some-base-name")
+		c.Check(dlOpts.TargetDir, check.Equals, "some-target-dir")
+		c.Check(dlOpts.Channel, check.Equals, "some-channel")
+		c.Check(dlOpts.CohortKey, check.Equals, "some-cohort")
+		n++
+		return nil
+	})
+	defer restore()
+
+	// check that a direct download got issued
+	_, err := snapCmd.Parser(snapCmd.Client()).ParseArgs([]string{
+		"download",
+		"--target-directory=some-target-dir",
+		"--basename=some-base-name",
+		"--channel=some-channel",
+		"--cohort=some-cohort",
+		"a-snap"},
+	)
+	c.Assert(err, check.IsNil)
+	c.Check(n, check.Equals, 1)
 }

--- a/cmd/snap/cmd_download_test.go
+++ b/cmd/snap/cmd_download_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -108,5 +109,22 @@ func (s *SnapSuite) TestDownloadDirect(c *check.C) {
 		"a-snap"},
 	)
 	c.Assert(err, check.IsNil)
+	c.Check(n, check.Equals, 1)
+}
+
+func (s *SnapSuite) TestDownloadDirectErrors(c *check.C) {
+	var n int
+	restore := snapCmd.MockDownloadDirect(func(snapName string, revision snap.Revision, dlOpts image.DownloadOptions) error {
+		n++
+		return fmt.Errorf("some-error")
+	})
+	defer restore()
+
+	// check that a direct download got issued
+	_, err := snapCmd.Parser(snapCmd.Client()).ParseArgs([]string{
+		"download",
+		"a-snap"},
+	)
+	c.Assert(err, check.ErrorMatches, "some-error")
 	c.Check(n, check.Equals, 1)
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/sandbox/selinux"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -355,5 +356,13 @@ func MockIoutilTempDir(f func(string, string) (string, error)) (restore func()) 
 	ioutilTempDir = f
 	return func() {
 		ioutilTempDir = old
+	}
+}
+
+func MockDownloadDirect(f func(snapName string, revision snap.Revision, dlOpts image.DownloadOptions) error) (restore func()) {
+	old := downloadDirect
+	downloadDirect = f
+	return func() {
+		downloadDirect = old
 	}
 }


### PR DESCRIPTION
This commit adds tests that `snap download <snap>` is calling
the right helpers. It's a first step for the snap downloads
via the snapd daemon from the client.
