### PR TITLE
boot: represent boot chains, helpers for marshalling and equivalence checks

### DIFF
--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -1,0 +1,173 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+)
+
+type bootChain struct {
+	Model          string      `json:"model"`
+	BrandID        string      `json:"brand-id"`
+	Grade          string      `json:"grade"`
+	ModelSignKeyID string      `json:"model-sign-key-id"`
+	AssetChain     []bootAsset `json:"asset-chain"`
+	Kernel         string      `json:"kernel"`
+	// KernelRevision is the revision of the kernel snap. It is empty if
+	// kernel is unasserted, in which case always reseal.
+	KernelRevision string `json:"kernel-revision"`
+	KernelCmdline  string `json:"kernel-cmdline"`
+}
+
+type bootAsset struct {
+	Role   string   `json:"role"`
+	Name   string   `json:"name"`
+	Hashes []string `json:"hashes"`
+}
+
+func bootAssetLess(b, other *bootAsset) bool {
+	byRole := b.Role < other.Role
+	byName := b.Name < other.Name
+	// sort order: role -> name -> hash list (len -> lexical)
+	if b.Role != other.Role {
+		return byRole
+	}
+	if b.Name != other.Name {
+		return byName
+	}
+	return hashListsLess(b.Hashes, other.Hashes)
+}
+
+func hashListsLess(h1, h2 []string) bool {
+	if len(h1) != len(h2) {
+		return len(h1) < len(h2)
+	}
+	for idx := range h1 {
+		if h1[idx] < h2[idx] {
+			return true
+		}
+	}
+	return false
+}
+
+func toPredictableBootAsset(b *bootAsset) *bootAsset {
+	if b == nil {
+		return nil
+	}
+	newB := *b
+	if b.Hashes != nil {
+		newB.Hashes = make([]string, len(b.Hashes))
+		copy(newB.Hashes, b.Hashes)
+		sort.Strings(newB.Hashes)
+	}
+	return &newB
+}
+
+type byBootAssetOrder []bootAsset
+
+func (b byBootAssetOrder) Len() int      { return len(b) }
+func (b byBootAssetOrder) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b byBootAssetOrder) Less(i, j int) bool {
+	return bootAssetLess(&b[i], &b[j])
+}
+
+func toPredictableBootChain(b *bootChain) *bootChain {
+	if b == nil {
+		return nil
+	}
+	newB := *b
+	if b.AssetChain != nil {
+		newB.AssetChain = make([]bootAsset, len(b.AssetChain))
+		for i := range b.AssetChain {
+			newB.AssetChain[i] = *toPredictableBootAsset(&b.AssetChain[i])
+		}
+		sort.Sort(byBootAssetOrder(newB.AssetChain))
+	}
+	return &newB
+}
+
+// equal returns true when boot chains are equivalent for reseal.
+func (b *bootChain) equalForReseal(other *bootChain) bool {
+	bJSON, err := json.Marshal(toPredictableBootChain(b))
+	if err != nil {
+		return false
+	}
+	otherJSON, err := json.Marshal(toPredictableBootChain(other))
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(bJSON, otherJSON)
+}
+
+func predictableBootAssetsLess(b1, b2 []bootAsset) bool {
+	if len(b1) != len(b2) {
+		return len(b1) < len(b2)
+	}
+	for i := range b1 {
+		if bootAssetLess(&b1[i], &b2[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+type byBootChainOrder []bootChain
+
+func (b byBootChainOrder) Len() int      { return len(b) }
+func (b byBootChainOrder) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b byBootChainOrder) Less(i, j int) bool {
+	if b[i].Model != b[j].Model {
+		return b[i].Model < b[j].Model
+	}
+	if b[i].BrandID != b[j].BrandID {
+		return b[i].BrandID < b[j].BrandID
+	}
+	if b[i].Grade != b[j].Grade {
+		return b[i].Grade < b[j].Grade
+	}
+	if b[i].ModelSignKeyID != b[j].ModelSignKeyID {
+		return b[i].ModelSignKeyID < b[j].ModelSignKeyID
+	}
+	if b[i].Kernel != b[j].Kernel {
+		return b[i].Kernel < b[j].Kernel
+	}
+	if b[i].KernelRevision != b[j].KernelRevision {
+		return b[i].KernelRevision < b[j].KernelRevision
+	}
+	if b[i].KernelCmdline != b[j].KernelCmdline {
+		return b[i].KernelCmdline < b[j].KernelCmdline
+	}
+	// XXX: add new fields as when bootChain is modified
+	return predictableBootAssetsLess(b[i].AssetChain, b[j].AssetChain)
+}
+
+func toPredictableBootChains(chains []bootChain) []bootChain {
+	if chains == nil {
+		return nil
+	}
+	predictableChains := make([]bootChain, len(chains))
+	for i := range chains {
+		predictableChains[i] = *toPredictableBootChain(&chains[i])
+	}
+	sort.Sort(byBootChainOrder(predictableChains))
+	return predictableChains
+}

--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -25,9 +25,10 @@ import (
 	"sort"
 )
 
+// TODO:UC20 add a doc comment when this is stabilized
 type bootChain struct {
-	Model          string      `json:"model"`
 	BrandID        string      `json:"brand-id"`
+	Model          string      `json:"model"`
 	Grade          string      `json:"grade"`
 	ModelSignKeyID string      `json:"model-sign-key-id"`
 	AssetChain     []bootAsset `json:"asset-chain"`
@@ -38,6 +39,7 @@ type bootChain struct {
 	KernelCmdline  string `json:"kernel-cmdline"`
 }
 
+// TODO:UC20 add a doc comment when this is stabilized
 type bootAsset struct {
 	Role   string   `json:"role"`
 	Name   string   `json:"name"`
@@ -134,20 +136,12 @@ type byBootChainOrder []bootChain
 func (b byBootChainOrder) Len() int      { return len(b) }
 func (b byBootChainOrder) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 func (b byBootChainOrder) Less(i, j int) bool {
-	if !predictableBootAssetsEqual(b[i].AssetChain, b[j].AssetChain) {
-		return predictableBootAssetsLess(b[i].AssetChain, b[j].AssetChain)
-	}
-	if b[i].Kernel != b[j].Kernel {
-		return b[i].Kernel < b[j].Kernel
-	}
-	if b[i].KernelRevision != b[j].KernelRevision {
-		return b[i].KernelRevision < b[j].KernelRevision
+	// sort by model info
+	if b[i].BrandID != b[j].BrandID {
+		return b[i].BrandID < b[j].BrandID
 	}
 	if b[i].Model != b[j].Model {
 		return b[i].Model < b[j].Model
-	}
-	if b[i].BrandID != b[j].BrandID {
-		return b[i].BrandID < b[j].BrandID
 	}
 	if b[i].Grade != b[j].Grade {
 		return b[i].Grade < b[j].Grade
@@ -155,6 +149,18 @@ func (b byBootChainOrder) Less(i, j int) bool {
 	if b[i].ModelSignKeyID != b[j].ModelSignKeyID {
 		return b[i].ModelSignKeyID < b[j].ModelSignKeyID
 	}
+	// then boot assets
+	if !predictableBootAssetsEqual(b[i].AssetChain, b[j].AssetChain) {
+		return predictableBootAssetsLess(b[i].AssetChain, b[j].AssetChain)
+	}
+	// then kernel
+	if b[i].Kernel != b[j].Kernel {
+		return b[i].Kernel < b[j].Kernel
+	}
+	if b[i].KernelRevision != b[j].KernelRevision {
+		return b[i].KernelRevision < b[j].KernelRevision
+	}
+	// and last kernel command line
 	if b[i].KernelCmdline != b[j].KernelCmdline {
 		return b[i].KernelCmdline < b[j].KernelCmdline
 	}
@@ -186,5 +192,6 @@ func predictableBootChainsEqualForReseal(pb1, pb2 predictableBootChains) bool {
 	if err != nil {
 		return false
 	}
+	// TODO:UC20: return false if either chains have unasserted kernels
 	return bytes.Equal(pb1JSON, pb2JSON)
 }

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -177,7 +177,7 @@ func (s *sealSuite) TestBootChainMarshalOnlyAssets(c *C) {
 
 	d, err := json.Marshal(predictableBc)
 	c.Assert(err, IsNil)
-	c.Check(string(d), Equals, `{"model":"","brand-id":"","grade":"","model-sign-key-id":"","asset-chain":[{"role":"recovery","name":"loader","hashes":["d","e"]},{"role":"recovery","name":"shim","hashes":["b"]},{"role":"run","name":"0oader","hashes":["x","z"]},{"role":"run","name":"1oader","hashes":["d","e"]},{"role":"run","name":"loader","hashes":["z"]},{"role":"run","name":"loader","hashes":["c","d"]}],"kernel":"","kernel-revision":"","kernel-cmdline":""}`)
+	c.Check(string(d), Equals, `{"brand-id":"","model":"","grade":"","model-sign-key-id":"","asset-chain":[{"role":"recovery","name":"loader","hashes":["d","e"]},{"role":"recovery","name":"shim","hashes":["b"]},{"role":"run","name":"0oader","hashes":["x","z"]},{"role":"run","name":"1oader","hashes":["d","e"]},{"role":"run","name":"loader","hashes":["z"]},{"role":"run","name":"loader","hashes":["c","d"]}],"kernel":"","kernel-revision":"","kernel-cmdline":""}`)
 
 	// already predictable, but try again
 	alreadySortedBc := boot.ToPredictableBootChain(predictableBc)
@@ -196,8 +196,8 @@ func (s *sealSuite) TestBootChainMarshalOnlyAssets(c *C) {
 
 func (s *sealSuite) TestBootChainMarshalFull(c *C) {
 	bc := &boot.BootChain{
-		Model:          "foo",
 		BrandID:        "mybrand",
+		Model:          "foo",
 		Grade:          "dangerous",
 		ModelSignKeyID: "my-key-id",
 		// asset chain will get sorted when marshaling
@@ -215,8 +215,8 @@ func (s *sealSuite) TestBootChainMarshalFull(c *C) {
 	predictableBc := boot.ToPredictableBootChain(bc)
 
 	c.Check(predictableBc, DeepEquals, &boot.BootChain{
-		Model:          "foo",
 		BrandID:        "mybrand",
+		Model:          "foo",
 		Grade:          "dangerous",
 		ModelSignKeyID: "my-key-id",
 		// assets are sorted
@@ -233,11 +233,11 @@ func (s *sealSuite) TestBootChainMarshalFull(c *C) {
 
 	d, err := json.Marshal(predictableBc)
 	c.Assert(err, IsNil)
-	c.Check(string(d), Equals, `{"model":"foo","brand-id":"mybrand","grade":"dangerous","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"loader","hashes":["d"]},{"role":"recovery","name":"shim","hashes":["a","b"]},{"role":"run","name":"loader","hashes":["c","d"]}],"kernel":"pc-kernel","kernel-revision":"1234","kernel-cmdline":"foo=bar baz=0x123"}`)
+	c.Check(string(d), Equals, `{"brand-id":"mybrand","model":"foo","grade":"dangerous","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"loader","hashes":["d"]},{"role":"recovery","name":"shim","hashes":["a","b"]},{"role":"run","name":"loader","hashes":["c","d"]}],"kernel":"pc-kernel","kernel-revision":"1234","kernel-cmdline":"foo=bar baz=0x123"}`)
 	// original structure has not been modified
 	c.Check(bc, DeepEquals, &boot.BootChain{
-		Model:          "foo",
 		BrandID:        "mybrand",
+		Model:          "foo",
 		Grade:          "dangerous",
 		ModelSignKeyID: "my-key-id",
 		// asset chain will get sorted when marshaling
@@ -256,8 +256,8 @@ func (s *sealSuite) TestBootChainMarshalFull(c *C) {
 func (s *sealSuite) TestBootChainEqualForResealComplex(c *C) {
 	bc := []boot.BootChain{
 		{
-			Model:          "foo",
 			BrandID:        "mybrand",
+			Model:          "foo",
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
@@ -275,8 +275,8 @@ func (s *sealSuite) TestBootChainEqualForResealComplex(c *C) {
 	// sorted variant
 	pbOther := boot.PredictableBootChains{
 		{
-			Model:          "foo",
 			BrandID:        "mybrand",
+			Model:          "foo",
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
@@ -300,8 +300,8 @@ func (s *sealSuite) TestPredictableBootChainsEqualForResealSimple(c *C) {
 
 	bcJustOne := []boot.BootChain{
 		{
-			Model:          "foo",
 			BrandID:        "mybrand",
+			Model:          "foo",
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
@@ -321,8 +321,8 @@ func (s *sealSuite) TestPredictableBootChainsEqualForResealSimple(c *C) {
 
 	bcMoreAssets := []boot.BootChain{
 		{
-			Model:          "foo",
 			BrandID:        "mybrand",
+			Model:          "foo",
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
@@ -332,8 +332,8 @@ func (s *sealSuite) TestPredictableBootChainsEqualForResealSimple(c *C) {
 			KernelRevision: "1234",
 			KernelCmdline:  `foo`,
 		}, {
-			Model:          "foo",
 			BrandID:        "mybrand",
+			Model:          "foo",
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
@@ -356,8 +356,8 @@ func (s *sealSuite) TestPredictableBootChainsFullMarshal(c *C) {
 	// chains will be sorted
 	chains := []boot.BootChain{
 		{
-			Model:          "foo",
 			BrandID:        "mybrand",
+			Model:          "foo",
 			Grade:          "signed",
 			ModelSignKeyID: "my-key-id",
 			// assets will be sorted
@@ -371,8 +371,8 @@ func (s *sealSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			KernelRevision: "2345",
 			KernelCmdline:  `foo`,
 		}, {
-			Model:          "foo",
 			BrandID:        "mybrand",
+			Model:          "foo",
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			// assets will be sorted
@@ -387,8 +387,8 @@ func (s *sealSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			KernelCmdline:  `foo`,
 		}, {
 			// recovery system
-			Model:          "foo",
 			BrandID:        "mybrand",
+			Model:          "foo",
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			// will be sorted
@@ -458,8 +458,8 @@ func (s *sealSuite) TestPredictableBootChainsFields(c *C) {
 
 	justOne := []boot.BootChain{
 		{
-			Model:          "foo",
 			BrandID:        "mybrand",
+			Model:          "foo",
 			Grade:          "signed",
 			ModelSignKeyID: "my-key-id",
 			Kernel:         "pc-kernel-other",
@@ -625,23 +625,23 @@ func (s *sealSuite) TestPredictableBootChainsFields(c *C) {
 			BrandID:        "foo",
 			Model:          "box",
 			Grade:          "dangerous",
-			Kernel:         "foo",
-			KernelCmdline:  `panic=1`,
 			ModelSignKeyID: "key-1",
 			AssetChain: []boot.BootAsset{
 				// will be sorted
 				{Hashes: []string{"b", "a"}},
 			},
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
 		}, {
 			BrandID:        "foo",
 			Model:          "box",
 			Grade:          "dangerous",
-			Kernel:         "foo",
-			KernelCmdline:  `panic=1`,
 			ModelSignKeyID: "key-1",
 			AssetChain: []boot.BootAsset{
 				{Hashes: []string{"b"}},
 			},
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
 		},
 	}
 	c.Check(boot.ToPredictableBootChains(chainsAssets), DeepEquals, boot.PredictableBootChains{
@@ -649,22 +649,22 @@ func (s *sealSuite) TestPredictableBootChainsFields(c *C) {
 			BrandID:        "foo",
 			Model:          "box",
 			Grade:          "dangerous",
-			Kernel:         "foo",
-			KernelCmdline:  `panic=1`,
 			ModelSignKeyID: "key-1",
 			AssetChain: []boot.BootAsset{
 				{Hashes: []string{"b"}},
 			},
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
 		}, {
 			BrandID:        "foo",
 			Model:          "box",
 			Grade:          "dangerous",
-			Kernel:         "foo",
-			KernelCmdline:  `panic=1`,
 			ModelSignKeyID: "key-1",
 			AssetChain: []boot.BootAsset{
 				{Hashes: []string{"a", "b"}},
 			},
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
 		},
 	})
 
@@ -698,134 +698,292 @@ func (s *sealSuite) TestPredictableBootChainsFields(c *C) {
 		{
 			BrandID:        "foo",
 			Model:          "box",
-			Grade:          "dangerous",
-			Kernel:         "foo",
-			KernelCmdline:  `panic=1`,
 			ModelSignKeyID: "key-1",
 			AssetChain: []boot.BootAsset{
 				{Name: "asset", Hashes: []string{"a", "b"}},
 				{Name: "asset", Hashes: []string{"a", "b"}},
 			},
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
 		}, {
 			BrandID:        "foo",
 			Model:          "box",
 			Grade:          "dangerous",
-			Kernel:         "foo",
-			KernelCmdline:  `panic=1`,
 			ModelSignKeyID: "key-1",
 			AssetChain: []boot.BootAsset{
 				{Name: "asset", Hashes: []string{"a", "b"}},
 				{Name: "asset", Hashes: []string{"a", "b"}},
 			},
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
 		},
 	}
 	c.Check(boot.ToPredictableBootChains(chainsIdenticalAssets), DeepEquals, boot.PredictableBootChains(chainsIdenticalAssets))
 }
 
 func (s *sealSuite) TestPredictableBootChainsSortOrder(c *C) {
-	// check that sort order is assets -> kernel (name, revision) -> rest
+	// check that sort order is model info, assets, kernel, kernel cmdline
 
 	chains := []boot.BootChain{
 		{
-			Model:          "foo",
-			BrandID:        "mybrand",
-			Grade:          "signed",
-			ModelSignKeyID: "my-key-id",
-			Kernel:         "pc-kernel",
-			KernelRevision: "2345",
-			KernelCmdline:  `foo`,
+			Model: "b",
 			AssetChain: []boot.BootAsset{
-				{Name: "asset", Hashes: []string{"a", "b"}},
-				{Name: "asset", Hashes: []string{"b"}},
+				{Name: "asset", Hashes: []string{"y"}},
 			},
-		}, {
-			Model:          "foo",
-			BrandID:        "mybrand",
-			Grade:          "signed",
-			ModelSignKeyID: "my-key-id",
-			Kernel:         "pc-kernel",
-			KernelRevision: "1234",
-			KernelCmdline:  `foo`,
+			Kernel:        "k1",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "b",
 			AssetChain: []boot.BootAsset{
-				{Name: "asset", Hashes: []string{"a", "b"}},
-				{Name: "asset", Hashes: []string{"b"}},
+				{Name: "asset", Hashes: []string{"y"}},
 			},
-		}, {
-			Model:          "foo",
-			BrandID:        "mybrand",
-			Grade:          "signed",
-			ModelSignKeyID: "my-key-id",
-			Kernel:         "pc-kernel-other",
-			KernelRevision: "2345",
-			KernelCmdline:  `foo`,
+			Kernel:        "k2",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "a",
 			AssetChain: []boot.BootAsset{
-				{Name: "asset", Hashes: []string{"c", "d"}},
-				{Name: "asset", Hashes: []string{"c"}},
+				{Name: "asset", Hashes: []string{"y"}},
 			},
-		}, {
-			Model:          "foo",
-			BrandID:        "mybrand",
-			Grade:          "signed",
-			ModelSignKeyID: "my-key-id",
-			Kernel:         "pc-kernel-other",
-			KernelRevision: "1234",
-			KernelCmdline:  `foo`,
+			Kernel:        "k1",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "a",
 			AssetChain: []boot.BootAsset{
-				{Name: "asset", Hashes: []string{"c", "d"}},
-				{Name: "asset", Hashes: []string{"c"}},
+				{Name: "asset", Hashes: []string{"y"}},
 			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=2",
 		},
 	}
 	predictable := boot.ToPredictableBootChains(chains)
 	c.Check(predictable, DeepEquals, boot.PredictableBootChains{
 		{
-			Model:          "foo",
-			BrandID:        "mybrand",
-			Grade:          "signed",
-			ModelSignKeyID: "my-key-id",
-			Kernel:         "pc-kernel",
-			KernelRevision: "1234",
-			KernelCmdline:  `foo`,
+			Model: "a",
 			AssetChain: []boot.BootAsset{
-				{Name: "asset", Hashes: []string{"b"}},
-				{Name: "asset", Hashes: []string{"a", "b"}},
+				{Name: "asset", Hashes: []string{"x"}},
 			},
-		}, {
-			Model:          "foo",
-			BrandID:        "mybrand",
-			Grade:          "signed",
-			ModelSignKeyID: "my-key-id",
-			Kernel:         "pc-kernel",
-			KernelRevision: "2345",
-			KernelCmdline:  `foo`,
+			Kernel:        "k1",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "a",
 			AssetChain: []boot.BootAsset{
-				{Name: "asset", Hashes: []string{"b"}},
-				{Name: "asset", Hashes: []string{"a", "b"}},
+				{Name: "asset", Hashes: []string{"x"}},
 			},
-		}, {
-			Model:          "foo",
-			BrandID:        "mybrand",
-			Grade:          "signed",
-			ModelSignKeyID: "my-key-id",
-			Kernel:         "pc-kernel-other",
-			KernelRevision: "1234",
-			KernelCmdline:  `foo`,
+			Kernel:        "k1",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "a",
 			AssetChain: []boot.BootAsset{
-				{Name: "asset", Hashes: []string{"c"}},
-				{Name: "asset", Hashes: []string{"c", "d"}},
+				{Name: "asset", Hashes: []string{"x"}},
 			},
-		}, {
-			Model:          "foo",
-			BrandID:        "mybrand",
-			Grade:          "signed",
-			ModelSignKeyID: "my-key-id",
-			Kernel:         "pc-kernel-other",
-			KernelRevision: "2345",
-			KernelCmdline:  `foo`,
+			Kernel:        "k2",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "a",
 			AssetChain: []boot.BootAsset{
-				{Name: "asset", Hashes: []string{"c"}},
-				{Name: "asset", Hashes: []string{"c", "d"}},
+				{Name: "asset", Hashes: []string{"x"}},
 			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "a",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"x"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k1",
+			KernelCmdline: "cm=2",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=1",
+		},
+		{
+			Model: "b",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"y"}},
+			},
+			Kernel:        "k2",
+			KernelCmdline: "cm=2",
 		},
 	})
 }

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -1,0 +1,699 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot_test
+
+import (
+	"encoding/json"
+	"sort"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type bootchainSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&bootchainSuite{})
+
+func (s *sealSuite) TestBootAssetsSort(c *C) {
+	// by role
+	d := []boot.BootAsset{
+		{Role: "run", Name: "1ist", Hashes: []string{"b", "c"}},
+		{Role: "recovery", Name: "1ist", Hashes: []string{"b", "c"}},
+	}
+	sort.Sort(boot.ByBootAssetOrder(d))
+	c.Check(d, DeepEquals, []boot.BootAsset{
+		{Role: "recovery", Name: "1ist", Hashes: []string{"b", "c"}},
+		{Role: "run", Name: "1ist", Hashes: []string{"b", "c"}},
+	})
+
+	// by name
+	d = []boot.BootAsset{
+		{Role: "recovery", Name: "shim", Hashes: []string{"d", "e"}},
+		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
+	}
+	sort.Sort(boot.ByBootAssetOrder(d))
+	c.Check(d, DeepEquals, []boot.BootAsset{
+		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
+		{Role: "recovery", Name: "shim", Hashes: []string{"d", "e"}},
+	})
+
+	// by hash list length
+	d = []boot.BootAsset{
+		{Role: "run", Name: "1ist", Hashes: []string{"a", "f"}},
+		{Role: "run", Name: "1ist", Hashes: []string{"d"}},
+	}
+	sort.Sort(boot.ByBootAssetOrder(d))
+	c.Check(d, DeepEquals, []boot.BootAsset{
+		{Role: "run", Name: "1ist", Hashes: []string{"d"}},
+		{Role: "run", Name: "1ist", Hashes: []string{"a", "f"}},
+	})
+
+	// hash list entries
+	d = []boot.BootAsset{
+		{Role: "run", Name: "1ist", Hashes: []string{"b", "d"}},
+		{Role: "run", Name: "1ist", Hashes: []string{"b", "c"}},
+	}
+	sort.Sort(boot.ByBootAssetOrder(d))
+	c.Check(d, DeepEquals, []boot.BootAsset{
+		{Role: "run", Name: "1ist", Hashes: []string{"b", "c"}},
+		{Role: "run", Name: "1ist", Hashes: []string{"b", "d"}},
+	})
+
+	d = []boot.BootAsset{
+		{Role: "run", Name: "loader", Hashes: []string{"z"}},
+		{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
+		{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+		{Role: "run", Name: "1oader", Hashes: []string{"d", "e"}},
+		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
+		{Role: "run", Name: "0oader", Hashes: []string{"x", "z"}},
+	}
+	sort.Sort(boot.ByBootAssetOrder(d))
+	c.Check(d, DeepEquals, []boot.BootAsset{
+		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
+		{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
+		{Role: "run", Name: "0oader", Hashes: []string{"x", "z"}},
+		{Role: "run", Name: "1oader", Hashes: []string{"d", "e"}},
+		{Role: "run", Name: "loader", Hashes: []string{"z"}},
+		{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+	})
+
+	// d is already sorted, sort it again
+	sort.Sort(boot.ByBootAssetOrder(d))
+	// still the same
+	c.Check(d, DeepEquals, []boot.BootAsset{
+		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
+		{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
+		{Role: "run", Name: "0oader", Hashes: []string{"x", "z"}},
+		{Role: "run", Name: "1oader", Hashes: []string{"d", "e"}},
+		{Role: "run", Name: "loader", Hashes: []string{"z"}},
+		{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+	})
+
+	// 2 identical entries
+	d = []boot.BootAsset{
+		{Role: "run", Name: "loader", Hashes: []string{"x", "z"}},
+		{Role: "run", Name: "loader", Hashes: []string{"x", "z"}},
+	}
+	sort.Sort(boot.ByBootAssetOrder(d))
+	c.Check(d, DeepEquals, []boot.BootAsset{
+		{Role: "run", Name: "loader", Hashes: []string{"x", "z"}},
+		{Role: "run", Name: "loader", Hashes: []string{"x", "z"}},
+	})
+
+}
+
+func (s *sealSuite) TestBootAssetsPredictable(c *C) {
+	// by role
+	ba := boot.BootAsset{
+		Role: "run", Name: "list", Hashes: []string{"b", "a"},
+	}
+	pred := boot.ToPredictableBootAsset(&ba)
+	c.Check(pred, DeepEquals, &boot.BootAsset{
+		Role: "run", Name: "list", Hashes: []string{"a", "b"},
+	})
+	// original structure is not changed
+	c.Check(ba, DeepEquals, boot.BootAsset{
+		Role: "run", Name: "list", Hashes: []string{"b", "a"},
+	})
+
+	// try to make a predictable struct predictable once more
+	predAgain := boot.ToPredictableBootAsset(pred)
+	c.Check(predAgain, DeepEquals, pred)
+}
+
+func (s *sealSuite) TestBootChainMarshalOnlyAssets(c *C) {
+	bc := &boot.BootChain{
+		AssetChain: []boot.BootAsset{
+			{Role: "run", Name: "loader", Hashes: []string{"z"}},
+			{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
+			{Role: "run", Name: "loader", Hashes: []string{"d", "c"}},
+			{Role: "run", Name: "1oader", Hashes: []string{"e", "d"}},
+			{Role: "recovery", Name: "loader", Hashes: []string{"e", "d"}},
+			{Role: "run", Name: "0oader", Hashes: []string{"z", "x"}},
+		},
+	}
+
+	predictableBc := boot.ToPredictableBootChain(bc)
+
+	c.Check(predictableBc, DeepEquals, &boot.BootChain{
+		// assets are sorted
+		AssetChain: []boot.BootAsset{
+			// hash lists are sorted
+			{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
+			{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
+			{Role: "run", Name: "0oader", Hashes: []string{"x", "z"}},
+			{Role: "run", Name: "1oader", Hashes: []string{"d", "e"}},
+			{Role: "run", Name: "loader", Hashes: []string{"z"}},
+			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+		},
+	})
+
+	d, err := json.Marshal(predictableBc)
+	c.Assert(err, IsNil)
+	c.Check(string(d), Equals, `{"model":"","brand-id":"","grade":"","model-sign-key-id":"","asset-chain":[{"role":"recovery","name":"loader","hashes":["d","e"]},{"role":"recovery","name":"shim","hashes":["b"]},{"role":"run","name":"0oader","hashes":["x","z"]},{"role":"run","name":"1oader","hashes":["d","e"]},{"role":"run","name":"loader","hashes":["z"]},{"role":"run","name":"loader","hashes":["c","d"]}],"kernel":"","kernel-revision":"","kernel-cmdline":""}`)
+
+	// already predictable, but try again
+	alreadySortedBc := boot.ToPredictableBootChain(predictableBc)
+	c.Check(alreadySortedBc, DeepEquals, predictableBc)
+
+	// boot chain with 2 identical assets
+	bcIdenticalAssets := &boot.BootChain{
+		AssetChain: []boot.BootAsset{
+			{Role: "run", Name: "loader", Hashes: []string{"z"}},
+			{Role: "run", Name: "loader", Hashes: []string{"z"}},
+		},
+	}
+	sortedBcIdentical := boot.ToPredictableBootChain(bcIdenticalAssets)
+	c.Check(sortedBcIdentical, DeepEquals, bcIdenticalAssets)
+}
+
+func (s *sealSuite) TestBootChainMarshalFull(c *C) {
+	bc := &boot.BootChain{
+		Model:          "foo",
+		BrandID:        "mybrand",
+		Grade:          "dangerous",
+		ModelSignKeyID: "my-key-id",
+		// asset chain will get sorted when marshaling
+		AssetChain: []boot.BootAsset{
+			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+			// hash list will get sorted
+			{Role: "recovery", Name: "shim", Hashes: []string{"b", "a"}},
+			{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1234",
+		KernelCmdline:  `foo=bar baz=0x123`,
+	}
+
+	predictableBc := boot.ToPredictableBootChain(bc)
+
+	c.Check(predictableBc, DeepEquals, &boot.BootChain{
+		Model:          "foo",
+		BrandID:        "mybrand",
+		Grade:          "dangerous",
+		ModelSignKeyID: "my-key-id",
+		// assets are sorted
+		AssetChain: []boot.BootAsset{
+			{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+			// hash lists are sorted
+			{Role: "recovery", Name: "shim", Hashes: []string{"a", "b"}},
+			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1234",
+		KernelCmdline:  `foo=bar baz=0x123`,
+	})
+
+	d, err := json.Marshal(predictableBc)
+	c.Assert(err, IsNil)
+	c.Check(string(d), Equals, `{"model":"foo","brand-id":"mybrand","grade":"dangerous","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"loader","hashes":["d"]},{"role":"recovery","name":"shim","hashes":["a","b"]},{"role":"run","name":"loader","hashes":["c","d"]}],"kernel":"pc-kernel","kernel-revision":"1234","kernel-cmdline":"foo=bar baz=0x123"}`)
+	// original structure has not been modified
+	c.Check(bc, DeepEquals, &boot.BootChain{
+		Model:          "foo",
+		BrandID:        "mybrand",
+		Grade:          "dangerous",
+		ModelSignKeyID: "my-key-id",
+		// asset chain will get sorted when marshaling
+		AssetChain: []boot.BootAsset{
+			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+			// hash list will get sorted
+			{Role: "recovery", Name: "shim", Hashes: []string{"b", "a"}},
+			{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1234",
+		KernelCmdline:  `foo=bar baz=0x123`,
+	})
+}
+
+func (s *sealSuite) TestBootChainEqualForResealComplex(c *C) {
+	bc := &boot.BootChain{
+		Model:          "foo",
+		BrandID:        "mybrand",
+		Grade:          "dangerous",
+		ModelSignKeyID: "my-key-id",
+		AssetChain: []boot.BootAsset{
+			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+			// hash list will get sorted
+			{Role: "recovery", Name: "shim", Hashes: []string{"b", "a"}},
+			{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1234",
+		KernelCmdline:  `foo=bar baz=0x123`,
+	}
+	// sorted variant
+	bcOther := &boot.BootChain{
+		Model:          "foo",
+		BrandID:        "mybrand",
+		Grade:          "dangerous",
+		ModelSignKeyID: "my-key-id",
+		AssetChain: []boot.BootAsset{
+			{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+			{Role: "recovery", Name: "shim", Hashes: []string{"a", "b"}},
+			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1234",
+		KernelCmdline:  `foo=bar baz=0x123`,
+	}
+
+	eq := bc.EqualForReseal(bcOther)
+	c.Check(eq, Equals, true, Commentf("not equal\none: %v\nother: %v", bc, bcOther))
+	// original structure is unodified
+	c.Check(bc, DeepEquals, &boot.BootChain{
+		Model:          "foo",
+		BrandID:        "mybrand",
+		Grade:          "dangerous",
+		ModelSignKeyID: "my-key-id",
+		AssetChain: []boot.BootAsset{
+			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+			// hash list will get sorted
+			{Role: "recovery", Name: "shim", Hashes: []string{"b", "a"}},
+			{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1234",
+		KernelCmdline:  `foo=bar baz=0x123`,
+	})
+}
+
+func (s *sealSuite) TestBootChainEqualForResealSimple(c *C) {
+	var bcNil *boot.BootChain
+
+	bc := &boot.BootChain{
+		Model:          "foo",
+		BrandID:        "mybrand",
+		Grade:          "dangerous",
+		ModelSignKeyID: "my-key-id",
+		AssetChain: []boot.BootAsset{
+			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+		},
+		Kernel:         "pc-kernel-other",
+		KernelRevision: "1234",
+		KernelCmdline:  `foo`,
+	}
+	c.Check(bc.EqualForReseal(bc), Equals, true)
+
+	c.Check(bc.EqualForReseal(bcNil), Equals, false)
+	c.Check(bcNil.EqualForReseal(bc), Equals, false)
+
+	c.Check(bcNil.EqualForReseal(nil), Equals, true)
+
+	bcOtherGrade := &boot.BootChain{
+		Model:          "foo",
+		BrandID:        "mybrand",
+		Grade:          "signed",
+		ModelSignKeyID: "my-key-id",
+		AssetChain: []boot.BootAsset{
+			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+		},
+		Kernel:         "pc-kernel-other",
+		KernelRevision: "1234",
+		KernelCmdline:  `foo`,
+	}
+	c.Check(bcOtherGrade.EqualForReseal(bc), Equals, false)
+	c.Check(bc.EqualForReseal(bcOtherGrade), Equals, false)
+
+	bcOtherAssets := &boot.BootChain{
+		Model:          "foo",
+		BrandID:        "mybrand",
+		Grade:          "signed",
+		ModelSignKeyID: "my-key-id",
+		AssetChain: []boot.BootAsset{
+			// one asset hash differs
+			{Role: "run", Name: "loader", Hashes: []string{"c", "f"}},
+		},
+		Kernel:         "pc-kernel-other",
+		KernelRevision: "1234",
+		KernelCmdline:  `foo`,
+	}
+	c.Check(bcOtherAssets.EqualForReseal(bc), Equals, false)
+	c.Check(bc.EqualForReseal(bcOtherAssets), Equals, false)
+}
+
+func (s *sealSuite) TestPredictableBootChainsFullMarshal(c *C) {
+	// chains will be sorted
+	chains := []boot.BootChain{
+		{
+			Model:          "foo",
+			BrandID:        "mybrand",
+			Grade:          "signed",
+			ModelSignKeyID: "my-key-id",
+			// assets will be sorted
+			AssetChain: []boot.BootAsset{
+				// hashes will be sorted
+				{Role: "recovery", Name: "shim", Hashes: []string{"x", "y"}},
+				{Role: "recovery", Name: "loader", Hashes: []string{"c", "d"}},
+				{Role: "run", Name: "loader", Hashes: []string{"z", "x"}},
+			},
+			Kernel:         "pc-kernel-other",
+			KernelRevision: "2345",
+			KernelCmdline:  `foo`,
+		}, {
+			Model:          "foo",
+			BrandID:        "mybrand",
+			Grade:          "dangerous",
+			ModelSignKeyID: "my-key-id",
+			// assets will be sorted
+			AssetChain: []boot.BootAsset{
+				// hashes will be sorted
+				{Role: "recovery", Name: "shim", Hashes: []string{"y", "x"}},
+				{Role: "recovery", Name: "loader", Hashes: []string{"c", "d"}},
+				{Role: "run", Name: "loader", Hashes: []string{"b", "a"}},
+			},
+			Kernel:         "pc-kernel-other",
+			KernelRevision: "1234",
+			KernelCmdline:  `foo`,
+		}, {
+			// recovery system
+			Model:          "foo",
+			BrandID:        "mybrand",
+			Grade:          "dangerous",
+			ModelSignKeyID: "my-key-id",
+			// will be sorted
+			AssetChain: []boot.BootAsset{
+				{Role: "recovery", Name: "shim", Hashes: []string{"y", "x"}},
+				{Role: "recovery", Name: "loader", Hashes: []string{"c", "d"}},
+			},
+			Kernel:         "pc-kernel-other",
+			KernelRevision: "12",
+			KernelCmdline:  `foo`,
+		},
+	}
+
+	predictableChains := boot.ToPredictableBootChains(chains)
+	d, err := json.Marshal(predictableChains)
+	c.Assert(err, IsNil)
+
+	var data []map[string]interface{}
+	err = json.Unmarshal(d, &data)
+	c.Assert(err, IsNil)
+	c.Check(data, DeepEquals, []map[string]interface{}{
+		{
+			"model":             "foo",
+			"brand-id":          "mybrand",
+			"grade":             "dangerous",
+			"model-sign-key-id": "my-key-id",
+			"kernel":            "pc-kernel-other",
+			"kernel-revision":   "12",
+			"kernel-cmdline":    "foo",
+			"asset-chain": []interface{}{
+				map[string]interface{}{"role": "recovery", "name": "loader", "hashes": []interface{}{"c", "d"}},
+				map[string]interface{}{"role": "recovery", "name": "shim", "hashes": []interface{}{"x", "y"}},
+			},
+		}, {
+			"model":             "foo",
+			"brand-id":          "mybrand",
+			"grade":             "dangerous",
+			"model-sign-key-id": "my-key-id",
+			"kernel":            "pc-kernel-other",
+			"kernel-revision":   "1234",
+			"kernel-cmdline":    "foo",
+			"asset-chain": []interface{}{
+				map[string]interface{}{"role": "recovery", "name": "loader", "hashes": []interface{}{"c", "d"}},
+				map[string]interface{}{"role": "recovery", "name": "shim", "hashes": []interface{}{"x", "y"}},
+				map[string]interface{}{"role": "run", "name": "loader", "hashes": []interface{}{"a", "b"}},
+			},
+		}, {
+			"model":             "foo",
+			"brand-id":          "mybrand",
+			"grade":             "signed",
+			"model-sign-key-id": "my-key-id",
+			"kernel":            "pc-kernel-other",
+			"kernel-revision":   "2345",
+			"kernel-cmdline":    "foo",
+			"asset-chain": []interface{}{
+				map[string]interface{}{"role": "recovery", "name": "loader", "hashes": []interface{}{"c", "d"}},
+				map[string]interface{}{"role": "recovery", "name": "shim", "hashes": []interface{}{"x", "y"}},
+				map[string]interface{}{"role": "run", "name": "loader", "hashes": []interface{}{"x", "z"}},
+			},
+		},
+	})
+}
+
+func (s *sealSuite) TestPredictableBootChainsFields(c *C) {
+	chainsNil := boot.ToPredictableBootChains(nil)
+	c.Check(chainsNil, IsNil)
+
+	justOne := []boot.BootChain{
+		{
+			Model:          "foo",
+			BrandID:        "mybrand",
+			Grade:          "signed",
+			ModelSignKeyID: "my-key-id",
+			Kernel:         "pc-kernel-other",
+			KernelRevision: "2345",
+			KernelCmdline:  `foo`,
+		},
+	}
+	predictableJustOne := boot.ToPredictableBootChains(justOne)
+	c.Check(predictableJustOne, DeepEquals, justOne)
+
+	chainsGrade := []boot.BootChain{
+		{
+			Grade: "signed",
+		}, {
+			Grade: "dangerous",
+		},
+	}
+	c.Check(boot.ToPredictableBootChains(chainsGrade), DeepEquals, []boot.BootChain{
+		{
+			Grade: "dangerous",
+		}, {
+			Grade: "signed",
+		},
+	})
+
+	chainsKernel := []boot.BootChain{
+		{
+			Grade:  "dangerous",
+			Kernel: "foo",
+		}, {
+			Grade:  "dangerous",
+			Kernel: "bar",
+		},
+	}
+	c.Check(boot.ToPredictableBootChains(chainsKernel), DeepEquals, []boot.BootChain{
+		{
+			Grade:  "dangerous",
+			Kernel: "bar",
+		}, {
+			Grade:  "dangerous",
+			Kernel: "foo",
+		},
+	})
+
+	chainsCmdline := []boot.BootChain{
+		{
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		}, {
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `a`,
+		},
+	}
+	c.Check(boot.ToPredictableBootChains(chainsCmdline), DeepEquals, []boot.BootChain{
+		{
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `a`,
+		}, {
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		},
+	})
+
+	chainsModel := []boot.BootChain{
+		{
+			Model:         "fridge",
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		}, {
+			Model:         "box",
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		},
+	}
+	c.Check(boot.ToPredictableBootChains(chainsModel), DeepEquals, []boot.BootChain{
+		{
+			Model:         "box",
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		}, {
+			Model:         "fridge",
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		},
+	})
+
+	chainsBrand := []boot.BootChain{
+		{
+			BrandID:       "foo",
+			Model:         "box",
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		}, {
+			BrandID:       "acme",
+			Model:         "box",
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		},
+	}
+	c.Check(boot.ToPredictableBootChains(chainsBrand), DeepEquals, []boot.BootChain{
+		{
+			BrandID:       "acme",
+			Model:         "box",
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		}, {
+			BrandID:       "foo",
+			Model:         "box",
+			Grade:         "dangerous",
+			Kernel:        "foo",
+			KernelCmdline: `panic=1`,
+		},
+	})
+
+	chainsKeyID := []boot.BootChain{
+		{
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-2",
+		}, {
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-1",
+		},
+	}
+	c.Check(boot.ToPredictableBootChains(chainsKeyID), DeepEquals, []boot.BootChain{
+		{
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-1",
+		}, {
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-2",
+		},
+	})
+
+	chainsAssets := []boot.BootChain{
+		{
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-1",
+			AssetChain: []boot.BootAsset{
+				// will be sorted
+				{Hashes: []string{"b", "a"}},
+			},
+		}, {
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-1",
+			AssetChain: []boot.BootAsset{
+				{Hashes: []string{"b"}},
+			},
+		},
+	}
+	c.Check(boot.ToPredictableBootChains(chainsAssets), DeepEquals, []boot.BootChain{
+		{
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-1",
+			AssetChain: []boot.BootAsset{
+				{Hashes: []string{"b"}},
+			},
+		}, {
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-1",
+			AssetChain: []boot.BootAsset{
+				{Hashes: []string{"a", "b"}},
+			},
+		},
+	})
+
+	// not confused if 2 chains are identical
+	chainsIdenticalAssets := []boot.BootChain{
+		{
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-1",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"a", "b"}},
+				{Name: "asset", Hashes: []string{"a", "b"}},
+			},
+		}, {
+			BrandID:        "foo",
+			Model:          "box",
+			Grade:          "dangerous",
+			Kernel:         "foo",
+			KernelCmdline:  `panic=1`,
+			ModelSignKeyID: "key-1",
+			AssetChain: []boot.BootAsset{
+				{Name: "asset", Hashes: []string{"a", "b"}},
+				{Name: "asset", Hashes: []string{"a", "b"}},
+			},
+		},
+	}
+	c.Check(boot.ToPredictableBootChains(chainsIdenticalAssets), DeepEquals, chainsIdenticalAssets)
+}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -90,13 +90,11 @@ func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash
 type BootAsset = bootAsset
 type BootChain = bootChain
 type ByBootAssetOrder = byBootAssetOrder
-
-func (b *BootChain) EqualForReseal(other *BootChain) bool {
-	return b.equalForReseal(other)
-}
+type PredictableBootChains = predictableBootChains
 
 var (
-	ToPredictableBootAsset  = toPredictableBootAsset
-	ToPredictableBootChain  = toPredictableBootChain
-	ToPredictableBootChains = toPredictableBootChains
+	ToPredictableBootAsset              = toPredictableBootAsset
+	ToPredictableBootChain              = toPredictableBootChain
+	ToPredictableBootChains             = toPredictableBootChains
+	PredictableBootChainsEqualForReseal = predictableBootChainsEqualForReseal
 )

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -86,3 +86,17 @@ func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash
 		o.seedChangedAssets = append(o.seedChangedAssets, ta)
 	}
 }
+
+type BootAsset = bootAsset
+type BootChain = bootChain
+type ByBootAssetOrder = byBootAssetOrder
+
+func (b *BootChain) EqualForReseal(other *BootChain) bool {
+	return b.equalForReseal(other)
+}
+
+var (
+	ToPredictableBootAsset  = toPredictableBootAsset
+	ToPredictableBootChain  = toPredictableBootChain
+	ToPredictableBootChains = toPredictableBootChains
+)


### PR DESCRIPTION
Add a data structure representing a boot chain, composed of system properties,
boot assets and kernel.

Prerequisite for #9287  and #9278 