### PR TITLE
boot: verify boot chain file in seal and reseal tests

### DIFF
--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -1183,7 +1183,7 @@ func (s *sealSuite) TestReadWriteBootChains(c *C) {
 	expected := `{"boot-chains":[{"brand-id":"mybrand","model":"foo","grade":"dangerous","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"shim","hashes":["x","y"]},{"role":"recovery","name":"loader","hashes":["c","d"]}],"kernel":"pc-kernel-recovery","kernel-revision":"1234","kernel-cmdlines":["snapd_recovery_mode=recover foo"]},{"brand-id":"mybrand","model":"foo","grade":"signed","model-sign-key-id":"my-key-id","asset-chain":[{"role":"recovery","name":"shim","hashes":["x","y"]},{"role":"recovery","name":"loader","hashes":["c","d"]},{"role":"run-mode","name":"loader","hashes":["x","z"]}],"kernel":"pc-kernel-other","kernel-revision":"2345","kernel-cmdlines":["snapd_recovery_mode=run foo"]}]}
 `
 	// creates a complete tree and writes a file
-	err := boot.BootChainsToFile(pbc, filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
+	err := boot.WriteBootChains(pbc, filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
 	c.Assert(err, IsNil)
 	c.Check(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"), testutil.FileEquals, expected)
 
@@ -1191,7 +1191,7 @@ func (s *sealSuite) TestReadWriteBootChains(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(fi.Mode().Perm(), Equals, os.FileMode(0600))
 
-	loaded, err := boot.BootChainsFromFile(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
+	loaded, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
 	c.Assert(err, IsNil)
 	c.Check(loaded, DeepEquals, pbc)
 	// boot chains should be same for reseal purpose
@@ -1203,18 +1203,18 @@ func (s *sealSuite) TestReadWriteBootChains(c *C) {
 	c.Assert(os.Chmod(dirs.SnapFDEDirUnder(otherRootdir), 0000), IsNil)
 	defer os.Chmod(dirs.SnapFDEDirUnder(otherRootdir), 0755)
 
-	err = boot.BootChainsToFile(pbc, filepath.Join(dirs.SnapFDEDirUnder(otherRootdir), "boot-chains"))
+	err = boot.WriteBootChains(pbc, filepath.Join(dirs.SnapFDEDirUnder(otherRootdir), "boot-chains"))
 	c.Assert(err, ErrorMatches, `cannot create a temporary boot chains file: open .*/boot-chains\.[a-zA-Z0-9]+~: permission denied`)
 
 	// make the original file non readable
 	c.Assert(os.Chmod(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"), 0000), IsNil)
 	defer os.Chmod(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"), 0755)
-	loaded, err = boot.BootChainsFromFile(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
+	loaded, err = boot.ReadBootChains(filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
 	c.Assert(err, ErrorMatches, "cannot open existing boot chains data file: open .*/boot-chains: permission denied")
 	c.Check(loaded, IsNil)
 
 	// loading from a file that does not exist yields a nil boot chain
-	loaded, err = boot.BootChainsFromFile("does-not-exist")
+	loaded, err = boot.ReadBootChains("does-not-exist")
 	c.Assert(err, IsNil)
 	c.Check(loaded, IsNil)
 }

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -134,8 +134,8 @@ var (
 	PredictableBootChainsEqualForReseal = predictableBootChainsEqualForReseal
 	BootAssetsToLoadChains              = bootAssetsToLoadChains
 	BootAssetLess                       = bootAssetLess
-	BootChainsToFile                    = writeBootChains
-	BootChainsFromFile                  = readBootChains
+	WriteBootChains                     = writeBootChains
+	ReadBootChains                      = readBootChains
 	IsResealNeeded                      = isResealNeeded
 )
 

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -565,55 +565,8 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 	// make sure SealKey was called
 	c.Check(sealKeyCalls, Equals, 1)
 
-	pbc, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"))
-	c.Assert(err, IsNil)
-	c.Check(pbc, DeepEquals, boot.PredictableBootChains{
-		boot.BootChain{
-			BrandID:        "my-brand",
-			Model:          "my-model-uc20",
-			Grade:          "dangerous",
-			ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
-			AssetChain: []boot.BootAsset{
-				{
-					Role:   "recovery",
-					Name:   "bootx64.efi",
-					Hashes: []string{"39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"},
-				}, {
-					Role:   "recovery",
-					Name:   "grubx64.efi",
-					Hashes: []string{"aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"},
-				},
-			},
-			Kernel:         "pc-kernel",
-			KernelRevision: "1",
-			KernelCmdlines: []string{
-				"snapd_recovery_mode=recover snapd_recovery_system=20191216 console=ttyS0 console=tty1 panic=-1",
-			},
-		},
-		boot.BootChain{
-			BrandID:        "my-brand",
-			Model:          "my-model-uc20",
-			Grade:          "dangerous",
-			ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
-			AssetChain: []boot.BootAsset{
-				{
-					Role: "recovery", Name: "bootx64.efi",
-					Hashes: []string{"39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"},
-				}, {
-					Role: "recovery", Name: "grubx64.efi",
-					Hashes: []string{"aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"},
-				}, {
-					Role: "run-mode", Name: "grubx64.efi",
-					Hashes: []string{"5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"},
-				},
-			},
-			Kernel:         "pc-kernel",
-			KernelRevision: "5",
-			KernelCmdlines: []string{
-				"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
-			},
-		},
-	})
+	// make sure we wrote the boot chains data file
+	c.Check(osutil.FileExists(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains")), Equals, true)
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20RunModeInstallBootConfigErr(c *C) {

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -565,7 +565,7 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 	// make sure SealKey was called
 	c.Check(sealKeyCalls, Equals, 1)
 
-	pbc, err := boot.BootChainsFromFile(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"))
+	pbc, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"))
 	c.Assert(err, IsNil)
 	c.Check(pbc, DeepEquals, boot.PredictableBootChains{
 		boot.BootChain{

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -112,7 +112,8 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 			kernelSnap := &seed.Snap{
 				Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 				SideInfo: &snap.SideInfo{
-					Revision: snap.Revision{N: 0},
+					RealName: "pc-kernel",
+					Revision: snap.Revision{N: 1},
 				},
 			}
 			return model, []*seed.Snap{kernelSnap}, nil
@@ -157,7 +158,65 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 			c.Assert(err, IsNil)
 		} else {
 			c.Assert(err, ErrorMatches, tc.err)
+			continue
 		}
+
+		// verify the boot chains data file
+		pbc, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"))
+		c.Assert(err, IsNil)
+		c.Check(pbc, DeepEquals, boot.PredictableBootChains{
+			boot.BootChain{
+				BrandID:        "my-brand",
+				Model:          "my-model-uc20",
+				Grade:          "dangerous",
+				ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+				AssetChain: []boot.BootAsset{
+					{
+						Role:   "recovery",
+						Name:   "bootx64.efi",
+						Hashes: []string{"shim-hash-1"},
+					},
+					{
+						Role:   "recovery",
+						Name:   "grubx64.efi",
+						Hashes: []string{"grub-hash-1"},
+					},
+				},
+				Kernel:         "pc-kernel",
+				KernelRevision: "1",
+				KernelCmdlines: []string{
+					"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+				},
+			},
+			boot.BootChain{
+				BrandID:        "my-brand",
+				Model:          "my-model-uc20",
+				Grade:          "dangerous",
+				ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+				AssetChain: []boot.BootAsset{
+					{
+						Role:   "recovery",
+						Name:   "bootx64.efi",
+						Hashes: []string{"shim-hash-1"},
+					},
+					{
+						Role:   "recovery",
+						Name:   "grubx64.efi",
+						Hashes: []string{"grub-hash-1"},
+					},
+					{
+						Role:   "run-mode",
+						Name:   "grubx64.efi",
+						Hashes: []string{"run-grub-hash-1"},
+					},
+				},
+				Kernel:         "pc-kernel",
+				KernelRevision: "500",
+				KernelCmdlines: []string{
+					"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+				},
+			},
+		})
 	}
 }
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -276,7 +276,8 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 			kernelSnap := &seed.Snap{
 				Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 				SideInfo: &snap.SideInfo{
-					Revision: snap.Revision{N: 0},
+					RealName: "pc-kernel",
+					Revision: snap.Revision{N: 1},
 				},
 			}
 			return model, []*seed.Snap{kernelSnap}, nil
@@ -363,7 +364,93 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 			c.Assert(err, IsNil)
 		} else {
 			c.Assert(err, ErrorMatches, tc.err)
+			continue
 		}
+
+		// verify the boot chains data file
+		pbc, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"))
+		c.Assert(err, IsNil)
+		c.Check(pbc, DeepEquals, boot.PredictableBootChains{
+			boot.BootChain{
+				BrandID:        "my-brand",
+				Model:          "my-model-uc20",
+				Grade:          "dangerous",
+				ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+				AssetChain: []boot.BootAsset{
+					{
+						Role:   "recovery",
+						Name:   "bootx64.efi",
+						Hashes: []string{"shim-hash-1", "shim-hash-2"},
+					},
+					{
+						Role:   "recovery",
+						Name:   "grubx64.efi",
+						Hashes: []string{"grub-hash-1"},
+					},
+				},
+				Kernel:         "pc-kernel",
+				KernelRevision: "1",
+				KernelCmdlines: []string{
+					"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+				},
+			},
+			boot.BootChain{
+				BrandID:        "my-brand",
+				Model:          "my-model-uc20",
+				Grade:          "dangerous",
+				ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+				AssetChain: []boot.BootAsset{
+					{
+						Role:   "recovery",
+						Name:   "bootx64.efi",
+						Hashes: []string{"shim-hash-1", "shim-hash-2"},
+					},
+					{
+						Role:   "recovery",
+						Name:   "grubx64.efi",
+						Hashes: []string{"grub-hash-1"},
+					},
+					{
+						Role:   "run-mode",
+						Name:   "grubx64.efi",
+						Hashes: []string{"run-grub-hash-1", "run-grub-hash-2"},
+					},
+				},
+				Kernel:         "pc-kernel",
+				KernelRevision: "500",
+				KernelCmdlines: []string{
+					"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+				},
+			},
+			boot.BootChain{
+				BrandID:        "my-brand",
+				Model:          "my-model-uc20",
+				Grade:          "dangerous",
+				ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+				AssetChain: []boot.BootAsset{
+					{
+						Role:   "recovery",
+						Name:   "bootx64.efi",
+						Hashes: []string{"shim-hash-1", "shim-hash-2"},
+					},
+					{
+						Role:   "recovery",
+						Name:   "grubx64.efi",
+						Hashes: []string{"grub-hash-1"},
+					},
+					{
+						Role:   "run-mode",
+						Name:   "grubx64.efi",
+						Hashes: []string{"run-grub-hash-1", "run-grub-hash-2"},
+					},
+				},
+				Kernel:         "pc-kernel",
+				KernelRevision: "600",
+				KernelCmdlines: []string{
+					"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+				},
+			},
+		})
 	}
 }
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -563,7 +563,7 @@ func (s *sealSuite) TestIsResealNeeded(c *C) {
 	pbc := boot.ToPredictableBootChains(chains)
 
 	rootdir := c.MkDir()
-	err := boot.BootChainsToFile(pbc, filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
+	err := boot.WriteBootChains(pbc, filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"))
 	c.Assert(err, IsNil)
 
 	needed, err := boot.IsResealNeeded(pbc, rootdir)


### PR DESCRIPTION
This is a follow-up to PR #9328 and moves the verification of the
boot chains file from makebootable_test.go to TestSealKeyToModeenv
and TestResealKeyToModeenv in seal_test.go.

Also fix exported test aliases for WriteBootChains and ReadBootChains.