### PR TITLE
tests: remove "set -e" from function only shell libs

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 # shellcheck source=tests/lib/systemd.sh
 . "$TESTSLIB"/systemd.sh
 

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e -x
-
 # shellcheck source=tests/lib/dirs.sh
 . "$TESTSLIB/dirs.sh"
 # shellcheck source=tests/lib/state.sh


### PR DESCRIPTION
The two shell libraries "nested.sh" and "reset.sh" currently set
"set -e" or "set -e -x". None of the other shell helper libraries
we have are doing this. Plus if one sources the library it may
change the current "set -e" setting. This is especially problematic
if nested.sh is imported to interactively debug a nested failure.
The first failed command will exit the shell and the session.

Hence this commit removes the "set -e" from the libraries, this
option should be set from whatever imports the shell helper.
