### PR TITLE
gadget: correct sfdisk arguments

### DIFF
--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -204,7 +204,7 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 
 	// Check partition table read and write
 	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "-d", "/dev/node"},
+		{"sfdisk", "--json", "/dev/node"},
 		{"sfdisk", "--append", "--no-reread", "/dev/node"},
 	})
 
@@ -234,7 +234,7 @@ func (s *partitionTestSuite) TestRemovePartitionsTrivial(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "-d", "/dev/node"},
+		{"sfdisk", "--json", "/dev/node"},
 	})
 
 	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
@@ -295,9 +295,9 @@ echo '{
 	c.Assert(err, IsNil)
 
 	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "-d", "/dev/node"},
+		{"sfdisk", "--json", "/dev/node"},
 		{"sfdisk", "--no-reread", "--delete", "/dev/node", "3"},
-		{"sfdisk", "--json", "-d", "/dev/node"},
+		{"sfdisk", "--json", "/dev/node"},
 	})
 }
 

--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -110,7 +110,7 @@ type OnDiskVolume struct {
 // OnDiskVolumeFromDevice obtains the partitioning and filesystem information from
 // the block device.
 func OnDiskVolumeFromDevice(device string) (*OnDiskVolume, error) {
-	output, err := exec.Command("sfdisk", "--json", "-d", device).Output()
+	output, err := exec.Command("sfdisk", "--json", device).Output()
 	if err != nil {
 		return nil, osutil.OutputErr(output, err)
 	}

--- a/gadget/ondisk_test.go
+++ b/gadget/ondisk_test.go
@@ -190,7 +190,7 @@ func (s *ondiskTestSuite) TestDeviceInfoGPT(c *C) {
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
 	c.Assert(err, IsNil)
 	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "-d", "/dev/node"},
+		{"sfdisk", "--json", "/dev/node"},
 	})
 	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
 		{"lsblk", "--fs", "--json", "/dev/node1"},
@@ -279,7 +279,7 @@ exit 0`
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
 	c.Assert(err, IsNil)
 	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "-d", "/dev/node"},
+		{"sfdisk", "--json", "/dev/node"},
 	})
 	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
 		{"lsblk", "--fs", "--json", "/dev/node1"},


### PR DESCRIPTION
sfdisk --json means dump disk in json format. --dump means dump disk
in sfdisk format. The two options have been made mutually exclusive in
2.35. It is best to be precise and specify only the format that is
expected.

This prevents installation of UC22.