### PR TITLE
spread: use the official image for Ubuntu 20.10, no longer an unstable system

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -102,6 +102,9 @@ backends:
                   secure-boot: true
                   # XXX: old name, remove once new spread is deployed
                   secureboot: true
+            - ubuntu-20.10-64:
+                  workers: 6
+                  image: ubuntu-20.10-64
 
             - debian-9-64:
                   workers: 6
@@ -137,9 +140,6 @@ backends:
                   workers: 4
                   storage: preserve-size
                   image: centos-8-64
-            - ubuntu-20.10-64:
-                  workers: 6
-                  image: ubuntu-os-cloud-devel/ubuntu-2010
 
     google-sru:
         type: google


### PR DESCRIPTION
Groovy was released, update spread.yaml.


