### PR TITLE
o/ifacestate: fix bug in snapsWithSecurityProfiles

### DIFF
--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -941,7 +941,7 @@ func snapsWithSecurityProfiles(st *state.State) ([]*snap.Info, error) {
 		doneProfiles := false
 		for _, t1 := range t.WaitTasks() {
 			if t1.Kind() == "setup-profiles" && t1.Status() == state.DoneStatus {
-				snapsup1, err := snapstate.TaskSnapSetup(t)
+				snapsup1, err := snapstate.TaskSnapSetup(t1)
 				if err != nil {
 					return nil, err
 				}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -5657,6 +5657,78 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfiles(c *C) {
 	})
 }
 
+func (s *interfaceManagerSuite) TestSnapsWithSecurityProfilesMiddleOfFirstBoot(c *C) {
+	// make sure snapsWithSecurityProfiles does the right thing
+	// if invoked after a restart in the middle of first boot
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si0 := &snap.SideInfo{
+		RealName: "snap0",
+		Revision: snap.R(10),
+	}
+	snaptest.MockSnap(c, `name: snap0`, si0)
+	snapstate.Set(s.state, "snap0", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si0},
+		Current:  si0.Revision,
+	})
+
+	si1 := &snap.SideInfo{
+		RealName: "snap1",
+		Revision: snap.R(11),
+	}
+	snaptest.MockSnap(c, `name: snap1`, si1)
+	snapstate.Set(s.state, "snap1", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si1},
+		Current:  si1.Revision,
+	})
+
+	chg := s.state.NewChange("linking", "linking")
+
+	snaps := []struct {
+		name        string
+		setupStatus state.Status
+		linkStatus  state.Status
+		si          *snap.SideInfo
+	}{
+		{"snap0", state.DoneStatus, state.DoneStatus, si0},
+		{"snap1", state.DoStatus, state.DoStatus, si1},
+	}
+
+	var tsPrev *state.TaskSet
+	for i, snp := range snaps {
+		t1 := s.state.NewTask("setup-profiles", fmt.Sprintf("setup profiles %d", i))
+		t1.Set("snap-setup", &snapstate.SnapSetup{
+			SideInfo: snp.si,
+		})
+		t1.SetStatus(snp.setupStatus)
+		t2 := s.state.NewTask("link-snap", fmt.Sprintf("link snap %d", i))
+		t2.Set("snap-setup", &snapstate.SnapSetup{
+			SideInfo: snp.si,
+		})
+		t2.WaitFor(t1)
+		t2.SetStatus(snp.linkStatus)
+		chg.AddTask(t1)
+		chg.AddTask(t2)
+
+		// this is the kind of wait chain used by first boot
+		ts := state.NewTaskSet(t1, t2)
+		if tsPrev != nil {
+			ts.WaitAll(tsPrev)
+		}
+		tsPrev = ts
+	}
+
+	infos, err := ifacestate.SnapsWithSecurityProfiles(s.state)
+	c.Assert(err, IsNil)
+	// snap1 link-snap waiting on snap0 setup-profiles didn't confuse
+	// snapsWithSecurityProfiles
+	c.Check(infos, HasLen, 1)
+	c.Check(infos[0].InstanceName(), Equals, "snap0")
+}
+
 func (s *interfaceManagerSuite) TestDisconnectInterfaces(c *C) {
 	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
 	_ = s.manager(c)

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -90,3 +90,9 @@ execute: |
     test -f "$SEED_DIR/snaps/basic_"*.snap
     snap list | MATCH "^classic-gadget"
     test -f "$SEED_DIR/snaps/classic-gadget_"*.snap
+
+    # test regression
+    if journalctl -u snapd | MATCH "missing file /snap/classic-gadget/unset/meta/snap.yaml"; then
+         echo "snapd is still reading the gadget too early"
+         exit 1
+    fi


### PR DESCRIPTION
because of s/t1/t/ the code would get confused when a setup-profiles
of another snaps would be waited by link-snap, this could be triggered
by firstboot code just across a restart where snapd/core is active
and the rest of the snaps aren't yet

modifies a related spread test to make sure the consequence of this are gone
