### PR TITLE
tests: set the opensuse tumbleweed system as manual in spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -136,6 +136,7 @@ backends:
                   workers: 6
             - opensuse-tumbleweed-64:
                   workers: 6
+                  manual: true
             - centos-8-64:
                   workers: 4
                   storage: preserve-size


### PR DESCRIPTION
The idea is to make periodical checks to determine if the problem related to the kernel
is already fixed.

The executions are still failing when doing "govendor sync". 

I'll set a spread-cron wekly execution 