### PR TITLE
snap: add new "fde-setup" hooktype

### DIFF
--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -35,6 +35,7 @@ var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^connect-(?:plug|slot)-[-a-z0-9]+$")),
 	NewHookType(regexp.MustCompile("^disconnect-(?:plug|slot)-[-a-z0-9]+$")),
 	NewHookType(regexp.MustCompile("^check-health$")),
+	NewHookType(regexp.MustCompile("^fde-setup$")),
 }
 
 // HookType represents a pattern of supported hook names.


### PR DESCRIPTION
Even though this is trivial having this is useful when testing the full "fde-setup" branch. The reason is that snap-exec will read the hooks and discard hooks that are not valid. But snap-exec is taken from inside the core or snapd snap so right now to test the full fde-setup branch a bind mount of snap-exec is needed or a full rebuild of the core/snapd snap. With this PR a local snapd build is enough.