### PR TITLE
spread.yaml: increase number of workers on 20.10

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -103,7 +103,7 @@ backends:
                   # XXX: old name, remove once new spread is deployed
                   secureboot: true
             - ubuntu-20.10-64:
-                  workers: 6
+                  workers: 8
                   image: ubuntu-20.10-64
 
             - debian-9-64:


### PR DESCRIPTION
The ubuntu-20.10 spread tests currently run with 6 workers.
However 20.04 and 18.04 use 8 workers and looking at the
spread runtime it seems like 20.10 is currently delaying
runs. So this commit increases the number of workers on
20.10 to 8.
