### PR TITLE
cmd/snap-update-ns: handle anomalies better

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -361,6 +361,25 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 					umountOpts = append(umountOpts, fmt.Sprintf("%#x", unknownFlags))
 				}
 				logger.Debugf("umount %q %s (error: %v)", c.Entry.Dir, strings.Join(umountOpts, "|"), err)
+				if err == syscall.EINVAL {
+					// We attempted to unmount but got an EINVAL, one of the
+					// possibilities and the only one unless we provided wrong
+					// flags, is that the mount no longer exists.
+					//
+					// We can verify that now by scanning mountinfo:
+					entries, _ := osutil.LoadMountInfo()
+					for _, entry := range entries {
+						if entry.MountDir == c.Entry.Dir {
+							return err
+						}
+					}
+					// We didn't find a mount point at the location we tried to
+					// unmount. The EINVAL we observed indicates that the mount
+					// profile no longer agrees with reality. The mount point
+					// longer exists. As such, consume the error and carry on.
+					logger.Debugf("ignoring EINVAL from unmount, %q is not mounted", c.Entry.Dir)
+					err = nil
+				}
 				if err != nil {
 					return err
 				}
@@ -373,6 +392,10 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			path := c.Entry.Dir
 			var fd int
 			fd, err = OpenPath(path)
+			// If the place does not exist anymore, we are done.
+			if os.IsNotExist(err) {
+				return nil
+			}
 			if err != nil {
 				return err
 			}

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -376,7 +376,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 					// We didn't find a mount point at the location we tried to
 					// unmount. The EINVAL we observed indicates that the mount
 					// profile no longer agrees with reality. The mount point
-					// longer exists. As such, consume the error and carry on.
+					// no longer exists. As such, consume the error and carry on.
 					logger.Debugf("ignoring EINVAL from unmount, %q is not mounted", c.Entry.Dir)
 					err = nil
 				}

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -370,6 +370,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 					entries, _ := osutil.LoadMountInfo()
 					for _, entry := range entries {
 						if entry.MountDir == c.Entry.Dir {
+							// Mount point still exists, EINVAL was unexpected.
 							return err
 						}
 					}

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -2997,14 +2997,14 @@ func (s *changeSuite) TestUnmountFailsWithEINVALAndUnmounted(c *C) {
 	_, err := chg.Perform(s.as)
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
-		testutil.CallResultError{C: `unmount "/target" UMOUNT_NOFOLLOW`, E: syscall.EINVAL},
-		testutil.CallResultError{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
-		testutil.CallResultError{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
-		testutil.CallResultError{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
-		testutil.CallResultError{C: `close 3`},
-		testutil.CallResultError{C: `fstatfs 4 <ptr>`, R: syscall.Statfs_t{}},
-		testutil.CallResultError{C: `remove "/target"`},
-		testutil.CallResultError{C: `close 4`},
+		{C: `unmount "/target" UMOUNT_NOFOLLOW`, E: syscall.EINVAL},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `fstatfs 4 <ptr>`, R: syscall.Statfs_t{}},
+		{C: `remove "/target"`},
+		{C: `close 4`},
 	})
 }
 
@@ -3018,6 +3018,6 @@ func (s *changeSuite) TestUnmountFailsWithEINVALButStillMounted(c *C) {
 	_, err := chg.Perform(s.as)
 	c.Assert(err, Equals, syscall.EINVAL)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
-		testutil.CallResultError{C: `unmount "/target" UMOUNT_NOFOLLOW`, E: syscall.EINVAL},
+		{C: `unmount "/target" UMOUNT_NOFOLLOW`, E: syscall.EINVAL},
 	})
 }

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -2984,3 +2984,40 @@ func (s *changeSuite) TestComplexPropagatingChanges(c *C) {
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "/snap/app/x2/b", Dir: "/snap/app/x2/d", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}}},
 	})
 }
