### PR TITLE
tests: fix rare interaction of tests.session and specific tests

### DIFF
--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -363,8 +363,9 @@ done
 trap - INT TERM QUIT
 
 # Kill dbus-monitor that otherwise runs until it notices the pipe is no longer
-# connected, which happens after a longer while.
-kill $dbus_monitor_pid || true
+# connected, which happens after a longer while. Redirect stderr to /dev/null
+# to avoid upsetting tests which are sensitive to stderr, e.g. tests/main/document-portal-activation
+kill $dbus_monitor_pid 2>/dev/null || true
 wait $dbus_monitor_pid 2>/dev/null || true
 wait $awk_pid
 


### PR DESCRIPTION
I saw this message a few times but always forgot to fix the problem:

	+ echo 'stderr contains some messages'
	stderr contains some messages
	+ cat stderr.log
	/home/gopath/src/github.com/snapcore/snapd/tests/bin/tests.session:
	line 368: 19637 Terminated              stdbuf -oL dbus-monitor --system
	--monitor "$monitor_expr" > "$tmp_dir/dbus-monitor.pipe" 2>
	"$tmp_dir/dbus-monitor.stderr"
	+ exit 1

This is caused by the kill we use to stop dbus-monitor which is used to
ensure that dbus-monitor does not leak if it doesn't exit normally. When
we manage to kill it, mainly due to timing, we may produce a diagnostic
message from the shell, that a background task has terminated.

This patch silences the invocation of kill.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
