### PR TITLE
cmd/snap: do not show $PATH warning when executing under sudo on a known distro

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -321,10 +321,7 @@ func maybeWithSudoSecurePath() bool {
 		return false
 	}
 	// Known distros setting secure_path:
-	if !release.DistroLike("fedora", "opensuse") {
-		return false
-	}
-	return true
+	return release.DistroLike("fedora", "opensuse")
 }
 
 // show what has been done

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -312,6 +313,20 @@ func isSameRisk(tracking, current string) (bool, error) {
 	return trackingRisk == currentRisk, nil
 }
 
+func maybeWithSudoSecurePath() bool {
+	// Some distributions set secure_path to a known list of paths in
+	// /etc/sudoers. The snapd package currently has no means of overwriting
+	// or extending that setting.
+	if _, isSet := os.LookupEnv("SUDO_UID"); !isSet {
+		return false
+	}
+	// Known distros setting secure_path:
+	if !release.DistroLike("fedora", "opensuse") {
+		return false
+	}
+	return true
+}
+
 // show what has been done
 func showDone(cli *client.Client, names []string, op string, opts *client.SnapOptions, esc *escapes) error {
 	snaps, err := cli.List(names, nil)
@@ -319,7 +334,7 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 		return err
 	}
 
-	needsPathWarning := !isSnapInPath()
+	needsPathWarning := !isSnapInPath() && !maybeWithSudoSecurePath()
 	for _, snap := range snaps {
 		channelStr := ""
 		if snap.Channel != "" {

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -26,6 +26,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -37,8 +38,8 @@ import (
 	snap "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/progress/progresstest"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
-	"os"
 )
 
 type snapOpTestServer struct {
@@ -224,6 +225,34 @@ func (s *SnapOpSuite) TestInstallNoPATH(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(candidate\) 1.0 from Bar installed`)
 	c.Check(s.Stderr(), testutil.MatchesWrapped, `Warning: \S+/bin was not found in your \$PATH.*`)
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
+func (s *SnapOpSuite) TestInstallNoPATHMaybeResetBySudo(c *check.C) {
+	// PATH restored by test tear down
+	os.Setenv("PATH", "/bin:/usr/bin:/sbin:/usr/sbin")
+	if old, isset := os.LookupEnv("SUDO_UID"); isset {
+		defer os.Setenv("SUDO_UID", old)
+	}
+	os.Setenv("SUDO_UID", "1234")
+	restore := release.MockReleaseInfo(&release.OS{ID: "fedora"})
+	defer restore()
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":  "install",
+			"channel": "candidate",
+		})
+		s.srv.channel = "candidate"
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel", "candidate", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(candidate\) 1.0 from Bar installed`)
+	c.Check(s.Stderr(), check.HasLen, 0)
 	// ensure that the fake server api was actually hit
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }


### PR DESCRIPTION
Some distributions set sudo's secure_path to a list of known paths that does not
include the snap 'bin' directory. There is now way for the snapd package to
override or extend this variable.

For this reason, hide the warning on systems that are known be shipping such
setup.