### PR TITLE
many: typos and small test tweak

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -33,7 +33,6 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -93,7 +93,7 @@ void sc_reassociate_with_pid1_mount_ns(void)
 	if (readlinkat(init_mnt_fd, "", init_buf, sizeof init_buf) < 0) {
 		if (errno == ENOENT) {
 			// According to namespaces(7) on a pre 3.8 kernel the namespace
-			// files are hardlinks, not sylinks. If that happens readlinkat
+			// files are hardlinks, not symlinks. If that happens readlinkat
 			// fails with ENOENT. As a quick workaround for this special-case
 			// functionality, just bail out and do nothing without raising an
 			// error.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -124,7 +124,7 @@ typedef struct sc_preserved_process_state {
 /**
  * sc_preserve_and_sanitize_process_state sanitizes process state.
  *
- * The following process state is sanitised:
+ * The following process state is sanitized:
  *  - the umask is set to 0
  *  - the current working directory is set to /
  *

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -231,7 +231,7 @@ var templateCommon = `
   # example, allow access to /dev/std{in,out,err} which are all symlinks to
   # /proc/self/fd/{0,1,2} respectively. To support the open(..., O_TMPFILE)
   # linkat() temporary file technique, allow all fds. Importantly, access to
-  # another's task's fd via this proc interface is mediated via 'ptrace (read)'
+  # another task's fd via this proc interface is mediated via 'ptrace (read)'
   # (readonly) and 'ptrace (trace)' (read/write) which is denied by default, so
   # this rule by itself doesn't allow opening another snap's fds via proc.
   owner @{PROC}/@{pid}/{,task/@{tid}}fd/[0-9]* rw,

--- a/tests/main/snap-run-gdbserver/task.yaml
+++ b/tests/main/snap-run-gdbserver/task.yaml
@@ -18,7 +18,7 @@ execute: |
     # run the gdbserver command as a user
     # XXX: use "systemd-run --user -p StandardOutput=file:$(pwd)/stdout"
     # shellcheck disable=SC2016
-    su -l -c 'snap run --experimental-gdbserver test-snapd-sh.sh -c "echo hello-hello-hello uid:$UID"' test >stdout &
+    su -c 'snap run --experimental-gdbserver test-snapd-sh.sh -c "echo hello-hello-hello uid:$UID"' test >stdout &
 
     # wait for the instructions that gdb is ready to get attached
     retry -n60 grep '^gdb -ex' stdout


### PR DESCRIPTION
A few simple typos, duplicate `#include` directive and a harmless test tweak to avoid `su -l`.