### PR TITLE
tests: moving the core test suite from systems.sh to os.query tool

### DIFF
--- a/tests/core/config-defaults-once/task.yaml
+++ b/tests/core/config-defaults-once/task.yaml
@@ -51,13 +51,11 @@ restore: |
     . "$TESTSLIB"/core-config.sh
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     # XXX: this should work once it is possible to install snapd on core
     SNAP=snapd
     SERVICES="ssh rsyslog"
-    if is_core18_system; then
+    if os.query is-core18; then
         # a core18 already has a snapd snap, verify whether installation of core
         # does not break the configuration
         SNAP=core
@@ -108,13 +106,10 @@ execute: |
         exit
     fi
 
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     # XXX: this should work once it is possible to install snapd on core
     SNAP=snapd
     SERVICES="ssh rsyslog"
-    if is_core18_system; then
+    if os.query is-core18; then
         # a core18 already has a snapd snap, verify whether installation of core
         # does not break the configuration
         SNAP=core
@@ -142,6 +137,6 @@ execute: |
     test ! -e /etc/ssh/sshd_not_to_be_run
 
     # Unmask rsyslog service on core18
-    if is_core18_system; then
+    if os.query is-core18; then
         systemctl unmask rsyslog
     fi

--- a/tests/core/custom-device-reg/task.yaml
+++ b/tests/core/custom-device-reg/task.yaml
@@ -15,8 +15,6 @@ prepare: |
     . "$TESTSLIB"/core-config.sh
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     systemctl stop snapd.service snapd.socket
     clean_snapd_lib

--- a/tests/core/gadget-config-defaults-vitality/task.yaml
+++ b/tests/core/gadget-config-defaults-vitality/task.yaml
@@ -19,8 +19,6 @@ prepare: |
     . "$TESTSLIB"/core-config.sh
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     # Stop snapd and remove existing state, modify and repack gadget
     # snap and provide developer assertions in order to force first
@@ -77,8 +75,6 @@ restore: |
     fi
     #shellcheck source=tests/lib/core-config.sh
     . "$TESTSLIB"/core-config.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     SUFFIX="$(get_test_snap_suffix)"
 
@@ -122,8 +118,6 @@ execute: |
     fi
     #shellcheck source=tests/lib/core-config.sh
     . "$TESTSLIB"/core-config.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     SUFFIX="$(get_test_snap_suffix)"
 

--- a/tests/core/gadget-config-defaults/task.yaml
+++ b/tests/core/gadget-config-defaults/task.yaml
@@ -24,10 +24,8 @@ prepare: |
     . "$TESTSLIB"/core-config.sh
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
-    if [ "$SERVICE" = "rsyslog" ] && is_core18_system; then
+    if [ "$SERVICE" = "rsyslog" ] && os.query is-core18; then
         echo "The service to test does not exist in the core18 system, skipping..."
         touch "${SERVICE}.skip"
         exit
@@ -49,7 +47,7 @@ prepare: |
         # test-snapd-with-configure
         TEST_SNAP_ID=jHxWQxtGqu7tHwiq7F8Ojk5qazcEeslT
 
-        if is_core18_system; then
+        if os.query is-core18; then
             # test-snapd-with-configure-core18
             TEST_SNAP_ID=jHxWQxtGqu7tHwiq7F8Ojk5qazcEeslT
         fi
@@ -57,7 +55,7 @@ prepare: |
         # test-snapd-with-configure
         TEST_SNAP_ID=aLcJorEJZgJNUGL2GMb3WR9SoVyHUNAd
 
-        if is_core18_system; then
+        if os.query is-core18; then
             # test-snapd-with-configure-core18
             TEST_SNAP_ID=BzMG26hwO2ccNBzV5BxK4DZgulJ2AXsa
         fi
@@ -100,8 +98,6 @@ restore: |
     . "$TESTSLIB"/core-config.sh
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     SUFFIX="$(get_test_snap_suffix)"
 
