### PR TITLE
overlord/snapshotstate/backend: specify tar format for snapshots

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -377,6 +377,7 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 	tarArgs := []string{
 		"--create",
 		"--sparse", "--gzip",
+		"--format", "gnu",
 		"--directory", parent,
 	}
 


### PR DESCRIPTION
Explicitly specify the format of tar archive in the backend. This ensures we use
the same format on all platforms, rather than whatever the default is on a
a given distro.

In particular, the following failure was observed on openSUSE:
```
----------------------------------------------------------------------
FAIL: <autogenerated>:1: isTestingSuite.TestExportTwice

backend_test.go:849:
    c.Check(se.Size(), check.Equals, expectedSize)
... obtained int64 = 4608
... expected int64 = 4096

backend_test.go:853:
    c.Check(buf.Len(), check.Equals, int(expectedSize))
... obtained int = 4608
... expected int = 4096

backend_test.go:866:
    c.Check(se2.Size(), check.Equals, expectedSize)
... obtained int64 = 4608
... expected int64 = 4096

backend_test.go:871:
    c.Check(buf.Len(), check.Equals, int(expectedSize))
... obtained int = 4608
... expected int = 4096
```
Upon further investigation, the snapshot file was larger, because the *.tgz
files inside were larger. Further investigation revealed that on openSUSE, the
tar format as reported by file, was: POSIX tar archive, while on Arch and
Ubuntu: POSIX tar archive (GNU).
