### PR TITLE
o/snapstate: implement undo handler for unlink-snap

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1947,10 +1947,9 @@ func (m *SnapManager) undoUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// XXX: is it safe (can panic)?
 	isInstalled := snapst.IsInstalled()
 	if !isInstalled {
-		return fmt.Errorf("internal error: snap %q not installed", snapsup.InstanceName())
+		return fmt.Errorf("internal error: snap %q not installed anymore", snapsup.InstanceName())
 	}
 
 	info, err := snapst.CurrentInfo()
@@ -1972,6 +1971,8 @@ func (m *SnapManager) undoUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	for _, dir := range []string{place.DataDir(), place.CommonDataDir()} {
 		if exists, _, _ := osutil.DirExists(dir); !exists {
 			t.Logf("cannot link snap %q back, some of its data has already been removed", snapsup.InstanceName())
+			// TODO: mark the snap broken at the SnapState level when we have
+			// such concept.
 			return nil
 		}
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2007,6 +2007,9 @@ func (m *SnapManager) undoUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	// Notify link snap participants about link changes.
+	notifyLinkParticipants(t, snapsup.InstanceName())
+
 	// if we just linked back a core snap, request a restart
 	// so that we switch executing its snapd.
 	m.maybeRestart(t, info, reboot, deviceCtx)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -448,7 +448,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 
 	// remove related
 	runner.AddHandler("stop-snap-services", m.stopSnapServices, m.startSnapServices)
-	runner.AddHandler("unlink-snap", m.doUnlinkSnap, nil)
+	runner.AddHandler("unlink-snap", m.doUnlinkSnap, m.undoUnlinkSnap)
 	runner.AddHandler("clear-snap", m.doClearSnapData, nil)
 	runner.AddHandler("discard-snap", m.doDiscardSnap, nil)
 

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -1331,3 +1331,235 @@ func (s *snapmgrTestSuite) TestRemoveManyDiskSpaceCheckPasses(c *C) {
 	err := s.testRemoveManyDiskSpaceCheck(c, featureFlag, automaticSnapshot, freeSpaceCheckFail)
 	c.Check(err, IsNil)
 }
+
+func isUndone(c *C, tasks []*state.Task, kind string, numExpected int) {
+	var count int
+	for _, t := range tasks {
+		if t.Kind() == kind {
+			c.Assert(t.Status(), Equals, state.UndoneStatus)
+			count++
+		}
+	}
+	c.Assert(count, Equals, numExpected)
+}
+
+func injectError(c *C, chg *state.Change, beforeTaskKind string, snapRev snap.Revision) {
+	var found bool
+	for _, t := range chg.Tasks() {
+		if t.Kind() != beforeTaskKind {
+			continue
+		}
+		sup, err := snapstate.TaskSnapSetup(t)
+		c.Assert(err, IsNil)
+		if sup.Revision() != snapRev {
+			continue
+		}
+		prev := t.WaitTasks()[0]
+		terr := chg.State().NewTask("error-trigger", "provoking undo")
+		t.WaitFor(terr)
+		terr.WaitFor(prev)
+		chg.AddTask(terr)
+		found = true
+		break
+	}
+	c.Assert(found, Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestRemoveManyUndoRestoresCurrent(c *C) {
+	si1 := snap.SideInfo{
+		SnapID:   "some-snap-id",
+		RealName: "some-snap",
+		Revision: snap.R(1),
+	}
+
+	si2 := snap.SideInfo{
+		SnapID:   "some-snap-id",
+		RealName: "some-snap",
+		Revision: snap.R(2),
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si1, &si2},
+		Current:  si1.Revision,
+		SnapType: "app",
+	})
+
+	chg := s.state.NewChange("remove", "remove a snap")
+	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(0), nil)
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	// inject an error before clear-snap of revision 1 (current), after
+	// discard-snap for revision 2, that means data and snap rev 1
+	// are still present.
+	injectError(c, chg, "clear-snap", si1.Revision)
+
+	s.state.Unlock()
+	defer s.se.Stop()
+	s.settle(c)
+	s.state.Lock()
+
+	c.Assert(chg.Status(), Equals, state.ErrorStatus)
+	isUndone(c, chg.Tasks(), "unlink-snap", 1)
+
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, "some-snap", &snapst), IsNil)
+	c.Check(snapst.Active, Equals, true)
+	c.Assert(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence[0].Revision, Equals, si1.Revision)
+
+	expected := fakeOps{
+		{
+			op:    "auto-disconnect:Doing",
+			name:  "some-snap",
+			revno: snap.R(1),
+		},
+		{
+			op:   "remove-snap-aliases",
+			name: "some-snap",
+		},
+		{
+			op:   "unlink-snap",
+			path: filepath.Join(dirs.SnapMountDir, "some-snap/1"),
+		},
+		{
+			op:    "remove-profiles:Doing",
+			name:  "some-snap",
+			revno: snap.R(1),
+		},
+		{
+			op:   "remove-snap-data",
+			path: filepath.Join(dirs.SnapMountDir, "some-snap/2"),
+		},
+		{
+			op:    "remove-snap-files",
+			path:  filepath.Join(dirs.SnapMountDir, "some-snap/2"),
+			stype: "app",
+		},
+		{
+			op:    "remove-profiles:Undoing",
+			name:  "some-snap",
+			revno: snap.R(1),
+		},
+		{
+			op:   "link-snap",
+			path: filepath.Join(dirs.SnapMountDir, "some-snap/1"),
+		},
+		{
+			op: "update-aliases",
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Check(len(s.fakeBackend.ops), Equals, len(expected))
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Check(s.fakeBackend.ops, DeepEquals, expected)
+}
+
+func (s *snapmgrTestSuite) TestRemoveManyUndoLeavesInactiveSnapAfterDataIsLost(c *C) {
+	si1 := snap.SideInfo{
+		SnapID:   "some-snap-id",
+		RealName: "some-snap",
+		Revision: snap.R(1),
+	}
+
+	si2 := snap.SideInfo{
+		SnapID:   "some-snap-id",
+		RealName: "some-snap",
+		Revision: snap.R(2),
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si1, &si2},
+		Current:  si1.Revision,
+		SnapType: "app",
+	})
+
+	chg := s.state.NewChange("remove", "remove a snap")
+	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(0), nil)
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	// inject an error after removing data of both revisions (which includes
+	// current rev 1), before discarding the snap completely.
+	injectError(c, chg, "discard-snap", si1.Revision)
+
+	s.state.Unlock()
+	defer s.se.Stop()
+	s.settle(c)
+	s.state.Lock()
+
+	c.Assert(chg.Status(), Equals, state.ErrorStatus)
+	isUndone(c, chg.Tasks(), "unlink-snap", 1)
+
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, "some-snap", &snapst), IsNil)
+
+	// revision 1 is still present but not active, since the error happened
+	// after its data was removed.
+	c.Check(snapst.Active, Equals, false)
+	c.Assert(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence[0].Revision, Equals, si1.Revision)
+
+	expected := fakeOps{
+		{
+			op:    "auto-disconnect:Doing",
+			name:  "some-snap",
+			revno: snap.R(1),
+		},
+		{
+			op:   "remove-snap-aliases",
+			name: "some-snap",
+		},
+		{
+			op:   "unlink-snap",
+			path: filepath.Join(dirs.SnapMountDir, "some-snap/1"),
+		},
+		{
+			op:    "remove-profiles:Doing",
+			name:  "some-snap",
+			revno: snap.R(1),
+		},
+		{
+			op:   "remove-snap-data",
+			path: filepath.Join(dirs.SnapMountDir, "some-snap/2"),
+		},
+		{
+			op:    "remove-snap-files",
+			path:  filepath.Join(dirs.SnapMountDir, "some-snap/2"),
+			stype: "app",
+		},
+		{
+			op:   "remove-snap-data",
+			path: filepath.Join(dirs.SnapMountDir, "some-snap/1"),
+		},
+		{
+			op:   "remove-snap-common-data",
+			path: filepath.Join(dirs.SnapMountDir, "some-snap/1"),
+		},
+		{
+			op:   "remove-snap-data-dir",
+			name: "some-snap",
+			path: filepath.Join(dirs.SnapDataDir, "some-snap"),
+		},
+		{
+			op:    "remove-profiles:Undoing",
+			name:  "some-snap",
+			revno: snap.R(1),
+		},
+		{
+			op: "update-aliases",
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Check(len(s.fakeBackend.ops), Equals, len(expected))
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Check(s.fakeBackend.ops, DeepEquals, expected)
+}


### PR DESCRIPTION
Implement undo for unlink-snap - in case of a failure during snap remove it is able to restore current revision of the snap, as long as clear-snap of this revision hasn't been reached. With #9511 current is guaranteed to be removed last (after other revisions) to increase the chance of success. If however snap data got lost, then the snap is marked inactive.

This is going to be hard to experience and test in practice after #9522, I'm thinking about a followup with a spread test but not sure it's doable, I think the only way is to somehow trigger an error in discard-snap.

This is related to https://bugs.launchpad.net/snapd/+bug/1899614