### PR TITLE
packaging/opensuse: fix for /usr/libexec on TW, do not hardcode AppArmor profile path

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/snapcore/snapd/release"
@@ -362,9 +363,28 @@ func SetRootDir(rootdir string) {
 	LocaleDir = filepath.Join(rootdir, "/usr/share/locale")
 	ClassicDir = filepath.Join(rootdir, "/writable/classic")
 
-	if release.DistroLike("fedora") {
-		// rhel, centos, fedora and derivatives
-		// both rhel and centos list "fedora" in ID_LIKE
+	opensuseTWWithLibexec := func() bool {
+		// XXX: this is pretty naive if openSUSE ever starts going back
+		// and forth about the change
+		if !release.DistroLike("opensuse-tumbleweed") {
+			return false
+		}
+		v, err := strconv.Atoi(release.ReleaseInfo.VersionID)
+		if err != nil {
+			// nothing we can do here
+			return false
+		}
+		// first seen on snapshot "20200826"
+		if v < 20200826 {
+			return false
+		}
+		return true
+	}
+
+	if release.DistroLike("fedora") || opensuseTWWithLibexec() {
+		// RHEL, CentOS, Fedora and derivatives, some more recent
+		// snapshots of openSUSE Tumbleweed;
+		// both RHEL and CentOS list "fedora" in ID_LIKE
 		DistroLibExecDir = filepath.Join(rootdir, "/usr/libexec/snapd")
 	} else {
 		DistroLibExecDir = filepath.Join(rootdir, "/usr/lib/snapd")

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -189,3 +189,20 @@ func (s *DirsTestSuite) TestAddRootDirCallback(c *C) {
 	c.Assert(someVar, Equals, filepath.Join("/hello", "my", "path"))
 	c.Assert(someDerivedVar, Equals, filepath.Join("/hello", "var", "snap", "other", "mnt"))
 }
+
+func (s *DirsTestSuite) TestLibexecdirOpenSUSETW(c *C) {
+	restore := release.MockReleaseInfo(&release.OS{ID: "opensuse-tumbleweed", VersionID: "20200820"})
+	defer restore()
+	dirs.SetRootDir("/")
+	c.Check(dirs.DistroLibExecDir, Equals, "/usr/lib/snapd")
+
+	restore = release.MockReleaseInfo(&release.OS{ID: "opensuse-tumbleweed", VersionID: "20200826"})
+	defer restore()
+	dirs.SetRootDir("/")
+	c.Check(dirs.DistroLibExecDir, Equals, "/usr/libexec/snapd")
+
+	restore = release.MockReleaseInfo(&release.OS{ID: "opensuse-tumbleweed", VersionID: "20200901"})
+	defer restore()
+	dirs.SetRootDir("/")
+	c.Check(dirs.DistroLibExecDir, Equals, "/usr/libexec/snapd")
+}

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -14,6 +14,9 @@
 
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 
+# takes an absolute path with slashes and turns it into an AppArmor profile path
+%define as_apparmor_path() %(echo "%1" | tr / . | cut -c2-)
+
 # Test keys: used for internal testing in snapd.
 %bcond_with testkeys
 
@@ -69,6 +72,9 @@
 # This directory is arranged so that it is already contained inside the future
 # GOPATH so that nothing needs to be moved or copied for "go build" to work.
 %global indigo_srcdir   %{indigo_gopath}/src/%{import_path}
+
+# path to snap-confine encoded as AppArmor profile
+%define apparmor_snapconfine_profile %as_apparmor_path %{_libexecdir}/snapd/snap-confine
 
 # Set if multilib is enabled for supported arches
 %ifarch x86_64 aarch64 %{power64} s390x
@@ -443,7 +449,7 @@ fi
 %config %{_sysconfdir}/apparmor.d
 %{_libexecdir}/snapd/snapd-apparmor
 %{_sbindir}/rcsnapd.apparmor
-%{_sysconfdir}/apparmor.d/usr.lib.snapd.snap-confine
+%{_sysconfdir}/apparmor.d/%{apparmor_snapconfine_profile}
 %{_unitdir}/snapd.apparmor.service
 %endif
 

--- a/tests/lib/dirs.sh
+++ b/tests/lib/dirs.sh
@@ -17,6 +17,10 @@ case "$SPREAD_SYSTEM" in
     opensuse-*)
         export SNAP_MOUNT_DIR=/snap
         export MEDIA_DIR=/run/media
+        if [ "$( . /etc/os-release ; echo "$ID")" = "opensuse-tumbleweed" ]; then
+            # Tumbleweed since snapshot 20200827 is using /usr/libexec as libexecdir
+            export LIBEXECDIR=/usr/libexec
+        fi
         ;;
     *)
         ;;


### PR DESCRIPTION
opensuse Tumbleweed has switched to using /usr/libexec, while 15.x stayed with
/usr/lib. Update the RPM spec so that we try to install the right profile.

See https://lists.opensuse.org/opensuse-factory/2019-10/msg00204.html for more details.

@Conan-Kudo can you take a look at the macro bits?