### PR TITLE
tests/nested/manual/grade-signed-above-testkeys-boot: enable kvm

### DIFF
--- a/tests/nested/manual/grade-signed-above-testkeys-boot/task.yaml
+++ b/tests/nested/manual/grade-signed-above-testkeys-boot/task.yaml
@@ -8,9 +8,6 @@ environment:
   NESTED_ENABLE_TPM: true
   NESTED_ENABLE_SECURE_BOOT: true
 
-  # kvm doesn't work with tpm + secure boot on gce unfortunately
-  NESTED_ENABLE_KVM: false
-
   # use snapd from the spread run so that we have testkeys trusted in the snapd
   # run
   NESTED_BUILD_SNAPD_FROM_CURRENT: true


### PR DESCRIPTION
This now works with the image + kernel combo we are using in GCE with spread.

This was missed because the PR adding this test was opened before the fix was made available, but now that it is we should use it.