### PR TITLE
tests: wait after creating partitions with sfdisk

### DIFF
--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -55,6 +55,7 @@ prepare: |
     start=2048, size=2048, type=21686148-6449-6E6F-744E-656564454649, name="BIOS Boot"
     start=4096, size=2457600, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, name="ubuntu-seed"
     EOF
+    retry -n 3 --wait 1 test -e "${LOOP}p2"
     udevadm trigger --settle "${LOOP}p2"
     mkfs.vfat "${LOOP}p2"
     udevadm trigger --settle "${LOOP}p2"

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -33,6 +33,7 @@ prepare: |
     start=2048, size=2048, type=21686148-6449-6E6F-744E-656564454649, name="BIOS Boot"
     start=4096, size=2457600, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, name="ubuntu-seed"
     EOF
+    retry -n 3 --wait 1 test -e "${LOOP}p2"
     udevadm trigger --settle "${LOOP}p2"
     mkfs.vfat "${LOOP}p2"
     udevadm trigger --settle "${LOOP}p2"

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -36,6 +36,7 @@ prepare: |
     start=2048, size=2048, type=21686148-6449-6E6F-744E-656564454649, name="BIOS Boot"
     start=4096, size=2457600, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, name="ubuntu-seed"
     EOF
+    retry -n 3 --wait 1 test -e "${LOOP}p2"
     udevadm trigger --settle "${LOOP}p2"
     mkfs.vfat "${LOOP}p2"
     udevadm trigger --settle "${LOOP}p2"


### PR DESCRIPTION
The operation must have an asynchronous component as this failure was
spotted in the wild.

    + sfdisk /dev/loop1
    + cat
    Checking that no-one is using this disk right now ... OK

    Disk /dev/loop1: 9.32 GiB, 10000000000 bytes, 19531250 sectors
    Units: sectors of 1 * 512 = 512 bytes
    Sector size (logical/physical): 512 bytes / 512 bytes
    I/O size (minimum/optimal): 512 bytes / 512 bytes

    >>> Script header accepted.
    >>> Created a new GPT disklabel (GUID: FE2B733B-077C-5546-9370-ED645954F76D).
    /dev/loop1p1: Created a new partition 1 of type 'BIOS boot' and of size 1 MiB.
    /dev/loop1p2: Created a new partition 2 of type 'EFI System' and of size 1.2 GiB.
    /dev/loop1p3: Done.

    New situation:
    Disklabel type: gpt
    Disk identifier: FE2B733B-077C-5546-9370-ED645954F76D

    Device       Start     End Sectors  Size Type
    /dev/loop1p1  2048    4095    2048    1M BIOS boot
    /dev/loop1p2  4096 2461695 2457600  1.2G EFI System

    The partition table has been altered.
    Calling ioctl() to re-read partition table.
    Syncing disks.
    + udevadm trigger --settle /dev/loop1p2
    Failed to open the device '/dev/loop1p2': No such file or directory

It seems that by the time we run udevadm and pass a partition path that
partition device node has not been created yet.

As a workaround, use retry to give the test a chance to see the device
node before waiting for udev to settle.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
