### PR TITLE
interfaces/many: deny arbitrary desktop files and misc from /usr/share - 2.45

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -127,19 +127,6 @@ deny /usr/share/applications/python*.desktop r,
 deny /usr/share/applications/vim.desktop r,
 deny /usr/share/applications/snap-handle-link.desktop r,  # core16
 
-# Snaps should use xdg-open from the runtime instead of reading these
-# files directly. When apps read these files, it is in an effort to offer
-# alternatives but those alternatives may not be usable by the snap (eg, the
-# snap might try to execute applications directly). Furthermore, access to the
-# desktop files in /var/lib/snapd/desktop/applications breaks GLib's portals
-# support since g_app_info_launch_default_for_uri() only calls out to the
-# portal if it can't find a .desktop file that can handle the mime type.
-# LP: #1868051. This is duplicated from desktop-legacy for compatibilty with
-# existing snaps (eg, unity messaging, xdg-mime, etc). Note: a future update
-# may suppress noisy denials.
-/var/lib/snapd/desktop/applications/ r,
-/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
-
 # Chromium content api unfortunately needs these for normal operation
 owner @{PROC}/@{pid}/fd/[0-9]* w,
 

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -111,19 +111,34 @@ deny capability mknod,
 `
 
 const browserSupportConnectedPlugAppArmorWithSandbox = `
-# Leaks installed applications
 # TODO: should this be somewhere else?
 /etc/mailcap r,
-# Snaps should be using xdg-open from the runtime instead of reading these
-# files directly since the snap is unable to do anything with these files
-# but these accesses have been allowed for a long time and remain so as not
-# to break existing snaps. These could be changed to explicit deny rules,
-# but that provides a worse debugging experience. Combined, the risks
-# outweigh the benefits of closing this information leak for the small
-# number of snaps allowed to use allow-sandbox: true. Reference:
-# https://forum.snapcraft.io/t/cannot-open-pdf-attachment-with-thunderbird/11845
-/usr/share/applications/{,*} r,
-/var/lib/snapd/desktop/applications/{,*} r,
+
+# While /usr/share/applications comes from the base runtime of the snap, it
+# has some things that snaps actually need, so allow access to those and deny
+# access to the others. This is duplicated from desktop for compatibility with
+# existing snaps.
+/usr/share/applications/ r,
+/usr/share/applications/mimeapps.list r,
+/usr/share/applications/xdg-open.desktop r,
+# silence noisy denials from desktop files in core* snaps that aren't usable by
+# snaps
+deny /usr/share/applications/python*.desktop r,
+deny /usr/share/applications/vim.desktop r,
+deny /usr/share/applications/snap-handle-link.desktop r,  # core16
+
+# Snaps should use xdg-open from the runtime instead of reading these
+# files directly. When apps read these files, it is in an effort to offer
+# alternatives but those alternatives may not be usable by the snap (eg, the
+# snap might try to execute applications directly). Furthermore, access to the
+# desktop files in /var/lib/snapd/desktop/applications breaks GLib's portals
+# support since g_app_info_launch_default_for_uri() only calls out to the
+# portal if it can't find a .desktop file that can handle the mime type.
+# LP: #1868051. Note: a future update may suppress noisy denials.
+/var/lib/snapd/desktop/applications/ r,
+/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
+
+# Chromium content api unfortunately needs these for normal operation
 owner @{PROC}/@{pid}/fd/[0-9]* w,
 
 # Various files in /run/udev/data needed by Chrome Settings. Leaks device

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -134,7 +134,9 @@ deny /usr/share/applications/snap-handle-link.desktop r,  # core16
 # desktop files in /var/lib/snapd/desktop/applications breaks GLib's portals
 # support since g_app_info_launch_default_for_uri() only calls out to the
 # portal if it can't find a .desktop file that can handle the mime type.
-# LP: #1868051. Note: a future update may suppress noisy denials.
+# LP: #1868051. This is duplicated from desktop-legacy for compatibilty with
+# existing snaps (eg, unity messaging, xdg-mime, etc). Note: a future update
+# may suppress noisy denials.
 /var/lib/snapd/desktop/applications/ r,
 /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
 

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -158,7 +158,18 @@ dbus (receive)
 
 # Allow use of snapd's internal 'xdg-open'
 /usr/bin/xdg-open ixr,
