### PR TITLE
systemd/escape: fix issues with "" and "\t" handling

### DIFF
--- a/systemd/escape.go
+++ b/systemd/escape.go
@@ -34,6 +34,11 @@ const allowed = `:_.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567
 //
 //        But thats not in the archive and it won't work with go1.3
 func EscapeUnitNamePath(in string) string {
+	// "" is the same as "/" which corresponds to ""
+	// the filepath.Clean will turn "" into "." and make this incorrect
+	if len(in) == 0 {
+		return "-"
+	}
 	buf := bytes.NewBuffer(nil)
 
 	// clean and trim leading/trailing "/"
@@ -58,7 +63,7 @@ func EscapeUnitNamePath(in string) string {
 		} else if strings.IndexByte(allowed, c) >= 0 {
 			buf.WriteByte(c)
 		} else {
-			fmt.Fprintf(buf, `\x%x`, in[i])
+			fmt.Fprintf(buf, `\x%x`, []byte{in[i]})
 		}
 	}
 

--- a/systemd/escape.go
+++ b/systemd/escape.go
@@ -34,7 +34,7 @@ const allowed = `:_.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567
 //
 //        But thats not in the archive and it won't work with go1.3
 func EscapeUnitNamePath(in string) string {
-	// "" is the same as "/" which corresponds to ""
+	// "" is the same as "/" which is escaped to "-"
 	// the filepath.Clean will turn "" into "." and make this incorrect
 	if len(in) == 0 {
 		return "-"

--- a/systemd/escape_test.go
+++ b/systemd/escape_test.go
@@ -52,6 +52,16 @@ func (ts *SystemdTestSuite) TestEscapePath(c *C) {
 			`leading dot escaped differently (without leading slash)`,
 		},
 		{
+			// TODO: this case shouldn't work it should cause an error to be
+			// fully compatible with systemd-escape(1), but it's not documented
+			// how or why systemd-escape considers this kind of path to be
+			// invalid, so for now we just process it in an expected and
+			// deterministic way
+			`/top_level_1/../top_level_2/`,
+			`top_level_2`,
+			`invalid path`,
+		},
+		{
 			``,
 			`-`,
 			`empty string`,

--- a/systemd/escape_test.go
+++ b/systemd/escape_test.go
@@ -22,16 +22,123 @@ package systemd_test
 import (
 	. "gopkg.in/check.v1"
 
-	. "github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd"
 )
 
-func (s *SystemdTestSuite) TestEscape(c *C) {
-	c.Check(EscapeUnitNamePath("Hallöchen, Meister"), Equals, `Hall\xc3\xb6chen\x2c\x20Meister`)
+func (ts *SystemdTestSuite) TestEscapePath(c *C) {
+	tt := []struct {
+		in      string
+		out     string
+		comment string
+	}{
+		{
+			`Hallöchen, Meister`,
+			`Hall\xc3\xb6chen\x2c\x20Meister`,
+			`utf-8 char and spaces`,
+		},
+		{
+			`/tmp//waldi/foobar/`,
+			`tmp-waldi-foobar`,
+			`unclean path`,
+		},
+		{
+			`/.foo/.bar`,
+			`\x2efoo-.bar`,
+			`leading dot escaped differently`,
+		},
+		{
+			`.foo/.bar`,
+			`\x2efoo-.bar`,
+			`leading dot escaped differently (without leading slash)`,
+		},
+		{
+			``,
+			`-`,
+			`empty string`,
+		},
+		{
+			`/`,
+			`-`,
+			`root /`,
+		},
+		{
+			`////////`,
+			`-`,
+			`root / unclean`,
+		},
+		{
+			`-`,
+			`\x2d`,
+			`just dash`,
+		},
+		{
+			`/run/ubuntu------data`,
+			`run-ubuntu\x2d\x2d\x2d\x2d\x2d\x2ddata`,
+			`consecutive dashes`,
+		},
+		{
+			`/path-with-forward-slash\`,
+			`path\x2dwith\x2dforward\x2dslash\x5c`,
+			`forward slash in path element`,
+		},
+		{
+			`/run/1000/numbers`,
+			`run-1000-numbers`,
+			`numbers`,
+		},
+		{
+			`/silly/path/,!@#$%^&*()`,
+			`silly-path-\x2c\x21\x40\x23\x24\x25\x5e\x26\x2a\x28\x29`,
+			`ascii punctuation`,
+		},
+		{
+			`/run/mnt/data`,
+			`run-mnt-data`,
+			`typical data initramfs mount`,
+		},
+		{
+			`run/mnt/data`,
+			`run-mnt-data`,
+			`typical data initramfs mount w/o leading slash`,
+		},
+		{
+			`/run/mnt/ubuntu-seed`,
+			`run-mnt-ubuntu\x2dseed`,
+			`typical ubuntu-seed initramfs mount`,
+		},
+		{
+			`/run/mnt/ubuntu data`,
+			`run-mnt-ubuntu\x20data`,
+			`path with space in it`,
+		},
+		{
+			`/run/mnt/ubuntu_data`,
+			`run-mnt-ubuntu_data`,
+			`path with underscore in it`,
+		},
+		{
+			` `,
+			`\x20`,
+			"space character",
+		},
+		{
+			`	`,
+			`\x09`,
+			`tab character`,
+		},
+		{
+			`/home/日本語`,
+			`home-\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e`,
+			`utf-8 characters`,
+		},
+		{
+			`/path⌘place-of-interest/hello`,
+			`path\xe2\x8c\x98place\x2dof\x2dinterest-hello`,
+			`utf-8 character embedded in ascii path element`,
+		},
+	}
 
-	c.Check(EscapeUnitNamePath("/tmp//waldi/foobar/"), Equals, `tmp-waldi-foobar`)
-	c.Check(EscapeUnitNamePath("/.foo/.bar"), Equals, `\x2efoo-.bar`)
-	c.Check(EscapeUnitNamePath("////"), Equals, `-`)
-	c.Check(EscapeUnitNamePath("."), Equals, `\x2e`)
-	c.Check(EscapeUnitNamePath("/foo/bar-baz"), Equals, `foo-bar\x2dbaz`)
-	c.Check(EscapeUnitNamePath("/foo/bar--baz"), Equals, `foo-bar\x2d\x2dbaz`)
+	for _, t := range tt {
+		c.Assert(systemd.EscapeUnitNamePath(t.in), Equals, t.out, Commentf(t.comment+" (with input %q)", t.in))
+	}
 }


### PR DESCRIPTION
"" is supposed to be treated as "/" by systemd-escape(1), however filepath.Clean("") gives "." which then in our implementation gets escaped and is incorrect.

"\t" needs the prefixing 0 in the \x escaping to match systemd-escape(1) exactly, the easy way to have Go do this automatically is to use %x format spec with a byte list.

Add many more unit tests here and stop importing the package with "." as it is slightly confusing.