@@ -156,8 +152,6 @@ execute: |
     fi
     #shellcheck source=tests/lib/core-config.sh
     . "$TESTSLIB"/core-config.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     SUFFIX="$(get_test_snap_suffix)"
 

--- a/tests/core/gadget-update-pc/task.yaml
+++ b/tests/core/gadget-update-pc/task.yaml
@@ -35,9 +35,6 @@ prepare: |
     . "$TESTSLIB"/store.sh
     setup_fake_store "$BLOB_DIR"
 
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     cp /var/lib/snapd/snaps/pc_*.snap gadget.snap
     unsquashfs -d pc-snap gadget.snap
 
@@ -59,7 +56,7 @@ prepare: |
     cp pc-snap/meta/gadget.yaml gadget.yaml.orig
 
     system_seed=""
-    if is_core20_system ; then
+    if os.query is-core20 ; then
         system_seed="--system-seed"
     fi
 
@@ -68,7 +65,7 @@ prepare: |
     echo 'this is foo-x2' > foo-x2.img
     cp foo-x2.img pc-snap/foo.img
     echo 'this is foo.cfg' > pc-snap/foo.cfg
-    if is_core20_system; then
+    if os.query is-core20; then
         echo 'this is foo-seed.cfg' > pc-snap/foo-seed.cfg
     fi
     sed -i -e 's/^version: \(.*\)-1/version: \1-2/' pc-snap/meta/snap.yaml
@@ -82,7 +79,7 @@ prepare: |
     echo 'this is updated foo-x3' > foo-x3.img
     cp foo-x3.img pc-snap/foo.img
     echo 'this is updated foo.cfg' > pc-snap/foo.cfg
-    if is_core20_system; then
+    if os.query is-core20; then
         echo 'this is updated foo-seed.cfg' > pc-snap/foo-seed.cfg
     fi
     echo 'this is bar.cfg' > pc-snap/bar.cfg
@@ -134,15 +131,13 @@ execute: |
 
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     # XXX: the test hardcodes a bunch of locations
     # - 'BIOS Boot' and 'EFI System' are modified during the update
     # - 'EFI System' is mounted at /boot/efi
 
     bootdir=/boot/efi
-    if is_core20_system; then
+    if os.query is-core20; then
         # /boot/efi is not mounted on UC20, so use the /run/mnt hierarchy
         bootdir=/run/mnt/ubuntu-boot
     fi
@@ -173,7 +168,7 @@ execute: |
         dd if='/dev/disk/by-partlabel/BIOS\x20Boot' skip="$szimg" bs=1 count="$szfoo" of=foo-written.img
         test "$(cat foo-written.img)" = 'this is foo-x2'
 
-        if is_core20_system; then
+        if os.query is-core20; then
             # a filesystem structure entry was copied to the right place
             test "$(cat /run/mnt/ubuntu-seed/foo-seed.cfg)" = 'this is foo-seed.cfg'
 
@@ -210,7 +205,7 @@ execute: |
         dd if='/dev/disk/by-partlabel/BIOS\x20Boot' skip="$szimg" bs=1 count="$szfoo" of=foo-updated-written.img
         test "$(cat foo-updated-written.img)" = 'this is updated foo-x3'
 
-        if is_core20_system; then
+        if os.query is-core20; then
             # a filesystem structure entry was copied to the right place
             test "$(cat /run/mnt/ubuntu-seed/foo-seed.cfg)" = 'this is updated foo-seed.cfg'
 

--- a/tests/core/kernel-ver/task.yaml
+++ b/tests/core/kernel-ver/task.yaml
@@ -4,15 +4,12 @@ summary: Ensure that we have the right kernel
 systems: [ubuntu-core-*-64]
 
 execute: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     echo "Check kernel version"
-    if is_core16_system; then
+    if os.query is-core16; then
         VER="^4.4"
-    elif is_core18_system; then
+    elif os.query is-core18; then
         VER="^4.15"
