### PR TITLE
update-pot: include file locations in translation template, and extract strings from desktop files

### DIFF
--- a/update-pot
+++ b/update-pot
@@ -55,6 +55,8 @@ check_canaries
 sed -i 's/charset=CHARSET/charset=UTF-8/' "$OUTPUT"
 
 find "$HERE" -path "$HERE/data/desktop/*.desktop.in" -type f -printf "%P\n" > "$tmpdir/desktop.files"
+# we need the || true because Ubuntu 14.04's xgettext does not support
+# extracting from desktop files.
 xgettext \
     -f "$tmpdir/desktop.files" \
     -D "$HERE" \
@@ -63,7 +65,7 @@ xgettext \
     --sort-output \
     --package-name=snappy \
     --msgid-bugs-address=snappy-devel@lists.ubuntu.com \
-    --join-existing
+    --join-existing || true
 
 find "$HERE" -path "$HERE/data/polkit/*.policy" -type f -printf "%P\n" > "$tmpdir/polkit.files"
 # we need the || true because of

--- a/update-pot
+++ b/update-pot
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- Mode: sh; indent-tabs-mode: t -*-
 
-set -e
+set -eu
 
 # In LP#1758684 we got reports that the pot file generation
 # is broken. To get to the bottom of this add checks here
@@ -25,24 +25,24 @@ check_canaries() {
 HERE="$(readlink -f "$(dirname "$0")")"
 
 OUTPUT="$HERE/po/snappy.pot"
-if [ -n "$1" ]; then
+if [ -n "${1:-}" ]; then
 	OUTPUT="$1"
 fi
 
 # ensure we have our xgettext-go
 go install github.com/snapcore/snapd/i18n/xgettext-go
 
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
 # exclude vendor and _build subdir
-I18N_FILES="$(mktemp -d)/i18n.files"
-find "$HERE" -type d \( -name "vendor" -o -name "_build" -o -name ".git" \) -prune -o -name "*.go" -type f -print > "$I18N_FILES"
-# shellcheck disable=SC2064
-trap "rm -rf $(dirname "$I18N_FILES")" EXIT
+find "$HERE" -type d \( -name "vendor" -o -name "_build" -o -name ".git" \) -prune -o -name "*.go" -type f -printf "%P\n" > "$tmpdir/go.files"
 
 "${GOPATH%%:*}/bin/xgettext-go" \
-    -f "$I18N_FILES" \
+    -f "$tmpdir/go.files" \
+    -D "$HERE" \
     -o "$OUTPUT" \
     --add-comments-tag=TRANSLATORS: \
-    --no-location \
     --sort-output \
     --package-name=snappy\
     --msgid-bugs-address=snappy-devel@lists.ubuntu.com \
@@ -54,12 +54,26 @@ check_canaries
 
 sed -i 's/charset=CHARSET/charset=UTF-8/' "$OUTPUT"
 
+find "$HERE" -path "$HERE/data/desktop/*.desktop.in" -type f -printf "%P\n" > "$tmpdir/desktop.files"
+xgettext \
+    -f "$tmpdir/desktop.files" \
+    -D "$HERE" \
+    -o "$OUTPUT" \
+    --language=Desktop \
+    --sort-output \
+    --package-name=snappy \
+    --msgid-bugs-address=snappy-devel@lists.ubuntu.com \
+    --join-existing
+
+find "$HERE" -path "$HERE/data/polkit/*.policy" -type f -printf "%P\n" > "$tmpdir/polkit.files"
 # we need the || true because of
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=891347
-xgettext "$HERE"/data/polkit/*.policy \
+xgettext \
+    -f "$tmpdir/polkit.files" \
+    -D "$HERE" \
     -o "$OUTPUT" \
     --its="$HERE/po/its/polkit.its" \
-    --no-location \
+    --sort-output \
     --package-name=snappy \
     --msgid-bugs-address=snappy-devel@lists.ubuntu.com \
     --join-existing || true


### PR DESCRIPTION
This is a simple PR based on some of my thoughts from https://forum.snapcraft.io/t/snapd-localisation/20696?u=jamesh

This branch improves the generation of the translation template:
* Include file name and line number for each translatable string.
* Extract strings from `data/desktop/*.desktop.in` files.
* Make sure later xgettext runs keep the output sorted.

We only want relative path names in the translation template so that we don't save details of the build environment.  This is accomplished by using `find ... -printf "%P\n"` to generate relative paths, and adding the `-D` option to the xgettext-go script (matching the semantics of `xgettext`).

While this does extract strings from the translation template, it makes no attempt to merge them back.  That won't be particularly useful until we have some system to export translations from Launchpad and integrate them into git.