### PR TITLE
tests: account for apt-get on core18

### DIFF
--- a/tests/core/apt/task.yaml
+++ b/tests/core/apt/task.yaml
@@ -1,24 +1,14 @@
-summary: Ensure that the apt output on UC16 is correct
-
+summary: Ensure that the core systems have a special apt placeholder
+systems: [ubuntu-core-*]
 execute: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
-    if is_core16_system; then
-        # UC16 has apt-get output a message
-        expected="Ubuntu Core does not use apt-get, see 'snap --help'!"
-        if apt-get update > output.txt; then
-            echo "apt should exit 1 but did not"
-            exit 1
-        fi
-        if [ "$(cat output.txt)" != "$expected" ]; then
-            echo "Unexpected apt output: $(cat output.txt)"
-            exit 1
-        fi
-    else 
-        # UC18+ does not have apt-get at all
-        if command -v apt-get; then
-            echo "apt-get command exists on Ubuntu Core, but should not!"
-            exit 1
-        fi
-    fi
+  case "$SPREAD_SYSTEM" in
+    # Some core systems have the fake apt-get script.
+    ubuntu-core-16-*|ubuntu-core-18-*)
+      apt-get | MATCH "Ubuntu Core does not use apt-get, see 'snap --help'!"
+      not apt-get
+      ;;
+    # Other systems do not.
+    ubuntu-core-*)
+      test "$(command -v apt-get)" = ""
+      ;;
+  esac


### PR DESCRIPTION
For unknown reasons core18 now contains the fake apt-get script, while
core20 does not. Adjust the test to match reality.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
