### PR TITLE
tests/lib/nested.sh: use more robust code for finding what loop dev we mounted

### DIFF
--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -8,5 +8,4 @@ defaults:
     system:
       power-key-action: ignore
       disable-backlight-service: true
-    system:
       timezone: Europe/Malta


### PR DESCRIPTION
This is what is done for the same purpose in prepare.sh in reflash_magic. I have seen some nested tests fail because they raced with the loop device creation and lost.

Also make the nested.sh file use -e to exit on errors.

Also fix a typo introduced by #9102 which broke the early config core20 test.