### PR TITLE
tests: add system information and image information when debug info is displayed

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -491,7 +491,7 @@ debug-each: |
         . "$TESTSLIB/nested.sh"
 
         echo '# System information'
-        lsb_release -a || true
+        cat /etc/os-release || true
 
         echo '# Kernel information'
         uname -a

--- a/spread.yaml
+++ b/spread.yaml
@@ -490,7 +490,15 @@ debug-each: |
         #shellcheck source=tests/lib/nested.sh
         . "$TESTSLIB/nested.sh"
 
-        
+        echo '# System information'
+        lsb_release -a || true
+
+        echo '# Kernel information'
+        uname -a
+
+        echo '# Go information'
+        go version || true
+
         if is_nested_system; then
             echo '# nested VM status'
             systemctl status nested-vm || true


### PR DESCRIPTION
google metadate in not included in this change. The only usefull metadata that can be retrieved with the current permissions is the cpu used in the server hosting the vm, like "Intel Haswell"