### PR TITLE
tests: fix the basic20 test for uc20 on external backend

### DIFF
--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -31,8 +31,11 @@ execute: |
     test -e /boot/grub/kernel.efi
 
     # ensure that our the-tool (and thus our snap-bootstrap ran)
+    # for external backend the initramfs is not rebuilt
     echo "Check that we booted with the rebuilt initramfs in the kernel snap"
-    test -e /writable/system-data/the-tool-ran
+    if [ "$SPREAD_BACKEND" != "external" ]; then
+        test -e /writable/system-data/the-tool-ran
+    fi
 
     # ensure we handled cloud-init, either we have:
     # a) cloud init is disabled


### PR DESCRIPTION
Skip a check in case the backend is external. This fails on beta validation.