### PR TITLE
cmd/snap, snapmgr, tests: cleanups after #9418

### DIFF
--- a/cmd/snap/cmd_routine_console_conf.go
+++ b/cmd/snap/cmd_routine_console_conf.go
@@ -65,9 +65,7 @@ func printfFunc(msg string, format ...interface{}) func() {
 }
 
 func (x *cmdRoutineConsoleConfStart) Execute(args []string) error {
-	snapdReloadMsgOnce := sync.Once{}
-	systemReloadMsgOnce := sync.Once{}
-	snapRefreshMsgOnce := sync.Once{}
+	var snapdReloadMsgOnce, systemReloadMsgOnce, snapRefreshMsgOnce sync.Once
 
 	for {
 		chgs, snaps, err := x.client.InternalConsoleConfStart()
@@ -111,7 +109,7 @@ func (x *cmdRoutineConsoleConfStart) Execute(args []string) error {
 		}
 
 		if len(chgs) == 0 {
-			break
+			return nil
 		}
 
 		if len(snaps) == 0 {
@@ -139,6 +137,4 @@ func (x *cmdRoutineConsoleConfStart) Execute(args []string) error {
 		// don't DDOS snapd by hitting it's API too often
 		time.Sleep(snapdAPIInterval)
 	}
-
-	return nil
 }

--- a/cmd/snap/cmd_routine_console_conf_test.go
+++ b/cmd/snap/cmd_routine_console_conf_test.go
@@ -30,59 +30,84 @@ import (
 )
 
 func (s *SnapSuite) TestRoutineConsoleConfStartTrivialCase(c *C) {
+	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, Equals, "POST")
+			c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
 
-		fmt.Fprintf(w, `{"type":"sync", "status-code": 200, "result": {}}`)
+			fmt.Fprintf(w, `{"type":"sync", "status-code": 200, "result": {}}`)
+		default:
+			c.Errorf("unexpected request %v", n)
+		}
 	})
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"routine", "console-conf-start"})
 	c.Assert(err, IsNil)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
+	c.Assert(n, Equals, 1)
 }
 
 func (s *SnapSuite) TestRoutineConsoleConfStartInconsistentAPIResponseError(c *C) {
+	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, Equals, "POST")
+			c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
 
-		// return just refresh changes but no snap ids
-		fmt.Fprintf(w, `{
-			"type":"sync",
-			"status-code": 200,
-			"result": {
-				"active-auto-refreshes": ["1"]
-			}
-		}`)
+			// return just refresh changes but no snap ids
+			fmt.Fprintf(w, `{
+				"type":"sync",
+				"status-code": 200,
+				"result": {
+					"active-auto-refreshes": ["1"]
+				}
+			}`)
+		default:
+			c.Errorf("unexpected request %v", n)
+		}
 	})
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"routine", "console-conf-start"})
 	c.Assert(err, ErrorMatches, `internal error: returned changes .* but no snap names`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
+	c.Assert(n, Equals, 1)
+
 }
 
 func (s *SnapSuite) TestRoutineConsoleConfStartNonMaintenanceErrorReturned(c *C) {
+	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, Equals, "POST")
+			c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
 
-		// return internal server error
-		fmt.Fprintf(w, `{
+			// return internal server error
+			fmt.Fprintf(w, `{
 			"type":"error",
 			"status-code": 500,
 			"result": {
 				"message": "broken server"
 			}
 		}`)
+		default:
+			c.Errorf("unexpected request %v", n)
+		}
 	})
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"routine", "console-conf-start"})
 	c.Assert(err, ErrorMatches, "broken server")
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
+	c.Assert(n, Equals, 1)
 }
 
 func (s *SnapSuite) TestRoutineConsoleConfStartSingleSnap(c *C) {
@@ -124,6 +149,7 @@ func (s *SnapSuite) TestRoutineConsoleConfStartSingleSnap(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "Snaps (pc-kernel) are refreshing, please wait...\n")
+	c.Assert(n, Equals, 5)
 }
 
 func (s *SnapSuite) TestRoutineConsoleConfStartTwoSnaps(c *C) {
@@ -165,6 +191,7 @@ func (s *SnapSuite) TestRoutineConsoleConfStartTwoSnaps(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "Snaps (core20 and pc-kernel) are refreshing, please wait...\n")
+	c.Assert(n, Equals, 5)
 }
 
 func (s *SnapSuite) TestRoutineConsoleConfStartMultipleSnaps(c *C) {
@@ -205,6 +232,7 @@ func (s *SnapSuite) TestRoutineConsoleConfStartMultipleSnaps(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "Snaps (core20, pc, pc-kernel, and snapd) are refreshing, please wait...\n")
+	c.Assert(n, Equals, 5)
 }
 
 // TODO:UC20: when maintenance.json is a thing, then add a similar test as this
@@ -288,6 +316,7 @@ func (s *SnapSuite) TestRoutineConsoleConfStartSnapdRefreshRestart(c *C) {
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), testutil.Contains, "Snapd is reloading, please wait...\n")
 	c.Check(s.Stderr(), testutil.Contains, "Snaps (snapd) are refreshing, please wait...\n")
+	c.Assert(n, Equals, 5)
 }
 
 func (s *SnapSuite) TestRoutineConsoleConfStartKernelRefreshReboot(c *C) {
@@ -352,4 +381,5 @@ func (s *SnapSuite) TestRoutineConsoleConfStartKernelRefreshReboot(c *C) {
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), testutil.Contains, "System is rebooting, please wait for reboot...\n")
 	c.Check(s.Stderr(), testutil.Contains, "Snaps (pc-kernel) are refreshing, please wait...\n")
+	c.Assert(n, Equals, 3)
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -569,14 +569,14 @@ func (m *SnapManager) EnsureAutoRefreshesAreDelayed(delay time.Duration) ([]*sta
 	}
 
 	// look for auto refresh changes in progress
-	autoRefreshChgs := []*state.Change{}
+	autoRefreshChgsInFlight := []*state.Change{}
 	for _, chg := range m.state.Changes() {
 		if chg.Kind() == "auto-refresh" && !chg.Status().Ready() {
-			autoRefreshChgs = append(autoRefreshChgs, chg)
+			autoRefreshChgsInFlight = append(autoRefreshChgsInFlight, chg)
 		}
 	}
 
-	return autoRefreshChgs, nil
+	return autoRefreshChgsInFlight, nil
 }
 
 // ensureForceDevmodeDropsDevmodeFromState undoes the forced devmode


### PR DESCRIPTION
To address @mvo5's comments: https://github.com/snapcore/snapd/pull/9418#pullrequestreview-517592963

I didn't implement i18n here at all because as per https://bugs.launchpad.net/subiquity/+bug/1621378, it's not currently in scope for the default images to do any sort of l10n to maintain a small disk footprint in the common case. Additionally, we eventually don't want to have this command used at all, and instead want console-conf to consume our REST API so it can display it's own messages/UI's around snaps being refreshed, in which case the burden is again on console-conf to implement some kind of l10n using either user input or auto-detection or something.