### PR TITLE
secboot,cmd/snap-bootstrap: fix degraded mode cases with better device handling

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -746,6 +746,16 @@ func (m *recoverModeStateMachine) finalize() error {
 		// (e.g. activated with a recovery key) to get access
 		// via its logins to the secrets in ubuntu-save (in
 		// particular the policy update auth key)
+		// TODO: we should try to be a bit more specific here in checking that
+		//       data and save match, and not mark data as untrusted if we
+		//       know that the real save is locked/protected (or doesn't exist
+		//       in the case of bad corruption) because currently this code will
+		//       mark data as untrusted, even if it was unlocked with the run
+		//       object key and we failed to unlock ubuntu-save at all, which is
+		//       undesirable. This effectively means that you need to have both
+		//       ubuntu-data and ubuntu-save unlockable and have matching marker
+		//       files in order to use the files from ubuntu-data to log-in,
+		//       etc.
 		trustData, _ := checkDataAndSavaPairing(boot.InitramfsHostWritableDir)
 		if !trustData {
 			part.MountState = partitionMountedUntrusted

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -398,10 +398,9 @@ type stateFunc func() (stateFunc, error)
 /**
 
 
-TODO: this state diagram actually is missing a state transition from
-"unlock save w/ run key" to "locate unencrypted save" (which is a state that is
-missing from this diagram), and then from "locate unencrypted save" to either
-"done" or "mount save" states
+TODO: the state diagram is out-of-date, locate save unencrypted is being
+taken care via unlock save w/ fallback key which also works for
+unencrypted save
 
 
                          +---------+                    +----------+
@@ -455,6 +454,8 @@ type recoverModeStateMachine struct {
 	// the disk we have all our partitions on
 	disk disks.Disk
 
+	// TODO:UC20: for clarity turn this into into tristate:
+	// unknown|encrypted|unencrypted
 	isEncryptedDev bool
 
 	// state for tracking what happens as we progress through degraded mode of
@@ -663,7 +664,7 @@ func (m *recoverModeStateMachine) setUnlockStateWithFallbackKey(partName string,
 	// As such, if m.isEncryptedDev is false, but unlockRes.IsEncrypted is
 	// true, then it is safe to assign m.isEncryptedDev to true.
 	if !m.isEncryptedDev && unlockRes.IsEncrypted {
-		m.isEncryptedDev = unlockRes.IsEncrypted
+		m.isEncryptedDev = true
 	}
 
 	if err != nil {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1078,7 +1078,7 @@ func generateMountsModeRecover(mst *initramfsMountsState) error {
 		// ubuntu-data doesn't mean that attackers wouldn't be able to if they
 		// could login
 
-		if err := copySafeDefaultData(boot.InitramfsHostUbuntuDataDir); err != nil {
+		if err := copySafeDefaultData(boot.InitramfsDataDir); err != nil {
 			return err
 		}
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -3866,7 +3866,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedUnencrypted
 	defer restore()
 
 	_, err := main.Parser().ParseArgs([]string{"initramfs-mounts"})
-	c.Assert(err, ErrorMatches, `inconsistent encryption status for disk dataUnencSaveEnc: ubuntu-data \(device /dev/disk/by-partuuid/ubuntu-data-partuuid\) was mounted unencrypted but ubuntu-save \(device /dev/mapper/ubuntu-save-random\) was found to be encrypted`)
+	c.Assert(err, ErrorMatches, `inconsistent encryption status for disk dataUnencSaveEnc: ubuntu-data \(device /dev/disk/by-partuuid/ubuntu-data-partuuid\) was found unencrypted but ubuntu-save \(device /dev/mapper/ubuntu-save-random\) was found to be encrypted`)
 
 	// we always need to lock access to sealed keys
 	c.Check(sealedKeysLocked, Equals, true)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -236,10 +236,10 @@ func foundUnencrypted(name string) secboot.UnlockResult {
 
 func happyUnlocked(name string, method secboot.UnlockMethod) secboot.UnlockResult {
 	return secboot.UnlockResult{
-		PartDevice:        filepath.Join("/dev/disk/by-partuuid", name+"-enc-partuuid"),
-		FsDevice:          filepath.Join("/dev/mapper", name+"-random"),
-		IsDecryptedDevice: true,
-		UnlockMethod:      method,
+		PartDevice:   filepath.Join("/dev/disk/by-partuuid", name+"-enc-partuuid"),
+		FsDevice:     filepath.Join("/dev/mapper", name+"-random"),
+		IsEncrypted:  true,
+		UnlockMethod: method,
 	}
 }
 
@@ -247,8 +247,8 @@ func foundEncrypted(name string) secboot.UnlockResult {
 	return secboot.UnlockResult{
 		PartDevice: filepath.Join("/dev/disk/by-partuuid", name+"-enc-partuuid"),
 		// FsDevice is empty if we didn't unlock anything
-		FsDevice:          "",
-		IsDecryptedDevice: true,
+		FsDevice:    "",
+		IsEncrypted: true,
 	}
 }
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -3520,7 +3520,7 @@ recovery_system=20191118
 
 	// since we didn't mount data at all, we won't have copied in files from
 	// there and instead will copy safe defaults to the ephemeral data
-	c.Assert(filepath.Join(boot.InitramfsHostWritableDir, "var/lib/console-conf/complete"), testutil.FilePresent)
+	c.Assert(filepath.Join(boot.InitramfsRunMntDir, "/data/system-data/var/lib/console-conf/complete"), testutil.FilePresent)
 
 	c.Check(dataActivationAttempts, Equals, 2)
 	c.Check(saveActivated, Equals, true)
@@ -3712,7 +3712,7 @@ recovery_system=20191118
 
 	// since we didn't mount data at all, we won't have copied in files from
 	// there and instead will copy safe defaults to the ephemeral data
-	c.Assert(filepath.Join(boot.InitramfsHostWritableDir, "var/lib/console-conf/complete"), testutil.FilePresent)
+	c.Assert(filepath.Join(boot.InitramfsRunMntDir, "/data/system-data/var/lib/console-conf/complete"), testutil.FilePresent)
 
 	c.Check(dataActivated, Equals, true)
 	c.Check(saveActivated, Equals, true)
@@ -4061,7 +4061,7 @@ recovery_system=20191118
 
 	// since we didn't mount data at all, we won't have copied in files from
 	// there and instead will copy safe defaults to the ephemeral data
-	c.Assert(filepath.Join(boot.InitramfsHostWritableDir, "var/lib/console-conf/complete"), testutil.FilePresent)
+	c.Assert(filepath.Join(boot.InitramfsRunMntDir, "/data/system-data/var/lib/console-conf/complete"), testutil.FilePresent)
 
 	c.Check(dataActivated, Equals, true)
 	c.Check(saveActivated, Equals, true)
@@ -4256,7 +4256,7 @@ recovery_system=20191118
 
 	// since we didn't mount data at all, we won't have copied in files from
 	// there and instead will copy safe defaults to the ephemeral data
-	c.Assert(filepath.Join(boot.InitramfsHostWritableDir, "var/lib/console-conf/complete"), testutil.FilePresent)
+	c.Assert(filepath.Join(boot.InitramfsRunMntDir, "/data/system-data/var/lib/console-conf/complete"), testutil.FilePresent)
 
 	c.Check(dataActivationAttempts, Equals, 2)
 	c.Check(saveUnsealActivationAttempted, Equals, true)
@@ -4429,7 +4429,7 @@ recovery_system=20191118
 
 	// since we didn't mount data at all, we won't have copied in files from
 	// there and instead will copy safe defaults to the ephemeral data
-	c.Assert(filepath.Join(boot.InitramfsHostWritableDir, "var/lib/console-conf/complete"), testutil.FilePresent)
+	c.Assert(filepath.Join(boot.InitramfsRunMntDir, "/data/system-data/var/lib/console-conf/complete"), testutil.FilePresent)
 
 	c.Check(dataActivated, Equals, true)
 	c.Check(saveActivated, Equals, true)

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -126,14 +126,14 @@ const (
 
 // UnlockResult is the result of trying to unlock a volume.
 type UnlockResult struct {
-	// Device is the block device, which may be encrypted or unencrypted. Device
-	// can be empty when none was found. If IsDecryptedDevice is true, then
-	// DecryptedDevice represents the decrypted mapper device that most things
-	// should use.
-	Device string
-	// DecryptedDevice is the decrypted mapper device that was unlocked and
-	// created from Device. This will only be set if IsDecryptedDevice is true.
-	DecryptedDevice string
+	// FsDevice is the device with filesystem ready to mount.
+	// It is the activated device if encrypted or just
+	// the underlying device (same as PartDevice) if non-encrypted.
+	// FsDevice can be empty when none was found.
+	FsDevice string
+	// PartDevice is the underlying partition device.
+	// PartDevice can be empty when no device was found.
+	PartDevice string
 	// IsDecryptedDevice indicates if Device is a decrypted device or an
 	// unencrypted device.
 	IsDecryptedDevice bool

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -126,9 +126,14 @@ const (
 
 // UnlockResult is the result of trying to unlock a volume.
 type UnlockResult struct {
-	// Device is the decrypted device, if encrypted or just the unencrypted
-	// device. Device can be empty when none was found.
+	// Device is the block device, which may be encrypted or unencrypted. Device
+	// can be empty when none was found. If IsDecryptedDevice is true, then
+	// DecryptedDevice represents the decrypted mapper device that most things
+	// should use.
 	Device string
+	// DecryptedDevice is the decrypted mapper device that was unlocked and
+	// created from Device. This will only be set if IsDecryptedDevice is true.
+	DecryptedDevice string
 	// IsDecryptedDevice indicates if Device is a decrypted device or an
 	// unencrypted device.
 	IsDecryptedDevice bool

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -134,13 +134,12 @@ type UnlockResult struct {
 	// PartDevice is the underlying partition device.
 	// PartDevice can be empty when no device was found.
 	PartDevice string
-	// IsDecryptedDevice indicates if Device is a decrypted device or an
-	// unencrypted device.
-	IsDecryptedDevice bool
+	// IsEncrypted indicates that PartDevice is encrypted.
+	IsEncrypted bool
 	// UnlockMethod is the method used to unlock the device. Valid values are
 	// - NotUnlocked
 	// - UnlockedWithRecoveryKey
 	// - UnlockedWithSealedKey
-	// - UnlockedWithUnsealedKey
+	// - UnlockedWithKey
 	UnlockMethod UnlockMethod
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -315,6 +315,9 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(
 // path to the device node is returned.
 // TODO: use UnlockResult here too?
 func UnlockEncryptedVolumeUsingKey(disk disks.Disk, name string, key []byte) (UnlockResult, error) {
+	unlockRes := UnlockResult{
+		UnlockMethod: NotUnlocked,
+	}
 	// find the encrypted device using the disk we were provided - note that
 	// we do not specify IsDecryptedDevice in opts because here we are
 	// looking for the encrypted device to unlock, later on in the boot
@@ -322,13 +325,12 @@ func UnlockEncryptedVolumeUsingKey(disk disks.Disk, name string, key []byte) (Un
 	// what we expected
 	partUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
 	if err != nil {
-		return UnlockResult{}, err
+		return unlockRes, err
 	}
-	unlockRes := UnlockResult{
-		IsDecryptedDevice: true,
-	}
+	unlockRes.IsDecryptedDevice = true
 	// we have a device
 	encdev := filepath.Join("/dev/disk/by-partuuid", partUUID)
+	unlockRes.Device = encdev
 	// make up a new name for the mapped device
 	mapperName := name + "-" + randutilRandomKernelUUID()
 	if err := unlockEncryptedPartitionWithKey(mapperName, encdev, key); err != nil {

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -337,7 +337,7 @@ func UnlockEncryptedVolumeUsingKey(disk disks.Disk, name string, key []byte) (Un
 		return unlockRes, err
 	}
 
-	unlockRes.Device = filepath.Join("/dev/mapper/", mapperName)
+	unlockRes.DecryptedDevice = filepath.Join("/dev/mapper/", mapperName)
 	unlockRes.UnlockMethod = UnlockedWithKey
 	return unlockRes, nil
 }

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -523,7 +523,7 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 		unlockRes, err := secboot.UnlockVolumeUsingSealedKeyIfEncrypted(tc.disk, defaultDevice, expKeyPath, opts)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
-			c.Assert(unlockRes.IsDecryptedDevice, Equals, tc.hasEncdev)
+			c.Assert(unlockRes.IsEncrypted, Equals, tc.hasEncdev)
 			c.Assert(unlockRes.PartDevice, Equals, devicePath)
 			if tc.hasEncdev {
 				c.Assert(unlockRes.FsDevice, Equals, filepath.Join("/dev/mapper", defaultDevice+"-"+randomUUID))
@@ -532,12 +532,12 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 			}
 		} else {
 			c.Assert(err, ErrorMatches, tc.err)
-			// also check that the isDecryptDev value matches, this is
+			// also check that the IsEncrypted value matches, this is
 			// important for robust callers to know whether they should try to
 			// unlock using a different method or not
 			// this is only skipped on some test cases where we get an error
 			// very early, like trying to connect to the tpm
-			c.Assert(unlockRes.IsDecryptedDevice, Equals, tc.hasEncdev)
+			c.Assert(unlockRes.IsEncrypted, Equals, tc.hasEncdev)
 			if tc.hasEncdev {
 				c.Check(unlockRes.PartDevice, Equals, devicePath)
 				c.Check(unlockRes.FsDevice, Equals, "")
@@ -1122,10 +1122,10 @@ func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyHappy(c *C) {
 	unlockRes, err := secboot.UnlockEncryptedVolumeUsingKey(disk, "ubuntu-save", []byte("fooo"))
 	c.Assert(err, IsNil)
 	c.Check(unlockRes, DeepEquals, secboot.UnlockResult{
-		PartDevice:        "/dev/disk/by-partuuid/123-123-123",
-		FsDevice:          "/dev/mapper/ubuntu-save-random-uuid-123-123",
-		IsDecryptedDevice: true,
-		UnlockMethod:      secboot.UnlockedWithKey,
+		PartDevice:   "/dev/disk/by-partuuid/123-123-123",
+		FsDevice:     "/dev/mapper/ubuntu-save-random-uuid-123-123",
+		IsEncrypted:  true,
+		UnlockMethod: secboot.UnlockedWithKey,
 	})
 }
 
@@ -1148,8 +1148,8 @@ func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyErr(c *C) {
 	c.Assert(err, ErrorMatches, "failed")
 	// we would have at least identified that the device is a decrypted one
 	c.Check(unlockRes, DeepEquals, secboot.UnlockResult{
-		IsDecryptedDevice: true,
-		PartDevice:        "/dev/disk/by-partuuid/123-123-123",
-		FsDevice:          "",
+		IsEncrypted: true,
+		PartDevice:  "/dev/disk/by-partuuid/123-123-123",
+		FsDevice:    "",
 	})
 }

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -1145,5 +1145,6 @@ func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyErr(c *C) {
 	// we would have at least identified that the device is a decrypted one
 	c.Check(unlockRes, DeepEquals, secboot.UnlockResult{
 		IsDecryptedDevice: true,
+		Device:            "/dev/disk/by-partuuid/123-123-123",
 	})
 }

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -524,10 +524,9 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 			c.Assert(unlockRes.IsDecryptedDevice, Equals, tc.hasEncdev)
+			c.Assert(unlockRes.Device, Equals, devicePath)
 			if tc.hasEncdev {
-				c.Assert(unlockRes.Device, Equals, filepath.Join("/dev/mapper", defaultDevice+"-"+randomUUID))
-			} else {
-				c.Assert(unlockRes.Device, Equals, devicePath)
+				c.Assert(unlockRes.DecryptedDevice, Equals, filepath.Join("/dev/mapper", defaultDevice+"-"+randomUUID))
 			}
 		} else {
 			c.Assert(err, ErrorMatches, tc.err)
@@ -1119,7 +1118,8 @@ func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyHappy(c *C) {
 	unlockRes, err := secboot.UnlockEncryptedVolumeUsingKey(disk, "ubuntu-save", []byte("fooo"))
 	c.Assert(err, IsNil)
 	c.Check(unlockRes, DeepEquals, secboot.UnlockResult{
-		Device:            "/dev/mapper/ubuntu-save-random-uuid-123-123",
+		Device:            "/dev/disk/by-partuuid/123-123-123",
+		DecryptedDevice:   "/dev/mapper/ubuntu-save-random-uuid-123-123",
 		IsDecryptedDevice: true,
 		UnlockMethod:      secboot.UnlockedWithKey,
 	})

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1111,7 +1111,10 @@ nested_start_classic_vm() {
 }
 
 nested_destroy_vm() {
-    systemd_stop_and_destroy_unit "$NESTED_VM"
+    # XXX: is this the right way to do this ???
+    systemctl stop "$NESTED_VM"
+    rm -f "/etc/systemd/system/$NESTED_VM.service"
+    rm -rf "/etc/systemd/system/$NESTED_VM.service.d"
 
     local CURRENT_IMAGE
     CURRENT_IMAGE="$NESTED_IMAGES_DIR/$(nested_get_current_image_name)" 


### PR DESCRIPTION
Based on top of https://github.com/snapcore/snapd/pull/9626.

Now secboot.UnlockResult has two better named fields, FsDevice and PartDevice, where
the PartDevice is always the underlying block device, and FsDevice (if not
the empty string) is whatever device should be mounted to access the
filesystem.

Also update the handling of setting up state for degraded mode in recover
mode to use these variables in a simpler way.

Finally, simplify some logic in the state machine around ubuntu-save being
optional if it is unencrypted and add an additional consistency check that
if ubuntu-data was mounted unencrypted that ubuntu-save must be unencrypted
as well.

All this allows us to implement more correct state handling in the initramfs, where
we can better distinguish between the case of "found but not unlocked" and "not
found and not unlocked".

Also update the exported Device field of degraded.json to have the following
meaning:
- Device is set to "" if the encrypted device and the possible unencrypted
  device are not found.
- Device is set to the block device of the encrypted device if the encrypted
  block device is found but not successfully decrypted.
- Device is set to the decrypted mapper device if decryption is successful.
- Device is set to the block device of the unencrypted device if that was found.

This also contains an internal refactoring of the recoverDegradedState struct to
now track separately the partDevice (corresponding to the partition block device) 
and fsDevice (which corresponds to the unencrypted or decrypted device which 
can be directly mounted to access the filesystem). These  have the
following meanings:
- partDevice is always set to the block device of the partition in question if
  the partition in question can be found
- fsDevice is set to the block device of the encrypted partition if it
  has not yet been decrypted (thus also if it failed to be decrypted)
- fsDevice is set to the decrypted mapper device if it was successfully
  decrypted

Finally, add a new unit test for the unencrypted case where data is absent from
the disk, and update the degraded mode test names to be more clear what they are
supposed to be testing, and add another unit test around having an unencrypted data, 
but an encrypted save somehow.
