### PR TITLE
o/snapstate: integrate free space checks with install/refresh and remove (3/N)

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -209,8 +209,8 @@ func isInsideBaseSnap() (bool, error) {
 	return err == nil, err
 }
 
-// SnapdVarDir returns the path to /var/lib/snapd dir under rootdir.
-func SnapdVarDir(rootdir string) string {
+// SnapdStateDir returns the path to /var/lib/snapd dir under rootdir.
+func SnapdStateDir(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir)
 }
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -209,6 +209,11 @@ func isInsideBaseSnap() (bool, error) {
 	return err == nil, err
 }
 
+// SnapdVarDir returns the path to /var/lib/snapd dir under rootdir.
+func SnapdVarDir(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir)
+}
+
 // SnapBlobDirUnder returns the path to the snap blob dir under rootdir.
 func SnapBlobDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "snaps")

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -718,3 +718,65 @@ func (s *snapshotSuite) TestMaybeRunuserNoHappy(c *check.C) {
 	})
 	c.Check(strings.TrimSpace(logbuf.String()), check.Matches, ".* No user wrapper found.*")
 }
+
+func (s *snapshotSuite) TestEstimateSnapshotSize(c *check.C) {
+	var info = &snap.Info{
+		SuggestedName: "foo",
+		SideInfo: snap.SideInfo{
+			Revision: snap.R(7),
+		},
+	}
+
+	snapData := []string{
+		"/var/snap/foo/7/somedatadir",
+		"/var/snap/foo/7/otherdata",
+		"/var/snap/foo/7",
+		"/var/snap/foo/common",
+		"/var/snap/foo/common/a",
+	}
+	var data []byte
+	var expected int
+	for _, d := range snapData {
+		data = append(data, 0)
+		expected += len(data)
+		c.Assert(os.MkdirAll(filepath.Join(s.root, d), 0755), check.IsNil)
+		c.Assert(ioutil.WriteFile(filepath.Join(s.root, d, "somfile"), data, 0644), check.IsNil)
+	}
+
+	sz, err := backend.EstimateSnapshotSize(info)
+	c.Assert(err, check.IsNil)
+	c.Check(sz, check.Equals, int64(expected))
+}
+
+func (s *snapshotSuite) TestEstimateSnapshotSizeEmpty(c *check.C) {
+	var info = &snap.Info{
+		SuggestedName: "foo",
+		SideInfo: snap.SideInfo{
+			Revision: snap.R(7),
+		},
+	}
+
+	snapData := []string{
+		"/var/snap/foo/common",
+		"/var/snap/foo/7",
+	}
+	for _, d := range snapData {
+		c.Assert(os.MkdirAll(filepath.Join(s.root, d), 0755), check.IsNil)
+	}
+
+	sz, err := backend.EstimateSnapshotSize(info)
+	c.Assert(err, check.IsNil)
+	c.Check(sz, check.Equals, int64(0))
+}
+
+
+func (s *snapshotSuite) TestEstimateSnapshotSizeNotDataDirs(c *check.C) {
+	var info = &snap.Info{
+		SuggestedName: "foo",
+		SideInfo: snap.SideInfo{Revision: snap.R(7)},
+	}
+
+	sz, err := backend.EstimateSnapshotSize(info)
+	c.Assert(err, check.IsNil)
+	c.Check(sz, check.Equals, int64(0))
+}

--- a/overlord/snapshotstate/export_test.go
+++ b/overlord/snapshotstate/export_test.go
@@ -142,6 +142,14 @@ func MockBackendCleanup(f func(*backend.RestoreState)) (restore func()) {
 	}
 }
 
