### PR TITLE
interfaces: add system-source-code for access to /usr/src

### DIFF
--- a/interfaces/builtin/system_source_code.go
+++ b/interfaces/builtin/system_source_code.go
@@ -20,7 +20,7 @@
 package builtin
 
 // https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#usrsrcSourceCode
-const systemSourceCodeSummary = `allows read-only access to /usr/src of the system`
+const systemSourceCodeSummary = `allows read-only access to /usr/src on the system`
 
 // Manually connected since this reveals kernel config, patches, etc of the
 // running system which may or may not correspond to public distro packages

--- a/interfaces/builtin/system_source_code.go
+++ b/interfaces/builtin/system_source_code.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+// https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#usrsrcSourceCode
+const systemSourceCodeSummary = `allows read-only access to /usr/src of the system`
+
+// Manually connected since this reveals kernel config, patches, etc of the
+// running system which may or may not correspond to public distro packages
+// as mapped from 'uname -r'
+const systemSourceCodeBaseDeclarationSlots = `
+  system-source-code:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const systemSourceCodeConnectedPlugAppArmor = `
+# Description: can access /usr/src for kernel headers, etc
+/usr/src/{,**} r,
+`
+
+type systemSourceCodeInterface struct {
+	commonInterface
+}
+
+func init() {
+	registerIface(&systemSourceCodeInterface{
+		commonInterface: commonInterface{
+			name:                  "system-source-code",
+			summary:               systemSourceCodeSummary,
+			implicitOnCore:        true,
+			implicitOnClassic:     true,
+			baseDeclarationSlots:  systemSourceCodeBaseDeclarationSlots,
+			connectedPlugAppArmor: systemSourceCodeConnectedPlugAppArmor,
+		},
+	})
+}

--- a/interfaces/builtin/system_source_code_test.go
+++ b/interfaces/builtin/system_source_code_test.go
@@ -87,7 +87,7 @@ func (s *systemSourceCodeSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, true)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
-	c.Assert(si.Summary, Equals, `allows read-only access to /usr/src of the system`)
+	c.Assert(si.Summary, Equals, `allows read-only access to /usr/src on the system`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "system-source-code")
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
 }

--- a/interfaces/builtin/system_source_code_test.go
+++ b/interfaces/builtin/system_source_code_test.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type systemSourceCodeSuite struct {
+	iface        interfaces.Interface
+	coreSlotInfo *snap.SlotInfo
+	coreSlot     *interfaces.ConnectedSlot
+	plugInfo     *snap.PlugInfo
+	plug         *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&systemSourceCodeSuite{iface: builtin.MustInterface("system-source-code")})
+
+const systemSourceCodeConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [system-source-code]
+`
+
+const systemSourceCodeCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  system-source-code:
+`
+
+func (s *systemSourceCodeSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, systemSourceCodeConsumerYaml, nil, "system-source-code")
+	s.coreSlot, s.coreSlotInfo = MockConnectedSlot(c, systemSourceCodeCoreYaml, nil, "system-source-code")
+}
+
+func (s *systemSourceCodeSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *systemSourceCodeSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "system-source-code")
+}
+
+func (s *systemSourceCodeSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.coreSlotInfo), IsNil)
+}
+
+func (s *systemSourceCodeSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *systemSourceCodeSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: can access /usr/src for kernel headers, etc")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/usr/src/{,**} r,")
+}
+
+func (s *systemSourceCodeSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows read-only access to /usr/src of the system`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "system-source-code")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *systemSourceCodeSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -161,6 +161,9 @@ apps:
   system-packages-doc:
     command: bin/run
     plugs: [ system-packages-doc ]
+  system-source-code:
+    command: bin/run
+    plugs: [ system-source-code ]
   hostname-control:
     command: bin/run
     plugs: [ hostname-control ]


### PR DESCRIPTION
I went back and forth on the name before finally landing on system-source-code. Thoughts:

* usr-src: this is accurate and understandable, but leaves no room for extending the interface
* system-usr-src: same as above
* system-source-code: this seems to convey the best balance of what it is, how the FHS defines it and allows for future additions

Adding the 'Needs Samuele review' to finalize the name.

Note, /usr/src is already handled by snap-confine with accesses already allowed via `system-trace` so mount rules are not needed.

References:
* https://forum.snapcraft.io/t/request-for-classic-confinement-device-tree-compiler/17490/13
* https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#usrsrcSourceCode