### PR TITLE
bootloader, boot: compose kernel command line passed by grub bootloader

### DIFF
--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -178,5 +178,8 @@ func CommandLine(model *asserts.Model) (string, error) {
 		}
 		return "", err
 	}
-	return mbl.CommandLine(nil)
+	modeArgs := []string{
+		"snapd_recovery_mode=run",
+	}
+	return mbl.CommandLine(modeArgs)
 }

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -209,5 +209,5 @@ func (s *kernelCommandLineSuite) TestCommandLineManagedHappy(c *C) {
 	c.Assert(cmdline, Equals, "panic=-1 snapd_recovery_mode=recover snapd_recovery_system=20200314")
 	cmdline, err = boot.CommandLine(model)
 	c.Assert(err, IsNil)
-	c.Assert(cmdline, Equals, "panic=-1")
+	c.Assert(cmdline, Equals, "panic=-1 snapd_recovery_mode=run")
 }

--- a/bootloader/assets/grub.go
+++ b/bootloader/assets/grub.go
@@ -41,7 +41,7 @@ set timeout_style=hidden
 # load only kernel_status from the bootenv
 load_env --file /EFI/ubuntu/grubenv kernel_status
 
-set cmdline="console=ttyS0 console=tty1 panic=-1"
+set snapd_static_cmdline_args='console=ttyS0 console=tty1 panic=-1'
 
 set kernel=kernel.efi
 
@@ -70,7 +70,7 @@ menuentry "Run Ubuntu Core 20" {
     # use $prefix because the symlink manipulation at runtime for kernel snap
     # upgrades, etc. should only need the /boot/grub/ directory, not the
     # /EFI/ubuntu/ directory
-    chainloader $prefix/$kernel snapd_recovery_mode=run $cmdline
+    chainloader $prefix/$kernel $snapd_static_cmdline_args snapd_recovery_mode=run
 }
 else
     # nothing to boot :-/
@@ -89,7 +89,7 @@ if [ -e /EFI/ubuntu/grubenv ]; then
 fi
 
 # standard cmdline params
-set cmdline="console=ttyS0 console=tty1 panic=-1"
+set snapd_static_cmdline_args='console=ttyS0 console=tty1 panic=-1'
 
 # if no default boot mode set, pick one
 if [ -z "$snapd_recovery_mode" ]; then
