### PR TITLE
bootloader: indicate when boot config was updated

### DIFF
--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -170,8 +170,9 @@ type TrustedAssetsBootloader interface {
 	// ManagedAssets returns a list of boot assets managed by the bootloader
 	// in the boot filesystem. Does not require rootdir to be set.
 	ManagedAssets() []string
-	// UpdateBootConfig updates the boot config assets used by the bootloader.
-	UpdateBootConfig(*Options) error
+	// UpdateBootConfig attempts to update the boot config assets used by
+	// the bootloader. Returns true when assets were updated.
+	UpdateBootConfig() (bool, error)
 	// CommandLine returns the kernel command line composed of mode and
 	// system arguments, built-in bootloader specific static arguments
 	// corresponding to the on-disk boot asset edition, followed by any
@@ -215,28 +216,31 @@ func genericSetBootConfigFromAsset(systemFile, assetName string) error {
 	return osutil.AtomicWriteFile(systemFile, bootConfig, 0644, 0)
 }
 
-func genericUpdateBootConfigFromAssets(systemFile string, assetName string) error {
+func genericUpdateBootConfigFromAssets(systemFile string, assetName string) (updated bool, err error) {
 	currentBootConfigEdition, err := editionFromDiskConfigAsset(systemFile)
 	if err != nil && err != errNoEdition {
-		return err
+		return false, err
 	}
 	if err == errNoEdition {
-		return nil
+		return false, nil
 	}
 	newBootConfig := assets.Internal(assetName)
 	if len(newBootConfig) == 0 {
-		return fmt.Errorf("no boot config asset with name %q", assetName)
+		return false, fmt.Errorf("no boot config asset with name %q", assetName)
 	}
 	bc, err := configAssetFrom(newBootConfig)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if bc.Edition() <= currentBootConfigEdition {
 		// edition of the candidate boot config is lower than or equal
 		// to one currently installed
-		return nil
+		return false, nil
 	}
-	return osutil.AtomicWriteFile(systemFile, bc.Raw(), 0644, 0)
+	if err := osutil.AtomicWriteFile(systemFile, bc.Raw(), 0644, 0); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // InstallBootConfig installs the bootloader config from the gadget

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -392,6 +392,7 @@ type MockTrustedAssetsBootloader struct {
 
 	UpdateErr                  error
 	UpdateCalls                int
+	Updated                    bool
 	ManagedAssetsList          []string
 	StaticCommandLine          string
 	CandidateStaticCommandLine string
@@ -408,9 +409,9 @@ func (b *MockTrustedAssetsBootloader) ManagedAssets() []string {
 	return b.ManagedAssetsList
 }
 
-func (b *MockTrustedAssetsBootloader) UpdateBootConfig(opts *bootloader.Options) error {
+func (b *MockTrustedAssetsBootloader) UpdateBootConfig() (bool, error) {
 	b.UpdateCalls++
-	return b.UpdateErr
+	return b.Updated, b.UpdateErr
 }
 
 func glueCommandLine(modeArg, systemArg, staticArgs, extraArgs string) string {

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -344,11 +344,11 @@ func (g *grub) TryKernel() (snap.PlaceInfo, error) {
 // and has a lower edition.
 //
 // Implements TrustedAssetsBootloader for the grub bootloader.
-func (g *grub) UpdateBootConfig(opts *Options) error {
+func (g *grub) UpdateBootConfig() (bool, error) {
 	// XXX: do we need to take opts here?
 	bootScriptName := "grub.cfg"
 	currentBootConfig := filepath.Join(g.dir(), "grub.cfg")
-	if opts != nil && opts.Role == RoleRecovery {
+	if g.recovery {
 		// use the recovery asset when asked to do so
 		bootScriptName = "grub-recovery.cfg"
 	}

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -646,9 +646,9 @@ this is mocked grub-recovery.conf
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 	// install the recovery boot script
-	err := tg.UpdateBootConfig(opts)
+	updated, err := tg.UpdateBootConfig()
 	c.Assert(err, IsNil)
-
+	c.Assert(updated, Equals, false)
 	c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, `recovery boot script`)
 }
 
@@ -672,8 +672,9 @@ this is mocked grub.conf
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
 	// install the recovery boot script
-	err := tg.UpdateBootConfig(opts)
+	updated, err := tg.UpdateBootConfig()
 	c.Assert(err, IsNil)
+	c.Assert(updated, Equals, true)
 	// the recovery boot asset was picked
 	c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, `# Snapd-Boot-Config-Edition: 3
 this is mocked grub-recovery.conf
@@ -693,8 +694,9 @@ func (s *grubTestSuite) testBootUpdateBootConfigUpdates(c *C, oldConfig, newConf
 
 	tg, ok := g.(bootloader.TrustedAssetsBootloader)
 	c.Assert(ok, Equals, true)
-	err := tg.UpdateBootConfig(opts)
+	updated, err := tg.UpdateBootConfig()
 	c.Assert(err, IsNil)
+	c.Assert(updated, Equals, update)
 	if update {
 		c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, newConfig)
 	} else {
@@ -775,8 +777,9 @@ this is updated grub.cfg
 	c.Assert(err, IsNil)
 	defer os.Chmod(s.grubEFINativeDir(), 0755)
 
-	err = tg.UpdateBootConfig(opts)
+	updated, err := tg.UpdateBootConfig()
 	c.Assert(err, ErrorMatches, "cannot load existing config asset: .*/EFI/ubuntu/grub.cfg: permission denied")
+	c.Assert(updated, Equals, false)
 	err = os.Chmod(s.grubEFINativeDir(), 0555)
 	c.Assert(err, IsNil)
 
@@ -785,8 +788,9 @@ this is updated grub.cfg
 	// writing out new config fails
 	err = os.Chmod(s.grubEFINativeDir(), 0111)
 	c.Assert(err, IsNil)
-	err = tg.UpdateBootConfig(opts)
+	updated, err = tg.UpdateBootConfig()
 	c.Assert(err, ErrorMatches, `open .*/EFI/ubuntu/grub.cfg\..+: permission denied`)
+	c.Assert(updated, Equals, false)
 	c.Assert(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), testutil.FileEquals, oldConfig)
 }
 


### PR DESCRIPTION
Indicate when the bootloader boot config was updated. This allows the callers to
take a better decision as to whether an update or some other action is required.

