### PR TITLE
tests: rename user-tool to user-state, fix --help

### DIFF
--- a/tests/lib/tools/README
+++ b/tests/lib/tools/README
@@ -84,9 +84,9 @@ subcommands dealing with system state:
 
 * simple option rename them with a -state suffix in most cases:
 
-user-tool -> test/lib/tools/user-state
-  fix with no args
-  fix -h help
+[done] user-tool -> test/lib/tools/user-state
+  [done] fix with no args
+  [done] fix -h help
 
 [done] apt-tool -> tests/lib/tools/apt-state
   use any-python?

--- a/tests/lib/tools/suite/user-state/task.yaml
+++ b/tests/lib/tools/suite/user-state/task.yaml
@@ -1,0 +1,4 @@
+summary: help test for the user-state tool
+execute: |
+    "$TESTSTOOLS"/user-state --help | grep -qFx 'usage: user-state [-h] {remove-with-group} ...'
+    "$TESTSTOOLS"/user-state remove-with-group --help | grep -qFx 'usage: user-state remove-with-group [-h] user'

--- a/tests/lib/tools/user-state
+++ b/tests/lib/tools/user-state
@@ -43,12 +43,17 @@ def main():
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers()
     cmd = sub.add_parser(
-        "remove-with-group", description="Remove system user and group, if present"
+        "remove-with-group",
+        description="Remove system user and group, if present",
+        help="remove system user and group, if present",
     )
     cmd.set_defaults(func=lambda ns: remove_user_with_group(ns.user))
     cmd.add_argument("user", help="name of the user and group to remove")
     ns = parser.parse_args()
-    ns.func(ns)
+    if hasattr(ns, "func"):
+        ns.func(ns)
+    else:
+        parser.print_help()
 
 
 if __name__ == "__main__":

--- a/tests/main/non-home/task.yaml
+++ b/tests/main/non-home/task.yaml
@@ -13,7 +13,7 @@ prepare: |
     adduser --home "$THOME" "$TUSER"
 
 restore: |
-    user-tool remove-with-group "$TUSER"
+    "$TESTSTOOLS"/user-state remove-with-group "$TUSER"
 
 execute: |
     echo "Install a snap"

--- a/tests/main/system-usernames-install-twice/task.yaml
+++ b/tests/main/system-usernames-install-twice/task.yaml
@@ -14,7 +14,7 @@ restore: |
 
     # snapd will create this for us, but we'll remove it for consistency in
     # test runs
-    user-tool remove-with-group snap_daemon
+    "$TESTSTOOLS"/user-state remove-with-group snap_daemon
 
 execute: |
     echo "When the snap is removed"

--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -5,7 +5,7 @@ summary: ensure seccomp rules for snap_daemon user work correctly
 # -----
 # + snap remove --purge test-snapd-daemon-user
 # test-snapd-daemon-user removed
-# + user-tool remove-with-group snap_daemon
+# + user-state remove-with-group snap_daemon
 # userdel: user 'snap_daemon' does not exist
 # snap_daemon:x:584788:584788::/nonexistent:/usr/bin/false
 # user exists after removal?
@@ -33,7 +33,7 @@ restore: |
 
     # snapd will create this for us, but we'll remove it for consistency in
     # test runs
-    user-tool remove-with-group snap_daemon
+    "$TESTSTOOLS"/user-state remove-with-group snap_daemon
 
 execute: |
     # to accommodate different distros, we pick the LSB required 'daemon' user


### PR DESCRIPTION
In accordance with the tooling naming agreement, user-tool becomes
user-state and is invoked with the full path. It also no longer crashes
when invoked without arguments and responds to -h and --help.

There's also a trivial test to ensure it works enough to print the
help message on all the systems.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
