### PR TITLE
boot/modeenv: track unknown keys in Read and put back into modeenv during Write

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -53,6 +53,8 @@ func (m *Modeenv) DeepEqual(m2 *Modeenv) bool {
 }
 
 var (
+	ModeenvKnownKeys = modeenvKnownKeys
+
 	MarshalModeenvEntryTo        = marshalModeenvEntryTo
 	UnmarshalModeenvValueFromCfg = unmarshalModeenvValueFromCfg
 

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -93,7 +93,6 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 		return nil, err
 	}
 
-	fmt.Println(cfg.Options(""))
 	// TODO:UC20: should we check these errors and try to do something?
 	m := Modeenv{
 		read:          true,

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/strutil"
 )
 
 type bootAssetsMap map[string][]string
@@ -125,21 +124,23 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 	if err != nil {
 		return nil, err
 	}
-	var knownKeys = []string{
-		"recovery_system",
-		"current_recovery_systems",
-		"mode",
-		"base",
-		"base_status",
-		"try_base",
-		"current_kernels",
-		"model",
-		"grade",
-		"current_trusted_boot_assets",
-		"current_trusted_recovery_boot_assets",
+	var knownKeys = map[string]struct{}{
+		"recovery_system":          {},
+		"current_recovery_systems": {},
+		// for gofmt
+		"mode":            {},
+		"base":            {},
+		"base_status":     {},
+		"try_base":        {},
+		"current_kernels": {},
+		"model":           {},
+		"grade":           {},
+		// for gofmt
+		"current_trusted_boot_assets":          {},
+		"current_trusted_recovery_boot_assets": {},
 	}
 	for _, k := range keys {
-		if !strutil.ListContains(knownKeys, k) {
+		if _, known := knownKeys[k]; !known {
 			val, err := cfg.Get("", k)
 			if err != nil {
 				return nil, err

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -51,6 +51,23 @@ func (s *modeenvSuite) SetUpTest(c *C) {
 	s.mockModeenvPath = filepath.Join(s.tmpdir, dirs.SnapModeenvFile)
 }
 
+func (s *modeenvSuite) TestKnownKnown(c *C) {
+	// double check keys as found with reflect
+	c.Check(boot.ModeenvKnownKeys, DeepEquals, map[string]bool{
+		"mode":                     true,
+		"recovery_system":          true,
+		"current_recovery_systems": true,
+		"base":            true,
+		"try_base":        true,
+		"base_status":     true,
+		"current_kernels": true,
+		"model":           true,
+		"grade":           true,
+		"current_trusted_boot_assets":          true,
+		"current_trusted_recovery_boot_assets": true,
+	})
+}
+
 func (s *modeenvSuite) TestReadEmptyErrors(c *C) {
 	modeenv, err := boot.ReadModeenv("/no/such/file")
 	c.Assert(os.IsNotExist(err), Equals, true)

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -270,6 +270,29 @@ recovery_system=20191126
 	c.Check(modeenv.RecoverySystem, Equals, "20191126")
 }
 
+func (s *modeenvSuite) TestReadModeenvWithUnknownKeysKeepsWrites(c *C) {
+	s.makeMockModeenvFile(c, `first_unknown=thing
+mode=recovery
+recovery_system=20191126
+unknown_key=some unknown value
+a_key=other
+`)
+
+	modeenv, err := boot.ReadModeenv(s.tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(modeenv.Mode, Equals, "recovery")
+	c.Check(modeenv.RecoverySystem, Equals, "20191126")
+
+	c.Assert(modeenv.Write(), IsNil)
+
+	c.Assert(s.mockModeenvPath, testutil.FileEquals, `mode=recovery
+recovery_system=20191126
+a_key=other
+first_unknown=thing
+unknown_key=some unknown value
+`)
+}
+
 func (s *modeenvSuite) TestReadModeWithBase(c *C) {
 	s.makeMockModeenvFile(c, `mode=recovery
 recovery_system=20191126


### PR DESCRIPTION
This ensures that if we need to add new keys to the modeenv later on, and also
need to modify the modeenv with an old snapd/snap-bootstrap, such as in recovery
or the initramfs, we will not lose those keys in the modeenv.