+
+func (s *changeSuite) TestUnmountFailsWithEINVALAndUnmounted(c *C) {
+	// We wanted to unmount /target, which failed with EINVAL.
+	// Because /target is no longer mounted, we consume the error and carry on.
+	restore := osutil.MockMountInfo("")
+	defer restore()
+	s.sys.InsertFault(`unmount "/target" UMOUNT_NOFOLLOW`, syscall.EINVAL)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatfsResult(`fstatfs 4 <ptr>`, syscall.Statfs_t{})
+	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/target", Type: "tmpfs"}}
+	_, err := chg.Perform(s.as)
+	c.Assert(err, IsNil)
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		testutil.CallResultError{C: `unmount "/target" UMOUNT_NOFOLLOW`, E: syscall.EINVAL},
+		testutil.CallResultError{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		testutil.CallResultError{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		testutil.CallResultError{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		testutil.CallResultError{C: `close 3`},
+		testutil.CallResultError{C: `fstatfs 4 <ptr>`, R: syscall.Statfs_t{}},
+		testutil.CallResultError{C: `remove "/target"`},
+		testutil.CallResultError{C: `close 4`},
+	})
+}
+
+func (s *changeSuite) TestUnmountFailsWithEINVALButStillMounted(c *C) {
+	// We wanted to unmount /target, which failed with EINVAL.
+	// Because /target is still mounted, we propagate the error.
+	restore := osutil.MockMountInfo("132 28 0:82 / /target rw,relatime shared:74 - tmpfs tmpfs rw")
+	defer restore()
+	s.sys.InsertFault(`unmount "/target" UMOUNT_NOFOLLOW`, syscall.EINVAL)
+	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/target", Type: "tmpfs"}}
+	_, err := chg.Perform(s.as)
+	c.Assert(err, Equals, syscall.EINVAL)
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		testutil.CallResultError{C: `unmount "/target" UMOUNT_NOFOLLOW`, E: syscall.EINVAL},
+	})
+}

--- a/tests/regression/lp-1884849/task.yaml
+++ b/tests/regression/lp-1884849/task.yaml
@@ -4,31 +4,34 @@ details: |
   unmounting it again does not result in an error.
 systems: [ubuntu-16.04-64]
 prepare: |
-  # Having gimp installed, with the desktop plug connected
-  snap install gimp
-  snap connect gimp:desktop
+  #shellcheck source=tests/lib/snaps.sh
+  . "$TESTSLIB"/snaps.sh
+  # Having test-snapd-desktop installed, with the desktop plug connected
+  install_local test-snapd-desktop
+  snap install test-snapd-desktop
+  snap connect test-snapd-desktop:desktop
   # Having constructed the mount namespace as the test user
   tests.session -u test prepare
-  tests.session -u test exec snap run --shell gimp </dev/null
-  test -e /run/snapd/ns/gimp.mnt
+  tests.session -u test exec snap run --shell test-snapd-desktop.sh </dev/null
+  test -e /run/snapd/ns/test-snapd-desktop.mnt
   # Having altered the desired mount profile so that fontconfig cache is not meant to be mounted
-  sed -i -e 's@^/var/lib/snapd/hostfs/var/cache/fontconfig@#/var/lib/snapd/hostfs/var/cache/fontconfig@' /var/lib/snapd/mount/snap.gimp.fstab
+  sed -i -e 's@^/var/lib/snapd/hostfs/var/cache/fontconfig@#/var/lib/snapd/hostfs/var/cache/fontconfig@' /var/lib/snapd/mount/snap.test-snapd-desktop.fstab
   # Having manually altered the mount namespace, so that fontconfig cache is not mounted
   touch /var/cache/fontconfig/.canary
-  nsenter -m/run/snapd/ns/gimp.mnt test -e /var/cache/fontconfig/.canary
-  nsenter -m/run/snapd/ns/gimp.mnt umount /var/cache/fontconfig
-  nsenter -m/run/snapd/ns/gimp.mnt test ! -e /var/cache/fontconfig/.canary
+  nsenter -m/run/snapd/ns/test-snapd-desktop.mnt test -e /var/cache/fontconfig/.canary
+  nsenter -m/run/snapd/ns/test-snapd-desktop.mnt umount /var/cache/fontconfig
+  nsenter -m/run/snapd/ns/test-snapd-desktop.mnt test ! -e /var/cache/fontconfig/.canary
   # Having confirmed that snap-update-ns manifest assumes it still is.
-  grep -qFx '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.gimp.fstab
+  grep -qFx '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.test-snapd-desktop.fstab
 execute: |
   # I can update the mount namespace without an error.
