### PR TITLE
many: use BootFile type in load sequences

### DIFF
--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -353,7 +353,7 @@ type BootImage struct {
 	// Relative is the path to the EFI image inside a snap container.
 	Relative string
 	// FromRecovery is true if this boot image originates from the recovery
-	// bootload boot chain.
+	// bootloader boot chain.
 	FromRecovery bool
 	// IsKernel is true if this boot image corresponds to a kernel file.
 	IsKernel bool
@@ -368,11 +368,15 @@ func NewBootImage(path, rel string, fromRecovery, isKernel bool) BootImage {
 	}
 }
 
+// WithPath returns a copy of the BootImage with path updated to the
+// specified value.
 func (b BootImage) WithPath(path string) BootImage {
 	b.Path = path
 	return b
 }
 
+// Equals verifies whether all fields of two BootImage instances contain
+// the same values.
 func (b BootImage) Equals(a BootImage) bool {
 	return b.Path == a.Path && b.Relative == a.Relative && b.IsKernel == a.IsKernel && b.FromRecovery == a.FromRecovery
 }

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -376,20 +376,21 @@ func ForGadget(gadgetDir, rootDir string, opts *Options) (Bootloader, error) {
 // used in the boot process. A boot file can be an EFI binary or a snap file
 // containing an EFI binary.
 type BootFile struct {
-	// Path is the path to the boot file.
+	// Path is the path to the file in the filesystem or, if Snap
+	// is set, the relative path inside the snap file.
 	Path string
-	// Relative is the path to the EFI image inside a snap container.
-	Relative string
+	// Snap contains the path to the snap file if a snap file is used.
+	Snap string
 	// Role is set to the role of the bootloader this boot image
 	// originates from.
 	Role Role
 }
 
-func NewBootFile(path, rel string, role Role) BootFile {
+func NewBootFile(snap, path string, role Role) BootFile {
 	return BootFile{
-		Path:     path,
-		Relative: rel,
-		Role:     role,
+		Snap: snap,
+		Path: path,
+		Role: role,
 	}
 }
 

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -383,16 +383,13 @@ type BootFile struct {
 	// FromRecovery is true if this boot image originates from the recovery
 	// bootloader boot chain.
 	FromRecovery bool
-	// IsKernel is true if this boot image corresponds to a kernel file.
-	IsKernel bool
 }
 
-func NewBootFile(path, rel string, fromRecovery, isKernel bool) BootFile {
+func NewBootFile(path, rel string, fromRecovery bool) BootFile {
 	return BootFile{
 		Path:         path,
 		Relative:     rel,
 		FromRecovery: fromRecovery,
-		IsKernel:     isKernel,
 	}
 }
 
@@ -401,10 +398,4 @@ func NewBootFile(path, rel string, fromRecovery, isKernel bool) BootFile {
 func (b BootFile) WithPath(path string) BootFile {
 	b.Path = path
 	return b
-}
-
-// Equals verifies whether all fields of two BootFile instances contain
-// the same values.
-func (b BootFile) Equals(a BootFile) bool {
-	return b.Path == a.Path && b.Relative == a.Relative && b.IsKernel == a.IsKernel && b.FromRecovery == a.FromRecovery
 }

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -372,11 +372,11 @@ func ForGadget(gadgetDir, rootDir string, opts *Options) (Bootloader, error) {
 	return nil, ErrBootloader
 }
 
-// BootImage represents each image in the chains of trusted assets and kernels
-// used in the boot process. A boot image can be an EFI binary or a snap file
+// BootFile represents each file in the chains of trusted assets and kernels
+// used in the boot process. A boot file can be an EFI binary or a snap file
 // containing an EFI binary.
-type BootImage struct {
-	// Path is the path to the boot image file.
+type BootFile struct {
+	// Path is the path to the boot file.
 	Path string
 	// Relative is the path to the EFI image inside a snap container.
 	Relative string
@@ -387,8 +387,8 @@ type BootImage struct {
 	IsKernel bool
 }
 
-func NewBootImage(path, rel string, fromRecovery, isKernel bool) BootImage {
-	return BootImage{
+func NewBootFile(path, rel string, fromRecovery, isKernel bool) BootFile {
+	return BootFile{
 		Path:         path,
 		Relative:     rel,
 		FromRecovery: fromRecovery,
@@ -396,15 +396,15 @@ func NewBootImage(path, rel string, fromRecovery, isKernel bool) BootImage {
 	}
 }
 
-// WithPath returns a copy of the BootImage with path updated to the
+// WithPath returns a copy of the BootFile with path updated to the
 // specified value.
-func (b BootImage) WithPath(path string) BootImage {
+func (b BootFile) WithPath(path string) BootFile {
 	b.Path = path
 	return b
 }
 
-// Equals verifies whether all fields of two BootImage instances contain
+// Equals verifies whether all fields of two BootFile instances contain
 // the same values.
-func (b BootImage) Equals(a BootImage) bool {
+func (b BootFile) Equals(a BootFile) bool {
 	return b.Path == a.Path && b.Relative == a.Relative && b.IsKernel == a.IsKernel && b.FromRecovery == a.FromRecovery
 }

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -343,3 +343,36 @@ func ForGadget(gadgetDir, rootDir string, opts *Options) (Bootloader, error) {
 	}
 	return nil, ErrBootloader
 }
+
+// BootImage represents each image in the chains of trusted assets and kernels
+// used in the boot process. A boot image can be an EFI binary or a snap file
+// containing an EFI binary.
+type BootImage struct {
+	// Path is the path to the boot image file.
+	Path string
+	// Relative is the path to the EFI image inside a snap container.
+	Relative string
+	// FromRecovery is true if this boot image originates from the recovery
+	// bootload boot chain.
+	FromRecovery bool
+	// IsKernel is true if this boot image corresponds to a kernel file.
+	IsKernel bool
+}
+
+func NewBootImage(path, rel string, fromRecovery, isKernel bool) BootImage {
+	return BootImage{
+		Path:         path,
+		Relative:     rel,
+		FromRecovery: fromRecovery,
+		IsKernel:     isKernel,
+	}
+}
+
+func (b BootImage) WithPath(path string) BootImage {
+	b.Path = path
+	return b
+}
+
+func (b BootImage) Equals(a BootImage) bool {
+	return b.Path == a.Path && b.Relative == a.Relative && b.IsKernel == a.IsKernel && b.FromRecovery == a.FromRecovery
+}

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -380,16 +380,16 @@ type BootFile struct {
 	Path string
 	// Relative is the path to the EFI image inside a snap container.
 	Relative string
-	// FromRecovery is true if this boot image originates from the recovery
-	// bootloader boot chain.
-	FromRecovery bool
+	// Role is set to the role of the bootloader this boot image
+	// originates from.
+	Role Role
 }
 
-func NewBootFile(path, rel string, fromRecovery bool) BootFile {
+func NewBootFile(path, rel string, role Role) BootFile {
 	return BootFile{
-		Path:         path,
-		Relative:     rel,
-		FromRecovery: fromRecovery,
+		Path:     path,
+		Relative: rel,
+		Role:     role,
 	}
 }
 

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -309,3 +309,10 @@ func (s *bootenvTestSuite) TestBootloaderForGadget(c *C) {
 		c.Check(bl.Name(), Equals, tc.expName)
 	}
 }
+
+func (s *bootenvTestSuite) TestBootFileWithPath(c *C) {
+	a := bootloader.NewBootFile("", "some/path", bootloader.RoleRunMode)
+	b := a.WithPath("other/path")
+	c.Assert(a.Path, Equals, "some/path")
+	c.Assert(b.Path, Equals, "other/path")
+}

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -168,19 +168,17 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 	}
 
 	// TODO:UC20: binaries are EFI/bootloader-specific, hardcoded for now
-	fromRecovery := true
-	fromSystem := false
 	loadChain := []bootloader.BootFile{
 		// the path to the shim EFI binary
-		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), "", fromRecovery),
+		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), "", bootloader.RoleRecovery),
 		// the path to the recovery grub EFI binary
-		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), "", fromRecovery),
+		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), "", bootloader.RoleRecovery),
 		// the path to the run mode grub EFI binary
-		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), "", fromSystem),
+		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), "", bootloader.RoleRunMode),
 	}
 	if options.KernelPath != "" {
 		// the path to the kernel EFI binary
-		loadChain = append(loadChain, bootloader.NewBootFile(options.KernelPath, "", fromSystem))
+		loadChain = append(loadChain, bootloader.NewBootFile(options.KernelPath, "", bootloader.RoleRunMode))
 	}
 
 	// Get the expected kernel command line for the system that is currently being installed

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -170,19 +170,17 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 	// TODO:UC20: binaries are EFI/bootloader-specific, hardcoded for now
 	fromRecovery := true
 	fromSystem := false
