### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: also copy /etc/machine-id for same IP addr

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -163,6 +163,11 @@ func copyNetworkConfig(src, dst string) error {
 		//            network configuration for recover mode as well, but for
 		//            now this is fine
 		"system-data/etc/netplan/*",
+		// etc/machine-id is part of what systemd-networkd uses to generate a
+		// DHCP clientid (the other part being the interface name), so to have
+		// the same IP addresses across run mode and recover mode, we need to
+		// also copy the machine-id across
+		"system-data/etc/machine-id",
 	} {
 		if err := copyFromGlobHelper(src, dst, globEx); err != nil {
 			return err

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1632,6 +1632,7 @@ func (s *initramfsMountsSuite) testRecoverModeHappy(c *C) {
 		"system-data/etc/netplan/50-cloud-init.yaml",   // example cloud-init filename
 		// systemd clock file
 		"system-data/var/lib/systemd/timesync/clock",
+		"system-data/etc/machine-id", // machine-id for systemd-networkd
 	}
 	mockUnrelatedFiles := []string{
 		"system-data/var/lib/foo",
@@ -1641,6 +1642,7 @@ func (s *initramfsMountsSuite) testRecoverModeHappy(c *C) {
 		"user-data/user2/.snap/sneaky-not-auth.json",
 		"system-data/etc/not-networking/netplan",
 		"system-data/var/lib/systemd/timesync/clock-not-the-clock",
+		"system-data/etc/machine-id-except-not",
 	}
 	for _, mockFile := range append(mockCopiedFiles, mockUnrelatedFiles...) {
 		p := filepath.Join(hostUbuntuData, mockFile)


### PR DESCRIPTION
In order to have the same IP address in recover mode as in run mode, we need to
have /etc/machine-id be the same in recover mode and run mode, as
systemd-networkd uses that along with the interface name to generate a stable
DHCP clientid, which is what goes into DHCP lease requests.

We didn't catch this in tests because in tests the machine-id is generated from VM 
firmware, as per @xnox [here](https://github.com/snapcore/core20/issues/88#issuecomment-704459418):

> Note this probably is not observed under libvirt-qemu, because UUID is allocated in firmware, and exposed at runtime, which systemd uses to initialize machine-id. Which is only done on KVM-QEMU. On real bare-metal, fresh machine-id is initialized from random uuid, if not otherwise there. DHCP clientid in networkd is stable and is generated from interface name + machine-id, hence change of machine-id, results in change of DHCP clientid, and thus a different lease.

