### PR TITLE
boot,dirs,c/snap-bootstrap: avoid InstallHost* at the cost of some messiness

### DIFF
--- a/boot/seal.go
+++ b/boot/seal.go
@@ -294,7 +294,8 @@ func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, 
 		bootloader.RoleRunMode:  bl.Name(),
 	}
 
-	authKeyFile := filepath.Join(dirs.SnapSaveFDEDirUnder(rootdir), "tpm-policy-auth-key")
+	saveFDEDir := dirs.SnapFDEDirUnderSave(dirs.SnapSaveDirUnder(rootdir))
+	authKeyFile := filepath.Join(saveFDEDir, "tpm-policy-auth-key")
 	if err := resealRunObjectKeys(pbc, authKeyFile, roleToBlName); err != nil {
 		return err
 	}

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -130,10 +130,16 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 			switch sealKeysCalls {
 			case 1:
 				// the run object seals only the ubuntu-data key
+				c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-policy-auth-key"))
+				c.Check(params.TPMLockoutAuthFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-lockout-auth"))
+
 				dataKeyFile := filepath.Join(rootdir, "/run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key")
 				c.Check(keys, DeepEquals, []secboot.SealKeyRequest{{Key: myKey, KeyFile: dataKeyFile}})
 			case 2:
 				// the fallback object seals the ubuntu-data and the ubuntu-save keys
+				c.Check(params.TPMPolicyAuthKeyFile, Equals, "")
+				c.Check(params.TPMLockoutAuthFile, Equals, "")
+
 				dataKeyFile := filepath.Join(rootdir, "/run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key")
 				saveKeyFile := filepath.Join(rootdir, "/run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key")
 				c.Check(keys, DeepEquals, []secboot.SealKeyRequest{{Key: myKey, KeyFile: dataKeyFile}, {Key: myKey2, KeyFile: saveKeyFile}})
@@ -378,6 +384,8 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 		// set mock key resealing
 		resealKeysCalls := 0
 		restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+			c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+
 			resealKeysCalls++
 			c.Assert(params.ModelParams, HasLen, 1)
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1055,10 +1055,7 @@ func checkDataAndSavaPairing(rootdir string) (bool, error) {
 		return false, err
 	}
 	// read the secret marker file from ubuntu-save
-	// TODO:UC20: this is a bit of an abuse of the Install*Dir variable, we
-	// should really only be using Initramfs*Dir variables since we are in the
-	// initramfs and not in install mode, no?
-	markerFile2 := filepath.Join(boot.InstallHostFDESaveDir, "marker")
+	markerFile2 := filepath.Join(dirs.SnapFDEDirUnderSave(boot.InitramfsUbuntuSaveDir), "marker")
 	marker2, err := ioutil.ReadFile(markerFile2)
 	if err != nil {
 		return false, err

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -276,10 +276,10 @@ func SnapSaveDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "save")
 }
 
-// SnapSaveFDEDirUnder returns the path to full disk encryption state directory
-// inside save under rootdir.
-func SnapSaveFDEDirUnder(rootdir string) string {
-	return filepath.Join(SnapSaveDirUnder(rootdir), "device/fde")
+// SnapFDEDirUnderSave returns the path to full disk encryption state directory
+// inside the given save tree dir.
+func SnapFDEDirUnderSave(savedir string) string {
+	return filepath.Join(savedir, "device/fde")
 }
 
 // AddRootDirCallback registers a callback for whenever the global root


### PR DESCRIPTION
This avoids the use of InstallHostFDESaveDir in initramfs at the cost
of some definitional messiness.

We have probably reached the limit of clarity that *Under functions
as they are can bring,
