### PR TITLE
snap: fix repeated "cannot list recovery system" and add test

### DIFF
--- a/cmd/snap/cmd_recovery.go
+++ b/cmd/snap/cmd_recovery.go
@@ -60,7 +60,7 @@ func (x *cmdRecovery) Execute(args []string) error {
 
 	systems, err := x.client.ListSystems()
 	if err != nil {
-		return fmt.Errorf("cannot list recovery systems: %v", err)
+		return err
 	}
 	if len(systems) == 0 {
 		fmt.Fprintf(Stderr, i18n.G("No recovery systems available.\n"))


### PR DESCRIPTION
The `snap recovery` command can produce errors like:
```
error: cannot list recovery systems: cannot list recovery systems: access denied
```
right now. This commit fixes the nesting and adds a test.
