### PR TITLE
bootloader: extend managed assets bootloader interface to compose a candidate command line

### DIFF
--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -137,14 +137,14 @@ func getBootloaderManagingItsAssets(where string, opts *bootloader.Options) (boo
 const (
 	currentEdition = iota
 	candidateEdition
-
-	runBootloader = iota
-	recoveryBootloader
 )
 
-func composeCommandLine(model *asserts.Model, currentOrCandidate, runOrRecovery int, system string) (string, error) {
+func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, system string) (string, error) {
 	if model.Grade() == asserts.ModelGradeUnset {
 		return "", nil
+	}
+	if mode != ModeRun && mode != ModeRecover {
+		return "", fmt.Errorf("internal error: unsupported command line mode %q", mode)
 	}
 	// get the ubuntu-seed bootloader
 	opts := &bootloader.Options{
@@ -153,7 +153,7 @@ func composeCommandLine(model *asserts.Model, currentOrCandidate, runOrRecovery 
 	bootloaderRootDir := InitramfsUbuntuBootDir
 	modeArg := "snapd_recovery_mode=run"
 	systemArg := ""
-	if runOrRecovery == recoveryBootloader {
+	if mode == ModeRecover {
 		// dealing with recovery system bootloader
 		opts.Recovery = true
 		bootloaderRootDir = InitramfsUbuntuSeedDir
@@ -178,20 +178,20 @@ func composeCommandLine(model *asserts.Model, currentOrCandidate, runOrRecovery 
 }
 
 // ComposeRecoveryCommandLine composes the kernel command line used when booting
-// a given recovery mode system.
+// a given system in recover mode.
 func ComposeRecoveryCommandLine(model *asserts.Model, system string) (string, error) {
-	return composeCommandLine(model, currentEdition, recoveryBootloader, system)
+	return composeCommandLine(model, currentEdition, ModeRecover, system)
 }
 
 // ComposeCommandLine composes the kernel command line used when booting the
 // system in run mode.
 func ComposeCommandLine(model *asserts.Model) (string, error) {
-	return composeCommandLine(model, currentEdition, runBootloader, "")
+	return composeCommandLine(model, currentEdition, ModeRun, "")
 }
 
 // ComposeCandidateCommandLine composes the kernel command line used when
 // booting the system in run mode with the current built-in edition of managed
 // boot assets.
 func ComposeCandidateCommandLine(model *asserts.Model) (string, error) {
-	return composeCommandLine(model, candidateEdition, runBootloader, "")
+	return composeCommandLine(model, candidateEdition, ModeRun, "")
 }

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -139,7 +139,7 @@ func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, syst
 	if mode != ModeRun && mode != ModeRecover {
 		return "", fmt.Errorf("internal error: unsupported command line mode %q", mode)
 	}
-	// get the ubuntu-seed bootloader
+	// get a bootloader under a native root directory
 	opts := &bootloader.Options{
 		NoSlashBoot: true,
 	}
@@ -181,6 +181,8 @@ func ComposeRecoveryCommandLine(model *asserts.Model, system string) (string, er
 func ComposeCommandLine(model *asserts.Model) (string, error) {
 	return composeCommandLine(model, currentEdition, ModeRun, "")
 }
+
+// TODO:UC20: add helper to compose candidate command line for a recovery system
 
 // ComposeCandidateCommandLine composes the kernel command line used when
 // booting the system in run mode with the current built-in edition of managed

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -124,13 +124,6 @@ func getBootloaderManagingItsAssets(where string, opts *bootloader.Options) (boo
 		// the bootloader cannot manage its scripts
 		return nil, errBootConfigNotManaged
 	}
-	managed, err := mbl.IsCurrentlyManaged()
-	if err != nil {
-		return nil, err
-	}
-	if !managed {
-		return nil, errBootConfigNotManaged
-	}
 	return mbl, nil
 }
 

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -211,3 +211,19 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineManagedHappy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=run panic=-1")
 }
+
+func (s *kernelCommandLineSuite) TestComposeCandidateCommandLineManagedHappy(c *C) {
+	model := makeMockUC20Model()
+
+	mbl := bootloadertest.Mock("btloader", c.MkDir()).WithManagedAssets()
+	bootloader.Force(mbl)
+	defer bootloader.Force(nil)
+
+	mbl.IsManaged = true
+	mbl.StaticCommandLine = "panic=-1"
+	mbl.CandidateStaticCommandLine = "candidate panic=-1"
+
+	cmdline, err := boot.ComposeCandidateCommandLine(model)
+	c.Assert(err, IsNil)
+	c.Assert(cmdline, Equals, "snapd_recovery_mode=run candidate panic=-1")
+}

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -20,7 +20,6 @@
 package boot_test
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -128,13 +127,16 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineNotManagedHappy(c *C) {
 	bootloader.Force(mbl)
 	mbl.IsManaged = false
 
+	// TODO:UC20: remove is managed checks
+
+	// is-managed is ignored with the right model and bootloader interface
 	cmdline, err = boot.ComposeRecoveryCommandLine(model, "20200314")
 	c.Assert(err, IsNil)
-	c.Assert(cmdline, Equals, "")
+	c.Assert(cmdline, Equals, "snapd_recovery_mode=recover snapd_recovery_system=20200314")
 
 	cmdline, err = boot.ComposeCommandLine(model)
 	c.Assert(err, IsNil)
-	c.Assert(cmdline, Equals, "")
+	c.Assert(cmdline, Equals, "snapd_recovery_mode=run")
 }
 
 func (s *kernelCommandLineSuite) TestComposeCommandLineNotUC20(c *C) {
@@ -165,35 +167,6 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineNotUC20(c *C) {
 	c.Check(cmdline, Equals, "")
 }
 
-func (s *kernelCommandLineSuite) TestComposeComamndLineSystemManagedErr(c *C) {
-	model := makeMockUC20Model()
-
-	mbl := bootloadertest.Mock("btloader", c.MkDir()).WithManagedAssets()
-	bootloader.Force(mbl)
-	defer bootloader.Force(nil)
-
-	errFail := errors.New("is managed fail")
-	mbl.IsManagedErr = errFail
-
-	cmdline, err := boot.ComposeRecoveryCommandLine(model, "20200314")
-	c.Assert(err, ErrorMatches, "is managed fail")
-	c.Assert(cmdline, Equals, "")
-	cmdline, err = boot.ComposeCommandLine(model)
-	c.Assert(err, ErrorMatches, "is managed fail")
-	c.Assert(cmdline, Equals, "")
-
-	mbl.IsManagedErr = nil
-	mbl.IsManaged = true
-	mbl.CommandLineErr = errors.New("kernel command line fail")
-
-	cmdline, err = boot.ComposeRecoveryCommandLine(model, "20200314")
-	c.Assert(err, ErrorMatches, "kernel command line fail")
-	c.Assert(cmdline, Equals, "")
-	cmdline, err = boot.ComposeCommandLine(model)
-	c.Assert(err, ErrorMatches, "kernel command line fail")
-	c.Assert(cmdline, Equals, "")
-}
-
 func (s *kernelCommandLineSuite) TestComposeCommandLineManagedHappy(c *C) {
 	model := makeMockUC20Model()
 
@@ -205,6 +178,16 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineManagedHappy(c *C) {
 	mbl.StaticCommandLine = "panic=-1"
 
 	cmdline, err := boot.ComposeRecoveryCommandLine(model, "20200314")
+	c.Assert(err, IsNil)
+	c.Assert(cmdline, Equals, "snapd_recovery_mode=recover snapd_recovery_system=20200314 panic=-1")
+	cmdline, err = boot.ComposeCommandLine(model)
+	c.Assert(err, IsNil)
+	c.Assert(cmdline, Equals, "snapd_recovery_mode=run panic=-1")
+
+	// managed status is effectively ignored
+	mbl.IsManaged = false
+
+	cmdline, err = boot.ComposeRecoveryCommandLine(model, "20200314")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=recover snapd_recovery_system=20200314 panic=-1")
 	cmdline, err = boot.ComposeCommandLine(model)
@@ -224,6 +207,12 @@ func (s *kernelCommandLineSuite) TestComposeCandidateCommandLineManagedHappy(c *
 	mbl.CandidateStaticCommandLine = "candidate panic=-1"
 
 	cmdline, err := boot.ComposeCandidateCommandLine(model)
+	c.Assert(err, IsNil)
+	c.Assert(cmdline, Equals, "snapd_recovery_mode=run candidate panic=-1")
+
+	// managed status is effectively ignored
+	mbl.IsManaged = false
+	cmdline, err = boot.ComposeCandidateCommandLine(model)
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=run candidate panic=-1")
 }

--- a/bootloader/asset.go
+++ b/bootloader/asset.go
@@ -28,6 +28,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/snapcore/snapd/bootloader/assets"
 )
 
 var errNoEdition = errors.New("no edition")
@@ -71,6 +73,16 @@ func editionFromConfigAsset(asset io.Reader) (uint, error) {
 		return 0, fmt.Errorf("cannot parse asset edition: %v", err)
 	}
 	return uint(edition), nil
+}
+
+// editionFromInternalConfigAsset extracts edition information from a named
+// internal boot config asset.
+func editionFromInternalConfigAsset(assetName string) (uint, error) {
+	data := assets.Internal(assetName)
+	if data == nil {
+		return 0, fmt.Errorf("internal error: no boot asset for %q", assetName)
+	}
+	return editionFromConfigAsset(bytes.NewReader(data))
 }
 
 // configAsset is a boot config asset, such as text script, used by grub or

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -161,6 +161,9 @@ type ManagedAssetsBootloader interface {
 	// extra arguments. The command line may be different when using a
 	// recovery bootloader.
 	CommandLine(modeArg, systemArg, extraArgs string) (string, error)
+	// CandidateCommandLine is similar to CommandLine, but uses the current
+	// edition of managed built-in boot assets as reference.
+	CandidateCommandLine(modeArg, systemArg, extraArgs string) (string, error)
 }
 
 func genericInstallBootConfig(gadgetFile, systemFile string) (bool, error) {

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -419,7 +419,15 @@ func (g *grub) CommandLine(modeArg, systemArg, extraArgs string) (string, error)
 	currentBootConfig := filepath.Join(g.dir(), "grub.cfg")
 	edition, err := editionFromDiskConfigAsset(currentBootConfig)
 	if err != nil {
-		return "", fmt.Errorf("cannot obtain edition number of current boot config: %v", err)
+		if err != errNoEdition {
+			return "", fmt.Errorf("cannot obtain edition number of current boot config: %v", err)
+		}
+		// we were called using the ManagedAssetsBootloader interface
+		// meaning the caller expects to us to use the managed assets,
+		// since one on disk is not managed, use the initial edition of
+		// the internal boot asset which is compatible with grub.cfg
+		// used before we started writing out the files ourselves
+		edition = 1
 	}
 	return g.commandLineForEdition(edition, modeArg, systemArg, extraArgs)
 }

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -384,23 +384,10 @@ func (g *grub) ManagedAssets() []string {
 	}
 }
 
-// CommandLine returns the kernel command line composed of mode and
-// system arguments, built-in bootloader specific static arguments
-// corresponding to the on-disk boot asset edition, followed by any
-// extra arguments. The command line may be different when using a
-// recovery bootloader.
-//
-// Implements ManagedAssetsBootloader for the grub bootloader.
-func (g *grub) CommandLine(modeArg, systemArg, extraArgs string) (string, error) {
-	// we do not trust the on disk asset, use the built-in one
+func (g *grub) commandLineForEdition(edition uint, modeArg, systemArg, extraArgs string) (string, error) {
 	assetName := "grub.cfg"
 	if g.recovery {
 		assetName = "grub-recovery.cfg"
-	}
-	currentBootConfig := filepath.Join(g.dir(), "grub.cfg")
-	edition, err := editionFromDiskConfigAsset(currentBootConfig)
-	if err != nil {
-		return "", fmt.Errorf("cannot obtain edition number of current boot config: %v", err)
 	}
 	staticCmdline := staticCommandLineForGrubAssetEdition(assetName, edition)
 	args, err := strutil.KernelCommandLineSplit(staticCmdline + " " + extraArgs)
@@ -419,6 +406,38 @@ func (g *grub) CommandLine(modeArg, systemArg, extraArgs string) (string, error)
 		snapdArgs = append(snapdArgs, systemArg)
 	}
 	return strings.Join(append(snapdArgs, args...), " "), nil
+}
+
+// CommandLine returns the kernel command line composed of mode and
+// system arguments, built-in bootloader specific static arguments
+// corresponding to the on-disk boot asset edition, followed by any
+// extra arguments. The command line may be different when using a
+// recovery bootloader.
+//
+// Implements ManagedAssetsBootloader for the grub bootloader.
+func (g *grub) CommandLine(modeArg, systemArg, extraArgs string) (string, error) {
+	currentBootConfig := filepath.Join(g.dir(), "grub.cfg")
+	edition, err := editionFromDiskConfigAsset(currentBootConfig)
+	if err != nil {
+		return "", fmt.Errorf("cannot obtain edition number of current boot config: %v", err)
+	}
+	return g.commandLineForEdition(edition, modeArg, systemArg, extraArgs)
+}
+
+// CandidateCommandLine is similar to CommandLine, but uses the current
+// edition of managed built-in boot assets as reference.
+//
+// Implements ManagedAssetsBootloader for the grub bootloader.
+func (g *grub) CandidateCommandLine(modeArg, systemArg, extraArgs string) (string, error) {
+	assetName := "grub.cfg"
+	if g.recovery {
+		assetName = "grub-recovery.cfg"
+	}
+	edition, err := editionFromInternalConfigAsset(assetName)
+	if err != nil {
+		return "", err
+	}
+	return g.commandLineForEdition(edition, modeArg, systemArg, extraArgs)
 }
 
 // staticCommandLineForGrubAssetEdition fetches a static command line for given

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -841,15 +841,30 @@ func (s *grubTestSuite) TestCommandLineNotManaged(c *C) {
 	// native EFI/ubuntu setup
 	s.makeFakeGrubEFINativeEnv(c, []byte(grubCfg))
 
-	opts := &bootloader.Options{NoSlashBoot: true}
-	g := bootloader.NewGrub(s.rootdir, opts)
-	c.Assert(g, NotNil)
-	mg, ok := g.(bootloader.ManagedAssetsBootloader)
-	c.Assert(ok, Equals, true)
+	restore := assets.MockSnippetsForEdition("grub.cfg:static-cmdline", []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte(`static=1`)},
+		{FirstEdition: 2, Snippet: []byte(`static=2`)},
+	})
+	defer restore()
+	restore = assets.MockSnippetsForEdition("grub-recovery.cfg:static-cmdline", []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte(`static=1 recovery`)},
+		{FirstEdition: 2, Snippet: []byte(`static=2 recovery`)},
+	})
+	defer restore()
 
-	args, err := mg.CommandLine("", "", "")
-	c.Assert(err, ErrorMatches, "cannot obtain edition number of current boot config: no edition")
-	c.Check(args, Equals, "")
+	opts := &bootloader.Options{NoSlashBoot: true}
+	mg := bootloader.NewGrub(s.rootdir, opts).(bootloader.ManagedAssetsBootloader)
+
+	args, err := mg.CommandLine("snapd_recovery_mode=run", "", "extra")
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, "snapd_recovery_mode=run static=1 extra")
+
+	optsRecovery := &bootloader.Options{NoSlashBoot: true, Recovery: true}
+	mgr := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.ManagedAssetsBootloader)
+
+	args, err = mgr.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=1234", "extra")
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, "snapd_recovery_mode=recover snapd_recovery_system=1234 static=1 recovery extra")
 }
 
 func (s *grubTestSuite) TestCommandLineMocked(c *C) {

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -909,6 +909,71 @@ boot script
 	c.Check(args, Equals, `snapd_recovery_mode=run edition=3 static args extra_arg=1`)
 }
 
+func (s *grubTestSuite) TestCandidateCommandLineMocked(c *C) {
+	grubCfg := `# Snapd-Boot-Config-Edition: 1
+boot script
+`
+	// edition on disk
+	s.makeFakeGrubEFINativeEnv(c, []byte(grubCfg))
+
+	edition2 := []byte(`# Snapd-Boot-Config-Edition: 2`)
+	edition3 := []byte(`# Snapd-Boot-Config-Edition: 3`)
+	edition4 := []byte(`# Snapd-Boot-Config-Edition: 4`)
+
+	restore := assets.MockInternal("grub.cfg", edition2)
+	defer restore()
+	restore = assets.MockInternal("grub-recovery.cfg", edition2)
+	defer restore()
+
+	restore = assets.MockSnippetsForEdition("grub.cfg:static-cmdline", []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte(`edition=1`)},
+		{FirstEdition: 3, Snippet: []byte(`edition=3`)},
+	})
+	defer restore()
+	restore = assets.MockSnippetsForEdition("grub-recovery.cfg:static-cmdline", []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte(`recovery edition=1`)},
+		{FirstEdition: 3, Snippet: []byte(`recovery edition=3`)},
+		{FirstEdition: 4, Snippet: []byte(`recovery edition=4up`)},
+	})
+	defer restore()
+
+	optsNoSlashBoot := &bootloader.Options{NoSlashBoot: true}
+	mg := bootloader.NewGrub(s.rootdir, optsNoSlashBoot).(bootloader.ManagedAssetsBootloader)
+	optsRecovery := &bootloader.Options{NoSlashBoot: true, Recovery: true}
+	recoverymg := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.ManagedAssetsBootloader)
+
+	args, err := mg.CandidateCommandLine("snapd_recovery_mode=run", "", "extra=1")
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, `snapd_recovery_mode=run edition=1 extra=1`)
+	args, err = recoverymg.CandidateCommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=20200202", "extra=1")
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, `snapd_recovery_mode=recover snapd_recovery_system=20200202 recovery edition=1 extra=1`)
+
+	restore = assets.MockInternal("grub.cfg", edition3)
+	defer restore()
+	restore = assets.MockInternal("grub-recovery.cfg", edition3)
+	defer restore()
+
+	args, err = mg.CandidateCommandLine("snapd_recovery_mode=run", "", "extra=1")
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, `snapd_recovery_mode=run edition=3 extra=1`)
+	args, err = recoverymg.CandidateCommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=20200202", "extra=1")
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, `snapd_recovery_mode=recover snapd_recovery_system=20200202 recovery edition=3 extra=1`)
+
+	// bump edition only for recovery
+	restore = assets.MockInternal("grub-recovery.cfg", edition4)
+	defer restore()
+	// boot bootloader unchanged
+	args, err = mg.CandidateCommandLine("snapd_recovery_mode=run", "", "extra=1")
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, `snapd_recovery_mode=run edition=3 extra=1`)
+	// recovery uses a new edition
+	args, err = recoverymg.CandidateCommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=20200202", "extra=1")
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, `snapd_recovery_mode=recover snapd_recovery_system=20200202 recovery edition=4up extra=1`)
+}
+
 func (s *grubTestSuite) TestCommandLineReal(c *C) {
 	grubCfg := `# Snapd-Boot-Config-Edition: 1
 boot script

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -334,6 +334,8 @@ func maybePreserveManagedBootAssets(mountPoint string, ps *LaidOutStructure) ([]
 		// assets
 		return nil, nil
 	}
+	// TODO:UC20: this should no longer be checked when we use the updater
+	// interface from boot
 	managed, err := mbl.IsCurrentlyManaged()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Where the candidate command line is based on the current internal edition of the
asset.
