### PR TITLE
tests/nested/core20/gadget,kernel-reseal: add sanity checks to the reseal tests

### DIFF
--- a/tests/nested/core20/gadget-reseal/task.yaml
+++ b/tests/nested/core20/gadget-reseal/task.yaml
@@ -46,6 +46,9 @@ execute: |
     nested_wait_for_reboot "${boot_id}"
     nested_exec sudo snap watch "${REMOTE_CHG_ID}"
 
+    # sanity check that the gadget asset was changed
+    nested_exec sudo grep -q -a "This program cannot be run in XXX mode" /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+
     # the gadget has changed, we should see resealing
     SEALED_KEY_MTIME_3="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-seed/device/fde/ubuntu-data.sealed-key)"
     test "$SEALED_KEY_MTIME_3" -gt "$SEALED_KEY_MTIME_2"

--- a/tests/nested/core20/kernel-reseal/task.yaml
+++ b/tests/nested/core20/kernel-reseal/task.yaml
@@ -11,7 +11,8 @@ prepare: |
   # ensure we really have the header we expect
   grep -q -a "This program cannot be run in DOS mode" pc-kernel/kernel.efi
   # modify the kernel so that the hash changes
-  sed -i 's/This program cannot be run in DOS mode/This program cannot be run in D0S mode/' pc-kernel/kernel.efi
+  sed -i 's/This program cannot be run in DOS mode/This program cannot be run in XXX mode/' pc-kernel/kernel.efi
+  grep -q -a "This program cannot be run in XXX mode" pc-kernel/kernel.efi
 
   KEY_NAME=$(nested_get_snakeoil_key)
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
@@ -35,6 +36,9 @@ execute: |
   REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous new-pc-kernel.snap --no-wait)
   nested_wait_for_reboot "${boot_id}"
   nested_exec sudo snap watch "${REMOTE_CHG_ID}"
+
+  # sanity check that we are using the right kernel
+  nested_exec sudo grep -q -a "This program cannot be run in XXX mode" /boot/grub/kernel.efi
 
   # ensure ubuntu-data.sealed-key mtime is newer
   SEALED_KEY_MTIME_2="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-seed/device/fde/ubuntu-data.sealed-key)"


### PR DESCRIPTION
Add sanity checks to make sure we are running/using the right binaries
