### PR TITLE
run-checks: only check files in git for misspelling

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -231,12 +231,9 @@ if [ "$STATIC" = 1 ]; then
     if ! command -v misspell >/dev/null; then
         go get -u github.com/client9/misspell/cmd/misspell
     fi
-    for file in *; do
-        if [ "$file" = "vendor" ] || [ "$file" = "po" ]; then
-            continue
-        fi
-        misspell -error -i auther,PROCES,PROCESSS,proces,processs,exportfs "$file"
-    done
+    MISSPELL_IGNORE="auther,PROCES,PROCESSS,proces,processs,exportfs"
+    git ls-files -z -- . ':!:./po' ':!:./vendor' |
+        xargs -0 misspell -error -i "$MISSPELL_IGNORE"
 
     echo "Checking for ineffective assignments"
     if ! command -v ineffassign >/dev/null; then

--- a/run-checks
+++ b/run-checks
@@ -231,6 +231,9 @@ if [ "$STATIC" = 1 ]; then
     if ! command -v misspell >/dev/null; then
         go get -u github.com/client9/misspell/cmd/misspell
     fi
+    # FIXME: auter is only misspelled in the changelog so we should fix there
+    # PROCES is used in the seccomp tests (PRIO_PROCES{,S,SS})
+    # exportfs is used in the nfs-support test
     MISSPELL_IGNORE="auther,PROCES,PROCESSS,proces,processs,exportfs"
     git ls-files -z -- . ':!:./po' ':!:./vendor' |
         xargs -0 misspell -error -i "$MISSPELL_IGNORE"


### PR DESCRIPTION
This commit changes run-checks to only run "misspell" on files
that are in git. This avoids running it against the generated
autotools files that have some typos in them.

This is an alternative solution for the problem Ian outlined in #9217
