### PR TITLE
usersession: support additional zoom URL schemes

### DIFF
--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -99,6 +99,7 @@ var (
 		//   - scheme: msteams:...
 		//   - https://github.com/snapcore/snapd/pull/8761
 		"msteams",
+		// TODO: document slack URL scheme.
 		"slack",
 		// snap: the scheme allows specifying a package for xdg-open to pass to a
 		//   snap-handling installer application, like snap-store, etc which are

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -102,6 +102,12 @@ const launcherIntrospectionXML = `
 //   - scheme: https://medium.com/zoom-developer-blog/zoom-url-schemes-748b95fd9205
 //     (eg, zoommtg://zoom.us/...)
 //   - https://github.com/snapcore/snapd/pull/8304
+//
+// zoomus: alternative name for zoommtg
+//   - https://github.com/snapcore/snapd/pull/8910
+//
+// zoomphonecall: another zoom URL scheme, for dialing phone numbers
+//   - https://github.com/snapcore/snapd/pull/8910
 
 var (
 	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams"}

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -74,53 +74,44 @@ const launcherIntrospectionXML = `
 // This code uses golang's net/url.Parse() which will help ensure the url is
 // ok before passing to xdg-open. xdg-open itself properly quotes the url so
 // shell metacharacters are blocked.
-//
-// apt: the scheme allows specifying a package for xdg-open to pass to an
-//   apt-handling application, like gnome-software, apturl, etc which are all
-//   protected by policykit
-//   - scheme: apt:<name of package>
-//   - https://github.com/snapcore/snapd/pull/7731
-//
-// help: the scheme allows for specifying a help URL. This code ensures that
-//   the url is parseable
-//   - scheme: help://topic
-//   - https://github.com/snapcore/snapd/pull/6493
-//
-// http/https: the scheme allows specifying a web URL. This code ensures that
-//   the url is parseable
-//   - scheme: http(s)://example.com
-//
-// mailto: the scheme allows for specifying an email address
-//   - scheme: mailto:foo@example.com
-//
-// snap: the scheme allows specifying a package for xdg-open to pass to a
-//   snap-handling installer application, like snap-store, etc which are
-//   protected by policykit/snap login
-//   - https://github.com/snapcore/snapd/pull/5181
-//
-// zoommtg: the scheme is a modified web url scheme
-//   - scheme: https://medium.com/zoom-developer-blog/zoom-url-schemes-748b95fd9205
-//     (eg, zoommtg://zoom.us/...)
-//   - https://github.com/snapcore/snapd/pull/8304
-//
-// zoomus: alternative name for zoommtg
-//   - https://github.com/snapcore/snapd/pull/8910
-//
-// zoomphonecall: another zoom URL scheme, for dialing phone numbers
-//   - https://github.com/snapcore/snapd/pull/8910
-
 var (
 	allowedURLSchemes = []string{
+		// apt: the scheme allows specifying a package for xdg-open to pass to an
+		//   apt-handling application, like gnome-software, apturl, etc which are all
+		//   protected by policykit
+		//   - scheme: apt:<name of package>
+		//   - https://github.com/snapcore/snapd/pull/7731
 		"apt",
+		// help: the scheme allows for specifying a help URL. This code ensures that
+		//   the url is parseable
+		//   - scheme: help://topic
+		//   - https://github.com/snapcore/snapd/pull/6493
 		"help",
+		// http/https: the scheme allows specifying a web URL. This code ensures that
+		//   the url is parseable
+		//   - scheme: http(s)://example.com
 		"http",
 		"https",
+		// mailto: the scheme allows for specifying an email address
+		//   - scheme: mailto:foo@example.com
 		"mailto",
 		"msteams",
 		"slack",
+		// snap: the scheme allows specifying a package for xdg-open to pass to a
+		//   snap-handling installer application, like snap-store, etc which are
+		//   protected by policykit/snap login
+		//   - https://github.com/snapcore/snapd/pull/5181
 		"snap",
+		// zoommtg: the scheme is a modified web url scheme
+		//   - scheme: https://medium.com/zoom-developer-blog/zoom-url-schemes-748b95fd9205
+		//     (eg, zoommtg://zoom.us/...)
+		//   - https://github.com/snapcore/snapd/pull/8304
 		"zoommtg",
+		// zoomphonecall: another zoom URL scheme, for dialing phone numbers
+		//   - https://github.com/snapcore/snapd/pull/8910
 		"zoomphonecall",
+		// zoomus: alternative name for zoommtg
+		//   - https://github.com/snapcore/snapd/pull/8910
 		"zoomus",
 	}
 )

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -95,6 +95,7 @@ var (
 		// mailto: the scheme allows for specifying an email address
 		//   - scheme: mailto:foo@example.com
 		"mailto",
+		// msteams: TODO: document me.
 		"msteams",
 		"slack",
 		// snap: the scheme allows specifying a package for xdg-open to pass to a

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -95,7 +95,9 @@ var (
 		// mailto: the scheme allows for specifying an email address
 		//   - scheme: mailto:foo@example.com
 		"mailto",
-		// msteams: TODO: document me.
+		// msteams: the scheme is a thin wrapper around https.
+		//   - scheme: msteams:...
+		//   - https://github.com/snapcore/snapd/pull/8761
 		"msteams",
 		"slack",
 		// snap: the scheme allows specifying a package for xdg-open to pass to a

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -110,7 +110,19 @@ const launcherIntrospectionXML = `
 //   - https://github.com/snapcore/snapd/pull/8910
 
 var (
-	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams"}
+	allowedURLSchemes = []string{
+		"apt",
+		"help",
+		"http",
+		"https",
+		"mailto",
+		"msteams",
+		"slack",
+		"snap",
+		"zoommtg",
+		"zoomphonecall",
+		"zoomus",
+	}
 )
 
 // Launcher implements the 'io.snapcraft.Launcher' DBus interface.

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -104,7 +104,7 @@ const launcherIntrospectionXML = `
 //   - https://github.com/snapcore/snapd/pull/8304
 
 var (
-	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "slack", "msteams"}
+	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams"}
 )
 
 // Launcher implements the 'io.snapcraft.Launcher' DBus interface.

--- a/usersession/userd/launcher_test.go
+++ b/usersession/userd/launcher_test.go
@@ -75,7 +75,7 @@ func (s *launcherSuite) TestOpenURLWithNotAllowedScheme(c *C) {
 }
 
 func (s *launcherSuite) TestOpenURLWithAllowedSchemeHappy(c *C) {
-	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "slack", "msteams"} {
+	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams"} {
 		err := s.launcher.OpenURL(schema+"://snapcraft.io", ":some-dbus-sender")
 		c.Assert(err, IsNil)
 		c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{


### PR DESCRIPTION
We've recently added support for the zoommtg:// URL scheme
but zoom documentation also mentions two others, zoomus and
zoomphonecall.

Ref: https://marketplace.zoom.us/docs/guides/guides/client-url-schemes
Fixes: https://bugs.launchpad.net/snapd/+bug/1880606
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>