### PR TITLE
cmd/snap-bootstrap,o/devicestate: use a secret to pair data and save

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -655,7 +655,7 @@ func (m *stateMachine) setUnlockStateWithFallbackKey(partName string, unlockRes 
 func newStateMachine(model *asserts.Model, disk disks.Disk) *stateMachine {
 	m := &stateMachine{
 		model: model,
-		disk: disk,
+		disk:  disk,
 		degradedState: &recoverDegradedState{
 			ErrorLog: []string{},
 		},
@@ -1065,7 +1065,10 @@ func checkDataAndSavaPairing(rootdir string) (bool, error) {
 		return false, err
 	}
 	// read the secret marker file from ubuntu-save
-	markerFile2 := filepath.Join(dirs.SnapFDEDirUnder(boot.InitramfsUbuntuSaveDir), "marker")
+	// TODO:UC20: this is a bit of an abuse of the Install*Dir variable, we
+	// should really only be using Initramfs*Dir variables since we are in the
+	// initramfs and not in install mode, no?
+	markerFile2 := filepath.Join(boot.InstallHostFDESaveDir, "marker")
 	marker2, err := ioutil.ReadFile(markerFile2)
 	if err != nil {
 		return false, err

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -680,7 +680,7 @@ func (m *stateMachine) execute() (finished bool, err error) {
 
 func (m *stateMachine) finalize() error {
 	// check soundness
-	// the grade check makes sure that if data was mounted unecrypted
+	// the grade check makes sure that if data was mounted unencrypted
 	// but the model is secured it will end up marked as untrusted
 	isEncrypted := m.isEncryptedDev || m.model.Grade() == asserts.ModelSecured
 	part := m.degradedState.partition("ubuntu-data")
@@ -1320,6 +1320,14 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 		}
 
 		if isEncryptedDev {
+			// in run mode the path to open an encrypted save is for
+			// data to be encrypted and the save key in it
+			// to be successfully used. This already should stop
+			// allowing to chose ubuntu-data to try to access
+			// save. as safety boot also stops if the keys cannot
+			// be locked.
+			// for symmetry with recover code and extra paranoia
+			// though also check that the markers match.
 			paired, err := checkDataAndSavaPairing(boot.InitramfsWritableDir)
 			if err != nil {
 				return err

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -679,9 +679,14 @@ func (m *stateMachine) finalize() error {
 	part := m.degradedState.partition("ubuntu-data")
 	if part.MountState == partitionMounted && m.isEncryptedDev {
 		// check that save and data match
+		// We want to avoid a chosen ubuntu-data
+		// (e.g. activated with a recovery key) to get access
+		// via its logins to the secrets in ubuntu-save (in
+		// particular the policy update auth key)
 		trustData, _ := checkDataAndSavaPairing(boot.InitramfsHostWritableDir)
 		if !trustData {
 			part.MountState = partitionMountedUntrusted
+			m.degradedState.LogErrorf("cannot trust ubuntu-data, ubuntu-save and ubuntu-data are not marked as from the same install")
 		}
 	}
 	return nil

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -254,7 +254,7 @@ func (s *initramfsMountsSuite) mockUbuntuSaveKeyAndMarker(c *C, rootDir, key, ma
 }
 
 func (s *initramfsMountsSuite) mockUbuntuSaveMarker(c *C, rootDir, marker string) {
-	markerPath := filepath.Join(dirs.SnapFDEDirUnder(rootDir), "marker")
+	markerPath := filepath.Join(rootDir, "device/fde", "marker")
 	c.Assert(os.MkdirAll(filepath.Dir(markerPath), 0700), IsNil)
 	c.Assert(ioutil.WriteFile(markerPath, []byte(marker), 0600), IsNil)
 }

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -4000,7 +4000,7 @@ recovery_system=20191118
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{},
+		"error-log": []interface{}{"cannot trust ubuntu-data, ubuntu-save and ubuntu-data are not marked as from the same install"},
 	})
 
 	bloader2, err := bootloader.Find("", nil)

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -473,6 +473,9 @@ func (s *deviceMgrInstallModeSuite) TestInstallSecuredWithTPMAndSave(c *C) {
 	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "recovery.key"), testutil.FileEquals, dataRecoveryKey[:])
 	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "ubuntu-save.key"), testutil.FileEquals, saveKey[:])
 	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "reinstall.key"), testutil.FileEquals, reinstallKey[:])
+	marker, err := ioutil.ReadFile(filepath.Join(boot.InstallHostFDEDataDir, "marker"))
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(boot.InstallHostFDESaveDir, "marker"), testutil.FileEquals, marker)
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallSecuredBypassEncryption(c *C) {

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -475,6 +475,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallSecuredWithTPMAndSave(c *C) {
 	c.Check(filepath.Join(boot.InstallHostFDEDataDir, "reinstall.key"), testutil.FileEquals, reinstallKey[:])
 	marker, err := ioutil.ReadFile(filepath.Join(boot.InstallHostFDEDataDir, "marker"))
 	c.Assert(err, IsNil)
+	c.Check(marker, HasLen, 32)
 	c.Check(filepath.Join(boot.InstallHostFDESaveDir, "marker"), testutil.FileEquals, marker)
 }
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -20,7 +20,6 @@
 package devicestate
 
 import (
-	"crypto/rand"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -36,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/randutil"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/sysconfig"
 )
@@ -247,9 +247,8 @@ func writeMarkers() error {
 		return err
 	}
 
-	markerSecret := make([]byte, 32)
-	// crypto rand is protected against short reads
-	_, err := rand.Read(markerSecret)
+	// generate a secret random marker
+	markerSecret, err := randutil.CryptoTokenBytes(32)
 	if err != nil {
 		return fmt.Errorf("cannot create ubuntu-data/save marker secret: %v", err)
 	}


### PR DESCRIPTION
this is to make sure that we don't use credentials from data to give access to a save from a different install
