### PR TITLE
interfaces/udev: do not reload udevadm rules when preseeding

### DIFF
--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -40,10 +40,15 @@ import (
 )
 
 // Backend is responsible for maintaining udev rules.
-type Backend struct{}
+type Backend struct {
+	preseed bool
+}
 
 // Initialize does nothing.
-func (b *Backend) Initialize(*interfaces.SecurityBackendOptions) error {
+func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
+	if opts != nil && opts.Preseed {
+		b.preseed = true
+	}
 	return nil
 }
 
@@ -90,7 +95,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 			// FIXME: somehow detect the interfaces that were
 			// disconnected and set subsystemTriggers appropriately.
 			// ATM, it is always going to be empty on disconnect.
-			return ReloadRules(subsystemTriggers)
+			return b.reloadRules(subsystemTriggers)
 		}
 		return nil
 	}
@@ -127,7 +132,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	// FIXME: somehow detect the interfaces that were disconnected and set
 	// subsystemTriggers appropriately. ATM, it is always going to be empty
 	// on disconnect.
-	return ReloadRules(subsystemTriggers)
+	return b.reloadRules(subsystemTriggers)
 }
 
 // Remove removes udev rules specific to a given snap.
@@ -149,7 +154,7 @@ func (b *Backend) Remove(snapName string) error {
 	// FIXME: somehow detect the interfaces that were disconnected and set
 	// subsystemTriggers appropriately. ATM, it is always going to be empty
 	// on disconnect.
-	return ReloadRules(nil)
+	return b.reloadRules(nil)
 }
 
 func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (content []string) {

--- a/interfaces/udev/export_test.go
+++ b/interfaces/udev/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package udev
+
+func (b *Backend) ReloadRules(subsystemTriggers []string) error {
+	return b.reloadRules(subsystemTriggers)
+}

--- a/interfaces/udev/udev.go
+++ b/interfaces/udev/udev.go
@@ -24,7 +24,7 @@ import (
 	"os/exec"
 )
 
-// ReloadRules runs three commands that reload udev rule database.
+// reloadRules runs three commands that reload udev rule database.
 //
 // The commands are: udevadm control --reload-rules
 //                   udevadm trigger --subsystem-nomatch=input
@@ -32,7 +32,11 @@ import (
 // and optionally trigger other subsystems as defined in the interfaces. Eg:
 //                   udevadm trigger --subsystem-match=input
 //                   udevadm trigger --property-match=ID_INPUT_JOYSTICK=1
-func ReloadRules(subsystemTriggers []string) error {
+func (b *Backend) reloadRules(subsystemTriggers []string) error {
+	if b.preseed {
+		return nil
+	}
+
 	output, err := exec.Command("udevadm", "control", "--reload-rules").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cannot reload udev rules: %s\nudev output:\n%s", err, string(output))


### PR DESCRIPTION
Don't try to reload udev rules when preseeding (it fails in preseeding chroot, as I discovered when investigating another issue).

This PR makes ReloadRules a private method of udev backend, so that we don't have to check preseed flag before every reload call, instead it's in a central place and reload becomes a no-op if pressed flag is set.