### PR TITLE
interfaces/kmod: don't load kernel modules in kmod backend when preseeding

### DIFF
--- a/interfaces/kmod/backend.go
+++ b/interfaces/kmod/backend.go
@@ -50,10 +50,15 @@ import (
 )
 
 // Backend is responsible for maintaining kernel modules
-type Backend struct{}
+type Backend struct {
+	preseed bool
+}
 
 // Initialize does nothing.
-func (b *Backend) Initialize(*interfaces.SecurityBackendOptions) error {
+func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
+	if opts != nil && opts.Preseed {
+		b.preseed = true
+	}
 	return nil
 }
 
@@ -89,7 +94,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementO
 	}
 
 	if len(changed) > 0 {
-		loadModules(modules)
+		b.loadModules(modules)
 	}
 	return nil
 }

--- a/interfaces/kmod/export_test.go
+++ b/interfaces/kmod/export_test.go
@@ -19,6 +19,6 @@
 
 package kmod
 
-var (
-	LoadModules = loadModules
-)
+func (b *Backend) LoadModules(modules []string) {
+	b.loadModules(modules)
+}

--- a/interfaces/kmod/kmod.go
+++ b/interfaces/kmod/kmod.go
@@ -28,7 +28,10 @@ import (
 // error from modprobe as non-fatal and subsequent module loads are attempted
 // (otherwise failure to load a module means failure to connect the interface
 // and the other security backends)
-func loadModules(modules []string) {
+func (b *Backend) loadModules(modules []string) {
+	if b.preseed {
+		return
+	}
 	for _, mod := range modules {
 		// ignore errors which are logged by loadModule() via syslog
 		_ = exec.Command("modprobe", "--syslog", mod).Run()

--- a/interfaces/kmod/kmod_test.go
+++ b/interfaces/kmod/kmod_test.go
@@ -20,6 +20,7 @@
 package kmod_test
 
 import (
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/testutil"
@@ -45,7 +46,9 @@ func (s *kmodSuite) TestModprobeCall(c *C) {
 	cmd := testutil.MockCommand(c, "modprobe", "")
 	defer cmd.Restore()
 
-	kmod.LoadModules([]string{
+	b, ok := s.Backend.(*kmod.Backend)
+	c.Assert(ok, Equals, true)
+	b.LoadModules([]string{
 		"module1",
 		"module2",
 	})
@@ -53,4 +56,18 @@ func (s *kmodSuite) TestModprobeCall(c *C) {
 		{"modprobe", "--syslog", "module1"},
 		{"modprobe", "--syslog", "module2"},
 	})
+}
+
+func (s *kmodSuite) TestNoModprobeCallWhenPreseeding(c *C) {
+	cmd := testutil.MockCommand(c, "modprobe", "")
+	defer cmd.Restore()
+
+	b := kmod.Backend{}
+	opts := &interfaces.SecurityBackendOptions{
+		Preseed: true,
+	}
+	c.Assert(b.Initialize(opts), IsNil)
+
+	b.LoadModules([]string{"module1"})
+	c.Assert(cmd.Calls(), HasLen, 0)
 }


### PR DESCRIPTION
LoadModules should be a noop when preseeding.
