### PR TITLE
snap-confine: don't die if a device from sysfs path cannot be found by udev (2.45)

### DIFF
--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -3,7 +3,7 @@ snapd (2.45.1-1) unstable; urgency=medium
   * New upstream release, LP: #1875071
     - data/selinux: allow checking /var/cache/app-info
     - cmd/snap-confine: add support for libc6-lse
-    - interfaces: miscellanious policy updates xlv
+    - interfaces: miscellaneous policy updates xlv
     - snap-bootstrap: remove sealed key file on reinstall
     - interfaces-ssh-keys: Support reading /etc/ssh/ssh_config.d/
     - gadget: make ext4 filesystems with or without metadata checksum

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -911,7 +911,7 @@ fi
 - New upstream release 2.45.1
  - data/selinux: allow checking /var/cache/app-info
  - cmd/snap-confine: add support for libc6-lse
- - interfaces: miscellanious policy updates xlv
+ - interfaces: miscellaneous policy updates xlv
  - snap-bootstrap: remove sealed key file on reinstall
  - interfaces-ssh-keys: Support reading /etc/ssh/ssh_config.d/
  - gadget: make ext4 filesystems with or without metadata checksum

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -3,7 +3,7 @@ snapd (2.45.1~14.04) trusty; urgency=medium
   * New upstream release, LP: #1875071
     - data/selinux: allow checking /var/cache/app-info
     - cmd/snap-confine: add support for libc6-lse
-    - interfaces: miscellanious policy updates xlv
+    - interfaces: miscellaneous policy updates xlv
     - snap-bootstrap: remove sealed key file on reinstall
     - interfaces-ssh-keys: Support reading /etc/ssh/ssh_config.d/
     - gadget: make ext4 filesystems with or without metadata checksum

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -3,7 +3,7 @@ snapd (2.45.1) xenial; urgency=medium
   * New upstream release, LP: #1875071
     - data/selinux: allow checking /var/cache/app-info
     - cmd/snap-confine: add support for libc6-lse
-    - interfaces: miscellanious policy updates xlv
+    - interfaces: miscellaneous policy updates xlv
     - snap-bootstrap: remove sealed key file on reinstall
     - interfaces-ssh-keys: Support reading /etc/ssh/ssh_config.d/
     - gadget: make ext4 filesystems with or without metadata checksum


### PR DESCRIPTION
Cherry-pick of #8939 for 2.45. Fixes LP: #1881209

Also fixes changelog typos that affect 2.45 and fail static checks.
