### PR TITLE
tests/nested/manual/refresh-revert-fundamentals: disable temporarily

### DIFF
--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -4,6 +4,11 @@ description: |
     This test validates the fundamental snaps can be refreshed
     and reverted to the new snaps published to edge channel.
 
+# TODO:UC20: re-enable this test when kernel snap has been re-built with new
+# initramfs, currently beta or newer snapd snapd + any published kernel snap
+# results in broken install
+manual: true
+
 systems: [ubuntu-20.04-*]
 
 environment:


### PR DESCRIPTION
These tests currently always fail because the snapd snap in beta and newer
writes a modeenv which the initramfs in all published kernel snaps will corrupt
essentially, resulting in broken installs. To fix the issue we need a new kernel
snap, so until that happens mark the test as manual to allow landing PR's.

For concrete example, see the runs from https://github.com/snapcore/snapd/pull/9367, where they all failed like this:

```
2020-09-17T22:11:32.1668073Z + nested_exec sudo journalctl --no-pager -u snapd
2020-09-17T22:11:32.1669127Z + sshpass -p ubuntu ssh -p 8022 -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost sudo journalctl --no-pager -u snapd
2020-09-17T22:11:32.1670181Z Warning: Permanently added '[localhost]:8022' (ECDSA) to the list of known hosts.
2020-09-17T22:11:32.1670821Z -- Logs begin at Thu 2020-09-17 22:00:32 UTC, end at Thu 2020-09-17 22:11:30 UTC. --
2020-09-17T22:11:32.1671205Z Sep 17 22:05:24 ubuntu systemd[1]: Starting Snap Daemon...
2020-09-17T22:11:32.1672049Z Sep 17 22:05:30 ubuntu snapd[1522]: AppArmor status: apparmor is enabled and all features are available
2020-09-17T22:11:32.1672639Z Sep 17 22:05:31 ubuntu snapd[1522]: patch.go:64: Patching system state level 6 to sublevel 1...
2020-09-17T22:11:32.1673168Z Sep 17 22:05:31 ubuntu snapd[1522]: patch.go:64: Patching system state level 6 to sublevel 2...
2020-09-17T22:11:32.1673697Z Sep 17 22:05:31 ubuntu snapd[1522]: patch.go:64: Patching system state level 6 to sublevel 3...
2020-09-17T22:11:32.1674604Z Sep 17 22:05:31 ubuntu snapd[1522]: daemon.go:343: started snapd/2.47~pre1+git732.ga8341c5 (series 16) ubuntu-core/20 (amd64) linux/5.4.0-48-generic.
2020-09-17T22:11:32.1675365Z Sep 17 22:05:32 ubuntu snapd[1522]: daemon.go:436: adjusting startup timeout by 30s (pessimistic estimate of 30s plus 5s per snap)
2020-09-17T22:11:32.1675918Z Sep 17 22:05:34 ubuntu systemd[1]: Started Snap Daemon.
2020-09-17T22:11:32.1676704Z Sep 17 22:05:34 ubuntu snapd[1522]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1677639Z Sep 17 22:05:35 ubuntu snapd[1522]: daemon.go:542: gracefully waiting for running hooks
2020-09-17T22:11:32.1678147Z Sep 17 22:05:35 ubuntu snapd[1522]: daemon.go:544: done waiting for running hooks
2020-09-17T22:11:32.1678623Z Sep 17 22:05:35 ubuntu systemd[1]: snapd.service: Succeeded.
2020-09-17T22:11:32.1679170Z Sep 17 22:05:35 ubuntu systemd[1]: snapd.service: Scheduled restart job, restart counter is at 1.
2020-09-17T22:11:32.1679674Z Sep 17 22:05:35 ubuntu systemd[1]: Stopped Snap Daemon.
2020-09-17T22:11:32.1680067Z Sep 17 22:05:36 ubuntu systemd[1]: Starting Snap Daemon...
2020-09-17T22:11:32.1680579Z Sep 17 22:05:38 ubuntu snapd[1588]: AppArmor status: apparmor is enabled and all features are available
2020-09-17T22:11:32.1681154Z Sep 17 22:05:41 ubuntu snapd[1588]: patch.go:64: Patching system state level 6 to sublevel 1...
2020-09-17T22:11:32.1681689Z Sep 17 22:05:41 ubuntu snapd[1588]: patch.go:64: Patching system state level 6 to sublevel 2...
2020-09-17T22:11:32.1682220Z Sep 17 22:05:41 ubuntu snapd[1588]: patch.go:64: Patching system state level 6 to sublevel 3...
2020-09-17T22:11:32.1686948Z Sep 17 22:05:42 ubuntu snapd[1588]: daemon.go:343: started snapd/2.47~pre1+git732.ga8341c5 (series 16) ubuntu-core/20 (amd64) linux/5.4.0-48-generic.
2020-09-17T22:11:32.1687930Z Sep 17 22:05:43 ubuntu snapd[1588]: daemon.go:436: adjusting startup timeout by 35s (pessimistic estimate of 30s plus 5s per snap)
2020-09-17T22:11:32.1688492Z Sep 17 22:05:45 ubuntu systemd[1]: Started Snap Daemon.
2020-09-17T22:11:32.1689264Z Sep 17 22:05:47 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1690605Z Sep 17 22:05:48 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1692106Z Sep 17 22:05:48 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1693269Z Sep 17 22:05:49 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1694415Z Sep 17 22:05:49 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1695567Z Sep 17 22:05:50 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1696709Z Sep 17 22:05:50 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1697856Z Sep 17 22:05:50 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1698995Z Sep 17 22:05:56 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1700300Z Sep 17 22:07:03 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1701455Z Sep 17 22:07:03 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1702736Z Sep 17 22:07:04 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1704363Z Sep 17 22:07:04 ubuntu snapd[1588]: taskrunner.go:271: [change 1 "Make snap \"pc-kernel\" (604) available to the system" task] failed: cannot set next boot: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1705570Z Sep 17 22:07:04 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1706722Z Sep 17 22:07:04 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1707880Z Sep 17 22:07:04 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot compose run mode boot chains: cannot find expected boot asset bootx64.efi in modeenv
2020-09-17T22:11:32.1709046Z Sep 17 22:07:18 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot identify kernel snap with bootloader grub: cannot read dangling symlink kernel.efi
2020-09-17T22:11:32.1710271Z Sep 17 22:07:22 ubuntu snapd[1588]: handlers.go:495: Reported install problem for "pc-kernel" as Crash report successfully submitted.
2020-09-17T22:11:32.1711363Z Sep 17 22:07:22 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot identify kernel snap with bootloader grub: cannot read dangling symlink kernel.efi
2020-09-17T22:11:32.1712742Z Sep 17 22:07:23 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot identify kernel snap with bootloader grub: cannot read dangling symlink kernel.efi
2020-09-17T22:11:32.1713933Z Sep 17 22:07:23 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot identify kernel snap with bootloader grub: cannot read dangling symlink kernel.efi
2020-09-17T22:11:32.1715121Z Sep 17 22:07:23 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot identify kernel snap with bootloader grub: cannot read dangling symlink kernel.efi
2020-09-17T22:11:32.1716305Z Sep 17 22:07:24 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot identify kernel snap with bootloader grub: cannot read dangling symlink kernel.efi
2020-09-17T22:11:32.1724574Z Sep 17 22:07:24 ubuntu snapd[1588]: stateengine.go:150: state ensure error: devicemgr: cannot mark boot successful: cannot identify kernel snap with bootloader grub: cannot read dangling symlink kernel.efi
2020-09-17T22:11:32.1725461Z Sep 17 22:07:24 ubuntu snapd[1588]: main.go:155: Exiting on terminated signal.
2020-09-17T22:11:32.1725912Z Sep 17 22:07:24 ubuntu systemd[1]: Stopping Snap Daemon...
2020-09-17T22:11:32.1726718Z Sep 17 22:08:54 ubuntu systemd[1]: snapd.service: State 'stop-sigterm' timed out. Killing.
2020-09-17T22:11:32.1727348Z Sep 17 22:08:54 ubuntu systemd[1]: snapd.service: Killing process 1588 (snapd) with signal SIGKILL.
2020-09-17T22:11:32.1727969Z Sep 17 22:08:55 ubuntu systemd[1]: snapd.service: Main process exited, code=killed, status=9/KILL
2020-09-17T22:11:32.1728724Z Sep 17 22:08:55 ubuntu systemd[1]: snapd.service: Failed with result 'timeout'.
2020-09-17T22:11:32.1729188Z Sep 17 22:08:55 ubuntu systemd[1]: Stopped Snap Daemon.
2020-09-17T22:11:32.1729701Z Sep 17 22:08:55 ubuntu systemd[1]: snapd.service: Triggering OnFailure= dependencies.
```

(and I could only clearly see this after adding the `nested_exec sudo journalctl --no-pager -u snapd` so we should merge that PR too :wink: )