### PR TITLE
tests: add a unit test for UpdateMany where a single snap fails

### DIFF
--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -4341,8 +4341,8 @@ func (s *snapmgrTestSuite) TestUpdateManyFailureDoesntUndoSnapdRefresh(c *C) {
 		Sequence: []*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
 		},
-		Current:  snap.R(1),
-		SnapType: "app",
+		Current:         snap.R(1),
+		SnapType:        "app",
 		TrackingChannel: "channel-for-base/stable",
 	})
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -4343,6 +4343,7 @@ func (s *snapmgrTestSuite) TestUpdateManyFailureDoesntUndoSnapdRefresh(c *C) {
 		},
 		Current:  snap.R(1),
 		SnapType: "app",
+		TrackingChannel: "channel-for-base/stable",
 	})
 
 	snapstate.Set(s.state, "core18", &snapstate.SnapState{


### PR DESCRIPTION
Add a test to verify that a refresh of multiple snaps, where a single snap fails, doesn't undo the entire operation. The test uses a regular snap, a base and snapd snap, but would work for any snaps really since UpdateMany uses lanes.