### PR TITLE
gadget: mv encodeLabel to osutil/disks.EncodeHexBlkIDFormat

### DIFF
--- a/gadget/device_linux.go
+++ b/gadget/device_linux.go
@@ -20,15 +20,13 @@
 package gadget
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
-	"unicode/utf8"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/disks"
 )
 
 var ErrDeviceNotFound = errors.New("device not found")
@@ -45,7 +43,7 @@ func FindDeviceForStructure(ps *LaidOutStructure) (string, error) {
 	var candidates []string
 
 	if ps.Name != "" {
-		byPartlabel := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel/", encodeLabel(ps.Name))
+		byPartlabel := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel/", disks.EncodeHexBlkIDFormat(ps.Name))
 		candidates = append(candidates, byPartlabel)
 	}
 	if ps.HasFilesystem() {
@@ -57,7 +55,7 @@ func FindDeviceForStructure(ps *LaidOutStructure) (string, error) {
 			fsLabel = ps.Name
 		}
 		if fsLabel != "" {
-			byFsLabel := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label/", encodeLabel(fsLabel))
+			byFsLabel := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label/", disks.EncodeHexBlkIDFormat(fsLabel))
 			candidates = append(candidates, byFsLabel)
 		}
 	}
@@ -141,26 +139,6 @@ func findDeviceForStructureWithFallback(ps *LaidOutStructure) (dev string, offs 
 	}
 	// start offset is calculated as an absolute position within the volume
 	return dev, ps.StartOffset, nil
-}
-
-// encodeLabel encodes a name for use a partition or filesystem label symlink by
-// udev. The result matches the output of blkid_encode_string().
-func encodeLabel(in string) string {
-	const allowed = `#+-.:=@_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`
-
-	buf := &bytes.Buffer{}
-
-	for _, r := range in {
-		switch {
-		case utf8.RuneLen(r) > 1:
-			buf.WriteRune(r)
-		case !strings.ContainsRune(allowed, r):
-			fmt.Fprintf(buf, `\x%x`, r)
-		default:
-			buf.WriteRune(r)
-		}
-	}
-	return buf.String()
 }
 
 // findMountPointForStructure locates a mount point of a device that matches

--- a/gadget/device_test.go
+++ b/gadget/device_test.go
@@ -458,45 +458,6 @@ func (d *deviceSuite) TestDeviceFindFallbackPassThrough(c *C) {
 	c.Check(offs, Equals, gadget.Size(0))
 }
 
