### PR TITLE
o/snapstate: disk space check with snap update

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -96,6 +96,8 @@ var (
 	DefaultContentPlugProviders = defaultContentPlugProviders
 
 	HasOtherInstances = hasOtherInstances
+
+	SafetyMarginDiskSpace = safetyMarginDiskSpace
 )
 
 func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
@@ -5334,4 +5335,76 @@ func (s *snapmgrTestSuite) TestEmptyUpdateWithChannelChangeAndAutoAlias(c *C) {
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.IsReady(), Equals, true)
+}
+
+func (s *snapmgrTestSuite) testUpdateDiskSpaceCheck(c *C, featureFlag, failInstallSize bool) error {
+	restore := snapstate.MockOsutilCheckFreeSpace(func(path string, sz uint64) error {
+		c.Check(sz, Equals, snapstate.SafetyMarginDiskSpace(123))
+		return &osutil.NotEnoughDiskSpaceError{}
+	})
+	defer restore()
+
+	var installSizeCalled bool
+
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+		installSizeCalled = true
+		if failInstallSize {
+			return 0, fmt.Errorf("boom")
+		}
+		c.Assert(snaps, HasLen, 1)
+		c.Check(snaps[0].InstanceName(), Equals, "some-snap")
+		return 123, nil
+	})
+	defer restoreInstallSize()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.check-disk-space-refresh", featureFlag)
+	tr.Commit()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
+		},
+		Current:  snap.R(4),
+		SnapType: "app",
+	})
+
+	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
+	_, err := snapstate.Update(s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
+
+	if featureFlag {
+		c.Check(installSizeCalled, Equals, true)
+	} else {
+		c.Check(installSizeCalled, Equals, false)
+	}
+
+	return err
+}
+
+func (s *snapmgrTestSuite) TestUpdateDiskSpaceError(c *C) {
+	featureFlag := true
+	failInstallSize := false
+	err := s.testUpdateDiskSpaceCheck(c, featureFlag, failInstallSize)
+	diskSpaceErr := err.(*snapstate.InsufficientSpaceError)
+	c.Assert(diskSpaceErr, ErrorMatches, `insufficient space in .* to perform "refresh" change for the following snaps: some-snap`)
+	c.Check(diskSpaceErr.Path, Equals, filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd"))
+	c.Check(diskSpaceErr.Snaps, DeepEquals, []string{"some-snap"})
+}
+
+func (s *snapmgrTestSuite) TestUpdateDiskCheckSkippedIfDisabled(c *C) {
+	featureFlag := false
+	failInstallSize := false
+	err := s.testUpdateDiskSpaceCheck(c, featureFlag, failInstallSize)
+	c.Check(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateDiskCheckInstallSizeError(c *C) {
+	featureFlag := true
+	failInstallSize := true
+	err := s.testUpdateDiskSpaceCheck(c, featureFlag, failInstallSize)
+	c.Check(err, ErrorMatches, "boom")
 }


### PR DESCRIPTION
Check disk space when updating single snap (and potentially of its prerequsites).