### PR TITLE
snap/prepare_image: Add support for append/remove

### DIFF
--- a/tests/main/classic-prepare-image-append-remove/task.yaml
+++ b/tests/main/classic-prepare-image-append-remove/task.yaml
@@ -1,0 +1,107 @@
+summary: Check that prepare-image --classic --append|--remove works.
+
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
+
+backends: [-autopkgtest]
+
+environment:
+    ROOT: /tmp/root
+    STORE_DIR: $(pwd)/fake-store-blobdir
+    STORE_ADDR: localhost:11028
+    SEED_DIR: /var/lib/snapd/seed
+
+kill-timeout: 5m
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    setup_fake_store "$STORE_DIR"
+
+    snap pack "$TESTSLIB/snaps/basic"
+    snap pack "$TESTSLIB/snaps/classic-gadget"
+    snap pack "$TESTSLIB/snaps/basic-run"
+    snap pack "$TESTSLIB/snaps/test-snapd-sh"
+
+    echo Expose the needed assertions through the fakestore
+    cp "$TESTSLIB"/assertions/developer1.account "$STORE_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account-key "$STORE_DIR/asserts"
+    # have snap use the fakestore for assertions (but nothing else)
+    export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
+
+    echo Running prepare-image
+    #shellcheck disable=SC2086
+    ARCH="$(dpkg-architecture -qDEB_HOST_ARCH)"
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --channel $CORE_CHANNEL --snap basic_*.snap  --snap classic-gadget_*.snap --snap test-snapd-sh_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT"
+
+    # Remove unwanted snap
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --remove --snap test-snapd-sh $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT"
+
+    # Append a new snap
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --append --snap basic-run_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT"
+    
+    "$TESTSLIB/reset.sh" --keep-stopped
+    cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"
+
+    # start fake device svc
+    systemd_create_and_start_unit fakedevicesvc "$(command -v fakedevicesvc) localhost:11029"
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/systemd.sh
+    . "$TESTSLIB/systemd.sh"
+    systemctl stop snapd.service snapd.socket
+    systemd_stop_and_destroy_unit fakedevicesvc
+
+    rm -rf "$SEED_DIR"
+    systemctl start snapd.socket snapd.service
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    teardown_fake_store "$STORE_DIR"
+    rm -f -- *.snap
+    rm -rf "$ROOT"
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # kick seeding
+    systemctl start snapd.service snapd.socket
+
+    echo "Wait for seeding to be done"
+    snap wait system seed.loaded
+
+    echo "We have a model assertion"
+    snap model --verbose|MATCH "model:\s* my-classic-w-gadget"
+
+    echo "Wait for device initialisation to be done"
+    while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
+
+    echo "Check we have a serial"
+    snap model --serial --assertion|MATCH "authority-id: developer1"
+    snap model --serial --assertion|MATCH "brand-id: developer1"
+    snap model --serial --assertion|MATCH "model: my-classic-w-gadget"
+    snap model --serial --assertion|MATCH "serial: 7777"
+
+    snap list | MATCH "^basic "
+    test -f "$SEED_DIR/snaps/basic_"*.snap
+    snap list | MATCH "^classic-gadget"
+    test -f "$SEED_DIR/snaps/classic-gadget_"*.snap
+    snap list | MATCH "^basic-run "
+    test -f "$SEED_DIR/snaps/basic-run_"*.snap
+    if snap list test-snapd-sh >/dev/null 2>&1 ; then
+        echo "removed test-snapd-sh remained on the image, this is unexpected"
+        exit 1
+    fi
+    test -f "$SEED_DIR/snaps/basic-run_"*.snap


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

This might be of interest to @rcj4747

When seeding classic images in livecd-rootfs we often need to tweak the seed by removing snaps or appending new snaps.

Currently we do it by hand and parsing yaml in shell scripts, but ideally it should be possible to do this with just prepare-image.

This branch attempts to add "--append/--remove" operations to prepare-image, which append or remove snaps from already populated seed.yaml.

Adding this now as a draft to see if my spread test works, as I don't know how to run it locally.

There is still work to do around switching models and actually saving disk-space when removing snaps.