### PR TITLE
tests: fix debug section of appstream-id test

### DIFF
--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -11,9 +11,7 @@ restore: |
     rm -f response
 
 debug: |
-    if [ -e response ]; then
-        grep -n '' response
-    fi
+    test -e response && cat response
 
 execute: |
     echo "Verify that search results contain common-ids"


### PR DESCRIPTION
This test just failed without good debug information:

    ##[error]2020-08-07 09:20:57 Error executing google:debian-9-64:tests/main/appstream-id (aug070859-774504) :
    -----
    + echo 'Verify that search results contain common-ids'
    Verify that search results contain common-ids
    + curl -s --unix-socket /run/snapd.socket --max-time 5 'http://localhost/v2/find?name=test-snapd-appstreamid'
    -----
    .
    2020-08-07 09:20:57 Error debugging google:debian-9-64:tests/main/appstream-id (aug070859-774504) :
    -----
    + '[' -e response ']'
    + grep -n '' response
    -----
    .
    2020-08-07 09:20:57 Discarding google:debian-9-64 (aug070859-774504)...

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
