### PR TITLE
features: add HiddenSnapFolder feature flag

### DIFF
--- a/cmd/libsnap-confine-private/feature-test.c
+++ b/cmd/libsnap-confine-private/feature-test.c
@@ -89,6 +89,20 @@ static void test_feature_parallel_instances(void)
 	g_assert(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
 }
 
+static void test_feature_hidden_snap_folder(void)
+{
+	const char *d = sc_testdir();
+	sc_mock_feature_flag_dir(d);
+
+	g_assert(!sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
+
+	char pname[PATH_MAX];
+	sc_must_snprintf(pname, sizeof pname, "%s/hidden-snap-folder", d);
+	g_file_set_contents(pname, "", -1, NULL);
+
+	g_assert(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
+}
+
 static void __attribute__((constructor)) init(void)
 {
 	g_test_add_func("/feature/missing_dir",
@@ -99,4 +113,6 @@ static void __attribute__((constructor)) init(void)
 			test_feature_enabled__present_file);
 	g_test_add_func("/feature/parallel_instances",
 			test_feature_parallel_instances);
+	g_test_add_func("/feature/hidden_snap_folder",
+			test_feature_hidden_snap_folder);
 }

--- a/cmd/libsnap-confine-private/feature.c
+++ b/cmd/libsnap-confine-private/feature.c
@@ -43,6 +43,9 @@ bool sc_feature_enabled(sc_feature_flag flag)
 	case SC_FEATURE_PARALLEL_INSTANCES:
 		file_name = "parallel-instances";
 		break;
+	case SC_FEATURE_HIDDEN_SNAP_FOLDER:
+		file_name = "hidden-snap-folder";
+		break;
 	default:
 		die("unknown feature flag code %d", flag);
 	}

--- a/cmd/libsnap-confine-private/feature.h
+++ b/cmd/libsnap-confine-private/feature.h
@@ -24,6 +24,7 @@ typedef enum sc_feature_flag {
 	SC_FEATURE_PER_USER_MOUNT_NAMESPACE = 1 << 0,
 	SC_FEATURE_REFRESH_APP_AWARENESS = 1 << 1,
 	SC_FEATURE_PARALLEL_INSTANCES = 1 << 2,
+	SC_FEATURE_HIDDEN_SNAP_FOLDER = 1 << 3,
 } sc_feature_flag;
 
 /**

--- a/features/features.go
+++ b/features/features.go
@@ -51,6 +51,8 @@ const (
 	UserDaemons
 	// DbusActivation controls whether snaps daemons can be activated via D-Bus
 	DbusActivation
+	// HiddenSnapFolder moves ~/snap to ~/.snapdata.
+	HiddenSnapFolder
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
 )
@@ -79,6 +81,8 @@ var featureNames = map[SnapdFeature]string{
 
 	UserDaemons:    "user-daemons",
 	DbusActivation: "dbus-activation",
+
+	HiddenSnapFolder: "hidden-snap-folder",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
@@ -95,6 +99,7 @@ var featuresExported = map[SnapdFeature]bool{
 
 	ClassicPreservesXdgRuntimeDir: true,
 	RobustMountNamespaceUpdates:   true,
+	HiddenSnapFolder:              true,
 }
 
 // String returns the name of a snapd feature.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -49,6 +49,7 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.RobustMountNamespaceUpdates.String(), Equals, "robust-mount-namespace-updates")
 	c.Check(features.UserDaemons.String(), Equals, "user-daemons")
 	c.Check(features.DbusActivation.String(), Equals, "dbus-activation")
+	c.Check(features.HiddenSnapFolder.String(), Equals, "hidden-snap-folder")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 
@@ -72,6 +73,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	c.Check(features.ClassicPreservesXdgRuntimeDir.IsExported(), Equals, true)
 	c.Check(features.UserDaemons.IsExported(), Equals, false)
 	c.Check(features.DbusActivation.IsExported(), Equals, false)
+	c.Check(features.HiddenSnapFolder.IsExported(), Equals, true)
 }
 
 func (*featureSuite) TestIsEnabled(c *C) {
@@ -104,6 +106,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.RobustMountNamespaceUpdates.IsEnabledWhenUnset(), Equals, true)
 	c.Check(features.UserDaemons.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.DbusActivation.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.HiddenSnapFolder.IsEnabledWhenUnset(), Equals, false)
 }
 
 func (*featureSuite) TestControlFile(c *C) {
@@ -111,6 +114,7 @@ func (*featureSuite) TestControlFile(c *C) {
 	c.Check(features.RefreshAppAwareness.ControlFile(), Equals, "/var/lib/snapd/features/refresh-app-awareness")
 	c.Check(features.ParallelInstances.ControlFile(), Equals, "/var/lib/snapd/features/parallel-instances")
 	c.Check(features.RobustMountNamespaceUpdates.ControlFile(), Equals, "/var/lib/snapd/features/robust-mount-namespace-updates")
+	c.Check(features.HiddenSnapFolder.ControlFile(), Equals, "/var/lib/snapd/features/hidden-snap-folder")
 	// Features that are not exported don't have a control file.
 	c.Check(features.Layouts.ControlFile, PanicMatches, `cannot compute the control file of feature "layouts" because that feature is not exported`)
 }


### PR DESCRIPTION
This new feature flag will control the location of the per-user snap
data root. When the flag is unset, the ~/snap location is used. When
the flag is set the new ~/.snapdata location will be used as the root of
all other locations (such as SNAP_USER_DATA and SNAP_USER_COMMON).

The flag is implemented on the go and C sides, as both need to observe
it.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
