### PR TITLE
dirs: delete unused Cloud var, fix typo

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -332,7 +332,6 @@ func SetRootDir(rootdir string) {
 	SnapSystemdConfDir = SnapSystemdConfDirUnder(rootdir)
 	SnapBusPolicyDir = filepath.Join(rootdir, "/etc/dbus-1/system.d")
 
-	CloudMetaDataFile = filepath.Join(rootdir, "/var/lib/cloud/seed/nocloud-net/meta-data")
 	CloudInstanceDataFile = filepath.Join(rootdir, "/run/cloud-init/instance-data.json")
 
 	SnapUdevRulesDir = filepath.Join(rootdir, "/etc/udev/rules.d")

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -202,7 +202,7 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv
 
 	state.Lock()
 	defer state.Unlock()
-	// check snapd, core18, kernel, gadget
+	// check snapd, core20, kernel, gadget
 	_, err = snapstate.CurrentInfo(state, "snapd")
 	c.Check(err, IsNil)
 	_, err = snapstate.CurrentInfo(state, "core20")


### PR DESCRIPTION
This is not used by anything and seems to be leftover from something else.