### PR TITLE
github: run tests also on push to release branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: Tests
 on:
   pull_request:
     branches: [ "master", "release/**" ]
+  push:
+    branches: [ "release/**" ]
+
 jobs:
   snap-builds:
     runs-on: ubuntu-16.04


### PR DESCRIPTION
Fixes for release branches are often cherry-picked and then
directly pushed. This commit ensures that this results in a
full test run too. Right now we are flying a bit blind and
may miss that fixes like PR#9242 also need to go to the
release branches.

This is #9279 for master.