### PR TITLE
github: port macOS sanity checks from travis

### DIFF
--- a/.github/workflows/macos-sanity.yaml
+++ b/.github/workflows/macos-sanity.yaml
@@ -1,0 +1,48 @@
+name: MacOS sanity checks
+on:
+  # Only run on pull requests: not pushes
+  pull_request:
+    branches: [ "master", "release/**" ]
+
+jobs:
+  macos-sanity:
+    runs-on: macos-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+      GO111MODULE: off
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.10.x"
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # NOTE: checkout the code in a fixed location, even for forks, as this
+          # is relevant for go's import system.
+          path: ./src/github.com/snapcore/snapd
+
+      - name: Install squashfs from homebrew
+        run: |
+          brew install squashfs
+
+      - name: Install Go package dependencies
+        working-directory: ./src/github.com/snapcore/snapd
+        run: |
+          ./mkversion.sh
+          ./get-deps.sh
+          # extra dependency on darwin:
+          go get golang.org/x/sys/unix
+
+      - name: Build sanity checks
+        run: |
+          go build -o /tmp/snp github.com/snapcore/snapd/cmd/snap
+
+      - name: Runtime sanity checks
+        working-directory: ./src/github.com/snapcore/snapd
+        run: |
+          /tmp/snp download hello
+          /tmp/snp version
+          # TODO: homebrew appears to be broken, brew install of squashfs fails
+          # and goes unnoticed by travis
+          if command -v mksquashfs; then /tmp/snp pack tests/lib/snaps/test-snapd-tools/ /tmp ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,6 @@ git:
 matrix:
   include:
     - stage: quick
-      go: "1.10.x"
-      name: OSX build and minimal runtime sanity check
-      os: osx
-      addons:
-        homebrew:
-          packages: [squashfs]
-      install:
-        - ./get-deps.sh
-        # extra dependency on darwin:
-        - go get golang.org/x/sys/unix
-      before_script:
-        - ./mkversion.sh
-        - go build -o /tmp/snp ./cmd/snap
-      script:
-        - /tmp/snp download hello
-        - /tmp/snp version
-        # TODO: homebrew appears to be broken, brew install of squashfs fails
-        # and goes unnoticed by travis
-        - if command -v mksquashfs; then /tmp/snp pack tests/lib/snaps/test-snapd-tools/ /tmp ; fi
-    - stage: quick
       name: CLA check
       dist: xenial
       if: type = pull_request


### PR DESCRIPTION
Now that a bunch of tests is running via github actions, port the macOS sanity checks too.
