### PR TITLE
packaging: umount /snap on purge in containers

### DIFF
--- a/packaging/debian-sid/snapd.postrm
+++ b/packaging/debian-sid/snapd.postrm
@@ -126,6 +126,12 @@ if [ "$1" = "purge" ]; then
         umount -l /run/snapd/ns/ || true
     fi
 
+    # inside containers we have a generator that creates a bind mount to /snap
+    if [ -e /run/systemd/container ]; then
+        echo "Unmount /snap inside a container"
+        umount /snap || true
+    fi
+
     echo "Removing extra snap-confine apparmor rules"
     rm -f /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine
 

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -126,6 +126,12 @@ if [ "$1" = "purge" ]; then
         umount -l /run/snapd/ns/ || true
     fi
 
+    # inside containers we have a generator that creates a bind mount to /snap
+    if [ -e /run/systemd/container ]; then
+        echo "Unmount /snap inside a container"
+        umount /snap || true
+    fi
+
     echo "Removing extra snap-confine apparmor rules"
     rm -f /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine
 

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -136,6 +136,9 @@ if [ "$1" = "purge" ]; then
         umount -l /run/snapd/ns/ || true
     fi
 
+    echo "Unmount /snap"
+    umount /snap || true
+
     echo "Removing extra snap-confine apparmor rules"
     rm -f /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine
 

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -136,8 +136,11 @@ if [ "$1" = "purge" ]; then
         umount -l /run/snapd/ns/ || true
     fi
 
-    echo "Unmount /snap"
-    umount /snap || true
+    # inside containers we have a generator that creates a bind mount to /snap
+    if [ -e /run/systemd/container ]; then
+        echo "Unmount /snap inside a container"
+        umount /snap || true
+    fi
 
     echo "Removing extra snap-confine apparmor rules"
     rm -f /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine

--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+# ensure /snap can be removed by the "apt purge snapd" later
+umount /snap || true
+
 apt autoremove --purge -y snapd ubuntu-core-launcher
 apt update
 

--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -2,8 +2,12 @@
 
 set -ex
 
-# ensure /snap can be removed by the "apt purge snapd" later
-umount /snap || true
+# XXX: remove once the "umount /snap" change in postrm has propagated all
+#      the way to the image
+if [ -e /var/lib/dpkg/info/snapd.postrm ]; then
+    # ensure we can umount /snap
+    sed -i 's#echo "Final directory cleanup"#umount /snap || true#' /var/lib/dpkg/info/snapd.postrm
+fi
 
 apt autoremove --purge -y snapd ubuntu-core-launcher
 apt update

--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -17,7 +17,9 @@ apt update
 apt install -y /root/snapd_*.deb
 
 # reload to take effect of the proxy that may have been set before this script
-systemctl daemon-reload
+# XXX: systemctl daemon-reload times out in 16.04:my-nesting-lxd but every
+#      appears to be working normally
+systemctl daemon-reload || true
 systemctl restart snapd.service
 
 # wait for snapd to finish seeding


### PR DESCRIPTION
We observed a bunch of failures inside the lxd snap test. It
looks like there is a mountpoint on top of /snap that keeps
the directory busy. By umounting /snap this works. This is
very much a proof-of-concept at this point, we should probably
look at making this umount a bit more clever and less blunt.

This may make tests great again.