### PR TITLE
interfaces: add vcio interface

### DIFF
--- a/interfaces/builtin/vcio.go
+++ b/interfaces/builtin/vcio.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+// https://docs.broadcom.com/doc/12358545
+// https://github.com/raspberrypi/linux/tree/rpi-5.4.y/drivers/char/broadcom
+const vcioSummary = `allows access to VideoCore I/O`
+
+// The raspberry pi allows programming its GPU from userspace via the /dev/vcio
+// device. These operations should be considered privileged since the driver
+// assumes trusted input, therefore require manual connection.
+const vcioBaseDeclarationSlots = `
+  vcio:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const vcioConnectedPlugAppArmor = `
+# Description: Can access to vcio.
+
+# vcio v1 access to ARM VideoCore (BCM_VCIO) for userspace GPU programming
+/dev/vcio rw,
+/sys/devices/virtual/bcm2708_vcio/vcio/** r,
+/run/udev/data/c248:[0-9]* r,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "vcio",
+		summary:               vcioSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  vcioBaseDeclarationSlots,
+		connectedPlugAppArmor: vcioConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/vcio.go
+++ b/interfaces/builtin/vcio.go
@@ -43,6 +43,10 @@ const vcioConnectedPlugAppArmor = `
 /run/udev/data/c248:[0-9]* r,
 `
 
+var vcioConnectedPlugUDev = []string{
+	`SUBSYSTEM=="bcm2708_vcio", KERNEL=="vcio"`,
+}
+
 func init() {
 	registerIface(&commonInterface{
 		name:                  "vcio",
@@ -51,5 +55,6 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  vcioBaseDeclarationSlots,
 		connectedPlugAppArmor: vcioConnectedPlugAppArmor,
+		connectedPlugUDev:     vcioConnectedPlugUDev,
 	})
 }

--- a/interfaces/builtin/vcio.go
+++ b/interfaces/builtin/vcio.go
@@ -40,7 +40,12 @@ const vcioConnectedPlugAppArmor = `
 # vcio v1 access to ARM VideoCore (BCM_VCIO) for userspace GPU programming
 /dev/vcio rw,
 /sys/devices/virtual/bcm2708_vcio/vcio/** r,
-/run/udev/data/c248:[0-9]* r,
+# the vcio driver uses dynamic allocation for its major number and
+# https://www.kernel.org/doc/Documentation/admin-guide/devices.txt lists
+# 234-254 char as "RESERVED FOR DYNAMIC ASSIGNMENT".
+/run/udev/data/c23[4-9]:[0-9]* r,
+/run/udev/data/c24[0-9]:[0-9]* r,
+/run/udev/data/c25[0-4]:[0-9]* r,
 `
 
 var vcioConnectedPlugUDev = []string{

--- a/interfaces/builtin/vcio_test.go
+++ b/interfaces/builtin/vcio_test.go
@@ -1,0 +1,92 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type VcioInterfaceSuite struct {
+	iface        interfaces.Interface
+	coreSlotInfo *snap.SlotInfo
+	coreSlot     *interfaces.ConnectedSlot
+	plugInfo     *snap.PlugInfo
+	plug         *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&VcioInterfaceSuite{
+	iface: builtin.MustInterface("vcio"),
+})
+
+const vcioConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [vcio]
+`
+
+const vcioCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  vcio:
+`
+
+func (s *VcioInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, vcioConsumerYaml, nil, "vcio")
+	s.coreSlot, s.coreSlotInfo = MockConnectedSlot(c, vcioCoreYaml, nil, "vcio")
+}
+
+func (s *VcioInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "vcio")
+}
+
+func (s *VcioInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.coreSlotInfo), IsNil)
+}
+
+func (s *VcioInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *VcioInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/vcio rw,`)
+}
+
+func (s *VcioInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to VideoCore I/O`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *VcioInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/vcio_test.go
+++ b/interfaces/builtin/vcio_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -77,6 +78,15 @@ func (s *VcioInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/vcio rw,`)
+}
+
+func (s *VcioInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `# vcio
+SUBSYSTEM=="bcm2708_vcio", KERNEL=="vcio", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
 }
 
 func (s *VcioInterfaceSuite) TestStaticInfo(c *C) {

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -422,6 +422,9 @@ apps:
   upower-observe:
     command: bin/run
     plugs: [ upower-observe ]
+  vcio:
+    command: bin/run
+    plugs: [ vcio ]
   wayland:
     command: bin/run
     plugs: [ wayland ]


### PR DESCRIPTION
The raspberry pi allows programming its GPU (eg, for deep learning, etc)
from userspace via the /dev/vcio device (this is separate from the vcio2
driver which allows similar programming without being root). Because
there is only limited input validation by the driver, manually connect
for now.

References:
- https://github.com/raspberrypi/linux/tree/rpi-5.4.y/drivers/char/broadcom
- https://github.com/raspberrypi/linux/pull/1097
- https://github.com/raspberrypi/linux/wiki/Upstreaming
- https://docs.broadcom.com/doc/12358545
- https://petewarden.com/2014/08/07/how-to-optimize-raspberry-pi-code-using-its-gpu/

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
