### PR TITLE
snap/naming: add ParseSecurityTag and friends

### DIFF
--- a/snap/naming/tag.go
+++ b/snap/naming/tag.go
@@ -1,0 +1,125 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package naming
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var errInvalidSecurityTag = errors.New("invalid security tag")
+
+// ParsedSecurityTag describes a parsed snap security tag.
+type ParsedSecurityTag interface {
+	// String returns the entire security tag.
+	String() string
+
+	// InstanceName returns the snap name and instance key.
+	InstanceName() string
+}
+
+// ParsedAppSecurityTag describes a parsed snap application security tag.
+type ParsedAppSecurityTag interface {
+	ParsedSecurityTag
+	// AppName returns the name of the application.
+	AppName() string
+}
+
+type appSecurityTag struct {
+	instanceName string
+	appName      string
+}
+
+func (t appSecurityTag) String() string {
+	return fmt.Sprintf("snap.%s.%s", t.instanceName, t.appName)
+}
+
+func (t appSecurityTag) InstanceName() string {
+	return t.instanceName
+}
+
+func (t appSecurityTag) AppName() string {
+	return t.appName
+}
+
+// ParsedAppSecurityTag describes a parsed snap hook security tag.
+type ParsedHookSecurityTag interface {
+	ParsedSecurityTag
+	// HookName returns the name of the hook.
+	HookName() string
+}
+
+type hookSecurityTag struct {
+	instanceName string
+	hookName     string
+}
+
+func (t hookSecurityTag) String() string {
+	return fmt.Sprintf("snap.%s.hook.%s", t.instanceName, t.hookName)
+}
+
+func (t hookSecurityTag) InstanceName() string {
+	return t.instanceName
+}
+
+func (t hookSecurityTag) HookName() string {
+	return t.hookName
+}
+
+// ParseSecurityTag parses a snap security tag and returns a parsed representation or an error.
+//
+// Further type assertions can be used to described the particular form, either
+// describing an application or a hook specific security tag.
+func ParseSecurityTag(tag string) (ParsedSecurityTag, error) {
+	// We expect at most four parts. Split with up to five parts so that the
+	// len(parts) test catches invalid format tags very early.
+	parts := strings.SplitN(tag, ".", 5)
+	// We expect either three or four components.
+	if len(parts) != 3 && len(parts) != 4 {
+		return nil, errInvalidSecurityTag
+	}
+	// We expect "snap" and the snap instance name as first two fields.
+	snapLiteral, snapName := parts[0], parts[1]
+	if snapLiteral != "snap" {
+		return nil, errInvalidSecurityTag
+	}
+	if err := ValidateInstance(snapName); err != nil {
+		return nil, errInvalidSecurityTag
+	}
+	// Depending on the type of the tag we either expect application name or
+	// the "hook" literal and the hook name.
+	if len(parts) == 3 {
+		appName := parts[2]
+		if err := ValidateApp(appName); err != nil {
+			return nil, errInvalidSecurityTag
+		}
+		return &appSecurityTag{instanceName: snapName, appName: appName}, nil
+	} else {
+		hookLiteral, hookName := parts[2], parts[3]
+		if hookLiteral != "hook" {
+			return nil, errInvalidSecurityTag
+		}
+		if err := ValidateHook(hookName); err != nil {
+			return nil, errInvalidSecurityTag
+		}
+		return &hookSecurityTag{instanceName: snapName, hookName: hookName}, nil
+	}
+}

