### PR TITLE
nested: add support to telnet to serial port in nested VM

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -627,7 +627,7 @@ nested_start_core_vm_unit() {
         # XXX: remove once we no longer support xenial hosts
         PARAM_SERIAL="-serial file:${NESTED_LOGS_DIR}/serial.log"
     else
-        PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log -serial chardev:char0"
+        PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log,logappend=on -serial chardev:char0"
     fi
 
     # Set kvm attribute
@@ -903,7 +903,7 @@ nested_start_classic_vm() {
         # XXX: remove once we no longer support xenial hosts
         PARAM_SERIAL="-serial file:${NESTED_LOGS_DIR}/serial.log"
     else
-        PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log -serial chardev:char0"
+        PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log,logappend=on -serial chardev:char0"
     fi
     PARAM_BIOS=""
     PARAM_TPM=""

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -593,7 +593,13 @@ nested_start_core_vm_unit() {
     PARAM_CPU=""
     PARAM_TRACE="-d cpu_reset"
     PARAM_LOG="-D $NESTED_LOGS_DIR/qemu.log"
-    PARAM_SERIAL="-serial file:${NESTED_LOGS_DIR}/serial.log"
+    # Open port 7777 on the host so that failures in the nested VM (e.g. to
+    # create users) can be debugged interactively via
+    # "telnet localhost 7777". Also keeps the logs
+    #
+    # XXX: should serial just be logged to stdout so that we just need
+    #      to "journalctl -u nested-vm" to see what is going on ?
+    PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log -serial chardev:char0"
 
     # Set kvm attribute
     local ATTR_KVM
@@ -620,7 +626,6 @@ nested_start_core_vm_unit() {
     
     local PARAM_ASSERTIONS PARAM_BIOS PARAM_TPM PARAM_IMAGE
     PARAM_ASSERTIONS=""
-    PARAM_SERIAL="-serial file:${NESTED_LOGS_DIR}/serial.log"
     PARAM_BIOS=""
     PARAM_TPM=""
     if [ "$NESTED_USE_CLOUD_INIT" != "true" ]; then
@@ -845,7 +850,13 @@ nested_start_classic_vm() {
 
     PARAM_IMAGE="-drive file=$NESTED_IMAGES_DIR/$IMAGE_NAME,if=virtio"
     PARAM_SEED="-drive file=$NESTED_ASSETS_DIR/seed.img,if=virtio"
-    PARAM_SERIAL="-serial file:$NESTED_LOGS_DIR/serial.log"
+    # Open port 7777 on the host so that failures in the nested VM (e.g. to
+    # create users) can be debugged interactively via
+    # "telnet localhost 7777". Also keeps the logs
+    #
+    # XXX: should serial just be logged to stdout so that we just need
+    #      to "journalctl -u nested-vm" to see what is going on ?
+    PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log -serial chardev:char0"
     PARAM_BIOS=""
     PARAM_TPM=""
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -623,7 +623,12 @@ nested_start_core_vm_unit() {
     #
     # XXX: should serial just be logged to stdout so that we just need
     #      to "journalctl -u nested-vm" to see what is going on ?
-    PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log -serial chardev:char0"
+    if "$QEMU" -version | grep '2\.5'; then
+        # XXX: remove once we no longer support xenial hosts
+        PARAM_SERIAL="-serial file:${NESTED_LOGS_DIR}/serial.log"
+    else
+        PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log -serial chardev:char0"
+    fi
 
     # Set kvm attribute
     local ATTR_KVM
@@ -894,7 +899,12 @@ nested_start_classic_vm() {
     #
     # XXX: should serial just be logged to stdout so that we just need
     #      to "journalctl -u nested-vm" to see what is going on ?
-    PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log -serial chardev:char0"
+    if "$QEMU" -version | grep '2\.5'; then
+        # XXX: remove once we no longer support xenial hosts
+        PARAM_SERIAL="-serial file:${NESTED_LOGS_DIR}/serial.log"
+    else
+        PARAM_SERIAL="-chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=${NESTED_LOGS_DIR}/serial.log -serial chardev:char0"
+    fi
     PARAM_BIOS=""
     PARAM_TPM=""
 


### PR DESCRIPTION
This commit adds support to use telnet to access the nested VM
serial port. This is useful for interactive debugging of the
nested VM if e.g. the creation of a user fails. It is also useful
to test/play-with console-conf in the nested env.

With that inside the L1 qemu one can type:
```
$ telnet localhost 7777
```
to get access to the serial port.

With "ctrl-]" and "send escape\nq\n" the telnet session can be
stopped again.

As a drive-by it cleans a duplicated PARAM_SERIAL definition. We
should address the duplication of all the PARAM_* for qemu in a
followup.
