### PR TITLE
vendor: run ./get-deps.sh to update the secboot hash

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -110,7 +110,7 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "UHhUJNcYbKn3xxZDuPh9GX6BWrM=",
+			"checksumSHA1": "uLS+3ymPr8NztAjDjmiRkpKIsIQ=",
 			"path": "github.com/snapcore/secboot",
 			"revision": "68200eea7bdcb97e27fe8e5ff443776383908637",
 			"revisionTime": "2020-08-13T11:40:20Z"


### PR DESCRIPTION
The snap build of snapd produces a dirty git tree right now. This
leads to test failures in the listing test and is generally
undesired. This commit updates the hash of secboot to fix this.


