### PR TITLE
many: introduce content write observer, install mode glue, initial seal stubs

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -24,23 +24,23 @@ import (
 	"github.com/snapcore/snapd/gadget"
 )
 
-func InitialSealObserver(model *asserts.Model) gadget.ContentObserver {
+func NewTrustedAssetsInstallObserver(model *asserts.Model) *TrustedAssetsInstallObserver {
 	if model.Grade() == asserts.ModelGradeUnset {
 		// no need to observe updates when assets are not managed
 		return nil
 	}
 
-	return &initialSealObserver{
+	return &TrustedAssetsInstallObserver{
 		model: model,
 	}
 }
 
-type initialSealObserver struct {
+type TrustedAssetsInstallObserver struct {
 	model *asserts.Model
 }
 
 // Implements gadget.ContentObserver.
-func (o *initialSealObserver) Observe(op gadget.ContentOperation, affectedStruct *gadget.LaidOutStructure, root, realSource, relativeTarget string) (bool, error) {
+func (o *TrustedAssetsInstallObserver) Observe(op gadget.ContentOperation, affectedStruct *gadget.LaidOutStructure, root, realSource, relativeTarget string) (bool, error) {
 	// TODO:UC20:
 	// steps on write action:
 	// - copy new asset to assets cache
@@ -51,9 +51,8 @@ func (o *initialSealObserver) Observe(op gadget.ContentOperation, affectedStruct
 	return true, nil
 }
 
-// Implements gadget.ContentWriteObserver.
-func (o *initialSealObserver) Apply() error {
+func (o *TrustedAssetsInstallObserver) Seal() error {
 	// TODO:UC20: steps:
-	// - reseal
+	// - initial seal
 	return nil
 }

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -39,7 +39,7 @@ type initialSealObserver struct {
 	model *asserts.Model
 }
 
-// Implements gadget.FileWriteObserver.
+// Implements gadget.ContentWriteObserver.
 func (o *initialSealObserver) Observe(op gadget.ObserveAction, affectedStruct *gadget.LaidOutStructure, root, realSource, relativeTarget string) (gadget.ObserveResult, error) {
 	// TODO:UC20:
 	// steps on write action:
@@ -51,7 +51,7 @@ func (o *initialSealObserver) Observe(op gadget.ObserveAction, affectedStruct *g
 	return gadget.ObserveResultNoted, nil
 }
 
-// Implements gadget.FileWriteObserver.
+// Implements gadget.ContentWriteObserver.
 func (o *initialSealObserver) Apply() error {
 	// TODO:UC20: steps:
 	// - reseal

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -39,6 +39,11 @@ type TrustedAssetsInstallObserver struct {
 	model *asserts.Model
 }
 
+// Observe observes the operation related to the content of a given gadget
+// structure. In particular, the TrustedAssetsInstallObserver tracks writing of
+// managed boot assets, such as the bootloader binary which is measured as part
+// of the secure boot.
+//
 // Implements gadget.ContentObserver.
 func (o *TrustedAssetsInstallObserver) Observe(op gadget.ContentOperation, affectedStruct *gadget.LaidOutStructure, root, realSource, relativeTarget string) (bool, error) {
 	// TODO:UC20:
@@ -51,6 +56,8 @@ func (o *TrustedAssetsInstallObserver) Observe(op gadget.ContentOperation, affec
 	return true, nil
 }
 
+// Seal performs the initial sealing of encryption key to the TPM device
+// available in the system.
 func (o *TrustedAssetsInstallObserver) Seal() error {
 	// TODO:UC20: steps:
 	// - initial seal

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -24,7 +24,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 )
 
-func InitialSealObserver(model *asserts.Model) gadget.ContentWriteObserver {
+func InitialSealObserver(model *asserts.Model) gadget.ContentObserver {
 	if model.Grade() == asserts.ModelGradeUnset {
 		// no need to observe updates when assets are not managed
 		return nil
@@ -39,8 +39,8 @@ type initialSealObserver struct {
 	model *asserts.Model
 }
 
-// Implements gadget.ContentWriteObserver.
-func (o *initialSealObserver) Observe(op gadget.ObserveAction, affectedStruct *gadget.LaidOutStructure, root, realSource, relativeTarget string) (gadget.ObserveResult, error) {
+// Implements gadget.ContentObserver.
+func (o *initialSealObserver) Observe(op gadget.ContentOperation, affectedStruct *gadget.LaidOutStructure, root, realSource, relativeTarget string) (bool, error) {
 	// TODO:UC20:
 	// steps on write action:
 	// - copy new asset to assets cache
@@ -48,7 +48,7 @@ func (o *initialSealObserver) Observe(op gadget.ObserveAction, affectedStruct *g
 	// steps on rollback action:
 	// - drop file from cache if no longer referenced
 	// - update modeenv
-	return gadget.ObserveResultNoted, nil
+	return true, nil
 }
 
 // Implements gadget.ContentWriteObserver.

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import (
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/gadget"
+)
+
+func InitialSealObserver(model *asserts.Model) gadget.ContentWriteObserver {
+	if model.Grade() == asserts.ModelGradeUnset {
+		// no need to observe updates when assets are not managed
+		return nil
+	}
+
+	return &initialSealObserver{
+		model: model,
+	}
+}
+
+type initialSealObserver struct {
+	model *asserts.Model
+}
+
+// Implements gadget.FileWriteObserver.
+func (o *initialSealObserver) Observe(op gadget.ObserveAction, affectedStruct *gadget.LaidOutStructure, root, realSource, relativeTarget string) (gadget.ObserveResult, error) {
+	// TODO:UC20:
+	// steps on write action:
+	// - copy new asset to assets cache
+	// - update modeeenv
+	// steps on rollback action:
+	// - drop file from cache if no longer referenced
+	// - update modeenv
+	return gadget.ObserveResultNoted, nil
+}
+
+// Implements gadget.FileWriteObserver.
+func (o *initialSealObserver) Apply() error {
+	// TODO:UC20: steps:
+	// - reseal
+	return nil
+}

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -54,13 +54,13 @@ type BootableSet struct {
 // rootdir points to an image filesystem (UC 16/18), image recovery
 // filesystem (UC20 at prepare-image time) or ephemeral system (UC20
 // install mode).
-func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet, sealer *TrustedAssetsInstallObserver) error {
 	if model.Grade() == asserts.ModelGradeUnset {
 		return makeBootable16(model, rootdir, bootWith)
 	}
 
 	if !bootWith.Recovery {
-		return makeBootable20RunMode(model, rootdir, bootWith)
+		return makeBootable20RunMode(model, rootdir, bootWith, sealer)
 	}
 	return makeBootable20(model, rootdir, bootWith)
 }
@@ -225,7 +225,7 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	return nil
 }
 
-func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *BootableSet, sealer *TrustedAssetsInstallObserver) error {
 	// TODO:UC20:
 	// - figure out what to do for uboot gadgets, currently we require them to
 	//   install the boot.sel onto ubuntu-boot directly, but the file should be

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -126,7 +126,7 @@ version: 4.0
 		UnpackedGadgetDir: unpackedGadgetDir,
 	}
 
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, IsNil)
 
 	// check the bootloader config
@@ -268,7 +268,7 @@ version: 5.0
 		Recovery:            true,
 	}
 
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, IsNil)
 
 	// ensure only a single file got copied (the grub.cfg)
@@ -313,7 +313,7 @@ func (s *makeBootable20Suite) TestMakeBootable20UnsetRecoverySystemLabelError(c 
 		Recovery:          true,
 	}
 
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, ErrorMatches, "internal error: recovery system label unset")
 }
 
@@ -327,7 +327,7 @@ func (s *makeBootable20Suite) TestMakeBootable20MultipleRecoverySystemsError(c *
 	err = os.MkdirAll(filepath.Join(rootdir, "systems/20191205"), 0755)
 	c.Assert(err, IsNil)
 
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, ErrorMatches, "cannot make multiple recovery systems bootable yet")
 }
 
@@ -402,7 +402,7 @@ version: 5.0
 		UnpackedGadgetDir: unpackedGadgetDir,
 	}
 
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, IsNil)
 
 	// ensure grub.cfg in boot was installed from internal assets
@@ -508,7 +508,7 @@ version: 5.0
 	}
 
 	// no grub cfg in gadget directory raises an error
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, ErrorMatches, "cannot install boot config with a mismatched gadget")
 
 	// set up grub.cfg in gadget
@@ -519,7 +519,7 @@ version: 5.0
 	// no write access to destination directory
 	restore := assets.MockInternal("grub.cfg", nil)
 	defer restore()
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, ErrorMatches, `cannot install managed bootloader assets: internal error: no boot asset for "grub.cfg"`)
 }
 
