### PR TITLE
store, snap-repair: fix use of retry strategies

### DIFF
--- a/cmd/snap-repair/export_test.go
+++ b/cmd/snap-repair/export_test.go
@@ -46,7 +46,7 @@ func MockBaseURL(baseurl string) (restore func()) {
 	}
 }
 
-func MockFetchRetryStrategy(strategy retry.Strategy) (restore func()) {
+func MockFetchRetryStrategy(strategy func() retry.Strategy) (restore func()) {
 	originalFetchRetryStrategy := fetchRetryStrategy
 	fetchRetryStrategy = strategy
 	return func() {
@@ -54,7 +54,7 @@ func MockFetchRetryStrategy(strategy retry.Strategy) (restore func()) {
 	}
 }
 
-func MockPeekRetryStrategy(strategy retry.Strategy) (restore func()) {
+func MockPeekRetryStrategy(strategy func() retry.Strategy) (restore func()) {
 	originalPeekRetryStrategy := peekRetryStrategy
 	peekRetryStrategy = strategy
 	return func() {

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -295,12 +295,14 @@ func (s *runnerSuite) TestFetchScriptTooBig(c *C) {
 }
 
 var (
-	testRetryStrategy = retry.LimitCount(5, retry.LimitTime(1*time.Second,
-		retry.Exponential{
-			Initial: 1 * time.Millisecond,
-			Factor:  1,
-		},
-	))
+	testRetryStrategy = func() retry.Strategy {
+		return retry.LimitCount(5, retry.LimitTime(1*time.Second,
+			retry.Exponential{
+				Initial: 1 * time.Millisecond,
+				Factor:  1,
+			},
+		))
+	}
 )
 
 func (s *runnerSuite) TestFetch500(c *C) {

--- a/store/auth.go
+++ b/store/auth.go
@@ -119,7 +119,7 @@ func retryPostRequest(httpClient *http.Client, endpoint string, headers map[stri
 		}
 
 		return httpClient.Do(req)
-	}, readResponseBody, defaultRetryStrategy)
+	}, readResponseBody, defaultRetryStrategy())
 }
 
 // requestStoreMacaroon requests a macaroon for accessing package data from the ubuntu store.

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -78,12 +78,14 @@ const mockStoreReturnNonce = `{"nonce": "the-nonce"}`
 const mockStoreReturnNoNonce = `{}`
 
 func (s *authTestSuite) SetUpTest(c *C) {
-	store.MockDefaultRetryStrategy(&s.BaseTest, retry.LimitCount(5, retry.LimitTime(1*time.Second,
-		retry.Exponential{
-			Initial: 1 * time.Millisecond,
-			Factor:  1.1,
-		},
-	)))
+	store.MockDefaultRetryStrategy(&s.BaseTest, func() retry.Strategy {
+		return retry.LimitCount(5, retry.LimitTime(1*time.Second,
+			retry.Exponential{
+				Initial: 1 * time.Millisecond,
+				Factor:  1.1,
+			},
+		))
+	})
 }
 
 func (s *authTestSuite) TestRequestStoreMacaroon(c *C) {

--- a/store/download_test.go
+++ b/store/download_test.go
@@ -56,10 +56,12 @@ var _ = Suite(&downloadSuite{})
 func (s *downloadSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	store.MockDownloadRetryStrategy(&s.BaseTest, retry.LimitCount(5, retry.Exponential{
-		Initial: time.Millisecond,
-		Factor:  2.5,
-	}))
+	store.MockDownloadRetryStrategy(&s.BaseTest, func() retry.Strategy {
+		return retry.LimitCount(5, retry.Exponential{
+			Initial: time.Millisecond,
+			Factor:  2.5,
+		})
+	})
 
 	mockXdelta := testutil.MockCommand(c, "xdelta3", "")
 	s.AddCleanup(mockXdelta.Restore)

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -61,7 +61,7 @@ var (
 )
 
 // MockDefaultRetryStrategy mocks the retry strategy used by several store requests
-func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
+func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy func() retry.Strategy) {
 	originalDefaultRetryStrategy := defaultRetryStrategy
 	defaultRetryStrategy = strategy
 	t.AddCleanup(func() {
@@ -69,7 +69,7 @@ func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
 	})
 }
 
-func MockDownloadRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
+func MockDownloadRetryStrategy(t *testutil.BaseTest, strategy func() retry.Strategy) {
 	originalDownloadRetryStrategy := downloadRetryStrategy
 	downloadRetryStrategy = strategy
 	t.AddCleanup(func() {
@@ -77,7 +77,7 @@ func MockDownloadRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
 	})
 }
 
-func MockConnCheckStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
+func MockConnCheckStrategy(t *testutil.BaseTest, strategy func() retry.Strategy) {
 	originalConnCheckStrategy := connCheckStrategy
 	connCheckStrategy = strategy
 	t.AddCleanup(func() {

--- a/store/store_asserts.go
+++ b/store/store_asserts.go
@@ -138,7 +138,7 @@ func (s *Store) downloadAssertions(u *url.URL, decodeBody func(io.Reader) error,
 			}
 		}
 		return e
-	}, defaultRetryStrategy)
+	}, defaultRetryStrategy())
 
 	if err != nil {
 		return err

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -74,12 +74,14 @@ func (s *storeDownloadSuite) SetUpTest(c *C) {
 	s.mockXDelta = testutil.MockCommand(c, "xdelta3", "")
 	s.AddCleanup(s.mockXDelta.Restore)
 
-	store.MockDownloadRetryStrategy(&s.BaseTest, retry.LimitCount(5, retry.LimitTime(1*time.Second,
-		retry.Exponential{
-			Initial: 1 * time.Millisecond,
-			Factor:  1,
-		},
-	)))
+	store.MockDownloadRetryStrategy(&s.BaseTest, func() retry.Strategy {
+		return retry.LimitCount(5, retry.LimitTime(1*time.Second,
+			retry.Exponential{
+				Initial: 1 * time.Millisecond,
+				Factor:  1,
+			},
+		))
+	})
 }
 
 func (s *storeDownloadSuite) TestDownloadOK(c *C) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -400,12 +400,14 @@ func (s *baseStoreSuite) SetUpTest(c *C) {
 	s.user, err = createTestUser(1, root, discharge)
 	c.Assert(err, IsNil)
 
-	store.MockDefaultRetryStrategy(&s.BaseTest, retry.LimitCount(5, retry.LimitTime(1*time.Second,
-		retry.Exponential{
-			Initial: 1 * time.Millisecond,
-			Factor:  1,
-		},
-	)))
+	store.MockDefaultRetryStrategy(&s.BaseTest, func() retry.Strategy {
+		return retry.LimitCount(5, retry.LimitTime(1*time.Second,
+			retry.Exponential{
+				Initial: 1 * time.Millisecond,
+				Factor:  1,
+			},
+		))
+	})
 }
 
 type storeTestSuite struct {
@@ -4024,10 +4026,12 @@ func (s *storeTestSuite) TestConnectivityCheckHappy(c *C) {
 }
 
 func (s *storeTestSuite) TestConnectivityCheckUnhappy(c *C) {
-	store.MockConnCheckStrategy(&s.BaseTest, retry.LimitCount(3, retry.Exponential{
-		Initial: time.Millisecond,
-		Factor:  1.3,
-	}))
+	store.MockConnCheckStrategy(&s.BaseTest, func() retry.Strategy {
+		return retry.LimitCount(3, retry.Exponential{
+			Initial: time.Millisecond,
+			Factor:  1.3,
+		})
+	})
 
 	seenPaths := make(map[string]int, 2)
 	var mockServerURL *url.URL

--- a/store/userinfo.go
+++ b/store/userinfo.go
@@ -56,7 +56,7 @@ func (s *Store) UserInfo(email string) (userinfo *User, err error) {
 			return fmt.Errorf("cannot unmarshal: %v", err)
 		}
 		return nil
-	}, defaultRetryStrategy)
+	}, defaultRetryStrategy())
 
 	if err != nil {
 		return nil, err

--- a/store/userinfo_test.go
+++ b/store/userinfo_test.go
@@ -66,12 +66,14 @@ func (t *userInfoSuite) SetUpTest(c *check.C) {
 	_, t.restoreLogger = logger.MockLogger()
 	t.store = store.New(nil, nil)
 
-	store.MockDefaultRetryStrategy(&t.BaseTest, retry.LimitCount(6, retry.LimitTime(1*time.Second,
-		retry.Exponential{
-			Initial: 1 * time.Millisecond,
-			Factor:  1.1,
-		},
-	)))
+	store.MockDefaultRetryStrategy(&t.BaseTest, func() retry.Strategy {
+		return retry.LimitCount(6, retry.LimitTime(1*time.Second,
+			retry.Exponential{
+				Initial: 1 * time.Millisecond,
+				Factor:  1.1,
+			},
+		))
+	})
 }
 
 func (t *userInfoSuite) TearDownTest(c *check.C) {


### PR DESCRIPTION
Fix retry strategies to use factory functions, not package-level variables. Retry strategies have some internal state (in particular LimitTime, which depends on time.Now() at creation time; simple ones such as LimitCount might be ok but I haven't dug into them) and having them initialized once and then reused is incorrect and may have unexpected effects.

This bug is probably the explanation of occasional download tasks getting stuck in Doing (we may have concurrent download tasks using single instance of downloadStrategy).