### PR TITLE
overlord/snapstate: stop warning about inhibited refreshes

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -559,7 +559,6 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 			refreshInfo = err.PendingSnapRefreshInfo()
 		}
 
-		days := int(maxInhibition.Truncate(time.Hour).Hours() / 24)
 		now := time.Now()
 		client := userclient.New()
 		if snapst.RefreshInhibitedTime == nil {
@@ -571,11 +570,6 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 				refreshInfo.TimeRemaining = (maxInhibition - now.Sub(*snapst.RefreshInhibitedTime)).Truncate(time.Second)
 				// Send the notification asynchronously to avoid holding the state lock.
 				asyncPendingRefreshNotification(context.TODO(), client, refreshInfo)
-				// XXX: remove the warning or send it only if no notification was delivered?
-				st.Warnf(i18n.NG(
-					"snap %q is currently in use. Its refresh will be postponed for up to %d day to wait for the snap to no longer be in use.",
-					"snap %q is currently in use. Its refresh will be postponed for up to %d days to wait for the snap to no longer be in use.", days),
-					info.SnapName(), days)
 			}
 			return err
 		}
@@ -592,11 +586,6 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 		}
 		if _, ok := err.(*BusySnapError); ok {
 			asyncPendingRefreshNotification(context.TODO(), client, refreshInfo)
-			// XXX: remove the warning or send it only if no notification was delivered?
-			st.Warnf(i18n.NG(
-				"snap %q has been running for the maximum allowable %d day since its refresh was postponed. It will now be refreshed.",
-				"snap %q has been running for the maximum allowable %d days since its refresh was postponed. It will now be refreshed.", days),
-				info.SnapName(), days)
 		}
 	}
 	return nil

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -823,10 +823,6 @@ func (s *autoRefreshTestSuite) TestInitialInhibitRefreshWithinInhibitWindow(c *C
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks`)
-
-	pending, _ := s.state.PendingWarnings()
-	c.Assert(pending, HasLen, 1)
-	c.Check(pending[0].String(), Equals, `snap "pkg" is currently in use. Its refresh will be postponed for up to 14 days to wait for the snap to no longer be in use.`)
 	c.Check(notificationCount, Equals, 1)
 }
 
@@ -859,13 +855,10 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks`)
-
-	pending, _ := s.state.PendingWarnings()
-	c.Assert(pending, HasLen, 0) // This case does not warn
 	c.Check(notificationCount, Equals, 1)
 }
 
-func (s *autoRefreshTestSuite) TestInhibitRefreshWarnsAndRefreshesWhenOverdue(c *C) {
+func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -891,9 +884,5 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshWarnsAndRefreshesWhenOverdue(c 
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	c.Assert(err, IsNil)
-
-	pending, _ := s.state.PendingWarnings()
-	c.Assert(pending, HasLen, 1)
-	c.Check(pending[0].String(), Equals, `snap "pkg" has been running for the maximum allowable 14 days since its refresh was postponed. It will now be refreshed.`)
 	c.Check(notificationCount, Equals, 1)
 }


### PR DESCRIPTION
Usage of warnings was an early attempt at an user interface. We now
have a much more useful desktop notification mechanism. As such stop
issuing warnings on postponed refreshes.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
