### PR TITLE
tests: fix uc20-create-parition-* tests for updated gadget

### DIFF
--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -17,9 +17,11 @@ restore: |
         umount ./mnt || true
     fi
     umount /run/mnt/ubuntu-seed || true
+    umount /dev/mapper/ubuntu-save || true
     umount /dev/mapper/ubuntu-data || true
     umount /dev/mapper/test-udata || true
 
+    cryptsetup close /dev/mapper/ubuntu-save || true
     cryptsetup close /dev/mapper/ubuntu-data || true
     cryptsetup close /dev/mapper/test-udata || true
 
@@ -107,14 +109,19 @@ execute: |
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p2 .*size=\s*2457600, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B,.*ubuntu-seed"
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p3 .*size=\s*1536000, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-boot"
-    sfdisk -d "$LOOP" | MATCH "^${LOOP}p4 .*size=\s*15533521, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-data"
+    sfdisk -d "$LOOP" | MATCH "^${LOOP}p4 .*size=\s*32768, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-save"
+    sfdisk -d "$LOOP" | MATCH "^${LOOP}p5 .*size=\s*15500753, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-data"
 
     not cryptsetup isLuks "${LOOP}p1"
     not cryptsetup isLuks "${LOOP}p2"
     not cryptsetup isLuks "${LOOP}p3"
     cryptsetup isLuks "${LOOP}p4"
+    cryptsetup isLuks "${LOOP}p5"
 
-    cryptsetup luksDump "${LOOP}p4" | MATCH 'Label:\s*ubuntu-data-enc'
+    cryptsetup luksDump "${LOOP}p4" | MATCH 'Label:\s*ubuntu-save-enc'
+    POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-save | MATCH 'volume name "ubuntu-save"'
+
+    cryptsetup luksDump "${LOOP}p5" | MATCH 'Label:\s*ubuntu-data-enc'
     POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
 
     cryptsetup close /dev/mapper/ubuntu-data
@@ -123,14 +130,14 @@ execute: |
 
     # Test the unsealed key
     echo "Ensure that we can open the encrypted device using the unsealed key"
-    cryptsetup open --key-file unsealed-key "${LOOP}p4" test
+    cryptsetup open --key-file unsealed-key "${LOOP}p5" test
     mount /dev/mapper/test ./mnt
     umount ./mnt
     cryptsetup close /dev/mapper/test
 
     # Test the recovery key
     echo "Ensure that we can open the encrypted device using the recovery key"
-    cryptsetup open --key-file recovery-key "${LOOP}p4" test-recovery
+    cryptsetup open --key-file recovery-key "${LOOP}p5" test-recovery
     mount /dev/mapper/test-recovery ./mnt
     umount ./mnt
     cryptsetup close /dev/mapper/test-recovery

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -18,6 +18,7 @@ restore: |
     fi
     umount ./ubuntu-seed || true
     umount ./ubuntu-boot || true
+    umount ./ubuntu-save || true
     umount ./ubuntu-data || true
 
 prepare: |
@@ -62,14 +63,16 @@ execute: |
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'
     sfdisk -l "$LOOP" | MATCH '16\.7G Linux filesystem'
     file -s "${LOOP}p3" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-boot"'
-    file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
+    file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-save"'
+    file -s "${LOOP}p5" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
 
     echo "Create canary files on the ubuntu-{seed,boot,data} partitions"
-    mkdir ./ubuntu-seed ./ubuntu-boot ./ubuntu-data
+    mkdir ./ubuntu-seed ./ubuntu-boot ./ubuntu-save ./ubuntu-data
     mount "${LOOP}p2" ./ubuntu-seed
     mount "${LOOP}p3" ./ubuntu-boot
-    mount "${LOOP}p4" ./ubuntu-data
-    for label in ubuntu-seed ubuntu-boot ubuntu-data; do
+    mount "${LOOP}p4" ./ubuntu-save
+    mount "${LOOP}p5" ./ubuntu-data
+    for label in ubuntu-seed ubuntu-boot ubuntu-save ubuntu-data; do
         echo "$label" > ./"$label"/canary.txt
         umount ./"$label"
     done
@@ -81,16 +84,19 @@ execute: |
     echo "And check that the partitions are there"
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'
     sfdisk -l "$LOOP" | MATCH '16\.7G Linux filesystem'
-    sfdisk -l "$LOOP" | not MATCH "${LOOP}p[56789]"
+    sfdisk -l "$LOOP" | NOMATCH "${LOOP}p[6789]"
     file -s "${LOOP}p3" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-boot"'
-    file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
+    file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-save"'
+    file -s "${LOOP}p5" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
 
     echo "Mount partitions again"
     mount "${LOOP}p2" ./ubuntu-seed
     mount "${LOOP}p3" ./ubuntu-boot
