### PR TITLE
snapstate: installSize helper that calculates total size of snaps and their prerequisites

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -200,7 +200,7 @@ func (f *fakeStore) snap(spec snapSpec, user *auth.UserState) (*snap.Info, error
 	switch spec.Name {
 	case "core", "core16", "ubuntu-core", "some-core":
 		typ = snap.TypeOS
-	case "some-base", "core18":
+	case "some-base", "other-base", "some-other-base", "yet-another-base", "core18":
 		typ = snap.TypeBase
 	case "some-kernel":
 		typ = snap.TypeKernel

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
 )
 
 type ManagerBackend managerBackend
@@ -95,6 +96,8 @@ var (
 	UserFromUserID         = userFromUserID
 	ValidateFeatureFlags   = validateFeatureFlags
 	ResolveChannel         = resolveChannel
+
+	CurrentSnaps = currentSnaps
 
 	DefaultContentPlugProviders = defaultContentPlugProviders
 
@@ -236,6 +239,14 @@ func MockPidsOfSnap(f func(instanceName string) (map[string][]int, error)) func(
 	pidsOfSnap = f
 	return func() {
 		pidsOfSnap = old
+	}
+}
+
+func MockCurrentSnaps(f func(st *state.State) ([]*store.CurrentSnap, error)) func() {
+	old := currentSnaps
+	currentSnaps = f
+	return func() {
+		currentSnaps = old
 	}
 }
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -109,7 +109,7 @@ func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {
 }
 
 // helpers
-var InstallSizeInfo = installSizeInfo
+var InstallSize = installSize
 
 // aliases v2
 var (

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -99,6 +99,9 @@ func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {
 	return snapst.previousSideInfo()
 }
 
+// helpers
+var InstallSizeInfo = installSizeInfo
+
 // aliases v2
 var (
 	ApplyAliasesChange    = applyAliasesChange

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -84,12 +84,12 @@ func refreshOptions(st *state.State, origOpts *store.RefreshOptions) (*store.Ref
 	return &opts, nil
 }
 
-// installSizeInfo returns total download size of snaps and their prerequisites
+// installSize returns total download size of snaps and their prerequisites
 // (bases and default content providers), querying the store as neccessarry,
 // potentially more than once. It assumes the initial list of snaps already has
 // download infos set.
 // The state must be locked by the caller.
-func installSizeInfo(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+func installSize(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
 	curSnaps, err := currentSnaps(st)
 	if err != nil {
 		return 0, err
@@ -132,7 +132,6 @@ func installSizeInfo(st *state.State, snaps []*snap.Info, userID int) (uint64, e
 	snapSizes := map[string]uint64{}
 	for _, snapInfo := range snaps {
 		if snapInfo.DownloadInfo.Size == 0 {
-			// XXX: we could support this by simply adding to prereqs
 			return 0, fmt.Errorf("internal error: download info missing for %q", snapInfo.InstanceName())
 		}
 		snapSizes[snapInfo.InstanceName()] = uint64(snapInfo.Size)

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -32,6 +32,8 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
+var currentSnaps = currentSnapsImpl
+
 func userIDForSnap(st *state.State, snapst *SnapState, fallbackUserID int) (int, error) {
 	userID := snapst.UserID
 	_, err := auth.User(st, userID)
@@ -374,7 +376,7 @@ func updateToRevisionInfo(st *state.State, snapst *SnapState, revision snap.Revi
 	return sar.Info, err
 }
 
-func currentSnaps(st *state.State) ([]*store.CurrentSnap, error) {
+func currentSnapsImpl(st *state.State) ([]*store.CurrentSnap, error) {
 	snapStates, err := All(st)
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/storehelpers_test.go
+++ b/overlord/snapstate/storehelpers_test.go
@@ -190,7 +190,7 @@ func (s *snapmgrTestSuite) TestInstallSizeSimple(c *C) {
 	})
 	snap2.Size = snap2Size
 
-	sz, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1, snap2}, 0)
+	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap2}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size))
 }
@@ -232,7 +232,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithBases(c *C) {
 		Current: snap.R(1),
 	})
 
-	sz, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1, snap2, snap3, snap4}, 0)
+	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap2, snap3, snap4}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+snap3Size+snap4Size+someBaseSize+otherBaseSize))
 }
@@ -262,7 +262,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithContentProviders(c *C) {
 	s.mockCoreSnap(c)
 
 	// both snaps have same content providers and base
-	sz, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1, snap2}, 0)
+	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap2}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+someBaseSize+snapContentSlotSize))
 }
@@ -284,7 +284,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithNestedDependencies(c *C) {
 
 	s.mockCoreSnap(c)
 
-	sz, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1}, 0)
+	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize+snapOtherContentSlotSize+someOtherBaseSize))
 }
@@ -303,7 +303,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithOtherChangeAffectingSameSnaps(c *C
 			return curr, err
 		}
 		// simulate other change that installed some-snap3 and other-base while
