### PR TITLE
cmd/snap-bootstrap,seed: backport of uc20 PR's (2.45)

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -110,6 +110,26 @@ func generateMountsModeInstall(mst initramfsMountsState, recoverySystem string) 
 	return nil
 }
 
+// copyNetworkConfig copies the network configuration to the target
+// directory. This is used to copy the network configuration
+// data from a real uc20 ubuntu-data partition into a ephemeral one.
+func copyNetworkConfig(src, dst string) error {
+	for _, globEx := range []string{
+		// for network configuration setup by console-conf, etc.
+		// TODO:UC20: we want some way to "try" or "verify" the network
+		//            configuration before installing it onto recover mode,
+		//            because the network configuration could have been what was
+		//            broken so we don't want to break network configuration for
+		//            recover mode as well, but for now this is fine
+		"system-data/etc/netplan/*",
+	} {
+		if err := copyFromGlobHelper(src, dst, globEx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // copyUbuntuDataAuth copies the authenication files like
 //  - extrausers passwd,shadow etc
 //  - sshd host configuration
@@ -129,13 +149,6 @@ func copyUbuntuDataAuth(src, dst string) error {
 		// so that users have proper perms, i.e. console-conf added users are
 		// sudoers
 		"system-data/etc/sudoers.d/*",
-		// for network configuration setup by console-conf, etc.
-		// TODO:UC20: we want some way to "try" or "verify" the network
-		//            configuration before installing it onto recover mode,
-		//            because the network configuration could have been what was
-		//            broken so we don't want to break network configuration for
-		//            recover mode as well, but for now this is fine
-		"system-data/etc/netplan/*",
 		// so that the time in recover mode moves forward to what it was in run
 		// mode
 		// NOTE: we don't sync back the time movement from recover mode to run
@@ -144,35 +157,8 @@ func copyUbuntuDataAuth(src, dst string) error {
 		// problem to "lose" the time spent in recover mode
 		"system-data/var/lib/systemd/timesync/clock",
 	} {
-		matches, err := filepath.Glob(filepath.Join(src, globEx))
-		if err != nil {
+		if err := copyFromGlobHelper(src, dst, globEx); err != nil {
 			return err
-		}
-		for _, p := range matches {
-			comps := strings.Split(strings.TrimPrefix(p, src), "/")
-			for i := range comps {
-				part := filepath.Join(comps[0 : i+1]...)
-				fi, err := os.Stat(filepath.Join(src, part))
-				if err != nil {
-					return err
-				}
-				if fi.IsDir() {
-					if err := os.Mkdir(filepath.Join(dst, part), fi.Mode()); err != nil && !os.IsExist(err) {
-						return err
-					}
-					st, ok := fi.Sys().(*syscall.Stat_t)
-					if !ok {
-						return fmt.Errorf("cannot get stat data: %v", err)
-					}
-					if err := os.Chown(filepath.Join(dst, part), int(st.Uid), int(st.Gid)); err != nil {
-						return err
-					}
-				} else {
-					if err := osutil.CopyFile(p, filepath.Join(dst, part), osutil.CopyFlagPreserveAll); err != nil {
-						return err
-					}
-				}
-			}
 		}
 	}
 
@@ -187,7 +173,43 @@ func copyUbuntuDataAuth(src, dst string) error {
 	return nil
 }
 
+func copyFromGlobHelper(src, dst, globEx string) error {
+	matches, err := filepath.Glob(filepath.Join(src, globEx))
+	if err != nil {
+		return err
+	}
+	for _, p := range matches {
+		comps := strings.Split(strings.TrimPrefix(p, src), "/")
+		for i := range comps {
+			part := filepath.Join(comps[0 : i+1]...)
+			fi, err := os.Stat(filepath.Join(src, part))
+			if err != nil {
+				return err
+			}
+			if fi.IsDir() {
+				if err := os.Mkdir(filepath.Join(dst, part), fi.Mode()); err != nil && !os.IsExist(err) {
+					return err
+				}
+				st, ok := fi.Sys().(*syscall.Stat_t)
+				if !ok {
+					return fmt.Errorf("cannot get stat data: %v", err)
+				}
+				if err := os.Chown(filepath.Join(dst, part), int(st.Uid), int(st.Gid)); err != nil {
+					return err
+				}
+			} else {
+				if err := osutil.CopyFile(p, filepath.Join(dst, part), osutil.CopyFlagPreserveAll); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 func generateMountsModeRecover(mst initramfsMountsState, recoverySystem string) error {
+	// steps 1 and 2 are shared with install mode
 	allMounted, err := generateMountsCommonInstallRecover(mst, recoverySystem)
 	if err != nil {
 		return err
@@ -212,14 +234,17 @@ func generateMountsModeRecover(mst initramfsMountsState, recoverySystem string) 
 		return nil
 	}
 
-	// now copy the auth data from the real ubuntu-data dir to the ephemeral
-	// ubuntu-data dir
+	// 4. final step: copy the auth data and network config from
+	//    the real ubuntu-data dir to the ephemeral ubuntu-data
+	//    dir, write the modeenv to the tmpfs data, and disable
+	//    cloud-init in recover mode
 	if err := copyUbuntuDataAuth(boot.InitramfsHostUbuntuDataDir, boot.InitramfsDataDir); err != nil {
 		return err
 	}
+	if err := copyNetworkConfig(boot.InitramfsHostUbuntuDataDir, boot.InitramfsDataDir); err != nil {
+		return err
+	}
 
-	// n+2: final step: write $(tmpfs-data)/var/lib/snapd/modeenv - this
-	//      is the tmpfs we just created above
 	modeEnv := &boot.Modeenv{
 		Mode:           "recover",
 		RecoverySystem: recoverySystem,

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -121,6 +121,9 @@ func copyUbuntuDataAuth(src, dst string) error {
 		"system-data/var/lib/extrausers/*",
 		"system-data/etc/ssh/*",
 		"user-data/*/.ssh/*",
+		// this ensures we get proper authentication to snapd from "snap"
+		// commands in recover mode
+		"user-data/*/.snap/auth.json",
 		// this ensures we also get non-ssh enabled accounts copied
 		"user-data/*/.profile",
 		// so that users have proper perms, i.e. console-conf added users are
@@ -162,7 +165,7 @@ func copyUbuntuDataAuth(src, dst string) error {
 	// ensure the user state is transferred as well
 	srcState := filepath.Join(src, "system-data/var/lib/snapd/state.json")
 	dstState := filepath.Join(dst, "system-data/var/lib/snapd/state.json")
-	err := state.CopyState(srcState, dstState, []string{"auth.users"})
+	err := state.CopyState(srcState, dstState, []string{"auth.users", "auth.macaroon-key", "auth.last-id"})
 	if err != nil && err != state.ErrNoState {
 		return fmt.Errorf("cannot copy user state: %v", err)
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -117,10 +117,12 @@ func copyNetworkConfig(src, dst string) error {
 	for _, globEx := range []string{
 		// for network configuration setup by console-conf, etc.
 		// TODO:UC20: we want some way to "try" or "verify" the network
-		//            configuration before installing it onto recover mode,
-		//            because the network configuration could have been what was
-		//            broken so we don't want to break network configuration for
-		//            recover mode as well, but for now this is fine
+		//            configuration or to only use known-to-be-good network
+		//            configuration i.e. from ubuntu-save before installing it
+		//            onto recover mode, because the network configuration could
+		//            have been what was broken so we don't want to break
+		//            network configuration for recover mode as well, but for
+		//            now this is fine
 		"system-data/etc/netplan/*",
 	} {
 		if err := copyFromGlobHelper(src, dst, globEx); err != nil {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -129,6 +129,20 @@ func copyUbuntuDataAuth(src, dst string) error {
 		// so that users have proper perms, i.e. console-conf added users are
 		// sudoers
 		"system-data/etc/sudoers.d/*",
+		// for network configuration setup by console-conf, etc.
+		// TODO:UC20: we want some way to "try" or "verify" the network
+		//            configuration before installing it onto recover mode,
+		//            because the network configuration could have been what was
+		//            broken so we don't want to break network configuration for
+		//            recover mode as well, but for now this is fine
+		"system-data/etc/netplan/*",
+		// so that the time in recover mode moves forward to what it was in run
+		// mode
+		// NOTE: we don't sync back the time movement from recover mode to run
+		// mode currently, unclear how/when we could do this, but recover mode
+		// isn't meant to be long lasting and as such it's probably not a big
+		// problem to "lose" the time spent in recover mode
+		"system-data/var/lib/systemd/timesync/clock",
 	} {
 		matches, err := filepath.Glob(filepath.Join(src, globEx))
 		if err != nil {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1418,7 +1418,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep3Encrypted(c *C
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, fmt.Sprintf("%s-model-measured", s.sysLabel)), testutil.FilePresent)
 }
 
-var mockStateContent = `{"data":{"auth":{"users":[{"name":"mvo"}]}},"some":{"other":"stuff"}}`
+var mockStateContent = `{"data":{"auth":{"users":[{"id":1,"name":"mvo"}],"macaroon-key":"not-a-cookie","last-id":1}},"some":{"other":"stuff"}}`
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=recover snapd_recovery_system="+s.sysLabel)
@@ -1453,6 +1453,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 		// user ssh
 		"user-data/user1/.ssh/authorized_keys",
 		"user-data/user2/.ssh/authorized_keys",
+		// user snap authentication
+		"user-data/user1/.snap/auth.json",
 		// sudoers
 		"system-data/etc/sudoers.d/create-user-test",
 	}
@@ -1461,6 +1463,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeStep4(c *C) {
 		"system-data/etc/passwd",
 		"user-data/user1/some-random-data",
 		"user-data/user2/other-random-data",
+		"user-data/user2/.snap/sneaky-not-auth.json",
 	}
 	for _, mockAuthFile := range append(mockAuthFiles, mockUnrelatedFiles...) {
 		p := filepath.Join(hostUbuntuData, mockAuthFile)
@@ -1501,7 +1504,7 @@ recovery_system=20191118
 		c.Check(fiParent.Mode(), Equals, os.FileMode(os.ModeDir|0750))
 	}
 
-	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"users":[{"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0}`)
+	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0}`)
 }
 
 func mockSecbootTPM(c *C) (tpm *secboot.TPMConnection, restore func()) {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -448,8 +448,16 @@ func (s *seed20) loadModelMeta(filterEssential func(*asserts.ModelSnap) bool, tm
 		}
 	}
 
+	modelSnaps := allSnaps
+	if essentialOnly {
+		// TODO:UC20: maybe just have Model.EssentialSnaps ?
+		expectedEssentialSnaps := len(model.RequiredWithEssentialSnaps()) - len(model.RequiredNoEssentialSnaps())
+		// we don't need to look further than the essential snaps
+		modelSnaps = modelSnaps[:expectedEssentialSnaps]
+	}
+
 	essential := true
-	for _, modelSnap := range allSnaps {
+	for _, modelSnap := range modelSnaps {
 		seedSnap, err := s.addModelSnap(modelSnap, essential, filter, tm)
 		if err != nil {
 			if err == errFiltered {

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -704,7 +704,8 @@ func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
 	s.makeSnap(c, "core20", "")
 	s.makeSnap(c, "pc-kernel=20", "")
 	s.makeSnap(c, "pc=20", "")
-	s.makeSnap(c, "required20", "developerid")
+	s.makeSnap(c, "core18", "")
+	s.makeSnap(c, "required18", "developerid")
 
 	sysLabel := "20191018"
 	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
@@ -725,8 +726,13 @@ func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
 				"default-channel": "20",
 			},
 			map[string]interface{}{
-				"name": "required20",
-				"id":   s.AssertedSnapID("required20"),
+				"name": "core18",
+				"id":   s.AssertedSnapID("core18"),
+				"type": "base",
+			},
+			map[string]interface{}{
+				"name": "required18",
+				"id":   s.AssertedSnapID("required18"),
 			}},
 	}, nil)
 
@@ -761,11 +767,16 @@ func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
 		Required:      true,
 		Channel:       "20",
 	}
-	required20Snap := &seed.Snap{
-		Path: s.expectedPath("required20"),
+	core18Snap := &seed.Snap{
+		// no EssentialType, so it's always hidden, shouldn't matter
+		// because we should not look at it
+		Path: s.expectedPath("core18"),
+	}
+	required18Snap := &seed.Snap{
+		Path: s.expectedPath("required18"),
 	}
 
-	all := []*seed.Snap{snapdSnap, pcKernelSnap, core20Snap, pcSnap, required20Snap}
+	all := []*seed.Snap{snapdSnap, pcKernelSnap, core20Snap, pcSnap, core18Snap, required18Snap}
 
 	tests := []struct {
 		onlyTypes []snap.Type


### PR DESCRIPTION
This is the first backport to 2.45, the other one that is mainly just for the writable defaults work has conflicts that I am still working out...

This is the following PR's :
* https://github.com/snapcore/snapd/pull/8890
* https://github.com/snapcore/snapd/pull/8652
* https://github.com/snapcore/snapd/pull/8795