### PR TITLE
 boot: make MockUC20Device use a model and MockDevice more realistic 

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -581,7 +581,7 @@ func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
 		// boot assets was updated
 		return nil
 	}
-	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.model, o.modeenv); err != nil {
 		return err
 	}
 	return nil
@@ -646,7 +646,7 @@ func (o *TrustedAssetsUpdateObserver) Canceled() error {
 		return fmt.Errorf("cannot write modeeenv: %v", err)
 	}
 
-	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.model, o.modeenv); err != nil {
 		return fmt.Errorf("while canceling gadget update: %v", err)
 	}
 	return nil

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -330,6 +330,10 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model) (*TrustedAssetsUp
 		// no need to observe updates when assets are not managed
 		return nil, ErrObserverNotApplicable
 	}
+	// there is no need to track assets if we did not seal any keys
+	if !hasSealedKeys(dirs.GlobalRootDir) {
+		return nil, ErrObserverNotApplicable
+	}
 
 	return &TrustedAssetsUpdateObserver{
 		cache: newTrustedAssetsCache(dirs.SnapBootAssetsDir),

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -578,7 +578,7 @@ func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
 		return nil
 	}
 	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
-		return fmt.Errorf("cannot reseal encryption key: %v", err)
+		return err
 	}
 	return nil
 }
@@ -643,7 +643,7 @@ func (o *TrustedAssetsUpdateObserver) Canceled() error {
 	}
 
 	if err := resealKeyToModeenv(o.model, o.modeenv); err != nil {
-		return fmt.Errorf("cannot reseal encryption key after a canceled update: %v", err)
+		return fmt.Errorf("while canceling gadget update: %v", err)
 	}
 	return nil
 }

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -80,6 +80,12 @@ func (s *assetsSuite) bootloaderWithTrustedAssets(c *C, trustedAssets []string) 
 	return tab
 }
 
