### PR TITLE
interfaces/greengrass-support: add additional "process" flavor for 1.11 update

### DIFF
--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -20,8 +20,6 @@
 package builtin
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -412,8 +410,6 @@ func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 		// this is the process-mode version, it does not use as much privilege
 		// as the default "container" flavor
 		spec.AddSnippet(greengrassSupportProcessModeConnectedPlugAppArmor)
-	default:
-		return fmt.Errorf("cannot add apparmor plug policy: unsupported flavor attribute value %q for greengrass-support interface", flavor)
 	}
 
 	return nil
@@ -428,8 +424,6 @@ func (iface *greengrassSupportInterface) SecCompConnectedPlug(spec *seccomp.Spec
 		spec.AddSnippet(greengrassSupportConnectedPlugSeccomp)
 	case "process":
 		// process mode has no additional seccomp available to it
-	default:
-		return fmt.Errorf("cannot add seccomp plug policy: unsupported flavor attribute value %q for greengrass-support interface", flavor)
 	}
 
 	return nil
@@ -444,8 +438,6 @@ func (iface *greengrassSupportInterface) UDevConnectedPlug(spec *udev.Specificat
 		spec.SetControlsDeviceCgroup()
 	case "process":
 		// process mode does not control the device cgroup
-	default:
-		return fmt.Errorf("cannot add udev plug policy: unsupported flavor attribute value %q for greengrass-support interface", flavor)
 	}
 
 	return nil

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -42,6 +42,14 @@ type GreengrassSupportInterfaceSuite struct {
 	extraSlot     *interfaces.ConnectedSlot
 	extraPlugInfo *snap.PlugInfo
 	extraPlug     *interfaces.ConnectedPlug
+
+	// for the process flavor
+	processModePlugInfo *snap.PlugInfo
+	processModePlug     *interfaces.ConnectedPlug
+
+	// for the container flavor
+	containerModePlugInfo *snap.PlugInfo
+	containerModePlug     *interfaces.ConnectedPlug
 }
 
 const coreSlotYaml = `name: core
@@ -53,10 +61,26 @@ slots:
 `
 const ggMockPlugSnapInfoYaml = `name: other
 version: 1.0
+plugs:
+ greengrass-support-container-mode:
+  interface: greengrass-support
+  flavor: container
 apps:
  app2:
   command: foo
-  plugs: [greengrass-support, network-control]
+  plugs: [greengrass-support-container-mode, greengrass-support, network-control]
+`
+
+const ggProcessModeMockPlugSnapInfoYaml = `name: other
+version: 1.0
+plugs:
+ greengrass-support-process-mode:
+  interface: greengrass-support
+  flavor: process
+apps:
+ app2:
+  command: foo
+  plugs: [greengrass-support-process-mode, network-control]
 `
 
 var _ = Suite(&GreengrassSupportInterfaceSuite{
@@ -68,6 +92,10 @@ func (s *GreengrassSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slot, s.slotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "greengrass-support")
 	s.extraPlug, s.extraPlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "network-control")
 	s.extraSlot, s.extraSlotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "network-control")
+
+	s.processModePlug, s.processModePlugInfo = MockConnectedPlug(c, ggProcessModeMockPlugSnapInfoYaml, nil, "greengrass-support-process-mode")
+
+	s.containerModePlug, s.containerModePlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "greengrass-support-container-mode")
 
 }
 
@@ -84,39 +112,86 @@ func (s *GreengrassSupportInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestAppArmorSpec(c *C) {
+
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		spec := &apparmor.Specification{}
+		c.Assert(spec.AddConnectedPlug(s.iface, plug, s.slot), IsNil)
+		c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+		c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "mount options=(rw, bind) /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,\n")
+		c.Check(spec.UsesPtraceTrace(), Equals, true)
+	}
+}
+
+func (s *GreengrassSupportInterfaceSuite) TestProcessModeAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.processModePlug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
-	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "mount options=(rw, bind) /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,\n")
-	c.Check(spec.UsesPtraceTrace(), Equals, true)
+	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "/ ix,\n")
+	c.Check(spec.SnippetForTag("snap.other.app2"), Not(testutil.Contains), "mount options=(rw, bind) /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,\n")
+	c.Check(spec.UsesPtraceTrace(), Equals, false)
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestSecCompSpec(c *C) {
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		spec := &seccomp.Specification{}
+		c.Assert(spec.AddConnectedPlug(s.iface, plug, s.slot), IsNil)
+		c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "# for overlayfs and various bind mounts\nmount\numount2\npivot_root\n")
+	}
+}
+
+func (s *GreengrassSupportInterfaceSuite) TestProcessModeSecCompSpec(c *C) {
 	spec := &seccomp.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "# for overlayfs and various bind mounts\nmount\numount2\npivot_root\n")
+	c.Assert(spec.AddConnectedPlug(s.iface, s.processModePlug, s.slot), IsNil)
+	c.Check(spec.SnippetForTag("snap.other.app2"), Not(testutil.Contains), "# for overlayfs and various bind mounts\nmount\numount2\npivot_root\n")
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestUdevTaggingDisablingRemoveLast(c *C) {
-	// make a spec with network-control that has udev tagging
-	spec := &udev.Specification{}
-	c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), s.extraPlug, s.extraSlot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 3)
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		// make a spec with network-control that has udev tagging
+		spec := &udev.Specification{}
+		c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), s.extraPlug, s.extraSlot), IsNil)
+		c.Assert(spec.Snippets(), HasLen, 3)
 
