### PR TITLE
tests: fix nested core20 shellcheck bug

### DIFF
--- a/tests/nested/core20/basic/task.yaml
+++ b/tests/nested/core20/basic/task.yaml
@@ -30,4 +30,4 @@ execute: |
     nested_exec "sudo snap remove test-snapd-sh" || true
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is removed"
-    ! nested_exec "snap list test-snapd-sh"
+    nested_exec "! snap list test-snapd-sh"


### PR DESCRIPTION
The usage of "!" in tests/nested/core20/basic/task.yaml is incorrect.
