### PR TITLE
sandbox/cgroup: avoid parsing security tags twice

### DIFF
--- a/sandbox/cgroup/process.go
+++ b/sandbox/cgroup/process.go
@@ -31,8 +31,6 @@ func snapNameFromPidUsingTrackingCgroup(pid int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// TODO: this could return the parsed tag already, as it's doing all the
-	// work and discarding the parsed result. Make it so.
 	if parsedTag := securityTagFromCgroupPath(path); parsedTag != nil {
 		return parsedTag.InstanceName(), nil
 	}

--- a/sandbox/cgroup/process.go
+++ b/sandbox/cgroup/process.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-
-	"github.com/snapcore/snapd/snap/naming"
 )
 
 func snapNameFromPidUsingTrackingCgroup(pid int) (string, error) {
@@ -35,12 +33,10 @@ func snapNameFromPidUsingTrackingCgroup(pid int) (string, error) {
 	}
 	// TODO: this could return the parsed tag already, as it's doing all the
 	// work and discarding the parsed result. Make it so.
-	tag := securityTagFromCgroupPath(path)
-	parsedTag, err := naming.ParseSecurityTag(tag)
-	if err != nil {
-		return "", err
+	if parsedTag := securityTagFromCgroupPath(path); parsedTag != nil {
+		return parsedTag.InstanceName(), nil
 	}
-	return parsedTag.InstanceName(), nil
+	return "", fmt.Errorf("cannot find snap security tag")
 }
 
 func snapNameFromPidUsingFreezerCgroup(pid int) (string, error) {


### PR DESCRIPTION
When discovering snap name of a given PID using the tracking cgroup we
used to parse the security tag twice, because securityTagFromCgroupPath
returned a string and not a naming.SecurityTag, even though it had the
information. This patch fixes this.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
