### PR TITLE
secboot,cmd/snap-bootstrap: don't import boot package from secboot

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -271,7 +271,7 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 	}
 	if !isRecoverDataMounted {
 		const lockKeysForLast = true
-		device, err := secbootUnlockVolumeIfEncrypted("ubuntu-data", lockKeysForLast)
+		device, err := secbootUnlockVolumeIfEncrypted("ubuntu-data", boot.InitramfsEncryptionKeyDir, lockKeysForLast)
 		if err != nil {
 			return err
 		}
@@ -446,7 +446,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 	}
 	if !isDataMounted {
 		const lockKeysForLast = true
-		device, err := secbootUnlockVolumeIfEncrypted("ubuntu-data", lockKeysForLast)
+		device, err := secbootUnlockVolumeIfEncrypted("ubuntu-data", boot.InitramfsEncryptionKeyDir, lockKeysForLast)
 		if err != nil {
 			return err
 		}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -256,7 +256,7 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 
 	// 3. mount ubuntu-data for recovery
 	const lockKeysForLast = true
-	device, err := secbootUnlockVolumeIfEncrypted("ubuntu-data", lockKeysForLast)
+	device, err := secbootUnlockVolumeIfEncrypted("ubuntu-data", boot.InitramfsEncryptionKeyDir, lockKeysForLast)
 	if err != nil {
 		return err
 
@@ -391,7 +391,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 
 	// 3.2. mount Data
 	const lockKeysForLast = true
-	device, err := secbootUnlockVolumeIfEncrypted("ubuntu-data", lockKeysForLast)
+	device, err := secbootUnlockVolumeIfEncrypted("ubuntu-data", boot.InitramfsEncryptionKeyDir, lockKeysForLast)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1561,8 +1561,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 	defer restore()
 
 	activated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(name string, lockKeysOnFinish bool) (string, error) {
+	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(name, encryptionKeyDir string, lockKeysOnFinish bool) (string, error) {
 		c.Assert(name, Equals, "ubuntu-data")
+		c.Assert(encryptionKeyDir, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde"))
 		c.Assert(lockKeysOnFinish, Equals, true)
 		activated = true
 		return "path-to-device", nil

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -81,7 +81,7 @@ func MockDefaultMarkerFile(p string) (restore func()) {
 	}
 }
 
-func MockSecbootUnlockVolumeIfEncrypted(f func(name string, lockKeysOnFinish bool) (string, error)) (restore func()) {
+func MockSecbootUnlockVolumeIfEncrypted(f func(name, encryptionKeyDir string, lockKeysOnFinish bool) (string, error)) (restore func()) {
 	old := secbootUnlockVolumeIfEncrypted
 	secbootUnlockVolumeIfEncrypted = f
 	return func() {

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -32,7 +32,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader/efi"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -181,7 +180,7 @@ func MeasureSnapModelWhenPossible(findModel func() (*asserts.Model, error)) erro
 // name exists and unlocks it. With lockKeysOnFinish set, access to the sealed
 // keys will be locked when this function completes. The path to the unencrypted
 // device node is returned.
-func UnlockVolumeIfEncrypted(name string, lockKeysOnFinish bool) (string, error) {
+func UnlockVolumeIfEncrypted(name, encryptionKeyDir string, lockKeysOnFinish bool) (string, error) {
 	// TODO:UC20: use sb.SecureConnectToDefaultTPM() if we decide there's benefit in doing that or
 	//            we have a hard requirement for a valid EK cert chain for every boot (ie, panic
 	//            if there isn't one). But we can't do that as long as we need to download
@@ -229,7 +228,7 @@ func UnlockVolumeIfEncrypted(name string, lockKeysOnFinish bool) (string, error)
 		//            we expect (and not e.g. an external disk), and also that
 		//            <name> is from <name>-enc and not an unencrypted partition
 		//            with the same name (LP #1863886)
-		sealedKeyPath := filepath.Join(boot.InitramfsEncryptionKeyDir, name+".sealed-key")
+		sealedKeyPath := filepath.Join(encryptionKeyDir, name+".sealed-key")
 		return unlockEncryptedPartitionWithSealedKey(tpm, mapperName, encdev, sealedKeyPath, "", lockKeysOnFinish)
 	}()
 	if err != nil {

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -377,7 +377,7 @@ func (s *secbootSuite) TestUnlockIfEncrypted(c *C) {
 		})
 		defer restore()
 
-		device, err := secboot.UnlockVolumeIfEncrypted("name", tc.lockRequest)
+		device, err := secboot.UnlockVolumeIfEncrypted("name", boot.InitramfsEncryptionKeyDir, tc.lockRequest)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 		} else {


### PR DESCRIPTION
As part of the reseal infrastructure changes, key sealing will be moved
from gadget/install to boot. The boot package shouldn't import secboot
to avoid an import cycle.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
