### PR TITLE
tests: simplify and fix tests for disk space checks on snap remove

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1074,66 +1074,15 @@ func (s *snapmgrTestSuite) TestRemoveConflict(c *C) {
 	c.Assert(err, ErrorMatches, `snap "some-snap" has "remove" change in progress`)
 }
 
-func (s *snapmgrTestSuite) TestRemoveDiskSpaceForSnapshotError(c *C) {
+func (s *snapmgrTestSuite) testRemoveDiskSpaceCheck(c *C, featureFlag, automaticSnapshot bool) error {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.check-disk-space-remove", true)
-	tr.Commit()
-
-	restore := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error { return &osutil.NotEnoughDiskSpaceError{} })
-	defer restore()
-
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(11)}},
-		Current:  snap.R(11),
-		SnapType: "app",
-	})
-
-	_, err := snapstate.Remove(s.state, "some-snap", snap.R(0), nil)
-	diskSpaceErr := err.(*snapstate.InsufficientSpaceError)
-	c.Assert(diskSpaceErr, ErrorMatches, `cannot create automatic snapshot when removing last revision of the snap: insufficient space.*`)
-	c.Check(diskSpaceErr.Path, Equals, filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd"))
-	c.Check(diskSpaceErr.Snaps, DeepEquals, []string{"some-snap"})
-	c.Check(diskSpaceErr.ChangeKind, Equals, "remove")
-}
-
-func (s *snapmgrTestSuite) TestRemoveDiskSpaceForSnapshotNotCheckedWhenSnapshotsDisabled(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	restore := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error { return &osutil.NotEnoughDiskSpaceError{} })
-	defer restore()
-
-	var automaticSnapshotCalled bool
-	snapstate.AutomaticSnapshot = func(st *state.State, instanceName string) (ts *state.TaskSet, err error) {
-		automaticSnapshotCalled = true
-		// ErrNothingToDo is returned if automatic snapshots are disabled
-		return nil, snapstate.ErrNothingToDo
-	}
-
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(11)}},
-		Current:  snap.R(11),
-		SnapType: "app",
-	})
-
-	_, err := snapstate.Remove(s.state, "some-snap", snap.R(0), nil)
-	c.Assert(err, IsNil)
-	c.Assert(automaticSnapshotCalled, Equals, true)
-}
-
-func (s *snapmgrTestSuite) TestRemoveDiskSpaceCheckDisabled(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	var diskCheckHit bool
-	// this shouldn't be hit since we're disabling the the feature below
 	restore := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error {
-		diskCheckHit = true
+		// osutil.CheckFreeSpace shouldn't be hit if either featureFlag
+		// or automaticSnapshot is false. If both are true then we return disk
+		// space error which should result in snapstate.InsufficientSpaceError
+		// on remove().
 		return &osutil.NotEnoughDiskSpaceError{}
 	})
 	defer restore()
@@ -1141,12 +1090,17 @@ func (s *snapmgrTestSuite) TestRemoveDiskSpaceCheckDisabled(c *C) {
 	var automaticSnapshotCalled bool
 	snapstate.AutomaticSnapshot = func(st *state.State, instanceName string) (ts *state.TaskSet, err error) {
 		automaticSnapshotCalled = true
+		if automaticSnapshot {
+			t := s.state.NewTask("foo", "")
+			ts = state.NewTaskSet(t)
+			return ts, nil
+		}
 		// ErrNothingToDo is returned if automatic snapshots are disabled
 		return nil, snapstate.ErrNothingToDo
 	}
 
 	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.check-disk-space-remove", false)
+	tr.Set("core", "experimental.check-disk-space-remove", featureFlag)
 	tr.Commit()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
@@ -1157,9 +1111,37 @@ func (s *snapmgrTestSuite) TestRemoveDiskSpaceCheckDisabled(c *C) {
 	})
 
 	_, err := snapstate.Remove(s.state, "some-snap", snap.R(0), nil)
-	c.Check(err, IsNil)
-	c.Check(diskCheckHit, Equals, false)
 	c.Assert(automaticSnapshotCalled, Equals, true)
+	return err
+}
+
+func (s *snapmgrTestSuite) TestRemoveDiskSpaceCheckDisabledWhenNoSnapshot(c *C) {
+	featureFlag := true
+	snapshot := false
+	err := s.testRemoveDiskSpaceCheck(c, featureFlag, snapshot)
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestRemoveDiskSpaceCheckDisabledByFeatureFlag(c *C) {
+	featureFlag := false
+	snapshot := true
+	err := s.testRemoveDiskSpaceCheck(c, featureFlag, snapshot)
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestRemoveDiskSpaceForSnapshotError(c *C) {
+	featureFlag := true
+	snapshot := true
+	// both the snapshot and disk check feature are enabled, so we should hit
+	// the disk check (which fails).
+	err := s.testRemoveDiskSpaceCheck(c, featureFlag, snapshot)
+	c.Assert(err, NotNil)
+
+	diskSpaceErr := err.(*snapstate.InsufficientSpaceError)
+	c.Assert(diskSpaceErr, ErrorMatches, `cannot create automatic snapshot when removing last revision of the snap: insufficient space.*`)
+	c.Check(diskSpaceErr.Path, Equals, filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd"))
+	c.Check(diskSpaceErr.Snaps, DeepEquals, []string{"some-snap"})
+	c.Check(diskSpaceErr.ChangeKind, Equals, "remove")
 }
 
 func (s *snapmgrTestSuite) TestDisableSnapDisabledServicesSaved(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1115,7 +1115,7 @@ func (s *snapmgrTestSuite) testRemoveDiskSpaceCheck(c *C, featureFlag, automatic
 	return err
 }
 
-func (s *snapmgrTestSuite) TestRemoveDiskSpaceCheckDisabledWhenNoSnapshot(c *C) {
+func (s *snapmgrTestSuite) TestRemoveDiskSpaceCheckDoesNothingWhenNoSnapshot(c *C) {
 	featureFlag := true
 	snapshot := false
 	err := s.testRemoveDiskSpaceCheck(c, featureFlag, snapshot)


### PR DESCRIPTION
Simplify unit tests for disk space checks on remove, and fix the test for feature flag which wasn't really testing the flag because snapstate.AutomaticSnapshot mock was returning NothingToDo error (meaning feature flag conditional wasn't hit), thanks @pedronis for spotting.