### PR TITLE
snap/validate.go: disallow snap layouts with new top-level directories

### DIFF
--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -143,10 +143,10 @@ version: 0
 layout:
   /usr:
     bind: $SNAP/usr
-  /mytmp:
+  /lib/mytmp:
     type: tmpfs
     mode: 1777
-  /mylink:
+  /lib/mylink:
     symlink: $SNAP/link/target
   /etc/foo.conf:
     bind-file: $SNAP/foo.conf
@@ -158,8 +158,8 @@ func (s *specSuite) TestMountEntryFromLayout(c *C) {
 	c.Assert(s.spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// Layout result is sorted by mount path.
 		{Dir: "/etc/foo.conf", Name: "/snap/vanguard/42/foo.conf", Options: []string{"bind", "rw", "x-snapd.kind=file", "x-snapd.origin=layout"}},
-		{Dir: "/mylink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/vanguard/42/link/target", "x-snapd.origin=layout"}},
-		{Dir: "/mytmp", Name: "tmpfs", Type: "tmpfs", Options: []string{"x-snapd.mode=01777", "x-snapd.origin=layout"}},
+		{Dir: "/lib/mylink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/vanguard/42/link/target", "x-snapd.origin=layout"}},
+		{Dir: "/lib/mytmp", Name: "tmpfs", Type: "tmpfs", Options: []string{"x-snapd.mode=01777", "x-snapd.origin=layout"}},
 		{Dir: "/usr", Name: "/snap/vanguard/42/usr", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
 	})
 }
