### PR TITLE
[RFC] Support for gadget.yaml "$kernel:" style references (1/N)

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -196,6 +196,14 @@ type VolumeContent struct {
 	Size Size `yaml:"size"`
 
 	Unpack bool `yaml:"unpack"`
+
+	// XXX: we could mutate Source instead of having an extra field
+	//      but doing that leads to ugly output
+	//
+	// ResolvedSource is the absolute path of the Source after resolving
+	// any references (e.g. to a "$kernel:" snap)
+	ResolvedSource string
+	// XXX: provide resolvedImage too
 }
 
 func (vc VolumeContent) String() string {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -51,7 +51,7 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 
 // Run bootstraps the partitions of a device, by either creating
 // missing ones or recreating installed ones.
-func Run(gadgetRoot, device string, options Options, observer gadget.ContentObserver) error {
+func Run(gadgetRoot, kernelRoot, device string, options Options, observer gadget.ContentObserver) error {
 	if options.Encrypt && (options.KeyFile == "" || options.RecoveryKeyFile == "") {
 		return fmt.Errorf("key file and recovery key file must be specified when encrypting")
 	}
@@ -63,6 +63,9 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 	lv, err := gadget.PositionedVolumeFromGadget(gadgetRoot)
 	if err != nil {
 		return fmt.Errorf("cannot layout the volume: %v", err)
+	}
+	if err := gadget.ResolveContentPaths(gadgetRoot, kernelRoot, lv); err != nil {
+		return fmt.Errorf("cannot resolve gadget references: %v", err)
 	}
 
 	// XXX: the only situation where auto-detect is not desired is

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -57,7 +57,7 @@ func (s *installSuite) SetUpTest(c *C) {
 }
 
 func (s *installSuite) TestInstallRunError(c *C) {
-	err := install.Run("", "", install.Options{}, nil)
+	err := install.Run("", "", "", install.Options{}, nil)
 	c.Assert(err, ErrorMatches, "cannot use empty gadget root directory")
 }
 

--- a/gadget/kernel.go
+++ b/gadget/kernel.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package gadget
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
+// XXX: should this be in a "gadget/kernel" or "kernel" package?
+
+type KernelAsset struct {
+	Edition editionNumber `yaml:"edition,omitempty"`
+	Content []string      `yaml:"content,omitempty"`
+}
+
+type KernelInfo struct {
+	Assets map[string]*KernelAsset `yaml:"assets,omitempty"`
+}
+
+// KernelInfoFromKernelYaml reads the provided kernel metadata.
+func KernelInfoFromKernelYaml(kernelYaml []byte) (*KernelInfo, error) {
+	var ki KernelInfo
+
+	if err := yaml.Unmarshal(kernelYaml, &ki); err != nil {
+		return nil, fmt.Errorf("cannot parse kernel metadata: %v", err)
+	}
+
+	return &ki, nil
+}
+
+// ReadInfo reads the kernel specific metadata from meta/kernel.yaml
+// in the snap root directory.
+func ReadKernelInfo(kernelSnapRootDir string) (*KernelInfo, error) {
+	p := filepath.Join(kernelSnapRootDir, "meta", "kernel.yaml")
+	content, err := ioutil.ReadFile(p)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read kernel info: %v", err)
+	}
+	return KernelInfoFromKernelYaml(content)
+}

--- a/gadget/kernel_test.go
+++ b/gadget/kernel_test.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package gadget_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/gadget"
+)
+
+type kernelYamlTestSuite struct{}
+
+var _ = Suite(&kernelYamlTestSuite{})
+
+var mockKernelYaml = []byte(`
+assets:
+  dtbs:
+    edition: 1
+    content:
+      - dtbs/bcm2711-rpi-4-b.dtb
+      - dtbs/bcm2836-rpi-2-b.dtb
+`)
+
+func (s *kernelYamlTestSuite) TestInfoFromKernelYamlSad(c *C) {
+	ki, err := gadget.KernelInfoFromKernelYaml([]byte("foo"))
+	c.Check(err, ErrorMatches, "(?m)cannot parse kernel metadata: .*")
+	c.Check(ki, IsNil)
+}
+
+func (s *kernelYamlTestSuite) TestInfoFromKernelYamlHappy(c *C) {
+	ki, err := gadget.KernelInfoFromKernelYaml(mockKernelYaml)
+	c.Check(err, IsNil)
+	c.Check(ki, DeepEquals, &gadget.KernelInfo{
+		Assets: map[string]*gadget.KernelAsset{
+			"dtbs": &gadget.KernelAsset{
+				Edition: 1,
+				Content: []string{
+					"dtbs/bcm2711-rpi-4-b.dtb",
+					"dtbs/bcm2836-rpi-2-b.dtb",
+				},
+			},
+		},
+	})
+}
+
+func (s *kernelYamlTestSuite) TestReadKernelYamlSad(c *C) {
+	ki, err := gadget.ReadKernelInfo("this-path-does-not-exist")
+	c.Check(err, ErrorMatches, `cannot read kernel info: open this-path-does-not-exist/meta/kernel.yaml: no such file or directory`)
+	c.Check(ki, IsNil)
+}
+
+func (s *kernelYamlTestSuite) TestReadKernelYamlHappy(c *C) {
+	mockKernelSnapRoot := c.MkDir()
+	kernelYamlPath := filepath.Join(mockKernelSnapRoot, "meta/kernel.yaml")
+	err := os.MkdirAll(filepath.Dir(kernelYamlPath), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(kernelYamlPath, mockKernelYaml, 0644)
+	c.Assert(err, IsNil)
+
+	ki, err := gadget.ReadKernelInfo(mockKernelSnapRoot)
+	c.Assert(err, IsNil)
+	c.Check(ki, DeepEquals, &gadget.KernelInfo{
+		Assets: map[string]*gadget.KernelAsset{
+			"dtbs": &gadget.KernelAsset{
+				Edition: 1,
+				Content: []string{
+					"dtbs/bcm2711-rpi-4-b.dtb",
+					"dtbs/bcm2836-rpi-2-b.dtb",
+				},
+			},
+		},
+	})
+}

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -1138,4 +1139,61 @@ volumes:
 			},
 		},
 	})
