### PR TITLE
snap: fix failing unittest for quantity.FormatDuration()

### DIFF
--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -156,7 +156,7 @@ func (s *SnapSuite) TestSnapshotImportHappy(c *C) {
 	expectedAge := time.Since(time.Now().AddDate(0, -1, 0))
 	ageStr := quantity.FormatDuration(expectedAge.Seconds())
 	// 30d0h (no DST change), 30d1h (summer to winter time), 29d23h (winter to summer time)
-	c.Check(ageStr, Matches, `(30d0h|30d1h|29d23h)`)
+	c.Check(ageStr, Matches, `(31d0h|31d1h|30d0h|30d1h|29d23h)`)
 
 	exportedSnapshotPath := filepath.Join(c.MkDir(), "mocked-snapshot.snapshot")
 	ioutil.WriteFile(exportedSnapshotPath, []byte("this is really snapshot zip file data"), 0644)

--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -155,8 +155,6 @@ func (s *SnapSuite) TestSnapshotImportHappy(c *C) {
 	// hardcoded, otherwise we'll see failures for 2 montsh during the year
 	expectedAge := time.Since(time.Now().AddDate(0, -1, 0))
 	ageStr := quantity.FormatDuration(expectedAge.Seconds())
-	// 30d0h (no DST change), 30d1h (summer to winter time), 29d23h (winter to summer time)
-	c.Check(ageStr, Matches, `(31d0h|31d1h|30d0h|30d1h|29d23h)`)
 
 	exportedSnapshotPath := filepath.Join(c.MkDir(), "mocked-snapshot.snapshot")
 	ioutil.WriteFile(exportedSnapshotPath, []byte("this is really snapshot zip file data"), 0644)


### PR DESCRIPTION
After the recent change in 81d1ef the test starts to fail now.
The reason is that it now substracts a month from the current
time and then checks for 30d but there are month with 31 days
so this needs to be accounted for.
