### PR TITLE
secboot: use EFIImage type in load sequences

### DIFF
--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -163,17 +163,17 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 	}
 
 	// TODO:UC20: binaries are EFI/bootloader-specific, hardcoded for now
-	loadChain := []string{
+	loadChain := []secboot.EFIImage{
 		// the path to the shim EFI binary
-		filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
+		secboot.NewEFIImage(secboot.RecoveryBootloaderAsset, filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), ""),
 		// the path to the recovery grub EFI binary
-		filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
+		secboot.NewEFIImage(secboot.RecoveryBootloaderAsset, filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), ""),
 		// the path to the run mode grub EFI binary
-		filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"),
+		secboot.NewEFIImage(secboot.BootloaderAsset, filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), ""),
 	}
 	if options.KernelPath != "" {
 		// the path to the kernel EFI binary
-		loadChain = append(loadChain, options.KernelPath)
+		loadChain = append(loadChain, secboot.NewEFIImage(secboot.BootloaderAsset, options.KernelPath, ""))
 	}
 
 	// Get the expected kernel command line for the system that is currently being installed
@@ -198,7 +198,7 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 			{
 				Model:          options.Model,
 				KernelCmdlines: kernelCmdlines,
-				EFILoadChains:  [][]string{loadChain},
+				EFILoadChains:  [][]secboot.EFIImage{loadChain},
 			},
 		},
 		KeyFile:                 options.KeyFile,

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -28,11 +28,46 @@ import (
 	"github.com/snapcore/snapd/asserts"
 )
 
+const (
+	RecoveryBootloaderAsset = iota
+	RecoveryBootloaderKernel
+	BootloaderAsset
+	BootloaderKernel
+)
+
+// EFIImage represents an EFI binary (or snap file containing an EFI
+// binary) that is part of a load sequence.
+type EFIImage struct {
+	// Type specified the role and origin of this image
+	Type int
+	// The path to the image or snap file
+	Path string
+	// The relative path to the EFI binary in the snap file
+	Relative string
+}
+
+func NewEFIImage(t int, path, rel string) EFIImage {
+	return EFIImage{
+		Type:     t,
+		Path:     path,
+		Relative: rel,
+	}
+}
+
+func (e EFIImage) WithPath(path string) EFIImage {
+	e.Path = path
+	return e
+}
+
+func (e EFIImage) Equals(f EFIImage) bool {
+	return e.Type == f.Type && e.Path == f.Path && e.Relative == f.Relative
+}
+
 type SealKeyModelParams struct {
 	// The snap model
 	Model *asserts.Model
 	// The set of EFI binary load paths for the current device configuration
-	EFILoadChains [][]string
+	EFILoadChains [][]EFIImage
 	// The kernel command line
 	KernelCmdlines []string
 }


### PR DESCRIPTION
Wrap snapcore/secboot EFI images in a type that holds information
about the origin of the asset and the relative path inside a container
in case of adding snap files to the load chain. This will be used more
extensively when we move the seal code to boot and retrieve the list
of boot assets and kernel snaps directly from a bootloader that
manages trusted assets.
