### PR TITLE
spread-shellcheck: speed up spread-shellcheck even more

### DIFF
--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -186,19 +186,18 @@ def findfiles(locations):
             yield loc
 
 
+def check1path(path):
+    try:
+        checkfile(path)
+    except ShellcheckError as err:
+        return err
+    return None
+
+
 def checkpaths(locs, max_workers):
     # setup iterator
     locations = findfiles(locs)
-
     failed = []
-
-    def check1path(path):
-        try:
-            checkfile(path)
-        except ShellcheckError as err:
-            return err
-        return None
-
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for serr in executor.map(check1path, locations):
             if serr is None:

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -107,6 +107,7 @@ def checksection(data, env: Dict[str, str]):
     # shellcheck knows about that
     script_data = []
     script_data.append('set -e')
+
     for key, value in env.items():
         value = str(value)
         # Unpack the special "$(HOST: ...) syntax and tell shellcheck not to
@@ -160,16 +161,20 @@ def checkfile(path):
 
     if path.endswith('spread.yaml') and 'suites' in data:
         # check suites
-        for suite in data['suites'].keys():
-            for section in SECTIONS:
-                if section not in data['suites'][suite]:
-                    continue
+        with ThreadPoolExecutor() as executor:
+            futures = []
+            for suite in data['suites'].keys():
+                for section in SECTIONS:
+                    if section not in data['suites'][suite]:
+                        continue
+                        logging.debug("%s (suite %s): checking section %s", path, suite, section)
+                        futures.append(executor.submit(checksection, data['suites'][suite][section], env))
+            for future in futures:
                 try:
-                    logging.debug("%s (suite %s): checking section %s", path, suite, section)
-                    checksection(data['suites'][suite][section], env)
+                    future.result()
                 except ShellcheckRunError as serr:
                     errors.addfailure('suites/' + suite + '/' + section,
-                                      serr.stderr.decode('utf-8'))
+                                    serr.stderr.decode('utf-8'))
 
     if errors:
         raise errors


### PR DESCRIPTION
Prompted by Maciej's improvements and my 16 core desktop.

On my system this now runs in 9 seconds, down from 49.