### PR TITLE
github: use latest/stable go, not latest/edge

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         gochannel:
           - 1.9
-          - latest/edge
+          - latest/stable
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
It seems revision 6315 is somehow busted, as go tries to write to
/snap/go/6312/pkg/linux_amd64/runtime.a. For more stability, follow
latest/stable instead.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
