### PR TITLE
tests/lib/cla_check.py: don't allow users.noreply.github.com commits to pass CLA

### DIFF
--- a/tests/lib/cla_check.py
+++ b/tests/lib/cla_check.py
@@ -73,7 +73,7 @@ def static_email_check(email, master_emails, width):
                 yellow, reset, email, width
             )
         )
-        return True
+        return False
     return False
 
 


### PR DESCRIPTION
We can't verify that a user on GitHub has signed the CLA unless we have their
email address to cross-reference with LP, so for potential contributors who
don't want to provide their email, we will need to manually work with them to
verify their contribution and verify that they have signed the CLA.

As such, fail the CLA check if the email address ends with `@users.noreply.github.com`