### PR TITLE
tests: fix the scenario when the "$SRC".orig file does not exist

### DIFF
--- a/tests/main/security-seccomp/task.yaml
+++ b/tests/main/security-seccomp/task.yaml
@@ -44,8 +44,10 @@ prepare: |
 restore: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
-    mv -f "$SRC".orig "$SRC"
-    snapd.tool exec snap-seccomp compile "$SRC" "$BIN"
+    if [ -e "$SRC".orig ]; then
+        mv -f "$SRC".orig "$SRC"
+        snapd.tool exec snap-seccomp compile "$SRC" "$BIN"
+    fi
     if [ -f "$AAP".orig ]; then
         mv -f "$AAP".orig "$AAP"
         apparmor_parser -r "$AAP"


### PR DESCRIPTION
If the test fails before the file "$SRC".orig is created, then the test fails during restore making the whole suite fail.
