### PR TITLE
tests: fix lxd test wrongly tracking 'latest'

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -92,8 +92,9 @@ execute: |
     # prep two containers, the my-ubuntu normal container and the
     # my-nesting-ubuntu nesting container
 
-    lxd.lxc launch --quiet "ubuntu:${VERSION_ID:-}" my-ubuntu
-    lxd.lxc launch --quiet "ubuntu:${VERSION_ID:-}" my-nesting-ubuntu -c security.nesting=true
+    VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
+    lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-ubuntu
+    lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-nesting-ubuntu -c security.nesting=true
     if [ "$(uname -m)" = x86_64 ] && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then
         echo "LXD spawned 32bit userspace container on a 64bit host, WAT?"
         snap info lxd


### PR DESCRIPTION
The test tests/main/lxd was silently corrupted by
d4a802934b1e62ec8924ea1c165a627695df5044 which removed the assignment of
VERSION_ID, based on what is present on the host system. This made us
expand "${VERSION_ID:-}" to nothing, which effectively meant we were
tracking latest stable ubuntu, instead of getting an image matching the
host of the container.

As an unrelated bug, it does seem that the new focal image is somehow
broken. While we investigate that error, we should fix this one. Load
VERSION_ID from /etc/os-release and use variable expansion syntax
that does not mask undefined variables.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
