### PR TITLE
spread.yaml, tests/nested: misc changes

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -835,6 +835,7 @@ suites:
             # Directory where the images and test assets are stored
             NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/tmp/work-dir}")'
         manual: true
+        warn-timeout: 10m
         kill-timeout: 40m
         debug: |
             #shellcheck source=tests/lib/nested.sh
@@ -1024,6 +1025,7 @@ suites:
             if [ -f "${NESTED_LOGS_DIR}/serial.log" ]; then
                 cat "${NESTED_LOGS_DIR}/serial.log"
             fi
+        warn-timeout: 10m
         kill-timeout: 40m
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -917,9 +917,9 @@ nested_exec() {
 
 nested_exec_as() {
     local USER="$1"
-    local PWD="$2"
+    local PASSWD="$2"
     shift 2
-    sshpass -p "$PWD" ssh -p "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$USER"@localhost "$@"
+    sshpass -p "$PASSWD" ssh -p "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$USER"@localhost "$@"
 }
 
 nested_copy() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -465,8 +465,8 @@ EOF
                         EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $GADGET_SNAP"
                     fi
                     snap download --channel="latest/edge" snapd
-                    repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$PWD/new-snapd" "false"
-                    EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $PWD/new-snapd/snapd_*.snap"
+                    repack_snapd_deb_into_snapd_snap "$PWD"
+                    EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $PWD/snapd-from-deb.snap"
                 else
                     echo "unknown nested core system (host is $(lsb_release -cs) )"
                     exit 1

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -448,6 +448,16 @@ nested_create_core_vm() {
                         snap download --basename=pc --channel="20/edge" pc
                         unsquashfs -d pc-gadget pc.snap
                         nested_secboot_sign_gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+                        # also make logging persistent for easier debugging of 
+                        # test failures, otherwise we have no way to see what 
+                        # happened during a failed nested VM boot where we 
+                        # weren't able to login to a device
+                        cat >> pc-gadget/meta/gadget.yaml << EOF
+defaults:
+  system:
+    journal:
+      persistent: true
+EOF
                         snap pack pc-gadget/ "$NESTED_ASSETS_DIR"
 
                         GADGET_SNAP=$(ls "$NESTED_ASSETS_DIR"/pc_*.snap)


### PR DESCRIPTION
See individual commits for details. This arose out of my work on making nested tests work with fakestore and non-dangerous grade models for UC20.