### PR TITLE
[RFC] snap-repair: minimal uc20 support

### DIFF
--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -67,3 +67,6 @@ execute: |
         BRAND_ID="$BRAND_ID\*"
     fi
     snap recovery --unicode=never | MATCH "[0-9]+ +$BRAND_ID +$MODEL +current"
+
+    echo "snap repair does not fail"
+    /usr/lib/snapd/snap-repair run


### PR DESCRIPTION
This is a minimal change for snap-repair to support uc20. Note that
this does not support multiple systems yet. We need to see how to
support this, we may need to read the state.json for this.

Or is this too naive :) ?