### PR TITLE
boot: observe update & rollback of trusted assets

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -192,12 +192,6 @@ type trackedAsset struct {
 	blName, name, hash string
 }
 
-func (t *trackedAsset) equal(other *trackedAsset) bool {
-	return t.blName == other.blName &&
-		t.name == other.name &&
-		t.hash == other.hash
-}
-
 func isAssetAlreadyTracked(bam bootAssetsMap, newAsset *trackedAsset) bool {
 	return isAssetHashTrackedInMap(bam, newAsset.name, newAsset.hash)
 }
@@ -508,8 +502,6 @@ func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, 
 		}
 	}
 
-	// XXX: do we need to support using the same asset name multiple times
-	// for a given bootloader?
 	newHash := ""
 	if len(hashList) == 1 {
 		if newlyAdded {

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -59,6 +59,16 @@ func (c *trustedAssetsCache) pathInCache(part string) string {
 	return filepath.Join(c.cacheDir, part)
 }
 
+// fileHash calculates the hash of an arbitrary file using the same hash method
+// as the cache.
+func (c *trustedAssetsCache) fileHash(name string) (string, error) {
+	digest, _, err := osutil.FileDigest(name, c.hash)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(digest), nil
+}
+
 // Add entry for a new named asset owned by a particular bootloader, with the
 // binary content of the located at a given path. The cache ensures that only
 // one entry for given tuple of (bootloader name, asset name, content-hash)
@@ -188,6 +198,42 @@ func (t *trackedAsset) equal(other *trackedAsset) bool {
 		t.hash == other.hash
 }
 
+func isAlreadyTracked(current []*trackedAsset, newAsset *trackedAsset) bool {
+	for _, ta := range current {
+		if newAsset.equal(ta) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlreadyTrackedInBootMap(bam bootAssetsMap, newAsset *trackedAsset) bool {
+	return isAssetHashTrackedInBootMap(bam, newAsset.name, newAsset.hash)
+}
+
+func isAssetHashTrackedInBootMap(bam bootAssetsMap, assetName, assetHash string) bool {
+	if bam == nil {
+		return false
+	}
+	hashes, ok := bam[assetName]
+	if !ok {
+		return false
+	}
+	return strutil.ListContains(hashes, assetHash)
+}
+
+func trackedAssetsToBootMap(trackedAssets []*trackedAsset) bootAssetsMap {
+	if len(trackedAssets) == 0 {
+		return nil
+	}
+	bm := bootAssetsMap{}
+	for _, tracked := range trackedAssets {
+		// we expect to have added exactly one hash per tracked asset
+		bm[tracked.name] = append(bm[tracked.name], tracked.hash)
+	}
+	return bm
+}
+
 // TrustedAssetsInstallObserver tracks the installation of trusted boot assets.
 type TrustedAssetsInstallObserver struct {
 	model         *asserts.Model
@@ -275,12 +321,42 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model) (*TrustedAssetsUp
 		return nil, ErrObserverNotApplicable
 	}
 
-	return &TrustedAssetsUpdateObserver{}, nil
+	return &TrustedAssetsUpdateObserver{
+		cache: newTrustedAssetsCache(dirs.SnapBootAssetsDir),
+	}, nil
 }
 
 // TrustedAssetsUpdateObserver tracks the updates of trusted boot assets and
 // attempts to reseal when needed.
-type TrustedAssetsUpdateObserver struct{}
+type TrustedAssetsUpdateObserver struct {
+	cache *trustedAssetsCache
+
+	bootBootloader    bootloader.Bootloader
+	bootTrustedAssets []string
+	trackedAssets     []*trackedAsset
+
+	seedBootloader        bootloader.Bootloader
+	seedTrustedAssets     []string
+	trackedRecoveryAssets []*trackedAsset
+
+	modeenv *Modeenv
+}
+
+func findTrustedAssetsBootloader(root string, opts *bootloader.Options) (found bootloader.Bootloader, trustedAssets []string, err error) {
+	found, err = bootloader.Find(root, opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot find bootloader: %v", err)
+	}
+	tbl, ok := found.(bootloader.TrustedAssetsBootloader)
+	if !ok {
+		return found, nil, nil
+	}
+	trustedAssets, err = tbl.TrustedAssets()
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot list %q bootloader trusted assets: %v", found.Name(), err)
+	}
+	return found, trustedAssets, nil
+}
 
 // Observe observes the operation related to the update or rollback of the
 // content of a given gadget structure. In particular, the
@@ -289,14 +365,161 @@ type TrustedAssetsUpdateObserver struct{}
 //
 // Implements gadget.ContentUpdateObserver.
 func (o *TrustedAssetsUpdateObserver) Observe(op gadget.ContentOperation, affectedStruct *gadget.LaidOutStructure, root, realSource, relativeTarget string) (bool, error) {
+	var whichBootloader bootloader.Bootloader
+	var whichAssets []string
+	var err error
+	var isRecovery bool
+
+	switch affectedStruct.Role {
+	case gadget.SystemBoot:
+		if o.bootBootloader == nil {
+			o.bootBootloader, o.bootTrustedAssets, err = findTrustedAssetsBootloader(root, &bootloader.Options{
+				NoSlashBoot: true,
+			})
+			if err != nil {
+				return false, err
+			}
+		}
+		whichBootloader = o.bootBootloader
+		whichAssets = o.bootTrustedAssets
+	case gadget.SystemSeed:
+		if o.seedBootloader == nil {
+			o.seedBootloader, o.seedTrustedAssets, err = findTrustedAssetsBootloader(root, &bootloader.Options{
+				NoSlashBoot: true,
+				Recovery:    true,
+			})
+			if err != nil {
+				return false, err
+			}
+		}
+		whichBootloader = o.seedBootloader
+		whichAssets = o.seedTrustedAssets
+		isRecovery = true
+	default:
+		// only system-seed and system-boot are of interest
+		return true, nil
+	}
+	if len(whichAssets) == 0 || !strutil.ListContains(whichAssets, relativeTarget) {
+		// not one of the trusted assets
+		return true, nil
+	}
+	if o.modeenv == nil {
+		// we've hit a trusted asset, so a modeenv is needed now too
+		o.modeenv, err = ReadModeenv("")
+		if err != nil {
+			return false, fmt.Errorf("cannot load modeenv: %v", err)
+		}
+	}
+	switch op {
+	case gadget.ContentUpdate:
+		return o.observeUpdate(whichBootloader, isRecovery, root, realSource, relativeTarget)
+	case gadget.ContentRollback:
+		return o.observeRollback(whichBootloader, isRecovery, root, realSource, relativeTarget)
+	default:
+		// we only care about update and rollback actions
+		return false, nil
+	}
+}
+
+func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, recovery bool, root, realSource, relativeTarget string) (bool, error) {
+	modeenvBefore, err := o.modeenv.Copy()
+	if err != nil {
+		return false, fmt.Errorf("cannot copy modeenv: %v", err)
+	}
+
+	ta, err := o.cache.Add(realSource, bl.Name(), filepath.Base(relativeTarget))
+	if err != nil {
+		return false, err
+	}
+
+	trustedAssets := &o.modeenv.CurrentTrustedBootAssets
+	if recovery {
+		trustedAssets = &o.modeenv.CurrentTrustedRecoveryBootAssets
+	}
+	if !isAlreadyTrackedInBootMap(*trustedAssets, ta) {
+		if *trustedAssets == nil {
+			*trustedAssets = bootAssetsMap{}
+		}
+		(*trustedAssets)[ta.name] = append((*trustedAssets)[ta.name], ta.hash)
+	}
+
+	if o.modeenv.deepEqual(modeenvBefore) {
+		return true, nil
+	}
+	if err := o.modeenv.WriteTo(""); err != nil {
+		return false, fmt.Errorf("cannot write modeeenv: %v", err)
+	}
+	return true, nil
+}
+
+func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, recovery bool, root, realSource, relativeTarget string) (bool, error) {
 	// TODO:UC20:
-	// steps on write action:
-	// - copy new asset to assets cache
-	// - update modeeenv
 	// steps on rollback action:
 	// - drop file from cache if no longer referenced
 	// - update modeenv
-	return true, nil
+
+	trustedAssets := &o.modeenv.CurrentTrustedBootAssets
+	otherTrustedAssets := o.modeenv.CurrentTrustedRecoveryBootAssets
+	if recovery {
+		trustedAssets = &o.modeenv.CurrentTrustedRecoveryBootAssets
+		otherTrustedAssets = o.modeenv.CurrentTrustedBootAssets
+	}
+
+	assetName := filepath.Base(relativeTarget)
+	hashList, ok := (*trustedAssets)[assetName]
+	if !ok || len(hashList) == 0 {
+		// asset not tracked in modeenv
+		return true, nil
+	}
+
+	// new assets are appended to the list
+	expectedHash := hashList[0]
+	// sanity check, make sure that the current file is what we expect
+	newlyAdded := false
+	ondiskHash, err := o.cache.fileHash(filepath.Join(root, relativeTarget))
+	if err != nil {
+		// file may not exist if it was added by the update, that's ok
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("cannot calculate the digest of current asset: %v", err)
+		}
+		newlyAdded = true
+	} else {
+		if ondiskHash != expectedHash {
+			// this is unexpected, a different file exists on disk?
+			return false, fmt.Errorf("unexpected content of existing asset %q", relativeTarget)
+		}
+	}
+
+	// XXX: do we need to support using the same asset name multiple times
+	// for a given bootloader?
+	newHash := ""
+	if len(hashList) == 1 {
+		if newlyAdded {
+			newHash = hashList[0]
+		}
+	} else {
+		newHash = hashList[1]
+	}
+	if newHash != "" && !isAssetHashTrackedInBootMap(otherTrustedAssets, assetName, newHash) {
+		// asset revision is not used used elsewhere, we can remove it from the cache
+		if err := o.cache.Remove(bl.Name(), assetName, newHash); err != nil {
+			// XXX: should this be a log instead?
+			return false, fmt.Errorf("cannot remove unused boot asset %v:%v: %v", assetName, newHash, err)
+		}
+	}
+
+	// update modeenv content
+	if !newlyAdded {
+		(*trustedAssets)[assetName] = hashList[:1]
+	} else {
+		delete(*trustedAssets, assetName)
+	}
+
+	if err := o.modeenv.WriteTo(""); err != nil {
+		return false, fmt.Errorf("cannot write modeeenv: %v", err)
+	}
+
+	return false, nil
 }
 
 // BeforeWrite is called when the update process has been staged for execution.

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -343,11 +343,9 @@ type TrustedAssetsUpdateObserver struct {
 
 	bootBootloader    bootloader.Bootloader
 	bootTrustedAssets []string
-	trackedAssets     []*trackedAsset
 
-	seedBootloader        bootloader.Bootloader
-	seedTrustedAssets     []string
-	trackedRecoveryAssets []*trackedAsset
+	seedBootloader    bootloader.Bootloader
+	seedTrustedAssets []string
 
 	modeenv *Modeenv
 }

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -691,6 +691,97 @@ func (s *assetsSuite) TestUpdateObserverUpdateNotTrustedMocked(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *assetsSuite) TestUpdateObserverUpdateTrivialErr(c *C) {
+	// test trivial error scenarios of the update observer
+
+	d := c.MkDir()
+	root := c.MkDir()
+
+	uc20Model := makeMockUC20Model()
+	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
+	c.Assert(obs, NotNil)
+	c.Assert(err, IsNil)
+
+	// first no bootloader
+	bootloader.ForceError(fmt.Errorf("bootloader fail"))
+
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, "cannot find bootloader: bootloader fail")
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, "cannot find bootloader: bootloader fail")
+
+	bootloader.ForceError(nil)
+	bl := bootloadertest.Mock("trusted", "").WithTrustedAssets()
+	bootloader.Force(bl)
+	defer bootloader.Force(nil)
+
+	bl.TrustedAssetsList = []string{"asset"}
+	bl.TrustedAssetsErr = fmt.Errorf("fail")
+
+	// listing trusted assets fails
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, `cannot list "trusted" bootloader trusted assets: fail`)
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, `cannot list "trusted" bootloader trusted assets: fail`)
+
+	bl.TrustedAssetsErr = nil
+
+	// no modeenv
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, `cannot load modeenv: .* no such file or directory`)
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, `cannot load modeenv: .* no such file or directory`)
+
+	m := boot.Modeenv{
+		Mode: "run",
+	}
+	err = m.WriteTo("")
+	c.Assert(err, IsNil)
+
+	// no source file, hash will fail
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, `cannot open asset file: .*/foobar: no such file or directory`)
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, `cannot open asset file: .*/foobar: no such file or directory`)
+}
+
+func (s *assetsSuite) TestUpdateObserverUpdateRepeatedAssetErr(c *C) {
+	d := c.MkDir()
+	root := c.MkDir()
+
+	bl := bootloadertest.Mock("trusted", "").WithTrustedAssets()
+	bootloader.Force(bl)
+	defer bootloader.Force(nil)
+	bl.TrustedAssetsList = []string{"asset"}
+
+	uc20Model := makeMockUC20Model()
+	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
+	c.Assert(obs, NotNil)
+	c.Assert(err, IsNil)
+
+	// we are already tracking 2 assets, this is an unexpected state for observing content updates
+	m := boot.Modeenv{
+		Mode: "run",
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {"one", "two"},
+		},
+		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			"asset": {"one", "two"},
+		},
+	}
+	err = m.WriteTo("")
+	c.Assert(err, IsNil)
+
+	// and the source file
+	err = ioutil.WriteFile(filepath.Join(d, "foobar"), nil, 0644)
+	c.Assert(err, IsNil)
+
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, `cannot reuse asset name "asset"`)
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, root, filepath.Join(d, "foobar"), "asset")
+	c.Assert(err, ErrorMatches, `cannot reuse asset name "asset"`)
+}
+
 func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) {
 	root := c.MkDir()
 
@@ -781,6 +872,248 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 		"asset": {dataHash},
 		"shim":  {shimHash},
 	})