-	isKernel := true
-	notKernel := false
 	loadChain := []bootloader.BootFile{
 		// the path to the shim EFI binary
-		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), "", fromRecovery, notKernel),
+		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), "", fromRecovery),
 		// the path to the recovery grub EFI binary
-		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), "", fromRecovery, notKernel),
+		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), "", fromRecovery),
 		// the path to the run mode grub EFI binary
-		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), "", fromSystem, notKernel),
+		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), "", fromSystem),
 	}
 	if options.KernelPath != "" {
 		// the path to the kernel EFI binary
-		loadChain = append(loadChain, bootloader.NewBootFile(options.KernelPath, "", fromSystem, isKernel))
+		loadChain = append(loadChain, bootloader.NewBootFile(options.KernelPath, "", fromSystem))
 	}
 
 	// Get the expected kernel command line for the system that is currently being installed

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -172,17 +172,17 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 	fromSystem := false
 	isKernel := true
 	notKernel := false
-	loadChain := []bootloader.BootImage{
+	loadChain := []bootloader.BootFile{
 		// the path to the shim EFI binary
-		bootloader.NewBootImage(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), "", fromRecovery, notKernel),
+		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), "", fromRecovery, notKernel),
 		// the path to the recovery grub EFI binary
-		bootloader.NewBootImage(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), "", fromRecovery, notKernel),
+		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), "", fromRecovery, notKernel),
 		// the path to the run mode grub EFI binary
