### PR TITLE
[RFC] cmd/s-b/initramfs-mounts: make recover -> run mode transition automatic

### DIFF
--- a/boot/initramfs.go
+++ b/boot/initramfs.go
@@ -59,3 +59,27 @@ func InitramfsRunModeSelectSnapsToMount(
 
 	return m, nil
 }
+
+// MarkRecoverModeBootSuccessful will mark the bootenv of the recovery
+// bootloader such that recover mode is now ready to leave
+func MarkRecoverModeBootSuccessful(systemLabel string) error {
+	// at the end of the initramfs we need to set the bootenv such that a reboot
+	// now at any point will rollback to run mode without additional config or
+	// actions
+
+	opts := &bootloader.Options{
+		// setup the recovery bootloader
+		Recovery: true,
+	}
+
+	bl, err := bootloader.Find(InitramfsUbuntuSeedDir, opts)
+	if err != nil {
+		return err
+	}
+
+	m := map[string]string{
+		"snapd_recovery_system": systemLabel,
+		"snapd_recovery_mode":   "run",
+	}
+	return bl.SetBootVars(m)
+}

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -45,6 +45,56 @@ func (s *initramfsSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 }
 
+func (s *initramfsSuite) TestMarkRecoverModeBootSuccessful(c *C) {
+	// with no bootloader available we can't mark successful
+	err := boot.MarkRecoverModeBootSuccessful("label")
+	c.Assert(err, ErrorMatches, "cannot determine bootloader")
+
+	// forcing a bootloader works
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+
+	err = boot.MarkRecoverModeBootSuccessful("label")
+	c.Assert(err, IsNil)
+
+	// the bloader vars have been updated
+	m, err := bloader.GetBootVars("snapd_recovery_mode", "snapd_recovery_system")
+	c.Assert(err, IsNil)
+	c.Assert(m, DeepEquals, map[string]string{
+		"snapd_recovery_mode":   "run",
+		"snapd_recovery_system": "label",
+	})
+}
+
+func (s *initramfsSuite) TestMarkRecoverModeBootSuccessfulRealBootloader(c *C) {
+	// create a real grub.cfg on ubuntu-seed
+	err := os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/ubuntu"), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/ubuntu", "grub.cfg"), nil, 0644)
+	c.Assert(err, IsNil)
+
+	err = boot.MarkRecoverModeBootSuccessful("somelabel")
+	c.Assert(err, IsNil)
+
+	opts := &bootloader.Options{
+		// setup the recovery bootloader
+		Recovery: true,
+	}
+	bloader, err := bootloader.Find(boot.InitramfsUbuntuSeedDir, opts)
+	c.Assert(err, IsNil)
+	c.Assert(bloader.Name(), Equals, "grub")
+
+	// the bloader vars have been updated
+	m, err := bloader.GetBootVars("snapd_recovery_mode", "snapd_recovery_system")
+	c.Assert(err, IsNil)
+	c.Assert(m, DeepEquals, map[string]string{
+		"snapd_recovery_mode":   "run",
+		"snapd_recovery_system": "somelabel",
+	})
+}
+
 func makeSnapFilesOnInitramfsUbuntuData(c *C, comment CommentInterface, snaps ...snap.PlaceInfo) (restore func()) {
 	// also make sure the snaps also exist on ubuntu-data
 	snapDir := dirs.SnapBlobDirUnder(boot.InitramfsWritableDir)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -315,6 +315,14 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 		return err
 	}
 
+	// finally we need to modify the bootenv to mark the system as successful,
+	// this ensures that when you reboot from recover mode without doing
+	// anything else, you are auto-transitioned back to run mode
+	err = boot.MarkRecoverModeBootSuccessful(recoverySystem)
+	if err != nil {
+		return err
+	}
+
 	// done, no output, no error indicates to initramfs we are done with
 	// mounting stuff
 	return nil

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -22,31 +22,8 @@ debug: |
     fi
 
 execute: |
