### PR TITLE
configcore: do not error in console-conf.disable for install mode

### DIFF
--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -98,6 +99,21 @@ func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName string, d
 
 	// at runtime we can not change this setting
 	if opts == nil {
+
+		// Special case: during install mode the
+		// gadget-defaults will also be set as part of the
+		// system install change. However during install mode
+		// console-conf has no "complete" file, it just never runs
+		// in install mode. So we need to detect this and do nothing
+		// or the install mode will fail.
+		// XXX: instead of this hack we should look at the config
+		//      defaults and compare with the setting and exit if
+		//      they are the same but that requires some more changes.
+		mode, _, _ := boot.ModeAndRecoverySystemFromKernelCommandLine()
+		if mode == boot.ModeInstall {
+			return nil
+		}
+
 		hasDisabledFile := osutil.FileExists(filepath.Join(dirs.GlobalRootDir, consoleConfDisabled))
 		if disabled != hasDisabledFile {
 			return fmt.Errorf("cannot toggle console-conf at runtime, but only initially via gadget defaults")

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -27,6 +27,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/release"
@@ -226,6 +227,26 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableAlreadyDisabledIsFine(c *
 			"service.console-conf.disable": true,
 		},
 	})
+	c.Assert(err, IsNil)
+}
+
+func (s *servicesSuite) TestConfigureConsoleConfEnableDuringInstallMode(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockProcCmdline := filepath.Join(c.MkDir(), "cmdline")
+	err := ioutil.WriteFile(mockProcCmdline, []byte("snapd_recovery_mode=install snapd_recovery_system=20201212\n"), 0644)
+	c.Assert(err, IsNil)
+	restore = boot.MockProcCmdline(mockProcCmdline)
+	defer restore()
+
+	err = configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"service.console-conf.disable": true,
+		},
+	})
+	// no error because we are in install mode
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
During install mode the gadget-defaults will also be set as part
of the system install change. However during install mode
console-conf has no "complete" file, it just never runs
in install mode. So we need to detect this and do nothing
or the install mode will fail.

Note that this is not a great solution, ideally we would compare
what is set with the system default. But that requires some deeper
changes.
