### PR TITLE
tests: cope with ghost cgroupv2

### DIFF
--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -70,18 +70,18 @@ execute: |
     # - hybrid cgroup system, like Ubuntu 18.04
     # - pure cgroup v1 system, like Ubuntu 16.04
     echo "Find the path and id of the cgroup snapd uses for tracking."
-    if grep -q -F "0::" < /proc/self/cgroup; then
-        # Hybrid or pure v2 mode available.
-        if [ "$(stat -f --print=%T /sys/fs/cgroup)" = "cgroup2fs" ]; then
-            base_cg_path=/sys/fs/cgroup
-        else
-            base_cg_path=/sys/fs/cgroup/unified
-        fi
+    if [ "$(stat -f --print=%T /sys/fs/cgroup)" = "cgroup2fs" ]; then
+        base_cg_path=/sys/fs/cgroup
         base_cg_id=0
-    else
-        # Only name=systemd available
+    elif [ "$(stat -f --print=%T /sys/fs/cgroup/unified)" = "cgroup2fs" ]; then
+        base_cg_path=/sys/fs/cgroup/unified
+        base_cg_id=0
+    elif [ "$(stat -f --print=%T /sys/fs/cgroup/systemd)" = "cgroupfs" ]; then
         base_cg_path=/sys/fs/cgroup/systemd
         base_cg_id="$(grep -F 'name=systemd' < /proc/self/cgroup | cut -d : -f 1)"
+    else
+        echo "cannot find any tracking cgroup"
+        exit 1
     fi
 
     echo "Sanity check, base directory of selected cgroup exists."


### PR DESCRIPTION
Mounting cgroup2, even for a moment, is sticky. Consider this shell
program, running on 4.15 kernel and Ubuntu 16.04 user-space, which does
not mount this hierarchy by default:

    cat /proc/self/cgroup | grep -F '0::' # no matches
    mkdir /tmp/cg2
    mount -t cgroup2 cgroup2 /tmp/cg2
    umount /tmp/cg2
    rmdir /tmp/cg2
    cat /proc/self/cgroup | grep -F '0::' # does match

After mounting cgroup2 all processes gain additional entry for it, as
seen in /proc/PID/cgroup. Even after unmounting the file-system the
entry persists. This is expected behavior, all controllers remain in use
until the system is rebooted. User-space is expected to cross-verify if
the controller is mounted before using it.

This can happen when systemd mounts a cgroupv2 inside a container, such
as the act of booting Ubuntu 18.04 on a Ubuntu 16.04 host. This is a
now-known kernel bug, as normally the unprivileged container should not
be able to do this. This was reported via the LXD maintainers but the
bug is unlikely to be fixed as the behavior exists since 2016 and is not
a security issue since the no controllers are bound to the hierarchy by
default.

When looking for the location of the tracking cgroup, take this into
account and only honor mounted cgroups.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
