### PR TITLE
boot,many: do not reseal unless is meaningful and necessary

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -572,6 +572,11 @@ func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, 
 
 // BeforeWrite is called when the update process has been staged for execution.
 func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
+	if o.modeenv == nil {
+		// modeenv wasn't even loaded yet, meaning none of the trusted
+		// boot assets was updated
+		return nil
+	}
 	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
 		return fmt.Errorf("cannot reseal encryption key: %v", err)
 	}

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -333,6 +333,7 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model) (*TrustedAssetsUp
 
 	return &TrustedAssetsUpdateObserver{
 		cache: newTrustedAssetsCache(dirs.SnapBootAssetsDir),
+		model: model,
 	}, nil
 }
 
@@ -340,6 +341,7 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model) (*TrustedAssetsUp
 // attempts to reseal when needed.
 type TrustedAssetsUpdateObserver struct {
 	cache *trustedAssetsCache
+	model *asserts.Model
 
 	bootBootloader    bootloader.Bootloader
 	bootTrustedAssets []string
@@ -570,8 +572,9 @@ func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, 
 
 // BeforeWrite is called when the update process has been staged for execution.
 func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
-	// TODO:UC20:
-	// - reseal with a given state of modeenv
+	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
+		return fmt.Errorf("cannot reseal encryption key: %v", err)
+	}
 	return nil
 }
 
@@ -634,8 +637,9 @@ func (o *TrustedAssetsUpdateObserver) Canceled() error {
 		return fmt.Errorf("cannot write modeeenv: %v", err)
 	}
 
-	// TODO:UC20:
-	// - reseal with a given state of modeenv
+	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
+		return fmt.Errorf("cannot reseal encryption key after a canceled update: %v", err)
+	}
 	return nil
 }
 

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -330,6 +330,10 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model) (*TrustedAssetsUp
 		// no need to observe updates when assets are not managed
 		return nil, ErrObserverNotApplicable
 	}
+	// there is no need to track assets if we did not seal any keys
+	if !hasSealedKeys(dirs.GlobalRootDir) {
+		return nil, ErrObserverNotApplicable
+	}
 
 	return &TrustedAssetsUpdateObserver{
 		cache: newTrustedAssetsCache(dirs.SnapBootAssetsDir),

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -80,6 +80,12 @@ func (s *assetsSuite) bootloaderWithTrustedAssets(c *C, trustedAssets []string) 
 	return tab
 }
 
