### PR TITLE
secboot: fix tpm connection leak when it's not enabled

### DIFF
--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -85,6 +85,7 @@ func CheckKeySealingSupported() error {
 		logger.Noticef("%v", err)
 		return err
 	}
+	defer tpm.Close()
 
 	if !isTPMEnabled(tpm) {
 		logger.Noticef("TPM device detected but not enabled")
@@ -93,7 +94,7 @@ func CheckKeySealingSupported() error {
 
 	logger.Noticef("TPM device detected and enabled")
 
-	return tpm.Close()
+	return nil
 }
 
 func checkSecureBootEnabled() error {


### PR DESCRIPTION
Make sure the device is properly closed when checking if the system's
TPM is present and enabled, even if it's not enabled.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>