### PR TITLE
tests: fix leaked dbus-daemon in selinux-clean

### DIFF
--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -32,6 +32,8 @@ restore: |
     rm -f stamp enforcing.mode
 
     tests.session -u test restore
+    # Stop dbus activated by test-snapd-desktop snap.
+    systemctl --user stop dbus.service || true
 
 execute: |
     systemctl restart snapd.socket


### PR DESCRIPTION
There's one more D-Bus daemon that was leaking from the selinux-clean
test, due to that test's usage of the desktop interface. This failure
was masked by the unstable nature of the CentOS 8 image where we ignore
known errors and the invariant violation fell through the cracks.

Thanks to Sergio for spotting.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>