### PR TITLE
o/snapstate, features: add feature flag for disk space check on remove (2.46)

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -53,6 +53,8 @@ const (
 	DbusActivation
 	// HiddenSnapFolder moves ~/snap to ~/.snapdata.
 	HiddenSnapFolder
+	// CheckDiskSpaceRemove controls free disk space check on remove whenever automatic snapshot needs to be created.
+	CheckDiskSpaceRemove
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
 )
@@ -83,6 +85,8 @@ var featureNames = map[SnapdFeature]string{
 	DbusActivation: "dbus-activation",
 
 	HiddenSnapFolder: "hidden-snap-folder",
+
+	CheckDiskSpaceRemove: "check-disk-space-remove",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -50,6 +50,7 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.UserDaemons.String(), Equals, "user-daemons")
 	c.Check(features.DbusActivation.String(), Equals, "dbus-activation")
 	c.Check(features.HiddenSnapFolder.String(), Equals, "hidden-snap-folder")
+	c.Check(features.CheckDiskSpaceRemove.String(), Equals, "check-disk-space-remove")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 
@@ -74,6 +75,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	c.Check(features.UserDaemons.IsExported(), Equals, false)
 	c.Check(features.DbusActivation.IsExported(), Equals, false)
 	c.Check(features.HiddenSnapFolder.IsExported(), Equals, true)
+	c.Check(features.CheckDiskSpaceRemove.IsExported(), Equals, false)
 }
 
 func (*featureSuite) TestIsEnabled(c *C) {
@@ -107,6 +109,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.UserDaemons.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.DbusActivation.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.HiddenSnapFolder.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.CheckDiskSpaceRemove.IsEnabledWhenUnset(), Equals, false)
 }
 
 func (*featureSuite) TestControlFile(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1078,6 +1078,10 @@ func (s *snapmgrTestSuite) TestRemoveDiskSpaceForSnapshotError(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.check-disk-space-remove", true)
+	tr.Commit()
+
 	restore := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error { return &osutil.NotEnoughDiskSpaceError{} })
 	defer restore()
 
@@ -1118,6 +1122,42 @@ func (s *snapmgrTestSuite) TestRemoveDiskSpaceForSnapshotNotCheckedWhenSnapshots
 
 	_, err := snapstate.Remove(s.state, "some-snap", snap.R(0), nil)
 	c.Assert(err, IsNil)
+	c.Assert(automaticSnapshotCalled, Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestRemoveDiskSpaceCheckDisabled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var diskCheckHit bool
+	// this shouldn't be hit since we're disabling the the feature below
+	restore := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error {
+		diskCheckHit = true
+		return &osutil.NotEnoughDiskSpaceError{}
+	})
+	defer restore()
+
+	var automaticSnapshotCalled bool
+	snapstate.AutomaticSnapshot = func(st *state.State, instanceName string) (ts *state.TaskSet, err error) {
+		automaticSnapshotCalled = true
+		// ErrNothingToDo is returned if automatic snapshots are disabled
+		return nil, snapstate.ErrNothingToDo
+	}
+
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.check-disk-space-remove", false)
+	tr.Commit()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(11)}},
+		Current:  snap.R(11),
+		SnapType: "app",
+	})
+
+	_, err := snapstate.Remove(s.state, "some-snap", snap.R(0), nil)
+	c.Check(err, IsNil)
+	c.Check(diskCheckHit, Equals, false)
 	c.Assert(automaticSnapshotCalled, Equals, true)
 }
 


### PR DESCRIPTION
Cherry pick #9251 for 2.46. Note, there was a conflict due to earlier changes around this area and for 2.46 I omitted the renaming of ErrInsufficientSpace and the introduction of safetyMarginDiskSpace helper.