### PR TITLE
bootloader: remove installableBootloader interface and methods

### DIFF
--- a/bootloader/androidboot.go
+++ b/bootloader/androidboot.go
@@ -42,10 +42,6 @@ func (a *androidboot) Name() string {
 	return "androidboot"
 }
 
-func (a *androidboot) setRootDir(rootdir string) {
-	a.rootdir = rootdir
-}
-
 func (a *androidboot) dir() string {
 	if a.rootdir == "" {
 		panic("internal error: unset rootdir")

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -110,11 +110,6 @@ type Bootloader interface {
 	RemoveKernelAssets(s snap.PlaceInfo) error
 }
 
-type installableBootloader interface {
-	Bootloader
-	setRootDir(string)
-}
-
 type RecoveryAwareBootloader interface {
 	Bootloader
 	SetRecoverySystemEnv(recoverySystemDir string, values map[string]string) error

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -34,7 +34,6 @@ import (
 // sanity - grub implements the required interfaces
 var (
 	_ Bootloader                        = (*grub)(nil)
-	_ installableBootloader             = (*grub)(nil)
 	_ RecoveryAwareBootloader           = (*grub)(nil)
 	_ ExtractedRunKernelImageBootloader = (*grub)(nil)
 	_ TrustedAssetsBootloader           = (*grub)(nil)
@@ -73,10 +72,6 @@ func newGrub(rootdir string, opts *Options) Bootloader {
 
 func (g *grub) Name() string {
 	return "grub"
-}
-
-func (g *grub) setRootDir(rootdir string) {
-	g.rootdir = rootdir
 }
 
 func (g *grub) dir() string {

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -55,10 +55,6 @@ func newLk(rootdir string, opts *Options) Bootloader {
 	return l
 }
 
-func (l *lk) setRootDir(rootdir string) {
-	l.rootdir = rootdir
-}
-
 func (l *lk) Name() string {
 	return "lk"
 }

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -74,10 +74,6 @@ func (u *uboot) Name() string {
 	return "uboot"
 }
 
-func (u *uboot) setRootDir(rootdir string) {
-	u.rootdir = rootdir
-}
-
 func (u *uboot) dir() string {
 	if u.rootdir == "" {
 		panic("internal error: unset rootdir")


### PR DESCRIPTION
This is not used anywhere anymore, so let's just drop it. If we need it again,
we can bring it back.