### PR TITLE
sandbox/cgroup: add tests for ParsePids

### DIFF
--- a/sandbox/cgroup/cgroup_test.go
+++ b/sandbox/cgroup/cgroup_test.go
@@ -236,6 +236,24 @@ func (s *cgroupSuite) TestProgGroupBadSelector(c *C) {
 	c.Check(group, Equals, "")
 }
 
+func (s *cgroupSuite) TestParsePid(c *C) {
+	pid, err := cgroup.ParsePid("10")
+	c.Assert(err, IsNil)
+	c.Check(pid, Equals, 10)
+	_, err = cgroup.ParsePid("")
+	c.Assert(err, ErrorMatches, `cannot parse pid ""`)
+	_, err = cgroup.ParsePid("-1")
+	c.Assert(err, ErrorMatches, `cannot parse pid "-1"`)
+	_, err = cgroup.ParsePid("foo")
+	c.Assert(err, ErrorMatches, `cannot parse pid "foo"`)
+	_, err = cgroup.ParsePid("12\x0034")
+	c.Assert(err.Error(), Equals, "cannot parse pid \"12\\x0034\"")
+	_, err = cgroup.ParsePid("ł")
+	c.Assert(err, ErrorMatches, `cannot parse pid "ł"`)
+	_, err = cgroup.ParsePid("1000000000000000000000000000000000000000000000")
+	c.Assert(err, ErrorMatches, `cannot parse pid "1000000000000000000000000000000000000000000000"`)
+}
+
 func (s *cgroupSuite) TestPidsHappy(c *C) {
 	err := os.MkdirAll(filepath.Join(s.rootDir, "group1/group2"), 0755)
 	c.Assert(err, IsNil)

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -21,6 +21,7 @@ package cgroup
 var (
 	Cgroup2SuperMagic  = cgroup2SuperMagic
 	ProbeCgroupVersion = probeCgroupVersion
+	ParsePid           = parsePid
 )
 
 func MockFsTypeForPath(mock func(string) (int64, error)) (restore func()) {


### PR DESCRIPTION
This existing function did not seem to carry any tests so I wrote some
earlier. This is taken from the big refresh app awareness backend
branch.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
