### PR TITLE
boot: introduce current_boot_assets and current_recovery_boot_assets to modeenv

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -49,3 +49,5 @@ var (
 	MarshalModeenvEntryTo        = marshalModeenvEntryTo
 	UnmarshalModeenvValueFromCfg = unmarshalModeenvValueFromCfg
 )
+
+type BootAssetsMap = bootAssetsMap

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -268,6 +268,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		BrandID:        model.BrandID(),
 		Model:          model.Model(),
 		Grade:          string(model.Grade()),
+		// TODO:UC20: set current boot assets for run and recovery
 	}
 	if err := modeenv.WriteTo(InstallHostWritableDir); err != nil {
 		return fmt.Errorf("cannot write modeenv: %v", err)

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -39,18 +39,18 @@ type bootAssetsMap map[string][]string
 // Modeenv is a file on UC20 that provides additional information
 // about the current mode (run,recover,install)
 type Modeenv struct {
-	Mode                      string
-	RecoverySystem            string
-	CurrentRecoverySystems    []string
-	Base                      string
-	TryBase                   string
-	BaseStatus                string
-	CurrentKernels            []string
-	Model                     string
-	BrandID                   string
-	Grade                     string
-	CurrentBootAssets         bootAssetsMap
-	CurrentRecoveryBootAssets bootAssetsMap
+	Mode                             string
+	RecoverySystem                   string
+	CurrentRecoverySystems           []string
+	Base                             string
+	TryBase                          string
+	BaseStatus                       string
+	CurrentKernels                   []string
+	Model                            string
+	BrandID                          string
+	Grade                            string
+	CurrentTrustedBootAssets         bootAssetsMap
+	CurrentTrustedRecoveryBootAssets bootAssetsMap
 
 	// read is set to true when a modenv was read successfully
 	read bool
@@ -99,8 +99,8 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 	m.Model = bm.model
 	// expect the caller to validate the grade
 	unmarshalModeenvValueFromCfg(cfg, "grade", &m.Grade)
-	unmarshalModeenvValueFromCfg(cfg, "current_boot_assets", &m.CurrentBootAssets)
-	unmarshalModeenvValueFromCfg(cfg, "current_recovery_boot_assets", &m.CurrentRecoveryBootAssets)
+	unmarshalModeenvValueFromCfg(cfg, "current_trusted_boot_assets", &m.CurrentTrustedBootAssets)
+	unmarshalModeenvValueFromCfg(cfg, "current_trusted_recovery_boot_assets", &m.CurrentTrustedRecoveryBootAssets)
 
 	return &m, nil
 }
@@ -179,8 +179,8 @@ func (m *Modeenv) WriteTo(rootdir string) error {
 		marshalModeenvEntryTo(buf, "model", &modeenvModel{brandID: m.BrandID, model: m.Model})
 	}
 	marshalModeenvEntryTo(buf, "grade", m.Grade)
-	marshalModeenvEntryTo(buf, "current_boot_assets", m.CurrentBootAssets)
-	marshalModeenvEntryTo(buf, "current_recovery_boot_assets", m.CurrentRecoveryBootAssets)
+	marshalModeenvEntryTo(buf, "current_trusted_boot_assets", m.CurrentTrustedBootAssets)
+	marshalModeenvEntryTo(buf, "current_trusted_recovery_boot_assets", m.CurrentTrustedRecoveryBootAssets)
 
 	if err := osutil.AtomicWriteFile(modeenvPath, buf.Bytes(), 0644, 0); err != nil {
 		return err

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -34,19 +34,23 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
+type bootAssetsMap map[string][]string
+
 // Modeenv is a file on UC20 that provides additional information
 // about the current mode (run,recover,install)
 type Modeenv struct {
-	Mode                   string
-	RecoverySystem         string
-	CurrentRecoverySystems []string
-	Base                   string
-	TryBase                string
-	BaseStatus             string
-	CurrentKernels         []string
-	Model                  string
-	BrandID                string
-	Grade                  string
+	Mode                      string
+	RecoverySystem            string
+	CurrentRecoverySystems    []string
+	Base                      string
+	TryBase                   string
+	BaseStatus                string
+	CurrentKernels            []string
+	Model                     string
+	BrandID                   string
+	Grade                     string
+	CurrentBootAssets         bootAssetsMap
+	CurrentRecoveryBootAssets bootAssetsMap
 
 	// read is set to true when a modenv was read successfully
 	read bool
@@ -95,6 +99,8 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 	m.Model = bm.model
 	// expect the caller to validate the grade
 	unmarshalModeenvValueFromCfg(cfg, "grade", &m.Grade)
+	unmarshalModeenvValueFromCfg(cfg, "current_boot_assets", &m.CurrentBootAssets)
+	unmarshalModeenvValueFromCfg(cfg, "current_recovery_boot_assets", &m.CurrentRecoveryBootAssets)
 
 	return &m, nil
 }
@@ -173,6 +179,8 @@ func (m *Modeenv) WriteTo(rootdir string) error {
 		marshalModeenvEntryTo(buf, "model", &modeenvModel{brandID: m.BrandID, model: m.Model})
 	}
 	marshalModeenvEntryTo(buf, "grade", m.Grade)
+	marshalModeenvEntryTo(buf, "current_boot_assets", m.CurrentBootAssets)
+	marshalModeenvEntryTo(buf, "current_recovery_boot_assets", m.CurrentRecoveryBootAssets)
 
 	if err := osutil.AtomicWriteFile(modeenvPath, buf.Bytes(), 0644, 0); err != nil {
 		return err
@@ -216,6 +224,10 @@ func marshalModeenvEntryTo(out io.Writer, key string, what interface{}) error {
 				return fmt.Errorf("cannot marshal value for key %q as JSON: %v", key, err)
 			}
 			asString = string(marshalled)
+			if asString == "null" {
+				//  no need to keep nulls in the modeenv
+				return nil
+			}
 		} else {
 			return fmt.Errorf("internal error: cannot marshal unsupported type %T value %v for key %q", what, what, key)
 		}
@@ -296,5 +308,19 @@ func (m *modeenvModel) UnmarshalModeenvValue(brandSlashModel string) error {
 			m.model = bsmSplit[1]
 		}
 	}
+	return nil
+}
+
+func (b bootAssetsMap) MarshalJSON() ([]byte, error) {
+	asMap := map[string][]string(b)
+	return json.Marshal(asMap)
+}
+
+func (b *bootAssetsMap) UnmarshalJSON(data []byte) error {
+	var asMap map[string][]string
+	if err := json.Unmarshal(data, &asMap); err != nil {
+		return err
+	}
+	*b = bootAssetsMap(asMap)
 	return nil
 }

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -114,7 +114,7 @@ recovery_system=20191126
 base=core20_123.snap
 try_base=core20_124.snap
 base_status=try
