### PR TITLE
snap: support different exit-code in the snap command

### DIFF
--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"golang.org/x/xerrors"
+
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/i18n"
@@ -114,7 +116,7 @@ func (x *packCmd) Execute([]string) error {
 	if err != nil {
 		// TRANSLATORS: the %q is the snap-dir (the first positional
 		// argument to the command); the %v is an error
-		return fmt.Errorf(i18n.G("cannot pack %q: %v"), x.Positional.SnapDir, err)
+		return xerrors.Errorf(i18n.G("cannot pack %q: %w"), x.Positional.SnapDir, err)
 
 	}
 	// TRANSLATORS: %s is the path to the built snap file

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -531,11 +531,11 @@ var wrongDashes = string([]rune{
 })
 
 type unknownCommandError struct {
-	errStr string
+	msg string
 }
 
 func (e unknownCommandError) Error() string {
-	return e.errStr
+	return e.msg
 }
 
 func run() error {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -436,12 +436,13 @@ func exitCodeFromError(err error) int {
 	switch {
 	case err == nil:
 		return 0
-	case xerrors.As(err, &cmdlineFlagsError) || xerrors.As(err, &unknownCmdError):
-		return 5
 	case client.IsRetryable(err):
 		return 10
 	case xerrors.As(err, &mksquashfsError):
 		return 20
+	case xerrors.As(err, &cmdlineFlagsError) || xerrors.As(err, &unknownCmdError):
+		// EX_USAGE, see sysexit.h
+		return 64
 	default:
 		return 1
 	}

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -476,11 +476,11 @@ func verifyContentAccessibleForBuild(sourceDir string) error {
 }
 
 type MksquashfsError struct {
-	errStr string
+	msg string
 }
 
 func (m MksquashfsError) Error() string {
-	return m.errStr
+	return m.msg
 }
 
 type BuildOpts struct {

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -475,6 +475,14 @@ func verifyContentAccessibleForBuild(sourceDir string) error {
 	return errPaths.asErr()
 }
 
+type MksquashfsError struct {
+	errStr string
+}
+
+func (m MksquashfsError) Error() string {
+	return m.errStr
+}
+
 type BuildOpts struct {
 	SnapType     string
 	Compression  string
@@ -527,7 +535,7 @@ func (s *Snap) Build(sourceDir string, opts *BuildOpts) error {
 	return osutil.ChDir(sourceDir, func() error {
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("mksquashfs call failed: %s", osutil.OutputErr(output, err))
+			return MksquashfsError{fmt.Sprintf("mksquashfs call failed: %s", osutil.OutputErr(output, err))}
 		}
 
 		return nil

--- a/tests/main/exitcodes/task.yaml
+++ b/tests/main/exitcodes/task.yaml
@@ -1,0 +1,29 @@
+summary: Checks for snap exit codes
+
+systems: [ubuntu-1*, ubuntu-2*]
+
+restore: |
+    umount /usr/bin/mksquashfs || true
+
+execute: |
+    echo "snap command with unknown command return exit code 5"
+    set +e
+    snap unknown-command
+    RET=$?
+    set -e
+    test "$RET" -eq 5
+
+    echo "snap command with unknown flag return exit code 5"
+    set +e
+    snap pack --unknown-option
+    RET=$?
+    set -e
+    test "$RET" -eq 5
+
+    echo "snap command with broken mksquashfs returns exit code 20"
+    mount -o bind /bin/false /usr/bin/mksquashfs
+    set +e
+    snap pack "$TESTSLIB/snaps/test-snapd-sh"
+    RET=$?
+    set -e
+    test "$RET" -eq 20

--- a/tests/main/exitcodes/task.yaml
+++ b/tests/main/exitcodes/task.yaml
@@ -2,9 +2,8 @@ summary: Checks for snap exit codes
 
 systems: [ubuntu-1*, ubuntu-2*]
 
-restore: |
-    umount /usr/bin/mksquashfs || true
-    umount /snap/core/current/usr/bin/mksquashfs || true
+prepare: |
+    tests.cleanup prepare
 
 execute: |
     echo "snap command with unknown command return exit code 5"
@@ -22,10 +21,15 @@ execute: |
     test "$RET" -eq 64
 
     echo "snap command with broken mksquashfs returns exit code 20"
-    mount -o bind /bin/false /usr/bin/mksquashfs
-    mount -o bind /bin/false /snap/core/current/usr/bin/mksquashfs
+    for b in /usr/bin/mksquashfs /snap/core/current/usr/bin/mksquashfs; do
+        mount -o bind /bin/false "$b"
+        tests.cleanup defer umount "$b"
+    done
     set +e
     snap pack "$TESTSLIB/snaps/test-snapd-sh"
     RET=$?
     set -e
     test "$RET" -eq 20
+
+restore: |
+    tests.cleanup restore

--- a/tests/main/exitcodes/task.yaml
+++ b/tests/main/exitcodes/task.yaml
@@ -12,14 +12,14 @@ execute: |
     snap unknown-command
     RET=$?
     set -e
-    test "$RET" -eq 5
+    test "$RET" -eq 64
 
     echo "snap command with unknown flag return exit code 5"
     set +e
     snap pack --unknown-option
     RET=$?
     set -e
-    test "$RET" -eq 5
+    test "$RET" -eq 64
 
     echo "snap command with broken mksquashfs returns exit code 20"
     mount -o bind /bin/false /usr/bin/mksquashfs

--- a/tests/main/exitcodes/task.yaml
+++ b/tests/main/exitcodes/task.yaml
@@ -4,6 +4,7 @@ systems: [ubuntu-1*, ubuntu-2*]
 
 restore: |
     umount /usr/bin/mksquashfs || true
+    umount /snap/core/current/usr/bin/mksquashfs || true
 
 execute: |
     echo "snap command with unknown command return exit code 5"
@@ -22,6 +23,7 @@ execute: |
 
     echo "snap command with broken mksquashfs returns exit code 20"
     mount -o bind /bin/false /usr/bin/mksquashfs
+    mount -o bind /bin/false /snap/core/current/usr/bin/mksquashfs
     set +e
     snap pack "$TESTSLIB/snaps/test-snapd-sh"
     RET=$?


### PR DESCRIPTION
One request we got from the snapcraft team is that they want to get different exit code from `snap pack` depending on the error condition to detect this in snapcraft and provide useful feedback.

Specifically they need a different error if `mksquashfs` fails (because it e.g. is not build with lzo support) and if snap does not understand the given command or flags (if e.g. an old snap binary is used that does not understand `snap pack --compression=lzo.

This PR implements it using a centralised helper in main.go. I was initially thinking of returning errors with a new `interface{ExitCode() int}` helper and have main.go check for this. But the downside is that then it's harder to see what errors are handled specially with what exit code (and the risk of duplicating the exit code by accident is bigger). However if the other approach is preferred that is fine of course!

