### PR TITLE
interfaces/utf: Add MIRKey to u2f devices

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -116,6 +116,11 @@ var u2fDevices = []u2fDevice{
 		VendorIDPattern:  "1d50",
 		ProductIDPattern: "60fc",
 	},
+	{
+		Name:             "MIRKey",
+		VendorIDPattern:  "0483",
+		ProductIDPattern: "a2ac",
+	},
 }
 
 const u2fDevicesConnectedPlugAppArmor = `

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -86,7 +86,7 @@ func (s *u2fDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 16)
+	c.Assert(spec.Snippets(), HasLen, 17)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
The MIRKey supports both FIDO U2F and FIDO2 - please add it to the U2F device list.

Thanks