### PR TITLE
secboot: add LockTPMSealedKeys() to lock access to keys independently

### DIFF
--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -185,6 +185,41 @@ func MeasureSnapModelWhenPossible(findModel func() (*asserts.Model, error)) erro
 	return nil
 }
 
+// LockTPMSealedKeys manually locks access to the sealed keys. Meant to be
+// called in place of passing lockKeysOnFinish as true to
+// UnlockVolumeUsingSealedKeyIfEncrypted for cases where we don't know if a
+// given call is the last one to unlock a volume like in degraded recover mode.
+func LockTPMSealedKeys() error {
+	tpm, tpmErr := sbConnectToDefaultTPM()
+	if tpmErr != nil {
+		if !xerrors.Is(tpmErr, sb.ErrNoTPM2Device) {
+			return fmt.Errorf("cannot lock TPM: %v", tpmErr)
+		}
+		logger.Noticef("cannot open TPM connection: %v", tpmErr)
+	} else {
+		defer tpm.Close()
+	}
+
+	// Also check if the TPM device is enabled. The platform firmware may disable the storage
+	// and endorsement hierarchies, but the device will remain visible to the operating system.
+	if tpmErr == nil && isTPMEnabled(tpm) {
+		// Lock access to the sealed keys. This should be called whenever there
+		// is a TPM device detected, regardless of whether secure boot is enabled
+		// or there is an encrypted volume to unlock. Note that snap-bootstrap can
+		// be called several times during initialization, and if there are multiple
+		// volumes to unlock we should lock access to the sealed keys only after
+		// the last encrypted volume is unlocked, in which case lockKeysOnFinish
+		// should be set to true.
+		//
+		// We should only touch the PCR that we've currently reserved for the kernel
+		// EFI image. Touching others will break the ability to perform any kind of
+		// attestation using the TPM because it will make the log inconsistent.
+		return sbBlockPCRProtectionPolicies(tpm, []int{initramfsPCR})
+	}
+
+	return nil
+}
+
 // UnlockVolumeUsingSealedKeyIfEncrypted verifies whether an encrypted volume
 // with the specified name exists and unlocks it using a sealed key in a file
 // with a corresponding name. With lockKeysOnFinish set, access to the sealed


### PR DESCRIPTION
With the run mode and previous implementation of recover mode using
UnlockVolumeUsingSealedKeyIfEncrypted, we would always know what the last call
was and thus when to pass lockKeysOnFinish = true, however with the new degraded
mode, we do not know which call will be the last one.

As such, we need to use a separate function to lock access to the sealed keys,
and call that from the recover mode in initramfs-mounts.

Broken out from https://github.com/snapcore/snapd/pull/9592