### PR TITLE
tests: misc nested changes

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -407,12 +407,14 @@ debug-each: |
         if nested_is_nested_system; then
             echo '# nested VM status'
             systemctl status nested-vm || true
-            journalctl -e --no-pager -u nested-vm || true
+            journalctl --no-pager -u nested-vm || true
 
             if [ -f "${NESTED_LOGS_DIR}/serial.log" ]; then
                 echo '# nested VM serial boot log'
                 cat "${NESTED_LOGS_DIR}/serial.log"
             fi
+
+            nested_exec journalctl --no-pager -u snapd || true
         fi
 
         echo '# journal messages for snapd'

--- a/spread.yaml
+++ b/spread.yaml
@@ -414,7 +414,7 @@ debug-each: |
                 cat "${NESTED_LOGS_DIR}/serial.log"
             fi
 
-            nested_exec journalctl --no-pager -u snapd || true
+            nested_exec sudo journalctl --no-pager -u snapd || true
         fi
 
         echo '# journal messages for snapd'

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -912,10 +912,16 @@ nested_start_core_vm() {
 }
 
 nested_shutdown() {
+    # we sometimes have bugs in nested vm's where files that were successfully
+    # written become empty all of a sudden, so doing a sync here in the VM, and
+    # another one in the host when done probably helps to avoid that, and at
+    # least can't hurt anything
+    nested_exec "sync"
     nested_exec "sudo shutdown now" || true
     nested_wait_for_no_ssh
     nested_force_stop_vm
     wait_for_service "$NESTED_VM" inactive
+    sync
 }
 
 nested_start() {

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/seed/user-data
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/seed/user-data
@@ -4,4 +4,4 @@ users:
   - name: attacker-user
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: false
-    passwd: $6$rounds=4096$ftDwPSSVP0Jq9$4hXIcusbcZMxbSnfv8D/vp/bdzgVAds9qGcFjeBvv1Ths9mLiNPKAxW8/1zOtGLPKsEcorUOzl16hn9jxswDz0
+    passwd: $6$rounds=4096$PCrfo.ggdf4ubP$REjyaoY2tUWH2vjFJjvLs3rDxVTszGR9P7mhH9sHb2MsELfc53uV/v15jDDOJU/9WInfjjTKJPlD5URhX5Mix0

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -106,8 +106,7 @@ execute: |
 
     # gracefully shutdown so that we don't have file corruption
     echo "Gracefully shutting down the nested VM to prepare a simulated attack"
-    nested_exec "sudo shutdown -h now" || true
-    nested_wait_for_no_ssh
+    nested_shutdown
 
     # now if we reboot and add a cloud-init drive, it will not be imported onto
     # the system

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/seed1/user-data
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/seed1/user-data
@@ -4,4 +4,4 @@ users:
   - name: normal-user
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: false
-    passwd: $6$rounds=4096$ftDwPSSVP0Jq9$4hXIcusbcZMxbSnfv8D/vp/bdzgVAds9qGcFjeBvv1Ths9mLiNPKAxW8/1zOtGLPKsEcorUOzl16hn9jxswDz0
+    passwd: $6$rounds=4096$PCrfo.ggdf4ubP$REjyaoY2tUWH2vjFJjvLs3rDxVTszGR9P7mhH9sHb2MsELfc53uV/v15jDDOJU/9WInfjjTKJPlD5URhX5Mix0

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/seed2/user-data
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/seed2/user-data
@@ -4,4 +4,4 @@ users:
   - name: attacker-user
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: false
-    passwd: $6$rounds=4096$ftDwPSSVP0Jq9$4hXIcusbcZMxbSnfv8D/vp/bdzgVAds9qGcFjeBvv1Ths9mLiNPKAxW8/1zOtGLPKsEcorUOzl16hn9jxswDz0
+    passwd: $6$rounds=4096$PCrfo.ggdf4ubP$REjyaoY2tUWH2vjFJjvLs3rDxVTszGR9P7mhH9sHb2MsELfc53uV/v15jDDOJU/9WInfjjTKJPlD5URhX5Mix0

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -127,8 +127,7 @@ execute: |
 
     # gracefully shutdown so that we don't have file corruption
     echo "Gracefully shutting down the nested VM to prepare a simulated attack"
-    nested_exec "sudo shutdown -h now" || true
-    nested_wait_for_no_ssh
+    nested_shutdown
 
     # now if we reboot and add a cloud-init drive, it will not be imported onto
     # the system


### PR DESCRIPTION
* Add nested snapd logs from the VM, this should help debug problems like https://paste.ubuntu.com/p/FBBRKSKBGH/ where as soon as the snap command is available we aren't able to wait for seeding to finish because snapd is refusing connections for some reason
* Use the nested_shutdown helper from the cloud-init nested tests
* Add sync commands to nested_shutdown to hopefully eliminate problems with file corruption inside the nested VM
* Change the password for the cloud-init nested test users to "ubuntu" from "passw0rd" for consistency