### PR TITLE
tests: fix sudo-env test

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -67,6 +67,10 @@ create_test_user(){
     fi
     unset owner
 
+    # Add a new line first to prevent an error which happens when
+    # the file has not new line, and we see this:
+    # syntax error, unexpected WORD, expecting END or ':' or '\n'
+    echo >> /etc/sudoers
     echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
     chown test.test -R "$SPREAD_PATH"


### PR DESCRIPTION
This change adds a new line in the /etc/sudoers file to prevent an error
which is happening in Debian and fedora after the latest updates:
    # syntax error, unexpected WORD, expecting END or ':' or '\n'

The error:

Error: 2020-09-28 21:54:59 Error executing
google:debian-sid-64:tests/main/sudo-env (sep282050-048295) :
...
> tests.session -u test exec sudo sh -c 'echo :$PATH:'
/etc/sudoers:28: syntax error, unexpected WORD, expecting END or ':' or
'\n'
test ALL=(ALL) NOPASSWD:ALL
^~~~

...