### PR TITLE
snap-bootstrap,secboot: call BlockPCRProtectionPolicies in all boot modes

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -105,7 +105,13 @@ func generateInitramfsMounts() (err error) {
 	// regardless of mode or early failures.
 	defer func() {
 		if e := secbootLockTPMSealedKeys(); e != nil {
-			err = fmt.Errorf("error locking access to sealed keys: %v", e)
+			e = fmt.Errorf("error locking access to sealed keys: %v", e)
+			if err == nil {
+				err = e
+			} else {
+				// preserve err but log
+				logger.Noticef("%v", e)
+			}
 		}
 	}()
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1493,7 +1493,6 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
 		c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
-			LockKeysOnFinish: true,
 			AllowRecoveryKey: true,
 		})
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -219,6 +219,9 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 	s.AddCleanup(main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		return secboot.UnlockResult{Device: filepath.Join("/dev/disk/by-partuuid", name+"-partuuid")}, nil
 	}))
+	s.AddCleanup(main.MockSecbootLockTPMSealedKeys(func() error {
+		return nil
+	}))
 }
 
 // makeSnapFilesOnEarlyBootUbuntuData creates the snap files on ubuntu-data as
@@ -380,6 +383,13 @@ func (s *initramfsMountsSuite) mockSystemdMountSequence(c *C, mounts []systemdMo
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install snapd_recovery_system="+s.sysLabel)
 
+	// ensure that we check that access to sealed keys were locked
+	sealedKeysLocked := false
+	defer main.MockSecbootLockTPMSealedKeys(func() error {
+		sealedKeysLocked = true
+		return nil
+	})()
+
 	restore := s.mockSystemdMountSequence(c, []systemdMount{
 		ubuntuLabelMount("ubuntu-seed", "install"),
 		s.makeSeedSnapSystemdMount(snap.TypeSnapd),
@@ -402,6 +412,8 @@ recovery_system=20191118
 `)
 	cloudInitDisable := filepath.Join(boot.InitramfsWritableDir, "_writable_defaults/etc/cloud/cloud-init.disabled")
 	c.Check(cloudInitDisable, testutil.FilePresent)
+
+	c.Check(sealedKeysLocked, Equals, true)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeGadgetDefaultsHappy(c *C) {
@@ -546,7 +558,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUnencryptedWithSaveHapp
 	c.Assert(err, IsNil)
 }
 
-func (s *initramfsMountsSuite) TestInitramfsMountsRunModeNoSaveUnencryptedHappy(c *C) {
+func (s *initramfsMountsSuite) testInitramfsMountsRunModeNoSaveUnencrypted(c *C) error {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	restore := disks.MockMountPointDisksToPartitionMapping(
@@ -587,7 +599,31 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeNoSaveUnencryptedHappy(
 	c.Assert(err, IsNil)
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+	return err
+}
+
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeNoSaveUnencryptedHappy(c *C) {
+	// ensure that we check that access to sealed keys were locked
+	sealedKeysLocked := false
+	defer main.MockSecbootLockTPMSealedKeys(func() error {
+		sealedKeysLocked = true
+		return nil
+	})()
+
+	err := s.testInitramfsMountsRunModeNoSaveUnencrypted(c)
 	c.Assert(err, IsNil)
+
+	c.Check(sealedKeysLocked, Equals, true)
+}
+
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeNoSaveUnencryptedKeyLockingUnhappy(c *C) {
+	// have blocking sealed keys fail
+	defer main.MockSecbootLockTPMSealedKeys(func() error {
+		return fmt.Errorf("blocking keys failed")
+	})()
+
+	err := s.testInitramfsMountsRunModeNoSaveUnencrypted(c)
+	c.Assert(err, ErrorMatches, "error locking access to sealed keys: blocking keys failed")
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeRealSystemdMountTimesOutNoMount(c *C) {
@@ -1452,6 +1488,13 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeWithBootedKernelPartUUI
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
+	// ensure that we check that access to sealed keys were locked
+	sealedKeysLocked := false
+	defer main.MockSecbootLockTPMSealedKeys(func() error {
+		sealedKeysLocked = true
+		return nil
+	})()
+
 	restore := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuBootDir}:                          defaultEncBootDisk,
@@ -1564,6 +1607,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C
 	c.Check(measureEpochCalls, Equals, 1)
 	c.Check(measureModelCalls, Equals, 1)
 	c.Check(measuredModel, DeepEquals, s.model)
+	c.Check(sealedKeysLocked, Equals, true)
 
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "secboot-epoch-measured"), testutil.FilePresent)
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "run-model-measured"), testutil.FilePresent)
@@ -1655,6 +1699,13 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyNoS
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyUnlockSaveFail(c *C) {
+	// ensure that we check that access to sealed keys were locked
+	sealedKeysLocked := false
+	defer main.MockSecbootLockTPMSealedKeys(func() error {
+		sealedKeysLocked = true
+		return fmt.Errorf("blocking keys failed")
+	})()
+
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 	restore := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
@@ -1725,6 +1776,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyUnl
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, ErrorMatches, "cannot unlock ubuntu-save volume: ubuntu-save unlock fail")
 	c.Check(dataActivated, Equals, true)
+	// locking sealing keys was attempted, error was only logged
+	c.Check(sealedKeysLocked, Equals, true)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedNoModel(c *C) {

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -99,9 +99,6 @@ type ResealKeysParams struct {
 // UnlockVolumeUsingSealedKeyOptions contains options for unlocking encrypted
 // volumes using keys sealed to the TPM.
 type UnlockVolumeUsingSealedKeyOptions struct {
-	// LockKeysOnFinish when true indicates that access to the sealed keys
-	// shall be locked after the operation using the options completes.
-	LockKeysOnFinish bool
 	// AllowRecoveryKey when true indicates activation with the recovery key
 	// will be attempted if activation with the sealed key failed.
 	AllowRecoveryKey bool

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -350,8 +350,8 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 			disk:            mockDiskWithEncDev,
 			expUnlockMethod: secboot.UnlockedWithSealedKey,
 		}, {
-			// happy case with tpm and encrypted device (lock requested) with
-			// an alternative keyfile
+			// happy case with tpm and encrypted device
+			// with an alternative keyfile
 			tpmEnabled: true, hasEncdev: true,
 			activated:       true,
 			disk:            mockDiskWithEncDev,

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1111,7 +1111,10 @@ nested_start_classic_vm() {
 }
 
 nested_destroy_vm() {
-    systemd_stop_and_destroy_unit "$NESTED_VM"
+    # XXX: is this the right way to do this ???
+    systemctl stop "$NESTED_VM"
+    rm -f "/etc/systemd/system/$NESTED_VM.service"
+    rm -rf "/etc/systemd/system/$NESTED_VM.service.d"
 
     local CURRENT_IMAGE
     CURRENT_IMAGE="$NESTED_IMAGES_DIR/$(nested_get_current_image_name)" 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1111,10 +1111,7 @@ nested_start_classic_vm() {
 }
 
 nested_destroy_vm() {
-    # XXX: is this the right way to do this ???
-    systemctl stop "$NESTED_VM"
-    rm -f "/etc/systemd/system/$NESTED_VM.service"
-    rm -rf "/etc/systemd/system/$NESTED_VM.service.d"
+    systemd_stop_and_remove_unit "$NESTED_VM"
 
     local CURRENT_IMAGE
     CURRENT_IMAGE="$NESTED_IMAGES_DIR/$(nested_get_current_image_name)" 


### PR DESCRIPTION
BlockPCRProtectionPolicies is only called during run and recover modes.
This changes snap-bootstrap so that it is called in all boot modes using
a deferred function that is declared very early which ensures that it is
called on most early failures as well.

In addition to this, the same code path for calling it is now used on
all boot modes, which allows UnlockVolumeUsingSealedKeyIfEncrypted to
be significantly simplified.