### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: also copy systemd clock + netplan files

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -147,6 +147,26 @@ func generateMountsModeInstall(mst *initramfsMountsState, recoverySystem string)
 	return nil
 }
 
+// copyNetworkConfig copies the network configuration to the target
+// directory. This is used to copy the network configuration
+// data from a real uc20 ubuntu-data partition into a ephemeral one.
+func copyNetworkConfig(src, dst string) error {
+	for _, globEx := range []string{
+		// for network configuration setup by console-conf, etc.
+		// TODO:UC20: we want some way to "try" or "verify" the network
+		//            configuration before installing it onto recover mode,
+		//            because the network configuration could have been what was
+		//            broken so we don't want to break network configuration for
+		//            recover mode as well, but for now this is fine
+		"system-data/etc/netplan/*",
+	} {
+		if err := copyFromGlobHelper(src, dst, globEx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // copyUbuntuDataAuth copies the authenication files like
 //  - extrausers passwd,shadow etc
 //  - sshd host configuration
@@ -166,13 +186,6 @@ func copyUbuntuDataAuth(src, dst string) error {
 		// so that users have proper perms, i.e. console-conf added users are
 		// sudoers
 		"system-data/etc/sudoers.d/*",
-		// for network configuration setup by console-conf, etc.
-		// TODO:UC20: we want some way to "try" or "verify" the network
-		//            configuration before installing it onto recover mode,
-		//            because the network configuration could have been what was
-		//            broken so we don't want to break network configuration for
-		//            recover mode as well, but for now this is fine
-		"system-data/etc/netplan/*",
 		// so that the time in recover mode moves forward to what it was in run
 		// mode
 		// NOTE: we don't sync back the time movement from recover mode to run
@@ -181,35 +194,8 @@ func copyUbuntuDataAuth(src, dst string) error {
 		// problem to "lose" the time spent in recover mode
 		"system-data/var/lib/systemd/timesync/clock",
 	} {
-		matches, err := filepath.Glob(filepath.Join(src, globEx))
-		if err != nil {
+		if err := copyFromGlobHelper(src, dst, globEx); err != nil {
 			return err
-		}
-		for _, p := range matches {
-			comps := strings.Split(strings.TrimPrefix(p, src), "/")
-			for i := range comps {
-				part := filepath.Join(comps[0 : i+1]...)
-				fi, err := os.Stat(filepath.Join(src, part))
-				if err != nil {
-					return err
-				}
-				if fi.IsDir() {
-					if err := os.Mkdir(filepath.Join(dst, part), fi.Mode()); err != nil && !os.IsExist(err) {
-						return err
-					}
-					st, ok := fi.Sys().(*syscall.Stat_t)
-					if !ok {
-						return fmt.Errorf("cannot get stat data: %v", err)
-					}
-					if err := os.Chown(filepath.Join(dst, part), int(st.Uid), int(st.Gid)); err != nil {
-						return err
-					}
-				} else {
-					if err := osutil.CopyFile(p, filepath.Join(dst, part), osutil.CopyFlagPreserveAll); err != nil {
-						return err
-					}
-				}
-			}
 		}
 	}
 
@@ -219,6 +205,41 @@ func copyUbuntuDataAuth(src, dst string) error {
 	err := state.CopyState(srcState, dstState, []string{"auth.users", "auth.macaroon-key", "auth.last-id"})
 	if err != nil && err != state.ErrNoState {
 		return fmt.Errorf("cannot copy user state: %v", err)
+	}
+
+	return nil
+}
+
+func copyFromGlobHelper(src, dst, globEx string) error {
+	matches, err := filepath.Glob(filepath.Join(src, globEx))
+	if err != nil {
+		return err
+	}
+	for _, p := range matches {
+		comps := strings.Split(strings.TrimPrefix(p, src), "/")
+		for i := range comps {
+			part := filepath.Join(comps[0 : i+1]...)
+			fi, err := os.Stat(filepath.Join(src, part))
+			if err != nil {
+				return err
+			}
+			if fi.IsDir() {
+				if err := os.Mkdir(filepath.Join(dst, part), fi.Mode()); err != nil && !os.IsExist(err) {
+					return err
+				}
+				st, ok := fi.Sys().(*syscall.Stat_t)
+				if !ok {
+					return fmt.Errorf("cannot get stat data: %v", err)
+				}
+				if err := os.Chown(filepath.Join(dst, part), int(st.Uid), int(st.Gid)); err != nil {
+					return err
+				}
+			} else {
+				if err := osutil.CopyFile(p, filepath.Join(dst, part), osutil.CopyFlagPreserveAll); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	return nil
@@ -250,12 +271,17 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 		return nil
 	}
 
-	// 4. final step: copy the auth data from the real ubuntu-data dir to the
-	//    ephemeral ubuntu-data dir, write the modeenv to the tmpfs data, and
-	//    disable cloud-init in recover mode
+	// 4. final step: copy the auth data and network config from
+	//    the real ubuntu-data dir to the ephemeral ubuntu-data
+	//    dir, write the modeenv to the tmpfs data, and disable
+	//    cloud-init in recover mode
 	if err := copyUbuntuDataAuth(boot.InitramfsHostUbuntuDataDir, boot.InitramfsDataDir); err != nil {
 		return err
 	}
+	if err := copyNetworkConfig(boot.InitramfsHostUbuntuDataDir, boot.InitramfsDataDir); err != nil {
+		return err
+	}
+
 	modeEnv := &boot.Modeenv{
 		Mode:           "recover",
 		RecoverySystem: recoverySystem,

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -166,6 +166,20 @@ func copyUbuntuDataAuth(src, dst string) error {
 		// so that users have proper perms, i.e. console-conf added users are
 		// sudoers
 		"system-data/etc/sudoers.d/*",
+		// for network configuration setup by console-conf, etc.
+		// TODO:UC20: we want some way to "try" or "verify" the network
+		//            configuration before installing it onto recover mode,
+		//            because the network configuration could have been what was
+		//            broken so we don't want to break network configuration for
+		//            recover mode as well, but for now this is fine
+		"system-data/etc/netplan/*",
+		// so that the time in recover mode moves forward to what it was in run
+		// mode
+		// NOTE: we don't sync back the time movement from recover mode to run
+		// mode currently, unclear how/when we could do this, but recover mode
+		// isn't meant to be long lasting and as such it's probably not a big
+		// problem to "lose" the time spent in recover mode
+		"system-data/var/lib/systemd/timesync/clock",
 	} {
 		matches, err := filepath.Glob(filepath.Join(src, globEx))
 		if err != nil {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -154,10 +154,12 @@ func copyNetworkConfig(src, dst string) error {
 	for _, globEx := range []string{
 		// for network configuration setup by console-conf, etc.
 		// TODO:UC20: we want some way to "try" or "verify" the network
-		//            configuration before installing it onto recover mode,
-		//            because the network configuration could have been what was
-		//            broken so we don't want to break network configuration for
-		//            recover mode as well, but for now this is fine
+		//            configuration or to only use known-to-be-good network
+		//            configuration i.e. from ubuntu-save before installing it
+		//            onto recover mode, because the network configuration could
+		//            have been what was broken so we don't want to break
+		//            network configuration for recover mode as well, but for
+		//            now this is fine
 		"system-data/etc/netplan/*",
 	} {
 		if err := copyFromGlobHelper(src, dst, globEx); err != nil {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1273,7 +1273,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 	hostUbuntuData := filepath.Join(boot.InitramfsRunMntDir, "host/ubuntu-data/")
 	err = os.MkdirAll(hostUbuntuData, 0755)
 	c.Assert(err, IsNil)
-	mockAuthFiles := []string{
+	mockCopiedFiles := []string{
 		// extrausers
 		"system-data/var/lib/extrausers/passwd",
 		"system-data/var/lib/extrausers/shadow",
@@ -1289,6 +1289,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 		"user-data/user1/.snap/auth.json",
 		// sudoers
 		"system-data/etc/sudoers.d/create-user-test",
+		// netplan networking
+		"system-data/etc/netplan/00-snapd-config.yaml", // example console-conf filename
+		"system-data/etc/netplan/50-cloud-init.yaml",   // example cloud-init filename
+		// systemd clock file
+		"system-data/var/lib/systemd/timesync/clock",
 	}
 	mockUnrelatedFiles := []string{
 		"system-data/var/lib/foo",
@@ -1296,12 +1301,14 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 		"user-data/user1/some-random-data",
 		"user-data/user2/other-random-data",
 		"user-data/user2/.snap/sneaky-not-auth.json",
+		"system-data/etc/not-networking/netplan",
+		"system-data/var/lib/systemd/timesync/clock-not-the-clock",
 	}
-	for _, mockAuthFile := range append(mockAuthFiles, mockUnrelatedFiles...) {
-		p := filepath.Join(hostUbuntuData, mockAuthFile)
+	for _, mockFile := range append(mockCopiedFiles, mockUnrelatedFiles...) {
+		p := filepath.Join(hostUbuntuData, mockFile)
 		err = os.MkdirAll(filepath.Dir(p), 0750)
 		c.Assert(err, IsNil)
-		mockContent := fmt.Sprintf("content of %s", filepath.Base(mockAuthFile))
+		mockContent := fmt.Sprintf("content of %s", filepath.Base(mockFile))
 		err = ioutil.WriteFile(p, []byte(mockContent), 0640)
 		c.Assert(err, IsNil)
 	}
@@ -1324,7 +1331,7 @@ recovery_system=20191118
 	for _, p := range mockUnrelatedFiles {
 		c.Check(filepath.Join(ephemeralUbuntuData, p), testutil.FileAbsent)
 	}
-	for _, p := range mockAuthFiles {
+	for _, p := range mockCopiedFiles {
 		c.Check(filepath.Join(ephemeralUbuntuData, p), testutil.FilePresent)
 		fi, err := os.Stat(filepath.Join(ephemeralUbuntuData, p))
 		// check file mode is set


### PR DESCRIPTION
The netplan files are needed if a user configured their device to only use WiFi for example.

The systemd clock file is as described in https://bugs.launchpad.net/snapd/+bug/1878422.

This will need to propagate through ubuntu-core-initramfs and then the kernel snap before it ends up usable for any devices. Furthermore, since recover mode will use the kernel snap from the recovery system, this fix will only apply for devices with a recovery system that was built with a kernel snap that contains this fix in the initramfs.