### PR TITLE
boot: consider boot chains with unrevisioned kernels incomparable

### DIFF
--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -188,6 +188,18 @@ func (b byBootChainOrder) Less(i, j int) bool {
 
 type predictableBootChains []bootChain
 
+// hasUnrevisionedKernels returns true if any of the chains have an
+// unrevisioned kernel. Revisions will not be set for unasserted
+// kernels.
+func (pbc predictableBootChains) hasUnrevisionedKernels() bool {
+	for i := range pbc {
+		if pbc[i].KernelRevision == "" {
+			return true
+		}
+	}
+	return false
+}
+
 func toPredictableBootChains(chains []bootChain) predictableBootChains {
 	if chains == nil {
 		return nil
@@ -201,7 +213,8 @@ func toPredictableBootChains(chains []bootChain) predictableBootChains {
 }
 
 // predictableBootChainsEqualForReseal returns true when boot chains are
-// equivalent for reseal.
+// equivalent for reseal. If the chains contain unrevisioned kernels
+// this always return false, such chains are incomparable.
 func predictableBootChainsEqualForReseal(pb1, pb2 predictableBootChains) bool {
 	pb1JSON, err := json.Marshal(pb1)
 	if err != nil {
@@ -211,8 +224,7 @@ func predictableBootChainsEqualForReseal(pb1, pb2 predictableBootChains) bool {
 	if err != nil {
 		return false
 	}
-	// TODO:UC20: return false if either chains have unasserted kernels
-	return bytes.Equal(pb1JSON, pb2JSON)
+	return bytes.Equal(pb1JSON, pb2JSON) && !pb1.hasUnrevisionedKernels()
 }
 
 // bootAssetsToLoadChains generates a list of load chains covering given boot

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -269,6 +269,23 @@ func (s *bootchainSuite) TestPredictableBootChainsEqualForReseal(c *C) {
 		[]boot.BootChain{pbMoreAssets[0]},
 		[]boot.BootChain{pbMoreAssets[1]}),
 		Equals, false)
+
+	// unrevisioned/unasserted kernels
+	bcUnrevOne := []boot.BootChain{pbJustOne[0]}
+	bcUnrevOne[0].KernelRevision = ""
+	pbUnrevOne := boot.ToPredictableBootChains(bcUnrevOne)
+	// soundness
+	c.Check(boot.PredictableBootChainsEqualForReseal(pbJustOne, pbJustOne), Equals, true)
+	// never equal even with self because of unrevisioned
+	c.Check(boot.PredictableBootChainsEqualForReseal(pbJustOne, pbUnrevOne), Equals, false)
+	c.Check(boot.PredictableBootChainsEqualForReseal(pbUnrevOne, pbUnrevOne), Equals, false)
+
+	bcUnrevMoreAssets := []boot.BootChain{pbMoreAssets[0], pbMoreAssets[1]}
+	bcUnrevMoreAssets[1].KernelRevision = ""
+	pbUnrevMoreAssets := boot.ToPredictableBootChains(bcUnrevMoreAssets)
+	// never equal even with self because of unrevisioned
+	c.Check(boot.PredictableBootChainsEqualForReseal(pbUnrevMoreAssets, pbMoreAssets), Equals, false)
+	c.Check(boot.PredictableBootChainsEqualForReseal(pbUnrevMoreAssets, pbUnrevMoreAssets), Equals, false)
 }
 
 func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {


### PR DESCRIPTION
no revision wil be set of unasserted kernels, chains with them
should never be considered equivalent (for the time being) and
trigger resealing

