### PR TITLE
client,daemon,snap: auto-import does not error on managed devices

### DIFF
--- a/client/users.go
+++ b/client/users.go
@@ -45,6 +45,7 @@ type CreateUserOptions struct {
 	Sudoer       bool   `json:"sudoer,omitempty"`
 	Known        bool   `json:"known,omitempty"`
 	ForceManaged bool   `json:"force-managed,omitempty"`
+	Automatic    bool   `json:"automatic,omitempty"`
 }
 
 // RemoveUserOptions holds options for removing a local system user.
@@ -88,7 +89,7 @@ func (client *Client) CreateUser(options *CreateUserOptions) (*CreateUserResult,
 // Results may be provided even if there are errors.
 func (client *Client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserResult, error) {
 	for _, opts := range options {
-		if opts == nil || (opts.Email == "" && !opts.Known) {
+		if opts == nil || (opts.Email == "" && !(opts.Known || opts.Automatic)) {
 			return nil, fmt.Errorf("cannot create user from store details without an email to query for")
 		}
 	}

--- a/client/users.go
+++ b/client/users.go
@@ -45,7 +45,8 @@ type CreateUserOptions struct {
 	Sudoer       bool   `json:"sudoer,omitempty"`
 	Known        bool   `json:"known,omitempty"`
 	ForceManaged bool   `json:"force-managed,omitempty"`
-	Automatic    bool   `json:"automatic,omitempty"`
+	// Automatic is for internal snapd use, behavior might evolve
+	Automatic bool `json:"automatic,omitempty"`
 }
 
 // RemoveUserOptions holds options for removing a local system user.

--- a/client/users_test.go
+++ b/client/users_test.go
@@ -139,11 +139,25 @@ var createUsersTests = []struct {
 		Username: "two",
 	}, {
 		Username: "three",
+	},
+	},
+}, {
+	options: []*client.CreateUserOptions{{
+		Automatic: true,
 	}},
-}}
+	bodies: []string{
+		`{"action":"create","automatic":true}`,
+	},
+	responses: []string{
+		// for automatic result can be empty
+		`{"type": "sync", "result": []}`,
+	},
+},
+}
 
 func (cs *clientSuite) TestClientCreateUsers(c *C) {
 	for _, test := range createUsersTests {
+		cs.reqs = nil
 		cs.rsps = test.responses
 
 		results, err := cs.cli.CreateUsers(test.options)

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -279,12 +279,15 @@ func init() {
 }
 
 func (x *cmdAutoImport) autoAddUsers() error {
-	cmd := cmdCreateUser{
-		clientMixin: x.clientMixin,
-		Known:       true,
-		Sudoer:      true,
+	options := client.CreateUserOptions{
+		Automatic: true,
 	}
-	return cmd.Execute(nil)
+	results, err := x.client.CreateUsers([]*client.CreateUserOptions{&options})
+	for _, result := range results {
+		fmt.Fprintf(Stdout, i18n.G("created user %q\n"), result.Username)
+	}
+
+	return err
 }
 
 func removableBlockDevices() (removableDevices []string) {

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -315,12 +315,21 @@ func createUser(c *Command, createData postUserCreateData) Response {
 	}
 
 	if !createData.ForceManaged {
+		if len(users) > 0 && createData.Automatic {
+			// no users created but no error with the automatic flag
+			return SyncResponse([]userResponseData{}, nil)
+		}
 		if len(users) > 0 {
 			return BadRequest("cannot create user: device already managed")
 		}
 		if release.OnClassic {
 			return BadRequest("cannot create user: device is a classic system")
 		}
+	}
+	if createData.Automatic {
+		// Automatic implies known/sudoers
+		createData.Known = true
+		createData.Sudoer = true
 	}
 
 	var model *asserts.Model
@@ -521,6 +530,7 @@ type postUserCreateData struct {
 	Sudoer       bool   `json:"sudoer"`
 	Known        bool   `json:"known"`
 	ForceManaged bool   `json:"force-managed"`
+	Automatic    bool   `json:"automatic"`
 
 	// singleUserResultCompat indicates whether to preserve
 	// backwards compatibility, which results in more clunky


### PR DESCRIPTION
The snap auto-import code right will always try to create all
known system-users when it imports any assertions. However this
leads to systemd errors and a degraded boot when a device is already
managed and a removable device with a user assertion is attached
to the device.

This commit changes the auto-import code to send a new
`automatic: true` json when running auto-imports. With that
option already managed device just return that no users are
created and no error.

This fixes https://bugs.launchpad.net/newparis/+bug/1893331

This is a better version of #9293