### PR TITLE
tests/main/lxd: disable cgroup combination for 16.04 that is failing a lot

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -43,11 +43,6 @@ restore: |
         exit
     fi
 
-    if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] && [ "$REFRESH_APP_AWARENESS_OUTER" = false ] && [ "$REFRESH_APP_AWARENESS_INNER" = true ]; then
-        echo "Not running old xenial combination which lacks proper patches"
-        exit 0
-    fi
-
     for cont_name in my-nesting-ubuntu my-ubuntu; do
         lxd.lxc stop $cont_name --force || true
         lxd.lxc delete $cont_name || true
@@ -73,11 +68,6 @@ execute: |
     if  [[ "$(find "$GOHOME" -name 'snapd_*.deb' | wc -l || echo 0)" -eq 0 ]]; then
         echo "No run lxd test when there are not .deb files built"
         exit
-    fi
-
-    if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] && [ "$REFRESH_APP_AWARENESS_OUTER" = false ] && [ "$REFRESH_APP_AWARENESS_INNER" = true ]; then
-        echo "Not running old xenial combination which lacks proper patches"
-        exit 0
     fi
 
     echo "Install lxd"
@@ -155,7 +145,13 @@ execute: |
     lxd.lxc exec my-ubuntu -- find /var/run/systemd/generator/ -name container.conf | MATCH "/var/run/systemd/generator/snap-core-.*mount.d/container.conf"
     lxd.lxc exec my-ubuntu -- test -f /var/run/systemd/generator/snap.mount
 
-    # Ensure that we can run lxd as a snap inside a nested container
+    # Ensure that we can run lxd as a snap inside a container to create a nested
+    # container
+
+    if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] && [ "$REFRESH_APP_AWARENESS_OUTER" = false ] && [ "$REFRESH_APP_AWARENESS_INNER" = true ]; then
+        echo "Not running old xenial combination which lacks proper patches"
+        exit 0
+    fi
 
     echo "Ensure we can use lxd as a snap inside lxd"
     lxd.lxc exec my-nesting-ubuntu -- apt autoremove -y lxd

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -27,7 +27,6 @@ environment:
     REFRESH_APP_AWARENESS_OUTER/snapd_cgroup_neither: false
     REFRESH_APP_AWARENESS_INNER/snapd_cgroup_neither: false
 
-
 prepare: |
     # using apt here is ok because this test only runs on ubuntu
     echo "Remove any installed debs (some images carry them) to ensure we test the snap"
@@ -44,9 +43,14 @@ restore: |
         exit
     fi
 
+    if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] && [ "$REFRESH_APP_AWARENESS_OUTER" = false ] && [ "$REFRESH_APP_AWARENESS_INNER" = true ]; then
+        echo "Not running old xenial combination which lacks proper patches"
+        exit 0
+    fi
+
     for cont_name in my-nesting-ubuntu my-ubuntu; do
-        lxd.lxc stop $cont_name --force
-        lxd.lxc delete $cont_name
+        lxd.lxc stop $cont_name --force || true
+        lxd.lxc delete $cont_name || true
     done
     snap remove --purge lxd
     snap remove --purge lxd-demo-server
@@ -69,6 +73,11 @@ execute: |
     if  [[ "$(find "$GOHOME" -name 'snapd_*.deb' | wc -l || echo 0)" -eq 0 ]]; then
         echo "No run lxd test when there are not .deb files built"
         exit
+    fi
+
+    if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] && [ "$REFRESH_APP_AWARENESS_OUTER" = false ] && [ "$REFRESH_APP_AWARENESS_INNER" = true ]; then
+        echo "Not running old xenial combination which lacks proper patches"
+        exit 0
     fi
 
     echo "Install lxd"


### PR DESCRIPTION
Xenial lacks some patches which makes this combination flaky and it fails
consistently in tests, so disable it.