### PR TITLE
bootloader/many: return error from ConfigFile and new* functions

### DIFF
--- a/bootloader/androidboot.go
+++ b/bootloader/androidboot.go
@@ -32,9 +32,9 @@ type androidboot struct {
 }
 
 // newAndroidboot creates a new Androidboot bootloader object
-func newAndroidBoot(rootdir string, _ *Options) Bootloader {
+func newAndroidBoot(rootdir string, _ *Options) (Bootloader, error) {
 	a := &androidboot{rootdir: rootdir}
-	return a
+	return a, nil
 }
 
 func (a *androidboot) Name() string {
@@ -54,16 +54,17 @@ func (a *androidboot) dir() string {
 
 func (a *androidboot) InstallBootConfig(gadgetDir string, opts *Options) error {
 	gadgetFile := filepath.Join(gadgetDir, a.Name()+".conf")
-	systemFile := a.ConfigFile()
+	systemFile, _ := a.ConfigFile()
 	return genericInstallBootConfig(gadgetFile, systemFile)
 }
 
-func (a *androidboot) ConfigFile() string {
-	return filepath.Join(a.dir(), "androidboot.env")
+func (a *androidboot) ConfigFile() (string, error) {
+	return filepath.Join(a.dir(), "androidboot.env"), nil
 }
 
 func (a *androidboot) GetBootVars(names ...string) (map[string]string, error) {
-	env := androidbootenv.NewEnv(a.ConfigFile())
+	f, _ := a.ConfigFile()
+	env := androidbootenv.NewEnv(f)
 	if err := env.Load(); err != nil {
 		return nil, err
 	}
@@ -77,7 +78,8 @@ func (a *androidboot) GetBootVars(names ...string) (map[string]string, error) {
 }
 
 func (a *androidboot) SetBootVars(values map[string]string) error {
-	env := androidbootenv.NewEnv(a.ConfigFile())
+	f, _ := a.ConfigFile()
+	env := androidbootenv.NewEnv(f)
 	if err := env.Load(); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -89,7 +91,6 @@ func (a *androidboot) SetBootVars(values map[string]string) error {
 
 func (a *androidboot) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
 	return nil
-
 }
 
 func (a *androidboot) RemoveKernelAssets(s snap.PlaceInfo) error {

--- a/bootloader/androidboot_test.go
+++ b/bootloader/androidboot_test.go
@@ -46,12 +46,14 @@ func (s *androidBootTestSuite) SetUpTest(c *C) {
 }
 
 func (s *androidBootTestSuite) TestNewAndroidboot(c *C) {
-	a := bootloader.NewAndroidBoot(s.rootdir)
+	a, err := bootloader.NewAndroidBoot(s.rootdir)
+	c.Assert(err, IsNil)
 	c.Assert(a, NotNil)
 }
 
 func (s *androidBootTestSuite) TestSetGetBootVar(c *C) {
-	a := bootloader.NewAndroidBoot(s.rootdir)
+	a, err := bootloader.NewAndroidBoot(s.rootdir)
+	c.Assert(err, IsNil)
 	bootVars := map[string]string{"snap_mode": boot.TryStatus}
 	a.SetBootVars(bootVars)
 
@@ -62,7 +64,8 @@ func (s *androidBootTestSuite) TestSetGetBootVar(c *C) {
 }
 
 func (s *androidBootTestSuite) TestExtractKernelAssetsNoUnpacksKernel(c *C) {
-	a := bootloader.NewAndroidBoot(s.rootdir)
+	a, err := bootloader.NewAndroidBoot(s.rootdir)
+	c.Assert(err, IsNil)
 
 	c.Assert(a, NotNil)
 

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -99,8 +99,8 @@ func (b *MockBootloader) Name() string {
 	return b.name
 }
 
-func (b *MockBootloader) ConfigFile() string {
-	return filepath.Join(b.bootdir, "mockboot/mockboot.cfg")
+func (b *MockBootloader) ConfigFile() (string, error) {
+	return filepath.Join(b.bootdir, "mockboot/mockboot.cfg"), nil
 }
 
 func (b *MockBootloader) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -31,20 +31,30 @@ import (
 )
 
 // creates a new Androidboot bootloader object
-func NewAndroidBoot(rootdir string) Bootloader {
-	return newAndroidBoot(rootdir, nil)
+func NewAndroidBoot(rootdir string) (Bootloader, error) {
+	bl, err := newAndroidBoot(rootdir, nil)
+	if err != nil {
+		return nil, err
+	}
+	return bl, nil
 }
 
 func MockAndroidBootFile(c *C, rootdir string, mode os.FileMode) {
 	f := &androidboot{rootdir: rootdir}
 	err := os.MkdirAll(f.dir(), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(f.ConfigFile(), nil, mode)
+	confFile, err := f.ConfigFile()
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(confFile, nil, mode)
 	c.Assert(err, IsNil)
 }
 
-func NewUboot(rootdir string, blOpts *Options) ExtractedRecoveryKernelImageBootloader {
-	return newUboot(rootdir, blOpts).(ExtractedRecoveryKernelImageBootloader)
+func NewUboot(rootdir string, blOpts *Options) (ExtractedRecoveryKernelImageBootloader, error) {
+	bl, err := newUboot(rootdir, blOpts)
+	if err != nil {
+		return nil, err
+	}
+	return bl.(ExtractedRecoveryKernelImageBootloader), err
 }
 
 func MockUbootFiles(c *C, rootdir string, blOpts *Options) {
@@ -61,8 +71,12 @@ func MockUbootFiles(c *C, rootdir string, blOpts *Options) {
 	c.Assert(err, IsNil)
 }
 
-func NewGrub(rootdir string, opts *Options) RecoveryAwareBootloader {
-	return newGrub(rootdir, opts).(RecoveryAwareBootloader)
+func NewGrub(rootdir string, opts *Options) (RecoveryAwareBootloader, error) {
+	bl, err := newGrub(rootdir, opts)
+	if err != nil {
+		return nil, err
+	}
+	return bl.(RecoveryAwareBootloader), nil
 }
 
 func MockGrubFiles(c *C, rootdir string) {
@@ -72,7 +86,7 @@ func MockGrubFiles(c *C, rootdir string) {
 	c.Assert(err, IsNil)
 }
 
-func NewLk(rootdir string, opts *Options) Bootloader {
+func NewLk(rootdir string, opts *Options) (Bootloader, error) {
 	if opts == nil {
 		opts = &Options{}
 	}

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -52,7 +52,7 @@ type grub struct {
 }
 
 // newGrub create a new Grub bootloader object
-func newGrub(rootdir string, opts *Options) Bootloader {
+func newGrub(rootdir string, opts *Options) (Bootloader, error) {
 	g := &grub{rootdir: rootdir}
 	if opts != nil {
 		// Set the flag to extract the run kernel, only
@@ -69,7 +69,7 @@ func newGrub(rootdir string, opts *Options) Bootloader {
 		g.basedir = "boot/grub"
 	}
 
-	return g
+	return g, nil
 }
 
 func (g *grub) Name() string {
@@ -144,8 +144,8 @@ func (g *grub) GetRecoverySystemEnv(recoverySystemDir string, key string) (strin
 	return genv.Get(key), nil
 }
 
-func (g *grub) ConfigFile() string {
-	return filepath.Join(g.dir(), "grub.cfg")
+func (g *grub) ConfigFile() (string, error) {
+	return filepath.Join(g.dir(), "grub.cfg"), nil
 }
 
 func (g *grub) envFile() string {

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -102,7 +102,8 @@ func (s *grubTestSuite) makeFakeGrubEnv(c *C) {
 func (s *grubTestSuite) TestNewGrub(c *C) {
 	s.makeFakeGrubEnv(c)
 
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 	c.Assert(g.Name(), Equals, "grub")
 }
@@ -130,7 +131,8 @@ func (s *grubTestSuite) TestGetBootVer(c *C) {
 	s.makeFakeGrubEnv(c)
 	s.grubEditenvSet(c, "snap_mode", "regular")
 
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	v, err := g.GetBootVars("snap_mode")
 	c.Assert(err, IsNil)
 	c.Check(v, HasLen, 1)
@@ -140,8 +142,9 @@ func (s *grubTestSuite) TestGetBootVer(c *C) {
 func (s *grubTestSuite) TestSetBootVer(c *C) {
 	s.makeFakeGrubEnv(c)
 
-	g := bootloader.NewGrub(s.rootdir, nil)
-	err := g.SetBootVars(map[string]string{
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
+	err = g.SetBootVars(map[string]string{
 		"k1": "v1",
 		"k2": "v2",
 	})
@@ -154,7 +157,8 @@ func (s *grubTestSuite) TestSetBootVer(c *C) {
 func (s *grubTestSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {
 	s.makeFakeGrubEnv(c)
 
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 
 	files := [][]string{
 		{"kernel.img", "I'm a kernel"},
@@ -183,7 +187,8 @@ func (s *grubTestSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {
 func (s *grubTestSuite) TestExtractKernelForceWorks(c *C) {
 	s.makeFakeGrubEnv(c)
 
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 
 	files := [][]string{
@@ -239,18 +244,20 @@ func (s *grubTestSuite) makeFakeGrubEFINativeEnv(c *C, content []byte) {
 func (s *grubTestSuite) TestNewGrubWithOptionRecovery(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
 
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	g, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 	c.Assert(g.Name(), Equals, "grub")
 }
 
 func (s *grubTestSuite) TestNewGrubWithOptionRecoveryBootEnv(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	g, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	c.Assert(err, IsNil)
 
 	// check that setting vars goes to the right place
 	c.Check(filepath.Join(s.grubEFINativeDir(), "grubenv"), testutil.FileAbsent)
-	err := g.SetBootVars(map[string]string{
+	err = g.SetBootVars(map[string]string{
 		"k1": "v1",
 		"k2": "v2",
 	})
@@ -277,7 +284,8 @@ func (s *grubTestSuite) TestNewGrubWithOptionRecoveryNoEnv(c *C) {
 
 func (s *grubTestSuite) TestGrubSetRecoverySystemEnv(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	g, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	c.Assert(err, IsNil)
 
 	// check that we can set a recovery system specific bootenv
 	bvars := map[string]string{
@@ -285,7 +293,7 @@ func (s *grubTestSuite) TestGrubSetRecoverySystemEnv(c *C) {
 		"other_options":         "are-supported",
 	}
 
-	err := g.SetRecoverySystemEnv("/systems/20191209", bvars)
+	err = g.SetRecoverySystemEnv("/systems/20191209", bvars)
 	c.Assert(err, IsNil)
 	recoverySystemGrubenv := filepath.Join(s.rootdir, "/systems/20191209/grubenv")
 	c.Assert(recoverySystemGrubenv, testutil.FilePresent)
@@ -299,9 +307,10 @@ func (s *grubTestSuite) TestGrubSetRecoverySystemEnv(c *C) {
 
 func (s *grubTestSuite) TestGetRecoverySystemEnv(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	g, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	c.Assert(err, IsNil)
 
-	err := os.MkdirAll(filepath.Join(s.rootdir, "/systems/20191209"), 0755)
+	err = os.MkdirAll(filepath.Join(s.rootdir, "/systems/20191209"), 0755)
 	c.Assert(err, IsNil)
 	recoverySystemGrubenv := filepath.Join(s.rootdir, "/systems/20191209/grubenv")
 
@@ -357,7 +366,8 @@ func (s *grubTestSuite) makeKernelAssetSnapAndSymlink(c *C, snapFileName, symlin
 
 func (s *grubTestSuite) TestGrubExtractedRunKernelImageKernel(c *C) {
 	s.makeFakeGrubEnv(c)
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	eg, ok := g.(bootloader.ExtractedRunKernelImageBootloader)
 	c.Assert(ok, Equals, true)
 
@@ -371,12 +381,13 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageKernel(c *C) {
 
 func (s *grubTestSuite) TestGrubExtractedRunKernelImageTryKernel(c *C) {
 	s.makeFakeGrubEnv(c)
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	eg, ok := g.(bootloader.ExtractedRunKernelImageBootloader)
 	c.Assert(ok, Equals, true)
 
 	// ensure it doesn't return anything when the symlink doesn't exist
-	_, err := eg.TryKernel()
+	_, err = eg.TryKernel()
 	c.Assert(err, Equals, bootloader.ErrNoTryKernelRef)
 
 	// when a bad kernel snap name is in the extracted path, it will complain
@@ -417,7 +428,8 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageTryKernel(c *C) {
 
 func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableKernel(c *C) {
 	s.makeFakeGrubEnv(c)
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	eg, ok := g.(bootloader.ExtractedRunKernelImageBootloader)
 	c.Assert(ok, Equals, true)
 
@@ -453,14 +465,15 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableKernel(c *C) {
 
 func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableTryKernel(c *C) {
 	s.makeFakeGrubEnv(c)
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	eg, ok := g.(bootloader.ExtractedRunKernelImageBootloader)
 	c.Assert(ok, Equals, true)
 
 	kernel := s.makeKernelAssetSnap(c, "pc-kernel_1.snap")
 
 	// enable the Kernel we extracted
-	err := eg.EnableTryKernel(kernel)
+	err = eg.EnableTryKernel(kernel)
 	c.Assert(err, IsNil)
 
 	// ensure that the symlink was put where we expect it
@@ -476,13 +489,14 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageDisableTryKernel(c *C) {
 	}
 
 	s.makeFakeGrubEnv(c)
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	eg, ok := g.(bootloader.ExtractedRunKernelImageBootloader)
 	c.Assert(ok, Equals, true)
 
 	// trying to disable when the try-kernel.efi symlink is missing does not
 	// raise any errors
-	err := eg.DisableTryKernel()
+	err = eg.DisableTryKernel()
 	c.Assert(err, IsNil)
 
 	// make the symlink and check that the symlink is missing afterwards
@@ -510,7 +524,8 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageDisableTryKernel(c *C) {
 func (s *grubTestSuite) TestKernelExtractionRunImageKernel(c *C) {
 	s.makeFakeGrubEnv(c)
 
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
+	g, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 
 	files := [][]string{
@@ -552,7 +567,8 @@ func (s *grubTestSuite) TestKernelExtractionRunImageKernelNoSlashBoot(c *C) {
 	// layout, same as Recovery, without the /boot mount
 	s.makeFakeGrubEFINativeEnv(c, nil)
 
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode, NoSlashBoot: true})
+	g, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode, NoSlashBoot: true})
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 
 	files := [][]string{
@@ -606,7 +622,8 @@ func (s *grubTestSuite) TestListManagedAssets(c *C) {
 some random boot config`))
 
 	opts := &bootloader.Options{NoSlashBoot: true}
-	g := bootloader.NewGrub(s.rootdir, opts)
+	g, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
@@ -617,14 +634,18 @@ some random boot config`))
 	})
 
 	opts = &bootloader.Options{Role: bootloader.RoleRecovery}
-	tg = bootloader.NewGrub(s.rootdir, opts).(bootloader.TrustedAssetsBootloader)
+	bl2, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
+	tg = bl2.(bootloader.TrustedAssetsBootloader)
 	c.Check(tg.ManagedAssets(), DeepEquals, []string{
 		"EFI/ubuntu/grub.cfg",
 	})
 
 	// as it called for the root fs rather than a mount point of a partition
 	// with boot assets
-	tg = bootloader.NewGrub(s.rootdir, nil).(bootloader.TrustedAssetsBootloader)
+	bl3, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
+	tg = bl3.(bootloader.TrustedAssetsBootloader)
 	c.Check(tg.ManagedAssets(), DeepEquals, []string{
 		"boot/grub/grub.cfg",
 	})
@@ -635,7 +656,8 @@ func (s *grubTestSuite) TestRecoveryUpdateBootConfigNoEdition(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, []byte("recovery boot script"))
 
 	opts := &bootloader.Options{Role: bootloader.RoleRecovery}
-	g := bootloader.NewGrub(s.rootdir, opts)
+	g, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 
 	restore := assets.MockInternal("grub-recovery.cfg", []byte(`# Snapd-Boot-Config-Edition: 5
@@ -646,7 +668,7 @@ this is mocked grub-recovery.conf
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 	// install the recovery boot script
-	err := tg.UpdateBootConfig(opts)
+	err = tg.UpdateBootConfig(opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, `recovery boot script`)
@@ -658,7 +680,8 @@ func (s *grubTestSuite) TestRecoveryUpdateBootConfigUpdates(c *C) {
 recovery boot script`))
 
 	opts := &bootloader.Options{Role: bootloader.RoleRecovery}
-	g := bootloader.NewGrub(s.rootdir, opts)
+	g, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 
 	restore := assets.MockInternal("grub-recovery.cfg", []byte(`# Snapd-Boot-Config-Edition: 3
@@ -672,7 +695,7 @@ this is mocked grub.conf
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 	// install the recovery boot script
-	err := tg.UpdateBootConfig(opts)
+	err = tg.UpdateBootConfig(opts)
 	c.Assert(err, IsNil)
 	// the recovery boot asset was picked
 	c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, `# Snapd-Boot-Config-Edition: 3
@@ -685,7 +708,8 @@ func (s *grubTestSuite) testBootUpdateBootConfigUpdates(c *C, oldConfig, newConf
 	s.makeFakeGrubEFINativeEnv(c, []byte(oldConfig))
 
 	opts := &bootloader.Options{NoSlashBoot: true}
-	g := bootloader.NewGrub(s.rootdir, opts)
+	g, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 
 	restore := assets.MockInternal("grub.cfg", []byte(newConfig))
@@ -693,7 +717,7 @@ func (s *grubTestSuite) testBootUpdateBootConfigUpdates(c *C, oldConfig, newConf
 
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
-	err := tg.UpdateBootConfig(opts)
+	err = tg.UpdateBootConfig(opts)
 	c.Assert(err, IsNil)
 	if update {
 		c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, newConfig)
@@ -766,12 +790,13 @@ this is updated grub.cfg
 	defer restore()
 
 	opts := &bootloader.Options{NoSlashBoot: true}
-	g := bootloader.NewGrub(s.rootdir, opts)
+	g, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	err := os.Chmod(s.grubEFINativeDir(), 0000)
+	err = os.Chmod(s.grubEFINativeDir(), 0000)
 	c.Assert(err, IsNil)
 	defer os.Chmod(s.grubEFINativeDir(), 0755)
 
@@ -821,14 +846,18 @@ func (s *grubTestSuite) TestCommandLineNotManaged(c *C) {
 	defer restore()
 
 	opts := &bootloader.Options{NoSlashBoot: true}
-	mg := bootloader.NewGrub(s.rootdir, opts).(bootloader.TrustedAssetsBootloader)
+	bl, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
+	mg := bl.(bootloader.TrustedAssetsBootloader)
 
 	args, err := mg.CommandLine("snapd_recovery_mode=run", "", "extra")
 	c.Assert(err, IsNil)
 	c.Check(args, Equals, "snapd_recovery_mode=run static=1 extra")
 
 	optsRecovery := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
-	mgr := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.TrustedAssetsBootloader)
+	bl2, err := bootloader.NewGrub(s.rootdir, optsRecovery)
+	c.Assert(err, IsNil)
+	mgr := bl2.(bootloader.TrustedAssetsBootloader)
 
 	args, err = mgr.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=1234", "extra")
 	c.Assert(err, IsNil)
@@ -856,7 +885,8 @@ boot script
 	s.makeFakeGrubEFINativeEnv(c, []byte(grubCfg))
 
 	optsNoSlashBoot := &bootloader.Options{NoSlashBoot: true}
-	g := bootloader.NewGrub(s.rootdir, optsNoSlashBoot)
+	g, err := bootloader.NewGrub(s.rootdir, optsNoSlashBoot)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
@@ -873,7 +903,9 @@ boot script
 
 	// now check the recovery bootloader
 	optsRecovery := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
-	mrg := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.TrustedAssetsBootloader)
+	bl, err := bootloader.NewGrub(s.rootdir, optsRecovery)
+	c.Assert(err, IsNil)
+	mrg := bl.(bootloader.TrustedAssetsBootloader)
 	args, err = mrg.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=20200202", extraArgs)
 	c.Assert(err, IsNil)
 	// static command line from recovery asset
@@ -884,7 +916,9 @@ boot script
 boot script
 `
 	s.makeFakeGrubEFINativeEnv(c, []byte(grubCfg3))
-	tg = bootloader.NewGrub(s.rootdir, optsNoSlashBoot).(bootloader.TrustedAssetsBootloader)
+	bl3, err := bootloader.NewGrub(s.rootdir, optsNoSlashBoot)
+	c.Assert(err, IsNil)
+	tg = bl3.(bootloader.TrustedAssetsBootloader)
 	c.Assert(g, NotNil)
 	extraArgs = `extra_arg=1`
 	args, err = tg.CommandLine("snapd_recovery_mode=run", "", extraArgs)
@@ -921,9 +955,13 @@ boot script
 	defer restore()
 
 	optsNoSlashBoot := &bootloader.Options{NoSlashBoot: true}
-	mg := bootloader.NewGrub(s.rootdir, optsNoSlashBoot).(bootloader.TrustedAssetsBootloader)
+	bl, err := bootloader.NewGrub(s.rootdir, optsNoSlashBoot)
+	c.Assert(err, IsNil)
+	mg := bl.(bootloader.TrustedAssetsBootloader)
 	optsRecovery := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
-	recoverymg := bootloader.NewGrub(s.rootdir, optsRecovery).(bootloader.TrustedAssetsBootloader)
+	bl2, err := bootloader.NewGrub(s.rootdir, optsRecovery)
+	c.Assert(err, IsNil)
+	recoverymg := bl2.(bootloader.TrustedAssetsBootloader)
 
 	args, err := mg.CandidateCommandLine("snapd_recovery_mode=run", "", "extra=1")
 	c.Assert(err, IsNil)
@@ -965,7 +1003,8 @@ boot script
 	s.makeFakeGrubEFINativeEnv(c, []byte(grubCfg))
 
 	opts := &bootloader.Options{NoSlashBoot: true}
-	g := bootloader.NewGrub(s.rootdir, opts)
+	g, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
@@ -977,7 +1016,9 @@ boot script
 
 	// now check the recovery bootloader
 	opts = &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
-	mrg := bootloader.NewGrub(s.rootdir, opts).(bootloader.TrustedAssetsBootloader)
+	bl2, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
+	mrg := bl2.(bootloader.TrustedAssetsBootloader)
 	args, err = mrg.CommandLine("snapd_recovery_mode=recover", "snapd_recovery_system=20200202", extraArgs)
 	c.Assert(err, IsNil)
 	// static command line from recovery asset
@@ -988,7 +1029,8 @@ func (s *grubTestSuite) TestTrustedAssetsNativePartitionLayout(c *C) {
 	// native EFI/ubuntu setup
 	s.makeFakeGrubEFINativeEnv(c, []byte("grub.cfg"))
 	opts := &bootloader.Options{NoSlashBoot: true}
-	g := bootloader.NewGrub(s.rootdir, opts)
+	g, err := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(err, IsNil)
 	c.Assert(g, NotNil)
 
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
@@ -1002,7 +1044,9 @@ func (s *grubTestSuite) TestTrustedAssetsNativePartitionLayout(c *C) {
 
 	// recovery bootloader
 	recoveryOpts := &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRecovery}
-	tarb := bootloader.NewGrub(s.rootdir, recoveryOpts).(bootloader.TrustedAssetsBootloader)
+	bl2, err := bootloader.NewGrub(s.rootdir, recoveryOpts)
+	c.Assert(err, IsNil)
+	tarb := bl2.(bootloader.TrustedAssetsBootloader)
 	c.Assert(tarb, NotNil)
 
 	ta, err = tarb.TrustedAssets()
@@ -1016,7 +1060,8 @@ func (s *grubTestSuite) TestTrustedAssetsNativePartitionLayout(c *C) {
 
 func (s *grubTestSuite) TestTrustedAssetsRoot(c *C) {
 	s.makeFakeGrubEnv(c)
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
@@ -1027,7 +1072,8 @@ func (s *grubTestSuite) TestTrustedAssetsRoot(c *C) {
 
 func (s *grubTestSuite) TestRecoveryBootChains(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	g, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	c.Assert(err, IsNil)
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
@@ -1042,21 +1088,24 @@ func (s *grubTestSuite) TestRecoveryBootChains(c *C) {
 
 func (s *grubTestSuite) TestRecoveryBootChainsNotRecoveryBootloader(c *C) {
 	s.makeFakeGrubEnv(c)
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	_, err := tab.RecoveryBootChain("kernel.snap")
+	_, err = tab.RecoveryBootChain("kernel.snap")
 	c.Assert(err, ErrorMatches, "not a recovery bootloader")
 }
 
 func (s *grubTestSuite) TestBootChains(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
-	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	g, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	c.Assert(err, IsNil)
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
+	g2, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
+	c.Assert(err, IsNil)
 
 	chain, err := tab.BootChain(g2, "kernel.snap")
 	c.Assert(err, IsNil)
@@ -1070,12 +1119,14 @@ func (s *grubTestSuite) TestBootChains(c *C) {
 
 func (s *grubTestSuite) TestBootChainsNotRecoveryBootloader(c *C) {
 	s.makeFakeGrubEnv(c)
-	g := bootloader.NewGrub(s.rootdir, nil)
+	g, err := bootloader.NewGrub(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	tab, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 
-	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRunMode})
+	g2, err := bootloader.NewGrub(s.rootdir, &bootloader.Options{NoSlashBoot: true, Role: bootloader.RoleRunMode})
+	c.Assert(err, IsNil)
 
-	_, err := tab.BootChain(g2, "kernel.snap")
+	_, err = tab.BootChain(g2, "kernel.snap")
 	c.Assert(err, ErrorMatches, "not a recovery bootloader")
 }

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -37,7 +37,7 @@ type lk struct {
 }
 
 // newLk create a new lk bootloader object
-func newLk(rootdir string, opts *Options) Bootloader {
+func newLk(rootdir string, opts *Options) (Bootloader, error) {
 	l := &lk{rootdir: rootdir}
 
 	if opts != nil {
@@ -51,7 +51,7 @@ func newLk(rootdir string, opts *Options) Bootloader {
 		l.inRuntimeMode = !opts.PrepareImageTime
 	}
 
-	return l
+	return l, nil
 }
 
 func (l *lk) setRootDir(rootdir string) {
@@ -74,12 +74,12 @@ func (l *lk) dir() string {
 
 func (l *lk) InstallBootConfig(gadgetDir string, opts *Options) error {
 	gadgetFile := filepath.Join(gadgetDir, l.Name()+".conf")
-	systemFile := l.ConfigFile()
+	systemFile, _ := l.ConfigFile()
 	return genericInstallBootConfig(gadgetFile, systemFile)
 }
 
-func (l *lk) ConfigFile() string {
-	return l.envFile()
+func (l *lk) ConfigFile() (string, error) {
+	return l.envFile(), nil
 }
 
 func (l *lk) envFile() string {

--- a/bootloader/lk_test.go
+++ b/bootloader/lk_test.go
@@ -44,10 +44,13 @@ var _ = Suite(&lkTestSuite{})
 
 func (s *lkTestSuite) TestNewLk(c *C) {
 	bootloader.MockLkFiles(c, s.rootdir, nil)
-	l := bootloader.NewLk(s.rootdir, nil)
+	l, err := bootloader.NewLk(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	c.Assert(l, NotNil)
 	c.Check(bootloader.LkRuntimeMode(l), Equals, true)
-	c.Check(l.ConfigFile(), Equals, filepath.Join(s.rootdir, "/dev/disk/by-partlabel", "snapbootsel"))
+	f, err := l.ConfigFile()
+	c.Assert(err, IsNil)
+	c.Check(f, Equals, filepath.Join(s.rootdir, "/dev/disk/by-partlabel", "snapbootsel"))
 }
 
 func (s *lkTestSuite) TestNewLkImageBuildingTime(c *C) {
@@ -55,15 +58,19 @@ func (s *lkTestSuite) TestNewLkImageBuildingTime(c *C) {
 		PrepareImageTime: true,
 	}
 	bootloader.MockLkFiles(c, s.rootdir, opts)
-	l := bootloader.NewLk(s.rootdir, opts)
+	l, err := bootloader.NewLk(s.rootdir, opts)
+	c.Assert(err, IsNil)
 	c.Assert(l, NotNil)
 	c.Check(bootloader.LkRuntimeMode(l), Equals, false)
-	c.Check(l.ConfigFile(), Equals, filepath.Join(s.rootdir, "/boot/lk", "snapbootsel.bin"))
+	f, err := l.ConfigFile()
+	c.Assert(err, IsNil)
+	c.Check(f, Equals, filepath.Join(s.rootdir, "/boot/lk", "snapbootsel.bin"))
 }
 
 func (s *lkTestSuite) TestSetGetBootVar(c *C) {
 	bootloader.MockLkFiles(c, s.rootdir, nil)
-	l := bootloader.NewLk(s.rootdir, nil)
+	l, err := bootloader.NewLk(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	bootVars := map[string]string{"snap_mode": boot.TryStatus}
 	l.SetBootVars(bootVars)
 
@@ -78,7 +85,8 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksBootimgImageBuilding(c *C) {
 		PrepareImageTime: true,
 	}
 	bootloader.MockLkFiles(c, s.rootdir, opts)
-	l := bootloader.NewLk(s.rootdir, opts)
+	l, err := bootloader.NewLk(s.rootdir, opts)
+	c.Assert(err, IsNil)
 
 	c.Assert(l, NotNil)
 
@@ -122,15 +130,17 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksCustomBootimgImageBuilding(c
 		PrepareImageTime: true,
 	}
 	bootloader.MockLkFiles(c, s.rootdir, opts)
-	l := bootloader.NewLk(s.rootdir, opts)
-
+	l, err := bootloader.NewLk(s.rootdir, opts)
+	c.Assert(err, IsNil)
 	c.Assert(l, NotNil)
 
 	// first configure custom boot image file name
-	env := lkenv.NewEnv(l.ConfigFile())
+	f, err := l.ConfigFile()
+	c.Assert(err, IsNil)
+	env := lkenv.NewEnv(f)
 	env.Load()
 	env.ConfigureBootimgName("boot-2.img")
-	err := env.Save()
+	err = env.Save()
 	c.Assert(err, IsNil)
 
 	files := [][]string{
@@ -163,7 +173,8 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksCustomBootimgImageBuilding(c
 
 func (s *lkTestSuite) TestExtractKernelAssetsUnpacksAndRemoveInRuntimeMode(c *C) {
 	bootloader.MockLkFiles(c, s.rootdir, nil)
-	lk := bootloader.NewLk(s.rootdir, nil)
+	lk, err := bootloader.NewLk(s.rootdir, nil)
+	c.Assert(err, IsNil)
 	c.Assert(lk, NotNil)
 
 	// create mock bootsel, boot_a, boot_b partitions
@@ -178,7 +189,7 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksAndRemoveInRuntimeMode(c *C)
 	bootselPartition := filepath.Join(s.rootdir, "/dev/disk/by-partlabel/snapbootsel")
 	lkenv := lkenv.NewEnv(bootselPartition)
 	lkenv.ConfigureBootPartitions("boot_a", "boot_b")
-	err := lkenv.Save()
+	err = lkenv.Save()
 	c.Assert(err, IsNil)
 
 	// mock a kernel snap that has a boot.img

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -59,14 +59,14 @@ func (u *uboot) processBlOpts(blOpts *Options) {
 }
 
 // newUboot create a new Uboot bootloader object
-func newUboot(rootdir string, blOpts *Options) Bootloader {
+func newUboot(rootdir string, blOpts *Options) (Bootloader, error) {
 	u := &uboot{
 		rootdir: rootdir,
 	}
 	u.setDefaults()
 	u.processBlOpts(blOpts)
 
-	return u
+	return u, nil
 }
 
 func (u *uboot) Name() string {
@@ -131,12 +131,12 @@ func (u *uboot) InstallBootConfig(gadgetDir string, blOpts *Options) error {
 		return fmt.Errorf("non-empty uboot.env not supported on UC20 yet")
 	}
 
-	systemFile := u.ConfigFile()
+	systemFile, _ := u.ConfigFile()
 	return genericInstallBootConfig(gadgetFile, systemFile)
 }
 
-func (u *uboot) ConfigFile() string {
-	return u.envFile()
+func (u *uboot) ConfigFile() (string, error) {
+	return u.envFile(), nil
 }
 
 func (u *uboot) envFile() string {


### PR DESCRIPTION
The new lk bootloader needs to be able to return errors from multiple places
now, so to accommodate this we need to change the function signatures in many
places to return errors.