### PR TITLE
tests: use full path to test-snapd-refresh.version binary

### DIFF
--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -47,7 +47,7 @@ execute: |
 
     # We can run "snap run" as a test user, which does not have the permission
     # to create the run inhibition lock file.
-    su -c 'snap run test-snapd-refresh.version' test | MATCH v1
+    tests.session -u test exec snap run test-snapd-refresh.version | MATCH v1
 
     # Run a sleeper app to keep the snap busy. The purpose of the stamp file is
     # to allow us to synchronize with the concurrently running program.
@@ -97,4 +97,4 @@ execute: |
 
     # We can run "snap run" as a test user, which does not have the permission
     # to open the run inhibition lock file for writing.
-    su -c 'snap run test-snapd-refresh.version' test | MATCH v2
+    tests.session -u test exec snap run test-snapd-refresh.version | MATCH v2

--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -47,7 +47,7 @@ execute: |
 
     # We can run "snap run" as a test user, which does not have the permission
     # to create the run inhibition lock file.
-    tests.session -u test exec /snap/bin/test-snapd-refresh.version | MATCH v1
+    su -c 'snap run test-snapd-refresh.version' test | MATCH v1
 
     # Run a sleeper app to keep the snap busy. The purpose of the stamp file is
     # to allow us to synchronize with the concurrently running program.
@@ -97,4 +97,4 @@ execute: |
 
     # We can run "snap run" as a test user, which does not have the permission
     # to open the run inhibition lock file for writing.
-    tests.session -u test exec /snap/bin/test-snapd-refresh.version | MATCH v2
+    su -c 'snap run test-snapd-refresh.version' test | MATCH v2

--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -47,7 +47,7 @@ execute: |
 
     # We can run "snap run" as a test user, which does not have the permission
     # to create the run inhibition lock file.
-    tests.session -u test exec test-snapd-refresh.version | MATCH v1
+    tests.session -u test exec /snap/bin/test-snapd-refresh.version | MATCH v1
 
     # Run a sleeper app to keep the snap busy. The purpose of the stamp file is
     # to allow us to synchronize with the concurrently running program.
@@ -97,4 +97,4 @@ execute: |
 
     # We can run "snap run" as a test user, which does not have the permission
     # to open the run inhibition lock file for writing.
-    tests.session -u test exec test-snapd-refresh.version | MATCH v2
+    tests.session -u test exec /snap/bin/test-snapd-refresh.version | MATCH v2


### PR DESCRIPTION
Add full path to the test-snapd-refresh.version binary

This is the error running with external backend:

tests.session -u test exec test-snapd-refresh.version
/tmp/tests.session-4f317b13-6145-488d-9d94-b962b8dc6017/exec: 2: exec:
test-snapd-refresh.version: not found
grep error: pattern not found, got:
