### PR TITLE
boot: store boot chains during install, helper for checking whether reseal is needed

### DIFF
--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -265,6 +265,7 @@ func bootChainsFromFile(path string) (pbc predictableBootChains, err error) {
 		}
 		return nil, fmt.Errorf("cannot open existing boot chains state file: %v", err)
 	}
+	defer inf.Close()
 	if err := json.NewDecoder(inf).Decode(&pbc); err != nil {
 		return nil, fmt.Errorf("cannot read boot chains data: %v", err)
 	}

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -1180,7 +1180,7 @@ func (s *sealSuite) TestReadWriteBootChains(c *C) {
 
 	rootdir := c.MkDir()
 
-	expected := `[{"brand-id":"mybrand","model":"foo","grade":"dangerous","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"shim","hashes":["x","y"]},{"role":"recovery","name":"loader","hashes":["c","d"]}],"kernel":"pc-kernel-recovery","kernel-revision":"1234","kernel-cmdlines":["snapd_recovery_mode=recover foo"]},{"brand-id":"mybrand","model":"foo","grade":"signed","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"shim","hashes":["x","y"]},{"role":"recovery","name":"loader","hashes":["c","d"]},{"role":"run-mode","name":"loader","hashes":["x","z"]}],"kernel":"pc-kernel-other","kernel-revision":"2345","kernel-cmdlines":["snapd_recovery_mode=run foo"]}]
+	expected := `{"boot-chains":[{"brand-id":"mybrand","model":"foo","grade":"dangerous","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"shim","hashes":["x","y"]},{"role":"recovery","name":"loader","hashes":["c","d"]}],"kernel":"pc-kernel-recovery","kernel-revision":"1234","kernel-cmdlines":["snapd_recovery_mode=recover foo"]},{"brand-id":"mybrand","model":"foo","grade":"signed","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"shim","hashes":["x","y"]},{"role":"recovery","name":"loader","hashes":["c","d"]},{"role":"run-mode","name":"loader","hashes":["x","z"]}],"kernel":"pc-kernel-other","kernel-revision":"2345","kernel-cmdlines":["snapd_recovery_mode=run foo"]}]}
 `
 	// creates a complete tree and writes a file
 	err := boot.BootChainsToFile(pbc, filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
@@ -1210,7 +1210,7 @@ func (s *sealSuite) TestReadWriteBootChains(c *C) {
 	c.Assert(os.Chmod(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"), 0000), IsNil)
 	defer os.Chmod(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"), 0755)
 	loaded, err = boot.BootChainsFromFile(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
-	c.Assert(err, ErrorMatches, "cannot open existing boot chains state file: open .*/boot-chains: permission denied")
+	c.Assert(err, ErrorMatches, "cannot open existing boot chains data file: open .*/boot-chains: permission denied")
 	c.Check(loaded, IsNil)
 
 	// loading from a file that does not exist yields a nil boot chain

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -134,8 +134,8 @@ var (
 	PredictableBootChainsEqualForReseal = predictableBootChainsEqualForReseal
 	BootAssetsToLoadChains              = bootAssetsToLoadChains
 	BootAssetLess                       = bootAssetLess
-	BootChainsToFile                    = bootChainsToFile
-	BootChainsFromFile                  = bootChainsFromFile
+	BootChainsToFile                    = writeBootChains
+	BootChainsFromFile                  = readBootChains
 	IsResealNeeded                      = isResealNeeded
 )
 

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -125,6 +125,8 @@ var (
 	PredictableBootChainsEqualForReseal = predictableBootChainsEqualForReseal
 	BootAssetsToLoadChains              = bootAssetsToLoadChains
 	BootAssetLess                       = bootAssetLess
+	BootChainsToFile                    = bootChainsToFile
+	BootChainsFromFile                  = bootChainsFromFile
 )
 
 func (b *bootChain) SetModelAssertion(model *asserts.Model) {

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -127,6 +127,7 @@ var (
 	BootAssetLess                       = bootAssetLess
 	BootChainsToFile                    = bootChainsToFile
 	BootChainsFromFile                  = bootChainsFromFile
+	IsResealNeeded                      = isResealNeeded
 )
 
 func (b *bootChain) SetModelAssertion(model *asserts.Model) {

--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -71,7 +71,7 @@ func setInitramfsDirVars(rootdir string) {
 	InitramfsUbuntuBootDir = filepath.Join(InitramfsRunMntDir, "ubuntu-boot")
 	InitramfsUbuntuSeedDir = filepath.Join(InitramfsRunMntDir, "ubuntu-seed")
 	InstallHostWritableDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data", "system-data")
-	InstallHostFDEDataDir = filepath.Join(InstallHostWritableDir, "var/lib/snapd/device/fde")
+	InstallHostFDEDataDir = dirs.SnapFDEDirUnder(InstallHostWritableDir)
 	InitramfsWritableDir = filepath.Join(InitramfsDataDir, "system-data")
 	InitramfsEncryptionKeyDir = filepath.Join(InitramfsUbuntuSeedDir, "device/fde")
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -446,7 +446,7 @@ version: 5.0
 		kernelSnap := &seed.Snap{
 			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 0},
+				Revision: snap.Revision{N: -1},
 				RealName: "pc-kernel",
 			},
 		}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -564,6 +564,56 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 
 	// make sure SealKey was called
 	c.Check(sealKeyCalls, Equals, 1)
+
+	pbc, err := boot.BootChainsFromFile(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"))
+	c.Assert(err, IsNil)
+	c.Check(pbc, DeepEquals, boot.PredictableBootChains{
+		boot.BootChain{
+			BrandID:        "my-brand",
+			Model:          "my-model-uc20",
+			Grade:          "dangerous",
+			ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+			AssetChain: []boot.BootAsset{
+				{
+					Role:   "recovery",
+					Name:   "bootx64.efi",
+					Hashes: []string{"39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"},
+				}, {
+					Role:   "recovery",
+					Name:   "grubx64.efi",
+					Hashes: []string{"aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"},
+				},
+			},
+			Kernel:         "pc-kernel",
+			KernelRevision: "",
+			KernelCmdlines: []string{
+				"snapd_recovery_mode=recover snapd_recovery_system=20191216 console=ttyS0 console=tty1 panic=-1",
+			},
+		},
+		boot.BootChain{
+			BrandID:        "my-brand",
+			Model:          "my-model-uc20",
+			Grade:          "dangerous",
+			ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+			AssetChain: []boot.BootAsset{
+				{
+					Role: "recovery", Name: "bootx64.efi",
+					Hashes: []string{"39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"},
+				}, {
+					Role: "recovery", Name: "grubx64.efi",
+					Hashes: []string{"aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"},
+				}, {
+					Role: "run-mode", Name: "grubx64.efi",
+					Hashes: []string{"5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"},
+				},
+			},
+			Kernel:         "pc-kernel",
+			KernelRevision: "5",
+			KernelCmdlines: []string{
+				"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+			},
+		},
+	})
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20RunModeInstallBootConfigErr(c *C) {

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -446,7 +446,7 @@ version: 5.0
 		kernelSnap := &seed.Snap{
 			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: -1},
+				Revision: snap.Revision{N: 1},
 				RealName: "pc-kernel",
 			},
 		}
@@ -585,7 +585,7 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 				},
 			},
 			Kernel:         "pc-kernel",
-			KernelRevision: "",
+			KernelRevision: "1",
 			KernelCmdlines: []string{
 				"snapd_recovery_mode=recover snapd_recovery_system=20191216 console=ttyS0 console=tty1 panic=-1",
 			},

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -40,6 +40,10 @@ var (
 	seedReadSystemEssential = seed.ReadSystemEssential
 )
 
+func bootChainsFileUnder(rootdir string) string {
+	return filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains")
+}
+
 // sealKeyToModeenv seals the supplied key to the parameters specified
 // in modeenv.
 func sealKeyToModeenv(key secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
@@ -97,9 +101,9 @@ func sealKeyToModeenv(key secboot.EncryptionKey, model *asserts.Model, modeenv *
 		return fmt.Errorf("cannot seal the encryption key: %v", err)
 	}
 
-	installBootChainsPath := filepath.Join(dirs.SnapFDEDirUnder(InstallHostWritableDir), "boot-chains")
+	installBootChainsPath := bootChainsFileUnder(InstallHostWritableDir)
 	if err := writeBootChains(pbc, installBootChainsPath); err != nil {
-		return fmt.Errorf("cannot store boot chains: %v", err)
+		return err
 	}
 
 	return nil
@@ -167,7 +171,7 @@ func resealKeyToModeenv(model *asserts.Model, modeenv *Modeenv) error {
 		return fmt.Errorf("cannot reseal the encryption key: %v", err)
 	}
 
-	bootChainsPath := filepath.Join(dirs.SnapFDEDirUnder(InstallHostWritableDir), "boot-chains")
+	bootChainsPath := bootChainsFileUnder(InstallHostWritableDir)
 	if err := writeBootChains(pbc, bootChainsPath); err != nil {
 		return err
 	}
@@ -335,7 +339,7 @@ func sealKeyModelParams(pbc predictableBootChains, roleToBlName map[bootloader.R
 // isResealNeeded returns true when the predictable boot chains provided as
 // input do not match the cached boot chains on disk under rootdir.
 func isResealNeeded(pbc predictableBootChains, rootdir string) (bool, error) {
-	previousPbc, err := readBootChains(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
+	previousPbc, err := readBootChains(bootChainsFileUnder(rootdir))
 	if err != nil {
 		return false, err
 	}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -98,7 +98,7 @@ func sealKeyToModeenv(key secboot.EncryptionKey, model *asserts.Model, modeenv *
 	}
 
 	installBootChainsPath := filepath.Join(dirs.SnapFDEDirUnder(InstallHostWritableDir), "boot-chains")
-	if err := bootChainsToFile(pbc, installBootChainsPath); err != nil {
+	if err := writeBootChains(pbc, installBootChainsPath); err != nil {
 		return fmt.Errorf("cannot store boot chains: %v", err)
 	}
 
@@ -168,8 +168,8 @@ func resealKeyToModeenv(model *asserts.Model, modeenv *Modeenv) error {
 	}
 
 	bootChainsPath := filepath.Join(dirs.SnapFDEDirUnder(InstallHostWritableDir), "boot-chains")
-	if err := bootChainsToFile(pbc, bootChainsPath); err != nil {
-		return fmt.Errorf("cannot store boot chains: %v", err)
+	if err := writeBootChains(pbc, bootChainsPath); err != nil {
+		return err
 	}
 
 	return nil
@@ -333,11 +333,11 @@ func sealKeyModelParams(pbc predictableBootChains, roleToBlName map[bootloader.R
 }
 
 // isResealNeeded returns true when the predictable boot chains provided as
-// input do not match the cached boot chains on disk.
+// input do not match the cached boot chains on disk under rootdir.
 func isResealNeeded(pbc predictableBootChains, rootdir string) (bool, error) {
-	otherPbc, err := bootChainsFromFile(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
+	previousPbc, err := readBootChains(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
 	if err != nil {
 		return false, err
 	}
-	return !predictableBootChainsEqualForReseal(pbc, otherPbc), nil
+	return !predictableBootChainsEqualForReseal(pbc, previousPbc), nil
 }

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -586,6 +586,6 @@ func (s *sealSuite) TestIsResealNeeded(c *C) {
 	c.Assert(os.Chmod(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"), 0000), IsNil)
 	defer os.Chmod(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"), 0755)
 	needed, err = boot.IsResealNeeded(otherchain, rootdir)
-	c.Assert(err, ErrorMatches, "cannot open existing boot chains state file: open .*/boot-chains: permission denied")
+	c.Assert(err, ErrorMatches, "cannot open existing boot chains data file: open .*/boot-chains: permission denied")
 	c.Check(needed, Equals, false)
 }

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -100,6 +100,7 @@ var (
 
 	SnapModeenvFile   string
 	SnapBootAssetsDir string
+	SnapFDEDir        string
 
 	CloudMetaDataFile     string
 	CloudInstanceDataFile string
@@ -255,6 +256,17 @@ func SnapBootAssetsDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "boot-assets")
 }
 
+// SnapDeviceDirUnder returns the path to device directory under rootdir.
+func SnapDeviceDirUnder(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir, "device")
+}
+
+// SnapFDEDirUnder returns the path to full disk encryption state directory
+// under rootdir.
+func SnapFDEDirUnder(rootdir string) string {
+	return filepath.Join(SnapDeviceDirUnder(rootdir), "fde")
+}
+
 // AddRootDirCallback registers a callback for whenever the global root
 // directory (set by SetRootDir) is changed to enable updates to variables in
 // other packages that depend on its location.
@@ -329,10 +341,11 @@ func SetRootDir(rootdir string) {
 	SnapAuxStoreInfoDir = filepath.Join(SnapCacheDir, "aux")
 
 	SnapSeedDir = SnapSeedDirUnder(rootdir)
-	SnapDeviceDir = filepath.Join(rootdir, snappyDir, "device")
+	SnapDeviceDir = SnapDeviceDirUnder(rootdir)
 
 	SnapModeenvFile = SnapModeenvFileUnder(rootdir)
 	SnapBootAssetsDir = SnapBootAssetsDirUnder(rootdir)
+	SnapFDEDir = SnapDeviceDirUnder(rootdir)
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")
 	SnapRepairStateFile = filepath.Join(SnapRepairDir, "repair.json")


### PR DESCRIPTION
A bunch of helpers for checking whether reseal is actually needed and storing boot chains. Store the boot chains during installation.
