### PR TITLE
tests: add tests.cleanup helper

### DIFF
--- a/tests/bin/tests.cleanup
+++ b/tests/bin/tests.cleanup
@@ -1,0 +1,1 @@
+../lib/tools/tests.cleanup

--- a/tests/lib/tools/suite/tests.cleanup/task.yaml
+++ b/tests/lib/tools/suite/tests.cleanup/task.yaml
@@ -65,3 +65,10 @@ execute: |
     not tests.cleanup restore
     tests.cleanup restore 2>&1 | MATCH 'tests.cleanup: deferred command "false" failed with exit code 1'
     test -e defer.sh
+
+    # Leftover defer.sh scripts are detected by the invariant checker.
+    # This also detects forgotten tests.cleanup calls.
+    not tests.invariant check leftover-defer-sh
+    tests.invariant check leftover-defer-sh 2>&1 | MATCH "tests.invariant: leftover defer.sh script"
+    rm -f defer.sh
+    tests.invariant check leftover-defer-sh

--- a/tests/lib/tools/suite/tests.cleanup/task.yaml
+++ b/tests/lib/tools/suite/tests.cleanup/task.yaml
@@ -1,0 +1,67 @@
+summary: tests for the tests.cleanup tool
+systems: [ubuntu-16.04-64]
+prepare: |
+    apt-get install -y shellcheck
+restore: |
+    apt-get remove --purge -y shellcheck
+execute: |
+    # The script passes shellcheck.
+    shellcheck "$TESTSTOOLS"/tests.cleanup
+
+    # Without any arguments a help message is printed.
+    tests.cleanup | MATCH "usage: tests.cleanup prepare"
+    tests.cleanup | MATCH "       tests.cleanup defer <cmd> \[args\]"
+    tests.cleanup | MATCH "       tests.cleanup restore"
+
+    # Both -h and --help are also recognized.
+    tests.cleanup --help | MATCH "usage: tests.cleanup"
+    tests.cleanup -h | MATCH "usage: tests.cleanup"
+
+    # Unknown commands and options are reported
+    tests.cleanup --foo 2>&1 | MATCH "tests.cleanup: unknown option --foo"
+    tests.cleanup foo 2>&1 | MATCH "tests.cleanup: unknown command foo"
+
+    # Normal usage consists of a sequence of prepare, defer+, restore
+    # Note that restore runs the deferred commands in the opposite order.
+    tests.cleanup prepare
+    tests.cleanup defer echo one
+    tests.cleanup defer echo two
+    tests.cleanup defer echo three
+    tests.cleanup restore > restore.log
+    diff -u restore.log - <<EXPECTED
+    three
+    two
+    one
+    EXPECTED
+
+    # Preparing twice is detected
+    tests.cleanup prepare
+    not tests.cleanup prepare
+    tests.cleanup prepare 2>&1 | MATCH "tests.cleanup: cannot prepare, already prepared"
+    tests.cleanup restore
+
+    # Restoring twice is detected
+    tests.cleanup prepare
+    tests.cleanup restore
+    not tests.cleanup restore
+    tests.cleanup restore 2>&1 | MATCH "tests.cleanup: cannot restore, must call tests.prepare first"
+
+    # Deferred commands are appended to defer.sh
+    tests.cleanup prepare
+    test -e defer.sh
+    tests.cleanup defer echo a b c
+    tests.cleanup defer echo 1 2 3
+    diff -u defer.sh - <<EXPECTED
+    echo a b c
+    echo 1 2 3
+    EXPECTED
+    tests.cleanup restore
+    test ! -e defer.sh
+
+    # Deferred commands can fail their exit code is retained and the defer
+    # stack is not purged.
+    tests.cleanup prepare
+    tests.cleanup defer false
+    not tests.cleanup restore
+    tests.cleanup restore 2>&1 | MATCH 'tests.cleanup: deferred command "false" failed with exit code 1'
+    test -e defer.sh

--- a/tests/lib/tools/suite/tests.invariant/task.yaml
+++ b/tests/lib/tools/suite/tests.invariant/task.yaml
@@ -1,12 +1,8 @@
 summary: tests.invariant is detecting problems
 prepare: |
-    truncate --size=0 defer.sh
-    chmod +x defer.sh
+    tests.cleanup prepare
 restore: |
-    # Restore system to the previous state by running deferred commands in
-    # reverse order.
-    tac defer.sh > refed.sh
-    sh -xe refed.sh && rm -f {defer,refed}.sh
+    tests.cleanup restore
 execute: |
     # Invariant tool presents the usage screen when invoked without arguments
     # or with the -h or --help options.
