### PR TITLE
boot/bootstate20: reboot to rollback to previous kernel

### DIFF
--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -317,31 +317,37 @@ func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo) (rebootRequired bool
 func (ks20 *bootState20Kernel) selectAndCommitSnapInitramfsMount(modeenv *Modeenv) (sn snap.PlaceInfo, err error) {
 	// first do the generic choice of which snap to use
 	first, second, err := genericInitramfsSelectSnap(ks20, modeenv, TryingStatus, "kernel")
-	if err != nil {
+	if err != nil && err != errTrySnapFallback {
 		return nil, err
+	}
+
+	if err == errTrySnapFallback {
+		// this should not actually return, it should immediately reboot
+		return nil, initramfsReboot()
 	}
 
 	// now validate the chosen kernel snap against the modeenv CurrentKernel's
 	// setting
-
-	// always try the first and fallback to the second if we fail
 	if strutil.ListContains(modeenv.CurrentKernels, first.Filename()) {
 		return first, nil
 	}
 
-	// first isn't trusted, so if we expected a fallback then use it
+	// if we didn't trust the first kernel in the modeenv, and second is set as
+	// a fallback, that means we booted a try kernel which is the first kernel,
+	// but we need to fallback to the second kernel, but we can't do that in the
+	// initramfs, we need to reboot so the bootloader boots the fallback kernel
+	// for us
+
 	if second != nil {
-		if strutil.ListContains(modeenv.CurrentKernels, second.Filename()) {
-			// TODO:UC20: actually we really shouldn't be falling back here at
-			//            all - if the kernel we booted isn't mountable in the
-			//            initramfs, we should trigger a reboot so that we boot
-			//            the fallback kernel and then mount that one when we
-			//            get back to the initramfs again
-			return second, nil
-		}
+		// this should not actually return, it should immediately reboot
+		return nil, initramfsReboot()
 	}
 
-	// no fallback expected, so first snap _is_ the fallback and isn't trusted!
+	// no fallback expected, so first snap _is_ the only kernel and isn't
+	// trusted!
+	// since we have nothing to fallback to, we don't issue a reboot and will
+	// instead just fail the systemd unit in the initramfs for an operator to
+	// debug/fix
 	return nil, fmt.Errorf("fallback kernel snap %q is not trusted in the modeenv", first.Filename())
 }
 
@@ -439,7 +445,8 @@ func (bs20 *bootState20Base) selectAndCommitSnapInitramfsMount(modeenv *Modeenv)
 	// whether the chosen snap is a try snap or not, if it is then we process
 	// the modeenv in the "try" -> "trying" case
 	first, second, err := genericInitramfsSelectSnap(bs20, modeenv, TryStatus, "base")
-	if err != nil {
+	// errTrySnapFallback is handled manually by inspecting second below
+	if err != nil && err != errTrySnapFallback {
 		return nil, err
 	}
 
@@ -594,29 +601,32 @@ func genericInitramfsSelectSnap(bs bootState20, modeenv *Modeenv, expectedTrySta
 		// just log that we had issues with the try snap and continue with
 		// using the normal snap
 		logger.Noticef("unable to process try %s snap: %v", typeString, err)
-		return curSnap, nil, nil
+		return curSnap, nil, errTrySnapFallback
 	}
 	if snapTryStatus != expectedTryStatus {
 		// the status is unexpected, log if its value is invalid and continue
 		// with the normal snap
+		fallbackErr := errTrySnapFallback
 		switch snapTryStatus {
-		case TryStatus, DefaultStatus, TryingStatus:
+		case DefaultStatus:
+			fallbackErr = nil
+		case TryStatus, TryingStatus:
 		default:
 			logger.Noticef("\"%s_status\" has an invalid setting: %q", typeString, snapTryStatus)
 		}
-		return curSnap, nil, nil
+		return curSnap, nil, fallbackErr
 	}
 	// then we are trying a snap update and there should be a try snap
 	if trySnap == nil {
 		// it is unexpected when there isn't one
 		logger.Noticef("try-%[1]s snap is empty, but \"%[1]s_status\" is \"trying\"", typeString)
-		return curSnap, nil, nil
+		return curSnap, nil, errTrySnapFallback
 	}
 	trySnapPath := filepath.Join(dirs.SnapBlobDirUnder(InitramfsWritableDir), trySnap.Filename())
 	if !osutil.FileExists(trySnapPath) {
 		// or when the snap file does not exist
 		logger.Noticef("try-%s snap %q does not exist", typeString, trySnap.Filename())
-		return curSnap, nil, nil
+		return curSnap, nil, errTrySnapFallback
 	}
 
 	// we have a try snap and everything appears in order

--- a/boot/errors.go
+++ b/boot/errors.go
@@ -19,7 +19,10 @@
 
 package boot
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // trySnapError is an error that only applies to the try snaps where multiple
 // snaps are returned, this is mainly and primarily used in revisions().
@@ -42,3 +45,5 @@ func isTrySnapError(err error) bool {
 	}
 	return false
 }
+
+var errTrySnapFallback = errors.New("fallback to original snap")

--- a/boot/initramfs.go
+++ b/boot/initramfs.go
@@ -93,7 +93,7 @@ var initramfsReboot = func() error {
 		panic("initramfsReboot must be mocked in tests")
 	}
 
-	out, err := exec.Command("/bin/reboot").CombinedOutput()
+	out, err := exec.Command("/sbin/reboot").CombinedOutput()
 	if err != nil {
 		return osutil.OutputErr(out, err)
 	}

--- a/boot/initramfs.go
+++ b/boot/initramfs.go
@@ -21,6 +21,7 @@ package boot
 
 import (
 	"os/exec"
+	"time"
 
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/osutil"
@@ -97,8 +98,14 @@ var initramfsReboot = func() error {
 	if err != nil {
 		return osutil.OutputErr(out, err)
 	}
-	// should be unreachable
-	return nil
+
+	// reboot command in practice seems to not return, but apparently it is
+	// theoretically possible it could return, so to account for this we will
+	// loop for a "long" time waiting for the system to be rebooted, and panic
+	// after a timeout so that if something goes wrong with the reboot we do
+	// exit with some info about the expected reboot
+	time.Sleep(10 * time.Minute)
+	panic("expected reboot to happen within 10 minutes after calling /sbin/reboot")
 }
 
 func MockInitramfsReboot(f func() error) (restore func()) {

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -551,6 +551,13 @@ func (s *initramfsSuite) TestInitramfsRunModeChooseSnapsToMount(c *C) {
 
 			if t.blvars != nil {
 				c.Assert(bl.SetBootVars(t.blvars), IsNil, comment)
+				emptyMap := make(map[string]string, len(t.blvars))
+				for k := range t.blvars {
+					emptyMap[k] = ""
+				}
+				cleanups = append(cleanups, func() {
+					c.Assert(bl.SetBootVars(emptyMap), IsNil, comment)
+				})
 			}
 
 			if len(t.snapsToMake) != 0 {

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -115,7 +115,7 @@ func makeSnapFilesOnInitramfsUbuntuData(c *C, comment CommentInterface, snaps ..
 	}
 }
 
-func (s *initramfsSuite) TestInitramfsRunModeChooseSnapsToMount(c *C) {
+func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 	// make some snap infos we will use in the tests
 	kernel1, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
 	c.Assert(err, IsNil)
@@ -133,16 +133,17 @@ func (s *initramfsSuite) TestInitramfsRunModeChooseSnapsToMount(c *C) {
 	kernelT := snap.TypeKernel
 
 	tt := []struct {
-		m           *boot.Modeenv
-		expectedM   *boot.Modeenv
-		typs        []snap.Type
-		kernel      snap.PlaceInfo
-		trykernel   snap.PlaceInfo
-		blvars      map[string]string
-		snapsToMake []snap.PlaceInfo
-		expected    map[snap.Type]snap.PlaceInfo
-		errPattern  string
-		comment     string
+		m              *boot.Modeenv
+		expectedM      *boot.Modeenv
+		typs           []snap.Type
+		kernel         snap.PlaceInfo
+		trykernel      snap.PlaceInfo
+		blvars         map[string]string
+		snapsToMake    []snap.PlaceInfo
+		expected       map[snap.Type]snap.PlaceInfo
+		errPattern     string
+		comment        string
+		expRebootPanic string
 	}{
 		//
 		// default paths
@@ -181,29 +182,13 @@ func (s *initramfsSuite) TestInitramfsRunModeChooseSnapsToMount(c *C) {
 			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel2},
 			comment:     "successful kernel upgrade path",
 		},
-		// kernel upgrade path, but uses fallback due to untrusted kernel from modeenv
-		{
-			m:           &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename()}},
-			kernel:      kernel1,
-			trykernel:   kernel2,
-			typs:        []snap.Type{kernelT},
-			blvars:      map[string]string{"kernel_status": boot.TryingStatus},
-			snapsToMake: []snap.PlaceInfo{kernel1, kernel2},
-			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
-			comment:     "fallback kernel upgrade path, due to modeenv untrusted try kernel",
-		},
-		// kernel upgrade path, but uses fallback due to try kernel file not existing
-		{
-			m:           &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename(), kernel2.Filename()}},
-			kernel:      kernel1,
-			trykernel:   kernel2,
-			typs:        []snap.Type{kernelT},
-			blvars:      map[string]string{"kernel_status": boot.TryingStatus},
-			snapsToMake: []snap.PlaceInfo{kernel1},
-			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
-			comment:     "fallback kernel upgrade path, due to try kernel file not existing",
-		},
-		// kernel upgrade path, but uses fallback due to default kernel_status
+		// extraneous kernel extracted/set, but kernel_status is default,
+		// so the bootloader will ignore that and boot the default kernel
+		// note that this test case is a bit ambiguous as we don't actually know
+		// in the initramfs that the bootloader actually booted the default
+		// kernel, we are just assuming that the bootloader implementation in
+		// the real world is robust enough to only boot the try kernel if and
+		// only if kernel_status is not DefaultStatus
 		{
 			m:           &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename(), kernel2.Filename()}},
 			kernel:      kernel1,
@@ -214,21 +199,49 @@ func (s *initramfsSuite) TestInitramfsRunModeChooseSnapsToMount(c *C) {
 			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
 			comment:     "fallback kernel upgrade path, due to kernel_status empty (default)",
 		},
-		// kernel upgrade path, but uses fallback due to invalid kernel_status
+
+		//
+		// unhappy reboot fallback kernel paths
+		//
+
+		// kernel upgrade path, but reboots to fallback due to untrusted kernel from modeenv
 		{
-			m:           &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename(), kernel2.Filename()}},
-			kernel:      kernel1,
-			trykernel:   kernel2,
-			typs:        []snap.Type{kernelT},
-			blvars:      map[string]string{"kernel_status": boot.TryStatus},
-			snapsToMake: []snap.PlaceInfo{kernel1, kernel2},
-			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
-			comment:     "fallback kernel upgrade path, due to kernel_status wrong",
+			m:              &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename()}},
+			kernel:         kernel1,
+			trykernel:      kernel2,
+			typs:           []snap.Type{kernelT},
+			blvars:         map[string]string{"kernel_status": boot.TryingStatus},
+			snapsToMake:    []snap.PlaceInfo{kernel1, kernel2},
+			expRebootPanic: "reboot due to modeenv untrusted try kernel",
+			comment:        "fallback kernel upgrade path, due to modeenv untrusted try kernel",
+		},
+		// kernel upgrade path, but reboots to fallback due to try kernel file not existing
+		{
+			m:              &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename(), kernel2.Filename()}},
+			kernel:         kernel1,
+			trykernel:      kernel2,
+			typs:           []snap.Type{kernelT},
+			blvars:         map[string]string{"kernel_status": boot.TryingStatus},
+			snapsToMake:    []snap.PlaceInfo{kernel1},
+			expRebootPanic: "reboot due to try kernel file not existing",
+			comment:        "fallback kernel upgrade path, due to try kernel file not existing",
+		},
+		// kernel upgrade path, but reboots to fallback due to invalid kernel_status
+		{
+			m:              &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename(), kernel2.Filename()}},
+			kernel:         kernel1,
+			trykernel:      kernel2,
+			typs:           []snap.Type{kernelT},
+			blvars:         map[string]string{"kernel_status": boot.TryStatus},
+			snapsToMake:    []snap.PlaceInfo{kernel1, kernel2},
+			expRebootPanic: "reboot due to kernel_status wrong",
+			comment:        "fallback kernel upgrade path, due to kernel_status wrong",
 		},
 
 		//
