### PR TITLE
interfaces/apparmor: fix generating of extended s-c AppArmor profiles with /usr/libexec

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -412,3 +412,14 @@ func MockFeatures(kernelFeatures []string, kernelError error, parserFeatures []s
 	}
 
 }
+
+// ProfileNameForPath returns he name of the profile for an executable at given
+// path.
+func ProfileNameForPath(path string) (string, error) {
+	path = filepath.Clean(path)
+	relToRoot, err := filepath.Rel("/", path)
+	if err != nil {
+		return "", fmt.Errorf("cannot make path %q relative to /", path)
+	}
+	return strings.Replace(relToRoot, "/", ".", -1), nil
+}

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -303,3 +303,21 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 	_, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
 }
+
+func (s *apparmorSuite) TestProfileNameForPath(c *C) {
+	p, err := apparmor.ProfileNameForPath("/usr/lib/snapd/snap-confine")
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, "usr.lib.snapd.snap-confine")
+
+	p, err = apparmor.ProfileNameForPath("/usr/lib/snapd/snap-confine.real")
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, "usr.lib.snapd.snap-confine.real")
+
+	p, err = apparmor.ProfileNameForPath("/usr/libexec/snapd/snap-confine")
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, "usr.libexec.snapd.snap-confine")
+
+	p, err = apparmor.ProfileNameForPath("usr/lib/snapd/snap-confine")
+	c.Assert(err, ErrorMatches, `cannot make path "usr/lib/snapd/snap-confine" relative to /`)
+	c.Check(p, Equals, "")
+}


### PR DESCRIPTION
The path to the AppArmor profile was hardcoded. Thus when one tries to use openSUSE Tumbleweed with home on NFS, snapd will fail.