### PR TITLE
desktop/notification: add bindings for FDO notifications

### DIFF
--- a/desktop/notification/caps.go
+++ b/desktop/notification/caps.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notification
+
+const (
+	// ActionIconsCapability indicates that the server supports using icons
+	// instead of text for displaying actions. Using icons for actions must be
+	// enabled on a per-notification basis using the "action-icons" hint.
+	ActionIconsCapability ServerCapability = "action-icons"
+	// ActionsCapability indicates that the server will provide the specified
+	// actions to the user. Even if this cap is missing, actions may still be
+	// specified by the client, however the server is free to ignore them.
+	ActionsCapability ServerCapability = "actions"
+	// BodyCapability indicates that the server supports body text. Some
+	// implementations may only show the summary (for instance, onscreen
+	// displays, marquee/scrollers).
+	BodyCapability ServerCapability = "body"
+	// BodyHyperlinksCapability indicates that the server supports hyperlinks in
+	// the notifications.
+	BodyHyperlinksCapability ServerCapability = "body-hyperlinks"
+	// BodyImagesCapability indicates that the server supports images in the
+	// notifications.
+	BodyImagesCapability ServerCapability = "body-images"
+	// BodyMarkupCapability indicates that the server supports markup in the
+	// body text. If marked up text is sent to a server that does not give this
+	// cap, the markup will show through as regular text so must be stripped
+	// clientside.
+	BodyMarkupCapability ServerCapability = "body-markup"
+	// IconMultiCapability indicates that the server will render an animation of
+	// all the frames in a given image array. The client may still specify
+	// multiple frames even if this cap and/or "icon-static" is missing, however
+	// the server is free to ignore them and use only the primary frame.
+	IconMultiCapability ServerCapability = "icon-multi"
+	// IconStaticCapability indicates that the server supports display of
+	// exactly one frame of any given image array. This value is mutually
+	// exclusive with "icon-multi", it is a protocol error for the server to
+	// specify both.
+	IconStaticCapability ServerCapability = "icon-static"
+	// PersistenceCapability indicates that the server supports persistence of
+	// notifications. Notifications will be retained until they are acknowledged
+	// or removed by the user or recalled by the sender. The presence of this
+	// capability allows clients to depend on the server to ensure a
+	// notification is seen and eliminate the need for the client to display a
+	// reminding function (such as a status icon) of its own.
+	PersistenceCapability ServerCapability = "persistence"
+	// SoundCapability indicates that the server supports sounds on
+	// notifications. If returned, the server must support the "sound-file" and
+	// "suppress-sound" hints.
+	SoundCapability ServerCapability = "sound"
+)