+func (s *assetsSuite) stampSealedKeys(c *C) {
+	c.Assert(os.MkdirAll(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), 0755), IsNil)
+	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys"), nil, 0644)
+	c.Assert(err, IsNil)
+}
+
 func (s *assetsSuite) TestAssetsCacheAddRemove(c *C) {
 	cacheDir := c.MkDir()
 	d := c.MkDir()
@@ -675,6 +681,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
+	s.stampSealedKeys(c)
+
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"nested/other-asset",
@@ -748,6 +756,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
+
+	s.stampSealedKeys(c)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
@@ -1514,6 +1524,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
+
+	s.stampSealedKeys(c)
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 
@@ -2330,6 +2342,8 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
+	s.stampSealedKeys(c)
+
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"shim",
@@ -2459,6 +2473,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
+
+	s.stampSealedKeys(c)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -68,6 +68,8 @@ func (s *assetsSuite) uc20UpdateObserver(c *C) (*boot.TrustedAssetsUpdateObserve
 	uc20Model := makeMockUC20Model()
 	// checked by TrustedAssetsUpdateObserverForModel
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
+	// checked by resealKeyToModeenv, under this rootdir
+	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
 	c.Assert(obs, NotNil)
 	c.Assert(err, IsNil)
@@ -689,9 +691,6 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
-
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"nested/other-asset",
@@ -765,9 +764,6 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
-
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
@@ -1531,9 +1527,6 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
-
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 
 	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 
@@ -2350,9 +2343,6 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
-
 	tab := s.bootloaderWithTrustedAssets(c, []string{
 		"asset",
 		"shim",
@@ -2482,9 +2472,6 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
-
-	// checked by resealKeyToModeenv, under that rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 
 	tab := s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
 

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
@@ -65,7 +66,7 @@ func checkContentGlob(c *C, glob string, expected []string) {
 }
 
 func (s *assetsSuite) uc20UpdateObserver(c *C) (*boot.TrustedAssetsUpdateObserver, *asserts.Model) {
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	// checked by TrustedAssetsUpdateObserverForModel and
 	// resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
@@ -229,13 +230,13 @@ func (s *assetsSuite) TestAssetsCacheRemoveErr(c *C) {
 func (s *assetsSuite) TestInstallObserverNew(c *C) {
 	d := c.MkDir()
 	// we get an observer for UC20
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
 
 	// but nil for non UC20
-	nonUC20Model := makeMockModel()
+	nonUC20Model := boottest.MakeMockModel()
 	nonUC20obs, err := boot.TrustedAssetsInstallObserverForModel(nonUC20Model, d)
 	c.Assert(err, Equals, boot.ErrObserverNotApplicable)
 	c.Assert(nonUC20obs, IsNil)
@@ -262,7 +263,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootRealGrub(c *C) {
 	c.Assert(err, IsNil)
 
 	// we get an observer for UC20
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -338,7 +339,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootMocked(c *C) {
 	}
 
 	// we get an observer for UC20
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -393,7 +394,7 @@ func (s *assetsSuite) TestInstallObserverNonTrustedBootloader(c *C) {
 	defer bootloader.Force(nil)
 
 	// we get an observer for UC20
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -417,7 +418,7 @@ func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
 	defer bootloader.Force(nil)
 
 	// we get an observer for UC20
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -449,7 +450,7 @@ func (s *assetsSuite) TestInstallObserverTrustedReuseNameErr(c *C) {
 	}
 
 	// we get an observer for UC20
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -511,7 +512,7 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryMocked(c *C) {
 	}
 
 	// we get an observer for UC20
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -557,7 +558,7 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryNoAssets(c *C) {
 	bootloader.Force(tab)
 	defer bootloader.Force(nil)
 
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -587,7 +588,7 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryReuseNameErr(c *
 		"nested/asset",
 	})
 	// we get an observer for UC20
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -609,7 +610,7 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryReuseNameErr(c *
 func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryErr(c *C) {
 	d := c.MkDir()
 
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -636,7 +637,7 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryErr(c *C) {
 
 func (s *assetsSuite) TestUpdateObserverNew(c *C) {
 	// we get an observer for UC20, but only if we sealed keys
-	uc20Model := makeMockUC20Model()
+	uc20Model := boottest.MakeMockUC20Model()
 	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
 	c.Assert(err, Equals, boot.ErrObserverNotApplicable)
 	c.Check(obs, IsNil)
@@ -647,7 +648,7 @@ func (s *assetsSuite) TestUpdateObserverNew(c *C) {
 	c.Assert(obs, NotNil)
 
 	// but nil for non UC20
-	nonUC20Model := makeMockModel()
+	nonUC20Model := boottest.MakeMockModel()
 	nonUC20obs, err := boot.TrustedAssetsUpdateObserverForModel(nonUC20Model)
 	c.Assert(err, Equals, boot.ErrObserverNotApplicable)
 	c.Assert(nonUC20obs, IsNil)
@@ -2379,10 +2380,10 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-linux_1.snap",
+			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 0},
-				RealName: "pc-linux",
+				Revision: snap.Revision{N: 1},
+				RealName: "pc-kernel",
 			},
 		}
 		return uc20model, []*seed.Snap{kernelSnap}, nil
@@ -2421,14 +2422,14 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 		c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
 			secboot.NewLoadChain(shimBf,
 				secboot.NewLoadChain(assetBf,
-					secboot.NewLoadChain(runKernelBf)),
-				secboot.NewLoadChain(beforeAssetBf,
-					secboot.NewLoadChain(runKernelBf))),
-			secboot.NewLoadChain(shimBf,
-				secboot.NewLoadChain(assetBf,
 					secboot.NewLoadChain(recoveryKernelBf)),
 				secboot.NewLoadChain(beforeAssetBf,
 					secboot.NewLoadChain(recoveryKernelBf))),
+			secboot.NewLoadChain(shimBf,
+				secboot.NewLoadChain(assetBf,
+					secboot.NewLoadChain(runKernelBf)),
+				secboot.NewLoadChain(beforeAssetBf,
+					secboot.NewLoadChain(runKernelBf))),
 		})
 		return nil
 	})
@@ -2501,10 +2502,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-linux_1.snap",
+			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 0},
-				RealName: "pc-linux",
+				Revision: snap.Revision{N: 1},
+				RealName: "pc-kernel",
 			},
 		}
 		return uc20model, []*seed.Snap{kernelSnap}, nil

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -66,10 +66,9 @@ func checkContentGlob(c *C, glob string, expected []string) {
 
 func (s *assetsSuite) uc20UpdateObserver(c *C) (*boot.TrustedAssetsUpdateObserver, *asserts.Model) {
 	uc20Model := makeMockUC20Model()
-	// checked by TrustedAssetsUpdateObserverForModel
+	// checked by TrustedAssetsUpdateObserverForModel and
+	// resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
-	// checked by resealKeyToModeenv, under this rootdir
-	s.stampSealedKeys(c, boot.InstallHostWritableDir)
 	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model)
 	c.Assert(obs, NotNil)
 	c.Assert(err, IsNil)

--- a/boot/boot_robustness_test.go
+++ b/boot/boot_robustness_test.go
@@ -192,7 +192,7 @@ func (s *bootenv20Suite) checkBootStateAfterUnexpectedRebootAndCleanup(
 }
 
 func (s *bootenv20Suite) TestHappyMarkBootSuccessful20KernelUpgradeUnexpectedReboots(c *C) {
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	tt := []struct {
@@ -256,7 +256,7 @@ func (s *bootenv20Suite) TestHappyMarkBootSuccessful20KernelUpgradeUnexpectedReb
 }
 
 func (s *bootenv20Suite) TestHappySetNextBoot20KernelUpgradeUnexpectedReboots(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	tt := []struct {

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -378,7 +378,7 @@ func (s *bootenvSuite) TestCurrentBootNameAndRevision(c *C) {
 }
 
 func (s *bootenv20Suite) TestCurrentBoot20NameAndRevision(c *C) {
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -406,7 +406,7 @@ func (s *bootenv20Suite) TestCurrentBoot20NameAndRevision(c *C) {
 // only difference between this test and TestCurrentBoot20NameAndRevision is the
 // base bootloader which doesn't support ExtractedRunKernelImageBootloader.
 func (s *bootenv20EnvRefKernelSuite) TestCurrentBoot20NameAndRevision(c *C) {
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -648,7 +648,7 @@ func (s *bootenvSuite) TestMarkBootSuccessfulTryKernelKernelStatusDefaultCleansU
 }
 
 func (s *bootenv20Suite) TestCoreKernel20(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -683,7 +683,7 @@ func (s *bootenv20Suite) TestCoreKernel20(c *C) {
 }
 
 func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -726,7 +726,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 }
 
 func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -767,7 +767,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextSameKernelSnap(
 }
 
 func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -805,7 +805,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 }
 
 func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -840,7 +840,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextNewKernelSnap(c
 }
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapCleansUp(c *C) {
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// set all the same vars as if we were doing trying, except don't set a try
@@ -898,7 +898,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapC
 }
 
 func (s *bootenv20EnvRefKernelSuite) TestMarkBootSuccessful20KernelStatusTryingNoKernelSnapCleansUp(c *C) {
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// set all the same vars as if we were doing trying, except don't set a try
@@ -960,7 +960,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseStatusTryingNoTryBaseSnapCl
 	)
 	defer r()
 
-	coreDev := boottest.MockUC20Device("core20")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// mark successful
@@ -986,7 +986,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseStatusTryingNoTryBaseSnapCl
 }
 
 func (s *bootenv20Suite) TestCoreParticipant20SetNextSameBaseSnap(c *C) {
-	coreDev := boottest.MockUC20Device("core20")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	m := &boot.Modeenv{
@@ -1024,7 +1024,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameBaseSnap(c *C) {
 }
 
 func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnap(c *C) {
-	coreDev := boottest.MockUC20Device("core20")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// default state
@@ -1087,7 +1087,7 @@ func (s *bootenvSuite) TestMarkBootSuccessfulAllSnap(c *C) {
 }
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// bonus points: we were trying both a base snap and a kernel snap
@@ -1151,7 +1151,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20AllSnap(c *C) {
 }
 
 func (s *bootenv20EnvRefKernelSuite) TestMarkBootSuccessful20AllSnap(c *C) {
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// bonus points: we were trying both a base snap and a kernel snap
@@ -1264,7 +1264,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdate(c *C) {
 	)
 	defer r()
 
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// mark successful
@@ -1322,7 +1322,7 @@ func (s *bootenv20EnvRefKernelSuite) TestMarkBootSuccessful20KernelUpdate(c *C) 
 	)
 	defer r()
 
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// mark successful
@@ -1369,7 +1369,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseUpdate(c *C) {
 	)
 	defer r()
 
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// mark successful
@@ -1456,7 +1456,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	)
 	defer r()
 
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// mark successful
@@ -1531,7 +1531,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	)
 	defer r()
 
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// mark successful
@@ -1591,7 +1591,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 	)
 	defer r()
 
-	coreDev := boottest.MockUC20Device("some-snap")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// mark successful
@@ -1627,7 +1627,7 @@ func (s *recoveryBootenv20Suite) SetUpTest(c *C) {
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
 	s.forceBootloader(s.bootloader)
 
-	s.dev = boottest.MockUC20Device("some-snap")
+	s.dev = boottest.MockUC20Device("", nil)
 }
 
 func (s *recoveryBootenv20Suite) TestSetRecoveryBootSystemAndModeHappy(c *C) {

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -28,6 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/secboot"
@@ -151,7 +152,7 @@ func (s *bootchainSuite) TestBootChainMarshalFull(c *C) {
 		KernelCmdlines: []string{`foo=bar baz=0x123`, `a=1`},
 	}
 
-	uc20model := makeMockUC20Model()
+	uc20model := boottest.MakeMockUC20Model()
 	bc.SetModelAssertion(uc20model)
 	kernelBootFile := bootloader.NewBootFile("pc-kernel", "/foo", bootloader.RoleRecovery)
 	bc.SetKernelBootFile(kernelBootFile)

--- a/boot/boottest/device.go
+++ b/boot/boottest/device.go
@@ -22,6 +22,7 @@ package boottest
 import (
 	"strings"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 )
 
@@ -29,37 +30,61 @@ type mockDevice struct {
 	bootSnap string
 	mode     string
 	uc20     bool
+
+	model *asserts.Model
 }
 
 // MockDevice implements boot.Device. It wraps a string like
-// <boot-snap-name>[@<mode>], no <boot-snap-name> means classic, no
-// <mode> defaults to "run". It returns <boot-snap-name> for both
-// Base and Kernel, for more control mock a DeviceContext.
+// <boot-snap-name>[@<mode>], no <boot-snap-name> means classic, empty
+// <mode> defaults to "run" for UC16/18. If mode is set HasModeenv
+// returns true for UC20 and an empty boot snap name panics.
+// It returns <boot-snap-name> for both Base and Kernel, for more
+// control mock a DeviceContext.
 func MockDevice(s string) boot.Device {
-	bootsnap, mode := snapAndMode(s)
+	bootsnap, mode, uc20 := snapAndMode(s)
+	if uc20 && bootsnap == "" {
+		panic("MockDevice with no snap name and @mode is unsupported")
+	}
 	return &mockDevice{
 		bootSnap: bootsnap,
 		mode:     mode,
+		uc20:     uc20,
 	}
 }
 
 // MockUC20Device implements boot.Device and returns true for HasModeenv.
-func MockUC20Device(s string) boot.Device {
-	m := MockDevice(s).(*mockDevice)
-	m.uc20 = true
-	return m
+// Arguments are mode (empty means "run"), and model.
+// If model is nil a default model is used (same as MakeMockUC20Model).
+func MockUC20Device(mode string, model *asserts.Model) boot.Device {
+	if mode == "" {
+		mode = "run"
+	}
+	if model == nil {
+		model = MakeMockUC20Model()
+	}
+	return &mockDevice{
+		bootSnap: model.Kernel(),
+		mode:     mode,
+		uc20:     true,
+		model:    model,
+	}
 }
 
-func snapAndMode(str string) (snap, mode string) {
+func snapAndMode(str string) (snap, mode string, uc20 bool) {
 	parts := strings.SplitN(string(str), "@", 2)
 	if len(parts) == 1 || parts[1] == "" {
-		return parts[0], "run"
+		return parts[0], "run", false
 	}
-	return parts[0], parts[1]
+	return parts[0], parts[1], true
 }
 
 func (d *mockDevice) Kernel() string   { return d.bootSnap }
-func (d *mockDevice) Base() string     { return d.bootSnap }
 func (d *mockDevice) Classic() bool    { return d.bootSnap == "" }
 func (d *mockDevice) RunMode() bool    { return d.mode == "run" }
 func (d *mockDevice) HasModeenv() bool { return d.uc20 }
+func (d *mockDevice) Base() string {
+	if d.model != nil {
+		return d.model.Base()
+	}
+	return d.bootSnap
+}

--- a/boot/boottest/device_test.go
+++ b/boot/boottest/device_test.go
@@ -41,19 +41,7 @@ func (s *boottestSuite) TestMockDeviceClassic(c *C) {
 	c.Check(dev.RunMode(), Equals, true)
 	c.Check(dev.HasModeenv(), Equals, false)
 
-	dev = boottest.MockDevice("@run")
-	c.Check(dev.Classic(), Equals, true)
-	c.Check(dev.Kernel(), Equals, "")
-	c.Check(dev.Base(), Equals, "")
-	c.Check(dev.RunMode(), Equals, true)
-	c.Check(dev.HasModeenv(), Equals, false)
-
-	dev = boottest.MockDevice("@recover")
-	c.Check(dev.Classic(), Equals, true)
-	c.Check(dev.Kernel(), Equals, "")
-	c.Check(dev.Base(), Equals, "")
-	c.Check(dev.RunMode(), Equals, false)
-	c.Check(dev.HasModeenv(), Equals, false)
+	c.Check(func() { boottest.MockDevice("@run") }, Panics, "MockDevice with no snap name and @mode is unsupported")
 }
 
 func (s *boottestSuite) TestMockDeviceBaseOrKernel(c *C) {
@@ -69,32 +57,45 @@ func (s *boottestSuite) TestMockDeviceBaseOrKernel(c *C) {
 	c.Check(dev.Kernel(), Equals, "boot-snap")
 	c.Check(dev.Base(), Equals, "boot-snap")
 	c.Check(dev.RunMode(), Equals, true)
-	c.Check(dev.HasModeenv(), Equals, false)
+	c.Check(dev.HasModeenv(), Equals, true)
 
 	dev = boottest.MockDevice("boot-snap@recover")
 	c.Check(dev.Classic(), Equals, false)
 	c.Check(dev.Kernel(), Equals, "boot-snap")
 	c.Check(dev.Base(), Equals, "boot-snap")
 	c.Check(dev.RunMode(), Equals, false)
-	c.Check(dev.HasModeenv(), Equals, false)
+	c.Check(dev.HasModeenv(), Equals, true)
 }
 
 func (s *boottestSuite) TestMockUC20Device(c *C) {
-	dev := boottest.MockUC20Device("boot-snap")
+	dev := boottest.MockUC20Device("", nil)
 	c.Check(dev.HasModeenv(), Equals, true)
+	c.Check(dev.Classic(), Equals, false)
+	c.Check(dev.RunMode(), Equals, true)
+	c.Check(dev.Kernel(), Equals, "pc-kernel")
+	c.Check(dev.Base(), Equals, "core20")
 
-	dev = boottest.MockUC20Device("boot-snap@run")
-	c.Check(dev.HasModeenv(), Equals, true)
+	dev = boottest.MockUC20Device("run", nil)
+	c.Check(dev.RunMode(), Equals, true)
 
-	dev = boottest.MockUC20Device("boot-snap@recover")
-	c.Check(dev.HasModeenv(), Equals, true)
+	dev = boottest.MockUC20Device("recover", nil)
+	c.Check(dev.RunMode(), Equals, false)
 
-	dev = boottest.MockUC20Device("")
-	c.Check(dev.HasModeenv(), Equals, true)
-
-	dev = boottest.MockUC20Device("@run")
-	c.Check(dev.HasModeenv(), Equals, true)
-
-	dev = boottest.MockUC20Device("@recover")
-	c.Check(dev.HasModeenv(), Equals, true)
+	model := boottest.MakeMockUC20Model(map[string]interface{}{
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name": "pc-linux",
+				"id":   "pclinuxdidididididididididididid",
+				"type": "kernel",
+			},
+			map[string]interface{}{
+				"name": "pc",
+				"id":   "pcididididididididididididididid",
+				"type": "gadget",
+			},
+		},
+	})
+	dev = boottest.MockUC20Device("recover", model)
+	c.Check(dev.RunMode(), Equals, false)
+	c.Check(dev.Kernel(), Equals, "pc-linux")
 }

--- a/boot/boottest/model.go
+++ b/boot/boottest/model.go
@@ -1,0 +1,70 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boottest
+
+import (
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+)
+
+func MakeMockModel(overrides ...map[string]interface{}) *asserts.Model {
+	headers := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"display-name": "My Model",
+		"architecture": "amd64",
+		"base":         "core18",
+		"gadget":       "pc=18",
+		"kernel":       "pc-kernel=18",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}
+	return assertstest.FakeAssertion(append([]map[string]interface{}{headers}, overrides...)...).(*asserts.Model)
+}
+
+func MakeMockUC20Model(overrides ...map[string]interface{}) *asserts.Model {
+	headers := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model-uc20",
+		"display-name": "My Model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"timestamp":    "2019-11-01T08:00:00+00:00",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name": "pc-kernel",
+				"id":   "pckernelidididididididididididid",
+				"type": "kernel",
+			},
+			map[string]interface{}{
+				"name": "pc",
+				"id":   "pcididididididididididididididid",
+				"type": "gadget",
+			},
+		},
+	}
+	return assertstest.FakeAssertion(append([]map[string]interface{}{headers}, overrides...)...).(*asserts.Model)
+}

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -26,9 +26,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/testutil"
@@ -109,7 +108,7 @@ func (s *kernelCommandLineSuite) TestModeAndLabel(c *C) {
 }
 
 func (s *kernelCommandLineSuite) TestComposeCommandLineNotManagedHappy(c *C) {
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 
 	bl := bootloadertest.Mock("btloader", c.MkDir())
 	bootloader.Force(bl)
@@ -140,20 +139,7 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineNotManagedHappy(c *C) {
 }
 
 func (s *kernelCommandLineSuite) TestComposeCommandLineNotUC20(c *C) {
-	headers := map[string]interface{}{
-		"type":         "model",
-		"authority-id": "my-brand",
-		"series":       "16",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
-		"display-name": "My Model",
-		"architecture": "amd64",
-		"base":         "core18",
-		"gadget":       "pc=18",
-		"kernel":       "pc-kernel=18",
-		"timestamp":    "2018-01-01T08:00:00+00:00",
-	}
-	model := assertstest.FakeAssertion(headers).(*asserts.Model)
+	model := boottest.MakeMockModel()
 
 	bl := bootloadertest.Mock("btloader", c.MkDir())
 	bootloader.Force(bl)
@@ -168,7 +154,7 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineNotUC20(c *C) {
 }
 
 func (s *kernelCommandLineSuite) TestComposeCommandLineManagedHappy(c *C) {
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 
 	mbl := bootloadertest.Mock("btloader", c.MkDir()).WithManagedAssets()
 	bootloader.Force(mbl)
@@ -196,7 +182,7 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineManagedHappy(c *C) {
 }
 
 func (s *kernelCommandLineSuite) TestComposeCandidateCommandLineManagedHappy(c *C) {
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 
 	mbl := bootloadertest.Mock("btloader", c.MkDir()).WithManagedAssets()
 	bootloader.Force(mbl)

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -148,7 +148,7 @@ func (s *bootenvSuite) TestSetNextBootForKernel(c *C) {
 }
 
 func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -191,7 +191,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
 }
 
 func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernel(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -245,7 +245,7 @@ func (s *bootenvSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 }
 
 func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -288,7 +288,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 }
 
 func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	r := setupUC20Bootenv(
@@ -348,7 +348,7 @@ func (s *bootenvSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C) {
 }
 
 func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// set all the same vars as if we were doing trying, except don't set a try
@@ -402,7 +402,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C)
 }
 
 func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C) {
-	coreDev := boottest.MockUC20Device("pc-kernel")
+	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	// set all the same vars as if we were doing trying, except don't set a try

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -28,8 +28,8 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/assets"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
@@ -78,25 +78,8 @@ func makeSnapWithFiles(c *C, name, yaml string, revno snap.Revision, files [][]s
 	return fn, info
 }
 
-func makeMockModel() *asserts.Model {
-	headers := map[string]interface{}{
-		"type":         "model",
-		"authority-id": "my-brand",
-		"series":       "16",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
-		"display-name": "My Model",
-		"architecture": "amd64",
-		"base":         "core18",
-		"gadget":       "pc=18",
-		"kernel":       "pc-kernel=18",
-		"timestamp":    "2018-01-01T08:00:00+00:00",
-	}
-	return assertstest.FakeAssertion(headers).(*asserts.Model)
-}
-
 func (s *makeBootableSuite) TestMakeBootable(c *C) {
-	model := makeMockModel()
+	model := boottest.MakeMockModel()
 
 	grubCfg := []byte("#grub cfg")
 	unpackedGadgetDir := c.MkDir()
@@ -189,36 +172,8 @@ func (s *makeBootable20UbootSuite) SetUpTest(c *C) {
 	s.forceBootloader(s.bootloader)
 }
 
-func makeMockUC20Model() *asserts.Model {
-	headers := map[string]interface{}{
-		"type":         "model",
-		"authority-id": "my-brand",
-		"series":       "16",
-		"brand-id":     "my-brand",
-		"model":        "my-model-uc20",
-		"display-name": "My Model",
-		"architecture": "amd64",
-		"base":         "core20",
-		"grade":        "dangerous",
-		"timestamp":    "2019-11-01T08:00:00+00:00",
-		"snaps": []interface{}{
-			map[string]interface{}{
-				"name": "pc-linux",
-				"id":   "pclinuxdidididididididididididid",
-				"type": "kernel",
-			},
-			map[string]interface{}{
-				"name": "pc",
-				"id":   "pcididididididididididididididid",
-				"type": "gadget",
-			},
-		},
-	}
-	return assertstest.FakeAssertion(headers).(*asserts.Model)
-}
-
 func (s *makeBootable20Suite) TestMakeBootable20(c *C) {
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 
 	unpackedGadgetDir := c.MkDir()
 	grubRecoveryCfg := []byte("#grub-recovery cfg")
@@ -292,7 +247,7 @@ version: 5.0
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20UnsetRecoverySystemLabelError(c *C) {
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 
 	unpackedGadgetDir := c.MkDir()
 	grubRecoveryCfg := []byte("#grub-recovery cfg")
@@ -315,7 +270,7 @@ func (s *makeBootable20Suite) TestMakeBootable20UnsetRecoverySystemLabelError(c 
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20MultipleRecoverySystemsError(c *C) {
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 
 	bootWith := &boot.BootableSet{Recovery: true}
 	err := os.MkdirAll(filepath.Join(s.rootdir, "systems/20191204"), 0755)
@@ -330,7 +285,7 @@ func (s *makeBootable20Suite) TestMakeBootable20MultipleRecoverySystemsError(c *
 func (s *makeBootable20Suite) TestMakeBootable20RunMode(c *C) {
 	bootloader.Force(nil)
 
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 	seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
 	err := os.MkdirAll(seedSnapsDirs, 0755)
 	c.Assert(err, IsNil)
@@ -575,7 +530,7 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 func (s *makeBootable20Suite) TestMakeBootable20RunModeInstallBootConfigErr(c *C) {
 	bootloader.Force(nil)
 
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 	seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
 	err := os.MkdirAll(seedSnapsDirs, 0755)
 	c.Assert(err, IsNil)
@@ -646,7 +601,7 @@ version: 5.0
 func (s *makeBootable20Suite) TestMakeBootable20RunModeSealKeyErr(c *C) {
 	bootloader.Force(nil)
 
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 	seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
 	err := os.MkdirAll(seedSnapsDirs, 0755)
 	c.Assert(err, IsNil)
@@ -808,7 +763,7 @@ version: 5.0
 }
 
 func (s *makeBootable20UbootSuite) TestUbootMakeBootable20TraditionalUbootenvFails(c *C) {
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 
 	unpackedGadgetDir := c.MkDir()
 	ubootEnv := []byte("#uboot env")
@@ -859,7 +814,7 @@ version: 5.0
 }
 
 func (s *makeBootable20UbootSuite) TestUbootMakeBootable20BootScr(c *C) {
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 
 	unpackedGadgetDir := c.MkDir()
 	// the uboot.conf must be empty for this to work/do the right thing
@@ -930,7 +885,7 @@ version: 5.0
 func (s *makeBootable20UbootSuite) TestUbootMakeBootable20RunModeBootScr(c *C) {
 	bootloader.Force(nil)
 
-	model := makeMockUC20Model()
+	model := boottest.MakeMockUC20Model()
 	seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
 	err := os.MkdirAll(seedSnapsDirs, 0755)
 	c.Assert(err, IsNil)

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -565,6 +565,9 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 	// make sure SealKey was called
 	c.Check(sealKeyCalls, Equals, 1)
 
+	// make sure the marker file for sealed key was created
+	c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys"), testutil.FilePresent)
+
 	// make sure we wrote the boot chains data file
 	c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"), testutil.FilePresent)
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -566,7 +566,7 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0
 	c.Check(sealKeyCalls, Equals, 1)
 
 	// make sure we wrote the boot chains data file
-	c.Check(osutil.FileExists(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains")), Equals, true)
+	c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "boot-chains"), testutil.FilePresent)
 }
 
 func (s *makeBootable20Suite) TestMakeBootable20RunModeInstallBootConfigErr(c *C) {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -20,6 +20,7 @@
 package boot
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
@@ -183,8 +185,11 @@ func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv) 
 	}
 	if !ok {
 		// no need to actually reseal
+		logger.Debugf("reseal not necessary")
 		return nil
 	}
+	pbcJSON, _ := json.Marshal(pbc)
+	logger.Debugf("resealing (%d) to boot chains: %s", nextCount, pbcJSON)
 
 	roleToBlName := map[bootloader.Role]string{
 		bootloader.RoleRecovery: rbl.Name(),

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -181,7 +181,14 @@ func resealKeyToModeenv(model *asserts.Model, modeenv *Modeenv) error {
 
 	pbc := toPredictableBootChains(append(runModeBootChains, recoveryBootChains...))
 
-	// TODO:UC20: load and compare the predictable bootchains
+	ok, err := isResealNeeded(pbc, InstallHostWritableDir)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// no need to actually reseal
+		return nil
+	}
 
 	roleToBlName := map[bootloader.Role]string{
 		bootloader.RoleRecovery: rbl.Name(),

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -293,7 +293,8 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 			// shared parameters
 			c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
 			c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
-				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1", "snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+				"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
 			})
 
 			// load chains

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -748,12 +748,12 @@ func (s *sealSuite) TestIsResealNeeded(c *C) {
 	err := boot.WriteBootChains(pbc, filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains"), 2)
 	c.Assert(err, IsNil)
 
-	needed, cnt, err := boot.IsResealNeeded(pbc, rootdir)
+	needed, _, err := boot.IsResealNeeded(pbc, rootdir)
 	c.Assert(err, IsNil)
 	c.Check(needed, Equals, false)
 
 	otherchain := []boot.BootChain{pbc[0]}
-	needed, cnt, err = boot.IsResealNeeded(otherchain, rootdir)
+	needed, cnt, err := boot.IsResealNeeded(otherchain, rootdir)
 	c.Assert(err, IsNil)
 	// chains are different
 	c.Check(needed, Equals, true)

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -345,7 +345,7 @@ func SetRootDir(rootdir string) {
 
 	SnapModeenvFile = SnapModeenvFileUnder(rootdir)
 	SnapBootAssetsDir = SnapBootAssetsDirUnder(rootdir)
-	SnapFDEDir = SnapDeviceDirUnder(rootdir)
+	SnapFDEDir = SnapFDEDirUnder(rootdir)
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")
 	SnapRepairStateFile = filepath.Join(SnapRepairDir, "repair.json")

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2019 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -198,7 +198,7 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetOnCoreSimple(c *C, grade string) 
 
 	chg, t := s.setupGadgetUpdate(c, grade)
 
-	// procure modeenv
+	// procure modeenv and stamp that we sealed keys
 	if grade != "" {
 		// state after mark-seeded ran
 		modeenv := boot.Modeenv{
@@ -206,6 +206,12 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetOnCoreSimple(c *C, grade string) 
 			RecoverySystem: "",
 		}
 		err := modeenv.WriteTo("")
+		c.Assert(err, IsNil)
+
+		// sealed keys stamp
+		stamp := filepath.Join(dirs.SnapFDEDir, "sealed-keys")
+		c.Assert(os.MkdirAll(filepath.Dir(stamp), 0755), IsNil)
+		err = ioutil.WriteFile(stamp, nil, 0644)
 		c.Assert(err, IsNil)
 	}
 	devicestate.SetBootOkRan(s.mgr, true)


### PR DESCRIPTION
We will need to add Model to Device for UC20 cases, prepare for that
by forcing MockUC20Device to use one and produce output consistent
with it.

Make also the behavior of MockDevice a bit more consistent/realistic
though it has limited use for UC20, it allowed for mode != "run"
with HasModeenv false for example.

Add/move helpers to mock model assertion for boot tests to bootest as well.

Build on top of #9339 