### PR TITLE
[RFC] many: export tools from core/snapd to mount namespaces

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -390,7 +390,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			struct stat sb;
 			sc_must_snprintf(src, sizeof src, "/var/lib/snapd/export/%s/tools/snap-exec", *provider);
 			/* Check that snap-exec exists, the tools directory may be empty. */
-			if (stat(src, &sb) != 0) {
+			if (lstat(src, &sb) != 0) {
 				continue;
 			}
 			/* Mount the entire tools directory as /usr/lib/snapd inside the mount namespace. */

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -213,10 +213,9 @@
     mount options=(rw bind) @LIBEXECDIR@/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
-    # allow making re-execed host snap-exec available inside base snaps
-    mount options=(ro bind) @SNAP_MOUNT_DIR@/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
     # allow making snapd snap tools available inside base snaps
-    mount options=(ro bind) @SNAP_MOUNT_DIR@/snapd/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(rw bind) /var/lib/snapd/export/{core,snapd}/tools/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
     mount options=(rw bind) /usr/bin/snapctl -> /tmp/snap.rootfs_*/usr/bin/snapctl,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -33,6 +33,9 @@ var (
 	GlobalRootDir string
 
 	SnapMountDir string
+	// This is like SnapMountDir but always gives value true only
+	// from inside the snap mount namespace.
+	SnapMountDirInsideNs string
 
 	DistroLibExecDir string
 
@@ -270,6 +273,7 @@ func SetRootDir(rootdir string) {
 	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)
 	}
+	SnapMountDirInsideNs = filepath.Join(rootdir, defaultSnapMountDir)
 
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/", UserHomeSnapDir)

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -194,6 +194,7 @@ var templateCommon = `
   # snapctl and its requirements
   /usr/bin/snapctl ixr,
   /usr/lib/snapd/snapctl ixr,
+  /snap/{core,snapd}/*/usr/lib/snapd/snapctl ixr,
   @{PROC}/sys/net/core/somaxconn r,
   /run/snapd-snap.socket rw,
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -165,14 +165,15 @@ var templateCommon = `
   /etc/libnl-3/{classid,pktloc} r,      # apps that use libnl
 
   # For snappy reexec on 4.8+ kernels
-  /usr/lib/snapd/snap-exec m,
+  /{,snap/{core,snapd}/*/,var/lib/snapd/snap/{core,snapd}/*/}usr/lib/snapd/snap-exec m,
+  /{,snap/{core,snapd}/*/,var/lib/snapd/snap/{core,snapd}/*/}usr/lib/snapd/snap-exec ixr,
 
   # For gdb support
-  /usr/lib/snapd/snap-gdb-shim ixr,
+  /{,snap/{core,snapd}/*/,var/lib/snapd/snap/{core,snapd}/*/}usr/lib/snapd/snap-gdb-shim ixr,
 
   # For in-snap tab completion
   /etc/bash_completion.d/{,*} r,
-  /usr/lib/snapd/etelpmoc.sh ixr,               # marshaller (see complete.sh for out-of-snap unmarshal)
+  /{,snap/{core,snapd}/*/,var/lib/snapd/snap/{core,snapd}/*/}usr/lib/snapd/etelpmoc.sh ixr,               # marshaller (see complete.sh for out-of-snap unmarshal)
   /usr/share/bash-completion/bash_completion r, # user-provided completions (run in-snap) may use functions from here
 
   # uptime
@@ -193,8 +194,7 @@ var templateCommon = `
 
   # snapctl and its requirements
   /usr/bin/snapctl ixr,
-  /usr/lib/snapd/snapctl ixr,
-  /snap/{core,snapd}/*/usr/lib/snapd/snapctl ixr,
+  /{,snap/{core,snapd}/*/,var/lib/snapd/snap/{core,snapd}/*/}usr/lib/snapd/snapctl ixr,
   @{PROC}/sys/net/core/somaxconn r,
   /run/snapd-snap.socket rw,
 

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -73,6 +73,7 @@ func checkPreseedTaskStates(c *C, st *state.State) {
 		"prerequisites":    true,
 		"prepare-snap":     true,
 		"link-snap":        true,
+		"export-content":   true,
 		"mount-snap":       true,
 		"setup-profiles":   true,
 		"copy-snap-data":   true,

--- a/overlord/exportstate/exportmgr.go
+++ b/overlord/exportstate/exportmgr.go
@@ -113,7 +113,7 @@ func (m *ExportManager) exportOne(baseDir string, export *snap.Export) error {
 	switch export.Method {
 	case snap.ExportMethodSymlink:
 		// Do we have an existing file?
-		fi, err := os.Stat(publicName)
+		fi, err := os.Lstat(publicName)
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}

--- a/overlord/exportstate/exportmgr.go
+++ b/overlord/exportstate/exportmgr.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package exportstate
+
+import (
+	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type ExportManager struct {
+	state  *state.State
+	runner *state.TaskRunner
+}
+
+// Manager returns a new ExportManager.
+func Manager(s *state.State, runner *state.TaskRunner) *ExportManager {
+	manager := &ExportManager{state: s, runner: runner}
+	runner.AddHandler("export-content", manager.doExportContent, manager.undoExportContent)
+	runner.AddHandler("unexport-content", manager.doUnexportContent, manager.undoUnexportContent)
+	return manager
+}
+
+// Ensure implements StateManager.Ensure.
+func (m *ExportManager) Ensure() error {
+	return nil
+}
+
+func (m *ExportManager) readInfo(task *state.Task) (*snap.Info, error) {
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	snapsup, err := snapstate.TaskSnapSetup(task)
+	if err != nil {
+		return nil, err
+	}
+	return snapstate.Info(st, snapsup.InstanceName(), snapsup.Revision())
+}
+
+func (m *ExportManager) doExportContent(task *state.Task, tomb *tomb.Tomb) error {
+	info, err := m.readInfo(task)
+	if err != nil {
+		return err
+	}
+	return m.exportContent(task, info)
+}
+
+func (m *ExportManager) undoExportContent(task *state.Task, tomb *tomb.Tomb) error {
+	info, err := m.readInfo(task)
+	if err != nil {
+		return err
+	}
+	return m.unexportContent(task, info)
+}
+
+func (m *ExportManager) doUnexportContent(task *state.Task, tomb *tomb.Tomb) error {
+	info, err := m.readInfo(task)
+	if err != nil {
+		return err
+	}
+	return m.unexportContent(task, info)
+}
+
+func (m *ExportManager) undoUnexportContent(task *state.Task, tomb *tomb.Tomb) error {
+	info, err := m.readInfo(task)
+	if err != nil {
+		return err
+	}
+	return m.exportContent(task, info)
+}
+
+func (m *ExportManager) exportContent(task *state.Task, info *snap.Info) error {
+	return nil
+}
+
+func (m *ExportManager) unexportContent(task *state.Task, info *snap.Info) error {
+	return nil
+}

--- a/overlord/exportstate/exportmgr.go
+++ b/overlord/exportstate/exportmgr.go
@@ -24,8 +24,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/tomb.v2"
-
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -70,38 +68,6 @@ func (m *ExportManager) readInfo(task *state.Task) (*snap.Info, error) {
 		return nil, err
 	}
 	return snapstate.Info(st, snapsup.InstanceName(), snapsup.Revision())
-}
-
-func (m *ExportManager) doExportContent(task *state.Task, tomb *tomb.Tomb) error {
-	info, err := m.readInfo(task)
-	if err != nil {
-		return err
-	}
-	return m.exportContent(task, info)
-}
-
-func (m *ExportManager) undoExportContent(task *state.Task, tomb *tomb.Tomb) error {
-	info, err := m.readInfo(task)
-	if err != nil {
-		return err
-	}
-	return m.unexportContent(task, info)
-}
-
-func (m *ExportManager) doUnexportContent(task *state.Task, tomb *tomb.Tomb) error {
-	info, err := m.readInfo(task)
-	if err != nil {
-		return err
-	}
-	return m.unexportContent(task, info)
-}
-
-func (m *ExportManager) undoUnexportContent(task *state.Task, tomb *tomb.Tomb) error {
-	info, err := m.readInfo(task)
-	if err != nil {
-		return err
-	}
-	return m.exportContent(task, info)
 }
 
 func (m *ExportManager) exportContent(task *state.Task, info *snap.Info) error {

--- a/overlord/exportstate/exportstate.go
+++ b/overlord/exportstate/exportstate.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package exportstate implements the manager and state aspects responsible
+// for exporting content from snaps to the host system.
+package exportstate

--- a/overlord/exportstate/handlers.go
+++ b/overlord/exportstate/handlers.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package exportstate
+
+import (
+	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func (m *ExportManager) doExportContent(task *state.Task, tomb *tomb.Tomb) error {
+	info, err := m.readInfo(task)
+	if err != nil {
+		return err
+	}
+	return m.exportContent(task, info)
+}
+
+func (m *ExportManager) undoExportContent(task *state.Task, tomb *tomb.Tomb) error {
+	info, err := m.readInfo(task)
+	if err != nil {
+		return err
+	}
+	return m.unexportContent(task, info)
+}
+
+func (m *ExportManager) doUnexportContent(task *state.Task, tomb *tomb.Tomb) error {
+	info, err := m.readInfo(task)
+	if err != nil {
+		return err
+	}
+	return m.unexportContent(task, info)
+}
+
+func (m *ExportManager) undoUnexportContent(task *state.Task, tomb *tomb.Tomb) error {
+	info, err := m.readInfo(task)
+	if err != nil {
+		return err
+	}
+	return m.exportContent(task, info)
+}

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -315,6 +315,7 @@ var (
 		"copy-snap-data",
 		"setup-profiles",
 		"link-snap",
+		"export-content",
 		"auto-connect",
 		"set-auto-aliases",
 		"setup-aliases",
@@ -336,6 +337,7 @@ var (
 		"copy-snap-data",
 		"setup-profiles",
 		"link-snap",
+		"export-content",
 		"auto-connect",
 		"set-auto-aliases",
 		"setup-aliases",
@@ -386,10 +388,10 @@ func (s *servicectlSuite) TestQueuedCommands(c *C) {
 	for i := 1; i <= 2; i++ {
 		laneTasks := chg.LaneTasks(i)
 		c.Assert(taskKinds(laneTasks), DeepEquals, expectedTaskKinds)
-		c.Check(laneTasks[12].Summary(), Matches, `Run configure hook of .* snap if present`)
-		c.Check(laneTasks[14].Summary(), Equals, "stop of [test-snap.test-service]")
-		c.Check(laneTasks[15].Summary(), Equals, "start of [test-snap.test-service]")
-		c.Check(laneTasks[16].Summary(), Equals, "restart of [test-snap.test-service]")
+		c.Check(laneTasks[13].Summary(), Matches, `Run configure hook of .* snap if present`)
+		c.Check(laneTasks[15].Summary(), Equals, "stop of [test-snap.test-service]")
+		c.Check(laneTasks[16].Summary(), Equals, "start of [test-snap.test-service]")
+		c.Check(laneTasks[17].Summary(), Equals, "restart of [test-snap.test-service]")
 	}
 }
 
@@ -499,10 +501,10 @@ func (s *servicectlSuite) TestQueuedCommandsUpdateMany(c *C) {
 	for i := 1; i <= 2; i++ {
 		laneTasks := chg.LaneTasks(i)
 		c.Assert(taskKinds(laneTasks), DeepEquals, expectedTaskKinds)
-		c.Check(laneTasks[17].Summary(), Matches, `Run configure hook of .* snap if present`)
-		c.Check(laneTasks[19].Summary(), Equals, "stop of [test-snap.test-service]")
-		c.Check(laneTasks[20].Summary(), Equals, "start of [test-snap.test-service]")
-		c.Check(laneTasks[21].Summary(), Equals, "restart of [test-snap.test-service]")
+		c.Check(laneTasks[18].Summary(), Matches, `Run configure hook of .* snap if present`)
+		c.Check(laneTasks[20].Summary(), Equals, "stop of [test-snap.test-service]")
+		c.Check(laneTasks[21].Summary(), Equals, "start of [test-snap.test-service]")
+		c.Check(laneTasks[22].Summary(), Equals, "restart of [test-snap.test-service]")
 	}
 }
 
@@ -537,10 +539,10 @@ func (s *servicectlSuite) TestQueuedCommandsSingleLane(c *C) {
 
 	laneTasks := chg.LaneTasks(0)
 	c.Assert(taskKinds(laneTasks), DeepEquals, append(installTaskKinds, "exec-command", "exec-command", "exec-command"))
-	c.Check(laneTasks[12].Summary(), Matches, `Run configure hook of .* snap if present`)
-	c.Check(laneTasks[14].Summary(), Equals, "stop of [test-snap.test-service]")
-	c.Check(laneTasks[15].Summary(), Equals, "start of [test-snap.test-service]")
-	c.Check(laneTasks[16].Summary(), Equals, "restart of [test-snap.test-service]")
+	c.Check(laneTasks[13].Summary(), Matches, `Run configure hook of .* snap if present`)
+	c.Check(laneTasks[15].Summary(), Equals, "stop of [test-snap.test-service]")
+	c.Check(laneTasks[16].Summary(), Equals, "start of [test-snap.test-service]")
+	c.Check(laneTasks[17].Summary(), Equals, "restart of [test-snap.test-service]")
 }
 
 func (s *servicectlSuite) TestTwoServices(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3859,6 +3859,8 @@ func validateInstallTasks(c *C, tasks []*state.Task, name, revno string, flags i
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Make snap "%s" (%s) available to the system`, name, revno))
 	i++
