### PR TITLE
interfaces/systemd: compare dereferenced Service

### DIFF
--- a/interfaces/systemd/spec.go
+++ b/interfaces/systemd/spec.go
@@ -37,8 +37,8 @@ type Specification struct {
 
 // AddService adds a new systemd service unit.
 func (spec *Specification) AddService(name string, s *Service) error {
-	if old, ok := spec.services[name]; ok && old != s {
-		return fmt.Errorf("interface requires conflicting system needs")
+	if old, ok := spec.services[name]; ok && old != nil && s != nil && *old != *s {
+		return fmt.Errorf("interface requires conflicting system needs: service %q used to be defined as %#v, now re-defined as %#v", name, *old, *s)
 	}
 	if spec.services == nil {
 		spec.services = make(map[string]*Service)

--- a/interfaces/systemd/spec_test.go
+++ b/interfaces/systemd/spec_test.go
@@ -51,5 +51,15 @@ func (s *specSuite) TestClashing(c *C) {
 	err := spec.AddService("foo.service", svc1)
 	c.Assert(err, IsNil)
 	err = spec.AddService("foo.service", svc2)
-	c.Assert(err, ErrorMatches, "interface requires conflicting system needs")
+	c.Assert(err, ErrorMatches, `interface requires conflicting system needs: service "foo.service" used to be defined as .*, now re-defined as .*`)
+}
+
+func (s *specSuite) TestDifferentObjectsNotClashing(c *C) {
+	svc1 := &systemd.Service{ExecStart: "one and the same"}
+	svc2 := &systemd.Service{ExecStart: "one and the same"}
+	spec := systemd.Specification{}
+	err := spec.AddService("foo.service", svc1)
+	c.Assert(err, IsNil)
+	err = spec.AddService("foo.service", svc2)
+	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
The systemd backend is relatively unique, as it is only used by one
interface. The GPIO interface uses it to create systemd units which
export GPIOs from kernel / firmware to userspace and back.

The specification system for the systemd backend is comprised of named
services. The code allows for repeated generation of identical services,
sharing the same name, that are coalesced as long as their definitions
are identical.

Based on a customer report, we found a mistake in how this coalescing
was performed. The code performed pointer comparison, not object
equality comparison. This patch fixes this issue, adds unit tests
checking that case and improves the diagnostic error message to simplify
debugging in the future.

Fixes: https://bugs.launchpad.net/tillamook/+bug/1892804
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
