### PR TITLE
exportstate: add scaffolding for the export manager

### DIFF
--- a/overlord/exportstate/export_test.go
+++ b/overlord/exportstate/export_test.go
@@ -1,0 +1,27 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package exportstate
+
+var (
+	ExportManifestForClassicSystem = exportManifestForClassicSystem
+	ExportManifestForHostSystem    = exportManifestForHostSystem
+
+	ExportManifestForSnap = exportManifestForSnap
+)

--- a/overlord/exportstate/exportstate.go
+++ b/overlord/exportstate/exportstate.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package exportstate implements the manager and state aspects responsible
+// for the exporting portions of installed snaps to the system.
+package exportstate
+
+// TODO: add export manager, task hooks and glue connecting it to the overlord.
+
+// TODO: on initialization of export manager, elect the new provider of snapd
+// tools, so that it is guaranteed to be present before we need to invoke
+// anything in snap world or before we need to setup security profiles.
+
+// TODO: track export sets in the state, so that for each on-disk tuple
+// (PrimaryKey, SubKey, ExportSetName) we can find the associated snap name and
+// snap revision. This may not be required for snapd but might be required in
+// the general case, where snaps provide possibly-conflicting exports and snapd
+// picks one or another snap as a provider (e.g. manual page de-conflicting).
+
+// TODO: add function electing the new provider of an export set, so that the
+// export-set current symlink can be updated.
+
+// TODO: add a special-case function that elects new provider of snapd tools,
+// which span two snaps and the classic host.
+
+// TODO: add function that performs the mechanics of switching the current
+// provider of an export set, performing appropriate locking or using lockless
+// primitives where available.

--- a/overlord/exportstate/exportstate_test.go
+++ b/overlord/exportstate/exportstate_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package exportstate_test
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }

--- a/overlord/exportstate/host.go
+++ b/overlord/exportstate/host.go
@@ -1,0 +1,90 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package exportstate
+
+import (
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/release"
+)
+
+// exportManifestForHostSystem returns the export manifest of the host system.
+//
+// Ubuntu Core systems do not have an export manifest. Classic systems have an export
+// manifest which describes snapd tools from the classic package.
+func exportManifestForHostSystem() *ExportManifest {
+	if release.OnClassic {
+		// This does not need to consider re-exec vs not, as that logic
+		// is only necessary during the election process of the current
+		// export set.
+		return exportManifestForClassicSystem()
+	}
+	return nil
+}
+
+// exportManifestForClassicSystem returns the export manifest of the classic system.
+//
+// The classic system exposes snapd tools coming from the classic package.
+// The tools are exposes under the "snapd" name, with the subkey "host".
+func exportManifestForClassicSystem() *ExportManifest {
+	return &ExportManifest{
+		// The system contains a classic package.
+		PrimaryKey: "snapd",
+		SubKey:     "host",
+		ExportSets: map[ExportSetName][]ExportEntry{
+			snapdTools: exportedSnapdToolsFromHost(),
+		},
+	}
+}
+
+// exportedHostFile implements ExportEntry describing a file from the classic file system.
+//
+// TODO: consider using this to describe nvidia libraries from the host.
+type exportedHostFile struct {
+	pathOnHost      string
+	pathInExportSet string
+}
+
+func (ehf *exportedHostFile) PathInHostMountNS() string {
+	return ehf.pathOnHost
+}
+
+func (ehf *exportedHostFile) PathInSnapMountNS() string {
+	return filepath.Join("/var/lib/snapd/hostfs", ehf.pathOnHost)
+}
+
+func (ehf *exportedHostFile) PathInExportSet() string {
+	return ehf.pathInExportSet
+}
+
+func (ehf *exportedHostFile) IsExportedPathValidInHostMountNS() bool {
+	return false
+}
+
+func exportedSnapdToolsFromHost() []ExportEntry {
+	return []ExportEntry{
+		&exportedHostFile{
+			pathOnHost:      filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
+			pathInExportSet: "snap-exec",
+		},
+		// TODO: add the remaining tools here.
+	}
+}

