### PR TITLE
tests: using systemd-run instead of manually create a systemd unit - part 1

### DIFF
--- a/tests/core/custom-device-reg-extras/task.yaml
+++ b/tests/core/custom-device-reg-extras/task.yaml
@@ -14,8 +14,6 @@ prepare: |
     fi
     #shellcheck source=tests/lib/core-config.sh
     . "$TESTSLIB"/core-config.sh
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB"/systemd.sh
 
     systemctl stop snapd.service snapd.socket
     clean_snapd_lib
@@ -37,7 +35,8 @@ prepare: |
     prepare_testrootorg_store
 
     # start fake device svc
-    systemd_create_and_start_unit fakedevicesvc "$(command -v fakedevicesvc) localhost:11029"
+    #shellcheck disable=SC2148
+    systemd-run --unit fakedevicesvc $(command -v fakedevicesvc) localhost:11029
 
     # kick first boot again
     systemctl start snapd.service snapd.socket
@@ -52,10 +51,7 @@ restore: |
     fi
     #shellcheck source=tests/lib/core-config.sh
     . "$TESTSLIB"/core-config.sh
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB"/systemd.sh
-    systemctl stop snapd.service snapd.socket
-    systemd_stop_and_destroy_unit fakedevicesvc
+    systemctl stop snapd.service snapd.socket fakedevicesvc
     clean_snapd_lib
 
     # Restore pc snap configuration

--- a/tests/core/custom-device-reg-extras/task.yaml
+++ b/tests/core/custom-device-reg-extras/task.yaml
@@ -36,7 +36,7 @@ prepare: |
 
     # start fake device svc
     #shellcheck disable=SC2148
-    systemd-run --unit fakedevicesvc $(command -v fakedevicesvc) localhost:11029
+    systemd-run --unit fakedevicesvc fakedevicesvc localhost:11029
 
     # kick first boot again
     systemctl start snapd.service snapd.socket

--- a/tests/core/custom-device-reg/task.yaml
+++ b/tests/core/custom-device-reg/task.yaml
@@ -13,8 +13,6 @@ prepare: |
     fi
     #shellcheck source=tests/lib/core-config.sh
     . "$TESTSLIB"/core-config.sh
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB"/systemd.sh
 
     systemctl stop snapd.service snapd.socket
     clean_snapd_lib
@@ -36,7 +34,8 @@ prepare: |
     prepare_testrootorg_store
 
     # start fake device svc
-    systemd_create_and_start_unit fakedevicesvc "$(command -v fakedevicesvc) localhost:11029"
+    #shellcheck disable=SC2148
+    systemd-run --unit fakedevicesvc $(command -v fakedevicesvc) localhost:11029
 
     # kick first boot again
     systemctl start snapd.service snapd.socket
@@ -51,11 +50,8 @@ restore: |
     fi
     #shellcheck source=tests/lib/core-config.sh
     . "$TESTSLIB"/core-config.sh
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB"/systemd.sh
 
-    systemctl stop snapd.service snapd.socket
-    systemd_stop_and_destroy_unit fakedevicesvc
+    systemctl stop snapd.service snapd.socket fakedevicesvc
     clean_snapd_lib
 
     # Restore pc snap configuration

--- a/tests/core/custom-device-reg/task.yaml
+++ b/tests/core/custom-device-reg/task.yaml
@@ -35,7 +35,7 @@ prepare: |
 
     # start fake device svc
     #shellcheck disable=SC2148
-    systemd-run --unit fakedevicesvc $(command -v fakedevicesvc) localhost:11029
+    systemd-run --unit fakedevicesvc fakedevicesvc localhost:11029
 
     # kick first boot again
     systemctl start snapd.service snapd.socket

--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -10,11 +10,8 @@ prepare: |
     if [ $rc = 4 ]; then
         # systemctl(1) exit code 4: no such unit
 
-        #shellcheck source=tests/lib/systemd.sh
-        . "$TESTSLIB"/systemd.sh
-
         # start fake rsyslog service
-        systemd_create_and_start_unit rsyslog "/bin/sleep 2h"
+        systemd-run --unit rsyslog /bin/sleep 2h
 
         # create a flag to indicate the ryslog service is fake
         touch rsyslog.fake
@@ -22,9 +19,7 @@ prepare: |
 
 restore: |
     if [ -f rsyslog.fake ]; then
-        #shellcheck source=tests/lib/systemd.sh
-        . "$TESTSLIB"/systemd.sh
-        systemd_stop_and_destroy_unit rsyslog
+        systemctl stop rsyslog
     else
         systemctl enable rsyslog.service
         systemctl start rsyslog.service

--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -10,8 +10,11 @@ prepare: |
     if [ $rc = 4 ]; then
         # systemctl(1) exit code 4: no such unit
 
+        #shellcheck source=tests/lib/systemd.sh
+        . "$TESTSLIB"/systemd.sh
+
         # start fake rsyslog service
