### PR TITLE
snap: snap help output refresh

### DIFF
--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -214,8 +214,8 @@ var helpCategories = []helpCategory{
 		Description: i18n.G("archives of snap data"),
 		Commands:    []string{"saved", "save", "check-snapshot", "restore", "forget"},
 	}, {
-		Label:       i18n.G("Devices"),
-		Description: i18n.G("system management"),
+		Label:       i18n.G("Device"),
+		Description: i18n.G("manage device"),
 		Commands:    []string{"model", "reboot", "recovery"},
 	}, {
 		Label:       i18n.G("Other"),
@@ -224,7 +224,7 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("Development"),
 		Description: i18n.G("developer-oriented features"),
-		Commands:    []string{"download", "pack", "run", "try"},
+		Commands:    []string{"download", "pack", "run", "try", "prepare-image"},
 	},
 }
 

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -180,51 +180,51 @@ var helpCategories = []helpCategory{
 	{
 		Label:       i18n.G("Basics"),
 		Description: i18n.G("basic snap management"),
-		Commands:    []string{"find", "info", "install", "list", "refresh", "remove"},
+		Commands:    []string{"find", "info", "install", "remove", "list"},
 	}, {
 		Label:       i18n.G("...more"),
 		Description: i18n.G("slightly more advanced snap management"),
-		Commands:    []string{"create-cohort", "disable", "enable", "revert", "switch"},
+		Commands:    []string{"refresh", "revert", "switch","disable", "enable"},
 	}, {
 		Label:       i18n.G("History"),
 		Description: i18n.G("manage system change transactions"),
-		Commands:    []string{"abort", "changes", "tasks", "watch"},
+		Commands:    []string{"changes", "tasks", "abort", "watch"},
 	}, {
 		Label:       i18n.G("Daemons"),
 		Description: i18n.G("manage services"),
-		Commands:    []string{"logs", "restart", "services", "start", "stop"},
+		Commands:    []string{"services", "start", "stop", "restart", "logs"},
 	}, {
-		Label:       i18n.G("Paths"),
-		Description: i18n.G("manage aliases"),
-		Commands:    []string{"alias", "aliases", "prefer", "unalias"},
+		Label:       i18n.G("Permissions"),
+		Description: i18n.G("manage permissions"),
+		Commands:    []string{"connections", "interface", "connect", "disconnect"},
 	}, {
 		Label:       i18n.G("Configuration"),
 		Description: i18n.G("system administration and configuration"),
 		Commands:    []string{"get", "set", "unset", "wait"},
 	}, {
+		Label:       i18n.G("App Aliases"),
+		Description: i18n.G("manage aliases"),
+		Commands:    []string{"alias", "aliases", "unalias", "prefer"},
+	}, {
 		Label:       i18n.G("Account"),
 		Description: i18n.G("authentication to snapd and the snap store"),
 		Commands:    []string{"login", "logout", "whoami"},
 	}, {
-		Label:       i18n.G("Permissions"),
-		Description: i18n.G("manage permissions"),
-		Commands:    []string{"connect", "connections", "disconnect", "interface"},
-	}, {
 		Label:       i18n.G("Snapshots"),
 		Description: i18n.G("archives of snap data"),
-		Commands:    []string{"check-snapshot", "forget", "restore", "save", "saved"},
-	}, {
-		Label:       i18n.G("Status"),
-		Description: i18n.G("information output and support"),
-		Commands:    []string{"known", "okay", "version", "warnings"},
+		Commands:    []string{"saved", "save", "check-snapshot", "restore", "forget"},
 	}, {
 		Label:       i18n.G("Devices"),
 		Description: i18n.G("system management"),
 		Commands:    []string{"model", "prepare-image", "reboot", "recovery"},
 	}, {
+		Label:       i18n.G("Other"),
+		Description: i18n.G("miscellanea"),
+		Commands:    []string{"version", "warnings", "okay", "ack", "known", "create-cohort"},
+	}, {
 		Label:       i18n.G("Development"),
 		Description: i18n.G("developer-oriented features"),
-		Commands:    []string{"ack", "download", "pack", "run", "try"},
+		Commands:    []string{"download", "pack", "run", "try"},
 	},
 }
 

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -180,11 +180,11 @@ var helpCategories = []helpCategory{
 	{
 		Label:       i18n.G("Basics"),
 		Description: i18n.G("basic snap management"),
-		Commands:    []string{"find", "info", "install", "list", "remove"},
+		Commands:    []string{"find", "info", "install", "list", "refresh", "remove"},
 	}, {
 		Label:       i18n.G("...more"),
 		Description: i18n.G("slightly more advanced snap management"),
-		Commands:    []string{"refresh", "revert", "switch", "disable", "enable"},
+		Commands:    []string{"revert", "switch", "disable", "enable"},
 	}, {
 		Label:       i18n.G("History"),
 		Description: i18n.G("manage system change transactions"),

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -216,7 +216,7 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("Devices"),
 		Description: i18n.G("system management"),
-		Commands:    []string{"model", "prepare-image", "reboot", "recovery"},
+		Commands:    []string{"model", "reboot", "recovery"},
 	}, {
 		Label:       i18n.G("Other"),
 		Description: i18n.G("miscellanea"),

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -184,7 +184,7 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("...more"),
 		Description: i18n.G("slightly more advanced snap management"),
-		Commands:    []string{"create-cohort", "disable", "enable", "revert", "switch", },
+		Commands:    []string{"create-cohort", "disable", "enable", "revert", "switch"},
 	}, {
 		Label:       i18n.G("History"),
 		Description: i18n.G("manage system change transactions"),

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -194,7 +194,7 @@ var helpCategories = []helpCategory{
 		Description: i18n.G("manage services"),
 		Commands:    []string{"services", "start", "stop", "restart", "logs"},
 	}, {
-		Label:       i18n.G("Commands"),
+		Label:       i18n.G("Paths"),
 		Description: i18n.G("manage aliases"),
 		Commands:    []string{"alias", "aliases", "unalias", "prefer"},
 	}, {

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -188,15 +188,15 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("History"),
 		Description: i18n.G("manage system change transactions"),
-		Commands:    []string{"changes", "tasks", "abort", "watch"},
+		Commands:    []string{"abort", "changes", "tasks", "watch"},
 	}, {
 		Label:       i18n.G("Daemons"),
 		Description: i18n.G("manage services"),
-		Commands:    []string{"services", "start", "stop", "restart", "logs"},
+		Commands:    []string{"logs", "restart", "services", "start", "stop"},
 	}, {
 		Label:       i18n.G("Paths"),
 		Description: i18n.G("manage aliases"),
-		Commands:    []string{"alias", "aliases", "unalias", "prefer"},
+		Commands:    []string{"alias", "aliases", "prefer", "unalias"},
 	}, {
 		Label:       i18n.G("Configuration"),
 		Description: i18n.G("system administration and configuration"),
@@ -208,19 +208,23 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("Permissions"),
 		Description: i18n.G("manage permissions"),
-		Commands:    []string{"connections", "interface", "connect", "disconnect"},
+		Commands:    []string{"connect", "connections", "disconnect", "interface"},
 	}, {
 		Label:       i18n.G("Snapshots"),
 		Description: i18n.G("archives of snap data"),
-		Commands:    []string{"saved", "save", "check-snapshot", "restore", "forget"},
+		Commands:    []string{"check-snapshot", "forget", "restore", "save", "saved"},
 	}, {
-		Label:       i18n.G("Other"),
-		Description: i18n.G("miscellanea"),
-		Commands:    []string{"version", "warnings", "okay", "ack", "known", "model", "recovery", "reboot"},
+		Label:       i18n.G("Status"),
+		Description: i18n.G("information output and support"),
+		Commands:    []string{"known", "okay", "version", "warnings"},
+	}, {
+		Label:       i18n.G("Devices"),
+		Description: i18n.G("system management"),
+		Commands:    []string{"model", "prepare-image", "reboot", "recovery"},
 	}, {
 		Label:       i18n.G("Development"),
 		Description: i18n.G("developer-oriented features"),
-		Commands:    []string{"run", "pack", "try", "download", "prepare-image"},
+		Commands:    []string{"ack", "download", "pack", "run", "try"},
 	},
 }
 

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -184,7 +184,7 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("...more"),
 		Description: i18n.G("slightly more advanced snap management"),
-		Commands:    []string{"revert", "switch", "disable", "enable"},
+		Commands:    []string{"create-cohort", "disable", "enable", "revert", "switch", },
 	}, {
 		Label:       i18n.G("History"),
 		Description: i18n.G("manage system change transactions"),
@@ -216,7 +216,7 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("Other"),
 		Description: i18n.G("miscellanea"),
-		Commands:    []string{"version", "warnings", "okay", "ack", "known", "model", "create-cohort", "recovery", "reboot"},
+		Commands:    []string{"version", "warnings", "okay", "ack", "known", "model", "recovery", "reboot"},
 	}, {
 		Label:       i18n.G("Development"),
 		Description: i18n.G("developer-oriented features"),


### PR DESCRIPTION
Proposed update to `snap help` output now that the Other category is too long. I touched a couple of other things too that I thought needed some attention:
- replaced the _Commands_ category with _Paths_ as this seems clearer to me 
  (Commands jarred with our use of command in help output)
- replaced _Other_ with _Status_ to hold commands for managing information/acknowledgements
- created a _Devices_ category to hold commands that can operate on the entire device
- some shuffling of commands from the old Other category (create-cohort, ack, recovery, reboot)
- put commands for each category into alphabetical order. There is some advantage in having common commands first, but our list had become seemingly random and difficult to scan.

Original `snap help` output:
```
         Basics: find, info, install, list, remove
        ...more: refresh, revert, switch, disable, enable
        History: changes, tasks, abort, watch
        Daemons: services, start, stop, restart, logs
       Commands: alias, aliases, unalias, prefer
  Configuration: get, set, unset, wait
        Account: login, logout, whoami
    Permissions: connections, interface, connect, disconnect
      Snapshots: saved, save, check-snapshot, restore, forget
          Other: version, warnings, okay, ack, known, model, create-cohort, recovery, reboot
    Development: run, pack, try, download, prepare-image
```

Proposed `snap help` output:
```
         Basics: find, info, install, list, refresh, remove
        ...more: create-cohort, disable, enable, revert, switch
        History: abort, changes, tasks, watch
        Daemons: logs, restart, services, start, stop
          Paths: alias, aliases, prefer, unalias
  Configuration: get, set, unset, wait
        Account: login, logout, whoami
    Permissions: connect, connections, disconnect, interface
      Snapshots: check-snapshot, forget, restore, save, saved
         Status: known, okay, version, warnings
        Devices: model, prepare-image, reboot, recovery
    Development: ack, download, pack, run, try
```
