### PR TITLE
kernel: remove "edition" from kernel.yaml and add "update"

### DIFF
--- a/kernel/kernel.go
+++ b/kernel/kernel.go
@@ -27,13 +27,13 @@ import (
 	"regexp"
 
 	"gopkg.in/yaml.v2"
-
-	"github.com/snapcore/snapd/gadget/edition"
 )
 
 type Asset struct {
-	Edition edition.Number `yaml:"edition,omitempty"`
-	Content []string       `yaml:"content,omitempty"`
+	// TODO: we may make this an (optional) map at some point in
+	//       the future to select what things should be updated.
+	Update  bool     `yaml:"update,omitempty"`
+	Content []string `yaml:"content,omitempty"`
 }
 
 type Info struct {

--- a/kernel/kernel.go
+++ b/kernel/kernel.go
@@ -32,6 +32,8 @@ import (
 type Asset struct {
 	// TODO: we may make this an (optional) map at some point in
 	//       the future to select what things should be updated.
+	//
+	// Update set to true indicates that assets shall be updated.
 	Update  bool     `yaml:"update,omitempty"`
 	Content []string `yaml:"content,omitempty"`
 }

--- a/kernel/kernel_test.go
+++ b/kernel/kernel_test.go
@@ -57,7 +57,7 @@ func TestCommand(t *testing.T) { TestingT(t) }
 var mockKernelYaml = []byte(`
 assets:
   dtbs:
-    edition: 1
+    update: true
     content:
       - dtbs/bcm2711-rpi-4-b.dtb
       - dtbs/bcm2836-rpi-2-b.dtb
@@ -86,7 +86,7 @@ func (s *kernelYamlTestSuite) TestInfoFromKernelYamlHappy(c *C) {
 	c.Check(ki, DeepEquals, &kernel.Info{
 		Assets: map[string]*kernel.Asset{
 			"dtbs": {
-				Edition: 1,
+				Update: true,
 				Content: []string{
 					"dtbs/bcm2711-rpi-4-b.dtb",
 					"dtbs/bcm2836-rpi-2-b.dtb",
@@ -128,7 +128,7 @@ func (s *kernelYamlTestSuite) TestReadKernelYamlHappy(c *C) {
 	c.Check(ki, DeepEquals, &kernel.Info{
 		Assets: map[string]*kernel.Asset{
 			"dtbs": {
-				Edition: 1,
+				Update: true,
 				Content: []string{
 					"dtbs/bcm2711-rpi-4-b.dtb",
 					"dtbs/bcm2836-rpi-2-b.dtb",


### PR DESCRIPTION
This commit changes the supported yaml for the kernel snap. For
the raspberry pi DTB use case the kernel assets are tightly
coupled with the kernel. So the edition would have to be bumped
every time the kernel is build. So the edition does not make much
sense in this context. Hence a new "update" field that is boolean
for now but we may expand it later into a map. This map would
allow to specify what content items should get updated and which
should not get updated.

We could now also move edition back into gadget. If desired I can
do that via a followup.
