### PR TITLE
interfaces: miscellanious policy updates xlv

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -275,7 +275,7 @@ var templateCommon = `
   /run/uuidd/request rw,
   /sys/devices/virtual/tty/{console,tty*}/active r,
   /sys/fs/cgroup/memory/memory.limit_in_bytes r,
-  /sys/fs/cgroup/memory/snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.limit_in_bytes r,
+  /sys/fs/cgroup/memory/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.limit_in_bytes r,
   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
   /sys/module/apparmor/parameters/enabled r,
   /{,usr/}lib/ r,

--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -42,7 +42,9 @@ const accountControlConnectedPlugAppArmor = `
 /{,usr/}sbin/chpasswd ixr,
 /{,usr/}sbin/user{add,del} ixr,
 
-# Only allow modifying the non-system extrausers database
+# Allow modifying the non-system extrausers NSS database. The extrausers
+# database is used on Ubuntu Core devices to manage both privileged and
+# unprivileged users (since /etc/passwd, /etc/group, etc are all read-only).
 /var/lib/extrausers/ r,
 /var/lib/extrausers/** rwkl,
 

--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -56,8 +56,9 @@ const audioPlaybackConnectedPlugAppArmor = `
 
 owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,
-owner /run/user/[0-9]*/ r,
-owner /run/user/[0-9]*/pulse/ rw,
+owner /{,var/}run/pulse/pid r,
+owner /{,var/}run/user/[0-9]*/ r,
+owner /{,var/}run/user/[0-9]*/pulse/ rw,
 
 /run/udev/data/c116:[0-9]* r,
 /run/udev/data/+sound:card[0-9]* r,
@@ -74,6 +75,7 @@ owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
 owner /{,var/}run/user/*/pulse/ rwk,
 owner /{,var/}run/user/*/pulse/native rwk,
+owner /{,var/}run/user/*/pulse/pid r,
 `
 
 const audioPlaybackConnectedPlugSecComp = `

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -231,6 +231,12 @@ dbus (receive, send)
 # These accesses are noisy and applications can't do anything with the found
 # icon files, so explicitly deny to silence the denials
 deny /var/lib/snapd/desktop/icons/{,**/} r,
