### PR TITLE
tests/core/snap-auto-mount: try to make the test more robust

### DIFF
--- a/tests/core/snap-auto-mount/task.yaml
+++ b/tests/core/snap-auto-mount/task.yaml
@@ -47,6 +47,7 @@ prepare: |
     # Jun 28 09:18:34 localhost kernel: [   36.434686] device-mapper: ioctl: error adding target to table
     udevadm settle
     dmsetup -v --noudevsync --noudevrules create dm-ram0 --table "0 $(blockdev --getsize /dev/ram0) linear /dev/ram0 0"
+    udevadm settle
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -64,4 +65,4 @@ execute: |
         exit
     fi
     echo "The auto-mount magic has given us the assertion"
-    snap known account-key | MATCH "name: test-store"
+    retry -n 5 sh -c 'snap known account-key | MATCH "name: test-store"'

--- a/tests/core/snap-auto-mount/task.yaml
+++ b/tests/core/snap-auto-mount/task.yaml
@@ -56,7 +56,7 @@ restore: |
     dmsetup -v --noudevsync --noudevrules  remove dm-ram0
 
 debug: |
-    tail -n 20 /var/log/syslog
+    journalctl -b | tail -100
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -155,7 +155,7 @@ is_nested_system(){
 }
 
 is_core_nested_system(){
-    if [ -z "$NESTED_TYPE" ]; then
+    if [ -z "${NESTED_TYPE-}" ]; then
         echo "Variable NESTED_TYPE not defined. Exiting..."
         exit 1
     fi
@@ -164,7 +164,7 @@ is_core_nested_system(){
 }
 
 is_classic_nested_system(){
-    if [ -z "$NESTED_TYPE" ]; then
+    if [ -z "${NESTED_TYPE-}" ]; then
         echo "Variable NESTED_TYPE not defined. Exiting..."
         exit 1
     fi


### PR DESCRIPTION
Use journal instead of trying /var/log/syslog.

