### PR TITLE
 secboot,cmd/snap-bootstrap: cross-check partitions before unlocking, mounting

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1073,12 +1073,13 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C
 	c.Assert(err, IsNil)
 
 	activated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, error) {
+	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(encryptionKeyDir, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde"))
 		c.Assert(lockKeysOnFinish, Equals, true)
 		activated = true
-		return "path-to-device", nil
+		// return true because we are using an encrypted device
+		return "path-to-device", true, nil
 	})
 	defer restore()
 
@@ -1700,7 +1701,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 	defer restore()
 
 	activated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, error) {
+	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(encryptionKeyDir, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde"))
 		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
@@ -1708,7 +1709,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 		c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 		c.Assert(lockKeysOnFinish, Equals, true)
 		activated = true
-		return filepath.Join("/dev/disk/by-partuuid", encDevPartUUID), nil
+		return filepath.Join("/dev/disk/by-partuuid", encDevPartUUID), true, nil
 	})
 	defer restore()
 
@@ -1791,14 +1792,14 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	defer restore()
 
 	activated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, error) {
+	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 		c.Assert(lockKeysOnFinish, Equals, true)
 		activated = true
-		return filepath.Join("/dev/disk/by-partuuid", encDevPartUUID), nil
+		return filepath.Join("/dev/disk/by-partuuid", encDevPartUUID), true, nil
 	})
 	defer restore()
 

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/osutil/disks"
 )
 
 var (
@@ -76,7 +77,7 @@ func MockDefaultMarkerFile(p string) (restore func()) {
 	}
 }
 
