### PR TITLE
o/configstate: create /etc/sysctl.d when applying early config defaults

### DIFF
--- a/overlord/configstate/configcore/sysctl.go
+++ b/overlord/configstate/configcore/sysctl.go
@@ -93,7 +93,7 @@ func handleSysctlConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error 
 	}
 
 	dir := filepath.Join(root, sysctlConfsDir)
-	if opts != nil && !osutil.IsDirectory(dir) {
+	if opts != nil {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}

--- a/overlord/configstate/configcore/sysctl.go
+++ b/overlord/configstate/configcore/sysctl.go
@@ -22,6 +22,7 @@ package configcore
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -91,8 +92,14 @@ func handleSysctlConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error 
 		}
 	}
 
-	// write the new config
 	dir := filepath.Join(root, sysctlConfsDir)
+	if opts != nil && !osutil.IsDirectory(dir) {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+
+	// write the new config
 	glob := snapdSysctlConf
 	changed, removed, err := osutil.EnsureDirState(dir, glob, dirContent)
 	if err != nil {

--- a/overlord/configstate/configcore/sysctl_test.go
+++ b/overlord/configstate/configcore/sysctl_test.go
@@ -130,7 +130,6 @@ func (s *sysctlSuite) TestFilesystemOnlyApply(c *C) {
 	})
 
 	tmpDir := c.MkDir()
-	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "/etc/sysctl.d/"), 0755), IsNil)
 	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
 
 	networkSysctlPath := filepath.Join(tmpDir, "/etc/sysctl.d/99-snapd.conf")


### PR DESCRIPTION
The <writable defaults>/etc/systctl.d may not exist when applying early config defaults and fails when applies from the gadget. This was hidden by the test which created the directory on start. This PR fixes it.
