### PR TITLE
preseed: cherry-pick #8704, #8709, #9088 (2.45)

### DIFF
--- a/cmd/snap-preseed/export_test.go
+++ b/cmd/snap-preseed/export_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	Run                     = run
-	SystemSnapFromSeed      = systemSnapFromSeed
-	CheckTargetSnapdVersion = checkTargetSnapdVersion
+	Run                      = run
+	SystemSnapFromSeed       = systemSnapFromSeed
+	ChooseTargetSnapdVersion = chooseTargetSnapdVersion
 )
 
 func MockOsGetuid(f func() int) (restore func()) {
@@ -59,4 +59,8 @@ func MockSeedOpen(f func(rootDir, label string) (seed.Seed, error)) (restore fun
 	return func() {
 		seedOpen = oldSeedOpen
 	}
+}
+
+func SnapdPathAndVersion(targetSnapd *targetSnapdInfo) (string, string) {
+	return targetSnapd.path, targetSnapd.version
 }

--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -99,13 +99,13 @@ func run(parser *flags.Parser, args []string) error {
 		return err
 	}
 
-	cleanup, err := prepareChroot(chrootDir)
+	targetSnapd, cleanup, err := prepareChroot(chrootDir)
 	if err != nil {
 		return err
 	}
 
 	// executing inside the chroot
-	err = runPreseedMode(chrootDir)
+	err = runPreseedMode(chrootDir, targetSnapd)
 	cleanup()
 	return err
 }

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/cmd/snap-preseed"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/squashfs"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
@@ -53,6 +54,8 @@ type startPreseedSuite struct {
 
 func (s *startPreseedSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	restore := squashfs.MockNeedsFuse(false)
+	s.BaseTest.AddCleanup(restore)
 }
 
 func (s *startPreseedSuite) TearDownTest(c *C) {
@@ -198,7 +201,7 @@ func (s *startPreseedSuite) TestRunPreseedHappy(c *C) {
 	c.Assert(mockMountCmd.Calls(), HasLen, 1)
 	// note, tmpDir, targetSnapdRoot are contactenated again cause we're not really chrooting in the test
 	// and mocking dirs.RootDir
-	c.Check(mockMountCmd.Calls()[0], DeepEquals, []string{"mount", "-t", "squashfs", "/a/core.snap", filepath.Join(tmpDir, targetSnapdRoot)})
+	c.Check(mockMountCmd.Calls()[0], DeepEquals, []string{"mount", "-t", "squashfs", "-o", "ro,x-gdu.hide", "/a/core.snap", filepath.Join(tmpDir, targetSnapdRoot)})
 
 	c.Assert(mockTargetSnapd.Calls(), HasLen, 1)
 	c.Check(mockTargetSnapd.Calls()[0], DeepEquals, []string{"snapd"})

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"syscall"
 
 	"github.com/snapcore/snapd/cmd/cmdutil"
@@ -59,12 +60,29 @@ func checkChroot(preseedChroot string) error {
 		return fmt.Errorf("the system at %q appears to be preseeded, pass --reset flag to clean it up", preseedChroot)
 	}
 
-	// sanity checks of the critical mountpoints inside chroot directory
-	for _, p := range []string{"/sys/kernel/security/apparmor", "/proc/self", "/dev/mem"} {
-		path := filepath.Join(preseedChroot, p)
-		if exists := osutil.FileExists(path); !exists {
-			return fmt.Errorf("cannot pre-seed without access to %q", path)
+	// sanity checks of the critical mountpoints inside chroot directory.
+	required := map[string]bool{}
+	// required mountpoints are relative to the preseed chroot
+	for _, p := range []string{"/sys/kernel/security", "/proc", "/dev"} {
+		required[filepath.Join(preseedChroot, p)] = true
+	}
+	entries, err := osutil.LoadMountInfo()
+	if err != nil {
+		return fmt.Errorf("cannot parse mount info: %v", err)
+	}
+	for _, ent := range entries {
+		if _, ok := required[ent.MountDir]; ok {
+			delete(required, ent.MountDir)
 		}
+	}
+	// non empty required indicates missing mountpoint(s), print just one.
+	if len(required) > 0 {
+		sorted := []string{}
+		for path := range required {
+			sorted = append(sorted, path)
+		}
+		sort.Strings(sorted)
+		return fmt.Errorf("cannot preseed without access to %q (not a mountpoint)", sorted[0])
 	}
 
 	return nil

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -150,30 +150,68 @@ var systemSnapFromSeed = func(rootDir string) (string, error) {
 
 const snapdPreseedSupportVer = `2.43.3+`
 
-func checkTargetSnapdVersion(infoPath string) error {
-	ver, err := cmdutil.SnapdVersionFromInfoFile(infoPath)
-	if err != nil {
-		return err
-	}
-
-	res, err := strutil.VersionCompare(ver, snapdPreseedSupportVer)
-	if err != nil {
-		return err
-	}
-	if res < 0 {
-		return fmt.Errorf("snapd %s from the target system does not support preseeding, the minimum required version is %s",
-			ver, snapdPreseedSupportVer)
-	}
-	return nil
+type targetSnapdInfo struct {
+	path    string
+	version string
 }
 
-func prepareChroot(preseedChroot string) (func(), error) {
+// chooseTargetSnapdVersion checks if the version of snapd under chroot env
+// is good enough for preseeding. It checks both the snapd from the deb
+// and from the seeded snap mounted under snapdMountPath and returns the
+// information (path, version) about snapd to execute as part of preseeding
+// (it picks the newer version of the two).
+// The function must be called after syscall.Chroot(..).
+func chooseTargetSnapdVersion() (*targetSnapdInfo, error) {
+	// read snapd version from the mounted core/snapd snap
+	infoPath := filepath.Join(snapdMountPath, dirs.CoreLibExecDir, "info")
+	verFromSnap, err := snapdtool.SnapdVersionFromInfoFile(infoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// read snapd version from the main fs under chroot (snapd from the deb);
+	// assumes running under chroot already.
+	infoPath = filepath.Join(dirs.GlobalRootDir, dirs.CoreLibExecDir, "info")
+	verFromDeb, err := snapdtool.SnapdVersionFromInfoFile(infoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := strutil.VersionCompare(verFromSnap, verFromDeb)
+	if err != nil {
+		return nil, err
+	}
+
+	var whichVer, snapdPath string
+	if res < 0 {
+		// snapd from the deb under chroot is the candidate to run
+		whichVer = verFromDeb
+		snapdPath = filepath.Join(dirs.GlobalRootDir, dirs.CoreLibExecDir, "snapd")
+	} else {
+		// snapd from the mounted core/snapd snap is the candidate to run
+		whichVer = verFromSnap
+		snapdPath = filepath.Join(snapdMountPath, dirs.CoreLibExecDir, "snapd")
+	}
+
+	res, err = strutil.VersionCompare(whichVer, snapdPreseedSupportVer)
+	if err != nil {
+		return nil, err
+	}
+	if res < 0 {
+		return nil, fmt.Errorf("snapd %s from the target system does not support preseeding, the minimum required version is %s",
+			whichVer, snapdPreseedSupportVer)
+	}
+
+	return &targetSnapdInfo{path: snapdPath, version: whichVer}, nil
+}
+
+func prepareChroot(preseedChroot string) (*targetSnapdInfo, func(), error) {
 	if err := syscallChroot(preseedChroot); err != nil {
-		return nil, fmt.Errorf("cannot chroot into %s: %v", preseedChroot, err)
+		return nil, nil, fmt.Errorf("cannot chroot into %s: %v", preseedChroot, err)
 	}
 
 	if err := os.Chdir("/"); err != nil {
-		return nil, fmt.Errorf("cannot chdir to /: %v", err)
+		return nil, nil, fmt.Errorf("cannot chdir to /: %v", err)
 	}
 
 	// GlobalRootDir is now relative to chroot env. We assume all paths
@@ -185,13 +223,13 @@ func prepareChroot(preseedChroot string) (func(), error) {
 
 	coreSnapPath, err := systemSnapFromSeed(rootDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// create mountpoint for core/snapd
 	where := filepath.Join(rootDir, snapdMountPath)
 	if err := os.MkdirAll(where, 0755); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	removeMountpoint := func() {
@@ -204,7 +242,7 @@ func prepareChroot(preseedChroot string) (func(), error) {
 	cmd := exec.Command("mount", "-t", fstype, "-o", strings.Join(fsopts, ","), coreSnapPath, where)
 	if err := cmd.Run(); err != nil {
 		removeMountpoint()
-		return nil, fmt.Errorf("cannot mount %s at %s in preseed mode: %v ", coreSnapPath, where, err)
+		return nil, nil, fmt.Errorf("cannot mount %s at %s in preseed mode: %v ", coreSnapPath, where, err)
 	}
 
 	unmount := func() {
@@ -215,15 +253,14 @@ func prepareChroot(preseedChroot string) (func(), error) {
 		}
 	}
 
-	// read version from the mounted core snap
-	infoPath := filepath.Join(snapdMountPath, dirs.CoreLibExecDir, "info")
-	if err := checkTargetSnapdVersion(infoPath); err != nil {
+	targetSnapd, err := chooseTargetSnapdVersion()
+	if err != nil {
 		unmount()
 		removeMountpoint()
-		return nil, err
+		return nil, nil, err
 	}
 
-	return func() {
+	return targetSnapd, func() {
 		unmount()
 		removeMountpoint()
 	}, nil
@@ -231,18 +268,16 @@ func prepareChroot(preseedChroot string) (func(), error) {
 
 // runPreseedMode runs snapd in a preseed mode. It assumes running in a chroot.
 // The chroot is expected to be set-up and ready to use (critical system directories mounted).
-func runPreseedMode(preseedChroot string) error {
-	// exec snapd relative to new chroot, e.g. /snapd-preseed/usr/lib/snapd/snapd
-	path := filepath.Join(snapdMountPath, dirs.CoreLibExecDir, "snapd")
-
+func runPreseedMode(preseedChroot string, targetSnapd *targetSnapdInfo) error {
 	// run snapd in preseed mode
-	cmd := exec.Command(path)
+	cmd := exec.Command(targetSnapd.path)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "SNAPD_PRESEED=1")
 	cmd.Stderr = Stderr
 	cmd.Stdout = Stdout
 
-	fmt.Fprintf(Stdout, "starting to preseed root: %s\n", preseedChroot)
+	// note, snapdPath is relative to preseedChroot
+	fmt.Fprintf(Stdout, "starting to preseed root: %s\nusing snapd binary: %s (%s)\n", preseedChroot, targetSnapd.path, targetSnapd.version)
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error running snapd in preseed mode: %v\n", err)

--- a/cmd/snap-preseed/preseed_other.go
+++ b/cmd/snap-preseed/preseed_other.go
@@ -30,7 +30,7 @@ func checkChroot(preseedChroot string) error {
 	return preseedNotAvailableError
 }
 
-func prepareChroot(preseedChroot string) (func(), error) {
+func prepareChroot(preseedChroot string) (*targetSnapdInfo, func(), error) {
 	return nil, preseedNotAvailableError
 }
 

--- a/osutil/squashfs/fstype.go
+++ b/osutil/squashfs/fstype.go
@@ -62,11 +62,16 @@ func NeedsFuse() bool {
 	return needsFuseImpl()
 }
 
+// StandardOptions returns base squashfs options.
+func StandardOptions() []string {
+	return []string{"ro", "x-gdu.hide"}
+}
+
 // FsType returns what fstype to use for squashfs mounts and what
 // mount options
-func FsType() (fstype string, options []string, err error) {
+func FsType() (fstype string, options []string) {
 	fstype = "squashfs"
-	options = []string{"ro", "x-gdu.hide"}
+	options = StandardOptions()
 
 	if NeedsFuse() {
 		options = append(options, "allow_other")
@@ -80,5 +85,5 @@ func FsType() (fstype string, options []string, err error) {
 		}
 	}
 
-	return fstype, options, nil
+	return fstype, options
 }

--- a/sanity/squashfs.go
+++ b/sanity/squashfs.go
@@ -108,10 +108,7 @@ func checkSquashfsMount() error {
 	}
 
 	// the fstype can be squashfs or fuse.{snap,squash}fuse
-	fstype, _, err := squashfs.FsType()
-	if err != nil {
-		return err
-	}
+	fstype, _ := squashfs.FsType()
 	options := []string{"-t", fstype}
 	if selinux.ProbedLevel() != selinux.Unsupported {
 		if ctx := selinux.SnapMountContext(); ctx != "" {

--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -55,7 +55,7 @@ func MockOsutilIsMounted(f func(path string) (bool, error)) func() {
 	}
 }
 
-func MockSquashFsType(f func() (string, []string, error)) func() {
+func MockSquashFsType(f func() (string, []string)) func() {
 	old := squashfsFsType
 	squashfsFsType = f
 	return func() {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -718,28 +718,7 @@ func MountUnitPath(baseDir string) string {
 
 var squashfsFsType = squashfs.FsType
 
-func writeMountUnitFile(snapName, revision, what, where, fstype string) (mountUnitName, actualFsType string, options []string, err error) {
-	options = []string{"nodev"}
-	actualFsType = fstype
-	if fstype == "squashfs" {
-		newFsType, newOptions, err := squashfsFsType()
-		if err != nil {
-			return "", "", nil, err
-		}
-		options = append(options, newOptions...)
-		actualFsType = newFsType
-		if selinux.ProbedLevel() != selinux.Unsupported {
-			if mountCtx := selinux.SnapMountContext(); mountCtx != "" {
-				options = append(options, "context="+mountCtx)
-			}
-		}
-	}
-	if osutil.IsDirectory(what) {
-		options = append(options, "bind")
-		actualFsType = "none"
-	}
-
-	c := fmt.Sprintf(`[Unit]
+var mountUnitTemplate = `[Unit]
 Description=Mount unit for %s, revision %s
 Before=snapd.service
 
@@ -752,25 +731,58 @@ LazyUnmount=yes
 
 [Install]
 WantedBy=multi-user.target
-`, snapName, revision, what, where, actualFsType, strings.Join(options, ","))
+`
 
+func writeMountUnitFile(snapName, revision, what, where, fstype string, options []string) (mountUnitName string, err error) {
+	content := fmt.Sprintf(mountUnitTemplate, snapName, revision, what, where, fstype, strings.Join(options, ","))
 	mu := MountUnitPath(where)
-	mountUnitName, err = filepath.Base(mu), osutil.AtomicWriteFile(mu, []byte(c), 0644, 0)
+	mountUnitName, err = filepath.Base(mu), osutil.AtomicWriteFile(mu, []byte(content), 0644, 0)
 	if err != nil {
-		return "", "", nil, err
+		return "", err
 	}
+	return mountUnitName, nil
+}
 
-	return mountUnitName, actualFsType, options, err
+func fsMountOptions(fstype string) []string {
+	options := []string{"nodev"}
+	if fstype == "squashfs" {
+		if selinux.ProbedLevel() != selinux.Unsupported {
+			if mountCtx := selinux.SnapMountContext(); mountCtx != "" {
+				options = append(options, "context="+mountCtx)
+			}
+		}
+	}
+	return options
+}
+
+// actualFsTypeAndMountOptions returns filesystem type and options to actually
+// mount the given fstype at runtime, i.e. it determines if fuse should be used
+// for squashfs.
+func actualFsTypeAndMountOptions(fstype string) (actualFsType string, options []string) {
+	options = fsMountOptions(fstype)
+	actualFsType = fstype
+	if fstype == "squashfs" {
+		newFsType, newOptions := squashfsFsType()
+		options = append(options, newOptions...)
+		actualFsType = newFsType
+	}
+	return actualFsType, options
 }
 
 func (s *systemd) AddMountUnitFile(snapName, revision, what, where, fstype string) (string, error) {
 	daemonReloadLock.Lock()
 	defer daemonReloadLock.Unlock()
 
-	mountUnitName, _, _, err := writeMountUnitFile(snapName, revision, what, where, fstype)
+	actualFsType, options := actualFsTypeAndMountOptions(fstype)
+	if osutil.IsDirectory(what) {
+		options = append(options, "bind")
+		actualFsType = "none"
+	}
+	mountUnitName, err := writeMountUnitFile(snapName, revision, what, where, actualFsType, options)
 	if err != nil {
 		return "", err
 	}
+
 	// we need to do a daemon-reload here to ensure that systemd really
 	// knows about this new mount unit file
 	if err := s.daemonReloadNoLock(); err != nil {

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -635,7 +635,7 @@ Before=snapd.service
 What=%s
 Where=/snap/snapname/123
 Type=squashfs
-Options=nodev,ro,x-gdu.hide,context=system_u:object_r:snappy_snap_t:s0
+Options=nodev,context=system_u:object_r:snappy_snap_t:s0,ro,x-gdu.hide
 LazyUnmount=yes
 
 [Install]
@@ -932,7 +932,7 @@ func (s *SystemdTestSuite) TestPreseedModeAddMountUnit(c *C) {
 func (s *SystemdTestSuite) TestPreseedModeAddMountUnitWithFuse(c *C) {
 	sysd := NewEmulationMode(dirs.GlobalRootDir)
 
-	restore := MockSquashFsType(func() (string, []string, error) { return "fuse.squashfuse", []string{"a,b,c"}, nil })
+	restore := MockSquashFsType(func() (string, []string) { return "fuse.squashfuse", []string{"a,b,c"} })
 	defer restore()
 
 	mockMountCmd := testutil.MockCommand(c, "mount", "")
@@ -946,7 +946,7 @@ func (s *SystemdTestSuite) TestPreseedModeAddMountUnitWithFuse(c *C) {
 	defer os.Remove(mountUnitName)
 
 	c.Check(mockMountCmd.Calls()[0], DeepEquals, []string{"mount", "-t", "fuse.squashfuse", mockSnapPath, "/snap/snapname/123", "-o", "nodev,a,b,c"})
-	c.Check(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(unitTemplate[1:], mockSnapPath, "fuse.squashfuse", "nodev,a,b,c"))
+	c.Check(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(unitTemplate[1:], mockSnapPath, "squashfs", "nodev,ro,x-gdu.hide"))
 }
 
 func (s *SystemdTestSuite) TestPreseedModeMountError(c *C) {

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -37,8 +37,8 @@ execute: |
   #shellcheck source=tests/lib/preseed.sh
   . "$TESTSLIB/preseed.sh"
 
-  echo "Running pre-seeeding"
-  /usr/lib/snapd/snap-preseed "$IMAGE_MOUNTPOINT"
+  echo "Running pre-seeding"
+  /usr/lib/snapd/snap-preseed "$IMAGE_MOUNTPOINT" | MATCH "using snapd binary: /tmp/snapd-preseed/usr/lib/snapd/snapd"
 
   # mark-preseeded task is where snap-preseed stopped, therefore it's in Doing.
   snap debug state "$IMAGE_MOUNTPOINT"/var/lib/snapd/state.json --change=1 | MATCH "Doing .+ mark-preseeded +Mark system pre-seeded"


### PR DESCRIPTION
This cherry-picks more pressed work to 2.45. Notably:
- the fixes to run preseed inside lxd containers (#8704, #8709) but not the tests (#8710) because those had too many conflicts
- the fix to use snapd from the deb if newer (#9088) [had conflicts too]

This should be fine but in general the cherry picking is a bit more messy than I would like. We may need to get back to this because I'm not fully confident that we have enough backported to 2.45 for this to work. Maybe we need to go with 2.46 :/ 