### PR TITLE
releases: release 2.46~pre1 to groovy

### DIFF
--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,9 @@
+snapd (2.46~pre1.gitaf15176) groovy; urgency=medium
+
+  * New git snapshot for the upcoming 2.46 release
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Fri, 07 Aug 2020 09:15:31 +0200
+
 snapd (2.45.3.1) xenial; urgency=medium
 
   * New upstream release, LP: #1875071


### PR DESCRIPTION
Merge changelog so that we get accurate version numbers in the snapd/core edge builds.
