### PR TITLE
tests: fix some snapstate tests to use pointers for snapmgrTestSuite

### DIFF
--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -264,7 +264,7 @@ epoch: 1*
 	})
 }
 
-func (s snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
+func (s *snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -287,7 +287,7 @@ func dummyInUseCheck(snap.Type) (boot.InUseFunc, error) {
 	}, nil
 }
 
-func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
+func (s *snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -340,7 +340,7 @@ func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 	c.Check(snapst.RefreshInhibitedTime, NotNil)
 }
 
-func (s snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
+func (s *snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -389,7 +389,7 @@ func (s snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s snapmgrTestSuite) TestInstallFailsOnSystem(c *C) {
+func (s *snapmgrTestSuite) TestInstallFailsOnSystem(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -6921,7 +6921,7 @@ func (s *snapmgrTestSuite) TestNoConfigureForSnapdSnap(c *C) {
 
 }
 
-func (s snapmgrTestSuite) TestCanLoadOldSnapSetupWithoutType(c *C) {
+func (s *snapmgrTestSuite) TestCanLoadOldSnapSetupWithoutType(c *C) {
 	// ensure we don't crash when loading a SnapSetup json without
 	// a type set
 	oldSnapSetup := []byte(`{
@@ -6946,7 +6946,7 @@ func (s snapmgrTestSuite) TestCanLoadOldSnapSetupWithoutType(c *C) {
 	c.Check(snapsup.Type, Equals, snap.Type(""))
 }
 
-func (s snapmgrTestSuite) TestHasOtherInstances(c *C) {
+func (s *snapmgrTestSuite) TestHasOtherInstances(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 


### PR DESCRIPTION
Fix a trivial mistake in a few snapstate tests spotted when working on another PR. This doesn't fix any immediate problem, but such error can lead to very confusing problems / misbehaving tests.