### PR TITLE
interfaces,snap: use correct type: {os,snapd} for test data

### DIFF
--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -100,6 +100,7 @@ apps:
 `
 
 const bluezCoreYaml = `name: core
+type: os
 version: 0
 slots:
   bluez:

--- a/interfaces/builtin/network_manager_observe_test.go
+++ b/interfaces/builtin/network_manager_observe_test.go
@@ -59,6 +59,7 @@ apps:
 `
 
 const networkManagerObserveCoreYaml = `name: core
+type: os
 version: 0
 slots:
   network-manager-observe:

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -131,6 +131,13 @@ func MockInfo(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	defer restoreSanitize()
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(yamlText))
 	c.Assert(err, check.IsNil)
+	if snapInfo.InstanceName() == "core" && snapInfo.Type() != snap.TypeOS {
+		panic("core snap must use type: os")
+	}
+	if snapInfo.InstanceName() == "snapd" && snapInfo.Type() != snap.TypeSnapd {
+		panic("snapd snap must use type: snapd")
+	}
+
 	snapInfo.SideInfo = *sideInfo
 	err = snap.Validate(snapInfo)
 	c.Assert(err, check.IsNil)

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -153,6 +153,7 @@ func (s *snapTestSuite) TestMockInvalidInfo(c *C) {
 
 func (s *snapTestSuite) TestRenameSlot(c *C) {
 	snapInfo := snaptest.MockInfo(c, `name: core
+type: os
 version: 0
 slots:
   old:


### PR DESCRIPTION
While working on something else I've noticed some test data has
incorrect snap type. This patch fixes all instances and adds
panics in test helpers, to ensure this doesn't happen again.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
