### PR TITLE
tests: find -ignore_readdir_race when scanning cgroups

### DIFF
--- a/tests/main/snap-confine-undesired-mode-group/task.yaml
+++ b/tests/main/snap-confine-undesired-mode-group/task.yaml
@@ -18,14 +18,17 @@ execute: |
     # the group of the calling user and did not manage that properly.
     for dname in /run/snapd /sys/fs/cgroup /tmp/snap.*; do
         # Filter out cgroups that are expected to be owned by the test user.
-        find "$dname" -user test ! -path '*/user@12345.service*' ! -path '*/user-12345.slice*' >> wrong-user.txt
-        find "$dname" -group test ! -path '*/user@12345.service*' ! -path '*/user-12345.slice*' >> wrong-group.txt
+        # Since we are a looking at sysfs, which is modified asynchronously,
+        # ignore errors of the kind where readdir and stat race with a
+        # concurrent mutator.
+        find "$dname" -ignore_readdir_race -user test ! -path '*/user@12345.service*' ! -path '*/user-12345.slice*' >> wrong-user.txt
+        find "$dname" -ignore_readdir_race -group test ! -path '*/user@12345.service*' ! -path '*/user-12345.slice*' >> wrong-group.txt
         # Filter out the following elements:
         # - sockets, we don't create any and there are some that are 777
         # - symbolic links, those are always 777
         # - the file cgroup.event_control which is ugo+w for some reason
         # - the per-snap tmp directory as it is meant to be world-writable
-        find "$dname" ! -type s ! -type l ! -name cgroup.event_control ! -path '/tmp/snap.*/tmp' -perm /o+w >> world-writable.txt
+        find "$dname" -ignore_readdir_race ! -type s ! -type l ! -name cgroup.event_control ! -path '/tmp/snap.*/tmp' -perm /o+w >> world-writable.txt
     done
 
     # The test fails if any such file is detected


### PR DESCRIPTION
I noticed a random failure of the test
snap-confine-undesired-mode-cgroup that can be explained by a concurrent
modification of the /sys/fs/cgroup directory (most likely by systemd).
The error looked like this, note that find(1) failed to find a cgroup
directory related to kbdsettings.service - a suse-specific, short-lived
service that sets up keyboard configuration such as delay and repeat
rate.

    Error executing google:opensuse-tumbleweed-64:tests/main/snap-confine-undesired-mode-group:
    -----
    + su test -c 'snap run test-snapd-app.sh -c /bin/true'
    + for dname in /run/snapd /sys/fs/cgroup /tmp/snap.*
    + find /run/snapd -user test '!' -path '*/user@12345.service*' '!' -path '*/user-12345.slice*'
    + find /run/snapd -group test '!' -path '*/user@12345.service*' '!' -path '*/user-12345.slice*'
    + find /run/snapd '!' -type s '!' -type l '!' -name cgroup.event_control '!' -path '/tmp/snap.*/tmp' -perm /o+w
    + for dname in /run/snapd /sys/fs/cgroup /tmp/snap.*
    + find /sys/fs/cgroup -user test '!' -path '*/user@12345.service*' '!' -path '*/user-12345.slice*'
    find: ‘/sys/fs/cgroup/unified/system.slice/kbdsettings.service’: No such file or directory

This can happen when find(1) uses readdir reports a file name but the
file is removed before find can stat it. For this purpose, find sports
the option -ignore_readdir_race which makes that error silently ignored.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
