### PR TITLE
tests/nested/manual/preseed: include a system-usernames snap when preseeding

### DIFF
--- a/osutil/group.go
+++ b/osutil/group.go
@@ -76,6 +76,18 @@ func getent(database, name string) (uint64, error) {
 	return strconv.ParseUint(string(parts[2]), 10, 64)
 }
 
+// TODO: both findUidNoGetentFallback and findGidNoGetentFallback should return
+//       a more qualified default value than uint64, because currently the
+//       default return value for findUid is "0" as per Go conventions, which is
+//       unfortunately also the uid of root, so if a caller ignored the error
+//       from this function and used that to perform access authorization, then
+//       the caller would accidentally provide the same access level as root in
+//       the error case. This is excaberated by the fact that the error case is
+//       very difficult to positively identify correctly as "not found", see the
+//       comments inside the functions for more details.
+// Note: there is a similar implementation in overlord/snapshotstate which
+//       should be similarly adjusted when resolving the above TODO.
+
 var findUidNoGetentFallback = func(username string) (uint64, error) {
 	myuser, err := user.Lookup(username)
 	if err != nil {

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -41,6 +41,13 @@ prepare: |
   mv snapd-from-deb.snap snapd.snap
   inject_snap_into_seed "$IMAGE_MOUNTPOINT" snapd
 
+  # inject a snap that uses system-usernames into the seed to confirm that works
+  # as expected
+  # TODO: replace this snap with a simpler one instead that is smaller, this one
+  # is 37M, but test-snapd-daemon-user does not have a daemon yet
+  snap download --edge --basename=test-postgres-system-usernames test-postgres-system-usernames
+  inject_snap_into_seed "$IMAGE_MOUNTPOINT" test-postgres-system-usernames
+
   # for images that are already preseeded, we need to undo the preseeding there
   echo "Running preseed --reset for already preseeded cloud images"
   SNAPD_DEBUG=1 /usr/lib/snapd/snap-preseed --reset "$IMAGE_MOUNTPOINT"
@@ -119,3 +126,9 @@ execute: |
   nested_exec "snap services" | MATCH "lxd.daemon +enabled +inactive +socket-activated"
   nested_exec "sudo lxd init --auto"
   nested_exec "snap services" | MATCH "+lxd.daemon +enabled +active +socket-activated"
+
+  echo "Checking that the test-postgres-system-usernames snap is operational"
+  nested_exec "sudo snap start --enable test-postgres-system-usernames.postgres"
+  # wait for postgres to come online
+  sleep 10
+  nested_exec "snap services" | MATCH "+test-postgres-system-usernames.postgres +enabled +active"


### PR DESCRIPTION
This exercises additional logic that must be taken care of when seeding vs
preseeding which was buggy (but was subsequently fixed in both the upstream
livecd-rootfs and now in snapd).

Also adds a TODO as requested in https://github.com/snapcore/snapd/pull/9041#discussion_r495805547