### PR TITLE
osutil/disks: add FindMatchingPartitionUUIDWithPartLabel to Disk iface

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -39,6 +39,12 @@ type Disk interface {
 	// were encountered, a PartitionNotFoundError will be returned.
 	FindMatchingPartitionUUIDWithFsLabel(string) (string, error)
 
+	// FindMatchingPartitionUUIDWithPartLabel is like
+	// FindMatchingPartitionUUIDWithFsLabel, but searches for a partition that
+	// has a matching partition label instead of the filesystem label. The same
+	// encoding scheme is performed on the label as in that function.
+	FindMatchingPartitionUUIDWithPartLabel(string) (string, error)
+
 	// MountPointIsFromDisk returns whether the specified mountpoint corresponds
 	// to a partition on the disk. Note that this only considers partitions
 	// and mountpoints found when the disk was identified with

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -442,6 +442,26 @@ func (d *disk) populatePartitions() error {
 	return nil
 }
 
+func (d *disk) FindMatchingPartitionUUIDWithPartLabel(label string) (string, error) {
+	// always encode the label
+	encodedLabel := BlkIDEncodeLabel(label)
+
+	if err := d.populatePartitions(); err != nil {
+		return "", err
+	}
+
+	for _, p := range d.partitions {
+		if p.partLabel == encodedLabel {
+			return p.partUUID, nil
+		}
+	}
+
+	return "", PartitionNotFoundError{
+		SearchType:  "partition-label",
+		SearchQuery: label,
+	}
+}
+
 func (d *disk) FindMatchingPartitionUUIDWithFsLabel(label string) (string, error) {
 	// always encode the label
 	encodedLabel := BlkIDEncodeLabel(label)

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -560,7 +560,22 @@ func (s *diskSuite) TestDiskFromMountPointPartitionsHappy(c *C) {
 		SearchQuery: "bios-boot",
 	})
 
-	// however we can find bios-boot by it's partition label
+	// however we can find it via the partition label
+	uuid, err := ubuntuBootDisk.FindMatchingPartitionUUIDWithPartLabel("BIOS Boot")
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Equals, "bios-boot-partuuid")
+
+	uuid, err = ubuntuDataDisk.FindMatchingPartitionUUIDWithPartLabel("BIOS Boot")
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Equals, "bios-boot-partuuid")
+
+	// trying to find an unknown partition label fails however
+	_, err = ubuntuDataDisk.FindMatchingPartitionUUIDWithPartLabel("NOT BIOS Boot")
+	c.Assert(err, ErrorMatches, "partition label \"NOT BIOS Boot\" not found")
+	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
+		SearchType:  "partition-label",
+		SearchQuery: "NOT BIOS Boot",
+	})
 }
 
 func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -55,6 +55,19 @@ func (d *MockDiskMapping) FindMatchingPartitionUUIDWithFsLabel(label string) (st
 	}
 }
 
+// FindMatchingPartitionUUIDWithPartLabel returns a matching PartitionUUID
+// for the specified filesystem label if it exists. Part of the Disk interface.
+func (d *MockDiskMapping) FindMatchingPartitionUUIDWithPartLabel(label string) (string, error) {
+	osutil.MustBeTestBinary("mock disks only to be used in tests")
+	if partuuid, ok := d.PartitionLabelToPartUUID[label]; ok {
+		return partuuid, nil
+	}
+	return "", PartitionNotFoundError{
+		SearchType:  "partition-label",
+		SearchQuery: label,
+	}
+}
+
 // HasPartitions returns if the mock disk has partitions or not. Part of the
 // Disk interface.
 func (d *MockDiskMapping) HasPartitions() bool {

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -161,6 +161,9 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 		FilesystemLabelToPartUUID: map[string]string{
 			"label1": "part1",
 		},
+		PartitionLabelToPartUUID: map[string]string{
+			"part-label1": "part1",
+		},
 		DiskHasPartitions: true,
 		DevNum:            "d1",
 	}
@@ -168,6 +171,9 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	d2 := &disks.MockDiskMapping{
 		FilesystemLabelToPartUUID: map[string]string{
 			"label2": "part2",
+		},
+		PartitionLabelToPartUUID: map[string]string{
+			"part-label2": "part2",
 		},
 		DiskHasPartitions: true,
 		DevNum:            "d2",
@@ -186,10 +192,15 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	foundDisk, err := disks.DiskFromMountPoint("mount1", nil)
 	c.Assert(err, IsNil)
 
-	// and it has labels
-	label, err := foundDisk.FindMatchingPartitionUUIDWithFsLabel("label1")
+	// and it has filesystem labels
+	uuid, err := foundDisk.FindMatchingPartitionUUIDWithFsLabel("label1")
 	c.Assert(err, IsNil)
-	c.Assert(label, Equals, "part1")
+	c.Assert(uuid, Equals, "part1")
+
+	// and partition labels
+	uuid, err = foundDisk.FindMatchingPartitionUUIDWithPartLabel("part-label1")
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Equals, "part1")
 
 	// the same mount point is always from the same disk
 	matches, err := foundDisk.MountPointIsFromDisk("mount1", nil)
@@ -211,9 +222,14 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	c.Assert(err, IsNil)
 
 	// we can find label2 from mount3's disk
-	label, err = foundDisk2.FindMatchingPartitionUUIDWithFsLabel("label2")
+	uuid, err = foundDisk2.FindMatchingPartitionUUIDWithFsLabel("label2")
 	c.Assert(err, IsNil)
-	c.Assert(label, Equals, "part2")
+	c.Assert(uuid, Equals, "part2")
+
+	// and the partition label
+	uuid, err = foundDisk2.FindMatchingPartitionUUIDWithPartLabel("part-label2")
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Equals, "part2")
 
 	// we can't find label1 from mount1's or mount2's disk
 	_, err = foundDisk2.FindMatchingPartitionUUIDWithFsLabel("label1")
@@ -221,6 +237,13 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
 		SearchType:  "filesystem-label",
 		SearchQuery: "label1",
+	})
+
+	_, err = foundDisk2.FindMatchingPartitionUUIDWithPartLabel("part-label1")
+	c.Assert(err, ErrorMatches, "partition label \"part-label1\" not found")
+	c.Assert(err, DeepEquals, disks.PartitionNotFoundError{
+		SearchType:  "partition-label",
+		SearchQuery: "part-label1",
 	})
 
 	// mount1 and mount2 do not match mount3 disk


### PR DESCRIPTION
This will enable searching for a partition with a given label on the provided
disk.

This is needed for the lk bootloader on UC20 work.