### PR TITLE
run-checks: check for dirty build tree too

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -394,3 +394,9 @@ $UNCLEAN
 EOF
     exit 1
 fi
+
+if git describe --always --dirty | grep -q dirty; then
+    echo "Build tree is dirty"
+    git diff
+    exit 1
+fi


### PR DESCRIPTION
This commit errors early if we "dirty" the build tree during
the unit tests.