### PR TITLE
vendor.json: update mysterious secboot SHA again

### DIFF
--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -434,7 +434,7 @@ snapd (2.46-1) unstable; urgency=medium
     - tests: modernize and use snapd.tool
     - vendor: update to latest github.com/snapcore/bolt for riscv64
     - cmd/snap-confine: add support for libc6-lse
-    - interfaces: miscellanious policy updates xlv
+    - interfaces: miscellaneous policy updates xlv
     - interfaces/system-packages-doc: fix typo in variable names
     - tests: port interfaces-calendar-service to tests.session
     - tests: install/run the lzo test snap too
@@ -627,7 +627,7 @@ snapd (2.46-1) unstable; urgency=medium
     - store: handle error-list in fetch-assertions results
     - tests: port interfaces-audio-playback-record to session-tool
     - data/completion: add `snap` command completion for zsh
-    - tests/degrated: ignore failure in systemd-vconsole-setup.service
+    - tests/degraded: ignore failure in systemd-vconsole-setup.service
     - image: stub implementation of image.Prepare for darwin
     - tests: session-tool --restore -u stops user-$UID.slice
     - o/ifacestate/handlers.go: fix typo

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -1350,7 +1350,7 @@ fi
  - tests: modernize and use snapd.tool
  - vendor: update to latest github.com/snapcore/bolt for riscv64
  - cmd/snap-confine: add support for libc6-lse
- - interfaces: miscellanious policy updates xlv
+ - interfaces: miscellaneous policy updates xlv
  - interfaces/system-packages-doc: fix typo in variable names
  - tests: port interfaces-calendar-service to tests.session
  - tests: install/run the lzo test snap too
@@ -1543,7 +1543,7 @@ fi
  - store: handle error-list in fetch-assertions results
  - tests: port interfaces-audio-playback-record to session-tool
  - data/completion: add `snap` command completion for zsh
- - tests/degrated: ignore failure in systemd-vconsole-setup.service
+ - tests/degraded: ignore failure in systemd-vconsole-setup.service
  - image: stub implementation of image.Prepare for darwin
  - tests: session-tool --restore -u stops user-$UID.slice
  - o/ifacestate/handlers.go: fix typo

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -434,7 +434,7 @@ snapd (2.46~14.04) trusty; urgency=medium
     - tests: modernize and use snapd.tool
     - vendor: update to latest github.com/snapcore/bolt for riscv64
     - cmd/snap-confine: add support for libc6-lse
-    - interfaces: miscellanious policy updates xlv
+    - interfaces: miscellaneous policy updates xlv
     - interfaces/system-packages-doc: fix typo in variable names
     - tests: port interfaces-calendar-service to tests.session
     - tests: install/run the lzo test snap too
@@ -627,7 +627,7 @@ snapd (2.46~14.04) trusty; urgency=medium
     - store: handle error-list in fetch-assertions results
     - tests: port interfaces-audio-playback-record to session-tool
     - data/completion: add `snap` command completion for zsh
-    - tests/degrated: ignore failure in systemd-vconsole-setup.service
+    - tests/degraded: ignore failure in systemd-vconsole-setup.service
     - image: stub implementation of image.Prepare for darwin
     - tests: session-tool --restore -u stops user-$UID.slice
     - o/ifacestate/handlers.go: fix typo

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -434,7 +434,7 @@ snapd (2.46) xenial; urgency=medium
     - tests: modernize and use snapd.tool
     - vendor: update to latest github.com/snapcore/bolt for riscv64
     - cmd/snap-confine: add support for libc6-lse
-    - interfaces: miscellanious policy updates xlv
+    - interfaces: miscellaneous policy updates xlv
     - interfaces/system-packages-doc: fix typo in variable names
     - tests: port interfaces-calendar-service to tests.session
     - tests: install/run the lzo test snap too
@@ -627,7 +627,7 @@ snapd (2.46) xenial; urgency=medium
     - store: handle error-list in fetch-assertions results
     - tests: port interfaces-audio-playback-record to session-tool
     - data/completion: add `snap` command completion for zsh
-    - tests/degrated: ignore failure in systemd-vconsole-setup.service
+    - tests/degraded: ignore failure in systemd-vconsole-setup.service
     - image: stub implementation of image.Prepare for darwin
     - tests: session-tool --restore -u stops user-$UID.slice
     - o/ifacestate/handlers.go: fix typo

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -110,7 +110,7 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "UHhUJNcYbKn3xxZDuPh9GX6BWrM=",
+			"checksumSHA1": "uLS+3ymPr8NztAjDjmiRkpKIsIQ=",
 			"path": "github.com/snapcore/secboot",
 			"revision": "68200eea7bdcb97e27fe8e5ff443776383908637",
 			"revisionTime": "2020-08-13T11:40:20Z"


### PR DESCRIPTION
This should make the snapd snap behave when generated git versions, at least it does for me when I built it locally, I get just 2.46 as the version number (but note that I locally changed the 2.46 tag to point to the commit from this branch, otherwise you will get a diff between the changelog and this commit that doesn't reflect the current problem we have in LP).

Still unclear what makes the SHA change like this for the same commit message