### PR TITLE
boot/initramfs_test.go: reset boot vars on the bootloader for each iteration

### DIFF
--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -551,6 +551,13 @@ func (s *initramfsSuite) TestInitramfsRunModeChooseSnapsToMount(c *C) {
 
 			if t.blvars != nil {
 				c.Assert(bl.SetBootVars(t.blvars), IsNil, comment)
+				cleanBootVars := make(map[string]string, len(t.blvars))
+				for k := range t.blvars {
+					cleanBootVars[k] = ""
+				}
+				cleanups = append(cleanups, func() {
+					c.Assert(bl.SetBootVars(cleanBootVars), IsNil, comment)
+				})
 			}
 
 			if len(t.snapsToMake) != 0 {


### PR DESCRIPTION
This was missed in the initial implementation, but doesn't actually affect any
test results (probably by accident due to the order of the test cases not
depending on boot vars being after the ones depending on boot vars).

Missing this does make tests fail with changes I will be proposing separately,
so it will make for simpler review of that behavior change to see there is no
test infrastructure change for that, only test case behavior change.