### PR TITLE
spread: remove workaround for openSUSE go issue

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -623,19 +623,6 @@ prepare: |
     type REBOOT | tail -n +2 >> "$TESTSLIB"/spread-funcs.sh
     unset REBOOT
 
-    if [ -e /etc/profile.d/go.sh ]; then
-        # Up until recently openSUSE golang packaging injected environment
-        # variables into the global shell profile. This caused issues across
-        # updates and was, in fact, entirely useless. As such, if we are
-        # working against an older image that still has that file, we can
-        # remove it and unset certain variables to avoid the problem.
-        unset GOBIN
-        unset GOARCH
-        unset GOROOT
-        unset GOOS
-        rm -f /etc/profile.d/go.sh
-    fi
-
     # NOTE: At this stage the source tree is available and no more special
     # considerations apply.
     "$TESTSLIB"/prepare-restore.sh --prepare-project


### PR DESCRIPTION
The workaround is no longer relevant as that part of the golang
packaging no longer exists in openSUSE.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
