### PR TITLE
tests/main/xdg-open-compat: backup and restore original xdg-open

### DIFF
--- a/tests/main/xdg-open-compat/task.yaml
+++ b/tests/main/xdg-open-compat/task.yaml
@@ -24,10 +24,20 @@ restore: |
     rm -f /usr/share/applications/defaults.list
     rm -f /usr/share/applications/xdg-open.desktop
 
+    # restore original xdg-open
+    if [ -e /usr/bin/xdg-open.orig ]; then
+        mv /usr/bin/xdg-open.orig /usr/bin/xdg-open
+    fi
+
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
     install_local test-snapd-desktop
+
+    # make a backup of the original xdg-open
+    if [ -e /usr/bin/xdg-open ]; then
+        mv /usr/bin/xdg-open /usr/bin/xdg-open.orig
+    fi
 
     # download from LP, it is not available in the archive anymore
     wget https://launchpad.net/ubuntu/+source/snapd-xdg-open/0.0.0~16.04/+build/10503735/+files/snapd-xdg-open_0.0.0~16.04_amd64.deb


### PR DESCRIPTION
The test overwrites and then removes its copy of /usr/bin/xdg-open, but never
restores the original file. This would break the tests that follow that rely on
the behavior of xdg-open. Specifically snap-handle link was broken like so:

```
2020-06-15 19:35:11 Error executing google:ubuntu-16.04-64:tests/main/snap-handle-link (jun151913-234107) :
-----
...
+ tests.session -u test exec env DISPLAY=:placeholder xdg-open snap://package
env: 'xdg-open': No such file or directory
grep error: pattern not found, got:
-----
```
