### PR TITLE
many: misc doc-comment changes and typo fixes

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -415,12 +415,12 @@ func (mod *Model) Classic() bool {
 	return mod.classic
 }
 
-// Architecture returns the archicteture the model is based on.
+// Architecture returns the architecture the model is based on.
 func (mod *Model) Architecture() string {
 	return mod.HeaderString("architecture")
 }
 
-// Grade returns the stability grade of the model. Will be ModeGradeUnset
+// Grade returns the stability grade of the model. Will be ModelGradeUnset
 // for Core 16/18 models.
 func (mod *Model) Grade() ModelGrade {
 	return mod.grade

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2276,6 +2276,8 @@ func NumSnaps(st *state.State) (int, error) {
 }
 
 // Set sets the SnapState of the given snap, overwriting any earlier state.
+// Note that a SnapState with an empty Sequence will be treated as if snapst was
+// nil and name will be deleted from the state.
 func Set(st *state.State, name string, snapst *SnapState) {
 	var snaps map[string]*json.RawMessage
 	err := st.Get("snaps", &snaps)

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -44,6 +44,8 @@ type Options struct {
 	GadgetDir string
 }
 
+// FilesystemOnlyApplyOptions is the set of options for
+// ApplyFilesystemOnlyDefaults.
 type FilesystemOnlyApplyOptions struct {
 	// Classic is true when the system in rootdir is a classic system
 	Classic bool


### PR DESCRIPTION
See commit messages for individual changes

To be clear, there are no actual code changes here, so this can be landed orthogonally to all my other cloud-init PR's and isn't labeled as such.