### PR TITLE
sysconfig/cloudinit.go: add DisableNoCloud to CloudInitRestrictOptions

### DIFF
--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -204,10 +204,17 @@ type CloudInitRestrictionResult struct {
 }
 
 // CloudInitRestrictOptions are options for how to restrict cloud-init with
-// RestrictCloudInit. ForceDisable will force disabling cloud-init even if it is
-// in an active/running or errored state.
+// RestrictCloudInit.
 type CloudInitRestrictOptions struct {
+	// ForceDisable will force disabling cloud-init even if it is
+	// in an active/running or errored state.
 	ForceDisable bool
+
+	// DisableNoCloud modifies the behavior to whole-sale disable cloud-init,
+	// if the datasource detected is NoCloud, if the datasource detected is
+	// anything other than NoCloud then it is merely restricted as described in
+	// the doc-comment on RestrictCloudInit.
+	DisableNoCloud bool
 }
 
 // RestrictCloudInit will limit the operations of cloud-init on subsequent boots
@@ -294,7 +301,16 @@ func RestrictCloudInit(state CloudInitState, opts *CloudInitRestrictOptions) (Cl
 		// USB drive inserted by an attacker with label CIDATA will defeat
 		// security measures on Ubuntu Core, so with the additional fs_label
 		// spec, we disable that import.
-		err = ioutil.WriteFile(cloudInitRestrictFile, nocloudRestrictYaml, 0644)
+
+		// Note that on UC20, we will also specify DisableNoCloud, to disable
+		// cloud-init even after the first boot
+		if opts.DisableNoCloud {
+			// change the action taken to disable
+			res.Action = "disable"
+			err = DisableCloudInit(dirs.GlobalRootDir)
+		} else {
+			err = ioutil.WriteFile(cloudInitRestrictFile, nocloudRestrictYaml, 0644)
+		}
 	default:
 		// all other datasources that are not NoCloud will be restricted to only
 		// allow this specific datasource to prevent an attack via NoCloud for

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -337,6 +337,17 @@ func (s *sysconfigSuite) TestRestrictCloudInit(c *C) {
 			expAction:              "restrict",
 			expRestrictYamlWritten: restrictNoCloudYaml,
 		},
+		{
+			comment:             "nocloud uc20 done",
+			state:               sysconfig.CloudInitDone,
+			cloudInitStatusJSON: multipassNoCloudCloudInitStatusJSON,
+			sysconfOpts: &sysconfig.CloudInitRestrictOptions{
+				DisableNoCloud: true,
+			},
+			expDatasource:  "NoCloud",
+			expAction:      "disable",
+			expDisableFile: true,
+		},
 		// the two cases for lxd and multipass are effectively the same, but as
 		// the largest known users of cloud-init w/ UC, we leave them as
 		// separate test cases for their different cloud-init status.json
@@ -356,6 +367,28 @@ func (s *sysconfigSuite) TestRestrictCloudInit(c *C) {
 			expDatasource:          "NoCloud",
 			expAction:              "restrict",
 			expRestrictYamlWritten: restrictNoCloudYaml,
+		},
+		{
+			comment:             "nocloud uc20 multipass done",
+			state:               sysconfig.CloudInitDone,
+			cloudInitStatusJSON: multipassNoCloudCloudInitStatusJSON,
+			sysconfOpts: &sysconfig.CloudInitRestrictOptions{
+				DisableNoCloud: true,
+			},
+			expDatasource:  "NoCloud",
+			expAction:      "disable",
+			expDisableFile: true,
+		},
+		{
+			comment:             "nocloud uc20 seed lxd done",
+			state:               sysconfig.CloudInitDone,
+			cloudInitStatusJSON: lxdNoCloudCloudInitStatusJSON,
+			sysconfOpts: &sysconfig.CloudInitRestrictOptions{
+				DisableNoCloud: true,
+			},
+			expDatasource:  "NoCloud",
+			expAction:      "disable",
+			expDisableFile: true,
 		},
 	}
 


### PR DESCRIPTION
For UC20, we will want to disable cloud-init even with NoCloud after first-boot,
as cloud-init for UC20 will really only to be provide initial bootstrapping
details and is not meant to be used to persistently configure a device on every
boot.

Broken out from #9237 