@@ -175,34 +175,34 @@ func (s *specSuite) TestParallelInstanceMountEntryFromLayout(c *C) {
 		{Dir: "/var/snap/vanguard", Name: "/var/snap/vanguard_instance", Options: []string{"rbind", "x-snapd.origin=overname"}},
 		// Layout result is sorted by mount path.
 		{Dir: "/etc/foo.conf", Name: "/snap/vanguard/42/foo.conf", Options: []string{"bind", "rw", "x-snapd.kind=file", "x-snapd.origin=layout"}},
-		{Dir: "/mylink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/vanguard/42/link/target", "x-snapd.origin=layout"}},
-		{Dir: "/mytmp", Name: "tmpfs", Type: "tmpfs", Options: []string{"x-snapd.mode=01777", "x-snapd.origin=layout"}},
+		{Dir: "/lib/mylink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/vanguard/42/link/target", "x-snapd.origin=layout"}},
+		{Dir: "/lib/mytmp", Name: "tmpfs", Type: "tmpfs", Options: []string{"x-snapd.mode=01777", "x-snapd.origin=layout"}},
 		{Dir: "/usr", Name: "/snap/vanguard/42/usr", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
 	})
 }
 
 func (s *specSuite) TestSpecificationUberclash(c *C) {
-	// When everything clashes for access to /foo, what happens?
+	// When everything clashes for access to /usr/foo, what happens?
 	const uberclashYaml = `name: uberclash
 version: 0
 layout:
-  /foo:
+  /usr/foo:
     type: tmpfs
 `
 	snapInfo := snaptest.MockInfo(c, uberclashYaml, &snap.SideInfo{Revision: snap.R(42)})
-	entry := osutil.MountEntry{Dir: "/foo", Type: "tmpfs", Name: "tmpfs"}
+	entry := osutil.MountEntry{Dir: "/usr/foo", Type: "tmpfs", Name: "tmpfs"}
 	s.spec.AddMountEntry(entry)
 	s.spec.AddUserMountEntry(entry)
 	s.spec.AddLayout(snapInfo)
 	c.Assert(s.spec.MountEntries(), DeepEquals, []osutil.MountEntry{
-		{Dir: "/foo", Type: "tmpfs", Name: "tmpfs", Options: []string{"x-snapd.origin=layout"}},
+		{Dir: "/usr/foo", Type: "tmpfs", Name: "tmpfs", Options: []string{"x-snapd.origin=layout"}},
 		// This is the non-layout entry, it was renamed to "foo-2"
-		{Dir: "/foo-2", Type: "tmpfs", Name: "tmpfs"},
+		{Dir: "/usr/foo-2", Type: "tmpfs", Name: "tmpfs"},
 	})
 	c.Assert(s.spec.UserMountEntries(), DeepEquals, []osutil.MountEntry{
 		// This is the user entry, it was _not_ renamed and it would clash with
 		// /foo but there is no way to request things like that for now.
-		{Dir: "/foo", Type: "tmpfs", Name: "tmpfs"},
+		{Dir: "/usr/foo", Type: "tmpfs", Name: "tmpfs"},
 	})
 }
 

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -401,8 +401,8 @@ func ValidateLayoutAll(info *Info) error {
 	sort.Strings(paths)
 
 	// Validate that each source path is not a new top-level directory
-	for pathSrc := range info.Layout {
-		cleanPathSrc := info.ExpandSnapVariables(filepath.Clean(pathSrc))
+	for _, layout := range info.Layout {
+		cleanPathSrc := info.ExpandSnapVariables(filepath.Clean(layout.Path))
 		elems := strings.SplitN(cleanPathSrc, string(os.PathSeparator), 3)
 		switch len(elems) {
 		// len(1) is either relative path or empty string, will be validated
@@ -413,7 +413,7 @@ func ValidateLayoutAll(info *Info) error {
 			if elems[0] != "" {
 				// not the empty string which means this was a relative
 				// specification, i.e. usr/src/doc
-				return fmt.Errorf("layout %q is a relative filename", pathSrc)
+				return fmt.Errorf("layout %q is a relative filename", layout.Path)
 			}
 			if elems[1] != "" {
 				// verify that the top-level directory is a supported one
@@ -426,7 +426,7 @@ func ValidateLayoutAll(info *Info) error {
 				// denied top-level directories
 				case "bin", "etc", "lib", "lib64", "meta", "mnt", "opt", "root", "sbin", "snap", "srv", "usr", "var", "writable":
 				default:
-					return fmt.Errorf("layout %q defines a new top-level directory %q", pathSrc, "/"+elems[1])
+					return fmt.Errorf("layout %q defines a new top-level directory %q", layout.Path, "/"+elems[1])
 				}
 			}
 		}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -400,6 +400,38 @@ func ValidateLayoutAll(info *Info) error {
 	}
 	sort.Strings(paths)
 
+	// Validate that each source path is not a new top-level directory
+	for pathSrc := range info.Layout {
+		cleanPathSrc := info.ExpandSnapVariables(filepath.Clean(pathSrc))
+		elems := strings.SplitN(cleanPathSrc, string(os.PathSeparator), 3)
+		switch len(elems) {
+		// len(1) is either relative path or empty string, will be validated
+		// elsewhere
+		case 2, 3:
+			// if the first string is the empty string, then we have a top-level
+			// directory to check
+			if elems[0] != "" {
+				// not the empty string which means this was a relative
+				// specification, i.e. usr/src/doc
+				return fmt.Errorf("layout %q is a relative filename", pathSrc)
+			}
+			if elems[1] != "" {
+				// verify that the top-level directory is a supported one
+				// we can't create new top-level directories because that would
+				// require creating a mimic on top of "/" which we don't
+				// currently support
+				switch elems[1] {
+				// this list was produced by taking all of the top level
+				// directories in the core snap and removing the explicitly
+				// denied top-level directories
+				case "bin", "etc", "lib", "lib64", "meta", "mnt", "opt", "root", "sbin", "snap", "srv", "usr", "var", "writable":
+				default:
+					return fmt.Errorf("layout %q defines a new top-level directory %q", pathSrc, "/"+elems[1])
+				}
+			}
+		}
+	}
+
 	// Validate that each source path is used consistently as a file or as a directory.
 	sourceKindMap := make(map[string]string)
 	for _, path := range paths {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1210,7 +1210,7 @@ layout:
 	err = ValidateLayoutAll(info)
 	c.Assert(err, IsNil)
 
-	// Layout replacing files in another snap's mount p oit
+	// Layout replacing files in another snap's mount point
 	const yaml12 = `
 name: this-snap
 layout:

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1224,6 +1224,47 @@ layout:
 	c.Assert(info.Layout, HasLen, 1)
 	err = ValidateLayoutAll(info)
 	c.Assert(err, ErrorMatches, `layout "/snap/that-snap/current/stuff" defines a layout in space belonging to another snap`)
+
+	const yaml13 = `
+name: this-snap
+layout:
+  $SNAP/relative:
+    symlink: $SNAP/existent-dir
+`
+
+	// Layout using $SNAP/... as source
+	strk = NewScopedTracker()
+	info, err = InfoFromSnapYamlWithSideInfo([]byte(yaml13), &SideInfo{Revision: R(42)}, strk)
+	c.Assert(err, IsNil)
+	c.Assert(info.Layout, HasLen, 1)
+	err = ValidateLayoutAll(info)
+	c.Assert(err, IsNil)
+
+	var yaml14Pattern = `
+name: this-snap
+layout:
+  %s:
+    symlink: $SNAP/existent-dir
+`
+
+	for _, testCase := range []struct {
+		str         string
+		topLevelDir string
+	}{
+		{"/nonexistent-dir", "/nonexistent-dir"},
+		{"/nonexistent-dir/subdir", "/nonexistent-dir"},
+		{"///////unclean-absolute-dir", "/unclean-absolute-dir"},
+	} {
+		// Layout adding a new top-level directory
+		strk = NewScopedTracker()
+		yaml14 := fmt.Sprintf(yaml14Pattern, testCase.str)
+		info, err = InfoFromSnapYamlWithSideInfo([]byte(yaml14), &SideInfo{Revision: R(42)}, strk)
+		c.Assert(err, IsNil)
+		c.Assert(info.Layout, HasLen, 1)
+		err = ValidateLayoutAll(info)
+		c.Assert(err, ErrorMatches, fmt.Sprintf(`layout %q defines a new top-level directory %q`, testCase.str, testCase.topLevelDir))
+	}
+
 }
 
 func (s *YamlSuite) TestValidateAppStartupOrder(c *C) {


### PR DESCRIPTION
We previously wouldn't fail on verification for snaps that used new top-level directories, and would fail at runtime, which produces a very unhelpful message.

Also adjust some test yamls in interfaces/mount tests, which are not valid as they are for new top-level directories in /.

Finally, add an additional unit test for the test case with LP #1831010 that is already covered by spread tests, but not yet by unit tests.

See https://forum.snapcraft.io/t/snap-application-works-in-classic-mode-fails-in-dev-mode-and-strict/18562/7 for an example of such a confusion.