### PR TITLE
spread.yaml: allow amazon-linux-2-64 qemu with ec2-user/ec2-user

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -251,6 +251,9 @@ backends:
             - centos-7-64:
                   username: centos
                   password: centos
+            - amazon-linux-2-64:
+                  username: ec2-user
+                  password: ec2-user
     autopkgtest:
         type: adhoc
         allocate: |


### PR DESCRIPTION
spread.yaml: allow amazon-linux-2-64 qemu with ec2-user/ec2-user

Reference:
- https://aws.amazon.com/amazon-linux-2/
- https://cdn.amazonlinux.com/os-images/2.0.20200602.0/
- https://cdn.amazonlinux.com/os-images/2.0.20200602.0/README.cloud-init
- https://cdn.amazonlinux.com/os-images/2.0.20200602.0/kvm/
- https://blog.strandboge.com/2019/04/16/cloud-images-qemu-cloud-init-and-snapd-spread-tests/ (see 'UPDATE 2020-06-27')