### PR TITLE
tests: remove ausearch which fails during prepare

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -623,12 +623,6 @@ prepare_suite_each() {
     # Check if journalctl is ready to run the test
     "$TESTSTOOLS"/journal-state check-log-started
 
-    case "$SPREAD_SYSTEM" in
-        fedora-*|centos-*|amazon-*)
-            ausearch -i -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" || true
-            ;;
-    esac
-
     # Check for invariants late, in order to detect any bugs in the code above.
     if [[ "$variant" = full ]]; then
         "$TESTSTOOLS"/cleanup-state pre-invariant


### PR DESCRIPTION
This check currently fails in many tests on fedora and centos. It has "||
true" because of that.

ausearch -i -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" ||
true

I tested that and fails in many tests during prepare, even adding a
retry.
