### PR TITLE
tests: port interfaces-many-core-provided to tests.session

### DIFF
--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -35,18 +35,27 @@ debug: |
     # shellcheck disable=SC2119
     get_journalctl_log
 
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+
+    echo "Given a snap is installed"
+    install_local "$CONSUMER_SNAP"
+
+    # If possible, prepare a session for the test user. On many systems this
+    # will allow running all tests as the unprivileged user. This shields us
+    # from accidentally triggering any additional processes from run in the
+    # session of the root user and stay behind after this test terminates.
+    if tests.session has-session-systemd-and-dbus; then
+        tests.session -u test prepare
+    fi
+
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
 
     # shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB/systems.sh"
-    
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
-    echo "Given a snap is installed"
-    install_local "$CONSUMER_SNAP"
 
     echo "For each core-provided slot"
     for plugcmd in "$SNAP_MOUNT_DIR"/bin/"$CONSUMER_SNAP".* ; do
@@ -82,9 +91,28 @@ execute: |
         snap interfaces | MATCH "$CONNECTED_PATTERN"
 
         echo "Then $plugcmd should succeed"
-        "$plugcmd" | MATCH PASS
+        if tests.session has-session-systemd-and-dbus; then
+            tests.session -u test exec "$plugcmd" | MATCH PASS
+        else
+            # If we cannot run the plug command as the test user, in the
+            # relative safety of the user session which gets torn down, then
+            # run the test directly EXCEPT when testing the desktop interface.
+            #
+            # The desktop interface causes, at minimum, XDG document portal to
+            # activate in the root users's session, which is not cleaned up.
+            # Since that interface will only be used in a real session, leaving
+            # it out is acceptable.
+            if [ "$plugcmd" != "${CONSUMER_SNAP}.desktop" ]; then
+                "$plugcmd" | MATCH PASS
+            else
+                echo "skipping $plugcmd on an unsupported system"
+            fi
+        fi
     done
 
 restore: |
     # Remove the snaps to avoid timeout in next test
     snap remove --purge "$CONSUMER_SNAP"
+    if tests.session has-session-systemd-and-dbus; then
+        tests.session -u test restore
+    fi


### PR DESCRIPTION
This test, surprisingly, spawns and leaves behind the XDG document
portal. By exercising all interfaces, one by one, it invokes a app that
has the desktop plug declared. This causes "snap run" to activate the
document portal over D-Bus.

On systems without D-Bus session bus available, it will also spawn and
leak a dbus-daemon. On systems with the D-Bus session bus available, it
will just leak the document portal service.

As a solution, if possible, run all the tests via tests.session, inside
the session of the test user, that is automatically torn down along all
the processes in it. On systems where we cannot use tests.session, we
run all but the "desktop" test app directly as root. The desktop test
app is left out and not tested on systems that, arguably, are not very
desktop like. This leaves out Amazon Linux 2, CentOS 7 and also Ubuntu
14.04 which is not supported for desktop applications.

With this patch, there is only one remaining test leaking dbus-daemon,
the one testing xdg-settings.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>