### PR TITLE
cmd/snap/remove: mention snap restore/automatic snapshots

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -75,8 +75,8 @@ common data directory. When a --revision option is passed only the specified
 revision is removed.
 
 Unless automatic snapshots are disabled, a snapshot of all data for the snap is 
-saved upon removable and available for future restoration with snap restore. The
---purge option disables automatically creating snapshots.
+saved upon removal, which is then available for future restoration with snap
+restore. The --purge option disables automatically creating snapshots.
 `)
 
 var longRefreshHelp = i18n.G(`

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -73,6 +73,10 @@ The remove command removes the named snap instance from the system.
 By default all the snap revisions are removed, including their data and the
 common data directory. When a --revision option is passed only the specified
 revision is removed.
+
+Unless automatic snapshots are disabled, a snapshot of all data for the snap is 
+saved upon removable and available for future restoration with snap restore. The
+--purge option disables automatically creating snapshots.
 `)
 
 var longRefreshHelp = i18n.G(`


### PR DESCRIPTION
This should help users realize that removing a snap by default they can still get their data for a snap back with snap restore.

Prompted by the discussion at https://forum.snapcraft.io/t/removing-a-snap-also-removes-its-matching-users-configuration/17890/5