### PR TITLE
cmd/snap/debug/seeding: use unicode for proper yaml

### DIFF
--- a/cmd/snap/cmd_debug_seeding.go
+++ b/cmd/snap/cmd_debug_seeding.go
@@ -32,6 +32,7 @@ import (
 
 type cmdSeeding struct {
 	clientMixin
+	unicodeMixin
 }
 
 func init() {
@@ -45,6 +46,8 @@ func init() {
 }
 
 func (x *cmdSeeding) Execute(args []string) error {
+	esc := x.getEscapes()
+
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
@@ -76,13 +79,13 @@ func (x *cmdSeeding) Execute(args []string) error {
 
 	// if we are missing time values, we will default to showing "-" for the
 	// duration
-	seedDuration := "-"
+	seedDuration := esc.dash
 	if resp.Preseeded {
 		if resp.PreseedTime != nil && resp.PreseedStartTime != nil {
 			preseedDuration := resp.PreseedTime.Sub(*resp.PreseedStartTime).Round(time.Millisecond)
 			fmt.Fprintf(w, "image-preseeding:\t%v\n", preseedDuration)
 		} else {
-			fmt.Fprintf(w, "image-preseeding:\t-\n")
+			fmt.Fprintf(w, "image-preseeding:\t%s\n", esc.dash)
 		}
 
 		if resp.SeedTime != nil && resp.SeedRestartTime != nil {

--- a/cmd/snap/cmd_debug_seeding_test.go
+++ b/cmd/snap/cmd_debug_seeding_test.go
@@ -258,11 +258,12 @@ var stillSeedingNoPreseed = `{
 
 func (s *SnapSuite) TestDebugSeeding(c *C) {
 	tt := []struct {
-		jsonResp  string
-		expStdout string
-		expStderr string
-		expErr    string
-		comment   string
+		jsonResp   string
+		expStdout  string
+		expStderr  string
+		expErr     string
+		comment    string
+		hasUnicode bool
 	}{
 		{
 			jsonResp: newPreseedNewSnapdSameSysKey,
@@ -361,9 +362,19 @@ seed-restart-system-key: {
 			expStdout: `
 seeded:           true
 preseeded:        false
-seed-completion:  -
+seed-completion:  --
 `[1:],
-			comment: "not preseeded",
+			comment: "not preseeded no unicode",
+		},
+		{
+			jsonResp: noPreseedingJSON,
+			expStdout: `
+seeded:           true
+preseeded:        false
+seed-completion:  –
+`[1:],
+			comment:    "not preseeded",
+			hasUnicode: true,
 		},
 		{
 			jsonResp: oldPreseedingJSON,
@@ -381,18 +392,39 @@ seed-completion:   2m0s
 seeded:            false
 preseeded:         true
 image-preseeding:  9.318s
-seed-completion:   -
+seed-completion:   --
 `[1:],
-			comment: "preseeded, still seeding",
+			comment: "preseeded, still seeding no unicode",
+		},
+		{
+			jsonResp: stillSeeding,
+			expStdout: `
+seeded:            false
+preseeded:         true
+image-preseeding:  9.318s
+seed-completion:   –
+`[1:],
+			hasUnicode: true,
+			comment:    "preseeded, still seeding",
 		},
 		{
 			jsonResp: stillSeedingNoPreseed,
 			expStdout: `
 seeded:           false
 preseeded:        false
-seed-completion:  -
+seed-completion:  --
 `[1:],
-			comment: "not preseeded, still seeding",
+			comment: "not preseeded, still seeding no unicode",
+		},
+		{
+			jsonResp: stillSeedingNoPreseed,
+			expStdout: `
+seeded:           false
+preseeded:        false
+seed-completion:  –
+`[1:],
+			hasUnicode: true,
+			comment:    "not preseeded, still seeding",
 		},
 	}
 
@@ -414,7 +446,11 @@ seed-completion:  -
 				c.Fatalf("expected to get 1 request, now on %d", n)
 			}
 		})
-		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "seeding"})
+		args := []string{"debug", "seeding"}
+		if t.hasUnicode {
+			args = append(args, "--unicode=always")
+		}
+		rest, err := snap.Parser(snap.Client()).ParseArgs(args)
 		if t.expErr != "" {
 			c.Assert(err, ErrorMatches, t.expErr, comment)
 			c.Assert(s.Stdout(), Equals, "", comment)


### PR DESCRIPTION
In order for the output to always be valid yaml, we need to escape the "-" we
output when we cannot calculate a time, as that is not valid yaml. If we have
unicode, then we can output a special unicode dash that looks nice like a
standard dash, but is yaml, and if we don't have unicode we can output just two
dashes instead.