### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: add doSystemdMount + unit tests

### DIFF
--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -33,6 +33,8 @@ var (
 	DoSystemdMount = doSystemdMountImpl
 )
 
+type SystemdMountOptions = systemdMountOptions
+
 func MockTimeNow(f func() time.Time) (restore func()) {
 	old := timeNow
 	timeNow = f

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -29,7 +29,17 @@ import (
 
 var (
 	Parser = parser
+
+	DoSystemdMount = doSystemdMountImpl
 )
+
+func MockTimeNow(f func() time.Time) (restore func()) {
+	old := timeNow
+	timeNow = f
+	return func() {
+		timeNow = old
+	}
+}
 
 func MockStdout(newStdout io.Writer) (restore func()) {
 	oldStdout := stdout

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -1,0 +1,187 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/systemd"
+)
+
+var (
+	timeNow = time.Now
+
+	// default 1:30, as that is how long systemd will wait for services by
+	// default so seems a sensible default
+	defaultMountUnitWaitTimeout = time.Minute + 30*time.Second
+
+	unitFileDependOverride = `[Unit]
+Requires=%[1]s
+After=%[1]s
+`
+
+	doSystemdMount = doSystemdMountImpl
+)
+
+// SystemdMountOptions reflects the set of options for mounting something using
+// systemd-mount(1)
+type SystemdMountOptions struct {
+	// IsTmpfs indicates that "what" should be ignored and a new tmpfs should
+	// be mounted at the location.
+	IsTmpfs bool
+	// EphemeralInitramfsMount indicates that the mount should not persist from
+	// the initramfs to after the pivot_root to normal userspace. The default
+	// value, false, means that the mount will persist across the transition,
+	// this is done by creating systemd unit overrides for various initrd
+	// targets in /run that systemd understands when it isolates to the
+	// initrd-cleanup.target when the pivot_root is performed.
+	EphemeralInitramfsMount bool
+	// NeedsFsck indicates that before returning to the caller, an fsck check
+	// should be performed on the thing being mounted.
+	NeedsFsck bool
+	// NoWait will not wait until the systemd unit is active and running, which
+	// is the default behavior.
+	NoWait bool
+}
+
+// doSystemdMount will mount "what" at "where" using systemd-mount(1) with
+// various options
+func doSystemdMountImpl(what, where string, opts *SystemdMountOptions) error {
+	if opts == nil {
+		opts = &SystemdMountOptions{}
+	}
+
+	// doesn't make sense to fsck a tmpfs
+	if opts.NeedsFsck && opts.IsTmpfs {
+		return fmt.Errorf("cannot mount %q at %q: impossible to fsck a tmpfs", what, where)
+	}
+
+	whereEscaped := systemd.EscapeUnitNamePath(where)
+	unitName := whereEscaped + ".mount"
+
+	args := []string{what, where, "--no-pager", "--no-ask-password"}
+	if opts.IsTmpfs {
+		args = append(args, "--type=tmpfs")
+	}
+
+	if opts.NeedsFsck {
+		// note that with the --fsck=yes argument, systemd will block starting
+		// the mount unit on a new systemd-fsck@<what> unit that will run the
+		// fsck, so we don't need to worry about waiting for that to finish in
+		// the case where we are supposed to wait (which is the default for this
+		// function)
+		args = append(args, "--fsck=yes")
+	}
+
+	// Under all circumstances that we use systemd-mount here from
+	// snap-bootstrap, it is expected to be okay to block waiting for the unit
+	// to be started and become active, because snap-bootstrap is, by design,
+	// expected to run as late as possible in the initramfs, and so any
+	// dependencies there might be in systemd creating and starting these mount
+	// units should already be ready and so we will not block forever. If
+	// however there was something going on in systemd at the same time that the
+	// mount unit depended on, we could hit a deadlock blocking as systemd will
+	// not enqueue this job until it's dependencies are ready, and so if those
+	// things depend on this mount unit we are stuck. The solution to this
+	// situation is to make snap-bootstrap run as late as possible before
+	// mounting things.
+	// However, we leave in the option to not block if there is ever a reason
+	// we need to do so.
+	if opts.NoWait {
+		args = append(args, "--no-block")
+	}
+
+	// note that we do not currently parse any output from systemd-mount, but if
+	// we ever do, take special care surrounding the debug output that systemd
+	// outputs with the "debug" kernel command line present (or equivalently the
+	// SYSTEMD_LOG_LEVEL=debug env var) which will add lots of additional output
+	// to stderr from systemd commands
+	out, err := exec.Command("systemd-mount", args...).CombinedOutput()
+	if err != nil {
+		return osutil.OutputErr(out, err)
+	}
+
+	// if it should survive pivot_root() then we need to add overrides for this
+	// unit to /run/systemd units
+	if !opts.EphemeralInitramfsMount {
+		// to survive the pivot_root, we need to make the mount units depend on
+		// all of the various initrd special targets by adding runtime conf
+		// files there
+		// note we could do this statically in the initramfs main filesystem
+		// layout, but that means that changes to snap-bootstrap would block on
+		// waiting for those files to be added before things works here, this is
+		// a more flexible strategy that puts snap-bootstrap in control
+		for _, initrdUnit := range []string{
+			"initrd.target",
+			"initrd-fs.target",
+			"initrd-switch-root.target",
+			"local-fs.target",
+		} {
+			targetDir := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d")
+			err := os.MkdirAll(targetDir, 0755)
+			if err != nil {
+				return err
+			}
+
+			// add an override file for the initrd unit to depend on this mount
+			// unit so that when we isolate to the initrd unit, it does not get
+			// unmounted
+			fname := fmt.Sprintf("snap_bootstrap_%s.conf", whereEscaped)
+			content := []byte(fmt.Sprintf(unitFileDependOverride, unitName))
+			err = ioutil.WriteFile(filepath.Join(targetDir, fname), content, 0644)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if !opts.NoWait {
+		// TODO: is this necessary, systemd-mount seems to only return when the
+		// unit is active and the mount is there, but perhaps we should be a bit
+		// paranoid here and wait anyways?
+		// see systemd-mount(1)
+
+		// wait for the mount to exist
+		start := timeNow()
+		var now time.Time
+		for now = timeNow(); now.Sub(start) < defaultMountUnitWaitTimeout; now = timeNow() {
+			mounted, err := osutilIsMounted(where)
+			if mounted {
+				break
+			}
+			if err != nil {
+				return err
+			}
+		}
+
+		if now.Sub(start) > defaultMountUnitWaitTimeout {
+			return fmt.Errorf("timed out after %s waiting for mount %s on %s", defaultMountUnitWaitTimeout, what, where)
+		}
+	}
+
+	return nil
+}

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -50,9 +50,9 @@ After=%[1]s
 // systemdMountOptions reflects the set of options for mounting something using
 // systemd-mount(1)
 type systemdMountOptions struct {
-	// IsTmpfs indicates that "what" should be ignored and a new tmpfs should
-	// be mounted at the location.
-	IsTmpfs bool
+	// Tmpfs indicates that "what" should be ignored and a new tmpfs should be
+	// mounted at the location.
+	Tmpfs bool
 	// Ephemeral indicates that the mount should not persist from the initramfs
 	// to after the pivot_root to normal userspace. The default value, false,
 	// means that the mount will persist across the transition, this is done by
@@ -79,7 +79,7 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 	}
 
 	// doesn't make sense to fsck a tmpfs
-	if opts.NeedsFsck && opts.IsTmpfs {
+	if opts.NeedsFsck && opts.Tmpfs {
 		return fmt.Errorf("cannot mount %q at %q: impossible to fsck a tmpfs", what, where)
 	}
 
@@ -87,7 +87,7 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 	unitName := whereEscaped + ".mount"
 
 	args := []string{what, where, "--no-pager", "--no-ask-password"}
-	if opts.IsTmpfs {
+	if opts.Tmpfs {
 		args = append(args, "--type=tmpfs")
 	}
 

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -47,9 +47,9 @@ After=%[1]s
 	doSystemdMount = doSystemdMountImpl
 )
 
-// SystemdMountOptions reflects the set of options for mounting something using
+// systemdMountOptions reflects the set of options for mounting something using
 // systemd-mount(1)
-type SystemdMountOptions struct {
+type systemdMountOptions struct {
 	// IsTmpfs indicates that "what" should be ignored and a new tmpfs should
 	// be mounted at the location.
 	IsTmpfs bool
@@ -69,10 +69,13 @@ type SystemdMountOptions struct {
 }
 
 // doSystemdMount will mount "what" at "where" using systemd-mount(1) with
-// various options
-func doSystemdMountImpl(what, where string, opts *SystemdMountOptions) error {
+// various options. Note that in some error cases, the mount unit may have
+// already been created and it will not be deleted here, if that is the case
+// callers should check manually if the unit needs to be removed on error
+// conditions.
+func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 	if opts == nil {
-		opts = &SystemdMountOptions{}
+		opts = &systemdMountOptions{}
 	}
 
 	// doesn't make sense to fsck a tmpfs

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -53,13 +53,13 @@ type systemdMountOptions struct {
 	// IsTmpfs indicates that "what" should be ignored and a new tmpfs should
 	// be mounted at the location.
 	IsTmpfs bool
-	// EphemeralInitramfsMount indicates that the mount should not persist from
-	// the initramfs to after the pivot_root to normal userspace. The default
-	// value, false, means that the mount will persist across the transition,
-	// this is done by creating systemd unit overrides for various initrd
-	// targets in /run that systemd understands when it isolates to the
-	// initrd-cleanup.target when the pivot_root is performed.
-	EphemeralInitramfsMount bool
+	// Ephemeral indicates that the mount should not persist from the initramfs
+	// to after the pivot_root to normal userspace. The default value, false,
+	// means that the mount will persist across the transition, this is done by
+	// creating systemd unit overrides for various initrd targets in /run that
+	// systemd understands when it isolates to the initrd-cleanup.target when
+	// the pivot_root is performed.
+	Ephemeral bool
 	// NeedsFsck indicates that before returning to the caller, an fsck check
 	// should be performed on the thing being mounted.
 	NeedsFsck bool
@@ -130,7 +130,7 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 
 	// if it should survive pivot_root() then we need to add overrides for this
 	// unit to /run/systemd units
-	if !opts.EphemeralInitramfsMount {
+	if !opts.Ephemeral {
 		// to survive the pivot_root, we need to make the mount units depend on
 		// all of the various initrd special targets by adding runtime conf
 		// files there

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -87,7 +87,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "tmpfs",
 			where: "/run/mnt/data",
 			opts: &main.SystemdMountOptions{
-				EphemeralInitramfsMount: true,
+				Ephemeral: true,
 			},
 			timeNowTimes:     []time.Time{testStart, testStart},
 			isMountedReturns: []bool{true},
@@ -193,8 +193,8 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			}
 			c.Assert(cmd.Calls(), DeepEquals, [][]string{args})
 
-			// check the mount units being there if opts.EphemeralInitramfsMount is
-			// false
+			// check that the overrides are present if opts.Ephemeral is false,
+			// or check the overrides are not present if opts.Ephemeral is true
 			for _, initrdUnit := range []string{
 				"initrd.target",
 				"initrd-fs.target",
@@ -204,7 +204,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 				mountUnit := systemd.EscapeUnitNamePath(t.where)
 				fname := fmt.Sprintf("snap_bootstrap_%s.conf", mountUnit)
 				unitFile := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d", fname)
-				if opts.EphemeralInitramfsMount {
+				if opts.Ephemeral {
 					c.Assert(unitFile, testutil.FileAbsent)
 				} else {
 					c.Assert(unitFile, testutil.FileEquals, fmt.Sprintf(`[Unit]

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -43,6 +43,17 @@ func (s *doSystemdMountSuite) SetUpTest(c *C) {
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 }
 
+func (s *doSystemdMountSuite) TestDoSystemdMountUnhappy(c *C) {
+	cmd := testutil.MockCommand(c, "systemd-mount", `
+echo "mocked error"
+exit 1
+`)
+	defer cmd.Restore()
+
+	err := main.DoSystemdMount("something", "somewhere only we know", nil)
+	c.Assert(err, ErrorMatches, "mocked error")
+}
+
 func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 
 	testStart := time.Now()

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -1,0 +1,222 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	main "github.com/snapcore/snapd/cmd/snap-bootstrap"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+)
+
+type doSystemdMountSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&doSystemdMountSuite{})
+
+func (s *doSystemdMountSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+}
+
+func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
+
+	testStart := time.Now()
+
+	tt := []struct {
+		what             string
+		where            string
+		opts             *main.SystemdMountOptions
+		timeNowTimes     []time.Time
+		isMountedReturns []bool
+		expErr           string
+		comment          string
+	}{
+		{
+			what:             "/dev/sda3",
+			where:            "/run/mnt/data",
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy default",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				IsTmpfs: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy tmpfs",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				NeedsFsck: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy fsck",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				EphemeralInitramfsMount: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy initramfs ephemeral",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				NoWait: true,
+			},
+			comment: "happy no wait",
+		},
+		{
+			what:             "what",
+			where:            "where",
+			timeNowTimes:     []time.Time{testStart, testStart, testStart, testStart.Add(2 * time.Minute)},
+			isMountedReturns: []bool{false, false},
+			expErr:           "timed out after 1m30s waiting for mount what on where",
+			comment:          "times out waiting for mount to appear",
+		},
+		{
+			what:  "what",
+			where: "where",
+			opts: &main.SystemdMountOptions{
+				IsTmpfs:   true,
+				NeedsFsck: true,
+			},
+			expErr:  "cannot mount \"what\" at \"where\": impossible to fsck a tmpfs",
+			comment: "invalid tmpfs + fsck",
+		},
+	}
+
+	for _, t := range tt {
+		comment := Commentf(t.comment)
+
+		var cleanups []func()
+
+		opts := t.opts
+		if opts == nil {
+			opts = &main.SystemdMountOptions{}
+		}
+		dirs.SetRootDir(c.MkDir())
+		cleanups = append(cleanups, func() { dirs.SetRootDir("") })
+
+		cmd := testutil.MockCommand(c, "systemd-mount", ``)
+		cleanups = append(cleanups, cmd.Restore)
+
+		timeCalls := 0
+		restore := main.MockTimeNow(func() time.Time {
+			timeCalls++
+			c.Assert(timeCalls <= len(t.timeNowTimes), Equals, true, comment)
+			if timeCalls > len(t.timeNowTimes) {
+				c.Errorf("too many time.Now calls (%d)", timeCalls)
+				// we want the test to fail at some point and not run forever, so
+				// move time way forward to make it for sure time out
+				return testStart.Add(10000 * time.Hour)
+			}
+			return t.timeNowTimes[timeCalls-1]
+		})
+		cleanups = append(cleanups, restore)
+
+		cleanups = append(cleanups, func() {
+			c.Assert(timeCalls, Equals, len(t.timeNowTimes), comment)
+		})
+
+		isMountedCalls := 0
+		restore = main.MockOsutilIsMounted(func(where string) (bool, error) {
+			isMountedCalls++
+			c.Assert(isMountedCalls <= len(t.isMountedReturns), Equals, true, comment)
+			if isMountedCalls > len(t.isMountedReturns) {
+				e := fmt.Sprintf("too many osutil.IsMounted calls (%d)", isMountedCalls)
+				c.Errorf(e)
+				// we want the test to fail at some point and not run forever, so
+				// move time way forward to make it for sure time out
+				return false, fmt.Errorf(e)
+			}
+			return t.isMountedReturns[isMountedCalls-1], nil
+		})
+		cleanups = append(cleanups, restore)
+
+		cleanups = append(cleanups, func() {
+			c.Assert(isMountedCalls, Equals, len(t.isMountedReturns), comment)
+		})
+
+		err := main.DoSystemdMount(t.what, t.where, t.opts)
+		if t.expErr != "" {
+			c.Assert(err, ErrorMatches, t.expErr)
+		} else {
+			c.Assert(err, IsNil)
+
+			args := []string{
+				"systemd-mount", t.what, t.where, "--no-pager", "--no-ask-password",
+			}
+			if opts.NoWait {
+				args = append(args, "--no-block")
+			}
+			if opts.IsTmpfs {
+				args = append(args, "--type=tmpfs")
+			}
+			if opts.NeedsFsck {
+				args = append(args, "--fsck=yes")
+			}
+			c.Assert(cmd.Calls(), DeepEquals, [][]string{args})
+
+			// check the mount units being there if opts.EphemeralInitramfsMount is
+			// false
+			for _, initrdUnit := range []string{
+				"initrd.target",
+				"initrd-fs.target",
+				"initrd-switch-root.target",
+				"local-fs.target",
+			} {
+				mountUnit := systemd.EscapeUnitNamePath(t.where)
+				fname := fmt.Sprintf("snap_bootstrap_%s.conf", mountUnit)
+				unitFile := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d", fname)
+				if opts.EphemeralInitramfsMount {
+					c.Assert(unitFile, testutil.FileAbsent)
+				} else {
+					c.Assert(unitFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
+Requires=%[1]s
+After=%[1]s
+`, mountUnit+".mount"))
+				}
+			}
+		}
+
+		for _, r := range cleanups {
+			r()
+		}
+	}
+}

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -67,7 +67,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "tmpfs",
 			where: "/run/mnt/data",
 			opts: &main.SystemdMountOptions{
-				IsTmpfs: true,
+				Tmpfs: true,
 			},
 			timeNowTimes:     []time.Time{testStart, testStart},
 			isMountedReturns: []bool{true},
@@ -113,7 +113,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				IsTmpfs:   true,
+				Tmpfs:     true,
 				NeedsFsck: true,
 			},
 			expErr:  "cannot mount \"what\" at \"where\": impossible to fsck a tmpfs",
@@ -185,7 +185,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			if opts.NoWait {
 				args = append(args, "--no-block")
 			}
-			if opts.IsTmpfs {
+			if opts.Tmpfs {
 				args = append(args, "--type=tmpfs")
 			}
 			if opts.NeedsFsck {


### PR DESCRIPTION
Broken out from https://github.com/snapcore/snapd/pull/9010, this is the logic for mounting things from the
initramfs that snap-bootstrap will use there. 

Since the unit testing here is rather involved, I thought it would make for easier reviewing to break it out, then the diff inside cmd_initramfs_mounts.go in the other PR will become simpler as well after this is merged as it will be pure logic and test changes with no additional helpers, etc.