### PR TITLE
interfaces: deny connected x11 plugs access to ICE

### DIFF
--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -143,6 +143,7 @@ network netlink raw,
 # Deny access to ICE granted by abstractions/X
 # See: https://bugs.launchpad.net/snapd/+bug/1901489
 deny owner @{HOME}/.ICEauthority r,
+deny owner /run/user/*/ICEauthority r,
 deny unix (connect, receive, send)
     type=stream
     peer=(addr="@/tmp/.ICE-unix/[0-9]*"),

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -102,6 +102,7 @@ unix (connect, receive, send, accept)
     type=stream
     addr="@/tmp/.X11-unix/X[0-9]*"
     peer=(label=###PLUG_SECURITY_TAGS###),
+# TODO: deprecate and remove this if it doesn't break X11 server snaps.
 unix (connect, receive, send, accept)
     type=stream
     addr="@/tmp/.ICE-unix/[0-9]*"
@@ -138,6 +139,13 @@ owner /run/user/[0-9]*/mutter/Xauthority r,
 network netlink raw,
 /run/udev/data/c13:[0-9]* r,
 /run/udev/data/+input:* r,
+
+# Deny access to ICE granted by abstractions/X
+# See: https://bugs.launchpad.net/snapd/+bug/1901489
+deny owner @{HOME}/.ICEauthority r,
+deny unix (connect, receive, send)
+    type=stream
+    peer=(addr="@/tmp/.ICE-unix/[0-9]*"),
 `
 
 const x11ConnectedPlugSecComp = `


### PR DESCRIPTION
The ICE protocol allows the application to tell the session manager how
to restart an application from previously saved state, along with the
entire command line to execute. This can be used to craft a sandbox
escape, assuming a compatible session manager is used.

Fixes: https://bugs.launchpad.net/snapd/+bug/1901489
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
