### PR TITLE
many: check that users of BaseTest don't forget to consume cleanups

### DIFF
--- a/cmd/snap-repair/main_test.go
+++ b/cmd/snap-repair/main_test.go
@@ -76,6 +76,10 @@ func (r *repairSuite) SetUpTest(c *C) {
 	r.AddCleanup(func() { dirs.SetRootDir("/") })
 }
 
+func (r *repairSuite) TearDownTest(c *C) {
+	r.BaseTest.TearDownTest(c)
+}
+
 func (r *repairSuite) Stdout() string {
 	return r.stdout.String()
 }

--- a/cmd/snap-repair/main_test.go
+++ b/cmd/snap-repair/main_test.go
@@ -77,6 +77,7 @@ func (r *repairSuite) SetUpTest(c *C) {
 }
 
 func (r *repairSuite) TearDownTest(c *C) {
+	r.baseRunnerSuite.TearDownTest(c)
 	r.BaseTest.TearDownTest(c)
 }
 

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -142,15 +142,14 @@ func (s *SnapSuite) TestInterfacesOneSlotOnePlug(c *C) {
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), testutil.EqualsWrapped, InterfacesDeprecationNotice)
 
-	s.SetUpTest(c)
+	s.ResetStdStreams()
 	// should be the same
 	rest, err = Parser(Client()).ParseArgs([]string{"interfaces", "canonical-pi2"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), testutil.EqualsWrapped, InterfacesDeprecationNotice)
-
-	s.SetUpTest(c)
+	s.ResetStdStreams()
 	// and the same again
 	rest, err = Parser(Client()).ParseArgs([]string{"interfaces", "keyboard-lights"})
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -86,10 +86,6 @@ type deviceMgrBaseSuite struct {
 
 	restartRequests []state.RestartType
 
-	restoreOnClassic         func()
-	restoreGenericClassicMod func()
-	restoreSanitize          func()
-
 	newFakeStore func(storecontext.DeviceBackend) snapstate.StoreService
 
 	// saved so that if a derived suite wants to undo the cloud-init mocking to
@@ -134,16 +130,18 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
 	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
 	os.MkdirAll(dirs.SnapRunDir, 0755)
 
 	s.restartRequests = nil
 
-	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	s.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(s.bootloader)
+	s.AddCleanup(func() { bootloader.Force(nil) })
 
-	s.restoreOnClassic = release.MockOnClassic(false)
+	s.AddCleanup(release.MockOnClassic(false))
 
 	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
 	s.o = overlord.MockWithStateAndRestartHandler(nil, func(req state.RestartType) {
@@ -155,7 +153,7 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	s.state.Unlock()
 	s.se = s.o.StateEngine()
 
-	s.restoreGenericClassicMod = sysdb.MockGenericClassicModel(s.storeSigning.GenericClassicModel)
+	s.AddCleanup(sysdb.MockGenericClassicModel(s.storeSigning.GenericClassicModel))
 
 	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
 	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
@@ -174,6 +172,11 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	s.state.Lock()
 	assertstate.ReplaceDB(s.state, db)
 	s.state.Unlock()
+	s.AddCleanup(func() {
+		s.state.Lock()
+		assertstate.ReplaceDB(s.state, nil)
+		s.state.Unlock()
+	})
 
 	err = db.Add(s.storeSigning.StoreAccountKey(""))
 	c.Assert(err, IsNil)
@@ -208,23 +211,13 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	s.restoreCloudInitStatusRestore = devicestate.MockCloudInitStatus(func() (sysconfig.CloudInitState, error) {
 		return sysconfig.CloudInitRestrictedBySnapd, nil
 	})
+	s.AddCleanup(s.restoreCloudInitStatusRestore)
+
+	s.AddCleanup(func() { s.ancillary = nil })
 }
 
 func (s *deviceMgrBaseSuite) newStore(devBE storecontext.DeviceBackend) snapstate.StoreService {
 	return s.newFakeStore(devBE)
-}
-
-func (s *deviceMgrBaseSuite) TearDownTest(c *C) {
-	s.ancillary = nil
-	s.state.Lock()
-	assertstate.ReplaceDB(s.state, nil)
-	s.state.Unlock()
-	bootloader.Force(nil)
-	dirs.SetRootDir("")
-	s.restoreGenericClassicMod()
-	s.restoreOnClassic()
-	s.restoreSanitize()
-	s.restoreCloudInitStatusRestore()
 }
 
 func (s *deviceMgrBaseSuite) settle(c *C) {

--- a/testutil/base.go
+++ b/testutil/base.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -31,15 +31,19 @@ type BaseTest struct {
 
 // SetUpTest prepares the cleanup
 func (s *BaseTest) SetUpTest(c *check.C) {
-	s.cleanupHandlers = nil
+	if len(s.cleanupHandlers) != 0 {
+		panic("BaseTest cleanup handlers were not consumed before a new test start, missing BaseTest.TearDownTest call?")
+	}
 }
 
 // TearDownTest cleans up the channel.ini files in case they were changed by
 // the test.
 // It also runs the cleanup handlers
 func (s *BaseTest) TearDownTest(c *check.C) {
-	// run cleanup handlers and clear the slice
-	for _, f := range s.cleanupHandlers {
+	// run cleanup handlers in reverse order and clear the slice
+	n := len(s.cleanupHandlers)
+	for i := range s.cleanupHandlers {
+		f := s.cleanupHandlers[n-1-i]
 		f()
 	}
 	s.cleanupHandlers = nil


### PR DESCRIPTION
make their order of execution also LIFO which is more expected

fix places that were wrong, also cleanup some of devicestate
suites to use AddCleanup more and not need specific TearDownTest