### PR TITLE
tests: moving main suite to snaps-state tool part 4

### DIFF
--- a/tests/main/interfaces-process-control/task.yaml
+++ b/tests/main/interfaces-process-control/task.yaml
@@ -13,11 +13,8 @@ summary: |
     extended later.
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB/snaps.sh"
-
     echo "Given a snap declaring a plug on the process-control interface is installed"
-    install_local process-control-consumer
+    "$TESTSTOOLS"/snaps-state install-local process-control-consumer
 
 execute: |
     echo "The interface is disconnected by default"

--- a/tests/main/interfaces-raw-usb/task.yaml
+++ b/tests/main/interfaces-raw-usb/task.yaml
@@ -4,9 +4,7 @@ details: |
     The raw-usb interface allows detection and grants access to all connected USB devices.
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB/snaps.sh"
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
 execute: |
     echo "The interface is not connected by default"

--- a/tests/main/interfaces-removable-media/task.yaml
+++ b/tests/main/interfaces-removable-media/task.yaml
@@ -4,9 +4,7 @@ details: |
     The removable-media interface allows to access to removable storage filesystems.
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     if ! [ -d /media ]; then
         mkdir -p /media

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -9,11 +9,8 @@ details: |
     the Introspect method on org.freedesktop.login1.
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
     echo "Given a snap declaring a plug on the shutdown interface is installed"
-    install_local shutdown-introspection-consumer
+    "$TESTSTOOLS"/snaps-state install-local shutdown-introspection-consumer
 
 execute: |
     echo "The interface is disconnected by default"

--- a/tests/main/interfaces-ssh-keys/task.yaml
+++ b/tests/main/interfaces-ssh-keys/task.yaml
@@ -10,9 +10,7 @@ environment:
     CONFDIR: "/etc/ssh/ssh_config.d/"
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     if [ -d "$KEYSDIR" ]; then
         cp -rf "$KEYSDIR" "$KEYSDIR".old

--- a/tests/main/interfaces-ssh-public-keys/task.yaml
+++ b/tests/main/interfaces-ssh-public-keys/task.yaml
@@ -9,10 +9,7 @@ environment:
     TESTKEY: "/$HOME/.ssh/testkey"
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB/snaps.sh"
-
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     if [ -d "$KEYSDIR" ]; then
         cp -rf "$KEYSDIR" "$KEYSDIR".old

--- a/tests/main/interfaces-system-files/task.yaml
+++ b/tests/main/interfaces-system-files/task.yaml
@@ -8,9 +8,7 @@ environment:
     TESTDIR: /mnt/testdir
 
 prepare: |
-    # shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB/snaps.sh"
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     # Fist layer of dirs and files
     "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -9,11 +9,8 @@ details: |
 systems: [-opensuse-*,-fedora-*,-ubuntu-core-*,-ubuntu-14.04-*,-*-s390x,-arch-*]
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
     # Install a snap declaring a plug on time-control
-    install_local test-snapd-timedate-control-consumer
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-timedate-control-consumer
 
     date +'%m%d%H%M.%y' > now.txt
 

--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -42,9 +42,7 @@ prepare: |
     esac
 
     # Install a snap declaring a plug on timeserver-control
-    # shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-timedate-control-consumer
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-timedate-control-consumer
     tests.cleanup defer snap remove --purge test-snapd-timedate-control-consumer
 
 restore: |

--- a/tests/main/interfaces-timezone-control/task.yaml
+++ b/tests/main/interfaces-timezone-control/task.yaml
@@ -9,11 +9,8 @@ details: |
     can access timezone information and update it.
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
     # Install a snap declaring a plug on timezone-control
-    install_local test-snapd-timedate-control-consumer
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-timedate-control-consumer
 
 restore: |
     # Restore the initial timezone

--- a/tests/main/interfaces-udev/task.yaml
+++ b/tests/main/interfaces-udev/task.yaml
@@ -11,11 +11,8 @@ details: |
     more interfaces declare udev snippets.
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
     echo "Given a snap declaring a slot with associated udev rules is installed"
-    install_local modem-manager-consumer
+    "$TESTSTOOLS"/snaps-state install-local modem-manager-consumer
 
 execute: |
     echo "Then the udev rules files specific to it are created"

--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -7,9 +7,7 @@ details: |
     hooks get permissions to access those areas.
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-layout
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-layout
 
 debug: |
     ls -ld /etc || :
@@ -18,12 +16,10 @@ debug: |
     ls -ld /etc/demo.cfg || :
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
     for i in $(seq 2); do
         if [ "$i" -eq 2 ]; then
             echo "The snap works across refreshes"
