### PR TITLE
dbusutil/dbustest: separate license from package

### DIFF
--- a/dbusutil/dbustest/stub.go
+++ b/dbusutil/dbustest/stub.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package dbustest
 
 import (


### PR DESCRIPTION
This makes go doc not think that the GPL license is the documentation.
Thanks to Samuele for spotting.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
