### PR TITLE
tests: replace _wait_for_file_change with retry

### DIFF
--- a/tests/main/services-snapctl/task.yaml
+++ b/tests/main/services-snapctl/task.yaml
@@ -26,18 +26,6 @@ execute: |
         done
     }
 
-    _wait_for_file_change() {
-        retry=5
-        while ! MATCH "$2" < "$1"  ; do
-            retry=$(( retry - 1 ))
-            if [ $retry -le 0 ]; then
-                echo "Failed to match the content of file $1, expected: $2"
-                exit 1
-            fi
-            sleep 1
-        done
-    }
-
     # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
 
@@ -75,7 +63,7 @@ execute: |
     snap tasks --last=configure|MATCH -z "restart of .test-snapd-service.test-snapd-service.+restart of .test-snapd-service.test-snapd-other-service"
 
     echo "And service could get the new service-option set from the hook"
-    _wait_for_file_change "$SERVICEOPTIONFILE" "^foo$"
+    retry -n 5 --wait 1 MATCH '^foo$' "$SERVICEOPTIONFILE"
 
     echo "Reinstalling the snap with configure hook calling snapctl restart works"
     snap set test-snapd-service command=restart


### PR DESCRIPTION
We can use retry with MATCH instead of the specialized
_wait_for_file_change() - thus making it easier to read the test without
knowing special purpose functions.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
