### PR TITLE
daemon: correctly parse Content-Type HTTP header.

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1378,7 +1378,12 @@ func snapsOp(c *Command, r *http.Request, user *auth.UserState) Response {
 func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 	contentType := r.Header.Get("Content-Type")
 
-	if contentType == "application/json" {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil || mediaType != "application/json" {
+		return BadRequest("unknown content type: %s", contentType)
+	}
+
+	if mediaType == "application/json" {
 		return snapsOp(c, r, user)
 	}
 
@@ -1392,11 +1397,6 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	// POSTs to sideload snaps must be a multipart/form-data file upload.
-	_, params, err := mime.ParseMediaType(contentType)
-	if err != nil {
-		return BadRequest("cannot parse POST body: %v", err)
-	}
-
 	form, err := multipart.NewReader(r.Body, params["boundary"]).ReadForm(maxReadBuflen)
 	if err != nil {
 		return BadRequest("cannot read POST form: %v", err)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1383,8 +1383,11 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot parse content type: %v", err)
 	}
 
-	charset := strings.ToUpper(params["charset"])
-	if mediaType == "application/json" && (charset == "" || charset == "UTF-8") {
+	if mediaType == "application/json" {
+		charset := strings.ToUpper(params["charset"])
+		if (charset != "" && charset != "UTF-8") {
+			return BadRequest("unknown charset in content type: %s", contentType)
+		}
 		return snapsOp(c, r, user)
 	}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1383,7 +1383,7 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot parse content type: %v", err)
 	}
 
-	charset := params["charset"].ToUpper()
+	charset := strings.ToUpper(params["charset"])
 	if mediaType == "application/json" && (charset == "" || charset == "UTF-8") {
 		return snapsOp(c, r, user)
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1383,7 +1383,7 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot parse content type: %v", err)
 	}
 
-	charset := params["charset"].ToUpper();
+	charset := params["charset"].ToUpper()
 	if mediaType == "application/json" && (charset == "" || charset == "UTF-8") {
 		return snapsOp(c, r, user)
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1379,8 +1379,8 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 	contentType := r.Header.Get("Content-Type")
 
 	mediaType, params, err := mime.ParseMediaType(contentType)
-	if err != nil || mediaType != "application/json" {
-		return BadRequest("unknown content type: %s", contentType)
+	if err != nil {
+		return BadRequest("cannot parse content type: %v", err)
 	}
 
 	if mediaType == "application/json" {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1385,7 +1385,7 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	if mediaType == "application/json" {
 		charset := strings.ToUpper(params["charset"])
-		if (charset != "" && charset != "UTF-8") {
+		if charset != "" && charset != "UTF-8" {
 			return BadRequest("unknown charset in content type: %s", contentType)
 		}
 		return snapsOp(c, r, user)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1383,7 +1383,8 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot parse content type: %v", err)
 	}
 
-	if mediaType == "application/json" {
+	charset := params["charset"].ToUpper();
+	if mediaType == "application/json" && (charset == "" || charset == "UTF-8") {
 		return snapsOp(c, r, user)
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4163,7 +4163,15 @@ func (s *apiSuite) TestSwitchInstruction(c *check.C) {
 	}
 }
 
-func (s *apiSuite) TestPostSnapsOp(c *check.C) {
+func (s *apiSuite) TestPostSnapOp(c *check.C) {
+	s.testPostSnapsOp(c, "application/json")
+}
+
+func (s *apiSuite) TestPostSnapOpMoreComplexContentType(c *check.C) {
+	s.testPostSnapsOp(c, "application/json; charset=utf-8")
+}
+
+func (s *apiSuite) testPostSnapsOp(c *check.C, contentType string) {
 	assertstateRefreshSnapDeclarations = func(*state.State, int) error { return nil }
 	snapstateUpdateMany = func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
 		c.Check(names, check.HasLen, 0)
@@ -4176,7 +4184,7 @@ func (s *apiSuite) TestPostSnapsOp(c *check.C) {
 	buf := bytes.NewBufferString(`{"action": "refresh"}`)
 	req, err := http.NewRequest("POST", "/v2/snaps", buf)
 	c.Assert(err, check.IsNil)
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentType)
 
 	rsp, ok := postSnaps(snapsCmd, req, nil).(*resp)
 	c.Assert(ok, check.Equals, true)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4179,14 +4179,12 @@ func (s *apiSuite) TestPostSnapOpInvalidCharset(c *check.C) {
 		return []string{"fake1", "fake2"}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	}
 
-	d := s.daemonWithOverlordMock(c)
-
 	buf := bytes.NewBufferString(`{"action": "refresh"}`)
 	req, err := http.NewRequest("POST", "/v2/snaps", buf)
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "application/json; charset=iso-8859-1")
 
-	rsp, ok := postSnaps(snapsCmd, req, nil).(*resp)
+	rsp := postSnaps(snapsCmd, req, nil).(*resp)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "unknown charset in content type")
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4172,13 +4172,6 @@ func (s *apiSuite) TestPostSnapOpMoreComplexContentType(c *check.C) {
 }
 
 func (s *apiSuite) TestPostSnapOpInvalidCharset(c *check.C) {
-	assertstateRefreshSnapDeclarations = func(*state.State, int) error { return nil }
-	snapstateUpdateMany = func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
-		c.Check(names, check.HasLen, 0)
-		t := s.NewTask("fake-refresh-all", "Refreshing everything")
-		return []string{"fake1", "fake2"}, []*state.TaskSet{state.NewTaskSet(t)}, nil
-	}
-
 	buf := bytes.NewBufferString(`{"action": "refresh"}`)
 	req, err := http.NewRequest("POST", "/v2/snaps", buf)
 	c.Assert(err, check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4174,7 +4174,7 @@ func (s *apiSuite) TestPostSnapsOp(c *check.C) {
 	d := s.daemonWithOverlordMock(c)
 
 	buf := bytes.NewBufferString(`{"action": "refresh"}`)
-	req, err := http.NewRequest("POST", "/v2/login", buf)
+	req, err := http.NewRequest("POST", "/v2/snaps", buf)
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -21,6 +21,7 @@ package agent
 
 import (
 	"encoding/json"
+	"mime"
 	"net/http"
 	"strings"
 	"sync"
@@ -167,7 +168,9 @@ type dummyReporter struct{}
 func (dummyReporter) Notify(string) {}
 
 func postServiceControl(c *Command, r *http.Request) Response {
-	if contentType := r.Header.Get("Content-Type"); contentType != "application/json" {
+	contentType := r.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil || mediaType != "application/json" {
 		return BadRequest("unknown content type: %s", contentType)
 	}
 

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -170,7 +170,7 @@ func (dummyReporter) Notify(string) {}
 func postServiceControl(c *Command, r *http.Request) Response {
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
-	charset := params["charset"].ToUpper()
+	charset := strings.ToUpper(params["charset"])
 	if err != nil || mediaType != "application/json" || !(charset == "" || charset == "UTF-8") {
 		return BadRequest("unknown content type: %s", contentType)
 	}

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -170,7 +170,7 @@ func (dummyReporter) Notify(string) {}
 func postServiceControl(c *Command, r *http.Request) Response {
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
-	charset := params["charset"].ToUpper();
+	charset := params["charset"].ToUpper()
 	if err != nil || mediaType != "application/json" || !(charset == "" || charset == "UTF-8") {
 		return BadRequest("unknown content type: %s", contentType)
 	}

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -170,9 +170,17 @@ func (dummyReporter) Notify(string) {}
 func postServiceControl(c *Command, r *http.Request) Response {
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
-	charset := strings.ToUpper(params["charset"])
-	if err != nil || mediaType != "application/json" || !(charset == "" || charset == "UTF-8") {
+	if err != nil {
+		return BadRequest("cannot parse content type: %v", err)
+	}
+
+	if mediaType != "application/json" {
 		return BadRequest("unknown content type: %s", contentType)
+	}
+
+	charset := strings.ToUpper(params["charset"])
+	if (charset != "" && charset != "UTF-8") {
+		return BadRequest("unknown charset in content type: %s", contentType)
 	}
 
 	decoder := json.NewDecoder(r.Body)

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -179,7 +179,7 @@ func postServiceControl(c *Command, r *http.Request) Response {
 	}
 
 	charset := strings.ToUpper(params["charset"])
-	if (charset != "" && charset != "UTF-8") {
+	if charset != "" && charset != "UTF-8" {
 		return BadRequest("unknown charset in content type: %s", contentType)
 	}
 

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -169,8 +169,9 @@ func (dummyReporter) Notify(string) {}
 
 func postServiceControl(c *Command, r *http.Request) Response {
 	contentType := r.Header.Get("Content-Type")
-	mediaType, _, err := mime.ParseMediaType(contentType)
-	if err != nil || mediaType != "application/json" {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	charset := params["charset"].ToUpper();
+	if err != nil || mediaType != "application/json" || !(charset == "" || charset == "UTF-8") {
 		return BadRequest("unknown content type: %s", contentType)
 	}
 

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -114,6 +114,20 @@ func (s *restSuite) TestServiceControlDaemonReloadComplexerContentType(c *C) {
 	s.testServiceControlDaemonReload(c, "application/json; charset=utf-8")
 }
 
+func (s *restSuite) TestServiceControlDaemonReloadInvalidCharset(c *C) {
+	_, err := agent.New()
+	c.Assert(err, IsNil)
+
+	req, err := http.NewRequest("POST", "/v1/service-control", bytes.NewBufferString(`{"action":"daemon-reload"}`))
+	req.Header.Set("Content-Type", "application/json; charset=iso-8859-1")
+	c.Assert(err, IsNil)
+	rec := httptest.NewRecorder()
+	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
+	c.Check(rec.Code, Equals, 400)
+	c.Check(rec.Body.String(), testutil.Contains,
+		"unknown charset in content type")
+}
+
 func (s *restSuite) testServiceControlDaemonReload(c *C, contentType string) {
 	_, err := agent.New()
 	c.Assert(err, IsNil)

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -107,11 +107,19 @@ func (s *restSuite) TestServiceControl(c *C) {
 }
 
 func (s *restSuite) TestServiceControlDaemonReload(c *C) {
+	s.testServiceControlDaemonReload(c, "application/json")
+}
+
+func (s *restSuite) TestServiceControlDaemonReloadComplexerContentType(c *C) {
+	s.testServiceControlDaemonReload(c, "application/json; charset=utf-8")
+}
+
+func (s *restSuite) testServiceControlDaemonReload(c *C, contentType string) {
 	_, err := agent.New()
 	c.Assert(err, IsNil)
 
 	req, err := http.NewRequest("POST", "/v1/service-control", bytes.NewBufferString(`{"action":"daemon-reload"}`))
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentType)
 	c.Assert(err, IsNil)
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)


### PR DESCRIPTION
The previous code was checking it was set to 'application/json'. However some
clients will send 'application/json; charset=utf-8' which is also valid and
should be allowed.

