### PR TITLE
many: rename back snap.Info.GetType to Type

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -529,10 +529,10 @@ func (s *bootenvSuite) TestParticipantBaseWithModel(c *C) {
 
 	for i, t := range table {
 		dev := boottest.MockDevice(t.model)
-		bp := boot.Participant(t.with, t.with.GetType(), dev)
+		bp := boot.Participant(t.with, t.with.Type(), dev)
 		c.Check(bp.IsTrivial(), Equals, t.nop, Commentf("%d", i))
 		if !t.nop {
-			c.Check(bp, DeepEquals, boot.NewCoreBootParticipant(t.with, t.with.GetType(), dev))
+			c.Check(bp, DeepEquals, boot.NewCoreBootParticipant(t.with, t.with.Type(), dev))
 		}
 	}
 }

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -77,7 +77,7 @@ func (s *bootenvSuite) TestSetNextBootForCore(c *C) {
 	info.RealName = "core"
 	info.Revision = snap.R(100)
 
-	bs := boot.NewCoreBootParticipant(info, info.GetType(), coreDev)
+	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
 	reboot, err := bs.SetNextBoot()
 	c.Assert(err, IsNil)
 
@@ -99,7 +99,7 @@ func (s *bootenvSuite) TestSetNextBootWithBaseForCore(c *C) {
 	info.RealName = "core18"
 	info.Revision = snap.R(1818)
 
-	bs := boot.NewCoreBootParticipant(info, info.GetType(), coreDev)
+	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
 	reboot, err := bs.SetNextBoot()
 	c.Assert(err, IsNil)
 

--- a/cmd/snapinfo.go
+++ b/cmd/snapinfo.go
@@ -61,7 +61,7 @@ func ClientSnapFromSnapInfo(snapInfo *snap.Info) (*client.Snap, error) {
 		Name:        snapInfo.InstanceName(),
 		Revision:    snapInfo.Revision,
 		Summary:     snapInfo.Summary(),
-		Type:        string(snapInfo.GetType()),
+		Type:        string(snapInfo.Type()),
 		Base:        snapInfo.Base,
 		Version:     snapInfo.Version,
 		Channel:     snapInfo.Channel,

--- a/daemon/api_mock_test.go
+++ b/daemon/api_mock_test.go
@@ -51,7 +51,7 @@ func (s *apiSuite) mockSnap(c *C, yamlText string) *snap.Info {
 			},
 		},
 		Current:  snapInfo.Revision,
-		SnapType: string(snapInfo.GetType()),
+		SnapType: string(snapInfo.Type()),
 	})
 
 	// Put the snap into the interface repository

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -397,7 +397,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 	// that boot.MakeBootable can DTRT
 	gadgetFname := ""
 	for _, sn := range bootSnaps {
-		switch sn.Info.GetType() {
+		switch sn.Info.Type() {
 		case snap.TypeGadget:
 			gadgetFname = sn.Path
 		case snap.TypeOS, snap.TypeBase:

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -606,7 +606,7 @@ func (s *imageSuite) TestSetupSeed(c *C) {
 
 			SideInfo: &info.SideInfo,
 
-			EssentialType: info.GetType(),
+			EssentialType: info.Type(),
 			Essential:     true,
 			Required:      true,
 
@@ -741,7 +741,7 @@ func (s *imageSuite) TestSetupSeedLocalCoreBrandKernel(c *C) {
 			}
 		} else {
 			sideInfo = &info.SideInfo
-			snapType = info.GetType()
+			snapType = info.Type()
 		}
 
 		fn := pinfo.Filename()
@@ -869,7 +869,7 @@ func (s *imageSuite) TestSetupSeedDevmodeSnap(c *C) {
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
 			Path:          filepath.Join(seedsnapsdir, info.Filename()),
 			SideInfo:      &info.SideInfo,
-			EssentialType: info.GetType(),
+			EssentialType: info.Type(),
 			Essential:     true,
 			Required:      true,
 			Channel:       "beta",
@@ -978,7 +978,7 @@ func (s *imageSuite) TestSetupSeedWithBase(c *C) {
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
 			Path:          p,
 			SideInfo:      &info.SideInfo,
-			EssentialType: info.GetType(),
+			EssentialType: info.Type(),
 			Essential:     true,
 			Required:      true,
 			Channel:       stableChannel,
@@ -1139,7 +1139,7 @@ func (s *imageSuite) TestSetupSeedWithBaseLegacySnap(c *C) {
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
 			Path:          p,
 			SideInfo:      &info.SideInfo,
-			EssentialType: info.GetType(),
+			EssentialType: info.Type(),
 			Essential:     true,
 			Required:      true,
 			Channel:       stableChannel,
@@ -1234,7 +1234,7 @@ func (s *imageSuite) TestSetupSeedWithBaseDefaultTrackSnap(c *C) {
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
 			Path:          p,
 			SideInfo:      &info.SideInfo,
-			EssentialType: info.GetType(),
+			EssentialType: info.Type(),
 			Essential:     true,
 			Required:      true,
 			Channel:       stableChannel,
@@ -1387,7 +1387,7 @@ func (s *imageSuite) TestSetupSeedLocalSnapsWithStoreAsserts(c *C) {
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
 			Path:          p,
 			SideInfo:      &info.SideInfo,
-			EssentialType: info.GetType(),
+			EssentialType: info.Type(),
 			Essential:     true,
 			Required:      true,
 			Channel:       stableChannel,
@@ -1484,7 +1484,7 @@ func (s *imageSuite) TestSetupSeedLocalSnapsWithChannels(c *C) {
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
 			Path:          p,
 			SideInfo:      &info.SideInfo,
-			EssentialType: info.GetType(),
+			EssentialType: info.Type(),
 			Essential:     true,
 			Required:      true,
 			Channel:       channel,
@@ -2389,7 +2389,7 @@ func (s *imageSuite) TestSetupSeedClassicSnapdOnly(c *C) {
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
 			Path:          p,
 			SideInfo:      &info.SideInfo,
-			EssentialType: info.GetType(),
+			EssentialType: info.Type(),
 			Essential:     true,
 			Required:      true,
 			Channel:       stableChannel,
@@ -2621,7 +2621,7 @@ func (s *imageSuite) TestSetupSeedCore20(c *C) {
 		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
 			Path:          p,
 			SideInfo:      &info.SideInfo,
-			EssentialType: info.GetType(),
+			EssentialType: info.Type(),
 			Essential:     true,
 			Required:      true,
 			Channel:       channel,

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -357,7 +357,7 @@ func (b *Backend) prepareProfiles(snapInfo *snap.Info, opts interfaces.Confineme
 	// Deal with the "snapd" snap - we do the setup slightly differently
 	// here because this will run both on classic and on Ubuntu Core 18
 	// systems but /etc/apparmor.d is not writable on core18 systems
-	if snapInfo.GetType() == snap.TypeSnapd && apparmor_sandbox.ProbedLevel() != apparmor_sandbox.Unsupported {
+	if snapInfo.Type() == snap.TypeSnapd && apparmor_sandbox.ProbedLevel() != apparmor_sandbox.Unsupported {
 		if err := b.setupSnapConfineReexec(snapInfo); err != nil {
 			return nil, fmt.Errorf("cannot create host snap-confine apparmor configuration: %s", err)
 		}
@@ -368,7 +368,7 @@ func (b *Backend) prepareProfiles(snapInfo *snap.Info, opts interfaces.Confineme
 	// See LP:#1460152 and
 	// https://forum.snapcraft.io/t/core-snap-revert-issues-on-core-devices/
 	//
-	if (snapInfo.GetType() == snap.TypeOS || snapInfo.GetType() == snap.TypeSnapd) && !release.OnClassic {
+	if (snapInfo.Type() == snap.TypeOS || snapInfo.Type() == snap.TypeSnapd) && !release.OnClassic {
 		if li, err := filepath.Glob(filepath.Join(apparmor_sandbox.SystemCacheDir, "*")); err == nil {
 			for _, p := range li {
 				if st, err := os.Stat(p); err == nil && st.Mode().IsRegular() && profileIsRemovableOnCoreSetup(p) {

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -89,7 +89,7 @@ func plugAppLabelExpr(plug *interfaces.ConnectedPlug) string {
 // - slot owned by an application snap typically requires rules updates
 func implicitSystemPermanentSlot(slot *snap.SlotInfo) bool {
 	if release.OnClassic &&
-		(slot.Snap.GetType() == snap.TypeOS || slot.Snap.GetType() == snap.TypeSnapd) {
+		(slot.Snap.Type() == snap.TypeOS || slot.Snap.Type() == snap.TypeSnapd) {
 		return true
 	}
 	return false
@@ -100,7 +100,7 @@ func implicitSystemPermanentSlot(slot *snap.SlotInfo) bool {
 // application.
 func implicitSystemConnectedSlot(slot *interfaces.ConnectedSlot) bool {
 	if release.OnClassic &&
-		(slot.Snap().GetType() == snap.TypeOS || slot.Snap().GetType() == snap.TypeSnapd) {
+		(slot.Snap().Type() == snap.TypeOS || slot.Snap().Type() == snap.TypeSnapd) {
 		return true
 	}
 	return false

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -100,7 +100,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	}
 
 	// core/snapd on classic are special
-	if (snapInfo.GetType() == snap.TypeOS || snapInfo.GetType() == snap.TypeSnapd) && release.OnClassic {
+	if (snapInfo.Type() == snap.TypeOS || snapInfo.Type() == snap.TypeSnapd) && release.OnClassic {
 		if err := setupDbusServiceForUserd(snapInfo); err != nil {
 			logger.Noticef("cannot create host `snap userd` dbus service file: %s", err)
 		}

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -35,7 +35,7 @@ func checkSnapType(snapInfo *snap.Info, types []string) error {
 	if len(types) == 0 {
 		return nil
 	}
-	snapType := snapInfo.GetType()
+	snapType := snapInfo.Type()
 	s := string(snapType)
 	if snapType == snap.TypeOS || snapType == snap.TypeSnapd {
 		// we use "core" in the assertions and we need also to

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -144,7 +144,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, _ snap.C
 	kind := ""
 	var snapType snap.Type
 	var getName func(*asserts.Model) string
-	switch snapInfo.GetType() {
+	switch snapInfo.Type() {
 	case snap.TypeGadget:
 		kind = "gadget"
 		snapType = snap.TypeGadget
@@ -204,7 +204,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, _ snap.C
 }
 
 func checkGadgetValid(st *state.State, snapInfo, _ *snap.Info, snapf snap.Container, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
-	if snapInfo.GetType() != snap.TypeGadget {
+	if snapInfo.Type() != snap.TypeGadget {
 		// not a gadget, nothing to do
 		return nil
 	}

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -223,7 +223,7 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 		if err != nil {
 			return nil, err
 		}
-		if info.GetType() == snap.TypeKernel || info.GetType() == snap.TypeGadget {
+		if info.Type() == snap.TypeKernel || info.Type() == snap.TypeGadget {
 			configTs := snapstate.ConfigureSnap(st, info.SnapName(), snapstate.UseConfigDefaults)
 			// wait for the previous configTss
 			configTss = chainTs(configTss, configTs)

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -181,7 +181,7 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 	if release.OnClassic {
 		return nil
 	}
-	if snapInfo.GetType() != snap.TypeGadget {
+	if snapInfo.Type() != snap.TypeGadget {
 		// We are only interested in gadget snaps.
 		return nil
 	}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -45,7 +45,7 @@ import (
 
 func (m *InterfaceManager) selectInterfaceMapper(snaps []*snap.Info) {
 	for _, snapInfo := range snaps {
-		if snapInfo.GetType() == snap.TypeSnapd {
+		if snapInfo.Type() == snap.TypeSnapd {
 			mapper = &CoreSnapdSystemMapper{}
 			break
 		}

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -304,7 +304,7 @@ func (s *helpersSuite) TestCheckIsSystemSnapPresentWithCore(c *C) {
 		Active:      true,
 		Sequence:    []*snap.SideInfo{sideInfo},
 		Current:     sideInfo.Revision,
-		SnapType:    string(snapInfo.GetType()),
+		SnapType:    string(snapInfo.Type()),
 		InstanceKey: snapInfo.InstanceKey,
 	})
 	s.st.Unlock()
@@ -334,7 +334,7 @@ func (s *helpersSuite) TestCheckIsSystemSnapPresentWithSnapd(c *C) {
 		Active:      true,
 		Sequence:    []*snap.SideInfo{sideInfo},
 		Current:     sideInfo.Revision,
-		SnapType:    string(snapInfo.GetType()),
+		SnapType:    string(snapInfo.Type()),
 		InstanceKey: snapInfo.InstanceKey,
 	})
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2019,7 +2019,7 @@ func (s *interfaceManagerSuite) mockSnapInstance(c *C, instanceName, yamlText st
 		Active:      true,
 		Sequence:    []*snap.SideInfo{sideInfo},
 		Current:     sideInfo.Revision,
-		SnapType:    string(snapInfo.GetType()),
+		SnapType:    string(snapInfo.Type()),
 		InstanceKey: snapInfo.InstanceKey,
 	})
 	return snapInfo

--- a/overlord/ifacestate/implicit.go
+++ b/overlord/ifacestate/implicit.go
@@ -44,13 +44,13 @@ func addImplicitSlots(st *state.State, snapInfo *snap.Info) error {
 	// Implicit slots can be added to the special "snapd" snap or to snaps with
 	// type "os". Currently there are no other snaps that gain implicit
 	// interfaces.
-	if snapInfo.GetType() != snap.TypeOS && snapInfo.GetType() != snap.TypeSnapd {
+	if snapInfo.Type() != snap.TypeOS && snapInfo.Type() != snap.TypeSnapd {
 		return nil
 	}
 
 	// If the manager has chosen to put implicit slots on the "snapd" snap
 	// then stop adding them to any other core snaps.
-	if shouldSnapdHostImplicitSlots(mapper) && snapInfo.GetType() != snap.TypeSnapd {
+	if shouldSnapdHostImplicitSlots(mapper) && snapInfo.Type() != snap.TypeSnapd {
 		return nil
 	}
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -700,7 +700,7 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 		hit = strings.Replace(hit, "@ICON@", baseURL.String()+"/icon", -1)
 		hit = strings.Replace(hit, "@VERSION@", info.Version, -1)
 		hit = strings.Replace(hit, "@REVISION@", revno, -1)
-		hit = strings.Replace(hit, `@TYPE@`, string(info.GetType()), -1)
+		hit = strings.Replace(hit, `@TYPE@`, string(info.Type()), -1)
 		hit = strings.Replace(hit, `@EPOCH@`, string(epochBuf), -1)
 		return hit
 	}

--- a/overlord/patch/patch1.go
+++ b/overlord/patch/patch1.go
@@ -56,7 +56,7 @@ var patch1ReadType = func(name string, rev snap.Revision) (snap.Type, error) {
 		return snap.TypeApp, err
 	}
 
-	return info.GetType(), nil
+	return info.Type(), nil
 }
 
 type patch1Flags int

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -85,7 +85,7 @@ func updateCurrentSymlinks(info *snap.Info) (e error) {
 }
 
 func hasFontConfigCache(info *snap.Info) bool {
-	if info.GetType() == snap.TypeOS || info.GetType() == snap.TypeSnapd {
+	if info.Type() == snap.TypeOS || info.Type() == snap.TypeSnapd {
 		return true
 	}
 	return false
@@ -126,7 +126,7 @@ func (b Backend) LinkSnap(info *snap.Info, dev boot.Device, linkCtx LinkContext,
 		})
 	}
 
-	reboot, err := boot.Participant(info, info.GetType(), dev).SetNextBoot()
+	reboot, err := boot.Participant(info, info.Type(), dev).SetNextBoot()
 	if err != nil {
 		return false, err
 	}
@@ -170,7 +170,7 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	}()
 
 	disabledSvcs := linkCtx.PrevDisabledServices
-	if s.GetType() == snap.TypeSnapd {
+	if s.Type() == snap.TypeSnapd {
 		// snapd services are handled separately
 		return generateSnapdWrappers(s)
 	}
@@ -209,7 +209,7 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 }
 
 func removeGeneratedWrappers(s *snap.Info, firstInstallUndo bool, meter progress.Meter) error {
-	if s.GetType() == snap.TypeSnapd {
+	if s.Type() == snap.TypeSnapd {
 		return removeGeneratedSnapdWrappers(s, firstInstallUndo, progress.Null)
 	}
 

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -58,7 +58,7 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 		}
 
 		// this may remove the snap from /var/lib/snapd/snaps depending on installRecord
-		if e := b.RemoveSnapFiles(s, s.GetType(), installRecord, dev, meter); e != nil {
+		if e := b.RemoveSnapFiles(s, s.Type(), installRecord, dev, meter); e != nil {
 			meter.Notify(fmt.Sprintf("while trying to clean up due to previous failure: %v", e))
 		}
 	}()
@@ -90,7 +90,7 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 		return snapType, nil, err
 	}
 
-	t := s.GetType()
+	t := s.Type()
 	if err := boot.Kernel(s, t, dev).ExtractKernelAssets(snapf); err != nil {
 		return snapType, nil, fmt.Errorf("cannot install kernel: %s", err)
 	}

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -405,7 +405,7 @@ func MockCheckSnapCallbacks(checks []CheckSnapCallback) (restore func()) {
 }
 
 func checkSnapdName(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, flags Flags, deviceCtx DeviceContext) error {
-	if snapInfo.GetType() != snap.TypeSnapd {
+	if snapInfo.Type() != snap.TypeSnapd {
 		// not a relevant check
 		return nil
 	}
@@ -417,7 +417,7 @@ func checkSnapdName(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Contai
 }
 
 func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, flags Flags, deviceCtx DeviceContext) error {
-	if snapInfo.GetType() != snap.TypeOS {
+	if snapInfo.Type() != snap.TypeOS {
 		// not a relevant check
 		return nil
 	}
@@ -453,7 +453,7 @@ func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Contain
 }
 
 func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, snapf snap.Container, flags Flags, deviceCtx DeviceContext) error {
-	typ := snapInfo.GetType()
+	typ := snapInfo.Type()
 	kind := ""
 	var whichName func(*asserts.Model) string
 	switch typ {
@@ -513,7 +513,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, snapf sn
 
 func checkBases(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, flags Flags, deviceCtx DeviceContext) error {
 	// check if this is relevant
-	if snapInfo.GetType() != snap.TypeApp && snapInfo.GetType() != snap.TypeGadget {
+	if snapInfo.Type() != snap.TypeApp && snapInfo.Type() != snap.TypeGadget {
 		return nil
 	}
 	if snapInfo.Base == "" {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1192,7 +1192,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	}
 
 	// record type
-	snapst.SetType(newInfo.GetType())
+	snapst.SetType(newInfo.Type())
 
 	pb := NewTaskProgressAdapterLocked(t)
 
@@ -1305,7 +1305,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 
 	// Compatibility with old snapd: check if we have auto-connect task and
 	// if not, inject it after self (link-snap) for snaps that are not core
-	if newInfo.GetType() != snap.TypeOS {
+	if newInfo.Type() != snap.TypeOS {
 		var hasAutoConnect, hasSetupProfiles bool
 		for _, other := range t.Change().Tasks() {
 			// Check if this is auto-connect task for same snap and we it's part of the change with setup-profiles task
@@ -1355,7 +1355,7 @@ func (m *SnapManager) maybeRestart(t *state.Task, info *snap.Info, rebootRequire
 		return
 	}
 
-	typ := info.GetType()
+	typ := info.Type()
 
 	// if bp is non-trivial then either we're not on classic, or the snap is
 	// snapd. So daemonRestartReason will always return "" which is what we
@@ -1447,7 +1447,7 @@ func (m *SnapManager) maybeUndoRemodelBootChanges(t *state.Task) error {
 	if err != nil && err != ErrNoCurrent {
 		return err
 	}
-	bp := boot.Participant(info, info.GetType(), groundDeviceCtx)
+	bp := boot.Participant(info, info.Type(), groundDeviceCtx)
 	reboot, err := bp.SetNextBoot()
 	if err != nil {
 		return err
@@ -1634,7 +1634,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	// the cleanup is performed by snapd from core;
 	// when reverting a subsequent snapd revision, the restart happens in
 	// undoLinkCurrentSnap() instead
-	if linkCtx.FirstInstall && newInfo.GetType() == snap.TypeSnapd {
+	if linkCtx.FirstInstall && newInfo.Type() == snap.TypeSnapd {
 		// only way to get
 		deviceCtx, err := DeviceCtx(st, t, nil)
 		if err != nil {
@@ -1658,7 +1658,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	// snap. We need to undo that restart here. Instead of in
 	// doUnlinkCurrentSnap() like we usually do when going from
 	// core snap -> next core snap
-	if release.OnClassic && newInfo.GetType() == snap.TypeOS && oldCurrent.Unset() {
+	if release.OnClassic && newInfo.Type() == snap.TypeOS && oldCurrent.Unset() {
 		t.Logf("Requested daemon restart (undo classic initial core install)")
 		st.RequestRestart(state.RestartDaemon)
 	}

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -102,7 +102,7 @@ func baseUsedBy(st *state.State, baseName string) ([]string, error) {
 		for _, si := range snapst.Sequence {
 			snapInfo, err := snap.ReadInfo(name, si)
 			if err == nil {
-				if typ := snapInfo.GetType(); typ != snap.TypeApp && typ != snap.TypeGadget {
+				if typ := snapInfo.Type(); typ != snap.TypeApp && typ != snap.TypeGadget {
 					continue
 				}
 				if !(baseName == snapInfo.Base || (alsoCore16 && snapInfo.Base == "core16")) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -692,7 +692,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		SnapPath:    path,
 		Channel:     channel,
 		Flags:       flags.ForSnapSetup(),
-		Type:        info.GetType(),
+		Type:        info.Type(),
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: info.InstanceKey,
 	}
@@ -759,8 +759,8 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 	}
 	info := sar.Info
 
-	if flags.RequireTypeBase && info.GetType() != snap.TypeBase && info.GetType() != snap.TypeOS {
-		return nil, fmt.Errorf("unexpected snap type %q, instead of 'base'", info.GetType())
+	if flags.RequireTypeBase && info.Type() != snap.TypeBase && info.Type() != snap.TypeOS {
+		return nil, fmt.Errorf("unexpected snap type %q, instead of 'base'", info.Type())
 	}
 
 	if flags.Classic && !info.NeedsClassic() {
@@ -780,7 +780,7 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 		Flags:        flags.ForSnapSetup(),
 		DownloadInfo: &info.DownloadInfo,
 		SideInfo:     &info.SideInfo,
-		Type:         info.GetType(),
+		Type:         info.Type(),
 		PlugsOnly:    len(info.Slots) == 0,
 		InstanceKey:  info.InstanceKey,
 		auxStoreInfo: auxStoreInfo{
@@ -857,7 +857,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 			Flags:        flags.ForSnapSetup(),
 			DownloadInfo: &info.DownloadInfo,
 			SideInfo:     &info.SideInfo,
-			Type:         info.GetType(),
+			Type:         info.Type(),
 			PlugsOnly:    len(info.Slots) == 0,
 			InstanceKey:  info.InstanceKey,
 		}
@@ -1056,7 +1056,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 			Flags:        flags.ForSnapSetup(),
 			DownloadInfo: &update.DownloadInfo,
 			SideInfo:     &update.SideInfo,
-			Type:         update.GetType(),
+			Type:         update.Type(),
 			PlugsOnly:    len(update.Slots) == 0,
 			InstanceKey:  update.InstanceKey,
 			auxStoreInfo: auxStoreInfo{
@@ -1079,7 +1079,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 		// because of the sorting of updates we fill prereqs
 		// first (if branch) and only then use it to setup
 		// waits (else branch)
-		if t := update.GetType(); t == snap.TypeOS || t == snap.TypeBase || t == snap.TypeSnapd {
+		if t := update.Type(); t == snap.TypeOS || t == snap.TypeBase || t == snap.TypeSnapd {
 			// prereq types come first in updates, we
 			// also assume bases don't have hooks, otherwise
 			// they would need to wait on core or snapd
@@ -1636,18 +1636,18 @@ func LinkNewBaseOrKernel(st *state.State, name string) (*state.TaskSet, error) {
 		return nil, err
 	}
 
-	switch info.GetType() {
+	switch info.Type() {
 	case snap.TypeOS, snap.TypeBase, snap.TypeKernel:
 		// good
 	default:
 		// bad
-		return nil, fmt.Errorf("cannot link type %v", info.GetType())
+		return nil, fmt.Errorf("cannot link type %v", info.Type())
 	}
 
 	snapsup := &SnapSetup{
 		SideInfo:    snapst.CurrentSideInfo(),
 		Flags:       snapst.Flags.ForSnapSetup(),
-		Type:        info.GetType(),
+		Type:        info.Type(),
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
@@ -1692,7 +1692,7 @@ func Enable(st *state.State, name string) (*state.TaskSet, error) {
 	snapsup := &SnapSetup{
 		SideInfo:    snapst.CurrentSideInfo(),
 		Flags:       snapst.Flags.ForSnapSetup(),
-		Type:        info.GetType(),
+		Type:        info.Type(),
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
@@ -1751,7 +1751,7 @@ func Disable(st *state.State, name string) (*state.TaskSet, error) {
 			RealName: snap.InstanceSnap(name),
 			Revision: snapst.Current,
 		},
-		Type:        info.GetType(),
+		Type:        info.Type(),
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
@@ -1778,7 +1778,7 @@ func Disable(st *state.State, name string) (*state.TaskSet, error) {
 // canDisable verifies that a snap can be deactivated.
 func canDisable(si *snap.Info) bool {
 	for _, importantSnapType := range []snap.Type{snap.TypeGadget, snap.TypeKernel, snap.TypeOS} {
-		if importantSnapType == si.GetType() {
+		if importantSnapType == si.Type() {
 			return false
 		}
 	}
@@ -1793,7 +1793,7 @@ func canRemove(st *state.State, si *snap.Info, snapst *SnapState, removeAll bool
 		rev = si.Revision
 	}
 
-	return PolicyFor(si.GetType(), deviceCtx.Model()).CanRemove(st, snapst, rev, deviceCtx)
+	return PolicyFor(si.Type(), deviceCtx.Model()).CanRemove(st, snapst, rev, deviceCtx)
 }
 
 // RemoveFlags are used to pass additional flags to the Remove operation.
@@ -1865,7 +1865,7 @@ func Remove(st *state.State, name string, revision snap.Revision, flags *RemoveF
 			RealName: snap.InstanceSnap(name),
 			Revision: revision,
 		},
-		Type:        info.GetType(),
+		Type:        info.Type(),
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
@@ -2058,7 +2058,7 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		Base:        info.Base,
 		SideInfo:    snapst.Sequence[i],
 		Flags:       flags.ForSnapSetup(),
-		Type:        info.GetType(),
+		Type:        info.Type(),
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
@@ -2102,7 +2102,7 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 			Channel:      oldSnapst.TrackingChannel,
 			DownloadInfo: &newInfo.DownloadInfo,
 			SideInfo:     &newInfo.SideInfo,
-			Type:         newInfo.GetType(),
+			Type:         newInfo.Type(),
 		}, 0, "", nil)
 		if err != nil {
 			return nil, err

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4538,7 +4538,7 @@ version: v1
 	c.Check(info.InstanceName(), Equals, "gadget")
 	c.Check(info.Revision, Equals, snap.R(2))
 	c.Check(info.Version, Equals, "v1")
-	c.Check(info.GetType(), Equals, snap.TypeGadget)
+	c.Check(info.Type(), Equals, snap.TypeGadget)
 }
 
 func (s *snapmgrQuerySuite) TestKernelInfo(c *C) {
@@ -4583,7 +4583,7 @@ version: v2
 	c.Check(info.InstanceName(), Equals, "pc-kernel")
 	c.Check(info.Revision, Equals, snap.R(3))
 	c.Check(info.Version, Equals, "v2")
-	c.Check(info.GetType(), Equals, snap.TypeKernel)
+	c.Check(info.Type(), Equals, snap.TypeKernel)
 }
 
 func (s *snapmgrQuerySuite) TestBootBaseInfo(c *C) {
@@ -4640,7 +4640,7 @@ version: v20
 	c.Check(info.InstanceName(), Equals, "core20")
 	c.Check(info.Revision, Equals, snap.R(4))
 	c.Check(info.Version, Equals, "v20")
-	c.Check(info.GetType(), Equals, snap.TypeBase)
+	c.Check(info.Type(), Equals, snap.TypeBase)
 }
 
 func (s *snapmgrQuerySuite) TestCoreInfoInternal(c *C) {
@@ -4697,7 +4697,7 @@ func (s *snapmgrQuerySuite) TestCoreInfoInternal(c *C) {
 		} else {
 			c.Assert(info, NotNil)
 			c.Check(info.InstanceName(), Equals, t.expectedSnap, Commentf("(%d) test %q %v", testNr, t.expectedSnap, t.snapNames))
-			c.Check(info.GetType(), Equals, snap.TypeOS)
+			c.Check(info.Type(), Equals, snap.TypeOS)
 		}
 	}
 }

--- a/seed/seedwriter/helpers.go
+++ b/seed/seedwriter/helpers.go
@@ -107,15 +107,15 @@ func checkType(sn *SeedSnap, model *asserts.Model) error {
 		// ModelSnap for Core 16/18 "required-snaps" have
 		// SnapType not set given the model assertion does not
 		// have the information
-		typ := sn.Info.GetType()
+		typ := sn.Info.Type()
 		if typ == snap.TypeKernel || typ == snap.TypeGadget {
 			return fmt.Errorf("snap %q has unexpected type: %s", sn.SnapName(), typ)
 		}
 		return nil
 	}
-	if sn.Info.GetType() != expectedType {
+	if sn.Info.Type() != expectedType {
 		what := whichModelSnap(sn.modelSnap, model)
-		return fmt.Errorf("%s has unexpected type: %s", what, sn.Info.GetType())
+		return fmt.Errorf("%s has unexpected type: %s", what, sn.Info.Type())
 	}
 	return nil
 }
@@ -125,7 +125,7 @@ type seedSnapsByType []*SeedSnap
 func (s seedSnapsByType) Len() int      { return len(s) }
 func (s seedSnapsByType) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s seedSnapsByType) Less(i, j int) bool {
-	return s[i].Info.GetType().SortsBefore(s[j].Info.GetType())
+	return s[i].Info.Type().SortsBefore(s[j].Info.Type())
 }
 
 // finderFromFetcher exposes an assertion Finder interface out of a Fetcher.

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -89,7 +89,7 @@ func (pol *policy16) extraSnapDefaultChannel() string {
 func (pol *policy16) checkBase(info *snap.Info, availableSnaps *naming.SnapSet) error {
 	// snap needs no base (or it simply needs core which is never listed explicitly): nothing to do
 	if info.Base == "" {
-		if info.GetType() == snap.TypeGadget || info.GetType() == snap.TypeApp {
+		if info.Type() == snap.TypeGadget || info.Type() == snap.TypeApp {
 			// remember to make sure we have core installed
 			pol.needsCore = append(pol.needsCore, info.SnapName())
 		}

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -94,7 +94,7 @@ func (pol *policy20) extraSnapDefaultChannel() string {
 func (pol *policy20) checkBase(info *snap.Info, availableSnaps *naming.SnapSet) error {
 	base := info.Base
 	if base == "" {
-		if info.GetType() != snap.TypeGadget && info.GetType() != snap.TypeApp {
+		if info.Type() != snap.TypeGadget && info.Type() != snap.TypeApp {
 			return nil
 		}
 		base = "core"

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -813,7 +813,7 @@ func (w *Writer) checkBase(info *snap.Info) error {
 	// Sanity check, note that we could support this case
 	// if we have a use-case but it requires changes in the
 	// devicestate/firstboot.go ordering code.
-	if info.GetType() == snap.TypeGadget && !w.model.Classic() && info.Base != w.model.Base() {
+	if info.Type() == snap.TypeGadget && !w.model.Classic() && info.Base != w.model.Base() {
 		return fmt.Errorf("cannot use gadget snap because its base %q is different from model base %q", info.Base, w.model.Base())
 	}
 
@@ -958,7 +958,7 @@ func (w *Writer) checkPublisher(sn *SeedSnap) error {
 	}
 	info := sn.Info
 	var kind string
-	switch info.GetType() {
+	switch info.Type() {
 	case snap.TypeKernel:
 		kind = "kernel"
 	case snap.TypeGadget:
@@ -1089,7 +1089,7 @@ func (w *Writer) BootSnaps() ([]*SeedSnap, error) {
 	var bootSnaps []*SeedSnap
 	for _, sn := range w.snapsFromModel {
 		bootSnaps = append(bootSnaps, sn)
-		if sn.Info.GetType() == snap.TypeGadget {
+		if sn.Info.Type() == snap.TypeGadget {
 			break
 
 		}

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -712,7 +712,7 @@ func (s *writerSuite) TestDownloadedCheckType(c *C) {
 
 		_, _, err := s.upToDownloaded(c, model, s.fillMetaDownloadedSnap)
 
-		expErr := fmt.Sprintf("%s %q has unexpected type: %v", t.what, t.wrongTypeSnap, s.AssertedSnapInfo(t.wrongTypeSnap).GetType())
+		expErr := fmt.Sprintf("%s %q has unexpected type: %v", t.what, t.wrongTypeSnap, s.AssertedSnapInfo(t.wrongTypeSnap).Type())
 		c.Check(err, ErrorMatches, expErr)
 	}
 }

--- a/snap/broken.go
+++ b/snap/broken.go
@@ -90,7 +90,7 @@ func GuessAppsForBroken(info *Info) map[string]*AppInfo {
 // was not validated before.  To avoid a flag day and any potential issues,
 // transparently rename the two clashing plugs by appending the "-plug" suffix.
 func (info *Info) renameClashingCorePlugs() {
-	if info.InstanceName() == "core" && info.GetType() == TypeOS {
+	if info.InstanceName() == "core" && info.Type() == TypeOS {
 		for _, plugName := range []string{"network-bind", "core-support"} {
 			info.forceRenamePlug(plugName, plugName+"-plug")
 		}

--- a/snap/info.go
+++ b/snap/info.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2016 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -433,9 +433,9 @@ func (s *Info) Description() string {
 	return s.OriginalDescription
 }
 
-// GetType returns the type of the snap, including additional snap ID check
+// Type returns the type of the snap, including additional snap ID check
 // for the legacy snapd snap definitions.
-func (s *Info) GetType() Type {
+func (s *Info) Type() Type {
 	if s.SnapType == TypeApp && IsSnapd(s.SnapID) {
 		return TypeSnapd
 	}
@@ -1284,7 +1284,7 @@ type ByType []*Info
 func (r ByType) Len() int      { return len(r) }
 func (r ByType) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
 func (r ByType) Less(i, j int) bool {
-	return r[i].GetType().SortsBefore(r[j].GetType())
+	return r[i].Type().SortsBefore(r[j].Type())
 }
 
 // SortServices sorts the apps based on their Before and After specs, such that

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -61,7 +61,7 @@ func (s *InfoSnapYamlTestSuite) TestSimple(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(info.InstanceName(), Equals, "foo")
 	c.Assert(info.Version, Equals, "1.0")
-	c.Assert(info.GetType(), Equals, snap.TypeApp)
+	c.Assert(info.Type(), Equals, snap.TypeApp)
 	c.Assert(info.Epoch, DeepEquals, snap.E("0"))
 }
 
@@ -71,7 +71,7 @@ version: 1.0`))
 	c.Assert(err, IsNil)
 	c.Assert(info.InstanceName(), Equals, "snapd")
 	c.Assert(info.Version, Equals, "1.0")
-	c.Assert(info.GetType(), Equals, snap.TypeSnapd)
+	c.Assert(info.Type(), Equals, snap.TypeSnapd)
 }
 
 func (s *InfoSnapYamlTestSuite) TestFail(c *C) {
@@ -1225,7 +1225,7 @@ slots:
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.2")
-	c.Check(info.GetType(), Equals, snap.TypeApp)
+	c.Check(info.Type(), Equals, snap.TypeApp)
 	c.Check(info.Epoch, DeepEquals, snap.E("1*"))
 	c.Check(info.Confinement, Equals, snap.DevModeConfinement)
 	c.Check(info.Title(), Equals, "Foo")
@@ -1416,7 +1416,7 @@ version: 1.0
 `)
 	info, err := snap.InfoFromSnapYaml(y)
 	c.Assert(err, IsNil)
-	c.Assert(info.GetType(), Equals, snap.TypeApp)
+	c.Assert(info.Type(), Equals, snap.TypeApp)
 }
 
 func (s *YamlSuite) TestSnapYamlEpochDefault(c *C) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -403,7 +403,7 @@ confinement: devmode`
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.0")
-	c.Check(info.GetType(), Equals, snap.TypeApp)
+	c.Check(info.Type(), Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(0))
 	c.Check(info.Epoch.String(), Equals, "1*")
 	c.Check(info.Confinement, Equals, snap.DevModeConfinement)
@@ -425,7 +425,7 @@ confinement: classic`
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.0")
-	c.Check(info.GetType(), Equals, snap.TypeApp)
+	c.Check(info.Type(), Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(0))
 	c.Check(info.Confinement, Equals, snap.ClassicConfinement)
 	c.Check(info.NeedsDevMode(), Equals, false)
@@ -445,7 +445,7 @@ type: app`
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.0")
-	c.Check(info.GetType(), Equals, snap.TypeApp)
+	c.Check(info.Type(), Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(0))
 	c.Check(info.Epoch.String(), Equals, "0") // Defaults to 0
 	c.Check(info.Confinement, Equals, snap.StrictConfinement)
@@ -468,7 +468,7 @@ type: app`
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "baz")
 	c.Check(info.Version, Equals, "1.0")
-	c.Check(info.GetType(), Equals, snap.TypeApp)
+	c.Check(info.Type(), Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(42))
 }
 
@@ -1566,14 +1566,14 @@ func (s *infoSuite) TestIsActive(c *C) {
 	c.Check(info2.IsActive(), Equals, false)
 }
 
-func (s *infoSuite) TestGetTypeSnapdBackwardCompatibility(c *C) {
+func (s *infoSuite) TestInfoTypeSnapdBackwardCompatibility(c *C) {
 	const snapdYaml = `
 name: snapd
 type: app
 version: 1
 `
 	snapInfo := snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{Revision: snap.R(1), SnapID: "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"})
-	c.Check(snapInfo.GetType(), Equals, snap.TypeSnapd)
+	c.Check(snapInfo.Type(), Equals, snap.TypeSnapd)
 }
 
 func (s *infoSuite) TestDirAndFileHelpers(c *C) {

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -220,7 +220,7 @@ func Snap(sourceDir string, opts *Options) (string, error) {
 	snapName := snapPath(info, opts.TargetDir, opts.SnapName)
 	d := squashfs.New(snapName)
 	if err = d.Build(sourceDir, &squashfs.BuildOpts{
-		SnapType:     string(info.GetType()),
+		SnapType:     string(info.Type()),
 		Compression:  opts.Compression,
 		ExcludeFiles: []string{excludes},
 	}); err != nil {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -370,9 +370,9 @@ func Validate(info *Info) error {
 // ValidateBase validates the base field.
 func ValidateBase(info *Info) error {
 	// validate that bases do not have base fields
-	if info.GetType() == TypeOS || info.GetType() == TypeBase {
+	if info.Type() == TypeOS || info.Type() == TypeBase {
 		if info.Base != "" && info.Base != "none" {
-			return fmt.Errorf(`cannot have "base" field on %q snap %q`, info.GetType(), info.InstanceName())
+			return fmt.Errorf(`cannot have "base" field on %q snap %q`, info.Type(), info.InstanceName())
 		}
 	}
 

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -229,7 +229,7 @@ func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Back
 		Digest:      snapDigest,
 		Size:        size,
 		Confinement: string(info.Confinement),
-		Type:        string(info.GetType()),
+		Type:        string(info.Type()),
 	}, nil
 }
 

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -128,7 +128,7 @@ func undoSnapdToolingMountUnit(sysd systemd.Systemd) error {
 // AddSnapdSnapServices sets up the services based on a given snapd snap in the
 // system.
 func AddSnapdSnapServices(s *snap.Info, inter interacter) error {
-	if snapType := s.GetType(); snapType != snap.TypeSnapd {
+	if snapType := s.Type(); snapType != snap.TypeSnapd {
 		return fmt.Errorf("internal error: adding explicit snapd services for snap %q type %q is unexpected", s.InstanceName(), snapType)
 	}
 
@@ -490,7 +490,7 @@ func undoSnapdUserServicesOnCore(s *snap.Info, inter interacter) error {
 // restoring the system state, making this undo helper suitable for use when
 // reverting the first installation of the snapd snap on a core device.
 func RemoveSnapdSnapServicesOnCore(s *snap.Info, inter interacter) error {
-	if snapType := s.GetType(); snapType != snap.TypeSnapd {
+	if snapType := s.Type(); snapType != snap.TypeSnapd {
 		return fmt.Errorf("internal error: removing explicit snapd services for snap %q type %q is unexpected", s.InstanceName(), snapType)
 	}
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -292,7 +292,7 @@ type AddSnapServicesOptions struct {
 
 // AddSnapServices adds service units for the applications from the snap which are services.
 func AddSnapServices(s *snap.Info, disabledSvcs []string, opts *AddSnapServicesOptions, inter interacter) (err error) {
-	if s.GetType() == snap.TypeSnapd {
+	if s.Type() == snap.TypeSnapd {
 		return fmt.Errorf("internal error: adding explicit services for snapd snap is unexpected")
 	}
 
@@ -550,7 +550,7 @@ func ServicesEnableState(s *snap.Info, inter interacter) (map[string]bool, error
 // from the snap which are services. The optional flag indicates whether
 // services are removed as part of undoing of first install of a given snap.
 func RemoveSnapServices(s *snap.Info, inter interacter) error {
-	if s.GetType() == snap.TypeSnapd {
+	if s.Type() == snap.TypeSnapd {
 		return fmt.Errorf("internal error: removing explicit services for snapd snap is unexpected")
 	}
 	systemSysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, inter)


### PR DESCRIPTION
to follow again golang naming conventions
