### PR TITLE
tests: disable part of the lxd test completely on 16.04.

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -148,7 +148,7 @@ execute: |
     # Ensure that we can run lxd as a snap inside a container to create a nested
     # container
 
-    if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] && [ "$REFRESH_APP_AWARENESS_OUTER" = false ] && [ "$REFRESH_APP_AWARENESS_INNER" = true ]; then
+    if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ]; then
         echo "Not running old xenial combination which lacks proper patches"
         exit 0
     fi

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -149,6 +149,7 @@ execute: |
     # container
 
     if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ]; then
+        # related bug: https://bugs.launchpad.net/snapd/+bug/1892468
         echo "Not running old xenial combination which lacks proper patches"
         exit 0
     fi


### PR DESCRIPTION
Disable part of the lxd test completely on 16.04 as this is now failing too:
google:ubuntu-16.04-64:tests/main/lxd:snapd_cgroup_both
