### PR TITLE
boot: add scaffolding for "fde-setup" hook support for sealing

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -367,7 +367,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 
 	if sealer != nil {
 		// seal the encryption key to the parameters specified in modeenv
-		if err := sealKeyToModeenv(sealer.dataEncryptionKey, sealer.saveEncryptionKey, model, modeenv); err != nil {
+		if err := sealKeyToModeenv(sealer.dataEncryptionKey, sealer.saveEncryptionKey, model, bootWith, modeenv); err != nil {
 			return err
 		}
 	}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -47,14 +47,16 @@ var (
 	seedReadSystemEssential = seed.ReadSystemEssential
 )
 
-// Hook function setup by devicestate to support device-specific full
+// Hook functions setup by devicestate to support device-specific full
 // disk encryption implementations.
-var HasFDESetupHook = func(*BootableSet) bool {
-	return false
-}
-var RunFDESetupHook = func(op string, params *FdeSetupHookParams) error {
-	return fmt.Errorf("internal error: RunFDESetupHook not set yet")
-}
+var (
+	HasFDESetupHook = func(*BootableSet) bool {
+		return false
+	}
+	RunFDESetupHook = func(op string, params *FdeSetupHookParams) error {
+		return fmt.Errorf("internal error: RunFDESetupHook not set yet")
+	}
+)
 
 // FdeSetupHookParams contains the inputs for the fde-setup hook
 type FdeSetupHookParams struct {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -45,12 +45,16 @@ var (
 	secbootResealKeys = secboot.ResealKeys
 
 	seedReadSystemEssential = seed.ReadSystemEssential
-
-	// HasFdeSetupHook,FdeSetupHookRunner will be set by the
-	// devicestate code
-	HasFdeSetupHook    func(*BootableSet) bool
-	FdeSetupHookRunner func(string, *FdeSetupHookParams) error
 )
+
+// Hook function setup by devicestate to support device-specific full
+// disk encryption implementations.
+var HasFDESetupHook = func(*BootableSet) bool {
+	return false
+}
+var RunFDESetupHook = func(op string, params *FdeSetupHookParams) error {
+	return fmt.Errorf("internal error: RunFDESetupHook not set yet")
+}
 
 // FdeSetupHookParams contains the inputs for the fde-setup hook
 type FdeSetupHookParams struct {
@@ -76,7 +80,7 @@ func recoveryBootChainsFileUnder(rootdir string) string {
 // in modeenv.
 // It assumes to be invoked in install mode.
 func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, bootWith *BootableSet, modeenv *Modeenv) error {
-	if HasFdeSetupHook != nil && HasFdeSetupHook(bootWith) {
+	if HasFDESetupHook(bootWith) {
 		return sealKeyToModeenvUsingFdeSetupHook(key, saveKey, model, bootWith, modeenv)
 	}
 
@@ -84,10 +88,6 @@ func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, 
 }
 
 func sealKeyToModeenvUsingFdeSetupHook(key, saveKey secboot.EncryptionKey, model *asserts.Model, bootWith *BootableSet, modeenv *Modeenv) error {
-	if FdeSetupHookRunner == nil {
-		return fmt.Errorf("internal error: FdeSetupHookRunner not set")
-	}
-
 	return fmt.Errorf("cannot use fde-setup hook yet")
 }
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -907,16 +907,15 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookFailsToday(c *C) {
 	dirs.SetRootDir(rootdir)
 	defer dirs.SetRootDir("")
 
-	oldHasFdeSetupHook := boot.HasFdeSetupHook
-	defer func() { boot.HasFdeSetupHook = oldHasFdeSetupHook }()
-	boot.HasFdeSetupHook = func(bootWith *boot.BootableSet) bool {
+	oldHasFDESetupHook := boot.HasFDESetupHook
+	defer func() { boot.HasFDESetupHook = oldHasFDESetupHook }()
+	boot.HasFDESetupHook = func(bootWith *boot.BootableSet) bool {
 		c.Assert(bootWith.Kernel.SuggestedName, Equals, "mock-kernel")
-		//bootWith.Kernel.Hooks["fde-setup"]
 		return true
 	}
-	oldFdeSetupHookRunner := boot.FdeSetupHookRunner
-	defer func() { boot.FdeSetupHookRunner = oldFdeSetupHookRunner }()
-	boot.FdeSetupHookRunner = func(string, *boot.FdeSetupHookParams) error {
+	oldRunFDESetupHook := boot.RunFDESetupHook
+	defer func() { boot.RunFDESetupHook = oldRunFDESetupHook }()
+	boot.RunFDESetupHook = func(string, *boot.FdeSetupHookParams) error {
 		c.Fatalf("hook runner should not be called yet")
 		return nil
 	}
@@ -932,7 +931,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookFailsToday(c *C) {
 		Kernel: &snap.Info{
 			SuggestedName: "mock-kernel",
 			Hooks: map[string]*snap.HookInfo{
-				"fde-setup": &snap.HookInfo{
+				"fde-setup": {
 					Name: "fde-setup",
 				},
 			},


### PR DESCRIPTION
Add intial support for sealKeyToModeenv() to support running
a "fde-setup" hook instead of using the build-in secboot
implementation for key sealing.

This is broken out of the larger
https://github.com/mvo5/snappy/tree/fdehook-skeleton-2
branch to ensure we agree on naming and approach in this part.

