### PR TITLE
interfaces/builtin/log_observe.go: allow controlling apparmor audit levels

### DIFF
--- a/interfaces/builtin/log_observe.go
+++ b/interfaces/builtin/log_observe.go
@@ -53,6 +53,17 @@ const logObserveConnectedPlugAppArmor = `
 /{,usr/}sbin/sysctl ixr,
 @{PROC}/sys/kernel/printk_ratelimit rw,
 
+# Allow controlling apparmor logging levels, the possible values written to this
+# are as follows:
+# normal       - return to normal auditing behavior
+# quiet_denied - don't log denial messages
+# quiet        - turn off all auditing
+# noquiet      - turn of quieting of denial messages by the quiet flag (what deny rules set unless preceded by the audit keyword)
+# all          - audit everything even stuff that is being allowed, it is very noisy
+# Note that we cannot restrict what is written to the file, we can only allow
+# all writes to the file.
+/sys/module/apparmor/parameters/audit rw,
+
 # Allow resolving kernel seccomp denials
 /usr/bin/scmp_sys_resolver ixr,
 


### PR DESCRIPTION
This is similar in purpose to allowing writes to /sys/kernel/printk_ratelimit.

This will allow i.e. snappy-debug to write `noquiet` to this file and thus show file accesses that were denied, even when a snap is in devmode. This is not quite as useful as my original proposal with [this other PR](https://github.com/snapcore/snapd/pull/8019), but it is more useful than the status quo since if a user runs snappy-debug as root, then tries to debug their devmode snap, they will at least see the denied accesses whereas today those accesses will not be seen.

This is supported since kernel version 2.X so this should be safe for snappy-debug to do on all systems which support snaps.

CC @jrjohansen who notified me of this :smile: 