### PR TITLE
bootstate20: rm bootState20Modeenv, pass around modeenv directly

### DIFF
--- a/boot/initramfs.go
+++ b/boot/initramfs.go
@@ -38,20 +38,16 @@ func InitramfsRunModeSelectSnapsToMount(
 		switch typ {
 		case snap.TypeBase:
 			bs := &bootState20Base{
-				bootState20Modeenv: bootState20Modeenv{
-					modeenv: modeenv,
-				},
+				modeenv: modeenv,
 			}
 			selectSnapFn = bs.selectAndCommitSnapInitramfsMount
 		case snap.TypeKernel:
 			blOpts := &bootloader.Options{NoSlashBoot: true}
 			blDir := InitramfsUbuntuBootDir
 			bs := &bootState20Kernel{
-				blDir:  blDir,
-				blOpts: blOpts,
-				bootState20Modeenv: bootState20Modeenv{
-					modeenv: modeenv,
-				},
+				blDir:   blDir,
+				blOpts:  blOpts,
+				modeenv: modeenv,
 			}
 			selectSnapFn = bs.selectAndCommitSnapInitramfsMount
 		}


### PR DESCRIPTION
This removes an additional abstraction layer from bootstate20 code, and results
in easier to understand code. 

Note that contrary to my own expectations, this actually is independent from https://github.com/snapcore/snapd/pull/9135 and does not conflict with that somehow.