### PR TITLE
tests: use `nested_exec` in core{20,}-early-config test

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -666,6 +666,8 @@ nested_start_core_vm_unit() {
         PARAM_IMAGE="-drive file=$CURRENT_IMAGE,cache=none,format=raw"
     fi
 
+    # ensure we have a log dir
+    mkdir -p "$NESTED_LOGS_DIR"
     # Systemd unit is created, it is important to respect the qemu parameters order
     systemd_create_and_start_unit "$NESTED_VM" "${QEMU} \
         ${PARAM_SMP} \
@@ -847,6 +849,9 @@ nested_start_classic_vm() {
     PARAM_BIOS=""
     PARAM_TPM=""
 
+    # ensure we have a log dir
+    mkdir -p "$NESTED_LOGS_DIR"
+    # Systemd unit is created, it is important to respect the qemu parameters order
     systemd_create_and_start_unit "$NESTED_VM" "${QEMU}  \
         ${PARAM_SMP} \
         ${PARAM_CPU} \

--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -71,4 +71,4 @@ execute: |
     nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
 
     # check console-conf disabled
-    execute_remote "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
+    nested_exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -73,4 +73,4 @@ execute: |
     nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
 
     # check console-conf disabled
-    execute_remote "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
+    nested_exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"


### PR DESCRIPTION
The core{20,}-early-config tests are using nested_exec
but the check for early config was using execute_remote.
This commit fixes that.

This should fix parts of the nested execution that is currently red everywhere.