### PR TITLE
tests/lib/fakestore: some improvements for testing console-conf things

### DIFF
--- a/tests/lib/fakestore/cmd/fakestore/cmd_run.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_run.go
@@ -28,9 +28,10 @@ import (
 )
 
 type cmdRun struct {
-	TopDir         string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
-	Addr           string `long:"addr" default:"localhost:11028" description:"Store address"`
-	AssertFallback bool   `long:"assert-fallback" description:"Fallback to the main online store for missing assertions"`
+	TopDir                    string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
+	Addr                      string `long:"addr" default:"localhost:11028" description:"Store address"`
+	AssertFallback            bool   `long:"assert-fallback" description:"Fallback to the main online store for missing assertions"`
+	ActionsEndpointContextual bool   `long:"actions-endpoint-contextual" description:"Make the actions endpoint act like the real store, serving only real refreshes based on context"`
 
 	HttpProxy  string `long:"http-proxy" description:"HTTP proxy address"`
 	HttpsProxy string `long:"https-proxy" description:"HTTPS proxy address"`
@@ -46,7 +47,7 @@ func (x *cmdRun) Execute(args []string) error {
 		os.Setenv("http_proxy", x.HttpProxy)
 	}
 
-	return runServer(x.TopDir, x.Addr, x.AssertFallback)
+	return runServer(x.TopDir, x.Addr, x.AssertFallback, x.ActionsEndpointContextual)
 }
 
 func init() {
@@ -55,8 +56,8 @@ func init() {
 	}
 }
 
-func runServer(topDir, addr string, assertFallback bool) error {
-	st := store.NewStore(topDir, addr, assertFallback)
+func runServer(topDir, addr string, assertFallback, actionsEndpointContextual bool) error {
+	st := store.NewStore(topDir, addr, assertFallback, actionsEndpointContextual)
 
 	if err := st.Start(); err != nil {
 		return err

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -153,11 +153,12 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 	return store
 }
 
-// URL returns the base-url that the store is listening on
+// URL returns the base-url that the store is listening on.
 func (s *Store) URL() string {
 	return s.url
 }
 
+// SnapsDir returns the blob dir for snap files.
 func (s *Store) SnapsDir() string {
 	return s.blobDir
 }

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -145,6 +145,8 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 	// don't log download it's too verbose and mostly binary data
 	mux.Handle("/download/", http.StripPrefix("/download/", http.FileServer(http.Dir(topDir))))
 	mux.HandleFunc("/api/v1/snaps/assertions/", debugLogger(http.HandlerFunc(store.assertionsEndpoint)))
+	mux.HandleFunc("/api/v1/snaps/auth/nonces", debugLogger(http.HandlerFunc(store.authNonceEndpoint)))
+	mux.HandleFunc("/api/v1/snaps/auth/sessions", debugLogger(http.HandlerFunc(store.authSessionsEndpoint)))
 	// v2
 	mux.HandleFunc("/v2/snaps/refresh", debugLogger(http.HandlerFunc(store.snapActionEndpoint)))
 
@@ -296,6 +298,36 @@ type detailsReplyJSON struct {
 	DownloadDigest  string   `json:"download_sha3_384"`
 	Confinement     string   `json:"confinement"`
 	Type            string   `json:"type"`
+}
+
+type nonceResponse struct {
+	Nonce string `json:"nonce"`
+}
+
+func (s *Store) authNonceEndpoint(w http.ResponseWriter, req *http.Request) {
+	resp := &nonceResponse{Nonce: "hello-there"}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("internal error marshalling nonce json: %v", err), 500)
+		return
+	}
+
+	w.Write(b)
+}
+
+type authSessionResponse struct {
+	Macaroon string `json:"macaroon"`
+}
+
+func (s *Store) authSessionsEndpoint(w http.ResponseWriter, req *http.Request) {
+	resp := &authSessionResponse{Macaroon: "general-kenobi"}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("internal error marshalling session json: %v", err), 500)
+		return
+	}
+
+	w.Write(b)
 }
 
 func (s *Store) searchEndpoint(w http.ResponseWriter, req *http.Request) {

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -112,8 +112,16 @@ type Store struct {
 	srv *graceful.Server
 }
 
-// NewStore creates a new store server serving snaps from the given top directory and assertions from topDir/asserts. If assertFallback is true missing assertions are looked up in the main online store.
-func NewStore(topDir, addr string, assertFallback bool) *Store {
+// NewStore creates a new store server serving snaps from the given top
+// directory and assertions from topDir/asserts. If assertFallback is true
+// missing assertions are looked up in the main online store.
+// If actionEndpointContextual is true, then the actions endpoint acts more
+// like the real store, looking up all available assertion revisions and only
+// providing snap revision refreshes that actually correspond to a real refresh.
+// TODO: port old tests/usages from the previous action behavior to work with
+// the new one so we only have one implementation, which is closest to what the
+// real store does with contextual responses.
+func NewStore(topDir, addr string, assertFallback bool, actionEndpointContextual bool) *Store {
 	mux := http.NewServeMux()
 	var sto *store.Store
 	if assertFallback {

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -61,7 +61,7 @@ func (s *storeTestSuite) SetUpTest(c *C) {
 	topdir := c.MkDir()
 	err := os.Mkdir(filepath.Join(topdir, "asserts"), 0755)
 	c.Assert(err, IsNil)
-	s.store = NewStore(topdir, defaultAddr, false)
+	s.store = NewStore(topdir, defaultAddr, false, false)
 	err = s.store.Start()
 	c.Assert(err, IsNil)
 

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -112,7 +112,36 @@ func (s *storeTestSuite) TestSearchEndpoint(c *C) {
 	body, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, IsNil)
 	c.Assert(string(body), Equals, "search not implemented")
+}
 
+func (s *storeTestSuite) TestNonceEndpoint(c *C) {
+	resp, err := s.StoreGet("/api/v1/snaps/auth/nonces")
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	var nonceResp struct {
+		Nonce string
+	}
+
+	c.Assert(resp.StatusCode, Equals, 200)
+	err = json.NewDecoder(resp.Body).Decode(&nonceResp)
+	c.Assert(err, IsNil)
+	c.Assert(nonceResp.Nonce, Equals, "hello-there")
+}
+
+func (s *storeTestSuite) TestSessionsEndpoint(c *C) {
+	resp, err := s.StoreGet("/api/v1/snaps/auth/sessions")
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	var macaroonResp struct {
+		Macaroon string
+	}
+
+	c.Assert(resp.StatusCode, Equals, 200)
+	err = json.NewDecoder(resp.Body).Decode(&macaroonResp)
+	c.Assert(err, IsNil)
+	c.Assert(macaroonResp.Macaroon, Equals, "general-kenobi")
 }
 
 func (s *storeTestSuite) TestDetailsEndpointWithAssertions(c *C) {


### PR DESCRIPTION
These improvements fell out of my need to use fakestore to test uc20 console-conf related things. Fakestore is still just that, a fake store, but now it is a little more realistic of a fake store and can at least respond to all the necessary requests for a first boot UC20 device to attempt and finish auto-refreshes. 

In an ideal world, we would not have this duality of mind about the actions endpoint implementation, but it wasn't quite obvious how to change the existing tests that expect this hard-coded behavior, so I opted to just skip that for now and maybe revisit it again when I inevitably have to test something fakestore related and need to do more head-keyboard banging to make things work. If this is a sticking point for folks it's probably not a lot of work, but it's work I'd at least like to do later on so we can get the console-conf stuff in before 1.0. 