### PR TITLE
cmd: compile snap gdbserver shim correctly

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -494,7 +494,7 @@ snap_gdb_shim_snap_gdb_shim_LDADD = libsnap-confine-private.a
 
 libexec_PROGRAMS += snap-gdb-shim/snap-gdbserver-shim
 
-snap_gdb_shim_snap_gdb_shim_SOURCES = \
+snap_gdb_shim_snap_gdbserver_shim_SOURCES = \
 	snap-gdb-shim/snap-gdbserver-shim.c
 
 snap_gdb_shim_snap_gdbserver_shim_LDADD = libsnap-confine-private.a


### PR DESCRIPTION
When building with ./configure --enable-silent-rules automake complains
that a SOURCES variable has multiple definitions:

    Makefile.am:497: warning: snap_gdb_shim_snap_gdb_shim_SOURCES multiply defined in condition TRUE ...
    Makefile.am:486: ... 'snap_gdb_shim_snap_gdb_shim_SOURCES' previously defined here

Indeed the gdb shim and gdbserver shim were defined incorrectly. It
seems we have not compiled or tested this code for real before. Whoops.

Ref: https://listed.zygoon.pl/17493/signal-to-noise-ratio-in-build-systems
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
