### PR TITLE
osutil/disks: add mock disk and tests for happy path of mock disks

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -22,6 +22,7 @@ package disks
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -30,6 +31,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"golang.org/x/xerrors"
 
 	"github.com/snapcore/snapd/osutil"
 )
@@ -309,6 +312,8 @@ func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
 	return nil, fmt.Errorf("cannot find disk for partition %s, incomplete udev output", partMountPointSource)
 }
 
+var FilesystemLabelNotFound = errors.New("filesystem label not found")
+
 func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
 	encodedLabel := BlkIDEncodeLabel(label)
 	// if we haven't found the partitions for this disk yet, do that now
@@ -379,7 +384,7 @@ func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
 		return partuuid, nil
 	}
 
-	return "", fmt.Errorf("couldn't find label %q", label)
+	return "", xerrors.Errorf("could not find label %q: %w", label, FilesystemLabelNotFound)
 }
 
 func (d *disk) MountPointIsFromDisk(mountpoint string, opts *Options) (bool, error) {

--- a/osutil/disks/disks_test.go
+++ b/osutil/disks/disks_test.go
@@ -418,11 +418,11 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 	// finally we can't find the bios-boot partition because it has no label
 	_, err = ubuntuBootDisk.FindMatchingPartitionUUID("bios-boot")
 	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
-	c.Assert(xerrors.Is(err, disks.FilesystemLabelNotFound), Equals, true)
+	c.Assert(xerrors.Is(err, disks.ErrFilesystemLabelNotFound), Equals, true)
 
 	_, err = ubuntuDataDisk.FindMatchingPartitionUUID("bios-boot")
 	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
-	c.Assert(xerrors.Is(err, disks.FilesystemLabelNotFound), Equals, true)
+	c.Assert(xerrors.Is(err, disks.ErrFilesystemLabelNotFound), Equals, true)
 }
 
 func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {

--- a/osutil/disks/disks_test.go
+++ b/osutil/disks/disks_test.go
@@ -27,6 +27,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"golang.org/x/xerrors"
+
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
@@ -415,10 +417,12 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 
 	// finally we can't find the bios-boot partition because it has no label
 	_, err = ubuntuBootDisk.FindMatchingPartitionUUID("bios-boot")
-	c.Assert(err, ErrorMatches, "couldn't find label \"bios-boot\"")
+	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
+	c.Assert(xerrors.Is(err, disks.FilesystemLabelNotFound), Equals, true)
 
 	_, err = ubuntuDataDisk.FindMatchingPartitionUUID("bios-boot")
-	c.Assert(err, ErrorMatches, "couldn't find label \"bios-boot\"")
+	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
+	c.Assert(xerrors.Is(err, disks.FilesystemLabelNotFound), Equals, true)
 }
 
 func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -22,8 +22,6 @@ package disks
 import (
 	"fmt"
 
-	"golang.org/x/xerrors"
-
 	"github.com/snapcore/snapd/osutil"
 )
 
