### PR TITLE
sysconfig,o/devicestate: mv DisableNoCloud to DisableAfterLocalDatasourcesRun

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -689,15 +689,12 @@ func (m *DeviceManager) ensureCloudInitRestricted() error {
 		// first boot unless we are in a "real cloud", i.e. not using NoCloud,
 		// or if we installed cloud-init configuration from the gadget
 		if model.Grade() != asserts.ModelGradeUnset {
-			// always disable NoCloud after first boot on uc20, this is because
-			// even if the gadget has a cloud.conf configuring NoCloud, the
-			// config installed by cloud-init should not work differently for
-			// later boots, so it's sufficient that NoCloud runs on first-boot
-			// and never again
-			// note that the name DisableNoCloud is slightly misleading, it's
-			// more specifically "disable cloud-init after first boot if
-			// NoCloud, but just restrict after first boot if not NoCloud"
-			opts.DisableNoCloud = true
+			// always disable NoCloud/local datasources after first boot on
+			// uc20, this is because even if the gadget has a cloud.conf
+			// configuring NoCloud, the config installed by cloud-init should
+			// not work differently for later boots, so it's sufficient that
+			// NoCloud runs on first-boot and never again
+			opts.DisableAfterLocalDatasourcesRun = true
 		}
 
 		// now restrict/disable cloud-init

--- a/overlord/devicestate/devicestate_cloudinit_test.go
+++ b/overlord/devicestate/devicestate_cloudinit_test.go
@@ -120,7 +120,7 @@ func (s *cloudInitUC20Suite) TestCloudInitUC20CloudGadgetNoDisable(c *C) {
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitDone)
 		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
-			DisableNoCloud: true,
+			DisableAfterLocalDatasourcesRun: true,
 		})
 		// in this case, pretend it was a real cloud, so it just got restricted
 		return sysconfig.CloudInitRestrictionResult{
@@ -153,7 +153,7 @@ func (s *cloudInitUC20Suite) TestCloudInitUC20NoCloudGadgetDisables(c *C) {
 		// no gadget cloud.conf, so we should be asked to disable if it was
 		// NoCloud
 		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
-			DisableNoCloud: true,
+			DisableAfterLocalDatasourcesRun: true,
 		})
 		// cloud-init never ran, so no datasource
 		return sysconfig.CloudInitRestrictionResult{
@@ -188,7 +188,7 @@ fi`)
 		restrictCalls++
 		c.Assert(state, Equals, sysconfig.CloudInitDone)
 		c.Assert(opts, DeepEquals, &sysconfig.CloudInitRestrictOptions{
-			DisableNoCloud: true,
+			DisableAfterLocalDatasourcesRun: true,
 		})
 		// we would have disabled it as per the opts
 		return sysconfig.CloudInitRestrictionResult{

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil"
 )
 
 // HasGadgetCloudConf takes a gadget directory and returns whether there is
@@ -153,6 +154,8 @@ datasource:
     fs_label: null`)
 
 	genericCloudRestrictYamlPattern = `datasource_list: [%s]`
