### PR TITLE
tests/uc20-create-partitions: don't check for grub.cfg

### DIFF
--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -107,7 +107,6 @@ execute: |
     mount "${LOOP}p3" ./mnt
     ls ./mnt/EFI/boot/grubx64.efi
     ls ./mnt/EFI/boot/bootx64.efi
-    ls ./mnt/EFI/ubuntu/grub.cfg
     # remove a file
     rm ./mnt/EFI/boot/grubx64.efi
     umount ./mnt


### PR DESCRIPTION
The grub.cfg file is deployed by snap prepare-image, it is not contained in the pc gadget anymore, so we will not see it here when we mount the gadget dir.

See https://github.com/snapcore/pc-amd64-gadget/pull/50