### PR TITLE
overlord/devicestate: workaround non-nil interface with nil struct

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -20,22 +20,29 @@
 package boot
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/gadget"
 )
 
+// ErrObserverNotApplicable indicates that observer is not applicable for use
+// with the model.
+var ErrObserverNotApplicable = errors.New("observer not applicable")
+
 // TrustedAssetsInstallObserverForModel returns a new trusted assets observer
 // for use during installation of the run mode system, provided the device model
-// supports secure boot. Otherwise, nil is returned.
-func TrustedAssetsInstallObserverForModel(model *asserts.Model) *TrustedAssetsInstallObserver {
+// supports secure boot. Otherwise, nil and ErrObserverNotApplicable is
+// returned.
+func TrustedAssetsInstallObserverForModel(model *asserts.Model) (*TrustedAssetsInstallObserver, error) {
 	if model.Grade() == asserts.ModelGradeUnset {
 		// no need to observe updates when assets are not managed
-		return nil
+		return nil, ErrObserverNotApplicable
 	}
 
 	return &TrustedAssetsInstallObserver{
 		model: model,
-	}
+	}, nil
 }
 
 // TrustedAssetsInstallObserver tracks the installation of trusted boot assets.
@@ -67,14 +74,15 @@ func (o *TrustedAssetsInstallObserver) Seal() error {
 
 // TrustedAssetsUpdateObserverForModel returns a new trusted assets observer for
 // tracking changes to the measured boot assets during gadget updates, provided
-// the device model supports secure boot. Otherwise, nil is returned.
-func TrustedAssetsUpdateObserverForModel(model *asserts.Model) *TrustedAssetsUpdateObserver {
+// the device model supports secure boot. Otherwise, nil and ErrObserverNotApplicable is
+// returned.
+func TrustedAssetsUpdateObserverForModel(model *asserts.Model) (*TrustedAssetsUpdateObserver, error) {
 	if model.Grade() == asserts.ModelGradeUnset {
 		// no need to observe updates when assets are not managed
-		return nil
+		return nil, ErrObserverNotApplicable
 	}
 
-	return &TrustedAssetsUpdateObserver{}
+	return &TrustedAssetsUpdateObserver{}, nil
 }
 
 // TrustedAssetsUpdateObserver tracks the updates of trusted boot assets and

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/boot"
+)
+
+type assetsSuite struct {
+	baseBootenvSuite
+}
+
+var _ = Suite(&assetsSuite{})
+
+func (s *assetsSuite) TestInstallObserverNew(c *C) {
+	// we get an observer for UC20
+	uc20Model := makeMockUC20Model()
+	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model)
+	c.Assert(err, IsNil)
+	c.Assert(obs, NotNil)
+
+	// but nil for non UC20
+	nonUC20Model := makeMockModel()
+	nonUC20obs, err := boot.TrustedAssetsInstallObserverForModel(nonUC20Model)
+	c.Assert(err, Equals, boot.ErrObserverNotApplicable)
+	c.Assert(nonUC20obs, IsNil)
+}
+
+func (s *assetsSuite) TestUpdateObserverNew(c *C) {
+	// we get an observer for UC20
+	uc20Model := makeMockUC20Model()
+	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
+	c.Assert(err, IsNil)
+	c.Assert(obs, NotNil)
+
+	// but nil for non UC20
+	nonUC20Model := makeMockModel()
+	nonUC20obs, err := boot.TrustedAssetsUpdateObserverForModel(nonUC20Model)
+	c.Assert(err, Equals, boot.ErrObserverNotApplicable)
+	c.Assert(nonUC20obs, IsNil)
+}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -74,6 +74,23 @@ func makeSnapWithFiles(c *C, name, yaml string, revno snap.Revision, files [][]s
 	return fn, info
 }
 
