### PR TITLE
secboot: refactor Unlock...IfEncrypted to take keyfile + check disks first

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -75,7 +75,7 @@ var (
 
 	secbootMeasureSnapSystemEpochWhenPossible    func() error
 	secbootMeasureSnapModelWhenPossible          func(findModel func() (*asserts.Model, error)) error
-	secbootUnlockVolumeUsingSealedKeyIfEncrypted func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error)
+	secbootUnlockVolumeUsingSealedKeyIfEncrypted func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error)
 	secbootUnlockEncryptedVolumeUsingKey         func(disk disks.Disk, name string, key []byte) (string, error)
 
 	bootFindPartitionUUIDForBootedKernelDisk = boot.FindPartitionUUIDForBootedKernelDisk
@@ -281,9 +281,10 @@ func generateMountsModeRecover(mst *initramfsMountsState) error {
 		return err
 	}
 
-	// 3. mount ubuntu-data for recovery
+	// 3. mount ubuntu-data for recovery using run mode key
 	const lockKeysOnFinish = true
-	device, isDecryptDev, err := secbootUnlockVolumeUsingSealedKeyIfEncrypted(disk, "ubuntu-data", boot.InitramfsEncryptionKeyDir, lockKeysOnFinish)
+	runModeKey := filepath.Join(boot.InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key")
+	device, isDecryptDev, err := secbootUnlockVolumeUsingSealedKeyIfEncrypted(disk, "ubuntu-data", runModeKey, lockKeysOnFinish)
 	if err != nil {
 		return err
 	}
@@ -554,7 +555,8 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 
 	// 3.2. mount Data
 	const lockKeysOnFinish = true
-	device, isDecryptDev, err := secbootUnlockVolumeUsingSealedKeyIfEncrypted(disk, "ubuntu-data", boot.InitramfsEncryptionKeyDir, lockKeysOnFinish)
+	runModeKey := filepath.Join(boot.InitramfsEncryptionKeyDir, "ubuntu-data.sealed-key")
+	device, isDecryptDev, err := secbootUnlockVolumeUsingSealedKeyIfEncrypted(disk, "ubuntu-data", runModeKey, lockKeysOnFinish)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
@@ -38,7 +38,7 @@ func init() {
 	secbootMeasureSnapModelWhenPossible = func(_ func() (*asserts.Model, error)) error {
 		return errNotImplemented
 	}
-	secbootUnlockVolumeUsingSealedKeyIfEncrypted = func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+	secbootUnlockVolumeUsingSealedKeyIfEncrypted = func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		return "", false, errNotImplemented
 	}
 	secbootUnlockEncryptedVolumeUsingKey = func(disk disks.Disk, name string, key []byte) (string, error) {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -226,7 +226,7 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 		c.Check(f, NotNil)
 		return nil
 	}))
-	s.AddCleanup(main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+	s.AddCleanup(main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		return filepath.Join("/dev/disk/by-partuuid", name+"-partuuid"), false, nil
 	}))
 }
@@ -1470,9 +1470,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C
 	c.Assert(err, IsNil)
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
-		c.Assert(encryptionKeyDir, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde"))
+		c.Assert(encryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.sealed-key"))
 		c.Assert(lockKeysOnFinish, Equals, true)
 		dataActivated = true
 		// return true because we are using an encrypted device
@@ -1578,7 +1578,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyNoS
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		dataActivated = true
 		// return true because we are using an encrypted device
@@ -1649,7 +1649,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyUnl
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		dataActivated = true
 		// return true because we are using an encrypted device
@@ -2396,9 +2396,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
-		c.Assert(encryptionKeyDir, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde"))
+		c.Assert(encryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.sealed-key"))
 		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
@@ -2525,7 +2525,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	defer restore()
 
 	activated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
 		c.Assert(err, IsNil)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -226,7 +226,7 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 		c.Check(f, NotNil)
 		return nil
 	}))
-	s.AddCleanup(main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
+	s.AddCleanup(main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		return filepath.Join("/dev/disk/by-partuuid", name+"-partuuid"), false, nil
 	}))
 }
