### PR TITLE
vendor: update secboot to fix key data validation

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -110,16 +110,34 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "Yfj2ZrgRrklXrshCM1RxH5pvUY8=",
+			"checksumSHA1": "UHhUJNcYbKn3xxZDuPh9GX6BWrM=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "79ab430e52a5c8284ff2822839c32736872643fe",
-			"revisionTime": "2020-07-07T19:41:53Z"
+			"revision": "68200eea7bdcb97e27fe8e5ff443776383908637",
+			"revisionTime": "2020-08-13T11:40:20Z"
 		},
 		{
 			"checksumSHA1": "loFEiH6evGaDnDSlQgk3ugemkcU=",
 			"path": "github.com/snapcore/secboot/internal/pe1.14",
-			"revision": "79ab430e52a5c8284ff2822839c32736872643fe",
-			"revisionTime": "2020-07-07T19:41:53Z"
+			"revision": "68200eea7bdcb97e27fe8e5ff443776383908637",
+			"revisionTime": "2020-08-13T11:40:20Z"
+		},
+		{
+			"checksumSHA1": "kDay47kq9OgDplpkrYw0/a8Z+YY=",
+			"path": "github.com/snapcore/secboot/internal/tcg",
+			"revision": "68200eea7bdcb97e27fe8e5ff443776383908637",
+			"revisionTime": "2020-08-13T11:40:20Z"
+		},
+		{
+			"checksumSHA1": "PRS8ACUu14shrvAgb747Izc25ns=",
+			"path": "github.com/snapcore/secboot/internal/tcti",
+			"revision": "68200eea7bdcb97e27fe8e5ff443776383908637",
+			"revisionTime": "2020-08-13T11:40:20Z"
+		},
+		{
+			"checksumSHA1": "TnfofdyojXYWOwdWCKMY5RCeI7s=",
+			"path": "github.com/snapcore/secboot/internal/truststore",
+			"revision": "68200eea7bdcb97e27fe8e5ff443776383908637",
+			"revisionTime": "2020-08-13T11:40:20Z"
 		},
 		{
 			"checksumSHA1": "3AmEm18mKj8XxBuru/ix4OOpRkE=",


### PR DESCRIPTION
This change allows us to update the PCR protection profile for a sealed
key after locking access to the sealed keys.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
