### PR TITLE
sandbox/cgroup: extend SnapNameFromPid with tracking cgroup data

### DIFF
--- a/sandbox/cgroup/process.go
+++ b/sandbox/cgroup/process.go
@@ -23,28 +23,52 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/snapcore/snapd/snap/naming"
 )
 
-func SnapNameFromPid(pid int) (string, error) {
+func snapNameFromPidUsingTrackingCgroup(pid int) (string, error) {
+	// Maybe we have application tracking and can use it?
+	path, err := ProcessPathInTrackingCgroup(pid)
+	if err != nil {
+		return "", err
+	}
+	// TODO: this could return the parsed tag already, as it's doing all the
+	// work and discarding the parsed result. Make it so.
+	tag := securityTagFromCgroupPath(path)
+	parsedTag, err := naming.ParseSecurityTag(tag)
+	if err != nil {
+		return "", err
+	}
+	return parsedTag.InstanceName(), nil
+}
+
+func snapNameFromPidUsingFreezerCgroup(pid int) (string, error) {
+	// This logic only makes sense with cgroup v1.
 	if IsUnified() {
-		// not supported
 		return "", fmt.Errorf("not supported")
 	}
 
+	// Find the path in the freezer cgroup.
 	group, err := ProcGroup(pid, MatchV1Controller("freezer"))
 	if err != nil {
 		return "", fmt.Errorf("cannot determine cgroup path of pid %v: %v", pid, err)
 	}
-
 	if !strings.HasPrefix(group, "/snap.") {
 		return "", fmt.Errorf("cannot find a snap for pid %v", pid)
 	}
 
+	// Extract the snap name form the path.
 	snapName := strings.SplitN(filepath.Base(group), ".", 2)[1]
-
 	if snapName == "" {
 		return "", fmt.Errorf("snap name in cgroup path is empty")
 	}
-
 	return snapName, nil
+}
+
+func SnapNameFromPid(pid int) (string, error) {
+	if snapName, err := snapNameFromPidUsingTrackingCgroup(pid); err == nil {
+		return snapName, nil
+	}
+	return snapNameFromPidUsingFreezerCgroup(pid)
 }


### PR DESCRIPTION
The function SnapNameFromPid is used by `snap routine ...` to determine
if a given process is a snap. The function used to look for the
freezer cgroup but this is no longer used in cgroupv2 world.
Instead, it will now look for the new tracking cgroup, if one is available
and if not, fall back to the freezer cgroup.

In practice, this will soon allow `snap routine portal-info` to work
on Fedora 31+. This is not yet possible as we do not track applications
just yet.

This patch was extracted out of the larger feature branch.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
