### PR TITLE
cmd/snap-update-ns: add better unit test for overname sorting

### DIFF
--- a/cmd/snap-update-ns/sorting_test.go
+++ b/cmd/snap-update-ns/sorting_test.go
@@ -73,6 +73,25 @@ func (s *sortSuite) TestParallelInstancesAndSimple(c *C) {
 	})
 }
 
+func (s *sortSuite) TestOvernameOrder(c *C) {
+	expected := []osutil.MountEntry{
+		{Dir: "/a/b/2", Options: []string{osutil.XSnapdOriginOvername()}},
+		{Dir: "/a/b"},
+	}
+	entries := []osutil.MountEntry{
+		{Dir: "/a/b"},
+		{Dir: "/a/b/2", Options: []string{osutil.XSnapdOriginOvername()}},
+	}
+	entriesRev := []osutil.MountEntry{
+		{Dir: "/a/b/2", Options: []string{osutil.XSnapdOriginOvername()}},
+		{Dir: "/a/b"},
+	}
+	sort.Sort(byOriginAndMagicDir(entries))
+	c.Assert(entries, DeepEquals, expected)
+	sort.Sort(byOriginAndMagicDir(entriesRev))
+	c.Assert(entriesRev, DeepEquals, expected)
+}
+
 func (s *sortSuite) TestParallelInstancesAlmostSorted(c *C) {
 	// use a mount profile that was seen to be broken in the wild
 	entries := []osutil.MountEntry{


### PR DESCRIPTION
A followup to #9751.

Add a simpler test case for checking the order of sorting with overname.


