### PR TITLE
tests: work around broken update of systemd-networkd

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -397,11 +397,26 @@ prepare_project() {
     esac
 
     restart_logind=
+    restart_networkd=
     if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -lt 246 ]; then
         restart_logind=maybe
+        restart_networkd=maybe
     fi
 
-    install_pkg_dependencies
+
+    # Try installing package dependencies. Because we pull in some systemd
+    # development packages we can easily pull in a whole systemd upgrade. Most
+    # of the time that's okay but, well, not always.
+    if ! install_pkg_dependencies; then
+        # If this failed, maybe systemd-networkd got busted during the 245-246
+        # upgrade? If so we can just restart it and try again.
+        # This is related to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966612
+        if [ "$restart_networkd" = maybe ]; then
+            systemctl reset-failed systemd-networkd.service
+            systemctl try-restart systemd-networkd.service
+            install_pkg_dependencies
+        fi
+    fi
 
     if [ "$restart_logind" = maybe ]; then
         if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 246 ]; then


### PR DESCRIPTION
New systemd has hit Groovy and upgrading causes networking problems.
Detect the faulty upgrade and work around it.

Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966612
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
