### PR TITLE
data/selinux: update the policy to allow operations on non-tmpfs /tmp

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -454,6 +454,13 @@ admin_pattern(snappy_mount_t, snappy_tmp_t)
 # up with user_tmp_t allow acting on it
 allow snappy_mount_t user_tmp_t:dir { mounton rmdir };
 userdom_delete_user_tmp_files(snappy_mount_t)
+# when managing some interfaces, a mount from the host /tmp may need to be set
+# up and files or directories may need to be created or removed (eg. x11
+# interface), in most distros the /tmp is on tmpfs and thus fs_manage_tmpfs_*
+# will provide the right policy, but we still need to allow those operations
+# when the host's /tmp is not a tmpfs
+files_manage_generic_tmp_dirs(snappy_mount_t)
+files_manage_generic_tmp_files(snappy_mount_t)
 
 # Allow snap-{update,discard}-ns to manage mounts
 gen_require(`


### PR DESCRIPTION
Some distros, eg. CentOS 7 do not have /tmp on tmpfs. Because of this, the
policy rules for tmpfs are not effective and the following denial can be
observed when disconnecting the x11 interface (which mounts /tmp/.X11-unix from
the host):

```
type=AVC msg=audit(1606220902.660:1383): avc:  denied  { rmdir } for
         pid=28575 comm="snap-update-ns" name=".X11-unix" dev="sda2"
         ino=17552915
         scontext=system_u:system_r:snappy_mount_t:s0
         tcontext=system_u:object_r:tmp_t:s0
         tclass=dir permissive=1
```

We need to extend the policy to explicitly allow poking generic tmp_t files and
directories.

@Conan-Kudo can you take a look too?