### PR TITLE
osutil: detect autofs mounted in /home

### DIFF
--- a/osutil/nfs_linux.go
+++ b/osutil/nfs_linux.go
@@ -35,7 +35,7 @@ func IsHomeUsingNFS() (bool, error) {
 		return false, fmt.Errorf("cannot parse mountinfo: %s", err)
 	}
 	for _, entry := range mountinfo {
-		if (entry.FsType == "nfs4" || entry.FsType == "nfs") && (strings.HasPrefix(entry.MountDir, "/home/") || entry.MountDir == "/home") {
+		if (entry.FsType == "nfs4" || entry.FsType == "nfs" || entry.FsType == "autofs") && (strings.HasPrefix(entry.MountDir, "/home/") || entry.MountDir == "/home") {
 			return true, nil
 		}
 	}

--- a/osutil/nfs_linux_test.go
+++ b/osutil/nfs_linux_test.go
@@ -76,6 +76,10 @@ func (s *nfsSuite) TestIsHomeUsingNFS(c *C) {
 	}, {
 		// NFS that may be mounted at /mnt/nfs is ignored (not in $HOME).
 		fstab: "localhost:/srv/nfs /mnt/nfs nfs defaults 0 0",
+	}, {
+		// autofs that is mounted at /home.
+		mountinfo: "137 29 0:50 / /home rw,relatime shared:87 - autofs /etc/auto.master.d/home rw,fd=7,pgrp=22588,timeout=300,minproto=5,maxproto=5,indirect,pipe_ino=173399",
+		nfs:       true,
 	}}
 	for _, tc := range cases {
 		restore := osutil.MockMountInfo(tc.mountinfo)


### PR DESCRIPTION
For a while, we had reports about autofs being incompatible with snapd.
We just got extra information about how an autofs setup looks like.

There are two participating components, autofs uses an automount mount
point, which is a kernel feature that mounts a filesystem whenever a
path is accessed in a normal way, and an userspace service that responds
to those mount requets and performs the actual mount operation on when
asked by the kernel.

We can expand the existing NFS detection to trigger on autofs and treat
it the exact same way. We could attempt to parse autofs configuration as
well but in practice it seems to be used for network filesystems so I
don't think this is required.

Ref: https://www.kernel.org/doc/html/latest/filesystems/autofs.html
Ref: https://www.kernel.org/doc/html/latest/filesystems/automount-support.html
Fixes: https://bugs.launchpad.net/snapd/+bug/1784774
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
