### PR TITLE
devicestate: implement boot.HasFDESetupHook

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -360,7 +360,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 
 	if sealer != nil {
 		// seal the encryption key to the parameters specified in modeenv
-		if err := sealKeyToModeenv(sealer.dataEncryptionKey, sealer.saveEncryptionKey, model, bootWith, modeenv); err != nil {
+		if err := sealKeyToModeenv(sealer.dataEncryptionKey, sealer.saveEncryptionKey, model, modeenv); err != nil {
 			return err
 		}
 	}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -81,23 +81,23 @@ func recoveryBootChainsFileUnder(rootdir string) string {
 // sealKeyToModeenv seals the supplied keys to the parameters specified
 // in modeenv.
 // It assumes to be invoked in install mode.
-func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, bootWith *BootableSet, modeenv *Modeenv) error {
+func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
 	hasHook, err := HasFDESetupHook()
 	if err != nil {
 		return fmt.Errorf("cannot get fde-setup hook %v", err)
 	}
 	if hasHook {
-		return sealKeyToModeenvUsingFdeSetupHook(key, saveKey, model, bootWith, modeenv)
+		return sealKeyToModeenvUsingFdeSetupHook(key, saveKey, model, modeenv)
 	}
 
-	return sealKeyToModeenvUsingSecboot(key, saveKey, model, bootWith, modeenv)
+	return sealKeyToModeenvUsingSecboot(key, saveKey, model, modeenv)
 }
 
-func sealKeyToModeenvUsingFdeSetupHook(key, saveKey secboot.EncryptionKey, model *asserts.Model, bootWith *BootableSet, modeenv *Modeenv) error {
+func sealKeyToModeenvUsingFdeSetupHook(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
 	return fmt.Errorf("cannot use fde-setup hook yet")
 }
 
-func sealKeyToModeenvUsingSecboot(key, saveKey secboot.EncryptionKey, model *asserts.Model, bootWith *BootableSet, modeenv *Modeenv) error {
+func sealKeyToModeenvUsingSecboot(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
 	// build the recovery mode boot chain
 	rbl, err := bootloader.Find(InitramfsUbuntuSeedDir, &bootloader.Options{
 		Role: bootloader.RoleRecovery,

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -84,7 +84,7 @@ func recoveryBootChainsFileUnder(rootdir string) string {
 func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
 	hasHook, err := HasFDESetupHook()
 	if err != nil {
-		return fmt.Errorf("cannot get fde-setup hook %v", err)
+		return fmt.Errorf("cannot check for fde-setup hook %v", err)
 	}
 	if hasHook {
 		return sealKeyToModeenvUsingFdeSetupHook(key, saveKey, model, modeenv)

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -50,8 +50,8 @@ var (
 // Hook functions setup by devicestate to support device-specific full
 // disk encryption implementations.
 var (
-	HasFDESetupHook = func(*BootableSet) bool {
-		return false
+	HasFDESetupHook = func() (bool, error) {
+		return false, nil
 	}
 	RunFDESetupHook = func(op string, params *FdeSetupHookParams) error {
 		return fmt.Errorf("internal error: RunFDESetupHook not set yet")
@@ -82,7 +82,11 @@ func recoveryBootChainsFileUnder(rootdir string) string {
 // in modeenv.
 // It assumes to be invoked in install mode.
 func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, bootWith *BootableSet, modeenv *Modeenv) error {
-	if HasFDESetupHook(bootWith) {
+	hasHook, err := HasFDESetupHook()
+	if err != nil {
+		return fmt.Errorf("cannot get fde-setup hook %v", err)
+	}
+	if hasHook {
 		return sealKeyToModeenvUsingFdeSetupHook(key, saveKey, model, bootWith, modeenv)
 	}
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -107,7 +107,6 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		}
 
 		model := boottest.MakeMockUC20Model()
-		bootWith := &boot.BootableSet{}
 
 		// set a mock recovery kernel
 		readSystemEssentialCalls := 0
@@ -192,7 +191,7 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		})
 		defer restore()
 
-		err = boot.SealKeyToModeenv(myKey, myKey2, model, bootWith, modeenv)
+		err = boot.SealKeyToModeenv(myKey, myKey2, model, modeenv)
 		if tc.sealErr != nil {
 			c.Assert(sealKeysCalls, Equals, 1)
 		} else {
@@ -926,17 +925,6 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookFailsToday(c *C) {
 	myKey2 := secboot.EncryptionKey{}
 
 	model := boottest.MakeMockUC20Model()
-	bootWith := &boot.BootableSet{
-		Kernel: &snap.Info{
-			SuggestedName: "mock-kernel",
-			Hooks: map[string]*snap.HookInfo{
-				"fde-setup": {
-					Name: "fde-setup",
-				},
-			},
-		},
-	}
-
-	err := boot.SealKeyToModeenv(myKey, myKey2, model, bootWith, modeenv)
+	err := boot.SealKeyToModeenv(myKey, myKey2, model, modeenv)
 	c.Assert(err, ErrorMatches, "cannot use fde-setup hook yet")
 }

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -909,9 +909,8 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookFailsToday(c *C) {
 
 	oldHasFDESetupHook := boot.HasFDESetupHook
 	defer func() { boot.HasFDESetupHook = oldHasFDESetupHook }()
-	boot.HasFDESetupHook = func(bootWith *boot.BootableSet) bool {
-		c.Assert(bootWith.Kernel.SuggestedName, Equals, "mock-kernel")
-		return true
+	boot.HasFDESetupHook = func() (bool, error) {
+		return true, nil
 	}
 	oldRunFDESetupHook := boot.RunFDESetupHook
 	defer func() { boot.RunFDESetupHook = oldRunFDESetupHook }()

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -142,7 +142,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 
 	runner.AddBlocked(gadgetUpdateBlocked)
 
-	// add FDE hook support to boot
+	// wire FDE kernel hook support into boot
 	boot.HasFDESetupHook = m.hasFDESetupHook
 
 	return m, nil
@@ -1362,12 +1362,12 @@ func (m *DeviceManager) hasFDESetupHook() (bool, error) {
 
 	deviceCtx, err := DeviceCtx(st, nil, nil)
 	if err != nil {
-		return false, fmt.Errorf("cannto find device context: %v", err)
+		return false, fmt.Errorf("cannot get device context: %v", err)
 	}
 
 	kernelInfo, err := snapstate.KernelInfo(st, deviceCtx)
 	if err != nil {
-		return false, fmt.Errorf("cannot find kernel: %v", err)
+		return false, fmt.Errorf("cannot get kernel info: %v", err)
 	}
 	_, ok := kernelInfo.Hooks["fde-setup"]
 	return ok, nil

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1359,17 +1359,15 @@ func (m *DeviceManager) StoreContextBackend() storecontext.Backend {
 
 func (m *DeviceManager) hasFDESetupHook() (bool, error) {
 	st := m.state
-	st.Lock()
-	defer st.Unlock()
 
-	deviceCtx, err := DeviceCtx(m.state, nil, nil)
+	deviceCtx, err := DeviceCtx(st, nil, nil)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("cannto find device context: %v", err)
 	}
 
 	kernelInfo, err := snapstate.KernelInfo(st, deviceCtx)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("cannot find kernel: %v", err)
 	}
 	_, ok := kernelInfo.Hooks["fde-setup"]
 	return ok, nil

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -142,6 +142,9 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 
 	runner.AddBlocked(gadgetUpdateBlocked)
 
+	// add FDE hook support to boot
+	boot.HasFDESetupHook = hasFDESetupHook
+
 	return m, nil
 }
 
@@ -1352,4 +1355,12 @@ func (scb storeContextBackend) SignDeviceSessionRequest(serial *asserts.Serial, 
 
 func (m *DeviceManager) StoreContextBackend() storecontext.Backend {
 	return storeContextBackend{m}
+}
+
+func hasFDESetupHook(bootWith *boot.BootableSet) bool {
+	if bootWith == nil || bootWith.Kernel == nil {
+		return false
+	}
+	_, ok := bootWith.Kernel.Hooks["fde-setup"]
+	return ok
 }

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
@@ -232,6 +233,8 @@ func delayedCrossMgrInit() {
 	snapstate.IsOnMeteredConnection = netutil.IsOnMeteredConnection
 	snapstate.DeviceCtx = DeviceCtx
 	snapstate.Remodeling = Remodeling
+
+	boot.HasFDESetupHook = hasFDESetupHook
 }
 
 // proxyStore returns the store assertion for the proxy store if one is set.

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
@@ -233,8 +232,6 @@ func delayedCrossMgrInit() {
 	snapstate.IsOnMeteredConnection = netutil.IsOnMeteredConnection
 	snapstate.DeviceCtx = DeviceCtx
 	snapstate.Remodeling = Remodeling
-
-	boot.HasFDESetupHook = hasFDESetupHook
 }
 
 // proxyStore returns the store assertion for the proxy store if one is set.

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1285,10 +1285,20 @@ hooks:
  fde-setup:
 `
 
-func (s *deviceMgrSuite) TestHadFdeSetupHook(c *C) {
+func (s *deviceMgrSuite) TestHasFdeSetupHook(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
+
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+	})
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc",
+	})
 
 	for _, tc := range []struct {
 		kernelYaml      string
@@ -1298,15 +1308,6 @@ func (s *deviceMgrSuite) TestHadFdeSetupHook(c *C) {
 		{kernelYamlWithFdeSetup, true},
 	} {
 		makeInstalledMockKernelSnap(c, st, tc.kernelYaml)
-		s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
-			"architecture": "amd64",
-			"kernel":       "pc-kernel",
-			"gadget":       "pc",
-		})
-		devicestatetest.SetDevice(s.state, &auth.DeviceState{
-			Brand: "canonical",
-			Model: "pc",
-		})
 
 		hasHook, err := devicestate.DeviceManagerHasFDESetupHook(s.mgr)
 		c.Assert(err, IsNil)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1261,24 +1261,10 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupNonUC20NoUbuntuSave(c *C) {
 }
 
 func (s *deviceMgrSuite) TestHadFdeSetupHook(c *C) {
-	// no hook
-	c.Check(devicestate.HasFDESetupHook(nil), Equals, false)
-	c.Check(devicestate.HasFDESetupHook(&boot.BootableSet{}), Equals, false)
-	c.Check(devicestate.HasFDESetupHook(&boot.BootableSet{Kernel: &snap.Info{}}), Equals, false)
-	// not the right hook
-	mockKernelWithOtherHook := &snap.Info{
-		Hooks: map[string]*snap.HookInfo{
-			"other-hook": &snap.HookInfo{},
-		},
-	}
-	c.Check(devicestate.HasFDESetupHook(&boot.BootableSet{Kernel: mockKernelWithOtherHook}), Equals, false)
-	// happy hook
-	mockKernel := &snap.Info{
-		Hooks: map[string]*snap.HookInfo{
-			"fde-setup": &snap.HookInfo{},
-		},
-	}
-	c.Check(devicestate.HasFDESetupHook(&boot.BootableSet{Kernel: mockKernel}), Equals, true)
+	// XXX: more real tests
+	hasHook, err := devicestate.DeviceManagerHasFDESetupHook(s.mgr)
+	c.Check(hasHook, Equals, false)
+	c.Check(err, Equals, state.ErrNoState)
 }
 
 type startOfOperationTimeSuite struct {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1260,6 +1260,27 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupNonUC20NoUbuntuSave(c *C) {
 	c.Check(devicestate.SaveAvailable(mgr), Equals, false)
 }
 
+func (s *deviceMgrSuite) TestHadFdeSetupHook(c *C) {
+	// no hook
+	c.Check(devicestate.HasFDESetupHook(nil), Equals, false)
+	c.Check(devicestate.HasFDESetupHook(&boot.BootableSet{}), Equals, false)
+	c.Check(devicestate.HasFDESetupHook(&boot.BootableSet{Kernel: &snap.Info{}}), Equals, false)
+	// not the right hook
+	mockKernelWithOtherHook := &snap.Info{
+		Hooks: map[string]*snap.HookInfo{
+			"other-hook": &snap.HookInfo{},
+		},
+	}
+	c.Check(devicestate.HasFDESetupHook(&boot.BootableSet{Kernel: mockKernelWithOtherHook}), Equals, false)
+	// happy hook
+	mockKernel := &snap.Info{
+		Hooks: map[string]*snap.HookInfo{
+			"fde-setup": &snap.HookInfo{},
+		},
+	}
+	c.Check(devicestate.HasFDESetupHook(&boot.BootableSet{Kernel: mockKernel}), Equals, true)
+}
+
 type startOfOperationTimeSuite struct {
 	state  *state.State
 	mgr    *devicestate.DeviceManager

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -214,8 +214,6 @@ var (
 	PendingGadgetInfo   = pendingGadgetInfo
 
 	CriticalTaskEdges = criticalTaskEdges
-
-	HasFDESetupHook = hasFDESetupHook
 )
 
 func MockGadgetUpdate(mock func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc, observer gadget.ContentUpdateObserver) error) (restore func()) {
@@ -288,4 +286,8 @@ func MockRestrictCloudInit(f func(sysconfig.CloudInitState, *sysconfig.CloudInit
 	return func() {
 		restrictCloudInit = old
 	}
+}
+
+func DeviceManagerHasFDESetupHook(mgr *DeviceManager) (bool, error) {
+	return mgr.hasFDESetupHook()
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -214,6 +214,8 @@ var (
 	PendingGadgetInfo   = pendingGadgetInfo
 
 	CriticalTaskEdges = criticalTaskEdges
+
+	HasFDESetupHook = hasFDESetupHook
 )
 
 func MockGadgetUpdate(mock func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc, observer gadget.ContentUpdateObserver) error) (restore func()) {


### PR DESCRIPTION
This commit adds support for setting boot.HasFDESetupHook and matching
tests.
