### PR TITLE
packaging: add placeholder changelog for 2.45.3

### DIFF
--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,9 @@
+snapd (2.45.3) xenial; urgency=medium
+
+  * Placeholder for 2.45.3 release
+
+ -- Zygmunt Krynicki <me@zygoon.pl>  Mon, 27 Jul 2020 13:08:47 +0200
+
 snapd (2.45.2) xenial; urgency=medium
 
   * SECURITY UPDATE: sandbox escape vulnerability on snapctl xdg-open


### PR DESCRIPTION
Per release instructions:

> Go to the master branch and create a debian/changelog with a placeholder 
> entry for 2.45.3 to ensure the next “ppa:snappy-dev/edge” build has the right version number
