### PR TITLE
tests: fix for basic20 test running on external backend and rpi

### DIFF
--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -26,8 +26,11 @@ execute: |
     echo "Ensure passwd/group is available for snaps"
     test-snapd-sh-core20.sh -c 'cat /var/lib/extrausers/passwd' | MATCH test
 
+    #shellcheck source=tests/lib/names.sh
+    . "$TESTSLIB"/names.sh
+
     echo "Ensure extracted kernel.efi exists"
-    test -e /boot/grub/pc-kernel*/kernel.efi
+    test -e /boot/grub/"$kernel_name"*/kernel.efi
     test -e /boot/grub/kernel.efi
 
     echo "Ensure we are using managed boot assets"
@@ -58,4 +61,11 @@ execute: |
     done
 
     # ensure the "snap recovery" command works
-    snap recovery | MATCH '[0-9]+\ +canonical\*\ +ubuntu-core-20-[^ ]+\ +current'
+    MODEL="$(snap model | grep '^model' | awk '{ print $2 }')"
+    BRAND="$(snap model | grep '^brand' | cut -d' ' -f2- | xargs)"
+    if echo "$BRAND" | MATCH ".*\(.*\)"; then
+        BRAND="$(echo $BRAND | cut -d '(' -f2 | cut -d ')' -f1)"
+    elif [ "$BRAND" = "Canonical*" ]; then
+        BRAND="canonical\*"
+    fi
+    snap recovery | MATCH "[0-9]+ +$BRAND +$MODEL +current"

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -61,11 +61,9 @@ execute: |
     done
 
     # ensure the "snap recovery" command works
-    MODEL="$(snap model | grep '^model' | awk '{ print $2 }')"
-    BRAND="$(snap model | grep '^brand' | cut -d' ' -f2- | xargs)"
+    MODEL="$(snap model --verbose | grep '^model' | awk '{ print $2 }')"
+    BRAND="$(snap model --verbose | grep '^brand' | cut -d' ' -f2- | xargs)"
     if echo "$BRAND" | MATCH ".*\(.*\)"; then
         BRAND="$(echo $BRAND | cut -d '(' -f2 | cut -d ')' -f1)"
-    elif [ "$BRAND" = "Canonical*" ]; then
-        BRAND="canonical\*"
     fi
     snap recovery | MATCH "[0-9]+ +$BRAND +$MODEL +current"

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -62,8 +62,8 @@ execute: |
 
     # ensure the "snap recovery" command works
     MODEL="$(snap model --verbose | grep '^model' | awk '{ print $2 }')"
-    BRAND="$(snap model --verbose | grep '^brand' | cut -d' ' -f2- | xargs)"
-    if [ "$BRAND" = "canonical" ]; then
-        BRAND="canonical\*"
+    BRAND_ID="$(snap model --verbose | grep '^brand-id:' | awk '{print $2}')"
+    if [ "$(snap known account "username=$BRAND_ID" | grep '^validation:' | awk '{print $2}')" != "unproven" ]; then
+        BRAND_ID="$BRAND_ID\*"
     fi
-    snap recovery --unicode=never | MATCH "[0-9]+ +$BRAND +$MODEL +current"
+    snap recovery --unicode=never | MATCH "[0-9]+ +$BRAND_ID +$MODEL +current"

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -63,4 +63,7 @@ execute: |
     # ensure the "snap recovery" command works
     MODEL="$(snap model --verbose | grep '^model' | awk '{ print $2 }')"
     BRAND="$(snap model --verbose | grep '^brand' | cut -d' ' -f2- | xargs)"
-    snap recovery | MATCH "[0-9]+ +$BRAND +$MODEL +current"
+    if [ "$BRAND" = "canonical" ]; then
+        BRAND="canonical\*"
+    fi
+    snap recovery --unicode=never | MATCH "[0-9]+ +$BRAND +$MODEL +current"

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -63,7 +63,4 @@ execute: |
     # ensure the "snap recovery" command works
     MODEL="$(snap model --verbose | grep '^model' | awk '{ print $2 }')"
     BRAND="$(snap model --verbose | grep '^brand' | cut -d' ' -f2- | xargs)"
-    if echo "$BRAND" | MATCH ".*\(.*\)"; then
-        BRAND="$(echo $BRAND | cut -d '(' -f2 | cut -d ')' -f1)"
-    fi
     snap recovery | MATCH "[0-9]+ +$BRAND +$MODEL +current"


### PR DESCRIPTION
This fix includes:
 . Matching the right kernel which could be pc-kerne or pi-kernel
 . Checking snap recovery output against the model information

These changes are needed to make the test work with external backend on
lab devices
