### PR TITLE
tests: moving main suite from systems.sh to os.query tool

### DIFF
--- a/tests/lib/tools/os.query
+++ b/tests/lib/tools/os.query
@@ -35,7 +35,7 @@ is_classic() {
 }
 
 is_trusty() {
-    grep -qFx 'UBUNTU_CODENAME=trusty' /etc/os-release
+    grep -qFx 'ID=ubuntu' /etc/os-release && grep -qFx 'VERSION_ID="14.04"' /etc/os-release
 }
 
 is_xenial() {

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -19,16 +19,13 @@ execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
 
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     echo "Auto refresh information is shown"
     output=$(snap refresh --time)
     for expected in ^schedule: ^last: ^next:; do
         echo "$output" | MATCH "$expected"
     done
 
-    if is_core_system; then
+    if os.query is-core; then
         # no holding
         echo "$output" | not MATCH "^hold:"
     else

--- a/tests/main/core-snap-refresh/task.yaml
+++ b/tests/main/core-snap-refresh/task.yaml
@@ -11,9 +11,6 @@ execute: |
     #shellcheck source=tests/lib/boot.sh
     . "$TESTSLIB"/boot.sh
 
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$SPREAD_REBOOT" = 0 ]; then
         # save current core revision
         snap list | awk "/^core / {print(\$3)}" > prevBoot
@@ -24,7 +21,7 @@ execute: |
         # check boot env vars
         snap list | awk "/^core / {print(\$3)}" > nextBoot
 
-        if is_core_system; then
+        if os.query is-core; then
             test "$(bootenv snap_core)" = "core_$(cat prevBoot).snap"
             test "$(bootenv snap_try_core)" = "core_$(cat nextBoot).snap"
         fi
@@ -41,7 +38,7 @@ execute: |
         sleep 1
     done
 
-    if is_core_system; then
+    if os.query is-core; then
         test "$(bootenv snap_core)" = "core_$(cat nextBoot).snap"
         test "$(bootenv snap_try_core)" = ""
     fi

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -16,8 +16,6 @@ restore: |
     snap logout || true
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     echo "When a snap is private it doesn't show up in the find without login and without specifying private search"
     snap find test-snapd-private | not MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
@@ -27,7 +25,7 @@ execute: |
 
     echo "Given account store credentials are available"
     # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
-    if [ -n "$SPREAD_STORE_USER" ] && [ -n "$SPREAD_STORE_PASSWORD" ] && is_classic_system; then
+    if [ -n "$SPREAD_STORE_USER" ] && [ -n "$SPREAD_STORE_PASSWORD" ] && os.query is-classic; then
         echo "And the user has logged in"
         expect -f "$TESTSLIB"/successful_login.exp
 

--- a/tests/main/hook-permissions/task.yaml
+++ b/tests/main/hook-permissions/task.yaml
@@ -8,17 +8,13 @@ details: |
     and enumerate upower devices.
 
 prepare: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-    if is_core_system; then
+    if os.query is-core; then
         snap install test-snapd-upower --edge
     fi
     "$TESTSTOOLS"/snaps-state install-local test-snap
 
 execute: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-    if ! is_core_system; then
+    if ! os.query is-core; then
       # trigger upowerd to have the service started as AppArmor would deny to
       # start it in response to a dbus call from inside a snap (because the
       # service is not started yet and AppArmor doesn't know what confinement

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -67,12 +67,10 @@ execute: |
     snap install --dangerous ./test-snapd-tools_1.0_all.snap
     test-snapd-tools.success
 
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
     # TODO:UC20: fix to work on uc20 too
     # The "seed/" dir is on a FAT partition on uc20 so the permissions are
     # different here.
-    if ! is_core20_system; then
+    if ! os.query is-core20; then
         echo "All snap blobs are 0600"
         test "$( find /var/lib/snapd/{snaps,cache,seed/snaps}/ -type f -printf '%#m\n' | sort -u | xargs )" = "0600"
     fi

--- a/tests/main/interfaces-home/task.yaml
+++ b/tests/main/interfaces-home/task.yaml
@@ -33,10 +33,7 @@ restore: |
     rm -f "$READABLE_FILE" "$WRITABLE_FILE" "$CREATABLE_FILE" "$HIDDEN_READABLE_FILE"
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
-    if is_core_system; then
+    if os.query is-core; then
         echo "The interface is not connected by default"
         snap interfaces -i home | MATCH '^- +home-consumer:home'
 

--- a/tests/main/interfaces-hostname-control/task.yaml
+++ b/tests/main/interfaces-hostname-control/task.yaml
@@ -8,9 +8,6 @@ prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     hostname="$(hostname)"
 
     echo "The plug is disconnected by default"
@@ -24,7 +21,7 @@ execute: |
     [ "$hostname" = "$snap_hostname" ]
 
     # On core systems /etc/hostname is not writable
-    if is_classic_system; then
+    if os.query is-classic; then
         echo "And the /etc/hostname file can be written"
         test-snapd-sh.with-hostname-control-plug -c "echo $hostname > /etc/hostname"
     fi

--- a/tests/main/interfaces-many-snap-provided/task.yaml
+++ b/tests/main/interfaces-many-snap-provided/task.yaml
@@ -36,11 +36,8 @@ execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
 
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"    
-    if is_core_system; then
+    if os.query is-core; then
         PROVIDER_SNAP="test-snapd-policy-app-provider-core"
     fi
 
@@ -72,12 +69,9 @@ execute: |
     done
 
 restore: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-    
     # Remove the snaps to avoid timeout in next test
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"    
-    if is_core_system; then
+    if os.query is-core; then
         PROVIDER_SNAP="test-snapd-policy-app-provider-core"
     fi
     snap remove --purge "$PROVIDER_SNAP"

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -23,9 +23,7 @@ prepare: |
     echo "Given a snap declaring a plug on the upower-observe interface is installed"
     snap install --edge test-snapd-upower-observe-consumer
 
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-    if is_core_system; then
+    if os.query is-core; then
         echo "And a snap providing a upower-observe slot is installed"
         snap install test-snapd-upower --edge
     fi

--- a/tests/main/parallel-install-remove-after/task.yaml
+++ b/tests/main/parallel-install-remove-after/task.yaml
@@ -28,12 +28,9 @@ restore: |
     esac
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     # install confined and classic snaps
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
-    if is_classic_system ; then
+    if os.query is-classic ; then
         "$TESTSTOOLS"/snaps-state install-local test-snapd-classic-confinement --classic
     fi
 
@@ -42,33 +39,33 @@ execute: |
     # regular instances work
     # shellcheck disable=SC2016
     test-snapd-sh.sh -c 'echo confined $SNAP_INSTANCE_NAME works'
-    if is_classic_system ; then
+    if os.query is-classic ; then
         # shellcheck disable=SC2016
         test-snapd-classic-confinement.sh -c 'echo classic $SNAP_INSTANCE_NAME works'
     fi
 
     # new instances of same snaps
     "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_foo
-    if is_classic_system ; then
+    if os.query is-classic ; then
         "$TESTSTOOLS"/snaps-state install-local-as test-snapd-classic-confinement test-snapd-classic-confinement_foo --classic
     fi
 
     # parallel instances works
     # shellcheck disable=SC2016
     test-snapd-sh_foo.sh -c 'echo confined $SNAP_INSTANCE_NAME works'
-    if is_classic_system ; then
+    if os.query is-classic ; then
         # shellcheck disable=SC2016
         test-snapd-classic-confinement_foo.sh -c 'echo classic $SNAP_INSTANCE_NAME works'
     fi
 
     # removal of snaps should not fail
     snap remove --purge test-snapd-sh
-    if is_classic_system ; then
+    if os.query is-classic ; then
         snap remove --purge test-snapd-classic-confinement
     fi
 
     # neither should the removal of instances
     snap remove --purge test-snapd-sh_foo
-    if is_classic_system ; then
+    if os.query is-classic ; then
         snap remove --purge test-snapd-classic-confinement_foo
     fi

--- a/tests/main/refresh-devmode/task.yaml
+++ b/tests/main/refresh-devmode/task.yaml
@@ -17,11 +17,8 @@ environment:
     STORE_TYPE/remote: ${REMOTE_STORE}
 
 prepare: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -45,11 +42,8 @@ prepare: |
     fi
 
 restore: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -62,11 +56,8 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -20,11 +20,9 @@ environment:
 
 prepare: |
     tests.cleanup prepare
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -63,11 +61,9 @@ prepare: |
 
 restore: |
     tests.cleanup restore
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -84,11 +80,8 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -119,7 +112,7 @@ execute: |
     tests.cleanup defer snap unset system experimental.refresh-app-awareness
 
     #shellcheck source=tests/lib/pkgdb.sh
-    if ! is_core_system && [ "$(. /etc/os-release && echo "$ID-$VERSION_ID")" != ubuntu-14.04 ] && [ "$(. /etc/os-release && echo "$ID")" != amzn ]; then
+    if os.query is-classic && ! os.query is-trusty && [ "$(. /etc/os-release && echo "$ID")" != amzn ]; then
       . "$TESTSLIB/pkgdb.sh"
       distro_install_package inotify-tools
       # XXX: probably a bug in defer, this fails without ' ' quotes around the rest.

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -9,11 +9,8 @@ environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir
 
 prepare: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -37,11 +34,8 @@ prepare: |
     fi
 
 restore: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -54,11 +48,8 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/revert/task.yaml
+++ b/tests/main/revert/task.yaml
@@ -6,11 +6,8 @@ environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir
 
 prepare: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -34,11 +31,8 @@ prepare: |
     fi
 
 restore: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -51,11 +45,8 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if os.query is-core; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -15,9 +15,6 @@ restore: |
     rm -f ./*.snap
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     inspect_connection() {
       CONN="$1"
       # shellcheck disable=SC2002
@@ -62,7 +59,7 @@ execute: |
 
 
     # these checks rely on automatic connection of home on non-core systems
-    if ! is_core_system; then
+    if ! os.query is-core; then
       echo "Checking that --forget forgets connection when auto-connected"
       snap remove --purge "$SNAP_FILE"
       snap install --dangerous "$SNAP_FILE"

--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -51,8 +51,6 @@ prepare: |
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     ensure_xdg_open_output() {
         rm -f /tmp/xdg-open-output


### PR DESCRIPTION
This is the third part of the migration to the new tool
