### PR TITLE
boot: add sealKeyToModeenvUsingFdeSetupHook()

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -167,3 +167,17 @@ func (b *bootChain) SetKernelBootFile(kbf bootloader.BootFile) {
 func (b *bootChain) KernelBootFile() bootloader.BootFile {
 	return b.kernelBootFile
 }
+
+func MockHasFDESetupHook(f func() (bool, error)) (restore func()) {
+	oldHasFDESetupHook := HasFDESetupHook
+	HasFDESetupHook = f
+	return func() {
+		HasFDESetupHook = oldHasFDESetupHook
+	}
+}
+
+func MockRunFDESetupHook(f func(string, *FDESetupHookParams) ([]byte, error)) (restore func()) {
+	oldRunFDESetupHook := RunFDESetupHook
+	RunFDESetupHook = f
+	return func() { RunFDESetupHook = oldRunFDESetupHook }
+}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -100,7 +100,7 @@ func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, 
 		return fmt.Errorf("cannot check for fde-setup hook %v", err)
 	}
 	if hasHook {
-		return sealKeyToModeenvUsingFdeSetupHook(key, saveKey, model, modeenv)
+		return sealKeyToModeenvUsingFDESetupHook(key, saveKey, model, modeenv)
 	}
 
 	return sealKeyToModeenvUsingSecboot(key, saveKey, model, modeenv)
@@ -128,7 +128,7 @@ func fallbackKeySealRequests(key, saveKey secboot.EncryptionKey) []secboot.SealK
 	}
 }
 
