### PR TITLE
tests: new tests for nested and external

### DIFF
--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -1,6 +1,6 @@
 summary: Check basic core20 system functionality
 
-systems: [ubuntu-core-20-*]
+systems: [ubuntu-core-2*]
 
 execute: |
     echo "Check that the system snaps are there"

--- a/tests/core/tpm/task.yaml
+++ b/tests/core/tpm/task.yaml
@@ -1,0 +1,25 @@
+summary: Run a smoke test on UC20 with encryption enabled
+
+description: |
+    This test checks basic snapd commands on UC20 with secure boot and encryption enabled
+
+systems: [ubuntu-core-2*]
+
+# Do not remove manual:true, it is used to run just when the test is targeted
+manual: true
+
+execute: |
+
+    echo "Verifying tpm working on the nested vm"
+    dmesg | grep -i tpm | MATCH "efi: +SMBIOS=.* +TPMFinalLog=.*
+    test -e /sys/kernel/security/tpm0/binary_bios_measurements
+
+    echo "and secure boot is enabled on the nested vm"
+    xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c | MATCH "00000000: 0600 0000 01\s+....."
+
+    echo "and the recovery key is available"
+    test -e /var/lib/snapd/device/fde/recovery.key
+    echo "and has the expected size"
+    stat --printf=%s /var/lib/snapd/device/fde/recovery.key | MATCH '^16$'
+    echo "and has the expected owner and permissions"
+    stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key | MATCH '^0:0 600$'

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -795,6 +795,27 @@ copy_remote(){
     sshpass -p ubuntu scp -P "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$@" user1@localhost:~
 }
 
+run_local_test(){
+    local TESTS_TO_RUN=$1
+    set +x
+    fetch_spread
+    NESTED_SPREAD_SYSTEM=$(get_nested_spread_system)
+    SPREAD_EXTERNAL_ADDRESS=localhost:"$SSH_PORT" "$WORK_DIR/spread" -v "external:$NESTED_SPREAD_SYSTEM:$TESTS_TO_RUN"
+}
+
+get_nested_spread_system(){
+    if is_core_20_nested_system ; then
+        echo ubuntu-core-20-64
+    elif is_core_18_nested_system; then
+        echo ubuntu-core-18-64
+    elif is_core_16_nested_system; then
+        echo ubuntu-core-16-64
+    else
+        echo "unsupported nested system"
+        exit 1
+    fi
+}
+
 add_tty_chardev(){
     local CHARDEV_ID=$1
     local CHARDEV_PATH=$2

--- a/tests/nested/core20/basic/task.yaml
+++ b/tests/nested/core20/basic/task.yaml
@@ -6,28 +6,5 @@ description: |
 execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
-
-    # wait for the system to be seeded first
-    execute_remote "sudo snap wait system seed.loaded"
-
-    echo "Ensure 'snap install' works"
-    # The install command could cause a ssh break, so || true is used
-    # and then we check the installation was completed successfully
-    execute_remote "sudo snap install test-snapd-sh" || true
-
-    echo "Ensure 'snap list' works and test-snapd-sh snap is installed"
-    execute_remote "snap list" | MATCH test-snapd-sh
-
-    echo "Ensure 'snap find' works"
-    execute_remote "snap find test-snapd-sh" | MATCH ^test-snapd-sh
-
-    echo "Ensure 'snap info' works"
-    execute_remote "snap info test-snapd-sh" | MATCH '^name:\ +test-snapd-sh'
-
-    echo "Ensure 'snap remove' works"
-    # The install command could cause a ssh break, so || true is used
-    # and then we check the removal was completed successfully
-    execute_remote "sudo snap remove test-snapd-sh" || true
-
-    echo "Ensure 'snap list' works and test-snapd-sh snap is removed"
-    not execute_remote "snap list test-snapd-sh"
+    run_local_test tests/core/basic20
+    

--- a/tests/nested/core20/tpm/task.yaml
+++ b/tests/nested/core20/tpm/task.yaml
@@ -6,17 +6,4 @@ description: |
 execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
-
-    echo "Verifying tpm working on the nested vm"
-    execute_remote "dmesg | grep -i tpm" | MATCH "efi: +SMBIOS=.* +TPMFinalLog=.*"
-    execute_remote "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
-
-    echo "and secure boot is enabled on the nested vm"
-    execute_remote "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
-
-    echo "and the recovery key is available"
-    execute_remote "test -e /var/lib/snapd/device/fde/recovery.key"
-    echo "and has the expected size"
-    execute_remote "stat --printf=%s /var/lib/snapd/device/fde/recovery.key" | MATCH '^16$'
-    echo "and has the expected owner and permissions"
-    execute_remote "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$' 
+    run_local_test tests/core/tpm


### PR DESCRIPTION
The idea of this change is to allow to run some tests which are currently executed on nested vms but on boards.

This is the first step to validate the idea and the new tests will be migrated. 