### PR TITLE
tests: fix and trim debug section in xdg-open-portal

### DIFF
--- a/tests/main/xdg-open-portal/task.yaml
+++ b/tests/main/xdg-open-portal/task.yaml
@@ -101,9 +101,4 @@ execute: |
     MATCH /home/test/snap/test-snapd-desktop/common/test.txt < "$EDITOR_HISTORY"
 
 debug: |
-    #shellcheck source=tests/lib/desktop-portal.sh
-    . "$TESTSLIB"/desktop-portal.sh
-
-    ls -la "/run/user/$TEST_UID/" || true
-    #shellcheck disable=SC2009
-    ps -ef | grep xdg || true
+    ls -la /run/user/12345/ || true


### PR DESCRIPTION
There were two issues with the debug section:
 - reference to TEST_UID that is no longer defined
 - showing a subset of processes, duplicated by global debug

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>