### PR TITLE
tests: fix bug waiting for snap command to be ready

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -915,11 +915,15 @@ prepare_ubuntu_core() {
     # Wait for the snap command to become available.
     if [ "$SPREAD_BACKEND" != "external" ]; then
         for i in $(seq 120); do
-            if [ "$(command -v snap)" = "/usr/bin/snap" ] && snap version | grep -q 'snapd +1337.*'; then
+            if [ "$(command -v snap)" = "/usr/bin/snap" ] && snap version | grep -E -q 'snapd +1337.*'; then
                 break
             fi
             sleep 1
         done
+        if [ "$i" = 120 ]; then
+            echo "cannot find snap command after $i seconds"
+            exit 1
+        fi
     fi
 
     # Wait for seeding to finish.

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -914,16 +914,8 @@ prepare_ubuntu_core() {
 
     # Wait for the snap command to become available.
     if [ "$SPREAD_BACKEND" != "external" ]; then
-        for i in $(seq 120); do
-            if [ "$(command -v snap)" = "/usr/bin/snap" ] && snap version | grep -E -q 'snapd +1337.*'; then
-                break
-            fi
-            sleep 1
-        done
-        if [ "$i" = 120 ]; then
-            echo "cannot find snap command after $i seconds"
-            exit 1
-        fi
+        # shellcheck disable=SC2016
+        retry -n 120 --wait 1 sh -c 'test "$(command -v snap)" = /usr/bin/snap && snap version | grep -E -q "snapd +1337.*"'
     fi
 
     # Wait for seeding to finish.


### PR DESCRIPTION
This commit fixes a bug when the prepare.sh waits for snap to
be ready. The code is using standard grep with an extended
regexp. This causes the code to timeout instead of stopping.
