### PR TITLE
packaging: make sure that static binaries are indeed static, fix openSUSE

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -256,6 +256,10 @@ popd
 %make_build -f %{indigo_srcdir}/packaging/snapd.mk GOPATH=%{indigo_gopath}:$GOPATH all
 
 %check
+for binary in snap-exec snap-update-ns snapctl; do
+    ldd $binary 2>&1 | grep 'not a dynamic executable'
+done
+
 %make_build -C %{indigo_srcdir}/cmd check
 # Use the common packaging helper for testing.
 %make_build -f %{indigo_srcdir}/packaging/snapd.mk GOPATH=%{indigo_gopath}:$GOPATH check

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -65,7 +65,9 @@ snap snap-seccomp:
 # nearly-arbitrary mount namespace that does not contain anything we can depend
 # on (no standard library, for example).
 snap-update-ns snap-exec snapctl:
-	go build -buildmode=default -ldflags '-extldflags "-static"' $(import_path)/cmd/$@
+	# Explicit request to use an external linker, otherwise extldflags may not be
+	# used
+	go build -buildmode=default -ldflags '-linkmode external -extldflags "-static"' $(import_path)/cmd/$@
 
 # Snapd can be built with test keys. This is only used by the internal test
 # suite to add test assertions. Do not enable this in distribution packages.


### PR DESCRIPTION
The openSUSE packaging is using snapd.mk for build. Make sure that we pass the
right flags to Go build so that an external linker is used for binaries that
need to be built statically.
