### PR TITLE
boot: add call to reseal an existing key

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -60,6 +60,7 @@ var (
 
 	ObserveSuccessfulBootWithAssets = observeSuccessfulBootAssets
 	SealKeyToModeenv                = sealKeyToModeenv
+	ResealKeyToModeenv              = resealKeyToModeenv
 	RecoveryBootChainsForSystems    = recoveryBootChainsForSystems
 )
 
@@ -89,6 +90,14 @@ func MockSecbootSealKey(f func(key secboot.EncryptionKey, params *secboot.SealKe
 	secbootSealKey = f
 	return func() {
 		secbootSealKey = old
+	}
+}
+
+func MockSecbootResealKey(f func(params *secboot.ResealKeyParams) error) (restore func()) {
+	old := secbootResealKey
+	secbootResealKey = f
+	return func() {
+		secbootResealKey = old
 	}
 }
 

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -112,7 +112,7 @@ func resealKeyToModeenv(model *asserts.Model, modeenv *Modeenv) error {
 		return fmt.Errorf("cannot find the recovery bootloader: %v", err)
 	}
 
-	recoveryBootChains, err := recoveryBootChainsForSystems([]string{modeenv.RecoverySystem}, rbl, model, modeenv)
+	recoveryBootChains, err := recoveryBootChainsForSystems(modeenv.CurrentRecoverySystems, rbl, model, modeenv)
 	if err != nil {
 		return fmt.Errorf("cannot build recovery boot chain: %v", err)
 	}

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -156,6 +156,124 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 	}
 }
 
+func (s *sealSuite) TestResealKeyToModeenv(c *C) {
+	for _, tc := range []struct {
+		resealErr error
+		err       string
+	}{
+		{resealErr: nil, err: ""},
+		{resealErr: errors.New("reseal error"), err: "cannot reseal the encryption key: reseal error"},
+	} {
+		tmpDir := c.MkDir()
+		dirs.SetRootDir(tmpDir)
+		defer dirs.SetRootDir("")
+
+		err := createMockGrubCfg(filepath.Join(tmpDir, "run/mnt/ubuntu-seed"))
+		c.Assert(err, IsNil)
+
+		err = createMockGrubCfg(filepath.Join(tmpDir, "run/mnt/ubuntu-boot"))
+		c.Assert(err, IsNil)
+
+		modeenv := &boot.Modeenv{
+			RecoverySystem: "20200825",
+			CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+				"grubx64.efi": []string{"grub-hash-1"},
+				"bootx64.efi": []string{"shim-hash-1", "shim-hash-2"},
+			},
+
+			CurrentTrustedBootAssets: boot.BootAssetsMap{
+				"grubx64.efi": []string{"run-grub-hash-1", "run-grub-hash-2"},
+			},
+
+			CurrentKernels: []string{"pc-kernel_500.snap", "pc-kernel_600.snap"},
+		}
+
+		// mock asset cache
+		p := filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-1")
+		err = os.MkdirAll(filepath.Dir(p), 0755)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(p, nil, 0644)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-2"), nil, 0644)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-grub-hash-1"), nil, 0644)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-1"), nil, 0644)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-2"), nil, 0644)
+		c.Assert(err, IsNil)
+
+		model := makeMockUC20Model()
+
+		// set a mock recovery kernel
+		readSystemEssentialCalls := 0
+		restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
+			readSystemEssentialCalls++
+			kernelSnap := &seed.Snap{
+				Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
+				SideInfo: &snap.SideInfo{
+					Revision: snap.Revision{N: 0},
+				},
+			}
+			return model, []*seed.Snap{kernelSnap}, nil
+		})
+		defer restore()
+
+		// set mock key resealing
+		resealKeyCalls := 0
+		restore = boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
+			resealKeyCalls++
+			c.Assert(params.ModelParams, HasLen, 3)
+
+			// recovery parameters
+			shim := bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-1"), bootloader.RoleRecovery)
+			shim2 := bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-2"), bootloader.RoleRecovery)
+			grub := bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-grub-hash-1"), bootloader.RoleRecovery)
+			kernel := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
+
+			c.Assert(params.ModelParams[0].EFILoadChains, DeepEquals, []*secboot.LoadChain{
+				secboot.NewLoadChain(shim, secboot.NewLoadChain(grub, secboot.NewLoadChain(kernel))),
+				secboot.NewLoadChain(shim2, secboot.NewLoadChain(grub, secboot.NewLoadChain(kernel))),
+			})
+			c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
+				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+			})
+			c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
+
+			// run mode parameters
+			runGrub := bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-1"), bootloader.RoleRunMode)
+			runGrub2 := bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-2"), bootloader.RoleRunMode)
+			runKernel := bootloader.NewBootFile(filepath.Join(tmpDir, "var/lib/snapd/snaps/pc-kernel_500.snap"), "kernel.efi", bootloader.RoleRunMode)
+
+			c.Assert(params.ModelParams[1].EFILoadChains, DeepEquals, []*secboot.LoadChain{
+				secboot.NewLoadChain(shim, secboot.NewLoadChain(grub,
+					secboot.NewLoadChain(runGrub, secboot.NewLoadChain(runKernel)),
+					secboot.NewLoadChain(runGrub2, secboot.NewLoadChain(runKernel)),
+				)),
+				secboot.NewLoadChain(shim2, secboot.NewLoadChain(grub,
+					secboot.NewLoadChain(runGrub, secboot.NewLoadChain(runKernel)),
+					secboot.NewLoadChain(runGrub2, secboot.NewLoadChain(runKernel)),
+				)),
+			})
+			c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
+				"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+			})
+			c.Assert(params.ModelParams[1].Model.DisplayName(), Equals, "My Model")
+
+			return tc.resealErr
+		})
+		defer restore()
+
+		err = boot.ResealKeyToModeenv(model, modeenv)
+		c.Assert(resealKeyCalls, Equals, 1)
+		if tc.err == "" {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, ErrorMatches, tc.err)
+		}
+	}
+}
+
 func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 	// TODO:UC20: make the test support multiple recovery systems
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -125,8 +125,13 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 			runKernel := bootloader.NewBootFile(filepath.Join(tmpDir, "var/lib/snapd/snaps/pc-kernel_500.snap"), "kernel.efi", bootloader.RoleRunMode)
 
 			c.Assert(params.ModelParams[0].EFILoadChains, DeepEquals, []*secboot.LoadChain{
-				secboot.NewLoadChain(shim, secboot.NewLoadChain(grub, secboot.NewLoadChain(kernel))),
-				secboot.NewLoadChain(shim, secboot.NewLoadChain(grub, secboot.NewLoadChain(runGrub, secboot.NewLoadChain(runKernel)))),
+				secboot.NewLoadChain(shim,
+					secboot.NewLoadChain(grub,
+						secboot.NewLoadChain(kernel))),
+				secboot.NewLoadChain(shim,
+					secboot.NewLoadChain(grub,
+						secboot.NewLoadChain(runGrub,
+							secboot.NewLoadChain(runKernel)))),
 			})
 			c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
 				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