+func MockBackendEstimateSnapshotSize(f func(*snap.Info) (int64, error)) (restore func()) {
+	old := backendEstimateSnapshotSize
+	backendEstimateSnapshotSize = f
+	return func() {
+		backendEstimateSnapshotSize = old
+	}
+}
+
 func MockConfigGetSnapConfig(f func(*state.State, string) (*json.RawMessage, error)) (restore func()) {
 	old := configGetSnapConfig
 	configGetSnapConfig = f

--- a/overlord/snapshotstate/snapshotmgr.go
+++ b/overlord/snapshotstate/snapshotmgr.go
@@ -399,6 +399,7 @@ func delayedCrossMgrInit() {
 	// hook automatic snapshots into snapstate logic
 	snapstate.AutomaticSnapshot = AutomaticSnapshot
 	snapstate.AutomaticSnapshotExpiration = AutomaticSnapshotExpiration
+	snapstate.EstimateSnapshotSize = EstimateSnapshotSize
 }
 
 func MockBackendSave(f func(context.Context, uint64, *snap.Info, map[string]interface{}, []string, *backend.Flags) (*client.Snapshot, error)) (restore func()) {

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -41,6 +41,7 @@ var (
 	snapstateAll                     = snapstate.All
 	snapstateCheckChangeConflictMany = snapstate.CheckChangeConflictMany
 	backendIter                      = backend.Iter
+	backendEstimateSnapshotSize      = backend.EstimateSnapshotSize
 
 	// Default expiration time for automatic snapshots, if not set by the user
 	defaultAutomaticSnapshotExpiration = time.Hour * 24 * 31
@@ -79,6 +80,25 @@ func allActiveSnapNames(st *state.State) ([]string, error) {
 	sort.Strings(names)
 
 	return names, nil
+}
+
+func EstimateSnapshotSize(st *state.State, instanceName string) (int64, error) {
+	cur, err := snapstateCurrentInfo(st, instanceName)
+	if err != nil {
+		return 0, err
+	}
+	rawCfg, err := configGetSnapConfig(st, instanceName)
+	if err != nil {
+		return 0, err
+	}
+	sz, err := backendEstimateSnapshotSize(cur)
+	if err != nil {
+		return 0, err
+	}
+	if rawCfg != nil {
+		sz += int64(len([]byte(*rawCfg)))
+	}
+	return sz, nil
 }
 
 func AutomaticSnapshotExpiration(st *state.State) (time.Duration, error) {

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -78,6 +78,12 @@ func MockOsutilEnsureUserGroup(mock func(name string, id uint32, extraUsers bool
 	return func() { osutilEnsureUserGroup = old }
 }
 
+func MockOsutilCheckFreeSpace(mock func(path string, minSize uint64) error) (restore func()) {
+	old := osutilCheckFreeSpace
+	osutilCheckFreeSpace = mock
+	return func() { osutilCheckFreeSpace = old }
+}
+
 var (
 	CoreInfoInternal       = coreInfo
 	CheckSnap              = checkSnap

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -57,6 +57,9 @@ func (s *prereqSuite) SetUpTest(c *C) {
 	s.state.Set("seeded", true)
 	s.state.Set("refresh-privacy-key", "privacy-key")
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
+
+	restoreCheckFreeSpace := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error { return nil })
+	s.AddCleanup(restoreCheckFreeSpace)
 }
 
 func (s *prereqSuite) TestDoPrereqNothingToDo(c *C) {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -292,6 +292,7 @@ var snapReadInfo = snap.ReadInfo
 // AutomaticSnapshot allows to hook snapshot manager's AutomaticSnapshot.
 var AutomaticSnapshot func(st *state.State, instanceName string) (ts *state.TaskSet, err error)
 var AutomaticSnapshotExpiration func(st *state.State) (time.Duration, error)
+var EstimateSnapshotSize func(st *state.State, instanceName string) (int64, error)
 
 func readInfo(name string, si *snap.SideInfo, flags int) (*snap.Info, error) {
 	info, err := snapReadInfo(name, si)

--- a/tests/main/disk-space-awareness/task.yaml
+++ b/tests/main/disk-space-awareness/task.yaml
@@ -4,21 +4,38 @@ description: |
   Check that operations such as snap installation or snap removal (with an
   automatic snapshot) error out early if there is not enough disk space.
 
+# excluded on core16 because installing hello-world as part of the test would
+# not pull core as a base, which makes it tricky to resize tmpfs properly to
+# trigger error condition.
+systems: [-ubuntu-core-16-*]
+
 environment:
   TMPFSMOUNT: /var/lib/snapd
 
 prepare: |
+  # wait for first boot to be done
+  snap wait system seed.loaded
+
   systemctl stop snapd.{socket,service}
 
-  # mount /var/lib/snapd on a tmpfs
+  # mount /var/lib/snapd on a tmpfs and copy original contents there.
+  cp -ar /var/lib/snapd ./snapd.real
   mount -t tmpfs tmpfs -o size=500M,mode=0755 "$TMPFSMOUNT"
+  cp -ar ./snapd.real/* /var/lib/snapd/
 
   systemctl start snapd.{socket,service}
 
 restore: |
+  rm -rf ./snapd.real
   systemctl stop snapd.{socket,service}
   umount -l "$TMPFSMOUNT"
   systemctl start snapd.{socket,service}
+  if ! snap list | grep -q "core "; then
+    for mnt in $(ls /snap/core); do
+      umount "/snap/core/$mnt" || true
+    done
+    rm -rf /snap/core
+  fi
 
 execute: |
   resize() {
@@ -35,27 +52,35 @@ execute: |
   echo "Snap download fails with little disk space"
   NEWSIZE=$(expr $(get_disk_usage) + 1)
   resize "${NEWSIZE}M"
-  snap install hello-world 2>&1 | MATCH "Ensure prerequisites for \"hello-world\" are available \(cannot install snap base \"core\": insufficient space in \"/var/lib/snapd\", at least .* more is required\)"
+  dd if=/dev/zero of=/var/lib/snapd/filler bs=1024 count=1023
+  # note, the error differs slightly depending on the test system, e.g. on core18
+  # it fails on prerequisites when trying to download "core" base snap.
+  snap install hello-world 2>&1 | MATCH ".*cannot install .*: insufficient space in \"/var/lib/snapd\""
+  rm /var/lib/snapd/filler
 
-  # note, installing hello-world also pulls core snap.
   echo "And succeeds with enough space"
-  resize 600M
+  NEWSIZE=$(expr $(get_disk_usage) + 200)
+  resize "${NEWSIZE}M"
   snap install hello-world
 
-  # run the snap once to have data dirs created
-  hello-world
+  # automatic snapshots are not created on core systems, so skip remove test there
+  if [[ "$SPREAD_SYSTEM" != ubuntu-core-* ]]; then
+    # run the snap once to have data dirs created
+    hello-world
 
-  # create 4M filler in common directory to inflate backup size
-  dd if=/dev/zero of=/var/snap/hello-world/common/filler bs=1024 count=4096
+    # create 4M filler in common directory to inflate backup size
+    dd if=/dev/zero of=/var/snap/hello-world/common/filler bs=1024 count=4096
 
-  echo "Resizing the disk down with just 1MB extra"
-  NEWSIZE=$(expr $(get_disk_usage) + 1)
-  resize "${NEWSIZE}M"
+    echo "Resizing the disk down with just 1MB extra"
+    NEWSIZE=$(expr $(get_disk_usage) + 1)
+    resize "${NEWSIZE}M"
 
-  if snap remove hello-world > error.txt 2>&1; then
-    echo "expected snap remove hello-world to fail"
-    exit 1
+    if snap remove hello-world > error.txt 2>&1; then
+      echo "expected snap remove hello-world to fail"
+      exit 1
+    fi
+
+    MATCH "error: cannot remove \"hello-world\": cannot create automatic snapshot when" < error.txt
+    MATCH "removing last revision of the snap: insufficient space in" < error.txt
   fi
-  
-  MATCH "error: cannot remove \"hello-world\": cannot create automatic snapshot when" < error.txt
-  MATCH "removing last revision of the snap: insufficient space in" < error.txt
+

--- a/tests/main/disk-space-awareness/task.yaml
+++ b/tests/main/disk-space-awareness/task.yaml
@@ -1,0 +1,61 @@
+summary: Check that basic snap operation are aware of low disk space.
+
+description: |
+  Check that operations such as snap installation or snap removal (with an
+  automatic snapshot) error out early if there is not enough disk space.
+
+environment:
+  TMPFSMOUNT: /var/lib/snapd
+
+prepare: |
+  systemctl stop snapd.{socket,service}
+
+  # mount /var/lib/snapd on a tmpfs
+  mount -t tmpfs tmpfs -o size=500M,mode=0755 "$TMPFSMOUNT"
+
+  systemctl start snapd.{socket,service}
+
+restore: |
+  systemctl stop snapd.{socket,service}
+  umount -l "$TMPFSMOUNT"
+  systemctl start snapd.{socket,service}
+
+execute: |
+  resize() {
+    # remount can increase/decrease the size as long as it is enough for
+    # already stored data.
+    mount -o remount,size="$1",mode=0755 "$TMPFSMOUNT"
+  }
+
+  # disk usage, in MB
+  get_disk_usage() {
+    echo $(du -s --block-size=1048576 "$TMPFSMOUNT" | awk '{print $1}')
+  }
+
+  echo "Snap download fails with little disk space"
+  NEWSIZE=$(expr $(get_disk_usage) + 1)
+  resize "${NEWSIZE}M"
+  snap install hello-world 2>&1 | MATCH "Ensure prerequisites for \"hello-world\" are available \(cannot install snap base \"core\": insufficient space in \"/var/lib/snapd\", at least .* more is required\)"
+
+  # note, installing hello-world also pulls core snap.
+  echo "And succeeds with enough space"
+  resize 600M
+  snap install hello-world
+
+  # run the snap once to have data dirs created
+  hello-world
+
+  # create 4M filler in common directory to inflate backup size
+  dd if=/dev/zero of=/var/snap/hello-world/common/filler bs=1024 count=4096
+
+  echo "Resizing the disk down with just 1MB extra"
+  NEWSIZE=$(expr $(get_disk_usage) + 1)
+  resize "${NEWSIZE}M"
+
+  if snap remove hello-world > error.txt 2>&1; then
+    echo "expected snap remove hello-world to fail"
+    exit 1
+  fi
+  
+  MATCH "error: cannot remove \"hello-world\": cannot create automatic snapshot when" < error.txt
+  MATCH "removing last revision of the snap: insufficient space in" < error.txt


### PR DESCRIPTION
Integrate free disk space checks with install/refresh (before downloading) and remove ops (only if automatic snapshot needs to be created). Add spread test.

Based on #9001 