+func (s *assetsSuite) stampSealedKeys(c *C) {
+	c.Assert(os.MkdirAll(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), 0755), IsNil)
+	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys"), nil, 0644)
+	c.Assert(err, IsNil)
+}
+
 func (s *assetsSuite) TestAssetsCacheAddRemove(c *C) {
 	cacheDir := c.MkDir()
 	d := c.MkDir()
@@ -675,6 +681,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
+	s.stampSealedKeys(c)
+
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"nested/other-asset",
@@ -748,6 +756,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
+
+	s.stampSealedKeys(c)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
@@ -1514,6 +1524,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
+
+	s.stampSealedKeys(c)
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 
@@ -2330,6 +2342,8 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
+	s.stampSealedKeys(c)
+
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"shim",
@@ -2459,6 +2473,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
+
+	s.stampSealedKeys(c)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
@@ -35,7 +36,11 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timings"
 )
 
 type assetsSuite struct {
@@ -48,6 +53,9 @@ func (s *assetsSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755), IsNil)
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuSeedDir, 0755), IsNil)
+
+	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error { return nil })
+	s.AddCleanup(restore)
 }
 
 func checkContentGlob(c *C, glob string, expected []string) {
@@ -56,12 +64,12 @@ func checkContentGlob(c *C, glob string, expected []string) {
 	c.Check(l, DeepEquals, expected)
 }
 
-func (s *assetsSuite) uc20UpdateObserver(c *C) *boot.TrustedAssetsUpdateObserver {
+func (s *assetsSuite) uc20UpdateObserver(c *C) (*boot.TrustedAssetsUpdateObserver, *asserts.Model) {
 	uc20Model := makeMockUC20Model()
 	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
 	c.Assert(obs, NotNil)
 	c.Assert(err, IsNil)
-	return obs
+	return obs, uc20Model
 }
 
 func (s *assetsSuite) bootloaderWithTrustedAssets(c *C, trustedAssets []string) *bootloadertest.MockTrustedAssetsBootloader {
@@ -459,7 +467,7 @@ func (s *assetsSuite) TestInstallObserverObserveErr(c *C) {
 
 	bootloader.ForceError(fmt.Errorf("mocked bootloader error"))
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	err := ioutil.WriteFile(filepath.Join(d, "foobar"), []byte("data"), 0644)
 	c.Assert(err, IsNil)
@@ -630,8 +638,9 @@ func (s *assetsSuite) TestUpdateObserverNew(c *C) {
 	c.Assert(nonUC20obs, IsNil)
 }
 
-func (s *assetsSuite) TestUpdateObserverUpdateMocked(c *C) {
-	// observe an update where some of the assets exist and some are new
+func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
+	// observe an update where some of the assets exist and some are new,
+	// followed by reseal
 
 	d := c.MkDir()
 	backups := c.MkDir()
@@ -673,7 +682,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateMocked(c *C) {
 	})
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
 		&gadget.ContentChange{
@@ -722,6 +731,18 @@ func (s *assetsSuite) TestUpdateObserverUpdateMocked(c *C) {
 		"shim":        {shimHash},
 		"other-asset": {dataHash},
 	})
+
+	// everything is set up, trigger a reseal
+	resealCalls := 0
+	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
+		resealCalls++
+		return nil
+	})
+	defer restore()
+
+	err = obs.BeforeWrite()
+	c.Assert(err, IsNil)
+	c.Check(resealCalls, Equals, 1)
 }
 
 func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
@@ -768,7 +789,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	c.Assert(err, IsNil)
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// observe the updates
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
@@ -822,7 +843,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateNothingTrackedMocked(c *C) {
 	c.Assert(err, IsNil)
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// observe the updates
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
@@ -859,7 +880,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateOtherRoleStructMocked(c *C) {
 	// modeenv is not set up, but the observer should not care
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// non system-boot or system-seed structure gets ignored
 	mockVolumeStruct := &gadget.LaidOutStructure{
@@ -891,7 +912,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateNotTrustedMocked(c *C) {
 	// no need to mock modeenv, the bootloader has no trusted assets
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// observe the updates
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
@@ -908,7 +929,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateTrivialErr(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// first no bootloader
 	bootloader.ForceError(fmt.Errorf("bootloader fail"))
@@ -1052,7 +1073,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateAfterSuccessfulBootMocked(c *C) {
 	})
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
 		&gadget.ContentChange{
@@ -1133,7 +1154,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 	}
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	m := boot.Modeenv{
 		Mode: "run",
@@ -1210,7 +1231,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileSanity(c *C) {
 	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// sane state of modeenv before rollback
 	m := boot.Modeenv{
@@ -1245,7 +1266,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileSanity(c *C) {
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, HasLen, 0)
 
 	// new observer
-	obs = s.uc20UpdateObserver(c)
+	obs, _ = s.uc20UpdateObserver(c)
 	m = boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
@@ -1287,7 +1308,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 	seedDir := c.MkDir()
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	cache := boot.NewTrustedAssetsCache(dirs.SnapBootAssetsDir)
 
@@ -1475,7 +1496,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -1519,6 +1540,13 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		"asset": {"recoveryhash", dataHash},
 		"shim":  {shimHash},
 	})
+	resealCalls := 0
+	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
+		resealCalls++
+		return nil
+	})
+	defer restore()
+
 	// update is canceled
 	err = obs.Canceled()
 	c.Assert(err, IsNil)
@@ -1533,6 +1561,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		filepath.Join(dirs.SnapBootAssetsDir, "trusted", "asset-recoveryhash"),
 		filepath.Join(dirs.SnapBootAssetsDir, "trusted", "shim-shimhash"),
 	})
+
+	c.Check(resealCalls, Equals, 1)
 }
 
 func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
@@ -1565,7 +1595,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 	}
 
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	m := boot.Modeenv{
 		Mode: "run",
@@ -1659,7 +1689,14 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
+
+	resealCalls := 0
+	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
+		resealCalls++
+		return nil
+	})
+	defer restore()
 
 	// cancel the update
 	err = obs.Canceled()
@@ -1675,6 +1712,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 		filepath.Join(dirs.SnapBootAssetsDir, "trusted", "asset-recoveryhash"),
 		filepath.Join(dirs.SnapBootAssetsDir, "trusted", "shim-shimhash"),
 	})
+
+	c.Check(resealCalls, Equals, 0)
 
 	err = ioutil.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
 	c.Assert(err, IsNil)
