### PR TITLE
POC:  skip binary to skip tests in an easy way

### DIFF
--- a/tests/bin/SKIP
+++ b/tests/bin/SKIP
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -z "$@" ] && [ -f skip.test ]; then
+	echo "Skipping phase..."
+	exit
+fi
+
+if eval "$@" &>/dev/null; then
+	echo "SKIP matched..."
+	touch skip.test
+	exit
+fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -595,6 +595,9 @@ restore_suite_each() {
         # to prevent hitting the system restart rate-limit for these services
         systemctl reset-failed snapd.service snapd.socket snapd.failure.service
     fi
+
+    # Clean the skip file
+    rm -f skip.test
 }
 
 restore_suite() {

--- a/tests/main/broken-seeding/task.yaml
+++ b/tests/main/broken-seeding/task.yaml
@@ -7,10 +7,8 @@ environment:
     SEED_DIR: /var/lib/snapd/seed
 
 prepare: |
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
-    fi
+    echo "This test needs test keys to be trusted"
+    SKIP [ "$TRUST_TEST_KEYS" = "false" ]
 
     snap pack "$TESTSLIB/snaps/basic18"
     snap download "--$CORE_CHANNEL" core
@@ -38,10 +36,7 @@ prepare: |
     cp ./basic18_1.0_all.snap "$SEED_DIR/snaps/basic.snap"
 
 restore: |
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
-    fi
+    SKIP
 
     rm -rf "$SEED_DIR"
     rm -f -- *.snap
@@ -49,10 +44,7 @@ restore: |
     systemctl start snapd.socket snapd.service
 
 execute: |
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
-    fi
+    SKIP
 
     echo "Start the daemon with an empty state"
     systemctl start snapd.service

--- a/tests/main/interfaces-autopilot-introspection/task.yaml
+++ b/tests/main/interfaces-autopilot-introspection/task.yaml
@@ -44,9 +44,7 @@ execute: |
     echo "And the snap app state can be introspected"
     tests.session -u test exec test-snapd-autopilot-consumer.consumer GetState | MATCH "my-ap-state"
 
-    if [ "$(snap debug confinement)" = partial ] ; then
-        exit 0
-    fi
+    SKIP [ "$(snap debug confinement)" = partial ]
 
     echo "When the plug is disconnected"
     snap disconnect test-snapd-autopilot-consumer:autopilot-introspection

--- a/tests/main/services-watchdog/task.yaml
+++ b/tests/main/services-watchdog/task.yaml
@@ -42,10 +42,8 @@ execute: |
     done
     systemctl show -p SubState snap.test-snapd-service-watchdog.direct-watchdog-ok | MATCH 'SubState=running'
 
-    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
-        # service watchdog does not appear to work in Ubuntu 14.04 at all
-        exit 0
-    fi
+    # service watchdog does not appear to work in Ubuntu 14.04 at all
+    SKIP [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]
 
     echo "Services not poking the watchdog fail due to watchdog"
     service=direct-watchdog-bad


### PR DESCRIPTION
This new SKIP command allows to simplify the way we check and exit from
tests.

SKIP needs to be implemented as part of spread code but first it is needed to agree how it should behave.

The idea is that SKIP receives a line, which determines if the phase has
to be skept. In case it evaluation is true, then the phase in exited
with 0. In case the SKIP does not receive any parameter, it will check
if the evaluation has been already done and in this case it will exit
the current phase.


