### PR TITLE
bootloader: add helper for getting recovery system environment variables

### DIFF
--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -96,6 +96,7 @@ type installableBootloader interface {
 type RecoveryAwareBootloader interface {
 	Bootloader
 	SetRecoverySystemEnv(recoverySystemDir string, values map[string]string) error
+	GetRecoverySystemEnv(recoverySystemDir string, key string) (string, error)
 }
 
 type ExtractedRecoveryKernelImageBootloader interface {

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -413,3 +413,30 @@ func (b *MockManagedAssetsBootloader) CommandLine(args []string) (string, error)
 	line := strings.Join(append([]string{b.StaticCommandLine}, args...), " ")
 	return strings.TrimSpace(line), nil
 }
+
+// MockManagedAssetsRecoveryAwreBootloader mocks a bootloader implementing the
+// bootloader.ManagedAssetsBootloader and bootloader.RecoveryAwareBootloader
+// interfaces.
+type MockManagedAssetsRecoveryAwareBootloader struct {
+	*MockManagedAssetsBootloader
+
+	EnvVars map[string]string
+}
+
+func (b *MockBootloader) WithManagedAssetsRecoveryAware() *MockManagedAssetsRecoveryAwareBootloader {
+	return &MockManagedAssetsRecoveryAwareBootloader{
+		MockManagedAssetsBootloader: &MockManagedAssetsBootloader{
+			MockBootloader: b,
+		},
+		EnvVars: make(map[string]string),
+	}
+}
+
+func (b *MockManagedAssetsRecoveryAwareBootloader) SetRecoverySystemEnv(systemDir string, env map[string]string) error {
+	b.EnvVars = env
+	return nil
+}
+
+func (b *MockManagedAssetsRecoveryAwareBootloader) GetRecoverySystemEnv(systemDir, key string) (string, error) {
+	return b.EnvVars[key], nil
+}

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -205,6 +205,16 @@ func (b *MockRecoveryAwareBootloader) SetRecoverySystemEnv(recoverySystemDir str
 	return nil
 }
 
+// GetRecoverySystemEnv gets the recovery system environment bootloader
+// variables; part of RecoveryAwareBootloader.
+func (b *MockRecoveryAwareBootloader) GetRecoverySystemEnv(recoverySystemDir, key string) (string, error) {
+	if recoverySystemDir == "" {
+		panic("MockBootloader.GetRecoverySystemEnv called without recoverySystemDir")
+	}
+	b.RecoverySystemDir = recoverySystemDir
+	return b.RecoverySystemBootVars[key], nil
+}
+
 // MockExtractedRunKernelImageBootloader mocks a bootloader
 // implementing the ExtractedRunKernelImageBootloader interface.
 type MockExtractedRunKernelImageBootloader struct {

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -131,6 +131,21 @@ func (g *grub) SetRecoverySystemEnv(recoverySystemDir string, values map[string]
 	return genv.Save()
 }
 
+func (g *grub) GetRecoverySystemEnv(recoverySystemDir string, key string) (string, error) {
+	if recoverySystemDir == "" {
+		return "", fmt.Errorf("internal error: recoverySystemDir unset")
+	}
+	recoverySystemGrubEnv := filepath.Join(g.rootdir, recoverySystemDir, "grubenv")
+	genv := grubenv.NewEnv(recoverySystemGrubEnv)
+	if err := genv.Load(); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return genv.Get(key), nil
+}
+
 func (g *grub) ConfigFile() string {
 	return filepath.Join(g.dir(), "grub.cfg")
 }


### PR DESCRIPTION
We have `SetRecoverySystemEnv`, for completeness and future use in composing kernel command line, the PR adds `GetRecoverySystemEnv`. This bit is a dependency for more tweaks in #8993
