### PR TITLE
interfaces: update cups-control and add cups for providing snaps - 2.46

### DIFF
--- a/interfaces/builtin/cups.go
+++ b/interfaces/builtin/cups.go
@@ -19,16 +19,20 @@
 
 package builtin
 
-// The cups interface is the companion interface to the cups-control interface.
-// The design of this interface is based on the idea that the slot
-// implementation (eg cupsd) is expected to query snapd on if the cups-control
-// interface is connected or not and the print service will mediate admin
-// functionality (ie, the rules in these interfaces allow connecting to the
-// print service, but do not implement enforcement rules; it is up to the
-// print service to provide enforcement).
+// On systems where the slot is provided by an app snap, the cups interface is
+// the companion interface to the cups-control interface. The design of these
+// interfaces is based on the idea that the slot implementation (eg cupsd) is
+// expected to query snapd on if the cups-control interface is connected or not
+// and the print service will mediate admin functionality (ie, the rules in
+// these interfaces allow connecting to the print service, but do not implement
+// enforcement rules; it is up to the print service to provide enforcement).
 const cupsSummary = `allows access to the CUPS socket for printing`
 
-// cups is currently only available via a providing app snap
+// cups is currently only available via a providing app snap and this interface
+// assumes that the providing app snap also slots 'cups-control' (the current
+// design allows the snap provider to slots both cups-control and cups or just
+// cups-control (like with implicit classic or any slot provider without
+// mediation patches), but not just cups).
 const cupsBaseDeclarationSlots = `
   cups:
     allow-installation:

--- a/interfaces/builtin/cups.go
+++ b/interfaces/builtin/cups.go
@@ -22,10 +22,11 @@ package builtin
 // On systems where the slot is provided by an app snap, the cups interface is
 // the companion interface to the cups-control interface. The design of these
 // interfaces is based on the idea that the slot implementation (eg cupsd) is
-// expected to query snapd on if the cups-control interface is connected or not
-// and the print service will mediate admin functionality (ie, the rules in
-// these interfaces allow connecting to the print service, but do not implement
-// enforcement rules; it is up to the print service to provide enforcement).
+// expected to query snapd to determine if the cups-control interface is
+// connected or not for the peer client process and the print service will
+// mediate admin functionality (ie, the rules in these interfaces allow
+// connecting to the print service, but do not implement enforcement rules; it
+// is up to the print service to provide enforcement).
 const cupsSummary = `allows access to the CUPS socket for printing`
 
 // cups is currently only available via a providing app snap and this interface

--- a/interfaces/builtin/cups.go
+++ b/interfaces/builtin/cups.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+// The cups interface is the companion interface to the cups-control interface.
+// The design of this interface is based on the idea that the slot
+// implementation (eg cupsd) is expected to query snapd on if the cups-control
+// interface is connected or not and the print service will mediate admin
+// functionality (ie, the rules in these interfaces allow connecting to the
+// print service, but do not implement enforcement rules; it is up to the
+// print service to provide enforcement).
+const cupsSummary = `allows access to the CUPS socket for printing`
+
+// cups is currently only available via a providing app snap
+const cupsBaseDeclarationSlots = `
+  cups:
+    allow-installation:
+      slot-snap-type:
+        - app
+    deny-connection: true
+    deny-auto-connection: true
+`
+
+const cupsConnectedPlugAppArmor = `
+# Allow communicating with the cups server
+
+#include <abstractions/cups-client>
+/{,var/}run/cups/printcap r,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "cups",
+		summary:               cupsSummary,
+		implicitOnCore:        false,
+		implicitOnClassic:     false,
+		baseDeclarationSlots:  cupsBaseDeclarationSlots,
+		connectedPlugAppArmor: cupsConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,30 +19,145 @@
 
 package builtin
 
