### PR TITLE
bootloader: introduce TrustedAssetsBootloader, implement for grub

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -268,6 +268,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		BrandID:        model.BrandID(),
 		Model:          model.Model(),
 		Grade:          string(model.Grade()),
+		// TODO:UC20: set current boot assets for run and recovery
 	}
 	if err := modeenv.WriteTo(InstallHostWritableDir); err != nil {
 		return fmt.Errorf("cannot write modeenv: %v", err)

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -169,10 +169,10 @@ type ManagedAssetsBootloader interface {
 // TrustedAssetsBootloader has boot assets that take part in secure boot
 // process.
 type TrustedAssetsBootloader interface {
-	// TrustedAssetsChain returns the list of relative paths to files inside
+	// TrustedAssets returns the list of relative paths to assets inside
 	// the bootloader's rootdir that are measured in the boot process in the
 	// order of loading during the boot.
-	TrustedAssetsChain() ([]string, error)
+	TrustedAssets() ([]string, error)
 }
 
 func genericInstallBootConfig(gadgetFile, systemFile string) (bool, error) {

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -172,7 +172,7 @@ type TrustedAssetsBootloader interface {
 	// TrustedAssetsChain returns the list of relative paths to files inside
 	// the bootloader's rootdir that are measured in the boot process in the
 	// order of loading during the boot.
-	TrustedAssetsChain() []string
+	TrustedAssetsChain() ([]string, error)
 }
 
 func genericInstallBootConfig(gadgetFile, systemFile string) (bool, error) {

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -166,6 +166,15 @@ type ManagedAssetsBootloader interface {
 	CandidateCommandLine(modeArg, systemArg, extraArgs string) (string, error)
 }
 
+// TrustedAssetsBootloader has boot assets that take part in secure boot
+// process.
+type TrustedAssetsBootloader interface {
+	// TrustedAssetsChain returns the list of relative paths to files inside
+	// the bootloader's rootdir that are measured in the boot process in the
+	// order of loading during the boot.
+	TrustedAssetsChain() []string
+}
+
 func genericInstallBootConfig(gadgetFile, systemFile string) (bool, error) {
 	if !osutil.FileExists(gadgetFile) {
 		return false, nil

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -461,10 +461,10 @@ func staticCommandLineForGrubAssetEdition(asset string, edition uint) string {
 	return string(cmdline)
 }
 
-// TrustedAssetsChain returns the list of relative paths to files inside
+// TrustedAssets returns the list of relative paths to assets inside
 // the bootloader's rootdir that are measured in the boot process in the
 // order of loading during the boot.
-func (g *grub) TrustedAssetsChain() ([]string, error) {
+func (g *grub) TrustedAssets() ([]string, error) {
 	if !g.native {
 		return nil, fmt.Errorf("internal error: trusted assets called without native hierarchy")
 	}

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -464,21 +464,20 @@ func staticCommandLineForGrubAssetEdition(asset string, edition uint) string {
 // TrustedAssetsChain returns the list of relative paths to files inside
 // the bootloader's rootdir that are measured in the boot process in the
 // order of loading during the boot.
-func (g *grub) TrustedAssetsChain() []string {
-	if g.native {
-		if g.recovery {
-			return []string{
-				// recovery mode shim EFI binary
-				"EFI/boot/bootx64.efi",
-				// recovery mode grub EFI binary
-				"EFI/boot/grubx64.efi",
-			}
-		} else {
-			return []string{
-				// run mode grub EFI binary
-				"EFI/boot/grubx64.efi",
-			}
-		}
+func (g *grub) TrustedAssetsChain() ([]string, error) {
+	if !g.native {
+		return nil, fmt.Errorf("internal error: trusted assets called without native hierarchy")
 	}
-	return nil
+	if g.recovery {
+		return []string{
+			// recovery mode shim EFI binary
+			"EFI/boot/bootx64.efi",
+			// recovery mode grub EFI binary
+			"EFI/boot/grubx64.efi",
+		}, nil
+	}
+	return []string{
+		// run mode grub EFI binary
+		"EFI/boot/grubx64.efi",
+	}, nil
 }

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -1026,7 +1026,9 @@ func (s *grubTestSuite) TestTrustedAssetsNative(c *C) {
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	c.Check(tab.TrustedAssetsChain(), DeepEquals, []string{
+	ta, err := tab.TrustedAssetsChain()
+	c.Assert(err, IsNil)
+	c.Check(ta, DeepEquals, []string{
 		"EFI/boot/grubx64.efi",
 	})
 
@@ -1035,7 +1037,9 @@ func (s *grubTestSuite) TestTrustedAssetsNative(c *C) {
 	tarb := bootloader.NewGrub(s.rootdir, recoveryOpts).(bootloader.TrustedAssetsBootloader)
 	c.Assert(tarb, NotNil)
 
-	c.Check(tarb.TrustedAssetsChain(), DeepEquals, []string{
+	ta, err = tarb.TrustedAssetsChain()
+	c.Assert(err, IsNil)
+	c.Check(ta, DeepEquals, []string{
 		"EFI/boot/bootx64.efi",
 		"EFI/boot/grubx64.efi",
 	})
@@ -1048,5 +1052,7 @@ func (s *grubTestSuite) TestTrustedAssetsRoot(c *C) {
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	c.Check(tab.TrustedAssetsChain(), IsNil)
+	ta, err := tab.TrustedAssetsChain()
+	c.Assert(err, ErrorMatches, "internal error: trusted assets called without native hierarchy")
+	c.Check(ta, IsNil)
 }

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -1026,7 +1026,7 @@ func (s *grubTestSuite) TestTrustedAssetsNative(c *C) {
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	ta, err := tab.TrustedAssetsChain()
+	ta, err := tab.TrustedAssets()
 	c.Assert(err, IsNil)
 	c.Check(ta, DeepEquals, []string{
 		"EFI/boot/grubx64.efi",
@@ -1037,7 +1037,7 @@ func (s *grubTestSuite) TestTrustedAssetsNative(c *C) {
 	tarb := bootloader.NewGrub(s.rootdir, recoveryOpts).(bootloader.TrustedAssetsBootloader)
 	c.Assert(tarb, NotNil)
 
-	ta, err = tarb.TrustedAssetsChain()
+	ta, err = tarb.TrustedAssets()
 	c.Assert(err, IsNil)
 	c.Check(ta, DeepEquals, []string{
 		"EFI/boot/bootx64.efi",
@@ -1052,7 +1052,7 @@ func (s *grubTestSuite) TestTrustedAssetsRoot(c *C) {
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	ta, err := tab.TrustedAssetsChain()
+	ta, err := tab.TrustedAssets()
 	c.Assert(err, ErrorMatches, "internal error: trusted assets called without native hierarchy")
 	c.Check(ta, IsNil)
 }


### PR DESCRIPTION
Introduce a new bootloader interface capturing a bootloader with assets that
take part in the secure boot process. As such, the assets will be measured and
the encryption keys must be resealed with a policy that includes those assets in
the load chain.
