### PR TITLE
interfaces: builtin: add iotedge interface to support Azure iotedge

### DIFF
--- a/interfaces/builtin/iotedge.go
+++ b/interfaces/builtin/iotedge.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const iotedgeSummary = `allows Azure iotedge daemon and client`
+
+const iotedgeBaseDeclarationSlots = `
+  azure-iotedge:
+    allow-installation: false
+    deny-connection: true
+    deny-auto-connection: true
+`
+
+const iotedgeConnectedPlugAppArmor = `
+# Description: allow access to the iotedge daemon socket and
+# tasks to manage containers. This gives privileged access to the system
+# via iotedge's socket API to iotedged, which then talks to dockerd
+
+# Description: control and tracing of dockerd containers
+@{PROC}/[0-9]*/environ r,
+ptrace (read),
+capability sys_ptrace,
+capability dac_read_search,
+
+# Allow iotedge daemon sockets
+/{,var/}run/iotedge/mgmt.sock rw,
+/{,var/}run/iotedge/workload.sock rw,
+
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "iotedge",
+		summary:               iotedgeSummary,
+		baseDeclarationSlots:  iotedgeBaseDeclarationSlots,
+		connectedPlugAppArmor: iotedgeConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/iotedge_test.go
+++ b/interfaces/builtin/iotedge_test.go
@@ -1,0 +1,95 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type IotedgeInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+const iotedgeMockPlugSnapInfoYaml = `name: iotedge
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [iotedge]
+`
+
+const iotedgeCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  iotedge:
+`
+
+var _ = Suite(&IotedgeInterfaceSuite{
+	iface: builtin.MustInterface("iotedge"),
+})
+
+func (s *IotedgeInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, iotedgeMockPlugSnapInfoYaml, nil, "iotedge")
+	s.slot, s.slotInfo = MockConnectedSlot(c, iotedgeCoreYaml, nil, "iotedge")
+}
+
+func (s *IotedgeInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "iotedge")
+}
+
+func (s *IotedgeInterfaceSuite) TestConnectedPlugSnippet(c *C) {
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.iotedge.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.iotedge.app"), testutil.Contains, `run/iotedge/mgmt.sock`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.iotedge.app"), testutil.Contains, `run/iotedge/workload.sock`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.iotedge.app"), testutil.Contains, `@{PROC}/[0-9]*/environ`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.iotedge.app"), testutil.Contains, "ptrace")
+	c.Assert(apparmorSpec.SnippetForTag("snap.iotedge.app"), testutil.Contains, "capability sys_ptrace")
+	c.Assert(apparmorSpec.SnippetForTag("snap.iotedge.app"), testutil.Contains, "capability dac_read_search")
+}
+
+func (s *IotedgeInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *IotedgeInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *IotedgeInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *IotedgeInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(nil, nil), Equals, true)
+}


### PR DESCRIPTION
New interface to support Azure iotedge as snap. https://github.com/Azure/azure-iotedge

Azure iotedge enables data analytics on the edge. In many aspects it's similar to AWS greengrass, so tendency would be to reuse greengrass interface, but that would give many unnecessary permissions. So dedicated interface would be preferred way. 
Iotedge does not run workloads directly, instead uses docker as engine to deploy workloads. So as such does not require permissions to run containers(docker plug is mostly enough to connected to dockerd), it still requires permissions to monitor workloads.
Additionally iotedge has two sockets for client to connect to. iotedge client performs similars tasks which are performed by iotedge daemon, so there is no clear reparation between client and daemon permission wise.

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