-            install_local test-snapd-layout
+            "$TESTSTOOLS"/snaps-state install-local test-snapd-layout
         fi
 
         echo "snap declaring layouts doesn't explode on startup"

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -1,12 +1,10 @@
 summary: Check snap listings
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     snap set system experimental.parallel-instances=true
-    install_local_as test-snapd-sh test-snapd-sh_foo
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_foo
 
 restore: |
     snap set system experimental.parallel-instances=null
@@ -75,9 +73,7 @@ execute: |
     snap list | MATCH "^test-snapd-sh_foo +$NUMERIC_VERSION +$SIDELOAD_REV +- +- +- *$"
 
     echo "Install test-snapd-sh again"
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     echo "And run snap list --all"
     output=$(snap list --all | grep 'test-snapd-sh ')

--- a/tests/main/media-sharing/task.yaml
+++ b/tests/main/media-sharing/task.yaml
@@ -7,11 +7,9 @@ details: |
     use /run/media path instead.
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
-    install_local_devmode test-snapd-tools
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-tools --devmode
     mkdir -p ${MEDIA_DIR}/src
     mkdir -p ${MEDIA_DIR}/dst
     touch ${MEDIA_DIR}/src/canary

--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -15,9 +15,7 @@ systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -centos-*]
 backends: [-autopkgtest]
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB/snaps.sh"
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     # If /proc/fs/nfsd is not initially mounted then ask the test to unmount it later.
     if not mountinfo.query /proc/fs/nfsd .fs_type=nfsd; then

--- a/tests/main/op-install-failed-undone/task.yaml
+++ b/tests/main/op-install-failed-undone/task.yaml
@@ -21,9 +21,7 @@ execute: |
     mkdir -p $SNAP_MOUNT_DIR/test-snapd-sh/current/foo
 
     echo "And we try to install it"
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    if install_local test-snapd-sh; then
+    if "$TESTSTOOLS"/snaps-state install-local test-snapd-sh; then
         echo "A snap shouldn't be installable if its mount point is busy"
         exit 1
     fi

--- a/tests/main/op-remove-retry/task.yaml
+++ b/tests/main/op-remove-retry/task.yaml
@@ -14,9 +14,7 @@ execute: |
     . "$TESTSLIB"/systemd.sh
 
     echo "Given a snap is installed"
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-tools
 
     echo "And its mount point is kept busy"
     # we need a marker file, because just using systemd to figure out

--- a/tests/main/parallel-install-aliases/task.yaml
+++ b/tests/main/parallel-install-aliases/task.yaml
@@ -1,13 +1,10 @@
 summary: Check snap alias and snap unalias across different instances of the same snap
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB/snaps.sh"
-
     snap set system experimental.parallel-instances=true
 
-    install_local aliases
-    install_local_as aliases aliases_foo
+    "$TESTSTOOLS"/snaps-state install-local aliases
+    "$TESTSTOOLS"/snaps-state install-local-as aliases aliases_foo
 
 restore: |
     snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-basic/task.yaml
+++ b/tests/main/parallel-install-basic/task.yaml
@@ -8,11 +8,8 @@ prepare: |
     snap set system experimental.parallel-instances=true
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
-    install_local test-snapd-sh
-    install_local_as test-snapd-sh test-snapd-sh_foo
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_foo
 
     su -l -c '! test -d ~/snap/test-snapd-sh' test
     su -l -c '! test -d ~/snap/test-snapd-sh_foo' test

--- a/tests/main/parallel-install-classic/task.yaml
+++ b/tests/main/parallel-install-classic/task.yaml
@@ -35,11 +35,8 @@ restore: |
     esac
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
-    install_local test-snapd-classic-confinement --classic
-    install_local_as test-snapd-classic-confinement test-snapd-classic-confinement_foo --classic
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-classic-confinement --classic
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-classic-confinement test-snapd-classic-confinement_foo --classic
 
     su test -l -c '! test -d ~/snap/test-snapd-classic-confinement'
     su test -l -c '! test -d ~/snap/test-snapd-classic-confinement_foo'

--- a/tests/main/parallel-install-common-dirs/task.yaml
+++ b/tests/main/parallel-install-common-dirs/task.yaml
@@ -7,13 +7,11 @@ prepare: |
     snap set system experimental.parallel-instances=true
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
 
     echo "Install a snap with instance key set"
