### PR TITLE
gadget/many: drop usage of gpt attr 59 for indicating creation of partitions

### DIFF
--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -85,7 +85,7 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 	}
 
 	// remove partitions added during a previous install attempt
-	if err := removeCreatedPartitions(diskLayout); err != nil {
+	if err := removeCreatedPartitions(lv, diskLayout); err != nil {
 		return nil, fmt.Errorf("cannot remove partitions from previous install: %v", err)
 	}
 	// at this point we removed any existing partition, nuke any
@@ -166,30 +166,74 @@ func Run(gadgetRoot, device string, options Options, observer gadget.ContentObse
 	}, nil
 }
 
+// isCreatableAtInstall returns whether the gadget structure would be created at
+// install - currently that is only ubuntu-save, ubuntu-data, and ubuntu-boot
+func isCreatableAtInstall(gv *gadget.VolumeStructure) bool {
+	// a structure is creatable at install if it is one of the roles for
+	// system-save, system-data, or system-boot
+	switch gv.Role {
+	case gadget.SystemSave, gadget.SystemData, gadget.SystemBoot:
+		return true
+	default:
+		return false
+	}
+}
+
 func ensureLayoutCompatibility(gadgetLayout *gadget.LaidOutVolume, diskLayout *gadget.OnDiskVolume) error {
-	eq := func(ds gadget.OnDiskStructure, gs gadget.LaidOutStructure) bool {
+	eq := func(ds gadget.OnDiskStructure, gs gadget.LaidOutStructure) (bool, string) {
 		dv := ds.VolumeStructure
 		gv := gs.VolumeStructure
 		nameMatch := gv.Name == dv.Name
 		if gadgetLayout.Schema == "mbr" {
-			// partitions have no names in MBR
+			// partitions have no names in MBR so bypass the name check
 			nameMatch = true
 		}
-		// Previous installation may have failed before filesystem creation or partition may be encrypted
-		check := nameMatch && ds.StartOffset == gs.StartOffset && (ds.CreatedDuringInstall || dv.Filesystem == gv.Filesystem)
+		// Previous installation may have failed before filesystem creation or
+		// partition may be encrypted, so if the on disk offset matches the
+		// gadget offset, and the gadget structure is creatable during install,
+		// then they are equal
+		// otherwise, if they are not created during installation, the
+		// filesystem must be the same
+		check := nameMatch && ds.StartOffset == gs.StartOffset && (isCreatableAtInstall(gv) || dv.Filesystem == gv.Filesystem)
+		sizeMatches := dv.Size == gv.Size
 		if gv.Role == gadget.SystemData {
 			// system-data may have been expanded
-			return check && dv.Size >= gv.Size
+			sizeMatches = dv.Size >= gv.Size
 		}
-		return check && dv.Size == gv.Size
+		if check && sizeMatches {
+			return true, ""
+		}
+		switch {
+		case !nameMatch:
+			// don't return a reason if the names don't match
+			return false, ""
+		case ds.StartOffset != gs.StartOffset:
+			return false, fmt.Sprintf("start offsets do not match (disk: %d (%s) and gadget: %d (%s))", ds.StartOffset, ds.StartOffset.IECString(), gs.StartOffset, gs.StartOffset.IECString())
+		case !isCreatableAtInstall(gv) && dv.Filesystem != gv.Filesystem:
+			return false, "filesystems do not match and the partition is not creatable at install"
+		case dv.Size < gv.Size:
+			return false, "on disk size is smaller than gadget size"
+		case gv.Role != gadget.SystemData && dv.Size > gv.Size:
+			return false, "on disk size is larger than gadget size (and the role should not be expanded)"
+		default:
+			return false, "some other logic condition (should be impossible?)"
+		}
 	}
-	contains := func(haystack []gadget.LaidOutStructure, needle gadget.OnDiskStructure) bool {
+
+	contains := func(haystack []gadget.LaidOutStructure, needle gadget.OnDiskStructure) (bool, string) {
+		reasonAbsent := ""
 		for _, h := range haystack {
-			if eq(needle, h) {
-				return true
+			matches, reasonNotMatches := eq(needle, h)
+			if matches {
+				return true, ""
+			}
+			// this has the effect of only returning the last non-empty reason
+			// string
+			if reasonNotMatches != "" {
+				reasonAbsent = reasonNotMatches
 			}
 		}
-		return false
+		return false, reasonAbsent
 	}
 
 	if gadgetLayout.Size > diskLayout.Size {
@@ -207,7 +251,11 @@ func ensureLayoutCompatibility(gadgetLayout *gadget.LaidOutVolume, diskLayout *g
 
 	// Check if all existing device partitions are also in gadget
 	for _, ds := range diskLayout.Structure {
-		if !contains(gadgetLayout.LaidOutStructure, ds) {
+		present, reasonAbsent := contains(gadgetLayout.LaidOutStructure, ds)
+		if !present {
+			if reasonAbsent != "" {
+				return fmt.Errorf("cannot find disk partition %s (starting at %d) in gadget: %s", ds.Node, ds.StartOffset, reasonAbsent)
+			}
 			return fmt.Errorf("cannot find disk partition %s (starting at %d) in gadget", ds.Node, ds.StartOffset)
 		}
 	}

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -243,12 +243,13 @@ func (s *installSuite) TestMBRLayoutCompatibility(c *C) {
 		},
 	)
 	err = install.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &deviceLayoutWithExtras)
-	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/node4 .* in gadget`)
+	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/node4 \(starting at 1260388352\) in gadget: start offsets do not match \(disk: 1260388352 \(1.17 GiB\) and gadget: 2097152 \(2 MiB\)\)`)
 }
 
 func (s *installSuite) TestLayoutCompatibilityWithCreatedPartitions(c *C) {
 	gadgetLayoutWithExtras := layoutFromYaml(c, mockGadgetYaml+mockExtraStructure)
 	deviceLayout := mockDeviceLayout
+
 	// device matches gadget except for the filesystem type
 	deviceLayout.Structure = append(deviceLayout.Structure,
 		gadget.OnDiskStructure{
@@ -261,17 +262,45 @@ func (s *installSuite) TestLayoutCompatibilityWithCreatedPartitions(c *C) {
 				},
 				StartOffset: 2 * gadget.SizeMiB,
 			},
-			Node:                 "/dev/node3",
-			CreatedDuringInstall: true,
+			Node: "/dev/node3",
 		},
 	)
 	err := install.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &deviceLayout)
 	c.Assert(err, IsNil)
 
-	// compare layouts without partitions created at install time (should fail)
-	deviceLayout.Structure[len(deviceLayout.Structure)-1].CreatedDuringInstall = false
+	// change the role for the laid out volume to not be a partition role that
+	// is created at install time (note that the duplicated seed role here is
+	// technically incorrect, you can't have duplicated roles, but this
+	// demonstrates that a structure that otherwise fits the bill but isn't a
+	// role that is created during install will fail the filesystem match check)
+	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Role = gadget.SystemSeed
+
+	// now we fail to find the /dev/node3 structure from the gadget on disk
 	err = install.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &deviceLayout)
-	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/node3.* in gadget`)
+	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/node3 \(starting at 2097152\) in gadget: filesystems do not match and the partition is not creatable at install`)
+
+	// undo the role change
+	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Role = gadget.SystemData
+
+	// change the gadget size to be bigger than the on disk size
+	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Size = 10000000 * gadget.SizeMiB
+
+	// now we fail to find the /dev/node3 structure from the gadget on disk because the gadget says it must be bigger
+	err = install.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &deviceLayout)
+	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/node3 \(starting at 2097152\) in gadget: on disk size is smaller than gadget size`)
+
+	// change the gadget size to be smaller than the on disk size and the role to be one that is not expanded
+	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Size = 1 * gadget.SizeMiB
+	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Role = gadget.SystemBoot
+
+	// now we fail because the gadget says it should be smaller and it can't be expanded
+	err = install.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &deviceLayout)
+	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/node3 \(starting at 2097152\) in gadget: on disk size is larger than gadget size \(and the role should not be expanded\)`)
+
+	// but a smaller partition on disk for SystemData role is okay
+	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Role = gadget.SystemData
+	err = install.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &deviceLayout)
+	c.Assert(err, IsNil)
 }
 
 func (s *installSuite) TestSchemaCompatibility(c *C) {

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -284,14 +284,14 @@ func (s *installSuite) TestLayoutCompatibilityWithCreatedPartitions(c *C) {
 	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Role = gadget.SystemData
 
 	// change the gadget size to be bigger than the on disk size
-	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Size = 10000000 * gadget.SizeMiB
+	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Size = 10000000 * quantity.SizeMiB
 
 	// now we fail to find the /dev/node3 structure from the gadget on disk because the gadget says it must be bigger
 	err = install.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &deviceLayout)
 	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/node3 \(starting at 2097152\) in gadget: on disk size is smaller than gadget size`)
 
 	// change the gadget size to be smaller than the on disk size and the role to be one that is not expanded
-	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Size = 1 * gadget.SizeMiB
+	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Size = 1 * quantity.SizeMiB
 	gadgetLayoutWithExtras.Structure[len(deviceLayout.Structure)-1].Role = gadget.SystemBoot
 
 	// now we fail because the gadget says it should be smaller and it can't be expanded

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -272,7 +272,6 @@ func (s *installSuite) TestLayoutCompatibilityWithCreatedPartitions(c *C) {
 	deviceLayout.Structure[len(deviceLayout.Structure)-1].CreatedDuringInstall = false
 	err = install.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &deviceLayout)
 	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/node3.* in gadget`)
