### PR TITLE
packaging/opensuse: enable AppArmor on Leap

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -23,7 +23,7 @@
 # Enable AppArmor on openSUSE Tumbleweed (post 15.0) or higher
 # N.B.: Prior to openSUSE Tumbleweed in May 2018, the AppArmor userspace in SUSE
 # did not support what we needed to be able to turn on basic integration.
-%if 0%{?suse_version} >= 1550
+%if 0%{?suse_version} >= 1500
 %bcond_without apparmor
 %else
 %bcond_with apparmor


### PR DESCRIPTION
The current state of snapd and AppArmor support on Leap is confusing. The kernel seemingly has most features:
```
AppArmor status: apparmor is enabled but some kernel features are missing: dbus
```
AppArmor parser version (eg. 18.04 has 2.12):
```
linux@localhost:~> sudo apparmor_parser --version
AppArmor parser version 2.12.3
```

This leads to a confusing state where snapd tries to use AppArmor, i.e. tries to extend s-c profile when home is on NFS, or / is on overlay, as well as generates (degraded) profiles for snaps, but snap-confine lacks AppArmor support so the profiles are not used. Additionally, not having s-c AppArmor profile shipped by the package, extending its profile will trigger failure like described in https://forum.snapcraft.io/t/snapd-doesnt-start-on-opensuse-leap-15-1/13710/10.