### PR TITLE
sandbox/cgroup: move FreezerCgroupDir from dirs.go

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -110,7 +110,6 @@ var (
 	SystemLocalFontsDir       string
 	SystemFontconfigCacheDirs []string
 
-	FreezerCgroupDir string
 	PidsCgroupDir    string
 
 	SnapshotsDir string
@@ -377,7 +376,6 @@ func SetRootDir(rootdir string) {
 		SystemFontconfigCacheDirs = append(SystemFontconfigCacheDirs, filepath.Join(rootdir, "/usr/lib/fontconfig/cache"))
 	}
 
-	FreezerCgroupDir = filepath.Join(rootdir, "/sys/fs/cgroup/freezer/")
 	PidsCgroupDir = filepath.Join(rootdir, "/sys/fs/cgroup/pids/")
 	SnapshotsDir = filepath.Join(rootdir, snappyDir, "snapshots")
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -110,7 +110,7 @@ var (
 	SystemLocalFontsDir       string
 	SystemFontconfigCacheDirs []string
 
-	PidsCgroupDir    string
+	PidsCgroupDir string
 
 	SnapshotsDir string
 

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -18,10 +18,6 @@
  */
 package cgroup
 
-import (
-	. "gopkg.in/check.v1"
-)
-
 var (
 	Cgroup2SuperMagic  = cgroup2SuperMagic
 	ProbeCgroupVersion = probeCgroupVersion
@@ -41,16 +37,4 @@ func MockFsRootPath(p string) (restore func()) {
 	return func() {
 		rootPath = old
 	}
-}
-
-func MockFreezerCgroupDir(c *C) (restore func()) {
-	old := freezerCgroupDir
-	freezerCgroupDir = c.MkDir()
-	return func() {
-		freezerCgroupDir = old
-	}
-}
-
-func FreezerCgroupDir() string {
-	return freezerCgroupDir
 }

--- a/sandbox/cgroup/freezer_test.go
+++ b/sandbox/cgroup/freezer_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -35,12 +36,12 @@ type freezerSuite struct{}
 var _ = Suite(&freezerSuite{})
 
 func (s *freezerSuite) TestFreezeSnapProcesses(c *C) {
-	restore := cgroup.MockFreezerCgroupDir(c)
-	defer restore()
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
 
-	n := "foo"                                                               // snap name
-	p := filepath.Join(cgroup.FreezerCgroupDir(), fmt.Sprintf("snap.%s", n)) // snap freezer cgroup
-	f := filepath.Join(p, "freezer.state")                                   // freezer.state file of the cgroup
+	n := "foo"                                                             // snap name
+	p := filepath.Join(cgroup.FreezerCgroupDir, fmt.Sprintf("snap.%s", n)) // snap freezer cgroup
+	f := filepath.Join(p, "freezer.state")                                 // freezer.state file of the cgroup
 
 	// When the freezer cgroup filesystem doesn't exist we do nothing at all.
 	c.Assert(cgroup.FreezeSnapProcesses(n), IsNil)
@@ -49,7 +50,7 @@ func (s *freezerSuite) TestFreezeSnapProcesses(c *C) {
 
 	// When the freezer cgroup filesystem exists but the particular cgroup
 	// doesn't exist we don nothing at all.
-	c.Assert(os.MkdirAll(cgroup.FreezerCgroupDir(), 0755), IsNil)
+	c.Assert(os.MkdirAll(cgroup.FreezerCgroupDir, 0755), IsNil)
 	c.Assert(cgroup.FreezeSnapProcesses(n), IsNil)
 	_, err = os.Stat(f)
 	c.Assert(os.IsNotExist(err), Equals, true)
@@ -63,12 +64,12 @@ func (s *freezerSuite) TestFreezeSnapProcesses(c *C) {
 }
 
 func (s *freezerSuite) TestThawSnapProcesses(c *C) {
-	restore := cgroup.MockFreezerCgroupDir(c)
-	defer restore()
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
 
-	n := "foo"                                                               // snap name
-	p := filepath.Join(cgroup.FreezerCgroupDir(), fmt.Sprintf("snap.%s", n)) // snap freezer cgroup
-	f := filepath.Join(p, "freezer.state")                                   // freezer.state file of the cgroup
+	n := "foo"                                                             // snap name
+	p := filepath.Join(cgroup.FreezerCgroupDir, fmt.Sprintf("snap.%s", n)) // snap freezer cgroup
+	f := filepath.Join(p, "freezer.state")                                 // freezer.state file of the cgroup
 
 	// When the freezer cgroup filesystem doesn't exist we do nothing at all.
 	c.Assert(cgroup.ThawSnapProcesses(n), IsNil)
@@ -77,7 +78,7 @@ func (s *freezerSuite) TestThawSnapProcesses(c *C) {
 
 	// When the freezer cgroup filesystem exists but the particular cgroup
 	// doesn't exist we don nothing at all.
-	c.Assert(os.MkdirAll(cgroup.FreezerCgroupDir(), 0755), IsNil)
+	c.Assert(os.MkdirAll(cgroup.FreezerCgroupDir, 0755), IsNil)
 	c.Assert(cgroup.ThawSnapProcesses(n), IsNil)
 	_, err = os.Stat(f)
 	c.Assert(os.IsNotExist(err), Equals, true)


### PR DESCRIPTION
This is something that was brought up in the review of the large
cgroup tracking branch. With the new callback system we can move the
definition close to the only usage location.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
