### PR TITLE
tests: enable lxd test on ubuntu-core-20 and 16.04-32

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -2,9 +2,8 @@ summary: Ensure that lxd works
 
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
-# TODO:UC20: enable for UC20
 # TODO: enable for ubuntu-16-32 again
-systems: [ubuntu-16.04*64, ubuntu-18.04*, ubuntu-20.04*, ubuntu-20.10*, ubuntu-core-1*]
+systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*, ubuntu-core-*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro


### PR DESCRIPTION
This commit enables the lxd test on all Ubuntu releases except for
14.04. It also simplifies the systems: string to ensure it is run
as soon as we open e.g. ubuntu-21.04 for spread testing.
