### PR TITLE
many: fix partion vs partition typo

### DIFF
--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -49,7 +49,7 @@ type grub struct {
 
 	uefiRunKernelExtraction bool
 	recovery                bool
-	nativePartionLayout     bool
+	nativePartitionLayout   bool
 }
 
 // newGrub create a new Grub bootloader object
@@ -62,9 +62,9 @@ func newGrub(rootdir string, opts *Options) Bootloader {
 		// the kernel directly from snaps.
 		g.uefiRunKernelExtraction = opts.Role == RoleRunMode
 		g.recovery = opts.Role == RoleRecovery
-		g.nativePartionLayout = opts.NoSlashBoot || g.recovery
+		g.nativePartitionLayout = opts.NoSlashBoot || g.recovery
 	}
-	if g.nativePartionLayout {
+	if g.nativePartitionLayout {
 		g.basedir = "EFI/ubuntu"
 	} else {
 		g.basedir = "boot/grub"
@@ -467,7 +467,7 @@ func staticCommandLineForGrubAssetEdition(asset string, edition uint) string {
 // the bootloader's rootdir that are measured in the boot process in the
 // order of loading during the boot.
 func (g *grub) TrustedAssets() ([]string, error) {
-	if !g.nativePartionLayout {
+	if !g.nativePartitionLayout {
 		return nil, fmt.Errorf("internal error: trusted assets called without native host-partition layout")
 	}
 	if g.recovery {

--- a/bootloader/lk_test.go
+++ b/bootloader/lk_test.go
@@ -222,7 +222,7 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksAndRemoveInRuntimeMode(c *C)
 	// now remove the kernel
 	err = lk.RemoveKernelAssets(info)
 	c.Assert(err, IsNil)
-	// and ensure its no longer available in the boot partions
+	// and ensure its no longer available in the boot partitions
 	err = lkenv.Load()
 	c.Assert(err, IsNil)
 	bootPart, err = lkenv.GetBootPartition("ubuntu-kernel_42.snap")

--- a/bootloader/lkenv/lkenv.go
+++ b/bootloader/lkenv/lkenv.go
@@ -93,7 +93,7 @@ type SnapBootSelect_v1 struct {
 	Reboot_reason [SNAP_NAME_MAX_LEN]byte
 
 	/**
-	 * Matrix for mapping of boot img partion to installed kernel snap revision
+	 * Matrix for mapping of boot img partition to installed kernel snap revision
 	 *
 	 * First column represents boot image partition label (e.g. boot_a,boot_b )
 	 *   value are static and should be populated at gadget built time
@@ -134,7 +134,7 @@ type SnapBootSelect_v1 struct {
 	Bootimg_file_name [SNAP_NAME_MAX_LEN]byte
 
 	/**
-	 * gadget assets: Matrix for mapping of gadget asset partions
+	 * gadget assets: Matrix for mapping of gadget asset partitions
 	 * Optional boot asset tracking, based on bootloader support
 	 * Some boot chains support A/B boot assets for increased robustness
 	 * example being A/B TrustExecutionEnvironment

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -414,7 +414,7 @@ recovery_system=20191118
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
-	restore := disks.MockMountPointDisksToPartionMapping(
+	restore := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultBootDisk,
 			{Mountpoint: boot.InitramfsDataDir}:       defaultBootDisk,
@@ -647,7 +647,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyRealSystemdMou
 	kernelMnt := filepath.Join(boot.InitramfsRunMntDir, "kernel")
 	snapdMnt := filepath.Join(boot.InitramfsRunMntDir, "snapd")
 
-	restore := disks.MockMountPointDisksToPartionMapping(
+	restore := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuSeedDir}:     defaultBootDisk,
 			{Mountpoint: boot.InitramfsHostUbuntuDataDir}: defaultBootDisk,
@@ -801,7 +801,7 @@ After=%[1]s
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeHappyRealSystemdMount(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
-	restore := disks.MockMountPointDisksToPartionMapping(
+	restore := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultBootDisk,
 			{Mountpoint: boot.InitramfsDataDir}:       defaultBootDisk,
@@ -945,7 +945,7 @@ After=%[1]s
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeFirstBootRecoverySystemSetHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
-	restore := disks.MockMountPointDisksToPartionMapping(
+	restore := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultBootDisk,
 			{Mountpoint: boot.InitramfsDataDir}:       defaultBootDisk,
@@ -995,7 +995,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeWithBootedKernelPartUUI
 	restore := main.MockPartitionUUIDForBootedKernelDisk("ubuntu-boot-partuuid")
 	defer restore()
 
-	restore = disks.MockMountPointDisksToPartionMapping(
+	restore = disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultBootDisk,
 			{Mountpoint: boot.InitramfsDataDir}:       defaultBootDisk,
@@ -1043,7 +1043,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeWithBootedKernelPartUUI
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
-	restore := disks.MockMountPointDisksToPartionMapping(
+	restore := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuBootDir}:                    defaultEncBootDisk,
 			{Mountpoint: boot.InitramfsDataDir, IsDecryptedDevice: true}: defaultEncBootDisk,
@@ -1158,7 +1158,7 @@ func (s *initramfsMountsSuite) testInitramfsMountsEncryptedNoModel(c *C, mode, l
 			ubuntuLabelMount("ubuntu-boot", mode),
 			ubuntuPartUUIDMount("ubuntu-seed-partuuid", mode),
 		}, nil)
-		restore2 := disks.MockMountPointDisksToPartionMapping(
+		restore2 := disks.MockMountPointDisksToPartitionMapping(
 			map[disks.Mountpoint]*disks.MockDiskMapping{
 				{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultEncBootDisk,
 			},
@@ -1457,7 +1457,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 		cleanups = append(cleanups, func() { dirs.SetRootDir(dirs.GlobalRootDir) })
 		dirs.SetRootDir(rootDir)
 
-		restore := disks.MockMountPointDisksToPartionMapping(
+		restore := disks.MockMountPointDisksToPartitionMapping(
 			map[disks.Mountpoint]*disks.MockDiskMapping{
 				{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultBootDisk,
 				{Mountpoint: boot.InitramfsDataDir}:       defaultBootDisk,
@@ -1638,7 +1638,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappy(c *C) {
 	restore := main.MockPartitionUUIDForBootedKernelDisk("")
 	defer restore()
 
-	restore = disks.MockMountPointDisksToPartionMapping(
+	restore = disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuSeedDir}:     defaultBootDisk,
 			{Mountpoint: boot.InitramfsHostUbuntuDataDir}: defaultBootDisk,
@@ -1678,7 +1678,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyBootedKernelPa
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
 
-	restore = disks.MockMountPointDisksToPartionMapping(
+	restore = disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuSeedDir}:     defaultBootDisk,
 			{Mountpoint: boot.InitramfsHostUbuntuDataDir}: defaultBootDisk,
@@ -1722,7 +1722,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
 
-	restore = disks.MockMountPointDisksToPartionMapping(
+	restore = disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuSeedDir}: defaultEncBootDisk,
 			{
@@ -1815,7 +1815,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 		DevNum:            "bootDev",
 	}
 
-	restore = disks.MockMountPointDisksToPartionMapping(
+	restore = disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuSeedDir}: mockDisk,
 			{
@@ -1943,7 +1943,7 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallRecoverModeMeasure(c *C
 		mockDiskMapping[disks.Mountpoint{Mountpoint: boot.InitramfsHostUbuntuDataDir}] = disk
 	}
 
-	restore := disks.MockMountPointDisksToPartionMapping(mockDiskMapping)
+	restore := disks.MockMountPointDisksToPartitionMapping(mockDiskMapping)
 	defer restore()
 
 	measureEpochCalls := 0

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -173,7 +173,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 			// Classic, PrepareDir is the root dir itself
 			rootDir = opts.PrepareDir
 		} else {
-			// Core 16/18,  writing for the writeable partion
+			// Core 16/18,  writing for the writeable partition
 			rootDir = filepath.Join(opts.PrepareDir, "image")
 			bootRootDir = rootDir
 		}

--- a/include/lk/snappy_boot_v1.h
+++ b/include/lk/snappy_boot_v1.h
@@ -65,7 +65,7 @@ typedef struct SNAP_BOOT_SELECTION {
     char reboot_reason[SNAP_NAME_MAX_LEN];
 
     /**
-     * Matrix for mapping of boot img partion to installed kernel snap revision
+     * Matrix for mapping of boot img partition to installed kernel snap revision
      *
      * First column represents boot image partition label (e.g. boot_a,boot_b )
      *   value are static and should be populated at gadget built time
@@ -104,7 +104,7 @@ typedef struct SNAP_BOOT_SELECTION {
     char bootimg_file_name[SNAP_NAME_MAX_LEN];
 
     /**
-     * gadget assets: Matrix for mapping of gadget asset partions
+     * gadget assets: Matrix for mapping of gadget asset partitions
      * Optional boot asset tracking, based on bootloader support
      * Some boot chains support A/B boot assets for increased robustness
      * example being A/B TrustExecutionEnvironment

--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -50,7 +50,7 @@ var (
 )
 
 // diskFromMountPoint is exposed for mocking from other tests via
-// MockMountPointDisksToPartionMapping, but we can't just assign
+// MockMountPointDisksToPartitionMapping, but we can't just assign
 // diskFromMountPointImpl to diskFromMountPoint due to signature differences,
 // the former returns a *disk, the latter returns a Disk, and as such they can't
 // be assigned to each other

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -82,18 +82,18 @@ func (d *MockDiskMapping) Dev() string {
 // Mountpoint is a combination of a mountpoint location and whether that
 // mountpoint is a decrypted device. It is only used in identifying mount points
 // with MountPointIsFromDisk and DiskFromMountPoint with
-// MockMountPointDisksToPartionMapping.
+// MockMountPointDisksToPartitionMapping.
 type Mountpoint struct {
 	Mountpoint        string
 	IsDecryptedDevice bool
 }
 
-// MockMountPointDisksToPartionMapping will mock DiskFromMountPoint such that
+// MockMountPointDisksToPartitionMapping will mock DiskFromMountPoint such that
 // the specified mapping is returned/used. Specifically, keys in the provided
 // map are mountpoints, and the values for those keys are the disks that will
 // be returned from DiskFromMountPoint or used internally in
 // MountPointIsFromDisk.
-func MockMountPointDisksToPartionMapping(mockedMountPoints map[Mountpoint]*MockDiskMapping) (restore func()) {
+func MockMountPointDisksToPartitionMapping(mockedMountPoints map[Mountpoint]*MockDiskMapping) (restore func()) {
 	osutil.MustBeTestBinary("mock disks only to be used in tests")
 
 	// verify that all unique MockDiskMapping's have unique DevNum's

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -39,7 +39,7 @@ func (s *mockDiskSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 }
 
-func (s *mockDiskSuite) TestMockMountPointDisksToPartionMappingVerifiesUniqueness(c *C) {
+func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMappingVerifiesUniqueness(c *C) {
 	// two different disks with different DevNum's
 	d1 := &disks.MockDiskMapping{
 		FilesystemLabelToPartUUID: map[string]string{
@@ -68,13 +68,13 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMappingVerifiesUniquenes
 	}
 
 	// mocking works
-	r := disks.MockMountPointDisksToPartionMapping(m)
+	r := disks.MockMountPointDisksToPartitionMapping(m)
 	defer r()
 
 	// changing so they have the same DevNum doesn't work though
 	d2.DevNum = "d1"
 	c.Assert(
-		func() { disks.MockMountPointDisksToPartionMapping(m) },
+		func() { disks.MockMountPointDisksToPartitionMapping(m) },
 		PanicMatches,
 		`mocked disks .* and .* have the same DevNum \(d1\) but are not the same object`,
 	)
@@ -84,11 +84,11 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMappingVerifiesUniquenes
 		{Mountpoint: "mount1"}: d1,
 		{Mountpoint: "mount2"}: d1,
 	}
-	r = disks.MockMountPointDisksToPartionMapping(m2)
+	r = disks.MockMountPointDisksToPartitionMapping(m2)
 	defer r()
 }
 
-func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
+func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	d1 := &disks.MockDiskMapping{
 		FilesystemLabelToPartUUID: map[string]string{
 			"label1": "part1",
@@ -105,7 +105,7 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
 		DevNum:            "d2",
 	}
 
-	r := disks.MockMountPointDisksToPartionMapping(
+	r := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: "mount1"}: d1,
 			{Mountpoint: "mount2"}: d1,
@@ -162,7 +162,7 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMapping(c *C) {
 	c.Assert(matches, Equals, false)
 }
 
-func (s *mockDiskSuite) TestMockMountPointDisksToPartionMappingDecryptedDevices(c *C) {
+func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMappingDecryptedDevices(c *C) {
 	d1 := &disks.MockDiskMapping{
 		FilesystemLabelToPartUUID: map[string]string{
 			"ubuntu-seed":     "ubuntu-seed-part",
@@ -173,7 +173,7 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartionMappingDecryptedDevices(
 		DevNum:            "d1",
 	}
 
-	r := disks.MockMountPointDisksToPartionMapping(
+	r := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: "/run/mnt/ubuntu-boot"}: d1,
 			{Mountpoint: "/run/mnt/ubuntu-seed"}: d1,

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -238,7 +238,7 @@ func (s *secbootSuite) TestMeasureSnapModelWhenPossible(c *C) {
 func (s *secbootSuite) TestUnlockIfEncrypted(c *C) {
 
 	// setup mock disks to use for locating the partition
-	// restore := disks.MockMountPointDisksToPartionMapping()
+	// restore := disks.MockMountPointDisksToPartitionMapping()
 	// defer restore()
 
 	mockDiskWithEncDev := &disks.MockDiskMapping{


### PR DESCRIPTION
There are several places where "partition" is (seemingly) misspelled as "partion". Replace these with the correct word.
