### PR TITLE
sysconfig/cloudinit: add CloudInitStatus func + CloudInitState type

### DIFF
--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -23,8 +23,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 )
 
@@ -87,4 +90,76 @@ func configureCloudInit(opts *Options) (err error) {
 		err = installCloudInitCfg(opts.CloudInitSrcDir, WritableDefaultsDir(opts.TargetRootDir))
 	}
 	return err
+}
+
+// CloudInitState represents the various cloud-init states
+type CloudInitState int
+
+var (
+	// the (?m) is needed since cloud-init output will have newlines
+	cloudInitStatusRe = regexp.MustCompile(`(?m)^status: (.*)$`)
+
+	cloudInitSnapdRestrictFile = "/etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+)
+
+const (
+	// CloudInitDisabledPermanently is when cloud-init is disabled as per the
+	// cloud-init.disabled file.
+	CloudInitDisabledPermanently CloudInitState = iota
+	// CloudInitRestrictedBySnapd is when cloud-init has been restricted by
+	// snapd with a specific config file.
+	CloudInitRestrictedBySnapd
+	// CloudInitUntriggered is when cloud-init is disabled because nothing has
+	// triggered it to run, but it could still be run.
+	CloudInitUntriggered
+	// CloudInitDone is when cloud-init has been run on this boot.
+	CloudInitDone
+	// CloudInitRunning is when cloud-init is still running/processing and has
+	// not finished yet.
+	CloudInitRunning
+	// CloudInitErrored is when cloud-init tried to run, but failed or had invalid
+	// configuration.
+	CloudInitErrored
+)
+
+func cloudInitDisabledByFile() bool {
+	disabledFile := filepath.Join(dirs.GlobalRootDir, "etc/cloud/cloud-init.disabled")
+	return osutil.FileExists(disabledFile)
+}
+
+// CloudInitStatus returns the current status of cloud-init.
+func CloudInitStatus() (CloudInitState, error) {
+	// if cloud-init has been restricted by snapd, check that first
+	snapdRestrictingFile := filepath.Join(dirs.GlobalRootDir, cloudInitSnapdRestrictFile)
+	if osutil.FileExists(snapdRestrictingFile) {
+		return CloudInitRestrictedBySnapd, nil
+	}
+
+	out, err := exec.Command("cloud-init", "status").CombinedOutput()
+	if err != nil {
+		return CloudInitErrored, osutil.OutputErr(out, err)
+	}
+	// output should just be "status: <state>"
+	match := cloudInitStatusRe.FindSubmatch(out)
+	if len(match) != 2 {
+		return CloudInitErrored, fmt.Errorf("invalid cloud-init output: %v", osutil.OutputErr(out, err))
+	}
+	switch string(match[1]) {
+	case "disabled":
+		// check if it was permanently disabled by the disabled file or if it
+		// just "hasn't run" in which case it is untriggered
+		if cloudInitDisabledByFile() {
+			return CloudInitDisabledPermanently, nil
+		}
+		return CloudInitUntriggered, nil
+	case "error":
+		return CloudInitErrored, nil
+	case "done":
+		return CloudInitDone, nil
+	case "running":
+		return CloudInitRunning, nil
+	default:
+		// unknown what other state cloud-init could be in ...
+		return CloudInitErrored, fmt.Errorf("internal error: unexpected cloud-init status %q", string(match[1]))
+	}
 }

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -125,11 +125,6 @@ const (
 	CloudInitErrored
 )
 
-func cloudInitDisabledByFile() bool {
-	disabledFile := filepath.Join(dirs.GlobalRootDir, "etc/cloud/cloud-init.disabled")
-	return osutil.FileExists(disabledFile)
-}
-
 // CloudInitStatus returns the current status of cloud-init. Note that it will
 // first check for static file-based statuses first through the snapd
 // restriction file and the disabled file before consulting
@@ -146,7 +141,8 @@ func CloudInitStatus() (CloudInitState, error) {
 
 	// if it was explicitly disabled via the cloud-init disable file, then
 	// return special status for that
-	if cloudInitDisabledByFile() {
+	disabledFile := filepath.Join(dirs.GlobalRootDir, "etc/cloud/cloud-init.disabled")
+	if osutil.FileExists(disabledFile) {
 		return CloudInitDisabledPermanently, nil
 	}
 

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -168,9 +168,7 @@ func CloudInitStatus() (CloudInitState, error) {
 	case "done":
 		return CloudInitDone, nil
 	// "running" and "not run" are considered Enabled, see doc-comment
-	case "running":
-		fallthrough
-	case "not run":
+	case "running", "not run":
 		fallthrough
 	default:
 		// these states are all

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -114,9 +114,12 @@ const (
 	CloudInitUntriggered
 	// CloudInitDone is when cloud-init has been run on this boot.
 	CloudInitDone
-	// CloudInitRunning is when cloud-init is still running/processing and has
-	// not finished yet.
-	CloudInitRunning
+	// CloudInitEnabled is when cloud-init is active, but not necessarily
+	// finished. This matches the "running" and "not run" states from cloud-init
+	// as well as any other state that does not match any of the other defined
+	// states, as we are conservative in assuming that cloud-init is doing
+	// something.
+	CloudInitEnabled
 	// CloudInitErrored is when cloud-init tried to run, but failed or had invalid
 	// configuration.
 	CloudInitErrored
@@ -156,10 +159,13 @@ func CloudInitStatus() (CloudInitState, error) {
 		return CloudInitErrored, nil
 	case "done":
 		return CloudInitDone, nil
+	// "running" and "not run" are considered Enabled, see doc-comment
 	case "running":
-		return CloudInitRunning, nil
+		fallthrough
+	case "not run":
+		fallthrough
 	default:
-		// unknown what other state cloud-init could be in ...
-		return CloudInitErrored, fmt.Errorf("internal error: unexpected cloud-init status %q", string(match[1]))
+		// these states are all
+		return CloudInitEnabled, nil
 	}
 }

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -178,7 +178,7 @@ fi
 
 		// if the restricted file was there we don't call cloud-init status
 		var expCalls [][]string
-		if !t.restrictedFile {
+		if !t.restrictedFile && !t.disabledFile {
 			expCalls = [][]string{
 				{"cloud-init", "status"},
 			}

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -99,7 +99,17 @@ func (s *sysconfigSuite) TestCloudInitStatus(c *C) {
 		{
 			comment:         "running",
 			cloudInitOutput: "status: running",
-			exp:             sysconfig.CloudInitRunning,
+			exp:             sysconfig.CloudInitEnabled,
+		},
+		{
+			comment:         "not run",
+			cloudInitOutput: "status: not run",
+			exp:             sysconfig.CloudInitEnabled,
+		},
+		{
+			comment:         "new unrecognized state",
+			cloudInitOutput: "status: newfangledstatus",
+			exp:             sysconfig.CloudInitEnabled,
 		},
 		{
 			comment:        "restricted by snapd",
@@ -126,11 +136,6 @@ func (s *sysconfigSuite) TestCloudInitStatus(c *C) {
 			comment:         "broken cloud-init output",
 			cloudInitOutput: "broken cloud-init output",
 			expError:        "invalid cloud-init output: broken cloud-init output",
-		},
-		{
-			comment:         "new cloud-init status",
-			cloudInitOutput: "status: some-new-thing",
-			expError:        "internal error: unexpected cloud-init status \"some-new-thing\"",
 		},
 	}
 

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -82,6 +82,23 @@ func (s *sysconfigSuite) TestCloudInitInstalls(c *C) {
 	c.Check(filepath.Join(ubuntuDataCloudCfg, "bar.cfg"), testutil.FileEquals, "bar.cfg config")
 }
 
+func (s *sysconfigSuite) TestCloudInitStatusUnhappy(c *C) {
+	old := dirs.GlobalRootDir
+	dirs.SetRootDir(c.MkDir())
+	defer func() { dirs.SetRootDir(old) }()
+	cmd := testutil.MockCommand(c, "cloud-init", `
+echo cloud-init borken
+exit 1
+`)
+
+	status, err := sysconfig.CloudInitStatus()
+	c.Assert(err, ErrorMatches, "cloud-init borken")
+	c.Assert(status, Equals, sysconfig.CloudInitErrored)
+	c.Assert(cmd.Calls(), DeepEquals, [][]string{
+		{"cloud-init", "status"},
+	})
+}
+
 func (s *sysconfigSuite) TestCloudInitStatus(c *C) {
 	tt := []struct {
 		comment         string

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -22,6 +22,7 @@ package sysconfig_test
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -79,4 +80,106 @@ func (s *sysconfigSuite) TestCloudInitInstalls(c *C) {
 	ubuntuDataCloudCfg := filepath.Join(boot.InstallHostWritableDir, "_writable_defaults/etc/cloud/cloud.cfg.d/")
 	c.Check(filepath.Join(ubuntuDataCloudCfg, "foo.cfg"), testutil.FileEquals, "foo.cfg config")
 	c.Check(filepath.Join(ubuntuDataCloudCfg, "bar.cfg"), testutil.FileEquals, "bar.cfg config")
+}
+
+func (s *sysconfigSuite) TestCloudInitStatus(c *C) {
+	tt := []struct {
+		comment         string
+		cloudInitOutput string
+		exp             sysconfig.CloudInitState
+		restrictedFile  bool
+		disabledFile    bool
+		expError        string
+	}{
+		{
+			comment:         "done",
+			cloudInitOutput: "status: done",
+			exp:             sysconfig.CloudInitDone,
+		},
+		{
+			comment:         "running",
+			cloudInitOutput: "status: running",
+			exp:             sysconfig.CloudInitRunning,
+		},
+		{
+			comment:        "restricted by snapd",
+			restrictedFile: true,
+			exp:            sysconfig.CloudInitRestrictedBySnapd,
+		},
+		{
+			comment:         "disabled temporarily",
+			cloudInitOutput: "status: disabled",
+			exp:             sysconfig.CloudInitUntriggered,
+		},
+		{
+			comment:         "disabled permanently via file",
+			cloudInitOutput: "status: disabled",
+			disabledFile:    true,
+			exp:             sysconfig.CloudInitDisabledPermanently,
+		},
+		{
+			comment:         "errored",
+			cloudInitOutput: "status: error",
+			exp:             sysconfig.CloudInitErrored,
+		},
+		{
+			comment:         "broken cloud-init output",
+			cloudInitOutput: "broken cloud-init output",
+			expError:        "invalid cloud-init output: broken cloud-init output",
+		},
+		{
+			comment:         "new cloud-init status",
+			cloudInitOutput: "status: some-new-thing",
+			expError:        "internal error: unexpected cloud-init status \"some-new-thing\"",
+		},
+	}
+
+	for _, t := range tt {
+		old := dirs.GlobalRootDir
+		dirs.SetRootDir(c.MkDir())
+		defer func() { dirs.SetRootDir(old) }()
+		cmd := testutil.MockCommand(c, "cloud-init", fmt.Sprintf(`
+if [ "$1" = "status" ]; then
+	echo '%s'
+else 
+	echo "unexpected args, $"
+	exit 1
+fi
+		`, t.cloudInitOutput))
+
+		if t.disabledFile {
+			cloudDir := filepath.Join(dirs.GlobalRootDir, "etc/cloud")
+			err := os.MkdirAll(cloudDir, 0755)
+			c.Assert(err, IsNil)
+			err = ioutil.WriteFile(filepath.Join(cloudDir, "cloud-init.disabled"), nil, 0644)
+			c.Assert(err, IsNil)
+		}
+
+		if t.restrictedFile {
+			cloudDir := filepath.Join(dirs.GlobalRootDir, "etc/cloud/cloud.cfg.d")
+			err := os.MkdirAll(cloudDir, 0755)
+			c.Assert(err, IsNil)
+			err = ioutil.WriteFile(filepath.Join(cloudDir, "zzzz_snapd.cfg"), nil, 0644)
+			c.Assert(err, IsNil)
+		}
+
+		status, err := sysconfig.CloudInitStatus()
+		if t.expError != "" {
+			c.Assert(err, ErrorMatches, t.expError, Commentf(t.comment))
+		} else {
+			c.Assert(err, IsNil)
+			c.Assert(status, Equals, t.exp, Commentf(t.comment))
+		}
+
+		// if the restricted file was there we don't call cloud-init status
+		var expCalls [][]string
+		if !t.restrictedFile {
+			expCalls = [][]string{
+				{"cloud-init", "status"},
+			}
+		}
+
+		c.Assert(cmd.Calls(), DeepEquals, expCalls, Commentf(t.comment))
+		cmd.Restore()
+	}
 }

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -83,9 +83,6 @@ func (s *sysconfigSuite) TestCloudInitInstalls(c *C) {
 }
 
 func (s *sysconfigSuite) TestCloudInitStatusUnhappy(c *C) {
-	old := dirs.GlobalRootDir
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir(old) }()
 	cmd := testutil.MockCommand(c, "cloud-init", `
 echo cloud-init borken
 exit 1
@@ -139,10 +136,9 @@ func (s *sysconfigSuite) TestCloudInitStatus(c *C) {
 			exp:             sysconfig.CloudInitUntriggered,
 		},
 		{
-			comment:         "disabled permanently via file",
-			cloudInitOutput: "status: disabled",
-			disabledFile:    true,
-			exp:             sysconfig.CloudInitDisabledPermanently,
+			comment:      "disabled permanently via file",
+			disabledFile: true,
+			exp:          sysconfig.CloudInitDisabledPermanently,
 		},
 		{
 			comment:         "errored",


### PR DESCRIPTION
These are used to identify what state cloud-init is in for future manipulations of cloud-init during the running system on Ubuntu Core.

This is #3 from the snapd-private repo used to address the cloud-init fix.