### PR TITLE
 gadget: resolve device mapper devices for fallback device lookup

### DIFF
--- a/gadget/device_linux.go
+++ b/gadget/device_linux.go
@@ -22,7 +22,9 @@ package gadget
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
@@ -202,17 +204,47 @@ func findParentDeviceWithWritableFallback() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return ParentDiskFromPartition(partitionWritable)
+	return ParentDiskFromMountSource(partitionWritable)
 }
 
-// ParentDiskFromPartition will find the parent disk device for the
-// given partition. E.g. /dev/nvmen0n1p5 -> /dev/nvme0n1
+// ParentDiskFromMountSource will find the parent disk device for the given
+// partition. E.g. /dev/nvmen0n1p5 -> /dev/nvme0n1.
 //
-// Note that this does not work for anything using device mapper (like
-// LUKS/LVM) yet.
-func ParentDiskFromPartition(partition string) (string, error) {
+// When the mount source is a symlink, it is resolved to the actual device that
+// is mounted. Should the device be one created by device mapper, it is followed
+// up to the actual underlying block device. As an example, this is how devices
+// are followed with a /writable mounted from an encrypted volume:
+//
+// /dev/mapper/ubuntu-data-<uuid> (a symlink)
+//   ⤷ /dev/dm-0 (set up by device mapper)
+//       ⤷ /dev/hda4 (returned by this function)
+//
+func ParentDiskFromMountSource(mountSource string) (string, error) {
+	// mount source can be a symlink
+	st, err := os.Lstat(mountSource)
+	if err != nil {
+		return "", err
+	}
+	if mode := st.Mode(); mode&os.ModeSymlink != 0 {
+		// resolve to actual device
+		target, err := filepath.EvalSymlinks(mountSource)
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve mount source symlink %v: %v", mountSource, err)
+		}
+		mountSource = target
+	}
 	// /dev/sda3 -> sda3
-	devname := filepath.Base(partition)
+	devname := filepath.Base(mountSource)
+
+	if strings.HasPrefix(devname, "dm-") {
+		// looks like a device set up by device mapper
+		var err error
+		resolved, err := resolveParentOfDeviceMapperDevice(devname)
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve device mapper device %v: %v", devname, err)
+		}
+		devname = resolved
+	}
 
 	// do not bother with investigating major/minor devices (inconsistent
 	// across block device types) or mangling strings, but look at sys
@@ -238,4 +270,32 @@ func ParentDiskFromPartition(partition string) (string, error) {
 		return "", fmt.Errorf("device %v does not exist", mainDev)
 	}
 	return mainDev, nil
+}
+
+func resolveParentOfDeviceMapperDevice(devname string) (string, error) {
+	// devices set up by device mapper have /dev/block/dm-*/slaves/ which
+	// lists the devices that are upper in the chain, follow that to find
+	// the first device that is non-dm one
+	dmSlavesLevel := 0
+	const maxDmSlavesLevel = 5
+	for strings.HasPrefix(devname, "dm-") {
+		// /sys/block/dm-*/slaves/ lists a device that this dm device is part of
+		slavesGlob := filepath.Join(dirs.GlobalRootDir, "/sys/block", devname, "slaves/*")
+		slaves, err := filepath.Glob(slavesGlob)
+		if err != nil {
+			return "", fmt.Errorf("cannot glob slaves of dm device %v: %v", devname, err)
+		}
+		if len(slaves) != 1 {
+			return "", fmt.Errorf("unexpected number of dm device %v slaves: %v", devname, len(slaves))
+		}
+		devname = filepath.Base(slaves[0])
+
+		// if we're this deep in resolving dm devices, things are clearly getting out of hand
+		dmSlavesLevel++
+		if dmSlavesLevel >= maxDmSlavesLevel {
+			return "", fmt.Errorf("too many levels")
+		}
+
+	}
+	return devname, nil
 }

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -43,7 +43,7 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 			if err != nil {
 				return "", fmt.Errorf("cannot find device for role %q: %v", role, err)
 			}
-			return gadget.ParentDiskFromPartition(device)
+			return gadget.ParentDiskFromMountSource(device)
 		}
 	}
 	return "", fmt.Errorf("cannot find role %s in gadget", role)

--- a/tests/nested/core20/gadget-reseal/manip_gadget.py
+++ b/tests/nested/core20/gadget-reseal/manip_gadget.py
@@ -14,6 +14,13 @@ def parse_arguments():
     return parser.parse_args()
 
 
+def must_find_struct(structs, name):
+    found = [s for s in structs if s["name"] == name]
+    if len(found) != 1:
+        raise RuntimeError("no structure with name {} among: {}".format(name, structs))
+    return found[0]
+
+
 def bump_update_edition(update):
     if update is None:
         return {"edition": 1}
@@ -28,12 +35,12 @@ def main(opts):
     gadget_yaml = yaml.safe_load(opts.gadgetyaml)
 
     structs = gadget_yaml["volumes"]["pc"]["structure"]
-    matched = [s for s in structs if s["name"] == "ubuntu-seed"]
-    if not matched:
-        raise RuntimeError("ubuntu-seed not found among: {}".format(structs))
-
-    ubuntu_seed = matched[0]
+    ubuntu_seed = must_find_struct(structs, "ubuntu-seed")
     ubuntu_seed["update"] = bump_update_edition(ubuntu_seed.get("update"))
+
+    # trigger an update, so that device lookup is performed
+    mbr = must_find_struct(structs, "mbr")
+    mbr["update"] = bump_update_edition(mbr.get("update"))
 
     yaml.dump(gadget_yaml, stream=sys.stdout, indent=2, default_flow_style=False)
 


### PR DESCRIPTION
Structures without partition require a fallback device lookup path, which
attempts to identify a mount source of /writable, and work out a device from
that. On devices with full disk encryption, /writable will be mounted from an
encrypted device, set up by device mapper. Attempt to resolve the actual
underlying block device by following device mapped slave entries.