### PR TITLE
github: remove Ubuntu 19.10 from actions workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -151,7 +151,6 @@ jobs:
         - ubuntu-16.04-32
         - ubuntu-16.04-64
         - ubuntu-18.04-64
-        - ubuntu-19.10-64
         - ubuntu-20.04-64
         - ubuntu-20.10-64
         - ubuntu-core-16-64


### PR DESCRIPTION
It seems we removed Ubuntu 19.10 from spread.yaml without waiting for a
complete test run.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
