### PR TITLE
vendor: update github.com/kr/pretty to fix diffs of values with pointer cycles

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -67,10 +67,10 @@
 			"revisionTime": "2017-10-26T09:04:26Z"
 		},
 		{
-			"checksumSHA1": "3ohk4dFYrERZ6WTdKkIwnTA0HSI=",
+			"checksumSHA1": "uSYSOqWHns5IziQOPrgKq+ianZ8=",
 			"path": "github.com/kr/pretty",
-			"revision": "73f6ac0b30a98e433b289500d779f50c1a6f0712",
-			"revisionTime": "2018-05-06T08:33:45Z"
+			"revision": "814ac30b4b181fedaa28ed1b6763ee87f0096826",
+			"revisionTime": "2020-08-10T07:44:40Z"
 		},
 		{
 			"checksumSHA1": "SbguDK5lY8uhaHNrmJmNbiWIGM0=",


### PR DESCRIPTION
This PR updates the vendored version of `github.com/kr/pretty`, which recently merged my fix for the infinite recursion bug when diffing values that contain pointer cycles.  This can prevent tests using gocheck's `Equals` or `DeepEquals` from hanging on failure.

In particular, this can affect tests checking `snap.Info`, which often includes cycles with `snap.AppInfo` and other types.