### PR TITLE
interfaces/apparmor: allow snap-specific /run/lock

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -439,6 +439,11 @@ var templateCommon = `
   # (see 'parallel installs', above)
   /run/snap.@{SNAP_INSTANCE_NAME}/ rw,
   /run/snap.@{SNAP_INSTANCE_NAME}/** mrwklix,
+
+  # Snap-specific lock directory and prerequisite navigation permissions.
+  /run/lock/ r,
+  /run/lock/snap.@{SNAP_INSTANCE_NAME}/ rw,
+  /run/lock/snap.@{SNAP_INSTANCE_NAME}/** mrwklix,
 `
 
 var templateFooter = `


### PR DESCRIPTION
Snaps get access to snap instance specific /run/ directory but no such
permissions are granted to a corresponding /run/lock directory. This
patch adds the permission to the common snap template.

Fixes: https://bugs.launchpad.net/snapd/+bug/1881590
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