-func MockSecbootUnlockVolumeIfEncrypted(f func(name, encryptionKeyDir string, lockKeysOnFinish bool) (string, error)) (restore func()) {
+func MockSecbootUnlockVolumeIfEncrypted(f func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, error)) (restore func()) {
 	old := secbootUnlockVolumeIfEncrypted
 	secbootUnlockVolumeIfEncrypted = f
 	return func() {

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -77,7 +77,7 @@ func MockDefaultMarkerFile(p string) (restore func()) {
 	}
 }
 
-func MockSecbootUnlockVolumeIfEncrypted(f func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, error)) (restore func()) {
+func MockSecbootUnlockVolumeIfEncrypted(f func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error)) (restore func()) {
 	old := secbootUnlockVolumeIfEncrypted
 	secbootUnlockVolumeIfEncrypted = f
 	return func() {

--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -67,6 +67,9 @@ type Options struct {
 }
 
 // Disk is a single physical disk device that contains partitions.
+// TODO:UC20: add function to get some properties like an associated /dev node
+//            for a disk for better user error reporting, i.e. /dev/vda3 is much
+//            more helpful than 252:3
 type Disk interface {
 	// FindMatchingPartitionUUID finds the partition uuid for a partition
 	// matching the specified filesystem label on the disk. Note that for
@@ -80,6 +83,9 @@ type Disk interface {
 	// to a partition on the disk. Note that this only considers partitions
 	// and mountpoints found when the disk was identified with
 	// DiskFromMountPoint.
+	// TODO:UC20: make this function return what a Disk of where the mount point
+	//            is actually from if it is not from the same disk for better
+	//            error reporting
 	MountPointIsFromDisk(string, *Options) (bool, error)
 
 	// Dev returns the string "major:minor" number for the disk device.

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -118,14 +118,6 @@ func MockSbMeasureSnapModelToTPM(f func(tpm *sb.TPMConnection, pcrIndex int, mod
 	}
 }
 
-func MockDevDiskByLabelDir(f string) (restore func()) {
-	old := devDiskByLabelDir
-	devDiskByLabelDir = f
-	return func() {
-		devDiskByLabelDir = old
-	}
-}
-
 func MockRandomKernelUUID(f func() string) (restore func()) {
 	old := randutilRandomKernelUUID
 	randutilRandomKernelUUID = f

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -25,15 +25,7 @@ package secboot
 // Debian does run "go list" without any support for passing -tags.
 
 import (
-	"path/filepath"
-
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/osutil"
-)
-
-var (
-	// for mocking by tests
-	devDiskByLabelDir = "/dev/disk/by-label"
 )
 
 type SealKeyModelParams struct {
@@ -54,12 +46,4 @@ type SealKeyParams struct {
 	TPMPolicyUpdateDataFile string
 	// The path to the lockout authorization file (only relevant for TPM)
 	TPMLockoutAuthFile string
-}
-
-func isDeviceEncrypted(name string) (ok bool, encdev string) {
-	encdev = filepath.Join(devDiskByLabelDir, name+"-enc")
-	if osutil.FileExists(encdev) {
-		return true, encdev
-	}
-	return false, ""
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -239,10 +239,7 @@ func UnlockVolumeIfEncrypted(disk disks.Disk, name string, encryptionKeyDir stri
 		if !tpmDeviceAvailable {
 			return unlockEncryptedPartitionWithRecoveryKey(mapperName, encdev), true
 		}
-		// TODO:UC20: snap-bootstrap should validate that <name>-enc is what
-		//            we expect (and not e.g. an external disk), and also that
-		//            <name> is from <name>-enc and not an unencrypted partition
-		//            with the same name (LP #1863886)
+
 		sealedKeyPath := filepath.Join(encryptionKeyDir, name+".sealed-key")
 		return unlockEncryptedPartitionWithSealedKey(tpm, mapperName, encdev, sealedKeyPath, "", lockKeysOnFinish), true
 	}()

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -431,9 +431,10 @@ func (s *secbootSuite) TestUnlockIfEncrypted(c *C) {
 		})
 		defer restore()
 
-		device, err := secboot.UnlockVolumeIfEncrypted(tc.disk, "name", boot.InitramfsEncryptionKeyDir, tc.lockRequest)
+		device, isDecryptDev, err := secboot.UnlockVolumeIfEncrypted(tc.disk, "name", boot.InitramfsEncryptionKeyDir, tc.lockRequest)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
+			c.Assert(isDecryptDev, Equals, tc.hasEncdev)
 			if tc.hasEncdev {
 				c.Assert(device, Equals, filepath.Join("/dev/mapper", tc.device+"-"+randomUUID))
 			} else {

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader/efi"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -231,6 +232,27 @@ func (s *secbootSuite) TestMeasureSnapModelWhenPossible(c *C) {
 }
 
 func (s *secbootSuite) TestUnlockIfEncrypted(c *C) {
+
+	// setup mock disks to use for locating the partition
+	// restore := disks.MockMountPointDisksToPartionMapping()
+	// defer restore()
+
+	mockDiskWithEncDev := &disks.MockDiskMapping{
+		FilesystemLabelToPartUUID: map[string]string{
+			"name-enc": "enc-dev-partuuid",
+		},
+	}
+
+	mockDiskWithoutAnyDev := &disks.MockDiskMapping{
+		FilesystemLabelToPartUUID: map[string]string{},
+	}
+
+	mockDiskWithUnencDev := &disks.MockDiskMapping{
+		FilesystemLabelToPartUUID: map[string]string{
+			"name": "unenc-dev-partuuid",
+		},
+	}
+
 	for idx, tc := range []struct {
 		tpmErr      error
 		tpmEnabled  bool  // TPM storage and endorsement hierarchies disabled, only relevant if TPM available
@@ -241,84 +263,116 @@ func (s *secbootSuite) TestUnlockIfEncrypted(c *C) {
 		activated   bool  // the activation operation succeeded
 		device      string
 		err         string
+		disk        *disks.MockDiskMapping
 	}{
 		{
 			// happy case with tpm and encrypted device (lock requested)
 			tpmEnabled: true, hasEncdev: true, lockRequest: true, lockOk: true,
 			activated: true, device: "name",
+			disk: mockDiskWithEncDev,
 		}, {
 			// device activation fails (lock requested)
 			tpmEnabled: true, hasEncdev: true, lockRequest: true, lockOk: true,
-			err: "cannot activate encrypted device .*: activation error",
+			err:    "cannot activate encrypted device .*: activation error",
+			device: "name",
+			disk:   mockDiskWithEncDev,
 		}, {
 			// activation works but lock fails (lock requested)
 			tpmEnabled: true, hasEncdev: true, lockRequest: true, activated: true,
-			err: "cannot lock access to sealed keys: lock failed",
+			err:    "cannot lock access to sealed keys: lock failed",
+			device: "name",
+			disk:   mockDiskWithEncDev,
 		}, {
 			// happy case with tpm and encrypted device
 			tpmEnabled: true, hasEncdev: true, lockOk: true, activated: true,
 			device: "name",
+			disk:   mockDiskWithEncDev,
 		}, {
 			// device activation fails
 			tpmEnabled: true, hasEncdev: true,
-			err: "cannot activate encrypted device .*: activation error",
+			err:    "cannot activate encrypted device .*: activation error",
+			device: "name",
+			disk:   mockDiskWithEncDev,
 		}, {
 			// activation works but lock fails
 			tpmEnabled: true, hasEncdev: true, activated: true, device: "name",
+			disk: mockDiskWithEncDev,
 		}, {
 			// happy case without encrypted device (lock requested)
 			tpmEnabled: true, lockRequest: true, lockOk: true, activated: true,
 			device: "name",
+			disk:   mockDiskWithUnencDev,
 		}, {
 			// activation works but lock fails, without encrypted device (lock requested)
 			tpmEnabled: true, lockRequest: true, activated: true,
-			err: "cannot lock access to sealed keys: lock failed",
+			err:  "cannot lock access to sealed keys: lock failed",
+			disk: mockDiskWithUnencDev,
 		}, {
 			// happy case without encrypted device
 			tpmEnabled: true, lockOk: true, activated: true, device: "name",
+			disk: mockDiskWithUnencDev,
 		}, {
 			// activation works but lock fails, no encrypted device
 			tpmEnabled: true, activated: true, device: "name",
+			disk: mockDiskWithUnencDev,
 		}, {
 			// tpm error, no encrypted device
 			tpmErr: errors.New("tpm error"),
 			err:    `cannot unlock encrypted device "name": tpm error`,
+			disk:   mockDiskWithUnencDev,
 		}, {
 			// tpm error, has encrypted device
 			tpmErr: errors.New("tpm error"), hasEncdev: true,
-			err: `cannot unlock encrypted device "name": tpm error`,
+			err:  `cannot unlock encrypted device "name": tpm error`,
+			disk: mockDiskWithEncDev,
 		}, {
 			// tpm disabled, no encrypted device
 			device: "name",
+			disk:   mockDiskWithUnencDev,
 		}, {
 			// tpm disabled, has encrypted device, unlocked using the recovery key
 			hasEncdev: true,
 			device:    "name",
+			disk:      mockDiskWithEncDev,
 		}, {
 			// tpm disabled, has encrypted device, recovery key unlocking fails
 			hasEncdev: true, rkErr: errors.New("cannot unlock with recovery key"),
-			err: `cannot unlock encrypted device ".*/name-enc": cannot unlock with recovery key`,
+			disk: mockDiskWithEncDev,
+			err:  `cannot unlock encrypted device ".*/enc-dev-partuuid": cannot unlock with recovery key`,
 		}, {
 			// no tpm, has encrypted device, unlocked using the recovery key (lock requested)
 			tpmErr: sb.ErrNoTPM2Device, hasEncdev: true, lockRequest: true,
+			disk:   mockDiskWithEncDev,
 			device: "name",
 		}, {
 			// no tpm, has encrypted device, recovery key unlocking fails
 			rkErr:  errors.New("cannot unlock with recovery key"),
 			tpmErr: sb.ErrNoTPM2Device, hasEncdev: true, lockRequest: true,
-			err: `cannot unlock encrypted device ".*/name-enc": cannot unlock with recovery key`,
+			disk: mockDiskWithEncDev,
+			err:  `cannot unlock encrypted device ".*/enc-dev-partuuid": cannot unlock with recovery key`,
 		}, {
 			// no tpm, has encrypted device, unlocked using the recovery key
 			tpmErr: sb.ErrNoTPM2Device, hasEncdev: true,
+			disk:   mockDiskWithEncDev,
 			device: "name",
 		}, {
 			// no tpm, no encrypted device (lock requested)
 			tpmErr: sb.ErrNoTPM2Device, lockRequest: true,
+			disk:   mockDiskWithUnencDev,
 			device: "name",
 		}, {
 			// no tpm, no encrypted device
 			tpmErr: sb.ErrNoTPM2Device,
+			disk:   mockDiskWithUnencDev,
 			device: "name",
+		}, {
+			// no disks at all
+			disk:   mockDiskWithoutAnyDev,
+			device: "name",
+			// error is specifically for failing to find name, NOT name-enc, we
+			// will properly fall back to looking for name if we didn't find
+			// name-enc
+			err: "filesystem label \"name\" not found",
 		},
 	} {
 		randomUUID := fmt.Sprintf("random-uuid-for-test-%d", idx)
@@ -347,17 +401,17 @@ func (s *secbootSuite) TestUnlockIfEncrypted(c *C) {
 		})
 		defer restore()
 
-		devDiskByLabel, restoreDev := mockDevDiskByLabel(c)
-		defer restoreDev()
+		fsLabel := tc.device
 		if tc.hasEncdev {
-			err := ioutil.WriteFile(filepath.Join(devDiskByLabel, "name-enc"), nil, 0644)
-			c.Assert(err, IsNil)
+			fsLabel += "-enc"
 		}
+		partuuid := tc.disk.FilesystemLabelToPartUUID[fsLabel]
+		devicePath := filepath.Join("/dev/disk/by-partuuid", partuuid)
 
 		restore = secboot.MockSbActivateVolumeWithTPMSealedKey(func(tpm *sb.TPMConnection, volumeName, sourceDevicePath,
 			keyPath string, pinReader io.Reader, options *sb.ActivateWithTPMSealedKeyOptions) (bool, error) {
 			c.Assert(volumeName, Equals, "name-"+randomUUID)
-			c.Assert(sourceDevicePath, Equals, filepath.Join(devDiskByLabel, "name-enc"))
+			c.Assert(sourceDevicePath, Equals, devicePath)
 			c.Assert(keyPath, Equals, filepath.Join(boot.InitramfsEncryptionKeyDir, "name.sealed-key"))
 			c.Assert(*options, DeepEquals, sb.ActivateWithTPMSealedKeyOptions{
 				PINTries:            1,
@@ -377,20 +431,16 @@ func (s *secbootSuite) TestUnlockIfEncrypted(c *C) {
 		})
 		defer restore()
 
-		device, err := secboot.UnlockVolumeIfEncrypted("name", boot.InitramfsEncryptionKeyDir, tc.lockRequest)
+		device, err := secboot.UnlockVolumeIfEncrypted(tc.disk, "name", boot.InitramfsEncryptionKeyDir, tc.lockRequest)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
-		} else {
-			c.Assert(err, ErrorMatches, tc.err)
-		}
-		if tc.device == "" {
-			c.Assert(device, Equals, tc.device)
-		} else {
 			if tc.hasEncdev {
 				c.Assert(device, Equals, filepath.Join("/dev/mapper", tc.device+"-"+randomUUID))
 			} else {
-				c.Assert(device, Equals, filepath.Join(devDiskByLabel, tc.device))
+				c.Assert(device, Equals, devicePath)
 			}
+		} else {
+			c.Assert(err, ErrorMatches, tc.err)
 		}
 		// LockAccessToSealedKeys should be called whenever there is a TPM device
 		// detected, regardless of whether secure boot is enabled or there is an
@@ -650,12 +700,4 @@ func mockSbTPMConnection(c *C, tpmErr error) (*sb.TPMConnection, func()) {
 		return tpm, nil
 	})
 	return tpm, restore
-}
-
-func mockDevDiskByLabel(c *C) (string, func()) {
-	devDir := filepath.Join(c.MkDir(), "dev/disk/by-label")
-	err := os.MkdirAll(devDir, 0755)
-	c.Assert(err, IsNil)
-	restore := secboot.MockDevDiskByLabelDir(devDir)
-	return devDir, restore
 }


### PR DESCRIPTION
Based on top of #9170 for easier conflict resolution

Before we mount partitions, we should check / verify that the partition we want
to mount is coming from the same disk that we have already mounted partitions
from, or in the original case, that the partition comes from the same disk as we
booted the kernel from.

In the unlocking case in secboot, we should only try to unlock an encrypted
partition if it comes from the same disk that we mounted the first partition
from, i.e. ubuntu-boot in run mode and ubuntu-seed in recover mode.

Additionally, we should verify that the decrypted partition we got after
unlocking comes from the same encrypted partition that we requested it come
from.

Fixes: https://bugs.launchpad.net/snapd/+bug/1863886