### PR TITLE
tests/main/interfaces-pulseaudio: disable start limit checking for pulseaudio service / enable debug logging

### DIFF
--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -71,6 +71,11 @@ prepare: |
     test -e ~test/.config/pulse/cookie || test -e ~test/.config/pulse/.pulse-cookie
     tests.cleanup defer rm -rf ~test/.config/pulse
 
+    # enable debug logging in pulseaudio
+    cp /etc/pulse/daemon.conf /etc/pulse/daemon.conf.backup
+    echo 'log-level = debug' >> /etc/pulse/daemon.conf
+    tests.cleanup defer mv /etc/pulse/daemon.conf.backup /etc/pulse/daemon.conf
+
 debug: |
     echo "Files present in the test user's home directory"
     test -d /home/test && find /home/test
@@ -80,6 +85,8 @@ debug: |
     test -d /home/user/12345 && find /run/user/12345
     echo "Processes running as the test user"
     ps -u test
+    echo "Pulseaudio log"
+    tests.session -u test exec journalctl --user -u pulseaudio.service || true
 
 restore: |
     tests.cleanup restore

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -83,6 +83,8 @@ prepare: |
     StartLimitBurst=0
     EOF
     tests.cleanup defer rm /etc/systemd/user/pulseaudio.service.d/no-start-limit.conf
+    # reload user's systemd instance
+    tests.session -u test exec systemctl daemon-reload --user
 
 debug: |
     echo "Files present in the test user's home directory"

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -76,6 +76,14 @@ prepare: |
     echo 'log-level = debug' >> /etc/pulse/daemon.conf
     tests.cleanup defer mv /etc/pulse/daemon.conf.backup /etc/pulse/daemon.conf
 
+    # disable start limit checking for pulseaudio service
+    mkdir -p /etc/systemd/user/pulseaudio.service.d
+    cat <<-EOF > /etc/systemd/user/pulseaudio.service.d/no-start-limit.conf
+    [Unit]
+    StartLimitBurst=0
+    EOF
+    tests.cleanup defer rm /etc/systemd/user/pulseaudio.service.d/no-start-limit.conf
+
 debug: |
     echo "Files present in the test user's home directory"
     test -d /home/test && find /home/test

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -74,6 +74,14 @@ prepare: |
     echo 'log-level = debug' >> /etc/pulse/daemon.conf
     tests.cleanup defer mv /etc/pulse/daemon.conf.backup /etc/pulse/daemon.conf
 
+    # disable start limit checking for pulseaudio service
+    mkdir -p /etc/systemd/user/pulseaudio.service.d
+    cat <<-EOF > /etc/systemd/user/pulseaudio.service.d/no-start-limit.conf
+    [Unit]
+    StartLimitBurst=0
+    EOF
+    tests.cleanup defer rm /etc/systemd/user/pulseaudio.service.d/no-start-limit.conf
+
 debug: |
     echo "Files present in the test user's home directory"
     test -d /home/test && find /home/test

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -69,6 +69,11 @@ prepare: |
     test -e ~test/.config/pulse/cookie || test -e ~test/.config/pulse/.pulse-cookie
     tests.cleanup defer rm -rf ~test/.config/pulse
 
+    # enable debug logging in pulseaudio
+    cp /etc/pulse/daemon.conf /etc/pulse/daemon.conf.backup
+    echo 'log-level = debug' >> /etc/pulse/daemon.conf
+    tests.cleanup defer mv /etc/pulse/daemon.conf.backup /etc/pulse/daemon.conf
+
 debug: |
     echo "Files present in the test user's home directory"
     test -d /home/test && find /home/test
@@ -78,6 +83,8 @@ debug: |
     test -d /home/user/12345 && find /run/user/12345
     echo "Processes running as the test user"
     ps -u test
+    echo "Pulseaudio log"
+    tests.session -u test exec journalctl --user -u pulseaudio.service || true
 
 restore: |
     tests.cleanup restore

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -81,6 +81,8 @@ prepare: |
     StartLimitBurst=0
     EOF
     tests.cleanup defer rm /etc/systemd/user/pulseaudio.service.d/no-start-limit.conf
+    # reload user's systemd instance
+    tests.session -u test exec systemctl daemon-reload --user
 
 debug: |
     echo "Files present in the test user's home directory"


### PR DESCRIPTION
Trying to debug why the test keeps failing on 20.10

