### PR TITLE
tests: clean up up the use of configcoreSuite in the configcore tests

### DIFF
--- a/overlord/configstate/configcore/backlight_test.go
+++ b/overlord/configstate/configcore/backlight_test.go
@@ -39,8 +39,6 @@ var _ = Suite(&backlightSuite{})
 func (s *backlightSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
 
-	s.systemctlArgs = nil
-
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
 	c.Assert(err, IsNil)
 }

--- a/overlord/configstate/configcore/backlight_test.go
+++ b/overlord/configstate/configcore/backlight_test.go
@@ -41,13 +41,12 @@ func (s *backlightSuite) SetUpTest(c *C) {
 
 	s.systemctlArgs = nil
 
-	dirs.SetRootDir(c.MkDir())
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
 	c.Assert(err, IsNil)
 }
 
 func (s *backlightSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("/")
+	s.configcoreSuite.TearDownTest(c)
 }
 
 func (s *backlightSuite) TestConfigureBacklightServiceMaskIntegration(c *C) {

--- a/overlord/configstate/configcore/backlight_test.go
+++ b/overlord/configstate/configcore/backlight_test.go
@@ -45,10 +45,6 @@ func (s *backlightSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *backlightSuite) TearDownTest(c *C) {
-	s.configcoreSuite.TearDownTest(c)
-}
-
 func (s *backlightSuite) TestConfigureBacklightServiceMaskIntegration(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()

--- a/overlord/configstate/configcore/cloud_test.go
+++ b/overlord/configstate/configcore/cloud_test.go
@@ -39,11 +39,10 @@ var _ = Suite(&cloudSuite{})
 
 func (s *cloudSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
-	dirs.SetRootDir(c.MkDir())
 }
 
 func (s *cloudSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("/")
+	s.configcoreSuite.TearDownTest(c)
 }
 
 func (s *cloudSuite) TestHandleCloud(c *C) {

--- a/overlord/configstate/configcore/cloud_test.go
+++ b/overlord/configstate/configcore/cloud_test.go
@@ -37,10 +37,6 @@ type cloudSuite struct {
 
 var _ = Suite(&cloudSuite{})
 
-func (s *cloudSuite) SetUpTest(c *C) {
-	s.configcoreSuite.SetUpTest(c)
-}
-
 func (s *cloudSuite) TestHandleCloud(c *C) {
 	tests := []struct {
 		instData         string

--- a/overlord/configstate/configcore/cloud_test.go
+++ b/overlord/configstate/configcore/cloud_test.go
@@ -41,10 +41,6 @@ func (s *cloudSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
 }
 
-func (s *cloudSuite) TearDownTest(c *C) {
-	s.configcoreSuite.TearDownTest(c)
-}
-
 func (s *cloudSuite) TestHandleCloud(c *C) {
 	tests := []struct {
 		instData         string

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -153,6 +153,10 @@ func (s *configcoreSuite) SetUpTest(c *C) {
 	s.systemctlArgs = nil
 }
 
+func (s *configcoreSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
 // runCfgSuite tests configcore.Run()
 type runCfgSuite struct {
 	configcoreSuite

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -153,10 +153,6 @@ func (s *configcoreSuite) SetUpTest(c *C) {
 	s.systemctlArgs = nil
 }
 
-func (s *configcoreSuite) TearDownTest(c *C) {
-	s.BaseTest.TearDownTest(c)
-}
-
 // runCfgSuite tests configcore.Run()
 type runCfgSuite struct {
 	configcoreSuite

--- a/overlord/configstate/configcore/network_test.go
+++ b/overlord/configstate/configcore/network_test.go
@@ -46,7 +46,7 @@ func (s *networkSuite) SetUpTest(c *C) {
 	s.AddCleanup(release.MockOnClassic(false))
 
 	s.mockSysctl = testutil.MockCommand(c, "sysctl", "")
-	s.AddCleanup(func() { s.mockSysctl.Restore() })
+	s.AddCleanup(s.mockSysctl.Restore)
 
 	s.mockNetworkSysctlPath = filepath.Join(dirs.GlobalRootDir, "/etc/sysctl.d/10-snapd-network.conf")
 	c.Assert(os.MkdirAll(filepath.Dir(s.mockNetworkSysctlPath), 0755), IsNil)

--- a/overlord/configstate/configcore/network_test.go
+++ b/overlord/configstate/configcore/network_test.go
@@ -43,17 +43,13 @@ var _ = Suite(&networkSuite{})
 
 func (s *networkSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
-	s.BaseTest.AddCleanup(release.MockOnClassic(false))
+	s.AddCleanup(release.MockOnClassic(false))
 
 	s.mockSysctl = testutil.MockCommand(c, "sysctl", "")
-	s.BaseTest.AddCleanup(func() { s.mockSysctl.Restore() })
+	s.AddCleanup(func() { s.mockSysctl.Restore() })
 
 	s.mockNetworkSysctlPath = filepath.Join(dirs.GlobalRootDir, "/etc/sysctl.d/10-snapd-network.conf")
 	c.Assert(os.MkdirAll(filepath.Dir(s.mockNetworkSysctlPath), 0755), IsNil)
-}
-
-func (s *networkSuite) TearDownTest(c *C) {
-	s.configcoreSuite.TearDownTest(c)
 }
 
 func (s *networkSuite) TestConfigureNetworkIntegrationIPv6(c *C) {

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -54,7 +54,6 @@ unrelated_options=are-kept
 
 func (s *piCfgSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
-	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc"), 0755), IsNil)
 
 	s.mockConfigPath = filepath.Join(dirs.GlobalRootDir, "/boot/uboot/config.txt")
@@ -64,7 +63,7 @@ func (s *piCfgSuite) SetUpTest(c *C) {
 }
 
 func (s *piCfgSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("/")
+	s.configcoreSuite.TearDownTest(c)
 }
 
 func (s *piCfgSuite) mockConfig(c *C, txt string) {

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -62,10 +62,6 @@ func (s *piCfgSuite) SetUpTest(c *C) {
 	s.mockConfig(c, mockConfigTxt)
 }
 
-func (s *piCfgSuite) TearDownTest(c *C) {
-	s.configcoreSuite.TearDownTest(c)
-}
-
 func (s *piCfgSuite) mockConfig(c *C, txt string) {
 	err := ioutil.WriteFile(s.mockConfigPath, []byte(txt), 0644)
 	c.Assert(err, IsNil)

--- a/overlord/configstate/configcore/powerbtn_test.go
+++ b/overlord/configstate/configcore/powerbtn_test.go
@@ -42,14 +42,13 @@ var _ = Suite(&powerbtnSuite{})
 
 func (s *powerbtnSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
-	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc"), 0755), IsNil)
 
 	s.mockPowerBtnCfg = filepath.Join(dirs.GlobalRootDir, "/etc/systemd/logind.conf.d/00-snap-core.conf")
 }
 
 func (s *powerbtnSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("/")
+	s.configcoreSuite.TearDownTest(c)
 }
 
 func (s *powerbtnSuite) TestConfigurePowerButtonInvalid(c *C) {

--- a/overlord/configstate/configcore/powerbtn_test.go
+++ b/overlord/configstate/configcore/powerbtn_test.go
@@ -47,10 +47,6 @@ func (s *powerbtnSuite) SetUpTest(c *C) {
 	s.mockPowerBtnCfg = filepath.Join(dirs.GlobalRootDir, "/etc/systemd/logind.conf.d/00-snap-core.conf")
 }
 
-func (s *powerbtnSuite) TearDownTest(c *C) {
-	s.configcoreSuite.TearDownTest(c)
-}
-
 func (s *powerbtnSuite) TestConfigurePowerButtonInvalid(c *C) {
 	err := configcore.SwitchHandlePowerKey("invalid-action", nil)
 	c.Check(err, ErrorMatches, `invalid action "invalid-action" supplied for system.power-key-action option`)

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -51,7 +51,6 @@ var _ = Suite(&proxySuite{})
 func (s *proxySuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
 
-	dirs.SetRootDir(c.MkDir())
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
 	c.Assert(err, IsNil)
 	s.mockEtcEnvironment = filepath.Join(dirs.GlobalRootDir, "/etc/environment")
@@ -74,7 +73,7 @@ func (s *proxySuite) SetUpTest(c *C) {
 }
 
 func (s *proxySuite) TearDownTest(c *C) {
-	dirs.SetRootDir("/")
+	s.configcoreSuite.TearDownTest(c)
 }
 
 func (s *proxySuite) makeMockEtcEnvironment(c *C) {

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -72,10 +72,6 @@ func (s *proxySuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *proxySuite) TearDownTest(c *C) {
-	s.configcoreSuite.TearDownTest(c)
-}
-
 func (s *proxySuite) makeMockEtcEnvironment(c *C) {
 	err := ioutil.WriteFile(s.mockEtcEnvironment, []byte(`
 PATH="/usr/bin"

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -47,10 +47,6 @@ func (s *servicesSuite) SetUpTest(c *C) {
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 }
 
-func (s *servicesSuite) TearDownTest(c *C) {
-	s.configcoreSuite.TearDownTest(c)
-}
-
 func (s *servicesSuite) TestConfigureServiceInvalidValue(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -36,23 +36,19 @@ import (
 
 type servicesSuite struct {
 	configcoreSuite
-	testutil.BaseTest
 }
 
 var _ = Suite(&servicesSuite{})
 
 func (s *servicesSuite) SetUpTest(c *C) {
-	s.BaseTest.SetUpTest(c)
 	s.configcoreSuite.SetUpTest(c)
-	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc"), 0755), IsNil)
 	s.systemctlArgs = nil
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 }
 
 func (s *servicesSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("/")
-	s.BaseTest.TearDownTest(c)
+	s.configcoreSuite.TearDownTest(c)
 }
 
 func (s *servicesSuite) TestConfigureServiceInvalidValue(c *C) {

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -50,10 +50,6 @@ func (s *watchdogSuite) SetUpTest(c *C) {
 	s.systemctlArgs = nil
 }
 
-func (s *watchdogSuite) TearDownTest(c *C) {
-	s.configcoreSuite.TearDownTest(c)
-}
-
 func (s *watchdogSuite) TestConfigureWatchdog(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -47,7 +47,6 @@ func (s *watchdogSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
 
 	s.mockEtcEnvironment = filepath.Join(dirs.SnapSystemdConfDir, "10-snapd-watchdog.conf")
-	s.systemctlArgs = nil
 }
 
 func (s *watchdogSuite) TestConfigureWatchdog(c *C) {

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -46,14 +46,12 @@ var _ = Suite(&watchdogSuite{})
 func (s *watchdogSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
 
-	dirs.SetRootDir(c.MkDir())
 	s.mockEtcEnvironment = filepath.Join(dirs.SnapSystemdConfDir, "10-snapd-watchdog.conf")
-
 	s.systemctlArgs = nil
 }
 
 func (s *watchdogSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("/")
+	s.configcoreSuite.TearDownTest(c)
 }
 
 func (s *watchdogSuite) TestConfigureWatchdog(c *C) {


### PR DESCRIPTION
Small drive-by from reviewing configcore PR, I noticed some inconsistencies in existing tests, this PR cleans them up. 
Since configcoreSuite is used in almost all of these tests (and it uses BaseTest):
- use AddCleanup 
- don't set/restore rootdir in tests that use configcoreSuite since this is already covered by base suite
- TearDownTest not needed in most cases

Another followup deals with journal_test - #8831