### PR TITLE
boot: be consistent using bootloader.Role* consts instead of strings

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -49,7 +49,7 @@ func newTrustedAssetsCache(cacheDir string) *trustedAssetsCache {
 	return &trustedAssetsCache{cacheDir: cacheDir, hash: crypto.SHA3_384}
 }
 
-func (c *trustedAssetsCache) tempAssetKey(blName, assetName string) string {
+func (c *trustedAssetsCache) tempAssetRelPath(blName, assetName string) string {
 	return filepath.Join(blName, assetName+".temp")
 }
 
@@ -57,7 +57,7 @@ func (c *trustedAssetsCache) pathInCache(part string) string {
 	return filepath.Join(c.cacheDir, part)
 }
 
-func trustedAssetCacheKey(blName, assetName, assetHash string) string {
+func trustedAssetCacheRelPath(blName, assetName, assetHash string) string {
 	return filepath.Join(blName, fmt.Sprintf("%s-%s", assetName, assetHash))
 }
 
@@ -87,7 +87,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 	}
 	defer inf.Close()
 	// temporary output
-	tempPath := c.pathInCache(c.tempAssetKey(blName, assetName))
+	tempPath := c.pathInCache(c.tempAssetRelPath(blName, assetName))
 	outf, err := osutil.NewAtomicFile(tempPath, 0644, 0, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create temporary cache file: %v", err)
@@ -101,7 +101,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 		return nil, fmt.Errorf("cannot copy trusted asset to cache: %v", err)
 	}
 	hashStr := hex.EncodeToString(h.Sum(nil))
-	cacheKey := trustedAssetCacheKey(blName, assetName, hashStr)
+	cacheKey := trustedAssetCacheRelPath(blName, assetName, hashStr)
 
 	ta := &trackedAsset{
 		blName: blName,
@@ -122,7 +122,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 }
 
 func (c *trustedAssetsCache) Remove(blName, assetName, hashStr string) error {
-	cacheKey := trustedAssetCacheKey(blName, assetName, hashStr)
+	cacheKey := trustedAssetCacheRelPath(blName, assetName, hashStr)
 	if err := os.Remove(c.pathInCache(cacheKey)); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -49,16 +49,16 @@ func newTrustedAssetsCache(cacheDir string) *trustedAssetsCache {
 	return &trustedAssetsCache{cacheDir: cacheDir, hash: crypto.SHA3_384}
 }
 
-func (c *trustedAssetsCache) assetKey(blName, assetName, assetHash string) string {
-	return filepath.Join(blName, fmt.Sprintf("%s-%s", assetName, assetHash))
-}
-
 func (c *trustedAssetsCache) tempAssetKey(blName, assetName string) string {
 	return filepath.Join(blName, assetName+".temp")
 }
 
 func (c *trustedAssetsCache) pathInCache(part string) string {
 	return filepath.Join(c.cacheDir, part)
+}
+
+func trustedAssetCacheKey(blName, assetName, assetHash string) string {
+	return filepath.Join(blName, fmt.Sprintf("%s-%s", assetName, assetHash))
 }
 
 // fileHash calculates the hash of an arbitrary file using the same hash method
@@ -101,7 +101,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 		return nil, fmt.Errorf("cannot copy trusted asset to cache: %v", err)
 	}
 	hashStr := hex.EncodeToString(h.Sum(nil))
-	cacheKey := c.assetKey(blName, assetName, hashStr)
+	cacheKey := trustedAssetCacheKey(blName, assetName, hashStr)
 
 	ta := &trackedAsset{
 		blName: blName,
@@ -122,7 +122,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 }
 
 func (c *trustedAssetsCache) Remove(blName, assetName, hashStr string) error {
-	cacheKey := c.assetKey(blName, assetName, hashStr)
+	cacheKey := trustedAssetCacheKey(blName, assetName, hashStr)
 	if err := os.Remove(c.pathInCache(cacheKey)); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -22,7 +22,14 @@ package boot
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"sort"
+
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/secboot"
 )
 
 // TODO:UC20 add a doc comment when this is stabilized
@@ -194,4 +201,45 @@ func predictableBootChainsEqualForReseal(pb1, pb2 predictableBootChains) bool {
 	}
 	// TODO:UC20: return false if either chains have unasserted kernels
 	return bytes.Equal(pb1JSON, pb2JSON)
+}
+
+// bootAssetsToLoadChains generates a list of load chains covering given boot
+// assets sequence. At the end of each chain, adds an entry for the kernel boot
+// file.
+func bootAssetsToLoadChains(assets []bootAsset, kernelBootFile bootloader.BootFile, roleToBlName map[string]string) ([]*secboot.LoadChain, error) {
+	// kernel is added after all the assets
+	addKernelBootFile := len(assets) == 0
+	if addKernelBootFile {
+		return []*secboot.LoadChain{secboot.NewLoadChain(kernelBootFile)}, nil
+	}
+
+	thisAsset := assets[0]
+	blName := roleToBlName[thisAsset.Role]
+	if blName == "" {
+		return nil, fmt.Errorf("internal error: no bootloader name for asset role %q", thisAsset.Role)
+	}
+	var chains []*secboot.LoadChain
+	for _, hash := range thisAsset.Hashes {
+		var bf bootloader.BootFile
+		var next []*secboot.LoadChain
+		var err error
+
+		p := filepath.Join(
+			dirs.SnapBootAssetsDir,
+			trustedAssetCacheKey(blName, thisAsset.Name, hash))
+		if !osutil.FileExists(p) {
+			return nil, fmt.Errorf("file %s not found in assets cache", p)
+		}
+		bf = bootloader.NewBootFile(
+			"", // asset comes from the filesystem, not a snap
+			p,
+			bootloader.Role(thisAsset.Role),
+		)
+		next, err = bootAssetsToLoadChains(assets[1:], kernelBootFile, roleToBlName)
+		if err != nil {
+			return nil, err
+		}
+		chains = append(chains, secboot.NewLoadChain(bf, next...))
+	}
+	return chains, nil
 }

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -1042,13 +1042,13 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 		{Name: "loader-run", Hashes: []string{"hash0"}, Role: "run"},
 	}
 
