### PR TITLE
many: correctly calculate the desktop file prefix everywhere

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -859,6 +859,7 @@ const commonPrefix = `
 @{SNAP_NAME}="samba"
 # This is a snap name with instance key
 @{SNAP_INSTANCE_NAME}="samba"
+@{SNAP_INSTANCE_DESKTOP}="samba"
 @{SNAP_COMMAND_NAME}="smbd"
 @{SNAP_REVISION}="1"
 @{PROFILE_DBUS}="snap_2esamba_2esmbd"
@@ -1017,6 +1018,7 @@ func (s *backendSuite) TestParallelInstallCombineSnippets(c *C) {
 @{SNAP_NAME}="samba"
 # This is a snap name with instance key
 @{SNAP_INSTANCE_NAME}="samba_foo"
+@{SNAP_INSTANCE_DESKTOP}="samba+foo"
 @{SNAP_COMMAND_NAME}="smbd"
 @{SNAP_REVISION}="1"
 @{PROFILE_DBUS}="snap_2esamba_5ffoo_2esmbd"
@@ -1055,6 +1057,7 @@ func (s *backendSuite) TestTemplateVarsWithHook(c *C) {
 @{SNAP_NAME}="foo"
 # This is a snap name with instance key
 @{SNAP_INSTANCE_NAME}="foo"
+@{SNAP_INSTANCE_DESKTOP}="foo"
 @{SNAP_COMMAND_NAME}="hook.configure"
 @{SNAP_REVISION}="1"
 @{PROFILE_DBUS}="snap_2efoo_2ehook_2econfigure"

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -35,6 +35,7 @@ func templateVariables(info *snap.Info, securityTag string, cmdName string) stri
 	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", info.SnapName())
 	fmt.Fprintf(&buf, "# This is a snap name with instance key\n")
 	fmt.Fprintf(&buf, "@{SNAP_INSTANCE_NAME}=\"%s\"\n", info.InstanceName())
+	fmt.Fprintf(&buf, "@{SNAP_INSTANCE_DESKTOP}=\"%s\"\n", info.DesktopPrefix())
 	fmt.Fprintf(&buf, "@{SNAP_COMMAND_NAME}=\"%s\"\n", cmdName)
 	fmt.Fprintf(&buf, "@{SNAP_REVISION}=\"%s\"\n", info.Revision)
 	fmt.Fprintf(&buf, "@{PROFILE_DBUS}=\"%s\"\n",

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -240,7 +240,7 @@ dbus (send)
 # Support BAMF_DESKTOP_FILE_HINT by allowing reading our desktop files
 # parallel-installs: this leaks read access to desktop files owned by keyed
 # instances of @{SNAP_NAME} to @{SNAP_NAME} snap
-/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
+/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_DESKTOP}_*.desktop r,
 
 # glib-networking's GLib proxy (different than the portal's proxy service
 # org.freedesktop.portal.ProxyResolver)

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -658,15 +658,16 @@ func (iface *unity7Interface) StaticInfo() interfaces.StaticInfo {
 }
 
 func (iface *unity7Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Unity7 will take the desktop filename and convert all '-' (and '.',
-	// but we don't care about that here because the rule above already
-	// does that) to '_'. Since we know that the desktop filename starts
-	// with the snap name, perform this conversion on the snap name.
+	// Unity7 will take the desktop filename and convert all '-' and '+'
+	// (and '.', but we don't care about that here because the rule above
+	// already does that) to '_'. Since we know that the desktop filename
+	// starts with the snap name, perform this conversion on the snap name.
 	//
 	// parallel-installs: UNITY_SNAP_NAME is used in the context of dbus
 	// mediation, this unintentionally opens access to dbus paths of keyed
 	// instances of @{SNAP_NAME} to @{SNAP_NAME} snap
-	new := strings.Replace(plug.Snap().InstanceName(), "-", "_", -1)
+	new := strings.Replace(plug.Snap().DesktopPrefix(), "-", "_", -1)
+	new = strings.Replace(new, "+", "_", -1)
 	old := "###UNITY_SNAP_NAME###"
 	snippet := strings.Replace(unity7ConnectedPlugAppArmor, old, new, -1)
 	spec.AddSnippet(snippet)

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -499,9 +499,9 @@ dbus (receive)
 /var/lib/snapd/desktop/applications/ r,
 /var/lib/snapd/desktop/applications/mimeinfo.cache r,
 # Support BAMF_DESKTOP_FILE_HINT by allowing reading our desktop files
-# parallel-installs: when @{SNAP_INSTANCE_NAME} == @{SNAP_NAME},
+# parallel-installs: when @{SNAP_INSTANCE_DESKTOP} == @{SNAP_NAME},
 # this leaks read access to desktop files of parallel installs of the snap
-/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,
+/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_DESKTOP}_*.desktop r,
 
 # then allow talking to Unity DBus service
 dbus (send)

--- a/snap/info.go
+++ b/snap/info.go
@@ -968,7 +968,7 @@ func (app *AppInfo) SecurityTag() string {
 // DesktopFile returns the path to the installed optional desktop file for the
 // application.
 func (app *AppInfo) DesktopFile() string {
-	return filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_%s.desktop", app.Snap.InstanceName(), app.Name))
+	return filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_%s.desktop", app.Snap.DesktopPrefix(), app.Name))
 }
 
 // WrapperPath returns the path to wrapper invoking the app binary.

--- a/snap/info.go
+++ b/snap/info.go
@@ -596,6 +596,21 @@ func BadInterfacesSummary(snapInfo *Info) string {
 	return strings.TrimSuffix(buf.String(), "; ")
 }
 
+// DesktopPrefix returns the prefix string for the desktop files that
+// belongs to the given snapInstance. We need to do something custom
+// here because a) we need to be compatible with the world before we had
+// parallel installs b) we can't just use the usual "_" parallel installs
+// separator because that is already used as the separator between snap
+// and desktop filename.
+func (s *Info) DesktopPrefix() string {
+	if s.SnapName() == s.InstanceName() {
+		return s.SnapName()
+	}
+	// we cannot use the usual "_" separator because that is also used
+	// to separate "$snap_$desktopfile"
+	return fmt.Sprintf("%s+%s", s.SnapName(), s.InstanceKey)
+}
+
 // DownloadInfo contains the information to download a snap.
 // It can be marshalled.
 type DownloadInfo struct {

--- a/snap/info.go
+++ b/snap/info.go
@@ -603,7 +603,7 @@ func BadInterfacesSummary(snapInfo *Info) string {
 // separator because that is already used as the separator between snap
 // and desktop filename.
 func (s *Info) DesktopPrefix() string {
-	if s.SnapName() == s.InstanceName() {
+	if s.InstanceKey == "" {
 		return s.SnapName()
 	}
 	// we cannot use the usual "_" separator because that is also used

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1105,12 +1105,14 @@ func (s *infoSuite) TestAppDesktopFile(c *C) {
 	c.Check(snapInfo.InstanceName(), Equals, "sample")
 	c.Check(snapInfo.Apps["app"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample_app.desktop`)
 	c.Check(snapInfo.Apps["sample"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample_sample.desktop`)
+	c.Check(snapInfo.DesktopPrefix(), Equals, "sample")
 
 	// snap with instance key
 	snapInfo.InstanceKey = "instance"
 	c.Check(snapInfo.InstanceName(), Equals, "sample_instance")
-	c.Check(snapInfo.Apps["app"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample_instance_app.desktop`)
-	c.Check(snapInfo.Apps["sample"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample_instance_sample.desktop`)
+	c.Check(snapInfo.Apps["app"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample\+instance_app.desktop`)
+	c.Check(snapInfo.Apps["sample"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample\+instance_sample.desktop`)
+	c.Check(snapInfo.DesktopPrefix(), Equals, "sample+instance")
 }
 
 const coreSnapYaml = `name: core

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -235,21 +235,6 @@ func updateDesktopDatabase(desktopFiles []string) error {
 	return nil
 }
 
-// desktopPrefix returns the prefix string for the desktop files that
-// belongs to the given snapInstance. We need to do something custom
-// here because a) we need to be compatible with the world before we had
-// parallel installs b) we can't just use the usual "_" parallel installs
-// separator because that is already used as the separator between snap
-// and desktop filename.
-func desktopPrefix(s *snap.Info) string {
-	if s.SnapName() == s.InstanceName() {
-		return s.SnapName()
-	}
-	// we cannot use the usual "_" separator because that is also used
-	// to separate "$snap_$desktopfile"
-	return fmt.Sprintf("%s+%s", s.SnapName(), s.InstanceKey)
-}
-
 // AddSnapDesktopFiles puts in place the desktop files for the applications from the snap.
 func AddSnapDesktopFiles(s *snap.Info) (err error) {
 	var created []string
@@ -284,7 +269,7 @@ func AddSnapDesktopFiles(s *snap.Info) (err error) {
 		// but we can't just use the app name because a desktop file
 		// may call the same app with multiple parameters, e.g.
 		// --create-new, --open-existing etc
-		installedDesktopFileName := filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_%s", desktopPrefix(s), filepath.Base(df)))
+		installedDesktopFileName := filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_%s", s.DesktopPrefix(), filepath.Base(df)))
 		content = sanitizeDesktopFile(s, installedDesktopFileName, content)
 		if err := osutil.AtomicWriteFile(installedDesktopFileName, content, 0755, 0); err != nil {
 			return err
@@ -304,7 +289,7 @@ func AddSnapDesktopFiles(s *snap.Info) (err error) {
 func RemoveSnapDesktopFiles(s *snap.Info) error {
 	removedDesktopFiles := make([]string, 0, len(s.Apps))
 
-	desktopFiles, err := filepath.Glob(filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_*.desktop", desktopPrefix(s))))
+	desktopFiles, err := filepath.Glob(filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_*.desktop", s.DesktopPrefix())))
 	if err != nil {
 		return nil
 	}

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -181,7 +182,7 @@ func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
 	c.Check(err, NotNil)
 	c.Check(osutil.FileExists(mockDesktopFilePath), Equals, false)
 	c.Check(s.mockUpdateDesktopDatabase.Calls(), HasLen, 0)
-	// foo_instance file was not removed by cleanup
+	// foo+instance file was not removed by cleanup
 	c.Check(osutil.FileExists(mockDesktopInstanceFilePath), Equals, true)
 }
 
@@ -577,6 +578,13 @@ func (s *desktopSuite) TestAddRemoveDesktopFiles(c *C) {
 		err = wrappers.AddSnapDesktopFiles(info)
 		c.Assert(err, IsNil)
 		c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, true)
+
+		// Ensure that the old-style parallel install desktop file was
+		// not created.
+		if t.instance != "" {
+			unexpectedOldStyleDesktopFilePath := strings.Replace(expectedDesktopFilePath, "+", "_", 1)
+			c.Assert(osutil.FileExists(unexpectedOldStyleDesktopFilePath), Equals, false)
+		}
 
 		// remove it again
 		err = wrappers.RemoveSnapDesktopFiles(info)

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -158,7 +158,7 @@ func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
 
-	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance_foobar.desktop")
+	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo+instance_foobar.desktop")
 	err = ioutil.WriteFile(mockDesktopInstanceFilePath, mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 
@@ -405,7 +405,7 @@ Exec=snap.app
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 X-SnapInstanceName=snap_bar
 Name=foo
-Exec=env BAMF_DESKTOP_FILE_HINT=snap_bar_app.desktop %s/bin/snap_bar.app
+Exec=env BAMF_DESKTOP_FILE_HINT=snap+bar_app.desktop %s/bin/snap_bar.app
 `, dirs.SnapMountDir))
 }
 
@@ -429,7 +429,7 @@ Exec=snap.app %U
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 X-SnapInstanceName=snap_bar
 Name=foo
-Exec=env BAMF_DESKTOP_FILE_HINT=snap_bar_app.desktop %s/bin/snap_bar.app %%U
+Exec=env BAMF_DESKTOP_FILE_HINT=snap+bar_app.desktop %s/bin/snap_bar.app %%U
 `, dirs.SnapMountDir))
 }
 
@@ -540,7 +540,7 @@ Exec=snap.app
 X-SnapInstanceName=snap_bar
 Name=foo
 Icon=snap.snap_bar.icon
-Exec=env BAMF_DESKTOP_FILE_HINT=snap_bar_app.desktop %s/bin/snap_bar.app
+Exec=env BAMF_DESKTOP_FILE_HINT=snap+bar_app.desktop %s/bin/snap_bar.app
 `, dirs.SnapMountDir))
 }
 


### PR DESCRIPTION
@jhenstridge discovered that the AppArmor policy for parallel installs did
not have the correct rule for desktop files since wrappers/desktop.go's
move to desktopPrefix().

* move wrappers/desktop.go:desktopPrefix() to snap/info.go:DesktopPrefix()
* snap/info: DesktopFile() should use DesktopPrefix()
* add SNAP_INSTANCE_DESKTOP template var and use it
* unity7: indicator-messages also converts '+' to '_'

See individual commits for additional details.

References:
- https://github.com/snapcore/snapd/pull/8301#discussion_r462017029