@@ -26,7 +22,7 @@ execute: |
     # The root-files-in-home invariant detects files owned by root anywhere in /home/
     tests.invariant check root-files-in-home | MATCH 'tests.invariant: root-files-in-home ok'
     touch /home/test/invariant-canary
-    echo 'rm -f /home/test/invariant-canary' >> defer.sh
+    tests.cleanup defer rm -f /home/test/invariant-canary
     chown root /home/test/invariant-canary
     tests.invariant check root-files-in-home 2>&1 | MATCH 'tests.invariant: root-files-in-home not-ok'
     tests.invariant check root-files-in-home 2>&1 | MATCH 'tests.invariant: the following files should not be owned by root'
@@ -47,10 +43,10 @@ execute: |
     if [ -d /home/ubuntu ]; then
         old_uid="$(stat -c %u /home/ubuntu)"
         chown root /home/ubuntu
-        echo "chown $old_uid /home/ubuntu" >> defer.sh
+        tests.cleanup defer chown "$old_uid" /home/ubuntu
     else
         mkdir -p /home/ubuntu
-        echo 'rmdir /home/ubuntu' >> defer.sh
+        tests.cleanup defer rmdir /home/ubuntu
         chown root /home/ubuntu
     fi
     tests.invariant check root-files-in-home | MATCH 'tests.invariant: root-files-in-home ok'

--- a/tests/lib/tools/tests.cleanup
+++ b/tests/lib/tools/tests.cleanup
@@ -1,0 +1,79 @@
+#!/bin/sh -e
+
+show_help() {
+    echo "usage: tests.cleanup prepare"
+    echo "       tests.cleanup defer <cmd> [args]"
+    echo "       tests.cleanup restore"
+}
+
+cmd_prepare() {
+    if [ -e defer.sh ]; then
+        echo "tests.cleanup: cannot prepare, already prepared" >&2
+        exit 1
+    fi
+    truncate --size=0 defer.sh
+    chmod +x defer.sh
+}
+
+cmd_defer() {
+    if [ ! -e defer.sh ]; then
+        echo "tests.cleanup: cannot defer, must call tests.prepare first" >&2
+        exit 1
+    fi
+    echo "$*" >> defer.sh
+}
+
+cmd_restore() {
+    if [ ! -e defer.sh ]; then
+        echo "tests.cleanup: cannot restore, must call tests.prepare first" >&2
+        exit 1
+    fi
+    tac defer.sh | while read -r CMD; do
+        set +e
+        sh -ec "$CMD"
+        RET=$?
+        set -e
+        if [ $RET -ne 0 ]; then
+            echo "tests.cleanup: deferred command \"$CMD\" failed with exit code $RET"
+            exit $RET
+        fi
+    done
+    rm -f defer.sh
+}
+
+if [ $# -eq 0 ]; then
+    show_help
+    exit
+fi
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            show_help
+            exit
+            ;;
+        prepare)
+            shift
+            cmd_prepare
+            exit
+            ;;
+        defer)
+            shift
+            cmd_defer "$@"
+            exit
+            ;;
+        restore)
+            shift
+            cmd_restore
+            exit
+            ;;
+        -*)
+            echo "tests.cleanup: unknown option $1" >&2
+            exit 1
+            ;;
+        *)
+            echo "tests.cleanup: unknown command $1" >&2
+            exit 1
+            ;;
+    esac
+done

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -8,7 +8,7 @@ show_help() {
 	echo "    crashed-snap-confine: /tmp/snap.rootfs_* does not exist"
 	echo "    lxcfs-mounted: /var/lib/lxcfs is a mount point"
 	echo "    stray-dbus-daemon: at most one dbus-daemon is running"
-
+	echo "    leftover-defer-sh: defer.sh must not be left over by tests"
 }
 
 if [ $# -eq 0 ]; then
@@ -104,6 +104,18 @@ check_stray_dbus_daemon() {
 	fi
 }
 
+check_leftover_defer_sh() {
+	n="$1" # invariant name
+	(
+		find "$PROJECT_PATH" -name defer.sh > "/tmp/tests.invariant.$n"
+	) > "/tmp/tests.invariant.$n"
+	if [ -s "/tmp/tests.invariant.$n" ]; then
+		echo "tests.invariant: leftover defer.sh script" >&2
+		cat "/tmp/tests.invariant.$n" >&2
+		return 1
+	fi
+}
+
 check_invariant() {
 	case "$1" in
 		root-files-in-home)
@@ -118,6 +130,9 @@ check_invariant() {
 		stray-dbus-daemon)
 			check_stray_dbus_daemon "$1"
 			;;
+		leftover-defer-sh)
+			check_leftover_defer_sh "$1"
+			;;
 		*)
 			echo "tests.invariant: unknown invariant $1" >&2
 			exit 1
