### PR TITLE
interfaces/system-key: in WriteSystemKey during tests, don't call ParserFeatures

### DIFF
--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -177,10 +177,15 @@ func WriteSystemKey() error {
 		return err
 	}
 
-	// We only want to calculate this when the mtime of the parser changes.
-	// Since we calculate the mtime() as part of generateSystemKey, we can
-	// simply unconditionally write this out here.
-	sk.AppArmorParserFeatures, _ = apparmor.ParserFeatures()
+	// only fix AppArmorParserFeatures if we didn't already mock a system-key
+	// if we mocked a system-key we are running a test and don't want to use
+	// the real host system's parser features
+	if mockedSystemKey == nil {
+		// We only want to calculate this when the mtime of the parser changes.
+		// Since we calculate the mtime() as part of generateSystemKey, we can
+		// simply unconditionally write this out here.
+		sk.AppArmorParserFeatures, _ = apparmor.ParserFeatures()
+	}
 
 	sks, err := json.Marshal(sk)
 	if err != nil {

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -373,9 +373,7 @@ func (s *systemKeySuite) TestSystemKeysUnmarshalSame(c *C) {
 			"rlimit",
 			"signal"
 		],
-		"apparmor-parser-features": [
-			"unsafe"
-		],
+		"apparmor-parser-features": [],
 		"apparmor-parser-mtime": 1589907589,
 		"build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
 		"cgroup-version": "1",


### PR DESCRIPTION
Follow-up to https://github.com/snapcore/snapd/pull/9076. With that, we found that the test was failing like so:

```
system_key_test.go:415:
    c.Check(ok, Equals, true, Commentf("key1:%#v key2:%#v", key1, key2))
... obtained bool = false
... expected bool = true
... key1:&interfaces.systemKey{Version:10, BuildID:"cb94e5eeee4cf7ecda53f8308a984cb155b55732", AppArmorFeatures:[]string{"caps", "dbus", "domain", "file", "mount", "namespaces", "network", "network_v8", "policy", "ptrace", "query", "rlimit", "signal"}, AppArmorParserMtime:1589907589, AppArmorParserFeatures:[]string{"unsafe"}, NFSHome:false, OverlayRoot:"", SecCompActions:[]string{"allow", "errno", "kill_process", "kill_thread", "log", "trace", "trap", "user_notif"}, SeccompCompilerVersion:"e6e309ad8aee052e5aa695dfaa040328ae1559c5 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog", CgroupVersion:"1"} key2:&interfaces.systemKey{Version:10, BuildID:"cb94e5eeee4cf7ecda53f8308a984cb155b55732", AppArmorFeatures:[]string{"caps", "dbus", "domain", "file", "mount", "namespaces", "network", "network_v8", "policy", "ptrace", "query", "rlimit", "signal"}, AppArmorParserMtime:1589907589, AppArmorParserFeatures:[]string{}, NFSHome:false, OverlayRoot:"", SecCompActions:[]string{"allow", "errno", "kill_process", "kill_thread", "log", "trace", "trap", "user_notif"}, SeccompCompilerVersion:"e6e309ad8aee052e5aa695dfaa040328ae1559c5 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog", CgroupVersion:"1"}
```

Note the lack of "unsafe" in ApparmorParserFeatures in key1, which is the one that was written to disk with WriteSystemKey. This was because the apparmor-parser version from the host used in the lp buildd machine didn't support unsafe, so it ended up dropping "unsafe" from our mocked system key before writing it to disk.  

During tests, this would end up getting the parser features from the host rather
than from the mocked key, so on systems like LP buildd hosts with old kernels we
would end up modifying the mocked system key, which is wrong.

Also change the test that was failing on LP to use a system key which will be
different from the one on most modern Ubuntu systems to trigger the test failure
so that the change is proven effective.