### PR TITLE
tests/prepare-restore.sh: reset-failed systemd-journald before restarting

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -519,6 +519,7 @@ prepare_suite_each() {
         "$TESTSLIB"/reset.sh --reuse-core
     fi
     # Restart journal log and reset systemd journal cursor.
+    systemctl reset-failed systemd-journald.service
     if ! systemctl restart systemd-journald.service; then
         systemctl status systemd-journald.service || true
         echo "Failed to restart systemd-journald.service, exiting..."


### PR DESCRIPTION
This has failed in tests recently like this one:

```
+ systemctl restart systemd-journald.service
Job for systemd-journald.service failed because start of the service was attempted too often. See "systemctl status systemd-journald.service" and "journalctl -xe" for details.
To force a start use "systemctl reset-failed systemd-journald.service" followed by "systemctl start systemd-journald.service" again.
+ systemctl status systemd-journald.service
● systemd-journald.service - Journal Service
   Loaded: loaded (/usr/lib/systemd/system/systemd-journald.service; static; vendor preset: disabled)
  Drop-In: /etc/systemd/system/systemd-journald.service.d
           └─no-start-limit.conf
   Active: failed (Result: start-limit) since Mon 2020-06-15 19:23:07 UTC; 28ms ago
     Docs: man:systemd-journald.service(8)
           man:journald.conf(5)
  Process: 3166 ExecStart=/usr/lib/systemd/systemd-journald (code=exited, status=0/SUCCESS)
 Main PID: 3166 (code=exited, status=0/SUCCESS)
   Status: "Processing requests..."

Jun 15 19:23:06 may201530-015177 systemd-journal[3166]: Runtime journal is using 24.0M (max allowed 184.6M, trying to leave 276.9M free of 1.7G available → current limit 184.6M).
Jun 15 19:23:06 may201530-015177 systemd-journal[3166]: Journal started
Jun 15 19:23:07 may201530-015177 systemd-journal[3166]: Journal stopped
+ true
+ echo 'Failed to restart systemd-journald.service, exiting...'
Failed to restart systemd-journald.service, exiting...
+ exit 1
```