### PR TITLE
strutil: add SortedListsUniqueMerge

### DIFF
--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -71,6 +71,49 @@ func SortedListContains(list []string, str string) bool {
 	return list[i] == str
 }
 
+// SortedListsUniqueMerge merges the two given sorted lists of strings,
+// repeated values will appear once in the result.
+func SortedListsUniqueMerge(sl1, sl2 []string) []string {
+	n1 := len(sl1)
+	n2 := len(sl2)
+	sz := n1
+	if n2 > sz {
+		sz = n2
+	}
+	if sz == 0 {
+		return nil
+	}
+	m := make([]string, 0, sz)
+	appendUnique := func(s string) {
+		if l := len(m); l > 0 && m[l-1] == s {
+			return
+		}
+		m = append(m, s)
+	}
+	i, j := 0, 0
+	for i < n1 && j < n2 {
+		var s string
+		if sl1[i] < sl2[j] {
+			s = sl1[i]
+			i++
+		} else {
+			s = sl2[j]
+			j++
+		}
+		appendUnique(s)
+	}
+	if i < n1 {
+		for ; i < n1; i++ {
+			appendUnique(sl1[i])
+		}
+	} else if j < n2 {
+		for ; j < n2; j++ {
+			appendUnique(sl2[j])
+		}
+	}
+	return m
+}
+
 // TruncateOutput truncates input data by maxLines, imposing maxBytes limit (total) for them.
 // The maxLines may be 0 to avoid the constraint on number of lines.
 func TruncateOutput(data []byte, maxLines, maxBytes int) []byte {

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -223,5 +223,29 @@ func (strutilSuite) TestEllipt(c *check.C) {
 	} {
 		c.Check(strutil.ElliptRight(t.in, t.n), check.Equals, t.right, check.Commentf("%q[:%d] -> %q", t.in, t.n, t.right))
 		c.Check(strutil.ElliptLeft(t.in, t.n), check.Equals, t.left, check.Commentf("%q[-%d:] -> %q", t.in, t.n, t.left))
+	}
+}
+
+func (strutilSuite) TestSortedListsUniqueMerge(c *check.C) {
+	l1 := []string{"a", "a", "c", "d", "e", "f", "h", "h"}
+	l2 := []string{"b", "c", "d", "d", "g"}
+	l3 := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+
+	tests := []struct {
+		sl1 []string
+		sl2 []string
+		res []string
+	}{
+		{nil, nil, nil},
+		{nil, []string{"a", "a", "b"}, []string{"a", "b"}},
+		{[]string{"a", "a", "b"}, nil, []string{"a", "b"}},
+		{l1, l2, l3},
+		{l2, l1, l3},
+		{l3, l3, l3},
+	}
+
+	for _, t := range tests {
+		res := strutil.SortedListsUniqueMerge(t.sl1, t.sl2)
+		c.Check(res, check.DeepEquals, t.res)
 	}
 }


### PR DESCRIPTION
from the doc comment:

SortedListsUniqueMerge merges the two given sorted lists of strings, repeated values will appear once in the result.


This will be useful in #9320.