### PR TITLE
client, daemon, cmd/snap: cleanups from #9489 + more unit tests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -346,9 +346,7 @@ var doNoTimeoutAndRetry = &doOptions{
 func (client *Client) do(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}, opts *doOptions) (statusCode int, err error) {
 	opts = ensureDoOpts(opts)
 
-	if err := client.checkMaintenanceJSON(); err != nil {
-		return 500, err
-	}
+	client.checkMaintenanceJSON()
 
 	var rsp *http.Response
 	var ctx context.Context = context.Background()
@@ -424,14 +422,16 @@ func (client *Client) doSync(method, path string, query url.Values, headers map[
 // maintenance, either for snapd restarting itself to update, or rebooting the
 // system to update the kernel or base snap, etc. If there is ongoing
 // maintenance, then the maintenance object on the client is set appropriately.
-// note that currently checkMaintenanceJSON does not return non-nil errors, so
-// if the file is missing or corrupt or empty, nothing will happen
-func (client *Client) checkMaintenanceJSON() error {
+// note that currently checkMaintenanceJSON does not return errors, such that
+// if the file is missing or corrupt or empty, nothing will happen and it will
+// be silently ignored
+func (client *Client) checkMaintenanceJSON() {
 	f, err := os.Open(dirs.SnapdMaintenanceFile)
 	// just continue if we can't read the maintenance file
 	if err != nil {
-		return nil
+		return
 	}
+	defer f.Close()
 
 	// we have a maintenance file, try to read it
 	maintenance := &Error{}
@@ -439,7 +439,7 @@ func (client *Client) checkMaintenanceJSON() error {
 	if err := json.NewDecoder(f).Decode(&maintenance); err != nil {
 		// if the json is malformed, just ignore it for now, we only use it for
 		// positive identification of snapd down for maintenance
-		return nil
+		return
 	}
 
 	if maintenance != nil {
@@ -455,8 +455,6 @@ func (client *Client) checkMaintenanceJSON() error {
 		// this also means an empty json object in maintenance.json doesn't get
 		// treated as a real maintenance downtime for example
 	}
-
-	return nil
 }
 
 func (client *Client) doSyncWithOpts(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}, opts *doOptions) (*ResultInfo, error) {
@@ -466,9 +464,7 @@ func (client *Client) doSyncWithOpts(method, path string, query url.Values, head
 	// won't respond and return a specific error, but that's a big behavior
 	// change we probably shouldn't make right now, not to mention it probably
 	// requires adjustments in other areas too
-	if err := client.checkMaintenanceJSON(); err != nil {
-		return nil, err
-	}
+	client.checkMaintenanceJSON()
 
 	var rsp response
 	statusCode, err := client.do(method, path, query, headers, body, &rsp, opts)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -146,58 +146,37 @@ func (cs *clientSuite) TestClientWorks(c *C) {
 	c.Check(cs.req.URL.Path, Equals, "/this")
 }
 
+func makeMaintenanceFile(c *C, b []byte) {
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.SnapdMaintenanceFile, b, 0644), IsNil)
+}
+
 func (cs *clientSuite) TestClientSetMaintenanceForMaintenanceJSON(c *C) {
 	// write a maintenance.json that says snapd is down for a restart
 	maintErr := &client.Error{
 		Kind:    client.ErrorKindSystemRestart,
 		Message: "system is restarting",
 	}
-
 	b, err := json.Marshal(maintErr)
 	c.Assert(err, IsNil)
+	makeMaintenanceFile(c, b)
 
-	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapdMaintenanceFile, b, 0644), IsNil)
-	var v []int
-	cs.rsp = `[1,2]`
-	reqBody := ioutil.NopCloser(strings.NewReader(""))
-	statusCode, err := cs.cli.Do("GET", "/this", nil, reqBody, &v, nil)
+	// now after a Do(), we will have maintenance set to what we wrote
+	// originally
+	_, err = cs.cli.Do("GET", "/this", nil, nil, nil, nil)
 	c.Check(err, IsNil)
-	c.Check(statusCode, Equals, 200)
-	c.Check(v, DeepEquals, []int{1, 2})
-	c.Assert(cs.req, NotNil)
-	c.Assert(cs.req.URL, NotNil)
-	c.Check(cs.req.Method, Equals, "GET")
-	c.Check(cs.req.Body, Equals, reqBody)
-	c.Check(cs.req.URL.Path, Equals, "/this")
 
 	returnedErr := cs.cli.Maintenance()
-	c.Assert(returnedErr, Not(IsNil))
-
-	returnedMaintErr, ok := returnedErr.(*client.Error)
-	c.Check(ok, Equals, true)
-
-	c.Assert(returnedMaintErr, DeepEquals, maintErr)
+	c.Assert(returnedErr, DeepEquals, maintErr)
 }
 
 func (cs *clientSuite) TestClientIgnoresGarbageMaintenanceJSON(c *C) {
 	// write a garbage maintenance.json that can't be unmarshalled
-	maintGarbage := []byte("blah blah blah not json")
+	makeMaintenanceFile(c, []byte("blah blah blah not json"))
 
-	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapdMaintenanceFile, maintGarbage, 0644), IsNil)
-	var v []int
-	cs.rsp = `[1,2]`
-	reqBody := ioutil.NopCloser(strings.NewReader(""))
-	statusCode, err := cs.cli.Do("GET", "/this", nil, reqBody, &v, nil)
+	// after a Do(), no maintenance set and also no error returned from Do()
+	_, err := cs.cli.Do("GET", "/this", nil, nil, nil, nil)
 	c.Check(err, IsNil)
-	c.Check(statusCode, Equals, 200)
-	c.Check(v, DeepEquals, []int{1, 2})
-	c.Assert(cs.req, NotNil)
-	c.Assert(cs.req.URL, NotNil)
-	c.Check(cs.req.Method, Equals, "GET")
-	c.Check(cs.req.Body, Equals, reqBody)
-	c.Check(cs.req.URL.Path, Equals, "/this")
 
 	returnedErr := cs.cli.Maintenance()
 	c.Assert(returnedErr, IsNil)

--- a/cmd/snap/cmd_routine_console_conf_test.go
+++ b/cmd/snap/cmd_routine_console_conf_test.go
@@ -20,12 +20,18 @@
 package main_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/client"
 	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -207,9 +213,114 @@ func (s *SnapSuite) TestRoutineConsoleConfStartMultipleSnaps(c *C) {
 	c.Check(s.Stderr(), Equals, "Snaps (core20, pc, pc-kernel, and snapd) are refreshing, please wait...\n")
 }
 
-// TODO:UC20: when maintenance.json is a thing, then add a similar test as this
-// one, but using the maintenance.json file instead of the maintenance response
-// as that is closer to the real desired behavior
+func (s *SnapSuite) TestRoutineConsoleConfStartSnapdRefreshMaintenanceJSON(c *C) {
+	// make the command hit the API as fast as possible for testing
+	r := snap.MockSnapdAPIInterval(0)
+	defer r()
+
+	// write a maintenance.json before any requests and then the first request
+	// should fail and see the maintenance.json and then subsequent operations
+	// succeed
+	maintErr := client.Error{
+		Kind:    client.ErrorKindDaemonRestart,
+		Message: "daemon is restarting",
+	}
+	b, err := json.Marshal(&maintErr)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(dirs.SnapdMaintenanceFile, b, 0644)
+	c.Assert(err, IsNil)
+
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		// 1st time we don't respond at all to simulate what happens if the user
+		// triggers console-conf to start after snapd has shut down for a
+		// refresh
+		case 1:
+			c.Check(r.Method, Equals, "POST")
+			c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
+
+		// 2nd time we hit the API, return an in-progress refresh
+		case 2:
+			c.Check(r.Method, Equals, "POST")
+			c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
+
+			fmt.Fprintf(w, `{
+				"type":"sync",
+				"status-code": 200,
+				"result": {
+					"active-auto-refreshes": ["1"],
+					"active-auto-refresh-snaps": ["snapd"]
+				}
+			}`)
+		// 3rd time we are actually done
+		case 3:
+			c.Check(r.Method, Equals, "POST")
+			c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
+
+			fmt.Fprintf(w, `{"type":"sync", "status-code": 200, "result": {}}`)
+
+		default:
+			c.Errorf("unexpected request %v", n)
+		}
+	})
+
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"routine", "console-conf-start"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, "")
+	c.Check(s.Stderr(), testutil.Contains, "Snapd is reloading, please wait...\n")
+	c.Check(s.Stderr(), testutil.Contains, "Snaps (snapd) are refreshing, please wait...\n")
+	c.Assert(n, Equals, 3)
+}
+
+func (s *SnapSuite) TestRoutineConsoleConfStartSystemRebootMaintenanceJSON(c *C) {
+	// make the command hit the API as fast as possible for testing
+	r := snap.MockSnapdAPIInterval(0)
+	defer r()
+
+	r = snap.MockSnapdWaitForFullSystemReboot(0)
+	defer r()
+
+	// write a maintenance.json before any requests and then the first request
+	// should fail and see the maintenance.json and then subsequent operations
+	// succeed
+	maintErr := client.Error{
+		Kind:    client.ErrorKindSystemRestart,
+		Message: "system is restarting",
+	}
+	b, err := json.Marshal(&maintErr)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(dirs.SnapdMaintenanceFile, b, 0644)
+	c.Assert(err, IsNil)
+
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		// 1st time we don't respond at all to simulate what happens if the user
+		// triggers console-conf to start after snapd has shut down for a
+		// refresh
+		case 1:
+			c.Check(r.Method, Equals, "POST")
+			c.Check(r.URL.Path, Equals, "/v2/internal/console-conf-start")
+
+		default:
+			c.Errorf("unexpected request %v", n)
+		}
+	})
+
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"routine", "console-conf-start"})
+	c.Assert(err, ErrorMatches, "system didn't reboot after 10 minutes even though snapd daemon is in maintenance")
+	c.Check(s.Stdout(), Equals, "")
+	c.Check(s.Stderr(), testutil.Contains, "System is rebooting, please wait for reboot...\n")
+	c.Assert(n, Equals, 1)
+}
+
 func (s *SnapSuite) TestRoutineConsoleConfStartSnapdRefreshRestart(c *C) {
 	// make the command hit the API as fast as possible for testing
 	r := snap.MockSnapdAPIInterval(0)

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -186,6 +186,9 @@ func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
 	logger.Debugf("system key mismatch detected, waiting for snapd to start responding...")
 
 	for i := 0; i < timeout; i++ {
+		// TODO: we could also check cli.Maintenance() here too in case snapd is
+		// down semi-permanently for a refresh, but what message do we show to
+		// the user or what do we do if we know snapd is down for maintenance?
 		if _, err := cli.SysInfo(); err == nil {
 			return nil
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -626,8 +626,7 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	}
 	d.overlord.Stop()
 
-	err := d.tomb.Wait()
-	if err != nil {
+	if err := d.tomb.Wait(); err != nil {
 		if err == context.DeadlineExceeded {
 			logger.Noticef("WARNING: cannot gracefully shut down in-flight snapd API activity within: %v", shutdownTimeout)
 			// the process is shutting down anyway, so we may just


### PR DESCRIPTION
This adds more realistic unit tests for the console-conf-start routine around the existence of the maintenance.json file, as well as addresses comments from @mvo5 and @zyga in https://github.com/snapcore/snapd/pull/9489.