### PR TITLE
logger: use KernelCommandLineSplit to parse debug flag

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -172,6 +172,6 @@ func debugEnabledOnKernelCmdline() bool {
 	if err != nil {
 		return false
 	}
-	l := strings.Fields(string(buf))
+	l, _ := strutil.KernelCommandLineSplit(strings.TrimSpace(string(buf)))
 	return strutil.ListContains(l, "snapd.debug=1")
 }


### PR DESCRIPTION
Use our kernel command line splitter instead of strings.Fields() as
suggested by Maciej Borzecki in PR #9486 to verify if snapd.debug=1
was specified.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
