### PR TITLE
tests: re-enable udisks test on debian-sid

### DIFF
--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -4,10 +4,9 @@ details: |
     The udisks2 interface allows operating as or interacting with the UDisks2 service
 
 # Interfaces not defined for ubuntu core systems
-# FIXME: fails in debian-sid for unknown reasons
 # FIXME: `udisksctl mount -b  "$device"` fails on arch with:
 #   Object /org/freedesktop/UDisks2/block_devices/loop200 is not a mountable filesystem.
-systems: [-ubuntu-core-*, -debian-sid-*, -arch-linux-*]
+systems: [-ubuntu-core-*, -arch-linux-*]
 
 prepare: |
     snap install test-snapd-udisks2


### PR DESCRIPTION
The debian-sid test of udisks is working again. Let's re-enable it.
