### PR TITLE
tests: add more checks to disk space awareness spread test

### DIFF
--- a/tests/main/disk-space-awareness/task.yaml
+++ b/tests/main/disk-space-awareness/task.yaml
@@ -15,7 +15,7 @@ prepare: |
   systemctl stop snapd.{socket,service}
 
   # mount /var/lib/snapd on a tmpfs
-  mount -t tmpfs tmpfs -o size=500M,mode=0755 "$TMPFSMOUNT"
+  mount -t tmpfs tmpfs -o size=150M,mode=0755 "$TMPFSMOUNT"
 
   systemctl start snapd.{socket,service}
 
@@ -39,6 +39,7 @@ execute: |
   echo "Enabling experimental disk space checks"
   snap set system experimental.check-disk-space-install=true
   snap set system experimental.check-disk-space-remove=true
+  snap set system experimental.check-disk-space-refresh=true
 
   echo "Snap download fails with little disk space"
   NEWSIZE=$(($(get_disk_usage) + 1))
@@ -47,7 +48,7 @@ execute: |
 
   # note, installing hello-world also pulls core snap.
   echo "And succeeds with enough space"
-  resize 600M
+  resize 150M
   snap install hello-world
 
   # run the snap once to have data dirs created
@@ -70,3 +71,40 @@ execute: |
 
   echo "Removing the snap with --purge works despite of low disk space"
   snap remove --purge hello-world
+
+  resize 150M
+  snap install hello-world test-snapd-sh
+
+  # create 4M filler in common directory to inflate backup size
+  dd if=/dev/zero of=/var/snap/hello-world/common/filler bs=1024 count=4096
+
+  echo "Resizing the disk down with just 1MB extra"
+  NEWSIZE=$(($(get_disk_usage) + 1))
+  resize "${NEWSIZE}M"
+
+  echo "Removing multiple snaps at once fails due to low disk space"
+  if snap remove hello-world test-snapd-sh > error.txt 2>&1; then
+    echo "expected snap remove hello-world test-snapd-sh to fail"
+    exit 1
+  fi
+  MATCH "error: cannot remove \"hello-world\", \"test-snapd-sh\" due to low disk space" < error.txt
+
+  snap remove --purge hello-world
+  snap remove --purge test-snapd-sh
+
+  resize 150M
+  snap install test-snapd-tools
+
+  echo "Refresh fails due to low disk space"
+  NEWSIZE=$(($(get_disk_usage) + 1))
+  resize "${NEWSIZE}M"
+  # create 4M filler in common directory
+  if snap refresh --edge test-snapd-tools > error.txt 2>&1; then
+    echo "expected snap refresh --edge test-snapd-tools to fail"
+    exit 1
+  fi
+  MATCH "error: cannot refresh \"test-snapd-tools\" due to low disk space" < error.txt
+
+  # succeeds with enough space
+  resize 150M
+  snap refresh --edge test-snapd-tools

--- a/tests/main/disk-space-awareness/task.yaml
+++ b/tests/main/disk-space-awareness/task.yaml
@@ -1,8 +1,7 @@
 summary: Check that basic snap operation are aware of low disk space.
 
-# this test is remounts /var/lib/snapd which is too intrusive for core and
-# selinux, disabled on these systems.
-systems: [-fedora-*, -amazon-*, -centos-*, -ubuntu-core-*]
+# this test is remounts /var/lib/snapd which is too intrusive for core.
+systems: [-ubuntu-core-*]
 
 description: |
   Check that operations such as snap installation or snap removal (with an


### PR DESCRIPTION
Add checks for removing many snaps and for refresh. Enable centos and fedora. Reduce max size of tmpfs used in the test.