### PR TITLE
strutil: add a helper for parsing kernel command line

### DIFF
--- a/strutil/cmdline.go
+++ b/strutil/cmdline.go
@@ -24,8 +24,9 @@ import (
 	"fmt"
 )
 
-// KernelCommandLineSplit tries to split the string into a list of elements that
-// would be passed by the bootloader as the kernel command arguments.
+// KernelCommandLineSplit tries to split the string comprising full or a part
+// of a kernel command line into a list of individual arguments. Returns an
+// error when the input string is incorrectly formatted.
 //
 // See https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html for details.
 func KernelCommandLineSplit(s string) (out []string, err error) {

--- a/strutil/cmdline.go
+++ b/strutil/cmdline.go
@@ -100,8 +100,6 @@ func KernelCommandLineSplit(s string) (out []string, err error) {
 			case '"':
 				// arg=foo"
 				return nil, errUnexpectedQuote
-			case '=':
-				return nil, errUnexpectedAssignment
 			case ' ':
 				state = argNone
 				maybeSplit = true

--- a/strutil/cmdline.go
+++ b/strutil/cmdline.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// KernelCommandLineSplit tries to split the string into a list of elements that
+// would be passed by the bootloader as the kernel command arguments.
+//
+// See https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html for details.
+func KernelCommandLineSplit(s string) (out []string, err error) {
+	var quoting bool
+	var b bytes.Buffer
+	var rs = []rune(s)
+	var last = len(rs) - 1
+	// arguments are:
+	// - arg
+	// - arg=value, where value can be any string, spaces are preserve when quoting ".."
+	for idx, r := range rs {
+		maybeSplit := false
+		switch r {
+		case '"':
+			if !quoting {
+				if b.Len() < 2 || idx == 0 || (idx > 0 && rs[idx-1] != '=') {
+					// either:
+					// - the whole input starts with "
+					// - preceding character is not =
+					// - there's no at least `a=` collected so far
+					return nil, fmt.Errorf("unexpected quoting")
+				}
+				quoting = true
+			} else {
+				quoting = false
+			}
+			b.WriteRune(r)
+		case ' ':
+			if quoting {
+				b.WriteRune(r)
+			} else {
+				maybeSplit = true
+			}
+		default:
+			b.WriteRune(r)
+		}
+		if maybeSplit || idx == last {
+			// split now
+			if b.Len() != 0 {
+				out = append(out, b.String())
+				b.Reset()
+			}
+			continue
+		}
+	}
+	if quoting {
+		return nil, fmt.Errorf("unbalanced quoting")
+	}
+	return out, nil
+}

--- a/strutil/cmdline_test.go
+++ b/strutil/cmdline_test.go
@@ -45,6 +45,26 @@ func (s *cmdlineTestSuite) TestSplitKernelCommandLine(c *C) {
 		{cmd: `foo=""`, exp: []string{`foo=""`}},
 		{cmd: `   cpu=1,2,3   mem=0x2000;0x4000:$2  `, exp: []string{"cpu=1,2,3", "mem=0x2000;0x4000:$2"}},
 		{cmd: "isolcpus=1,2,10-20,100-2000:2/25", exp: []string{"isolcpus=1,2,10-20,100-2000:2/25"}},
+		// something more realistic
+		{
+			cmd: `BOOT_IMAGE=/vmlinuz-linux root=/dev/mapper/linux-root rw quiet loglevel=3 rd.udev.log_priority=3 vt.global_cursor_default=0 rd.luks.uuid=1a273f76-3118-434b-8597-a3b12a59e017 rd.luks.uuid=775e4582-33c1-423b-ac19-f734e0d5e21c rd.luks.options=discard,timeout=0 root=/dev/mapper/linux-root apparmor=1 security=apparmor`,
+			exp: []string{
+				"BOOT_IMAGE=/vmlinuz-linux",
+				"root=/dev/mapper/linux-root",
+				"rw", "quiet",
+				"loglevel=3",
+				"rd.udev.log_priority=3",
+				"vt.global_cursor_default=0",
+				"rd.luks.uuid=1a273f76-3118-434b-8597-a3b12a59e017",
+				"rd.luks.uuid=775e4582-33c1-423b-ac19-f734e0d5e21c",
+				"rd.luks.options=discard,timeout=0",
+				"root=/dev/mapper/linux-root",
+				"apparmor=1",
+				"security=apparmor",
+			},
+		},
+		// this is actually ok, eg. rd.luks.options=discard,timeout=0
+		{cmd: `a=b=`, exp: []string{"a=b="}},
 		// bad quoting, or otherwise malformed command line
 		{cmd: `foo="1$2`, errStr: "unbalanced quoting"},
 		{cmd: `"foo"`, errStr: "unexpected quoting"},
@@ -55,7 +75,6 @@ func (s *cmdlineTestSuite) TestSplitKernelCommandLine(c *C) {
 		{cmd: `foo="a"="b"`, errStr: "unexpected assignment"},
 		{cmd: `=`, errStr: "unexpected assignment"},
 		{cmd: `a =`, errStr: "unexpected assignment"},
-		{cmd: `a=b=`, errStr: "unexpected assignment"},
 		{cmd: `="foo"`, errStr: "unexpected assignment"},
 		{cmd: `a==`, errStr: "unexpected assignment"},
 		{cmd: `foo ==a`, errStr: "unexpected assignment"},

--- a/strutil/cmdline_test.go
+++ b/strutil/cmdline_test.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/strutil"
+)
+
+type cmdlineTestSuite struct{}
+
+var _ = Suite(&cmdlineTestSuite{})
+
+func (s *cmdlineTestSuite) TestSplitKernelCommandLine(c *C) {
+	for idx, tc := range []struct {
+		cmd    string
+		exp    []string
+		errStr string
+	}{
+		{cmd: `foo bar baz`, exp: []string{"foo", "bar", "baz"}},
+		{cmd: `foo=" many   spaces  " bar`, exp: []string{`foo=" many   spaces  "`, "bar"}},
+		{cmd: `foo="1$2"`, exp: []string{`foo="1$2"`}},
+		{cmd: `foo=1$2`, exp: []string{`foo=1$2`}},
+		{cmd: `foo= bar`, exp: []string{"foo=", "bar"}},
+		{cmd: `   cpu=1,2,3   mem=0x2000;0x4000:$2  `, exp: []string{"cpu=1,2,3", "mem=0x2000;0x4000:$2"}},
+		{cmd: "isolcpus=1,2,10-20,100-2000:2/25", exp: []string{"isolcpus=1,2,10-20,100-2000:2/25"}},
+		// bad quoting
+		{cmd: `foo="1$2`, errStr: "unbalanced quoting"},
+		{cmd: `"foo"`, errStr: "unexpected quoting"},
+		{cmd: `="foo"`, errStr: "unexpected quoting"},
+		{cmd: `foo"foo"`, errStr: "unexpected quoting"},
+	} {
+		c.Logf("%v: cmd: %q", idx, tc.cmd)
+		out, err := strutil.KernelCommandLineSplit(tc.cmd)
+		if tc.errStr != "" {
+			c.Assert(err, ErrorMatches, tc.errStr)
+			c.Check(out, IsNil)
+		} else {
+			c.Assert(err, IsNil)
+			c.Check(out, DeepEquals, tc.exp)
+		}
+	}
+}

--- a/strutil/cmdline_test.go
+++ b/strutil/cmdline_test.go
@@ -48,12 +48,17 @@ func (s *cmdlineTestSuite) TestSplitKernelCommandLine(c *C) {
 		// bad quoting, or otherwise malformed command line
 		{cmd: `foo="1$2`, errStr: "unbalanced quoting"},
 		{cmd: `"foo"`, errStr: "unexpected quoting"},
-		{cmd: `="foo"`, errStr: "unexpected quoting"},
 		{cmd: `foo"foo"`, errStr: "unexpected quoting"},
 		{cmd: `foo=foo"`, errStr: "unexpected quoting"},
 		{cmd: `foo="a""b"`, errStr: "unexpected quoting"},
 		{cmd: `foo="a foo="b`, errStr: "unexpected argument"},
 		{cmd: `foo="a"="b"`, errStr: "unexpected assignment"},
+		{cmd: `=`, errStr: "unexpected assignment"},
+		{cmd: `a =`, errStr: "unexpected assignment"},
+		{cmd: `a=b=`, errStr: "unexpected assignment"},
+		{cmd: `="foo"`, errStr: "unexpected assignment"},
+		{cmd: `a==`, errStr: "unexpected assignment"},
+		{cmd: `foo ==a`, errStr: "unexpected assignment"},
 	} {
 		c.Logf("%v: cmd: %q", idx, tc.cmd)
 		out, err := strutil.KernelCommandLineSplit(tc.cmd)

--- a/strutil/cmdline_test.go
+++ b/strutil/cmdline_test.go
@@ -35,18 +35,25 @@ func (s *cmdlineTestSuite) TestSplitKernelCommandLine(c *C) {
 		exp    []string
 		errStr string
 	}{
+		{cmd: ``, exp: nil},
 		{cmd: `foo bar baz`, exp: []string{"foo", "bar", "baz"}},
 		{cmd: `foo=" many   spaces  " bar`, exp: []string{`foo=" many   spaces  "`, "bar"}},
 		{cmd: `foo="1$2"`, exp: []string{`foo="1$2"`}},
 		{cmd: `foo=1$2`, exp: []string{`foo=1$2`}},
 		{cmd: `foo= bar`, exp: []string{"foo=", "bar"}},
+		{cmd: `foo= bar`, exp: []string{"foo=", "bar"}},
+		{cmd: `foo=""`, exp: []string{`foo=""`}},
 		{cmd: `   cpu=1,2,3   mem=0x2000;0x4000:$2  `, exp: []string{"cpu=1,2,3", "mem=0x2000;0x4000:$2"}},
 		{cmd: "isolcpus=1,2,10-20,100-2000:2/25", exp: []string{"isolcpus=1,2,10-20,100-2000:2/25"}},
-		// bad quoting
+		// bad quoting, or otherwise malformed command line
 		{cmd: `foo="1$2`, errStr: "unbalanced quoting"},
 		{cmd: `"foo"`, errStr: "unexpected quoting"},
 		{cmd: `="foo"`, errStr: "unexpected quoting"},
 		{cmd: `foo"foo"`, errStr: "unexpected quoting"},
+		{cmd: `foo=foo"`, errStr: "unexpected quoting"},
+		{cmd: `foo="a""b"`, errStr: "unexpected quoting"},
+		{cmd: `foo="a foo="b`, errStr: "unexpected argument"},
+		{cmd: `foo="a"="b"`, errStr: "unexpected assignment"},
 	} {
 		c.Logf("%v: cmd: %q", idx, tc.cmd)
 		out, err := strutil.KernelCommandLineSplit(tc.cmd)

--- a/strutil/cmdline_test.go
+++ b/strutil/cmdline_test.go
@@ -41,7 +41,6 @@ func (s *cmdlineTestSuite) TestSplitKernelCommandLine(c *C) {
 		{cmd: `foo="1$2"`, exp: []string{`foo="1$2"`}},
 		{cmd: `foo=1$2`, exp: []string{`foo=1$2`}},
 		{cmd: `foo= bar`, exp: []string{"foo=", "bar"}},
-		{cmd: `foo= bar`, exp: []string{"foo=", "bar"}},
 		{cmd: `foo=""`, exp: []string{`foo=""`}},
 		{cmd: `   cpu=1,2,3   mem=0x2000;0x4000:$2  `, exp: []string{"cpu=1,2,3", "mem=0x2000;0x4000:$2"}},
 		{cmd: "isolcpus=1,2,10-20,100-2000:2/25", exp: []string{"isolcpus=1,2,10-20,100-2000:2/25"}},


### PR DESCRIPTION
Add a helper for parsing a string representing an existing or potential kernel command line. Extracted from #8993
