### PR TITLE
o/devicetate,dirs: keep device keys in ubuntu-save/save for UC20

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -104,6 +104,7 @@ var (
 	SnapBootAssetsDir string
 	SnapFDEDir        string
 	SnapSaveDir       string
+	SnapDeviceSaveDir string
 
 	CloudMetaDataFile     string
 	CloudInstanceDataFile string
@@ -356,6 +357,7 @@ func SetRootDir(rootdir string) {
 	SnapBootAssetsDir = SnapBootAssetsDirUnder(rootdir)
 	SnapFDEDir = SnapFDEDirUnder(rootdir)
 	SnapSaveDir = SnapSaveDirUnder(rootdir)
+	SnapDeviceSaveDir = filepath.Join(SnapSaveDir, "device")
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")
 	SnapRepairStateFile = filepath.Join(SnapRepairDir, "repair.json")

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -178,8 +178,6 @@ func (m *DeviceManager) maybeSetupUbuntuSave() error {
 		return nil
 	}
 
-	m.saveAvailable = osutil.IsDirectory(dirs.SnapSaveDir)
-
 	runMntSaveMounted, err := osutil.IsMounted(boot.InitramfsUbuntuSaveDir)
 	if err != nil {
 		return err

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -60,9 +60,15 @@ var (
 // policies.
 type DeviceManager struct {
 	systemMode string
+	// saveAvailable keeps track whether /var/lib/snapd/save
+	// is available, i.e. exists and is mounted from ubuntu-save
+	// if the latter exists.
+	// TODO: it must be set to false if ubuntu-save is unmounted.
+	saveAvailable bool
 
-	state      *state.State
-	keypairMgr asserts.KeypairManager
+	state *state.State
+
+	cachedKeypairMgr asserts.KeypairManager
 
 	// newStore can make new stores for remodeling
 	newStore func(storecontext.DeviceBackend) snapstate.StoreService
@@ -90,17 +96,11 @@ type DeviceManager struct {
 func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.TaskRunner, newStore func(storecontext.DeviceBackend) snapstate.StoreService) (*DeviceManager, error) {
 	delayedCrossMgrInit()
 
-	keypairMgr, err := asserts.OpenFSKeypairManager(dirs.SnapDeviceDir)
-	if err != nil {
-		return nil, err
-	}
-
 	m := &DeviceManager{
-		state:      s,
-		keypairMgr: keypairMgr,
-		newStore:   newStore,
-		reg:        make(chan struct{}),
-		preseed:    snapdenv.Preseeding(),
+		state:    s,
+		newStore: newStore,
+		reg:      make(chan struct{}),
+		preseed:  snapdenv.Preseeding(),
 	}
 
 	modeEnv, err := maybeReadModeenv()
@@ -157,7 +157,7 @@ func (m *DeviceManager) StartUp() error {
 	// system mode is explicitly set on UC20
 	// TODO:UC20: ubuntu-save needs to be mounted for recover too
 	if !release.OnClassic && m.systemMode == "run" {
-		if err := maybeSetupUbuntuSave(); err != nil {
+		if err := m.maybeSetupUbuntuSave(); err != nil {
 			return fmt.Errorf("cannot set up ubuntu-save: %v", err)
 		}
 	}
@@ -165,7 +165,7 @@ func (m *DeviceManager) StartUp() error {
 	return nil
 }
 
-func maybeSetupUbuntuSave() error {
+func (m *DeviceManager) maybeSetupUbuntuSave() error {
 	// only called for UC20
 
 	saveMounted, err := osutil.IsMounted(dirs.SnapSaveDir)
@@ -174,16 +174,20 @@ func maybeSetupUbuntuSave() error {
 	}
 	if saveMounted {
 		logger.Noticef("save already mounted under %v", dirs.SnapSaveDir)
+		m.saveAvailable = true
 		return nil
 	}
+
+	m.saveAvailable = osutil.IsDirectory(dirs.SnapSaveDir)
 
 	runMntSaveMounted, err := osutil.IsMounted(boot.InitramfsUbuntuSaveDir)
 	if err != nil {
 		return err
 	}
 	if !runMntSaveMounted {
-		// we don't have ubuntu-save
+		// we don't have ubuntu-save, save will be used directly
 		logger.Noticef("no ubuntu-save mount")
+		m.saveAvailable = true
 		return nil
 	}
 
@@ -195,6 +199,7 @@ func maybeSetupUbuntuSave() error {
 		logger.Noticef("mounting ubuntu-save failed %v", err)
 		return fmt.Errorf("cannot bind mount %v under %v: %v", boot.InitramfsUbuntuSaveDir, dirs.SnapSaveDir, err)
 	}
+	m.saveAvailable = true
 	return nil
 }
 
@@ -954,6 +959,50 @@ func (m *DeviceManager) Ensure() error {
 	return nil
 }
 
+// withKeypairMgr invokes a function making the device KeypairManager
+// available to it.
+// It uses the right location for the manager depending on UC16/18 vs 20,
+// the latter uses ubuntu-save.
+// For UC20 it also checks that ubuntu-save is mounted.
+func (m *DeviceManager) withKeypairMgr(f func(asserts.KeypairManager) error) error {
+	// we use the model to check whether this is a UC20 device
+	// TODO: during a theoretical UC18->20 remodel the location of
+	// keypair manager keys would move, we will need dedicated code
+	// to deal with that, this code typically will return the old location
+	// until a restart
+	model, err := m.Model()
+	if err == state.ErrNoState {
+		return fmt.Errorf("internal error: cannot access device keypair manager before a model is set")
+	}
+	if err != nil {
+		return err
+	}
+	underSave := false
+	if model.Grade() != asserts.ModelGradeUnset {
+		// on UC20 the keys are kept under the save dir
+		underSave = true
+	}
+	where := dirs.SnapDeviceDir
+	if underSave {
+		// check for availability in case save gets mounted/unmounted,
+		// it's responsibility of the caller to have it mounted
+		if !m.saveAvailable {
+			return fmt.Errorf("internal error: cannot access device keypair manager if ubuntu-save is unavailable")
+		}
+		where = dirs.SnapDeviceSaveDir
+	}
+	keypairMgr := m.cachedKeypairMgr
+	if keypairMgr == nil {
+		var err error
+		keypairMgr, err = asserts.OpenFSKeypairManager(where)
+		if err != nil {
+			return err
+		}
+		m.cachedKeypairMgr = keypairMgr
+	}
+	return f(keypairMgr)
+}
+
 func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
 	device, err := m.device()
 	if err != nil {
@@ -964,9 +1013,16 @@ func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
 		return nil, state.ErrNoState
 	}
 
-	privKey, err := m.keypairMgr.Get(device.KeyID)
+	var privKey asserts.PrivateKey
+	err = m.withKeypairMgr(func(keypairMgr asserts.KeypairManager) (err error) {
+		privKey, err = keypairMgr.Get(device.KeyID)
+		if err != nil {
+			return fmt.Errorf("cannot read device key pair: %v", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot read device key pair: %v", err)
+		return nil, err
 	}
 	return privKey, nil
 }

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
@@ -1944,10 +1943,6 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationUC20Happy(c *C) {
 
 	devicestatetest.MockGadget(c, s.state, "pc", snap.R(2), nil)
 	// mark it as seeded
-	modeenv := boot.Modeenv{
-		Mode: "run",
-	}
-	err := modeenv.WriteTo("")
 	s.state.Set("seeded", true)
 	// skip boot ok logic
 	devicestate.SetBootOkRan(s.mgr, true)

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -34,8 +35,11 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -47,8 +51,10 @@ import (
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var testKeyLength = 1024
@@ -67,7 +73,7 @@ func (s *deviceMgrSerialSuite) signSerial(c *C, bhv *devicestatetest.DeviceServi
 	var signing assertstest.SignerDB = s.storeSigning
 
 	switch model {
-	case "pc", "pc2":
+	case "pc", "pc2", "pc-20":
 		fallthrough
 	case "classic-alt-store":
 		c.Check(brandID, Equals, "canonical")
@@ -189,6 +195,9 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappy(c *C) {
 	c.Check(privKey, NotNil)
 
 	c.Check(device.KeyID, Equals, privKey.PublicKey().ID())
+
+	// check that keypair manager is under device
+	c.Check(osutil.IsDirectory(filepath.Join(dirs.SnapDeviceDir, "private-keys-v1")), Equals, true)
 }
 
 func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyWithProxy(c *C) {
@@ -697,6 +706,12 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialErrorsOnNoHost(c *C) {
 	// setup state as done by first-boot/Ensure/doGenerateDeviceKey
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+	})
 
 	devicestatetest.MockGadget(c, s.state, "gadget", snap.R(2), nil)
 
@@ -1468,6 +1483,17 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendDeviceSessionRequestParams
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	// set model as seeding would
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+	})
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc",
+	})
+
 	scb := s.mgr.StoreContextBackend()
 
 	// nothing there
@@ -1866,4 +1892,107 @@ func (s *deviceMgrSerialSuite) TestDeviceRegistrationNotInInstallMode(c *C) {
 	defer st.Unlock()
 	becomeOperational := s.findBecomeOperationalChange()
 	c.Assert(becomeOperational, IsNil)
+}
+
+func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationUC20Happy(c *C) {
+	r1 := devicestate.MockKeyLength(testKeyLength)
+	defer r1()
+
+	mockServer := s.mockServer(c, "REQID-1", nil)
+	defer mockServer.Close()
+
+	r2 := devicestate.MockBaseStoreURL(mockServer.URL)
+	defer r2()
+
+	// setup state as will be done by first-boot
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+		"architecture": "amd64",
+		// UC20
+		"base": "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              snaptest.AssertedSnapID("oc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              snaptest.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+		},
+	})
+
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-20",
+	})
+
+	// save is available
+	devicestate.SetSaveAvailable(s.mgr, true)
+
+	// avoid full seeding
+	s.seeding()
+
+	becomeOperational := s.findBecomeOperationalChange()
+	c.Check(becomeOperational, IsNil)
+
+	devicestatetest.MockGadget(c, s.state, "pc", snap.R(2), nil)
+	// mark it as seeded
+	modeenv := boot.Modeenv{
+		Mode: "run",
+	}
+	err := modeenv.WriteTo("")
+	s.state.Set("seeded", true)
+	// skip boot ok logic
+	devicestate.SetBootOkRan(s.mgr, true)
+
+	// runs the whole device registration process
+	s.state.Unlock()
+	s.settle(c)
+	s.state.Lock()
+
+	becomeOperational = s.findBecomeOperationalChange()
+	c.Assert(becomeOperational, NotNil)
+
+	c.Check(becomeOperational.Status().Ready(), Equals, true)
+	c.Check(becomeOperational.Err(), IsNil)
+
+	device, err := devicestatetest.Device(s.state)
+	c.Assert(err, IsNil)
+	c.Check(device.Brand, Equals, "canonical")
+	c.Check(device.Model, Equals, "pc-20")
+	c.Check(device.Serial, Equals, "9999")
+
+	ok := false
+	select {
+	case <-s.mgr.Registered():
+		ok = true
+	case <-time.After(5 * time.Second):
+		c.Fatal("should have been marked registered")
+	}
+	c.Check(ok, Equals, true)
+
+	a, err := s.db.Find(asserts.SerialType, map[string]string{
+		"brand-id": "canonical",
+		"model":    "pc-20",
+		"serial":   "9999",
+	})
+	c.Assert(err, IsNil)
+	serial := a.(*asserts.Serial)
+
+	privKey, err := devicestate.KeypairManager(s.mgr).Get(serial.DeviceKey().ID())
+	c.Assert(err, IsNil)
+	c.Check(privKey, NotNil)
+
+	c.Check(device.KeyID, Equals, privKey.PublicKey().ID())
+
+	// check that keypair manager is under save
+	c.Check(osutil.IsDirectory(filepath.Join(dirs.SnapDeviceSaveDir, "private-keys-v1")), Equals, true)
+	c.Check(filepath.Join(dirs.SnapDeviceDir, "private-keys-v1"), testutil.FileAbsent)
 }

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -132,7 +132,11 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
-	os.MkdirAll(dirs.SnapRunDir, 0755)
+
+	err := os.MkdirAll(dirs.SnapRunDir, 0755)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(dirs.SnapdStateDir(dirs.GlobalRootDir), 0755)
+	c.Assert(err, IsNil)
 
 	s.AddCleanup(osutil.MockMountInfo(``))
 
@@ -1163,6 +1167,9 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveFullHappy(c *C) {
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{"systemd-mount", "-o", "bind", boot.InitramfsUbuntuSaveDir, dirs.SnapSaveDir},
 	})
+
+	// known as available
+	c.Check(devicestate.SaveAvailable(mgr), Equals, true)
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveAlreadyMounted(c *C) {
@@ -1183,6 +1190,9 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveAlreadyMounted(c 
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), HasLen, 0)
+
+	// known as available
+	c.Check(devicestate.SaveAvailable(mgr), Equals, true)
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerStartupUC20NoUbuntuSave(c *C) {
@@ -1199,6 +1209,9 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20NoUbuntuSave(c *C) {
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), HasLen, 0)
+
+	// known as available
+	c.Check(devicestate.SaveAvailable(mgr), Equals, true)
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveErr(c *C) {
@@ -1219,6 +1232,9 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveErr(c *C) {
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{"systemd-mount", "-o", "bind", boot.InitramfsUbuntuSaveDir, dirs.SnapSaveDir},
 	})
+
+	// known as not available
+	c.Check(devicestate.SaveAvailable(mgr), Equals, false)
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerStartupNonUC20NoUbuntuSave(c *C) {
@@ -1234,6 +1250,9 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupNonUC20NoUbuntuSave(c *C) {
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), HasLen, 0)
+
+	// known as not available
+	c.Check(devicestate.SaveAvailable(mgr), Equals, false)
 }
 
 type startOfOperationTimeSuite struct {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -80,8 +80,24 @@ func MockTimeNow(f func() time.Time) (restore func()) {
 	}
 }
 
-func KeypairManager(m *DeviceManager) asserts.KeypairManager {
-	return m.keypairMgr
+func KeypairManager(m *DeviceManager) (keypairMgr asserts.KeypairManager) {
+	// XXX expose the with... method at some point
+	err := m.withKeypairMgr(func(km asserts.KeypairManager) error {
+		keypairMgr = km
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	return keypairMgr
+}
+
+func SaveAvailable(m *DeviceManager) bool {
+	return m.saveAvailable
+}
+
+func SetSaveAvailable(m *DeviceManager, avail bool) {
+	m.saveAvailable = avail
 }
 
 func EnsureOperationalShouldBackoff(m *DeviceManager, now time.Time) bool {

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -106,7 +106,9 @@ func (m *DeviceManager) doGenerateDeviceKey(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	privKey := asserts.RSAPrivateKey(keyPair)
-	err = m.keypairMgr.Put(privKey)
+	err = m.withKeypairMgr(func(keypairMgr asserts.KeypairManager) error {
+		return keypairMgr.Put(privKey)
+	})
 	if err != nil {
 		return fmt.Errorf("cannot store device key pair: %v", err)
 	}


### PR DESCRIPTION
This makes creation and access to the device keypair manager lazy.

Also some initial care to allow later to mount/unmount save as needed.