-		bootloader.NewBootImage(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), "", fromSystem, notKernel),
+		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), "", fromSystem, notKernel),
 	}
 	if options.KernelPath != "" {
 		// the path to the kernel EFI binary
-		loadChain = append(loadChain, bootloader.NewBootImage(options.KernelPath, "", fromSystem, isKernel))
+		loadChain = append(loadChain, bootloader.NewBootFile(options.KernelPath, "", fromSystem, isKernel))
 	}
 
 	// Get the expected kernel command line for the system that is currently being installed
@@ -207,7 +207,7 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 			{
 				Model:          options.Model,
 				KernelCmdlines: kernelCmdlines,
-				EFILoadChains:  [][]bootloader.BootImage{loadChain},
+				EFILoadChains:  [][]bootloader.BootFile{loadChain},
 			},
 		},
 		KeyFile:                 filepath.Join(boot.InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -170,15 +170,15 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 	// TODO:UC20: binaries are EFI/bootloader-specific, hardcoded for now
 	loadChain := []bootloader.BootFile{
 		// the path to the shim EFI binary
-		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), "", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), bootloader.RoleRecovery),
 		// the path to the recovery grub EFI binary
-		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), "", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), bootloader.RoleRecovery),
 		// the path to the run mode grub EFI binary
-		bootloader.NewBootFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), "", bootloader.RoleRunMode),
+		bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), bootloader.RoleRunMode),
 	}
 	if options.KernelPath != "" {
 		// the path to the kernel EFI binary
-		loadChain = append(loadChain, bootloader.NewBootFile(options.KernelPath, "", bootloader.RoleRunMode))
+		loadChain = append(loadChain, bootloader.NewBootFile("", options.KernelPath, bootloader.RoleRunMode))
 	}
 
 	// Get the expected kernel command line for the system that is currently being installed

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	EFIImageFromBootImage = efiImageFromBootImage
+	EFIImageFromBootFile = efiImageFromBootFile
 )
 
 func MockSbConnectToDefaultTPM(f func() (*sb.TPMConnection, error)) (restore func()) {

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/snapcore/snapd/asserts"
 )
 
