### PR TITLE
usersession/userd: separate bus name ownership from defining interfaces

### DIFF
--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -122,13 +122,13 @@ type Launcher struct {
 	conn *dbus.Conn
 }
 
-// Name returns the name of the interface this object implements
-func (s *Launcher) Name() string {
+// Interface returns the name of the interface this object implements
+func (s *Launcher) Interface() string {
 	return "io.snapcraft.Launcher"
 }
 
-// BasePath returns the base path of the object
-func (s *Launcher) BasePath() dbus.ObjectPath {
+// ObjectPath returns the path that the object is exported as
+func (s *Launcher) ObjectPath() dbus.ObjectPath {
 	return "/io/snapcraft/Launcher"
 }
 

--- a/usersession/userd/settings.go
+++ b/usersession/userd/settings.go
@@ -122,13 +122,13 @@ type Settings struct {
 	conn *dbus.Conn
 }
 
-// Name returns the name of the interface this object implements
-func (s *Settings) Name() string {
+// Interface returns the name of the interface this object implements
+func (s *Settings) Interface() string {
 	return "io.snapcraft.Settings"
 }
 
-// BasePath returns the base path of the object
-func (s *Settings) BasePath() dbus.ObjectPath {
+// ObjectPath returns the path that the object is exported as
+func (s *Settings) ObjectPath() dbus.ObjectPath {
 	return "/io/snapcraft/Settings"
 }
 

--- a/usersession/userd/userd.go
+++ b/usersession/userd/userd.go
@@ -41,6 +41,14 @@ type Userd struct {
 	dbusIfaces []dbusInterface
 }
 
+// userdBusNames contains the list of bus names userd will acquire on
+// the session bus.  It is unnecessary (and undesirable) to add more
+// names here when adding new interfaces to the daemon.
+var userdBusNames = []string{
+	"io.snapcraft.Launcher",
+	"io.snapcraft.Settings",
+}
+
 func dbusSessionBus() (*dbus.Conn, error) {
 	// use a private connection to the session bus, this way we can manage
 	// its lifetime without worrying of breaking other code
@@ -82,10 +90,7 @@ func (ud *Userd) Init() error {
 
 	}
 
-	for _, name := range []string{
-		"io.snapcraft.Launcher",
-		"io.snapcraft.Settings",
-	} {
+	for _, name := range userdBusNames {
 		// beyond this point the name is available and all handlers must
 		// have been set up
 		reply, err := ud.conn.RequestName(name, dbus.NameFlagDoNotQueue)

--- a/usersession/userd/userd.go
+++ b/usersession/userd/userd.go
@@ -30,8 +30,8 @@ import (
 )
 
 type dbusInterface interface {
-	Name() string
-	BasePath() dbus.ObjectPath
+	Interface() string
+	ObjectPath() dbus.ObjectPath
 	IntrospectionData() string
 }
 
@@ -77,18 +77,24 @@ func (ud *Userd) Init() error {
 		// at the object level and the actual well-known object name
 		// becoming available on the bus
 		xml := "<node>" + iface.IntrospectionData() + introspect.IntrospectDataString + "</node>"
-		ud.conn.Export(iface, iface.BasePath(), iface.Name())
-		ud.conn.Export(introspect.Introspectable(xml), iface.BasePath(), "org.freedesktop.DBus.Introspectable")
+		ud.conn.Export(iface, iface.ObjectPath(), iface.Interface())
+		ud.conn.Export(introspect.Introspectable(xml), iface.ObjectPath(), "org.freedesktop.DBus.Introspectable")
 
+	}
+
+	for _, name := range []string{
+		"io.snapcraft.Launcher",
+		"io.snapcraft.Settings",
+	} {
 		// beyond this point the name is available and all handlers must
 		// have been set up
-		reply, err := ud.conn.RequestName(iface.Name(), dbus.NameFlagDoNotQueue)
+		reply, err := ud.conn.RequestName(name, dbus.NameFlagDoNotQueue)
 		if err != nil {
 			return err
 		}
 
 		if reply != dbus.RequestNameReplyPrimaryOwner {
-			return fmt.Errorf("cannot obtain bus name '%s'", iface.Name())
+			return fmt.Errorf("cannot obtain bus name '%s'", name)
 		}
 	}
 	return nil


### PR DESCRIPTION
This branch is prompted by PR #8699, where Alan is extending userd.

Previously bus names and interface names were conflated, which would encourage anyone extending userd with new interfaces to also have it acquire new bus names. That is not necessary or desirable.  There's no need for userd to have multiple well known bus names, and adding new service activation files requires updates in multiple locations.

This branch keeps the two names userd currently claims, but separates them from the exporting of new methods on object paths. I also took the opportunity to change the nomenclature to more closely match what D-Bus's terminology to avoid future confusion.