### PR TITLE
tests/lib/nested.sh: use more focused cloud-init config for uc20

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -981,6 +981,7 @@ suites:
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
             nested_start_core_vm
+            nested_wait_for_snap_command
         restore-each: |
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
@@ -1042,6 +1043,7 @@ suites:
             nested_prepare_env
             nested_create_core_vm
             nested_start_core_vm
+            nested_wait_for_snap_command
         restore: |
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -760,6 +760,8 @@ nested_start_core_vm_unit() {
     nested_wait_for_snap_command
     # Wait for snap seeding to be done
     nested_exec "sudo snap wait system seed.loaded"
+    # Wait for cloud init to be done
+    nested_exec "cloud-init status --wait"
 }
 
 nested_get_current_image_name() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -758,7 +758,8 @@ nested_start_core_vm_unit() {
     nested_wait_for_ssh
     # Wait for the snap command to be available
     nested_wait_for_snap_command
-
+    # Wait for snap seeding to be done
+    nested_exec "sudo snap wait system seed.loaded"
 }
 
 nested_get_current_image_name() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -542,6 +542,8 @@ instance_id: cloud-images
 EOF
 }
 
+# TODO: see if the uc20 config works for classic here too, that would be faster
+#       as the chpasswd module from cloud-init runs rather late in the boot
 nested_create_cloud_init_config() {
     local CONFIG_PATH=$1
     cat <<EOF > "$CONFIG_PATH"
@@ -564,9 +566,23 @@ nested_create_cloud_init_config() {
 EOF
 }
 
+nested_create_cloud_init_uc20_config() {
+    local CONFIG_PATH=$1
+    cat << 'EOF' > "$CONFIG_PATH"
+#cloud-config
+datasource_list: [NoCloud]
+users:
+  - name: user1
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    lock_passwd: false
+    # passwd is just "ubuntu"
+    passwd: "$6$rounds=4096$PCrfo.ggdf4ubP$REjyaoY2tUWH2vjFJjvLs3rDxVTszGR9P7mhH9sHb2MsELfc53uV/v15jDDOJU/9WInfjjTKJPlD5URhX5Mix0"
+EOF
+}
+
 nested_configure_cloud_init_on_core20_vm() {
     local IMAGE=$1
-    nested_create_cloud_init_config "$NESTED_ASSETS_DIR/data.cfg"
+    nested_create_cloud_init_uc20_config "$NESTED_ASSETS_DIR/data.cfg"
 
     local devloop dev ubuntuSeedDev tmp
     # mount the image and find the loop device /dev/loop that is created for it

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -24,6 +24,10 @@ nested_wait_for_no_ssh() {
     nested_retry_while_success 200 1 "true"
 }
 
+nested_wait_for_snap_command() {
+    nested_retry_until_success 200 1 command -v snap
+}
+
 nested_get_boot_id() {
     nested_exec "cat /proc/sys/kernel/random/boot_id"
 }
@@ -56,7 +60,7 @@ nested_retry_while_success() {
     while nested_exec "$@"; do
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
-            echo "Timed out waiting for ssh. Aborting!"
+            echo "Timed out waiting for command '$*' to fail. Aborting!"
             return 1
         fi
         sleep "$wait"
@@ -71,7 +75,7 @@ nested_retry_until_success() {
     until nested_exec "$@"; do
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
-            echo "Timed out waiting for ssh. Aborting!"
+            echo "Timed out waiting for command '$*' to succeed. Aborting!"
             return 1
         fi
         sleep "$wait"
@@ -752,6 +756,9 @@ nested_start_core_vm_unit() {
 
     # Wait until ssh is ready
     nested_wait_for_ssh
+    # Wait for the snap command to be available
+    nested_wait_for_snap_command
+
 }
 
 nested_get_current_image_name() {


### PR DESCRIPTION
This uses just the users module/key so it runs entirely when that runs, which is
earlier in the boot process than the chpasswd module, so it saves us some time
from waiting for that to run later in the boot which matters for uc20 since
nested uc20 runs are rather slow already.

Maybe this helps with the uc20 reseal nested tests being so slow