### PR TITLE
cmd/snap-update-ns: detach all bind-mounted file

### DIFF
--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -134,11 +134,18 @@ func (s *changeSuite) TestNeededChangesNoChangeOld(c *C) {
 func (s *changeSuite) TestNeededChangesNoChangeNew(c *C) {
 	s.enableRobustMountNamespaceUpdates(c)
 
-	current := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff"}}}
+	current := &osutil.MountProfile{
+		Entries: []osutil.MountEntry{
+			{Dir: "/common/stuff"},
+			{Dir: "/common/file", Options: []string{"bind", "x-snapd.kind=file"}},
+		},
+	}
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff"}}}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: osutil.MountEntry{Dir: "/common/stuff"}, Action: update.Unmount},
+		// File bind mounts are detached.
+		{Entry: osutil.MountEntry{Dir: "/common/file", Options: []string{"bind", "x-snapd.kind=file", "x-snapd.detach"}}, Action: update.Unmount},
 		{Entry: osutil.MountEntry{Dir: "/common/stuff"}, Action: update.Mount},
 	})
 }

--- a/tests/regression/lp-1891371/task.yaml
+++ b/tests/regression/lp-1891371/task.yaml
@@ -1,0 +1,19 @@
+summary: mount changes can happen while a bind-mount file is open
+prepare: |
+    tests.cleanup prepare
+    snap pack test-snapd-app
+    tests.cleanup defer rm -f test-snapd-app_1_all.snap
+    snap pack test-snapd-extra-content
+    tests.cleanup defer rm -f test-snapd-extra-content_1_all.snap
+execute: |
+    # This starts a service that opens /opt/foo via bind-file layout.
+    snap install --dangerous ./test-snapd-app_1_all.snap
+    tests.cleanup defer snap remove --purge test-snapd-app
+    # This contains a content snap that does nothing and can be attached to the snap above.
+    snap install --dangerous ./test-snapd-extra-content_1_all.snap
+    tests.cleanup defer snap remove --purge test-snapd-extra-content
+    # This attaches the content snap, forcing bind-file layout to be reconstructed.
+    snap connect test-snapd-app:extra-content test-snapd-extra-content:extra-content
+    tests.cleanup defer snap disconnect test-snapd-app:extra-content test-snapd-extra-content:extra-content
+restore: |
+    tests.cleanup restore

--- a/tests/regression/lp-1891371/test-snapd-app/bin/keep-foo-open
+++ b/tests/regression/lp-1891371/test-snapd-app/bin/keep-foo-open
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+import time
+
+def main() -> None:
+    # Open /opt/foo - which is provided by a layout with bind-file and wait
+    # forever.
+    foo = open("/opt/foo")
+    while True:
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+	main()

--- a/tests/regression/lp-1891371/test-snapd-app/extra-content/README.txt
+++ b/tests/regression/lp-1891371/test-snapd-app/extra-content/README.txt
@@ -1,0 +1,2 @@
+This directory is a mount point for extra content that is attached sometime
+after the snap service starts.

--- a/tests/regression/lp-1891371/test-snapd-app/foo
+++ b/tests/regression/lp-1891371/test-snapd-app/foo
@@ -1,0 +1,2 @@
+This file is bind mounted to /opt/foo and opened from there by the service
+defined in this snap.

--- a/tests/regression/lp-1891371/test-snapd-app/meta/snap.yaml
+++ b/tests/regression/lp-1891371/test-snapd-app/meta/snap.yaml
@@ -1,0 +1,16 @@
+name: test-snapd-app
+version: 1
+
+base: core18
+
+layout:
+  /opt/foo:
+      bind-file: $SNAP/foo
+apps:
+    keep-foo-open:
+        daemon: simple
+        command: bin/keep-foo-open
+plugs:
+    extra-content:
+        interface: content
+        target: $SNAP/extra-content

--- a/tests/regression/lp-1891371/test-snapd-extra-content/meta/snap.yaml
+++ b/tests/regression/lp-1891371/test-snapd-extra-content/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snapd-extra-content
+version: 1
+
+base: none
+
+slots:
+    extra-content:
+        interface: content
+        read: [$SNAP]


### PR DESCRIPTION
When a mount namespace update, coupled with robust mount namespace
update option occurs, a mount namespace is torn down and re-constructed,
at least to the extent possible with snap-update-ns and the mount
profiles.

During the tear-down operation, snap-update-ns computes a set of mount
changes to perform, based on the currently applied mount profile. Those
actions are in general, the "undo" of the profile, so when something is
mounted, it gets unmounted during the undo process.

Some things are handled specially, as we've learned over time that the
extreme popularity of layouts and content has allowed for interesting
interactions that were not originally envisioned when designing the
mount/layout system. One such realization was that we can and should
detach bind-mounted directories as they can internally hold other mount
points due to how mount events propagate.

Today we realized that we need to detach bind-mounted files as well, as
a file that is open via file descriptor _or_ mapped as a section into a
process by the dynamic linker, can keep a file busy. In effect a file
that is busy this way cannot be unmounted.

There's an interesting interaction between layouts and content
connections. When a snap application, for example a service, is running
while content snap connection is established, the mount namespace may
not tear down correctly when such service (or any application really)
keeps a file open either via linker mapping or via an open file
descriptor.

Fixes: https://bugs.launchpad.net/snapd/+bug/1891371
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

