### PR TITLE
interfaces/process-control: add sched_setattr to seccomp

### DIFF
--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -58,6 +58,7 @@ const processControlConnectedPlugSecComp = `
 nice
 setpriority
 sched_setaffinity
+sched_setattr
 sched_setparam
 sched_setscheduler
 `


### PR DESCRIPTION
This came about as investigation on https://forum.snapcraft.io/t/interface-required-for-glib-thread-scheduler/19908/

From Jamie, we are allowing this since the interface is already quite privileged
in that it can renice and kill arbitrary processes. Using sched_setattr isn't
appreciably different in this regard, plus we can't readily mediate the pid or
the sched_attr attr of the call. In all, breaking this out into a separate
interface seems premature until we have finer-grained controls for mediation.