### PR TITLE
hookstate: add new HookManager.EphemeralRunHook()

### DIFF
--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -137,7 +137,13 @@ func (c *Context) writing() {
 	}
 }
 
-func (c *Context) initContextData(m map[string]interface{}) error {
+func (c *Context) initEphemeralContextData(m map[string]interface{}) error {
+	if m == nil {
+		return nil
+	}
+	if !c.IsEphemeral() {
+		return fmt.Errorf("internal error: called initEphemeralContextData for non-ephemeral context %v", c)
+	}
 	serialized, err := json.Marshal(m)
 	if err != nil {
 		return err
@@ -146,12 +152,7 @@ func (c *Context) initContextData(m map[string]interface{}) error {
 	if err := json.Unmarshal(serialized, &data); err != nil {
 		return err
 	}
-
-	if c.IsEphemeral() {
-		c.cache["ephemeral-context"] = data
-	} else {
-		c.task.Set("hook-context", &data)
-	}
+	c.cache["ephemeral-context"] = data
 	return nil
 }
 

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -137,14 +137,17 @@ func (c *Context) writing() {
 	}
 }
 
-func (c *Context) initEphemeralContextData(m map[string]interface{}) error {
-	if m == nil {
+func (c *Context) initForRun(handler Handler, contextData map[string]interface{}) error {
+	c.handler = handler
+	if contextData == nil {
 		return nil
 	}
+
 	if !c.IsEphemeral() {
-		return fmt.Errorf("internal error: called initEphemeralContextData for non-ephemeral context %v", c)
+		return fmt.Errorf("internal error: cannot pass contextData to initForRun for %v", c)
 	}
-	serialized, err := json.Marshal(m)
+
+	serialized, err := json.Marshal(contextData)
 	if err != nil {
 		return err
 	}

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -137,7 +137,7 @@ func (c *Context) writing() {
 	}
 }
 
-func (c *Context) InitContextData(m map[string]interface{}) error {
+func (c *Context) initContextData(m map[string]interface{}) error {
 	serialized, err := json.Marshal(m)
 	if err != nil {
 		return err

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -137,6 +137,24 @@ func (c *Context) writing() {
 	}
 }
 
+func (c *Context) InitContextData(m map[string]interface{}) error {
+	serialized, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	var data map[string]*json.RawMessage
+	if err := json.Unmarshal(serialized, &data); err != nil {
+		return err
+	}
+
+	if c.IsEphemeral() {
+		c.cache["ephemeral-context"] = data
+	} else {
+		c.task.Set("hook-context", &data)
+	}
+	return nil
+}
+
 // Set associates value with key. The provided value must properly marshal and
 // unmarshal with encoding/json. Note that the context needs to be locked and
 // unlocked by the caller.

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -291,7 +291,7 @@ func (m *HookManager) EphemeralRunHook(ctx context.Context, hooksup *HookSetup, 
 	err := snapstate.Get(m.state, hooksup.Snap, &snapst)
 	m.state.Unlock()
 	if err != nil {
-		return nil, fmt.Errorf("cannot run ephemeral hook %s: %v", hooksup.Hook, err)
+		return nil, fmt.Errorf("cannot run ephemeral hook %q for snap %q: %v", hooksup.Hook, hooksup.Snap, err)
 	}
 
 	return m.runHookCommon(nil, tomb, &snapst, hooksup, contextData)

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -343,7 +343,7 @@ func (m *HookManager) runHookReturnContext(task *state.Task, tomb *tomb.Tomb, sn
 	}
 	// XXX: ugly
 	if contextData != nil {
-		context.InitContextData(contextData)
+		context.initContextData(contextData)
 	}
 
 	// Obtain a handler for this hook. The repository returns a list since it's

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -341,9 +341,11 @@ func (m *HookManager) runHookReturnContext(task *state.Task, tomb *tomb.Tomb, sn
 	if err != nil {
 		return nil, err
 	}
-	// XXX: ugly
-	if contextData != nil {
-		context.initContextData(contextData)
+	// init of conextData is only needed for ephemeral hooks, task
+	// based ones get the ephemeral data via HookTask() and it's
+	// stored in the task
+	if err := context.initEphemeralContextData(contextData); err != nil {
+		return nil, err
 	}
 
 	// Obtain a handler for this hook. The repository returns a list since it's

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -284,8 +284,6 @@ func (m *HookManager) undoRunHook(task *state.Task, tomb *tomb.Tomb) error {
 }
 
 func (m *HookManager) EphemeralRunHook(ctx context.Context, hooksup *HookSetup, contextData map[string]interface{}) (*Context, error) {
-	tomb, _ := tomb.WithContext(ctx)
-
 	var snapst snapstate.SnapState
 	m.state.Lock()
 	err := snapstate.Get(m.state, hooksup.Snap, &snapst)
@@ -294,6 +292,7 @@ func (m *HookManager) EphemeralRunHook(ctx context.Context, hooksup *HookSetup, 
 		return nil, fmt.Errorf("cannot run ephemeral hook %q for snap %q: %v", hooksup.Hook, hooksup.Snap, err)
 	}
 
+	tomb, _ := tomb.WithContext(ctx)
 	return m.runHookCommon(nil, tomb, &snapst, hooksup, contextData)
 }
 

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -341,12 +341,6 @@ func (m *HookManager) runHookReturnContext(task *state.Task, tomb *tomb.Tomb, sn
 	if err != nil {
 		return nil, err
 	}
-	// init of conextData is only needed for ephemeral hooks, task
-	// based ones get the ephemeral data via HookTask() and it's
-	// stored in the task
-	if err := context.initEphemeralContextData(contextData); err != nil {
-		return nil, err
-	}
 
 	// Obtain a handler for this hook. The repository returns a list since it's
 	// possible for regular expressions to overlap, but multiple handlers is an
@@ -365,7 +359,9 @@ func (m *HookManager) runHookReturnContext(task *state.Task, tomb *tomb.Tomb, sn
 	if handlersCount > 1 {
 		return nil, fmt.Errorf("internal error: %d handlers registered for hook %q, expected 1", handlersCount, hooksup.Hook)
 	}
-	context.handler = handlers[0]
+	if err := context.initForRun(handlers[0], contextData); err != nil {
+		return nil, err
+	}
 
 	contextID := context.ID()
 	m.contextsMutex.Lock()

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -1227,7 +1227,7 @@ func (s *hookManagerSuite) testEphemeralRunHook(c *C, contextData map[string]int
 
 func (s *hookManagerSuite) TestEphemeralRunHookNoSnap(c *C) {
 	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
-		c.Fatalf("hook should not be invoced in this test")
+		c.Fatalf("hook should not be invoked in this test")
 		return nil, nil
 	}
 	restore := hookstate.MockRunHook(hookInvoke)


### PR DESCRIPTION
This commit adds support to run hooks in an ephemeral mode. This
will be used by the fde-setup hook runner in PR#9705.
