### PR TITLE
cmd/snap-preseed: handle relative chroot path

### DIFF
--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -80,7 +81,11 @@ func run(parser *flags.Parser, args []string) error {
 		return fmt.Errorf("need chroot path as argument")
 	}
 
-	chrootDir := rest[0]
+	chrootDir, err := filepath.Abs(rest[0])
+	if err != nil {
+		return err
+	}
+
 	// safety check
 	if chrootDir == "/" {
 		return fmt.Errorf("cannot run snap-preseed against /")

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -205,6 +205,16 @@ func (s *startPreseedSuite) TestRunPreseedHappy(c *C) {
 
 	c.Assert(mockTargetSnapd.Calls(), HasLen, 1)
 	c.Check(mockTargetSnapd.Calls()[0], DeepEquals, []string{"snapd"})
+
+	// relative chroot path works too
+	tmpDirPath, relativeChroot := filepath.Split(tmpDir)
+	pwd, err := os.Getwd()
+	c.Assert(err, IsNil)
+	defer func() {
+		os.Chdir(pwd)
+	}()
+	c.Assert(os.Chdir(tmpDirPath), IsNil)
+	c.Check(main.Run(parser, []string{relativeChroot}), IsNil)
 }
 
 type Fake16Seed struct {

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -66,3 +66,7 @@ execute: |
   echo "Running preseeeding again should succeed"
   /usr/lib/snapd/snap-preseed "$IMAGE_MOUNTPOINT"
 
+  echo "And running snap-preseed with a relative path works"
+  cd /mnt
+  /usr/lib/snapd/snap-preseed --reset cloudimg
+  /usr/lib/snapd/snap-preseed cloudimg


### PR DESCRIPTION
It was found out that snap-preseed doesn't handle relative chroot path argument and fails with a confusing error on mountpoints checks, e.g.

```
error: cannot preseed without the following mountpoints:
 - chroot/dev
 - chroot/proc
 - chroot/sys/kernel/security
```

This fails because mountpoint validation expects absolute paths when matching mount table entries.