### PR TITLE
secboot, many: return UnlockMethod from Unlock* methods for future usage

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
@@ -39,8 +39,8 @@ func init() {
 	secbootMeasureSnapModelWhenPossible = func(_ func() (*asserts.Model, error)) error {
 		return errNotImplemented
 	}
-	secbootUnlockVolumeUsingSealedKeyIfEncrypted = func(disk disks.Disk, name string, encryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (string, bool, error) {
-		return "", false, errNotImplemented
+	secbootUnlockVolumeUsingSealedKeyIfEncrypted = func(disk disks.Disk, name string, encryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+		return secboot.UnlockResult{}, errNotImplemented
 	}
 	secbootUnlockEncryptedVolumeUsingKey = func(disk disks.Disk, name string, key []byte) (string, error) {
 		return "", errNotImplemented

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -78,7 +78,7 @@ func MockDefaultMarkerFile(p string) (restore func()) {
 	}
 }
 
-func MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(f func(disk disks.Disk, name string, encryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (string, bool, error)) (restore func()) {
+func MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(f func(disk disks.Disk, name string, encryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error)) (restore func()) {
 	old := secbootUnlockVolumeUsingSealedKeyIfEncrypted
 	secbootUnlockVolumeUsingSealedKeyIfEncrypted = f
 	return func() {

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -120,6 +120,8 @@ const (
 	// UnlockedWithRecoveryKey indicates that the device was unlocked by the
 	// user providing the recovery key at the prompt.
 	UnlockedWithRecoveryKey
+	// UnlockStatusUnknown indicates that the unlock status of the device is not clear.
+	UnlockStatusUnknown
 )
 
 // UnlockResult is the result of trying to unlock a volume.

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -106,3 +106,37 @@ type UnlockVolumeUsingSealedKeyOptions struct {
 	// will be attempted if activation with the sealed key failed.
 	AllowRecoveryKey bool
 }
+
+// UnlockMethod is the method that was used to unlock a volume.
+type UnlockMethod int
+
+const (
+	// NotUnlocked indicates that the device was either not unlocked or is not
+	// an encrypted device.
+	NotUnlocked UnlockMethod = iota
+	// UnlockedWithSealedKey indicates that the device was unlocked with the
+	// provided sealed key object.
+	UnlockedWithSealedKey
+	// UnlockedWithRecoveryKey indicates that the device was unlocked by the
+	// user providing the recovery key at the prompt.
+	UnlockedWithRecoveryKey
+	// UnlockedWithUnsealedKey indicates that the device was unlocked with the
+	// provided key object that is not sealed.
+	UnlockedWithUnsealedKey
+)
+
+// UnlockResult is the result of trying to unlock a volume.
+type UnlockResult struct {
+	// Device is the decrypted device, if encrypted or just the unencrypted
+	// device.
+	Device string
+	// IsDecryptedDevice indicates if Device is a decrypted device or an
+	// unencrypted device.
+	IsDecryptedDevice bool
+	// UnlockMethod is the method used to unlock the device. Valid values are
+	// - NotUnlocked
+	// - UnlockedWithRecoveryKey
+	// - UnlockedWithSealedKey
+	// - UnlockedWithUnsealedKey
+	UnlockMethod UnlockMethod
+}

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -120,15 +120,12 @@ const (
 	// UnlockedWithRecoveryKey indicates that the device was unlocked by the
 	// user providing the recovery key at the prompt.
 	UnlockedWithRecoveryKey
-	// UnlockedWithUnsealedKey indicates that the device was unlocked with the
-	// provided key object that is not sealed.
-	UnlockedWithUnsealedKey
 )
 
 // UnlockResult is the result of trying to unlock a volume.
 type UnlockResult struct {
 	// Device is the decrypted device, if encrypted or just the unencrypted
-	// device.
+	// device. Device can be empty when none was found.
 	Device string
 	// IsDecryptedDevice indicates if Device is a decrypted device or an
 	// unencrypted device.

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -325,11 +325,8 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(
 		// otherwise we have a tpm and we should use the sealed key first, but
 		// this method will fallback to using the recovery key if enabled
 		method, err := unlockEncryptedPartitionWithSealedKey(tpm, mapperName, res.Device, sealedEncryptionKeyFile, "", opts.AllowRecoveryKey)
-		if err != nil {
-			return err
-		}
 		res.UnlockMethod = method
-		return nil
+		return err
 	}()
 	if err != nil {
 		return res, err
@@ -428,7 +425,7 @@ func unlockEncryptedPartitionWithSealedKey(tpm *sb.TPMConnection, name, device, 
 			return UnlockedWithRecoveryKey, nil
 		}
 		// no other error is possible when activation succeeded
-		return NotUnlocked, fmt.Errorf("internal error: volume activated with unexpected error: %v", err)
+		return UnlockStatusUnknown, fmt.Errorf("internal error: volume activated with unexpected error: %v", err)
 	}
 	// ActivateVolumeWithTPMSealedKey should always return an error if activated == false
 	return NotUnlocked, fmt.Errorf("cannot activate encrypted device %q: %v", device, err)

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -385,6 +385,20 @@ func UnlockEncryptedVolumeWithRecoveryKey(name, device string) error {
 	return nil
 }
 
+func isActivatedWithRecoveryKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	// with non-nil err, we should check for err being ActivateWithTPMSealedKeyError
+	// and RecoveryKeyUsageErr inside that being nil - this indicates that the
+	// recovery key was used to unlock it
+	activateErr, ok := err.(*sb.ActivateWithTPMSealedKeyError)
+	if !ok {
+		return false
+	}
+	return activateErr.RecoveryKeyUsageErr == nil
+}
+
 // unlockEncryptedPartitionWithSealedKey unseals the keyfile and opens an encrypted
 // device. If activation with the sealed key fails, this function will attempt to
 // activate it with the fallback recovery key instead.
@@ -400,32 +414,24 @@ func unlockEncryptedPartitionWithSealedKey(tpm *sb.TPMConnection, name, device, 
 		options.RecoveryKeyTries = 3
 	}
 
-	var method UnlockMethod
-
 	// XXX: pinfile is currently not used
 	activated, err := sbActivateVolumeWithTPMSealedKey(tpm, name, device, keyfile, nil, &options)
 
-	// with non-nil err, we should check for err being ActivateWithTPMSealedKeyError
-	// and RecoveryKeyUsageErr inside that being nil - this indicates that the
-	// recovery key was used to unlock it
-	if !activated {
-		// ActivateVolumeWithTPMSealedKey should always return an error if activated == false
-		return NotUnlocked, fmt.Errorf("cannot activate encrypted device %q: %v", device, err)
-	}
-	if err != nil {
-		if activateErr, ok := err.(*sb.ActivateWithTPMSealedKeyError); ok {
-			if activateErr.RecoveryKeyUsageErr == nil {
-				// then we know for sure that it was unlocked with recover key
-				method = UnlockedWithRecoveryKey
-			}
+	if activated {
+		// non nil error may indicate the volume was unlocked using the
+		// recovery key
+		if err == nil {
+			logger.Noticef("successfully activated encrypted device %q with TPM", device)
+			return UnlockedWithSealedKey, nil
+		} else if isActivatedWithRecoveryKey(err) {
+			logger.Noticef("successfully activated encrypted device %q using a fallback activation method", device)
+			return UnlockedWithRecoveryKey, nil
 		}
-		logger.Noticef("successfully activated encrypted device %q using a fallback activation method", device)
-	} else {
-		method = UnlockedWithSealedKey
-		logger.Noticef("successfully activated encrypted device %q with TPM", device)
+		// no other error is possible when activation succeeded
+		return NotUnlocked, fmt.Errorf("internal error: volume activated with unexpected error: %v", err)
 	}
-
-	return method, nil
+	// ActivateVolumeWithTPMSealedKey should always return an error if activated == false
+	return NotUnlocked, fmt.Errorf("cannot activate encrypted device %q: %v", device, err)
 }
 
 // unlockEncryptedPartitionWithKey unlocks encrypted partition with the provided

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -408,8 +408,9 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 			activateErr: &sb.ActivateWithTPMSealedKeyError{
 				RecoveryKeyUsageErr: fmt.Errorf("unexpected"),
 			},
-			err:  `internal error: volume activated with unexpected error: .* \(unexpected\)`,
-			disk: mockDiskWithEncDev,
+			expUnlockMethod: secboot.UnlockStatusUnknown,
+			err:             `internal error: volume activated with unexpected error: .* \(unexpected\)`,
+			disk:            mockDiskWithEncDev,
 		}, {
 			// activation works but lock fails, without encrypted device (lock requested)
 			tpmEnabled: true, lockRequest: true, activated: true,


### PR DESCRIPTION
We eventually will want to know how we unlocked a volume for implementing
degraded mode and providing some indication to the user as to what happened
automatically during boot.

As such, change UnlockUsingSealedKeyIfEncrypted to return an UnlockResult to be
inspected eventually from cmd_initramfs_mounts.go.