### PR TITLE
client,daemon,snap: use constant for snapshot content-type

### DIFF
--- a/client/snapshot.go
+++ b/client/snapshot.go
@@ -34,6 +34,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+const SnapshotExportContentType = "application/x.snapd.snapshot"
+
 var (
 	ErrSnapshotSetNotFound   = errors.New("no snapshot set with the given ID")
 	ErrSnapshotSnapsNotFound = errors.New("no snapshot for the requested snaps found in the set with the given ID")
@@ -198,7 +200,7 @@ func (client *Client) SnapshotExport(setID uint64) (stream io.ReadCloser, conten
 		return nil, 0, fmt.Errorf("unexpected status code: %v", rsp.Status)
 	}
 	contentType := rsp.Header.Get("Content-Type")
-	if contentType != "application/x.snapd.snapshot" {
+	if contentType != SnapshotExportContentType {
 		return nil, 0, fmt.Errorf("unexpected snapshot export content type %q", contentType)
 	}
 
@@ -214,7 +216,7 @@ type SnapshotImportSet struct {
 // SnapshotImport imports an exported snapshot set.
 func (client *Client) SnapshotImport(exportStream io.Reader) (SnapshotImportSet, error) {
 	headers := map[string]string{
-		"Content-Type": "application/x.snapd.snapshot",
+		"Content-Type": SnapshotExportContentType,
 	}
 
 	var importSet SnapshotImportSet

--- a/client/snapshot.go
+++ b/client/snapshot.go
@@ -34,7 +34,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// SnapshotExportMediaType is a media type used to identify snapshot exports in the API.
+// SnapshotExportMediaType is the media type used to identify snapshot exports in the API.
 const SnapshotExportMediaType = "application/x.snapd.snapshot"
 
 var (

--- a/client/snapshot.go
+++ b/client/snapshot.go
@@ -34,7 +34,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-const SnapshotExportContentType = "application/x.snapd.snapshot"
+// SnapshotExportMediaType is a media type used to identify snapshot exports in the API.
+const SnapshotExportMediaType = "application/x.snapd.snapshot"
 
 var (
 	ErrSnapshotSetNotFound   = errors.New("no snapshot set with the given ID")
@@ -200,7 +201,7 @@ func (client *Client) SnapshotExport(setID uint64) (stream io.ReadCloser, conten
 		return nil, 0, fmt.Errorf("unexpected status code: %v", rsp.Status)
 	}
 	contentType := rsp.Header.Get("Content-Type")
-	if contentType != SnapshotExportContentType {
+	if contentType != SnapshotExportMediaType {
 		return nil, 0, fmt.Errorf("unexpected snapshot export content type %q", contentType)
 	}
 
@@ -216,7 +217,7 @@ type SnapshotImportSet struct {
 // SnapshotImport imports an exported snapshot set.
 func (client *Client) SnapshotImport(exportStream io.Reader) (SnapshotImportSet, error) {
 	headers := map[string]string{
-		"Content-Type": SnapshotExportContentType,
+		"Content-Type": SnapshotExportMediaType,
 	}
 
 	var importSet SnapshotImportSet

--- a/client/snapshot_test.go
+++ b/client/snapshot_test.go
@@ -149,7 +149,7 @@ func (cs *clientSuite) TestClientExportSnapshot(c *check.C) {
 	}
 
 	table := []tableT{
-		{"dummy-export", "application/x.snapd.snapshot", 200},
+		{"dummy-export", client.SnapshotExportContentType, 200},
 		{"dummy-export", "application/x-tar", 400},
 		{"", "", 400},
 	}
@@ -206,7 +206,7 @@ func (cs *clientSuite) TestClientSnapshotImport(c *check.C) {
 			continue
 		}
 		c.Assert(err, check.IsNil, comm)
-		c.Assert(cs.req.Header.Get("Content-Type"), check.Equals, "application/x.snapd.snapshot")
+		c.Assert(cs.req.Header.Get("Content-Type"), check.Equals, client.SnapshotExportContentType)
 		c.Check(importSet.ID, check.Equals, t.setID, comm)
 		c.Check(importSet.Snaps, check.DeepEquals, []string{"baz", "bar", "foo"}, comm)
 	}

--- a/client/snapshot_test.go
+++ b/client/snapshot_test.go
@@ -149,7 +149,7 @@ func (cs *clientSuite) TestClientExportSnapshot(c *check.C) {
 	}
 
 	table := []tableT{
-		{"dummy-export", client.SnapshotExportContentType, 200},
+		{"dummy-export", client.SnapshotExportMediaType, 200},
 		{"dummy-export", "application/x-tar", 400},
 		{"", "", 400},
 	}
@@ -206,7 +206,7 @@ func (cs *clientSuite) TestClientSnapshotImport(c *check.C) {
 			continue
 		}
 		c.Assert(err, check.IsNil, comm)
-		c.Assert(cs.req.Header.Get("Content-Type"), check.Equals, client.SnapshotExportContentType)
+		c.Assert(cs.req.Header.Get("Content-Type"), check.Equals, client.SnapshotExportMediaType)
 		c.Check(importSet.ID, check.Equals, t.setID, comm)
 		c.Check(importSet.Snaps, check.DeepEquals, []string{"baz", "bar", "foo"}, comm)
 	}

--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -126,7 +126,7 @@ func (s *SnapSuite) mockSnapshotsServer(c *C) {
 				fmt.Fprintf(w, `{"type":"sync","status-code":200,"status":"OK","result":[{"id":1,"snapshots":[{"set":1,"time":%q,"snap":"htop","revision":"1168","snap-id":"Z","epoch":{"read":[0],"write":[0]},"summary":"","version":"2","sha3-384":{"archive.tgz":""},"size":1}]}]}`, snapshotTime)
 			}
 			if r.Method == "POST" {
-				if r.Header.Get("Content-Type") == client.SnapshotExportContentType {
+				if r.Header.Get("Content-Type") == client.SnapshotExportMediaType {
 					fmt.Fprintln(w, `{"type": "sync", "result": {"set-id": 42, "snaps": ["htop"]}}`)
 				} else {
 
@@ -137,7 +137,7 @@ func (s *SnapSuite) mockSnapshotsServer(c *C) {
 		case "/v2/changes/9":
 			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {}}}`)
 		case "/v2/snapshots/1/export":
-			w.Header().Set("Content-Type", client.SnapshotExportContentType)
+			w.Header().Set("Content-Type", client.SnapshotExportMediaType)
 			fmt.Fprint(w, "Hello World!")
 		default:
 			c.Errorf("unexpected path %q", r.URL.Path)

--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/client"
 	main "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -125,7 +126,7 @@ func (s *SnapSuite) mockSnapshotsServer(c *C) {
 				fmt.Fprintf(w, `{"type":"sync","status-code":200,"status":"OK","result":[{"id":1,"snapshots":[{"set":1,"time":%q,"snap":"htop","revision":"1168","snap-id":"Z","epoch":{"read":[0],"write":[0]},"summary":"","version":"2","sha3-384":{"archive.tgz":""},"size":1}]}]}`, snapshotTime)
 			}
 			if r.Method == "POST" {
-				if r.Header.Get("Content-Type") == "application/x.snapd.snapshot" {
+				if r.Header.Get("Content-Type") == client.SnapshotExportContentType {
 					fmt.Fprintln(w, `{"type": "sync", "result": {"set-id": 42, "snaps": ["htop"]}}`)
 				} else {
 
@@ -136,7 +137,7 @@ func (s *SnapSuite) mockSnapshotsServer(c *C) {
 		case "/v2/changes/9":
 			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {}}}`)
 		case "/v2/snapshots/1/export":
-			w.Header().Set("Content-Type", "application/x.snapd.snapshot")
+			w.Header().Set("Content-Type", client.SnapshotExportContentType)
 			fmt.Fprint(w, "Hello World!")
 		default:
 			c.Errorf("unexpected path %q", r.URL.Path)

--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -89,7 +89,7 @@ func (action snapshotAction) String() string {
 
 func changeSnapshots(c *Command, r *http.Request, user *auth.UserState) Response {
 	contentType := r.Header.Get("Content-Type")
-	if contentType == "application/x.snapd.snapshot" {
+	if contentType == client.SnapshotExportContentType {
 		return doSnapshotImport(c, r, user)
 	}
 

--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -89,7 +89,7 @@ func (action snapshotAction) String() string {
 
 func changeSnapshots(c *Command, r *http.Request, user *auth.UserState) Response {
 	contentType := r.Header.Get("Content-Type")
-	if contentType == client.SnapshotExportContentType {
+	if contentType == client.SnapshotExportMediaType {
 		return doSnapshotImport(c, r, user)
 	}
 

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -395,7 +395,7 @@ func (s *snapshotSuite) TestImportSnapshot(c *check.C) {
 
 	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
 	c.Assert(err, check.IsNil)
-	req.Header.Set("Content-Type", "application/x.snapd.snapshot")
+	req.Header.Set("Content-Type", client.SnapshotExportContentType)
 
 	rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
@@ -411,7 +411,7 @@ func (s *snapshotSuite) TestImportSnapshotError(c *check.C) {
 	data := []byte("mocked snapshot export data file")
 	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
 	c.Assert(err, check.IsNil)
-	req.Header.Set("Content-Type", "application/x.snapd.snapshot")
+	req.Header.Set("Content-Type", client.SnapshotExportContentType)
 
 	rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -395,7 +395,7 @@ func (s *snapshotSuite) TestImportSnapshot(c *check.C) {
 
 	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
 	c.Assert(err, check.IsNil)
-	req.Header.Set("Content-Type", client.SnapshotExportContentType)
+	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
 	rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
@@ -411,7 +411,7 @@ func (s *snapshotSuite) TestImportSnapshotError(c *check.C) {
 	data := []byte("mocked snapshot export data file")
 	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
 	c.Assert(err, check.IsNil)
-	req.Header.Set("Content-Type", client.SnapshotExportContentType)
+	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
 	rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -259,7 +259,7 @@ type snapshotExportResponse struct {
 // ServeHTTP from the Response interface
 func (s snapshotExportResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Length", strconv.FormatInt(s.Size(), 10))
-	w.Header().Add("Content-Type", "application/x.snapd.snapshot")
+	w.Header().Add("Content-Type", client.SnapshotExportContentType)
 	if err := s.StreamTo(w); err != nil {
 		logger.Debugf("cannot export snapshot: %v", err)
 	}

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -259,7 +259,7 @@ type snapshotExportResponse struct {
 // ServeHTTP from the Response interface
 func (s snapshotExportResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Length", strconv.FormatInt(s.Size(), 10))
-	w.Header().Add("Content-Type", client.SnapshotExportContentType)
+	w.Header().Add("Content-Type", client.SnapshotExportMediaType)
 	if err := s.StreamTo(w); err != nil {
 		logger.Debugf("cannot export snapshot: %v", err)
 	}


### PR DESCRIPTION
This commit makes the content-type of the import/export snapshot
data a constant.
