### PR TITLE
many: verify that unit tests work with nosecboot tag and without secboot package

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,6 +168,15 @@ jobs:
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         ./run-checks --unit
+    - name: Test Go (nosecboot)
+      if: steps.cached-results.outputs.already-ran != 'true'
+      run: |
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
+        echo "Dropping github.com/snapcore/secboot"
+        # use govendor remove so that a subsequent govendor sync does not
+        # install secboot again
+        govendor remove github.com/snapcore/secboot +unused
+        UNIT_TAGS=nosecboot ./run-checks --unit
     - name: Cache successful run
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -177,7 +177,7 @@ jobs:
         # install secboot again
         ${{ github.workspace }}/bin/govendor remove github.com/snapcore/secboot
         ${{ github.workspace }}/bin/govendor remove +unused
-        GO_BUILD_TAGS=nosecboot ./run-checks --unit
+        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
     - name: Cache successful run
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -175,7 +175,8 @@ jobs:
         echo "Dropping github.com/snapcore/secboot"
         # use govendor remove so that a subsequent govendor sync does not
         # install secboot again
-        govendor remove github.com/snapcore/secboot +unused
+        ${{ github.workspace }}/bin/govendor remove github.com/snapcore/secboot
+        ${{ github.workspace }}/bin/govendor remove +unused
         GO_BUILD_TAGS=nosecboot ./run-checks --unit
     - name: Cache successful run
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -176,7 +176,7 @@ jobs:
         # use govendor remove so that a subsequent govendor sync does not
         # install secboot again
         govendor remove github.com/snapcore/secboot +unused
-        UNIT_TAGS=nosecboot ./run-checks --unit
+        GO_BUILD_TAGS=nosecboot ./run-checks --unit
     - name: Cache successful run
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -35,7 +35,6 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/sysconfig"
@@ -74,9 +73,9 @@ var (
 		snap.TypeSnapd:  "snapd",
 	}
 
