### PR TITLE
tests: workaround for cups issue on 20.10 where default printer is not configured.

### DIFF
--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -39,7 +39,9 @@ prepare: |
     fi
 
     # XXX: on ubuntu 20.10 default printer is not set and root is not allowed
-    # to add/modify printers
+    # to add/modify printers.
+    # We do not bother to restore the previous state, for now it should be
+    # generally immaterial to other tests.
     if [[ "$SPREAD_SYSTEM" == ubuntu-20.10-* ]]; then
         sed -i -e's/SystemGroup lpadmin$/SystemGroup lpadmin root/' /etc/cups/cups-files.conf
         systemctl restart cups

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -38,6 +38,16 @@ prepare: |
         fi
     fi
 
+    # XXX: on ubuntu 20.10 default printer is not set and root is not allowed
+    # to add/modify printers
+    if [[ "$SPREAD_SYSTEM" == ubuntu-20.10-* ]]; then
+        sed -i -e's/SystemGroup lpadmin$/SystemGroup lpadmin root/' /etc/cups/cups-files.conf
+        systemctl restart cups
+        # add a printer and make it default
+        lpadmin -p pdfprinter -E -v cups-pdf:/"$HOME"/PDF -U root
+        lpadmin -d pdfprinter
+    fi
+
 restore: |
     rm -rf "$HOME"/PDF "$TEST_FILE"
 


### PR DESCRIPTION
I don't know what the exact delta between 20.04 and 20.10 is (crucial config files look the same afaict), but what I found out by poking around with lpadmin and lpstat is the there is no default printer on 20.10 (cups-pdf is installed), and root is not allowed to add printers by default (despite identical cups.conf rules, so perhaps there is a code change in cups?).