### PR TITLE
boot: skip some unit tests when running as root

### DIFF
--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -1146,6 +1146,10 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 }
 
 func (s *sealSuite) TestReadWriteBootChains(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	chains := []boot.BootChain{
 		{
 			BrandID:        "mybrand",

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -718,6 +718,10 @@ func (s *sealSuite) TestSealKeyModelParams(c *C) {
 }
 
 func (s *sealSuite) TestIsResealNeeded(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	chains := []boot.BootChain{
 		{
 			BrandID:        "mybrand",

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -471,6 +471,10 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableTryKernel(c *C) {
 }
 
 func (s *grubTestSuite) TestGrubExtractedRunKernelImageDisableTryKernel(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	s.makeFakeGrubEnv(c)
 	g := bootloader.NewGrub(s.rootdir, nil)
 	eg, ok := g.(bootloader.ExtractedRunKernelImageBootloader)
@@ -745,6 +749,10 @@ this is updated grub.cfg
 }
 
 func (s *grubTestSuite) TestBootUpdateBootConfigTrivialErr(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	oldConfig := `# Snapd-Boot-Config-Edition: 2
 boot script
 `

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -455,6 +455,10 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorMissingSource(c *C) {
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedWriterErrorBadDestination(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	makeSizedFile(c, filepath.Join(s.dir, "foo"), 0, []byte("foo foo foo"))
 
 	ps := &gadget.LaidOutStructure{
@@ -1234,6 +1238,10 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupNonexistent(c *C) {
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnBackupDirErrors(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	outDir := filepath.Join(c.MkDir(), "out-dir")
 
 	ps := &gadget.LaidOutStructure{
@@ -1268,6 +1276,10 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnBackupDirErr
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnDestinationErrors(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	// some data for the gadget
 	gd := []gadgetData{
 		{name: "bar", content: "data"},
@@ -1310,6 +1322,10 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnDestinationE
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnBadSrcComparison(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	// some data for the gadget
 	gd := []gadgetData{
 		{name: "bar", content: "data"},
@@ -2335,6 +2351,10 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackNewFiles(c *C) {
 }
 
 func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackRestoreFails(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	makeGadgetData(c, s.dir, []gadgetData{
 		{name: "bar", content: "data"},
 	})

--- a/gadget/raw_test.go
+++ b/gadget/raw_test.go
@@ -661,6 +661,10 @@ func (r *rawTestSuite) TestRawUpdaterFindDeviceFailed(c *C) {
 }
 
 func (r *rawTestSuite) TestRawUpdaterRollbackErrors(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	diskPath := filepath.Join(r.dir, "disk.img")
 	// 0 sized disk, copying will fail with early EOF
 	makeSizedFile(c, diskPath, 0, nil)
@@ -707,6 +711,10 @@ func (r *rawTestSuite) TestRawUpdaterRollbackErrors(c *C) {
 }
 
 func (r *rawTestSuite) TestRawUpdaterUpdateErrors(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("the test cannot be run by the root user")
+	}
+
 	diskPath := filepath.Join(r.dir, "disk.img")
 	// 0 sized disk, copying will fail with early EOF
 	makeSizedFile(c, diskPath, 2048, nil)

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -330,17 +330,19 @@ func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
 	c.Assert(err, ErrorMatches, `symlink target /.*/nested/bar\..*~: no such file or directory`)
 	checkLeftoverFiles(nestedBarSymlink, nil)
 
-	// create a dir without write permission
-	err = os.MkdirAll(nested, 0644)
-	c.Assert(err, IsNil)
+	if os.Geteuid() != 0 {
+		// create a dir without write permission
+		err = os.MkdirAll(nested, 0644)
+		c.Assert(err, IsNil)
 
-	// no permission to write in dir
-	err = osutil.AtomicSymlink("target", nestedBarSymlink)
-	c.Assert(err, ErrorMatches, `symlink target /.*/nested/bar\..*~: permission denied`)
-	checkLeftoverFiles(nestedBarSymlink, nil)
+		// no permission to write in dir
+		err = osutil.AtomicSymlink("target", nestedBarSymlink)
+		c.Assert(err, ErrorMatches, `symlink target /.*/nested/bar\..*~: permission denied`)
+		checkLeftoverFiles(nestedBarSymlink, nil)
 
-	err = os.Chmod(nested, 0755)
-	c.Assert(err, IsNil)
+		err = os.Chmod(nested, 0755)
+		c.Assert(err, IsNil)
+	}
 
 	err = osutil.AtomicSymlink("target", nestedBarSymlink)
 	c.Assert(err, IsNil)
@@ -419,16 +421,18 @@ func (ts *AtomicRenameTestSuite) TestAtomicRename(c *C) {
 		c.Assert(err, ErrorMatches, "rename /.*/bar /.*/nested/bar: no such file or directory")
 	}
 
-	// create a dir without write permission
-	err = os.MkdirAll(nested, 0644)
-	c.Assert(err, IsNil)
+	if os.Geteuid() != 0 {
+		// create a dir without write permission
+		err = os.MkdirAll(nested, 0644)
+		c.Assert(err, IsNil)
 
-	// no permission to write in dir
-	err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))
-	c.Assert(err, ErrorMatches, "rename /.*/bar /.*/nested/bar: permission denied")
+		// no permission to write in dir
+		err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))
+		c.Assert(err, ErrorMatches, "rename /.*/bar /.*/nested/bar: permission denied")
 
-	err = os.Chmod(nested, 0755)
-	c.Assert(err, IsNil)
+		err = os.Chmod(nested, 0755)
+		c.Assert(err, IsNil)
+	}
 
 	// all good now
 	err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))


### PR DESCRIPTION
Some package tooling may run unit tests during the build as root. Unfortunately,
not all of the tests set up scenarios which can be correctly executed as root
when the DAC override can be applied. Skip whole tests or just the relevant bits.


