### PR TITLE
o/snapstate/autorefresh.go: eliminate race when launching autorefresh

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -203,6 +203,8 @@ func (m *autoRefresh) Ensure() error {
 	if CanAutoRefresh == nil {
 		return nil
 	}
+
+	// NOTE: this will unlock and re-lock state for network ops
 	if ok, err := CanAutoRefresh(m.state); err != nil || !ok {
 		return err
 	}
@@ -254,49 +256,49 @@ func (m *autoRefresh) Ensure() error {
 		logger.Debugf("Next refresh scheduled for %s.", m.nextRefresh.Format(time.RFC3339))
 	}
 
-	// should we hold back refreshes?
-	holdTime, err := m.EffectiveRefreshHold()
+	held, holdTime, err := m.isRefreshHeld(refreshSchedule)
 	if err != nil {
 		return err
 	}
-	if holdTime.After(now) {
-		return nil
-	}
-	if !holdTime.IsZero() {
-		// expired hold case
-		m.clearRefreshHold()
-		if m.nextRefresh.Before(holdTime) {
-			// next refresh is obsolete, compute the next one
-			delta := timeutil.Next(refreshSchedule, holdTime, maxPostponement)
-			now = time.Now()
-			m.nextRefresh = now.Add(delta)
-		}
-	}
 
 	// do refresh attempt (if needed)
-	if !m.nextRefresh.After(now) {
-		var can bool
-		can, err = m.canRefreshRespectingMetered(now, lastRefresh)
-		if err != nil {
-			return err
-		}
-		if !can {
-			// clear nextRefresh so that another refresh time is calculated
-			m.nextRefresh = time.Time{}
-			return nil
-		}
-
-		// Check that we have reasonable delays between attempts.
-		// If the store is under stress we need to make sure we do not
-		// hammer it too often
-		if !m.lastRefreshAttempt.IsZero() && m.lastRefreshAttempt.Add(refreshRetryDelay).After(time.Now()) {
-			return nil
+	if !held {
+		// expired hold case
+		if !holdTime.IsZero() {
+			m.clearRefreshHold()
+			if m.nextRefresh.Before(holdTime) {
+				// next refresh is obsolete, compute the next one
+				delta := timeutil.Next(refreshSchedule, holdTime, maxPostponement)
+				now = time.Now()
+				m.nextRefresh = now.Add(delta)
+			}
 		}
 
-		err = m.launchAutoRefresh()
-		if _, ok := err.(*httputil.PersistentNetworkError); !ok {
-			m.nextRefresh = time.Time{}
-		} // else - refresh will be retried after refreshRetryDelay
+		// refresh is also "held" if the next time is after now
+		if !m.nextRefresh.After(now) {
+			var can bool
+			can, err = m.canRefreshRespectingMetered(now, lastRefresh)
+			if err != nil {
+				return err
+			}
+			if !can {
+				// clear nextRefresh so that another refresh time is calculated
+				m.nextRefresh = time.Time{}
+				return nil
+			}
+
+			// Check that we have reasonable delays between attempts.
+			// If the store is under stress we need to make sure we do not
+			// hammer it too often
+			if !m.lastRefreshAttempt.IsZero() && m.lastRefreshAttempt.Add(refreshRetryDelay).After(time.Now()) {
+				return nil
+			}
+
+			err = m.launchAutoRefresh(refreshSchedule)
+			if _, ok := err.(*httputil.PersistentNetworkError); !ok {
+				m.nextRefresh = time.Time{}
+			} // else - refresh will be retried after refreshRetryDelay
+		}
 	}
 
 	return err
@@ -384,7 +386,7 @@ func (m *autoRefresh) refreshScheduleWithDefaultsFallback() (ts []*timeutil.Sche
 }
 
 // launchAutoRefresh creates the auto-refresh taskset and a change for it.
-func (m *autoRefresh) launchAutoRefresh() error {
+func (m *autoRefresh) launchAutoRefresh(refreshSchedule []*timeutil.Schedule) error {
 	perfTimings := timings.New(map[string]string{"ensure": "auto-refresh"})
 	tm := perfTimings.StartSpan("auto-refresh", "query store and setup auto-refresh change")
 	defer func() {
@@ -393,7 +395,29 @@ func (m *autoRefresh) launchAutoRefresh() error {
 	}()
 
 	m.lastRefreshAttempt = time.Now()
+
+	// NOTE: this will unlock and re-lock state for network ops
 	updated, tasksets, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
+
+	// TODO: we should have some way to lock just creating and starting changes,
+	//       as that would alleviate this race condition we are guarding against
+	//       with this check and probably would eliminate other similar race
+	//       conditions elsewhere
+
+	// re-check if the refresh is held because it could have been re-held and
+	// pushed back, in which case we need to abort the auto-refresh and wait
+	held, _, holdErr := m.isRefreshHeld(refreshSchedule)
+	if holdErr != nil {
+		return holdErr
+	}
+
+	if held {
+		// then a request came in that pushed the refresh out, so we will need
+		// to try again later
+		logger.Noticef("Auto-refresh was delayed mid-way through launching, aborting to try again later")
+		return nil
+	}
+
 	if _, ok := err.(*httputil.PersistentNetworkError); ok {
 		logger.Noticef("Cannot prepare auto-refresh change due to a permanent network error: %s", err)
 		return err
@@ -525,4 +549,18 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 		}
 	}
 	return nil
+}
+
+func (m *autoRefresh) isRefreshHeld(refreshSchedule []*timeutil.Schedule) (bool, time.Time, error) {
+	now := time.Now()
+	// should we hold back refreshes?
+	holdTime, err := m.EffectiveRefreshHold()
+	if err != nil {
+		return false, time.Time{}, err
+	}
+	if holdTime.After(now) {
+		return true, holdTime, nil
+	}
+
+	return false, holdTime, nil
 }

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -274,8 +274,8 @@ func (m *autoRefresh) Ensure() error {
 			}
 		}
 
-		// refresh is also "held" if the next time is after now
-		if !m.nextRefresh.After(now) {
+		// refresh is also "held" if the next time is in the future
+		if m.nextRefresh.Before(now) {
 			var can bool
 			can, err = m.canRefreshRespectingMetered(now, lastRefresh)
 			if err != nil {

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -275,7 +275,9 @@ func (m *autoRefresh) Ensure() error {
 		}
 
 		// refresh is also "held" if the next time is in the future
-		if m.nextRefresh.Before(now) {
+		// note that After() is also true if the two times are equal, while
+		// Before() is not, hence it is simpler to just use !After() here
+		if !m.nextRefresh.After(now) {
 			var can bool
 			can, err = m.canRefreshRespectingMetered(now, lastRefresh)
 			if err != nil {

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -261,8 +261,8 @@ func (m *autoRefresh) Ensure() error {
 
 	// do refresh attempt (if needed)
 	if !held {
-		// expired hold case
 		if !holdTime.IsZero() {
+			// expired hold case
 			m.clearRefreshHold()
 			if m.nextRefresh.Before(holdTime) {
 				// next refresh is obsolete, compute the next one

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -203,8 +203,6 @@ func (m *autoRefresh) Ensure() error {
 	if CanAutoRefresh == nil {
 		return nil
 	}
-
-	// NOTE: this will unlock and re-lock state for network ops
 	if ok, err := CanAutoRefresh(m.state); err != nil || !ok {
 		return err
 	}

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -275,8 +275,10 @@ func (m *autoRefresh) Ensure() error {
 		}
 
 		// refresh is also "held" if the next time is in the future
-		// note that After() is also true if the two times are equal, while
-		// Before() is not, hence it is simpler to just use !After() here
+		// note that the two times here could be exactly equal, so we use
+		// !After() because that is true in the case that the next refresh is
+		// before now, and the next refresh is equal to now without requiring an
+		// or operation
 		if !m.nextRefresh.After(now) {
 			var can bool
 			can, err = m.canRefreshRespectingMetered(now, lastRefresh)

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -105,6 +105,8 @@ func (s *autoRefreshTestSuite) SetUpTest(c *C) {
 
 	s.store = &autoRefreshStore{}
 
+	s.AddCleanup(func() { s.store.snapActionOpsFunc = nil })
+
 	s.state.Lock()
 	defer s.state.Unlock()
 	snapstate.ReplaceStore(s.state, s.store)
@@ -496,9 +498,6 @@ func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredButResetWhileLoc
 			<-ch
 		}
 	}
-	defer func() {
-		s.store.snapActionOpsFunc = nil
-	}()
 
 	af := snapstate.NewAutoRefresh(s.state)
 	s.state.Unlock()

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -61,28 +61,30 @@ func (r *autoRefreshStore) SnapAction(ctx context.Context, currentSnaps []*store
 	// change the auto-refresh hold
 	if r.snapActionOpsFunc != nil {
 		r.snapActionOpsFunc()
-	} else {
-		if assertQuery != nil {
-			panic("no assertion query support")
-		}
-		if !opts.IsAutoRefresh {
-			panic("AutoRefresh snap action did not set IsAutoRefresh flag")
-		}
-
-		if ctx == nil || !auth.IsEnsureContext(ctx) {
-			panic("Ensure marked context required")
-		}
-		if len(currentSnaps) != len(actions) || len(currentSnaps) == 0 {
-			panic("expected in test one action for each current snaps, and at least one snap")
-		}
-		for _, a := range actions {
-			if a.Action != "refresh" {
-				panic("expected refresh actions")
-			}
-		}
-
-		r.ops = append(r.ops, "list-refresh")
+		return nil, nil, r.err
 	}
+
+	if assertQuery != nil {
+		panic("no assertion query support")
+	}
+	if !opts.IsAutoRefresh {
+		panic("AutoRefresh snap action did not set IsAutoRefresh flag")
+	}
+
+	if ctx == nil || !auth.IsEnsureContext(ctx) {
+		panic("Ensure marked context required")
+	}
+	if len(currentSnaps) != len(actions) || len(currentSnaps) == 0 {
+		panic("expected in test one action for each current snaps, and at least one snap")
+	}
+	for _, a := range actions {
+		if a.Action != "refresh" {
+			panic("expected refresh actions")
+		}
+	}
+
+	r.ops = append(r.ops, "list-refresh")
+
 	return nil, nil, r.err
 }
 

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -524,8 +525,11 @@ func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredButResetWhileLoc
 
 	// we shouldn't have had a message about "all snaps are up to date", we
 	// should have a message about being aborted mid way
-	c.Assert(logbuf.String(), testutil.Contains, "Auto-refresh was delayed mid-way through launching, aborting to try again later")
-	c.Assert(logbuf.String(), testutil.Contains, "auto-refresh: all snaps are up-to-date")
+
+	re1 := regexp.MustCompile(`(?m).*Auto-refresh was delayed mid-way through launching, aborting to try again later`)
+	c.Assert(re1.Match([]byte(logbuf.String())), Equals, true)
+	re2 := regexp.MustCompile(`(?m).*auto-refresh: all snaps are up-to-date`)
+	c.Assert(re2.Match([]byte(logbuf.String())), Equals, false)
 }
 
 func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredReschedule(c *C) {

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -526,7 +526,7 @@ func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredButResetWhileLoc
 	// should have a message about being aborted mid way
 
 	c.Assert(logbuf.String(), testutil.Contains, "Auto-refresh was delayed mid-way through launching, aborting to try again later")
-	c.Assert(logbuf.String(), testutil.Contains, "auto-refresh: all snaps are up-to-date")
+	c.Assert(logbuf.String(), Not(testutil.Contains), "auto-refresh: all snaps are up-to-date")
 }
 
 func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredReschedule(c *C) {

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -524,8 +524,8 @@ func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredButResetWhileLoc
 
 	// we shouldn't have had a message about "all snaps are up to date", we
 	// should have a message about being aborted mid way
-	c.Assert(strings.Contains(logbuf.String(), "Auto-refresh was delayed mid-way through launching, aborting to try again later"), Equals, true)
-	c.Assert(strings.Contains(logbuf.String(), "auto-refresh: all snaps are up-to-date"), Equals, false)
+	c.Assert(logbuf.String(), testutil.Contains, "Auto-refresh was delayed mid-way through launching, aborting to try again later")
+	c.Assert(logbuf.String(), testutil.Contains, "auto-refresh: all snaps are up-to-date")
 }
 
 func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredReschedule(c *C) {

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -526,10 +525,8 @@ func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredButResetWhileLoc
 	// we shouldn't have had a message about "all snaps are up to date", we
 	// should have a message about being aborted mid way
 
-	re1 := regexp.MustCompile(`(?m).*Auto-refresh was delayed mid-way through launching, aborting to try again later`)
-	c.Assert(re1.Match([]byte(logbuf.String())), Equals, true)
-	re2 := regexp.MustCompile(`(?m).*auto-refresh: all snaps are up-to-date`)
-	c.Assert(re2.Match([]byte(logbuf.String())), Equals, false)
+	c.Assert(logbuf.String(), testutil.Contains, "Auto-refresh was delayed mid-way through launching, aborting to try again later")
+	c.Assert(logbuf.String(), testutil.Contains, "auto-refresh: all snaps are up-to-date")
 }
 
 func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredReschedule(c *C) {


### PR DESCRIPTION
When ensuring that an autorefresh is held via console-conf-start, we need to get
a state lock and set the refresh hold, but if another task in overlord already
started an auto-refresh, via autoRefresh.Ensure(), it will at some point release
the lock because it does network operations after checking whether the
auto-refresh should be held back or not, effectively meaning that the hold gets
ignored. To remedy this, we should check whether there is an effective hold
again right before actually queueing up the change to be run by the overlord.

Also add a unit test for this situation.

This race condition is not currently a problem unless someone tries to do `snap set system refresh.hold="tomorrow"` during the short window here, but the race condition is much more likely to happen with my upcoming work on console-conf where snapd will be racing trying to launch it's first auto-refresh with console-conf trying to simultaneously disable auto-refresh and if console-conf hits this window, we want console-conf to win.