### PR TITLE
many: update to secboot v1

### DIFF
--- a/boot/seal.go
+++ b/boot/seal.go
@@ -107,10 +107,9 @@ func sealKeyToModeenv(key secboot.EncryptionKey, model *asserts.Model, modeenv *
 		}
 	}
 	sealKeyParams := &secboot.SealKeyParams{
-		ModelParams:             modelParams,
-		KeyFile:                 filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
-		TPMPolicyUpdateDataFile: filepath.Join(InstallHostFDEDataDir, "policy-update-data"),
-		TPMLockoutAuthFile:      filepath.Join(InstallHostFDEDataDir, "tpm-lockout-auth"),
+		ModelParams:        modelParams,
+		KeyFile:            filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
+		TPMLockoutAuthFile: filepath.Join(InstallHostFDEDataDir, "tpm-lockout-auth"),
 	}
 	// finally, seal the key
 	if err := secbootSealKey(key, sealKeyParams); err != nil {
@@ -217,9 +216,8 @@ func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, 
 		return fmt.Errorf("cannot prepare for key resealing: %v", err)
 	}
 	resealKeyParams := &secboot.ResealKeyParams{
-		ModelParams:             modelParams,
-		KeyFile:                 filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
-		TPMPolicyUpdateDataFile: filepath.Join(dirs.SnapFDEDirUnder(rootdir), "policy-update-data"),
+		ModelParams: modelParams,
+		KeyFile:     filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
 	}
 	if err := secbootResealKey(resealKeyParams); err != nil {
 		return fmt.Errorf("cannot reseal the encryption key: %v", err)

--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -18,6 +18,7 @@ Type=notify
 SuccessExitStatus=42
 RestartPreventExitStatus=42
 KillMode=process
+KeyringMode=shared
 
 [Install]
 WantedBy=multi-user.target

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -40,7 +40,7 @@ type DeviceContext interface {
 	// ForRemodeling returns whether this context is for use over a remodeling.
 	ForRemodeling() bool
 
-	// SystemMode returns the system  mode (run,install,recover,...).
+	// SystemMode returns the system mode (run,install,recover,...).
 	SystemMode() string
 
 	// DeviceContext should be usable as boot.Device

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -86,22 +86,6 @@ func MockSbSealKeyToTPM(f func(tpm *sb.TPMConnection, key []byte, keyPath string
 	}
 }
 
-func MockReadSealedKeyObject(f func(path string) (*sb.SealedKeyObject, error)) (restore func()) {
-	old := sbReadSealedKeyObject
-	sbReadSealedKeyObject = f
-	return func() {
-		sbReadSealedKeyObject = old
-	}
-}
-
-func MockUnsealAuthKey(f func(tpm *sb.TPMConnection, k *sb.SealedKeyObject) (sb.TPMPolicyAuthKey, error)) (restore func()) {
-	old := unsealAuthKey
-	unsealAuthKey = f
-	return func() {
-		unsealAuthKey = old
-	}
-}
-
 func MockSbUpdateKeyPCRProtectionPolicy(f func(tpm *sb.TPMConnection, keyPath string, authKey sb.TPMPolicyAuthKey, pcrProfile *sb.PCRProtectionProfile) error) (restore func()) {
 	old := sbUpdateKeyPCRProtectionPolicy
 	sbUpdateKeyPCRProtectionPolicy = f
@@ -110,11 +94,11 @@ func MockSbUpdateKeyPCRProtectionPolicy(f func(tpm *sb.TPMConnection, keyPath st
 	}
 }
 
-func MockSbLockAccessToSealedKeys(f func(tpm *sb.TPMConnection) error) (restore func()) {
-	old := sbLockAccessToSealedKeys
-	sbLockAccessToSealedKeys = f
+func MockSbBlockPCRProtectionPolicies(f func(tpm *sb.TPMConnection, pcrs []int) error) (restore func()) {
+	old := sbBlockPCRProtectionPolicies
+	sbBlockPCRProtectionPolicies = f
 	return func() {
-		sbLockAccessToSealedKeys = old
+		sbBlockPCRProtectionPolicies = old
 	}
 }
 
@@ -176,10 +160,26 @@ func MockSbAddRecoveryKeyToLUKS2Container(f func(devicePath string, key []byte, 
 	}
 }
 
+func MockSbGetActivationDataFromKernel(f func(prefix, sourceDevicePath string, remove bool) (sb.ActivationData, error)) (restore func()) {
+	old := sbGetActivationDataFromKernel
+	sbGetActivationDataFromKernel = f
+	return func() {
+		sbGetActivationDataFromKernel = old
+	}
+}
+
 func MockIsTPMEnabled(f func(tpm *sb.TPMConnection) bool) (restore func()) {
 	old := isTPMEnabled
 	isTPMEnabled = f
 	return func() {
 		isTPMEnabled = old
+	}
+}
+
+func MockUnixKeyctlInt(f func(cmd, arg2, arg3, arg4, arg5 int) (int, error)) (restore func()) {
+	old := unixKeyctlInt
+	unixKeyctlInt = f
+	return func() {
+		unixKeyctlInt = old
 	}
 }

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -38,11 +38,11 @@ func MockSbConnectToDefaultTPM(f func() (*sb.TPMConnection, error)) (restore fun
 	}
 }
 
-func MockSbProvisionTPM(f func(tpm *sb.TPMConnection, mode sb.ProvisionMode, newLockoutAuth []byte) error) (restore func()) {
-	old := sbProvisionTPM
-	sbProvisionTPM = f
+func MockProvisionTPM(f func(tpm *sb.TPMConnection, mode sb.ProvisionMode, newLockoutAuth []byte) error) (restore func()) {
+	old := provisionTPM
+	provisionTPM = f
 	return func() {
-		sbProvisionTPM = old
+		provisionTPM = old
 	}
 }
 
@@ -78,7 +78,7 @@ func MockSbAddSnapModelProfile(f func(profile *sb.PCRProtectionProfile, params *
 	}
 }
 
-func MockSbSealKeyToTPM(f func(tpm *sb.TPMConnection, key []byte, keyPath, policyUpdatePath string, params *sb.KeyCreationParams) error) (restore func()) {
+func MockSbSealKeyToTPM(f func(tpm *sb.TPMConnection, key []byte, keyPath string, params *sb.KeyCreationParams) (sb.TPMPolicyAuthKey, error)) (restore func()) {
 	old := sbSealKeyToTPM
 	sbSealKeyToTPM = f
 	return func() {
@@ -86,7 +86,23 @@ func MockSbSealKeyToTPM(f func(tpm *sb.TPMConnection, key []byte, keyPath, polic
 	}
 }
 
-func MockSbUpdateKeyPCRProtectionPolicy(f func(tpm *sb.TPMConnection, keyPath, policyUpdatePath string, pcrProfile *sb.PCRProtectionProfile) error) (restore func()) {
+func MockReadSealedKeyObject(f func(path string) (*sb.SealedKeyObject, error)) (restore func()) {
+	old := sbReadSealedKeyObject
+	sbReadSealedKeyObject = f
+	return func() {
+		sbReadSealedKeyObject = old
+	}
+}
+
+func MockUnsealAuthKey(f func(tpm *sb.TPMConnection, k *sb.SealedKeyObject) (sb.TPMPolicyAuthKey, error)) (restore func()) {
+	old := unsealAuthKey
+	unsealAuthKey = f
+	return func() {
+		unsealAuthKey = old
+	}
+}
+
+func MockSbUpdateKeyPCRProtectionPolicy(f func(tpm *sb.TPMConnection, keyPath string, authKey sb.TPMPolicyAuthKey, pcrProfile *sb.PCRProtectionProfile) error) (restore func()) {
 	old := sbUpdateKeyPCRProtectionPolicy
 	sbUpdateKeyPCRProtectionPolicy = f
 	return func() {
@@ -103,7 +119,7 @@ func MockSbLockAccessToSealedKeys(f func(tpm *sb.TPMConnection) error) (restore 
 }
 
 func MockSbActivateVolumeWithRecoveryKey(f func(volumeName, sourceDevicePath string,
-	keyReader io.Reader, options *sb.ActivateWithRecoveryKeyOptions) error) (restore func()) {
+	keyReader io.Reader, options *sb.ActivateVolumeOptions) error) (restore func()) {
 	old := sbActivateVolumeWithRecoveryKey
 	sbActivateVolumeWithRecoveryKey = f
 	return func() {
@@ -112,7 +128,7 @@ func MockSbActivateVolumeWithRecoveryKey(f func(volumeName, sourceDevicePath str
 }
 
 func MockSbActivateVolumeWithTPMSealedKey(f func(tpm *sb.TPMConnection, volumeName, sourceDevicePath, keyPath string,
-	pinReader io.Reader, options *sb.ActivateWithTPMSealedKeyOptions) (bool, error)) (restore func()) {
+	pinReader io.Reader, options *sb.ActivateVolumeOptions) (bool, error)) (restore func()) {
 	old := sbActivateVolumeWithTPMSealedKey
 	sbActivateVolumeWithTPMSealedKey = f
 	return func() {

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -69,4 +69,6 @@ type ResealKeyParams struct {
 	ModelParams []*SealKeyModelParams
 	// The path to the sealed key file
 	KeyFile string
+	// The source device name
+	DeviceName string
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -69,6 +69,6 @@ type ResealKeyParams struct {
 	ModelParams []*SealKeyModelParams
 	// The path to the sealed key file
 	KeyFile string
-	// The source device name
-	DeviceName string
+	// The TPM policy auth key
+	AuthKey []byte
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -60,8 +60,6 @@ type SealKeyParams struct {
 	ModelParams []*SealKeyModelParams
 	// The path to store the sealed key file
 	KeyFile string
-	// The path to the authorization policy update data file (only relevant for TPM)
-	TPMPolicyUpdateDataFile string
 	// The path to the lockout authorization file (only relevant for TPM)
 	TPMLockoutAuthFile string
 }
@@ -71,6 +69,4 @@ type ResealKeyParams struct {
 	ModelParams []*SealKeyModelParams
 	// The path to the sealed key file
 	KeyFile string
-	// The path to the authorization policy update data file (only relevant for TPM)
-	TPMPolicyUpdateDataFile string
 }

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -24,6 +24,10 @@ import (
 	"fmt"
 )
 
+func AuthKeyFromKernelKeyring() ([]byte, error) {
+	return nil, nil
+}
+
 func CheckKeySealingSupported() error {
 	return fmt.Errorf("build without secboot support")
 }

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 )
 
-func AuthKeyFromKernelKeyring() ([]byte, error) {
+func AuthKeyFromKernelKeyring(sourceDevice string) ([]byte, error) {
 	return nil, nil
 }
 

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -45,13 +45,15 @@ const (
 	// Handles are in the block reserved for owner objects (0x01800000 - 0x01bfffff)
 	pinHandle           = 0x01880000
 	policyCounterHandle = 0x01880001
+
+	keyringPrefix = "snapd"
 )
 
 var (
 	sbConnectToDefaultTPM            = sb.ConnectToDefaultTPM
 	sbMeasureSnapSystemEpochToTPM    = sb.MeasureSnapSystemEpochToTPM
 	sbMeasureSnapModelToTPM          = sb.MeasureSnapModelToTPM
-	sbLockAccessToSealedKeys         = sb.LockAccessToSealedKeys
+	sbBlockPCRProtectionPolicies     = sb.BlockPCRProtectionPolicies
 	sbActivateVolumeWithTPMSealedKey = sb.ActivateVolumeWithTPMSealedKey
 	sbActivateVolumeWithRecoveryKey  = sb.ActivateVolumeWithRecoveryKey
 	sbAddEFISecureBootPolicyProfile  = sb.AddEFISecureBootPolicyProfile
@@ -59,6 +61,7 @@ var (
 	sbAddSystemdEFIStubProfile       = sb.AddSystemdEFIStubProfile
 	sbAddSnapModelProfile            = sb.AddSnapModelProfile
 	sbSealKeyToTPM                   = sb.SealKeyToTPM
+	sbGetActivationDataFromKernel    = sb.GetActivationDataFromKernel
 	sbReadSealedKeyObject            = sb.ReadSealedKeyObject
 	sbUpdateKeyPCRProtectionPolicy   = sb.UpdateKeyPCRProtectionPolicy
 
@@ -222,7 +225,7 @@ func UnlockVolumeIfEncrypted(disk disks.Disk, name string, encryptionKeyDir stri
 				// volumes to unlock we should lock access to the sealed keys only after
 				// the last encrypted volume is unlocked, in which case lockKeysOnFinish
 				// should be set to true.
-				lockErr = sbLockAccessToSealedKeys(tpm)
+				lockErr = sbBlockPCRProtectionPolicies(tpm, []int{tpmPCR})
 			}
 		}()
 
@@ -249,7 +252,7 @@ func UnlockVolumeIfEncrypted(disk disks.Disk, name string, encryptionKeyDir stri
 		}
 
 		sealedKeyPath := filepath.Join(encryptionKeyDir, name+".sealed-key")
-		return unlockEncryptedPartitionWithSealedKey(tpm, mapperName, encdev, sealedKeyPath, "", lockKeysOnFinish), true
+		return unlockEncryptedPartitionWithSealedKey(tpm, mapperName, encdev, sealedKeyPath, ""), true
 	}()
 	if err != nil {
 		return "", false, err
@@ -277,6 +280,7 @@ func UnlockVolumeIfEncrypted(disk disks.Disk, name string, encryptionKeyDir stri
 func unlockEncryptedPartitionWithRecoveryKey(name, device string) error {
 	options := sb.ActivateVolumeOptions{
 		RecoveryKeyTries: 3,
+		KeyringPrefix:    keyringPrefix,
 	}
 
 	if err := sbActivateVolumeWithRecoveryKey(name, device, nil, &options); err != nil {
@@ -289,11 +293,11 @@ func unlockEncryptedPartitionWithRecoveryKey(name, device string) error {
 // unlockEncryptedPartitionWithSealedKey unseals the keyfile and opens an encrypted
 // device. If activation with the sealed key fails, this function will attempt to
 // activate it with the fallback recovery key instead.
-func unlockEncryptedPartitionWithSealedKey(tpm *sb.TPMConnection, name, device, keyfile, pinfile string, lock bool) error {
+func unlockEncryptedPartitionWithSealedKey(tpm *sb.TPMConnection, name, device, keyfile, pinfile string) error {
 	options := sb.ActivateVolumeOptions{
 		PassphraseTries:  1,
 		RecoveryKeyTries: 3,
-		LockSealedKeys:   lock,
+		KeyringPrefix:    keyringPrefix,
 	}
 
 	// XXX: pinfile is currently not used
@@ -351,7 +355,7 @@ func SealKey(key EncryptionKey, params *SealKeyParams) error {
 
 // ResealKey updates the PCR protection policy for the sealed encryption key according to
 // the specified parameters.
-func ResealKey(params *ResealKeyParams) error {
+func ResealKey(disk disks.Disk, params *ResealKeyParams) error {
 	numModels := len(params.ModelParams)
 	if numModels < 1 {
 		return fmt.Errorf("at least one set of model-specific parameters is required")
@@ -371,13 +375,20 @@ func ResealKey(params *ResealKeyParams) error {
 		return err
 	}
 
-	k, err := sbReadSealedKeyObject(params.KeyFile)
+	partUUID, err := disk.FindMatchingPartitionUUID(params.DeviceName + "-enc")
 	if err != nil {
-		return fmt.Errorf("cannot read the sealed key: %v", err)
+		return err
 	}
-	authKey, err := unsealAuthKey(tpm, k)
+	encdev := filepath.Join("/dev/disk/by-partuuid", partUUID)
+
+	keep := true
+	k, err := sbGetActivationDataFromKernel(keyringPrefix, encdev, keep)
 	if err != nil {
-		return fmt.Errorf("cannot unseal the authorization policy update key: %v", err)
+		return err
+	}
+	authKey, ok := k.(sb.TPMPolicyAuthKey)
+	if !ok {
+		return fmt.Errorf("internal error: wrong type for auth key")
 	}
 
 	return sbUpdateKeyPCRProtectionPolicy(tpm, params.KeyFile, authKey, pcrProfile)

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -516,7 +516,7 @@ func tpmProvision(tpm *sb.TPMConnection, lockoutAuthFile string) error {
 }
 
 func provisionTPMImpl(tpm *sb.TPMConnection, mode sb.ProvisionMode, lockoutAuth []byte) error {
-	return tpm.EnsureProvisioned(sb.ProvisionModeFull, lockoutAuth)
+	return tpm.EnsureProvisioned(mode, lockoutAuth)
 }
 
 // buildLoadSequences builds EFI load image event trees from this package LoadChains

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -44,7 +44,6 @@ import (
 
 const (
 	// Handles are in the block reserved for owner objects (0x01800000 - 0x01bfffff)
-	pinHandle           = 0x01880000
 	policyCounterHandle = 0x01880001
 
 	keyringPrefix = "snapd"

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -43,7 +43,8 @@ import (
 
 const (
 	// Handles are in the block reserved for owner objects (0x01800000 - 0x01bfffff)
-	pinHandle = 0x01880000
+	pinHandle           = 0x01880000
+	policyCounterHandle = 0x01880001
 )
 
 var (
@@ -57,8 +58,8 @@ var (
 	sbAddEFIBootManagerProfile       = sb.AddEFIBootManagerProfile
 	sbAddSystemdEFIStubProfile       = sb.AddSystemdEFIStubProfile
 	sbAddSnapModelProfile            = sb.AddSnapModelProfile
-	sbProvisionTPM                   = sb.ProvisionTPM
 	sbSealKeyToTPM                   = sb.SealKeyToTPM
+	sbReadSealedKeyObject            = sb.ReadSealedKeyObject
 	sbUpdateKeyPCRProtectionPolicy   = sb.UpdateKeyPCRProtectionPolicy
 
 	randutilRandomKernelUUID = randutil.RandomKernelUUID
@@ -272,8 +273,8 @@ func UnlockVolumeIfEncrypted(disk disks.Disk, name string, encryptionKeyDir stri
 // unlockEncryptedPartitionWithRecoveryKey prompts for the recovery key and use
 // it to open an encrypted device.
 func unlockEncryptedPartitionWithRecoveryKey(name, device string) error {
-	options := sb.ActivateWithRecoveryKeyOptions{
-		Tries: 3,
+	options := sb.ActivateVolumeOptions{
+		RecoveryKeyTries: 3,
 	}
 
 	if err := sbActivateVolumeWithRecoveryKey(name, device, nil, &options); err != nil {
@@ -287,10 +288,10 @@ func unlockEncryptedPartitionWithRecoveryKey(name, device string) error {
 // device. If activation with the sealed key fails, this function will attempt to
 // activate it with the fallback recovery key instead.
 func unlockEncryptedPartitionWithSealedKey(tpm *sb.TPMConnection, name, device, keyfile, pinfile string, lock bool) error {
-	options := sb.ActivateWithTPMSealedKeyOptions{
-		PINTries:            1,
-		RecoveryKeyTries:    3,
-		LockSealedKeyAccess: lock,
+	options := sb.ActivateVolumeOptions{
+		PassphraseTries:  1,
+		RecoveryKeyTries: 3,
+		LockSealedKeys:   lock,
 	}
 
 	// XXX: pinfile is currently not used
@@ -338,10 +339,12 @@ func SealKey(key EncryptionKey, params *SealKeyParams) error {
 
 	// Seal key to the TPM
 	creationParams := sb.KeyCreationParams{
-		PCRProfile: pcrProfile,
-		PINHandle:  pinHandle,
+		PCRProfile:             pcrProfile,
+		PCRPolicyCounterHandle: policyCounterHandle,
 	}
-	return sbSealKeyToTPM(tpm, key[:], params.KeyFile, params.TPMPolicyUpdateDataFile, &creationParams)
+	_, err = sbSealKeyToTPM(tpm, key[:], params.KeyFile, &creationParams)
+
+	return err
 }
 
 // ResealKey updates the PCR protection policy for the sealed encryption key according to
@@ -366,7 +369,17 @@ func ResealKey(params *ResealKeyParams) error {
 		return err
 	}
 
-	return sbUpdateKeyPCRProtectionPolicy(tpm, params.KeyFile, params.TPMPolicyUpdateDataFile, pcrProfile)
+	k, err := sbReadSealedKeyObject(params.KeyFile)
+	if err != nil {
+		return fmt.Errorf("cannot read the sealed key: %v", err)
+	}
+	pin := ""
+	_, authKey, err := k.UnsealFromTPM(tpm, pin)
+	if err != nil {
+		return fmt.Errorf("cannot unseal the authorization policy update key: %v", err)
+	}
+
+	return sbUpdateKeyPCRProtectionPolicy(tpm, params.KeyFile, authKey, pcrProfile)
 }
 
 func buildPCRProtectionProfile(modelParams []*SealKeyModelParams) (*sb.PCRProtectionProfile, error) {
@@ -458,7 +471,7 @@ func tpmProvision(tpm *sb.TPMConnection, lockoutAuthFile string) error {
 	// TODO:UC20: ideally we should ask the firmware to clear the TPM and then reboot
 	//            if the device has previously been provisioned, see
 	//            https://godoc.org/github.com/snapcore/secboot#RequestTPMClearUsingPPI
-	if err := sbProvisionTPM(tpm, sb.ProvisionModeFull, lockoutAuth); err != nil {
+	if err := tpm.EnsureProvisioned(sb.ProvisionModeFull, lockoutAuth); err != nil {
 		logger.Noticef("TPM provisioning error: %v", err)
 		return fmt.Errorf("cannot provision TPM: %v", err)
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -47,10 +47,6 @@ const (
 	pinHandle           = 0x01880000
 	policyCounterHandle = 0x01880001
 
-	// keyctl(2) key identifiers
-	sessionKeyring = -3
-	userKeyring    = -4
-
 	keyringPrefix = "snapd"
 )
 
@@ -330,7 +326,7 @@ func AuthKeyFromKernelKeyring(sourceDevice string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot get activation data: %v", err)
 	}
-	if err := unlinkUserKeyring(); err != nil {
+	if err := unlinkUserKeyringFromSessionKeyring(); err != nil {
 		return nil, fmt.Errorf("cannot unlink user keyring: %v", err)
 	}
 
@@ -408,8 +404,8 @@ func ResealKey(params *ResealKeyParams) error {
 	return sbUpdateKeyPCRProtectionPolicy(tpm, params.KeyFile, params.AuthKey, pcrProfile)
 }
 
-func unlinkUserKeyring() error {
-	_, err := unixKeyctlInt(unix.KEYCTL_UNLINK, userKeyring, sessionKeyring, 0, 0)
+func unlinkUserKeyringFromSessionKeyring() error {
+	_, err := unixKeyctlInt(unix.KEYCTL_UNLINK, unix.KEY_SPEC_USER_KEYRING, unix.KEY_SPEC_SESSION_KEYRING, 0, 0)
 	return err
 }
 

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -72,6 +72,8 @@ var (
 
 	randutilRandomKernelUUID = randutil.RandomKernelUUID
 
+	unixKeyctlInt = unix.KeyctlInt
+
 	isTPMEnabled = isTPMEnabledImpl
 	provisionTPM = provisionTPMImpl
 )
@@ -321,7 +323,7 @@ func unlockEncryptedPartitionWithSealedKey(tpm *sb.TPMConnection, name, device, 
 
 // AuthKeyFromKernelKeyring obtains the TPM policy update authorization key
 // for the specified disk and device name from the kernel keyring and unlinks
-// the user keyring.
+// the user keyring from the session keyring.
 func AuthKeyFromKernelKeyring(disk disks.Disk, deviceName string) ([]byte, error) {
 	partUUID, err := disk.FindMatchingPartitionUUID(deviceName + "-enc")
 	if err != nil {
@@ -410,7 +412,7 @@ func ResealKey(params *ResealKeyParams) error {
 }
 
 func unlinkUserKeyring() error {
-	_, err := unix.KeyctlInt(unix.KEYCTL_UNLINK, userKeyring, sessionKeyring, 0, 0)
+	_, err := unixKeyctlInt(unix.KEYCTL_UNLINK, userKeyring, sessionKeyring, 0, 0)
 	return err
 }
 

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -554,12 +554,7 @@ func (s *secbootSuite) TestAuthKeyFromKernelKeyring(c *C) {
 		})
 		defer restore()
 
-		disk := &disks.MockDiskMapping{
-			FilesystemLabelToPartUUID: map[string]string{
-				"device-name-enc": "partition-uuid",
-			},
-		}
-		authKey, err := secboot.AuthKeyFromKernelKeyring(disk, "device-name")
+		authKey, err := secboot.AuthKeyFromKernelKeyring("/dev/disk/by-partuuid/partition-uuid")
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 			c.Assert(authKey, DeepEquals, mockAuthKey)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -25,10 +25,10 @@
 			"revisionTime": "2020-08-24T11:54:14Z"
 		},
 		{
-			"checksumSHA1": "eDjzake0GpHm9kfTH7FMUWX8zVA=",
-			"path": "github.com/chrisccoulson/tcglog-parser",
-			"revision": "7b0f085a85398d368e10382a21a44ec2226c35b3",
-			"revisionTime": "2020-02-28T14:36:39Z"
+			"checksumSHA1": "QGwWyf2f/5+FacNj2iKpjp8N5hg=",
+			"path": "github.com/canonical/tcglog-parser",
+			"revision": "12a3a7bcf5a14486e838fea211e8d4aa280e9671",
+			"revisionTime": "2020-09-08T16:50:21Z"
 		},
 		{
 			"checksumSHA1": "zg16zjZTQ9R89+UOLmEZxHgxDtM=",
@@ -116,40 +116,40 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "bNQROczU0gF+BeQHApftqWNUMe8=",
+			"checksumSHA1": "sKSczCVVhI1zTfY4zQBPYs/34vQ=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "c7jHLQSWFWbymTcFWZMQH0C5Wik=",
 			"path": "github.com/snapcore/secboot/internal/efi",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "loFEiH6evGaDnDSlQgk3ugemkcU=",
 			"path": "github.com/snapcore/secboot/internal/pe1.14",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "kDay47kq9OgDplpkrYw0/a8Z+YY=",
 			"path": "github.com/snapcore/secboot/internal/tcg",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "PRS8ACUu14shrvAgb747Izc25ns=",
 			"path": "github.com/snapcore/secboot/internal/tcti",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "TnfofdyojXYWOwdWCKMY5RCeI7s=",
 			"path": "github.com/snapcore/secboot/internal/truststore",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "3AmEm18mKj8XxBuru/ix4OOpRkE=",
@@ -301,6 +301,12 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "86f5ed62f8a0ee96bd888d2efdfd6d4fb100a4eb",
 			"revisionTime": "2018-03-26T05:07:29Z"
+		},
+		{
+			"checksumSHA1": "tZ9GNzrjTZEPDhoJEkouGPKRmZk=",
+			"path": "maze.io/x/crypto/afis",
+			"revision": "9b94c9afe06676a7da39a608a48ed4e31f5d125f",
+			"revisionTime": "2019-01-31T09:06:03Z"
 		}
 	],
 	"rootPath": "github.com/snapcore/snapd"


### PR DESCRIPTION
Update to use the new snapcore/secboot v1 API, which contain changes
in policy blocking, policy update authorization and volume activation options,
among others. We also start the snapd process in shared keyring mode to
retrieve the TPM policy update auth key from the root user kernel keying,
unlinking it from the systemd session keyring afterwards.

TODO: handle activation with recovery key, adjust tests.