### PR TITLE
tests: use tests.backup tool

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -856,6 +856,8 @@ suites:
             # Install the snapd built
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb
         prepare-each: |
+            tests.backup prepare
+
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
             nested_prepare_env
@@ -864,6 +866,8 @@ suites:
             . "$TESTSLIB/nested.sh"
             nested_destroy_vm
             nested_cleanup_env
+
+            tests.backup restore
         restore: |
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
@@ -905,6 +909,8 @@ suites:
             nested_prepare_env
             nested_create_classic_vm
         prepare-each: |
+            tests.backup prepare
+
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
             nested_start_classic_vm
@@ -912,6 +918,8 @@ suites:
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
             nested_destroy_vm
+
+            tests.backup restore
         restore: |
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
@@ -953,6 +961,8 @@ suites:
             nested_prepare_env
             nested_create_core_vm
         prepare-each: |
+            tests.backup prepare
+
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
             nested_start_core_vm
@@ -961,6 +971,8 @@ suites:
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
             nested_destroy_vm
+
+            tests.backup restore
         restore: |
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"
@@ -1003,8 +1015,19 @@ suites:
             . "$TESTSLIB/nested.sh"
             nested_prepare_env
             nested_create_core_vm
+        prepare-each: |
+            tests.backup prepare
+
+            #shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB/nested.sh"
             nested_start_core_vm
             nested_wait_for_snap_command
+        restore-each: |
+            #shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB/nested.sh"
+            nested_destroy_vm
+
+            tests.backup restore
         restore: |
             #shellcheck source=tests/lib/nested.sh
             . "$TESTSLIB/nested.sh"

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -588,7 +588,7 @@ prepare_suite_each() {
     local variant="$1"
 
     # back test directory to be restored during the restore
-    tar cf "${PWD}.tar" "$PWD"
+    tests.backup prepare
 
     # WORKAROUND for memleak https://github.com/systemd/systemd/issues/11502
     if [[ "$SPREAD_SYSTEM" == debian-sid* ]]; then
@@ -642,13 +642,7 @@ restore_suite_each() {
     rm -f "$RUNTIME_STATE_PATH/audit-stamp"
 
     # restore test directory saved during prepare
-    if [ -f "${PWD}.tar" ]; then
-        rm -rf "$PWD"
-        tar -C/ -xf "${PWD}.tar"
-        rm -rf "${PWD}.tar"
-        # $PWD was removed and recreated, enter the new directory
-        cd "$PWD"
-    fi
+    tests.backup restore
 
     if [[ "$variant" = full && "$PROFILE_SNAPS" = 1 ]]; then
         echo "Save snaps profiler log"


### PR DESCRIPTION
Start using tests.backup tool for regular tests and nested tests.
