### PR TITLE
 snapdtool: helper to check whether the current binary is reexeced from a snap

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -42,6 +42,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/snapdtool"
 )
 
 var (
@@ -216,12 +217,11 @@ func snapConfineProfileDigest(suffix string) string {
 }
 
 var didSnapdReExec = func() string {
-	// TODO: move this into osutil.Reexeced() ?
-	exe, err := os.Readlink(procSelfExe)
+	didReexec, err := snapdtool.IsReexecd()
 	if err != nil {
 		return "unknown"
 	}
-	if strings.HasPrefix(exe, dirs.SnapMountDir) {
+	if didReexec {
 		return "yes"
 	}
 	return "no"

--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -205,6 +205,18 @@ func ExecInSnapdOrCoreSnap() {
 	panic(syscallExec(full, os.Args, os.Environ()))
 }
 
+// IsReexecd returns true when the current process binary is running from a snap.
+func IsReexecd() (bool, error) {
+	exe, err := osReadlink(selfExe)
+	if err != nil {
+		return false, err
+	}
+	if strings.HasPrefix(exe, dirs.SnapMountDir) {
+		return true, nil
+	}
+	return false, nil
+}
+
 // MockOsReadlink is for use in tests
 func MockOsReadlink(f func(string) (string, error)) func() {
 	realOsReadlink := osReadlink

--- a/snapdtool/tool_other.go
+++ b/snapdtool/tool_other.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 )
 
+var errUnsupported = errors.New("unsupported on non-Linux systems")
+
 // ExecInSnapdOrCoreSnap makes sure you're executing the binary that ships in
 // the snapd/core snap.
 // On this OS this is a stub.
@@ -36,5 +38,12 @@ func ExecInSnapdOrCoreSnap() {
 //
 // On this OS this is a stub and always returns an error.
 func InternalToolPath(tool string) (string, error) {
-	return "", errors.New("unsupported on non-Linux systems")
+	return "", errUnsupported
+}
+
+// IsReexecd returns true when the current process binary is running from a snap.
+//
+// On this OS this is a stub and always returns an error.
+func IsReexecd() (bool, error) {
+	return false, errUnsupported
 }


### PR DESCRIPTION
Add a helper for checking whether the current binary is running from a snap.