### PR TITLE
tests: fix "restart.service"

### DIFF
--- a/tests/lib/tools/cleanup-state
+++ b/tests/lib/tools/cleanup-state
@@ -74,7 +74,7 @@ case "$action" in
 			fi
 			# XXX: if there's a way to check if an unit exists but is stopped,
 			# use it here to avoid starting a non-existing unit.
-			systemctl --user start restart snapd.session-agent.socket || true
+			systemctl --user start snapd.session-agent.socket || true
 		fi
 		;;
 	post-invariant)


### PR DESCRIPTION
While looking at an unrelated failure I noticed this oddly looking error
message:

    Failed to start restart.service: Unit restart.service not found.

Quick look around the tree and sure enough there's a mistake in how we
invoke systemctl to start a service.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