+import (
+	"strings"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+)
+
 const cupsControlSummary = `allows access to the CUPS control socket`
 
 const cupsControlBaseDeclarationSlots = `
   cups-control:
     allow-installation:
       slot-snap-type:
+        - app
         - core
     deny-auto-connection: true
+    deny-connection:
+      on-classic: false
+`
+
+const cupsControlPermanentSlotAppArmor = `
+# Allow daemon access to create the CUPS socket
+/{,var/}run/cups/ rw,
+/{,var/}run/cups/** rwk,
+
+# Allow cups to verify passwords directly
+/etc/shadow r,
+/var/lib/extrausers/shadow r,
+
+# Some versions of CUPS will verify the connecting pid's
+# security label
+@{PROC}/[0-9]*/attr/current r,
+
+# Allow daemon access to the color manager on the system
+dbus (receive, send)
+    bus=system
+    path=/org/freedesktop/ColorManager
+    interface=org.freedesktop.ColorManager
+    peer=(name=org.freedesktop.ColorManager),
+
+# Allow daemon to send notifications
+dbus (send)
+    bus=system
+    path=/org/cups/cupsd/Notifier
+    interface=org.cups.cupsd.Notifier
+    peer=(name=org.freedesktop.DBus,label=unconfined),
+
+# Allow daemon to send signals to its snap_daemon processes
+capability kill,
+
+# Allow daemon to manage snap_daemon files and directories
+capability fsetid,
+`
+
+const cupsControlConnectedSlotAppArmor = `
+# Allow daemon to send notifications to connected snaps
+dbus (send)
+    bus=system
+    path=/org/cups/cupsd/Notifier
+    interface=org.cups.cupsd.Notifier
+    peer=(name=org.freedesktop.DBus,label=###PLUG_SECURITY_TAGS###),
 `
 
 const cupsControlConnectedPlugAppArmor = `
-# Description: Can access cups control socket. This is restricted because it provides
-# privileged access to configure printing.
+# Description: Can access cups control socket. This is restricted because it
+# provides privileged access to configure printing.
 
 #include <abstractions/cups-client>
-/run/cups/printcap r,
+/{,var/}run/cups/printcap r,
+
+# Allow receiving all DBus signal notifications from the daemon (see
+# notifier/dbus.c in cups sources)
+dbus (receive)
+    bus=system
+    path=/org/cups/cupsd/Notifier
+    interface=org.cups.cupsd.Notifier
+    peer=(name=org.freedesktop.DBus,label=###SLOT_SECURITY_TAGS###),
 `
 
