### PR TITLE
tests/core/uc20-recovery: fix mkdir error on second boot into recovery

### DIFF
--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -67,7 +67,7 @@ execute: |
         # that spread uses
         # silence the output so that nothing is output to a ssh command,
         # potentially confusing spread
-        sudo mkdir /home/gopath > /dev/null
+        sudo mkdir -p /home/gopath > /dev/null
         sudo mount --bind /host/ubuntu-data/user-data/gopath /home/gopath > /dev/null
     fi
     EOF


### PR DESCRIPTION
Sometimes, the 2nd reboot into recovery will fail to recover from spread runs,
because mkdir will complain about the dir already existing, and for whatever
reason this causes unexpected/unhandled packets to be sent via SSH to spread and
then spread fails the run eventually, being unable to make a normal SSH
connection. This is probably either a spread bug or a Go stdlib bug with SSH
handling, but for now we can just work around it by silencing the mkdir error
with the "-p" option to not complain if the directory already exists.

Forward-port PR to master of https://github.com/snapcore/snapd/pull/9465