### PR TITLE
boot: keep track of the original asset when observing updates 

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -425,13 +425,27 @@ func (o *TrustedAssetsUpdateObserver) Observe(op gadget.ContentOperation, affect
 	}
 }
 
-func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, recovery bool, root, relativeTarget string, data *gadget.ContentChange) (bool, error) {
+func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, recovery bool, root, relativeTarget string, change *gadget.ContentChange) (bool, error) {
 	modeenvBefore, err := o.modeenv.Copy()
 	if err != nil {
 		return false, fmt.Errorf("cannot copy modeenv: %v", err)
 	}
 
-	ta, err := o.cache.Add(data.After, bl.Name(), filepath.Base(relativeTarget))
+	// we may be running after a mid-update reboot, where a successful boot
+	// would have trimmed the tracked assets hash lists to contain only the
+	// asset we booted with
+
+	var taBefore *trackedAsset
+	if change.Before != "" {
+		// make sure that the original copy is present in the cache if
+		// it existed
+		taBefore, err = o.cache.Add(change.Before, bl.Name(), filepath.Base(relativeTarget))
+		if err != nil {
+			return false, err
+		}
+	}
+
+	ta, err := o.cache.Add(change.After, bl.Name(), filepath.Base(relativeTarget))
 	if err != nil {
 		return false, err
 	}
@@ -445,10 +459,19 @@ func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, re
 	// keep track of the change for cancellation purpose
 	*changedAssets = append(*changedAssets, ta)
 
+	if *trustedAssets == nil {
+		*trustedAssets = bootAssetsMap{}
+	}
+
+	if taBefore != nil && !isAssetAlreadyTracked(*trustedAssets, taBefore) {
+		// make sure that the boot asset that was was in the filesystem
+		// before the update, is properly tracked until either a
+		// successful boot or the update is canceled
+		// the original asset hash is listed first
+		(*trustedAssets)[taBefore.name] = append([]string{taBefore.hash}, (*trustedAssets)[taBefore.name]...)
+	}
+
 	if !isAssetAlreadyTracked(*trustedAssets, ta) {
-		if *trustedAssets == nil {
-			*trustedAssets = bootAssetsMap{}
-		}
 		if len((*trustedAssets)[ta.name]) > 1 {
 			// we expect at most 2 different blobs for a given asset
 			// name, the current one and one that will be installed


### PR DESCRIPTION
When an observer is called during an update, it is provided with path to files
containing the original and new data applied by the update. This allows us to
restore the modeenv to correct state.

Specifically, a scenario in which an unexpected reboot may have occurred
mid-update, followed by a successful boot. The code marking boot successful,
will have processed modeenv and left hashes of assets that were present on disk
during boot, which could have been updated. When the update is picked up again
and an error occurs, rollback/cancelation would observe an incorrect state in
the modeenv and on the disk.

~~This is stacked on top of #9264, the relevant commit is https://github.com/snapcore/snapd/commit/31e7e06058e923a0d9a8116944e93426dfa78e67~~