+type cupsControlInterface struct {
+	commonInterface
+}
+
+func (iface *cupsControlInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
+	// Only apply slot snippet when running as application snap on classic
+	// since the slot side may be from the classic OS or snap.
+	if !implicitSystemPermanentSlot(slot) {
+		spec.AddSnippet(cupsControlPermanentSlotAppArmor)
+	}
+	return nil
+}
+
+func (iface *cupsControlInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Only apply slot snippet when running as application snap on classic
+	// since the slot side may be from the classic OS or snap.
+	if !implicitSystemConnectedSlot(slot) {
+		old := "###PLUG_SECURITY_TAGS###"
+		new := plugAppLabelExpr(plug)
+		snippet := strings.Replace(cupsControlConnectedSlotAppArmor, old, new, -1)
+		spec.AddSnippet(snippet)
+	}
+	return nil
+}
+
+func (iface *cupsControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	var new string
+	// If we're running on classic, cups may be installed either as a snap
+	// or as part of the classic OS. If it is part of the classic OS, it
+	// will not have a security label like it would when installed as a
+	// snap.
+	if implicitSystemConnectedSlot(slot) {
+		// cupsd from the OS may be confined or unconfined. Newer
+		// releases may use the 'cupsd' label instead of the old
+		// path-based label.
+		new = "\"{unconfined,/usr/sbin/cupsd,cupsd}\""
+	} else {
+		new = slotAppLabelExpr(slot)
+	}
+
+	// implement 'implicitOnCore: false/implicitOnClassic: true' by only
+	// applying the snippet if the slot is an app or we are on classic
+	if slot.Snap().Type() == snap.TypeApp || release.OnClassic {
+		snippet := strings.Replace(cupsControlConnectedPlugAppArmor, old, new, -1)
+		spec.AddSnippet(snippet)
+	}
+	return nil
+}
+
 func init() {
-	registerIface(&commonInterface{
-		name:                  "cups-control",
-		summary:               cupsControlSummary,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  cupsControlBaseDeclarationSlots,
-		connectedPlugAppArmor: cupsControlConnectedPlugAppArmor,
+	registerIface(&cupsControlInterface{
+		commonInterface: commonInterface{
+			name:                 "cups-control",
+			summary:              cupsControlSummary,
+			baseDeclarationSlots: cupsControlBaseDeclarationSlots,
+			implicitOnCore:       false,
+			implicitOnClassic:    true,
+		},
 	})
 }

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -28,17 +28,23 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// The cups-control interface is the companion interface to the cups interface.
-// The design of this interface is based on the idea that the slot
-// implementation (eg cupsd) is expected to query snapd on if the cups-control
-// interface is connected or not and the print service will mediate admin
-// functionality (ie, the rules in these interfaces allow connecting to the
-// print service, but do not implement enforcement rules; it is up to the
-// print service to provide enforcement).
+// On classic systems where the slot is implicitly provided, the interface
+// allows access to the cups control socket.
+//
+// On systems where the slot is provided by an app snap, the cups-control
+// interface is the companion interface to the cups interface. The design of
+// these interfaces is based on the idea that the slot implementation (eg
+// cupsd) is expected to query snapd on if the cups-control interface is
+// connected or not and the print service will mediate admin functionality (ie,
+// the rules in these interfaces allow connecting to the print service, but do
+// not implement enforcement rules; it is up to the print service to provide
+// enforcement).
 const cupsControlSummary = `allows access to the CUPS control socket`
 
 // cups-control is implicit on classic but may also be provided by an app snap
-// on core or classic.
+// on core or classic (the current design allows the snap provider to slots
+// both cups-control and cups or just cups-control (like with implicit classic
+// or any slot provider without mediation patches), but not just cups).
 const cupsControlBaseDeclarationSlots = `
   cups-control:
     allow-installation:

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -28,8 +28,17 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+// The cups-control interface is the companion interface to the cups interface.
+// The design of this interface is based on the idea that the slot
+// implementation (eg cupsd) is expected to query snapd on if the cups-control
+// interface is connected or not and the print service will mediate admin
+// functionality (ie, the rules in these interfaces allow connecting to the
+// print service, but do not implement enforcement rules; it is up to the
+// print service to provide enforcement).
 const cupsControlSummary = `allows access to the CUPS control socket`
 
+// cups-control is implicit on classic but may also be provided by an app snap
+// on core or classic.
 const cupsControlBaseDeclarationSlots = `
   cups-control:
     allow-installation:
@@ -85,8 +94,7 @@ dbus (send)
 `
 
 const cupsControlConnectedPlugAppArmor = `
-# Description: Can access cups control socket. This is restricted because it
-# provides privileged access to configure printing.
+# Allow communicating with the cups server for printing and configuration.
 
 #include <abstractions/cups-client>
 /{,var/}run/cups/printcap r,

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -34,11 +34,11 @@ import (
 // On systems where the slot is provided by an app snap, the cups-control
 // interface is the companion interface to the cups interface. The design of
 // these interfaces is based on the idea that the slot implementation (eg
-// cupsd) is expected to query snapd on if the cups-control interface is
-// connected or not and the print service will mediate admin functionality (ie,
-// the rules in these interfaces allow connecting to the print service, but do
-// not implement enforcement rules; it is up to the print service to provide
-// enforcement).
+// cupsd) is expected to query snapd to determine if the cups-control interface
+// is connected or not for the peer client process and the print service will
+// mediate admin functionality (ie, the rules in these interfaces allow
+// connecting to the print service, but do not implement enforcement rules; it
+// is up to the print service to provide enforcement).
 const cupsControlSummary = `allows access to the CUPS control socket`
 
 // cups-control is implicit on classic but may also be provided by an app snap

--- a/interfaces/builtin/cups_control_test.go
+++ b/interfaces/builtin/cups_control_test.go
@@ -22,7 +22,6 @@ package builtin_test
 import (
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -68,10 +67,6 @@ func (s *cupsControlSuite) SetUpTest(c *C) {
 	s.plug, s.plugInfo = MockConnectedPlug(c, cupsControlConsumerYaml, nil, "cups-control")
 	s.coreSlot, s.coreSlotInfo = MockConnectedSlot(c, cupsControlCoreYaml, nil, "cups-control")
 	s.providerSlot, s.providerSlotInfo = MockConnectedSlot(c, cupsControlProviderYaml, nil, "cups-control")
-}
-
-func (s *cupsControlSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("/")
 }
 
 func (s *cupsControlSuite) TestName(c *C) {

--- a/interfaces/builtin/cups_control_test.go
+++ b/interfaces/builtin/cups_control_test.go
@@ -1,0 +1,188 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type cupsControlSuite struct {
+	iface            interfaces.Interface
+	coreSlotInfo     *snap.SlotInfo
+	coreSlot         *interfaces.ConnectedSlot
+	plugInfo         *snap.PlugInfo
+	plug             *interfaces.ConnectedPlug
+	providerSlotInfo *snap.SlotInfo
+	providerSlot     *interfaces.ConnectedSlot
+}
+
+var _ = Suite(&cupsControlSuite{iface: builtin.MustInterface("cups-control")})
+
+const cupsControlConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [cups-control]
+`
+
+const cupsControlCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  cups-control:
+`
+
+const cupsControlProviderYaml = `name: provider
+version: 0
+apps:
+ app:
+  slots: [cups-control]
+`
+
+func (s *cupsControlSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, cupsControlConsumerYaml, nil, "cups-control")
+	s.coreSlot, s.coreSlotInfo = MockConnectedSlot(c, cupsControlCoreYaml, nil, "cups-control")
+	s.providerSlot, s.providerSlotInfo = MockConnectedSlot(c, cupsControlProviderYaml, nil, "cups-control")
+}
+
+func (s *cupsControlSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *cupsControlSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "cups-control")
+}
+
+func (s *cupsControlSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.coreSlotInfo), IsNil)
+}
+
+func (s *cupsControlSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *cupsControlSuite) TestAppArmorSpecCore(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	// core to consumer on core is empty for ConnectedPlug
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// core to consumer on core is empty for PermanentSlot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// core to consumer on core is empty for ConnectedSlot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// consumer to provider on core for ConnectedPlug
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.providerSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access cups control socket.")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.provider.app\"")
+	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "# Allow daemon access to create the CUPS socket")
+
+	// provider to consumer on core for PermanentSlot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.providerSlotInfo), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.provider.app"})
+	c.Assert(spec.SnippetForTag("snap.provider.app"), testutil.Contains, "# Allow daemon access to create the CUPS socket")
+	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "label=\"snap.consumer.app\"")
+
+	// provider to consumer on core for ConnectedSlot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.providerSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.provider.app"})
+	c.Assert(spec.SnippetForTag("snap.provider.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.consumer.app\"")
+}
+
+func (s *cupsControlSuite) TestAppArmorSpecClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// consumer to core on classic for ConnectedPlug
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access cups control socket.")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"{unconfined,/usr/sbin/cupsd,cupsd}\"")
+	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "# Allow daemon access to create the CUPS socket")
+
+	// core to consumer on classic is empty for PermanentSlot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// core to consumer on classic is empty for ConnectedSlot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// consumer to provider on classic for ConnectedPlug
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.providerSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access cups control socket.")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.provider.app\"")
+	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "# Allow daemon access to create the CUPS socket")
+
+	// provider to consumer on classic for PermanentSlot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.providerSlotInfo), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.provider.app"})
+	c.Assert(spec.SnippetForTag("snap.provider.app"), testutil.Contains, "# Allow daemon access to create the CUPS socket")
+	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "label=\"snap.consumer.app\"")
+
+	// provider to consumer on classic for ConnectedSlot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.providerSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.provider.app"})
+	c.Assert(spec.SnippetForTag("snap.provider.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.consumer.app\"")
+}
+
+func (s *cupsControlSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to the CUPS control socket`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "cups-control")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *cupsControlSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/cups_control_test.go
+++ b/interfaces/builtin/cups_control_test.go
@@ -109,7 +109,7 @@ func (s *cupsControlSuite) TestAppArmorSpecCore(c *C) {
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.providerSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access cups control socket.")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow communicating with the cups server for printing and configuration.")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.provider.app\"")
 	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "# Allow daemon access to create the CUPS socket")
@@ -136,7 +136,7 @@ func (s *cupsControlSuite) TestAppArmorSpecClassic(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access cups control socket.")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow communicating with the cups server for printing and configuration.")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"{unconfined,/usr/sbin/cupsd,cupsd}\"")
 	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "# Allow daemon access to create the CUPS socket")
@@ -155,7 +155,7 @@ func (s *cupsControlSuite) TestAppArmorSpecClassic(c *C) {
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.providerSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access cups control socket.")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow communicating with the cups server for printing and configuration.")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.provider.app\"")
 	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "# Allow daemon access to create the CUPS socket")

--- a/interfaces/builtin/cups_test.go
+++ b/interfaces/builtin/cups_test.go
@@ -1,0 +1,115 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type cupsSuite struct {
+	iface            interfaces.Interface
+	plugInfo         *snap.PlugInfo
+	plug             *interfaces.ConnectedPlug
+	providerSlotInfo *snap.SlotInfo
+	providerSlot     *interfaces.ConnectedSlot
+}
+
+var _ = Suite(&cupsSuite{iface: builtin.MustInterface("cups")})
+
+const cupsConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [cups]
+`
+
+const cupsProviderYaml = `name: provider
+version: 0
+apps:
+ app:
+  slots: [cups]
+`
+
+func (s *cupsSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, cupsConsumerYaml, nil, "cups")
+	s.providerSlot, s.providerSlotInfo = MockConnectedSlot(c, cupsProviderYaml, nil, "cups")
+}
+
+func (s *cupsSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *cupsSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "cups")
+}
+
+func (s *cupsSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.providerSlotInfo), IsNil)
+}
+
+func (s *cupsSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *cupsSuite) TestAppArmorSpecCore(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	// consumer to provider on core for ConnectedPlug
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.providerSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow communicating with the cups server")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
+}
+
+func (s *cupsSuite) TestAppArmorSpecClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// consumer to provider on classic for ConnectedPlug
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.providerSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow communicating with the cups server")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
+}
+
+func (s *cupsSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnClassic, Equals, false)
+	c.Assert(si.Summary, Equals, `allows access to the CUPS socket for printing`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "cups")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-connection: true")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *cupsSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -36,8 +36,8 @@ const upowerObserveBaseDeclarationSlots = `
   upower-observe:
     allow-installation:
       slot-snap-type:
-        - core
         - app
+        - core
     deny-connection:
       on-classic: false
 `

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -826,6 +826,103 @@ func (s *baseDeclSuite) TestConnectionOnClassic(c *C) {
 	}
 }
 
+func (s *baseDeclSuite) TestConnectionImplicitOnClassicOrAppSnap(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	all := builtin.Interfaces()
+
+	// These interfaces represent when the interface might be implicit on
+	// classic or when the interface is provided via an app snap. As such,
+	// they all share the following:
+	//
+	// - implicitOnCore: false
+	// - implicitOnClassis: true
+	// - base declaration uses:
+	//     allow-installation:
+	//       slot-snap-type:
+	//         - app
+	//         - core
+	//     deny-connection:
+	//       on-classic: false
+	//     deny-auto-connection: true|false|unspecified
+	//
+	// connecting with these interfaces needs to be allowed on
+	// case-by-case basis when not on classic
+	ifaces := map[string]bool{
+		"audio-playback":  true,
+		"audio-record":    true,
+		"cups-control":    true,
+		"modem-manager":   true,
+		"network-manager": true,
+		"ofono":           true,
+		"pulseaudio":      true,
+		"upower-observe":  true,
+	}
+
+	for _, iface := range all {
+		if !ifaces[iface.Name()] {
+			continue
+		}
+		comm := Commentf(iface.Name())
+
+		// verify the interface is setup as expected wrt
+		// implicitOnCore, implicitOnClassic, no plugs and has
+		// expected slots (ignoring AutoConnection)
+		si := interfaces.StaticInfoOf(iface)
+		c.Assert(si.ImplicitOnCore, Equals, false)
+		c.Assert(si.ImplicitOnClassic, Equals, true)
+
+		c.Assert(s.baseDecl.PlugRule(iface.Name()), IsNil)
+
+		sr := s.baseDecl.SlotRule(iface.Name())
+		c.Assert(sr, Not(IsNil))
+		c.Assert(sr.AllowInstallation, HasLen, 1)
+		c.Check(sr.AllowInstallation[0].SlotSnapTypes, DeepEquals, []string{"app", "core"}, comm)
+		c.Assert(sr.DenyConnection, HasLen, 1)
+		c.Check(sr.DenyConnection[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: false}, comm)
+
+		for _, onClassic := range []bool{true, false} {
+			release.OnClassic = onClassic
+
+			for _, implicit := range []bool{true, false} {
+				// When implicitOnCore is false, there is
+				// nothing to test on Core
+				if implicit && !onClassic {
+					continue
+				}
+
+				snapType := "app"
+				if implicit {
+					snapType = "os"
+				}
+				slotYaml := fmt.Sprintf(`name: slot-snap
+version: 0
+type: %s
+slots:
+  %s:
+`, snapType, iface.Name())
+
+				// XXX: eventually 'onClassic && !implicit' but
+				// the current declaration allows connection on
+				// Core when 'type: app'. See:
+				// https://github.com/snapcore/snapd/pull/8920/files#r471678529
+				expected := onClassic
+
+				// check base declaration
+				cand := s.connectCand(c, iface.Name(), slotYaml, "")
+				err := cand.Check()
+
+				if expected {
+					c.Check(err, IsNil, comm)
+				} else {
+					c.Check(err, NotNil, comm)
+				}
+			}
+		}
+	}
+}
+
 func (s *baseDeclSuite) TestSanity(c *C) {
 	all := builtin.Interfaces()
 

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -595,6 +595,7 @@ var (
 		"browser-support":         {"core"},
 		"content":                 {"app", "gadget"},
 		"core-support":            {"core"},
+		"cups-control":            {"app", "core"},
 		"dbus":                    {"app"},
 		"docker-support":          {"core"},
 		"dummy":                   {"app"},

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -595,6 +595,7 @@ var (
 		"browser-support":         {"core"},
 		"content":                 {"app", "gadget"},
 		"core-support":            {"core"},
+		"cups":                    {"app"},
 		"cups-control":            {"app", "core"},
 		"dbus":                    {"app"},
 		"docker-support":          {"core"},
@@ -753,6 +754,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 	// case-by-case basis
 	noconnect := map[string]bool{
 		"content":          true,
+		"cups":             true,
 		"docker":           true,
 		"fwupd":            true,
 		"location-control": true,

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -74,6 +74,9 @@ apps:
   cpu-control:
     command: bin/run
     plugs: [ cpu-control ]
+  cups:
+    command: bin/run
+    plugs: [ cups ]
   cups-control:
     command: bin/run
     plugs: [ cups-control ]

--- a/tests/lib/snaps/test-snapd-policy-app-provider-core/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-provider-core/meta/snap.yaml
@@ -15,6 +15,7 @@ slots:
     content: test-content
     read:
     - $SNAP/content
+  cups: null
   cups-control: null
   dbus-session:
     interface: dbus
@@ -68,6 +69,9 @@ apps:
   content-read:
     command: bin/run
     slots: [ content-read ]
+  cups:
+    command: bin/run
+    slots: [ cups ]
   cups-control:
     command: bin/run
     slots: [ cups-control ]

--- a/tests/lib/snaps/test-snapd-policy-app-provider-core/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-provider-core/meta/snap.yaml
@@ -15,6 +15,7 @@ slots:
     content: test-content
     read:
     - $SNAP/content
+  cups-control: null
   dbus-session:
     interface: dbus
     bus: session
@@ -67,6 +68,9 @@ apps:
   content-read:
     command: bin/run
     slots: [ content-read ]
+  cups-control:
+    command: bin/run
+    slots: [ cups-control ]
   dbus-session:
     command: bin/run
     slots: [ dbus-session ]

--- a/tests/main/interfaces-cups/task.yaml
+++ b/tests/main/interfaces-cups/task.yaml
@@ -1,5 +1,7 @@
 summary: Ensure that the cups interfaces work with app providers
 
+systems: [ubuntu-*]
+
 details: |
     A snap providing the cups-control and cups interfaces should be able to
     create the control socket, with connecting consuming snaps able to use it.
@@ -7,10 +9,10 @@ details: |
     server.
 
 prepare: |
-    snap pack test-snapd-provider
-    snap install --dangerous ./test-snapd-provider_1_all.snap
-    snap pack test-snapd-consumer
-    snap install --dangerous ./test-snapd-consumer_1_all.snap
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local test-snapd-provider
+    install_local test-snapd-consumer
 
     if [ -e /run/cups ]; then
         mv /run/cups /run/cups.orig

--- a/tests/main/interfaces-cups/task.yaml
+++ b/tests/main/interfaces-cups/task.yaml
@@ -1,0 +1,66 @@
+summary: Ensure that the cups interfaces work with app providers
+
+details: |
+    A snap providing the cups-control and cups interfaces should be able to
+    create the control socket, with connecting consuming snaps able to use it.
+    This intentionally does not test the mediation properties of the cupsd
+    server.
+
+prepare: |
+    snap pack test-snapd-provider
+    snap install --dangerous ./test-snapd-provider_1_all.snap
+    snap pack test-snapd-consumer
+    snap install --dangerous ./test-snapd-consumer_1_all.snap
+
+    if [ -e /run/cups ]; then
+        mv /run/cups /run/cups.orig
+    fi
+    mkdir -m 0755 /run/cups
+
+restore: |
+    snap remove --purge test-snapd-provider
+    rm -f ./test-snapd-provider_1_all.snap
+    snap remove --purge test-snapd-consumer
+    rm -f ./test-snapd-consumer_1_all.snap
+
+    rm -rf /run/cups
+    if [ -e /run/cups.orig ]; then
+        mv /run/cups.orig /run/cups
+    fi
+
+execute: |
+    # The provider can create the socket and any other files
+    test-snapd-provider.sh -c "echo slot > /run/cups/cups.sock"
+    test-snapd-provider.sh -c "echo slot > /run/cups/other"
+
+    # The consumer's interface is not auto-connected
+    not test-snapd-consumer.cups-control -c "head /run/cups/cups.sock"
+    not test-snapd-consumer.cups -c "head /run/cups/cups.sock"
+
+    # The cups-control interface works as expected
+    snap connect test-snapd-consumer:cups-control test-snapd-provider:cups-control
+    # plug can't access arbitrary files
+    not test-snapd-consumer.cups-control -c "head /run/cups/other"
+    # plug can write to the socket
+    test-snapd-consumer.cups-control -c "echo cups-control-plug > /run/cups/cups.sock"
+    test-snapd-provider.sh -c "cat /run/cups/cups.sock" | MATCH cups-control-plug
+    # plug can read from the socket
+    test-snapd-provider.sh -c "echo slot > /run/cups/cups.sock"
+    test-snapd-consumer.cups-control -c "cat /run/cups/cups.sock" | MATCH slot
+
+    # The cups interface works as expected
+    snap connect test-snapd-consumer:cups test-snapd-provider:cups
+    # plug can't access arbitrary files
+    not test-snapd-consumer.cups -c "head /run/cups/other"
+    # plug can write to the socket
+    test-snapd-consumer.cups -c "echo cups-plug > /run/cups/cups.sock"
+    test-snapd-provider.sh -c "cat /run/cups/cups.sock" | MATCH cups-plug
+    # plug can read from the socket
+    test-snapd-provider.sh -c "echo slot > /run/cups/cups.sock"
+    test-snapd-consumer.cups -c "cat /run/cups/cups.sock" | MATCH slot
+
+    # The interface can be disconnected
+    snap disconnect test-snapd-consumer:cups-control
+    not test-snapd-consumer.cups-control -c "head /run/cups/cups.sock"
+    snap disconnect test-snapd-consumer:cups
+    not test-snapd-consumer.cups -c "head /run/cups/cups.sock"

--- a/tests/main/interfaces-cups/task.yaml
+++ b/tests/main/interfaces-cups/task.yaml
@@ -49,6 +49,9 @@ execute: |
     # plug can read from the socket
     test-snapd-provider.sh -c "echo slot > /run/cups/cups.sock"
     test-snapd-consumer.cups-control -c "cat /run/cups/cups.sock" | MATCH slot
+    # The cups-control interface can be disconnected
+    snap disconnect test-snapd-consumer:cups-control
+    not test-snapd-consumer.cups-control -c "head /run/cups/cups.sock"
 
     # The cups interface works as expected
     snap connect test-snapd-consumer:cups test-snapd-provider:cups
@@ -60,9 +63,6 @@ execute: |
     # plug can read from the socket
     test-snapd-provider.sh -c "echo slot > /run/cups/cups.sock"
     test-snapd-consumer.cups -c "cat /run/cups/cups.sock" | MATCH slot
-
-    # The interface can be disconnected
-    snap disconnect test-snapd-consumer:cups-control
-    not test-snapd-consumer.cups-control -c "head /run/cups/cups.sock"
+    # The cups interface can be disconnected
     snap disconnect test-snapd-consumer:cups
     not test-snapd-consumer.cups -c "head /run/cups/cups.sock"

--- a/tests/main/interfaces-cups/test-snapd-consumer/bin/sh
+++ b/tests/main/interfaces-cups/test-snapd-consumer/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/interfaces-cups/test-snapd-consumer/meta/snap.yaml
+++ b/tests/main/interfaces-cups/test-snapd-consumer/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: test-snapd-consumer
+version: 1
+architectures: [all]
+apps:
+  cups-control:
+    command: bin/sh
+    plugs:
+    - cups-control
+  cups:
+    command: bin/sh
+    plugs:
+    - cups

--- a/tests/main/interfaces-cups/test-snapd-provider/bin/sh
+++ b/tests/main/interfaces-cups/test-snapd-provider/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/interfaces-cups/test-snapd-provider/meta/snap.yaml
+++ b/tests/main/interfaces-cups/test-snapd-provider/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snapd-provider
+version: 1
+architectures: [all]
+apps:
+  sh:
+    command: bin/sh
+    slots:
+    - cups-control
+    - cups


### PR DESCRIPTION
https://github.com/snapcore/snapd/pull/8920 for 2.46.

@mvo5 - I created this in case this isn't committed to master or you don't merge master into 2.46. If you merge with this included, please feel free to close this PR.