### PR TITLE
tests/nested/core20/kernel-failover: add test for failed refresh of uc20 kernel

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -921,6 +921,10 @@ nested_copy() {
     sshpass -p ubuntu scp -P "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$@" user1@localhost:~
 }
 
+nested_copy_from_remote() {
+    sshpass -p ubuntu scp -P "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost:"$1" "$2"
+}
+
 nested_add_tty_chardev() {
     local CHARDEV_ID=$1
     local CHARDEV_PATH=$2

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -418,12 +418,12 @@ nested_create_core_vm() {
                 elif nested_is_core_20_system; then
                     snap download --basename=pc-kernel --channel="20/edge" pc-kernel
                     uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+                    rm -f "$PWD/pc-kernel.snap"
 
                     # Prepare the pc kernel snap
                     KERNEL_SNAP=$(ls "$NESTED_ASSETS_DIR"/pc-kernel_*.snap)
 
                     chmod 0600 "$KERNEL_SNAP"
-                    rm -f "$PWD/pc-kernel.snap"
                     EXTRA_FUNDAMENTAL="--snap $KERNEL_SNAP"
 
                     # Prepare the pc gadget snap (unless provided by extra-snaps)

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -419,24 +419,11 @@ nested_create_core_vm() {
                     snap download --basename=pc-kernel --channel="20/edge" pc-kernel
                     uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
 
-                    # Get the snakeoil key and cert
-                    local KEY_NAME SNAKEOIL_KEY SNAKEOIL_CERT
-                    KEY_NAME=$(nested_get_snakeoil_key)
-                    SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
-                    SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
-
                     # Prepare the pc kernel snap
-                    local KERNEL_SNAP KERNEL_UNPACKED
                     KERNEL_SNAP=$(ls "$NESTED_ASSETS_DIR"/pc-kernel_*.snap)
-                    KERNEL_UNPACKED="$NESTED_ASSETS_DIR"/kernel-unpacked
-                    unsquashfs -d "$KERNEL_UNPACKED" "$KERNEL_SNAP"
-                    sbattach --remove "$KERNEL_UNPACKED/kernel.efi"
-                    sbsign --key "$SNAKEOIL_KEY" --cert "$SNAKEOIL_CERT" "$KERNEL_UNPACKED/kernel.efi"  --output "$KERNEL_UNPACKED/kernel.efi"
-                    snap pack "$KERNEL_UNPACKED" "$NESTED_ASSETS_DIR"
 
                     chmod 0600 "$KERNEL_SNAP"
                     rm -f "$PWD/pc-kernel.snap"
-                    rm -rf "$KERNEL_UNPACKED"
                     EXTRA_FUNDAMENTAL="--snap $KERNEL_SNAP"
 
                     # Prepare the pc gadget snap (unless provided by extra-snaps)
@@ -447,6 +434,12 @@ nested_create_core_vm() {
                     fi
                     # XXX: deal with [ "$NESTED_ENABLE_SECURE_BOOT" != "true" ] && [ "$NESTED_ENABLE_TPM" != "true" ]
                     if [ -z "$GADGET_SNAP" ]; then
+                        # Get the snakeoil key and cert
+                        local KEY_NAME SNAKEOIL_KEY SNAKEOIL_CERT
+                        KEY_NAME=$(nested_get_snakeoil_key)
+                        SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+                        SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+
                         snap download --basename=pc --channel="20/edge" pc
                         unsquashfs -d pc-gadget pc.snap
                         nested_secboot_sign_gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"

--- a/tests/nested/core20/kernel-failover/task.yaml
+++ b/tests/nested/core20/kernel-failover/task.yaml
@@ -1,0 +1,91 @@
+summary: Check that a broken kernel snap automatically rolls itself back
+
+prepare: |
+  echo "Build a broken kernel snap where the initramfs panic's"
+
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB/prepare.sh"
+
+  # shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  # use the kernel snap from the nested VM and repack it so that it panic's in
+  # the initramfs and rolls back to the original version
+  # TODO:UC20: this doesn't work for some reason when we copy it from the 
+  #            running system, we should look into that, but for now just 
+  #            re-download the snap
+  snap download pc-kernel --channel=20/edge --basename=pc-kernel
+  rm -rf repacked-kernel
+  uc20_build_initramfs_kernel_snap pc-kernel.snap "$PWD" --inject-kernel-panic-in-initramfs
+  mv pc-kernel_*.snap panicking-initramfs-kernel.snap
+
+execute: |
+  # shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  # Copy the broken initramfs kernel snap to the UC20 VM
+  nested_copy panicking-initramfs-kernel.snap
+
+  # wait for snapd to be "available"
+  retry=120
+  wait=1
+  until nested_exec command -v snap; do
+      retry=$(( retry - 1 ))
+      if [ $retry -le 0 ]; then
+          echo "Timed out waiting for no snap command. Aborting!"
+          exit 1
+      fi
+      sleep "$wait"
+  done
+
+  # Wait for snapd to be seeded
+  nested_exec sudo snap wait system seed.loaded
+
+  # Get the current revision of the kernel snap
+  # TODO:UC20: enable for pi-kernel, etc. when used with external systems
+  startRevision=$(nested_exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')
+  if [ -z "${startRevision}" ]; then
+    echo "missing pc-kernel revision"
+    exit 1
+  fi
+
+  boot_id="$( nested_get_boot_id )"
+
+  # Install it and get the ID for the change
+  REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous panicking-initramfs-kernel.snap --no-wait)
+
+  # wait for a reboot
+  nested_wait_for_reboot "${boot_id}"
+
+  # Wait for the change to finish - note it will exit with non-zero since the 
+  # change will fail, so don't let that kill the test here
+  if nested_exec sudo snap watch "${REMOTE_CHG_ID}"; then 
+    echo "remote snap change ${REMOTE_CHG_ID} for broken kernel snap refresh should have failed!"
+    exit 1
+  fi
+
+  # Check that the refresh failed
+  nested_exec sudo snap changes | grep "${REMOTE_CHG_ID}" | MATCH Error
+  nested_exec sudo snap tasks "${REMOTE_CHG_ID}" | MATCH "cannot finish .* installation, there was a rollback across reboot"
+
+  # We should be on the same revision of the kernel snap
+  if [ "$(nested_exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')" != "${startRevision}" ]; then
+    echo "pc-kernel is on the wrong revision"
+    exit 1
+  fi
+
+  # Make sure we don't have leftover bootenv
+  nested_exec sudo snap debug boot-vars --uc20 | MATCH '^kernel_status=$'
+
+  # Make sure that we don't have extra assets in the ubuntu-boot dir and that
+  # the currently enabled kernel is the original kernel
+
+  # kernel.efi symlink should point to the original kernel
+  nested_exec readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi | MATCH "pc-kernel_${startRevision}.snap/kernel.efi"
+  # should still have pc-kernel_$rev.snap dir
+  nested_exec test -d "/run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_${startRevision}.snap"
+  if [ "$(nested_exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap | wc -l)" != 1 ]; then
+    echo "Extra leftover pc-kernel assets in ubuntu-boot:"
+    nested_exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap
+    exit 1
+  fi


### PR DESCRIPTION
This exercises both the snapd logic for falling back properly and cleaning up
after a failed refresh, as well as pc-gadget grub.conf logic that rollbacks are
handled properly.

Eventually with resealing there should be additional things we check for here,
but for now it's sufficient to show that the kernel got rolled back successfully
and that we don't leave any intermediate state behind about the attempted
refresh.

Also some miscellaneous nested.sh improvements.