### PR TITLE
gadget: introduce content update observer

### DIFF
--- a/gadget/update.go
+++ b/gadget/update.go
@@ -54,6 +54,8 @@ type ContentOperation int
 
 const (
 	ContentWrite ContentOperation = iota
+	ContentUpdate
+	ContentRollback
 )
 
 // ContentObserver allows for observing operations on the content of the gadget
@@ -62,12 +64,29 @@ type ContentObserver interface {
 	// TODO:UC20: add Observe() result value indicating that a file should
 	// be preserved
 
-	// Observe is called to observe a pending action, typically a file
-	// write, from source path to the relative path under a given target
-	// root directory. When called during rollback, the source path points
-	// to the backup copy of the original file.
+	// Observe is called to observe an pending or completed action, related
+	// to content being written, updated or being rolled back. In each of
+	// the scenarios, the target path is relative under the root.
+	//
+	// For a file write or update, the source path points to the content
+	// that will be written. When called during rollback, observe call
+	// happens after the original file has been restored (or removed if the
+	// file was added during the update), the source path is empty.
 	Observe(op ContentOperation, sourceStruct *LaidOutStructure,
 		targetRootDir, sourcePath, relativeTargetPath string) (bool, error)
+}
+
+// ContentUpdateObserver allows for observing update (and potentially a
+// rollback) of the gadget structure content.
+type ContentUpdateObserver interface {
+	ContentObserver
+	// BeforeWrite is called when the backups of content that will get
+	// modified during the update are complete and update is ready to be
+	// applied.
+	BeforeWrite() error
+	// Canceled is called when the update has been canceled, or if changes
+	// were written and the update has been reverted.
+	Canceled() error
 }
 
 // Update applies the gadget update given the gadget information and data from
