### PR TITLE
boot,secboot: switch to expose and use snapcore/secboot load event trees

### DIFF
--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -444,14 +444,13 @@ version: 5.0
 		c.Check(key, DeepEquals, myKey)
 		c.Assert(params.ModelParams, HasLen, 1)
 		c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
-		c.Assert(params.ModelParams[0].EFILoadChains, DeepEquals, [][]bootloader.BootFile{
+		bfs := bootFiles(c, params.ModelParams[0].EFILoadChains)
+		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
 			// run mode load sequence
-			{
-				bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/EFI/boot/bootx64.efi"), bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/EFI/boot/grubx64.efi"), bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/EFI/boot/grubx64.efi"), bootloader.RoleRunMode),
-				bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi"), bootloader.RoleRunMode),
-			},
+			bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/EFI/boot/bootx64.efi"), bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/EFI/boot/grubx64.efi"), bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/EFI/boot/grubx64.efi"), bootloader.RoleRunMode),
+			bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi"), bootloader.RoleRunMode),
 		})
 		c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
@@ -730,14 +729,13 @@ version: 5.0
 		c.Check(key, DeepEquals, myKey)
 		c.Assert(params.ModelParams, HasLen, 1)
 		c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
-		c.Assert(params.ModelParams[0].EFILoadChains, DeepEquals, [][]bootloader.BootFile{
+		bfs := bootFiles(c, params.ModelParams[0].EFILoadChains)
+		c.Assert(bfs, DeepEquals, []bootloader.BootFile{
 			// run mode load sequence
-			{
-				bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/EFI/boot/bootx64.efi"), bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/EFI/boot/grubx64.efi"), bootloader.RoleRecovery),
-				bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/EFI/boot/grubx64.efi"), bootloader.RoleRunMode),
-				bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi"), bootloader.RoleRunMode),
-			},
+			bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/EFI/boot/bootx64.efi"), bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/EFI/boot/grubx64.efi"), bootloader.RoleRecovery),
+			bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/EFI/boot/grubx64.efi"), bootloader.RoleRunMode),
+			bootloader.NewBootFile("", filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi"), bootloader.RoleRunMode),
 		})
 		c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
 			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -31,6 +31,8 @@ import (
 
 type LoadChain struct {
 	*bootloader.BootFile
+	// Next is a list of alternative chains that can be loaded
+	// following the boot file.
 	Next []*LoadChain
 }
 

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -29,11 +29,26 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 )
 
