### PR TITLE
tests: update spread test for unknown plug/slot with snapctl is-connected

### DIFF
--- a/tests/main/snapctl-is-connected/task.yaml
+++ b/tests/main/snapctl-is-connected/task.yaml
@@ -35,6 +35,7 @@ execute: |
   OUT=$(test-snap.checkconn network 2>&1 || true)
   check_empty "$OUT"
 
-  if test-snap.checkconn home; then
+  if OUT=$(test-snap.checkconn home 2>&1); then
     echo "home is not expected"
   fi
+  echo "$OUT" | MATCH "error running snapctl: snap \"test-snap\" has no plug or slot named \"home\""


### PR DESCRIPTION
Update snapctl is-connected spread test to check new error introduced with #9168 (will fail until that PR lands).
