### PR TITLE
tests: use "set -ex" in prep-snapd-in-lxd.sh

### DIFF
--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -ex
+#!/bin/sh
+
+set -ex
 
 apt autoremove --purge -y snapd ubuntu-core-launcher
 apt update

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -123,7 +123,7 @@ execute: |
         fi
 
         echo "Install snapd in container"
-        lxd.lxc exec $cont_name -- /bin/bash /root/prep-snapd-in-lxd.sh
+        lxd.lxc exec $cont_name -- /root/prep-snapd-in-lxd.sh
         lxd.lxc exec $cont_name -- snap set system experimental.refresh-app-awareness=$REFRESH_APP_AWARENESS_INNER
     done
 
@@ -178,7 +178,7 @@ execute: |
     fi
     lxd.lxc exec my-nesting-ubuntu -- \
         lxd.lxc exec my-inner-ubuntu -- \
-            /bin/bash /root/prep-snapd-in-lxd.sh
+            /root/prep-snapd-in-lxd.sh
 
     not lxd.lxc exec my-nesting-ubuntu -- \
         lxd.lxc exec my-inner-ubuntu -- \


### PR DESCRIPTION
We got some confusing test failures in the lxd test. It turns
out the "purge" in the nested container fail. But we did not
notice because the script `prep-snapd-in-lxd.sh` has
```
#!/bin/sh -ex
...
```
but we run the script via:
```
lxd.lxc exec $cont_name -- /bin/bash /root/prep-snapd-in-lxd.sh
```
so the `-e` is never set.

