### PR TITLE
tests: fix broken snapd.session agent.socket

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -9,6 +9,7 @@ environment:
     # a different go in gccgo tests)
     PATH: $GOHOME/bin:/snap/bin:$PATH:/usr/lib/go-1.6/bin:/var/lib/snapd/snap/bin:$PROJECT_PATH/tests/lib/bin
     TESTSLIB: $PROJECT_PATH/tests/lib
+    TESTSTOOLS: $PROJECT_PATH/tests/lib/tools
     SNAPPY_TESTING: 1
     # we run the entire suite with re-exec on (the default) and modify
     # the core snap so that it contains our new code.  So we run new

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -605,8 +605,10 @@ restore_project_each() {
     invariant-tool check
     "$TESTSTOOLS"/cleanup-state post-invariant
 
+    # TODO: move this to tests.cleanup.
     restore_dev_random
 
+    # TODO: move this to tests.invariant.
     # Udev rules are notoriously hard to write and seemingly correct but subtly
     # wrong rules can pass review. Whenever that happens udev logs an error
     # message. As a last resort from lack of a better mechanism we can try to
@@ -616,6 +618,7 @@ restore_project_each() {
         exit 1
     fi
 
+    # TODO: move this to tests.invariant.
     # Check if the OOM killer got invoked - if that is the case our tests
     # will most likely not function correctly anymore. It looks like this
     # happens with: https://forum.snapcraft.io/t/4101 and is a source of
@@ -629,6 +632,7 @@ restore_project_each() {
         exit 1
     fi
 
+    # TODO: move this to tests.invariant.
     # check if there is a shutdown pending, no test should trigger this
     # and it leads to very confusing test failures
     if [ -e /run/systemd/shutdown/scheduled ]; then
@@ -637,6 +641,7 @@ restore_project_each() {
         exit 1
     fi
 
+    # TODO: move this to tests.invariant.
     # Check for kernel oops during the tests
     if dmesg|grep "Oops: "; then
         echo "A kernel oops happened during the tests, test results will be unreliable"
@@ -645,6 +650,7 @@ restore_project_each() {
         exit 1
     fi
 
+    # TODO: move this to tests.invariant.
     if getent passwd snap_daemon; then
         echo "Test left the snap_daemon user behind, this should not happen"
         exit 1
@@ -654,13 +660,16 @@ restore_project_each() {
         exit 1
     fi
 
+    # TODO: move this to tests.invariant.
     # Something is hosing the filesystem so look for signs of that
     not grep -F "//deleted /etc" /proc/self/mountinfo
 
+    # TODO: move this to tests.invariant.
     if journalctl -u snapd.service | grep -F "signal: terminated"; then
         exit 1;
     fi
 
+    # TODO: move this to tests.invariant.
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*)
             # Make sure that we are not leaving behind incorrectly labeled snap

--- a/tests/lib/tools/cleanup-state
+++ b/tests/lib/tools/cleanup-state
@@ -64,6 +64,17 @@ case "$action" in
 		# processes of the "test" user are terminated.
 		if pgrep -u root --full "systemd --user"; then
 			systemctl --user daemon-reload
+			# Following that, check if there's a snapd.session-agent.socket and
+			# if one exists stop it and then start it, ignoring errors.  If the
+			# unit was removed, stopping it clears it from memory. This is
+			# different from restarting the unit, which doesn't do anything if
+			# the unit on disk is gone.
+			if systemctl --user is-active snapd.session-agent.socket; then
+				systemctl --user stop snapd.session-agent.socket
+			fi
+			# XXX: if there's a way to check if an unit exists but is stopped,
+			# use it here to avoid starting a non-existing unit.
+			systemctl --user start restart snapd.session-agent.socket || true
 		fi
 		;;
 	post-invariant)

--- a/tests/lib/tools/cleanup-state
+++ b/tests/lib/tools/cleanup-state
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+show_help() {
+	echo "usage: cleanup-state <pre-invariant|post-invariant>"
+	echo
+	echo "Runs cleanup actions of the selected class:"
+	echo "   pre-invariant:"
+	echo "      Clean state that is currently expected to leak from"
+	echo "      any test, due to imperfections in the code."
+	echo "   post-invariant:"
+	echo "      Clean state that is not expected to be restored by"
+	echo "      each test, that should not leak across tests."
+}
+
+if [ $# -eq 0 ]; then
+	show_help
+	exit 1
+fi
+
+action=
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-h|--help)
+			show_help
+			exit 0
+			;;
+		--)
+			shift
+			break
+			;;
+		pre-invariant)
+			action=pre-invariant
+			shift
+			;;
+		post-invariant)
+			action=post-invariant
+			shift
+			;;
+		-*)
+			echo "cleanup-state: unsupported argument $1" >&2
+			exit 1
+			;;
+		*)
+			echo "cleanup-state: unknown action $1" >&2
+			exit 1
+			;;
+	esac
+done
+
+case "$action" in
+	pre-invariant)
+		# If the root user has a systemd --user instance then ask it to reload.
+		# This prevents tests from leaking user-session services that stay in
+		# memory but are not present on disk, or have been modified on disk, as is
+		# common with tests that use snaps with user services _or_ with tests that
+		# cause installation of the snapd.session-agent.service unit via re-exec
+		# machinery.
+		#
+		# This is done AHEAD of the invariant checks as it is very widespread
+		# and fixing it in each test is not a priority right now.
+		#
+		# Note that similar treatment is not required for the "test" user as
+		# correct usage of session-tool ensures that the session and all the
+		# processes of the "test" user are terminated.
+		if pgrep -u root --full "systemd --user"; then
+			systemctl --user daemon-reload
+		fi
+		;;
+	post-invariant)
+		true
+		;;
+	*)
+		echo "cleanup-state: unknown action $action" >&2
+		exit 1
+		;;
+esac


### PR DESCRIPTION
We've started noticing a problem where snapd session agent for the root user
cannot be reached, with socket, for the root user, responding with EOF.

This was traced to the way systemd handles socket units after they were removed
from disk. Even if systemd --user is restarted via daemon-reload, the unit
stays in "active" state while being broken. Systemd is even kind enough to let
us know about it.

        # systemctl --user status snapd.session-agent.socket
        ● snapd.session-agent.socket
           Loaded: not-found (Reason: Unit snapd.session-agent.socket not found.)
           Active: active (listening) since Fri 2020-05-29 09:39:55 UTC; 8min ago
           CGroup: /user.slice/user-0.slice/user@0.service/snapd.session-agent.socket

        May 29 09:39:55 may290939-310559 systemd[1269]: Listening on REST API socket for snapd user session agent.
        May 29 09:47:45 may290939-310559 systemd[1269]: snapd.session-agent.socket: Socket unit configuration has changed while unit has been running

Subsequent re-installation of the socket is insufficient to recover. Stopping
the socket removes the broken state and allow tests to work correctly.

Please refer to particular commit messages for details.                                                                                                                                                                                             
