### PR TITLE
snapstate: fix autorefresh from classic->strict

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -941,11 +941,6 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 
 	params := func(update *snap.Info) (*RevisionOptions, Flags, *SnapState) {
 		snapst := stateByInstanceName[update.InstanceName()]
-		updateFlags := snapst.Flags
-		if !update.NeedsClassic() && updateFlags.Classic {
-			// allow updating from classic to strict
-			updateFlags.Classic = false
-		}
 		// setting options to what's in state as multi-refresh doesn't let you change these
 		opts := &RevisionOptions{
 			Channel:   snapst.TrackingChannel,
@@ -1485,12 +1480,7 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 	}
 
 	params := func(update *snap.Info) (*RevisionOptions, Flags, *SnapState) {
-		updateFlags := flags
-		if !update.NeedsClassic() && updateFlags.Classic {
-			// allow updating from classic to strict
-			updateFlags.Classic = false
-		}
-		return opts, updateFlags, &snapst
+		return opts, flags, &snapst
 	}
 
 	_, tts, err := doUpdate(context.TODO(), st, []string{name}, updates, params, userID, &flags, deviceCtx, fromChange)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -677,7 +677,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 	}
 	info.InstanceKey = instanceKey
 
-	newFlags, err := ensureInstallPreconditions(st, info, flags, &snapst, deviceCtx)
+	flags, err = ensureInstallPreconditions(st, info, flags, &snapst, deviceCtx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -692,7 +692,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		SideInfo:    si,
 		SnapPath:    path,
 		Channel:     channel,
-		Flags:       newFlags.ForSnapSetup(),
+		Flags:       flags.ForSnapSetup(),
 		Type:        info.GetType(),
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: info.InstanceKey,
@@ -764,7 +764,7 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 		return nil, fmt.Errorf("unexpected snap type %q, instead of 'base'", info.GetType())
 	}
 
-	newFlags, err := ensureInstallPreconditions(st, info, flags, &snapst, deviceCtx)
+	flags, err = ensureInstallPreconditions(st, info, flags, &snapst, deviceCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -774,7 +774,7 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 		Base:         info.Base,
 		Prereq:       defaultContentPlugProviders(st, info),
 		UserID:       userID,
-		Flags:        newFlags.ForSnapSetup(),
+		Flags:        flags.ForSnapSetup(),
 		DownloadInfo: &info.DownloadInfo,
 		SideInfo:     &info.SideInfo,
 		Type:         info.GetType(),
@@ -837,7 +837,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 		var snapst SnapState
 		var flags Flags
 
-		newFlags, err := ensureInstallPreconditions(st, info, flags, &snapst, deviceCtx)
+		flags, err := ensureInstallPreconditions(st, info, flags, &snapst, deviceCtx)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -852,7 +852,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 			Base:         info.Base,
 			Prereq:       defaultContentPlugProviders(st, info),
 			UserID:       userID,
-			Flags:        newFlags.ForSnapSetup(),
+			Flags:        flags.ForSnapSetup(),
 			DownloadInfo: &info.DownloadInfo,
 			SideInfo:     &info.SideInfo,
 			Type:         info.GetType(),
@@ -1019,7 +1019,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 		revnoOpts, flags, snapst := params(update)
 		flags.IsAutoRefresh = globalFlags.IsAutoRefresh
 
-		newFlags, err := ensureInstallPreconditions(st, update, flags, snapst, deviceCtx)
+		flags, err := ensureInstallPreconditions(st, update, flags, snapst, deviceCtx)
 		if err != nil {
 			if refreshAll {
 				logger.Noticef("cannot update %q: %v", update.InstanceName(), err)
@@ -1047,7 +1047,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 			Channel:      revnoOpts.Channel,
 			CohortKey:    revnoOpts.CohortKey,
 			UserID:       snapUserID,
-			Flags:        newFlags.ForSnapSetup(),
+			Flags:        flags.ForSnapSetup(),
 			DownloadInfo: &update.DownloadInfo,
 			SideInfo:     &update.SideInfo,
 			Type:         update.GetType(),

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -513,7 +513,7 @@ func (s *snapmgrTestSuite) TestInstallSnapWithDefaultTrack(c *C) {
 	defer s.state.Unlock()
 
 	opts := &snapstate.RevisionOptions{Channel: "candidate"}
-	ts, err := snapstate.Install(context.Background(), s.state, "some-snap-with-default-track", opts, s.user.ID, snapstate.Flags{Classic: true})
+	ts, err := snapstate.Install(context.Background(), s.state, "some-snap-with-default-track", opts, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
 	chg := s.state.NewChange("install", "install snap")

--- a/tests/main/refresh-classic/task.yaml
+++ b/tests/main/refresh-classic/task.yaml
@@ -1,0 +1,38 @@
+summary: Check that refresh from classic->strict works
+
+# ubuntu-core does not support classic confinement
+systems: [-ubuntu-core-*]
+
+prepare: |
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+
+    case "$SPREAD_SYSTEM" in
+        fedora-*|arch-*|centos-*)
+            # although classic snaps do not work out of the box on fedora,
+            # we still want to verify if the basics do work if the user
+            # symlinks /snap to $SNAP_MOUNT_DIR themselves
+            ln -sf $SNAP_MOUNT_DIR /snap
+            ;;
+    esac
+
+restore: |
+    case "$SPREAD_SYSTEM" in
+        fedora-*|arch-*|centos-*)
+            rm -f /snap
+            ;;
+    esac
+
+execute: |
+    echo "Install a snap that needs classic confinement"
+    snap install --classic --edge test-snapd-classic-confinement
+    snap list test-snapd-classic-confinement | MATCH '2.0\+fake1'
+
+    echo "Now switch to candidate that is strictly confined"
+    snap switch --candidate test-snapd-classic-confinement
+
+    echo "And validate that a refresh will go from classic->strict"
+    snap refresh
+
+    echo "Validate we got the new version"
+    snap list test-snapd-classic-confinement | MATCH '2.0\+now-strict'


### PR DESCRIPTION
We got a bugreport that going from classic->strict in a refresh
does not work. This commit fixes this issue.

Back in c6117368b75 code was added in validateFlagsForInfo() to
check that it is not possible to do:
```
$ snap install --classic test-snapd-tools
```
i.e. this resulted in an error with this check.

However in 9e3b3a43f32 this was changed so that it is now possible
to do such an install. If this happens the --classic option is
simply ignored.

This commit now changes the code from 9e3b3a43f32 to also apply
to refreshes, not just installs.  This fixes refreshes that go
from classic->strict. This unblocks multipass (LP: #1883538).

I renamed the checkInstallPreconditions to ensureInstallPreconditions because
this code is now doing more than just checking.