### PR TITLE
mkversion.sh: disallow changelog versions that have git in it, if we also have git version

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -67,17 +67,25 @@ else
     exit 1
 fi
 
-# if we don't have a user provided versions and if the version is not
+# if we don't have a user provided version and if the version is not
 # a release (i.e. the git tag does not match the debian changelog
 # version) then we need to construct the version similar to how we do
 # it in a packaging recipe. We take the debian version from the changelog
 # and append the git revno and commit hash. A simpler approach would be
 # to git tag all pre/rc releases.
 if [ -z "$version_from_user" ] && [ "$version_from_git" != "" ] && [ "$version_from_git" != "$version_from_changelog" ]; then
-    revno=$(git describe --always --abbrev=7|cut -d- -f2)
-    commit=$(git describe --always --abbrev=7|cut -d- -f3)
-    v="${version_from_changelog}+git${revno}.${commit}"
-    o="changelog+git"
+    # if the changelog version has "git" in it and we also have a git version
+    # directly, that is a bad changelog version, so fail, otherwise the below
+    # code will produce a duplicated git info
+    if echo "$version_from_changelog" | grep -q git; then
+        echo "Cannot generate version, there is a version from git and the changelog has a git version"
+        exit 1
+    else
+        revno=$(git describe --always --abbrev=7|cut -d- -f2)
+        commit=$(git describe --always --abbrev=7|cut -d- -f3)
+        v="${version_from_changelog}+git${revno}.${commit}"
+        o="changelog+git"
+    fi
 fi
 
 

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -39,9 +39,7 @@ fi
 
 # Let's try to derive the version from git..
 if command -v git >/dev/null; then
-    # not using "--dirty" here until the following bug is fixed:
-    # https://bugs.launchpad.net/snapcraft/+bug/1662388
-    version_from_git="$(git describe --always | sed -e 's/-/+git/;y/-/./' )"
+    version_from_git="$(git describe --dirty --always | sed -e 's/-/+git/;y/-/./' )"
 fi
 
 # at this point we maybe in _build/src/github etc where we have no


### PR DESCRIPTION
This may happen in accidental uploads or proposals of prerelease versions uploaded to the dev version of Ubuntu for example. If we don't do this, then we get version numbers from mkversion.sh like
```
2.46~pre1.gitaf15176+git2464.g723a86e
```
which is not super helpful or clear. Instead, we would fail here to generate the version.

Also add --dirty now that a snapcraft bug has been fixed.