### PR TITLE
tests: fix nested to work with qemu and kvm

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -607,12 +607,19 @@ nested_start_core_vm_unit() {
         PARAM_SMP="-smp 1"
     fi
 
-    # with qemu-nested, we can't use kvm acceleration
     local PARAM_MACHINE
     if [ "$SPREAD_BACKEND" = "google-nested" ]; then
         PARAM_MACHINE="-machine ubuntu${ATTR_KVM}"
     elif [ "$SPREAD_BACKEND" = "qemu-nested" ]; then
-        PARAM_MACHINE=""
+        # check if we have nested kvm
+        if [ "$(cat /sys/module/kvm_*/parameters/nested)" = "1" ]; then
+            PARAM_MACHINE="-machine ubuntu${ATTR_KVM}"
+        else
+            # and if not reset kvm related parameters
+            PARAM_MACHINE=""
+            PARAM_CPU=""
+            ATTR_KVM=""
+        fi
     else
         echo "unknown spread backend $SPREAD_BACKEND"
         exit 1
@@ -830,12 +837,19 @@ nested_start_classic_vm() {
     PARAM_SNAPSHOT="-snapshot"
 
     local PARAM_MACHINE PARAM_IMAGE PARAM_SEED PARAM_SERIAL PARAM_BIOS PARAM_TPM
-    # with qemu-nested, we can't use kvm acceleration
     if [ "$SPREAD_BACKEND" = "google-nested" ]; then
         PARAM_MACHINE="-machine ubuntu,accel=kvm"
         PARAM_CPU="-cpu host"
     elif [ "$SPREAD_BACKEND" = "qemu-nested" ]; then
-        PARAM_MACHINE=""
+        # check if we have nested kvm
+        if [ "$(cat /sys/module/kvm_*/parameters/nested)" = "1" ]; then
+            PARAM_MACHINE="-machine ubuntu${ATTR_KVM}"
+        else
+            # and if not reset kvm related parameters
+            PARAM_MACHINE=""
+            PARAM_CPU=""
+            ATTR_KVM=""
+        fi
     else
         echo "unknown spread backend $SPREAD_BACKEND"
         exit 1


### PR DESCRIPTION
The current code will clean the PARAM_MACHINE if running with qemu.
This is incorrect for two reasons:
1. nested kvm is possible with the right module parameter
2. it does not reset PARAM_CPU which leads to "-cpu host" but that
   will fail to start without using the accel=kvm option

This commit fixes both issues by checking if nested kvm is available
and uses it if it is. If not it resets both parameters. To test
run:
```
$ spread -v qemu-nested:ubuntu-20.04-64:tests/nested/manual/core-early-config
```
which did not work before this commit.

