### PR TITLE
boot: add helper for generating candidate kernel lines for recovery system

### DIFF
--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -118,6 +118,9 @@ func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, syst
 	modeArg := "snapd_recovery_mode=run"
 	systemArg := ""
 	if mode == ModeRecover {
+		if system == "" {
+			return "", fmt.Errorf("internal error: system is unset")
+		}
 		// dealing with recovery system bootloader
 		opts.Role = bootloader.RoleRecovery
 		bootloaderRootDir = InitramfsUbuntuSeedDir
@@ -153,11 +156,16 @@ func ComposeCommandLine(model *asserts.Model) (string, error) {
 	return composeCommandLine(model, currentEdition, ModeRun, "")
 }
 
-// TODO:UC20: add helper to compose candidate command line for a recovery system
-
 // ComposeCandidateCommandLine composes the kernel command line used when
 // booting the system in run mode with the current built-in edition of managed
 // boot assets.
 func ComposeCandidateCommandLine(model *asserts.Model) (string, error) {
 	return composeCommandLine(model, candidateEdition, ModeRun, "")
+}
+
+// ComposeCandidateRecoveryCommandLine composes the kernel command line used
+// when booting the given system in recover mode with the current built-in
+// edition of managed boot assets.
+func ComposeCandidateRecoveryCommandLine(model *asserts.Model, system string) (string, error) {
+	return composeCommandLine(model, candidateEdition, ModeRecover, system)
 }

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -188,14 +188,28 @@ func (s *kernelCommandLineSuite) TestComposeCandidateCommandLineManagedHappy(c *
 	defer bootloader.Force(nil)
 
 	tbl.StaticCommandLine = "panic=-1"
-	tbl.CandidateStaticCommandLine = "candidate panic=-1"
+	tbl.CandidateStaticCommandLine = "candidate panic=0"
 
 	cmdline, err := boot.ComposeCandidateCommandLine(model)
 	c.Assert(err, IsNil)
-	c.Assert(cmdline, Equals, "snapd_recovery_mode=run candidate panic=-1")
+	c.Assert(cmdline, Equals, "snapd_recovery_mode=run candidate panic=0")
+}
 
-	// managed status is effectively ignored
-	cmdline, err = boot.ComposeCandidateCommandLine(model)
+func (s *kernelCommandLineSuite) TestComposeCandidateRecoveryCommandLineManagedHappy(c *C) {
+	model := boottest.MakeMockUC20Model()
+
+	tbl := bootloadertest.Mock("btloader", c.MkDir()).WithTrustedAssets()
+	bootloader.Force(tbl)
+	defer bootloader.Force(nil)
+
+	tbl.StaticCommandLine = "panic=-1"
+	tbl.CandidateStaticCommandLine = "candidate panic=0"
+
+	cmdline, err := boot.ComposeCandidateRecoveryCommandLine(model, "1234")
 	c.Assert(err, IsNil)
-	c.Assert(cmdline, Equals, "snapd_recovery_mode=run candidate panic=-1")
+	c.Check(cmdline, Equals, "snapd_recovery_mode=recover snapd_recovery_system=1234 candidate panic=0")
+
+	cmdline, err = boot.ComposeCandidateRecoveryCommandLine(model, "")
+	c.Assert(err, ErrorMatches, "internal error: system is unset")
+	c.Check(cmdline, Equals, "")
 }


### PR DESCRIPTION
Add a helper that can generate a candidate kernel command line that would be
used when booting a recovery system.

