### PR TITLE
o/snapstate: improve snapshot iteration

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -33,6 +33,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -100,6 +102,11 @@ func Iter(ctx context.Context, f func(*Reader) error) error {
 				break
 			}
 
+			// filter out non-snapshot directory entries
+			ok, setID := isSnapshotFilename(name)
+			if !ok {
+				continue
+			}
 			filename := filepath.Join(dirs.SnapshotsDir, name)
 			reader, openError := backendOpen(filename)
 			// reader can be non-nil even when openError is not nil (in
@@ -107,6 +114,14 @@ func Iter(ctx context.Context, f func(*Reader) error) error {
 			// check and either ignore or return an error when
 			// finding a broken snapshot.
 			if reader != nil {
+				if reader.SetID != setID && openError == nil {
+					// ignore snapshots where set id of the filename disagree
+					// with internal set id. This may be the case in the future
+					// with new enhanced snapshot format.
+					// XXX: warning instead?
+					logger.Noticef("Snapshot %q ignored, internal set-id %d disagrees with filename", name, reader.SetID)
+					continue
+				}
 				err = f(reader)
 			} else {
 				// TODO: use warnings instead
@@ -162,6 +177,25 @@ func List(ctx context.Context, setID uint64, snapNames []string) ([]client.Snaps
 func Filename(snapshot *client.Snapshot) string {
 	// this _needs_ the snap name and version to be valid
 	return filepath.Join(dirs.SnapshotsDir, fmt.Sprintf("%d_%s_%s_%s.zip", snapshot.SetID, snapshot.Snap, snapshot.Version, snapshot.Revision))
+}
+
+func isSnapshotFilename(fname string) (ok bool, setID uint64) {
+	// XXX: we could use a regexp here to match very precisely all the elements
+	// of the filename following Filename() above, but perhaps it's better no to
+	// go overboard with it in case the format evolves in the future. Only check
+	// if the name starts with a set-id and ends with .zip.
+	if ext := filepath.Ext(fname); ext != ".zip" {
+		return false, 0
+	}
+	parts := strings.SplitN(fname, "_", 2)
+	if len(parts) != 2 {
+		return false, 0
+	}
+	id, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false, 0
+	}
+	return true, uint64(id)
 }
 
 // EstimateSnapshotSize calculates estimated size of the snapshot.

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -118,8 +118,7 @@ func Iter(ctx context.Context, f func(*Reader) error) error {
 					// ignore snapshots where set id of the filename disagree
 					// with internal set id. This may be the case in the future
 					// with new enhanced snapshot format.
-					// XXX: warning instead?
-					logger.Debugf("Snapshot %q ignored, internal set-id %d disagrees with filename", name, reader.SetID)
+					logger.Noticef("Snapshot %q ignored, internal set-id %d disagrees with filename", name, reader.SetID)
 					continue
 				}
 				err = f(reader)

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -119,7 +119,7 @@ func Iter(ctx context.Context, f func(*Reader) error) error {
 					// with internal set id. This may be the case in the future
 					// with new enhanced snapshot format.
 					// XXX: warning instead?
-					logger.Noticef("Snapshot %q ignored, internal set-id %d disagrees with filename", name, reader.SetID)
+					logger.Debugf("Snapshot %q ignored, internal set-id %d disagrees with filename", name, reader.SetID)
 					continue
 				}
 				err = f(reader)

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -183,11 +183,18 @@ func isSnapshotFilename(fname string) (ok bool, setID uint64) {
 	// of the filename following Filename() above, but perhaps it's better no to
 	// go overboard with it in case the format evolves in the future. Only check
 	// if the name starts with a set-id and ends with .zip.
-	if ext := filepath.Ext(fname); ext != ".zip" {
+	//
+	// Filename is "<sid>_<snapName>.zip", e.g. "13_foo.zip"
+	ext := filepath.Ext(fname)
+	if ext != ".zip" {
 		return false, 0
 	}
 	parts := strings.SplitN(fname, "_", 2)
 	if len(parts) != 2 {
+		return false, 0
+	}
+	// invalid: no <snapName> part
+	if parts[1] == ext {
 		return false, 0
 	}
 	id, err := strconv.Atoi(parts[0])

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -146,7 +146,7 @@ func (s *snapshotSuite) TestIsSnapshotFilename(c *check.C) {
 	}{
 		{"1_foo.zip", true, 1},
 		{"14_hello-world_6.4_29.zip", true, 14},
-		{"1_.zip", true, 1}, // we're only validating set id, so this is ok too
+		{"1_.zip", false, 0},
 		{"1_foo.zip.bak", false, 0},
 		{"foo_1_foo.zip", false, 0},
 		{"foo_bar_baz.zip", false, 0},
@@ -157,7 +157,7 @@ func (s *snapshotSuite) TestIsSnapshotFilename(c *check.C) {
 	for _, t := range tests {
 		ok, setID := backend.IsSnapshotFilename(t.name)
 		c.Check(ok, check.Equals, t.valid, check.Commentf("fail: %s", t.name))
-		c.Check(setID, check.Equals, t.setID)
+		c.Check(setID, check.Equals, t.setID, check.Commentf("fail: %s", t.name))
 	}
 }
 

--- a/overlord/snapshotstate/backend/export_test.go
+++ b/overlord/snapshotstate/backend/export_test.go
@@ -31,6 +31,8 @@ var (
 	AddDirToZip     = addDirToZip
 	TarAsUser       = tarAsUser
 	PickUserWrapper = pickUserWrapper
+
+	IsSnapshotFilename = isSnapshotFilename
 )
 
 func MockIsTesting(newIsTesting bool) func() {


### PR DESCRIPTION
Improve snapshot Iter method to ignore files that do not end with .zip (it currently treats all files as .zips and logs errors for any random file in snapshots directory) or whose set id deducted from filename doesn't match set id stored inside metadata.
The latter change prepares snapd for future changes in that area where only the set id in the filename will matter.
