### PR TITLE
workflow: test PR title as part of the static checks again

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,16 @@ jobs:
         # is relevant for go's import system.
         path: ./src/github.com/snapcore/snapd
 
+    - name: Check PR title
+      uses: dylanvann/check-pull-request-title@v1
+      with:
+        # cover most common cases:
+        # package: foo
+        # package, otherpackage/subpackage: this is a title
+        # tests/regression/lp-12341234: foo
+        # [RFC] foo: bar
+        pattern: '[a-zA-Z0-9_\-/,. \[\]{}]+: .*'
+
     - name: Cache Debian dependencies
       id: cache-deb-downloads
       uses: actions/cache@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,14 +32,14 @@ jobs:
         path: ./src/github.com/snapcore/snapd
 
     - name: Check PR title
-      uses: dylanvann/check-pull-request-title@v1
+      uses: deepakputhraya/action-pr-title@master
       with:
         # cover most common cases:
         # package: foo
         # package, otherpackage/subpackage: this is a title
         # tests/regression/lp-12341234: foo
         # [RFC] foo: bar
-        pattern: '[a-zA-Z0-9_\-/,. \[\]{}]+: .*'
+        regex: '[a-zA-Z0-9_\-/,. \[\]{}]+: .*'
 
     - name: Cache Debian dependencies
       id: cache-deb-downloads

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,12 @@ jobs:
       GOROOT: ""
       # XXX: only skip format checks on 1.13+
       SKIP_GOFMT: 1
+      # XXX: compat env for "check-pr-title.py" in "run-checks", can go
+      #      once we switch away from that. Note that we cannot currently
+      #      use a github action check (like deepakputhraya/action-pr-title)
+      #      because an update of the PR title in the github UI is not visible
+      #      to the github action.
+      TRAVIS_PULL_REQUEST: ${{ github.event.number }}
     strategy:
       # we cache successful runs so it's fine to keep going
       fail-fast: false      
@@ -30,16 +36,6 @@ jobs:
         # NOTE: checkout the code in a fixed location, even for forks, as this
         # is relevant for go's import system.
         path: ./src/github.com/snapcore/snapd
-
-    - name: Check PR title
-      uses: deepakputhraya/action-pr-title@master
-      with:
-        # cover most common cases:
-        # package: foo
-        # package, otherpackage/subpackage: this is a title
-        # tests/regression/lp-12341234: foo
-        # [RFC] foo: bar
-        regex: '[a-zA-Z0-9_\-/,. \[\]{}]+: .*'
 
     - name: Cache Debian dependencies
       id: cache-deb-downloads

--- a/run-checks
+++ b/run-checks
@@ -150,17 +150,9 @@ if [ "$STATIC" = 1 ]; then
     echo Checking docs
     ./mdlint.py ./*.md docs/*.md
 
-    # XXX: obsolete
     if [ -n "${TRAVIS_PULL_REQUEST:-}" ] && [ "${TRAVIS_PULL_REQUEST:-}" != "false" ]; then
-        echo "Checking pull request summary"
+        echo Checking pull request summary
         ./check-pr-title.py "$TRAVIS_PULL_REQUEST"
-    fi
-    # XXX: is there a better way on GH?
-    if [ -n "${GITHUB_EVENT_PATH:-}" ]; then
-        set -x
-        echo "Checking pull request summary"
-        PR_TITLE="$(jq -r .pull_request.title $GITHUB_EVENT_PATH)"
-        ./check-pr-title.py "$PR_TITLE"
     fi
 
     if [ -z "${SKIP_GOFMT:-}" ]; then

--- a/run-checks
+++ b/run-checks
@@ -150,6 +150,8 @@ if [ "$STATIC" = 1 ]; then
     echo Checking docs
     ./mdlint.py ./*.md docs/*.md
 
+    # XXX: remove once we can use an action, see workflows/test.yaml for
+    #      details why we still use this script
     if [ -n "${TRAVIS_PULL_REQUEST:-}" ] && [ "${TRAVIS_PULL_REQUEST:-}" != "false" ]; then
         echo Checking pull request summary
         ./check-pr-title.py "$TRAVIS_PULL_REQUEST"

--- a/run-checks
+++ b/run-checks
@@ -150,9 +150,17 @@ if [ "$STATIC" = 1 ]; then
     echo Checking docs
     ./mdlint.py ./*.md docs/*.md
 
+    # XXX: obsolete
     if [ -n "${TRAVIS_PULL_REQUEST:-}" ] && [ "${TRAVIS_PULL_REQUEST:-}" != "false" ]; then
-        echo Checking pull request summary
+        echo "Checking pull request summary"
         ./check-pr-title.py "$TRAVIS_PULL_REQUEST"
+    fi
+    # XXX: is there a better way on GH?
+    if [ -n "${GITHUB_EVENT_PATH:-}" ]; then
+        set -x
+        echo "Checking pull request summary"
+        PR_TITLE="$(jq -r .pull_request.title $GITHUB_EVENT_PATH)"
+        ./check-pr-title.py "$PR_TITLE"
     fi
 
     if [ -z "${SKIP_GOFMT:-}" ]; then


### PR DESCRIPTION
When transitioning to GH actions we lost the check for the
pr title syntax. This commit re-adds it.

