### PR TITLE
tests: shorten lxd-state undo-mount-changes

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -223,7 +223,7 @@ prepare_project() {
     if [[ "$SPREAD_SYSTEM" == ubuntu-* ]] && [[ "$SPREAD_SYSTEM" != ubuntu-core-* ]]; then
         apt-get remove --purge -y lxd lxcfs || true
         apt-get autoremove --purge -y
-        "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+        "$TESTSTOOLS"/lxd-state undo-mount-changes
     fi
 
     # Check if running inside a container.

--- a/tests/lib/tools/lxd-state
+++ b/tests/lib/tools/lxd-state
@@ -1,9 +1,9 @@
 #!/bin/sh -e
 case "${1:-}" in
     -h|--help|'')
-        echo "usage: lxd-state [-h] {undo-lxd-mount-changes} ..."
+        echo "usage: lxd-state [-h] {undo-mount-changes} ..."
         ;;
-    undo-lxd-mount-changes)
+    undo-mount-changes)
         # Vanilla systems have /sys/fs/cgroup/cpuset without clone_children option.
         # Using LXD to create a container enables this option, as can be seen here:
         #

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -53,4 +53,4 @@ execute: |
 restore: |
     lxc delete --force my-ubuntu
     snap remove ---purge lxd
-    "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+    "$TESTSTOOLS"/lxd-state undo-mount-changes

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -6,7 +6,7 @@ systems: [ubuntu-18.04-64]
 restore: |
     lxc delete --force my-ubuntu
     snap remove ---purge lxd
-    "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
 
 execute: |
     echo "Ensure we use the snap"

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -35,7 +35,7 @@ restore: |
         lxd.lxc delete $cont_name
     done
 
-    "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
 
 debug: |
     # shellcheck source=tests/lib/journalctl.sh

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -56,7 +56,7 @@ restore: |
   # reporting it's still in use.
   retry -n 5 --wait 1 qemu-nbd -d /dev/nbd0
 
-  "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+  "$TESTSTOOLS"/lxd-state undo-mount-changes
 
 execute: |
   echo "Create a trivial container using the lxd snap"

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -27,7 +27,7 @@ restore: |
         umount /proc/sys/fs/binfmt_misc
     fi
 
-    "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
 
     rm -f avc-after
 

--- a/tests/nightly/install-snaps/task.yaml
+++ b/tests/nightly/install-snaps/task.yaml
@@ -89,7 +89,7 @@ restore: |
     fi
 
     if [ "$SNAP" = lxd ]; then
-        "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+        "$TESTSTOOLS"/lxd-state undo-mount-changes
     fi
 
 execute: |

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -57,7 +57,7 @@ restore: |
     lxc delete --force xenial || true
 
     snap remove --purge lxd
-    "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
 
 execute: |
     # Run python0 with a hello.py script and redirect the logs to /var/lib/test/hello.log

--- a/tests/regression/lp-1867193/task.yaml
+++ b/tests/regression/lp-1867193/task.yaml
@@ -21,4 +21,4 @@ restore: |
     lxc stop --force bionic
     lxc delete bionic
     snap remove --purge lxd
-    "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+    "$TESTSTOOLS"/lxd-state undo-mount-changes

--- a/tests/regression/lp-1867752/task.yaml
+++ b/tests/regression/lp-1867752/task.yaml
@@ -21,6 +21,6 @@ restore: |
     lxc stop --force bionic
     lxc delete bionic
     snap remove --purge lxd
-    "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
 debug: |
     lxc exec bionic -- bash -c "SNAPD_DEBUG=1 /usr/lib/snapd/snap-update-ns maas"

--- a/tests/regression/lp-1871652/task.yaml
+++ b/tests/regression/lp-1871652/task.yaml
@@ -60,4 +60,4 @@ restore: |
     lxc exec bionic -- chmod -x /usr/local/bin/systemctl
     lxc stop --force bionic
     snap remove --purge lxd
-    "$TESTSTOOLS"/lxd-state undo-lxd-mount-changes
+    "$TESTSTOOLS"/lxd-state undo-mount-changes


### PR DESCRIPTION
There is no need to repeat the word "LXD" in the sub-command since we
already are talking about lxd-state.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
