### PR TITLE
many: move ManagedAssetsBootloader into TrustedAssetsBootloader, drop former

### DIFF
--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -2532,10 +2532,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
 			secboot.NewLoadChain(shimBf,
 				secboot.NewLoadChain(assetBf,
-					secboot.NewLoadChain(runKernelBf))),
+					secboot.NewLoadChain(recoveryKernelBf))),
 			secboot.NewLoadChain(shimBf,
 				secboot.NewLoadChain(assetBf,
-					secboot.NewLoadChain(recoveryKernelBf))),
+					secboot.NewLoadChain(runKernelBf))),
 		})
 		return nil
 	})

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -1111,8 +1111,25 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// write boot-chains for current state that will stay unchanged
-	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"run-mode","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"1","kernel-cmdlines":["snapd_recovery_mode=run"]}]}`
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "boot-chains"), []byte(bootChainsData), 0600)
+	bootChains := []boot.BootChain{{
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{
+			{
+				Role: bootloader.RoleRunMode,
+				Name: "asset",
+				Hashes: []string{
+					"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+				},
+			},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}}
+	err := boot.WriteBootChains(bootChains, filepath.Join(dirs.SnapFDEDir, "boot-chains"), 0)
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
@@ -1209,8 +1226,25 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// write boot-chains for current state that will stay unchanged
-	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"run-mode","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"","kernel-cmdlines":["snapd_recovery_mode=run"]}]}`
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "boot-chains"), []byte(bootChainsData), 0600)
+	bootChains := []boot.BootChain{{
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{
+			{
+				Role: bootloader.RoleRunMode,
+				Name: "asset",
+				Hashes: []string{
+					"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+				},
+			},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}}
+	err := boot.WriteBootChains(bootChains, filepath.Join(dirs.SnapFDEDir, "boot-chains"), 0)
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
@@ -2218,8 +2252,44 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	defer restore()
 
 	// write boot-chains for current state that will stay unchanged
-	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"1","kernel-cmdlines":["snapd_recovery_mode=run"]},{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel-recovery","kernel-revision":"1","kernel-cmdlines":["snapd_recovery_mode=recover snapd_recovery_system=system"]}]}`
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "boot-chains"), []byte(bootChainsData), 0600)
+	bootChains := []boot.BootChain{{
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{{
+			Role: bootloader.RoleRecovery, Name: "shim",
+			Hashes: []string{
+				"dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b",
+			},
+		}, {
+			Role: bootloader.RoleRecovery, Name: "asset", Hashes: []string{
+				"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+			},
+		}},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}, {
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{{
+			Role: bootloader.RoleRecovery, Name: "shim",
+			Hashes: []string{
+				"dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b",
+			},
+		}, {
+			Role: bootloader.RoleRecovery, Name: "asset", Hashes: []string{
+				"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+			},
+		}},
+		Kernel:         "pc-kernel-recovery",
+		KernelRevision: "1",
+		KernelCmdlines: []string{"snapd_recovery_mode=recover snapd_recovery_system=system"},
+	}}
+	err := boot.WriteBootChains(boot.ToPredictableBootChains(bootChains), filepath.Join(dirs.SnapFDEDir, "boot-chains"), 0)
 	c.Assert(err, IsNil)
 
 	// mark successful
@@ -2338,8 +2408,45 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	defer restore()
 
 	// write boot-chains for current state that will stay unchanged
-	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"","kernel-cmdlines":["snapd_recovery_mode=run"]},{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel-recovery","kernel-revision":"1","kernel-cmdlines":["snapd_recovery_mode=recover snapd_recovery_system=system"]}]}`
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "boot-chains"), []byte(bootChainsData), 0600)
+	bootChains := []boot.BootChain{{
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{{
+			Role: bootloader.RoleRecovery, Name: "shim",
+			Hashes: []string{
+				"dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b",
+			},
+		}, {
+			Role: bootloader.RoleRecovery, Name: "asset", Hashes: []string{
+				"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+			},
+		}},
+		Kernel: "pc-kernel",
+		// unasserted kernel snap
+		KernelRevision: "",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}, {
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{{
+			Role: bootloader.RoleRecovery, Name: "shim",
+			Hashes: []string{
+				"dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b",
+			},
+		}, {
+			Role: bootloader.RoleRecovery, Name: "asset", Hashes: []string{
+				"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+			},
+		}},
+		Kernel:         "pc-kernel-recovery",
+		KernelRevision: "1",
+		KernelCmdlines: []string{"snapd_recovery_mode=recover snapd_recovery_system=system"},
+	}}
+	err := boot.WriteBootChains(boot.ToPredictableBootChains(bootChains), filepath.Join(dirs.SnapFDEDir, "boot-chains"), 0)
 	c.Assert(err, IsNil)
 
 	// mark successful

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -1101,7 +1101,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	resealCalls := 0
 	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
 		resealCalls++
-		return nil
+		return fmt.Errorf("unexpected call")
 	})
 	defer restore()
 
@@ -1111,7 +1111,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// write boot-chains for current state that will stay unchanged
-	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"run-mode","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"1","kernel-cmdlines":[""]}]}`
+	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"run-mode","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"1","kernel-cmdlines":["snapd_recovery_mode=run"]}]}`
 	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "boot-chains"), []byte(bootChainsData), 0600)
 	c.Assert(err, IsNil)
 
@@ -1199,7 +1199,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	resealCalls := 0
 	restore := boot.MockSecbootResealKey(func(params *secboot.ResealKeyParams) error {
 		resealCalls++
-		return nil
+		return fmt.Errorf("unexpected call")
 	})
 	defer restore()
 
