### PR TITLE
tests: fix issues related to restarting systemd-logind.service

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -458,8 +458,8 @@ prepare_project() {
     #   systemctl restart systemd-logind.service
     # But due to this issue, restarting systemd-logind is unsafe.
     # https://github.com/systemd/systemd/issues/16685#issuecomment-671239737
-    echo "logind upgraded, reboot required"
     if [ "$restart_logind" = yes ]; then
+        echo "logind upgraded, reboot required"
         REBOOT
     fi
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -411,35 +411,6 @@ prepare_project() {
         fi
     fi
 
-    # Make /var/lib/systemd writable so that we can get linger enabled.
-    # This only applies to Ubuntu Core 16 where individual directories were
-    # writable. In Core 18 and beyond all of /var/lib/systemd is writable.
-    case "$SPREAD_SYSTEM" in
-        ubuntu-core-16-*)
-            mount tmpfs -t tmpfs /var/lib/systemd/
-            mkdir -p /var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill}
-            mkdir -p /writable/system-data/var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill}
-            touch /var/lib/systemd/random-seed
-            touch /writable/system-data/var/lib/systemd/random-seed
-            # NOTE: The here-doc below must use tabs for proper operation.
-            cat >/etc/systemd/system/var-lib-systemd-rfkill.mount <<-UNIT
-			[Mount]
-			What=/writable/system-data/var/lib/systemd/rfkill
-			Where=/var/lib/systemd/rfkill
-			Options=bind
-			UNIT
-            systemctl enable --now var-lib-systemd-rfkill.mount
-            # NOTE: The here-doc below must use tabs for proper operation.
-            cat >/etc/systemd/system/var-lib-systemd-random\\x2dseed.mount <<-UNIT
-			[Mount]
-			What=/writable/system-data/var/lib/systemd/random-seed
-			Where=/var/lib/systemd/random-seed
-			Options=bind
-			UNIT
-            systemctl enable --now var-lib-systemd-random\\x2dseed.mount
-            ;;
-    esac
-
     # Work around systemd / Debian bug interaction. We are installing
     # libsystemd-dev which upgrades systemd to 246-2 (from 245-*) leaving
     # behind systemd-logind.service from the old version. This is tracked as

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -430,11 +430,12 @@ prepare_project() {
     # session used by spread is tracked.
     if ! loginctl enable-linger test; then
         if systemctl cat systemd-logind.service | not grep -q StateDirectory; then
-            mkdir -p /etc/systemd/system/systemd-logind.service.d
-            (
-            echo "[Service]"
-            echo "StateDirectory=systemd/linger"
-            ) > /etc/systemd/system/systemd-logind.service.d/linger.conf
+            mkdir -p /mnt/system-data/etc/systemd/system/systemd-logind.service.d
+            # NOTE: The here-doc below must use tabs for proper operation.
+            cat >/mnt/system-data/etc/systemd/system/systemd-logind.service.d/linger.conf <<-CONF
+	[Service]
+	StateDirectory=systemd/linger
+	CONF
             mkdir -p /var/lib/systemd/linger
             test "$(command -v restorecon)" != "" && restorecon /var/lib/systemd/linger
             restart_logind=yes

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -417,11 +417,26 @@ prepare_project() {
     case "$SPREAD_SYSTEM" in
         ubuntu-core-16-*)
             mount tmpfs -t tmpfs /var/lib/systemd/
-            mkdir /var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill}
+            mkdir -p /var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill}
+            mkdir -p /writable/system-data/var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill}
             touch /var/lib/systemd/random-seed
