### PR TITLE
.github/workflows/snap-build.yaml: build the snapd snap via GH Actions too

### DIFF
--- a/.github/workflows/snap-build.yaml
+++ b/.github/workflows/snap-build.yaml
@@ -11,11 +11,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Build the snapd snap
         uses: snapcore/action-build@v1
-      - name: Rename built snap file
-        run: |
-          sudo mv snapd*.snap snapd.snap
       - name: Uploading snap artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
-          name: snapd.snap
-          path: snapd.snap
+          name: snap-files
+          path: "*.snap"

--- a/.github/workflows/snap-build.yaml
+++ b/.github/workflows/snap-build.yaml
@@ -1,0 +1,21 @@
+name: Snap Build
+on:
+  pull_request:
+    branches: ["master", "release/**"]
+jobs:
+  build:
+    name: Build the snapd snap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build the snapd snap
+        uses: snapcore/action-build@v1
+      - name: Rename built snap file
+        run: |
+          sudo mv snapd*.snap snapd.snap
+      - name: Uploading snap artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: snapd.snap
+          path: snapd.snap


### PR DESCRIPTION
This will be useful if folks want to test a build of snapd from a branch or from a PR, as the artifact will be built and available for testing by just downloading it from the Actions page.