### PR TITLE
spread: add opensuse 15.2 and tumbleweed for qemu

### DIFF
--- a/packaging/opensuse-15.2
+++ b/packaging/opensuse-15.2
@@ -1,0 +1,1 @@
+opensuse

--- a/spread.yaml
+++ b/spread.yaml
@@ -268,6 +268,9 @@ backends:
             - amazon-linux-2-64:
                   username: ec2-user
                   password: ec2-user
+            - opensuse-15.2-64:
+                  username: opensuse
+                  password: opensuse
     autopkgtest:
         type: adhoc
         allocate: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -271,6 +271,9 @@ backends:
             - opensuse-15.2-64:
                   username: opensuse
                   password: opensuse
+            - opensuse-tumbleweed-64:
+                  username: opensuse
+                  password: opensuse
     autopkgtest:
         type: adhoc
         allocate: |


### PR DESCRIPTION
* spread.yaml: allow opensuse-15.2-64 qemu with opensuse/opensuse
* add packaging/opensuse/opensuse-15.2 symlink
* spread.yaml: allow opensuse-tumbleweed-64 qemu with opensuse/opensuse

References:
* https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.2/images/
* https://download.opensuse.org/tumbleweed/appliances/
* https://docs.openstack.org/image-guide/obtain-images.html
* https://blog.strandboge.com/2019/04/16/cloud-images-qemu-cloud-init-and-snapd-spread-tests/ (see 'UPDATE 2020-07-21')