@@ -83,7 +102,7 @@ type ContentObserver interface {
 // Data that would be modified during the update is first backed up inside the
 // rollback directory. Should the apply step fail, the modified data is
 // recovered.
-func Update(old, new GadgetData, rollbackDirPath string, updatePolicy UpdatePolicyFunc) error {
+func Update(old, new GadgetData, rollbackDirPath string, updatePolicy UpdatePolicyFunc, observer ContentUpdateObserver) error {
 	// TODO: support multi-volume gadgets. But for now we simply
 	//       do not do any gadget updates on those. We cannot error
 	//       here because this would break refreshes of gadgets even
@@ -135,7 +154,7 @@ func Update(old, new GadgetData, rollbackDirPath string, updatePolicy UpdatePoli
 		}
 	}
 
-	return applyUpdates(new, updates, rollbackDirPath)
+	return applyUpdates(new, updates, rollbackDirPath, observer)
 }
 
 func resolveVolume(old *Info, new *Info) (oldVol, newVol *Volume, err error) {
@@ -298,20 +317,36 @@ type Updater interface {
 	Rollback() error
 }
 
-func applyUpdates(new GadgetData, updates []updatePair, rollbackDir string) error {
+func applyUpdates(new GadgetData, updates []updatePair, rollbackDir string, observer ContentUpdateObserver) error {
 	updaters := make([]Updater, len(updates))
 
 	for i, one := range updates {
-		up, err := updaterForStructure(one.to, new.RootDir, rollbackDir)
+		up, err := updaterForStructure(one.to, new.RootDir, rollbackDir, observer)
 		if err != nil {
 			return fmt.Errorf("cannot prepare update for volume structure %v: %v", one.to, err)
 		}
 		updaters[i] = up
 	}
 
+	var backupErr error
 	for i, one := range updaters {
 		if err := one.Backup(); err != nil {
-			return fmt.Errorf("cannot backup volume structure %v: %v", updates[i].to, err)
+			backupErr = fmt.Errorf("cannot backup volume structure %v: %v", updates[i].to, err)
+			break
+		}
+	}
+	if backupErr != nil {
+		if observer != nil {
+			if err := observer.Canceled(); err != nil {
+				logger.Noticef("cannot observe canceled prepare update: %v", err)
+			}
+		}
+		return backupErr
+	} else {
+		if observer != nil {
+			if err := observer.BeforeWrite(); err != nil {
+				return fmt.Errorf("cannot observe prepared update: %v", err)
+			}
 		}
 	}
 
@@ -349,24 +384,30 @@ func applyUpdates(new GadgetData, updates []updatePair, rollbackDir string) erro
 		}
 	}
 
+	if observer != nil {
+		if err := observer.Canceled(); err != nil {
+			logger.Noticef("cannot observe canceled update: %v", err)
+		}
+	}
+
 	return updateErr
 }
 
 var updaterForStructure = updaterForStructureImpl
 
-func updaterForStructureImpl(ps *LaidOutStructure, newRootDir, rollbackDir string) (Updater, error) {
+func updaterForStructureImpl(ps *LaidOutStructure, newRootDir, rollbackDir string, observer ContentUpdateObserver) (Updater, error) {
 	var updater Updater
 	var err error
 	if !ps.HasFilesystem() {
 		updater, err = newRawStructureUpdater(newRootDir, ps, rollbackDir, findDeviceForStructureWithFallback)
 	} else {
-		updater, err = newMountedFilesystemUpdater(newRootDir, ps, rollbackDir, findMountPointForStructure)
+		updater, err = newMountedFilesystemUpdater(newRootDir, ps, rollbackDir, findMountPointForStructure, observer)
 	}
 	return updater, err
 }
 
 // MockUpdaterForStructure replace internal call with a mocked one, for use in tests only
-func MockUpdaterForStructure(mock func(ps *LaidOutStructure, rootDir, rollbackDir string) (Updater, error)) (restore func()) {
+func MockUpdaterForStructure(mock func(ps *LaidOutStructure, rootDir, rollbackDir string, observer ContentUpdateObserver) (Updater, error)) (restore func()) {
 	old := updaterForStructure
 	updaterForStructure = mock
 	return func() {

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -342,11 +342,10 @@ func applyUpdates(new GadgetData, updates []updatePair, rollbackDir string, obse
 			}
 		}
 		return backupErr
-	} else {
-		if observer != nil {
-			if err := observer.BeforeWrite(); err != nil {
-				return fmt.Errorf("cannot observe prepared update: %v", err)
-			}
+	}
+	if observer != nil {
+		if err := observer.BeforeWrite(); err != nil {
+			return fmt.Errorf("cannot observe prepared update: %v", err)
 		}
 	}
 

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -703,18 +703,43 @@ func updateDataSet(c *C) (oldData gadget.GadgetData, newData gadget.GadgetData, 
 	return oldData, newData, rollbackDir
 }
 
+type mockUpdateProcessObserver struct {
+	beforeWriteCalled int
+	canceledCalled    int
+	beforeWriteErr    error
+	canceledErr       error
+}
+
+func (m *mockUpdateProcessObserver) Observe(op gadget.ContentOperation, sourceStruct *gadget.LaidOutStructure,
+	targetRootDir, sourcePath, relativeTargetPath string) (bool, error) {
+	return false, errors.New("unexpected call")
+}
+
+func (m *mockUpdateProcessObserver) BeforeWrite() error {
+	m.beforeWriteCalled++
+	return m.beforeWriteErr
+}
+
+func (m *mockUpdateProcessObserver) Canceled() error {
+	m.canceledCalled++
+	return m.canceledErr
+}
+
 func (u *updateTestSuite) TestUpdateApplyHappy(c *C) {
 	oldData, newData, rollbackDir := updateDataSet(c)
 	// update two structs
 	newData.Info.Volumes["foo"].Structure[0].Update.Edition = 1
 	newData.Info.Volumes["foo"].Structure[1].Update.Edition = 1
 
+	muo := &mockUpdateProcessObserver{}
 	updaterForStructureCalls := 0
 	updateCalls := make(map[string]bool)
 	backupCalls := make(map[string]bool)
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		c.Assert(psRootDir, Equals, newData.RootDir)
 		c.Assert(psRollbackDir, Equals, rollbackDir)
+		c.Assert(observer, Equals, muo)
+		// TODO:UC20 verify observer
 
 		switch updaterForStructureCalls {
 		case 0:
@@ -762,7 +787,7 @@ func (u *updateTestSuite) TestUpdateApplyHappy(c *C) {
 	defer restore()
 
 	// go go go
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, muo)
 	c.Assert(err, IsNil)
 	c.Assert(backupCalls, DeepEquals, map[string]bool{
 		"first":  true,
@@ -773,6 +798,8 @@ func (u *updateTestSuite) TestUpdateApplyHappy(c *C) {
 		"second": true,
 	})
 	c.Assert(updaterForStructureCalls, Equals, 2)
+	c.Assert(muo.beforeWriteCalled, Equals, 1)
+	c.Assert(muo.canceledCalled, Equals, 0)
 }
 
 func (u *updateTestSuite) TestUpdateApplyOnlyWhenNeeded(c *C) {
@@ -787,8 +814,9 @@ func (u *updateTestSuite) TestUpdateApplyOnlyWhenNeeded(c *C) {
 	oldData.Info.Volumes["foo"].Structure[2].Update.Edition = 3
 	newData.Info.Volumes["foo"].Structure[2].Update.Edition = 3
 
+	muo := &mockUpdateProcessObserver{}
 	updaterForStructureCalls := 0
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		c.Assert(psRootDir, Equals, newData.RootDir)
 		c.Assert(psRollbackDir, Equals, rollbackDir)
 
@@ -811,8 +839,11 @@ func (u *updateTestSuite) TestUpdateApplyOnlyWhenNeeded(c *C) {
 	defer restore()
 
 	// go go go
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, muo)
 	c.Assert(err, IsNil)
+
+	c.Assert(muo.beforeWriteCalled, Equals, 1)
+	c.Assert(muo.canceledCalled, Equals, 0)
 }
 
 func (u *updateTestSuite) TestUpdateApplyErrorLayout(c *C) {
@@ -855,13 +886,13 @@ func (u *updateTestSuite) TestUpdateApplyErrorLayout(c *C) {
 	// both old and new bare struct data is missing
 
 	// cannot lay out the new volume when bare struct data is missing
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, nil)
 	c.Assert(err, ErrorMatches, `cannot lay out the new volume: cannot lay out structure #0 \("foo"\): content "first.img": .* no such file or directory`)
 
 	makeSizedFile(c, filepath.Join(newRootDir, "first.img"), gadget.SizeMiB, nil)
 
 	// Update does not error out when when the bare struct data of the old volume is missing
-	err = gadget.Update(oldData, newData, rollbackDir, nil)
+	err = gadget.Update(oldData, newData, rollbackDir, nil, nil)
 	c.Assert(err, Equals, gadget.ErrNoUpdate)
 }
 
@@ -908,7 +939,7 @@ func (u *updateTestSuite) TestUpdateApplyErrorIllegalVolumeUpdate(c *C) {
 	makeSizedFile(c, filepath.Join(oldRootDir, "first.img"), gadget.SizeMiB, nil)
 	makeSizedFile(c, filepath.Join(newRootDir, "first.img"), 900*gadget.SizeKiB, nil)
 
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, nil)
 	c.Assert(err, ErrorMatches, `cannot apply update to volume: cannot change the number of structures within volume from 1 to 2`)
 }
 
@@ -959,7 +990,7 @@ func (u *updateTestSuite) TestUpdateApplyErrorIllegalStructureUpdate(c *C) {
 
 	makeSizedFile(c, filepath.Join(oldRootDir, "first.img"), gadget.SizeMiB, nil)
 
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, nil)
 	c.Assert(err, ErrorMatches, `cannot update volume structure #0 \("foo"\): cannot change a bare structure to filesystem one`)
 }
 
@@ -992,13 +1023,13 @@ func (u *updateTestSuite) TestUpdateApplyErrorDifferentVolume(c *C) {
 	newData := gadget.GadgetData{Info: newInfo, RootDir: c.MkDir()}
 	rollbackDir := c.MkDir()
 
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		c.Fatalf("unexpected call")
 		return &mockUpdater{}, nil
 	})
 	defer restore()
 
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, nil)
 	c.Assert(err, ErrorMatches, `cannot find entry for volume "foo" in updated gadget info`)
 }
 
@@ -1036,14 +1067,19 @@ func (u *updateTestSuite) TestUpdateApplyUpdatesAreOptInWithDefaultPolicy(c *C) 
 
 	rollbackDir := c.MkDir()
 
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	muo := &mockUpdateProcessObserver{}
+
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		c.Fatalf("unexpected call")
 		return &mockUpdater{}, nil
 	})
 	defer restore()
 
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, muo)
 	c.Assert(err, Equals, gadget.ErrNoUpdate)