@@ -1470,7 +1470,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C
 	c.Assert(err, IsNil)
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(encryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.sealed-key"))
 		c.Assert(lockKeysOnFinish, Equals, true)
@@ -1578,7 +1578,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyNoS
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		dataActivated = true
 		// return true because we are using an encrypted device
@@ -1649,7 +1649,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyUnl
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		dataActivated = true
 		// return true because we are using an encrypted device
@@ -2396,7 +2396,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(encryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.sealed-key"))
 		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
@@ -2525,7 +2525,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	defer restore()
 
 	activated := false
-	restore = main.MockSecbootUnlockVolumeIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
 		c.Assert(err, IsNil)

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -77,7 +77,7 @@ func MockDefaultMarkerFile(p string) (restore func()) {
 	}
 }
 
-func MockSecbootUnlockVolumeIfEncrypted(f func(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error)) (restore func()) {
+func MockSecbootUnlockVolumeIfEncrypted(f func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error)) (restore func()) {
 	old := secbootUnlockVolumeUsingSealedKeyIfEncrypted
 	secbootUnlockVolumeUsingSealedKeyIfEncrypted = f
 	return func() {

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -77,7 +77,7 @@ func MockDefaultMarkerFile(p string) (restore func()) {
 	}
 }
 
-func MockSecbootUnlockVolumeIfEncrypted(f func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error)) (restore func()) {
+func MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(f func(disk disks.Disk, name string, encryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error)) (restore func()) {
 	old := secbootUnlockVolumeUsingSealedKeyIfEncrypted
 	secbootUnlockVolumeUsingSealedKeyIfEncrypted = f
 	return func() {

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -192,15 +192,46 @@ func MeasureSnapModelWhenPossible(findModel func() (*asserts.Model, error)) erro
 // is returned as well as whether the device node is an decrypted device node (
 // in the encrypted case). If no encrypted volume was found, then the returned
 // device node is an unencrypted normal volume.
-func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, encryptionKeyDir string, lockKeysOnFinish bool) (string, bool, error) {
+// Note that if the function proceeds to the point where it knows definitely
+// whether there is an encrypted device or not, the second return value will be
+// true, even if error is non-nil. This is so that callers can be robust and
+// try unlocking using another method for example.
+func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, sealedEncryptionKeyFile string, lockKeysOnFinish bool) (string, bool, error) {
 	// TODO:UC20: use sb.SecureConnectToDefaultTPM() if we decide there's benefit in doing that or
 	//            we have a hard requirement for a valid EK cert chain for every boot (ie, panic
 	//            if there isn't one). But we can't do that as long as we need to download
 	//            intermediate certs from the manufacturer.
+
+	// find the encrypted device using the disk we were provided - note that
+	// we do not specify IsDecryptedDevice in opts because here we are
+	// looking for the encrypted device to unlock, later on in the boot
+	// process we will look for the decrypted device to ensure it matches
+	// what we expected
+	foundEncDev := false
+	partUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+	var errNotFound disks.FilesystemLabelNotFoundError
+	if err == nil {
+		foundEncDev = true
+	} else {
+		if !xerrors.As(err, &errNotFound) {
+			// some other kind of catastrophic error searching
+			// TODO: need to defer the connection to the default TPM somehow
+			return "", false, fmt.Errorf("error enumerating partitions for disk to find encrypted device %q: %v", name, err)
+		}
+		// otherwise it is an error not found and we should search for the
+		// unencrypted device
+		partUUID, err = disk.FindMatchingPartitionUUID(name)
+		if err != nil {
+			return "", false, fmt.Errorf("error enumerating partitions for disk to find unencrypted device %q: %v", name, err)
+		}
+	}
+
+	devpath := filepath.Join("/dev/disk/by-partuuid", partUUID)
+
 	tpm, tpmErr := sbConnectToDefaultTPM()
 	if tpmErr != nil {
 		if !xerrors.Is(tpmErr, sb.ErrNoTPM2Device) {
-			return "", false, fmt.Errorf("cannot unlock encrypted device %q: %v", name, tpmErr)
+			return "", foundEncDev, fmt.Errorf("cannot unlock encrypted device %q: %v", name, tpmErr)
 		}
 		logger.Noticef("cannot open TPM connection: %v", tpmErr)
 	} else {
@@ -213,7 +244,7 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, encrypt
 
 	var lockErr error
 	var mapperName string
-	err, foundEncDev := func() (error, bool) {
+	err = func() error {
 		defer func() {
 			if lockKeysOnFinish && tpmDeviceAvailable {
 				// Lock access to the sealed keys. This should be called whenever there
@@ -231,36 +262,24 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, encrypt
 			}
 		}()
 
-		// find the encrypted device using the disk we were provided - note that
-		// we do not specify IsDecryptedDevice in opts because here we are
-		// looking for the encrypted device to unlock, later on in the boot
-		// process we will look for the decrypted device to ensure it matches
-		// what we expected
-		partUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
-		var errNotFound disks.FilesystemLabelNotFoundError
-		if xerrors.As(err, &errNotFound) {
-			// didn't find the encrypted label, so return nil to try the
-			// decrypted label again
-			return nil, false
+		if !foundEncDev {
+			// if we didn't find an encrypted device just return, don't try to
+			// unlock it
+			return nil
 		}
-		if err != nil {
-			return err, false
-		}
-		encdev := filepath.Join("/dev/disk/by-partuuid", partUUID)
 
 		mapperName = name + "-" + randutilRandomKernelUUID()
 		if !tpmDeviceAvailable {
-			return unlockEncryptedPartitionWithRecoveryKey(mapperName, encdev), true
+			return unlockEncryptedPartitionWithRecoveryKey(mapperName, devpath)
 		}
 
-		sealedKeyPath := filepath.Join(encryptionKeyDir, name+".sealed-key")
-		return unlockEncryptedPartitionWithSealedKey(tpm, mapperName, encdev, sealedKeyPath, ""), true
+		return unlockEncryptedPartitionWithSealedKey(tpm, mapperName, devpath, sealedEncryptionKeyFile, "")
 	}()
 	if err != nil {
-		return "", false, err
+		return "", foundEncDev, err
 	}
 	if lockErr != nil {
-		return "", false, fmt.Errorf("cannot lock access to sealed keys: %v", lockErr)
+		return "", foundEncDev, fmt.Errorf("cannot lock access to sealed keys: %v", lockErr)
 	}
 
 	if foundEncDev {
@@ -269,12 +288,7 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, encrypt
 		return filepath.Join("/dev/mapper", mapperName), true, nil
 	}
 
-	// otherwise find the device from the disk
-	partUUID, err := disk.FindMatchingPartitionUUID(name)
-	if err != nil {
-		return "", false, err
-	}
-	return filepath.Join("/dev/disk/by-partuuid", partUUID), false, nil
+	return devpath, false, nil
 }
 
 // UnlockEncryptedVolumeUsingKey unlocks an existing volume using the provided key. The

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -259,54 +259,57 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 	}
 
 	for idx, tc := range []struct {
-		tpmErr      error
-		tpmEnabled  bool  // TPM storage and endorsement hierarchies disabled, only relevant if TPM available
-		hasEncdev   bool  // an encrypted device exists
-		rkErr       error // recovery key unlock error, only relevant if TPM not available
-		lockRequest bool  // request to lock access to the sealed key, only relevant if TPM available
-		lockOk      bool  // the lock operation succeeded
-		activated   bool  // the activation operation succeeded
-		device      string
-		err         string
-		disk        *disks.MockDiskMapping
+		tpmErr              error
+		keyfile             string // the keyfile to be used to unseal
+		tpmEnabled          bool   // TPM storage and endorsement hierarchies disabled, only relevant if TPM available
+		hasEncdev           bool   // an encrypted device exists
+		rkErr               error  // recovery key unlock error, only relevant if TPM not available
+		lockRequest         bool   // request to lock access to the sealed key, only relevant if TPM available
+		lockOk              bool   // the lock operation succeeded
+		activated           bool   // the activation operation succeeded
+		err                 string
+		skipDiskEnsureCheck bool // whether to check to ensure the mock disk contains the device label
+		disk                *disks.MockDiskMapping
 	}{
 		{
 			// happy case with tpm and encrypted device (lock requested)
 			tpmEnabled: true, hasEncdev: true, lockRequest: true, lockOk: true,
-			activated: true, device: "name",
-			disk: mockDiskWithEncDev,
+			activated: true,
+			disk:      mockDiskWithEncDev,
+		}, {
+			// happy case with tpm and encrypted device (lock requested) with
+			// an alternative keyfile
+			tpmEnabled: true, hasEncdev: true, lockRequest: true, lockOk: true,
+			activated: true,
+			disk:      mockDiskWithEncDev,
+			keyfile:   "some-other-keyfile",
 		}, {
 			// device activation fails (lock requested)
 			tpmEnabled: true, hasEncdev: true, lockRequest: true, lockOk: true,
-			err:    "cannot activate encrypted device .*: activation error",
-			device: "name",
-			disk:   mockDiskWithEncDev,
+			err:  "cannot activate encrypted device .*: activation error",
+			disk: mockDiskWithEncDev,
 		}, {
 			// activation works but PCR policy block fails (lock requested)
 			tpmEnabled: true, hasEncdev: true, lockRequest: true, activated: true,
-			err:    "cannot lock access to sealed keys: block failed",
-			device: "name",
-			disk:   mockDiskWithEncDev,
+			err:  "cannot lock access to sealed keys: block failed",
+			disk: mockDiskWithEncDev,
 		}, {
 			// happy case with tpm and encrypted device
 			tpmEnabled: true, hasEncdev: true, lockOk: true, activated: true,
-			device: "name",
-			disk:   mockDiskWithEncDev,
+			disk: mockDiskWithEncDev,
 		}, {
 			// device activation fails
 			tpmEnabled: true, hasEncdev: true,
-			err:    "cannot activate encrypted device .*: activation error",
-			device: "name",
-			disk:   mockDiskWithEncDev,
+			err:  "cannot activate encrypted device .*: activation error",
+			disk: mockDiskWithEncDev,
 		}, {
 			// activation works but lock fails
-			tpmEnabled: true, hasEncdev: true, activated: true, device: "name",
+			tpmEnabled: true, hasEncdev: true, activated: true,
 			disk: mockDiskWithEncDev,
 		}, {
 			// happy case without encrypted device (lock requested)
-			tpmEnabled: true, lockRequest: true, lockOk: true, activated: true,
-			device: "name",
-			disk:   mockDiskWithUnencDev,
+			tpmEnabled: true, lockRequest: true, lockOk: true,
+			disk: mockDiskWithUnencDev,
 		}, {
 			// activation works but lock fails, without encrypted device (lock requested)
 			tpmEnabled: true, lockRequest: true, activated: true,
@@ -314,12 +317,12 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 			disk: mockDiskWithUnencDev,
 		}, {
 			// happy case without encrypted device
-			tpmEnabled: true, lockOk: true, activated: true, device: "name",
+			tpmEnabled: true, lockOk: true,
 			disk: mockDiskWithUnencDev,
 		}, {
 			// activation works but lock fails, no encrypted device
-			tpmEnabled: true, activated: true, device: "name",
-			disk: mockDiskWithUnencDev,
+			tpmEnabled: true,
+			disk:       mockDiskWithUnencDev,
 		}, {
 			// tpm error, no encrypted device
 			tpmErr: errors.New("tpm error"),
@@ -332,12 +335,10 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 			disk: mockDiskWithEncDev,
 		}, {
 			// tpm disabled, no encrypted device
-			device: "name",
-			disk:   mockDiskWithUnencDev,
+			disk: mockDiskWithUnencDev,
 		}, {
 			// tpm disabled, has encrypted device, unlocked using the recovery key
 			hasEncdev: true,
-			device:    "name",
 			disk:      mockDiskWithEncDev,
 		}, {
 			// tpm disabled, has encrypted device, recovery key unlocking fails
@@ -347,8 +348,7 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 		}, {
 			// no tpm, has encrypted device, unlocked using the recovery key (lock requested)
 			tpmErr: sb.ErrNoTPM2Device, hasEncdev: true, lockRequest: true,
-			disk:   mockDiskWithEncDev,
-			device: "name",
+			disk: mockDiskWithEncDev,
 		}, {
 			// no tpm, has encrypted device, recovery key unlocking fails
 			rkErr:  errors.New("cannot unlock with recovery key"),
@@ -358,26 +358,23 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 		}, {
 			// no tpm, has encrypted device, unlocked using the recovery key
 			tpmErr: sb.ErrNoTPM2Device, hasEncdev: true,
-			disk:   mockDiskWithEncDev,
-			device: "name",
+			disk: mockDiskWithEncDev,
 		}, {
 			// no tpm, no encrypted device (lock requested)
 			tpmErr: sb.ErrNoTPM2Device, lockRequest: true,
-			disk:   mockDiskWithUnencDev,
-			device: "name",
+			disk: mockDiskWithUnencDev,
 		}, {
 			// no tpm, no encrypted device
 			tpmErr: sb.ErrNoTPM2Device,
 			disk:   mockDiskWithUnencDev,
-			device: "name",
 		}, {
 			// no disks at all
-			disk:   mockDiskWithoutAnyDev,
-			device: "name",
+			disk:                mockDiskWithoutAnyDev,
+			skipDiskEnsureCheck: true,
 			// error is specifically for failing to find name, NOT name-enc, we
 			// will properly fall back to looking for name if we didn't find
 			// name-enc
-			err: "filesystem label \"name\" not found",
+			err: "error enumerating partitions for disk to find unencrypted device \"name\": filesystem label \"name\" not found",
 		},
 	} {
 		randomUUID := fmt.Sprintf("random-uuid-for-test-%d", idx)
@@ -407,18 +404,28 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 		})
 		defer restore()
 
-		fsLabel := tc.device
+		defaultDevice := "name"
+
+		fsLabel := defaultDevice
 		if tc.hasEncdev {
 			fsLabel += "-enc"
 		}
-		partuuid := tc.disk.FilesystemLabelToPartUUID[fsLabel]
+		partuuid, ok := tc.disk.FilesystemLabelToPartUUID[fsLabel]
+		if !tc.skipDiskEnsureCheck {
+			c.Assert(ok, Equals, true)
+		}
 		devicePath := filepath.Join("/dev/disk/by-partuuid", partuuid)
+
+		expKeyPath := tc.keyfile
+		if expKeyPath == "" {
+			expKeyPath = "vanilla-keyfile"
+		}
 
 		restore = secboot.MockSbActivateVolumeWithTPMSealedKey(func(tpm *sb.TPMConnection, volumeName, sourceDevicePath,
 			keyPath string, pinReader io.Reader, options *sb.ActivateVolumeOptions) (bool, error) {
 			c.Assert(volumeName, Equals, "name-"+randomUUID)
 			c.Assert(sourceDevicePath, Equals, devicePath)
-			c.Assert(keyPath, Equals, filepath.Join("encrypt-key-dir", "name.sealed-key"))
+			c.Assert(keyPath, Equals, expKeyPath)
 			c.Assert(*options, DeepEquals, sb.ActivateVolumeOptions{
 				PassphraseTries:  1,
 				RecoveryKeyTries: 3,
@@ -437,17 +444,23 @@ func (s *secbootSuite) TestUnlockUsingSealedKeyIfEncrypted(c *C) {
 		})
 		defer restore()
 
-		device, isDecryptDev, err := secboot.UnlockVolumeUsingSealedKeyIfEncrypted(tc.disk, "name", "encrypt-key-dir", tc.lockRequest)
+		device, isDecryptDev, err := secboot.UnlockVolumeUsingSealedKeyIfEncrypted(tc.disk, defaultDevice, expKeyPath, tc.lockRequest)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 			c.Assert(isDecryptDev, Equals, tc.hasEncdev)
 			if tc.hasEncdev {
-				c.Assert(device, Equals, filepath.Join("/dev/mapper", tc.device+"-"+randomUUID))
+				c.Assert(device, Equals, filepath.Join("/dev/mapper", defaultDevice+"-"+randomUUID))
 			} else {
 				c.Assert(device, Equals, devicePath)
 			}
 		} else {
 			c.Assert(err, ErrorMatches, tc.err)
+			// also check that the isDecryptDev value matches, this is
+			// important for robust callers to know whether they should try to
+			// unlock using a different method or not
+			// this is only skipped on some test cases where we get an error
+			// very early, like trying to connect to the tpm
+			c.Assert(isDecryptDev, Equals, tc.hasEncdev)
 		}
 		// BlockPCRProtectionPolicies should be called whenever there is a TPM device
 		// detected, regardless of whether secure boot is enabled or there is an


### PR DESCRIPTION
Refactor UnlockVolumeUsingSealedKeyIfEncrypted to always check the disk for
partitions first, then do the TPM connection. This is so that we always know
for sure (if we can know and FindMatchingPartitionUUID doesn't have a
catastrophic error) when we return from UnlockVolumeUsingSealedKeyIfEncrypted
that there is an encrypted device or not. This will make the degraded
recover implementation more robust as it means that even with TPM errors
for i.e. unlocking ubuntu-data-enc, we will still know that we should try
to unlock ubuntu-save.

Additionally, we will want to be able to call this function with different
sealed keys for ubuntu-data, either the main run object or the fallback
object, both of which will be in the encryption dir on ubuntu-seed. As such,
take in a specific key to use rather than construct the name of the keyfile.

Finally, update usage of UnlockVolumeUsingSealedKeyIfEncrypted in 
snap-bootstrap to account for this change.

Broken out from #9592