### PR TITLE
osutil/systemd: add new pkg and systemd.EscapePath

### DIFF
--- a/osutil/systemd/escape.go
+++ b/osutil/systemd/escape.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package systemd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const asciiAlphanumerics = `abcdefghijklmnopqrstuvwxyz0123456789`
+
+// EscapePath follows the same logic as systemd-escape(1) when called
+// with --path. This is implemented without calling systemd-escape and as such
+// is suitable for use in the initramfs where systemd-escape is not available.
+// See "STRING ESCAPING FOR INCLUSION IN UNIT NAMES" in systemd.unit(5) for a
+// detailed explanation of the algorithm followed.
+func EscapePath(str string) string {
+	if len(str) == 0 {
+		return ""
+	}
+
+	clean := filepath.Clean(str)
+	// easy case first, "/" becomes "-"
+	if clean == "/" {
+		return "-"
+	}
+
+	// if we have a leading "/" it is dropped
+	if strings.HasPrefix(clean, "/") {
+		clean = clean[1:]
+	}
+
+	var builder strings.Builder
+	for _, b := range []byte(clean) {
+		// this is not the best handling of UTF-8 characters, but this is what
+		// systemd does and is reversible back to the same bag of bytes, so meh
+		r := rune(b)
+		switch {
+		case r == '/':
+			builder.WriteRune('-')
+		case r == '_':
+			builder.WriteRune('_')
+		case strings.ContainsRune(asciiAlphanumerics, r):
+			builder.WriteRune(r)
+		default:
+			// escape the byte value of the byte C-style with a \x
+			// the slice of bytes is needed to make go pad bytes less than 16
+			// display with a prefixed 0 the same way that systemd-escape(1)
+			// does
+			builder.WriteString(fmt.Sprintf(`\x%2x`, []byte{b}))
+		}
+	}
+
+	return builder.String()
+}

--- a/osutil/systemd/escape_test.go
+++ b/osutil/systemd/escape_test.go
@@ -1,0 +1,122 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package systemd_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil/systemd"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type escapeSuite struct{}
+
+var _ = Suite(&escapeSuite{})
+
+func (ts *escapeSuite) TestEscapePath(c *C) {
+	tt := []struct {
+		in      string
+		out     string
+		comment string
+	}{
+		{
+			``,
+			``,
+			`empty string`,
+		},
+		{
+			`/`,
+			`-`,
+			`root /`,
+		},
+		{
+			`-`,
+			`\x2d`,
+			`just dash`,
+		},
+		{
+			`/path-with-forward-slash\`,
+			`path\x2dwith\x2dforward\x2dslash\x5c`,
+			`forward slash in path element`,
+		},
+		{
+			`/run/1000/numbers`,
+			`run-1000-numbers`,
+			`numbers`,
+		},
+		{
+			`/silly/path/,!@#$%^&*()`,
+			`silly-path-\x2c\x21\x40\x23\x24\x25\x5e\x26\x2a\x28\x29`,
+			`ascii punctuation`,
+		},
+		{
+			`/run/mnt/data`,
+			`run-mnt-data`,
+			`typical data initramfs mount`,
+		},
+		{
+			`run/mnt/data`,
+			`run-mnt-data`,
+			`typical data initramfs mount w/o leading slash`,
+		},
+		{
+			`/run/mnt/ubuntu-seed`,
+			`run-mnt-ubuntu\x2dseed`,
+			`typical ubuntu-seed initramfs mount`,
+		},
+		{
+			`/run/mnt/ubuntu data`,
+			`run-mnt-ubuntu\x20data`,
+			`path with space in it`,
+		},
+		{
+			`/run/mnt/ubuntu_data`,
+			`run-mnt-ubuntu_data`,
+			`path with underscore in it`,
+		},
+		{
+			` `,
+			`\x20`,
+			"space character",
+		},
+		{
+			`	`,
+			`\x09`,
+			`tab character`,
+		},
+		{
+			`/home/日本語`,
+			`home-\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e`,
+			`utf-8 characters`,
+		},
+		{
+			`/path⌘place-of-interest/hello`,
+			`path\xe2\x8c\x98place\x2dof\x2dinterest-hello`,
+			`utf-8 character embedded in ascii path element`,
+		},
+	}
+
+	for _, t := range tt {
+		c.Assert(systemd.EscapePath(t.in), Equals, t.out, Commentf(t.comment+" (with input %s)", t.in))
+	}
+}


### PR DESCRIPTION
This function will be needed in the initramfs where we don't have systemd-escape(1) to know the systemd mount unit names for mount paths we will dynamically create.

This is the first of a series of PR's which will move more responsibility for mounting things in the initramfs from "the-tool" in the ubuntu-core-initramfs debian package to `snap-bootstrap initramfs-mounts` itself.