### PR TITLE
tests: copy /usr/lib/snapd/info to correct directory

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -340,7 +340,7 @@ repack_snapd_snap_with_deb_content() {
     rm -f "$UNPACK_DIR"/etc/apparmor.d/*
 
     dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
-    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/
+    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/snapd
     snap pack "$UNPACK_DIR" "$TARGET"
     rm -rf "$UNPACK_DIR"
 }
@@ -358,7 +358,7 @@ repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks() {
     rm -f "$UNPACK_DIR"/etc/apparmor.d/*
 
     dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
-    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/
+    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/snapd
 
     if [ "$ENABLE_SSH" = "true" ]; then
         # now install a unit that sets up enough so that we can connect


### PR DESCRIPTION
While looking at some failures of the new export manager tests, I noticed
that the info file was not being repackaged correctly.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
