### PR TITLE
daemon: actually move APIBaseSuite to daemon_test.apiBaseSuite

### DIFF
--- a/daemon/api_aliases_test.go
+++ b/daemon/api_aliases_test.go
@@ -41,7 +41,7 @@ import (
 var _ = check.Suite(&aliasesSuite{})
 
 type aliasesSuite struct {
-	daemon.APIBaseSuite
+	apiBaseSuite
 }
 
 const aliasYaml = `
@@ -55,9 +55,9 @@ apps:
 func (s *aliasesSuite) TestAliasSuccess(c *check.C) {
 	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
 	c.Assert(err, check.IsNil)
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, aliasYaml)
+	s.mockSnap(c, aliasYaml)
 
 	oldAutoAliases := snapstate.AutoAliases
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
@@ -80,7 +80,7 @@ func (s *aliasesSuite) TestAliasSuccess(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/aliases", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -107,11 +107,11 @@ func (s *aliasesSuite) TestAliasSuccess(c *check.C) {
 func (s *aliasesSuite) TestAliasChangeConflict(c *check.C) {
 	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
 	c.Assert(err, check.IsNil)
-	s.Daemon(c)
+	s.daemon(c)
 
-	s.MockSnap(c, aliasYaml)
+	s.mockSnap(c, aliasYaml)
 
-	s.SimulateConflict("alias-snap")
+	s.simulateConflict("alias-snap")
 
 	oldAutoAliases := snapstate.AutoAliases
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
@@ -131,7 +131,7 @@ func (s *aliasesSuite) TestAliasChangeConflict(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/aliases", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 409)
 
 	var body map[string]interface{}
@@ -152,7 +152,7 @@ func (s *aliasesSuite) TestAliasChangeConflict(c *check.C) {
 }
 
 func (s *aliasesSuite) TestAliasErrors(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 
 	errScenarios := []struct {
 		mangle func(*daemon.AliasAction)
@@ -180,7 +180,7 @@ func (s *aliasesSuite) TestAliasErrors(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/aliases", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.Req(c, req, nil).(*daemon.Resp)
+		rsp := s.req(c, req, nil).(*daemon.Resp)
 		c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
 		c.Check(rsp.Status, check.Equals, 400)
 		c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, scen.err)
@@ -190,9 +190,9 @@ func (s *aliasesSuite) TestAliasErrors(c *check.C) {
 func (s *aliasesSuite) TestUnaliasSnapSuccess(c *check.C) {
 	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
 	c.Assert(err, check.IsNil)
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, aliasYaml)
+	s.mockSnap(c, aliasYaml)
 
 	oldAutoAliases := snapstate.AutoAliases
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
@@ -213,7 +213,7 @@ func (s *aliasesSuite) TestUnaliasSnapSuccess(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/aliases", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -244,9 +244,9 @@ func (s *aliasesSuite) TestUnaliasSnapSuccess(c *check.C) {
 func (s *aliasesSuite) TestUnaliasDWIMSnapSuccess(c *check.C) {
 	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
 	c.Assert(err, check.IsNil)
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, aliasYaml)
+	s.mockSnap(c, aliasYaml)
 
 	oldAutoAliases := snapstate.AutoAliases
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
@@ -268,7 +268,7 @@ func (s *aliasesSuite) TestUnaliasDWIMSnapSuccess(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/aliases", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -299,9 +299,9 @@ func (s *aliasesSuite) TestUnaliasDWIMSnapSuccess(c *check.C) {
 func (s *aliasesSuite) TestUnaliasAliasSuccess(c *check.C) {
 	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
 	c.Assert(err, check.IsNil)
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, aliasYaml)
+	s.mockSnap(c, aliasYaml)
 
 	oldAutoAliases := snapstate.AutoAliases
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
@@ -324,7 +324,7 @@ func (s *aliasesSuite) TestUnaliasAliasSuccess(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/aliases", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -355,7 +355,7 @@ func (s *aliasesSuite) TestUnaliasAliasSuccess(c *check.C) {
 	req, err = http.NewRequest("POST", "/v2/aliases", buf)
 	c.Assert(err, check.IsNil)
 	rec = httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
@@ -381,9 +381,9 @@ func (s *aliasesSuite) TestUnaliasAliasSuccess(c *check.C) {
 func (s *aliasesSuite) TestUnaliasDWIMAliasSuccess(c *check.C) {
 	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
 	c.Assert(err, check.IsNil)
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, aliasYaml)
+	s.mockSnap(c, aliasYaml)
 
 	oldAutoAliases := snapstate.AutoAliases
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
@@ -406,7 +406,7 @@ func (s *aliasesSuite) TestUnaliasDWIMAliasSuccess(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/aliases", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -438,7 +438,7 @@ func (s *aliasesSuite) TestUnaliasDWIMAliasSuccess(c *check.C) {
 	req, err = http.NewRequest("POST", "/v2/aliases", buf)
 	c.Assert(err, check.IsNil)
 	rec = httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
@@ -464,9 +464,9 @@ func (s *aliasesSuite) TestUnaliasDWIMAliasSuccess(c *check.C) {
 func (s *aliasesSuite) TestPreferSuccess(c *check.C) {
 	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
 	c.Assert(err, check.IsNil)
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, aliasYaml)
+	s.mockSnap(c, aliasYaml)
 
 	oldAutoAliases := snapstate.AutoAliases
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
@@ -487,7 +487,7 @@ func (s *aliasesSuite) TestPreferSuccess(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/aliases", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -516,7 +516,7 @@ func (s *aliasesSuite) TestPreferSuccess(c *check.C) {
 }
 
 func (s *aliasesSuite) TestAliases(c *check.C) {
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
 	st := d.Overlord().State()
 	st.Lock()
@@ -549,7 +549,7 @@ func (s *aliasesSuite) TestAliases(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/aliases", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.DeepEquals, map[string]map[string]daemon.AliasStatus{
@@ -598,7 +598,7 @@ func (s *aliasesSuite) TestInstallUnaliased(c *check.C) {
 		return state.NewTaskSet(t), nil
 	})()
 
-	d := s.Daemon(c)
+	d := s.daemon(c)
 	inst := &daemon.SnapInstruction{
 		Action: "install",
 		// Install the snap without enabled automatic aliases
@@ -625,7 +625,7 @@ func (s *aliasesSuite) TestInstallIgnoreRunning(c *check.C) {
 		return state.NewTaskSet(t), nil
 	})()
 
-	d := s.Daemon(c)
+	d := s.daemon(c)
 	inst := &daemon.SnapInstruction{
 		Action: "install",
 		// Install the snap without enabled automatic aliases

--- a/daemon/api_base_d_test.go
+++ b/daemon/api_base_d_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon_test
+package daemon
 
 import (
 	"context"
@@ -37,7 +37,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
-	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
@@ -62,7 +61,7 @@ import (
 // instead of daemon, split out functionality from APIBaseSuite
 // to only the relevant suite when possible
 
-type apiBaseSuite struct {
+type APIBaseSuite struct {
 	testutil.BaseTest
 
 	storetest.Store
@@ -72,7 +71,7 @@ type apiBaseSuite struct {
 	vars              map[string]string
 	storeSearch       store.Search
 	suggestedCurrency string
-	d                 *daemon.Daemon
+	d                 *Daemon
 	user              *auth.UserState
 	ctx               context.Context
 	currentSnaps      []*store.CurrentSnap
@@ -91,19 +90,18 @@ type apiBaseSuite struct {
 	loginUserDischarge     string
 
 	restoreSanitize func()
-	restoreMuxVars  func()
 }
 
-func (s *apiBaseSuite) pokeStateLock() {
+func (s *APIBaseSuite) PokeStateLock() {
 	// the store should be called without the state lock held. Try
 	// to acquire it.
-	st := s.d.Overlord().State()
+	st := s.d.overlord.State()
 	st.Lock()
 	st.Unlock()
 }
 
-func (s *apiBaseSuite) SnapInfo(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
-	s.pokeStateLock()
+func (s *APIBaseSuite) SnapInfo(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
+	s.PokeStateLock()
 	s.user = user
 	s.ctx = ctx
 	if len(s.rsnaps) > 0 {
@@ -112,8 +110,8 @@ func (s *apiBaseSuite) SnapInfo(ctx context.Context, spec store.SnapSpec, user *
 	return nil, s.err
 }
 
-func (s *apiBaseSuite) Find(ctx context.Context, search *store.Search, user *auth.UserState) ([]*snap.Info, error) {
-	s.pokeStateLock()
+func (s *APIBaseSuite) Find(ctx context.Context, search *store.Search, user *auth.UserState) ([]*snap.Info, error) {
+	s.PokeStateLock()
 
 	s.storeSearch = *search
 	s.user = user
@@ -122,8 +120,8 @@ func (s *apiBaseSuite) Find(ctx context.Context, search *store.Search, user *aut
 	return s.rsnaps, s.err
 }
 
-func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
-	s.pokeStateLock()
+func (s *APIBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	s.PokeStateLock()
 	if assertQuery != nil {
 		toResolve, err := assertQuery.ToResolve()
 		if err != nil {
@@ -148,43 +146,43 @@ func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.Cur
 	return sars, nil, s.err
 }
 
-func (s *apiBaseSuite) SuggestedCurrency() string {
-	s.pokeStateLock()
+func (s *APIBaseSuite) SuggestedCurrency() string {
+	s.PokeStateLock()
 
 	return s.suggestedCurrency
 }
 
-func (s *apiBaseSuite) ConnectivityCheck() (map[string]bool, error) {
-	s.pokeStateLock()
+func (s *APIBaseSuite) ConnectivityCheck() (map[string]bool, error) {
+	s.PokeStateLock()
 
 	return s.connectivityResult, s.err
 }
 
-func (s *apiBaseSuite) LoginUser(username, password, otp string) (string, string, error) {
-	s.pokeStateLock()
+func (s *APIBaseSuite) LoginUser(username, password, otp string) (string, string, error) {
+	s.PokeStateLock()
 
 	return s.loginUserStoreMacaroon, s.loginUserDischarge, s.err
 }
 
-func (s *apiBaseSuite) muxVars(*http.Request) map[string]string {
+func (s *APIBaseSuite) muxVars(*http.Request) map[string]string {
 	return s.vars
 }
 
-func (s *apiBaseSuite) SetUpSuite(c *check.C) {
-	s.restoreMuxVars = daemon.MockMuxVars(s.muxVars)
+func (s *APIBaseSuite) SetUpSuite(c *check.C) {
+	muxVars = s.muxVars
 	s.restoreRelease = sandbox.MockForceDevMode(false)
 	s.systemctlRestorer = systemd.MockSystemctl(s.systemctl)
 	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 }
 
-func (s *apiBaseSuite) TearDownSuite(c *check.C) {
-	s.restoreMuxVars()
+func (s *APIBaseSuite) TearDownSuite(c *check.C) {
+	muxVars = nil
 	s.restoreRelease()
 	s.systemctlRestorer()
 	s.restoreSanitize()
 }
 
-func (s *apiBaseSuite) systemctl(args ...string) (buf []byte, err error) {
+func (s *APIBaseSuite) systemctl(args ...string) (buf []byte, err error) {
 	if len(s.SysctlBufs) > 0 {
 		buf, s.SysctlBufs = s.SysctlBufs[0], s.SysctlBufs[1:]
 	}
@@ -195,7 +193,7 @@ var (
 	BrandPrivKey, _ = assertstest.GenerateKey(752)
 )
 
-func (s *apiBaseSuite) SetUpTest(c *check.C) {
+func (s *APIBaseSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
 
 	ctlcmds := testutil.MockCommand(c, "systemctl", "").Also("journalctl", "")
@@ -229,17 +227,46 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 
 	s.Brands = assertstest.NewSigningAccounts(s.StoreSigning)
 	s.Brands.Register("my-brand", BrandPrivKey, nil)
+
+	assertstateRefreshSnapDeclarations = nil
+	snapstateInstall = nil
+	snapstateInstallMany = nil
+	snapstateInstallPath = nil
+	snapstateRefreshCandidates = nil
+	snapstateRemoveMany = nil
+	snapstateRevert = nil
+	snapstateRevertToRevision = nil
+	snapstateTryPath = nil
+	snapstateUpdate = nil
+	snapstateUpdateMany = nil
+	snapstateSwitch = nil
 }
 
-func (s *apiBaseSuite) TearDownTest(c *check.C) {
+func (s *APIBaseSuite) TearDownTest(c *check.C) {
 	s.d = nil
 	s.ctx = nil
 
+	unsafeReadSnapInfo = unsafeReadSnapInfoImpl
+	ensureStateSoon = ensureStateSoonImpl
 	dirs.SetRootDir("")
+
+	assertstateRefreshSnapDeclarations = assertstate.RefreshSnapDeclarations
+	snapstateInstall = snapstate.Install
+	snapstateInstallMany = snapstate.InstallMany
+	snapstateInstallPath = snapstate.InstallPath
+	snapstateRefreshCandidates = snapstate.RefreshCandidates
+	snapstateRemoveMany = snapstate.RemoveMany
+	snapstateRevert = snapstate.Revert
+	snapstateRevertToRevision = snapstate.RevertToRevision
+	snapstateTryPath = snapstate.TryPath
+	snapstateUpdate = snapstate.Update
+	snapstateUpdateMany = snapstate.UpdateMany
+	snapstateSwitch = snapstate.Switch
+
 	s.BaseTest.TearDownTest(c)
 }
 
-func (s *apiBaseSuite) mockModel(c *check.C, st *state.State, model *asserts.Model) {
+func (s *APIBaseSuite) MockModel(c *check.C, st *state.State, model *asserts.Model) {
 	// realistic model setup
 	if model == nil {
 		model = s.Brands.Model("can0nical", "pc", map[string]interface{}{
@@ -260,23 +287,24 @@ func (s *apiBaseSuite) mockModel(c *check.C, st *state.State, model *asserts.Mod
 	})
 }
 
-func (s *apiBaseSuite) daemonWithStore(c *check.C, sto snapstate.StoreService) *daemon.Daemon {
+func (s *APIBaseSuite) DaemonWithStore(c *check.C, sto snapstate.StoreService) *Daemon {
 	if s.d != nil {
 		panic("called Daemon*() twice")
 	}
-	d, err := daemon.NewAndAddRoutes()
+	d, err := New()
 	c.Assert(err, check.IsNil)
+	d.addRoutes()
 
-	c.Assert(d.Overlord().StartUp(), check.IsNil)
+	c.Assert(d.overlord.StartUp(), check.IsNil)
 
-	st := d.Overlord().State()
+	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
 	snapstate.ReplaceStore(st, sto)
 	// mark as already seeded
 	st.Set("seeded", true)
 	// registered
-	s.mockModel(c, st, nil)
+	s.MockModel(c, st, nil)
 
 	// don't actually try to talk to the store on snapstate.Ensure
 	// needs doing after the call to devicestate.Manager (which
@@ -287,23 +315,36 @@ func (s *apiBaseSuite) daemonWithStore(c *check.C, sto snapstate.StoreService) *
 	return d
 }
 
-func (s *apiBaseSuite) resetDaemon() {
+func (s *APIBaseSuite) ResetDaemon() {
 	s.d = nil
 }
 
-func (s *apiBaseSuite) daemon(c *check.C) *daemon.Daemon {
-	return s.daemonWithStore(c, s)
+func (s *APIBaseSuite) Daemon(c *check.C) *Daemon {
+	return s.daemon(c)
 }
 
-func (s *apiBaseSuite) daemonWithOverlordMock(c *check.C) *daemon.Daemon {
+// XXX this one will go away
+func (s *APIBaseSuite) daemon(c *check.C) *Daemon {
+	return s.DaemonWithStore(c, s)
+}
+
+// XXX this one will go away
+func (s *APIBaseSuite) daemonWithOverlordMock(c *check.C) *Daemon {
+	return s.DaemonWithOverlordMock(c)
+}
+
+func (s *APIBaseSuite) DaemonWithOverlordMock(c *check.C) *Daemon {
 	if s.d != nil {
 		panic("called Daemon*() twice")
 	}
+	d, err := New()
+	c.Assert(err, check.IsNil)
+	d.addRoutes()
 
 	o := overlord.Mock()
-	d := daemon.NewWithOverlord(o)
+	d.overlord = o
 
-	st := d.Overlord().State()
+	st := d.overlord.State()
 	// adds an assertion db
 	assertstate.Manager(st, o.TaskRunner())
 	st.Lock()
@@ -334,23 +375,23 @@ func (m *fakeSnapManager) Ensure() error {
 // sanity
 var _ overlord.StateManager = (*fakeSnapManager)(nil)
 
-func (s *apiBaseSuite) daemonWithFakeSnapManager(c *check.C) *daemon.Daemon {
+func (s *APIBaseSuite) daemonWithFakeSnapManager(c *check.C) *Daemon {
 	d := s.daemonWithOverlordMock(c)
-	st := d.Overlord().State()
-	runner := d.Overlord().TaskRunner()
-	d.Overlord().AddManager(newFakeSnapManager(st, runner))
-	d.Overlord().AddManager(runner)
-	c.Assert(d.Overlord().StartUp(), check.IsNil)
+	st := d.overlord.State()
+	runner := d.overlord.TaskRunner()
+	d.overlord.AddManager(newFakeSnapManager(st, runner))
+	d.overlord.AddManager(runner)
+	c.Assert(d.overlord.StartUp(), check.IsNil)
 	return d
 }
 
-func (s *apiBaseSuite) waitTrivialChange(c *check.C, chg *state.Change) {
-	err := s.d.Overlord().Settle(5 * time.Second)
+func (s *APIBaseSuite) waitTrivialChange(c *check.C, chg *state.Change) {
+	err := s.d.overlord.Settle(5 * time.Second)
 	c.Assert(err, check.IsNil)
 	c.Assert(chg.IsReady(), check.Equals, true)
 }
 
-func (s *apiBaseSuite) mkInstalledDesktopFile(c *check.C, name, content string) string {
+func (s *APIBaseSuite) mkInstalledDesktopFile(c *check.C, name, content string) string {
 	df := filepath.Join(dirs.SnapDesktopFilesDir, name)
 	err := os.MkdirAll(filepath.Dir(df), 0755)
 	c.Assert(err, check.IsNil)
@@ -359,14 +400,19 @@ func (s *apiBaseSuite) mkInstalledDesktopFile(c *check.C, name, content string) 
 	return df
 }
 
-func (s *apiBaseSuite) mockSnap(c *check.C, yamlText string) *snap.Info {
+// XXX this one will go away
+func (s *APIBaseSuite) mkInstalledInState(c *check.C, daemon *Daemon, instanceName, developer, version string, revision snap.Revision, active bool, extraYaml string) *snap.Info {
+	return s.MkInstalledInState(c, daemon, instanceName, developer, version, revision, active, extraYaml)
+}
+
+func (s *APIBaseSuite) MockSnap(c *check.C, yamlText string) *snap.Info {
 	if s.d == nil {
 		panic("call s.Daemon(c) etc in your test first")
 	}
 
 	snapInfo := snaptest.MockSnap(c, yamlText, &snap.SideInfo{Revision: snap.R(1)})
 
-	st := s.d.Overlord().State()
+	st := s.d.overlord.State()
 
 	st.Lock()
 	defer st.Unlock()
@@ -386,13 +432,13 @@ func (s *apiBaseSuite) mockSnap(c *check.C, yamlText string) *snap.Info {
 	})
 
 	// Put the snap into the interface repository
-	repo := s.d.Overlord().InterfaceManager().Repository()
+	repo := s.d.overlord.InterfaceManager().Repository()
 	err := repo.AddSnap(snapInfo)
 	c.Assert(err, check.IsNil)
 	return snapInfo
 }
 
-func (s *apiBaseSuite) mkInstalledInState(c *check.C, d *daemon.Daemon, instanceName, developer, version string, revision snap.Revision, active bool, extraYaml string) *snap.Info {
+func (s *APIBaseSuite) MkInstalledInState(c *check.C, daemon *Daemon, instanceName, developer, version string, revision snap.Revision, active bool, extraYaml string) *snap.Info {
 	snapName, instanceKey := snap.SplitInstanceName(instanceName)
 
 	if revision.Local() && developer != "" {
@@ -431,10 +477,10 @@ version: %s
 	c.Assert(os.MkdirAll(guidir, 0755), check.IsNil)
 	c.Check(ioutil.WriteFile(filepath.Join(guidir, "icon.svg"), []byte("yadda icon"), 0644), check.IsNil)
 
-	if d == nil {
+	if daemon == nil {
 		return snapInfo
 	}
-	st := d.Overlord().State()
+	st := daemon.overlord.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -492,19 +538,19 @@ version: %s
 	return snapInfo
 }
 
-func handlerCommand(c *check.C, d *daemon.Daemon, req *http.Request) (cmd *daemon.Command, vars map[string]string) {
+func handlerCommand(c *check.C, d *Daemon, req *http.Request) (cmd *Command, vars map[string]string) {
 	m := &mux.RouteMatch{}
-	if !d.RouterMatch(req, m) {
+	if !d.router.Match(req, m) {
 		c.Fatalf("no command for URL %q", req.URL)
 	}
-	cmd, ok := m.Handler.(*daemon.Command)
+	cmd, ok := m.Handler.(*Command)
 	if !ok {
 		c.Fatalf("no command for URL %q", req.URL)
 	}
 	return cmd, m.Vars
 }
 
-func (s *apiBaseSuite) checkGetOnly(c *check.C, req *http.Request) {
+func (s *APIBaseSuite) CheckGetOnly(c *check.C, req *http.Request) {
 	if s.d == nil {
 		panic("call s.Daemon(c) etc in your test first")
 	}
@@ -515,14 +561,14 @@ func (s *apiBaseSuite) checkGetOnly(c *check.C, req *http.Request) {
 	c.Check(cmd.GET, check.NotNil)
 }
 
-func (s *apiBaseSuite) req(c *check.C, req *http.Request, u *auth.UserState) daemon.Response {
+func (s *APIBaseSuite) Req(c *check.C, req *http.Request, u *auth.UserState) Response {
 	if s.d == nil {
 		panic("call s.Daemon(c) etc in your test first")
 	}
 
 	cmd, vars := handlerCommand(c, s.d, req)
 	s.vars = vars
-	var f daemon.ResponseFunc
+	var f ResponseFunc
 	switch req.Method {
 	case "GET":
 		f = cmd.GET
@@ -539,7 +585,7 @@ func (s *apiBaseSuite) req(c *check.C, req *http.Request, u *auth.UserState) dae
 	return f(cmd, req, u)
 }
 
-func (s *apiBaseSuite) serveHTTP(c *check.C, w http.ResponseWriter, req *http.Request) {
+func (s *APIBaseSuite) ServeHTTP(c *check.C, w http.ResponseWriter, req *http.Request) {
 	if s.d == nil {
 		panic("call s.Daemon(c) etc in your test first")
 	}
@@ -550,12 +596,12 @@ func (s *apiBaseSuite) serveHTTP(c *check.C, w http.ResponseWriter, req *http.Re
 	cmd.ServeHTTP(w, req)
 }
 
-func (s *apiBaseSuite) simulateConflict(name string) {
+func (s *APIBaseSuite) SimulateConflict(name string) {
 	if s.d == nil {
 		panic("call s.Daemon(c) etc in your test first")
 	}
 
-	o := s.d.Overlord()
+	o := s.d.overlord
 	st := o.State()
 	st.Lock()
 	defer st.Unlock()

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -192,7 +192,7 @@ func (s *apiBaseSuite) systemctl(args ...string) (buf []byte, err error) {
 }
 
 var (
-	BrandPrivKey, _ = assertstest.GenerateKey(752)
+	brandPrivKey, _ = assertstest.GenerateKey(752)
 )
 
 func (s *apiBaseSuite) SetUpTest(c *check.C) {
@@ -228,7 +228,7 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	s.AddCleanup(sysdb.InjectTrusted(s.StoreSigning.Trusted))
 
 	s.Brands = assertstest.NewSigningAccounts(s.StoreSigning)
-	s.Brands.Register("my-brand", BrandPrivKey, nil)
+	s.Brands.Register("my-brand", brandPrivKey, nil)
 }
 
 func (s *apiBaseSuite) TearDownTest(c *check.C) {

--- a/daemon/api_buy_unsupp_test.go
+++ b/daemon/api_buy_unsupp_test.go
@@ -33,7 +33,7 @@ import (
 var _ = check.Suite(&buySuite{})
 
 type buySuite struct {
-	daemon.APIBaseSuite
+	apiBaseSuite
 
 	user *auth.UserState
 	err  error
@@ -43,7 +43,7 @@ type buySuite struct {
 }
 
 func (s *buySuite) Buy(options *client.BuyOptions, user *auth.UserState) (*client.BuyResult, error) {
-	s.PokeStateLock()
+	s.pokeStateLock()
 
 	s.buyOptions = options
 	s.user = user
@@ -51,21 +51,21 @@ func (s *buySuite) Buy(options *client.BuyOptions, user *auth.UserState) (*clien
 }
 
 func (s *buySuite) ReadyToBuy(user *auth.UserState) error {
-	s.PokeStateLock()
+	s.pokeStateLock()
 
 	s.user = user
 	return s.err
 }
 
 func (s *buySuite) SetUpTest(c *check.C) {
-	s.APIBaseSuite.SetUpTest(c)
+	s.apiBaseSuite.SetUpTest(c)
 
 	s.user = nil
 	s.err = nil
 	s.buyOptions = nil
 	s.buyResult = nil
 
-	s.DaemonWithStore(c, s)
+	s.daemonWithStore(c, s)
 }
 
 const validBuyInput = `{
@@ -186,7 +186,7 @@ func (s *buySuite) TestBuySnap(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/buy", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.Req(c, req, user).(*daemon.Resp)
+		rsp := s.req(c, req, user).(*daemon.Resp)
 
 		c.Check(rsp.Status, check.Equals, test.expectedStatus)
 		c.Check(rsp.Type, check.Equals, test.expectedResponseType)
@@ -245,7 +245,7 @@ func (s *buySuite) TestReadyToBuy(c *check.C) {
 		req, err := http.NewRequest("GET", "/v2/buy/ready", nil)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.Req(c, req, user).(*daemon.Resp)
+		rsp := s.req(c, req, user).(*daemon.Resp)
 		c.Check(rsp.Status, check.Equals, test.status)
 		c.Check(rsp.Type, check.Equals, test.respType)
 		c.Assert(rsp.Result, check.FitsTypeOf, test.response)

--- a/daemon/api_interfaces_test.go
+++ b/daemon/api_interfaces_test.go
@@ -41,7 +41,7 @@ import (
 var _ = check.Suite(&interfacesSuite{})
 
 type interfacesSuite struct {
-	daemon.APIBaseSuite
+	apiBaseSuite
 }
 
 func mockIface(c *check.C, d *daemon.Daemon, iface interfaces.Interface) {
@@ -123,10 +123,10 @@ func (s *interfacesSuite) TestConnectPlugSuccess(c *check.C) {
 	restore = ifacestate.MockSnapMapper(&inverseCaseMapper{})
 	defer restore()
 
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
 
 	d.Overlord().Loop()
 	defer d.Overlord().Stop()
@@ -142,7 +142,7 @@ func (s *interfacesSuite) TestConnectPlugSuccess(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -172,12 +172,12 @@ func (s *interfacesSuite) TestConnectPlugSuccess(c *check.C) {
 }
 
 func (s *interfacesSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
 	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
 	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "different"})
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, differentProducerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, differentProducerYaml)
 
 	action := &client.InterfaceAction{
 		Action: "connect",
@@ -190,7 +190,7 @@ func (s *interfacesSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -209,12 +209,12 @@ func (s *interfacesSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 }
 
 func (s *interfacesSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
 	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
 	// there is no consumer, no plug defined
-	s.MockSnap(c, producerYaml)
-	s.MockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
 
 	action := &client.InterfaceAction{
 		Action: "connect",
@@ -227,7 +227,7 @@ func (s *interfacesSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 
 	var body map[string]interface{}
@@ -248,12 +248,12 @@ func (s *interfacesSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 }
 
 func (s *interfacesSuite) TestConnectAlreadyConnected(c *check.C) {
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
 	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
 	// there is no consumer, no plug defined
-	s.MockSnap(c, producerYaml)
-	s.MockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
 
 	repo := d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
@@ -287,7 +287,7 @@ func (s *interfacesSuite) TestConnectAlreadyConnected(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -302,11 +302,11 @@ func (s *interfacesSuite) TestConnectAlreadyConnected(c *check.C) {
 }
 
 func (s *interfacesSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
 	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
 	// there is no producer, no slot defined
 
 	action := &client.InterfaceAction{
@@ -320,7 +320,7 @@ func (s *interfacesSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 
 	var body map[string]interface{}
@@ -341,14 +341,14 @@ func (s *interfacesSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 }
 
 func (s *interfacesSuite) TestConnectPlugChangeConflict(c *check.C) {
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
 	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
 	// there is no producer, no slot defined
 
-	s.SimulateConflict("consumer")
+	s.simulateConflict("consumer")
 
 	action := &client.InterfaceAction{
 		Action: "connect",
@@ -361,7 +361,7 @@ func (s *interfacesSuite) TestConnectPlugChangeConflict(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 409)
 
 	var body map[string]interface{}
@@ -384,10 +384,10 @@ func (s *interfacesSuite) TestConnectPlugChangeConflict(c *check.C) {
 func (s *interfacesSuite) TestConnectCoreSystemAlias(c *check.C) {
 	revert := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer revert()
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, coreProducerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, coreProducerYaml)
 
 	d.Overlord().Loop()
 	defer d.Overlord().Stop()
@@ -403,7 +403,7 @@ func (s *interfacesSuite) TestConnectCoreSystemAlias(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -437,10 +437,10 @@ func (s *interfacesSuite) testDisconnect(c *check.C, plugSnap, plugName, slotSna
 	// Install an inverse case mapper to exercise the interface mapping at the same time.
 	restore = ifacestate.MockSnapMapper(&inverseCaseMapper{})
 	defer restore()
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
 
 	repo := d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
@@ -473,7 +473,7 @@ func (s *interfacesSuite) testDisconnect(c *check.C, plugSnap, plugName, slotSna
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -511,10 +511,10 @@ func (s *interfacesSuite) TestDisconnectPlugSuccessWithEmptySlot(c *check.C) {
 func (s *interfacesSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	revert := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer revert()
-	s.Daemon(c)
+	s.daemon(c)
 
 	// there is no consumer, no plug defined
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, producerYaml)
 
 	action := &client.InterfaceAction{
 		Action: "disconnect",
@@ -527,7 +527,7 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -545,10 +545,10 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 func (s *interfacesSuite) TestDisconnectPlugNothingToDo(c *check.C) {
 	revert := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer revert()
-	s.Daemon(c)
+	s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
 
 	action := &client.InterfaceAction{
 		Action: "disconnect",
@@ -561,7 +561,7 @@ func (s *interfacesSuite) TestDisconnectPlugNothingToDo(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -580,9 +580,9 @@ func (s *interfacesSuite) TestDisconnectPlugNothingToDo(c *check.C) {
 func (s *interfacesSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	revert := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer revert()
-	s.Daemon(c)
+	s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
+	s.mockSnap(c, consumerYaml)
 	// there is no producer, no slot defined
 
 	action := &client.InterfaceAction{
@@ -596,7 +596,7 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 
 	c.Check(rec.Code, check.Equals, 400)
 	var body map[string]interface{}
@@ -615,10 +615,10 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 func (s *interfacesSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	revert := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer revert()
-	s.Daemon(c)
+	s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
 
 	action := &client.InterfaceAction{
 		Action: "disconnect",
@@ -631,7 +631,7 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 
 	c.Check(rec.Code, check.Equals, 400)
 	var body map[string]interface{}
@@ -650,10 +650,10 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 func (s *interfacesSuite) TestDisconnectForgetPlugFailureNotConnected(c *check.C) {
 	revert := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer revert()
-	s.Daemon(c)
+	s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
 
 	action := &client.InterfaceAction{
 		Action: "disconnect",
@@ -667,7 +667,7 @@ func (s *interfacesSuite) TestDisconnectForgetPlugFailureNotConnected(c *check.C
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 
 	c.Check(rec.Code, check.Equals, 400)
 	var body map[string]interface{}
@@ -686,10 +686,10 @@ func (s *interfacesSuite) TestDisconnectForgetPlugFailureNotConnected(c *check.C
 func (s *interfacesSuite) TestDisconnectConflict(c *check.C) {
 	revert := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer revert()
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
 
 	repo := d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
@@ -708,7 +708,7 @@ func (s *interfacesSuite) TestDisconnectConflict(c *check.C) {
 	})
 	st.Unlock()
 
-	s.SimulateConflict("consumer")
+	s.simulateConflict("consumer")
 
 	action := &client.InterfaceAction{
 		Action: "disconnect",
@@ -721,7 +721,7 @@ func (s *interfacesSuite) TestDisconnectConflict(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 
 	c.Check(rec.Code, check.Equals, 409)
 
@@ -745,10 +745,10 @@ func (s *interfacesSuite) TestDisconnectConflict(c *check.C) {
 func (s *interfacesSuite) TestDisconnectCoreSystemAlias(c *check.C) {
 	revert := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer revert()
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, coreProducerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, coreProducerYaml)
 
 	repo := d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
@@ -781,7 +781,7 @@ func (s *interfacesSuite) TestDisconnectCoreSystemAlias(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -805,12 +805,12 @@ func (s *interfacesSuite) TestDisconnectCoreSystemAlias(c *check.C) {
 }
 
 func (s *interfacesSuite) TestUnsupportedInterfaceRequest(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 	buf := bytes.NewBuffer([]byte(`garbage`))
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -826,7 +826,7 @@ func (s *interfacesSuite) TestUnsupportedInterfaceRequest(c *check.C) {
 }
 
 func (s *interfacesSuite) TestMissingInterfaceAction(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 	action := &client.InterfaceAction{}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -834,7 +834,7 @@ func (s *interfacesSuite) TestMissingInterfaceAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -850,7 +850,7 @@ func (s *interfacesSuite) TestMissingInterfaceAction(c *check.C) {
 }
 
 func (s *interfacesSuite) TestUnsupportedInterfaceAction(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 	action := &client.InterfaceAction{Action: "foo"}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -858,7 +858,7 @@ func (s *interfacesSuite) TestUnsupportedInterfaceAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -882,7 +882,7 @@ func (s *interfacesSuite) TestInterfacesLegacy(c *check.C) {
 	restore = ifacestate.MockSnapMapper(&inverseCaseMapper{})
 	defer restore()
 
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
 	var anotherConsumerYaml = `
 name: another-consumer-%s
@@ -895,10 +895,10 @@ plugs:
   key: value
   label: label
 `
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, fmt.Sprintf(anotherConsumerYaml, "def"))
-	s.MockSnap(c, fmt.Sprintf(anotherConsumerYaml, "abc"))
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, fmt.Sprintf(anotherConsumerYaml, "def"))
+	s.mockSnap(c, fmt.Sprintf(anotherConsumerYaml, "abc"))
+	s.mockSnap(c, producerYaml)
 
 	repo := d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
@@ -931,7 +931,7 @@ plugs:
 	req, err := http.NewRequest("GET", "/v2/interfaces", nil)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 200)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -1002,10 +1002,10 @@ func (s *interfacesSuite) TestInterfacesModern(c *check.C) {
 	restore = ifacestate.MockSnapMapper(&inverseCaseMapper{})
 	defer restore()
 
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
-	s.MockSnap(c, consumerYaml)
-	s.MockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
 
 	repo := d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
@@ -1018,7 +1018,7 @@ func (s *interfacesSuite) TestInterfacesModern(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/interfaces?select=connected&doc=true&plugs=true&slots=true", nil)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 200)
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -50,18 +50,18 @@ var modelDefaults = map[string]interface{}{
 var _ = check.Suite(&modelSuite{})
 
 type modelSuite struct {
-	daemon.APIBaseSuite
+	apiBaseSuite
 }
 
 func (s *modelSuite) TestPostRemodelUnhappy(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 
 	data, err := json.Marshal(daemon.PostModelData{NewModel: "invalid model"})
 	c.Check(err, check.IsNil)
 
 	req, err := http.NewRequest("POST", "/v2/model", bytes.NewBuffer(data))
 	c.Assert(err, check.IsNil)
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
 	c.Assert(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, "cannot decode new model assertion: .*")
@@ -73,7 +73,7 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 		"revision": "2",
 	})
 
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -83,7 +83,7 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 	st.Lock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.MockModel(c, st, oldModel)
+	s.mockModel(c, st, oldModel)
 	st.Unlock()
 
 	soon := 0
@@ -111,7 +111,7 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 	// devicestateRemodel
 	req, err := http.NewRequest("POST", "/v2/model", bytes.NewBuffer(data))
 	c.Assert(err, check.IsNil)
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Assert(rsp.Status, check.Equals, 202)
 	c.Check(devicestateRemodelGotModel, check.DeepEquals, newModel)
 
@@ -131,7 +131,7 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 
 func (s *modelSuite) TestGetModelNoModelAssertion(c *check.C) {
 
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -140,7 +140,7 @@ func (s *modelSuite) TestGetModelNoModelAssertion(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/model", nil)
 	c.Assert(err, check.IsNil)
-	response := s.Req(c, req, nil)
+	response := s.req(c, req, nil)
 	c.Assert(response, check.FitsTypeOf, &daemon.Resp{})
 	rsp := response.(*daemon.Resp)
 	c.Assert(rsp.Status, check.Equals, 404)
@@ -156,7 +156,7 @@ func (s *modelSuite) TestGetModelHasModelAssertion(c *check.C) {
 	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	// model assertion setup
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -166,14 +166,14 @@ func (s *modelSuite) TestGetModelHasModelAssertion(c *check.C) {
 	st.Lock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.MockModel(c, st, theModel)
+	s.mockModel(c, st, theModel)
 	st.Unlock()
 
 	// make a new get request to the model endpoint
 	req, err := http.NewRequest("GET", "/v2/model", nil)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 
 	// check that we get an assertion response
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
@@ -199,7 +199,7 @@ func (s *modelSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	// model assertion setup
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -209,13 +209,13 @@ func (s *modelSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 	st.Lock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.MockModel(c, st, theModel)
+	s.mockModel(c, st, theModel)
 	st.Unlock()
 
 	// make a new get request to the model endpoint with json as true
 	req, err := http.NewRequest("GET", "/v2/model?json=true", nil)
 	c.Assert(err, check.IsNil)
-	response := s.Req(c, req, nil)
+	response := s.req(c, req, nil)
 
 	// check that we get an generic response type
 	c.Assert(response, check.FitsTypeOf, &daemon.Resp{})
@@ -236,7 +236,7 @@ func (s *modelSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 
 func (s *modelSuite) TestGetModelNoSerialAssertion(c *check.C) {
 
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -245,7 +245,7 @@ func (s *modelSuite) TestGetModelNoSerialAssertion(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/model/serial", nil)
 	c.Assert(err, check.IsNil)
-	response := s.Req(c, req, nil)
+	response := s.req(c, req, nil)
 	c.Assert(response, check.FitsTypeOf, &daemon.Resp{})
 	rsp := response.(*daemon.Resp)
 	c.Assert(rsp.Status, check.Equals, 404)
@@ -266,7 +266,7 @@ func (s *modelSuite) TestGetModelHasSerialAssertion(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// model assertion setup
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -277,7 +277,7 @@ func (s *modelSuite) TestGetModelHasSerialAssertion(c *check.C) {
 	defer st.Unlock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.MockModel(c, st, theModel)
+	s.mockModel(c, st, theModel)
 
 	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
 		"authority-id":        "my-brand",
@@ -303,7 +303,7 @@ func (s *modelSuite) TestGetModelHasSerialAssertion(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/model/serial", nil)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 
 	// check that we get an assertion response
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
@@ -334,7 +334,7 @@ func (s *modelSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// model assertion setup
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -345,7 +345,7 @@ func (s *modelSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	defer st.Unlock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.MockModel(c, st, theModel)
+	s.mockModel(c, st, theModel)
 
 	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
 		"authority-id":        "my-brand",
@@ -370,7 +370,7 @@ func (s *modelSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	// make a new get request to the model endpoint with json as true
 	req, err := http.NewRequest("GET", "/v2/model/serial?json=true", nil)
 	c.Assert(err, check.IsNil)
-	response := s.Req(c, req, nil)
+	response := s.req(c, req, nil)
 
 	// check that we get an generic response type
 	c.Assert(response, check.FitsTypeOf, &daemon.Resp{})

--- a/daemon/api_snap_conf_test.go
+++ b/daemon/api_snap_conf_test.go
@@ -28,7 +28,6 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -36,14 +35,14 @@ import (
 var _ = check.Suite(&snapConfSuite{})
 
 type snapConfSuite struct {
-	daemon.APIBaseSuite
+	apiBaseSuite
 }
 
 func (s *snapConfSuite) runGetConf(c *check.C, snapName string, keys []string, statusCode int) map[string]interface{} {
 	req, err := http.NewRequest("GET", "/v2/snaps/"+snapName+"/conf?keys="+strings.Join(keys, ","), nil)
 	c.Check(err, check.IsNil)
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, statusCode)
 
 	var body map[string]interface{}
@@ -53,7 +52,7 @@ func (s *snapConfSuite) runGetConf(c *check.C, snapName string, keys []string, s
 }
 
 func (s *snapConfSuite) TestGetConfSingleKey(c *check.C) {
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
 	// Set a config that we'll get in a moment
 	d.Overlord().State().Lock()
@@ -71,7 +70,7 @@ func (s *snapConfSuite) TestGetConfSingleKey(c *check.C) {
 }
 
 func (s *snapConfSuite) TestGetConfCoreSystemAlias(c *check.C) {
-	d := s.Daemon(c)
+	d := s.daemon(c)
 
 	// Set a config that we'll get in a moment
 	d.Overlord().State().Lock()
@@ -88,7 +87,7 @@ func (s *snapConfSuite) TestGetConfCoreSystemAlias(c *check.C) {
 }
 
 func (s *snapConfSuite) TestGetConfMissingKey(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 	result := s.runGetConf(c, "test-snap", []string{"test-key2"}, 400)
 	c.Check(result, check.DeepEquals, map[string]interface{}{
 		"value": map[string]interface{}{
@@ -101,7 +100,7 @@ func (s *snapConfSuite) TestGetConfMissingKey(c *check.C) {
 }
 
 func (s *snapConfSuite) TestGetRootDocument(c *check.C) {
-	d := s.Daemon(c)
+	d := s.daemon(c)
 	d.Overlord().State().Lock()
 	tr := config.NewTransaction(d.Overlord().State())
 	tr.Set("test-snap", "test-key1", "test-value1")
@@ -114,7 +113,7 @@ func (s *snapConfSuite) TestGetRootDocument(c *check.C) {
 }
 
 func (s *snapConfSuite) TestGetConfBadKey(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 	// TODO: this one in particular should really be a 400 also
 	result := s.runGetConf(c, "test-snap", []string{"."}, 500)
 	c.Check(result, check.DeepEquals, map[string]interface{}{"message": `invalid option name: ""`})
@@ -128,8 +127,8 @@ hooks:
 `
 
 func (s *snapConfSuite) TestSetConf(c *check.C) {
-	d := s.Daemon(c)
-	s.MockSnap(c, configYaml)
+	d := s.daemon(c)
+	s.mockSnap(c, configYaml)
 
 	// Mock the hook runner
 	hookRunner := testutil.MockCommand(c, "snap", "")
@@ -146,7 +145,7 @@ func (s *snapConfSuite) TestSetConf(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
 
 	var body map[string]interface{}
@@ -174,8 +173,8 @@ func (s *snapConfSuite) TestSetConf(c *check.C) {
 }
 
 func (s *snapConfSuite) TestSetConfCoreSystemAlias(c *check.C) {
-	d := s.Daemon(c)
-	s.MockSnap(c, `
+	d := s.daemon(c)
+	s.mockSnap(c, `
 name: core
 version: 1
 `)
@@ -194,7 +193,7 @@ version: 1
 	c.Assert(err, check.IsNil)
 
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
 
 	var body map[string]interface{}
@@ -225,8 +224,8 @@ version: 1
 }
 
 func (s *snapConfSuite) TestSetConfNumber(c *check.C) {
-	d := s.Daemon(c)
-	s.MockSnap(c, configYaml)
+	d := s.daemon(c)
+	s.mockSnap(c, configYaml)
 
 	// Mock the hook runner
 	hookRunner := testutil.MockCommand(c, "snap", "")
@@ -243,7 +242,7 @@ func (s *snapConfSuite) TestSetConfNumber(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
 
 	var body map[string]interface{}
@@ -268,7 +267,7 @@ func (s *snapConfSuite) TestSetConfNumber(c *check.C) {
 }
 
 func (s *snapConfSuite) TestSetConfBadSnap(c *check.C) {
-	s.DaemonWithOverlordMock(c)
+	s.daemonWithOverlordMock(c)
 
 	text, err := json.Marshal(map[string]interface{}{"key": "value"})
 	c.Assert(err, check.IsNil)
@@ -278,7 +277,7 @@ func (s *snapConfSuite) TestSetConfBadSnap(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 404)
 
 	var body map[string]interface{}
@@ -296,10 +295,10 @@ func (s *snapConfSuite) TestSetConfBadSnap(c *check.C) {
 }
 
 func (s *snapConfSuite) TestSetConfChangeConflict(c *check.C) {
-	s.Daemon(c)
-	s.MockSnap(c, configYaml)
+	s.daemon(c)
+	s.mockSnap(c, configYaml)
 
-	s.SimulateConflict("config-snap")
+	s.simulateConflict("config-snap")
 
 	text, err := json.Marshal(map[string]interface{}{"key": "value"})
 	c.Assert(err, check.IsNil)
@@ -309,7 +308,7 @@ func (s *snapConfSuite) TestSetConfChangeConflict(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rec := httptest.NewRecorder()
-	s.Req(c, req, nil).ServeHTTP(rec, req)
+	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 409)
 
 	var body map[string]interface{}

--- a/daemon/api_snapctl_test.go
+++ b/daemon/api_snapctl_test.go
@@ -36,20 +36,20 @@ import (
 var _ = check.Suite(&snapctlSuite{})
 
 type snapctlSuite struct {
-	daemon.APIBaseSuite
+	apiBaseSuite
 }
 
 func (s *snapctlSuite) TestSnapctlGetNoUID(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 	buf := bytes.NewBufferString(`{"context-id": "some-context", "args": ["get", "something"]}`)
 	req, err := http.NewRequest("POST", "/v2/snapctl", buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Assert(rsp.Status, check.Equals, 403)
 }
 
 func (s *snapctlSuite) TestSnapctlForbiddenError(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 
 	defer daemon.MockUcrednetGet(func(string) (int32, uint32, string, error) {
 		return 100, 9999, dirs.SnapSocket, nil
@@ -62,12 +62,12 @@ func (s *snapctlSuite) TestSnapctlForbiddenError(c *check.C) {
 	buf := bytes.NewBufferString(fmt.Sprintf(`{"context-id": "some-context", "args": [%q, %q]}`, "set", "foo=bar"))
 	req, err := http.NewRequest("POST", "/v2/snapctl", buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Assert(rsp.Status, check.Equals, 403)
 }
 
 func (s *snapctlSuite) TestSnapctlUnsuccesfulError(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 
 	defer daemon.MockUcrednetGet(func(string) (int32, uint32, string, error) {
 		return 100, 9999, dirs.SnapSocket, nil
@@ -80,7 +80,7 @@ func (s *snapctlSuite) TestSnapctlUnsuccesfulError(c *check.C) {
 	buf := bytes.NewBufferString(fmt.Sprintf(`{"context-id": "some-context", "args": [%q, %q]}`, "is-connected", "plug"))
 	req, err := http.NewRequest("POST", "/v2/snapctl", buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindUnsuccessful)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Value, check.DeepEquals, map[string]interface{}{

--- a/daemon/api_system_recovery_keys_test.go
+++ b/daemon/api_system_recovery_keys_test.go
@@ -38,7 +38,7 @@ import (
 var _ = Suite(&recoveryKeysSuite{})
 
 type recoveryKeysSuite struct {
-	daemon.APIBaseSuite
+	apiBaseSuite
 }
 
 func mockSystemRecoveryKeys(c *C) {
@@ -63,13 +63,13 @@ func (s *recoveryKeysSuite) TestSystemGetRecoveryKeysAsRootHappy(c *C) {
 		c.Skip("needs working secboot recovery key")
 	}
 
-	s.Daemon(c)
+	s.daemon(c)
 	mockSystemRecoveryKeys(c)
 
 	req, err := http.NewRequest("GET", "/v2/system-recovery-keys", nil)
 	c.Assert(err, IsNil)
 
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Assert(rsp.Status, Equals, 200)
 	srk := rsp.Result.(*client.SystemRecoveryKeysResponse)
 	c.Assert(srk, DeepEquals, &client.SystemRecoveryKeysResponse{
@@ -79,7 +79,7 @@ func (s *recoveryKeysSuite) TestSystemGetRecoveryKeysAsRootHappy(c *C) {
 }
 
 func (s *recoveryKeysSuite) TestSystemGetRecoveryAsUserErrors(c *C) {
-	s.Daemon(c)
+	s.daemon(c)
 	mockSystemRecoveryKeys(c)
 
 	req, err := http.NewRequest("GET", "/v2/system-recovery-keys", nil)
@@ -87,6 +87,6 @@ func (s *recoveryKeysSuite) TestSystemGetRecoveryAsUserErrors(c *C) {
 
 	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rec := httptest.NewRecorder()
-	s.ServeHTTP(c, rec, req)
+	s.serveHTTP(c, rec, req)
 	c.Assert(rec.Code, Equals, 401)
 }

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -53,7 +53,7 @@ import (
 var _ = check.Suite(&systemsSuite{})
 
 type systemsSuite struct {
-	daemon.APIBaseSuite
+	apiBaseSuite
 }
 
 func (s *systemsSuite) mockSystemSeeds(c *check.C) (restore func()) {
@@ -121,7 +121,7 @@ func (s *systemsSuite) TestSystemsGetSome(c *check.C) {
 	err := m.WriteTo("")
 	c.Assert(err, check.IsNil)
 
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -142,7 +142,7 @@ func (s *systemsSuite) TestSystemsGetSome(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/systems", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 
 	c.Assert(rsp.Status, check.Equals, 200)
 	sys := rsp.Result.(*daemon.SystemsResponse)
@@ -197,7 +197,7 @@ func (s *systemsSuite) TestSystemsGetNone(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// model assertion setup
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -207,7 +207,7 @@ func (s *systemsSuite) TestSystemsGetNone(c *check.C) {
 	// no system seeds
 	req, err := http.NewRequest("GET", "/v2/systems", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 
 	c.Assert(rsp.Status, check.Equals, 200)
 	sys := rsp.Result.(*daemon.SystemsResponse)
@@ -223,7 +223,7 @@ func (s *systemsSuite) TestSystemActionRequestErrors(c *check.C) {
 	err := m.WriteTo("")
 	c.Assert(err, check.IsNil)
 
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
@@ -299,7 +299,7 @@ func (s *systemsSuite) TestSystemActionRequestErrors(c *check.C) {
 		c.Logf("tc: %#v", tc)
 		req, err := http.NewRequest("POST", path.Join("/v2/systems", tc.label), strings.NewReader(tc.body))
 		c.Assert(err, check.IsNil)
-		rsp := s.Req(c, req, nil).(*daemon.Resp)
+		rsp := s.req(c, req, nil).(*daemon.Resp)
 		c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
 		c.Check(rsp.Status, check.Equals, tc.status)
 		c.Check(rsp.ErrorResult().Message, check.Matches, tc.error)
@@ -427,7 +427,7 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		}
 		err := m.WriteTo("")
 		c.Assert(err, check.IsNil)
-		d := s.Daemon(c)
+		d := s.daemon(c)
 		st := d.Overlord().State()
 		st.Lock()
 		// devicemgr needs boot id to request a reboot
@@ -435,7 +435,7 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		// device model
 		assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 		assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-		s.MockModel(c, st, model)
+		s.mockModel(c, st, model)
 		if tc.currentMode == "run" {
 			// only set in run mode
 			st.Set("seeded-systems", currentSystem)
@@ -456,7 +456,7 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		// as root
 		req.RemoteAddr = "pid=100;uid=0;socket=;"
 		rec := httptest.NewRecorder()
-		s.ServeHTTP(c, rec, req)
+		s.serveHTTP(c, rec, req)
 		if tc.expUnsupported {
 			c.Check(rec.Code, check.Equals, 400, check.Commentf(tc.comment))
 		} else {
@@ -506,7 +506,7 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		c.Assert(rspBody, check.DeepEquals, expResp, check.Commentf(tc.comment))
 
 		cmd.ForgetCalls()
-		s.ResetDaemon()
+		s.resetDaemon()
 	}
 
 }
@@ -518,7 +518,7 @@ func (s *systemsSuite) TestSystemActionBrokenSeed(c *check.C) {
 	err := m.WriteTo("")
 	c.Assert(err, check.IsNil)
 
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -540,13 +540,13 @@ func (s *systemsSuite) TestSystemActionBrokenSeed(c *check.C) {
 	body := `{"action":"do","title":"reinstall","mode":"install"}`
 	req, err := http.NewRequest("POST", "/v2/systems/20191119", strings.NewReader(body))
 	c.Assert(err, check.IsNil)
-	rsp := s.Req(c, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Status, check.Equals, 500)
 	c.Check(rsp.ErrorResult().Message, check.Matches, `cannot load seed system: cannot load assertions: .*`)
 }
 
 func (s *systemsSuite) TestSystemActionNonRoot(c *check.C) {
-	d := s.DaemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -562,7 +562,7 @@ func (s *systemsSuite) TestSystemActionNonRoot(c *check.C) {
 	req.RemoteAddr = "pid=100;uid=1234;socket=;"
 
 	rec := httptest.NewRecorder()
-	s.ServeHTTP(c, rec, req)
+	s.serveHTTP(c, rec, req)
 	c.Assert(rec.Code, check.Equals, 401)
 
 	var rspBody map[string]interface{}
@@ -580,7 +580,7 @@ func (s *systemsSuite) TestSystemActionNonRoot(c *check.C) {
 }
 
 func (s *systemsSuite) TestSystemRebootNeedsRoot(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 
 	restore := daemon.MockDeviceManagerReboot(func(dm *devicestate.DeviceManager, systemLabel, mode string) error {
 		c.Fatalf("request reboot should not get called")
@@ -595,12 +595,12 @@ func (s *systemsSuite) TestSystemRebootNeedsRoot(c *check.C) {
 	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 
 	rec := httptest.NewRecorder()
-	s.ServeHTTP(c, rec, req)
+	s.serveHTTP(c, rec, req)
 	c.Check(rec.Code, check.Equals, 401)
 }
 
 func (s *systemsSuite) TestSystemRebootHappy(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 
 	for _, tc := range []struct {
 		systemLabel, mode string
@@ -632,14 +632,14 @@ func (s *systemsSuite) TestSystemRebootHappy(c *check.C) {
 		req.RemoteAddr = "pid=100;uid=0;socket=;"
 
 		rec := httptest.NewRecorder()
-		s.ServeHTTP(c, rec, req)
+		s.serveHTTP(c, rec, req)
 		c.Check(rec.Code, check.Equals, 200)
 		c.Check(called, check.Equals, 1)
 	}
 }
 
 func (s *systemsSuite) TestSystemRebootUnhappy(c *check.C) {
-	s.Daemon(c)
+	s.daemon(c)
 
 	for _, tc := range []struct {
 		rebootErr        error
@@ -664,7 +664,7 @@ func (s *systemsSuite) TestSystemRebootUnhappy(c *check.C) {
 		req.RemoteAddr = "pid=100;uid=0;socket=;"
 
 		rec := httptest.NewRecorder()
-		s.ServeHTTP(c, rec, req)
+		s.serveHTTP(c, rec, req)
 		c.Check(rec.Code, check.Equals, tc.expectedHttpCode)
 		c.Check(called, check.Equals, 1)
 

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -43,7 +43,7 @@ func NewAndAddRoutes() (*Daemon, error) {
 }
 
 func NewWithOverlord(o *overlord.Overlord) *Daemon {
-	d := &Daemon{overlord: o}
+	d := &Daemon{overlord: o, state: o.State()}
 	d.addRoutes()
 	return d
 }

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gorilla/mux"
+
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -31,10 +33,23 @@ import (
 
 var MinLane = minLane
 
+func NewAndAddRoutes() (*Daemon, error) {
+	d, err := New()
+	if err != nil {
+		return nil, err
+	}
+	d.addRoutes()
+	return d, nil
+}
+
 func NewWithOverlord(o *overlord.Overlord) *Daemon {
 	d := &Daemon{overlord: o}
 	d.addRoutes()
 	return d
+}
+
+func (d *Daemon) RouterMatch(req *http.Request, m *mux.RouteMatch) bool {
+	return d.router.Match(req, m)
 }
 
 func (d *Daemon) Overlord() *overlord.Overlord {


### PR DESCRIPTION
temporarely keep a version also in daemon in api_base_d_test.go, that will go away...

unexport all methods that are not interface implementations

sorry for the flip-flop about this
