### PR TITLE
cmd/snap-preseed: use snapd from the deb if newer than from seeds

### DIFF
--- a/cmd/snap-preseed/export_test.go
+++ b/cmd/snap-preseed/export_test.go
@@ -60,3 +60,7 @@ func MockSeedOpen(f func(rootDir, label string) (seed.Seed, error)) (restore fun
 		seedOpen = oldSeedOpen
 	}
 }
+
+func SnapdPathAndVersion(targetSnapd *targetSnapdInfo) (string, string) {
+	return targetSnapd.path, targetSnapd.version
+}

--- a/cmd/snap-preseed/export_test.go
+++ b/cmd/snap-preseed/export_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	Run                     = run
-	SystemSnapFromSeed      = systemSnapFromSeed
+	Run                      = run
+	SystemSnapFromSeed       = systemSnapFromSeed
 	ChooseTargetSnapdVersion = chooseTargetSnapdVersion
 )
 

--- a/cmd/snap-preseed/export_test.go
+++ b/cmd/snap-preseed/export_test.go
@@ -26,7 +26,7 @@ import (
 var (
 	Run                     = run
 	SystemSnapFromSeed      = systemSnapFromSeed
-	CheckTargetSnapdVersion = checkTargetSnapdVersion
+	ChooseTargetSnapdVersion = chooseTargetSnapdVersion
 )
 
 func MockOsGetuid(f func() int) (restore func()) {

--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -99,13 +99,13 @@ func run(parser *flags.Parser, args []string) error {
 		return err
 	}
 
-	cleanup, err := prepareChroot(chrootDir)
+	targetSnapd, cleanup, err := prepareChroot(chrootDir)
 	if err != nil {
 		return err
 	}
 
 	// executing inside the chroot
-	err = runPreseedMode(chrootDir)
+	err = runPreseedMode(chrootDir, targetSnapd)
 	cleanup()
 	return err
 }

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -424,47 +424,47 @@ func (s *startPreseedSuite) TestCheckTargetSnapdVersion(c *C) {
 	restoreMountPath := main.MockSnapdMountPath(targetSnapdRoot)
 	defer restoreMountPath()
 
-	var versions = []struct{
-		fromSnap string
-		fromDeb string
-		expectedPath string
+	var versions = []struct {
+		fromSnap        string
+		fromDeb         string
+		expectedPath    string
 		expectedVersion string
-		expectedErr string
+		expectedErr     string
 	}{
 		{
-			fromDeb: "2.44.0",
+			fromDeb:  "2.44.0",
 			fromSnap: "2.45.3+git123",
 			// snap version wins
 			expectedVersion: "2.45.3+git123",
-			expectedPath: filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
+			expectedPath:    filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
 		},
 		{
-			fromDeb: "2.44.0",
+			fromDeb:  "2.44.0",
 			fromSnap: "2.44.0",
 			// snap version wins
 			expectedVersion: "2.44.0",
-			expectedPath: filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
+			expectedPath:    filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
 		},
 		{
-			fromDeb: "2.45.1+20.04",
+			fromDeb:  "2.45.1+20.04",
 			fromSnap: "2.45.1",
 			// deb version wins
 			expectedVersion: "2.45.1+20.04",
-			expectedPath: filepath.Join(tmpDir, "usr/lib/snapd/snapd"),
+			expectedPath:    filepath.Join(tmpDir, "usr/lib/snapd/snapd"),
 		},
 		{
-			fromDeb: "2.45.2",
+			fromDeb:  "2.45.2",
 			fromSnap: "2.45.1",
 			// deb version wins
 			expectedVersion: "2.45.2",
-			expectedPath: filepath.Join(tmpDir, "usr/lib/snapd/snapd"),
+			expectedPath:    filepath.Join(tmpDir, "usr/lib/snapd/snapd"),
 		},
 		{
-			fromSnap: "2.45.1",
+			fromSnap:    "2.45.1",
 			expectedErr: fmt.Sprintf("cannot open snapd info file %q.*", filepath.Join(tmpDir, "usr/lib/snapd/info")),
 		},
 		{
-			fromDeb: "2.45.1",
+			fromDeb:     "2.45.1",
 			expectedErr: fmt.Sprintf("cannot open snapd info file %q.*", filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/info")),
 		},
 	}

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -481,11 +481,13 @@ func (s *startPreseedSuite) TestChooseTargetSnapdVersion(c *C) {
 			c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromSnap)), 0644), IsNil)
 		}
 
