### PR TITLE
snap: add size to the random access file return interface

### DIFF
--- a/snap/container.go
+++ b/snap/container.go
@@ -33,11 +33,12 @@ type Container interface {
 	Size() (int64, error)
 
 	// RandomAccessFile returns an implementation to read at any
-	// given location for a single file inside the snap.
+	// given location for a single file inside the snap plus
+	// information about the file size.
 	RandomAccessFile(relative string) (interface {
 		io.ReaderAt
 		io.Closer
-		Size() (int64, error)
+		Size() int64
 	}, error)
 
 	// ReadFile returns the content of a single file from the snap.

--- a/snap/container.go
+++ b/snap/container.go
@@ -37,6 +37,7 @@ type Container interface {
 	RandomAccessFile(relative string) (interface {
 		io.ReaderAt
 		io.Closer
+		Stat() (os.FileInfo, error)
 	}, error)
 
 	// ReadFile returns the content of a single file from the snap.

--- a/snap/container.go
+++ b/snap/container.go
@@ -37,7 +37,7 @@ type Container interface {
 	RandomAccessFile(relative string) (interface {
 		io.ReaderAt
 		io.Closer
-		Stat() (os.FileInfo, error)
+		Size() (int64, error)
 	}, error)
 
 	// ReadFile returns the content of a single file from the snap.

--- a/snap/internal/file.go
+++ b/snap/internal/file.go
@@ -1,0 +1,36 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import (
+	"os"
+)
+
+type SizedFile struct {
+	*os.File
+}
+
+func (f SizedFile) Size() (int64, error) {
+	fi, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}

--- a/snap/internal/file.go
+++ b/snap/internal/file.go
@@ -23,14 +23,20 @@ import (
 	"os"
 )
 
+// SizedFile holds an os.File plus its (initial) size.
 type SizedFile struct {
 	*os.File
+	size int64
 }
 
-func (f SizedFile) Size() (int64, error) {
+func NewSizedFile(f *os.File) (*SizedFile, error) {
 	fi, err := f.Stat()
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return fi.Size(), nil
+	return &SizedFile{File: f, size: fi.Size()}, nil
+}
+
+func (f *SizedFile) Size() int64 {
+	return f.size
 }

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -74,6 +74,7 @@ func (s *SnapDir) Install(targetPath, mountDir string, opts *snap.InstallOptions
 func (s *SnapDir) RandomAccessFile(file string) (interface {
 	io.ReaderAt
 	io.Closer
+	Stat() (os.FileInfo, error)
 }, error) {
 	return os.Open(filepath.Join(s.path, file))
 }

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -75,13 +75,13 @@ func (s *SnapDir) Install(targetPath, mountDir string, opts *snap.InstallOptions
 func (s *SnapDir) RandomAccessFile(file string) (interface {
 	io.ReaderAt
 	io.Closer
-	Size() (int64, error)
+	Size() int64
 }, error) {
 	f, err := os.Open(filepath.Join(s.path, file))
 	if err != nil {
 		return nil, err
 	}
-	return internal.SizedFile{f}, nil
+	return internal.NewSizedFile(f)
 }
 
 func (s *SnapDir) ReadFile(file string) (content []byte, err error) {

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/internal"
 )
 
 func IsSnapDir(path string) bool {
@@ -74,9 +75,13 @@ func (s *SnapDir) Install(targetPath, mountDir string, opts *snap.InstallOptions
 func (s *SnapDir) RandomAccessFile(file string) (interface {
 	io.ReaderAt
 	io.Closer
-	Stat() (os.FileInfo, error)
+	Size() (int64, error)
 }, error) {
-	return os.Open(filepath.Join(s.path, file))
+	f, err := os.Open(filepath.Join(s.path, file))
+	if err != nil {
+		return nil, err
+	}
+	return internal.SizedFile{f}, nil
 }
 
 func (s *SnapDir) ReadFile(file string) (content []byte, err error) {

--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -82,9 +82,9 @@ func (s *SnapdirTestSuite) TestRandomAccessFile(c *C) {
 	c.Assert(err, IsNil)
 	defer r.Close()
 
-	ri, err := r.Stat()
+	size, err := r.Size()
 	c.Assert(err, IsNil)
-	c.Assert(ri.Size(), Equals, int64(5))
+	c.Assert(size, Equals, int64(5))
 
 	b := make([]byte, 2)
 	n, err := r.ReadAt(b, 2)

--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -82,9 +82,7 @@ func (s *SnapdirTestSuite) TestRandomAccessFile(c *C) {
 	c.Assert(err, IsNil)
 	defer r.Close()
 
-	size, err := r.Size()
-	c.Assert(err, IsNil)
-	c.Assert(size, Equals, int64(5))
+	c.Assert(r.Size(), Equals, int64(5))
 
 	b := make([]byte, 2)
 	n, err := r.ReadAt(b, 2)

--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -82,6 +82,10 @@ func (s *SnapdirTestSuite) TestRandomAccessFile(c *C) {
 	c.Assert(err, IsNil)
 	defer r.Close()
 
+	ri, err := r.Stat()
+	c.Assert(err, IsNil)
+	c.Assert(ri.Size(), Equals, int64(5))
+
 	b := make([]byte, 2)
 	n, err := r.ReadAt(b, 2)
 	c.Assert(err, IsNil)

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -242,6 +242,7 @@ func (s *Snap) withUnpackedFile(filePath string, f func(p string) error) error {
 func (s *Snap) RandomAccessFile(filePath string) (interface {
 	io.ReaderAt
 	io.Closer
+	Stat() (os.FileInfo, error)
 }, error) {
 	var f *os.File
 	err := s.withUnpackedFile(filePath, func(p string) (err error) {

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -238,12 +238,13 @@ func (s *Snap) withUnpackedFile(filePath string, f func(p string) error) error {
 	return f(filepath.Join(unpackDir, filePath))
 }
 
-// RandomAccessFile returns an implementation to read at any given location
-// for a single file inside the squashfs snap.
+// RandomAccessFile returns an implementation to read at any given
+// location for a single file inside the squashfs snap plus
+// information about the file size.
 func (s *Snap) RandomAccessFile(filePath string) (interface {
 	io.ReaderAt
 	io.Closer
-	Size() (int64, error)
+	Size() int64
 }, error) {
 	var f *os.File
 	err := s.withUnpackedFile(filePath, func(p string) (err error) {
@@ -253,7 +254,7 @@ func (s *Snap) RandomAccessFile(filePath string) (interface {
 	if err != nil {
 		return nil, err
 	}
-	return internal.SizedFile{f}, nil
+	return internal.NewSizedFile(f)
 }
 
 // ReadFile returns the content of a single file inside a squashfs snap.

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/internal"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -242,7 +243,7 @@ func (s *Snap) withUnpackedFile(filePath string, f func(p string) error) error {
 func (s *Snap) RandomAccessFile(filePath string) (interface {
 	io.ReaderAt
 	io.Closer
-	Stat() (os.FileInfo, error)
+	Size() (int64, error)
 }, error) {
 	var f *os.File
 	err := s.withUnpackedFile(filePath, func(p string) (err error) {
@@ -252,7 +253,7 @@ func (s *Snap) RandomAccessFile(filePath string) (interface {
 	if err != nil {
 		return nil, err
 	}
-	return f, nil
+	return internal.SizedFile{f}, nil
 }
 
 // ReadFile returns the content of a single file inside a squashfs snap.

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -328,9 +328,7 @@ func (s *SquashfsTestSuite) TestRandomAccessFile(c *C) {
 	c.Assert(err, IsNil)
 	defer r.Close()
 
-	size, err := r.Size()
-	c.Assert(err, IsNil)
-	c.Assert(size, Equals, int64(9))
+	c.Assert(r.Size(), Equals, int64(9))
 
 	b := make([]byte, 4)
 	n, err := r.ReadAt(b, 4)

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -328,6 +328,10 @@ func (s *SquashfsTestSuite) TestRandomAccessFile(c *C) {
 	c.Assert(err, IsNil)
 	defer r.Close()
 
+	ri, err := r.Stat()
+	c.Assert(err, IsNil)
+	c.Assert(ri.Size(), Equals, int64(9))
+
 	b := make([]byte, 4)
 	n, err := r.ReadAt(b, 4)
 	c.Assert(err, IsNil)

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -328,9 +328,9 @@ func (s *SquashfsTestSuite) TestRandomAccessFile(c *C) {
 	c.Assert(err, IsNil)
 	defer r.Close()
 
-	ri, err := r.Stat()
+	size, err := r.Size()
 	c.Assert(err, IsNil)
-	c.Assert(ri.Size(), Equals, int64(9))
+	c.Assert(size, Equals, int64(9))
 
 	b := make([]byte, 4)
 	n, err := r.ReadAt(b, 4)


### PR DESCRIPTION
Add ~~Stat()~~ Size() to the RandomAccessFile return interface to be used ~~to
implement Size()~~ in snapcore/secboot's EFIImage interface.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>