--- a/overlord/exportstate/host_test.go
+++ b/overlord/exportstate/host_test.go
@@ -1,0 +1,84 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package exportstate_test
+
+import (
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/exportstate"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type hostSuite struct {
+	testutil.BaseTest
+	rootfs string
+}
+
+var _ = Suite(&hostSuite{})
+
+func (s *hostSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.rootfs = c.MkDir()
+	dirs.SetRootDir(s.rootfs)
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+}
+
+func (s *hostSuite) TestExportManifestForHostSystem(c *C) {
+	s.AddCleanup(release.MockOnClassic(true))
+	c.Assert(exportstate.ExportManifestForHostSystem(), NotNil)
+
+	s.AddCleanup(release.MockOnClassic(false))
+	c.Assert(exportstate.ExportManifestForHostSystem(), IsNil)
+}
+
+func (s *hostSuite) checkSnapExec(c *C, snapExec exportstate.ExportEntry) {
+	c.Check(snapExec.PathInExportSet(), Equals, "snap-exec")
+	c.Check(snapExec.PathInHostMountNS(), Equals, filepath.Join(dirs.DistroLibExecDir, "snap-exec"))
+	c.Check(snapExec.PathInSnapMountNS(), Equals, filepath.Join("/var/lib/snapd/hostfs", dirs.DistroLibExecDir, "snap-exec"))
+	c.Check(snapExec.IsExportedPathValidInHostMountNS(), Equals, false)
+}
+
+func (s *hostSuite) TestExportManifestForClassicSystemWithDefaultSnapMountDir(c *C) {
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "ubuntu"}))
+	manifest := exportstate.ExportManifestForClassicSystem()
+	c.Assert(manifest, NotNil)
+	c.Check(manifest.PrimaryKey, Equals, "snapd")
+	c.Check(manifest.SubKey, Equals, "host")
+	tools, ok := manifest.ExportSets["tools"]
+	c.Assert(ok, Equals, true)
+	c.Assert(tools, HasLen, 1)
+	s.checkSnapExec(c, tools[0])
+}
+
+func (s *hostSuite) TestExportManifestForClassicSystemWithAltSnapMountDir(c *C) {
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "fedora"}))
+	manifest := exportstate.ExportManifestForClassicSystem()
+	c.Assert(manifest, NotNil)
+	c.Check(manifest.PrimaryKey, Equals, "snapd")
+	c.Check(manifest.SubKey, Equals, "host")
+	tools, ok := manifest.ExportSets["tools"]
+	c.Assert(ok, Equals, true)
+	c.Assert(tools, HasLen, 1)
+	s.checkSnapExec(c, tools[0])
+}

--- a/overlord/exportstate/manifest.go
+++ b/overlord/exportstate/manifest.go
@@ -1,0 +1,90 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package exportstate implements the manager and state aspects responsible
+// for the exporting portions of installed snaps to the system.
+package exportstate
+
+import "fmt"
+
+// ExportManifest describes content exported by one provider.
+//
+// The provider is usually a single revision of a given snap, but there are
+// some exceptions discussed below.
+//
+// PrimaryKey is usually the snap name without the instance key. SubKey is
+// usually the snap revision combined with the instance key.  ExportSets
+// describes the set of exported files, grouped into topics by export set name.
+//
+// Exceptions apply whe PrimaryKey is "snapd". The SybKey has additional forms,
+// incluging "$revision", "core_$revision" and "host". Neither primary nor sub
+// keys should be parsed.
+type ExportManifest struct {
+	// XXX: should the keys be at the same level as export set name,
+	// allowing a single snap to provide multiple objects under distinct
+	// primary key, sub key and export set name?  Currently we don't need
+	// this as only the "core" snap is a special case.
+	PrimaryKey string
+	SubKey     string
+	ExportSets map[ExportSetName][]ExportEntry
+}
+
+// PutOnDisk writes a manifest to disk.
+//
+// The directory /var/lib/snapd/export/$primary/$sub is created and
+// populated with symbolic links, as described by the export sets.
+func (em *ExportManifest) PutOnDisk() error {
+	// TODO: implement this.
+	return fmt.Errorf("putting exports on disk is not implemented")
+}
+
+// RemoveFromDisk removes an error manifest from disk.
+//
+// The directory hosting the export set is recursively removed.
+// In addition the path /var/lib/snapd/export/$primary/$sub
+// is pruned, and empty directories are removed.
+func (em *ExportManifest) RemoveFromDisk() error {
+	// TODO: implement this
+	return fmt.Errorf("removing exports from disk is not implemented")
+}
+
+// ExportSetName designates a group of related files exported by a snap.
+type ExportSetName string
+
+// snapdTools is the export set name for all internal snapd tools.
+const snapdTools ExportSetName = "tools"
+
+// ExportEntry is an interface describing a single file placed in a specific export set.
+//
+// The original file is described by two paths. PathInHostMountNS is is valid
+// in the host mount namespace while PathInSnapMountNS is valid in the per-snap
+// mount namespace. The original file is exported by creating a symbolic link
+// under PathInExportSet, which is relative to the export set that the entry
+// belongs to, to one of the two other paths.  If
+// IsExportedPathValidInHostMountNS returns true then PathInHostMountNS is
+// used, if it returns false PathInSnapMountNS is used instead.
+//
+// This distinction enables exporting files that are consumed by either other
+// snaps or by the classic system.
+type ExportEntry interface {
+	PathInExportSet() string
+	PathInHostMountNS() string
+	PathInSnapMountNS() string
+	IsExportedPathValidInHostMountNS() bool
+}

