### PR TITLE
cmd/snap: allow snap help vs --all to diverge purposefully

### DIFF
--- a/cmd/snap/cmd_create_cohort.go
+++ b/cmd/snap/cmd_create_cohort.go
@@ -26,7 +26,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 )
 
-var shortCreateCohortHelp = i18n.G("Create cohort keys for a series of snaps")
+var shortCreateCohortHelp = i18n.G("Create cohort keys for a set of snaps")
 var longCreateCohortHelp = i18n.G(`
 The create-cohort command creates a set of cohort keys for a given set of snaps.
 

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -172,7 +172,7 @@ func (cmd cmdHelp) Execute(args []string) error {
 type helpCategory struct {
 	Label string
 	// Other is set if the category Commands should be listed
-	// together under "...Other" in the `snap help` list.
+	// together under "... Other" in the `snap help` list.
 	Other       bool
 	Description string
 	// Commands list commands belonging to the category that should
@@ -192,7 +192,7 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("...more"),
 		Description: i18n.G("slightly more advanced snap management"),
-		Commands:    []string{"refresh", "revert", "switch", "disable", "enable"},
+		Commands:    []string{"refresh", "revert", "switch", "disable", "enable", "create-cohort"},
 	}, {
 		Label:       i18n.G("History"),
 		Description: i18n.G("manage system change transactions"),
@@ -226,11 +226,6 @@ var helpCategories = []helpCategory{
 		Description: i18n.G("manage device"),
 		Commands:    []string{"model", "reboot", "recovery"},
 	}, {
-		Label:           i18n.G("Special Purpose"),
-		Description:     i18n.G("special activities"),
-		AllOnlyCommands: []string{"create-cohort", "prepare-image"},
-	},
-	{
 		Label:       i18n.G("Warnings"),
 		Other:       true,
 		Description: i18n.G("manage warnings"),
@@ -242,15 +237,16 @@ var helpCategories = []helpCategory{
 		Commands:    []string{"known", "ack"},
 	}, {
 		Label:           i18n.G("Introspection"),
-		Other: true,
-		Description:     i18n.G("introspection and debugging"),
+		Other:           true,
+		Description:     i18n.G("introspection and debugging of snapd"),
 		Commands:        []string{"version"},
 		AllOnlyCommands: []string{"debug"},
 	},
 	{
-		Label:       i18n.G("Development"),
-		Description: i18n.G("developer-oriented features"),
-		Commands:    []string{"download", "pack", "run", "try"},
+		Label:           i18n.G("Development"),
+		Description:     i18n.G("developer-oriented features"),
+		Commands:        []string{"download", "pack", "run", "try"},
+		AllOnlyCommands: []string{"prepare-image"},
 	},
 }
 
@@ -261,17 +257,18 @@ Snaps are packages that work across many different Linux distributions,
 enabling secure delivery and operation of the latest apps and utilities.
 `))
 	snapUsage               = i18n.G("Usage: snap <command> [<options>...]")
-	snapHelpCategoriesIntro = i18n.G("Commands can be classified as follows:")
+	snapHelpCategoriesIntro = i18n.G("Commonly used commands can be classified as follows:")
+	snapHelpAllIntro        = i18n.G("Commands can be classified as follows:")
 	snapHelpAllFooter       = i18n.G("For more information about a command, run 'snap help <command>'.")
 	snapHelpFooter          = i18n.G("For a short summary of all commands, run 'snap help --all'.")
 )
 
-func printHelpHeader() {
+func printHelpHeader(cmdsIntro string) {
 	fmt.Fprintln(Stdout, longSnapDescription)
 	fmt.Fprintln(Stdout)
 	fmt.Fprintln(Stdout, snapUsage)
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, snapHelpCategoriesIntro)
+	fmt.Fprintln(Stdout, cmdsIntro)
 	fmt.Fprintln(Stdout)
 }
 
