### PR TITLE
tests: some fixes and improvements for nested execution

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -848,6 +848,9 @@ suites:
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils
             snap install ubuntu-image --classic
+
+            # Install the snapd built
+            dpkg -i "$SPREAD_PATH"/../snapd_*.deb
         prepare-each: |
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
@@ -903,6 +906,9 @@ suites:
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils
             snap install ubuntu-image --classic
+
+            # Install the snapd built
+            dpkg -i "$SPREAD_PATH"/../snapd_*.deb
 
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
@@ -962,6 +968,9 @@ suites:
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils
             snap install ubuntu-image --classic
+
+            # Install the snapd built
+            dpkg -i "$SPREAD_PATH"/../snapd_*.deb
 
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
@@ -1023,9 +1032,8 @@ suites:
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils
             snap install ubuntu-image --classic
 
-            # TODO: replace with distro package once 2.45 is in stable
+            # Install the snapd built
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb
-            snap install core --beta
 
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"

--- a/spread.yaml
+++ b/spread.yaml
@@ -848,14 +848,15 @@ suites:
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils
             snap install ubuntu-image --classic
-
-            # TODO: replace with distro package once 2.45 is in stable
-            dpkg -i "$SPREAD_PATH"/../snapd_*.deb
-
+        prepare-each: |
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
             nested_prepare_env
