### PR TITLE
run-checks: add typos from auto-tools when using `make hack`

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -235,7 +235,7 @@ if [ "$STATIC" = 1 ]; then
         if [ "$file" = "vendor" ] || [ "$file" = "po" ]; then
             continue
         fi
-        misspell -error -i auther,PROCES,PROCESSS,proces,processs,exportfs "$file"
+        misspell -error -i auther,PROCES,PROCESSS,proces,processs,exportfs,includ,nto,maked,occurence "$file"
     done
 
     echo "Checking for ineffective assignments"


### PR DESCRIPTION
These typos prevent a clean run-checks run, and as they come from auto-generated
files we should ignore them:

```
$ ./run-checks --static
Obtaining dependencies
Checking docs
Running vet
Checking for usages of http.Status*
Checking for direct usages of math/rand
Checking shell scripts...
Checking spelling errors
cmd/config.sub:117:2: "nto" is a misspelling of "not"
cmd/config.sub:1401:7: "nto" is a misspelling of "not"
cmd/config.sub:1405:2: "nto" is a misspelling of "not"
cmd/config.sub:1407:2: "nto" is a misspelling of "not"
cmd/config.sub:1408:27: "nto" is a misspelling of "not"
cmd/config.sub:1408:31: "nto" is a misspelling of "not"
cmd/config.guess:1332:42: "nto" is a misspelling of "not"
cmd/depcomp:438:26: "Maked" is a misspelling of "Marked"
cmd/depcomp:447:14: "Maked" is a misspelling of "Marked"
cmd/depcomp:451:10: "Maked" is a misspelling of "Marked"
cmd/aclocal.m4:111:22: "occurence" is a misspelling of "occurrence"
cmd/configure:996:6: "includ" is a misspelling of "include"
cmd/configure:999:6: "includ" is a misspelling of "include"
cmd/configure:1197:49: "includ" is a misspelling of "include"
cmd/configure:1200:55: "includ" is a misspelling of "include"
cmd/autom4te.cache/output.1:996:6: "includ" is a misspelling of "include"
cmd/autom4te.cache/output.1:999:6: "includ" is a misspelling of "include"
cmd/autom4te.cache/output.1:1197:49: "includ" is a misspelling of "include"
cmd/autom4te.cache/output.1:1200:55: "includ" is a misspelling of "include"
cmd/autom4te.cache/output.0:996:6: "includ" is a misspelling of "include"
cmd/autom4te.cache/output.0:999:6: "includ" is a misspelling of "include"
cmd/autom4te.cache/output.0:1197:49: "includ" is a misspelling of "include"
cmd/autom4te.cache/output.0:1200:55: "includ" is a misspelling of "include"

Crushing failure and despair.
```

these files come from running `make hack` as mentioned in the HACKING.md file we have