### PR TITLE
o/devistate: fix chaining of tasks related to regular snaps when preseeding

### DIFF
--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -179,10 +179,6 @@ func checkPreseedOrder(c *C, tsAll []*state.TaskSet, snaps ...string) {
 			continue
 		}
 
-		snapsup, err := snapstate.TaskSnapSetup(task0)
-		c.Assert(err, IsNil, Commentf("%#v", task0))
-		c.Check(snapsup.InstanceName(), Equals, snaps[matched])
-		matched++
 		if i == 0 {
 			c.Check(waitTasks, HasLen, 0)
 		} else {
@@ -190,6 +186,47 @@ func checkPreseedOrder(c *C, tsAll []*state.TaskSet, snaps ...string) {
 			c.Assert(waitTasks[0].Kind(), Equals, prevTask.Kind())
 			c.Check(waitTasks[0], Equals, prevTask)
 		}
+
+		// make sure that install-hooks wait for the previous snap, and for
+		// mark-preseeded.
+		hookEdgeTask, err := ts.Edge(snapstate.HooksEdge)
+		c.Assert(err, IsNil)
+		c.Assert(hookEdgeTask.Kind(), Equals, "run-hook")
+		var hsup hookstate.HookSetup
+		c.Assert(hookEdgeTask.Get("hook-setup", &hsup), IsNil)
+		c.Check(hsup.Hook, Equals, "install")
+		if hsup.Snap != "core" && hsup.Snap != "core18" && hsup.Snap != "snapd" {
+			var waitsForMarkPreseeded, waitsForPreviousSnapHook, waitsForPreviousSnap bool
+			for _, wt := range hookEdgeTask.WaitTasks() {
+				switch wt.Kind() {
+				case "setup-aliases":
+					continue
+				case "run-hook":
+					var hsup hookstate.HookSetup
+					c.Assert(wt.Get("hook-setup", &hsup), IsNil)
+					c.Check(hsup.Snap, Equals, snaps[matched-1])
+					waitsForPreviousSnapHook = true
+				case "mark-preseeded":
+					waitsForMarkPreseeded = true
+				case "prerequisites":
+				default:
+					snapsup, err := snapstate.TaskSnapSetup(wt)
+					c.Assert(err, IsNil, Commentf("%#v", wt))
+					c.Check(snapsup.SnapName(), Equals, snaps[matched-1], Commentf("%s: %#v", hsup.Snap, wt))
+					waitsForPreviousSnap = true
+				}
+			}
+			c.Assert(waitsForMarkPreseeded, Equals, true)
+			c.Assert(waitsForPreviousSnapHook, Equals, true)
+			if snaps[matched-1] != "core" && snaps[matched-1] != "core18" && snaps[matched-1] != "pc" {
+				c.Check(waitsForPreviousSnap, Equals, true, Commentf("%s", snaps[matched-1]))
+			}
+		}
+
+		snapsup, err := snapstate.TaskSnapSetup(task0)
+		c.Assert(err, IsNil, Commentf("%#v", task0))
+		c.Check(snapsup.InstanceName(), Equals, snaps[matched])
+		matched++
 
 		// find setup-aliases task in current taskset; its position
 		// is not fixed due to e.g. optional update-gadget-assets task.
@@ -273,6 +310,13 @@ version: 1.0
 	fooFname, fooDecl, fooRev := s.MakeAssertedSnap(c, snapYaml, nil, snap.R(128), "developerid")
 	s.WriteAssertions("foo.asserts", s.devAcct, fooRev, fooDecl)
 
+	// put a firstboot snap into the SnapBlobDir
+	snapYaml2 := `name: bar
+version: 1.0
+`
+	barFname, barDecl, barRev := s.MakeAssertedSnap(c, snapYaml2, nil, snap.R(33), "developerid")
+	s.WriteAssertions("bar.asserts", s.devAcct, barRev, barDecl)
+
 	// add a model assertion and its chain
 	assertsChain := s.makeModelAssertionChain(c, "my-model-classic", nil)
 	s.WriteAssertions("model.asserts", assertsChain...)
@@ -282,9 +326,11 @@ version: 1.0
 snaps:
  - name: foo
    file: %s
+ - name: bar
+   file: %s
  - name: core
    file: %s
-`, fooFname, coreFname))
+`, fooFname, barFname, coreFname))
 	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
