### PR TITLE
github: run CLA checks on self-hosted workers

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -6,12 +6,14 @@ on:
 
 jobs:
   cla-check:
-    runs-on: ubuntu-16.04
+    runs-on: self-hosted
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install python-launchpadlib
+          # sudo apt-get update
+          # sudo apt-get install python-launchpadlib
+          # TODO: make this conditional on self-hosted or not
+          echo "dependencies are baked into unprivileged test containers"
       - name: Checkout code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
I've altered all the self-hosted workers to come pre-baked with
python-launchpadlib. This should allow us to use them to run the
relatively light-weight CLA check away from the rather precious
cloud-hosted workers that can be used for the heavier lifting of running
unit tests.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
