### PR TITLE
bootloader: retrieve boot chains from bootloader

### DIFF
--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -192,6 +192,12 @@ type TrustedAssetsBootloader interface {
 	// the bootloader's rootdir that are measured in the boot process in the
 	// order of loading during the boot.
 	TrustedAssets() ([]string, error)
+
+	// RecoveryBootChain returns the chain of recovery mode boot files.
+	RecoveryBootChain(kernelPath string) ([]BootFile, error)
+
+	// RecoveryBootChain returns the chain of run mode boot files.
+	BootChain(runBl TrustedAssetsBootloader, kernelPath string) ([]BootFile, error)
 }
 
 func genericInstallBootConfig(gadgetFile, systemFile string) (bool, error) {

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -193,10 +193,13 @@ type TrustedAssetsBootloader interface {
 	// order of loading during the boot.
 	TrustedAssets() ([]string, error)
 
-	// RecoveryBootChain returns the chain of recovery mode boot files.
+	// RecoveryBootChain returns the load chain for recovery modes.
+	// It should be called on a RoleRecovery bootloader.
 	RecoveryBootChain(kernelPath string) ([]BootFile, error)
 
-	// RecoveryBootChain returns the chain of run mode boot files.
+	// BootChain returns the load chain for run mode.
+	// It should be called on a RoleRecovery bootloader passing the
+	// RoleRunMode bootloader.
 	BootChain(runBl TrustedAssetsBootloader, kernelPath string) ([]BootFile, error)
 }
 

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -200,7 +200,7 @@ type TrustedAssetsBootloader interface {
 	// BootChain returns the load chain for run mode.
 	// It should be called on a RoleRecovery bootloader passing the
 	// RoleRunMode bootloader.
-	BootChain(runBl TrustedAssetsBootloader, kernelPath string) ([]BootFile, error)
+	BootChain(runBl Bootloader, kernelPath string) ([]BootFile, error)
 }
 
 func genericInstallBootConfig(gadgetFile, systemFile string) (bool, error) {

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -441,6 +441,13 @@ type MockTrustedAssetsBootloader struct {
 	TrustedAssetsList  []string
 	TrustedAssetsErr   error
 	TrustedAssetsCalls int
+
+	RecoveryBootChainList  []bootloader.BootFile
+	RecoveryBootChainErr   error
+	RecoveryBootChainCalls int
+	BootChainList          []bootloader.BootFile
+	BootChainErr           error
+	BootChainCalls         int
 }
 
 func (b *MockBootloader) WithTrustedAssets() *MockTrustedAssetsBootloader {
@@ -455,22 +462,13 @@ func (b *MockTrustedAssetsBootloader) TrustedAssets() ([]string, error) {
 }
 
 func (b *MockTrustedAssetsBootloader) RecoveryBootChain(kernelPath string) ([]bootloader.BootFile, error) {
-	chain := []bootloader.BootFile{
-		bootloader.NewBootFile("", "recovery-asset-1", bootloader.RoleRecovery),
-		bootloader.NewBootFile("", "recovery-asset-2", bootloader.RoleRecovery),
-		bootloader.NewBootFile(kernelPath, "kernel.efi", bootloader.RoleRecovery),
-	}
-	return chain, nil
+	b.RecoveryBootChainCalls++
+	return b.RecoveryBootChainList, b.RecoveryBootChainErr
 }
 
 func (b *MockTrustedAssetsBootloader) BootChain(runBl bootloader.TrustedAssetsBootloader, kernelPath string) ([]bootloader.BootFile, error) {
-	chain := []bootloader.BootFile{
-		bootloader.NewBootFile("", "recovery-asset-1", bootloader.RoleRecovery),
-		bootloader.NewBootFile("", "recovery-asset-2", bootloader.RoleRecovery),
-		bootloader.NewBootFile("", "run-mode-asset-1", bootloader.RoleRunMode),
-		bootloader.NewBootFile(kernelPath, "kernel.efi", bootloader.RoleRunMode),
-	}
-	return chain, nil
+	b.BootChainCalls++
+	return b.BootChainList, b.BootChainErr
 }
 
 // MockManagedAssetsRecoveryAwareBootloader mocks a bootloader implementing the

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -55,6 +55,7 @@ type MockBootloader struct {
 // ensure MockBootloader(s) implement the Bootloader interface
 var _ bootloader.Bootloader = (*MockBootloader)(nil)
 var _ bootloader.RecoveryAwareBootloader = (*MockRecoveryAwareBootloader)(nil)
+var _ bootloader.TrustedAssetsBootloader = (*MockTrustedAssetsBootloader)(nil)
 var _ bootloader.ExtractedRunKernelImageBootloader = (*MockExtractedRunKernelImageBootloader)(nil)
 var _ bootloader.ExtractedRecoveryKernelImageBootloader = (*MockExtractedRecoveryKernelImageBootloader)(nil)
 var _ bootloader.ManagedAssetsBootloader = (*MockManagedAssetsBootloader)(nil)
@@ -451,6 +452,25 @@ func (b *MockBootloader) WithTrustedAssets() *MockTrustedAssetsBootloader {
 func (b *MockTrustedAssetsBootloader) TrustedAssets() ([]string, error) {
 	b.TrustedAssetsCalls++
 	return b.TrustedAssetsList, b.TrustedAssetsErr
+}
+
+func (b *MockTrustedAssetsBootloader) RecoveryBootChain(kernelPath string) ([]bootloader.BootFile, error) {
+	chain := []bootloader.BootFile{
+		bootloader.NewBootFile("", "recovery-asset-1", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "recovery-asset-2", bootloader.RoleRecovery),
+		bootloader.NewBootFile(kernelPath, "kernel.efi", bootloader.RoleRecovery),
+	}
+	return chain, nil
+}
+
+func (b *MockTrustedAssetsBootloader) BootChain(runBl bootloader.TrustedAssetsBootloader, kernelPath string) ([]bootloader.BootFile, error) {
+	chain := []bootloader.BootFile{
+		bootloader.NewBootFile("", "recovery-asset-1", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "recovery-asset-2", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "run-mode-asset-1", bootloader.RoleRunMode),
+		bootloader.NewBootFile(kernelPath, "kernel.efi", bootloader.RoleRunMode),
+	}
+	return chain, nil
 }
 
 // MockManagedAssetsRecoveryAwareBootloader mocks a bootloader implementing the

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -466,7 +466,7 @@ func (b *MockTrustedAssetsBootloader) RecoveryBootChain(kernelPath string) ([]bo
 	return b.RecoveryBootChainList, b.RecoveryBootChainErr
 }
 
-func (b *MockTrustedAssetsBootloader) BootChain(runBl bootloader.TrustedAssetsBootloader, kernelPath string) ([]bootloader.BootFile, error) {
+func (b *MockTrustedAssetsBootloader) BootChain(runBl bootloader.Bootloader, kernelPath string) ([]bootloader.BootFile, error) {
 	b.BootChainCalls++
 	return b.BootChainList, b.BootChainErr
 }

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -442,12 +442,14 @@ type MockTrustedAssetsBootloader struct {
 	TrustedAssetsErr   error
 	TrustedAssetsCalls int
 
-	RecoveryBootChainList  []bootloader.BootFile
-	RecoveryBootChainErr   error
-	RecoveryBootChainCalls int
-	BootChainList          []bootloader.BootFile
-	BootChainErr           error
-	BootChainCalls         int
+	RecoveryBootChainList []bootloader.BootFile
+	RecoveryBootChainErr  error
+	BootChainList         []bootloader.BootFile
+	BootChainErr          error
+
+	RecoveryBootChainCalls []string
+	BootChainRunBl         []bootloader.Bootloader
+	BootChainKernelPath    []string
 }
 
 func (b *MockBootloader) WithTrustedAssets() *MockTrustedAssetsBootloader {
@@ -462,12 +464,13 @@ func (b *MockTrustedAssetsBootloader) TrustedAssets() ([]string, error) {
 }
 
 func (b *MockTrustedAssetsBootloader) RecoveryBootChain(kernelPath string) ([]bootloader.BootFile, error) {
-	b.RecoveryBootChainCalls++
+	b.RecoveryBootChainCalls = append(b.RecoveryBootChainCalls, kernelPath)
 	return b.RecoveryBootChainList, b.RecoveryBootChainErr
 }
 
 func (b *MockTrustedAssetsBootloader) BootChain(runBl bootloader.Bootloader, kernelPath string) ([]bootloader.BootFile, error) {
-	b.BootChainCalls++
+	b.BootChainRunBl = append(b.BootChainRunBl, runBl)
+	b.BootChainKernelPath = append(b.BootChainKernelPath, kernelPath)
 	return b.BootChainList, b.BootChainErr
 }
 

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -464,14 +464,14 @@ func staticCommandLineForGrubAssetEdition(asset string, edition uint) string {
 }
 
 var (
-	recoveryModeTrustedAssets = []string{
+	grubRecoveryModeTrustedAssets = []string{
 		// recovery mode shim EFI binary
 		"EFI/boot/bootx64.efi",
 		// recovery mode grub EFI binary
 		"EFI/boot/grubx64.efi",
 	}
 
-	runModeTrustedAssets = []string{
+	grubRunModeTrustedAssets = []string{
 		// run mode grub EFI binary
 		"EFI/boot/grubx64.efi",
 	}
@@ -485,9 +485,9 @@ func (g *grub) TrustedAssets() ([]string, error) {
 		return nil, fmt.Errorf("internal error: trusted assets called without native host-partition layout")
 	}
 	if g.recovery {
-		return recoveryModeTrustedAssets, nil
+		return grubRecoveryModeTrustedAssets, nil
 	}
-	return runModeTrustedAssets, nil
+	return grubRunModeTrustedAssets, nil
 }
 
 // RecoveryBootChain returns the load chain for recovery modes.
@@ -498,8 +498,8 @@ func (g *grub) RecoveryBootChain(kernelPath string) ([]BootFile, error) {
 	}
 
 	// add trusted assets to the recovery chain
-	chain := make([]BootFile, 0, len(recoveryModeTrustedAssets)+1)
-	for _, ta := range recoveryModeTrustedAssets {
+	chain := make([]BootFile, 0, len(grubRecoveryModeTrustedAssets)+1)
+	for _, ta := range grubRecoveryModeTrustedAssets {
 		chain = append(chain, NewBootFile("", ta, RoleRecovery))
 	}
 	// add recovery kernel to the recovery chain
@@ -520,11 +520,11 @@ func (g *grub) BootChain(runBl Bootloader, kernelPath string) ([]BootFile, error
 	}
 
 	// add trusted assets to the recovery chain
-	chain := make([]BootFile, 0, len(recoveryModeTrustedAssets)+len(runModeTrustedAssets)+1)
-	for _, ta := range recoveryModeTrustedAssets {
+	chain := make([]BootFile, 0, len(grubRecoveryModeTrustedAssets)+len(grubRunModeTrustedAssets)+1)
+	for _, ta := range grubRecoveryModeTrustedAssets {
 		chain = append(chain, NewBootFile("", ta, RoleRecovery))
 	}
-	for _, ta := range runModeTrustedAssets {
+	for _, ta := range grubRunModeTrustedAssets {
 		chain = append(chain, NewBootFile("", ta, RoleRunMode))
 	}
 	// add kernel to the boot chain

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -497,14 +497,9 @@ func (g *grub) RecoveryBootChain(kernelPath string) ([]BootFile, error) {
 		return nil, fmt.Errorf("not a recovery bootloader")
 	}
 
-	trustedAssets, err := g.TrustedAssets()
-	if err != nil {
-		return nil, err
-	}
-
 	// add trusted assets to the recovery chain
-	chain := make([]BootFile, 0, len(trustedAssets)+1)
-	for _, ta := range trustedAssets {
+	chain := make([]BootFile, 0, len(recoveryModeTrustedAssets)+1)
+	for _, ta := range recoveryModeTrustedAssets {
 		chain = append(chain, NewBootFile("", ta, RoleRecovery))
 	}
 	// add recovery kernel to the recovery chain
@@ -524,14 +519,9 @@ func (g *grub) BootChain(runBl Bootloader, kernelPath string) ([]BootFile, error
 		return nil, fmt.Errorf("run mode bootloader must be grub")
 	}
 
-	trustedAssets, err := g.TrustedAssets()
-	if err != nil {
-		return nil, err
-	}
-
 	// add trusted assets to the recovery chain
-	chain := make([]BootFile, 0, len(trustedAssets)+len(runModeTrustedAssets)+1)
-	for _, ta := range trustedAssets {
+	chain := make([]BootFile, 0, len(recoveryModeTrustedAssets)+len(runModeTrustedAssets)+1)
+	for _, ta := range recoveryModeTrustedAssets {
 		chain = append(chain, NewBootFile("", ta, RoleRecovery))
 	}
 	for _, ta := range runModeTrustedAssets {

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -484,9 +484,8 @@ func (g *grub) TrustedAssets() ([]string, error) {
 	}, nil
 }
 
-// RecoveryBootChain returns the chain of recovery mode boot files for the
-// specified recovery system and kernel. This function should be called
-// only for the recovery bootloader.
+// RecoveryBootChain returns the load chain for recovery modes.
+// It should be called on a RoleRecovery bootloader.
 func (g *grub) RecoveryBootChain(kernelPath string) ([]BootFile, error) {
 	if !g.recovery {
 		return nil, fmt.Errorf("not a recovery bootloader")
@@ -508,9 +507,9 @@ func (g *grub) RecoveryBootChain(kernelPath string) ([]BootFile, error) {
 	return chain, nil
 }
 
-// BootChain returns the chain of run mode boot files for the specified run
-// mode bootloader and kernel. This function should be called only for the
-// recovery bootloader.
+// BootChain returns the load chain for run mode.
+// It should be called on a RoleRecovery bootloader passing the
+// RoleRunMode bootloader.
 func (g *grub) BootChain(runBl TrustedAssetsBootloader, kernelPath string) ([]BootFile, error) {
 	if !g.recovery {
 		return nil, fmt.Errorf("not a recovery bootloader")

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -1052,3 +1052,62 @@ func (s *grubTestSuite) TestTrustedAssetsRoot(c *C) {
 	c.Assert(err, ErrorMatches, "internal error: trusted assets called without native hierarchy")
 	c.Check(ta, IsNil)
 }
+
+func (s *grubTestSuite) TestRecoveryBootChains(c *C) {
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	chain, err := tab.RecoveryBootChain("kernel.snap")
+	c.Assert(err, IsNil)
+	c.Assert(chain, DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/boot/bootx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRecovery},
+	})
+}
+
+func (s *grubTestSuite) TestRecoveryBootChainsNotRecoveryBootloader(c *C) {
+	s.makeFakeGrubEnv(c)
+	g := bootloader.NewGrub(s.rootdir, nil)
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	_, err := tab.RecoveryBootChain("kernel.snap")
+	c.Assert(err, ErrorMatches, "not a recovery bootloader")
+}
+
+func (s *grubTestSuite) TestBootChains(c *C) {
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRunMode})
+	tab2, ok := g2.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	chain, err := tab.BootChain(tab2, "kernel.snap")
+	c.Assert(err, IsNil)
+	c.Assert(chain, DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/boot/bootx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRunMode},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
+	})
+}
+
+func (s *grubTestSuite) TestBootChainsNotRecoveryBootloader(c *C) {
+	s.makeFakeGrubEnv(c)
+	g := bootloader.NewGrub(s.rootdir, nil)
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRunMode})
+	tab2, ok := g2.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	_, err := tab.BootChain(tab2, "kernel.snap")
+	c.Assert(err, ErrorMatches, "not a recovery bootloader")
+}

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -1084,11 +1084,9 @@ func (s *grubTestSuite) TestBootChains(c *C) {
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRunMode})
-	tab2, ok := g2.(bootloader.TrustedAssetsBootloader)
-	c.Assert(ok, Equals, true)
+	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
 
-	chain, err := tab.BootChain(tab2, "kernel.snap")
+	chain, err := tab.BootChain(g2, "kernel.snap")
 	c.Assert(err, IsNil)
 	c.Assert(chain, DeepEquals, []bootloader.BootFile{
 		{Path: "EFI/boot/bootx64.efi", Role: bootloader.RoleRecovery},
@@ -1105,9 +1103,7 @@ func (s *grubTestSuite) TestBootChainsNotRecoveryBootloader(c *C) {
 	c.Assert(ok, Equals, true)
 
 	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRunMode})
-	tab2, ok := g2.(bootloader.TrustedAssetsBootloader)
-	c.Assert(ok, Equals, true)
 
-	_, err := tab.BootChain(tab2, "kernel.snap")
+	_, err := tab.BootChain(g2, "kernel.snap")
 	c.Assert(err, ErrorMatches, "not a recovery bootloader")
 }


### PR DESCRIPTION
Add functions to get the recovery and run mode boot chains from a
trusted bootloader.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>