### PR TITLE
update-pot: ignore .go files inside .git when running xgettext-go

### DIFF
--- a/update-pot
+++ b/update-pot
@@ -34,7 +34,7 @@ go install github.com/snapcore/snapd/i18n/xgettext-go
 
 # exclude vendor and _build subdir
 I18N_FILES="$(mktemp -d)/i18n.files"
-find "$HERE" -type d \( -name "vendor" -o -name "_build" \) -prune -o -name "*.go" -type f -print > "$I18N_FILES"
+find "$HERE" -type d \( -name "vendor" -o -name "_build" -o -name ".git" \) -prune -o -name "*.go" -type f -print > "$I18N_FILES"
 # shellcheck disable=SC2064
 trap "rm -rf $(dirname "$I18N_FILES")" EXIT
 


### PR DESCRIPTION
If someone has a branch name that ends with ".go", then the file for that branch
in the .git folder will also be picked up, but it will not be a real .go file
and as such the processing in xgettext-go will fail like so:

```
2020/09/22 16:14:08 processFiles failed with: /root/parts/snapd-deb/build/.git/logs/refs/remotes/bboozzoo/bboozzoo/uc20-tweak-sid-packaging-params.go:1:1: expected 'package', found 'INT' 0000000000000000000000000000000000000000 (and 1 more errors)
```

With the git remote branch on https://github.com/bboozzoo/snapd,
"bboozzoo/uc20-tweak-sid-packaging-params.go".

This ensures that all files from .git are ignored when we process the i18n as
part of the build process.

Signed-off-by: Ian Johnson <ian.johnson@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
