### PR TITLE
boot,bootloader,gadget: apply new bootloader.Options.Role

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -232,7 +232,7 @@ func (o *TrustedAssetsInstallObserver) Observe(op gadget.ContentOperation, affec
 
 	if o.blName == "" {
 		// we have no information about the bootloader yet
-		bl, err := bootloader.ForGadget(o.gadgetDir, root, &bootloader.Options{NoSlashBoot: true})
+		bl, err := bootloader.ForGadget(o.gadgetDir, root, &bootloader.Options{Role: bootloader.RoleRunMode, NoSlashBoot: true})
 		if err != nil {
 			return false, fmt.Errorf("cannot find bootloader: %v", err)
 		}
@@ -274,8 +274,7 @@ func (o *TrustedAssetsInstallObserver) Observe(op gadget.ContentOperation, affec
 // recovery bootloader located inside a given root directory.
 func (o *TrustedAssetsInstallObserver) ObserveExistingTrustedRecoveryAssets(recoveryRootDir string) error {
 	bl, err := bootloader.Find(recoveryRootDir, &bootloader.Options{
-		NoSlashBoot: true,
-		Recovery:    true,
+		Role: bootloader.RoleRecovery,
 	})
 	if err != nil {
 		return fmt.Errorf("cannot identify recovery system bootloader: %v", err)
@@ -376,6 +375,7 @@ func (o *TrustedAssetsUpdateObserver) Observe(op gadget.ContentOperation, affect
 	case gadget.SystemBoot:
 		if o.bootBootloader == nil {
 			o.bootBootloader, o.bootTrustedAssets, err = findMaybeTrustedAssetsBootloader(root, &bootloader.Options{
+				Role:        bootloader.RoleRunMode,
 				NoSlashBoot: true,
 			})
 			if err != nil {
@@ -387,8 +387,7 @@ func (o *TrustedAssetsUpdateObserver) Observe(op gadget.ContentOperation, affect
 	case gadget.SystemSeed:
 		if o.seedBootloader == nil {
 			o.seedBootloader, o.seedTrustedAssets, err = findMaybeTrustedAssetsBootloader(root, &bootloader.Options{
-				NoSlashBoot: true,
-				Recovery:    true,
+				Role: bootloader.RoleRecovery,
 			})
 			if err != nil {
 				return false, err

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -113,9 +113,12 @@ func Participant(s snap.PlaceInfo, t snap.Type, dev Device) BootParticipant {
 // bootloaderOptionsForDeviceKernel returns a set of bootloader options that
 // enable correct kernel extraction and removal for given device
 func bootloaderOptionsForDeviceKernel(dev Device) *bootloader.Options {
+	if !dev.HasModeenv() {
+		return nil
+	}
+	// find the run-mode bootloader with its kernel support for UC20
 	return &bootloader.Options{
-		// unified extractable kernel if in uc20 mode
-		ExtractedRunKernelImage: dev.HasModeenv(),
+		Role: bootloader.RoleRunMode,
 	}
 }
 
@@ -353,7 +356,7 @@ func SetRecoveryBootSystemAndMode(dev Device, systemLabel, mode string) error {
 
 	opts := &bootloader.Options{
 		// setup the recovery bootloader
-		Recovery: true,
+		Role: bootloader.RoleRecovery,
 	}
 	// TODO:UC20: should the recovery partition stay around as RW during run
 	// mode all the time?

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -1449,7 +1449,7 @@ func (s *recoveryBootenv20Suite) TestSetRecoveryBootSystemAndModeRealHappy(c *C)
 	err = boot.SetRecoveryBootSystemAndMode(s.dev, "1234", "install")
 	c.Assert(err, IsNil)
 
-	bl, err := bootloader.Find(boot.InitramfsUbuntuSeedDir, &bootloader.Options{Recovery: true})
+	bl, err := bootloader.Find(boot.InitramfsUbuntuSeedDir, &bootloader.Options{Role: bootloader.RoleRecovery})
 	c.Assert(err, IsNil)
 
 	blvars, err := bl.GetBootVars("snapd_recovery_mode", "snapd_recovery_system")

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -185,20 +185,13 @@ func (ks20 *bootState20Kernel) loadBootenv() error {
 		return nil
 	}
 
-	// find the bootloader and ensure it's an extracted run kernel image
-	// bootloader
-
+	// find the run-mode bootloader
 	var opts *bootloader.Options
 	if ks20.blOpts != nil {
 		opts = ks20.blOpts
 	} else {
-		// we want extracted run kernel images for uc20
-		// TODO:UC20: the name of this flag is now confusing, as it is being
-		//            slightly abused to tell the uboot bootloader to just look
-		//            in a different directory, even when we don't have an
-		//            actual extracted kernel image for that impl
 		opts = &bootloader.Options{
-			ExtractedRunKernelImage: true,
+			Role: bootloader.RoleRunMode,
 		}
 	}
 	bl, err := bootloader.Find(ks20.blDir, opts)

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -141,6 +141,7 @@ func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, syst
 	}
 	// get a bootloader under a native root directory
 	opts := &bootloader.Options{
+		Role:        bootloader.RoleRunMode,
 		NoSlashBoot: true,
 	}
 	bootloaderRootDir := InitramfsUbuntuBootDir
@@ -148,7 +149,7 @@ func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, syst
 	systemArg := ""
 	if mode == ModeRecover {
 		// dealing with recovery system bootloader
-		opts.Recovery = true
+		opts.Role = bootloader.RoleRecovery
 		bootloaderRootDir = InitramfsUbuntuSeedDir
 		// recovery mode & system command line arguments
 		modeArg = "snapd_recovery_mode=recover"

--- a/boot/initramfs.go
+++ b/boot/initramfs.go
@@ -45,7 +45,10 @@ func InitramfsRunModeSelectSnapsToMount(
 			bs := &bootState20Base{}
 			selectSnapFn = bs.selectAndCommitSnapInitramfsMount
 		case snap.TypeKernel:
-			blOpts := &bootloader.Options{NoSlashBoot: true}
+			blOpts := &bootloader.Options{
+				Role:        bootloader.RoleRunMode,
+				NoSlashBoot: true,
+			}
 			blDir := InitramfsUbuntuBootDir
 			bs := &bootState20Kernel{
 				blDir:  blDir,
@@ -73,7 +76,7 @@ func EnsureNextBootToRunMode(systemLabel string) error {
 
 	opts := &bootloader.Options{
 		// setup the recovery bootloader
-		Recovery: true,
+		Role: bootloader.RoleRecovery,
 	}
 
 	bl, err := bootloader.Find(InitramfsUbuntuSeedDir, opts)

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -80,7 +80,7 @@ func (s *initramfsSuite) TestEnsureNextBootToRunModeRealBootloader(c *C) {
 
 	opts := &bootloader.Options{
 		// setup the recovery bootloader
-		Recovery: true,
+		Role: bootloader.RoleRecovery,
 	}
 	bloader, err := bootloader.Find(boot.InitramfsUbuntuSeedDir, opts)
 	c.Assert(err, IsNil)

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -480,6 +480,7 @@ func (s *ubootSuite) forceUC20UbootBootloader(c *C) {
 	// to find the uboot bootloader we need to pass in NoSlashBoot because
 	// that's where the gadget assets get installed to
 	installOpts := &bootloader.Options{
+		Role:        bootloader.RoleRunMode,
 		NoSlashBoot: true,
 	}
 
@@ -506,9 +507,9 @@ func (s *ubootSuite) forceUC20UbootBootloader(c *C) {
 	c.Assert(err, IsNil)
 
 	// however when finding the bootloader, since we want it to show up as the
-	// "runtime" bootloader, just use ExtractedRunKernelImage
+	// "runtime" bootloader
 	runtimeOpts := &bootloader.Options{
-		ExtractedRunKernelImage: true,
+		Role: bootloader.RoleRunMode,
 	}
 
 	bloader, err := bootloader.Find("", runtimeOpts)

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -159,7 +159,7 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	opts := &bootloader.Options{
 		PrepareImageTime: true,
 		// setup the recovery bootloader
-		Recovery: true,
+		Role: bootloader.RoleRecovery,
 	}
 
 	// install the bootloader configuration from the gadget
@@ -291,8 +291,8 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		// At this point the run mode bootloader is under the native
 		// layout, no /boot mount.
 		NoSlashBoot: true,
-		// Bootloader that supports kernel asset extraction
-		ExtractedRunKernelImage: true,
+		// Bootloader for run mode
+		Role: bootloader.RoleRunMode,
 	}
 	bl, err := bootloader.Find(InitramfsUbuntuBootDir, opts)
 	if err != nil {
@@ -366,7 +366,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 	opts = &bootloader.Options{
 		// let the bootloader know we will be touching the recovery
 		// partition
-		Recovery: true,
+		Role: bootloader.RoleRecovery,
 	}
 	bl, err = bootloader.Find(InitramfsUbuntuSeedDir, opts)
 	if err != nil {

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -40,6 +40,18 @@ var (
 	ErrNoTryKernelRef = errors.New("no try-kernel referenced")
 )
 
+// Role indicates whether the bootloader is used for recovery or run mode.
+type Role string
+
+const (
+	// RoleSole applies to the sole bootloader used by UC16/18.
+	RoleSole Role = ""
+	// RoleRunMode applies to the run mode booloader.
+	RoleRunMode Role = "run-mode"
+	// RoleRecovery apllies to the recovery bootloader.
+	RoleRecovery Role = "recovery"
+)
+
 // Options carries bootloader options.
 type Options struct {
 	// PrepareImageTime indicates whether the booloader is being
@@ -47,18 +59,25 @@ type Options struct {
 	// system.
 	PrepareImageTime bool
 
-	// Recovery indicates to use the recovery bootloader. Note that
-	// UC16/18 do not have a recovery partition.
-	Recovery bool
+	// Role specifies to use the bootloader for the given role.
+	Role Role
 
-	// TODO:UC20 consider different/better names for flags that follow
-
-	// NoSlashBoot indicates to use the run mode bootloader but
-	// under the native layout and not the /boot mount.
+	// NoSlashBoot indicates to use the native layout of the
+	// bootloader partition and not the /boot mount.
+	// It applies only for RoleRunMode.
+	// It is implied and ignored for RoleRecovery.
+	// It is an error to set it for RoleSole.
 	NoSlashBoot bool
+}
 
-	// ExtractedRunKernelImage is whether to force kernel asset extraction.
-	ExtractedRunKernelImage bool
+func (o *Options) validate() error {
+	if o == nil {
+		return nil
+	}
+	if o.NoSlashBoot && o.Role == RoleSole {
+		return fmt.Errorf("internal error: bootloader.RoleSole doesn't expect NoSlashBoot set")
+	}
+	return nil
 }
 
 // Bootloader provides an interface to interact with the system
@@ -223,6 +242,9 @@ func genericUpdateBootConfigFromAssets(systemFile string, assetName string) erro
 // InstallBootConfig installs the bootloader config from the gadget
 // snap dir into the right place.
 func InstallBootConfig(gadgetDir, rootDir string, opts *Options) error {
+	if err := opts.validate(); err != nil {
+		return err
+	}
 	// TODO:UC20 use ForGadget() to obtain the right bootloader
 	for _, bl := range []installableBootloader{&grub{}, &uboot{}, &androidboot{}, &lk{}} {
 		bl.setRootDir(rootDir)
@@ -260,6 +282,9 @@ var (
 // can also be used to find the recovery bootloader, e.g. on uc20:
 //   bootloader.Find("/run/mnt/ubuntu-seed")
 func Find(rootdir string, opts *Options) (Bootloader, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
 	if forcedBootloader != nil || forcedError != nil {
 		return forcedBootloader, forcedError
 	}
@@ -331,6 +356,9 @@ func removeKernelAssetsFromBootDir(bootDir string, s snap.PlaceInfo) error {
 // ForGadget returns a bootloader matching a given gadget by inspecting the
 // contents of gadget directory or an error if no matching bootloader is found.
 func ForGadget(gadgetDir, rootDir string, opts *Options) (Bootloader, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
 	if forcedBootloader != nil || forcedError != nil {
 		return forcedBootloader, forcedError
 	}

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -110,7 +110,7 @@ func (s *bootenvTestSuite) TestInstallBootloaderConfigFromGadget(c *C) {
 			name:       "uboot boot.scr",
 			gadgetFile: "uboot.conf",
 			sysFile:    "/uboot/ubuntu/boot.sel",
-			opts:       &bootloader.Options{NoSlashBoot: true},
+			opts:       &bootloader.Options{Role: bootloader.RoleRecovery},
 		},
 		{name: "androidboot", gadgetFile: "androidboot.conf", sysFile: "/boot/androidboot/androidboot.env"},
 		{name: "lk", gadgetFile: "lk.conf", sysFile: "/boot/lk/snapbootsel.bin"},
@@ -128,10 +128,10 @@ func (s *bootenvTestSuite) TestInstallBootloaderConfigFromGadget(c *C) {
 
 func (s *bootenvTestSuite) TestInstallBootloaderConfigFromAssets(c *C) {
 	recoveryOpts := &bootloader.Options{
-		Recovery: true,
+		Role: bootloader.RoleRecovery,
 	}
 	systemBootOpts := &bootloader.Options{
-		ExtractedRunKernelImage: true,
+		Role: bootloader.RoleRunMode,
 	}
 	defaultRecoveryGrubAsset := assets.Internal("grub-recovery.cfg")
 	c.Assert(defaultRecoveryGrubAsset, NotNil)
@@ -242,16 +242,23 @@ func (s *bootenvTestSuite) TestBootloaderFind(c *C) {
 		{
 			// native hierarchy
 			name: "grub", sysFile: "/EFI/ubuntu/grub.cfg",
-			opts:    &bootloader.Options{NoSlashBoot: true},
+			opts:    &bootloader.Options{Role: bootloader.RoleRunMode, NoSlashBoot: true},
 			expName: "grub",
 		},
+		{
+			// recovery layout
+			name: "grub", sysFile: "/EFI/ubuntu/grub.cfg",
+			opts:    &bootloader.Options{Role: bootloader.RoleRecovery},
+			expName: "grub",
+		},
+
 		// traditional uboot.env - the uboot.env file needs to be non-empty
 		{name: "uboot.env", sysFile: "/boot/uboot/uboot.env", expName: "uboot"},
 		// boot.sel variant
 		{
 			name:    "uboot boot.scr",
 			sysFile: "/uboot/ubuntu/boot.sel",
-			opts:    &bootloader.Options{NoSlashBoot: true},
+			opts:    &bootloader.Options{Role: bootloader.RoleRunMode, NoSlashBoot: true},
 			expName: "uboot",
 		},
 		{name: "androidboot", sysFile: "/boot/androidboot/androidboot.env", expName: "androidboot"},
@@ -283,7 +290,8 @@ func (s *bootenvTestSuite) TestBootloaderForGadget(c *C) {
 		expName    string
 	}{
 		{name: "grub", gadgetFile: "grub.conf", expName: "grub"},
-		{name: "grub", gadgetFile: "grub.conf", opts: &bootloader.Options{NoSlashBoot: true}, expName: "grub"},
+		{name: "grub", gadgetFile: "grub.conf", opts: &bootloader.Options{Role: bootloader.RoleRunMode, NoSlashBoot: true}, expName: "grub"},
+		{name: "grub", gadgetFile: "grub.conf", opts: &bootloader.Options{Role: bootloader.RoleRecovery}, expName: "grub"},
 		{name: "uboot", gadgetFile: "uboot.conf", expName: "uboot"},
 		{name: "androidboot", gadgetFile: "androidboot.conf", expName: "androidboot"},
 		{name: "lk", gadgetFile: "lk.conf", expName: "lk"},

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -55,15 +55,15 @@ type grub struct {
 // newGrub create a new Grub bootloader object
 func newGrub(rootdir string, opts *Options) Bootloader {
 	g := &grub{rootdir: rootdir}
-	if opts != nil && (opts.Recovery || opts.NoSlashBoot) {
+	if opts != nil {
+		g.uefiRunKernelExtraction = opts.Role == RoleRunMode
+		g.recovery = opts.Role == RoleRecovery
+		g.native = opts.NoSlashBoot || g.recovery
+	}
+	if g.native {
 		g.basedir = "EFI/ubuntu"
 	} else {
 		g.basedir = "boot/grub"
-	}
-	if opts != nil {
-		g.uefiRunKernelExtraction = opts.ExtractedRunKernelImage
-		g.recovery = opts.Recovery
-		g.native = opts.NoSlashBoot
 	}
 
 	return g
@@ -107,11 +107,11 @@ func (g *grub) installManagedBootConfig(gadgetDir string) (bool, error) {
 }
 
 func (g *grub) InstallBootConfig(gadgetDir string, opts *Options) (bool, error) {
-	if opts != nil && opts.Recovery {
+	if opts != nil && opts.Role == RoleRecovery {
 		// install managed config for the recovery partition
 		return g.installManagedRecoveryBootConfig(gadgetDir)
 	}
-	if opts != nil && opts.ExtractedRunKernelImage {
+	if opts != nil && opts.Role == RoleRunMode {
 		// install managed boot config that can handle kernel.efi
 		return g.installManagedBootConfig(gadgetDir)
 	}
@@ -353,9 +353,10 @@ func (g *grub) TryKernel() (snap.PlaceInfo, error) {
 //
 // Implements ManagedAssetsBootloader for the grub bootloader.
 func (g *grub) UpdateBootConfig(opts *Options) error {
+	// XXX: do we need to take opts here?
 	bootScriptName := "grub.cfg"
 	currentBootConfig := filepath.Join(g.dir(), "grub.cfg")
-	if opts != nil && opts.Recovery {
+	if opts != nil && opts.Role == RoleRecovery {
 		// use the recovery asset when asked to do so
 		bootScriptName = "grub-recovery.cfg"
 	}

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -239,14 +239,14 @@ func (s *grubTestSuite) makeFakeGrubEFINativeEnv(c *C, content []byte) {
 func (s *grubTestSuite) TestNewGrubWithOptionRecovery(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
 
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Recovery: true})
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
 	c.Assert(g, NotNil)
 	c.Assert(g.Name(), Equals, "grub")
 }
 
 func (s *grubTestSuite) TestNewGrubWithOptionRecoveryBootEnv(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Recovery: true})
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
 
 	// check that setting vars goes to the right place
 	c.Check(filepath.Join(s.grubEFINativeDir(), "grubenv"), testutil.FileAbsent)
@@ -270,14 +270,14 @@ func (s *grubTestSuite) TestNewGrubWithOptionRecoveryNoEnv(c *C) {
 	s.makeFakeGrubEnv(c)
 
 	// we can't create a recovery grub with that
-	g, err := bootloader.Find(s.rootdir, &bootloader.Options{Recovery: true})
+	g, err := bootloader.Find(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
 	c.Assert(g, IsNil)
 	c.Assert(err, Equals, bootloader.ErrBootloader)
 }
 
 func (s *grubTestSuite) TestGrubSetRecoverySystemEnv(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Recovery: true})
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
 
 	// check that we can set a recovery system specific bootenv
 	bvars := map[string]string{
@@ -299,7 +299,7 @@ func (s *grubTestSuite) TestGrubSetRecoverySystemEnv(c *C) {
 
 func (s *grubTestSuite) TestGetRecoverySystemEnv(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Recovery: true})
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
 
 	err := os.MkdirAll(filepath.Join(s.rootdir, "/systems/20191209"), 0755)
 	c.Assert(err, IsNil)
@@ -506,7 +506,7 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageDisableTryKernel(c *C) {
 func (s *grubTestSuite) TestKernelExtractionRunImageKernel(c *C) {
 	s.makeFakeGrubEnv(c)
 
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{ExtractedRunKernelImage: true})
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
 	c.Assert(g, NotNil)
 
 	files := [][]string{
@@ -548,7 +548,7 @@ func (s *grubTestSuite) TestKernelExtractionRunImageKernelNoSlashBoot(c *C) {
 	// layout, same as Recovery, without the /boot mount
 	s.makeFakeGrubEFINativeEnv(c, nil)
 
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{ExtractedRunKernelImage: true, NoSlashBoot: true})
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode, NoSlashBoot: true})
 	c.Assert(g, NotNil)
 
 	files := [][]string{
@@ -648,7 +648,7 @@ some random boot config`))
 		"EFI/ubuntu/grub.cfg",
 	})
 
-	opts = &bootloader.Options{Recovery: true}
+	opts = &bootloader.Options{Role: bootloader.RoleRecovery}
 	mg = bootloader.NewGrub(s.rootdir, opts).(bootloader.ManagedAssetsBootloader)
 	c.Check(mg.ManagedAssets(), DeepEquals, []string{
 		"EFI/ubuntu/grub.cfg",
@@ -666,7 +666,7 @@ func (s *grubTestSuite) TestRecoveryUpdateBootConfigNoEdition(c *C) {
 	// native EFI/ubuntu setup
 	s.makeFakeGrubEFINativeEnv(c, []byte("recovery boot script"))
 
-	opts := &bootloader.Options{Recovery: true}
+	opts := &bootloader.Options{Role: bootloader.RoleRecovery}
 	g := bootloader.NewGrub(s.rootdir, opts)
 	c.Assert(g, NotNil)
 
@@ -689,7 +689,7 @@ func (s *grubTestSuite) TestRecoveryUpdateBootConfigUpdates(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, []byte(`# Snapd-Boot-Config-Edition: 1
 recovery boot script`))
 
-	opts := &bootloader.Options{Recovery: true}
+	opts := &bootloader.Options{Role: bootloader.RoleRecovery}
 	g := bootloader.NewGrub(s.rootdir, opts)
 	c.Assert(g, NotNil)
 
@@ -855,7 +855,7 @@ func (s *grubTestSuite) TestCommandLineNotManaged(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(args, Equals, "snapd_recovery_mode=run static=1 extra")
 
-	optsRecovery := &bootloader.Options{NoSlashBoot: true, Recovery: true}
+	optsRecovery := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
 	mgr := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.ManagedAssetsBootloader)
 
 	args, err = mgr.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=1234", "extra")
@@ -900,7 +900,7 @@ boot script
 	c.Check(args, Equals, `arg1 foo=123 panic=-1 arg2="with spaces " extra_arg=1 extra_foo=-1 panic=3 baz="more  spaces"`)
 
 	// now check the recovery bootloader
-	optsRecovery := &bootloader.Options{NoSlashBoot: true, Recovery: true}
+	optsRecovery := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
 	mrg := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.ManagedAssetsBootloader)
 	args, err = mrg.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=20200202", extraArgs)
 	c.Assert(err, IsNil)
@@ -950,7 +950,7 @@ boot script
 
 	optsNoSlashBoot := &bootloader.Options{NoSlashBoot: true}
 	mg := bootloader.NewGrub(s.rootdir, optsNoSlashBoot).(bootloader.ManagedAssetsBootloader)
-	optsRecovery := &bootloader.Options{NoSlashBoot: true, Recovery: true}
+	optsRecovery := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
 	recoverymg := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.ManagedAssetsBootloader)
 
 	args, err := mg.CandidateCommandLine("snapd_recovery_mode=run", "", "extra=1")
@@ -1004,7 +1004,7 @@ boot script
 	c.Check(args, Equals, `snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 foo bar baz=1`)
 
 	// now check the recovery bootloader
-	opts = &bootloader.Options{NoSlashBoot: true, Recovery: true}
+	opts = &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
 	mrg := bootloader.NewGrub(s.rootdir, opts).(bootloader.ManagedAssetsBootloader)
 	args, err = mrg.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=20200202", extraArgs)
 	c.Assert(err, IsNil)
@@ -1029,7 +1029,7 @@ func (s *grubTestSuite) TestTrustedAssetsNative(c *C) {
 	})
 
 	// recovery bootloader
-	recoveryOpts := &bootloader.Options{NoSlashBoot: true, Recovery: true}
+	recoveryOpts := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
 	tarb := bootloader.NewGrub(s.rootdir, recoveryOpts).(bootloader.TrustedAssetsBootloader)
 	c.Assert(tarb, NotNil)
 

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -43,15 +43,16 @@ func (u *uboot) setDefaults() {
 func (u *uboot) processBlOpts(blOpts *Options) {
 	if blOpts != nil {
 		switch {
-		case blOpts.NoSlashBoot, blOpts.Recovery:
-			// Recovery or NoSlashBoot imply we use the "boot.sel" simple text
-			// format file in /uboot/ubuntu as it exists on the partition
+		case blOpts.Role == RoleRecovery || blOpts.NoSlashBoot:
+			// RoleRecovery or NoSlashBoot imply we use
+			// the "boot.sel" simple text format file in
+			// /uboot/ubuntu as it exists on the partition
 			// directly
 			u.basedir = "/uboot/ubuntu/"
 			fallthrough
-		case blOpts.ExtractedRunKernelImage:
-			// if just ExtractedRunKernelImage is defined, we expect to find
-			// /boot/uboot/boot.sel
+		case blOpts.Role == RoleRunMode:
+			// if RoleRunMode (and no NoSlashBoot), we
+			// expect to find /boot/uboot/boot.sel
 			u.ubootEnvFileName = "boot.sel"
 		}
 	}
@@ -124,7 +125,7 @@ func (u *uboot) InstallBootConfig(gadgetDir string, blOpts *Options) (bool, erro
 	// so we need to apply the defaults here
 	u.setDefaults()
 
-	if blOpts != nil && blOpts.Recovery {
+	if blOpts != nil && blOpts.Role == RoleRecovery {
 		// not supported yet, this is traditional uboot.env from gadget
 		// TODO:UC20: support this use-case
 		return false, fmt.Errorf("non-empty uboot.env not supported on UC20 yet")

--- a/bootloader/uboot_test.go
+++ b/bootloader/uboot_test.go
@@ -229,17 +229,17 @@ func (s *ubootTestSuite) TestUbootUC20OptsPlacement(c *C) {
 			"traditional uboot.env",
 		},
 		{
-			&bootloader.Options{NoSlashBoot: true},
+			&bootloader.Options{Role: bootloader.RoleRunMode, NoSlashBoot: true},
 			"/uboot/ubuntu/boot.sel",
 			"uc20 install mode boot.sel",
 		},
 		{
-			&bootloader.Options{ExtractedRunKernelImage: true},
+			&bootloader.Options{Role: bootloader.RoleRunMode},
 			"/boot/uboot/boot.sel",
 			"uc20 run mode boot.sel",
 		},
 		{
-			&bootloader.Options{Recovery: true},
+			&bootloader.Options{Role: bootloader.RoleRecovery},
 			"/uboot/ubuntu/boot.sel",
 			"uc20 recovery boot.sel",
 		},

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -345,12 +345,21 @@ func maybePreserveManagedBootAssets(mountPoint string, ps *LaidOutStructure) ([]
 	if ps.Role != SystemSeed && ps.Role != SystemBoot {
 		return nil, nil
 	}
+	// TODO:UC20: this code should no longer be needed when we use
+	// the updater interface from boot, in particular we shouldn't
+	// try to find a bootloader from this place, we don't have
+	// quite enough info not to guess
+
 	// the assets are within the system-boot or system-seed partition, set
 	// the right flags so that files are looked for using their paths inside
 	// the partition
+	role := bootloader.RoleRecovery
+	if ps.Role == SystemBoot {
+		role = bootloader.RoleRunMode
+	}
 	opts := &bootloader.Options{
-		Recovery:    ps.Role == SystemSeed,
-		NoSlashBoot: ps.Role == SystemBoot,
+		Role:        role,
+		NoSlashBoot: true,
 	}
 	bl, err := bootloader.Find(mountPoint, opts)
 	if err != nil {
@@ -367,8 +376,6 @@ func maybePreserveManagedBootAssets(mountPoint string, ps *LaidOutStructure) ([]
 		// assets
 		return nil, nil
 	}
-	// TODO:UC20: this should no longer be checked when we use the updater
-	// interface from boot
 	managed, err := mbl.IsCurrentlyManaged()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
introduce bootloader.Options.Role to cover more generically
what was covered before by the Recovery and ExtractedRunKernelImage
flags

the default is RoleSole = "" which applies to the sole bootloader
for UC16/18

adjust tests and comments