### PR TITLE
many: use more specific check for unit test mocking

### DIFF
--- a/bootloader/assets/assets.go
+++ b/bootloader/assets/assets.go
@@ -22,7 +22,7 @@ package assets
 import (
 	"fmt"
 	"os"
-	"strings"
+	"regexp"
 )
 
 var registeredAssets = map[string][]byte{}
@@ -43,7 +43,8 @@ func Internal(name string) []byte {
 
 // MockInternal mocks the contents of an internal asset for use in testing.
 func MockInternal(name string, data []byte) (restore func()) {
-	var isSnapdTest = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test")
+	var goTestExeRe = regexp.MustCompile(`^.*/.*go-build.*/.*\.test$`)
+	var isSnapdTest = len(os.Args) > 0 && goTestExeRe.MatchString(os.Args[0])
 	if !isSnapdTest {
 		panic("mocking can be done only in tests")
 	}

--- a/bootloader/efi/efi.go
+++ b/bootloader/efi/efi.go
@@ -29,7 +29,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 	"unicode/utf16"
 
 	"github.com/snapcore/snapd/dirs"
@@ -48,8 +48,10 @@ const (
 )
 
 var (
-	isSnapdTest = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test")
-	openEFIVar  = openEFIVarImpl
+	goTestExeRe = regexp.MustCompile(`^.*/.*go-build.*/.*\.test$`)
+	isSnapdTest = len(os.Args) > 0 && goTestExeRe.MatchString(os.Args[0])
+
+	openEFIVar = openEFIVarImpl
 )
 
 const expectedEFIvarfsDir = "/sys/firmware/efi/efivars"

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 	"syscall"
 
 	"github.com/snapcore/snapd/osutil/sys"
@@ -43,7 +43,8 @@ const (
 // Allow disabling sync for testing. This brings massive improvements on
 // certain filesystems (like btrfs) and very much noticeable improvements in
 // all unit tests in genreal.
-var snapdUnsafeIO bool = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test") && GetenvBool("SNAPD_UNSAFE_IO", true)
+var goTestExeRe = regexp.MustCompile(`^.*/.*go-build.*/.*\.test$`)
+var snapdUnsafeIO bool = len(os.Args) > 0 && goTestExeRe.MatchString(os.Args[0]) && GetenvBool("SNAPD_UNSAFE_IO", true)
 
 // An AtomicFile is similar to an os.File but it has an additional
 // Commit() method that does whatever needs to be done so the

--- a/osutil/mountinfo_linux.go
+++ b/osutil/mountinfo_linux.go
@@ -48,7 +48,7 @@ type MountInfoEntry struct {
 	SuperOptions   map[string]string
 }
 
-var isSnapdTest = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test")
+var isSnapdTest = len(os.Args) > 0 && goTestExeRe.MatchString(os.Args[0])
 
 func flattenMap(m map[string]string) string {
 	keys := make([]string, 0, len(m))

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -22,7 +22,7 @@ package progress
 import (
 	"fmt"
 	"os"
-	"strings"
+	"regexp"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -82,7 +82,8 @@ func MockMeter(meter Meter) func() {
 	}
 }
 
-var inTesting bool = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test") || os.Getenv("SPREAD_SYSTEM") != ""
+var goTestExeRe = regexp.MustCompile(`^.*/.*go-build.*/.*\.test$`)
+var inTesting bool = (len(os.Args) > 0 && goTestExeRe.MatchString(os.Args[0])) || os.Getenv("SPREAD_SYSTEM") != ""
 
 // MakeProgressBar creates an appropriate progress.Meter for the environ in
 // which it is called:

--- a/tests/regression/lp-1886786/task.yaml
+++ b/tests/regression/lp-1886786/task.yaml
@@ -1,0 +1,10 @@
+summary: regression test for LP:#1886786
+
+prepare: |
+  #shellcheck source=tests/lib/snaps.sh
+  . "$TESTSLIB"/snaps.sh
+  install_local test-snapd-app-with-test-name
+
+execute: |
+  echo "running the command with .test suffix does not panic"
+  test-snapd-app-with-test-name.test

--- a/tests/regression/lp-1886786/test-snapd-app-with-test-name/meta/snap.yaml
+++ b/tests/regression/lp-1886786/test-snapd-app-with-test-name/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: test-snapd-app-with-test-name
+version: "0.1"
+summary: regression test snap for LP 1886786
+description: regression test snap for LP 1886786
+apps:
+  test:
+    command: test.sh
+base: core18
+confinement: strict
+grade: stable

--- a/tests/regression/lp-1886786/test-snapd-app-with-test-name/test.sh
+++ b/tests/regression/lp-1886786/test-snapd-app-with-test-name/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo test


### PR DESCRIPTION
Currently, if you try to use a snap with an app named "test", os.Args will also end in ".test", making numerous places in the codebase think that it is being run in a test environment and behave differently. In the case of the reported bug, the code panics from `snap run` as it seems to the mountinfo code that we are not mocking something that we should always be mocking in unit tests.

The bug could still hypothetically happen if someone made a symlink from somewhere with "go-build" in the path (but not as part of the app name in the snap) and a .test suffix on the executable, but this is sufficiently specific that it is highly unlikely we would ever actually run into that problem "in the wild".

Fixes: https://bugs.launchpad.net/snapd/+bug/1886786

Also add a regression test for this scenario.