### PR TITLE
boot,many: reseal only when meaningful and necessary

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -581,7 +581,7 @@ func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
 		// boot assets was updated
 		return nil
 	}
-	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.model, o.modeenv); err != nil {
 		return err
 	}
 	return nil
@@ -646,7 +646,7 @@ func (o *TrustedAssetsUpdateObserver) Canceled() error {
 		return fmt.Errorf("cannot write modeeenv: %v", err)
 	}
 
-	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.model, o.modeenv); err != nil {
 		return fmt.Errorf("while canceling gadget update: %v", err)
 	}
 	return nil

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -330,6 +330,10 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model) (*TrustedAssetsUp
 		// no need to observe updates when assets are not managed
 		return nil, ErrObserverNotApplicable
 	}
+	// there is no need to track assets if we did not seal any keys
+	if !hasSealedKeys(dirs.GlobalRootDir) {
+		return nil, ErrObserverNotApplicable
+	}
 
 	return &TrustedAssetsUpdateObserver{
 		cache: newTrustedAssetsCache(dirs.SnapBootAssetsDir),

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -578,7 +578,7 @@ func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
 		return nil
 	}
 	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
-		return fmt.Errorf("cannot reseal encryption key: %v", err)
+		return err
 	}
 	return nil
 }
@@ -643,7 +643,7 @@ func (o *TrustedAssetsUpdateObserver) Canceled() error {
 	}
 
 	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
-		return fmt.Errorf("cannot reseal encryption key after a canceled update: %v", err)
+		return fmt.Errorf("while canceling gadget update: %v", err)
 	}
 	return nil
 }

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -80,6 +80,12 @@ func (s *assetsSuite) bootloaderWithTrustedAssets(c *C, trustedAssets []string) 
 	return tab
 }
 
