### PR TITLE
daemon: limit reading from snapshot import to Content-Length

### DIFF
--- a/client/snapshot.go
+++ b/client/snapshot.go
@@ -215,9 +215,10 @@ type SnapshotImportSet struct {
 }
 
 // SnapshotImport imports an exported snapshot set.
-func (client *Client) SnapshotImport(exportStream io.Reader) (SnapshotImportSet, error) {
+func (client *Client) SnapshotImport(exportStream io.Reader, size int64) (SnapshotImportSet, error) {
 	headers := map[string]string{
-		"Content-Type": SnapshotExportMediaType,
+		"Content-Type":   SnapshotExportMediaType,
+		"Content-Length": strconv.FormatInt(size, 10),
 	}
 
 	var importSet SnapshotImportSet

--- a/client/snapshot_test.go
+++ b/client/snapshot_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -198,8 +199,9 @@ func (cs *clientSuite) TestClientSnapshotImport(c *check.C) {
 		cs.rsp = t.rsp
 		cs.status = t.status
 
-		r := strings.NewReader("Hello World!")
-		importSet, err := cs.cli.SnapshotImport(r)
+		fakeSnapshotData := "fake"
+		r := strings.NewReader(fakeSnapshotData)
+		importSet, err := cs.cli.SnapshotImport(r, int64(len(fakeSnapshotData)))
 		if t.error != "" {
 			c.Assert(err, check.NotNil, comm)
 			c.Check(err.Error(), check.Equals, t.error, comm)
@@ -207,7 +209,11 @@ func (cs *clientSuite) TestClientSnapshotImport(c *check.C) {
 		}
 		c.Assert(err, check.IsNil, comm)
 		c.Assert(cs.req.Header.Get("Content-Type"), check.Equals, client.SnapshotExportMediaType)
+		c.Assert(cs.req.Header.Get("Content-Length"), check.Equals, strconv.Itoa(len(fakeSnapshotData)))
 		c.Check(importSet.ID, check.Equals, t.setID, comm)
 		c.Check(importSet.Snaps, check.DeepEquals, []string{"baz", "bar", "foo"}, comm)
+		d, err := ioutil.ReadAll(cs.req.Body)
+		c.Assert(err, check.IsNil)
+		c.Check(string(d), check.Equals, fakeSnapshotData)
 	}
 }

--- a/cmd/snap/cmd_snapshot.go
+++ b/cmd/snap/cmd_snapshot.go
@@ -505,8 +505,12 @@ func (x *importSnapshotCmd) Execute([]string) error {
 		return fmt.Errorf("error accessing file: %v", err)
 	}
 	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("cannot stat file: %v", err)
+	}
 
-	importSet, err := x.client.SnapshotImport(f)
+	importSet, err := x.client.SnapshotImport(f, st.Size())
 	if err != nil {
 		return err
 	}

--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -182,9 +182,14 @@ func getSnapshotExport(c *Command, r *http.Request, user *auth.UserState) Respon
 func doSnapshotImport(c *Command, r *http.Request, user *auth.UserState) Response {
 	defer r.Body.Close()
 
+	expectedSize, err := strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64)
+	if err != nil {
+		return BadRequest("cannot parse Content-Length: %v", err)
+	}
+
 	// XXX: check that we have enough space to import the compressed snapshots
 	st := c.d.overlord.State()
-	setID, snapNames, _, err := snapshotImport(context.TODO(), st, r.Body)
+	setID, snapNames, _, err := snapshotImport(context.TODO(), st, r.Body, expectedSize)
 	if err != nil {
 		return BadRequest(err.Error())
 	}

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -436,4 +437,27 @@ func (s *snapshotSuite) TestImportSnapshotNoContentLengthError(c *check.C) {
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.ErrorResult().Message, check.Equals, `cannot parse Content-Length: strconv.ParseInt: parsing "": invalid syntax`)
+}
+
+func (s *snapshotSuite) TestImportSnapshotLimits(c *check.C) {
+	var dataRead int
+
+	defer daemon.MockSnapshotImport(func(ctx context.Context, st *state.State, r io.Reader, expectedSize int64) (uint64, []string, int64, error) {
+		data, err := ioutil.ReadAll(r)
+		c.Assert(err, check.IsNil)
+		dataRead = len(data)
+		return uint64(0), nil, int64(0), nil
+	})()
+
+	data := []byte("much more data than expected from Content-Length")
+	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
+	// limit to 10 and check that this is really all that is read
+	req.Header.Add("Content-Length", "10")
+	c.Assert(err, check.IsNil)
+	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
+
+	rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
+	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeSync)
+	c.Check(rsp.Status, check.Equals, 200)
+	c.Check(dataRead, check.Equals, 10)
 }

--- a/daemon/export_api_snapshots_test.go
+++ b/daemon/export_api_snapshots_test.go
@@ -81,7 +81,7 @@ func MockSnapshotForget(newForget func(*state.State, uint64, []string) ([]string
 	}
 }
 
-func MockSnapshotImport(newImport func(context.Context, *state.State, io.Reader) (uint64, []string, int64, error)) (restore func()) {
+func MockSnapshotImport(newImport func(context.Context, *state.State, io.Reader, int64) (uint64, []string, int64, error)) (restore func()) {
 	oldImport := snapshotImport
 	snapshotImport = newImport
 	return func() {

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -293,7 +293,7 @@ func checkSnapshotTaskConflict(st *state.State, setID uint64, conflictingKinds .
 var List = backend.List
 
 // Import a given snapshot ID from an exported snapshot
-func Import(ctx context.Context, st *state.State, r io.Reader) (uint64, []string, int64, error) {
+func Import(ctx context.Context, st *state.State, r io.Reader, size int64) (uint64, []string, int64, error) {
 	return 0, nil, 0, fmt.Errorf("snapshot import not implemented yet")
 }
 


### PR DESCRIPTION
We know the expected content length so limit the amount of data
that will be read from the daemon.

Based on #9461