### PR TITLE
cmd/s-b/initramfs-mounts: use ConfigureTargetSystem for install, recover modes

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -381,18 +381,14 @@ func readInfo(f func(string) ([]byte, error), gadgetYamlFn string, model Model) 
 }
 
 // ReadInfo reads the gadget specific metadata from meta/gadget.yaml in the snap
-// root directory. If constraints is nil, ReadInfo will just check for
-// self-consistency, otherwise rules for the classic or system seed cases are
-// enforced.
+// root directory.
 func ReadInfo(gadgetSnapRootDir string, model Model) (*Info, error) {
 	gadgetYamlFn := filepath.Join(gadgetSnapRootDir, "meta", "gadget.yaml")
 	return readInfo(ioutil.ReadFile, gadgetYamlFn, model)
 }
 
 // ReadInfoFromSnapFile reads the gadget specific metadata from
-// meta/gadget.yaml in the given snap container. If constraints is
-// nil, ReadInfo will just check for self-consistency, otherwise rules
-// for the classic or system seed cases are enforced.
+// meta/gadget.yaml in the given snap container.
 func ReadInfoFromSnapFile(snapf snap.Container, model Model) (*Info, error) {
 	gadgetYamlFn := "meta/gadget.yaml"
 	return readInfo(snapf.ReadFile, gadgetYamlFn, model)

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -240,11 +240,11 @@ func MockHttputilNewHTTPClient(f func(opts *httputil.ClientOptions) *http.Client
 	}
 }
 