@@ -125,7 +140,7 @@ check_invariant() {
 	esac
 }
 
-ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted stray-dbus-daemon"
+ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted stray-dbus-daemon leftover-defer-sh"
 
 case "$action" in
 	check)

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -10,8 +10,7 @@ environment:
     EXFAIL: "ubuntu-14"
 
 prepare: |
-    truncate --size=0 defer.sh
-    chmod +x defer.sh
+    tests.cleanup prepare
 
     # Install pulseaudio.
     apt-get update
@@ -19,22 +18,22 @@ prepare: |
     # Remove the package and reload systemd later, when we are restoring. This
     # is important because of rtkit-daemon.service that gets pulled by
     # pulseaudio and that is subsequently removed.
-    echo "systemctl daemon-reload" >>defer.sh
-    echo "apt-get autoremove --purge -y pulseaudio pulseaudio-utils" >>defer.sh
+    tests.cleanup defer systemctl daemon-reload
+    tests.cleanup defer apt-get autoremove --purge -y pulseaudio pulseaudio-utils
 
     # Make sure the socket and the server is available in the user session.
     if [ "$(systemctl --user --global is-enabled pulseaudio.socket)" != enabled ]; then
         systemctl --user --global enable pulseaudio.socket
-        echo "systemctl --user --global disable pulseaudio.socket" >>defer.sh
+        tests.cleanup defer systemctl --user --global disable pulseaudio.socket
     fi
     if [ "$(systemctl --user --global is-enabled pulseaudio.service)" != enabled ]; then
         systemctl --user --global enable pulseaudio.service
-        echo "systemctl --user --global disable pulseaudio.service" >>defer.sh
+        tests.cleanup defer systemctl --user --global disable pulseaudio.service
     fi
 
     # Install a snap that uses the audio-playback/audio-record interfaces.
     snap install --edge test-snapd-audio-record
-    echo "snap remove --purge test-snapd-audio-record" >>defer.sh
+    tests.cleanup defer snap remove --purge test-snapd-audio-record
 
     # TODO: move this to the test that is responsible for creating this data.
     # Remove potentially large go build cache that makes the debug section more
@@ -47,7 +46,7 @@ prepare: |
 
     # Prepare a session for the user.
     tests.session -u test prepare
-    echo "tests.session -u test restore" >>defer.sh
+    tests.cleanup defer tests.session -u test restore
 
     # Ensure that the socket is active but do not check the service. In user
     # mode pulseaudio is documented to quit when there are no active logind
@@ -70,7 +69,7 @@ prepare: |
 
     # Ensure, that the cookie file is present.
     test -e ~test/.config/pulse/cookie || test -e ~test/.config/pulse/.pulse-cookie
-    echo "rm -rf ~test/.config/pulse" >>defer.sh
+    tests.cleanup defer rm -rf ~test/.config/pulse
 
 debug: |
     echo "Files present in the test user's home directory"
@@ -83,10 +82,7 @@ debug: |
     ps -u test
 
 restore: |
-    # Restore system to the previous state by running deferred commands in
-    # reverse order.
-    tac defer.sh > refed.sh
-    sh -xe refed.sh && rm -f {defer,refed}.sh
+    tests.cleanup restore
 
 execute: |
     echo "The unconfined user can play audio"

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -8,8 +8,7 @@ environment:
     PLAY_FILE: "/snap/test-snapd-pulseaudio/current/usr/share/sounds/alsa/Noise.wav"
 
 prepare: |
-    truncate --size=0 defer.sh
-    chmod +x defer.sh
+    tests.cleanup prepare
 
     # Install pulseaudio.
     apt-get update
@@ -17,22 +16,22 @@ prepare: |
     # Remove the package and reload systemd later, when we are restoring. This
     # is important because of rtkit-daemon.service that gets pulled by
     # pulseaudio and that is subsequently removed.
-    echo "systemctl daemon-reload" >>defer.sh
-    echo "apt-get autoremove --purge -y pulseaudio pulseaudio-utils" >>defer.sh
+    tests.cleanup defer systemctl daemon-reload
+    tests.cleanup defer apt-get autoremove --purge -y pulseaudio pulseaudio-utils
 
     # Make sure the socket and the server is available in the user session.
     if [ "$(systemctl --user --global is-enabled pulseaudio.socket)" != enabled ]; then
         systemctl --user --global enable pulseaudio.socket
-        echo "systemctl --user --global disable pulseaudio.socket" >>defer.sh
+        tests.cleanup defer systemctl --user --global disable pulseaudio.socket
     fi
     if [ "$(systemctl --user --global is-enabled pulseaudio.service)" != enabled ]; then
         systemctl --user --global enable pulseaudio.service
