### PR TITLE
cmd/snap: display the error in snap debug seeding if seeding is in error

### DIFF
--- a/cmd/snap/cmd_debug_seeding.go
+++ b/cmd/snap/cmd_debug_seeding.go
@@ -59,6 +59,8 @@ func (x *cmdSeeding) Execute(args []string) error {
 		// use json.RawMessage to delay unmarshal'ing to the interfaces pkg
 		PreseedSystemKey     *json.RawMessage `json:"preseed-system-key,omitempty"`
 		SeedRestartSystemKey *json.RawMessage `json:"seed-restart-system-key,omitempty"`
+
+		SeedError string `json:"seed-error,omitempty"`
 	}
 	if err := x.client.DebugGet("seeding", &resp, nil); err != nil {
 		return err
@@ -68,6 +70,19 @@ func (x *cmdSeeding) Execute(args []string) error {
 
 	// show seeded and preseeded keys
 	fmt.Fprintf(w, "seeded:\t%v\n", resp.Seeded)
+	if resp.SeedError != "" {
+		// print seed-error
+		termWidth, _ := termSize()
+		termWidth -= 3
+		if termWidth > 100 {
+			// any wider than this and it gets hard to read
+			termWidth = 100
+		}
+		fmt.Fprintln(w, "seed-error: |")
+		// XXX: reuse/abuse
+		printDescr(w, resp.SeedError, termWidth)
+	}
+
 	fmt.Fprintf(w, "preseeded:\t%v\n", resp.Preseeded)
 
 	// calculate the time spent preseeding (if preseeded) and seeding

--- a/cmd/snap/cmd_debug_seeding_test.go
+++ b/cmd/snap/cmd_debug_seeding_test.go
@@ -219,6 +219,18 @@ var noPreseedingJSON = `
     "type": "sync"
 }`
 
+var seedingError = `{
+    "result": {
+        "preseed-start-time": "2020-07-24T21:41:33.838194712Z",
+        "preseed-time": "2020-07-24T21:41:43.156401424Z",
+        "preseeded": true,
+        "seed-error": "cannot perform the following tasks:\n- xxx"
+    },
+    "status": "OK",
+    "status-code": 200,
+    "type": "sync"
+}`
+
 // a system that was preseeded, but didn't record the new keys
 // this is the case for a system that was preseeded and then seeded with an old
 // snapd, but then is refreshed to a version of snapd that supports snap debug
@@ -393,6 +405,19 @@ preseeded:        false
 seed-completion:  -
 `[1:],
 			comment: "not preseeded, still seeding",
+		},
+		{
+			jsonResp: seedingError,
+			expStdout: `
+seeded:  false
+seed-error: |
+  cannot perform the following tasks:
+  - xxx
+preseeded:         true
+image-preseeding:  9.318s
+seed-completion:   -
+`[1:],
+			comment: "preseeded, error during seeding",
 		},
 	}
 

--- a/cmd/snap/cmd_debug_seeding_test.go
+++ b/cmd/snap/cmd_debug_seeding_test.go
@@ -447,7 +447,7 @@ seed-error: |
   - xxx
 preseeded:         true
 image-preseeding:  9.318s
-seed-completion:   -
+seed-completion:   --
 `[1:],
 			comment: "preseeded, error during seeding",
 		},

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/state"
 )
 
 var _ = Suite(&seedingDebugSuite{})
@@ -150,5 +152,66 @@ func (s *seedingDebugSuite) TestSeedingDebugPreseededStillSeeding(c *C) {
 		PreseedStartTime:     &preseedStartTime,
 		PreseedTime:          &preseedTime,
 		SeedRestartTime:      &seedRestartTime,
+	})
+}
+
+func (s *seedingDebugSuite) TestSeedingDebugPreseededSeedError(c *C) {
+	preseedStartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:00Z")
+	c.Assert(err, IsNil)
+	preseedTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:01Z")
+	c.Assert(err, IsNil)
+	seedRestartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:03Z")
+	c.Assert(err, IsNil)
+
+	st := s.d.overlord.State()
+	st.Lock()
+
+	st.Set("preseeded", true)
+	st.Set("seeded", false)
+
+	st.Set("preseed-system-key", "foo")
+	st.Set("seed-restart-system-key", "bar")
+
+	st.Set("preseed-start-time", preseedStartTime)
+	st.Set("seed-restart-time", seedRestartTime)
+
+	st.Set("preseed-time", preseedTime)
+
+	chg1 := st.NewChange("seed", "tentative 1")
+	t11 := st.NewTask("seed task", "t11")
+	t12 := st.NewTask("seed task", "t12")
+	chg1.AddTask(t11)
+	chg1.AddTask(t12)
+	t11.SetStatus(state.UndoneStatus)
+	t11.Errorf("t11: undone")
+	t12.SetStatus(state.ErrorStatus)
+	t12.Errorf("t12: fail")
+
+	// ensure different spawn time
+	time.Sleep(50 * time.Millisecond)
+	chg2 := st.NewChange("seed", "tentative 2")
+	t21 := st.NewTask("seed task", "t21")
+	chg2.AddTask(t21)
+	t21.SetStatus(state.ErrorStatus)
+	t21.Errorf("t21: error")
+
+	chg3 := st.NewChange("seed", "tentative 3")
+	t31 := st.NewTask("seed task", "t31")
+	chg3.AddTask(t31)
+	t31.SetStatus(state.DoingStatus)
+
+	st.Unlock()
+
+	data := s.getSeedingDebug(c)
+	c.Check(data, DeepEquals, &seedingInfo{
+		Seeded:               false,
+		Preseeded:            true,
+		PreseedSystemKey:     "foo",
+		SeedRestartSystemKey: "bar",
+		PreseedStartTime:     &preseedStartTime,
+		PreseedTime:          &preseedTime,
+		SeedRestartTime:      &seedRestartTime,
+		SeedError: `cannot perform the following tasks:
+- t12 (t12: fail)`,
 	})
 }


### PR DESCRIPTION
For this include a seed-error in the /v2/debug?aspect=seeding debug API as well.