### PR TITLE
snap-repair: add uc20 support

### DIFF
--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -707,7 +707,7 @@ func findBrandAndModel20() (brand string, model string, err error) {
 	return l[0], l[1], nil
 }
 
-func findBrandAndModel16() (string, string, error) {
+func findBrandAndModel16() (brand, model string, err error) {
 	workBS := asserts.NewMemoryBackstore()
 	assertSeedDir := filepath.Join(dirs.SnapSeedDir, "assertions")
 	dc, err := ioutil.ReadDir(assertSeedDir)

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -1837,9 +1837,14 @@ func (s *runner20Suite) writeSeedAssert20(c *C, fname string, a asserts.Assertio
 	} else {
 		fn = filepath.Join(s.seedAssertsDir, fname)
 	}
-
 	err := ioutil.WriteFile(fn, asserts.Encode(a), 0644)
 	c.Assert(err, IsNil)
+
+	// ensure model assertion file has the correct seed time
+	if _, ok := a.(*asserts.Model); ok {
+		err = os.Chtimes(fn, s.seedTime, s.seedTime)
+		c.Assert(err, IsNil)
+	}
 }
 
 func (s *runner20Suite) TestLoadStateInitDeviceInfoModeenvInvalidContent(c *C) {

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/boot"
 	repair "github.com/snapcore/snapd/cmd/snap-repair"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
@@ -1794,6 +1795,7 @@ type runner20Suite struct {
 var _ = Suite(&runner20Suite{})
 
 var mockModeenv = []byte(`
+mode=run
 model=my-brand/my-model-uc20
 `)
 
@@ -1802,11 +1804,15 @@ func (s *runner20Suite) SetUpTest(c *C) {
 
 	s.seedAssertsDir = filepath.Join(dirs.SnapSeedDir, "/systems/20201212/assertions")
 
-	// dummy modeenv
+	// write dummy modeenv
 	err := os.MkdirAll(filepath.Dir(dirs.SnapModeenvFile), 0755)
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(dirs.SnapModeenvFile, mockModeenv, 0644)
 	c.Assert(err, IsNil)
+	// validate that modeenv is actually valid
+	_, err = boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+
 	seedTime, err := time.Parse(time.RFC3339, "2017-08-11T15:49:49Z")
 	c.Assert(err, IsNil)
 	err = os.Chtimes(dirs.SnapModeenvFile, seedTime, seedTime)

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -67,3 +67,6 @@ execute: |
         BRAND_ID="$BRAND_ID\*"
     fi
     snap recovery --unicode=never | MATCH "[0-9]+ +$BRAND_ID +$MODEL +current"
+
+    echo "snap repair does not fail"
+    /usr/lib/snapd/snap-repair run

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -67,6 +67,3 @@ execute: |
         BRAND_ID="$BRAND_ID\*"
     fi
     snap recovery --unicode=never | MATCH "[0-9]+ +$BRAND_ID +$MODEL +current"
-
-    echo "snap repair does not fail"
-    /usr/lib/snapd/snap-repair run

--- a/tests/main/snap-repair/task.yaml
+++ b/tests/main/snap-repair/task.yaml
@@ -1,8 +1,7 @@
 summary: Ensure that snap-repair is available
 
-# TODO:UC20: snap-repair fishes in /var/lib/snapd/seed/assertions for the model
-#            assertion - this no longer works on UC20
-systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*, -ubuntu-core-20-*]
+# snap-repair is not shipped on non-ubuntu
+systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*]
 
 execute: |
     if ! grep -q "ID=ubuntu-core" /etc/os-release; then


### PR DESCRIPTION
This is a minimal change for snap-repair to support uc20. Some test refactor as well to make it easier to run tests with both a uc16 and uc20 setup.
