### PR TITLE
[RFC] tests/main/install-fontconfig-cache-gen: for bionic, focal use broken font

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -120,19 +120,7 @@ parts:
       cp -a fc-cache-xenial $SNAPCRAFT_PART_INSTALL/bin/fc-cache-v6
     prime:
       - bin/fc-cache-v6
-  # the version in Ubuntu 18.04 (cache v7)
-  fontconfig-bionic:
-    plugin: nil
-    build-packages: [python3-apt]
-    source: https://github.com/anonymouse64/fc-cache-static-builder.git
-    source-branch: fonts-are-silly
-    override-build: |
-      ./build-from-security.py bionic
-      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
-      cp -a fc-cache-bionic $SNAPCRAFT_PART_INSTALL/bin/fc-cache-v7
-    prime:
-      - bin/fc-cache-v7
-  # the version in Ubuntu 20.04 (cache v7.5ish????)
+  # the version in Ubuntu 20.04 (cache v7 + some new version?)
   fontconfig-focal:
     plugin: nil
     build-packages: [python3-apt, uuid-dev]
@@ -141,6 +129,6 @@ parts:
     override-build: |
       ./build-from-security.py focal
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
-      cp -a fc-cache-focal $SNAPCRAFT_PART_INSTALL/bin/fc-cache-v7.5
+      cp -a fc-cache-focal $SNAPCRAFT_PART_INSTALL/bin/fc-cache-v7
     prime:
-      - bin/fc-cache-v7.5
+      - bin/fc-cache-v7

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
 adopt-info: snapd-deb
 # build-base is needed here for snapcraft to build this snap as with "modern"
 # snapcraft
-build-base: core
+build-base: core18
 grade: stable
 license: GPL-3.0
 
@@ -37,8 +37,6 @@ parts:
       export DEBCONF_NONINTERACTIVE_SEEN=true
       sudo -E apt-get build-dep -y ./
       ./get-deps.sh --skip-unused-check
-      # set version after installing dependencies so we have all the tools here
-      snapcraftctl set-version "$(./mkversion.sh --output-only)"
     override-build: |
       # unset the LD_FLAGS and LD_LIBRARY_PATH vars that snapcraft sets for us
       # as those will point to the $SNAPCRAFT_STAGE which on re-builds will 
@@ -57,6 +55,10 @@ parts:
       # bother compressing it too much)
       dpkg-buildpackage -b -Zgzip -zfast
       dpkg-deb -x $(pwd)/../snapd_*.deb $SNAPCRAFT_PART_INSTALL
+      # set version as late as possible cause snapcraft is picky about setting 
+      # it and re-setting it, so only set the version if we had a successful 
+      # build
+      snapcraftctl set-version "$(./mkversion.sh --output-only)"
 
   # xdelta is used to enable delta downloads (even if the host does not have it)
   xdelta3:
@@ -109,7 +111,8 @@ parts:
   fontconfig-xenial:
     plugin: nil
     build-packages: [python3-apt]
-    source: https://github.com/snapcore/fc-cache-static-builder.git
+    source: https://github.com/anonymouse64/fc-cache-static-builder.git
+    source-branch: fonts-are-silly
     override-build: |
       ./build-from-security.py xenial
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
@@ -120,10 +123,23 @@ parts:
   fontconfig-bionic:
     plugin: nil
     build-packages: [python3-apt]
-    source: https://github.com/snapcore/fc-cache-static-builder.git
+    source: https://github.com/anonymouse64/fc-cache-static-builder.git
+    source-branch: fonts-are-silly
     override-build: |
       ./build-from-security.py bionic
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
       cp -a fc-cache-bionic $SNAPCRAFT_PART_INSTALL/bin/fc-cache-v7
     prime:
       - bin/fc-cache-v7
+  # the version in Ubuntu 20.04 (cache v7.5ish????)
+  fontconfig-focal:
+    plugin: nil
+    build-packages: [python3-apt, uuid-dev]
+    source: https://github.com/anonymouse64/fc-cache-static-builder.git
+    source-branch: fonts-are-silly
+    override-build: |
+      ./build-from-security.py focal
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      cp -a fc-cache-focal $SNAPCRAFT_PART_INSTALL/bin/fc-cache-v7.5
+    prime:
+      - bin/fc-cache-v7.5

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -35,6 +35,7 @@ parts:
       # install build dependencies
       export DEBIAN_FRONTEND=noninteractive
       export DEBCONF_NONINTERACTIVE_SEEN=true
+      sudo -E apt upgrade -y
       sudo -E apt-get build-dep -y ./
       ./get-deps.sh --skip-unused-check
     override-build: |

