### PR TITLE
tests: fail in setup_reflash_magic() if there are snaps already

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -643,6 +643,14 @@ setup_reflash_magic() {
     # install the stuff we need
     distro_install_package kpartx busybox-static
 
+    # Ensure we don't have snapd already. On some ubuntu-20.04 images
+    # it seems like we have snapd/core18/lxd already installed 
+    if [ "$(find /snap -type d | wc -l)" -gt 1 ]; then
+        echo "reflash image not pristine, snaps already installed"
+        find /snap -type d
+        exit 1
+    fi
+
     distro_install_local_package "$GOHOME"/snapd_*.deb
     distro_clean_package_cache
 


### PR DESCRIPTION
This commit adds a hard error when setup_reflash_magic find that
there are already snaps installed. We saw errors in e.g.
https://github.com/snapcore/snapd/pull/8845/checks?check_run_id=757318867
when an image with snaps is used.

Note that most likely there is a real error lurking here somewhere
which will be tracked down separately.
