### PR TITLE
snapshotstate: move sizer to osutil.Sizer()

### DIFF
--- a/osutil/sizer.go
+++ b/osutil/sizer.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,18 +17,24 @@
  *
  */
 
-package backend
+// XXX: not a great fit for osutil but we have no ioutil and even if we
+// did the name ioutil is taken so we would need something else.
+package osutil
 
-type sizer struct {
+type Sizer struct {
 	size int64
 }
 
-func (sz *sizer) Write(data []byte) (n int, err error) {
+func (sz *Sizer) Write(data []byte) (n int, err error) {
 	n = len(data)
 	sz.size += int64(n)
 	return
 }
 
-func (sz *sizer) Reset() {
+func (sz *Sizer) Reset() {
 	sz.size = 0
+}
+
+func (sz *Sizer) Size() int64 {
+	return sz.size
 }

--- a/osutil/sizer_test.go
+++ b/osutil/sizer_test.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"io"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type sizerTestSuite struct{}
+
+var _ = Suite(&sizerTestSuite{})
+
+func (s *sizerTestSuite) TestSizer(c *C) {
+	sz := &osutil.Sizer{}
+	c.Check(sz.Size(), Equals, int64(0))
+
+	io.WriteString(sz, "12345")
+	c.Check(sz.Size(), Equals, int64(5))
+	io.WriteString(sz, "12345")
+	c.Check(sz.Size(), Equals, int64(10))
+
+	sz.Reset()
+	c.Check(sz.Size(), Equals, int64(0))
+	io.WriteString(sz, "12345")
+	c.Check(sz.Size(), Equals, int64(5))
+}

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -299,7 +299,7 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 		return err
 	}
 
-	var sz sizer
+	var sz osutil.Sizer
 	hasher := crypto.SHA3_384.New()
 
 	cmd := tarAsUser(username, tarArgs...)
@@ -319,7 +319,7 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 	}
 
 	snapshot.SHA3_384[entry] = fmt.Sprintf("%x", hasher.Sum(nil))
-	snapshot.Size += sz.size
+	snapshot.Size += sz.Size()
 
 	return nil
 }

--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -72,7 +72,7 @@ func Open(fn string) (reader *Reader, e error) {
 	}
 
 	// first try to load the metadata itself
-	var sz sizer
+	var sz osutil.Sizer
 	hasher := crypto.SHA3_384.New()
 	metaReader, metaSize, err := zipMember(f, metadataName)
 	if err != nil {
@@ -91,8 +91,8 @@ func Open(fn string) (reader *Reader, e error) {
 		return reader, errors.New(reader.Broken)
 	}
 
-	if sz.size != metaSize {
-		reader.Broken = fmt.Sprintf("declared metadata size (%d) does not match actual (%d)", metaSize, sz.size)
+	if sz.Size() != metaSize {
+		reader.Broken = fmt.Sprintf("declared metadata size (%d) does not match actual (%d)", metaSize, sz.Size())
 		return reader, errors.New(reader.Broken)
 	}
 
@@ -110,8 +110,8 @@ func Open(fn string) (reader *Reader, e error) {
 		reader.Broken = err.Error()
 		return reader, err
 	}
-	if sz.size != metaHashSize {
-		reader.Broken = fmt.Sprintf("declared hash size (%d) does not match actual (%d)", metaHashSize, sz.size)
+	if sz.Size() != metaHashSize {
+		reader.Broken = fmt.Sprintf("declared hash size (%d) does not match actual (%d)", metaHashSize, sz.Size())
 		return reader, errors.New(reader.Broken)
 	}
 	if expectedMetaHash := string(bytes.TrimSpace(metaHashBuf)); actualMetaHash != expectedMetaHash {
@@ -190,7 +190,7 @@ func (r *Reader) Restore(ctx context.Context, current snap.Revision, usernames [
 	isRoot := sys.Geteuid() == 0
 	si := snap.MinimalPlaceInfo(r.Snap, r.Revision)
 	hasher := crypto.SHA3_384.New()
-	var sz sizer
+	var sz osutil.Sizer
 
 	var curdir string
 	if !current.Unset() {
@@ -324,9 +324,9 @@ func (r *Reader) Restore(ctx context.Context, current snap.Revision, usernames [
 			return rs, fmt.Errorf("tar failed: %v", err)
 		}
 
-		if sz.size != expectedSize {
+		if sz.Size() != expectedSize {
 			return rs, fmt.Errorf("snapshot %q entry %q expected size (%d) does not match actual (%d)",
-				r.Name(), entry, expectedSize, sz.size)
+				r.Name(), entry, expectedSize, sz.Size())
 		}
 
 		if actualHash := fmt.Sprintf("%x", hasher.Sum(nil)); actualHash != expectedHash {


### PR DESCRIPTION
This commit moves the "sizer" io.Writer out into the osutil package
because it turns out we need a writer that just counts the amount
of bytes written in various places so it makes sense to have a
helper for this.

This was suggested in 
https://github.com/snapcore/snapd/pull/8982#discussion_r454284099