### PR TITLE
daemon: start cleaning up api tests

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -1,0 +1,582 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"context"
+	"crypto"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/crypto/sha3"
+	"gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/sandbox"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/store/storetest"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type APIBaseSuite struct {
+	storetest.Store
+
+	rsnaps            []*snap.Info
+	err               error
+	vars              map[string]string
+	storeSearch       store.Search
+	suggestedCurrency string
+	d                 *Daemon
+	user              *auth.UserState
+	ctx               context.Context
+	currentSnaps      []*store.CurrentSnap
+	actions           []*store.SnapAction
+	buyOptions        *client.BuyOptions
+	buyResult         *client.BuyResult
+
+	restoreRelease func()
+
+	storeSigning *assertstest.StoreStack
+	brands       *assertstest.SigningAccounts
+
+	systemctlRestorer func()
+	sysctlBufs        [][]byte
+
+	journalctlRestorer func()
+	jctlSvcses         [][]string
+	jctlNs             []int
+	jctlFollows        []bool
+	jctlRCs            []io.ReadCloser
+	jctlErrs           []error
+
+	serviceControlError error
+	serviceControlCalls []serviceControlArgs
+
+	connectivityResult     map[string]bool
+	loginUserStoreMacaroon string
+	loginUserDischarge     string
+
+	restoreSanitize func()
+
+	testutil.BaseTest
+}
+
+type serviceControlArgs struct {
+	action  string
+	options string
+	names   []string
+}
+
+func (s *APIBaseSuite) pokeStateLock() {
+	// the store should be called without the state lock held. Try
+	// to acquire it.
+	st := s.d.overlord.State()
+	st.Lock()
+	st.Unlock()
+}
+
+func (s *APIBaseSuite) SnapInfo(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
+	s.pokeStateLock()
+	s.user = user
+	s.ctx = ctx
+	if len(s.rsnaps) > 0 {
+		return s.rsnaps[0], s.err
+	}
+	return nil, s.err
+}
+
+func (s *APIBaseSuite) Find(ctx context.Context, search *store.Search, user *auth.UserState) ([]*snap.Info, error) {
+	s.pokeStateLock()
+
+	s.storeSearch = *search
+	s.user = user
+	s.ctx = ctx
+
+	return s.rsnaps, s.err
+}
+
+func (s *APIBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	s.pokeStateLock()
+	if assertQuery != nil {
+		toResolve, err := assertQuery.ToResolve()
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(toResolve) != 0 {
+			panic("no assertion query support")
+		}
+	}
+
+	if ctx == nil {
+		panic("context required")
+	}
+	s.currentSnaps = currentSnaps
+	s.actions = actions
+	s.user = user
+
+	sars := make([]store.SnapActionResult, len(s.rsnaps))
+	for i, rsnap := range s.rsnaps {
+		sars[i] = store.SnapActionResult{Info: rsnap}
+	}
+	return sars, nil, s.err
+}
+
+func (s *APIBaseSuite) SuggestedCurrency() string {
+	s.pokeStateLock()
+
+	return s.suggestedCurrency
+}
+
+func (s *APIBaseSuite) Buy(options *client.BuyOptions, user *auth.UserState) (*client.BuyResult, error) {
+	s.pokeStateLock()
+
+	s.buyOptions = options
+	s.user = user
+	return s.buyResult, s.err
+}
+
+func (s *APIBaseSuite) ReadyToBuy(user *auth.UserState) error {
+	s.pokeStateLock()
+
+	s.user = user
+	return s.err
+}
+
+func (s *APIBaseSuite) ConnectivityCheck() (map[string]bool, error) {
+	s.pokeStateLock()
+
+	return s.connectivityResult, s.err
+}
+
+func (s *APIBaseSuite) LoginUser(username, password, otp string) (string, string, error) {
+	s.pokeStateLock()
+
+	return s.loginUserStoreMacaroon, s.loginUserDischarge, s.err
+}
+
+func (s *APIBaseSuite) muxVars(*http.Request) map[string]string {
+	return s.vars
+}
+
+func (s *APIBaseSuite) SetUpSuite(c *check.C) {
+	muxVars = s.muxVars
+	s.restoreRelease = sandbox.MockForceDevMode(false)
+	s.systemctlRestorer = systemd.MockSystemctl(s.systemctl)
+	s.journalctlRestorer = systemd.MockJournalctl(s.journalctl)
+	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+}
+
+func (s *APIBaseSuite) TearDownSuite(c *check.C) {
+	muxVars = nil
+	s.restoreRelease()
+	s.systemctlRestorer()
+	s.journalctlRestorer()
+	s.restoreSanitize()
+}
+
+func (s *APIBaseSuite) systemctl(args ...string) (buf []byte, err error) {
+	if len(s.sysctlBufs) > 0 {
+		buf, s.sysctlBufs = s.sysctlBufs[0], s.sysctlBufs[1:]
+	}
+
+	return buf, err
+}
+
+func (s *APIBaseSuite) journalctl(svcs []string, n int, follow bool) (rc io.ReadCloser, err error) {
+	s.jctlSvcses = append(s.jctlSvcses, svcs)
+	s.jctlNs = append(s.jctlNs, n)
+	s.jctlFollows = append(s.jctlFollows, follow)
+
+	if len(s.jctlErrs) > 0 {
+		err, s.jctlErrs = s.jctlErrs[0], s.jctlErrs[1:]
+	}
+	if len(s.jctlRCs) > 0 {
+		rc, s.jctlRCs = s.jctlRCs[0], s.jctlRCs[1:]
+	}
+
+	return rc, err
+}
+
+var (
+	brandPrivKey, _ = assertstest.GenerateKey(752)
+)
+
+func (s *APIBaseSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.sysctlBufs = nil
+	s.jctlSvcses = nil
+	s.jctlNs = nil
+	s.jctlFollows = nil
+	s.jctlRCs = nil
+	s.jctlErrs = nil
+
+	dirs.SetRootDir(c.MkDir())
+	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
+	restore := osutil.MockMountInfo("")
+	s.AddCleanup(restore)
+
+	c.Assert(err, check.IsNil)
+	c.Assert(os.MkdirAll(dirs.SnapMountDir, 0755), check.IsNil)
+	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), check.IsNil)
+
+	s.rsnaps = nil
+	s.suggestedCurrency = ""
+	s.storeSearch = store.Search{}
+	s.err = nil
+	s.vars = nil
+	s.user = nil
+	s.d = nil
+	s.currentSnaps = nil
+	s.actions = nil
+	// Disable real security backends for all API tests
+	s.AddCleanup(ifacestate.MockSecurityBackends(nil))
+
+	s.buyOptions = nil
+	s.buyResult = nil
+
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
+	s.AddCleanup(sysdb.InjectTrusted(s.storeSigning.Trusted))
+
+	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
+	s.brands.Register("my-brand", brandPrivKey, nil)
+
+	assertstateRefreshSnapDeclarations = nil
+	snapstateInstall = nil
+	snapstateInstallMany = nil
+	snapstateInstallPath = nil
+	snapstateRefreshCandidates = nil
+	snapstateRemoveMany = nil
+	snapstateRevert = nil
+	snapstateRevertToRevision = nil
+	snapstateTryPath = nil
+	snapstateUpdate = nil
+	snapstateUpdateMany = nil
+	snapstateSwitch = nil
+
+	devicestateRemodel = nil
+
+	s.serviceControlCalls = nil
+	s.serviceControlError = nil
+	restoreServicestateCtrl := MockServicestateControl(s.fakeServiceControl)
+	s.AddCleanup(restoreServicestateCtrl)
+}
+
+func (s *APIBaseSuite) TearDownTest(c *check.C) {
+	s.d = nil
+	s.ctx = nil
+
+	unsafeReadSnapInfo = unsafeReadSnapInfoImpl
+	ensureStateSoon = ensureStateSoonImpl
+	dirs.SetRootDir("")
+
+	assertstateRefreshSnapDeclarations = assertstate.RefreshSnapDeclarations
+	snapstateInstall = snapstate.Install
+	snapstateInstallMany = snapstate.InstallMany
+	snapstateInstallPath = snapstate.InstallPath
+	snapstateRefreshCandidates = snapstate.RefreshCandidates
+	snapstateRemoveMany = snapstate.RemoveMany
+	snapstateRevert = snapstate.Revert
+	snapstateRevertToRevision = snapstate.RevertToRevision
+	snapstateTryPath = snapstate.TryPath
+	snapstateUpdate = snapstate.Update
+	snapstateUpdateMany = snapstate.UpdateMany
+	snapstateSwitch = snapstate.Switch
+
+	s.BaseTest.TearDownTest(c)
+}
+
+var modelDefaults = map[string]interface{}{
+	"architecture": "amd64",
+	"gadget":       "gadget",
+	"kernel":       "kernel",
+}
+
+func (s *APIBaseSuite) fakeServiceControl(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
+	if flags != nil {
+		panic("flags are not expected")
+	}
+
+	if s.serviceControlError != nil {
+		return nil, s.serviceControlError
+	}
+
+	serviceCommand := serviceControlArgs{action: inst.Action}
+	if inst.RestartOptions.Reload {
+		serviceCommand.options = "reload"
+	}
+	// only one flag should ever be set (depending on Action), but appending
+	// them below acts as an extra sanity check.
+	if inst.StartOptions.Enable {
+		serviceCommand.options += "enable"
+	}
+	if inst.StopOptions.Disable {
+		serviceCommand.options += "disable"
+	}
+	for _, app := range appInfos {
+		serviceCommand.names = append(serviceCommand.names, fmt.Sprintf("%s.%s", app.Snap.InstanceName(), app.Name))
+	}
+	s.serviceControlCalls = append(s.serviceControlCalls, serviceCommand)
+
+	t := st.NewTask("dummy", "")
+	ts := state.NewTaskSet(t)
+	return []*state.TaskSet{ts}, nil
+}
+
+func (s *APIBaseSuite) mockModel(c *check.C, st *state.State, model *asserts.Model) {
+	// realistic model setup
+	if model == nil {
+		model = s.brands.Model("can0nical", "pc", modelDefaults)
+	}
+
+	snapstate.DeviceCtx = devicestate.DeviceCtx
+
+	assertstatetest.AddMany(st, model)
+
+	devicestatetest.SetDevice(st, &auth.DeviceState{
+		Brand:  model.BrandID(),
+		Model:  model.Model(),
+		Serial: "serialserial",
+	})
+}
+
+func (s *APIBaseSuite) DaemonWithStore(c *check.C, sto snapstate.StoreService) *Daemon {
+	if s.d != nil {
+		panic("called daemon() twice")
+	}
+	d, err := New()
+	c.Assert(err, check.IsNil)
+	d.addRoutes()
+
+	c.Assert(d.overlord.StartUp(), check.IsNil)
+
+	st := d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+	snapstate.ReplaceStore(st, sto)
+	// mark as already seeded
+	st.Set("seeded", true)
+	// registered
+	s.mockModel(c, st, nil)
+
+	// don't actually try to talk to the store on snapstate.Ensure
+	// needs doing after the call to devicestate.Manager (which
+	// happens in daemon.New via overlord.New)
+	snapstate.CanAutoRefresh = nil
+
+	s.d = d
+	return d
+}
+
+func (s *APIBaseSuite) daemon(c *check.C) *Daemon {
+	return s.DaemonWithStore(c, s)
+}
+
+func (s *APIBaseSuite) daemonWithOverlordMock(c *check.C) *Daemon {
+	if s.d != nil {
+		panic("called daemon() twice")
+	}
+	d, err := New()
+	c.Assert(err, check.IsNil)
+	d.addRoutes()
+
+	o := overlord.Mock()
+	d.overlord = o
+
+	st := d.overlord.State()
+	// adds an assertion db
+	assertstate.Manager(st, o.TaskRunner())
+	st.Lock()
+	defer st.Unlock()
+	snapstate.ReplaceStore(st, s)
+
+	s.d = d
+	return d
+}
+
+type fakeSnapManager struct{}
+
+func newFakeSnapManager(st *state.State, runner *state.TaskRunner) *fakeSnapManager {
+	runner.AddHandler("fake-install-snap", func(t *state.Task, _ *tomb.Tomb) error {
+		return nil
+	}, nil)
+	runner.AddHandler("fake-install-snap-error", func(t *state.Task, _ *tomb.Tomb) error {
+		return fmt.Errorf("fake-install-snap-error errored")
+	}, nil)
+
+	return &fakeSnapManager{}
+}
+
+func (m *fakeSnapManager) Ensure() error {
+	return nil
+}
+
+// sanity
+var _ overlord.StateManager = (*fakeSnapManager)(nil)
+
+func (s *APIBaseSuite) daemonWithFakeSnapManager(c *check.C) *Daemon {
+	d := s.daemonWithOverlordMock(c)
+	st := d.overlord.State()
+	runner := d.overlord.TaskRunner()
+	d.overlord.AddManager(newFakeSnapManager(st, runner))
+	d.overlord.AddManager(runner)
+	c.Assert(d.overlord.StartUp(), check.IsNil)
+	return d
+}
+
+func (s *APIBaseSuite) waitTrivialChange(c *check.C, chg *state.Change) {
+	err := s.d.overlord.Settle(5 * time.Second)
+	c.Assert(err, check.IsNil)
+	c.Assert(chg.IsReady(), check.Equals, true)
+}
+
+func (s *APIBaseSuite) mkInstalledDesktopFile(c *check.C, name, content string) string {
+	df := filepath.Join(dirs.SnapDesktopFilesDir, name)
+	err := os.MkdirAll(filepath.Dir(df), 0755)
+	c.Assert(err, check.IsNil)
+	err = ioutil.WriteFile(df, []byte(content), 0644)
+	c.Assert(err, check.IsNil)
+	return df
+}
+
+func (s *APIBaseSuite) mkInstalledInState(c *check.C, daemon *Daemon, instanceName, developer, version string, revision snap.Revision, active bool, extraYaml string) *snap.Info {
+	snapName, instanceKey := snap.SplitInstanceName(instanceName)
+
+	if revision.Local() && developer != "" {
+		panic("not supported")
+	}
+
+	var snapID string
+	if revision.Store() {
+		snapID = snapName + "-id"
+	}
+	// Collect arguments into a snap.SideInfo structure
+	sideInfo := &snap.SideInfo{
+		SnapID:   snapID,
+		RealName: snapName,
+		Revision: revision,
+		Channel:  "stable",
+	}
+
+	// Collect other arguments into a yaml string
+	yamlText := fmt.Sprintf(`
+name: %s
+version: %s
+%s`, snapName, version, extraYaml)
+
+	// Mock the snap on disk
+	snapInfo := snaptest.MockSnapInstance(c, instanceName, yamlText, sideInfo)
+	if active {
+		dir, rev := filepath.Split(snapInfo.MountDir())
+		c.Assert(os.Symlink(rev, dir+"current"), check.IsNil)
+	}
+	c.Assert(snapInfo.InstanceName(), check.Equals, instanceName)
+
+	c.Assert(os.MkdirAll(snapInfo.DataDir(), 0755), check.IsNil)
+	metadir := filepath.Join(snapInfo.MountDir(), "meta")
+	guidir := filepath.Join(metadir, "gui")
+	c.Assert(os.MkdirAll(guidir, 0755), check.IsNil)
+	c.Check(ioutil.WriteFile(filepath.Join(guidir, "icon.svg"), []byte("yadda icon"), 0644), check.IsNil)
+
+	if daemon == nil {
+		return snapInfo
+	}
+	st := daemon.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var snapst snapstate.SnapState
+	snapstate.Get(st, instanceName, &snapst)
+	snapst.Active = active
+	snapst.Sequence = append(snapst.Sequence, &snapInfo.SideInfo)
+	snapst.Current = snapInfo.SideInfo.Revision
+	snapst.TrackingChannel = "stable"
+	snapst.InstanceKey = instanceKey
+
+	snapstate.Set(st, instanceName, &snapst)
+
+	if developer == "" {
+		return snapInfo
+	}
+
+	devAcct := assertstest.NewAccount(s.storeSigning, developer, map[string]interface{}{
+		"account-id": developer + "-id",
+	}, "")
+
+	snapInfo.Publisher = snap.StoreAccount{
+		ID:          devAcct.AccountID(),
+		Username:    devAcct.Username(),
+		DisplayName: devAcct.DisplayName(),
+		Validation:  devAcct.Validation(),
+	}
+
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+		"series":       "16",
+		"snap-id":      snapID,
+		"snap-name":    snapName,
+		"publisher-id": devAcct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, check.IsNil)
+
+	content, err := ioutil.ReadFile(snapInfo.MountFile())
+	c.Assert(err, check.IsNil)
+	h := sha3.Sum384(content)
+	dgst, err := asserts.EncodeDigest(crypto.SHA3_384, h[:])
+	c.Assert(err, check.IsNil)
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+		"snap-sha3-384": string(dgst),
+		"snap-size":     "999",
+		"snap-id":       snapID,
+		"snap-revision": fmt.Sprintf("%s", revision),
+		"developer-id":  devAcct.AccountID(),
+		"timestamp":     time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, check.IsNil)
+
+	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""), devAcct, snapDecl, snapRev)
+
+	return snapInfo
+}