-		path, version, err := main.ChooseTargetSnapdVersion()
+		targetSnapd, err := main.ChooseTargetSnapdVersion()
 		if test.expectedErr != "" {
 			c.Assert(err, ErrorMatches, test.expectedErr)
 		} else {
 			c.Assert(err, IsNil)
+			c.Assert(targetSnapd, NotNil)
+			path, version := main.SnapdPathAndVersion(targetSnapd)
 			c.Check(path, Equals, test.expectedPath)
 			c.Check(version, Equals, test.expectedVersion)
 		}

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -414,7 +414,7 @@ func (s *startPreseedSuite) TestRunPreseedUnsupportedVersion(c *C) {
 		`snapd 2.43.0 from the target system does not support preseeding, the minimum required version is 2.43.3\+`)
 }
 
-func (s *startPreseedSuite) TestCheckTargetSnapdVersion(c *C) {
+func (s *startPreseedSuite) TestChooseTargetSnapdVersion(c *C) {
 	tmpDir := c.MkDir()
 	dirs.SetRootDir(tmpDir)
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "usr/lib/snapd/"), 0755), IsNil)
@@ -481,7 +481,7 @@ func (s *startPreseedSuite) TestCheckTargetSnapdVersion(c *C) {
 			c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromSnap)), 0644), IsNil)
 		}
 
-		path, version, err := main.CheckTargetSnapdVersion()
+		path, version, err := main.ChooseTargetSnapdVersion()
 		if test.expectedErr != "" {
 			c.Assert(err, ErrorMatches, test.expectedErr)
 		} else {

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -150,13 +150,13 @@ var systemSnapFromSeed = func(rootDir string) (string, error) {
 
 const snapdPreseedSupportVer = `2.43.3+`
 
-// checkTargetSnapdVersion checks if the version of snapd under chroot env
+// chooseTargetSnapdVersion checks if the version of snapd under chroot env
 // is good enough for preseeding. It checks both the snapd from the deb
 // and from the seeded snap mounted under snapdMountPath and returns the
 // full path of snapd to execute as part of preseeding (whichever version is
 // newer).
 // The function must be called after syscall.Chroot(..).
-func checkTargetSnapdVersion() (snapdPath string, whichVer string, err error) {
+func chooseTargetSnapdVersion() (snapdPath string, whichVer string, err error) {
 	// read snapd version from the mounted core/snapd snap
 	infoPath := filepath.Join(snapdMountPath, dirs.CoreLibExecDir, "info")
 	ver1, err := snapdtool.SnapdVersionFromInfoFile(infoPath)
@@ -255,7 +255,7 @@ func prepareChroot(preseedChroot string) (func(), error) {
 // runPreseedMode runs snapd in a preseed mode. It assumes running in a chroot.
 // The chroot is expected to be set-up and ready to use (critical system directories mounted).
 func runPreseedMode(preseedChroot string) error {
-	snapdPath, version, err := checkTargetSnapdVersion()
+	snapdPath, version, err := chooseTargetSnapdVersion()
 	if err != nil {
 		return err
 	}

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -151,7 +151,7 @@ var systemSnapFromSeed = func(rootDir string) (string, error) {
 const snapdPreseedSupportVer = `2.43.3+`
 
 type targetSnapdInfo struct {
-	path string
+	path    string
 	version string
 }
 

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -158,8 +158,8 @@ type targetSnapdInfo struct {
 // chooseTargetSnapdVersion checks if the version of snapd under chroot env
 // is good enough for preseeding. It checks both the snapd from the deb
 // and from the seeded snap mounted under snapdMountPath and returns the
-// full path of snapd to execute as part of preseeding (whichever version is
-// newer).
+// information (path, version) about snapd to execute as part of preseeding
+// (it picks the newer version of the two).
 // The function must be called after syscall.Chroot(..).
 func chooseTargetSnapdVersion() (*targetSnapdInfo, error) {
 	// read snapd version from the mounted core/snapd snap

--- a/cmd/snap-preseed/preseed_other.go
+++ b/cmd/snap-preseed/preseed_other.go
@@ -30,7 +30,7 @@ func checkChroot(preseedChroot string) error {
 	return preseedNotAvailableError
 }
 
-func prepareChroot(preseedChroot string) (func(), error) {
+func prepareChroot(preseedChroot string) (*targetSnapdInfo, func(), error) {
 	return nil, preseedNotAvailableError
 }
 

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -63,7 +63,7 @@ execute: |
   . "$TESTSLIB/preseed.sh"
 
   echo "Running pre-seeding"
-  /usr/lib/snapd/snap-preseed "$IMAGE_MOUNTPOINT"
+  /usr/lib/snapd/snap-preseed "$IMAGE_MOUNTPOINT" | MATCH "using snapd binary: /tmp/snapd-preseed/usr/lib/snapd/snapd"
 
   # mark-preseeded task is where snap-preseed stopped, therefore it's in Doing.
   snap debug state "$IMAGE_MOUNTPOINT"/var/lib/snapd/state.json --change=1 | MATCH "Doing .+ mark-preseeded +Mark system pre-seeded"


### PR DESCRIPTION
Compare snapd version from the deb and core*/snapd snap when preseeding, and use the newer one.