### PR TITLE
tests: fix snap-routime-portal-info test

### DIFF
--- a/tests/main/snap-routine-portal-info/task.yaml
+++ b/tests/main/snap-routine-portal-info/task.yaml
@@ -21,7 +21,7 @@ restore: |
 execute: |
     # Start a "sleep" process in the background
     #shellcheck disable=SC2016
-    tests.session -u test exec systemd-run --user --unit test-snapd-desktop-sleep.service /snap/bin/test-snapd-desktop.cmd sh -c 'touch $SNAP_USER_DATA/1.stamp && exec sleep 1h'
+    tests.session -u test exec systemd-run --user --unit test-snapd-desktop-sleep.service snap run test-snapd-desktop.cmd sh -c 'touch $SNAP_USER_DATA/1.stamp && exec sleep 1h'
     # Ensure that snap-confine has finished its task and that the snap process
     # is active. Note that we don't want to wait forever either.
     retry -n 30 --wait 0.1 test -e /home/test/snap/test-snapd-desktop/current/1.stamp

--- a/tests/main/snap-routine-portal-info/task.yaml
+++ b/tests/main/snap-routine-portal-info/task.yaml
@@ -21,7 +21,7 @@ restore: |
 execute: |
     # Start a "sleep" process in the background
     #shellcheck disable=SC2016
-    tests.session -u test exec systemd-run --user --unit test-snapd-desktop-sleep.service test-snapd-desktop.cmd sh -c 'touch $SNAP_USER_DATA/1.stamp && exec sleep 1h'
+    tests.session -u test exec systemd-run --user --unit test-snapd-desktop-sleep.service /snap/bin/test-snapd-desktop.cmd sh -c 'touch $SNAP_USER_DATA/1.stamp && exec sleep 1h'
     # Ensure that snap-confine has finished its task and that the snap process
     # is active. Note that we don't want to wait forever either.
     retry -n 30 --wait 0.1 test -e /home/test/snap/test-snapd-desktop/current/1.stamp


### PR DESCRIPTION
It is failing because it can't find the binary to execute:

2020-09-10 09:45:27 Error executing
external:ubuntu-core-16-64:tests/main/snap-routine-portal-info
(external:ubuntu-core-16-64) :

tests.session -u test exec systemd-run --user --unit
test-snapd-desktop-sleep.service test-snapd-desktop.cmd sh -c 'touch
$SNAP_USER_DATA/1.stamp && exec sleep 1h'
Failed to find executable test-snapd-desktop.cmd: No such file or
directory

This test just fails on external backend
