### PR TITLE
client: reduce again the /v2/system-info timeout

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2018 Canonical Ltd
+ * Copyright (C) 2015-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -698,7 +698,11 @@ func parseError(r *http.Response) error {
 func (client *Client) SysInfo() (*SysInfo, error) {
 	var sysInfo SysInfo
 
-	if _, err := client.doSync("GET", "/v2/system-info", nil, nil, nil, &sysInfo); err != nil {
+	opts := &doOptions{
+		Timeout: 25 * time.Second,
+		Retry:   doRetry,
+	}
+	if _, err := client.doSyncWithOpts("GET", "/v2/system-info", nil, nil, nil, &sysInfo, opts); err != nil {
 		return nil, fmt.Errorf("cannot obtain system details: %v", err)
 	}
 


### PR DESCRIPTION
we increased the default client pkg timeout to deal with slow machines,
but /v2/system-info request timeout influences how long
snap version will take to come back if snapd is not running at all

reduce to 25 secs

ideally all the client methods should take context so that each
caller can set up a caller specific timeout if desired, that is much more
involved though

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
