### PR TITLE
 boot: helper for generating secboot load chains from a given boot asset sequence

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -49,7 +49,7 @@ func newTrustedAssetsCache(cacheDir string) *trustedAssetsCache {
 	return &trustedAssetsCache{cacheDir: cacheDir, hash: crypto.SHA3_384}
 }
 
-func (c *trustedAssetsCache) tempAssetKey(blName, assetName string) string {
+func (c *trustedAssetsCache) tempAssetRelPath(blName, assetName string) string {
 	return filepath.Join(blName, assetName+".temp")
 }
 
@@ -57,7 +57,7 @@ func (c *trustedAssetsCache) pathInCache(part string) string {
 	return filepath.Join(c.cacheDir, part)
 }
 
-func trustedAssetCacheKey(blName, assetName, assetHash string) string {
+func trustedAssetCacheRelPath(blName, assetName, assetHash string) string {
 	return filepath.Join(blName, fmt.Sprintf("%s-%s", assetName, assetHash))
 }
 
@@ -87,7 +87,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 	}
 	defer inf.Close()
 	// temporary output
-	tempPath := c.pathInCache(c.tempAssetKey(blName, assetName))
+	tempPath := c.pathInCache(c.tempAssetRelPath(blName, assetName))
 	outf, err := osutil.NewAtomicFile(tempPath, 0644, 0, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create temporary cache file: %v", err)
@@ -101,7 +101,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 		return nil, fmt.Errorf("cannot copy trusted asset to cache: %v", err)
 	}
 	hashStr := hex.EncodeToString(h.Sum(nil))
-	cacheKey := trustedAssetCacheKey(blName, assetName, hashStr)
+	cacheKey := trustedAssetCacheRelPath(blName, assetName, hashStr)
 
 	ta := &trackedAsset{
 		blName: blName,
@@ -122,7 +122,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 }
 
 func (c *trustedAssetsCache) Remove(blName, assetName, hashStr string) error {
-	cacheKey := trustedAssetCacheKey(blName, assetName, hashStr)
+	cacheKey := trustedAssetCacheRelPath(blName, assetName, hashStr)
 	if err := os.Remove(c.pathInCache(cacheKey)); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -49,16 +49,16 @@ func newTrustedAssetsCache(cacheDir string) *trustedAssetsCache {
 	return &trustedAssetsCache{cacheDir: cacheDir, hash: crypto.SHA3_384}
 }
 
-func (c *trustedAssetsCache) assetKey(blName, assetName, assetHash string) string {
-	return filepath.Join(blName, fmt.Sprintf("%s-%s", assetName, assetHash))
-}
-
 func (c *trustedAssetsCache) tempAssetKey(blName, assetName string) string {
 	return filepath.Join(blName, assetName+".temp")
 }
 
 func (c *trustedAssetsCache) pathInCache(part string) string {
 	return filepath.Join(c.cacheDir, part)
+}
+
+func trustedAssetCacheKey(blName, assetName, assetHash string) string {
+	return filepath.Join(blName, fmt.Sprintf("%s-%s", assetName, assetHash))
 }
 
 // fileHash calculates the hash of an arbitrary file using the same hash method
@@ -101,7 +101,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 		return nil, fmt.Errorf("cannot copy trusted asset to cache: %v", err)
 	}
 	hashStr := hex.EncodeToString(h.Sum(nil))
-	cacheKey := c.assetKey(blName, assetName, hashStr)
+	cacheKey := trustedAssetCacheKey(blName, assetName, hashStr)
 
 	ta := &trackedAsset{
 		blName: blName,
@@ -122,7 +122,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 }
 
 func (c *trustedAssetsCache) Remove(blName, assetName, hashStr string) error {
-	cacheKey := c.assetKey(blName, assetName, hashStr)
+	cacheKey := trustedAssetCacheKey(blName, assetName, hashStr)
 	if err := os.Remove(c.pathInCache(cacheKey)); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -22,7 +22,14 @@ package boot
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"sort"
+
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/secboot"
 )
 
 // TODO:UC20 add a doc comment when this is stabilized
@@ -194,4 +201,45 @@ func predictableBootChainsEqualForReseal(pb1, pb2 predictableBootChains) bool {
 	}
 	// TODO:UC20: return false if either chains have unasserted kernels
 	return bytes.Equal(pb1JSON, pb2JSON)
+}
+
+// bootAssetsToLoadChains generates a list of load chains covering given boot
+// assets sequence. At the end of each chain, adds an entry for the kernel boot
+// file.
+func bootAssetsToLoadChains(assets []bootAsset, kernelBootFile bootloader.BootFile, roleToBlName map[string]string) ([]*secboot.LoadChain, error) {
+	// kernel is added after all the assets
+	addKernelBootFile := len(assets) == 0
+	if addKernelBootFile {
+		return []*secboot.LoadChain{secboot.NewLoadChain(kernelBootFile)}, nil
+	}
+
+	thisAsset := assets[0]
+	blName := roleToBlName[thisAsset.Role]
+	if blName == "" {
+		return nil, fmt.Errorf("internal error: no bootloader name for asset role %q", thisAsset.Role)
+	}
+	var chains []*secboot.LoadChain
+	for _, hash := range thisAsset.Hashes {
+		var bf bootloader.BootFile
+		var next []*secboot.LoadChain
+		var err error
+
+		p := filepath.Join(
+			dirs.SnapBootAssetsDir,
+			trustedAssetCacheKey(blName, thisAsset.Name, hash))
+		if !osutil.FileExists(p) {
+			return nil, fmt.Errorf("file %s not found in assets cache", p)
+		}
+		bf = bootloader.NewBootFile(
+			"", // asset comes from the filesystem, not a snap
+			p,
+			bootloader.Role(thisAsset.Role),
+		)
+		next, err = bootAssetsToLoadChains(assets[1:], kernelBootFile, roleToBlName)
+		if err != nil {
+			return nil, err
+		}
+		chains = append(chains, secboot.NewLoadChain(bf, next...))
+	}
+	return chains, nil
 }

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -1042,13 +1042,13 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 		{Name: "loader-run", Hashes: []string{"hash0"}, Role: "run"},
 	}
 
