### PR TITLE
dirs, boot: add ubuntu-save directories and related locations

### DIFF
--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -46,6 +46,10 @@ var (
 	// initramfs.
 	InitramfsUbuntuSeedDir string
 
+	// InitramfsUbuntuSaveDir is the location of ubuntu-save during the
+	// initramfs.
+	InitramfsUbuntuSaveDir string
+
 	// InitramfsWritableDir is the location of the writable partition during the
 	// initramfs. Note that this may refer to a temporary filesystem or a
 	// physical partition depending on what system mode the system is in.
@@ -70,6 +74,7 @@ func setInitramfsDirVars(rootdir string) {
 	InitramfsHostUbuntuDataDir = filepath.Join(InitramfsRunMntDir, "host", "ubuntu-data")
 	InitramfsUbuntuBootDir = filepath.Join(InitramfsRunMntDir, "ubuntu-boot")
 	InitramfsUbuntuSeedDir = filepath.Join(InitramfsRunMntDir, "ubuntu-seed")
+	InitramfsUbuntuSaveDir = filepath.Join(InitramfsRunMntDir, "ubuntu-save")
 	InstallHostWritableDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data", "system-data")
 	InstallHostFDEDataDir = dirs.SnapFDEDirUnder(InstallHostWritableDir)
 	InitramfsWritableDir = filepath.Join(InitramfsDataDir, "system-data")

--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -38,6 +38,10 @@ var (
 	// during the initramfs, typically used in recover mode.
 	InitramfsHostUbuntuDataDir string
 
+	// InitramfsHostWritableDir is the location of the host writable
+	// partition during the initramfs, typically used in recover mode.
+	InitramfsHostWritableDir string
+
 	// InitramfsUbuntuBootDir is the location of ubuntu-boot during the
 	// initramfs.
 	InitramfsUbuntuBootDir string
@@ -72,6 +76,7 @@ func setInitramfsDirVars(rootdir string) {
 	InitramfsRunMntDir = filepath.Join(rootdir, "run/mnt")
 	InitramfsDataDir = filepath.Join(InitramfsRunMntDir, "data")
 	InitramfsHostUbuntuDataDir = filepath.Join(InitramfsRunMntDir, "host", "ubuntu-data")
+	InitramfsHostWritableDir = filepath.Join(InitramfsHostUbuntuDataDir, "system-data")
 	InitramfsUbuntuBootDir = filepath.Join(InitramfsRunMntDir, "ubuntu-boot")
 	InitramfsUbuntuSeedDir = filepath.Join(InitramfsRunMntDir, "ubuntu-seed")
 	InitramfsUbuntuSaveDir = filepath.Join(InitramfsRunMntDir, "ubuntu-save")

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -101,6 +101,7 @@ var (
 	SnapModeenvFile   string
 	SnapBootAssetsDir string
 	SnapFDEDir        string
+	SnapSaveDir       string
 
 	CloudMetaDataFile     string
 	CloudInstanceDataFile string
@@ -267,6 +268,11 @@ func SnapFDEDirUnder(rootdir string) string {
 	return filepath.Join(SnapDeviceDirUnder(rootdir), "fde")
 }
 
+// SnapSaveDirUnder returns the path to device save directory under rootdir.
+func SnapSaveDirUnder(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir, "save")
+}
+
 // AddRootDirCallback registers a callback for whenever the global root
 // directory (set by SetRootDir) is changed to enable updates to variables in
 // other packages that depend on its location.
@@ -346,6 +352,7 @@ func SetRootDir(rootdir string) {
 	SnapModeenvFile = SnapModeenvFileUnder(rootdir)
 	SnapBootAssetsDir = SnapBootAssetsDirUnder(rootdir)
 	SnapFDEDir = SnapFDEDirUnder(rootdir)
+	SnapSaveDir = SnapSaveDirUnder(rootdir)
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")
 	SnapRepairStateFile = filepath.Join(SnapRepairDir, "repair.json")


### PR DESCRIPTION
Add a mount location of ubuntu-save during initramfs, and a desired mount point during run mode. Add helper locations for accessing host's writable in initramfs.