### PR TITLE
tests/main/uc20-create-partitions: verify ubuntu-save encryption keys, tweak not MATCH

### DIFF
--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -100,10 +100,14 @@ execute: |
         ./gadget-dir "$LOOP"
     # keep for later
 
-    echo "Check that the key file was created"
+    echo "Check that the ubuntu-data key files were created"
     test "$(stat --printf=%s unsealed-key)" -eq 64
     # recovery key is 16 bytes long
     test "$(stat --printf=%s recovery-key)" -eq 16
+    echo "Check that the ubuntu-save key files were created"
+    test "$(stat --printf=%s save-key)" -eq 64
+    # recovery key is 16 bytes long
+    test "$(stat --printf=%s reinstall-key)" -eq 16
 
     echo "Check that the partitions are created"
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
@@ -125,19 +129,34 @@ execute: |
     POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
 
     cryptsetup close /dev/mapper/ubuntu-data
+    cryptsetup close /dev/mapper/ubuntu-save
 
     mkdir -p ./mnt
 
     # Test the unsealed key
-    echo "Ensure that we can open the encrypted device using the unsealed key"
+    echo "Ensure that we can open the encrypted ubuntu-data device using the unsealed key"
     cryptsetup open --key-file unsealed-key "${LOOP}p5" test
     mount /dev/mapper/test ./mnt
     umount ./mnt
     cryptsetup close /dev/mapper/test
 
     # Test the recovery key
-    echo "Ensure that we can open the encrypted device using the recovery key"
+    echo "Ensure that we can open the encrypted ubuntu-data device using the recovery key"
     cryptsetup open --key-file recovery-key "${LOOP}p5" test-recovery
     mount /dev/mapper/test-recovery ./mnt
     umount ./mnt
     cryptsetup close /dev/mapper/test-recovery
+
+    # Test the save key
+    echo "Ensure that we can open the encrypted ubuntu-save device using the run mode key"
+    cryptsetup open --key-file save-key "${LOOP}p4" test-save
+    mount /dev/mapper/test-save ./mnt
+    umount ./mnt
+    cryptsetup close /dev/mapper/test-save
+
+    # Test the reinstall key
+    echo "Ensure that we can open the encrypted ubuntu-save device using the reinstall key"
+    cryptsetup open --key-file reinstall-key "${LOOP}p4" test-reinstall
+    mount /dev/mapper/test-reinstall ./mnt
+    umount ./mnt
+    cryptsetup close /dev/mapper/test-reinstall

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -64,10 +64,10 @@ execute: |
     file -s "${LOOP}p5" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
 
     echo "Check that the filesystems were not auto-mounted"
-    mount | not MATCH /run/mnt/ubuntu-seed
-    mount | not MATCH /run/mnt/ubuntu-boot
-    mount | not MATCH /run/mnt/ubuntu-save
-    mount | not MATCH /run/mnt/ubuntu-data
+    mount | NOMATCH /run/mnt/ubuntu-seed
+    mount | NOMATCH /run/mnt/ubuntu-boot
+    mount | NOMATCH /run/mnt/ubuntu-save
+    mount | NOMATCH /run/mnt/ubuntu-data
 
     # we used "lsblk --fs" here but it was unreliable
     mkdir -p ./mnt


### PR DESCRIPTION
A followup to #9706. Verify that ubuntu-save encryption keys are valid and can open the partitions. Replace `not MATCH` with `NOMATCH`
