### PR TITLE
interfaces: optimize rules of multiple connected iio/i2c/spi plugs

### DIFF
--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -114,3 +114,7 @@ func MockParserFeatures(f func() ([]string, error)) (resture func()) {
 func (b *Backend) SetupSnapConfineReexec(info *snap.Info) error {
 	return b.setupSnapConfineReexec(info)
 }
+
+func (s *Specification) SnippetsForTag(tag string) []string {
+	return s.snippetsForTag(tag)
+}

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -208,8 +208,8 @@ func (spec *Specification) AddParametricSnippet(templateFragment []string, value
 			values = &strutil.OrderedSet{}
 			expansions[template] = values
 		}
-		// Expand the spec's parametric snippets, initializing
-		// each part of the map as needed
+		// Now that everything is initialized, insert value into the
+		// spec.parametricSnippets[<tag>][<template>]'s OrderedSet.
 		values.Put(value)
 	}
 }

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -141,7 +141,7 @@ func (spec *Specification) AddParametricSnippet(templateFragment []string, value
 		return
 	}
 
-	// We need to build a temlate string from the templateFragment.
+	// We need to build a template string from the templateFragment.
 	//
 	// If only a single fragment is given we just  append our "###PARM###":
 	//  []string{"prefix"} becomes -> "prefix###PARAM###"

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -157,9 +157,9 @@ func (spec *Specification) AddDeduplicatedSnippet(snippet string) {
 //
 // For example the code:
 //
-// 		AddParametricSnippet([]{"/dev/", "rw,", "sda1")
-//		AddParametricSnippet([]{"/dev/", "rw,", "sda3")
-//		AddParametricSnippet([]{"/dev/", "rw,", "sdb2")
+// 		AddParametricSnippet([]{"/dev/", "rw,"}, "sda1")
+//		AddParametricSnippet([]{"/dev/", "rw,"}, "sda3")
+//		AddParametricSnippet([]{"/dev/", "rw,"}, "sdb2")
 //
 // Results in a single apparmor rule:
 //

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -157,9 +157,9 @@ func (spec *Specification) AddDeduplicatedSnippet(snippet string) {
 //
 // For example the code:
 //
-// 		AddParametricSnippet([]{"/dev/", "rw,"}, "sda1")
-//		AddParametricSnippet([]{"/dev/", "rw,"}, "sda3")
-//		AddParametricSnippet([]{"/dev/", "rw,"}, "sdb2")
+// 		AddParametricSnippet([]string{"/dev/", "rw,"}, "sda1")
+//		AddParametricSnippet([]string{"/dev/", "rw,"}, "sda3")
+//		AddParametricSnippet([]string{"/dev/", "rw,"}, "sdb2")
 //
 // Results in a single apparmor rule:
 //

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -165,9 +165,11 @@ func (spec *Specification) AddDeduplicatedSnippet(snippet string) {
 //
 //		"/dev/{sda1,sda3,sdb2} rw,"
 //
-// It should be used whenever the apparmor template combines more than one use
-// of "**" syntax (which represent arbitrary many directories or files) and a
-// variable component, like a device name or similar.
+// This function should be used whenever the apparmor template features more
+// than one use of "**" syntax (which represent arbitrary many directories or
+// files) and a variable component, like a device name or similar. Repeated
+// instances of this pattern require exponential memory when compiled with
+// apparmor_parser -O no-expr-simplify.
 func (spec *Specification) AddParametricSnippet(templateFragment []string, value string) {
 	if len(spec.securityTags) == 0 {
 		return

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -136,13 +136,30 @@ func (spec *Specification) AddDeduplicatedSnippet(snippet string) {
 	}
 }
 
-func (spec *Specification) AddParametricSnippet(template, value string) {
-	if !strings.Contains(template, "###PARAM###") {
-		panic(fmt.Sprintf("template %q does not contain ###PARAM###", template))
-	}
+func (spec *Specification) AddParametricSnippet(templateFragment []string, value string) {
 	if len(spec.securityTags) == 0 {
 		return
 	}
+
+	// We need to build a temlate string from the templateFragment.
+	//
+	// If only a single fragment is given we just  append our "###PARM###":
+	//  []string{"prefix"} becomes -> "prefix###PARAM###"
+	//
+	// Otherwise we join the strings:
+	//  []string{"pre","post"} becomes -> "pre###PARAM###post"
+	//
+	// This seems to be the most natural way of doing this.
+	var template string
+	switch len(templateFragment) {
+	case 0:
+		return
+	case 1:
+		template = templateFragment[0] + "###PARAM###"
+	default:
+		template = strings.Join(templateFragment, "###PARAM###")
+	}
+
 	// Expand the spec's parametric snippets, initializing each
 	// part of the map as needed
 	if spec.parametricSnippets == nil {

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -46,6 +46,20 @@ type Specification struct {
 	// rules by apparmor_parser.
 	dedupSnippets map[string]*strutil.OrderedSet
 
+	// parametricSnippets are like snippets but are further parametrized where
+	// one template is instantiated with multiple values that end up producing
+	// a single apparmor rule that is computationally cheaper than naive
+	// repetition of the template alone. The first map index is the security
+	// tag, the second map index is the template. The final map value is the
+	// set of strings that the template is instantiated with across all the
+	// interfaces.
+	//
+	// As a simple example, it can be used to craft rules like
+	// "/sys/**/foo{1,2,3}/** r,", which are not triggering the exponential
+	// cost of parsing "/sys/**/foo1/** r,", followed by two similar rules for
+	// "2" and "3".
+	parametricSnippets map[string]map[string]*strutil.OrderedSet
+
 	// updateNS describe parts of apparmor policy for snap-update-ns executing
 	// on behalf of a given snap.
 	updateNS strutil.OrderedSet
@@ -119,6 +133,31 @@ func (spec *Specification) AddDeduplicatedSnippet(snippet string) {
 			spec.dedupSnippets[tag] = bag
 		}
 		bag.Put(snippet)
+	}
+}
+
+func (spec *Specification) AddParametricSnippet(template, value string) {
+	if !strings.Contains(template, "###PARAM###") {
+		panic(fmt.Sprintf("template %q does not contain ###PARAM###", template))
+	}
+	if len(spec.securityTags) == 0 {
+		return
+	}
+	if spec.parametricSnippets == nil {
+		spec.parametricSnippets = make(map[string]map[string]*strutil.OrderedSet)
+	}
+	for _, tag := range spec.securityTags {
+		templates := spec.parametricSnippets[tag]
+		if templates == nil {
+			templates = make(map[string]*strutil.OrderedSet)
+			spec.parametricSnippets[tag] = templates
+		}
+		bag := templates[template]
+		if bag == nil {
+			bag = &strutil.OrderedSet{}
+			templates[template] = bag
+		}
+		bag.Put(value)
 	}
 }
 
@@ -366,11 +405,10 @@ func parent(path string) string {
 
 // Snippets returns a deep copy of all the added application snippets.
 func (spec *Specification) Snippets() map[string][]string {
-	snippets := copySnippets(spec.snippets)
-	for tag, bag := range spec.dedupSnippets {
-		if bag != nil {
-			snippets[tag] = append(snippets[tag], bag.Items()...)
-		}
+	tags := spec.SecurityTags()
+	snippets := make(map[string][]string, len(tags))
+	for _, tag := range tags {
+		snippets[tag] = spec.snippetsForTag(tag)
 	}
 	return snippets
 }
@@ -379,11 +417,7 @@ func (spec *Specification) Snippets() map[string][]string {
 // individual snippets joined with the newline character. Empty string is
 // returned for non-existing security tag.
 func (spec *Specification) SnippetForTag(tag string) string {
-	snippets := append([]string(nil), spec.snippets[tag]...)
-	if bag := spec.dedupSnippets[tag]; bag != nil {
-		snippets = append(snippets, bag.Items()...)
-	}
-	return strings.Join(snippets, "\n")
+	return strings.Join(spec.snippetsForTag(tag), "\n")
 }
 
 // SecurityTags returns a list of security tags which have a snippet.
@@ -399,8 +433,43 @@ func (spec *Specification) SecurityTags() []string {
 			tags = append(tags, t)
 		}
 	}
+	for t := range spec.parametricSnippets {
+		if !seen[t] {
+			tags = append(tags, t)
+		}
+	}
 	sort.Strings(tags)
 	return tags
+}
+
+func (spec *Specification) snippetsForTag(tag string) []string {
+	snippets := append([]string(nil), spec.snippets[tag]...)
+	if bag := spec.dedupSnippets[tag]; bag != nil {
+		snippets = append(snippets, bag.Items()...)
+	}
+	templates := make([]string, 0, len(spec.parametricSnippets[tag]))
+	for template := range spec.parametricSnippets[tag] {
+		templates = append(templates, template)
+	}
+	sort.Strings(templates)
+	for _, template := range templates {
+		bag := spec.parametricSnippets[tag][template]
+		if bag != nil {
+			values := bag.Items()
+			switch len(values) {
+			case 0:
+				/* no values, nothing to do */
+			case 1:
+				snippet := strings.Replace(template, "###PARAM###", values[0], -1)
+				snippets = append(snippets, snippet)
+			default:
+				snippet := strings.Replace(template, "###PARAM###",
+					fmt.Sprintf("{%s}", strings.Join(values, ",")), -1)
+				snippets = append(snippets, snippet)
+			}
+		}
+	}
+	return snippets
 }
 
 // UpdateNS returns a deep copy of all the added snap-update-ns snippets.

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -171,14 +171,14 @@ func (spec *Specification) AddParametricSnippet(templateFragment []string, value
 			expansions = make(map[string]*strutil.OrderedSet)
 			spec.parametricSnippets[tag] = expansions
 		}
-		bag := expansions[template]
-		if bag == nil {
-			bag = &strutil.OrderedSet{}
-			expansions[template] = bag
+		values := expansions[template]
+		if values == nil {
+			values = &strutil.OrderedSet{}
+			expansions[template] = values
 		}
 		// Expand the spec's parametric snippets, initializing
 		// each part of the map as needed
-		bag.Put(value)
+		values.Put(value)
 	}
 }
 

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -180,7 +180,7 @@ func (s *specSuite) TestAddSnippetAndAddDeduplicatedAndParamSnippet(c *C) {
 	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})
 	defer restore()
 
-	// Add two snippets in the context we are in.
+	// Add three snippets in the context we are in.
 	s.spec.AddSnippet("normal")
 	s.spec.AddDeduplicatedSnippet("dedup")
 	s.spec.AddParametricSnippet([]string{""}, "param")

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -155,7 +155,7 @@ func (s *specSuite) TestAddDeduplicatedSnippet(c *C) {
 	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.command", "snap.demo.service"})
 }
 
-// Both AddSnippet, AddDeduplicatedSnippet, AddParameticSnippet work correctly together.
+// All of AddSnippet, AddDeduplicatedSnippet, AddParameticSnippet work correctly together.
 func (s *specSuite) TestAddSnippetAndAddDeduplicatedAndParamSnippet(c *C) {
 	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})
 	defer restore()

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -209,7 +209,7 @@ func (s *specSuite) TestTagsButNoSnippets(c *C) {
 }
 
 // Don't define any tags but add snippets.
-func (s *specSuite) TestNoTagsNoSnippets(c *C) {
+func (s *specSuite) TestNoTagsButWithSnippets(c *C) {
 	restore := apparmor.SetSpecScope(s.spec, []string{})
 	defer restore()
 

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -196,6 +196,46 @@ func (s *specSuite) TestAddSnippetAndAddDeduplicatedAndParamSnippet(c *C) {
 	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.command", "snap.demo.service"})
 }
 
+// Define tags but don't add any snippets.
+func (s *specSuite) TestTagsButNoSnippets(c *C) {
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})
+	defer restore()
+
+	c.Assert(s.spec.UpdateNS(), HasLen, 0)
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{})
+	c.Assert(s.spec.SnippetsForTag("snap.demo.command"), DeepEquals, []string(nil))
+	c.Assert(s.spec.SnippetForTag("snap.demo.command"), Equals, "")
+	c.Assert(s.spec.SecurityTags(), DeepEquals, []string(nil))
+}
+
+// Don't define any tags but add snippets.
+func (s *specSuite) TestNoTagsNoSnippets(c *C) {
+	restore := apparmor.SetSpecScope(s.spec, []string{})
+	defer restore()
+
+	s.spec.AddSnippet("normal")
+	s.spec.AddDeduplicatedSnippet("dedup")
+	s.spec.AddParametricSnippet([]string{""}, "param")
+
+	c.Assert(s.spec.UpdateNS(), HasLen, 0)
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{})
+	c.Assert(s.spec.SnippetsForTag("snap.demo.command"), DeepEquals, []string(nil))
+	c.Assert(s.spec.SnippetForTag("snap.demo.command"), Equals, "")
+	c.Assert(s.spec.SecurityTags(), DeepEquals, []string(nil))
+}
+
+// Don't define any tags or snippets.
+func (s *specSuite) TestsNoTagsOrSnippets(c *C) {
+	restore := apparmor.SetSpecScope(s.spec, []string{})
+	defer restore()
+
+	c.Assert(s.spec.UpdateNS(), HasLen, 0)
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{})
+	c.Assert(s.spec.SnippetsForTag("snap.demo.command"), DeepEquals, []string(nil))
+	c.Assert(s.spec.SnippetForTag("snap.demo.command"), Equals, "")
+	c.Assert(s.spec.SecurityTags(), DeepEquals, []string(nil))
+}
+
 // AddUpdateNS adds a snippet for the snap-update-ns profile for a given snap.
 func (s *specSuite) TestAddUpdateNS(c *C) {
 	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -157,11 +157,11 @@ func (s *specSuite) TestAddParametricSnippet(c *C) {
 	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})
 	defer restore()
 
-	s.spec.AddParametricSnippet("prefix ###PARAM### postfix", "param1")
-	s.spec.AddParametricSnippet("prefix ###PARAM### postfix", "param1")
-	s.spec.AddParametricSnippet("prefix ###PARAM### postfix", "param2")
-	s.spec.AddParametricSnippet("prefix ###PARAM### postfix", "param2")
-	s.spec.AddParametricSnippet("other ###PARAM###", "param")
+	s.spec.AddParametricSnippet([]string{"prefix ", " postfix"}, "param1")
+	s.spec.AddParametricSnippet([]string{"prefix ", " postfix"}, "param1")
+	s.spec.AddParametricSnippet([]string{"prefix ", " postfix"}, "param2")
+	s.spec.AddParametricSnippet([]string{"prefix ", " postfix"}, "param2")
+	s.spec.AddParametricSnippet([]string{"other "}, "param")
 	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
 		"snap.demo.command": {"other param", "prefix {param1,param2} postfix"},
 		"snap.demo.service": {"other param", "prefix {param1,param2} postfix"},
@@ -176,7 +176,7 @@ func (s *specSuite) TestAddSnippetAndAddDeduplicatedAndParamSnippet(c *C) {
 	// Add two snippets in the context we are in.
 	s.spec.AddSnippet("normal")
 	s.spec.AddDeduplicatedSnippet("dedup")
-	s.spec.AddParametricSnippet("###PARAM###", "param")
+	s.spec.AddParametricSnippet([]string{""}, "param")
 
 	// The snippets were recorded correctly.
 	c.Assert(s.spec.UpdateNS(), HasLen, 0)

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -129,7 +129,9 @@ func (iface *i2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 
 	cleanedPath := filepath.Clean(path)
 	spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugAppArmorPath, cleanedPath))
-	spec.AddParametricSnippet([]string{"/sys/devices/platform/{*,**.i2c}/", "/** rw,"}, strings.TrimPrefix(path, "/dev/"))
+	spec.AddParametricSnippet([]string{
+		"/sys/devices/platform/{*,**.i2c}/" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
+	}, strings.TrimPrefix(path, "/dev/"))
 	return nil
 }
 

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -130,8 +130,8 @@ func (iface *i2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	cleanedPath := filepath.Clean(path)
 	spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugAppArmorPath, cleanedPath))
 	spec.AddParametricSnippet([]string{
-		"/sys/devices/platform/{*,**.i2c}/" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
-	}, strings.TrimPrefix(path, "/dev/"))
+		"/sys/devices/platform/{*,**.i2c}/i2c-" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
+	}, strings.TrimPrefix(path, "/dev/i2c-"))
 	return nil
 }
 

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -46,7 +46,6 @@ const i2cConnectedPlugAppArmorPath = `
 # Description: Can access I2C controller
 
 %s rw,
-/sys/devices/platform/{*,**.i2c}/%s/** rw,
 `
 
 const i2cConnectedPlugAppArmorSysfsName = `
@@ -129,7 +128,8 @@ func (iface *i2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	}
 
 	cleanedPath := filepath.Clean(path)
-	spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugAppArmorPath, cleanedPath, strings.TrimPrefix(path, "/dev/")))
+	spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugAppArmorPath, cleanedPath))
+	spec.AddParametricSnippet([]string{"/sys/devices/platform/{*,**.i2c}/", "/** rw,"}, strings.TrimPrefix(path, "/dev/"))
 	return nil
 }
 

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -129,6 +129,7 @@ func (iface *i2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 
 	cleanedPath := filepath.Clean(path)
 	spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugAppArmorPath, cleanedPath))
+	// Use parametric snippets to avoid no-expr-simplify side-effects.
 	spec.AddParametricSnippet([]string{
 		"/sys/devices/platform/{*,**.i2c}/i2c-" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
 	}, strings.TrimPrefix(path, "/dev/i2c-"))

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -110,7 +110,7 @@ slots:
     path: /dev/i2c-1
   test-udev-2:
     interface: i2c
-    path: /dev/i2c-11
+    path: /dev/i2c-2
   test-udev-3:
     interface: i2c
     path: /dev/i2c-0
@@ -247,6 +247,17 @@ func (s *I2cInterfaceSuite) TestAppArmorSpecPath(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-1-port"})
 	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/dev/i2c-1 rw,`)
 	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/sys/devices/platform/{*,**.i2c}/i2c-1/** rw,  # Add any condensed parametric rules`)
+}
+
+func (s *I2cInterfaceSuite) TestAppArmorSpecPathMany(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUDev1), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUDev2), IsNil)
+	// NOTE: the snap name is misleading.
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-1-port"})
+	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/dev/i2c-1 rw,`)
+	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/dev/i2c-2 rw,`)
+	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/sys/devices/platform/{*,**.i2c}/i2c-{1,2}/** rw,  # Add any condensed parametric rules`)
 }
 
 func (s *I2cInterfaceSuite) TestAppArmorSpecSysfsName(c *C) {

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -246,7 +246,7 @@ func (s *I2cInterfaceSuite) TestAppArmorSpecPath(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUDev1), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-1-port"})
 	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/dev/i2c-1 rw,`)
-	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/sys/devices/platform/{*,**.i2c}/i2c-1/** rw,`)
+	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/sys/devices/platform/{*,**.i2c}/i2c-1/** rw,  # Add any condensed parametric rules`)
 }
 
 func (s *I2cInterfaceSuite) TestAppArmorSpecSysfsName(c *C) {

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -119,7 +119,7 @@ func (iface *iioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	// snippet workaround. Only one instance of this line will show up in the
 	// resulting profile. Eg, if the snap is assigned iio:device1 and
 	// iio:device3, this rule will expand to:
-	//  /sys/devices/**/{iio:device1,iio:device3}/** rwk,
+	//  /sys/devices/**/iio:device{1,3}/** rwk,
 
 	// Because all deviceName values have the prefix of "iio:device" enforced
 	// by the sanitization logic above, we can trim that prefix and provide a

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -125,9 +125,13 @@ func (iface *iioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	// by the sanitization logic above, we can trim that prefix and provide a
 	// shorter expansion expression.
 	deviceNum := strings.TrimPrefix(deviceName, "iio:device")
-	spec.AddParametricSnippet([]string{"/sys/devices/**/iio:device", "/** rwk,"}, deviceNum)
+	spec.AddParametricSnippet([]string{
+		"/sys/devices/**/iio:device" /* ###PARAM### */, "/** rwk,  # Add any condensed parametric rules",
+	}, deviceNum)
 	// For consistency, not an efficiency problem.
-	spec.AddParametricSnippet([]string{"/sys/devices/**/iio:device", "/ r,"}, deviceNum)
+	spec.AddParametricSnippet([]string{
+		"/sys/devices/**/iio:device" /* ###PARAM### */, "/ r,  # Add any condensed parametric rules",
+	}, deviceNum)
 
 	return nil
 }

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -121,9 +121,13 @@ func (iface *iioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	// iio:device3, this rule will expand to:
 	//  /sys/devices/**/{iio:device1,iio:device3}/** rwk,
 
-	spec.AddParametricSnippet([]string{"/sys/devices/**/", "/** rwk,"}, deviceName)
+	// Because all deviceName values have the prefix of "iio:device" enforced
+	// by the sanitization logic above, we can trim that prefix and provide a
+	// shorter expansion expression.
+	deviceNum := strings.TrimPrefix(deviceName, "iio:device")
+	spec.AddParametricSnippet([]string{"/sys/devices/**/iio:device", "/** rwk,"}, deviceNum)
 	// For consistency, not an efficiency problem.
-	spec.AddParametricSnippet([]string{"/sys/devices/**/", "/ r,"}, deviceName)
+	spec.AddParametricSnippet([]string{"/sys/devices/**/iio:device", "/ r,"}, deviceNum)
 
 	return nil
 }

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -114,17 +114,13 @@ func (iface *iioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	// Add a snippet for various device specific rules, except for sysfs write
 	// access that are specialized below.
 	spec.AddSnippet(snippet)
-	// This part contains two sets of "**" that can use exponential memory when
-	// compiling without -O no-expr-simplify, so handle it with the parametric
-	// snippet workaround. Only one instance of this line will show up in the
-	// resulting profile. Eg, if the snap is assigned iio:device1 and
-	// iio:device3, this rule will expand to:
-	//  /sys/devices/**/iio:device{1,3}/** rwk,
 
 	// Because all deviceName values have the prefix of "iio:device" enforced
 	// by the sanitization logic above, we can trim that prefix and provide a
 	// shorter expansion expression.
 	deviceNum := strings.TrimPrefix(deviceName, "iio:device")
+
+	// Use parametric snippets to avoid no-expr-simplify side-effects.
 	spec.AddParametricSnippet([]string{
 		"/sys/devices/**/iio:device" /* ###PARAM### */, "/** rwk,  # Add any condensed parametric rules",
 	}, deviceNum)

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -121,9 +121,9 @@ func (iface *iioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	// iio:device3, this rule will expand to:
 	//  /sys/devices/**/{iio:device1,iio:device3}/** rwk,
 
-	spec.AddParametricSnippet("/sys/devices/**/###PARAM###/** rwk,", deviceName)
+	spec.AddParametricSnippet([]string{"/sys/devices/**/", "/** rwk,"}, deviceName)
 	// For consistency, not an efficiency problem.
-	spec.AddParametricSnippet("/sys/devices/**/###PARAM###/ r,", deviceName)
+	spec.AddParametricSnippet([]string{"/sys/devices/**/", "/ r,"}, deviceName)
 
 	return nil
 }

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -117,7 +117,10 @@ func (iface *iioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	// This part contains two sets of "**" that can use exponential memory when
 	// compiling without -O no-expr-simplify, so handle it with the parametric
 	// snippet workaround. Only one instance of this line will show up in the
-	// resulting profile.
+	// resulting profile. Eg, if the snap is assigned iio:device1 and
+	// iio:device3, this rule will expand to:
+	//  /sys/devices/**/{iio:device1,iio:device3}/** rwk,
+
 	spec.AddParametricSnippet("/sys/devices/**/###PARAM###/** rwk,", deviceName)
 	// For consistency, not an efficiency problem.
 	spec.AddParametricSnippet("/sys/devices/**/###PARAM###/ r,", deviceName)

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -238,8 +238,8 @@ func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSnippetsMultipleOptimized(c
 /sys/bus/iio/devices/iio:device2/ r,
 /sys/bus/iio/devices/iio:device2/** rwk,
 
-/sys/devices/**/{iio:device1,iio:device2}/ r,
-/sys/devices/**/{iio:device1,iio:device2}/** rwk,`
+/sys/devices/**/iio:device{1,2}/ r,
+/sys/devices/**/iio:device{1,2}/** rwk,`
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUDev1)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -205,7 +205,7 @@ KERNEL=="iio:device1", TAG+="snap_client-snap_app-accessing-1-port"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_client-snap_app-accessing-1-port", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-1-port $devpath $major:$minor"`)
 }
 
-func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
+func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSingleSnippet(c *C) {
 	expectedSnippet := `
 # Description: Give access to a specific IIO device on the system.
 
@@ -246,6 +246,8 @@ func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSnippetsMultipleOptimized(c
 	err = apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUDev2)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-1-port"})
+	// XXX: the tag snap.client-snap.app-accessing-1-port is
+	// misleading when you are testing for '1' and '2' ports
 	snippet := apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-1-port")
 	c.Assert(snippet, Equals, expectedSnippet)
 }

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -213,8 +213,8 @@ func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSingleSnippet(c *C) {
 /sys/bus/iio/devices/iio:device1/ r,
 /sys/bus/iio/devices/iio:device1/** rwk,
 
-/sys/devices/**/iio:device1/ r,
-/sys/devices/**/iio:device1/** rwk,`
+/sys/devices/**/iio:device1/ r,  # Add any condensed parametric rules
+/sys/devices/**/iio:device1/** rwk,  # Add any condensed parametric rules`
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUDev1)
 	c.Assert(err, IsNil)
@@ -238,8 +238,8 @@ func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSnippetsMultipleOptimized(c
 /sys/bus/iio/devices/iio:device2/ r,
 /sys/bus/iio/devices/iio:device2/** rwk,
 
-/sys/devices/**/iio:device{1,2}/ r,
-/sys/devices/**/iio:device{1,2}/** rwk,`
+/sys/devices/**/iio:device{1,2}/ r,  # Add any condensed parametric rules
+/sys/devices/**/iio:device{1,2}/** rwk,  # Add any condensed parametric rules`
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUDev1)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -84,7 +84,7 @@ func (iface *spiInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 		return nil
 	}
 	spec.AddSnippet(fmt.Sprintf("%s rw,", path))
-	spec.AddParametricSnippet("/sys/devices/platform/**/**.spi/**/###PARAM###/** rw,", strings.TrimPrefix(path, "/dev/"))
+	spec.AddParametricSnippet([]string{"/sys/devices/platform/**/**.spi/**/", "/** rw,"}, strings.TrimPrefix(path, "/dev/"))
 	return nil
 }
 

--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -84,7 +84,9 @@ func (iface *spiInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 		return nil
 	}
 	spec.AddSnippet(fmt.Sprintf("%s rw,", path))
-	spec.AddParametricSnippet([]string{"/sys/devices/platform/**/**.spi/**/", "/** rw,"}, strings.TrimPrefix(path, "/dev/"))
+	spec.AddParametricSnippet([]string{
+		"/sys/devices/platform/**/**.spi/**/" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
+	}, strings.TrimPrefix(path, "/dev/"))
 	return nil
 }
 

--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -84,7 +84,7 @@ func (iface *spiInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 		return nil
 	}
 	spec.AddSnippet(fmt.Sprintf("%s rw,", path))
-	spec.AddSnippet(fmt.Sprintf("/sys/devices/platform/**/**.spi/**/%s/** rw,", strings.TrimPrefix(path, "/dev/")))
+	spec.AddParametricSnippet("/sys/devices/platform/**/**.spi/**/###PARAM###/** rw,", strings.TrimPrefix(path, "/dev/"))
 	return nil
 }
 