@@ -571,7 +571,7 @@ version: 5.0
 	}
 
 	// TODO:UC20: enable this use case
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot find boot config in %q", unpackedGadgetDir))
 }
 
@@ -622,7 +622,7 @@ version: 5.0
 		Recovery:            true,
 	}
 
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, IsNil)
 
 	// since uboot.conf was absent, we won't have installed the uboot.env, as
@@ -701,7 +701,7 @@ version: 5.0
 		Recovery:          false,
 	}
 
-	err = boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith, nil)
 	c.Assert(err, IsNil)
 
 	// ensure base/kernel got copied to /var/lib/snapd/snaps

--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -40,8 +40,7 @@ var (
 	CanUpdateStructure = canUpdateStructure
 	CanUpdateVolume    = canUpdateVolume
 
-	WriteFile      = writeFileOrSymlink
-	WriteDirectory = writeDirectory
+	WriteFile = writeFileOrSymlink
 
 	RawContentBackupPath = rawContentBackupPath
 
@@ -70,4 +69,8 @@ func MockEvalSymlinks(mock func(path string) (string, error)) (restore func()) {
 	return func() {
 		evalSymlinks = oldEvalSymlinks
 	}
+}
+
+func (m *MountedFilesystemWriter) WriteDirectory(volumeRoot, src, dst string, preserveInDst []string) error {
+	return m.writeDirectory(volumeRoot, src, dst, preserveInDst)
 }

--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -52,7 +52,7 @@ func makeFilesystem(ds *gadget.OnDiskStructure) error {
 
 // writeContent populates the given on-disk structure, according to the contents
 // defined in the gadget.
-func writeContent(ds *gadget.OnDiskStructure, gadgetRoot string, observer gadget.ContentWriteObserver) error {
+func writeContent(ds *gadget.OnDiskStructure, gadgetRoot string, observer gadget.ContentObserver) error {
 	switch {
 	case !ds.IsPartition():
 		return fmt.Errorf("cannot write non-partitions yet")
@@ -90,7 +90,7 @@ func mountFilesystem(ds *gadget.OnDiskStructure, baseMntPoint string) error {
 	return nil
 }
 
-func writeFilesystemContent(ds *gadget.OnDiskStructure, gadgetRoot string, observer gadget.ContentWriteObserver) (err error) {
+func writeFilesystemContent(ds *gadget.OnDiskStructure, gadgetRoot string, observer gadget.ContentObserver) (err error) {
 	mountpoint := filepath.Join(contentMountpoint, strconv.Itoa(ds.Index))
 	if err := os.MkdirAll(mountpoint, 0755); err != nil {
 		return err

--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -52,7 +52,7 @@ func makeFilesystem(ds *gadget.OnDiskStructure) error {
 
 // writeContent populates the given on-disk structure, according to the contents
 // defined in the gadget.
-func writeContent(ds *gadget.OnDiskStructure, gadgetRoot string) error {
+func writeContent(ds *gadget.OnDiskStructure, gadgetRoot string, observer gadget.ContentWriteObserver) error {
 	switch {
 	case !ds.IsPartition():
 		return fmt.Errorf("cannot write non-partitions yet")
@@ -61,7 +61,7 @@ func writeContent(ds *gadget.OnDiskStructure, gadgetRoot string) error {
 			return err
 		}
 	case ds.HasFilesystem():
-		if err := writeFilesystemContent(ds, gadgetRoot); err != nil {
+		if err := writeFilesystemContent(ds, gadgetRoot, observer); err != nil {
 			return err
 		}
 	}
@@ -90,7 +90,7 @@ func mountFilesystem(ds *gadget.OnDiskStructure, baseMntPoint string) error {
 	return nil
 }
 
-func writeFilesystemContent(ds *gadget.OnDiskStructure, gadgetRoot string) (err error) {
+func writeFilesystemContent(ds *gadget.OnDiskStructure, gadgetRoot string, observer gadget.ContentWriteObserver) (err error) {
 	mountpoint := filepath.Join(contentMountpoint, strconv.Itoa(ds.Index))
 	if err := os.MkdirAll(mountpoint, 0755); err != nil {
 		return err
@@ -106,8 +106,7 @@ func writeFilesystemContent(ds *gadget.OnDiskStructure, gadgetRoot string) (err 
 			err = errUnmount
 		}
 	}()
-
-	fs, err := gadget.NewMountedFilesystemWriter(gadgetRoot, &ds.LaidOutStructure)
+	fs, err := gadget.NewMountedFilesystemWriter(gadgetRoot, &ds.LaidOutStructure, observer)
 	if err != nil {
 		return fmt.Errorf("cannot create filesystem image writer: %v", err)
 	}

--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -172,26 +172,49 @@ const gadgetContent = `volumes:
         size: 1200M
 `
 
+type mockWriteObserver struct {
+	content     map[string][][]string
+	applyErr    error
+	applyCalled int
+	c           *C
+}
+
+func (m *mockWriteObserver) Observe(op gadget.ObserveAction, sourceStruct *gadget.LaidOutStructure,
+	targetRootDir, sourcePath, relativeTargetPath string) (gadget.ObserveResult, error) {
+	if m.content == nil {
+		m.content = make(map[string][][]string)
+	}
+	m.content[targetRootDir] = append(m.content[targetRootDir], []string{sourcePath, relativeTargetPath})
+	return gadget.ObserveResultNoted, nil
+}
+
+func (m *mockWriteObserver) Apply() error {
+	m.applyCalled++
+	return m.applyErr
+}
+
 func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 	for _, tc := range []struct {
 		mountErr   error
 		unmountErr error
+		applyErr   error
 		err        string
 	}{
 		{
 			mountErr:   nil,
 			unmountErr: nil,
 			err:        "",
-		},
-		{
+		}, {
 			mountErr:   errors.New("mount error"),
 			unmountErr: nil,
 			err:        "cannot mount filesystem .*: mount error",
-		},
-		{
+		}, {
 			mountErr:   nil,
 			unmountErr: errors.New("unmount error"),
 			err:        "unmount error",
+		}, {
+			applyErr: errors.New("apply/seal error"),
+			err:      "cannot create filesystem image: cannot apply observed write actions: apply/seal error",
 		},
 	} {
 		mockMountpoint := c.MkDir()
@@ -219,8 +242,11 @@ func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 				},
 			},
 		}
-
-		err := install.WriteContent(&m, s.gadgetRoot)
+		obs := &mockWriteObserver{
+			c:        c,
+			applyErr: tc.applyErr,
+		}
+		err := install.WriteContent(&m, s.gadgetRoot, obs)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 		} else {
@@ -232,6 +258,12 @@ func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 			content, err := ioutil.ReadFile(filepath.Join(mockMountpoint, "2", "EFI/boot/grubx64.efi"))
 			c.Assert(err, IsNil)
 			c.Check(string(content), Equals, "grubx64.efi content")
+			c.Assert(obs.content, DeepEquals, map[string][][]string{
+				filepath.Join(mockMountpoint, "2"): {
+					{filepath.Join(s.gadgetRoot, "grubx64.efi"), "EFI/boot/grubx64.efi"},
+				},
+			})
+			c.Assert(obs.applyCalled, Equals, 1)
 		}
 	}
 }
@@ -254,7 +286,7 @@ func (s *contentTestSuite) TestWriteRawContent(c *C) {
 		},
 	}
 
-	err = install.WriteContent(&m, s.gadgetRoot)
+	err = install.WriteContent(&m, s.gadgetRoot, nil)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(m.Node)

--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -173,9 +173,10 @@ const gadgetContent = `volumes:
 `
 
 type mockWriteObserver struct {
-	content    map[string][][]string
-	observeErr error
-	c          *C
+	content        map[string][][]string
+	observeErr     error
+	expectedStruct *gadget.LaidOutStructure
+	c              *C
 }
 
 func (m *mockWriteObserver) Observe(op gadget.ContentOperation, sourceStruct *gadget.LaidOutStructure,
@@ -184,6 +185,8 @@ func (m *mockWriteObserver) Observe(op gadget.ContentOperation, sourceStruct *ga
 		m.content = make(map[string][][]string)
 	}
 	m.content[targetRootDir] = append(m.content[targetRootDir], []string{sourcePath, relativeTargetPath})
+	m.c.Assert(sourceStruct, NotNil)
+	m.c.Check(sourceStruct, DeepEquals, m.expectedStruct)
 	return true, m.observeErr
 }
 
@@ -237,8 +240,9 @@ func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 			},
 		}
 		obs := &mockWriteObserver{
-			c:          c,
-			observeErr: tc.observeErr,
+			c:              c,
+			observeErr:     tc.observeErr,
+			expectedStruct: &m.LaidOutStructure,
 		}
 		err := install.WriteContent(&m, s.gadgetRoot, obs)
 		if tc.err == "" {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -51,7 +51,7 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 
 // Run bootstraps the partitions of a device, by either creating
 // missing ones or recreating installed ones.
-func Run(gadgetRoot, device string, options Options) error {
+func Run(gadgetRoot, device string, options Options, observer gadget.ContentWriteObserver) error {
 	if options.Encrypt && (options.KeyFile == "" || options.RecoveryKeyFile == "") {
 		return fmt.Errorf("key file and recovery key file must be specified when encrypting")
 	}
@@ -142,7 +142,7 @@ func Run(gadgetRoot, device string, options Options) error {
 			return err
 		}
 
-		if err := writeContent(&part, gadgetRoot); err != nil {
+		if err := writeContent(&part, gadgetRoot, observer); err != nil {
 			return err
 		}
 

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -51,7 +51,7 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 
 // Run bootstraps the partitions of a device, by either creating
 // missing ones or recreating installed ones.
-func Run(gadgetRoot, device string, options Options, observer gadget.ContentWriteObserver) error {
+func Run(gadgetRoot, device string, options Options, observer gadget.ContentObserver) error {
 	if options.Encrypt && (options.KeyFile == "" || options.RecoveryKeyFile == "") {
 		return fmt.Errorf("key file and recovery key file must be specified when encrypting")
 	}

--- a/gadget/install/install_dummy.go
+++ b/gadget/install/install_dummy.go
@@ -22,8 +22,10 @@ package install
 
 import (
 	"fmt"
+
+	"github.com/snapcore/snapd/gadget"
 )
 
-func Run(gadgetRoot, device string, options Options) error {
+func Run(gadgetRoot, device string, options Options, _ gadget.ContentWriteObserver) error {
 	return fmt.Errorf("build without secboot support")
 }

--- a/gadget/install/install_dummy.go
+++ b/gadget/install/install_dummy.go
@@ -26,6 +26,6 @@ import (
 	"github.com/snapcore/snapd/gadget"
 )
 
-func Run(gadgetRoot, device string, options Options, _ gadget.ContentWriteObserver) error {
+func Run(gadgetRoot, device string, options Options, _ gadget.ContentObserver) error {
 	return fmt.Errorf("build without secboot support")
 }

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -57,7 +57,7 @@ func (s *installSuite) SetUpTest(c *C) {
 }
 
 func (s *installSuite) TestInstallRunError(c *C) {
-	err := install.Run("", "", install.Options{})
+	err := install.Run("", "", install.Options{}, nil)
 	c.Assert(err, ErrorMatches, "cannot use empty gadget root directory")
 }
 

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -64,12 +64,12 @@ func checkContent(content *VolumeContent) error {
 type MountedFilesystemWriter struct {
 	contentDir string
 	ps         *LaidOutStructure
-	observer   ContentWriteObserver
+	observer   ContentObserver
 }
 
 // NewMountedFilesystemWriter returns a writer capable of writing provided
 // structure, with content of the structure stored in the given root directory.
-func NewMountedFilesystemWriter(contentDir string, ps *LaidOutStructure, observer ContentWriteObserver) (*MountedFilesystemWriter, error) {
+func NewMountedFilesystemWriter(contentDir string, ps *LaidOutStructure, observer ContentObserver) (*MountedFilesystemWriter, error) {
 	if ps == nil {
 		return nil, fmt.Errorf("internal error: *LaidOutStructure is nil")
 	}
@@ -123,14 +123,6 @@ func (m *MountedFilesystemWriter) Write(whereDir string, preserve []string) erro
 			return fmt.Errorf("cannot write filesystem content of %s: %v", c, err)
 		}
 	}
-
-	// TODO:UC20: should this be called externally?
-	if m.observer != nil {
-		if err := m.observer.Apply(); err != nil {
-			return fmt.Errorf("cannot apply observed write actions: %v", err)
-		}
-	}
-
 	return nil
 }
 
@@ -187,7 +179,7 @@ func (m *MountedFilesystemWriter) observedWriteFileOrSymlink(volumeRoot, src, ds
 		if err != nil {
 			return err
 		}
-		_, err = m.observer.Observe(FileAssetWrite, m.ps, volumeRoot, src, relativeDst)
+		_, err = m.observer.Observe(ContentWrite, m.ps, volumeRoot, src, relativeDst)
 		if err != nil {
 			return fmt.Errorf("cannot observe file write: %v", err)
 		}

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -64,11 +64,12 @@ func checkContent(content *VolumeContent) error {
 type MountedFilesystemWriter struct {
 	contentDir string
 	ps         *LaidOutStructure
+	observer   ContentWriteObserver
 }
 
 // NewMountedFilesystemWriter returns a writer capable of writing provided
 // structure, with content of the structure stored in the given root directory.
-func NewMountedFilesystemWriter(contentDir string, ps *LaidOutStructure) (*MountedFilesystemWriter, error) {
+func NewMountedFilesystemWriter(contentDir string, ps *LaidOutStructure, observer ContentWriteObserver) (*MountedFilesystemWriter, error) {
 	if ps == nil {
 		return nil, fmt.Errorf("internal error: *LaidOutStructure is nil")
 	}
@@ -81,6 +82,7 @@ func NewMountedFilesystemWriter(contentDir string, ps *LaidOutStructure) (*Mount
 	fw := &MountedFilesystemWriter{
 		contentDir: contentDir,
 		ps:         ps,
+		observer:   observer,
 	}
 	return fw, nil
 }
@@ -121,6 +123,14 @@ func (m *MountedFilesystemWriter) Write(whereDir string, preserve []string) erro
 			return fmt.Errorf("cannot write filesystem content of %s: %v", c, err)
 		}
 	}
+
+	// TODO:UC20: should this be called externally?
+	if m.observer != nil {
+		if err := m.observer.Apply(); err != nil {
+			return fmt.Errorf("cannot apply observed write actions: %v", err)
+		}
+	}
+
 	return nil
 }
 
@@ -128,7 +138,7 @@ func (m *MountedFilesystemWriter) Write(whereDir string, preserve []string) erro
 // location dst. Follows rsync like semantics, that is:
 //   /foo/ -> /bar - writes contents of foo under /bar
 //   /foo  -> /bar - writes foo and its subtree under /bar
-func writeDirectory(src, dst string, preserveInDst []string) error {
+func (m *MountedFilesystemWriter) writeDirectory(volumeRoot, src, dst string, preserveInDst []string) error {
 	hasDirSourceSlash := strings.HasSuffix(src, "/")
 
 	if err := checkSourceIsDir(src); err != nil {
@@ -149,21 +159,40 @@ func writeDirectory(src, dst string, preserveInDst []string) error {
 		pSrc := filepath.Join(src, fi.Name())
 		pDst := filepath.Join(dst, fi.Name())
 
-		write := writeFileOrSymlink
+		write := m.observedWriteFileOrSymlink
 		if fi.IsDir() {
 			if err := os.MkdirAll(pDst, 0755); err != nil {
 				return fmt.Errorf("cannot create directory prefix: %v", err)
 			}
 
-			write = writeDirectory
+			write = m.writeDirectory
 			pSrc += "/"
 		}
-		if err := write(pSrc, pDst, preserveInDst); err != nil {
+		if err := write(volumeRoot, pSrc, pDst, preserveInDst); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (m *MountedFilesystemWriter) observedWriteFileOrSymlink(volumeRoot, src, dst string, preserveInDst []string) error {
+	if strings.HasSuffix(dst, "/") {
+		// write to directory
+		dst = filepath.Join(dst, filepath.Base(src))
+	}
+
+	if m.observer != nil {
+		relativeDst, err := filepath.Rel(volumeRoot, dst)
+		if err != nil {
+			return err
+		}
+		_, err = m.observer.Observe(FileAssetWrite, m.ps, volumeRoot, src, relativeDst)
+		if err != nil {
+			return fmt.Errorf("cannot observe file write: %v", err)
+		}
+	}
+	return writeFileOrSymlink(src, dst, preserveInDst)
 }
 
 // writeFileOrSymlink writes the source file or a symlink at given location or
@@ -225,10 +254,10 @@ func (m *MountedFilesystemWriter) writeVolumeContent(volumeRoot string, content 
 
 	if osutil.IsDirectory(realSource) || strings.HasSuffix(content.Source, "/") {
 		// write a directory
-		return writeDirectory(realSource, realTarget, preserveInDst)
+		return m.writeDirectory(volumeRoot, realSource, realTarget, preserveInDst)
 	} else {
 		// write a file
-		return writeFileOrSymlink(realSource, realTarget, preserveInDst)
+		return m.observedWriteFileOrSymlink(volumeRoot, realSource, realTarget, preserveInDst)
 	}
 }
 
@@ -275,7 +304,7 @@ type mountedFilesystemUpdater struct {
 // mount is located by calling a mount lookup helper. The backup directory
 // contains backup state information for use during rollback.
 func newMountedFilesystemUpdater(rootDir string, ps *LaidOutStructure, backupDir string, mountLookup mountLookupFunc) (*mountedFilesystemUpdater, error) {
-	fw, err := NewMountedFilesystemWriter(rootDir, ps)
+	fw, err := NewMountedFilesystemWriter(rootDir, ps, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -658,7 +687,6 @@ func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, targe
 
 	if strutil.SortedListContains(preserveInDst, dstPath) {
 		// file is to be preserved, create a relevant stamp
-
 		if !osutil.FileExists(dstPath) {
 			// preserve, but does not exist, will be written anyway
 			return nil

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -180,9 +180,17 @@ func (s *mountedfilesystemTestSuite) TestWriteDirectoryContents(c *C) {
 	}
 	makeGadgetData(c, s.dir, gd)
 
+	ps := &gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Filesystem: "ext4",
+		},
+	}
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
+	c.Assert(err, IsNil)
+
 	outDir := c.MkDir()
 	// boot-assets/ -> / (contents of boot assets under /)
-	err := gadget.WriteDirectory(filepath.Join(s.dir, "boot-assets")+"/", outDir+"/", nil)
+	err = rw.WriteDirectory(outDir, filepath.Join(s.dir, "boot-assets")+"/", outDir+"/", nil)
 	c.Assert(err, IsNil)
 
 	verifyWrittenGadgetData(c, outDir, gd)
@@ -198,9 +206,17 @@ func (s *mountedfilesystemTestSuite) TestWriteDirectoryWhole(c *C) {
 	}
 	makeGadgetData(c, s.dir, gd)
 
+	ps := &gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Filesystem: "ext4",
+		},
+	}
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
+	c.Assert(err, IsNil)
+
 	outDir := c.MkDir()
 	// boot-assets -> / (boot-assets and children under /)
-	err := gadget.WriteDirectory(filepath.Join(s.dir, "boot-assets"), outDir+"/", nil)
+	err = rw.WriteDirectory(outDir, filepath.Join(s.dir, "boot-assets"), outDir+"/", nil)
 	c.Assert(err, IsNil)
 
 	verifyWrittenGadgetData(c, outDir, gd)
@@ -211,14 +227,48 @@ func (s *mountedfilesystemTestSuite) TestWriteNonDirectory(c *C) {
 		{name: "foo", content: "nested"},
 	}
 	makeGadgetData(c, s.dir, gd)
+	ps := &gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Filesystem: "ext4",
+		},
+	}
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
+	c.Assert(err, IsNil)
 
 	outDir := c.MkDir()
 
-	err := gadget.WriteDirectory(filepath.Join(s.dir, "foo")+"/", outDir, nil)
+	err = rw.WriteDirectory(outDir, filepath.Join(s.dir, "foo")+"/", outDir, nil)
 	c.Assert(err, ErrorMatches, `cannot specify trailing / for a source which is not a directory`)
 
-	err = gadget.WriteDirectory(filepath.Join(s.dir, "foo"), outDir, nil)
+	err = rw.WriteDirectory(outDir, filepath.Join(s.dir, "foo"), outDir, nil)
 	c.Assert(err, ErrorMatches, `source is not a directory`)
+}
+
+type mockWriteObserver struct {
+	content     map[string][][]string
+	observeErr  error
+	applyErr    error
+	applyCalled int
+	c           *C
+}
+
+func (m *mockWriteObserver) Observe(op gadget.ObserveAction, sourceStruct *gadget.LaidOutStructure,
+	targetRootDir, sourcePath, relativeTargetPath string) (gadget.ObserveResult, error) {
+	if m.content == nil {
+		m.content = make(map[string][][]string)
+	}
+	m.c.Check(osutil.FileExists(sourcePath) && !osutil.IsDirectory(sourcePath), Equals, true,
+		Commentf("path %q does not exist or is not a directory", sourcePath))
+	m.c.Check(filepath.IsAbs(relativeTargetPath), Equals, false,
+		Commentf("target path %q is absolute", relativeTargetPath))
+
+	m.content[targetRootDir] = append(m.content[targetRootDir], []string{sourcePath, relativeTargetPath})
+	return gadget.ObserveResultNoted, m.observeErr
+}
+
+func (m *mockWriteObserver) Apply() error {
+	m.applyCalled++
+	return m.applyErr
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedWriterHappy(c *C) {
@@ -231,6 +281,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterHappy(c *C) {
 		{name: "boot-assets/some-dir/empty-file", target: "some-dir/empty-file"},
 		{name: "boot-assets/nested-dir/nested", target: "/nested-copy/nested", content: "nested"},
 		{name: "boot-assets/nested-dir/more-nested/more", target: "/nested-copy/more-nested/more", content: "more"},
+		{name: "baz", target: "/baz", content: "baz"},
 	}
 	makeGadgetData(c, s.dir, gd)
 	err := os.MkdirAll(filepath.Join(s.dir, "boot-assets/empty-dir"), 0755)
@@ -261,6 +312,10 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterHappy(c *C) {
 					// contents of nested directory under new target directory
 					Source: "boot-assets/nested-dir/",
 					Target: "/nested-copy/",
+				}, {
+					// contents of nested directory under new target directory
+					Source: "baz",
+					Target: "baz",
 				},
 			},
 		},
@@ -268,7 +323,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterHappy(c *C) {
 
 	outDir := c.MkDir()
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	obs := &mockWriteObserver{c: c}
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, obs)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -277,6 +333,28 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterHappy(c *C) {
 
 	verifyWrittenGadgetData(c, outDir, gd)
 	c.Assert(osutil.IsDirectory(filepath.Join(outDir, "empty-dir")), Equals, true)
+
+	// verify observer was notified of writes for files only
+	c.Assert(obs.content, DeepEquals, map[string][][]string{
+		outDir: {
+			{filepath.Join(s.dir, "foo"), "foo-dir/foo"},
+			{filepath.Join(s.dir, "bar"), "bar-name"},
+
+			{filepath.Join(s.dir, "boot-assets/nested-dir/more-nested/more"), "nested-dir/more-nested/more"},
+			{filepath.Join(s.dir, "boot-assets/nested-dir/nested"), "nested-dir/nested"},
+			{filepath.Join(s.dir, "boot-assets/some-dir/data"), "some-dir/data"},
+			{filepath.Join(s.dir, "boot-assets/some-dir/empty-file"), "some-dir/empty-file"},
+			{filepath.Join(s.dir, "boot-assets/splash"), "splash"},
+
+			{filepath.Join(s.dir, "boot-assets/some-dir/data"), "data-copy"},
+
+			{filepath.Join(s.dir, "boot-assets/nested-dir/more-nested/more"), "nested-copy/more-nested/more"},
+			{filepath.Join(s.dir, "boot-assets/nested-dir/nested"), "nested-copy/nested"},
+
+			{filepath.Join(s.dir, "baz"), "baz"},
+		},
+	})
+	c.Assert(obs.applyCalled, Equals, 1)
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedWriterNonDirectory(c *C) {
@@ -301,7 +379,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterNonDirectory(c *C) {
 
 	outDir := c.MkDir()
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -326,7 +404,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorMissingSource(c *C) {
 
 	outDir := c.MkDir()
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -356,7 +434,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorBadDestination(c *C) 
 	err := os.Chmod(outDir, 0000)
 	c.Assert(err, IsNil)
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -390,7 +468,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterConflictingDestinationDire
 
 	outDir := c.MkDir()
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, psOverwritesDirectoryWithFile)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, psOverwritesDirectoryWithFile, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -424,7 +502,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterConflictingDestinationFile
 
 	outDir := c.MkDir()
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, psOverwritesFile)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, psOverwritesFile, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -460,7 +538,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorNested(c *C) {
 
 	makeSizedFile(c, filepath.Join(outDir, "/foo-dir/foo/bar"), 0, nil)
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -541,7 +619,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterPreserve(c *C) {
 		},
 	}
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -586,7 +664,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterNonFilePreserveError(c *C)
 		},
 	}
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -617,7 +695,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterImplicitDir(c *C) {
 
 	outDir := c.MkDir()
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -642,13 +720,13 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterNoFs(c *C) {
 		},
 	}
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, ErrorMatches, "structure #0 has no filesystem")
 	c.Assert(rw, IsNil)
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedWriterTrivialValidation(c *C) {
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, nil)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, nil, nil)
 	c.Assert(err, ErrorMatches, `internal error: \*LaidOutStructure.*`)
 	c.Assert(rw, IsNil)
 
@@ -666,11 +744,11 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterTrivialValidation(c *C) {
 		},
 	}
 
-	rw, err = gadget.NewMountedFilesystemWriter("", ps)
+	rw, err = gadget.NewMountedFilesystemWriter("", ps, nil)
 	c.Assert(err, ErrorMatches, `internal error: gadget content directory cannot be unset`)
 	c.Assert(rw, IsNil)
 
-	rw, err = gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err = gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
 
 	err = rw.Write("", nil)
@@ -707,7 +785,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterSymlinks(c *C) {
 		},
 	}
 
-	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps)
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
 
@@ -807,6 +885,41 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupSimple(c *C) {
 	// running backup again does not error out
 	err = rw.Backup()
 	c.Assert(err, IsNil)
+}
+
+func (s *mountedfilesystemTestSuite) TestMountedWriterObserverErr(c *C) {
+	makeGadgetData(c, s.dir, []gadgetData{
+		{name: "foo", content: "data"},
+	})
+
+	ps := &gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Size:       2048,
+			Filesystem: "ext4",
+			Content: []gadget.VolumeContent{
+				{Source: "/", Target: "/"},
+			},
+		},
+	}
+
+	outDir := c.MkDir()
+	obs := &mockWriteObserver{
+		c:          c,
+		observeErr: errors.New("observe fail"),
+		applyErr:   errors.New("apply fail"),
+	}
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, obs)
+	c.Assert(err, IsNil)
+	c.Assert(rw, NotNil)
+
+	err = rw.Write(outDir, nil)
+	c.Assert(err, ErrorMatches, "cannot write filesystem content of source:/: cannot observe file write: observe fail")
+
+	// try again, have apply fail
+	obs.observeErr = nil
+	outDir2 := c.MkDir()
+	err = rw.Write(outDir2, nil)
+	c.Assert(err, ErrorMatches, "cannot apply observed write actions: apply fail")
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupWithDirectories(c *C) {

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -50,30 +50,24 @@ type GadgetData struct {
 // and returns true when the pair should be part of an update.
 type UpdatePolicyFunc func(from, to *LaidOutStructure) bool
 
-type ObserveResult int
-type ObserveAction int
+type ContentOperation int
 
 const (
-	FileAssetWrite ObserveAction = iota
-	FileAssetRollback
-
-	// ObserveResultNoted indicates that the given file write was observed.
-	ObserveResultNoted ObserveResult = iota
-	// TODO:UC20: add result indicating that a file should be preserved
+	ContentWrite ContentOperation = iota
 )
 
-// ContentWriteObserver allows for observing write related operations on the
-// content of the gadget structure.
-type ContentWriteObserver interface {
-	// Observe is called to observe a pending write action, typically a file
+// ContentObserver allows for observing operations on the content of the gadget
+// structures.
+type ContentObserver interface {
+	// TODO:UC20: add Observe() result value indicating that a file should
+	// be preserved
+
+	// Observe is called to observe a pending action, typically a file
 	// write, from source path to the relative path under a given target
 	// root directory. When called during rollback, the source path points
 	// to the backup copy of the original file.
-	Observe(op ObserveAction, sourceStruct *LaidOutStructure,
-		targetRootDir, sourcePath, relativeTargetPath string) (ObserveResult, error)
-
-	// Apply is called when there is no more pending actions.
-	Apply() error
+	Observe(op ContentOperation, sourceStruct *LaidOutStructure,
+		targetRootDir, sourcePath, relativeTargetPath string) (bool, error)
 }
 
 // Update applies the gadget update given the gadget information and data from

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -50,6 +50,32 @@ type GadgetData struct {
 // and returns true when the pair should be part of an update.
 type UpdatePolicyFunc func(from, to *LaidOutStructure) bool
 
+type ObserveResult int
+type ObserveAction int
+
+const (
+	FileAssetWrite ObserveAction = iota
+	FileAssetRollback
+
+	// ObserveResultNoted indicates that the given file write was observed.
+	ObserveResultNoted ObserveResult = iota
+	// TODO:UC20: add result indicating that a file should be preserved
+)
+
+// ContentWriteObserver allows for observing write related operations on the
+// content of the gadget structure.
+type ContentWriteObserver interface {
+	// Observe is called to observe a pending write action, typically a file
+	// write, from source path to the relative path under a given target
+	// root directory. When called during rollback, the source path points
+	// to the backup copy of the original file.
+	Observe(op ObserveAction, sourceStruct *LaidOutStructure,
+		targetRootDir, sourcePath, relativeTargetPath string) (ObserveResult, error)
+
+	// Apply is called when there is no more pending actions.
+	Apply() error
+}
+
 // Update applies the gadget update given the gadget information and data from
 // old and new revisions. It errors out when the update is not possible or
 // illegal, or a failure occurs at any of the steps. When there is no update, a

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -414,7 +414,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 		return err
 	}
 
-	if err := boot.MakeBootable(model, bootRootDir, bootWith); err != nil {
+	if err := boot.MakeBootable(model, bootRootDir, bootWith, nil); err != nil {
 		return err
 	}
 

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -216,13 +216,16 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	}
 
 	bootMakeBootableCalled := 0
-	restore = devicestate.MockBootMakeBootable(func(model *asserts.Model, rootdir string, bootWith *boot.BootableSet) error {
+	restore = devicestate.MockBootMakeBootable(func(model *asserts.Model, rootdir string, bootWith *boot.BootableSet, seal *boot.TrustedAssetsInstallObserver) error {
 		c.Check(model, DeepEquals, mockModel)
 		c.Check(rootdir, Equals, dirs.GlobalRootDir)
 		c.Check(bootWith.KernelPath, Matches, ".*/var/lib/snapd/snaps/pc-kernel_1.snap")
 		c.Check(bootWith.BasePath, Matches, ".*/var/lib/snapd/snaps/core20_2.snap")
 		c.Check(bootWith.RecoverySystemDir, Matches, "/systems/20191218")
 		c.Check(bootWith.UnpackedGadgetDir, Equals, filepath.Join(dirs.SnapMountDir, "pc/1"))
+		if tc.encrypt {
+			c.Check(seal, NotNil)
+		}
 		bootMakeBootableCalled++
 		return nil
 	})
@@ -419,7 +422,7 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade, gadg
 	s.state.Unlock()
 	c.Check(mockModel.Grade(), Equals, asserts.ModelGrade(modelGrade))
 
-	restore = devicestate.MockBootMakeBootable(func(model *asserts.Model, rootdir string, bootWith *boot.BootableSet) error {
+	restore = devicestate.MockBootMakeBootable(func(model *asserts.Model, rootdir string, bootWith *boot.BootableSet, seal *boot.TrustedAssetsInstallObserver) error {
 		return nil
 	})
 	defer restore()

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -176,8 +176,8 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	var brGadgetRoot, brDevice string
 	var brOpts install.Options
 	var installRunCalled int
-	var sealingObserver gadget.ContentWriteObserver
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, obs gadget.ContentWriteObserver) error {
+	var sealingObserver gadget.ContentObserver
+	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, obs gadget.ContentObserver) error {
 		// ensure we can grab the lock here, i.e. that it's not taken
 		s.state.Lock()
 		s.state.Unlock()
@@ -293,7 +293,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentWriteObserver) error {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) error {
 		return fmt.Errorf("The horror, The horror")
 	})
 	defer restore()
@@ -409,7 +409,7 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade, gadg
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentWriteObserver) error {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) error {
 		return nil
 	})
 	defer restore()

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -216,7 +216,7 @@ func MockGadgetIsCompatible(mock func(current, update *gadget.Info) error) (rest
 	}
 }
 
-func MockBootMakeBootable(f func(model *asserts.Model, rootdir string, bootWith *boot.BootableSet) error) (restore func()) {
+func MockBootMakeBootable(f func(model *asserts.Model, rootdir string, bootWith *boot.BootableSet, seal *boot.TrustedAssetsInstallObserver) error) (restore func()) {
 	old := bootMakeBootable
 	bootMakeBootable = f
 	return func() {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -248,7 +248,7 @@ func MockSysconfigConfigureRunSystem(f func(opts *sysconfig.Options) error) (res
 	}
 }
 
-func MockInstallRun(f func(gadgetRoot, device string, options install.Options) error) (restore func()) {
+func MockInstallRun(f func(gadgetRoot, device string, options install.Options, observer gadget.ContentWriteObserver) error) (restore func()) {
 	old := installRun
 	installRun = f
 	return func() {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -248,7 +248,7 @@ func MockSysconfigConfigureRunSystem(f func(opts *sysconfig.Options) error) (res
 	}
 }
 
-func MockInstallRun(f func(gadgetRoot, device string, options install.Options, observer gadget.ContentWriteObserver) error) (restore func()) {
+func MockInstallRun(f func(gadgetRoot, device string, options install.Options, observer gadget.ContentObserver) error) (restore func()) {
 	old := installRun
 	installRun = f
 	return func() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -113,7 +113,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	var sealComponentObserver gadget.ContentWriteObserver
+	var sealComponentObserver gadget.ContentObserver
 	if useEncryption {
 		fdeDir := "var/lib/snapd/device/fde"
 		// ensure directories

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -113,7 +113,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	var sealComponentObserver gadget.ContentObserver
+	var sealingContentObserver gadget.ContentObserver
 	if useEncryption {
 		fdeDir := "var/lib/snapd/device/fde"
 		// ensure directories
@@ -132,7 +132,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		bopts.Model = deviceCtx.Model()
 		bopts.SystemLabel = modeEnv.RecoverySystem
 
-		sealComponentObserver = boot.InitialSealObserver(deviceCtx.Model())
+		sealingContentObserver = boot.NewTrustedAssetsInstallObserver(deviceCtx.Model())
 	}
 
 	// run the create partition code
@@ -140,7 +140,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	func() {
 		st.Unlock()
 		defer st.Lock()
-		err = installRun(gadgetDir, "", bopts, sealComponentObserver)
+		err = installRun(gadgetDir, "", bopts, sealingContentObserver)
 	}()
 	if err != nil {
 		return fmt.Errorf("cannot create partitions: %v", err)

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -29,7 +29,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -113,7 +112,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	var sealingContentObserver gadget.ContentObserver
+	var sealingContentObserver *boot.TrustedAssetsInstallObserver
 	if useEncryption {
 		fdeDir := "var/lib/snapd/device/fde"
 		// ensure directories
@@ -176,7 +175,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		UnpackedGadgetDir: gadgetDir,
 	}
 	rootdir := dirs.GlobalRootDir
-	if err := bootMakeBootable(deviceCtx.Model(), rootdir, bootWith); err != nil {
+	if err := bootMakeBootable(deviceCtx.Model(), rootdir, bootWith, sealingContentObserver); err != nil {
 		return fmt.Errorf("cannot make run system bootable: %v", err)
 	}
 

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -94,7 +94,7 @@ func main() {
 		KernelPath:              args.KernelPath,
 		Model:                   model,
 	}
-	err = installRun(args.Positional.GadgetRoot, args.Positional.Device, options)
+	err = installRun(args.Positional.GadgetRoot, args.Positional.Device, options, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The PR introduces a content write observer, focusing on writing file content. Add relevant observer stubs in the boot package an the necessary devicestate & gadget/install glue.
