### PR TITLE
snapcraft.yaml: allow configuring the snapd snap build via dev options files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,10 @@ jobs:
                   echo "::set-output name=already-ran::true"
               fi
           fi
+    - name: Set CI snapcraft build options
+      run: |
+        mkdir -p developer-snapd-snap-options
+        touch ./developer-snapd-snap-options/both-testkeys
     - name: Build snapd snap
       if: steps.cached-results.outputs.already-ran != 'true'
       uses: snapcore/action-build@v1

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ cmd/test-driver
 
 # Image files
 *.img
+
+# Developer options for the snapd snap build
+developer-snapd-snap-options/

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -53,7 +53,34 @@ parts:
         DEB_BUILD_OPTIONS=nocheck
         export DEB_BUILD_OPTIONS
       fi
-      # run the real build (but just build the binary package, and don't
+      if [ -d "$SNAPCRAFT_PART_SRC/developer-snapd-snap-options" ]; then
+        if [ -f "$SNAPCRAFT_PART_SRC/developer-snapd-snap-options/testkeys" ]; then
+          # set the testkeys deb build option
+          echo "building deb with testkeys"
+          DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS testkeys"
+          export DEB_BUILD_OPTIONS
+        elif [ -f "$SNAPCRAFT_PART_SRC/developer-snapd-snap-options/both-testkeys" ]; then
+          # build both a deb with the testkeys and a normal deb, extracting the
+          # normal deb into the snap, and stuffing the unextracted testkeys deb
+          # into the build - this is useful for spread runs on github actions 
+          # where we build a single snap file with both testkeys and without, 
+          # and then unpack and create two separate snaps to attach to a PR,
+          # one for normal folks to test and install with normal root of trust,
+          # and the other with the testkeys to eventually be used from inside 
+          # spread itself to eliminate also building snapd in the spread run
+
+          PREV_DEB_BUILD_OPTIONS=$DEB_BUILD_OPTIONS
+
+          echo "building additional deb with testkeys"
+          DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS testkeys"
+          export DEB_BUILD_OPTIONS
+          dpkg-buildpackage -b -Zgzip -zfast
+          cp $(pwd)/../snapd_*.deb $SNAPCRAFT_PART_INSTALL/testkeys-snapd.deb
+
+          DEB_BUILD_OPTIONS=$PREV_DEB_BUILD_OPTIONS
+        fi
+      fi
+      # NOW run the real build (but just build the binary package, and don't
       # bother compressing it too much)
       dpkg-buildpackage -b -Zgzip -zfast
       dpkg-deb -x $(pwd)/../snapd_*.deb $SNAPCRAFT_PART_INSTALL


### PR DESCRIPTION
Presently, snapcraft does not allow specifying any environment variables or
anything that can be read or used from inside the snapcraft.yaml to customize
the build, so to accomplish this we use a gitignored top-level directory,
developer-snapd-snap-options which will be copied from the host's system into
the build environment when building a snap, to put files that act like env vars
to customize the build appropriately.

This commit also exposes the "testkeys" and "both-testkeys" options with the
former building a snapd snap that directly uses testkey root of trust.
The latter building a snapd snap with normal root of trust, but also including
the testkeys build snapd deb for CI purposes, as building both like this
minimizes the amount of time we spend building things to get both a normal snapd
snap that folks can download from the PR and use without compromising their
system's trust, and also be able to easily repack into a version that uses the
testkeys snapd for testing.

Relevant timings on my build machine for building the snapd snap with these
options turned on:

testkeys:       12m25.434s
both-testkeys:  15m3.530s + (< 1m for repacking)

Thus, if we just duplicated the whole snap build, it would take ~25 minutes,
whereas building both the testkeys deb and the normal one inside the snapcraft
build env saves us a whole 9-10 minutes. Note that is probably due to all the
overhead of building other things inside the snapd snap, as well as the time it
takes to stand up/setup the build environment by snapcraft.

Originally opened as https://github.com/snapcore/snapd/pull/9458