-
 }
 
 func (s *installSuite) TestSchemaCompatibility(c *C) {

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -70,10 +70,10 @@ func createMissingPartitions(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) 
 }
 
 // removeCreatedPartitions removes partitions added during a previous install.
-func removeCreatedPartitions(dl *gadget.OnDiskVolume) error {
+func removeCreatedPartitions(lv *gadget.LaidOutVolume, dl *gadget.OnDiskVolume) error {
 	indexes := make([]string, 0, len(dl.Structure))
 	for i, s := range dl.Structure {
-		if s.CreatedDuringInstall {
+		if gadget.WasCreatedDuringInstall(lv, s) {
 			logger.Noticef("partition %s was created during previous install", s.Node)
 			indexes = append(indexes, strconv.Itoa(i+1))
 		}
@@ -100,7 +100,7 @@ func removeCreatedPartitions(dl *gadget.OnDiskVolume) error {
 	}
 
 	// Ensure all created partitions were removed
-	if remaining := gadget.CreatedDuringInstall(dl); len(remaining) > 0 {
+	if remaining := gadget.CreatedDuringInstall(lv, dl); len(remaining) > 0 {
 		return fmt.Errorf("cannot remove partitions: %s", strings.Join(remaining, ", "))
 	}
 

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -90,8 +90,7 @@ echo '{
         "size": 2457600,
         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
         "uuid": "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
-        "name": "Recovery",
-        "attrs": "GUID:59"
+        "name": "Recovery"
       }`)
 	}
 
@@ -104,8 +103,7 @@ echo '{
         "size": 2457600,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "f940029d-bfbb-4887-9d44-321e85c63866",
-        "name": "Writable",
-        "attrs": "GUID:59"
+        "name": "Writable"
       }`)
 	}
 
@@ -240,7 +238,10 @@ elif [ -f %[1]s/1 ]; then
    touch %[1]s/2
    exit 0
 else
-   PART=',{"node": "/dev/node2", "start": 4096, "size": 2457600, "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4", "uuid": "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F", "name": "Recovery", "attrs": "GUID:59"}'
+   PART=',
+   {"node": "/dev/node2", "start": 4096, "size": 2457600, "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4", "uuid": "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F", "name": "Recovery"},
+   {"node": "/dev/node3", "start": 2461696, "size": 2457600, "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4", "uuid": "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F", "name": "Recovery"}
+   '
    touch %[1]s/1
 fi
 echo '{
@@ -261,7 +262,7 @@ echo '{
 	cmdSfdisk := testutil.MockCommand(c, "sfdisk", fmt.Sprintf(mockSfdiskScriptRemovablePartition, s.dir))
 	defer cmdSfdisk.Restore()
 
-	cmdLsblk := testutil.MockCommand(c, "lsblk", makeLsblkScript(scriptPartitionsBiosSeed))
+	cmdLsblk := testutil.MockCommand(c, "lsblk", makeLsblkScript(scriptPartitionsBiosSeedData))
 	defer cmdLsblk.Restore()
 
 	cmdPartx := testutil.MockCommand(c, "partx", "")
@@ -273,6 +274,7 @@ echo '{
 	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
 		{"lsblk", "--fs", "--json", "/dev/node1"},
 		{"lsblk", "--fs", "--json", "/dev/node2"},
+		{"lsblk", "--fs", "--json", "/dev/node3"},
 	})
 
 	err = install.RemoveCreatedPartitions(dl)
