### PR TITLE
tests: enable main lxd test on 20.10

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -4,8 +4,7 @@ summary: Ensure that lxd works
 # currently nor on ubuntu 14.04
 # TODO:UC20: enable for UC20
 # TODO: enable for ubuntu-16-32 again
-# TODO: enable ubuntu-20.10-64 once the image is available
-systems: [ubuntu-16.04*64, ubuntu-18.04*, ubuntu-20.04*, ubuntu-core-1*]
+systems: [ubuntu-16.04*64, ubuntu-18.04*, ubuntu-20.04*, ubuntu-20.10*, ubuntu-core-1*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro


### PR DESCRIPTION
It seems we forgot about enabling this test on 20.10 too.