-current_boot_assets={"thing1":["hash1","hash2"],"thing2":["hash3"]}
+current_trusted_boot_assets={"thing1":["hash1","hash2"],"thing2":["hash3"]}
 `)
 
 	diskModeenv, err := boot.ReadModeenv(s.tmpdir)
@@ -125,7 +125,7 @@ current_boot_assets={"thing1":["hash1","hash2"],"thing2":["hash3"]}
 		Base:           "core20_123.snap",
 		TryBase:        "core20_124.snap",
 		BaseStatus:     "try",
-		CurrentBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
 			"thing1": {"hash1", "hash2"},
 			"thing2": {"hash3"},
 		},
@@ -210,7 +210,7 @@ func (s *modeenvSuite) TestDeepEquals(c *C) {
 		BrandID: "brand",
 		Grade:   "secured",
 
-		CurrentBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
 			"thing1": {"hash1", "hash2"},
 			"thing2": {"hash3"},
 		},
@@ -230,7 +230,7 @@ func (s *modeenvSuite) TestDeepEquals(c *C) {
 		BrandID: "brand",
 		Grade:   "secured",
 
-		CurrentBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
 			"thing1": {"hash1", "hash2"},
 			"thing2": {"hash3"},
 		},
@@ -559,16 +559,16 @@ func (s *modeenvSuite) TestFancyUnmarshalJSONEmpty(c *C) {
 	c.Check(djsonRev.Foo, IsNil)
 }
 
-func (s *modeenvSuite) TestMarshalCurrentBootAssets(c *C) {
+func (s *modeenvSuite) TestMarshalCurrentTrustedBootAssets(c *C) {
 	c.Assert(s.mockModeenvPath, testutil.FileAbsent)
 
 	modeenv := &boot.Modeenv{
 		Mode:           "run",
 		RecoverySystem: "20191128",
-		CurrentBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
 			"grubx64.efi": []string{"hash1", "hash2"},
 		},
-		CurrentRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
 			"grubx64.efi": []string{"recovery-hash1"},
 			"bootx64.efi": []string{"shimhash1", "shimhash2"},
 		},
@@ -578,16 +578,16 @@ func (s *modeenvSuite) TestMarshalCurrentBootAssets(c *C) {
 
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, `mode=run
 recovery_system=20191128
-current_boot_assets={"grubx64.efi":["hash1","hash2"]}
-current_recovery_boot_assets={"bootx64.efi":["shimhash1","shimhash2"],"grubx64.efi":["recovery-hash1"]}
+current_trusted_boot_assets={"grubx64.efi":["hash1","hash2"]}
+current_trusted_recovery_boot_assets={"bootx64.efi":["shimhash1","shimhash2"],"grubx64.efi":["recovery-hash1"]}
 `)
 
 	modeenvRead, err := boot.ReadModeenv(s.tmpdir)
 	c.Assert(err, IsNil)
-	c.Assert(modeenvRead.CurrentBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Assert(modeenvRead.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
 		"grubx64.efi": []string{"hash1", "hash2"},
 	})
-	c.Assert(modeenvRead.CurrentRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Assert(modeenvRead.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
 		"grubx64.efi": []string{"recovery-hash1"},
 		"bootx64.efi": []string{"shimhash1", "shimhash2"},
 	})


### PR DESCRIPTION
Introduce new entries in modeenv for keeping the list of current boot assets for both the recovery and run systems. 
