### PR TITLE
interfaces/many: miscellaneous updates for strict microk8s

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -613,9 +613,9 @@ ptrace (read, trace) peer=unconfined,
 /dev/** mrwkl,
 @{PROC}/** mrwkl,
 
-# When kubernetes drives docker, it creates files in the container at arbitrary
-# locations.
-/** wl,
+# When kubernetes drives docker/containerd, it creates and runs files in the
+# container at arbitrary locations (eg, via pivot_root).
+/** rwlix,
 `
 
 const dockerSupportPrivilegedSecComp = `

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -92,6 +92,10 @@ profile systemd_run (attach_disconnected,mediate_deleted) {
   ptrace (read) peer=unconfined,
   /run/systemd/private rw,
 
+  # kubelet calls 'systemd-run --scope true' triggers this when kubelet is run
+  # in a nested container (eg, under lxd).
+  @{PROC}/1/cmdline r,
+
   # Ubuntu's ptrace patchset before (at least) 20.04 did not correctly evaluate
   # PTRACE_MODE_READ and policy required 'trace' instead of 'read'.
   # (LP: #1890848). This child profile doesn't have 'capability sys_ptrace', so

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -142,7 +142,7 @@ mount options=(rw, rshared) -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
 
 /{,usr/}bin/mount ixr,
 /{,usr/}bin/umount ixr,
-deny /run/mount/utab rw,
+deny /run/mount/utab{,.lock} rw,
 umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
 `
 
@@ -151,7 +151,7 @@ const kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun = `
   capability sys_admin,
   /{,usr/}bin/mount ixr,
   mount fstype="tmpfs" tmpfs -> /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
-  deny /run/mount/utab rw,
+  deny /run/mount/utab{,.lock} rw,
 
   # For mounting volume subPaths
   mount /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -72,7 +72,7 @@ profile systemd_run (attach_disconnected,mediate_deleted) {
   /{,usr/}bin/systemd-run rm,
   owner @{PROC}/@{pid}/stat r,
   owner @{PROC}/@{pid}/environ r,
-  @{PROC}/cmdline r,
+  @{PROC}/cmdline r,  # proc_cmdline()
 
   # setsockopt()
   capability net_admin,

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -63,7 +63,7 @@ capability sys_resource,
 
 capability dac_override,
 
-/usr/bin/systemd-run Cxr -> systemd_run,
+/{,usr/}bin/systemd-run Cxr -> systemd_run,
 /run/systemd/private r,
 profile systemd_run (attach_disconnected,mediate_deleted) {
   # Common rules for kubernetes use of systemd_run

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -92,8 +92,8 @@ profile systemd_run (attach_disconnected,mediate_deleted) {
   ptrace (read) peer=unconfined,
   /run/systemd/private rw,
 
-  # kubelet calls 'systemd-run --scope true' triggers this when kubelet is run
-  # in a nested container (eg, under lxd).
+  # kubelet calling 'systemd-run --scope true' triggers this when kubelet is
+  # run in a nested container (eg, under lxd).
   @{PROC}/1/cmdline r,
 
   # Ubuntu's ptrace patchset before (at least) 20.04 did not correctly evaluate

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -73,11 +73,15 @@ profile systemd_run (attach_disconnected,mediate_deleted) {
   owner @{PROC}/@{pid}/stat r,
   owner @{PROC}/@{pid}/environ r,
   @{PROC}/cmdline r,
-  @{PROC}/sys/kernel/osrelease r,
-  @{PROC}/1/sched r,
 
   # setsockopt()
   capability net_admin,
+
+  # systemd-run's detect_container() looks at several files to determine if it
+  # is running in a container.
+  @{PROC}/sys/kernel/osrelease r,
+  @{PROC}/1/sched r,
+  /run/systemd/container r,
 
   # kubelet calls 'systemd-run --scope true' to determine if systemd is
   # available and usable for calling certain mount commands under transient

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -144,6 +144,11 @@ mount options=(rw, rshared) -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
 /{,usr/}bin/umount ixr,
 deny /run/mount/utab{,.lock} rw,
 umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
+
+# When fsGroup is set, the pod's volume will be recursively chowned with the
+# setgid bit set on directories so new files will be owned by the fsGroup. See
+# kubernetes pkg/volume/volume_linux.go:changeFilePermission()
+capability fsetid,
 `
 
 const kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun = `
@@ -197,6 +202,11 @@ umount2
 
 unshare
 setns - CLONE_NEWNET
+
+# When fsGroup is set, the pod's volume will be recursively chowned with the
+# setgid bit set on directories so new files will be owned by the fsGroup. See
+# kubernetes pkg/volume/volume_linux.go:changeFilePermission()
+fchownat
 `
 
 var kubernetesSupportConnectedPlugUDevKubelet = []string{


### PR DESCRIPTION
* also deny /run/mount/utab.lock in kubelet flavor
* allow fchownat and capability fsetid in kubelet flavor to support fsGroup
* also use /bin/systemd-run for child exec transition
* update ptrace comment and allow systemd-run ptrace (trace) on unconfined
* docker-support: also allow rix on files with privileged-containers
* also allow systemd-run to ptrace read the kubelet parent

See individual commits for more detail.