### PR TITLE
cmd/snapd-generator: use PATH fallback if PATH is not set

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -144,6 +144,7 @@ execute: |
 
     echo "Sanity check that mount overrides were generated inside the container"
     lxd.lxc exec my-ubuntu -- find /var/run/systemd/generator/ -name container.conf | MATCH "/var/run/systemd/generator/snap-core-.*mount.d/container.conf"
+    lxd.lxc exec my-ubuntu -- test -f /var/run/systemd/generator/snap.mount
 
     # Ensure that we can run lxd as a snap inside a nested container
 


### PR DESCRIPTION
PATH is not set in systemd generators on 16.04 but the problem was masked by the issue with lxd test (now fixed in master).
This should unbreak master.