### PR TITLE
spread, tests: tweaks for openSUSE

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -317,7 +317,7 @@ install -m 644 -D %{indigo_srcdir}/data/completion/zsh/_snap %{buildroot}%{_data
 %post
 %set_permissions %{_libexecdir}/snapd/snap-confine
 %if %{with apparmor}
-%apparmor_reload /etc/apparmor.d/usr.lib.snapd.snap-confine
+%apparmor_reload /etc/apparmor.d/%{apparmor_snapconfine_profile}
 %endif
 %service_add_post %{systemd_services_list}
 %systemd_user_post %{systemd_user_services_list}

--- a/spread.yaml
+++ b/spread.yaml
@@ -447,10 +447,14 @@ debug-each: |
                 ) | grep -v snappy_home_t || true
                 find /var/snap -printf '%Z\t%H/%P\n' | grep -v snappy_var_t || true
                 ;;
+            opensuse-*)
+                echo '# apparmor denials logged by auditd'
+                ausearch -m AVC | grep DENIED || true
+                ;;
             *)
-               echo '# apparmor denials '
-               dmesg --ctime | grep DENIED || true
-               ;;
+                echo '# apparmor denials '
+                dmesg --ctime | grep DENIED || true
+                ;;
         esac
         echo '# seccomp denials (kills) '
         dmesg --ctime | grep type=1326 || true

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -520,6 +520,12 @@ distro_install_build_snapd(){
             fi
         fi
 
+        if [[ "$SPREAD_SYSTEM" == opensuse-tumbleweed-* ]]; then
+            # Package installation applies vendor presets only, which leaves
+            # snapd.apparmor disabled.
+            systemctl enable --now snapd.apparmor.service
+        fi
+
         # On some distributions the snapd.socket is not yet automatically
         # enabled as we don't have a systemd present configuration approved
         # by the distribution for it in place yet.


### PR DESCRIPTION
Look for AppArmor denials in the audit log rather than dmesg. Workaround snapd.apparmor.service being disabled on package install, follow the instructions from the docs page: https://snapcraft.io/docs/installing-snap-on-opensuse