+	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Export content from snap "%s" (%s) to the system`, name, revno))
+	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Automatically connect eligible plugs and slots of snap "%s"`, name))
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Set automatic aliases for snap "%s"`, name))
@@ -3900,6 +3902,8 @@ func validateRefreshTasks(c *C, tasks []*state.Task, name, revno string, flags i
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Setup snap "%s" (%s) security profiles`, name, revno))
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Make snap "%s" (%s) available to the system`, name, revno))
+	i++
+	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Export content from snap "%s" (%s) to the system`, name, revno))
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Automatically connect eligible plugs and slots of snap "%s"`, name))
 	i++

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/proxyconf"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/exportstate"
 	"github.com/snapcore/snapd/overlord/healthstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -99,6 +100,7 @@ type Overlord struct {
 	deviceMgr *devicestate.DeviceManager
 	cmdMgr    *cmdstate.CommandManager
 	shotMgr   *snapshotstate.SnapshotManager
+	xprtMgr   *exportstate.ExportManager
 	// proxyConf mediates the http proxy config
 	proxyConf func(req *http.Request) (*url.URL, error)
 }
@@ -177,6 +179,7 @@ func New(restartBehavior RestartBehavior) (*Overlord, error) {
 
 	o.addManager(cmdstate.Manager(s, o.runner))
 	o.addManager(snapshotstate.Manager(s, o.runner))
+	o.addManager(exportstate.Manager(s, o.runner))
 
 	if err := configstateInit(s, hookMgr); err != nil {
 		return nil, err

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -247,6 +247,11 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	addTask(linkSnap)
 	prev = linkSnap
 
+	// export content
+	exportContent := st.NewTask("export-content", fmt.Sprintf(i18n.G("Export content from snap %q%s to the system"), snapsup.InstanceName(), revisionStr))
+	addTask(exportContent)
+	prev = exportContent
+
 	// auto-connections
 	autoConnect := st.NewTask("auto-connect", fmt.Sprintf(i18n.G("Automatically connect eligible plugs and slots of snap %q"), snapsup.InstanceName()))
 	addTask(autoConnect)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -73,6 +73,7 @@ func verifyInstallTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.S
 		"copy-snap-data",
 		"setup-profiles",
 		"link-snap",
+		"export-content",
 	)
 	expected = append(expected,
 		"auto-connect",
@@ -876,6 +877,11 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/11"),
 		},
 		{
+			op:    "export-content:Doing",
+			name:  "some-snap",
+			revno: snap.R(11),
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap",
 			revno: snap.R(11),
@@ -902,14 +908,14 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap" (11) from channel "some-channel"`)
 
 	// check install-record present