-        echo "systemctl --user --global disable pulseaudio.service" >>defer.sh
+        tests.cleanup defer systemctl --user --global disable pulseaudio.service
     fi
 
     # Install a snap that uses the pulseaudio interface.
     snap install --edge test-snapd-pulseaudio
-    echo "snap remove --purge test-snapd-pulseaudio" >>defer.sh
+    tests.cleanup defer snap remove --purge test-snapd-pulseaudio
 
     # TODO: move this to the test that is responsible for creating this data.
     # Remove potentially large go build cache that makes the debug section more
@@ -45,7 +44,7 @@ prepare: |
 
     # Prepare a session for the user.
     tests.session -u test prepare
-    echo "tests.session -u test restore" >>defer.sh
+    tests.cleanup defer tests.session -u test restore
 
     # Ensure that the socket is active but do not check the service. In user
     # mode pulseaudio is documented to quit when there are no active logind
@@ -68,7 +67,7 @@ prepare: |
 
     # Ensure, that the cookie file is present.
     test -e ~test/.config/pulse/cookie || test -e ~test/.config/pulse/.pulse-cookie
-    echo "rm -rf ~test/.config/pulse" >>defer.sh
+    tests.cleanup defer rm -rf ~test/.config/pulse
 
 debug: |
     echo "Files present in the test user's home directory"
@@ -81,10 +80,7 @@ debug: |
     ps -u test
 
 restore: |
-    # Restore system to the previous state by running deferred commands in
-    # reverse order.
-    tac defer.sh > refed.sh
-    sh -xe refed.sh && rm -f {defer,refed}.sh
+    tests.cleanup restore
 
 execute: |
     echo "The unconfined user can play audio"

--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -5,15 +5,14 @@ details: |
     can access timeserver information and update it.
 
 prepare: |
-    truncate --size=0 defer.sh
-    chmod +x defer.sh
+    tests.cleanup prepare
 
     # This test requires busctl but on 14.04 we don't have one.
     # Let's pick the one from the core snap in such case.
     if [ -z "$(command -v busctl 2>/dev/null)" ]; then
         ln -s /snap/core/current/usr/bin/busctl /usr/local/bin/busctl
         hash -r
-        echo "rm -f /usr/local/bin/busctl" >> defer.sh
+        tests.cleanup defer rm -f /usr/local/bin/busctl
     fi
 
     # Technically the interface may be implemented by many things but in
@@ -24,19 +23,19 @@ prepare: |
     case "$SPREAD_SYSTEM" in
         debian-sid-*)
             apt-get remove -y ntp
-            echo 'apt-get install -y ntp' >> defer.sh
+            tests.cleanup defer apt-get install -y ntp
             ;;
         ubuntu-19.10-*)
             apt-get remove -y chrony
-            echo 'apt-get install -y chrony' >> defer.sh
+            tests.cleanup defer apt-get install -y chrony
             ;;
         *)
             case "$(busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP)" in
                 "b true")
-                    echo "busctl call org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 SetNTP bb true false" >> defer.sh
+                    tests.cleanup defer busctl call org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 SetNTP bb true false
                     ;;
                 "b false")
-                    echo "busctl call org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 SetNTP bb false false" >> defer.sh
+                    tests.cleanup defer busctl call org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 SetNTP bb false false
                     ;;
                 *)
                     echo "Unexpected value of NTP property"
@@ -50,13 +49,10 @@ prepare: |
     # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-timedate-control-consumer
-    echo "snap remove --purge test-snapd-timedate-control-consumer" >> defer.sh
+    tests.cleanup defer snap remove --purge test-snapd-timedate-control-consumer
 
 restore: |
-    # Restore system to the previous state by running deferred commands in
-    # reverse order.
-    tac defer.sh > refed.sh
-    sh -xe refed.sh && rm -f {defer,refed}.sh
+    tests.cleanup restore
 
 execute: |
     # If we cannot use network time protocol then the test is meaningless.


### PR DESCRIPTION
Several of our tests used a trick where a "defer.sh" script was appended
to, collecting more and more commands to execute. The restore section
then used tac(1) to reverse file order and execute the result,
implementing a simple cleanup stack in shell.

This patch takes that idea and polishes the rough edges. The new
tests.cleanup tool comes with basic but sufficient functionality, tests
and documentation to complete the same task.

Using this pattern can simplify restore logic as the conditions that
lead to prepare or execute customizing something do not have to be
repeated.

The branch contains distinct commits for individual ported tests.
In addition tests.invariant detects left-over defer information
indicating forgotten call to tests.cleanup restore.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