+func (s *assetsSuite) stampSealedKeys(c *C) {
+	c.Assert(os.MkdirAll(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), 0755), IsNil)
+	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys"), nil, 0644)
+	c.Assert(err, IsNil)
+}
+
 func (s *assetsSuite) TestAssetsCacheAddRemove(c *C) {
 	cacheDir := c.MkDir()
 	d := c.MkDir()
@@ -675,6 +681,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
+	s.stampSealedKeys(c)
+
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"nested/other-asset",
@@ -748,6 +756,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
+
+	s.stampSealedKeys(c)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
@@ -1514,6 +1524,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
+
+	s.stampSealedKeys(c)
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 
@@ -2330,6 +2342,8 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
+	s.stampSealedKeys(c)
+
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"shim",
@@ -2459,6 +2473,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
+
+	s.stampSealedKeys(c)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -68,6 +68,8 @@ func (s *assetsSuite) uc20UpdateObserver(c *C) (*boot.TrustedAssetsUpdateObserve
 	uc20Model := makeMockUC20Model()
 	// checked by TrustedAssetsUpdateObserverForModel
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
+	// checked by resealKeyToModeenv, under this rootdir
+	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
 	c.Assert(obs, NotNil)
 	c.Assert(err, IsNil)
@@ -689,9 +691,6 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
-
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"nested/other-asset",
@@ -765,9 +764,6 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
-
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
@@ -1531,9 +1527,6 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
-
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 
@@ -2350,9 +2343,6 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
-
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"shim",
@@ -2482,9 +2472,6 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
-
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -66,10 +66,9 @@ func checkContentGlob(c *C, glob string, expected []string) {
 
 func (s *assetsSuite) uc20UpdateObserver(c *C) (*boot.TrustedAssetsUpdateObserver, *asserts.Model) {
 	uc20Model := makeMockUC20Model()
-	// checked by TrustedAssetsUpdateObserverForModel
+	// checked by TrustedAssetsUpdateObserverForModel and
+	// resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
-	// checked by resealKeyToModeenv, under this rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
 	c.Assert(obs, NotNil)
 	c.Assert(err, IsNil)

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -565,6 +565,9 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 	// make sure SealKey was called
 	c.Check(sealKeyCalls, Equals, 1)
 
+	// make sure the marker file for sealed key was created
+	c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys"), testutil.FilePresent)
+
 	// make sure we wrote the boot chains data file
 	c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"), testutil.FilePresent)
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -566,7 +566,7 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 	c.Check(sealKeyCalls, Equals, 1)
 
 	// make sure we wrote the boot chains data file
-	c.Check(osutil.FileExists(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains")), Equals, true)
+	c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"), testutil.FilePresent)
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20RunModeInstallBootConfigErr(c *C) {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -20,6 +20,7 @@
 package boot
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
@@ -183,8 +185,11 @@ func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv) 
 	}
 	if !ok {
 		// no need to actually reseal
+		logger.Debugf("reseal not necessary")
 		return nil
 	}
+	pbcJSON, _ := json.Marshal(pbc)
+	logger.Debugf("resealing (%d) to boot chains: %s", nextCount, pbcJSON)
 
 	roleToBlName := map[bootloader.Role]string{
 		bootloader.RoleRecovery: rbl.Name(),

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -181,7 +181,14 @@ func resealKeyToModeenv(model *asserts.Model, modeenv *Modeenv) error {
 
 	pbc := toPredictableBootChains(append(runModeBootChains, recoveryBootChains...))
 
-	// TODO:UC20: load and compare the predictable bootchains
+	ok, err := isResealNeeded(pbc, InstallHostWritableDir)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// no need to actually reseal
+		return nil
+	}
 
 	roleToBlName := map[bootloader.Role]string{
 		bootloader.RoleRecovery: rbl.Name(),

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -293,7 +293,8 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 			// shared parameters
 			c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
 			c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
-				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1", "snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+				"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
 			})
 
 			// load chains

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -748,12 +748,12 @@ func (s *sealSuite) TestIsResealNeeded(c *C) {
 	err := boot.WriteBootChains(pbc, filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"), 2)
 	c.Assert(err, IsNil)
 
-	needed, cnt, err := boot.IsResealNeeded(pbc, rootdir)
+	needed, _, err := boot.IsResealNeeded(pbc, rootdir)
 	c.Assert(err, IsNil)
 	c.Check(needed, Equals, false)
 
 	otherchain := []boot.BootChain{pbc[0]}
-	needed, cnt, err = boot.IsResealNeeded(otherchain, rootdir)
+	needed, cnt, err := boot.IsResealNeeded(otherchain, rootdir)
 	c.Assert(err, IsNil)
 	// chains are different
 	c.Check(needed, Equals, true)

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -345,7 +345,7 @@ func SetRootDir(rootdir string) {
 
 	SnapModeenvFile = SnapModeenvFileUnder(rootdir)
 	SnapBootAssetsDir = SnapBootAssetsDirUnder(rootdir)
-	SnapFDEDir = SnapDeviceDirUnder(rootdir)
+	SnapFDEDir = SnapFDEDirUnder(rootdir)
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")
 	SnapRepairStateFile = filepath.Join(SnapRepairDir, "repair.json")

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2019 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -198,7 +198,7 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetOnCoreSimple(c *C, grade string) 
 
 	chg, t := s.setupGadgetUpdate(c, grade)
 
-	// procure modeenv
+	// procure modeenv and stamp that we sealed keys
 	if grade != "" {
 		// state after mark-seeded ran
 		modeenv := boot.Modeenv{
@@ -206,6 +206,12 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetOnCoreSimple(c *C, grade string) 
 			RecoverySystem: "",
 		}
 		err := modeenv.WriteTo("")
+		c.Assert(err, IsNil)
+
+		// sealed keys stamp
+		stamp := filepath.Join(dirs.SnapFDEDir, "sealed-keys")
+		c.Assert(os.MkdirAll(filepath.Dir(stamp), 0755), IsNil)
+		err = ioutil.WriteFile(stamp, nil, 0644)
 		c.Assert(err, IsNil)
 	}
 	devicestate.SetBootOkRan(s.mgr, true)


### PR DESCRIPTION
This uses a stamp file to track whether we sealed any keys at install at all.

Also don't make a TrustedAssetsUpdateObserver if we do not seal any keys.

There are some cleanups, the usage of InstallHost* in resealKeyToModeenv was incorrect, now it was fixed and takes a rootdir
which is the run mode root in practice.

I also added debug logging of reseals, and a reseal-count saved to boot-chains JSON.

Based on #9330