### PR TITLE
spread.yaml: remove tests/lib/tools from PATH

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -65,7 +65,7 @@ environment:
     TESTSLIB: $PROJECT_PATH/tests/lib
     TESTSTOOLS: $PROJECT_PATH/tests/lib/tools
     SNAPPY_TESTING: 1
-    PATH: $PATH:$PROJECT_PATH/tests/bin:$PROJECT_PATH/tests/lib/tools
+    PATH: $PATH:$PROJECT_PATH/tests/bin
 backends:
     autopkgtest:
         type: adhoc

--- a/spread.yaml
+++ b/spread.yaml
@@ -7,7 +7,7 @@ environment:
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
     # /usr/lib/go-1.6/bin for trusty (needs to be last as we use
     # a different go in gccgo tests)
-    PATH: $GOHOME/bin:/snap/bin:$PATH:/usr/lib/go-1.6/bin:/var/lib/snapd/snap/bin:$PROJECT_PATH/tests/bin:$PROJECT_PATH/tests/lib/tools
+    PATH: $GOHOME/bin:/snap/bin:$PATH:/usr/lib/go-1.6/bin:/var/lib/snapd/snap/bin:$PROJECT_PATH/tests/bin
     TESTSLIB: $PROJECT_PATH/tests/lib
     TESTSTOOLS: $PROJECT_PATH/tests/lib/tools
     SNAPPY_TESTING: 1

--- a/tests/bin/any-python
+++ b/tests/bin/any-python
@@ -1,0 +1,1 @@
+../lib/tools/any-python

--- a/tests/lib/tools/README
+++ b/tests/lib/tools/README
@@ -50,7 +50,7 @@ TODO:
 [done] rename tests/lib/bin to tests/lib/tools, define TESTSTOOLS in
 spread.yaml pointing at it
 
-[wip] create tests/bin, have ultimately this on the PATH and not tools:
+[done] create tests/bin, have ultimately this on the PATH and not tools:
   drop tests/lib/tools from PATH in spread.yaml and debian/tests/integrationtests
 
 symlinks and renames (plus fixes):
@@ -60,7 +60,7 @@ symlinks and renames (plus fixes):
 [done] tests/bin/not -> tests/lib/tools/not
 [done] tests/bin/retry -> tests/lib/tools/retry (was retry-tool)
 
-tests/bin/tests.session -> tests/lib/tools/tests.session (was session-tool)
+[done] tests/bin/tests.session -> tests/lib/tools/tests.session (was session-tool)
   [done] fix to have -h
   [done] convert --ACTION into subcommands
   [done] require "exec" subcommand to execute a command
@@ -71,7 +71,7 @@ tests/bin/tests.session -> tests/lib/tools/tests.session (was session-tool)
 [done] tests/bin/mountinfo.query -> tests/lib/tools/mountinfo.query (was mountinfo-tool)
   (we might not do this and keep just tests/lib/tools/mountinfo and call it the long way)
 
-tests/bin/snapd.tool -> tests/lib/tools/snapd.tool (was snap-tool)
+[done] tests/bin/snapd.tool -> tests/lib/tools/snapd.tool (was snap-tool)
   [done] fix no args
   [done] fix to have -h
   (we might not do this, this would be a special case, the name has


### PR DESCRIPTION
Internal test tools are now separated into two classes, common tools are
symlinked to tests/bin and are on PATH, remaining tools are invoked with
full path.

The README file had some stale TODO entries that were changed earlier,
those are now marked as done.

Lastly any-python is now on PATH, so that scripts can invoke it via #!
mechanism.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>