### PR TITLE
gadget: disable ubuntu-boot role validation check

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -625,8 +625,11 @@ func validateCrossVolumeStructure(structures []LaidOutStructure, knownStructures
 
 var (
 	reservedLabels = []string{
-		ubuntuBootLabel, ubuntuSeedLabel,
-		ubuntuDataLabel, ubuntuSaveLabel,
+		// 2020-12-02 disabled because of customer gadget hotfix
+		/*ubuntuBootLabel,*/
+		ubuntuSeedLabel,
+		ubuntuDataLabel,
+		ubuntuSaveLabel,
 	}
 )
 

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1296,7 +1296,8 @@ func (s *gadgetYamlTestSuite) TestValidateStructureReservedLabels(c *C) {
 		role, label, err string
 	}{
 		{label: "ubuntu-seed", err: `label "ubuntu-seed" is reserved`},
-		{label: "ubuntu-boot", err: `label "ubuntu-boot" is reserved`},
+		// 2020-12-02: disable for customer hotfix
+		/*{label: "ubuntu-boot", err: `label "ubuntu-boot" is reserved`},*/
 		{label: "ubuntu-data", err: `label "ubuntu-data" is reserved`},
 		{label: "ubuntu-save", err: `label "ubuntu-save" is reserved`},
 		// these are ok


### PR DESCRIPTION
A customer with a gadget snap that has a "ubuntu-boot" label
in the wild is broken by this new validation in 2.48. This
commit fixes this.

