### PR TITLE
gadget, osutil: use atomic file copy, adjust tests

### DIFF
--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -221,7 +221,7 @@ func writeFileOrSymlink(src, dst string, preserveInDst []string) error {
 
 		// do not follow sylimks, dst is a reflection of the src which
 		// is a file
-		if err := osutil.CopyFileAtomic(src, dst, 0); err != nil {
+		if err := osutil.AtomicWriteFileCopy(dst, src, 0); err != nil {
 			return fmt.Errorf("cannot copy %s: %v", src, err)
 		}
 	}

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -219,7 +219,8 @@ func writeFileOrSymlink(src, dst string, preserveInDst []string) error {
 	} else {
 		// TODO try to preserve ownership and permission bits
 
-		// dst is a reflection of src, no additional flags are needed
+		// do not follow sylimks, dst is a reflection of the src which
+		// is a file
 		if err := osutil.CopyFileAtomic(src, dst, 0); err != nil {
 			return fmt.Errorf("cannot copy %s: %v", src, err)
 		}

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -217,12 +217,10 @@ func writeFileOrSymlink(src, dst string, preserveInDst []string) error {
 			return fmt.Errorf("cannot write a symlink: %v", err)
 		}
 	} else {
-		// overwrite & sync by default
-		copyFlags := osutil.CopyFlagOverwrite | osutil.CopyFlagSync
-
-		// TODO use osutil.AtomicFile
 		// TODO try to preserve ownership and permission bits
-		if err := osutil.CopyFile(src, dst, copyFlags); err != nil {
+
+		// dst is a reflection of src, no additional flags are needed
+		if err := osutil.CopyFileAtomic(src, dst, 0); err != nil {
 			return fmt.Errorf("cannot copy %s: %v", src, err)
 		}
 	}

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -2021,8 +2021,8 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackRestoreFails(c *C
 		{target: "foo", content: "written"},
 		{target: "some-dir/foo", content: "written"},
 	})
-	// the file exists, rollback will try to restore it, but make the file
-	// non-modifiable directly
+	// the file exists, and cannot be modified directly, rollback will still
+	// restore the backup as we atomically swap copies with rename()
 	err := os.Chmod(filepath.Join(outDir, "foo"), 0000)
 	c.Assert(err, IsNil)
 

--- a/osutil/cp.go
+++ b/osutil/cp.go
@@ -117,11 +117,12 @@ func CopyFile(src, dst string, flags CopyFlag) (err error) {
 	return nil
 }
 
-// CopyFileAtomic copies src to dst using AtomicFile internally to create the
-// destination. The destination path is always overwritten. The destination and
+// AtomicWriteFileCopy writes to dst a copy of src using AtomicFile
+// internally to create the destination.
+// The destination path is always overwritten. The destination and
 // the owning directory are synced after copy completes. Pass additional flags
 // for AtomicFile wrapping the destination.
-func CopyFileAtomic(src, dst string, flags AtomicWriteFlags) (err error) {
+func AtomicWriteFileCopy(dst, src string, flags AtomicWriteFlags) (err error) {
 	fin, err := openfile(src, os.O_RDONLY, 0)
 	if err != nil {
 		return fmt.Errorf("unable to open source file %s: %v", src, err)

--- a/osutil/cp_test.go
+++ b/osutil/cp_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -301,23 +301,23 @@ func (s *cpSuite) TestCopyPreserveAllSyncSyncFailure(c *C) {
 	})
 }
 
-func (s *cpSuite) TestCopyAtomicSimple(c *C) {
-	err := CopyFileAtomic(s.f1, s.f2, 0)
+func (s *cpSuite) TestAtomicWriteFileCopySimple(c *C) {
+	err := AtomicWriteFileCopy(s.f2, s.f1, 0)
 	c.Assert(err, IsNil)
 	c.Assert(s.f2, testutil.FileEquals, s.data)
 
 }
 
-func (s *cpSuite) TestCopyAtomicOverwrites(c *C) {
+func (s *cpSuite) TestAtomicWriteFileCopyOverwrites(c *C) {
 	err := ioutil.WriteFile(s.f2, []byte("this is f2 content"), 0644)
 	c.Assert(err, IsNil)
 
-	err = CopyFileAtomic(s.f1, s.f2, 0)
+	err = AtomicWriteFileCopy(s.f2, s.f1, 0)
 	c.Assert(err, IsNil)
 	c.Assert(s.f2, testutil.FileEquals, s.data)
 }
 
-func (s *cpSuite) TestCopyAtomicSymlinks(c *C) {
+func (s *cpSuite) TestAtomicWriteFileCopySymlinks(c *C) {
 	f2Symlink := filepath.Join(s.dir, "f2-symlink")
 	err := os.Symlink(s.f2, f2Symlink)
 	c.Assert(err, IsNil)
@@ -327,35 +327,35 @@ func (s *cpSuite) TestCopyAtomicSymlinks(c *C) {
 	c.Assert(err, IsNil)
 
 	// follows symlink, dst is f2
-	err = CopyFileAtomic(s.f1, f2Symlink, AtomicWriteFollow)
+	err = AtomicWriteFileCopy(f2Symlink, s.f1, AtomicWriteFollow)
 	c.Assert(err, IsNil)
 	c.Check(IsSymlink(f2Symlink), Equals, true, Commentf("%q is not a symlink", f2Symlink))
 	c.Check(s.f2, testutil.FileEquals, s.data)
 	c.Check(f2SymlinkNoFollow, testutil.FileEquals, s.data)
 
 	// when not following, copy overwrites the symlink
-	err = CopyFileAtomic(s.f1, f2SymlinkNoFollow, 0)
+	err = AtomicWriteFileCopy(f2SymlinkNoFollow, s.f1, 0)
 	c.Assert(err, IsNil)
 	c.Check(IsSymlink(f2SymlinkNoFollow), Equals, false, Commentf("%q is not a file", f2SymlinkNoFollow))
 	c.Check(f2SymlinkNoFollow, testutil.FileEquals, s.data)
 }
 
-func (s *cpSuite) TestCopyAtomicErrReal(c *C) {
-	err := CopyFileAtomic(filepath.Join(s.dir, "random-file"), s.f2, 0)
+func (s *cpSuite) TestAtomicWriteFileCopyErrReal(c *C) {
+	err := AtomicWriteFileCopy(s.f2, filepath.Join(s.dir, "random-file"), 0)
 	c.Assert(err, ErrorMatches, "unable to open source file .*/random-file: open .* no such file or directory")
 
 	dir := c.MkDir()
 
-	err = CopyFileAtomic(s.f1, filepath.Join(dir, "random-dir", "f3"), 0)
+	err = AtomicWriteFileCopy(filepath.Join(dir, "random-dir", "f3"), s.f1, 0)
 	c.Assert(err, ErrorMatches, `cannot create atomic file: open .*/random-dir/f3\.[a-zA-Z0-9]+~: no such file or directory`)
 
 	err = os.MkdirAll(filepath.Join(dir, "read-only"), 0000)
 	c.Assert(err, IsNil)
-	err = CopyFileAtomic(s.f1, filepath.Join(dir, "read-only", "f3"), 0)
+	err = AtomicWriteFileCopy(filepath.Join(dir, "read-only", "f3"), s.f1, 0)
 	c.Assert(err, ErrorMatches, `cannot create atomic file: open .*/read-only/f3\.[a-zA-Z0-9]+~: permission denied`)
 }
 
-func (s *cpSuite) TestCopyAtomicErrMockedCopy(c *C) {
+func (s *cpSuite) TestAtomicWriteFileCopyErrMockedCopy(c *C) {
 	s.mock()
 	s.errs = []error{
 		nil, // openFile
@@ -363,7 +363,7 @@ func (s *cpSuite) TestCopyAtomicErrMockedCopy(c *C) {
 		errors.New("copy fail"),
 	}
 
-	err := CopyFileAtomic(s.f1, s.f2, 0)
+	err := AtomicWriteFileCopy(s.f2, s.f1, 0)
 	c.Assert(err, ErrorMatches, `unable to copy .*/f1 to .*/f2\.[a-zA-Z0-9]+~: copy fail`)
 	entries, err := filepath.Glob(filepath.Join(s.dir, "*"))
 	c.Assert(err, IsNil)

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
The regular CopyFile() call can only overwrite the destination location in
place. Add a new helper that wraps the destination path with AtomicFile, to
obtain a 2 stage write & commit (or cancel) behavior.

Use the CopyFileAtomic helper in gadget for moving file data around.
Update the tests to match slightly changed semantics.
