### PR TITLE
[RFC] config: "virtual" configuration for timezone

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -59,6 +59,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/servicestate"
@@ -1603,6 +1604,8 @@ func getSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 	s.Lock()
 	tr := config.NewTransaction(s)
 	s.Unlock()
+	// ensure configcore can hijack requests to e.g. hostname
+	configcore.RegisterHijackers(tr)
 
 	currentConfValues := make(map[string]interface{})
 	// Special case - return root document

--- a/overlord/configstate/configcore/export_test.go
+++ b/overlord/configstate/configcore/export_test.go
@@ -48,3 +48,8 @@ func MockChownPath(f func(string, sys.UserID, sys.GroupID) error) func() {
 		sysChownPath = old
 	}
 }
+
+var (
+	HijackedCoreCfg = hijackedCoreCfg
+	ValidTimezone   = validTimezone
+)

--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -48,6 +49,8 @@ func ContextTransaction(context *hookstate.Context) *config.Transaction {
 
 	// It wasn't already cached, so create and cache a new one
 	tr = config.NewTransaction(context.State())
+	// ensure configcore can hijack requests to e.g. hostname
+	configcore.RegisterHijackers(tr)
 
 	context.OnDone(func() error {
 		tr.Commit()

--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -141,5 +141,11 @@ execute: |
     echo "setting the timezone works"
     cat /etc/timezone > current-timezone
     snap set system system.timezone=Europe/Malta
-    MATCH "Europe/Malta" /etc/timezone
+    MATCH "Europe/Malta" < /etc/timezone
     test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/Europe/Malta"
+    echo "but the timezone setting is not stored in the state"
+    snap get system -d | not grep "timezone"
+
+    echo "and setting the timezone outside of snapd is reflected by snap get"
+    timedatectl set-timezone "America/Denver"
+    snap get system system.timezone | MATCH "America/Denver"


### PR DESCRIPTION
This PR implements "virtual" configuration, i.e. the ability to get/set certain configuration options directly from the system instead of retrieving/storing in the state.

Use cases for this are: timezone, hostname, netplan config, pi config

This means that e.g.
```
$ snap set system system.timezone=UTC
$ snap get system system.timezone
UTC
$ timedatectl set-timezone Europe/Berlin
$ snap get system system.timezone
Europe/Berlin
```
works as expected (this will not work right and the last command yield a wrong result).

The PR itself consists of two commits, the first implements "hijacking" of config values. The second commit uses this mechanism to implement the mechanism for `system.timezone`.

There is some room for making this nicer, especially the integration part inside corecfg
and some more tests. But I don't want to spend too much time on this before Samuele
had a chance to double-check the design.