@@ -280,7 +282,7 @@ echo '{
 
 	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
 		{"sfdisk", "--json", "-d", "/dev/node"},
-		{"sfdisk", "--no-reread", "--delete", "/dev/node", "2"},
+		{"sfdisk", "--no-reread", "--delete", "/dev/node", "3"},
 		{"sfdisk", "--json", "-d", "/dev/node"},
 	})
 }

--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -82,10 +82,10 @@ type sfdiskPartition struct {
 	Name  string `json:"name"`
 }
 
-// WasCreatedDuringInstall returns if the OnDiskStructure was created during 
-// install by referencing the gadget volume. A structure is only considered to 
+// WasCreatedDuringInstall returns if the OnDiskStructure was created during
+// install by referencing the gadget volume. A structure is only considered to
 // be created during install if it is a role that is created during install and
-// the start offsets match. We specifically don't look at anything on the 
+// the start offsets match. We specifically don't look at anything on the
 // structure such as filesystem information since this may be incomplete due to
 // a failed installation, or due to the partial layout that is created by some
 // ARM tools (i.e. ptool and fastboot) when flashing images to internal MMC.

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -74,12 +74,6 @@ execute: |
         umount ./"$label"
     done
 
-    echo "Check if attribute bits were set for new partitions"
-    sfdisk -d "$LOOP" | not MATCH "${LOOP}p1.*attrs=\"GUID:59\""
-    sfdisk -d "$LOOP" | not MATCH "${LOOP}p2.*attrs=\"GUID:59\""
-    sfdisk -d "$LOOP" | MATCH "${LOOP}p3.*attrs=\"GUID:59\""
-    sfdisk -d "$LOOP" | MATCH "${LOOP}p4.*attrs=\"GUID:59\""
-
     # re-create partitions on a new install attempt
     echo "Run the snap-bootstrap again"
     uc20-create-partitions ./gadget-dir

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -61,12 +61,6 @@ execute: |
     file -s "${LOOP}p3" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-boot"'
     file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
 
