### PR TITLE
boot, o/devicestate: observe existing recovery bootloader trusted boot assets

### DIFF
--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -406,6 +406,121 @@ func (s *assetsSuite) TestInstallObserverObserveErr(c *C) {
 	c.Assert(err, ErrorMatches, `cannot list "trusted-assets" bootloader trusted assets: mocked trusted assets error`)
 }
 
+func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryMocked(c *C) {
+	d := c.MkDir()
+
+	tab := bootloadertest.Mock("recovery-bootloader", "").WithTrustedAssets()
+	// MockBootloader does not implement trusted assets
+	bootloader.Force(tab)
+	defer bootloader.Force(nil)
+	tab.TrustedAssetsList = []string{
+		"asset",
+		"nested/other-asset",
+		"shim",
+	}
+
+	// we get an observer for UC20
+	uc20Model := makeMockUC20Model()
+	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
+	c.Assert(obs, NotNil)
+	c.Assert(err, IsNil)
+
+	data := []byte("foobar")
+	// SHA3-384
+	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
+	err = ioutil.WriteFile(filepath.Join(d, "asset"), data, 0644)
+	c.Assert(err, IsNil)
+	err = os.Mkdir(filepath.Join(d, "nested"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(d, "nested/other-asset"), data, 0644)
+	c.Assert(err, IsNil)
+	shim := []byte("shim")
+	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
+	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	c.Assert(err, IsNil)
+
+	err = obs.ObserveExistingTrustedRecoveryAssets(d)
+	c.Assert(err, IsNil)
+	// a single file in cache
+	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDir, "recovery-bootloader", "*"), []string{
+		filepath.Join(dirs.SnapBootAssetsDir, "recovery-bootloader", fmt.Sprintf("asset-%s", dataHash)),
+		filepath.Join(dirs.SnapBootAssetsDir, "recovery-bootloader", fmt.Sprintf("other-asset-%s", dataHash)),
+		filepath.Join(dirs.SnapBootAssetsDir, "recovery-bootloader", fmt.Sprintf("shim-%s", shimHash)),
+	})
+	// the list of trusted assets was asked for just once
+	c.Check(tab.TrustedAssetsCalls, Equals, 1)
+	// let's see what the observer has tracked
+	tracked := obs.CurrentTrustedRecoveryBootAssetsMap()
+	c.Check(tracked, DeepEquals, boot.BootAssetsMap{
+		"asset":       []string{dataHash},
+		"other-asset": []string{dataHash},
+		"shim":        []string{shimHash},
+	})
+}
+
+func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryNoAssets(c *C) {
+	d := c.MkDir()
+
+	tab := bootloadertest.Mock("recovery-bootloader", "").WithTrustedAssets()
+	// MockBootloader does not implement trusted assets
+	bootloader.Force(tab)
+	defer bootloader.Force(nil)
+
+	uc20Model := makeMockUC20Model()
+	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
+	c.Assert(obs, NotNil)
+	c.Assert(err, IsNil)
+
+	// does not fail when the bootloader has no trusted assets
+	err = obs.ObserveExistingTrustedRecoveryAssets(d)
+	c.Assert(err, IsNil)
+	// asked for the list of trusted assets
+	c.Check(tab.TrustedAssetsCalls, Equals, 1)
+	// nothing was tracked
+	tracked := obs.CurrentTrustedRecoveryBootAssetsMap()
+	c.Check(tracked, IsNil)
+
+	// force a non trusted bootloader
+	bl := bootloadertest.Mock("non-trusted-bootloader", "")
+	bootloader.Force(bl)
+	// happy with non trusted bootloader too
+	err = obs.ObserveExistingTrustedRecoveryAssets(d)
+	c.Assert(err, IsNil)
+}
+
+func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryErr(c *C) {
+	d := c.MkDir()
+
+	uc20Model := makeMockUC20Model()
+	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
+	c.Assert(obs, NotNil)
+	c.Assert(err, IsNil)
+
+	tab := bootloadertest.Mock("recovery-bootloader", "").WithTrustedAssets()
+	// MockBootloader does not implement trusted assets
+	bootloader.Force(tab)
+	defer bootloader.Force(nil)
+
+	tab.TrustedAssetsList = []string{
+		"asset",
+	}
+
+	// no trusted asset
+	err = obs.ObserveExistingTrustedRecoveryAssets(d)
+	c.Assert(err, ErrorMatches, "cannot open asset file: .*/asset: no such file or directory")
+	c.Check(tab.TrustedAssetsCalls, Equals, 1)
+
+	tab.TrustedAssetsErr = fmt.Errorf("fail")
+	err = obs.ObserveExistingTrustedRecoveryAssets(d)
+	c.Assert(err, ErrorMatches, `cannot list "recovery-bootloader" recovery bootloader trusted assets: fail`)
+	c.Check(tab.TrustedAssetsCalls, Equals, 2)
+
+	// force an error
+	bootloader.ForceError(fmt.Errorf("fail bootloader"))
+	err = obs.ObserveExistingTrustedRecoveryAssets(d)
+	c.Assert(err, ErrorMatches, `cannot identify recovery system bootloader: fail bootloader`)
+}
+
 func (s *assetsSuite) TestUpdateObserverNew(c *C) {
 	// we get an observer for UC20
 	uc20Model := makeMockUC20Model()

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -58,3 +58,7 @@ type TrackedAsset = trackedAsset
 func (o *TrustedAssetsInstallObserver) CurrentTrustedBootAssetsMap() BootAssetsMap {
 	return o.currentTrustedBootAssetsMap()
 }
+
+func (o *TrustedAssetsInstallObserver) CurrentTrustedRecoveryBootAssetsMap() BootAssetsMap {
+	return o.currentTrustedRecoveryBootAssetsMap()
+}

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -258,8 +258,10 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 	// TODO:UC20: replicate the boot assets cache in host's writable
 
 	var currentTrustedBootAssets bootAssetsMap
+	var currentTrustedRecoveryBootAssets bootAssetsMap
 	if sealer != nil {
 		currentTrustedBootAssets = sealer.currentTrustedBootAssetsMap()
+		currentTrustedRecoveryBootAssets = sealer.currentTrustedRecoveryBootAssetsMap()
 	}
 	recoverySystemLabel := filepath.Base(bootWith.RecoverySystemDir)
 	// write modeenv on the ubuntu-data partition
@@ -267,10 +269,9 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		Mode:           "run",
 		RecoverySystem: recoverySystemLabel,
 		// default to the system we were installed from
-		CurrentRecoverySystems:   []string{recoverySystemLabel},
-		CurrentTrustedBootAssets: currentTrustedBootAssets,
-		// TODO:UC20: set current boot assets for recovery
-
+		CurrentRecoverySystems:           []string{recoverySystemLabel},
+		CurrentTrustedBootAssets:         currentTrustedBootAssets,
+		CurrentTrustedRecoveryBootAssets: currentTrustedRecoveryBootAssets,
 		// keep this comment to make gofmt 1.9 happy
 		Base:           filepath.Base(bootWith.BasePath),
 		CurrentKernels: []string{bootWith.Kernel.Filename()},

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -494,12 +494,27 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 		"grub",
 		"grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d",
 	)
