### PR TITLE
run-checks: run spread-shellcheck too

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -225,6 +225,8 @@ if [ "$STATIC" = 1 ]; then
             exit 1
         fi
         unset regexp
+        # also run spread-shellcheck
+        ./spread-shellcheck spread.yaml tests
     fi
 
     echo "Checking spelling errors"


### PR DESCRIPTION
This commit runs spread-shellcheck as part of the static checks
to catch errors early. This will make the static checks a bit
slower but more complete.

On my system this means ~1m20s longer time for ./run-checks --static. But given that ./run-checks --unit takes ~6m it seems not that critical(?).

Note: if we do it here I will remove the "tests/unit/spread-shellcheck" too.