### PR TITLE
overlord/configstate: add sysctl option

### DIFF
--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -78,6 +78,9 @@ func init() {
 	// system.disable-backlight-service
 	addFSOnlyHandler(validateBacklightServiceSettings, handleBacklightServiceConfiguration, coreOnly)
 
+	// system.kernel.printk.console-loglevel
+	addFSOnlyHandler(validateSysctlOptions, handleSysctlConfiguration, coreOnly)
+
 	// journal.persistent
 	addFSOnlyHandler(validateJournalSettings, handleJournalConfiguration, coreOnly)
 }

--- a/overlord/configstate/configcore/sysctl.go
+++ b/overlord/configstate/configcore/sysctl.go
@@ -1,0 +1,99 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+)
+
+func init() {
+	// add supported configuration of this module
+	supportedConfigurations["core.system.kernel.printk.console-loglevel"] = true
+}
+
+func validateSysctlOptions(tr config.ConfGetter) error {
+	consoleLoglevelStr, err := coreCfg(tr, "system.kernel.printk.console-loglevel")
+	if err != nil {
+		return err
+	}
+	if consoleLoglevelStr != "" {
+		if n, err := strconv.ParseUint(consoleLoglevelStr, 10, 8); err != nil || (n < 0 || n > 7) {
+			return fmt.Errorf("console-loglevel must be a number between 0 and 7, not %q", consoleLoglevelStr)
+		}
+	}
+	return nil
+}
+
+func handleSysctlConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+	root := dirs.GlobalRootDir
+	if opts != nil {
+		root = opts.RootDir
+	}
+	dir := filepath.Join(root, "/etc/sysctl.d")
+	name := "99-snapd.conf"
+	content := bytes.NewBuffer(nil)
+
+	consoleLoglevelStr, err := coreCfg(tr, "system.kernel.printk.console-loglevel")
+	if err != nil {
+		return nil
+	}
+
+	var sysctlConf string
+	if consoleLoglevelStr != "" {
+		content.WriteString(fmt.Sprintf("kernel.printk = %s 4 1 7\n", consoleLoglevelStr))
+		sysctlConf = filepath.Join(dir, name)
+	} else {
+		// Don't write values to content so that the file setting this option gets removed.
+		// Reset console-loglevel to default value.
+		sysctlConf = filepath.Join(dir, "10-console-messages.conf")
+	}
+	dirContent := map[string]osutil.FileState{}
+	if content.Len() > 0 {
+		dirContent[name] = &osutil.MemoryFileState{
+			Content: content.Bytes(),
+			Mode:    0644,
+		}
+	}
+
+	// write the new config
+	glob := name
+	changed, removed, err := osutil.EnsureDirState(dir, glob, dirContent)
+	if err != nil {
+		return err
+	}
+
+	if opts == nil {
+		if len(changed) > 0 || len(removed) > 0 {
+			if output, err := exec.Command("sysctl", "-p", sysctlConf).CombinedOutput(); err != nil {
+				return osutil.OutputErr(output, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/overlord/configstate/configcore/sysctl_test.go
+++ b/overlord/configstate/configcore/sysctl_test.go
@@ -1,0 +1,150 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type sysctlSuite struct {
+	configcoreSuite
+
+	mockSysctlPath               string
+	mockSysctlConsoleMsgConfPath string
+	restores                     []func()
+	mockSysctl                   *testutil.MockCmd
+}
+
+var _ = Suite(&sysctlSuite{})
+
+func (s *sysctlSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.restores = append(s.restores, release.MockOnClassic(false))
+
+	s.mockSysctl = testutil.MockCommand(c, "sysctl", "")
+	s.restores = append(s.restores, func() { s.mockSysctl.Restore() })
+
+	s.mockSysctlPath = filepath.Join(dirs.GlobalRootDir, "/etc/sysctl.d/99-snapd.conf")
+	c.Assert(os.MkdirAll(filepath.Dir(s.mockSysctlPath), 0755), IsNil)
+	s.mockSysctlConsoleMsgConfPath = filepath.Join(dirs.GlobalRootDir, "/etc/sysctl.d/10-console-messages.conf")
+}
+
+func (s *sysctlSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+	for _, f := range s.restores {
+		f()
+	}
+}
+
+func (s *sysctlSuite) TestConfigureSysctlIntegration(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.kernel.printk.console-loglevel": "2",
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.mockSysctlPath, testutil.FileEquals, "kernel.printk = 2 4 1 7\n")
+	c.Check(s.mockSysctl.Calls(), DeepEquals, [][]string{
+		{"sysctl", "-p", s.mockSysctlPath},
+	})
+	s.mockSysctl.ForgetCalls()
+
+	// Unset console-loglevel and restore default vaule
+	err = configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.kernel.printk.console-loglevel": "",
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(osutil.FileExists(s.mockSysctlPath), Equals, false)
+	c.Check(s.mockSysctl.Calls(), DeepEquals, [][]string{
+		{"sysctl", "-p", s.mockSysctlConsoleMsgConfPath},
+	})
+}
+
+func (s *sysctlSuite) TestConfigureLoglevelUnderRange(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.kernel.printk.console-loglevel": "-1",
+		},
+	})
+	c.Check(osutil.FileExists(s.mockSysctlPath), Equals, false)
+	c.Assert(err, ErrorMatches, `console-loglevel must be a number between 0 and 7, not "-1"`)
+}
+
+func (s *sysctlSuite) TestConfigureLoglevelOverRange(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.kernel.printk.console-loglevel": "8",
+		},
+	})
+	c.Check(osutil.FileExists(s.mockSysctlPath), Equals, false)
+	c.Assert(err, ErrorMatches, `console-loglevel must be a number between 0 and 7, not "8"`)
+}
+
+func (s *sysctlSuite) TestConfigureLevelRejected(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.kernel.printk.console-loglevel": "invalid",
+		},
+	})
+	c.Check(osutil.FileExists(s.mockSysctlPath), Equals, false)
+	c.Assert(err, ErrorMatches, `console-loglevel must be a number between 0 and 7, not "invalid"`)
+}
+
+func (s *sysctlSuite) TestConfigureSysctlIntegrationNoSetting(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf:  map[string]interface{}{},
+	})
+	c.Assert(err, IsNil)
+	c.Check(osutil.FileExists(s.mockSysctlPath), Equals, false)
+}
+
+func (s *sysctlSuite) TestFilesystemOnlyApply(c *C) {
+	conf := configcore.PlainCoreConfig(map[string]interface{}{
+		"system.kernel.printk.console-loglevel": "4",
+	})
+
+	tmpDir := c.MkDir()
+	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "/etc/sysctl.d/"), 0755), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+
+	networkSysctlPath := filepath.Join(tmpDir, "/etc/sysctl.d/99-snapd.conf")
+	c.Check(networkSysctlPath, testutil.FileEquals, "kernel.printk = 4 4 1 7\n")
+
+	// sysctl was not executed
+	c.Check(s.mockSysctl.Calls(), HasLen, 0)
+}


### PR DESCRIPTION
Add a sysctl option to change kernel console loglevel
It is documented in the kernel:
https://www.kernel.org/doc/Documentation/sysctl/kernel.txt

Get some kernel messages when power off or reboot the system
systemd-shutdown: Failed to wait for process...
systemd-shutdown: Failed to wait for process...
reboot: Restarting system
In some projects with UI snap, it's expected to have no kernel message on screen when end-user power off or reboot the system.

Original PR: #8702
Re-send the PR for
1. Rename log_control.go to sysctl.go
2. Rename the option to core.system.kernel.printk.console-loglevel
3. emit the command by sysctl -p /etc/sysctl.d/99-snapd.conf
4. Use 99-snapd.conf instead of 10-console-messages.conf
