### PR TITLE
tests/cmd/snap-bootstrap/initramfs-mounts: add test case for empty recovery_mode

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1183,6 +1183,14 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallRecoverModeStep2Measure
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep2Measure(c *C) {
+	s.testInitramfsMountsInstallRecoverModeStep2Measure(c, "install")
+}
+
+func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeUnsetStep2Measure(c *C) {
+	// TODO:UC20: eventually we should require snapd_recovery_mode to be set to
+	// explicitly "install" for install mode, but we originally allowed
+	// snapd_recovery_mode="" and interpreted it as install mode, so test that
+	// case too
 	s.testInitramfsMountsInstallRecoverModeStep2Measure(c, "")
 }
 


### PR DESCRIPTION
This is in install mode, so we should also be testing snapd_recovery_mode=install here.

The empty string here is still interpreted as install mode so this is a pure test change. Eventually we should consider dropping support for snapd_recovery_mode="" meaning install mode, but for now just test both cases.

The relevant code is

https://github.com/snapcore/snapd/blob/f64e8564bec3fb47637bfe1633924b2df7570a5e/boot/cmdline.go#L60-L67