### PR TITLE
[RFC] devicestate: keep log from install-mode on installed system

### DIFF
--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -11,3 +11,5 @@ defaults:
       power-key-action: ignore
       disable-backlight-service: true
       timezone: Europe/Malta
+    journal:
+      persistent: true

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -74,3 +74,7 @@ execute: |
 
     # check console-conf disabled
     nested_exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
+
+    # check journal is persistent
+    nested_exec "test -d /var/log/journal"
+    nested_exec "test -e /var/log/install-mode.log"


### PR DESCRIPTION
This commit ensures that we capture the full log of the emphemeral
install mode on the writable disk when installing the system.

This is useful for debugging if install mode worked as expected
or to get logs about why things are different than they should
have been.
