### PR TITLE
boot: add current recovery systems to modeenv

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -255,15 +255,18 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		}
 	}
 
+	recoverySystemLabel := filepath.Base(bootWith.RecoverySystemDir)
 	// write modeenv on the ubuntu-data partition
 	modeenv := &Modeenv{
 		Mode:           "run",
-		RecoverySystem: filepath.Base(bootWith.RecoverySystemDir),
-		Base:           filepath.Base(bootWith.BasePath),
-		CurrentKernels: []string{bootWith.Kernel.Filename()},
-		BrandID:        model.BrandID(),
-		Model:          model.Model(),
-		Grade:          string(model.Grade()),
+		RecoverySystem: recoverySystemLabel,
+		// default to the system we were installed from
+		CurrentRecoverySystems: []string{recoverySystemLabel},
+		Base:                   filepath.Base(bootWith.BasePath),
+		CurrentKernels:         []string{bootWith.Kernel.Filename()},
+		BrandID:                model.BrandID(),
+		Model:                  model.Model(),
+		Grade:                  string(model.Grade()),
 	}
 	if err := modeenv.WriteTo(InstallHostWritableDir); err != nil {
 		return fmt.Errorf("cannot write modeenv: %v", err)

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -262,11 +262,12 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		RecoverySystem: recoverySystemLabel,
 		// default to the system we were installed from
 		CurrentRecoverySystems: []string{recoverySystemLabel},
-		Base:                   filepath.Base(bootWith.BasePath),
-		CurrentKernels:         []string{bootWith.Kernel.Filename()},
-		BrandID:                model.BrandID(),
-		Model:                  model.Model(),
-		Grade:                  string(model.Grade()),
+		// keep this comment to make gofmt 1.9 happy
+		Base:           filepath.Base(bootWith.BasePath),
+		CurrentKernels: []string{bootWith.Kernel.Filename()},
+		BrandID:        model.BrandID(),
+		Model:          model.Model(),
+		Grade:          string(model.Grade()),
 	}
 	if err := modeenv.WriteTo(InstallHostWritableDir); err != nil {
 		return fmt.Errorf("cannot write modeenv: %v", err)

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -442,6 +442,7 @@ version: 5.0
 	ubuntuDataModeEnvPath := filepath.Join(rootdir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/modeenv")
 	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, `mode=run
 recovery_system=20191216
+current_recovery_systems=20191216
 base=core20_3.snap
 current_kernels=pc-kernel_5.snap
 model=my-brand/my-model-uc20
@@ -732,6 +733,7 @@ version: 5.0
 	ubuntuDataModeEnvPath := filepath.Join(rootdir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/modeenv")
 	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, `mode=run
 recovery_system=20191216
+current_recovery_systems=20191216
 base=core20_3.snap
 current_kernels=arm-kernel_5.snap
 model=my-brand/my-model-uc20

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -101,15 +101,16 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 		Mode:                   mode,
 		RecoverySystem:         recoverySystem,
 		CurrentRecoverySystems: currentRecoverySystems,
-		Base:                   base,
-		TryBase:                tryBase,
-		BaseStatus:             baseStatus,
-		CurrentKernels:         kernels,
-		BrandID:                brand,
-		Grade:                  grade,
-		Model:                  model,
-		read:                   true,
-		originRootdir:          rootdir,
+		// keep this comment to make gofmt 1.9 happy
+		Base:           base,
+		TryBase:        tryBase,
+		BaseStatus:     baseStatus,
+		CurrentKernels: kernels,
+		BrandID:        brand,
+		Grade:          grade,
+		Model:          model,
+		read:           true,
+		originRootdir:  rootdir,
 	}, nil
 }
 

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -251,21 +251,53 @@ func (s *modeenvSuite) TestWriteToNonExistingFull(c *C) {
 	c.Assert(s.mockModeenvPath, testutil.FileAbsent)
 
 	modeenv := &boot.Modeenv{
-		Mode:           "run",
-		RecoverySystem: "20191128",
-		Base:           "core20_321.snap",
-		TryBase:        "core20_322.snap",
-		BaseStatus:     boot.TryStatus,
-		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
+		Mode:                   "run",
+		RecoverySystem:         "20191128",
+		CurrentRecoverySystems: []string{"20191128", "2020-02-03", "20240101-FOO"},
+		Base:                   "core20_321.snap",
+		TryBase:                "core20_322.snap",
+		BaseStatus:             boot.TryStatus,
+		CurrentKernels:         []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
 	}
 	err := modeenv.WriteTo(s.tmpdir)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, `mode=run
 recovery_system=20191128
+current_recovery_systems=20191128,2020-02-03,20240101-FOO
 base=core20_321.snap
 try_base=core20_322.snap
 base_status=try
 current_kernels=pc-kernel_1.snap,pc-kernel_2.snap
 `)
+}
+
+func (s *modeenvSuite) TestReadRecoverySystems(c *C) {
+	tt := []struct {
+		systemsString   string
+		expectedSystems []string
+	}{
+		{
+			"20191126",
+			[]string{"20191126"},
+		}, {
+			"20191128,2020-02-03,20240101-FOO",
+			[]string{"20191128", "2020-02-03", "20240101-FOO"},
+		},
+		{",,,", nil},
+		{"", nil},
+	}
+
+	for _, t := range tt {
+		c.Logf("tc: %q", t.systemsString)
+		s.makeMockModeenvFile(c, `mode=recovery
+recovery_system=20191126
+current_recovery_systems=`+t.systemsString+"\n")
+
+		modeenv, err := boot.ReadModeenv(s.tmpdir)
+		c.Assert(err, IsNil)
+		c.Check(modeenv.Mode, Equals, "recovery")
+		c.Check(modeenv.RecoverySystem, Equals, "20191126")
+		c.Check(modeenv.CurrentRecoverySystems, DeepEquals, t.expectedSystems)
+	}
 }

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -254,10 +254,11 @@ func (s *modeenvSuite) TestWriteToNonExistingFull(c *C) {
 		Mode:                   "run",
 		RecoverySystem:         "20191128",
 		CurrentRecoverySystems: []string{"20191128", "2020-02-03", "20240101-FOO"},
-		Base:                   "core20_321.snap",
-		TryBase:                "core20_322.snap",
-		BaseStatus:             boot.TryStatus,
-		CurrentKernels:         []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
+		// keep this comment to make gofmt 1.9 happy
+		Base:           "core20_321.snap",
+		TryBase:        "core20_322.snap",
+		BaseStatus:     boot.TryStatus,
+		CurrentKernels: []string{"pc-kernel_1.snap", "pc-kernel_2.snap"},
 	}
 	err := modeenv.WriteTo(s.tmpdir)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Add current recovery systems to modeenv, stored as a comma separated string list
under `current_recovery_systems` key.
