### PR TITLE
boot: store the TPM{PolicyAuthKey,LockoutAuth}File in ubuntu-save

### DIFF
--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -86,7 +86,7 @@ func setInitramfsDirVars(rootdir string) {
 	InitramfsUbuntuSaveDir = filepath.Join(InitramfsRunMntDir, "ubuntu-save")
 	InstallHostWritableDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data", "system-data")
 	InstallHostFDEDataDir = dirs.SnapFDEDirUnder(InstallHostWritableDir)
-	InstallHostFDESaveDir = filepath.Join(dirs.SnapSaveDirUnder(InstallHostWritableDir), "device", "fde")
+	InstallHostFDESaveDir = filepath.Join(InitramfsUbuntuSaveDir, "device/fde")
 	InitramfsWritableDir = filepath.Join(InitramfsDataDir, "system-data")
 	InitramfsEncryptionKeyDir = filepath.Join(InitramfsUbuntuSeedDir, "device/fde")
 }

--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -67,6 +67,10 @@ var (
 	// InstallHostFDEDataDir is the location of the FDE data during install mode.
 	InstallHostFDEDataDir string
 
+	// InstallHostSaveDir is the directory of the FDE data on the
+	// ubuntu-save partition.
+	InstallHostFDESaveDir string
+
 	// InitramfsEncryptionKeyDir is the location of the encrypted partition keys
 	// during the initramfs.
 	InitramfsEncryptionKeyDir string
@@ -82,6 +86,7 @@ func setInitramfsDirVars(rootdir string) {
 	InitramfsUbuntuSaveDir = filepath.Join(InitramfsRunMntDir, "ubuntu-save")
 	InstallHostWritableDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data", "system-data")
 	InstallHostFDEDataDir = dirs.SnapFDEDirUnder(InstallHostWritableDir)
+	InstallHostFDESaveDir = filepath.Join(dirs.SnapSaveDirUnder(InstallHostWritableDir), "device", "fde")
 	InitramfsWritableDir = filepath.Join(InitramfsDataDir, "system-data")
 	InitramfsEncryptionKeyDir = filepath.Join(InitramfsUbuntuSeedDir, "device/fde")
 }

--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -68,7 +68,8 @@ var (
 	InstallHostFDEDataDir string
 
 	// InstallHostSaveDir is the directory of the FDE data on the
-	// ubuntu-save partition.
+	// ubuntu-save partition during install mode. For other modes,
+	// use dirs.SnapSaveFDEDirUnder().
 	InstallHostFDESaveDir string
 
 	// InitramfsEncryptionKeyDir is the location of the encrypted partition keys

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -101,7 +101,8 @@ func sealKeyToModeenv(key secboot.EncryptionKey, model *asserts.Model, modeenv *
 		return fmt.Errorf("cannot prepare for key sealing: %v", err)
 	}
 	// make sure relevant locations exist
-	for _, p := range []string{InitramfsEncryptionKeyDir, InstallHostFDEDataDir} {
+	for _, p := range []string{InitramfsEncryptionKeyDir, InstallHostFDEDataDir, InstallHostFDESaveDir} {
+		// XXX: should that be 0700 ?
 		if err := os.MkdirAll(p, 0755); err != nil {
 			return err
 		}
@@ -109,8 +110,8 @@ func sealKeyToModeenv(key secboot.EncryptionKey, model *asserts.Model, modeenv *
 	sealKeyParams := &secboot.SealKeyParams{
 		ModelParams:          modelParams,
 		KeyFile:              filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
-		TPMPolicyAuthKeyFile: filepath.Join(InstallHostFDEDataDir, "tpm-policy-auth-key"),
-		TPMLockoutAuthFile:   filepath.Join(InstallHostFDEDataDir, "tpm-lockout-auth"),
+		TPMPolicyAuthKeyFile: filepath.Join(InstallHostFDESaveDir, "tpm-policy-auth-key"),
+		TPMLockoutAuthFile:   filepath.Join(InstallHostFDESaveDir, "tpm-lockout-auth"),
 	}
 	// finally, seal the key
 	if err := secbootSealKey(key, sealKeyParams); err != nil {
@@ -219,7 +220,7 @@ func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, 
 	resealKeyParams := &secboot.ResealKeyParams{
 		ModelParams:          modelParams,
 		KeyFile:              filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
-		TPMPolicyAuthKeyFile: filepath.Join(dirs.SnapFDEDirUnder(rootdir), "tpm-policy-auth-key"),
+		TPMPolicyAuthKeyFile: filepath.Join(dirs.SnapSaveDirUnder(rootdir), "device/fde/tpm-policy-auth-key"),
 	}
 	if err := secbootResealKey(resealKeyParams); err != nil {
 		return fmt.Errorf("cannot reseal the encryption key: %v", err)

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -220,7 +220,7 @@ func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, 
 	resealKeyParams := &secboot.ResealKeyParams{
 		ModelParams:          modelParams,
 		KeyFile:              filepath.Join(InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key"),
-		TPMPolicyAuthKeyFile: filepath.Join(dirs.SnapSaveDirUnder(rootdir), "device/fde/tpm-policy-auth-key"),
+		TPMPolicyAuthKeyFile: filepath.Join(dirs.SnapSaveFDEDirUnder(rootdir), "tpm-policy-auth-key"),
 	}
 	if err := secbootResealKey(resealKeyParams); err != nil {
 		return fmt.Errorf("cannot reseal the encryption key: %v", err)

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -275,6 +275,12 @@ func SnapSaveDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "save")
 }
 
+// SnapSaveFDEDirUnder returns the path to full disk encryption state directory
+// inside save under rootdir.
+func SnapSaveFDEDirUnder(rootdir string) string {
+	return filepath.Join(SnapSaveDirUnder(rootdir), "device/fde")
+}
+
 // AddRootDirCallback registers a callback for whenever the global root
 // directory (set by SetRootDir) is changed to enable updates to variables in
 // other packages that depend on its location.

--- a/tests/nested/core20/tpm/task.yaml
+++ b/tests/nested/core20/tpm/task.yaml
@@ -21,6 +21,10 @@ execute: |
     echo "and has the expected owner and permissions"
     nested_exec "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$'
 
+    echo "and the tpm-{policy-auth-key,lockout-auth} files are in ubuntu-save"
+    nested_exec "test -e /var/lib/snapd/save/device/fde/tpm-policy-auth-key"
+    nested_exec "test -e /var/lib/snapd/save/device/fde/tpm-lockout-auth"
+
     # grab modeenv content
     nested_exec "cat /var/lib/snapd/modeenv" > modeenv
     # and checksums


### PR DESCRIPTION
This commit changes the location of the
TPM{PolicyAuthKey,LockoutAuth}File files to go into the
/var/lib/snapd/save directory.

Systems with a ubuntu-save partition will have this partition
bind mounted at this location.

