### PR TITLE
interfaces: misc policy updates xlvi

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -99,8 +99,11 @@
     # '/'. Use 'unsafe' to support snap-exec on armhf and its reliance on
     # the environment for determining the capabilities of the architecture.
     # 'unsafe' is ok here because the kernel will have already cleared the
-    # environment as part of launching snap-confine with
-    # CAP_SYS_ADMIN.
+    # environment as part of launching snap-confine with CAP_SYS_ADMIN. This
+    # does leave directories as configured by ld.so.preload as well as
+    # LD_PRELOAD to be set to a library which is in a directory configured by
+    # ld.so.conf, but access to those locations is mediated by this profile
+    # (which requires rules for specific locations).
     change_profile unsafe /** -> [^u/]**,
     change_profile unsafe /** -> u[^n]**,
     change_profile unsafe /** -> un[^c]**,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -111,6 +111,8 @@ var templateCommon = `
 
   # for perl apps/services
   #include <abstractions/perl>
+  # Missing from perl abstraction
+  /usr/lib/@{multiarch}/perl{,5,-base}/auto/**.so* mr,
 
   # Note: the following dangerous accesses should not be allowed in most
   # policy, but we cannot explicitly deny since other trusted interfaces might

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -278,8 +278,12 @@ var templateCommon = `
   # unprivilged, dedicated user).
   /run/uuidd/request rw,
   /sys/devices/virtual/tty/{console,tty*}/active r,
-  /sys/fs/cgroup/memory/memory.limit_in_bytes r,
+  /sys/fs/cgroup/memory/{,user.slice/}memory.limit_in_bytes r,
   /sys/fs/cgroup/memory/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.limit_in_bytes r,
+  /sys/fs/cgroup/cpu,cpuacct/{,user.slice/}cpu.cfs_{period,quota}_us r,
+  /sys/fs/cgroup/cpu,cpuacct/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/cpu.cfs_{period,quota}_us r,
+  /sys/fs/cgroup/cpu,cpuacct/{,user.slice/}cpu.shares r,
+  /sys/fs/cgroup/cpu,cpuacct/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/cpu.shares r,
   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
   /sys/module/apparmor/parameters/enabled r,
   /{,usr/}lib/ r,

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -253,6 +253,20 @@ deny /var/lib/snapd/desktop/icons/{,**/} r,
 # we have better XDG_DATA_DIRS handling, silence these noisy denials.
 # https://github.com/snapcrafters/discord/issues/23#issuecomment-637607843
 deny @{HOME}/.local/share/flatpak/exports/share/** r,
+
+# Allow access to the IBus portal (IBUS_USE_PORTAL=1)
+dbus (send)
+      bus=session
+      path=/org/freedesktop/IBus
+      interface=org.freedesktop.IBus.Portal
+      member=CreateInputContext
+      peer=(name=org.freedesktop.portal.IBus),
+
+dbus (send, receive)
+      bus=session
+      path=/org/freedesktop/IBus/InputContext_[0-9]*
+      interface=org.freedesktop.IBus.InputContext
+      peer=(label=unconfined),
 `
 
 type desktopInterface struct {

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -243,7 +243,9 @@ dbus (send)
 /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_DESKTOP}_*.desktop r,
 
 # glib-networking's GLib proxy (different than the portal's proxy service
-# org.freedesktop.portal.ProxyResolver)
+# org.freedesktop.portal.ProxyResolver). The Lookup API allows specifying
+# various URLs (eg, file://, http:// and https://) which will be given to the
+# unconfined glib-pacrunner.
 dbus (send)
     bus=session
     path=/org/gtk/GLib/PACRunner

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -250,6 +250,89 @@ dbus (send)
     interface=org.gtk.GLib.PACRunner
     member=Lookup
     peer=(label=unconfined),
+
+# app-indicators
+dbus (send)
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(name=org.kde.StatusNotifierWatcher, label=unconfined),
+
+dbus (send)
+    bus=session
+    path=/org/freedesktop/DBus
+    interface=org.freedesktop.DBus
+    member="{GetConnectionUnixProcessID,RequestName,ReleaseName}"
+    peer=(name=org.freedesktop.DBus, label=unconfined),
+
+dbus (bind)
+    bus=session
+    name=org.kde.StatusNotifierItem-[0-9]*,
+
+dbus (send)
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.freedesktop.DBus.Properties
+    member=Get
+    peer=(name=org.kde.StatusNotifierWatcher, label=unconfined),
+
+dbus (send)
+    bus=session
+    path=/{StatusNotifierWatcher,org/ayatana/NotificationItem/*}
+    interface=org.kde.StatusNotifierWatcher
+    member=RegisterStatusNotifierItem
+    peer=(label=unconfined),
+
+dbus (send)
+    bus=session
+    path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
+    interface=org.kde.StatusNotifierItem
+    member="New{AttentionIcon,Icon,IconThemePath,OverlayIcon,Status,Title,ToolTip}"
+    peer=(name=org.freedesktop.DBus, label=unconfined),
+
+dbus (receive)
+    bus=session
+    path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
+    interface=org.kde.StatusNotifierItem
+    member={Activate,ContextMenu,Scroll,SecondaryActivate,XAyatanaSecondaryActivate}
+    peer=(label=unconfined),
+
+dbus (send)
+    bus=session
+    path=/{StatusNotifierItem/menu,org/ayatana/NotificationItem/*/Menu}
+    interface=com.canonical.dbusmenu
+    member="{LayoutUpdated,ItemsPropertiesUpdated}"
+    peer=(name=org.freedesktop.DBus, label=unconfined),
+
+dbus (receive)
+    bus=session
+    path=/{StatusNotifierItem,StatusNotifierItem/menu,org/ayatana/NotificationItem/**}
+    interface={org.freedesktop.DBus.Properties,com.canonical.dbusmenu}
+    member={Get*,AboutTo*,Event*}
+    peer=(label=unconfined),
+
+# notifications
+dbus (send)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.Notifications
+    member="{GetCapabilities,GetServerInformation,Notify,CloseNotification}"
+    peer=(label=unconfined),
+
+dbus (receive)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.Notifications
+    member={ActionInvoked,NotificationClosed,NotificationReplied}
+    peer=(label=unconfined),
+
+dbus (send)
+    bus=session
+    path=/org/ayatana/NotificationItem/*
+    interface=org.kde.StatusNotifierItem
+    member=XAyatanaNew*
+    peer=(name=org.freedesktop.DBus, label=unconfined),
 `
 
 const desktopLegacyConnectedPlugSecComp = `

--- a/interfaces/builtin/network_manager_observe.go
+++ b/interfaces/builtin/network_manager_observe.go
@@ -137,6 +137,12 @@ dbus (receive)
     peer=(label=###SLOT_SECURITY_TAGS###),
 dbus (receive)
     bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.NetworkManager
+    member=PropertiesChanged
+    peer=(label=###SLOT_SECURITY_TAGS###),
+dbus (receive)
+    bus=system
     path="/org/freedesktop/NetworkManager{,/{ActiveConnection,Devices}/*}"
     interface="org.freedesktop.NetworkManger{,.*}"
     member=StateChanged

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -58,8 +58,12 @@ const openglConnectedPlugAppArmor = `
 # Main bi-arch GL libraries
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}{,nvidia*/}lib{GL,GLU,GLESv1_CM,GLESv2,EGL,GLX}.so{,.*} rm,
 
