### PR TITLE
sanity: check for unsynchronized real time clock

### DIFF
--- a/sanity/export_test.go
+++ b/sanity/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,14 +19,18 @@
 
 package sanity
 
+import (
+	"time"
+)
+
 var (
 	CheckSquashfsMount  = checkSquashfsMount
 	CheckKernelVersion  = checkKernelVersion
 	CheckApparmorUsable = checkApparmorUsable
 	CheckWSL            = checkWSL
 	CheckCgroup         = checkCgroup
-
-	CheckFuse = firstCheckFuse
+	CheckFuse           = firstCheckFuse
+	CheckTime           = checkTime
 )
 
 func Checks() []func() error {
@@ -54,5 +58,13 @@ func MockFuseBinary(new string) (restore func()) {
 	fuseBinary = new
 	return func() {
 		fuseBinary = oldFuseBinary
+	}
+}
+
+func MockTimeNow(fn func() time.Time) (restore func()) {
+	old := timeNow
+	timeNow = fn
+	return func() {
+		timeNow = old
 	}
 }

--- a/sanity/time.go
+++ b/sanity/time.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sanity
+
+import (
+	"fmt"
+	"time"
+)
+
+func init() {
+	checks = append(checks, checkTime)
+}
+
+var timeNow = time.Now
+
+func checkTime() error {
+	now := timeNow()
+	definitelyPast := time.Date(2020, 6, 4, 15, 44, 0, 0, time.UTC)
+	if now.Before(definitelyPast) {
+		// If the time is in the past of the constant above, then the device,
+		// most likely, lacks battery powered RTC and did not use any other
+		// means to synchronize the system clock. Since assertions and SSL
+		// certificates rely on relatively accurate time, bail out early.
+		return fmt.Errorf("current time %v is not realistic, clock is not set", now)
+	}
+	return nil
+}

--- a/sanity/time_test.go
+++ b/sanity/time_test.go
@@ -1,0 +1,49 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sanity_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/sanity"
+)
+
+func (s *sanitySuite) TestCheckTimePast(c *C) {
+	restore := sanity.MockTimeNow(func() time.Time {
+		return time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
+	})
+	defer restore()
+
+	err := sanity.CheckTime()
+	c.Check(err, ErrorMatches, "current time 2016-01-01 00:00:00 \\+0000 UTC is not realistic, clock is not set")
+}
+
+func (s *sanitySuite) TestCheckTimeFuture(c *C) {
+	// Future as of this writing.
+	restore := sanity.MockTimeNow(func() time.Time {
+		return time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC)
+	})
+	defer restore()
+
+	err := sanity.CheckTime()
+	c.Check(err, IsNil)
+}


### PR DESCRIPTION
Some popular core devices do not have a real-time clock and boot with an
arbitrary date baked into the boot loader or initrd. Snapd relies on
correct clock for validating assertions and checking SSL certificates.

To avoid confusion, fail early and loud, when the clock is before a
canned date.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>