-/usr/share/applications/{,*} r,
+# While /usr/share/applications comes from the base runtime of the snap, it
+# has some things that snaps actually need, so allow access to those and deny
+# access to the others
+/usr/share/applications/ r,
+/usr/share/applications/mimeapps.list r,
+/usr/share/applications/xdg-open.desktop r,
+# silence noisy denials from desktop files in core* snaps that aren't usable by
+# snaps
+deny /usr/share/applications/python*.desktop r,
+deny /usr/share/applications/vim.desktop r,
+deny /usr/share/applications/snap-handle-link.desktop r,  # core16
+
 dbus (send)
     bus=session
     path=/

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -236,6 +236,8 @@ dbus (send)
 
 # This leaks the names of snaps with desktop files
 /var/lib/snapd/desktop/applications/ r,
+# There isn't anything useful in this file that snaps can use, but many
+# applications read it so leave it for compatibility.
 /var/lib/snapd/desktop/applications/mimeinfo.cache r,
 # Support BAMF_DESKTOP_FILE_HINT by allowing reading our desktop files
 # parallel-installs: this leaks read access to desktop files owned by keyed

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -19,6 +19,13 @@
 
 package builtin
 
+import (
+	"strings"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+)
+
 const desktopLegacySummary = `allows privileged access to desktop legacy methods`
 
 // While this gives privileged access to legacy methods we should auto-connect
@@ -234,15 +241,7 @@ dbus (send)
     interface=org.gtk.vfs.MountTracker
     member=LookupMount,
 
-# support applications which use the unity messaging menu, xdg-mime, etc
-# This leaks the names of snaps with desktop files
-/var/lib/snapd/desktop/applications/ r,
-# allowing reading only our desktop files (required by (at least) the unity
-# messaging menu). Note: a future update may suppress noisy denials when
-# attempting to read other desktop files.
-# parallel-installs: this leaks read access to desktop files owned by keyed
-# instances of @{SNAP_NAME} to @{SNAP_NAME} snap
-/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
+###SNAP_DESKTOP_FILE_RULES###
 # Snaps are unable to use the data in mimeinfo.cache (since they can't execute
 # the returned desktop file themselves). unity messaging menu doesn't require
 # mimeinfo.cache and xdg-mime will fallback to reading the desktop files
@@ -251,7 +250,6 @@ dbus (send)
 # return one of the snap's mimetypes, or none).
 deny /var/lib/snapd/desktop/applications/mimeinfo.cache r,
 `
-
 const desktopLegacyConnectedPlugSecComp = `
 # Description: Can access common desktop legacy methods. This gives privileged
 # access to the user's input.