-            mount --bind /writable/system-data/var/lib/systemd/rfkill /var/lib/systemd/rfkill
-            mount --bind /writable/system-data/var/lib/systemd/random-seed /var/lib/systemd/random-seed
-            touch /run/tests.session-core16.workaround
+            touch /writable/system-data/var/lib/systemd/random-seed
+            # NOTE: The here-doc below must use tabs for proper operation.
+            cat >/etc/systemd/system/var-lib-systemd-rfkill.mount <<-UNIT
+			[Mount]
+			What=/writable/system-data/var/lib/systemd/rfkill
+			Where=/var/lib/systemd/rfkill
+			Options=bind
+			UNIT
+            systemctl enable --now var-lib-systemd-rfkill.mount
+            # NOTE: The here-doc below must use tabs for proper operation.
+            cat >/etc/systemd/system/var-lib-systemd-random\\x2dseed.mount <<-UNIT
+			[Mount]
+			What=/writable/system-data/var/lib/systemd/random-seed
+			Where=/var/lib/systemd/random-seed
+			Options=bind
+			UNIT
+            systemctl enable --now var-lib-systemd-random\\x2dseed.mount
             ;;
     esac
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -403,10 +403,35 @@ prepare_project() {
     # behind systemd-logind.service from the old version. This is tracked as
     # Debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=919509 and
     # it really affects Desktop systems where Wayland/X don't like logind from
-    # ever being restarted. As a workaround, restart logind ourselves once
-    # here. This change is generic, as it may happen on any distribution that
-    # undergoes a similar transition.
-    systemctl restart systemd-logind.service || true
+    # ever being restarted.
+    #
+    # As a workaround we tried to restart logind ourselves but this caused
+    # another issue.  Restarted logind, as of systemd v245, forgets about the
+    # root session and subsequent loginctl enable-linger root, loginctl
+    # disable-linger stops the running systemd --user for the root session,
+    # along with other services like session bus.
+    #
+    # In consequence all the code that restarts logind for one reason or
+    # another is coalesced below and ends with REBOOT. This ensures that after
+    # rebooting, we have an up-to-date, working logind and that the initial
+    # session used by spread is tracked.
+    if systemctl cat systemd-logind.service | not grep -q StateDirectory; then
+        mkdir -p /etc/systemd/system/systemd-logind.service.d
+        (
+        echo "[Service]"
+        echo "StateDirectory=systemd/linger"
+        ) > /etc/systemd/system/systemd-logind.service.d/linger.conf
+        mkdir -p /var/lib/systemd/linger
+        test "$(command -v restorecon)" != "" && restorecon /var/lib/systemd/linger
+    fi
+
+    # FIXME: In an ideal world we'd just do this:
+    #   systemctl daemon-reload
+    #   systemctl restart systemd-logind.service
+    # But due to this issue, restarting systemd-logind is unsafe.
+    # https://github.com/systemd/systemd/issues/16685#issuecomment-671239737
+    echo "logind upgraded, reboot required"
+    REBOOT
 
     # We take a special case for Debian/Ubuntu where we install additional build deps
     # base on the packaging. In Fedora/Suse this is handled via mock/osc

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -411,6 +411,20 @@ prepare_project() {
         fi
     fi
 
+    # Make /var/lib/systemd writable so that we can get linger enabled.
+    # This only applies to Ubuntu Core 16 where individual directories were
+    # writable. In Core 18 and beyond all of /var/lib/systemd is writable.
+    case "$SPREAD_SYSTEM" in
+        ubuntu-core-16-*)
+            mount tmpfs -t tmpfs /var/lib/systemd/
+            mkdir /var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill}
+            touch /var/lib/systemd/random-seed
+            mount --bind /writable/system-data/var/lib/systemd/rfkill /var/lib/systemd/rfkill
+            mount --bind /writable/system-data/var/lib/systemd/random-seed /var/lib/systemd/random-seed
+            touch /run/tests.session-core16.workaround
+            ;;
+    esac
+
     # Work around systemd / Debian bug interaction. We are installing
     # libsystemd-dev which upgrades systemd to 246-2 (from 245-*) leaving
     # behind systemd-logind.service from the old version. This is tracked as

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -641,6 +641,22 @@ EOF
 
     mkdir -p /mnt/system-data/var/lib/console-conf
 
+    # NOTE: The here-doc below must use tabs for proper operation.
+    cat >/mnt/system-data/etc/systemd/system/var-lib-systemd-linger.mount <<-UNIT
+	[Mount]
+	What=/writable/system-data/var/lib/systemd/linger
+	Where=/var/lib/systemd/linger
+	Options=bind
+	UNIT
+    ln -s /etc/systemd/system/var-lib-systemd-linger.mount /mnt/system-data/etc/systemd/system/multi-user.target.wants/var-lib-systemd-linger.mount
+
+    # NOTE: The here-doc below must use tabs for proper operation.
+    mkdir -p /mnt/system-data/etc/systemd/system/systemd-logind.service.d
+    cat     >/mnt/system-data/etc/systemd/system/systemd-logind.service.d/linger.conf <<-CONF
+	[Service]
+	StateDirectory=systemd/linger
+	CONF
+
     (cd /tmp ; unsquashfs -no-progress -v  /var/lib/snapd/snaps/"$core_name"_*.snap etc/systemd/system)
     cp -avr /tmp/squashfs-root/etc/systemd/system /mnt/system-data/etc/systemd/
 }
@@ -737,6 +753,12 @@ slots:
         interface: iio
         path: /dev/iio:device0
 EOF
+
+        # Make /var/lib/systemd writable so that we can get linger enabled.
+        # This only applies to Ubuntu Core 16 where individual directories were
+        # writable. In Core 18 and beyond all of /var/lib/systemd is writable.
+        mkdir -p $UNPACK_DIR/var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill,linger}
+        touch "$UNPACK_DIR"/var/lib/systemd/random-seed
 
         # build new core snap for the image
         snap pack "$UNPACK_DIR" "$IMAGE_HOME"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -652,7 +652,7 @@ EOF
 
     # NOTE: The here-doc below must use tabs for proper operation.
     mkdir -p /mnt/system-data/etc/systemd/system/systemd-logind.service.d
