### PR TITLE
tests: updated the systems to run prepare-image-grub test

### DIFF
--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that prepare-image --classic works.
 
-# ubuntu-14.04: systemd-run not supported
-systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -ubuntu-14.04*]
+# building images is only supported on classic ubuntu, but ubuntu 14.04 does not have systemd-run to perform the test
+systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*]
 
 backends: [-autopkgtest]
 

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that prepare-image --classic works.
 
-# ubuntu-14.04: systemd-run not supported
-systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -ubuntu-14.04*]
+# building images is only supported on classic ubuntu, but ubuntu 14.04 does not have systemd-run to perform the test
+systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*]
 
 backends: [-autopkgtest]
 

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -1,12 +1,6 @@
 summary: Check that prepare-image works for grub-systems
 
-# ubuntu-14.04: systemd-run not supported
-# ubuntu-core-*: building images is not explicitly supported
-# fedora-*: building images is not explicitly supported
-# centos-*: building images is not explicitly supported
-# arch-*: building images is not explicitly supported
-# amazon-*: building images is not explicitly supported
-systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -ubuntu-14.04*]
+systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*]
 
 backends: [-autopkgtest]
 

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -1,11 +1,9 @@
 summary: Check that prepare-image works for grub-systems
 
-systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
+# ubuntu-14.04: systemd-run not supported
+systems: [-ubuntu-core-*, -opensuse-*, -ubuntu-14.04*]
 
 backends: [-autopkgtest]
-
-# ubuntu-14.04: systemd-run not supported
-systems: [-ubuntu-14.04*]
 
 # TODO: use the real stores with proper assertions fully as well once possible
 environment:

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -1,7 +1,12 @@
 summary: Check that prepare-image works for grub-systems
 
 # ubuntu-14.04: systemd-run not supported
-systems: [-ubuntu-core-*, -opensuse-*, -ubuntu-14.04*]
+# ubuntu-core-*: building images is not explicitly supported
+# fedora-*: building images is not explicitly supported
+# centos-*: building images is not explicitly supported
+# arch-*: building images is not explicitly supported
+# amazon-*: building images is not explicitly supported
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -ubuntu-14.04*]
 
 backends: [-autopkgtest]
 

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -1,5 +1,6 @@
 summary: Check that prepare-image works for grub-systems
 
+# building images is only supported on classic ubuntu, but ubuntu 14.04 does not have systemd-run to perform the test
 systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*]
 
 backends: [-autopkgtest]


### PR DESCRIPTION
Revert change which made this test to be executed on some non supported systems.