--- a/overlord/exportstate/manifest_test.go
+++ b/overlord/exportstate/manifest_test.go
@@ -1,0 +1,75 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package exportstate_test
+
+import (
+	"github.com/snapcore/snapd/overlord/exportstate"
+
+	. "gopkg.in/check.v1"
+)
+
+type testExportEntry struct {
+	pathInExportSet                  string
+	pathInHostMountNS                string
+	pathInSnapMountNS                string
+	isExportedPathValidInHostMountNS bool
+}
+
+func (tee *testExportEntry) PathInExportSet() string {
+	return tee.pathInExportSet
+}
+
+func (tee *testExportEntry) PathInHostMountNS() string {
+	return tee.pathInHostMountNS
+}
+
+func (tee *testExportEntry) PathInSnapMountNS() string {
+	return tee.pathInSnapMountNS
+}
+
+func (tee *testExportEntry) IsExportedPathValidInHostMountNS() bool {
+	return tee.isExportedPathValidInHostMountNS
+}
+
+type manifestSuite struct {
+	manifest *exportstate.ExportManifest
+}
+
+var _ = Suite(&manifestSuite{
+	manifest: &exportstate.ExportManifest{
+		PrimaryKey: "primary",
+		SubKey:     "sub",
+		ExportSets: map[exportstate.ExportSetName][]exportstate.ExportEntry{
+			"export-set": []exportstate.ExportEntry{
+				&testExportEntry{},
+			},
+		},
+	},
+})
+
+func (s *manifestSuite) TestPutOnDisk(c *C) {
+	err := s.manifest.PutOnDisk()
+	c.Assert(err, ErrorMatches, ".* not implemented")
+}
+
+func (s *manifestSuite) TestRemoveFromDisk(c *C) {
+	err := s.manifest.RemoveFromDisk()
+	c.Assert(err, ErrorMatches, ".* not implemented")
+}

--- a/overlord/exportstate/snapd.go
+++ b/overlord/exportstate/snapd.go
@@ -1,0 +1,103 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package exportstate
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+// exportManifestForSnap returns the export manifest, if any, for a given snap.
+//
+// Currently only the core and snapd snaps export any content to the system. As
+// such the export manifest is not embedded into the snap meta-data but instead
+// computed here.
+//
+// Both snapd and core snaps export content under the snap name "snapd", using
+// the export set name "tools". The revision is mangled, for "snapd" it is used
+// directly. For "core" it is transformed to "core_$revision".
+func exportManifestForSnap(info *snap.Info) *ExportManifest {
+	// XXX: should we use WellKnownSnapID here? Probably not as this must work for
+	// unsigned snaps as well. Alternatively, should we look at snap type, as we
+	// have unique values for both snapd and core.
+	switch info.SnapName() {
+	case "snapd":
+		return &ExportManifest{
+			PrimaryKey: "snapd",
+			// The snapd snap cannot be installed in parallel and
+			// thus do not have an instance key.
+			SubKey: info.Revision.String(),
+			ExportSets: map[ExportSetName][]ExportEntry{
+				snapdTools: exportedSnapToolsFromSnapdOrCore(info),
+			},
+		}
+	case "core":
+		return &ExportManifest{
+			// The core snap contains embedded copy of snapd.
+			PrimaryKey: "snapd",
+			// The core snap cannot be installed in parallel and
+			// does not have an instance key.  As a special
+			// exception, the sub key is prefixed with "core_", to
+			// indicate that snapd is packaged inside the core
+			// snap.
+			SubKey: fmt.Sprintf("core_%s", info.Revision),
+			ExportSets: map[ExportSetName][]ExportEntry{
+				snapdTools: exportedSnapToolsFromSnapdOrCore(info),
+			},
+		}
+	}
+	return nil
+}
+
+// exportedSnapFile implements ExportEntry describing a file stored inside a snap.
+type exportedSnapFile struct {
+	snap            *snap.Info
+	pathInSnap      string
+	pathInExportSet string
+}
+
+func (esf *exportedSnapFile) PathInHostMountNS() string {
+	return filepath.Join(esf.snap.MountDir(), esf.pathInSnap)
+}
+
+func (esf *exportedSnapFile) PathInSnapMountNS() string {
+	return filepath.Join("/snap", esf.snap.InstanceName(), esf.snap.Revision.String(), esf.pathInSnap)
+}
+
+func (esf *exportedSnapFile) PathInExportSet() string {
+	return esf.pathInExportSet
+}
+
+func (esf *exportedSnapFile) IsExportedPathValidInHostMountNS() bool {
+	return false
+}
+
+func exportedSnapToolsFromSnapdOrCore(info *snap.Info) []ExportEntry {
+	return []ExportEntry{
+		&exportedSnapFile{
+			snap:            info,
+			pathInSnap:      "usr/lib/snapd/snap-exec",
+			pathInExportSet: "snap-exec",
+		},
+		// TODO: add the remaining tools here.
+	}
+}