@@ -261,13 +259,28 @@ accept
 accept4
 `
 
+type desktopLegacyInterface struct {
+	commonInterface
+}
+
+func (iface *desktopLegacyInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	snippet := ""
+	for _, r := range getDesktopFileRules(plug.Snap().InstanceName()) {
+		snippet += r + "\n"
+	}
+	spec.AddSnippet(strings.Replace(desktopLegacyConnectedPlugAppArmor, "###SNAP_DESKTOP_FILE_RULES###", snippet, -1))
+
+	return nil
+}
+
 func init() {
-	registerIface(&commonInterface{
-		name:                  "desktop-legacy",
-		summary:               desktopLegacySummary,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  desktopLegacyBaseDeclarationSlots,
-		connectedPlugAppArmor: desktopLegacyConnectedPlugAppArmor,
-		connectedPlugSecComp:  desktopLegacyConnectedPlugSecComp,
+	registerIface(&desktopLegacyInterface{
+		commonInterface: commonInterface{
+			name:                 "desktop-legacy",
+			summary:              desktopLegacySummary,
+			implicitOnClassic:    true,
+			baseDeclarationSlots: desktopLegacyBaseDeclarationSlots,
+			connectedPlugSecComp: desktopLegacyConnectedPlugSecComp,
+		},
 	})
 }

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -234,15 +234,22 @@ dbus (send)
     interface=org.gtk.vfs.MountTracker
     member=LookupMount,
 
+# support applications which use the unity messaging menu, xdg-mime, etc
 # This leaks the names of snaps with desktop files
 /var/lib/snapd/desktop/applications/ r,
-# There isn't anything useful in this file that snaps can use, but many
-# applications read it so leave it for compatibility.
-/var/lib/snapd/desktop/applications/mimeinfo.cache r,
-# Support BAMF_DESKTOP_FILE_HINT by allowing reading our desktop files
+# allowing reading only our desktop files (required by (at least) the unity
+# messaging menu). Note: a future update may suppress noisy denials when
+# attempting to read other desktop files.
 # parallel-installs: this leaks read access to desktop files owned by keyed
 # instances of @{SNAP_NAME} to @{SNAP_NAME} snap
 /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
+# Snaps are unable to use the data in mimeinfo.cache (since they can't execute
+# the returned desktop file themselves). unity messaging menu doesn't require
+# mimeinfo.cache and xdg-mime will fallback to reading the desktop files
+# directly to look for MimeType. Since reading the snap's own desktop files is
+# allowed, we can safely deny access to this file (and xdg-mime will either
+# return one of the snap's mimetypes, or none).
+deny /var/lib/snapd/desktop/applications/mimeinfo.cache r,
 `
 
 const desktopLegacyConnectedPlugSecComp = `

--- a/interfaces/builtin/desktop_legacy_test.go
+++ b/interfaces/builtin/desktop_legacy_test.go
@@ -80,6 +80,15 @@ func (s *DesktopLegacyInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access common desktop legacy methods")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/dbus-accessibility-strict>")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `peer=(addr="@/tmp/ibus/dbus-*"),`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/mimeinfo.cache r,`)
+
+	// getDesktopFileRules() rules
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `# This leaks the names of snaps with desktop files`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/var/lib/snapd/desktop/applications/ r,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}[^_.]*.desktop r,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/[^c]* r,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/consume[^r]* r,`)
 
 	// connected plug to core slot
 	spec = &apparmor.Specification{}

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -37,6 +37,8 @@ var (
 	LabelExpr                   = labelExpr
 	PlugAppLabelExpr            = plugAppLabelExpr
 	SlotAppLabelExpr            = slotAppLabelExpr
+	AareExclusivePatterns       = aareExclusivePatterns
+	GetDesktopFileRules         = getDesktopFileRules
 )
 
 func MprisGetName(iface interfaces.Interface, attribs map[string]interface{}) (string, error) {

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -62,8 +62,6 @@ owner @{HOME}/.local/share/fonts/{,**} r,
 
 # subset of gnome abstraction
 /etc/gnome/defaults.list r,
-/usr/share/gnome/applications/             r,
-/usr/share/applications/mimeinfo.cache     r,
 
 /etc/gtk-*/*                               r,
 /usr/lib{,32,64}/gtk-*/**                  mr,
@@ -80,22 +78,24 @@ owner @{HOME}/.local/share/fonts/{,**} r,
 /usr/share/icons/*/index.theme             rk,
 /usr/share/pixmaps/                        r,
 /usr/share/pixmaps/**                      r,
-/usr/share/unity/icons/**                  r,
-/usr/share/thumbnailer/icons/**            r,
-/usr/share/themes/**                       r,
 
 # The snapcraft desktop part may look for schema files in various locations, so
 # allow reading system installed schemas.
 /usr/share/glib*/schemas/{,*}              r,
-/usr/share/gnome/glib*/schemas/{,*}        r,
-/usr/share/ubuntu/glib*/schemas/{,*}       r,
 
 # Snappy's 'xdg-open' talks to the snapd-xdg-open service which currently works
 # only in environments supporting dbus-send (eg, X11). In the future once
 # snappy's xdg-open supports all snaps images, this access may move to another
 # interface.
 /usr/bin/xdg-open ixr,
-/usr/share/applications/{,*} r,
+/usr/share/applications/ r,
+/usr/share/applications/mimeapps.list r,
+/usr/share/applications/xdg-open.desktop r,
+# silence noisy denials from desktop files in core* snaps that aren't usable by
+# snaps
+deny /usr/share/applications/python*.desktop r,
+deny /usr/share/applications/vim.desktop r,
+deny /usr/share/applications/snap-handle-link.desktop r,  # core16
 
 # This allow access to the first version of the snapd-xdg-open
 # version which was shipped outside of snapd

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -499,15 +499,7 @@ deny /usr/share/applications/python*.desktop r,
 deny /usr/share/applications/vim.desktop r,
 deny /usr/share/applications/snap-handle-link.desktop r,  # core16
 
-# support applications which use the unity messaging menu, xdg-mime, etc
-# This leaks the names of snaps with desktop files
-/var/lib/snapd/desktop/applications/ r,
-# allowing reading only our desktop files (required by (at least) the unity
-# messaging menu). Note: a future update may suppress noisy denials when
-# attempting to read other desktop files.
-# parallel-installs: this leaks read access to desktop files owned by keyed
-# instances of @{SNAP_NAME} to @{SNAP_NAME} snap
-/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
+###SNAP_DESKTOP_FILE_RULES###
 # Snaps are unable to use the data in mimeinfo.cache (since they can't execute
 # the returned desktop file themselves). unity messaging menu doesn't require
 # mimeinfo.cache and xdg-mime will fallback to reading the desktop files
@@ -682,6 +674,14 @@ func (iface *unity7Interface) AppArmorConnectedPlug(spec *apparmor.Specification
 	new := strings.Replace(plug.Snap().InstanceName(), "-", "_", -1)
 	old := "###UNITY_SNAP_NAME###"
 	snippet := strings.Replace(unity7ConnectedPlugAppArmor, old, new, -1)
+
+	old = "###SNAP_DESKTOP_FILE_RULES###"
+	new = ""
+	for _, r := range getDesktopFileRules(plug.Snap().InstanceName()) {
+		new += r + "\n"
+	}
+	snippet = strings.Replace(snippet, old, new, -1)
+
 	spec.AddSnippet(snippet)
 	return nil
 }

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -89,6 +89,10 @@ owner @{HOME}/.local/share/fonts/{,**} r,
 # interface. This is duplicated from desktop for compatibility with existing
 # snaps.
 /usr/bin/xdg-open ixr,
+# While /usr/share/applications comes from the base runtime of the snap, it
+# has some things that snaps actually need, so allow access to those and deny
+# access to the others. This is duplicated from desktop for compatibility with
+# existing snaps.
 /usr/share/applications/ r,
 /usr/share/applications/mimeapps.list r,
 /usr/share/applications/xdg-open.desktop r,
@@ -485,19 +489,6 @@ dbus (receive)
     interface="{com.canonical.dbusmenu,org.freedesktop.DBus.Properties}"
     member=Get*
     peer=(label=unconfined),
-
-# While /usr/share/applications comes from the base runtime of the snap, it
-# has some things that snaps actually need, so allow access to those and deny
-# access to the others. This is duplicated from desktop for compatibility with
-# existing snaps.
-/usr/share/applications/ r,
-/usr/share/applications/mimeapps.list r,
-/usr/share/applications/xdg-open.desktop r,
-# silence noisy denials from desktop files in core* snaps that aren't usable by
-# snaps
-deny /usr/share/applications/python*.desktop r,
-deny /usr/share/applications/vim.desktop r,
-deny /usr/share/applications/snap-handle-link.desktop r,  # core16
 
 ###SNAP_DESKTOP_FILE_RULES###
 # Snaps are unable to use the data in mimeinfo.cache (since they can't execute

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -86,7 +86,8 @@ owner @{HOME}/.local/share/fonts/{,**} r,
 # Snappy's 'xdg-open' talks to the snapd-xdg-open service which currently works
 # only in environments supporting dbus-send (eg, X11). In the future once
 # snappy's xdg-open supports all snaps images, this access may move to another
-# interface.
+# interface. This is duplicated from desktop for compatibility with existing
+# snaps.
 /usr/bin/xdg-open ixr,
 /usr/share/applications/ r,
 /usr/share/applications/mimeapps.list r,
@@ -485,18 +486,35 @@ dbus (receive)
     member=Get*
     peer=(label=unconfined),
 
-# unity messaging menu
-# first, allow finding the desktop file
+# While /usr/share/applications comes from the base runtime of the snap, it
+# has some things that snaps actually need, so allow access to those and deny
+# access to the others. This is duplicated from desktop for compatibility with
+# existing snaps.
 /usr/share/applications/ r,
-# this leaks the names of snaps with desktop files
+/usr/share/applications/mimeapps.list r,
+/usr/share/applications/xdg-open.desktop r,
+# silence noisy denials from desktop files in core* snaps that aren't usable by
+# snaps
+deny /usr/share/applications/python*.desktop r,
+deny /usr/share/applications/vim.desktop r,
+deny /usr/share/applications/snap-handle-link.desktop r,  # core16
+
+# support applications which use the unity messaging menu, xdg-mime, etc
+# This leaks the names of snaps with desktop files
 /var/lib/snapd/desktop/applications/ r,
-# There isn't anything useful in this file that snaps can use, but many
-# applications read it so leave it for compatibility.
-/var/lib/snapd/desktop/applications/mimeinfo.cache r,
-# Support BAMF_DESKTOP_FILE_HINT by allowing reading our desktop files
-# parallel-installs: when @{SNAP_INSTANCE_NAME} == @{SNAP_NAME},
-# this leaks read access to desktop files of parallel installs of the snap
+# allowing reading only our desktop files (required by (at least) the unity
+# messaging menu). Note: a future update may suppress noisy denials when
+# attempting to read other desktop files.
+# parallel-installs: this leaks read access to desktop files owned by keyed
+# instances of @{SNAP_NAME} to @{SNAP_NAME} snap
 /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
+# Snaps are unable to use the data in mimeinfo.cache (since they can't execute
+# the returned desktop file themselves). unity messaging menu doesn't require
+# mimeinfo.cache and xdg-mime will fallback to reading the desktop files
+# directly to look for MimeType. Since reading the snap's own desktop files is
+# allowed, we can safely deny access to this file (and xdg-mime will either
+# return one of the snap's mimetypes, or none).
+deny /var/lib/snapd/desktop/applications/mimeinfo.cache r,
 
 # then allow talking to Unity DBus service
 dbus (send)

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -490,6 +490,8 @@ dbus (receive)
 /usr/share/applications/ r,
 # this leaks the names of snaps with desktop files
 /var/lib/snapd/desktop/applications/ r,
+# There isn't anything useful in this file that snaps can use, but many
+# applications read it so leave it for compatibility.
 /var/lib/snapd/desktop/applications/mimeinfo.cache r,
 # Support BAMF_DESKTOP_FILE_HINT by allowing reading our desktop files
 # parallel-installs: when @{SNAP_INSTANCE_NAME} == @{SNAP_NAME},

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -83,6 +83,15 @@ func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other-snap.app2"})
 	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `/usr/share/pixmaps`)
 	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `path=/com/canonical/indicator/messages/other_snap_*_desktop`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/mimeinfo.cache r,`)
