### PR TITLE
many/apparmor: adjust rules for reading profile/ execing new profiles for new kernel

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -86,7 +86,7 @@
     # changing profile
     @{PROC}/[0-9]*/attr/exec w,
     # Reading current profile
-    @{PROC}/[0-9]*/attr/current r,
+    @{PROC}/[0-9]*/attr/{,apparmor/}current r,
     # Reading available filesystems
     @{PROC}/filesystems r,
 
@@ -426,7 +426,7 @@
     /var/lib/snapd/cookie/snap.* r,
 
     # For aa_change_hat() to go into ^mount-namespace-capture-helper
-    @{PROC}/[0-9]*/attr/current w,
+    @{PROC}/[0-9]*/attr/{,apparmor/}current w,
 
     # As a special exception allow snap-confine to write to anything in /var/lib.
     # This code should be changed to allow delegation so that snap-confine can

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -84,7 +84,7 @@
     capability setgid,
 
     # changing profile
-    @{PROC}/[0-9]*/attr/exec w,
+    @{PROC}/[0-9]*/attr/{,apparmor/}exec w,
     # Reading current profile
     @{PROC}/[0-9]*/attr/{,apparmor/}current r,
     # Reading available filesystems

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -92,7 +92,7 @@ deny dbus (send)
 
 # webbrowser-app/webapp-container tries to read this file to determine if it is
 # confined or not, so explicitly deny to avoid noise in the logs.
-deny @{PROC}/@{pid}/attr/current r,
+deny @{PROC}/@{pid}/attr/{,apparmor/}current r,
 
 # This is an information leak but disallowing it leads to developer confusion
 # when using the chromium content api file chooser due to a (harmless) glib

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -67,7 +67,7 @@ const cupsControlPermanentSlotAppArmor = `
 
 # Some versions of CUPS will verify the connecting pid's
 # security label
-@{PROC}/[0-9]*/attr/current r,
+@{PROC}/[0-9]*/attr/{,apparmor/}current r,
 
 # Allow daemon access to the color manager on the system
 dbus (receive, send)

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -91,7 +91,7 @@ unix (bind,listen) type=stream addr="@/containerd-shim/**.sock\x00",
 # Wide read access to /proc, but somewhat limited writes for now
 @{PROC}/ r,
 @{PROC}/** r,
-@{PROC}/[0-9]*/attr/exec w,
+@{PROC}/[0-9]*/attr/{,apparmor/}exec w,
 @{PROC}/[0-9]*/oom_score_adj w,
 
 # Limited read access to specific bits of /sys

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -39,7 +39,7 @@ const lxdSupportConnectedPlugAppArmor = `
 # Description: Can change to any apparmor profile (including unconfined) thus
 # giving access to all resources of the system so LXD may manage what to give
 # to its containers. This gives device ownership to connected snaps.
-@{PROC}/**/attr/current r,
+@{PROC}/**/attr/{,apparmor/}current r,
 /{,usr/}{,s}bin/aa-exec ux,
 
 # Allow discovering the os-release of the host

--- a/sandbox/apparmor/process.go
+++ b/sandbox/apparmor/process.go
@@ -25,10 +25,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
 func labelFromPid(pid int) (string, error) {
-	procFile := filepath.Join(rootPath, fmt.Sprintf("proc/%v/attr/current", pid))
+	// first check new kernel path, /proc/<pid>/attr/apparmor/current, falling
+	// back to the old path if that doesn't exist
+	procFile := filepath.Join(rootPath, fmt.Sprintf("proc/%v/attr/apparmor/current", pid))
+	if !osutil.FileExists(procFile) {
+		// fallback
+		procFile = filepath.Join(rootPath, fmt.Sprintf("proc/%v/attr/current", pid))
+	}
 	contents, err := ioutil.ReadFile(procFile)
 	if os.IsNotExist(err) {
 		return "unconfined", nil


### PR DESCRIPTION
Newer kernels such as the one in groovy currently will report AppArmor status
through /proc/<pid>/attr/apparmor/current instead of /proc/<pid>/attr/current
because due to some new LSM development, the latter is used by SELinux, so the
former is now used for AppArmor and libapparmor will search on the new path
to find the current profile if the kernel exposes it.

Also adjust snapd's apparmor package to use the new path if it exists.

See for example this failure on groovy from this morning:

```
2020-09-24T14:54:00.2774085Z ##[error]2020-09-24 14:54:00 Error executing google:ubuntu-20.10-64:tests/main/snap-run (sep241419-302260) :  
2020-09-24T14:54:00.2799269Z ----- 
2020-09-24T14:54:00.2799822Z + echo 'Running a trivial command causes no DENIED messages' 
2020-09-24T14:54:00.2800257Z Running a trivial command causes no DENIED messages 
2020-09-24T14:54:00.2800783Z + test-snapd-sh.sh -c 'echo hello' 
2020-09-24T14:54:00.2801067Z hello 2020-09-24T14:54:00.2801317Z + not grep DENIED 
2020-09-24T14:54:00.2801615Z + dmesg 
2020-09-24T14:54:00.2802696Z [ 2050.309731] audit: type=1400 audit(1600959240.108:1493): apparmor="DENIED" operation="open" profile="/snap/core/10045/usr/lib/snapd/snap-confine" name="/proc/109735/attr/apparmor/current" pid=109735 comm="snap-confine" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```

CC @jdstrand who explained the issue over IRC