### PR TITLE
tests: remove workaround for cups on ubuntu-20.10

### DIFF
--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -38,18 +38,6 @@ prepare: |
         fi
     fi
 
-    # XXX: on ubuntu 20.10 default printer is not set and root is not allowed
-    # to add/modify printers.
-    # We do not bother to restore the previous state, for now it should be
-    # generally immaterial to other tests.
-    if [[ "$SPREAD_SYSTEM" == ubuntu-20.10-* ]]; then
-        sed -i -e's/SystemGroup lpadmin$/SystemGroup lpadmin root/' /etc/cups/cups-files.conf
-        systemctl restart cups
-        # add a printer and make it default
-        lpadmin -p pdfprinter -E -v cups-pdf:/"$HOME"/PDF -U root
-        lpadmin -d pdfprinter
-    fi
-
 restore: |
     rm -rf "$HOME"/PDF "$TEST_FILE"
 


### PR DESCRIPTION
The cups regression in 20.10 that was mitigated with #9281 has been identified and fixed with cups-2.3.3-3ubuntu1, workaround shouldn't be needed anymore. This PR removes it. See https://github.com/snapcore/snapd/pull/9281#issuecomment-687253188 for details of the regression.