### PR TITLE
testutil: add checkers for symbolic link target

### DIFF
--- a/testutil/symlinktargetchecker.go
+++ b/testutil/symlinktargetchecker.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/check.v1"
+)
+
+type symlinkTargetChecker struct {
+	*check.CheckerInfo
+	exact bool
+}
+
+// SymlinkTargetEquals verifies that the given file is a symbolic link with the given target.
+var SymlinkTargetEquals check.Checker = &symlinkTargetChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "SymlinkTargetEquals", Params: []string{"filename", "target"}},
+	exact:       true,
+}
+
+// SymlinkTargetContains verifies that the given file is a symbolic link whose target contains the provided text.
+var SymlinkTargetContains check.Checker = &symlinkTargetChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "SymlinkTargetContains", Params: []string{"filename", "target"}},
+}
+
+// SymlinkTargetMatches verifies that the given file is a symbolic link whose target matches the provided regular expression.
+var SymlinkTargetMatches check.Checker = &symlinkTargetChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "SymlinkTargetMatches", Params: []string{"filename", "regex"}},
+}
+
+func (c *symlinkTargetChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	filename, ok := params[0].(string)
+	if !ok {
+		return false, "Filename must be a string"
+	}
+	if names[1] == "regex" {
+		regexpr, ok := params[1].(string)
+		if !ok {
+			return false, "Regex must be a string"
+		}
+		rx, err := regexp.Compile(regexpr)
+		if err != nil {
+			return false, fmt.Sprintf("Cannot compile regexp %q: %v", regexpr, err)
+		}
+		params[1] = rx
+	}
+	return symlinkTargetCheck(filename, params[1], c.exact)
+}
+
+func symlinkTargetCheck(filename string, expectedTarget interface{}, exact bool) (result bool, error string) {
+	target, err := os.Readlink(filename)
+	if err != nil {
+		return false, fmt.Sprintf("Cannot read symbolic link: %v", err)
+	}
+	if exact {
+		switch expectedTarget := expectedTarget.(type) {
+		case string:
+			result = target == expectedTarget
+		default:
+			error = fmt.Sprintf("Cannot compare symbolic link target with something of type %T", expectedTarget)
+		}
+	} else {
+		switch expectedTarget := expectedTarget.(type) {
+		case string:
+			result = strings.Contains(target, expectedTarget)
+		case *regexp.Regexp:
+			result = expectedTarget.MatchString(target)
+		default:
+			error = fmt.Sprintf("Cannot compare symbolic link target with something of type %T", expectedTarget)
+		}
+	}
+	if !result {
+		if error == "" {
+			error = fmt.Sprintf("Failed to match with symbolic link target:\n%v", target)
+		}
+		return result, error
+	}
+	return result, ""
+}

--- a/testutil/symlinktargetchecker_test.go
+++ b/testutil/symlinktargetchecker_test.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"gopkg.in/check.v1"
+
+	. "github.com/snapcore/snapd/testutil"
+)
+
+type symlinkTargetCheckerSuite struct {
+	d       string
+	symlink string
+	target  string
+}
+
+var _ = check.Suite(&symlinkTargetCheckerSuite{})
+
+func (s *symlinkTargetCheckerSuite) SetUpTest(c *check.C) {
+	s.d = c.MkDir()
+	s.symlink = filepath.Join(s.d, "symlink")
+	s.target = "target"
+	c.Assert(os.Symlink(s.target, s.symlink), check.IsNil)
+}
+
+func (s *symlinkTargetCheckerSuite) TestSymlinkTargetEquals(c *check.C) {
+	testInfo(c, SymlinkTargetEquals, "SymlinkTargetEquals", []string{"filename", "target"})
+	testCheck(c, SymlinkTargetEquals, true, "", s.symlink, s.target)
+
+	testCheck(c, SymlinkTargetEquals, false, "Failed to match with symbolic link target:\ntarget", s.symlink, "not-target")
+	testCheck(c, SymlinkTargetEquals, false, `Cannot read symbolic link: readlink missing: no such file or directory`, "missing", "")
+	testCheck(c, SymlinkTargetEquals, false, "Filename must be a string", 42, "")
+	testCheck(c, SymlinkTargetEquals, false, "Cannot compare symbolic link target with something of type int", s.symlink, 1)
+}
+
+func (s *symlinkTargetCheckerSuite) TestSymlinkTargetContains(c *check.C) {
+	testInfo(c, SymlinkTargetContains, "SymlinkTargetContains", []string{"filename", "target"})
+	testCheck(c, SymlinkTargetContains, true, "", s.symlink, s.target[1:])
+	testCheck(c, SymlinkTargetContains, true, "", s.symlink, regexp.MustCompile(".*"))
+
+	testCheck(c, SymlinkTargetContains, false, "Failed to match with symbolic link target:\ntarget", s.symlink, "not-target")
+	testCheck(c, SymlinkTargetContains, false, "Failed to match with symbolic link target:\ntarget", s.symlink, regexp.MustCompile("^$"))
+	testCheck(c, SymlinkTargetContains, false, `Cannot read symbolic link: readlink missing: no such file or directory`, "missing", "")
+	testCheck(c, SymlinkTargetContains, false, "Filename must be a string", 42, "")
+	testCheck(c, SymlinkTargetContains, false, "Cannot compare symbolic link target with something of type int", s.symlink, 1)
+}
+
+func (s *symlinkTargetCheckerSuite) TestSymlinkTargetMatches(c *check.C) {
+	testInfo(c, SymlinkTargetMatches, "SymlinkTargetMatches", []string{"filename", "regex"})
+	testCheck(c, SymlinkTargetMatches, true, "", s.symlink, ".*")
+	testCheck(c, SymlinkTargetMatches, true, "", s.symlink, "^"+regexp.QuoteMeta(s.target)+"$")
+
+	testCheck(c, SymlinkTargetMatches, false, "Failed to match with symbolic link target:\ntarget", s.symlink, "^$")
+	testCheck(c, SymlinkTargetMatches, false, "Failed to match with symbolic link target:\ntarget", s.symlink, "123"+regexp.QuoteMeta(s.target))
+	testCheck(c, SymlinkTargetMatches, false, `Cannot read symbolic link: readlink missing: no such file or directory`, "missing", "")
+	testCheck(c, SymlinkTargetMatches, false, "Filename must be a string", 42, ".*")
+	testCheck(c, SymlinkTargetMatches, false, "Regex must be a string", s.symlink, 1)
+}


### PR DESCRIPTION
Add three checkers relevant for examining symbolic links:

- SymlinkTargetEquals checks for a fixed target
- SymlinkTargetContains checks for a substring
- SymlinkTargetMatches checks for a regular expression

They are modelled after FileContentsChecker but implement fewer
variants as symbolic link targets are usually short strings.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

