### PR TITLE
client: bump the default request timeout to 120s

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -272,7 +272,7 @@ var (
 	// timeout for the whole of a single request to complete, requests are
 	// retried for up to 38s in total, make sure that the client timeout is
 	// not shorter than that
-	doTimeout = 50 * time.Second
+	doTimeout = 120 * time.Second
 )
 
 // MockDoTimings mocks the delay used by the do retry loop and request timeout.


### PR DESCRIPTION
Bump the default timeout of client requests. We have seen this cause problems
for people with slower machines where snapd can take longer to respond. On
especially slow systems, eg. when running a nested suite, this can cause
unexpected test failures.