-	mountTask := ta[len(ta)-11]
+	mountTask := ta[len(ta)-12]
 	c.Check(mountTask.Kind(), Equals, "mount-snap")
 	var installRecord backend.InstallRecord
 	c.Assert(mountTask.Get("install-record", &installRecord), IsNil)
 	c.Check(installRecord.TargetSnapExisted, Equals, false)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-8]
+	linkTask := ta[len(ta)-9]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap" (11) available to the system`)
 	startTask := ta[len(ta)-3]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap" (11) services`)
@@ -1053,6 +1059,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap_instance/11"),
 		},
 		{
+			op:    "export-content:Doing",
+			name:  "some-snap_instance",
+			revno: snap.R(11),
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap_instance",
 			revno: snap.R(11),
@@ -1079,7 +1090,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap_instance" (11) from channel "some-channel"`)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-8]
+	linkTask := ta[len(ta)-9]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap_instance" (11) available to the system`)
 	startTask := ta[len(ta)-3]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap_instance" (11) services`)
@@ -1160,7 +1171,7 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 	s.settle(c)
 	s.state.Lock()
 
-	mountTask := tasks[len(tasks)-11]
+	mountTask := tasks[len(tasks)-12]
 	c.Assert(mountTask.Kind(), Equals, "mount-snap")
 	var installRecord backend.InstallRecord
 	c.Assert(mountTask.Get("install-record", &installRecord), IsNil)
@@ -1238,6 +1249,11 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/11"),
+		},
+		{
+			op:    "export-content:Doing",
+			name:  "some-snap",
+			revno: snap.R(11),
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -1386,6 +1402,11 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/666"),
 		},
 		{
+			op:    "export-content:Doing",
+			name:  "some-snap",
+			revno: snap.R(666),
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap",
 			revno: snap.R(666),
@@ -1412,7 +1433,7 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap" (666) from channel "some-channel"`)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-8]
+	linkTask := ta[len(ta)-9]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap" (666) available to the system`)
 	startTask := ta[len(ta)-3]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap" (666) services`)
@@ -1549,6 +1570,11 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/42"),
 		},
 		{
+			op:    "export-content:Doing",
+			name:  "some-snap",
+			revno: snap.R(42),
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap",
 			revno: snap.R(42),
@@ -1575,7 +1601,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap" (42) from channel "some-channel"`)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-8]
+	linkTask := ta[len(ta)-9]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap" (42) available to the system`)
 	startTask := ta[len(ta)-3]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap" (42) services`)
@@ -1721,6 +1747,11 @@ version: 1.0`)
 			path: filepath.Join(dirs.SnapMountDir, "mock/x1"),
 		},
 		{
+			op:    "export-content:Doing",
+			name:  "mock",
+			revno: snap.R("x1"),
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "mock",
 			revno: snap.R("x1"),
@@ -1838,6 +1869,11 @@ epoch: 1*
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "mock/x3"),
+		},
+		{
+			op:    "export-content:Doing",
+			name:  "mock",
+			revno: snap.R("x3"),
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -1962,6 +1998,11 @@ epoch: 1*
 			path: filepath.Join(dirs.SnapMountDir, "mock/x1"),
 		},
 		{
+			op:    "export-content:Doing",
+			name:  "mock",
+			revno: snap.R("x1"),
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "mock",
 			revno: snap.R("x1"),
@@ -2020,7 +2061,7 @@ version: 1.0`)
 	s.state.Lock()
 
 	// ensure only local install was run, i.e. first actions are pseudo-action current
