### PR TITLE
tests: Fix snap-debug-bootvars test to make it work on arm devices and core18

### DIFF
--- a/tests/core/snap-debug-bootvars/task.yaml
+++ b/tests/core/snap-debug-bootvars/task.yaml
@@ -6,9 +6,6 @@ debug: |
     cat run.out || true
     cat recovery.out || true
 
-restore: |
-    rm -f default.out uc20.out run.out recovery.out
-
 execute: |
     # does not outright fail
     snap debug boot-vars  > default.out
@@ -31,8 +28,11 @@ execute: |
         snap debug boot-vars --root-dir /run/mnt/ubuntu-seed > recovery.out
         MATCH 'snapd_recovery_mode=run' < recovery.out
     else
-        MATCH 'snap_core=core.*\.snap' < default.out
-        MATCH 'snap_kernel=pc-kernel.*\.snap' < default.out
+        #shellcheck source=tests/lib/names.sh
+        . "$TESTSLIB"/names.sh
+
+        MATCH "snap_core=${core_name}_*\.snap" < default.out
+        MATCH "snap_kernel=${kernel_name}_*\.snap" < default.out
         # relevant snaps are not being updated, so snap_mode is unset
         MATCH 'snap_mode=$' < default.out
     fi

--- a/tests/core/snap-debug-bootvars/task.yaml
+++ b/tests/core/snap-debug-bootvars/task.yaml
@@ -31,8 +31,8 @@ execute: |
         #shellcheck source=tests/lib/names.sh
         . "$TESTSLIB"/names.sh
 
-        MATCH "snap_core=${core_name}_*\.snap" < default.out
-        MATCH "snap_kernel=${kernel_name}_*\.snap" < default.out
+        MATCH "snap_core=${core_name}_.*\.snap" < default.out
+        MATCH "snap_kernel=${kernel_name}_.*\.snap" < default.out
         # relevant snaps are not being updated, so snap_mode is unset
         MATCH 'snap_mode=$' < default.out
     fi


### PR DESCRIPTION
The test is failing on arm devices because the kernel and the core do not match.

