### PR TITLE
secboot: use `fde-reveal-key` if available to unseal key

### DIFF
--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -184,5 +184,12 @@ func MockFDEHasRevealKey(f func() bool) (restore func()) {
 	return func() {
 		FDEHasRevealKey = old
 	}
+}
 
+func MockFdeRevealKeyCommandExtra(args []string) (restore func()) {
+	oldFdeRevealKeyCommandExtra := fdeRevealKeyCommandExtra
+	fdeRevealKeyCommandExtra = args
+	return func() {
+		fdeRevealKeyCommandExtra = oldFdeRevealKeyCommandExtra
+	}
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -295,6 +295,7 @@ var fdeRevealKeyRuntimeMax = "2m"
 // fdeRevealKeyCommand returns a *exec.Cmd that is suitable to run
 // fde-reveal-key using systemd-run
 func fdeRevealKeyCommand() *exec.Cmd {
+	// TODO: put this into a new "systemd/run" package
 	return exec.Command(
 		"systemd-run",
 		"--pipe", "--same-dir", "--wait", "--collect",

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -310,8 +310,12 @@ func fdeRevealKeyCommand() *exec.Cmd {
 		fmt.Sprintf("--property=RuntimeMaxSec=%s", fdeRevealKeyRuntimeMax),
 		// this ensures we get useful output for e.g. segfaults
 		`--property=ExecStopPost=/bin/sh -c 'if [ "$EXIT_STATUS" != 0 ]; then echo "service result: $SERVICE_RESULT" 1>&2; fi'`,
-		// do not allow mounting, this ensures hooks in initrd
-		// can not mess around with ubuntu-data
+		// Do not allow mounting, this ensures hooks in initrd
+		// can not mess around with ubuntu-data.
+		//
+		// Note that this is not about perfect confinement, more about
+		// making sure that people using the hook know that we do not
+		// want them to mess around outside of just providing unseal.
 		"--property=SystemCallFilter=~@mount",
 	)
 	if fdeRevealKeyCommandExtra != nil {

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -292,7 +292,7 @@ type FDERevealKeyRequest struct {
 // XXX: what is a reasonable default here?
 var fdeRevealKeyRuntimeMax = "2m"
 
-// overriden in tests
+// overridden in tests
 var fdeRevealKeyCommandExtra []string
 
 // fdeRevealKeyCommand returns a *exec.Cmd that is suitable to run
@@ -308,6 +308,7 @@ func fdeRevealKeyCommand() *exec.Cmd {
 		// reasonable timeout and output from systemd if
 		// things go wrong
 		fmt.Sprintf("--property=RuntimeMaxSec=%s", fdeRevealKeyRuntimeMax),
+		// this ensures we get useful output for e.g. segfaults
 		`--property=ExecStopPost=/bin/sh -c 'if [ "$EXIT_STATUS" != 0 ]; then echo "service result: $SERVICE_RESULT" 1>&2; fi'`,
 		// do not allow mounting, this ensures hooks in initrd
 		// can not mess around with ubuntu-data

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -340,7 +340,7 @@ func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourc
 	if err := unlockEncryptedPartitionWithKey(mapperName, sourceDevice, unsealedKey); err != nil {
 		return res, fmt.Errorf("cannot unlock encrypted partition: %v", err)
 	}
-
+	res.FsDevice = targetDevice
 	res.UnlockMethod = UnlockedWithSealedKey
 	return res, nil
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -282,8 +282,8 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, sealedE
 type FDERevealKeyRequest struct {
 	Op string `json:"op"`
 
-	SealedKey     []byte `json:"sealed-key"`
-	SealedKeyName string `json:"sealed-key-name"`
+	SealedKey []byte `json:"sealed-key"`
+	KeyName   string `json:"key-name"`
 
 	// TODO: add VolumeName,SourceDevicePath later
 }

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -1160,6 +1160,11 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKey(c *
 	})
 	defer restore()
 
+	restore = secboot.MockRandomKernelUUID(func() string {
+		return "random-uuid-for-test"
+	})
+	defer restore()
+
 	mockDiskWithEncDev := &disks.MockDiskMapping{
 		FilesystemLabelToPartUUID: map[string]string{
 			"name-enc": "enc-dev-partuuid",
@@ -1191,6 +1196,7 @@ printf "unsealed-key-from-hook"
 		UnlockMethod: secboot.UnlockedWithSealedKey,
 		IsEncrypted:  true,
 		PartDevice:   "/dev/disk/by-partuuid/enc-dev-partuuid",
+		FsDevice:     "/dev/mapper/name-random-uuid-for-test",
 	})
 	c.Check(mockSystemdRun.Calls(), DeepEquals, [][]string{
 		{


### PR DESCRIPTION
This commit implements running fde-reveal-key and using the
output to unlock a disk that was previously sealed using the
fde-setup hook.
