### PR TITLE
tests: add debug for 20.04 prepare failure

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -661,6 +661,14 @@ setup_reflash_magic() {
     elif is_core20_system; then        
         core_name="core20"
     fi
+    # XXX: we get "error: too early for operation, device not yet
+    # seeded or device model not acknowledged" here sometimes. To
+    # understand that better show some debug output.
+    snap changes
+    snap tasks --last=seed || true
+    journalctl -u snapd
+    snap model --verbose
+    # remove the above debug lines once the mentioned bug is fixed
     snap install "--channel=${CORE_CHANNEL}" "$core_name"
     if is_core16_system || is_core18_system; then
         UNPACK_DIR="/tmp/$core_name-snap"


### PR DESCRIPTION
During the 20.04 prepare we sometimes get the error message:
```
2020-06-08T16:15:40.6726609Z + core_name=core20
2020-06-08T16:15:40.6726846Z + snap install --channel=edge core20
2020-06-08T16:15:40.6727109Z error: too early for operation, device not yet seeded or device model not acknowledged
```
C.f.
https://github.com/snapcore/snapd/pull/8722/checks?check_run_id=749363669

To understand this better this commit adds a bunch of debug lines
before this install is done.