-func MockSysconfigConfigureRunSystem(f func(opts *sysconfig.Options) error) (restore func()) {
-	old := sysconfigConfigureRunSystem
-	sysconfigConfigureRunSystem = f
+func MockSysconfigConfigureTargetSystem(f func(opts *sysconfig.Options) error) (restore func()) {
+	old := sysconfigConfigureTargetSystem
+	sysconfigConfigureTargetSystem = f
 	return func() {
-		sysconfigConfigureRunSystem = old
+		sysconfigConfigureTargetSystem = old
 	}
 }
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -39,9 +39,10 @@ import (
 )
 
 var (
-	bootMakeBootable            = boot.MakeBootable
-	sysconfigConfigureRunSystem = sysconfig.ConfigureRunSystem
-	installRun                  = install.Run
+	bootMakeBootable = boot.MakeBootable
+	installRun       = install.Run
+
+	sysconfigConfigureTargetSystem = sysconfig.ConfigureTargetSystem
 )
 
 func setSysconfigCloudOptions(opts *sysconfig.Options, gadgetDir string, model *asserts.Model) {
@@ -50,7 +51,7 @@ func setSysconfigCloudOptions(opts *sysconfig.Options, gadgetDir string, model *
 	switch {
 	// if the gadget has a cloud.conf file, always use that regardless of grade
 	case sysconfig.HasGadgetCloudConf(gadgetDir):
-		// this is implicitly handled by ConfigureRunSystem when it configures
+		// this is implicitly handled by ConfigureTargetSystem when it configures
 		// cloud-init if none of the other options are set, so just break here
 		opts.AllowCloudInit = true
 
@@ -170,7 +171,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	opts := &sysconfig.Options{TargetRootDir: boot.InstallHostWritableDir, GadgetDir: gadgetDir}
 	// configure cloud init
 	setSysconfigCloudOptions(opts, gadgetDir, deviceCtx.Model())
-	if err := sysconfigConfigureRunSystem(opts); err != nil {
+	if err := sysconfigConfigureTargetSystem(opts); err != nil {
 		return err
 	}
 

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -99,7 +99,7 @@ func (s *sysconfigSuite) TestEphemeralModeInitramfsCloudInitDisables(c *C) {
 }
 
 func (s *sysconfigSuite) TestInstallModeCloudInitDisablesByDefaultRunMode(c *C) {
-	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 	})
 	c.Assert(err, IsNil)
@@ -112,7 +112,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitDisallowedIgnoresOtherOptions(c
 	cloudCfgSrcDir := s.makeCloudCfgSrcDirFiles(c)
 	gadgetDir := s.makeGadgetCloudConfFile(c)
 
-	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
 		AllowCloudInit:  false,
 		CloudInitSrcDir: cloudCfgSrcDir,
 		GadgetDir:       gadgetDir,
@@ -133,7 +133,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitDisallowedIgnoresOtherOptions(c
 }
 
 func (s *sysconfigSuite) TestInstallModeCloudInitAllowedDoesNotDisable(c *C) {
-	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
 		AllowCloudInit: true,
 		TargetRootDir:  boot.InstallHostWritableDir,
 	})
@@ -150,7 +150,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitAllowedDoesNotDisable(c *C) {
 func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunMode(c *C) {
 	cloudCfgSrcDir := s.makeCloudCfgSrcDirFiles(c)
 
-	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
 		AllowCloudInit:  true,
 		CloudInitSrcDir: cloudCfgSrcDir,
 		TargetRootDir:   boot.InstallHostWritableDir,
@@ -165,7 +165,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunMode(c *C) {
 
 func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunModeWithGadgetCloudConf(c *C) {
 	gadgetDir := s.makeGadgetCloudConfFile(c)
-	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
 		AllowCloudInit: true,
 		GadgetDir:      gadgetDir,
 		TargetRootDir:  boot.InstallHostWritableDir,
@@ -181,7 +181,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunModeWithGadg
 	cloudCfgSrcDir := s.makeCloudCfgSrcDirFiles(c)
 	gadgetDir := s.makeGadgetCloudConfFile(c)
 
-	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
 		AllowCloudInit:  true,
 		CloudInitSrcDir: cloudCfgSrcDir,
 		GadgetDir:       gadgetDir,

--- a/sysconfig/gadget_defaults_test.go
+++ b/sysconfig/gadget_defaults_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/systemd"
 )
@@ -110,4 +111,47 @@ defaults:
 		GadgetDir:     snapInfo.MountDir(),
 	})
 	c.Check(err, ErrorMatches, `option "service.rsyslog.disable" has invalid value "foo"`)
+}
+
+func (s *sysconfigSuite) TestInstallModeEarlyDefaultsFromGadgetSeedSnap(c *C) {
+	const gadgetDefaultsYaml = `
+defaults:
+  system:
+    service:
+      rsyslog.disable: true
+      ssh.disable: true
+    journal.persistent: true
+`
+	snapFile := snaptest.MakeTestSnapWithFiles(c, "name: pc\ntype: gadget\nversion: 1", [][]string{
+		{"meta/gadget.yaml", gadgetYaml + gadgetDefaultsYaml},
+	})
+
+	snapContainer := squashfs.New(snapFile)
+
+	var sysctlArgs [][]string
+	systemctlRestorer := systemd.MockSystemctl(func(args ...string) (buf []byte, err error) {
+		sysctlArgs = append(sysctlArgs, args)
+		return nil, nil
+	})
+	defer systemctlRestorer()
+
+	journalPath := filepath.Join(boot.InstallHostWritableDir, "_writable_defaults/var/log/journal")
+	sshDontRunFile := filepath.Join(boot.InstallHostWritableDir, "_writable_defaults/etc/ssh/sshd_not_to_be_run")
+
+	// sanity
+	c.Check(osutil.FileExists(sshDontRunFile), Equals, false)
+	exists, _, _ := osutil.DirExists(journalPath)
+	c.Check(exists, Equals, false)
+
+	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+		TargetRootDir: boot.InstallHostWritableDir,
+		GadgetSnap:    snapContainer,
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(osutil.FileExists(sshDontRunFile), Equals, true)
+	exists, _, _ = osutil.DirExists(journalPath)
+	c.Check(exists, Equals, true)
+
+	c.Check(sysctlArgs, DeepEquals, [][]string{{"--root", filepath.Join(boot.InstallHostWritableDir, "_writable_defaults"), "mask", "rsyslog.service"}})
 }

--- a/sysconfig/gadget_defaults_test.go
+++ b/sysconfig/gadget_defaults_test.go
@@ -76,7 +76,7 @@ defaults:
 	exists, _, _ := osutil.DirExists(journalPath)
 	c.Check(exists, Equals, false)
 
-	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 		GadgetDir:     snapInfo.MountDir(),
 	})
@@ -106,7 +106,7 @@ defaults:
 		{"meta/gadget.yaml", gadgetYaml + gadgetDefaultsYaml},
 	})
 
-	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 		GadgetDir:     snapInfo.MountDir(),
 	})
@@ -143,7 +143,7 @@ defaults:
 	exists, _, _ := osutil.DirExists(journalPath)
 	c.Check(exists, Equals, false)
 
-	err := sysconfig.ConfigureRunSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 		GadgetSnap:    snapContainer,
 	})

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -74,10 +74,12 @@ func ApplyFilesystemOnlyDefaults(rootDir string, defaults map[string]interface{}
 	return ApplyFilesystemOnlyDefaultsImpl(rootDir, defaults, options)
 }
 
-// ConfigureRunSystem configures the ubuntu-data partition with any
-// configuration needed from e.g. the gadget or for cloud-init (and also for
+// ConfigureTargetSystem configures the ubuntu-data partition with
+// any configuration needed from e.g. the gadget or for cloud-init (and also for
 // cloud-init from the gadget).
