### PR TITLE
bootloader/{lk,lkenv}: followups from #9695

### DIFF
--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -383,7 +383,7 @@ func (l *lk) ExtractRecoveryKernelAssets(recoverySystemDir string, sn snap.Place
 
 	// we are preparing a recovery system, just extract boot image to bootloader
 	// directory
-	logger.Debugf("ExtractRecoveryKernelAssets handling image prepare")
+	logger.Debugf("extracting recovery kernel %s to %s with lk bootloader", sn.SnapName(), recoverySystem)
 	if err := snapf.Unpack(env.GetBootImageName(), l.dir()); err != nil {
 		return fmt.Errorf("cannot open unpacked %s: %v", env.GetBootImageName(), err)
 	}
@@ -404,7 +404,7 @@ func (l *lk) ExtractRecoveryKernelAssets(recoverySystemDir string, sn snap.Place
 func (l *lk) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
 	blobName := s.Filename()
 
-	logger.Debugf("ExtractKernelAssets (%s)", blobName)
+	logger.Debugf("extracting kernel %s with lk bootloader", s.SnapName())
 
 	env, err := l.newenv()
 	if err != nil {
@@ -428,12 +428,10 @@ func (l *lk) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
 
 	if l.prepareImageTime {
 		// we are preparing image, just extract boot image to bootloader directory
-		logger.Debugf("ExtractKernelAssets handling image prepare")
 		if err := snapf.Unpack(env.GetBootImageName(), l.dir()); err != nil {
 			return fmt.Errorf("cannot open unpacked %s: %v", env.GetBootImageName(), err)
 		}
 	} else {
-		logger.Debugf("ExtractKernelAssets handling run time usecase")
 		// this is live system, extracted bootimg needs to be flashed to
 		// free bootimg partition and env has to be updated with
 		// new kernel snap to bootimg partition mapping
@@ -486,7 +484,7 @@ func (l *lk) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
 
 func (l *lk) RemoveKernelAssets(s snap.PlaceInfo) error {
 	blobName := s.Filename()
-	logger.Debugf("RemoveKernelAssets (%s)", blobName)
+	logger.Debugf("removing kernel assets for %s with lk bootloader", s.SnapName())
 
 	env, err := l.newenv()
 	if err != nil {

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -137,7 +137,14 @@ func (l *lk) Present() (bool, error) {
 			return true, nil
 		}
 
-		// if the primary backstore doesn't exist, check the backup storage
+		// at prepare-image time, we won't have a backup file from the gadget,
+		// so just give up here
+		if l.prepareImageTime {
+			return false, nil
+		}
+
+		// but at runtime we should check the backup in case the primary
+		// partition got corrupted
 		backup, err := l.envBackstore(backupStorage)
 		if err != nil {
 			return false, err

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -411,7 +411,7 @@ func (l *lk) ExtractRecoveryKernelAssets(recoverySystemDir string, sn snap.Place
 func (l *lk) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
 	blobName := s.Filename()
 
-	logger.Debugf("extracting kernel %s with lk bootloader", s.SnapName())
+	logger.Debugf("extracting kernel assets for %s with lk bootloader", s.SnapName())
 
 	env, err := l.newenv()
 	if err != nil {

--- a/bootloader/lkenv/lkenv.go
+++ b/bootloader/lkenv/lkenv.go
@@ -305,7 +305,7 @@ func (l *Env) LoadEnv(path string) error {
 	if crc != l.variant.currentCrc32() {
 		return fmt.Errorf("cannot validate %s: expected checksum 0x%X, got 0x%X", path, crc, l.variant.currentCrc32())
 	}
-	logger.Debugf("Load: validated crc32 (0x%X)", l.variant.currentCrc32())
+	logger.Debugf("validated crc32 as 0x%X for lkenv loaded from file %s", l.variant.currentCrc32(), path)
 
 	return nil
 }
@@ -323,7 +323,7 @@ func (l *Env) Save() error {
 
 	// calculate crc32
 	newCrc32 := crc32.ChecksumIEEE(buf.Bytes()[:ss-4])
-	logger.Debugf("calculated lk bootloader environment crc32: 0x%X", newCrc32)
+	logger.Debugf("calculated lk bootloader environment crc32 as 0x%X to save", newCrc32)
 	// note for efficiency's sake to avoid re-writing the whole structure, we
 	// re-write _just_ the crc32 to w as little-endian
 	buf.Truncate(ss - 4)


### PR DESCRIPTION
* bootloader/{lk,lkenv}: adjust Debugf's to be more useful and specific 
* bootloader/lk.go: don't check backup file in Present() during prepare-image time