### PR TITLE
cmd/snap-bootstrap, secboot, tests: misc cleanups, add spread test

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -746,7 +746,7 @@ func (m *recoverModeStateMachine) finalize() error {
 		// (e.g. activated with a recovery key) to get access
 		// via its logins to the secrets in ubuntu-save (in
 		// particular the policy update auth key)
-		// TODO: we should try to be a bit more specific here in checking that
+		// TODO:UC20: we should try to be a bit more specific here in checking that
 		//       data and save match, and not mark data as untrusted if we
 		//       know that the real save is locked/protected (or doesn't exist
 		//       in the case of bad corruption) because currently this code will

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -395,8 +395,7 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 		}, {
 			// tpm error, no encrypted device
 			tpmErr: errors.New("tpm error"),
-			//err:    `cannot unlock encrypted device "name": tpm error`,
-			disk: mockDiskWithUnencDev,
+			disk:   mockDiskWithUnencDev,
 		}, {
 			// tpm error, has encrypted device
 			tpmErr: errors.New("tpm error"), hasEncdev: true,

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -59,6 +59,20 @@ nested_wait_for_reboot() {
     [ "$last_boot_id" != "$initial_boot_id" ]
 }
 
+nested_uc20_transition_to_system_mode() {
+    local recovery_system="$1"
+    local mode="$2"
+    local current_boot_id
+    current_boot_id=$(nested_get_boot_id)
+    nested_exec "sudo snap reboot --$mode $recovery_system"
+    nested_wait_for_reboot "$current_boot_id"
+
+    # verify we are now in the requested mode
+    if ! nested_exec "cat /proc/cmdline" | MATCH "snapd_recovery_mode=$mode"; then
+        return 1
+    fi
+}
+
 nested_retry_while_success() {
     local retry="$1"
     local wait="$2"

--- a/tests/nested/core20/degraded/task.yaml
+++ b/tests/nested/core20/degraded/task.yaml
@@ -46,4 +46,4 @@ execute: |
 
   echo "Check degraded.json exists and has the unlock-key for ubuntu-data as the fallback key"
   nested_exec "test -f $DEGRADED_JSON"
-  test "$(nested_exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-save" | ."unlock-key"')" = fallback
+  test "$(nested_exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-data" | ."unlock-key"')" = fallback

--- a/tests/nested/core20/degraded/task.yaml
+++ b/tests/nested/core20/degraded/task.yaml
@@ -1,0 +1,49 @@
+summary: Transition to recover mode with things missing so we use degraded mode
+
+environment:
+  DEGRADED_JSON: /run/snapd/snap-bootstrap/degraded.json
+
+execute: |
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  # wait for the system to be seeded first
+
+  nested_wait_for_snap_command
+  nested_exec "sudo snap wait system seed.loaded"
+
+  echo "Install jq in the host environment"
+  snap install jq
+
+  echo "Move the run key for ubuntu-save out of the way so we use the fallback key to unlock ubuntu-save"
+  nested_exec "sudo mv /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk"
+
+  recoverySystem=$(nested_exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
+
+  echo "Transition to recover mode"
+  nested_uc20_transition_to_system_mode "$recoverySystem" recover
+
+  nested_wait_for_snap_command
+  nested_exec "sudo snap wait system seed.loaded"
+
+  echo "Check degraded.json exists and has the unlock-key for ubuntu-save as the fallback key"
+  nested_exec "test -f $DEGRADED_JSON"
+  test "$(nested_exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-save" | ."unlock-key"')" = fallback
+
+  echo "Move the run object key for ubuntu-save back and go back to run mode"
+  nested_exec "sudo mv /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key"
+  nested_uc20_transition_to_system_mode "$recoverySystem" run
+
+  nested_wait_for_snap_command
+  nested_exec "sudo snap wait system seed.loaded"
+
+  echo "Now move the run object key on ubuntu-boot out of the way so we use the fallback key to unlock ubuntu-data"
+  nested_exec "sudo mv /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key.bk"
+  nested_uc20_transition_to_system_mode "$recoverySystem" recover
+
+  nested_wait_for_snap_command
+  nested_exec "sudo snap wait system seed.loaded"
+
+  echo "Check degraded.json exists and has the unlock-key for ubuntu-data as the fallback key"
+  nested_exec "test -f $DEGRADED_JSON"
+  test "$(nested_exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-save" | ."unlock-key"')" = fallback


### PR DESCRIPTION
This test currently just exercises the logic if we are missing the run object
key for ubuntu-data and ubuntu-save respectively, since we don't yet have a nice
way to test the other degraded mode cases.