### PR TITLE
boot: look at the gadget for run mode bootloader when making the system bootable

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -294,9 +294,13 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		// run partition layout, no /boot mount.
 		NoSlashBoot: true,
 	}
-	bl, err := bootloader.Find(InitramfsUbuntuBootDir, opts)
+	// the bootloader config may have been installed when the ubuntu-boot
+	// partition was created, but for a trusted assets the bootloader config
+	// will be installed further down; for now identify the run mode
+	// bootloader by looking at the gadget
+	bl, err := bootloader.ForGadget(bootWith.UnpackedGadgetDir, InitramfsUbuntuBootDir, opts)
 	if err != nil {
-		return fmt.Errorf("internal error: cannot find run system bootloader: %v", err)
+		return fmt.Errorf("internal error: cannot identify run system bootloader: %v", err)
 	}
 
 	// extract the kernel first and mark kernel_status ready

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -582,9 +582,9 @@ version: 5.0
 		UnpackedGadgetDir: unpackedGadgetDir,
 	}
 
-	// no grub cfg in gadget directory raises an error
+	// no grub marker in gadget directory raises an error
 	err = boot.MakeBootable(model, s.rootdir, bootWith, nil)
-	c.Assert(err, ErrorMatches, "cannot install boot config with a mismatched gadget")
+	c.Assert(err, ErrorMatches, "internal error: cannot identify run system bootloader: cannot determine bootloader")
 
 	// set up grub.cfg in gadget
 	grubCfg := []byte("#grub cfg")
@@ -882,7 +882,7 @@ version: 5.0
 	)
 }
 
-func (s *makeBootable20UbootSuite) TestUbootMakeBootable20RunModeBootScr(c *C) {
+func (s *makeBootable20UbootSuite) TestUbootMakeBootable20RunModeBootSel(c *C) {
 	bootloader.Force(nil)
 
 	model := boottest.MakeMockUC20Model()
@@ -898,13 +898,16 @@ func (s *makeBootable20UbootSuite) TestUbootMakeBootable20RunModeBootScr(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(env.Save(), IsNil)
 
-	// uboot on ubuntu-boot
+	// uboot on ubuntu-boot (as if it was installed when creating the partition)
 	mockBootUbootBootSel := filepath.Join(boot.InitramfsUbuntuBootDir, "uboot/ubuntu/boot.sel")
 	err = os.MkdirAll(filepath.Dir(mockBootUbootBootSel), 0755)
 	c.Assert(err, IsNil)
 	env, err = ubootenv.Create(mockBootUbootBootSel, 4096)
 	c.Assert(err, IsNil)
 	c.Assert(env.Save(), IsNil)
+
+	unpackedGadgetDir := c.MkDir()
+	c.Assert(ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), nil, 0644), IsNil)
 
 	baseFn, baseInfo := makeSnap(c, "core20", `name: core20
 type: base
@@ -934,8 +937,8 @@ version: 5.0
 		KernelPath:        kernelInSeed,
 		Kernel:            kernelInfo,
 		Recovery:          false,
+		UnpackedGadgetDir: unpackedGadgetDir,
 	}
-
 	err = boot.MakeBootable(model, s.rootdir, bootWith, nil)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
When setting up a UC20 run mode system, the bootloader config may have been
installed when populating the ubuntu-boot partition. However, for trusted assets
bootloader which have their configuration managed directly by snapd, the config
will only be installed though an explicit call to InstallBootConfig().

Tweak the code to use the gadget snap to identify the right bootloader.

Split out from #9427 