+
+	localDatasources = []string{"NoCloud", "None"}
 )
 
 const (
@@ -253,11 +256,12 @@ type CloudInitRestrictOptions struct {
 	// in an active/running or errored state.
 	ForceDisable bool
 
-	// DisableNoCloud modifies the behavior to whole-sale disable cloud-init,
-	// if the datasource detected is NoCloud, if the datasource detected is
-	// anything other than NoCloud then it is merely restricted as described in
-	// the doc-comment on RestrictCloudInit.
-	DisableNoCloud bool
+	// DisableAfterLocalDatasourcesRun modifies RestrictCloudInit to disable
+	// cloud-init after it has run on first-boot if the datasource detected is
+	// a local source such as NoCloud or None. If the datasource detected is not
+	// a local source, such as GCE or AWS EC2 it is merely restricted as
+	// described in the doc-comment on RestrictCloudInit.
+	DisableAfterLocalDatasourcesRun bool
 }
 
 // RestrictCloudInit will limit the operations of cloud-init on subsequent boots
@@ -337,27 +341,26 @@ func RestrictCloudInit(state CloudInitState, opts *CloudInitRestrictOptions) (Cl
 
 	cloudInitRestrictFile := filepath.Join(dirs.GlobalRootDir, cloudInitSnapdRestrictFile)
 
-	switch res.DataSource {
-	case "NoCloud":
-		// With the NoCloud datasource, we also need to restrict/disable the
-		// import of arbitrary filesystem labels to use as datasources, i.e. a
-		// USB drive inserted by an attacker with label CIDATA will defeat
-		// security measures on Ubuntu Core, so with the additional fs_label
-		// spec, we disable that import.
+	switch {
+	case opts.DisableAfterLocalDatasourcesRun && strutil.ListContains(localDatasources, res.DataSource):
+		// On UC20, DisableAfterLocalDatasourcesRun will be set, where we want
+		// to disable local sources like NoCloud and None after first-boot
+		// instead of just restricting them like we do below for UC16 and UC18.
 
-		// Note that on UC20, we will also specify DisableNoCloud, to disable
-		// cloud-init even after the first boot
-		if opts.DisableNoCloud {
-			// change the action taken to disable
-			res.Action = "disable"
-			err = DisableCloudInit(dirs.GlobalRootDir)
-		} else {
-			err = ioutil.WriteFile(cloudInitRestrictFile, nocloudRestrictYaml, 0644)
-		}
+		// as such, change the action taken to disable and disable cloud-init
+		res.Action = "disable"
+		err = DisableCloudInit(dirs.GlobalRootDir)
+	case res.DataSource == "NoCloud":
+		// With the NoCloud datasource (which is one of the local datasources),
+		// we also need to restrict/disable the import of arbitrary filesystem
+		// labels to use as datasources, i.e. a USB drive inserted by an
+		// attacker with label CIDATA will defeat security measures on Ubuntu
+		// Core, so with the additional fs_label spec, we disable that import.
+		err = ioutil.WriteFile(cloudInitRestrictFile, nocloudRestrictYaml, 0644)
 	default:
-		// all other datasources that are not NoCloud will be restricted to only
-		// allow this specific datasource to prevent an attack via NoCloud for
-		// example
+		// all other cases are either not local on UC20, or not NoCloud and as
+		// such we simply restrict cloud-init to the specific datasource used so
+		// that an attack via NoCloud is protected against
 		yaml := []byte(fmt.Sprintf(genericCloudRestrictYamlPattern, res.DataSource))
 		err = ioutil.WriteFile(cloudInitRestrictFile, yaml, 0644)
 	}

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -343,6 +343,18 @@ var multipassNoCloudCloudInitStatusJSON = `{
  }
 }`
 
+var localNoneCloudInitStatusJSON = `{
+ "v1": {
+  "datasource": "DataSourceNone",
+  "init": {
+   "errors": [],
+   "finished": 1591788514.4656117,
+   "start": 1591788514.2607572
+  },
+  "stage": null
+ }
+}`
+
 var lxdNoCloudCloudInitStatusJSON = `{
  "v1": {
   "datasource": "DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]",
@@ -443,12 +455,24 @@ func (s *sysconfigSuite) TestRestrictCloudInit(c *C) {
 			state:               sysconfig.CloudInitDone,
 			cloudInitStatusJSON: multipassNoCloudCloudInitStatusJSON,
 			sysconfOpts: &sysconfig.CloudInitRestrictOptions{
-				DisableNoCloud: true,
+				DisableAfterLocalDatasourcesRun: true,
 			},
 			expDatasource:  "NoCloud",
 			expAction:      "disable",
 			expDisableFile: true,
 		},
+		{
+			comment:             "none uc20 done",
+			state:               sysconfig.CloudInitDone,
+			cloudInitStatusJSON: localNoneCloudInitStatusJSON,
+			sysconfOpts: &sysconfig.CloudInitRestrictOptions{
+				DisableAfterLocalDatasourcesRun: true,
+			},
+			expDatasource:  "None",
+			expAction:      "disable",
+			expDisableFile: true,
+		},
+
 		// the two cases for lxd and multipass are effectively the same, but as
 		// the largest known users of cloud-init w/ UC, we leave them as
 		// separate test cases for their different cloud-init status.json
@@ -474,7 +498,7 @@ func (s *sysconfigSuite) TestRestrictCloudInit(c *C) {
 			state:               sysconfig.CloudInitDone,
 			cloudInitStatusJSON: multipassNoCloudCloudInitStatusJSON,
 			sysconfOpts: &sysconfig.CloudInitRestrictOptions{
-				DisableNoCloud: true,
+				DisableAfterLocalDatasourcesRun: true,
 			},
 			expDatasource:  "NoCloud",
 			expAction:      "disable",
@@ -485,7 +509,7 @@ func (s *sysconfigSuite) TestRestrictCloudInit(c *C) {
 			state:               sysconfig.CloudInitDone,
 			cloudInitStatusJSON: lxdNoCloudCloudInitStatusJSON,
 			sysconfOpts: &sysconfig.CloudInitRestrictOptions{
-				DisableNoCloud: true,
+				DisableAfterLocalDatasourcesRun: true,
 			},
 			expDatasource:  "NoCloud",
 			expAction:      "disable",


### PR DESCRIPTION
Also include "None" datasource in the definition of a local datasource on UC20
so it is disabled after first boot even when used.

We don't change the behavior on UC16/UC18 however, so on those platforms the
"None" datasource will just be restricted to only ever allow cloud-init to use
"None" as a datasource, so users of the "None" datasource with cloud-init on
Ubuntu Core will still be protected from the specific NoCloud attack from
CVE-2020-11933.