### PR TITLE
  gadget: preserve files when indicated by content change observer 

### DIFF
--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -199,7 +199,7 @@ func (m *MountedFilesystemWriter) observedWriteFileOrSymlink(volumeRoot, src, ds
 	if err != nil {
 		return fmt.Errorf("cannot observe file write: %v", err)
 	}
-	if act == ChangePreserveBefore {
+	if act == ChangeIgnore {
 		return nil
 	}
 	return writeFileOrSymlink(src, dst, preserveInDst)
@@ -635,7 +635,7 @@ func (f *mountedFilesystemUpdater) checkpointPrefix(dstRoot, target string, back
 	return nil
 }
 
-func (f *mountedFilesystemUpdater) preserveChangeContent(change *ContentChange, backupPath string) error {
+func (f *mountedFilesystemUpdater) ignoreChange(change *ContentChange, backupPath string) error {
 	preserveStamp := backupPath + ".preserve"
 	backupName := backupPath + ".backup"
 	sameStamp := backupPath + ".same"
@@ -661,10 +661,10 @@ func (f *mountedFilesystemUpdater) observedBackupOrCheckpointFile(dstRoot, sourc
 		if err != nil {
 			return fmt.Errorf("cannot observe pending file write %v\n", err)
 		}
-		if act == ChangePreserveBefore {
-			// observer asked for the change to be preserved
-			if err := f.preserveChangeContent(change, backupPath); err != nil {
-				return fmt.Errorf("cannot preserve change content: %v", err)
+		if act == ChangeIgnore {
+			// observer asked for the change to be ignored
+			if err := f.ignoreChange(change, backupPath); err != nil {
+				return fmt.Errorf("cannot ignore content change: %v", err)
 			}
 		}
 	}

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -615,7 +615,8 @@ func (f *mountedFilesystemUpdater) Backup() error {
 		return fmt.Errorf("cannot create backup directory: %v", err)
 	}
 
-	preserveInDst, err := mapPreserve(f.mountPoint, f.ps.Update.Preserve)
+	preserveInDst, err := mapPreserve(f.mountPoint,
+		append(f.ps.Update.Preserve, f.managedBootAssets...))
 	if err != nil {
 		return fmt.Errorf("cannot map preserve entries for mount location %q: %v", f.mountPoint, err)
 	}

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
@@ -303,9 +304,10 @@ type mountLookupFunc func(ps *LaidOutStructure) (string, error)
 // backup copies of files, newly created directories are removed
 type mountedFilesystemUpdater struct {
 	*MountedFilesystemWriter
-	backupDir      string
-	mountPoint     string
-	updateObserver ContentObserver
+	backupDir         string
+	mountPoint        string
+	managedBootAssets []string
+	updateObserver    ContentObserver
 }
 
 // newMountedFilesystemUpdater returns an updater for given filesystem
@@ -328,11 +330,17 @@ func newMountedFilesystemUpdater(rootDir string, ps *LaidOutStructure, backupDir
 	if err != nil {
 		return nil, fmt.Errorf("cannot find mount location of structure %v: %v", ps, err)
 	}
+	// find out if we need to preserve any boot assets
+	bootAssets, err := maybePreserveManagedBootAssets(mount, ps)
+	if err != nil {
+		return nil, fmt.Errorf("cannot preserve managed boot assets: %v", err)
+	}
 
 	fu := &mountedFilesystemUpdater{
 		MountedFilesystemWriter: fw,
 		backupDir:               backupDir,
 		mountPoint:              mount,
+		managedBootAssets:       bootAssets,
 		updateObserver:          observer,
 	}
 	return fu, nil
@@ -340,6 +348,52 @@ func newMountedFilesystemUpdater(rootDir string, ps *LaidOutStructure, backupDir
 
 func fsStructBackupPath(backupDir string, ps *LaidOutStructure) string {
 	return filepath.Join(backupDir, fmt.Sprintf("struct-%v", ps.Index))
+}
+
+func maybePreserveManagedBootAssets(mountPoint string, ps *LaidOutStructure) ([]string, error) {
+	if ps.Role != SystemSeed && ps.Role != SystemBoot {
+		return nil, nil
+	}
+	// TODO:UC20: this code should no longer be needed when we use
+	// the updater interface from boot, in particular we shouldn't
+	// try to find a bootloader from this place, we don't have
+	// quite enough info not to guess
+
+	// the assets are within the system-boot or system-seed partition, set
+	// the right flags so that files are looked for using their paths inside
+	// the partition
+	role := bootloader.RoleRecovery
+	if ps.Role == SystemBoot {
+		role = bootloader.RoleRunMode
+	}
+	opts := &bootloader.Options{
+		Role:        role,
+		NoSlashBoot: true,
+	}
+	bl, err := bootloader.Find(mountPoint, opts)
+	if err != nil {
+		if err == bootloader.ErrBootloader {
+			// no bootloader in the partition?
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
+	if !ok {
+		// bootloader implementation does not support managing its
+		// assets
+		return nil, nil
+	}
+	managed, err := tbl.IsCurrentlyManaged()
+	if err != nil {
+		return nil, err
+	}
+	if !managed {
+		// assets are not managed
+		return nil, nil
+	}
+	return tbl.ManagedAssets(), nil
 }
 
 // entryDestPaths resolves destination and backup paths for given
@@ -375,7 +429,8 @@ func (f *mountedFilesystemUpdater) entrySourcePath(source string) string {
 // Update applies an update to a mounted filesystem. The caller must have
 // executed a Backup() before, to prepare a data set for rollback purpose.
 func (f *mountedFilesystemUpdater) Update() error {
-	preserveInDst, err := mapPreserve(f.mountPoint, f.ps.Update.Preserve)
+	preserveInDst, err := mapPreserve(f.mountPoint,
+		append(f.ps.Update.Preserve, f.managedBootAssets...))
 	if err != nil {
 		return fmt.Errorf("cannot map preserve entries for mount location %q: %v", f.mountPoint, err)
 	}
@@ -819,7 +874,8 @@ func (f *mountedFilesystemUpdater) backupVolumeContent(volumeRoot string, conten
 func (f *mountedFilesystemUpdater) Rollback() error {
 	backupRoot := fsStructBackupPath(f.backupDir, f.ps)
 
-	preserveInDst, err := mapPreserve(f.mountPoint, f.ps.Update.Preserve)
+	preserveInDst, err := mapPreserve(f.mountPoint,
+		append(f.ps.Update.Preserve, f.managedBootAssets...))
 	if err != nil {
 		return fmt.Errorf("cannot map preserve entries for mount location %q: %v", f.mountPoint, err)
 	}

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -28,9 +28,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -134,8 +134,11 @@ func verifyDirContents(c *C, where string, expected map[string]contentType) {
 
 		return nil
 	})
-
-	c.Assert(got, DeepEquals, expected)
+	if len(expected) > 0 {
+		c.Assert(got, DeepEquals, expected)
+	} else {
+		c.Check(got, HasLen, 0)
+	}
 }
 
 func (s *mountedfilesystemTestSuite) TestWriteFile(c *C) {
@@ -250,10 +253,11 @@ type mockContentChange struct {
 }
 
 type mockWriteObserver struct {
-	content        map[string][]*mockContentChange
-	observeErr     error
-	expectedStruct *gadget.LaidOutStructure
-	c              *C
+	content         map[string][]*mockContentChange
+	preserveTargets []string
+	observeErr      error
+	expectedStruct  *gadget.LaidOutStructure
+	c               *C
 }
 
 func (m *mockWriteObserver) Observe(op gadget.ContentOperation, sourceStruct *gadget.LaidOutStructure,
@@ -276,6 +280,10 @@ func (m *mockWriteObserver) Observe(op gadget.ContentOperation, sourceStruct *ga
 
 	m.c.Assert(sourceStruct, NotNil)
 	m.c.Check(m.expectedStruct, DeepEquals, sourceStruct)
+
+	if strutil.ListContains(m.preserveTargets, relativeTargetPath) {
+		return gadget.ChangePreserveBefore, nil
+	}
 	return gadget.ChangeApply, m.observeErr
 }
 
@@ -662,6 +670,52 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterPreserve(c *C) {
 	verifyWrittenGadgetData(c, outDir, gdWritten)
 }
 
+func (s *mountedfilesystemTestSuite) TestMountedWriterPreserveWithObserver(c *C) {
+	// some data for the gadget
+	gd := []gadgetData{
+		{name: "foo", target: "foo-dir/foo", content: "foo from gadget"},
+	}
+	makeGadgetData(c, s.dir, gd)
+
+	outDir := filepath.Join(c.MkDir(), "out-dir")
+	makeSizedFile(c, filepath.Join(outDir, "foo"), 0, []byte("foo from disk"))
+
+	ps := &gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Size:       2048,
+			Filesystem: "ext4",
+			Content: []gadget.VolumeContent{
+				{
+					Source: "foo",
+					// would overwrite existing foo
+					Target: "foo",
+				}, {
+					Source: "foo",
+					// does not exist
+					Target: "foo-new",
+				},
+			},
+		},
+	}
+
+	obs := &mockWriteObserver{
+		c:              c,
+		expectedStruct: ps,
+		preserveTargets: []string{
+			"foo",
+			"foo-new",
+		},
+	}
+	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, obs)
+	c.Assert(err, IsNil)
+	c.Assert(rw, NotNil)
+
+	err = rw.Write(outDir, nil)
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from disk")
+	c.Check(filepath.Join(outDir, "foo-new"), testutil.FileEquals, "foo from gadget")
+}
+
 func (s *mountedfilesystemTestSuite) TestMountedWriterNonFilePreserveError(c *C) {
 	// some data for the gadget
 	gd := []gadgetData{
@@ -833,9 +887,15 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterSymlinks(c *C) {
 type mockContentUpdateObserver struct {
 	contentUpdate   map[string][]*mockContentChange
 	contentRollback map[string][]*mockContentChange
+	preserveTargets []string
 	observeErr      error
 	expectedStruct  *gadget.LaidOutStructure
 	c               *C
+}
+
+func (m *mockContentUpdateObserver) reset() {
+	m.contentUpdate = nil
+	m.contentRollback = nil
 }
 
 func (m *mockContentUpdateObserver) Observe(op gadget.ContentOperation, sourceStruct *gadget.LaidOutStructure,
@@ -870,7 +930,14 @@ func (m *mockContentUpdateObserver) Observe(op gadget.ContentOperation, sourceSt
 
 	m.c.Assert(sourceStruct, NotNil)
 	m.c.Check(m.expectedStruct, DeepEquals, sourceStruct)
-	return gadget.ChangeApply, m.observeErr
+
+	if m.observeErr != nil {
+		return gadget.ChangeAbort, m.observeErr
+	}
+	if strutil.ListContains(m.preserveTargets, relativeTargetPath) {
+		return gadget.ChangePreserveBefore, nil
+	}
+	return gadget.ChangeApply, nil
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupSimple(c *C) {
@@ -2512,6 +2579,10 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 		{name: "foo", target: "/foo", content: "data"},
 		{name: "boot-assets/some-dir/data", target: "data-copy", content: "data"},
 		{name: "boot-assets/nested-dir/nested", target: "/nested-copy/nested", content: "data"},
+		{name: "preserved/same-content", target: "preserved/same-content", content: "can't touch this"},
+	}
+	gdSameContent := []gadgetData{
+		{name: "foo", target: "/foo-same", content: "data"},
 	}
 	makeGadgetData(c, s.dir, append(gdWritten, gdNotWritten...))
 	err := os.MkdirAll(filepath.Join(s.dir, "boot-assets/empty-dir"), 0755)
@@ -2522,12 +2593,15 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 	makeExistingData(c, outDir, []gadgetData{
 		{target: "dtb", content: "updated"},
 		{target: "foo", content: "can't touch this"},
+		{target: "foo-same", content: "data"},
 		{target: "data-copy-preserved", content: "can't touch this"},
 		{target: "data-copy", content: "can't touch this"},
 		{target: "nested-copy/nested", content: "can't touch this"},
 		{target: "nested-copy/more-nested/"},
 		{target: "not-listed", content: "can't touch this"},
 		{target: "unrelated/data/here", content: "unrelated"},
+		{target: "preserved/same-content-for-list", content: "can't touch this"},
+		{target: "preserved/same-content-for-observer", content: "can't touch this"},
 	})
 	// these exist in the root directory and are preserved
 	preserve := []string{
@@ -2536,6 +2610,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 		"/data-copy-preserved",
 		"nested-copy/nested",
 		"not-listed", // not present in 'gadget' contents
+		"preserved/same-content-for-list",
 	}
 	// these are preserved, but don't exist in the root, so data from gadget
 	// will be written
@@ -2556,6 +2631,10 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 					// would overwrite /foo
 					Source: "foo",
 					Target: "/",
+				}, {
+					// nothing written, content is unchanged
+					Source: "foo",
+					Target: "/foo-same",
 				}, {
 					// preserved, but not present, will be
 					// written
@@ -2583,6 +2662,12 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 				}, {
 					Source: "/boot-assets/empty-dir/",
 					Target: "/lone-dir/nested/",
+				}, {
+					Source: "preserved/same-content",
+					Target: "preserved/same-content-for-list",
+				}, {
+					Source: "preserved/same-content",
+					Target: "preserved/same-content-for-observer",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2595,6 +2680,9 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 	muo := &mockContentUpdateObserver{
 		c:              c,
 		expectedStruct: ps,
+		preserveTargets: []string{
+			"preserved/same-content-for-observer",
+		},
 	}
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2604,14 +2692,17 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 	c.Assert(rw, NotNil)
 
 	originalState := map[string]contentType{
-		"foo":                     typeFile,
-		"dtb":                     typeFile,
-		"data-copy":               typeFile,
-		"not-listed":              typeFile,
-		"data-copy-preserved":     typeFile,
-		"nested-copy/nested":      typeFile,
-		"nested-copy/more-nested": typeDir,
-		"unrelated/data/here":     typeFile,
+		"foo":                                 typeFile,
+		"foo-same":                            typeFile,
+		"dtb":                                 typeFile,
+		"data-copy":                           typeFile,
+		"not-listed":                          typeFile,
+		"data-copy-preserved":                 typeFile,
+		"nested-copy/nested":                  typeFile,
+		"nested-copy/more-nested":             typeDir,
+		"unrelated/data/here":                 typeFile,
+		"preserved/same-content-for-list":     typeFile,
+		"preserved/same-content-for-observer": typeFile,
 	}
 	verifyDirContents(c, outDir, originalState)
 
@@ -2620,16 +2711,21 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 	c.Assert(err, IsNil)
 
 	verifyDirContents(c, filepath.Join(s.backup, "struct-0"), map[string]contentType{
-		"nested-copy.backup":             typeFile,
-		"nested-copy/nested.preserve":    typeFile,
-		"nested-copy/more-nested.backup": typeFile,
-		"foo.preserve":                   typeFile,
-		"data-copy-preserved.preserve":   typeFile,
-		"data-copy.backup":               typeFile,
-		"dtb.backup":                     typeFile,
+		"nested-copy.backup":                       typeFile,
+		"nested-copy/nested.preserve":              typeFile,
+		"nested-copy/more-nested.backup":           typeFile,
+		"foo.preserve":                             typeFile,
+		"foo-same.same":                            typeFile,
+		"data-copy-preserved.preserve":             typeFile,
+		"data-copy.backup":                         typeFile,
+		"dtb.backup":                               typeFile,
+		"preserved.backup":                         typeFile,
+		"preserved/same-content-for-list.preserve": typeFile,
+		"preserved/same-content-for-observer.same": typeFile,
 	})
 
 	expectedObservedContentChange := map[string][]*mockContentChange{
+		// observer is notified about changed and new files
 		outDir: {
 			{"foo-dir/foo", &gadget.ContentChange{
 				After: filepath.Join(s.dir, "foo"),
@@ -2698,6 +2794,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 
 	verifyDirContents(c, outDir, map[string]contentType{
 		"foo":        typeFile,
+		"foo-same":   typeFile,
 		"not-listed": typeFile,
 
 		// boot-assets/some-dir/data -> /data-copy
@@ -2739,6 +2836,9 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 
 		// boot-assets/empty-dir/ -> /lone-dir/nested/
 		"lone-dir/nested": typeDir,
+
+		"preserved/same-content-for-list":     typeFile,
+		"preserved/same-content-for-observer": typeFile,
 	})
 
 	// files that existed were preserved
@@ -2747,7 +2847,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 		c.Check(p, testutil.FileEquals, "can't touch this")
 	}
 	// everything else was written
-	verifyWrittenGadgetData(c, outDir, gdWritten)
+	verifyWrittenGadgetData(c, outDir, append(gdWritten, gdSameContent...))
 
 	err = rw.Rollback()
 	c.Assert(err, IsNil)
@@ -2905,7 +3005,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterNonFilePreserveError(c *C
 	c.Check(err, ErrorMatches, `cannot map preserve entries for mount location ".*/out-dir": preserved entry "foo" cannot be a directory`)
 }
 
-func (s *mountedfilesystemTestSuite) testMountedUpdaterGrubBootAssets(c *C, managed bool, role string, preserved bool) {
+func (s *mountedfilesystemTestSuite) TestMountedUpdaterObserverPreservesBootAssets(c *C) {
 	// mirror pc-amd64-gadget
 	gd := []gadgetData{
 		{name: "grub.conf", content: "grub.conf from gadget"},
@@ -2918,9 +3018,6 @@ func (s *mountedfilesystemTestSuite) testMountedUpdaterGrubBootAssets(c *C, mana
 
 	existingGrubCfg := `# Snapd-Boot-Config-Edition: 1
 managed grub.cfg from disk`
-	if !managed {
-		existingGrubCfg = `existing grub.cfg from disk`
-	}
 	makeExistingData(c, outDir, []gadgetData{
 		{target: "EFI/boot/grubx64.efi", content: "grubx64.efi from disk"},
 		{target: "EFI/ubuntu/grub.cfg", content: existingGrubCfg},
@@ -2930,7 +3027,7 @@ managed grub.cfg from disk`
 	ps := &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
 			Size:       2048,
-			Role:       role,
+			Role:       gadget.SystemBoot,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{Source: "grubx64.efi", Target: "EFI/boot/grubx64.efi"},
@@ -2943,14 +3040,20 @@ managed grub.cfg from disk`
 			},
 		},
 	}
+	obs := &mockContentUpdateObserver{
+		expectedStruct:  ps,
+		preserveTargets: []string{"EFI/ubuntu/grub.cfg"},
+	}
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup,
 		func(to *gadget.LaidOutStructure) (string, error) {
 			c.Check(to, DeepEquals, ps)
 			return outDir, nil
 		},
-		nil)
+		obs)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
+
+	preserveStamp := filepath.Join(s.backup, "struct-0/EFI/ubuntu/grub.cfg.preserve")
 
 	for _, step := range []struct {
 		name string
@@ -2969,73 +3072,156 @@ managed grub.cfg from disk`
 			c.Check(filepath.Join(outDir, "EFI/boot/grubx64.efi"), testutil.FileEquals, "grubx64.efi from disk")
 			c.Check(filepath.Join(outDir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals, existingGrubCfg)
 			c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from disk")
+			c.Check(preserveStamp, testutil.FilePresent)
 		case "update":
 			c.Check(filepath.Join(outDir, "EFI/boot/grubx64.efi"), testutil.FileEquals, "grubx64.efi from gadget")
-			if preserved {
-				c.Check(filepath.Join(outDir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals,
-					`# Snapd-Boot-Config-Edition: 1
+			c.Check(filepath.Join(outDir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals,
+				`# Snapd-Boot-Config-Edition: 1
 managed grub.cfg from disk`)
-			} else {
-				c.Check(filepath.Join(outDir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals,
-					`grub.conf from gadget`)
-			}
 			c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from disk")
+			c.Check(preserveStamp, testutil.FilePresent)
 		case "rollback":
 			c.Check(filepath.Join(outDir, "EFI/boot/grubx64.efi"), testutil.FileEquals, "grubx64.efi from disk")
 			c.Check(filepath.Join(outDir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals, existingGrubCfg)
 			c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from disk")
+			c.Check(preserveStamp, testutil.FilePresent)
 		default:
 			c.Fatalf("unexpected step: %q", step.name)
 		}
 	}
 }
 
-func (s *mountedfilesystemTestSuite) TestMountedUpdaterGrubBootAssetsManaged(c *C) {
-	managed := true
-	preserved := true
-	s.testMountedUpdaterGrubBootAssets(c, managed, gadget.SystemBoot, preserved)
-}
-
-func (s *mountedfilesystemTestSuite) TestMountedUpdaterGrubSeedAssetsManaged(c *C) {
-	managed := true
-	preserved := true
-	s.testMountedUpdaterGrubBootAssets(c, managed, gadget.SystemSeed, preserved)
-}
-
-func (s *mountedfilesystemTestSuite) TestMountedUpdaterGrubBootAssetsNotManaged(c *C) {
-	managed := false
-	preserved := false
-	s.testMountedUpdaterGrubBootAssets(c, managed, gadget.SystemSeed, preserved)
-}
-
-func (s *mountedfilesystemTestSuite) TestMountedUpdaterGrubBootAssetsManagedOtherRole(c *C) {
-	managed := true
-	preserved := false
-	s.testMountedUpdaterGrubBootAssets(c, managed, gadget.SystemData, preserved)
-}
-
-func (s *mountedfilesystemTestSuite) TestMountedUpdaterBootAssetsErr(c *C) {
-	outDir := filepath.Join(c.MkDir(), "out-dir")
-
-	bootloader.ForceError(errors.New("foo"))
-	defer bootloader.ForceError(nil)
+var (
 	// based on pc gadget
-	ps := &gadget.LaidOutStructure{
+	psForObserver = &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
 			Size:       2048,
 			Role:       gadget.SystemBoot,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "grubx64.efi", Target: "EFI/boot/grubx64.efi"},
-				{Source: "grub.conf", Target: "EFI/ubuntu/grub.cfg"},
+				{Source: "foo", Target: "foo"},
+			},
+			Update: gadget.VolumeUpdate{
+				Edition: 1,
 			},
 		},
 	}
-	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup,
+)
+
+func (s *mountedfilesystemTestSuite) TestMountedUpdaterObserverPreserveNewFile(c *C) {
+	gd := []gadgetData{
+		{name: "foo", content: "foo from gadget"},
+	}
+	makeGadgetData(c, s.dir, gd)
+
+	outDir := filepath.Join(c.MkDir(), "out-dir")
+
+	obs := &mockContentUpdateObserver{
+		expectedStruct:  psForObserver,
+		preserveTargets: []string{"foo"},
+	}
+	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, psForObserver, s.backup,
 		func(to *gadget.LaidOutStructure) (string, error) {
+			c.Check(to, DeepEquals, psForObserver)
 			return outDir, nil
 		},
-		nil)
-	c.Assert(err, ErrorMatches, "cannot preserve managed boot assets: foo")
-	c.Assert(rw, IsNil)
+		obs)
+	c.Assert(err, IsNil)
+	c.Assert(rw, NotNil)
+
+	expectedNewFileChanges := map[string][]*mockContentChange{
+		outDir: {
+			{"foo", &gadget.ContentChange{After: filepath.Join(s.dir, "foo")}},
+		},
+	}
+	// file does not exist
+	err = rw.Backup()
+	c.Assert(err, IsNil)
+	// no stamps
+	verifyDirContents(c, filepath.Join(s.backup, "struct-0"), nil)
+	// observer got notified about change
+	c.Assert(obs.contentUpdate, DeepEquals, expectedNewFileChanges)
+
+	obs.reset()
+
+	// try the same pass again
+	err = rw.Backup()
+	c.Assert(err, IsNil)
+	verifyDirContents(c, filepath.Join(s.backup, "struct-0"), nil)
+	// observer got notified about change
+	c.Assert(obs.contentUpdate, DeepEquals, expectedNewFileChanges)
+
+	obs.reset()
+	c.Assert(os.RemoveAll(filepath.Join(s.backup, "struct-0")), IsNil)
+
+	// file does not exist, so it gets written
+	err = rw.Update()
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from gadget")
+
+	// since it's a new file, it gets removed on rollback
+	err = rw.Rollback()
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(outDir, "foo"), testutil.FileAbsent)
+}
+
+func (s *mountedfilesystemTestSuite) TestMountedUpdaterObserverPreserveExistingFile(c *C) {
+	gd := []gadgetData{
+		{name: "foo", content: "foo from gadget"},
+	}
+	makeGadgetData(c, s.dir, gd)
+
+	outDir := filepath.Join(c.MkDir(), "out-dir")
+
+	obs := &mockContentUpdateObserver{
+		expectedStruct:  psForObserver,
+		preserveTargets: []string{"foo"},
+	}
+	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, psForObserver, s.backup,
+		func(to *gadget.LaidOutStructure) (string, error) {
+			c.Check(to, DeepEquals, psForObserver)
+			return outDir, nil
+		},
+		obs)
+	c.Assert(err, IsNil)
+	c.Assert(rw, NotNil)
+
+	// file exists now
+	makeExistingData(c, outDir, []gadgetData{
+		{target: "foo", content: "foo from disk"},
+	})
+	expectedExistingFileChanges := map[string][]*mockContentChange{
+		outDir: {
+			{"foo", &gadget.ContentChange{
+				After:  filepath.Join(s.dir, "foo"),
+				Before: filepath.Join(s.backup, "struct-0/foo.backup"),
+			}},
+		},
+	}
+	expectedExistingFileStamps := map[string]contentType{
+		"foo.preserve": typeFile,
+	}
+	err = rw.Backup()
+	c.Assert(err, IsNil)
+	verifyDirContents(c, filepath.Join(s.backup, "struct-0"), expectedExistingFileStamps)
+	// get notified about change
+	c.Assert(obs.contentUpdate, DeepEquals, expectedExistingFileChanges)
+
+	obs.reset()
+	// backup called again (eg. after reset)
+	err = rw.Backup()
+	c.Assert(err, IsNil)
+	verifyDirContents(c, filepath.Join(s.backup, "struct-0"), expectedExistingFileStamps)
+	// get notified about change
+	c.Assert(obs.contentUpdate, DeepEquals, expectedExistingFileChanges)
+
+	// and nothing gets updated
+	err = rw.Update()
+	c.Assert(err, Equals, gadget.ErrNoUpdate)
+	c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from disk")
+
+	// the file existed and was preserved, nothing gets removed on rollback
+	err = rw.Rollback()
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from disk")
 }

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -3067,6 +3067,20 @@ managed grub.cfg from disk`
 		nil)
 	c.Assert(err, IsNil)
 	c.Assert(rw, NotNil)
+	expectedFileStamps := map[string]contentType{
+		"EFI.backup":                  typeFile,
+		"EFI/boot/grubx64.efi.backup": typeFile,
+		"EFI/boot.backup":             typeFile,
+		"EFI/ubuntu.backup":           typeFile,
+
+		// listed explicitly in the structure
+		"foo.preserve": typeFile,
+	}
+	if preserved {
+		expectedFileStamps["EFI/ubuntu/grub.cfg.preserve"] = typeFile
+	} else {
+		expectedFileStamps["EFI/ubuntu/grub.cfg.backup"] = typeFile
+	}
 
 	for _, step := range []struct {
 		name string
@@ -3103,6 +3117,7 @@ managed grub.cfg from disk`)
 		default:
 			c.Fatalf("unexpected step: %q", step.name)
 		}
+		verifyDirContents(c, filepath.Join(s.backup, "struct-0"), expectedFileStamps)
 	}
 }
 

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
@@ -3014,6 +3015,145 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterNonFilePreserveError(c *C
 	c.Check(err, ErrorMatches, `cannot map preserve entries for mount location ".*/out-dir": preserved entry "foo" cannot be a directory`)
 	err = rw.Rollback()
 	c.Check(err, ErrorMatches, `cannot map preserve entries for mount location ".*/out-dir": preserved entry "foo" cannot be a directory`)
+}
+
+// TODO:UC20: remove this when we have support in the observer
+func (s *mountedfilesystemTestSuite) testMountedUpdaterGrubBootAssets(c *C, managed bool, role string, preserved bool) {
+	// observe boot config files being preserved by the means of finding the
+	// bootloader and querying it directly
+
+	// mirror pc-amd64-gadget
+	gd := []gadgetData{
+		{name: "grub.conf", content: "grub.conf from gadget"},
+		{name: "grubx64.efi", content: "grubx64.efi from gadget"},
+		{name: "foo", content: "foo from gadget"},
+	}
+	makeGadgetData(c, s.dir, gd)
+
+	outDir := filepath.Join(c.MkDir(), "out-dir")
+
+	existingGrubCfg := `# Snapd-Boot-Config-Edition: 1
+managed grub.cfg from disk`
+	if !managed {
+		existingGrubCfg = `existing grub.cfg from disk`
+	}
+	makeExistingData(c, outDir, []gadgetData{
+		{target: "EFI/boot/grubx64.efi", content: "grubx64.efi from disk"},
+		{target: "EFI/ubuntu/grub.cfg", content: existingGrubCfg},
+		{target: "foo", content: "foo from disk"},
+	})
+	// based on pc gadget
+	ps := &gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Size:       2048,
+			Role:       role,
+			Filesystem: "ext4",
+			Content: []gadget.VolumeContent{
+				{Source: "grubx64.efi", Target: "EFI/boot/grubx64.efi"},
+				{Source: "grub.conf", Target: "EFI/ubuntu/grub.cfg"},
+				{Source: "foo", Target: "foo"},
+			},
+			Update: gadget.VolumeUpdate{
+				Preserve: []string{"foo"},
+				Edition:  1,
+			},
+		},
+	}
+	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup,
+		func(to *gadget.LaidOutStructure) (string, error) {
+			c.Check(to, DeepEquals, ps)
+			return outDir, nil
+		},
+		nil)
+	c.Assert(err, IsNil)
+	c.Assert(rw, NotNil)
+
+	for _, step := range []struct {
+		name string
+		call func() error
+	}{
+		{name: "backup", call: rw.Backup},
+		{name: "update", call: rw.Update},
+		{name: "rollback", call: rw.Rollback},
+	} {
+		c.Logf("step: %v", step.name)
+		err := step.call()
+		c.Assert(err, IsNil)
+
+		switch step.name {
+		case "backup":
+			c.Check(filepath.Join(outDir, "EFI/boot/grubx64.efi"), testutil.FileEquals, "grubx64.efi from disk")
+			c.Check(filepath.Join(outDir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals, existingGrubCfg)
+			c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from disk")
+		case "update":
+			c.Check(filepath.Join(outDir, "EFI/boot/grubx64.efi"), testutil.FileEquals, "grubx64.efi from gadget")
+			if preserved {
+				c.Check(filepath.Join(outDir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals,
+					`# Snapd-Boot-Config-Edition: 1
+managed grub.cfg from disk`)
+			} else {
+				c.Check(filepath.Join(outDir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals,
+					`grub.conf from gadget`)
+			}
+			c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from disk")
+		case "rollback":
+			c.Check(filepath.Join(outDir, "EFI/boot/grubx64.efi"), testutil.FileEquals, "grubx64.efi from disk")
+			c.Check(filepath.Join(outDir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals, existingGrubCfg)
+			c.Check(filepath.Join(outDir, "foo"), testutil.FileEquals, "foo from disk")
+		default:
+			c.Fatalf("unexpected step: %q", step.name)
+		}
+	}
+}
+
+func (s *mountedfilesystemTestSuite) TestMountedUpdaterGrubBootAssetsManaged(c *C) {
+	managed := true
+	preserved := true
+	s.testMountedUpdaterGrubBootAssets(c, managed, gadget.SystemBoot, preserved)
+}
+
+func (s *mountedfilesystemTestSuite) TestMountedUpdaterGrubSeedAssetsManaged(c *C) {
+	managed := true
+	preserved := true
+	s.testMountedUpdaterGrubBootAssets(c, managed, gadget.SystemSeed, preserved)
+}
+
+func (s *mountedfilesystemTestSuite) TestMountedUpdaterGrubBootAssetsNotManaged(c *C) {
+	managed := false
+	preserved := false
+	s.testMountedUpdaterGrubBootAssets(c, managed, gadget.SystemSeed, preserved)
+}
+
+func (s *mountedfilesystemTestSuite) TestMountedUpdaterGrubBootAssetsManagedOtherRole(c *C) {
+	managed := true
+	preserved := false
+	s.testMountedUpdaterGrubBootAssets(c, managed, gadget.SystemData, preserved)
+}
+
+func (s *mountedfilesystemTestSuite) TestMountedUpdaterBootAssetsErr(c *C) {
+	outDir := filepath.Join(c.MkDir(), "out-dir")
+
+	bootloader.ForceError(errors.New("foo"))
+	defer bootloader.ForceError(nil)
+	// based on pc gadget
+	ps := &gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Size:       2048,
+			Role:       gadget.SystemBoot,
+			Filesystem: "ext4",
+			Content: []gadget.VolumeContent{
+				{Source: "grubx64.efi", Target: "EFI/boot/grubx64.efi"},
+				{Source: "grub.conf", Target: "EFI/ubuntu/grub.cfg"},
+			},
+		},
+	}
+	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup,
+		func(to *gadget.LaidOutStructure) (string, error) {
+			return outDir, nil
+		},
+		nil)
+	c.Assert(err, ErrorMatches, "cannot preserve managed boot assets: foo")
+	c.Assert(rw, IsNil)
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedUpdaterObserverPreservesBootAssets(c *C) {

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -289,7 +289,7 @@ func (m *mockWriteObserver) Observe(op gadget.ContentOperation, sourceStruct *ga
 	m.c.Check(m.expectedStruct, DeepEquals, sourceStruct)
 
 	if strutil.ListContains(m.preserveTargets, relativeTargetPath) {
-		return gadget.ChangePreserveBefore, nil
+		return gadget.ChangeIgnore, nil
 	}
 	return gadget.ChangeApply, m.observeErr
 }
@@ -946,7 +946,7 @@ func (m *mockContentUpdateObserver) Observe(op gadget.ContentOperation, sourceSt
 		return gadget.ChangeAbort, m.observeErr
 	}
 	if strutil.ListContains(m.preserveTargets, relativeTargetPath) {
-		return gadget.ChangePreserveBefore, nil
+		return gadget.ChangeIgnore, nil
 	}
 	return gadget.ChangeApply, nil
 }

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -70,7 +70,7 @@ const (
 
 	ChangeAbort ContentChangeAction = iota
 	ChangeApply
-	ChangePreserveBefore
+	ChangeIgnore
 )
 
 // ContentObserver allows for observing operations on the content of the gadget
@@ -87,9 +87,9 @@ type ContentObserver interface {
 	//
 	// Returning ChangeApply indicates that the observer agrees for a given
 	// change to be applied. When called with a ContentUpdate or
-	// ContentWrite operation, returning ChangePreserveBefore indicates that
-	// the 'before' content shall be preserved. ChangeAbort is expected to
-	// be returned along with a non-nil error.
+	// ContentWrite operation, returning ChangeIgnore indicates that the
+	// change shall be ignored. ChangeAbort is expected to be returned along
+	// with a non-nil error.
 	Observe(op ContentOperation, sourceStruct *LaidOutStructure,
 		targetRootDir, relativeTargetPath string, dataChange *ContentChange) (ContentChangeAction, error)
 }

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -76,9 +76,6 @@ const (
 // ContentObserver allows for observing operations on the content of the gadget
 // structures.
 type ContentObserver interface {
-	// TODO:UC20: add Observe() result value indicating that a file should
-	// be preserved
-
 	// Observe is called to observe an pending or completed action, related
 	// to content being written, updated or being rolled back. In each of
 	// the scenarios, the target path is relative under the root.
@@ -89,10 +86,10 @@ type ContentObserver interface {
 	// file was added during the update), the source path is empty.
 	//
 	// Returning ChangeApply indicates that the observer agrees for a given
-	// change to be applied. When called with a ContentUpdate operation,
-	// returning ChangePreserveBefore indicates that the 'before' content
-	// shall be preserved. ChangeAbort is expected to be returned along with
-	// a non-nil error.
+	// change to be applied. When called with a ContentUpdate or
+	// ContentWrite operation, returning ChangePreserveBefore indicates that
+	// the 'before' content shall be preserved. ChangeAbort is expected to
+	// be returned along with a non-nil error.
 	Observe(op ContentOperation, sourceStruct *LaidOutStructure,
 		targetRootDir, relativeTargetPath string, dataChange *ContentChange) (ContentChangeAction, error)
 }


### PR DESCRIPTION
The observer can indicate that a file should be preserved during update/write,
even if it is not listed in the `preserve` files list inside gadget.yaml file.
Adjust the backup/update/rollback passes so that the requests are respected.

Split out from #9427.