### PR TITLE
snap/naming: upgrade TODO to TODO:UC20

### DIFF
--- a/snap/naming/wellknown.go
+++ b/snap/naming/wellknown.go
@@ -35,7 +35,7 @@ var (
 		"core":   "xMNMpEm0COPZy7jq9YRwWVLCD9q5peow",
 		"snapd":  "Z44rtQD1v4r1LXGPCDZAJO3AOw1EDGqy",
 		"core18": "NhSvwckvNdvgdiVGlsO1vYmi3FPdTZ9U",
-		// XXX no core20 uploaded to staging yet
+		// TODO:UC20 no core20 uploaded to staging yet
 		"core20": "",
 	}
 )


### PR DESCRIPTION
The core20 snap needs to be published to staging.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
