### PR TITLE
osutil/disks: use a dedicated error to indicate a fs label wasn't found

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -22,6 +22,7 @@ package disks
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -30,6 +31,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"golang.org/x/xerrors"
 
 	"github.com/snapcore/snapd/osutil"
 )
@@ -309,6 +312,8 @@ func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
 	return nil, fmt.Errorf("cannot find disk for partition %s, incomplete udev output", partMountPointSource)
 }
 
+var FilesystemLabelNotFound = errors.New("filesystem label not found")
+
 func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
 	encodedLabel := BlkIDEncodeLabel(label)
 	// if we haven't found the partitions for this disk yet, do that now
@@ -379,7 +384,7 @@ func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
 		return partuuid, nil
 	}
 
-	return "", fmt.Errorf("couldn't find label %q", label)
+	return "", xerrors.Errorf("could not find label %q: %w", label, FilesystemLabelNotFound)
 }
 
 func (d *disk) MountPointIsFromDisk(mountpoint string, opts *Options) (bool, error) {

--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -73,7 +73,7 @@ type Disk interface {
 	// non-ascii labels like "Some label", the label will be encoded using
 	// \x<hex> for potentially non-safe characters like in "Some\x20Label".
 	// If the filesystem label was not found on the disk, and no other errors
-	// were encountered, ErrFilesystemLabelNotFound will be returned.
+	// were encountered, a FilesystemLabelNotFoundError will be returned.
 	FindMatchingPartitionUUID(string) (string, error)
 
 	// MountPointIsFromDisk returns whether the specified mountpoint corresponds
@@ -311,17 +311,17 @@ func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
 	return nil, fmt.Errorf("cannot find disk for partition %s, incomplete udev output", partMountPointSource)
 }
 
-// ErrFilesystemLabelNotFound is an error where the specified label was not
+// FilesystemLabelNotFoundError is an error where the specified label was not
 // found on the disk.
-type ErrFilesystemLabelNotFound struct {
+type FilesystemLabelNotFoundError struct {
 	Label string
 }
 
 var (
-	_ = error(ErrFilesystemLabelNotFound{})
+	_ = error(FilesystemLabelNotFoundError{})
 )
 
-func (e ErrFilesystemLabelNotFound) Error() string {
+func (e FilesystemLabelNotFoundError) Error() string {
 	return fmt.Sprintf("filesystem label %q not found", e.Label)
 }
 
@@ -395,7 +395,7 @@ func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
 		return partuuid, nil
 	}
 
-	return "", ErrFilesystemLabelNotFound{Label: label}
+	return "", FilesystemLabelNotFoundError{Label: label}
 }
 
 func (d *disk) MountPointIsFromDisk(mountpoint string, opts *Options) (bool, error) {

--- a/osutil/disks/disks_test.go
+++ b/osutil/disks/disks_test.go
@@ -418,11 +418,11 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 	// finally we can't find the bios-boot partition because it has no label
 	_, err = ubuntuBootDisk.FindMatchingPartitionUUID("bios-boot")
 	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
-	c.Assert(xerrors.Is(err, disks.FilesystemLabelNotFound), Equals, true)
+	c.Assert(xerrors.Is(err, disks.ErrFilesystemLabelNotFound), Equals, true)
 
 	_, err = ubuntuDataDisk.FindMatchingPartitionUUID("bios-boot")
 	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
-	c.Assert(xerrors.Is(err, disks.FilesystemLabelNotFound), Equals, true)
+	c.Assert(xerrors.Is(err, disks.ErrFilesystemLabelNotFound), Equals, true)
 }
 
 func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {

--- a/osutil/disks/disks_test.go
+++ b/osutil/disks/disks_test.go
@@ -418,7 +418,7 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 	// finally we can't find the bios-boot partition because it has no label
 	_, err = ubuntuBootDisk.FindMatchingPartitionUUID("bios-boot")
 	c.Assert(err, ErrorMatches, "filesystem label \"bios-boot\" not found")
-	var notFoundErr disks.ErrFilesystemLabelNotFound
+	var notFoundErr disks.FilesystemLabelNotFoundError
 	c.Assert(xerrors.As(err, &notFoundErr), Equals, true)
 
 	_, err = ubuntuDataDisk.FindMatchingPartitionUUID("bios-boot")

--- a/osutil/disks/disks_test.go
+++ b/osutil/disks/disks_test.go
@@ -417,12 +417,13 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 
 	// finally we can't find the bios-boot partition because it has no label
 	_, err = ubuntuBootDisk.FindMatchingPartitionUUID("bios-boot")
-	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
-	c.Assert(xerrors.Is(err, disks.ErrFilesystemLabelNotFound), Equals, true)
+	c.Assert(err, ErrorMatches, "filesystem label \"bios-boot\" not found")
+	var notFoundErr disks.ErrFilesystemLabelNotFound
+	c.Assert(xerrors.As(err, &notFoundErr), Equals, true)
 
 	_, err = ubuntuDataDisk.FindMatchingPartitionUUID("bios-boot")
-	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
-	c.Assert(xerrors.Is(err, disks.ErrFilesystemLabelNotFound), Equals, true)
+	c.Assert(err, ErrorMatches, "filesystem label \"bios-boot\" not found")
+	c.Assert(xerrors.As(err, &notFoundErr), Equals, true)
 }
 
 func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {

--- a/osutil/disks/disks_test.go
+++ b/osutil/disks/disks_test.go
@@ -27,6 +27,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"golang.org/x/xerrors"
+
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
@@ -415,10 +417,12 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 
 	// finally we can't find the bios-boot partition because it has no label
 	_, err = ubuntuBootDisk.FindMatchingPartitionUUID("bios-boot")
-	c.Assert(err, ErrorMatches, "couldn't find label \"bios-boot\"")
+	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
+	c.Assert(xerrors.Is(err, disks.FilesystemLabelNotFound), Equals, true)
 
 	_, err = ubuntuDataDisk.FindMatchingPartitionUUID("bios-boot")
-	c.Assert(err, ErrorMatches, "couldn't find label \"bios-boot\"")
+	c.Assert(err, ErrorMatches, "could not find label \"bios-boot\": filesystem label not found")
+	c.Assert(xerrors.Is(err, disks.FilesystemLabelNotFound), Equals, true)
 }
 
 func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {


### PR DESCRIPTION
It will be necessary in the secboot package to positively indicate that a FS
label was not found and that we didn't have some other error, as the first step
to unlocking is to check if there is an encrypted device. We currently identify
that by using /dev/disk/by-label/ubuntu-data-enc, but this is insecure and buggy
as it means if the boot disk was not encrypted (i.e. on a device with a TPM but
without FDE enabled/used), an attacker can attach a USB drive with a FS label of
ubuntu-data-enc (as opposed to the real boot disk with ubuntu-data label on it),
and now the system will fail to boot because the ubuntu-data-enc USB drive FS
label will not be unlockable. We will avoid this bug by checking if the disk
that we booted the kernel from (and mounted the first partition using) has a
partition with a FS label on it called ubuntu-data-enc, rather than any
partition with a FS label of ubuntu-data-enc.