+
+# These accesses occur when flatpaks are on the system since it updates
+# XDG_DATA_DIRS to contain $HOME/.local/share/flatpak/exports/share. Until
+# we have better XDG_DATA_DIRS handling, silence these noisy denials.
+# https://github.com/snapcrafters/discord/issues/23#issuecomment-637607843
+deny @{HOME}/.local/share/flatpak/exports/share/** r,
 `
 
 type desktopInterface struct {

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -228,6 +228,22 @@ dbus (receive, send)
     path=/org/freedesktop/portal/{desktop,documents}{,/**}
     peer=(label=unconfined),
 
+# The portals service is normally running and newer versions of
+# xdg-desktop-portal include AssumedAppArmor=unconfined. Since older
+# systems don't have this and because gtkfilechoosernativeportal.c relies on
+# service activation, allow sends to peer=(name=org.freedesktop.portal.Desktop)
+# for service activation.
+dbus (send)
+    bus=session
+    interface=org.freedesktop.portal.*
+    path=/org/freedesktop/portal/{desktop,documents}{,/**}
+    peer=(name=org.freedesktop.portal.Desktop),
+dbus (send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/freedesktop/portal/{desktop,documents}{,/**}
+    peer=(name=org.freedesktop.portal.Desktop),
+
 # These accesses are noisy and applications can't do anything with the found
 # icon files, so explicitly deny to silence the denials
 deny /var/lib/snapd/desktop/icons/{,**/} r,

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -160,7 +160,8 @@ func (s *FwupdInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(dbusSpec.SecurityTags(), HasLen, 1)
 
-	// On an all-snaps system, the only UpdateNS rule is applied
+	// UpdateNS rules are only applied if the permanent slot is provided by
+	// an app snap
 	updateNS := apparmorSpec.UpdateNS()
 	c.Check(updateNS, testutil.Contains, "  # Read-write access to /boot\n")
 
@@ -190,8 +191,8 @@ func (s *FwupdInterfaceSuite) TestMountPermanentSlot(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/boot"), 0777), IsNil)
 
-	// On all-snaps systems, boot partition should be
-	// bind mounted from the host system if they exist.
+	// If the permanent slot is provided by an app snap, the boot partition
+	// should be bind mounted from the host system if they exist.
 	mountSpec := &mount.Specification{}
 	c.Assert(mountSpec.AddPermanentSlot(s.iface, s.appSlotInfo), IsNil)
 

--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -31,7 +31,9 @@ const gsettingsBaseDeclarationSlots = `
 const gsettingsConnectedPlugAppArmor = `
 # Description: Can access global gsettings of the user's session. Restricted
 # because this gives privileged access to sensitive information stored in
-# gsettings and allows adjusting settings of other applications.
+# gsettings and allows adjusting settings of other applications. Future GLib
+# will not require plugging the interface and will instead probe if running
+# under confinement and use a private data store in $SNAP_USER_DATA).
 
 #include <abstractions/dbus-session-strict>
 

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -42,7 +42,8 @@ capability sys_module,
 @{PROC}/modules r,
 /{,usr/}bin/kmod ixr,
 
-# FIXME: moved to physical-memory-observe (remove this in series 20)
+# FIXME: moved to physical-memory-observe (will be removed when using different
+# policies for different bases)
 /dev/mem r,
 
 # Required to use SYSLOG_ACTION_READ_ALL and SYSLOG_ACTION_SIZE_BUFFER when

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -33,7 +33,8 @@ const networkConnectedPlugAppArmor = `
 # Description: Can access the network as a client.
 #include <abstractions/nameservice>
 /run/systemd/resolve/stub-resolv.conf rk,
-/etc/mdns.allow r,  # not yet include in mdns abstraction
+/etc/mdns.allow r,     # not yet included in the mdns abstraction
+network netlink dgram, # not yet included in the nameservice abstraction
 
 # systemd-resolved (not yet included in nameservice abstraction)
 #

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -33,6 +33,7 @@ const networkBindConnectedPlugAppArmor = `
 # Description: Can access the network as a server.
 #include <abstractions/nameservice>
 /run/systemd/resolve/stub-resolv.conf rk,
+network netlink dgram, # not yet included in the nameservice abstraction
 
 # systemd-resolved (not yet included in nameservice abstraction)
 #

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -48,8 +48,9 @@ const pulseaudioConnectedPlugAppArmor = `
 
 owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,
-owner /run/user/[0-9]*/ r,
-owner /run/user/[0-9]*/pulse/ rw,
+owner /{,var/}run/pulse/pid r,
+owner /{,var/}run/user/[0-9]*/ r,
+owner /{,var/}run/user/[0-9]*/pulse/ rw,
 
 /run/udev/data/c116:[0-9]* r,
 /run/udev/data/+sound:card[0-9]* r,
@@ -65,6 +66,7 @@ owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
 owner /{,var/}run/user/*/pulse/ rwk,
 owner /{,var/}run/user/*/pulse/native rwk,
+owner /{,var/}run/user/*/pulse/pid r,
 `
 
 const pulseaudioConnectedPlugSecComp = `

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -380,6 +380,13 @@ dbus (receive)
     member=Introspect
     peer=(label=unconfined),
 
+dbus (receive)
+    bus=session
+    path=/com/canonical/dbusmenu
+    interface=org.freedesktop.DBus.Properties
+    member=Get*
+    peer=(label=unconfined),
+
 # app-indicators
 dbus (send)
     bus=session

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -82,11 +82,11 @@ func plugAppLabelExpr(plug *interfaces.ConnectedPlug) string {
 	return labelExpr(plug.Apps(), plug.Hooks(), plug.Snap())
 }
 
-// determine if permanent slot side is provided by the system
-// on classic system some implicit slots can be provided by system or by
-// application snap e.g. avahi (it can be installed as deb or snap)
-// - slot owned by the system (core,snapd snap)  usually requires no action
-// - slot owned by application snap typically requires rules update
+// Determine if the permanent slot side is provided by the system. On classic
+// systems some implicit slots can be provided by the system or by an
+// application snap (eg avahi can be installed as deb or snap).
+// - slot owned by the system (core/snapd snap) usually requires no action
+// - slot owned by an application snap typically requires rules updates
 func implicitSystemPermanentSlot(slot *snap.SlotInfo) bool {
 	if release.OnClassic &&
 		(slot.Snap.GetType() == snap.TypeOS || slot.Snap.GetType() == snap.TypeSnapd) {
@@ -95,8 +95,9 @@ func implicitSystemPermanentSlot(slot *snap.SlotInfo) bool {
 	return false
 }
 
-// determine if connected slot side is provided by the system
-// as for isPermanentSlotSystemSlot() slot can be owned by app or system
+// Determine if the connected slot side is provided by the system. As for
+// isPermanentSlotSystemSlot(), the slot can be owned by the system or an
+// application.
 func implicitSystemConnectedSlot(slot *interfaces.ConnectedSlot) bool {
 	if release.OnClassic &&
 		(slot.Snap().GetType() == snap.TypeOS || slot.Snap().GetType() == snap.TypeSnapd) {

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -56,6 +56,53 @@ const launcherIntrospectionXML = `
 	</method>
 </interface>`
 
+// allowedURLSchemes are those that can be passed to xdg-open so that it may
+// launch the handler for the url scheme on behalf of the snap (and therefore
+// outside of the calling snap's confinement). Historically we've been
+// conservative about adding url schemes but the thinking was refined in
+// https://github.com/snapcore/snapd/pull/7731#pullrequestreview-362900171
+//
+// The current criteria for adding url schemes is:
+// * understanding and documenting the scheme in this file
+// * the scheme itself does not cause xdg-open to open files (eg, file:// or
+//   matching '^[[:alpha:]+\.\-]+:' (from xdg-open source))
+// * verifying that the recipient of the url (ie, what xdg-open calls) won't
+//   process file paths/etc that can be leveraged to break out of the sandbox
+//   (but understanding how the url can drive the recipient application is
+//   important)
+//
+// This code uses golang's net/url.Parse() which will help ensure the url is
+// ok before passing to xdg-open. xdg-open itself properly quotes the url so
+// shell metacharacters are blocked.
+//
+// apt: the scheme allows specifying a package for xdg-open to pass to an
+//   apt-handling application, like gnome-software, apturl, etc which are all
+//   protected by policykit
+//   - scheme: apt:<name of package>
+//   - https://github.com/snapcore/snapd/pull/7731
+//
+// help: the scheme allows for specifying a help URL. This code ensures that
+//   the url is parseable
+//   - scheme: help://topic
+//   - https://github.com/snapcore/snapd/pull/6493
+//
+// http/https: the scheme allows specifying a web URL. This code ensures that
+//   the url is parseable
+//   - scheme: http(s)://example.com
+//
+// mailto: the scheme allows for specifying an email address
+//   - scheme: mailto:foo@example.com
+//
+// snap: the scheme allows specifying a package for xdg-open to pass to a
+//   snap-handling installer application, like snap-store, etc which are
+//   protected by policykit/snap login
+//   - https://github.com/snapcore/snapd/pull/5181
+//
+// zoommtg: the scheme is a modified web url scheme
+//   - scheme: https://medium.com/zoom-developer-blog/zoom-url-schemes-748b95fd9205
+//     (eg, zoommtg://zoom.us/...)
+//   - https://github.com/snapcore/snapd/pull/8304
+
 var (
 	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg"}
 )


### PR DESCRIPTION
* interfaces/desktop: deny access to flatpak's standard XDG_DATA_DIRS export
* interfaces/{audio-playback,pulseaudio}: allow read to pulseaudio pid file
* usersession/userd: document allowedURLSchemes
* interfaces/account-control: clarify the extrausers database
* apparmor: allow reading `memory/**/<snap>/memory.limit_in_bytes`
* interfaces/kernel-modules-observe: clarify FIXME
* interfaces/gsettings: document future GLib
* interfaces/unity7: allow Get* from unconfined on org.freedesktop.DBus.Properties
* interfaces/desktop: handle unstarted xdg-desktop-portal on older releases
* interfaces/network{,-bind}: allow 'network netlink dgram'
* interfaces/utils.go: comment cleanup
* fwupd_test.go: clarify comments