### PR TITLE
tests: unmount /boot/efi in fsck-on-boot test

### DIFF
--- a/tests/core/fsck-on-boot/task.yaml
+++ b/tests/core/fsck-on-boot/task.yaml
@@ -35,6 +35,7 @@ execute: |
       fi
       umount /var/lib/snapd/seed
       umount /run/mnt/ubuntu-seed
+      umount /boot/efi
     else
       echo "Please adjust the test to support this core system"
       false


### PR DESCRIPTION
With the updated initrd /boot/efi is now bind mounted to ubuntu-seed,
see https://github.com/snapcore/core-initrd/pull/8. This needs to
be unmounted before we do the vfat partition manipulation.