--- a/overlord/exportstate/snapd_test.go
+++ b/overlord/exportstate/snapd_test.go
@@ -1,0 +1,124 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package exportstate_test
+
+import (
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/exportstate"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type snapdSuite struct {
+	testutil.BaseTest
+	rootfs    string
+	snapdSnap *snap.Info
+	coreSnap  *snap.Info
+}
+
+var _ = Suite(&snapdSuite{})
+
+const snapdYaml = `
+name: snapd
+version: 1
+type: snapd
+`
+
+const coreYaml = `
+name: core
+version: 1
+type: os
+`
+
+func (s *snapdSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.rootfs = c.MkDir()
+	dirs.SetRootDir(s.rootfs)
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+	s.snapdSnap = snaptest.MockInfo(c, snapdYaml, &snap.SideInfo{
+		Revision: snap.Revision{N: 1},
+	})
+	s.coreSnap = snaptest.MockInfo(c, coreYaml, &snap.SideInfo{
+		Revision: snap.Revision{N: 2},
+	})
+}
+
+func (s *snapdSuite) checkSnapExec(c *C, snapExec exportstate.ExportEntry, info *snap.Info) {
+	c.Check(snapExec.PathInExportSet(), Equals, "snap-exec")
+	c.Check(snapExec.PathInHostMountNS(), Equals, filepath.Join(
+		dirs.SnapMountDir, info.SnapName(), info.Revision.String(), "usr/lib/snapd/snap-exec"))
+	c.Check(snapExec.PathInSnapMountNS(), Equals, filepath.Join(
+		"/snap", info.SnapName(), info.Revision.String(), "usr/lib/snapd/snap-exec"))
+	c.Check(snapExec.IsExportedPathValidInHostMountNS(), Equals, false)
+}
+
+func (s *snapdSuite) TestExportManifestSnapdSnapWithDefaultSnapMountDir(c *C) {
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "ubuntu"}))
+	manifest := exportstate.ExportManifestForSnap(s.snapdSnap)
+	c.Assert(manifest, NotNil)
+	c.Check(manifest.PrimaryKey, Equals, "snapd")
+	c.Check(manifest.SubKey, Equals, "1")
+	tools, ok := manifest.ExportSets["tools"]
+	c.Assert(ok, Equals, true)
+	c.Assert(tools, HasLen, 1)
+	s.checkSnapExec(c, tools[0], s.snapdSnap)
+}
+
+func (s *snapdSuite) TestExportManifestForSnapdSnapWithAltSnapMountDir(c *C) {
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "fedora"}))
+	manifest := exportstate.ExportManifestForSnap(s.snapdSnap)
+	c.Assert(manifest, NotNil)
+	c.Check(manifest.PrimaryKey, Equals, "snapd")
+	c.Check(manifest.SubKey, Equals, "1")
+	tools, ok := manifest.ExportSets["tools"]
+	c.Assert(ok, Equals, true)
+	c.Assert(tools, HasLen, 1)
+	s.checkSnapExec(c, tools[0], s.snapdSnap)
+}
+
+func (s *snapdSuite) TestExportManifestCoreSnapWithDefaultSnapMountDir(c *C) {
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "ubuntu"}))
+	manifest := exportstate.ExportManifestForSnap(s.coreSnap)
+	c.Assert(manifest, NotNil)
+	c.Check(manifest.PrimaryKey, Equals, "snapd")
+	c.Check(manifest.SubKey, Equals, "core_2")
+	tools, ok := manifest.ExportSets["tools"]
+	c.Assert(ok, Equals, true)
+	c.Assert(tools, HasLen, 1)
+	s.checkSnapExec(c, tools[0], s.coreSnap)
+}
+
+func (s *snapdSuite) TestExportManifestForCoreSnapWithAltSnapMountDir(c *C) {
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "fedora"}))
+	manifest := exportstate.ExportManifestForSnap(s.coreSnap)
+	c.Assert(manifest, NotNil)
+	c.Check(manifest.PrimaryKey, Equals, "snapd")
+	c.Check(manifest.SubKey, Equals, "core_2")
+	tools, ok := manifest.ExportSets["tools"]
+	c.Assert(ok, Equals, true)
+	c.Assert(tools, HasLen, 1)
+	s.checkSnapExec(c, tools[0], s.coreSnap)
+}


### PR DESCRIPTION
The export manager is responsible for exporting certain content from
snaps to the host and to other snaps. This patch contains the hollow
implementation of the new manager, with many missing implementations
but with important data structures and interfaces to discuss the
finer points of the design.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>