### PR TITLE
cmd/snap: Debian does not allow $SNAP_MOUNT_DIR/bin in sudo secure_path

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -320,8 +320,9 @@ func maybeWithSudoSecurePath() bool {
 	if _, isSet := os.LookupEnv("SUDO_UID"); !isSet {
 		return false
 	}
-	// Known distros setting secure_path:
-	return release.DistroLike("fedora", "opensuse")
+	// Known distros setting secure_path that does not include
+	// $SNAP_MOUNT_DIR/bin:
+	return release.DistroLike("fedora", "opensuse", "debian")
 }
 
 // show what has been done


### PR DESCRIPTION
The sudo configuration in Debian sets secure_path which does not include
$SNAP_MOUNT_DIR/bin. Add Debian to a list of known distros doing that so that we
do not show the warning.
