### PR TITLE
sandbox: track applications unconditionally

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -707,6 +707,10 @@ allow snappy_cli_t snappy_var_lib_t:dir { list_dir_perms };
 allow snappy_cli_t snappy_var_lib_t:file { read_file_perms };
 allow snappy_cli_t snappy_var_lib_t:lnk_file { read_lnk_file_perms };
 
+# allow talking to system and session bus for app tracking
+dbus_system_bus_client(snappy_cli_t);
+dbus_chat_system_bus(snappy_cli_t);
+
 # allow reading passwd
 auth_read_passwd(snappy_cli_t)
 # allow reading sssd files

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -412,6 +412,11 @@ ifndef(`distro_rhel7',`
   ')
 ')
 
+# Snapd tries to kill hooks that run for over 10 minutes. Allow killing
+# processes both in "snap run" and in "post-snap-confine" phases.
+allow snappy_t snappy_cli_t:process { getpgid sigkill };
+allow snappy_t unconfined_service_t:process { getpgid sigkill };
+
 ########################################
 #
 # snap-update-ns, snap-dicsard-ns local policy

--- a/sandbox/cgroup/tracking.go
+++ b/sandbox/cgroup/tracking.go
@@ -9,7 +9,6 @@ import (
 	"github.com/godbus/dbus"
 
 	"github.com/snapcore/snapd/dbusutil"
-	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/randutil"
 )
@@ -38,9 +37,6 @@ type TrackingOptions struct {
 // Scope names must be unique, a randomly generated UUID is appended to the
 // security tag, further suffixed with the string ".scope".
 func CreateTransientScopeForTracking(securityTag string, opts *TrackingOptions) error {
-	if !features.RefreshAppAwareness.IsEnabled() {
-		return nil
-	}
 	if opts == nil {
 		// Retain original semantics when not explicitly configured otherwise.
 		opts = &TrackingOptions{AllowSessionBus: true}

--- a/sandbox/cgroup/tracking_test.go
+++ b/sandbox/cgroup/tracking_test.go
@@ -56,18 +56,20 @@ func (s *trackingSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 }
 
-// CreateTransientScopeForTracking is a no-op when refresh app awareness is off
+// CreateTransientScopeForTracking is not a no-op when refresh app awareness is off
 func (s *trackingSuite) TestCreateTransientScopeForTrackingFeatureDisabled(c *C) {
 	noDBus := func() (*dbus.Conn, error) {
-		c.Error("test sequence violated")
-		return nil, fmt.Errorf("dbus should not have been used")
+		return nil, fmt.Errorf("dbus not available")
 	}
 	restore := dbusutil.MockConnections(noDBus, noDBus)
 	defer restore()
 
+	// The feature is disabled but we still track applications. The feature
+	// flag is now only observed in side snapd snap manager, while considering
+	// snap refreshes.
 	c.Assert(features.RefreshAppAwareness.IsEnabled(), Equals, false)
 	err := cgroup.CreateTransientScopeForTracking("snap.pkg.app", nil)
-	c.Check(err, IsNil)
+	c.Assert(err, ErrorMatches, "cannot track application process")
 }
 
 // CreateTransientScopeForTracking does stuff when refresh app awareness is on

--- a/sandbox/cgroup/tracking_test.go
+++ b/sandbox/cgroup/tracking_test.go
@@ -56,7 +56,7 @@ func (s *trackingSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 }
 
-// CreateTransientScopeForTracking is not a no-op when refresh app awareness is off
+// CreateTransientScopeForTracking always attempts to track, even when refresh app awareness flag is off.
 func (s *trackingSuite) TestCreateTransientScopeForTrackingFeatureDisabled(c *C) {
 	noDBus := func() (*dbus.Conn, error) {
 		return nil, fmt.Errorf("dbus not available")

--- a/tests/lib/snaps/test-snapd-xdg-settings/bin/xdg-settings-wrapper
+++ b/tests/lib/snaps/test-snapd-xdg-settings/bin/xdg-settings-wrapper
@@ -4,6 +4,7 @@ set -o pipefail
 # We need to add a "cut -b4-" everywhere because `dbus-send
 # --print-reply=literal` indents the output by 3 spaces (hard-coded in
 # dbus-print-message.c:print_iter).
+# TODO: change this to busctl, it's much easier to use.
 case "$1" in
     get)
         if [ $# -eq 3 ]; then

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -80,11 +80,16 @@ check_stray_dbus_daemon() {
 	n="$1" # invariant name
 	(
 		skipped_system=0
+		skipped_root_session=0
 		for pid in $(pgrep dbus-daemon); do
 			cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline")"
 			# Ignore one dbus-daemon responsible for the system bus.
 			if echo "$cmdline" | grep -q 'dbus-daemon --system' && [ "$skipped_system" -eq 0 ]; then
 				skipped_system=1
+				continue
+			fi
+			if echo "$cmdline" | grep -q 'dbus-daemon --session' && [ "$(stat -c %u "/proc/$pid")" -eq 0 ] && [ "$skipped_root_session" -eq 0 ]; then
+				skipped_root_session=1
 				continue
 			fi
 			# Ignore dbus-daemon running the session of the "external" user.

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -130,7 +130,7 @@ execute: |
     fi
 
     echo "When the snap is refreshed"
-    snap refresh --channel=edge "$SNAP_NAME"
+    snap refresh --ignore-running --channel=edge "$SNAP_NAME"
 
     if [ -f /tmp/inhibit.events ]; then
       echo "During the refresh process, the inhibition lock was established and released"

--- a/tests/main/xdg-settings/task.yaml
+++ b/tests/main/xdg-settings/task.yaml
@@ -20,6 +20,7 @@ prepare: |
     tests.session -u test prepare
 
     # wait for session to be ready
+    # TODO: change this to busctl, it's much easier to use.
     tests.session -u test exec env "PATH=$PATH" retry -n 5 --wait 0.5 dbus-send \
             --session                                         \
             --dest=io.snapcraft.Settings                      \
@@ -74,37 +75,21 @@ execute: |
         test ! -e /tmp/xdg-settings-output
     }
 
-
-    # we are expecting the test to fail on a cgroup v2 system
-    if is_cgroupv2 ; then
-        ensure_error_no_xdg_settings_output "set" "default-web-browser" "smoke-test-cgroupv2.desktop" 2> stderr.log
-        MATCH 'WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement' < stderr.log
-        MATCH 'cannot find snap for connection: not supported' < stderr.log
-        # don't run further tests
-        exit 0
-    fi
-
-
     # ensure zenity answers "yes"
     touch /usr/bin/zenity
     mount --bind /bin/true /usr/bin/zenity
 
-
     # Test valid actions
     ensure_xdg_settings_output "set" "default-web-browser" "browser.desktop"
-
     ensure_xdg_settings_output "set" "default-url-scheme-handler" "irc" "browser.desktop"
-
 
     # Test unknown action
     ensure_error_no_xdg_settings_output "unknown" 2> stderr.log
     MATCH 'unknown action unknown' < stderr.log
 
-
     # Ensure settings whitelist works
     ensure_error_no_xdg_settings_output "set" "random-settting" "something" 2> stderr.log
     MATCH 'invalid setting "random-settting"' < stderr.log
-
 
     # Ensure settings value validation works
     ensure_error_no_xdg_settings_output "set" "default-web-browser" "inälid" 2> stderr.log


### PR DESCRIPTION
This patch moves refresh app awareness closer to being enabled by
enabling application tracking unconditionally. This will improve our
understanding of the feature, specifically the interaction with systemd,
without actually acting on the new information yet.

In addition, this will allow us to map any pid to a snap name, improving
interaction with some portals.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

