### PR TITLE
corecfg: add "system.timezone" setting to the system settings

### DIFF
--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -85,6 +85,9 @@ func init() {
 	// journal.persistent
 	addFSOnlyHandler(validateJournalSettings, handleJournalConfiguration, coreOnly)
 
+	// system.timezone
+	addFSOnlyHandler(validateTimezoneSettings, handleTimezoneConfiguration, coreOnly)
+
 	sysconfig.ApplyFilesystemOnlyDefaultsImpl = func(rootDir string, defaults map[string]interface{}, options *sysconfig.FilesystemOnlyApplyOptions) error {
 		return filesystemOnlyApply(rootDir, plainCoreConfig(defaults), options)
 	}

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -1,0 +1,86 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+)
+
+func init() {
+	// add supported configuration of this module
+	supportedConfigurations["core.system.timezone"] = true
+}
+
+var validTimezone = regexp.MustCompile(`^[a-zA-Z0-9+-]+(/[a-zA-Z0-9+-]+)?$`).MatchString
+
+func validateTimezoneSettings(tr config.ConfGetter) error {
+	timezone, err := coreCfg(tr, "system.timezone")
+	if err != nil {
+		return err
+	}
+	if timezone == "" {
+		return nil
+	}
+	if !validTimezone(timezone) {
+		return fmt.Errorf("cannot set timezone %q: name not valid", timezone)
+	}
+
+	return nil
+}
+
+func handleTimezoneConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+	output, err := coreCfg(tr, "system.timezone")
+	if err != nil {
+		return nil
+	}
+	// nothing to do
+	if output == "" {
+		return nil
+	}
+	// runtime system
+	if opts == nil {
+		output, err := exec.Command("timedatectl", "set-timezone", output).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("cannot set timezone: %v", osutil.OutputErr(output, err))
+		}
+	} else {
+		// important to use /etc/writable/
+		localtimePath := filepath.Join(opts.RootDir, "/etc/writable/localtime")
+		if err := os.MkdirAll(filepath.Dir(localtimePath), 0755); err != nil {
+			return err
+		}
+		if err := os.Symlink(filepath.Join("/usr/share/zoneinfo", output), localtimePath); err != nil {
+			return err
+		}
+		timezonePath := filepath.Join(opts.RootDir, "/etc/writable/timezone")
+		if err := osutil.AtomicWriteFile(timezonePath, []byte(output+"\n"), 0644, 0); err != nil {
+			return fmt.Errorf("cannot write timezone: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -60,17 +60,17 @@ func handleTimezoneConfiguration(tr config.ConfGetter, opts *fsOnlyContext) erro
 	//
 	// It will also override any hostname on the next `snap set` run
 	// that was written not using `snap set system system.hostname`.
-	output, err := coreCfg(tr, "system.timezone")
+	timezone, err := coreCfg(tr, "system.timezone")
 	if err != nil {
 		return nil
 	}
 	// nothing to do
-	if output == "" {
+	if timezone == "" {
 		return nil
 	}
 	// runtime system
 	if opts == nil {
-		output, err := exec.Command("timedatectl", "set-timezone", output).CombinedOutput()
+		output, err := exec.Command("timedatectl", "set-timezone", timezone).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("cannot set timezone: %v", osutil.OutputErr(output, err))
 		}
@@ -80,11 +80,11 @@ func handleTimezoneConfiguration(tr config.ConfGetter, opts *fsOnlyContext) erro
 		if err := os.MkdirAll(filepath.Dir(localtimePath), 0755); err != nil {
 			return err
 		}
-		if err := os.Symlink(filepath.Join("/usr/share/zoneinfo", output), localtimePath); err != nil {
+		if err := os.Symlink(filepath.Join("/usr/share/zoneinfo", timezone), localtimePath); err != nil {
 			return err
 		}
 		timezonePath := filepath.Join(opts.RootDir, "/etc/writable/timezone")
-		if err := osutil.AtomicWriteFile(timezonePath, []byte(output+"\n"), 0644, 0); err != nil {
+		if err := osutil.AtomicWriteFile(timezonePath, []byte(timezone+"\n"), 0644, 0); err != nil {
 			return fmt.Errorf("cannot write timezone: %v", err)
 		}
 	}

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -53,6 +53,13 @@ func validateTimezoneSettings(tr config.ConfGetter) error {
 }
 
 func handleTimezoneConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+	// TODO: convert to "virtual" configuration nodes once we have support
+	// for this. The current code is not ideal because if one calls
+	// `snap get system system.hostname` the answer can be ""
+	// when not set via snap set.
+	//
+	// It will also override any hostname on the next `snap set` run
+	// that was written not using `snap set system system.hostname`.
 	output, err := coreCfg(tr, "system.timezone")
 	if err != nil {
 		return nil

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -35,7 +35,7 @@ func init() {
 	supportedConfigurations["core.system.timezone"] = true
 }
 
-var validTimezone = regexp.MustCompile(`^[a-zA-Z0-9+-]+(/[a-zA-Z0-9+-]+)?$`).MatchString
+var validTimezone = regexp.MustCompile(`^[a-zA-Z0-9+_-]+(/[a-zA-Z0-9+_-]+)?(/[a-zA-Z0-9+_-]+)?$`).MatchString
 
 func validateTimezoneSettings(tr config.ConfGetter) error {
 	timezone, err := coreCfg(tr, "system.timezone")

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -75,7 +75,10 @@ func handleTimezoneConfiguration(tr config.ConfGetter, opts *fsOnlyContext) erro
 			return fmt.Errorf("cannot set timezone: %v", osutil.OutputErr(output, err))
 		}
 	} else {
-		// important to use /etc/writable/
+		// On the UC16/UC18/UC20 images the file /etc/hostname is a
+		// symlink to /etc/writable/hostname. The /etc/hostname is
+		// not part of the "writable-path" so we must set the file
+		// in /etc/writable here for this to work.
 		localtimePath := filepath.Join(opts.RootDir, "/etc/writable/localtime")
 		if err := os.MkdirAll(filepath.Dir(localtimePath), 0755); err != nil {
 			return err

--- a/overlord/configstate/configcore/timezone_test.go
+++ b/overlord/configstate/configcore/timezone_test.go
@@ -46,7 +46,7 @@ func (s *timezoneSuite) SetUpTest(c *C) {
 
 func (s *timezoneSuite) TestConfigureTimezoneInvalid(c *C) {
 	invalidTimezones := []string{
-		"no-#", "no-ä", "no/tripple/slash/",
+		"no-#", "no-ä", "no/triple/slash/",
 	}
 
 	for _, tz := range invalidTimezones {

--- a/overlord/configstate/configcore/timezone_test.go
+++ b/overlord/configstate/configcore/timezone_test.go
@@ -46,7 +46,7 @@ func (s *timezoneSuite) SetUpTest(c *C) {
 
 func (s *timezoneSuite) TestConfigureTimezoneInvalid(c *C) {
 	invalidTimezones := []string{
-		"no-#", "no-ä", "no/double/slash",
+		"no-#", "no-ä", "no/tripple/slash/",
 	}
 
 	for _, tz := range invalidTimezones {
@@ -68,7 +68,8 @@ func (s *timezoneSuite) TestConfigureTimezoneIntegration(c *C) {
 	defer mockedTimedatectl.Restore()
 
 	validTimezones := []string{
-		"UTC", "Europe/Malta", "US/Indiana-Starke",
+		"UTC", "Europe/Malta", "US/Indiana-Starke", "Africa/Sao_Tome",
+		"America/Argentina/Cordoba", "America/Argentina/La_Rioja",
 		"Etc/GMT+1", "CST6CDT", "GMT0", "GMT-0", "PST8PDT",
 	}
 

--- a/overlord/configstate/configcore/timezone_test.go
+++ b/overlord/configstate/configcore/timezone_test.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type timezoneSuite struct {
+	configcoreSuite
+}
+
+var _ = Suite(&timezoneSuite{})
+
+func (s *timezoneSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
+	c.Assert(err, IsNil)
+}
+
+func (s *timezoneSuite) TestConfigureTimezoneInvalid(c *C) {
+	invalidTimezones := []string{
+		"no-#", "no-ä", "no/double/slash",
+	}
+
+	for _, tz := range invalidTimezones {
+		err := configcore.Run(&mockConf{
+			state: s.state,
+			conf: map[string]interface{}{
+				"system.timezone": tz,
+			},
+		})
+		c.Assert(err, ErrorMatches, `cannot set timezone.*`)
+	}
+}
+
+func (s *timezoneSuite) TestConfigureTimezoneIntegration(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockedTimedatectl := testutil.MockCommand(c, "timedatectl", "")
+	defer mockedTimedatectl.Restore()
+
+	validTimezones := []string{
+		"UTC", "Europe/Malta", "US/Indiana-Starke",
+		"Etc/GMT+1", "CST6CDT", "GMT0", "GMT-0", "PST8PDT",
+	}
+
+	for _, tz := range validTimezones {
+		err := configcore.Run(&mockConf{
+			state: s.state,
+			conf: map[string]interface{}{
+				"system.timezone": tz,
+			},
+		})
+		c.Assert(err, IsNil)
+		c.Check(mockedTimedatectl.Calls(), DeepEquals, [][]string{
+			{"timedatectl", "set-timezone", tz},
+		})
+		mockedTimedatectl.ForgetCalls()
+	}
+}
+
+func (s *timezoneSuite) TestFilesystemOnlyApply(c *C) {
+	conf := configcore.PlainCoreConfig(map[string]interface{}{
+		"system.timezone": "Europe/Berlin",
+	})
+	tmpDir := c.MkDir()
+	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+
+	c.Check(filepath.Join(tmpDir, "/etc/writable/timezone"), testutil.FileEquals, "Europe/Berlin\n")
+	p, err := os.Readlink(filepath.Join(tmpDir, "/etc/writable/localtime"))
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, "/usr/share/zoneinfo/Europe/Berlin")
+}

--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -29,7 +29,10 @@ restore: |
         systemctl enable rsyslog.service
         systemctl start rsyslog.service
     fi
-
+    if [ -e current-timezone ]; then
+        timedatectl set-timezone "$(cat current-timezone)"
+    fi
+ 
     rm -f /etc/systemd/login.conf.d/00-snap-core.conf
 
 execute: |
@@ -134,3 +137,9 @@ execute: |
     snap unset system system.kernel.printk.console-loglevel
     not test -e /etc/sysctl.d/99-snapd.conf
     sysctl -n kernel.printk|MATCH "^4\s+"
+
+    echo "setting the timezone works"
+    cat /etc/timezone > current-timezone
+    snap set system system.timezone=Europe/Malta
+    MATCH "Europe/Malta" /etc/timezone
+    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/Europe/Malta"

--- a/tests/nested/manual/core-early-config/defaults.yaml
+++ b/tests/nested/manual/core-early-config/defaults.yaml
@@ -3,3 +3,5 @@ defaults:
     service:
       rsyslog:
         disable: true
+    system:
+      timezone: Europe/Malta

--- a/tests/nested/manual/core-early-config/install
+++ b/tests/nested/manual/core-early-config/install
@@ -1,2 +1,10 @@
 #!/bin/sh
-readlink /etc/systemd/system/rsyslog.service > "$SNAP_COMMON"/debug.txt  2>&1 || true
+
+# rsyslog.service is expected to be a symlink at this point, and apparmor
+# doesn't control readlink, so this should work even without devmode or
+# system-files plug.
+RSYSLOG=$(readlink /etc/systemd/system/rsyslog.service)
+echo "rsyslog symlink: $RSYSLOG" > "$SNAP_COMMON"/debug.txt || true
+
+LOCALTIME=$(readlink /etc/writable/localtime)
+echo "localtime symlink: $LOCALTIME"  >> "$SNAP_COMMON"/debug.txt  2>&1 || true

--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -59,9 +59,10 @@ execute: |
 
     echo "Test that rsyslog was disabled early."
     # early config is witnessed by install hook of the pc gadget
-    execute_remote "cat /var/snap/pc/common/debug.txt" | MATCH "/dev/null"
+    execute_remote "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
     execute_remote "test -L /etc/systemd/system/rsyslog.service"
 
     # timezone is set
     execute_remote "cat /etc/timezone" | MATCH "Europe/Malta"
     execute_remote "readlink -f /etc/localtime" | MATCH "Europe/Malta"
+    execute_remote "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"

--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -61,3 +61,7 @@ execute: |
     # early config is witnessed by install hook of the pc gadget
     execute_remote "cat /var/snap/pc/common/debug.txt" | MATCH "/dev/null"
     execute_remote "test -L /etc/systemd/system/rsyslog.service"
+
+    # timezone is set
+    execute_remote "cat /etc/timezone" | MATCH "Europe/Malta"
+    execute_remote "readlink -f /etc/localtime" | MATCH "Europe/Malta"

--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -8,3 +8,5 @@ defaults:
     system:
       power-key-action: ignore
       disable-backlight-service: true
+    system:
+      timezone: Europe/Malta

--- a/tests/nested/manual/core20-early-config/install
+++ b/tests/nested/manual/core20-early-config/install
@@ -8,3 +8,6 @@ echo "rsyslog symlink: $RSYSLOG" > "$SNAP_COMMON"/debug.txt || true
 
 BACKLIGHT=$(readlink /etc/systemd/system/systemd-backlight@.service)
 echo "backlight symlink: $BACKLIGHT" >> "$SNAP_COMMON"/debug.txt || true
+
+LOCALTIME=$(readlink /etc/writable/localtime)
+echo "localtime symlink: $LOCALTIME"  >> "$SNAP_COMMON"/debug.txt  2>&1 || true

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -65,3 +65,7 @@ execute: |
     # inspected from install hook of the gadget.
     execute_remote "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
     execute_remote "cat /var/snap/pc/common/debug.txt" | MATCH "backlight symlink: /dev/null"
+
+    # timezone is set
+    execute_remote "cat /etc/timezone" | MATCH "Europe/Malta"
+    execute_remote "readlink -f /etc/localtime" | MATCH "Europe/Malta"

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -69,3 +69,4 @@ execute: |
     # timezone is set
     execute_remote "cat /etc/timezone" | MATCH "Europe/Malta"
     execute_remote "readlink -f /etc/localtime" | MATCH "Europe/Malta"
+    execute_remote "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"


### PR DESCRIPTION
This commit adds support for setting the timezone via the snap
configuration system. This allows image customizations in UC20
that used to be done via direct manipulation of the "writable"
partition in UC16/UC18.

The image customization part will be fine as is but for the runtime
setting we also need to fix LP: #1650688

