### PR TITLE
logger: fix snapd.debug=1 parsing

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -172,6 +172,6 @@ func debugEnabledOnKernelCmdline() bool {
 	if err != nil {
 		return false
 	}
-	l := strings.Split(string(buf), " ")
+	l := strings.Fields(string(buf))
 	return strutil.ListContains(l, "snapd.debug=1")
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -127,7 +127,7 @@ func (s *LogSuite) TestWithLoggerLock(c *C) {
 
 func (s *LogSuite) TestIntegrationDebugFromKernelCmdline(c *C) {
 	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
-	err := ioutil.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 snapd.debug=1"), 0644)
+	err := ioutil.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 snapd.debug=1\n"), 0644)
 	c.Assert(err, IsNil)
 	restore := logger.MockProcCmdline(mockProcCmdline)
 	defer restore()


### PR DESCRIPTION
We were previously splitting the kernel cmdline fields using strictly
a space character as separator. If snapd.debug=1 is at the end of
the cmdline it also gets a trailing newline and the parameter was
ignored.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>