### PR TITLE
osutil/disks: re-implement partition searching for disk w/ non-adjacent parts

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -28,16 +28,15 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 )
 
 var (
-	// for mocking in tests
-	devBlockDir = "/sys/dev/block"
-
 	// this regexp is for the DM_UUID udev property, or equivalently the dm/uuid
 	// sysfs entry for a luks2 device mapper volume dynamically created by
 	// systemd-cryptsetup when unlocking
@@ -233,12 +232,14 @@ func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
 		//            be missing from the initrd previously, and are not
 		//            available at all during userspace on UC20 for some reason
 		errFmt := "mountpoint source %s is not a decrypted device: could not read device mapper metadata: %v"
-		dmUUID, err := ioutil.ReadFile(filepath.Join(devBlockDir, d.Dev(), "dm", "uuid"))
+
+		dmDir := filepath.Join(dirs.SysfsDir, "dev", "block", d.Dev(), "dm")
+		dmUUID, err := ioutil.ReadFile(filepath.Join(dmDir, "uuid"))
 		if err != nil {
 			return nil, fmt.Errorf(errFmt, partMountPointSource, err)
 		}
 
-		dmName, err := ioutil.ReadFile(filepath.Join(devBlockDir, d.Dev(), "dm", "name"))
+		dmName, err := ioutil.ReadFile(filepath.Join(dmDir, "name"))
 		if err != nil {
 			return nil, fmt.Errorf(errFmt, partMountPointSource, err)
 		}
@@ -336,59 +337,88 @@ func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
 	// if we haven't found the partitions for this disk yet, do that now
 	if d.fsLabelToPartUUID == nil {
 		d.fsLabelToPartUUID = make(map[string]string)
-		// step 1. find all devices with a matching major number
-		// step 2. start at the major + minor device for the disk, and iterate over
-		//         all devices that have a partition attribute, starting with the
-		//         device with major same as disk and minor equal to disk minor + 1
-		// step 3. if we hit a device that does not have a partition attribute, then
-		//         we hit another disk, and shall stop searching
 
-		// note that this code assumes that all contiguous major / minor devices
-		// belong to the same physical device, even with MBR and
-		// logical/extended partition nodes jumping to i.e. /dev/sd*5
+		// step 1. find the devpath for the disk, then glob for matching
+		//         devices using the devname in that sysfs directory
+		// step 2. iterate over all those devices and save all the ones that are
+		//         partitions using the partition sysfs file
+		// step 3. for all partition devices found, query udev to get the fs
+		//         label and partition uuid
 
-		// start with the minor + 1, since the major + minor of the disk we have
-		// itself is not a partition
-		currentMinor := d.minor
-		for {
-			currentMinor++
-			partMajMin := fmt.Sprintf("%d:%d", d.major, currentMinor)
-			props, err := udevProperties(filepath.Join("/dev/block", partMajMin))
-			if err != nil && strings.Contains(err.Error(), "Unknown device") {
-				// the device doesn't exist, we hit the end of the disk
-				break
-			} else if err != nil {
-				// some other error trying to get udev properties, we should fail
-				return "", fmt.Errorf("cannot get udev properties for partition %s: %v", partMajMin, err)
+		udevProps, err := udevProperties(filepath.Join("/dev/block", d.Dev()))
+		if err != nil {
+			return "", err
+		}
+
+		// get the base device name
+		devName := udevProps["DEVNAME"]
+		if devName == "" {
+			return "", fmt.Errorf("cannot get udev properties for device %s, missing udev property \"DEVNAME\"", d.Dev())
+		}
+		// the DEVNAME as returned by udev includes the /dev/mmcblk0 path, we
+		// just want mmcblk0 for example
+		devName = filepath.Base(devName)
+
+		// get the device path in sysfs
+		devPath := udevProps["DEVPATH"]
+		if devPath == "" {
+			return "", fmt.Errorf("cannot get udev properties for device %s, missing udev property \"DEVPATH\"", d.Dev())
+		}
+
+		// glob for /sys/${devPath}/${devName}*
+		paths, err := filepath.Glob(filepath.Join(dirs.SysfsDir, devPath, devName+"*"))
+		if err != nil {
+			return "", fmt.Errorf("internal error getting udev properties for device %s: %v", err, d.Dev())
+		}
+
+		// Glob does not sort, so sort manually to have consistent tests
+		sort.Strings(paths)
+
+		for _, path := range paths {
+			// check if this device is a partition - note that the mere
+			// existence of this file is sufficient to indicate that it is a
+			// partition, the file is the partition number of the device, it
+			// will be absent for pseudo sub-devices, such as the
+			// /dev/mmcblk0boot0 disk device on the dragonboard which exists
+			// under the /dev/mmcblk0 disk, but is not a partition and is
+			// instead a proper disk
+			_, err := ioutil.ReadFile(filepath.Join(path, "partition"))
+			if err != nil {
+				continue
 			}
 
-			if props["DEVTYPE"] != "partition" {
-				// we ran into another disk, break out
-				break
+			// then the device is a partition, get the udev props for it
+			partDev := filepath.Base(path)
+			udevProps, err := udevProperties(partDev)
+			if err != nil {
+				continue
+			}
+
+			partUUID := udevProps["ID_PART_ENTRY_UUID"]
+			if partUUID == "" {
+				return "", fmt.Errorf("cannot get udev properties for device %s (a partition of %s), missing udev property \"ID_PART_ENTRY_UUID\"", partDev, d.Dev())
+			}
+
+			fsLabelEnc := udevProps["ID_FS_LABEL_ENC"]
+			if fsLabelEnc == "" {
+				// it is valid for there to be a partition without a fs
+				// label - such as the bios-boot partition on amd64 pc
+				// gadget systems
+				// in this case just skip this, since we are only matching
+				// by filesystem labels, obviously we cannot ever match to
+				// a partition which does not have a filesystem
+				continue
 			}
 
 			// TODO: maybe save ID_PART_ENTRY_NAME here too, which is the name
 			//       of the partition. this may be useful if this function gets
 			//       used in the gadget update code
-			fsLabelEnc := props["ID_FS_LABEL_ENC"]
-			if fsLabelEnc == "" {
-				// this partition does not have a filesystem, and thus doesn't
-				// have a filesystem label - this is not fatal, i.e. the
-				// bios-boot partition does not have a filesystem label but it
-				// is the first structure and so we should just skip it
-				continue
-			}
 
-			partuuid := props["ID_PART_ENTRY_UUID"]
-			if partuuid == "" {
-				return "", fmt.Errorf("cannot get udev properties for partition %s, missing udev property \"ID_PART_ENTRY_UUID\"", partMajMin)
-			}
-
-			// we always overwrite the fsLabelEnc with the last one, this has
-			// the result that the last partition with a given filesystem label
-			// will be set/found
+			// we always overwrite the fsLabelEnc with the last one, this
+			// has the result that the last partition with a given
+			// filesystem label will be set/found
 			// this matches what udev does with the symlinks in /dev
-			d.fsLabelToPartUUID[fsLabelEnc] = partuuid
+			d.fsLabelToPartUUID[fsLabelEnc] = partUUID
 		}
 	}
 

--- a/osutil/disks/export_test.go
+++ b/osutil/disks/export_test.go
@@ -41,11 +41,3 @@ func MockUdevPropertiesForDevice(new func(string) (map[string]string, error)) (r
 		udevadmProperties = old
 	}
 }
-
-func MockDevBlockDir(new string) (restore func()) {
-	old := devBlockDir
-	devBlockDir = new
-	return func() {
-		devBlockDir = old
-	}
-}


### PR DESCRIPTION
We now have a bit more clarity on why this happens, and sometimes the kernel
either races with itself/udev in creating device nodes for the partitions, and
in case of clashing will create the clashing nodes with a blockext block device
instead, which will be a different major number than the normal mmc block
number.

Due to this, we now know we have to handle for sure the case where device
numbers are not-adjacent, so re-implement FindMatchingPartitionUUID as such. The
new implementation relies on partitions being subdirectories of the device path
in sysfs, and checks them for the partition file existing. If it exists we know it is a 
partition.

Also adjust the unit tests for this new implementation and switch to expecting
certain udevadm calls in order, as the order in which we query things matters 
and the test becomes a bit more clear if we detail what is being queried in what
order.

Finally remove the test helper for mocking /sys/dev/block and instead use 
dirs.SysfsDir which will automatically get updated whenever we change 
dirs.GlobalRootDir as we do for each test.

Fixes: https://bugs.launchpad.net/snapd/+bug/1900842

NOTE: this is opened as a draft waiting for feedback on this approach from
foundations and/or kernel team in the linked bug report where I detailed this
approach in psuedo-code.