### PR TITLE
gadget: start separating rule/convention validation from basic soundness 

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -36,6 +36,7 @@ var (
 	ValidateRole            = validateRole
 	ValidateVolume          = validateVolume
 
+	RuleValidateVolumes         = ruleValidateVolumes
 	RuleValidateVolumeStructure = ruleValidateVolumeStructure
 	EnsureVolumeRuleConsistency = ensureVolumeRuleConsistency
 

--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -36,6 +36,9 @@ var (
 	ValidateRole            = validateRole
 	ValidateVolume          = validateVolume
 
+	RuleValidateVolumeStructure = ruleValidateVolumeStructure
+	EnsureVolumeRuleConsistency = ensureVolumeRuleConsistency
+
 	ResolveVolume      = resolveVolume
 	CanUpdateStructure = canUpdateStructure
 	CanUpdateVolume    = canUpdateVolume
@@ -45,8 +48,6 @@ var (
 	RawContentBackupPath = rawContentBackupPath
 
 	UpdaterForStructure = updaterForStructure
-
-	EnsureVolumeConsistency = ensureVolumeConsistency
 
 	Flatten = flatten
 

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -25,7 +25,188 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil"
 )
+
+type validationState struct {
+	SystemSeed *VolumeStructure
+	SystemData *VolumeStructure
+	SystemBoot *VolumeStructure
+	SystemSave *VolumeStructure
+}
+
+func ruleValidateVolumes(vols map[string]Volume, model Model) error {
+	for name, v := range vols {
+		if err := ruleValidateVolume(name, &v, model); err != nil {
+			return fmt.Errorf("invalid volume %q: %v", name, err)
+		}
+	}
+	return nil
+}
+
+func ruleValidateVolume(name string, vol *Volume, model Model) error {
+	state := &validationState{}
+
+	for idx, s := range vol.Structure {
+		if err := ruleValidateVolumeStructure(&s); err != nil {
+			return fmt.Errorf("invalid structure %v: %v", fmtIndexAndName(idx, s.Name), err)
+		}
+
+		// XXX what about implicit roles?
+		switch s.Role {
+		case SystemSeed:
+			if state.SystemSeed != nil {
+				return fmt.Errorf("cannot have more than one partition with system-seed role")
+			}
+			state.SystemSeed = &vol.Structure[idx]
+		case SystemData:
+			if state.SystemData != nil {
+				return fmt.Errorf("cannot have more than one partition with system-data role")
+			}
+			state.SystemData = &vol.Structure[idx]
+		case SystemBoot:
+			if state.SystemBoot != nil {
+				return fmt.Errorf("cannot have more than one partition with system-boot role")
+			}
+			state.SystemBoot = &vol.Structure[idx]
+		case SystemSave:
+			if state.SystemSave != nil {
+				return fmt.Errorf("cannot have more than one partition with system-save role")
+			}
+			state.SystemSave = &vol.Structure[idx]
+		}
+
+	}
+
+	if err := ensureVolumeRuleConsistency(state, model); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ruleValidateVolumeStructure(vs *VolumeStructure) error {
+	if err := validateReservedLabels(vs); err != nil {
+		return err
+	}
+	return nil
+}
+
+var (
+	reservedLabels = []string{
+		// 2020-12-02 disabled because of customer gadget hotfix
+		/*ubuntuBootLabel,*/
+		ubuntuSeedLabel,
+		ubuntuDataLabel,
+		ubuntuSaveLabel,
+	}
+)
+
+func validateReservedLabels(vs *VolumeStructure) error {
+	if vs.Role != "" {
+		// structure specifies a role, its labels will be checked later
+		return nil
+	}
+	if vs.Label == "" {
+		return nil
+	}
+	if strutil.ListContains(reservedLabels, vs.Label) {
+		// a structure without a role uses one of reserved labels
+		return fmt.Errorf("label %q is reserved", vs.Label)
+	}
+	return nil
+}
+
+func ensureVolumeRuleConsistencyNoConstraints(state *validationState) error {
+	switch {
+	case state.SystemSeed == nil && state.SystemData == nil:
+		// happy so far
+	case state.SystemSeed != nil && state.SystemData == nil:
+		return fmt.Errorf("the system-seed role requires system-data to be defined")
+	case state.SystemSeed == nil && state.SystemData != nil:
+		if state.SystemData.Label != "" && state.SystemData.Label != implicitSystemDataLabel {
+			return fmt.Errorf("system-data structure must have an implicit label or %q, not %q", implicitSystemDataLabel, state.SystemData.Label)
+		}
+	case state.SystemSeed != nil && state.SystemData != nil:
+		if err := ensureSeedDataLabelsUnset(state); err != nil {
+			return err
+		}
+	}
+	if state.SystemSave != nil {
+		if err := ensureSystemSaveRuleConsistency(state); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureVolumeRuleConsistencyWithConstraints(state *validationState, model Model) error {
+	// TODO: should we validate usage of uc20 specific system-recovery-{image,select}
+	//       roles too? they should only be used on uc20 systems, so models that
+	//       have a grade set and are not classic
+
+	switch {
+	case state.SystemSeed == nil && state.SystemData == nil:
+		if wantsSystemSeed(model) {
+			return fmt.Errorf("model requires system-seed partition, but no system-seed or system-data partition found")
+		}
+	case state.SystemSeed != nil && state.SystemData == nil:
+		return fmt.Errorf("the system-seed role requires system-data to be defined")
+	case state.SystemSeed == nil && state.SystemData != nil:
+		// error if we have the SystemSeed constraint but no actual system-seed structure
+		if wantsSystemSeed(model) {
+			return fmt.Errorf("model requires system-seed structure, but none was found")
+		}
+		// without SystemSeed, system-data label must be implicit or writable
+		if state.SystemData.Label != "" && state.SystemData.Label != implicitSystemDataLabel {
+			return fmt.Errorf("system-data structure must have an implicit label or %q, not %q",
+				implicitSystemDataLabel, state.SystemData.Label)
+		}
+	case state.SystemSeed != nil && state.SystemData != nil:
+		// error if we don't have the SystemSeed constraint but we have a system-seed structure
+		if !wantsSystemSeed(model) {
+			return fmt.Errorf("model does not support the system-seed role")
+		}
+		if err := ensureSeedDataLabelsUnset(state); err != nil {
+			return err
+		}
+	}
+	if state.SystemSave != nil {
+		if err := ensureSystemSaveRuleConsistency(state); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureVolumeRuleConsistency(state *validationState, model Model) error {
+	if model == nil {
+		return ensureVolumeRuleConsistencyNoConstraints(state)
+	}
+	return ensureVolumeRuleConsistencyWithConstraints(state, model)
+}
+
+func ensureSeedDataLabelsUnset(state *validationState) error {
+	if state.SystemData.Label != "" {
+		return fmt.Errorf("system-data structure must not have a label")
+	}
+	if state.SystemSeed.Label != "" {
+		return fmt.Errorf("system-seed structure must not have a label")
+	}
+	return nil
+}
+
+func ensureSystemSaveRuleConsistency(state *validationState) error {
+	if state.SystemData == nil || state.SystemSeed == nil {
+		return fmt.Errorf("system-save requires system-seed and system-data structures")
+	}
+	if state.SystemSave.Label != "" {
+		return fmt.Errorf("system-save structure must not have a label")
+	}
+	return nil
+}
+
+// content validation
 
 func validateVolumeContentsPresence(gadgetSnapRootDir string, vol *LaidOutVolume) error {
 	// bare structure content is checked to exist during layout

--- a/gadget/validate_test.go
+++ b/gadget/validate_test.go
@@ -157,6 +157,57 @@ func (s *validateGadgetTestSuite) TestEnsureVolumeRuleConsistency(c *C) {
 	c.Assert(err, ErrorMatches, "system-save requires system-seed and system-data structures")
 }
 
+func (s *validateGadgetTestSuite) TestRuleValidateHybridGadget(c *C) {
+	// this is the kind of volumes setup recommended to be
+	// prepared for a possible UC18 -> UC20 transition
+	hybridyGadgetYaml := []byte(`volumes:
+  hybrid:
+    bootloader: grub
+    structure:
+      - name: mbr
+        type: mbr
+        size: 440
+        content:
+          - image: pc-boot.img
+      - name: BIOS Boot
+        type: DA,21686148-6449-6E6F-744E-656564454649
+        size: 1M
+        offset: 1M
+        offset-write: mbr+92
+        content:
+          - image: pc-core.img
+      - name: EFI System
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: vfat
+        filesystem-label: system-boot
+        size: 1200M
+        content:
+          - source: grubx64.efi
+            target: EFI/boot/grubx64.efi
+          - source: shim.efi.signed
+            target: EFI/boot/bootx64.efi
+          - source: mmx64.efi
+            target: EFI/boot/mmx64.efi
+          - source: grub.cfg
+            target: EFI/ubuntu/grub.cfg
+      - name: Ubuntu Boot
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        filesystem: ext4
+        filesystem-label: ubuntu-boot
+        size: 750M
+`)
+
+	constraints := &modelConstraints{
+		classic: false,
+	}
+	giMeta, err := gadget.InfoFromGadgetYaml(hybridyGadgetYaml, constraints)
+	c.Assert(err, IsNil)
+
+	// XXX this should become a (new) Validate test
+	err = gadget.RuleValidateVolumes(giMeta.Volumes, constraints)
+	c.Check(err, IsNil)
+}
+
 func (s *validateGadgetTestSuite) TestValidateMissingRawContent(c *C) {
 	var gadgetYamlContent = `
 volumes:


### PR DESCRIPTION
This is a first step on the journey to not do full validation where we might get stricter or change rules slightly intentionally or by mistake for already on-system gadgets.

The idea is to separate the more convention/rule based checks, from the ones that should always be valid (basic syntax and not overlapping) and then gain control over when the former are run.

Also add a test about hybrid setups in the context of the new started separation.
