### PR TITLE
many: seed.Model panics now if called before LoadAssertions

### DIFF
--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -312,8 +312,8 @@ func (fs *Fake16Seed) LoadAssertions(db asserts.RODatabase, commitTo func(*asser
 	return fs.LoadAssertionsErr
 }
 
-func (fs *Fake16Seed) Model() (*asserts.Model, error) {
-	return fs.AssertsModel, nil
+func (fs *Fake16Seed) Model() *asserts.Model {
+	return fs.AssertsModel
 }
 
 func (fs *Fake16Seed) Brand() (*asserts.Account, error) {

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -109,14 +109,10 @@ var systemSnapFromSeed = func(rootDir string) (string, error) {
 	if err := seed.LoadAssertions(nil, nil); err != nil {
 		return "", err
 	}
+	model := seed.Model()
 
 	tm := timings.New(nil)
 	if err := seed.LoadMeta(tm); err != nil {
-		return "", err
-	}
-
-	model, err := seed.Model()
-	if err != nil {
 		return "", err
 	}
 

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -323,11 +323,7 @@ func importAssertionsFromSeed(st *state.State, deviceSeed seed.Seed) (*asserts.M
 	if err != nil {
 		return nil, err
 	}
-
-	modelAssertion, err := deviceSeed.Model()
-	if err != nil {
-		return nil, err
-	}
+	modelAssertion := deviceSeed.Model()
 
 	classicModel := modelAssertion.Classic()
 	if release.OnClassic != classicModel {

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -75,10 +75,7 @@ func systemFromSeed(label string, current *currentSystem) (*System, error) {
 		return nil, fmt.Errorf("cannot load assertions: %v", err)
 	}
 	// get the model
-	model, err := s.Model()
-	if err != nil {
-		return nil, fmt.Errorf("cannot obtain model: %v", err)
-	}
+	model := s.Model()
 	brand, err := s.Brand()
 	if err != nil {
 		return nil, fmt.Errorf("cannot obtain brand: %v", err)

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2019 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -142,12 +142,8 @@ func essentialSnapTypesToModelFilter(essentialTypes []snap.Type) func(modSnap *a
 }
 
 func findBrand(seed Seed, db asserts.RODatabase) (*asserts.Account, error) {
-	model, err := seed.Model()
-	if err != nil {
-		return nil, err
-	}
 	a, err := db.Find(asserts.AccountType, map[string]string{
-		"account-id": model.BrandID(),
+		"account-id": seed.Model().BrandID(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("internal error: %v", err)

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -105,11 +105,11 @@ func (s *seed16) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Ba
 	return nil
 }
 
-func (s *seed16) Model() (*asserts.Model, error) {
+func (s *seed16) Model() *asserts.Model {
 	if s.model == nil {
-		return nil, fmt.Errorf("internal error: model assertion unset")
+		panic("internal error: model assertion unset (LoadAssertions not called)")
 	}
-	return s.model, nil
+	return s.model
 }
 
 func (s *seed16) Brand() (*asserts.Account, error) {
@@ -170,10 +170,7 @@ func (e *essentialSnapMissingError) Error() string {
 }
 
 func (s *seed16) LoadMeta(tm timings.Measurer) error {
-	model, err := s.Model()
-	if err != nil {
-		return err
-	}
+	model := s.Model()
 
 	seedYamlFile := filepath.Join(s.seedDir, "seed.yaml")
 	if !osutil.FileExists(seedYamlFile) {

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -156,8 +156,7 @@ func (s *seed16Suite) TestLoadAssertionsModelHappy(c *C) {
 	err = s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	model, err := s.seed16.Model()
-	c.Assert(err, IsNil)
+	model := s.seed16.Model()
 	c.Check(model.Model(), Equals, "my-model")
 
 	_, err = s.db.Find(asserts.ModelType, map[string]string{
@@ -186,25 +185,13 @@ func (s *seed16Suite) TestLoadAssertionsModelTempDBHappy(c *C) {
 	err = s.seed16.LoadAssertions(nil, nil)
 	c.Assert(err, IsNil)
 
-	model, err := s.seed16.Model()
-	c.Assert(err, IsNil)
+	model := s.seed16.Model()
 	c.Check(model.Model(), Equals, "my-model")
 
 	brand, err := s.seed16.Brand()
 	c.Assert(err, IsNil)
 	c.Check(brand.AccountID(), Equals, "my-brand")
 	c.Check(brand.DisplayName(), Equals, "My-brand")
-}
-
-func (s *seed16Suite) TestSkippedLoadAssertion(c *C) {
-	_, err := s.seed16.Model()
-	c.Check(err, ErrorMatches, "internal error: model assertion unset")
-
-	err = s.seed16.LoadMeta(s.perfTimings)
-	c.Check(err, ErrorMatches, "internal error: model assertion unset")
-
-	_, err = s.seed16.Brand()
-	c.Check(err, ErrorMatches, "internal error: model assertion unset")
 }
 
 func (s *seed16Suite) TestLoadMetaNoMeta(c *C) {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -177,11 +177,11 @@ func (s *seed20) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Ba
 	return nil
 }
 
-func (s *seed20) Model() (*asserts.Model, error) {
+func (s *seed20) Model() *asserts.Model {
 	if s.model == nil {
-		return nil, fmt.Errorf("internal error: model assertion unset")
+		panic("internal error: model assertion unset (LoadAssertions not called)")
 	}
-	return s.model, nil
+	return s.model
 }
 
 func (s *seed20) Brand() (*asserts.Account, error) {
@@ -420,10 +420,7 @@ func (s *seed20) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measur
 }
 
 func (s *seed20) loadEssentialMeta(filterEssential func(*asserts.ModelSnap) bool, tm timings.Measurer) error {
-	model, err := s.Model()
-	if err != nil {
-		return err
-	}
+	model := s.Model()
 
 	if err := s.loadOptions(); err != nil {
 		return err
@@ -470,10 +467,7 @@ func (s *seed20) loadEssentialMeta(filterEssential func(*asserts.ModelSnap) bool
 }
 
 func (s *seed20) loadModelRestMeta(tm timings.Measurer) error {
-	model, err := s.Model()
-	if err != nil {
-		return err
-	}
+	model := s.Model()
 
 	const notEssential = false
 	for _, modelSnap := range model.SnapsWithoutEssential() {

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -224,8 +224,7 @@ func (s *seed20Suite) TestLoadAssertionsModelTempDBHappy(c *C) {
 	err = seed20.LoadAssertions(nil, nil)
 	c.Assert(err, IsNil)
 
-	model, err := seed20.Model()
-	c.Assert(err, IsNil)
+	model := seed20.Model()
 	c.Check(model.Model(), Equals, "my-model")
 	c.Check(model.Base(), Equals, "core20")
 

--- a/seed/validate.go
+++ b/seed/validate.go
@@ -99,9 +99,7 @@ func ValidateFromYaml(seedYamlFile string) error {
 	tm := timings.New(nil)
 	if err := seed.LoadMeta(tm); err != nil {
 		if missingErr, ok := err.(*essentialSnapMissingError); ok {
-			// Model always succeed after LoadAssertions
-			mod, _ := seed.Model()
-			if mod.Classic() && missingErr.SnapName == "core" {
+			if seed.Model().Classic() && missingErr.SnapName == "core" {
 				err = fmt.Errorf("essential snap core or snapd must be part of the seed")
 			}
 		}


### PR DESCRIPTION
with experience and after the simplifications of snap-bootstrap
all our usages call Model just after LoadAssertions
in the same functions, so it seems panicing is good enough
and removes the wondering what kind of error might be involved
in retrieving the model after loading successfully all assertions

this is a follow-up to the discussions in #9283 about mod, _ := seed.Model()