### PR TITLE
devicestate: support "storage-safety" defaults during install

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -690,7 +690,7 @@ func (m *recoverModeStateMachine) finalize() error {
 	// check soundness
 	// the grade check makes sure that if data was mounted unencrypted
 	// but the model is secured it will end up marked as untrusted
-	isEncrypted := m.isEncryptedDev || m.model.Grade() == asserts.ModelSecured
+	isEncrypted := m.isEncryptedDev || m.model.StorageSafety() == asserts.StorageSafetyEncrypted
 	part := m.degradedState.partition("ubuntu-data")
 	if part.MountState == partitionMounted && isEncrypted {
 		// check that save and data match

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -440,7 +440,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallSignedBypassEncryption(c *C) {
 
 func (s *deviceMgrInstallModeSuite) TestInstallSecured(c *C) {
 	err := s.doRunChangeTestWithEncryption(c, "secured", encTestCase{tpm: false, bypass: false, encrypt: false})
-	c.Assert(err, ErrorMatches, "(?s).*cannot encrypt secured device: TPM not available.*")
+	c.Assert(err, ErrorMatches, "(?s).*cannot encrypt device storage as mandated by model grade secured: TPM not available.*")
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallSecuredWithTPM(c *C) {
@@ -482,7 +482,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallSecuredWithTPMAndSave(c *C) {
 
 func (s *deviceMgrInstallModeSuite) TestInstallSecuredBypassEncryption(c *C) {
 	err := s.doRunChangeTestWithEncryption(c, "secured", encTestCase{tpm: false, bypass: true, encrypt: false})
-	c.Assert(err, ErrorMatches, "(?s).*cannot encrypt secured device: TPM not available.*")
+	c.Assert(err, ErrorMatches, "(?s).*cannot encrypt device storage as mandated by model grade secured: TPM not available.*")
 }
 
 func (s *deviceMgrInstallModeSuite) testInstallEncryptionSanityChecks(c *C, errMatch string) {
@@ -848,5 +848,51 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncrypted(c *C) {
 		encrypt, err := devicestate.CheckEncryption(mockModel)
 		c.Assert(err, IsNil)
 		c.Check(encrypt, Equals, tc.expectedEncryption)
+	}
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrors(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restore := devicestate.MockSecbootCheckKeySealingSupported(func() error { return fmt.Errorf("tpm says no") })
+	defer restore()
+
+	var testCases = []struct {
+		grade, storageSafety string
+
+		expectedErr string
+	}{
+		// we don't test unset here because the assertion assembly
+		// will ensure it has a default
+		{"dangerous", "encrypted", "cannot encrypt device storage as mandated by encrypted storage-safety model option: tpm says no"},
+		{"signed", "encrypted", "cannot encrypt device storage as mandated by encrypted storage-safety model option: tpm says no"},
+		{"secured", "", "cannot encrypt device storage as mandated by model grade secured: tpm says no"},
+		{"secured", "encrypted", "cannot encrypt device storage as mandated by model grade secured: tpm says no"},
+	}
+	for _, tc := range testCases {
+		mockModel := s.makeModelAssertionInState(c, "my-brand", "my-model", map[string]interface{}{
+			"display-name":   "my model",
+			"architecture":   "amd64",
+			"base":           "core20",
+			"grade":          tc.grade,
+			"storage-safety": tc.storageSafety,
+			"snaps": []interface{}{
+				map[string]interface{}{
+					"name":            "pc-kernel",
+					"id":              pcKernelSnapID,
+					"type":            "kernel",
+					"default-channel": "20",
+				},
+				map[string]interface{}{
+					"name":            "pc",
+					"id":              pcSnapID,
+					"type":            "gadget",
+					"default-channel": "20",
+				}},
+		})
+
+		_, err := devicestate.CheckEncryption(mockModel)
+		c.Check(err, ErrorMatches, tc.expectedErr, Commentf("%s %s", tc.grade, tc.storageSafety))
 	}
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -214,6 +214,8 @@ var (
 	PendingGadgetInfo   = pendingGadgetInfo
 
 	CriticalTaskEdges = criticalTaskEdges
+
+	CheckEncryption = checkEncryption
 )
 
 func MockGadgetUpdate(mock func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc, observer gadget.ContentUpdateObserver) error) (restore func()) {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -320,5 +320,16 @@ func checkEncryption(model *asserts.Model) (res bool, err error) {
 		return false, nil
 	}
 
+	// encryption is available but some models may prefer to not
+	// use it
+	// TODO: provide way to select via install chooser menu
+	// if the install is unencrypted or encrypted
+	if model.StorageSafety() == asserts.StorageSafetyPreferUnencrypted {
+		logger.Noticef(`installing system unencrypted because of "storage-safety: prefer-unencrypted"`)
+		return false, nil
+	}
+
+	// encrypt if it's supported and the user/model did not express
+	// other preferences
 	return true, nil
 }

--- a/tests/lib/assertions/developer1-20-storage-safety-prefer-unencrypted.json
+++ b/tests/lib/assertions/developer1-20-storage-safety-prefer-unencrypted.json
@@ -1,0 +1,41 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "testkeys-snapd-signed-core-20-amd64",
+    "architecture": "amd64",
+    "timestamp": "2020-11-17T22:00:00+00:00",
+    "grade": "dangerous",
+    "storage-safety": "prefer-unencrypted",
+    "base": "core20",
+    "serial-authority": [
+        "generic"
+    ],
+    "snaps": [
+        {
+            "default-channel": "20/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "20/edge",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel",
+            "type": "kernel"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q",
+            "name": "core20",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        }
+    ]
+}

--- a/tests/lib/assertions/developer1-20-storage-safety-prefer-unencrypted.model
+++ b/tests/lib/assertions/developer1-20-storage-safety-prefer-unencrypted.model
@@ -1,0 +1,45 @@
+type: model
+authority-id: developer1
+series: 16
+brand-id: developer1
+model: testkeys-snapd-signed-core-20-amd64
+architecture: amd64
+base: core20
+grade: dangerous
+serial-authority:
+  - generic
+snaps:
+  -
+    default-channel: 20/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 20/edge
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
+    name: core20
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+storage-safety: prefer-unencrypted
+timestamp: 2020-11-17T22:00:00+00:00
+sign-key-sha3-384: EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
+
+AcLBUgQAAQoABgUCX7OZLQAA184QAKhwE9DuDhsgyOhAxernDIqHAEOuyI/57qPKDeVWLZLKB9/Y
+5BDwR65G3tYL/3ZinnSPmshJYxk/S233JosglguGF+Wykqdhic+FknIy58X1ELVaTvPbn9UgiJBj
+5LqUDa/wm0hMTE48UcQuR59qOhTr2sBRjK3ZUfAqHPYGhUgSBa2P2wgAWkRjTI1C58pU/RXgG9Ov
+DR8dvZlxPk7G7TwZXr2Q8gT/bEOePiGBD3rE574R8xgRWRYVpEUJQDSTCtS2ZK24DcHt5dO6Y7fj
+cxKZae0ySm63TP9pXB5blESj1f9QTLH5lG1NAsKyC3A0yG4s0g2z4LKj23wLuV6GkQmXsLPBI7OT
+kUvFq3XxaZnPKF12hYLXc0SLH3pAZruOXtzVW39YwXzCRDZ5g71K19JHjGaKO9PG8YAFC7dNocld
+OEFpxFtSIq0SlYXlrDujeQ/LCx89NpD8602By93ZBeYBGVV2WGAE1ccwqDf7yAJ0aWk014c2Ox3h
+gqDrMlLdkAyXDMnTVCr9q1Yc+zO3t4ZET/6jb8vdOThX4wfgHUk7RiP3Kfge8CT+piGO9hTDVUdX
+b7byA1Ayqgd0/eOc6eKv6uH20BApK9iw1qj/FQFSmnU+cvI1iKfO6dNaReuQkuV3QA4moMQfC7R7
++BG6unTYovptwY2h5E47bhC76dgj

--- a/tests/nested/manual/uc20-storage-safety/task.yaml
+++ b/tests/nested/manual/uc20-storage-safety/task.yaml
@@ -1,0 +1,71 @@
+summary: Test that storage-safety prefer-unencrypted works
+
+systems: [ubuntu-20.04-64]
+
+environment:
+    NESTED_ENABLE_TPM: true
+    NESTED_ENABLE_SECURE_BOOT: true
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+    NESTED_USE_CLOUD_INIT: true
+
+    MODEL_STORAGE_SAFETY/preferunencrypted: prefer-unencrypted
+    NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-20-storage-safety-${MODEL_STORAGE_SAFETY}.model
+    NESTED_IMAGE_ID: core20-storage-safety-${MODEL_STORAGE_SAFETY}
+    NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
+    NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+  
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+
+    # setup the fakestore, but don't use it for our snapd here on the
+    # host VM, so tear down the staging_store immediately afterwards
+    # so that only the SAS is running and our snapd is not pointed at
+    # it, ubuntu-image is the only thing that actually needs to use
+    # the fakestore, and we will manually point it at the fakestore
+    # below using NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL
+    setup_fake_store "$NESTED_FAKESTORE_BLOB_DIR"
+    teardown_staging_store
+
+    echo Expose the needed assertions through the fakestore
+    cp "$TESTSLIB"/assertions/developer1.account "$NESTED_FAKESTORE_BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account-key "$NESTED_FAKESTORE_BLOB_DIR/asserts"
+
+    "$TESTSTOOLS"/nested-state build-image core
+    "$TESTSTOOLS"/nested-state create-vm core
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    teardown_fake_store "$NESTED_FAKESTORE_BLOB_DIR"
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    echo "Verify that no fde keys are generated"
+    nested_exec "test ! -d /var/lib/snapd/device/fde"
+
+    # TODO: once we have a install-mode log (PR#9545) we could grep
+    #       "installing system unencrypted because of ..."
+
+    # check that data is mounted from a regular device, not a mapper
+    nested_exec "mount" | MATCH "/dev/[svh]da[45] on /run/mnt/data"


### PR DESCRIPTION
This commit adds support for the model storage-safety preferences.
So for models that set "prefer-unencrypted" the encryption will be
skipped currently. Note that this does not yet implement setting
a different preference via the install chooser menu. This should
also be supported eventually.
