### PR TITLE
tests/lib/nested: enable snapd logging to console for core18

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -454,6 +454,16 @@ nested_create_core_vm() {
                     repack_snapd_deb_into_snapd_snap "$NESTED_ASSETS_DIR"
                     EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $NESTED_ASSETS_DIR/snapd-from-deb.snap"
 
+                    snap download --channel="$CORE_CHANNEL" --basename=core18 core18
+                    repack_core_snap_with_tweaks "core18.snap" "new-core18.snap"
+                    EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $PWD/new-core18.snap"
+
+                    repack_core_snap_with_tweaks "core18.snap" "new-core18.snap"
+
+                    if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
+                        make_snap_installable_with_id "$NESTED_FAKESTORE_BLOB_DIR" "$PWD/new-core18.snap" "CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6"
+                    fi
+
                 elif nested_is_core_20_system; then
                     snap download --basename=pc-kernel --channel="20/edge" pc-kernel
                     uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
@@ -524,7 +534,7 @@ EOF
 
                     # which channel?
                     snap download --channel="$CORE_CHANNEL" --basename=core20 core20
-                    repack_core20_snap_with_tweaks "core20.snap" "new-core20.snap"
+                    repack_core_snap_with_tweaks "core20.snap" "new-core20.snap"
                     EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $PWD/new-core20.snap"
 
                     # sign the snapd snap with fakestore if requested

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -343,12 +343,12 @@ repack_snapd_snap_with_deb_content() {
     rm -rf "$UNPACK_DIR"
 }
 
-repack_core20_snap_with_tweaks() {
-    local CORE20SNAP="$1"
+repack_core_snap_with_tweaks() {
+    local CORESNAP="$1"
     local TARGET="$2"
 
-    local UNPACK_DIR="/tmp/core20-unpack"
-    unsquashfs -no-progress -d "$UNPACK_DIR" "$CORE20SNAP"
+    local UNPACK_DIR="/tmp/core-unpack"
+    unsquashfs -no-progress -d "$UNPACK_DIR" "$CORESNAP"
 
     mkdir -p "$UNPACK_DIR"/etc/systemd/journald.conf.d
     cat <<EOF > "$UNPACK_DIR"/etc/systemd/journald.conf.d/to-console.conf


### PR DESCRIPTION
Repack the core18 snap with tweaks that enable snapd logging to console.


