### PR TITLE
many: introduce ContentChange for tracking gadget content in observers

### DIFF
--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -434,8 +434,9 @@ version: 5.0
 		},
 	}
 	// only grubx64.efi gets installed to system-boot
-	_, err = obs.Observe(gadget.ContentWrite, runBootStruct, boot.InitramfsUbuntuBootDir,
-		filepath.Join(unpackedGadgetDir, "grubx64.efi"), "EFI/boot/grubx64.efi")
+	_, err = obs.Observe(gadget.ContentWrite, runBootStruct, boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi",
+		&gadget.ContentChange{After: filepath.Join(unpackedGadgetDir, "grubx64.efi")})
+
 	c.Assert(err, IsNil)
 	// observe recovery assets
 	err = obs.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir)

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -57,7 +57,7 @@ func checkContent(content *VolumeContent) error {
 	return nil
 }
 
-func observe(observer ContentObserver, op ContentOperation, ps *LaidOutStructure, root, src, dst string) error {
+func observe(observer ContentObserver, op ContentOperation, ps *LaidOutStructure, root, dst string, data *ContentChange) error {
 	if observer == nil {
 		return nil
 	}
@@ -70,7 +70,7 @@ func observe(observer ContentObserver, op ContentOperation, ps *LaidOutStructure
 		}
 		relativeTarget = relative
 	}
-	_, err := observer.Observe(op, ps, root, src, relativeTarget)
+	_, err := observer.Observe(op, ps, root, relativeTarget, data)
 	return err
 }
 
@@ -191,7 +191,13 @@ func (m *MountedFilesystemWriter) observedWriteFileOrSymlink(volumeRoot, src, ds
 		dst = filepath.Join(dst, filepath.Base(src))
 	}
 
