### PR TITLE
interfaces/seccomp/template.go: allow copy_file_range

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -108,6 +108,10 @@ close
 # needed by ls -l
 connect
 
+# the file descriptors used here will already be mediated by apparmor,
+# the 6th argument is flags, which currently is always 0
+copy_file_range - - - - - 0
+
 chroot
 
 creat
@@ -315,10 +319,6 @@ readahead
 readdir
 readlink
 readlinkat
-
-# the file descriptors used here will already be mediated by apparmor, so it's 
-# safe to not filter syscall args here 
-copy_file_range
 
 # allow reading from sockets
 recv

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -316,6 +316,10 @@ readdir
 readlink
 readlinkat
 
+# the file descriptors used here will already be mediated by apparmor, so it's 
+# safe to not filter syscall args here 
+copy_file_range
+
 # allow reading from sockets
 recv
 recvfrom


### PR DESCRIPTION
This was recently introduced as an optimization to Go 1.15, and so apps that
start compiling may start to try and use it.

Note that Go 1.15 does currently fall back to using other methods if copy_file_range
returns EPERM so that apps that get denied usage of copy_file_range will fallback
to potentially slower implementations. (originally upon Go 1.15 release there
was not a fallback implementation and the app would just crash returning a non-nil
error up the stack).

See https://github.com/golang/go/issues/40893 and
https://go-review.googlesource.com/c/go/+/249257/ for more details on the Go
issue and the fallback implementation.