### PR TITLE
snapstate/check_snap: add snap_docker to shared system-usernames

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -174,6 +174,7 @@ var featureSet = map[string]bool{
 // https://github.com/lxc/lxd/blob/master/doc/userns-idmap.md
 var supportedSystemUsernames = map[string]uint32{
 	"snap_daemon": 584788,
+	"snap_docker": 584789,
 }
 
 func checkAssumes(si *snap.Info) error {

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -985,6 +985,12 @@ var systemUsernamesTests = []struct {
 	sysIDs: "snap_daemon:\n    scope: shared",
 	scVer:  "dead 2.4.1 deadbeef bpf-actlog",
 }, {
+	sysIDs: "snap_docker:\n    scope: shared",
+	scVer:  "dead 2.4.1 deadbeef bpf-actlog",
+}, {
+	sysIDs: "snap_docker:\n    scope: shared",
+	scVer:  "dead 2.4.1 deadbeef bpf-actlog",
+}, {
 	sysIDs: "snap_daemon:\n    scope: private",
 	scVer:  "dead 2.4.1 deadbeef bpf-actlog",
 	error:  `snap "foo" requires unsupported user scope "private" for this version of snapd`,
@@ -1197,6 +1203,76 @@ system-usernames:
 			c.Check(mockUserAdd.Calls(), DeepEquals, [][]string{
 				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "524288", "--no-user-group", "--uid", "524288", "--extrausers", "snapd-range-524288-root"},
 				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "584788", "--no-user-group", "--uid", "584788", "--extrausers", "snap_daemon"},
+			})
+
+		}
+	}
+}
+
+func (s *checkSnapSuite) TestCheckSnapSystemUsernamesCallsSnapDocker(c *C) {
+	r := osutil.MockFindGid(func(groupname string) (uint64, error) {
+		if groupname == "snap_docker" || groupname == "snapd-range-524288-root" {
+			return 0, user.UnknownGroupError(groupname)
+		}
+		return 0, fmt.Errorf("unexpected call to FindGid for %s", groupname)
+	})
+	defer r()
+
+	r = osutil.MockFindUid(func(username string) (uint64, error) {
+		if username == "snap_docker" || username == "snapd-range-524288-root" {
+			return 0, user.UnknownUserError(username)
+		}
+		return 0, fmt.Errorf("unexpected call to FindUid for %s", username)
+	})
+	defer r()
+
+	falsePath := osutil.LookPathDefault("false", "/bin/false")
+	for _, classic := range []bool{false, true} {
+		restore := release.MockOnClassic(classic)
+		defer restore()
+
+		restore = seccomp_compiler.MockCompilerVersionInfo("dead 2.4.1 deadbeef bpf-actlog")
+		defer restore()
+
+		const yaml = `name: foo
+version: 1.0
+system-usernames:
+  snap_docker: shared`
+
+		info, err := snap.InfoFromSnapYaml([]byte(yaml))
+		c.Assert(err, IsNil)
+
+		var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
+			return info, emptyContainer(c), nil
+		}
+		restore = snapstate.MockOpenSnapFile(openSnapFile)
+		defer restore()
+
+		mockGroupAdd := testutil.MockCommand(c, "groupadd", "")
+		defer mockGroupAdd.Restore()
+
+		mockUserAdd := testutil.MockCommand(c, "useradd", "")
+		defer mockUserAdd.Restore()
+
+		err = snapstate.CheckSnap(s.st, "snap-path", "foo", nil, nil, snapstate.Flags{}, nil)
+		c.Assert(err, IsNil)
+		if classic {
+			c.Check(mockGroupAdd.Calls(), DeepEquals, [][]string{
+				{"groupadd", "--system", "--gid", "524288", "snapd-range-524288-root"},
+				{"groupadd", "--system", "--gid", "584789", "snap_docker"},
+			})
+			c.Check(mockUserAdd.Calls(), DeepEquals, [][]string{
+				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "524288", "--no-user-group", "--uid", "524288", "snapd-range-524288-root"},
+				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "584789", "--no-user-group", "--uid", "584789", "snap_docker"},
+			})
+		} else {
+			c.Check(mockGroupAdd.Calls(), DeepEquals, [][]string{
+				{"groupadd", "--system", "--gid", "524288", "--extrausers", "snapd-range-524288-root"},
+				{"groupadd", "--system", "--gid", "584789", "--extrausers", "snap_docker"},
+			})
+			c.Check(mockUserAdd.Calls(), DeepEquals, [][]string{
+				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "524288", "--no-user-group", "--uid", "524288", "--extrausers", "snapd-range-524288-root"},
+				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "584789", "--no-user-group", "--uid", "584789", "--extrausers", "snap_docker"},
 			})
 
 		}

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -1140,78 +1140,26 @@ func (s *checkSnapSuite) TestCheckSnapSystemUsernames(c *C) {
 }
 
 func (s *checkSnapSuite) TestCheckSnapSystemUsernamesCallsSnapDaemon(c *C) {
-	r := osutil.MockFindGid(func(groupname string) (uint64, error) {
-		if groupname == "snap_daemon" || groupname == "snapd-range-524288-root" {
-			return 0, user.UnknownGroupError(groupname)
-		}
-		return 0, fmt.Errorf("unexpected call to FindGid for %s", groupname)
-	})
-	defer r()
-
-	r = osutil.MockFindUid(func(username string) (uint64, error) {
-		if username == "snap_daemon" || username == "snapd-range-524288-root" {
-			return 0, user.UnknownUserError(username)
-		}
-		return 0, fmt.Errorf("unexpected call to FindUid for %s", username)
-	})
-	defer r()
-
-	falsePath := osutil.LookPathDefault("false", "/bin/false")
-	for _, classic := range []bool{false, true} {
-		restore := release.MockOnClassic(classic)
-		defer restore()
-
-		restore = seccomp_compiler.MockCompilerVersionInfo("dead 2.4.1 deadbeef bpf-actlog")
-		defer restore()
-
-		const yaml = `name: foo
+	const yaml = `name: foo
 version: 1.0
 system-usernames:
   snap_daemon: shared`
 
-		info, err := snap.InfoFromSnapYaml([]byte(yaml))
-		c.Assert(err, IsNil)
-
-		var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-			return info, emptyContainer(c), nil
-		}
-		restore = snapstate.MockOpenSnapFile(openSnapFile)
-		defer restore()
-
-		mockGroupAdd := testutil.MockCommand(c, "groupadd", "")
-		defer mockGroupAdd.Restore()
-
-		mockUserAdd := testutil.MockCommand(c, "useradd", "")
-		defer mockUserAdd.Restore()
-
-		err = snapstate.CheckSnap(s.st, "snap-path", "foo", nil, nil, snapstate.Flags{}, nil)
-		c.Assert(err, IsNil)
-		if classic {
-			c.Check(mockGroupAdd.Calls(), DeepEquals, [][]string{
-				{"groupadd", "--system", "--gid", "524288", "snapd-range-524288-root"},
-				{"groupadd", "--system", "--gid", "584788", "snap_daemon"},
-			})
-			c.Check(mockUserAdd.Calls(), DeepEquals, [][]string{
-				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "524288", "--no-user-group", "--uid", "524288", "snapd-range-524288-root"},
-				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "584788", "--no-user-group", "--uid", "584788", "snap_daemon"},
-			})
-		} else {
-			c.Check(mockGroupAdd.Calls(), DeepEquals, [][]string{
-				{"groupadd", "--system", "--gid", "524288", "--extrausers", "snapd-range-524288-root"},
-				{"groupadd", "--system", "--gid", "584788", "--extrausers", "snap_daemon"},
-			})
-			c.Check(mockUserAdd.Calls(), DeepEquals, [][]string{
-				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "524288", "--no-user-group", "--uid", "524288", "--extrausers", "snapd-range-524288-root"},
-				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "584788", "--no-user-group", "--uid", "584788", "--extrausers", "snap_daemon"},
-			})
-
-		}
-	}
+	s.testCheckSnapSystemUsernamesCallsCommon(c, "snap_daemon", "584788", yaml)
 }
 
 func (s *checkSnapSuite) TestCheckSnapSystemUsernamesCallsSnapDocker(c *C) {
+	const yaml = `name: foo
+version: 1.0
+system-usernames:
+  snap_docker: shared`
+
+	s.testCheckSnapSystemUsernamesCallsCommon(c, "snap_docker", "584789", yaml)
+}
+
+func (s *checkSnapSuite) testCheckSnapSystemUsernamesCallsCommon(c *C, expectedUser, expectedID, yaml string) {
 	r := osutil.MockFindGid(func(groupname string) (uint64, error) {
-		if groupname == "snap_docker" || groupname == "snapd-range-524288-root" {
+		if groupname == expectedUser || groupname == "snapd-range-524288-root" {
 			return 0, user.UnknownGroupError(groupname)
 		}
 		return 0, fmt.Errorf("unexpected call to FindGid for %s", groupname)
@@ -1219,7 +1167,7 @@ func (s *checkSnapSuite) TestCheckSnapSystemUsernamesCallsSnapDocker(c *C) {
 	defer r()
 
 	r = osutil.MockFindUid(func(username string) (uint64, error) {
-		if username == "snap_docker" || username == "snapd-range-524288-root" {
+		if username == expectedUser || username == "snapd-range-524288-root" {
 			return 0, user.UnknownUserError(username)
 		}
 		return 0, fmt.Errorf("unexpected call to FindUid for %s", username)
@@ -1234,11 +1182,6 @@ func (s *checkSnapSuite) TestCheckSnapSystemUsernamesCallsSnapDocker(c *C) {
 		restore = seccomp_compiler.MockCompilerVersionInfo("dead 2.4.1 deadbeef bpf-actlog")
 		defer restore()
 
-		const yaml = `name: foo
-version: 1.0
-system-usernames:
-  snap_docker: shared`
-
 		info, err := snap.InfoFromSnapYaml([]byte(yaml))
 		c.Assert(err, IsNil)
 
@@ -1259,20 +1202,20 @@ system-usernames:
 		if classic {
 			c.Check(mockGroupAdd.Calls(), DeepEquals, [][]string{
 				{"groupadd", "--system", "--gid", "524288", "snapd-range-524288-root"},
-				{"groupadd", "--system", "--gid", "584789", "snap_docker"},
+				{"groupadd", "--system", "--gid", expectedID, expectedUser},
 			})
 			c.Check(mockUserAdd.Calls(), DeepEquals, [][]string{
 				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "524288", "--no-user-group", "--uid", "524288", "snapd-range-524288-root"},
-				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "584789", "--no-user-group", "--uid", "584789", "snap_docker"},
+				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", expectedID, "--no-user-group", "--uid", expectedID, expectedUser},
 			})
 		} else {
 			c.Check(mockGroupAdd.Calls(), DeepEquals, [][]string{
 				{"groupadd", "--system", "--gid", "524288", "--extrausers", "snapd-range-524288-root"},
-				{"groupadd", "--system", "--gid", "584789", "--extrausers", "snap_docker"},
+				{"groupadd", "--system", "--gid", expectedID, "--extrausers", expectedUser},
 			})
 			c.Check(mockUserAdd.Calls(), DeepEquals, [][]string{
 				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "524288", "--no-user-group", "--uid", "524288", "--extrausers", "snapd-range-524288-root"},
-				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", "584789", "--no-user-group", "--uid", "584789", "--extrausers", "snap_docker"},
+				{"useradd", "--system", "--home-dir", "/nonexistent", "--no-create-home", "--shell", falsePath, "--gid", expectedID, "--no-user-group", "--uid", expectedID, "--extrausers", expectedUser},
 			})
 
 		}


### PR DESCRIPTION
After discussion with Gustavo and Samuele, we decided that it is best for the Canonical maintained docker snap to start listening on it's socket with group ownership of a specific `snap_docker` group that is shared with the host system on Ubuntu Core specifically (and eventually perhaps also on classic Ubuntu, but that requires additional design/thought). This is because it allows us to eventually add mechanisms for users to be added to this group on Ubuntu Core and facilitate non-root user access to the docker socket via i.e. docker commands.

Marking as blocked because while this PR is simple, I *think* we also want associated changes in the review-tools to block any snaps from being uploaded that use the snap_docker group, except the docker snap. AFAICT, other, non-docker snaps in practice cannot abuse membership of the snap_docker group alone to gain access to the docker socket due to our security-in-depth approach because they would still need to be provided access to the socket via AppArmor using the `docker` interface which is considered super-privileged and already blocked in the store, but perhaps this understanding is too naive on my part. Additionally, dockerd in the docker snap will not drop privileges to this snap_docker user, it will still run as root due to the operations it needs to take to start containers, so this new system-usernames group will really only be used by the docker snap for specifically it's socket group ownership and nothing else.

This PR is also the second ever system-username we are supporting in snapd, so we may want to explore other additional tests, etc. before we start adding additional system-usernames. 

I have manually tested this PR with a version of the docker snap which supports listening on its socket using the snap_docker group, which I will make available for testing on this PR somehow.

Stacked on top of https://github.com/snapcore/snapd/pull/9395 for the test helpers improvement so that we can actually test this out in snapstate properly.