@@ -1209,7 +1209,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// write boot-chains for current state that will stay unchanged
-	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"run-mode","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"","kernel-cmdlines":[""]}]}`
+	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"run-mode","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"","kernel-cmdlines":["snapd_recovery_mode=run"]}]}`
 	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "boot-chains"), []byte(bootChainsData), 0600)
 	c.Assert(err, IsNil)
 
@@ -2172,10 +2172,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-linux_1.snap",
+			Path: "/var/lib/snapd/seed/snaps/pc-kernel-recovery_1.snap",
 			SideInfo: &snap.SideInfo{
 				Revision: snap.Revision{N: 1},
-				RealName: "pc-linux",
+				RealName: "pc-kernel-recovery",
 			},
 		}
 		return uc20Model, []*seed.Snap{kernelSnap}, nil
@@ -2218,7 +2218,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	defer restore()
 
 	// write boot-chains for current state that will stay unchanged
-	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"1","kernel-cmdlines":[""]},{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-linux","kernel-revision":"1","kernel-cmdlines":[""]}]}`
+	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"1","kernel-cmdlines":["snapd_recovery_mode=run"]},{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel-recovery","kernel-revision":"1","kernel-cmdlines":["snapd_recovery_mode=recover snapd_recovery_system=system"]}]}`
 	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "boot-chains"), []byte(bootChainsData), 0600)
 	c.Assert(err, IsNil)
 
@@ -2292,10 +2292,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-linux_1.snap",
+			Path: "/var/lib/snapd/seed/snaps/pc-kernel-recovery_1.snap",
 			SideInfo: &snap.SideInfo{
 				Revision: snap.Revision{N: 1},
-				RealName: "pc-linux",
+				RealName: "pc-kernel-recovery",
 			},
 		}
 		return uc20Model, []*seed.Snap{kernelSnap}, nil
@@ -2338,7 +2338,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	defer restore()
 
 	// write boot-chains for current state that will stay unchanged