-    cat     >/mnt/system-data/etc/systemd/system/systemd-logind.service.d/linger.conf <<-CONF
+    cat >/mnt/system-data/etc/systemd/system/systemd-logind.service.d/linger.conf <<-CONF
 	[Service]
 	StateDirectory=systemd/linger
 	CONF

--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -122,33 +122,14 @@ case "$action" in
 		esac
 
 		# Try to enable linger for the selected user(s).
-		needs_linger_workaround=
 		for u in $(echo "$user" | tr ',' ' '); do
 			if ! loginctl enable-linger "$u"; then
-				needs_linger_workaround=true
+				echo "tests.session requires external fix for //github.com/systemd/systemd/issues/12401" >&2
+				exit 1
 			fi
 		done
 
-		# Work around https://github.com/systemd/systemd/issues/12401 fixed in
-		# systemd v243.
-		if [ "$needs_linger_workaround" = "true" ] && systemctl cat systemd-logind.service | not grep -q StateDirectory; then
-			mkdir -p /etc/systemd/system/systemd-logind.service.d
-			(
-				echo "[Service]"
-				echo "StateDirectory=systemd/linger"
-			) > /etc/systemd/system/systemd-logind.service.d/linger.conf
-			mkdir -p /var/lib/systemd/linger
-			test "$(command -v restorecon)" != "" && restorecon /var/lib/systemd/linger
-
-			systemctl daemon-reload
-			systemctl restart systemd-logind.service
-
-			touch /run/tests.session-systemd-issue-12401.workaround
-		fi
-
-		# Enable linger for the selected user(s).
 		for u in $(echo "$user" | tr ',' ' '); do
-			loginctl enable-linger "$u"
 			# We've enabled linger, now let's explicitly start the
 			# default.target. This ensures that test code does not need to pay
 			# extra attention to synchronization.
@@ -166,6 +147,7 @@ case "$action" in
 	restore)
 		# Disable linger for the selected user(s).
 		for u in $(echo "$user" | tr ',' ' '); do
+
 			loginctl disable-linger "$u"
 			# If the user is not root, also stop their user slice and ensure
 			# their XDG_RUNTIME_DIR goes away. Currently doing this for root is
@@ -202,17 +184,6 @@ case "$action" in
 			rm  /run/tests.session-core16.workaround
 			# Undo changes to make /var/lib/systemd/ writable.
 			umount -l /var/lib/systemd
-		fi
-
-		if [ -e /run/tests.session-systemd-issue-12401.workaround ]; then
-			rm  /run/tests.session-systemd-issue-12401.workaround
-
-			# Remove the logind customizations we (may have) done above.
-			rm -rf /etc/systemd/system/systemd-logind.service.d
-
-			# Reload systemd and restart logind.
-			systemctl daemon-reload
-			systemctl restart systemd-logind.service
 		fi
 
 		exit 0

--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -106,21 +106,6 @@ case "$action" in
 		exit 0
 		;;
 	prepare)
-		# Make /var/lib/systemd writable so that we can get linger enabled.
-		# This only applies to Ubuntu Core 16 where individual directories were
-		# writable. In Core 18 and beyond all of /var/lib/systemd is writable.
-		case "$SPREAD_SYSTEM" in
-			ubuntu-core-16-*)
-				mount tmpfs -t tmpfs /var/lib/systemd/
-				mkdir /var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill}
-				touch /var/lib/systemd/random-seed
-				mount --bind /writable/system-data/var/lib/systemd/rfkill /var/lib/systemd/rfkill
-				mount --bind /writable/system-data/var/lib/systemd/random-seed /var/lib/systemd/random-seed
-
-				touch /run/tests.session-core16.workaround
-				;;
-		esac
-
 		# Try to enable linger for the selected user(s).
 		for u in $(echo "$user" | tr ',' ' '); do
 			if ! loginctl enable-linger "$u"; then


### PR DESCRIPTION
Just recently we added logic to restart systemd-logind.service
after upgrading all packages. This has caused persistent failures
where tests that interact with session-level services fail to talk
to the D-Bus socket of the root user.

This was traced to the fact that restarting systemd-logind.service,
at least on version v245 is not safe. The restarted systemd does not
remember the session of the root user anymore. Subsequently executed
test that uses tests.session -u root prepare to enable linger and
tests.session -u root restore to disable linger will have the
catastrophic effect of stopping all session services of the root user,
now that logind thinks root has no sessions left.

As a workaround for this workaround, refrain from restarting logind,
and REBOOT instead. To avoid rebooting in tests.session, move the
workaround for another logind bug earlier to one-time prepare-restore.sh
project-wide prepare.

Refs: https://github.com/systemd/systemd/issues/16685#issuecomment-671239737

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
