### PR TITLE
tests/core/snap-debug-bootvars: also check snap_mode

### DIFF
--- a/tests/core/snap-debug-bootvars/task.yaml
+++ b/tests/core/snap-debug-bootvars/task.yaml
@@ -36,4 +36,6 @@ execute: |
     else
         MATCH 'snap_core=core.*\.snap' < default.out
         MATCH 'snap_kernel=pc-kernel.*\.snap' < default.out
+        # relevant snaps are not being updated, so snap_mode is unset
+        MATCH 'snap_mode=$' < default.out
     fi


### PR DESCRIPTION
As requested in #9408, also check that snap_mode is unset in a non-update scenario.

