### PR TITLE
interfaces: fix greengrass attr naming

### DIFF
--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -392,12 +392,19 @@ mknod - |S_IFCHR -
 mknodat - - |S_IFCHR -
 `
 
+// XXX: decide on the final names and adjust tests too
+const (
+	flavorAttrStr   = "flavor"
+	flavorContainer = "container"
+	falvorProcess   = "process"
+)
+
 func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// check the flavor
 	var flavor string
-	_ = plug.Attr("flavor", &flavor)
+	_ = plug.Attr(flavorAttrStr, &flavor)
 	switch flavor {
-	case "", "container":
+	case "", flavorContainer:
 		// default, legacy version of the interface
 		if release.OnClassic {
 			spec.AddSnippet(greengrassSupportFullContainerConnectedPlugAppArmor)
@@ -406,9 +413,9 @@ func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 		}
 		// greengrass needs to use ptrace for controlling it's containers
 		spec.SetUsesPtraceTrace()
-	case "process":
+	case falvorProcess:
 		// this is the process-mode version, it does not use as much privilege
-		// as the default "container" flavor
+		// as the default flavorContainer flavor
 		spec.AddSnippet(greengrassSupportProcessModeConnectedPlugAppArmor)
 	}
 
@@ -418,11 +425,11 @@ func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 func (iface *greengrassSupportInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// check the flavor
 	var flavor string
-	_ = plug.Attr("flavor", &flavor)
+	_ = plug.Attr(flavorAttrStr, &flavor)
 	switch flavor {
-	case "", "container":
+	case "", flavorContainer:
 		spec.AddSnippet(greengrassSupportConnectedPlugSeccomp)
-	case "process":
+	case falvorProcess:
 		// process mode has no additional seccomp available to it
 	}
 
@@ -431,12 +438,12 @@ func (iface *greengrassSupportInterface) SecCompConnectedPlug(spec *seccomp.Spec
 
 func (iface *greengrassSupportInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	var flavor string
-	_ = plug.Attr("flavor", &flavor)
+	_ = plug.Attr(flavorAttrStr, &flavor)
 	switch flavor {
-	case "", "container":
+	case "", flavorContainer:
 		// default containerization controls the device cgroup
 		spec.SetControlsDeviceCgroup()
-	case "process":
+	case falvorProcess:
 		// process mode does not control the device cgroup
 	}
 

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -62,25 +62,25 @@ slots:
 const ggMockPlugSnapInfoYaml = `name: other
 version: 1.0
 plugs:
- greengrass-support-container-mode:
+ greengrass-support-legacy-container:
   interface: greengrass-support
-  flavor: container
+  flavor: legacy-container
 apps:
  app2:
   command: foo
-  plugs: [greengrass-support-container-mode, greengrass-support, network-control]
+  plugs: [greengrass-support-legacy-container, greengrass-support, network-control]
 `
 
 const ggProcessModeMockPlugSnapInfoYaml = `name: other
 version: 1.0
 plugs:
- greengrass-support-process-mode:
+ greengrass-support-no-container:
   interface: greengrass-support
-  flavor: process
+  flavor: no-container
 apps:
  app2:
   command: foo
-  plugs: [greengrass-support-process-mode, network-control]
+  plugs: [greengrass-support-no-container, network-control]
 `
 
 var _ = Suite(&GreengrassSupportInterfaceSuite{
@@ -93,9 +93,9 @@ func (s *GreengrassSupportInterfaceSuite) SetUpTest(c *C) {
 	s.extraPlug, s.extraPlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "network-control")
 	s.extraSlot, s.extraSlotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "network-control")
 
-	s.processModePlug, s.processModePlugInfo = MockConnectedPlug(c, ggProcessModeMockPlugSnapInfoYaml, nil, "greengrass-support-process-mode")
+	s.processModePlug, s.processModePlugInfo = MockConnectedPlug(c, ggProcessModeMockPlugSnapInfoYaml, nil, "greengrass-support-no-container")
 
-	s.containerModePlug, s.containerModePlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "greengrass-support-container-mode")
+	s.containerModePlug, s.containerModePlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "greengrass-support-legacy-container")
 
 }
 


### PR DESCRIPTION
The flavor attribute names are now as follows:

- "legacy-container" is the full containerization also known as
  "Greengrass container" in AWS's UI.
- "no-container" is the process-mode, no confinement mode, also known as "no
  container" in AWS's UI.