--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -84,6 +84,7 @@ func (iface *spiInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 		return nil
 	}
 	spec.AddSnippet(fmt.Sprintf("%s rw,", path))
+	// Use parametric snippets to avoid no-expr-simplify side-effects.
 	spec.AddParametricSnippet([]string{
 		"/sys/devices/platform/**/**.spi/**/spidev" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
 	}, strings.TrimPrefix(path, "/dev/spidev"))

--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -85,8 +85,8 @@ func (iface *spiInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	}
 	spec.AddSnippet(fmt.Sprintf("%s rw,", path))
 	spec.AddParametricSnippet([]string{
-		"/sys/devices/platform/**/**.spi/**/" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
-	}, strings.TrimPrefix(path, "/dev/"))
+		"/sys/devices/platform/**/**.spi/**/spidev" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
+	}, strings.TrimPrefix(path, "/dev/spidev"))
 	return nil
 }
 

--- a/interfaces/builtin/spi_test.go
+++ b/interfaces/builtin/spi_test.go
@@ -222,12 +222,12 @@ func (s *spiInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
 		"/dev/spidev0.0 rw,\n"+
-		"/sys/devices/platform/**/**.spi/**/spidev0.0/** rw,")
+		"/sys/devices/platform/**/**.spi/**/spidev0.0/** rw,  # Add any condensed parametric rules")
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug1, s.slotGadget2), IsNil)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
 		"/dev/spidev0.0 rw,\n"+
 		"/dev/spidev0.1 rw,\n"+
