### PR TITLE
spread-shellcheck: process paths from arguments in parallel

### DIFF
--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -175,19 +175,20 @@ def checkfile(path):
         raise errors
 
 
-def findfiles(indir):
-    for root, _, files in os.walk(indir, topdown=True):
-        for name in files:
-            if name in ['spread.yaml', 'task.yaml']:
-                yield os.path.join(root, name)
+def findfiles(locations):
+    for loc in locations:
+        if os.path.isdir(loc):
+            for root, _, files in os.walk(loc, topdown=True):
+                for name in files:
+                    if name in ['spread.yaml', 'task.yaml']:
+                        yield os.path.join(root, name)
+        else:
+            yield loc
 
 
-def checkpath(loc, max_workers):
-    if os.path.isdir(loc):
-        # setup iterator
-        locations = findfiles(loc)
-    else:
-        locations = [loc]
+def checkpaths(locs, max_workers):
+    # setup iterator
+    locations = findfiles(locs)
 
     failed = []
 
@@ -225,11 +226,10 @@ def loadfilelist(flistpath):
 def main(opts):
     paths = opts.paths or ['.']
     failures = ShellcheckFailures()
-    for pth in paths:
-        try:
-            checkpath(pth, opts.max_procs)
-        except ShellcheckFailures as sf:
-            failures.merge(sf)
+    try:
+        checkpaths(paths, opts.max_procs)
+    except ShellcheckFailures as sf:
+        failures.merge(sf)
 
     if failures:
         if opts.can_fail:


### PR DESCRIPTION
Attempt to speed up the spread-shellcheck execution a bit, by processing the
paths passed in the arguments in parallel. In particular, the run-checks command
executes: `spread-shellcheck spread.yaml tests`. The old code would firs process
spread.yaml, and then proceed to walk tests and process all files in
parallel (limited to by the workers count). I

It also happens that spread.yaml is composed of many longish sections and the
processing of a complete file takes longer than for a typical test.

The patch makes all the locations passed in the command line be processed in
parallel by one executors pool.

A bit of data, running `spread-shellcheck spread.yaml tests` on my machine:
- baseline:       75s
- with the patch: 59s