+# Allow access to all cards since a) this is common on hybrid systems, b) ARM
+# devices commonly have two devices (such as on the Raspberry Pi 4, one for KMS
+# and another that does not) and c) there is nothing saying that /dev/dri/card0
+# is the default card or the application is currently using.
 /dev/dri/ r,
-/dev/dri/card0 rw,
+/dev/dri/card[0-9]* rw,
 
 # nvidia
 /etc/vdpau_wrapper.cfg r,

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -61,6 +61,7 @@ socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 
 var rawusbConnectedPlugUDev = []string{
 	`SUBSYSTEM=="usb"`,
+	`SUBSYSTEM=="usbmisc"`,
 	`SUBSYSTEM=="tty", ENV{ID_BUS}=="usb"`,
 }
 

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -43,7 +43,7 @@ const rawusbConnectedPlugAppArmor = `
 # Allow detection of usb devices. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,
 /sys/devices/pci**/usb[0-9]** r,
-/sys/devices/platform/soc/*.usb/usb[0-9]** r,
+/sys/devices/platform/{sbc,soc}/*.usb/usb[0-9]** r,
 
 /run/udev/data/c16[67]:[0-9] r, # ACM USB modems
 /run/udev/data/b180:*    r, # various USB block devices

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -91,9 +91,11 @@ func (s *RawUsbInterfaceSuite) TestSecCompSpec(c *C) {
 func (s *RawUsbInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 3)
+	c.Assert(spec.Snippets(), HasLen, 4)
 	c.Assert(spec.Snippets(), testutil.Contains, `# raw-usb
 SUBSYSTEM=="usb", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# raw-usb
+SUBSYSTEM=="usbmisc", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# raw-usb
 SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)


### PR DESCRIPTION
* apparmor: also allow mmap on files in Perl 'auto' directory
* apparmor: allow read access to additional cgroup files
* interfaces/raw-usb: also all usb access to .../platform/scb/ for rip4
* interfaces/network-manager-observe: allow PropertiesChanged from NM path
* interfaces/raw-usb: some USB devices use the usbmisc SUBSYSTEM
* interfaces/desktop-legacy: allow app-indicator and notifications
* snap-confine.apparmor.in: add clarifying comment wrt 'unsafe'
* interface/desktop-legacy: add clarifying comment on Lookup() API
* interfaces/desktop: allow access to the IBus portal (LP: #1881232)
* opengl: also allow access to /dev/dri/card1 and higher (LP: #1890783)

See commit messages for details