-	// connect the greengrass-support interface and ensure the spec is now nil
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+		// connect the greengrass-support interface and ensure the spec is now nil
+		c.Assert(spec.AddConnectedPlug(s.iface, plug, s.slot), IsNil)
+		c.Check(spec.Snippets(), HasLen, 0)
+	}
+}
+
+func (s *GreengrassSupportInterfaceSuite) TestProcessModeUdevTaggingWorks(c *C) {
+	spec := &udev.Specification{}
+	// connect the greengrass-support interface and ensure the spec is nil
+	c.Assert(spec.AddConnectedPlug(s.iface, s.processModePlug, s.slot), IsNil)
 	c.Check(spec.Snippets(), HasLen, 0)
+
+	// add network-control and now the spec is not nil
+	c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), s.extraPlug, s.extraSlot), IsNil)
+	c.Assert(spec.Snippets(), Not(HasLen), 0)
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestUdevTaggingDisablingRemoveFirst(c *C) {
-	spec := &udev.Specification{}
-	// connect the greengrass-support interface and ensure the spec is nil
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Check(spec.Snippets(), HasLen, 0)
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		spec := &udev.Specification{}
+		// connect the greengrass-support interface and ensure the spec is nil
+		c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+		c.Check(spec.Snippets(), HasLen, 0)
 
-	// add network-control and ensure the spec is still nil
-	c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), s.extraPlug, s.extraSlot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 0)
+		// add network-control and ensure the spec is still nil
+		c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), plug, s.extraSlot), IsNil)
+		c.Assert(spec.Snippets(), HasLen, 0)
+	}
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestInterfaces(c *C) {
@@ -127,24 +202,34 @@ func (s *GreengrassSupportInterfaceSuite) TestPermanentSlotAppArmorSessionNative
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		apparmorSpec := &apparmor.Specification{}
+		err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
+		c.Assert(err, IsNil)
+		c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 
-	// verify core rule present
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "# /system-data/var/snap/greengrass/x1/ggc-writable/packages/1.7.0/var/worker/overlays/$UUID/upper/\n")
+		// verify core rule present
+		c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "# /system-data/var/snap/greengrass/x1/ggc-writable/packages/1.7.0/var/worker/overlays/$UUID/upper/\n")
+	}
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestPermanentSlotAppArmorSessionClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
-	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		apparmorSpec := &apparmor.Specification{}
+		err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
+		c.Assert(err, IsNil)
+		c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 
-	// verify core rule not present
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), Not(testutil.Contains), "# /system-data/var/snap/greengrass/x1/ggc-writable/packages/1.7.0/var/worker/overlays/$UUID/upper/\n")
+		// verify core rule not present
+		c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), Not(testutil.Contains), "# /system-data/var/snap/greengrass/x1/ggc-writable/packages/1.7.0/var/worker/overlays/$UUID/upper/\n")
+	}
 }

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -117,6 +117,13 @@ dbus (send)
     interface=org.freedesktop.DBus.Peer
     member=GetMachineId
     peer=(label=unconfined),
+
+# Allow reading if protected hardlinks are enabled, but don't allow enabling or
+# disabling them
+@{PROC}/sys/fs/protected_hardlinks r,
+@{PROC}/sys/fs/protected_symlinks r,
+@{PROC}/sys/fs/protected_fifos r,
+@{PROC}/sys/fs/protected_regular r,
 `
 
 const systemObserveConnectedPlugSecComp = `


### PR DESCRIPTION
This adds a new attribute to the greengrass-support interface, "flavor", which
indicates what mode of containerization the greengrassd daemon is meant to be
supporting with the plug. With no flavor attribute, or the "container" flavor,
then the old policy is available so as to not break old users of the snap, but
with a new "process" flavor, then a far less privileged version of the interface
is provided, which allows the greengrassd daemon to implement no
containerization and thus the lambdas that are run are not run with the
additional privilege afforded to the original implementation of the interface,
as that would allow lambdas to trivially escape the sandbox.

I have tested this change with a version of the greengrass snap that was provided to me by AWS, but my testing is minimal and just ensures that lambdas start-up, etc. AWS has tested the specific policy included here by not using greengrass-support and adding the policy snippets to the AppArmor profile for their new version of the snap and then re-loading the AppArmor profile. However, they would like to have this available in edge ASAP so they can test it "in the field" with the new snap as well to see if there are any other gotchas or other accesses that they might need before their release. As such, because there is a possibility that this might need to be changed, I've milestoned it for 2.49 (and marked it as blocked until 2.48 is branched) so that 2.48 doesn't get blocked waiting for AWS's testing, but conceivably after it is put onto edge and confirmed to be good, it could be backported to 2.48 to be included in 2.48.1 or something.

(the original version of this PR had a much longer description - it was removed to make this more clear for reviewers but can still be viewed with the edit history function in GitHub)