@@ -130,11 +130,11 @@ for label in /systems/*; do
     # We could "source /systems/$snapd_recovery_system/grub.cfg" here as well
     menuentry "Recover using $label" --hotkey=r --id=recover-$label $snapd_recovery_kernel recover $label {
         loopback loop $2
-        chainloader (loop)/kernel.efi snapd_recovery_mode=$3 snapd_recovery_system=$4 $cmdline
+        chainloader (loop)/kernel.efi $snapd_static_cmdline_args snapd_recovery_mode=$3 snapd_recovery_system=$4
     }
     menuentry "Install using $label" --hotkey=i --id=install-$label $snapd_recovery_kernel install $label {
         loopback loop $2
-        chainloader (loop)/kernel.efi snapd_recovery_mode=$3 snapd_recovery_system=$4 $cmdline
+        chainloader (loop)/kernel.efi $snapd_static_cmdline_args snapd_recovery_mode=$3 snapd_recovery_system=$4
     }
 done
 

--- a/bootloader/assets/grub.go
+++ b/bootloader/assets/grub.go
@@ -70,7 +70,7 @@ menuentry "Run Ubuntu Core 20" {
     # use $prefix because the symlink manipulation at runtime for kernel snap
     # upgrades, etc. should only need the /boot/grub/ directory, not the
     # /EFI/ubuntu/ directory
-    chainloader $prefix/$kernel $snapd_static_cmdline_args $snapd_extra_cmdline_args snapd_recovery_mode=run
+    chainloader $prefix/$kernel snapd_recovery_mode=run $snapd_static_cmdline_args $snapd_extra_cmdline_args
 }
 else
     # nothing to boot :-/
@@ -130,11 +130,11 @@ for label in /systems/*; do
     # We could "source /systems/$snapd_recovery_system/grub.cfg" here as well
     menuentry "Recover using $label" --hotkey=r --id=recover-$label $snapd_recovery_kernel recover $label {
         loopback loop $2
-        chainloader (loop)/kernel.efi $snapd_static_cmdline_args $snapd_extra_cmdline_args snapd_recovery_mode=$3 snapd_recovery_system=$4
+        chainloader (loop)/kernel.efi snapd_recovery_mode=$3 snapd_recovery_system=$4 $snapd_static_cmdline_args $snapd_extra_cmdline_args
     }
     menuentry "Install using $label" --hotkey=i --id=install-$label $snapd_recovery_kernel install $label {
         loopback loop $2
-        chainloader (loop)/kernel.efi $snapd_static_cmdline_args $snapd_extra_cmdline_args snapd_recovery_mode=$3 snapd_recovery_system=$4
+        chainloader (loop)/kernel.efi snapd_recovery_mode=$3 snapd_recovery_system=$4 $snapd_static_cmdline_args $snapd_extra_cmdline_args
     }
 done
 

--- a/bootloader/assets/grub.go
+++ b/bootloader/assets/grub.go
@@ -39,7 +39,7 @@ set timeout=3
 set timeout_style=hidden
 
 # load only kernel_status from the bootenv
-load_env --file /EFI/ubuntu/grubenv kernel_status
+load_env --file /EFI/ubuntu/grubenv kernel_status snapd_extra_cmdline_args
 
 set snapd_static_cmdline_args='console=ttyS0 console=tty1 panic=-1'
 
@@ -70,7 +70,7 @@ menuentry "Run Ubuntu Core 20" {
     # use $prefix because the symlink manipulation at runtime for kernel snap
     # upgrades, etc. should only need the /boot/grub/ directory, not the
     # /EFI/ubuntu/ directory
-    chainloader $prefix/$kernel $snapd_static_cmdline_args snapd_recovery_mode=run
+    chainloader $prefix/$kernel $snapd_static_cmdline_args $snapd_extra_cmdline_args snapd_recovery_mode=run
 }
 else
     # nothing to boot :-/
@@ -125,16 +125,16 @@ for label in /systems/*; do
         default=$snapd_recovery_mode-$best
     fi
     set snapd_recovery_kernel=
-    load_env --file /systems/$label/grubenv snapd_recovery_kernel
+    load_env --file /systems/$label/grubenv snapd_recovery_kernel snapd_extra_cmdline_args
 
     # We could "source /systems/$snapd_recovery_system/grub.cfg" here as well
     menuentry "Recover using $label" --hotkey=r --id=recover-$label $snapd_recovery_kernel recover $label {
         loopback loop $2
-        chainloader (loop)/kernel.efi $snapd_static_cmdline_args snapd_recovery_mode=$3 snapd_recovery_system=$4
+        chainloader (loop)/kernel.efi $snapd_static_cmdline_args $snapd_extra_cmdline_args snapd_recovery_mode=$3 snapd_recovery_system=$4
     }
     menuentry "Install using $label" --hotkey=i --id=install-$label $snapd_recovery_kernel install $label {
         loopback loop $2
-        chainloader (loop)/kernel.efi $snapd_static_cmdline_args snapd_recovery_mode=$3 snapd_recovery_system=$4
+        chainloader (loop)/kernel.efi $snapd_static_cmdline_args $snapd_extra_cmdline_args snapd_recovery_mode=$3 snapd_recovery_system=$4
     }
 done
 

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -20,6 +20,7 @@
 package bootloader
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -309,4 +310,57 @@ func removeKernelAssetsFromBootDir(bootDir string, s snap.PlaceInfo) error {
 	}
 
 	return nil
+}
+
+// kernelCommandLineSplit tries to split the string into a list of elements that
+// would be passed by the bootloader as the kernel command arguments.
+//
+// See https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html for details.
+func kernelCommandLineSplit(s string) (out []string, err error) {
+	var quoting bool
+	var b bytes.Buffer
+	var rs = []rune(s)
+	var last = len(rs) - 1
+	// arguments are:
+	// - arg
+	// - arg=value, where value can be any string, spaces are preserve when quoting ".."
+	for idx, r := range rs {
+		maybeSplit := false
+		switch r {
+		case '"':
+			if !quoting {
+				if b.Len() < 2 || idx == 0 || (idx > 0 && rs[idx-1] != '=') {
+					// either:
+					// - the whole input starts with "
+					// - preceding character is not =
+					// - there's no at least `a=` collected so far
+					return nil, fmt.Errorf("unexpected quoting")
+				}
+				quoting = true
+			} else {
+				quoting = false
+			}
+			b.WriteRune(r)
+		case ' ':
+			if quoting {
+				b.WriteRune(r)
+			} else {
+				maybeSplit = true
+			}
+		default:
+			b.WriteRune(r)
+		}
+		if maybeSplit || idx == last {
+			// split now
+			if b.Len() != 0 {
+				out = append(out, b.String())
+				b.Reset()
+			}
+			continue
+		}
+	}
+	if quoting {
+		return nil, fmt.Errorf("unbalanced quoting")
+	}
+	return out, nil
 }

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -317,38 +317,113 @@ func removeKernelAssetsFromBootDir(bootDir string, s snap.PlaceInfo) error {
 //
 // See https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html for details.
 func kernelCommandLineSplit(s string) (out []string, err error) {
-	var quoting bool
+	const (
+		argNone            int = iota // initial state
+		argName                       // looking at argument name
+		argAssign                     // looking at =
+		argValue                      // looking at unquoted value
+		argValueQuoteStart            // looking at start of quoted value
+		argValueQuoted                // looking at quoted value
+		argValueQuoteEnd              // looking at end of quoted value
+	)
 	var b bytes.Buffer
 	var rs = []rune(s)
 	var last = len(rs) - 1
+	var errUnexpectedQuote = fmt.Errorf("unexpected quoting")
+	var errUnbalancedQUote = fmt.Errorf("unbalanced quoting")
+	var errUnexpectedArgument = fmt.Errorf("unexpected argument")
+	var errUnexpectedAssignment = fmt.Errorf("unexpected assignment")
 	// arguments are:
 	// - arg
 	// - arg=value, where value can be any string, spaces are preserve when quoting ".."
+	var state = argNone
 	for idx, r := range rs {
 		maybeSplit := false
-		switch r {
-		case '"':
-			if !quoting {
-				if b.Len() < 2 || idx == 0 || (idx > 0 && rs[idx-1] != '=') {
-					// either:
-					// - the whole input starts with "
-					// - preceding character is not =
-					// - there's no at least `a=` collected so far
-					return nil, fmt.Errorf("unexpected quoting")
-				}
-				quoting = true
-			} else {
-				quoting = false
-			}
-			b.WriteRune(r)
-		case ' ':
-			if quoting {
-				b.WriteRune(r)
-			} else {
+		switch state {
+		case argNone:
+			switch r {
+			case '"':
+				return nil, errUnexpectedQuote
+			case ' ':
 				maybeSplit = true
+			default:
+				state = argName
+				b.WriteRune(r)
 			}
-		default:
-			b.WriteRune(r)
+		case argName:
+			switch r {
+			case ' ':
+				maybeSplit = true
+				state = argNone
+			case '"':
+				return nil, errUnexpectedQuote
+			case '=':
+				state = argAssign
+				fallthrough
+			default:
+				b.WriteRune(r)
+			}
+		case argAssign:
+			switch r {
+			case ' ':
+				// no value: arg=
+				maybeSplit = true
+				state = argNone
+			case '"':
+				// arg="..
+				state = argValueQuoteStart
+				b.WriteRune(r)
+			default:
+				// arg=v..
+				state = argValue
+				b.WriteRune(r)
+			}
+		case argValue:
+			switch r {
+			case ' ':
+				state = argNone
+				maybeSplit = true
+			case '"':
+				// arg=foo"
+				return nil, errUnexpectedQuote
+			default:
+				// arg=value...
+				b.WriteRune(r)
+			}
+		case argValueQuoteStart:
+			switch r {
+			case '"':
+				// closing quote: arg=""
+				state = argValueQuoteEnd
+				b.WriteRune(r)
+			default:
+				state = argValueQuoted
+				b.WriteRune(r)
+			}
+		case argValueQuoted:
+			switch r {
+			case '"':
+				// closing quote: arg="foo"
+				state = argValueQuoteEnd
+				fallthrough
+			default:
+				b.WriteRune(r)
+			}
+		case argValueQuoteEnd:
+			switch r {
+			case '"':
+				// arg="foo""
+				return nil, errUnexpectedQuote
+			case ' ':
+				maybeSplit = true
+				state = argNone
+			case '=':
+				// arg="foo"bar
+				return nil, errUnexpectedAssignment
+			default:
+				// arg="foo"bar
+				return nil, errUnexpectedArgument
+			}
 		}
 		if maybeSplit || idx == last {
 			// split now
@@ -356,11 +431,12 @@ func kernelCommandLineSplit(s string) (out []string, err error) {
 				out = append(out, b.String())
 				b.Reset()
 			}
-			continue
 		}
 	}
-	if quoting {
-		return nil, fmt.Errorf("unbalanced quoting")
+	switch state {
+	case argValueQuoteStart, argValueQuoted:
+		// ended at arg=" or arg="foo
+		return nil, errUnbalancedQUote
 	}
 	return out, nil
 }

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -236,18 +236,25 @@ func (s *bootenvTestSuite) TestSplitKernelCommandLine(c *C) {
 		exp    []string
 		errStr string
 	}{
+		{cmd: ``, exp: nil},
 		{cmd: `foo bar baz`, exp: []string{"foo", "bar", "baz"}},
 		{cmd: `foo=" many   spaces  " bar`, exp: []string{`foo=" many   spaces  "`, "bar"}},
 		{cmd: `foo="1$2"`, exp: []string{`foo="1$2"`}},
 		{cmd: `foo=1$2`, exp: []string{`foo=1$2`}},
 		{cmd: `foo= bar`, exp: []string{"foo=", "bar"}},
+		{cmd: `foo= bar`, exp: []string{"foo=", "bar"}},
+		{cmd: `foo=""`, exp: []string{`foo=""`}},
 		{cmd: `   cpu=1,2,3   mem=0x2000;0x4000:$2  `, exp: []string{"cpu=1,2,3", "mem=0x2000;0x4000:$2"}},
 		{cmd: "isolcpus=1,2,10-20,100-2000:2/25", exp: []string{"isolcpus=1,2,10-20,100-2000:2/25"}},
-		// bad quoting
+		// bad quoting, or otherwise malformed command line
 		{cmd: `foo="1$2`, errStr: "unbalanced quoting"},
 		{cmd: `"foo"`, errStr: "unexpected quoting"},
 		{cmd: `="foo"`, errStr: "unexpected quoting"},
 		{cmd: `foo"foo"`, errStr: "unexpected quoting"},
+		{cmd: `foo=foo"`, errStr: "unexpected quoting"},
+		{cmd: `foo="a""b"`, errStr: "unexpected quoting"},
+		{cmd: `foo="a foo="b`, errStr: "unexpected argument"},
+		{cmd: `foo="a"="b"`, errStr: "unexpected assignment"},
 	} {
 		c.Logf("%v: cmd: %q", idx, tc.cmd)
 		out, err := bootloader.KernelCommandLineSplit(tc.cmd)

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -249,12 +249,17 @@ func (s *bootenvTestSuite) TestSplitKernelCommandLine(c *C) {
 		// bad quoting, or otherwise malformed command line
 		{cmd: `foo="1$2`, errStr: "unbalanced quoting"},
 		{cmd: `"foo"`, errStr: "unexpected quoting"},
-		{cmd: `="foo"`, errStr: "unexpected quoting"},
 		{cmd: `foo"foo"`, errStr: "unexpected quoting"},
 		{cmd: `foo=foo"`, errStr: "unexpected quoting"},
 		{cmd: `foo="a""b"`, errStr: "unexpected quoting"},
 		{cmd: `foo="a foo="b`, errStr: "unexpected argument"},
 		{cmd: `foo="a"="b"`, errStr: "unexpected assignment"},
+		{cmd: `=`, errStr: "unexpected assignment"},
+		{cmd: `a =`, errStr: "unexpected assignment"},
+		{cmd: `a=b=`, errStr: "unexpected assignment"},
+		{cmd: `="foo"`, errStr: "unexpected assignment"},
+		{cmd: `a==`, errStr: "unexpected assignment"},
+		{cmd: `foo ==a`, errStr: "unexpected assignment"},
 	} {
 		c.Logf("%v: cmd: %q", idx, tc.cmd)
 		out, err := bootloader.KernelCommandLineSplit(tc.cmd)

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -104,7 +104,10 @@ func LkRuntimeMode(b Bootloader) bool {
 }
 
 var (
-	EditionFromDiskConfigAsset = editionFromDiskConfigAsset
-	EditionFromConfigAsset     = editionFromConfigAsset
-	ConfigAssetFrom            = configAssetFrom
+	EditionFromDiskConfigAsset            = editionFromDiskConfigAsset
+	EditionFromConfigAsset                = editionFromConfigAsset
+	ConfigAssetFrom                       = configAssetFrom
+	StaticCommandLineFromGrubAsset        = staticCommandLineFromGrubAsset
+	KernelCommandLineSplit                = kernelCommandLineSplit
+	SortSnapdKernelCommandLineArgsForGrub = sortSnapdKernelCommandLineArgsForGrub
 )

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -44,6 +44,7 @@ type grub struct {
 	basedir string
 
 	uefiRunKernelExtraction bool
+	recovery                bool
 }
 
 // newGrub create a new Grub bootloader object
@@ -59,6 +60,7 @@ func newGrub(rootdir string, opts *Options) RecoveryAwareBootloader {
 	}
 	if opts != nil {
 		g.uefiRunKernelExtraction = opts.ExtractedRunKernelImage
+		g.recovery = opts.Recovery
 	}
 
 	return g

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -456,17 +456,16 @@ func sortSnapdKernelCommandLineArgsForGrub(args []string) []string {
 		}
 	}
 	// see grub.cfg and grub-recovery.cfg assets, the order is:
-	//      for run mode: <args> snapd_recovery_mode=run
-	// for recovery mode: <args> snapd_recovery_mode=recover snapd_recovery_system=<label>
-
-	for _, prefixOrder := range []string{"snapd_recovery_mode=", "snapd_recovery_system="} {
+	//      for run mode: snapd_recovery_mode=run <args>
+	// for recovery mode: snapd_recovery_mode=recover snapd_recovery_system=<label> <args>
+	for _, prefixOrder := range []string{"snapd_recovery_system=", "snapd_recovery_mode="} {
 		for i, marg := range modeArgs {
 			if strings.HasPrefix(marg, prefixOrder) {
 				modeArgs = append(modeArgs[:i], modeArgs[i+1:]...)
-				modeArgs = append(modeArgs, marg)
+				modeArgs = append([]string{marg}, modeArgs...)
 				break
 			}
 		}
 	}
-	return append(out, modeArgs...)
+	return append(modeArgs, out...)
 }

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -20,10 +20,14 @@
 package bootloader
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/snapcore/snapd/bootloader/assets"
 	"github.com/snapcore/snapd/bootloader/grubenv"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -372,5 +376,97 @@ func (g *grub) ManagedAssets() []string {
 //
 // Implements ManagedAssetsBootloader for the grub bootloader.
 func (g *grub) CommandLine(extra []string) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	// we do not trust the on disk asset, use the built-in one
+	assetName := "grub.cfg"
+	if g.recovery {
+		assetName = "grub-recovery.cfg"
+	}
+	staticCmdline, err := staticCommandLineFromGrubAsset(assetName)
+	if err != nil {
+		return "", fmt.Errorf("cannot extract static command line element: %v", err)
+	}
+	bv, err := g.GetBootVars("snapd_extra_cmdline_args")
+	if err != nil {
+		return "", fmt.Errorf("cannot load command line arguments from boot environment: %v", err)
+	}
+	args, err := kernelCommandLineSplit(staticCmdline + " " + bv["snapd_extra_cmdline_args"])
+	if err != nil {
+		return "", err
+	}
+	args = append(args, extra...)
+	// sort arguments so that they match their positions
+	args = sortSnapdKernelCommandLineArgsForGrub(args)
+	// join all argument with a single space, see
+	// grub-core/lib/cmdline.c:grub_create_loader_cmdline() for reference,
+	// arguments are separated by a single space, the space after last is
+	// replaced with terminating NULL
+	return strings.Join(args, " "), nil
+}
+
+// static command line is defined as:
+//     set snapd_static_cmdline_args='arg arg arg'\n
+// or
+//     set snapd_static_cmdline_args='arg'\n
+const grubStaticCmdlinePrefix = `set snapd_static_cmdline_args=`
+const grubStaticCmdlineQuote = `'`
+
+// staticCommandLineFromGrubAsset extracts the static command line element from
+// grub boot config asset on disk.
+func staticCommandLineFromGrubAsset(asset string) (string, error) {
+	gbc := assets.Internal(asset)
+	if gbc == nil {
+		return "", fmt.Errorf("internal error: asset %q not found", asset)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(gbc))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, grubStaticCmdlinePrefix) {
+			continue
+		}
+		// minimal length is the prefix + suffix with no content
+		minLength := len(grubStaticCmdlinePrefix) + len(grubStaticCmdlineQuote)*2
+		if !strings.HasPrefix(line, grubStaticCmdlinePrefix+grubStaticCmdlineQuote) ||
+			!strings.HasSuffix(line, grubStaticCmdlineQuote) ||
+			len(line) < minLength {
+
+			return "", fmt.Errorf("incorrect static command line format: %q", line)
+		}
+		cmdline := line[len(grubStaticCmdlinePrefix+grubStaticCmdlineQuote) : len(line)-len(grubStaticCmdlineQuote)]
+		return cmdline, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+// sortSnapdKernelCommandLineArgsForGrub sorts the command line arguments so
+// that the snapd_recovery_mode/system arguments are placed at the location that
+// matches the built-in grub boot config assets. Other arguments remain in the order
+// they appear.
+func sortSnapdKernelCommandLineArgsForGrub(args []string) []string {
+	out := make([]string, 0, len(args))
+	modeArgs := []string(nil)
+
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "snapd_recovery_") {
+			modeArgs = append(modeArgs, arg)
+		} else {
+			out = append(out, arg)
+		}
+	}
+	// see grub.cfg and grub-recovery.cfg assets, the order is:
+	//      for run mode: <args> snapd_recovery_mode=run
+	// for recovery mode: <args> snapd_recovery_mode=recover snapd_recovery_system=<label>
+
+	for _, prefixOrder := range []string{"snapd_recovery_mode=", "snapd_recovery_system="} {
+		for i, marg := range modeArgs {
+			if strings.HasPrefix(marg, prefixOrder) {
+				modeArgs = append(modeArgs[:i], modeArgs[i+1:]...)
+				modeArgs = append(modeArgs, marg)
+				break
+			}
+		}
+	}
+	return append(out, modeArgs...)
 }

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -884,12 +884,15 @@ boot script
 
 	args, err := mg.CommandLine(nil)
 	c.Assert(err, IsNil)
-
 	c.Check(args, Equals, `arg1 foo=123 panic=-1 arg2="with spaces " extra_arg=1 extra_foo=-1 panic=3 baz="more  spaces"`)
 
-	args, err = mg.CommandLine([]string{"snapd_recovery_mode=recover", "snapd_recovery_system=20200202"})
+	args, err = mg.CommandLine([]string{"snapd_recovery_mode=run"})
 	c.Assert(err, IsNil)
-	c.Check(args, Equals, `arg1 foo=123 panic=-1 arg2="with spaces " extra_arg=1 extra_foo=-1 panic=3 baz="more  spaces" snapd_recovery_mode=recover snapd_recovery_system=20200202`)
+	c.Check(args, Equals, `snapd_recovery_mode=run arg1 foo=123 panic=-1 arg2="with spaces " extra_arg=1 extra_foo=-1 panic=3 baz="more  spaces"`)
+
+	args, err = mg.CommandLine([]string{"snapd_recovery_system=20200202", "snapd_recovery_mode=recover"})
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, `snapd_recovery_mode=recover snapd_recovery_system=20200202 arg1 foo=123 panic=-1 arg2="with spaces " extra_arg=1 extra_foo=-1 panic=3 baz="more  spaces"`)
 
 	// now check the recovery bootloader
 	opts = &bootloader.Options{NoSlashBoot: true, Recovery: true}
@@ -897,19 +900,19 @@ boot script
 	args, err = mrg.CommandLine([]string{"snapd_recovery_mode=recover", "snapd_recovery_system=20200202"})
 	c.Assert(err, IsNil)
 	// static command line from recovery asset
-	c.Check(args, Equals, `recovery config panic=-1 extra_arg=1 extra_foo=-1 panic=3 baz="more  spaces" snapd_recovery_mode=recover snapd_recovery_system=20200202`)
+	c.Check(args, Equals, `snapd_recovery_mode=recover snapd_recovery_system=20200202 recovery config panic=-1 extra_arg=1 extra_foo=-1 panic=3 baz="more  spaces"`)
 }
 
 func (s *grubTestSuite) TestSortArgsForGrub(c *C) {
 	out := bootloader.SortSnapdKernelCommandLineArgsForGrub([]string{"foo", "bar", "snapd_recovery_mode=run", "panic=-1"})
-	c.Assert(out, DeepEquals, []string{"foo", "bar", "panic=-1", "snapd_recovery_mode=run"})
+	c.Assert(out, DeepEquals, []string{"snapd_recovery_mode=run", "foo", "bar", "panic=-1"})
 	// recovery mode
 	out = bootloader.SortSnapdKernelCommandLineArgsForGrub([]string{
 		"snapd_recovery_system=1234", "foo",
 		"snapd_recovery_mode=recover", "panic=-1",
 	})
 	c.Assert(out, DeepEquals, []string{
-		"foo", "panic=-1",
 		"snapd_recovery_mode=recover", "snapd_recovery_system=1234",
+		"foo", "panic=-1",
 	})
 }


### PR DESCRIPTION
The patchset adds functionality for composing/computing the kernel command that will be passed by the grub bootloader when booting the system.

The command line is composed of a static element defined in the boot config asset in a line `set snapd_static_cmdline_args='...'`. Extra arguments controlled by snapd can be injected by setting the bootloader environment variable `snapd_extra_cmdline_args` to a string containing the boot variables. The run/recovery mode variables `snapd_recovery_mode=.. snapd_recovery_system=..` are appended last.
