### PR TITLE
tests: rename memory-tool to memory-observe-do

### DIFF
--- a/tests/lib/tools/README
+++ b/tests/lib/tools/README
@@ -65,7 +65,7 @@ tests/bin/tests.session -> tests/lib/tools/tests.session (was session-tool)
   [done] convert --ACTION into subcommands
   [done] require "exec" subcommand to execute a command
 
-tests/lib/tools/memory-observe-do (was memory-tool)
+[done] tests/lib/tools/memory-observe-do (was memory-tool)
 tests/lib/tools/version-compare (was version-tool)
 
 tests/bin/mountinfo.query -> tests/lib/tools/mountinfo.query (was mountinfo-tool)

--- a/tests/lib/tools/memory-observe-do
+++ b/tests/lib/tools/memory-observe-do
@@ -45,7 +45,7 @@ def _make_parser():
     # type: () -> argparse.ArgumentParser
     parser = argparse.ArgumentParser(
         description="""
-Memory-tool executes COMMAND and stores the maximum size of RSS
+This program executes COMMAND and stores the maximum size of RSS
 into the specified file. The exit status of COMMAND is preserved.
 """
     )

--- a/tests/regression/lp-1848567/task.yaml
+++ b/tests/regression/lp-1848567/task.yaml
@@ -21,9 +21,9 @@ execute: |
     # Re-compile the apparmor profile for snap-update-ns for the
     # test-snapd-app snap while ensuring that the profile is not loaded
     # into kernel memory and that the compiler is not using any existing
-    # caches. Use memory-tool(1) to record the maximum resident memory usage
+    # caches. Use memory-observe-do to record the maximum resident memory usage
     # and store it in a file.
-    memory-tool -o memory-kb.txt apparmor_parser \
+    "$TESTSTOOLS"/memory-observe-do -o memory-kb.txt apparmor_parser \
       --skip-read-cache --skip-cache --skip-kernel-load -Ono-expr-simplify \
       /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-app
     # Without de-duplicating mount rules the compiler would take about 1.5GB on a


### PR DESCRIPTION
Since this program is used infrequently, it is not going to stay on PATH
and needs to be executed as "$TESTSTOOLS"/memory-observe-do.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>