-	if err := observe(m.observer, ContentWrite, m.ps, volumeRoot, src, dst); err != nil {
+	data := &ContentChange{
+		// we are writing a new thing
+		Before: "",
+		// with content in this file
+		After: src,
+	}
+	if err := observe(m.observer, ContentWrite, m.ps, volumeRoot, dst, data); err != nil {
 		return fmt.Errorf("cannot observe file write: %v", err)
 	}
 	return writeFileOrSymlink(src, dst, preserveInDst)
@@ -672,21 +678,28 @@ func (f *mountedFilesystemUpdater) checkpointPrefix(dstRoot, target string, back
 }
 
 func (f *mountedFilesystemUpdater) observedBackupOrCheckpointFile(dstRoot, source, target string, preserveInDst []string, backupDir string) error {
-	willBeWritten, err := f.backupOrCheckpointFile(dstRoot, source, target, preserveInDst, backupDir)
+	willBeWritten, originalDataPath, err := f.backupOrCheckpointFile(dstRoot, source, target, preserveInDst, backupDir)
 	if err != nil {
 		return err
 	}
 	if willBeWritten {
 		srcPath := f.entrySourcePath(source)
 		dstPath, _ := f.entryDestPaths(dstRoot, source, target, backupDir)
-		if err := observe(f.updateObserver, ContentUpdate, f.ps, f.mountPoint, srcPath, dstPath); err != nil {
+		data := &ContentChange{
+			// content of the new data
+			After: srcPath,
+			// this is the original data that was present before the
+			// update or "" if the file did not exist
+			Before: originalDataPath,
+		}
+		if err := observe(f.updateObserver, ContentUpdate, f.ps, f.mountPoint, dstPath, data); err != nil {
 			return fmt.Errorf("cannot observe pending file write %v\n", err)
 		}
 	}
 	return nil
 }
 
-func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, target string, preserveInDst []string, backupDir string) (willWrite bool, err error) {
+func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, target string, preserveInDst []string, backupDir string) (willWrite bool, originalDataPath string, err error) {
 	srcPath := f.entrySourcePath(source)
 	dstPath, backupPath := f.entryDestPaths(dstRoot, source, target, backupDir)
 
@@ -696,39 +709,39 @@ func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, targe
 
 	// TODO: enable support for symlinks when needed
 	if osutil.IsSymlink(dstPath) {
-		return false, fmt.Errorf("cannot backup file %s: symbolic links are not supported", target)
+		return false, "", fmt.Errorf("cannot backup file %s: symbolic links are not supported", target)
 	}
 
 	if !osutil.FileExists(dstPath) {
 		// destination does not exist and will be created when writing
 		// the udpate, no need for backup
-		return true, nil
+		return true, "", nil
 	}
 
 	if osutil.FileExists(backupName) {
 		// file already checked and backed up
-		return true, nil
+		return true, backupName, nil
 	}
 	if osutil.FileExists(sameStamp) {
 		// file already checked, same as the update, move on
-		return false, nil
+		return false, dstPath, nil
 	}
 
 	if strutil.SortedListContains(preserveInDst, dstPath) {
 		// file is to be preserved, create a relevant stamp
 		if !osutil.FileExists(dstPath) {
 			// preserve, but does not exist, will be written anyway
-			return true, nil
+			return true, "", nil
 		}
 		if osutil.FileExists(preserveStamp) {
 			// already stamped
-			return false, nil
+			return false, dstPath, nil
 		}
 		// make a stamp
 		if err := makeStamp(preserveStamp); err != nil {
-			return false, fmt.Errorf("cannot create preserve stamp: %v", err)
+			return false, "", fmt.Errorf("cannot create preserve stamp: %v", err)
 		}
-		return false, nil
+		return false, dstPath, nil
 	}
 
 	// try to find out whether the update and the existing file are
@@ -736,13 +749,13 @@ func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, targe
 
 	orig, err := os.Open(dstPath)
 	if err != nil {
-		return false, fmt.Errorf("cannot open destination file: %v", err)
+		return false, "", fmt.Errorf("cannot open destination file: %v", err)
 	}
 
 	// backup of the original content
 	backup, err := newStampFile(backupName)
 	if err != nil {
-		return false, fmt.Errorf("cannot create backup file: %v", err)
+		return false, "", fmt.Errorf("cannot create backup file: %v", err)
 	}
 	// becomes a backup copy or a noop if canceled
 	defer backup.Commit()
@@ -754,14 +767,14 @@ func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, targe
 	_, err = io.Copy(backup, htr)
 	if err != nil {
 		backup.Cancel()
-		return false, fmt.Errorf("cannot backup original file: %v", err)
+		return false, "", fmt.Errorf("cannot backup original file: %v", err)
 	}
 
 	// digest of the update
 	updateDigest, _, err := osutil.FileDigest(srcPath, crypto.SHA1)
 	if err != nil {
 		backup.Cancel()
-		return false, fmt.Errorf("cannot checksum update file: %v", err)
+		return false, "", fmt.Errorf("cannot checksum update file: %v", err)
 	}
 	// digest of the currently present data
 	origDigest := origHash.Sum(nil)
@@ -771,17 +784,17 @@ func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, targe
 		// mark that files are identical and update can be skipped, no
 		// backup is needed
 		if err := makeStamp(sameStamp); err != nil {
-			return false, fmt.Errorf("cannot create a checkpoint file: %v", err)
+			return false, "", fmt.Errorf("cannot create a checkpoint file: %v", err)
 		}
 
 		// makes the deferred commit a noop
 		backup.Cancel()
-		return false, nil
+		return false, dstPath, nil
 	}
 
 	// update will overwrite existing file, a backup copy is created on
 	// Commit()
-	return true, nil
+	return true, backupName, nil
 }
 
 func (f *mountedFilesystemUpdater) backupVolumeContent(volumeRoot string, content *VolumeContent, preserveInDst []string, backupDir string) error {
@@ -869,6 +882,7 @@ func (f *mountedFilesystemUpdater) rollbackDirectory(dstRoot, source, target str
 }
 
 func (f *mountedFilesystemUpdater) rollbackFile(dstRoot, source, target string, preserveInDst []string, backupDir string) error {
+	srcPath := f.entrySourcePath(source)
 	dstPath, backupPath := f.entryDestPaths(dstRoot, source, target, backupDir)
 
 	backupName := backupPath + ".backup"
@@ -884,6 +898,12 @@ func (f *mountedFilesystemUpdater) rollbackFile(dstRoot, source, target string, 
 		return nil
 	}
 
+	data := &ContentChange{
+		After: srcPath,
+		// original content was in the backup file
+		Before: backupName,
+	}
+
 	if osutil.FileExists(backupName) {
 		// restore backup -> destination
 		if err := writeFileOrSymlink(backupName, dstPath, nil); err != nil {
@@ -895,10 +915,12 @@ func (f *mountedFilesystemUpdater) rollbackFile(dstRoot, source, target string, 
 		if err := os.Remove(dstPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("cannot remove written update: %v", err)
 		}
+		// since it's a new file, there was no original content
+		data.Before = ""
 	}
 	// avoid passing source path during rollback, the file has been restored
 	// to the disk already
-	if err := observe(f.updateObserver, ContentRollback, f.ps, f.mountPoint, "", dstPath); err != nil {
+	if err := observe(f.updateObserver, ContentRollback, f.ps, f.mountPoint, dstPath, data); err != nil {
 		return fmt.Errorf("cannot observe pending file rollback %v\n", err)
 	}
 

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -733,6 +733,8 @@ func (f *mountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, targe
 		// file already checked, same as the update, move on
 		return false, "", nil
 	}
+	// TODO: correctly identify new files that were written by a partially
+	// executed update pass
 
 	if strutil.SortedListContains(preserveInDst, dstPath) {
 		// file is to be preserved, create a relevant stamp

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -50,6 +50,16 @@ type GadgetData struct {
 // and returns true when the pair should be part of an update.
 type UpdatePolicyFunc func(from, to *LaidOutStructure) bool
 
+// ContentChange carries paths to files containing the content data being
+// modified by the operation.
+type ContentChange struct {
+	// Before is a path to a file containing the original data before the
+	// operation takes place (or took place in case of ContentRollback).
+	Before string
+	// After is a path to a file location of the data applied by the operation.
+	After string
+}
+
 type ContentOperation int
 
 const (
@@ -73,7 +83,7 @@ type ContentObserver interface {
 	// happens after the original file has been restored (or removed if the
 	// file was added during the update), the source path is empty.
 	Observe(op ContentOperation, sourceStruct *LaidOutStructure,
-		targetRootDir, sourcePath, relativeTargetPath string) (bool, error)
+		targetRootDir, relativeTargetPath string, dataChange *ContentChange) (bool, error)
 }
 
 // ContentUpdateObserver allows for observing update (and potentially a

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -711,7 +711,7 @@ type mockUpdateProcessObserver struct {
 }
 
 func (m *mockUpdateProcessObserver) Observe(op gadget.ContentOperation, sourceStruct *gadget.LaidOutStructure,
-	targetRootDir, sourcePath, relativeTargetPath string) (bool, error) {
+	targetRootDir, relativeTargetPath string, data *gadget.ContentChange) (bool, error) {
 	return false, errors.New("unexpected call")
 }
 


### PR DESCRIPTION
Introduce a new type that is passed to gaddget.ContentObserver.Observe() and provides access to data of an asset being updated/rolled back.

This is stacked on top of #9246, the relevant commit is: https://github.com/snapcore/snapd/commit/9a1cf529a05aba9b46e4d8ea2104d968456247c4
