### PR TITLE
cmd/snap/auto-import: stop importing system user assertions from initramfs mnts

### DIFF
--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -61,6 +61,9 @@ func autoImportCandidates() ([]string, error) {
 
 	isTesting := snapdenv.Testing()
 
+	// TODO: re-write this to use osutil.LoadMountInfo instead of doing the
+	//       parsing ourselves
+
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		l := strings.Fields(scanner.Text())
@@ -94,7 +97,24 @@ func autoImportCandidates() ([]string, error) {
 			continue
 		}
 
+		// TODO: should the following 2 checks try to be more smart like
+		//       `snap-bootstrap initramfs-mounts` and try to find the boot disk
+		//       and determine what partitions to skip using the disks package?
+
+		// skip all initramfs mounted disks on uc20
 		mountPoint := l[4]
+		if strings.HasPrefix(mountPoint, boot.InitramfsRunMntDir) {
+			continue
+		}
+
+		// skip all seed dir mount points too, as these are bind mounts to the
+		// initramfs dirs on uc20, this can show up as
+		// /writable/system-data/var/lib/snapd/seed as well as
+		// /var/lib/snapd/seed
+		if strings.HasSuffix(mountPoint, dirs.SnapSeedDir) {
+			continue
+		}
+
 		cand := filepath.Join(mountPoint, autoImportsName)
 		if osutil.FileExists(cand) {
 			cands = append(cands, cand)
@@ -102,7 +122,6 @@ func autoImportCandidates() ([]string, error) {
 	}
 
 	return cands, scanner.Err()
-
 }
 
 func queueFile(src string) error {


### PR DESCRIPTION
These are erroneously being imported, we don't want assertions on the partitions
ubuntu-seed, ubuntu-boot, or ubuntu-data to be imported automatically, but the
current mount code sees these disks as already mounted since they are mounted in
the initramfs and as such considered for auto-import.

A more intelligent way to handle this would be to follow the bind mounts to a
device and see if those devices correspond to any of the partitions, but this
should be good enough as /var/lib/snapd/seed should never be a mount point on
Ubuntu Core 16 or 18.