### PR TITLE
tests: fail in setup_reflash_magic() if there is snapd state left

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -377,6 +377,8 @@ prepare_project() {
                 systemctl stop "$(basename "$f")" || true
                 rm -f "$f"
             done
+            # double check that purge really worked
+            test ! -d /var/lib/snapd
             ;;
         *)
             # snapd state directory must not exist when the package is not

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -643,6 +643,15 @@ setup_reflash_magic() {
     # install the stuff we need
     distro_install_package kpartx busybox-static
 
+    # Ensure we don't have snapd already installed, sometimes
+    # on 20.04 purge seems to fail, catch that for further
+    # debugging
+    if [ -e /var/lib/snapd/state.json ]; then
+        echo "reflash image not pristine, snaps already installed"
+        python3 -m json.tool < /var/lib/snapd/state.json
+        exit 1
+    fi
+
     distro_install_local_package "$GOHOME"/snapd_*.deb
     distro_clean_package_cache
 


### PR DESCRIPTION
We saw in
https://github.com/snapcore/snapd/pull/8845/checks?check_run_id=757318867
that setup_refresh_magic sometimes runs with snapd not fully
purged.

This commit adds extra checks to ensure that snapd purge really
worked and that no state is left. This should help track down
the above test failure.