+	copiedRecoveryGrubBin := filepath.Join(
+		dirs.SnapBootAssetsDirUnder(boot.InstallHostWritableDir),
+		"grub",
+		"grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5",
+	)
+	copiedRecoveryShimBin := filepath.Join(
+		dirs.SnapBootAssetsDirUnder(boot.InstallHostWritableDir),
+		"grub",
+		"bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37",
+	)
+
 	// only one file in the cache under new root
 	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDirUnder(boot.InstallHostWritableDir), "grub", "*"), []string{
+		copiedRecoveryShimBin,
 		copiedGrubBin,
+		copiedRecoveryGrubBin,
 	})
 	// with the right content
 	c.Check(copiedGrubBin, testutil.FileEquals, "grub content")
+	c.Check(copiedRecoveryGrubBin, testutil.FileEquals, "recovery grub content")
+	c.Check(copiedRecoveryShimBin, testutil.FileEquals, "recovery shim content")
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20RunModeInstallBootConfigErr(c *C) {

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -354,6 +354,18 @@ func (s *makeBootable20Suite) TestMakeBootable20RunMode(c *C) {
 	err = ioutil.WriteFile(mockSeedGrubCfg, nil, 0644)
 	c.Assert(err, IsNil)
 
+	// setup recovery boot assets
+	err = os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot"), 0755)
+	c.Assert(err, IsNil)
+	// SHA3-384: 39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37
+	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
+		[]byte("recovery shim content"), 0644)
+	c.Assert(err, IsNil)
+	// SHA3-384: aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5
+	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
+		[]byte("recovery grub content"), 0644)
+	c.Assert(err, IsNil)
+
 	// grub on ubuntu-boot
 	mockBootGrubDir := filepath.Join(boot.InitramfsUbuntuBootDir, "EFI", "ubuntu")
 	mockBootGrubCfg := filepath.Join(mockBootGrubDir, "grub.cfg")
@@ -425,6 +437,9 @@ version: 5.0
 	_, err = obs.Observe(gadget.ContentWrite, runBootStruct, boot.InitramfsUbuntuBootDir,
 		filepath.Join(unpackedGadgetDir, "grubx64.efi"), "EFI/boot/grubx64.efi")
 	c.Assert(err, IsNil)
+	// observe recovery assets
+	err = obs.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir)
+	c.Assert(err, IsNil)
 
 	err = boot.MakeBootable(model, rootdir, bootWith, obs)
 	c.Assert(err, IsNil)
@@ -472,6 +487,7 @@ current_kernels=pc-kernel_5.snap
 model=my-brand/my-model-uc20
 grade=dangerous
 current_trusted_boot_assets={"grubx64.efi":["5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"]}
+current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"],"grubx64.efi":["aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"]}
 `)
 }
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -154,6 +154,12 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("cannot create partitions: %v", err)
 	}
 
+	if trustedInstallObserver != nil {
+		if err := trustedInstallObserver.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir); err != nil {
+			return fmt.Errorf("cannot observe existing trusted recovery assets: err")
+		}
+	}
+
 	// keep track of the model we installed
 	err = writeModel(deviceCtx.Model(), filepath.Join(boot.InitramfsUbuntuBootDir, "model"))
 	if err != nil {


### PR DESCRIPTION
Add code for observing existing recovery bootloader trusted boot assets. Hook up with devicestate install handler.
