### PR TITLE
tests: fix incorrect check in smoke/remove test

### DIFF
--- a/tests/smoke/remove/task.yaml
+++ b/tests/smoke/remove/task.yaml
@@ -13,7 +13,7 @@ execute: |
     snap remove test-snapd-sh
     test ! -d "$SNAP_MOUNT_DIR/test-snapd-sh"
 
-    if snap list | grep -E ^test-snapd-sh; then
+    if snap list test-snapd-sh; then
         echo "test-snapd-sh should be removed but it is not"
         snap list
         exit 1


### PR DESCRIPTION
The remove test can easily be confused if there are snaps like
test-snapd-sh-core20. This commit fixes the test by not using
grep.

This fixes a autopkgest failure from the recent 20.10 upload.