### PR TITLE
interfaces: update network-manager interface to allow ObjectManager access from unconfined clients

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -186,6 +186,13 @@ dbus (receive, send)
     interface=org.freedesktop.DBus.*
     peer=(label=unconfined),
 
+# Allow ObjectManager methods from and signals to unconfined clients.
+dbus (receive, send)
+    bus=system
+    path=/org/freedesktop
+    interface=org.freedesktop.DBus.ObjectManager
+    peer=(label=unconfined),
+
 # Allow access to hostname system service
 dbus (receive, send)
     bus=system


### PR DESCRIPTION
The `network-manager` interface allows connected snaps to talk to the daemon via the `org.freedesktop.DBus.ObjectManager` interface, which is used by current NetworkManager client libraries.  This same access is missing from the permanent slot AppArmor rules for talking to unconfined clients though.

I noticed this problem when trying to configure the network-manager snap via an unconfined gnome-control-center: as far as it was concerned, NetworkManager was not running.  Patching these same rules into its AppArmor profile got things working.