### PR TITLE
tests: disable udisks2 test on arch linux

### DIFF
--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -5,7 +5,9 @@ details: |
 
 # Interfaces not defined for ubuntu core systems
 # FIXME: fails in debian-sid for unknown reasons
-systems: [-ubuntu-core-*, -debian-sid-*]
+# FIXME: `udisksctl mount -b  "$device"` fails on arch with:
+#   Object /org/freedesktop/UDisks2/block_devices/loop200 is not a mountable filesystem.
+systems: [-ubuntu-core-*, -debian-sid-*, -arch-linux-*]
 
 prepare: |
     snap install test-snapd-udisks2


### PR DESCRIPTION
The udisks2 interface test fails on arch linux currently. This
is not a problem with the confinement, even the unconfined command
fails. But running plain "mount" works:
```
$ udisksctl mount -b  "$device"
Object /org/freedesktop/UDisks2/block_devices/loop200 is not a mountable filesystem.
$ mount   "$device" $(mktemp -d tmp-mount.XXXXXXXXXX)
$ udisksctl mount -b  "$device"
Error mounting /dev/loop200: GDBus.Error:org.freedesktop.UDisks2.Error.AlreadyMounted: Device /dev/loop200 is already mounted at `/home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-udisks2/tmp-mount.jDJmsK2fZF'.
$ ls /home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-udisks2/tmp-mount.jDJmsK2fZF
lost+found
```
so it seems udisks2 is currently broken in arch.
