### PR TITLE
tests: fix for timing issues on journal-state test

### DIFF
--- a/tests/lib/tools/suite/journal-state/task.yaml
+++ b/tests/lib/tools/suite/journal-state/task.yaml
@@ -12,6 +12,7 @@ execute: |
 
     # Check that the test is correctly started in the journal log
     "$TESTSTOOLS"/journal-state start-new-log
+    echo "Add some extra logs" | systemd-cat -t snapd-test
     retry --wait 1 --attempts 30 sh -c "test $(journalctl --cursor "$cursor1" | grep -c "$SPREAD_JOB") -eq 1"
 
     # Check that the subcommand check-log-started works
@@ -24,6 +25,9 @@ execute: |
 
     # Check that the subcommand get-last-cursor works
     echo "TEST-XX2" | systemd-cat -t snapd-test
+    echo "Add some extra logs" | systemd-cat -t different-test
+    retry --wait 1 --attempts 30 sh -c "test $("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX2) -eq 1"
+
     cursor2=$("$TESTSTOOLS"/journal-state get-last-cursor)
     test "$("$TESTSTOOLS"/journal-state get-log-from-cursor "$cursor2" | grep -c "TEST-XX1")" -eq 0
 


### PR DESCRIPTION
Add some extra logs in the journal log to prevent timing issues on test.

Issue 1: 
----------
++ journalctl --cursor 's=6b278bd9ac084416952b40431ea0e8a7;i=5dc;b=c20c14c462e6472bb56887598e4c5ed8;m=1dee46fd;t=5ac34ee1eece6;x=9d2c2d5237dcb442'
+ retry --wait 1 --attempts 30 sh -c 'test 0 -eq 1'
retry: command sh -c test 0 -eq 1 failed with code 1
retry: next attempt in 1.0 second(s) (attempt 1 of 30)
.....
retry: next attempt in 1.0 second(s) (attempt 29 of 30)
retry: command sh -c test 0 -eq 1 failed with code 1
retry: command sh -c test 0 -eq 1 keeps failing after 30 attempts

Issue 2: 
----------

2020-08-05T12:37:50.3590006Z + retry --wait 1 --attempts 30 sh -c 'test 1 -eq 1'
2020-08-05T12:37:50.3590392Z + systemd-cat -t snapd-test
2020-08-05T12:37:50.3590757Z + echo TEST-XX2
2020-08-05T12:37:50.3592298Z ++ /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/journal-state get-last-cursor
2020-08-05T12:37:50.3592921Z + cursor2='s=92bd708e4bb945e5b33b27f6f29e2fb7;i=770;b=4240db0d1e804567a4c524fe24d1cb13;m=21d8b2f8;t=5ac20a3c773da;x=8e48d9754bc439a7'
2020-08-05T12:37:50.3593329Z ++ grep -c TEST-XX1
2020-08-05T12:37:50.3594089Z ++ /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/journal-state get-log-from-cursor 's=92bd708e4bb945e5b33b27f6f29e2fb7;i=770;b=4240db0d1e804567a4c524fe24d1cb13;m=21d8b2f8;t=5ac20a3c773da;x=8e48d9754bc439a7'
2020-08-05T12:37:50.3594530Z + test 1 -eq 0