-		"/sys/devices/platform/**/**.spi/**/{spidev0.0,spidev0.1}/** rw,")
+		"/sys/devices/platform/**/**.spi/**/{spidev0.0,spidev0.1}/** rw,  # Add any condensed parametric rules")
 }
 
 func (s *spiInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/spi_test.go
+++ b/interfaces/builtin/spi_test.go
@@ -227,7 +227,7 @@ func (s *spiInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
 		"/dev/spidev0.0 rw,\n"+
 		"/dev/spidev0.1 rw,\n"+
-		"/sys/devices/platform/**/**.spi/**/{spidev0.0,spidev0.1}/** rw,  # Add any condensed parametric rules")
+		"/sys/devices/platform/**/**.spi/**/spidev{0.0,0.1}/** rw,  # Add any condensed parametric rules")
 }
 
 func (s *spiInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/spi_test.go
+++ b/interfaces/builtin/spi_test.go
@@ -223,6 +223,11 @@ func (s *spiInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
 		"/dev/spidev0.0 rw,\n"+
 		"/sys/devices/platform/**/**.spi/**/spidev0.0/** rw,")
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug1, s.slotGadget2), IsNil)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
+		"/dev/spidev0.0 rw,\n"+
+		"/dev/spidev0.1 rw,\n"+
+		"/sys/devices/platform/**/**.spi/**/{spidev0.0,spidev0.1}/** rw,")
 }
 
 func (s *spiInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
Connecting multiple iio slots to a single plug results in an apparmor profile
containing the following rules (simplified):

    /sys/devices/**/iio:device0/** rwk,
    /sys/devices/**/iio:device1/** rwk,
    ...
    /sys/devices/**/iio:device15/** rwk,

When compiling this profile with apparmor_parser -O no-expr-simplify the
presence of double star-star "**" causes exponential memory usage,
requiring about 2GB to compile such sixteen lines on an 64bit system.

This patch introduces parametric snippets that bind a snippet containing the
text "###PARAM###" to an ordered set of strings that represent possible
parameters. This mechanism is subsequently used to optimize the generated
apparmor profile to this form:

    /sys/devices/**/{iio:device1,...,iio:device15}/** rwk,

I've confirmed that the memory and time complexity is equivalent to the use of
optimizing apparmor_parser (without the -O no-expr-simplify argument)

Similar patch is applied to the spi and i2c interfaces.

Fixes: https://bugs.launchpad.net/stuttgart/+bug/1883710
