### PR TITLE
tests/core/snap-debug-bootvars: spread test for snap debug boot-vars

### DIFF
--- a/tests/core/snap-debug-bootvars/task.yaml
+++ b/tests/core/snap-debug-bootvars/task.yaml
@@ -1,0 +1,39 @@
+summary: Ensure `snap debug bootvars` command works
+
+debug: |
+    cat default.out || true
+    cat uc20.out || true
+    cat run.out || true
+    cat recovery.out || true
+
+restore: |
+    rm -f default.out uc20.out run.out recovery.out
+
+execute: |
+    #shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB"/systems.sh
+
+    # does not outright fail
+    snap debug boot-vars  > default.out
+
+    if is_core20_system; then
+        # boot-vars default output is for the run mode bootloader, make sure its
+        # output looks sane (though we don't expect any of the variables to be
+        # set)
+        MATCH 'kernel_status=$' < default.out
+
+        snap debug boot-vars --uc20 > uc20.out
+        snap debug boot-vars --root-dir /run/mnt/ubuntu-boot > run.out
+        # the no-parameters output and explicit --uc20 should be the same
+        diff -up default.out uc20.out
+        # default shows a run mode bootloader variables, so the output shall be
+        # identical again
+        diff -up default.out run.out
+
+        # try the recovery bootloader now
+        snap debug boot-vars --root-dir /run/mnt/ubuntu-seed > recovery.out
+        MATCH 'snapd_recovery_mode=run' < recovery.out
+    else
+        MATCH 'snap_core=core.*\.snap' < default.out
+        MATCH 'snap_kernel=pc-kernel.*\.snap' < default.out
+    fi


### PR DESCRIPTION
Add a spread test for `snap debug boot-vars` command.

A followup after #9390 