### PR TITLE
many: update to secboot v1 (part 1)

### DIFF
--- a/boot/seal.go
+++ b/boot/seal.go
@@ -107,10 +107,9 @@ func sealKeyToModeenv(key secboot.EncryptionKey, model *asserts.Model, modeenv *
 		}
 	}
 	sealKeyParams := &secboot.SealKeyParams{
-		ModelParams:             modelParams,
-		KeyFile:                 filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
-		TPMPolicyUpdateDataFile: filepath.Join(InstallHostFDEDataDir, "policy-update-data"),
-		TPMLockoutAuthFile:      filepath.Join(InstallHostFDEDataDir, "tpm-lockout-auth"),
+		ModelParams:        modelParams,
+		KeyFile:            filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
+		TPMLockoutAuthFile: filepath.Join(InstallHostFDEDataDir, "tpm-lockout-auth"),
 	}
 	// finally, seal the key
 	if err := secbootSealKey(key, sealKeyParams); err != nil {
@@ -217,9 +216,8 @@ func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, 
 		return fmt.Errorf("cannot prepare for key resealing: %v", err)
 	}
 	resealKeyParams := &secboot.ResealKeyParams{
-		ModelParams:             modelParams,
-		KeyFile:                 filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
-		TPMPolicyUpdateDataFile: filepath.Join(dirs.SnapFDEDirUnder(rootdir), "policy-update-data"),
+		ModelParams: modelParams,
+		KeyFile:     filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
 	}
 	if err := secbootResealKey(resealKeyParams); err != nil {
 		return fmt.Errorf("cannot reseal the encryption key: %v", err)

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -86,22 +86,6 @@ func MockSbSealKeyToTPM(f func(tpm *sb.TPMConnection, key []byte, keyPath string
 	}
 }
 
-func MockReadSealedKeyObject(f func(path string) (*sb.SealedKeyObject, error)) (restore func()) {
-	old := sbReadSealedKeyObject
-	sbReadSealedKeyObject = f
-	return func() {
-		sbReadSealedKeyObject = old
-	}
-}
-
-func MockUnsealAuthKey(f func(tpm *sb.TPMConnection, k *sb.SealedKeyObject) (sb.TPMPolicyAuthKey, error)) (restore func()) {
-	old := unsealAuthKey
-	unsealAuthKey = f
-	return func() {
-		unsealAuthKey = old
-	}
-}
-
 func MockSbUpdateKeyPCRProtectionPolicy(f func(tpm *sb.TPMConnection, keyPath string, authKey sb.TPMPolicyAuthKey, pcrProfile *sb.PCRProtectionProfile) error) (restore func()) {
 	old := sbUpdateKeyPCRProtectionPolicy
 	sbUpdateKeyPCRProtectionPolicy = f
@@ -110,11 +94,11 @@ func MockSbUpdateKeyPCRProtectionPolicy(f func(tpm *sb.TPMConnection, keyPath st
 	}
 }
 
-func MockSbLockAccessToSealedKeys(f func(tpm *sb.TPMConnection) error) (restore func()) {
-	old := sbLockAccessToSealedKeys
-	sbLockAccessToSealedKeys = f
+func MockSbBlockPCRProtectionPolicies(f func(tpm *sb.TPMConnection, pcrs []int) error) (restore func()) {
+	old := sbBlockPCRProtectionPolicies
+	sbBlockPCRProtectionPolicies = f
 	return func() {
-		sbLockAccessToSealedKeys = old
+		sbBlockPCRProtectionPolicies = old
 	}
 }
 

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -38,11 +38,11 @@ func MockSbConnectToDefaultTPM(f func() (*sb.TPMConnection, error)) (restore fun
 	}
 }
 
-func MockSbProvisionTPM(f func(tpm *sb.TPMConnection, mode sb.ProvisionMode, newLockoutAuth []byte) error) (restore func()) {
-	old := sbProvisionTPM
-	sbProvisionTPM = f
+func MockProvisionTPM(f func(tpm *sb.TPMConnection, mode sb.ProvisionMode, newLockoutAuth []byte) error) (restore func()) {
+	old := provisionTPM
+	provisionTPM = f
 	return func() {
-		sbProvisionTPM = old
+		provisionTPM = old
 	}
 }
 
@@ -78,7 +78,7 @@ func MockSbAddSnapModelProfile(f func(profile *sb.PCRProtectionProfile, params *
 	}
 }
 
-func MockSbSealKeyToTPM(f func(tpm *sb.TPMConnection, key []byte, keyPath, policyUpdatePath string, params *sb.KeyCreationParams) error) (restore func()) {
+func MockSbSealKeyToTPM(f func(tpm *sb.TPMConnection, key []byte, keyPath string, params *sb.KeyCreationParams) (sb.TPMPolicyAuthKey, error)) (restore func()) {
 	old := sbSealKeyToTPM
 	sbSealKeyToTPM = f
 	return func() {
@@ -86,7 +86,23 @@ func MockSbSealKeyToTPM(f func(tpm *sb.TPMConnection, key []byte, keyPath, polic
 	}
 }
 
-func MockSbUpdateKeyPCRProtectionPolicy(f func(tpm *sb.TPMConnection, keyPath, policyUpdatePath string, pcrProfile *sb.PCRProtectionProfile) error) (restore func()) {
+func MockReadSealedKeyObject(f func(path string) (*sb.SealedKeyObject, error)) (restore func()) {
+	old := sbReadSealedKeyObject
+	sbReadSealedKeyObject = f
+	return func() {
+		sbReadSealedKeyObject = old
+	}
+}
+
+func MockUnsealAuthKey(f func(tpm *sb.TPMConnection, k *sb.SealedKeyObject) (sb.TPMPolicyAuthKey, error)) (restore func()) {
+	old := unsealAuthKey
+	unsealAuthKey = f
+	return func() {
+		unsealAuthKey = old
+	}
+}
+
+func MockSbUpdateKeyPCRProtectionPolicy(f func(tpm *sb.TPMConnection, keyPath string, authKey sb.TPMPolicyAuthKey, pcrProfile *sb.PCRProtectionProfile) error) (restore func()) {
 	old := sbUpdateKeyPCRProtectionPolicy
 	sbUpdateKeyPCRProtectionPolicy = f
 	return func() {
@@ -103,7 +119,7 @@ func MockSbLockAccessToSealedKeys(f func(tpm *sb.TPMConnection) error) (restore 
 }
 
 func MockSbActivateVolumeWithRecoveryKey(f func(volumeName, sourceDevicePath string,
-	keyReader io.Reader, options *sb.ActivateWithRecoveryKeyOptions) error) (restore func()) {
+	keyReader io.Reader, options *sb.ActivateVolumeOptions) error) (restore func()) {
 	old := sbActivateVolumeWithRecoveryKey
 	sbActivateVolumeWithRecoveryKey = f
 	return func() {
@@ -112,7 +128,7 @@ func MockSbActivateVolumeWithRecoveryKey(f func(volumeName, sourceDevicePath str
 }
 
 func MockSbActivateVolumeWithTPMSealedKey(f func(tpm *sb.TPMConnection, volumeName, sourceDevicePath, keyPath string,
-	pinReader io.Reader, options *sb.ActivateWithTPMSealedKeyOptions) (bool, error)) (restore func()) {
+	pinReader io.Reader, options *sb.ActivateVolumeOptions) (bool, error)) (restore func()) {
 	old := sbActivateVolumeWithTPMSealedKey
 	sbActivateVolumeWithTPMSealedKey = f
 	return func() {

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -69,4 +69,6 @@ type ResealKeyParams struct {
 	ModelParams []*SealKeyModelParams
 	// The path to the sealed key file
 	KeyFile string
+	// The source device name
+	DeviceName string
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -60,8 +60,6 @@ type SealKeyParams struct {
 	ModelParams []*SealKeyModelParams
 	// The path to store the sealed key file
 	KeyFile string
-	// The path to the authorization policy update data file (only relevant for TPM)
-	TPMPolicyUpdateDataFile string
 	// The path to the lockout authorization file (only relevant for TPM)
 	TPMLockoutAuthFile string
 }
@@ -71,6 +69,4 @@ type ResealKeyParams struct {
 	ModelParams []*SealKeyModelParams
 	// The path to the sealed key file
 	KeyFile string
-	// The path to the authorization policy update data file (only relevant for TPM)
-	TPMPolicyUpdateDataFile string
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -60,6 +60,8 @@ type SealKeyParams struct {
 	ModelParams []*SealKeyModelParams
 	// The path to store the sealed key file
 	KeyFile string
+	// The path to the authorization policy update key file (only relevant for TPM)
+	TPMPolicyAuthKeyFile string
 	// The path to the lockout authorization file (only relevant for TPM)
 	TPMLockoutAuthFile string
 }
@@ -69,6 +71,6 @@ type ResealKeyParams struct {
 	ModelParams []*SealKeyModelParams
 	// The path to the sealed key file
 	KeyFile string
-	// The source device name
-	DeviceName string
+	// The path to the authorization policy update key file (only relevant for TPM)
+	TPMPolicyAuthKeyFile string
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -63,7 +63,9 @@ var (
 
 	randutilRandomKernelUUID = randutil.RandomKernelUUID
 
-	isTPMEnabled = isTPMEnabledImpl
+	isTPMEnabled  = isTPMEnabledImpl
+	unsealAuthKey = unsealAuthKeyImpl
+	provisionTPM  = provisionTPMImpl
 )
 
 func isTPMEnabledImpl(tpm *sb.TPMConnection) bool {
@@ -372,13 +374,18 @@ func ResealKey(params *ResealKeyParams) error {
 	if err != nil {
 		return fmt.Errorf("cannot read the sealed key: %v", err)
 	}
-	pin := ""
-	_, authKey, err := k.UnsealFromTPM(tpm, pin)
+	authKey, err := unsealAuthKey(tpm, k)
 	if err != nil {
 		return fmt.Errorf("cannot unseal the authorization policy update key: %v", err)
 	}
 
 	return sbUpdateKeyPCRProtectionPolicy(tpm, params.KeyFile, authKey, pcrProfile)
+}
+
+func unsealAuthKeyImpl(tpm *sb.TPMConnection, k *sb.SealedKeyObject) (sb.TPMPolicyAuthKey, error) {
+	pin := ""
+	_, authKey, err := k.UnsealFromTPM(tpm, pin)
+	return authKey, err
 }
 
 func buildPCRProtectionProfile(modelParams []*SealKeyModelParams) (*sb.PCRProtectionProfile, error) {
@@ -470,11 +477,15 @@ func tpmProvision(tpm *sb.TPMConnection, lockoutAuthFile string) error {
 	// TODO:UC20: ideally we should ask the firmware to clear the TPM and then reboot
 	//            if the device has previously been provisioned, see
 	//            https://godoc.org/github.com/snapcore/secboot#RequestTPMClearUsingPPI
-	if err := tpm.EnsureProvisioned(sb.ProvisionModeFull, lockoutAuth); err != nil {
+	if err := provisionTPM(tpm, sb.ProvisionModeFull, lockoutAuth); err != nil {
 		logger.Noticef("TPM provisioning error: %v", err)
 		return fmt.Errorf("cannot provision TPM: %v", err)
 	}
 	return nil
+}
+
+func provisionTPMImpl(tpm *sb.TPMConnection, mode sb.ProvisionMode, lockoutAuth []byte) error {
+	return tpm.EnsureProvisioned(mode, lockoutAuth)
 }
 
 // buildLoadSequences builds EFI load image event trees from this package LoadChains

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -351,11 +351,14 @@ func SealKey(key EncryptionKey, params *SealKeyParams) error {
 	}
 
 	authKey, err := sbSealKeyToTPM(tpm, key[:], params.KeyFile, &creationParams)
+	if err != nil {
+		return err
+	}
 	if err := osutil.AtomicWriteFile(params.TPMPolicyAuthKeyFile, authKey, 0600, 0); err != nil {
 		return fmt.Errorf("cannot write the policy auth key file: %v", err)
 	}
 
-	return err
+	return nil
 }
 
 // ResealKey updates the PCR protection policy for the sealed encryption key according to
@@ -382,7 +385,7 @@ func ResealKey(params *ResealKeyParams) error {
 
 	authKey, err := ioutil.ReadFile(params.TPMPolicyAuthKeyFile)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot read the policy auth key file: %v", err)
 	}
 
 	return sbUpdateKeyPCRProtectionPolicy(tpm, params.KeyFile, authKey, pcrProfile)

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -823,9 +823,9 @@ func (s *secbootSuite) TestResealKey(c *C) {
 		{tpmEnabled: true, resealErr: mockErr, resealCalls: 1, expectedErr: "some error"},
 		{tpmEnabled: true, resealCalls: 1, expectedErr: ""},
 	} {
-		mockAuthKey := []byte{1, 3, 3, 7}
-		mockAuthKeyFile := filepath.Join(c.MkDir(), "auth-key-file")
-		err := ioutil.WriteFile(mockAuthKeyFile, mockAuthKey, 0600)
+		mockTPMPolicyAuthKey := []byte{1, 3, 3, 7}
+		mockTPMPolicyAuthKeyFile := filepath.Join(c.MkDir(), "policy-auth-key-file")
+		err := ioutil.WriteFile(mockTPMPolicyAuthKeyFile, mockTPMPolicyAuthKey, 0600)
 		c.Assert(err, IsNil)
 
 		mockEFI := bootloader.NewBootFile("", filepath.Join(c.MkDir(), "file.efi"), bootloader.RoleRecovery)
@@ -843,7 +843,7 @@ func (s *secbootSuite) TestResealKey(c *C) {
 				},
 			},
 			KeyFile:              "keyfile",
-			TPMPolicyAuthKeyFile: mockAuthKeyFile,
+			TPMPolicyAuthKeyFile: mockTPMPolicyAuthKeyFile,
 		}
 
 		sequences := []*sb.EFIImageLoadEvent{
@@ -916,7 +916,7 @@ func (s *secbootSuite) TestResealKey(c *C) {
 			resealCalls++
 			c.Assert(t, Equals, tpm)
 			c.Assert(keyPath, Equals, myParams.KeyFile)
-			c.Assert(authKey, DeepEquals, sb.TPMPolicyAuthKey(mockAuthKey))
+			c.Assert(authKey, DeepEquals, sb.TPMPolicyAuthKey(mockTPMPolicyAuthKey))
 			c.Assert(profile, Equals, pcrProfile)
 			return tc.resealErr
 		})

--- a/tests/nested/core20/kernel-reseal/task.yaml
+++ b/tests/nested/core20/kernel-reseal/task.yaml
@@ -6,8 +6,12 @@ prepare: |
   # shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
-  snap download pc-kernel --channel=20/edge --basename=pc-kernel
-  unsquashfs -d pc-kernel pc-kernel.snap
+  # we cannot use the kernel from store as it may have a version of
+  # snap-bootstrap that will not be able to unseal the keys and unlock the
+  # encrypted volumes, instead use the kernel we repacked when building the UC20
+  # image
+  KERNEL_SNAP="$(ls "$NESTED_ASSETS_DIR"/pc-kernel_*.snap)"
+  unsquashfs -d pc-kernel "$KERNEL_SNAP"
   # ensure we really have the header we expect
   grep -q -a "This program cannot be run in DOS mode" pc-kernel/kernel.efi
   # modify the kernel so that the hash changes

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -25,10 +25,10 @@
 			"revisionTime": "2020-08-24T11:54:14Z"
 		},
 		{
-			"checksumSHA1": "eDjzake0GpHm9kfTH7FMUWX8zVA=",
-			"path": "github.com/chrisccoulson/tcglog-parser",
-			"revision": "7b0f085a85398d368e10382a21a44ec2226c35b3",
-			"revisionTime": "2020-02-28T14:36:39Z"
+			"checksumSHA1": "QGwWyf2f/5+FacNj2iKpjp8N5hg=",
+			"path": "github.com/canonical/tcglog-parser",
+			"revision": "12a3a7bcf5a14486e838fea211e8d4aa280e9671",
+			"revisionTime": "2020-09-08T16:50:21Z"
 		},
 		{
 			"checksumSHA1": "zg16zjZTQ9R89+UOLmEZxHgxDtM=",
@@ -116,40 +116,40 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "bNQROczU0gF+BeQHApftqWNUMe8=",
+			"checksumSHA1": "sKSczCVVhI1zTfY4zQBPYs/34vQ=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "c7jHLQSWFWbymTcFWZMQH0C5Wik=",
 			"path": "github.com/snapcore/secboot/internal/efi",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "loFEiH6evGaDnDSlQgk3ugemkcU=",
 			"path": "github.com/snapcore/secboot/internal/pe1.14",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "kDay47kq9OgDplpkrYw0/a8Z+YY=",
 			"path": "github.com/snapcore/secboot/internal/tcg",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "PRS8ACUu14shrvAgb747Izc25ns=",
 			"path": "github.com/snapcore/secboot/internal/tcti",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "TnfofdyojXYWOwdWCKMY5RCeI7s=",
 			"path": "github.com/snapcore/secboot/internal/truststore",
-			"revision": "7e933de20d914ff47ad080f25d2ed93cef6e8530",
-			"revisionTime": "2020-09-10T15:49:09Z"
+			"revision": "0ebc6c7e1dc3c184baf8c4a2b936afa99f988acb",
+			"revisionTime": "2020-10-15T16:53:38Z"
 		},
 		{
 			"checksumSHA1": "3AmEm18mKj8XxBuru/ix4OOpRkE=",
@@ -301,6 +301,12 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "86f5ed62f8a0ee96bd888d2efdfd6d4fb100a4eb",
 			"revisionTime": "2018-03-26T05:07:29Z"
+		},
+		{
+			"checksumSHA1": "tZ9GNzrjTZEPDhoJEkouGPKRmZk=",
+			"path": "maze.io/x/crypto/afis",
+			"revision": "9b94c9afe06676a7da39a608a48ed4e31f5d125f",
+			"revisionTime": "2019-01-31T09:06:03Z"
 		}
 	],
 	"rootPath": "github.com/snapcore/snapd"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -304,6 +304,7 @@
 		},
 		{
 			"checksumSHA1": "tZ9GNzrjTZEPDhoJEkouGPKRmZk=",
+			"origin": "github.com/pedronis/maze.io-x-crypto/afis",
 			"path": "maze.io/x/crypto/afis",
 			"revision": "9b94c9afe06676a7da39a608a48ed4e31f5d125f",
 			"revisionTime": "2019-01-31T09:06:03Z"


### PR DESCRIPTION
Update to use the new snapcore/secboot v1 API, which contain changes
in policy blocking, policy update authorization and volume activation options,
among others. This PR doesn't include passing the policy auth key using
the kernel keyring, relying instead on a file inside the encrypted data partition.

These changes were originally part of PR #9534, proposing as a separate
PR for clarity and avoid too many reverted commits.
