### PR TITLE
interfaces: misc small interface updates

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -266,6 +266,7 @@ var templateCommon = `
   @{PROC}/sys/kernel/yama/ptrace_scope r,
   @{PROC}/sys/kernel/shmmax r,
   @{PROC}/sys/fs/file-max r,
+  @{PROC}/sys/fs/file-nr r,
   @{PROC}/sys/fs/inotify/max_* r,
   @{PROC}/sys/kernel/pid_max r,
   @{PROC}/sys/kernel/random/boot_id r,

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -241,6 +241,15 @@ dbus (send)
 # parallel-installs: this leaks read access to desktop files owned by keyed
 # instances of @{SNAP_NAME} to @{SNAP_NAME} snap
 /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
+
+# glib-networking's GLib proxy (different than the portal's proxy service
+# org.freedesktop.portal.ProxyResolver)
+dbus (send)
+    bus=session
+    path=/org/gtk/GLib/PACRunner
+    interface=org.gtk.GLib.PACRunner
+    member=Lookup
+    peer=(label=unconfined),
 `
 
 const desktopLegacyConnectedPlugSecComp = `

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -186,7 +186,12 @@ inotify_init
 inotify_init1
 inotify_rm_watch
 
-# TIOCSTI allows for faking input (man tty_ioctl)
+# ioctl() mediation currently primarily relies on Linux capabilities as well as
+# the initial syscall for the fd to pass to ioctl(). See 'man capabilities'
+# and 'man ioctl_list'. TIOCSTI requires CAP_SYS_ADMIN but allows for faking
+# input (man tty_ioctl), so we disallow it to prevent snaps plugging interfaces
+# with 'capability sys_admin' from interfering with other snaps or the
+# unconfined user's terminal.
 # TODO: this should be scaled back even more
 ioctl - !TIOCSTI
 


### PR DESCRIPTION
* apparmor: allow read on @{PROC}/sys/fs/file-nr by default
* seccomp: better document ioctl mediation
* interfaces/desktop-legacy: allow org.gtk.GLib.PACRunner.Lookup()