### PR TITLE
overlord: explicitly set refresh-app-awareness in tests

### DIFF
--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -1300,7 +1300,7 @@ func (s *linkSnapSuite) TestUndoLinkSnapdNthInstall(c *C) {
 	c.Check(t.Log()[1], Matches, `.*INFO unlink`)
 }
 
-func (s *linkSnapSuite) TestDoUnlinkSnapRefreshAwarenessHardCheck(c *C) {
+func (s *linkSnapSuite) TestDoUnlinkSnapRefreshAwarenessHardCheckOn(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1316,6 +1316,10 @@ func (s *linkSnapSuite) TestDoUnlinkSnapRefreshAwarenessHardCheck(c *C) {
 func (s *linkSnapSuite) TestDoUnlinkSnapRefreshHardCheckOff(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness", false)
+	tr.Commit()
 
 	chg := s.testDoUnlinkSnapRefreshAwareness(c)
 


### PR DESCRIPTION
We'd like to flip the default while keeping test coverage and test
semantics as-is. As such, do not assume a feature flag has a specific
value but instead set it explicitly in tests.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