-func sealKeyToModeenvUsingFdeSetupHook(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
+func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
 	// TODO: support full boot chains
 
 	for _, skr := range append(runKeySealRequests(key), fallbackKeySealRequests(key, saveKey)...) {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -140,10 +140,10 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 		}
 		sealedKey, err := RunFDESetupHook("initial-setup", params)
 		if err != nil {
-			return fmt.Errorf("cannot run fde-setup hook for %s: %v", params.KeyName, err)
+			return err
 		}
 		if err := osutil.AtomicWriteFile(filepath.Join(skr.KeyFile), sealedKey, 0600, 0); err != nil {
-			return fmt.Errorf("cannot store %s key: %v", params.KeyName, err)
+			return fmt.Errorf("cannot store key: %v", err)
 		}
 	}
 	return nil

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -133,9 +133,10 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 
 	for _, skr := range append(runKeySealRequests(key), fallbackKeySealRequests(key, saveKey)...) {
 		params := &FDESetupHookParams{
-			Key:     skr.Key,
-			KeyName: filepath.Base(skr.KeyFile),
-			Models:  []*asserts.Model{model},
+			Key: skr.Key,
+			// TODO: decide what the right KeyName is
+			// KeyName: filepath.Base(skr.KeyFile),
+			Models: []*asserts.Model{model},
 		}
 		sealedKey, err := RunFDESetupHook("initial-setup", params)
 		if err != nil {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -295,12 +295,24 @@ func hasSealedKeys(rootdir string) bool {
 	return osutil.FileExists(stamp)
 }
 
+func resealKeyToModeenvUsingFDESetupHook(rootdir string, model *asserts.Model, modeenv *Modeenv, expectReseal bool) error {
+	// TODO: implement reseal using the fde-setup hook
+	return nil
+}
+
 // resealKeyToModeenv reseals the existing encryption key to the
 // parameters specified in modeenv.
 func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, expectReseal bool) error {
 	if !hasSealedKeys(rootdir) {
 		// nothing to do
 		return nil
+	}
+	hasHook, err := HasFDESetupHook()
+	if err != nil {
+		return fmt.Errorf("cannot check for fde-setup hook in reseal %v", err)
+	}
+	if hasHook {
+		return resealKeyToModeenvUsingFDESetupHook(rootdir, model, modeenv, expectReseal)
 	}
 
 	// build the recovery mode boot chain

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -64,7 +64,7 @@ type FDESetupHookParams struct {
 	Key     secboot.EncryptionKey
 	KeyName string
 
-	Model *asserts.Model
+	Models []*asserts.Model
 
 	//TODO:UC20: provide bootchains and a way to track measured
 	//boot-assets
@@ -135,7 +135,7 @@ func sealKeyToModeenvUsingFdeSetupHook(key, saveKey secboot.EncryptionKey, model
 		params := &FDESetupHookParams{
 			Key:     skr.Key,
 			KeyName: filepath.Base(skr.KeyFile),
-			Model:   model,
+			Models:  []*asserts.Model{model},
 		}
 		sealedKey, err := RunFDESetupHook("initial-setup", params)
 		if err != nil {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -146,6 +146,11 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 			return fmt.Errorf("cannot store key: %v", err)
 		}
 	}
+
+	if err := stampSealedKeys(InstallHostWritableDir, "fde-setup-hook"); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -206,7 +211,7 @@ func sealKeyToModeenvUsingSecboot(key, saveKey secboot.EncryptionKey, model *ass
 		return err
 	}
 
-	if err := stampSealedKeys(InstallHostWritableDir); err != nil {
+	if err := stampSealedKeys(InstallHostWritableDir, "tpm"); err != nil {
 		return err
 	}
 
@@ -270,13 +275,13 @@ func sealFallbackObjectKeys(key, saveKey secboot.EncryptionKey, pbc predictableB
 	return nil
 }
 
-func stampSealedKeys(rootdir string) error {
+func stampSealedKeys(rootdir, content string) error {
 	stamp := filepath.Join(dirs.SnapFDEDirUnder(rootdir), "sealed-keys")
 	if err := os.MkdirAll(filepath.Dir(stamp), 0755); err != nil {
 		return fmt.Errorf("cannot create device fde state directory: %v", err)
 	}
 
-	if err := osutil.AtomicWriteFile(stamp, nil, 0644, 0); err != nil {
+	if err := osutil.AtomicWriteFile(stamp, []byte(content), 0644, 0); err != nil {
 		return fmt.Errorf("cannot create fde sealed keys stamp file: %v", err)
 	}
 	return nil

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -309,7 +309,7 @@ func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, 
 	}
 	hasHook, err := HasFDESetupHook()
 	if err != nil {
-		return fmt.Errorf("cannot check for fde-setup hook in reseal %v", err)
+		return fmt.Errorf("cannot check for fde-setup hook in reseal: %v", err)
 	}
 	if hasHook {
 		return resealKeyToModeenvUsingFDESetupHook(rootdir, model, modeenv, expectReseal)

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -951,7 +951,6 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 	}
 	marker := filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys")
 	c.Check(marker, testutil.FileEquals, "fde-setup-hook")
-
 }
 
 func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -298,8 +298,8 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		})
 
 		// marker
-		c.Check(filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys"), testutil.FilePresent)
-
+		marker := filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys")
+		c.Check(marker, testutil.FileEquals, "tpm")
 	}
 }
 
@@ -949,6 +949,9 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 	} {
 		c.Check(p, testutil.FileEquals, "sealed-key: "+strconv.Itoa(i+1))
 	}
+	marker := filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys")
+	c.Check(marker, testutil.FileEquals, "fde-setup-hook")
+
 }
 
 func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
@@ -975,4 +978,6 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 	model := boottest.MakeMockUC20Model()
 	err := boot.SealKeyToModeenv(key, saveKey, model, modeenv)
 	c.Assert(err, ErrorMatches, "hook failed")
