### PR TITLE
tests: add spread test for disconnect undo caused by failing disconnect hook

### DIFF
--- a/tests/main/disconnect-undo/task.yaml
+++ b/tests/main/disconnect-undo/task.yaml
@@ -1,0 +1,35 @@
+summary: Test disconnect hook failure
+
+details: |
+  Test that failures of disconnect hook are handled gracefully and plug
+  remains connected.
+
+prepare: |
+  #shellcheck source=tests/lib/snaps.sh
+  . "$TESTSLIB/snaps.sh"
+  install_local test-disconnect
+
+restore: |
+  rm -f /var/snap/test-disconnect/common/do-not-fail
+
+execute: |
+  # sanity check, network is connected automatically
+  snap connections | MATCH "test-disconnect:network .*:network"
+
+  echo "Disconnect fails due to failing disconnect hook"
+  snap disconnect test-disconnect:network 2>&1 | MATCH "failure of disconnect hook"
+
+  echo "And network plug remains connected"
+  snap connections | MATCH "test-disconnect:network .*:network"
+
+  echo "Snap removal fails because of failing disconnect hook"
+  snap remove test-disconnect 2>&1 | MATCH "failure of disconnect hook"
+
+  echo "And the plug is still connected"
+  snap connections | MATCH "test-disconnect:network .*:network"
+
+  echo "Making disconnect hook happy"
+  touch /var/snap/test-disconnect/common/do-not-fail
+
+  echo "And removing the snap is now possible"
+  snap remove --purge test-disconnect

--- a/tests/main/disconnect-undo/test-disconnect/meta/hooks/disconnect-plug-network
+++ b/tests/main/disconnect-undo/test-disconnect/meta/hooks/disconnect-plug-network
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -f "$SNAP_COMMON"/do-not-fail ]; then
+    exit 0
+fi
+echo "failure of disconnect hook"
+exit 1

--- a/tests/main/disconnect-undo/test-disconnect/meta/snap.yaml
+++ b/tests/main/disconnect-undo/test-disconnect/meta/snap.yaml
@@ -1,6 +1,6 @@
 name: test-disconnect
 version: 1
-summary: Basic snap with a disconnect hook
+summary: Basic snap with a failing disconnect hook
 
 plugs:
   network:

--- a/tests/main/disconnect-undo/test-disconnect/meta/snap.yaml
+++ b/tests/main/disconnect-undo/test-disconnect/meta/snap.yaml
@@ -1,0 +1,6 @@
+name: test-disconnect
+version: 1
+summary: Basic snap with a disconnect hook
+
+plugs:
+  network:


### PR DESCRIPTION
Disconnect undo handler is unit-tested with `TestDisconnectUndo`, this adds a spread test.

(we may need to think how to allow removing of a snap with failing disconnect hook - as the spread test demonstrates, this is not possible atm. Something like `snap remove --force <snap>` would be useful).
