### PR TITLE
logger: use strutil.KernelCommandLineSplit in debugEnabledOnKernelCmdline

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -172,6 +172,6 @@ func debugEnabledOnKernelCmdline() bool {
 	if err != nil {
 		return false
 	}
-	l := strings.Fields(string(buf))
+	l, _ := strutil.KernelCommandLineSplit(strings.TrimSpace(string(buf)))
 	return strutil.ListContains(l, "snapd.debug=1")
 }


### PR DESCRIPTION
This is a followup from PR#9486 which adds a precise kernel commandline
parsing.