+type LoadChain struct {
+	*bootloader.BootFile
+	Next []*LoadChain
+}
+
+// NewLoadChain returns a LoadChain corresponding to loading the given
+// BootFile before any of the given next chains.
+func NewLoadChain(bf bootloader.BootFile, next ...*LoadChain) *LoadChain {
+	return &LoadChain{
+		BootFile: &bf,
+		Next:     next,
+	}
+}
+
 type SealKeyModelParams struct {
 	// The snap model
 	Model *asserts.Model
-	// The set of EFI binary load paths for the current device configuration
-	EFILoadChains [][]bootloader.BootFile
+	// The set of EFI binary load chains for the current device
+	// configuration
+	EFILoadChains []*LoadChain
 	// The kernel command line
 	KernelCmdlines []string
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -418,58 +418,51 @@ func tpmProvision(tpm *sb.TPMConnection, lockoutAuthFile string) error {
 	return nil
 }
 
-// buildLoadSequences creates a linear EFI image load event chain for each one of the
-// specified sequences of file paths.
-func buildLoadSequences(bootImages [][]bootloader.BootFile) ([]*sb.EFIImageLoadEvent, error) {
-	// The idea of EFIImageLoadEvent is to build a set of load paths for the current
-	// device configuration. So you could have something like this:
+// buildLoadSequences builds EFI load image event trees from this package LoadChains
+func buildLoadSequences(chains []*LoadChain) (loadseqs []*sb.EFIImageLoadEvent, err error) {
+	// this will build load event trees for the current
+	// device configuration, e.g. something like:
 	//
 	// shim -> recovery grub -> recovery kernel 1
 	//                      |-> recovery kernel 2
 	//                      |-> recovery kernel ...
 	//                      |-> normal grub -> run kernel good
 	//                                     |-> run kernel try
-	//
-	// Or it could look like this, which is the same thing:
-	//
-	// shim -> recovery grub -> recovery kernel 1
-	// shim -> recovery grub -> recovery kernel 2
-	// shim -> recovery grub -> recovery kernel ...
-	// shim -> recovery grub -> normal grub -> run kernel good
-	// shim -> recovery grub -> normal grub -> run kernel try
-	//
-	// When we add the ability to seal against specific binaries in order to secure
-	// the system with the Microsoft chain of trust, then the actual trees of
-	// EFIImageLoadEvents will need to match the exact supported boot sequences.
 
-	loadEvents := make([]*sb.EFIImageLoadEvent, 0, len(bootImages))
-
-	for _, sequence := range bootImages {
-		var event *sb.EFIImageLoadEvent
-		var next []*sb.EFIImageLoadEvent
-
-		for i := len(sequence) - 1; i >= 0; i-- {
-			image, err := efiImageFromBootFile(sequence[i])
-			if err != nil {
-				return nil, err
-			}
-			event = &sb.EFIImageLoadEvent{
-				Source: sb.Shim,
-				Image:  image,
-				Next:   next,
-			}
-			next = []*sb.EFIImageLoadEvent{event}
+	for _, chain := range chains {
+		// root of load events has source Firmware
+		loadseq, err := chain.loadEvent(sb.Firmware)
+		if err != nil {
+			return nil, err
 		}
-		// fix event source for the first binary in chain (shim)
-		event.Source = sb.Firmware
-
-		loadEvents = append(loadEvents, event)
+		loadseqs = append(loadseqs, loadseq)
 	}
-
-	return loadEvents, nil
+	return loadseqs, nil
 }
 
-func efiImageFromBootFile(b bootloader.BootFile) (sb.EFIImage, error) {
+// loadEvent builds the corresponding load event and its tree
+func (lc *LoadChain) loadEvent(source sb.EFIImageLoadEventSource) (*sb.EFIImageLoadEvent, error) {
+	var next []*sb.EFIImageLoadEvent
+	for _, nextChain := range lc.Next {
+		// everything that is not the root has source shim
+		ev, err := nextChain.loadEvent(sb.Shim)
+		if err != nil {
+			return nil, err
+		}
+		next = append(next, ev)
+	}
+	image, err := efiImageFromBootFile(lc.BootFile)
+	if err != nil {
+		return nil, err
+	}
+	return &sb.EFIImageLoadEvent{
+		Source: source,
+		Image:  image,
+		Next:   next,
+	}, nil
+}
+
+func efiImageFromBootFile(b *bootloader.BootFile) (sb.EFIImage, error) {
 	if b.Snap == "" {
 		if !osutil.FileExists(b.Path) {
 			return nil, fmt.Errorf("file %s does not exist", b.Path)

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -568,15 +568,24 @@ func (s *secbootSuite) TestSealKey(c *C) {
 			ModelParams: []*secboot.SealKeyModelParams{
 				{
 					EFILoadChains: []*secboot.LoadChain{
-						secboot.NewLoadChain(mockBF[0], secboot.NewLoadChain(mockBF[4])),
+						secboot.NewLoadChain(mockBF[0],
+							secboot.NewLoadChain(mockBF[4])),
 					},
 					KernelCmdlines: []string{"cmdline1"},
 					Model:          &asserts.Model{},
 				},
 				{
 					EFILoadChains: []*secboot.LoadChain{
-						secboot.NewLoadChain(mockBF[0], secboot.NewLoadChain(mockBF[2], secboot.NewLoadChain(mockBF[4])), secboot.NewLoadChain(mockBF[3], secboot.NewLoadChain(mockBF[4]))),
-						secboot.NewLoadChain(mockBF[1], secboot.NewLoadChain(mockBF[2], secboot.NewLoadChain(mockBF[4])), secboot.NewLoadChain(mockBF[3], secboot.NewLoadChain(mockBF[4]))),
+						secboot.NewLoadChain(mockBF[0],
+							secboot.NewLoadChain(mockBF[2],
+								secboot.NewLoadChain(mockBF[4])),
+							secboot.NewLoadChain(mockBF[3],
+								secboot.NewLoadChain(mockBF[4]))),
+						secboot.NewLoadChain(mockBF[1],
+							secboot.NewLoadChain(mockBF[2],
+								secboot.NewLoadChain(mockBF[4])),
+							secboot.NewLoadChain(mockBF[3],
+								secboot.NewLoadChain(mockBF[4]))),
 					},
 					KernelCmdlines: []string{"cmdline2", "cmdline3"},
 					Model:          &asserts.Model{},

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -99,6 +99,7 @@ func main() {
 	}
 
 	if args.Encrypt {
+		// TODO:UC20: how realistic should we be here?
 		loadChain := []bootloader.BootFile{
 			// the path to the shim EFI binary
 			bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), bootloader.RoleRecovery),

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -100,20 +100,21 @@ func main() {
 
 	if args.Encrypt {
 		// TODO:UC20: how realistic should we be here?
-		loadChain := []bootloader.BootFile{
-			// the path to the shim EFI binary
-			bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), bootloader.RoleRecovery),
-			// the path to the recovery grub EFI binary
-			bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), bootloader.RoleRecovery),
-			// the path to the run mode grub EFI binary
-			bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), bootloader.RoleRunMode),
-		}
+		// the path to the run mode grub EFI binary
+		runbf := bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/boot/grubx64.efi"), bootloader.RoleRunMode)
+		loadChain := secboot.NewLoadChain(runbf)
+		// the path to the recovery grub EFI binary
+		recbf := bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"), bootloader.RoleRecovery)
+		loadChain = secboot.NewLoadChain(recbf, loadChain)
+		// the path to the shim EFI binary
+		shimbf := bootloader.NewBootFile("", filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"), bootloader.RoleRecovery)
+		loadChain = secboot.NewLoadChain(shimbf, loadChain)
 
 		sealKeyParams := secboot.SealKeyParams{
 			ModelParams: []*secboot.SealKeyModelParams{
 				{
 					KernelCmdlines: []string{"cmdline"},
-					EFILoadChains:  [][]bootloader.BootFile{loadChain},
+					EFILoadChains:  []*secboot.LoadChain{loadChain},
 				},
 			},
 


### PR DESCRIPTION
there is more to do in boot to fully embrace this, but it makes sense to build on top of bootChain for that
