### PR TITLE
logger: add support for setting snapd.debug=1 on kernel cmdline

### DIFF
--- a/logger/export_test.go
+++ b/logger/export_test.go
@@ -34,3 +34,11 @@ func GetLoggerFlags() int {
 
 	return log.log.Flags()
 }
+
+func MockProcCmdline(new string) (restore func()) {
+	old := procCmdline
+	procCmdline = new
+	return func() {
+		procCmdline = old
+	}
+}

--- a/logger/export_test.go
+++ b/logger/export_test.go
@@ -27,7 +27,7 @@ func GetLogger() Logger {
 }
 
 func GetLoggerFlags() int {
-	log, ok := GetLogger().(Log)
+	log, ok := GetLogger().(*Log)
 	if !ok {
 		return -1
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -129,20 +129,20 @@ type Log struct {
 }
 
 // Debug only prints if SNAPD_DEBUG is set
-func (l Log) Debug(msg string) {
+func (l *Log) Debug(msg string) {
 	if l.debug || osutil.GetenvBool("SNAPD_DEBUG") {
 		l.log.Output(3, "DEBUG: "+msg)
 	}
 }
 
 // Notice alerts the user about something, as well as putting it syslog
-func (l Log) Notice(msg string) {
+func (l *Log) Notice(msg string) {
 	l.log.Output(3, msg)
 }
 
 // New creates a log.Logger using the given io.Writer and flag.
 func New(w io.Writer, flag int) (Logger, error) {
-	logger := Log{
+	logger := &Log{
 		log:   log.New(w, "", flag),
 		debug: debugEnabledOnKernelCmdline(),
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -165,6 +165,8 @@ func SimpleSetup() error {
 
 var procCmdline = "/proc/cmdline"
 
+// TODO: consider generalizing this to snapdenv and having it used by
+// other places that consider SNAPD_DEBUG
 func debugEnabledOnKernelCmdline() bool {
 	buf, err := ioutil.ReadFile(procCmdline)
 	if err != nil {


### PR DESCRIPTION
While debugging a failure during UC20 seeding I noticed it is
hard to get debug data from snapd. I booted the system with:
```
dangerous systemd.debug-shell=1
```
but the
```
journalctl -u snapd
```
output did not contain that much information because debug
was not enabled. So this commit allows to enable debug via
the kernel commandline to allow easier seeding debugging.