+
+	// nothing was updated
+	c.Assert(muo.beforeWriteCalled, Equals, 0)
 }
 
 func policyDataSet(c *C) (oldData gadget.GadgetData, newData gadget.GadgetData, rollbackDir string) {
@@ -1089,7 +1125,7 @@ func (u *updateTestSuite) TestUpdateApplyUpdatesArePolicyControlled(c *C) {
 	newData.Info.Volumes["foo"].Structure[4].Update.Edition = 5
 
 	toUpdate := map[string]int{}
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		toUpdate[ps.Name]++
 		return &mockUpdater{}, nil
 	})
@@ -1099,7 +1135,7 @@ func (u *updateTestSuite) TestUpdateApplyUpdatesArePolicyControlled(c *C) {
 	err := gadget.Update(oldData, newData, rollbackDir, func(_, to *gadget.LaidOutStructure) bool {
 		policySeen[to.Name]++
 		return false
-	})
+	}, nil)
 	c.Assert(err, Equals, gadget.ErrNoUpdate)
 	c.Assert(policySeen, DeepEquals, map[string]int{
 		"first":        1,
@@ -1115,7 +1151,7 @@ func (u *updateTestSuite) TestUpdateApplyUpdatesArePolicyControlled(c *C) {
 	err = gadget.Update(oldData, newData, rollbackDir, func(_, to *gadget.LaidOutStructure) bool {
 		policySeen[to.Name]++
 		return to.Name == "second"
-	})
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(policySeen, DeepEquals, map[string]int{
 		"first":        1,
@@ -1140,13 +1176,13 @@ func (u *updateTestSuite) TestUpdateApplyUpdatesRemodelPolicy(c *C) {
 	oldData.Info.Volumes["foo"].Structure[4].Update.Edition = 5
 
 	toUpdate := map[string]int{}
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		toUpdate[ps.Name] = toUpdate[ps.Name] + 1
 		return &mockUpdater{}, nil
 	})
 	defer restore()
 
-	err := gadget.Update(oldData, newData, rollbackDir, gadget.RemodelUpdatePolicy)
+	err := gadget.Update(oldData, newData, rollbackDir, gadget.RemodelUpdatePolicy, nil)
 	c.Assert(err, IsNil)
 	c.Assert(toUpdate, DeepEquals, map[string]int{
 		"first":        1,
@@ -1164,8 +1200,9 @@ func (u *updateTestSuite) TestUpdateApplyBackupFails(c *C) {
 	newData.Info.Volumes["foo"].Structure[1].Update.Edition = 1
 	newData.Info.Volumes["foo"].Structure[2].Update.Edition = 3
 
+	muo := &mockUpdateProcessObserver{}
 	updaterForStructureCalls := 0
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		updater := &mockUpdater{
 			updateCb: func() error {
 				c.Fatalf("unexpected update call")
@@ -1188,8 +1225,12 @@ func (u *updateTestSuite) TestUpdateApplyBackupFails(c *C) {
 	defer restore()
 
 	// go go go
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, muo)
 	c.Assert(err, ErrorMatches, `cannot backup volume structure #1 \("second"\): failed`)
+
+	// update was canceled before backup pass completed
+	c.Check(muo.canceledCalled, Equals, 1)
+	c.Check(muo.beforeWriteCalled, Equals, 0)
 }
 
 func (u *updateTestSuite) TestUpdateApplyUpdateFailsThenRollback(c *C) {
@@ -1199,11 +1240,12 @@ func (u *updateTestSuite) TestUpdateApplyUpdateFailsThenRollback(c *C) {
 	newData.Info.Volumes["foo"].Structure[1].Update.Edition = 2
 	newData.Info.Volumes["foo"].Structure[2].Update.Edition = 3
 
+	muo := &mockUpdateProcessObserver{}
 	updateCalls := make(map[string]bool)
 	backupCalls := make(map[string]bool)
 	rollbackCalls := make(map[string]bool)
 	updaterForStructureCalls := 0
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		updater := &mockUpdater{
 			backupCb: func() error {
 				backupCalls[ps.Name] = true
@@ -1232,7 +1274,7 @@ func (u *updateTestSuite) TestUpdateApplyUpdateFailsThenRollback(c *C) {
 	defer restore()
 
 	// go go go
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, muo)
 	c.Assert(err, ErrorMatches, `cannot update volume structure #1 \("second"\): failed`)
 	c.Assert(backupCalls, DeepEquals, map[string]bool{
 		// all were backed up
@@ -1250,6 +1292,10 @@ func (u *updateTestSuite) TestUpdateApplyUpdateFailsThenRollback(c *C) {
 		"second": true,
 		// third does not need as it was not updated
 	})
+	// backup pass completed
+	c.Check(muo.beforeWriteCalled, Equals, 1)
+	// and then the update was canceled
+	c.Check(muo.canceledCalled, Equals, 1)
 }
 
 func (u *updateTestSuite) TestUpdateApplyUpdateErrorRollbackFail(c *C) {
@@ -1266,7 +1312,7 @@ func (u *updateTestSuite) TestUpdateApplyUpdateErrorRollbackFail(c *C) {
 	backupCalls := make(map[string]bool)
 	rollbackCalls := make(map[string]bool)
 	updaterForStructureCalls := 0
-	restore = gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore = gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		updater := &mockUpdater{
 			backupCb: func() error {
 				backupCalls[ps.Name] = true
@@ -1303,7 +1349,7 @@ func (u *updateTestSuite) TestUpdateApplyUpdateErrorRollbackFail(c *C) {
 	defer restore()
 
 	// go go go
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, nil)
 	// preserves update error
 	c.Assert(err, ErrorMatches, `cannot update volume structure #2 \("third"\): update error`)
 	c.Assert(backupCalls, DeepEquals, map[string]bool{
@@ -1334,13 +1380,13 @@ func (u *updateTestSuite) TestUpdateApplyBadUpdater(c *C) {
 	newData.Info.Volumes["foo"].Structure[1].Update.Edition = 2
 	newData.Info.Volumes["foo"].Structure[2].Update.Edition = 3
 
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		return nil, errors.New("bad updater for structure")
 	})
 	defer restore()
 
 	// go go go
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, nil)
 	c.Assert(err, ErrorMatches, `cannot prepare update for volume structure #0 \("first"\): bad updater for structure`)
 }
 
@@ -1374,7 +1420,7 @@ func (u *updateTestSuite) TestUpdaterForStructure(c *C) {
 		},
 		StartOffset: 1 * gadget.SizeMiB,
 	}
-	updater, err := gadget.UpdaterForStructure(psBare, gadgetRootDir, rollbackDir)
+	updater, err := gadget.UpdaterForStructure(psBare, gadgetRootDir, rollbackDir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(updater, FitsTypeOf, &gadget.RawStructureUpdater{})
 
@@ -1386,16 +1432,16 @@ func (u *updateTestSuite) TestUpdaterForStructure(c *C) {
 		},
 		StartOffset: 1 * gadget.SizeMiB,
 	}
-	updater, err = gadget.UpdaterForStructure(psFs, gadgetRootDir, rollbackDir)
+	updater, err = gadget.UpdaterForStructure(psFs, gadgetRootDir, rollbackDir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(updater, FitsTypeOf, &gadget.MountedFilesystemUpdater{})
 
 	// trigger errors
-	updater, err = gadget.UpdaterForStructure(psBare, gadgetRootDir, "")
+	updater, err = gadget.UpdaterForStructure(psBare, gadgetRootDir, "", nil)
 	c.Assert(err, ErrorMatches, "internal error: backup directory cannot be unset")
 	c.Assert(updater, IsNil)
 
-	updater, err = gadget.UpdaterForStructure(psFs, "", rollbackDir)
+	updater, err = gadget.UpdaterForStructure(psFs, "", rollbackDir, nil)
 	c.Assert(err, ErrorMatches, "internal error: gadget content directory cannot be unset")
 	c.Assert(updater, IsNil)
 }
@@ -1421,13 +1467,13 @@ func (u *updateTestSuite) TestUpdaterMultiVolumesDoesNotError(c *C) {
 	}
 
 	// a new multi volume gadget update gives no error
-	err := gadget.Update(singleVolume, multiVolume, "some-rollback-dir", nil)
+	err := gadget.Update(singleVolume, multiVolume, "some-rollback-dir", nil, nil)
 	c.Assert(err, IsNil)
 	// but it warns that nothing happens either
 	c.Assert(logbuf.String(), testutil.Contains, "WARNING: gadget assests cannot be updated yet when multiple volumes are used")
 
 	// same for old
-	err = gadget.Update(multiVolume, singleVolume, "some-rollback-dir", nil)
+	err = gadget.Update(multiVolume, singleVolume, "some-rollback-dir", nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(strings.Count(logbuf.String(), "WARNING: gadget assests cannot be updated yet when multiple volumes are used"), Equals, 2)
 }
@@ -1441,9 +1487,10 @@ func (u *updateTestSuite) TestUpdateApplyNoChangedContentInAll(c *C) {
 	oldData.Info.Volumes["foo"].Structure[1].Update.Edition = 1
 	newData.Info.Volumes["foo"].Structure[1].Update.Edition = 2
 
+	muo := &mockUpdateProcessObserver{}
 	expectedStructs := []string{"first", "second"}
 	updateCalls := 0
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		mu := &mockUpdater{
 			updateCb: func() error {
 				c.Assert(expectedStructs, testutil.Contains, ps.Name)
@@ -1460,10 +1507,13 @@ func (u *updateTestSuite) TestUpdateApplyNoChangedContentInAll(c *C) {
 	defer restore()
 
 	// go go go
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, muo)
 	c.Assert(err, Equals, gadget.ErrNoUpdate)
 	// update called for 2 structures
 	c.Assert(updateCalls, Equals, 2)
+	// nothing was updated, but the backup pass still executed
+	c.Assert(muo.beforeWriteCalled, Equals, 1)
+	c.Assert(muo.canceledCalled, Equals, 0)
 }
 
 func (u *updateTestSuite) TestUpdateApplyNoChangedContentInSome(c *C) {
@@ -1475,9 +1525,10 @@ func (u *updateTestSuite) TestUpdateApplyNoChangedContentInSome(c *C) {
 	oldData.Info.Volumes["foo"].Structure[1].Update.Edition = 1
 	newData.Info.Volumes["foo"].Structure[1].Update.Edition = 2
 
+	muo := &mockUpdateProcessObserver{}
 	expectedStructs := []string{"first", "second"}
 	updateCalls := 0
-	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string) (gadget.Updater, error) {
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		mu := &mockUpdater{
 			updateCb: func() error {
 				c.Assert(expectedStructs, testutil.Contains, ps.Name)
@@ -1497,8 +1548,78 @@ func (u *updateTestSuite) TestUpdateApplyNoChangedContentInSome(c *C) {
 	defer restore()
 
 	// go go go
-	err := gadget.Update(oldData, newData, rollbackDir, nil)
+	err := gadget.Update(oldData, newData, rollbackDir, nil, muo)
 	c.Assert(err, IsNil)
 	// update called for 2 structures
 	c.Assert(updateCalls, Equals, 2)
+	// at least one structure had an update
+	c.Assert(muo.beforeWriteCalled, Equals, 1)
+	c.Assert(muo.canceledCalled, Equals, 0)
+}
+
+func (u *updateTestSuite) TestUpdateApplyObserverBeforeWriteErrs(c *C) {
+	oldData, newData, rollbackDir := updateDataSet(c)
+	newData.Info.Volumes["foo"].Structure[0].Update.Edition = 1
+
+	restore := gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
+		updater := &mockUpdater{
+			updateCb: func() error {
+				c.Fatalf("unexpected call")
+				return fmt.Errorf("unexpected call")
+			},
+		}
+		return updater, nil
+	})
+	defer restore()
+
+	// go go go
+	muo := &mockUpdateProcessObserver{
+		beforeWriteErr: errors.New("before write fail"),
+	}
+	err := gadget.Update(oldData, newData, rollbackDir, nil, muo)
+	c.Assert(err, ErrorMatches, `cannot observe prepared update: before write fail`)
+	// update was canceled before backup pass completed
+	c.Check(muo.canceledCalled, Equals, 0)
+	c.Check(muo.beforeWriteCalled, Equals, 1)
+}
+
+func (u *updateTestSuite) TestUpdateApplyObserverCanceledErrs(c *C) {
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	oldData, newData, rollbackDir := updateDataSet(c)
+	newData.Info.Volumes["foo"].Structure[0].Update.Edition = 1
+
+	backupErr := errors.New("backup fails")
+	updateErr := errors.New("update fails")
+	restore = gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
+		updater := &mockUpdater{
+			backupCb: func() error { return backupErr },
+			updateCb: func() error { return updateErr },
+		}
+		return updater, nil
+	})
+	defer restore()
+
+	// go go go
+	muo := &mockUpdateProcessObserver{
+		canceledErr: errors.New("canceled fail"),
+	}
+	err := gadget.Update(oldData, newData, rollbackDir, nil, muo)
+	c.Assert(err, ErrorMatches, `cannot backup volume structure #0 .*: backup fails`)
+	// canceled called after backup pass
+	c.Check(muo.canceledCalled, Equals, 1)
+	c.Check(muo.beforeWriteCalled, Equals, 0)
+
+	c.Check(logbuf.String(), testutil.Contains, `cannot observe canceled prepare update: canceled fail`)
+
+	// backup works, update fails, triggers another canceled call
+	backupErr = nil
+	err = gadget.Update(oldData, newData, rollbackDir, nil, muo)
+	c.Assert(err, ErrorMatches, `cannot update volume structure #0 .*: update fails`)
+	// canceled called after backup pass
+	c.Check(muo.canceledCalled, Equals, 2)
+	c.Check(muo.beforeWriteCalled, Equals, 1)
+
+	c.Check(logbuf.String(), testutil.Contains, `cannot observe canceled update: canceled fail`)
 }

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1339,7 +1339,7 @@ volumes:
 	defer restore()
 
 	gadgetUpdateCalled := false
-	restore = devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error {
+	restore = devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc, _ gadget.ContentUpdateObserver) error {
 		gadgetUpdateCalled = true
 		c.Check(policy, NotNil)
 		c.Check(reflect.ValueOf(policy).Pointer(), Equals, reflect.ValueOf(gadget.RemodelUpdatePolicy).Pointer())
@@ -1485,7 +1485,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelGadgetAssetsParanoidCheck(c *C) {
 	defer restore()
 
 	gadgetUpdateCalled := false
-	restore = devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error {
+	restore = devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc, _ gadget.ContentUpdateObserver) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -200,7 +200,7 @@ var (
 	CriticalTaskEdges = criticalTaskEdges
 )
 
-func MockGadgetUpdate(mock func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error) (restore func()) {
+func MockGadgetUpdate(mock func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc, observer gadget.ContentUpdateObserver) error) (restore func()) {
 	old := gadgetUpdate
 	gadgetUpdate = mock
 	return func() {

--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -136,8 +136,9 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 		updatePolicy = gadget.RemodelUpdatePolicy
 	}
 
+	// TODO:UC20: pass trusted assets update observer
 	st.Unlock()
-	err = gadgetUpdate(*currentData, *updateData, snapRollbackDir, updatePolicy)
+	err = gadgetUpdate(*currentData, *updateData, snapRollbackDir, updatePolicy, nil)
 	st.Lock()
 	if err != nil {
 		if err == gadget.ErrNoUpdate {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -5188,7 +5188,7 @@ volumes:
 	s.serveSnap(snapPath, "2")
 
 	updaterForStructureCalls := 0
-	restore = gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, rootDir, rollbackDir string) (gadget.Updater, error) {
+	restore = gadget.MockUpdaterForStructure(func(ps *gadget.LaidOutStructure, rootDir, rollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
 		updaterForStructureCalls++
 		c.Assert(ps.Name, Equals, "foo")
 		return &mockUpdater{}, nil


### PR DESCRIPTION
This is a piece of https://github.com/snapcore/snapd/compare/master...bboozzoo:bboozzoo/boot-gadget-update-interface branch that carries a content update observer. The idea behind the observe is to be notified when the trusted boot assets are about to be modified so that we can:
- update modeenv to include the old and the new asset
- reseal for both the new and the old asset when we are about to apply update
