### PR TITLE
features: enable classic-preserves-xdg-runtime-dir

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -98,8 +98,9 @@ var featureNames = map[SnapdFeature]string{
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
 var featuresEnabledWhenUnset = map[SnapdFeature]bool{
-	Layouts:                     true,
-	RobustMountNamespaceUpdates: true,
+	Layouts:                       true,
+	RobustMountNamespaceUpdates:   true,
+	ClassicPreservesXdgRuntimeDir: true,
 }
 
 // featuresExported contains a set of features that are exported outside of snapd.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -108,7 +108,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.SnapdSnap.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.PerUserMountNamespace.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.RefreshAppAwareness.IsEnabledWhenUnset(), Equals, false)
-	c.Check(features.ClassicPreservesXdgRuntimeDir.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.ClassicPreservesXdgRuntimeDir.IsEnabledWhenUnset(), Equals, true)
 	c.Check(features.RobustMountNamespaceUpdates.IsEnabledWhenUnset(), Equals, true)
 	c.Check(features.UserDaemons.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.DbusActivation.IsEnabledWhenUnset(), Equals, false)


### PR DESCRIPTION
We agreed to enable this feature after a release a long while ago and
forgot about this entirely. This should improve compatibility of some
snaps that use classic confinement, as $XDG_RUNTIME_DIR will no longer
be altered, allowing unmodified binaries to find sockets and other
resources there.

Forum: https://forum.snapcraft.io/t/classic-confinement-breaks-high-dpi-support/13868
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>