### PR TITLE
gadget/internal: tune ext4 setting for smaller filesystems

### DIFF
--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -42,7 +42,7 @@ func init() {
 func makeFilesystem(ds *gadget.OnDiskStructure) error {
 	if ds.HasFilesystem() {
 		logger.Debugf("create %s filesystem on %s with label %q", ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label)
-		if err := internal.Mkfs(ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label); err != nil {
+		if err := internal.Mkfs(ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label, uint64(ds.Size)); err != nil {
 			return err
 		}
 		if err := udevTrigger(ds.Node); err != nil {

--- a/gadget/internal/mkfs.go
+++ b/gadget/internal/mkfs.go
@@ -61,11 +61,7 @@ func mkfsExt4(img, label, contentsRootDir string) error {
 	// Switched to use mkfs defaults for https://bugs.launchpad.net/snappy/+bug/1878374
 	// For caveats/requirements in case we need support for older systems:
 	// https://github.com/snapcore/snapd/pull/6997#discussion_r293967140
-	mkfsArgs := []string{
-		"mkfs.ext4",
-		// default usage type
-		"-T", "default",
-	}
+	mkfsArgs := []string{"mkfs.ext4"}
 	if contentsRootDir != "" {
 		// mkfs.ext4 can populate the filesystem with contents of given
 		// root directory

--- a/gadget/internal/mkfs.go
+++ b/gadget/internal/mkfs.go
@@ -29,7 +29,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-type MkfsFunc func(imgFile, label, contentsRootDir string) error
+type MkfsFunc func(imgFile, label, contentsRootDir string, deviceSize uint64) error
 
 var (
 	mkfsHandlers = map[string]MkfsFunc{
@@ -38,30 +38,44 @@ var (
 	}
 )
 
-// Mkfs creates a filesystem of given type and provided label in the device or file.
-func Mkfs(typ, img, label string) error {
-	return MkfsWithContent(typ, img, label, "")
+// Mkfs creates a filesystem of given type and provided label in the device or
+// file. The device size provides hints for additional tuning of the created
+// filesystem.
+func Mkfs(typ, img, label string, deviceSize uint64) error {
+	return MkfsWithContent(typ, img, label, "", deviceSize)
 }
 
-// Mkfs creates a filesystem of given type and provided label in the device or file.
-// The filesystem is populated with contents of contentRootDir.
-func MkfsWithContent(typ, img, label, contentRootDir string) error {
+// Mkfs creates a filesystem of given type and provided label in the device or
+// file. The filesystem is populated with contents of contentRootDir. The device
+// size provides hints for additional tuning of the created filesystem.
+func MkfsWithContent(typ, img, label, contentRootDir string, deviceSize uint64) error {
 	h, ok := mkfsHandlers[typ]
 	if !ok {
 		return fmt.Errorf("cannot create unsupported filesystem %q", typ)
 	}
-	return h(img, label, contentRootDir)
+	return h(img, label, contentRootDir, deviceSize)
 }
 
 // mkfsExt4 creates an EXT4 filesystem in given image file, with an optional
 // filesystem label, and populates it with the contents of provided root
 // directory.
-func mkfsExt4(img, label, contentsRootDir string) error {
+func mkfsExt4(img, label, contentsRootDir string, deviceSize uint64) error {
 	// Originally taken from ubuntu-image
 	// Switched to use mkfs defaults for https://bugs.launchpad.net/snappy/+bug/1878374
 	// For caveats/requirements in case we need support for older systems:
 	// https://github.com/snapcore/snapd/pull/6997#discussion_r293967140
 	mkfsArgs := []string{"mkfs.ext4"}
+	const size32MiB = 32 * 1024 * 1024
+	if deviceSize != 0 && deviceSize <= size32MiB {
+		// With the default of 4096 bytes, the minimal journal size is
+		// 4M, meaning we loose a lot of usable space. Try to follow the
+		// e2fsprogs upstream and use a 1k block size for smaller
+		// filesystems, note that this may cause issues like
+		// https://bugs.launchpad.net/ubuntu/+source/lvm2/+bug/1817097
+		// if one migrates the filesystem to a device with a different
+		// block size
+		mkfsArgs = append(mkfsArgs, "-b", "1024")
+	}
 	if contentsRootDir != "" {
 		// mkfs.ext4 can populate the filesystem with contents of given
 		// root directory
@@ -91,7 +105,7 @@ func mkfsExt4(img, label, contentsRootDir string) error {
 // mkfsVfat creates a VFAT filesystem in given image file, with an optional
 // filesystem label, and populates it with the contents of provided root
 // directory.
-func mkfsVfat(img, label, contentsRootDir string) error {
+func mkfsVfat(img, label, contentsRootDir string, deviceSize uint64) error {
 	// taken from ubuntu-image
 	mkfsArgs := []string{
 		// 512B logical sector size

--- a/gadget/internal/mkfs_test.go
+++ b/gadget/internal/mkfs_test.go
@@ -69,7 +69,6 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-T", "default",
 			"-d", "contents",
 			"-L", "my-label",
 			"foo.img",
@@ -85,7 +84,6 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-T", "default",
 			"-d", "contents",
 			"foo.img",
 		},
@@ -100,7 +98,6 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-T", "default",
 			"-L", "my-label",
 			"foo.img",
 		},

--- a/gadget/internal/mkfs_test.go
+++ b/gadget/internal/mkfs_test.go
@@ -63,7 +63,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd := testutil.MockCommand(c, "fakeroot", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents")
+	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -78,7 +78,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd.ForgetCalls()
 
 	// empty label
-	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents")
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -92,7 +92,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd.ForgetCalls()
 
 	// no content
-	err = internal.Mkfs("ext4", "foo.img", "my-label")
+	err = internal.Mkfs("ext4", "foo.img", "my-label", 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -105,11 +105,45 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 
 }
 
+func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
+	cmd := testutil.MockCommand(c, "fakeroot", "")
+	defer cmd.Restore()
+
+	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 250*1024*1024)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-d", "contents",
+			"-L", "my-label",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
+	// empty label
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 32*1024*1024)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-b", "1024",
+			"-d", "contents",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+}
+
 func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
 	cmd := testutil.MockCommand(c, "fakeroot", "echo 'command failed'; exit 1")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents")
+	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0)
 	c.Assert(err, ErrorMatches, "command failed")
 }
 
@@ -120,7 +154,7 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -136,7 +170,7 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd.ForgetCalls()
 
 	// empty label
-	err = internal.MkfsWithContent("vfat", "foo.img", "", d)
+	err = internal.MkfsWithContent("vfat", "foo.img", "", d, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -151,7 +185,27 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd.ForgetCalls()
 
 	// no content
-	err = internal.Mkfs("vfat", "foo.img", "my-label")
+	err = internal.Mkfs("vfat", "foo.img", "my-label", 0)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"mkfs.vfat",
+			"-S", "512",
+			"-s", "1",
+			"-F", "32",
+			"-n", "my-label",
+			"foo.img",
+		},
+	})
+}
+
+func (m *mkfsSuite) TestMkfsVfatWithSize(c *C) {
+	d := c.MkDir()
+
+	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
+	defer cmd.Restore()
+
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 32*1024*1024)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -176,7 +230,7 @@ func (m *mkfsSuite) TestMkfsVfatHappyContents(c *C) {
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "")
 	defer cmdMcopy.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 
@@ -191,7 +245,7 @@ func (m *mkfsSuite) TestMkfsVfatErrorSimpleFail(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "echo 'failed'; false")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
 	c.Assert(err, ErrorMatches, "failed")
 }
 
@@ -199,7 +253,7 @@ func (m *mkfsSuite) TestMkfsVfatErrorUnreadableDir(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "dir-does-not-exist")
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "dir-does-not-exist", 0)
 	c.Assert(err, ErrorMatches, "cannot list directory contents: .* no such file or directory")
 	c.Assert(cmd.Calls(), HasLen, 1)
 }
@@ -214,7 +268,7 @@ func (m *mkfsSuite) TestMkfsVfatErrorInMcopy(c *C) {
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "echo 'hard fail'; exit 1")
 	defer cmdMcopy.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
 	c.Assert(err, ErrorMatches, "cannot populate vfat filesystem with contents: hard fail")
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 	c.Assert(cmdMcopy.Calls(), HasLen, 1)
@@ -227,7 +281,7 @@ func (m *mkfsSuite) TestMkfsVfatHappyNoContents(c *C) {
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "")
 	defer cmdMcopy.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "")
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "", 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 	// mcopy was not called
@@ -235,10 +289,10 @@ func (m *mkfsSuite) TestMkfsVfatHappyNoContents(c *C) {
 }
 
 func (m *mkfsSuite) TestMkfsInvalidFs(c *C) {
-	err := internal.MkfsWithContent("no-fs", "foo.img", "my-label", "")
+	err := internal.MkfsWithContent("no-fs", "foo.img", "my-label", "", 0)
 	c.Assert(err, ErrorMatches, `cannot create unsupported filesystem "no-fs"`)
 
-	err = internal.Mkfs("no-fs", "foo.img", "my-label")
+	err = internal.Mkfs("no-fs", "foo.img", "my-label", 0)
 	c.Assert(err, ErrorMatches, `cannot create unsupported filesystem "no-fs"`)
 }
 


### PR DESCRIPTION
The mkfs.ext4 use the heuristic for choosing the best setup. It should check the
block device size and choose and appropriate setting from /etc/mke2fs.conf (or
the built-in copy if the file is missing).

In the particular case of ubuntu-save, it will choose the 'small' profile, which
should give us more free space on the device.

