### PR TITLE
asserts: implement "storage-safety" in uc20 model assertion

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -671,7 +671,7 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 			return nil, fmt.Errorf("cannot specify a grade for model without the extended snaps header")
 		}
 		if _, ok := assert.headers["storage-safety"]; ok {
-			return nil, fmt.Errorf("cannot specify a storage-safety for model without the extended snaps header")
+			return nil, fmt.Errorf("cannot specify storage-safety for model without the extended snaps header")
 		}
 	}
 

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -747,16 +747,16 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		}
 		if storageSafetyStr != "" {
 			storageSafety = StorageSafety(storageSafetyStr)
-		}
-		if grade == ModelSecured && storageSafety != StorageSafetyUnset && storageSafety != StorageSafetyEncrypted {
-			return nil, fmt.Errorf(`"grade: secured" must have "storage-safety: encrypted"`)
-		}
-		if storageSafety == StorageSafetyUnset {
+		} else {
 			if grade == ModelSecured {
 				storageSafety = StorageSafetyEncrypted
 			} else {
 				storageSafety = StorageSafetyPreferEncrypted
 			}
+		}
+
+		if grade == ModelSecured && storageSafety != StorageSafetyEncrypted {
+			return nil, fmt.Errorf(`secured grade model must not have storage-safety overridden, only "encrypted" is valid`)
 		}
 
 		modSnaps, err = checkExtendedSnaps(extendedSnaps, base, grade)

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -748,8 +748,15 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		if storageSafetyStr != "" {
 			storageSafety = StorageSafety(storageSafetyStr)
 		}
