### PR TITLE
interface/fwupd: add more policies for making fwupd upstream strict

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -71,6 +71,8 @@ const fwupdPermanentSlotAppArmor = `
   /sys/firmware/efi/efivars/** rw,
 
   # Allow write access for efi firmware updater
+  /boot/efi/{,**/} r,
+  /boot/efi/EFI/ubuntu/fwupd*.efi* rw,
   /boot/efi/EFI/ubuntu/fw/** rw,
 
   # Allow access from efivar library
@@ -129,11 +131,11 @@ const fwupdConnectedPlugAppArmor = `
   #   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
   #
   dbus send
-       bus=system
-       path="/org/freedesktop/resolve1"
-       interface="org.freedesktop.resolve1.Manager"
-       member="Resolve{Address,Hostname,Record,Service}"
-       peer=(name="org.freedesktop.resolve1"),
+      bus=system
+      path="/org/freedesktop/resolve1"
+      interface="org.freedesktop.resolve1.Manager"
+      member="Resolve{Address,Hostname,Record,Service}"
+      peer=(name="org.freedesktop.resolve1"),
 
   # Allow access to fwupd service
   dbus (receive, send)


### PR DESCRIPTION
To confine fwupd upstream to be strict, there are more rules that need
to be added into apparmor for several reasons:

* get ESP path from /boot/efi in order to update daemon status.
* allow fwupd to write fwupd*.efi to /boot/efi/EFI/ubuntu.

Thanks,
Woodrow