### PR TITLE
interfaces/raw_usb: allow read access to /proc/tty/drivers (LP: #1890365)

### DIFF
--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -36,6 +36,7 @@ const rawusbConnectedPlugAppArmor = `
 
 # Allow access to all ttyUSB devices too
 /dev/tty{USB,ACM}[0-9]* rwk,
+@{PROC}/tty/drivers r,
 
 # Allow raw access to USB printers (i.e. for receipt printers in POS systems).
 /dev/usb/lp[0-9]* rwk,


### PR DESCRIPTION
This appears to be needed for the chromium snap to talk to a ttyACM0 device.
See [bug #1890365](https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/1890365) for details.