-        systemd-run --unit rsyslog /bin/sleep 2h
+        systemd_create_and_start_unit rsyslog "/bin/sleep 2h"
 
         # create a flag to indicate the ryslog service is fake
         touch rsyslog.fake
@@ -19,7 +22,9 @@ prepare: |
 
 restore: |
     if [ -f rsyslog.fake ]; then
-        systemctl stop rsyslog
+        #shellcheck source=tests/lib/systemd.sh
+        . "$TESTSLIB"/systemd.sh
+        systemd_stop_and_destroy_unit rsyslog
     else
         systemctl enable rsyslog.service
         systemctl start rsyslog.service

--- a/tests/lib/network.sh
+++ b/tests/lib/network.sh
@@ -21,14 +21,8 @@ wait_listen_port(){
 
 make_network_service() {
     SERVICE_NAME="$1"
-    SERVICE_FILE="$2"
-    PORT="$3"
+    PORT="$2"
 
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB"/systemd.sh
-
-    printf '#!/bin/sh -e\nwhile true; do printf '\''HTTP/1.1 200 OK\\n\\nok\\n'\'' |  nc -l -p %s -w 1; done' "$PORT" > "$SERVICE_FILE"
-    chmod a+x "$SERVICE_FILE"
-    systemd_create_and_start_unit "$SERVICE_NAME" "$(readlink -f "$SERVICE_FILE")"
+    systemd-run --unit "$SERVICE_NAME" sh -c "while true; do printf 'HTTP/1.1 200 OK\\n\\nok\\n' |  nc -l -p $PORT -w 1; done"
     wait_listen_port "$PORT"
 }

--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -1,7 +1,8 @@
 summary: |
     Test gadget customized device initialisation and registration also on classic
 
-systems: [-ubuntu-core-*]
+# ubuntu-14.04: systemd-run not supported
+systems: [-ubuntu-core-*, -ubuntu-14.04*]
 
 environment:
     SEED_DIR: /var/lib/snapd/seed
@@ -13,8 +14,6 @@ prepare: |
         echo "This test needs test keys to be trusted"
         exit
     fi
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB/systemd.sh"
 
     snap pack "$TESTSLIB/snaps/classic-gadget"
     snap download "--$CORE_CHANNEL" core
@@ -41,18 +40,17 @@ prepare: |
     echo "Copy the needed snaps to $SEED_DIR/snaps"
     cp ./core_*.snap "$SEED_DIR/snaps/core.snap"
     cp ./classic-gadget_1.0_all.snap "$SEED_DIR/snaps/classic-gadget.snap"
+
     # start fake device svc
-    systemd_create_and_start_unit fakedevicesvc "$(command -v fakedevicesvc) localhost:11029"
+    #shellcheck disable=SC2148
+    systemd-run --unit fakedevicesvc $(command -v fakedevicesvc) localhost:11029
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
     fi
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB/systemd.sh"
-    systemctl stop snapd.service snapd.socket
-    systemd_stop_and_destroy_unit fakedevicesvc
+    systemctl stop snapd.service snapd.socket fakedevicesvc
 
     rm -rf "$SEED_DIR"
     rm -f -- *.snap

--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -43,7 +43,7 @@ prepare: |
 
     # start fake device svc
     #shellcheck disable=SC2148
-    systemd-run --unit fakedevicesvc $(command -v fakedevicesvc) localhost:11029
+    systemd-run --unit fakedevicesvc fakedevicesvc localhost:11029
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -41,7 +41,7 @@ prepare: |
 
     # start fake device svc
     #shellcheck disable=SC2148
-    systemd-run --unit fakedevicesvc $(command -v fakedevicesvc) localhost:11029
+    systemd-run --unit fakedevicesvc fakedevicesvc localhost:11029
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that prepare-image --classic works.
 
-systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
+# ubuntu-14.04: systemd-run not supported
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -ubuntu-14.04*]
 
 backends: [-autopkgtest]
 

--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -40,18 +40,15 @@ prepare: |
     cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"
 
     # start fake device svc
-    systemd_create_and_start_unit fakedevicesvc "$(command -v fakedevicesvc) localhost:11029"
+    #shellcheck disable=SC2148
+    systemd-run --unit fakedevicesvc $(command -v fakedevicesvc) localhost:11029
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
     fi
-
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB/systemd.sh"
-    systemctl stop snapd.service snapd.socket
-    systemd_stop_and_destroy_unit fakedevicesvc
+    systemctl stop snapd.service snapd.socket fakedevicesvc
 
     rm -rf "$SEED_DIR"
     systemctl start snapd.socket snapd.service

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -1,6 +1,7 @@
 summary: Ensure that the network-control interface works.
 
-systems: [-fedora-*, -opensuse-*]
+# ubuntu-14.04: systemd-run not supported
+systems: [-fedora-*, -opensuse-*, -ubuntu-14.04*]
 
 details: |
     The network-control interface allows a snap to configure networking.
@@ -15,7 +16,6 @@ details: |
 
 environment:
     PORT: 8081
-    SERVICE_FILE: "./service.sh"
     SERVICE_NAME: "test-service"
     ARP_ENTRY_ADDR: "30.30.30.30"
 
