### PR TITLE
tests: add value to INSTANCE_KEY/regular

### DIFF
--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -2,7 +2,7 @@ summary: inspect all the set environment variables prefixed with SNAP_ and XDG_
 
 environment:
     NAME/regular: test-snapd-tools
-    INSTANCE_KEY/regular:
+    INSTANCE_KEY/regular: ""
     NAME/parallel: test-snapd-tools_foo
     INSTANCE_KEY/parallel: foo
 


### PR DESCRIPTION
Without this, spread just built from master complains:

    error: invalid tests/main/snap-env environment: invalid variable name: INSTANCE_KEY/regular

I suspect we all run old spread that somehow does not care.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
