### PR TITLE
tests: remove End-Of-Life releases from spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -68,8 +68,6 @@ backends:
                   workers: 8
             - ubuntu-18.04-64:
                   workers: 8
-            - ubuntu-19.10-64:
-                  workers: 6
             - ubuntu-20.04-64:
                   workers: 8
             - ubuntu-core-16-64:
@@ -139,8 +137,6 @@ backends:
                   workers: 6
             - ubuntu-18.04-64:
                   workers: 6
-            - ubuntu-19.10-64:
-                  workers: 6
             - ubuntu-20.04-64:
                   workers: 6
 
@@ -159,10 +155,6 @@ backends:
                   image: ubuntu-1804-64-virt-enabled
                   storage: 20G
                   workers: 2
-            - ubuntu-19.10-64:
-                  image: ubuntu-1910-64-virt-enabled
-                  storage: 20G
-                  workers: 1
             - ubuntu-20.04-64:
                   image: ubuntu-2004-64-virt-enabled
                   storage: 20G
@@ -211,31 +203,10 @@ backends:
                   username: ubuntu
                   password: ubuntu
                   flags: [virtio]
-            - ubuntu-17.10-64:
-                  username: ubuntu
-                  password: ubuntu
             - ubuntu-18.04-64:
                   username: ubuntu
                   password: ubuntu
             - ubuntu-18.04-32:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-18.10-64:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-18.10-32:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.04-64:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.04-32:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.10-64:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.10-32:
                   username: ubuntu
                   password: ubuntu
             - ubuntu-20.04-64:
@@ -343,63 +314,6 @@ backends:
                   username: ubuntu
                   password: ubuntu
             - ubuntu-18.04-arm64:
-                  username: ubuntu
-                  password: ubuntu
-            # Cosmic
-            - ubuntu-18.10-amd64:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-18.10-i386:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-18.10-ppc64el:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-18.10-armhf:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-18.10-s390x:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-18.10-arm64:
-                  username: ubuntu
-                  password: ubuntu
-            # Disco
-            - ubuntu-19.04-amd64:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.04-i386:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.04-ppc64el:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.04-armhf:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.04-s390x:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.04-arm64:
-                  username: ubuntu
-                  password: ubuntu
-            # Eoan
-            - ubuntu-19.10-amd64:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.10-i386:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.10-ppc64el:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.10-armhf:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.10-s390x:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-19.10-arm64:
                   username: ubuntu
                   password: ubuntu
             # Focal
@@ -902,7 +816,6 @@ suites:
         systems:
             - ubuntu-16.04-64
             - ubuntu-18.04-64
-            - ubuntu-19.10-64
             - ubuntu-20.04-64
         environment:
             NESTED_TYPE: "classic"


### PR DESCRIPTION
This commit removes Ubuntu 19.10 (eoan) from spread.yaml. Eoan
is EOL since July 17, 2020. It also cleans up some more obsolete
releases in the qemu sections.