-    elif is_core20_system; then
+    elif os.query is-core20; then
         VER="^5.4"
     fi
     uname -r | MATCH $VER

--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -15,9 +15,6 @@ prepare: |
     snap install test-snapd-netplan-apply --edge
 
 execute: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     echo "The interface is disconnected by default"
     snap connections test-snapd-netplan-apply | MATCH 'network-setup-control +test-snapd-netplan-apply:network-setup-control +- +-'
 
@@ -54,7 +51,7 @@ execute: |
     echo "Ensure that the number of network restarts is greater after netplan apply was run"
     [ "$stopped_after" -gt "$stopped_before" ] && [ "$started_after" -gt "$started_before" ]
 
-    if is_core16_system; then
+    if os.query is-core16; then
         echo "Skipping Ubuntu Core 16 which does not have Info D-Bus method"
         exit 0
     fi

--- a/tests/core/os-release/task.yaml
+++ b/tests/core/os-release/task.yaml
@@ -4,14 +4,11 @@ debug: |
     cat /etc/lsb-release
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
-    if is_core16_system; then
+    if os.query is-core16; then
         MATCH "DISTRIB_RELEASE=16" < /etc/lsb-release
-    elif is_core18_system; then
+    elif os.query is-core18; then
         MATCH "DISTRIB_RELEASE=18" < /etc/lsb-release
-    elif is_core20_system; then
+    elif os.query is-core20; then
         MATCH "DISTRIB_RELEASE=20" < /etc/lsb-release
     else
         echo "Unknown Ubuntu Core system!"

--- a/tests/core/remodel/task.yaml
+++ b/tests/core/remodel/task.yaml
@@ -13,8 +13,6 @@ prepare: |
     . "$TESTSLIB"/core-config.sh
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     systemctl stop snapd.service snapd.socket
     clean_snapd_lib

--- a/tests/core/remove/task.yaml
+++ b/tests/core/remove/task.yaml
@@ -12,7 +12,7 @@ execute: |
 
     if os.query is-core18; then
         base=core18
-    elif is_core20_system; then
+    elif os.query is-core20; then
         base=core20
     fi
     echo "Ensure $base cannot be removed"

--- a/tests/core/remove/task.yaml
+++ b/tests/core/remove/task.yaml
@@ -4,16 +4,13 @@ summary: Check that removal of essential snaps does not work
 systems: [-ubuntu-core-16-*]
 
 execute: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     echo "Ensure snapd cannot be removed"
     if snap remove --purge snapd; then
         echo "The snapd snap should not be removable"
         exit 1
     fi
 
-    if is_core18_system; then
+    if os.query is-core18; then
         base=core18
     elif is_core20_system; then
         base=core20

--- a/tests/core/snap-auto-mount/task.yaml
+++ b/tests/core/snap-auto-mount/task.yaml
@@ -7,8 +7,6 @@ prepare: |
         echo "This test needs test keys to be trusted"
         exit
     fi
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
 
     echo "Install dmsetup"
     snap install --devmode --edge dmsetup
@@ -26,7 +24,7 @@ prepare: |
 
     # We use different filesystems to cover both: fat and ext. fat is the most
     # common fs used and we also use ext3 because fat is not available on ubuntu core 18
-    if is_core18_system; then
+    if os.query is-core18; then
         mkfs.ext3 /dev/ram0
     else
         mkfs.vfat /dev/ram0

--- a/tests/core/snap-debug-bootvars/task.yaml
+++ b/tests/core/snap-debug-bootvars/task.yaml
@@ -10,13 +10,10 @@ restore: |
     rm -f default.out uc20.out run.out recovery.out
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     # does not outright fail
     snap debug boot-vars  > default.out
 
-    if is_core20_system; then
+    if os.query is-core20; then
         # boot-vars default output is for the run mode bootloader, make sure its
         # output looks sane (though we don't expect any of the variables to be
         # set)

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -1,9 +1,6 @@
 summary: Check that snapd failure handling works
 
 prepare: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
 
