### PR TITLE
overlord: mock timings.DurationThreshold in TestNewWithGoodState

### DIFF
--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timings"
 )
 
 func TestOverlord(t *testing.T) { TestingT(t) }
@@ -151,6 +152,12 @@ func (ovs *overlordSuite) TestNewStore(c *C) {
 }
 
 func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
+	// ensure we don't write state load timing in the state on really
+	// slow architectures (e.g. risc-v)
+	oldDurationThreshold := timings.DurationThreshold
+	timings.DurationThreshold = time.Second * 30
+	defer func() { timings.DurationThreshold = oldDurationThreshold }()
+
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"patch-sublevel-last-version":%q,"some":"data","refresh-privacy-key":"0123456789ABCDEF"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, snapdtool.Version))
 	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The TestNewWithGoodState test checks that reading/writing the
state works correctly. However when the loading is longer than
timings.DurationThreshold which is 5ms right now then the test
will fail because the state contains more data than the test
expects. This can happen on really slow architectures like
the emulated risc-v.

To fix this this commit just increase timings.DurationThreshold
during the test.