-    mount "${LOOP}p4" ./ubuntu-data
+    mount "${LOOP}p4" ./ubuntu-save
+    mount "${LOOP}p5" ./ubuntu-data
     echo "The ubuntu-seed partition is still there untouched"
     test -e ./ubuntu-seed/canary.txt
-    echo "But ubuntu-{boot,data} got re-created"
+    echo "But ubuntu-{boot,save,data} got re-created"
     not test -e ./ubuntu-boot/canary.txt
+    not test -e ./ubuntu-save/canary.txt
     not test -e ./ubuntu-data/canary.txt

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -18,6 +18,7 @@ restore: |
         losetup -d "$LOOP"
         umount "${LOOP}p3"
         umount "${LOOP}p4"
+        umount "${LOOP}p5"
     fi
 
 prepare: |
@@ -59,11 +60,13 @@ execute: |
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'
     sfdisk -l "$LOOP" | MATCH '16.7G Linux filesystem'
     file -s "${LOOP}p3" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-boot"'
-    file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
+    file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-save"'
+    file -s "${LOOP}p5" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
 
     echo "Check that the filesystems were not auto-mounted"
     mount | not MATCH /run/mnt/ubuntu-seed
     mount | not MATCH /run/mnt/ubuntu-boot
+    mount | not MATCH /run/mnt/ubuntu-save
     mount | not MATCH /run/mnt/ubuntu-data
 
     # we used "lsblk --fs" here but it was unreliable
@@ -84,11 +87,19 @@ execute: |
     mount "${LOOP}p4" ./mnt
     df -T "${LOOP}p4" | MATCH ext4
     umount ./mnt
-    file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
+    file -s "${LOOP}p4" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-save"'
     # check metadata_csum
-    tune2fs -l "${LOOP}p3" | MATCH '^Filesystem features:.*metadata_csum'
+    tune2fs -l "${LOOP}p4" | MATCH '^Filesystem features:.*metadata_csum'
+
+    mkdir -p ./mnt
+    mount "${LOOP}p5" ./mnt
+    df -T "${LOOP}p5" | MATCH ext4
+    umount ./mnt
+    file -s "${LOOP}p5" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
+    # check metadata_csum
+    tune2fs -l "${LOOP}p5" | MATCH '^Filesystem features:.*metadata_csum'
     # size is reported in 512 blocks
-    sz="$(udevadm info -q property "${LOOP}p4" |grep "^ID_PART_ENTRY_SIZE=" | cut -f2 -d=)"
+    sz="$(udevadm info -q property "${LOOP}p5" |grep "^ID_PART_ENTRY_SIZE=" | cut -f2 -d=)"
     # the disk size is 20GB, 1GB in 512 blocks is 2097152, with auto grow, the
     # partition can be safely assumed to be > 10GB
     if [ "$sz" -lt "$((10 * 2097152))" ]; then
@@ -117,17 +128,19 @@ execute: |
     sfdisk -l "$LOOP" | MATCH "${LOOP}p1 .* 1M\s* BIOS boot"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p2 .* 1.2G\s* EFI System"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p3 .* 750M\s* Linux filesystem"
-    sfdisk -l "$LOOP" | MATCH "${LOOP}p4 .* 1G\s* Linux filesystem"
-    sfdisk -l "$LOOP" | MATCH "${LOOP}p5 .* 110M\s* Linux filesystem"
+    sfdisk -l "$LOOP" | MATCH "${LOOP}p4 .* 16M\s* Linux filesystem"
+    sfdisk -l "$LOOP" | MATCH "${LOOP}p5 .* 1G\s* Linux filesystem"
+    sfdisk -l "$LOOP" | MATCH "${LOOP}p6 .* 110M\s* Linux filesystem"
 
     echo "check that the filesystems are created and mounted"
     mount
 
     mount | MATCH /run/mnt/ubuntu-boot
+    mount | MATCH /run/mnt/ubuntu-save
     mount | MATCH /run/mnt/ubuntu-data
     mount | MATCH /run/mnt/other-ext4
-    df -T "${LOOP}p5" | MATCH ext4
-    file -s "${LOOP}p5" | MATCH 'volume name "other-ext4"'
+    df -T "${LOOP}p6" | MATCH ext4
+    file -s "${LOOP}p6" | MATCH 'volume name "other-ext4"'
     umount /run/mnt/other-ext4
 
     echo "Make sure the filesystem was redeployed"


### PR DESCRIPTION
The "pc" gadget contains the ubuntu-save partition now. This
shifts the partition tables and the create-partitions test
needs adjustment.