-	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"","kernel-cmdlines":[""]},{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-linux","kernel-revision":"1","kernel-cmdlines":[""]}]}`
+	bootChainsData := `{"boot-chains":[{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel","kernel-revision":"","kernel-cmdlines":["snapd_recovery_mode=run"]},{"brand-id":"my-brand","model":"my-model-uc20","grade":"dangerous","model-sign-key-id":"Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij","asset-chain":[{"role":"recovery","name":"shim","hashes":["dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"]},{"role":"recovery","name":"asset","hashes":["0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"]}],"kernel":"pc-kernel-recovery","kernel-revision":"1","kernel-cmdlines":["snapd_recovery_mode=recover snapd_recovery_system=system"]}]}`
 	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "boot-chains"), []byte(bootChainsData), 0600)
 	c.Assert(err, IsNil)
 

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -114,12 +114,12 @@ func MockProcCmdline(newPath string) (restore func()) {
 
 var errBootConfigNotManaged = errors.New("boot config is not managed")
 
-func getBootloaderManagingItsAssets(where string, opts *bootloader.Options) (bootloader.ManagedAssetsBootloader, error) {
+func getBootloaderManagingItsAssets(where string, opts *bootloader.Options) (bootloader.TrustedAssetsBootloader, error) {
 	bl, err := bootloader.Find(where, opts)
 	if err != nil {
-		return nil, fmt.Errorf("internal error: cannot find managed assets bootloader under %q: %v", where, err)
+		return nil, fmt.Errorf("internal error: cannot find trusted assets bootloader under %q: %v", where, err)
 	}
-	mbl, ok := bl.(bootloader.ManagedAssetsBootloader)
+	mbl, ok := bl.(bootloader.TrustedAssetsBootloader)
 	if !ok {
 		// the bootloader cannot manage its scripts
 		return nil, errBootConfigNotManaged

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -122,9 +122,9 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineNotManagedHappy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "")
 
-	mbl := bl.WithManagedAssets()
-	bootloader.Force(mbl)
-	mbl.IsManaged = false
+	tbl := bl.WithTrustedAssets()
+	bootloader.Force(tbl)
+	tbl.IsManaged = false
 
 	// TODO:UC20: remove is managed checks
 
@@ -156,12 +156,12 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineNotUC20(c *C) {
 func (s *kernelCommandLineSuite) TestComposeCommandLineManagedHappy(c *C) {
 	model := boottest.MakeMockUC20Model()
 
-	mbl := bootloadertest.Mock("btloader", c.MkDir()).WithManagedAssets()
-	bootloader.Force(mbl)
+	tbl := bootloadertest.Mock("btloader", c.MkDir()).WithTrustedAssets()
+	bootloader.Force(tbl)
 	defer bootloader.Force(nil)
 
-	mbl.IsManaged = true
-	mbl.StaticCommandLine = "panic=-1"
+	tbl.IsManaged = true
+	tbl.StaticCommandLine = "panic=-1"
 
 	cmdline, err := boot.ComposeRecoveryCommandLine(model, "20200314")
 	c.Assert(err, IsNil)
@@ -171,7 +171,7 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineManagedHappy(c *C) {
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=run panic=-1")
 
 	// managed status is effectively ignored
-	mbl.IsManaged = false
+	tbl.IsManaged = false
 
 	cmdline, err = boot.ComposeRecoveryCommandLine(model, "20200314")
 	c.Assert(err, IsNil)
@@ -184,20 +184,20 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineManagedHappy(c *C) {
 func (s *kernelCommandLineSuite) TestComposeCandidateCommandLineManagedHappy(c *C) {
 	model := boottest.MakeMockUC20Model()
 
-	mbl := bootloadertest.Mock("btloader", c.MkDir()).WithManagedAssets()
-	bootloader.Force(mbl)
+	tbl := bootloadertest.Mock("btloader", c.MkDir()).WithTrustedAssets()
+	bootloader.Force(tbl)
 	defer bootloader.Force(nil)
 
-	mbl.IsManaged = true
-	mbl.StaticCommandLine = "panic=-1"
-	mbl.CandidateStaticCommandLine = "candidate panic=-1"
+	tbl.IsManaged = true
+	tbl.StaticCommandLine = "panic=-1"
+	tbl.CandidateStaticCommandLine = "candidate panic=-1"
 
 	cmdline, err := boot.ComposeCandidateCommandLine(model)
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=run candidate panic=-1")
 
 	// managed status is effectively ignored
-	mbl.IsManaged = false
+	tbl.IsManaged = false
 	cmdline, err = boot.ComposeCandidateCommandLine(model)
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=run candidate panic=-1")

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -346,7 +346,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		return fmt.Errorf("cannot set run system environment: %v", err)
 	}
 
-	_, ok = bl.(bootloader.ManagedAssetsBootloader)
+	_, ok = bl.(bootloader.TrustedAssetsBootloader)
 	if ok {
 		// the bootloader can manage its boot config
 

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -115,6 +115,7 @@ type installableBootloader interface {
 type RecoveryAwareBootloader interface {
 	Bootloader
 	SetRecoverySystemEnv(recoverySystemDir string, values map[string]string) error
+	GetRecoverySystemEnv(recoverySystemDir string, key string) (string, error)
 }
 
 type ExtractedRecoveryKernelImageBootloader interface {

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -161,8 +161,9 @@ type ExtractedRunKernelImageBootloader interface {
 	DisableTryKernel() error
 }
 
-// TrustedAssetsBootloader has boot assets that take part in secure boot
-// process, while other boot asses (typically boot config) is managed by snapd.
+// TrustedAssetsBootloader has boot assets that take part in the secure boot
+// process and need to be tracked, while other boot asses (typically boot
+// config) is managed by snapd.
 type TrustedAssetsBootloader interface {
 	Bootloader
 

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -162,12 +162,13 @@ type ExtractedRunKernelImageBootloader interface {
 	DisableTryKernel() error
 }
 
-// ManagedAssetsBootloader has its boot assets (typically boot config) managed
-// by snapd.
-type ManagedAssetsBootloader interface {
+// TrustedAssetsBootloader has boot assets that take part in secure boot
+// process, while other boot asses (typically boot config) is managed by snapd.
+type TrustedAssetsBootloader interface {
 	Bootloader
 
 	// IsCurrentlyManaged returns true when the on disk boot assets are managed.
+	// TODO:UC20: remove once no longer used
 	IsCurrentlyManaged() (bool, error)
 	// ManagedAssets returns a list of boot assets managed by the bootloader
 	// in the boot filesystem.
@@ -183,11 +184,7 @@ type ManagedAssetsBootloader interface {
 	// CandidateCommandLine is similar to CommandLine, but uses the current
 	// edition of managed built-in boot assets as reference.
 	CandidateCommandLine(modeArg, systemArg, extraArgs string) (string, error)
-}
 
-// TrustedAssetsBootloader has boot assets that take part in secure boot
-// process.
-type TrustedAssetsBootloader interface {
 	// TrustedAssets returns the list of relative paths to assets inside
 	// the bootloader's rootdir that are measured in the boot process in the
 	// order of loading during the boot.

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -163,8 +163,8 @@ type ExtractedRunKernelImageBootloader interface {
 }
 
 // TrustedAssetsBootloader has boot assets that take part in the secure boot
-// process and need to be tracked, while other boot asses (typically boot
-// config) is managed by snapd.
+// process and need to be tracked, while other boot assets (typically boot
+// config) are managed by snapd.
 type TrustedAssetsBootloader interface {
 	Bootloader
 

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -115,7 +115,6 @@ type installableBootloader interface {
 type RecoveryAwareBootloader interface {
 	Bootloader
 	SetRecoverySystemEnv(recoverySystemDir string, values map[string]string) error
-	GetRecoverySystemEnv(recoverySystemDir string, key string) (string, error)
 }
 
 type ExtractedRecoveryKernelImageBootloader interface {

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -460,3 +460,30 @@ func (b *MockTrustedAssetsBootloader) BootChain(runBl bootloader.Bootloader, ker
 	b.BootChainKernelPath = append(b.BootChainKernelPath, kernelPath)
 	return b.BootChainList, b.BootChainErr
 }
+
+// MockTrustedAssetsRecoveryAwareBootloader mocks a bootloader implementing the
+// bootloader.TrustedAssetsBootloader and bootloader.RecoveryAwareBootloader
+// interfaces.
+type MockTrustedAssetsRecoveryAwareBootloader struct {
+	*MockTrustedAssetsBootloader
+
+	EnvVars map[string]string
+}
+
+func (b *MockBootloader) WithTrustedAssetsRecoveryAware() *MockTrustedAssetsRecoveryAwareBootloader {
+	return &MockTrustedAssetsRecoveryAwareBootloader{
+		MockTrustedAssetsBootloader: &MockTrustedAssetsBootloader{
+			MockBootloader: b,
+		},
+		EnvVars: make(map[string]string),
+	}
+}
+
+func (b *MockTrustedAssetsRecoveryAwareBootloader) SetRecoverySystemEnv(systemDir string, env map[string]string) error {
+	b.EnvVars = env
+	return nil
+}
+
+func (b *MockTrustedAssetsRecoveryAwareBootloader) GetRecoverySystemEnv(systemDir, key string) (string, error) {
+	return b.EnvVars[key], nil
+}

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -58,7 +58,6 @@ var _ bootloader.RecoveryAwareBootloader = (*MockRecoveryAwareBootloader)(nil)
 var _ bootloader.TrustedAssetsBootloader = (*MockTrustedAssetsBootloader)(nil)
 var _ bootloader.ExtractedRunKernelImageBootloader = (*MockExtractedRunKernelImageBootloader)(nil)
 var _ bootloader.ExtractedRecoveryKernelImageBootloader = (*MockExtractedRecoveryKernelImageBootloader)(nil)
-var _ bootloader.ManagedAssetsBootloader = (*MockManagedAssetsBootloader)(nil)
 
 func Mock(name, bootdir string) *MockBootloader {
 	return &MockBootloader{
@@ -374,65 +373,6 @@ func (b *MockExtractedRunKernelImageBootloader) DisableTryKernel() error {
 	return b.runKernelImageMockedErrs["DisableTryKernel"]
 }
 
-// MockManagedAssetsBootloader mocks a bootloader implementing the
-// bootloader.ManagedAssetsBootloader interface.
-type MockManagedAssetsBootloader struct {
-	*MockBootloader
-
-	IsManaged                  bool
-	IsManagedErr               error
-	UpdateErr                  error
-	UpdateCalls                int
-	Assets                     []string
-	StaticCommandLine          string
-	CandidateStaticCommandLine string
-	CommandLineErr             error
-}
-
-func (b *MockBootloader) WithManagedAssets() *MockManagedAssetsBootloader {
-	return &MockManagedAssetsBootloader{
-		MockBootloader: b,
-	}
-}
-
-func (b *MockManagedAssetsBootloader) IsCurrentlyManaged() (bool, error) {
-	return b.IsManaged, b.IsManagedErr
-}
-
-func (b *MockManagedAssetsBootloader) ManagedAssets() []string {
-	return b.Assets
-}
-
-func (b *MockManagedAssetsBootloader) UpdateBootConfig(opts *bootloader.Options) error {
-	b.UpdateCalls++
-	return b.UpdateErr
-}
-
-func glueCommandLine(modeArg, systemArg, staticArgs, extraArgs string) string {
-	args := []string(nil)
-	for _, argSet := range []string{modeArg, systemArg, staticArgs, extraArgs} {
-		if argSet != "" {
-			args = append(args, argSet)
-		}
-	}
-	line := strings.Join(args, " ")
-	return strings.TrimSpace(line)
-}
-
-func (b *MockManagedAssetsBootloader) CommandLine(modeArg, systemArg, extraArgs string) (string, error) {
-	if b.CommandLineErr != nil {
-		return "", b.CommandLineErr
-	}
-	return glueCommandLine(modeArg, systemArg, b.StaticCommandLine, extraArgs), nil
-}
-
-func (b *MockManagedAssetsBootloader) CandidateCommandLine(modeArg, systemArg, extraArgs string) (string, error) {
-	if b.CommandLineErr != nil {
-		return "", b.CommandLineErr
-	}
-	return glueCommandLine(modeArg, systemArg, b.CandidateStaticCommandLine, extraArgs), nil
-}
-
 // MockTrustedAssetsBootloader mocks a bootloader implementing the
 // bootloader.TrustedAssetsBootloader interface.
 type MockTrustedAssetsBootloader struct {
@@ -450,12 +390,59 @@ type MockTrustedAssetsBootloader struct {
 	RecoveryBootChainCalls []string
 	BootChainRunBl         []bootloader.Bootloader
 	BootChainKernelPath    []string
+
+	IsManaged                  bool
+	IsManagedErr               error
+	UpdateErr                  error
+	UpdateCalls                int
+	ManagedAssetsList          []string
+	StaticCommandLine          string
+	CandidateStaticCommandLine string
+	CommandLineErr             error
 }
 
 func (b *MockBootloader) WithTrustedAssets() *MockTrustedAssetsBootloader {
 	return &MockTrustedAssetsBootloader{
 		MockBootloader: b,
 	}
+}
+
+func (b *MockTrustedAssetsBootloader) IsCurrentlyManaged() (bool, error) {
+	return b.IsManaged, b.IsManagedErr
+}
+
+func (b *MockTrustedAssetsBootloader) ManagedAssets() []string {
+	return b.ManagedAssetsList
+}
+
+func (b *MockTrustedAssetsBootloader) UpdateBootConfig(opts *bootloader.Options) error {
+	b.UpdateCalls++
+	return b.UpdateErr
+}
+
+func glueCommandLine(modeArg, systemArg, staticArgs, extraArgs string) string {
+	args := []string(nil)
+	for _, argSet := range []string{modeArg, systemArg, staticArgs, extraArgs} {
+		if argSet != "" {
+			args = append(args, argSet)
+		}
+	}
+	line := strings.Join(args, " ")
+	return strings.TrimSpace(line)
+}
+
+func (b *MockTrustedAssetsBootloader) CommandLine(modeArg, systemArg, extraArgs string) (string, error) {
+	if b.CommandLineErr != nil {
+		return "", b.CommandLineErr
+	}
+	return glueCommandLine(modeArg, systemArg, b.StaticCommandLine, extraArgs), nil
+}
+
+func (b *MockTrustedAssetsBootloader) CandidateCommandLine(modeArg, systemArg, extraArgs string) (string, error) {
+	if b.CommandLineErr != nil {
+		return "", b.CommandLineErr
+	}
+	return glueCommandLine(modeArg, systemArg, b.CandidateStaticCommandLine, extraArgs), nil
 }
 
 func (b *MockTrustedAssetsBootloader) TrustedAssets() ([]string, error) {
@@ -474,29 +461,29 @@ func (b *MockTrustedAssetsBootloader) BootChain(runBl bootloader.Bootloader, ker
 	return b.BootChainList, b.BootChainErr
 }
 
-// MockManagedAssetsRecoveryAwareBootloader mocks a bootloader implementing the
-// bootloader.ManagedAssetsBootloader and bootloader.RecoveryAwareBootloader
+// MockTrustedAssetsRecoveryAwareBootloader mocks a bootloader implementing the
+// bootloader.TrustedAssetsBootloader and bootloader.RecoveryAwareBootloader
 // interfaces.
-type MockManagedAssetsRecoveryAwareBootloader struct {
-	*MockManagedAssetsBootloader
+type MockTrustedAssetsRecoveryAwareBootloader struct {
+	*MockTrustedAssetsBootloader
 
 	EnvVars map[string]string
 }
 
-func (b *MockBootloader) WithManagedAssetsRecoveryAware() *MockManagedAssetsRecoveryAwareBootloader {
-	return &MockManagedAssetsRecoveryAwareBootloader{
-		MockManagedAssetsBootloader: &MockManagedAssetsBootloader{
+func (b *MockBootloader) WithTrustedAssetsRecoveryAware() *MockTrustedAssetsRecoveryAwareBootloader {
+	return &MockTrustedAssetsRecoveryAwareBootloader{
+		MockTrustedAssetsBootloader: &MockTrustedAssetsBootloader{
 			MockBootloader: b,
 		},
 		EnvVars: make(map[string]string),
 	}
 }
 
-func (b *MockManagedAssetsRecoveryAwareBootloader) SetRecoverySystemEnv(systemDir string, env map[string]string) error {
+func (b *MockTrustedAssetsRecoveryAwareBootloader) SetRecoverySystemEnv(systemDir string, env map[string]string) error {
 	b.EnvVars = env
 	return nil
 }
 
-func (b *MockManagedAssetsRecoveryAwareBootloader) GetRecoverySystemEnv(systemDir, key string) (string, error) {
+func (b *MockTrustedAssetsRecoveryAwareBootloader) GetRecoverySystemEnv(systemDir, key string) (string, error) {
 	return b.EnvVars[key], nil
 }

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -460,30 +460,3 @@ func (b *MockTrustedAssetsBootloader) BootChain(runBl bootloader.Bootloader, ker
 	b.BootChainKernelPath = append(b.BootChainKernelPath, kernelPath)
 	return b.BootChainList, b.BootChainErr
 }
-
-// MockTrustedAssetsRecoveryAwareBootloader mocks a bootloader implementing the
-// bootloader.TrustedAssetsBootloader and bootloader.RecoveryAwareBootloader
-// interfaces.
-type MockTrustedAssetsRecoveryAwareBootloader struct {
-	*MockTrustedAssetsBootloader
-
-	EnvVars map[string]string
-}
-
-func (b *MockBootloader) WithTrustedAssetsRecoveryAware() *MockTrustedAssetsRecoveryAwareBootloader {
-	return &MockTrustedAssetsRecoveryAwareBootloader{
-		MockTrustedAssetsBootloader: &MockTrustedAssetsBootloader{
-			MockBootloader: b,
-		},
-		EnvVars: make(map[string]string),
-	}
-}
-
-func (b *MockTrustedAssetsRecoveryAwareBootloader) SetRecoverySystemEnv(systemDir string, env map[string]string) error {
-	b.EnvVars = env
-	return nil
-}
-
-func (b *MockTrustedAssetsRecoveryAwareBootloader) GetRecoverySystemEnv(systemDir, key string) (string, error) {
-	return b.EnvVars[key], nil
-}

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -38,7 +38,6 @@ var (
 	_ installableBootloader             = (*grub)(nil)
 	_ RecoveryAwareBootloader           = (*grub)(nil)
 	_ ExtractedRunKernelImageBootloader = (*grub)(nil)
-	_ ManagedAssetsBootloader           = (*grub)(nil)
 	_ TrustedAssetsBootloader           = (*grub)(nil)
 )
 

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -139,6 +139,21 @@ func (g *grub) SetRecoverySystemEnv(recoverySystemDir string, values map[string]
 	return genv.Save()
 }
 
+func (g *grub) GetRecoverySystemEnv(recoverySystemDir string, key string) (string, error) {
+	if recoverySystemDir == "" {
+		return "", fmt.Errorf("internal error: recoverySystemDir unset")
+	}
+	recoverySystemGrubEnv := filepath.Join(g.rootdir, recoverySystemDir, "grubenv")
+	genv := grubenv.NewEnv(recoverySystemGrubEnv)
+	if err := genv.Load(); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return genv.Get(key), nil
+}
+
 func (g *grub) ConfigFile() string {
 	return filepath.Join(g.dir(), "grub.cfg")
 }

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -139,21 +139,6 @@ func (g *grub) SetRecoverySystemEnv(recoverySystemDir string, values map[string]
 	return genv.Save()
 }
 
-func (g *grub) GetRecoverySystemEnv(recoverySystemDir string, key string) (string, error) {
-	if recoverySystemDir == "" {
-		return "", fmt.Errorf("internal error: recoverySystemDir unset")
-	}
-	recoverySystemGrubEnv := filepath.Join(g.rootdir, recoverySystemDir, "grubenv")
-	genv := grubenv.NewEnv(recoverySystemGrubEnv)
-	if err := genv.Load(); err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", err
-	}
-	return genv.Get(key), nil
-}
-
 func (g *grub) ConfigFile() string {
 	return filepath.Join(g.dir(), "grub.cfg")
 }

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -297,36 +297,6 @@ func (s *grubTestSuite) TestGrubSetRecoverySystemEnv(c *C) {
 	c.Check(genv.Get("other_options"), Equals, "are-supported")
 }
 
-func (s *grubTestSuite) TestGetRecoverySystemEnv(c *C) {
-	s.makeFakeGrubEFINativeEnv(c, nil)
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
-
-	err := os.MkdirAll(filepath.Join(s.rootdir, "/systems/20191209"), 0755)
-	c.Assert(err, IsNil)
-	recoverySystemGrubenv := filepath.Join(s.rootdir, "/systems/20191209/grubenv")
-
-	// does not fail when there is no recovery env
-	value, err := g.GetRecoverySystemEnv("/systems/20191209", "no_file")
-	c.Assert(err, IsNil)
-	c.Check(value, Equals, "")
-
-	genv := grubenv.NewEnv(recoverySystemGrubenv)
-	genv.Set("snapd_extra_cmdline_args", "foo bar baz")
-	genv.Set("random_option", `has "some spaces"`)
-	err = genv.Save()
-	c.Assert(err, IsNil)
-
-	value, err = g.GetRecoverySystemEnv("/systems/20191209", "snapd_extra_cmdline_args")
-	c.Assert(err, IsNil)
-	c.Check(value, Equals, "foo bar baz")
-	value, err = g.GetRecoverySystemEnv("/systems/20191209", "random_option")
-	c.Assert(err, IsNil)
-	c.Check(value, Equals, `has "some spaces"`)
-	value, err = g.GetRecoverySystemEnv("/systems/20191209", "not_set")
-	c.Assert(err, IsNil)
-	c.Check(value, Equals, ``)
-}
-
 func (s *grubTestSuite) makeKernelAssetSnap(c *C, snapFileName string) snap.PlaceInfo {
 	kernelSnap, err := snap.ParsePlaceInfoFromSnapFileName(snapFileName)
 	c.Assert(err, IsNil)

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -297,6 +297,36 @@ func (s *grubTestSuite) TestGrubSetRecoverySystemEnv(c *C) {
 	c.Check(genv.Get("other_options"), Equals, "are-supported")
 }
 
+func (s *grubTestSuite) TestGetRecoverySystemEnv(c *C) {
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+
+	err := os.MkdirAll(filepath.Join(s.rootdir, "/systems/20191209"), 0755)
+	c.Assert(err, IsNil)
+	recoverySystemGrubenv := filepath.Join(s.rootdir, "/systems/20191209/grubenv")
+
+	// does not fail when there is no recovery env
+	value, err := g.GetRecoverySystemEnv("/systems/20191209", "no_file")
+	c.Assert(err, IsNil)
+	c.Check(value, Equals, "")
+
+	genv := grubenv.NewEnv(recoverySystemGrubenv)
+	genv.Set("snapd_extra_cmdline_args", "foo bar baz")
+	genv.Set("random_option", `has "some spaces"`)
+	err = genv.Save()
+	c.Assert(err, IsNil)
+
+	value, err = g.GetRecoverySystemEnv("/systems/20191209", "snapd_extra_cmdline_args")
+	c.Assert(err, IsNil)
+	c.Check(value, Equals, "foo bar baz")
+	value, err = g.GetRecoverySystemEnv("/systems/20191209", "random_option")
+	c.Assert(err, IsNil)
+	c.Check(value, Equals, `has "some spaces"`)
+	value, err = g.GetRecoverySystemEnv("/systems/20191209", "not_set")
+	c.Assert(err, IsNil)
+	c.Check(value, Equals, ``)
+}
+
 func (s *grubTestSuite) makeKernelAssetSnap(c *C, snapFileName string) snap.PlaceInfo {
 	kernelSnap, err := snap.ParsePlaceInfoFromSnapFileName(snapFileName)
 	c.Assert(err, IsNil)

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -605,14 +605,14 @@ some random boot config`))
 	opts := &bootloader.Options{NoSlashBoot: true}
 	g := bootloader.NewGrub(s.rootdir, opts)
 	c.Assert(g, NotNil)
-	mg, ok := g.(bootloader.ManagedAssetsBootloader)
+	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
 	// native EFI/ubuntu setup, as we're using NoSlashBoot
 	s.makeFakeGrubEFINativeEnv(c, []byte(`this is
 some random boot config`))
 
-	is, err := mg.IsCurrentlyManaged()
+	is, err := tg.IsCurrentlyManaged()
 	c.Assert(err, IsNil)
 	c.Assert(is, Equals, false)
 
@@ -620,7 +620,7 @@ some random boot config`))
 	s.makeFakeGrubEFINativeEnv(c, []byte(`# Snapd-Boot-Config-Edition: 5
 managed by snapd`))
 
-	is, err = mg.IsCurrentlyManaged()
+	is, err = tg.IsCurrentlyManaged()
 	c.Assert(err, IsNil)
 	c.Assert(is, Equals, true)
 
@@ -628,7 +628,7 @@ managed by snapd`))
 	err = os.Chmod(s.grubEFINativeDir(), 0000)
 	defer os.Chmod(s.grubEFINativeDir(), 0755)
 	c.Assert(err, IsNil)
-	is, err = mg.IsCurrentlyManaged()
+	is, err = tg.IsCurrentlyManaged()
 	c.Assert(err, ErrorMatches, "cannot load existing config asset: .*/grub.cfg: permission denied")
 	c.Assert(is, Equals, false)
 }
@@ -641,23 +641,23 @@ some random boot config`))
 	g := bootloader.NewGrub(s.rootdir, opts)
 	c.Assert(g, NotNil)
 
-	mg, ok := g.(bootloader.ManagedAssetsBootloader)
+	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	c.Check(mg.ManagedAssets(), DeepEquals, []string{
+	c.Check(tg.ManagedAssets(), DeepEquals, []string{
 		"EFI/ubuntu/grub.cfg",
 	})
 
 	opts = &bootloader.Options{Role: bootloader.RoleRecovery}
-	mg = bootloader.NewGrub(s.rootdir, opts).(bootloader.ManagedAssetsBootloader)
-	c.Check(mg.ManagedAssets(), DeepEquals, []string{
+	tg = bootloader.NewGrub(s.rootdir, opts).(bootloader.TrustedAssetsBootloader)
+	c.Check(tg.ManagedAssets(), DeepEquals, []string{
 		"EFI/ubuntu/grub.cfg",
 	})
 
 	// as it called for the root fs rather than a mount point of a partition
 	// with boot assets
-	mg = bootloader.NewGrub(s.rootdir, nil).(bootloader.ManagedAssetsBootloader)
-	c.Check(mg.ManagedAssets(), DeepEquals, []string{
+	tg = bootloader.NewGrub(s.rootdir, nil).(bootloader.TrustedAssetsBootloader)
+	c.Check(tg.ManagedAssets(), DeepEquals, []string{
 		"boot/grub/grub.cfg",
 	})
 }
@@ -675,10 +675,10 @@ this is mocked grub-recovery.conf
 `))
 	defer restore()
 
-	eg, ok := g.(bootloader.ManagedAssetsBootloader)
+	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 	// install the recovery boot script
-	err := eg.UpdateBootConfig(opts)
+	err := tg.UpdateBootConfig(opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, `recovery boot script`)
@@ -701,10 +701,10 @@ this is mocked grub-recovery.conf
 this is mocked grub.conf
 `))
 	defer restore()
-	eg, ok := g.(bootloader.ManagedAssetsBootloader)
+	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 	// install the recovery boot script
-	err := eg.UpdateBootConfig(opts)
+	err := tg.UpdateBootConfig(opts)
 	c.Assert(err, IsNil)
 	// the recovery boot asset was picked
 	c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, `# Snapd-Boot-Config-Edition: 3
@@ -723,9 +723,9 @@ func (s *grubTestSuite) testBootUpdateBootConfigUpdates(c *C, oldConfig, newConf
 	restore := assets.MockInternal("grub.cfg", []byte(newConfig))
 	defer restore()
 
-	eg, ok := g.(bootloader.ManagedAssetsBootloader)
+	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
-	err := eg.UpdateBootConfig(opts)
+	err := tg.UpdateBootConfig(opts)
 	c.Assert(err, IsNil)
 	if update {
 		c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, newConfig)
@@ -796,14 +796,14 @@ this is updated grub.cfg
 	opts := &bootloader.Options{NoSlashBoot: true}
 	g := bootloader.NewGrub(s.rootdir, opts)
 	c.Assert(g, NotNil)
-	eg, ok := g.(bootloader.ManagedAssetsBootloader)
+	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
 	err := os.Chmod(s.grubEFINativeDir(), 0000)
 	c.Assert(err, IsNil)
 	defer os.Chmod(s.grubEFINativeDir(), 0755)
 
-	err = eg.UpdateBootConfig(opts)
+	err = tg.UpdateBootConfig(opts)
 	c.Assert(err, ErrorMatches, "cannot load existing config asset: .*/EFI/ubuntu/grub.cfg: permission denied")
 	err = os.Chmod(s.grubEFINativeDir(), 0555)
 	c.Assert(err, IsNil)
@@ -813,7 +813,7 @@ this is updated grub.cfg
 	// writing out new config fails
 	err = os.Chmod(s.grubEFINativeDir(), 0111)
 	c.Assert(err, IsNil)
-	err = eg.UpdateBootConfig(opts)
+	err = tg.UpdateBootConfig(opts)
 	c.Assert(err, ErrorMatches, `open .*/EFI/ubuntu/grub.cfg\..+: permission denied`)
 	c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, oldConfig)
 }
@@ -849,14 +849,14 @@ func (s *grubTestSuite) TestCommandLineNotManaged(c *C) {
 	defer restore()
 
 	opts := &bootloader.Options{NoSlashBoot: true}
-	mg := bootloader.NewGrub(s.rootdir, opts).(bootloader.ManagedAssetsBootloader)
+	mg := bootloader.NewGrub(s.rootdir, opts).(bootloader.TrustedAssetsBootloader)
 
 	args, err := mg.CommandLine("snapd_recovery_mode=run", "", "extra")
 	c.Assert(err, IsNil)
 	c.Check(args, Equals, "snapd_recovery_mode=run static=1 extra")
 
 	optsRecovery := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
-	mgr := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.ManagedAssetsBootloader)
+	mgr := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.TrustedAssetsBootloader)
 
 	args, err = mgr.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=1234", "extra")
 	c.Assert(err, IsNil)
@@ -886,22 +886,22 @@ boot script
 	optsNoSlashBoot := &bootloader.Options{NoSlashBoot: true}
 	g := bootloader.NewGrub(s.rootdir, optsNoSlashBoot)
 	c.Assert(g, NotNil)
-	mg, ok := g.(bootloader.ManagedAssetsBootloader)
+	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
 	extraArgs := `extra_arg=1  extra_foo=-1   panic=3 baz="more  spaces"`
-	args, err := mg.CommandLine("snapd_recovery_mode=run", "", extraArgs)
+	args, err := tg.CommandLine("snapd_recovery_mode=run", "", extraArgs)
 	c.Assert(err, IsNil)
 	c.Check(args, Equals, `snapd_recovery_mode=run arg1 foo=123 panic=-1 arg2="with spaces " extra_arg=1 extra_foo=-1 panic=3 baz="more  spaces"`)
 
 	// empty mode/system do not produce confusing results
-	args, err = mg.CommandLine("", "", extraArgs)
+	args, err = tg.CommandLine("", "", extraArgs)
 	c.Assert(err, IsNil)
 	c.Check(args, Equals, `arg1 foo=123 panic=-1 arg2="with spaces " extra_arg=1 extra_foo=-1 panic=3 baz="more  spaces"`)
 
 	// now check the recovery bootloader
 	optsRecovery := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
-	mrg := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.ManagedAssetsBootloader)
+	mrg := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.TrustedAssetsBootloader)
 	args, err = mrg.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=20200202", extraArgs)
 	c.Assert(err, IsNil)
 	// static command line from recovery asset
@@ -912,10 +912,10 @@ boot script
 boot script
 `
 	s.makeFakeGrubEFINativeEnv(c, []byte(grubCfg3))
-	mg = bootloader.NewGrub(s.rootdir, optsNoSlashBoot).(bootloader.ManagedAssetsBootloader)
+	tg = bootloader.NewGrub(s.rootdir, optsNoSlashBoot).(bootloader.TrustedAssetsBootloader)
 	c.Assert(g, NotNil)
 	extraArgs = `extra_arg=1`
-	args, err = mg.CommandLine("snapd_recovery_mode=run", "", extraArgs)
+	args, err = tg.CommandLine("snapd_recovery_mode=run", "", extraArgs)
 	c.Assert(err, IsNil)
 	c.Check(args, Equals, `snapd_recovery_mode=run edition=3 static args extra_arg=1`)
 }
@@ -949,9 +949,9 @@ boot script
 	defer restore()
 
 	optsNoSlashBoot := &bootloader.Options{NoSlashBoot: true}
-	mg := bootloader.NewGrub(s.rootdir, optsNoSlashBoot).(bootloader.ManagedAssetsBootloader)
+	mg := bootloader.NewGrub(s.rootdir, optsNoSlashBoot).(bootloader.TrustedAssetsBootloader)
 	optsRecovery := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
-	recoverymg := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.ManagedAssetsBootloader)
+	recoverymg := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.TrustedAssetsBootloader)
 
 	args, err := mg.CandidateCommandLine("snapd_recovery_mode=run", "", "extra=1")
 	c.Assert(err, IsNil)
@@ -995,17 +995,17 @@ boot script
 	opts := &bootloader.Options{NoSlashBoot: true}
 	g := bootloader.NewGrub(s.rootdir, opts)
 	c.Assert(g, NotNil)
-	mg, ok := g.(bootloader.ManagedAssetsBootloader)
+	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
 	extraArgs := "foo bar baz=1"
-	args, err := mg.CommandLine("snapd_recovery_mode=run", "", extraArgs)
+	args, err := tg.CommandLine("snapd_recovery_mode=run", "", extraArgs)
 	c.Assert(err, IsNil)
 	c.Check(args, Equals, `snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 foo bar baz=1`)
 
 	// now check the recovery bootloader
 	opts = &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
-	mrg := bootloader.NewGrub(s.rootdir, opts).(bootloader.ManagedAssetsBootloader)
+	mrg := bootloader.NewGrub(s.rootdir, opts).(bootloader.TrustedAssetsBootloader)
 	args, err = mrg.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=20200202", extraArgs)
 	c.Assert(err, IsNil)
 	// static command line from recovery asset

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -376,13 +376,13 @@ func maybePreserveManagedBootAssets(mountPoint string, ps *LaidOutStructure) ([]
 		return nil, err
 	}
 
-	mbl, ok := bl.(bootloader.ManagedAssetsBootloader)
+	tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
 	if !ok {
 		// bootloader implementation does not support managing its
 		// assets
 		return nil, nil
 	}
-	managed, err := mbl.IsCurrentlyManaged()
+	managed, err := tbl.IsCurrentlyManaged()
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +390,7 @@ func maybePreserveManagedBootAssets(mountPoint string, ps *LaidOutStructure) ([]
 		// assets are not managed
 		return nil, nil
 	}
-	return mbl.ManagedAssets(), nil
+	return tbl.ManagedAssets(), nil
 }
 
 // entryDestPaths resolves destination and backup paths for given


### PR DESCRIPTION
Drop the ManagedAssetsBootloader, all its methods become part of
TrustedAssetsBootloader. Update relevant locations.