-		// unhappy kernel paths
+		// unhappy initramfs fail kernel paths
 		//
+
 		// fallback kernel not trusted in modeenv
 		{
 			m:           &boot.Modeenv{Mode: "run"},
@@ -537,6 +550,14 @@ func (s *initramfsSuite) TestInitramfsRunModeChooseSnapsToMount(c *C) {
 
 			comment := Commentf("[%s] %s", tbl.name, t.comment)
 
+			// we use a panic to simulate a reboot
+			if t.expRebootPanic != "" {
+				r := boot.MockInitramfsReboot(func() error {
+					panic(t.expRebootPanic)
+				})
+				cleanups = append(cleanups, r)
+			}
+
 			bootloader.Force(bl)
 			cleanups = append(cleanups, func() { bootloader.Force(nil) })
 
@@ -577,12 +598,17 @@ func (s *initramfsSuite) TestInitramfsRunModeChooseSnapsToMount(c *C) {
 			m, err := boot.ReadModeenv(boot.InitramfsWritableDir)
 			c.Assert(err, IsNil, comment)
 
-			mountSnaps, err := boot.InitramfsRunModeSelectSnapsToMount(t.typs, m)
-			if t.errPattern != "" {
-				c.Assert(err, ErrorMatches, t.errPattern, comment)
+			if t.expRebootPanic != "" {
+				f := func() { boot.InitramfsRunModeSelectSnapsToMount(t.typs, m) }
+				c.Assert(f, PanicMatches, t.expRebootPanic, comment)
 			} else {
-				c.Assert(err, IsNil, comment)
-				c.Assert(mountSnaps, DeepEquals, t.expected, comment)
+				mountSnaps, err := boot.InitramfsRunModeSelectSnapsToMount(t.typs, m)
+				if t.errPattern != "" {
+					c.Assert(err, ErrorMatches, t.errPattern, comment)
+				} else {
+					c.Assert(err, IsNil, comment)
+					c.Assert(mountSnaps, DeepEquals, t.expected, comment)
+				}
 			}
 
 			// check that the modeenv changed as expected

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1225,10 +1225,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 		snapFiles            []snap.PlaceInfo
 		kernelStatus         string
 
-		expLog     string
-		expError   string
-		expModeenv *boot.Modeenv
-		comment    string
+		expRebootPanic string
+		expLog         string
+		expError       string
+		expModeenv     *boot.Modeenv
+		comment        string
 	}{
 		// default case no upgrades
 		{
@@ -1382,25 +1383,17 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 			},
 			comment: "happy fallback failed boot with try snap",
 		},
-		// TODO:UC20: in this case snap-bootstrap should request a reboot, since we
-		//            already booted the try snap, so mounting the fallback kernel will
-		//            not match in some cases
 		{
 			modeenv: &boot.Modeenv{
 				Mode:           "run",
 				Base:           s.core20.Filename(),
 				CurrentKernels: []string{s.kernel.Filename()},
 			},
-			additionalMountsFunc: func() []systemdMount {
-				return []systemdMount{
-					s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
-					s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
-				}
-			},
 			enableKernel:    s.kernel,
 			enableTryKernel: s.kernelr2,
 			snapFiles:       []snap.PlaceInfo{s.core20, s.kernel, s.kernelr2},
 			kernelStatus:    boot.TryingStatus,
+			expRebootPanic:  "reboot due to untrusted try kernel snap",
 			comment:         "happy fallback untrusted try kernel snap",
 		},
 		// TODO:UC20: if we ever have a way to compare what kernel was booted,
@@ -1414,16 +1407,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 				Base:           s.core20.Filename(),
 				CurrentKernels: []string{s.kernel.Filename()},
 			},
-			kernelStatus: boot.TryingStatus,
-			additionalMountsFunc: func() []systemdMount {
-				return []systemdMount{
-					s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
-					s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
-				}
-			},
-			enableKernel: s.kernel,
-			snapFiles:    []snap.PlaceInfo{s.core20, s.kernel},
-			comment:      "happy fallback kernel_status trying no try kernel",
+			kernelStatus:   boot.TryingStatus,
+			enableKernel:   s.kernel,
+			snapFiles:      []snap.PlaceInfo{s.core20, s.kernel},
+			expRebootPanic: "reboot due to no try kernel snap",
+			comment:        "happy fallback kernel_status trying no try kernel",
 		},
 
 		// unhappy cases
@@ -1456,6 +1444,13 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 		comment := Commentf(t.comment)
 
 		var cleanups []func()
+
+		if t.expRebootPanic != "" {
+			r := boot.MockInitramfsReboot(func() error {
+				panic(t.expRebootPanic)
+			})
+			cleanups = append(cleanups, r)
+		}
 
 		// setup unique root dir per test
 		rootDir := c.MkDir()
@@ -1509,23 +1504,28 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 		// dir for each test case
 		makeSnapFilesOnEarlyBootUbuntuData(c, t.snapFiles...)
 
-		_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
-		if t.expError != "" {
-			c.Assert(err, ErrorMatches, t.expError, comment)
+		if t.expRebootPanic != "" {
+			f := func() { main.Parser().ParseArgs([]string{"initramfs-mounts"}) }
+			c.Assert(f, PanicMatches, t.expRebootPanic, comment)
 		} else {
-			c.Assert(err, IsNil, comment)
+			_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+			if t.expError != "" {
+				c.Assert(err, ErrorMatches, t.expError, comment)
+			} else {
+				c.Assert(err, IsNil, comment)
 
-			// check the resultant modeenv
-			// if the expModeenv is nil, we just compare to the start
-			newModeenv, err := boot.ReadModeenv(boot.InitramfsWritableDir)
-			c.Assert(err, IsNil, comment)
-			m := t.modeenv
-			if t.expModeenv != nil {
-				m = t.expModeenv
+				// check the resultant modeenv
+				// if the expModeenv is nil, we just compare to the start
+				newModeenv, err := boot.ReadModeenv(boot.InitramfsWritableDir)
+				c.Assert(err, IsNil, comment)
+				m := t.modeenv
+				if t.expModeenv != nil {
+					m = t.expModeenv
+				}
+				c.Assert(newModeenv.BaseStatus, DeepEquals, m.BaseStatus, comment)
+				c.Assert(newModeenv.TryBase, DeepEquals, m.TryBase, comment)
+				c.Assert(newModeenv.Base, DeepEquals, m.Base, comment)
 			}
-			c.Assert(newModeenv.BaseStatus, DeepEquals, m.BaseStatus, comment)
-			c.Assert(newModeenv.TryBase, DeepEquals, m.TryBase, comment)
-			c.Assert(newModeenv.Base, DeepEquals, m.Base, comment)
 		}
 
 		for _, r := range cleanups {
@@ -1805,7 +1805,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
-	
+
 	mockDisk := &disks.MockDiskMapping{
 		FilesystemLabelToPartUUID: map[string]string{
 			"ubuntu-seed":     "ubuntu-seed-partuuid",


### PR DESCRIPTION
We currently have a bug where we when we go to try a kernel snap revision that
was booted, if it fails verification somehow in the initramfs, we decide to
mount the old kernel snap even though we are running the new kernel snap. This
is problematic for things like kernel modules and firmware which are not
guaranteed to be compatible across kernel snap revisions.

The correct thing to do, which this commit implements, is to request a reboot
from the initramfs when we encounter this situation, as this will indicate to
the bootloader that the boot of the new kernel snap failed and that it should
rollback and boot the old kernel, in which case we will make the correct and
obvious choice in the initramfs to mount/use the old kernel, which fixes the
bug.

We simulate the reboot in tests with a panic.
