### PR TITLE
 o/snapstate/check_snap_test.go: mock osutil.Find{U,G}id to avoid bug in test

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -179,18 +179,6 @@ func MockFindGidNoFallback(mock func(name string) (uint64, error)) (restore func
 	return func() { findGidNoGetentFallback = old }
 }
 
-func MockFindUid(mock func(name string) (uint64, error)) (restore func()) {
-	old := findUid
-	findUid = mock
-	return func() { findUid = old }
-}
-
-func MockFindGid(mock func(name string) (uint64, error)) (restore func()) {
-	old := findGid
-	findGid = mock
-	return func() { findGid = old }
-}
-
 const MaxSymlinkTries = maxSymlinkTries
 
 var ParseRawEnvironment = parseRawEnvironment

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -29,15 +29,11 @@ import (
 
 // FindUid returns the identifier of the given UNIX user name. It will
 // automatically fallback to use "getent" if needed.
-var FindUid = func(username string) (uint64, error) {
-	return findUid(username)
-}
+var FindUid = findUid
 
 // FindGid returns the identifier of the given UNIX group name. It will
 // automatically fallback to use "getent" if needed.
-var FindGid = func(groupname string) (uint64, error) {
-	return findGid(groupname)
-}
+var FindGid = findGid
 
 // getent returns the identifier of the given UNIX user or group name as
 // determined by the specified database

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -29,13 +29,13 @@ import (
 
 // FindUid returns the identifier of the given UNIX user name. It will
 // automatically fallback to use "getent" if needed.
-func FindUid(username string) (uint64, error) {
+var FindUid = func(username string) (uint64, error) {
 	return findUid(username)
 }
 
 // FindGid returns the identifier of the given UNIX group name. It will
 // automatically fallback to use "getent" if needed.
-func FindGid(groupname string) (uint64, error) {
+var FindGid = func(groupname string) (uint64, error) {
 	return findGid(groupname)
 }
 

--- a/osutil/mockable.go
+++ b/osutil/mockable.go
@@ -34,6 +34,22 @@ func MockMountInfo(content string) (restore func()) {
 	}
 }
 
+func MockFindUid(f func(string) (uint64, error)) (restore func()) {
+	old := FindUid
+	FindUid = f
+	return func() {
+		FindUid = old
+	}
+}
+
+func MockFindGid(f func(string) (uint64, error)) (restore func()) {
+	old := FindGid
+	FindGid = f
+	return func() {
+		FindGid = old
+	}
+}
+
 var (
 	mockedMountInfo *string
 


### PR DESCRIPTION
This test currently was buggy in that the test host system was leaking state to the test and if the host system had the user already created the test would fail. 

Fix this by mocking the specific user/groups expected to be checked in the test by exporting the osutil.MockFindGid and osutil.MockFindUid.