### PR TITLE
tests: install test-snapd-rsync snap from edge channel

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -946,7 +946,7 @@ prepare_ubuntu_core() {
         elif is_core20_system; then
             rsync_snap="test-snapd-rsync-core20"
         fi
-        snap install --devmode "$rsync_snap"
+        snap install --devmode --edge "$rsync_snap"
         snap alias "$rsync_snap".rsync rsync
     fi
 


### PR DESCRIPTION
This is because the idea of the test snaps is to use edge channel

Also it is needed for uc20 validation