### PR TITLE
testutil, cmd/snap/version: fix misc little errors

### DIFF
--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -48,8 +48,7 @@ func (cmd cmdVersion) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	printVersions(cmd.client)
-	return nil
+	return printVersions(cmd.client)
 }
 
 func printVersions(cli *client.Client) error {

--- a/testutil/containschecker_test.go
+++ b/testutil/containschecker_test.go
@@ -137,7 +137,7 @@ type myStruct struct {
 }
 
 func (*containsCheckerSuite) TestContainsUncomparableType(c *check.C) {
-	if runtime.Compiler != "go" {
+	if runtime.Compiler != "gc" {
 		c.Skip("this test only works on go (not gccgo)")
 	}
 


### PR DESCRIPTION
When not using ggcgo, the value of runtime.Compiler is "gc" not "go".

We should return the error from printVersion in cmdVersion.Execute() too.

Thanks to @niemeyer for spotting both of these.