### PR TITLE
boot/modeenv: add deepEqual, Copy helpers to simplify bootstate20 refactor

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -40,3 +40,7 @@ type Trivial = trivial
 func (m *Modeenv) WasRead() bool {
 	return m.read
 }
+
+func (m *Modeenv) DeepEqual(m2 *Modeenv) bool {
+	return m.deepEqual(m2)
+}

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -212,3 +212,24 @@ func (m *Modeenv) deepEqual(m2 *Modeenv) bool {
 	}
 	return bytes.Equal(b, b2)
 }
+
+// Copy will make a deep copy of a Modeenv.
+func (m *Modeenv) Copy() (*Modeenv, error) {
+	// to avoid hard-coding all fields here and manually copying everything, we
+	// take the easy way out and serialize to json then re-import into a
+	// empty Modeenv
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	m2 := &Modeenv{}
+	err = json.Unmarshal(b, m2)
+	if err != nil {
+		return nil, err
+	}
+
+	// manually copy the unexported fields as they won't be in the JSON
+	m2.read = m.read
+	m2.originRootdir = m.originRootdir
+	return m2, nil
+}

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -21,6 +21,7 @@ package boot
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -194,4 +195,20 @@ func splitModeenvStringList(v string) []string {
 
 func asModeenvStringList(v []string) string {
 	return strings.Join(v, ",")
+}
+
+// deepEqual compares two modeenvs to ensure they are textually the same. It
+// does not consider whether the modeenvs were read from disk or created purely
+// in memory. It also does not sort or otherwise mutate any sub-objects,
+// performing simple strict verification of sub-objects.
+func (m *Modeenv) deepEqual(m2 *Modeenv) bool {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return false
+	}
+	b2, err := json.Marshal(m2)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(b, b2)
 }


### PR DESCRIPTION
This adds two helpers which are used in the refactor of the bootstate20 package to simplify things a bit. 