+func makeMockModel() *asserts.Model {
+	headers := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"display-name": "My Model",
+		"architecture": "amd64",
+		"base":         "core18",
+		"gadget":       "pc=18",
+		"kernel":       "pc-kernel=18",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}
+	return assertstest.FakeAssertion(headers).(*asserts.Model)
+}
+
 func (s *makeBootableSuite) TestMakeBootable(c *C) {
 	dirs.SetRootDir("")
 

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -188,7 +188,9 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetOnCoreSimple(c *C, grade string) 
 		} else {
 			c.Check(observer, NotNil)
 			// expecting a very specific observer
-			c.Check(observer, FitsTypeOf, &boot.TrustedAssetsUpdateObserver{})
+			trustedUpdateObserver, ok := observer.(*boot.TrustedAssetsUpdateObserver)
+			c.Assert(ok, Equals, true, Commentf("unexpected type: %T", observer))
+			c.Assert(trustedUpdateObserver, NotNil)
 		}
 		return nil
 	})

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -277,7 +277,12 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 		// directories were ensured
 		c.Assert(osutil.IsDirectory(boot.InitramfsEncryptionKeyDir), Equals, true)
 		c.Assert(osutil.IsDirectory(filepath.Join(boot.InstallHostWritableDir, "var/lib/snapd/device/fde")), Equals, true)
+		// inteface is not nil
 		c.Assert(sealingObserver, NotNil)
+		// we expect a very specific type
+		trustedInstallObserver, ok := sealingObserver.(*boot.TrustedAssetsInstallObserver)
+		c.Assert(ok, Equals, true, Commentf("unexpected type: %T", sealingObserver))
+		c.Assert(trustedInstallObserver, NotNil)
 	} else {
 		c.Assert(brGadgetRoot, Equals, filepath.Join(dirs.SnapMountDir, "/pc/1"))
 		c.Assert(brDevice, Equals, "")

--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -138,9 +138,16 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 		updatePolicy = gadget.RemodelUpdatePolicy
 	}
 
-	observeTrustedBootAssets := boot.TrustedAssetsUpdateObserverForModel(model)
+	var updateObserver gadget.ContentUpdateObserver
+	observeTrustedBootAssets, err := boot.TrustedAssetsUpdateObserverForModel(model)
+	if err != nil && err != boot.ErrObserverNotApplicable {
+		return err
+	}
+	if err == nil {
+		updateObserver = observeTrustedBootAssets
+	}
 	st.Unlock()
-	err = gadgetUpdate(*currentData, *updateData, snapRollbackDir, updatePolicy, observeTrustedBootAssets)
+	err = gadgetUpdate(*currentData, *updateData, snapRollbackDir, updatePolicy, updateObserver)
 	st.Lock()
 	if err != nil {
 		if err == gadget.ErrNoUpdate {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -112,7 +113,9 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	var installObserver *boot.TrustedAssetsInstallObserver
+	var trustedInstallObserver *boot.TrustedAssetsInstallObserver
+	// get a nice nil interface by default
+	var installObserver gadget.ContentObserver
 	if useEncryption {
 		fdeDir := "var/lib/snapd/device/fde"
 		// ensure directories
@@ -131,7 +134,13 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		bopts.Model = deviceCtx.Model()
 		bopts.SystemLabel = modeEnv.RecoverySystem
 
-		installObserver = boot.TrustedAssetsInstallObserverForModel(deviceCtx.Model())
+		trustedInstallObserver, err = boot.TrustedAssetsInstallObserverForModel(deviceCtx.Model())
+		if err != nil && err != boot.ErrObserverNotApplicable {
+			return fmt.Errorf("cannot setup asset install observer: %v", err)
+		}
+		if err == nil {
+			installObserver = trustedInstallObserver
+		}
 	}
 
 	// run the create partition code
@@ -175,7 +184,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		UnpackedGadgetDir: gadgetDir,
 	}
 	rootdir := dirs.GlobalRootDir
-	if err := bootMakeBootable(deviceCtx.Model(), rootdir, bootWith, installObserver); err != nil {
+	if err := bootMakeBootable(deviceCtx.Model(), rootdir, bootWith, trustedInstallObserver); err != nil {
 		return fmt.Errorf("cannot make run system bootable: %v", err)
 	}
 


### PR DESCRIPTION
Workaround non-nil interface, but nil struct weirdness. Make sure to return an explicit error when we return a nil initial install and update observers.