### PR TITLE
boot/makebootable.go: set snapd_recovery_mode=install at image-build time

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -181,6 +181,8 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	// ubuntu-seed
 	blVars := map[string]string{
 		"snapd_recovery_system": bootWith.RecoverySystemLabel,
+		// always set the mode as install
+		"snapd_recovery_mode": ModeInstall,
 	}
 	if err := bl.SetBootVars(blVars); err != nil {
 		return fmt.Errorf("cannot set recovery environment: %v", err)

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -910,6 +910,7 @@ version: 5.0
 
 	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
 		"snapd_recovery_system": label,
+		"snapd_recovery_mode":   "install",
 	})
 
 	// ensure the correct recovery system configuration was set

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2662,6 +2662,7 @@ func (s *imageSuite) TestSetupSeedCore20Grub(c *C) {
 	seedGenv := grubenv.NewEnv(seedGrubenv)
 	c.Assert(seedGenv.Load(), IsNil)
 	c.Check(seedGenv.Get("snapd_recovery_system"), Equals, filepath.Base(systems[0]))
+	c.Check(seedGenv.Get("snapd_recovery_mode"), Equals, "install")
 
 	c.Check(s.stderr.String(), Equals, "")
 
@@ -2773,6 +2774,7 @@ func (s *imageSuite) TestSetupSeedCore20UBoot(c *C) {
 	env, err := ubootenv.Open(bootSel)
 	c.Assert(err, IsNil)
 	c.Assert(env.Get("snapd_recovery_system"), Equals, expectedLabel)
+	c.Assert(env.Get("snapd_recovery_mode"), Equals, "install")
 
 	// check recovery system specific config
 	systems, err := filepath.Glob(filepath.Join(seeddir, "systems", "*"))


### PR DESCRIPTION
This is the first step to doing away with the current default of
snapd_recovery_mode being unset implying "install". We need prepare-image (and
thus also ubuntu-image) to start writing "snapd_recovery_mode=install".