### PR TITLE
spread.yaml: add ubuntu-20.10-64 to qemu

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -215,6 +215,9 @@ backends:
             - ubuntu-20.04-32:
                   username: ubuntu
                   password: ubuntu
+            - ubuntu-20.10-64:
+                  username: ubuntu
+                  password: ubuntu
             - debian-sid-64:
                   username: debian
                   password: debian


### PR DESCRIPTION
Support for 20.10 in qemu was missing. No -32 version as there is no i386 anymore.