### PR TITLE
interfaces/{docker,kubernetes}-support: load overlay and support systemd cgroup driver

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/release"
@@ -660,6 +661,14 @@ var (
 func (iface *dockerSupportInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	spec.SetControlsDeviceCgroup()
 
+	return nil
+}
+
+func (iface *dockerSupportInterface) KModConnectedPlug(spec *kmod.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// https://kubernetes.io/docs/setup/production-environment/container-runtimes/
+	if err := spec.AddModule("overlay"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -108,6 +108,15 @@ unix (bind,listen) type=stream addr="@/containerd-shim/**.sock\x00",
 /sys/fs/cgroup/*/kubepods/ rw,
 /sys/fs/cgroup/*/kubepods/** rw,
 
+# containerd can also be configured to use the systemd cgroup driver via
+# plugins.cri.systemd_cgroup = true which moves container processes into
+# systemd-managed cgroups. This is now the recommended configuration since it
+# provides a single cgroup manager (systemd) in an effort to achieve consistent
+# views of resources.
+/sys/fs/cgroup/*/systemd/{,system.slice/} rw,          # create missing dirs
+/sys/fs/cgroup/*/systemd/system.slice/** r,
+/sys/fs/cgroup/*/systemd/system.slice/cgroup.procs w,
+
 # Allow tracing ourself (especially the "runc" process we create)
 ptrace (trace) peer=@{profile_name},
 

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/release"
@@ -184,6 +185,14 @@ func (s *DockerSupportInterfaceSuite) TestSecCompSpec(c *C) {
 	spec := &seccomp.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Check(spec.SnippetForTag("snap.docker.app"), testutil.Contains, "# Calls the Docker daemon itself requires\n")
+}
+
+func (s *DockerSupportInterfaceSuite) TestKModSpec(c *C) {
+	spec := &kmod.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Modules(), DeepEquals, map[string]bool{
+		"overlay": true,
+	})
 }
 
 func (s *DockerSupportInterfaceSuite) TestPermanentSlotAppArmorSessionNative(c *C) {

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -125,6 +125,14 @@ const kubernetesSupportConnectedPlugAppArmorKubelet = `
 # allow managing pods' cgroups
 /sys/fs/cgroup/*/kubepods/{,**} rw,
 
+# kubelet can be configured to use the systemd cgroup driver which moves
+# container processes into systemd-managed cgroups. This is now the recommended
+# configuration since it provides a single cgroup manager (systemd) in an
+# effort to achieve consistent views of resources.
+/sys/fs/cgroup/*/systemd/{,system.slice/} rw,          # create missing dirs
+/sys/fs/cgroup/*/systemd/system.slice/** r,
+/sys/fs/cgroup/*/systemd/system.slice/cgroup.procs w,
+
 # Allow tracing our own processes. Note, this allows seccomp sandbox escape on
 # kernels < 4.8
 capability sys_ptrace,


### PR DESCRIPTION
* interfaces/{docker,kubernetes}-support: support systemd cgroup driver
* interfaces/docker-support: load overlay module via kmod