### PR TITLE
osutil: add ExchangeFiles

### DIFF
--- a/osutil/sys_linux_test.go
+++ b/osutil/sys_linux_test.go
@@ -20,6 +20,7 @@
 package osutil_test
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -27,6 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type sysSuite struct{}
@@ -69,4 +71,138 @@ func (s *sysSuite) TestSymlinkatAndReadlinkat(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, len("target"))
 	c.Assert(buf[:n], DeepEquals, []byte{'t', 'a', 'r', 'g', 'e', 't'})
+}
+
+func (s *sysSuite) TestExchangeFilesBothFilesMissing(c *C) {
+	// Create and open a temporary directory.
+	d := c.MkDir()
+	fd, err := syscall.Open(d, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	missingA := filepath.Join(d, "missing-a")
+	missingB := filepath.Join(d, "missing-b")
+
+	// Both missing-a and missing-b do not exist.
+	c.Assert(missingA, testutil.FileAbsent)
+	c.Assert(missingB, testutil.FileAbsent)
+
+	// Exchange fails with ENOENT
+	err = osutil.ExchangeFiles(fd, "missing-a", fd, "missing-b")
+	c.Assert(err, Equals, syscall.ENOENT)
+	c.Assert(os.IsNotExist(err), Equals, true)
+
+	// Exchange did not clobber file system state.
+	c.Assert(missingA, testutil.FileAbsent)
+	c.Assert(missingB, testutil.FileAbsent)
+}
+
+func (s *sysSuite) TestExchangeFilesFirstFileMissing(c *C) {
+	// Create and open a temporary directory.
+	d := c.MkDir()
+	fd, err := syscall.Open(d, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	missing := filepath.Join(d, "missing")
+	regular := filepath.Join(d, "regular")
+
+	err = ioutil.WriteFile(regular, []byte("regular"), 0644)
+	c.Assert(err, IsNil)
+
+	// Both the missing file is absent, the regular file is present.
+	c.Assert(missing, testutil.FileAbsent)
+	c.Assert(regular, testutil.FilePresent)
+
+	// Exchange fails with ENOENT because the first file is missing.
+	err = osutil.ExchangeFiles(fd, "missing", fd, "regular")
+	c.Assert(err, Equals, syscall.ENOENT)
+	c.Assert(os.IsNotExist(err), Equals, true)
+
+	// Exchange did not clobber file system state.
+	c.Assert(missing, testutil.FileAbsent)
+	c.Assert(regular, testutil.FileEquals, "regular")
+}
+
+func (s *sysSuite) TestExchangeFilesSecondFileMissing(c *C) {
+	// Create and open a temporary directory.
+	d := c.MkDir()
+	fd, err := syscall.Open(d, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	missing := filepath.Join(d, "missing")
+	regular := filepath.Join(d, "regular")
+
+	err = ioutil.WriteFile(regular, []byte("regular"), 0644)
+	c.Assert(err, IsNil)
+
+	// Both the missing file is absent, the regular file is present.
+	c.Assert(missing, testutil.FileAbsent)
+	c.Assert(regular, testutil.FilePresent)
+
+	// Exchange fails with ENOENT because the second file is missing.
+	err = osutil.ExchangeFiles(fd, "regular", fd, "missing")
+	c.Assert(err, Equals, syscall.ENOENT)
+	c.Assert(os.IsNotExist(err), Equals, true)
+
+	// Exchange did not clobber file system state.
+	c.Assert(missing, testutil.FileAbsent)
+	c.Assert(regular, testutil.FileEquals, "regular")
+}
+
+func (s *sysSuite) TestExchangeTwoRegularFiles(c *C) {
+	// Create and open a temporary directory.
+	d := c.MkDir()
+	fd, err := syscall.Open(d, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	regularA := filepath.Join(d, "regular-a")
+	regularB := filepath.Join(d, "regular-b")
+
+	err = ioutil.WriteFile(regularA, []byte("regular-a"), 0644)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(regularB, []byte("regular-b"), 0644)
+	c.Assert(err, IsNil)
+
+	// Both regular files are present and have content matching their name.
+	c.Assert(regularA, testutil.FileEquals, "regular-a")
+	c.Assert(regularB, testutil.FileEquals, "regular-b")
+
+	// Exchange succeeds.
+	err = osutil.ExchangeFiles(fd, "regular-a", fd, "regular-b")
+	c.Assert(err, IsNil)
+
+	// Exchange swapped the content of the two files.
+	c.Assert(regularA, testutil.FileEquals, "regular-b")
+	c.Assert(regularB, testutil.FileEquals, "regular-a")
+}
+
+func (s *sysSuite) TestExchangeTwoSymbolicLinks(c *C) {
+	// Create and open a temporary directory.
+	d := c.MkDir()
+	fd, err := syscall.Open(d, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	symlinkA := filepath.Join(d, "symlink-a")
+	symlinkB := filepath.Join(d, "symlink-b")
+
+	err = os.Symlink("target-a", symlinkA)
+	c.Assert(err, IsNil)
+	err = os.Symlink("target-b", symlinkB)
+	c.Assert(err, IsNil)
+
+	// Both symbolic links are pointing at their respective targets.
+	c.Assert(symlinkA, testutil.SymlinkTargetEquals, "target-a")
+	c.Assert(symlinkB, testutil.SymlinkTargetEquals, "target-b")
+
+	// Exchange succeeds.
+	err = osutil.ExchangeFiles(fd, "symlink-a", fd, "symlink-b")
+	c.Assert(err, IsNil)
+
+	// Exchange swapped the two targets.
+	c.Assert(symlinkA, testutil.SymlinkTargetEquals, "target-b")
+	c.Assert(symlinkB, testutil.SymlinkTargetEquals, "target-a")
 }

--- a/osutil/syscalls_linux_386.go
+++ b/osutil/syscalls_linux_386.go
@@ -1,0 +1,4 @@
+package osutil
+
+// sysRenameAt2 is the number of the renameat2 system call.
+const sysRenameAt2 = 353

--- a/osutil/syscalls_linux_amd64.go
+++ b/osutil/syscalls_linux_amd64.go
@@ -1,0 +1,4 @@
+package osutil
+
+// sysRenameAt2 is the number of the renameat2 system call.
+const sysRenameAt2 = 316

--- a/osutil/syscalls_linux_arm.go
+++ b/osutil/syscalls_linux_arm.go
@@ -1,0 +1,4 @@
+package osutil
+
+// sysRenameAt2 is the number of the renameat2 system call.
+const sysRenameAt2 = 382

--- a/osutil/syscalls_linux_arm64.go
+++ b/osutil/syscalls_linux_arm64.go
@@ -1,0 +1,4 @@
+package osutil
+
+// sysRenameAt2 is the number of the renameat2 system call.
+const sysRenameAt2 = 276

--- a/osutil/syscalls_linux_ppc64le.go
+++ b/osutil/syscalls_linux_ppc64le.go
@@ -1,0 +1,4 @@
+package osutil
+
+// sysRenameAt2 is the number of the renameat2 system call.
+const sysRenameAt2 = 357

--- a/osutil/syscalls_linux_riscv64.go
+++ b/osutil/syscalls_linux_riscv64.go
@@ -1,0 +1,4 @@
+package osutil
+
+// sysRenameAt2 is the number of the renameat2 system call.
+const sysRenameAt2 = 276

--- a/osutil/syscalls_linux_riscv64.go
+++ b/osutil/syscalls_linux_riscv64.go
@@ -1,3 +1,6 @@
+// +build linux
+// +build riscv64
+
 package osutil
 
 // sysRenameAt2 is the number of the renameat2 system call.

--- a/osutil/syscalls_linux_s390x.go
+++ b/osutil/syscalls_linux_s390x.go
@@ -1,0 +1,4 @@
+package osutil
+
+// sysRenameAt2 is the number of the renameat2 system call.
+const sysRenameAt2 = 347


### PR DESCRIPTION
ExchangeFiles is a high-level wrapper around renameat2(2) with the
RENAME_EXCHANGE flag. This system call atomically exchanges two files of
any kind.

The system call is not exposed by go directly, so it is invoked using
RawSyscall. The system call number is also not available, so a number of
architecture specific build variants are used to provide the system call
number. Supported architectures relevant to snapd are i386, x86_64, arm,
aarch64, ppc64le, s390x and riscv64. System call numbers were obtained
from https://fedora.juszkiewicz.com.pl/syscalls.html and verified on
hardware I had available.

A set of unit tests shows how the operation behaves on various kinds of
files. Those tests will fail if executed on a system call which does not
support the exchange operation.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
