### PR TITLE
tests: fix journal-state test

### DIFF
--- a/tests/lib/tools/suite/journal-state/task.yaml
+++ b/tests/lib/tools/suite/journal-state/task.yaml
@@ -30,13 +30,13 @@ execute: |
     # Check that the subcommand get-log works
     echo "TEST-XX1" | systemd-cat -t snapd-test
     # shellcheck disable=SC2016
-    retry --wait 1 --attempts 10 sh -c 'test $("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX1) -eq 1'
+    retry --wait 1 --attempts 10 sh -c 'test "$("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX1)" -eq 1'
 
     # Check that the subcommand get-last-cursor works
     echo "TEST-XX2" | systemd-cat -t snapd-test
     echo "Add some extra logs" | systemd-cat -t different-test
     # shellcheck disable=SC2016
-    retry --wait 1 --attempts 10 sh -c 'test $("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX2) -eq 1'
+    retry --wait 1 --attempts 10 sh -c 'test "$("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX2)" -eq 1'
 
     cursor2=$("$TESTSTOOLS"/journal-state get-last-cursor)
     test "$("$TESTSTOOLS"/journal-state get-log-from-cursor "$cursor2" | grep -c "TEST-XX1")" -eq 0

--- a/tests/lib/tools/suite/journal-state/task.yaml
+++ b/tests/lib/tools/suite/journal-state/task.yaml
@@ -13,7 +13,15 @@ execute: |
     # Check that the test is correctly started in the journal log
     "$TESTSTOOLS"/journal-state start-new-log
     echo "Add some extra logs" | systemd-cat -t snapd-test
-    retry --wait 1 --attempts 30 sh -c "test $(journalctl --cursor "$cursor1" | grep -c "$SPREAD_JOB") -eq 1"
+    # Here cannot be used the retry tool because we need to evaluate the whole
+    # test command within the retry but the cursor1 var within the test
+    for _ in $(seq 10); do
+        if test $(journalctl --cursor "$cursor1" | grep -c "$SPREAD_JOB") -eq 1; then
+            break
+        fi
+        sleep 1
+    done
+    test $(journalctl --cursor "$cursor1" | grep -c "$SPREAD_JOB") -eq 1
 
     # Check that the subcommand check-log-started works
     # The subcommand check-log-started could fail if the log does not contain the current SPREAD_JOB information
@@ -21,12 +29,12 @@ execute: |
 
     # Check that the subcommand get-log works
     echo "TEST-XX1" | systemd-cat -t snapd-test
-    retry --wait 1 --attempts 30 sh -c "test $("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX1) -eq 1"
+    retry --wait 1 --attempts 10 sh -c 'test $("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX1) -eq 1'
 
     # Check that the subcommand get-last-cursor works
     echo "TEST-XX2" | systemd-cat -t snapd-test
     echo "Add some extra logs" | systemd-cat -t different-test
-    retry --wait 1 --attempts 30 sh -c "test $("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX2) -eq 1"
+    retry --wait 1 --attempts 10 sh -c 'test $("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX2) -eq 1'
 
     cursor2=$("$TESTSTOOLS"/journal-state get-last-cursor)
     test "$("$TESTSTOOLS"/journal-state get-log-from-cursor "$cursor2" | grep -c "TEST-XX1")" -eq 0

--- a/tests/lib/tools/suite/journal-state/task.yaml
+++ b/tests/lib/tools/suite/journal-state/task.yaml
@@ -13,15 +13,8 @@ execute: |
     # Check that the test is correctly started in the journal log
     "$TESTSTOOLS"/journal-state start-new-log
     echo "Add some extra logs" | systemd-cat -t snapd-test
-    # Here cannot be used the retry tool because we need to evaluate the whole
-    # test command within the retry but the cursor1 var within the test
-    for _ in $(seq 10); do
-        if test $(journalctl --cursor "$cursor1" | grep -c "$SPREAD_JOB") -eq 1; then
-            break
-        fi
-        sleep 1
-    done
-    test $(journalctl --cursor "$cursor1" | grep -c "$SPREAD_JOB") -eq 1
+    # shellcheck disable=SC2016
+    retry --wait 1 --attempts 10 sh -c 'test $(journalctl --cursor '\'"$cursor1"\'' | grep -c '"$SPREAD_JOB"') -eq 1'
 
     # Check that the subcommand check-log-started works
     # The subcommand check-log-started could fail if the log does not contain the current SPREAD_JOB information

--- a/tests/lib/tools/suite/journal-state/task.yaml
+++ b/tests/lib/tools/suite/journal-state/task.yaml
@@ -29,11 +29,13 @@ execute: |
 
     # Check that the subcommand get-log works
     echo "TEST-XX1" | systemd-cat -t snapd-test
+    # shellcheck disable=SC2016
     retry --wait 1 --attempts 10 sh -c 'test $("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX1) -eq 1'
 
     # Check that the subcommand get-last-cursor works
     echo "TEST-XX2" | systemd-cat -t snapd-test
     echo "Add some extra logs" | systemd-cat -t different-test
+    # shellcheck disable=SC2016
     retry --wait 1 --attempts 10 sh -c 'test $("$TESTSTOOLS"/journal-state get-log | grep -c TEST-XX2) -eq 1'
 
     cursor2=$("$TESTSTOOLS"/journal-state get-last-cursor)


### PR DESCRIPTION
The fix is to avoid the test command is evaluated as part of the test
instead of being evaluated for each retry

error: 
> systemd-cat -t snapd-test
> echo 'Add some extra logs'
> grep -c google:ubuntu-20.10-64:tests/lib/tools/suite/journal-state
> journalctl --cursor 's=57e5493c828d495ab7d3f36e66653bd8;i=a02;b=4b1503056c4e4326b9a4918bd9c8dab4;m=28903434;t=5b101a02c4bd5;x=cb5218a0470c1d7'
> retry --wait 1 --attempts 30 sh -c 'test 0 -eq 1'
retry: command sh -c test 0 -eq 1 failed with code 1
retry: next attempt in 1.0 second(s) (attempt 1 of 30)
. . .
retry: next attempt in 1.0 second(s) (attempt 28 of 30)
retry: command sh -c test 0 -eq 1 failed with code 1
retry: next attempt in 1.0 second(s) (attempt 29 of 30)
retry: command sh -c test 0 -eq 1 failed with code 1
retry: command sh -c test 0 -eq 1 keeps failing after 30 attempts
