### PR TITLE
tests: do not set rsyslog.disable in core18 config defaults test

### DIFF
--- a/tests/core/config-defaults-once/gadget-defaults.yaml
+++ b/tests/core/config-defaults-once/gadget-defaults.yaml
@@ -3,5 +3,3 @@ defaults:
      service:
        ssh:
          disable: true
-       rsyslog:
-         disable: true

--- a/tests/core/config-defaults-once/task.yaml
+++ b/tests/core/config-defaults-once/task.yaml
@@ -7,6 +7,8 @@ summary: |
 systems: [ubuntu-core-18-*]
 
 environment:
+    # XXX: to test systems other than core18 with more defaults we will need
+    # separate defaults file(s).
     GADGET_FILE: gadget-defaults.yaml
 
 prepare: |


### PR DESCRIPTION
Do not set rsyslog.disable in core18 config defaults test as rsyslog service is not present on core18.

Since with configcore options we evaluate all disabled services on `snap set`, we also process rsyslog (because it is set by defaults) and it currently **silently fails because of a peculiar beahvior of systemctl,** which prints an error and returns exit=0 if --root= option is passed to 'disable' command. 

Check this out (also the case on 20.04, can be tried with a dummy unit name):

```
google:ubuntu-core-18-64 .../tests/core/config-defaults-once# systemctl --root=/ disable rsyslog.service
Failed to disable unit, unit rsyslog.service does not exist.
google:ubuntu-core-18-64 .../tests/core/config-defaults-once# echo $?
0
google:ubuntu-core-18-64 .../tests/core/config-defaults-once# systemctl disable rsyslog.service
Failed to disable unit: Unit file rsyslog.service does not exist.
google:ubuntu-core-18-64 .../tests/core/config-defaults-once# echo $?
1
```
(by the way, note the small difference in the spelling of error message).

This is needed for #8960 (services PR), because --root=/ is not passed with enable/disable there, so a missing unit is causing exit=1 as above snippet demonstrates.