-		// we release the lock inside installSizeInfo.
+		// we release the lock inside InstallSize.
 		curr = append(curr, &store.CurrentSnap{InstanceName: "some-snap3"})
 		curr = append(curr, &store.CurrentSnap{InstanceName: "other-base"})
 		return curr, nil
@@ -323,7 +323,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithOtherChangeAffectingSameSnaps(c *C
 	})
 	snap3.Size = snap3Size
 
-	sz, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1, snap3}, 0)
+	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap3}, 0)
 	c.Assert(err, IsNil)
 	// snap3 and its base installed by another change, not counted here
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize))
@@ -342,6 +342,6 @@ func (s *snapmgrTestSuite) TestInstallSizeErrorNoDownloadInfo(c *C) {
 			RealName: "snap",
 		}}
 
-	_, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1}, 0)
+	_, err := snapstate.InstallSize(st, []*snap.Info{snap1}, 0)
 	c.Assert(err, ErrorMatches, `internal error: download info missing.*`)
 }

--- a/overlord/snapstate/storehelpers_test.go
+++ b/overlord/snapstate/storehelpers_test.go
@@ -289,7 +289,6 @@ func (s *snapmgrTestSuite) TestInstallSizeWithNestedDependencies(c *C) {
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize+snapOtherContentSlotSize+someOtherBaseSize))
 }
 
