### PR TITLE
bootloader/lkenv: specify backup file as arg to NewEnv(), use "" as path+"bak"

### DIFF
--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -102,7 +102,7 @@ func MockLkFiles(c *C, rootdir string, opts *Options) {
 	err = ioutil.WriteFile(l.envFile(), buf, 0660)
 	c.Assert(err, IsNil)
 	// now write env in it with correct crc
-	env := lkenv.NewEnv(l.envFile(), lkenv.V1)
+	env := lkenv.NewEnv(l.envFile(), "", lkenv.V1)
 	env.InitializeBootPartitions("boot_a", "boot_b")
 	err = env.Save()
 	c.Assert(err, IsNil)

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -95,7 +95,7 @@ func (l *lk) envFile() string {
 func (l *lk) GetBootVars(names ...string) (map[string]string, error) {
 	out := make(map[string]string)
 
-	env := lkenv.NewEnv(l.envFile(), lkenv.V1)
+	env := lkenv.NewEnv(l.envFile(), "", lkenv.V1)
 	if err := env.Load(); err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (l *lk) GetBootVars(names ...string) (map[string]string, error) {
 }
 
 func (l *lk) SetBootVars(values map[string]string) error {
-	env := lkenv.NewEnv(l.envFile(), lkenv.V1)
+	env := lkenv.NewEnv(l.envFile(), "", lkenv.V1)
 	if err := env.Load(); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -142,7 +142,7 @@ func (l *lk) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
 
 	logger.Debugf("ExtractKernelAssets (%s)", blobName)
 
-	env := lkenv.NewEnv(l.envFile(), lkenv.V1)
+	env := lkenv.NewEnv(l.envFile(), "", lkenv.V1)
 	if err := env.Load(); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -202,7 +202,7 @@ func (l *lk) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
 func (l *lk) RemoveKernelAssets(s snap.PlaceInfo) error {
 	blobName := s.Filename()
 	logger.Debugf("RemoveKernelAssets (%s)", blobName)
-	env := lkenv.NewEnv(l.envFile(), lkenv.V1)
+	env := lkenv.NewEnv(l.envFile(), "", lkenv.V1)
 	if err := env.Load(); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/bootloader/lk_test.go
+++ b/bootloader/lk_test.go
@@ -139,7 +139,7 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksCustomBootimgImageBuilding(c
 	c.Assert(l, NotNil)
 
 	// first configure custom boot image file name
-	env := lkenv.NewEnv(bootloader.LkConfigFile(l), lkenv.V1)
+	env := lkenv.NewEnv(bootloader.LkConfigFile(l), "", lkenv.V1)
 	env.Load()
 	env.Set("bootimg_file_name", "boot-2.img")
 	err := env.Save()
@@ -188,7 +188,7 @@ func (s *lkTestSuite) TestExtractKernelAssetsUnpacksAndRemoveInRuntimeMode(c *C)
 	}
 	// ensure we have a valid boot env
 	bootselPartition := filepath.Join(s.rootdir, "/dev/disk/by-partlabel/snapbootsel")
-	lkenv := lkenv.NewEnv(bootselPartition, lkenv.V1)
+	lkenv := lkenv.NewEnv(bootselPartition, "", lkenv.V1)
 	lkenv.InitializeBootPartitions("boot_a", "boot_b")
 	err := lkenv.Save()
 	c.Assert(err, IsNil)

--- a/bootloader/lkenv/lkenv.go
+++ b/bootloader/lkenv/lkenv.go
@@ -153,7 +153,9 @@ type Env struct {
 	path string
 	// pathbak is the backup lkenv object file, it too can either be a regular
 	// file during build time, or a partition device node at run time, and it is
-	// always given by "<path>" + "bak", i.e. $PWD/lk.conf and $PWD/lk.confbak.
+	// typically at prepare-image time given by "<path>" + "bak", i.e.
+	// $PWD/lk.conf and $PWD/lk.confbak but will be different device nodes for
+	// different partitions at runtime.
 	pathbak string
 	// version is the configured version of the lkenv object from NewEnv.
 	version Version
@@ -194,10 +196,15 @@ func copyString(b []byte, s string) {
 // is expected to be a valid lkenv object, then the object should be loaded with
 // the Load() method, otherwise the lkenv object can be manipulated in memory
 // and later written to disk with Save().
-func NewEnv(path string, version Version) *Env {
+func NewEnv(path, backuppath string, version Version) *Env {
+	if backuppath == "" {
+		// legacy behavior is for the backup file to be the same name/dir, but
+		// with "bak" appended to it
+		backuppath = path + "bak"
+	}
 	e := &Env{
 		path:    path,
-		pathbak: path + "bak",
+		pathbak: backuppath,
 		version: version,
 	}
 

--- a/bootloader/lkenv/lkenv.go
+++ b/bootloader/lkenv/lkenv.go
@@ -196,15 +196,15 @@ func copyString(b []byte, s string) {
 // is expected to be a valid lkenv object, then the object should be loaded with
 // the Load() method, otherwise the lkenv object can be manipulated in memory
 // and later written to disk with Save().
-func NewEnv(path, backuppath string, version Version) *Env {
-	if backuppath == "" {
+func NewEnv(path, backupPath string, version Version) *Env {
+	if backupPath == "" {
 		// legacy behavior is for the backup file to be the same name/dir, but
 		// with "bak" appended to it
-		backuppath = path + "bak"
+		backupPath = path + "bak"
 	}
 	e := &Env{
 		path:    path,
-		pathbak: backuppath,
+		pathbak: backupPath,
 		version: version,
 	}
 

--- a/bootloader/lkenv/lkenv_test.go
+++ b/bootloader/lkenv/lkenv_test.go
@@ -132,7 +132,7 @@ func (l *lkenvTestSuite) TestCopyStringNoPanic(c *C) {
 func (l *lkenvTestSuite) TestGetBootImageName(c *C) {
 	for _, version := range lkversions {
 		for _, setValue := range []bool{true, false} {
-			env := lkenv.NewEnv(l.envPath, version)
+			env := lkenv.NewEnv(l.envPath, "", version)
 			c.Check(env, NotNil)
 
 			if setValue {
@@ -173,7 +173,7 @@ func (l *lkenvTestSuite) TestSet(c *C) {
 		},
 	}
 	for _, t := range tt {
-		env := lkenv.NewEnv(l.envPath, t.version)
+		env := lkenv.NewEnv(l.envPath, "", t.version)
 		c.Check(env, NotNil)
 		env.Set(t.key, t.val)
 		c.Check(env.Get(t.key), Equals, t.val)
@@ -248,7 +248,7 @@ func (l *lkenvTestSuite) TestSave(c *C) {
 			err := ioutil.WriteFile(testFile, buf, 0644)
 			c.Assert(err, IsNil, comment)
 
-			env := lkenv.NewEnv(testFile, t.version)
+			env := lkenv.NewEnv(testFile, "", t.version)
 			c.Check(env, NotNil, comment)
 
 			for k, v := range t.keyValuePairs {
@@ -258,7 +258,7 @@ func (l *lkenvTestSuite) TestSave(c *C) {
 			err = env.Save()
 			c.Assert(err, IsNil, comment)
 
-			env2 := lkenv.NewEnv(testFile, t.version)
+			env2 := lkenv.NewEnv(testFile, "", t.version)
 			err = env2.Load()
 			c.Assert(err, IsNil, comment)
 
@@ -268,7 +268,7 @@ func (l *lkenvTestSuite) TestSave(c *C) {
 
 			// check the backup too
 			if makeBackup {
-				env3 := lkenv.NewEnv(testFileBackup, t.version)
+				env3 := lkenv.NewEnv(testFileBackup, "", t.version)
 				err := env3.Load()
 				c.Assert(err, IsNil, comment)
 
@@ -285,7 +285,7 @@ func (l *lkenvTestSuite) TestSave(c *C) {
 				_, err = io.Copy(f, bytes.NewBuffer(buf))
 				c.Assert(err, IsNil, comment)
 
-				env4 := lkenv.NewEnv(testFile, t.version)
+				env4 := lkenv.NewEnv(testFile, "", t.version)
 				err = env4.Load()
 				c.Assert(err, IsNil, comment)
 
@@ -340,13 +340,82 @@ func (l *lkenvTestSuite) TestLoadValidatesCRC32(c *C) {
 		c.Assert(err, IsNil)
 
 		// now try importing the file with LoadEnv()
-		env := lkenv.NewEnv(testFile, version)
+		env := lkenv.NewEnv(testFile, "", version)
 		c.Assert(env, NotNil)
 
 		err = env.LoadEnv(testFile)
 		c.Assert(err, ErrorMatches, fmt.Sprintf("cannot validate %s: expected checksum 0x%X, got 0x%X", testFile, expCrc32, 0))
 	}
 
+}
+
+func (l *lkenvTestSuite) TestNewBackupFileLocation(c *C) {
+	// creating with the second argument as the empty string falls back to
+	// the main path + "bak"
+	for _, version := range lkversions {
+		logbuf, restore := logger.MockLogger()
+		defer restore()
+
+		testFile := filepath.Join(c.MkDir(), "lk.bin")
+		c.Assert(testFile, testutil.FileAbsent)
+		c.Assert(testFile+"bak", testutil.FileAbsent)
+		// make empty files for Save() to overwrite
+		err := ioutil.WriteFile(testFile, nil, 0644)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(testFile+"bak", nil, 0644)
+		c.Assert(err, IsNil)
+		env := lkenv.NewEnv(testFile, "", version)
+		c.Assert(env, NotNil)
+		err = env.Save()
+		c.Assert(err, IsNil)
+
+		// make sure both the primary and backup files were written and can be
+		// successfully loaded
+		env2 := lkenv.NewEnv(testFile, "", version)
+		err = env2.Load()
+		c.Assert(err, IsNil)
+
+		env3 := lkenv.NewEnv(testFile+"bak", "", version)
+		err = env3.Load()
+		c.Assert(err, IsNil)
+
+		// no messages logged
+		c.Assert(logbuf.String(), Equals, "")
+	}
+
+	// now specify a different backup file location
+	for _, version := range lkversions {
+		logbuf, restore := logger.MockLogger()
+		defer restore()
+		testFile := filepath.Join(c.MkDir(), "lk.bin")
+		testFileBackup := filepath.Join(c.MkDir(), "lkbackup.bin")
+		err := ioutil.WriteFile(testFile, nil, 0644)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(testFileBackup, nil, 0644)
+		c.Assert(err, IsNil)
+
+		env := lkenv.NewEnv(testFile, testFileBackup, version)
+		c.Assert(env, NotNil)
+		err = env.Save()
+		c.Assert(err, IsNil)
+
+		// make sure both the primary and backup files were written and can be
+		// successfully loaded
+		env2 := lkenv.NewEnv(testFile, "", version)
+		err = env2.Load()
+		c.Assert(err, IsNil)
+
+		env3 := lkenv.NewEnv(testFileBackup, "", version)
+		err = env3.Load()
+		c.Assert(err, IsNil)
+
+		// no "bak" files present
+		c.Assert(testFile+"bak", testutil.FileAbsent)
+		c.Assert(testFileBackup+"bak", testutil.FileAbsent)
+
+		// no messages logged
+		c.Assert(logbuf.String(), Equals, "")
+	}
 }
 
 func (l *lkenvTestSuite) TestLoadValidatesVersionSignatureConsistency(c *C) {
@@ -436,7 +505,7 @@ func (l *lkenvTestSuite) TestLoadValidatesVersionSignatureConsistency(c *C) {
 		c.Assert(err, IsNil)
 
 		// now try importing the file with LoadEnv()
-		env := lkenv.NewEnv(testFile, t.version)
+		env := lkenv.NewEnv(testFile, "", t.version)
 		c.Assert(env, NotNil)
 
 		var expNum, gotNum uint32
@@ -480,7 +549,7 @@ func (l *lkenvTestSuite) TestLoad(c *C) {
 			c.Assert(err, IsNil)
 
 			// create an env for this file and try to load it
-			env := lkenv.NewEnv(testFile, version)
+			env := lkenv.NewEnv(testFile, "", version)
 			c.Check(env, NotNil)
 
 			err = env.Load()
@@ -617,7 +686,7 @@ func (l *lkenvTestSuite) TestGetAndSetAndFindBootPartition(c *C) {
 		err := ioutil.WriteFile(l.envPath, buf, 0644)
 		c.Assert(err, IsNil, comment)
 
-		env := lkenv.NewEnv(l.envPath, t.version)
+		env := lkenv.NewEnv(l.envPath, "", t.version)
 		c.Assert(env, Not(IsNil), comment)
 
 		var findFunc func(string) (string, error)
@@ -724,7 +793,7 @@ func (l *lkenvTestSuite) TestGetAndSetAndFindBootPartition(c *C) {
 }
 
 func (l *lkenvTestSuite) TestV1NoRecoverySystemSupport(c *C) {
-	env := lkenv.NewEnv(l.envPath, lkenv.V1)
+	env := lkenv.NewEnv(l.envPath, "", lkenv.V1)
 	c.Assert(env, NotNil)
 
 	_, err := env.FindFreeRecoverySystemBootPartition("blah")
@@ -741,7 +810,7 @@ func (l *lkenvTestSuite) TestV1NoRecoverySystemSupport(c *C) {
 }
 
 func (l *lkenvTestSuite) TestV2RunNoRecoverySystemSupport(c *C) {
-	env := lkenv.NewEnv(l.envPath, lkenv.V2Run)
+	env := lkenv.NewEnv(l.envPath, "", lkenv.V2Run)
 	c.Assert(env, NotNil)
 
 	_, err := env.FindFreeRecoverySystemBootPartition("blah")
@@ -758,7 +827,7 @@ func (l *lkenvTestSuite) TestV2RunNoRecoverySystemSupport(c *C) {
 }
 
 func (l *lkenvTestSuite) TestV2RecoveryNoKernelSupport(c *C) {
-	env := lkenv.NewEnv(l.envPath, lkenv.V2Recovery)
+	env := lkenv.NewEnv(l.envPath, "", lkenv.V2Recovery)
 	c.Assert(env, NotNil)
 
 	_, err := env.FindFreeKernelBootPartition("blah")
@@ -808,7 +877,7 @@ func (l *lkenvTestSuite) TestZippedDataSample(c *C) {
 	err = ioutil.WriteFile(l.envPathbak, rawData, 0644)
 	c.Assert(err, IsNil)
 
-	env := lkenv.NewEnv(l.envPath, lkenv.V1)
+	env := lkenv.NewEnv(l.envPath, "", lkenv.V1)
 	c.Check(env, NotNil)
 	err = env.Load()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
To simplify existing code, use "" as the backup file to mean path+"bak".

Also add tests that when specifying a non-empty string as the backup file that
we don't use the legacy backup file handling logic.

This will resolve the issue we have in #9695 around passing in `/dev/disk/by-partuuid/1234` as the primary file and then getting `/dev/disk/by-partuuid/1234bak` as the backup file.