### PR TITLE
sandbox/cgroup: remove redundant pathOfProcPidCgroup

### DIFF
--- a/sandbox/cgroup/cgroup.go
+++ b/sandbox/cgroup/cgroup.go
@@ -278,19 +278,6 @@ type procInfoEntry struct {
 	Path        string
 }
 
-var pathOfProcPidCgroup = func(pid int) string {
-	return fmt.Sprintf("/proc/%d/cgroup", pid)
-}
-
-// MockPathOfProcPidCgroup mocks the function used to compute /proc/PID/cgroup
-func MockPathOfProcPidCgroup(fn func(int) string) func() {
-	old := pathOfProcPidCgroup
-	pathOfProcPidCgroup = fn
-	return func() {
-		pathOfProcPidCgroup = old
-	}
-}
-
 // ProcessPathInTrackingCgroup returns the path in the hierarchy of the tracking cgroup.
 //
 // Tracking cgroup is whichever cgroup systemd uses for tracking processes.
@@ -300,7 +287,7 @@ func MockPathOfProcPidCgroup(fn func(int) string) func() {
 // This function fails on systems where systemd is not used and subsequently
 // cgroups are not mounted.
 func ProcessPathInTrackingCgroup(pid int) (string, error) {
-	fname := pathOfProcPidCgroup(pid)
+	fname := ProcPidPath(pid)
 	// Cgroup entries we're looking for look like this:
 	// 1:name=systemd:/user.slice/user-1000.slice/user@1000.service/tmux.slice/tmux@default.service
 	// 0::/user.slice/user-1000.slice/user@1000.service/tmux.slice/tmux@default.service

--- a/sandbox/cgroup/cgroup_test.go
+++ b/sandbox/cgroup/cgroup_test.go
@@ -293,12 +293,11 @@ func (s *cgroupSuite) TestProcessPathInTrackingCgroup(c *C) {
 `
 
 	d := c.MkDir()
-	f := filepath.Join(d, "cgroup")
-	restore := cgroup.MockPathOfProcPidCgroup(func(pid int) string {
-		c.Assert(pid, Equals, 1234)
-		return f
-	})
+	restore := cgroup.MockFsRootPath(d)
 	defer restore()
+
+	f := filepath.Join(d, "proc", "1234", "cgroup")
+	c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
 
 	for _, scenario := range []struct{ cgroups, path, errMsg string }{
 		{cgroups: "", path: "", errMsg: "cannot find tracking cgroup"},


### PR DESCRIPTION
The cgroup package already contains the identical ProcPidPath which
also has the benefit of being testable without a special mock function.

There's a tiny change to tests, to phase out the custom mock function
MockPathOfProcPidCgroup. In a follow-up we should probably make
ProcPidPath private as it seems otherwise unused outside of this
package.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