+
+	// getDesktopFileRules() rules
+	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `# This leaks the names of snaps with desktop files`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `/var/lib/snapd/desktop/applications/ r,`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}[^_.]*.desktop r,`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/[^o]* r,`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/other-sna[^p]* r,`)
 
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -147,9 +147,9 @@ func aareExclusivePatterns(orig string) []string {
 
 // getDesktopFileRules(<snap instance name>) generates snippet rules for
 // allowing access to the specified snap's desktop files in
-// dirs.SnapDesktopFilesDir, but explicitly denies access to all other snap's
+// dirs.SnapDesktopFilesDir, but explicitly denies access to all other snaps'
 // desktop files since xdg libraries may try to read all the desktop files
-// in the dir. (LP: #1868051)
+// in the dir, causing excessive noise. (LP: #1868051)
 func getDesktopFileRules(snapInstanceName string) []string {
 	baseDir := dirs.SnapDesktopFilesDir
 

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"sort"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -123,4 +124,50 @@ func verifySlotPathAttribute(slotRef *interfaces.SlotRef, attrs interfaces.Attre
 		return "", fmt.Errorf(invalidErrFmt, slotRef)
 	}
 	return cleanPath, nil
+}
+
+// aareExclusivePatterns takes a string and generates deny alternations. Eg,
+// aareExclusivePatterns("foo") returns:
+// []string{
+//   "[^f]*",
+//   "f[^o]*",
+//   "fo[^o]*",
+// }
+func aareExclusivePatterns(orig string) []string {
+	s := make([]string, len(orig))
+	prefix := ""
+	for i, letter := range orig {
+		if i > 0 {
+			prefix = orig[:i]
+		}
+		s[i] = fmt.Sprintf("%s[^%c]*", prefix, letter)
+	}
+	return s
+}
+
+// getDesktopFileRules(<snap instance name>) generates snippet rules for
+// allowing access to the specified snap's desktop files in
+// dirs.SnapDesktopFilesDir, but explicitly denies access to all other snap's
+// desktop files since xdg libraries may try to read all the desktop files
+// in the dir. (LP: #1868051)
+func getDesktopFileRules(snapInstanceName string) []string {
+	baseDir := dirs.SnapDesktopFilesDir
+
+	rules := []string{
+		"# Support applications which use the unity messaging menu, xdg-mime, etc",
+		"# This leaks the names of snaps with desktop files",
+		fmt.Sprintf("%s/ r,", baseDir),
+		"# Allowing reading only our desktop files (required by (at least) the unity",
+		"# messaging menu).",
+		"# parallel-installs: this leaks read access to desktop files owned by keyed",
+		"# instances of @{SNAP_NAME} to @{SNAP_NAME} snap",
+		fmt.Sprintf("%s/@{SNAP_INSTANCE_NAME}_*.desktop r,", baseDir),
+		"# Explicitly deny access to other snap's desktop files",
+		fmt.Sprintf("deny %s/@{SNAP_INSTANCE_NAME}[^_.]*.desktop r,", baseDir),
+	}
+	for _, t := range aareExclusivePatterns(snapInstanceName) {
+		rules = append(rules, fmt.Sprintf("deny %s/%s r,", baseDir, t))
+	}
+
+	return rules
 }

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -142,6 +142,42 @@ func (s *utilsSuite) TestSlotLabelExpr(c *C) {
 	c.Check(label, Equals, `"snap.test-snap.*"`)
 }
 
+func (s *utilsSuite) TestAareExclusivePatterns(c *C) {
+	res := builtin.AareExclusivePatterns("foo-bar")
+	c.Check(res, DeepEquals, []string{
+		"[^f]*",
+		"f[^o]*",
+		"fo[^o]*",
+		"foo[^-]*",
+		"foo-[^b]*",
+		"foo-b[^a]*",
+		"foo-ba[^r]*",
+	})
+}
+
+func (s *utilsSuite) TestGetDesktopFileRules(c *C) {
+	res := builtin.GetDesktopFileRules("foo-bar")
+	c.Check(res, DeepEquals, []string{
+		"# Support applications which use the unity messaging menu, xdg-mime, etc",
+		"# This leaks the names of snaps with desktop files",
+		"/var/lib/snapd/desktop/applications/ r,",
+		"# Allowing reading only our desktop files (required by (at least) the unity",
+		"# messaging menu).",
+		"# parallel-installs: this leaks read access to desktop files owned by keyed",
+		"# instances of @{SNAP_NAME} to @{SNAP_NAME} snap",
+		"/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,",
+		"# Explicitly deny access to other snap's desktop files",
+		"deny /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}[^_.]*.desktop r,",
+		"deny /var/lib/snapd/desktop/applications/[^f]* r,",
+		"deny /var/lib/snapd/desktop/applications/f[^o]* r,",
+		"deny /var/lib/snapd/desktop/applications/fo[^o]* r,",
+		"deny /var/lib/snapd/desktop/applications/foo[^-]* r,",
+		"deny /var/lib/snapd/desktop/applications/foo-[^b]* r,",
+		"deny /var/lib/snapd/desktop/applications/foo-b[^a]* r,",
+		"deny /var/lib/snapd/desktop/applications/foo-ba[^r]* r,",
+	})
+}
+
 func MockPlug(c *C, yaml string, si *snap.SideInfo, plugName string) *snap.PlugInfo {
 	return builtin.MockPlug(c, yaml, si, plugName)
 }


### PR DESCRIPTION
https://github.com/snapcore/snapd/pull/8301 for 2.45.

I've submitted this so it is available at some future date if needed but am closing it and not milestoning it.