### PR TITLE
boot: copy boot assets cache to new root

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -146,9 +146,7 @@ func CopyBootAssetsCacheToRoot(dstRoot string) error {
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("unsupported non-file entry %q mode %v", relPath, info.Mode())
 		}
-		err = osutil.CopyFile(path, filepath.Join(newCacheRoot, relPath),
-			osutil.CopyFlagPreserveAll)
-		if err != nil {
+		if err := osutil.CopyFile(path, filepath.Join(newCacheRoot, relPath), osutil.CopyFlagPreserveAll); err != nil {
 			return fmt.Errorf("cannot copy boot asset cache file %q: %v", relPath, err)
 		}
 		return nil

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	. "gopkg.in/check.v1"
 
@@ -418,4 +419,89 @@ func (s *assetsSuite) TestUpdateObserverNew(c *C) {
 	nonUC20obs, err := boot.TrustedAssetsUpdateObserverForModel(nonUC20Model)
 	c.Assert(err, Equals, boot.ErrObserverNotApplicable)
 	c.Assert(nonUC20obs, IsNil)
+}
+
+func (s *assetsSuite) TestCopyBootAssetsCacheHappy(c *C) {
+	newRoot := c.MkDir()
+	// does not fail when dir does not exist
+	err := boot.CopyBootAssetsCacheToRoot(newRoot)
+	c.Assert(err, IsNil)
+
+	// temporarily overide umask
+	oldUmask := syscall.Umask(0000)
+	defer syscall.Umask(oldUmask)
+
+	entries := []struct {
+		name, content string
+		mode          uint
+	}{
+		{"foo/bar", "1234", 0644},
+		{"grub/grubx64.efi-1234", "grub content", 0622},
+		{"top-level", "top level content", 0666},
+		{"deeply/nested/content", "deeply nested content", 0611},
+	}
+
+	for _, entry := range entries {
+		p := filepath.Join(dirs.SnapBootAssetsDir, entry.name)
+		err = os.MkdirAll(filepath.Dir(p), 0755)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(p, []byte(entry.content), os.FileMode(entry.mode))
+		c.Assert(err, IsNil)
+	}
+
+	err = boot.CopyBootAssetsCacheToRoot(newRoot)
+	c.Assert(err, IsNil)
+	for _, entry := range entries {
+		p := filepath.Join(dirs.SnapBootAssetsDirUnder(newRoot), entry.name)
+		c.Check(p, testutil.FileEquals, entry.content)
+		fi, err := os.Stat(p)
+		c.Assert(err, IsNil)
+		c.Check(fi.Mode().Perm(), Equals, os.FileMode(entry.mode),
+			Commentf("unexpected mode of copied file %q: %v", entry.name, fi.Mode().Perm()))
+	}
+}
+
+func (s *assetsSuite) TestCopyBootAssetsCacheUnhappy(c *C) {
+	// non-file
+	newRoot := c.MkDir()
+	dirs.SnapBootAssetsDir = c.MkDir()
+	p := filepath.Join(dirs.SnapBootAssetsDir, "fifo")
+	syscall.Mkfifo(p, 0644)
+	err := boot.CopyBootAssetsCacheToRoot(newRoot)
+	c.Assert(err, ErrorMatches, `unsupported non-file entry "fifo" mode prw-.*`)
+
+	// non-writable root
+	newRoot = c.MkDir()
+	nonWritableRoot := filepath.Join(newRoot, "non-writable")
+	err = os.MkdirAll(nonWritableRoot, 0000)
+	c.Assert(err, IsNil)
+	dirs.SnapBootAssetsDir = c.MkDir()
+	err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "file"), nil, 0644)
+	c.Assert(err, IsNil)
+	err = boot.CopyBootAssetsCacheToRoot(nonWritableRoot)
+	c.Assert(err, ErrorMatches, `cannot create cache directory under new root: mkdir .*: permission denied`)
+
+	// file cannot be read
+	newRoot = c.MkDir()
+	dirs.SnapBootAssetsDir = c.MkDir()
+	err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "file"), nil, 0000)
+	c.Assert(err, IsNil)
+	err = boot.CopyBootAssetsCacheToRoot(newRoot)
+	c.Assert(err, ErrorMatches, `cannot copy boot asset cache file "file": failed to copy all: .*`)
+
+	// directory at destination cannot be recreated
+	newRoot = c.MkDir()
+	dirs.SnapBootAssetsDir = c.MkDir()
+	// make a directory at destination non writable
+	err = os.MkdirAll(dirs.SnapBootAssetsDirUnder(newRoot), 0755)
+	c.Assert(err, IsNil)
+	err = os.Chmod(dirs.SnapBootAssetsDirUnder(newRoot), 0000)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "dir"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "dir", "file"), nil, 0000)
+	c.Assert(err, IsNil)
+	err = boot.CopyBootAssetsCacheToRoot(newRoot)
+	c.Assert(err, ErrorMatches, `cannot recreate cache directory "dir": .*: permission denied`)
+
 }

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -255,7 +255,10 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		}
 	}
 
-	// TODO:UC20: replicate the boot assets cache in host's writable
+	// replicate the boot assets cache in host's writable
+	if err := CopyBootAssetsCacheToRoot(InstallHostWritableDir); err != nil {
+		return fmt.Errorf("cannot replicate boot assets cache: %v", err)
+	}
 
 	var currentTrustedBootAssets bootAssetsMap
 	if sealer != nil {

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -473,6 +473,17 @@ model=my-brand/my-model-uc20
 grade=dangerous
 current_trusted_boot_assets={"grubx64.efi":["5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"]}
 `)
+	copiedGrubBin := filepath.Join(
+		dirs.SnapBootAssetsDirUnder(boot.InstallHostWritableDir),
+		"grub",
+		"grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d",
+	)
+	// only one file in the cache under new root
+	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDirUnder(boot.InstallHostWritableDir), "grub", "*"), []string{
+		copiedGrubBin,
+	})
+	// with the right content
+	c.Check(copiedGrubBin, testutil.FileEquals, "grub content")
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20RunModeInstallBootConfigErr(c *C) {

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -243,6 +243,12 @@ func SnapSystemdConfDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, "/etc/systemd/system.conf.d")
 }
 
+// SnapBootAssetsDirUnder returns the path to boot assets directory under a
+// rootdir.
+func SnapBootAssetsDirUnder(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir, "boot-assets")
+}
+
 // AddRootDirCallback registers a callback for whenever the global root
 // directory (set by SetRootDir) is changed to enable updates to variables in
 // other packages that depend on its location.
@@ -320,7 +326,7 @@ func SetRootDir(rootdir string) {
 	SnapDeviceDir = filepath.Join(rootdir, snappyDir, "device")
 
 	SnapModeenvFile = SnapModeenvFileUnder(rootdir)
-	SnapBootAssetsDir = filepath.Join(rootdir, snappyDir, "boot-assets")
+	SnapBootAssetsDir = SnapBootAssetsDirUnder(rootdir)
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")
 	SnapRepairStateFile = filepath.Join(SnapRepairDir, "repair.json")


### PR DESCRIPTION
When setting up a run mode system, ensure that the boot assets cache directory
is copied from the ephemeral system to the target system-data filesystem.
