### PR TITLE
snap-bootstrap: remove sealed key file on reinstall (2.45)

### DIFF
--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -22,6 +22,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/snapcore/snapd/asserts"
@@ -91,6 +92,15 @@ func Run(gadgetRoot, device string, options Options) error {
 	// remove partitions added during a previous (failed) install attempt
 	if err := diskLayout.RemoveCreated(); err != nil {
 		return fmt.Errorf("cannot remove partitions from previous install: %v", err)
+	}
+	// at this point we removed any existing partition, nuke any
+	// of the existing sealed key files placed outside of the
+	// encrypted partitions (LP: #1879338)
+	if options.KeyFile != "" {
+		if err := os.Remove(options.KeyFile); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("cannot cleanup obsolete key file: %v", options.KeyFile)
+		}
+
 	}
 
 	created, err := diskLayout.CreateMissing(lv)

--- a/cmd/snap-bootstrap/partition/encrypt.go
+++ b/cmd/snap-bootstrap/partition/encrypt.go
@@ -163,6 +163,9 @@ func cryptsetupClose(name string) error {
 func cryptsetupAddKey(key EncryptionKey, rkey RecoveryKey, node string) error {
 	// create a named pipe to pass the recovery key
 	fpath := filepath.Join(dirs.SnapRunDir, "tmp-rkey")
+	if err := os.MkdirAll(dirs.SnapRunDir, 0755); err != nil {
+		return err
+	}
 	if err := syscall.Mkfifo(fpath, 0600); err != nil {
 		return fmt.Errorf("cannot create named pipe: %v", err)
 	}


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/8762 without the test (too many conflicts) for 2.45.

