### PR TITLE
spread: use find rather than recursive ls, skip mounted snaps

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -499,7 +499,7 @@ debug-each: |
         echo "# processes"
         ps aux
         echo "# /var/lib/snapd"
-        ls -lR /var/lib/snapd || true
+        find /var/lib/snapd/ -not -path '/var/lib/snapd/snap/*' -ls || true
     fi
 
 rename:


### PR DESCRIPTION
Doing recursive ls in debug section would print out a lot of information in a
very verbose manner. On systems where snaps are mounted under
/var/lib/snapd/snap/ the output would include the contents of mounted snaps,
making the output even longer.

