### PR TITLE
o/snapshotstate: set snapshot set id from its filename

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -171,8 +171,11 @@ func Filename(snapshot *client.Snapshot) string {
 	return filepath.Join(dirs.SnapshotsDir, fmt.Sprintf("%d_%s_%s_%s.zip", snapshot.SetID, snapshot.Snap, snapshot.Version, snapshot.Revision))
 }
 
-func isSnapshotFilename(fname string) (ok bool, setID uint64) {
-	fname = filepath.Base(fname)
+// isSnapshotFilename checks if the given filePath is a snapshot file name, i.e.
+// if it starts with a numeric set id and ends with .zip extension;
+// filePath can be just a file name, or a full path.
+func isSnapshotFilename(filePath string) (ok bool, setID uint64) {
+	fname := filepath.Base(filePath)
 	// XXX: we could use a regexp here to match very precisely all the elements
 	// of the filename following Filename() above, but perhaps it's better no to
 	// go overboard with it in case the format evolves in the future. Only check

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -103,7 +103,7 @@ func Iter(ctx context.Context, f func(*Reader) error) error {
 			}
 
 			// filter out non-snapshot directory entries
-			ok, setID := isSnapshotFilename(name)
+			ok, _ := isSnapshotFilename(name)
 			if !ok {
 				continue
 			}
@@ -114,13 +114,6 @@ func Iter(ctx context.Context, f func(*Reader) error) error {
 			// check and either ignore or return an error when
 			// finding a broken snapshot.
 			if reader != nil {
-				if reader.SetID != setID && openError == nil {
-					// ignore snapshots where set id of the filename disagree
-					// with internal set id. This may be the case in the future
-					// with new enhanced snapshot format.
-					logger.Noticef("Snapshot %q ignored, internal set-id %d disagrees with filename", name, reader.SetID)
-					continue
-				}
 				err = f(reader)
 			} else {
 				// TODO: use warnings instead
@@ -179,6 +172,7 @@ func Filename(snapshot *client.Snapshot) string {
 }
 
 func isSnapshotFilename(fname string) (ok bool, setID uint64) {
+	fname = filepath.Base(fname)
 	// XXX: we could use a regexp here to match very precisely all the elements
 	// of the filename following Filename() above, but perhaps it's better no to
 	// go overboard with it in case the format evolves in the future. Only check

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -365,40 +365,6 @@ func readerForFilename(fname string, c *check.C) *backend.Reader {
 	}
 }
 
-func (s *snapshotSuite) TestIterIgnoresSnapshotsWithSetIdMismatches(c *check.C) {
-	defer backend.MockOsOpen(func(string) (*os.File, error) {
-		return new(os.File), nil
-	})()
-	readNames := 0
-	defer backend.MockDirNames(func(*os.File, int) ([]string, error) {
-		readNames++
-		if readNames > 1 {
-			return nil, io.EOF
-		}
-		return []string{
-			"1_foo.zip",
-			"2_bar.zip"}, nil
-	})()
-	defer backend.MockOpen(func(fname string) (*backend.Reader, error) {
-		r := readerForFilename(fname, c)
-		if r.SetID == 1 {
-			r.SetID = 99
-		}
-		return r, nil
-	})()
-
-	var calledF int
-	f := func(snapshot *backend.Reader) error {
-		calledF++
-		c.Check(snapshot.SetID, check.Equals, uint64(2))
-		return nil
-	}
-
-	err := backend.Iter(context.Background(), f)
-	c.Check(err, check.IsNil)
-	c.Check(calledF, check.Equals, 1)
-}
-
 func (s *snapshotSuite) TestIterIgnoresSnapshotsWithInvalidNames(c *check.C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()

--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -84,6 +84,15 @@ func Open(fn string) (reader *Reader, e error) {
 		return nil, err
 	}
 
+	// XXX: this mirrors the check from Iter()
+	ok, setID := isSnapshotFilename(fn)
+	if !ok {
+		return nil, fmt.Errorf("not a snapshot filename: %q", fn)
+	}
+	// set id from the filename has the authority and overrides the one from
+	// meta file.
+	reader.SetID = setID
+
 	// OK, from here on we have a Snapshot
 
 	if !reader.IsValid() {

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -134,5 +134,7 @@ execute: |
     # rename the snapshot file to force a new set id.
     mv "$SNAPSHOT_FILE" "$NEWSNAPSHOT_FILE"
     snap saved | MATCH "123 +test-snapd-sh"
-    snap saved --id=123 | grep test-snapd-sh
+    # make sure there is just one such snapshot
+    [[ $(snap saved | grep test-snapd-sh | wc -l) == "1" ]]
+    snap saved --id=123 | MATCH "123 .+test-snapd-sh"
     snap restore 123 test-snapd-sh

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -125,3 +125,14 @@ execute: |
     # the io.Copy uses a 32k buffer, so extra memory usage should be limited.
     # The threshold in this test is set to about 40MB
     test "$(cat memory-kb.txt)" -lt 40000
+
+    # check that snapshot set id from the filename has authority
+    snap install test-snapd-sh
+    snap save test-snapd-sh
+    SNAPSHOT_FILE=$(ls /var/lib/snapd/snapshots/*test-snapd-sh*.zip)
+    NEWSNAPSHOT_FILE=$(echo "$SNAPSHOT_FILE" | sed -e's/[1-9]\+_/123_/')
+    # rename the snapshot file to force a new set id.
+    mv "$SNAPSHOT_FILE" "$NEWSNAPSHOT_FILE"
+    snap saved | MATCH "123 +test-snapd-sh"
+    snap saved --id=123 | grep test-snapd-sh
+    snap restore 123 test-snapd-sh

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -135,6 +135,6 @@ execute: |
     mv "$SNAPSHOT_FILE" "$NEWSNAPSHOT_FILE"
     snap saved | MATCH "123 +test-snapd-sh"
     # make sure there is just one such snapshot
-    [[ $(snap saved | grep test-snapd-sh | wc -l) == "1" ]]
+    [[ $(snap saved | grep -c test-snapd-sh) == "1" ]]
     snap saved --id=123 | MATCH "123 .+test-snapd-sh"
     snap restore 123 test-snapd-sh


### PR DESCRIPTION
Set set id from snapshot filename, which overrides set id read from meta. This change is annoying to unit-test currently, so I've provided spread check.

Also remove part of the iteration check landed previously as it won't be needed after this change. 