### PR TITLE
many: cherry-pick debug seeding api for 2.45

### DIFF
--- a/cmd/snap/cmd_debug_seeding.go
+++ b/cmd/snap/cmd_debug_seeding.go
@@ -1,0 +1,136 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/snapcore/snapd/interfaces"
+)
+
+type cmdSeeding struct {
+	clientMixin
+}
+
+func init() {
+	cmd := addDebugCommand("seeding",
+		"(internal) obtain seeding and preseeding details",
+		"(internal) obtain seeding and preseeding details",
+		func() flags.Commander {
+			return &cmdSeeding{}
+		}, nil, nil)
+	cmd.hidden = true
+}
+
+func (x *cmdSeeding) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	var resp struct {
+		Seeded               bool        `json:"seeded,omitempty"`
+		Preseeded            bool        `json:"preseeded,omitempty"`
+		PreseedStartTime     time.Time   `json:"preseed-start-time,omitempty"`
+		PreseedTime          time.Time   `json:"preseed-time,omitempty"`
+		SeedStartTime        time.Time   `json:"seed-start-time,omitempty"`
+		SeedRestartTime      time.Time   `json:"seed-restart-time,omitempty"`
+		SeedTime             time.Time   `json:"seed-time,omitempty"`
+		PreseedSystemKey     interface{} `json:"preseed-system-key,omitempty"`
+		SeedRestartSystemKey interface{} `json:"seed-restart-system-key,omitempty"`
+	}
+	if err := x.client.DebugGet("seeding", &resp, nil); err != nil {
+		return err
+	}
+
+	w := tabWriter()
+
+	// show seeded and preseeded keys
+	fmt.Fprintf(w, "seeded:\t%v\n", resp.Seeded)
+	fmt.Fprintf(w, "preseeded:\t%v\n", resp.Preseeded)
+
+	// calculate the time spent preseeding (if preseeded) and seeding
+	// for the preseeded case, we use the seed-restart-time as the start time
+	// to show how long we spent only after booting the preseeded image
+	var seedDuration time.Duration
+	if resp.Preseeded {
+		preseedDuration := resp.PreseedTime.Sub(resp.PreseedStartTime)
+		fmt.Fprintf(w, "image-preseeding:\t%v\n", preseedDuration)
+		seedDuration = resp.SeedTime.Sub(resp.SeedRestartTime)
+	} else {
+		seedDuration = resp.SeedTime.Sub(resp.SeedStartTime)
+	}
+	fmt.Fprintf(w, "seed-completion:\t%v\n", seedDuration)
+
+	// we flush the tabwriter now because if we have more output, it will be
+	// the system keys, which are JSON and thus will never display cleanly in
+	// line with the other keys we did above
+	w.Flush()
+
+	// only compare system-keys if preseeded and the system-keys exist
+	// they might not exist if this command is used on a system that was
+	// preseeded with an older version of snapd, i.e. while this feature is
+	// being rolled out, we may be preseeding images via old snapd deb, but with
+	// new snapd snap
+	if resp.Preseeded && resp.SeedRestartSystemKey != nil && resp.PreseedSystemKey != nil {
+		// only show them if they don't match
+
+		// we have to play a bit of a dance here, first marshalling the
+		// interface{} we got over JSON, which will basically just be a
+		// map[string]interface{} into bytes, then having the interfaces pkg
+		// decode those bytes into a proper interfaces.systemKey (which is not
+		// exported) and return that back to us as an interface{} again, which
+		// we can then use to compare the two system keys, and then finally
+		// display the originally marshalled json
+		seedRestartSkJSON, err := json.MarshalIndent(resp.SeedRestartSystemKey, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		seedSk, err := interfaces.UnmarshalJSONSystemKey(bytes.NewReader(seedRestartSkJSON))
+		if err != nil {
+			return err
+		}
+
+		preseedSkJSON, err := json.MarshalIndent(resp.PreseedSystemKey, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		preseedSk, err := interfaces.UnmarshalJSONSystemKey(bytes.NewReader(preseedSkJSON))
+		if err != nil {
+			return err
+		}
+
+		match, err := interfaces.SystemKeysMatch(preseedSk, seedSk)
+		if err != nil {
+			return err
+		}
+		if !match {
+			// mismatch, display the different keys
+			fmt.Fprintf(Stdout, "preseed-system-key: %s\n", string(preseedSkJSON))
+			fmt.Fprintf(Stdout, "seed-restart-system-key: %s\n", string(seedRestartSkJSON))
+		}
+	}
+
+	return nil
+}

--- a/cmd/snap/cmd_debug_seeding.go
+++ b/cmd/snap/cmd_debug_seeding.go
@@ -62,6 +62,8 @@ func (x *cmdSeeding) Execute(args []string) error {
 		// use json.RawMessage to delay unmarshal'ing to the interfaces pkg
 		PreseedSystemKey     *json.RawMessage `json:"preseed-system-key,omitempty"`
 		SeedRestartSystemKey *json.RawMessage `json:"seed-restart-system-key,omitempty"`
+
+		SeedError string `json:"seed-error,omitempty"`
 	}
 	if err := x.client.DebugGet("seeding", &resp, nil); err != nil {
 		return err
@@ -71,6 +73,19 @@ func (x *cmdSeeding) Execute(args []string) error {
 
 	// show seeded and preseeded keys
 	fmt.Fprintf(w, "seeded:\t%v\n", resp.Seeded)
+	if resp.SeedError != "" {
+		// print seed-error
+		termWidth, _ := termSize()
+		termWidth -= 3
+		if termWidth > 100 {
+			// any wider than this and it gets hard to read
+			termWidth = 100
+		}
+		fmt.Fprintln(w, "seed-error: |")
+		// XXX: reuse/abuse
+		printDescr(w, resp.SeedError, termWidth)
+	}
+
 	fmt.Fprintf(w, "preseeded:\t%v\n", resp.Preseeded)
 
 	// calculate the time spent preseeding (if preseeded) and seeding

--- a/cmd/snap/cmd_debug_seeding.go
+++ b/cmd/snap/cmd_debug_seeding.go
@@ -32,6 +32,7 @@ import (
 
 type cmdSeeding struct {
 	clientMixin
+	unicodeMixin
 }
 
 func init() {
@@ -45,6 +46,8 @@ func init() {
 }
 
 func (x *cmdSeeding) Execute(args []string) error {
+	esc := x.getEscapes()
+
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
@@ -76,13 +79,13 @@ func (x *cmdSeeding) Execute(args []string) error {
 
 	// if we are missing time values, we will default to showing "-" for the
 	// duration
-	seedDuration := "-"
+	seedDuration := esc.dash
 	if resp.Preseeded {
 		if resp.PreseedTime != nil && resp.PreseedStartTime != nil {
 			preseedDuration := resp.PreseedTime.Sub(*resp.PreseedStartTime).Round(time.Millisecond)
 			fmt.Fprintf(w, "image-preseeding:\t%v\n", preseedDuration)
 		} else {
-			fmt.Fprintf(w, "image-preseeding:\t-\n")
+			fmt.Fprintf(w, "image-preseeding:\t%s\n", esc.dash)
 		}
 
 		if resp.SeedTime != nil && resp.SeedRestartTime != nil {

--- a/cmd/snap/cmd_debug_seeding_test.go
+++ b/cmd/snap/cmd_debug_seeding_test.go
@@ -211,10 +211,6 @@ var newPreseedNewSnapdDiffSysKey = `
 var noPreseedingJSON = `
 {
     "result": {
-        "preseed-start-time": "0001-01-01T00:00:00Z",
-        "preseed-time": "0001-01-01T00:00:00Z",
-        "seed-restart-time": "0001-01-01T00:00:00Z",
-        "seed-start-time": "0001-01-01T00:00:00Z",
         "seed-time": "2019-07-04T19:16:10.548793375-05:00",
         "seeded": true
     },
@@ -234,9 +230,27 @@ var oldPreseedingJSON = `{
         "seed-restart-time": "2019-07-04T19:14:10.548793375-05:00",
         "seed-start-time": "0001-01-01T00:00:00Z",
         "seed-time": "2019-07-04T19:16:10.548793375-05:00",
-		"seeded": true,
-		"preseeded": true
+        "seeded": true,
+        "preseeded": true
     },
+    "status": "OK",
+    "status-code": 200,
+    "type": "sync"
+}`
+
+var stillSeeding = `{
+    "result": {
+        "preseed-start-time": "2020-07-24T21:41:33.838194712Z",
+        "preseed-time": "2020-07-24T21:41:43.156401424Z",
+        "preseeded": true
+    },
+    "status": "OK",
+    "status-code": 200,
+    "type": "sync"
+}`
+
+var stillSeedingNoPreseed = `{
+    "result": {},
     "status": "OK",
     "status-code": 200,
     "type": "sync"
@@ -255,8 +269,8 @@ func (s *SnapSuite) TestDebugSeeding(c *C) {
 			expStdout: `
 seeded:            true
 preseeded:         true
-image-preseeding:  9.318206712s
-seed-completion:   3.872508077s
+image-preseeding:  9.318s
+seed-completion:   3.873s
 `[1:],
 			comment: "new preseed keys, same system-key",
 		},
@@ -265,8 +279,8 @@ seed-completion:   3.872508077s
 			expStdout: `
 seeded:            true
 preseeded:         true
-image-preseeding:  9.318206712s
-seed-completion:   3.872508077s
+image-preseeding:  9.318s
+seed-completion:   3.873s
 preseed-system-key: {
   "apparmor-features": [
     "caps",
@@ -347,7 +361,7 @@ seed-restart-system-key: {
 			expStdout: `
 seeded:           true
 preseeded:        false
-seed-completion:  2562047h47m16.854775807s
+seed-completion:  -
 `[1:],
 			comment: "not preseeded",
 		},
@@ -360,6 +374,25 @@ image-preseeding:  0s
 seed-completion:   2m0s
 `[1:],
 			comment: "old preseeded json",
+		},
+		{
+			jsonResp: stillSeeding,
+			expStdout: `
+seeded:            false
+preseeded:         true
+image-preseeding:  9.318s
+seed-completion:   -
+`[1:],
+			comment: "preseeded, still seeding",
+		},
+		{
+			jsonResp: stillSeedingNoPreseed,
+			expStdout: `
+seeded:           false
+preseeded:        false
+seed-completion:  -
+`[1:],
+			comment: "not preseeded, still seeding",
 		},
 	}
 

--- a/cmd/snap/cmd_debug_seeding_test.go
+++ b/cmd/snap/cmd_debug_seeding_test.go
@@ -1,0 +1,399 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	. "gopkg.in/check.v1"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+var newPreseedNewSnapdSameSysKey = `
+{
+    "result": {
+        "preseed-start-time": "2020-07-24T21:41:33.838194712Z",
+        "preseed-system-key": {
+            "apparmor-features": [
+                "caps",
+                "dbus",
+                "domain",
+                "file",
+                "mount",
+                "namespaces",
+                "network",
+                "network_v8",
+                "policy",
+                "ptrace",
+                "query",
+                "rlimit",
+                "signal"
+            ],
+            "apparmor-parser-features": [
+                "unsafe"
+            ],
+            "apparmor-parser-mtime": 1589907589,
+            "build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
+            "cgroup-version": "1",
+            "nfs-home": false,
+            "overlay-root": "",
+            "seccomp-compiler-version": "e6e309ad8aee052e5aa695dfaa040328ae1559c5 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog",
+            "seccomp-features": [
+                "allow",
+                "errno",
+                "kill_process",
+                "kill_thread",
+                "log",
+                "trace",
+                "trap",
+                "user_notif"
+            ],
+            "version": 10
+        },
+        "preseed-time": "2020-07-24T21:41:43.156401424Z",
+        "preseeded": true,
+        "seed-restart-system-key": {
+            "apparmor-features": [
+                "caps",
+                "dbus",
+                "domain",
+                "file",
+                "mount",
+                "namespaces",
+                "network",
+                "network_v8",
+                "policy",
+                "ptrace",
+                "query",
+                "rlimit",
+                "signal"
+            ],
+            "apparmor-parser-features": [
+                "unsafe"
+            ],
+            "apparmor-parser-mtime": 1589907589,
+            "build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
+            "cgroup-version": "1",
+            "nfs-home": false,
+            "overlay-root": "",
+            "seccomp-compiler-version": "e6e309ad8aee052e5aa695dfaa040328ae1559c5 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog",
+            "seccomp-features": [
+                "allow",
+                "errno",
+                "kill_process",
+                "kill_thread",
+                "log",
+                "trace",
+                "trap",
+                "user_notif"
+            ],
+            "version": 10
+        },
+        "seed-restart-time": "2020-07-24T21:42:16.646098923Z",
+        "seed-start-time": "0001-01-01T00:00:00Z",
+        "seed-time": "2020-07-24T21:42:20.518607Z",
+        "seeded": true
+    },
+    "status": "OK",
+    "status-code": 200,
+    "type": "sync"
+}`
+
+var newPreseedNewSnapdDiffSysKey = `
+{
+    "result": {
+        "preseed-start-time": "2020-07-24T21:41:33.838194712Z",
+        "preseed-system-key": {
+            "apparmor-features": [
+                "caps",
+                "dbus",
+                "domain",
+                "file",
+                "mount",
+                "namespaces",
+                "network",
+                "network_v8",
+                "policy",
+                "ptrace",
+                "query",
+                "rlimit",
+                "signal"
+            ],
+            "apparmor-parser-features": [
+                "unsafe"
+            ],
+            "apparmor-parser-mtime": 1589907589,
+            "build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
+            "cgroup-version": "1",
+            "nfs-home": false,
+            "overlay-root": "",
+            "seccomp-compiler-version": "e6e309ad8aee052e5aa695dfaa040328ae1559c5 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog",
+            "seccomp-features": [
+                "allow",
+                "errno",
+                "kill_process",
+                "kill_thread",
+                "log",
+                "trace",
+                "trap",
+                "user_notif"
+            ],
+            "version": 10
+        },
+        "preseed-time": "2020-07-24T21:41:43.156401424Z",
+        "preseeded": true,
+        "seed-restart-system-key": {
+            "apparmor-features": [
+                "caps",
+                "dbus",
+                "domain",
+                "file",
+                "mount",
+                "namespaces",
+                "network",
+                "policy",
+                "ptrace",
+                "query",
+                "rlimit",
+                "signal"
+            ],
+            "apparmor-parser-features": [
+                "unsafe"
+            ],
+            "apparmor-parser-mtime": 1589907589,
+            "build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
+            "cgroup-version": "1",
+            "nfs-home": false,
+            "overlay-root": "",
+            "seccomp-compiler-version": "e6e309ad8aee052e5aa695dfaa040328ae1559c5 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog",
+            "seccomp-features": [
+                "allow",
+                "errno",
+                "kill",
+                "log",
+                "trace",
+                "trap",
+                "user_notif"
+            ],
+            "version": 10
+        },
+        "seed-restart-time": "2020-07-24T21:42:16.646098923Z",
+        "seed-start-time": "0001-01-01T00:00:00Z",
+        "seed-time": "2020-07-24T21:42:20.518607Z",
+        "seeded": true
+    },
+    "status": "OK",
+    "status-code": 200,
+    "type": "sync"
+}`
+
+// a system that was not preseeded at all
+var noPreseedingJSON = `
+{
+    "result": {
+        "preseed-start-time": "0001-01-01T00:00:00Z",
+        "preseed-time": "0001-01-01T00:00:00Z",
+        "seed-restart-time": "0001-01-01T00:00:00Z",
+        "seed-start-time": "0001-01-01T00:00:00Z",
+        "seed-time": "2019-07-04T19:16:10.548793375-05:00",
+        "seeded": true
+    },
+    "status": "OK",
+    "status-code": 200,
+    "type": "sync"
+}`
+
+// a system that was preseeded, but didn't record the new keys
+// this is the case for a system that was preseeded and then seeded with an old
+// snapd, but then is refreshed to a version of snapd that supports snap debug
+// seeding, where we want to still have sensible output
+var oldPreseedingJSON = `{
+    "result": {
+        "preseed-start-time": "0001-01-01T00:00:00Z",
+        "preseed-time": "0001-01-01T00:00:00Z",
+        "seed-restart-time": "2019-07-04T19:14:10.548793375-05:00",
+        "seed-start-time": "0001-01-01T00:00:00Z",
+        "seed-time": "2019-07-04T19:16:10.548793375-05:00",
+		"seeded": true,
+		"preseeded": true
+    },
+    "status": "OK",
+    "status-code": 200,
+    "type": "sync"
+}`
+
+func (s *SnapSuite) TestDebugSeeding(c *C) {
+	tt := []struct {
+		jsonResp  string
+		expStdout string
+		expStderr string
+		expErr    string
+		comment   string
+	}{
+		{
+			jsonResp: newPreseedNewSnapdSameSysKey,
+			expStdout: `
+seeded:            true
+preseeded:         true
+image-preseeding:  9.318206712s
+seed-completion:   3.872508077s
+`[1:],
+			comment: "new preseed keys, same system-key",
+		},
+		{
+			jsonResp: newPreseedNewSnapdDiffSysKey,
+			expStdout: `
+seeded:            true
+preseeded:         true
+image-preseeding:  9.318206712s
+seed-completion:   3.872508077s
+preseed-system-key: {
+  "apparmor-features": [
+    "caps",
+    "dbus",
+    "domain",
+    "file",
+    "mount",
+    "namespaces",
+    "network",
+    "network_v8",
+    "policy",
+    "ptrace",
+    "query",
+    "rlimit",
+    "signal"
+  ],
+  "apparmor-parser-features": [
+    "unsafe"
+  ],
+  "apparmor-parser-mtime": 1589907589,
+  "build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
+  "cgroup-version": "1",
+  "nfs-home": false,
+  "overlay-root": "",
+  "seccomp-compiler-version": "e6e309ad8aee052e5aa695dfaa040328ae1559c5 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog",
+  "seccomp-features": [
+    "allow",
+    "errno",
+    "kill_process",
+    "kill_thread",
+    "log",
+    "trace",
+    "trap",
+    "user_notif"
+  ],
+  "version": 10
+}
+seed-restart-system-key: {
+  "apparmor-features": [
+    "caps",
+    "dbus",
+    "domain",
+    "file",
+    "mount",
+    "namespaces",
+    "network",
+    "policy",
+    "ptrace",
+    "query",
+    "rlimit",
+    "signal"
+  ],
+  "apparmor-parser-features": [
+    "unsafe"
+  ],
+  "apparmor-parser-mtime": 1589907589,
+  "build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
+  "cgroup-version": "1",
+  "nfs-home": false,
+  "overlay-root": "",
+  "seccomp-compiler-version": "e6e309ad8aee052e5aa695dfaa040328ae1559c5 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog",
+  "seccomp-features": [
+    "allow",
+    "errno",
+    "kill",
+    "log",
+    "trace",
+    "trap",
+    "user_notif"
+  ],
+  "version": 10
+}
+`[1:],
+			comment: "new preseed keys, different system-key",
+		},
+		{
+			jsonResp: noPreseedingJSON,
+			expStdout: `
+seeded:           true
+preseeded:        false
+seed-completion:  2562047h47m16.854775807s
+`[1:],
+			comment: "not preseeded",
+		},
+		{
+			jsonResp: oldPreseedingJSON,
+			expStdout: `
+seeded:            true
+preseeded:         true
+image-preseeding:  0s
+seed-completion:   2m0s
+`[1:],
+			comment: "old preseeded json",
+		},
+	}
+
+	for _, t := range tt {
+		comment := Commentf(t.comment)
+		n := 0
+		s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+			n++
+			switch n {
+			case 1:
+				c.Assert(r.Method, Equals, "GET", comment)
+				c.Assert(r.URL.Path, Equals, "/v2/debug", comment)
+				c.Assert(r.URL.RawQuery, Equals, "aspect=seeding", comment)
+				data, err := ioutil.ReadAll(r.Body)
+				c.Assert(err, IsNil, comment)
+				c.Assert(string(data), Equals, "", comment)
+				fmt.Fprintln(w, t.jsonResp)
+			default:
+				c.Fatalf("expected to get 1 request, now on %d", n)
+			}
+		})
+		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "seeding"})
+		if t.expErr != "" {
+			c.Assert(err, ErrorMatches, t.expErr, comment)
+			c.Assert(s.Stdout(), Equals, "", comment)
+			c.Assert(s.Stderr(), Equals, t.expStderr, comment)
+			continue
+		}
+		c.Assert(err, IsNil, comment)
+		c.Assert(rest, DeepEquals, []string{}, comment)
+		c.Assert(s.Stdout(), Equals, t.expStdout, comment)
+		c.Assert(s.Stderr(), Equals, "", comment)
+		c.Assert(n, Equals, 1, comment)
+
+		s.ResetStdStreams()
+	}
+}

--- a/cmd/snap/cmd_debug_seeding_test.go
+++ b/cmd/snap/cmd_debug_seeding_test.go
@@ -219,6 +219,18 @@ var noPreseedingJSON = `
     "type": "sync"
 }`
 
+var seedingError = `{
+    "result": {
+        "preseed-start-time": "2020-07-24T21:41:33.838194712Z",
+        "preseed-time": "2020-07-24T21:41:43.156401424Z",
+        "preseeded": true,
+        "seed-error": "cannot perform the following tasks:\n- xxx"
+    },
+    "status": "OK",
+    "status-code": 200,
+    "type": "sync"
+}`
+
 // a system that was preseeded, but didn't record the new keys
 // this is the case for a system that was preseeded and then seeded with an old
 // snapd, but then is refreshed to a version of snapd that supports snap debug
@@ -425,6 +437,19 @@ seed-completion:  –
 `[1:],
 			hasUnicode: true,
 			comment:    "not preseeded, still seeding",
+		},
+		{
+			jsonResp: seedingError,
+			expStdout: `
+seeded:  false
+seed-error: |
+  cannot perform the following tasks:
+  - xxx
+preseeded:         true
+image-preseeding:  9.318s
+seed-completion:   --
+`[1:],
+			comment: "preseeded, error during seeding",
 		},
 	}
 

--- a/cmd/snap/cmd_debug_seeding_test.go
+++ b/cmd/snap/cmd_debug_seeding_test.go
@@ -258,11 +258,12 @@ var stillSeedingNoPreseed = `{
 
 func (s *SnapSuite) TestDebugSeeding(c *C) {
 	tt := []struct {
-		jsonResp  string
-		expStdout string
-		expStderr string
-		expErr    string
-		comment   string
+		jsonResp   string
+		expStdout  string
+		expStderr  string
+		expErr     string
+		comment    string
+		hasUnicode bool
 	}{
 		{
 			jsonResp: newPreseedNewSnapdSameSysKey,
@@ -361,9 +362,19 @@ seed-restart-system-key: {
 			expStdout: `
 seeded:           true
 preseeded:        false
-seed-completion:  -
+seed-completion:  --
 `[1:],
-			comment: "not preseeded",
+			comment: "not preseeded no unicode",
+		},
+		{
+			jsonResp: noPreseedingJSON,
+			expStdout: `
+seeded:           true
+preseeded:        false
+seed-completion:  –
+`[1:],
+			comment:    "not preseeded",
+			hasUnicode: true,
 		},
 		{
 			jsonResp: oldPreseedingJSON,
@@ -381,18 +392,39 @@ seed-completion:   2m0s
 seeded:            false
 preseeded:         true
 image-preseeding:  9.318s
-seed-completion:   -
+seed-completion:   --
 `[1:],
-			comment: "preseeded, still seeding",
+			comment: "preseeded, still seeding no unicode",
+		},
+		{
+			jsonResp: stillSeeding,
+			expStdout: `
+seeded:            false
+preseeded:         true
+image-preseeding:  9.318s
+seed-completion:   –
+`[1:],
+			hasUnicode: true,
+			comment:    "preseeded, still seeding",
 		},
 		{
 			jsonResp: stillSeedingNoPreseed,
 			expStdout: `
 seeded:           false
 preseeded:        false
-seed-completion:  -
+seed-completion:  --
 `[1:],
-			comment: "not preseeded, still seeding",
+			comment: "not preseeded, still seeding no unicode",
+		},
+		{
+			jsonResp: stillSeedingNoPreseed,
+			expStdout: `
+seeded:           false
+preseeded:        false
+seed-completion:  –
+`[1:],
+			hasUnicode: true,
+			comment:    "not preseeded, still seeding",
 		},
 	}
 
@@ -414,7 +446,11 @@ seed-completion:  -
 				c.Fatalf("expected to get 1 request, now on %d", n)
 			}
 		})
-		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "seeding"})
+		args := []string{"debug", "seeding"}
+		if t.hasUnicode {
+			args = append(args, "--unicode=always")
+		}
+		rest, err := snap.Parser(snap.Client()).ParseArgs(args)
 		if t.expErr != "" {
 			c.Assert(err, ErrorMatches, t.expErr, comment)
 			c.Assert(s.Stdout(), Equals, "", comment)

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -288,6 +288,8 @@ func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		startupTag := query.Get("startup")
 		all := query.Get("all")
 		return getChangeTimings(st, chgID, ensureTag, startupTag, all == "true")
+	case "seeding-info":
+		return getSeedingInfo(st)
 	default:
 		return BadRequest("unknown debug aspect %q", aspect)
 	}

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -288,7 +288,7 @@ func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		startupTag := query.Get("startup")
 		all := query.Get("all")
 		return getChangeTimings(st, chgID, ensureTag, startupTag, all == "true")
-	case "seeding-info":
+	case "seeding":
 		return getSeedingInfo(st)
 	default:
 		return BadRequest("unknown debug aspect %q", aspect)

--- a/daemon/api_debug_seeding.go
+++ b/daemon/api_debug_seeding.go
@@ -1,0 +1,107 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"time"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type seedingInfo struct {
+	// true if the device is seeded (same as "seeded" in the state)
+	Seeded bool `json:"seeded,omitempty"`
+
+	// true if snap-preseed was applied
+	Preseeded bool `json:"preseeded,omitempty"`
+
+	// when snap-preseed was started
+	PreseedStartTime time.Time `json:"preseed-start-time,omitempty"`
+
+	// when snap-preseed work finished (i.e. before firstboot)
+	PreseededTime time.Time `json:"preseeded-time,omitempty"`
+
+	// when traditional seeding started (when not preseeding)
+	SeedStartTime time.Time `json:"seed-start-time,omitempty"`
+
+	// when seeding was started after first boot of preseeded image
+	SeedRestartTime time.Time `json:"seed-restart-time,omitempty"`
+
+	// when seeding finished
+	SeedTime time.Time `json:"seed-time,omitempty"`
+
+	// system-key created during preseeding (when snap-preseed was ran)
+	PreseedSystemKey interface{} `json:"preseed-system-key,omitempty"`
+
+	// system-key created on first boot of the preseeded image
+	RestartSystemKey interface{} `json:"restart-system-key,omitempty"`
+}
+
+func getSeedingInfo(st *state.State) Response {
+	var seeded, preseeded bool
+	err := st.Get("seeded", &seeded)
+	if err != nil && err != state.ErrNoState {
+		return BadRequest(err.Error())
+	}
+	if err = st.Get("preseeded", &preseeded); err != nil && err != state.ErrNoState {
+		return BadRequest(err.Error())
+	}
+
+	var preseedStartTime, preseededTime, seedStartTime, seedRestartTime, seedTime time.Time
+	for _, t := range []struct {
+		name string
+		tm   *time.Time
+	}{
+		{"preseed-start-time", &preseedStartTime},
+		{"preseeded-time", &preseededTime},
+		{"seed-start-time", &seedStartTime},
+		{"seed-restart-time", &seedRestartTime},
+		{"seed-time", &seedTime},
+	} {
+		if err := st.Get(t.name, t.tm); err != nil && err != state.ErrNoState {
+			return BadRequest(err.Error())
+		}
+	}
+
+	var preseedSysKey, restartSysKey interface{}
+	if err := st.Get("preseed-system-key", &preseedSysKey); err != nil && err != state.ErrNoState {
+		return BadRequest(err.Error())
+	}
+	if err := st.Get("restart-system-key", &restartSysKey); err != nil && err != state.ErrNoState {
+		return BadRequest(err.Error())
+	}
+
+	// XXX: consistency & sanity checks, e.g. if preseeded, then need to have
+	// preseed-start-time, preseeded-time, preseed-system-key etc?
+
+	data := &seedingInfo{
+		Seeded:           seeded,
+		Preseeded:        preseeded,
+		PreseedSystemKey: preseedSysKey,
+		RestartSystemKey: restartSysKey,
+		PreseedStartTime: preseedStartTime,
+		PreseededTime:    preseededTime,
+		SeedStartTime:    seedStartTime,
+		SeedRestartTime:  seedRestartTime,
+		SeedTime:         seedTime,
+	}
+
+	return SyncResponse(data, nil)
+}

--- a/daemon/api_debug_seeding.go
+++ b/daemon/api_debug_seeding.go
@@ -26,81 +26,85 @@ import (
 )
 
 type seedingInfo struct {
-	// true if the device is seeded (same as "seeded" in the state)
+	// Seeded is true when the device was seeded (same as "seeded" in the
+	// state).
 	Seeded bool `json:"seeded,omitempty"`
 
-	// true if snap-preseed was applied
+	// Preseeded is true if snap-preseed was applied.
 	Preseeded bool `json:"preseeded,omitempty"`
 
-	// when snap-preseed was started
+	// PreseedStartTime is when snap-preseed was started.
 	PreseedStartTime time.Time `json:"preseed-start-time,omitempty"`
 
-	// when snap-preseed work finished (i.e. before firstboot)
-	PreseededTime time.Time `json:"preseeded-time,omitempty"`
+	// PreseedTime is when snap-preseed work finished (i.e. before firstboot).
+	PreseedTime time.Time `json:"preseed-time,omitempty"`
 
-	// when traditional seeding started (when not preseeding)
+	// SeedStartTime is when traditional seeding started (when not preseeding).
 	SeedStartTime time.Time `json:"seed-start-time,omitempty"`
 
-	// when seeding was started after first boot of preseeded image
+	// SeedRestartTime is when seeding was started after first boot of preseeded
+	// image.
 	SeedRestartTime time.Time `json:"seed-restart-time,omitempty"`
 
-	// when seeding finished
+	// SeedTime is when seeding finished.
 	SeedTime time.Time `json:"seed-time,omitempty"`
 
-	// system-key created during preseeding (when snap-preseed was ran)
+	// PreseedSystemKey is the system-key that was created during preseeding
+	// (when snap-preseed was ran).
 	PreseedSystemKey interface{} `json:"preseed-system-key,omitempty"`
 
-	// system-key created on first boot of the preseeded image
-	RestartSystemKey interface{} `json:"restart-system-key,omitempty"`
+	// SeedRestartSystemKey is the system-key that was created on first boot of the
+	// preseeded image.
+	SeedRestartSystemKey interface{} `json:"seed-restart-system-key,omitempty"`
 }
 
 func getSeedingInfo(st *state.State) Response {
 	var seeded, preseeded bool
 	err := st.Get("seeded", &seeded)
 	if err != nil && err != state.ErrNoState {
-		return BadRequest(err.Error())
+		return InternalError(err.Error())
 	}
 	if err = st.Get("preseeded", &preseeded); err != nil && err != state.ErrNoState {
-		return BadRequest(err.Error())
+		return InternalError(err.Error())
 	}
 
-	var preseedStartTime, preseededTime, seedStartTime, seedRestartTime, seedTime time.Time
+	var preseedStartTime, preseedTime, seedStartTime, seedRestartTime, seedTime time.Time
 	for _, t := range []struct {
 		name string
 		tm   *time.Time
 	}{
 		{"preseed-start-time", &preseedStartTime},
-		{"preseeded-time", &preseededTime},
+		{"preseed-time", &preseedTime},
 		{"seed-start-time", &seedStartTime},
 		{"seed-restart-time", &seedRestartTime},
 		{"seed-time", &seedTime},
 	} {
 		if err := st.Get(t.name, t.tm); err != nil && err != state.ErrNoState {
-			return BadRequest(err.Error())
+			return InternalError(err.Error())
 		}
 	}
 
-	var preseedSysKey, restartSysKey interface{}
+	var preseedSysKey, seedRestartSysKey interface{}
 	if err := st.Get("preseed-system-key", &preseedSysKey); err != nil && err != state.ErrNoState {
-		return BadRequest(err.Error())
+		return InternalError(err.Error())
 	}
-	if err := st.Get("restart-system-key", &restartSysKey); err != nil && err != state.ErrNoState {
-		return BadRequest(err.Error())
+	if err := st.Get("seed-restart-system-key", &seedRestartSysKey); err != nil && err != state.ErrNoState {
+		return InternalError(err.Error())
 	}
 
 	// XXX: consistency & sanity checks, e.g. if preseeded, then need to have
 	// preseed-start-time, preseeded-time, preseed-system-key etc?
 
 	data := &seedingInfo{
-		Seeded:           seeded,
-		Preseeded:        preseeded,
-		PreseedSystemKey: preseedSysKey,
-		RestartSystemKey: restartSysKey,
-		PreseedStartTime: preseedStartTime,
-		PreseededTime:    preseededTime,
-		SeedStartTime:    seedStartTime,
-		SeedRestartTime:  seedRestartTime,
-		SeedTime:         seedTime,
+		Seeded:               seeded,
+		Preseeded:            preseeded,
+		PreseedSystemKey:     preseedSysKey,
+		SeedRestartSystemKey: seedRestartSysKey,
+		PreseedStartTime:     preseedStartTime,
+		PreseedTime:          preseedTime,
+		SeedStartTime:        seedStartTime,
+		SeedRestartTime:      seedRestartTime,
+		SeedTime:             seedTime,
 	}
 
 	return SyncResponse(data, nil)

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -60,7 +60,7 @@ func (s *seedingDebugSuite) TestSeedingDebug(c *C) {
 
 	preseedStartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:00Z")
 	c.Assert(err, IsNil)
-	preseededTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:01Z")
+	preseedTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:01Z")
 	c.Assert(err, IsNil)
 	seedRestartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:03Z")
 	c.Assert(err, IsNil)
@@ -69,26 +69,30 @@ func (s *seedingDebugSuite) TestSeedingDebug(c *C) {
 
 	st := s.d.overlord.State()
 	st.Lock()
-	st.Set("seeded", seeded)
+
 	st.Set("preseeded", preseeded)
+	st.Set("seeded", seeded)
+
 	st.Set("preseed-system-key", key1)
-	st.Set("restart-system-key", key2)
+	st.Set("seed-restart-system-key", key2)
 
 	st.Set("preseed-start-time", preseedStartTime)
-	st.Set("preseeded-time", preseededTime)
 	st.Set("seed-restart-time", seedRestartTime)
+
+	st.Set("preseed-time", preseedTime)
 	st.Set("seed-time", seedTime)
+
 	st.Unlock()
 
 	data := s.getSeedingDebug(c)
 	c.Check(data, DeepEquals, &seedingInfo{
-		Seeded:           true,
-		Preseeded:        true,
-		PreseedSystemKey: "foo",
-		RestartSystemKey: "bar",
-		PreseedStartTime: preseedStartTime,
-		PreseededTime:    preseededTime,
-		SeedRestartTime:  seedRestartTime,
-		SeedTime:         seedTime,
+		Seeded:               true,
+		Preseeded:            true,
+		PreseedSystemKey:     "foo",
+		SeedRestartSystemKey: "bar",
+		PreseedStartTime:     preseedStartTime,
+		PreseedTime:          preseedTime,
+		SeedRestartTime:      seedRestartTime,
+		SeedTime:             seedTime,
 	})
 }

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -38,7 +38,7 @@ func (s *seedingDebugSuite) SetUpTest(c *C) {
 }
 
 func (s *seedingDebugSuite) getSeedingDebug(c *C) interface{} {
-	req, err := http.NewRequest("GET", "/v2/debug?aspect=seeding-info", nil)
+	req, err := http.NewRequest("GET", "/v2/debug?aspect=seeding", nil)
 	c.Assert(err, IsNil)
 
 	rsp := getDebug(debugCmd, req, nil).(*resp)

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"net/http"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&seedingDebugSuite{})
+
+type seedingDebugSuite struct {
+	apiBaseSuite
+}
+
+func (s *seedingDebugSuite) SetUpTest(c *C) {
+	s.apiBaseSuite.SetUpTest(c)
+	s.daemonWithOverlordMock(c)
+}
+
+func (s *seedingDebugSuite) getSeedingDebug(c *C) interface{} {
+	req, err := http.NewRequest("GET", "/v2/debug?aspect=seeding-info", nil)
+	c.Assert(err, IsNil)
+
+	rsp := getDebug(debugCmd, req, nil).(*resp)
+	c.Assert(rsp.Type, Equals, ResponseTypeSync)
+	return rsp.Result
+}
+
+func (s *seedingDebugSuite) TestNoData(c *C) {
+	data := s.getSeedingDebug(c)
+	c.Check(data, NotNil)
+	c.Check(data, DeepEquals, &seedingInfo{})
+}
+
+func (s *seedingDebugSuite) TestSeedingDebug(c *C) {
+	seeded := true
+	preseeded := true
+	key1 := "foo"
+	key2 := "bar"
+
+	preseedStartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:00Z")
+	c.Assert(err, IsNil)
+	preseededTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:01Z")
+	c.Assert(err, IsNil)
+	seedRestartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:03Z")
+	c.Assert(err, IsNil)
+	seedTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:07Z")
+	c.Assert(err, IsNil)
+
+	st := s.d.overlord.State()
+	st.Lock()
+	st.Set("seeded", seeded)
+	st.Set("preseeded", preseeded)
+	st.Set("preseed-system-key", key1)
+	st.Set("restart-system-key", key2)
+
+	st.Set("preseed-start-time", preseedStartTime)
+	st.Set("preseeded-time", preseededTime)
+	st.Set("seed-restart-time", seedRestartTime)
+	st.Set("seed-time", seedTime)
+	st.Unlock()
+
+	data := s.getSeedingDebug(c)
+	c.Check(data, DeepEquals, &seedingInfo{
+		Seeded:           true,
+		Preseeded:        true,
+		PreseedSystemKey: "foo",
+		RestartSystemKey: "bar",
+		PreseedStartTime: preseedStartTime,
+		PreseededTime:    preseededTime,
+		SeedRestartTime:  seedRestartTime,
+		SeedTime:         seedTime,
+	})
+}

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/state"
 )
 
 var _ = Suite(&seedingDebugSuite{})
@@ -150,5 +152,66 @@ func (s *seedingDebugSuite) TestSeedingDebugPreseededStillSeeding(c *C) {
 		PreseedStartTime:     &preseedStartTime,
 		PreseedTime:          &preseedTime,
 		SeedRestartTime:      &seedRestartTime,
+	})
+}
+
+func (s *seedingDebugSuite) TestSeedingDebugPreseededSeedError(c *C) {
+	preseedStartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:00Z")
+	c.Assert(err, IsNil)
+	preseedTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:01Z")
+	c.Assert(err, IsNil)
+	seedRestartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:03Z")
+	c.Assert(err, IsNil)
+
+	st := s.d.overlord.State()
+	st.Lock()
+
+	st.Set("preseeded", true)
+	st.Set("seeded", false)
+
+	st.Set("preseed-system-key", "foo")
+	st.Set("seed-restart-system-key", "bar")
+
+	st.Set("preseed-start-time", preseedStartTime)
+	st.Set("seed-restart-time", seedRestartTime)
+
+	st.Set("preseed-time", preseedTime)
+
+	chg1 := st.NewChange("seed", "tentative 1")
+	t11 := st.NewTask("seed task", "t11")
+	t12 := st.NewTask("seed task", "t12")
+	chg1.AddTask(t11)
+	chg1.AddTask(t12)
+	t11.SetStatus(state.UndoneStatus)
+	t11.Errorf("t11: undone")
+	t12.SetStatus(state.ErrorStatus)
+	t12.Errorf("t12: fail")
+
+	// ensure different spawn time
+	time.Sleep(50 * time.Millisecond)
+	chg2 := st.NewChange("seed", "tentative 2")
+	t21 := st.NewTask("seed task", "t21")
+	chg2.AddTask(t21)
+	t21.SetStatus(state.ErrorStatus)
+	t21.Errorf("t21: error")
+
+	chg3 := st.NewChange("seed", "tentative 3")
+	t31 := st.NewTask("seed task", "t31")
+	chg3.AddTask(t31)
+	t31.SetStatus(state.DoingStatus)
+
+	st.Unlock()
+
+	data := s.getSeedingDebug(c)
+	c.Check(data, DeepEquals, &seedingInfo{
+		Seeded:               false,
+		Preseeded:            true,
+		PreseedSystemKey:     "foo",
+		SeedRestartSystemKey: "bar",
+		PreseedStartTime:     &preseedStartTime,
+		PreseedTime:          &preseedTime,
+		SeedRestartTime:      &seedRestartTime,
+		SeedError: `cannot perform the following tasks:
+- t12 (t12: fail)`,
 	})
 }

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -246,7 +246,7 @@ func SystemKeyMismatch() (bool, error) {
 	diskSystemKey.AppArmorParserFeatures = nil
 	mySystemKey.AppArmorParserFeatures = nil
 
-	ok, err := MatchSystemKeys(mySystemKey, diskSystemKey)
+	ok, err := SystemKeysMatch(mySystemKey, diskSystemKey)
 	return !ok, err
 }
 
@@ -260,12 +260,12 @@ func readSystemKey() (*systemKey, error) {
 	}
 	var diskSystemKey systemKey
 	if err := json.Unmarshal(raw, &diskSystemKey); err != nil {
-			return nil, err
+		return nil, err
 	}
 	return &diskSystemKey, nil
 }
 
-// RecordedSystemKey returns opaque system key read from the disk.
+// RecordedSystemKey returns the system key read from the disk as opaque interface{}.
 func RecordedSystemKey() (interface{}, error) {
 	diskSystemKey, err := readSystemKey()
 	if err != nil {
@@ -274,19 +274,19 @@ func RecordedSystemKey() (interface{}, error) {
 	return diskSystemKey, nil
 }
 
-// CurrentSystemKey calculates and returns opaque system key.
+// CurrentSystemKey calculates and returns the current system key as opaque interface{}.
 func CurrentSystemKey() (interface{}, error) {
 	currentSystemKey, err := generateSystemKey()
 	return currentSystemKey, err
 }
 
-// MatchSystemKeys compares opaque system keys
-func MatchSystemKeys(systemKey1, systemKey2 interface{}) (bool, error) {
+// SystemKeysMatch returns whether the given system keys match.
+func SystemKeysMatch(systemKey1, systemKey2 interface{}) (bool, error) {
 	// sanity check
 	_, ok1 := systemKey1.(*systemKey)
 	_, ok2 := systemKey2.(*systemKey)
 	if !(ok1 && ok2) {
-		return false, fmt.Errorf("MatchSystemKeys: arguments are not system keys")
+		return false, fmt.Errorf("SystemKeysMatch: arguments are not system keys")
 	}
 
 	// TODO: write custom struct compare

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -155,6 +156,17 @@ func generateSystemKey() (*systemKey, error) {
 	}
 	sk.CgroupVersion = strconv.FormatInt(int64(cgv), 10)
 
+	return sk, nil
+}
+
+// UnmarshalJSONSystemKey unmarshalls the data from the reader as JSON into a
+// system key usable with SystemKeysMatch.
+func UnmarshalJSONSystemKey(r io.Reader) (interface{}, error) {
+	sk := &systemKey{}
+	err := json.NewDecoder(r).Decode(sk)
+	if err != nil {
+		return nil, err
+	}
 	return sk, nil
 }
 

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -177,10 +177,15 @@ func WriteSystemKey() error {
 		return err
 	}
 
-	// We only want to calculate this when the mtime of the parser changes.
-	// Since we calculate the mtime() as part of generateSystemKey, we can
-	// simply unconditionally write this out here.
-	sk.AppArmorParserFeatures, _ = apparmor.ParserFeatures()
+	// only fix AppArmorParserFeatures if we didn't already mock a system-key
+	// if we mocked a system-key we are running a test and don't want to use
+	// the real host system's parser features
+	if mockedSystemKey == nil {
+		// We only want to calculate this when the mtime of the parser changes.
+		// Since we calculate the mtime() as part of generateSystemKey, we can
+		// simply unconditionally write this out here.
+		sk.AppArmorParserFeatures, _ = apparmor.ParserFeatures()
+	}
 
 	sks, err := json.Marshal(sk)
 	if err != nil {

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -261,14 +261,14 @@ func RecordedSystemKey() (interface{}, error) {
 	raw, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, ErrSystemKeyMissing
+			return nil, ErrSystemKeyMissing
 		}
 		return nil, err
 	}
 
 	var diskSystemKey systemKey
 	if err := json.Unmarshal(raw, &diskSystemKey); err != nil {
-		return false, err
+		return nil, err
 	}
 
 	return &diskSystemKey, nil
@@ -286,7 +286,7 @@ func MatchSystemKeys(systemKey1, systemKey2 interface{}) (bool, error) {
 	_, ok1 := systemKey1.(*systemKey)
 	_, ok2 := systemKey2.(*systemKey)
 	if !(ok1 && ok2) {
-		return false, fmt.Errorf("internal error: cannot compare system keys")
+		return false, fmt.Errorf("MatchSystemKeys: arguments are not system keys")
 	}
 
 	// TODO: write custom struct compare

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -406,11 +406,11 @@ func (s *systemKeySuite) TestSystemKeysUnmarshalSame(c *C) {
 	c.Assert(err, IsNil)
 
 	// now read the system key from disk
-	key2, err := interfaces.CurrentSystemKey()
+	key2, err := interfaces.RecordedSystemKey()
 	c.Assert(err, IsNil)
 
 	// the two system-keys should be the same
 	ok, err := interfaces.SystemKeysMatch(key1, key2)
 	c.Assert(err, IsNil)
-	c.Check(ok, Equals, true)
+	c.Check(ok, Equals, true, Commentf("key1:%#v key2:%#v", key1, key2))
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -342,4 +342,11 @@ func (s *systemKeySuite) TestMatchSystemKeys(c *C) {
 	ok, err := interfaces.MatchSystemKeys(key1, key2)
 	c.Assert(err, IsNil)
 	c.Check(ok, Equals, false)
+
+	key3, err := interfaces.CurrentSystemKey()
+	c.Assert(err, IsNil)
+
+	ok, err = interfaces.MatchSystemKeys(key2, key3)
+	c.Assert(err, IsNil)
+	c.Check(ok, Equals, true)
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -282,3 +282,64 @@ func (s *systemKeySuite) TestStaticVersion(c *C) {
 		"CgroupVersion:",
 	}, " ")+"}")
 }
+
+func (s *systemKeySuite) TestRecordedSystemKey(c *C) {
+	_, err := interfaces.RecordedSystemKey()
+	c.Check(err, Equals, interfaces.ErrSystemKeyMissing)
+
+	restore := interfaces.MockSystemKey(`
+{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps"]
+}
+`)
+	defer restore()
+
+	c.Assert(interfaces.WriteSystemKey(), IsNil)
+
+	// just to ensure we really re-read it from the disk with RecordedSystemKey
+	interfaces.MockSystemKey(`{"build-id":"foo"}`)
+
+	key, err := interfaces.RecordedSystemKey()
+	c.Assert(err, IsNil)
+
+	sysKey, ok := key.(*interfaces.SystemKey)
+	c.Assert(ok, Equals, true)
+	c.Check(sysKey.BuildID, Equals, "7a94e9736c091b3984bd63f5aebfc883c4d859e0")
+}
+
+func (s *systemKeySuite) TestCurrentSystemKey(c *C) {
+	restore := interfaces.MockSystemKey(`{"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"}`)
+	defer restore()
+
+	key, err := interfaces.CurrentSystemKey()
+	c.Assert(err, IsNil)
+	sysKey, ok := key.(*interfaces.SystemKey)
+	c.Assert(ok, Equals, true)
+	c.Check(sysKey.BuildID, Equals, "7a94e9736c091b3984bd63f5aebfc883c4d859e0")
+}
+
+func (s *systemKeySuite) TestMatchSystemKeys(c *C) {
+	_, err := interfaces.MatchSystemKeys(nil, nil)
+	c.Check(err, ErrorMatches, `internal error: cannot compare system keys`)
+
+	restore := interfaces.MockSystemKey(`{"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"}`)
+	defer restore()
+
+	key1, err := interfaces.CurrentSystemKey()
+	c.Assert(err, IsNil)
+
+	_, err = interfaces.MatchSystemKeys(key1, nil)
+	c.Check(err, ErrorMatches, `internal error: cannot compare system keys`)
+
+	_, err = interfaces.MatchSystemKeys(nil, key1)
+	c.Check(err, ErrorMatches, `internal error: cannot compare system keys`)
+
+	interfaces.MockSystemKey(`{"build-id": "8888e9736c091b3984bd63f5aebfc883c4d85988"}`)
+	key2, err := interfaces.CurrentSystemKey()
+	c.Assert(err, IsNil)
+
+	ok, err := interfaces.MatchSystemKeys(key1, key2)
+	c.Assert(err, IsNil)
+	c.Check(ok, Equals, false)
+}

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -373,9 +373,7 @@ func (s *systemKeySuite) TestSystemKeysUnmarshalSame(c *C) {
 			"rlimit",
 			"signal"
 		],
-		"apparmor-parser-features": [
-			"unsafe"
-		],
+		"apparmor-parser-features": [],
 		"apparmor-parser-mtime": 1589907589,
 		"build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
 		"cgroup-version": "1",

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -20,6 +20,7 @@
 package interfaces_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -347,6 +348,69 @@ func (s *systemKeySuite) TestSystemKeysMatch(c *C) {
 	c.Assert(err, IsNil)
 
 	ok, err = interfaces.SystemKeysMatch(key2, key3)
+	c.Assert(err, IsNil)
+	c.Check(ok, Equals, true)
+}
+
+func (s *systemKeySuite) TestSystemKeysUnmarshalSame(c *C) {
+	// whitespace here simulates the serialization across HTTP, etc. that should
+	// not trigger any differences
+	// use a full system-key to fully test serialization, etc.
+	systemKeyJSON := `
+	{
+		"apparmor-features": [
+			"caps",
+			"dbus",
+			"domain",
+			"file",
+			"mount",
+			"namespaces",
+			"network",
+			"network_v8",
+			"policy",
+			"ptrace",
+			"query",
+			"rlimit",
+			"signal"
+		],
+		"apparmor-parser-features": [
+			"unsafe"
+		],
+		"apparmor-parser-mtime": 1589907589,
+		"build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
+		"cgroup-version": "1",
+		"nfs-home": false,
+		"overlay-root": "",
+		"seccomp-compiler-version": "e6e309ad8aee052e5aa695dfaa040328ae1559c5 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog",
+		"seccomp-features": [
+			"allow",
+			"errno",
+			"kill_process",
+			"kill_thread",
+			"log",
+			"trace",
+			"trap",
+			"user_notif"
+		],
+		"version": 10
+	}`
+
+	// write the mocked system key to disk
+	restore := interfaces.MockSystemKey(systemKeyJSON)
+	defer restore()
+	err := interfaces.WriteSystemKey()
+	c.Assert(err, IsNil)
+
+	// now unmarshal the specific json to a system key object
+	key1, err := interfaces.UnmarshalJSONSystemKey(bytes.NewBuffer([]byte(systemKeyJSON)))
+	c.Assert(err, IsNil)
+
+	// now read the system key from disk
+	key2, err := interfaces.CurrentSystemKey()
+	c.Assert(err, IsNil)
+
+	// the two system-keys should be the same
+	ok, err := interfaces.SystemKeysMatch(key1, key2)
 	c.Assert(err, IsNil)
 	c.Check(ok, Equals, true)
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -319,9 +319,9 @@ func (s *systemKeySuite) TestCurrentSystemKey(c *C) {
 	c.Check(sysKey.BuildID, Equals, "7a94e9736c091b3984bd63f5aebfc883c4d859e0")
 }
 
-func (s *systemKeySuite) TestMatchSystemKeys(c *C) {
-	_, err := interfaces.MatchSystemKeys(nil, nil)
-	c.Check(err, ErrorMatches, `MatchSystemKeys: arguments are not system keys`)
+func (s *systemKeySuite) TestSystemKeysMatch(c *C) {
+	_, err := interfaces.SystemKeysMatch(nil, nil)
+	c.Check(err, ErrorMatches, `SystemKeysMatch: arguments are not system keys`)
 
 	restore := interfaces.MockSystemKey(`{"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"}`)
 	defer restore()
@@ -329,24 +329,24 @@ func (s *systemKeySuite) TestMatchSystemKeys(c *C) {
 	key1, err := interfaces.CurrentSystemKey()
 	c.Assert(err, IsNil)
 
-	_, err = interfaces.MatchSystemKeys(key1, nil)
-	c.Check(err, ErrorMatches, `MatchSystemKeys: arguments are not system keys`)
+	_, err = interfaces.SystemKeysMatch(key1, nil)
+	c.Check(err, ErrorMatches, `SystemKeysMatch: arguments are not system keys`)
 
-	_, err = interfaces.MatchSystemKeys(nil, key1)
-	c.Check(err, ErrorMatches, `MatchSystemKeys: arguments are not system keys`)
+	_, err = interfaces.SystemKeysMatch(nil, key1)
+	c.Check(err, ErrorMatches, `SystemKeysMatch: arguments are not system keys`)
 
 	interfaces.MockSystemKey(`{"build-id": "8888e9736c091b3984bd63f5aebfc883c4d85988"}`)
 	key2, err := interfaces.CurrentSystemKey()
 	c.Assert(err, IsNil)
 
-	ok, err := interfaces.MatchSystemKeys(key1, key2)
+	ok, err := interfaces.SystemKeysMatch(key1, key2)
 	c.Assert(err, IsNil)
 	c.Check(ok, Equals, false)
 
 	key3, err := interfaces.CurrentSystemKey()
 	c.Assert(err, IsNil)
 
-	ok, err = interfaces.MatchSystemKeys(key2, key3)
+	ok, err = interfaces.SystemKeysMatch(key2, key3)
 	c.Assert(err, IsNil)
 	c.Check(ok, Equals, true)
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -321,7 +321,7 @@ func (s *systemKeySuite) TestCurrentSystemKey(c *C) {
 
 func (s *systemKeySuite) TestMatchSystemKeys(c *C) {
 	_, err := interfaces.MatchSystemKeys(nil, nil)
-	c.Check(err, ErrorMatches, `internal error: cannot compare system keys`)
+	c.Check(err, ErrorMatches, `MatchSystemKeys: arguments are not system keys`)
 
 	restore := interfaces.MockSystemKey(`{"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"}`)
 	defer restore()
@@ -330,10 +330,10 @@ func (s *systemKeySuite) TestMatchSystemKeys(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = interfaces.MatchSystemKeys(key1, nil)
-	c.Check(err, ErrorMatches, `internal error: cannot compare system keys`)
+	c.Check(err, ErrorMatches, `MatchSystemKeys: arguments are not system keys`)
 
 	_, err = interfaces.MatchSystemKeys(nil, key1)
-	c.Check(err, ErrorMatches, `internal error: cannot compare system keys`)
+	c.Check(err, ErrorMatches, `MatchSystemKeys: arguments are not system keys`)
 
 	interfaces.MockSystemKey(`{"build-id": "8888e9736c091b3984bd63f5aebfc883c4d85988"}`)
 	key2, err := interfaces.CurrentSystemKey()

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -483,7 +483,7 @@ func (m *DeviceManager) ensureSeeded() error {
 	var start time.Time
 	if m.preseed {
 		recordedStart = "preseed-start-time"
-		start = time.Now()
+		start = timeNow()
 	} else {
 		recordedStart = "seed-start-time"
 		start = startTime

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -436,6 +436,26 @@ func (m *DeviceManager) ensureOperational() error {
 	return nil
 }
 
+var startTime time.Time
+
+func init() {
+	startTime = time.Now()
+}
+
+func (m *DeviceManager) setTimeOnce(name string, t time.Time) error {
+	var prev time.Time
+	err := m.state.Get(name, &prev)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	if !prev.IsZero() {
+		// already set
+		return nil
+	}
+	m.state.Set(name, t)
+	return nil
+}
+
 var populateStateFromSeed = populateStateFromSeedImpl
 
 // ensureSeeded makes sure that the snaps from seed.yaml get installed
@@ -457,6 +477,19 @@ func (m *DeviceManager) ensureSeeded() error {
 
 	if m.changeInFlight("seed") {
 		return nil
+	}
+
+	var recordedStart string
+	var start time.Time
+	if m.preseed {
+		recordedStart = "preseed-start-time"
+		start = time.Now()
+	} else {
+		recordedStart = "seed-start-time"
+		start = startTime
+	}
+	if err := m.setTimeOnce(recordedStart, start); err != nil {
+		return err
 	}
 
 	var opts *populateStateFromSeedOptions

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -303,6 +303,10 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureSeededHappy(c *C) {
 	defer s.state.Unlock()
 
 	c.Check(s.state.Changes(), HasLen, 1)
+
+	var seedStartTime time.Time
+	c.Assert(s.state.Get("seed-start-time", &seedStartTime), IsNil)
+	c.Check(seedStartTime.Equal(devicestate.StartTime()), Equals, true)
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkSkippedOnClassic(c *C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -236,6 +236,26 @@ func (s *deviceMgrBaseSuite) seeding() {
 	chg.SetStatus(state.DoingStatus)
 }
 
+func (s *deviceMgrSuite) TestDeviceManagerSetTimeOnce(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// set first time
+	now := time.Now()
+	err := devicestate.SetTimeOnce(s.mgr, "key-name", now)
+	c.Assert(err, IsNil)
+
+	later := now.Add(1 * time.Minute)
+	// setting again doesn't change value
+	err = devicestate.SetTimeOnce(s.mgr, "key-name", later)
+	c.Assert(err, IsNil)
+
+	var t time.Time
+	s.state.Get("key-name", &t)
+
+	c.Assert(t.Equal(now), Equals, true)
+}
+
 func (s *deviceMgrSuite) TestDeviceManagerEnsureSeededAlreadySeeded(c *C) {
 	s.state.Lock()
 	s.state.Set("seeded", true)

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -100,6 +100,10 @@ func SetSystemMode(m *DeviceManager, mode string) {
 	m.systemMode = mode
 }
 
+func SetTimeOnce(m *DeviceManager, name string, t time.Time) error {
+	return m.setTimeOnce(name, t)
+}
+
 func MockRepeatRequestSerial(label string) (restore func()) {
 	old := repeatRequestSerial
 	repeatRequestSerial = label

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -152,6 +152,10 @@ func SetBootOkRan(m *DeviceManager, b bool) {
 	m.bootOkRan = b
 }
 
+func StartTime() time.Time {
+	return startTime
+}
+
 type (
 	RegistrationContext = registrationContext
 	RemodelContext      = remodelContext

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -29,9 +29,9 @@ import (
 
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -214,6 +215,9 @@ func (s *firstbootPreseed16Suite) SetUpTest(c *C) {
 
 	err := os.MkdirAll(filepath.Join(dirs.SnapSeedDir, "assertions"), 0755)
 	c.Assert(err, IsNil)
+
+	s.AddCleanup(interfaces.MockSystemKey(`{"core": "123"}`))
+	c.Assert(interfaces.WriteSystemKey(), IsNil)
 }
 
 func (s *firstbootPreseed16Suite) TestPreseedHappy(c *C) {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -76,7 +76,7 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 
 			st.Set("preseeded", preseeded)
 			st.Set("preseed-system-key", systemKey)
-			st.Set("preseeded-time", timeNow())
+			st.Set("preseed-time", timeNow())
 
 			// do not mark this task done as this makes it racy against taskrunner tear down (the next task
 			// could start). Let this task finish after snapd restart when preseed mode is off.
@@ -88,7 +88,7 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 
 	// normal snapd run after snapd restart (not in preseed mode anymore)
 
-	st.Set("restart-system-key", systemKey)
+	st.Set("seed-restart-system-key", systemKey)
 	if err := m.setTimeOnce("seed-restart-time", startTime); err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -68,6 +68,7 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 
 			// do not mark this task done as this makes it racy against taskrunner tear down (the next task
 			// could start). Let this task finish after snapd restart when preseed mode is off.
+			t.Set("preseeded-time", time.Now())
 			st.RequestRestart(state.StopDaemon)
 		}
 
@@ -75,6 +76,10 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// normal snapd run after snapd restart (not in preseed mode anymore)
+
+	if err := m.setTimeOnce("seed-restart-time", startTime); err != nil {
+		return err
+	}
 
 	// enable all services generated as part of preseeding, but not enabled
 	// XXX: this should go away once the problem of install & services is fixed.

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -45,7 +45,7 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 
 	systemKey, err := interfaces.RecordedSystemKey()
 	if err != nil {
-		return fmt.Errorf("internal error: cannot get recorded system key: %v", err)
+		return fmt.Errorf("cannot get recorded system key: %v", err)
 	}
 
 	if m.preseed {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -25,6 +25,7 @@ import (
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -42,11 +43,18 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	systemKey, err := interfaces.RecordedSystemKey()
+	if err != nil {
+		return fmt.Errorf("internal error: cannot get recorded system key: %v", err)
+	}
+
 	if m.preseed {
 		var preseeded bool
 		// the "preseeded" flag on this task is set to allow skipping the logic
 		// below in case this handler is retried in preseeding mode due to an
 		// EnsureBefore(0) done somewhere else.
+		// XXX: we should probably drop the flag from the task now that we have
+		// one on the state.
 		if err := t.Get("preseeded", &preseeded); err != nil && err != state.ErrNoState {
 			return err
 		}
@@ -66,9 +74,12 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 				}
 			}
 
+			st.Set("preseeded", preseeded)
+			st.Set("preseed-system-key", systemKey)
+			st.Set("preseeded-time", timeNow())
+
 			// do not mark this task done as this makes it racy against taskrunner tear down (the next task
 			// could start). Let this task finish after snapd restart when preseed mode is off.
-			t.Set("preseeded-time", time.Now())
 			st.RequestRestart(state.StopDaemon)
 		}
 
@@ -77,6 +88,7 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 
 	// normal snapd run after snapd restart (not in preseed mode anymore)
 
+	st.Set("restart-system-key", systemKey)
 	if err := m.setTimeOnce("seed-restart-time", startTime); err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -540,7 +540,7 @@ func (s *preseedModeSuite) TestDoMarkPreseeded(c *C) {
 	c.Check(systemKey["build-id"], Equals, "abcde")
 
 	var preseededTime time.Time
-	c.Assert(st.Get("preseeded-time", &preseededTime), IsNil)
+	c.Assert(st.Get("preseed-time", &preseededTime), IsNil)
 	c.Check(preseededTime.Equal(now), Equals, true)
 
 	// core snap was "manually" unmounted
@@ -629,7 +629,7 @@ func (s *preseedDoneSuite) TestDoMarkPreseededAfterFirstboot(c *C) {
 	// we mark-preseeded would twice (before & after preseeding); this is not
 	// the case in this test.
 	c.Assert(st.Get("preseed-system-key", &systemKey), Equals, state.ErrNoState)
-	c.Assert(st.Get("restart-system-key", &systemKey), IsNil)
+	c.Assert(st.Get("seed-restart-system-key", &systemKey), IsNil)
 	c.Check(systemKey["build-id"], Equals, "abcde")
 
 	var seedRestartTime time.Time

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -23,11 +23,13 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -450,6 +452,9 @@ func (s *preseedBaseSuite) SetUpTest(c *C, preseed bool) {
 	// deviceMgrBaseSuite due to device Manager init.
 	s.deviceMgrBaseSuite.SetUpTest(c)
 
+	s.AddCleanup(interfaces.MockSystemKey(`{"build-id":"abcde"}`))
+	c.Assert(interfaces.WriteSystemKey(), IsNil)
+
 	s.cmdUmount = testutil.MockCommand(c, "umount", "")
 	s.cmdSystemctl = testutil.MockCommand(c, "systemctl", "")
 
@@ -475,6 +480,7 @@ apps:
 }
 
 func (s *preseedBaseSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
 	s.deviceMgrBaseSuite.TearDownTest(c)
 	s.cmdUmount.Restore()
 	s.cmdSystemctl.Restore()
@@ -498,6 +504,12 @@ func (s *preseedModeSuite) TearDownTest(c *C) {
 }
 
 func (s *preseedModeSuite) TestDoMarkPreseeded(c *C) {
+	now := time.Now()
+	restore := devicestate.MockTimeNow(func() time.Time {
+		return now
+	})
+	defer restore()
+
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -518,6 +530,18 @@ func (s *preseedModeSuite) TestDoMarkPreseeded(c *C) {
 	var preseeded bool
 	c.Check(t.Get("preseeded", &preseeded), IsNil)
 	c.Check(preseeded, Equals, true)
+
+	c.Assert(st.Get("preseeded", &preseeded), IsNil)
+	c.Check(preseeded, Equals, true)
+
+	var systemKey map[string]interface{}
+	c.Assert(st.Get("restart-system-key", &systemKey), Equals, state.ErrNoState)
+	c.Assert(st.Get("preseed-system-key", &systemKey), IsNil)
+	c.Check(systemKey["build-id"], Equals, "abcde")
+
+	var preseededTime time.Time
+	c.Assert(st.Get("preseeded-time", &preseededTime), IsNil)
+	c.Check(preseededTime.Equal(now), Equals, true)
 
 	// core snap was "manually" unmounted
 	c.Check(s.cmdUmount.Calls(), DeepEquals, [][]string{
@@ -540,6 +564,12 @@ func (s *preseedModeSuite) TestDoMarkPreseeded(c *C) {
 }
 
 func (s *preseedModeSuite) TestEnsureSeededPreseedFlag(c *C) {
+	now := time.Now()
+	restoreTimeNow := devicestate.MockTimeNow(func() time.Time {
+		return now
+	})
+	defer restoreTimeNow()
+
 	called := false
 	restore := devicestate.MockPopulateStateFromSeed(func(st *state.State, opts *devicestate.PopulateStateFromSeedOptions, tm timings.Measurer) ([]*state.TaskSet, error) {
 		called = true
@@ -551,6 +581,13 @@ func (s *preseedModeSuite) TestEnsureSeededPreseedFlag(c *C) {
 	err := devicestate.EnsureSeeded(s.mgr)
 	c.Assert(err, IsNil)
 	c.Check(called, Equals, true)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var preseedStartTime time.Time
+	c.Assert(s.state.Get("preseed-start-time", &preseedStartTime), IsNil)
+	c.Check(preseedStartTime.Equal(now), Equals, true)
 }
 
 type preseedDoneSuite struct {
@@ -586,6 +623,18 @@ func (s *preseedDoneSuite) TestDoMarkPreseededAfterFirstboot(c *C) {
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 	c.Check(s.cmdUmount.Calls(), HasLen, 0)
 	c.Check(s.restartRequests, HasLen, 0)
+
+	var systemKey map[string]interface{}
+	// in real world preseed-system-key would be present at this point because
+	// we mark-preseeded would twice (before & after preseeding); this is not
+	// the case in this test.
+	c.Assert(st.Get("preseed-system-key", &systemKey), Equals, state.ErrNoState)
+	c.Assert(st.Get("restart-system-key", &systemKey), IsNil)
+	c.Check(systemKey["build-id"], Equals, "abcde")
+
+	var seedRestartTime time.Time
+	c.Assert(st.Get("seed-restart-time", &seedRestartTime), IsNil)
+	c.Check(seedRestartTime.Equal(devicestate.StartTime()), Equals, true)
 
 	c.Check(s.cmdSystemctl.Calls(), DeepEquals, [][]string{
 		{"systemctl", "--root", dirs.GlobalRootDir, "enable", "snap.test-snap.srv.service"},

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -535,7 +535,7 @@ func (s *preseedModeSuite) TestDoMarkPreseeded(c *C) {
 	c.Check(preseeded, Equals, true)
 
 	var systemKey map[string]interface{}
-	c.Assert(st.Get("restart-system-key", &systemKey), Equals, state.ErrNoState)
+	c.Assert(st.Get("seed-restart-system-key", &systemKey), Equals, state.ErrNoState)
 	c.Assert(st.Get("preseed-system-key", &systemKey), IsNil)
 	c.Check(systemKey["build-id"], Equals, "abcde")
 

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -626,8 +626,8 @@ func (s *preseedDoneSuite) TestDoMarkPreseededAfterFirstboot(c *C) {
 
 	var systemKey map[string]interface{}
 	// in real world preseed-system-key would be present at this point because
-	// we mark-preseeded would twice (before & after preseeding); this is not
-	// the case in this test.
+	// mark-preseeded would be run twice (before & after preseeding); this is
+	// not the case in this test.
 	c.Assert(st.Get("preseed-system-key", &systemKey), Equals, state.ErrNoState)
 	c.Assert(st.Get("seed-restart-system-key", &systemKey), IsNil)
 	c.Check(systemKey["build-id"], Equals, "abcde")

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -66,6 +66,19 @@ execute: |
   execute_remote "cat /var/lib/snapd/system-key" > system-key.real
   diff -u -w system-key.real system-key.preseeded
 
+  execute_remote "snap debug seeding" | MATCH "preseeded:\s+true"
+  execute_remote "snap debug seeding" | MATCH "seeded:\s+true"
+  # FIXME: this just checks that the time is of the form "xxx.xxxs", which could
+  # break if the preseeding takes more than 60s and golang formats the 
+  # time.Duration as "1m2.03s", etc. but for now this should be good enough
+  execute_remote "snap debug seeding" | MATCH "image-preseeding:\s+[0-9]+\.[0-9]+s"
+  execute_remote "snap debug seeding" | MATCH "seed-completion:\s+[0-9]+\.[0-9]+s"
+
+  # we should not have had any system-key difference as per above, so we 
+  # shouldn't output the preseed system-key or the seed-restart-system-key
+  execute_remote "snap debug seeding" | NOMATCH "preseed-system-key:"
+  execute_remote "snap debug seeding" | NOMATCH "seed-restart-system-key:"
+
   echo "Checking that lxd snap is operational"
   execute_remote "snap list" | not MATCH "broken"
   execute_remote "snap services" | MATCH "lxd.activate +enabled +inactive"


### PR DESCRIPTION
I haven't cherry-picked all the spread tests changes (except for a single commit that applied cleanly, but it will most likely fail anyway due to other missing changes), because preseeding tests and associated tests/lib helpers diverged too much (my old attempt to fix this for 2.45 https://github.com/snapcore/snapd/pull/8980).

PRs included:
https://github.com/snapcore/snapd/pull/9028
https://github.com/snapcore/snapd/pull/9029
https://github.com/snapcore/snapd/pull/9035
https://github.com/snapcore/snapd/pull/9063
https://github.com/snapcore/snapd/pull/9090
https://github.com/snapcore/snapd/pull/9091
https://github.com/snapcore/snapd/pull/9076
https://github.com/snapcore/snapd/pull/9082
