### PR TITLE
boot: build bootchains data for sealing

### DIFF
--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -23,6 +23,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"sort"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/bootloader"
 )
 
 // TODO:UC20 add a doc comment when this is stabilized
@@ -37,6 +40,9 @@ type bootChain struct {
 	// kernel is unasserted, in which case always reseal.
 	KernelRevision string `json:"kernel-revision"`
 	KernelCmdline  string `json:"kernel-cmdline"`
+	model          *asserts.Model
+	kernelBootFile bootloader.BootFile
+	blName         string
 }
 
 // TODO:UC20 add a doc comment when this is stabilized

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -58,9 +58,9 @@ var (
 
 	NewTrustedAssetsCache = newTrustedAssetsCache
 
-	ObserveSuccessfulBootWithAssets = observeSuccessfulBootAssets
-	SealKeyToModeenv                = sealKeyToModeenv
-	BuildRecoveryBootChain          = buildRecoveryBootChain
+	ObserveSuccessfulBootWithAssets   = observeSuccessfulBootAssets
+	SealKeyToModeenv                  = sealKeyToModeenv
+	BuildRecoveryBootChainsForSystems = buildRecoveryBootChainsForSystems
 )
 
 type BootAssetsMap = bootAssetsMap

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -60,6 +60,7 @@ var (
 
 	ObserveSuccessfulBootWithAssets = observeSuccessfulBootAssets
 	SealKeyToModeenv                = sealKeyToModeenv
+	BuildRecoveryBootChain          = buildRecoveryBootChain
 )
 
 type BootAssetsMap = bootAssetsMap

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -20,8 +20,11 @@
 package boot
 
 import (
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/timings"
 )
 
 func NewCoreBootParticipant(s snap.PlaceInfo, t snap.Type, dev Device) *coreBootParticipant {
@@ -71,6 +74,14 @@ func MockSecbootSealKey(f func(key secboot.EncryptionKey, params *secboot.SealKe
 	secbootSealKey = f
 	return func() {
 		secbootSealKey = old
+	}
+}
+
+func MockSeedReadSystemEssential(f func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error)) (restore func()) {
+	old := seedReadSystemEssential
+	seedReadSystemEssential = f
+	return func() {
+		seedReadSystemEssential = old
 	}
 }
 

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -38,10 +38,12 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timings"
 )
 
 type makeBootableSuite struct {
@@ -451,25 +453,57 @@ version: 5.0
 	}
 	obs.ChosenEncryptionKey(myKey)
 
+	// set a mock recovery kernel
+	readSystemEssentialCalls := 0
+	restore = boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
+		readSystemEssentialCalls++
+		kernelSnap := &seed.Snap{
+			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
+			SideInfo: &snap.SideInfo{
+				Revision: snap.Revision{N: 0},
+			},
+		}
+		return model, []*seed.Snap{kernelSnap}, nil
+	})
+	defer restore()
+
 	// set mock key sealing
 	sealKeyCalls := 0
 	restore = boot.MockSecbootSealKey(func(key secboot.EncryptionKey, params *secboot.SealKeyParams) error {
 		sealKeyCalls++
 		c.Check(key, DeepEquals, myKey)
-		c.Assert(params.ModelParams, HasLen, 1)
+		c.Assert(params.ModelParams, HasLen, 2)
 		c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
 		c.Assert(params.ModelParams[0].EFILoadChains, DeepEquals, [][]bootloader.BootFile{
-			// run mode load sequence
 			{
-				bootloader.NewBootFile("", filepath.Join(rootdir, "run/mnt/ubuntu-seed/EFI/boot/bootx64.efi"), bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir, "run/mnt/ubuntu-seed/EFI/boot/grubx64.efi"), bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir, "run/mnt/ubuntu-boot/EFI/boot/grubx64.efi"), bootloader.RoleRunMode),
-				bootloader.NewBootFile("", filepath.Join(rootdir, "run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi"), bootloader.RoleRunMode),
+				bootloader.NewBootFile("", filepath.Join(rootdir,
+					"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
+					bootloader.RoleRecovery),
+				bootloader.NewBootFile("", filepath.Join(rootdir,
+					"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
+					bootloader.RoleRecovery),
+				bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery),
 			},
 		})
 		c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
-			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
 			"snapd_recovery_mode=recover snapd_recovery_system=20191216 console=ttyS0 console=tty1 panic=-1",
+		})
+		c.Assert(params.ModelParams[1].EFILoadChains, DeepEquals, [][]bootloader.BootFile{
+			{
+				bootloader.NewBootFile("", filepath.Join(rootdir,
+					"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
+					bootloader.RoleRecovery),
+				bootloader.NewBootFile("", filepath.Join(rootdir,
+					"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
+					bootloader.RoleRecovery),
+				bootloader.NewBootFile("", filepath.Join(rootdir,
+					"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
+					bootloader.RoleRunMode),
+				bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
+			},
+		})
+		c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
+			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
 		})
 		return nil
 	})
