### PR TITLE
packaging/arch: sync with AUR packaging

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -77,8 +77,8 @@ build() {
   # because argument expansion with quoting in bash is hard, and -ldflags=-extldflags='-foo'
   # is not exactly the same as -ldflags "-extldflags '-foo'" use the array trick
   # to pass exactly what we want
-  flags=(-buildmode=pie -ldflags "-s -extldflags '$LDFLAGS'")
-  staticflags=(-buildmode=pie -ldflags "-s -linkmode external -extldflags '$LDFLAGS -static'")
+  flags=(-buildmode=pie -ldflags "-s -linkmode external -extldflags '$LDFLAGS'" -trimpath)
+  staticflags=(-buildmode=pie -ldflags "-s -linkmode external -extldflags '$LDFLAGS -static'" -trimpath)
   # Build/install snap and snapd
   go build "${flags[@]}" -o "$srcdir/go/bin/snap" $GOFLAGS_SNAP "${_gourl}/cmd/snap"
   go build "${flags[@]}" -o "$srcdir/go/bin/snapd" $GOFLAGS "${_gourl}/cmd/snapd"
@@ -132,6 +132,9 @@ check() {
 package() {
   cd "$pkgname"
   export GOPATH="$srcdir/go"
+  # snapd does not use modules, setting GO111MODULE=on in the environment breaks
+  # the build
+  unset GO111MODULE
 
   # Install bash completion
   install -Dm644 data/completion/bash/snap \
@@ -204,6 +207,7 @@ package() {
   # Remove snappy core specific units
   rm -fv "$pkgdir/usr/lib/systemd/system/snapd.system-shutdown.service"
   rm -fv "$pkgdir/usr/lib/systemd/system/snapd.autoimport.service"
+  rm -fv "$pkgdir/usr/lib/systemd/system/snapd.recovery-chooser-trigger.service"
   rm -fv "$pkgdir"/usr/lib/systemd/system/snapd.snap-repair.*
   rm -fv "$pkgdir"/usr/lib/systemd/system/snapd.core-fixup.*
   # and scripts


### PR DESCRIPTION
The 2.48 has been pushed to AUR. Sync PKGBUILDs to make the future updates
easier.

