### PR TITLE
data: fix case when $PATH has spaces in snapd.sh.in

### DIFF
--- a/data/env/snapd.sh.in
+++ b/data/env/snapd.sh.in
@@ -3,7 +3,7 @@
 # Expand $PATH to include the directory where snappy applications go.
 snap_bin_path="@SNAP_MOUNT_DIR@/bin"
 if [ -n "${PATH##*${snap_bin_path}}" ] && [ -n "${PATH##*${snap_bin_path}:*}" ]; then
-    export PATH=$PATH:${snap_bin_path}
+    export PATH="$PATH:${snap_bin_path}"
 fi
 
 # Ensure base distro defaults xdg path are set if nothing filed up some
@@ -19,4 +19,3 @@ snap_xdg_path="/var/lib/snapd/desktop"
 if [ -n "${XDG_DATA_DIRS##*${snap_xdg_path}}" ] && [ -n "${XDG_DATA_DIRS##*${snap_xdg_path}:*}" ]; then
     export XDG_DATA_DIRS="${XDG_DATA_DIRS}:${snap_xdg_path}"
 fi
-


### PR DESCRIPTION
**Refs:** <https://github.com/snapcore/snapd/pull/8520>
**Refs:** <https://github.com/koalaman/shellcheck/issues/951>
**Refs:** <https://github.com/PowerShell/PowerShell/issues/12020>

This was missed in <https://github.com/snapcore/snapd/pull/8520>.