### PR TITLE
sysconfig/cloudinit.go: add AllowCloudInit and use GadgetDir for cloud.conf

### DIFF
--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -107,10 +107,9 @@ func configureCloudInit(opts *Options) (err error) {
 	if osutil.FileExists(gadgetCloudConf) {
 		// then copy / install the gadget config and return without considering
 		// CloudInitSrcDir
-		if err := installGadgetCloudInitCfg(gadgetCloudConf, WritableDefaultsDir(opts.TargetRootDir)); err != nil {
-			return err
-		}
-		return nil
+		// TODO:UC20: we may eventually want to consider both CloudInitSrcDir
+		// and the gadget cloud.conf so returning here may be wrong
+		return installGadgetCloudInitCfg(gadgetCloudConf, WritableDefaultsDir(opts.TargetRootDir))
 	}
 
 	// TODO:UC20: implement filtering of files from src when specified via a
@@ -120,15 +119,13 @@ func configureCloudInit(opts *Options) (err error) {
 	// files from
 
 	if opts.CloudInitSrcDir != "" {
-		if err := installCloudInitCfgDir(opts.CloudInitSrcDir, WritableDefaultsDir(opts.TargetRootDir)); err != nil {
-			return err
-		}
+		return installCloudInitCfgDir(opts.CloudInitSrcDir, WritableDefaultsDir(opts.TargetRootDir))
 	}
 
-	// it's valid to have not set CloudInitSrcDir and not have a gadget
-	// cloud.conf, in this case cloud-init may pick up dynamic metadata and
-	// userdata from NoCloud sources such as a CD-ROM drive with label CIDATA,
-	// etc. during first-boot
+	// it's valid to allow cloud-init, but not set CloudInitSrcDir and not have
+	// a gadget cloud.conf, in this case cloud-init may pick up dynamic metadata
+	// and userdata from NoCloud sources such as a CD-ROM drive with label
+	// CIDATA, etc. during first-boot
 
 	return nil
 }

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -54,7 +54,11 @@ func DisableCloudInit(rootDir string) error {
 	return nil
 }
 
-func installCloudInitCfg(src, targetdir string) error {
+// installCloudInitCfgDir installs glob cfg files from the source directory to
+// the cloud config dir. For installing single files from anywhere with any
+// name, use installUnifiedCloudInitCfg
+func installCloudInitCfgDir(src, targetdir string) error {
+	// TODO:UC20: enforce patterns on the glob files and their suffix ranges
 	ccl, err := filepath.Glob(filepath.Join(src, "*.cfg"))
 	if err != nil {
 		return err
@@ -76,21 +80,50 @@ func installCloudInitCfg(src, targetdir string) error {
 	return nil
 }
 
-// TODO:UC20: - allow cloud.conf coming from the gadget
-//            - think about if/what cloud-init means on "secured" models
+// installUnifiedCloudInitCfg installs a single cloud-init config file to the
+// cloud config dir as "ubuntu-core-cloud_91.cfg".
+func installUnifiedCloudInitCfg(src, targetdir string) error {
+	ubuntuDataCloudCfgDir := filepath.Join(ubuntuDataCloudDir(targetdir), "cloud.cfg.d/")
+	if err := os.MkdirAll(ubuntuDataCloudCfgDir, 0755); err != nil {
+		return fmt.Errorf("cannot make cloud config dir: %v", err)
+	}
+
+	configFile := filepath.Join(ubuntuDataCloudCfgDir, "80_device_gadget.cfg")
+	return osutil.CopyFile(src, configFile, 0)
+}
+
 func configureCloudInit(opts *Options) (err error) {
 	if opts.TargetRootDir == "" {
 		return fmt.Errorf("unable to configure cloud-init, missing target dir")
 	}
 
-	switch opts.CloudInitSrcDir {
-	case "":
-		// disable cloud-init by default using the writable dir
-		err = DisableCloudInit(WritableDefaultsDir(opts.TargetRootDir))
-	default:
-		err = installCloudInitCfg(opts.CloudInitSrcDir, WritableDefaultsDir(opts.TargetRootDir))
+	// TODO: too naive to just re-use GadgetDir here automatically?
+	gadgetCloudConf := filepath.Join(opts.GadgetDir, "cloud.conf")
+	if osutil.FileExists(gadgetCloudConf) {
+		// then copy / install the gadget config and return without considering
+		// CloudInitSrcDir
+		if err := installUnifiedCloudInitCfg(gadgetCloudConf, WritableDefaultsDir(opts.TargetRootDir)); err != nil {
+			return err
+		}
+		return nil
 	}
-	return err
+
+	// it's valid to not set CloudInitSrcDir, in this case cloud-init may pick
+	// up dynamic metadata and userdata from NoCloud sources such as a CD-ROM
+	// drive with label CIDATA, etc.
+	if opts.CloudInitSrcDir != "" {
+		if err := installCloudInitCfgDir(opts.CloudInitSrcDir, WritableDefaultsDir(opts.TargetRootDir)); err != nil {
+			return err
+		}
+	}
+
+	if !opts.AllowCloudInit {
+		if err := DisableCloudInit(WritableDefaultsDir(opts.TargetRootDir)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // CloudInitState represents the various cloud-init states

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -99,9 +99,7 @@ func configureCloudInit(opts *Options) (err error) {
 
 	// first check if cloud-init should be disallowed entirely
 	if !opts.AllowCloudInit {
-		if err := DisableCloudInit(WritableDefaultsDir(opts.TargetRootDir)); err != nil {
-			return err
-		}
+		return DisableCloudInit(WritableDefaultsDir(opts.TargetRootDir))
 	}
 
 	// next check if there is a gadget cloud.conf to install

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -76,8 +76,8 @@ func (s *sysconfigSuite) TestInstallModeCloudInitDisablesByDefaultRunMode(c *C) 
 
 func (s *sysconfigSuite) TestInstallModeCloudInitAllowedDoesNotDisable(c *C) {
 	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
-		TargetRootDir:  boot.InstallHostWritableDir,
 		AllowCloudInit: true,
+		TargetRootDir:  boot.InstallHostWritableDir,
 	})
 	c.Assert(err, IsNil)
 
@@ -97,6 +97,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunMode(c *C) {
 	}
 
 	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+		AllowCloudInit:  true,
 		CloudInitSrcDir: cloudCfgSrcDir,
 		TargetRootDir:   boot.InstallHostWritableDir,
 	})
@@ -115,8 +116,9 @@ func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunModeWithGadg
 	c.Assert(err, IsNil)
 
 	err = sysconfig.ConfigureRunSystem(&sysconfig.Options{
-		TargetRootDir: boot.InstallHostWritableDir,
-		GadgetDir:     gadgetDir,
+		AllowCloudInit: true,
+		GadgetDir:      gadgetDir,
+		TargetRootDir:  boot.InstallHostWritableDir,
 	})
 	c.Assert(err, IsNil)
 
@@ -138,9 +140,10 @@ func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunModeWithGadg
 	c.Assert(err, IsNil)
 
 	err = sysconfig.ConfigureRunSystem(&sysconfig.Options{
+		AllowCloudInit:  true,
 		CloudInitSrcDir: cloudCfgSrcDir,
-		TargetRootDir:   boot.InstallHostWritableDir,
 		GadgetDir:       gadgetDir,
+		TargetRootDir:   boot.InstallHostWritableDir,
 	})
 	c.Assert(err, IsNil)
 

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -40,6 +40,10 @@ type Options struct {
 	// boot.InstallHostWritableDir
 	TargetRootDir string
 
+	// AllowCloudInit is whether to allow cloud-init to run or not in the
+	// TargetRootDir.
+	AllowCloudInit bool
+
 	// GadgetDir is the path of the mounted gadget snap.
 	GadgetDir string
 }

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -70,7 +70,8 @@ func ApplyFilesystemOnlyDefaults(rootDir string, defaults map[string]interface{}
 }
 
 // ConfigureRunSystem configures the ubuntu-data partition with any
-// configuration needed from e.g. the gadget or for cloud-init.
+// configuration needed from e.g. the gadget or for cloud-init (and also for
+// cloud-init from the gadget).
 func ConfigureRunSystem(opts *Options) error {
 	if err := configureCloudInit(opts); err != nil {
 		return err


### PR DESCRIPTION
ConfigureRunSystem now takes an option to specifically allow cloud-init to
remain enabled, with the intention that it is allowed to run only on first boot
of run mode, and that snapd in the devicemgr ensure will restrict or disable
cloud-init thereafter.

Additionally, if there is a cloud.conf in the GadgetDir provided to
ConfigureRunSystem, this is installed as trusted cloud-init config to a specific
filename in /etc/cloud/cloud.cfg.d.

Add unit tests for these scenarios.

Note that currently these helpers are not used yet, they will be used in devicestate handlers in the next PR in the series

Broken out from #9237 