### PR TITLE
snapstate: use testutil.HostScaledTimeout() in snapstate tests

### DIFF
--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -2397,7 +2397,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 
 		// we use our own settle as we need a bigger timeout
 		s.state.Unlock()
-		err = s.o.Settle(15 * time.Second)
+		err = s.o.Settle(testutil.HostScaledTimeout(15 * time.Second))
 		s.state.Lock()
 		c.Assert(err, IsNil)
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -83,7 +83,7 @@ type snapmgrTestSuite struct {
 }
 
 func (s *snapmgrTestSuite) settle(c *C) {
-	err := s.o.Settle(5 * time.Second)
+	err := s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
This commit adds missing testutil.HostScaledTimeout() in the
snapstate tests. This hopefully unblocks the RISC-V builds
that are failing in the snappy edge PPA.