-
+        restore-each: |
+            #shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB/nested.sh"
+            nested_destroy_vm
+            nested_cleanup_env
         restore: |
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -27,13 +27,15 @@ nested_wait_for_no_ssh() {
 }
 
 nested_get_last_reboot() {
-    nested_retry_until_success 200 1 "date -u -d '$(uptime -s) seconds ago' +'%Y-%m-%dT%H:%M:%SZ'"
+    local last_uptime
+    last_uptime=$(nested_retry_until_success 200 1 "uptime -s")
+    date -u -d "$last_uptime seconds ago" +'%Y-%m-%dT%H:%M:%SZ'
 }
 
 nested_wait_for_reboot() {
     local initial_reboot="$1"
     local retry wait last_reboot
-    retry=30
+    retry=120
     wait=5
 
     last_reboot=""

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -27,19 +27,20 @@ nested_wait_for_no_ssh() {
 }
 
 nested_get_boot_id() {
-    nested_retry_until_success 200 1 "cat /proc/sys/kernel/random/boot_id"
+    nested_exec "cat /proc/sys/kernel/random/boot_id"
 }
 
 nested_wait_for_reboot() {
     local initial_boot_id="$1"
     local retry wait last_boot_id
-    retry=120
+    retry=150
     wait=5
 
     last_boot_id=""
     while [ $retry -ge 0 ]; do
         retry=$(( retry - 1 ))
-        last_boot_id="$(nested_get_boot_id)"
+        # The get_boot_id could fail because the connection is broken due to the reboot
+        last_boot_id="$(nested_get_boot_id)" || true
         if [[ "$last_boot_id" =~ .*-.*-.*-.*-.* ]] && [ "$last_boot_id" != "$initial_boot_id" ]; then
             break
         fi

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -26,29 +26,27 @@ nested_wait_for_no_ssh() {
     nested_retry_while_success 200 1 "true"
 }
 
-nested_get_last_reboot() {
-    local last_uptime
-    last_uptime=$(nested_retry_until_success 200 1 "uptime -s")
-    date -u -d "$last_uptime seconds ago" +'%Y-%m-%dT%H:%M:%SZ'
+nested_get_boot_id() {
+    nested_retry_until_success 200 1 "cat /proc/sys/kernel/random/boot_id"
 }
 
 nested_wait_for_reboot() {
-    local initial_reboot="$1"
-    local retry wait last_reboot
+    local initial_boot_id="$1"
+    local retry wait last_boot_id
     retry=120
     wait=5
 
-    last_reboot=""
+    last_boot_id=""
     while [ $retry -ge 0 ]; do
         retry=$(( retry - 1 ))
-        last_reboot="$(nested_get_last_reboot)"
-        if [[ "$last_reboot" =~ .*-.*-.*T.*:.*:.*Z ]] && [ "$last_reboot" != "$initial_reboot" ]; then
+        last_boot_id="$(nested_get_boot_id)"
+        if [[ "$last_boot_id" =~ .*-.*-.*-.*-.* ]] && [ "$last_boot_id" != "$initial_boot_id" ]; then
             break
         fi
         sleep "$wait"
     done
 
-    [ "$last_reboot" != "$initial_reboot" ]
+    [ "$last_boot_id" != "$initial_boot_id" ]
 }
 
 nested_retry_while_success() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -69,7 +69,7 @@ nested_retry_until_success() {
     local wait="$2"
     shift 2
 
-    while ! nested_exec "$@"; do
+    until nested_exec "$@"; do
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
             echo "Timed out waiting for ssh. Aborting!"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -268,6 +268,7 @@ nested_cleanup_env() {
     rm -rf "$NESTED_ASSETS_DIR"
     rm -rf "$NESTED_LOGS_DIR"
     rm -rf "$NESTED_IMAGES_DIR"/*.img
+    rm -rf "$(nested_get_extra_snaps_path)"
 }
 
 nested_get_image_name() {
@@ -702,6 +703,9 @@ nested_start_core_vm() {
     CURRENT_NAME="$(nested_get_current_image_name)"
     CURRENT_IMAGE="$NESTED_IMAGES_DIR/$CURRENT_NAME"
 
+    # Create the logs directory used for the vm
+    mkdir -p "$NESTED_LOGS_DIR"
+
     # In case the current image already exists, it needs to be reused and in that
     # case is neither required to copy the base image nor prepare the ssh
     if [ ! -f "$CURRENT_IMAGE" ]; then
@@ -803,6 +807,9 @@ nested_start_classic_vm() {
     local IMAGE QEMU IMAGE_NAME
     QEMU="$(nested_qemu_name)"
     IMAGE_NAME="$(nested_get_image_name classic)"
+
+    # Create the logs directory used for the vm
+    mkdir -p "$NESTED_LOGS_DIR"
 
     if [ ! -f "$NESTED_IMAGES_DIR/$IMAGE_NAME" ] && [ -f "$NESTED_IMAGES_DIR/$IMAGE_NAME.xz" ]; then
         nested_uncompress_image "$IMAGE_NAME"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -737,9 +737,6 @@ nested_start_core_vm() {
     CURRENT_NAME="$(nested_get_current_image_name)"
     CURRENT_IMAGE="$NESTED_IMAGES_DIR/$CURRENT_NAME"
 
-    # Create the logs directory used for the vm
-    mkdir -p "$NESTED_LOGS_DIR"
-
     # In case the current image already exists, it needs to be reused and in that
     # case is neither required to copy the base image nor prepare the ssh
     if [ ! -f "$CURRENT_IMAGE" ]; then
@@ -841,9 +838,6 @@ nested_start_classic_vm() {
     local IMAGE QEMU IMAGE_NAME
     QEMU="$(nested_qemu_name)"
     IMAGE_NAME="$(nested_get_image_name classic)"
-
-    # Create the logs directory used for the vm
-    mkdir -p "$NESTED_LOGS_DIR"
 
     if [ ! -f "$NESTED_IMAGES_DIR/$IMAGE_NAME" ] && [ -f "$NESTED_IMAGES_DIR/$IMAGE_NAME.xz" ]; then
         nested_uncompress_image "$IMAGE_NAME"

--- a/tests/nested/core20/basic/task.yaml
+++ b/tests/nested/core20/basic/task.yaml
@@ -30,5 +30,4 @@ execute: |
     nested_exec "sudo snap remove test-snapd-sh" || true
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is removed"
-    # FIXME: this is invalid use of not
-    not nested_exec "snap list test-snapd-sh"
+    ! nested_exec "snap list test-snapd-sh"

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -23,17 +23,13 @@ prepare: |
     cd seed
     genisoimage -output ../seed1.iso -volid cidata -joliet -rock user-data meta-data
 
-restore: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-    nested_destroy_vm
-    nested_cleanup_env
-
 debug: |
     if [ -f snapd-before-reboot.logs ]; then
         echo "logs before reboot"
         cat snapd-before-reboot.logs
     fi
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
     echo "logs from current nested VM boot snapd"
     nested_exec "sudo journalctl -e --no-pager -u snapd" || true
 

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -40,17 +40,13 @@ prepare: |
     nested_create_core_vm
     nested_start_core_vm
 
-restore: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-    nested_destroy_vm
-    nested_cleanup_env
-
 debug: |
     if [ -f snapd-before-reboot.logs ]; then
         echo "logs before reboot"
         cat snapd-before-reboot.logs
     fi
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
     echo "logs from current nested VM boot snapd"
     nested_exec "sudo journalctl -e --no-pager -u snapd" || true
 

--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -10,8 +10,6 @@ prepare: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
-    nested_cleanup_env
-
     mkdir extra-snaps
 
     # modify and repack gadget snap (add defaults section and install hook)
@@ -46,13 +44,6 @@ prepare: |
     rmdir "$tmp"
 
     nested_start_core_vm
-
-restore: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-    nested_destroy_vm
-    nested_cleanup_env
-    rm -rf extra-snaps
 
 execute: |
     #shellcheck source=tests/lib/nested.sh

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -35,12 +35,6 @@ prepare: |
     nested_create_core_vm
     nested_start_core_vm
 
-restore: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-    nested_destroy_vm
-    nested_cleanup_env
-
 execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"

--- a/tests/nested/manual/minimal-smoke/task.yaml
+++ b/tests/nested/manual/minimal-smoke/task.yaml
@@ -8,12 +8,6 @@ prepare: |
     nested_fetch_spread
     nested_create_core_vm
 
-restore: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-    nested_destroy_vm
-    nested_cleanup_env
-
 execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -55,7 +55,6 @@ restore: |
   #shellcheck source=tests/lib/preseed.sh
   . "$TESTSLIB/preseed.sh"
   umount_ubuntu_image "$IMAGE_MOUNTPOINT" || true
-  nested_cleanup_env
 
 execute: |
   #shellcheck source=tests/lib/nested.sh

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -65,7 +65,7 @@ execute: |
 
     nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_CHANNEL}.*"
     # The snap is refreshed
-    INITIAL_REBOOT=$(nested_get_last_reboot)
+    INITIAL_BOOT=$(nested_get_last_reboot)
     REFRESH_ID=$(nested_exec "sudo snap refresh --no-wait --channel $NESTED_CORE_REFRESH_CHANNEL $SNAP")
 
     case "$SNAP" in
@@ -81,8 +81,8 @@ execute: |
             # don't manually reboot, wait for automatic snapd reboot
             ;;
     esac
-    nested_wait_for_reboot "$INITIAL_REBOOT"
-    SECOND_REBOOT=$(nested_get_last_reboot)
+    nested_wait_for_reboot "$INITIAL_BOOT"
+    SECOND_BOOT=$(nested_get_last_reboot)
 
     # Check the new version of the snaps is correct after the system reboot
     nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${TO_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
@@ -116,8 +116,7 @@ execute: |
             # don't manually reboot, wait for automatic snapd reboot
             ;;
     esac
-    nested_wait_for_reboot "$INITIAL_REBOOT"
-    SECOND_REBOOT=$(nested_get_last_reboot)
+    nested_wait_for_reboot "$SECOND_BOOT"
 
     # Check the version of the snaps after the revert is correct
     nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -65,6 +65,7 @@ execute: |
 
     nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_CHANNEL}.*"
     # The snap is refreshed
+    INITIAL_REBOOT=$(nested_get_last_reboot)
     REFRESH_ID=$(nested_exec "sudo snap refresh --no-wait --channel $NESTED_CORE_REFRESH_CHANNEL $SNAP")
 
     case "$SNAP" in
@@ -80,8 +81,8 @@ execute: |
             # don't manually reboot, wait for automatic snapd reboot
             ;;
     esac
-    nested_wait_for_no_ssh
-    nested_wait_for_ssh
+    nested_wait_for_reboot "$INITIAL_REBOOT"
+    SECOND_REBOOT=$(nested_get_last_reboot)
 
     # Check the new version of the snaps is correct after the system reboot
     nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${TO_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
@@ -115,8 +116,8 @@ execute: |
             # don't manually reboot, wait for automatic snapd reboot
             ;;
     esac
-    nested_wait_for_no_ssh
-    nested_wait_for_ssh
+    nested_wait_for_reboot "$INITIAL_REBOOT"
+    SECOND_REBOOT=$(nested_get_last_reboot)
 
     # Check the version of the snaps after the revert is correct
     nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -65,7 +65,7 @@ execute: |
 
     nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_CHANNEL}.*"
     # The snap is refreshed
-    INITIAL_BOOT=$(nested_get_last_reboot)
+    INITIAL_BOOT_ID=$(nested_get_boot_id)
     REFRESH_ID=$(nested_exec "sudo snap refresh --no-wait --channel $NESTED_CORE_REFRESH_CHANNEL $SNAP")
 
     case "$SNAP" in
@@ -81,8 +81,8 @@ execute: |
             # don't manually reboot, wait for automatic snapd reboot
             ;;
     esac
-    nested_wait_for_reboot "$INITIAL_BOOT"
-    SECOND_BOOT=$(nested_get_last_reboot)
+    nested_wait_for_reboot "$INITIAL_BOOT_ID"
+    SECOND_BOOT_ID=$(nested_get_boot_id)
 
     # Check the new version of the snaps is correct after the system reboot
     nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${TO_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
@@ -116,7 +116,7 @@ execute: |
             # don't manually reboot, wait for automatic snapd reboot
             ;;
     esac
-    nested_wait_for_reboot "$SECOND_BOOT"
+    nested_wait_for_reboot "$SECOND_BOOT_ID"
 
     # Check the version of the snaps after the revert is correct
     nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -43,18 +43,9 @@ prepare: |
     nested_start_core_vm
 
 restore: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-
     if [ -f skip.test ]; then
         rm -f skip.test
-        exit
     fi
-
-    nested_destroy_vm
-    nested_cleanup_env
-
-    rm -f "$NESTED_IMAGES_DIR/ubuntu-core.img"
 
 debug: |
     #shellcheck source=tests/lib/nested.sh


### PR DESCRIPTION
This change includes:
. Some tests could fail because logs dir not created when the vm is
started
. Creating environment for manual nested suite in spread.yaml
. Restoring environment for manual nested suite in spread.yaml
. Clean the extra-snaps directory as well
