### PR TITLE
tests: make nested signing helpers less confusing

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -302,19 +302,18 @@ nested_get_snakeoil_key() {
 }
 
 nested_secboot_sign_file() {
-    local DIR="$1"
+    local FILE="$1"
     local KEY="$2"
     local CERT="$3"
-    local FILE="$4"
-    sbattach --remove "$DIR"/"$FILE"
-    sbsign --key "$KEY" --cert "$CERT" --output "$DIR"/"$FILE" "$DIR"/"$FILE"
+    sbattach --remove "$FILE"
+    sbsign --key "$KEY" --cert "$CERT" --output "$FILE" "$FILE"
 }
 
 nested_secboot_sign_gadget() {
     local GADGET_DIR="$1"
     local KEY="$2"
     local CERT="$3"
-    nested_secboot_sign_file "$GADGET_DIR" "$KEY" "$CERT" "shim.efi.signed"
+    nested_secboot_sign_file "$GADGET_DIR/shim.efi.signed" "$KEY" "$CERT"
 }
 
 nested_prepare_env() {

--- a/tests/nested/core20/gadget-reseal/task.yaml
+++ b/tests/nested/core20/gadget-reseal/task.yaml
@@ -35,8 +35,8 @@ execute: |
     mv modified_gadget.yaml pc-gadget/meta/gadget.yaml
 
     # resign both assets
-    nested_secboot_sign_file pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" "shim.efi.signed"
-    nested_secboot_sign_file pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" "grubx64.efi"
+    nested_secboot_sign_file pc-gadget/shim.efi.signed "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+    nested_secboot_sign_file pc-gadget/grubx64.efi "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
     rm -f "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
     snap pack pc-gadget/
 

--- a/tests/nested/core20/kernel-reseal/task.yaml
+++ b/tests/nested/core20/kernel-reseal/task.yaml
@@ -16,7 +16,7 @@ prepare: |
   KEY_NAME=$(nested_get_snakeoil_key)
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
   SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
-  nested_secboot_sign_file "$PWD/pc-kernel" "$SNAKEOIL_KEY" "$SNAKEOIL_CERT" kernel.efi
+  nested_secboot_sign_file "$PWD/pc-kernel/kernel.efi" "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
 
   snap pack pc-kernel
   rm -rf pc-kernel


### PR DESCRIPTION
The helper arguments are a bit confusing. Try to simplify things.
