### PR TITLE
tests/core/uc20-recovery: apply hack to get gopath in recover mode w/ external backend

### DIFF
--- a/snapdenv/snapdenv.go
+++ b/snapdenv/snapdenv.go
@@ -32,7 +32,7 @@ var mockTesting *bool
 // is this a testing binary? (see withtestkeys.go)
 var testingBinary = false
 
-// Testing returns whether snapd compontents are under testing.
+// Testing returns whether snapd components are under testing.
 func Testing() bool {
 	if mockTesting != nil {
 		return *mockTesting

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -69,6 +69,12 @@ execute: |
         # restore shutdown so that spread can reboot the host
         umount /usr/sbin/shutdown
 
+        # with the external backend, we do not have the special snapd snap with
+        # the first-boot run mode tweaks as created from $TESTLIB/prepare.sh's 
+        # repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks func
+        # so instead to get the spread gopath and other data needed to continue
+        # the test, we need to add a .ssh/rc script which copies all of the data
+        # from /host/ubuntu-data in recover mode to the tmpfs /home
         if [ "$SPREAD_BACKEND" = "external" ]; then
             mkdir -p /home/external/.ssh
             chown external:external /home/external/.ssh
@@ -83,7 +89,8 @@ execute: |
         # that spread uses
         # silence the output so that nothing is output to a ssh command,
         # potentially confusing spread
-        sudo cp -r /host/ubuntu-data/user-data/gopath /home 2>/dev/null >/dev/null
+        sudo mkdir /home/gopath 2> /dev/null > /dev/null
+        sudo mount --bind /host/ubuntu-data/user-data/gopath /home/gopath 2> /dev/null > /dev/null
     fi
     EOF
         fi

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -69,6 +69,25 @@ execute: |
         # restore shutdown so that spread can reboot the host
         umount /usr/sbin/shutdown
 
+        if [ "$SPREAD_BACKEND" = "external" ]; then
+            mkdir -p /home/external/.ssh
+            chown external:external /home/external/.ssh
+            touch /home/external/.ssh/rc
+            chown external:external /home/external/.ssh/rc
+            cat <<-EOF > /home/external/.ssh/rc
+    #!/bin/sh
+    # added by spread tests
+    if grep -q 'snapd_recovery_mode=recover' /proc/cmdline; then
+        # use as sudo for proper permissions, assumes that the external user is
+        # a sudo user, which it must be by definition of it being the login user
+        # that spread uses
+        # silence the output so that nothing is output to a ssh command,
+        # potentially confusing spread
+        sudo cp -r /host/ubuntu-data/user-data/gopath /home 2>/dev/null >/dev/null
+    fi
+    EOF
+        fi
+
         # XXX: is this a race between spread seeing REBOOT and machine rebooting?
         REBOOT
 
@@ -120,6 +139,18 @@ execute: |
         MATCH -- '-r \+0' < /tmp/mock-shutdown.calls
 
         umount /usr/sbin/shutdown
+
+        # if we are using the external backend, remove the .ssh/rc hack we used
+        # to copy data around, it's not necessary going back to run mode, and it
+        # somehow interferes with spread re-connecting over ssh, causing an 
+        # spread to timeout trying to reconnect after the reboot with an error
+        # message like this:
+        # ssh: unexpected packet in response to channel open: <nil>
+        if [ "$SPREAD_BACKEND" = "external" ]; then
+            # TODO:UC20: if/when /host is mounted ro, then we will need to 
+            # either remount it rw or do some other hack to fix this
+            rm -f /host/ubuntu-data/user-data/external/.ssh/rc
+        fi
 
         REBOOT
 

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -1,130 +1,130 @@
 summary: verify booting into recovery mode on UC20 systems
 
-systems: [ ubuntu-core-20-* ]
+systems: [ubuntu-core-20-*]
 
 restore: |
-  rm -f /writable/systems.json.run
-  rm -f /writable/systems.label
+    rm -f /writable/systems.json.run
+    rm -f /writable/systems.label
 
-  if mountpoint /usr/sbin/shutdown; then
-      umount /usr/sbin/shutdown
-  fi
+    if mountpoint /usr/sbin/shutdown; then
+        umount /usr/sbin/shutdown
+    fi
 
 debug: |
-  if [ -e systems.json ]; then
-      cat systems.json
-  fi
-  if [ -e system-info ]; then
-      cat system-info
-  fi
-  if [ -e /tmp/mock-shutdown.calls ]; then
-      cat /tmp/mock-shutdown.calls
-  fi
+    if [ -e systems.json ]; then
+        cat systems.json
+    fi
+    if [ -e system-info ]; then
+        cat system-info
+    fi
+    if [ -e /tmp/mock-shutdown.calls ]; then
+        cat /tmp/mock-shutdown.calls
+    fi
 
 execute: |
-  if [ "$SPREAD_REBOOT" == "0" ]; then
-      echo "In run mode"
+    if [ "$SPREAD_REBOOT" == "0" ]; then
+        echo "In run mode"
 
-      snap install --edge jq
-      # devmode as the snap does not have snapd-control
-      snap install test-snapd-curl --devmode --edge
+        snap install --edge jq
+        # devmode as the snap does not have snapd-control
+        snap install test-snapd-curl --devmode --edge
 
-      MATCH 'snapd_recovery_mode=run' < /proc/cmdline
-      # verify we are in run mode via the API
-      test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
-      jq -r '.result["system-mode"]' < system-info | MATCH 'run'
+        MATCH 'snapd_recovery_mode=run' < /proc/cmdline
+        # verify we are in run mode via the API
+        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        jq -r '.result["system-mode"]' < system-info | MATCH 'run'
 
-      echo "Obtain available systems"
-      test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
-      # TODO:UC20: there is only one system for now
-      jq .result.systems[0].current < systems.json | MATCH 'true'
-      label="$(jq -r .result.systems[0].label < systems.json)"
-      test -n "$label"
-      # make sure that the seed exists
-      test -d "/var/lib/snapd/seed/systems/$label"
-      jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install recover run'
+        echo "Obtain available systems"
+        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
+        # TODO:UC20: there is only one system for now
+        jq .result.systems[0].current < systems.json | MATCH 'true'
+        label="$(jq -r .result.systems[0].label < systems.json)"
+        test -n "$label"
+        # make sure that the seed exists
+        test -d "/var/lib/snapd/seed/systems/$label"
+        jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install recover run'
 
-      # keep a copy of the systems dump for later reference
-      cp systems.json /writable/systems.json.run
-      echo "$label" > /writable/systems.label
+        # keep a copy of the systems dump for later reference
+        cp systems.json /writable/systems.json.run
+        echo "$label" > /writable/systems.label
 
-      # redirect shutdown command to our mock to observe calls and avoid racing
-      # with spread
-      mount -o bind "$PWD/mock-shutdown" /usr/sbin/shutdown
+        # redirect shutdown command to our mock to observe calls and avoid racing
+        # with spread
+        mount -o bind "$PWD/mock-shutdown" /usr/sbin/shutdown
 
-      # request a recovery mode
-      echo "Request rebooting into recovery mode"
-      # response contains maintenance: {"maintenance":{"message":"system is restarting","kind":"system-restart"}}
-      test-snapd-curl.curl -X POST --data '{"action":"do","mode":"recover"}' \
-          -s --unix-socket /run/snapd.socket "http://localhost/v2/systems/$label" | \
-          MATCH '"system-restart"'
+        # request a recovery mode
+        echo "Request rebooting into recovery mode"
+        # response contains maintenance: {"maintenance":{"message":"system is restarting","kind":"system-restart"}}
+        test-snapd-curl.curl -X POST --data '{"action":"do","mode":"recover"}' \
+            -s --unix-socket /run/snapd.socket "http://localhost/v2/systems/$label" | \
+            MATCH '"system-restart"'
 
-      # snapd schedules a slow timeout and an immediate one, however it is
-      # scheduled asynchronously, try keep the check simple
-      # shellcheck disable=SC2016
-      retry -n 30 --wait 1 sh -c 'test "$(wc -l < /tmp/mock-shutdown.calls)" = "2"'
-      # an immediate reboot should have been scheduled
-      MATCH -- '-r \+0' < /tmp/mock-shutdown.calls
+        # snapd schedules a slow timeout and an immediate one, however it is
+        # scheduled asynchronously, try keep the check simple
+        # shellcheck disable=SC2016
+        retry -n 30 --wait 1 sh -c 'test "$(wc -l < /tmp/mock-shutdown.calls)" = "2"'
+        # an immediate reboot should have been scheduled
+        MATCH -- '-r \+0' < /tmp/mock-shutdown.calls
 
-      # restore shutdown so that spread can reboot the host
-      umount /usr/sbin/shutdown
+        # restore shutdown so that spread can reboot the host
+        umount /usr/sbin/shutdown
 
-      # XXX: is this a race between spread seeing REBOOT and machine rebooting?
-      REBOOT
+        # XXX: is this a race between spread seeing REBOOT and machine rebooting?
+        REBOOT
 
-  elif [ "$SPREAD_REBOOT" == "1" ]; then
-      echo "In recovery mode"
+    elif [ "$SPREAD_REBOOT" == "1" ]; then
+        echo "In recovery mode"
 
-      # the system is seeding and snap command may not be available yet
-      # shellcheck disable=SC2016
-      retry -n 60 --wait 1 sh -c 'test "$(command -v snap)" = /usr/bin/snap'
+        # the system is seeding and snap command may not be available yet
+        # shellcheck disable=SC2016
+        retry -n 60 --wait 1 sh -c 'test "$(command -v snap)" = /usr/bin/snap'
 
-      # wait till the system seeding is finished
-      snap wait system seed.loaded
+        # wait till the system seeding is finished
+        snap wait system seed.loaded
 
-      # we're running in an ephemeral system and thus have to re-install snaps
-      snap install --edge jq
-      snap install test-snapd-curl --devmode --edge
+        # we're running in an ephemeral system and thus have to re-install snaps
+        snap install --edge jq
+        snap install test-snapd-curl --devmode --edge
 
-      MATCH 'snapd_recovery_mode=recover' < /proc/cmdline
-      # verify we are in recovery mode via the API
-      test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
-      jq -r '.result["system-mode"]' < system-info | MATCH 'recover'
+        MATCH 'snapd_recovery_mode=recover' < /proc/cmdline
+        # verify we are in recovery mode via the API
+        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        jq -r '.result["system-mode"]' < system-info | MATCH 'recover'
 
-      # host data should be accessible
-      test -e /host/ubuntu-data/systems.json.run
+        # host data should be accessible
+        test -e /host/ubuntu-data/systems.json.run
 
-      test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
-      jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install run'
+        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
+        jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install run'
 
-      label="$(cat /host/ubuntu-data/systems.label)"
-      test -n "$label"
-      # seed in mounted in recover mode too
-      test -d "/var/lib/snapd/seed/systems/$label"
+        label="$(cat /host/ubuntu-data/systems.label)"
+        test -n "$label"
+        # seed in mounted in recover mode too
+        test -d "/var/lib/snapd/seed/systems/$label"
 
-      MATCH "snapd_recovery_system=$label" < /proc/cmdline
+        MATCH "snapd_recovery_system=$label" < /proc/cmdline
 
-      # see earlier note
-      mount -o bind "$PWD/mock-shutdown" /usr/sbin/shutdown
+        # see earlier note
+        mount -o bind "$PWD/mock-shutdown" /usr/sbin/shutdown
 
-      # request going back to run mode
-      test-snapd-curl.curl -X POST --data '{"action":"do","mode":"run"}' \
-          -s --unix-socket /run/snapd.socket "http://localhost/v2/systems/$label" | \
-          MATCH '"system-restart"'
-      # XXX: is this a race between spread seeing REBOOT and machine rebooting?
+        # request going back to run mode
+        test-snapd-curl.curl -X POST --data '{"action":"do","mode":"run"}' \
+            -s --unix-socket /run/snapd.socket "http://localhost/v2/systems/$label" | \
+            MATCH '"system-restart"'
+        # XXX: is this a race between spread seeing REBOOT and machine rebooting?
 
-      # see earlier note about shutdown
-      # shellcheck disable=SC2016
-      retry -n 30 --wait 1 sh -c 'test "$(wc -l < /tmp/mock-shutdown.calls)" = "2"'
-      # an immediate reboot should have been scheduled
-      MATCH -- '-r \+0' < /tmp/mock-shutdown.calls
+        # see earlier note about shutdown
+        # shellcheck disable=SC2016
+        retry -n 30 --wait 1 sh -c 'test "$(wc -l < /tmp/mock-shutdown.calls)" = "2"'
+        # an immediate reboot should have been scheduled
+        MATCH -- '-r \+0' < /tmp/mock-shutdown.calls
 
-      umount /usr/sbin/shutdown
+        umount /usr/sbin/shutdown
 
-      REBOOT
+        REBOOT
 
-  elif [ "$SPREAD_REBOOT" == "2" ]; then
-      echo "In run mode again"
-      test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
-      jq -r '.result["system-mode"]' < system-info | MATCH 'run'
-  fi
+    elif [ "$SPREAD_REBOOT" == "2" ]; then
+        echo "In run mode again"
+        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        jq -r '.result["system-mode"]' < system-info | MATCH 'run'
+    fi


### PR DESCRIPTION
With the external backend, we do not have the special snapd snap like we do on the google backend which copies gopath data from ubuntu-seed to the current ubuntu-data (which in recover mode is a tmpfs). Instead, we use a small hack, abusing the ~/.ssh/rc file which is run on the first ssh connection from spread, and bind mount the required files from /host/ubuntu-data to /home so that spread can run successfully.

We need to remove this ~/.ssh/rc file before going back to run mode however, as otherwise spread fails to re-connect with:
```
ssh: unexpected packet in response to channel open: <nil>
```
Unclear what makes that happen, as a normal ssh connection from i.e. a terminal works fine with this ~/.ssh/rc file in place.