--- a/desktop/notification/fdo.go
+++ b/desktop/notification/fdo.go
@@ -1,0 +1,181 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notification
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/godbus/dbus"
+)
+
+const (
+	dBusName          = "org.freedesktop.Notifications"
+	dBusObjectPath    = "/org/freedesktop/Notifications"
+	dBusInterfaceName = "org.freedesktop.Notifications"
+)
+
+type fdoServer struct {
+	conn *dbus.Conn
+	obj  dbus.BusObject
+}
+
+// NewFreeDesktopServer returns an interface to a freedesktop.org message notification server.
+func NewFreeDesktopServer(conn *dbus.Conn) Server {
+	return &fdoServer{
+		conn: conn,
+		obj:  conn.Object(dBusName, dBusObjectPath),
+	}
+}
+
+// ServerInformation returns the information about the notification server.
+func (srv *fdoServer) ServerInformation() (name, vendor, version, specVersion string, err error) {
+	call := srv.obj.Call(dBusInterfaceName+".GetServerInformation", 0)
+	if err := call.Store(&name, &vendor, &version, &specVersion); err != nil {
+		return "", "", "", "", err
+	}
+	return name, vendor, version, specVersion, nil
+}
+
+// ServerCapabilities returns the list of notification capabilities provided by the session.
+func (srv *fdoServer) ServerCapabilities() ([]ServerCapability, error) {
+	call := srv.obj.Call(dBusInterfaceName+".GetCapabilities", 0)
+	var caps []ServerCapability
+	if err := call.Store(&caps); err != nil {
+		return nil, err
+	}
+	return caps, nil
+}
+
+// SendNotification sends a single notification message.
+func (srv *fdoServer) SendNotification(msg *Message) (ID, error) {
+	call := srv.obj.Call(dBusInterfaceName+".Notify", 0,
+		msg.AppName, msg.ReplacesID, msg.Icon, msg.Summary, msg.Body,
+		flattenActions(msg.Actions), mapHints(msg.Hints), msg.ExpireTimeout)
+	var id ID
+	if err := call.Store(&id); err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func flattenActions(actions []Action) []string {
+	result := make([]string, len(actions)*2)
+	for i, action := range actions {
+		result[i*2] = action.ActionKey
+		result[i*2+1] = action.LocalizedText
+	}
+	return result
+}
+
+func mapHints(hints []Hint) map[string]dbus.Variant {
+	result := make(map[string]dbus.Variant, len(hints))
+	for _, hint := range hints {
+		result[hint.Name] = dbus.MakeVariant(hint.Value)
+	}
+	return result
+}
+
+// CloseNotification closes a specific notification.
+func (srv *fdoServer) CloseNotification(id ID) error {
+	call := srv.obj.Call(dBusInterfaceName+".CloseNotification", 0, id)
+	return call.Store()
+}
+
+// ObserveNotifications blocks and processes message notification signals.
+//
+// The bus connection is configured to deliver signals from the notification
+// server. All received signals are dispatched to the provided observer. This
+// process continues until stopped by the context, or if an error occurs.
+func (srv *fdoServer) ObserveNotifications(ctx context.Context, observer Observer) (err error) {
+	// TODO: upgrade godbus and use un-buffered channel.
+	ch := make(chan *dbus.Signal, 10)
+	defer close(ch)
+
+	srv.conn.Signal(ch)
+	defer srv.conn.RemoveSignal(ch)
+
+	matchRules := []dbus.MatchOption{
+		dbus.WithMatchSender(dBusName),
+		dbus.WithMatchObjectPath(dBusObjectPath),
+		dbus.WithMatchInterface(dBusInterfaceName),
+	}
+	if err := srv.conn.AddMatchSignal(matchRules...); err != nil {
+		return err
+	}
+	defer func() {
+		err = srv.conn.RemoveMatchSignal(matchRules...)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case sig := <-ch:
+			if err := processSignal(sig, observer); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func processSignal(sig *dbus.Signal, observer Observer) error {
+	switch sig.Name {
+	case dBusInterfaceName + ".NotificationClosed":
+		if err := processNotificationClosed(sig, observer); err != nil {
+			return fmt.Errorf("cannot process NotificationClosed signal: %v", err)
+		}
+	case dBusInterfaceName + ".ActionInvoked":
+		if err := processActionInvoked(sig, observer); err != nil {
+			return fmt.Errorf("cannot process ActionInvoked signal: %v", err)
+		}
+	}
+	return nil
+}
+
+func processNotificationClosed(sig *dbus.Signal, observer Observer) error {
+	if len(sig.Body) != 2 {
+		return fmt.Errorf("unexpected number of body elements: %d", len(sig.Body))
+	}
+	id, ok := sig.Body[0].(uint32)
+	if !ok {
+		return fmt.Errorf("expected first body element to be uint32, got %T", sig.Body[0])
+	}
+	reason, ok := sig.Body[1].(uint32)
+	if !ok {
+		return fmt.Errorf("expected second body element to be uint32, got %T", sig.Body[1])
+	}
+	return observer.NotificationClosed(ID(id), CloseReason(reason))
+}
+
+func processActionInvoked(sig *dbus.Signal, observer Observer) error {
+	if len(sig.Body) != 2 {
+		return fmt.Errorf("unexpected number of body elements: %d", len(sig.Body))
+	}
+	id, ok := sig.Body[0].(uint32)
+	if !ok {
+		return fmt.Errorf("expected first body element to be uint32, got %T", sig.Body[0])
+	}
+	actionKey, ok := sig.Body[1].(string)
+	if !ok {
+		return fmt.Errorf("expected second body element to be string, got %T", sig.Body[1])
+	}
+	return observer.ActionInvoked(ID(id), actionKey)
+}

--- a/desktop/notification/fdo.go
+++ b/desktop/notification/fdo.go
@@ -22,6 +22,7 @@ package notification
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/godbus/dbus"
 )
@@ -130,7 +131,13 @@ func (srv *Server) ObserveNotifications(ctx context.Context, observer Observer) 
 		return err
 	}
 	defer func() {
-		err = srv.conn.RemoveMatchSignal(matchRules...)
+		if err := srv.conn.RemoveMatchSignal(matchRules...); err != nil {
+			// XXX: this should not fail for us in practice but we don't want
+			// to clobber the actual error being returned from the function in
+			// general, so ignore RemoveMatchSignal errors and just log them
+			// instead.
+			log.Print("Cannot remove D-Bus signal matcher:", err)
+		}
 	}()
 
 	for {

--- a/desktop/notification/hints.go
+++ b/desktop/notification/hints.go
@@ -200,5 +200,3 @@ func WithSuppressSound() Hint {
 	t := true
 	return Hint{Name: "suppress-sound", Value: &t}
 }
-
-// TODO: add remaining documented hints

--- a/desktop/notification/hints.go
+++ b/desktop/notification/hints.go
@@ -35,6 +35,8 @@ func WithActionIcons() Hint {
 }
 
 // Urgency describes the importance of a notification message.
+//
+// Specification: https://developer.gnome.org/notification-spec/#urgency-levels
 type Urgency byte
 
 const (
@@ -70,6 +72,8 @@ func WithUrgency(u Urgency) Hint {
 }
 
 // Category is a string indicating the category of a notification message.
+//
+// Specification: https://developer.gnome.org/notification-spec/#categories
 type Category string
 
 const (

--- a/desktop/notification/hints.go
+++ b/desktop/notification/hints.go
@@ -145,7 +145,7 @@ func WithTransient() Hint {
 	return Hint{Name: "transient", Value: &t}
 }
 
-// WithResident returns a hint asking the server to keep the message after an action is invked.
+// WithResident returns a hint asking the server to keep the message after an action is invoked.
 //
 // When set the server will not automatically remove the notification when an
 // action has been invoked. The notification will remain resident in the server

--- a/desktop/notification/hints.go
+++ b/desktop/notification/hints.go
@@ -1,0 +1,204 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notification
+
+import "fmt"
+
+// WithActionIcons returns a hint asking the server to use action key as icon names.
+//
+// A server that has the "action-icons" capability will attempt to interpret any
+// action key as a named icon. The localized display name will be used to
+// annotate the icon for accessibility purposes. The icon name should be
+// compliant with the Freedesktop.org Icon Naming Specification.
+//
+// Requires server version >= 1.2
+func WithActionIcons() Hint {
+	t := true
+	return Hint{Name: "action-icons", Value: &t}
+}
+
+// Urgency describes the importance of a notification message.
+type Urgency byte
+
+const (
+	// LowUrgency indicates that a notification message is below normal priority.
+	LowUrgency Urgency = 0
+	// NormalUrgency indicates that a notification message has the regular priority.
+	NormalUrgency Urgency = 1
+	// CriticalUrgency indicates that a notification message is above normal priority.
+	CriticalUrgency Urgency = 2
+)
+
+// String implements the Stringer interface.
+func (u Urgency) String() string {
+	switch u {
+	case LowUrgency:
+		return "low"
+	case NormalUrgency:
+		return "normal"
+	case CriticalUrgency:
+		return "critical"
+	default:
+		return fmt.Sprintf("Urgency(%d)", byte(u))
+	}
+}
+
+// WithUrgency returns a hint asking the server to set message urgency.
+//
+// Notification servers may show messages with higher urgency before messages
+// with lower urgency. In addition some urgency levels may not be shown when the
+// user has enabled a do-not-distrub mode.
+func WithUrgency(u Urgency) Hint {
+	return Hint{Name: "urgency", Value: &u}
+}
+
+// Category is a string indicating the category of a notification message.
+type Category string
+
+const (
+	// DeviceCategory is a generic notification category related to hardware devices.
+	DeviceCategory Category = "device"
+	// DeviceAddedCategory indicates that a device was added to the system.
+	DeviceAddedCategory Category = "device.added"
+	// DeviceErrorCategory indicates that a device error occurred.
+	DeviceErrorCategory Category = "device.error"
+	// DeviceRemovedCategory indicates that a device was removed from the system.
+	DeviceRemovedCategory Category = "device.removed"
+
+	// EmailCategory is a generic notification category related to electronic mail.
+	EmailCategory Category = "email"
+	//EmailArrivedCategory indicates that an e-mail has arrived.
+	EmailArrivedCategory Category = "email.arrived"
+	// EmailBouncedCategory indicates that an e-mail message has bounced.
+	EmailBouncedCategory Category = "email.bounced"
+
+	// InstantMessageCategory is a generic notification category related to instant messages.
+	InstantMessageCategory Category = "im"
+	// InstantMessageErrorCategory indicates that an instant message error occurred.
+	InstantMessageErrorCategory Category = "im.error"
+	// InstantMessageReceivedCategory indicates that an instant mesage has been received.
+	InstantMessageReceivedCategory Category = "im.received"
+
+	// NetworkCategory is a generic notification category related to network.
+	NetworkCategory Category = "network"
+	// NetworkConnectedCategory indicates that a network connection has been established.
+	NetworkConnectedCategory Category = "network.connected"
+	// NetworkDisconnectedCategory indicates that a network connection has been lost.
+	NetworkDisconnectedCategory Category = "network.disconnected"
+	// NetworkErrorCategory indicates that a network error occurred.
+	NetworkErrorCategory Category = "network.error"
+
+	// PresenceCategory is a generic notification category related to on-line presence.
+	PresenceCategory Category = "presence"
+	// PresenceOfflineCategory indicates that a contact disconnected from the network.
+	PresenceOfflineCategory Category = "presence.offline"
+	// PresenceOnlineCategory indicates that a contact connected to the network.
+	PresenceOnlineCategory Category = "presence.online"
+
+	// TransferCategory is a generic notification category for file transfers or downloads.
+	TransferCategory Category = "transfer"
+	// TransferCompleteCategory indicates that a file transfer has completed.
+	TransferCompleteCategory Category = "transfer.complete"
+	// TransferErrorCategory indicates that a file transfer error occurred.
+	TransferErrorCategory Category = "transfer.error"
+)
+
+// WithCategory returns a hint asking the server to set message category.
+func WithCategory(c Category) Hint {
+	return Hint{Name: "category", Value: &c}
+}
+
+// WithDesktopEntry returns a hint asking the server to associate a desktop file with a message.
+//
+// The desktopEntryName is the name of the desktop file without the ".desktop"
+// extension. The server may use this information to derive correct icon, for
+// logging, etc.
+func WithDesktopEntry(desktopEntryName string) Hint {
+	return Hint{Name: "desktop-entry", Value: &desktopEntryName}
+}
+
+// WithTransient returns a hint asking the server to bypass message persistence.
+//
+// When set the server will treat the notification as transient and by-pass the
+// server's persistence capability, if it should exist.
+//
+// Requires server version >= 1.2
+func WithTransient() Hint {
+	t := true
+	return Hint{Name: "transient", Value: &t}
+}
+
+// WithResident returns a hint asking the server to keep the message after an action is invked.
+//
+// When set the server will not automatically remove the notification when an
+// action has been invoked. The notification will remain resident in the server
+// until it is explicitly removed by the user or by the sender. This hint is
+// likely only useful when the server has the "persistence" capability.
+//
+// Requires server version >= 1.2
+func WithResident() Hint {
+	t := true
+	return Hint{Name: "resident", Value: &t}
+}
+
+// WithPointToX returns a hint asking the server to point the notification at a specific X coordinate.
+//
+// The coordinate is in desktop pixel units. Both X and Y hints must be included in the message.
+func WithPointToX(x int) Hint {
+	return Hint{Name: "x", Value: &x}
+}
+
+// WithPointToY returns a hint asking the server to point the notification at a specific Y coordinate.
+//
+// The coordinate is in desktop pixel units. Both X and Y hints must be included in the message.
+func WithPointToY(y int) Hint {
+	return Hint{Name: "y", Value: &y}
+}
+
+// WithImageFile returns a hint asking the server display an image loaded from file.
+//
+// When multiple hits related to images are used, the following priority list applies:
+// 1) "image-data" (not implemented in Go).
+// 2) "image-path", as provided by WithImageFile.
+// 3) Message.Icon field.
+func WithImageFile(path string) Hint {
+	// The hint name is image-path but the function is called WithImageFile for consistency with WithSoundFile.
+	return Hint{Name: "image-path", Value: &path}
+}
+
+// TODO: add WithImageData
+
+// WithSoundFile returns a hint asking the server to play a sound loaded from file.
+func WithSoundFile(path string) Hint {
+	return Hint{Name: "sound-file", Value: &path}
+}
+
+// WithSoundName returns a hint asking the server to play a sound from the sound theme.
+func WithSoundName(name string) Hint {
+	return Hint{Name: "sound-name", Value: &name}
+}
+
+// WithSuppressSound returns a hint asking the server not to play any notification sounds.
+func WithSuppressSound() Hint {
+	t := true
+	return Hint{Name: "suppress-sound", Value: &t}
+}
+
+// TODO: add remaining documented hints

--- a/desktop/notification/notify.go
+++ b/desktop/notification/notify.go
@@ -1,0 +1,166 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package notification implements bindings to D-Bus notification
+// specification, version 1.2, as documented at https://developer.gnome.org/notification-spec/
+package notification
+
+import (
+	"context"
+	"fmt"
+)
+
+// Message describes a single notification message.
+//
+// The notification should be related to a specific application, as indicated by
+// AppName. In practice this should be the name of the desktop file and could be
+// also accompanied by an appropriate hint indicating which icon to use.
+//
+// Message must include a summary and should include a body. The body may use
+// HTML-like markup language to include bold, italic or underline text, as well
+// as to include images and hyperlinks.
+//
+// A notification can automatically expire after the given number of
+// milliseconds. This is separate from the notification being visible or
+// invisible on-screen. Expired notifications are removed from persistent
+// message roster, if one is supported.
+//
+// A notification may replace an existing notification by setting the ReplacesID
+// to a non-zero value. This only works if the notification server was not
+// re-started and should be used for as long as the sender process is alive, as
+// sending the identifier across session startup boundary has no chance of
+// working correctly.
+//
+// A notification may optionally carry a number of hints that further customize it
+// in a specific way. Refer to various hint constructors for details.
+//
+// A notification may optionally also carry one of several actions. If
+// supported, actions can be invoked by the user, broadcasting a notification
+// response back to the session. This mechanism only works if there is someone
+// listening for the action being triggered.
+//
+// In all cases, the specific notification must take into account the
+// capabilities of the server. For instance, if a server does not support body
+// markup, then such markup is not automatically stripped by either the client
+// or the server.
+type Message struct {
+	AppName       string
+	Icon          string
+	Summary       string
+	Body          string
+	ExpireTimeout int32 // XXX: consider using time.Duration instead?
+	ReplacesID    ID
+	Actions       []Action
+	Hints         []Hint
+}
+
+// ID is the opaque identifier of a notification assigned by the server.
+//
+// Notifications with known identifiers can be closed or updated. The identifier
+// is valid within one desktop session and should not be used unless the calling
+// process initially sent the message.
+type ID uint32
+
+// Action describes a single notification action.
+//
+// ActionKey is returned in an D-Bus signal when an action is activated by the
+// user. The text must be localized for the appropriate language.
+type Action struct {
+	ActionKey     string
+	LocalizedText string
+}
+
+// Hint describes supplementeary information that may be used by the server.
+//
+// Various helpers create hint objects of specifc purpose.
+type Hint struct {
+	Name  string
+	Value interface{}
+}
+
+// ServerCapability describes a single capability of the notification server.
+//
+// Each server offers specific capabilities. It is advised to provide graceful
+// degradation of functionality, depending on the supported capabilities, so
+// that the notification messages are useful on a wide range of desktop
+// environments.
+type ServerCapability string
+
+// Server is an interface to a notification server interactions.
+type Server interface {
+	// ServerInformation returns the basic information about the notification server.
+	ServerInformation() (name, vendor, version, specVersion string, err error)
+	// ServerCapabilities returns the list of notification capabilities implemented by the server.
+	ServerCapabilities() ([]ServerCapability, error)
+	// SendNotification sends a new notification or updates an existing
+	// notification. In both cases the ID of the notification, as assigned by
+	// the server, is returned. The ID can be used to cancel a notification,
+	// update it or react to invoked user actions.
+	SendNotification(msg *Message) (ID, error)
+	// CloseNotification closes a notification message with the given ID.
+	CloseNotification(ID) error
+	// ObserveNotifications blocks waiting for notification message events to arrive.
+	// Cancel the context to stop the montoring process and return.
+	ObserveNotifications(ctx context.Context, observer Observer) error
+}
+
+// CloseReason indicates why a notification message was closed.
+type CloseReason uint32
+
+const (
+	// CloseReasonExpired indicates that a notification message has expired.
+	CloseReasonExpired CloseReason = 1
+	// CloseReasonDismissed indicates that a notification message was dismissed by the user.
+	CloseReasonDismissed CloseReason = 2
+	// CloseReasonClosed indicates that a notification message was closed with an API call.
+	CloseReasonClosed CloseReason = 3
+	// CloseReasonUndefined indicates that no other well-known reason applies.
+	CloseReasonUndefined CloseReason = 4
+)
+
+// String implements the Stringer interface.
+func (r CloseReason) String() string {
+	switch r {
+	case CloseReasonExpired:
+		return "expired"
+	case CloseReasonDismissed:
+		return "dismissed"
+	case CloseReasonClosed:
+		return "closed"
+	case CloseReasonUndefined:
+		return "undefined"
+	default:
+		return fmt.Sprintf("CloseReason(%d)", uint32(r))
+	}
+}
+
+// Observer is an interface for observing interactions with notification messages.
+//
+// An observer can be used to either observe a notification being closed or
+// dismissed or to react to actions being invoked by the user. Practical
+// implementations must remember the ID of the message they have sent to filter
+// out other notifications.
+type Observer interface {
+	// NotificationClosed is called when a notification is either closed or removed
+	// from the persistent roster.
+	NotificationClosed(id ID, reason CloseReason) error
+	// ActionInvoked is caliled when one of the notification message actions is
+	// clicked by the user.
+	ActionInvoked(id ID, actionKey string) error
+}

--- a/desktop/notification/notify.go
+++ b/desktop/notification/notify.go
@@ -88,6 +88,8 @@ type Action struct {
 // Hint describes supplementeary information that may be used by the server.
 //
 // Various helpers create hint objects of specifc purpose.
+//
+// Specification: https://developer.gnome.org/notification-spec/#hints
 type Hint struct {
 	Name  string
 	Value interface{}

--- a/desktop/notification/notify.go
+++ b/desktop/notification/notify.go
@@ -22,7 +22,6 @@
 package notification
 
 import (
-	"context"
 	"fmt"
 )
 
@@ -95,30 +94,7 @@ type Hint struct {
 }
 
 // ServerCapability describes a single capability of the notification server.
-//
-// Each server offers specific capabilities. It is advised to provide graceful
-// degradation of functionality, depending on the supported capabilities, so
-// that the notification messages are useful on a wide range of desktop
-// environments.
 type ServerCapability string
-
-// Server is an interface to a notification server interactions.
-type Server interface {
-	// ServerInformation returns the basic information about the notification server.
-	ServerInformation() (name, vendor, version, specVersion string, err error)
-	// ServerCapabilities returns the list of notification capabilities implemented by the server.
-	ServerCapabilities() ([]ServerCapability, error)
-	// SendNotification sends a new notification or updates an existing
-	// notification. In both cases the ID of the notification, as assigned by
-	// the server, is returned. The ID can be used to cancel a notification,
-	// update it or react to invoked user actions.
-	SendNotification(msg *Message) (ID, error)
-	// CloseNotification closes a notification message with the given ID.
-	CloseNotification(ID) error
-	// ObserveNotifications blocks waiting for notification message events to arrive.
-	// Cancel the context to stop the montoring process and return.
-	ObserveNotifications(ctx context.Context, observer Observer) error
-}
 
 // CloseReason indicates why a notification message was closed.
 type CloseReason uint32


### PR DESCRIPTION
This package contains go bindings to freedesktop message notification
interface. It can be used to send, cancel and respond to message actions.
The code has no unit tests yet. Sent for early feedback.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
