### PR TITLE
tests: mock servicestate in api tests to avoid systemctl checks  (6/8)

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -114,6 +114,8 @@ var api = []*Command{
 	systemsActionCmd,
 }
 
+var servicestateControl = servicestate.Control
+
 var (
 	// see daemon.go:canAccess for details how the access is controlled
 	rootCmd = &Command{
@@ -2436,7 +2438,7 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("no services found")
 	}
 
-	tss, err := servicestate.Control(st, appInfos, &inst, nil)
+	tss, err := servicestateControl(st, appInfos, &inst, nil)
 	if err != nil {
 		// TODO: use errToResponse here too and introduce a proper error kind ?
 		if _, ok := err.(servicestate.ServiceActionConflictError); ok {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -105,7 +105,6 @@ type apiBaseSuite struct {
 
 	systemctlRestorer func()
 	sysctlBufs        [][]byte
-	sysctlErrs        []error
 
 	journalctlRestorer func()
 	jctlSvcses         [][]string
@@ -245,9 +244,6 @@ func (s *apiBaseSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *apiBaseSuite) systemctl(args ...string) (buf []byte, err error) {
-	if len(s.sysctlErrs) > 0 {
-		err, s.sysctlErrs = s.sysctlErrs[0], s.sysctlErrs[1:]
-	}
 	if len(s.sysctlBufs) > 0 {
 		buf, s.sysctlBufs = s.sysctlBufs[0], s.sysctlBufs[1:]
 	}
@@ -272,7 +268,6 @@ func (s *apiBaseSuite) journalctl(svcs []string, n int, follow bool) (rc io.Read
 
 func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	s.sysctlBufs = nil
-	s.sysctlErrs = nil
 	s.jctlSvcses = nil
 	s.jctlNs = nil
 	s.jctlFollows = nil

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -371,6 +371,8 @@ func (s *apiBaseSuite) fakeServiceControl(st *state.State, appInfos []*snap.AppI
 	if inst.RestartOptions.Reload {
 		serviceCommand.options = "reload"
 	}
+	// only one flag should ever be set (depending on Action), but appending
+	// them below acts as an extra sanity check.
 	if inst.StartOptions.Enable {
 		serviceCommand.options += "enable"
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -104,7 +104,6 @@ type apiBaseSuite struct {
 	brands            *assertstest.SigningAccounts
 
 	systemctlRestorer func()
-	sysctlArgses      [][]string
 	sysctlBufs        [][]byte
 	sysctlErrs        []error
 
@@ -115,6 +114,9 @@ type apiBaseSuite struct {
 	jctlRCs            []io.ReadCloser
 	jctlErrs           []error
 
+	serviceControlError error
+	serviceControlCalls []serviceControlArgs
+
 	connectivityResult     map[string]bool
 	loginUserStoreMacaroon string
 	loginUserDischarge     string
@@ -124,6 +126,12 @@ type apiBaseSuite struct {
 	restoreSanitize func()
 
 	testutil.BaseTest
+}
+
+type serviceControlArgs struct {
+	action  string
+	options string
+	names   []string
 }
 
 func (s *apiBaseSuite) pokeStateLock() {
@@ -237,19 +245,6 @@ func (s *apiBaseSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *apiBaseSuite) systemctl(args ...string) (buf []byte, err error) {
-	s.sysctlArgses = append(s.sysctlArgses, args)
-
-	if len(args) > 2 && args[0] == "--root" && args[2] == "is-enabled" {
-		// drop the first 2 args which are "--root some-dir"
-		args = args[2:]
-	}
-
-	switch args[0] {
-	case "show", "start", "stop", "restart", "is-enabled":
-	default:
-		panic(fmt.Sprintf("unexpected systemctl call: %v", args))
-	}
-
 	if len(s.sysctlErrs) > 0 {
 		err, s.sysctlErrs = s.sysctlErrs[0], s.sysctlErrs[1:]
 	}
@@ -276,7 +271,6 @@ func (s *apiBaseSuite) journalctl(svcs []string, n int, follow bool) (rc io.Read
 }
 
 func (s *apiBaseSuite) SetUpTest(c *check.C) {
-	s.sysctlArgses = nil
 	s.sysctlBufs = nil
 	s.sysctlErrs = nil
 	s.jctlSvcses = nil
@@ -329,6 +323,11 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	snapstateSwitch = nil
 
 	devicestateRemodel = nil
+
+	s.serviceControlCalls = nil
+	s.serviceControlError = nil
+	restoreServicestateCtrl := MockServicestateControl(s.fakeServiceControl)
+	s.AddCleanup(restoreServicestateCtrl)
 }
 
 func (s *apiBaseSuite) TearDownTest(c *check.C) {
@@ -358,6 +357,34 @@ var modelDefaults = map[string]interface{}{
 	"architecture": "amd64",
 	"gadget":       "gadget",
 	"kernel":       "kernel",
+}
+
+func (s *apiBaseSuite) fakeServiceControl(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, context *hookstate.Context) ([]*state.TaskSet, error) {
+	st.Lock()
+	defer st.Unlock()
+
+	if s.serviceControlError != nil {
+		return nil, s.serviceControlError
+	}
+
+	serviceCommand := serviceControlArgs{action: inst.Action}
+	if inst.RestartOptions.Reload {
+		serviceCommand.options = "reload"
+	}
+	if inst.StartOptions.Enable {
+		serviceCommand.options += "enable"
+	}
+	if inst.StopOptions.Disable {
+		serviceCommand.options += "disable"
+	}
+	for _, app := range appInfos {
+		serviceCommand.names = append(serviceCommand.names, fmt.Sprintf("%s.%s", app.Snap.InstanceName(), app.Name))
+	}
+	s.serviceControlCalls = append(s.serviceControlCalls, serviceCommand)
+
+	t := st.NewTask("dummy", "")
+	ts := state.NewTaskSet(t)
+	return []*state.TaskSet{ts}, nil
 }
 
 func (s *apiBaseSuite) mockModel(c *check.C, st *state.State, model *asserts.Model) {
@@ -7217,7 +7244,7 @@ func (s *appSuite) TestLogsSad(c *check.C) {
 	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
 }
 
-func (s *appSuite) testPostApps(c *check.C, inst servicestate.Instruction, systemctlCall [][]string) *state.Change {
+func (s *appSuite) testPostApps(c *check.C, inst servicestate.Instruction, servicecmds []serviceControlArgs) *state.Change {
 	postBody, err := json.Marshal(inst)
 	c.Assert(err, check.IsNil)
 
@@ -7234,19 +7261,21 @@ func (s *appSuite) testPostApps(c *check.C, inst servicestate.Instruction, syste
 	defer st.Unlock()
 	chg := st.Change(rsp.Change)
 	c.Assert(chg, check.NotNil)
-	c.Check(chg.Tasks(), check.HasLen, len(systemctlCall))
+	c.Check(chg.Tasks(), check.HasLen, len(servicecmds))
 
 	st.Unlock()
 	<-chg.Ready()
 	st.Lock()
 
-	c.Check(s.cmd.Calls(), check.DeepEquals, systemctlCall)
+	c.Check(s.serviceControlCalls, check.DeepEquals, servicecmds)
 	return chg
 }
 
 func (s *appSuite) TestPostAppsStartOne(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a.svc2"}}
-	expected := [][]string{{"systemctl", "start", "snap.snap-a.svc2.service"}}
+	expected := []serviceControlArgs{
+		{action: "start", names: []string{"snap-a.svc2"}},
+	}
 	chg := s.testPostApps(c, inst, expected)
 	chg.State().Lock()
 	defer chg.State().Unlock()
@@ -7259,13 +7288,13 @@ func (s *appSuite) TestPostAppsStartOne(c *check.C) {
 
 func (s *appSuite) TestPostAppsStartTwo(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a"}}
-	expected := [][]string{{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service"}}
+	expected := []serviceControlArgs{
+		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2"}},
+	}
 	chg := s.testPostApps(c, inst, expected)
+
 	chg.State().Lock()
 	defer chg.State().Unlock()
-	// check the summary expands the snap into actual apps
-	c.Check(chg.Summary(), check.Equals, "Running service command")
-	c.Check(chg.Tasks()[0].Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2]")
 
 	var names []string
 	err := chg.Get("snap-names", &names)
@@ -7275,13 +7304,14 @@ func (s *appSuite) TestPostAppsStartTwo(c *check.C) {
 
 func (s *appSuite) TestPostAppsStartThree(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a", "snap-b"}}
-	expected := [][]string{{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service", "snap.snap-b.svc3.service"}}
+	expected := []serviceControlArgs{
+		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2", "snap-b.svc3"}},
+	}
 	chg := s.testPostApps(c, inst, expected)
 	// check the summary expands the snap into actual apps
 	c.Check(chg.Summary(), check.Equals, "Running service command")
 	chg.State().Lock()
 	defer chg.State().Unlock()
-	c.Check(chg.Tasks()[0].Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2 snap-b.svc3]")
 
 	var names []string
 	err := chg.Get("snap-names", &names)
@@ -7289,36 +7319,46 @@ func (s *appSuite) TestPostAppsStartThree(c *check.C) {
 	c.Assert(names, check.DeepEquals, []string{"snap-a", "snap-b"})
 }
 
-func (s *appSuite) TestPosetAppsStop(c *check.C) {
+func (s *appSuite) TestPostAppsStop(c *check.C) {
 	inst := servicestate.Instruction{Action: "stop", Names: []string{"snap-a.svc2"}}
-	expected := [][]string{{"systemctl", "stop", "snap.snap-a.svc2.service"}}
+	expected := []serviceControlArgs{
+		{action: "stop", names: []string{"snap-a.svc2"}},
+	}
 	s.testPostApps(c, inst, expected)
 }
 
-func (s *appSuite) TestPosetAppsRestart(c *check.C) {
+func (s *appSuite) TestPostAppsRestart(c *check.C) {
 	inst := servicestate.Instruction{Action: "restart", Names: []string{"snap-a.svc2"}}
-	expected := [][]string{{"systemctl", "restart", "snap.snap-a.svc2.service"}}
+	expected := []serviceControlArgs{
+		{action: "restart", names: []string{"snap-a.svc2"}},
+	}
 	s.testPostApps(c, inst, expected)
 }
 
-func (s *appSuite) TestPosetAppsReload(c *check.C) {
+func (s *appSuite) TestPostAppsReload(c *check.C) {
 	inst := servicestate.Instruction{Action: "restart", Names: []string{"snap-a.svc2"}}
 	inst.Reload = true
-	expected := [][]string{{"systemctl", "reload-or-restart", "snap.snap-a.svc2.service"}}
+	expected := []serviceControlArgs{
+		{action: "restart", options: "reload", names: []string{"snap-a.svc2"}},
+	}
 	s.testPostApps(c, inst, expected)
 }
 
-func (s *appSuite) TestPosetAppsEnableNow(c *check.C) {
+func (s *appSuite) TestPostAppsEnableNow(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a.svc2"}}
 	inst.Enable = true
-	expected := [][]string{{"systemctl", "enable", "snap.snap-a.svc2.service"}, {"systemctl", "start", "snap.snap-a.svc2.service"}}
+	expected := []serviceControlArgs{
+		{action: "start", options: "enable", names: []string{"snap-a.svc2"}},
+	}
 	s.testPostApps(c, inst, expected)
 }
 
-func (s *appSuite) TestPosetAppsDisableNow(c *check.C) {
+func (s *appSuite) TestPostAppsDisableNow(c *check.C) {
 	inst := servicestate.Instruction{Action: "stop", Names: []string{"snap-a.svc2"}}
 	inst.Disable = true
-	expected := [][]string{{"systemctl", "disable", "snap.snap-a.svc2.service"}, {"systemctl", "stop", "snap.snap-a.svc2.service"}}
+	expected := []serviceControlArgs{
+		{action: "stop", options: "disable", names: []string{"snap-a.svc2"}},
+	}
 	s.testPostApps(c, inst, expected)
 }
 
@@ -7358,34 +7398,20 @@ func (s *appSuite) TestPostAppsBadApp(c *check.C) {
 	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `snap "snap-a" has no service "what"`)
 }
 
-func (s *appSuite) TestPostAppsBadAction(c *check.C) {
-	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "discombobulate", "names": ["snap-a.svc1"]}`))
+func (s *appSuite) TestPostAppsServiceControlError(c *check.C) {
+	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "start", "names": ["snap-a.svc1"]}`))
 	c.Assert(err, check.IsNil)
+	s.serviceControlError = fmt.Errorf("total failure")
 	rsp := postApps(appsCmd, req, nil).(*resp)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `unknown action "discombobulate"`)
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `total failure`)
 }
 
 func (s *appSuite) TestPostAppsConflict(c *check.C) {
-	st := s.d.overlord.State()
-	st.Lock()
-	locked := true
-	defer func() {
-		if locked {
-			st.Unlock()
-		}
-	}()
-
-	ts, err := snapstate.Remove(st, "snap-a", snap.R(0), nil)
-	c.Assert(err, check.IsNil)
-	// need a change to make the tasks visible
-	st.NewChange("enable", "...").AddAll(ts)
-	st.Unlock()
-	locked = false
-
 	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "start", "names": ["snap-a.svc1"]}`))
 	c.Assert(err, check.IsNil)
+	s.serviceControlError = &snapstate.ChangeConflictError{Snap: "snap-a", ChangeKind: "enable"}
 	rsp := postApps(appsCmd, req, nil).(*resp)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -24,6 +24,10 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
 )
 
 type Resp = resp
@@ -58,5 +62,13 @@ func MockShutdownTimeout(tm time.Duration) (restore func()) {
 	shutdownTimeout = tm
 	return func() {
 		shutdownTimeout = old
+	}
+}
+
+func MockServicestateControl(f func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, context *hookstate.Context) ([]*state.TaskSet, error)) (restore func()) {
+	old := servicestateControl
+	servicestateControl = f
+	return func() {
+		servicestateControl = old
 	}
 }


### PR DESCRIPTION
Mock servicestate.Control in api tests to avoid direct checks of systemctl calls. This simplifies testing and will reduce the diff of the main services PR.

This PR will be followed by new tests for servicestate.Control function as it is lacking any tests atm (was tested through api tests that are changed here).