-    install_local_as test-snapd-sh test-snapd-sh_foo
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_foo
 
     # foo instance directories are present
     test -d "$SNAP_MOUNT_DIR/test-snapd-sh_foo"
@@ -24,13 +22,13 @@ execute: |
     test -d "/var/snap/test-snapd-sh"
 
     # get another revision of test-snapd-sh_foo
-    install_local_as test-snapd-sh test-snapd-sh_foo
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_foo
 
     # install instance-key-less snap
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     # and a bar instance
-    install_local_as test-snapd-sh test-snapd-sh_bar
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_bar
     # bar instance directories are present
     test -d "$SNAP_MOUNT_DIR/test-snapd-sh_bar"
     test -d "/var/snap/test-snapd-sh_bar"
@@ -71,9 +69,9 @@ execute: |
     not test -d "/var/snap/test-snapd-sh"
 
     # make sure that the sole snap without instance key is handled correctly too
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     # another revision
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
     test -d "/var/snap/test-snapd-sh"
     snap remove --purge test-snapd-sh

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -1,11 +1,8 @@
 summary: Checks for parallel installation of sideloaded snaps containing desktop applications
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
     echo "Sideload the regular snap"
-    install_local basic-desktop
+    "$TESTSTOOLS"/snaps-state install-local basic-desktop
 
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
@@ -15,7 +12,7 @@ execute: |
     for instance in foo longname; do
         echo "Sideload same snap as different instance named basic-desktop+$instance"
         expected="^basic-desktop_$instance 1.0 installed\$"
-        install_local_as basic-desktop "basic-desktop_$instance" | MATCH "$expected"
+        "$TESTSTOOLS"/snaps-state install-local-as basic-desktop "basic-desktop_$instance" | MATCH "$expected"
 
         diff -u <(head -n5 "/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop") - <<-EOF
     [Desktop Entry]

--- a/tests/main/parallel-install-interfaces-content/task.yaml
+++ b/tests/main/parallel-install-interfaces-content/task.yaml
@@ -20,14 +20,11 @@ prepare: |
     snap set system experimental.parallel-instances=true
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-advanced-slot
 
-    install_local test-snapd-content-advanced-slot
-
-    install_local test-snapd-content-advanced-plug
-    install_local_as test-snapd-content-advanced-plug test-snapd-content-advanced-plug_foo
-    install_local_as test-snapd-content-advanced-plug test-snapd-content-advanced-plug_bar
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-advanced-plug
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-content-advanced-plug test-snapd-content-advanced-plug_foo
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-content-advanced-plug test-snapd-content-advanced-plug_bar
 
     test-snapd-content-advanced-plug.sh -c "$(printf 'test ! -e $%s/target' "$VAR")"
 

--- a/tests/main/parallel-install-interfaces/task.yaml
+++ b/tests/main/parallel-install-interfaces/task.yaml
@@ -4,14 +4,11 @@ summary: Check that snap connect with parallel installs works
 backends: [-autopkgtest]
 
 prepare: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
     snap set system experimental.parallel-instances=true
 
     echo "Install test snaps"
-    install_local home-consumer
-    install_local_as home-consumer home-consumer_foo
+    "$TESTSTOOLS"/snaps-state install-local home-consumer
+    "$TESTSTOOLS"/snaps-state install-local-as home-consumer home-consumer_foo
 
     # the home interface is not autoconnected on all-snap systems
     if [[ ! "$SPREAD_SYSTEM" == ubuntu-core-* ]]; then

--- a/tests/main/parallel-install-layout/task.yaml
+++ b/tests/main/parallel-install-layout/task.yaml
@@ -10,14 +10,11 @@ prepare: |
     snap set system experimental.parallel-instances=true
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
     echo "Install the regular snap"
-    install_local test-snapd-layout
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-layout
 
     echo "Sideload the parallel installed snap"
-    install_local_as test-snapd-layout test-snapd-layout_foo
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-layout test-snapd-layout_foo
 
     for name in test-snapd-layout test-snapd-layout_foo; do
         # workaround trespassing bug

--- a/tests/main/parallel-install-local/task.yaml
+++ b/tests/main/parallel-install-local/task.yaml
@@ -4,17 +4,14 @@ restore: |
     snap set system experimental.parallel-instances=null
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
     echo "Install the regular snap"
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
 
-    if install_local_as test-snapd-sh test-snapd-sh_foo 2>run.err; then
-        echo "install_local_as was expected to fail"
+    if "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_foo 2>run.err; then
+        echo "install-local-as was expected to fail"
         exit 1
     fi
     MATCH 'experimental feature disabled' < run.err
