### PR TITLE
 interfaces/builtin/time-control: allow POSIX clock API

### DIFF
--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -110,6 +110,11 @@ const timeControlConnectedPlugSecComp = `
 
 settimeofday
 adjtimex
+# direct manipulation through POSIX clock time API
+clock_adjtime
+clock_adjtime64
+clock_settime
+clock_settime64
 
 # util-linux built with libaudit tries to write to the audit subsystem. We
 # allow the socket call here to avoid seccomp kill, but omit the AppArmor

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -85,9 +85,19 @@ func (s *TimeControlInterfaceSuite) TestSecCompSpec(c *C) {
 	spec := &seccomp.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "settimeofday")
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "adjtimex")
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "socket AF_NETLINK - NETLINK_AUDIT")
+
+	snippet := spec.SnippetForTag("snap.consumer.app")
+	for _, needle := range []string{
+		"settimeofday",
+		"adjtimex",
+		"socket AF_NETLINK - NETLINK_AUDIT",
+		"clock_adjtime",
+		"clock_adjtime64",
+		"clock_settime",
+		"clock_settime64",
+	} {
+		c.Check(snippet, testutil.Contains, needle)
+	}
 }
 
 func (s *TimeControlInterfaceSuite) TestUDevSpec(c *C) {

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer/bin/date
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer/bin/date
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/date "$@"

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer/meta/snap.yaml
@@ -16,3 +16,6 @@ apps:
     hwclock-time:
         command: bin/hwclock
         plugs: [time-control, netlink-audit]
+    date:
+        command: bin/date
+        plugs: [time-control]

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -15,11 +15,15 @@ prepare: |
     # Install a snap declaring a plug on time-control
     install_local test-snapd-timedate-control-consumer
 
+    date +'%m%d%H%M.%y' > now.txt
+
 restore: |
     # Restore the initial rtc configuration
     if [ -f rtc.txt ]; then
         timedatectl set-local-rtc "$(cat rtc.txt)"
     fi
+
+    date "$(cat now.txt)"
 
 execute: |
     # hwclock with libaudit (ie, core 16) also needs netlink-audit connected.
@@ -51,6 +55,10 @@ execute: |
     test-snapd-timedate-control-consumer.timedatectl-time set-local-rtc no
     [ "$(test-snapd-timedate-control-consumer.timedatectl-time status | grep -oP 'RTC in local TZ: \K(.*)')" = "no" ]
 
+    echo "And direct setting via date"
+    nice_when="$(date -d 'tomorrow' +'%m%d%H%M.%y')"
+    test-snapd-timedate-control-consumer.date "$nice_when"
+
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
@@ -64,3 +72,8 @@ execute: |
         exit 1
     fi
     MATCH "Permission denied" < call.error
+
+    now="$(cat now.txt)"
+    not test-snapd-timedate-control-consumer.date "$now" 2> call.error
+    # EPERM because date gets blocked by the seccomp profile
+    MATCH "cannot set date: Operation not permitted" < call.error


### PR DESCRIPTION
Allow manipulating the clocks via POSIX clock APIs. This allows setting system
time via `date`, which calls `clock_settime` directly like so:

```
stat(..) = 0
clock_settime(CLOCK_REALTIME, {tv_sec=1591517520, tv_nsec=0}) = 0
fstat(..) = 0
```