### PR TITLE
tests: update listing test for "-dirty" versions

### DIFF
--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -20,7 +20,7 @@ execute: |
     # Expressions for version and revision
     NUMERIC_VERSION="[0-9]+(\.[0-9]+)*"
     CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)?"
-    SNAPD_GIT_VERSION="+[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-z]+)?"
+    SNAPD_GIT_VERSION="+[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-z]+)?(-dirty)?"
     FINAL_VERSION="[0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+[0-9]+\\.[0-9a-f]+)?"
     SIDELOAD_REV="x[0-9]+"
     NUMBER_REV="[0-9]+"


### PR DESCRIPTION
Allow -dirty as part of the version number for the snapd snap.
This fixes the "listing" test that currently fails in master.
