### PR TITLE
tests: use the "jq" snap from the edge channel

### DIFF
--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -25,7 +25,7 @@ execute: |
   if [ "$SPREAD_REBOOT" == "0" ]; then
       echo "In run mode"
 
-      snap install jq
+      snap install --edge jq
       # devmode as the snap does not have snapd-control
       snap install test-snapd-curl --devmode --edge
 
@@ -83,7 +83,7 @@ execute: |
       snap wait system seed.loaded
 
       # we're running in an ephemeral system and thus have to re-install snaps
-      snap install jq
+      snap install --edge jq
       snap install test-snapd-curl --devmode --edge
 
       MATCH 'snapd_recovery_mode=recover' < /proc/cmdline

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -5,7 +5,7 @@ summary: Verify AppStream ID integration
 systems: [-ubuntu-14.04-*, -ubuntu-core*]
 
 prepare: |
-    snap install jq
+    snap install --edge jq
 
 restore: |
     rm -f response

--- a/tests/main/classic-firstboot/task.yaml
+++ b/tests/main/classic-firstboot/task.yaml
@@ -90,7 +90,7 @@ execute: |
     # sanity check
     snap change 1 | MATCH "Mark system seeded"
     snap change 1 | MATCH "restart of .*test-snapd-service.test-snapd-other-service"
-    snap install jq
+    snap install --edge jq
     # extract task ids from state
     # XXX: snap change output cannot be used for that; ideally we would have some sort of 'snap debug ..' command.
     MARKSEEDED_WAIT=$(jq -r '.tasks[] | select (.kind == "mark-seeded") | ."wait-tasks"' < /var/lib/snapd/state.json)

--- a/tests/main/health/task.yaml
+++ b/tests/main/health/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that health works
 
 prepare: |
-    snap install jq
+    snap install --edge jq
 
 execute: |
     echo "Test that 'try'ing a snap with a set-health hook sets health in state:"

--- a/tests/main/remove-auto-connections/task.yaml
+++ b/tests/main/remove-auto-connections/task.yaml
@@ -8,7 +8,7 @@ details: |
 systems: [-ubuntu-core-*]
 
 prepare: |
-  snap install jq
+  snap install --edge jq
   snap pack simplesnap.v1
   snap pack simplesnap.v2
 

--- a/tests/main/services-disabled-kept-happy/task.yaml
+++ b/tests/main/services-disabled-kept-happy/task.yaml
@@ -53,7 +53,7 @@ summary: Check that disabled snap services stay disabled across happy refreshes,
 #     => the new service is disabled
 
 prepare: |
-  snap install jq
+  snap install --edge jq
   # keep more revisions to simplify switching around between revisions in the 
   # test
   snap set system refresh.retain=5

--- a/tests/main/services-disabled-kept-unhappy/task.yaml
+++ b/tests/main/services-disabled-kept-unhappy/task.yaml
@@ -35,7 +35,7 @@ summary: Check that disabled snap services stay disabled across unhappy
 #    => state.json has the old service saved in last-active-disabled-services
 
 prepare: |
-  snap install jq
+  snap install --edge jq
   rm -f /root/disabled-svcs-kept-fail
   rm -rf disabled-svcs-kept*
 

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -9,7 +9,7 @@ prepare: |
     echo "Install a test snap"
     snap pack "$TESTSLIB"/snaps/home-consumer
     snap install --dangerous "$SNAP_FILE"
-    snap install jq
+    snap install --edge jq
 
 restore: |
     rm -f ./*.snap


### PR DESCRIPTION
We are currently "maintaining" the jq snap because we need it on
core devices. However the current stable version is still at 1.5
which is slightly embarrassing. We have 1.6 in edge so this commit
switches to use jq from edge to ensure we have no regresions. We
will keep using edge to ensure that we always test with the latest
jq.