@@ -1708,7 +1747,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledEmptyModeenvAssets(c *C) {
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// trigger loading modeenv and bootloader information
 	err = ioutil.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
@@ -1727,7 +1766,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledEmptyModeenvAssets(c *C) {
 	c.Check(afterCancelM.CurrentTrustedRecoveryBootAssets, HasLen, 0)
 
 	// get a new observer, and observe an update for run bootloader asset only
-	obs = s.uc20UpdateObserver(c)
+	obs, _ = s.uc20UpdateObserver(c)
 	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "shim",
 		&gadget.ContentChange{After: filepath.Join(d, "shim")})
 	c.Assert(err, IsNil)
@@ -1760,7 +1799,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledAfterRollback(c *C) {
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	// trigger loading modeenv and bootloader information
 	err = ioutil.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
@@ -1824,7 +1863,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 	// we get an observer for UC20
-	obs := s.uc20UpdateObserver(c)
+	obs, _ := s.uc20UpdateObserver(c)
 
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
@@ -2230,4 +2269,138 @@ func (s *assetsSuite) TestCopyBootAssetsCacheUnhappy(c *C) {
 	err = boot.CopyBootAssetsCacheToRoot(newRoot)
 	c.Assert(err, ErrorMatches, `cannot recreate cache directory "dir": .*: permission denied`)
 
+}
+
+func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
+	// observe an update followed by reseal
+
+	d := c.MkDir()
+	backups := c.MkDir()
+	root := c.MkDir()
+
+	// try to arrange the backups like the updater would do it
+	before := []byte("before")
+	beforeHash := "2df0976fd45ba2392dc7985cdfb7c2d096c1ea4917929dd7a0e9bffae90a443271e702663fc6a4189c1f4ab3ce7daee3"
+	err := ioutil.WriteFile(filepath.Join(backups, "asset.backup"), before, 0644)
+	c.Assert(err, IsNil)
+
+	data := []byte("foobar")
+	// SHA3-384
+	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
+	err = ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	c.Assert(err, IsNil)
+	shim := []byte("shim")
+	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
+	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	c.Assert(err, IsNil)
+
+	m := boot.Modeenv{
+		Mode: "run",
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {beforeHash},
+		},
+		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			"asset": {beforeHash},
+		},
+		CurrentRecoverySystems: []string{"recovery-system-label"},
+		CurrentKernels:         []string{"pc-kernel_500.snap"},
+	}
+	err = m.WriteTo("")
+	c.Assert(err, IsNil)
+
+	tab := s.bootloaderWithTrustedAssets(c, []string{
+		"asset",
+		"shim",
+	})
+
+	// we get an observer for UC20
+	obs, uc20model := s.uc20UpdateObserver(c)
+
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "asset",
+		&gadget.ContentChange{
+			After: filepath.Join(d, "foobar"),
+			// original content would get backed up by the updater
+			Before: filepath.Join(backups, "asset.backup"),
+		})
+	c.Assert(err, IsNil)
+	_, err = obs.Observe(gadget.ContentUpdate, mockRunBootStruct, root, "shim",
+		&gadget.ContentChange{After: filepath.Join(d, "shim")})
+	c.Assert(err, IsNil)
+	// observe the recovery struct
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, root, "shim",
+		&gadget.ContentChange{After: filepath.Join(d, "shim")})
+	c.Assert(err, IsNil)
+	_, err = obs.Observe(gadget.ContentUpdate, mockSeedStruct, root, "asset",
+		&gadget.ContentChange{
+			After: filepath.Join(d, "foobar"),
+			// original content
+			Before: filepath.Join(backups, "asset.backup"),
+		})
+	c.Assert(err, IsNil)
+	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDir, "trusted", "*"), []string{
+		filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)),
+		filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", beforeHash)),
+		filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("shim-%s", shimHash)),
+	})
+
+	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
+		kernelSnap := &seed.Snap{
+			Path: "/var/lib/snapd/seed/snaps/pc-linux_1.snap",
+			SideInfo: &snap.SideInfo{
+				Revision: snap.Revision{N: 0},
+				RealName: "pc-linux",
+			},
+		}
+		return uc20model, []*seed.Snap{kernelSnap}, nil
+	})
+	defer restore()
+
+	// everything is set up, trigger a reseal
+
+	resealCalls := 0
+	shimBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("shim-%s", shimHash)), bootloader.RoleRecovery)
+	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRecovery)
+	beforeAssetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", beforeHash)), bootloader.RoleRecovery)
+	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
+	runKernelBf := bootloader.NewBootFile(filepath.Join(s.rootdir, "var/lib/snapd/snaps/pc-kernel_500.snap"), "kernel.efi", bootloader.RoleRunMode)
+
+	tab.RecoveryBootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "shim", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "asset", bootloader.RoleRecovery),
+		recoveryKernelBf,
+	}
+	tab.BootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "shim", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "asset", bootloader.RoleRecovery),
+		runKernelBf,
+	}
+
+	restore = boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
+		resealCalls++
+
+		c.Assert(params.ModelParams, HasLen, 1)
+		mp := params.ModelParams[0]
+		c.Check(mp.Model, DeepEquals, uc20model)
+		for _, ch := range mp.EFILoadChains {
+			printChain(c, ch, "-")
+		}
+		c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
+			secboot.NewLoadChain(shimBf,
+				secboot.NewLoadChain(assetBf,
+					secboot.NewLoadChain(runKernelBf)),
+				secboot.NewLoadChain(beforeAssetBf,
+					secboot.NewLoadChain(runKernelBf))),
+			secboot.NewLoadChain(shimBf,
+				secboot.NewLoadChain(assetBf,
+					secboot.NewLoadChain(recoveryKernelBf)),
+				secboot.NewLoadChain(beforeAssetBf,
+					secboot.NewLoadChain(recoveryKernelBf))),
+		})
+		return nil
+	})
+	defer restore()
+
+	err = obs.BeforeWrite()
+	c.Assert(err, IsNil)
+	c.Check(resealCalls, Equals, 1)
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -565,6 +565,9 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 	// make sure SealKey was called
 	c.Check(sealKeyCalls, Equals, 1)
 
