### PR TITLE
tests/lib/nested.sh: reset the TPM when we create the uc20 vm

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -630,7 +630,11 @@ start_nested_core_vm_unit(){
         fi
 
         if [ "$ENABLE_TPM" = "true" ]; then
-            if ! snap list swtpm-mvo; then
+            if snap list swtpm-mvo; then
+                # reset the tpm state
+                rm /var/snap/swtpm-mvo/current/tpm2-00.permall
+                snap restart swtpm-mvo
+            else
                 snap install swtpm-mvo --beta
             fi
             PARAM_TPM="-chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"


### PR DESCRIPTION
This is necessary because new VM's require clean TPM state.

Some of the nested tests fail sometimes with logs like 

```
Aug 26 17:46:06 ubuntu snapd[1116]: secboot_tpm.go:416: TPM provisioning error: cannot access resource at handle TPM_RH_LOCKOUT because an authorization check failed
Aug 26 17:46:06 ubuntu snapd[1116]: taskrunner.go:271: [change 2 "Setup system for run mode" task] failed: cannot create partitions: cannot seal the encryption key: cannot provision TPM: cannot access resource at handle TPM_RH_LOCKOUT because an authorization check failed
```

this should fix those errors.