### PR TITLE
cmd/snap-confine: update path to snap-device-helper in AppArmor profile

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -71,7 +71,7 @@
     # querying udev
     /etc/udev/udev.conf r,
     /sys/**/uevent r,
-    /usr/lib/snapd/snap-device-helper ixr, # drop
+    @LIBEXECDIR@/snap-device-helper ixr, # drop
     /{,usr/}lib/udev/snappy-app-dev ixr, # drop
     /run/udev/** rw,
     /{,usr/}bin/tr ixr,


### PR DESCRIPTION
The AppArmor profile hardcodes the path to snap-device-helper to use
/usr/lib/snapd. This was true for all distros using AppArmor, but with the
change in Tumbleweed to usr /usr/libexec (and thus /usr/libexec/snapd), the path
no longer works and snaps having device added to the cgroup fail to start.
