### PR TITLE
snap/naming: add helpers to parse app and hook security tags

### DIFF
--- a/snap/naming/tag.go
+++ b/snap/naming/tag.go
@@ -27,7 +27,7 @@ import (
 
 var errInvalidSecurityTag = errors.New("invalid security tag")
 
-// SecurityTag describes a parsed snap security tag.
+// SecurityTag exposes details of a validated snap security tag.
 type SecurityTag interface {
 	// String returns the entire security tag.
 	String() string
@@ -36,7 +36,7 @@ type SecurityTag interface {
 	InstanceName() string
 }
 
-// AppSecurityTag describes a parsed snap application security tag.
+// AppSecurityTag exposes details of a validated snap application security tag.
 type AppSecurityTag interface {
 	SecurityTag
 	// AppName returns the name of the application.
@@ -60,7 +60,7 @@ func (t appSecurityTag) AppName() string {
 	return t.appName
 }
 
-// HookSecurityTag describes a parsed snap hook security tag.
+// HookSecurityTag exposes details of a validated snap hook security tag.
 type HookSecurityTag interface {
 	SecurityTag
 	// HookName returns the name of the hook.

--- a/snap/naming/tag.go
+++ b/snap/naming/tag.go
@@ -123,3 +123,15 @@ func ParseSecurityTag(tag string) (ParsedSecurityTag, error) {
 		return &hookSecurityTag{instanceName: snapName, hookName: hookName}, nil
 	}
 }
+
+// ParseAppSecurityTag parses an app security tag.
+func ParseAppSecurityTag(tag string) (AppSecurityTag, error) {
+	parsedTag, err := ParseSecurityTag(tag)
+	if err != nil {
+		return nil, err
+	}
+	if parsedAppTag, ok := parsedTag.(AppSecurityTag); ok {
+		return parsedAppTag, nil
+	}
+	return nil, fmt.Errorf("%q is not an app security tag", tag)
+}

--- a/snap/naming/tag.go
+++ b/snap/naming/tag.go
@@ -36,8 +36,8 @@ type ParsedSecurityTag interface {
 	InstanceName() string
 }
 
-// ParsedAppSecurityTag describes a parsed snap application security tag.
-type ParsedAppSecurityTag interface {
+// AppSecurityTag describes a parsed snap application security tag.
+type AppSecurityTag interface {
 	ParsedSecurityTag
 	// AppName returns the name of the application.
 	AppName() string
@@ -60,8 +60,8 @@ func (t appSecurityTag) AppName() string {
 	return t.appName
 }
 
-// ParsedAppSecurityTag describes a parsed snap hook security tag.
-type ParsedHookSecurityTag interface {
+// HookSecurityTag describes a parsed snap hook security tag.
+type HookSecurityTag interface {
 	ParsedSecurityTag
 	// HookName returns the name of the hook.
 	HookName() string

--- a/snap/naming/tag.go
+++ b/snap/naming/tag.go
@@ -27,8 +27,8 @@ import (
 
 var errInvalidSecurityTag = errors.New("invalid security tag")
 
-// ParsedSecurityTag describes a parsed snap security tag.
-type ParsedSecurityTag interface {
+// SecurityTag describes a parsed snap security tag.
+type SecurityTag interface {
 	// String returns the entire security tag.
 	String() string
 
@@ -38,7 +38,7 @@ type ParsedSecurityTag interface {
 
 // AppSecurityTag describes a parsed snap application security tag.
 type AppSecurityTag interface {
-	ParsedSecurityTag
+	SecurityTag
 	// AppName returns the name of the application.
 	AppName() string
 }
@@ -62,7 +62,7 @@ func (t appSecurityTag) AppName() string {
 
 // HookSecurityTag describes a parsed snap hook security tag.
 type HookSecurityTag interface {
-	ParsedSecurityTag
+	SecurityTag
 	// HookName returns the name of the hook.
 	HookName() string
 }
@@ -88,7 +88,7 @@ func (t hookSecurityTag) HookName() string {
 //
 // Further type assertions can be used to described the particular form, either
 // describing an application or a hook specific security tag.
-func ParseSecurityTag(tag string) (ParsedSecurityTag, error) {
+func ParseSecurityTag(tag string) (SecurityTag, error) {
 	// We expect at most four parts. Split with up to five parts so that the
 	// len(parts) test catches invalid format tags very early.
 	parts := strings.SplitN(tag, ".", 5)

--- a/snap/naming/tag.go
+++ b/snap/naming/tag.go
@@ -135,3 +135,15 @@ func ParseAppSecurityTag(tag string) (AppSecurityTag, error) {
 	}
 	return nil, fmt.Errorf("%q is not an app security tag", tag)
 }
+
+// ParseHookSecurityTag parses a hook security tag.
+func ParseHookSecurityTag(tag string) (HookSecurityTag, error) {
+	parsedTag, err := ParseSecurityTag(tag)
+	if err != nil {
+		return nil, err
+	}
+	if parsedHookTag, ok := parsedTag.(HookSecurityTag); ok {
+		return parsedHookTag, nil
+	}
+	return nil, fmt.Errorf("%q is not a hook security tag", tag)
+}

--- a/snap/naming/tag_test.go
+++ b/snap/naming/tag_test.go
@@ -35,25 +35,25 @@ func (s *tagSuite) TestParseSecurityTag(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(tag.String(), Equals, "snap.pkg.app")
 	c.Check(tag.InstanceName(), Equals, "pkg")
-	c.Check(tag.(naming.ParsedAppSecurityTag).AppName(), Equals, "app")
+	c.Check(tag.(naming.AppSecurityTag).AppName(), Equals, "app")
 
 	tag, err = naming.ParseSecurityTag("snap.pkg_key.app")
 	c.Assert(err, IsNil)
 	c.Check(tag.String(), Equals, "snap.pkg_key.app")
 	c.Check(tag.InstanceName(), Equals, "pkg_key")
-	c.Check(tag.(naming.ParsedAppSecurityTag).AppName(), Equals, "app")
+	c.Check(tag.(naming.AppSecurityTag).AppName(), Equals, "app")
 
 	tag, err = naming.ParseSecurityTag("snap.pkg.hook.configure")
 	c.Assert(err, IsNil)
 	c.Check(tag.String(), Equals, "snap.pkg.hook.configure")
 	c.Check(tag.InstanceName(), Equals, "pkg")
-	c.Check(tag.(naming.ParsedHookSecurityTag).HookName(), Equals, "configure")
+	c.Check(tag.(naming.HookSecurityTag).HookName(), Equals, "configure")
 
 	tag, err = naming.ParseSecurityTag("snap.pkg_key.hook.configure")
 	c.Assert(err, IsNil)
 	c.Check(tag.String(), Equals, "snap.pkg_key.hook.configure")
 	c.Check(tag.InstanceName(), Equals, "pkg_key")
-	c.Check(tag.(naming.ParsedHookSecurityTag).HookName(), Equals, "configure")
+	c.Check(tag.(naming.HookSecurityTag).HookName(), Equals, "configure")
 
 	// invalid format is rejected
 	_, err = naming.ParseSecurityTag("snap.pkg.app.surprise")
@@ -74,7 +74,7 @@ func (s *tagSuite) TestParseSecurityTag(c *C) {
 	c.Check(err, ErrorMatches, "invalid security tag")
 	tag, err = naming.ParseSecurityTag("snap.pkg.hook")
 	c.Assert(err, IsNil) // Perhaps somewhat unexpectedly, this tag is valid.
-	c.Check(tag.(naming.ParsedAppSecurityTag).AppName(), Equals, "hook")
+	c.Check(tag.(naming.AppSecurityTag).AppName(), Equals, "hook")
 	_, err = naming.ParseSecurityTag("snap.pkg.app.surprise")
 	c.Check(err, ErrorMatches, "invalid security tag")
 	_, err = naming.ParseSecurityTag("snap.pkg.")

--- a/snap/naming/tag_test.go
+++ b/snap/naming/tag_test.go
@@ -90,3 +90,22 @@ func (s *tagSuite) TestParseSecurityTag(c *C) {
 	_, err = naming.ParseSecurityTag("foo.bar.froz")
 	c.Check(err, ErrorMatches, "invalid security tag")
 }
+
+func (s *tagSuite) TestParseAppSecurityTag(c *C) {
+	// Invalid security tags cannot be parsed.
+	tag, err := naming.ParseAppSecurityTag("potato")
+	c.Assert(err, ErrorMatches, "invalid security tag")
+	c.Assert(tag, IsNil)
+
+	// App security tags can be parsed.
+	tag, err = naming.ParseAppSecurityTag("snap.pkg.app")
+	c.Assert(err, IsNil)
+	c.Check(tag.String(), Equals, "snap.pkg.app")
+	c.Check(tag.InstanceName(), Equals, "pkg")
+	c.Check(tag.AppName(), Equals, "app")
+
+	// Hook security tags are not app security tags.
+	tag, err = naming.ParseAppSecurityTag("snap.pkg.hook.configure")
+	c.Assert(err, ErrorMatches, `"snap.pkg.hook.configure" is not an app security tag`)
+	c.Assert(tag, IsNil)
+}

--- a/snap/naming/tag_test.go
+++ b/snap/naming/tag_test.go
@@ -109,3 +109,22 @@ func (s *tagSuite) TestParseAppSecurityTag(c *C) {
 	c.Assert(err, ErrorMatches, `"snap.pkg.hook.configure" is not an app security tag`)
 	c.Assert(tag, IsNil)
 }
+
+func (s *tagSuite) TestParseHookSecurityTag(c *C) {
+	// Invalid security tags cannot be parsed.
+	tag, err := naming.ParseHookSecurityTag("potato")
+	c.Assert(err, ErrorMatches, "invalid security tag")
+	c.Assert(tag, IsNil)
+
+	// Hook security tags can be parsed.
+	tag, err = naming.ParseHookSecurityTag("snap.pkg.hook.configure")
+	c.Assert(err, IsNil)
+	c.Check(tag.String(), Equals, "snap.pkg.hook.configure")
+	c.Check(tag.InstanceName(), Equals, "pkg")
+	c.Check(tag.HookName(), Equals, "configure")
+
+	// App security tags are not hook security tags.
+	tag, err = naming.ParseHookSecurityTag("snap.pkg.app")
+	c.Assert(err, ErrorMatches, `"snap.pkg.app" is not a hook security tag`)
+	c.Assert(tag, IsNil)
+}


### PR DESCRIPTION
In practice, when parsing security tags, it may be required to know exactly
which type we are after. This patch adds two helper functions that wrap
ParseSecurityTag and return the precise AppSecurityTag or HookSecurityTag.