-	c.Assert(s.fakeBackend.ops.Ops(), HasLen, 9)
+	c.Assert(s.fakeBackend.ops.Ops(), HasLen, 10)
 	c.Check(s.fakeBackend.ops[0].op, Equals, "current")
 	c.Check(s.fakeBackend.ops[0].old, Equals, "<no-current>")
 	// and setup-snap
@@ -2205,6 +2246,11 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "core/11"),
 		},
 		{
+			op:    "export-content:Doing",
+			name:  "core",
+			revno: snap.R(11),
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "core",
 			revno: snap.R(11),
@@ -2262,6 +2308,11 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/42"),
+		},
+		{
+			op:    "export-content:Doing",
+			name:  "some-snap",
+			revno: snap.R(42),
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -2345,8 +2396,8 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsRunThrough(c *C) {
 	if len(chg1.Tasks()) < len(chg2.Tasks()) {
 		chg1, chg2 = chg2, chg1
 	}
-	c.Assert(taskKinds(chg1.Tasks()), HasLen, 28)
-	c.Assert(taskKinds(chg2.Tasks()), HasLen, 14)
+	c.Assert(taskKinds(chg1.Tasks()), HasLen, 30)
+	c.Assert(taskKinds(chg2.Tasks()), HasLen, 15)
 
 	// FIXME: add helpers and do a DeepEquals here for the operations
 }
@@ -2658,6 +2709,10 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 		op:   "link-snap",
 		path: filepath.Join(dirs.SnapMountDir, "snap-content-slot/11"),
 	}, {
+		op:    "export-content:Doing",
+		name:  "snap-content-slot",
+		revno: snap.R(11),
+	}, {
 		op:    "auto-connect:Doing",
 		name:  "snap-content-slot",
 		revno: snap.R(11),
@@ -2704,6 +2759,10 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 	}, {
 		op:   "link-snap",
 		path: filepath.Join(dirs.SnapMountDir, "snap-content-plug/42"),
+	}, {
+		op:    "export-content:Doing",
+		name:  "snap-content-plug",
+		revno: snap.R(42),
 	}, {
 		op:    "auto-connect:Doing",
 		name:  "snap-content-plug",
@@ -2996,7 +3055,7 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughUndoContextOptional(c *C) {
 	s.settle(c)
 	s.state.Lock()
 
-	mountTask := tasks[len(tasks)-11]
+	mountTask := tasks[len(tasks)-12]
 	c.Assert(mountTask.Kind(), Equals, "mount-snap")
 	var installRecord backend.InstallRecord
 	c.Assert(mountTask.Get("install-record", &installRecord), Equals, state.ErrNoState)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1276,6 +1276,7 @@ func (s *snapmgrTestSuite) TestEnableTasks(c *C) {
 		"prepare-snap",
 		"setup-profiles",
 		"link-snap",
+		"export-content",
 		"setup-aliases",
 		"start-snap-services",
 	})
@@ -7797,6 +7798,11 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 			revno: snap.R(7),
 		},
 		{
+			op:    "export-content:Doing",
+			name:  "some-snap",
+			revno: snap.R(7),
+		},
+		{
 			op: "update-aliases",
 		},
 	}
