### PR TITLE
boot: fix debug bootloader variables dump on UC20 systems

### DIFF
--- a/boot/debug.go
+++ b/boot/debug.go
@@ -28,23 +28,42 @@ import (
 
 // DumpBootVars writes a dump of the snapd bootvars to the given writer
 func DumpBootVars(w io.Writer, dir string, uc20 bool) error {
-	bloader, err := bootloader.Find(dir, nil)
+	opts := &bootloader.Options{
+		NoSlashBoot: dir != "" && dir != "/",
+	}
+	switch dir {
+	// is it any of the well-known UC20 boot partition mount locations?
+	case InitramfsUbuntuBootDir:
+		opts.Role = bootloader.RoleRunMode
+		uc20 = true
+	case InitramfsUbuntuSeedDir:
+		opts.Role = bootloader.RoleRecovery
+		uc20 = true
+	}
+	allKeys := []string{
+		"snap_mode",
+		"snap_core",
+		"snap_try_core",
+		"snap_kernel",
+		"snap_try_kernel",
+	}
+	if uc20 {
+		if !opts.NoSlashBoot {
+			// no root directory set, default ot run mode
+			opts.Role = bootloader.RoleRunMode
+		}
+		// keys relevant to all uc20 bootloader implementations
+		allKeys = []string{
+			"snapd_recovery_mode",
+			"snapd_recovery_system",
+			"snapd_recovery_kernel",
+			"snap_kernel",
+			"kernel_status",
+		}
+	}
+	bloader, err := bootloader.Find(dir, opts)
 	if err != nil {
 		return err
-	}
-	var allKeys []string
-	if uc20 {
-		// TODO:UC20: what about snapd_recovery_kernel, snapd_recovery_mode, and
-		//            snapd_recovery_system?
-		allKeys = []string{"kernel_status"}
-	} else {
-		allKeys = []string{
-			"snap_mode",
-			"snap_core",
-			"snap_try_core",
-			"snap_kernel",
-			"snap_try_kernel",
-		}
 	}
 
 	bootVars, err := bloader.GetBootVars(allKeys...)

--- a/boot/debug.go
+++ b/boot/debug.go
@@ -24,6 +24,8 @@ import (
 	"io"
 
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 )
 
 // DumpBootVars writes a dump of the snapd bootvars to the given writer
@@ -39,6 +41,12 @@ func DumpBootVars(w io.Writer, dir string, uc20 bool) error {
 	case InitramfsUbuntuSeedDir:
 		opts.Role = bootloader.RoleRecovery
 		uc20 = true
+	}
+	if !opts.NoSlashBoot && !uc20 {
+		// this may still be a UC20 system
+		if osutil.FileExists(dirs.SnapModeenvFile) {
+			uc20 = true
+		}
 	}
 	allKeys := []string{
 		"snap_mode",


### PR DESCRIPTION
The output of `snap debug boot-vars` is not that useful on UC20 systems.
Specifically, on Raspberry PI, the alternative location of bootloader
environment (boot.sel) is not even selected if none of the bootloader flags is
set, so running the debug command on such system outright fails.

Try to remedy this by picking a reasonable set of options based on either root
dir, of the flags.