+}
+
+func mockKernel(c *C, kernelYaml string, filesWithContent map[string]string) string {
+	kernelRootDir := c.MkDir()
+	err := os.MkdirAll(filepath.Join(kernelRootDir, "meta"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(kernelRootDir, "meta/kernel.yaml"), []byte(kernelYaml), 0644)
+	c.Assert(err, IsNil)
+
+	for fname, content := range filesWithContent {
+		p := filepath.Join(kernelRootDir, fname)
+		err = os.MkdirAll(filepath.Dir(p), 0755)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(p, []byte(content), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	return kernelRootDir
+}
+
+func (p *layoutTestSuite) TestResolveContentPaths(c *C) {
+	gadgetYaml := `
+volumes:
+  pi:
+    bootloader: u-boot
+    structure:
+      - type: 00000000-0000-0000-0000-dd00deadbeef
+        filesystem: vfat
+        filesystem-label: system-boot
+        size: 128M
+        content:
+          - source: $kernel:pi-dtbs/boot-assets/
+            target: /
+`
+	kernelYaml := `
+assets:
+  pi-dtbs:
+    edition: 1
+    content:
+      - boot-assets/
+`
+	vol := mustParseVolume(c, gadgetYaml, "pi")
+	c.Assert(vol.Structure, HasLen, 1)
+
+	kernelSnapFiles := map[string]string{
+		"boot-assets/foo": "foo-content",
+	}
+	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
+	lv, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	c.Assert(err, IsNil)
+	err = gadget.ResolveContentPaths(p.dir, kernelSnapDir, lv)
+	c.Assert(err, IsNil)
+
+	c.Assert(lv.Volume.Structure, HasLen, 1)
+	c.Assert(lv.Volume.Structure[0].Content, HasLen, 1)
+	c.Check(lv.Volume.Structure[0].Content[0].ResolvedSource, Equals, filepath.Join(kernelSnapDir, "boot-assets/"))
+	c.Check(lv.Volume.Structure[0].Content[0].Target, Equals, "/")
 }

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -43,7 +43,10 @@ type GadgetData struct {
 	// Info is the gadget metadata
 	Info *Info
 	// RootDir is the root directory of gadget snap data
+	// XXX: should be GadgetRootDir
 	RootDir string
+	// RootDir is the root directory of kernel snap data
+	KernelRootDir string
 }
 
 // UpdatePolicyFunc is a callback that evaluates the provided pair of structures

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -177,7 +177,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	var brOpts install.Options
 	var installRunCalled int
 	var sealingObserver gadget.ContentObserver
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, obs gadget.ContentObserver) error {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, kernelRoot, device string, options install.Options, obs gadget.ContentObserver) error {
 		// ensure we can grab the lock here, i.e. that it's not taken
 		s.state.Lock()
 		s.state.Unlock()
@@ -296,7 +296,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) error {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) error {
 		return fmt.Errorf("The horror, The horror")
 	})
 	defer restore()
@@ -412,7 +412,7 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade, gadg
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) error {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) error {
 		return nil
 	})
 	defer restore()

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -248,7 +248,7 @@ func MockSysconfigConfigureRunSystem(f func(opts *sysconfig.Options) error) (res
 	}
 }
 
-func MockInstallRun(f func(gadgetRoot, device string, options install.Options, observer gadget.ContentObserver) error) (restore func()) {
+func MockInstallRun(f func(gadgetRoot, kernelRoot, device string, options install.Options, observer gadget.ContentObserver) error) (restore func()) {
 	old := installRun
 	installRun = f
 	return func() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -139,7 +139,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	func() {
 		st.Unlock()
 		defer st.Lock()
-		err = installRun(gadgetDir, "", bopts, sealingContentObserver)
+		err = installRun(gadgetDir, kernelDir, "", bopts, sealingContentObserver)
 	}()
 	if err != nil {
 		return fmt.Errorf("cannot create partitions: %v", err)


### PR DESCRIPTION
This is a draft/outline of how we can support the spec from https://forum.snapcraft.io/t/415/46 to support references from the gadget.yaml to the kernel.yaml for boot assets.

This is a minimal start to validate the rough direction. The implementation ideas are:

1. Support kernel.yaml [here]
1. Add support to resolve "$kernel:" style references from gadget.yaml to kernel.yaml and store in LaidOutVolume [here]
1. Change mountedfilesystem.go to use Content.ResolvedSource and stop passing "contentDir" in [#9147]
1. Make gadget.ResolveContentPaths() part of LayoutVolume() and private
1. Modify devicestate code to also check gadget update when the kernel changes 
1. Modfy ubuntu-image to install "$kernel:" references by re-using our snapd code.
