### PR TITLE
snapshotstate: improve handling of multiple errors

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -476,7 +476,7 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 
 var ErrCannotCancel = errors.New("cannot cancel: import already finished")
 
-// multiError is a helper to handle mutliple errors.
+// multiError collects multiple errors that affected an operation.
 type multiError struct {
 	header string
 	errs   []error
@@ -484,7 +484,7 @@ type multiError struct {
 
 // newMultiError returns a new multiError struct initialized with
 // the given format string that explains what operation potentially
-// want wrong. multiError can be nested and will render correctly
+// went wrong. multiError can be nested and will render correctly
 // in these cases.
 func newMultiError(header string, errs []error) error {
 	return &multiError{header: header, errs: errs}
@@ -499,8 +499,8 @@ func (me *multiError) Error() string {
 func (me *multiError) nestedError(level int) string {
 	indent := strings.Repeat(" ", level)
 	buf := bytes.NewBufferString(fmt.Sprintf("%s:\n", me.header))
-	if level > 5 {
-		return "cannot nest multi errors deeper than 5 levels"
+	if level > 8 {
+		return "circular or too deep error nesting (max 8)?!"
 	}
 	for i, err := range me.errs {
 		switch v := err.(type) {

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1445,8 +1445,10 @@ func (s *snapshotSuite) TestMultiError(c *check.C) {
 }
 
 func (s *snapshotSuite) TestMultiErrorCycle(c *check.C) {
-	me6 := backend.NewMultiError("he6", []error{fmt.Errorf("e6")})
-	me5 := backend.NewMultiError("he5", []error{me6, fmt.Errorf("e5")})
+	errs := []error{nil, fmt.Errorf("e5")}
+	me5 := backend.NewMultiError("he5", errs)
+	// very hard to happen in practice
+	errs[0] = me5
 	me4 := backend.NewMultiError("he4", []error{me5})
 	me3 := backend.NewMultiError("he3", []error{me4})
 	me2 := backend.NewMultiError("he3", []error{me3})
@@ -1459,6 +1461,12 @@ func (s *snapshotSuite) TestMultiErrorCycle(c *check.C) {
   - he3:
    - he4:
     - he5:
-     - cannot nest multi errors deeper than 5 levels
+     - he5:
+      - he5:
+       - he5:
+        - circular or too deep error nesting \(max 8\)\?!
+        - e5
+       - e5
+      - e5
      - e5`)
 }

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -1445,11 +1445,20 @@ func (s *snapshotSuite) TestMultiError(c *check.C) {
 }
 
 func (s *snapshotSuite) TestMultiErrorCycle(c *check.C) {
-	me1 := backend.NewMultiError("he1", []error{fmt.Errorf("e1")})
-	me := backend.NewMultiError("he", []error{me1, me1})
+	me6 := backend.NewMultiError("he6", []error{fmt.Errorf("e6")})
+	me5 := backend.NewMultiError("he5", []error{me6, fmt.Errorf("e5")})
+	me4 := backend.NewMultiError("he4", []error{me5})
+	me3 := backend.NewMultiError("he3", []error{me4})
+	me2 := backend.NewMultiError("he3", []error{me3})
+	me1 := backend.NewMultiError("he1", []error{me2})
+	me := backend.NewMultiError("he", []error{me1})
 
 	c.Check(me, check.ErrorMatches, `he:
 - he1:
- - e1
-- cycle detected to "he1"`)
+ - he3:
+  - he3:
+   - he4:
+    - he5:
+     - cannot nest multi errors deeper than 5 levels
+     - e5`)
 }

--- a/overlord/snapshotstate/backend/export_test.go
+++ b/overlord/snapshotstate/backend/export_test.go
@@ -130,3 +130,11 @@ func MockSnapshot(setID uint64, snapName string, revision snap.Revision, size in
 		Size:     size,
 	}
 }
+
+func MockFilepathGlob(new func(pattern string) (matches []string, err error)) (restore func()) {
+	oldFilepathGlob := filepathGlob
+	filepathGlob = new
+	return func() {
+		filepathGlob = oldFilepathGlob
+	}
+}

--- a/overlord/snapshotstate/backend/export_test.go
+++ b/overlord/snapshotstate/backend/export_test.go
@@ -35,6 +35,8 @@ var (
 	PickUserWrapper = pickUserWrapper
 
 	IsSnapshotFilename = isSnapshotFilename
+
+	NewMultiError = newMultiError
 )
 
 func MockIsTesting(newIsTesting bool) func() {


### PR DESCRIPTION
The snaphsot backend cleanup code may run into multiple errors
that should be captured but where the code should not stop.

When returning those to the user the formating easily becomes
messed up. This commit adds code and tests to make sure this
works better.

Followup to PR #9526 