@@ -215,7 +220,16 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 		resealKeyCalls := 0
 		restore = boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
 			resealKeyCalls++
-			c.Assert(params.ModelParams, HasLen, 3)
+			c.Assert(params.ModelParams, HasLen, 1)
+
+			// shared parameters
+			c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
+			c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
+				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1", "snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+			})
+
+			// load chains
+			c.Assert(params.ModelParams[0].EFILoadChains, HasLen, 6)
 
 			// recovery parameters
 			shim := bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-1"), bootloader.RoleRecovery)
@@ -223,14 +237,14 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 			grub := bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-grub-hash-1"), bootloader.RoleRecovery)
 			kernel := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
 
-			c.Assert(params.ModelParams[0].EFILoadChains, DeepEquals, []*secboot.LoadChain{
-				secboot.NewLoadChain(shim, secboot.NewLoadChain(grub, secboot.NewLoadChain(kernel))),
-				secboot.NewLoadChain(shim2, secboot.NewLoadChain(grub, secboot.NewLoadChain(kernel))),
+			c.Assert(params.ModelParams[0].EFILoadChains[:2], DeepEquals, []*secboot.LoadChain{
+				secboot.NewLoadChain(shim,
+					secboot.NewLoadChain(grub,
+						secboot.NewLoadChain(kernel))),
+				secboot.NewLoadChain(shim2,
+					secboot.NewLoadChain(grub,
+						secboot.NewLoadChain(kernel))),
 			})
-			c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
-				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
-			})
-			c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
 
 			// run mode parameters
 			runGrub := bootloader.NewBootFile("", filepath.Join(tmpDir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-1"), bootloader.RoleRunMode)
@@ -238,30 +252,38 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 			runKernel := bootloader.NewBootFile(filepath.Join(tmpDir, "var/lib/snapd/snaps/pc-kernel_500.snap"), "kernel.efi", bootloader.RoleRunMode)
 			runKernel2 := bootloader.NewBootFile(filepath.Join(tmpDir, "var/lib/snapd/snaps/pc-kernel_600.snap"), "kernel.efi", bootloader.RoleRunMode)
 
-			c.Assert(params.ModelParams[1].EFILoadChains, DeepEquals, []*secboot.LoadChain{
-				secboot.NewLoadChain(shim, secboot.NewLoadChain(grub,
-					secboot.NewLoadChain(runGrub, secboot.NewLoadChain(runKernel)),
-					secboot.NewLoadChain(runGrub2, secboot.NewLoadChain(runKernel)),
-				)),
-				secboot.NewLoadChain(shim2, secboot.NewLoadChain(grub,
-					secboot.NewLoadChain(runGrub, secboot.NewLoadChain(runKernel)),
-					secboot.NewLoadChain(runGrub2, secboot.NewLoadChain(runKernel)),
-				)),
+			c.Assert(params.ModelParams[0].EFILoadChains[2:4], DeepEquals, []*secboot.LoadChain{
+				secboot.NewLoadChain(shim,
+					secboot.NewLoadChain(grub,
+						secboot.NewLoadChain(runGrub,
+							secboot.NewLoadChain(runKernel)),
+						secboot.NewLoadChain(runGrub2,
+							secboot.NewLoadChain(runKernel)),
+					)),
+				secboot.NewLoadChain(shim2,
+					secboot.NewLoadChain(grub,
+						secboot.NewLoadChain(runGrub,
+							secboot.NewLoadChain(runKernel)),
+						secboot.NewLoadChain(runGrub2,
+							secboot.NewLoadChain(runKernel)),
+					)),
 			})
-			c.Assert(params.ModelParams[1].KernelCmdlines, DeepEquals, []string{
-				"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
-			})
-			c.Assert(params.ModelParams[1].Model.DisplayName(), Equals, "My Model")
 
-			c.Assert(params.ModelParams[2].EFILoadChains, DeepEquals, []*secboot.LoadChain{
-				secboot.NewLoadChain(shim, secboot.NewLoadChain(grub,
-					secboot.NewLoadChain(runGrub, secboot.NewLoadChain(runKernel2)),
-					secboot.NewLoadChain(runGrub2, secboot.NewLoadChain(runKernel2)),
-				)),
-				secboot.NewLoadChain(shim2, secboot.NewLoadChain(grub,
-					secboot.NewLoadChain(runGrub, secboot.NewLoadChain(runKernel2)),
-					secboot.NewLoadChain(runGrub2, secboot.NewLoadChain(runKernel2)),
-				)),
+			c.Assert(params.ModelParams[0].EFILoadChains[4:], DeepEquals, []*secboot.LoadChain{
+				secboot.NewLoadChain(shim,
+					secboot.NewLoadChain(grub,
+						secboot.NewLoadChain(runGrub,
+							secboot.NewLoadChain(runKernel2)),
+						secboot.NewLoadChain(runGrub2,
+							secboot.NewLoadChain(runKernel2)),
+					)),
+				secboot.NewLoadChain(shim2,
+					secboot.NewLoadChain(grub,
+						secboot.NewLoadChain(runGrub,
+							secboot.NewLoadChain(runKernel2)),
+						secboot.NewLoadChain(runGrub2,
+							secboot.NewLoadChain(runKernel2)),
+					)),
 			})
 
 			return tc.resealErr

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -31,3 +31,7 @@ func CheckKeySealingSupported() error {
 func SealKey(key EncryptionKey, params *SealKeyParams) error {
 	return fmt.Errorf("build without secboot support")
 }
+
+func ResealKey(params *ResealKeyParams) error {
+	return fmt.Errorf("build without secboot support")
+}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -319,6 +319,7 @@ func SealKey(key EncryptionKey, params *SealKeyParams) error {
 	if err != nil {
 		return fmt.Errorf("cannot connect to TPM: %v", err)
 	}
+	defer tpm.Close()
 	if !isTPMEnabled(tpm) {
 		return fmt.Errorf("TPM device is not enabled")
 	}
@@ -353,6 +354,7 @@ func ResealKey(params *ResealKeyParams) error {
 	if err != nil {
 		return fmt.Errorf("cannot connect to TPM: %v", err)
 	}
+	defer tpm.Close()
 	if !isTPMEnabled(tpm) {
 		return fmt.Errorf("TPM device is not enabled")
 	}


### PR DESCRIPTION
Add the ResealKeyToModeenv() function that should be called after
modeenv is updated to reflect the state of the system we want to
reseal to.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
