### PR TITLE
tests/lib/nested.sh: wait for the tpm socket to exist

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -690,6 +690,8 @@ nested_start_core_vm_unit() {
             else
                 snap install swtpm-mvo --beta
             fi
+            # wait for the tpm sock file to exist
+            retry -n 10 --wait 1 test -S /var/snap/swtpm-mvo/current/swtpm-sock
             PARAM_TPM="-chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"
         fi
         PARAM_IMAGE="-drive file=$CURRENT_IMAGE,cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1"


### PR DESCRIPTION
Tests have sometimes failed because qemu was started too quickly and swtpm
created the socket too slowly, see:

```
swtpm-mvo (beta) 0.1.0 from Michael Vogt (mvo) installed
+ PARAM_TPM='-chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0'
...
+ systemd_create_and_start_unit nested-vm '/usr/bin/qemu-system-x86_64         -smp 2                  -m 4096         -d cpu_reset         -D /tmp/work-dir/logs/qemu.log         -machine q35 -global ICH9-LPC.disable_s3=1         -nographic         -net nic,model=virtio -net user,hostfwd=tcp::8022-:22         -drive file=/usr/share/OVMF/OVMF_CODE.secboot.fd,if=pflash,format=raw,unit=0,readonly -drive file=/tmp/work-dir/assets/OVMF_VARS.snakeoil.fd,if=pflash,format=raw         -chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0         -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0         -drive file=/tmp/work-dir/images/ubuntu-core-current.img,cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1                  -chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=/tmp/work-dir/logs/serial.log,logappend=on -serial chardev:char0         -monitor tcp:127.0.0.1:8888,server,nowait         -usb          '
...
+ systemctl status nested-vm
● nested-vm.service - Support for test google-nested:ubuntu-20.04-64:tests/nested/manual/core20-early-config
Loaded: loaded (/run/systemd/system/nested-vm.service; static; vendor preset: enabled)
Active: failed (Result: exit-code) since Mon 2020-09-14 09:45:00 UTC; 6min ago
Process: 47199 ExecStart=/usr/bin/qemu-system-x86_64 -smp 2 -m 4096 -d cpu_reset -D /tmp/work-dir/logs/qemu.log -machine q35 -global ICH9-LPC.disable_s3=1 -nographic -net nic,model=virtio -net user,hostfwd=tcp::8022-:22 -drive file=/usr/share/OVMF/OVMF_CODE.secboot.fd,if=pflash,format=raw,unit=0,readonly -drive file=/tmp/work-dir/assets/OVMF_VARS.snakeoil.fd,if=pflash,format=raw -chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0 -drive file=/tmp/work-dir/images/ubuntu-core-current.img,cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1 -chardev socket,telnet,host=localhost,server,port=7777,nowait,id=char0,logfile=/tmp/work-dir/logs/serial.log,logappend=on -serial chardev:char0 -monitor tcp:127.0.0.1:8888,server,nowait -usb (code=exited, status=1/FAILURE)
Main PID: 47199 (code=exited, status=1/FAILURE)

Sep 14 09:45:00 sep140928-511088 systemd[1]: Started Support for test google-nested:ubuntu-20.04-64:tests/nested/manual/core20-early-config.
Sep 14 09:45:00 sep140928-511088 qemu-system-x86_64[47199]: qemu-system-x86_64: -chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock: Failed to connect socket /var/snap/swtpm-mvo/current/swtpm-sock: No such file or directory
Sep 14 09:45:00 sep140928-511088 systemd[1]: nested-vm.service: Main process exited, code=exited, status=1/FAILURE
Sep 14 09:45:00 sep140928-511088 systemd[1]: nested-vm.service: Failed with result 'exit-code'.
```