### PR TITLE
tests: simplify the tpm test by removing the test-snapd-mokutil snap

### DIFF
--- a/tests/nested/core20/tpm/task.yaml
+++ b/tests/nested/core20/tpm/task.yaml
@@ -12,7 +12,7 @@ execute: |
     execute_remote "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
 
     echo "and secure boot is enabled on the nested vm"
-    execute_remote "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2 -aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
+    execute_remote "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
 
     echo "and the recovery key is available"
     execute_remote "test -e /var/lib/snapd/device/fde/recovery.key"

--- a/tests/nested/core20/tpm/task.yaml
+++ b/tests/nested/core20/tpm/task.yaml
@@ -12,8 +12,7 @@ execute: |
     execute_remote "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
 
     echo "and secure boot is enabled on the nested vm"
-    execute_remote "ls /sys/firmware/efi/efivars/SecureBoot-*"
-    execute_remote "ls /sys/firmware/efi/efivars/SetupMode-*"
+    execute_remote "xxd /sys/firmware/efi/efivars/SecureBoot-*" | MATCH '0600 0000 01'
 
     echo "and the recovery key is available"
     execute_remote "test -e /var/lib/snapd/device/fde/recovery.key"

--- a/tests/nested/core20/tpm/task.yaml
+++ b/tests/nested/core20/tpm/task.yaml
@@ -12,7 +12,7 @@ execute: |
     execute_remote "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
 
     echo "and secure boot is enabled on the nested vm"
-    execute_remote "xxd /sys/firmware/efi/efivars/SecureBoot-*" | MATCH '0600 0000 01'
+    execute_remote "xxd /sys/firmware/efi/efivars/SecureBoot-*" | MATCH "00000000: 0600 0000 01\s+....."
 
     echo "and the recovery key is available"
     execute_remote "test -e /var/lib/snapd/device/fde/recovery.key"

--- a/tests/nested/core20/tpm/task.yaml
+++ b/tests/nested/core20/tpm/task.yaml
@@ -12,7 +12,7 @@ execute: |
     execute_remote "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
 
     echo "and secure boot is enabled on the nested vm"
-    execute_remote "xxd /sys/firmware/efi/efivars/SecureBoot-*" | MATCH "00000000: 0600 0000 01\s+....."
+    execute_remote "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2 -aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
 
     echo "and the recovery key is available"
     execute_remote "test -e /var/lib/snapd/device/fde/recovery.key"

--- a/tests/nested/core20/tpm/task.yaml
+++ b/tests/nested/core20/tpm/task.yaml
@@ -3,18 +3,6 @@ summary: Check that tpm works properly on UC20
 description: |
     This test check UC20 can boot with secure boot successfully
 
-prepare: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-
-    execute_remote "sudo snap install --beta --devmode test-snapd-mokutil" || true
-
-restore: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-
-    execute_remote "sudo snap remove test-snapd-mokutil" || true
-
 execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
@@ -24,7 +12,8 @@ execute: |
     execute_remote "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
 
     echo "and secure boot is enabled on the nested vm"
-    retry -n 5 --wait 5 execute_remote "test-snapd-mokutil --sb-state" | MATCH "SecureBoot enabled"
+    execute_remote "ls /sys/firmware/efi/efivars/SecureBoot-*"
+    execute_remote "ls /sys/firmware/efi/efivars/SetupMode-*"
 
     echo "and the recovery key is available"
     execute_remote "test -e /var/lib/snapd/device/fde/recovery.key"


### PR DESCRIPTION
Now the idea is to make the checks manually to verify if secure boot is
enabled.

This is to prevent errors on the tpm test caused by the
test-snapd-mokutil snap.

The solution is copied from the mokutil tool.