### PR TITLE
mkversion.sh: do not use git describe --dirty

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -39,7 +39,9 @@ fi
 
 # Let's try to derive the version from git..
 if command -v git >/dev/null; then
-    version_from_git="$(git describe --dirty --always | sed -e 's/-/+git/;y/-/./' )"
+    # do not use --dirty until snapcraft deals with this correctly
+    version_from_git="$(git describe --always | sed -e 's/-/+git/;y/-/./' )"
+    echo "version from git: $version_from_git"
 fi
 
 # at this point we maybe in _build/src/github etc where we have no
@@ -47,6 +49,7 @@ fi
 # switch to the real source dir for the changelog parsing
 if command -v dpkg-parsechangelog >/dev/null; then
     version_from_changelog="$(cd "$PKG_BUILDDIR"; dpkg-parsechangelog --show-field Version)";
+    echo "version from changelog: $version_from_changelog"
 fi
 
 # select version based on priority


### PR DESCRIPTION
mkversion.sh: do not use git describe --dirty

The most recent snapd snap build generates a version number:
2.46+git2.46.2.46

This indicates that the change in c8da36b that added --dirty
generated a "-dirty" version number and hence the check if
the version is a release failed.

It turns out that the hash of the vendor.json changed and
this caused the "dirty" flag in git. Given that it's time
consuming to do a point release because of issues like this
I would like to avoid using "--dirty" to deal with flukes
like this. Alternatively we need to include the "dirty"
flag in the auto-generated git versions too and watch out
for them so that future releases are not affected by this.

Something like:
```
@@ -82,9 +82,10 @@ if [ -z "$version_from_user" ] && [ "$version_from_git" != "" ] && [ "$version_f
         echo "Cannot generate version, there is a version from git and the changelog has a git version"
         exit 1
     else
-        revno=$(git describe --always --abbrev=7|cut -d- -f2)
-        commit=$(git describe --always --abbrev=7|cut -d- -f3)
-        v="${version_from_changelog}+git${revno}.${commit}"
+        revno=$(git describe --dirty --always --abbrev=7|cut -d- -f2)
+        commit=$(git describe --dirty  --always --abbrev=7|cut -d- -f3)
+        dirty=".$(git describe --dirty  --always --abbrev=7|cut -d- -f4)"
+        v="${version_from_changelog}+git${revno}.${commit}${dirty}"
         o="changelog+git"
     fi
 fi
```