@@ -7957,6 +7963,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceEnableRunThrough(c *C) {
 		},
 		{
 			op:    "auto-connect:Doing",
+			name:  "some-snap_instance",
+			revno: snap.R(7),
+		},
+		{
+			op:    "export-content:Doing",
 			name:  "some-snap_instance",
 			revno: snap.R(7),
 		},

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -469,6 +469,7 @@ func verifyRemoveTasks(c *C, ts *state.TaskSet) {
 		"auto-disconnect",
 		"save-snapshot",
 		"remove-aliases",
+		"unexport-content",
 		"unlink-snap",
 		"remove-profiles",
 		"clear-snap",
@@ -483,6 +484,7 @@ func verifyCoreRemoveTasks(c *C, ts *state.TaskSet) {
 		"run-hook[remove]",
 		"auto-disconnect",
 		"remove-aliases",
+		"unexport-content",
 		"unlink-snap",
 		"remove-profiles",
 		"clear-snap",
@@ -1998,6 +2000,7 @@ func (s *snapmgrTestSuite) TestRemoveTasksAutoSnapshotDisabled(c *C) {
 		"run-hook[remove]",
 		"auto-disconnect",
 		"remove-aliases",
+		"unexport-content",
 		"unlink-snap",
 		"remove-profiles",
 		"clear-snap",
@@ -2026,6 +2029,7 @@ func (s *snapmgrTestSuite) TestRemoveTasksAutoSnapshotDisabledByPurgeFlag(c *C) 
 		"run-hook[remove]",
 		"auto-disconnect",
 		"remove-aliases",
+		"unexport-content",
 		"unlink-snap",
 		"remove-profiles",
 		"clear-snap",
@@ -5872,6 +5876,11 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 			name: "some-snap",
 		},
 		{
+			op:    "unexport-content:Doing",
+			name:  "some-snap",
+			revno: snap.R(7),
+		},
+		{
 			op:   "unlink-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 		},
@@ -6007,6 +6016,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 		{
 			op:   "remove-snap-aliases",
 			name: "some-snap_instance",
+		},
+		{
+			op:    "unexport-content:Doing",
+			name:  "some-snap_instance",
+			revno: snap.R(7),
 		},
 		{
 			op:   "unlink-snap",
@@ -6152,6 +6166,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 			name: "some-snap_instance",
 		},
 		{
+			op:    "unexport-content:Doing",
+			name:  "some-snap_instance",
+			revno: snap.R(7),
+		},
+		{
 			op:   "unlink-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
 		},
@@ -6253,6 +6272,11 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 		{
 			op:   "remove-snap-aliases",
 			name: "some-snap",
+		},
+		{
+			op:    "unexport-content:Doing",
+			name:  "some-snap",
+			revno: snap.R(7),
 		},
 		{
 			op:   "unlink-snap",
@@ -10356,13 +10380,14 @@ func (s *snapmgrTestSuite) TestRemoveMany(c *C) {
 	c.Assert(tts, HasLen, 2)
 	c.Check(removed, DeepEquals, []string{"one", "two"})
 
-	c.Assert(s.state.TaskCount(), Equals, 8*2)
+	c.Assert(s.state.TaskCount(), Equals, 9*2)
 	for i, ts := range tts {
 		c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
 			"stop-snap-services",
 			"run-hook[remove]",
 			"auto-disconnect",
 			"remove-aliases",
+			"unexport-content",
 			"unlink-snap",
 			"remove-profiles",
 			"clear-snap",
@@ -10918,6 +10943,11 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 			name: "ubuntu-core",
 		},
 		{
+			op:    "unexport-content:Doing",
+			name:  "ubuntu-core",
+			revno: snap.R(1),
+		},
+		{
 			op:   "unlink-snap",
 			path: filepath.Join(dirs.SnapMountDir, "ubuntu-core/1"),
 		},
@@ -11012,6 +11042,11 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 		{
 			op:   "remove-snap-aliases",
 			name: "ubuntu-core",
+		},
+		{
+			op:    "unexport-content:Doing",
+			name:  "ubuntu-core",
+			revno: snap.R(1),
 		},
 		{
 			op:   "unlink-snap",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1478,6 +1478,7 @@ func (s *snapmgrTestSuite) TestDisableTasks(c *C) {
 	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
 		"stop-snap-services",
 		"remove-aliases",
+		"unexport-content",
 		"unlink-snap",
 		"remove-profiles",
 	})
@@ -7867,6 +7868,11 @@ func (s *snapmgrTestSuite) TestDisableRunThrough(c *C) {
 			name: "some-snap",
 		},
 		{
+			op:    "unexport-content:Doing",
+			name:  "some-snap",
+			revno: snap.R(7),
+		},
+		{
 			op:   "unlink-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 		},
@@ -8036,6 +8042,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceDisableRunThrough(c *C) {
 		{
 			op:   "remove-snap-aliases",
 			name: "some-snap_instance",
+		},
+		{
+			op:    "unexport-content:Doing",
+			name:  "some-snap_instance",
+			revno: snap.R(7),
 		},
 		{
 			op:   "unlink-snap",

--- a/overlord/snapstate/snapstate_try_test.go
+++ b/overlord/snapstate/snapstate_try_test.go
@@ -97,6 +97,7 @@ func (s *snapmgrTestSuite) testTrySetsTryMode(flags snapstate.Flags, c *C, extra
 		"copy-snap-data",
 		"setup-profiles",
 		"link-snap",
+		"export-content",
 		"auto-connect",
 		"set-auto-aliases",
 		"setup-aliases",

--- a/snap/info.go
+++ b/snap/info.go
@@ -311,6 +311,8 @@ type Info struct {
 	// List of system users (usernames) this snap may use. The group of the same
 	// name must also exist.
 	SystemUsernames map[string]*SystemUsernameInfo
+
+	Export map[string]*Export
 }
 
 // StoreAccount holds information about a store account, for example of snap
@@ -334,6 +336,13 @@ type Layout struct {
 	Group    string      `json:"group,omitempty"`
 	Mode     os.FileMode `json:"mode,omitempty"`
 	Symlink  string      `json:"symlink,omitempty"`
+}
+
+// Export describes a file or directory exported from a snap to the host system.
+type Export struct {
+	Snap   *Info
+	Path   string // Path relative to the snap mount directory.
+	Method string // symlink, copy, bind mount ...
 }
 
 // String returns a simple textual representation of a layout.

--- a/snap/info.go
+++ b/snap/info.go
@@ -312,7 +312,10 @@ type Info struct {
 	// name must also exist.
 	SystemUsernames map[string]*SystemUsernameInfo
 
-	Export map[string]*Export
+	// List of files to export to the host.
+	HostExports []*Export
+	// List of files to export to snap mount namespaces.
+	NamespaceExports []*Export
 }
 
 // StoreAccount holds information about a store account, for example of snap
@@ -338,11 +341,18 @@ type Layout struct {
 	Symlink  string      `json:"symlink,omitempty"`
 }
 
-// Export describes a file or directory exported from a snap to the host system.
+type ExportMethod string
+
+const (
+	ExportMethodSymlink ExportMethod = "symlink"
+)
+
+// Export describes a file or directory exported from a snap to the host system or the snap mount namespace.
 type Export struct {
-	Snap   *Info
-	Path   string // Path relative to the snap mount directory.
-	Method string // symlink, copy, bind mount ...
+	Snap        *Info
+	PrivatePath string       // path relative to snap mount point in the appropriate mount namespace.
+	PublicPath  string       // path relative to /var/lib/snapd/exports/
+	Method      ExportMethod // symlink, copy, bind mount ...
 }
 
 // String returns a simple textual representation of a layout.

--- a/snap/info.go
+++ b/snap/info.go
@@ -1195,14 +1195,14 @@ func ReadInfo(name string, si *SideInfo) (*Info, error) {
 			"etelpmoc.sh",        // sourced inside the mount namespace
 			"info",               // read inside the mount namespace by other tools
 		}
-		info.Export = make(map[string]*Export, len(exportedFiles))
+		info.NamespaceExports = make([]*Export, 0, len(exportedFiles))
 		for _, fname := range exportedFiles {
-			publicName := fmt.Sprintf("%s/tools/%s", info.SnapName(), fname)
-			privateName := fmt.Sprintf("usr/lib/snapd/%s", fname)
-			info.Export[publicName] = &Export{
-				Path:   privateName,
-				Method: "symlink",
-			}
+			info.NamespaceExports = append(info.NamespaceExports, &Export{
+				Snap:        info,
+				PublicPath:  fmt.Sprintf("%s/tools/%s", info.SnapName(), fname),
+				PrivatePath: fmt.Sprintf("usr/lib/snapd/%s", fname),
+				Method:      ExportMethodSymlink,
+			})
 		}
 	}
 

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -307,6 +307,8 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		"SideInfo.Channel",
 		"DownloadInfo.AnonDownloadURL", // TODO: going away at some point
 		"SystemUsernames",
+		"HostExports",
+		"NamespaceExports",
 	}
 	var checker func(string, reflect.Value)
 	checker = func(pfx string, x reflect.Value) {


### PR DESCRIPTION
This branch contains a quick and dirty implementation of the approach "C" of
https://forum.snapcraft.io/t/12139 - which allows us to update snapd or core
snap freely and keeping updated tools visible to running snaps.

I did not add any tests, but if you run spread you can confirm that this is
indeed working as expected. The code in the new export manager is extremely
simplistic, and in a proper implementation would need to handle many more
cases.

The branch has some logical progression through subsequent patches but you can
see it as the following conceptual list:

* A snap can export content to the host, in a special location that nothing
  currently looks at. This way classic world needs to be adapted to look for
  the new content, with full consequences. I picked the location
  /var/lib/snapd/export/ as the root of exported files. Files can be exported,
  in this implementation, only as symlinks, although other options are possible
  for discussion.

* Similar to implicit slots, both the core snap *and* the snapd snap gain
  implicit export man that exposes their /usr/lib/snapd directory, as
  core/tools and snapd/tools respectively. Note that the exported directory is
  named after a snap (core and snapd) but in general that is not required.  For
  example, many snaps could export fonts to fonts/FONT_NAME or manual pages to
  man/manN/PAGE.N.

* The new export manager handles the new pair of tasks, export-content and
  unexport-content, which are sequenced immediately after link-snap and before
  unlink-snap. Conceptually the export manager should handle the state of what
  is exported from which snaps and how conflicts are resolved. In this naive
  implementation there are no conflicts so everything is just exported at all
  times.

* Lastly snap-confine is modified to bind mount a read-only view of
  /var/lib/snapd/exports/{snapd,core}/tools/ as /usr/lib/snapd/ so that snaps
  using core18 or core20 as base can get a copy of things like snap-exec and
  snapctl. The whole benefit comes from the fact that the tools directory doesn't
  need to be changed via the mount system anymore and that the export manager will
  rewrite the symlinks placed inside. So for example tools/snap-exec will point to
  /snap/snapd/$SNAP_REVISION/usr/lib/snapd/snap-exec - with the full path being
  visible inside the mount namespace.
