### PR TITLE
tests/lib/nested: poke the API to get the snap revisions

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -232,9 +232,15 @@ nested_get_cdimage_current_image_url() {
 nested_get_snap_rev_for_channel() {
     local SNAP=$1
     local CHANNEL=$2
-    # This should be executed on remote system but as nested architecture is the same than the
-    # host then the snap info is executed in the host
-    snap info "$SNAP" | grep "$CHANNEL" | awk '{ print $4 }' | sed 's/.*(\(.*\))/\1/' | tr -d '\n'
+
+    curl -s \
+         -H "Snap-Device-Architecture: ${NESTED_ARCHITECTURE:-amd64}" \
+         -H "Snap-Device-Series: 16" \
+         -X POST \
+         -H "Content-Type: application/json" \
+         --data "{\"context\": [], \"actions\": [{\"action\": \"install\", \"name\": \"$SNAP\", \"channel\": \"$CHANNEL\", \"instance-key\": \"1\"}]}" \
+         https://api.snapcraft.io/v2/snaps/refresh | \
+        jq '.results[0].snap.revision'
 }
 
 nested_is_nested_system() {


### PR DESCRIPTION
The check to get the snap revisions was parsing the output of `snap info`
command, which may produce incorrect output when the looks like this:

```
channels:
  latest/stable:    20       2020-05-07 (634) 63MB -
  latest/candidate: 20       2020-05-07 (634) 63MB -
  latest/beta:      20201027 2020-11-11 (875) 64MB -
  latest/edge:      ↑
```

Instead of parsing text, use the store API directly to find out the revision of
a snap in a given channel.