### PR TITLE
tests/core/uc20-recovery: fix check for at least specific calls to mock-shutdown

### DIFF
--- a/tests/core/uc20-recovery/mock-shutdown
+++ b/tests/core/uc20-recovery/mock-shutdown
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
-echo "$*" >> /tmp/mock-shutdown.calls
+# only save calls with "-r" for actual shutdowns, because on uc20, shutdown is a
+# symlink to systemctl, so we also see calls like `systemctl stop serial-getty@ttyS0`
+# that would show up in the mock-shutdown.calls and confuse the test
+if [ "$1" = "-r" ]; then
+    echo "$*" >> /tmp/mock-shutdown.calls
+fi
 
 exit 0

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -37,10 +37,12 @@ execute: |
             MATCH '"system-restart"'
 
         # snapd schedules a slow timeout and an immediate one, however it is
-        # scheduled asynchronously, try keep the check simple
+        # scheduled asynchronously, try to keep the check simple
         # shellcheck disable=SC2016
         retry -n 30 --wait 1 sh -c 'test "$(wc -l < /tmp/mock-shutdown.calls)" = "2"'
-        # an immediate reboot should have been scheduled
+        # a reboot in 10 minutes should have been scheduled
+        MATCH -- '-r \+10' < /tmp/mock-shutdown.calls
+        # and an immediate reboot should have been scheduled
         MATCH -- '-r \+0' < /tmp/mock-shutdown.calls
 
         # restore shutdown so that spread can reboot the host
@@ -154,7 +156,9 @@ execute: |
         # see earlier note about shutdown
         # shellcheck disable=SC2016
         retry -n 30 --wait 1 sh -c 'test "$(wc -l < /tmp/mock-shutdown.calls)" = "2"'
-        # an immediate reboot should have been scheduled
+        # a reboot in 10 minutes should have been scheduled
+        MATCH -- '-r \+10' < /tmp/mock-shutdown.calls
+        # and an immediate reboot should have been scheduled
         MATCH -- '-r \+0' < /tmp/mock-shutdown.calls
 
         umount /usr/sbin/shutdown


### PR DESCRIPTION
The lines in the script currently actually look like:

```
+ cat /tmp/mock-shutdown.calls
-r +10 reboot scheduled to update the system
stop serial-getty@ttyS0
stop getty@tty1
-r +0 reboot scheduled to update the system
```

because on uc20 /usr/sbin/shutdown is a symlink to /bin/systemctl, so when we 
mount on top of it, we also end up mounting on top of /bin/systemctl because we
are mounting on top of a symlink. 

Thus, we only save invocations of mock-shutdown that start with "-r" to indicate
that a reboot was requested, and we then check for specifically the two reboots
that we expect to have been called.
