### PR TITLE
tests/nested/manual/refresh-revert-fundamentals: temporarily disable secure boot

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1111,7 +1111,7 @@ nested_start_classic_vm() {
 }
 
 nested_destroy_vm() {
-    systemd_stop_and_destroy_unit "$NESTED_VM"
+    systemd_stop_and_remove_unit "$NESTED_VM"
 
     local CURRENT_IMAGE
     CURRENT_IMAGE="$NESTED_IMAGES_DIR/$(nested_get_current_image_name)" 

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -11,8 +11,11 @@ environment:
     NESTED_CORE_REFRESH_CHANNEL: edge
     NESTED_BUILD_SNAPD_FROM_CURRENT: false
     NESTED_USE_CLOUD_INIT: true
-    NESTED_ENABLE_SECURE_BOOT: true
-    NESTED_ENABLE_TPM: true
+    # TODO:UC20: temporarily disable secure boot and encryption support. The
+    # location of encryption keys has changed, thus the nested VM will not boot
+    # until the kernel snap is rebuilt with snapd 2.48.
+    NESTED_ENABLE_SECURE_BOOT: false
+    NESTED_ENABLE_TPM: false
 
     SNAP/kernel: pc-kernel
     TRACK/kernel: 20


### PR DESCRIPTION
Temporarily disable secure boot and TPM until we get a new kernel with new
snap-bootstrap.


