### PR TITLE
 many: have install return encryption keys for data and save, improve tests

### DIFF
--- a/boot/seal.go
+++ b/boot/seal.go
@@ -100,6 +100,12 @@ func sealKeyToModeenv(key secboot.EncryptionKey, model *asserts.Model, modeenv *
 	if err != nil {
 		return fmt.Errorf("cannot prepare for key sealing: %v", err)
 	}
+	// make sure relevant locations exist
+	for _, p := range []string{InitramfsEncryptionKeyDir, InstallHostFDEDataDir} {
+		if err := os.MkdirAll(p, 0755); err != nil {
+			return err
+		}
+	}
 	sealKeyParams := &secboot.SealKeyParams{
 		ModelParams:             modelParams,
 		KeyFile:                 filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
@@ -126,6 +127,10 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 			sealKeyCalls++
 			c.Check(key, DeepEquals, myKey)
 			c.Assert(params.ModelParams, HasLen, 1)
+			for _, d := range []string{boot.InitramfsEncryptionKeyDir, boot.InstallHostFDEDataDir} {
+				ex, isdir, _ := osutil.DirExists(d)
+				c.Check(ex && isdir, Equals, true, Commentf("location %q does not exist or is not a directory", d))
+			}
 
 			shim := bootloader.NewBootFile("", filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-1"), bootloader.RoleRecovery)
 			grub := bootloader.NewBootFile("", filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/grubx64.efi-grub-hash-1"), bootloader.RoleRecovery)

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -52,14 +52,14 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 
 // Run bootstraps the partitions of a device, by either creating
 // missing ones or recreating installed ones.
-func Run(gadgetRoot, device string, options Options, observer SystemInstallObserver) error {
+func Run(gadgetRoot, device string, options Options, observer gadget.ContentObserver) (*InstalledSystemState, error) {
 	if gadgetRoot == "" {
-		return fmt.Errorf("cannot use empty gadget root directory")
+		return nil, fmt.Errorf("cannot use empty gadget root directory")
 	}
 
 	lv, err := gadget.PositionedVolumeFromGadget(gadgetRoot)
 	if err != nil {
-		return fmt.Errorf("cannot layout the volume: %v", err)
+		return nil, fmt.Errorf("cannot layout the volume: %v", err)
 	}
 
 	// XXX: the only situation where auto-detect is not desired is
@@ -69,24 +69,24 @@ func Run(gadgetRoot, device string, options Options, observer SystemInstallObser
 	if device == "" {
 		device, err = deviceFromRole(lv, gadget.SystemSeed)
 		if err != nil {
-			return fmt.Errorf("cannot find device to create partitions on: %v", err)
+			return nil, fmt.Errorf("cannot find device to create partitions on: %v", err)
 		}
 	}
 
 	diskLayout, err := gadget.OnDiskVolumeFromDevice(device)
 	if err != nil {
-		return fmt.Errorf("cannot read %v partitions: %v", device, err)
+		return nil, fmt.Errorf("cannot read %v partitions: %v", device, err)
 	}
 
 	// check if the current partition table is compatible with the gadget,
 	// ignoring partitions added by the installer (will be removed later)
 	if err := ensureLayoutCompatibility(lv, diskLayout); err != nil {
-		return fmt.Errorf("gadget and %v partition table not compatible: %v", device, err)
+		return nil, fmt.Errorf("gadget and %v partition table not compatible: %v", device, err)
 	}
 
 	// remove partitions added during a previous install attempt
 	if err := removeCreatedPartitions(diskLayout); err != nil {
-		return fmt.Errorf("cannot remove partitions from previous install: %v", err)
+		return nil, fmt.Errorf("cannot remove partitions from previous install: %v", err)
 	}
 	// at this point we removed any existing partition, nuke any
 	// of the existing sealed key files placed outside of the
@@ -94,20 +94,16 @@ func Run(gadgetRoot, device string, options Options, observer SystemInstallObser
 	sealedKeyFiles, _ := filepath.Glob(filepath.Join(boot.InitramfsEncryptionKeyDir, "*.sealed-key"))
 	for _, keyFile := range sealedKeyFiles {
 		if err := os.Remove(keyFile); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("cannot cleanup obsolete key file: %v", keyFile)
+			return nil, fmt.Errorf("cannot cleanup obsolete key file: %v", keyFile)
 		}
 	}
 
 	created, err := createMissingPartitions(diskLayout, lv)
 	if err != nil {
-		return fmt.Errorf("cannot create the partitions: %v", err)
+		return nil, fmt.Errorf("cannot create the partitions: %v", err)
 	}
 
-	type keySet struct {
-		key  secboot.EncryptionKey
-		rkey secboot.RecoveryKey
-	}
-	makeKeySet := func() (*keySet, error) {
+	makeKeySet := func() (*EncryptionKeySet, error) {
 		key, err := secboot.NewEncryptionKey()
 		if err != nil {
 			return nil, fmt.Errorf("cannot create encryption key: %v", err)
@@ -117,93 +113,57 @@ func Run(gadgetRoot, device string, options Options, observer SystemInstallObser
 		if err != nil {
 			return nil, fmt.Errorf("cannot create recovery key: %v", err)
 		}
-		return &keySet{
-			key:  key,
-			rkey: rkey,
+		return &EncryptionKeySet{
+			Key:         key,
+			RecoveryKey: rkey,
 		}, nil
 	}
 	roleNeedsEncryption := func(role string) bool {
 		return role == gadget.SystemData || role == gadget.SystemSave
 	}
-	keysForRoles := map[string]*keySet{}
+	var keysForRoles map[string]*EncryptionKeySet
 
 	for _, part := range created {
 		if options.Encrypt && roleNeedsEncryption(part.Role) {
 			keys, err := makeKeySet()
 			if err != nil {
-				return err
+				return nil, err
 			}
-			dataPart, err := newEncryptedDevice(&part, keys.key, part.Label)
+			dataPart, err := newEncryptedDevice(&part, keys.Key, part.Label)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
-			if err := dataPart.AddRecoveryKey(keys.key, keys.rkey); err != nil {
-				return err
+			if err := dataPart.AddRecoveryKey(keys.Key, keys.RecoveryKey); err != nil {
+				return nil, err
 			}
 
 			// update the encrypted device node
 			part.Node = dataPart.Node
+			if keysForRoles == nil {
+				keysForRoles = map[string]*EncryptionKeySet{}
+			}
 			keysForRoles[part.Role] = keys
 		}
 
 		if err := makeFilesystem(&part); err != nil {
-			return err
+			return nil, err
 		}
 
 		if err := writeContent(&part, gadgetRoot, observer); err != nil {
-			return err
+			return nil, err
 		}
 
 		if options.Mount && part.Label != "" && part.HasFilesystem() {
 			if err := mountFilesystem(&part, boot.InitramfsRunMntDir); err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
 
-	if !options.Encrypt {
-		return nil
-	}
-
-	// TODO:UC20: move key handling to the caller
-
-	// ensure directories
-	for _, p := range []string{boot.InitramfsEncryptionKeyDir, boot.InstallHostFDEDataDir} {
-		if err := os.MkdirAll(p, 0755); err != nil {
-			return err
-		}
-	}
-
-	dataKeySet := keysForRoles[gadget.SystemData]
-	if dataKeySet == nil {
-		return fmt.Errorf("internal error: system data encryption key set is unset")
-	}
-
-	// Write the recovery key
-	recoveryKeyFile := filepath.Join(boot.InstallHostFDEDataDir, "recovery.key")
-	if err := dataKeySet.rkey.Save(recoveryKeyFile); err != nil {
-		return fmt.Errorf("cannot store recovery key: %v", err)
-	}
-
-	if observer != nil {
-		observer.ChosenEncryptionKey(dataKeySet.key)
-	}
-
-	saveKeySet := keysForRoles[gadget.SystemSave]
-	if saveKeySet != nil {
-		saveKey := filepath.Join(boot.InstallHostFDEDataDir, "ubuntu-save.key")
-		reinstallSaveKey := filepath.Join(boot.InstallHostFDEDataDir, "reinstall.key")
-
-		if err := saveKeySet.key.Save(saveKey); err != nil {
-			return fmt.Errorf("cannot store system save key: %v", err)
-		}
-		if err := saveKeySet.rkey.Save(reinstallSaveKey); err != nil {
-			return fmt.Errorf("cannot store reinstall key: %v", err)
-		}
-	}
-
-	return nil
+	return &InstalledSystemState{
+		KeysForRoles: keysForRoles,
+	}, nil
 }
 
 func ensureLayoutCompatibility(gadgetLayout *gadget.LaidOutVolume, diskLayout *gadget.OnDiskVolume) error {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -52,7 +52,7 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 
 // Run bootstraps the partitions of a device, by either creating
 // missing ones or recreating installed ones.
-func Run(gadgetRoot, device string, options Options, observer gadget.ContentObserver) (*InstalledSystemState, error) {
+func Run(gadgetRoot, device string, options Options, observer gadget.ContentObserver) (*InstalledSystemSideData, error) {
 	if gadgetRoot == "" {
 		return nil, fmt.Errorf("cannot use empty gadget root directory")
 	}
@@ -161,7 +161,7 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 		}
 	}
 
-	return &InstalledSystemState{
+	return &InstalledSystemSideData{
 		KeysForRoles: keysForRoles,
 	}, nil
 }

--- a/gadget/install/install_dummy.go
+++ b/gadget/install/install_dummy.go
@@ -22,8 +22,10 @@ package install
 
 import (
 	"fmt"
+
+	"github.com/snapcore/snapd/gadget"
 )
 
-func Run(gadgetRoot, device string, options Options, _ SystemInstallObserver) (*InstalledSystemState, error) {
+func Run(gadgetRoot, device string, options Options, _ gadget.ContentObserver) (*InstalledSystemSideData, error) {
 	return nil, fmt.Errorf("build without secboot support")
 }

--- a/gadget/install/install_dummy.go
+++ b/gadget/install/install_dummy.go
@@ -24,6 +24,6 @@ import (
 	"fmt"
 )
 
-func Run(gadgetRoot, device string, options Options, _ SystemInstallObserver) error {
-	return fmt.Errorf("build without secboot support")
+func Run(gadgetRoot, device string, options Options, _ SystemInstallObserver) (*InstalledSystemState, error) {
+	return nil, fmt.Errorf("build without secboot support")
 }

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -57,8 +57,9 @@ func (s *installSuite) SetUpTest(c *C) {
 }
 
 func (s *installSuite) TestInstallRunError(c *C) {
-	err := install.Run("", "", install.Options{}, nil)
+	sys, err := install.Run("", "", install.Options{}, nil)
 	c.Assert(err, ErrorMatches, "cannot use empty gadget root directory")
+	c.Check(sys, IsNil)
 }
 
 const mockGadgetYaml = `volumes:

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -20,7 +20,6 @@
 package install
 
 import (
-	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/secboot"
 )
 
@@ -31,9 +30,14 @@ type Options struct {
 	Encrypt bool
 }
 
-type SystemInstallObserver interface {
-	gadget.ContentObserver
-	// ChosenEncryptionKey stores the encrypted data partition key to be sealed
-	// at the end of the installation process.
-	ChosenEncryptionKey(secboot.EncryptionKey)
+// EncryptionKeySet is a set of encryption keys.
+type EncryptionKeySet struct {
+	Key         secboot.EncryptionKey
+	RecoveryKey secboot.RecoveryKey
+}
+
+// InstalledSystemState carries state information about an installed system.
+type InstalledSystemState struct {
+	// KeysForRoles contains a key set for relevant structure roles
+	KeysForRoles map[string]*EncryptionKeySet
 }

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -36,8 +36,9 @@ type EncryptionKeySet struct {
 	RecoveryKey secboot.RecoveryKey
 }
 
-// InstalledSystemSideData carries the side data of an installed system.
+// InstalledSystemSideData carries side data of an installed system, eg. secrets
+// to access its partitions.
 type InstalledSystemSideData struct {
-	// KeysForRoles contains a key sets for the relevant structure roles.
+	// KeysForRoles contains key sets for the relevant structure roles.
 	KeysForRoles map[string]*EncryptionKeySet
 }

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -36,8 +36,8 @@ type EncryptionKeySet struct {
 	RecoveryKey secboot.RecoveryKey
 }
 
-// InstalledSystemState carries state information about an installed system.
-type InstalledSystemState struct {
-	// KeysForRoles contains a key set for relevant structure roles
+// InstalledSystemSideData carries the side data of an installed system.
+type InstalledSystemSideData struct {
+	// KeysForRoles contains a key sets for the relevant structure roles.
 	KeysForRoles map[string]*EncryptionKeySet
 }

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/sysconfig"
@@ -171,6 +172,14 @@ type encTestCase struct {
 	trustedBootloader bool
 }
 
+var (
+	dataEncryptionKey = secboot.EncryptionKey{'d', 'a', 't', 'a', 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	dataRecoveryKey   = secboot.RecoveryKey{'r', 'e', 'c', 'o', 'v', 'e', 'r', 'y', 10, 11, 12, 13, 14, 15, 16, 17}
+
+	saveKey      = secboot.EncryptionKey{'s', 'a', 'v', 'e', 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	reinstallKey = secboot.RecoveryKey{'r', 'e', 'i', 'n', 's', 't', 'a', 'l', 'l', 11, 12, 13, 14, 15, 16, 17}
+)
+
 func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade string, tc encTestCase) error {
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -180,7 +189,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	var brOpts install.Options
 	var installRunCalled int
 	var installSealingObserver gadget.ContentObserver
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, obs install.SystemInstallObserver) error {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, obs gadget.ContentObserver) (*install.InstalledSystemState, error) {
 		// ensure we can grab the lock here, i.e. that it's not taken
 		s.state.Lock()
 		s.state.Unlock()
@@ -190,7 +199,24 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 		brOpts = options
 		installSealingObserver = obs
 		installRunCalled++
-		return nil
+		var keysForRoles map[string]*install.EncryptionKeySet
+		if tc.encrypt {
+			keysForRoles = map[string]*install.EncryptionKeySet{
+				gadget.SystemData: {
+					Key:         dataEncryptionKey,
+					RecoveryKey: dataRecoveryKey,
+				},
+			}
+			if tc.trustedBootloader {
+				keysForRoles[gadget.SystemSave] = &install.EncryptionKeySet{
+					Key:         saveKey,
+					RecoveryKey: reinstallKey,
+				}
+			}
+		}
+		return &install.InstalledSystemState{
+			KeysForRoles: keysForRoles,
+		}, nil
 	})
 	defer restore()
 
@@ -310,8 +336,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ install.SystemInstallObserver) error {
-		return fmt.Errorf("The horror, The horror")
+	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemState, error) {
+		return nil, fmt.Errorf("The horror, The horror")
 	})
 	defer restore()
 
@@ -331,7 +357,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 
 	installSystem := s.findInstallSystem()
 	c.Check(installSystem.Err(), ErrorMatches, `(?ms)cannot perform the following tasks:
-- Setup system for run mode \(cannot create partitions: The horror, The horror\)`)
+- Setup system for run mode \(cannot install system: The horror, The horror\)`)
 	// no restart request on failure
 	c.Check(s.restartRequests, HasLen, 0)
 }
@@ -382,6 +408,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallDangerousWithTPM(c *C) {
 		tpm: true, bypass: false, encrypt: true, trustedBootloader: true,
 	})
 	c.Assert(err, IsNil)
+	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "recovery.key"), testutil.FileEquals, dataRecoveryKey[:])
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallDangerousBypassEncryption(c *C) {
@@ -404,6 +431,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallSignedWithTPM(c *C) {
 		tpm: true, bypass: false, encrypt: true, trustedBootloader: true,
 	})
 	c.Assert(err, IsNil)
+	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "recovery.key"), testutil.FileEquals, dataRecoveryKey[:])
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallSignedBypassEncryption(c *C) {
@@ -421,6 +449,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallSecuredWithTPM(c *C) {
 		tpm: true, bypass: false, encrypt: true, trustedBootloader: true,
 	})
 	c.Assert(err, IsNil)
+	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "recovery.key"), testutil.FileEquals, dataRecoveryKey[:])
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallDangerousEncryptionWithTPMNoTrustedAssets(c *C) {
@@ -428,6 +457,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallDangerousEncryptionWithTPMNoTrust
 		tpm: true, bypass: false, encrypt: true, trustedBootloader: false,
 	})
 	c.Assert(err, IsNil)
+	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "recovery.key"), testutil.FileEquals, dataRecoveryKey[:])
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallDangerousNoEncryptionWithTrustedAssets(c *C) {
@@ -437,17 +467,79 @@ func (s *deviceMgrInstallModeSuite) TestInstallDangerousNoEncryptionWithTrustedA
 	c.Assert(err, IsNil)
 }
 
+func (s *deviceMgrInstallModeSuite) TestInstallSecuredWithTPMAndSave(c *C) {
+	err := s.doRunChangeTestWithEncryption(c, "secured", encTestCase{
+		tpm: true, bypass: false, encrypt: true, trustedBootloader: true,
+	})
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "recovery.key"), testutil.FileEquals, dataRecoveryKey[:])
+	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "ubuntu-save.key"), testutil.FileEquals, saveKey[:])
+	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "reinstall.key"), testutil.FileEquals, reinstallKey[:])
+}
+
 func (s *deviceMgrInstallModeSuite) TestInstallSecuredBypassEncryption(c *C) {
 	err := s.doRunChangeTestWithEncryption(c, "secured", encTestCase{tpm: false, bypass: true, encrypt: false})
 	c.Assert(err, ErrorMatches, "(?s).*cannot encrypt secured device: TPM not available.*")
+}
+
+func (s *deviceMgrInstallModeSuite) testInstallEncryptionSanityChecks(c *C, errMatch string) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	restore = devicestate.MockSecbootCheckKeySealingSupported(func() error { return nil })
+	defer restore()
+
+	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+		[]byte("mode=install\n"), 0644)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	s.makeMockInstalledPcGadget(c, "dangerous", "")
+	devicestate.SetSystemMode(s.mgr, "install")
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	installSystem := s.findInstallSystem()
+	c.Check(installSystem.Err(), ErrorMatches, errMatch)
+	// no restart request on failure
+	c.Check(s.restartRequests, HasLen, 0)
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoKeys(c *C) {
+	restore := devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemState, error) {
+		c.Check(options.Encrypt, Equals, true)
+		// no keys set
+		return &install.InstalledSystemState{}, nil
+	})
+	defer restore()
+	s.testInstallEncryptionSanityChecks(c, `(?ms)cannot perform the following tasks:
+- Setup system for run mode \(internal error: system encryption keys are unset\)`)
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoSystemDataKey(c *C) {
+	restore := devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemState, error) {
+		c.Check(options.Encrypt, Equals, true)
+		// no keys set
+		return &install.InstalledSystemState{
+			// empty map
+			KeysForRoles: map[string]*install.EncryptionKeySet{},
+		}, nil
+	})
+	defer restore()
+	s.testInstallEncryptionSanityChecks(c, `(?ms)cannot perform the following tasks:
+- Setup system for run mode \(internal error: system encryption keys are unset\)`)
 }
 
 func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade, gadgetDefaultsYaml string) *asserts.Model {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ install.SystemInstallObserver) error {
-		return nil
+	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemState, error) {
+		return nil, nil
 	})
 	defer restore()
 

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -189,7 +189,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	var brOpts install.Options
 	var installRunCalled int
 	var installSealingObserver gadget.ContentObserver
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, obs gadget.ContentObserver) (*install.InstalledSystemState, error) {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, obs gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		// ensure we can grab the lock here, i.e. that it's not taken
 		s.state.Lock()
 		s.state.Unlock()
@@ -214,7 +214,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 				}
 			}
 		}
