### PR TITLE
.github/workflows/test.yaml: also run 20.04 nested tests with UC20 label

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -276,7 +276,7 @@ jobs:
               echo "::set-output name=already-ran::true"
           fi
     - name: Run spread tests
-      if: "contains(github.event.pull_request.labels.*.name, 'Run nested') && steps.cached-results.outputs.already-ran != 'true'"
+      if: "(contains(github.event.pull_request.labels.*.name, 'Run nested') || ( contains(github.event.pull_request.labels.*.name, 'UC20') && ${{ matrix.system }}  == 'ubuntu-20.04-64' ) ) && steps.cached-results.outputs.already-ran != 'true'"
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |


### PR DESCRIPTION
This should help prevent situations where a UC20 test that doesn't seem to
affect nested tests doesn't have nested tests run, but in actuality it broke
something there because certain UC20 features can only be tested in nested
tests.

/me doesn't know JS very well so this might need to be force pushed a few times to get the syntax right