### PR TITLE
sandbox/cgroup: improve pid parsing code

### DIFF
--- a/sandbox/cgroup/cgroup.go
+++ b/sandbox/cgroup/cgroup.go
@@ -208,49 +208,6 @@ func ProcGroup(pid int, matcher GroupMatcher) (string, error) {
 	return "", fmt.Errorf("cannot find %s cgroup path for pid %v", matcher, pid)
 }
 
-// PidsInGroup returns the list of process ID currently registered in a given cgroup
-func PidsInGroup(hierarchyMount, groupPath string) ([]int, error) {
-	// TODO: check whether hierarchyMount looks like a valid cgroup root
-	// (i.e. at cgroup.procs exists)
-	fname := filepath.Join(hierarchyMount, groupPath, "cgroup.procs")
-	file, err := os.Open(fname)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-	return parsePids(bufio.NewReader(file))
-}
-
-// parsePid parses a string as a process identifier.
-func parsePid(text string) (int, error) {
-	pid, err := strconv.Atoi(text)
-	if err != nil || (err == nil && pid <= 0) {
-		return 0, fmt.Errorf("cannot parse pid %q", text)
-	}
-	return pid, err
-}
-
-// parsePids parses a list of pids, one per line, from a reader.
-func parsePids(reader io.Reader) ([]int, error) {
-	scanner := bufio.NewScanner(reader)
-	var pids []int
-	for scanner.Scan() {
-		s := scanner.Text()
-		pid, err := parsePid(s)
-		if err != nil {
-			return nil, err
-		}
-		pids = append(pids, pid)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return pids, nil
-}
-
 // MockVersion sets the reported version of cgroup support. For use in testing only
 func MockVersion(mockVersion int, mockErr error) (restore func()) {
 	oldVersion, oldErr := probeVersion, probeErr

--- a/sandbox/cgroup/pids.go
+++ b/sandbox/cgroup/pids.go
@@ -1,0 +1,77 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cgroup
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// PidsInGroup returns the list of process ID currently registered in a given cgroup
+func PidsInGroup(hierarchyMount, groupPath string) ([]int, error) {
+	// TODO: check whether hierarchyMount looks like a valid cgroup root
+	// (i.e. at cgroup.procs exists)
+	fname := filepath.Join(hierarchyMount, groupPath, "cgroup.procs")
+	return pidsInFile(fname)
+}
+
+// pidsInFile returns the list of process IDs in a given file.
+func pidsInFile(fname string) ([]int, error) {
+	file, err := os.Open(fname)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return parsePids(bufio.NewReader(file))
+}
+
+// parsePids parses a list of pids, one per line, from a reader.
+func parsePids(reader io.Reader) ([]int, error) {
+	scanner := bufio.NewScanner(reader)
+	var pids []int
+	for scanner.Scan() {
+		s := scanner.Text()
+		pid, err := parsePid(s)
+		if err != nil {
+			return nil, err
+		}
+		pids = append(pids, pid)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return pids, nil
+}
+
+// parsePid parses a string as a process identifier.
+func parsePid(text string) (int, error) {
+	pid, err := strconv.Atoi(text)
+	if err != nil || (err == nil && pid <= 0) {
+		return 0, fmt.Errorf("cannot parse pid %q", text)
+	}
+	return pid, err
+}

--- a/sandbox/cgroup/pids_test.go
+++ b/sandbox/cgroup/pids_test.go
@@ -1,0 +1,93 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package cgroup_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/sandbox/cgroup"
+)
+
+type pidsSuite struct{}
+
+var _ = Suite(&pidsSuite{})
+
+func (s *pidsSuite) TestParsePid(c *C) {
+	pid, err := cgroup.ParsePid("10")
+	c.Assert(err, IsNil)
+	c.Check(pid, Equals, 10)
+	_, err = cgroup.ParsePid("")
+	c.Assert(err, ErrorMatches, `cannot parse pid ""`)
+	_, err = cgroup.ParsePid("-1")
+	c.Assert(err, ErrorMatches, `cannot parse pid "-1"`)
+	_, err = cgroup.ParsePid("foo")
+	c.Assert(err, ErrorMatches, `cannot parse pid "foo"`)
+	_, err = cgroup.ParsePid("12\x0034")
+	c.Assert(err.Error(), Equals, "cannot parse pid \"12\\x0034\"")
+	_, err = cgroup.ParsePid("ł")
+	c.Assert(err, ErrorMatches, `cannot parse pid "ł"`)
+	_, err = cgroup.ParsePid("1000000000000000000000000000000000000000000000")
+	c.Assert(err, ErrorMatches, `cannot parse pid "1000000000000000000000000000000000000000000000"`)
+}
+
+func (s *cgroupSuite) TestPidsHappy(c *C) {
+	err := os.MkdirAll(filepath.Join(s.rootDir, "group1/group2"), 0755)
+	c.Assert(err, IsNil)
+	g2Pids := []byte(`123
+234
+567
+`)
+	allPids := append(g2Pids, []byte(`999
+`)...)
+	err = ioutil.WriteFile(filepath.Join(s.rootDir, "group1/cgroup.procs"), allPids, 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(s.rootDir, "group1/group2/cgroup.procs"), g2Pids, 0755)
+	c.Assert(err, IsNil)
+
+	pids, err := cgroup.PidsInGroup(s.rootDir, "group1")
+	c.Assert(err, IsNil)
+	c.Assert(pids, DeepEquals, []int{123, 234, 567, 999})
+
+	pids, err = cgroup.PidsInGroup(s.rootDir, "group1/group2")
+	c.Assert(err, IsNil)
+	c.Assert(pids, DeepEquals, []int{123, 234, 567})
+
+	pids, err = cgroup.PidsInGroup(s.rootDir, "group.does.not.exist")
+	c.Assert(err, IsNil)
+	c.Assert(pids, IsNil)
+}
+
+func (s *cgroupSuite) TestPidsBadInput(c *C) {
+	err := os.MkdirAll(filepath.Join(s.rootDir, "group1"), 0755)
+	c.Assert(err, IsNil)
+	gPids := []byte(`123
+zebra
+567
+`)
+	err = ioutil.WriteFile(filepath.Join(s.rootDir, "group1/cgroup.procs"), gPids, 0755)
+	c.Assert(err, IsNil)
+
+	pids, err := cgroup.PidsInGroup(s.rootDir, "group1")
+	c.Assert(err, ErrorMatches, `cannot parse pid "zebra"`)
+	c.Assert(pids, IsNil)
+}


### PR DESCRIPTION
Move all the pid parsing code to pids.go and arrange in logical
progression. Add extra tests to improve coverage.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>