-	blNames := map[string]string{
+	blNames := map[bootloader.Role]string{
 		"recovery": "recovery-bl",
 		// missing bootloader name for role "run"
 	}
 	// fails when probing the shim asset in the cache
 	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames)
-	c.Assert(err, ErrorMatches, "file .*/recovery-bl/shim-hash0 not found in assets cache")
+	c.Assert(err, ErrorMatches, "file .*/recovery-bl/shim-hash0 not found in boot assets cache")
 	c.Check(chains, IsNil)
 	// make it work now
 	c.Assert(os.MkdirAll(filepath.Dir(cPath("recovery-bl/shim-hash0")), 0755), IsNil)
@@ -1056,7 +1056,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 
 	// nested error bubbled up
 	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames)
-	c.Assert(err, ErrorMatches, "file .*/recovery-bl/loader-recovery-hash0 not found in assets cache")
+	c.Assert(err, ErrorMatches, "file .*/recovery-bl/loader-recovery-hash0 not found in boot assets cache")
 	c.Check(chains, IsNil)
 	// again, make it work
 	c.Assert(os.MkdirAll(filepath.Dir(cPath("recovery-bl/loader-recovery-hash0")), 0755), IsNil)
@@ -1064,7 +1064,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 
 	// fails on missing bootloader name for role "run"
 	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames)
-	c.Assert(err, ErrorMatches, `internal error: no bootloader name for asset role "run"`)
+	c.Assert(err, ErrorMatches, `internal error: no bootloader name for boot asset role "run"`)
 	c.Check(chains, IsNil)
 }
 
@@ -1088,7 +1088,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainSimpleChain(c *C) {
 		c.Assert(ioutil.WriteFile(p, nil, 0644), IsNil)
 	}
 
-	blNames := map[string]string{
+	blNames := map[bootloader.Role]string{
 		"recovery": "recovery-bl",
 		"run":      "run-bl",
 	}
@@ -1132,7 +1132,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 		c.Assert(ioutil.WriteFile(p, nil, 0644), IsNil)
 	}
 
