### PR TITLE
strutil/shlex,osutil/udev/netlink: minimally import go-check

### DIFF
--- a/osutil/udev/netlink/conn_test.go
+++ b/osutil/udev/netlink/conn_test.go
@@ -4,7 +4,11 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	. "gopkg.in/check.v1"
 )
+
+func Test(t *testing.T) { TestingT(t) }
 
 func TestConnect(t *testing.T) {
 	conn := new(UEventConn)

--- a/strutil/quantity/example_test.go
+++ b/strutil/quantity/example_test.go
@@ -22,10 +22,15 @@ package quantity_test
 import (
 	"fmt"
 	"math"
+	"testing"
 	"time"
 
 	"github.com/snapcore/snapd/strutil/quantity"
+
+	. "gopkg.in/check.v1"
 )
+
+func Test(t *testing.T) { TestingT(t) }
 
 func ExampleFormatAmount_short() {
 	fmt.Printf("%q\n", quantity.FormatAmount(12345, -1))

--- a/strutil/shlex/shlex_test.go
+++ b/strutil/shlex/shlex_test.go
@@ -20,7 +20,11 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
+
+func Test(t *testing.T) { TestingT(t) }
 
 var (
 	// one two "three four" "five \"six\"" seven#eight # nine # ten


### PR DESCRIPTION
This allows us to use -gocheck options for the whole codebase, for example to
run all tests in the codebase with the name matching "kernel" one can now do:

go test ./... -gocheck.f kernel

and that will only fail if the tests fail, whereas previously it would fail
because in these packages gocheck was not imported and as such -gocheck.f was
not recognized as an option and the help text for `go test` was printed off
instead of running any tests.

Eventually we may want to adapt the tests in these packages to use go-check too
so that these can also be filtered/run successfully with go test and gocheck
options.