+	// make sure the marker file for sealed key was created
+	c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys"), testutil.FilePresent)
+
 	// make sure we wrote the boot chains data file
 	c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"), testutil.FilePresent)
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -566,7 +566,7 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 	c.Check(sealKeyCalls, Equals, 1)
 
 	// make sure we wrote the boot chains data file
-	c.Check(osutil.FileExists(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains")), Equals, true)
+	c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"), testutil.FilePresent)
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20RunModeInstallBootConfigErr(c *C) {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -181,7 +181,14 @@ func resealKeyToModeenv(model *asserts.Model, modeenv *Modeenv) error {
 
 	pbc := toPredictableBootChains(append(runModeBootChains, recoveryBootChains...))
 
-	// TODO:UC20: load and compare the predictable bootchains
+	ok, err := isResealNeeded(pbc, InstallHostWritableDir)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// no need to actually reseal
+		return nil
+	}
 
 	roleToBlName := map[bootloader.Role]string{
 		bootloader.RoleRecovery: rbl.Name(),

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -293,7 +293,8 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 			// shared parameters
 			c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
 			c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
-				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1", "snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+				"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
 			})
 
 			// load chains

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -345,7 +345,7 @@ func SetRootDir(rootdir string) {
 
 	SnapModeenvFile = SnapModeenvFileUnder(rootdir)
 	SnapBootAssetsDir = SnapBootAssetsDirUnder(rootdir)
-	SnapFDEDir = SnapDeviceDirUnder(rootdir)
+	SnapFDEDir = SnapFDEDirUnder(rootdir)
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")
 	SnapRepairStateFile = filepath.Join(SnapRepairDir, "repair.json")

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2019 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -198,7 +198,7 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetOnCoreSimple(c *C, grade string) 
 
 	chg, t := s.setupGadgetUpdate(c, grade)
 
-	// procure modeenv
+	// procure modeenv and stamp that we sealed keys
 	if grade != "" {
 		// state after mark-seeded ran
 		modeenv := boot.Modeenv{
@@ -206,6 +206,12 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetOnCoreSimple(c *C, grade string) 
 			RecoverySystem: "",
 		}
 		err := modeenv.WriteTo("")
+		c.Assert(err, IsNil)
+
+		// sealed keys stamp
+		stamp := filepath.Join(dirs.SnapFDEDir, "sealed-keys")
+		c.Assert(os.MkdirAll(filepath.Dir(stamp), 0755), IsNil)
+		err = ioutil.WriteFile(stamp, nil, 0644)
 		c.Assert(err, IsNil)
 	}
 	devicestate.SetBootOkRan(s.mgr, true)


### PR DESCRIPTION
This uses a stamp file to track whether we sealed any keys at install.

Also don't make a TrustedAssetsUpdateObserver if we do not seal any keys.


9c82949 just some test tweaks

7f7f0fb and 9a039b6 have the new logic