### PR TITLE
tests: re-enable the apt hooks test

### DIFF
--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -3,8 +3,6 @@ summary: Ensure apt hooks work
 # apt hook only available on 18.04+ and aws-cli only for amd64
 systems: [ubuntu-18.04-64, ubuntu-2*-64]
 
-manual: true
-
 debug: |
     ls -lh /var/cache/snapd
     # low tech dump of db


### PR DESCRIPTION
First test re-enabled, at some point, it was set as a manual but seems to be working well now again. 

It was disabled in nov-2019 (no details why, just saying that it was failing constantly).