### PR TITLE
boot: reseal when updating boot assets

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -572,6 +572,11 @@ func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, 
 
 // BeforeWrite is called when the update process has been staged for execution.
 func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
+	if o.modeenv == nil {
+		// modeenv wasn't even loaded yet, meaning none of the trusted
+		// boot assets was updated
+		return nil
+	}
 	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
 		return fmt.Errorf("cannot reseal encryption key: %v", err)
 	}

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -333,6 +333,7 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model) (*TrustedAssetsUp
 
 	return &TrustedAssetsUpdateObserver{
 		cache: newTrustedAssetsCache(dirs.SnapBootAssetsDir),
+		model: model,
 	}, nil
 }
 
@@ -340,6 +341,7 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model) (*TrustedAssetsUp
 // attempts to reseal when needed.
 type TrustedAssetsUpdateObserver struct {
 	cache *trustedAssetsCache
+	model *asserts.Model
 
 	bootBootloader    bootloader.Bootloader
 	bootTrustedAssets []string
@@ -570,8 +572,9 @@ func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, 
 
 // BeforeWrite is called when the update process has been staged for execution.
 func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
-	// TODO:UC20:
-	// - reseal with a given state of modeenv
+	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
+		return fmt.Errorf("cannot reseal encryption key: %v", err)
+	}
 	return nil
 }
 
@@ -634,8 +637,9 @@ func (o *TrustedAssetsUpdateObserver) Canceled() error {
 		return fmt.Errorf("cannot write modeeenv: %v", err)
 	}
 
-	// TODO:UC20:
-	// - reseal with a given state of modeenv
+	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
+		return fmt.Errorf("cannot reseal encryption key after a canceled update: %v", err)
+	}
 	return nil
 }
 

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
@@ -35,7 +36,11 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timings"
 )
 
 type assetsSuite struct {
@@ -48,6 +53,9 @@ func (s *assetsSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755), IsNil)
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuSeedDir, 0755), IsNil)
+
+	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error { return nil })
+	s.AddCleanup(restore)
 }
 
 func checkContentGlob(c *C, glob string, expected []string) {
@@ -56,12 +64,12 @@ func checkContentGlob(c *C, glob string, expected []string) {
 	c.Check(l, DeepEquals, expected)
 }
 
-func (s *assetsSuite) uc20UpdateObserver(c *C) *boot.TrustedAssetsUpdateObserver {
+func (s *assetsSuite) uc20UpdateObserver(c *C) (*boot.TrustedAssetsUpdateObserver, *asserts.Model) {
 	uc20Model := makeMockUC20Model()
 	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
 	c.Assert(obs, NotNil)
 	c.Assert(err, IsNil)
-	return obs
+	return obs, uc20Model
 }
 
 func (s *assetsSuite) bootloaderWithTrustedAssets(c *C, trustedAssets []string) *bootloadertest.MockTrustedAssetsBootloader {
@@ -459,7 +467,7 @@ func (s *assetsSuite) TestInstallObserverObserveErr(c *C) {
 
 	bootloader.ForceError(fmt.Errorf("mocked bootloader error"))
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	err := ioutil.WriteFile(filepath.Join(d, "foobar"), []byte("data"), 0644)
 	c.Assert(err, IsNil)
@@ -630,8 +638,9 @@ func (s *assetsSuite) TestUpdateObserverNew(c *C) {
 	c.Assert(nonUC20obs, IsNil)
 }
 
-func (s *assetsSuite) TestUpdateObserverUpdateMocked(c *C) {
-	// observe an update where some of the assets exist and some are new
+func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
+	// observe an update where some of the assets exist and some are new,
+	// followed by reseal
 
 	d := c.MkDir()
 	backups := c.MkDir()
@@ -673,7 +682,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateMocked(c *C) {
 	})
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
 		&gadget.ContentChange{
@@ -722,6 +731,18 @@ func (s *assetsSuite) TestUpdateObserverUpdateMocked(c *C) {
 		"shim":        {shimHash},
 		"other-asset": {dataHash},
 	})
+
+	// everything is set up, trigger a reseal
+	resealCalls := 0
+	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
+		resealCalls++
+		return nil
+	})
+	defer restore()
+
+	err = obs.BeforeWrite()
+	c.Assert(err, IsNil)
+	c.Check(resealCalls, Equals, 1)
 }
 
 func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
@@ -768,7 +789,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	c.Assert(err, IsNil)
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// observe the updates
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
@@ -822,7 +843,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateNothingTrackedMocked(c *C) {
 	c.Assert(err, IsNil)
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// observe the updates
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
@@ -859,7 +880,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateOtherRoleStructMocked(c *C) {
 	// modeenv is not set up, but the observer should not care
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// non system-boot or system-seed structure gets ignored
 	mockVolumeStruct := &gadget.LaidOutStructure{
@@ -891,7 +912,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateNotTrustedMocked(c *C) {
 	// no need to mock modeenv, the bootloader has no trusted assets
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// observe the updates
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
@@ -908,7 +929,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateTrivialErr(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// first no bootloader
 	bootloader.ForceError(fmt.Errorf("bootloader fail"))
@@ -1052,7 +1073,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateAfterSuccessfulBootMocked(c *C) {
 	})
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
 		&gadget.ContentChange{
@@ -1133,7 +1154,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 	}
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	m := boot.Modeenv{
 		Mode: "run",
@@ -1210,7 +1231,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileSanity(c *C) {
 	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// sane state of modeenv before rollback
 	m := boot.Modeenv{
@@ -1245,7 +1266,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileSanity(c *C) {
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, HasLen, 0)
 
 	// new observer
-	obs = s.uc20UpdateObserver(c)
+	obs, _ = s.uc20UpdateObserver(c)
 	m = boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
@@ -1287,7 +1308,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 	seedDir := c.MkDir()
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	cache := boot.NewTrustedAssetsCache(dirs.SnapBootAssetsDir)
 
@@ -1475,7 +1496,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -1519,6 +1540,13 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		"asset": {"recoveryhash", dataHash},
 		"shim":  {shimHash},
 	})
+	resealCalls := 0
+	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
+		resealCalls++
+		return nil
+	})
+	defer restore()
+
 	// update is canceled
 	err = obs.Canceled()
 	c.Assert(err, IsNil)
@@ -1533,6 +1561,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		filepath.Join(dirs.SnapBootAssetsDir, "trusted", "asset-recoveryhash"),
 		filepath.Join(dirs.SnapBootAssetsDir, "trusted", "shim-shimhash"),
 	})
+
+	c.Check(resealCalls, Equals, 1)
 }
 
 func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
@@ -1565,7 +1595,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 	}
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	m := boot.Modeenv{
 		Mode: "run",
@@ -1659,7 +1689,14 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
+
+	resealCalls := 0
+	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
+		resealCalls++
+		return nil
+	})
+	defer restore()
 
 	// cancel the update
 	err = obs.Canceled()
