### PR TITLE
o/snapstate, features: add feature flag for disk space check on remove

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -53,6 +53,8 @@ const (
 	DbusActivation
 	// HiddenSnapFolder moves ~/snap to ~/.snapdata.
 	HiddenSnapFolder
+	// CheckDiskSpaceRemove controls free disk space check on remove whenever automatic snapshot needs to be created.
+	CheckDiskSpaceRemove
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
 )
@@ -83,6 +85,8 @@ var featureNames = map[SnapdFeature]string{
 	DbusActivation: "dbus-activation",
 
 	HiddenSnapFolder: "hidden-snap-folder",
+
+	CheckDiskSpaceRemove: "check-disk-space-remove",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -50,6 +50,7 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.UserDaemons.String(), Equals, "user-daemons")
 	c.Check(features.DbusActivation.String(), Equals, "dbus-activation")
 	c.Check(features.HiddenSnapFolder.String(), Equals, "hidden-snap-folder")
+	c.Check(features.CheckDiskSpaceRemove.String(), Equals, "check-disk-space-remove")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 
@@ -74,6 +75,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	c.Check(features.UserDaemons.IsExported(), Equals, false)
 	c.Check(features.DbusActivation.IsExported(), Equals, false)
 	c.Check(features.HiddenSnapFolder.IsExported(), Equals, true)
+	c.Check(features.CheckDiskSpaceRemove.IsExported(), Equals, false)
 }
 
 func (*featureSuite) TestIsEnabled(c *C) {
@@ -107,6 +109,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.UserDaemons.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.DbusActivation.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.HiddenSnapFolder.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.CheckDiskSpaceRemove.IsEnabledWhenUnset(), Equals, false)
 }
 
 func (*featureSuite) TestControlFile(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1966,21 +1966,28 @@ func Remove(st *state.State, name string, revision snap.Revision, flags *RemoveF
 		if tp, _ := snapst.Type(); tp == snap.TypeApp && removeAll {
 			ts, err := AutomaticSnapshot(st, name)
 			if err == nil {
-				sz, err := EstimateSnapshotSize(st, name, nil)
-				if err != nil {
+				tr := config.NewTransaction(st)
+				checkDiskSpaceRemove, err := features.Flag(tr, features.CheckDiskSpaceRemove)
+				if err != nil && !config.IsNoOption(err) {
 					return nil, err
 				}
-				requiredSpace := safetyMarginDiskSpace(sz)
-				path := dirs.SnapdStateDir(dirs.GlobalRootDir)
-				if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
-					if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
-						return nil, &InsufficientSpaceError{
-							Path:       path,
-							Snaps:      []string{name},
-							ChangeKind: "remove",
-							Message:    fmt.Sprintf("cannot create automatic snapshot when removing last revision of the snap: %v", err)}
+				if checkDiskSpaceRemove {
+					sz, err := EstimateSnapshotSize(st, name, nil)
+					if err != nil {
+						return nil, err
 					}
-					return nil, err
+					requiredSpace := safetyMarginDiskSpace(sz)
+					path := dirs.SnapdStateDir(dirs.GlobalRootDir)
+					if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
+						if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
+							return nil, &InsufficientSpaceError{
+								Path:       path,
+								Snaps:      []string{name},
+								ChangeKind: "remove",
+								Message:    fmt.Sprintf("cannot create automatic snapshot when removing last revision of the snap: %v", err)}
+						}
+						return nil, err
+					}
 				}
 				addNext(ts)
 			} else {


### PR DESCRIPTION
Add feature flag for disk space check on snap remove. The feature is disabled by default.