### PR TITLE
tests: skip nested images pre-configuration by default

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -53,6 +53,8 @@ environment:
     # Use the installed snapd and reset the systems without removing snapd
     REUSE_SNAPD: '$(HOST: echo "${SPREAD_REUSE_SNAPD:-0}")'
     PROFILE_SNAPS: '$(HOST: echo "${SPREAD_PROFILE_SNAPS:-0}")'
+    # Configure nested images to be reused on the following tests
+    NESTED_CONFIGURE_IMAGES: '$(HOST: echo "${NESTED_CONFIGURE_IMAGES:-false}")'
 
 backends:
     google:

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -892,7 +892,7 @@ nested_start_core_vm() {
             sync
 
             # compress the current image if it is a generic image
-            if nested_is_generic_image; then
+            if nested_is_generic_image && [ "$NESTED_CONFIGURE_IMAGES" = "true" ]; then
                 # Stop the current image and compress it
                 nested_shutdown
                 nested_compress_image "$CURRENT_NAME"


### PR DESCRIPTION
This will allow to speed up when a single test run is done for testing
or debug. Then for full runs (nightly runs and github actions) we can
specify to configure the images.