@@ -1675,6 +1712,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 		filepath.Join(dirs.SnapBootAssetsDir, "trusted", "asset-recoveryhash"),
 		filepath.Join(dirs.SnapBootAssetsDir, "trusted", "shim-shimhash"),
 	})
+
+	c.Check(resealCalls, Equals, 0)
 
 	err = ioutil.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
 	c.Assert(err, IsNil)
@@ -1708,7 +1747,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledEmptyModeenvAssets(c *C) {
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// trigger loading modeenv and bootloader information
 	err = ioutil.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
@@ -1727,7 +1766,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledEmptyModeenvAssets(c *C) {
 	c.Check(afterCancelM.CurrentTrustedRecoveryBootAssets, HasLen, 0)
 
 	// get a new observer, and observe an update for run bootloader asset only
-	obs = s.uc20UpdateObserver(c)
+	obs, _ = s.uc20UpdateObserver(c)
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "shim",
 		&gadget.ContentChange{After: filepath.Join(d, "shim")})
 	c.Assert(err, IsNil)
@@ -1760,7 +1799,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledAfterRollback(c *C) {
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// trigger loading modeenv and bootloader information
 	err = ioutil.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
@@ -1824,7 +1863,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
@@ -2230,4 +2269,138 @@ func (s *assetsSuite) TestCopyBootAssetsCacheUnhappy(c *C) {
 	err = boot.CopyBootAssetsCacheToRoot(newRoot)
 	c.Assert(err, ErrorMatches, `cannot recreate cache directory "dir": .*: permission denied`)
 
+}
+
+func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
+	// observe an update followed by reseal
+
+	d := c.MkDir()
+	backups := c.MkDir()
+	root := c.MkDir()
+
+	// try to arrange the backups like the updater would do it
+	before := []byte("before")
+	beforeHash := "2df0976fd45ba2392dc7985cdfb7c2d096c1ea4917929dd7a0e9bffae90a443271e702663fc6a4189c1f4ab3ce7daee3"
+	err := ioutil.WriteFile(filepath.Join(backups, "asset.backup"), before, 0644)
+	c.Assert(err, IsNil)
+
+	data := []byte("foobar")
+	// SHA3-384
+	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
+	err = ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	c.Assert(err, IsNil)
+	shim := []byte("shim")
+	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
+	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	c.Assert(err, IsNil)
+
+	m := boot.Modeenv{
+		Mode: "run",
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {beforeHash},
+		},
+		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			"asset": {beforeHash},
+		},
+		CurrentRecoverySystems: []string{"recovery-system-label"},
+		CurrentKernels:         []string{"pc-kernel_500.snap"},
+	}
+	err = m.WriteTo("")
+	c.Assert(err, IsNil)
+
+	tab := s.bootloaderWithTrustedAssets(c, []string{
+		"asset",
+		"shim",
+	})
+
+	// we get an observer for UC20
+	obs, uc20model := s.uc20UpdateObserver(c)
+
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
+		&gadget.ContentChange{
+			After: filepath.Join(d, "foobar"),
+			// original content would get backed up by the updater
+			Before: filepath.Join(backups, "asset.backup"),
+		})
+	c.Assert(err, IsNil)
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "shim",
+		&gadget.ContentChange{After: filepath.Join(d, "shim")})
+	c.Assert(err, IsNil)
+	// observe the recovery struct
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, root, "shim",
+		&gadget.ContentChange{After: filepath.Join(d, "shim")})
+	c.Assert(err, IsNil)
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, root, "asset",
+		&gadget.ContentChange{
+			After: filepath.Join(d, "foobar"),
+			// original content
+			Before: filepath.Join(backups, "asset.backup"),
+		})
+	c.Assert(err, IsNil)
+	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDir, "trusted", "*"), []string{
+		filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)),
+		filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", beforeHash)),
+		filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("shim-%s", shimHash)),
+	})
+
+	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
+		kernelSnap := &seed.Snap{
+			Path: "/var/lib/snapd/seed/snaps/pc-linux_1.snap",
+			SideInfo: &snap.SideInfo{
+				Revision: snap.Revision{N: 0},
+				RealName: "pc-linux",
+			},
+		}
+		return uc20model, []*seed.Snap{kernelSnap}, nil
+	})
+	defer restore()
+
+	// everything is set up, trigger a reseal
+
+	resealCalls := 0
+	shimBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("shim-%s", shimHash)), bootloader.RoleRecovery)
+	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRecovery)
+	beforeAssetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", beforeHash)), bootloader.RoleRecovery)
+	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
+	runKernelBf := bootloader.NewBootFile(filepath.Join(s.rootdir, "var/lib/snapd/snaps/pc-kernel_500.snap"), "kernel.efi", bootloader.RoleRunMode)
+
+	tab.RecoveryBootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "shim", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "asset", bootloader.RoleRecovery),
+		recoveryKernelBf,
+	}
+	tab.BootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "shim", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "asset", bootloader.RoleRecovery),
+		runKernelBf,
+	}
+
+	restore = boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
+		resealCalls++
+
+		c.Assert(params.ModelParams, HasLen, 1)
+		mp := params.ModelParams[0]
+		c.Check(mp.Model, DeepEquals, uc20model)
+		for _, ch := range mp.EFILoadChains {
+			printChain(c, ch, "-")
+		}
+		c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
+			secboot.NewLoadChain(shimBf,
+				secboot.NewLoadChain(assetBf,
+					secboot.NewLoadChain(runKernelBf)),
+				secboot.NewLoadChain(beforeAssetBf,
+					secboot.NewLoadChain(runKernelBf))),
+			secboot.NewLoadChain(shimBf,
+				secboot.NewLoadChain(assetBf,
+					secboot.NewLoadChain(recoveryKernelBf)),
+				secboot.NewLoadChain(beforeAssetBf,
+					secboot.NewLoadChain(recoveryKernelBf))),
+		})
+		return nil
+	})
+	defer restore()
+
+	err = obs.BeforeWrite()
+	c.Assert(err, IsNil)
+	c.Check(resealCalls, Equals, 1)
 }


### PR DESCRIPTION
This is stacked on top of #9328. The relevant commit is https://github.com/snapcore/snapd/commit/2528fdbc7427fd0d980548d040a46e6cf436ba33