@@ -287,8 +284,8 @@ func printHelpFooter() {
 
 // this is called when the Execute returns a flags.Error with ErrCommandRequired
 func printShortHelp() {
-	printHelpHeader()
-	maxLen := utf8.RuneCountInString("...Other")
+	printHelpHeader(snapHelpCategoriesIntro)
+	maxLen := utf8.RuneCountInString("... Other")
 	var otherCommands []string
 	var develCateg *helpCategory
 	for _, categ := range helpCategories {
@@ -311,9 +308,9 @@ func printShortHelp() {
 		}
 		fmt.Fprintf(Stdout, "%*s: %s\n", maxLen+2, categ.Label, strings.Join(categ.Commands, ", "))
 	}
-	// ...Other
+	// ... Other
 	if len(otherCommands) > 0 {
-		fmt.Fprintf(Stdout, "%*s: %s\n", maxLen+2, "...Other", strings.Join(otherCommands, ", "))
+		fmt.Fprintf(Stdout, "%*s: %s\n", maxLen+2, "... Other", strings.Join(otherCommands, ", "))
 	}
 	// Development last
 	if develCateg != nil && len(develCateg.Commands) > 0 {
@@ -324,7 +321,7 @@ func printShortHelp() {
 
 // this is "snap help --all"
 func printLongHelp(parser *flags.Parser) {
-	printHelpHeader()
+	printHelpHeader(snapHelpAllIntro)
 	maxLen := 0
 	for _, categ := range helpCategories {
 		for _, command := range categ.Commands {

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -170,9 +170,17 @@ func (cmd cmdHelp) Execute(args []string) error {
 }
 
 type helpCategory struct {
-	Label       string
+	Label string
+	// Other is set if the category Commands should be listed
+	// together under "...Other" in the `snap help` list.
+	Other       bool
 	Description string
-	Commands    []string
+	// Commands list commands belonging to the category that should
+	// be listed under both `snap help` and "snap help --all`.
+	Commands []string
+	// AllOnlyCommands list commands belonging to the category that should
+	// be listed only under "snap help --all`.
+	AllOnlyCommands []string
 }
 
 // helpCategories helps us by grouping commands
@@ -184,7 +192,7 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("...more"),
 		Description: i18n.G("slightly more advanced snap management"),
-		Commands:    []string{"refresh", "revert", "switch","disable", "enable"},
+		Commands:    []string{"refresh", "revert", "switch", "disable", "enable"},
 	}, {
 		Label:       i18n.G("History"),
 		Description: i18n.G("manage system change transactions"),
@@ -218,13 +226,31 @@ var helpCategories = []helpCategory{
 		Description: i18n.G("manage device"),
 		Commands:    []string{"model", "reboot", "recovery"},
 	}, {
-		Label:       i18n.G("Other"),
-		Description: i18n.G("miscellanea"),
-		Commands:    []string{"version", "warnings", "okay", "ack", "known", "create-cohort"},
+		Label:           i18n.G("Special Purpose"),
+		Description:     i18n.G("special activities"),
+		AllOnlyCommands: []string{"create-cohort", "prepare-image"},
+	},
+	{
+		Label:       i18n.G("Warnings"),
+		Other:       true,
+		Description: i18n.G("manage warnings"),
+		Commands:    []string{"warnings", "okay"},
 	}, {
+		Label:       i18n.G("Assertions"),
+		Other:       true,
+		Description: i18n.G("manage assertions"),
+		Commands:    []string{"known", "ack"},
+	}, {
+		Label:           i18n.G("Introspection"),
+		Other: true,
+		Description:     i18n.G("introspection and debugging"),
+		Commands:        []string{"version"},
+		AllOnlyCommands: []string{"debug"},
+	},
+	{
 		Label:       i18n.G("Development"),
 		Description: i18n.G("developer-oriented features"),
-		Commands:    []string{"download", "pack", "run", "try", "prepare-image"},
+		Commands:    []string{"download", "pack", "run", "try"},
 	},
 }
 
@@ -262,14 +288,36 @@ func printHelpFooter() {
 // this is called when the Execute returns a flags.Error with ErrCommandRequired
 func printShortHelp() {
 	printHelpHeader()
-	maxLen := 0
+	maxLen := utf8.RuneCountInString("...Other")
+	var otherCommands []string
+	var develCateg *helpCategory
 	for _, categ := range helpCategories {
+		if categ.Other {
+			otherCommands = append(otherCommands, categ.Commands...)
+			continue
+		}
+		if categ.Label == "Development" {
+			develCateg = &categ
+		}
 		if l := utf8.RuneCountInString(categ.Label); l > maxLen {
 			maxLen = l
 		}
 	}
+
 	for _, categ := range helpCategories {
+		// Other and Development will come last
+		if categ.Other || categ.Label == "Development" || len(categ.Commands) == 0 {
+			continue
+		}
 		fmt.Fprintf(Stdout, "%*s: %s\n", maxLen+2, categ.Label, strings.Join(categ.Commands, ", "))
+	}
+	// ...Other
+	if len(otherCommands) > 0 {
+		fmt.Fprintf(Stdout, "%*s: %s\n", maxLen+2, "...Other", strings.Join(otherCommands, ", "))
+	}
+	// Development last
+	if develCateg != nil && len(develCateg.Commands) > 0 {
+		fmt.Fprintf(Stdout, "%*s: %s\n", maxLen+2, "Development", strings.Join(develCateg.Commands, ", "))
 	}
 	printHelpFooter()
 }
@@ -284,6 +332,11 @@ func printLongHelp(parser *flags.Parser) {
 				maxLen = l
 			}
 		}
+		for _, command := range categ.AllOnlyCommands {
+			if l := len(command); l > maxLen {
+				maxLen = l
+			}
+		}
 	}
 
 	// flags doesn't have a LookupCommand?
@@ -293,10 +346,8 @@ func printLongHelp(parser *flags.Parser) {
 		cmdLookup[cmd.Name] = cmd
 	}
 
-	for _, categ := range helpCategories {
-		fmt.Fprintln(Stdout)
-		fmt.Fprintf(Stdout, "  %s (%s):\n", categ.Label, categ.Description)
-		for _, name := range categ.Commands {
+	listCmds := func(cmds []string) {
+		for _, name := range cmds {
 			cmd := cmdLookup[name]
 			if cmd == nil {
 				fmt.Fprintf(Stderr, "??? Cannot find command %q mentioned in help categories, please report!\n", name)
@@ -304,6 +355,13 @@ func printLongHelp(parser *flags.Parser) {
 				fmt.Fprintf(Stdout, "    %*s  %s\n", -maxLen, name, cmd.ShortDescription)
 			}
 		}
+	}
+
+	for _, categ := range helpCategories {
+		fmt.Fprintln(Stdout)
+		fmt.Fprintf(Stdout, "  %s (%s):\n", categ.Label, categ.Description)
+		listCmds(categ.Commands)
+		listCmds(categ.AllOnlyCommands)
 	}
 	printHelpAllFooter()
 }

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -269,7 +269,6 @@ func printHelpHeader(cmdsIntro string) {
 	fmt.Fprintln(Stdout, snapUsage)
 	fmt.Fprintln(Stdout)
 	fmt.Fprintln(Stdout, cmdsIntro)
-	fmt.Fprintln(Stdout)
 }
 
 func printHelpAllFooter() {
@@ -301,6 +300,7 @@ func printShortHelp() {
 		}
 	}
 
+	fmt.Fprintln(Stdout)
 	for _, categ := range helpCategories {
 		// Other and Development will come last
 		if categ.Other || categ.Label == "Development" || len(categ.Commands) == 0 {

--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -135,14 +135,18 @@ func (s *SnapSuite) TestHelpCategories(c *check.C) {
 		categorised[cmd] = true
 	}
 	seen := make(map[string]string, len(all))
-	for _, categ := range snap.HelpCategories {
-		for _, cmd := range categ.Commands {
+	seenCmds := func(cmds []string, label string) {
+		for _, cmd := range cmds {
 			categorised[cmd] = true
 			if seen[cmd] != "" {
-				c.Errorf("duplicated: %q in %q and %q", cmd, seen[cmd], categ.Label)
+				c.Errorf("duplicated: %q in %q and %q", cmd, seen[cmd], label)
 			}
-			seen[cmd] = categ.Label
+			seen[cmd] = label
 		}
+	}
+	for _, categ := range snap.HelpCategories {
+		seenCmds(categ.Commands, categ.Label)
+		seenCmds(categ.AllOnlyCommands, categ.Label)
 	}
 	for cmd := range all {
 		if !categorised[cmd] {
@@ -150,7 +154,7 @@ func (s *SnapSuite) TestHelpCategories(c *check.C) {
 		}
 	}
 	for cmd := range categorised {
-		if !all[cmd] {
+		if !all[cmd] && cmd != "debug" {
 			c.Errorf("unknown (hidden?): %q", cmd)
 		}
 	}

--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -54,7 +54,9 @@ func (s *SnapSuite) TestHelpPrintsHelp(c *check.C) {
 			snap.LongSnapDescription,
 			"",
 			regexp.QuoteMeta(snap.SnapUsage),
-			"", ".*", "",
+			"",
+			snap.SnapHelpCategoriesIntro,
+			".*", "",
 			snap.SnapHelpAllFooter,
 			snap.SnapHelpFooter,
 		}, "\n")+`\s*`, comment)
@@ -75,7 +77,7 @@ func (s *SnapSuite) TestHelpAllPrintsLongHelp(c *check.C) {
 		"",
 		regexp.QuoteMeta(snap.SnapUsage),
 		"",
-		snap.SnapHelpCategoriesIntro,
+		snap.SnapHelpAllIntro,
 		"", ".*", "",
 		snap.SnapHelpAllFooter,
 	}, "\n")+`\s*`)
@@ -154,7 +156,7 @@ func (s *SnapSuite) TestHelpCategories(c *check.C) {
 		}
 	}
 	for cmd := range categorised {
-		if !all[cmd] && cmd != "debug" {
+		if !all[cmd] {
 			c.Errorf("unknown (hidden?): %q", cmd)
 		}
 	}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -72,6 +72,7 @@ var (
 	LongSnapDescription     = longSnapDescription
 	SnapUsage               = snapUsage
 	SnapHelpCategoriesIntro = snapHelpCategoriesIntro
+	SnapHelpAllIntro        = snapHelpAllIntro
 	SnapHelpAllFooter       = snapHelpAllFooter
 	SnapHelpFooter          = snapHelpFooter
 	HelpCategories          = helpCategories

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -350,7 +350,6 @@ func Parser(cli *client.Client) *flags.Parser {
 	})
 	// Add the debug command
 	debugCommand, err := parser.AddCommand("debug", shortDebugHelp, longDebugHelp, &cmdDebug{})
-	debugCommand.Hidden = true
 	if err != nil {
 		logger.Panicf("cannot add command %q: %v", "debug", err)
 	}


### PR DESCRIPTION
this allows two things:

  * for some commands (and possibly entire categories) to appear only
    under `snap help --all`
  * to split in precise categories the commands that appear under
    "...Other" (now) in `snap help`

it makes "snap debug" not hidden anymore and makes it appear under --all.

