### PR TITLE
o/devicestate: save model with serial in the device save db (2.48)

### DIFF
--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -1998,6 +1998,13 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationUC20Happy(c *C) {
 	// as well
 	savedb, err := sysdb.OpenAt(dirs.SnapDeviceSaveDir)
 	c.Assert(err, IsNil)
+	// a copy of model was saved there
+	_, err = savedb.Find(asserts.ModelType, map[string]string{
+		"series":   "16",
+		"brand-id": "canonical",
+		"model":    "pc-20",
+	})
+	c.Assert(err, IsNil)
 	// a copy of serial was backed up there
 	_, err = savedb.Find(asserts.SerialType, map[string]string{
 		"brand-id": "canonical",

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -694,6 +694,12 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 			}
 			b := asserts.NewBatch(nil)
 			err := b.Fetch(savedb, retrieve, func(f asserts.Fetcher) error {
+				// save the associated model as well
+				// as it might be required for cross-checks
+				// of the serial
+				if err := f.Save(regCtx.Model()); err != nil {
+					return err
+				}
 				return f.Save(serial)
 			})
 			if err != nil {

--- a/tests/nested/core20/basic/task.yaml
+++ b/tests/nested/core20/basic/task.yaml
@@ -40,3 +40,11 @@ execute: |
         echo "snap recovery --show-key should not work as a user"
         exit 1
     fi
+
+    echo "Wait for device initialisation to be done"
+    while ! nested_exec snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
+
+    echo "Check that the serial backed up to save is as expected"
+    nested_exec 'cat /var/lib/snapd/save/device/asserts-v0/serial/'"$(nested_model_authority)"'/pc/*/active' >serial.saved
+    nested_exec snap model --serial --assertion >serial
+    cmp serial serial.saved


### PR DESCRIPTION
this makes serial-authority cross-checks work for example

have a spread test as well

