### PR TITLE
tests: add tests.cleanup pop sub-command

### DIFF
--- a/tests/lib/tools/suite/tests.cleanup/task.yaml
+++ b/tests/lib/tools/suite/tests.cleanup/task.yaml
@@ -11,6 +11,7 @@ execute: |
     # Without any arguments a help message is printed.
     tests.cleanup | MATCH "usage: tests.cleanup prepare"
     tests.cleanup | MATCH "       tests.cleanup defer <cmd> \[args\]"
+    tests.cleanup | MATCH "       tests.cleanup pop"
     tests.cleanup | MATCH "       tests.cleanup restore"
 
     # Both -h and --help are also recognized.
@@ -72,3 +73,26 @@ execute: |
     tests.invariant check leftover-defer-sh 2>&1 | MATCH "tests.invariant: leftover defer.sh script"
     rm -f defer.sh
     tests.invariant check leftover-defer-sh
+
+    # Deferred commands can be popped and executed one by one. This is useful
+    # to ensure correctness in case of failure while still allowing precise
+    # resource management.
+    tests.cleanup prepare
+    tests.cleanup defer echo popped
+    tests.cleanup pop | MATCH popped
+
+    # Popping removes the last command from the stack
+    tests.cleanup defer echo cmd-a
+    tests.cleanup defer echo cmd-b
+    tests.cleanup defer echo cmd-c
+    tests.cleanup pop | MATCH cmd-c
+    diff -u defer.sh - <<EXPECTED
+    echo cmd-a
+    echo cmd-b
+    EXPECTED
+    tests.cleanup restore
+
+    # Popping a command when there isn't any fails with an appropriate message
+    tests.cleanup prepare
+    tests.cleanup pop 2>&1 | MATCH 'tests.cleanup: cannot pop, cleanup stack is empty'
+    not tests.cleanup pop

--- a/tests/lib/tools/tests.cleanup
+++ b/tests/lib/tools/tests.cleanup
@@ -3,7 +3,17 @@
 show_help() {
     echo "usage: tests.cleanup prepare"
     echo "       tests.cleanup defer <cmd> [args]"
+    echo "       tests.cleanup pop"
     echo "       tests.cleanup restore"
+    echo
+    echo "COMMANDS:"
+    echo "  prepare: establishes a cleanup stack"
+    echo "  restore: invokes all cleanup commands in reverse order"
+    echo "  defer: pushes a command onto the cleanup stack"
+    echo "  pop: invoke the most recently deferred command, discarding it"
+    echo
+    echo "The defer and pop commands can be to establish temporary"
+    echo "cleanup handler and remove it, in the case of success"
 }
 
 cmd_prepare() {
@@ -23,20 +33,37 @@ cmd_defer() {
     echo "$*" >> defer.sh
 }
 
+run_one_cmd() {
+    CMD="$1"
+    set +e
+    sh -ec "$CMD"
+    RET=$?
+    set -e
+    if [ $RET -ne 0 ]; then
+        echo "tests.cleanup: deferred command \"$CMD\" failed with exit code $RET"
+        exit $RET
+    fi
+}
+
+cmd_pop() {
+    if [ ! -s defer.sh ]; then
+        echo "tests.cleanup: cannot pop, cleanup stack is empty" >&2
+        exit 1
+    fi
+    head -n-1 defer.sh >defer.sh.pop
+    trap "mv defer.sh.pop defer.sh" EXIT
+    tail -n-1 defer.sh | while read -r CMD; do
+        run_one_cmd "$CMD"
+    done
+}
+
 cmd_restore() {
     if [ ! -e defer.sh ]; then
         echo "tests.cleanup: cannot restore, must call tests.prepare first" >&2
         exit 1
     fi
     tac defer.sh | while read -r CMD; do
-        set +e
-        sh -ec "$CMD"
-        RET=$?
-        set -e
-        if [ $RET -ne 0 ]; then
-            echo "tests.cleanup: deferred command \"$CMD\" failed with exit code $RET"
-            exit $RET
-        fi
+        run_one_cmd "$CMD"
     done
     rm -f defer.sh
 }
@@ -60,6 +87,11 @@ while [ $# -gt 0 ]; do
         defer)
             shift
             cmd_defer "$@"
+            exit
+            ;;
+        pop)
+            shift
+            cmd_pop "$@"
             exit
             ;;
         restore)


### PR DESCRIPTION
The "tests.cleanup pop" command pops the last command from the
cleanup stack and executes it. This functionality is useful for writing
tests where we want to use the "tests.cleanup restore" as a safeguard,
to ensure that, even in case of failure, the cleanup operation will be
performed, but want to perform the same cleanup faster in the case of
success.

For example:

    prepare: |
        tests.cleanup restore
    execute: |
        1) systemctl start helper.service
        2) tests.cleanup defer systemctl stop helper.service
        3) ... (some test activity that may fail)
        4) tests.cleanup pop
        5) ... (test code that should run without helper service)
    restore: |
        tests.cleanup restore

This allows us to avoid having to repeat the cleanup command twice and
diverging the cleanup logic into success and failure flows, one of which
would be usually not exercised.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
