### PR TITLE
tests: fix argument handling of apt-state

### DIFF
--- a/tests/lib/tools/README
+++ b/tests/lib/tools/README
@@ -90,8 +90,8 @@ user-tool -> test/lib/tools/user-state
 
 [done] apt-tool -> tests/lib/tools/apt-state
   use any-python?
-  fix no args
-  fix to have -h
+  [done] fix no args
+  [done] fix to have -h
 
 lxd-tool -> tests/lib/tools/lxd-state
   fix no args

--- a/tests/lib/tools/apt-state
+++ b/tests/lib/tools/apt-state
@@ -1,11 +1,12 @@
 #!/usr/bin/python3
 
 import sys
+import argparse
 
 import apt
 
 
-def checkpoint():
+def checkpoint() -> None:
     pkgs = set()
     cache = apt.Cache()
     for pkg in cache:
@@ -15,9 +16,9 @@ def checkpoint():
         print(name)
 
 
-def restore(fname):
+def restore(fname: str) -> None:
     desired = set([line.strip() for line in open(fname)])
-            
+
     cache = apt.Cache()
     for pkg in cache:
         if pkg.is_installed and not pkg.name in desired:
@@ -29,8 +30,35 @@ def restore(fname):
     cache.commit()
 
 
+def _make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    # TODO: make checkpoint and restore symmetric to use either stdin/stdout or
+    # FILE in both cases.
+    cmd = sub.add_parser(
+        "checkpoint",
+        help="preserve the set of installed packages",
+        description="Prints the set of installed installed packages.",
+    )
+    cmd.set_defaults(func=lambda ns: checkpoint())
+    cmd = sub.add_parser(
+        "restore",
+        help="restore the set of installed packages",
+        description="Adjusts the system retaining exactly the packages listed in FILE.",
+    )
+    cmd.add_argument("fname", metavar="FILE", help="preserved apt state")
+    cmd.set_defaults(func=lambda ns: restore(ns.fname))
+    return parser
+
+
+def main() -> None:
+    parser = _make_parser()
+    ns = parser.parse_args()
+    if hasattr(ns, "func"):
+        ns.func(ns)
+    else:
+        parser.print_help()
+
+
 if __name__ == "__main__":
-    if sys.argv[1] == "checkpoint":
-        checkpoint()
-    elif sys.argv[1] == "restore":
-        restore(sys.argv[2])
+    main()

--- a/tests/lib/tools/suite/apt-state/task.yaml
+++ b/tests/lib/tools/suite/apt-state/task.yaml
@@ -1,0 +1,10 @@
+summary: integration tests for apt-state
+systems:
+    - ubuntu-16.04-*
+    - ubuntu-18.04-*
+    - ubuntu-20.04-*
+    - debian-*
+execute: |
+    "$TESTSTOOLS"/apt-state -h | grep -qFx "usage: apt-state [-h] {checkpoint,restore} ..."
+    "$TESTSTOOLS"/apt-state checkpoint -h | grep -qFx "usage: apt-state checkpoint [-h]"
+    "$TESTSTOOLS"/apt-state restore -h | grep -qFx "usage: apt-state restore [-h] FILE"


### PR DESCRIPTION
This entails two things, invoking without any arguments and invoking
with --help or -h. All now work as one would expect. There's also a
test to ensure this works.

Add two trivial type annotations as a drive-by.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>