@@ -741,26 +775,27 @@ version: 5.0
 	}
 	obs.ChosenEncryptionKey(myKey)
 
+	// set a mock recovery kernel
+	readSystemEssentialCalls := 0
+	restore = boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
+		readSystemEssentialCalls++
+		kernelSnap := &seed.Snap{
+			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
+			SideInfo: &snap.SideInfo{
+				Revision: snap.Revision{N: 0},
+			},
+		}
+		return model, []*seed.Snap{kernelSnap}, nil
+	})
+	defer restore()
+
 	// set mock key sealing
 	sealKeyCalls := 0
 	restore = boot.MockSecbootSealKey(func(key secboot.EncryptionKey, params *secboot.SealKeyParams) error {
 		sealKeyCalls++
 		c.Check(key, DeepEquals, myKey)
-		c.Assert(params.ModelParams, HasLen, 1)
+		c.Assert(params.ModelParams, HasLen, 2)
 		c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
-		c.Assert(params.ModelParams[0].EFILoadChains, DeepEquals, [][]bootloader.BootFile{
-			// run mode load sequence
-			{
-				bootloader.NewBootFile("", filepath.Join(rootdir, "run/mnt/ubuntu-seed/EFI/boot/bootx64.efi"), bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir, "run/mnt/ubuntu-seed/EFI/boot/grubx64.efi"), bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir, "run/mnt/ubuntu-boot/EFI/boot/grubx64.efi"), bootloader.RoleRunMode),
-				bootloader.NewBootFile("", filepath.Join(rootdir, "run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi"), bootloader.RoleRunMode),
-			},
-		})
-		c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
-			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
-			"snapd_recovery_mode=recover snapd_recovery_system=20191216 console=ttyS0 console=tty1 panic=-1",
-		})
 		return fmt.Errorf("seal error")
 	})
 	defer restore()

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -463,10 +463,10 @@ version: 5.0
 
 		bfs := bootFiles(c, params.ModelParams[0].EFILoadChains)
 		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
 				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
 				bootloader.RoleRecovery),
 			bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery),
@@ -477,16 +477,16 @@ version: 5.0
 
 		bfs = bootFiles(c, params.ModelParams[1].EFILoadChains)
 		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
 				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
 				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
 				bootloader.RoleRunMode),
-			bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
+			bootloader.NewBootFile(filepath.Join(s.rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
 		})
 		c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
@@ -781,10 +781,10 @@ version: 5.0
 
 		bfs := bootFiles(c, params.ModelParams[0].EFILoadChains)
 		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
 				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
 				bootloader.RoleRecovery),
 			bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery),
@@ -795,16 +795,16 @@ version: 5.0
 
 		bfs = bootFiles(c, params.ModelParams[1].EFILoadChains)
 		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
 				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
 				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(rootdir,
+			bootloader.NewBootFile("", filepath.Join(s.rootdir,
 				"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
 				bootloader.RoleRunMode),
-			bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
+			bootloader.NewBootFile(filepath.Join(s.rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
 		})
 		c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -447,6 +447,7 @@ version: 5.0
 			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 			SideInfo: &snap.SideInfo{
 				Revision: snap.Revision{N: 0},
+				RealName: "pc-kernel",
 			},
 		}
 		return model, []*seed.Snap{kernelSnap}, nil
@@ -765,6 +766,7 @@ version: 5.0
 			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 			SideInfo: &snap.SideInfo{
 				Revision: snap.Revision{N: 0},
+				RealName: "pc-kernel",
 			},
 		}
 		return model, []*seed.Snap{kernelSnap}, nil

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -459,38 +459,38 @@ version: 5.0
 		sealKeyCalls++
 		c.Check(key, DeepEquals, myKey)
 		c.Assert(params.ModelParams, HasLen, 2)
-		c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
 
-		bfs := bootFiles(c, params.ModelParams[0].EFILoadChains)
-		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
-				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
-				bootloader.RoleRecovery),
-			bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery),
+		// recovery parameters
+		shim := bootloader.NewBootFile("", filepath.Join(s.rootdir,
+			"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
+			bootloader.RoleRecovery)
+		grub := bootloader.NewBootFile("", filepath.Join(s.rootdir,
+			"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
+			bootloader.RoleRecovery)
+		kernel := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
+
+		c.Assert(params.ModelParams[0].EFILoadChains, DeepEquals, []*secboot.LoadChain{
+			secboot.NewLoadChain(shim, secboot.NewLoadChain(grub, secboot.NewLoadChain(kernel))),
 		})
 		c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=recover snapd_recovery_system=20191216 console=ttyS0 console=tty1 panic=-1",
 		})