-    if [ "$SPREAD_REBOOT" == "0" ]; then
-        echo "In run mode"
-
-        snap install --edge jq
-        # devmode as the snap does not have snapd-control
-        snap install test-snapd-curl --devmode --edge
-
-        MATCH 'snapd_recovery_mode=run' < /proc/cmdline
-        # verify we are in run mode via the API
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
-        jq -r '.result["system-mode"]' < system-info | MATCH 'run'
-
-        echo "Obtain available systems"
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
-        # TODO:UC20: there is only one system for now
-        jq .result.systems[0].current < systems.json | MATCH 'true'
-        label="$(jq -r .result.systems[0].label < systems.json)"
-        test -n "$label"
-        # make sure that the seed exists
-        test -d "/var/lib/snapd/seed/systems/$label"
-        jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install recover run'
-
-        # keep a copy of the systems dump for later reference
-        cp systems.json /writable/systems.json.run
-        echo "$label" > /writable/systems.label
+    transition_to_recover_mode(){
+        local label=$1
 
         # redirect shutdown command to our mock to observe calls and avoid racing
         # with spread
@@ -99,10 +76,9 @@ execute: |
 
         # XXX: is this a race between spread seeing REBOOT and machine rebooting?
         REBOOT
+    }
 
-    elif [ "$SPREAD_REBOOT" == "1" ]; then
-        echo "In recovery mode"
-
+    prepare_recover_mode() {
         # the system is seeding and snap command may not be available yet
         # shellcheck disable=SC2016
         retry -n 60 --wait 1 sh -c 'test "$(command -v snap)" = /usr/bin/snap'
@@ -118,6 +94,40 @@ execute: |
         # verify we are in recovery mode via the API
         test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
         jq -r '.result["system-mode"]' < system-info | MATCH 'recover'
+    }
+
+    if [ "$SPREAD_REBOOT" == "0" ]; then
+        echo "In run mode"
+
+        snap install --edge jq
+        # devmode as the snap does not have snapd-control
+        snap install test-snapd-curl --devmode --edge
+
+        MATCH 'snapd_recovery_mode=run' < /proc/cmdline
+        # verify we are in run mode via the API
+        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        jq -r '.result["system-mode"]' < system-info | MATCH 'run'
+
+        echo "Obtain available systems"
+        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
+        # TODO:UC20: there is only one system for now
+        jq .result.systems[0].current < systems.json | MATCH 'true'
+        label="$(jq -r .result.systems[0].label < systems.json)"
+        test -n "$label"
+        # make sure that the seed exists
+        test -d "/var/lib/snapd/seed/systems/$label"
+        jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install recover run'
+
+        # keep a copy of the systems dump for later reference
+        cp systems.json /writable/systems.json.run
+        echo "$label" > /writable/systems.label
+
+        transition_to_recover_mode "$label"
+
+    elif [ "$SPREAD_REBOOT" == "1" ]; then
+        echo "In recovery mode"
+
+        prepare_recover_mode
 
         # host data should be accessible
         test -e /host/ubuntu-data/systems.json.run
@@ -165,6 +175,34 @@ execute: |
 
     elif [ "$SPREAD_REBOOT" == "2" ]; then
         echo "In run mode again"
+        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        jq -r '.result["system-mode"]' < system-info | MATCH 'run'
+
+        # now go back to recover mode so we can test that a simple reboot 
+        # works to transition us back to run mode
+        label="$(jq -r .result.systems[0].label < systems.json)"
+        transition_to_recover_mode "$label"
+    elif [ "$SPREAD_REBOOT" == "3" ]; then
+        echo "In recover mode again"
+        
+        prepare_recover_mode
+
+        # if we are using the external backend, remove the .ssh/rc hack we used
+        # to copy data around, it's not necessary going back to run mode, and it
+        # somehow interferes with spread re-connecting over ssh, causing
+        # spread to timeout trying to reconnect after the reboot with an error
+        # message like this:
+        # ssh: unexpected packet in response to channel open: <nil>
+        if [ "$SPREAD_BACKEND" = "external" ]; then
+            # TODO:UC20: if/when /host is mounted ro, then we will need to 
+            # either remount it rw or do some other hack to fix this
+            rm -f /host/ubuntu-data/user-data/external/.ssh/rc
+        fi
+
+        # do a simple reboot to verify that we go back to run mode
+        REBOOT
+    elif [ "$SPREAD_REBOOT" == "4" ]; then
+        echo "In run mode again again"
         test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
         jq -r '.result["system-mode"]' < system-info | MATCH 'run'
     fi


### PR DESCRIPTION
This ensures that reboots or even hard resets that happen at any point
after we exit the initramfs will cause the system to transition out of
recover mode to run mode automatically.

The names here of the boot functions are bit weird, not sure what the best thing to call them is.

Also, to be fair I didn't completely test out the alternative solution to this problem in devicestate as a manager, but it seemed to be more code and was subject to the problem where if systems are really slow and you rebooted/reset the system when it was starting up in recover mode you could be stuck in a recover mode "boot loop" whereas this PR avoids that problem.