### PR TITLE
many/tests/preseed: reset the preseeded images before preseeding them

### DIFF
--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -30,7 +30,6 @@ prepare: |
   echo "Running preseed --reset for already preseeded cloud images"
   SNAPD_DEBUG=1 /usr/lib/snapd/snap-preseed --reset "$IMAGE_MOUNTPOINT"
 
-
   # Inject current snapd into seeds
   #shellcheck source=tests/lib/snaps.sh
   . "$TESTSLIB"/snaps.sh

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -26,6 +26,11 @@ prepare: |
   mkdir -p "$IMAGE_MOUNTPOINT"
   mount /dev/nbd0p1 "$IMAGE_MOUNTPOINT"
 
+  # for images that are already preseeded, we need to undo the preseeding there
+  echo "Running preseed --reset for already preseeded cloud images"
+  SNAPD_DEBUG=1 /usr/lib/snapd/snap-preseed --reset "$IMAGE_MOUNTPOINT"
+
+
   # Inject current snapd into seeds
   #shellcheck source=tests/lib/snaps.sh
   . "$TESTSLIB"/snaps.sh

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that preseeding of current ubuntu cloud image works under lxd.
 description: |
   This test checks that preseeding of Ubuntu cloud images with snap-preseed
-  command works in lxc container. 
+  command works in lxc container.
 
 # this test works only on 18.04 because it requires lxd from deb (lxd snap
 # as it wouldn't allow mount) and tries to replicate launchpad builder setup.

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -20,6 +20,10 @@ prepare: |
   . "$TESTSLIB/preseed.sh"
   mount_ubuntu_image "$(pwd)/cloudimg.img" "$IMAGE_MOUNTPOINT"
 
+  # for images that are already preseeded, we need to undo the preseeding there
+  echo "Running preseed --reset for already preseeded cloud images"
+  SNAPD_DEBUG=1 /usr/lib/snapd/snap-preseed --reset "$IMAGE_MOUNTPOINT"
+
 restore: |
   rm -f before-preseeding.txt
   rm -f after-reset.txt

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -21,6 +21,10 @@ prepare: |
   . "$TESTSLIB/preseed.sh"
   mount_ubuntu_image "$(pwd)/cloudimg.img" "$IMAGE_MOUNTPOINT"
 
+  # for images that are already preseeded, we need to undo the preseeding there
+  echo "Running preseed --reset for already preseeded cloud images"
+  SNAPD_DEBUG=1 /usr/lib/snapd/snap-preseed --reset "$IMAGE_MOUNTPOINT"
+
 restore: |
   #shellcheck source=tests/lib/preseed.sh
   . "$TESTSLIB/preseed.sh"

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -30,7 +30,7 @@ execute: |
   echo "Checking missing chroot path arg error"
   /usr/lib/snapd/snap-preseed 2>&1 | MATCH "error: need chroot path as argument"
 
-  echo "Running pre-seeeding"
+  echo "Running pre-seeding"
   SNAPD_DEBUG=1 /usr/lib/snapd/snap-preseed "$IMAGE_MOUNTPOINT"
 
   # sanity, core snap mounted by snap-preseed got unmounted
@@ -42,7 +42,7 @@ execute: |
   # Note, these checks match statuses, but not the order
   # mark-preseeded task is where snap-preseed stopped, therefore it's in Doing.
   MATCH "Doing .+ mark-preseeded +Mark system pre-seeded" < tasks.log
- 
+
   MATCH "Done .+ prerequisites +Ensure prerequisites for \"snapd\" are available" < tasks.log
   MATCH "Done .+ prepare-snap +Prepare snap \"/var/lib/snapd/seed/snaps/snapd_[0-9]+.snap" < tasks.log
   MATCH "Done .+ mount-snap +Mount snap \"snapd\" \([0-9]+\)" < tasks.log

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -28,6 +28,10 @@ prepare: |
   # into seeds/ to make snap-preseed and the test happy.
   inject_snapd_into_seeds "$IMAGE_MOUNTPOINT"
 
+  # for images that are already preseeded, we need to undo the preseeding there
+  echo "Running preseed --reset for already preseeded cloud images"
+  SNAPD_DEBUG=1 /usr/lib/snapd/snap-preseed --reset "$IMAGE_MOUNTPOINT"
+
 restore: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"


### PR DESCRIPTION
The cloud images we consume for these tests are starting to be preseeded
themselves, so for now we reset any preseeding that might exist in the images
before doing our tests. Resetting the preseed is safe to do even if the image
wasn't preseeded, so this is always safe to do.

This will fix the groovy preseed spread test failures we have been seeing this week.