### PR TITLE
gadget/install: add progress logging

### DIFF
--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/install"
+	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -172,6 +173,8 @@ var mockOnDiskStructureWritable = gadget.OnDiskStructure{
 		StartOffset: 1260388352,
 		Index:       3,
 	},
+	// expanded to fill the disk
+	Size: 2*quantity.SizeGiB + 845*quantity.SizeMiB + 1031680,
 }
 
 func (s *partitionTestSuite) TestCreatePartitions(c *C) {

--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -91,6 +91,11 @@ type OnDiskStructure struct {
 
 	// Node identifies the device node of the block device.
 	Node string
+
+	// Size of the on disk structure, which is at least equal to the
+	// LaidOutStructure.Size but may be bigger if the partition was
+	// expanded.
+	Size quantity.Size
 }
 
 // OnDiskVolume holds information about the disk device including its partitioning
@@ -322,6 +327,7 @@ func BuildPartitionList(dl *OnDiskVolume, pv *LaidOutVolume) (sfdiskInput *bytes
 		toBeCreated = append(toBeCreated, OnDiskStructure{
 			LaidOutStructure: p,
 			Node:             node,
+			Size:             size,
 		})
 	}
 

--- a/gadget/ondisk_test.go
+++ b/gadget/ondisk_test.go
@@ -153,7 +153,7 @@ var mockOnDiskStructureSave = gadget.OnDiskStructure{
 	LaidOutStructure: gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
 			Name:       "Save",
-			Size:       134217728,
+			Size:       128 * quantity.SizeMiB,
 			Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
 			Role:       "system-save",
 			Label:      "ubuntu-save",
@@ -162,6 +162,7 @@ var mockOnDiskStructureSave = gadget.OnDiskStructure{
 		StartOffset: 1260388352,
 		Index:       3,
 	},
+	Size: 128 * quantity.SizeMiB,
 }
 
 var mockOnDiskStructureWritable = gadget.OnDiskStructure{
@@ -169,7 +170,7 @@ var mockOnDiskStructureWritable = gadget.OnDiskStructure{
 	LaidOutStructure: gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
 			Name:       "Writable",
-			Size:       1258291200,
+			Size:       1200 * quantity.SizeMiB,
 			Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
 			Role:       "system-data",
 			Label:      "ubuntu-data",
@@ -178,6 +179,8 @@ var mockOnDiskStructureWritable = gadget.OnDiskStructure{
 		StartOffset: 1394606080,
 		Index:       4,
 	},
+	// expanded to fill the disk
+	Size: 2*quantity.SizeGiB + 717*quantity.SizeMiB + 1031680,
 }
 
 func (s *ondiskTestSuite) TestDeviceInfoGPT(c *C) {


### PR DESCRIPTION
Add logs so that the console contains some information about the installation
progress.

```
snapd[1309]: handlers_install.go:160: create and deploy partitions
snapd[1309]: install.go:57: installing a new system
snapd[1309]: install.go:58:         gadget data from: /snap/pc/x1
snapd[1309]: install.go:60:         encryption: on
snapd[1309]: install.go:137: created new partition /dev/vda3 for structure #3 ("ubuntu-boot") (size 750 MiB) role system-boot
snapd[1309]: install.go:137: created new partition /dev/vda4 for structure #4 ("ubuntu-save") (size 16 MiB) role system-save
snapd[1309]: install.go:144: encrypting partition device /dev/vda4
snapd[1309]: install.go:160: encrypted device /dev/mapper/ubuntu-save
snapd[1309]: install.go:137: created new partition /dev/vda5 for structure #5 ("ubuntu-data") (size 1 GiB) role system-data
snapd[1309]: install.go:144: encrypting partition device /dev/vda5
snapd[1309]: install.go:160: encrypted device /dev/mapper/ubuntu-data
snapd[1309]: handlers_install.go:209: make system bootable
```