--- a/daemon/api_console_conf_test.go
+++ b/daemon/api_console_conf_test.go
@@ -35,7 +35,7 @@ import (
 var _ = Suite(&consoleConfSuite{})
 
 type consoleConfSuite struct {
-	apiBaseSuite
+	APIBaseSuite
 }
 
 func (s *consoleConfSuite) TestPostConsoleConfStartRoutine(c *C) {

--- a/daemon/api_debug_pprof_test.go
+++ b/daemon/api_debug_pprof_test.go
@@ -31,7 +31,7 @@ import (
 var _ = check.Suite(&pprofDebugSuite{})
 
 type pprofDebugSuite struct {
-	apiBaseSuite
+	APIBaseSuite
 }
 
 func (s *pprofDebugSuite) TestGetPprofCmdline(c *check.C) {

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -31,11 +31,11 @@ import (
 var _ = Suite(&seedingDebugSuite{})
 
 type seedingDebugSuite struct {
-	apiBaseSuite
+	APIBaseSuite
 }
 
 func (s *seedingDebugSuite) SetUpTest(c *C) {
-	s.apiBaseSuite.SetUpTest(c)
+	s.APIBaseSuite.SetUpTest(c)
 	s.daemonWithOverlordMock(c)
 }
 

--- a/daemon/api_debug_test.go
+++ b/daemon/api_debug_test.go
@@ -34,7 +34,7 @@ import (
 var _ = check.Suite(&postDebugSuite{})
 
 type postDebugSuite struct {
-	apiBaseSuite
+	APIBaseSuite
 }
 
 func (s *postDebugSuite) TestPostDebugEnsureStateSoon(c *check.C) {

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -51,8 +51,8 @@ func (s *apiSuite) TestPostRemodelUnhappy(c *check.C) {
 }
 
 func (s *apiSuite) TestPostRemodel(c *check.C) {
-	oldModel := s.brands.Model("my-brand", "my-old-model", modelDefaults)
-	newModel := s.brands.Model("my-brand", "my-old-model", modelDefaults, map[string]interface{}{
+	oldModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
+	newModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults, map[string]interface{}{
 		"revision": "2",
 	})
 
@@ -64,8 +64,8 @@ func (s *apiSuite) TestPostRemodel(c *check.C) {
 	d.overlord.AddManager(deviceMgr)
 	st := d.overlord.State()
 	st.Lock()
-	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
-	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
+	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
 	s.mockModel(c, st, oldModel)
 	st.Unlock()
 
@@ -135,7 +135,7 @@ func (s *apiSuite) TestGetModelNoModelAssertion(c *check.C) {
 
 func (s *apiSuite) TestGetModelHasModelAssertion(c *check.C) {
 	// make a model assertion
-	theModel := s.brands.Model("my-brand", "my-old-model", modelDefaults)
+	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	// model assertion setup
 	d := s.daemonWithOverlordMock(c)
@@ -146,8 +146,8 @@ func (s *apiSuite) TestGetModelHasModelAssertion(c *check.C) {
 	d.overlord.AddManager(deviceMgr)
 	st := d.overlord.State()
 	st.Lock()
-	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
-	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
+	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
 	s.mockModel(c, st, theModel)
 	st.Unlock()
 
@@ -173,7 +173,7 @@ func (s *apiSuite) TestGetModelHasModelAssertion(c *check.C) {
 
 func (s *apiSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 	// make a model assertion
-	theModel := s.brands.Model("my-brand", "my-old-model", modelDefaults)
+	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	// model assertion setup
 	d := s.daemonWithOverlordMock(c)
@@ -184,8 +184,8 @@ func (s *apiSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 	d.overlord.AddManager(deviceMgr)
 	st := d.overlord.State()
 	st.Lock()
-	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
-	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
+	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
 	s.mockModel(c, st, theModel)
 	st.Unlock()
 
@@ -235,7 +235,7 @@ func (s *apiSuite) TestGetModelNoSerialAssertion(c *check.C) {
 
 func (s *apiSuite) TestGetModelHasSerialAssertion(c *check.C) {
 	// make a model assertion
-	theModel := s.brands.Model("my-brand", "my-old-model", modelDefaults)
+	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	deviceKey, _ := assertstest.GenerateKey(752)
 
@@ -252,11 +252,11 @@ func (s *apiSuite) TestGetModelHasSerialAssertion(c *check.C) {
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
-	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
+	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
 	s.mockModel(c, st, theModel)
 
-	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-old-model",
@@ -298,7 +298,7 @@ func (s *apiSuite) TestGetModelHasSerialAssertion(c *check.C) {
 
 func (s *apiSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	// make a model assertion
-	theModel := s.brands.Model("my-brand", "my-old-model", modelDefaults)
+	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	deviceKey, _ := assertstest.GenerateKey(752)
 
@@ -315,11 +315,11 @@ func (s *apiSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
-	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
+	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
 	s.mockModel(c, st, theModel)
 
-	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-old-model",

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -52,20 +52,20 @@ func (s *apiSuite) mockSystemSeeds(c *check.C) (restore func()) {
 	// now create a minimal uc20 seed dir with snaps/assertions
 	seed20 := &seedtest.TestingSeed20{
 		SeedSnaps: seedtest.SeedSnaps{
-			StoreSigning: s.storeSigning,
-			Brands:       s.brands,
+			StoreSigning: s.StoreSigning,
+			Brands:       s.Brands,
 		},
 		SeedDir: dirs.SnapSeedDir,
 	}
 
 	restore = seed.MockTrusted(seed20.StoreSigning.Trusted)
 
-	assertstest.AddMany(s.storeSigning.Database, s.brands.AccountsAndKeys("my-brand")...)
+	assertstest.AddMany(s.StoreSigning.Database, s.Brands.AccountsAndKeys("my-brand")...)
 	// add essential snaps
-	seed20.MakeAssertedSnap(c, "name: snapd\nversion: 1\ntype: snapd", nil, snap.R(1), "my-brand", s.storeSigning.Database)
-	seed20.MakeAssertedSnap(c, "name: pc\nversion: 1\ntype: gadget\nbase: core20", nil, snap.R(1), "my-brand", s.storeSigning.Database)
-	seed20.MakeAssertedSnap(c, "name: pc-kernel\nversion: 1\ntype: kernel", nil, snap.R(1), "my-brand", s.storeSigning.Database)
-	seed20.MakeAssertedSnap(c, "name: core20\nversion: 1\ntype: base", nil, snap.R(1), "my-brand", s.storeSigning.Database)
+	seed20.MakeAssertedSnap(c, "name: snapd\nversion: 1\ntype: snapd", nil, snap.R(1), "my-brand", s.StoreSigning.Database)
+	seed20.MakeAssertedSnap(c, "name: pc\nversion: 1\ntype: gadget\nbase: core20", nil, snap.R(1), "my-brand", s.StoreSigning.Database)
+	seed20.MakeAssertedSnap(c, "name: pc-kernel\nversion: 1\ntype: kernel", nil, snap.R(1), "my-brand", s.StoreSigning.Database)
+	seed20.MakeAssertedSnap(c, "name: core20\nversion: 1\ntype: base", nil, snap.R(1), "my-brand", s.StoreSigning.Database)
 	seed20.MakeSeed(c, "20191119", "my-brand", "my-model", map[string]interface{}{
 		"display-name": "my fancy model",
 		"architecture": "amd64",
@@ -310,7 +310,7 @@ func (s *apiSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 	restore := s.mockSystemSeeds(c)
 	defer restore()
 
-	model := s.brands.Model("my-brand", "pc", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		// UC20
 		"grade": "dangerous",
@@ -427,8 +427,8 @@ func (s *apiSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		// devicemgr needs boot id to request a reboot
 		st.VerifyReboot("boot-id-0")
 		// device model
-		assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
-		assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+		assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
+		assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
 		s.mockModel(c, st, model)
 		if tc.currentMode == "run" {
 			// only set in run mode

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -22,7 +22,6 @@ package daemon
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,14 +40,11 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/crypto/sha3"
 	"gopkg.in/check.v1"
-	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
-	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
@@ -61,8 +57,6 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
-	"github.com/snapcore/snapd/overlord/devicestate"
-	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/healthstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
@@ -76,534 +70,11 @@ import (
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
-	"github.com/snapcore/snapd/store/storetest"
-	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 )
 
-type apiBaseSuite struct {
-	storetest.Store
-
-	rsnaps            []*snap.Info
-	err               error
-	vars              map[string]string
-	storeSearch       store.Search
-	suggestedCurrency string
-	d                 *Daemon
-	user              *auth.UserState
-	ctx               context.Context
-	restoreBackends   func()
-	currentSnaps      []*store.CurrentSnap
-	actions           []*store.SnapAction
-	buyOptions        *client.BuyOptions
-	buyResult         *client.BuyResult
-	storeSigning      *assertstest.StoreStack
-	restoreRelease    func()
-	trustedRestorer   func()
-	brands            *assertstest.SigningAccounts
-
-	systemctlRestorer func()
-	sysctlBufs        [][]byte
-
-	journalctlRestorer func()
-	jctlSvcses         [][]string
-	jctlNs             []int
-	jctlFollows        []bool
-	jctlRCs            []io.ReadCloser
-	jctlErrs           []error
-
-	serviceControlError error
-	serviceControlCalls []serviceControlArgs
-
-	connectivityResult     map[string]bool
-	loginUserStoreMacaroon string
-	loginUserDischarge     string
-	userInfoResult         *store.User
-	userInfoExpectedEmail  string
-
-	restoreSanitize func()
-
-	testutil.BaseTest
-}
-
-type serviceControlArgs struct {
-	action  string
-	options string
-	names   []string
-}
-
-func (s *apiBaseSuite) pokeStateLock() {
-	// the store should be called without the state lock held. Try
-	// to acquire it.
-	st := s.d.overlord.State()
-	st.Lock()
-	st.Unlock()
-}
-
-func (s *apiBaseSuite) SnapInfo(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
-	s.pokeStateLock()
-	s.user = user
-	s.ctx = ctx
-	if len(s.rsnaps) > 0 {
-		return s.rsnaps[0], s.err
-	}
-	return nil, s.err
-}
-
-func (s *apiBaseSuite) Find(ctx context.Context, search *store.Search, user *auth.UserState) ([]*snap.Info, error) {
-	s.pokeStateLock()
-
-	s.storeSearch = *search
-	s.user = user
-	s.ctx = ctx
-
-	return s.rsnaps, s.err
-}
-
-func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
-	s.pokeStateLock()
-	if assertQuery != nil {
-		toResolve, err := assertQuery.ToResolve()
-		if err != nil {
-			return nil, nil, err
-		}
-		if len(toResolve) != 0 {
-			panic("no assertion query support")
-		}
-	}
-
-	if ctx == nil {
-		panic("context required")
-	}
-	s.currentSnaps = currentSnaps
-	s.actions = actions
-	s.user = user
-
-	sars := make([]store.SnapActionResult, len(s.rsnaps))
-	for i, rsnap := range s.rsnaps {
-		sars[i] = store.SnapActionResult{Info: rsnap}
-	}
-	return sars, nil, s.err
-}
-
-func (s *apiBaseSuite) SuggestedCurrency() string {
-	s.pokeStateLock()
-
-	return s.suggestedCurrency
-}
-
-func (s *apiBaseSuite) Buy(options *client.BuyOptions, user *auth.UserState) (*client.BuyResult, error) {
-	s.pokeStateLock()
-
-	s.buyOptions = options
-	s.user = user
-	return s.buyResult, s.err
-}
-
-func (s *apiBaseSuite) ReadyToBuy(user *auth.UserState) error {
-	s.pokeStateLock()
-
-	s.user = user
-	return s.err
-}
-
-func (s *apiBaseSuite) ConnectivityCheck() (map[string]bool, error) {
-	s.pokeStateLock()
-
-	return s.connectivityResult, s.err
-}
-
-func (s *apiBaseSuite) LoginUser(username, password, otp string) (string, string, error) {
-	s.pokeStateLock()
-
-	return s.loginUserStoreMacaroon, s.loginUserDischarge, s.err
-}
-
-func (s *apiBaseSuite) UserInfo(email string) (userinfo *store.User, err error) {
-	s.pokeStateLock()
-
-	if s.userInfoExpectedEmail != email {
-		panic(fmt.Sprintf("%q != %q", s.userInfoExpectedEmail, email))
-	}
-	return s.userInfoResult, s.err
-}
-
-func (s *apiBaseSuite) muxVars(*http.Request) map[string]string {
-	return s.vars
-}
-
-func (s *apiBaseSuite) SetUpSuite(c *check.C) {
-	muxVars = s.muxVars
-	s.restoreRelease = sandbox.MockForceDevMode(false)
-	s.systemctlRestorer = systemd.MockSystemctl(s.systemctl)
-	s.journalctlRestorer = systemd.MockJournalctl(s.journalctl)
-	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
-}
-
-func (s *apiBaseSuite) TearDownSuite(c *check.C) {
-	muxVars = nil
-	s.restoreRelease()
-	s.systemctlRestorer()
-	s.journalctlRestorer()
-	s.restoreSanitize()
-}
-
-func (s *apiBaseSuite) systemctl(args ...string) (buf []byte, err error) {
-	if len(s.sysctlBufs) > 0 {
-		buf, s.sysctlBufs = s.sysctlBufs[0], s.sysctlBufs[1:]
-	}
-
-	return buf, err
-}
-
-func (s *apiBaseSuite) journalctl(svcs []string, n int, follow bool) (rc io.ReadCloser, err error) {
-	s.jctlSvcses = append(s.jctlSvcses, svcs)
-	s.jctlNs = append(s.jctlNs, n)
-	s.jctlFollows = append(s.jctlFollows, follow)
-
-	if len(s.jctlErrs) > 0 {
-		err, s.jctlErrs = s.jctlErrs[0], s.jctlErrs[1:]
-	}
-	if len(s.jctlRCs) > 0 {
-		rc, s.jctlRCs = s.jctlRCs[0], s.jctlRCs[1:]
-	}
-
-	return rc, err
-}
-
-func (s *apiBaseSuite) SetUpTest(c *check.C) {
-	s.sysctlBufs = nil
-	s.jctlSvcses = nil
-	s.jctlNs = nil
-	s.jctlFollows = nil
-	s.jctlRCs = nil
-	s.jctlErrs = nil
-
-	dirs.SetRootDir(c.MkDir())
-	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
-	restore := osutil.MockMountInfo("")
-	s.AddCleanup(restore)
-
-	c.Assert(err, check.IsNil)
-	c.Assert(os.MkdirAll(dirs.SnapMountDir, 0755), check.IsNil)
-	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), check.IsNil)
-
-	s.rsnaps = nil
-	s.suggestedCurrency = ""
-	s.storeSearch = store.Search{}
-	s.err = nil
-	s.vars = nil
-	s.user = nil
-	s.d = nil
-	s.currentSnaps = nil
-	s.actions = nil
-	// Disable real security backends for all API tests
-	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
-
-	s.buyOptions = nil
-	s.buyResult = nil
-
-	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
-	s.trustedRestorer = sysdb.InjectTrusted(s.storeSigning.Trusted)
-
-	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
-	s.brands.Register("my-brand", brandPrivKey, nil)
-
-	assertstateRefreshSnapDeclarations = nil
-	snapstateInstall = nil
-	snapstateInstallMany = nil
-	snapstateInstallPath = nil
-	snapstateRefreshCandidates = nil
-	snapstateRemoveMany = nil
-	snapstateRevert = nil
-	snapstateRevertToRevision = nil
-	snapstateTryPath = nil
-	snapstateUpdate = nil
-	snapstateUpdateMany = nil
-	snapstateSwitch = nil
-
-	devicestateRemodel = nil
-
-	s.serviceControlCalls = nil
-	s.serviceControlError = nil
-	restoreServicestateCtrl := MockServicestateControl(s.fakeServiceControl)
-	s.AddCleanup(restoreServicestateCtrl)
-}
-
-func (s *apiBaseSuite) TearDownTest(c *check.C) {
-	s.trustedRestorer()
-	s.d = nil
-	s.ctx = nil
-	s.restoreBackends()
-	unsafeReadSnapInfo = unsafeReadSnapInfoImpl
-	ensureStateSoon = ensureStateSoonImpl
-	dirs.SetRootDir("")
-
-	assertstateRefreshSnapDeclarations = assertstate.RefreshSnapDeclarations
-	snapstateInstall = snapstate.Install
-	snapstateInstallMany = snapstate.InstallMany
-	snapstateInstallPath = snapstate.InstallPath
-	snapstateRefreshCandidates = snapstate.RefreshCandidates
-	snapstateRemoveMany = snapstate.RemoveMany
-	snapstateRevert = snapstate.Revert
-	snapstateRevertToRevision = snapstate.RevertToRevision
-	snapstateTryPath = snapstate.TryPath
-	snapstateUpdate = snapstate.Update
-	snapstateUpdateMany = snapstate.UpdateMany
-	snapstateSwitch = snapstate.Switch
-}
-
-var modelDefaults = map[string]interface{}{
-	"architecture": "amd64",
-	"gadget":       "gadget",
-	"kernel":       "kernel",
-}
-
-func (s *apiBaseSuite) fakeServiceControl(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
-	if flags != nil {
-		panic("flags are not expected")
-	}
-
-	if s.serviceControlError != nil {
-		return nil, s.serviceControlError
-	}
-
-	serviceCommand := serviceControlArgs{action: inst.Action}
-	if inst.RestartOptions.Reload {
-		serviceCommand.options = "reload"
-	}
-	// only one flag should ever be set (depending on Action), but appending
-	// them below acts as an extra sanity check.
-	if inst.StartOptions.Enable {
-		serviceCommand.options += "enable"
-	}
-	if inst.StopOptions.Disable {
-		serviceCommand.options += "disable"
-	}
-	for _, app := range appInfos {
-		serviceCommand.names = append(serviceCommand.names, fmt.Sprintf("%s.%s", app.Snap.InstanceName(), app.Name))
-	}
-	s.serviceControlCalls = append(s.serviceControlCalls, serviceCommand)
-
-	t := st.NewTask("dummy", "")
-	ts := state.NewTaskSet(t)
-	return []*state.TaskSet{ts}, nil
-}
-
-func (s *apiBaseSuite) mockModel(c *check.C, st *state.State, model *asserts.Model) {
-	// realistic model setup
-	if model == nil {
-		model = s.brands.Model("can0nical", "pc", modelDefaults)
-	}
-
-	snapstate.DeviceCtx = devicestate.DeviceCtx
-
-	assertstatetest.AddMany(st, model)
-
-	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand:  model.BrandID(),
-		Model:  model.Model(),
-		Serial: "serialserial",
-	})
-}
-
-func (s *apiBaseSuite) daemon(c *check.C) *Daemon {
-	if s.d != nil {
-		panic("called daemon() twice")
-	}
-	d, err := New()
-	c.Assert(err, check.IsNil)
-	d.addRoutes()
-
-	c.Assert(d.overlord.StartUp(), check.IsNil)
-
-	st := d.overlord.State()
-	st.Lock()
-	defer st.Unlock()
-	snapstate.ReplaceStore(st, s)
-	// mark as already seeded
-	st.Set("seeded", true)
-	// registered
-	s.mockModel(c, st, nil)
-
-	// don't actually try to talk to the store on snapstate.Ensure
-	// needs doing after the call to devicestate.Manager (which
-	// happens in daemon.New via overlord.New)
-	snapstate.CanAutoRefresh = nil
-
-	s.d = d
-	return d
-}
-
-func (s *apiBaseSuite) daemonWithOverlordMock(c *check.C) *Daemon {
-	if s.d != nil {
-		panic("called daemon() twice")
-	}
-	d, err := New()
-	c.Assert(err, check.IsNil)
-	d.addRoutes()
-
-	o := overlord.Mock()
-	d.overlord = o
-
-	st := d.overlord.State()
-	// adds an assertion db
-	assertstate.Manager(st, o.TaskRunner())
-	st.Lock()
-	defer st.Unlock()
-	snapstate.ReplaceStore(st, s)
-
-	s.d = d
-	return d
-}
-
-type fakeSnapManager struct{}
-
-func newFakeSnapManager(st *state.State, runner *state.TaskRunner) *fakeSnapManager {
-	runner.AddHandler("fake-install-snap", func(t *state.Task, _ *tomb.Tomb) error {
-		return nil
-	}, nil)
-	runner.AddHandler("fake-install-snap-error", func(t *state.Task, _ *tomb.Tomb) error {
-		return fmt.Errorf("fake-install-snap-error errored")
-	}, nil)
-
-	return &fakeSnapManager{}
-}
-
-func (m *fakeSnapManager) Ensure() error {
-	return nil
-}
-
-// sanity
-var _ overlord.StateManager = (*fakeSnapManager)(nil)
-
-func (s *apiBaseSuite) daemonWithFakeSnapManager(c *check.C) *Daemon {
-	d := s.daemonWithOverlordMock(c)
-	st := d.overlord.State()
-	runner := d.overlord.TaskRunner()
-	d.overlord.AddManager(newFakeSnapManager(st, runner))
-	d.overlord.AddManager(runner)
-	c.Assert(d.overlord.StartUp(), check.IsNil)
-	return d
-}
-
-func (s *apiBaseSuite) waitTrivialChange(c *check.C, chg *state.Change) {
-	err := s.d.overlord.Settle(5 * time.Second)
-	c.Assert(err, check.IsNil)
-	c.Assert(chg.IsReady(), check.Equals, true)
-}
-
-func (s *apiBaseSuite) mkInstalledDesktopFile(c *check.C, name, content string) string {
-	df := filepath.Join(dirs.SnapDesktopFilesDir, name)
-	err := os.MkdirAll(filepath.Dir(df), 0755)
-	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(df, []byte(content), 0644)
-	c.Assert(err, check.IsNil)
-	return df
-}
-
-func (s *apiBaseSuite) mkInstalledInState(c *check.C, daemon *Daemon, instanceName, developer, version string, revision snap.Revision, active bool, extraYaml string) *snap.Info {
-	snapName, instanceKey := snap.SplitInstanceName(instanceName)
-
-	if revision.Local() && developer != "" {
-		panic("not supported")
-	}
-
-	var snapID string
-	if revision.Store() {
-		snapID = snapName + "-id"
-	}
-	// Collect arguments into a snap.SideInfo structure
-	sideInfo := &snap.SideInfo{
-		SnapID:   snapID,
-		RealName: snapName,
-		Revision: revision,
-		Channel:  "stable",
-	}
-
-	// Collect other arguments into a yaml string
-	yamlText := fmt.Sprintf(`
-name: %s
-version: %s
-%s`, snapName, version, extraYaml)
-
-	// Mock the snap on disk
-	snapInfo := snaptest.MockSnapInstance(c, instanceName, yamlText, sideInfo)
-	if active {
-		dir, rev := filepath.Split(snapInfo.MountDir())
-		c.Assert(os.Symlink(rev, dir+"current"), check.IsNil)
-	}
-	c.Assert(snapInfo.InstanceName(), check.Equals, instanceName)
-
-	c.Assert(os.MkdirAll(snapInfo.DataDir(), 0755), check.IsNil)
-	metadir := filepath.Join(snapInfo.MountDir(), "meta")
-	guidir := filepath.Join(metadir, "gui")
-	c.Assert(os.MkdirAll(guidir, 0755), check.IsNil)
-	c.Check(ioutil.WriteFile(filepath.Join(guidir, "icon.svg"), []byte("yadda icon"), 0644), check.IsNil)
-
-	if daemon == nil {
-		return snapInfo
-	}
-	st := daemon.overlord.State()
-	st.Lock()
-	defer st.Unlock()
-
-	var snapst snapstate.SnapState
-	snapstate.Get(st, instanceName, &snapst)
-	snapst.Active = active
-	snapst.Sequence = append(snapst.Sequence, &snapInfo.SideInfo)
-	snapst.Current = snapInfo.SideInfo.Revision
-	snapst.TrackingChannel = "stable"
-	snapst.InstanceKey = instanceKey
-
-	snapstate.Set(st, instanceName, &snapst)
-
-	if developer == "" {
-		return snapInfo
-	}
-
-	devAcct := assertstest.NewAccount(s.storeSigning, developer, map[string]interface{}{
-		"account-id": developer + "-id",
-	}, "")
-
-	snapInfo.Publisher = snap.StoreAccount{
-		ID:          devAcct.AccountID(),
-		Username:    devAcct.Username(),
-		DisplayName: devAcct.DisplayName(),
-		Validation:  devAcct.Validation(),
-	}
-
-	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
-		"series":       "16",
-		"snap-id":      snapID,
-		"snap-name":    snapName,
-		"publisher-id": devAcct.AccountID(),
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, check.IsNil)
-
-	content, err := ioutil.ReadFile(snapInfo.MountFile())
-	c.Assert(err, check.IsNil)
-	h := sha3.Sum384(content)
-	dgst, err := asserts.EncodeDigest(crypto.SHA3_384, h[:])
-	c.Assert(err, check.IsNil)
-	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
-		"snap-sha3-384": string(dgst),
-		"snap-size":     "999",
-		"snap-id":       snapID,
-		"snap-revision": fmt.Sprintf("%s", revision),
-		"developer-id":  devAcct.AccountID(),
-		"timestamp":     time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, check.IsNil)
-
-	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""), devAcct, snapDecl, snapRev)
-
-	return snapInfo
-}
-
 type apiSuite struct {
-	apiBaseSuite
+	APIBaseSuite
 }
 
 var _ = check.Suite(&apiSuite{})
@@ -6892,7 +6363,7 @@ func (s *apiSuite) TestSnapctlUnsuccesfulError(c *check.C) {
 }
 
 type appSuite struct {
-	apiBaseSuite
+	APIBaseSuite
 	cmd *testutil.MockCmd
 
 	infoA, infoB, infoC, infoD *snap.Info
@@ -6901,7 +6372,7 @@ type appSuite struct {
 var _ = check.Suite(&appSuite{})
 
 func (s *appSuite) SetUpTest(c *check.C) {
-	s.apiBaseSuite.SetUpTest(c)
+	s.APIBaseSuite.SetUpTest(c)
 	s.cmd = testutil.MockCommand(c, "systemctl", "").Also("journalctl", "")
 	s.daemon(c)
 	s.infoA = s.mkInstalledInState(c, s.d, "snap-a", "dev", "v1", snap.R(1), true, "apps: {svc1: {daemon: simple}, svc2: {daemon: simple, reload-command: x}}")
@@ -6914,7 +6385,7 @@ func (s *appSuite) SetUpTest(c *check.C) {
 func (s *appSuite) TearDownTest(c *check.C) {
 	s.d.overlord.Stop()
 	s.cmd.Restore()
-	s.apiBaseSuite.TearDownTest(c)
+	s.APIBaseSuite.TearDownTest(c)
 }
 
 func (s *appSuite) TestSplitAppName(c *check.C) {

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2018 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon
+package daemon_test
 
 import (
 	"bytes"
@@ -31,6 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -46,18 +47,20 @@ var _ = check.Suite(&userSuite{})
 // TODO: move to daemon_test package
 
 type userSuite struct {
-	APIBaseSuite
+	daemon.APIBaseSuite
 
 	userInfoResult        *store.User
 	userInfoExpectedEmail string
+	err                   error
 
-	mockUserHome   string
-	restoreClassic func()
-	oldUserAdmin   bool
+	d *daemon.Daemon
+
+	mockUserHome      string
+	trivialUserLookup func(username string) (*user.User, error)
 }
 
 func (s *userSuite) UserInfo(email string) (userinfo *store.User, err error) {
-	s.pokeStateLock()
+	s.PokeStateLock()
 
 	if s.userInfoExpectedEmail != email {
 		panic(fmt.Sprintf("%q != %q", s.userInfoExpectedEmail, email))
@@ -68,35 +71,25 @@ func (s *userSuite) UserInfo(email string) (userinfo *store.User, err error) {
 func (s *userSuite) SetUpTest(c *check.C) {
 	s.APIBaseSuite.SetUpTest(c)
 
-	s.restoreClassic = release.MockOnClassic(false)
+	s.AddCleanup(release.MockOnClassic(false))
 
-	s.DaemonWithStore(c, s)
+	s.d = s.DaemonWithStore(c, s)
 
 	s.mockUserHome = c.MkDir()
-	userLookup = mkUserLookup(s.mockUserHome)
-	s.oldUserAdmin = hasUserAdmin
-	hasUserAdmin = true
+	s.trivialUserLookup = mkUserLookup(s.mockUserHome)
+	s.AddCleanup(daemon.MockUserLookup(s.trivialUserLookup))
+
+	s.AddCleanup(daemon.MockHasUserAdmin(true))
 
 	// make sure we don't call these by accident
-	osutilAddUser = func(name string, opts *osutil.AddUserOptions) error {
+	s.AddCleanup(daemon.MockOsutilAddUser(func(name string, opts *osutil.AddUserOptions) error {
 		c.Fatalf("unexpected add user %q call", name)
 		return fmt.Errorf("unexpected add user %q call", name)
-	}
-	osutilDelUser = func(name string, opts *osutil.DelUserOptions) error {
+	}))
+	s.AddCleanup(daemon.MockOsutilDelUser(func(name string, opts *osutil.DelUserOptions) error {
 		c.Fatalf("unexpected del user %q call", name)
 		return fmt.Errorf("unexpected del user %q call", name)
-	}
-}
-
-func (s *userSuite) TearDownTest(c *check.C) {
-	s.APIBaseSuite.TearDownTest(c)
-
-	userLookup = user.Lookup
-	osutilAddUser = osutil.AddUser
-	osutilDelUser = osutil.DelUser
-
-	s.restoreClassic()
-	hasUserAdmin = s.oldUserAdmin
+	}))
 }
 
 func mkUserLookup(userHomeDir string) func(string) (*user.User, error) {
@@ -118,10 +111,10 @@ func (s *userSuite) TestPostCreateUserNoSSHKeys(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Result.(*errorResult).Message, check.Matches, `cannot create user for "popper@lse.ac.uk": no ssh keys found`)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot create user for "popper@lse.ac.uk": no ssh keys found`)
 }
 
 func (s *userSuite) TestPostCreateUser(c *check.C) {
@@ -140,43 +133,43 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 		SSHKeys:          []string{"ssh1", "ssh2"},
 		OpenIDIdentifier: "xxyyzz",
 	}
-	osutilAddUser = func(username string, opts *osutil.AddUserOptions) error {
+	defer daemon.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
 		c.Check(username, check.Equals, expectedUsername)
 		c.Check(opts.SSHKeys, check.DeepEquals, []string{"ssh1", "ssh2"})
 		c.Check(opts.Gecos, check.Equals, "popper@lse.ac.uk,xxyyzz")
 		c.Check(opts.Sudoer, check.Equals, false)
 		return nil
-	}
+	})()
 
-	var rsp *resp
+	var req *http.Request
 	var expected interface{}
-	expectedItem := userResponseData{
+	expectedItem := daemon.UserResponseData{
 		Username: expectedUsername,
 		SSHKeys:  []string{"ssh1", "ssh2"},
 	}
 
 	if oldWay {
+		var err error
 		buf := bytes.NewBufferString(fmt.Sprintf(`{"email": "%s"}`, s.userInfoExpectedEmail))
-		req, err := http.NewRequest("POST", "/v2/create-user", buf)
+		req, err = http.NewRequest("POST", "/v2/create-user", buf)
 		c.Assert(err, check.IsNil)
-
-		rsp = postCreateUser(createUserCmd, req, nil).(*resp)
 		expected = &expectedItem
 	} else {
+		var err error
 		buf := bytes.NewBufferString(fmt.Sprintf(`{"action":"create","email": "%s"}`, s.userInfoExpectedEmail))
-		req, err := http.NewRequest("POST", "/v2/users", buf)
+		req, err = http.NewRequest("POST", "/v2/users", buf)
 		c.Assert(err, check.IsNil)
-
-		rsp = postUsers(usersCmd, req, nil).(*resp)
-		expected = []userResponseData{expectedItem}
+		expected = []daemon.UserResponseData{expectedItem}
 	}
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
+
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 
 	// user was setup in state
-	state := s.d.overlord.State()
+	state := s.d.Overlord().State()
 	state.Lock()
 	user, err := auth.User(state, 1)
 	state.Unlock()
@@ -195,19 +188,20 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 func (s *userSuite) TestNoUserAdminCreateUser(c *check.C) { s.testNoUserAdmin(c, "/v2/create-user") }
 func (s *userSuite) TestNoUserAdminPostUser(c *check.C)   { s.testNoUserAdmin(c, "/v2/users") }
 func (s *userSuite) testNoUserAdmin(c *check.C, endpoint string) {
-	hasUserAdmin = false
+	defer daemon.MockHasUserAdmin(false)()
 
 	buf := bytes.NewBufferString("{}")
 	req, err := http.NewRequest("POST", endpoint, buf)
 	c.Assert(err, check.IsNil)
 
+	rsp := s.PostReq(c, req, nil)
+
+	const noUserAdmin = "system user administration via snapd is not allowed on this system"
 	switch endpoint {
 	case "/v2/users":
-		rsp := postUsers(usersCmd, req, nil).(*resp)
-		c.Check(rsp, check.DeepEquals, MethodNotAllowed(noUserAdmin))
+		c.Check(rsp, check.DeepEquals, daemon.MethodNotAllowed(noUserAdmin))
 	case "/v2/create-user":
-		rsp := postCreateUser(createUserCmd, req, nil).(*resp)
-		c.Check(rsp, check.DeepEquals, Forbidden(noUserAdmin))
+		c.Check(rsp, check.DeepEquals, daemon.Forbidden(noUserAdmin))
 	default:
 		c.Fatalf("unknown endpoint %q", endpoint)
 	}
@@ -218,9 +212,9 @@ func (s *userSuite) TestPostUserBadBody(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postUsers(usersCmd, req, nil).(*resp)
-	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Result.(*errorResult).Message, check.Matches, "cannot decode user action data from request body: .*")
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, "cannot decode user action data from request body: .*")
 }
 
 func (s *userSuite) TestPostUserBadAfterBody(c *check.C) {
@@ -228,8 +222,8 @@ func (s *userSuite) TestPostUserBadAfterBody(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postUsers(usersCmd, req, nil).(*resp)
-	c.Check(rsp, check.DeepEquals, BadRequest("spurious content after user action"))
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
+	c.Check(rsp, check.DeepEquals, daemon.BadRequest("spurious content after user action"))
 }
 
 func (s *userSuite) TestPostUserNoAction(c *check.C) {
@@ -237,8 +231,8 @@ func (s *userSuite) TestPostUserNoAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postUsers(usersCmd, req, nil).(*resp)
-	c.Check(rsp, check.DeepEquals, BadRequest("missing user action"))
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
+	c.Check(rsp, check.DeepEquals, daemon.BadRequest("missing user action"))
 }
 
 func (s *userSuite) TestPostUserBadAction(c *check.C) {
@@ -246,8 +240,8 @@ func (s *userSuite) TestPostUserBadAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postUsers(usersCmd, req, nil).(*resp)
-	c.Check(rsp, check.DeepEquals, BadRequest(`unsupported user action "patatas"`))
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
+	c.Check(rsp, check.DeepEquals, daemon.BadRequest(`unsupported user action "patatas"`))
 }
 
 func (s *userSuite) TestPostUserActionRemoveNoUsername(c *check.C) {
@@ -255,93 +249,93 @@ func (s *userSuite) TestPostUserActionRemoveNoUsername(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postUsers(usersCmd, req, nil).(*resp)
-	c.Check(rsp, check.DeepEquals, BadRequest("need a username to remove"))
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
+	c.Check(rsp, check.DeepEquals, daemon.BadRequest("need a username to remove"))
 }
 
 func (s *userSuite) TestPostUserActionRemoveDelUserErr(c *check.C) {
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	_, err := auth.NewUser(st, "some-user", "email@test.com", "macaroon", []string{"discharge"})
 	st.Unlock()
 	c.Check(err, check.IsNil)
 
 	called := 0
-	osutilDelUser = func(username string, opts *osutil.DelUserOptions) error {
+	defer daemon.MockOsutilDelUser(func(username string, opts *osutil.DelUserOptions) error {
 		called++
 		c.Check(username, check.Equals, "some-user")
 		return fmt.Errorf("wat")
-	}
+	})()
 
 	buf := bytes.NewBufferString(`{"action":"remove","username":"some-user"}`)
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postUsers(usersCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Status, check.Equals, 500)
-	c.Check(rsp.Result.(*errorResult).Message, check.Equals, "wat")
+	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, "wat")
 	c.Check(called, check.Equals, 1)
 }
 
 func (s *userSuite) TestPostUserActionRemoveStateErr(c *check.C) {
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	st.Set("auth", 42) // breaks auth
 	st.Unlock()
 	called := 0
-	osutilDelUser = func(username string, opts *osutil.DelUserOptions) error {
+	defer daemon.MockOsutilDelUser(func(username string, opts *osutil.DelUserOptions) error {
 		called++
 		c.Check(username, check.Equals, "some-user")
 		return nil
-	}
+	})()
 
 	buf := bytes.NewBufferString(`{"action":"remove","username":"some-user"}`)
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postUsers(usersCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Status, check.Equals, 500)
-	c.Check(rsp.Result.(*errorResult).Message, check.Matches, `internal error: could not unmarshal state entry "auth": .*`)
+	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `internal error: could not unmarshal state entry "auth": .*`)
 	c.Check(called, check.Equals, 0)
 }
 
 func (s *userSuite) TestPostUserActionRemoveNoUserInState(c *check.C) {
 	called := 0
-	osutilDelUser = func(username string, opts *osutil.DelUserOptions) error {
+	defer daemon.MockOsutilDelUser(func(username string, opts *osutil.DelUserOptions) error {
 		called++
 		c.Check(username, check.Equals, "some-user")
 		return nil
-	}
+	})
 
 	buf := bytes.NewBufferString(`{"action":"remove","username":"some-user"}`)
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postUsers(usersCmd, req, nil).(*resp)
-	c.Check(rsp, check.DeepEquals, BadRequest(`user "some-user" is not known`))
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
+	c.Check(rsp, check.DeepEquals, daemon.BadRequest(`user "some-user" is not known`))
 	c.Check(called, check.Equals, 0)
 }
 
 func (s *userSuite) TestPostUserActionRemove(c *check.C) {
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	user, err := auth.NewUser(st, "some-user", "email@test.com", "macaroon", []string{"discharge"})
 	st.Unlock()
 	c.Check(err, check.IsNil)
 
 	called := 0
-	osutilDelUser = func(username string, opts *osutil.DelUserOptions) error {
+	defer daemon.MockOsutilDelUser(func(username string, opts *osutil.DelUserOptions) error {
 		called++
 		c.Check(username, check.Equals, "some-user")
 		return nil
-	}
+	})()
 
 	buf := bytes.NewBufferString(`{"action":"remove","username":"some-user"}`)
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
-	rsp := postUsers(usersCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Status, check.Equals, 200)
-	expected := []userResponseData{
+	expected := []daemon.UserResponseData{
 		{ID: user.ID, Username: user.Username, Email: user.Email},
 	}
 	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{
@@ -357,15 +351,15 @@ func (s *userSuite) TestPostUserActionRemove(c *check.C) {
 }
 
 func (s *userSuite) setupSigner(accountID string, signerPrivKey asserts.PrivateKey) *assertstest.SigningDB {
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 
-	signerSigning := s.brands.Register(accountID, signerPrivKey, map[string]interface{}{
+	signerSigning := s.Brands.Register(accountID, signerPrivKey, map[string]interface{}{
 		"account-id":   accountID,
 		"verification": "verified",
 	})
-	acctNKey := s.brands.AccountsAndKeys(accountID)
+	acctNKey := s.Brands.AccountsAndKeys(accountID)
 
-	assertstest.AddMany(s.storeSigning, acctNKey...)
+	assertstest.AddMany(s.StoreSigning, acctNKey...)
 	assertstatetest.AddMany(st, acctNKey...)
 
 	return signerSigning
@@ -377,17 +371,17 @@ var (
 )
 
 func (s *userSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interface{}) {
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
 
-	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
+	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 
-	s.setupSigner("my-brand", brandPrivKey)
+	s.setupSigner("my-brand", daemon.BrandPrivKey)
 	s.setupSigner("partner", partnerPrivKey)
 	s.setupSigner("unknown", unknownPrivKey)
 
-	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":          "amd64",
 		"gadget":                "pc",
 		"kernel":                "pc-kernel",
@@ -400,7 +394,7 @@ func (s *userSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interfa
 	deviceKey, _ := assertstest.GenerateKey(752)
 	encDevKey, err := asserts.EncodePublicKey(deviceKey.PublicKey())
 	c.Assert(err, check.IsNil)
-	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-model",
@@ -413,7 +407,7 @@ func (s *userSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interfa
 	assertstatetest.AddMany(st, serial)
 
 	for _, suMap := range systemUsers {
-		su, err := s.brands.Signing(suMap["authority-id"].(string)).Sign(asserts.SystemUserType, suMap, nil, "")
+		su, err := s.Brands.Signing(suMap["authority-id"].(string)).Sign(asserts.SystemUserType, suMap, nil, "")
 		c.Assert(err, check.IsNil)
 		su = su.(*asserts.SystemUser)
 		// now add system-user assertion to the system
@@ -514,16 +508,16 @@ var unknownUser = map[string]interface{}{
 func (s *userSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
 	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 
 	st.Lock()
-	model, err := s.d.overlord.DeviceManager().Model()
+	model, err := s.d.Overlord().DeviceManager().Model()
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
 	// ensure that if we query the details from the assert DB we get
 	// the expected user
-	username, opts, err := getUserDetailsFromAssertion(st, model, nil, "foo@bar.com")
+	username, opts, err := daemon.GetUserDetailsFromAssertion(st, model, nil, "foo@bar.com")
 	c.Check(username, check.Equals, "guy")
 	c.Check(opts, check.DeepEquals, &osutil.AddUserOptions{
 		Gecos:    "foo@bar.com,Boring Guy",
@@ -539,36 +533,32 @@ func (s *userSuite) TestPostCreateUserFromAssertion(c *check.C) {
 	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
 
 	// mock the calls that create the user
-	osutilAddUser = func(username string, opts *osutil.AddUserOptions) error {
+	defer daemon.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
 		c.Check(username, check.Equals, "guy")
 		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
 		c.Check(opts.Sudoer, check.Equals, false)
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		c.Check(opts.ForcePasswordChange, check.Equals, false)
 		return nil
-	}
-
-	defer func() {
-		osutilAddUser = osutil.AddUser
-	}()
+	})()
 
 	// do it!
 	buf := bytes.NewBufferString(`{"email": "foo@bar.com","known":true}`)
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
-	expected := &userResponseData{
+	expected := &daemon.UserResponseData{
 		Username: "guy",
 	}
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 
 	// ensure the user was added to the state
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	users, err := auth.Users(st)
 	c.Assert(err, check.IsNil)
@@ -586,36 +576,32 @@ func (s *userSuite) TestPostCreateUserFromAssertionWithForcePasswordChange(c *ch
 	s.makeSystemUsers(c, lusers)
 
 	// mock the calls that create the user
-	osutilAddUser = func(username string, opts *osutil.AddUserOptions) error {
+	defer daemon.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
 		c.Check(username, check.Equals, "guy")
 		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
 		c.Check(opts.Sudoer, check.Equals, false)
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		c.Check(opts.ForcePasswordChange, check.Equals, true)
 		return nil
-	}
-
-	defer func() {
-		osutilAddUser = osutil.AddUser
-	}()
+	})()
 
 	// do it!
 	buf := bytes.NewBufferString(`{"email": "foo@bar.com","known":true}`)
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
-	expected := &userResponseData{
+	expected := &daemon.UserResponseData{
 		Username: "guy",
 	}
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 
 	// ensure the user was added to the state
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	users, err := auth.Users(st)
 	c.Assert(err, check.IsNil)
@@ -638,7 +624,7 @@ func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string,
 	s.makeSystemUsers(c, []map[string]interface{}{goodUser, partnerUser, serialUser, badUser, badUserNoMatchingSerial, unknownUser})
 	created := map[string]bool{}
 	// mock the calls that create the user
-	osutilAddUser = func(username string, opts *osutil.AddUserOptions) error {
+	defer daemon.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
 		switch username {
 		case "guy":
 			c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
@@ -654,31 +640,30 @@ func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string,
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		created[username] = true
 		return nil
-	}
-	oldLookup := userLookup
+	})()
 	// make sure we report them as non-existing until created
-	userLookup = func(username string) (*user.User, error) {
+	defer daemon.MockUserLookup(func(username string) (*user.User, error) {
 		if created[username] {
-			return oldLookup(username)
+			return s.trivialUserLookup(username)
 		}
 		return nil, fmt.Errorf("not created yet")
-	}
+	})()
 
 	// do it!
 	buf := bytes.NewBufferString(postData)
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	// note that we get a list here instead of a single
 	// userResponseData item
-	c.Check(rsp.Result, check.FitsTypeOf, []userResponseData{})
+	c.Check(rsp.Result, check.FitsTypeOf, []daemon.UserResponseData{})
 	seen := map[string]bool{}
-	for _, u := range rsp.Result.([]userResponseData) {
+	for _, u := range rsp.Result.([]daemon.UserResponseData) {
 		seen[u.Username] = true
-		c.Check(u, check.DeepEquals, userResponseData{Username: u.Username})
+		c.Check(u, check.DeepEquals, daemon.UserResponseData{Username: u.Username})
 	}
 	c.Check(seen, check.DeepEquals, map[string]bool{
 		"guy":           true,
@@ -687,7 +672,7 @@ func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string,
 	})
 
 	// ensure the user was added to the state
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	users, err := auth.Users(st)
 	c.Assert(err, check.IsNil)
@@ -706,16 +691,16 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownClassicErrors(c *chec
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Result.(*errorResult).Message, check.Matches, `cannot create user: device is a classic system`)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot create user: device is a classic system`)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwnedErrors(c *check.C) {
 	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	_, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
 	st.Unlock()
@@ -726,16 +711,16 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwnedErrors(c *che
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Result.(*errorResult).Message, check.Matches, `cannot create user: device already managed`)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot create user: device already managed`)
 }
 
 func (s *userSuite) TestPostCreateUserAutomaticManagedDoesNotActOrError(c *check.C) {
 	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	_, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
 	st.Unlock()
@@ -746,11 +731,11 @@ func (s *userSuite) TestPostCreateUserAutomaticManagedDoesNotActOrError(c *check
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
 	// expecting an empty reply
-	expected := []userResponseData{}
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	expected := []daemon.UserResponseData{}
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
@@ -759,7 +744,7 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownNoModelError(c *check
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	// have not model yet
 	st.Lock()
 	err := devicestatetest.SetDevice(st, &auth.DeviceState{})
@@ -771,17 +756,17 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownNoModelError(c *check
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Result.(*errorResult).Message, check.Matches, `cannot create user: cannot get model assertion: no state entry for key`)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot create user: cannot get model assertion: no state entry for key`)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionNoModel(c *check.C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	model := s.brands.Model("my-brand", "other-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "other-model", map[string]interface{}{
 		"architecture":          "amd64",
 		"gadget":                "pc",
 		"kernel":                "pc-kernel",
@@ -789,7 +774,7 @@ func (s *userSuite) TestPostCreateUserFromAssertionNoModel(c *check.C) {
 	})
 	s.makeSystemUsers(c, []map[string]interface{}{serialUser})
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	assertstatetest.AddMany(st, model)
 	err := devicestatetest.SetDevice(st, &auth.DeviceState{
@@ -805,16 +790,16 @@ func (s *userSuite) TestPostCreateUserFromAssertionNoModel(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Result.(*errorResult).Message, check.Matches, `cannot add system-user "serial@bar.com": bound to serial assertion but device not yet registered`)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot add system-user "serial@bar.com": bound to serial assertion but device not yet registered`)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	_, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
 	st.Unlock()
@@ -822,36 +807,35 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwned(c *check.C) 
 
 	// mock the calls that create the user
 	created := map[string]bool{}
-	osutilAddUser = func(username string, opts *osutil.AddUserOptions) error {
+	defer daemon.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
 		c.Check(username, check.Equals, "guy")
 		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
 		c.Check(opts.Sudoer, check.Equals, false)
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		created[username] = true
 		return nil
-	}
-	oldLookup := userLookup
+	})()
 	// make sure we report them as non-existing until created
-	userLookup = func(username string) (*user.User, error) {
+	defer daemon.MockUserLookup(func(username string) (*user.User, error) {
 		if created[username] {
-			return oldLookup(username)
+			return s.trivialUserLookup(username)
 		}
 		return nil, fmt.Errorf("not created yet")
-	}
+	})()
 
 	// do it!
 	buf := bytes.NewBufferString(`{"known":true,"force-managed":true}`)
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+	rsp := s.PostReq(c, req, nil).(*daemon.Resp)
 
 	// note that we get a list here instead of a single
 	// userResponseData item
-	expected := []userResponseData{
+	expected := []daemon.UserResponseData{
 		{Username: "guy"},
 	}
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
@@ -860,16 +844,16 @@ func (s *userSuite) TestUsersEmpty(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/users", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := getUsers(usersCmd, req, nil).(*resp)
+	rsp := s.GetReq(c, req, nil).(*daemon.Resp)
 
-	expected := []userResponseData{}
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	expected := []daemon.UserResponseData{}
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 
 func (s *userSuite) TestUsersHasUser(c *check.C) {
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	u, err := auth.NewUser(st, "someuser", "mymail@test.com", "macaroon", []string{"discharge"})
 	st.Unlock()
@@ -878,40 +862,12 @@ func (s *userSuite) TestUsersHasUser(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/users", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := getUsers(usersCmd, req, nil).(*resp)
+	rsp := s.GetReq(c, req, nil).(*daemon.Resp)
 
-	expected := []userResponseData{
+	expected := []daemon.UserResponseData{
 		{ID: u.ID, Username: u.Username, Email: u.Email},
 	}
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
-}
-
-// XXX: wrong suite
-func (s *userSuite) TestSysInfoIsManaged(c *check.C) {
-	st := s.d.overlord.State()
-	st.Lock()
-	_, err := auth.NewUser(st, "someuser", "mymail@test.com", "macaroon", []string{"discharge"})
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-
-	req, err := http.NewRequest("GET", "/v2/system-info", nil)
-	c.Assert(err, check.IsNil)
-
-	rsp := sysInfo(sysInfoCmd, req, nil).(*resp)
-
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
-	c.Check(rsp.Result.(map[string]interface{})["managed"], check.Equals, true)
-}
-
-// XXX: wrong suite
-func (s *userSuite) TestSysInfoWorksDegraded(c *check.C) {
-	s.d.SetDegradedMode(fmt.Errorf("some error"))
-
-	req, err := http.NewRequest("GET", "/v2/system-info", nil)
-	c.Assert(err, check.IsNil)
-
-	rsp := sysInfo(sysInfoCmd, req, nil).(*resp)
-	c.Check(rsp.Status, check.Equals, 200)
 }

--- a/daemon/export_api_users_test.go
+++ b/daemon/export_api_users_test.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"os/user"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+func MockHasUserAdmin(mockHasUserAdmin bool) (restore func()) {
+	oldHasUserAdmin := hasUserAdmin
+	hasUserAdmin = mockHasUserAdmin
+	return func() {
+		hasUserAdmin = oldHasUserAdmin
+	}
+}
+
+func MockUserLookup(lookup func(username string) (*user.User, error)) (restore func()) {
+	oldLookup := userLookup
+	userLookup = lookup
+	return func() {
+		userLookup = oldLookup
+	}
+}
+
+func MockOsutilAddUser(addUser func(name string, opts *osutil.AddUserOptions) error) (restore func()) {
+	oldAddUser := osutilAddUser
+	osutilAddUser = addUser
+	return func() {
+		osutilAddUser = oldAddUser
+	}
+}
+
+func MockOsutilDelUser(delUser func(name string, opts *osutil.DelUserOptions) error) (restore func()) {
+	oldDelUser := osutilDelUser
+	osutilDelUser = delUser
+	return func() {
+		osutilDelUser = oldDelUser
+	}
+}
+
+type (
+	UserResponseData = userResponseData
+)
+
+var (
+	GetUserDetailsFromAssertion = getUserDetailsFromAssertion
+)

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -41,6 +41,10 @@ func NewWithOverlord(o *overlord.Overlord) *Daemon {
 	return d
 }
 
+func (d *Daemon) Overlord() *overlord.Overlord {
+	return d.overlord
+}
+
 func MockMuxVars(vars func(*http.Request) map[string]string) (restore func()) {
 	old := muxVars
 	muxVars = vars


### PR DESCRIPTION
This branch does 3 things mainly:

* moves apiBaseSuite to api_base_test.go, it starts making some of its fields exported because for a while it will need to be used both from daemon vs daemon_test residing tests,  in the process it also uses more AddCleanup and correct some issues with its usage (missing BaseTest.SetUpTest etc)
* it switches api_users_test.go to live in daemon_test, it also moves some store method faking to it
* it adds a new way to invoke handling logic that sits between pure HTTP invocation and needing to know/expose Commands, this is implemented in APIBaseSuite as GetReq and PostReq helpers

The two commits are probably easier to read on their own.