-	secbootMeasureSnapSystemEpochWhenPossible = secboot.MeasureSnapSystemEpochWhenPossible
-	secbootMeasureSnapModelWhenPossible       = secboot.MeasureSnapModelWhenPossible
-	secbootUnlockVolumeIfEncrypted            = secboot.UnlockVolumeIfEncrypted
+	secbootMeasureSnapSystemEpochWhenPossible func() error
+	secbootMeasureSnapModelWhenPossible       func(findModel func() (*asserts.Model, error)) error
+	secbootUnlockVolumeIfEncrypted            func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error)
 
 	bootFindPartitionUUIDForBootedKernelDisk = boot.FindPartitionUUIDForBootedKernelDisk
 )

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build nosecboot
+
+/*
+ * Copyright (C) 2019-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/osutil/disks"
+)
+
+var (
+	errNotImplemented = errors.New("not implemented")
+)
+
+func init() {
+	secbootMeasureSnapSystemEpochWhenPossible = func() error {
+		return errNotImplemented
+	}
+	secbootMeasureSnapModelWhenPossible = func(_ func() (*asserts.Model, error)) error {
+		return errNotImplemented
+	}
+	secbootUnlockVolumeIfEncrypted = func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+		return "", false, errNotImplemented
+	}
+}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_secboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_secboot.go
@@ -1,0 +1,31 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nosecboot
+
+/*
+ * Copyright (C) 2019-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/secboot"
+)
+
+func init() {
+	secbootMeasureSnapSystemEpochWhenPossible = secboot.MeasureSnapSystemEpochWhenPossible
+	secbootMeasureSnapModelWhenPossible = secboot.MeasureSnapModelWhenPossible
+	secbootUnlockVolumeIfEncrypted = secboot.UnlockVolumeIfEncrypted
+}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -202,6 +202,16 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 	// by default mock that we don't have UEFI vars, etc. to get the booted
 	// kernel partition partition uuid
 	s.AddCleanup(main.MockPartitionUUIDForBootedKernelDisk(""))
+	s.AddCleanup(main.MockSecbootMeasureSnapSystemEpochWhenPossible(func() error {
+		return nil
+	}))
+	s.AddCleanup(main.MockSecbootMeasureSnapModelWhenPossible(func(f func() (*asserts.Model, error)) error {
+		c.Check(f, NotNil)
+		return nil
+	}))
+	s.AddCleanup(main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+		return filepath.Join("/dev/disk/by-partuuid", name+"-partuuid"), false, nil
+	}))
 }
 
 // makeSnapFilesOnEarlyBootUbuntuData creates the snap files on ubuntu-data as

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nosecboot
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nosecboot
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package install
+
+import (
+	"github.com/snapcore/snapd/secboot"
+)
+
+var (
+	EnsureLayoutCompatibility = ensureLayoutCompatibility
+	DeviceFromRole            = deviceFromRole
+	NewEncryptedDevice        = newEncryptedDevice
+)
+
+func MockSecbootFormatEncryptedDevice(f func(key secboot.EncryptionKey, label, node string) error) (restore func()) {
+	old := secbootFormatEncryptedDevice
+	secbootFormatEncryptedDevice = f
+	return func() {
+		secbootFormatEncryptedDevice = old
+	}
+}
+
+func MockSecbootAddRecoveryKey(f func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string) error) (restore func()) {
+	old := secbootAddRecoveryKey
+	secbootAddRecoveryKey = f
+	return func() {
+		secbootAddRecoveryKey = old
+	}
+}

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -23,14 +23,9 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/gadget"
-	"github.com/snapcore/snapd/secboot"
 )
 
 var (
-	EnsureLayoutCompatibility = ensureLayoutCompatibility
-	DeviceFromRole            = deviceFromRole
-	NewEncryptedDevice        = newEncryptedDevice
-
 	MakeFilesystem  = makeFilesystem
 	WriteContent    = writeContent
 	MountFilesystem = mountFilesystem
@@ -69,21 +64,5 @@ func MockEnsureNodesExist(f func(dss []gadget.OnDiskStructure, timeout time.Dura
 	ensureNodesExist = f
 	return func() {
 		ensureNodesExist = old
-	}
-}
-
-func MockSecbootFormatEncryptedDevice(f func(key secboot.EncryptionKey, label, node string) error) (restore func()) {
-	old := secbootFormatEncryptedDevice
-	secbootFormatEncryptedDevice = f
-	return func() {
-		secbootFormatEncryptedDevice = old
-	}
-}
-
-func MockSecbootAddRecoveryKey(f func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string) error) (restore func()) {
-	old := secbootAddRecoveryKey
-	secbootAddRecoveryKey = f
-	return func() {
-		secbootAddRecoveryKey = old
 	}
 }

--- a/run-checks
+++ b/run-checks
@@ -294,9 +294,9 @@ if [ "$UNIT" = 1 ]; then
     go version
 
     tags=
-    if [ -n "${UNIT_TAGS-}" ]; then
-        echo "Using build tags: $UNIT_TAGS"
-        tags="-tags $UNIT_TAGS"
+    if [ -n "${GO_BUILD_TAGS-}" ]; then
+        echo "Using build tags: $GO_BUILD_TAGS"
+        tags="-tags $GO_BUILD_TAGS"
     fi
 
     echo Building

--- a/run-checks
+++ b/run-checks
@@ -407,6 +407,10 @@ EOF
     exit 1
 fi
 
+if [ -n "${SKIP_DIRTY_CHECK-}" ]; then
+    exit 0
+fi
+
 if git describe --always --dirty | grep -q dirty; then
     echo "Build tree is dirty"
     git diff

--- a/run-checks
+++ b/run-checks
@@ -170,6 +170,7 @@ if [ "$STATIC" = 1 ]; then
         done
         if [ -n "$fmt" ]; then
             echo "Formatting wrong in following files:"
+            # shellcheck disable=SC2001
             echo "$fmt" | sed -e 's/\\n/\n/g'
             exit 1
         fi
@@ -292,14 +293,21 @@ if [ "$UNIT" = 1 ]; then
     command -v go
     go version
 
+    tags=
+    if [ -n "${UNIT_TAGS-}" ]; then
+        echo "Using build tags: $UNIT_TAGS"
+        tags="-tags $UNIT_TAGS"
+    fi
+
     echo Building
-    go build -v github.com/snapcore/snapd/...
+    # shellcheck disable=SC2086
+    go build -v $tags github.com/snapcore/snapd/...
 
     # tests
     echo Running tests from "$PWD"
     if [ "$short" = 1 ]; then
-            # shellcheck disable=SC2046
-            GOTRACEBACK=1 $goctest -short -timeout 5m $(go list ./... | grep -v '/vendor/' )
+            # shellcheck disable=SC2046,SC2086
+            GOTRACEBACK=1 $goctest $tags -short -timeout 5m $(go list ./... | grep -v '/vendor/' )
     else
         # Prepare the coverage output profile.
         rm -rf .coverage
@@ -307,12 +315,14 @@ if [ "$UNIT" = 1 ]; then
         echo "mode: $COVERMODE" > .coverage/coverage.out
 
         if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
-            # shellcheck disable=SC2046
-            GOTRACEBACK=1 $goctest -timeout 5m -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
+            # shellcheck disable=SC2046,SC2086
+            GOTRACEBACK=1 $goctest $tags -timeout 5m -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
         else
             for pkg in $(go list ./... | grep -v '/vendor/' ); do
-                GOTRACEBACK=1 go test -timeout 5m -i "$pkg"
-                GOTRACEBACK=1 $goctest -timeout 5m -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
+                # shellcheck disable=SC2086
+                GOTRACEBACK=1 go test $tags -timeout 5m -i "$pkg"
+                # shellcheck disable=SC2086
+                GOTRACEBACK=1 $goctest $tags -timeout 5m -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
                 append_coverage .coverage/profile.out
             done
         fi

--- a/secboot/encrypt_test.go
+++ b/secboot/encrypt_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nosecboot
 
 /*
  * Copyright (C) 2019-2020 Canonical Ltd


### PR DESCRIPTION
Some distros, eg. Debian Sid, run unit tests as part of the package build process. However, when dependencies are not vendored, there is no secboot package, and thus the unit tests fail to build. We can disable secboot by passing the `nosecboot`, package, but unit tests still fail to build and work. The branch attempts to fix that and add a step to the unit tests workflow that ensures we keep it working.

This should also fix #9502.
