### PR TITLE
boot: in seal.go adjust error message and function names

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -58,9 +58,9 @@ var (
 
 	NewTrustedAssetsCache = newTrustedAssetsCache
 
-	ObserveSuccessfulBootWithAssets   = observeSuccessfulBootAssets
-	SealKeyToModeenv                  = sealKeyToModeenv
-	BuildRecoveryBootChainsForSystems = buildRecoveryBootChainsForSystems
+	ObserveSuccessfulBootWithAssets = observeSuccessfulBootAssets
+	SealKeyToModeenv                = sealKeyToModeenv
+	RecoveryBootChainsForSystems    = recoveryBootChainsForSystems
 )
 
 type BootAssetsMap = bootAssetsMap

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -198,6 +198,10 @@ func runModeBootChains(rbl, bl bootloader.Bootloader, model *asserts.Model, mode
 	return chains, nil
 }
 
+// buildBootAssets takes the BootFiles of a bootloader boot chain and
+// produces corresponding bootAssets with the matching current asset
+// hashes from modeenv plus it returns separately the last BootFile
+// which is for the kernel.
 func buildBootAssets(bootFiles []bootloader.BootFile, modeenv *Modeenv) (assets []bootAsset, kernel bootloader.BootFile, err error) {
 	assets = make([]bootAsset, len(bootFiles)-1)
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -156,7 +156,7 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 	}
 }
 
-func (s *sealSuite) TestBuildRecoveryBootChain(c *C) {
+func (s *sealSuite) TestRecoveryBootChain(c *C) {
 	// TODO:UC20: make the test support multiple recovery systems
 
 	for _, tc := range []struct {
@@ -231,7 +231,7 @@ func (s *sealSuite) TestBuildRecoveryBootChain(c *C) {
 			CurrentTrustedRecoveryBootAssets: tc.assetsMap,
 		}
 
-		bc, err := boot.BuildRecoveryBootChainsForSystems([]string{tc.recoverySystem}, bl, model, modeenv)
+		bc, err := boot.RecoveryBootChainsForSystems([]string{tc.recoverySystem}, bl, model, modeenv)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 			c.Assert(bc, HasLen, 1)

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -156,7 +156,7 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 	}
 }
 
-func (s *sealSuite) TestRecoveryBootChain(c *C) {
+func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 	// TODO:UC20: make the test support multiple recovery systems
 
 	for _, tc := range []struct {


### PR DESCRIPTION
This is a follow-up to PR #9300 containing minor comment, error message and function name tweaks.
