### PR TITLE
spread.yaml: show /var/lib/snapd in debug

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -498,6 +498,8 @@ debug-each: |
         findmnt --ascii -o+PROPAGATION || true
         echo "# processes"
         ps aux
+        echo "# /var/lib/snapd"
+        ls -lR /var/lib/snapd || true
     fi
 
 rename:


### PR DESCRIPTION
We're seeing unexpected failure to prepare some tests systems, where
dpkg fails with:

    rm: cannot remove '/var/lib/snapd': Directory not empty
    dpkg: error processing package snapd (--purge):
     installed snapd package post-removal script subprocess returned error exit status 1
    Errors were encountered while processing:
     snapd
    E: Sub-process /usr/bin/dpkg returned an error code (1)

This debug section should shed some light on this mystery.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
