### PR TITLE
gadget/install,secboot: add debug messages

### DIFF
--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/internal"
+	"github.com/snapcore/snapd/logger"
 )
 
 var contentMountpoint string
@@ -40,6 +41,7 @@ func init() {
 // to the filesystem type defined in the gadget.
 func makeFilesystem(ds *gadget.OnDiskStructure) error {
 	if ds.HasFilesystem() {
+		logger.Debugf("create %s filesystem on %s with label %q", ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label)
 		if err := internal.Mkfs(ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label); err != nil {
 			return err
 		}

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -44,6 +44,8 @@ func createMissingPartitions(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) 
 		return created, nil
 	}
 
+	logger.Debugf("create partitions on %s: %s", dl.Device, buf.String())
+
 	// Write the partition table. By default sfdisk will try to re-read the
 	// partition table with the BLKRRPART ioctl but will fail because the
 	// kernel side rescan removes and adds partitions and we have partitions
@@ -81,6 +83,7 @@ func removeCreatedPartitions(dl *gadget.OnDiskVolume) error {
 	}
 
 	// Delete disk partitions
+	logger.Debugf("delete disk partitions %v", indexes)
 	cmd := exec.Command("sfdisk", append([]string{"--no-reread", "--delete", dl.Device}, indexes...)...)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return osutil.OutputErr(output, err)

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -438,6 +438,8 @@ func buildPCRProtectionProfile(modelParams []*SealKeyModelParams) (*sb.PCRProtec
 		pcrProfile = modelPCRProfiles[0]
 	}
 
+	logger.Debugf("PCR protection profile:\n%s", pcrProfile.String())
+
 	return pcrProfile, nil
 }
 


### PR DESCRIPTION
Add extra debug messages that can be useful to diagnose problems
during install or reseal.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
