### PR TITLE
o/snapstate: re-order remove tasks for individual snap revisions to remove current last

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2124,9 +2124,16 @@ func removeTasks(st *state.State, name string, revision snap.Revision, flags *Re
 
 	if removeAll {
 		seq := snapst.Sequence
+		currentIndex := snapst.LastIndex(snapst.Current)
 		for i := len(seq) - 1; i >= 0; i-- {
-			si := seq[i]
-			addNext(removeInactiveRevision(st, name, info.SnapID, si.Revision))
+			if i != currentIndex {
+				si := seq[i]
+				addNext(removeInactiveRevision(st, name, info.SnapID, si.Revision))
+			}
+		}
+		// tasks for removing current revision of the snap are last
+		if currentIndex >= 0 {
+			addNext(removeInactiveRevision(st, name, info.SnapID, seq[currentIndex].Revision))
 		}
 	} else {
 		addNext(removeInactiveRevision(st, name, info.SnapID, revision))

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2131,7 +2131,8 @@ func removeTasks(st *state.State, name string, revision snap.Revision, flags *Re
 				addNext(removeInactiveRevision(st, name, info.SnapID, si.Revision))
 			}
 		}
-		// tasks for removing current revision of the snap are last
+		// add tasks for removing the current revision last,
+		// this is then also when common data will be removed
 		if currentIndex >= 0 {
 			addNext(removeInactiveRevision(st, name, info.SnapID, seq[currentIndex].Revision))
 		}

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -668,15 +668,6 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 		},
 		{
 			op:   "remove-snap-data",
-			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
-		},
-		{
-			op:    "remove-snap-files",
-			path:  filepath.Join(dirs.SnapMountDir, "some-snap/7"),
-			stype: "app",
-		},
-		{
-			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/3"),
 		},
 		{
@@ -689,8 +680,17 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/5"),
 		},
 		{
+			op:    "remove-snap-files",
+			path:  filepath.Join(dirs.SnapMountDir, "some-snap/5"),
+			stype: "app",
+		},
+		{
+			op:   "remove-snap-data",
+			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
+		},
+		{
 			op:   "remove-snap-common-data",
-			path: filepath.Join(dirs.SnapMountDir, "some-snap/5"),
+			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 		},
 		{
 			op:   "remove-snap-data-dir",
@@ -699,7 +699,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 		},
 		{
 			op:    "remove-snap-files",
-			path:  filepath.Join(dirs.SnapMountDir, "some-snap/5"),
+			path:  filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 			stype: "app",
 		},
 		{
@@ -722,7 +722,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 
 	// verify snapSetup info
 	tasks := ts.Tasks()
-	revnos := []snap.Revision{{N: 7}, {N: 3}, {N: 5}}
+	revnos := []snap.Revision{{N: 3}, {N: 5}, {N: 7}}
 	whichRevno := 0
 	for _, t := range tasks {
 		if t.Kind() == "run-hook" {


### PR DESCRIPTION
Re-order tasks that remove individual snap revisions when removing snap completely to remove current revision last. 

Current revision is the most interesting one in case of a failure when we need to undo, so we should keep it for as long as possible and get rid of old (unused) revisions first; "current" is the revno we currently store in remove tasks in case of undo, but unfortunately since we remove revisions in "random" order, if we remove current revision first and then fail on removing one of the unused revisions, we are not able to do anything sensible on undo, and in fact fail really badly - see https://bugs.launchpad.net/snapd/+bug/1899614

This PR alone doesn't fix 1899614 because there are some more factors (e.g. remove is missing undo handler for unlink-snap) and they will be addressed separately. It's very likely that after making clear-snap task handler more resilient against os.Remove errors the main trigger for the above bug will be fixed, nonetheless re-ordering removal of snap revisions still makes sense in case of unexpected errors and undo.

