### PR TITLE
tests/lib/cl_check.py: use python3 compatible code

### DIFF
--- a/tests/lib/cla_check.py
+++ b/tests/lib/cla_check.py
@@ -14,7 +14,7 @@ from subprocess import check_call, check_output
 try:
     from launchpadlib.launchpad import Launchpad
 except ImportError:
-    sys.exit("Install launchpadlib: sudo apt install python-launchpadlib")
+    sys.exit("Install launchpadlib: sudo apt install python-launchpadlib python3-launchpadlib")
 
 shortlog_email_rx = re.compile("^\s*\d+\s+.*<(\S+)>$", re.M)
 
@@ -24,7 +24,7 @@ is_github_actions = os.getenv("GITHUB_ACTIONS", "") == "true"
 
 
 def get_emails_for_range(r):
-    output = check_output(["git", "shortlog", "-se", r])
+    output = check_output(["git", "shortlog", "-se", r]).decode("utf-8")
     return set(m.group(1) for m in shortlog_email_rx.finditer(output))
 
 


### PR DESCRIPTION
Also suggest installing python3 version of launchpadlib, as python2 is no longer
supported.