### PR TITLE
Revert "Enable riscv64 builds in the edge PPA without PIE"

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -43,8 +43,8 @@ GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
 # Disable -buildmode=pie mode on all our 32bit platforms
 # (i386 and armhf). For i386 because of LP: #1711052 and for
-# armhf because of LP: #1822738 and for riscv64 because of LP: #1881417
-ifeq (,$(filter i386 armhf riscv64,$(shell dpkg-architecture -qDEB_HOST_ARCH)))
+# armhf because of LP: #1822738
+ifeq ($(shell dpkg-architecture -qDEB_HOST_ARCH_BITS),64)
  BUILDFLAGS+= -buildmode=pie
 endif
 


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/golang-defaults/+bug/1881417
is now fixed and copied into the edge PPA such that -buildmode=pie now
works on riscv64.

This reverts commit 7ce0cf35baf2d924fcc3dd74f7c7d3e6f4c5523a.