### PR TITLE
tests/nested/manual/refresh-revert-fundamentals: re-enable test

### DIFF
--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -4,11 +4,6 @@ description: |
     This test validates the fundamental snaps can be refreshed
     and reverted to the new snaps published to edge channel.
 
-# TODO:UC20: re-enable this test when kernel snap has been re-built with new
-# initramfs, currently beta or newer snapd snapd + any published kernel snap
-# results in broken install
-manual: true
-
 systems: [ubuntu-20.04-*]
 
 environment:


### PR DESCRIPTION
This is a revert of https://github.com/snapcore/snapd/pull/9368, marking blocked until we have a new kernel snap with version 37 of ubuntu-core-initramfs built that won't be broken anymore.