@@ -26,16 +26,13 @@ prepare: |
     echo "And a network service is up"
     # shellcheck source=tests/lib/network.sh
     . "$TESTSLIB"/network.sh
-    make_network_service "$SERVICE_NAME" "$SERVICE_FILE" "$PORT"
+    make_network_service "$SERVICE_NAME" "$PORT"
 
 restore: |
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB/systemd.sh"
     #shellcheck source=tests/lib/network.sh
     . "$TESTSLIB/network.sh"
 
-    #shellcheck disable=SC2153
-    systemd_stop_and_destroy_unit "$SERVICE_NAME"
+    systemctl stop "$SERVICE_NAME"
     arp -d "$ARP_ENTRY_ADDR" -i "$(get_default_iface)" || true
 
     ip netns delete test-ns || true

--- a/tests/main/interfaces-network-observe/task.yaml
+++ b/tests/main/interfaces-network-observe/task.yaml
@@ -1,6 +1,7 @@
 summary: Ensure that the network-observe interface works
 
-systems: [-fedora-*, -opensuse-*]
+# ubuntu-14.04: systemd-run not supported
+systems: [-fedora-*, -opensuse-*, -ubuntu-14.04*]
 
 details: |
     The network-observe interface allows a snap to query the network status information.

--- a/tests/main/interfaces-network-observe/task.yaml
+++ b/tests/main/interfaces-network-observe/task.yaml
@@ -14,7 +14,6 @@ details: |
 
 environment:
     PORT: 8081
-    SERVICE_FILE: "./service.sh"
     SERVICE_NAME: "test-service"
 
 prepare: |
@@ -24,14 +23,10 @@ prepare: |
     echo "And a network service is up"
     # shellcheck source=tests/lib/network.sh
     . "$TESTSLIB"/network.sh
-    make_network_service "$SERVICE_NAME" "$SERVICE_FILE" "$PORT"
+    make_network_service "$SERVICE_NAME" "$PORT"
 
 restore: |
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB/systemd.sh"
-
-    #shellcheck disable=SC2153
-    systemd_stop_and_destroy_unit "$SERVICE_NAME"
+    systemctl stop "$SERVICE_NAME"
 
 execute: |
     echo "The interface is disconnected by default"

--- a/tests/main/interfaces-network/task.yaml
+++ b/tests/main/interfaces-network/task.yaml
@@ -10,12 +10,12 @@ details: |
     A snap declaring a plug on this interface must be able to access network services.
 
 # amazon: uses nmap-netcat
-systems: [-fedora-*, -opensuse-*, -amazon-*, -centos-*]
+# ubuntu-14.04: systemd-run not supported
+systems: [-fedora-*, -opensuse-*, -amazon-*, -centos-*, -ubuntu-14.04*]
 
 environment:
     SNAP_NAME: network-consumer
     PORT: 8081
-    SERVICE_FILE: "./service.sh"
     SERVICE_NAME: "test-service"
 
 prepare: |
@@ -25,13 +25,10 @@ prepare: |
     echo "And a service is listening"
     # shellcheck source=tests/lib/network.sh
     . "$TESTSLIB"/network.sh
-    make_network_service "$SERVICE_NAME" "$SERVICE_FILE" "$PORT"
+    make_network_service "$SERVICE_NAME" "$PORT"
 
 restore: |
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB"/systemd.sh
-    #shellcheck disable=SC2153
-    systemd_stop_and_destroy_unit "$SERVICE_NAME"
+    systemctl stop "$SERVICE_NAME"
 
 execute: |
     echo "The interface is connected by default"

--- a/tests/main/try/task.yaml
+++ b/tests/main/try/task.yaml
@@ -1,25 +1,22 @@
 summary: Check that try command works
 
 # s390x does not have /dev/kmsg
-systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -ubuntu-*-s390x, -centos-*]
+# ubuntu-14.04: systemd-run not supported
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -ubuntu-*-s390x, -centos-*, -ubuntu-14.04*]
 
 environment:
     PORT: 8081
-    SERVICE_FILE: "./service.sh"
     READABLE_FILE: "/var/snap/test-snapd-tools/x1/file.txt"
     SERVICE_NAME: "test-service"
 
 prepare: |
     # shellcheck source=tests/lib/network.sh
     . "$TESTSLIB"/network.sh
-    make_network_service "$SERVICE_NAME" "$SERVICE_FILE" "$PORT"
+    make_network_service "$SERVICE_NAME" "$PORT"
 
 restore: |
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB"/systemd.sh
-    #shellcheck disable=SC2153
-    systemd_stop_and_destroy_unit "$SERVICE_NAME"
-    rm -f "$SERVICE_FILE" "$READABLE_FILE"
+    systemctl stop "$SERVICE_NAME"
+    rm -f "$READABLE_FILE"
 
 execute: |
     echo "Given a buildable snap in a known directory"


### PR DESCRIPTION
This is a task to start replacing the system helper by systemd-run for non-persistent services. 
