### PR TITLE
interfaces: add gconf interface

### DIFF
--- a/interfaces/builtin/gconf.go
+++ b/interfaces/builtin/gconf.go
@@ -1,0 +1,74 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const gconfSummary = `allows access to any gconf item of the current user`
+
+// Manually connected since gconf is a global database for GNOME desktop and
+// application settings and offers no application isolation. Modern
+// applications should use dconf/gsettings instead and this interface is
+// provided for old codebases that cannot be migrated.
+const gconfBaseDeclarationSlots = `
+  gconf:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const gconfConnectedPlugAppArmor = `
+# Description: Can access gconf databases from the user's session.
+
+#include <abstractions/dbus-session-strict>
+
+# gconf_client_get_default() is used by all applications and will autostart
+# gconfd-2, but don't require label=unconfined since AssumedAppArmorLabel may
+# not be set. Once started, gconfd-2 remains running so the other APIs can use
+# label=unconfined. See gconf/gconf-dbus-utils.h
+dbus (send)
+    bus=session
+    path=/org/gnome/GConf/Server
+    member=Get{,Default}Database
+    peer=(name=org.gnome.GConf),
+
+# receive notifications and server messages
+dbus (receive)
+    bus=session
+    path=/org/gnome/GConf/{Client,Server}
+    interface=org.gnome.GConf.{Client,Server}
+    peer=(label=unconfined),
+
+# allow all operations on the database
+dbus (send)
+    bus=session
+    path=/org/gnome/GConf/Database/*
+    interface=org.gnome.GConf.Database
+    peer=(label=unconfined),
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "gconf",
+		summary:               gconfSummary,
+		implicitOnClassic:     true,
+		connectedPlugAppArmor: gconfConnectedPlugAppArmor,
+		baseDeclarationSlots:  gconfBaseDeclarationSlots,
+	})
+}

--- a/interfaces/builtin/gconf.go
+++ b/interfaces/builtin/gconf.go
@@ -19,7 +19,7 @@
 
 package builtin
 
-const gconfSummary = `allows access to any gconf item of the current user`
+const gconfSummary = `allows access to any item from the legacy gconf configuration system for the current user`
 
 // Manually connected since gconf is a global database for GNOME desktop and
 // application settings and offers no application isolation. Modern

--- a/interfaces/builtin/gconf_test.go
+++ b/interfaces/builtin/gconf_test.go
@@ -1,0 +1,103 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type gconfInterfaceSuite struct {
+	iface        interfaces.Interface
+	coreSlotInfo *snap.SlotInfo
+	coreSlot     *interfaces.ConnectedSlot
+	plugInfo     *snap.PlugInfo
+	plug         *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&gconfInterfaceSuite{
+	iface: builtin.MustInterface("gconf"),
+})
+
+const gconfConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [gconf]
+`
+
+const gconfCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  gconf:
+`
+
+func (s *gconfInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, gconfConsumerYaml, nil, "gconf")
+	s.coreSlot, s.coreSlotInfo = MockConnectedSlot(c, gconfCoreYaml, nil, "gconf")
+}
+
+func (s *gconfInterfaceSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *gconfInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "gconf")
+}
+
+func (s *gconfInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.coreSlotInfo), IsNil)
+}
+
+func (s *gconfInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *gconfInterfaceSuite) TestAppArmorSpec(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access gconf databases from the user's session.")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "interface=org.gnome.GConf.Database")
+}
+
+func (s *gconfInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to any gconf item of the current user`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "gconf")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *gconfInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/gconf_test.go
+++ b/interfaces/builtin/gconf_test.go
@@ -93,7 +93,7 @@ func (s *gconfInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
-	c.Assert(si.Summary, Equals, `allows access to any gconf item of the current user`)
+	c.Assert(si.Summary, Equals, `allows access to any item from the legacy gconf configuration system for the current user`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "gconf")
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
 }

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -128,6 +128,9 @@ apps:
   accounts-service:
     command: bin/run
     plugs: [ accounts-service ]
+  gconf:
+    command: bin/run
+    plugs: [ gconf ]
   gpg-keys:
     command: bin/run
     plugs: [ gpg-keys ]


### PR DESCRIPTION
Add a gconf interface to support old GNOME desktop libraries and
applications. The interface is manually connected since gconf is a
global database for GNOME desktop and application settings and offers no
application isolation. Modern applications should use dconf/gsettings
instead and this interface is provided for old codebases that cannot be
migrated.

References:
* https://gitlab.gnome.org/Archive/gconf
* https://gitlab.gnome.org/Archive/gconf/-/blob/master/gconf/gconf-dbus-utils.h#L28