### PR TITLE
o/devicestate/devicestate_cloudinit_test.go: test cleanup for uc20 cloud-init tests

### DIFF
--- a/overlord/devicestate/devicestate_cloudinit_test.go
+++ b/overlord/devicestate/devicestate_cloudinit_test.go
@@ -160,7 +160,9 @@ func (s *cloudInitSuite) TestCloudInitDeviceManagerEnsureRestrictsCloudInit(c *C
 }
 
 func (s *cloudInitSuite) TestCloudInitAlreadyRestrictedDoesNothing(c *C) {
+	statusCalls := 0
 	r := devicestate.MockCloudInitStatus(func() (sysconfig.CloudInitState, error) {
+		statusCalls++
 		return sysconfig.CloudInitRestrictedBySnapd, nil
 	})
 	defer r()
@@ -173,6 +175,7 @@ func (s *cloudInitSuite) TestCloudInitAlreadyRestrictedDoesNothing(c *C) {
 
 	err := devicestate.EnsureCloudInitRestricted(s.mgr)
 	c.Assert(err, IsNil)
+	c.Assert(statusCalls, Equals, 1)
 }
 
 func (s *cloudInitSuite) TestCloudInitAlreadyRestrictedFileDoesNothing(c *C) {

--- a/overlord/devicestate/devicestate_cloudinit_test.go
+++ b/overlord/devicestate/devicestate_cloudinit_test.go
@@ -264,8 +264,9 @@ fi`)
 	r := devicestate.MockRestrictCloudInit(func(state sysconfig.CloudInitState, opts *sysconfig.CloudInitRestrictOptions) (sysconfig.CloudInitRestrictionResult, error) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitUntriggered)
-		c.Assert(opts, Not(IsNil))
-		c.Assert(opts.ForceDisable, Equals, false)
+		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
+			ForceDisable: false,
+		})
 		// we would have disabled it
 		return sysconfig.CloudInitRestrictionResult{Action: "disable"}, nil
 	})
@@ -306,8 +307,9 @@ fi`)
 	r := devicestate.MockRestrictCloudInit(func(state sysconfig.CloudInitState, opts *sysconfig.CloudInitRestrictOptions) (sysconfig.CloudInitRestrictionResult, error) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitDone)
-		c.Assert(opts, Not(IsNil))
-		c.Assert(opts.ForceDisable, Equals, false)
+		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
+			ForceDisable: false,
+		})
 		// we would have restricted it since it ran
 		return sysconfig.CloudInitRestrictionResult{
 			// pretend it was NoCloud
@@ -353,8 +355,9 @@ fi`)
 	r := devicestate.MockRestrictCloudInit(func(state sysconfig.CloudInitState, opts *sysconfig.CloudInitRestrictOptions) (sysconfig.CloudInitRestrictionResult, error) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitDone)
-		c.Assert(opts, Not(IsNil))
-		c.Assert(opts.ForceDisable, Equals, false)
+		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
+			ForceDisable: false,
+		})
 		// we would have restricted it since it ran
 		return sysconfig.CloudInitRestrictionResult{
 			// pretend it was GCE
@@ -416,8 +419,9 @@ fi`, cloudInitScriptStateFile))
 	r := devicestate.MockRestrictCloudInit(func(state sysconfig.CloudInitState, opts *sysconfig.CloudInitRestrictOptions) (sysconfig.CloudInitRestrictionResult, error) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitDone)
-		c.Assert(opts, Not(IsNil))
-		c.Assert(opts.ForceDisable, Equals, false)
+		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
+			ForceDisable: false,
+		})
 		// we would have restricted it
 		return sysconfig.CloudInitRestrictionResult{
 			// pretend it was NoCloud
@@ -480,8 +484,9 @@ fi`)
 	r := devicestate.MockRestrictCloudInit(func(state sysconfig.CloudInitState, opts *sysconfig.CloudInitRestrictOptions) (sysconfig.CloudInitRestrictionResult, error) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitErrored)
-		c.Assert(opts, Not(IsNil))
-		c.Assert(opts.ForceDisable, Equals, true)
+		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
+			ForceDisable: true,
+		})
 		// we would have disabled it
 		return sysconfig.CloudInitRestrictionResult{
 			Action: "disable",
@@ -576,8 +581,9 @@ fi`)
 	r := devicestate.MockRestrictCloudInit(func(state sysconfig.CloudInitState, opts *sysconfig.CloudInitRestrictOptions) (sysconfig.CloudInitRestrictionResult, error) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitErrored)
-		c.Assert(opts, Not(IsNil))
-		c.Assert(opts.ForceDisable, Equals, true)
+		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
+			ForceDisable: true,
+		})
 		// we would have disabled it
 		return sysconfig.CloudInitRestrictionResult{
 			Action: "disable",
@@ -682,8 +688,9 @@ fi`)
 	r := devicestate.MockRestrictCloudInit(func(state sysconfig.CloudInitState, opts *sysconfig.CloudInitRestrictOptions) (sysconfig.CloudInitRestrictionResult, error) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitEnabled)
-		c.Assert(opts, Not(IsNil))
-		c.Assert(opts.ForceDisable, Equals, true)
+		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
+			ForceDisable: true,
+		})
 		// we would have disabled it
 		return sysconfig.CloudInitRestrictionResult{
 			Action: "disable",
@@ -780,8 +787,9 @@ fi`)
 	r := devicestate.MockRestrictCloudInit(func(state sysconfig.CloudInitState, opts *sysconfig.CloudInitRestrictOptions) (sysconfig.CloudInitRestrictionResult, error) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitEnabled)
-		c.Assert(opts, Not(IsNil))
-		c.Assert(opts.ForceDisable, Equals, true)
+		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
+			ForceDisable: true,
+		})
 		// we would have disabled it
 		return sysconfig.CloudInitRestrictionResult{
 			Action: "disable",
@@ -889,8 +897,9 @@ fi`, cloudInitScriptStateFile))
 	r := devicestate.MockRestrictCloudInit(func(state sysconfig.CloudInitState, opts *sysconfig.CloudInitRestrictOptions) (sysconfig.CloudInitRestrictionResult, error) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitDone)
-		c.Assert(opts, Not(IsNil))
-		c.Assert(opts.ForceDisable, Equals, false)
+		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
+			ForceDisable: false,
+		})
 		// we would have restricted it
 		return sysconfig.CloudInitRestrictionResult{
 			Action: "restrict",

--- a/overlord/devicestate/devicestate_cloudinit_test.go
+++ b/overlord/devicestate/devicestate_cloudinit_test.go
@@ -21,14 +21,18 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-type cloudInitSuite struct {
+type cloudInitBaseSuite struct {
 	deviceMgrBaseSuite
 	mockLogger *bytes.Buffer
 }
 
+type cloudInitSuite struct {
+	cloudInitBaseSuite
+}
+
 var _ = Suite(&cloudInitSuite{})
 
-func (s *cloudInitSuite) SetUpTest(c *C) {
+func (s *cloudInitBaseSuite) SetUpTest(c *C) {
 	s.deviceMgrBaseSuite.SetUpTest(c)
 
 	// undo the cloud-init mocking from deviceMgrBaseSuite, since here we


### PR DESCRIPTION
Some orthogonal test changes to prepare for the uc20 cloud-init features and those tests.

Broken out from https://github.com/snapcore/snapd/pull/9237