### PR TITLE
vendor: update secboot repo to avoid including secboot.test binary

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -116,10 +116,10 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "G2sH9o/0sihaKYbjmfWBOFU3Avs=",
+			"checksumSHA1": "QOWBbcZJqGF5v2rtNSjsGGLrUUE=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "fa14f1ac3b14d38025312da287728054f7c06b67",
-			"revisionTime": "2020-11-11T08:01:43Z"
+			"revision": "027522efe9c7dc36adde13ea8ab030d3dfa34267",
+			"revisionTime": "2020-11-19T14:48:04Z"
 		},
 		{
 			"checksumSHA1": "c7jHLQSWFWbymTcFWZMQH0C5Wik=",


### PR DESCRIPTION
The secboot repo had a accidental secboot.test binary commited
and we pulled it in via the vendor.json. This commit updates the
vendor.json to a version of secboot that does no longer include
this binary.

The version also implements a less strict AddEFISecureBootPolicyProfile.