### PR TITLE
client: cleanup the Client.raw* and Client.do* method families

### DIFF
--- a/client/asserts.go
+++ b/client/asserts.go
@@ -84,14 +84,12 @@ func (client *Client) Known(assertTypeName string, headers map[string]string, op
 		q.Set("remote", "true")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), doTimeout)
-	defer cancel()
-	response, err := client.raw(ctx, "GET", path, q, nil, nil)
+	response, cancel, err := client.rawWithTimeout(context.Background(), "GET", path, q, nil, nil, nil)
 	if err != nil {
 		fmt := "failed to query assertions: %w"
 		return nil, xerrors.Errorf(fmt, err)
 	}
-
+	defer cancel()
 	defer response.Body.Close()
 	if response.StatusCode != 200 {
 		return nil, parseError(response)

--- a/client/client.go
+++ b/client/client.go
@@ -335,10 +335,13 @@ func (client *Client) do(method, path string, query url.Values, headers map[stri
 
 	var rsp *http.Response
 	var ctx context.Context = context.Background()
-	if opts.Timeout < 0 {
+	if opts.Timeout <= 0 {
 		// no timeout and retries
 		rsp, err = client.raw(ctx, method, path, query, headers, body)
 	} else {
+		if opts.Retry <= 0 {
+			return 0, fmt.Errorf("internal error: retry setting %s invalid", opts.Retry)
+		}
 		retry := time.NewTicker(opts.Retry)
 		defer retry.Stop()
 		timeout := time.NewTimer(opts.Timeout)

--- a/client/client.go
+++ b/client/client.go
@@ -247,16 +247,19 @@ func (client *Client) raw(ctx context.Context, method, urlpath string, query url
 	return rsp, nil
 }
 
-// rawWithTimeout is like raw(), but sets a timeout for the whole of request and
-// response (including rsp.Body() read) round trip. The caller is responsible
-// for canceling the internal context to release the resources associated with
-// the request by calling the returned cancel function.
-func (client *Client) rawWithTimeout(ctx context.Context, method, urlpath string, query url.Values, headers map[string]string, body io.Reader, timeout time.Duration) (*http.Response, context.CancelFunc, error) {
-	if timeout == 0 {
-		return nil, nil, fmt.Errorf("internal error: timeout not set for rawWithTimeout")
+// rawWithTimeout is like raw(), but sets a timeout based on opts for
+// the whole of request and response (including rsp.Body() read) round
+// trip. If opts is nil the default doTimeout is used.
+// The caller is responsible for canceling the internal context
+// to release the resources associated with the request by calling the
+// returned cancel function.
+func (client *Client) rawWithTimeout(ctx context.Context, method, urlpath string, query url.Values, headers map[string]string, body io.Reader, opts *doOptions) (*http.Response, context.CancelFunc, error) {
+	opts = ensureDoOpts(opts)
+	if opts.Timeout <= 0 {
+		return nil, nil, fmt.Errorf("internal error: timeout not set in options for rawWithTimeout")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	rsp, err := client.raw(ctx, method, urlpath, query, headers, body)
 	if err != nil && ctx.Err() != nil {
 		cancel()
@@ -300,43 +303,66 @@ func (client *Client) Hijack(f func(*http.Request) (*http.Response, error)) {
 	client.doer = hijacked{f}
 }
 
-type doFlags struct {
-	NoTimeout bool
+type doOptions struct {
+	// Timeout is the overall request timeout
+	Timeout time.Duration
+	// Retry interval
+	Retry time.Duration
+}
+
+func ensureDoOpts(opts *doOptions) *doOptions {
+	if opts == nil {
+		// defaults
+		opts = &doOptions{
+			Timeout: doTimeout,
+			Retry:   doRetry,
+		}
+	}
+	return opts
+}
+
+// doNoTimeoutAndRetry can be passed to the do family to not have timeout
+// nor retries.
+var doNoTimeoutAndRetry = &doOptions{
+	Timeout: time.Duration(-1),
 }
 
 // do performs a request and decodes the resulting json into the given
 // value. It's low-level, for testing/experimenting only; you should
 // usually use a higher level interface that builds on this.
-func (client *Client) do(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}, flags doFlags) (statusCode int, err error) {
-	retry := time.NewTicker(doRetry)
-	defer retry.Stop()
-	timeout := time.NewTimer(doTimeout)
-	defer timeout.Stop()
+func (client *Client) do(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}, opts *doOptions) (statusCode int, err error) {
+	opts = ensureDoOpts(opts)
 
 	var rsp *http.Response
 	var ctx context.Context = context.Background()
-	for {
-		if flags.NoTimeout {
-			rsp, err = client.raw(ctx, method, path, query, headers, body)
-		} else {
+	if opts.Timeout < 0 {
+		// no timeout and retries
+		rsp, err = client.raw(ctx, method, path, query, headers, body)
+	} else {
+		retry := time.NewTicker(opts.Retry)
+		defer retry.Stop()
+		timeout := time.NewTimer(opts.Timeout)
+		defer timeout.Stop()
+
+		for {
 			var cancel context.CancelFunc
 			// use the same timeout as for the whole of the retry
 			// loop to error out the whole do() call when a single
 			// request exceeds the deadline
-			rsp, cancel, err = client.rawWithTimeout(ctx, method, path, query, headers, body, doTimeout)
+			rsp, cancel, err = client.rawWithTimeout(ctx, method, path, query, headers, body, opts)
 			if err == nil {
 				defer cancel()
 			}
-		}
-		if err == nil || method != "GET" {
+			if err == nil || method != "GET" {
+				break
+			}
+			select {
+			case <-retry.C:
+				continue
+			case <-timeout.C:
+			}
 			break
 		}
-		select {
-		case <-retry.C:
-			continue
-		case <-timeout.C:
-		}
-		break
 	}
 	if err != nil {
 		return 0, err
@@ -370,8 +396,12 @@ func decodeInto(reader io.Reader, v interface{}) error {
 // response payload into the given value using the "UseNumber" json decoding
 // which produces json.Numbers instead of float64 types for numbers.
 func (client *Client) doSync(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) (*ResultInfo, error) {
+	return client.doSyncWithOpts(method, path, query, headers, body, v, nil)
+}
+
+func (client *Client) doSyncWithOpts(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}, opts *doOptions) (*ResultInfo, error) {
 	var rsp response
-	statusCode, err := client.do(method, path, query, headers, body, &rsp, doFlags{})
+	statusCode, err := client.do(method, path, query, headers, body, &rsp, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -395,18 +425,13 @@ func (client *Client) doSync(method, path string, query url.Values, headers map[
 }
 
 func (client *Client) doAsync(method, path string, query url.Values, headers map[string]string, body io.Reader) (changeID string, err error) {
-	_, changeID, err = client.doAsyncFull(method, path, query, headers, body, doFlags{})
+	_, changeID, err = client.doAsyncFull(method, path, query, headers, body, nil)
 	return
 }
 
-func (client *Client) doAsyncNoTimeout(method, path string, query url.Values, headers map[string]string, body io.Reader) (changeID string, err error) {
-	_, changeID, err = client.doAsyncFull(method, path, query, headers, body, doFlags{NoTimeout: true})
-	return changeID, err
-}
-
-func (client *Client) doAsyncFull(method, path string, query url.Values, headers map[string]string, body io.Reader, flags doFlags) (result json.RawMessage, changeID string, err error) {
+func (client *Client) doAsyncFull(method, path string, query url.Values, headers map[string]string, body io.Reader, opts *doOptions) (result json.RawMessage, changeID string, err error) {
 	var rsp response
-	statusCode, err := client.do(method, path, query, headers, body, &rsp, flags)
+	statusCode, err := client.do(method, path, query, headers, body, &rsp, opts)
 	if err != nil {
 		return nil, "", err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -204,7 +204,7 @@ func (e ConnectionError) Unwrap() error {
 const AllowInteractionHeader = "X-Allow-Interaction"
 
 // raw performs a request and returns the resulting http.Response and
-// error you usually only need to call this directly if you expect the
+// error. You usually only need to call this directly if you expect the
 // response to not be JSON, otherwise you'd call Do(...) instead.
 func (client *Client) raw(ctx context.Context, method, urlpath string, query url.Values, headers map[string]string, body io.Reader) (*http.Response, error) {
 	// fake a url to keep http.Client happy

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -174,9 +174,6 @@ func (cs *clientSuite) TestClientDoRetryValidation(c *C) {
 }
 
 func (cs *clientSuite) TestClientDoRetryWorks(c *C) {
-	// TODO: this test might be racy or have wrong results on really slow test
-	//       systems since we are essentially counting how fast we can make
-	//       fake requests before the Timeout runs out
 	reqBody := ioutil.NopCloser(strings.NewReader(""))
 	cs.err = fmt.Errorf("borken")
 	doOpts := &client.DoOptions{
@@ -185,7 +182,10 @@ func (cs *clientSuite) TestClientDoRetryWorks(c *C) {
 	}
 	_, err := cs.cli.Do("GET", "/this", nil, reqBody, nil, doOpts)
 	c.Check(err, ErrorMatches, "cannot communicate with server: borken")
-	c.Assert(cs.doCalls, Equals, 1001)
+	// best effort checking given that execution could be slow
+	// on some machines
+	c.Assert(cs.doCalls > 500, Equals, true)
+	c.Assert(cs.doCalls < 1100, Equals, true)
 }
 
 func (cs *clientSuite) TestClientUnderstandsStatusCode(c *C) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -123,7 +123,7 @@ func (cs *clientSuite) TestNewPanics(c *C) {
 
 func (cs *clientSuite) TestClientDoReportsErrors(c *C) {
 	cs.err = errors.New("ouchie")
-	_, err := cs.cli.Do("GET", "/", nil, nil, nil, client.DoFlags{})
+	_, err := cs.cli.Do("GET", "/", nil, nil, nil, nil)
 	c.Check(err, ErrorMatches, "cannot communicate with server: ouchie")
 	if cs.doCalls < 2 {
 		c.Fatalf("do did not retry")
@@ -134,7 +134,7 @@ func (cs *clientSuite) TestClientWorks(c *C) {
 	var v []int
 	cs.rsp = `[1,2]`
 	reqBody := ioutil.NopCloser(strings.NewReader(""))
-	statusCode, err := cs.cli.Do("GET", "/this", nil, reqBody, &v, client.DoFlags{})
+	statusCode, err := cs.cli.Do("GET", "/this", nil, reqBody, &v, nil)
 	c.Check(err, IsNil)
 	c.Check(statusCode, Equals, 200)
 	c.Check(v, DeepEquals, []int{1, 2})
@@ -150,7 +150,7 @@ func (cs *clientSuite) TestClientUnderstandsStatusCode(c *C) {
 	cs.status = 202
 	cs.rsp = `[1,2]`
 	reqBody := ioutil.NopCloser(strings.NewReader(""))
-	statusCode, err := cs.cli.Do("GET", "/this", nil, reqBody, &v, client.DoFlags{})
+	statusCode, err := cs.cli.Do("GET", "/this", nil, reqBody, &v, nil)
 	c.Check(err, IsNil)
 	c.Check(statusCode, Equals, 202)
 	c.Check(v, DeepEquals, []int{1, 2})
@@ -166,7 +166,7 @@ func (cs *clientSuite) TestClientDefaultsToNoAuthorization(c *C) {
 	defer os.Unsetenv(client.TestAuthFileEnvKey)
 
 	var v string
-	_, _ = cs.cli.Do("GET", "/this", nil, nil, &v, client.DoFlags{})
+	_, _ = cs.cli.Do("GET", "/this", nil, nil, &v, nil)
 	c.Assert(cs.req, NotNil)
 	authorization := cs.req.Header.Get("Authorization")
 	c.Check(authorization, Equals, "")
@@ -184,7 +184,7 @@ func (cs *clientSuite) TestClientSetsAuthorization(c *C) {
 	c.Assert(err, IsNil)
 
 	var v string
-	_, _ = cs.cli.Do("GET", "/this", nil, nil, &v, client.DoFlags{})
+	_, _ = cs.cli.Do("GET", "/this", nil, nil, &v, nil)
 	authorization := cs.req.Header.Get("Authorization")
 	c.Check(authorization, Equals, `Macaroon root="macaroon", discharge="discharge"`)
 }
@@ -203,7 +203,7 @@ func (cs *clientSuite) TestClientHonorsDisableAuth(c *C) {
 	var v string
 	cli := client.New(&client.Config{DisableAuth: true})
 	cli.SetDoer(cs)
-	_, _ = cli.Do("GET", "/this", nil, nil, &v, client.DoFlags{})
+	_, _ = cli.Do("GET", "/this", nil, nil, &v, nil)
 	authorization := cs.req.Header.Get("Authorization")
 	c.Check(authorization, Equals, "")
 }
@@ -212,13 +212,13 @@ func (cs *clientSuite) TestClientHonorsInteractive(c *C) {
 	var v string
 	cli := client.New(&client.Config{Interactive: false})
 	cli.SetDoer(cs)
-	_, _ = cli.Do("GET", "/this", nil, nil, &v, client.DoFlags{})
+	_, _ = cli.Do("GET", "/this", nil, nil, &v, nil)
 	interactive := cs.req.Header.Get(client.AllowInteractionHeader)
 	c.Check(interactive, Equals, "")
 
 	cli = client.New(&client.Config{Interactive: true})
 	cli.SetDoer(cs)
-	_, _ = cli.Do("GET", "/this", nil, nil, &v, client.DoFlags{})
+	_, _ = cli.Do("GET", "/this", nil, nil, &v, nil)
 	interactive = cs.req.Header.Get(client.AllowInteractionHeader)
 	c.Check(interactive, Equals, "true")
 }
@@ -484,7 +484,7 @@ func (cs *clientSuite) TestUserAgent(c *C) {
 	cli.SetDoer(cs)
 
 	var v string
-	_, _ = cli.Do("GET", "/", nil, nil, &v, client.DoFlags{})
+	_, _ = cli.Do("GET", "/", nil, nil, &v, nil)
 	c.Assert(cs.req, NotNil)
 	c.Check(cs.req.Header.Get("User-Agent"), Equals, "some-agent/9.87")
 }
@@ -543,9 +543,9 @@ func (cs *integrationSuite) TestClientTimeoutLP1837804(c *C) {
 	defer func() { testServer.Close() }()
 
 	cli := client.New(&client.Config{BaseURL: testServer.URL})
-	_, err := cli.Do("GET", "/", nil, nil, nil, client.DoFlags{})
+	_, err := cli.Do("GET", "/", nil, nil, nil, nil)
 	c.Assert(err, ErrorMatches, `.* timeout exceeded while waiting for response`)
 
-	_, err = cli.Do("POST", "/", nil, nil, nil, client.DoFlags{})
+	_, err = cli.Do("POST", "/", nil, nil, nil, nil)
 	c.Assert(err, ErrorMatches, `.* timeout exceeded while waiting for response`)
 }

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -30,11 +30,9 @@ func (client *Client) SetDoer(d doer) {
 	client.doer = d
 }
 
-type DoFlags = doFlags
-
 // Do does do.
-func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}, flags DoFlags) (statusCode int, err error) {
-	return client.do(method, path, query, nil, body, v, flags)
+func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}, opts *doOptions) (statusCode int, err error) {
+	return client.do(method, path, query, nil, body, v, opts)
 }
 
 // expose parseError for testing

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -30,8 +30,10 @@ func (client *Client) SetDoer(d doer) {
 	client.doer = d
 }
 
+type DoOptions = doOptions
+
 // Do does do.
-func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}, opts *doOptions) (statusCode int, err error) {
+func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}, opts *DoOptions) (statusCode int, err error) {
 	return client.do(method, path, query, nil, body, v, opts)
 }
 

--- a/client/icons.go
+++ b/client/icons.go
@@ -40,13 +40,12 @@ var contentDispositionMatcher = regexp.MustCompile(`attachment; filename=(.+)`).
 func (c *Client) Icon(pkgID string) (*Icon, error) {
 	const errPrefix = "cannot retrieve icon"
 
-	ctx, cancel := context.WithTimeout(context.Background(), doTimeout)
-	defer cancel()
-	response, err := c.raw(ctx, "GET", fmt.Sprintf("/v2/icons/%s/icon", pkgID), nil, nil, nil)
+	response, cancel, err := c.rawWithTimeout(context.Background(), "GET", fmt.Sprintf("/v2/icons/%s/icon", pkgID), nil, nil, nil, nil)
 	if err != nil {
 		fmt := "%s: failed to communicate with server: %w"
 		return nil, xerrors.Errorf(fmt, errPrefix, err)
 	}
+	defer cancel()
 	defer response.Body.Close()
 
 	if response.StatusCode != 200 {

--- a/client/model.go
+++ b/client/model.go
@@ -80,13 +80,12 @@ func (client *Client) CurrentSerialAssertion() (*asserts.Serial, error) {
 func currentAssertion(client *Client, path string) (asserts.Assertion, error) {
 	q := url.Values{}
 
-	ctx, cancel := context.WithTimeout(context.Background(), doTimeout)
-	defer cancel()
-	response, err := client.raw(ctx, "GET", path, q, nil, nil)
+	response, cancel, err := client.rawWithTimeout(context.Background(), "GET", path, q, nil, nil, nil)
 	if err != nil {
 		fmt := "failed to query current assertion: %w"
 		return nil, xerrors.Errorf(fmt, err)
 	}
+	defer cancel()
 	defer response.Body.Close()
 	if response.StatusCode != 200 {
 		return nil, parseError(response)

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -204,7 +204,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 		"Content-Type": "application/json",
 	}
 
-	return client.doAsyncFull("POST", "/v2/snaps", nil, headers, bytes.NewBuffer(data), doFlags{})
+	return client.doAsyncFull("POST", "/v2/snaps", nil, headers, bytes.NewBuffer(data), nil)
 }
 
 // InstallPath sideloads the snap with the given path under optional provided name,
@@ -230,7 +230,8 @@ func (client *Client) InstallPath(path, name string, options *SnapOptions) (chan
 		"Content-Type": mw.FormDataContentType(),
 	}
 
-	return client.doAsyncNoTimeout("POST", "/v2/snaps", nil, headers, pr)
+	_, changeID, err = client.doAsyncFull("POST", "/v2/snaps", nil, headers, pr, doNoTimeoutAndRetry)
+	return changeID, err
 }
 
 // Try


### PR DESCRIPTION
* they now can take a *doOptions uniformly to control timeout:
  - nil or absence uses the defaults
  - there's a predefined doNoTimeoutAndRetry to get no timeout
* there's only a simple and a full parameter variant of doSync and doAsync
* use rawWithTimeout in the places that were using raw but setting
  a timeout via context themselves