-func (d *deviceSuite) TestDeviceEncodeLabel(c *C) {
-	// Test output obtained with the following program:
-	//
-	// #include <string.h>
-	// #include <stdio.h>
-	// #include <blkid/blkid.h>
-	// int main(int argc, char *argv[]) {
-	//   char out[2048] = {0};
-	//   if (blkid_encode_string(argv[1], out, sizeof(out)) != 0) {
-	//     fprintf(stderr, "failed to encode string\n");
-	//     return 1;
-	//   }
-	//   fprintf(stdout, out);
-	//   return 0;
-	// }
-	for i, tc := range []struct {
-		what string
-		exp  string
-	}{
-		{"foo", "foo"},
-		{"foo bar", `foo\x20bar`},
-		{"foo/bar", `foo\x2fbar`},
-		{"foo:#.@bar", `foo:#.@bar`},
-		{"foo..bar", `foo..bar`},
-		{"foo/../bar", `foo\x2f..\x2fbar`},
-		{"foo\\bar", `foo\x5cbar`},
-		{"Новый_том", "Новый_том"},
-		{"befs_test", "befs_test"},
-		{"P01_S16A", "P01_S16A"},
-		{"pinkié pie", `pinkié\x20pie`},
-		{"(EFI Boot)", `\x28EFI\x20Boot\x29`},
-		{"[System Boot]", `\x5bSystem\x20Boot\x5d`},
-	} {
-		c.Logf("tc: %v %q", i, tc)
-		res := gadget.EncodeLabel(tc.what)
-		c.Check(res, Equals, tc.exp)
-	}
-}
-
 func (d *deviceSuite) TestDeviceFindMountPointErrorsWithBare(c *C) {
 	p, err := gadget.FindMountPointForStructure(&gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{

--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -35,8 +35,6 @@ var (
 	CanUpdateStructure = canUpdateStructure
 	CanUpdateVolume    = canUpdateVolume
 
-	EncodeLabel = encodeLabel
-
 	WriteFile      = writeFileOrSymlink
 	WriteDirectory = writeDirectory
 

--- a/osutil/disks/labels.go
+++ b/osutil/disks/labels.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package disks
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// EncodeHexBlkIDFormat encodes a name for use as a partition or filesystem
+// label symlink by udev. The result matches the output of blkid_encode_string()
+// from libblkid.
+func EncodeHexBlkIDFormat(in string) string {
+	const allowed = `#+-.:=@_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`
+
+	buf := &bytes.Buffer{}
+
+	for _, r := range in {
+		switch {
+		case utf8.RuneLen(r) > 1:
+			buf.WriteRune(r)
+		case !strings.ContainsRune(allowed, r):
+			fmt.Fprintf(buf, `\x%x`, r)
+		default:
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
+}

--- a/osutil/disks/labels_test.go
+++ b/osutil/disks/labels_test.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package disks_test
+
+import (
+	"testing"
+
+	"github.com/snapcore/snapd/osutil/disks"
+	"gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type diskLabelSuite struct{}
+
+var _ = Suite(&diskLabelSuite{})
+
+func (ts *diskLabelSuite) TestEncodeHexBlkIDFormat(c *C) {
+	// Test output obtained with the following program:
+	//
+	// #include <string.h>
+	// #include <stdio.h>
+	// #include <blkid/blkid.h>
+	// int main(int argc, char *argv[]) {
+	//   char out[2048] = {0};
+	//   if (blkid_encode_string(argv[1], out, sizeof(out)) != 0) {
+	//     fprintf(stderr, "failed to encode string\n");
+	//     return 1;
+	//   }
+	//   fprintf(stdout, out);
+	//   return 0;
+	// }
+
+	tt := []struct {
+		in  string
+		out string
+	}{
+		// no changes
+		{"foo", "foo"},
+		{"plain", "plain"},
+		{"plain-ol-data", "plain-ol-data"},
+		{"foo:#.@bar", `foo:#.@bar`},
+		{"foo..bar", `foo..bar`},
+		{"3005", "3005"},
+		{"#1-the_BEST@colons:+easter.eggs=something", "#1-the_BEST@colons:+easter.eggs=something"},
+		{"", ""},
+		{"befs_test", "befs_test"},
+		{"P01_S16A", "P01_S16A"},
+
+		// these are single length utf-8 runes, so they are not encoded
+		{"héllo", "héllo"},
+		{"he🐧lo", "he🐧lo"},
+		{"Новый_том", "Новый_том"},
+
+		// these are "unsafe" chars, so they get encoded
+		{"ubuntu data", `ubuntu\x20data`},
+		{"ubuntu\ttab", `ubuntu\x9tab`},
+		{"ubuntu\nnewline", `ubuntu\xanewline`},
+		{"foo bar", `foo\x20bar`},
+		{"foo/bar", `foo\x2fbar`},
+		{"foo/../bar", `foo\x2f..\x2fbar`},
+		{"foo\\bar", `foo\x5cbar`},
+		{"pinkié pie", `pinkié\x20pie`},
+		{"(EFI Boot)", `\x28EFI\x20Boot\x29`},
+		{"[System Boot]", `\x5bSystem\x20Boot\x5d`},
+	}
+	for _, t := range tt {
+		c.Logf("tc: %v %q", t.in, t.out)
+		c.Assert(disks.EncodeHexBlkIDFormat(t.in), check.Equals, t.out)
+	}
+}


### PR DESCRIPTION
This is so that it can be used more widely outside of gadget, i.e. in the rest of the osutil/disks package in https://github.com/snapcore/snapd/pull/8675