### PR TITLE
snap: use the boot-base for kernel hooks

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1014,16 +1014,18 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	}
 	if info.Base != "" {
 		cmd = append(cmd, "--base", info.Base)
-	}
-	// kernels have no explicit base, we use the boot base
-	if info.Type() == snap.TypeKernel && info.Base == "" {
-		modelAssertion, err := x.client.CurrentModelAssertion()
-		if err != nil {
-			return err
-		}
-		modelBase := modelAssertion.Base()
-		if modelBase != "" {
-			cmd = append(cmd, "--base", modelBase)
+	} else {
+		if info.Type() == snap.TypeKernel {
+			// kernels have no explicit base, we use the boot base
+
+			modelAssertion, err := x.client.CurrentModelAssertion()
+			if err != nil {
+				return fmt.Errorf("cannot get model assertion for kernel hook: %v", err)
+			}
+			modelBase := modelAssertion.Base()
+			if modelBase != "" {
+				cmd = append(cmd, "--base", modelBase)
+			}
 		}
 	}
 	cmd = append(cmd, securityTag)

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1015,6 +1015,17 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	if info.Base != "" {
 		cmd = append(cmd, "--base", info.Base)
 	}
+	// kernels have no explicit base, we use the boot base
+	if info.Type() == snap.TypeKernel && info.Base == "" {
+		modelAssertion, err := x.client.CurrentModelAssertion()
+		if err != nil {
+			return err
+		}
+		modelBase := modelAssertion.Base()
+		if modelBase != "" {
+			cmd = append(cmd, "--base", modelBase)
+		}
+	}
 	cmd = append(cmd, securityTag)
 
 	// when under confinement, snap-exec is run from 'core' snap rootfs

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1017,10 +1017,13 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	} else {
 		if info.Type() == snap.TypeKernel {
 			// kernels have no explicit base, we use the boot base
-
 			modelAssertion, err := x.client.CurrentModelAssertion()
 			if err != nil {
-				return fmt.Errorf("cannot get model assertion for kernel hook: %v", err)
+				if hook != "" {
+					return fmt.Errorf("cannot get model assertion to setup kernel hook run: %v", err)
+				} else {
+					return fmt.Errorf("cannot get model assertion to setup kernel app run: %v", err)
+				}
 			}
 			modelBase := modelAssertion.Base()
 			if modelBase != "" {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -22,6 +22,7 @@ package main_test
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -1510,4 +1511,61 @@ func (s *RunSuite) TestSnapRunTrackingFailure(c *check.C) {
 
 	// Ensure that the debug message is printed.
 	c.Assert(logbuf.String(), testutil.Contains, "snapd cannot track the started application\n")
+}
+
+var mockKernelYaml = []byte(`name: pc-kernel
+type: kernel
+version: 1.0
+hooks:
+ fde-setup:
+`)
+
+func (s *RunSuite) TestSnapRunHookKernelImplicitBase(c *check.C) {
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	nModel := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/model":
+			switch nModel {
+			case 0:
+				c.Check(r.Method, check.Equals, "GET")
+				c.Check(r.URL.RawQuery, check.Equals, "")
+				fmt.Fprintln(w, happyUC20ModelAssertionResponse)
+			default:
+				c.Fatalf("expected to get 1 request for /v2/model, now on %d", nModel+1)
+			}
+			nModel++
+		}
+	})
+
+	// mock installed kernel
+	snaptest.MockSnapCurrent(c, string(mockKernelYaml), &snap.SideInfo{
+		Revision: snap.R(42),
+	})
+
+	// redirect exec
+	execArg0 := ""
+	execArgs := []string{}
+	execEnv := []string{}
+	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		execArg0 = arg0
+		execArgs = args
+		execEnv = envv
+		return nil
+	})
+	defer restorer()
+
+	// Run a hook from the active revision
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=fde-setup", "--", "pc-kernel"})
+	c.Assert(err, check.IsNil)
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
+	c.Check(execArgs, check.DeepEquals, []string{
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
+		"--base", "core20",
+		"snap.pc-kernel.hook.fde-setup",
+		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
+		"--hook=fde-setup", "pc-kernel"})
+	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
+	c.Check(nModel, check.Equals, 1)
 }


### PR DESCRIPTION
The kernel snap can have hooks, e.g. the fde-setup hook or a configure
hook. To support this we run the hooks with the boot base of the model.
