### PR TITLE
tests: disable test of nfs v3 with udp proto on debian-sid

### DIFF
--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -183,9 +183,11 @@ execute: |
     # Ensure that this removed the extra permissions.
     ensure_normal_perms
 
-    # Skip udp protocol on arch-linux because it is not supported
-    # Error displayed: mount.nfs: requested NFS version or transport protocol is not supported
-    if [[ ! "$SPREAD_SYSTEM" =~ arch-* ]]; then
+    # Skip udp protocol on arch-linux and debian-sid because it is not supported
+    # Error displayed:
+    # - arch: mount.nfs: requested NFS version or transport protocol is not supported
+    # - debian-sid: mount.nfs: an incorrect mount option was specified
+    if [[ "$SPREAD_SYSTEM" != arch-* && "$SPREAD_SYSTEM" != debian-sid-* ]]; then
         # Mount NFS-exported /home over real /home using NFSv3 and UDP transport
         mount -t nfs localhost:/home /home -o nfsvers=3,proto=udp
 


### PR DESCRIPTION
Disable part of the nfs-support test that checks nfsv3 with udp proto on debian-sid, as it fails now with "mount.nfs: an incorrect mount option was specified" (this is caused by proto=udp option of "mount -t nfs localhost:/home /home -o nfsvers=3,proto=udp").

This follows arch in the test where it has been disabled already (although the error message is slightly different on debian).