### PR TITLE
tests: adjust xdg-open after launcher changes

### DIFF
--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -63,17 +63,6 @@ execute: |
         test "$(head -1 /tmp/xdg-open-output)" = "$1"
     }
 
-    if is_cgroupv2 ; then
-        # we are expecting the test to fail on a cgroup v2 system
-        if ensure_xdg_open_output "http://smoke-test-cgroupv2.com" 2> stderr.log ; then
-            echo "expected failure, but none happened"
-            exit 1
-        fi
-        MATCH 'WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement' < stderr.log
-        MATCH 'cannot find snap for connection: not supported' < stderr.log
-        exit 0
-    fi
-
     # Ensure http, https, mailto, snap and help work
     ensure_xdg_open_output "https://snapcraft.io"
     ensure_xdg_open_output "http://snapcraft.io"


### PR DESCRIPTION
Commit 31045a8c0dc15e3ca9d12bdaeb90fbf7cf266692 removed the code path
where userd launcher resolved the pid of the calling process to a snap
name - something that currently only works with cgroup v1, without
properly adjusting the test. Without this code the launcher is no longer
sensitive to cgroup v1 vs v2 and the expectation in the test is no
longer upheld.

This change was merged in https://github.com/snapcore/snapd/pull/9022
but apparently, since it was a cherry pick from a security release, the
review was hasty and the fact this broke master was unnoticed.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>