### PR TITLE
interfaces/bluez: let slot access audio streams

### DIFF
--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -183,6 +183,9 @@ dbus (receive)
     path=/org/bluez{,/**}
     interface=org.freedesktop.DBus.*
     peer=(label=unconfined),
+
+# Allow access to bluetooth audio streams
+network bluetooth,
 `
 
 const bluezPermanentSlotSecComp = `


### PR DESCRIPTION
Let connected slots access audio streams.