### PR TITLE
tests/main/selinux-clean: workaround SELinux denials triggered by linger setup on Centos8

### DIFF
--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -64,7 +64,7 @@ execute: |
     # were logged, they it will show up now, but not for subsequent checkpoints.
     # XXX ausearch exits with 1 when there are denials
     ausearch --checkpoint stamp --start checkpoint -m AVC > avc-after 2>&1 || true
-    grep -v -E 'avc:  denied  { (setattr|read) } .* tcontext=unconfined_u:object_r:systemd_logind_var_lib_t:s0' < avc-after | \
+    grep -v -E 'avc:  denied  { (setattr|read) } .* name=linger .* scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:systemd_logind_var_lib_t:s0' < avc-after | \
         not MATCH 'type=AVC'
 
     # another revision triggers copy of snap data

--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -47,7 +47,26 @@ execute: |
     tests.session -u test exec test-snapd-desktop.sh -c 'echo hello world'
     tests.session -u test exec test-snapd-desktop.sh -c 'mkdir /home/test/foo'
     tests.session -u test exec test-snapd-desktop.sh -c 'echo foo >/home/test/foo/bar'
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+    # the way we set up linger makes systemd and SELinux unhappy and may trigger
+    # a denials like this:
+    # type=AVC msg=audit(07/27/20 14:52:25.845:3443) : avc: denied { setattr }
+    #     for pid=96609 comm=(d-logind) name=linger dev="sda2" ino=1437682
+    #     scontext=system_u:system_r:init_t:s0
+    #     tcontext=unconfined_u:object_r:systemd_logind_var_lib_t:s0 tclass=dir
+    #     permissive=1
+    # type=AVC msg=audit(07/27/20 14:52:25.845:3444) : avc: denied { read } for
+    #     pid=96609 comm=(d-logind) name=linger dev="sda2" ino=1437682
+    #     scontext=system_u:system_r:init_t:s0
+    #     tcontext=unconfined_u:object_r:systemd_logind_var_lib_t:s0 tclass=dir
+    #     permissive=1
+    #
+    # This is a first checkpoint after the session was started, so if denials
+    # were logged, they it will show up now, but not for subsequent checkpoints.
+    # XXX ausearch exits with 1 when there are denials
+    ausearch --checkpoint stamp --start checkpoint -m AVC > avc-after 2>&1 || true
+    grep -v -E 'avc:  denied  { (setattr|read) } .* tcontext=unconfined_u:object_r:systemd_logind_var_lib_t:s0' < avc-after | \
+        not MATCH 'type=AVC'
+
     # another revision triggers copy of snap data
     install_local test-snapd-desktop
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'


### PR DESCRIPTION


The user session linger setup we use may trigger AVC denials on Centos 8. Make
sure the test accounts for that.

```
type=AVC msg=audit(07/27/20 14:52:25.845:3443) : avc: denied { setattr }
     for pid=96609 comm=(d-logind) name=linger dev="sda2" ino=1437682
     scontext=system_u:system_r:init_t:s0
     tcontext=unconfined_u:object_r:systemd_logind_var_lib_t:s0 tclass=dir
     permissive=1
type=AVC msg=audit(07/27/20 14:52:25.845:3444) : avc: denied { read } for
     pid=96609 comm=(d-logind) name=linger dev="sda2" ino=1437682
     scontext=system_u:system_r:init_t:s0
     tcontext=unconfined_u:object_r:systemd_logind_var_lib_t:s0 tclass=dir
     permissive=1
```
