### PR TITLE
github: switch from ::set-env command to environment file

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       id: cached-results
       run: |
           CACHE_RESULT_STAMP="${{ github.workspace }}/.test-results/snap-build-success"
-          echo "::set-env name=CACHE_RESULT_STAMP::$CACHE_RESULT_STAMP"
+          echo "CACHE_RESULT_STAMP=$CACHE_RESULT_STAMP" >> $GITHUB_ENV
           if [ -e "$CACHE_RESULT_STAMP" ]; then
               has_cached_snap=0
               while read name; do
@@ -110,7 +110,7 @@ jobs:
       id: cached-results
       run: |
           CACHE_RESULT_STAMP="${{ github.workspace }}/.test-results/${{ matrix.gochannel }}-success"
-          echo "::set-env name=CACHE_RESULT_STAMP::$CACHE_RESULT_STAMP"
+          echo "CACHE_RESULT_STAMP=$CACHE_RESULT_STAMP" >> $GITHUB_ENV
           if [ -e "$CACHE_RESULT_STAMP" ]; then
               echo "::set-output name=already-ran::true"
           fi
@@ -219,7 +219,7 @@ jobs:
       id: cached-results
       run: |
           CACHE_RESULT_STAMP="${{ github.workspace }}/.test-results/${{ matrix.system }}-success"
-          echo "::set-env name=CACHE_RESULT_STAMP::$CACHE_RESULT_STAMP"
+          echo "CACHE_RESULT_STAMP=$CACHE_RESULT_STAMP" >> $GITHUB_ENV
           if [ -e "$CACHE_RESULT_STAMP" ]; then
               echo "::set-output name=already-ran::true"
           fi
@@ -271,7 +271,7 @@ jobs:
       id: cached-results
       run: |
           CACHE_RESULT_STAMP="${{ github.workspace }}/.test-results/${{ matrix.system }}-nested-success"
-          echo "::set-env name=CACHE_RESULT_STAMP::$CACHE_RESULT_STAMP"
+          echo "CACHE_RESULT_STAMP=$CACHE_RESULT_STAMP" >> $GITHUB_ENV
           if [ -e "$CACHE_RESULT_STAMP" ]; then
               echo "::set-output name=already-ran::true"
           fi


### PR DESCRIPTION
As detailed in CVE-2020-15228, the Github runners will drop support for the ::set-env and ::add-path commands at some point in the future, in favour of the new environment file syntax.

More details are available here: https://github.com/advisories/GHSA-mfwh-5m23-j46w