### PR TITLE
tests: fix lp-1899664 test when snapd_x1 is not installed in the system

### DIFF
--- a/tests/regression/lp-1899664/task.yaml
+++ b/tests/regression/lp-1899664/task.yaml
@@ -7,7 +7,8 @@ prepare: |
 execute: |
   # we are running current snapd build, re-install it to trigger core18
   # wrappers to be recreated.
-  snap install --dangerous /var/lib/snapd/seed/snaps/snapd_x1.snap 
+  current="$(readlink /snap/snapd/current)"
+  snap install --dangerous "/var/lib/snapd/seed/snaps/snapd_${current}.snap"
   journalctl -u snapd | MATCH "appears to be read-only, could not write snapd dbus config files"
 
 restore: |


### PR DESCRIPTION
This happens when snapd is not rev x1 during beta validation 