### PR TITLE
overlord/devicestate: bind mount ubuntu-save under /var/lib/snapd/save on startup

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -187,12 +187,12 @@ func maybeSetupUbuntuSave() error {
 		return nil
 	}
 
-	logger.Noticef("mounting ubuntu-save under %v", dirs.SnapSaveDir)
+	logger.Noticef("bind-mounting ubuntu-save under %v", dirs.SnapSaveDir)
 
 	err = systemd.New(systemd.SystemMode, progress.Null).Mount(boot.InitramfsUbuntuSaveDir,
 		dirs.SnapSaveDir, "-o", "bind")
 	if err != nil {
-		logger.Noticef("mounting ubuntu-save failed %v", err)
+		logger.Noticef("bind-mounting ubuntu-save failed %v", err)
 		return fmt.Errorf("cannot bind mount %v under %v: %v", boot.InitramfsUbuntuSaveDir, dirs.SnapSaveDir, err)
 	}
 	return nil

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -144,17 +144,6 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	return m, nil
 }
 
-// StartUp implements StateStarterUp.Startup.
-func (m *DeviceManager) StartUp() error {
-	if !release.OnClassic && m.SystemMode() == "run" {
-		if err := maybeSetupUbuntuSave(); err != nil {
-			return fmt.Errorf("cannot set up ubuntu-save mount: %v", err)
-		}
-	}
-
-	return nil
-}
-
 func maybeReadModeenv() (*boot.Modeenv, error) {
 	modeEnv, err := boot.ReadModeenv("")
 	if err != nil && !os.IsNotExist(err) {
@@ -163,7 +152,22 @@ func maybeReadModeenv() (*boot.Modeenv, error) {
 	return modeEnv, nil
 }
 
+// StartUp implements StateStarterUp.Startup.
+func (m *DeviceManager) StartUp() error {
+	// system mode is explicitly set on UC20
+	// TODO:UC20: ubuntu-save needs to be mounted for recover too
+	if !release.OnClassic && m.systemMode == "run" {
+		if err := maybeSetupUbuntuSave(); err != nil {
+			return fmt.Errorf("cannot set up ubuntu-save: %v", err)
+		}
+	}
+
+	return nil
+}
+
 func maybeSetupUbuntuSave() error {
+	// only called for UC20
+
 	saveMounted, err := osutil.IsMounted(dirs.SnapSaveDir)
 	if err != nil {
 		return err

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -181,6 +181,6 @@ func (s *emulation) Mount(what, where string, options ...string) error {
 	return errNotImplemented
 }
 
-func (s *emulation) Umount(where string) error {
+func (s *emulation) Umount(whatOrWhere string) error {
 	return errNotImplemented
 }

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -176,3 +176,7 @@ func (s *emulation) Unmask(service string) error {
 	_, err := systemctlCmd("--root", s.rootDir, "unmask", service)
 	return err
 }
+
+func (s *emulation) Mount(what, where string, options ...string) error {
+	return errNotImplemented
+}

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -180,3 +180,7 @@ func (s *emulation) Unmask(service string) error {
 func (s *emulation) Mount(what, where string, options ...string) error {
 	return errNotImplemented
 }
+
+func (s *emulation) Umount(where string) error {
+	return errNotImplemented
+}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -246,6 +246,8 @@ type Systemd interface {
 	Unmask(service string) error
 	// Mount requests a mount of what under where with options.
 	Mount(what, where string, options ...string) error
+	// Umount requests a mount at where to be unmounted.
+	Umount(where string) error
 }
 
 // A Log is a single entry in the systemd journal
@@ -920,6 +922,13 @@ func (s *systemd) Mount(what, where string, options ...string) error {
 	}
 	args = append(args, what, where)
 	if output, err := exec.Command("systemd-mount", args...).CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
+}
+
+func (s *systemd) Umount(where string) error {
+	if output, err := exec.Command("systemd-mount", "--umount", where).CombinedOutput(); err != nil {
 		return osutil.OutputErr(output, err)
 	}
 	return nil

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -244,6 +244,8 @@ type Systemd interface {
 	Mask(service string) error
 	// Unmask the given service.
 	Unmask(service string) error
+	// Mount requests a mount of what under where with options.
+	Mount(what, where string, options ...string) error
 }
 
 // A Log is a single entry in the systemd journal
@@ -909,4 +911,16 @@ func (s *systemd) ReloadOrRestart(serviceName string) error {
 	}
 	_, err := s.systemctl("reload-or-restart", serviceName)
 	return err
+}
+
+func (s *systemd) Mount(what, where string, options ...string) error {
+	args := make([]string, 0, 2+len(options))
+	if len(options) > 0 {
+		args = append(args, options...)
+	}
+	args = append(args, what, where)
+	if output, err := exec.Command("systemd-mount", args...).CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -246,8 +246,8 @@ type Systemd interface {
 	Unmask(service string) error
 	// Mount requests a mount of what under where with options.
 	Mount(what, where string, options ...string) error
-	// Umount requests a mount at where to be unmounted.
-	Umount(where string) error
+	// Umount requests a mount from what or at where to be unmounted.
+	Umount(whatOrWhere string) error
 }
 
 // A Log is a single entry in the systemd journal
@@ -927,8 +927,8 @@ func (s *systemd) Mount(what, where string, options ...string) error {
 	return nil
 }
 
-func (s *systemd) Umount(where string) error {
-	if output, err := exec.Command("systemd-mount", "--umount", where).CombinedOutput(); err != nil {
+func (s *systemd) Umount(whatOrWhere string) error {
+	if output, err := exec.Command("systemd-mount", "--umount", whatOrWhere).CombinedOutput(); err != nil {
 		return osutil.OutputErr(output, err)
 	}
 	return nil

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1153,3 +1153,28 @@ func (s *SystemdTestSuite) TestMountErr(c *C) {
 		{"systemd-mount", "foo", "bar"},
 	})
 }
+
+func (s *SystemdTestSuite) TestUmountHappy(c *C) {
+	sysd := New(SystemMode, nil)
+
+	cmd := testutil.MockCommand(c, "systemd-mount", "")
+	defer cmd.Restore()
+
+	c.Assert(sysd.Umount("bar"), IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "--umount", "bar"},
+	})
+}
+
+func (s *SystemdTestSuite) TestUmountErr(c *C) {
+	sysd := New(SystemMode, nil)
+
+	cmd := testutil.MockCommand(c, "systemd-mount", `echo "failed"; exit 111`)
+	defer cmd.Restore()
+
+	err := sysd.Umount("bar")
+	c.Assert(err, ErrorMatches, "failed")
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "--umount", "bar"},
+	})
+}

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1123,3 +1123,33 @@ func (s *SystemdTestSuite) TestUnmaskInEmulationMode(c *C) {
 	c.Check(s.argses, DeepEquals, [][]string{
 		{"--root", "/path", "unmask", "foo"}})
 }
+
+func (s *SystemdTestSuite) TestMountHappy(c *C) {
+	sysd := New(SystemMode, nil)
+
+	cmd := testutil.MockCommand(c, "systemd-mount", "")
+	defer cmd.Restore()
+
+	c.Assert(sysd.Mount("foo", "bar"), IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "foo", "bar"},
+	})
+	cmd.ForgetCalls()
+	c.Assert(sysd.Mount("foo", "bar", "-o", "bind"), IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "-o", "bind", "foo", "bar"},
+	})
+}
+
+func (s *SystemdTestSuite) TestMountErr(c *C) {
+	sysd := New(SystemMode, nil)
+
+	cmd := testutil.MockCommand(c, "systemd-mount", `echo "failed"; exit 111`)
+	defer cmd.Restore()
+
+	err := sysd.Mount("foo", "bar")
+	c.Assert(err, ErrorMatches, "failed")
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "foo", "bar"},
+	})
+}


### PR DESCRIPTION
The branch does a bind mount of /run/mnt/ubuntu-save under /var/lib/snapd/save on startup, if the former exists.
