### PR TITLE
snap: add an activates-on property to apps for D-Bus activation

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -49,6 +49,8 @@ const (
 	RobustMountNamespaceUpdates
 	// UserDaemons controls availability of user mode service support.
 	UserDaemons
+	// DbusActivation controls whether snaps daemons can be activated via D-Bus
+	DbusActivation
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
 )
@@ -75,7 +77,8 @@ var featureNames = map[SnapdFeature]string{
 	ClassicPreservesXdgRuntimeDir: "classic-preserves-xdg-runtime-dir",
 	RobustMountNamespaceUpdates:   "robust-mount-namespace-updates",
 
-	UserDaemons: "user-daemons",
+	UserDaemons:    "user-daemons",
+	DbusActivation: "dbus-activation",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -48,6 +48,7 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.ClassicPreservesXdgRuntimeDir.String(), Equals, "classic-preserves-xdg-runtime-dir")
 	c.Check(features.RobustMountNamespaceUpdates.String(), Equals, "robust-mount-namespace-updates")
 	c.Check(features.UserDaemons.String(), Equals, "user-daemons")
+	c.Check(features.DbusActivation.String(), Equals, "dbus-activation")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 
@@ -70,6 +71,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	c.Check(features.RefreshAppAwareness.IsExported(), Equals, true)
 	c.Check(features.ClassicPreservesXdgRuntimeDir.IsExported(), Equals, true)
 	c.Check(features.UserDaemons.IsExported(), Equals, false)
