### PR TITLE
client: implement RebootToSystem

### DIFF
--- a/client/systems.go
+++ b/client/systems.go
@@ -103,3 +103,25 @@ func (client *Client) DoSystemAction(systemLabel string, action *SystemAction) e
 	}
 	return nil
 }
+
+// DoSystemReboot issues a request to reboot into the given label/mode
+func (client *Client) DoSystemReboot(systemLabel, mode string) error {
+	// verification is done by the backend
+
+	req := struct {
+		Action string `json:"action"`
+		Mode   string `json:"mode"`
+	}{
+		Action: "reboot",
+		Mode:   mode,
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&req); err != nil {
+		return err
+	}
+	if _, err := client.doSync("POST", "/v2/systems/"+systemLabel, nil, nil, &body, nil); err != nil {
+		return xerrors.Errorf("cannot request system action: %v", err)
+	}
+	return nil
+}

--- a/client/systems.go
+++ b/client/systems.go
@@ -104,7 +104,8 @@ func (client *Client) DoSystemAction(systemLabel string, action *SystemAction) e
 	return nil
 }
 
-// DoSystemReboot issues a request to reboot into the given label/mode
+// RebootToSystem issues a request to reboot into system with the
+// given label and the given mode.
 //
 // When called without a systemLabel and without a mode it will just
 // trigger a regular reboot.

--- a/client/systems.go
+++ b/client/systems.go
@@ -105,7 +105,16 @@ func (client *Client) DoSystemAction(systemLabel string, action *SystemAction) e
 }
 
 // DoSystemReboot issues a request to reboot into the given label/mode
-func (client *Client) DoSystemReboot(systemLabel, mode string) error {
+//
+// When called without a systemLabel and without a mode it will just
+// trigger a regular reboot.
+//
+// When called without a systemLabel but with a mode it will use
+// the current system to enter the given mode.
+//
+// Note that "recover" and "run" modes are only available for the
+// current system.
+func (client *Client) RebootToSystem(systemLabel, mode string) error {
 	// verification is done by the backend
 
 	req := struct {

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -169,3 +169,37 @@ func (cs *clientSuite) TestRequestSystemActionInvalid(c *check.C) {
 	err = cs.cli.DoSystemAction("1234", nil)
 	c.Assert(err, check.ErrorMatches, "cannot request an action without one")
 }
+
+func (cs *clientSuite) TestRequestSystemRebootHappy(c *check.C) {
+	cs.rsp = `{
+	    "type": "sync",
+	    "status-code": 200,
+	    "result": {}
+	}`
+	err := cs.cli.DoSystemReboot("20201212", "install")
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/systems/20201212")
+
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+	var req map[string]interface{}
+	err = json.Unmarshal(body, &req)
+	c.Assert(err, check.IsNil)
+	c.Assert(req, check.DeepEquals, map[string]interface{}{
+		"action": "reboot",
+		"mode":   "install",
+	})
+}
+
+func (cs *clientSuite) TestRequestSystemRebootError(c *check.C) {
+	cs.rsp = `{
+	    "type": "error",
+	    "status-code": 500,
+	    "result": {"message": "failed"}
+	}`
+	err := cs.cli.DoSystemReboot("1234", "install")
+	c.Assert(err, check.ErrorMatches, "cannot request system action: failed")
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/systems/1234")
+}

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -176,7 +176,7 @@ func (cs *clientSuite) TestRequestSystemRebootHappy(c *check.C) {
 	    "status-code": 200,
 	    "result": {}
 	}`
-	err := cs.cli.DoSystemReboot("20201212", "install")
+	err := cs.cli.RebootToSystem("20201212", "install")
 	c.Assert(err, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/systems/20201212")
@@ -198,7 +198,7 @@ func (cs *clientSuite) TestRequestSystemRebootError(c *check.C) {
 	    "status-code": 500,
 	    "result": {"message": "failed"}
 	}`
-	err := cs.cli.DoSystemReboot("1234", "install")
+	err := cs.cli.RebootToSystem("1234", "install")
 	c.Assert(err, check.ErrorMatches, "cannot request system action: failed")
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/systems/1234")


### PR DESCRIPTION
This implements the client side of the /v2/systems POST action:reboot API.

Split out from https://github.com/snapcore/snapd/pull/9021