-		if grade == ModelSecured && storageSafety != StorageSafetyEncrypted {
+		if grade == ModelSecured && storageSafety != StorageSafetyUnset && storageSafety != StorageSafetyEncrypted {
 			return nil, fmt.Errorf(`"grade: secured" must have "storage-safety: encrypted"`)
+		}
+		if storageSafety == StorageSafetyUnset {
+			if grade == ModelSecured {
+				storageSafety = StorageSafetyEncrypted
+			} else {
+				storageSafety = StorageSafetyPreferEncrypted
+			}
 		}
 
 		modSnaps, err = checkExtendedSnaps(extendedSnaps, base, grade)

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -339,24 +339,24 @@ const (
 	ModelDangerous ModelGrade = "dangerous"
 )
 
-// ModelStorageSafety characterizes the requested storage safety of
+// StorageSafety characterizes the requested storage safety of
 // the model which then controls what encryption is used
-type ModelStorageSafety string
+type StorageSafety string
 
 const (
-	ModelStorageSafetyUnset ModelStorageSafety = "unset"
-	// ModelStorageSafetyEncrypted implies mandatory full disk encryption.
-	ModelStorageSafetyEncrypted ModelStorageSafety = "encrypted"
-	// ModelStorageSafetyPreferEncrypted implies full disk
+	StorageSafetyUnset StorageSafety = "unset"
+	// StorageSafetyEncrypted implies mandatory full disk encryption.
+	StorageSafetyEncrypted StorageSafety = "encrypted"
+	// StorageSafetyPreferEncrypted implies full disk
 	// encryption when the system supports it.
-	ModelStorageSafetyPreferEncrypted ModelStorageSafety = "prefer-encrypted"
-	// ModelStorageSafetyPreferUnencrypted implies no full disk
+	StorageSafetyPreferEncrypted StorageSafety = "prefer-encrypted"
+	// StorageSafetyPreferUnencrypted implies no full disk
 	// encryption by default even if the system supports
 	// encryption.
-	ModelStorageSafetyPreferUnencrypted ModelStorageSafety = "prefer-unencrypted"
+	StorageSafetyPreferUnencrypted StorageSafety = "prefer-unencrypted"
 )
 
-var validStorageSafeties = []string{string(ModelStorageSafetyEncrypted), string(ModelStorageSafetyPreferEncrypted), string(ModelStorageSafetyPreferUnencrypted)}
+var validStorageSafeties = []string{string(StorageSafetyEncrypted), string(StorageSafetyPreferEncrypted), string(StorageSafetyPreferUnencrypted)}
 
 var validModelGrades = []string{string(ModelSecured), string(ModelSigned), string(ModelDangerous)}
 
@@ -393,7 +393,7 @@ type Model struct {
 
 	grade ModelGrade
 
-	storageSafety ModelStorageSafety
+	storageSafety StorageSafety
 
 	allSnaps []*ModelSnap
 	// consumers of this info should care only about snap identity =>
@@ -449,7 +449,7 @@ func (mod *Model) Grade() ModelGrade {
 
 // StorageSafety returns the storage safety for the model. Will be
 // StorageSafetyUnset for Core 16/18 models.
-func (mod *Model) StorageSafety() ModelStorageSafety {
+func (mod *Model) StorageSafety() StorageSafety {
 	return mod.storageSafety
 }
 
@@ -724,7 +724,7 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 
 	var modSnaps *modelSnaps
 	grade := ModelGradeUnset
-	storageSafety := ModelStorageSafetyUnset
+	storageSafety := StorageSafetyUnset
 	if extended {
 		gradeStr, err := checkOptionalString(assert.headers, "grade")
 		if err != nil {
@@ -746,9 +746,9 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 			return nil, fmt.Errorf("storage-safety for model must be %s, not %q", strings.Join(validStorageSafeties, "|"), storageSafetyStr)
 		}
 		if storageSafetyStr != "" {
-			storageSafety = ModelStorageSafety(storageSafetyStr)
+			storageSafety = StorageSafety(storageSafetyStr)
 		}
-		if grade == ModelSecured && storageSafety == ModelStorageSafetyPreferUnencrypted {
+		if grade == ModelSecured && storageSafety == StorageSafetyPreferUnencrypted {
 			return nil, fmt.Errorf(`"grade: secured" cannot have "storage-safety: prefer-unencrypted"`)
 		}
 

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -748,8 +748,8 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		if storageSafetyStr != "" {
 			storageSafety = StorageSafety(storageSafetyStr)
 		}
-		if grade == ModelSecured && storageSafety == StorageSafetyPreferUnencrypted {
-			return nil, fmt.Errorf(`"grade: secured" cannot have "storage-safety: prefer-unencrypted"`)
+		if grade == ModelSecured && storageSafety != StorageSafetyEncrypted {
+			return nil, fmt.Errorf(`"grade: secured" must have "storage-safety: encrypted"`)
 		}
 
 		modSnaps, err = checkExtendedSnaps(extendedSnaps, base, grade)

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -736,7 +736,7 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		if err != nil {
 			return nil, err
 		}
-		if storageSafetyStr != "" && storageSafetyStr != "optional" && storageSafetyStr != "encrypted" {
+		if storageSafetyStr != "" && storageSafetyStr != string(ModelStorageSafetyOptional) && storageSafetyStr != string(ModelStorageSafetyEncrypted) {
 			return nil, fmt.Errorf("storage-safety for model must be optional|encrypted, not %q", storageSafetyStr)
 		}
 		if storageSafetyStr != "" {

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -133,6 +133,7 @@ snaps:
     type: app
     presence: optional
 OTHERgrade: secured
+storage-safety: encrypted
 ` + "TSLINE" +
 		"body-length: 0\n" +
 		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
@@ -178,6 +179,7 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	})
 	c.Check(model.Store(), Equals, "brand-store")
 	c.Check(model.Grade(), Equals, asserts.ModelGradeUnset)
+	c.Check(model.StorageSafety(), Equals, asserts.ModelStorageSafetyUnset)
 	essentialSnaps := model.EssentialSnaps()
 	c.Check(essentialSnaps, DeepEquals, []*asserts.ModelSnap{
 		model.KernelSnap(),
@@ -665,6 +667,7 @@ func (mods *modelSuite) TestCore20DecodeOK(c *C) {
 	})
 	c.Check(model.Store(), Equals, "brand-store")
 	c.Check(model.Grade(), Equals, asserts.ModelSecured)
+	c.Check(model.StorageSafety(), Equals, asserts.ModelStorageSafetyEncrypted)
 	essentialSnaps := model.EssentialSnaps()
 	c.Check(essentialSnaps, DeepEquals, []*asserts.ModelSnap{
 		model.KernelSnap(),
@@ -840,6 +843,21 @@ func (mods *modelSuite) TestCore20GradeDangerous(c *C) {
 	})
 }
 
+func (mods *modelSuite) TestCore20ValidStorageSafety(c *C) {
+	encoded := strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1)
+	encoded = strings.Replace(encoded, "OTHER", "", 1)
+	encoded = strings.Replace(encoded, "grade: secured\n", "grade: signed\n", 1)
+
+	for _, sss := range []string{"optional", "encrypted"} {
+		ex := strings.Replace(encoded, "storage-safety: encrypted\n", fmt.Sprintf("storage-safety: %s\n", sss), 1)
+		a, err := asserts.Decode([]byte(ex))
+		c.Assert(err, IsNil)
+		c.Check(a.Type(), Equals, asserts.ModelType)
+		model := a.(*asserts.Model)
+		c.Check(string(model.StorageSafety()), Equals, sss)
+	}
+}
+
 func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 	encoded := strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1)
 
@@ -878,6 +896,8 @@ func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 		{"OTHER", "gadget: foo\n", `cannot specify separate "gadget" header once using the extended snaps header`},
 		{"OTHER", "required-snaps:\n  - foo\n", `cannot specify separate "required-snaps" header once using the extended snaps header`},
 		{"grade: secured\n", "grade: foo\n", `grade for model must be secured|signed|dangerous`},
+		{"storage-safety: encrypted\n", "storage-safety: foo\n", `storage-safety for model must be optional|encrypted`},
+		{"storage-safety: encrypted\n", "storage-safety: optional\n", `"grade: secured" cannot have "storage-safety: optional"`},
 	}
 	for _, test := range invalidTests {
 		invalid := strings.Replace(encoded, test.original, test.invalid, 1)

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -858,6 +858,33 @@ func (mods *modelSuite) TestCore20ValidStorageSafety(c *C) {
 	}
 }
 
+func (mods *modelSuite) TestCore20DefaultStorageSafetySecured(c *C) {
+	encoded := strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1)
+	encoded = strings.Replace(encoded, "OTHER", "", 1)
+	ex := strings.Replace(encoded, "storage-safety: encrypted\n", "", 1)
+
+	a, err := asserts.Decode([]byte(ex))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.ModelType)
+	model := a.(*asserts.Model)
+	c.Check(model.StorageSafety(), Equals, asserts.StorageSafetyEncrypted)
+}
+
+func (mods *modelSuite) TestCore20DefaultStorageSafetySignedDangerous(c *C) {
+	encoded := strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1)
+	encoded = strings.Replace(encoded, "OTHER", "", 1)
+	encoded = strings.Replace(encoded, "storage-safety: encrypted\n", "", 1)
+
+	for _, grade := range []string{"dangerous", "signed"} {
+		ex := strings.Replace(encoded, "grade: secured\n", fmt.Sprintf("grade: %s\n", grade), 1)
+		a, err := asserts.Decode([]byte(ex))
+		c.Assert(err, IsNil)
+		c.Check(a.Type(), Equals, asserts.ModelType)
+		model := a.(*asserts.Model)
+		c.Check(model.StorageSafety(), Equals, asserts.StorageSafetyPreferEncrypted)
+	}
+}
+
 func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 	encoded := strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1)
 

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -179,7 +179,7 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	})
 	c.Check(model.Store(), Equals, "brand-store")
 	c.Check(model.Grade(), Equals, asserts.ModelGradeUnset)
-	c.Check(model.StorageSafety(), Equals, asserts.ModelStorageSafetyUnset)
+	c.Check(model.StorageSafety(), Equals, asserts.StorageSafetyUnset)
 	essentialSnaps := model.EssentialSnaps()
 	c.Check(essentialSnaps, DeepEquals, []*asserts.ModelSnap{
 		model.KernelSnap(),
@@ -667,7 +667,7 @@ func (mods *modelSuite) TestCore20DecodeOK(c *C) {
 	})
 	c.Check(model.Store(), Equals, "brand-store")
 	c.Check(model.Grade(), Equals, asserts.ModelSecured)
-	c.Check(model.StorageSafety(), Equals, asserts.ModelStorageSafetyEncrypted)
+	c.Check(model.StorageSafety(), Equals, asserts.StorageSafetyEncrypted)
 	essentialSnaps := model.EssentialSnaps()
 	c.Check(essentialSnaps, DeepEquals, []*asserts.ModelSnap{
 		model.KernelSnap(),

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -848,13 +848,20 @@ func (mods *modelSuite) TestCore20ValidStorageSafety(c *C) {
 	encoded = strings.Replace(encoded, "OTHER", "", 1)
 	encoded = strings.Replace(encoded, "grade: secured\n", "grade: signed\n", 1)
 
-	for _, sss := range []string{"prefer-encrypted", "prefer-unencrypted", "encrypted"} {
-		ex := strings.Replace(encoded, "storage-safety: encrypted\n", fmt.Sprintf("storage-safety: %s\n", sss), 1)
+	for _, tc := range []struct {
+		ss  asserts.StorageSafety
+		sss string
+	}{
+		{asserts.StorageSafetyPreferEncrypted, "prefer-encrypted"},
+		{asserts.StorageSafetyPreferUnencrypted, "prefer-unencrypted"},
+		{asserts.StorageSafetyEncrypted, "encrypted"},
+	} {
+		ex := strings.Replace(encoded, "storage-safety: encrypted\n", fmt.Sprintf("storage-safety: %s\n", tc.sss), 1)
 		a, err := asserts.Decode([]byte(ex))
 		c.Assert(err, IsNil)
 		c.Check(a.Type(), Equals, asserts.ModelType)
 		model := a.(*asserts.Model)
-		c.Check(string(model.StorageSafety()), Equals, sss)
+		c.Check(model.StorageSafety(), Equals, tc.ss)
 	}
 }
 

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -931,7 +931,7 @@ func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 		{"OTHER", "required-snaps:\n  - foo\n", `cannot specify separate "required-snaps" header once using the extended snaps header`},
 		{"grade: secured\n", "grade: foo\n", `grade for model must be secured|signed|dangerous`},
 		{"storage-safety: encrypted\n", "storage-safety: foo\n", `storage-safety for model must be encrypted\|prefer-encrypted\|prefer-unencrypted, not "foo"`},
-		{"storage-safety: encrypted\n", "storage-safety: prefer-unencrypted\n", `"grade: secured" must have "storage-safety: encrypted"`},
+		{"storage-safety: encrypted\n", "storage-safety: prefer-unencrypted\n", `secured grade model must not have storage-safety overridden, only "encrypted" is valid`},
 	}
 	for _, test := range invalidTests {
 		invalid := strings.Replace(encoded, test.original, test.invalid, 1)

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -897,7 +897,7 @@ func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 		{"OTHER", "required-snaps:\n  - foo\n", `cannot specify separate "required-snaps" header once using the extended snaps header`},
 		{"grade: secured\n", "grade: foo\n", `grade for model must be secured|signed|dangerous`},
 		{"storage-safety: encrypted\n", "storage-safety: foo\n", `storage-safety for model must be encrypted\|prefer-encrypted\|prefer-unencrypted, not "foo"`},
-		{"storage-safety: encrypted\n", "storage-safety: prefer-unencrypted\n", `"grade: secured" cannot have "storage-safety: prefer-unencrypted"`},
+		{"storage-safety: encrypted\n", "storage-safety: prefer-unencrypted\n", `"grade: secured" must have "storage-safety: encrypted"`},
 	}
 	for _, test := range invalidTests {
 		invalid := strings.Replace(encoded, test.original, test.invalid, 1)

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -848,7 +848,7 @@ func (mods *modelSuite) TestCore20ValidStorageSafety(c *C) {
 	encoded = strings.Replace(encoded, "OTHER", "", 1)
 	encoded = strings.Replace(encoded, "grade: secured\n", "grade: signed\n", 1)
 
-	for _, sss := range []string{"optional", "encrypted"} {
+	for _, sss := range []string{"prefer-encrypted", "prefer-unencrypted", "encrypted"} {
 		ex := strings.Replace(encoded, "storage-safety: encrypted\n", fmt.Sprintf("storage-safety: %s\n", sss), 1)
 		a, err := asserts.Decode([]byte(ex))
 		c.Assert(err, IsNil)
@@ -896,8 +896,8 @@ func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 		{"OTHER", "gadget: foo\n", `cannot specify separate "gadget" header once using the extended snaps header`},
 		{"OTHER", "required-snaps:\n  - foo\n", `cannot specify separate "required-snaps" header once using the extended snaps header`},
 		{"grade: secured\n", "grade: foo\n", `grade for model must be secured|signed|dangerous`},
-		{"storage-safety: encrypted\n", "storage-safety: foo\n", `storage-safety for model must be optional|encrypted`},
-		{"storage-safety: encrypted\n", "storage-safety: optional\n", `"grade: secured" cannot have "storage-safety: optional"`},
+		{"storage-safety: encrypted\n", "storage-safety: foo\n", `storage-safety for model must be encrypted\|prefer-encrypted\|prefer-unencrypted, not "foo"`},
+		{"storage-safety: encrypted\n", "storage-safety: prefer-unencrypted\n", `"grade: secured" cannot have "storage-safety: prefer-unencrypted"`},
 	}
 	for _, test := range invalidTests {
 		invalid := strings.Replace(encoded, test.original, test.invalid, 1)


### PR DESCRIPTION
This commit implements the new "storage-safety" header for the
model assertion. This header controls the encryption handling
for the given model and grade. Valid values for the storage-safety
header are "encrypted|prefer-encrypted|prefer-unencrypted".

Note that the the combination of "model: secured" and 
"storage-safety: prefer-unencrypted" is an error.

In addition to the assertion change this will need work on the
devicemanager to honor the settings.
