### PR TITLE
o/devicestate: wrap asset update observer error

### DIFF
--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -141,7 +141,7 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 	var updateObserver gadget.ContentUpdateObserver
 	observeTrustedBootAssets, err := boot.TrustedAssetsUpdateObserverForModel(model)
 	if err != nil && err != boot.ErrObserverNotApplicable {
-		return err
+		return fmt.Errorf("cannot setup asset update observer: %v", err)
 	}
 	if err == nil {
 		updateObserver = observeTrustedBootAssets


### PR DESCRIPTION
Tiny follow up after #9153.

The error case cannot really happen at the moment. However, for future changes, wrap the error when creating asset update observers.

