### PR TITLE
tests: autoremove after removing lxd in preseed-lxd test

### DIFF
--- a/tests/lib/tools/invariant-tool
+++ b/tests/lib/tools/invariant-tool
@@ -6,6 +6,7 @@ show_help() {
 	echo "Supported invariants:"
 	echo "    root-files-in-home: most of /home/* does not contain root-owned files"
 	echo "    crashed-snap-confine: /tmp/snap.rootfs_* does not exist"
+	echo "    lxcfs-mounted: /var/lib/lxcfs is a mount point"
 }
 
 if [ $# -eq 0 ]; then
@@ -63,6 +64,16 @@ check_crashed_snap_confine() {
 	fi
 }
 
+check_lxcfs_mounted() {
+	n="$1" # invariant name
+	"$TESTSTOOLS"/mountinfo-tool /var/lib/lxcfs > "/tmp/invariant-tool.$n"
+	if [ -s "/tmp/invariant-tool.$n" ]; then
+		echo "invariant-tool: it seems lxcfs is mounted" >&2
+		cat "/tmp/invariant-tool.$n" >&2
+		return 1
+	fi
+}
+
 check_invariant() {
 	case "$1" in
 		root-files-in-home)
@@ -71,6 +82,9 @@ check_invariant() {
 		crashed-snap-confine)
 			check_crashed_snap_confine "$1"
 			;;
+		lxcfs-mounted)
+			check_lxcfs_mounted "$1"
+			;;
 		*)
 			echo "invariant-tool: unknown invariant $1" >&2
 			exit 1
@@ -78,7 +92,7 @@ check_invariant() {
 	esac
 }
 
-ALL_INVARIANTS="root-files-in-home crashed-snap-confine"
+ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted"
 
 case "$action" in
 	check)

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -46,6 +46,7 @@ restore: |
     lxc stop my-ubuntu --force || true
     lxc delete my-ubuntu || true
     apt purge -y lxd
+    apt autoremove --purge -y
   fi
 
   umount "$IMAGE_MOUNTPOINT"


### PR DESCRIPTION
This test was leaking the lxcfs mount point that caused failure of
mount-ns:inherit test, if scheduled accordingly. The root cause is that
lxd Debian package depends on a number of dependencies, including lxcfs,
which keeps a mount point active at all times.

To prevent this from happening again, add an invariant that detects this
case.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
