### PR TITLE
devicestate: add tests around logging in RequestSystemAction

### DIFF
--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -20,7 +20,9 @@
 package devicestate_test
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
@@ -50,6 +53,7 @@ type mockedSystemSeed struct {
 type deviceMgrSystemsSuite struct {
 	deviceMgrBaseSuite
 
+	mockLogger        *bytes.Buffer
 	mockedSystemSeeds []mockedSystemSeed
 }
 
@@ -195,6 +199,10 @@ func (s *deviceMgrSystemsSuite) SetUpTest(c *C) {
 	s.state.Set("seeded", true)
 
 	c.Assert(err, IsNil)
+
+	logbuf, restore := logger.MockLogger()
+	s.mockLogger = logbuf
+	s.AddCleanup(restore)
 }
 
 func (s *deviceMgrSystemsSuite) TestListNoSystems(c *C) {
@@ -322,7 +330,7 @@ func (s *deviceMgrSystemsSuite) TestBrokenSeedSystems(c *C) {
 
 func (s *deviceMgrSystemsSuite) TestRequestModeInstallHappyForAny(c *C) {
 	// no current system
-	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install"})
+	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install", Title: "Install"})
 	c.Assert(err, IsNil)
 
 	m, err := s.bootloader.GetBootVars("snapd_recovery_mode", "snapd_recovery_system")
@@ -332,6 +340,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeInstallHappyForAny(c *C) {
 		"snapd_recovery_mode":   "install",
 	})
 	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
+	c.Check(s.mockLogger.String(), Matches, `.*: restarting into system "20191119" for action "Install"\n`)
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystem(c *C) {
@@ -351,6 +360,8 @@ func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystem(c *C) {
 	sadModes := []string{"install", "recover"}
 
 	for _, mode := range append(happyModes, sadModes...) {
+		s.mockLogger.Reset()
+
 		c.Logf("checking mode: %q", mode)
 		// non run modes use modeenv
 		modeenv := boot.Modeenv{
@@ -383,6 +394,8 @@ func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystem(c *C) {
 		})
 		// should never restart
 		c.Check(s.restartRequests, HasLen, 0)
+		// no log output
+		c.Check(s.mockLogger.String(), Equals, "")
 	}
 }
 
@@ -396,6 +409,8 @@ func (s *deviceMgrSystemsSuite) TestRequestSeedingSameConflict(c *C) {
 	s.state.Unlock()
 
 	for _, mode := range []string{"run", "install", "recover"} {
+		s.mockLogger.Reset()
+
 		c.Logf("checking mode: %q", mode)
 		modeenv := boot.Modeenv{
 			Mode:           mode,
@@ -411,6 +426,8 @@ func (s *deviceMgrSystemsSuite) TestRequestSeedingSameConflict(c *C) {
 		c.Assert(err, IsNil)
 		err = s.mgr.RequestSystemAction(label, devicestate.SystemAction{Mode: mode})
 		c.Assert(err, ErrorMatches, "cannot request system action, system is seeding")
+		// no log output
+		c.Check(s.mockLogger.String(), Equals, "")
 	}
 }
 
@@ -446,13 +463,13 @@ func (s *deviceMgrSystemsSuite) TestRequestSeedingDifferentNoConflict(c *C) {
 		"snapd_recovery_system": otherLabel,
 		"snapd_recovery_mode":   "install",
 	})
+	c.Check(s.mockLogger.String(), Matches, fmt.Sprintf(`.*: restarting into system "%s" for action "Install"\n`, otherLabel))
 }
 
 func (s *deviceMgrSystemsSuite) testRequestModeWithRestart(c *C, toModes []string, label string) {
 	for _, mode := range toModes {
 		c.Logf("checking mode: %q", mode)
-		err := s.mgr.RequestSystemAction(label,
-			devicestate.SystemAction{Mode: mode})
+		err := s.mgr.RequestSystemAction(label, devicestate.SystemAction{Mode: mode})
 		c.Assert(err, IsNil)
 		m, err := s.bootloader.GetBootVars("snapd_recovery_mode", "snapd_recovery_system")
 		c.Assert(err, IsNil)
@@ -463,6 +480,10 @@ func (s *deviceMgrSystemsSuite) testRequestModeWithRestart(c *C, toModes []strin
 		c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
 		s.restartRequests = nil
 		s.bootloader.BootVars = map[string]string{}
+
+		// TODO: also test correct action string logging
+		c.Check(s.mockLogger.String(), Matches, fmt.Sprintf(`.*: restarting into system "%s" for action ".*"\n`, label))
+		s.mockLogger.Reset()
 	}
 }
 
@@ -517,6 +538,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeErrInBoot(c *C) {
 	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, `cannot set device to boot into system "20191119" in mode "install": no can do`)
 	c.Check(s.restartRequests, HasLen, 0)
+	c.Check(s.mockLogger.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeNotFound(c *C) {
@@ -524,12 +546,14 @@ func (s *deviceMgrSystemsSuite) TestRequestModeNotFound(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(os.IsNotExist(err), Equals, true)
 	c.Check(s.restartRequests, HasLen, 0)
+	c.Check(s.mockLogger.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeBadMode(c *C) {
 	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "unknown-mode"})
 	c.Assert(err, Equals, devicestate.ErrUnsupportedAction)
 	c.Check(s.restartRequests, HasLen, 0)
+	c.Check(s.mockLogger.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeBroken(c *C) {
@@ -540,6 +564,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeBroken(c *C) {
 	err = s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, "cannot load seed system: cannot load assertions: .*")
 	c.Check(s.restartRequests, HasLen, 0)
+	c.Check(s.mockLogger.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeNonUC20(c *C) {
@@ -547,11 +572,13 @@ func (s *deviceMgrSystemsSuite) TestRequestModeNonUC20(c *C) {
 	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, `cannot set device to boot into system "20191119" in mode "install": system mode is unsupported`)
 	c.Check(s.restartRequests, HasLen, 0)
+	c.Check(s.mockLogger.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestActionNoLabel(c *C) {
 	err := s.mgr.RequestSystemAction("", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, "internal error: system label is unset")
+	c.Check(s.mockLogger.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeForNonCurrent(c *C) {
@@ -572,6 +599,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeForNonCurrent(c *C) {
 	err = s.mgr.RequestSystemAction(s.mockedSystemSeeds[1].label, devicestate.SystemAction{Mode: "recover"})
 	c.Assert(err, Equals, devicestate.ErrUnsupportedAction)
 	c.Check(s.restartRequests, HasLen, 0)
+	c.Check(s.mockLogger.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestInstallForOther(c *C) {
@@ -630,4 +658,5 @@ func (s *deviceMgrSystemsSuite) TestRequestAction1618(c *C) {
 
 	err = s.mgr.RequestSystemAction(s.mockedSystemSeeds[0].label, devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, ".*/seed/systems/20191119: no such file or directory")
+	c.Check(s.mockLogger.String(), Equals, "")
 }

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -53,7 +53,7 @@ type mockedSystemSeed struct {
 type deviceMgrSystemsSuite struct {
 	deviceMgrBaseSuite
 
-	mockLogger        *bytes.Buffer
+	logbuf            *bytes.Buffer
 	mockedSystemSeeds []mockedSystemSeed
 }
 
@@ -201,7 +201,7 @@ func (s *deviceMgrSystemsSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
-	s.mockLogger = logbuf
+	s.logbuf = logbuf
 	s.AddCleanup(restore)
 }
 
@@ -340,7 +340,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeInstallHappyForAny(c *C) {
 		"snapd_recovery_mode":   "install",
 	})
 	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
-	c.Check(s.mockLogger.String(), Matches, `.*: restarting into system "20191119" for action "Install"\n`)
+	c.Check(s.logbuf.String(), Matches, `.*: restarting into system "20191119" for action "Install"\n`)
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystem(c *C) {
@@ -360,7 +360,7 @@ func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystem(c *C) {
 	sadModes := []string{"install", "recover"}
 
 	for _, mode := range append(happyModes, sadModes...) {
-		s.mockLogger.Reset()
+		s.logbuf.Reset()
 
 		c.Logf("checking mode: %q", mode)
 		// non run modes use modeenv
@@ -395,7 +395,7 @@ func (s *deviceMgrSystemsSuite) TestRequestSameModeSameSystem(c *C) {
 		// should never restart
 		c.Check(s.restartRequests, HasLen, 0)
 		// no log output
-		c.Check(s.mockLogger.String(), Equals, "")
+		c.Check(s.logbuf.String(), Equals, "")
 	}
 }
 
@@ -409,7 +409,7 @@ func (s *deviceMgrSystemsSuite) TestRequestSeedingSameConflict(c *C) {
 	s.state.Unlock()
 
 	for _, mode := range []string{"run", "install", "recover"} {
-		s.mockLogger.Reset()
+		s.logbuf.Reset()
 
 		c.Logf("checking mode: %q", mode)
 		modeenv := boot.Modeenv{
@@ -427,7 +427,7 @@ func (s *deviceMgrSystemsSuite) TestRequestSeedingSameConflict(c *C) {
 		err = s.mgr.RequestSystemAction(label, devicestate.SystemAction{Mode: mode})
 		c.Assert(err, ErrorMatches, "cannot request system action, system is seeding")
 		// no log output
-		c.Check(s.mockLogger.String(), Equals, "")
+		c.Check(s.logbuf.String(), Equals, "")
 	}
 }
 
@@ -463,7 +463,7 @@ func (s *deviceMgrSystemsSuite) TestRequestSeedingDifferentNoConflict(c *C) {
 		"snapd_recovery_system": otherLabel,
 		"snapd_recovery_mode":   "install",
 	})
-	c.Check(s.mockLogger.String(), Matches, fmt.Sprintf(`.*: restarting into system "%s" for action "Install"\n`, otherLabel))
+	c.Check(s.logbuf.String(), Matches, fmt.Sprintf(`.*: restarting into system "%s" for action "Install"\n`, otherLabel))
 }
 
 func (s *deviceMgrSystemsSuite) testRequestModeWithRestart(c *C, toModes []string, label string) {
@@ -482,8 +482,8 @@ func (s *deviceMgrSystemsSuite) testRequestModeWithRestart(c *C, toModes []strin
 		s.bootloader.BootVars = map[string]string{}
 
 		// TODO: also test correct action string logging
-		c.Check(s.mockLogger.String(), Matches, fmt.Sprintf(`.*: restarting into system "%s" for action ".*"\n`, label))
-		s.mockLogger.Reset()
+		c.Check(s.logbuf.String(), Matches, fmt.Sprintf(`.*: restarting into system "%s" for action ".*"\n`, label))
+		s.logbuf.Reset()
 	}
 }
 
@@ -538,7 +538,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeErrInBoot(c *C) {
 	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, `cannot set device to boot into system "20191119" in mode "install": no can do`)
 	c.Check(s.restartRequests, HasLen, 0)
-	c.Check(s.mockLogger.String(), Equals, "")
+	c.Check(s.logbuf.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeNotFound(c *C) {
@@ -546,14 +546,14 @@ func (s *deviceMgrSystemsSuite) TestRequestModeNotFound(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(os.IsNotExist(err), Equals, true)
 	c.Check(s.restartRequests, HasLen, 0)
-	c.Check(s.mockLogger.String(), Equals, "")
+	c.Check(s.logbuf.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeBadMode(c *C) {
 	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "unknown-mode"})
 	c.Assert(err, Equals, devicestate.ErrUnsupportedAction)
 	c.Check(s.restartRequests, HasLen, 0)
-	c.Check(s.mockLogger.String(), Equals, "")
+	c.Check(s.logbuf.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeBroken(c *C) {
@@ -564,7 +564,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeBroken(c *C) {
 	err = s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, "cannot load seed system: cannot load assertions: .*")
 	c.Check(s.restartRequests, HasLen, 0)
-	c.Check(s.mockLogger.String(), Equals, "")
+	c.Check(s.logbuf.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeNonUC20(c *C) {
@@ -572,13 +572,13 @@ func (s *deviceMgrSystemsSuite) TestRequestModeNonUC20(c *C) {
 	err := s.mgr.RequestSystemAction("20191119", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, `cannot set device to boot into system "20191119" in mode "install": system mode is unsupported`)
 	c.Check(s.restartRequests, HasLen, 0)
-	c.Check(s.mockLogger.String(), Equals, "")
+	c.Check(s.logbuf.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestActionNoLabel(c *C) {
 	err := s.mgr.RequestSystemAction("", devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, "internal error: system label is unset")
-	c.Check(s.mockLogger.String(), Equals, "")
+	c.Check(s.logbuf.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestModeForNonCurrent(c *C) {
@@ -599,7 +599,7 @@ func (s *deviceMgrSystemsSuite) TestRequestModeForNonCurrent(c *C) {
 	err = s.mgr.RequestSystemAction(s.mockedSystemSeeds[1].label, devicestate.SystemAction{Mode: "recover"})
 	c.Assert(err, Equals, devicestate.ErrUnsupportedAction)
 	c.Check(s.restartRequests, HasLen, 0)
-	c.Check(s.mockLogger.String(), Equals, "")
+	c.Check(s.logbuf.String(), Equals, "")
 }
 
 func (s *deviceMgrSystemsSuite) TestRequestInstallForOther(c *C) {
@@ -658,5 +658,5 @@ func (s *deviceMgrSystemsSuite) TestRequestAction1618(c *C) {
 
 	err = s.mgr.RequestSystemAction(s.mockedSystemSeeds[0].label, devicestate.SystemAction{Mode: "install"})
 	c.Assert(err, ErrorMatches, ".*/seed/systems/20191119: no such file or directory")
-	c.Check(s.mockLogger.String(), Equals, "")
+	c.Check(s.logbuf.String(), Equals, "")
 }


### PR DESCRIPTION
The logging is current untested in RequestSystemAction but this
code will be refactored in PR #9210 so better coverage for this
to avoid regressions is desired.