+	c.Check(features.DbusActivation.IsExported(), Equals, false)
 }
 
 func (*featureSuite) TestIsEnabled(c *C) {
@@ -101,6 +103,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.ClassicPreservesXdgRuntimeDir.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.RobustMountNamespaceUpdates.IsEnabledWhenUnset(), Equals, true)
 	c.Check(features.UserDaemons.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.DbusActivation.IsEnabledWhenUnset(), Equals, false)
 }
 
 func (*featureSuite) TestControlFile(c *C) {

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -114,6 +114,14 @@ func SanitizePlugsSlots(snapInfo *snap.Info) {
 		delete(snapInfo.Slots, slotName)
 		for _, app := range snapInfo.Apps {
 			delete(app.Slots, slotName)
+
+			var activatesOn []*snap.SlotInfo
+			for _, slot := range app.ActivatesOn {
+				if slot.Name != slotName {
+					activatesOn = append(activatesOn, slot)
+				}
+			}
+			app.ActivatesOn = activatesOn
 		}
 		for _, hook := range snapInfo.Hooks {
 			delete(hook.Slots, slotName)

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -280,6 +280,7 @@ slots:
 apps:
     app:
         slots: [iface]
+        activates-on: [iface]
 hooks:
     install:
         slots: [iface]
@@ -324,9 +325,14 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
 }
 
 func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotInterface(c *C) {
-	snapInfo, err := snap.InfoFromSnapYaml([]byte(testInvalidSlotInterfaceYaml))
-	c.Assert(err, IsNil)
+	snapInfo := snaptest.MockInvalidInfo(c, testInvalidSlotInterfaceYaml, nil)
+	c.Check(snapInfo.Apps["app"].Slots, HasLen, 1)
+	c.Check(snapInfo.Apps["app"].ActivatesOn, HasLen, 1)
+	c.Check(snapInfo.Hooks["install"].Slots, HasLen, 1)
+	c.Check(snapInfo.Slots, HasLen, 1)
+	snap.SanitizePlugsSlots(snapInfo)
 	c.Check(snapInfo.Apps["app"].Slots, HasLen, 0)
+	c.Check(snapInfo.Apps["app"].ActivatesOn, HasLen, 0)
 	c.Check(snapInfo.Hooks["install"].Slots, HasLen, 0)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
 	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "testsnap" has bad plugs or slots: iface \(unknown interface "iface"\)`)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -265,6 +265,30 @@ func (f *fakeStore) snap(spec snapSpec, user *auth.UserState) (*snap.Info, error
 				DaemonScope: "user",
 			},
 		}
+	case "channel-for-dbus-activation":
+		slot := &snap.SlotInfo{
+			Snap:      info,
+			Name:      "dbus-slot",
+			Interface: "dbus",
+			Attrs: map[string]interface{}{
+				"bus":  "system",
+				"name": "org.example.Foo",
+			},
+			Apps: make(map[string]*snap.AppInfo),
+		}
+		info.Apps = map[string]*snap.AppInfo{
+			"dbus-daemon": {
+				Snap:        info,
+				Name:        "dbus-daemon",
+				Daemon:      "simple",
+				DaemonScope: snap.SystemDaemon,
+				ActivatesOn: []*snap.SlotInfo{slot},
+				Slots: map[string]*snap.SlotInfo{
+					slot.Name: slot,
+				},
+			},
+		}
+		slot.Apps["dbus-daemon"] = info.Apps["dbus-daemon"]
 	}
 
 	return info, nil

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -564,13 +564,16 @@ func validateFeatureFlags(st *state.State, info *snap.Info) error {
 		}
 	}
 
-	var hasUserService bool
+	var hasUserService, usesDbusActivation bool
 	for _, app := range info.Apps {
 		if app.IsService() && app.DaemonScope == snap.UserDaemon {
 			hasUserService = true
-			break
+		}
+		if len(app.ActivatesOn) != 0 {
+			usesDbusActivation = true
 		}
 	}
+
 	if hasUserService {
 		flag, err := features.Flag(tr, features.UserDaemons)
 		if err != nil {
@@ -578,6 +581,16 @@ func validateFeatureFlags(st *state.State, info *snap.Info) error {
 		}
 		if !flag {
 			return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.user-daemons' to true")
+		}
+	}
+
+	if usesDbusActivation {
+		flag, err := features.Flag(tr, features.DbusActivation)
+		if err != nil {
+			return err
+		}
+		if !flag {
+			return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.dbus-activation' to true")
 		}
 	}
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -2927,6 +2927,44 @@ func (s *snapmgrTestSuite) TestInstallUserDaemonsChecksFeatureFlag(c *C) {
 	c.Assert(err, ErrorMatches, "experimental feature disabled - test it by setting 'experimental.user-daemons' to true")
 }
 
+func (s *snapmgrTestSuite) TestInstallDbusActivationChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// D-Bus activation is disabled by default.
+	opts := &snapstate.RevisionOptions{Channel: "channel-for-dbus-activation"}
+	_, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "experimental feature disabled - test it by setting 'experimental.dbus-activation' to true")
+
+	// D-Bus activation can be explicitly enabled.
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.dbus-activation", true)
+	tr.Commit()
+	_, err = snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	// D-Bus activation can be explicitly disabled.
+	tr = config.NewTransaction(s.state)
+	tr.Set("core", "experimental.dbus-activation", false)
+	tr.Commit()
+	_, err = snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "experimental feature disabled - test it by setting 'experimental.dbus-activation' to true")
+
+	// The default empty value means "disabled"
+	tr = config.NewTransaction(s.state)
+	tr.Set("core", "experimental.dbus-activation", "")
+	tr.Commit()
+	_, err = snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "experimental feature disabled - test it by setting 'experimental.dbus-activation' to true")
+
+	// D-Bus activation is disabled when the controlling flag is reset to nil.
+	tr = config.NewTransaction(s.state)
+	tr.Set("core", "experimental.dbus-activation", nil)
+	tr.Commit()
+	_, err = snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "experimental feature disabled - test it by setting 'experimental.dbus-activation' to true")
+}
+
 func (s *snapmgrTestSuite) TestInstallValidatesInstanceNames(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/snap/info.go
+++ b/snap/info.go
@@ -854,7 +854,8 @@ type AppInfo struct {
 	// TODO: this should go away once we have more plumbing and can change
 	// things vs refactor
 	// https://github.com/snapcore/snapd/pull/794#discussion_r58688496
-	BusName string
+	BusName     string
+	ActivatesOn []*SlotInfo
 
 	Plugs   map[string]*PlugInfo
 	Slots   map[string]*SlotInfo

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -427,6 +427,17 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) error {
 			app.Slots[slotName] = slot
 			slot.Apps[appName] = app
 		}
+		for _, slotName := range yApp.ActivatesOn {
+			slot, ok := snap.Slots[slotName]
+			if !ok {
+				return fmt.Errorf("invalid activates-on value %q on app %q: slot not found", slotName, appName)
+			}
+			app.ActivatesOn = append(app.ActivatesOn, slot)
+			// Implicitly add the slot to the app
+			strk.markSlot(slot)
+			app.Slots[slotName] = slot
+			slot.Apps[appName] = app
+		}
 		for name, data := range yApp.Sockets {
 			app.Sockets[name] = &SocketInfo{
 				App:          app,
@@ -440,17 +451,6 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) error {
 				App:   app,
 				Timer: yApp.Timer,
 			}
-		}
-		for _, slotName := range yApp.ActivatesOn {
-			slot, ok := snap.Slots[slotName]
-			if !ok {
-				return fmt.Errorf("invalid activates-on value %q on app %q: slot not found", slotName, appName)
-			}
-			app.ActivatesOn = append(app.ActivatesOn, slot)
-			// Implicitly add the slot to the app
-			strk.markSlot(slot)
-			app.Slots[slotName] = slot
-			slot.Apps[appName] = app
 		}
 		// collect all common IDs
 		if app.CommonID != "" {

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -90,8 +90,9 @@ type appYaml struct {
 	SlotNames    []string         `yaml:"slots,omitempty"`
 	PlugNames    []string         `yaml:"plugs,omitempty"`
 
-	BusName  string `yaml:"bus-name,omitempty"`
-	CommonID string `yaml:"common-id,omitempty"`
+	BusName     string   `yaml:"bus-name,omitempty"`
+	ActivatesOn []string `yaml:"activates-on,omitempty"`
+	CommonID    string   `yaml:"common-id,omitempty"`
 
 	Environment strutil.OrderedMap `yaml:"environment,omitempty"`
 
@@ -377,6 +378,9 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) error {
 		if len(yApp.Sockets) > 0 {
 			app.Sockets = make(map[string]*SocketInfo, len(yApp.Sockets))
 		}
+		if len(yApp.ActivatesOn) > 0 {
+			app.ActivatesOn = make([]*SlotInfo, 0, len(yApp.ActivatesOn))
+		}
 		// Daemons default to being system daemons
 		if app.Daemon != "" && app.DaemonScope == "" {
 			app.DaemonScope = SystemDaemon
@@ -436,6 +440,17 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) error {
 				App:   app,
 				Timer: yApp.Timer,
 			}
+		}
+		for _, slotName := range yApp.ActivatesOn {
+			slot, ok := snap.Slots[slotName]
+			if !ok {
+				return fmt.Errorf("invalid activates-on value %q on app %q: slot not found", slotName, appName)
+			}
+			app.ActivatesOn = append(app.ActivatesOn, slot)
+			// Implicitly add the slot to the app
+			strk.markSlot(slot)
+			app.Slots[slotName] = slot
+			slot.Apps[appName] = app
 		}
 		// collect all common IDs
 		if app.CommonID != "" {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -566,6 +566,104 @@ func (s *ValidateSuite) TestAppWhitelistError(c *C) {
 	c.Check(err.Error(), Equals, `app description field 'command' contains illegal "x\n" (legal: '^[A-Za-z0-9/. _#:$-]*$')`)
 }
 
+func (s *ValidateSuite) TestAppActivatesOn(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+slots:
+  dbus-slot:
+    interface: dbus
+    bus: system
+apps:
+  server:
+    daemon: simple
+    activates-on: [dbus-slot]
+`))
+	c.Assert(err, IsNil)
+	app := info.Apps["server"]
+	c.Check(ValidateApp(app), IsNil)
+}
+
+func (s *ValidateSuite) TestAppActivatesOnNotDaemon(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+slots:
+  dbus-slot:
+apps:
+  server:
+    activates-on: [dbus-slot]
+`))
+	c.Assert(err, IsNil)
+	app := info.Apps["server"]
+	c.Check(ValidateApp(app), ErrorMatches, `activates-on is only applicable to services`)
+}
+
+func (s *ValidateSuite) TestAppActivatesOnSlotNotDbus(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+apps:
+  server:
+    daemon: simple
+    slots: [network-bind]
+    activates-on: [network-bind]
+`))
+	c.Assert(err, IsNil)
+	app := info.Apps["server"]
+	c.Check(ValidateApp(app), ErrorMatches, `invalid activates-on value "network-bind": slot does not use dbus interface`)
+}
+
+func (s *ValidateSuite) TestAppActivatesOnDaemonScopeMismatch(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+slots:
+  dbus-slot:
+    interface: dbus
+    bus: session
+apps:
+  server:
+    daemon: simple
+    activates-on: [dbus-slot]
+`))
+	c.Assert(err, IsNil)
+	app := info.Apps["server"]
+	c.Check(ValidateApp(app), ErrorMatches, `invalid activates-on value "dbus-slot": bus "session" does not match daemon-scope "system"`)
+
+	info, err = InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+slots:
+  dbus-slot:
+    interface: dbus
+    bus: system
+apps:
+  server:
+    daemon: simple
+    daemon-scope: user
+    activates-on: [dbus-slot]
+`))
+	c.Assert(err, IsNil)
+	app = info.Apps["server"]
+	c.Check(ValidateApp(app), ErrorMatches, `invalid activates-on value "dbus-slot": bus "system" does not match daemon-scope "user"`)
+}
+
+func (s *ValidateSuite) TestAppActivatesOnDuplicateApp(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+slots:
+  dbus-slot:
+    interface: dbus
+    bus: system
+apps:
+  server:
+    daemon: simple
+    activates-on: [dbus-slot]
+  dup:
+    daemon: simple
+    activates-on: [dbus-slot]
+`))
+	c.Assert(err, IsNil)
+	app := info.Apps["server"]
+	c.Check(ValidateApp(app), ErrorMatches, `invalid activates-on value "dbus-slot": slot is also activatable on app "dup"`)
+}
+
 // Validate
 
 func (s *ValidateSuite) TestDetectIllegalYamlBinaries(c *C) {


### PR DESCRIPTION
This PR is split out from #6258, containing just the code related to the snap.yaml syntax changes it introduces, plus logic to prevent its use until the rest lands.  In particular:

1. add a new `dbus-activation` feature flag.
2. add a preinstall check to forbid installation of a snap using `activates-on` if the feature flag is not set.

On the yaml side, `activates-on` is an array of slot names representing D-Bus names the app should be activated by.  The order of the slots should match the order the daemon acquires the bus names.  This way we can use the last slot to set the `BusName` for `Type=dbus` systemd services.  All slots listed in `activates-on` are implicitly added to the app.

On the Go side, `ActivatesOn` is a slice of `SlotInfo` pointers.  The following validation checks are performed:
1. when loading the yaml, check that names listed in `activates-on` reference slots that actually exist.
2. if an app has an `activates-on` property, ensure that it is a daemon.
3. any slot listed in `activates-on` must use the `dbus` interface.
4. the slot's bus must match the daemon' scope (i.e. system daemons can be activated from the system bus and user daemons can be activated from the session bus).
5. a slot can only be listed in the `activates-on` property of one app in the snap.

The original PR also removed support for the `bus-name` property, as we could get the same information from the final slot in `activates-on`.  I've left it as is in this PR to keep it self contained.