### PR TITLE
boot/makebootable.go: set snapd_recovery_mode=install at image-build time

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -181,6 +181,8 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	// ubuntu-seed
 	blVars := map[string]string{
 		"snapd_recovery_system": bootWith.RecoverySystemLabel,
+		// always set the mode as install
+		"snapd_recovery_mode": ModeInstall,
 	}
 	if err := bl.SetBootVars(blVars); err != nil {
 		return fmt.Errorf("cannot set recovery environment: %v", err)

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -243,6 +243,7 @@ version: 5.0
 	})
 	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
 		"snapd_recovery_system": label,
+		"snapd_recovery_mode":   "install",
 	})
 }
 
@@ -908,6 +909,7 @@ version: 5.0
 
 	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
 		"snapd_recovery_system": label,
+		"snapd_recovery_mode":   "install",
 	})
 
 	// ensure the correct recovery system configuration was set

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2663,6 +2663,7 @@ func (s *imageSuite) TestSetupSeedCore20(c *C) {
 	})
 	c.Check(bl.BootVars, DeepEquals, map[string]string{
 		"snapd_recovery_system": filepath.Base(systems[0]),
+		"snapd_recovery_mode":   "install",
 	})
 
 	// check the downloads
@@ -2769,6 +2770,7 @@ func (s *imageSuite) TestSetupSeedCore20UBoot(c *C) {
 	env, err := ubootenv.Open(bootSel)
 	c.Assert(err, IsNil)
 	c.Assert(env.Get("snapd_recovery_system"), Equals, expectedLabel)
+	c.Assert(env.Get("snapd_recovery_mode"), Equals, "install")
 
 	// check recovery system specific config
 	systems, err := filepath.Glob(filepath.Join(seeddir, "systems", "*"))


### PR DESCRIPTION
This is the first step to doing away with the current default of
snapd_recovery_mode being unset implying "install". We need prepare-image (and
thus also ubuntu-image) to start writing "snapd_recovery_mode=install".

This is a backport of https://github.com/snapcore/snapd/pull/9654 to 2.48, due to conflicts introduced by https://github.com/snapcore/snapd/pull/9643 which was landed to master before I wrote #9654.