### PR TITLE
tests: unmount FUSE file-systems from XDG runtime dir

### DIFF
--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -143,6 +143,14 @@ case "$action" in
 			# services, then there this condition could be removed.
 			if [ "$u" != root ]; then
 				uid="$(id -u "$u")"
+
+				# Unmount gvfs-fuse and the document portal explicitly.  FUSE
+				# file-systems can stay mounted in a broken state even if their
+				# corresponding process goes away. This can happen if we stop
+				# the slice and the cleanup is not perfectly graceful.
+				umount "/run/user/$uid/gvfs" || true
+				umount "/run/user/$uid/doc" || true
+
 				# See user@.service(5) for discussion about user-UID.slice and
 				# user@UID.service and why both are used. Here we stop the
 				# slice as that encompasses both user@UID.service and any


### PR DESCRIPTION
When a FUSE file system is mounted, killing the corresponding process
does not unmount it. Instead the filesystem stays around in a broken
state until it is unmounted explicitly.

When tests.session restores a non-root service it stops the whole user
slice, which effectively terminates all processes belonging to the test
user. This can cause issues with the XDG document portal, if shutdown is
performed on a busy machine and kill-timeout kicks in.

To avoid it, explicitly unmount gvfs and XDG document portal before
stopping the slice.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>