### PR TITLE
gadget/install,secboot: test if the tpm can be provisioned

### DIFF
--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -52,8 +52,14 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 // Run bootstraps the partitions of a device, by either creating
 // missing ones or recreating installed ones.
 func Run(gadgetRoot, device string, options Options) error {
-	if options.Encrypt && (options.KeyFile == "" || options.RecoveryKeyFile == "") {
-		return fmt.Errorf("key file and recovery key file must be specified when encrypting")
+	if options.Encrypt {
+		if options.KeyFile == "" || options.RecoveryKeyFile == "" {
+			return fmt.Errorf("key file and recovery key file must be specified when encrypting")
+		}
+		if err := secboot.CheckTPMProvisionable(); err != nil {
+			// XXX: request to clear the TPM if it's already provisioned?
+			return err
+		}
 	}
 
 	if gadgetRoot == "" {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -56,7 +56,7 @@ func Run(gadgetRoot, device string, options Options) error {
 		if options.KeyFile == "" || options.RecoveryKeyFile == "" {
 			return fmt.Errorf("key file and recovery key file must be specified when encrypting")
 		}
-		if err := secboot.CheckTPMProvisionable(); err != nil {
+		if err := secboot.CheckTPMUnprovisioned(); err != nil {
 			// XXX: request to clear the TPM if it's already provisioned?
 			return err
 		}

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -309,7 +309,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 
 	installSystem := s.findInstallSystem()
 	c.Check(installSystem.Err(), ErrorMatches, `(?ms)cannot perform the following tasks:
-- Setup system for run mode \(cannot create partitions: The horror, The horror\)`)
+- Setup system for run mode \(cannot install: The horror, The horror\)`)
 	// no restart request on failure
 	c.Check(s.restartRequests, HasLen, 0)
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -131,14 +131,14 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// run the create partition code
-	logger.Noticef("create and deploy partitions")
+	logger.Noticef("installing the system")
 	func() {
 		st.Unlock()
 		defer st.Lock()
 		err = installRun(gadgetDir, "", bopts)
 	}()
 	if err != nil {
-		return fmt.Errorf("cannot create partitions: %v", err)
+		return fmt.Errorf("cannot install: %v", err)
 	}
 
 	// keep track of the model we installed

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -36,6 +36,14 @@ func MockSbConnectToDefaultTPM(f func() (*sb.TPMConnection, error)) (restore fun
 	}
 }
 
+func MockSbProvisionStatus(f func(tpm *sb.TPMConnection) (sb.ProvisionStatusAttributes, error)) (restore func()) {
+	old := sbProvisionStatus
+	sbProvisionStatus = f
+	return func() {
+		sbProvisionStatus = old
+	}
+}
+
 func MockSbProvisionTPM(f func(tpm *sb.TPMConnection, mode sb.ProvisionMode, newLockoutAuth []byte) error) (restore func()) {
 	old := sbProvisionTPM
 	sbProvisionTPM = f

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -75,7 +75,7 @@ func CheckTPMUnprovisioned() error {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
-	// XXX: is testing against these attributes enough? should we test if !=0 instead?
+	// XXX: is testing against these attributes enough?
 	if attr&(sb.AttrValidSRK|sb.AttrLockoutAuthSet|sb.AttrValidLockNVIndex) != 0 {
 		return fmt.Errorf("the TPM is already provisioned (status=%04x)", attr)
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -77,7 +77,7 @@ func CheckTPMUnprovisioned() error {
 
 	// XXX: is testing against these attributes enough? should we test if !=0 instead?
 	if attr&(sb.AttrValidSRK|sb.AttrLockoutAuthSet|sb.AttrValidLockNVIndex) != 0 {
-		return errors.New("the TPM is already provisioned")
+		return fmt.Errorf("the TPM is already provisioned (status=%04x)", attr)
 	}
 
 	return nil

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -59,10 +59,10 @@ var (
 	sbSealKeyToTPM                   = sb.SealKeyToTPM
 )
 
-// CheckTPMProvisionable verifies if the TPM can be provisioned, returning an error
-// if the TPM device does not exist, or if it exists and is already provisioned.
-func CheckTPMProvisionable() error {
-	errPrefix := "cannot check if the TPM can be provisioned"
+// CheckTPMUnprovisioned verifies if the TPM can be provisioned, returning an error
+// if the TPM device does not exist, or if it's already provisioned.
+func CheckTPMUnprovisioned() error {
+	errPrefix := "cannot check if the TPM is unprovisioned"
 
 	tpm, err := sbConnectToDefaultTPM()
 	if err != nil {
@@ -75,7 +75,8 @@ func CheckTPMProvisionable() error {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
-	if attr&sb.AttrValidSRK == sb.AttrValidSRK {
+	// XXX: is testing against these attributes enough? should we test if !=0 instead?
+	if attr&(sb.AttrValidSRK|sb.AttrLockoutAuthSet|sb.AttrValidLockNVIndex) != 0 {
 		return errors.New("the TPM is already provisioned")
 	}
 

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -69,17 +69,17 @@ func (s *secbootSuite) TestCheckTPMProvisionable(c *C) {
 		{
 			// system is already provisioned
 			attr: sb.AttrValidSRK,
-			err:  "the TPM is already provisioned",
+			err:  `the TPM is already provisioned \(status=.*\)`,
 		},
 		{
 			// system is already provisioned
 			attr: sb.AttrLockoutAuthSet,
-			err:  "the TPM is already provisioned",
+			err:  `the TPM is already provisioned \(status=.*\)`,
 		},
 		{
 			// system is already provisioned
 			attr: sb.AttrValidLockNVIndex,
-			err:  "the TPM is already provisioned",
+			err:  `the TPM is already provisioned \(status=.*\)`,
 		},
 		{
 			// TPM error

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -63,7 +63,7 @@ func (s *secbootSuite) TestCheckTPMProvisionable(c *C) {
 	}{
 		{
 			// happy case
-			attr: ^sb.AttrValidSRK,
+			attr: ^(sb.AttrValidSRK | sb.AttrLockoutAuthSet | sb.AttrValidLockNVIndex),
 			err:  "",
 		},
 		{
@@ -72,14 +72,24 @@ func (s *secbootSuite) TestCheckTPMProvisionable(c *C) {
 			err:  "the TPM is already provisioned",
 		},
 		{
+			// system is already provisioned
+			attr: sb.AttrLockoutAuthSet,
+			err:  "the TPM is already provisioned",
+		},
+		{
+			// system is already provisioned
+			attr: sb.AttrValidLockNVIndex,
+			err:  "the TPM is already provisioned",
+		},
+		{
 			// TPM error
 			tpmErr: errors.New("TPM error"),
-			err:    "cannot check if the TPM can be provisioned: TPM error",
+			err:    "cannot check if the TPM is unprovisioned: TPM error",
 		},
 		{
 			// ProvisionStatus error
 			prvErr: errors.New("provision status error"),
-			err:    "cannot check if the TPM can be provisioned: provision status error",
+			err:    "cannot check if the TPM is unprovisioned: provision status error",
 		},
 	} {
 		mockTpm, restore := mockSbTPMConnection(c, tc.tpmErr)
@@ -91,7 +101,7 @@ func (s *secbootSuite) TestCheckTPMProvisionable(c *C) {
 		})
 		defer restore()
 
-		err := secboot.CheckTPMProvisionable()
+		err := secboot.CheckTPMUnprovisioned()
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 		} else {


### PR DESCRIPTION
Test if the TPM device can be provisioned before installing the system,
to avoid installing it first and then failing because the TPM is already
provisioned.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>