### PR TITLE
hookstate: implement snapctl fde-setup-{request,result}

### DIFF
--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/state"
 )
 
 type fdeSetupRequestCommand struct {
@@ -68,7 +69,11 @@ func (c *fdeSetupRequestCommand) Execute(args []string) error {
 	defer context.Unlock()
 
 	var fdeSetup hookstate.FDESetupOp
-	if err := context.Get("fde-setup-op", &fdeSetup); err != nil {
+	err := context.Get("fde-setup-op", &fdeSetup)
+	if err == state.ErrNoState {
+		return fmt.Errorf("cannot find FDE setup data, is the command called from a non fde-setup hook?")
+	}
+	if err != nil {
 		return fmt.Errorf("cannot get fde-setup-op from context: %v", err)
 	}
 	// Op is either "initial-setup" or "features"

--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -102,11 +102,11 @@ var longFdeSetupResultHelp = i18n.G(`
 The fde-setup-result command sets the result data for a fde-setup hook
 reading it from stdin.
 
-E.g.
+For example:
 When the fde-setup hook is called with "op":"features:
 $ echo "[]" | snapctl fde-setup-result
 
-Or when the fde-setup hook is called with "op":"initial-setup":
+When the fde-setup hook is called with "op":"initial-setup":
 $ echo "sealed-key" | snapctl fde-setup-result
 `)
 

--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -30,7 +30,8 @@ type fdeSetupRequestCommand struct {
 	baseCommand
 }
 
-var shortFdeSetupRequestHelp = i18n.G("Request setup of full disk encryption")
+var shortFdeSetupRequestHelp = i18n.G("Obtain full disk encryption setup request")
+
 var longFdeSetupRequestHelp = i18n.G(`
 The fde-setup-request command is used inside the fde-setup hook. It will
 return information about what operation for full-disk encryption is
@@ -77,7 +78,7 @@ type fdeSetupJSON struct {
 func (c *fdeSetupRequestCommand) Execute(args []string) error {
 	context := c.context()
 	if context == nil {
-		return fmt.Errorf("cannot  without a context")
+		return fmt.Errorf("cannot run fde-setup-request without a context")
 	}
 	context.Lock()
 	defer context.Unlock()
@@ -120,8 +121,8 @@ type fdeSetupResultCommand struct {
 
 var shortFdeSetupResultHelp = i18n.G("Set result for full disk encryption")
 var longFdeSetupResultHelp = i18n.G(`
-The fde-setup-result command reads the result data for a fde-setup hook
-from stdin.
+The fde-setup-result command sets the result data for a fde-setup hook
+reading it from stdin.
 
 E.g.
 When the fde-setup hook is called with "op":"features:
@@ -138,7 +139,7 @@ func init() {
 func (c *fdeSetupResultCommand) Execute(args []string) error {
 	context := c.context()
 	if context == nil {
-		return fmt.Errorf("cannot  without a context")
+		return fmt.Errorf("cannot run fde-setup-result without a context")
 	}
 	context.Lock()
 	defer context.Unlock()
@@ -148,7 +149,7 @@ func (c *fdeSetupResultCommand) Execute(args []string) error {
 		return fmt.Errorf("cannot get result from stdin: %v", err)
 	}
 	if fdeSetupResult == nil {
-		return fmt.Errorf("no result data found on stdin")
+		return fmt.Errorf("no result data found from stdin")
 	}
 	task, ok := context.Task()
 	if !ok {

--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -78,10 +78,8 @@ func (c *fdeSetupRequestCommand) Execute(args []string) error {
 	}
 	// Op is either "initial-setup" or "features"
 	switch fdeSetup.Op {
-	case "features":
-		// nothing
-	case "initial-setup":
-		// TODO: validate we have key, key-name, model
+	case "features", "initial-setup":
+		// fine
 	default:
 		return fmt.Errorf("unknown fde-setup-request op %q", fdeSetup.Op)
 

--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -133,11 +133,7 @@ func (c *fdeSetupResultCommand) Execute(args []string) error {
 	if fdeSetupResult == nil {
 		return fmt.Errorf("no result data found from stdin")
 	}
-	task, ok := context.Task()
-	if !ok {
-		return fmt.Errorf("internal error: fdeSetupResultCommand called without task")
-	}
-	task.Set("fde-setup-result", fdeSetupResult)
+	context.Set("fde-setup-result", fdeSetupResult)
 
 	return nil
 }

--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -1,0 +1,160 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/snapcore/snapd/i18n"
+)
+
+type fdeSetupRequestCommand struct {
+	baseCommand
+}
+
+var shortFdeSetupRequestHelp = i18n.G("Request setup of full disk encryption")
+var longFdeSetupRequestHelp = i18n.G(`
+The fde-setup-request command is used inside the fde-setup hook. It will
+return information about what operation for full-disk encryption is
+requested and auxiliary data to complete this operation.
+
+The fde-setup hook should do what is requested and then call
+"snapctl fde-setup-result" and pass the result data to stdin.
+
+Here is an example for how the fde-setup hook is called initially:
+$ snapctl fde-setup-request
+{"op":"features"}
+$ echo '[]' | snapctl fde-setup-result
+
+Alternatively the hook could reply with:
+$ echo '{"error":"hardware-unsupported"}' | snapctl fde-setup-result
+
+And then it is called again with a request to do the initial key setup:
+$ snapctl fde-setup-request
+{"op":"initial-setup", "key": "key-to-seal", "key-name":"key-for-ubuntu-data"}
+$ echo "$sealed_key" | snapctl fde-setup-result
+`)
+
+func init() {
+	addCommand("fde-setup-request", shortFdeSetupRequestHelp, longFdeSetupRequestHelp, func() command { return &fdeSetupRequestCommand{} })
+}
+
+type fdeSetupJSON struct {
+	// XXX: make "op" a type: "features", "initial-setup", "update" ?
+	Op string `json:"op"`
+
+	Key     []byte `json:"key,omitempty"`
+	KeyName string `json:"key-name,omitempty"`
+
+	// Model related fields, this will be set to follow the
+	// secboot:SnapModel interface.
+	//
+	// XXX: do we need this to be a list? i.e. multiple models?
+	Model map[string]string `json:"model,omitempty"`
+
+	// TODO: provide LoadChains, KernelCmdline etc to support full
+	//       tpm sealing
+}
+
+func (c *fdeSetupRequestCommand) Execute(args []string) error {
+	context := c.context()
+	if context == nil {
+		return fmt.Errorf("cannot  without a context")
+	}
+	context.Lock()
+	defer context.Unlock()
+
+	var js fdeSetupJSON
+	if err := context.Get("fde-op", &js.Op); err != nil {
+		return fmt.Errorf("cannot get fde op from context: %v", err)
+	}
+	// Op is either "initial-setup" or "features"
+	switch js.Op {
+	case "features":
+		// nothing
+	case "initial-setup":
+		if err := context.Get("fde-key", &js.Key); err != nil {
+			return fmt.Errorf("cannot get fde key from context: %v", err)
+		}
+		if err := context.Get("fde-key-name", &js.KeyName); err != nil {
+			return fmt.Errorf("cannot get fde key name from context: %v", err)
+		}
+		if err := context.Get("model", &js.Model); err != nil {
+			return fmt.Errorf("cannot get model from context: %v", err)
+		}
+	default:
+		return fmt.Errorf("unknown fde-setup-request op %q", js.Op)
+
+	}
+
+	bytes, err := json.Marshal(js)
+	if err != nil {
+		return fmt.Errorf("cannot json print fde key: %v", err)
+	}
+	c.printf("%s\n", string(bytes))
+
+	return nil
+}
+
+type fdeSetupResultCommand struct {
+	baseCommand
+}
+
+var shortFdeSetupResultHelp = i18n.G("Set result for full disk encryption")
+var longFdeSetupResultHelp = i18n.G(`
+The fde-setup-result command reads the result data for a fde-setup hook
+from stdin.
+
+E.g.
+When the fde-setup hook is called with "op":"features:
+$ echo "[]" | snapctl fde-setup-result
+
+Or when the fde-setup hook is called with "op":"initial-setup":
+$ echo "sealed-key" | snapctl fde-setup-result
+`)
+
+func init() {
+	addCommand("fde-setup-result", shortFdeSetupResultHelp, longFdeSetupResultHelp, func() command { return &fdeSetupResultCommand{} })
+}
+
+func (c *fdeSetupResultCommand) Execute(args []string) error {
+	context := c.context()
+	if context == nil {
+		return fmt.Errorf("cannot  without a context")
+	}
+	context.Lock()
+	defer context.Unlock()
+
+	var fdeSetupResult []byte
+	if err := context.Get("stdin", &fdeSetupResult); err != nil {
+		return fmt.Errorf("cannot get result from stdin: %v", err)
+	}
+	if fdeSetupResult == nil {
+		return fmt.Errorf("no result data found on stdin")
+	}
+	task, ok := context.Task()
+	if !ok {
+		return fmt.Errorf("internal error: fdeSetupResultCommand called without task")
+	}
+	task.Set("fde-setup-result", fdeSetupResult)
+
+	return nil
+}

--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -68,8 +68,8 @@ func (c *fdeSetupRequestCommand) Execute(args []string) error {
 	context.Lock()
 	defer context.Unlock()
 
-	var fdeSetup hookstate.FDESetupOp
-	err := context.Get("fde-setup-op", &fdeSetup)
+	var fdeSetup hookstate.FDESetupRequest
+	err := context.Get("fde-setup-request", &fdeSetup)
 	if err == state.ErrNoState {
 		return fmt.Errorf("cannot find FDE setup data, is the command called from a non fde-setup hook?")
 	}

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -1,0 +1,139 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type fdeSetupSuite struct {
+	testutil.BaseTest
+
+	st          *state.State
+	mockHandler *hooktest.MockHandler
+	mockTask    *state.Task
+	mockContext *hookstate.Context
+}
+
+var _ = Suite(&fdeSetupSuite{})
+
+var mockFdeSetupKernelYaml = `name: pc-kernel
+version: 1.0
+type: kernel
+hooks:
+ fde-setup:
+`
+
+func (s *fdeSetupSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+
+	s.st = state.New(nil)
+	s.mockHandler = hooktest.NewMockHandler()
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	mockInstalledSnap(c, s.st, mockFdeSetupKernelYaml)
+	s.mockTask = s.st.NewTask("test-task", "my test task")
+	hooksup := &hookstate.HookSetup{
+		Snap:     "pc-kernel",
+		Revision: snap.R(1),
+		Hook:     "fde-setup",
+	}
+	context, err := hookstate.NewContext(s.mockTask, s.st, hooksup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	s.mockContext = context
+}
+
+func (s *fdeSetupSuite) TestFdeSetupRequestOpInvalid(c *C) {
+	s.mockContext.Lock()
+	s.mockContext.Set("fde-op", "invalid-and-unknown")
+	s.mockContext.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)
+	c.Check(err, ErrorMatches, `unknown fde-setup-request op "invalid-and-unknown"`)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *fdeSetupSuite) TestFdeSetupRequestOpFeatures(c *C) {
+	s.mockContext.Lock()
+	s.mockContext.Set("fde-op", "features")
+	s.mockContext.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, `{"op":"features"}`+"\n")
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
+	b64EncodedKeyToSeal := base64.StdEncoding.EncodeToString([]byte("key-to-seal"))
+
+	s.mockContext.Lock()
+	s.mockContext.Set("fde-op", "initial-setup")
+	s.mockContext.Set("fde-key", b64EncodedKeyToSeal)
+	s.mockContext.Set("fde-key-name", "the-key-name")
+	s.mockContext.Set("model", map[string]string{
+		"series":     "16",
+		"brand-id":   "my-brand",
+		"model":      "my-model",
+		"grade":      "secured",
+		"signkey-id": "the-signkey-id",
+	})
+	s.mockContext.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%q,"key-name":"the-key-name","model":{"brand-id":"my-brand","grade":"secured","model":"my-model","series":"16","signkey-id":"the-signkey-id"}}`+"\n", b64EncodedKeyToSeal))
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *fdeSetupSuite) TestFdeSetupResult(c *C) {
+	mockStdin := []byte("sealed-key-data-from-stdin-as-set-by-daemon:runSnapctl")
+
+	s.mockContext.Lock()
+	s.mockContext.Set("stdin", mockStdin)
+	s.mockContext.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-result"}, 0)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+
+	// check that the task got the key that was passed via stdin
+	var fdeSetupResult []byte
+	s.st.Lock()
+	s.mockTask.Get("fde-setup-result", &fdeSetupResult)
+	s.st.Unlock()
+	c.Check(fdeSetupResult, DeepEquals, mockStdin)
+}

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -95,6 +95,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestNoFdeSetupOpData(c *C) {
 		Hook:     "other-hook",
 	}
 	context, err := hookstate.NewContext(nil, s.st, hooksup, s.mockHandler, "")
+	c.Assert(err, IsNil)
 
 	// check "fde-setup-request" error
 	stdout, stderr, err := ctlcmd.Run(context, []string{"fde-setup-request"}, 0)

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -162,8 +162,8 @@ func (s *fdeSetupSuite) TestFdeSetupResult(c *C) {
 
 	// check that the task got the key that was passed via stdin
 	var fdeSetupResult []byte
-	s.st.Lock()
-	s.mockTask.Get("fde-setup-result", &fdeSetupResult)
-	s.st.Unlock()
+	s.mockContext.Lock()
+	s.mockContext.Get("fde-setup-result", &fdeSetupResult)
+	s.mockContext.Unlock()
 	c.Check(fdeSetupResult, DeepEquals, mockStdin)
 }

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -75,11 +75,11 @@ func (s *fdeSetupSuite) SetUpTest(c *C) {
 }
 
 func (s *fdeSetupSuite) TestFdeSetupRequestOpInvalid(c *C) {
-	fdeSetup := &hookstate.FDESetupOp{
+	fdeSetup := &hookstate.FDESetupRequest{
 		Op: "invalid-and-unknown",
 	}
 	s.mockContext.Lock()
-	s.mockContext.Set("fde-setup-op", fdeSetup)
+	s.mockContext.Set("fde-setup-request", fdeSetup)
 	s.mockContext.Unlock()
 
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)
@@ -89,7 +89,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInvalid(c *C) {
 }
 
 func (s *fdeSetupSuite) TestFdeSetupRequestNoFdeSetupOpData(c *C) {
-	// note that we did not set "fde-setup-op" in mockContext in this test
+	// note that we did not set "fde-setup-request" in mockContext in this test
 
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)
 	c.Check(err, ErrorMatches, `cannot find FDE setup data, is the command called from a non fde-setup hook\?`)
@@ -98,11 +98,11 @@ func (s *fdeSetupSuite) TestFdeSetupRequestNoFdeSetupOpData(c *C) {
 }
 
 func (s *fdeSetupSuite) TestFdeSetupRequestOpFeatures(c *C) {
-	fdeSetup := &hookstate.FDESetupOp{
+	fdeSetup := &hookstate.FDESetupRequest{
 		Op: "features",
 	}
 	s.mockContext.Lock()
-	s.mockContext.Set("fde-setup-op", fdeSetup)
+	s.mockContext.Set("fde-setup-request", fdeSetup)
 	s.mockContext.Unlock()
 
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)
@@ -112,7 +112,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpFeatures(c *C) {
 }
 
 func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
-	fdeSetup := &hookstate.FDESetupOp{
+	fdeSetup := &hookstate.FDESetupRequest{
 		Op:      "initial-setup",
 		Key:     []byte("key-to-seal"),
 		KeyName: "the-key-name",
@@ -125,7 +125,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 		},
 	}
 	s.mockContext.Lock()
-	s.mockContext.Set("fde-setup-op", fdeSetup)
+	s.mockContext.Set("fde-setup-request", fdeSetup)
 	s.mockContext.Unlock()
 
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -89,10 +89,22 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInvalid(c *C) {
 }
 
 func (s *fdeSetupSuite) TestFdeSetupRequestNoFdeSetupOpData(c *C) {
-	// note that we did not set "fde-setup-request" in mockContext in this test
+	hooksup := &hookstate.HookSetup{
+		Snap:     "pc-kernel",
+		Revision: snap.R(1),
+		Hook:     "other-hook",
+	}
+	context, err := hookstate.NewContext(nil, s.st, hooksup, s.mockHandler, "")
 
-	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)
-	c.Check(err, ErrorMatches, `cannot find FDE setup data, is the command called from a non fde-setup hook\?`)
+	// check "fde-setup-request" error
+	stdout, stderr, err := ctlcmd.Run(context, []string{"fde-setup-request"}, 0)
+	c.Check(err, ErrorMatches, `cannot use fde-setup-request outside of the fde-setup hook`)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+
+	// check "fde-setup-result" error
+	stdout, stderr, err = ctlcmd.Run(context, []string{"fde-setup-result"}, 0)
+	c.Check(err, ErrorMatches, `cannot use fde-setup-result outside of the fde-setup hook`)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
 }

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -88,6 +88,15 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInvalid(c *C) {
 	c.Check(string(stderr), Equals, "")
 }
 
+func (s *fdeSetupSuite) TestFdeSetupRequestNoFdeSetupOpData(c *C) {
+	// note that we did not set "fde-setup-op" in mockContext in this test
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)
+	c.Check(err, ErrorMatches, `cannot find FDE setup data, is the command called from a non fde-setup hook\?`)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+}
+
 func (s *fdeSetupSuite) TestFdeSetupRequestOpFeatures(c *C) {
 	fdeSetup := &hookstate.FDESetupOp{
 		Op: "features",

--- a/overlord/hookstate/fdesetup.go
+++ b/overlord/hookstate/fdesetup.go
@@ -19,7 +19,7 @@
 
 package hookstate
 
-type FDESetupOp struct {
+type FDESetupRequest struct {
 	// XXX: make "op" a type: "features", "initial-setup", "update" ?
 	Op string `json:"op"`
 

--- a/overlord/hookstate/fdesetup.go
+++ b/overlord/hookstate/fdesetup.go
@@ -19,6 +19,8 @@
 
 package hookstate
 
+// FDESetupRequest is the struct that is passed the the fde-setup hooks
+// via the `snapctl fde-setup-request` command.
 type FDESetupRequest struct {
 	// XXX: make "op" a type: "features", "initial-setup", "update" ?
 	Op string `json:"op"`

--- a/overlord/hookstate/fdesetup.go
+++ b/overlord/hookstate/fdesetup.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020  Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hookstate
+
+type FDESetupOp struct {
+	// XXX: make "op" a type: "features", "initial-setup", "update" ?
+	Op string `json:"op"`
+
+	Key     []byte `json:"key,omitempty"`
+	KeyName string `json:"key-name,omitempty"`
+
+	// Model related fields, this will be set to follow the
+	// secboot:SnapModel interface.
+	//
+	// XXX: do we need this to be a list? i.e. multiple models?
+	Model map[string]string `json:"model,omitempty"`
+
+	// TODO: provide LoadChains, KernelCmdline etc to support full
+	//       tpm sealing
+}

--- a/overlord/hookstate/fdesetup.go
+++ b/overlord/hookstate/fdesetup.go
@@ -19,8 +19,8 @@
 
 package hookstate
 
-// FDESetupRequest is the struct that is passed the the fde-setup hooks
-// via the `snapctl fde-setup-request` command.
+// FDESetupRequest carries the operation and parameters for the fde-setup hooks
+// made available to them via the snapctl fde-setup-request command.
 type FDESetupRequest struct {
 	// XXX: make "op" a type: "features", "initial-setup", "update" ?
 	Op string `json:"op"`


### PR DESCRIPTION
This commit implements support for running `fde-setup-{request,result}`
from hooks.
