### PR TITLE
bootloader/grub: replace old reference to Managed...Blr... with Trusted...Blr...

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -332,11 +332,6 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 			return err
 		}
 	} else {
-		// TODO:UC20: should we make this more explicit with a new
-		//            bootloader interface that is checked for first before
-		//            ExtractedRunKernelImageBootloader the same way we do with
-		//            ExtractedRecoveryKernelImageBootloader?
-
 		// the bootloader does not support additional handling of
 		// extracted kernel images, we must name the kernel to be used
 		// explicitly in bootloader variables

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -354,7 +354,7 @@ func (g *grub) TryKernel() (snap.PlaceInfo, error) {
 // UpdateBootConfig updates the grub boot config only if it is already managed
 // and has a lower edition.
 //
-// Implements ManagedAssetsBootloader for the grub bootloader.
+// Implements TrustedAssetsBootloader for the grub bootloader.
 func (g *grub) UpdateBootConfig(opts *Options) error {
 	// XXX: do we need to take opts here?
 	bootScriptName := "grub.cfg"
@@ -369,7 +369,7 @@ func (g *grub) UpdateBootConfig(opts *Options) error {
 // ManagedAssets returns a list relative paths to boot assets inside the root
 // directory of the filesystem.
 //
-// Implements ManagedAssetsBootloader for the grub bootloader.
+// Implements TrustedAssetsBootloader for the grub bootloader.
 func (g *grub) ManagedAssets() []string {
 	return []string{
 		filepath.Join(g.basedir, "grub.cfg"),
@@ -406,7 +406,7 @@ func (g *grub) commandLineForEdition(edition uint, modeArg, systemArg, extraArgs
 // extra arguments. The command line may be different when using a
 // recovery bootloader.
 //
-// Implements ManagedAssetsBootloader for the grub bootloader.
+// Implements TrustedAssetsBootloader for the grub bootloader.
 func (g *grub) CommandLine(modeArg, systemArg, extraArgs string) (string, error) {
 	currentBootConfig := filepath.Join(g.dir(), "grub.cfg")
 	edition, err := editionFromDiskConfigAsset(currentBootConfig)
@@ -414,7 +414,7 @@ func (g *grub) CommandLine(modeArg, systemArg, extraArgs string) (string, error)
 		if err != errNoEdition {
 			return "", fmt.Errorf("cannot obtain edition number of current boot config: %v", err)
 		}
-		// we were called using the ManagedAssetsBootloader interface
+		// we were called using the TrustedAssetsBootloader interface
 		// meaning the caller expects to us to use the managed assets,
 		// since one on disk is not managed, use the initial edition of
 		// the internal boot asset which is compatible with grub.cfg
@@ -427,7 +427,7 @@ func (g *grub) CommandLine(modeArg, systemArg, extraArgs string) (string, error)
 // CandidateCommandLine is similar to CommandLine, but uses the current
 // edition of managed built-in boot assets as reference.
 //
-// Implements ManagedAssetsBootloader for the grub bootloader.
+// Implements TrustedAssetsBootloader for the grub bootloader.
 func (g *grub) CandidateCommandLine(modeArg, systemArg, extraArgs string) (string, error) {
 	assetName := "grub.cfg"
 	if g.recovery {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -2131,9 +2131,6 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 			expError: "fallback base snap unusable: cannot get snap revision: modeenv base boot variable is empty",
 			comment:  "unhappy empty modeenv",
 		},
-		// TODO:UC20: in this case snap-bootstrap should request a reboot, since we
-		//            already booted the try snap, so mounting the fallback kernel will
-		//            not match in some cases
 		{
 			modeenv: &boot.Modeenv{
 				Mode:           "run",


### PR DESCRIPTION
ManagedAssetsBootloader was merged back into TrustedAssetsBootloader, so these
methods implement TrustedAssetsBootloader interface methods now.