-
 func (s *snapmgrTestSuite) TestInstallSizeWithOtherChangeAffectingSameSnaps(c *C) {
 	st := s.state
 	st.Lock()

--- a/overlord/snapstate/storehelpers_test.go
+++ b/overlord/snapstate/storehelpers_test.go
@@ -1,0 +1,303 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/store"
+)
+
+const snapYaml1 = `
+name: some-snap
+version: 1.0
+`
+const snapYaml2 = `
+name: some-snap
+version: 1.0
+base: none
+`
+
+const snapYamlWithBase1 = `
+name: some-snap1
+version: 1.0
+base: some-base
+`
+const snapYamlWithBase2 = `
+name: some-snap2
+version: 1.0
+base: some-base
+`
+const snapYamlWithBase3 = `
+name: some-snap3
+version: 2.0
+base: other-base
+`
+const snapYamlWithBase4 = `
+name: some-snap4
+version: 1.0
+base: yet-another-base
+`
+const snapYamlWithContentPlug1 = `
+name: some-snap
+version: 1.0
+base: some-base
+plugs:
+  some-plug:
+    interface: content
+    content: shared-content
+    default-provider: snap-content-slot
+`
+
+const snapYamlWithContentPlug2 = `
+name: some-snap2
+version: 1.0
+base: some-base
+plugs:
+  some-plug:
+    interface: content
+    content: shared-content
+    default-provider: snap-content-slot
+`
+
+const snapYamlWithContentPlug3 = `
+name: some-snap
+version: 1.0
+base: some-base
+plugs:
+  some-plug:
+    interface: content
+    content: shared-content
+    default-provider: snap-content-slot-other
+`
+
+const (
+	// use sizes that make it easier to spot unexpected dependencies in the
+	// total sum.
+	someBaseSize             = 1
+	otherBaseSize            = 100
+	snap1Size                = 1000
+	snap2Size                = 10000
+	snap3Size                = 100000
+	snap4Size                = 1000000
+	snapContentSlotSize      = 10000000
+	snapOtherContentSlotSize = 100000000
+	someOtherBaseSize        = 1000000000
+)
+
+type installSizeTestStore struct {
+	*fakeStore
+}
+
+func (f installSizeTestStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	sizes := map[string]int64{
+		"some-base":               someBaseSize,
+		"other-base":              otherBaseSize,
+		"snap-content-slot":       snapContentSlotSize,
+		"snap-content-slot-other": snapOtherContentSlotSize,
+		"some-other-base":         someOtherBaseSize,
+	}
+	for _, sa := range actions {
+		if sa.Action != "install" {
+			panic(fmt.Sprintf("unexpected action: %s", sa.Action))
+		}
+		if sa.Channel != "stable" {
+			panic(fmt.Sprintf("unexpected channel: %s", sa.Channel))
+		}
+		if _, ok := sizes[sa.InstanceName]; !ok {
+			panic(fmt.Sprintf("unexpected snap: %q", sa.InstanceName))
+		}
+	}
+	sars, _, err := f.fakeStore.SnapAction(ctx, currentSnaps, actions, assertQuery, user, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, sr := range sars {
+		if sz, ok := sizes[sr.Info.InstanceName()]; ok {
+			sr.Info.Size = sz
+		} else {
+			panic(fmt.Sprintf("unexpected snap: %q", sr.Info.InstanceName()))
+		}
+		if sr.Info.InstanceName() == "snap-content-slot-other" {
+			sr.Info.Base = "some-other-base"
+		}
+	}
+	return sars, nil, nil
+}
+
+func (s *snapmgrTestSuite) mockCoreSnap(c *C) {
+	snapstate.Set(s.state, "core", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "core", SnapID: "core-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "os",
+	})
+	// mock the yaml
+	makeInstalledMockCoreSnap(c)
+}
+
+func (s *snapmgrTestSuite) setupInstallSizeStore() {
+	fakestore := installSizeTestStore{fakeStore: s.fakeStore}
+	snapstate.ReplaceStore(s.state, fakestore)
+}
+
+func (s *snapmgrTestSuite) TestInstallSizeSimple(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	s.setupInstallSizeStore()
+	s.mockCoreSnap(c)
+
+	snap1 := snaptest.MockSnap(c, snapYaml1, &snap.SideInfo{
+		RealName: "some-snap1",
+		Revision: snap.R(1),
+	})
+	snap1.Size = snap1Size
+	snap2 := snaptest.MockSnap(c, snapYaml2, &snap.SideInfo{
+		RealName: "some-snap2",
+		Revision: snap.R(2),
+	})
+	snap2.Size = snap2Size
+
+	sz, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1, snap2}, 0)
+	c.Assert(err, IsNil)
+	c.Check(sz, Equals, uint64(snap1Size+snap2Size))
+}
+
+func (s *snapmgrTestSuite) TestInstallSizeWithBases(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	s.setupInstallSizeStore()
+
+	snap1 := snaptest.MockSnap(c, snapYamlWithBase1, &snap.SideInfo{
+		RealName: "some-snap1",
+		Revision: snap.R(1),
+	})
+	snap1.Size = snap1Size
+	snap2 := snaptest.MockSnap(c, snapYamlWithBase2, &snap.SideInfo{
+		RealName: "some-snap2",
+		Revision: snap.R(2),
+	})
+	snap2.Size = snap2Size
+	snap3 := snaptest.MockSnap(c, snapYamlWithBase3, &snap.SideInfo{
+		RealName: "some-snap3",
+		Revision: snap.R(4),
+	})
+	snap3.Size = snap3Size
+	snap4 := snaptest.MockSnap(c, snapYamlWithBase4, &snap.SideInfo{
+		RealName: "some-snap4",
+		Revision: snap.R(1),
+	})
+	snap4.Size = snap4Size
+
+	// base of some-snap4 is already installed
+	snapstate.Set(st, "yet-another-base", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "yet-another-base", Revision: snap.R(1), SnapID: "yet-another-base-id"},
+		},
+		Current: snap.R(1),
+	})
+
+	sz, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1, snap2, snap3, snap4}, 0)
+	c.Assert(err, IsNil)
+	c.Check(sz, Equals, uint64(snap1Size+snap2Size+snap3Size+snap4Size+someBaseSize+otherBaseSize))
+}
+
+func (s *snapmgrTestSuite) TestInstallSizeWithContentProviders(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	repo := interfaces.NewRepository()
+	ifacerepo.Replace(st, repo)
+
+	s.setupInstallSizeStore()
+
+	snap1 := snaptest.MockSnap(c, snapYamlWithContentPlug1, &snap.SideInfo{
+		RealName: "some-snap",
+		Revision: snap.R(1),
+	})
+	snap1.Size = snap1Size
+
+	snap2 := snaptest.MockSnap(c, snapYamlWithContentPlug2, &snap.SideInfo{
+		RealName: "some-snap2",
+		Revision: snap.R(1),
+	})
+	snap2.Size = snap2Size
+
+	s.mockCoreSnap(c)
+
+	// both snaps have same content providers and base
+	sz, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1, snap2}, 0)
+	c.Assert(err, IsNil)
+	c.Check(sz, Equals, uint64(snap1Size+snap2Size+someBaseSize+snapContentSlotSize))
+}
+
+func (s *snapmgrTestSuite) TestInstallSizeWithNestedDependencies(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	repo := interfaces.NewRepository()
+	ifacerepo.Replace(st, repo)
+
+	s.setupInstallSizeStore()
+	snap1 := snaptest.MockSnap(c, snapYamlWithContentPlug3, &snap.SideInfo{
+		RealName: "some-snap",
+		Revision: snap.R(1),
+	})
+	snap1.Size = snap1Size
+
+	s.mockCoreSnap(c)
+
+	sz, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1}, 0)
+	c.Assert(err, IsNil)
+	c.Check(sz, Equals, uint64(snap1Size+someBaseSize+snapOtherContentSlotSize+someOtherBaseSize))
+}
+
+func (s *snapmgrTestSuite) TestInstallSizeErrorNoDownloadInfo(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	snap1 := &snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "snap",
+		}}
+
+	_, err := snapstate.InstallSizeInfo(st, []*snap.Info{snap1}, 0)
+	c.Assert(err, ErrorMatches, `internal error: download info missing.*`)
+}


### PR DESCRIPTION
Helper function to calculate total size of snaps and their dependencies, for use with Install and InstallMany. It's not hooked anywhere yet.

Note: this helper has a potential of preventing installs in case of a bug, so needs extra insight.