@@ -46,8 +44,7 @@ func (d *MockDiskMapping) FindMatchingPartitionUUID(label string) (string, error
 	if partuuid, ok := d.FilesystemLabelToPartUUID[label]; ok {
 		return partuuid, nil
 	}
-	fmt := "could not find label %q: %w"
-	return "", xerrors.Errorf(fmt, label, ErrFilesystemLabelNotFound)
+	return "", ErrFilesystemLabelNotFound{Label: label}
 }
 
 // HasPartitions returns if the mock disk has partitions or not. Part of the

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -1,0 +1,118 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package disks
+
+import (
+	"fmt"
+
+	"golang.org/x/xerrors"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+// MockDiskMapping is an implementation of Disk for mocking purposes, it is
+// exported so that other packages can easily mock a specific disk layout
+// without needing to mock the mount setup, sysfs, or udev commands just to test
+// high level logic.
+// DevNum must be a unique string per unique mocked disk, if only one disk is
+// being mocked it can be left empty.
+type MockDiskMapping struct {
+	FilesystemLabelToPartUUID map[string]string
+	DiskHasPartitions         bool
+	DevNum                    string
+}
+
+// FindMatchingPartitionUUID returns a matching PartitionUUID for the specified
+// label if it exists. Part of the Disk interface.
+func (d *MockDiskMapping) FindMatchingPartitionUUID(label string) (string, error) {
+	osutil.MustBeTestBinary("mock disks only to be used in tests")
+	if partuuid, ok := d.FilesystemLabelToPartUUID[label]; ok {
+		return partuuid, nil
+	}
+	fmt := "could not find label %q: %w"
+	return "", xerrors.Errorf(fmt, label, ErrFilesystemLabelNotFound)
+}
+
+// HasPartitions returns if the mock disk has partitions or not. Part of the
+// Disk interface.
+func (d *MockDiskMapping) HasPartitions() bool {
+	osutil.MustBeTestBinary("mock disks only to be used in tests")
+	return d.DiskHasPartitions
+}
+
+// MountPointIsFromDisk returns if the disk that the specified mount point comes
+// from is the same disk as the object. Part of the Disk interface.
+func (d *MockDiskMapping) MountPointIsFromDisk(mountpoint string, opts *Options) (bool, error) {
+	osutil.MustBeTestBinary("mock disks only to be used in tests")
+
+	// this is relying on the fact that DiskFromMountPoint should have been
+	// mocked for us to be using this mockDisk method anyways
+	otherDisk, err := DiskFromMountPoint(mountpoint, opts)
+	if err != nil {
+		return false, err
+	}
+
+	if otherDisk.Dev() == d.Dev() && otherDisk.HasPartitions() == d.HasPartitions() {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// Dev returns a unique representation of the mock disk, it is a hash of the
+// mock disk struct string representation. Part of the Disk interface.
+func (d *MockDiskMapping) Dev() string {
+	osutil.MustBeTestBinary("mock disks only to be used in tests")
+	return d.DevNum
+}
+
+// Mountpoint is a combination of a mountpoint location and whether that
+// mountpoint is a decrypted device. It is only used in identifying mount points
+// with MountPointIsFromDisk and DiskFromMountPoint with
+// MockMountPointDisksToPartionMapping.
+type Mountpoint struct {
+	Mountpoint        string
+	IsDecryptedDevice bool
+}
+
+// MockMountPointDisksToPartionMapping will mock DiskFromMountPoint such that
+// the specified mapping is returned/used. Specifically, keys in the provided
+// map are mountpoints, and the values for those keys are the disks that will
+// be returned from DiskFromMountPoint or used internally in
+// MountPointIsFromDisk.
+func MockMountPointDisksToPartionMapping(mockedMountPoints map[Mountpoint]MockDiskMapping) (restore func()) {
+	osutil.MustBeTestBinary("mock disks only to be used in tests")
+
+	old := diskFromMountPoint
+
+	diskFromMountPoint = func(mountpoint string, opts *Options) (Disk, error) {
+		if opts == nil {
+			opts = &Options{}
+		}
+		m := Mountpoint{mountpoint, opts.IsDecryptedDevice}
+		if mockedDisk, ok := mockedMountPoints[m]; ok {
+			return &mockedDisk, nil
+		}
+		return nil, fmt.Errorf("mountpoint %s not mocked", mountpoint)
+	}
+	return func() {
+		diskFromMountPoint = old
+	}
+}

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -101,25 +101,9 @@ func MockMountPointDisksToPartionMapping(mockedMountPoints map[Mountpoint]*MockD
 		if old, ok := alreadySeen[mockDisk.DevNum]; ok {
 			if mockDisk != old {
 				// we already saw a disk with this DevNum as a different pointer
-				// so verify that the disk's are the same
-				msg := "mocked disks %+v and %+v have the same DevNum but different %s values, mocking broken"
-				if old.DiskHasPartitions != mockDisk.DiskHasPartitions {
-					panic(fmt.Sprintf(msg, old, mockDisk, "DiskHasPartitions"))
-				}
-				// verify that all the keys in the old one are in this one
-				for k, v := range old.FilesystemLabelToPartUUID {
-					v2 := mockDisk.FilesystemLabelToPartUUID[k]
-					if v2 != v {
-						panic(fmt.Sprintf(msg, old, mockDisk, "FilesystemLabelToPartUUID"))
-					}
-				}
-				// verify that all the keys in this one are in the old one
-				for k, v := range mockDisk.FilesystemLabelToPartUUID {
-					v2 := old.FilesystemLabelToPartUUID[k]
-					if v2 != v {
-						panic(fmt.Sprintf(msg, old, mockDisk, "FilesystemLabelToPartUUID"))
-					}
-				}
+				// so just assume it's different
+				msg := fmt.Sprintf("mocked disks %+v and %+v have the same DevNum (%s) but are not the same object", old, mockDisk, mockDisk.DevNum)
+				panic(msg)
 			}
 			// otherwise same ptr, no point in comparing them
 		} else {

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -50,7 +50,6 @@ func (d *MockDiskMapping) FindMatchingPartitionUUID(label string) (string, error
 // HasPartitions returns if the mock disk has partitions or not. Part of the
 // Disk interface.
 func (d *MockDiskMapping) HasPartitions() bool {
-	osutil.MustBeTestBinary("mock disks only to be used in tests")
 	return d.DiskHasPartitions
 }
 
@@ -76,7 +75,6 @@ func (d *MockDiskMapping) MountPointIsFromDisk(mountpoint string, opts *Options)
 // Dev returns a unique representation of the mock disk, it is a hash of the
 // mock disk struct string representation. Part of the Disk interface.
 func (d *MockDiskMapping) Dev() string {
-	osutil.MustBeTestBinary("mock disks only to be used in tests")
 	return d.DevNum
 }
 

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -44,7 +44,7 @@ func (d *MockDiskMapping) FindMatchingPartitionUUID(label string) (string, error
 	if partuuid, ok := d.FilesystemLabelToPartUUID[label]; ok {
 		return partuuid, nil
 	}
-	return "", ErrFilesystemLabelNotFound{Label: label}
+	return "", FilesystemLabelNotFoundError{Label: label}
 }
 
 // HasPartitions returns if the mock disk has partitions or not. Part of the

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -72,8 +72,9 @@ func (d *MockDiskMapping) MountPointIsFromDisk(mountpoint string, opts *Options)
 	return false, nil
 }
 
-// Dev returns a unique representation of the mock disk, it is a hash of the
-// mock disk struct string representation. Part of the Disk interface.
+// Dev returns a unique representation of the mock disk that is suitable for
+// comparing two mock disks to see if they are the same. Part of the Disk
+// interface.
 func (d *MockDiskMapping) Dev() string {
 	return d.DevNum
 }

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -39,8 +39,8 @@ func (s *mockDiskSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 }
 
-func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
-	d1 := disks.MockDiskMapping{
+func (s *mockDiskSuite) TestMockMountPointDisksToPartionMappingVerifiesUniqueness(c *C) {
+	d1 := &disks.MockDiskMapping{
 		FilesystemLabelToPartUUID: map[string]string{
 			"label1": "part1",
 		},
@@ -48,7 +48,68 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
 		DevNum:            "d1",
 	}
 
-	d2 := disks.MockDiskMapping{
+	d2 := &disks.MockDiskMapping{
+		FilesystemLabelToPartUUID: map[string]string{
+			"label1": "part1",
+		},
+		DiskHasPartitions: false,
+		DevNum:            "d1",
+	}
+
+	// the pointers are different, and they are not the same
+	c.Assert(d1, Not(Equals), d2)
+	c.Assert(d1, Not(DeepEquals), d2)
+
+	m := map[disks.Mountpoint]*disks.MockDiskMapping{
+		{Mountpoint: "mount1"}: d1,
+		{Mountpoint: "mount2"}: d1,
+		{Mountpoint: "mount3"}: d2,
+	}
+
+	// mocking panics because the mocked disks are different but have the same
+	// DevNum
+	c.Assert(func() { disks.MockMountPointDisksToPartionMapping(m) }, PanicMatches, "mocked disks .* have the same DevNum but different DiskHasPartitions values, mocking broken")
+
+	// changing them to be the same now makes the mocking work
+	d2.DiskHasPartitions = true
+	c.Assert(d1, DeepEquals, d2)
+
+	// mocking works now because the two objects are the same
+	r := disks.MockMountPointDisksToPartionMapping(m)
+	defer r()
+
+	// adding to map values works to break the mocking too
+	d2.FilesystemLabelToPartUUID["label2"] = "part2"
+	c.Assert(func() { disks.MockMountPointDisksToPartionMapping(m) }, PanicMatches, "mocked disks .* have the same DevNum but different FilesystemLabelToPartUUID values, mocking broken")
+
+	// adding to d1 makes it work again
+	d1.FilesystemLabelToPartUUID["label2"] = "part2"
+	r = disks.MockMountPointDisksToPartionMapping(m)
+	defer r()
+
+	// but deleting label1 from d1 breaks again
+	delete(d1.FilesystemLabelToPartUUID, "label1")
+	c.Assert(func() { disks.MockMountPointDisksToPartionMapping(m) }, PanicMatches, "mocked disks .* have the same DevNum but different FilesystemLabelToPartUUID values, mocking broken")
+
+	// mocking with just one disk at multiple mount points works too
+	m2 := map[disks.Mountpoint]*disks.MockDiskMapping{
+		{Mountpoint: "mount1"}: d1,
+		{Mountpoint: "mount2"}: d1,
+	}
+	r = disks.MockMountPointDisksToPartionMapping(m2)
+	defer r()
+}
+
+func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
+	d1 := &disks.MockDiskMapping{
+		FilesystemLabelToPartUUID: map[string]string{
+			"label1": "part1",
+		},
+		DiskHasPartitions: true,
+		DevNum:            "d1",
+	}
+
+	d2 := &disks.MockDiskMapping{
 		FilesystemLabelToPartUUID: map[string]string{
 			"label2": "part2",
 		},
@@ -57,7 +118,7 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
 	}
 
 	r := disks.MockMountPointDisksToPartionMapping(
-		map[disks.Mountpoint]disks.MockDiskMapping{
+		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: "mount1"}: d1,
 			{Mountpoint: "mount2"}: d1,
 			{Mountpoint: "mount3"}: d2,
@@ -114,7 +175,7 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
 }
 
 func (s *mockDiskSuite) TestMockMountPointDisksToPartionMappingDecryptedDevices(c *C) {
-	d1 := disks.MockDiskMapping{
+	d1 := &disks.MockDiskMapping{
 		FilesystemLabelToPartUUID: map[string]string{
 			"ubuntu-seed":     "ubuntu-seed-part",
 			"ubuntu-boot":     "ubuntu-boot-part",
@@ -125,7 +186,7 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMappingDecryptedDevices(
 	}
 
 	r := disks.MockMountPointDisksToPartionMapping(
-		map[disks.Mountpoint]disks.MockDiskMapping{
+		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: "/run/mnt/ubuntu-boot"}: d1,
 			{Mountpoint: "/run/mnt/ubuntu-seed"}: d1,
 			{

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -162,7 +162,7 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
 	// we can't find label1 from mount1's or mount2's disk
 	_, err = foundDisk2.FindMatchingPartitionUUID("label1")
 	c.Assert(err, ErrorMatches, "filesystem label \"label1\" not found")
-	var errNotFound disks.ErrFilesystemLabelNotFound
+	var errNotFound disks.FilesystemLabelNotFoundError
 	c.Assert(xerrors.As(err, &errNotFound), Equals, true)
 
 	// mount1 and mount2 do not match mount3 disk

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -1,0 +1,158 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package disks_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"golang.org/x/xerrors"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type mockDiskSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&mockDiskSuite{})
+
+func (s *mockDiskSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
+	d1 := disks.MockDiskMapping{
+		FilesystemLabelToPartUUID: map[string]string{
+			"label1": "part1",
+		},
+		DiskHasPartitions: true,
+		DevNum:            "d1",
+	}
+
+	d2 := disks.MockDiskMapping{
+		FilesystemLabelToPartUUID: map[string]string{
+			"label2": "part2",
+		},
+		DiskHasPartitions: true,
+		DevNum:            "d2",
+	}
+
+	r := disks.MockMountPointDisksToPartionMapping(
+		map[disks.Mountpoint]disks.MockDiskMapping{
+			{Mountpoint: "mount1"}: d1,
+			{Mountpoint: "mount2"}: d1,
+			{Mountpoint: "mount3"}: d2,
+		},
+	)
+	defer r()
+
+	// we can find the mock disk
+	foundDisk, err := disks.DiskFromMountPoint("mount1", nil)
+	c.Assert(err, IsNil)
+
+	// and it has labels
+	label, err := foundDisk.FindMatchingPartitionUUID("label1")
+	c.Assert(err, IsNil)
+	c.Assert(label, Equals, "part1")
+
+	// the same mount point is always from the same disk
+	matches, err := foundDisk.MountPointIsFromDisk("mount1", nil)
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, true)
+
+	// mount2 goes to the same disk, as per the mapping above
+	matches, err = foundDisk.MountPointIsFromDisk("mount2", nil)
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, true)
+
+	// mount3 does not however
+	matches, err = foundDisk.MountPointIsFromDisk("mount3", nil)
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, false)
+
+	// a disk from mount3 is also able to be found
+	foundDisk2, err := disks.DiskFromMountPoint("mount3", nil)
+	c.Assert(err, IsNil)
+
+	// we can find label2 from mount3's disk
+	label, err = foundDisk2.FindMatchingPartitionUUID("label2")
+	c.Assert(err, IsNil)
+	c.Assert(label, Equals, "part2")
+
+	// we can't find label1 from mount1's or mount2's disk
+	_, err = foundDisk2.FindMatchingPartitionUUID("label1")
+	c.Assert(err, ErrorMatches, "could not find label \"label1\": filesystem label not found")
+	c.Assert(xerrors.Is(err, disks.ErrFilesystemLabelNotFound), Equals, true)
+
+	// mount1 and mount2 do not match mount3 disk
+	matches, err = foundDisk2.MountPointIsFromDisk("mount1", nil)
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, false)
+	matches, err = foundDisk2.MountPointIsFromDisk("mount2", nil)
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, false)
+}
+
+func (s *mockDiskSuite) TestMockMountPointDisksToPartionMappingDecryptedDevices(c *C) {
+	d1 := disks.MockDiskMapping{
+		FilesystemLabelToPartUUID: map[string]string{
+			"ubuntu-seed":     "ubuntu-seed-part",
+			"ubuntu-boot":     "ubuntu-boot-part",
+			"ubuntu-data-enc": "ubuntu-data-enc-part",
+		},
+		DiskHasPartitions: true,
+		DevNum:            "d1",
+	}
+
+	r := disks.MockMountPointDisksToPartionMapping(
+		map[disks.Mountpoint]disks.MockDiskMapping{
+			{Mountpoint: "/run/mnt/ubuntu-boot"}: d1,
+			{Mountpoint: "/run/mnt/ubuntu-seed"}: d1,
+			{
+				Mountpoint:        "/run/mnt/ubuntu-data",
+				IsDecryptedDevice: true,
+			}: d1,
+		},
+	)
+	defer r()
+
+	// first we get ubuntu-boot (which is not a decrypted device)
+	d, err := disks.DiskFromMountPoint("/run/mnt/ubuntu-boot", nil)
+	c.Assert(err, IsNil)
+
+	// next we find ubuntu-seed (also not decrypted)
+	label, err := d.FindMatchingPartitionUUID("ubuntu-seed")
+	c.Assert(err, IsNil)
+	c.Assert(label, Equals, "ubuntu-seed-part")
+
+	// then we find ubuntu-data-enc, which is not a decrypted device
+	label, err = d.FindMatchingPartitionUUID("ubuntu-data-enc")
+	c.Assert(err, IsNil)
+	c.Assert(label, Equals, "ubuntu-data-enc-part")
+
+	// and then finally ubuntu-data enc is from the same disk as ubuntu-boot
+	// with IsDecryptedDevice = true
+	opts := &disks.Options{IsDecryptedDevice: true}
+	matches, err := d.MountPointIsFromDisk("/run/mnt/ubuntu-data", opts)
+	c.Assert(err, IsNil)
+	c.Assert(matches, Equals, true)
+}

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -100,8 +100,9 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
 
 	// we can't find label1 from mount1's or mount2's disk
 	_, err = foundDisk2.FindMatchingPartitionUUID("label1")
-	c.Assert(err, ErrorMatches, "could not find label \"label1\": filesystem label not found")
-	c.Assert(xerrors.Is(err, disks.ErrFilesystemLabelNotFound), Equals, true)
+	c.Assert(err, ErrorMatches, "filesystem label \"label1\" not found")
+	var errNotFound disks.ErrFilesystemLabelNotFound
+	c.Assert(xerrors.As(err, &errNotFound), Equals, true)
 
 	// mount1 and mount2 do not match mount3 disk
 	matches, err = foundDisk2.MountPointIsFromDisk("mount1", nil)


### PR DESCRIPTION
This package will be used to mock disks and verification in the secboot and cmd/snap-bootstrap/initramfs-mounts packages, but as it is somewhat involved, it deserves its own tests and PR.

Currently based on top of https://github.com/snapcore/snapd/pull/9080