### PR TITLE
tests: improve uc20-create-partitions-reinstall test

### DIFF
--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -16,6 +16,9 @@ restore: |
     if [ -f loop.txt ]; then
         losetup -d "$(cat loop.txt)"
     fi
+    umount ./ubuntu-seed || true
+    umount ./ubuntu-boot || true
+    umount ./ubuntu-data || true
 
 prepare: |
     echo "Create a fake block device image that looks like an image from u-i"
@@ -61,6 +64,16 @@ execute: |
     file -s "${LOOP}p3" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-boot"'
     file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
 
+    echo "Create canary files on the ubuntu-{seed,boot,data} partitions"
+    mkdir ./ubuntu-seed ./ubuntu-boot ./ubuntu-data
+    mount "${LOOP}p2" ./ubuntu-seed
+    mount "${LOOP}p3" ./ubuntu-boot
+    mount "${LOOP}p4" ./ubuntu-data
+    for label in ubuntu-seed ubuntu-boot ubuntu-data; do
+        echo "$label" > ./"$label"/canary.txt
+        umount ./"$label"
+    done
+
     echo "Check if attribute bits were set for new partitions"
     sfdisk -d "$LOOP" | not MATCH "${LOOP}p1.*attrs=\"GUID:59\""
     sfdisk -d "$LOOP" | not MATCH "${LOOP}p2.*attrs=\"GUID:59\""
@@ -77,3 +90,13 @@ execute: |
     sfdisk -l "$LOOP" | not MATCH "${LOOP}p[56789]"
     file -s "${LOOP}p3" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-boot"'
     file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
+
+    echo "Mount partitions again"
+    mount "${LOOP}p2" ./ubuntu-seed
+    mount "${LOOP}p3" ./ubuntu-boot
+    mount "${LOOP}p4" ./ubuntu-data
+    echo "The ubuntu-seed partition is still there untouched"
+    test -e ./ubuntu-seed/canary.txt
+    echo "But ubuntu-{boot,data} got re-created"
+    not test -e ./ubuntu-boot/canary.txt
+    not test -e ./ubuntu-data/canary.txt


### PR DESCRIPTION
This commit adds checks that the filesystem is really re-created
after running uc20-create-partitions for ubuntu-{boot,data}. It
also checks that ubuntu-seed is left intact.
