### PR TITLE
secboot: call BlockPCRProtectionPolicies even if the TPM is disabled

### DIFF
--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -199,11 +199,6 @@ func LockTPMSealedKeys() error {
 		return fmt.Errorf("cannot lock TPM: %v", tpmErr)
 	}
 	defer tpm.Close()
-	// Also check if the TPM device is enabled. The platform firmware may disable the storage
-	// and endorsement hierarchies, but the device will remain visible to the operating system.
-	if !isTPMEnabled(tpm) {
-		return nil
-	}
 
 	// Lock access to the sealed keys. This should be called whenever there
 	// is a TPM device detected, regardless of whether secure boot is enabled
@@ -288,7 +283,7 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(
 	var mapperName string
 	err = func() error {
 		defer func() {
-			if opts.LockKeysOnFinish && tpmDeviceAvailable {
+			if opts.LockKeysOnFinish && tpmErr == nil {
 				// Lock access to the sealed keys. This should be called whenever there
 				// is a TPM device detected, regardless of whether secure boot is enabled
 				// or there is an encrypted volume to unlock. Note that snap-bootstrap can


### PR DESCRIPTION
BlockPCRProtectionPolicies inserts PCR events that signal the
transition from initramfs to runtime, in the same way that EV_SEPARATOR
events signal the transition from pre-OS (platform firmware) to
OS present. When the TPM is disabled, platform firmware will cap
PCRs 0-7 with a EV_SEPARATOR event. There is no reason for us not
to behave in a similar way.
