### PR TITLE
usersession/userd: add "slack" to the white list of URL schemes handled by xdg-open - 2.45

### DIFF
--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -92,6 +92,7 @@ execute: |
     ensure_xdg_open_output "help:snapcraft"
     ensure_xdg_open_output "apt:snapcraft"
     ensure_xdg_open_output "zoommtg://snapcraft.io"
+    ensure_xdg_open_output "slack://5NAPPY111/magic-login/bcaf81ee-07b1-4362-9c09-ff46bd6e1bb9"
     # Ensure XDG_DATA_DIRS was prefixed with snap specific location
     test "$(tail -1 /tmp/xdg-open-output)" = "XDG_DATA_DIRS=$SNAP_MOUNT_DIR/test-snapd-desktop/current/usr/share:/usr/share"
 

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -57,7 +57,7 @@ const launcherIntrospectionXML = `
 </interface>`
 
 var (
-	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg"}
+	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "slack"}
 )
 
 // Launcher implements the 'io.snapcraft.Launcher' DBus interface.

--- a/usersession/userd/launcher_test.go
+++ b/usersession/userd/launcher_test.go
@@ -75,7 +75,7 @@ func (s *launcherSuite) TestOpenURLWithNotAllowedScheme(c *C) {
 }
 
 func (s *launcherSuite) TestOpenURLWithAllowedSchemeHappy(c *C) {
-	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg"} {
+	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "slack"} {
 		err := s.launcher.OpenURL(schema+"://snapcraft.io", ":some-dbus-sender")
 		c.Assert(err, IsNil)
 		c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{


### PR DESCRIPTION
https://github.com/snapcore/snapd/pull/8398 for 2.45. Note I used this in the commit message:
```
usersession/userd: allow launching of slack app
    
Original-Author: troyready <troy@troyready.com>
Signed-off-by: Jamie Strandboge <jamie@ubuntu.com>
```

Hope that is ok