### PR TITLE
tests: rename invariant-tool to tests.invariant

### DIFF
--- a/tests/bin/tests.invariant
+++ b/tests/bin/tests.invariant
@@ -1,0 +1,1 @@
+../lib/tools/tests.invariant

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -560,7 +560,7 @@ prepare_suite_each() {
     if [[ "$variant" = full ]]; then
         "$TESTSTOOLS"/cleanup-state pre-invariant
     fi
-    invariant-tool check
+    tests.invariant check
 }
 
 restore_suite_each() {
@@ -627,7 +627,7 @@ restore_suite() {
 restore_project_each() {
     "$TESTSTOOLS"/cleanup-state pre-invariant
     # Check for invariants early, in order not to mask bugs in tests.
-    invariant-tool check
+    tests.invariant check
     "$TESTSTOOLS"/cleanup-state post-invariant
 
     # TODO: move this to tests.cleanup.

--- a/tests/lib/tools/README
+++ b/tests/lib/tools/README
@@ -98,7 +98,7 @@ lxd-tool -> tests/lib/tools/lxd-state
   fix to have -h
 
 invariant-tool -> tests/lib/tools/tests.invariant? then it could also live in /bin
-  fix to have -h
+  [done] fix to have -h
 
 * more complicated option, have a tests.state trampoline command in tests/bin
   that given `tests.state WHAT ARGS` invokes `tests/lib/tools/state-WHAT ARGS`

--- a/tests/lib/tools/README
+++ b/tests/lib/tools/README
@@ -97,7 +97,7 @@ lxd-tool -> tests/lib/tools/lxd-state
   fix no args
   fix to have -h
 
-invariant-tool -> tests/lib/tools/tests.invariant? then it could also live in /bin
+[done] invariant-tool -> tests/lib/tools/tests.invariant? then it could also live in /bin
   [done] fix to have -h
 
 * more complicated option, have a tests.state trampoline command in tests/bin

--- a/tests/lib/tools/invariant-tool
+++ b/tests/lib/tools/invariant-tool
@@ -18,7 +18,7 @@ fi
 action=
 while [ $# -gt 0 ]; do
 	case "$1" in
-		--help)
+		-h|--help)
 			show_help
 			exit 0
 			;;

--- a/tests/lib/tools/suite/tests.invariant/task.yaml
+++ b/tests/lib/tools/suite/tests.invariant/task.yaml
@@ -1,4 +1,4 @@
-summary: invariant-tool is detecting problems
+summary: tests.invariant is detecting problems
 prepare: |
     truncate --size=0 defer.sh
     chmod +x defer.sh
@@ -9,31 +9,31 @@ restore: |
     sh -xe refed.sh && rm -f {defer,refed}.sh
 execute: |
     # Invariant tool presents the usage screen when invoked without arguments
-    invariant-tool | MATCH 'usage: invariant-tool check \[INVARIANT...\]'
+    tests.invariant | MATCH 'usage: tests.invariant check \[INVARIANT...\]'
 
     # When invoked with "check" argument, it runs either all invariants
     # or the specified set of invariants.
-    invariant-tool check | MATCH 'invariant-tool: root-files-in-home ok'
-    invariant-tool check root-files-in-home | MATCH 'invariant-tool: root-files-in-home ok'
+    tests.invariant check | MATCH 'tests.invariant: root-files-in-home ok'
+    tests.invariant check root-files-in-home | MATCH 'tests.invariant: root-files-in-home ok'
 
     # Unknown invariant names are reported.
-    invariant-tool check foo 2>&1 | MATCH 'invariant-tool: unknown invariant foo'
-    not invariant-tool check foo 2>/dev/null
+    tests.invariant check foo 2>&1 | MATCH 'tests.invariant: unknown invariant foo'
+    not tests.invariant check foo 2>/dev/null
 
     # The root-files-in-home invariant detects files owned by root anywhere in /home/
-    invariant-tool check root-files-in-home | MATCH 'invariant-tool: root-files-in-home ok'
+    tests.invariant check root-files-in-home | MATCH 'tests.invariant: root-files-in-home ok'
     touch /home/test/invariant-canary
     echo 'rm -f /home/test/invariant-canary' >> defer.sh
     chown root /home/test/invariant-canary
-    invariant-tool check root-files-in-home 2>&1 | MATCH 'invariant-tool: root-files-in-home not-ok'
-    invariant-tool check root-files-in-home 2>&1 | MATCH 'invariant-tool: the following files should not be owned by root'
-    invariant-tool check root-files-in-home 2>&1 | MATCH '/home/test/invariant-canary'
-    invariant-tool check root-files-in-home 2>&1 | MATCH 'invariant-tool: system is corrupted'
-    not invariant-tool check root-files-in-home 2>/dev/null
+    tests.invariant check root-files-in-home 2>&1 | MATCH 'tests.invariant: root-files-in-home not-ok'
+    tests.invariant check root-files-in-home 2>&1 | MATCH 'tests.invariant: the following files should not be owned by root'
+    tests.invariant check root-files-in-home 2>&1 | MATCH '/home/test/invariant-canary'
+    tests.invariant check root-files-in-home 2>&1 | MATCH 'tests.invariant: system is corrupted'
+    not tests.invariant check root-files-in-home 2>/dev/null
 
     # Chown is the solution.
     chown test /home/test/invariant-canary
-    invariant-tool check root-files-in-home | MATCH 'invariant-tool: root-files-in-home ok'
+    tests.invariant check root-files-in-home | MATCH 'tests.invariant: root-files-in-home ok'
 
     # The root-files-in-home invariant ignores /home/gopath which comes from spread.yaml
     test -d /home/gopath
@@ -50,13 +50,13 @@ execute: |
         echo 'rmdir /home/ubuntu' >> defer.sh
         chown root /home/ubuntu
     fi
-    invariant-tool check root-files-in-home | MATCH 'invariant-tool: root-files-in-home ok'
+    tests.invariant check root-files-in-home | MATCH 'tests.invariant: root-files-in-home ok'
 
     # Invariant tool detects leftovers from crashed snap-confine.
-    mkdir /tmp/snap.rootfs_invariant-tool
-    invariant-tool check crashed-snap-confine 2>&1 | MATCH 'invariant-tool: crashed-snap-confine not-ok'
-    invariant-tool check crashed-snap-confine 2>&1 | MATCH 'invariant-tool: it seems snap-confine has crashed'
-    rmdir /tmp/snap.rootfs_invariant-tool
+    mkdir /tmp/snap.rootfs_tests.invariant
+    tests.invariant check crashed-snap-confine 2>&1 | MATCH 'tests.invariant: crashed-snap-confine not-ok'
+    tests.invariant check crashed-snap-confine 2>&1 | MATCH 'tests.invariant: it seems snap-confine has crashed'
+    rmdir /tmp/snap.rootfs_tests.invariant
 
     # This filters out 14.04 and ubuntu-core, respectively.
     if [ "$(command -v systemd-run)" != "" ] && [ "$(command -v dbus-launch)" != "" ]; then
@@ -64,7 +64,7 @@ execute: |
         systemd-run --service-type=forking --unit superfluous-dbus.service dbus-launch --sh-syntax
         # shellcheck disable=SC2016
         retry sh -c 'test "$(systemctl is-active superfluous-dbus.service)" = active'
-        invariant-tool check stray-dbus-daemon 2>&1 | MATCH 'invariant-tool: stray-dbus-daemon not-ok'
+        tests.invariant check stray-dbus-daemon 2>&1 | MATCH 'tests.invariant: stray-dbus-daemon not-ok'
         systemctl stop superfluous-dbus.service
-        invariant-tool check stray-dbus-daemon 2>&1 | MATCH 'invariant-tool: stray-dbus-daemon ok'
+        tests.invariant check stray-dbus-daemon 2>&1 | MATCH 'tests.invariant: stray-dbus-daemon ok'
     fi

--- a/tests/lib/tools/suite/tests.invariant/task.yaml
+++ b/tests/lib/tools/suite/tests.invariant/task.yaml
@@ -9,7 +9,10 @@ restore: |
     sh -xe refed.sh && rm -f {defer,refed}.sh
 execute: |
     # Invariant tool presents the usage screen when invoked without arguments
+    # or with the -h or --help options.
     tests.invariant | MATCH 'usage: tests.invariant check \[INVARIANT...\]'
+    tests.invariant -h | MATCH 'usage: tests.invariant check \[INVARIANT...\]'
+    tests.invariant --help | MATCH 'usage: tests.invariant check \[INVARIANT...\]'
 
     # When invoked with "check" argument, it runs either all invariants
     # or the specified set of invariants.

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -1,13 +1,14 @@
 #!/bin/sh
 
 show_help() {
-	echo "usage: invariant-tool check [INVARIANT...]"
+	echo "usage: tests.invariant check [INVARIANT...]"
 	echo
 	echo "Supported invariants:"
 	echo "    root-files-in-home: most of /home/* does not contain root-owned files"
 	echo "    crashed-snap-confine: /tmp/snap.rootfs_* does not exist"
 	echo "    lxcfs-mounted: /var/lib/lxcfs is a mount point"
 	echo "    stray-dbus-daemon: at most one dbus-daemon is running"
+
 }
 
 if [ $# -eq 0 ]; then
@@ -31,7 +32,7 @@ while [ $# -gt 0 ]; do
 			shift
 			;;
 		-*)
-			echo "invariant-tool: unsupported argument $1" >&2
+			echo "tests.invariant: unsupported argument $1" >&2
 			exit 1
 			;;
 		*)
@@ -46,31 +47,31 @@ check_root_files_in_home() {
 	# - The /home/ubuntu directory is root owned but is not used by the tests so we ignore it
 	# - The /home/gopath and everything inside it comes from spread.yaml and is too inconvenient to change
 	# As a note, the working theory for the origin of /home/ubuntu is cloud-init and data from GCE.
-	find /home -mindepth 1 -user root -a ! -path "/home/ubuntu" -a ! -path "$GOHOME" -a ! -path "$GOHOME/*" 2>/dev/null >"/tmp/invariant-tool.$n"
-	if [ -s "/tmp/invariant-tool.$n" ]; then
-		echo "invariant-tool: the following files should not be owned by root" >&2
-		cat "/tmp/invariant-tool.$n" >&2
+	find /home -mindepth 1 -user root -a ! -path "/home/ubuntu" -a ! -path "$GOHOME" -a ! -path "$GOHOME/*" 2>/dev/null >"/tmp/tests.invariant.$n"
+	if [ -s "/tmp/tests.invariant.$n" ]; then
+		echo "tests.invariant: the following files should not be owned by root" >&2
+		cat "/tmp/tests.invariant.$n" >&2
 		return 1
 	fi
 }
 
 check_crashed_snap_confine() {
 	n="$1" # invariant name
-	find /tmp -name 'snap.rootfs_*' > "/tmp/invariant-tool.$n"
+	find /tmp -name 'snap.rootfs_*' > "/tmp/tests.invariant.$n"
 	# NOTE: it may be a mount point but we are not checking that here.
-	if [ -s "/tmp/invariant-tool.$n" ]; then
-		echo "invariant-tool: it seems snap-confine has crashed" >&2
-		cat "/tmp/invariant-tool.$n" >&2
+	if [ -s "/tmp/tests.invariant.$n" ]; then
+		echo "tests.invariant: it seems snap-confine has crashed" >&2
+		cat "/tmp/tests.invariant.$n" >&2
 		return 1
 	fi
 }
 
 check_lxcfs_mounted() {
 	n="$1" # invariant name
-	"$TESTSTOOLS"/mountinfo-tool /var/lib/lxcfs > "/tmp/invariant-tool.$n"
-	if [ -s "/tmp/invariant-tool.$n" ]; then
-		echo "invariant-tool: it seems lxcfs is mounted" >&2
-		cat "/tmp/invariant-tool.$n" >&2
+	"$TESTSTOOLS"/mountinfo-tool /var/lib/lxcfs > "/tmp/tests.invariant.$n"
+	if [ -s "/tmp/tests.invariant.$n" ]; then
+		echo "tests.invariant: it seems lxcfs is mounted" >&2
+		cat "/tmp/tests.invariant.$n" >&2
 		return 1
 	fi
 }
@@ -95,10 +96,10 @@ check_stray_dbus_daemon() {
 			# Report stray dbus-daemon.
 			echo "pid:$pid cmdline:$cmdline"
 		done
-	) > "/tmp/invariant-tool.$n"
-	if [ -s "/tmp/invariant-tool.$n" ]; then
-		echo "invariant-tool: more than one dbus-daemon running" >&2
-		cat "/tmp/invariant-tool.$n" >&2
+	) > "/tmp/tests.invariant.$n"
+	if [ -s "/tmp/tests.invariant.$n" ]; then
+		echo "tests.invariant: more than one dbus-daemon running" >&2
+		cat "/tmp/tests.invariant.$n" >&2
 		return 1
 	fi
 }
@@ -118,7 +119,7 @@ check_invariant() {
 			check_stray_dbus_daemon "$1"
 			;;
 		*)
-			echo "invariant-tool: unknown invariant $1" >&2
+			echo "tests.invariant: unknown invariant $1" >&2
 			exit 1
 			;;
 	esac
@@ -136,19 +137,19 @@ case "$action" in
 		fi
 		for inv in $INV_LIST; do
 			if check_invariant "$inv"; then
-				echo "invariant-tool: $inv ok"
+				echo "tests.invariant: $inv ok"
 			else
-				echo "invariant-tool: $inv not-ok" >&2
+				echo "tests.invariant: $inv not-ok" >&2
 				ok=0
 			fi
 		done
 		if [ $ok -eq 0 ]; then
-			echo "invariant-tool: system is corrupted" >&2
+			echo "tests.invariant: system is corrupted" >&2
 			exit 1
 		fi
 		;;
 	*)
-		echo "invariant-tool: unknown action $action" >&2
+		echo "tests.invariant: unknown action $action" >&2
 		exit 1
 		;;
 esac


### PR DESCRIPTION
The invariant checker is now following the agreed upon name for tools placed on
PATH. It also responds to -h and --help and has tests to ensure this works correctly.
