### PR TITLE
interfaces/docker: use implicitOnClassic: true

### DIFF
--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -51,5 +51,6 @@ func init() {
 		baseDeclarationSlots:  dockerBaseDeclarationSlots,
 		connectedPlugAppArmor: dockerConnectedPlugAppArmor,
 		connectedPlugSecComp:  dockerConnectedPlugSecComp,
+		implicitOnClassic:     true,
 	})
 }


### PR DESCRIPTION
The docker interface currently can only be used with app snaps. This
works fine when the docker snap is installed, but doesn't work when a
snap plugs docker and tries to use docker from another package format.

Add implicitOnClassic: true to the setup. This is a breaking change for
the docker snap itself since to provides the docker slot and now so will
the system, thus causing an ambiguity for snapd which causes the
docker-cli plug to not auto-connect. With this change, the docker snap
needs to be updated to have (or similar):
```
  plugs:
    docker:
      allow-auto-connection:
        slot-snap-id:
          - <snap id of the docker snap>
```
The store will have to be queried to for any other snaps that have
auto-connections and their snap declarations will need to be updated to
use greedy plugs (or similar):
```
  plugs:
    docker:
      allow-auto-connection:
        slot-snap-type:
          - app
          - core
        slots-per-plug: *
```
(slot-snap-type is needed due to LP: #1873282). In this manner, snaps
will be able to auto-connect regardless of if the docker snap is
installed or not.

References:
https://forum.snapcraft.io/t/request-for-classic-confinement-for-package-wilfred/14912/49
