### PR TITLE
sysconfig/cloudinit: make callers of DisableCloudInit use WritableDefaultsDir

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -294,8 +294,10 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
 	}
-	cloudDir := sysconfig.WritableDefaultsDir(boot.InitramfsWritableDir)
-	if err := sysconfig.DisableCloudInit(cloudDir); err != nil {
+	// we need to put the file to disable cloud-init in the
+	// _writable_defaults dir for writable-paths(5) to install it properly
+	writableDefaultsDir := sysconfig.WritableDefaultsDir(boot.InitramfsWritableDir)
+	if err := sysconfig.DisableCloudInit(writableDefaultsDir); err != nil {
 		return err
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -138,7 +138,10 @@ func generateMountsModeInstall(mst *initramfsMountsState, recoverySystem string)
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
 	}
-	if err := sysconfig.DisableCloudInit(boot.InitramfsWritableDir); err != nil {
+	// we need to put the file to disable cloud-init in the
+	// _writable_defaults dir for writable-paths(5) to install it properly
+	writableDefaultsDir := sysconfig.WritableDefaultsDir(boot.InitramfsWritableDir)
+	if err := sysconfig.DisableCloudInit(writableDefaultsDir); err != nil {
 		return err
 	}
 
@@ -291,7 +294,8 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
 	}
-	if err := sysconfig.DisableCloudInit(boot.InitramfsWritableDir); err != nil {
+	cloudDir := sysconfig.WritableDefaultsDir(boot.InitramfsWritableDir)
+	if err := sysconfig.DisableCloudInit(cloudDir); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is to enable us to disable cloud-init not from the initramfs, i.e. when we are making direct changes to system-data/etc/cloud on the system.

Also add a doc-comment on DisableCloudInit about disabling this.