### PR TITLE
tests/lib: account for changes in arch package file name extension

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -479,7 +479,7 @@ distro_install_build_snapd(){
                 ;;
             arch-*)
                 # shellcheck disable=SC2125
-                packages="${GOHOME}"/snapd*.pkg.tar.xz
+                packages="${GOHOME}"/snapd*.pkg.tar.*
                 ;;
             *)
                 exit 1

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -189,7 +189,9 @@ build_arch_pkg() {
     chown -R test:test /tmp/pkg
     su -l -c "cd /tmp/pkg && WITH_TEST_KEYS=1 makepkg -f --nocheck" test
 
-    cp /tmp/pkg/snapd*.pkg.tar.xz "${GOPATH%%:*}"
+    # /etc/makepkg.conf defines PKGEXT which drives the compression alg and sets
+    # the package file name extension, keep it simple and try a glob instead
+    cp /tmp/pkg/snapd*.pkg.tar.* "${GOPATH%%:*}"
 }
 
 download_from_published(){


### PR DESCRIPTION
Arch has switched the default package compression (and thus package file name
extension) from .pkg.tar.xz to .pkg.tar.zstd. Ideally we should extract the
right value from /etc/makepkg.conf, however a simple glob should work too.