-	blNames := map[string]string{
+	blNames := map[bootloader.Role]string{
 		"recovery": "recovery-bl",
 		"run":      "run-bl",
 	}

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -55,87 +55,87 @@ func (s *bootchainSuite) SetUpTest(c *C) {
 func (s *bootchainSuite) TestBootAssetsSort(c *C) {
 	// by role
 	d := []boot.BootAsset{
-		{Role: "run", Name: "1ist", Hashes: []string{"b", "c"}},
-		{Role: "recovery", Name: "1ist", Hashes: []string{"b", "c"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"b", "c"}},
+		{Role: bootloader.RoleRecovery, Name: "1ist", Hashes: []string{"b", "c"}},
 	}
 	sort.Sort(boot.ByBootAssetOrder(d))
 	c.Check(d, DeepEquals, []boot.BootAsset{
-		{Role: "recovery", Name: "1ist", Hashes: []string{"b", "c"}},
-		{Role: "run", Name: "1ist", Hashes: []string{"b", "c"}},
+		{Role: bootloader.RoleRecovery, Name: "1ist", Hashes: []string{"b", "c"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"b", "c"}},
 	})
 
 	// by name
 	d = []boot.BootAsset{
-		{Role: "recovery", Name: "shim", Hashes: []string{"d", "e"}},
-		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d", "e"}},
 	}
 	sort.Sort(boot.ByBootAssetOrder(d))
 	c.Check(d, DeepEquals, []boot.BootAsset{
-		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
-		{Role: "recovery", Name: "shim", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"d", "e"}},
 	})
 
 	// by hash list length
 	d = []boot.BootAsset{
-		{Role: "run", Name: "1ist", Hashes: []string{"a", "f"}},
-		{Role: "run", Name: "1ist", Hashes: []string{"d"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"a", "f"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"d"}},
 	}
 	sort.Sort(boot.ByBootAssetOrder(d))
 	c.Check(d, DeepEquals, []boot.BootAsset{
-		{Role: "run", Name: "1ist", Hashes: []string{"d"}},
-		{Role: "run", Name: "1ist", Hashes: []string{"a", "f"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"d"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"a", "f"}},
 	})
 
 	// hash list entries
 	d = []boot.BootAsset{
-		{Role: "run", Name: "1ist", Hashes: []string{"b", "d"}},
-		{Role: "run", Name: "1ist", Hashes: []string{"b", "c"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"b", "d"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"b", "c"}},
 	}
 	sort.Sort(boot.ByBootAssetOrder(d))
 	c.Check(d, DeepEquals, []boot.BootAsset{
-		{Role: "run", Name: "1ist", Hashes: []string{"b", "c"}},
-		{Role: "run", Name: "1ist", Hashes: []string{"b", "d"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"b", "c"}},
+		{Role: bootloader.RoleRunMode, Name: "1ist", Hashes: []string{"b", "d"}},
 	})
 
 	d = []boot.BootAsset{
-		{Role: "run", Name: "loader", Hashes: []string{"z"}},
-		{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
-		{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
-		{Role: "run", Name: "1oader", Hashes: []string{"d", "e"}},
-		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
-		{Role: "run", Name: "0oader", Hashes: []string{"x", "z"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"z"}},
+		{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"b"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
+		{Role: bootloader.RoleRunMode, Name: "1oader", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRunMode, Name: "0oader", Hashes: []string{"x", "z"}},
 	}
 	sort.Sort(boot.ByBootAssetOrder(d))
 	c.Check(d, DeepEquals, []boot.BootAsset{
-		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
-		{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
-		{Role: "run", Name: "0oader", Hashes: []string{"x", "z"}},
-		{Role: "run", Name: "1oader", Hashes: []string{"d", "e"}},
-		{Role: "run", Name: "loader", Hashes: []string{"z"}},
-		{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+		{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"b"}},
+		{Role: bootloader.RoleRunMode, Name: "0oader", Hashes: []string{"x", "z"}},
+		{Role: bootloader.RoleRunMode, Name: "1oader", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"z"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 	})
 
 	// d is already sorted, sort it again
 	sort.Sort(boot.ByBootAssetOrder(d))
 	// still the same
 	c.Check(d, DeepEquals, []boot.BootAsset{
-		{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
-		{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
-		{Role: "run", Name: "0oader", Hashes: []string{"x", "z"}},
-		{Role: "run", Name: "1oader", Hashes: []string{"d", "e"}},
-		{Role: "run", Name: "loader", Hashes: []string{"z"}},
-		{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+		{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"b"}},
+		{Role: bootloader.RoleRunMode, Name: "0oader", Hashes: []string{"x", "z"}},
+		{Role: bootloader.RoleRunMode, Name: "1oader", Hashes: []string{"d", "e"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"z"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 	})
 
 	// 2 identical entries
 	d = []boot.BootAsset{
-		{Role: "run", Name: "loader", Hashes: []string{"x", "z"}},
-		{Role: "run", Name: "loader", Hashes: []string{"x", "z"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"x", "z"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"x", "z"}},
 	}
 	sort.Sort(boot.ByBootAssetOrder(d))
 	c.Check(d, DeepEquals, []boot.BootAsset{
-		{Role: "run", Name: "loader", Hashes: []string{"x", "z"}},
-		{Role: "run", Name: "loader", Hashes: []string{"x", "z"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"x", "z"}},
+		{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"x", "z"}},
 	})
 
 }
@@ -143,15 +143,15 @@ func (s *bootchainSuite) TestBootAssetsSort(c *C) {
 func (s *bootchainSuite) TestBootAssetsPredictable(c *C) {
 	// by role
 	ba := boot.BootAsset{
-		Role: "run", Name: "list", Hashes: []string{"b", "a"},
+		Role: bootloader.RoleRunMode, Name: "list", Hashes: []string{"b", "a"},
 	}
 	pred := boot.ToPredictableBootAsset(&ba)
 	c.Check(pred, DeepEquals, &boot.BootAsset{
-		Role: "run", Name: "list", Hashes: []string{"a", "b"},
+		Role: bootloader.RoleRunMode, Name: "list", Hashes: []string{"a", "b"},
 	})
 	// original structure is not changed
 	c.Check(ba, DeepEquals, boot.BootAsset{
-		Role: "run", Name: "list", Hashes: []string{"b", "a"},
+		Role: bootloader.RoleRunMode, Name: "list", Hashes: []string{"b", "a"},
 	})
 
 	// try to make a predictable struct predictable once more
@@ -168,12 +168,12 @@ func (s *bootchainSuite) TestBootChainMarshalOnlyAssets(c *C) {
 
 	bc := &boot.BootChain{
 		AssetChain: []boot.BootAsset{
-			{Role: "run", Name: "loader", Hashes: []string{"z"}},
-			{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
-			{Role: "run", Name: "loader", Hashes: []string{"d", "c"}},
-			{Role: "run", Name: "1oader", Hashes: []string{"e", "d"}},
-			{Role: "recovery", Name: "loader", Hashes: []string{"e", "d"}},
-			{Role: "run", Name: "0oader", Hashes: []string{"z", "x"}},
+			{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"z"}},
+			{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"b"}},
+			{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"d", "c"}},
+			{Role: bootloader.RoleRunMode, Name: "1oader", Hashes: []string{"e", "d"}},
+			{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"e", "d"}},
+			{Role: bootloader.RoleRunMode, Name: "0oader", Hashes: []string{"z", "x"}},
 		},
 	}
 
@@ -183,18 +183,18 @@ func (s *bootchainSuite) TestBootChainMarshalOnlyAssets(c *C) {
 		// assets are sorted
 		AssetChain: []boot.BootAsset{
 			// hash lists are sorted
-			{Role: "recovery", Name: "loader", Hashes: []string{"d", "e"}},
-			{Role: "recovery", Name: "shim", Hashes: []string{"b"}},
-			{Role: "run", Name: "0oader", Hashes: []string{"x", "z"}},
-			{Role: "run", Name: "1oader", Hashes: []string{"d", "e"}},
-			{Role: "run", Name: "loader", Hashes: []string{"z"}},
-			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+			{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d", "e"}},
+			{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"b"}},
+			{Role: bootloader.RoleRunMode, Name: "0oader", Hashes: []string{"x", "z"}},
+			{Role: bootloader.RoleRunMode, Name: "1oader", Hashes: []string{"d", "e"}},
+			{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"z"}},
+			{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 		},
 	})
 
 	d, err := json.Marshal(predictableBc)
 	c.Assert(err, IsNil)
-	c.Check(string(d), Equals, `{"brand-id":"","model":"","grade":"","model-sign-key-id":"","asset-chain":[{"role":"recovery","name":"loader","hashes":["d","e"]},{"role":"recovery","name":"shim","hashes":["b"]},{"role":"run","name":"0oader","hashes":["x","z"]},{"role":"run","name":"1oader","hashes":["d","e"]},{"role":"run","name":"loader","hashes":["z"]},{"role":"run","name":"loader","hashes":["c","d"]}],"kernel":"","kernel-revision":"","kernel-cmdlines":null}`)
+	c.Check(string(d), Equals, `{"brand-id":"","model":"","grade":"","model-sign-key-id":"","asset-chain":[{"role":"recovery","name":"loader","hashes":["d","e"]},{"role":"recovery","name":"shim","hashes":["b"]},{"role":"run-mode","name":"0oader","hashes":["x","z"]},{"role":"run-mode","name":"1oader","hashes":["d","e"]},{"role":"run-mode","name":"loader","hashes":["z"]},{"role":"run-mode","name":"loader","hashes":["c","d"]}],"kernel":"","kernel-revision":"","kernel-cmdlines":null}`)
 
 	// already predictable, but try again
 	alreadySortedBc := boot.ToPredictableBootChain(predictableBc)
@@ -203,8 +203,8 @@ func (s *bootchainSuite) TestBootChainMarshalOnlyAssets(c *C) {
 	// boot chain with 2 identical assets
 	bcIdenticalAssets := &boot.BootChain{
 		AssetChain: []boot.BootAsset{
-			{Role: "run", Name: "loader", Hashes: []string{"z"}},
-			{Role: "run", Name: "loader", Hashes: []string{"z"}},
+			{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"z"}},
+			{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"z"}},
 		},
 	}
 	sortedBcIdentical := boot.ToPredictableBootChain(bcIdenticalAssets)
@@ -219,10 +219,10 @@ func (s *bootchainSuite) TestBootChainMarshalFull(c *C) {
 		ModelSignKeyID: "my-key-id",
 		// asset chain will get sorted when marshaling
 		AssetChain: []boot.BootAsset{
-			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+			{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 			// hash list will get sorted
-			{Role: "recovery", Name: "shim", Hashes: []string{"b", "a"}},
-			{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+			{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"b", "a"}},
+			{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d"}},
 		},
 		Kernel:         "pc-kernel",
 		KernelRevision: "1234",
@@ -231,7 +231,7 @@ func (s *bootchainSuite) TestBootChainMarshalFull(c *C) {
 
 	uc20model := makeMockUC20Model()
 	bc.SetModelAssertion(uc20model)
-	kernelBootFile := bootloader.NewBootFile("pc-kernel", "/foo", "recovery")
+	kernelBootFile := bootloader.NewBootFile("pc-kernel", "/foo", bootloader.RoleRecovery)
 	bc.SetKernelBootFile(kernelBootFile)
 
 	expectedPredictableBc := &boot.BootChain{
@@ -241,10 +241,10 @@ func (s *bootchainSuite) TestBootChainMarshalFull(c *C) {
 		ModelSignKeyID: "my-key-id",
 		// assets are sorted
 		AssetChain: []boot.BootAsset{
-			{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+			{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d"}},
 			// hash lists are sorted
-			{Role: "recovery", Name: "shim", Hashes: []string{"a", "b"}},
-			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+			{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"a", "b"}},
+			{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 		},
 		Kernel:         "pc-kernel",
 		KernelRevision: "1234",
@@ -259,7 +259,7 @@ func (s *bootchainSuite) TestBootChainMarshalFull(c *C) {
 
 	d, err := json.Marshal(predictableBc)
 	c.Assert(err, IsNil)
-	c.Check(string(d), Equals, `{"brand-id":"mybrand","model":"foo","grade":"dangerous","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"loader","hashes":["d"]},{"role":"recovery","name":"shim","hashes":["a","b"]},{"role":"run","name":"loader","hashes":["c","d"]}],"kernel":"pc-kernel","kernel-revision":"1234","kernel-cmdlines":["a=1","foo=bar baz=0x123"]}`)
+	c.Check(string(d), Equals, `{"brand-id":"mybrand","model":"foo","grade":"dangerous","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"loader","hashes":["d"]},{"role":"recovery","name":"shim","hashes":["a","b"]},{"role":"run-mode","name":"loader","hashes":["c","d"]}],"kernel":"pc-kernel","kernel-revision":"1234","kernel-cmdlines":["a=1","foo=bar baz=0x123"]}`)
 
 	expectedOriginal := &boot.BootChain{
 		BrandID:        "mybrand",
@@ -268,10 +268,10 @@ func (s *bootchainSuite) TestBootChainMarshalFull(c *C) {
 		ModelSignKeyID: "my-key-id",
 		// asset chain will get sorted when marshaling
 		AssetChain: []boot.BootAsset{
-			{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+			{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 			// hash list will get sorted
-			{Role: "recovery", Name: "shim", Hashes: []string{"b", "a"}},
-			{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+			{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"b", "a"}},
+			{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d"}},
 		},
 		Kernel:         "pc-kernel",
 		KernelRevision: "1234",
@@ -291,10 +291,10 @@ func (s *bootchainSuite) TestBootChainEqualForResealComplex(c *C) {
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
-				{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+				{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 				// hash list will get sorted
-				{Role: "recovery", Name: "shim", Hashes: []string{"b", "a"}},
-				{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
+				{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"b", "a"}},
+				{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d"}},
 			},
 			Kernel:         "pc-kernel",
 			KernelRevision: "1234",
@@ -310,9 +310,9 @@ func (s *bootchainSuite) TestBootChainEqualForResealComplex(c *C) {
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
-				{Role: "recovery", Name: "loader", Hashes: []string{"d"}},
-				{Role: "recovery", Name: "shim", Hashes: []string{"a", "b"}},
-				{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+				{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"d"}},
+				{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"a", "b"}},
+				{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 			},
 			Kernel:         "pc-kernel",
 			KernelRevision: "1234",
@@ -335,7 +335,7 @@ func (s *bootchainSuite) TestPredictableBootChainsEqualForResealSimple(c *C) {
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
-				{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+				{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 			},
 			Kernel:         "pc-kernel-other",
 			KernelRevision: "1234",
@@ -356,7 +356,7 @@ func (s *bootchainSuite) TestPredictableBootChainsEqualForResealSimple(c *C) {
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
-				{Role: "run", Name: "loader", Hashes: []string{"c", "d"}},
+				{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"c", "d"}},
 			},
 			Kernel:         "pc-kernel-other",
 			KernelRevision: "1234",
@@ -367,7 +367,7 @@ func (s *bootchainSuite) TestPredictableBootChainsEqualForResealSimple(c *C) {
 			Grade:          "dangerous",
 			ModelSignKeyID: "my-key-id",
 			AssetChain: []boot.BootAsset{
-				{Role: "run", Name: "loader", Hashes: []string{"d", "e"}},
+				{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"d", "e"}},
 			},
 			Kernel:         "pc-kernel-other",
 			KernelRevision: "1234",
@@ -393,9 +393,9 @@ func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			// assets will be sorted
 			AssetChain: []boot.BootAsset{
 				// hashes will be sorted
-				{Role: "recovery", Name: "shim", Hashes: []string{"x", "y"}},
-				{Role: "recovery", Name: "loader", Hashes: []string{"c", "d"}},
-				{Role: "run", Name: "loader", Hashes: []string{"z", "x"}},
+				{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"x", "y"}},
+				{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"c", "d"}},
+				{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"z", "x"}},
 			},
 			Kernel:         "pc-kernel-other",
 			KernelRevision: "2345",
@@ -408,9 +408,9 @@ func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			// assets will be sorted
 			AssetChain: []boot.BootAsset{
 				// hashes will be sorted
-				{Role: "recovery", Name: "shim", Hashes: []string{"y", "x"}},
-				{Role: "recovery", Name: "loader", Hashes: []string{"c", "d"}},
-				{Role: "run", Name: "loader", Hashes: []string{"b", "a"}},
+				{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"y", "x"}},
+				{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"c", "d"}},
+				{Role: bootloader.RoleRunMode, Name: "loader", Hashes: []string{"b", "a"}},
 			},
 			Kernel:         "pc-kernel-other",
 			KernelRevision: "1234",
@@ -423,8 +423,8 @@ func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			ModelSignKeyID: "my-key-id",
 			// will be sorted
 			AssetChain: []boot.BootAsset{
-				{Role: "recovery", Name: "shim", Hashes: []string{"y", "x"}},
-				{Role: "recovery", Name: "loader", Hashes: []string{"c", "d"}},
+				{Role: bootloader.RoleRecovery, Name: "shim", Hashes: []string{"y", "x"}},
+				{Role: bootloader.RoleRecovery, Name: "loader", Hashes: []string{"c", "d"}},
 			},
 			Kernel:         "pc-kernel-other",
 			KernelRevision: "12",
@@ -470,7 +470,7 @@ func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			"asset-chain": []interface{}{
 				map[string]interface{}{"role": "recovery", "name": "loader", "hashes": []interface{}{"c", "d"}},
 				map[string]interface{}{"role": "recovery", "name": "shim", "hashes": []interface{}{"x", "y"}},
-				map[string]interface{}{"role": "run", "name": "loader", "hashes": []interface{}{"a", "b"}},
+				map[string]interface{}{"role": "run-mode", "name": "loader", "hashes": []interface{}{"a", "b"}},
 			},
 		}, {
 			"model":             "foo",
@@ -483,7 +483,7 @@ func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			"asset-chain": []interface{}{
 				map[string]interface{}{"role": "recovery", "name": "loader", "hashes": []interface{}{"c", "d"}},
 				map[string]interface{}{"role": "recovery", "name": "shim", "hashes": []interface{}{"x", "y"}},
-				map[string]interface{}{"role": "run", "name": "loader", "hashes": []interface{}{"x", "z"}},
+				map[string]interface{}{"role": "run-mode", "name": "loader", "hashes": []interface{}{"x", "z"}},
 			},
 		},
 	})
@@ -1070,33 +1070,31 @@ func cPath(p string) string {
 }
 
 // nbf is bootloader.NewBootFile but shorter
-func nbf(snap, path, role string) bootloader.BootFile {
-	return bootloader.NewBootFile(snap, path, bootloader.Role(role))
-}
+var nbf = bootloader.NewBootFile
 
 func (s *bootchainSuite) TestBootAssetsToLoadChainTrivialKernel(c *C) {
-	kbl := bootloader.NewBootFile("pc-kernel", "kernel.efi", bootloader.Role("run"))
+	kbl := bootloader.NewBootFile("pc-kernel", "kernel.efi", bootloader.RoleRunMode)
 
 	chains, err := boot.BootAssetsToLoadChains(nil, kbl, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(chains, DeepEquals, []*secboot.LoadChain{
-		secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run")),
+		secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode)),
 	})
 }
 
 func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
-	kbl := bootloader.NewBootFile("pc-kernel", "kernel.efi", bootloader.Role("run"))
+	kbl := bootloader.NewBootFile("pc-kernel", "kernel.efi", bootloader.RoleRunMode)
 
 	assets := []boot.BootAsset{
-		{Name: "shim", Hashes: []string{"hash0"}, Role: "recovery"},
-		{Name: "loader-recovery", Hashes: []string{"hash0"}, Role: "recovery"},
-		{Name: "loader-run", Hashes: []string{"hash0"}, Role: "run"},
+		{Name: "shim", Hashes: []string{"hash0"}, Role: bootloader.RoleRecovery},
+		{Name: "loader-recovery", Hashes: []string{"hash0"}, Role: bootloader.RoleRecovery},
+		{Name: "loader-run", Hashes: []string{"hash0"}, Role: bootloader.RoleRunMode},
 	}
 
 	blNames := map[bootloader.Role]string{
-		"recovery": "recovery-bl",
-		// missing bootloader name for role "run"
+		bootloader.RoleRecovery: "recovery-bl",
+		// missing bootloader name for role "run-mode"
 	}
 	// fails when probing the shim asset in the cache
 	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames)
@@ -1114,19 +1112,19 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 	c.Assert(os.MkdirAll(filepath.Dir(cPath("recovery-bl/loader-recovery-hash0")), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(cPath("recovery-bl/loader-recovery-hash0"), nil, 0644), IsNil)
 
-	// fails on missing bootloader name for role "run"
+	// fails on missing bootloader name for role "run-mode"
 	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames)
-	c.Assert(err, ErrorMatches, `internal error: no bootloader name for boot asset role "run"`)
+	c.Assert(err, ErrorMatches, `internal error: no bootloader name for boot asset role "run-mode"`)
 	c.Check(chains, IsNil)
 }
 
 func (s *bootchainSuite) TestBootAssetsToLoadChainSimpleChain(c *C) {
-	kbl := bootloader.NewBootFile("pc-kernel", "kernel.efi", bootloader.Role("run"))
+	kbl := bootloader.NewBootFile("pc-kernel", "kernel.efi", bootloader.RoleRunMode)
 
 	assets := []boot.BootAsset{
-		{Name: "shim", Hashes: []string{"hash0"}, Role: "recovery"},
-		{Name: "loader-recovery", Hashes: []string{"hash0"}, Role: "recovery"},
-		{Name: "loader-run", Hashes: []string{"hash0"}, Role: "run"},
+		{Name: "shim", Hashes: []string{"hash0"}, Role: bootloader.RoleRecovery},
+		{Name: "loader-recovery", Hashes: []string{"hash0"}, Role: bootloader.RoleRecovery},
+		{Name: "loader-run", Hashes: []string{"hash0"}, Role: bootloader.RoleRunMode},
 	}
 
 	// mock relevant files in cache
@@ -1141,8 +1139,8 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainSimpleChain(c *C) {
 	}
 
 	blNames := map[bootloader.Role]string{
-		"recovery": "recovery-bl",
-		"run":      "run-bl",
+		bootloader.RoleRecovery: "recovery-bl",
+		bootloader.RoleRunMode:  "run-bl",
 	}
 
 	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames)
@@ -1154,21 +1152,21 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainSimpleChain(c *C) {
 	}
 
 	expected := []*secboot.LoadChain{
-		secboot.NewLoadChain(nbf("", cPath("recovery-bl/shim-hash0"), "recovery"),
-			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash0"), "recovery"),
-				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), "run"),
-					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run"))))),
+		secboot.NewLoadChain(nbf("", cPath("recovery-bl/shim-hash0"), bootloader.RoleRecovery),
+			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash0"), bootloader.RoleRecovery),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))))),
 	}
 	c.Check(chains, DeepEquals, expected)
 }
 
 func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
-	kbl := bootloader.NewBootFile("pc-kernel", "kernel.efi", bootloader.Role("run"))
+	kbl := bootloader.NewBootFile("pc-kernel", "kernel.efi", bootloader.RoleRunMode)
 
 	assets := []boot.BootAsset{
-		{Name: "shim", Hashes: []string{"hash0", "hash1"}, Role: "recovery"},
-		{Name: "loader-recovery", Hashes: []string{"hash0", "hash1"}, Role: "recovery"},
-		{Name: "loader-run", Hashes: []string{"hash0", "hash1"}, Role: "run"},
+		{Name: "shim", Hashes: []string{"hash0", "hash1"}, Role: bootloader.RoleRecovery},
+		{Name: "loader-recovery", Hashes: []string{"hash0", "hash1"}, Role: bootloader.RoleRecovery},
+		{Name: "loader-run", Hashes: []string{"hash0", "hash1"}, Role: bootloader.RoleRunMode},
 	}
 
 	// mock relevant files in cache
@@ -1185,8 +1183,8 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 	}
 
 	blNames := map[bootloader.Role]string{
-		"recovery": "recovery-bl",
-		"run":      "run-bl",
+		bootloader.RoleRecovery: "recovery-bl",
+		bootloader.RoleRunMode:  "run-bl",
 	}
 	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames)
 	c.Assert(err, IsNil)
@@ -1197,28 +1195,28 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 	}
 
 	expected := []*secboot.LoadChain{
-		secboot.NewLoadChain(nbf("", cPath("recovery-bl/shim-hash0"), "recovery"),
-			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash0"), "recovery"),
-				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), "run"),
-					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run"))),
-				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), "run"),
-					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run")))),
-			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash1"), "recovery"),
-				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), "run"),
-					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run"))),
-				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), "run"),
-					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run"))))),
-		secboot.NewLoadChain(nbf("", cPath("recovery-bl/shim-hash1"), "recovery"),
-			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash0"), "recovery"),
-				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), "run"),
-					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run"))),
-				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), "run"),
-					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run")))),
-			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash1"), "recovery"),
-				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), "run"),
-					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run"))),
-				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), "run"),
-					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", "run"))))),
+		secboot.NewLoadChain(nbf("", cPath("recovery-bl/shim-hash0"), bootloader.RoleRecovery),
+			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash0"), bootloader.RoleRecovery),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode)))),
+			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash1"), bootloader.RoleRecovery),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))))),
+		secboot.NewLoadChain(nbf("", cPath("recovery-bl/shim-hash1"), bootloader.RoleRecovery),
+			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash0"), bootloader.RoleRecovery),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode)))),
+			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash1"), bootloader.RoleRecovery),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))))),
 	}
 	c.Check(chains, DeepEquals, expected)
 }

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -110,4 +110,5 @@ var (
 	ToPredictableBootChain              = toPredictableBootChain
 	ToPredictableBootChains             = toPredictableBootChains
 	PredictableBootChainsEqualForReseal = predictableBootChainsEqualForReseal
+	BootAssetsToLoadChains              = bootAssetsToLoadChains
 )


### PR DESCRIPTION
this is just a cleanup on top #9306. See last commit 0177209