+		c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
 
-		bfs = bootFiles(c, params.ModelParams[1].EFILoadChains)
-		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
-				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
-				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
-				bootloader.RoleRunMode),
-			bootloader.NewBootFile(filepath.Join(s.rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
+		// run mode parameters
+		runGrub := bootloader.NewBootFile("", filepath.Join(s.rootdir,
+			"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
+			bootloader.RoleRunMode)
+		runKernel := bootloader.NewBootFile(filepath.Join(s.rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode)
+
+		c.Assert(params.ModelParams[1].EFILoadChains, DeepEquals, []*secboot.LoadChain{
+			secboot.NewLoadChain(shim, secboot.NewLoadChain(grub, secboot.NewLoadChain(runGrub, secboot.NewLoadChain(runKernel)))),
 		})
 		c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
 		})
+		c.Assert(params.ModelParams[1].Model.DisplayName(), Equals, "My Model")
+
 		return nil
 	})
 	defer restore()
@@ -779,36 +779,37 @@ version: 5.0
 		c.Assert(params.ModelParams, HasLen, 2)
 		c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
 
-		bfs := bootFiles(c, params.ModelParams[0].EFILoadChains)
-		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
-				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
-				bootloader.RoleRecovery),
-			bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery),
+		// recovery parameters
+		shim := bootloader.NewBootFile("", filepath.Join(s.rootdir,
+			"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
+			bootloader.RoleRecovery)
+		grub := bootloader.NewBootFile("", filepath.Join(s.rootdir,
+			"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
+			bootloader.RoleRecovery)
+		kernel := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
+
+		c.Assert(params.ModelParams[0].EFILoadChains, DeepEquals, []*secboot.LoadChain{
+			secboot.NewLoadChain(shim, secboot.NewLoadChain(grub, secboot.NewLoadChain(kernel))),
 		})
 		c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=recover snapd_recovery_system=20191216 console=ttyS0 console=tty1 panic=-1",
 		})
+		c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
 
-		bfs = bootFiles(c, params.ModelParams[1].EFILoadChains)
-		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
-				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
-				bootloader.RoleRecovery),
-			bootloader.NewBootFile("", filepath.Join(s.rootdir,
-				"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
-				bootloader.RoleRunMode),
-			bootloader.NewBootFile(filepath.Join(s.rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
+		// run mode parameters
+		runGrub := bootloader.NewBootFile("", filepath.Join(s.rootdir,
+			"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
+			bootloader.RoleRunMode)
+		runKernel := bootloader.NewBootFile(filepath.Join(s.rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode)
+
+		c.Assert(params.ModelParams[1].EFILoadChains, DeepEquals, []*secboot.LoadChain{
+			secboot.NewLoadChain(shim, secboot.NewLoadChain(grub, secboot.NewLoadChain(runGrub, secboot.NewLoadChain(runKernel)))),
 		})
 		c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
 		})
+		c.Assert(params.ModelParams[1].Model.DisplayName(), Equals, "My Model")
+
 		return fmt.Errorf("seal error")
 	})
 	defer restore()

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -463,15 +463,13 @@ version: 5.0
 
 		bfs := bootFiles(c, params.ModelParams[0].EFILoadChains)
 		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			{
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
-					bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
-					bootloader.RoleRecovery),
-				bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery),
-			},
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
+				bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
+				bootloader.RoleRecovery),
+			bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery),
 		})
 		c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=recover snapd_recovery_system=20191216 console=ttyS0 console=tty1 panic=-1",
@@ -479,18 +477,16 @@ version: 5.0
 
 		bfs = bootFiles(c, params.ModelParams[1].EFILoadChains)
 		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			{
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
-					bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
-					bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
-					bootloader.RoleRunMode),
-				bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
-			},
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
+				bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
+				bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
+				bootloader.RoleRunMode),
+			bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
 		})
 		c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
@@ -785,15 +781,13 @@ version: 5.0
 
 		bfs := bootFiles(c, params.ModelParams[0].EFILoadChains)
 		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			{
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
-					bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
-					bootloader.RoleRecovery),
-				bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery),
-			},
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
+				bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
+				bootloader.RoleRecovery),
+			bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery),
 		})
 		c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=recover snapd_recovery_system=20191216 console=ttyS0 console=tty1 panic=-1",
@@ -801,18 +795,16 @@ version: 5.0
 
 		bfs = bootFiles(c, params.ModelParams[1].EFILoadChains)
 		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
