### PR TITLE
interfaces/fwupd: enforce the confined fwupd to align Ubuntu Core ESP layout

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -72,6 +72,10 @@ const fwupdPermanentSlotAppArmor = `
 
   # Allow write access for efi firmware updater
   /boot/efi/{,**/} r,
+  # allow access to fwupd* and fw/ under boot/ for core systems
+  /boot/efi/EFI/boot/fwupd*.efi* rw,
+  /boot/efi/EFI/boot/fw/** rw,
+  # allow access to fwupd* and fw/ under ubuntu/ for classic systems
   /boot/efi/EFI/ubuntu/fwupd*.efi* rw,
   /boot/efi/EFI/ubuntu/fw/** rw,
 


### PR DESCRIPTION
In the previous work, since UC16, we relied on the classic way to use
the path under /EFI/ubuntu for FW update, and this made shimx64.efi
redundant when it was copied to /EFI/ubuntu as well, as /EFI/boot
already provided bootx64.efi which is shim itself. It should be
improved by aligning the ESP layout the gadget specified, and the
confined fwupd just needs to do the same things under /EFI/boot instead.
However, the original rules for /EFI/ubuntu are needed to be maintained
for backward compatibility.
