### PR TITLE
[RFC] Support for gadget.yaml "$kernel:" style references (2/N)

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -61,6 +61,8 @@ var (
 
 	ParseSize           = parseSize
 	ParseRelativeOffset = parseRelativeOffset
+
+	ResolveContentPathsForStructure = resolveContentPathsForStructure
 )
 
 func MockEvalSymlinks(mock func(path string) (string, error)) (restore func()) {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -196,6 +196,14 @@ type VolumeContent struct {
 	Size Size `yaml:"size"`
 
 	Unpack bool `yaml:"unpack"`
+
+	// XXX: we could mutate Source instead of having an extra field
+	//      but doing that leads to ugly output
+	//
+	// ResolvedSource is the absolute path of the Source after resolving
+	// any references (e.g. to a "$kernel:" snap)
+	ResolvedSource string
+	// XXX: provide resolvedImage too
 }
 
 func (vc VolumeContent) String() string {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -210,6 +210,7 @@ func (vc VolumeContent) String() string {
 	if vc.Image != "" {
 		return fmt.Sprintf("image:%s", vc.Image)
 	}
+	// XXX: provide "ResolvedSource" here too?
 	return fmt.Sprintf("source:%s", vc.Source)
 }
 

--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -231,12 +231,11 @@ func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 
 		// copy existing mock
 		m := mockOnDiskStructureSystemSeed
-		m.LaidOutContent = []gadget.LaidOutContent{
-			{
-				VolumeContent: &gadget.VolumeContent{
-					Source: "grubx64.efi",
-					Target: "EFI/boot/grubx64.efi",
-				},
+		m.LaidOutStructure.VolumeStructure.Content = []gadget.VolumeContent{
+			gadget.VolumeContent{
+				Source:         "grubx64.efi",
+				ResolvedSource: filepath.Join(s.gadgetRoot, "grubx64.efi"),
+				Target:         "EFI/boot/grubx64.efi",
 			},
 		}
 		obs := &mockWriteObserver{

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -51,7 +51,7 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 
 // Run bootstraps the partitions of a device, by either creating
 // missing ones or recreating installed ones.
-func Run(gadgetRoot, device string, options Options, observer gadget.ContentObserver) error {
+func Run(gadgetRoot, kernelRoot, device string, options Options, observer gadget.ContentObserver) error {
 	if options.Encrypt && (options.KeyFile == "" || options.RecoveryKeyFile == "") {
 		return fmt.Errorf("key file and recovery key file must be specified when encrypting")
 	}
@@ -63,6 +63,9 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 	lv, err := gadget.PositionedVolumeFromGadget(gadgetRoot)
 	if err != nil {
 		return fmt.Errorf("cannot layout the volume: %v", err)
+	}
+	if err := gadget.ResolveContentPaths(gadgetRoot, kernelRoot, lv); err != nil {
+		return fmt.Errorf("cannot resolve gadget references: %v", err)
 	}
 
 	// XXX: the only situation where auto-detect is not desired is

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -57,7 +57,7 @@ func (s *installSuite) SetUpTest(c *C) {
 }
 
 func (s *installSuite) TestInstallRunError(c *C) {
-	err := install.Run("", "", install.Options{}, nil)
+	err := install.Run("", "", "", install.Options{}, nil)
 	c.Assert(err, ErrorMatches, "cannot use empty gadget root directory")
 }
 

--- a/gadget/kernel.go
+++ b/gadget/kernel.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package gadget
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
+// XXX: should this be in a "gadget/kernel" or "kernel" package?
+
+type KernelAsset struct {
+	Edition editionNumber `yaml:"edition,omitempty"`
+	Content []string      `yaml:"content,omitempty"`
+}
+
+type KernelInfo struct {
+	Assets map[string]*KernelAsset `yaml:"assets,omitempty"`
+}
+
+// KernelInfoFromKernelYaml reads the provided kernel metadata.
+func KernelInfoFromKernelYaml(kernelYaml []byte) (*KernelInfo, error) {
+	var ki KernelInfo
+
+	if err := yaml.Unmarshal(kernelYaml, &ki); err != nil {
+		return nil, fmt.Errorf("cannot parse kernel metadata: %v", err)
+	}
+
+	return &ki, nil
+}
+
+// ReadInfo reads the kernel specific metadata from meta/kernel.yaml
+// in the snap root directory.
+func ReadKernelInfo(kernelSnapRootDir string) (*KernelInfo, error) {
+	p := filepath.Join(kernelSnapRootDir, "meta", "kernel.yaml")
+	content, err := ioutil.ReadFile(p)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read kernel info: %v", err)
+	}
+	return KernelInfoFromKernelYaml(content)
+}

--- a/gadget/kernel_test.go
+++ b/gadget/kernel_test.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package gadget_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/gadget"
+)
+
+type kernelYamlTestSuite struct{}
+
+var _ = Suite(&kernelYamlTestSuite{})
+
+var mockKernelYaml = []byte(`
+assets:
+  dtbs:
+    edition: 1
+    content:
+      - dtbs/bcm2711-rpi-4-b.dtb
+      - dtbs/bcm2836-rpi-2-b.dtb
+`)
+
+func (s *kernelYamlTestSuite) TestInfoFromKernelYamlSad(c *C) {
+	ki, err := gadget.KernelInfoFromKernelYaml([]byte("foo"))
+	c.Check(err, ErrorMatches, "(?m)cannot parse kernel metadata: .*")
+	c.Check(ki, IsNil)
+}
+
+func (s *kernelYamlTestSuite) TestInfoFromKernelYamlHappy(c *C) {
+	ki, err := gadget.KernelInfoFromKernelYaml(mockKernelYaml)
+	c.Check(err, IsNil)
+	c.Check(ki, DeepEquals, &gadget.KernelInfo{
+		Assets: map[string]*gadget.KernelAsset{
+			"dtbs": &gadget.KernelAsset{
+				Edition: 1,
+				Content: []string{
+					"dtbs/bcm2711-rpi-4-b.dtb",
+					"dtbs/bcm2836-rpi-2-b.dtb",
+				},
+			},
+		},
+	})
+}
+
+func (s *kernelYamlTestSuite) TestReadKernelYamlSad(c *C) {
+	ki, err := gadget.ReadKernelInfo("this-path-does-not-exist")
+	c.Check(err, ErrorMatches, `cannot read kernel info: open this-path-does-not-exist/meta/kernel.yaml: no such file or directory`)
+	c.Check(ki, IsNil)
+}
+
+func (s *kernelYamlTestSuite) TestReadKernelYamlHappy(c *C) {
+	mockKernelSnapRoot := c.MkDir()
+	kernelYamlPath := filepath.Join(mockKernelSnapRoot, "meta/kernel.yaml")
+	err := os.MkdirAll(filepath.Dir(kernelYamlPath), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(kernelYamlPath, mockKernelYaml, 0644)
+	c.Assert(err, IsNil)
+
+	ki, err := gadget.ReadKernelInfo(mockKernelSnapRoot)
+	c.Assert(err, IsNil)
+	c.Check(ki, DeepEquals, &gadget.KernelInfo{
+		Assets: map[string]*gadget.KernelAsset{
+			"dtbs": &gadget.KernelAsset{
+				Edition: 1,
+				Content: []string{
+					"dtbs/bcm2711-rpi-4-b.dtb",
+					"dtbs/bcm2836-rpi-2-b.dtb",
+				},
+			},
+		},
+	})
+}

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -1194,6 +1194,6 @@ assets:
 
 	c.Assert(lv.Volume.Structure, HasLen, 1)
 	c.Assert(lv.Volume.Structure[0].Content, HasLen, 1)
-	c.Check(lv.Volume.Structure[0].Content[0].ResolvedSource, Equals, filepath.Join(kernelSnapDir, "boot-assets/"))
+	c.Check(lv.Volume.Structure[0].Content[0].ResolvedSource, Equals, filepath.Join(kernelSnapDir, "boot-assets/")+"/")
 	c.Check(lv.Volume.Structure[0].Content[0].Target, Equals, "/")
 }

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -1138,4 +1139,61 @@ volumes:
 			},
 		},
 	})
+}
+
+func mockKernel(c *C, kernelYaml string, filesWithContent map[string]string) string {
+	kernelRootDir := c.MkDir()
+	err := os.MkdirAll(filepath.Join(kernelRootDir, "meta"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(kernelRootDir, "meta/kernel.yaml"), []byte(kernelYaml), 0644)
+	c.Assert(err, IsNil)
+
+	for fname, content := range filesWithContent {
+		p := filepath.Join(kernelRootDir, fname)
+		err = os.MkdirAll(filepath.Dir(p), 0755)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(p, []byte(content), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	return kernelRootDir
+}
+
+func (p *layoutTestSuite) TestResolveContentPaths(c *C) {
+	gadgetYaml := `
+volumes:
+  pi:
+    bootloader: u-boot
+    structure:
+      - type: 00000000-0000-0000-0000-dd00deadbeef
+        filesystem: vfat
+        filesystem-label: system-boot
+        size: 128M
+        content:
+          - source: $kernel:pi-dtbs/boot-assets/
+            target: /
+`
+	kernelYaml := `
+assets:
+  pi-dtbs:
+    edition: 1
+    content:
+      - boot-assets/
+`
+	vol := mustParseVolume(c, gadgetYaml, "pi")
+	c.Assert(vol.Structure, HasLen, 1)
+
+	kernelSnapFiles := map[string]string{
+		"boot-assets/foo": "foo-content",
+	}
+	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
+	lv, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	c.Assert(err, IsNil)
+	err = gadget.ResolveContentPaths(p.dir, kernelSnapDir, lv)
+	c.Assert(err, IsNil)
+
+	c.Assert(lv.Volume.Structure, HasLen, 1)
+	c.Assert(lv.Volume.Structure[0].Content, HasLen, 1)
+	c.Check(lv.Volume.Structure[0].Content[0].ResolvedSource, Equals, filepath.Join(kernelSnapDir, "boot-assets/"))
+	c.Check(lv.Volume.Structure[0].Content[0].Target, Equals, "/")
 }

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -54,6 +54,9 @@ func checkContent(content *VolumeContent) error {
 	if content.Target == "" {
 		return fmt.Errorf("internal error: target cannot be unset")
 	}
+	if content.ResolvedSource == "" {
+		return fmt.Errorf("internal error: cannot used unresolved content source")
+	}
 	return nil
 }
 
@@ -62,9 +65,8 @@ func checkContent(content *VolumeContent) error {
 // MountedFilesystemWriter assists in writing contents of a structure to a
 // mounted filesystem.
 type MountedFilesystemWriter struct {
-	contentDir string
-	ps         *LaidOutStructure
-	observer   ContentObserver
+	ps       *LaidOutStructure
+	observer ContentObserver
 }
 
 // NewMountedFilesystemWriter returns a writer capable of writing provided
@@ -80,9 +82,8 @@ func NewMountedFilesystemWriter(contentDir string, ps *LaidOutStructure, observe
 		return nil, fmt.Errorf("internal error: gadget content directory cannot be unset")
 	}
 	fw := &MountedFilesystemWriter{
-		contentDir: contentDir,
-		ps:         ps,
-		observer:   observer,
+		ps:       ps,
+		observer: observer,
 	}
 	return fw, nil
 }
@@ -232,7 +233,8 @@ func (m *MountedFilesystemWriter) writeVolumeContent(volumeRoot string, content 
 	if err := checkContent(content); err != nil {
 		return err
 	}
-	realSource := filepath.Join(m.contentDir, content.Source)
+
+	realSource := content.ResolvedSource
 	realTarget := filepath.Join(volumeRoot, content.Target)
 
 	// filepath trims the trailing /, restore if needed
@@ -370,11 +372,11 @@ func maybePreserveManagedBootAssets(mountPoint string, ps *LaidOutStructure) ([]
 // entryDestPaths resolves destination and backup paths for given
 // source/target combination. Backup location is within provided
 // backup directory or empty if directory was not provided.
-func (f *mountedFilesystemUpdater) entryDestPaths(dstRoot, source, target, backupDir string) (dstPath, backupPath string) {
+func (f *mountedFilesystemUpdater) entryDestPaths(dstRoot, resolvedSource, target, backupDir string) (dstPath, backupPath string) {
 	dstBasePath := target
 	if strings.HasSuffix(target, "/") {
 		// write to a directory
-		dstBasePath = filepath.Join(dstBasePath, filepath.Base(source))
+		dstBasePath = filepath.Join(dstBasePath, filepath.Base(resolvedSource))
 	}
 	dstPath = filepath.Join(dstRoot, dstBasePath)
 
@@ -383,18 +385,6 @@ func (f *mountedFilesystemUpdater) entryDestPaths(dstRoot, source, target, backu
 	}
 
 	return dstPath, backupPath
-}
-
-// entrySourcePath returns the path of given source entry within the root
-// directory provided during initialization.
-func (f *mountedFilesystemUpdater) entrySourcePath(source string) string {
-	srcPath := filepath.Join(f.contentDir, source)
-
-	if strings.HasSuffix(source, "/") {
-		// restore trailing / if one was there
-		srcPath += "/"
-	}
-	return srcPath
 }
 
 // Update applies an update to a mounted filesystem. The caller must have
@@ -426,19 +416,17 @@ func (f *mountedFilesystemUpdater) Update() error {
 	return nil
 }
 
-func (f *mountedFilesystemUpdater) sourceDirectoryEntries(source string) ([]os.FileInfo, error) {
-	srcPath := f.entrySourcePath(source)
-
-	if err := checkSourceIsDir(srcPath); err != nil {
+func (f *mountedFilesystemUpdater) sourceDirectoryEntries(resolvedSource string) ([]os.FileInfo, error) {
+	if err := checkSourceIsDir(resolvedSource); err != nil {
 		return nil, err
 	}
 
 	// TODO: enable support for symlinks when needed
-	if osutil.IsSymlink(srcPath) {
+	if osutil.IsSymlink(resolvedSource) {
 		return nil, fmt.Errorf("source is a symbolic link")
 	}
 
-	return ioutil.ReadDir(srcPath)
+	return ioutil.ReadDir(resolvedSource)
 }
 
 // targetInSourceDir resolves the actual target for given source directory name
@@ -454,13 +442,13 @@ func targetForSourceDir(source, target string) string {
 	return filepath.Join(target, filepath.Base(source))
 }
 
-func (f *mountedFilesystemUpdater) updateDirectory(dstRoot, source, target string, preserveInDst []string, backupDir string) error {
-	fis, err := f.sourceDirectoryEntries(source)
+func (f *mountedFilesystemUpdater) updateDirectory(dstRoot, source, resolvedSource, target string, preserveInDst []string, backupDir string) error {
+	fis, err := f.sourceDirectoryEntries(resolvedSource)
 	if err != nil {
 		return fmt.Errorf("cannot list source directory %q: %v", source, err)
 	}
 
-	target = targetForSourceDir(source, target)
+	target = targetForSourceDir(resolvedSource, target)
 
 	// create current target directory if needed
 	if err := os.MkdirAll(filepath.Join(dstRoot, target), 0755); err != nil {
@@ -470,6 +458,7 @@ func (f *mountedFilesystemUpdater) updateDirectory(dstRoot, source, target strin
 	skipped := 0
 	for _, fi := range fis {
 		pSrc := filepath.Join(source, fi.Name())
+		pResolvedSrc := filepath.Join(resolvedSource, fi.Name())
 		pDst := filepath.Join(target, fi.Name())
 
 		update := f.updateOrSkipFile
@@ -477,10 +466,11 @@ func (f *mountedFilesystemUpdater) updateDirectory(dstRoot, source, target strin
 			// continue updating contents of the directory rather
 			// than the directory itself
 			pSrc += "/"
+			pResolvedSrc += "/"
 			pDst += "/"
 			update = f.updateDirectory
 		}
-		if err := update(dstRoot, pSrc, pDst, preserveInDst, backupDir); err != nil {
+		if err := update(dstRoot, pSrc, pResolvedSrc, pDst, preserveInDst, backupDir); err != nil {
 			if err == ErrNoUpdate {
 				skipped++
 				continue
@@ -496,12 +486,11 @@ func (f *mountedFilesystemUpdater) updateDirectory(dstRoot, source, target strin
 	return nil
 }
 
-func (f *mountedFilesystemUpdater) updateOrSkipFile(dstRoot, source, target string, preserveInDst []string, backupDir string) error {
-	srcPath := f.entrySourcePath(source)
-	dstPath, backupPath := f.entryDestPaths(dstRoot, source, target, backupDir)
+func (f *mountedFilesystemUpdater) updateOrSkipFile(dstRoot, source, resolvedSource, target string, preserveInDst []string, backupDir string) error {
+	dstPath, backupPath := f.entryDestPaths(dstRoot, resolvedSource, target, backupDir)
 
 	// TODO: enable support for symlinks when needed
-	if osutil.IsSymlink(srcPath) {
+	if osutil.IsSymlink(resolvedSource) {
 		return fmt.Errorf("cannot update file %s: symbolic links are not supported", source)
 	}
 
@@ -521,7 +510,7 @@ func (f *mountedFilesystemUpdater) updateOrSkipFile(dstRoot, source, target stri
 		}
 	}
 
-	return writeFileOrSymlink(srcPath, dstPath, preserveInDst)
+	return writeFileOrSymlink(resolvedSource, dstPath, preserveInDst)
 }
 
 func (f *mountedFilesystemUpdater) updateVolumeContent(volumeRoot string, content *VolumeContent, preserveInDst []string, backupDir string) error {
@@ -529,12 +518,10 @@ func (f *mountedFilesystemUpdater) updateVolumeContent(volumeRoot string, conten
 		return err
 	}
 
-	srcPath := f.entrySourcePath(content.Source)
-
-	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.Source, "/") {
-		return f.updateDirectory(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+	if osutil.IsDirectory(content.ResolvedSource) || strings.HasSuffix(content.Source, "/") {
+		return f.updateDirectory(volumeRoot, content.Source, content.ResolvedSource, content.Target, preserveInDst, backupDir)
 	} else {
-		return f.updateOrSkipFile(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		return f.updateOrSkipFile(volumeRoot, content.Source, content.ResolvedSource, content.Target, preserveInDst, backupDir)
 	}
 }
 
@@ -590,8 +577,8 @@ func (f *mountedFilesystemUpdater) Backup() error {
 	return nil
 }
 
-func (f *mountedFilesystemUpdater) backupOrCheckpointDirectory(dstRoot, source, target string, preserveInDst []string, backupDir string) error {
-	fis, err := f.sourceDirectoryEntries(source)
+func (f *mountedFilesystemUpdater) backupOrCheckpointDirectory(dstRoot, source, resolvedSource, target string, preserveInDst []string, backupDir string) error {
+	fis, err := f.sourceDirectoryEntries(resolvedSource)
 	if err != nil {
 		return fmt.Errorf("cannot backup directory %q: %v", source, err)
 	}
@@ -600,6 +587,7 @@ func (f *mountedFilesystemUpdater) backupOrCheckpointDirectory(dstRoot, source, 
 
 	for _, fi := range fis {
 		pSrc := filepath.Join(source, fi.Name())
+		pResolvedSrc := filepath.Join(resolvedSource, fi.Name())
 		pDst := filepath.Join(target, fi.Name())
 
 		backup := f.backupOrCheckpointFile
@@ -607,13 +595,14 @@ func (f *mountedFilesystemUpdater) backupOrCheckpointDirectory(dstRoot, source, 
 			// continue backing up the contents of the directory
 			// rather than the directory itself
 			pSrc += "/"
+			pResolvedSrc += "/"
 			pDst += "/"
 			backup = f.backupOrCheckpointDirectory
 		}
 		if err := f.checkpointPrefix(dstRoot, pDst, backupDir); err != nil {
 			return err
 		}
-		if err := backup(dstRoot, pSrc, pDst, preserveInDst, backupDir); err != nil {
+		if err := backup(dstRoot, pSrc, pResolvedSrc, pDst, preserveInDst, backupDir); err != nil {
 			return err
 		}
 	}
@@ -651,9 +640,8 @@ func (f *mountedFilesystemUpdater) checkpointPrefix(dstRoot, target string, back
 	return nil
 }
 
-func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, target string, preserveInDst []string, backupDir string) error {
-	srcPath := f.entrySourcePath(source)
-	dstPath, backupPath := f.entryDestPaths(dstRoot, source, target, backupDir)
+func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, resolvedSource, target string, preserveInDst []string, backupDir string) error {
+	dstPath, backupPath := f.entryDestPaths(dstRoot, resolvedSource, target, backupDir)
 
 	backupName := backupPath + ".backup"
 	sameStamp := backupPath + ".same"
@@ -720,7 +708,7 @@ func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, targe
 	}
 
 	// digest of the update
-	updateDigest, _, err := osutil.FileDigest(srcPath, crypto.SHA1)
+	updateDigest, _, err := osutil.FileDigest(resolvedSource, crypto.SHA1)
 	if err != nil {
 		backup.Cancel()
 		return fmt.Errorf("cannot checksum update file: %v", err)
@@ -751,17 +739,15 @@ func (f *mountedFilesystemUpdater) backupVolumeContent(volumeRoot string, conten
 		return err
 	}
 
-	srcPath := f.entrySourcePath(content.Source)
-
 	if err := f.checkpointPrefix(volumeRoot, content.Target, backupDir); err != nil {
 		return err
 	}
-	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.Source, "/") {
+	if osutil.IsDirectory(content.ResolvedSource) || strings.HasSuffix(content.Source, "/") {
 		// backup directory contents
-		return f.backupOrCheckpointDirectory(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		return f.backupOrCheckpointDirectory(volumeRoot, content.Source, content.ResolvedSource, content.Target, preserveInDst, backupDir)
 	} else {
 		// backup a file
-		return f.backupOrCheckpointFile(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		return f.backupOrCheckpointFile(volumeRoot, content.Source, content.ResolvedSource, content.Target, preserveInDst, backupDir)
 	}
 }
 
@@ -800,8 +786,8 @@ func (f *mountedFilesystemUpdater) rollbackPrefix(dstRoot, target string, backup
 	return nil
 }
 
-func (f *mountedFilesystemUpdater) rollbackDirectory(dstRoot, source, target string, preserveInDst []string, backupDir string) error {
-	fis, err := f.sourceDirectoryEntries(source)
+func (f *mountedFilesystemUpdater) rollbackDirectory(dstRoot, source, resolvedSource, target string, preserveInDst []string, backupDir string) error {
+	fis, err := f.sourceDirectoryEntries(resolvedSource)
 	if err != nil {
 		return fmt.Errorf("cannot rollback directory %q: %v", source, err)
 	}
@@ -810,6 +796,7 @@ func (f *mountedFilesystemUpdater) rollbackDirectory(dstRoot, source, target str
 
 	for _, fi := range fis {
 		pSrc := filepath.Join(source, fi.Name())
+		pResolvedSrc := filepath.Join(resolvedSource, fi.Name())
 		pDst := filepath.Join(target, fi.Name())
 
 		rollback := f.rollbackFile
@@ -818,9 +805,10 @@ func (f *mountedFilesystemUpdater) rollbackDirectory(dstRoot, source, target str
 			// rather than the directory itself
 			rollback = f.rollbackDirectory
 			pSrc += "/"
+			pResolvedSrc += "/"
 			pDst += "/"
 		}
-		if err := rollback(dstRoot, pSrc, pDst, preserveInDst, backupDir); err != nil {
+		if err := rollback(dstRoot, pSrc, pResolvedSrc, pDst, preserveInDst, backupDir); err != nil {
 			return err
 		}
 		if err := f.rollbackPrefix(dstRoot, pDst, backupDir); err != nil {
@@ -831,7 +819,7 @@ func (f *mountedFilesystemUpdater) rollbackDirectory(dstRoot, source, target str
 	return nil
 }
 
-func (f *mountedFilesystemUpdater) rollbackFile(dstRoot, source, target string, preserveInDst []string, backupDir string) error {
+func (f *mountedFilesystemUpdater) rollbackFile(dstRoot, source, resolvedSource, target string, preserveInDst []string, backupDir string) error {
 	dstPath, backupPath := f.entryDestPaths(dstRoot, source, target, backupDir)
 
 	backupName := backupPath + ".backup"
@@ -867,15 +855,13 @@ func (f *mountedFilesystemUpdater) rollbackVolumeContent(volumeRoot string, cont
 		return err
 	}
 
-	srcPath := f.entrySourcePath(content.Source)
-
 	var err error
-	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.Source, "/") {
+	if osutil.IsDirectory(content.ResolvedSource) || strings.HasSuffix(content.Source, "/") {
 		// rollback directory
-		err = f.rollbackDirectory(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		err = f.rollbackDirectory(volumeRoot, content.Source, content.ResolvedSource, content.Target, preserveInDst, backupDir)
 	} else {
 		// rollback file
-		err = f.rollbackFile(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		err = f.rollbackFile(volumeRoot, content.Source, content.ResolvedSource, content.Target, preserveInDst, backupDir)
 	}
 	if err != nil {
 		return err

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -37,6 +37,8 @@ import (
 type mountedfilesystemTestSuite struct {
 	dir    string
 	backup string
+
+	mockKernelRoot string
 }
 
 var _ = Suite(&mountedfilesystemTestSuite{})
@@ -136,6 +138,11 @@ func verifyDirContents(c *C, where string, expected map[string]contentType) {
 	})
 
 	c.Assert(got, DeepEquals, expected)
+}
+
+func (s *mountedfilesystemTestSuite) mustResolveContentPathsForStructure(c *C, ps *gadget.LaidOutStructure) {
+	err := gadget.ResolveContentPathsForStructure(s.dir, "", nil, ps.VolumeStructure)
+	c.Assert(err, IsNil)
 }
 
 func (s *mountedfilesystemTestSuite) TestWriteFile(c *C) {
@@ -317,6 +324,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterHappy(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	outDir := c.MkDir()
 
@@ -375,6 +383,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterNonDirectory(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	outDir := c.MkDir()
 
@@ -400,6 +409,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorMissingSource(c *C) {
 			},
 		},
 	}
+	err := gadget.ResolveContentPathsForStructure(s.dir, "", nil, ps.VolumeStructure)
+	c.Assert(err, IsNil)
 
 	outDir := c.MkDir()
 
@@ -427,6 +438,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorBadDestination(c *C) 
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	outDir := c.MkDir()
 
@@ -464,6 +476,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterConflictingDestinationDire
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, psOverwritesDirectoryWithFile)
 
 	outDir := c.MkDir()
 
@@ -498,6 +511,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterConflictingDestinationFile
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, psOverwritesFile)
 
 	outDir := c.MkDir()
 
@@ -532,6 +546,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorNested(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	outDir := c.MkDir()
 
@@ -617,6 +632,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterPreserve(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
@@ -691,6 +707,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterImplicitDir(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	outDir := c.MkDir()
 
@@ -783,6 +800,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterSymlinks(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
@@ -855,6 +873,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupSimple(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -900,6 +919,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterObserverErr(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	outDir := c.MkDir()
 	obs := &mockWriteObserver{
@@ -963,6 +983,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupWithDirectories(c *
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1017,6 +1038,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupNonexistent(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1097,6 +1119,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnDestinationE
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1138,6 +1161,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnBadSrcCompar
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1190,6 +1214,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFunnyNamesConflictB
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	backupBar := filepath.Join(s.backup, "backup-bar")
 	backupFoo := filepath.Join(s.backup, "backup-foo")
@@ -1252,6 +1277,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFunnyNamesOk(c *C) 
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1298,6 +1324,8 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupErrorOnSymlinkFile(
 			},
 		},
 	}
+	err := gadget.ResolveContentPathsForStructure(outDir, "", nil, ps.VolumeStructure)
+	c.Assert(err, IsNil)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1335,6 +1363,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupErrorOnSymlinkInPre
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1439,6 +1468,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterUpdate(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1504,6 +1534,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterDirContents(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1559,6 +1590,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterExpectsBackup(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1617,6 +1649,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEmptyDir(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1674,6 +1707,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterSameFileSkipped(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1727,6 +1761,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterLonePrefix(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1763,6 +1798,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterUpdateErrorOnSymlinkToFil
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1801,6 +1837,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupErrorOnSymlinkToDir
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1849,6 +1886,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackFromBackup(c *C) 
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1897,6 +1935,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackSkipSame(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1944,6 +1983,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackSkipPreserved(c *
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1996,6 +2036,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackNewFiles(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2044,6 +2085,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackRestoreFails(c *C
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2103,6 +2145,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackNotWritten(c *C) 
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2168,6 +2211,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackDirectory(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2290,6 +2334,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2562,6 +2607,8 @@ managed grub.cfg from disk`
 			},
 		},
 	}
+	s.mustResolveContentPathsForStructure(c, ps)
+
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup,
 		func(to *gadget.LaidOutStructure) (string, error) {
 			c.Check(to, DeepEquals, ps)

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -43,7 +43,10 @@ type GadgetData struct {
 	// Info is the gadget metadata
 	Info *Info
 	// RootDir is the root directory of gadget snap data
+	// XXX: should be GadgetRootDir
 	RootDir string
+	// RootDir is the root directory of kernel snap data
+	KernelRootDir string
 }
 
 // UpdatePolicyFunc is a callback that evaluates the provided pair of structures

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -177,7 +177,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	var brOpts install.Options
 	var installRunCalled int
 	var sealingObserver gadget.ContentObserver
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, obs gadget.ContentObserver) error {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, kernelRoot, device string, options install.Options, obs gadget.ContentObserver) error {
 		// ensure we can grab the lock here, i.e. that it's not taken
 		s.state.Lock()
 		s.state.Unlock()
@@ -296,7 +296,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) error {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) error {
 		return fmt.Errorf("The horror, The horror")
 	})
 	defer restore()
@@ -412,7 +412,7 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade, gadg
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) error {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) error {
 		return nil
 	})
 	defer restore()

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -248,7 +248,7 @@ func MockSysconfigConfigureRunSystem(f func(opts *sysconfig.Options) error) (res
 	}
 }
 
-func MockInstallRun(f func(gadgetRoot, device string, options install.Options, observer gadget.ContentObserver) error) (restore func()) {
+func MockInstallRun(f func(gadgetRoot, kernelRoot, device string, options install.Options, observer gadget.ContentObserver) error) (restore func()) {
 	old := installRun
 	installRun = f
 	return func() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -139,7 +139,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	func() {
 		st.Unlock()
 		defer st.Lock()
-		err = installRun(gadgetDir, "", bopts, sealingContentObserver)
+		err = installRun(gadgetDir, kernelDir, "", bopts, sealingContentObserver)
 	}()
 	if err != nil {
 		return fmt.Errorf("cannot create partitions: %v", err)

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -43,6 +43,7 @@ type cmdCreatePartitions struct {
 
 	Positional struct {
 		GadgetRoot string `positional-arg-name:"<gadget-root>"`
+		KernelRoot string `positional-arg-name:"<kernel-root>"`
 		Device     string `positional-arg-name:"<device>"`
 	} `positional-args:"yes"`
 }
@@ -94,7 +95,7 @@ func main() {
 		KernelPath:              args.KernelPath,
 		Model:                   model,
 	}
-	err = installRun(args.Positional.GadgetRoot, args.Positional.Device, options, nil)
+	err = installRun(args.Positional.GadgetRoot, args.Positional.KernelRoot, args.Positional.Device, options, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -91,6 +91,9 @@ execute: |
     sbverify --list "$seedbootdir"/grubx64.efi
     sbverify --list "$bootdir"/grubx64.efi
 
+    # XXX: make kernel-dir non-empty once we have a gadget that has a
+    #      "$kernel:" style ref in the meta/gadget.yaml
+    mkdir -p kernel-dir
     echo "Run the snap-bootstrap tool"
     go get ../../lib/uc20-create-partitions
     uc20-create-partitions \
@@ -99,7 +102,7 @@ execute: |
         --policy-update-data-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde/policy-update-data \
         --tpm-lockout-auth /run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde/tpm-lockout-auth \
         --model <(snap model --assertion) \
-        ./gadget-dir "$LOOP"
+        ./gadget-dir ./kernel-dir "$LOOP"
     # keep for later
     cp -a /run/mnt/ubuntu-seed/keyfile "/run/mnt/ubuntu-seed/keyfile.$SPREAD_REBOOT"
 

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -51,9 +51,12 @@ execute: |
     # debug message to see if the udev database is correctly updated
     udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
 
+    # XXX: make kernel-dir non-empty once we have a gadget that has a
+    #      "$kernel:" style ref in the meta/gadget.yaml
+    mkdir -p kernel-dir
     echo "Run the snap-bootstrap tool in auto-detect mode"
     go get ../../lib/uc20-create-partitions
-    uc20-create-partitions ./gadget-dir
+    uc20-create-partitions ./gadget-dir ./kernel-dir
 
     echo "And check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'
@@ -69,7 +72,7 @@ execute: |
 
     # re-create partitions on a new install attempt
     echo "Run the snap-bootstrap again"
-    uc20-create-partitions ./gadget-dir
+    uc20-create-partitions ./gadget-dir ./kernel-dir
 
     echo "And check that the partitions are there"
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -53,7 +53,10 @@ execute: |
 
     echo "Run the snap-bootstrap tool"
     go get ../../lib/uc20-create-partitions
-    uc20-create-partitions ./gadget-dir "$LOOP"
+    # XXX: make kernel-dir non-empty once we have a gadget that has a
+    #      "$kernel:" style ref in the meta/gadget.yaml
+    mkdir -p kernel-dir
+    uc20-create-partitions ./gadget-dir ./kernel-dir "$LOOP"
 
     echo "And check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'
@@ -120,7 +123,7 @@ execute: |
             filesystem-label: other-ext4
             size: 110M
     EOF
-    uc20-create-partitions --mount ./gadget-dir "$LOOP"
+    uc20-create-partitions --mount ./gadget-dir ./kernel-dir "$LOOP"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p1 .* 1M\s* BIOS boot"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p2 .* 1.2G\s* EFI System"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p3 .* 750M\s* Linux filesystem"


### PR DESCRIPTION
Build on top of https://github.com/snapcore/snapd/pull/9130, this implements:

3. Change mountedfilesystem.go to use Content.ResolvedSource and stop passing "contentDir" in