### PR TITLE
tests: run as hightest via tests.session

### DIFF
--- a/tests/main/high-user-handling/task.yaml
+++ b/tests/main/high-user-handling/task.yaml
@@ -1,20 +1,24 @@
 summary: Check that the refresh data copy works.
 
-systems: [-ubuntu-core-*]
+systems:
+    - -ubuntu-14.04-*  # no support for tests.session
+    - -ubuntu-core-*  # no support for useradd
 
 environment:
     # an empty $topsrcdir/tests/go.mod seems to break importing or building go
     # packages referenced by their import paths while under the tests directory,
-    # need to disable go modules supportfor this test
+    # need to disable go modules support for this test
     GO111MODULE: off
 
 prepare: |
+    "$(command -v go)" build -o hightest test.go
     useradd --uid "$(( (1<<32)-2 ))" --shell /bin/sh hightest
+    tests.session -u hightest prepare
 
 restore: |
+    tests.session -u hightest restore
     userdel hightest
     rm -f hightest
 
 execute: |
-    "$(command -v go)" build -o hightest test.go
-    sudo -E -u hightest ./hightest
+    tests.session -u hightest exec "$(pwd)/hightest"


### PR DESCRIPTION
I saw a few failures affecting tests/main/high-user-handling test.
They all show the same symptom: unable to remove user hightest because
of process (PID) still using it. It appears that on some systems using
"sudo" is sufficient to trigger PAM login session and get systemd --user
running. This was observed on openSUSE Tumbleweed and Fedora 32:

    -----
    + userdel hightest
    userdel: user hightest is currently used by process 21636
    -----

The debug section includes the process tree which contained:

    hightest 21636 11.3  0.2  18308 10784 ?        Ss   07:06   0:00 /usr/lib/systemd/systemd --user
    hightest 21640  0.0  0.1  26388  5300 ?        S    07:06   0:00 (sd-pam)

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
