### PR TITLE
cgroup,snap: track hooks on system bus only

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1122,10 +1122,13 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 		// sufficient to identify both the snap name and the app name.
 		needsTracking = false
 	}
+	// Allow using the session bus for all apps but not for hooks.
+	allowSessionBus := hook == ""
 	// Track, or confirm existing tracking from systemd.
 	var trackingErr error
 	if needsTracking {
-		trackingErr = cgroupCreateTransientScopeForTracking(securityTag)
+		opts := &cgroup.TrackingOptions{AllowSessionBus: allowSessionBus}
+		trackingErr = cgroupCreateTransientScopeForTracking(securityTag, opts)
 	} else {
 		trackingErr = cgroupConfirmSystemdServiceTracking(securityTag)
 	}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/image"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/sandbox/selinux"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
@@ -327,7 +328,7 @@ func MockSignalNotify(newSignalNotify func(sig ...os.Signal) (chan os.Signal, fu
 
 type ServiceName = serviceName
 
-func MockCreateTransientScopeForTracking(fn func(securityTag string) error) (restore func()) {
+func MockCreateTransientScopeForTracking(fn func(securityTag string, opts *cgroup.TrackingOptions) error) (restore func()) {
 	old := cgroupCreateTransientScopeForTracking
 	cgroupCreateTransientScopeForTracking = fn
 	return func() {

--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -11,19 +11,26 @@ environment:
     USER/root: root
     USER/test: test
 prepare: |
+    tests.cleanup prepare
+
     # This feature depends on the release-app-awareness feature
     snap set core experimental.refresh-app-awareness=true
+    tests.cleanup defer snap unset core experimental.refresh-app-awareness
 
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-sh
+    snap pack test-snapd-tracking
+    tests.cleanup defer rm -f test-snapd-tracking_1_all.snap
+
+    snap install --dangerous ./test-snapd-tracking_1_all.snap
+    tests.cleanup defer snap remove test-snapd-tracking
 
     tests.session -u "$USER" prepare
+    tests.cleanup defer tests.session -u "$USER" restore
 
 restore: |
-    snap unset core experimental.refresh-app-awareness
-    tests.session -u "$USER" restore
+    tests.cleanup restore
+
     rm -f /tmp/*.pid /tmp/*.stamp
+
     if [ "$USER" = root ]; then
         systemctl --user stop dbus.service || true
     fi
@@ -34,36 +41,6 @@ debug: |
     cat /proc/cmdline
 
 execute: |
-    # TODO: add a variant that uses a service
-    if [ "$USER" = test ] && "$TESTSTOOLS"/version-compare --strict "$(systemctl --version | head -n 1 | cut -d ' ' -f 2)" -lt 238; then
-        echo "Systemd running as user session manager cannot start transient units"
-        echo "that cross ownership boundary. This test effectively runs through root"
-        echo "that is using ssh to connect to a test machine. Crossing the boundary"
-        echo "of cgroup ownership is allowed by systemd 238 or newer, thanks to"
-        echo "org.freedesktop.systemd1.Manager.AttachProcessesToUnit method,"
-        echo "offered by systemd running as system manager, which allows"
-        echo "overcoming this kernel limitation".
-        echo "SKIP: systemd is too old to perform this test as user"
-
-        # This effectively can run starting with Ubuntu 19.10, Fedora 30,
-        # Debian 10 (but no version of openSUSE Leap yet) - older versions will
-        # not perform in this unique environment that spread provides for us.
-        # In typical desktop environment going all the way back to 16.04 should
-        # work fine, as far as the intended use-case is concerned.
-
-        exit 0
-    fi
-    if [ "$USER" = test ]; then
-        case "$SPREAD_SYSTEM" in
-            ubuntu-core-*)
-                echo "On core systems there is no session bus so the test variant does not make much sense"
-                echo "Please see the cgroup-tracking-failure test for more extensive analysis"
-                echo "SKIP: core systems don't have session services / session bus"
-                exit 0
-                ;;
-        esac
-    fi
-
     # This test varies between Ubuntu 16.04, Ubuntu 18.04 and Fedora 31.
     # This combination exercises each of the three cases below, namely:
     # - pure cgroup v2 system, like Fedora 31
@@ -83,28 +60,70 @@ execute: |
         echo "cannot find any tracking cgroup"
         exit 1
     fi
-
     echo "Sanity check, base directory of selected cgroup exists."
     test -d "$base_cg_path"
+
+    # The configure hook was executed and used a scope for tracking. The scope
+    # was attached to the system slice, as it is not associated with any user.
+    test -f /var/snap/test-snapd-tracking/common/configure.cgroup
+    hook_tracking_cg_path="$(grep -E "^$base_cg_id:" < /var/snap/test-snapd-tracking/common/configure.cgroup | cut -d : -f 3)"
+    echo "$hook_tracking_cg_path" | MATCH '/system\.slice/snap\.test-snapd-tracking\.hook\.configure\.[0-9a-f-]+\.scope'
+
+    # The nap service was executed and was tracked as a systemd service.
+    test -f /var/snap/test-snapd-tracking/common/nap.cgroup
+    service_tracking_cg_path="$(grep -E "^$base_cg_id:" < /var/snap/test-snapd-tracking/common/nap.cgroup | cut -d : -f 3)"
+    echo "$service_tracking_cg_path" | MATCH '/system\.slice/snap\.test-snapd-tracking\.nap\.service'
+
+    # The application tracking is tested below.
+    if [ "$USER" = test ] && "$TESTSTOOLS"/version-compare --strict "$(systemctl --version | head -n 1 | cut -d ' ' -f 2)" -lt 238; then
+        echo "Systemd running as user session manager cannot start transient units"
+        echo "that cross ownership boundary. This test effectively runs through root"
+        echo "that is using ssh to connect to a test machine. Crossing the boundary"
+        echo "of cgroup ownership is allowed by systemd 238 or newer, thanks to"
+        echo "org.freedesktop.systemd1.Manager.AttachProcessesToUnit method,"
+        echo "offered by systemd running as system manager, which allows"
+        echo "overcoming this kernel limitation".
+        echo "SKIP: systemd is too old to perform this test as user"
+
+        # This effectively can run starting with Ubuntu 19.10, Fedora 30,
+        # Debian 10 (but no version of openSUSE Leap yet) - older versions will
+        # not perform in this unique environment that spread provides for us.
+        # In typical desktop environment going all the way back to 16.04 should
+        # work fine, as far as the intended use-case is concerned.
+
+        exit 0
+    fi
+
+    if [ "$USER" = test ]; then
+        case "$SPREAD_SYSTEM" in
+            # XXX: this may now pass on core18+, verify that.
+            ubuntu-core-*)
+                echo "On core systems there is no session bus so the test variant does not make much sense"
+                echo "Please see the cgroup-tracking-failure test for more extensive analysis"
+                echo "SKIP: core systems don't have session services / session bus"
+                exit 0
+                ;;
+        esac
+    fi
 
     echo "Start a \"sleep\" process in the background, in a new session"
     # NOTE: tests.session handles PAM and that necessitates a management process
     # that eventually performs PAM termination activities. The PID returned from
     # invoking tests.session in the background will not be that of the invoked program
     # but rather of the monitoring helper process.
-    tests.session -p /tmp/1.pid -u "$USER" exec snap run test-snapd-sh.sh -c 'touch /tmp/1.stamp && exec sleep 3m' &
+    tests.session -p /tmp/1.pid -u "$USER" exec snap run test-snapd-tracking.sh -c 'touch /tmp/1.stamp && exec sleep 3m' &
     session1_pid=$!
     trap "pkill sleep || true" EXIT
     echo "Ensure that snap-confine has finished its task and that the snap process"
     echo "is active. Note that we don't want to wait forever either."
-    retry -n 30 test -e /tmp/snap.test-snapd-sh/tmp/1.stamp
+    retry -n 30 test -e /tmp/snap.test-snapd-tracking/tmp/1.stamp
     pid1_sleep=$(cat /tmp/1.pid)
 
     echo "During startup snap-run has asked systemd to move the process to a"
-    echo "new transient scope. The scope name is \"snap.\$random.test-snapd-sh.sh\"."
+    echo "new transient scope. The scope name is \"snap.\$random.test-snapd-tracking.sh\"."
     echo "Let's verify that."
     pid1_tracking_cg_path="$(grep -E "^$base_cg_id:" < "/proc/$pid1_sleep/cgroup" | cut -d : -f 3)"
-    echo "$pid1_tracking_cg_path" | MATCH '.*/snap\.test-snapd-sh\.sh\.[0-9a-f-]+\.scope'
+    echo "$pid1_tracking_cg_path" | MATCH '.*/snap\.test-snapd-tracking\.sh\.[0-9a-f-]+\.scope'
 
     echo "Sanity check, cgroup associated with the scope exists."
     test -d "${base_cg_path}${pid1_tracking_cg_path}"
@@ -114,12 +133,12 @@ execute: |
 
     echo "Start a second process so that we can check each scope is independent."
     #shellcheck disable=SC2016
-    tests.session -p /tmp/2.pid -u "$USER" exec snap run test-snapd-sh.sh -c 'touch /tmp/2.stamp && exec sleep 2m' &
+    tests.session -p /tmp/2.pid -u "$USER" exec snap run test-snapd-tracking.sh -c 'touch /tmp/2.stamp && exec sleep 2m' &
     session2_pid=$!
-    retry -n 30 test -e /tmp/snap.test-snapd-sh/tmp/2.stamp
+    retry -n 30 test -e /tmp/snap.test-snapd-tracking/tmp/2.stamp
     pid2_sleep=$(cat /tmp/2.pid)
     pid2_tracking_cg_path="$(grep -E "^$base_cg_id:" < "/proc/$pid2_sleep/cgroup" | cut -d : -f 3)"
-    echo "$pid2_tracking_cg_path" | MATCH '.*/snap\.test-snapd-sh\.sh\.[0-9a-f-]+\.scope'
+    echo "$pid2_tracking_cg_path" | MATCH '.*/snap\.test-snapd-tracking\.sh\.[0-9a-f-]+\.scope'
     MATCH "$pid2_sleep" < "${base_cg_path}${pid2_tracking_cg_path}/cgroup.procs"
 
     echo "Each invocation uses a new transient scope and thus a new cgroup path."
@@ -137,9 +156,9 @@ execute: |
 
     echo "If a snap command forks a child process it is also tracked."
     #shellcheck disable=SC2016
-    tests.session -p /tmp/3.pid -u "$USER" exec snap run test-snapd-sh.sh -c 'touch /tmp/3.stamp && sleep 1m' &
+    tests.session -p /tmp/3.pid -u "$USER" exec snap run test-snapd-tracking.sh -c 'touch /tmp/3.stamp && sleep 1m' &
     session3_pid=$!
-    retry -n 30 test -e /tmp/snap.test-snapd-sh/tmp/3.stamp
+    retry -n 30 test -e /tmp/snap.test-snapd-tracking/tmp/3.stamp
     pid3_sh=$(cat /tmp/3.pid)
     pid3_tracking_cg_path="$(grep -E "^$base_cg_id:" < "/proc/$pid3_sh/cgroup" | cut -d : -f 3)"
     MATCH "$pid3_sh" < "${base_cg_path}${pid3_tracking_cg_path}/cgroup.procs"

--- a/tests/main/cgroup-tracking/test-snapd-tracking/bin/nap
+++ b/tests/main/cgroup-tracking/test-snapd-tracking/bin/nap
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat /proc/self/cgroup > "$SNAP_COMMON/nap.cgroup"
+exec sleep infinity

--- a/tests/main/cgroup-tracking/test-snapd-tracking/bin/sh
+++ b/tests/main/cgroup-tracking/test-snapd-tracking/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/cgroup-tracking/test-snapd-tracking/meta/hooks/configure
+++ b/tests/main/cgroup-tracking/test-snapd-tracking/meta/hooks/configure
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec cat /proc/self/cgroup > "$SNAP_COMMON/configure.cgroup"

--- a/tests/main/cgroup-tracking/test-snapd-tracking/meta/snap.yaml
+++ b/tests/main/cgroup-tracking/test-snapd-tracking/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: test-snapd-tracking
+summary: A snap tailored for testing application tracking
+version: 1
+
+apps:
+    sh:
+        command: bin/sh
+    nap:
+        command: bin/nap
+        daemon: simple
+hooks:
+    configure:


### PR DESCRIPTION
I left a small TODO that became relevant just now. Hooks were using the
same uid-based tracking decision. For root user we would try the session
bus first and only later fall back to system bus.

For hooks it makes no sense to track them on the session bus, they are
not a property of the root session. They are a system-wide property.

Introduce TrackingOptions and allow CreateTransientScopeForTracking to
optionally use it to disable attempts to use the session bus. Use the
new capability to ensure that hooks do not use the session bus for
tracking.

Existing unit tests are extended and adjusted to observe the new behavior.
The spread test is extended to measure tracking of hooks and system-wide
services.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