-  SNAPD_DEBUG=1 snapd.tool exec snap-update-ns gimp 2>snap-update-ns.log
+  SNAPD_DEBUG=1 snapd.tool exec snap-update-ns test-snapd-desktop 2>snap-update-ns.log
   MATCH 'DEBUG: ignoring EINVAL from unmount, "/var/cache/fontconfig" is not mounted' <snap-update-ns.log
   # And confirm snap-update-ns fixed the situation
-  not grep -qF '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.gimp.fstab
-  nsenter -m/run/snapd/ns/gimp.mnt test ! -e /var/cache/fontconfig/.canary
+  not grep -qF '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.test-snapd-desktop.fstab
+  nsenter -m/run/snapd/ns/test-snapd-desktop.mnt test ! -e /var/cache/fontconfig/.canary
 restore: |
   rm -f snap-update-ns.log
   tests.session -u test restore
-  snap remove --purge gimp
+  snap remove --purge test-snapd-desktop
   rm -f /var/cache/fontconfig/.canary

--- a/tests/regression/lp-1884849/task.yaml
+++ b/tests/regression/lp-1884849/task.yaml
@@ -1,0 +1,34 @@
+summary: regression test for LP:#1884849
+details: |
+  When a mount point described by the mount profile is unmounted,
+  unmounting it again does not result in an error.
+systems: [ubuntu-16.04-64]
+prepare: |
+  # Having gimp installed, with the desktop plug connected
+  snap install gimp
+  snap connect gimp:desktop
+  # Having constructed the mount namespace as the test user
+  tests.session -u test prepare
+  tests.session -u test exec snap run --shell gimp </dev/null
+  test -e /run/snapd/ns/gimp.mnt
+  # Having altered the desired mount profile so that fontconfig cache is not meant to be mounted
+  sed -i -e 's@^/var/lib/snapd/hostfs/var/cache/fontconfig@#/var/lib/snapd/hostfs/var/cache/fontconfig@' /var/lib/snapd/mount/snap.gimp.fstab
+  # Having manually altered the mount namespace, so that fontconfig cache is not mounted
+  touch /var/cache/fontconfig/.canary
+  nsenter -m/run/snapd/ns/gimp.mnt test -e /var/cache/fontconfig/.canary
+  nsenter -m/run/snapd/ns/gimp.mnt umount /var/cache/fontconfig
+  nsenter -m/run/snapd/ns/gimp.mnt test ! -e /var/cache/fontconfig/.canary
+  # Having confirmed that snap-update-ns manifest assumes it still is.
+  grep -qFx '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.gimp.fstab
+execute: |
+  # I can update the mount namespace without an error.
+  SNAPD_DEBUG=1 snapd.tool exec snap-update-ns gimp 2>snap-update-ns.log
+  MATCH 'DEBUG: ignoring EINVAL from unmount, "/var/cache/fontconfig" is not mounted' <snap-update-ns.log
+  # And confirm snap-update-ns fixed the situation
+  not grep -qF '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.gimp.fstab
+  nsenter -m/run/snapd/ns/gimp.mnt test ! -e /var/cache/fontconfig/.canary
+restore: |
+  rm -f snap-update-ns.log
+  tests.session -u test restore
+  snap remove --purge gimp
+  rm -f /var/cache/fontconfig/.canary


### PR DESCRIPTION
When snap-update-ns decides to mount or unmount something, it makes the
decision based on the differences between mount profiles - fstab like
files that describe what is probably mounted and what should be mounted.
Actual mount table is much more complex, containing mounts performed by
snap-confine as well as the effect of complex recursive bind mounts and
unmounts.

As an analogy, we navigate a submarine not by looking out the window but
by looking at a map and our internal instruments. We may run into
problems if there's disagreement between the outside world and our
simplified representation.

This patch provides two improvements to situations when our internal
representation disagrees with reality: one for umount failing with
EINVAL and anther for rmdir/unlink which fails with ENOENT. In both
cases the idea is the same, we try to remove something which is not
there.

In the first case, when unmount fails with EINVAL, we can check if the
path we intended to unmount is really a mount point. If it is not then
the call has failed because our desired result is already present.

In the second case, when removing a file or directory fails with ENOENT
then the object is clearly already removed.

In both cases we can continue instead of failing.

Ref: https://bugs.launchpad.net/snapd/+bug/1884849
Ref: https://forum.snapcraft.io/t/18393/10
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>