+var (
+	EFIImageFromBootImage = efiImageFromBootImage
+)
+
 func MockSbConnectToDefaultTPM(f func() (*sb.TPMConnection, error)) (restore func()) {
 	old := sbConnectToDefaultTPM
 	sbConnectToDefaultTPM = f

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -33,7 +33,7 @@ type SealKeyModelParams struct {
 	// The snap model
 	Model *asserts.Model
 	// The set of EFI binary load paths for the current device configuration
-	EFILoadChains [][]bootloader.BootImage
+	EFILoadChains [][]bootloader.BootFile
 	// The kernel command line
 	KernelCmdlines []string
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -26,19 +26,20 @@ package secboot
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/bootloader"
 )
 
 type SealKeyModelParams struct {
 	// The snap model
 	Model *asserts.Model
 	// The set of EFI binary load paths for the current device configuration
-	EFILoadChains [][]string
+	EFILoadChains [][]bootloader.BootImage
 	// The kernel command line
 	KernelCmdlines []string
 }
 
 type SealKeyParams struct {
-	// The snap model
+	// The parameters we're sealing the key to
 	ModelParams []*SealKeyModelParams
 	// The path to store the sealed key file
 	KeyFile string

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -420,7 +420,7 @@ func tpmProvision(tpm *sb.TPMConnection, lockoutAuthFile string) error {
 
 // buildLoadSequences creates a linear EFI image load event chain for each one of the
 // specified sequences of file paths.
-func buildLoadSequences(bootImages [][]bootloader.BootImage) ([]*sb.EFIImageLoadEvent, error) {
+func buildLoadSequences(bootImages [][]bootloader.BootFile) ([]*sb.EFIImageLoadEvent, error) {
 	// The idea of EFIImageLoadEvent is to build a set of load paths for the current
 	// device configuration. So you could have something like this:
 	//
@@ -449,7 +449,7 @@ func buildLoadSequences(bootImages [][]bootloader.BootImage) ([]*sb.EFIImageLoad
 		var next []*sb.EFIImageLoadEvent
 
 		for i := len(sequence) - 1; i >= 0; i-- {
-			image, err := efiImageFromBootImage(sequence[i])
+			image, err := efiImageFromBootFile(sequence[i])
 			if err != nil {
 				return nil, err
 			}
@@ -469,7 +469,7 @@ func buildLoadSequences(bootImages [][]bootloader.BootImage) ([]*sb.EFIImageLoad
 	return loadEvents, nil
 }
 
-func efiImageFromBootImage(b bootloader.BootImage) (sb.EFIImage, error) {
+func efiImageFromBootFile(b bootloader.BootFile) (sb.EFIImage, error) {
 	if !osutil.FileExists(b.Path) {
 		return nil, fmt.Errorf("file %s does not exist", b.Path)
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -470,21 +470,20 @@ func buildLoadSequences(bootImages [][]bootloader.BootFile) ([]*sb.EFIImageLoadE
 }
 
 func efiImageFromBootFile(b bootloader.BootFile) (sb.EFIImage, error) {
-	if !osutil.FileExists(b.Path) {
-		return nil, fmt.Errorf("file %s does not exist", b.Path)
-	}
-
-	if b.Relative == "" {
+	if b.Snap == "" {
+		if !osutil.FileExists(b.Path) {
+			return nil, fmt.Errorf("file %s does not exist", b.Path)
+		}
 		return sb.FileEFIImage(b.Path), nil
 	}
 
-	snapf, err := snapfile.Open(b.Path)
+	snapf, err := snapfile.Open(b.Snap)
 	if err != nil {
 		return nil, err
 	}
 	return sb.SnapFileEFIImage{
 		Container: snapf,
-		Path:      b.Path,
-		FileName:  b.Relative,
+		Path:      b.Snap,
+		FileName:  b.Path,
 	}, nil
 }


### PR DESCRIPTION
Replace naked pathnames in load sequences with the ~~BootImage~~ BootFile type
that holds information about the origin ~~and type~~ of the image and the
relative path inside a container (in case of adding snap files to the load
chain). This information will be used in forthcoming PRs to obtain trusted
image chains from a bootloader that manages trusted assets.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>