@@ -11,7 +8,7 @@ prepare: |
     # test because it by default uses the core snap
     # there is a different test for the transition between the core snap and the
     # snapd snap
-    if is_core16_system; then
+    if os.query is-core16; then
         # rebuild the core snap into the snapd snap and install it
         repack_installed_core_snap_into_snapd_snap
         snap install --dangerous snapd-from-core.snap
@@ -21,13 +18,10 @@ prepare: |
     ls -l /snap/snapd/
 
 debug: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     # dump failure data
     journalctl -u snapd.failure.service
     journalctl -u snapd.socket || true
-    if is_core16_system; then
+    if os.query is-core16; then
         # might be useful to know what's up with the core snap too on uc16
         ls -l /snap/core/
     fi
@@ -39,10 +33,7 @@ debug: |
     /snap/snapd/x1/usr/bin/snap debug state --change="$(/snap/snapd/x1/usr/bin/snap debug state /var/lib/snapd/state.json|tail -n1|awk '{print $1}')" /var/lib/snapd/state.json || true
 
 restore: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
-    if is_core16_system; then
+    if os.query is-core16; then
         echo "ensuring we reverted fully to core snap system"
         not test -d /snap/snapd
         # cleanup the snapd-from-core snap we built
@@ -56,9 +47,6 @@ restore: |
     fi
 
 execute: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     if [ "$SPREAD_REBOOT" = 0 ]; then
         echo "Testing failover handling of the snapd snap"
 
@@ -141,7 +129,7 @@ execute: |
         # do that restoration here
         # TODO: move this to restore section when spread is fixed
         # see https://github.com/snapcore/spread/pull/85
-        if is_core16_system; then
+        if os.query is-core16; then
             echo "Manually uninstall the snapd snap on UC16"
             systemctl stop snapd.service snapd.socket snapd.autoimport.service snapd.snap-repair.service snapd.snap-repair.timer
             umount "/snap/snapd/$(readlink /snap/snapd/current)"
@@ -163,7 +151,7 @@ execute: |
     else # "$SPREAD_REBOOT" != 0
         # technically this check is unnecessary because we only reboot during
         # the test's execution on uc16, but just be extra safe
-        if is_core16_system; then
+        if os.query is-core16; then
             # now remove the snapd snap since we booted with the core snap
             snap list
             # this only succeeds because we reverted back to having the core 

--- a/tests/core/system-snap-refresh/task.yaml
+++ b/tests/core/system-snap-refresh/task.yaml
@@ -8,12 +8,10 @@ details: |
 systems: [ubuntu-core-*]
 
 restore: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
     TARGET_SNAP_NAME=core
-    if is_core18_system; then
+    if os.query is-core18; then
         TARGET_SNAP_NAME=core18
-    elif is_core20_system; then
+    elif os.query is-core20; then
         TARGET_SNAP_NAME=core20
     fi
 
@@ -23,13 +21,10 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     TARGET_SNAP_NAME=core
-    if is_core18_system; then
+    if os.query is-core18; then
         TARGET_SNAP_NAME=core18
-    elif is_core20_system; then
+    elif os.query is-core20; then
         TARGET_SNAP_NAME=core20
     fi    
 

--- a/tests/core/upgrade/task.yaml
+++ b/tests/core/upgrade/task.yaml
@@ -27,11 +27,8 @@ restore: |
     snap remove core --revision=x3
 
 prepare: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     TARGET_SNAP=core
-    if is_core18_system; then
+    if os.query is-core18; then
         TARGET_SNAP=core18
     fi
 
@@ -41,11 +38,9 @@ prepare: |
 execute: |
     #shellcheck source=tests/lib/boot.sh
     . "$TESTSLIB"/boot.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     TARGET_SNAP=core
-    if is_core18_system; then
+    if os.query is-core18; then
         TARGET_SNAP=core18
     fi
 


### PR DESCRIPTION
This is the second part of the migration from the helper to the new tool
