### PR TITLE
seed,c/snap-bootstrap: simplify snap-bootstrap seed reading with new seed.ReadSystemEssential

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
@@ -104,15 +105,16 @@ func generateInitramfsMounts() error {
 		return err
 	}
 
-	mst := newInitramfsMountsState(mode, recoverySystem)
+	mst := &initramfsMountsState{
+		mode:           mode,
+		recoverySystem: recoverySystem,
+	}
 
 	switch mode {
 	case "recover":
-		// XXX: don't pass both args
-		return generateMountsModeRecover(mst, recoverySystem)
+		return generateMountsModeRecover(mst)
 	case "install":
-		// XXX: don't pass both args
-		return generateMountsModeInstall(mst, recoverySystem)
+		return generateMountsModeInstall(mst)
 	case "run":
 		return generateMountsModeRun(mst)
 	}
@@ -122,9 +124,9 @@ func generateInitramfsMounts() error {
 
 // generateMountsMode* is called multiple times from initramfs until it
 // no longer generates more mount points and just returns an empty output.
-func generateMountsModeInstall(mst *initramfsMountsState, recoverySystem string) error {
+func generateMountsModeInstall(mst *initramfsMountsState) error {
 	// steps 1 and 2 are shared with recover mode
-	if err := generateMountsCommonInstallRecover(mst, recoverySystem); err != nil {
+	if err := generateMountsCommonInstallRecover(mst); err != nil {
 		return err
 	}
 
@@ -132,7 +134,7 @@ func generateMountsModeInstall(mst *initramfsMountsState, recoverySystem string)
 	//   install mode
 	modeEnv := &boot.Modeenv{
 		Mode:           "install",
-		RecoverySystem: recoverySystem,
+		RecoverySystem: mst.recoverySystem,
 	}
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
@@ -249,9 +251,9 @@ func copyFromGlobHelper(src, dst, globEx string) error {
 	return nil
 }
 
-func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string) error {
+func generateMountsModeRecover(mst *initramfsMountsState) error {
 	// steps 1 and 2 are shared with install mode
-	if err := generateMountsCommonInstallRecover(mst, recoverySystem); err != nil {
+	if err := generateMountsCommonInstallRecover(mst); err != nil {
 		return err
 	}
 
@@ -303,7 +305,7 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 
 	modeEnv := &boot.Modeenv{
 		Mode:           "recover",
-		RecoverySystem: recoverySystem,
+		RecoverySystem: mst.recoverySystem,
 	}
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
@@ -318,7 +320,8 @@ func generateMountsModeRecover(mst *initramfsMountsState, recoverySystem string)
 	// finally we need to modify the bootenv to mark the system as successful,
 	// this ensures that when you reboot from recover mode without doing
 	// anything else, you are auto-transitioned back to run mode
-	if err := boot.EnsureNextBootToRunMode(recoverySystem); err != nil {
+	// TODO:UC20: as discussed unclear we need to pass the recovery system here
+	if err := boot.EnsureNextBootToRunMode(mst.recoverySystem); err != nil {
 		return err
 	}
 
@@ -351,28 +354,31 @@ func mountPartitionMatchingKernelDisk(dir, fallbacklabel string) error {
 	return doSystemdMount(partSrc, dir, opts)
 }
 
-func generateMountsCommonInstallRecover(mst *initramfsMountsState, recoverySystem string) error {
+func generateMountsCommonInstallRecover(mst *initramfsMountsState) error {
 	// 1. always ensure seed partition is mounted first before the others,
 	//      since the seed partition is needed to mount the snap files there
 	if err := mountPartitionMatchingKernelDisk(boot.InitramfsUbuntuSeedDir, "ubuntu-seed"); err != nil {
 		return err
 	}
 
+	// load model and verified essential snaps metadata
+	typs := []snap.Type{snap.TypeBase, snap.TypeKernel, snap.TypeSnapd}
+	model, essSnaps, err := mst.ReadEssential("", typs)
+	if err != nil {
+		return fmt.Errorf("cannot load metadata and verify essential bootstrap snaps %v: %v", typs, err)
+	}
+
 	// 2.1. measure model
-	err := stampedAction(fmt.Sprintf("%s-model-measured", recoverySystem), func() error {
-		return secbootMeasureSnapModelWhenPossible(mst.Model)
+	err = stampedAction(fmt.Sprintf("%s-model-measured", mst.recoverySystem), func() error {
+		return secbootMeasureSnapModelWhenPossible(func() (*asserts.Model, error) {
+			return model, nil
+		})
 	})
 	if err != nil {
 		return err
 	}
 
 	// 2.2. (auto) select recovery system and mount seed snaps
-	typs := []snap.Type{snap.TypeBase, snap.TypeKernel, snap.TypeSnapd}
-	essSnaps, err := mst.RecoverySystemEssentialSnaps("", typs)
-	if err != nil {
-		return fmt.Errorf("cannot load metadata and verify essential bootstrap snaps %v: %v", typs, err)
-	}
-
 	// TODO:UC20: do we need more cross checks here?
 	for _, essentialSnap := range essSnaps {
 		dir := snapTypeToMountDir[essentialSnap.EssentialType]
@@ -509,7 +515,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 	// 4.4 mount snapd snap only on first boot
 	if modeEnv.RecoverySystem != "" {
 		// load the recovery system and generate mount for snapd
-		essSnaps, err := mst.RecoverySystemEssentialSnaps(modeEnv.RecoverySystem, []snap.Type{snap.TypeSnapd})
+		_, essSnaps, err := mst.ReadEssential(modeEnv.RecoverySystem, []snap.Type{snap.TypeSnapd})
 		if err != nil {
 			return fmt.Errorf("cannot load metadata and verify snapd snap: %v", err)
 		}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1136,18 +1136,18 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedNoModel(c *C) {
-	s.testInitramfsMountsEncryptedNoModel(c, "run", "")
+	s.testInitramfsMountsEncryptedNoModel(c, "run", "", 1)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeEncryptedNoModel(c *C) {
-	s.testInitramfsMountsEncryptedNoModel(c, "install", s.sysLabel)
+	s.testInitramfsMountsEncryptedNoModel(c, "install", s.sysLabel, 0)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedNoModel(c *C) {
-	s.testInitramfsMountsEncryptedNoModel(c, "recover", s.sysLabel)
+	s.testInitramfsMountsEncryptedNoModel(c, "recover", s.sysLabel, 0)
 }
 
-func (s *initramfsMountsSuite) testInitramfsMountsEncryptedNoModel(c *C, mode, label string) {
+func (s *initramfsMountsSuite) testInitramfsMountsEncryptedNoModel(c *C, mode, label string, expectedMeasureModelCalls int) {
 	s.mockProcCmdlineContent(c, fmt.Sprintf("snapd_recovery_mode=%s", mode))
 
 	// install and recover mounts are just ubuntu-seed before we fail
@@ -1205,9 +1205,9 @@ func (s *initramfsMountsSuite) testInitramfsMountsEncryptedNoModel(c *C, mode, l
 	if mode != "run" {
 		where = fmt.Sprintf("/run/mnt/ubuntu-seed/systems/%s/model", label)
 	}
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot read model assertion: open .*%s: no such file or directory", where))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(".*cannot read model assertion: open .*%s: no such file or directory", where))
 	c.Assert(measureEpochCalls, Equals, 1)
-	c.Assert(measureModelCalls, Equals, 1)
+	c.Assert(measureModelCalls, Equals, expectedMeasureModelCalls)
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "secboot-epoch-measured"), testutil.FilePresent)
 	gl, err := filepath.Glob(filepath.Join(dirs.SnapBootstrapRunDir, "*-model-measured"))
 	c.Assert(err, IsNil)

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -700,6 +700,9 @@ Hiding:
 }
 
 func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
+	r := seed.MockTrusted(s.StoreSigning.Trusted)
+	defer r()
+
 	s.makeSnap(c, "snapd", "")
 	s.makeSnap(c, "core20", "")
 	s.makeSnap(c, "pc-kernel=20", "")
@@ -804,7 +807,7 @@ func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
 		essSeed20, ok := seed20.(seed.EssentialMetaLoaderSeed)
 		c.Assert(ok, Equals, true)
 
-		err = essSeed20.LoadAssertions(s.db, s.commitTo)
+		err = essSeed20.LoadAssertions(nil, nil)
 		c.Assert(err, IsNil)
 
 		err = essSeed20.LoadEssentialMeta(t.onlyTypes, s.perfTimings)
@@ -822,6 +825,14 @@ func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
 		c.Check(runSnaps, HasLen, 0)
 
 		unhide()
+
+		// test short-cut helper as well
+		mod, essSnaps, err := seed.ReadSystemEssential(s.SeedDir, sysLabel, t.onlyTypes, s.perfTimings)
+		c.Assert(err, IsNil)
+		c.Check(mod.BrandID(), Equals, "my-brand")
+		c.Check(mod.Model(), Equals, "my-model")
+		c.Check(essSnaps, HasLen, len(t.expected))
+		c.Check(essSnaps, DeepEquals, t.expected)
 	}
 }
 


### PR DESCRIPTION
This should be useful also for the new code we need in boot to reseal.
