### PR TITLE
interfaces: allow snap-update-ns to read /proc/cmdline

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -1023,6 +1023,9 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   /tmp/ r,
   /tmp/.snap/{,**} rw,
 
+  # snapd logger.go checks /proc/cmdline
+  @{PROC}/cmdline r,
+
 ###SNIPPETS###
 }
 `

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -16,6 +16,10 @@ debug: |
     fi
 
 execute: |
+    echo "Running a trivial command causes no DENIED messages"
+    test-snapd-sh.sh -c 'echo hello'
+    dmesg | not grep DENIED
+
     echo "Test that snap run use environments"
     basic-run.echo-data | MATCH ^/var/snap
 


### PR DESCRIPTION
Recently we saw failures in
`google:ubuntu-16.04-64:tests/regression/lp-1813963` with:

```
2020-09-04T08:28:55.9397496Z [ 1190.482027] audit: type=1400 audit(1599208134.910:365): apparmor="DENIED" operation="open" profile="snap-update-ns.test-snapd-simple-service" name="/proc/cmdline" pid=22275 comm="5" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```

The logger.go code now looks at /proc/cmdline with the merge of
PR #9158 but the profile of snap-update-ns was not updated.
