### PR TITLE
secboot: set metadata and keyslots sizes when formatting LUKS2 volumes

### DIFF
--- a/secboot/encrypt_tpm.go
+++ b/secboot/encrypt_tpm.go
@@ -29,12 +29,20 @@ var (
 	sbAddRecoveryKeyToLUKS2Container = sb.AddRecoveryKeyToLUKS2Container
 )
 
+const keyslotsAreaKiBSize = 2560 // 2.5MB
+const metadataKiBSize = 2048     // 2MB
+
 // FormatEncryptedDevice initializes an encrypted volume on the block device
-// given by node, setting the specified label. The key used to unlock the
-// volume is provided using the key argument.
+// given by node, setting the specified label. The key used to unlock the volume
+// is provided using the key argument.
 func FormatEncryptedDevice(key EncryptionKey, label, node string) error {
-	// TODO:UC20: pass options
-	return sbInitializeLUKS2Container(node, label, key[:], nil)
+	opts := &sb.InitializeLUKS2ContainerOptions{
+		// use a lower, but still reasonable size that should give us
+		// enough room
+		MetadataKiBSize:     metadataKiBSize,
+		KeyslotsAreaKiBSize: keyslotsAreaKiBSize,
+	}
+	return sbInitializeLUKS2Container(node, label, key[:], opts)
 }
 
 // AddRecoveryKey adds a fallback recovery key rkey to the existing encrypted

--- a/secboot/encrypt_tpm_test.go
+++ b/secboot/encrypt_tpm_test.go
@@ -50,7 +50,10 @@ func (s *encryptSuite) TestFormatEncryptedDevice(c *C) {
 			c.Assert(devicePath, Equals, "/dev/node")
 			c.Assert(label, Equals, "my label")
 			c.Assert(key, DeepEquals, myKey[:])
-			c.Assert(opts, IsNil)
+			c.Assert(opts, DeepEquals, &sb.InitializeLUKS2ContainerOptions{
+				MetadataKiBSize:     2048,
+				KeyslotsAreaKiBSize: 2560,
+			})
 			return tc.initErr
 		})
 		defer restore()

--- a/tests/lib/ensure_ubuntu_save.py
+++ b/tests/lib/ensure_ubuntu_save.py
@@ -36,9 +36,7 @@ def main(opts):
         "name": "ubuntu-save",
         "role": "system-save",
         # TODO:UC20: update when pc-amd64-gadget changes
-        # TODO:UC20 reduce to 16M once we pass proper configuration when
-        #           creating LUKS2 volumes
-        "size": "32M",
+        "size": "16M",
         "filesystem": "ext4",
         "type": "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
     }


### PR DESCRIPTION
Set the size of metadata and keyslots area size when formatting a new encrypted
device. We request 2MB for metadata, and 2.5MB for keyslots area. This should
give enough space for storing the required keys along with some meta, and still
have reasonable amount of space left.

This is stacked on top of #9528 