-	blNames := map[string]string{
+	blNames := map[bootloader.Role]string{
 		"recovery": "recovery-bl",
 		// missing bootloader name for role "run"
 	}
 	// fails when probing the shim asset in the cache
 	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames)
-	c.Assert(err, ErrorMatches, "file .*/recovery-bl/shim-hash0 not found in assets cache")
+	c.Assert(err, ErrorMatches, "file .*/recovery-bl/shim-hash0 not found in boot assets cache")
 	c.Check(chains, IsNil)
 	// make it work now
 	c.Assert(os.MkdirAll(filepath.Dir(cPath("recovery-bl/shim-hash0")), 0755), IsNil)
@@ -1056,7 +1056,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 
 	// nested error bubbled up
 	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames)
-	c.Assert(err, ErrorMatches, "file .*/recovery-bl/loader-recovery-hash0 not found in assets cache")
+	c.Assert(err, ErrorMatches, "file .*/recovery-bl/loader-recovery-hash0 not found in boot assets cache")
 	c.Check(chains, IsNil)
 	// again, make it work
 	c.Assert(os.MkdirAll(filepath.Dir(cPath("recovery-bl/loader-recovery-hash0")), 0755), IsNil)
@@ -1064,7 +1064,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 
 	// fails on missing bootloader name for role "run"
 	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames)
-	c.Assert(err, ErrorMatches, `internal error: no bootloader name for asset role "run"`)
+	c.Assert(err, ErrorMatches, `internal error: no bootloader name for boot asset role "run"`)
 	c.Check(chains, IsNil)
 }
 
@@ -1088,7 +1088,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainSimpleChain(c *C) {
 		c.Assert(ioutil.WriteFile(p, nil, 0644), IsNil)
 	}
 
-	blNames := map[string]string{
+	blNames := map[bootloader.Role]string{
 		"recovery": "recovery-bl",
 		"run":      "run-bl",
 	}
@@ -1132,7 +1132,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 		c.Assert(ioutil.WriteFile(p, nil, 0644), IsNil)
 	}
 
-	blNames := map[string]string{
+	blNames := map[bootloader.Role]string{
 		"recovery": "recovery-bl",
 		"run":      "run-bl",
 	}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -110,4 +110,5 @@ var (
 	ToPredictableBootChain              = toPredictableBootChain
 	ToPredictableBootChains             = toPredictableBootChains
 	PredictableBootChainsEqualForReseal = predictableBootChainsEqualForReseal
+	BootAssetsToLoadChains              = bootAssetsToLoadChains
 )


### PR DESCRIPTION
The helpers enables generating secboot load chain trees from boot asset
sequences. 

This is stacked on top of #9303. The relevant commit is https://github.com/snapcore/snapd/commit/687fa3bb505b2813dc90bf326ecac476cb245839