### PR TITLE
boot: handle canceled update

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -577,7 +577,7 @@ func (o *TrustedAssetsUpdateObserver) canceledUpdate(recovery bool) {
 				delete(*trustedAssets, changed.name)
 			}
 		} else {
-			// asset updates are appended to the list
+			// asset updates were appended to the list
 			(*trustedAssets)[changed.name] = hashList[:1]
 		}
 		if !isAssetHashTrackedInMap(otherTrustedAssets, changed.name, changed.hash) {

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -463,7 +463,7 @@ func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, re
 	if o.modeenv.deepEqual(modeenvBefore) {
 		return true, nil
 	}
-	if err := o.modeenv.WriteTo(""); err != nil {
+	if err := o.modeenv.Write(); err != nil {
 		return false, fmt.Errorf("cannot write modeeenv: %v", err)
 	}
 	return true, nil
@@ -532,7 +532,7 @@ func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, 
 		delete(*trustedAssets, assetName)
 	}
 
-	if err := o.modeenv.WriteTo(""); err != nil {
+	if err := o.modeenv.Write(); err != nil {
 		return false, fmt.Errorf("cannot write modeeenv: %v", err)
 	}
 

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -1586,8 +1586,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledAfterRollback(c *C) {
 }
 
 func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) {
-	// make sure that trying to remove the file from cache will no break the
-	// cancellation
+	// make sure that trying to remove the file from cache will not break
+	// the cancellation
 
 	logBuf, restore := logger.MockLogger()
 	defer restore()

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -62,3 +62,16 @@ func (o *TrustedAssetsInstallObserver) CurrentTrustedBootAssetsMap() BootAssetsM
 func (o *TrustedAssetsInstallObserver) CurrentTrustedRecoveryBootAssetsMap() BootAssetsMap {
 	return o.currentTrustedRecoveryBootAssetsMap()
 }
+
+func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash string, recovery bool) {
+	ta := &trackedAsset{
+		blName: blName,
+		name:   assetName,
+		hash:   hash,
+	}
+	if !recovery {
+		o.changedAssets = append(o.changedAssets, ta)
+	} else {
+		o.seedChangedAssets = append(o.seedChangedAssets, ta)
+	}
+}


### PR DESCRIPTION
When a trusted boot assets update gets canceled, we need to clean up the pending
changes we have accumulated in modeenv.