-			{
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
-					bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
-					bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(rootdir,
-					"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
-					bootloader.RoleRunMode),
-				bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
-			},
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"),
+				bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"),
+				bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(rootdir,
+				"var/lib/snapd/boot-assets/grub/grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"),
+				bootloader.RoleRunMode),
+			bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_5.snap"), "kernel.efi", bootloader.RoleRunMode),
 		})
 		c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -155,6 +155,14 @@ func buildRunModeBootChains(rbl, bl bootloader.Bootloader, model *asserts.Model,
 
 	chains := make([]bootChain, 0, 2)
 	for _, k := range runModeKernels {
+		info, err := snap.ParsePlaceInfoFromSnapFileName(k)
+		if err != nil {
+			return nil, err
+		}
+		var kernelRev string
+		if info.SnapRevision().Store() {
+			kernelRev = info.SnapRevision().String()
+		}
 		chains = append(chains, bootChain{
 			BrandID:        model.BrandID(),
 			Model:          model.Model(),
@@ -162,8 +170,7 @@ func buildRunModeBootChains(rbl, bl bootloader.Bootloader, model *asserts.Model,
 			ModelSignKeyID: model.SignKeyID(),
 			AssetChain:     assetChain,
 			Kernel:         k,
-			// XXX: obtain revision
-			KernelRevision: "",
+			KernelRevision: kernelRev,
 			KernelCmdlines: []string{cmdline},
 			model:          model,
 			kernelBootFile: bootloader.NewBootFile(k, kbf.Path, kbf.Role),

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -143,7 +143,7 @@ func buildRecoveryBootChainsForSystems(systems []string, rbl bootloader.Bootload
 		chains = append(chains, bootChain{
 			BrandID:        model.BrandID(),
 			Model:          model.Model(),
-			Grade:          string(model.Grade()),
+			Grade:          model.Grade(),
 			ModelSignKeyID: model.SignKeyID(),
 			AssetChain:     assetChain,
 			Kernel:         seedKernel.SnapName(),
@@ -185,7 +185,7 @@ func buildRunModeBootChains(rbl, bl bootloader.Bootloader, model *asserts.Model,
 		chains = append(chains, bootChain{
 			BrandID:        model.BrandID(),
 			Model:          model.Model(),
-			Grade:          string(model.Grade()),
+			Grade:          model.Grade(),
 			ModelSignKeyID: model.SignKeyID(),
 			AssetChain:     assetChain,
 			Kernel:         info.SnapName(),

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -157,6 +157,8 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 }
 
 func (s *sealSuite) TestBuildRecoveryBootChain(c *C) {
+	// TODO:UC20: make the test support multiple recovery systems
+
 	for _, tc := range []struct {
 		assetsMap       boot.BootAssetsMap
 		recoverySystem  string
@@ -229,10 +231,11 @@ func (s *sealSuite) TestBuildRecoveryBootChain(c *C) {
 			CurrentTrustedRecoveryBootAssets: tc.assetsMap,
 		}
 
-		bc, err := boot.BuildRecoveryBootChain(bl, model, modeenv)
+		bc, err := boot.BuildRecoveryBootChainsForSystems([]string{tc.recoverySystem}, bl, model, modeenv)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
-			c.Assert(bc.AssetChain, DeepEquals, tc.expectedAssets)
+			c.Assert(bc, HasLen, 1)
+			c.Assert(bc[0].AssetChain, DeepEquals, tc.expectedAssets)
 		} else {
 			c.Assert(err, ErrorMatches, tc.err)
 		}

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -126,13 +126,12 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 			c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
 				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
 			})
-			c.Assert(params.ModelParams[1].EFILoadChains, DeepEquals, [][]bootloader.BootFile{
-				{
-					bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-1"), bootloader.RoleRecovery),
-					bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-grub-hash-1"), bootloader.RoleRecovery),
-					bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-1"), bootloader.RoleRunMode),
-					bootloader.NewBootFile(filepath.Join(tmpDir, "var/lib/snapd/snaps/pc-kernel_500.snap"), "kernel.efi", bootloader.RoleRunMode),
-				},
+			bfs = bootFiles(c, params.ModelParams[1].EFILoadChains)
+			c.Assert(bfs, DeepEquals, []bootloader.BootFile{
+				bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-1"), bootloader.RoleRecovery),
+				bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-grub-hash-1"), bootloader.RoleRecovery),
+				bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-1"), bootloader.RoleRunMode),
+				bootloader.NewBootFile(filepath.Join(tmpDir, "var/lib/snapd/snaps/pc-kernel_500.snap"), "kernel.efi", bootloader.RoleRunMode),
 			})
 			c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
 				"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",


### PR DESCRIPTION
Represent the data we seal the encryption key to as boot chains before
doing the actual sealing. A boot chain contains informations related
to system properties, trusted boot assets and kernel snaps.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

