### PR TITLE
o/assertstate: support refreshing any number of snap-declarations

### DIFF
--- a/asserts/internal/grouping.go
+++ b/asserts/internal/grouping.go
@@ -52,6 +52,12 @@ func NewGroupings(n int) (*Groupings, error) {
 	return &Groupings{n: uint(n), bitsetThreshold: uint16(n / 16)}, nil
 }
 
+// N returns up to how many groups are supported.
+// That is the value that was passed to NewGroupings.
+func (gr *Groupings) N() int {
+	return int(gr.n)
+}
+
 // WithinRange checks whether group is within the admissible range for
 // labeling otherwise it returns an error.
 func (gr *Groupings) WithinRange(group uint16) error {

--- a/asserts/internal/grouping_test.go
+++ b/asserts/internal/grouping_test.go
@@ -57,6 +57,7 @@ func (s *groupingsSuite) TestNewGroupings(c *C) {
 		if t.err == "" {
 			c.Check(err, IsNil, comm)
 			c.Check(gr, NotNil, comm)
+			c.Check(gr.N(), Equals, t.n)
 		} else {
 			c.Check(gr, IsNil, comm)
 			c.Check(err, ErrorMatches, t.err, comm)

--- a/overlord/assertstate/export_test.go
+++ b/overlord/assertstate/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -23,3 +23,11 @@ package assertstate
 var (
 	DoFetch = doFetch
 )
+
+func MockMaxGroups(n int) (restore func()) {
+	oldMaxGroups := maxGroups
+	maxGroups = n
+	return func() {
+		maxGroups = oldMaxGroups
+	}
+}


### PR DESCRIPTION
use the new Pool.ClearGroups and the pool reuse mechanisms for this, merging error sets as needed