### PR TITLE
tests: improve kernel reseal test

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -283,20 +283,20 @@ nested_get_snakeoil_key() {
     echo "$KEYNAME"
 }
 
-nested_secboot_sign_gadget_file() {
-    local GADGET_DIR="$1"
+nested_secboot_sign_file() {
+    local DIR="$1"
     local KEY="$2"
     local CERT="$3"
     local FILE="$4"
-    sbattach --remove "$GADGET_DIR"/"$FILE"
-    sbsign --key "$KEY" --cert "$CERT" --output "$GADGET_DIR"/"$FILE" "$GADGET_DIR"/"$FILE"
+    sbattach --remove "$DIR"/"$FILE"
+    sbsign --key "$KEY" --cert "$CERT" --output "$DIR"/"$FILE" "$DIR"/"$FILE"
 }
 
 nested_secboot_sign_gadget() {
     local GADGET_DIR="$1"
     local KEY="$2"
     local CERT="$3"
-    nested_secboot_sign_gadget_file "$GADGET_DIR" "$KEY" "$CERT" "shim.efi.signed"
+    nested_secboot_sign_file "$GADGET_DIR" "$KEY" "$CERT" "shim.efi.signed"
 }
 
 nested_prepare_env() {

--- a/tests/nested/core20/gadget-reseal/task.yaml
+++ b/tests/nested/core20/gadget-reseal/task.yaml
@@ -33,8 +33,8 @@ execute: |
     mv modified_gadget.yaml pc-gadget/meta/gadget.yaml
 
     # resign both assets
-    nested_secboot_sign_gadget_file pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" "shim.efi.signed"
-    nested_secboot_sign_gadget_file pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" "grubx64.efi"
+    nested_secboot_sign_file pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" "shim.efi.signed"
+    nested_secboot_sign_file pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" "grubx64.efi"
     rm -f "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
     snap pack pc-gadget/
 

--- a/tests/nested/core20/kernel-reseal/task.yaml
+++ b/tests/nested/core20/kernel-reseal/task.yaml
@@ -16,7 +16,7 @@ prepare: |
   KEY_NAME=$(nested_get_snakeoil_key)
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
   SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
-  nested_secboot_sign_file "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" pc-kernel/kernel.efi
+  nested_secboot_sign_file "$PWD/pc-kernel" "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" kernel.efi
 
   snap pack pc-kernel
   rm -rf pc-kernel
@@ -26,7 +26,7 @@ prepare: |
 execute: |
   # shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
-  
+
   SEALED_KEY_MTIME_1="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-seed/device/fde/ubuntu-data.sealed-key)"
   RESEAL_COUNT_1="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
 
@@ -35,7 +35,7 @@ execute: |
   REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous new-pc-kernel.snap --no-wait)
   nested_wait_for_reboot "${boot_id}"
   nested_exec sudo snap watch "${REMOTE_CHG_ID}"
-  
+
   # ensure ubuntu-data.sealed-key mtime is newer
   SEALED_KEY_MTIME_2="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-seed/device/fde/ubuntu-data.sealed-key)"
   test "$SEALED_KEY_MTIME_2" -gt "$SEALED_KEY_MTIME_1"

--- a/tests/nested/core20/kernel-reseal/task.yaml
+++ b/tests/nested/core20/kernel-reseal/task.yaml
@@ -13,10 +13,7 @@ prepare: |
   KEY_NAME=$(nested_get_snakeoil_key)
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
   SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
-  # FIXME: this looks almost like nested_secboot_sign_gadget
-  #        so refactor nested_secboot_sign_gadget
-  sbattach --remove pc-kernel/kernel.efi
-  sbsign --key "$SNAKEOIL_KEY" --cert "$SNAKEOIL_CERT" --output pc-kernel/kernel.efi pc-kernel/kernel.efi
+  nested_secboot_sign_file "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" pc-kernel/kernel.efi
 
   snap pack pc-kernel
   rm -rf pc-kernel

--- a/tests/nested/core20/kernel-reseal/task.yaml
+++ b/tests/nested/core20/kernel-reseal/task.yaml
@@ -2,19 +2,37 @@ summary: Check that a kernel refresh reseals
 
 systems: [ubuntu-20.04-64]
 
-execute: |
+prepare: |
   # shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
-  # Wait for snapd to be seeded
-  nested_exec sudo snap wait system seed.loaded
+  snap download pc-kernel --channel=20/edge --basename=pc-kernel
+  unsquashfs -d pc-kernel pc-kernel.snap
+  sed -i 's/This program cannot be run in DOS mode/This program cannot be run in D0S mode/' pc-kernel/kernel.efi
 
+  KEY_NAME=$(nested_get_snakeoil_key)
+  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+  # FIXME: this looks almost like nested_secboot_sign_gadget
+  #        so refactor nested_secboot_sign_gadget
+  sbattach --remove pc-kernel/kernel.efi
+  sbsign --key "$SNAKEOIL_KEY" --cert "$SNAKEOIL_CERT" --output pc-kernel/kernel.efi pc-kernel/kernel.efi
+
+  snap pack pc-kernel
+  rm -rf pc-kernel
+  mv pc-kernel_*.snap new-pc-kernel.snap
+  nested_copy new-pc-kernel.snap
+
+execute: |
+  # shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+  
   SEALED_KEY_MTIME_1="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-seed/device/fde/ubuntu-data.sealed-key)"
   RESEAL_COUNT_1="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
 
   # Install new (unasserted) kernel and wait for reboot/change finishing
   boot_id="$( nested_get_boot_id )"
-  REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous /var/lib/snapd/snaps/pc-kernel_*.snap --no-wait)
+  REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous new-pc-kernel.snap --no-wait)
   nested_wait_for_reboot "${boot_id}"
   nested_exec sudo snap watch "${REMOTE_CHG_ID}"
   

--- a/tests/nested/core20/kernel-reseal/task.yaml
+++ b/tests/nested/core20/kernel-reseal/task.yaml
@@ -8,6 +8,9 @@ prepare: |
 
   snap download pc-kernel --channel=20/edge --basename=pc-kernel
   unsquashfs -d pc-kernel pc-kernel.snap
+  # ensure we really have the header we expect
+  grep -q -a "This program cannot be run in DOS mode" pc-kernel/kernel.efi
+  # modify the kernel so that the hash changes
   sed -i 's/This program cannot be run in DOS mode/This program cannot be run in D0S mode/' pc-kernel/kernel.efi
 
   KEY_NAME=$(nested_get_snakeoil_key)


### PR DESCRIPTION
This commit changes the kernel reseal test to actually change
the kernel.efi so that the hashes of the kernel change during
the test.