-    echo "Check if attribute bits were set for new partitions"
-    sfdisk -d "$LOOP" | not MATCH "${LOOP}p1.*attrs=\"GUID:59\""
-    sfdisk -d "$LOOP" | not MATCH "${LOOP}p2.*attrs=\"GUID:59\""
-    sfdisk -d "$LOOP" | MATCH "${LOOP}p3.*attrs=\"GUID:59\""
-    sfdisk -d "$LOOP" | MATCH "${LOOP}p4.*attrs=\"GUID:59\""
-
     # re-create partitions on a new install attempt
     echo "Run the snap-bootstrap again"
     uc20-create-partitions ./gadget-dir

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -61,12 +61,6 @@ execute: |
     file -s "${LOOP}p3" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-boot"'
     file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
 
-    echo "Check if attribute bits were set for new partitions"
-    sfdisk -d "$LOOP" | not MATCH "${LOOP}p1.*attrs=\"GUID:59\""
-    sfdisk -d "$LOOP" | not MATCH "${LOOP}p2.*attrs=\"GUID:59\""
-    sfdisk -d "$LOOP" | MATCH "${LOOP}p3.*attrs=\"GUID:59\""
-    sfdisk -d "$LOOP" | MATCH "${LOOP}p4.*attrs=\"GUID:59\""
-
     echo "Check that the filesystems were not auto-mounted"
     mount | not MATCH /run/mnt/ubuntu-seed
     mount | not MATCH /run/mnt/ubuntu-boot


### PR DESCRIPTION
Usage of GPT attribute 59 technically requires ownership of the GPT Type UUID we
are using, which is just "Linux filesystem data" and not arguably owned by any
one entity.

Additionally, it is difficult to set this bit on tools traditionally used by arm
devices for flashing the image on them where all partitions are needed to be
present (even if empty) when flashing the internal memory.

As such, drop usage of the attribute and instead just perform matching based on
the offsets of structures we find in the gadget and on-disk, and if those structures 
in the gadget are "installable" roles.