### PR TITLE
many: allow disable user creation on system-user auto-import

### DIFF
--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -24,6 +24,9 @@ import (
 	"crypto"
 	"encoding/base64"
 	"fmt"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/strutil"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -279,6 +282,12 @@ func init() {
 }
 
 func (x *cmdAutoImport) autoAddUsers() error {
+	// only create users if auto-creation is not specifically disabled
+	if osutil.FileExists(dirs.SnapAssertsUsersCreateDisabledFile) {
+		fmt.Fprintf(Stderr, "auto-import user creation is disabled by config\n")
+		return nil
+	}
+
 	options := client.CreateUserOptions{
 		Automatic: true,
 	}

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -70,6 +70,8 @@ var (
 	SnapTrustedAccountKey string
 	SnapAssertsSpoolDir   string
 	SnapSeqDir            string
+
+	SnapAssertsUsersCreateDisabledFile string
 
 	SnapStateFile     string
 	SnapSystemKeyFile string
@@ -347,6 +349,8 @@ func SetRootDir(rootdir string) {
 	SnapCookieDir = filepath.Join(rootdir, snappyDir, "cookie")
 	SnapAssertsSpoolDir = filepath.Join(rootdir, "run/snapd/auto-import")
 	SnapSeqDir = filepath.Join(rootdir, snappyDir, "sequence")
+
+	SnapAssertsUsersCreateDisabledFile = filepath.Join(rootdir, snappyDir, "users-create/disabled")
 
 	SnapStateFile = SnapStateFileUnder(rootdir)
 	SnapSystemKeyFile = filepath.Join(rootdir, snappyDir, "system-key")

--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -88,6 +88,9 @@ func init() {
 	// system.timezone
 	addFSOnlyHandler(validateTimezoneSettings, handleTimezoneConfiguration, coreOnly)
 
+	// users.create
+	addFSOnlyHandler(nil, handleUsersCreateConfiguration, coreOnly)
+
 	sysconfig.ApplyFilesystemOnlyDefaultsImpl = func(rootDir string, defaults map[string]interface{}, options *sysconfig.FilesystemOnlyApplyOptions) error {
 		return filesystemOnlyApply(rootDir, plainCoreConfig(defaults), options)
 	}

--- a/overlord/configstate/configcore/users.go
+++ b/overlord/configstate/configcore/users.go
@@ -1,0 +1,70 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !nomanagers
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	supportedConfigurations["core.users.create"] = true
+}
+
+func switchHandleUsersCreate(disabled bool, opts *fsOnlyContext) error {
+	autoimportCanary := dirs.SnapAssertsUsersCreateDisabledFile
+	if opts != nil {
+		autoimportCanary = filepath.Join(opts.RootDir, autoimportCanary)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(autoimportCanary), 0755); err != nil {
+		return err
+	}
+
+	if disabled {
+		if err := ioutil.WriteFile(autoimportCanary, []byte("snapd autoimport user creation has been disabled\n"), 0644); err != nil {
+			return err
+		}
+	} else {
+		err := os.Remove(autoimportCanary)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func handleUsersCreateConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+	output, err := coreCfg(tr, "users.create")
+	if err != nil {
+		return err
+	}
+
+	switch output {
+	case "", "true":
+		return switchHandleUsersCreate(false, opts)
+	default:
+		return switchHandleUsersCreate(true, opts)
+	}
+}


### PR DESCRIPTION
We have had requests too have an option to disable the creation of a user when a system-user assertion is auto-imported. This change adds a `core.users.create` option that defaults to `true`.

Since the auto-import mechanism can be used for other assertions, this option only disables the user-creation step and does not stop the assertion(s) from being imported. Also, it does not prohibit user creation from other mechanisms e.g. command-line or API.