--- a/overlord/snapstate/backend/fontconfig.go
+++ b/overlord/snapstate/backend/fontconfig.go
@@ -31,7 +31,7 @@ var commandFromSystemSnap = cmdutil.CommandFromSystemSnap
 
 // updateFontconfigCaches always update the fontconfig caches
 func updateFontconfigCachesImpl() error {
-	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7", "fc-cache-v7.5"} {
+	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7"} {
 		cmd, err := commandFromSystemSnap("/bin/"+fc, "--system-only")
 		if err != nil {
 			return fmt.Errorf("cannot get %s from core: %v", fc, err)

--- a/overlord/snapstate/backend/fontconfig.go
+++ b/overlord/snapstate/backend/fontconfig.go
@@ -31,7 +31,7 @@ var commandFromSystemSnap = cmdutil.CommandFromSystemSnap
 
 // updateFontconfigCaches always update the fontconfig caches
 func updateFontconfigCachesImpl() error {
-	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7"} {
+	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7", "fc-cache-v7.5"} {
 		cmd, err := commandFromSystemSnap("/bin/"+fc, "--system-only")
 		if err != nil {
 			return fmt.Errorf("cannot get %s from core: %v", fc, err)

--- a/tests/main/install-fontconfig-cache-gen/task.yaml
+++ b/tests/main/install-fontconfig-cache-gen/task.yaml
@@ -44,7 +44,7 @@ restore: |
 
     # cleanup after ourselves
     # TODO: transition back to the snapd deb instead of the snapd snap
-    snap remove lxd snapcraft
+    snap remove lxd snapcraft || true
 
 execute: |
     if [ "$SPREAD_SYSTEM" = ubuntu-16.04-64 ]; then

--- a/tests/main/install-fontconfig-cache-gen/task.yaml
+++ b/tests/main/install-fontconfig-cache-gen/task.yaml
@@ -36,10 +36,8 @@ prepare: |
 restore: |
     if [ "$SPREAD_SYSTEM" = ubuntu-16.04-64 ]; then
         PKG=fonts-kiloji
-        NAME=kiloji
     else
         PKG=fonts-noto-color-emoji
-        NAME=NotoColorE
     fi
 
     apt autoremove -y "$PKG" || true

--- a/tests/main/install-fontconfig-cache-gen/task.yaml
+++ b/tests/main/install-fontconfig-cache-gen/task.yaml
@@ -4,6 +4,11 @@ summary: Check that install works
 # to install so that actual caches get generated
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64]
 
+debug: |
+    ls -lah /var/cache/fontconfig/
+    dpkg-reconfigure fontconfig
+    ls -lah /var/cache/fontconfig/
+
 prepare: |
     if [ "$SPREAD_SYSTEM" = ubuntu-16.04-64 ]; then
         PKG=fonts-kiloji

--- a/tests/main/install-fontconfig-cache-gen/task.yaml
+++ b/tests/main/install-fontconfig-cache-gen/task.yaml
@@ -20,6 +20,19 @@ prepare: |
     echo "ensure the font is now in the cache"
     fc-cat /var/cache/fontconfig/* 2>/dev/null | MATCH "$NAME"
 
+    # HACK HACK HACK - I fixed this in the snapd snap, so build that and install
+    # it here so we are using snapd from the snapd snap and not from the snapd
+    # deb
+    apt remove lxd lxc lxd-client -y
+    apt autoremove -y
+    snap install lxd 
+    snap install snapcraft --classic
+    lxd init --auto
+    cd /home/gopath/src/github.com/snapcore/snapd
+    snapcraft --use-lxd
+    ls -lah snapd*.snap
+    snap install --dangerous snapd_*.snap
+
 restore: |
     if [ "$SPREAD_SYSTEM" = ubuntu-16.04-64 ]; then
         PKG=fonts-kiloji
@@ -30,6 +43,10 @@ restore: |
     fi
 
     apt autoremove -y "$PKG" || true
+
+    # cleanup after ourselves
+    # TODO: transition back to the snapd deb instead of the snapd snap
+    snap remove lxd snapcraft
 
 execute: |
     if [ "$SPREAD_SYSTEM" = ubuntu-16.04-64 ]; then

--- a/tests/main/install-fontconfig-cache-gen/task.yaml
+++ b/tests/main/install-fontconfig-cache-gen/task.yaml
@@ -2,15 +2,42 @@ summary: Check that install works
 
 # limiting to ubuntu because we need a known fonts package
 # to install so that actual caches get generated
-systems: [ubuntu-16.04-64, ubuntu-18.04-64]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64]
 
 prepare: |
-    apt install -y fonts-kiloji
+    if [ "$SPREAD_SYSTEM" = ubuntu-16.04-64 ]; then
+        PKG=fonts-kiloji
+        NAME=kiloji
+    else
+        PKG=fonts-noto-color-emoji
+        NAME=NotoColorE
+    fi
+
+    echo "ensure the font is not already in the fontconfig cache before installing"
+    fc-cat /var/cache/fontconfig/* 2>/dev/null | not MATCH "$NAME"
+    apt update -yqq
+    apt install -y "$PKG"
+    echo "ensure the font is now in the cache"
+    fc-cat /var/cache/fontconfig/* 2>/dev/null | MATCH "$NAME"
 
 restore: |
-    apt autoremove -y fonts-kiloji
+    if [ "$SPREAD_SYSTEM" = ubuntu-16.04-64 ]; then
+        PKG=fonts-kiloji
+        NAME=kiloji
+    else
+        PKG=fonts-noto-color-emoji
+        NAME=NotoColorE
+    fi
+
+    apt autoremove -y "$PKG" || true
 
 execute: |
+    if [ "$SPREAD_SYSTEM" = ubuntu-16.04-64 ]; then
+        NAME=kiloji
+    else
+        NAME=NotoColorE
+    fi
+
     echo "With no fontconfig cache"
     rm /var/cache/fontconfig/*
 
@@ -18,3 +45,6 @@ execute: |
     snap install test-snapd-sh
     ls /var/cache/fontconfig/*.cache-6
     ls /var/cache/fontconfig/*.cache-7
+
+    echo "and the user installed font is in the cache"
+    fc-cat /var/cache/fontconfig/* 2>/dev/null | MATCH "$NAME"


### PR DESCRIPTION
This font currently does not work on bionic and focal with our fontconfig regen logic, but it's unclear why it doesn't work. Regardless, the test should really be expanded to ensure that specific fonts from the host system are indeed present in the fontconfig cache we generate as that appears to be the bug symptoms.

See https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1858636

I will be force pushing some random changes here to see if this is trivially fixable... 