--- a/snap/naming/tag_test.go
+++ b/snap/naming/tag_test.go
@@ -1,0 +1,92 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package naming_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/snap/naming"
+)
+
+type tagSuite struct{}
+
+var _ = Suite(&tagSuite{})
+
+func (s *tagSuite) TestParseSecurityTag(c *C) {
+	// valid snap names, snap instances, app names and hook names are accepted.
+	tag, err := naming.ParseSecurityTag("snap.pkg.app")
+	c.Assert(err, IsNil)
+	c.Check(tag.String(), Equals, "snap.pkg.app")
+	c.Check(tag.InstanceName(), Equals, "pkg")
+	c.Check(tag.(naming.ParsedAppSecurityTag).AppName(), Equals, "app")
+
+	tag, err = naming.ParseSecurityTag("snap.pkg_key.app")
+	c.Assert(err, IsNil)
+	c.Check(tag.String(), Equals, "snap.pkg_key.app")
+	c.Check(tag.InstanceName(), Equals, "pkg_key")
+	c.Check(tag.(naming.ParsedAppSecurityTag).AppName(), Equals, "app")
+
+	tag, err = naming.ParseSecurityTag("snap.pkg.hook.configure")
+	c.Assert(err, IsNil)
+	c.Check(tag.String(), Equals, "snap.pkg.hook.configure")
+	c.Check(tag.InstanceName(), Equals, "pkg")
+	c.Check(tag.(naming.ParsedHookSecurityTag).HookName(), Equals, "configure")
+
+	tag, err = naming.ParseSecurityTag("snap.pkg_key.hook.configure")
+	c.Assert(err, IsNil)
+	c.Check(tag.String(), Equals, "snap.pkg_key.hook.configure")
+	c.Check(tag.InstanceName(), Equals, "pkg_key")
+	c.Check(tag.(naming.ParsedHookSecurityTag).HookName(), Equals, "configure")
+
+	// invalid format is rejected
+	_, err = naming.ParseSecurityTag("snap.pkg.app.surprise")
+	c.Check(err, ErrorMatches, "invalid security tag")
+	_, err = naming.ParseSecurityTag("snap.pkg_key.app.surprise")
+	c.Check(err, ErrorMatches, "invalid security tag")
+
+	// invalid snap and app names are rejected.
+	_, err = naming.ParseSecurityTag("snap._.app")
+	c.Check(err, ErrorMatches, "invalid security tag")
+	_, err = naming.ParseSecurityTag("snap.pkg._")
+	c.Check(err, ErrorMatches, "invalid security tag")
+
+	// invalid number of components are rejected.
+	_, err = naming.ParseSecurityTag("snap.pkg.hook.surprise.")
+	c.Check(err, ErrorMatches, "invalid security tag")
+	_, err = naming.ParseSecurityTag("snap.pkg.hook.")
+	c.Check(err, ErrorMatches, "invalid security tag")
+	tag, err = naming.ParseSecurityTag("snap.pkg.hook")
+	c.Assert(err, IsNil) // Perhaps somewhat unexpectedly, this tag is valid.
+	c.Check(tag.(naming.ParsedAppSecurityTag).AppName(), Equals, "hook")
+	_, err = naming.ParseSecurityTag("snap.pkg.app.surprise")
+	c.Check(err, ErrorMatches, "invalid security tag")
+	_, err = naming.ParseSecurityTag("snap.pkg.")
+	c.Check(err, ErrorMatches, "invalid security tag")
+	_, err = naming.ParseSecurityTag("snap.pkg")
+	c.Check(err, ErrorMatches, "invalid security tag")
+	_, err = naming.ParseSecurityTag("snap.")
+	c.Check(err, ErrorMatches, "invalid security tag")
+	_, err = naming.ParseSecurityTag("snap")
+	c.Check(err, ErrorMatches, "invalid security tag")
+
+	// things that are not snap.* tags
+	_, err = naming.ParseSecurityTag("foo.bar.froz")
+	c.Check(err, ErrorMatches, "invalid security tag")
+}

--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -21,7 +21,6 @@
 package naming
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -176,8 +175,6 @@ func ValidateSnapID(id string) error {
 	return nil
 }
 
-var errInvalidSecurityTag = errors.New("invalid security tag")
-
 // ValidateSecurityTag validates known variants of snap security tag.
 //
 // Two forms are recognised, one for apps and one for hooks. Other forms
@@ -185,39 +182,6 @@ var errInvalidSecurityTag = errors.New("invalid security tag")
 //
 // TODO: handle the weird udev variant.
 func ValidateSecurityTag(tag string) error {
-	// We expect at most four parts. Split with up to five parts so that the
-	// len(parts) test catches invalid format tags very early.
-	parts := strings.SplitN(tag, ".", 5)
-	// We expect either three or four components.
-	if len(parts) != 3 && len(parts) != 4 {
-		return errInvalidSecurityTag
-	}
-	// We expect "snap" and the snap instance name as first two fields.
-	snapLiteral, snapName := parts[0], parts[1]
-	if snapLiteral != "snap" {
-		return errInvalidSecurityTag
-	}
-	if err := ValidateInstance(snapName); err != nil {
-		return errInvalidSecurityTag
-	}
-	// Depending on the type of the tag we either expect application name or
-	// the "hook" literal and the hook name.
-	switch len(parts) {
-	case 3:
-		appName := parts[2]
-		if err := ValidateApp(appName); err != nil {
-			return errInvalidSecurityTag
-		}
-		return nil
-	case 4:
-		hookLiteral, hookName := parts[2], parts[3]
-		if hookLiteral != "hook" {
-			return errInvalidSecurityTag
-		}
-		if err := ValidateHook(hookName); err != nil {
-			return errInvalidSecurityTag
-		}
-		return nil
-	}
-	return errInvalidSecurityTag
+	_, err := ParseSecurityTag(tag)
+	return err
 }

--- a/snap/naming/validate_test.go
+++ b/snap/naming/validate_test.go
@@ -306,6 +306,7 @@ func (s *ValidateSuite) TestValidateSecurityTag(c *C) {
 	c.Check(naming.ValidateSecurityTag("snap.pkg_key.app"), IsNil)
 	c.Check(naming.ValidateSecurityTag("snap.pkg_key.hook.configure"), IsNil)
 
+	// invalid format is rejected
 	c.Check(naming.ValidateSecurityTag("snap.pkg_key.app.surprise"), ErrorMatches, "invalid security tag")
 	c.Check(naming.ValidateSecurityTag("snap.pkg_key.hook.configure.surprise"), ErrorMatches, "invalid security tag")
 


### PR DESCRIPTION
We have a need to parse security tags and extract specific fields,
like snap name, in a reliable way. This patch introduces a new function,
ParseSecurityTag, along with a group of related interfaces
ParsedSecurityTag, ParsedAppSecurityTag and ParsedHookSecurityTag.

Together they piggy back on the work that was already done for
ValidateSecurityTag, to return the right data at the right time.
At the same time the aforementioned function reduces to a trivial
call to ParseSecurityTag.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
