### PR TITLE
tests/lib/prepare-restore.sh: if we failed to purge snapd deb, ls /var/lib/snapd

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -378,12 +378,20 @@ prepare_project() {
                 rm -f "$f"
             done
             # double check that purge really worked
-            test ! -d /var/lib/snapd
+            if [ -d /var/lib/snapd ]; then
+                echo "# /var/lib/snapd"
+                ls -lR /var/lib/snapd || true
+                exit 1
+            fi
             ;;
         *)
             # snapd state directory must not exist when the package is not
             # installed
-            test ! -d /var/lib/snapd
+            if [ -d /var/lib/snapd ]; then
+                echo "# /var/lib/snapd"
+                ls -lR /var/lib/snapd || true
+                exit 1
+            fi
             ;;
     esac
 


### PR DESCRIPTION


Ideally, the same statement we have in the debug-each defined in the global
spread.yaml would have run, but for some reason spread does not run the
debug-each when it fails to prepare the project, so give some debug info if this
fails here.