+}
+
+func (s *assetsSuite) TestUpdateObserverRollbackFileSanity(c *C) {
+	root := c.MkDir()
+
+	tab := bootloadertest.Mock("trusted", "").WithTrustedAssets()
+	// MockBootloader does not implement trusted assets
+	bootloader.Force(tab)
+	defer bootloader.Force(nil)
+	tab.TrustedAssetsList = []string{
+		"asset",
+	}
+
+	// we get an observer for UC20
+	uc20Model := makeMockUC20Model()
+	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
+	c.Assert(obs, NotNil)
+	c.Assert(err, IsNil)
+
+	// sane state of modeenv before rollback
+	m := boot.Modeenv{
+		Mode: "run",
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			// only one hash is listed, indicating it's a new file
+			"asset": {"newhash"},
+		},
+		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			// same thing
+			"asset": {"newhash"},
+		},
+	}
+	err = m.WriteTo("")
+	c.Assert(err, IsNil)
+	// file does not exist on disk
+	_, err = obs.Observe(gadget.ContentRollback, mockRunBootStruct, root, "", "asset")
+	c.Assert(err, IsNil)
+	// the list of trusted assets was asked once for the boot bootloader
+	c.Check(tab.TrustedAssetsCalls, Equals, 1)
+	// observe the recovery struct
+	_, err = obs.Observe(gadget.ContentRollback, mockSeedStruct, root, "", "asset")
+	c.Assert(err, IsNil)
+	// and once again for the recovery bootloader
+	c.Check(tab.TrustedAssetsCalls, Equals, 2)
+	// check modeenv
+	newM, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Check(newM.CurrentTrustedBootAssets, HasLen, 0)
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, HasLen, 0)
+
+	// new observer
+	obs, err = boot.TrustedAssetsUpdateObserverForModel(uc20Model)
+	c.Assert(obs, NotNil)
+	c.Assert(err, IsNil)
+	m = boot.Modeenv{
+		Mode: "run",
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			// only one hash is listed, indicating it's a new file
+			"asset": {"newhash", "bogushash"},
+		},
+		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			// same thing
+			"asset": {"newhash", "bogushash"},
+		},
+	}
+	err = m.WriteTo("")
+	c.Assert(err, IsNil)
+	// again, file does not exist on disk, but we expected it to be there
+	_, err = obs.Observe(gadget.ContentRollback, mockRunBootStruct, root, "", "asset")
+	c.Assert(err, ErrorMatches, `tracked asset "asset" is unexpectedly missing from disk`)
+	_, err = obs.Observe(gadget.ContentRollback, mockSeedStruct, root, "", "asset")
+	c.Assert(err, ErrorMatches, `tracked asset "asset" is unexpectedly missing from disk`)
+
+	// create the file which will fail checksum check
+	err = ioutil.WriteFile(filepath.Join(root, "asset"), nil, 0644)
+	c.Assert(err, IsNil)
+	// once more, the file exists on disk, but has unexpected checksum
+	_, err = obs.Observe(gadget.ContentRollback, mockRunBootStruct, root, "", "asset")
+	c.Assert(err, ErrorMatches, `unexpected content of existing asset "asset"`)
+	_, err = obs.Observe(gadget.ContentRollback, mockSeedStruct, root, "", "asset")
+	c.Assert(err, ErrorMatches, `unexpected content of existing asset "asset"`)
+}
+
+func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
+	// exercise a full update/rollback cycle with grub
+
+	gadgetDir := c.MkDir()
+	bootDir := c.MkDir()
+	seedDir := c.MkDir()
+
+	// we get an observer for UC20
+	uc20Model := makeMockUC20Model()
+	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
+	c.Assert(obs, NotNil)
+	c.Assert(err, IsNil)
+
+	cache := boot.NewTrustedAssetsCache(dirs.SnapBootAssetsDir)
+
+	for _, dir := range []struct {
+		root              string
+		fileWithContent   [][]string
+		addContentToCache bool
+	}{
+		{
+			// data of boot bootloader
+			root: bootDir,
+			// SHA3-384: 0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389
+			fileWithContent: [][]string{
+				{"EFI/boot/grubx64.efi", "grub efi"},
+			},
+			addContentToCache: true,
+		}, {
+			// data of seed bootloader
+			root: seedDir,
+			fileWithContent: [][]string{
+				// SHA3-384: 6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d
+				{"EFI/boot/grubx64.efi", "recovery grub efi"},
+				// SHA3-384: c0437507ac094a7e9c699725cc0a4726cd10799af9eb79bbeaa136c2773163c80432295c2a04d3aa2ddd535ce8f1a12b
+				{"EFI/boot/bootx64.efi", "recovery shim efi"},
+			},
+			addContentToCache: true,
+		}, {
+			// gadget content
+			root: gadgetDir,
+			fileWithContent: [][]string{
+				// SHA3-384: f9554844308e89b565c1cdbcbdb9b09b8210dd2f1a11cb3b361de0a59f780ae3d4bd6941729a60e0f8ce15b2edef605d
+				{"grubx64.efi", "new grub efi"},
+				// SHA3-384: cc0663cc7e6c7ada990261c3ff1d72da001dc02451558716422d3d2443b8789463363c9ff0cd1b853c6ced3e8e7dc39d
+				{"bootx64.efi", "new recovery shim efi"},
+			},
+		},
+		// just the markers
+		{
+			root: bootDir,
+			fileWithContent: [][]string{
+				{"EFI/ubuntu/grub.cfg", "grub marker"},
+			},
+		}, {
+			root: seedDir,
+			fileWithContent: [][]string{
+				{"EFI/ubuntu/grub.cfg", "grub marker"},
+			},
+		},
+	} {
+		for _, f := range dir.fileWithContent {
+			p := filepath.Join(dir.root, f[0])
+			err := os.MkdirAll(filepath.Dir(p), 0755)
+			c.Assert(err, IsNil)
+			err = ioutil.WriteFile(p, []byte(f[1]), 0644)
+			c.Assert(err, IsNil)
+			if dir.addContentToCache {
+				_, err = cache.Add(p, "grub", filepath.Base(p))
+				c.Assert(err, IsNil)
+			}
+		}
+	}
+	cacheContentBefore := []string{
+		// recovery shim
+		filepath.Join(dirs.SnapBootAssetsDir, "grub", "bootx64.efi-c0437507ac094a7e9c699725cc0a4726cd10799af9eb79bbeaa136c2773163c80432295c2a04d3aa2ddd535ce8f1a12b"),
+		// boot bootloader
+		filepath.Join(dirs.SnapBootAssetsDir, "grub", "grubx64.efi-0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389"),
+		// recovery bootloader
+		filepath.Join(dirs.SnapBootAssetsDir, "grub", "grubx64.efi-6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d"),
+	}
+	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDir, "grub", "*"), cacheContentBefore)
+	// current files are tracked
+	m := boot.Modeenv{
+		Mode: "run",
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"grubx64.efi": {"0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389"},
+		},
+		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			"grubx64.efi": {"6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d"},
+			"bootx64.efi": {"c0437507ac094a7e9c699725cc0a4726cd10799af9eb79bbeaa136c2773163c80432295c2a04d3aa2ddd535ce8f1a12b"},
+		},
+	}
+	err = m.WriteTo("")
+	c.Assert(err, IsNil)
+
+	// updates first
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, bootDir, filepath.Join(gadgetDir, "grubx64.efi"), "EFI/boot/grubx64.efi")
+	c.Assert(err, IsNil)
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, seedDir, filepath.Join(gadgetDir, "grubx64.efi"), "EFI/boot/grubx64.efi")
+	c.Assert(err, IsNil)
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, seedDir, filepath.Join(gadgetDir, "bootx64.efi"), "EFI/boot/bootx64.efi")
+	c.Assert(err, IsNil)
+	// verify cache contents
+	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDir, "grub", "*"), []string{
+		// recovery shim
+		filepath.Join(dirs.SnapBootAssetsDir, "grub", "bootx64.efi-c0437507ac094a7e9c699725cc0a4726cd10799af9eb79bbeaa136c2773163c80432295c2a04d3aa2ddd535ce8f1a12b"),
+		// new recovery shim
+		filepath.Join(dirs.SnapBootAssetsDir, "grub", "bootx64.efi-cc0663cc7e6c7ada990261c3ff1d72da001dc02451558716422d3d2443b8789463363c9ff0cd1b853c6ced3e8e7dc39d"),
+		// boot bootloader
+		filepath.Join(dirs.SnapBootAssetsDir, "grub", "grubx64.efi-0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389"),
+		// recovery bootloader
+		filepath.Join(dirs.SnapBootAssetsDir, "grub", "grubx64.efi-6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d"),
+		// new recovery and boot bootloader
+		filepath.Join(dirs.SnapBootAssetsDir, "grub", "grubx64.efi-f9554844308e89b565c1cdbcbdb9b09b8210dd2f1a11cb3b361de0a59f780ae3d4bd6941729a60e0f8ce15b2edef605d"),
+	})
+
+	// and modeenv contents
+	newM, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+		"grubx64.efi": {
+			// old hash
+			"0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389",
+			// update
+			"f9554844308e89b565c1cdbcbdb9b09b8210dd2f1a11cb3b361de0a59f780ae3d4bd6941729a60e0f8ce15b2edef605d",
+		},
+	})
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+		"grubx64.efi": {
+			// old hash
+			"6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d",
+			// update
+			"f9554844308e89b565c1cdbcbdb9b09b8210dd2f1a11cb3b361de0a59f780ae3d4bd6941729a60e0f8ce15b2edef605d",
+		},
+		"bootx64.efi": {
+			// old hash
+			"c0437507ac094a7e9c699725cc0a4726cd10799af9eb79bbeaa136c2773163c80432295c2a04d3aa2ddd535ce8f1a12b",
+			// update
+			"cc0663cc7e6c7ada990261c3ff1d72da001dc02451558716422d3d2443b8789463363c9ff0cd1b853c6ced3e8e7dc39d",
+		},
+	})
+
+	// hiya, update failed, pretend we do a rollback, files on disk are as
+	// if they were restored
+
+	_, err = obs.Observe(gadget.ContentRollback, mockRunBootStruct, bootDir, "", "EFI/boot/grubx64.efi")
+	c.Assert(err, IsNil)
+	_, err = obs.Observe(gadget.ContentRollback, mockSeedStruct, seedDir, "", "EFI/boot/grubx64.efi")
+	c.Assert(err, IsNil)
+	_, err = obs.Observe(gadget.ContentRollback, mockSeedStruct, seedDir, "", "EFI/boot/bootx64.efi")
+	c.Assert(err, IsNil)
+
+	// modeenv is back to the initial state
+	afterRollbackM, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Check(afterRollbackM.CurrentTrustedBootAssets, DeepEquals, m.CurrentTrustedBootAssets)
+	c.Check(afterRollbackM.CurrentTrustedRecoveryBootAssets, DeepEquals, m.CurrentTrustedRecoveryBootAssets)
+	// and cache is back to the same state as before
+	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDir, "grub", "*"), cacheContentBefore)
 }
 
 func (s *assetsSuite) TestCopyBootAssetsCacheHappy(c *C) {


### PR DESCRIPTION
Try to observe content updates and rollbacks of trusted assets. Update the
modeenv and boot assets cache on the fly, preparing a state for resealing of
encryption keys.