@@ -304,7 +350,7 @@ snaps:
 	}
 	c.Assert(st.Changes(), HasLen, 1)
 
-	checkPreseedOrder(c, tsAll, "core", "foo")
+	checkPreseedOrder(c, tsAll, "core", "foo", "bar")
 
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
@@ -329,6 +375,8 @@ snaps:
 	_, err = snapstate.CurrentInfo(diskState, "core")
 	c.Check(err, IsNil)
 	_, err = snapstate.CurrentInfo(diskState, "foo")
+	c.Check(err, IsNil)
+	_, err = snapstate.CurrentInfo(diskState, "bar")
 	c.Check(err, IsNil)
 
 	// but we're not considered seeded
@@ -389,8 +437,6 @@ snaps:
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, opts, s.perfTimings)
 	c.Assert(err, IsNil)
 
-	checkPreseedOrder(c, tsAll, "snapd", "core18", "foo")
-
 	// now run the change and check the result
 	chg := st.NewChange("seed", "run the populate from seed changes")
 	for _, ts := range tsAll {
@@ -398,6 +444,8 @@ snaps:
 	}
 	c.Assert(st.Changes(), HasLen, 1)
 	c.Assert(chg.Err(), IsNil)
+
+	checkPreseedOrder(c, tsAll, "snapd", "core18", "foo")
 
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -514,10 +514,6 @@ snaps:
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, opts, s.perfTimings)
 	c.Assert(err, IsNil)
 
-	checkOrder(c, tsAll, "core", "pc-kernel", "pc", "foo", "local")
-
-	checkTasks(c, tsAll)
-
 	// now run the change and check the result
 	// use the expected kind otherwise settle with start another one
 	chg := st.NewChange("seed", "run the populate from seed changes")
@@ -525,6 +521,9 @@ snaps:
 		chg.AddAll(ts)
 	}
 	c.Assert(st.Changes(), HasLen, 1)
+
+	checkOrder(c, tsAll, "core", "pc-kernel", "pc", "foo", "local")
+	checkTasks(c, tsAll)
 
 	// avoid device reg
 	chg1 := st.NewChange("become-operational", "init device")

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -133,3 +133,18 @@ execute: |
   # wait for postgres to come online
   sleep 10
   nested_exec "snap services" | MATCH "+test-postgres-system-usernames.postgres +enabled +active"
+
+  echo "Checking that mark-seeded task was executed last"
+  # snap debug timings are sorts by read-time, mark-seeded should be last
+  nested_exec "sudo snap debug timings 1" | tail -2 | MATCH "Mark system seeded"
+  # no task should have ready time after mark-seeded
+  # shellcheck disable=SC2046
+  MARK_SEEDED_TIME=$(date -d $(snap change 1 --abs-time | grep "Mark system seeded" | awk '{print $3}') "+%s")
+  for RT in $(snap change 1 --abs-time | grep Done | awk '{print $3}' )
+  do
+    READY_TIME=$(date -d "$RT" "+%s")
+    if [ "$READY_TIME" -gt "$MARK_SEEDED_TIME" ]; then
+      echo "Unexpected ready time greater than mark-seeded ready"
+      snap change 1
+    fi
+  done


### PR DESCRIPTION
At the moment, if more than one non-essential (i.e. regular app snap) snap is preseeded, only one is chained so that mark-seeded waits for it; tasks of other snaps are run after first boot when they should, but are not included in the wait chain of mark-seeded, so mark-seeded doesn't wait for them, and they may finish after seeding is marked "done".

To fix that, the chaining logic makes install-hook wait for all tasks of previous snaps.

