### PR TITLE
[RFC] many: add "system.service.snapd-autoimport.disable" setting

### DIFF
--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -332,6 +332,11 @@ func (x *cmdAutoImport) Execute(args []string) error {
 		return nil
 	}
 
+	if osutil.FileExists(dirs.SnapAssertsAutoImportDisabledFile) {
+		fmt.Fprintf(Stderr, "auto-import is disabled by config\n")
+		return nil
+	}
+
 	devices := x.Mount
 	if len(devices) == 0 {
 		// coldplug scenario, try all removable devices

--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -463,3 +463,19 @@ func (s *SnapSuite) TestAutoImportFromMount(c *C) {
 		filepath.Join(rootdir, "/tmp/snapd-auto-import-mount-1"),
 	})
 }
+
+func (s *SnapSuite) TestAutoImportAssertsDisabledByConfig(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	// pretend the auto-import is disabled
+	err := os.MkdirAll(filepath.Dir(dirs.SnapAssertsAutoImportDisabledFile), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(dirs.SnapAssertsAutoImportDisabledFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, "")
+	c.Check(s.Stderr(), Equals, "auto-import is disabled by config\n")
+}

--- a/data/systemd/snapd.autoimport.service.in
+++ b/data/systemd/snapd.autoimport.service.in
@@ -5,6 +5,8 @@ After=snapd.service snapd.socket snapd.seeded.service
 ConditionKernelCommandLine=|snap_core
 # TODO:UC20: only enable this in run mode?
 ConditionKernelCommandLine=|snapd_recovery_mode
+# allow disable via snap config
+ConditionPathExists=!/var/lib/snapd/auto-import/disabled
 
 [Service]
 Type=oneshot

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -68,6 +68,8 @@ var (
 	SnapAssertsSpoolDir   string
 	SnapSeqDir            string
 
+	SnapAssertsAutoImportDisabledFile string
+
 	SnapStateFile     string
 	SnapSystemKeyFile string
 
@@ -303,6 +305,9 @@ func SetRootDir(rootdir string) {
 	SnapCookieDir = filepath.Join(rootdir, snappyDir, "cookie")
 	SnapAssertsSpoolDir = filepath.Join(rootdir, "run/snapd/auto-import")
 	SnapSeqDir = filepath.Join(rootdir, snappyDir, "sequence")
+
+	// Keep in sync with data/systemd/snapd.autoimport.service
+	SnapAssertsAutoImportDisabledFile = filepath.Join(rootdir, snappyDir, "auto-import/disabled")
 
 	SnapStateFile = SnapStateFileUnder(rootdir)
 	SnapSystemKeyFile = filepath.Join(rootdir, snappyDir, "system-key")


### PR DESCRIPTION
We got requests to allow disable of the autoimport service
for some Core devices. This commit is one way of doing it.

It implements a `system.service.snapd-autoimport.disable` option
that will prevent both the systemd service from starting and
the udev rule from actually acting on any usb devices.

Note that this implementation will also disable any future
imports we may do like configuration.

