### PR TITLE
daemon,snapshotstate: do not return "size" from Import()

### DIFF
--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -189,7 +189,7 @@ func doSnapshotImport(c *Command, r *http.Request, user *auth.UserState) Respons
 
 	// XXX: check that we have enough space to import the compressed snapshots
 	st := c.d.overlord.State()
-	setID, snapNames, _, err := snapshotImport(context.TODO(), st, r.Body, expectedSize)
+	setID, snapNames, err := snapshotImport(context.TODO(), st, r.Body, expectedSize)
 	if err != nil {
 		return BadRequest(err.Error())
 	}

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -388,10 +388,9 @@ func (s *snapshotSuite) TestImportSnapshot(c *check.C) {
 	data := []byte("mocked snapshot export data file")
 
 	setID := uint64(3)
-	size := int64(len(data))
 	snapNames := []string{"baz", "bar", "foo"}
-	defer daemon.MockSnapshotImport(func(context.Context, *state.State, io.Reader, int64) (uint64, []string, int64, error) {
-		return setID, snapNames, size, nil
+	defer daemon.MockSnapshotImport(func(context.Context, *state.State, io.Reader, int64) (uint64, []string, error) {
+		return setID, snapNames, nil
 	})()
 
 	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
@@ -406,8 +405,8 @@ func (s *snapshotSuite) TestImportSnapshot(c *check.C) {
 }
 
 func (s *snapshotSuite) TestImportSnapshotError(c *check.C) {
-	defer daemon.MockSnapshotImport(func(context.Context, *state.State, io.Reader, int64) (uint64, []string, int64, error) {
-		return uint64(0), nil, 0, errors.New("no")
+	defer daemon.MockSnapshotImport(func(context.Context, *state.State, io.Reader, int64) (uint64, []string, error) {
+		return uint64(0), nil, errors.New("no")
 	})()
 
 	data := []byte("mocked snapshot export data file")
@@ -423,10 +422,6 @@ func (s *snapshotSuite) TestImportSnapshotError(c *check.C) {
 }
 
 func (s *snapshotSuite) TestImportSnapshotNoContentLengthError(c *check.C) {
-	defer daemon.MockSnapshotImport(func(context.Context, *state.State, io.Reader, int64) (uint64, []string, int64, error) {
-		return uint64(0), nil, 0, errors.New("no")
-	})()
-
 	data := []byte("mocked snapshot export data file")
 	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
 	c.Assert(err, check.IsNil)

--- a/daemon/export_api_snapshots_test.go
+++ b/daemon/export_api_snapshots_test.go
@@ -81,7 +81,7 @@ func MockSnapshotForget(newForget func(*state.State, uint64, []string) ([]string
 	}
 }
 
-func MockSnapshotImport(newImport func(context.Context, *state.State, io.Reader, int64) (uint64, []string, int64, error)) (restore func()) {
+func MockSnapshotImport(newImport func(context.Context, *state.State, io.Reader, int64) (uint64, []string, error)) (restore func()) {
 	oldImport := snapshotImport
 	snapshotImport = newImport
 	return func() {

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -293,8 +293,8 @@ func checkSnapshotTaskConflict(st *state.State, setID uint64, conflictingKinds .
 var List = backend.List
 
 // Import a given snapshot ID from an exported snapshot
-func Import(ctx context.Context, st *state.State, r io.Reader, size int64) (uint64, []string, int64, error) {
-	return 0, nil, 0, fmt.Errorf("snapshot import not implemented yet")
+func Import(ctx context.Context, st *state.State, r io.Reader, size int64) (setID uint64, snapNames []string, err error) {
+	return 0, nil, fmt.Errorf("snapshot import not implemented yet")
 }
 
 // Save creates a taskset for taking snapshots of snaps' data.


### PR DESCRIPTION
We don't really use the size of the imported snapshot anywhere (here or in #9036)
so this commit just removes it from:
```
snapshotstate.Import()
```
it also adds names to the returned parameters.


Build on top of #9461