-		return &install.InstalledSystemState{
+		return &install.InstalledSystemSideData{
 			KeysForRoles: keysForRoles,
 		}, nil
 	})
@@ -336,7 +336,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemState, error) {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		return nil, fmt.Errorf("The horror, The horror")
 	})
 	defer restore()
@@ -510,10 +510,10 @@ func (s *deviceMgrInstallModeSuite) testInstallEncryptionSanityChecks(c *C, errM
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoKeys(c *C) {
-	restore := devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemState, error) {
+	restore := devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		c.Check(options.Encrypt, Equals, true)
 		// no keys set
-		return &install.InstalledSystemState{}, nil
+		return &install.InstalledSystemSideData{}, nil
 	})
 	defer restore()
 	s.testInstallEncryptionSanityChecks(c, `(?ms)cannot perform the following tasks:
@@ -521,10 +521,10 @@ func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoKeys(c *C
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoSystemDataKey(c *C) {
-	restore := devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemState, error) {
+	restore := devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		c.Check(options.Encrypt, Equals, true)
 		// no keys set
-		return &install.InstalledSystemState{
+		return &install.InstalledSystemSideData{
 			// empty map
 			KeysForRoles: map[string]*install.EncryptionKeySet{},
 		}, nil
@@ -538,7 +538,7 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade, gadg
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemState, error) {
+	restore = devicestate.MockInstallRun(func(gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		return nil, nil
 	})
 	defer restore()

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -248,7 +248,7 @@ func MockSysconfigConfigureTargetSystem(f func(opts *sysconfig.Options) error) (
 	}
 }
 
-func MockInstallRun(f func(gadgetRoot, device string, options install.Options, observer install.SystemInstallObserver) error) (restore func()) {
+func MockInstallRun(f func(gadgetRoot, device string, options install.Options, observer gadget.ContentObserver) (*install.InstalledSystemState, error)) (restore func()) {
 	old := installRun
 	installRun = f
 	return func() {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -248,7 +248,7 @@ func MockSysconfigConfigureTargetSystem(f func(opts *sysconfig.Options) error) (
 	}
 }
 
-func MockInstallRun(f func(gadgetRoot, device string, options install.Options, observer gadget.ContentObserver) (*install.InstalledSystemState, error)) (restore func()) {
+func MockInstallRun(f func(gadgetRoot, device string, options install.Options, observer gadget.ContentObserver) (*install.InstalledSystemSideData, error)) (restore func()) {
 	old := installRun
 	installRun = f
 	return func() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -132,7 +133,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 
 	var trustedInstallObserver *boot.TrustedAssetsInstallObserver
 	// get a nice nil interface by default
-	var installObserver install.SystemInstallObserver
+	var installObserver gadget.ContentObserver
 	trustedInstallObserver, err = boot.TrustedAssetsInstallObserverForModel(deviceCtx.Model(), gadgetDir, useEncryption)
 	if err != nil && err != boot.ErrObserverNotApplicable {
 		return fmt.Errorf("cannot setup asset install observer: %v", err)
@@ -146,18 +147,29 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
+	var installedSystem *install.InstalledSystemState
 	// run the create partition code
 	logger.Noticef("create and deploy partitions")
 	func() {
 		st.Unlock()
 		defer st.Lock()
-		err = installRun(gadgetDir, "", bopts, installObserver)
+		installedSystem, err = installRun(gadgetDir, "", bopts, installObserver)
 	}()
 	if err != nil {
-		return fmt.Errorf("cannot create partitions: %v", err)
+		return fmt.Errorf("cannot install system: %v", err)
 	}
 
 	if trustedInstallObserver != nil {
+		// sanity check
+		if installedSystem.KeysForRoles == nil || installedSystem.KeysForRoles[gadget.SystemData] == nil {
+			return fmt.Errorf("internal error: system encryption keys are unset")
+		}
+		dataKeySet := installedSystem.KeysForRoles[gadget.SystemData]
+
+		// make note of the encryption key
+		trustedInstallObserver.ChosenEncryptionKey(dataKeySet.Key)
+
+		// keep track of recovery assets
 		if err := trustedInstallObserver.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir); err != nil {
 			return fmt.Errorf("cannot observe existing trusted recovery assets: err")
 		}
@@ -197,10 +209,50 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("cannot make run system bootable: %v", err)
 	}
 
+	if useEncryption {
+		if err := saveKeys(installedSystem.KeysForRoles); err != nil {
+			return err
+		}
+	}
+
 	// request a restart as the last action after a successful install
 	logger.Noticef("request system restart")
 	st.RequestRestart(state.RestartSystemNow)
 
+	return nil
+}
+
+func saveKeys(keysForRoles map[string]*install.EncryptionKeySet) error {
+	dataKeySet := keysForRoles[gadget.SystemData]
+
+	// ensure directories
+	for _, p := range []string{boot.InitramfsEncryptionKeyDir, boot.InstallHostFDEDataDir} {
+		if err := os.MkdirAll(p, 0755); err != nil {
+			return err
+		}
+	}
+
+	// Write the recovery key
+	recoveryKeyFile := filepath.Join(boot.InstallHostFDEDataDir, "recovery.key")
+	if err := dataKeySet.RecoveryKey.Save(recoveryKeyFile); err != nil {
+		return fmt.Errorf("cannot store recovery key: %v", err)
+	}
+
+	saveKeySet := keysForRoles[gadget.SystemSave]
+	if saveKeySet == nil {
+		// no system-save support
+		return nil
+	}
+
+	saveKey := filepath.Join(boot.InstallHostFDEDataDir, "ubuntu-save.key")
+	reinstallSaveKey := filepath.Join(boot.InstallHostFDEDataDir, "reinstall.key")
+
+	if err := saveKeySet.Key.Save(saveKey); err != nil {
+		return fmt.Errorf("cannot store system save key: %v", err)
+	}
+	if err := saveKeySet.RecoveryKey.Save(reinstallSaveKey); err != nil {
+		return fmt.Errorf("cannot store reinstall key: %v", err)
+	}
 	return nil
 }
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -225,11 +225,9 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 func saveKeys(keysForRoles map[string]*install.EncryptionKeySet) error {
 	dataKeySet := keysForRoles[gadget.SystemData]
 
-	// ensure directories
-	for _, p := range []string{boot.InitramfsEncryptionKeyDir, boot.InstallHostFDEDataDir} {
-		if err := os.MkdirAll(p, 0755); err != nil {
-			return err
-		}
+	// ensure directory for keys exists
+	if err := os.MkdirAll(boot.InstallHostFDEDataDir, 0755); err != nil {
+		return err
 	}
 
 	// Write the recovery key

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -176,7 +176,6 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		if err := saveKeys(installedSystem.KeysForRoles); err != nil {
 			return err
 		}
-
 	}
 
 	// keep track of the model we installed

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -147,7 +147,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	var installedSystem *install.InstalledSystemState
+	var installedSystem *install.InstalledSystemSideData
 	// run the create partition code
 	logger.Noticef("create and deploy partitions")
 	func() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -173,6 +173,10 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		if err := trustedInstallObserver.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir); err != nil {
 			return fmt.Errorf("cannot observe existing trusted recovery assets: err")
 		}
+		if err := saveKeys(installedSystem.KeysForRoles); err != nil {
+			return err
+		}
+
 	}
 
 	// keep track of the model we installed
@@ -207,12 +211,6 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	rootdir := dirs.GlobalRootDir
 	if err := bootMakeBootable(deviceCtx.Model(), rootdir, bootWith, trustedInstallObserver); err != nil {
 		return fmt.Errorf("cannot make run system bootable: %v", err)
-	}
-
-	if useEncryption {
-		if err := saveKeys(installedSystem.KeysForRoles); err != nil {
-			return err
-		}
 	}
 
 	// request a restart as the last action after a successful install

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -31,6 +31,9 @@ const (
 	// The encryption key size is set so it has the same entropy as the derived
 	// key.
 	encryptionKeySize = 64
+
+	// Size of the recovery key.
+	recoveryKeySize = 16
 )
 
 // EncryptionKey is the key used to encrypt the data partition.
@@ -46,6 +49,26 @@ func NewEncryptionKey() (EncryptionKey, error) {
 
 // Save writes the key in the location specified by filename.
 func (key EncryptionKey) Save(filename string) error {
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		return err
+	}
+	return osutil.AtomicWriteFile(filename, key[:], 0600, 0)
+}
+
+// RecoveryKey is a key used to unlock the encrypted partition when
+// the encryption key can't be used, for example when unseal fails.
+type RecoveryKey [recoveryKeySize]byte
+
+func NewRecoveryKey() (RecoveryKey, error) {
+	var key RecoveryKey
+	// rand.Read() is protected against short reads
+	_, err := rand.Read(key[:])
+	// On return, n == len(b) if and only if err == nil
+	return key, err
+}
+
+// Save writes the recovery key in the location specified by filename.
+func (key RecoveryKey) Save(filename string) error {
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
 		return err
 	}

--- a/secboot/encrypt_tpm.go
+++ b/secboot/encrypt_tpm.go
@@ -21,39 +21,13 @@
 package secboot
 
 import (
-	"crypto/rand"
-	"os"
-	"path/filepath"
-
 	sb "github.com/snapcore/secboot"
-
-	"github.com/snapcore/snapd/osutil"
 )
 
 var (
 	sbInitializeLUKS2Container       = sb.InitializeLUKS2Container
 	sbAddRecoveryKeyToLUKS2Container = sb.AddRecoveryKeyToLUKS2Container
 )
-
-// RecoveryKey is a key used to unlock the encrypted partition when
-// the encryption key can't be used, for example when unseal fails.
-type RecoveryKey sb.RecoveryKey
-
-func NewRecoveryKey() (RecoveryKey, error) {
-	var key RecoveryKey
-	// rand.Read() is protected against short reads
-	_, err := rand.Read(key[:])
-	// On return, n == len(b) if and only if err == nil
-	return key, err
-}
-
-// Save writes the recovery key in the location specified by filename.
-func (key RecoveryKey) Save(filename string) error {
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
-		return err
-	}
-	return osutil.AtomicWriteFile(filename, key[:], 0600, 0)
-}
 
 // FormatEncryptedDevice initializes an encrypted volume on the block device
 // given by node, setting the specified label. The key used to unlock the

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -91,16 +91,16 @@ func main() {
 		Mount:   args.Mount,
 		Encrypt: args.Encrypt,
 	}
-	installState, err := installRun(args.Positional.GadgetRoot, args.Positional.Device, options, obs)
+	installSideData, err := installRun(args.Positional.GadgetRoot, args.Positional.Device, options, obs)
 	if err != nil {
 		panic(err)
 	}
 
 	if args.Encrypt {
-		if installState == nil || installState.KeysForRoles == nil {
+		if installSideData == nil || installSideData.KeysForRoles == nil {
 			panic("expected encryption keys")
 		}
-		dataKey := installState.KeysForRoles[gadget.SystemData]
+		dataKey := installSideData.KeysForRoles[gadget.SystemData]
 		if dataKey == nil {
 			panic("ubuntu-data encryption key is unset")
 		}

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -91,13 +91,20 @@ func main() {
 		Mount:   args.Mount,
 		Encrypt: args.Encrypt,
 	}
-	err = installRun(args.Positional.GadgetRoot, args.Positional.Device, options, obs)
+	installState, err := installRun(args.Positional.GadgetRoot, args.Positional.Device, options, obs)
 	if err != nil {
 		panic(err)
 	}
 
 	if args.Encrypt {
-		if err := ioutil.WriteFile("unsealed-key", obs.encryptionKey[:], 0644); err != nil {
+		if installState == nil || installState.KeysForRoles == nil {
+			panic("expected encryption keys")
+		}
+		dataKey := installState.KeysForRoles[gadget.SystemData]
+		if dataKey == nil {
+			panic("ubuntu-data encryption key is unset")
+		}
+		if err := ioutil.WriteFile("unsealed-key", dataKey.Key[:], 0644); err != nil {
 			panic(err)
 		}
 	}

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -107,5 +107,8 @@ func main() {
 		if err := ioutil.WriteFile("unsealed-key", dataKey.Key[:], 0644); err != nil {
 			panic(err)
 		}
+		if err := ioutil.WriteFile("recovery-key", dataKey.RecoveryKey[:], 0644); err != nil {
+			panic(err)
+		}
 	}
 }

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -100,6 +100,8 @@ execute: |
 
     echo "Check that the key file was created"
     test "$(stat --printf=%s unsealed-key)" -eq 64
+    # recovery key is 16 bytes long
+    test "$(stat --printf=%s recovery-key)" -eq 16
 
     echo "Check that the partitions are created"
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
@@ -128,7 +130,7 @@ execute: |
 
     # Test the recovery key
     echo "Ensure that we can open the encrypted device using the recovery key"
-    cryptsetup open --key-file /run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde/recovery.key "${LOOP}p4" test-recovery
+    cryptsetup open --key-file recovery-key "${LOOP}p4" test-recovery
     mount /dev/mapper/test-recovery ./mnt
     umount ./mnt
     cryptsetup close /dev/mapper/test-recovery


### PR DESCRIPTION
Refactor install.Run() to return state information about the installed system.
In particular, return the encryption/reovery keys for ubuntu-data and
ubuntu-save partitions. With this, the saving of keys has been moved to
devicestate, what allowed for further improvements in unit tests, to verify that
the keys are properly saved to disk.

Stacked on top of #9443. The last commit is relevant.