### PR TITLE
tests: fix how gadget pc is detected when the snap does not exist and ls fails

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -274,7 +274,7 @@ create_nested_core_vm(){
             EXTRA_FUNDAMENTAL="--snap $KERNEL_SNAP"
 
             # Prepare the pc gadget snap (unless provided by extra-snaps)
-            GADGET_SNAP=$(ls "${PWD}"/extra-snaps/pc_*.snap)
+            GADGET_SNAP=$(find extra-snaps -name 'pc_*.snap')
             if [ -z "$GADGET_SNAP" ]; then
                 snap download --basename=pc --channel="20/edge" pc
                 unsquashfs -d pc-gadget pc.snap

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -274,6 +274,7 @@ create_nested_core_vm(){
             EXTRA_FUNDAMENTAL="--snap $KERNEL_SNAP"
 
             # Prepare the pc gadget snap (unless provided by extra-snaps)
+            GADGET_SNAP=""
             if [ -d extra-snaps ]; then
                 GADGET_SNAP=$(find extra-snaps -name 'pc_*.snap')
             fi

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -274,7 +274,9 @@ create_nested_core_vm(){
             EXTRA_FUNDAMENTAL="--snap $KERNEL_SNAP"
 
             # Prepare the pc gadget snap (unless provided by extra-snaps)
-            GADGET_SNAP=$(find extra-snaps -name 'pc_*.snap')
+            if [ -d extra-snaps ]; then
+                GADGET_SNAP=$(find extra-snaps -name 'pc_*.snap')
+            fi
             if [ -z "$GADGET_SNAP" ]; then
                 snap download --basename=pc --channel="20/edge" pc
                 unsquashfs -d pc-gadget pc.snap


### PR DESCRIPTION
This fix is used to deal with the error:
```
++ ls
'/home/gopath/src/github.com/snapcore/snapd/tests/nested/core20/tpm/extra-snaps/pc_*.snap'
ls: cannot access
'/home/gopath/src/github.com/snapcore/snapd/tests/nested/core20/tpm/extra-snaps/pc_*.snap':
No such file or directory
+ GADGET_SNAP=
```