### PR TITLE
many: rename disks.FindMatching... to FindMatching...WithFsLabel and err type

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -485,7 +485,7 @@ func (m *recoverModeStateMachine) verifyMountPoint(dir, name string) error {
 func (m *recoverModeStateMachine) setFindState(partName, partUUID string, err error) error {
 	part := m.degradedState.partition(partName)
 	if err != nil {
-		if _, ok := err.(disks.FilesystemLabelNotFoundError); ok {
+		if _, ok := err.(disks.PartitionNotFoundError); ok {
 			// explicit error that the device was not found
 			part.FindState = partitionNotFound
 			m.degradedState.LogErrorf("cannot find %v partition on disk %s", partName, m.disk.Dev())
@@ -755,7 +755,7 @@ func (m *recoverModeStateMachine) mountBoot() (stateFunc, error) {
 	part := m.degradedState.partition("ubuntu-boot")
 	// use the disk we mounted ubuntu-seed from as a reference to find
 	// ubuntu-seed and mount it
-	partUUID, findErr := m.disk.FindMatchingPartitionUUID("ubuntu-boot")
+	partUUID, findErr := m.disk.FindMatchingPartitionUUIDFromFsLabel("ubuntu-boot")
 	if err := m.setFindState("ubuntu-boot", partUUID, findErr); err != nil {
 		return nil, err
 	}
@@ -1226,9 +1226,9 @@ func maybeMountSave(disk disks.Disk, rootdir string, encrypted bool, mountOpts *
 		}
 		saveDevice = unlockRes.FsDevice
 	} else {
-		partUUID, err := disk.FindMatchingPartitionUUID("ubuntu-save")
+		partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel("ubuntu-save")
 		if err != nil {
-			if _, ok := err.(disks.FilesystemLabelNotFoundError); ok {
+			if _, ok := err.(disks.PartitionNotFoundError); ok {
 				// this is ok, ubuntu-save may not exist for
 				// non-encrypted device
 				return false, nil
@@ -1259,7 +1259,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 	// 2. mount ubuntu-seed
 	// use the disk we mounted ubuntu-boot from as a reference to find
 	// ubuntu-seed and mount it
-	partUUID, err := disk.FindMatchingPartitionUUID("ubuntu-seed")
+	partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel("ubuntu-seed")
 	if err != nil {
 		return err
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -755,7 +755,7 @@ func (m *recoverModeStateMachine) mountBoot() (stateFunc, error) {
 	part := m.degradedState.partition("ubuntu-boot")
 	// use the disk we mounted ubuntu-seed from as a reference to find
 	// ubuntu-seed and mount it
-	partUUID, findErr := m.disk.FindMatchingPartitionUUIDFromFsLabel("ubuntu-boot")
+	partUUID, findErr := m.disk.FindMatchingPartitionUUIDWithFsLabel("ubuntu-boot")
 	if err := m.setFindState("ubuntu-boot", partUUID, findErr); err != nil {
 		return nil, err
 	}
@@ -1226,7 +1226,7 @@ func maybeMountSave(disk disks.Disk, rootdir string, encrypted bool, mountOpts *
 		}
 		saveDevice = unlockRes.FsDevice
 	} else {
-		partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel("ubuntu-save")
+		partUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel("ubuntu-save")
 		if err != nil {
 			if _, ok := err.(disks.PartitionNotFoundError); ok {
 				// this is ok, ubuntu-save may not exist for
@@ -1259,7 +1259,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 	// 2. mount ubuntu-seed
 	// use the disk we mounted ubuntu-boot from as a reference to find
 	// ubuntu-seed and mount it
-	partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel("ubuntu-seed")
+	partUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel("ubuntu-seed")
 	if err != nil {
 		return err
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -2584,7 +2584,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
 
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 		c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -2599,7 +2599,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 	saveActivated := false
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -2719,7 +2719,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// pretend we can't unlock ubuntu-data with the main run key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -2729,7 +2729,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// now we can unlock ubuntu-data with the fallback key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -2749,7 +2749,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -2885,7 +2885,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 			// ubuntu data can be unlocked fine
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -2899,7 +2899,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 			c.Assert(saveActivationAttempted, Equals, true)
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -2919,7 +2919,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -3065,7 +3065,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			// directly to using the fallback key on ubuntu-seed
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3085,7 +3085,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -3222,7 +3222,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			// directly to using the fallback key on ubuntu-seed
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3244,7 +3244,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -3370,7 +3370,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// ubuntu data can't be unlocked with run key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -3381,7 +3381,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// nor can it be unlocked with fallback key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3394,7 +3394,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// we can however still unlock ubuntu-save (somehow?)
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3575,11 +3575,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedAbsentDataS
 			// ubuntu data can't be found at all
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			_, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
 			// sanity check that we can't find a normal ubuntu-data either
-			_, err = disk.FindMatchingPartitionUUIDFromFsLabel(name)
+			_, err = disk.FindMatchingPartitionUUIDWithFsLabel(name)
 			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
 			dataActivated = true
 			// data not found at all
@@ -3589,9 +3589,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedAbsentDataS
 			// we can however still mount unecrypted ubuntu-save
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			_, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
-			unencDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name)
+			unencDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name)
 			c.Assert(err, IsNil)
 			c.Assert(unencDevPartUUID, Equals, "ubuntu-save-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3770,11 +3770,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedUnencrypted
 			// ubuntu data is a plain old unencrypted partition
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			_, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
 			// sanity check that we can't find a normal ubuntu-data either
-			partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name)
+			partUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name)
 			c.Assert(err, IsNil)
 			c.Assert(partUUID, Equals, "ubuntu-data-partuuid")
 			dataActivated = true
@@ -3785,9 +3785,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedUnencrypted
 			// we can however still find/unlock ubuntu-save with the recovery key
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name)
+			_, err := disk.FindMatchingPartitionUUIDWithFsLabel(name)
 			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3927,7 +3927,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			// ubuntu data can't be found at all
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			_, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
 			dataActivated = true
@@ -3938,7 +3938,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			// we can however still unlock ubuntu-save with the fallback key
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -4110,7 +4110,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// ubuntu data can't be unlocked with run key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -4121,7 +4121,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// nor can it be unlocked with fallback key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -4136,7 +4136,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// no attempts to activate ubuntu-save yet
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -4298,7 +4298,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedMismatched
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
 
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 		c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -4313,7 +4313,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedMismatched
 	saveActivated := false
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -4491,7 +4491,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	activated := false
 	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		c.Assert(name, Equals, "ubuntu-data")
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 		c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -4505,7 +4505,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	s.mockUbuntuSaveMarker(c, boot.InitramfsUbuntuSaveDir, "marker")
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
-		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -2584,7 +2584,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
 
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 		c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -2599,7 +2599,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 	saveActivated := false
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -2719,7 +2719,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// pretend we can't unlock ubuntu-data with the main run key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -2729,7 +2729,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// now we can unlock ubuntu-data with the fallback key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -2749,7 +2749,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -2885,7 +2885,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 			// ubuntu data can be unlocked fine
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -2899,7 +2899,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 			c.Assert(saveActivationAttempted, Equals, true)
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -2919,7 +2919,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -3065,7 +3065,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			// directly to using the fallback key on ubuntu-seed
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3085,7 +3085,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -3222,7 +3222,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			// directly to using the fallback key on ubuntu-seed
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3244,7 +3244,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -3370,7 +3370,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// ubuntu data can't be unlocked with run key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -3381,7 +3381,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// nor can it be unlocked with fallback key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3394,7 +3394,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// we can however still unlock ubuntu-save (somehow?)
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3575,12 +3575,12 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedAbsentDataS
 			// ubuntu data can't be found at all
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUID(name + "-enc")
-			c.Assert(err, FitsTypeOf, disks.FilesystemLabelNotFoundError{})
+			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
 			// sanity check that we can't find a normal ubuntu-data either
-			_, err = disk.FindMatchingPartitionUUID(name)
-			c.Assert(err, FitsTypeOf, disks.FilesystemLabelNotFoundError{})
+			_, err = disk.FindMatchingPartitionUUIDFromFsLabel(name)
+			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
 			dataActivated = true
 			// data not found at all
 			return notFoundPart(), fmt.Errorf("error enumerating to find ubuntu-data")
@@ -3589,9 +3589,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedAbsentDataS
 			// we can however still mount unecrypted ubuntu-save
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUID(name + "-enc")
-			c.Assert(err, FitsTypeOf, disks.FilesystemLabelNotFoundError{})
-			unencDevPartUUID, err := disk.FindMatchingPartitionUUID(name)
+			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
+			unencDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name)
 			c.Assert(err, IsNil)
 			c.Assert(unencDevPartUUID, Equals, "ubuntu-save-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3770,11 +3770,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedUnencrypted
 			// ubuntu data is a plain old unencrypted partition
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUID(name + "-enc")
-			c.Assert(err, FitsTypeOf, disks.FilesystemLabelNotFoundError{})
+			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
 			// sanity check that we can't find a normal ubuntu-data either
-			partUUID, err := disk.FindMatchingPartitionUUID(name)
+			partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name)
 			c.Assert(err, IsNil)
 			c.Assert(partUUID, Equals, "ubuntu-data-partuuid")
 			dataActivated = true
@@ -3785,9 +3785,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedUnencrypted
 			// we can however still find/unlock ubuntu-save with the recovery key
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUID(name)
-			c.Assert(err, FitsTypeOf, disks.FilesystemLabelNotFoundError{})
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name)
+			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -3927,8 +3927,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			// ubuntu data can't be found at all
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			_, err := disk.FindMatchingPartitionUUID(name + "-enc")
-			c.Assert(err, FitsTypeOf, disks.FilesystemLabelNotFoundError{})
+			_, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+			c.Assert(err, FitsTypeOf, disks.PartitionNotFoundError{})
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
 			dataActivated = true
 			// data not found at all
@@ -3938,7 +3938,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			// we can however still unlock ubuntu-save with the fallback key
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -4110,7 +4110,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// ubuntu data can't be unlocked with run key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -4121,7 +4121,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// nor can it be unlocked with fallback key
 			c.Assert(name, Equals, "ubuntu-data")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -4136,7 +4136,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			// no attempts to activate ubuntu-save yet
 			c.Assert(name, Equals, "ubuntu-save")
 			c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
-			encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+			encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 			c.Assert(err, IsNil)
 			c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 			c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -4298,7 +4298,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedMismatched
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
 
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 		c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -4313,7 +4313,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedMismatched
 	saveActivated := false
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
 		c.Check(dataActivated, Equals, true, Commentf("ubuntu-data not activated yet"))
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))
@@ -4491,7 +4491,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	activated := false
 	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		c.Assert(name, Equals, "ubuntu-data")
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-data-enc-partuuid")
 		c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{})
@@ -4505,7 +4505,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	s.mockUbuntuSaveMarker(c, boot.InitramfsUbuntuSaveDir, "marker")
 
 	restore = main.MockSecbootUnlockEncryptedVolumeUsingKey(func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {
-		encDevPartUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+		encDevPartUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
 		c.Assert(encDevPartUUID, Equals, "ubuntu-save-enc-partuuid")
 		c.Assert(key, DeepEquals, []byte("foo"))

--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -34,13 +34,13 @@ type Options struct {
 //            for a disk for better user error reporting, i.e. /dev/vda3 is much
 //            more helpful than 252:3
 type Disk interface {
-	// FindMatchingPartitionUUIDFromFsLabel finds the partition uuid for a
+	// FindMatchingPartitionUUIDWithFsLabel finds the partition uuid for a
 	// partition matching the specified filesystem label on the disk. Note that
 	// for non-ascii labels like "Some label", the label will be encoded using
 	// \x<hex> for potentially non-safe characters like in "Some\x20Label".
 	// If the filesystem label was not found on the disk, and no other errors
 	// were encountered, a FilesystemLabelNotFoundError will be returned.
-	FindMatchingPartitionUUIDFromFsLabel(string) (string, error)
+	FindMatchingPartitionUUIDWithFsLabel(string) (string, error)
 
 	// MountPointIsFromDisk returns whether the specified mountpoint corresponds
 	// to a partition on the disk. Note that this only considers partitions

--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -30,9 +30,6 @@ type Options struct {
 }
 
 // Disk is a single physical disk device that contains partitions.
-// TODO:UC20: add function to get some properties like an associated /dev node
-//            for a disk for better user error reporting, i.e. /dev/vda3 is much
-//            more helpful than 252:3
 type Disk interface {
 	// FindMatchingPartitionUUIDWithFsLabel finds the partition uuid for a
 	// partition matching the specified filesystem label on the disk. Note that
@@ -46,9 +43,9 @@ type Disk interface {
 	// to a partition on the disk. Note that this only considers partitions
 	// and mountpoints found when the disk was identified with
 	// DiskFromMountPoint.
-	// TODO:UC20: make this function return what a Disk of where the mount point
-	//            is actually from if it is not from the same disk for better
-	//            error reporting
+	// TODO: make this function return what a Disk of where the mount point
+	//       is actually from if it is not from the same disk for better
+	//       error reporting
 	MountPointIsFromDisk(string, *Options) (bool, error)
 
 	// Dev returns the string "major:minor" number for the disk device.
@@ -58,6 +55,10 @@ type Disk interface {
 	// disk will have partitions, but a mapper device will just be a volume that
 	// does not have partitions for example.
 	HasPartitions() bool
+
+	// TODO: add function to get some properties like an associated /dev node
+	//       for a disk for better user error reporting, i.e. /dev/vda3 is much
+	//       more helpful than 252:3
 }
 
 // PartitionNotFoundError is an error where a partition matching the SearchType

--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -36,7 +36,7 @@ type Disk interface {
 	// for non-ascii labels like "Some label", the label will be encoded using
 	// \x<hex> for potentially non-safe characters like in "Some\x20Label".
 	// If the filesystem label was not found on the disk, and no other errors
-	// were encountered, a FilesystemLabelNotFoundError will be returned.
+	// were encountered, a PartitionNotFoundError will be returned.
 	FindMatchingPartitionUUIDWithFsLabel(string) (string, error)
 
 	// MountPointIsFromDisk returns whether the specified mountpoint corresponds

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -419,6 +419,10 @@ func (d *disk) populatePartitions() error {
 			// last while populating will be the one that the Find*()
 			// functions locate first while iterating over the disk's partitions
 			// this behavior matches what udev does
+			// TODO: perhaps we should just explicitly not support disks with
+			// non-unique filesystem labels or non-unique partition labels (or
+			// even non-unique partition uuids)? then we would just error if we
+			// encounter a duplicated value for a partition
 			d.partitions = append([]partition{part}, d.partitions...)
 		}
 	}
@@ -472,5 +476,8 @@ func (d *disk) Dev() string {
 }
 
 func (d *disk) HasPartitions() bool {
+	// TODO: instead of saving this value when we create/discover the disk, we
+	//       could instead populate the partitions here and then return whether
+	//       d.partitions is empty or not
 	return d.hasPartitions
 }

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -163,8 +163,8 @@ type disk struct {
 	major int
 	minor int
 	// partitions is the set of discovered partitions for the disk, each
-	// partition must have a partition label and partition uuid, and may or may
-	// not have a filesystem label
+	// partition must have a partition uuid, but may or may not have either a
+	// partition label or a filesystem label
 	partitions []partition
 
 	// whether the disk device has partitions, and thus is of type "disk", or
@@ -392,10 +392,10 @@ func (d *disk) populatePartitions() error {
 
 			// we should always have the partition uuid, and we may not have
 			// either the partition label or the filesystem label, on GPT disks
-			// we will always have the partition label, but may not have a
+			// the partition label is optional, and may or may not have a
 			// filesystem on the partition, on MBR we will never have a
-			// partition label, but may have a filesystem label. It's unclear if
-			// MBR disks can have partitions without a filesystem label.
+			// partition label, and we also may or may not have a filesystem on
+			// the partition
 			part.partUUID = udevProps["ID_PART_ENTRY_UUID"]
 			if part.partUUID == "" {
 				return fmt.Errorf("cannot get udev properties for device %s (a partition of %s), missing udev property \"ID_PART_ENTRY_UUID\"", partDev, d.Dev())

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -402,13 +402,18 @@ func (d *disk) populatePartitions() error {
 			}
 
 			// on MBR disks we may not have a partition label, so this may be
-			// the empty string
+			// the empty string. Note that this value is encoded similarly to
+			// libblkid and should be compared with normal Go strings that are
+			// encoded using BlkIDEncodeLabel.
 			part.partLabel = udevProps["ID_PART_ENTRY_NAME"]
 
 			// a partition doesn't need to have a filesystem, and such may not
 			// have a filesystem label; the bios-boot partition in the amd64 pc
 			// gadget is such an example of a partition GPT that does not have a
-			// filesystem
+			// filesystem.
+			// Note that this value is also encoded similarly to
+			// ID_PART_ENTRY_NAME and thus should only be compared with normal
+			// Go strings that are encoded with BlkIDEncodeLabel.
 			part.fsLabel = udevProps["ID_FS_LABEL_ENC"]
 
 			// prepend the partition to the front, this has the effect that if

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -153,12 +153,19 @@ func DiskFromMountPoint(mountpoint string, opts *Options) (Disk, error) {
 	return diskFromMountPoint(mountpoint, opts)
 }
 
+type partition struct {
+	fsLabel   string
+	partLabel string
+	partUUID  string
+}
+
 type disk struct {
 	major int
 	minor int
-	// fsLabelToPartUUID is a map of filesystem label -> partition uuid for now
-	// eventually this may be expanded to be more generally useful
-	fsLabelToPartUUID map[string]string
+	// partitions is the set of discovered partitions for the disk, each
+	// partition must have a partition label and partition uuid, and may or may
+	// not have a filesystem label
+	partitions []partition
 
 	// whether the disk device has partitions, and thus is of type "disk", or
 	// whether the disk device is a volume that is not a physical disk
@@ -320,28 +327,27 @@ func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
 	return nil, fmt.Errorf("cannot find disk for partition %s, incomplete udev output", partMountPointSource)
 }
 
-func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
-	encodedLabel := BlkIDEncodeLabel(label)
-	// if we haven't found the partitions for this disk yet, do that now
-	if d.fsLabelToPartUUID == nil {
-		d.fsLabelToPartUUID = make(map[string]string)
+func (d *disk) populatePartitions() error {
+	if d.partitions == nil {
+		d.partitions = []partition{}
 
 		// step 1. find the devpath for the disk, then glob for matching
 		//         devices using the devname in that sysfs directory
 		// step 2. iterate over all those devices and save all the ones that are
 		//         partitions using the partition sysfs file
-		// step 3. for all partition devices found, query udev to get the fs
-		//         label and partition uuid
+		// step 3. for all partition devices found, query udev to get the labels
+		//         of the partition and filesystem as well as the partition uuid
+		//         and save for later
 
 		udevProps, err := udevProperties(filepath.Join("/dev/block", d.Dev()))
 		if err != nil {
-			return "", err
+			return err
 		}
 
 		// get the base device name
 		devName := udevProps["DEVNAME"]
 		if devName == "" {
-			return "", fmt.Errorf("cannot get udev properties for device %s, missing udev property \"DEVNAME\"", d.Dev())
+			return fmt.Errorf("cannot get udev properties for device %s, missing udev property \"DEVNAME\"", d.Dev())
 		}
 		// the DEVNAME as returned by udev includes the /dev/mmcblk0 path, we
 		// just want mmcblk0 for example
@@ -350,19 +356,21 @@ func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
 		// get the device path in sysfs
 		devPath := udevProps["DEVPATH"]
 		if devPath == "" {
-			return "", fmt.Errorf("cannot get udev properties for device %s, missing udev property \"DEVPATH\"", d.Dev())
+			return fmt.Errorf("cannot get udev properties for device %s, missing udev property \"DEVPATH\"", d.Dev())
 		}
 
 		// glob for /sys/${devPath}/${devName}*
 		paths, err := filepath.Glob(filepath.Join(dirs.SysfsDir, devPath, devName+"*"))
 		if err != nil {
-			return "", fmt.Errorf("internal error getting udev properties for device %s: %v", err, d.Dev())
+			return fmt.Errorf("internal error getting udev properties for device %s: %v", err, d.Dev())
 		}
 
 		// Glob does not sort, so sort manually to have consistent tests
 		sort.Strings(paths)
 
 		for _, path := range paths {
+			part := partition{}
+
 			// check if this device is a partition - note that the mere
 			// existence of this file is sufficient to indicate that it is a
 			// partition, the file is the partition number of the device, it
@@ -382,44 +390,67 @@ func (d *disk) FindMatchingPartitionUUID(label string) (string, error) {
 				continue
 			}
 
-			partUUID := udevProps["ID_PART_ENTRY_UUID"]
-			if partUUID == "" {
-				return "", fmt.Errorf("cannot get udev properties for device %s (a partition of %s), missing udev property \"ID_PART_ENTRY_UUID\"", partDev, d.Dev())
+			// we should always have the partition uuid, and we may not have
+			// either the partition label or the filesystem label, on GPT disks
+			// we will always have the partition label, but may not have a
+			// filesystem on the partition, on MBR we will never have a
+			// partition label, but may have a filesystem label. It's unclear if
+			// MBR disks can have partitions without a filesystem label.
+			part.partUUID = udevProps["ID_PART_ENTRY_UUID"]
+			if part.partUUID == "" {
+				return fmt.Errorf("cannot get udev properties for device %s (a partition of %s), missing udev property \"ID_PART_ENTRY_UUID\"", partDev, d.Dev())
 			}
 
-			fsLabelEnc := udevProps["ID_FS_LABEL_ENC"]
-			if fsLabelEnc == "" {
-				// it is valid for there to be a partition without a fs
-				// label - such as the bios-boot partition on amd64 pc
-				// gadget systems
-				// in this case just skip this, since we are only matching
-				// by filesystem labels, obviously we cannot ever match to
-				// a partition which does not have a filesystem
-				continue
-			}
+			// on MBR disks we may not have a partition label, so this may be
+			// the empty string
+			part.partLabel = udevProps["ID_PART_ENTRY_NAME"]
 
-			// TODO: maybe save ID_PART_ENTRY_NAME here too, which is the name
-			//       of the partition. this may be useful if this function gets
-			//       used in the gadget update code
+			// a partition doesn't need to have a filesystem, and such may not
+			// have a filesystem label; the bios-boot partition in the amd64 pc
+			// gadget is such an example of a partition GPT that does not have a
+			// filesystem
+			part.fsLabel = udevProps["ID_FS_LABEL_ENC"]
 
-			// we always overwrite the fsLabelEnc with the last one, this
-			// has the result that the last partition with a given
-			// filesystem label will be set/found
-			// this matches what udev does with the symlinks in /dev
-			d.fsLabelToPartUUID[fsLabelEnc] = partUUID
+			// prepend the partition to the front, this has the effect that if
+			// two partitions have the same label (either filesystem or
+			// partition though it is unclear whether you could actually in
+			// practice create a disk partitioning scheme with the same
+			// partition label for multiple partitions), then the one we look at
+			// last while populating will be the one that the Find*()
+			// functions locate first while iterating over the disk's partitions
+			// this behavior matches what udev does
+			d.partitions = append([]partition{part}, d.partitions...)
 		}
 	}
 
-	// if we didn't find any partitions from above then return an error
-	if len(d.fsLabelToPartUUID) == 0 {
-		return "", fmt.Errorf("no partitions found for disk %s", d.Dev())
+	// if we didn't find any partitions from above then return an error, this is
+	// because all disks we search for partitions are expected to have some
+	// partitions
+	if len(d.partitions) == 0 {
+		return fmt.Errorf("no partitions found for disk %s", d.Dev())
 	}
 
-	if partuuid, ok := d.fsLabelToPartUUID[encodedLabel]; ok {
-		return partuuid, nil
+	return nil
+}
+
+func (d *disk) FindMatchingPartitionUUIDFromFsLabel(label string) (string, error) {
+	// always encode the label
+	encodedLabel := BlkIDEncodeLabel(label)
+
+	if err := d.populatePartitions(); err != nil {
+		return "", err
 	}
 
-	return "", FilesystemLabelNotFoundError{Label: label}
+	for _, p := range d.partitions {
+		if p.fsLabel == encodedLabel {
+			return p.partUUID, nil
+		}
+	}
+
+	return "", PartitionNotFoundError{
+		SearchType:  "filesystem-label",
+		SearchQuery: label,
+	}
 }
 
 func (d *disk) MountPointIsFromDisk(mountpoint string, opts *Options) (bool, error) {

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -433,7 +433,7 @@ func (d *disk) populatePartitions() error {
 	return nil
 }
 
-func (d *disk) FindMatchingPartitionUUIDFromFsLabel(label string) (string, error) {
+func (d *disk) FindMatchingPartitionUUIDWithFsLabel(label string) (string, error) {
 	// always encode the label
 	encodedLabel := BlkIDEncodeLabel(label)
 

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -292,7 +292,7 @@ func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitio
 	c.Assert(disk.Dev(), Equals, "42:0")
 	c.Assert(disk.HasPartitions(), Equals, true)
 	// searching for the single label we have for this partition will succeed
-	label, err := disk.FindMatchingPartitionUUIDFromFsLabel("some-label")
+	label, err := disk.FindMatchingPartitionUUIDWithFsLabel("some-label")
 	c.Assert(err, IsNil)
 	c.Assert(label, Equals, "some-uuid")
 
@@ -301,7 +301,7 @@ func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitio
 	c.Assert(matches, Equals, true)
 
 	// trying to search for any other labels though will fail
-	_, err = disk.FindMatchingPartitionUUIDFromFsLabel("ubuntu-boot")
+	_, err = disk.FindMatchingPartitionUUIDWithFsLabel("ubuntu-boot")
 	c.Assert(err, ErrorMatches, "filesystem label \"ubuntu-boot\" not found")
 	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
 		SearchType:  "filesystem-label",
@@ -514,7 +514,7 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 
 	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
 	for _, label := range []string{"ubuntu-seed", "ubuntu-boot", "ubuntu-data"} {
-		id, err := ubuntuDataDisk.FindMatchingPartitionUUIDFromFsLabel(label)
+		id, err := ubuntuDataDisk.FindMatchingPartitionUUIDWithFsLabel(label)
 		c.Assert(err, IsNil)
 		c.Assert(id, Equals, label+"-partuuid")
 	}
@@ -534,7 +534,7 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 
 	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
 	for _, label := range []string{"ubuntu-seed", "ubuntu-boot", "ubuntu-data"} {
-		id, err := ubuntuBootDisk.FindMatchingPartitionUUIDFromFsLabel(label)
+		id, err := ubuntuBootDisk.FindMatchingPartitionUUIDWithFsLabel(label)
 		c.Assert(err, IsNil)
 		c.Assert(id, Equals, label+"-partuuid")
 	}
@@ -546,14 +546,14 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 	c.Assert(matches, Equals, true)
 
 	// finally we can't find the bios-boot partition because it has no fs label
-	_, err = ubuntuBootDisk.FindMatchingPartitionUUIDFromFsLabel("bios-boot")
+	_, err = ubuntuBootDisk.FindMatchingPartitionUUIDWithFsLabel("bios-boot")
 	c.Assert(err, ErrorMatches, "filesystem label \"bios-boot\" not found")
 	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
 		SearchType:  "filesystem-label",
 		SearchQuery: "bios-boot",
 	})
 
-	_, err = ubuntuDataDisk.FindMatchingPartitionUUIDFromFsLabel("bios-boot")
+	_, err = ubuntuDataDisk.FindMatchingPartitionUUIDWithFsLabel("bios-boot")
 	c.Assert(err, ErrorMatches, "filesystem label \"bios-boot\" not found")
 	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
 		SearchType:  "filesystem-label",
@@ -682,7 +682,7 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 
 	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
 	for _, label := range []string{"ubuntu-seed", "ubuntu-boot", "ubuntu-data-enc"} {
-		id, err := ubuntuDataDisk.FindMatchingPartitionUUIDFromFsLabel(label)
+		id, err := ubuntuDataDisk.FindMatchingPartitionUUIDWithFsLabel(label)
 		c.Assert(err, IsNil)
 		c.Assert(id, Equals, label+"-partuuid")
 	}
@@ -702,7 +702,7 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 
 	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
 	for _, label := range []string{"ubuntu-seed", "ubuntu-boot", "ubuntu-data-enc"} {
-		id, err := ubuntuBootDisk.FindMatchingPartitionUUIDFromFsLabel(label)
+		id, err := ubuntuBootDisk.FindMatchingPartitionUUIDWithFsLabel(label)
 		c.Assert(err, IsNil)
 		c.Assert(id, Equals, label+"-partuuid")
 	}

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -27,8 +27,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"golang.org/x/xerrors"
-
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
@@ -45,25 +43,32 @@ var (
 		"DEVPATH":            virtioDiskDevPath,
 	}
 
-	// the udev prop for bios-boot has no fs label, which is typical of the
-	// real bios-boot partition on a amd64 pc gadget system, and so we should
-	// safely just ignore and skip this partition in the implementation
-	biotBootUdevPropMap = map[string]string{
+	biosBootUdevPropMap = map[string]string{
 		"ID_PART_ENTRY_UUID": "bios-boot-partuuid",
+		// the udev prop for bios-boot has no fs label, which is typical of the
+		// real bios-boot partition on a amd64 pc gadget system, and so we should
+		// safely just ignore and skip this partition in the fs label
+		// implementation
+		"ID_FS_LABEL_ENC": "",
+		// we will however still have a partition label of "BIOS Boot"
+		"ID_PART_ENTRY_NAME": "BIOS\\x20Boot",
 	}
 
 	// all the ubuntu- partitions have fs labels
 	ubuntuSeedUdevPropMap = map[string]string{
 		"ID_PART_ENTRY_UUID": "ubuntu-seed-partuuid",
 		"ID_FS_LABEL_ENC":    "ubuntu-seed",
+		"ID_PART_ENTRY_NAME": "ubuntu-seed",
 	}
 	ubuntuBootUdevPropMap = map[string]string{
 		"ID_PART_ENTRY_UUID": "ubuntu-boot-partuuid",
 		"ID_FS_LABEL_ENC":    "ubuntu-boot",
+		"ID_PART_ENTRY_NAME": "ubuntu-boot",
 	}
 	ubuntuDataUdevPropMap = map[string]string{
 		"ID_PART_ENTRY_UUID": "ubuntu-data-partuuid",
 		"ID_FS_LABEL_ENC":    "ubuntu-data",
+		"ID_PART_ENTRY_NAME": "ubuntu-data",
 	}
 )
 
@@ -287,7 +292,7 @@ func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitio
 	c.Assert(disk.Dev(), Equals, "42:0")
 	c.Assert(disk.HasPartitions(), Equals, true)
 	// searching for the single label we have for this partition will succeed
-	label, err := disk.FindMatchingPartitionUUID("some-label")
+	label, err := disk.FindMatchingPartitionUUIDFromFsLabel("some-label")
 	c.Assert(err, IsNil)
 	c.Assert(label, Equals, "some-uuid")
 
@@ -296,11 +301,12 @@ func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitio
 	c.Assert(matches, Equals, true)
 
 	// trying to search for any other labels though will fail
-	_, err = disk.FindMatchingPartitionUUID("ubuntu-boot")
+	_, err = disk.FindMatchingPartitionUUIDFromFsLabel("ubuntu-boot")
 	c.Assert(err, ErrorMatches, "filesystem label \"ubuntu-boot\" not found")
-	c.Assert(err, FitsTypeOf, disks.FilesystemLabelNotFoundError{})
-	labelNotFoundErr := err.(disks.FilesystemLabelNotFoundError)
-	c.Assert(labelNotFoundErr.Label, Equals, "ubuntu-boot")
+	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
+		SearchType:  "filesystem-label",
+		SearchQuery: "ubuntu-boot",
+	})
 }
 
 func (s *diskSuite) TestDiskFromMountPointHappyRealUdevadm(c *C) {
@@ -438,7 +444,7 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 			c.Assert(dev, Equals, "vda1")
 			// this is the sysfs entry for the first partition of the disk
 			// previously found under the DEVPATH for /dev/block/42:0
-			return biotBootUdevPropMap, nil
+			return biosBootUdevPropMap, nil
 		case 4:
 			c.Assert(dev, Equals, "vda2")
 			// the second partition of the disk from sysfs has a fs label
@@ -469,7 +475,7 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 			c.Assert(dev, Equals, "vda1")
 			// this is the sysfs entry for the first partition of the disk
 			// previously found under the DEVPATH for /dev/block/42:0
-			return biotBootUdevPropMap, nil
+			return biosBootUdevPropMap, nil
 		case 11:
 			c.Assert(dev, Equals, "vda2")
 			// the second partition of the disk from sysfs has a fs label
@@ -508,7 +514,7 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 
 	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
 	for _, label := range []string{"ubuntu-seed", "ubuntu-boot", "ubuntu-data"} {
-		id, err := ubuntuDataDisk.FindMatchingPartitionUUID(label)
+		id, err := ubuntuDataDisk.FindMatchingPartitionUUIDFromFsLabel(label)
 		c.Assert(err, IsNil)
 		c.Assert(id, Equals, label+"-partuuid")
 	}
@@ -528,7 +534,7 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 
 	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
 	for _, label := range []string{"ubuntu-seed", "ubuntu-boot", "ubuntu-data"} {
-		id, err := ubuntuBootDisk.FindMatchingPartitionUUID(label)
+		id, err := ubuntuBootDisk.FindMatchingPartitionUUIDFromFsLabel(label)
 		c.Assert(err, IsNil)
 		c.Assert(id, Equals, label+"-partuuid")
 	}
@@ -539,15 +545,22 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(matches, Equals, true)
 
-	// finally we can't find the bios-boot partition because it has no label
-	_, err = ubuntuBootDisk.FindMatchingPartitionUUID("bios-boot")
+	// finally we can't find the bios-boot partition because it has no fs label
+	_, err = ubuntuBootDisk.FindMatchingPartitionUUIDFromFsLabel("bios-boot")
 	c.Assert(err, ErrorMatches, "filesystem label \"bios-boot\" not found")
-	var notFoundErr disks.FilesystemLabelNotFoundError
-	c.Assert(xerrors.As(err, &notFoundErr), Equals, true)
+	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
+		SearchType:  "filesystem-label",
+		SearchQuery: "bios-boot",
+	})
 
-	_, err = ubuntuDataDisk.FindMatchingPartitionUUID("bios-boot")
+	_, err = ubuntuDataDisk.FindMatchingPartitionUUIDFromFsLabel("bios-boot")
 	c.Assert(err, ErrorMatches, "filesystem label \"bios-boot\" not found")
-	c.Assert(xerrors.As(err, &notFoundErr), Equals, true)
+	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
+		SearchType:  "filesystem-label",
+		SearchQuery: "bios-boot",
+	})
+
+	// however we can find bios-boot by it's partition label
 }
 
 func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
@@ -578,7 +591,7 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 		case 4:
 			// next find each partition in turn
 			c.Assert(dev, Equals, "vda1")
-			return biotBootUdevPropMap, nil
+			return biosBootUdevPropMap, nil
 		case 5:
 			c.Assert(dev, Equals, "vda2")
 			return ubuntuSeedUdevPropMap, nil
@@ -607,7 +620,7 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 		case 11:
 			// next find each partition in turn again, same as steps 4-7
 			c.Assert(dev, Equals, "vda1")
-			return biotBootUdevPropMap, nil
+			return biosBootUdevPropMap, nil
 		case 12:
 			c.Assert(dev, Equals, "vda2")
 			return ubuntuSeedUdevPropMap, nil
@@ -669,7 +682,7 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 
 	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
 	for _, label := range []string{"ubuntu-seed", "ubuntu-boot", "ubuntu-data-enc"} {
-		id, err := ubuntuDataDisk.FindMatchingPartitionUUID(label)
+		id, err := ubuntuDataDisk.FindMatchingPartitionUUIDFromFsLabel(label)
 		c.Assert(err, IsNil)
 		c.Assert(id, Equals, label+"-partuuid")
 	}
@@ -689,7 +702,7 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 
 	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
 	for _, label := range []string{"ubuntu-seed", "ubuntu-boot", "ubuntu-data-enc"} {
-		id, err := ubuntuBootDisk.FindMatchingPartitionUUID(label)
+		id, err := ubuntuBootDisk.FindMatchingPartitionUUIDFromFsLabel(label)
 		c.Assert(err, IsNil)
 		c.Assert(id, Equals, label+"-partuuid")
 	}

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -35,7 +35,7 @@ type MockDiskMapping struct {
 	// FilesystemLabelToPartUUID is a mapping of the udev encoded filesystem
 	// labels to the expected partition uuids.
 	FilesystemLabelToPartUUID map[string]string
-	// FilesystemLabelToPartUUID is a mapping of the udev encoded partition
+	// PartitionLabelToPartUUID is a mapping of the udev encoded partition
 	// labels to the expected partition uuids.
 	PartitionLabelToPartUUID map[string]string
 	DiskHasPartitions        bool

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -32,19 +32,27 @@ import (
 // DevNum must be a unique string per unique mocked disk, if only one disk is
 // being mocked it can be left empty.
 type MockDiskMapping struct {
+	// FilesystemLabelToPartUUID is a mapping of the udev encoded filesystem
+	// labels to the expected partition uuids.
 	FilesystemLabelToPartUUID map[string]string
-	DiskHasPartitions         bool
-	DevNum                    string
+	// FilesystemLabelToPartUUID is a mapping of the udev encoded partition
+	// labels to the expected partition uuids.
+	PartitionLabelToPartUUID map[string]string
+	DiskHasPartitions        bool
+	DevNum                   string
 }
 
-// FindMatchingPartitionUUID returns a matching PartitionUUID for the specified
-// label if it exists. Part of the Disk interface.
-func (d *MockDiskMapping) FindMatchingPartitionUUID(label string) (string, error) {
+// FindMatchingPartitionUUIDFromFsLabel returns a matching PartitionUUID
+// for the specified filesystem label if it exists. Part of the Disk interface.
+func (d *MockDiskMapping) FindMatchingPartitionUUIDFromFsLabel(label string) (string, error) {
 	osutil.MustBeTestBinary("mock disks only to be used in tests")
 	if partuuid, ok := d.FilesystemLabelToPartUUID[label]; ok {
 		return partuuid, nil
 	}
-	return "", FilesystemLabelNotFoundError{Label: label}
+	return "", PartitionNotFoundError{
+		SearchType:  "filesystem-label",
+		SearchQuery: label,
+	}
 }
 
 // HasPartitions returns if the mock disk has partitions or not. Part of the

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -42,9 +42,9 @@ type MockDiskMapping struct {
 	DevNum                   string
 }
 
-// FindMatchingPartitionUUIDFromFsLabel returns a matching PartitionUUID
+// FindMatchingPartitionUUIDWithFsLabel returns a matching PartitionUUID
 // for the specified filesystem label if it exists. Part of the Disk interface.
-func (d *MockDiskMapping) FindMatchingPartitionUUIDFromFsLabel(label string) (string, error) {
+func (d *MockDiskMapping) FindMatchingPartitionUUIDWithFsLabel(label string) (string, error) {
 	osutil.MustBeTestBinary("mock disks only to be used in tests")
 	if partuuid, ok := d.FilesystemLabelToPartUUID[label]; ok {
 		return partuuid, nil

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -187,7 +187,7 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	c.Assert(err, IsNil)
 
 	// and it has labels
-	label, err := foundDisk.FindMatchingPartitionUUIDFromFsLabel("label1")
+	label, err := foundDisk.FindMatchingPartitionUUIDWithFsLabel("label1")
 	c.Assert(err, IsNil)
 	c.Assert(label, Equals, "part1")
 
@@ -211,12 +211,12 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	c.Assert(err, IsNil)
 
 	// we can find label2 from mount3's disk
-	label, err = foundDisk2.FindMatchingPartitionUUIDFromFsLabel("label2")
+	label, err = foundDisk2.FindMatchingPartitionUUIDWithFsLabel("label2")
 	c.Assert(err, IsNil)
 	c.Assert(label, Equals, "part2")
 
 	// we can't find label1 from mount1's or mount2's disk
-	_, err = foundDisk2.FindMatchingPartitionUUIDFromFsLabel("label1")
+	_, err = foundDisk2.FindMatchingPartitionUUIDWithFsLabel("label1")
 	c.Assert(err, ErrorMatches, "filesystem label \"label1\" not found")
 	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
 		SearchType:  "filesystem-label",
@@ -260,12 +260,12 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMappingDecryptedDevice
 	c.Assert(err, IsNil)
 
 	// next we find ubuntu-seed (also not decrypted)
-	label, err := d.FindMatchingPartitionUUIDFromFsLabel("ubuntu-seed")
+	label, err := d.FindMatchingPartitionUUIDWithFsLabel("ubuntu-seed")
 	c.Assert(err, IsNil)
 	c.Assert(label, Equals, "ubuntu-seed-part")
 
 	// then we find ubuntu-data-enc, which is not a decrypted device
-	label, err = d.FindMatchingPartitionUUIDFromFsLabel("ubuntu-data-enc")
+	label, err = d.FindMatchingPartitionUUIDWithFsLabel("ubuntu-data-enc")
 	c.Assert(err, IsNil)
 	c.Assert(label, Equals, "ubuntu-data-enc-part")
 

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -244,11 +244,11 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(
 	// looking for the encrypted device to unlock, later on in the boot
 	// process we will look for the decrypted device to ensure it matches
 	// what we expected
-	partUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+	partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 	if err == nil {
 		res.IsEncrypted = true
 	} else {
-		var errNotFound disks.FilesystemLabelNotFoundError
+		var errNotFound disks.PartitionNotFoundError
 		if !xerrors.As(err, &errNotFound) {
 			// some other kind of catastrophic error searching
 			// TODO: need to defer the connection to the default TPM somehow
@@ -256,7 +256,7 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(
 		}
 		// otherwise it is an error not found and we should search for the
 		// unencrypted device
-		partUUID, err = disk.FindMatchingPartitionUUID(name)
+		partUUID, err = disk.FindMatchingPartitionUUIDFromFsLabel(name)
 		if err != nil {
 			return res, fmt.Errorf("error enumerating partitions for disk to find unencrypted device %q: %v", name, err)
 		}
@@ -323,7 +323,7 @@ func UnlockEncryptedVolumeUsingKey(disk disks.Disk, name string, key []byte) (Un
 	// looking for the encrypted device to unlock, later on in the boot
 	// process we will look for the decrypted device to ensure it matches
 	// what we expected
-	partUUID, err := disk.FindMatchingPartitionUUID(name + "-enc")
+	partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
 	if err != nil {
 		return unlockRes, err
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -244,7 +244,7 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(
 	// looking for the encrypted device to unlock, later on in the boot
 	// process we will look for the decrypted device to ensure it matches
 	// what we expected
-	partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+	partUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 	if err == nil {
 		res.IsEncrypted = true
 	} else {
@@ -256,7 +256,7 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(
 		}
 		// otherwise it is an error not found and we should search for the
 		// unencrypted device
-		partUUID, err = disk.FindMatchingPartitionUUIDFromFsLabel(name)
+		partUUID, err = disk.FindMatchingPartitionUUIDWithFsLabel(name)
 		if err != nil {
 			return res, fmt.Errorf("error enumerating partitions for disk to find unencrypted device %q: %v", name, err)
 		}
@@ -323,7 +323,7 @@ func UnlockEncryptedVolumeUsingKey(disk disks.Disk, name string, key []byte) (Un
 	// looking for the encrypted device to unlock, later on in the boot
 	// process we will look for the decrypted device to ensure it matches
 	// what we expected
-	partUUID, err := disk.FindMatchingPartitionUUIDFromFsLabel(name + "-enc")
+	partUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 	if err != nil {
 		return unlockRes, err
 	}


### PR DESCRIPTION
This is to accommodate a future FindMatching...WithPartLabel. Additionally, an
internal refactor to support storing additional properties for partitions when
we search a disk is implemented to allow for the additional future method.

The error type now is also more versatile to allow specifying what part failed,
searching for a partition by filesystem label or by partition label.

This PR is just the change to rename things to make the followup simpler to 
review, which I will open shortly...