### PR TITLE
gadget/install: retrieve command lines from bootloader

### DIFF
--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -176,12 +176,18 @@ func Run(gadgetRoot, device string, options Options) error {
 		loadChain = append(loadChain, options.KernelPath)
 	}
 
-	// TODO:UC20: get cmdline definition from bootloaders
+	// Get kernel command lines
+	cmdline, err := boot.ComposeCommandLine(options.Model)
+	if err != nil {
+		return fmt.Errorf("cannot obtain kernel command line: %v", err)
+	}
+	recoveryCmdline, err := boot.ComposeRecoveryCommandLine(options.Model, options.SystemLabel)
+	if err != nil {
+		return fmt.Errorf("cannot obtain recovery kernel command line: %v", err)
+	}
 	kernelCmdlines := []string{
-		// run mode
-		"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
-		// recover mode
-		fmt.Sprintf("snapd_recovery_mode=recover snapd_recovery_system=%s console=ttyS0 console=tty1 panic=-1", options.SystemLabel),
+		cmdline,
+		recoveryCmdline,
 	}
 
 	sealKeyParams := secboot.SealKeyParams{

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -176,15 +176,18 @@ func Run(gadgetRoot, device string, options Options) error {
 		loadChain = append(loadChain, options.KernelPath)
 	}
 
-	// Get kernel command lines
-	cmdline, err := boot.ComposeCommandLine(options.Model)
+	// Get the expected kernel command line for the system that is currently being installed
+	cmdline, err := boot.ComposeCandidateCommandLine(options.Model)
 	if err != nil {
 		return fmt.Errorf("cannot obtain kernel command line: %v", err)
 	}
+
+	// Get the expected kernel command line of the recovery system we're installing from
 	recoveryCmdline, err := boot.ComposeRecoveryCommandLine(options.Model, options.SystemLabel)
 	if err != nil {
 		return fmt.Errorf("cannot obtain recovery kernel command line: %v", err)
 	}
+
 	kernelCmdlines := []string{
 		cmdline,
 		recoveryCmdline,


### PR DESCRIPTION
Replace the hardcoded command lines with the actual kernel command
lines used in the bootloader.

Note: this is a simple replacement to use the composite command line, further
modifications to this code can be done during the key reseal feature development.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>