@@ -24,7 +21,7 @@ execute: |
     for instance in foo longname; do
         echo "Install snap instance named test-snapd-sh_$instance"
         expected="^test-snapd-sh_$instance 1.0 installed\$"
-        install_local_as test-snapd-sh "test-snapd-sh_$instance" | MATCH "$expected"
+        "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh "test-snapd-sh_$instance" | MATCH "$expected"
 
         test -d "$SNAP_MOUNT_DIR/test-snapd-sh_$instance/x1"
 

--- a/tests/main/parallel-install-remove-after/task.yaml
+++ b/tests/main/parallel-install-remove-after/task.yaml
@@ -28,15 +28,13 @@ restore: |
     esac
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 
     # install confined and classic snaps
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     if is_classic_system ; then
-        install_local test-snapd-classic-confinement --classic
+        "$TESTSTOOLS"/snaps-state install-local test-snapd-classic-confinement --classic
     fi
 
     snap set system experimental.parallel-instances=true
@@ -50,9 +48,9 @@ execute: |
     fi
 
     # new instances of same snaps
-    install_local_as test-snapd-sh test-snapd-sh_foo
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_foo
     if is_classic_system ; then
-        install_local_as test-snapd-classic-confinement test-snapd-classic-confinement_foo --classic
+        "$TESTSTOOLS"/snaps-state install-local-as test-snapd-classic-confinement test-snapd-classic-confinement_foo --classic
     fi
 
     # parallel instances works

--- a/tests/main/parallel-install-services/task.yaml
+++ b/tests/main/parallel-install-services/task.yaml
@@ -10,10 +10,7 @@ restore: |
     snap set system experimental.parallel-instances=null
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
-    install_local test-snapd-service
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-service
 
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
@@ -27,7 +24,7 @@ execute: |
     for instance in foo longname; do
         echo "Install a snap as instance named test-snapd-service_$instance"
         expected="^test-snapd-service_$instance 1.0 installed\$"
-        install_local_as test-snapd-service "test-snapd-service_$instance" | MATCH "$expected"
+        "$TESTSTOOLS"/snaps-state install-local-as test-snapd-service "test-snapd-service_$instance" | MATCH "$expected"
 
         test -d "$SNAP_MOUNT_DIR/test-snapd-service_$instance/x1"
 

--- a/tests/main/parallel-install-snap-icons/task.yaml
+++ b/tests/main/parallel-install-snap-icons/task.yaml
@@ -4,16 +4,13 @@ restore: |
     snap unset system experimental.parallel-instances
 
 execute: |
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-
     echo "Install a snap providing icons"
-    install_local test-snapd-icon-theme
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-icon-theme
 
     echo "Install additional instances of the snap"
     snap set system experimental.parallel-instances=true
-    install_local_as test-snapd-icon-theme test-snapd-icon-theme_longname
-    install_local_as test-snapd-icon-theme test-snapd-icon-theme_foo
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-icon-theme test-snapd-icon-theme_longname
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-icon-theme test-snapd-icon-theme_foo
 
     echo "Each instance provides its own icons"
     icondir=/var/lib/snapd/desktop/icons/hicolor/scalable/apps

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -13,8 +13,7 @@ restore: |
 prepare: |
     # TODO: unify this with tests/main/snap-mgmt/task.yaml
     echo "When some snaps are installed"
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
+
 
     snap set core experimental.user-daemons=true
 
@@ -29,7 +28,7 @@ prepare: |
             # None of the "user" snaps work on 14.04
             continue
         fi
-        install_local "$name"
+        "$TESTSTOOLS"/snaps-state install-local "$name"
         snap list | MATCH "$name"
     done
 

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -124,9 +124,7 @@ execute: |
     echo "classic snaps "
 
     echo "When multiple snaps have no update we have a good message"
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local basic
+    "$TESTSTOOLS"/snaps-state install-local basic
     snap refresh "$SNAP_NAME" basic 2>&1 | MATCH "All snaps up to date."
 
     echo "When moving to stable"

--- a/tests/main/regression-home-snap-root-owned/task.yaml
+++ b/tests/main/regression-home-snap-root-owned/task.yaml
@@ -5,9 +5,7 @@ prepare: |
     # ensure we have no snap user data directory yet
     rm -rf /home/test/snap
     rm -rf /root/snap
-    #shellcheck source=tests/lib/snaps.sh
-    . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     tests.session -u test prepare
 restore: |
     tests.session -u test restore


### PR DESCRIPTION
This is the part 4 of the migration
