### PR TITLE
asserts/internal: limit Grouping size switching to a bitset representation

### DIFF
--- a/asserts/internal/grouping.go
+++ b/asserts/internal/grouping.go
@@ -263,9 +263,8 @@ func (gr *Groupings) bitsetIter(g *Grouping, f func(group uint16) error) error {
 		if w == 0 {
 			continue
 		}
-		bit := uint16(1)
-		for j := uint16(0); j < 16; j++ {
-			if w&bit != 0 {
+		for j := uint16(0); w != 0; j++ {
+			if w&1 != 0 {
 				if err := f(i*16 + j); err != nil {
 					return err
 				}
@@ -275,7 +274,7 @@ func (gr *Groupings) bitsetIter(g *Grouping, f func(group uint16) error) error {
 					return nil
 				}
 			}
-			bit <<= 1
+			w >>= 1
 		}
 	}
 	return nil

--- a/asserts/internal/grouping.go
+++ b/asserts/internal/grouping.go
@@ -227,6 +227,10 @@ func (gr *Groupings) bitsetDeserialize(g *Grouping, b []byte) (*Grouping, error)
 	if g.size > gr.maxGroup+1 {
 		return nil, errSerializedLabel
 	}
+	if g.size <= gr.bitsetThreshold {
+		// should not have used a bitset repr for so few elements
+		return nil, errSerializedLabel
+	}
 	g.elems = make([]uint16, gr.bitsetThreshold)
 	binary.Read(buf, binary.LittleEndian, g.elems)
 	return g, nil

--- a/asserts/internal/grouping.go
+++ b/asserts/internal/grouping.go
@@ -36,8 +36,9 @@ import (
 //  - a few labels are sparse with more groups in them
 //  - very few comprise the universe of all groups
 type Groupings struct {
-	n        uint
-	maxGroup uint16
+	n               uint
+	maxGroup        uint16
+	bitsetThreshold uint16
 }
 
 // NewGroupings creates a new Groupings supporting labels for membership
@@ -49,7 +50,7 @@ func NewGroupings(n int) (*Groupings, error) {
 	if n%16 != 0 {
 		return nil, fmt.Errorf("n=%d groups is not a multiple of 16", n)
 	}
-	return &Groupings{n: uint(n)}, nil
+	return &Groupings{n: uint(n), bitsetThreshold: uint16(n / 16)}, nil
 }
 
 // WithinRange checks whether group is within the admissible range for
@@ -74,15 +75,23 @@ func (g Grouping) Copy() Grouping {
 }
 
 // search locates group among the sorted Grouping elements, it returns:
-//  * true and the index of group among them if group is found
-//  * false and the index at which group should be inserted to keep the
-//    elements sorted if not found
-func (g *Grouping) search(group uint16) (found bool, j uint16) {
+//  * true if found
+//  * false if not found
+//  * the index at which group should be inserted to keep the
+//    elements sorted if not found and the bit-set representation is not in use
+func (gr *Groupings) search(g *Grouping, group uint16) (found bool, j uint16) {
+	if g.size > gr.bitsetThreshold {
+		return bitsetContains(g, group), 0
+	}
 	j = uint16(sort.Search(int(g.size), func(i int) bool { return g.elems[i] >= group }))
 	if j < g.size && g.elems[j] == group {
-		return true, j
+		return true, 0
 	}
 	return false, j
+}
+
+func bitsetContains(g *Grouping, group uint16) bool {
+	return (g.elems[group/16] & (1 << (group % 16))) != 0
 }
 
 // AddTo adds the given group to the grouping.
@@ -98,32 +107,50 @@ func (gr *Groupings) AddTo(g *Grouping, group uint16) error {
 		g.elems = []uint16{group}
 		return nil
 	}
-	// TODO: support using a bit-set representation after the size point
-	// where the space cost is the same
-	found, j := g.search(group)
+	found, j := gr.search(g, group)
 	if found {
+		return nil
+	}
+	newsize := g.size + 1
+	if newsize > gr.bitsetThreshold {
+		// switching to a bit-set representation after the size point
+		// where the space cost is the same, the representation uses
+		// bitsetThreshold-many 16-bits words stored in elems
+		if g.size == gr.bitsetThreshold {
+			prevelems := g.elems
+			g.elems = make([]uint16, gr.bitsetThreshold)
+			for _, e := range prevelems {
+				bitsetAdd(g, e)
+			}
+		}
+		g.size = newsize
+		bitsetAdd(g, group)
 		return nil
 	}
 	var newelems []uint16
 	if int(g.size) == cap(g.elems) {
-		newelems = make([]uint16, g.size+1, cap(g.elems)*2)
+		newelems = make([]uint16, newsize, cap(g.elems)*2)
 		copy(newelems, g.elems[:j])
 	} else {
-		newelems = g.elems[:g.size+1]
+		newelems = g.elems[:newsize]
 	}
 	if j < g.size {
 		copy(newelems[j+1:], g.elems[j:])
 	}
 	// inserting new group at j index keeping the elements sorted
 	newelems[j] = group
-	g.size++
+	g.size = newsize
 	g.elems = newelems
 	return nil
 }
 
+func bitsetAdd(g *Grouping, group uint16) {
+	g.elems[group/16] |= 1 << (group % 16)
+}
+
 // Contains returns whether the given group is a member of the grouping.
 func (gr *Groupings) Contains(g *Grouping, group uint16) bool {
-	found, _ := g.search(group)
+	found, _ := gr.search(g, group)
 	return found
 }
 
@@ -136,7 +163,23 @@ func Serialize(elems []uint16) string {
 
 // Serialize produces a string representing the grouping label.
 func (gr *Groupings) Serialize(g *Grouping) string {
+	// groupings are serialized as:
+	//  * the actual element groups if there are up to
+	//    bitsetThreshold elements: elems[0], elems[1], ...
+	//  * otherwise the number of elements, followed by the bitset
+	//    representation comprised of bitsetThreshold-many 16-bits words
+	//    (stored using elems as well)
+	if g.size > gr.bitsetThreshold {
+		return gr.bitsetSerialize(g)
+	}
 	return Serialize(g.elems)
+}
+
+func (gr *Groupings) bitsetSerialize(g *Grouping) string {
+	b := bytes.NewBuffer(make([]byte, 0, (gr.bitsetThreshold+1)*2))
+	binary.Write(b, binary.LittleEndian, g.size)
+	binary.Write(b, binary.LittleEndian, g.elems)
+	return base64.RawURLEncoding.EncodeToString(b.Bytes())
 }
 
 var errSerializedLabel = errors.New("invalid serialized grouping label")
@@ -150,8 +193,17 @@ func (gr *Groupings) Deserialize(label string) (*Grouping, error) {
 	if len(b)%2 != 0 {
 		return nil, errSerializedLabel
 	}
+	m := len(b) / 2
 	var g Grouping
-	g.size = uint16(len(b) / 2)
+	if m == int(gr.bitsetThreshold+1) {
+		// deserialize number of elements + bitset representation
+		// comprising bitsetThreshold-many 16-bits words
+		return gr.bitsetDeserialize(&g, b)
+	}
+	if m > int(gr.bitsetThreshold) {
+		return nil, errSerializedLabel
+	}
+	g.size = uint16(m)
 	esz := uint16(1)
 	for esz < g.size {
 		esz *= 2
@@ -169,12 +221,51 @@ func (gr *Groupings) Deserialize(label string) (*Grouping, error) {
 	return &g, nil
 }
 
+func (gr *Groupings) bitsetDeserialize(g *Grouping, b []byte) (*Grouping, error) {
+	buf := bytes.NewBuffer(b)
+	binary.Read(buf, binary.LittleEndian, &g.size)
+	if g.size > gr.maxGroup+1 {
+		return nil, errSerializedLabel
+	}
+	g.elems = make([]uint16, gr.bitsetThreshold)
+	binary.Read(buf, binary.LittleEndian, g.elems)
+	return g, nil
+}
+
 // Iter iterates over the groups in the grouping and calls f with each of
 // them. If f returns an error Iter immediately returns with it.
 func (gr *Groupings) Iter(g *Grouping, f func(group uint16) error) error {
+	if g.size > gr.bitsetThreshold {
+		return gr.bitsetIter(g, f)
+	}
 	for _, e := range g.elems {
 		if err := f(e); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func (gr *Groupings) bitsetIter(g *Grouping, f func(group uint16) error) error {
+	c := g.size
+	for i := uint16(0); i <= gr.maxGroup/16; i++ {
+		w := g.elems[i]
+		if w == 0 {
+			continue
+		}
+		bit := uint16(1)
+		for j := uint16(0); j < 16; j++ {
+			if w&bit != 0 {
+				if err := f(i*16 + j); err != nil {
+					return err
+				}
+				c--
+				if c == 0 {
+					// found all elements
+					return nil
+				}
+			}
+			bit <<= 1
 		}
 	}
 	return nil

--- a/asserts/internal/grouping.go
+++ b/asserts/internal/grouping.go
@@ -115,7 +115,13 @@ func (gr *Groupings) AddTo(g *Grouping, group uint16) error {
 	if newsize > gr.bitsetThreshold {
 		// switching to a bit-set representation after the size point
 		// where the space cost is the same, the representation uses
-		// bitsetThreshold-many 16-bits words stored in elems
+		// bitsetThreshold-many 16-bits words stored in elems.
+		// We don't always use the bit-set representation because
+		// * we expect small groupings and iteration to be common,
+		//   iteration is more costly over the bit-set representation
+		// * serialization matches more or less what we do in memory,
+		//   so again is more efficient for small groupings in the
+		//   extensive representation.
 		if g.size == gr.bitsetThreshold {
 			prevelems := g.elems
 			g.elems = make([]uint16, gr.bitsetThreshold)

--- a/asserts/internal/grouping_test.go
+++ b/asserts/internal/grouping_test.go
@@ -160,6 +160,10 @@ func (s *groupingsSuite) TestDeserializeLabelErrors(c *C) {
 		internal.Serialize([]uint16{0, 0, 0, 0, 0, 0}),
 		// bitset: larger than maxgroup
 		internal.Serialize([]uint16{6, 0, 0, 0, 0}),
+		// bitset: grouping size is too small
+		internal.Serialize([]uint16{0, 0, 0, 0, 0}),
+		internal.Serialize([]uint16{1, 0, 0, 0, 0}),
+		internal.Serialize([]uint16{4, 0, 0, 0, 0}),
 	}
 
 	for _, il := range invalidLabels {

--- a/asserts/internal/grouping_test.go
+++ b/asserts/internal/grouping_test.go
@@ -108,7 +108,7 @@ func (s *groupingsSuite) TestOutsideRange(c *C) {
 func (s *groupingsSuite) TestSerializeLabel(c *C) {
 	var g internal.Grouping
 
-	gr, err := internal.NewGroupings(16)
+	gr, err := internal.NewGroupings(128)
 	c.Assert(err, IsNil)
 
 	err = gr.AddTo(&g, 1)
@@ -133,7 +133,7 @@ func (s *groupingsSuite) TestSerializeLabel(c *C) {
 func (s *groupingsSuite) TestDeserializeLabelErrors(c *C) {
 	var g internal.Grouping
 
-	gr, err := internal.NewGroupings(16)
+	gr, err := internal.NewGroupings(64)
 	c.Assert(err, IsNil)
 
 	err = gr.AddTo(&g, 0)
@@ -142,6 +142,10 @@ func (s *groupingsSuite) TestDeserializeLabelErrors(c *C) {
 	c.Assert(err, IsNil)
 	err = gr.AddTo(&g, 2)
 	c.Assert(err, IsNil)
+	err = gr.AddTo(&g, 3)
+	c.Assert(err, IsNil)
+	err = gr.AddTo(&g, 4)
+	c.Assert(err, IsNil)
 
 	invalidLabels := []string{
 		// not base64
@@ -149,9 +153,13 @@ func (s *groupingsSuite) TestDeserializeLabelErrors(c *C) {
 		// wrong length
 		base64.RawURLEncoding.EncodeToString([]byte{1}),
 		// not a known group
-		internal.Serialize([]uint16{3}),
+		internal.Serialize([]uint16{5}),
 		// not in order
 		internal.Serialize([]uint16{0, 2, 1}),
+		// bitset: too many words
+		internal.Serialize([]uint16{0, 0, 0, 0, 0, 0}),
+		// bitset: larger than maxgroup
+		internal.Serialize([]uint16{6, 0, 0, 0, 0}),
 	}
 
 	for _, il := range invalidLabels {
@@ -163,7 +171,7 @@ func (s *groupingsSuite) TestDeserializeLabelErrors(c *C) {
 func (s *groupingsSuite) TestIter(c *C) {
 	var g internal.Grouping
 
-	gr, err := internal.NewGroupings(16)
+	gr, err := internal.NewGroupings(128)
 	c.Assert(err, IsNil)
 
 	err = gr.AddTo(&g, 1)
@@ -191,7 +199,7 @@ func (s *groupingsSuite) TestIter(c *C) {
 func (s *groupingsSuite) TestIterError(c *C) {
 	var g internal.Grouping
 
-	gr, err := internal.NewGroupings(16)
+	gr, err := internal.NewGroupings(32)
 	c.Assert(err, IsNil)
 
 	err = gr.AddTo(&g, 1)
@@ -214,7 +222,7 @@ func (s *groupingsSuite) TestIterError(c *C) {
 func (s *groupingsSuite) TestRepeated(c *C) {
 	var g internal.Grouping
 
-	gr, err := internal.NewGroupings(16)
+	gr, err := internal.NewGroupings(64)
 	c.Assert(err, IsNil)
 
 	err = gr.AddTo(&g, 1)
@@ -267,4 +275,112 @@ func (s *groupingsSuite) TestCopy(c *C) {
 	c.Check(gr.Contains(&g2, 7), Equals, true)
 
 	c.Check(g2, Not(DeepEquals), g)
+}
+
+func (s *groupingsSuite) TestBitSet(c *C) {
+	var g internal.Grouping
+
+	gr, err := internal.NewGroupings(64)
+	c.Assert(err, IsNil)
+
+	for i := uint16(0); i < 64; i++ {
+		err := gr.AddTo(&g, i)
+		c.Assert(err, IsNil)
+		c.Check(gr.Contains(&g, i), Equals, true)
+
+		l := gr.Serialize(&g)
+
+		switch i {
+		case 4:
+			c.Check(l, Equals, internal.Serialize([]uint16{5, 0x1f, 0, 0, 0}))
+		case 15:
+			c.Check(l, Equals, internal.Serialize([]uint16{16, 0xffff, 0, 0, 0}))
+		case 16:
+			c.Check(l, Equals, internal.Serialize([]uint16{17, 0xffff, 0x1, 0, 0}))
+		case 63:
+			c.Check(l, Equals, internal.Serialize([]uint16{64, 0xffff, 0xffff, 0xffff, 0xffff}))
+		}
+
+		g1, err := gr.Deserialize(l)
+		c.Check(err, IsNil)
+
+		c.Check(g1, DeepEquals, &g)
+	}
+
+	for i := uint16(63); ; i-- {
+		err := gr.AddTo(&g, i)
+		c.Assert(err, IsNil)
+		c.Check(gr.Contains(&g, i), Equals, true)
+		if i == 0 {
+			break
+		}
+
+		l := gr.Serialize(&g)
+
+		g1, err := gr.Deserialize(l)
+		c.Check(err, IsNil)
+
+		c.Check(g1, DeepEquals, &g)
+	}
+}
+
+func (s *groupingsSuite) TestBitsetIter(c *C) {
+	gr, err := internal.NewGroupings(32)
+	c.Assert(err, IsNil)
+
+	var elems []uint16
+	f := func(group uint16) error {
+		elems = append(elems, group)
+		return nil
+	}
+
+	for i := uint16(2); i < 32; i++ {
+		var g internal.Grouping
+
+		err := gr.AddTo(&g, i-2)
+		c.Assert(err, IsNil)
+		err = gr.AddTo(&g, i-1)
+		c.Assert(err, IsNil)
+		err = gr.AddTo(&g, i)
+		c.Assert(err, IsNil)
+
+		err = gr.Iter(&g, f)
+		c.Assert(err, IsNil)
+		c.Check(elems, DeepEquals, []uint16{i - 2, i - 1, i})
+
+		elems = nil
+	}
+
+	var g internal.Grouping
+	for i := uint16(0); i < 32; i++ {
+		err = gr.AddTo(&g, i)
+		c.Assert(err, IsNil)
+	}
+
+	err = gr.Iter(&g, f)
+	c.Assert(err, IsNil)
+	c.Check(elems, HasLen, 32)
+}
+
+func (s *groupingsSuite) TestBitsetIterError(c *C) {
+	gr, err := internal.NewGroupings(16)
+	c.Assert(err, IsNil)
+
+	var g internal.Grouping
+
+	err = gr.AddTo(&g, 0)
+	c.Assert(err, IsNil)
+	err = gr.AddTo(&g, 1)
+	c.Assert(err, IsNil)
+
+	errBoom := errors.New("boom")
+	n := 0
+	f := func(group uint16) error {
+		n++
+		return errBoom
+	}
+
+	err = gr.Iter(&g, f)
+	c.Check(err, Equals, errBoom)
+	c.Check(n, Equals, 1)
 }

--- a/asserts/internal/grouping_test.go
+++ b/asserts/internal/grouping_test.go
@@ -280,6 +280,37 @@ func (s *groupingsSuite) TestCopy(c *C) {
 
 	c.Check(g2, Not(DeepEquals), g)
 }
+func (s *groupingsSuite) TestBitsetSerializeAndIterSimple(c *C) {
+	gr, err := internal.NewGroupings(32)
+	c.Assert(err, IsNil)
+
+	var elems []uint16
+	f := func(group uint16) error {
+		elems = append(elems, group)
+		return nil
+	}
+
+	var g internal.Grouping
+	err = gr.AddTo(&g, 1)
+	c.Assert(err, IsNil)
+	err = gr.AddTo(&g, 5)
+	c.Assert(err, IsNil)
+	err = gr.AddTo(&g, 17)
+	c.Assert(err, IsNil)
+	err = gr.AddTo(&g, 24)
+	c.Assert(err, IsNil)
+
+	l := gr.Serialize(&g)
+	c.Check(l, DeepEquals,
+		internal.Serialize([]uint16{4,
+			uint16(1<<1 | 1<<5),
+			uint16(1<<(17-16) | 1<<(24-16)),
+		}))
+
+	err = gr.Iter(&g, f)
+	c.Assert(err, IsNil)
+	c.Check(elems, DeepEquals, []uint16{1, 5, 17, 24})
+}
 
 func (s *groupingsSuite) TestBitSet(c *C) {
 	var g internal.Grouping


### PR DESCRIPTION
Switching to a bit-set representation after the size point
where the space cost is the same, the representation uses
bitsetThreshold-many 16-bits words stored in Grouping elems.
We don't always use the bit-set representation because:
 * we expect small groupings and iteration to be common,
   iteration is more costly over the bit-set representation
 * serialization matches more or less what we do in memory,
   so again is more efficient for small groupings in the
   extensive representation.

As mentioned this is reflected in the serialization too.