-func ConfigureRunSystem(opts *Options) error {
+// It is okay to use both from install mode for run mode, as well as from the
+// initramfs for recover mode.
+func ConfigureTargetSystem(opts *Options) error {
 	if err := configureCloudInit(opts); err != nil {
 		return err
 	}

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -39,32 +39,54 @@ execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
+    check_core20_early_config(){
+        # sanity - check that defaults were applied; note this doesn't guarantee
+        # that defaults were applied early - that is checked further down.
+        echo "Sanity check of the gadget defaults"
+        nested_exec "sudo snap get system service.rsyslog.disable" | MATCH "true"
+        nested_exec "sudo snap get system watchdog.runtime-timeout" | MATCH "13m"
+        nested_exec "sudo snap get system system.power-key-action" | MATCH "ignore"
+        nested_exec "sudo snap get system system.disable-backlight-service" | MATCH "true"
+
+        nested_exec "test -L /etc/systemd/system/rsyslog.service"
+        nested_exec "cat /etc/systemd/logind.conf.d/00-snap-core.conf" | MATCH "HandlePowerKey=ignore"
+        nested_exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=780"
+        nested_exec "test -L /etc/systemd/system/systemd-backlight@.service"
+
+        echo "Test that defaults were applied early."
+        # early config is witnessed by install hook of the pc gadget. Note we can
+        # only check rsyslog/backlight symlinks as other core settings cannot be
+        # inspected from install hook of the gadget.
+        nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
+        nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "backlight symlink: /dev/null"
+
+        # timezone is set
+        nested_exec "cat /etc/timezone" | MATCH "Europe/Malta"
+        nested_exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
+        nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
+
+        # check console-conf disabled
+        nested_exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
+    }
+
+    check_core20_early_config
+
+    # now transition to recover mode and check it again
+    boot_id="$(nested_get_boot_id)"
+    # TODO:UC20: shouldn't need to specify the label here, fix when snap reboot
+    #            works
+    # shellcheck disable=SC2016
+    nested_exec 'sudo snap reboot --recover $(sudo snap recovery | grep -v Label | awk "{print \$1}")'
+    nested_wait_for_reboot "${boot_id}"
+
+    # verify in recover mode
+    nested_exec 'sudo cat /proc/cmdline' | MATCH snapd_recovery_mode=recover
+
+    # Wait for the snap command to be available since recover mode needs to seed
+    # itself
+    nested_wait_for_snap_command
+
+    # Wait for snap seeding to be done
     nested_exec "sudo snap wait system seed.loaded"
 
-    # sanity - check that defaults were applied; note this doesn't guarantee
-    # that defaults were applied early - that is checked further down.
-    echo "Sanity check of the gadget defaults"
-    nested_exec "sudo snap get system service.rsyslog.disable" | MATCH "true"
-    nested_exec "sudo snap get system watchdog.runtime-timeout" | MATCH "13m"
-    nested_exec "sudo snap get system system.power-key-action" | MATCH "ignore"
-    nested_exec "sudo snap get system system.disable-backlight-service" | MATCH "true"
-
-    nested_exec "test -L /etc/systemd/system/rsyslog.service"
-    nested_exec "cat /etc/systemd/logind.conf.d/00-snap-core.conf" | MATCH "HandlePowerKey=ignore"
-    nested_exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=780"
-    nested_exec "test -L /etc/systemd/system/systemd-backlight@.service"
-
-    echo "Test that defaults were applied early."
-    # early config is witnessed by install hook of the pc gadget. Note we can
-    # only check rsyslog/backlight symlinks as other core settings cannot be
-    # inspected from install hook of the gadget.
-    nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
-    nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "backlight symlink: /dev/null"
-
-    # timezone is set
-    nested_exec "cat /etc/timezone" | MATCH "Europe/Malta"
-    nested_exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
-    nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
-
-    # check console-conf disabled
-    nested_exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
+    check_core20_early_config


### PR DESCRIPTION
RFC branch to show how I implemented the fix for console-conf running in recover mode when it should not be. It can easily be broken up into smaller PR's if desired, and obviously the names of functions are not the best.

For install mode, this will effectively do the same thing as just calling
DisableCloudInit directly, but for Recover mode since we provide the gadget snap
from the seed we opened, we will configure various things about the ephemeral
recover system using the gadget defaults such as disabling console-conf or SSH,
etc. in addition to disabling cloud-init.

Fixes: https://bugs.launchpad.net/snapd/+bug/1895856
