### PR TITLE
tests: run tests against 2.48 for the SRU

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+No real change
+
 [![Snapcraft](https://avatars2.githubusercontent.com/u/19532717?s=200)](https://snapcraft.io)
 
 # Welcome to snapd


### PR DESCRIPTION
This is not a real PR, please do not merge it. It is just here
so that the SRU team can see that the spread tests run against
2.48.

We need to integrate spread/GH actions so that this is done
automatically again (it was before in travis).
