### PR TITLE
o/devicestate,daemon: fix reboot system action to not require a system label

### DIFF
--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -31,8 +31,10 @@ import (
 )
 
 var systemsCmd = &Command{
-	Path: "/v2/systems",
-	GET:  getSystems,
+	Path:     "/v2/systems",
+	GET:      getSystems,
+	POST:     postSystemsAction,
+	RootOnly: true,
 }
 
 var systemsActionCmd = &Command{

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -31,8 +31,13 @@ import (
 )
 
 var systemsCmd = &Command{
-	Path:     "/v2/systems",
-	GET:      getSystems,
+	Path: "/v2/systems",
+	GET:  getSystems,
+	// this is awkward, we want the postSystemsAction function to be used
+	// when the label is empty too, but the router will not handle the request
+	// for /v2/systems with the systemsActionCmd and instead handles it through
+	// this command, so we need to set the POST for this command to essentially
+	// forward to that one
 	POST:     postSystemsAction,
 	RootOnly: true,
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1194,7 +1194,7 @@ func (m *DeviceManager) Reboot(systemLabel, mode string) error {
 		systemMode := m.SystemMode()
 		currentSys, err := currentSystemForMode(m.state, systemMode)
 		if err != nil {
-			return fmt.Errorf("cannot get curent system: %v", err)
+			return fmt.Errorf("cannot get current system: %v", err)
 		}
 		systemLabel = currentSys.System
 	}

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -76,10 +76,8 @@ execute: |
 
     # now transition to recover mode and check it again
     boot_id="$(nested_get_boot_id)"
-    # TODO:UC20: shouldn't need to specify the label here, fix when snap reboot
-    #            works
     # shellcheck disable=SC2016
-    nested_exec 'sudo snap reboot --recover $(sudo snap recovery | grep -v Label | awk "{print \$1}")'
+    nested_exec 'sudo snap reboot --recover'
     nested_wait_for_reboot "${boot_id}"
 
     # verify in recover mode


### PR DESCRIPTION
We should be able to trigger a reboot without specifying the system label, since
we can detect the current system label and use that for the specified mode.

This was not caught before because of how we test daemon command endpoints and
the fact that the router we use operates weirdly for paths like /v2/systems,
where we have separate commands for the version without any sub-path and the
version with a sub-path.