### PR TITLE
[RFC] snap-bootstrap: be more robust for recover mode, ignore some errors

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -510,6 +510,10 @@ func maybeMountSave(disk disks.Disk, rootdir string, encrypted bool, mountOpts *
 }
 
 func generateMountsModeRun(mst *initramfsMountsState) error {
+
+	// TODO:UC20: some of the error conditions here should trigger an automatic
+	// transition to recover mode, we need to figure out which ones
+
 	// 1. mount ubuntu-boot
 	if err := mountPartitionMatchingKernelDisk(boot.InitramfsUbuntuBootDir, "ubuntu-boot"); err != nil {
 		return err

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -187,12 +187,12 @@ func maybeSetupUbuntuSave() error {
 		return nil
 	}
 
-	logger.Noticef("mounting ubuntu-save under %v", dirs.SnapSaveDir)
+	logger.Noticef("bind-mounting ubuntu-save under %v", dirs.SnapSaveDir)
 
 	err = systemd.New(systemd.SystemMode, progress.Null).Mount(boot.InitramfsUbuntuSaveDir,
 		dirs.SnapSaveDir, "-o", "bind")
 	if err != nil {
-		logger.Noticef("mounting ubuntu-save failed %v", err)
+		logger.Noticef("bind-mounting ubuntu-save failed %v", err)
 		return fmt.Errorf("cannot bind mount %v under %v: %v", boot.InitramfsUbuntuSaveDir, dirs.SnapSaveDir, err)
 	}
 	return nil

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -144,17 +144,6 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	return m, nil
 }
 
-// StartUp implements StateStarterUp.Startup.
-func (m *DeviceManager) StartUp() error {
-	if !release.OnClassic && m.SystemMode() == "run" {
-		if err := maybeSetupUbuntuSave(); err != nil {
-			return fmt.Errorf("cannot set up ubuntu-save mount: %v", err)
-		}
-	}
-
-	return nil
-}
-
 func maybeReadModeenv() (*boot.Modeenv, error) {
 	modeEnv, err := boot.ReadModeenv("")
 	if err != nil && !os.IsNotExist(err) {
@@ -163,7 +152,22 @@ func maybeReadModeenv() (*boot.Modeenv, error) {
 	return modeEnv, nil
 }
 
+// StartUp implements StateStarterUp.Startup.
+func (m *DeviceManager) StartUp() error {
+	// system mode is explicitly set on UC20
+	// TODO:UC20: ubuntu-save needs to be mounted for recover too
+	if !release.OnClassic && m.systemMode == "run" {
+		if err := maybeSetupUbuntuSave(); err != nil {
+			return fmt.Errorf("cannot set up ubuntu-save: %v", err)
+		}
+	}
+
+	return nil
+}
+
 func maybeSetupUbuntuSave() error {
+	// only called for UC20
+
 	saveMounted, err := osutil.IsMounted(dirs.SnapSaveDir)
 	if err != nil {
 		return err

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -195,6 +195,10 @@ func MeasureSnapModelWhenPossible(findModel func() (*asserts.Model, error)) erro
 // is returned as well as whether the device node is an decrypted device node (
 // in the encrypted case). If no encrypted volume was found, then the returned
 // device node is an unencrypted normal volume.
+// Note that if the function proceeds to the point where it knows definitely
+// whether there is an encrypted device or not, the second return value will be
+// true, even if error is non-nil. This is so that callers can be robust and
+// try unlocking using another method for example.
 func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
 	// TODO:UC20: use sb.SecureConnectToDefaultTPM() if we decide there's benefit in doing that or
 	//            we have a hard requirement for a valid EK cert chain for every boot (ie, panic
@@ -243,7 +247,7 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, encrypt
 		var errNotFound disks.FilesystemLabelNotFoundError
 		if xerrors.As(err, &errNotFound) {
 			// didn't find the encrypted label, so return nil to try the
-			// decrypted label again
+			// decrypted label
 			return nil, false
 		}
 		if err != nil {
@@ -260,10 +264,10 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, encrypt
 		return unlockEncryptedPartitionWithSealedKey(tpm, mapperName, encdev, sealedKeyPath, ""), true
 	}()
 	if err != nil {
-		return "", false, err
+		return "", foundEncDev, err
 	}
 	if lockErr != nil {
-		return "", false, fmt.Errorf("cannot lock access to sealed keys: %v", lockErr)
+		return "", foundEncDev, fmt.Errorf("cannot lock access to sealed keys: %v", lockErr)
 	}
 
 	if foundEncDev {

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -235,7 +235,7 @@ func (s *secbootSuite) TestMeasureSnapModelWhenPossible(c *C) {
 	}
 }
 
-func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
+func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 
 	// setup mock disks to use for locating the partition
 	// restore := disks.MockMountPointDisksToPartitionMapping()
@@ -258,16 +258,17 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 	}
 
 	for idx, tc := range []struct {
-		tpmErr      error
-		tpmEnabled  bool  // TPM storage and endorsement hierarchies disabled, only relevant if TPM available
-		hasEncdev   bool  // an encrypted device exists
-		rkErr       error // recovery key unlock error, only relevant if TPM not available
-		lockRequest bool  // request to lock access to the sealed key, only relevant if TPM available
-		lockOk      bool  // the lock operation succeeded
-		activated   bool  // the activation operation succeeded
-		device      string
-		err         string
-		disk        *disks.MockDiskMapping
+		tpmErr            error
+		tpmEnabled        bool  // TPM storage and endorsement hierarchies disabled, only relevant if TPM available
+		hasEncdev         bool  // an encrypted device exists
+		rkErr             error // recovery key unlock error, only relevant if TPM not available
+		lockRequest       bool  // request to lock access to the sealed key, only relevant if TPM available
+		lockOk            bool  // the lock operation succeeded
+		activated         bool  // the activation operation succeeded
+		device            string
+		err               string
+		skipExpEncDevChec bool // whether to check the hasEncDev return value at the end
+		disk              *disks.MockDiskMapping
 	}{
 		{
 			// happy case with tpm and encrypted device (lock requested)
@@ -327,8 +328,9 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 		}, {
 			// tpm error, has encrypted device
 			tpmErr: errors.New("tpm error"), hasEncdev: true,
-			err:  `cannot unlock encrypted device "name": tpm error`,
-			disk: mockDiskWithEncDev,
+			err:               `cannot unlock encrypted device "name": tpm error`,
+			disk:              mockDiskWithEncDev,
+			skipExpEncDevChec: true,
 		}, {
 			// tpm disabled, no encrypted device
 			device: "name",
@@ -447,6 +449,14 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 			}
 		} else {
 			c.Assert(err, ErrorMatches, tc.err)
+			if !tc.skipExpEncDevChec {
+				// also check that the isDecryptDev value matches, this is
+				// important for robust callers to know whether they should try to
+				// unlock using a different method or not
+				// this is only skipped on some test cases where we get an error
+				// very early, like trying to connect to the tpm
+				c.Assert(isDecryptDev, Equals, tc.hasEncdev)
+			}
 		}
 		// BlockPCRProtectionPolicies should be called whenever there is a TPM device
 		// detected, regardless of whether secure boot is enabled or there is an

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -181,6 +181,6 @@ func (s *emulation) Mount(what, where string, options ...string) error {
 	return errNotImplemented
 }
 
-func (s *emulation) Umount(where string) error {
+func (s *emulation) Umount(whatOrWhere string) error {
 	return errNotImplemented
 }

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -176,3 +176,7 @@ func (s *emulation) Unmask(service string) error {
 	_, err := systemctlCmd("--root", s.rootDir, "unmask", service)
 	return err
 }
+
+func (s *emulation) Mount(what, where string, options ...string) error {
+	return errNotImplemented
+}

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -180,3 +180,7 @@ func (s *emulation) Unmask(service string) error {
 func (s *emulation) Mount(what, where string, options ...string) error {
 	return errNotImplemented
 }
+
+func (s *emulation) Umount(where string) error {
+	return errNotImplemented
+}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -246,6 +246,8 @@ type Systemd interface {
 	Unmask(service string) error
 	// Mount requests a mount of what under where with options.
 	Mount(what, where string, options ...string) error
+	// Umount requests a mount at where to be unmounted.
+	Umount(where string) error
 }
 
 // A Log is a single entry in the systemd journal
@@ -920,6 +922,13 @@ func (s *systemd) Mount(what, where string, options ...string) error {
 	}
 	args = append(args, what, where)
 	if output, err := exec.Command("systemd-mount", args...).CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
+}
+
+func (s *systemd) Umount(where string) error {
+	if output, err := exec.Command("systemd-mount", "--umount", where).CombinedOutput(); err != nil {
 		return osutil.OutputErr(output, err)
 	}
 	return nil

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -244,6 +244,8 @@ type Systemd interface {
 	Mask(service string) error
 	// Unmask the given service.
 	Unmask(service string) error
+	// Mount requests a mount of what under where with options.
+	Mount(what, where string, options ...string) error
 }
 
 // A Log is a single entry in the systemd journal
@@ -909,4 +911,16 @@ func (s *systemd) ReloadOrRestart(serviceName string) error {
 	}
 	_, err := s.systemctl("reload-or-restart", serviceName)
 	return err
+}
+
+func (s *systemd) Mount(what, where string, options ...string) error {
+	args := make([]string, 0, 2+len(options))
+	if len(options) > 0 {
+		args = append(args, options...)
+	}
+	args = append(args, what, where)
+	if output, err := exec.Command("systemd-mount", args...).CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -246,8 +246,8 @@ type Systemd interface {
 	Unmask(service string) error
 	// Mount requests a mount of what under where with options.
 	Mount(what, where string, options ...string) error
-	// Umount requests a mount at where to be unmounted.
-	Umount(where string) error
+	// Umount requests a mount from what or at where to be unmounted.
+	Umount(whatOrWhere string) error
 }
 
 // A Log is a single entry in the systemd journal
@@ -927,8 +927,8 @@ func (s *systemd) Mount(what, where string, options ...string) error {
 	return nil
 }
 
-func (s *systemd) Umount(where string) error {
-	if output, err := exec.Command("systemd-mount", "--umount", where).CombinedOutput(); err != nil {
+func (s *systemd) Umount(whatOrWhere string) error {
+	if output, err := exec.Command("systemd-mount", "--umount", whatOrWhere).CombinedOutput(); err != nil {
 		return osutil.OutputErr(output, err)
 	}
 	return nil

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1153,3 +1153,28 @@ func (s *SystemdTestSuite) TestMountErr(c *C) {
 		{"systemd-mount", "foo", "bar"},
 	})
 }
+
+func (s *SystemdTestSuite) TestUmountHappy(c *C) {
+	sysd := New(SystemMode, nil)
+
+	cmd := testutil.MockCommand(c, "systemd-mount", "")
+	defer cmd.Restore()
+
+	c.Assert(sysd.Umount("bar"), IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "--umount", "bar"},
+	})
+}
+
+func (s *SystemdTestSuite) TestUmountErr(c *C) {
+	sysd := New(SystemMode, nil)
+
+	cmd := testutil.MockCommand(c, "systemd-mount", `echo "failed"; exit 111`)
+	defer cmd.Restore()
+
+	err := sysd.Umount("bar")
+	c.Assert(err, ErrorMatches, "failed")
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "--umount", "bar"},
+	})
+}

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1123,3 +1123,33 @@ func (s *SystemdTestSuite) TestUnmaskInEmulationMode(c *C) {
 	c.Check(s.argses, DeepEquals, [][]string{
 		{"--root", "/path", "unmask", "foo"}})
 }
+
+func (s *SystemdTestSuite) TestMountHappy(c *C) {
+	sysd := New(SystemMode, nil)
+
+	cmd := testutil.MockCommand(c, "systemd-mount", "")
+	defer cmd.Restore()
+
+	c.Assert(sysd.Mount("foo", "bar"), IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "foo", "bar"},
+	})
+	cmd.ForgetCalls()
+	c.Assert(sysd.Mount("foo", "bar", "-o", "bind"), IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "-o", "bind", "foo", "bar"},
+	})
+}
+
+func (s *SystemdTestSuite) TestMountErr(c *C) {
+	sysd := New(SystemMode, nil)
+
+	cmd := testutil.MockCommand(c, "systemd-mount", `echo "failed"; exit 111`)
+	defer cmd.Restore()
+
+	err := sysd.Mount("foo", "bar")
+	c.Assert(err, ErrorMatches, "failed")
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"systemd-mount", "foo", "bar"},
+	})
+}


### PR DESCRIPTION
This is the first take at making recover mode more robust against errors, and
trying to do things anyways even if some things fail on us. This will be
important for robust devices that are still able to get to a recover mode when
things go very very wrong in run mode, and gives snaps that are meant to rescue
the device from recover mode a chance to run and do something about fixing the
device.

This needs tests and obviously needs discussion, but I thought it to be useful to open
before our meeting for folks to take a look at.