### PR TITLE
many: backport _writable_defaults dir changes (2.45)

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -256,8 +256,10 @@ func generateMountsModeRecover(mst initramfsMountsState, recoverySystem string) 
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
 	}
-	cloudDir := sysconfig.WritableDefaultsDir(boot.InitramfsWritableDir)
-	if err := sysconfig.DisableCloudInit(cloudDir); err != nil {
+	// we need to put the file to disable cloud-init in the
+	// _writable_defaults dir for writable-paths(5) to install it properly
+	writableDefaultsDir := sysconfig.WritableDefaultsDir(boot.InitramfsWritableDir)
+	if err := sysconfig.DisableCloudInit(writableDefaultsDir); err != nil {
 		return err
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -100,8 +100,10 @@ func generateMountsModeInstall(mst initramfsMountsState, recoverySystem string) 
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
 	}
-	// and disable cloud-init in install mode
-	if err := sysconfig.DisableCloudInit(boot.InitramfsWritableDir); err != nil {
+	// we need to put the file to disable cloud-init in the
+	// _writable_defaults dir for writable-paths(5) to install it properly
+	writableDefaultsDir := sysconfig.WritableDefaultsDir(boot.InitramfsWritableDir)
+	if err := sysconfig.DisableCloudInit(writableDefaultsDir); err != nil {
 		return err
 	}
 
@@ -254,8 +256,8 @@ func generateMountsModeRecover(mst initramfsMountsState, recoverySystem string) 
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
 	}
-	// and disable cloud-init in recover mode
-	if err := sysconfig.DisableCloudInit(boot.InitramfsWritableDir); err != nil {
+	cloudDir := sysconfig.WritableDefaultsDir(boot.InitramfsWritableDir)
+	if err := sysconfig.DisableCloudInit(cloudDir); err != nil {
 		return err
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -271,7 +271,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep4(c *C) {
 	c.Check(modeEnv, testutil.FileEquals, `mode=install
 recovery_system=20191118
 `)
-	cloudInitDisable := filepath.Join(boot.InitramfsWritableDir, "etc/cloud/cloud-init.disabled")
+	cloudInitDisable := filepath.Join(boot.InitramfsWritableDir, "_writable_defaults/etc/cloud/cloud-init.disabled")
 	c.Check(cloudInitDisable, testutil.FilePresent)
 }
 

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -33,11 +33,17 @@ import (
 )
 
 func ubuntuDataCloudDir(rootdir string) string {
-	return filepath.Join(rootdir, writableDefaultsDir, "etc/cloud/")
+	return filepath.Join(rootdir, "etc/cloud/")
 }
 
-func DisableCloudInit(targetdir string) error {
-	ubuntuDataCloud := ubuntuDataCloudDir(targetdir)
+// DisableCloudInit will disable cloud-init permanently by writing a
+// cloud-init.disabled config file in etc/cloud under the target dir, which
+// instructs cloud-init-generator to not trigger new cloud-init invocations.
+// Note that even with this disabled file, a root user could still manually run
+// cloud-init, but this capability is not provided to any strictly confined
+// snap.
+func DisableCloudInit(rootDir string) error {
+	ubuntuDataCloud := ubuntuDataCloudDir(rootDir)
 	if err := os.MkdirAll(ubuntuDataCloud, 0755); err != nil {
 		return fmt.Errorf("cannot make cloud config dir: %v", err)
 	}
@@ -79,10 +85,10 @@ func configureCloudInit(opts *Options) (err error) {
 
 	switch opts.CloudInitSrcDir {
 	case "":
-		// disable cloud-init by default (as it's not confined)
-		err = DisableCloudInit(opts.TargetRootDir)
+		// disable cloud-init by default using the writable dir
+		err = DisableCloudInit(WritableDefaultsDir(opts.TargetRootDir))
 	default:
-		err = installCloudInitCfg(opts.CloudInitSrcDir, opts.TargetRootDir)
+		err = installCloudInitCfg(opts.CloudInitSrcDir, WritableDefaultsDir(opts.TargetRootDir))
 	}
 	return err
 }

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -32,8 +32,12 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
+func ubuntuDataCloudDir(rootdir string) string {
+	return filepath.Join(rootdir, writableDefaultsDir, "etc/cloud/")
+}
+
 func DisableCloudInit(targetdir string) error {
-	ubuntuDataCloud := filepath.Join(targetdir, "etc/cloud/")
+	ubuntuDataCloud := ubuntuDataCloudDir(targetdir)
 	if err := os.MkdirAll(ubuntuDataCloud, 0755); err != nil {
 		return fmt.Errorf("cannot make cloud config dir: %v", err)
 	}
@@ -53,7 +57,7 @@ func installCloudInitCfg(src, targetdir string) error {
 		return nil
 	}
 
-	ubuntuDataCloudCfgDir := filepath.Join(targetdir, "etc/cloud/cloud.cfg.d/")
+	ubuntuDataCloudCfgDir := filepath.Join(ubuntuDataCloudDir(targetdir), "cloud.cfg.d/")
 	if err := os.MkdirAll(ubuntuDataCloudCfgDir, 0755); err != nil {
 		return fmt.Errorf("cannot make cloud config dir: %v", err)
 	}

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -59,7 +59,7 @@ func (s *sysconfigSuite) TestCloudInitDisablesByDefault(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	ubuntuDataCloudDisabled := filepath.Join(boot.InstallHostWritableDir, "etc/cloud/cloud-init.disabled/")
+	ubuntuDataCloudDisabled := filepath.Join(boot.InstallHostWritableDir, "_writable_defaults/etc/cloud/cloud-init.disabled")
 	c.Check(ubuntuDataCloudDisabled, testutil.FilePresent)
 }
 
@@ -77,7 +77,7 @@ func (s *sysconfigSuite) TestCloudInitInstalls(c *C) {
 	c.Assert(err, IsNil)
 
 	// and did copy the cloud-init files
-	ubuntuDataCloudCfg := filepath.Join(boot.InstallHostWritableDir, "etc/cloud/cloud.cfg.d/")
+	ubuntuDataCloudCfg := filepath.Join(boot.InstallHostWritableDir, "_writable_defaults/etc/cloud/cloud.cfg.d/")
 	c.Check(filepath.Join(ubuntuDataCloudCfg, "foo.cfg"), testutil.FileEquals, "foo.cfg config")
 	c.Check(filepath.Join(ubuntuDataCloudCfg, "bar.cfg"), testutil.FileEquals, "bar.cfg config")
 }

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -19,6 +19,9 @@
 
 package sysconfig
 
+// See https://github.com/snapcore/core20/pull/46
+const writableDefaultsDir = "_writable_defaults"
+
 // Options is the set of options used to configure the run system
 type Options struct {
 	// CloudInitSrcDir is where to find the cloud-init data when installing it,

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -19,6 +19,8 @@
 
 package sysconfig
 
+import "path/filepath"
+
 // See https://github.com/snapcore/core20/pull/46
 const writableDefaultsDir = "_writable_defaults"
 
@@ -43,4 +45,11 @@ func ConfigureRunSystem(opts *Options) error {
 	}
 
 	return nil
+}
+
+// WritableDefaultsDir returns the full path of the joined subdir under the
+// subtree for default content for system data living at rootdir,
+// i.e. rootdir/_writable_defaults/subdir...
+func WritableDefaultsDir(rootdir string, subdir ...string) string {
+	return filepath.Join(rootdir, writableDefaultsDir, filepath.Join(subdir...))
 }

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -15,9 +15,8 @@ execute: |
     snap changes | MATCH "Done.*Initialize system state"
 
     echo "Check that a simple shell snap"
-    # TODO:UC20: add test-snapd-sh-core20
-    snap install test-snapd-sh-core18
-    test-snapd-sh-core18.sh -c 'echo hello' | MATCH hello
+    snap install test-snapd-sh-core20
+    test-snapd-sh-core20.sh -c 'echo hello' | MATCH hello
 
     if python3 -m json.tool < /var/lib/snapd/system-key | grep '"build-id": ""'; then
         echo "The build-id of snapd must not be empty."
@@ -25,7 +24,7 @@ execute: |
     fi
 
     echo "Ensure passwd/group is available for snaps"
-    test-snapd-sh-core18.sh -c 'cat /var/lib/extrausers/passwd' | MATCH test
+    test-snapd-sh-core20.sh -c 'cat /var/lib/extrausers/passwd' | MATCH test
 
     echo "Ensure extracted kernel.efi exists"
     test -e /boot/grub/pc-kernel*/kernel.efi
@@ -34,6 +33,13 @@ execute: |
     # ensure that our the-tool (and thus our snap-bootstrap ran)
     echo "Check that we booted with the rebuilt initramfs in the kernel snap"
     test -e /writable/system-data/the-tool-ran
+
+    # ensure we handled cloud-init, either we have:
+    # a) cloud init is disabled
+    # b) there was a cloud.cfg.d override (e.g. MAAS), then we must have more
+    #    files in writable than in the core20 snap. The core20 content and the
+    #    extra config will be merged
+    test -e /writable/system-data/etc/cloud/cloud-init.disabled || [ "$(ls /writable/system-data/etc/cloud/cloud.cfg.d/ | wc -l)" -gt "$(ls /snap/core20/current/etc/cloud/cloud.cfg.d/ | wc -l)" ]
 
     # ensure that we have no symlinks from /var/lib/snapd/snaps to
     # /var/lib/snapd/seed

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -39,7 +39,7 @@ execute: |
     # b) there was a cloud.cfg.d override (e.g. MAAS), then we must have more
     #    files in writable than in the core20 snap. The core20 content and the
     #    extra config will be merged
-    test -e /writable/system-data/etc/cloud/cloud-init.disabled || [ "$(ls /writable/system-data/etc/cloud/cloud.cfg.d/ | wc -l)" -gt "$(ls /snap/core20/current/etc/cloud/cloud.cfg.d/ | wc -l)" ]
+    test -e /writable/system-data/etc/cloud/cloud-init.disabled || [ "$(find /writable/system-data/etc/cloud/cloud.cfg.d/ | wc -l)" -gt "$(find /snap/core20/current/etc/cloud/cloud.cfg.d/ | wc -l)" ]
 
     # ensure that we have no symlinks from /var/lib/snapd/snaps to
     # /var/lib/snapd/seed


### PR DESCRIPTION
This contains PRs:
* https://github.com/snapcore/snapd/pull/8612
* https://github.com/snapcore/snapd/pull/8854

as well as a manually applied patch from:
* https://github.com/snapcore/snapd/pull/8533/files#diff-783da8f78a2576a41ab7cb0ca2c25e55

that patch is in 1acaab10ed0fe2b7bd87ab4c22adcd7af6a2811e

which was difficult to cherry-pick to 2.45 wholesale. 