### PR TITLE
seed/seedwriter: consider modes when checking for deps availability

### DIFF
--- a/seed/seedwriter/helpers.go
+++ b/seed/seedwriter/helpers.go
@@ -21,6 +21,7 @@ package seedwriter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
@@ -118,6 +119,13 @@ func checkType(sn *SeedSnap, model *asserts.Model) error {
 		return fmt.Errorf("%s has unexpected type: %s", what, sn.Info.Type())
 	}
 	return nil
+}
+
+func errorMsgForModesSuffix(modes []string) string {
+	if len(modes) == 1 && modes[0] == "run" {
+		return ""
+	}
+	return fmt.Sprintf(" for all relevant modes (%s)", strings.Join(modes, ", "))
 }
 
 type seedSnapsByType []*SeedSnap

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -111,9 +111,16 @@ func (pol *policy20) checkAvailable(snapRef naming.SnapRef, modes []string, avai
 		byMode := availableByMode[mode]
 		if !byMode.Contains(snapRef) {
 			if mode == "run" || mode == "ephemeral" {
+				// no additional fallback for these
+				// cases:
+				// * run is not ephemeral,
+				//   is covered only by run
+				// * ephemeral is only covered by ephemeral
 				return false
 			}
-			// consider ephemeral as well
+			// all non-run modes (e.g. recover) are
+			// considered ephemeral, as a fallback check
+			// if the snap is listed under the ephemeral mode label
 			ephem := availableByMode["ephemeral"]
 			if ephem == nil || !ephem.Contains(snapRef) {
 				return false

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -850,6 +850,7 @@ func (w *Writer) downloaded(seedSnaps []*SeedSnap) error {
 	if w.availableSnaps == nil {
 		w.availableSnaps = naming.NewSnapSet(nil)
 		w.availableByMode = make(map[string]*naming.SnapSet)
+		w.availableByMode["run"] = naming.NewSnapSet(nil)
 	}
 
 	for _, sn := range seedSnaps {

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -90,6 +90,13 @@ type SeedSnap struct {
 	optionSnap *OptionsSnap
 }
 
+func (sn *SeedSnap) modes() []string {
+	if sn.modelSnap == nil {
+		return []string{"run"}
+	}
+	return sn.modelSnap.Modes
+}
+
 var _ naming.SnapRef = (*SeedSnap)(nil)
 
 /* Writer writes Core 16/18 and Core 20 seeds.
@@ -172,7 +179,8 @@ type Writer struct {
 	localSnaps      map[*OptionsSnap]*SeedSnap
 	byRefLocalSnaps *naming.SnapSet
 
-	availableSnaps *naming.SnapSet
+	availableSnaps  *naming.SnapSet
+	availableByMode map[string]*naming.SnapSet
 
 	// toDownload tracks which set of snaps SnapsToDownload should compute
 	// next
@@ -194,11 +202,13 @@ type policy interface {
 	modelSnapDefaultChannel() string
 	extraSnapDefaultChannel() string
 
-	checkBase(*snap.Info, *naming.SnapSet) error
+	checkBase(s *snap.Info, modes []string, availableByMode map[string]*naming.SnapSet) error
 
-	needsImplicitSnaps(*naming.SnapSet) (bool, error)
-	implicitSnaps(*naming.SnapSet) []*asserts.ModelSnap
-	implicitExtraSnaps(*naming.SnapSet) []*OptionsSnap
+	checkAvailable(snpRef naming.SnapRef, modes []string, availableByMode map[string]*naming.SnapSet) bool
+
+	needsImplicitSnaps(availableByMode map[string]*naming.SnapSet) (bool, error)
+	implicitSnaps(availableByMode map[string]*naming.SnapSet) []*asserts.ModelSnap
+	implicitExtraSnaps(availableByMode map[string]*naming.SnapSet) []*OptionsSnap
 }
 
 type tree interface {
@@ -769,11 +779,11 @@ func (w *Writer) SnapsToDownload() (snaps []*SeedSnap, err error) {
 		}
 		return toDownload, nil
 	case toDownloadImplicit:
-		return w.modelSnapsToDownload(w.policy.implicitSnaps(w.availableSnaps))
+		return w.modelSnapsToDownload(w.policy.implicitSnaps(w.availableByMode))
 	case toDownloadExtra:
 		return w.extraSnapsToDownload(w.optExtraSnaps())
 	case toDownloadExtraImplicit:
-		return w.extraSnapsToDownload(w.policy.implicitExtraSnaps(w.availableSnaps))
+		return w.extraSnapsToDownload(w.policy.implicitExtraSnaps(w.availableByMode))
 	default:
 		panic(fmt.Sprintf("unknown to-download set: %d", w.toDownload))
 	}
@@ -820,7 +830,7 @@ func (w *Writer) resolveChannel(whichSnap string, modSnap *asserts.ModelSnap, op
 	return resChannel, nil
 }
 
-func (w *Writer) checkBase(info *snap.Info) error {
+func (w *Writer) checkBase(info *snap.Info, modes []string) error {
 	// Sanity check, note that we could support this case
 	// if we have a use-case but it requires changes in the
 	// devicestate/firstboot.go ordering code.
@@ -833,12 +843,13 @@ func (w *Writer) checkBase(info *snap.Info) error {
 		return nil
 	}
 
-	return w.policy.checkBase(info, w.availableSnaps)
+	return w.policy.checkBase(info, modes, w.availableByMode)
 }
 
 func (w *Writer) downloaded(seedSnaps []*SeedSnap) error {
 	if w.availableSnaps == nil {
 		w.availableSnaps = naming.NewSnapSet(nil)
+		w.availableByMode = make(map[string]*naming.SnapSet)
 	}
 
 	for _, sn := range seedSnaps {
@@ -846,6 +857,14 @@ func (w *Writer) downloaded(seedSnaps []*SeedSnap) error {
 			return fmt.Errorf("internal error: before seedwriter.Writer.Downloaded snap %q Info should have been set", sn.SnapName())
 		}
 		w.availableSnaps.Add(sn)
+		for _, mode := range sn.modes() {
+			byMode := w.availableByMode[mode]
+			if byMode == nil {
+				byMode = naming.NewSnapSet(nil)
+				w.availableByMode[mode] = byMode
+			}
+			byMode.Add(sn)
+		}
 	}
 
 	for _, sn := range seedSnaps {
@@ -873,14 +892,16 @@ func (w *Writer) downloaded(seedSnaps []*SeedSnap) error {
 			return fmt.Errorf("cannot use classic snap %q in a core system", info.SnapName())
 		}
 
-		if err := w.checkBase(info); err != nil {
+		modes := sn.modes()
+
+		if err := w.checkBase(info, modes); err != nil {
 			return err
 		}
 		// error about missing default providers
 		for dp := range snap.NeededDefaultProviders(info) {
-			if !w.availableSnaps.Contains(naming.Snap(dp)) {
+			if !w.policy.checkAvailable(naming.Snap(dp), modes, w.availableByMode) {
 				// TODO: have a way to ignore this issue on a snap by snap basis?
-				return fmt.Errorf("cannot use snap %q without its default content provider %q being added explicitly", info.SnapName(), dp)
+				return fmt.Errorf("cannot use snap %q without its default content provider %q being added explicitly%s", info.SnapName(), dp, errorMsgForModesSuffix(modes))
 			}
 		}
 
@@ -925,7 +946,7 @@ func (w *Writer) Downloaded() (complete bool, err error) {
 
 	switch w.toDownload {
 	case toDownloadModel:
-		implicitNeeded, err := w.policy.needsImplicitSnaps(w.availableSnaps)
+		implicitNeeded, err := w.policy.needsImplicitSnaps(w.availableByMode)
 		if err != nil {
 			return false, err
 		}
@@ -942,7 +963,7 @@ func (w *Writer) Downloaded() (complete bool, err error) {
 			return false, nil
 		}
 	case toDownloadExtra:
-		implicitNeeded, err := w.policy.needsImplicitSnaps(w.availableSnaps)
+		implicitNeeded, err := w.policy.needsImplicitSnaps(w.availableByMode)
 		if err != nil {
 			return false, err
 		}

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -92,6 +92,8 @@ type SeedSnap struct {
 
 func (sn *SeedSnap) modes() []string {
 	if sn.modelSnap == nil {
+		// run is the assumed mode for extra snaps not listed
+		// in the model
 		return []string{"run"}
 	}
 	return sn.modelSnap.Modes

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -2027,6 +2027,101 @@ func (s *writerSuite) TestDownloadedCore20CheckBase(c *C) {
 	c.Check(err, ErrorMatches, `cannot add snap "cont-producer" without also adding its base "core18" explicitly`)
 }
 
+func (s *writerSuite) TestDownloadedCore20CheckBaseModes(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"store":        "my-store",
+		"base":         "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name": "core18",
+				"id":   s.AssertedSnapID("core18"),
+				"type": "base",
+			},
+			map[string]interface{}{
+				"name":  "cont-producer",
+				"id":    s.AssertedSnapID("cont-producer"),
+				"modes": []interface{}{"run", "ephemeral"},
+			},
+		},
+	})
+
+	// sanity
+	c.Assert(model.Grade(), Equals, asserts.ModelSigned)
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "core18", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "cont-producer", "developerid")
+
+	s.opts.Label = "20191003"
+	_, _, err := s.upToDownloaded(c, model, s.fillDownloadedSnap)
+	c.Check(err, ErrorMatches, `cannot add snap "cont-producer" without also adding its base "core18" explicitly for all relevant modes \(run, ephemeral\)`)
+}
+
+func (s *writerSuite) TestDownloadedCore20CheckBaseEphemeralOK(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"store":        "my-store",
+		"base":         "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":  "core18",
+				"id":    s.AssertedSnapID("core18"),
+				"type":  "base",
+				"modes": []interface{}{"ephemeral"},
+			},
+			map[string]interface{}{
+				"name":  "cont-producer",
+				"id":    s.AssertedSnapID("cont-producer"),
+				"modes": []interface{}{"recover"},
+			},
+		},
+	})
+
+	// sanity
+	c.Assert(model.Grade(), Equals, asserts.ModelSigned)
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "core18", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "cont-producer", "developerid")
+
+	s.opts.Label = "20191003"
+	_, _, err := s.upToDownloaded(c, model, s.fillDownloadedSnap)
+	c.Check(err, IsNil)
+}
+
 func (s *writerSuite) TestDownloadedCore20CheckBaseCoreXX(c *C) {
 	s.makeSnap(c, "snapd", "")
 	s.makeSnap(c, "core20", "")
@@ -2095,6 +2190,58 @@ func (s *writerSuite) TestDownloadedCore20CheckBaseCoreXX(c *C) {
 			c.Check(err, ErrorMatches, t.err)
 		}
 	}
+}
+func (s *writerSuite) TestDownloadedCore20MissingDefaultProviderModes(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"store":        "my-store",
+		"base":         "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":  "core18",
+				"id":    s.AssertedSnapID("core18"),
+				"type":  "base",
+				"modes": []interface{}{"run", "ephemeral"},
+			},
+			map[string]interface{}{
+				"name": "cont-producer",
+				"id":   s.AssertedSnapID("cont-producer"),
+			},
+			map[string]interface{}{
+				"name":  "cont-consumer",
+				"id":    s.AssertedSnapID("cont-consumer"),
+				"modes": []interface{}{"recover"},
+			},
+		},
+	})
+
+	// sanity
+	c.Assert(model.Grade(), Equals, asserts.ModelSigned)
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "core18", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "cont-producer", "developerid")
+	s.makeSnap(c, "cont-consumer", "developerid")
+
+	s.opts.Label = "20191003"
+	_, _, err := s.upToDownloaded(c, model, s.fillDownloadedSnap)
+	c.Check(err, ErrorMatches, `cannot use snap "cont-consumer" without its default content provider "cont-producer" being added explicitly for all relevant modes \(recover\)`)
 }
 
 func (s *writerSuite) TestCore20NonDangerousDisallowedDevmodeSnaps(c *C) {


### PR DESCRIPTION
the code before wasn't taking into account the modes in which
the base or default content providers were available vs
the modes of the dependent snap, with the changes here
it now does

fixes LP: #1883970
