### PR TITLE
packaging/arch: use external linker when building statically

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -78,7 +78,7 @@ build() {
   # is not exactly the same as -ldflags "-extldflags '-foo'" use the array trick
   # to pass exactly what we want
   flags=(-buildmode=pie -ldflags "-s -extldflags '$LDFLAGS'")
-  staticflags=(-buildmode=pie -ldflags "-s -extldflags '$LDFLAGS -static'")
+  staticflags=(-buildmode=pie -ldflags "-s -linkmode external -extldflags '$LDFLAGS -static'")
   # Build/install snap and snapd
   go build "${flags[@]}" -o "$srcdir/go/bin/snap" $GOFLAGS_SNAP "${_gourl}/cmd/snap"
   go build "${flags[@]}" -o "$srcdir/go/bin/snapd" $GOFLAGS "${_gourl}/cmd/snapd"


### PR DESCRIPTION
The Go version in Arch got updated to 1.15 and we hit the same problem as on
Fedora Rawhide. For some reason a PIE build on linux/amd64 no longer implies
external linking, thus -extldflags are never used, because gcc does not appear
to be invoked.

