### PR TITLE
github: run macOS job with Go 1.14

### DIFF
--- a/.github/workflows/macos-sanity.yaml
+++ b/.github/workflows/macos-sanity.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.10.x"
+          go-version: "1.14.x"
 
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
The github job on macOS is using Go 1.10 and fails when pulling dependencies
like so:

```
  Installing govendor
  Obtaining dependencies
  # golang.org/x/sys/unix
  ##[error]../../../golang.org/x/sys/unix/fcntl_darwin.go:11:9: undefined: fcntl
  ##[error]../../../golang.org/x/sys/unix/fcntl_darwin.go:16:12: undefined: fcntl
  ##[error]../../../golang.org/x/sys/unix/ioctl.go:20:9: undefined: ioctl
  ##[error]../../../golang.org/x/sys/unix/ioctl.go:29:9: undefined: ioctl
  ##[error]../../../golang.org/x/sys/unix/ioctl.go:38:9: undefined: ioctl
  ##[error]../../../golang.org/x/sys/unix/ioctl.go:48:9: undefined: ioctl
  ##[error]../../../golang.org/x/sys/unix/ioctl.go:60:9: undefined: ioctl
  ##[error]../../../golang.org/x/sys/unix/ioctl.go:66:9: undefined: ioctl
  ##[error]../../../golang.org/x/sys/unix/syscall_bsd.go:630:10: undefined: mmap
  ##[error]../../../golang.org/x/sys/unix/syscall_bsd.go:631:10: undefined: munmap
  ##[error]../../../golang.org/x/sys/unix/ioctl.go:66:9: too many errors
  ##[error]Process completed with exit code 2.
```