+	marker := filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys")
+	c.Check(marker, testutil.FileAbsent)
 }

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -935,9 +935,9 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookFailsToday(c *C) {
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way
 	c.Check(runFDESetupHookParams, DeepEquals, []*boot.FDESetupHookParams{
-		{KeyName: "ubuntu-data.sealed-key", Key: secboot.EncryptionKey{1, 2, 3, 4}, Model: model},
-		{KeyName: "ubuntu-data.recovery.sealed-key", Key: secboot.EncryptionKey{1, 2, 3, 4}, Model: model},
-		{KeyName: "ubuntu-save.recovery.sealed-key", Key: secboot.EncryptionKey{5, 6, 7, 8}, Model: model},
+		{KeyName: "ubuntu-data.sealed-key", Key: secboot.EncryptionKey{1, 2, 3, 4}, Models: []*asserts.Model{model}},
+		{KeyName: "ubuntu-data.recovery.sealed-key", Key: secboot.EncryptionKey{1, 2, 3, 4}, Models: []*asserts.Model{model}},
+		{KeyName: "ubuntu-save.recovery.sealed-key", Key: secboot.EncryptionKey{5, 6, 7, 8}, Models: []*asserts.Model{model}},
 	})
 	// check that the sealed keys got written to the expected places
 	for _, p := range []string{

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1418,7 +1418,7 @@ func (m *DeviceManager) runFDESetupHook(op string, params *boot.FDESetupHookPara
 	}
 	req := &fde.SetupRequest{
 		Op:      op,
-		Key:     params.Key,
+		Key:     &params.Key,
 		KeyName: params.KeyName,
 		Model: map[string]string{
 			"series":     params.Model.Series(),

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1420,14 +1420,16 @@ func (m *DeviceManager) runFDESetupHook(op string, params *boot.FDESetupHookPara
 		Op:      op,
 		Key:     &params.Key,
 		KeyName: params.KeyName,
-		Model: map[string]string{
-			"series":     params.Model.Series(),
-			"brand-id":   params.Model.BrandID(),
-			"model":      params.Model.Model(),
-			"grade":      string(params.Model.Grade()),
-			"signkey-id": params.Model.SignKeyID(),
-		},
 		// TODO: include boot chains
+	}
+	for _, model := range params.Models {
+		req.Models = append(req.Models, map[string]string{
+			"series":     model.Series(),
+			"brand-id":   model.BrandID(),
+			"model":      model.Model(),
+			"grade":      string(model.Grade()),
+			"signkey-id": model.SignKeyID(),
+		})
 	}
 	contextData := map[string]interface{}{
 		"fde-setup-request": req,

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1348,12 +1348,14 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 			Op:      "initial-setup",
 			Key:     &mockKey,
 			KeyName: "some-key-name",
-			Model: map[string]string{
-				"series":     "16",
-				"brand-id":   "canonical",
-				"model":      "pc",
-				"grade":      "unset",
-				"signkey-id": mockModel.SignKeyID(),
+			Models: []map[string]string{
+				{
+					"series":     "16",
+					"brand-id":   "canonical",
+					"model":      "pc",
+					"grade":      "unset",
+					"signkey-id": mockModel.SignKeyID(),
+				},
 			},
 		})
 
@@ -1372,7 +1374,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 	params := &boot.FDESetupHookParams{
 		Key:     mockKey,
 		KeyName: "some-key-name",
-		Model:   mockModel,
+		Models:  []*asserts.Model{mockModel},
 	}
 	st.Lock()
 	data, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)
@@ -1411,7 +1413,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrors(c *C) {
 	params := &boot.FDESetupHookParams{
 		Key:     secboot.EncryptionKey{1, 2, 3, 4},
 		KeyName: "some-key-name",
-		Model:   mockModel,
+		Models:  []*asserts.Model{mockModel},
 	}
 	st.Lock()
 	_, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)
@@ -1455,7 +1457,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrorResult(c *C) {
 	params := &boot.FDESetupHookParams{
 		Key:     secboot.EncryptionKey{1, 2, 3, 4},
 		KeyName: "some-key-name",
-		Model:   mockModel,
+		Models:  []*asserts.Model{mockModel},
 	}
 	st.Lock()
 	_, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1370,7 +1370,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 	defer s.o.Stop()
 
 	params := &boot.FDESetupHookParams{
-		Key:     &mockKey,
+		Key:     mockKey,
 		KeyName: "some-key-name",
 		Model:   mockModel,
 	}
@@ -1409,7 +1409,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrors(c *C) {
 	defer s.o.Stop()
 
 	params := &boot.FDESetupHookParams{
-		Key:     &secboot.EncryptionKey{1, 2, 3, 4},
+		Key:     secboot.EncryptionKey{1, 2, 3, 4},
 		KeyName: "some-key-name",
 		Model:   mockModel,
 	}
@@ -1453,7 +1453,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrorResult(c *C) {
 	defer s.o.Stop()
 
 	params := &boot.FDESetupHookParams{
-		Key:     &secboot.EncryptionKey{1, 2, 3, 4},
+		Key:     secboot.EncryptionKey{1, 2, 3, 4},
 		KeyName: "some-key-name",
 		Model:   mockModel,
 	}

--- a/overlord/devicestate/fde/fde.go
+++ b/overlord/devicestate/fde/fde.go
@@ -55,11 +55,9 @@ type SetupRequest struct {
 	Key     *secboot.EncryptionKey `json:"key,omitempty"`
 	KeyName string                 `json:"key-name,omitempty"`
 
-	// Model related fields, this will be set to follow the
-	// secboot:SnapModel interface.
-	//
-	// XXX: do we need this to be a list? i.e. multiple models?
-	Model map[string]string `json:"model,omitempty"`
+	// List of model with their related fields, this will be set
+	// to follow the secboot:SnapModel interface.
+	Models []map[string]string `json:"models,omitempty"`
 
 	// TODO: provide LoadChains, KernelCmdline etc to support full
 	//       tpm sealing

--- a/overlord/devicestate/fde/fde.go
+++ b/overlord/devicestate/fde/fde.go
@@ -55,7 +55,7 @@ type SetupRequest struct {
 	Key     *secboot.EncryptionKey `json:"key,omitempty"`
 	KeyName string                 `json:"key-name,omitempty"`
 
-	// List of model with their related fields, this will be set
+	// List of models with their related fields, this will be set
 	// to follow the secboot:SnapModel interface.
 	Models []map[string]string `json:"models,omitempty"`
 

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -131,12 +131,14 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 		Op:      "initial-setup",
 		Key:     &secboot.EncryptionKey{1, 2, 3, 4},
 		KeyName: "the-key-name",
-		Model: map[string]string{
-			"series":     "16",
-			"brand-id":   "my-brand",
-			"model":      "my-model",
-			"grade":      "secured",
-			"signkey-id": "the-signkey-id",
+		Models: []map[string]string{
+			{
+				"series":     "16",
+				"brand-id":   "my-brand",
+				"model":      "my-model",
+				"grade":      "secured",
+				"signkey-id": "the-signkey-id",
+			},
 		},
 	}
 	s.mockContext.Lock()
@@ -147,7 +149,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 	c.Assert(err, IsNil)
 
 	jsonEncodedEncryptionKey := `[1,2,3,4,` + strings.Repeat("0,", len(secboot.EncryptionKey{})-5) + `0]`
-	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%s,"key-name":"the-key-name","model":{"brand-id":"my-brand","grade":"secured","model":"my-model","series":"16","signkey-id":"the-signkey-id"}}`+"\n", jsonEncodedEncryptionKey))
+	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%s,"key-name":"the-key-name","models":[{"brand-id":"my-brand","grade":"secured","model":"my-model","series":"16","signkey-id":"the-signkey-id"}]}`+"\n", jsonEncodedEncryptionKey))
 	c.Check(string(stderr), Equals, "")
 }
 


### PR DESCRIPTION
This commit adds code so that sealKeyToModeenvUsingFdeSetupHook()
actually writes sealed keys to the expected places.

Preview at this point, needs more tests.

Build on top of https://github.com/snapcore/snapd/pull/9705 
(which needs to squash merged first and then this need to be re-based on top of master)