### PR TITLE
gadget: prepare gadget kernel refs (0/N)

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -167,9 +167,9 @@ func (vs *VolumeStructure) EffectiveFilesystemLabel() string {
 // either files within a filesystem described by the structure or raw images
 // written into the area of a bare structure.
 type VolumeContent struct {
-	// Source is the data of the partition relative to the gadget base
-	// directory
-	Source string `yaml:"source"`
+	// UnresovedSource is the data of the partition relative to
+	// the gadget base directory
+	UnresolvedSource string `yaml:"source"`
 	// Target is the location of the data inside the root filesystem
 	Target string `yaml:"target"`
 
@@ -193,7 +193,7 @@ func (vc VolumeContent) String() string {
 	if vc.Image != "" {
 		return fmt.Sprintf("image:%s", vc.Image)
 	}
-	return fmt.Sprintf("source:%s", vc.Source)
+	return fmt.Sprintf("source:%s", vc.UnresolvedSource)
 }
 
 type VolumeUpdate struct {
@@ -715,7 +715,7 @@ func validateRole(vs *VolumeStructure, vol *Volume) error {
 }
 
 func validateBareContent(vc *VolumeContent) error {
-	if vc.Source != "" || vc.Target != "" {
+	if vc.UnresolvedSource != "" || vc.Target != "" {
 		return fmt.Errorf("cannot use non-image content for bare file system")
 	}
 	if vc.Image == "" {
@@ -728,7 +728,7 @@ func validateFilesystemContent(vc *VolumeContent) error {
 	if vc.Image != "" || vc.Offset != nil || vc.OffsetWrite != nil || vc.Size != 0 {
 		return fmt.Errorf("cannot use image content for non-bare file system")
 	}
-	if vc.Source == "" || vc.Target == "" {
+	if vc.UnresolvedSource == "" || vc.Target == "" {
 		return fmt.Errorf("missing source or target")
 	}
 	return nil

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -720,7 +720,7 @@ func validateRole(vs *VolumeStructure, vol *Volume) error {
 }
 
 func validateBareContent(vc *VolumeContent) error {
-	if vc.ResolvedSource() != "" || vc.Target != "" {
+	if vc.UnresolvedSource != "" || vc.Target != "" {
 		return fmt.Errorf("cannot use non-image content for bare file system")
 	}
 	if vc.Image == "" {
@@ -733,7 +733,7 @@ func validateFilesystemContent(vc *VolumeContent) error {
 	if vc.Image != "" || vc.Offset != nil || vc.OffsetWrite != nil || vc.Size != 0 {
 		return fmt.Errorf("cannot use image content for non-bare file system")
 	}
-	if vc.ResolvedSource() == "" || vc.Target == "" {
+	if vc.UnresolvedSource == "" || vc.Target == "" {
 		return fmt.Errorf("missing source or target")
 	}
 	return nil

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -189,6 +189,11 @@ type VolumeContent struct {
 	Unpack bool `yaml:"unpack"`
 }
 
+func (vc VolumeContent) ResolvedSource() string {
+	// TODO: implement resolved sources
+	return vc.UnresolvedSource
+}
+
 func (vc VolumeContent) String() string {
 	if vc.Image != "" {
 		return fmt.Sprintf("image:%s", vc.Image)
@@ -715,7 +720,7 @@ func validateRole(vs *VolumeStructure, vol *Volume) error {
 }
 
 func validateBareContent(vc *VolumeContent) error {
-	if vc.UnresolvedSource != "" || vc.Target != "" {
+	if vc.ResolvedSource() != "" || vc.Target != "" {
 		return fmt.Errorf("cannot use non-image content for bare file system")
 	}
 	if vc.Image == "" {
@@ -728,7 +733,7 @@ func validateFilesystemContent(vc *VolumeContent) error {
 	if vc.Image != "" || vc.Offset != nil || vc.OffsetWrite != nil || vc.Size != 0 {
 		return fmt.Errorf("cannot use image content for non-bare file system")
 	}
-	if vc.UnresolvedSource == "" || vc.Target == "" {
+	if vc.ResolvedSource() == "" || vc.Target == "" {
 		return fmt.Errorf("missing source or target")
 	}
 	return nil

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -648,14 +648,14 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlValid(c *C) {
 						Filesystem:  "vfat",
 						Content: []gadget.VolumeContent{
 							{
-								Source: "subdir/",
-								Target: "/",
-								Unpack: false,
+								UnresolvedSource: "subdir/",
+								Target:           "/",
+								Unpack:           false,
 							},
 							{
-								Source: "foo",
-								Target: "/",
-								Unpack: false,
+								UnresolvedSource: "foo",
+								Target:           "/",
+								Unpack:           false,
 							},
 						},
 					},
@@ -687,8 +687,8 @@ func (s *gadgetYamlTestSuite) TestReadMultiVolumeGadgetYamlValid(c *C) {
 						Type:       "0C",
 						Content: []gadget.VolumeContent{
 							{
-								Source: "splash.bmp",
-								Target: ".",
+								UnresolvedSource: "splash.bmp",
+								Target:           ".",
 							},
 						},
 					},
@@ -822,9 +822,9 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlVolumeUpdate(c *C) {
 						Type:        "0C",
 						Filesystem:  "vfat",
 						Content: []gadget.VolumeContent{{
-							Source: "subdir/",
-							Target: "/",
-							Unpack: false,
+							UnresolvedSource: "subdir/",
+							Target:           "/",
+							Unpack:           false,
 						}},
 						Update: gadget.VolumeUpdate{
 							Edition: 5,
@@ -1296,7 +1296,7 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeErrorsWrapped(c *C) {
 
 	err = gadget.ValidateVolume("name", &gadget.Volume{
 		Structure: []gadget.VolumeStructure{
-			{Type: "bare", Name: "foo", Size: 1024, Content: []gadget.VolumeContent{{Source: "foo"}}},
+			{Type: "bare", Name: "foo", Size: 1024, Content: []gadget.VolumeContent{{UnresolvedSource: "foo"}}},
 		},
 	}, nil)
 	c.Assert(err, ErrorMatches, `invalid structure #0 \("foo"\): invalid content #0: cannot use non-image content for bare file system`)

--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -111,8 +111,8 @@ var mockOnDiskStructureSystemSeed = gadget.OnDiskStructure{
 			Filesystem: "vfat",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "grubx64.efi",
-					Target: "EFI/boot/grubx64.efi",
+					UnresolvedSource: "grubx64.efi",
+					Target:           "EFI/boot/grubx64.efi",
 				},
 			},
 		},
@@ -241,8 +241,8 @@ func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 		m.LaidOutContent = []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
-					Source: "grubx64.efi",
-					Target: "EFI/boot/grubx64.efi",
+					UnresolvedSource: "grubx64.efi",
+					Target:           "EFI/boot/grubx64.efi",
 				},
 			},
 		}

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -110,7 +110,7 @@ func (p LaidOutContent) String() string {
 	if p.Image != "" {
 		return fmt.Sprintf("#%v (%q@%#x{%v})", p.Index, p.Image, p.StartOffset, p.Size)
 	}
-	return fmt.Sprintf("#%v (source:%q)", p.Index, p.Source)
+	return fmt.Sprintf("#%v (source:%q)", p.Index, p.UnresolvedSource)
 }
 
 func layoutVolumeStructures(volume *Volume, constraints LayoutConstraints) (structures []LaidOutStructure, byName map[string]*LaidOutStructure, err error) {

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -47,7 +47,7 @@ func checkSourceIsDir(src string) error {
 }
 
 func checkContent(content *VolumeContent) error {
-	if content.Source == "" {
+	if content.UnresolvedSource == "" {
 		return fmt.Errorf("internal error: source cannot be unset")
 	}
 	if content.Target == "" {
@@ -250,18 +250,18 @@ func (m *MountedFilesystemWriter) writeVolumeContent(volumeRoot string, content 
 	if err := checkContent(content); err != nil {
 		return err
 	}
-	realSource := filepath.Join(m.contentDir, content.Source)
+	realSource := filepath.Join(m.contentDir, content.UnresolvedSource)
 	realTarget := filepath.Join(volumeRoot, content.Target)
 
 	// filepath trims the trailing /, restore if needed
 	if strings.HasSuffix(content.Target, "/") {
 		realTarget += "/"
 	}
-	if strings.HasSuffix(content.Source, "/") {
+	if strings.HasSuffix(content.UnresolvedSource, "/") {
 		realSource += "/"
 	}
 
-	if osutil.IsDirectory(realSource) || strings.HasSuffix(content.Source, "/") {
+	if osutil.IsDirectory(realSource) || strings.HasSuffix(content.UnresolvedSource, "/") {
 		// write a directory
 		return m.writeDirectory(volumeRoot, realSource, realTarget, preserveInDst)
 	} else {
@@ -512,12 +512,12 @@ func (f *mountedFilesystemUpdater) updateVolumeContent(volumeRoot string, conten
 		return err
 	}
 
-	srcPath := f.entrySourcePath(content.Source)
+	srcPath := f.entrySourcePath(content.UnresolvedSource)
 
-	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.Source, "/") {
-		return f.updateDirectory(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.UnresolvedSource, "/") {
+		return f.updateDirectory(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
 	} else {
-		return f.updateOrSkipFile(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		return f.updateOrSkipFile(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
 	}
 }
 
@@ -798,17 +798,17 @@ func (f *mountedFilesystemUpdater) backupVolumeContent(volumeRoot string, conten
 		return err
 	}
 
-	srcPath := f.entrySourcePath(content.Source)
+	srcPath := f.entrySourcePath(content.UnresolvedSource)
 
 	if err := f.checkpointPrefix(volumeRoot, content.Target, backupDir); err != nil {
 		return err
 	}
-	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.Source, "/") {
+	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.UnresolvedSource, "/") {
 		// backup directory contents
-		return f.backupOrCheckpointDirectory(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		return f.backupOrCheckpointDirectory(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
 	} else {
 		// backup a file
-		return f.observedBackupOrCheckpointFile(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		return f.observedBackupOrCheckpointFile(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
 	}
 }
 
@@ -933,15 +933,15 @@ func (f *mountedFilesystemUpdater) rollbackVolumeContent(volumeRoot string, cont
 		return err
 	}
 
-	srcPath := f.entrySourcePath(content.Source)
+	srcPath := f.entrySourcePath(content.UnresolvedSource)
 
 	var err error
-	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.Source, "/") {
+	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.UnresolvedSource, "/") {
 		// rollback directory
-		err = f.rollbackDirectory(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		err = f.rollbackDirectory(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
 	} else {
 		// rollback file
-		err = f.rollbackFile(volumeRoot, content.Source, content.Target, preserveInDst, backupDir)
+		err = f.rollbackFile(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
 	}
 	if err != nil {
 		return err

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -47,7 +47,7 @@ func checkSourceIsDir(src string) error {
 }
 
 func checkContent(content *VolumeContent) error {
-	if content.UnresolvedSource == "" {
+	if content.ResolvedSource() == "" {
 		return fmt.Errorf("internal error: source cannot be unset")
 	}
 	if content.Target == "" {
@@ -250,18 +250,19 @@ func (m *MountedFilesystemWriter) writeVolumeContent(volumeRoot string, content 
 	if err := checkContent(content); err != nil {
 		return err
 	}
-	realSource := filepath.Join(m.contentDir, content.UnresolvedSource)
+	// TODO: ResolvedSource() will already have resolved m.contentDir
+	realSource := filepath.Join(m.contentDir, content.ResolvedSource())
 	realTarget := filepath.Join(volumeRoot, content.Target)
 
 	// filepath trims the trailing /, restore if needed
 	if strings.HasSuffix(content.Target, "/") {
 		realTarget += "/"
 	}
-	if strings.HasSuffix(content.UnresolvedSource, "/") {
+	if strings.HasSuffix(content.ResolvedSource(), "/") {
 		realSource += "/"
 	}
 
-	if osutil.IsDirectory(realSource) || strings.HasSuffix(content.UnresolvedSource, "/") {
+	if osutil.IsDirectory(realSource) || strings.HasSuffix(content.ResolvedSource(), "/") {
 		// write a directory
 		return m.writeDirectory(volumeRoot, realSource, realTarget, preserveInDst)
 	} else {
@@ -512,12 +513,15 @@ func (f *mountedFilesystemUpdater) updateVolumeContent(volumeRoot string, conten
 		return err
 	}
 
-	srcPath := f.entrySourcePath(content.UnresolvedSource)
+	// TODO: ResolvedSource() will already have resolved f.entrySourcePath
+	srcPath := f.entrySourcePath(content.ResolvedSource())
 
-	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.UnresolvedSource, "/") {
-		return f.updateDirectory(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
+	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.ResolvedSource(), "/") {
+		// TODO: pass both Unresolved and resolved Source (unresolved for better error reporting)
+		return f.updateDirectory(volumeRoot, content.ResolvedSource(), content.Target, preserveInDst, backupDir)
 	} else {
-		return f.updateOrSkipFile(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
+		// TODO: pass both Unresolved and resolved Source (unresolved for better error reporting)
+		return f.updateOrSkipFile(volumeRoot, content.ResolvedSource(), content.Target, preserveInDst, backupDir)
 	}
 }
 
@@ -798,17 +802,19 @@ func (f *mountedFilesystemUpdater) backupVolumeContent(volumeRoot string, conten
 		return err
 	}
 
-	srcPath := f.entrySourcePath(content.UnresolvedSource)
+	// TODO: ResolvedSource() will already have resolved f.entrySourcePath
+	srcPath := f.entrySourcePath(content.ResolvedSource())
 
 	if err := f.checkpointPrefix(volumeRoot, content.Target, backupDir); err != nil {
 		return err
 	}
-	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.UnresolvedSource, "/") {
+	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.ResolvedSource(), "/") {
 		// backup directory contents
-		return f.backupOrCheckpointDirectory(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
+		// TODO: pass both Unresolved and resolved Source (unresolved for better error reporting)
+		return f.backupOrCheckpointDirectory(volumeRoot, content.ResolvedSource(), content.Target, preserveInDst, backupDir)
 	} else {
 		// backup a file
-		return f.observedBackupOrCheckpointFile(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
+		return f.observedBackupOrCheckpointFile(volumeRoot, content.ResolvedSource(), content.Target, preserveInDst, backupDir)
 	}
 }
 
@@ -933,15 +939,16 @@ func (f *mountedFilesystemUpdater) rollbackVolumeContent(volumeRoot string, cont
 		return err
 	}
 
-	srcPath := f.entrySourcePath(content.UnresolvedSource)
+	// TODO: ResolvedSource() will already have resolved f.entrySourcePath
+	srcPath := f.entrySourcePath(content.ResolvedSource())
 
 	var err error
-	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.UnresolvedSource, "/") {
+	if osutil.IsDirectory(srcPath) || strings.HasSuffix(content.ResolvedSource(), "/") {
 		// rollback directory
-		err = f.rollbackDirectory(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
+		err = f.rollbackDirectory(volumeRoot, content.ResolvedSource(), content.Target, preserveInDst, backupDir)
 	} else {
 		// rollback file
-		err = f.rollbackFile(volumeRoot, content.UnresolvedSource, content.Target, preserveInDst, backupDir)
+		err = f.rollbackFile(volumeRoot, content.ResolvedSource(), content.Target, preserveInDst, backupDir)
 	}
 	if err != nil {
 		return err

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -318,28 +318,28 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterHappy(c *C) {
 			Content: []gadget.VolumeContent{
 				{
 					// single file in target directory
-					Source: "foo",
-					Target: "/foo-dir/",
+					UnresolvedSource: "foo",
+					Target:           "/foo-dir/",
 				}, {
 					// single file under different name
-					Source: "bar",
-					Target: "/bar-name",
+					UnresolvedSource: "bar",
+					Target:           "/bar-name",
 				}, {
 					// whole directory contents
-					Source: "boot-assets/",
-					Target: "/",
+					UnresolvedSource: "boot-assets/",
+					Target:           "/",
 				}, {
 					// single file from nested directory
-					Source: "boot-assets/some-dir/data",
-					Target: "/data-copy",
+					UnresolvedSource: "boot-assets/some-dir/data",
+					Target:           "/data-copy",
 				}, {
 					// contents of nested directory under new target directory
-					Source: "boot-assets/nested-dir/",
-					Target: "/nested-copy/",
+					UnresolvedSource: "boot-assets/nested-dir/",
+					Target:           "/nested-copy/",
 				}, {
 					// contents of nested directory under new target directory
-					Source: "baz",
-					Target: "baz",
+					UnresolvedSource: "baz",
+					Target:           "baz",
 				},
 			},
 		},
@@ -412,8 +412,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterNonDirectory(c *C) {
 			Content: []gadget.VolumeContent{
 				{
 					// contents of nested directory under new target directory
-					Source: "foo/",
-					Target: "/nested-copy/",
+					UnresolvedSource: "foo/",
+					Target:           "/nested-copy/",
 				},
 			},
 		},
@@ -437,8 +437,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorMissingSource(c *C) {
 			Content: []gadget.VolumeContent{
 				{
 					// single file in target directory
-					Source: "foo",
-					Target: "/foo-dir/",
+					UnresolvedSource: "foo",
+					Target:           "/foo-dir/",
 				},
 			},
 		},
@@ -468,8 +468,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorBadDestination(c *C) 
 			Content: []gadget.VolumeContent{
 				{
 					// single file in target directory
-					Source: "foo",
-					Target: "/foo-dir/",
+					UnresolvedSource: "foo",
+					Target:           "/foo-dir/",
 				},
 			},
 		},
@@ -501,12 +501,12 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterConflictingDestinationDire
 			Content: []gadget.VolumeContent{
 				{
 					// single file in target directory
-					Source: "foo",
-					Target: "/foo-dir/",
+					UnresolvedSource: "foo",
+					Target:           "/foo-dir/",
 				}, {
 					// conflicts with /foo-dir directory
-					Source: "foo-dir",
-					Target: "/",
+					UnresolvedSource: "foo-dir",
+					Target:           "/",
 				},
 			},
 		},
@@ -535,12 +535,12 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterConflictingDestinationFile
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/",
+					UnresolvedSource: "bar",
+					Target:           "/",
 				}, {
 					// overwrites data from preceding entry
-					Source: "foo",
-					Target: "/bar",
+					UnresolvedSource: "foo",
+					Target:           "/bar",
 				},
 			},
 		},
@@ -573,8 +573,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorNested(c *C) {
 			Content: []gadget.VolumeContent{
 				{
 					// single file in target directory
-					Source: "/",
-					Target: "/foo-dir/",
+					UnresolvedSource: "/",
+					Target:           "/foo-dir/",
 				},
 			},
 		},
@@ -636,30 +636,30 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterPreserve(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "foo",
-					Target: "/foo-dir/",
+					UnresolvedSource: "foo",
+					Target:           "/foo-dir/",
 				}, {
 					// would overwrite /foo
-					Source: "foo",
-					Target: "/",
+					UnresolvedSource: "foo",
+					Target:           "/",
 				}, {
 					// preserved, but not present, will be
 					// written
-					Source: "bar",
-					Target: "/bar-name",
+					UnresolvedSource: "bar",
+					Target:           "/bar-name",
 				}, {
 					// some-dir/data is preserved, but not
 					// preset, hence will be written
-					Source: "boot-assets/",
-					Target: "/",
+					UnresolvedSource: "boot-assets/",
+					Target:           "/",
 				}, {
 					// would overwrite /data-copy
-					Source: "boot-assets/some-dir/data",
-					Target: "/data-copy",
+					UnresolvedSource: "boot-assets/some-dir/data",
+					Target:           "/data-copy",
 				}, {
 					// would overwrite /nested-copy/nested
-					Source: "boot-assets/nested-dir/",
-					Target: "/nested-copy/",
+					UnresolvedSource: "boot-assets/nested-dir/",
+					Target:           "/nested-copy/",
 				},
 			},
 		},
@@ -697,11 +697,11 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterPreserveWithObserver(c *C)
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "foo",
+					UnresolvedSource: "foo",
 					// would overwrite existing foo
 					Target: "foo",
 				}, {
-					Source: "foo",
+					UnresolvedSource: "foo",
 					// does not exist
 					Target: "foo-new",
 				},
@@ -749,8 +749,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterNonFilePreserveError(c *C)
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "/",
-					Target: "/",
+					UnresolvedSource: "/",
+					Target:           "/",
 				},
 			},
 		},
@@ -778,8 +778,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterImplicitDir(c *C) {
 			Content: []gadget.VolumeContent{
 				{
 					// contents of nested directory under new target directory
-					Source: "boot-assets/nested-dir",
-					Target: "/nested-copy/",
+					UnresolvedSource: "boot-assets/nested-dir",
+					Target:           "/nested-copy/",
 				},
 			},
 		},
@@ -805,8 +805,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterNoFs(c *C) {
 			Content: []gadget.VolumeContent{
 				{
 					// single file in target directory
-					Source: "foo",
-					Target: "/foo-dir/",
+					UnresolvedSource: "foo",
+					Target:           "/foo-dir/",
 				},
 			},
 		},
@@ -829,8 +829,8 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterTrivialValidation(c *C) {
 			// no filesystem
 			Content: []gadget.VolumeContent{
 				{
-					Source: "",
-					Target: "",
+					UnresolvedSource: "",
+					Target:           "",
 				},
 			},
 		},
@@ -850,7 +850,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterTrivialValidation(c *C) {
 	err = rw.Write(d, nil)
 	c.Assert(err, ErrorMatches, "cannot write filesystem content .* source cannot be unset")
 
-	ps.Content[0].Source = "/"
+	ps.Content[0].UnresolvedSource = "/"
 	err = rw.Write(d, nil)
 	c.Assert(err, ErrorMatches, "cannot write filesystem content .* target cannot be unset")
 }
@@ -872,7 +872,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterSymlinks(c *C) {
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 		},
 	}
@@ -986,20 +986,20 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupSimple(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/bar-name",
+					UnresolvedSource: "bar",
+					Target:           "/bar-name",
 				}, {
-					Source: "foo",
-					Target: "/",
+					UnresolvedSource: "foo",
+					Target:           "/",
 				}, {
-					Source: "foo",
-					Target: "/nested/",
+					UnresolvedSource: "foo",
+					Target:           "/nested/",
 				}, {
-					Source: "zed",
-					Target: "/",
+					UnresolvedSource: "zed",
+					Target:           "/",
 				}, {
-					Source: "same-data",
-					Target: "/same",
+					UnresolvedSource: "same-data",
+					Target:           "/same",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1100,7 +1100,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterObserverErr(c *C) {
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 		},
 	}
@@ -1148,17 +1148,17 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupWithDirectories(c *
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				}, {
-					Source: "bar",
-					Target: "/this/is/some/nested/",
+					UnresolvedSource: "bar",
+					Target:           "/this/is/some/nested/",
 				}, {
-					Source: "some-dir/",
-					Target: "/nested/",
+					UnresolvedSource: "some-dir/",
+					Target:           "/nested/",
 				}, {
-					Source: "empty-dir/",
-					Target: "/lone-dir/",
+					UnresolvedSource: "empty-dir/",
+					Target:           "/lone-dir/",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1208,11 +1208,11 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupNonexistent(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				}, {
-					Source: "bar",
-					Target: "/some-dir/foo",
+					UnresolvedSource: "bar",
+					Target:           "/some-dir/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1250,8 +1250,8 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnBackupDirErr
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1300,8 +1300,8 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnDestinationE
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1345,8 +1345,8 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnBadSrcCompar
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1399,7 +1399,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFunnyNamesConflictB
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 			Update: gadget.VolumeUpdate{
 				Edition: 1,
@@ -1458,7 +1458,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFunnyNamesOk(c *C) 
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 			Update: gadget.VolumeUpdate{
 				Edition: 1,
@@ -1510,7 +1510,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupErrorOnSymlinkFile(
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 		},
 	}
@@ -1547,7 +1547,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupErrorOnSymlinkInPre
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 		},
 	}
@@ -1620,33 +1620,33 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterUpdate(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "foo",
-					Target: "/foo-dir/",
+					UnresolvedSource: "foo",
+					Target:           "/foo-dir/",
 				}, {
 					// would overwrite /foo
-					Source: "foo",
-					Target: "/",
+					UnresolvedSource: "foo",
+					Target:           "/",
 				}, {
 					// preserved, but not present, will be
 					// written
-					Source: "bar",
-					Target: "/bar-name",
+					UnresolvedSource: "bar",
+					Target:           "/bar-name",
 				}, {
 					// some-dir/data is preserved, but not
 					// present, hence will be written
-					Source: "boot-assets/",
-					Target: "/",
+					UnresolvedSource: "boot-assets/",
+					Target:           "/",
 				}, {
 					// would overwrite /data-copy
-					Source: "boot-assets/some-dir/data",
-					Target: "/data-copy",
+					UnresolvedSource: "boot-assets/some-dir/data",
+					Target:           "/data-copy",
 				}, {
 					// would overwrite /nested-copy/nested
-					Source: "boot-assets/nested-dir/",
-					Target: "/nested-copy/",
+					UnresolvedSource: "boot-assets/nested-dir/",
+					Target:           "/nested-copy/",
 				}, {
-					Source: "boot-assets",
-					Target: "/boot-assets-copy/",
+					UnresolvedSource: "boot-assets",
+					Target:           "/boot-assets-copy/",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1773,16 +1773,16 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterDirContents(c *C) {
 			Content: []gadget.VolumeContent{
 				{
 					// contents of bar under /bar-name/
-					Source: "bar/",
-					Target: "/bar-name",
+					UnresolvedSource: "bar/",
+					Target:           "/bar-name",
 				}, {
 					// whole bar under /bar-copy/
-					Source: "bar",
-					Target: "/bar-copy/",
+					UnresolvedSource: "bar",
+					Target:           "/bar-copy/",
 				}, {
 					// deep prefix
-					Source: "deep-nested",
-					Target: "/this/is/some/deep/nesting/",
+					UnresolvedSource: "deep-nested",
+					Target:           "/this/is/some/deep/nesting/",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1828,14 +1828,14 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterExpectsBackup(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				}, {
-					Source: "bar",
-					Target: "/some-dir/foo",
+					UnresolvedSource: "bar",
+					Target:           "/some-dir/foo",
 				}, {
-					Source: "bar",
-					Target: "/preserved",
+					UnresolvedSource: "bar",
+					Target:           "/preserved",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1888,14 +1888,14 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEmptyDir(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "/",
-					Target: "/",
+					UnresolvedSource: "/",
+					Target:           "/",
 				}, {
-					Source: "/",
-					Target: "/foo",
+					UnresolvedSource: "/",
+					Target:           "/foo",
 				}, {
-					Source: "/non-empty/empty-dir/",
-					Target: "/contents-of-empty/",
+					UnresolvedSource: "/non-empty/empty-dir/",
+					Target:           "/contents-of-empty/",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1948,11 +1948,11 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterSameFileSkipped(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				}, {
-					Source: "bar",
-					Target: "/some-dir/foo",
+					UnresolvedSource: "bar",
+					Target:           "/some-dir/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -1998,14 +1998,14 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterLonePrefix(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/1/nested/",
+					UnresolvedSource: "bar",
+					Target:           "/1/nested/",
 				}, {
-					Source: "bar",
-					Target: "/2/nested/foo",
+					UnresolvedSource: "bar",
+					Target:           "/2/nested/foo",
 				}, {
-					Source: "/",
-					Target: "/3/nested/",
+					UnresolvedSource: "/",
+					Target:           "/3/nested/",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2045,7 +2045,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterUpdateErrorOnSymlinkToFil
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 		},
 	}
@@ -2083,7 +2083,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupErrorOnSymlinkToDir
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 		},
 	}
@@ -2123,11 +2123,11 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackFromBackup(c *C) 
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				}, {
-					Source: "bar",
-					Target: "/some-dir/foo",
+					UnresolvedSource: "bar",
+					Target:           "/some-dir/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2193,8 +2193,8 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackSkipSame(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2245,8 +2245,8 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackSkipPreserved(c *
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2298,14 +2298,14 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackNewFiles(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				}, {
-					Source: "bar",
-					Target: "some-dir/",
+					UnresolvedSource: "bar",
+					Target:           "some-dir/",
 				}, {
-					Source: "bar",
-					Target: "/this/is/some/deep/nesting/",
+					UnresolvedSource: "bar",
+					Target:           "/this/is/some/deep/nesting/",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2375,11 +2375,11 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackRestoreFails(c *C
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				}, {
-					Source: "bar",
-					Target: "/some-dir/foo",
+					UnresolvedSource: "bar",
+					Target:           "/some-dir/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2434,11 +2434,11 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackNotWritten(c *C) 
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "bar",
-					Target: "/foo",
+					UnresolvedSource: "bar",
+					Target:           "/foo",
 				}, {
-					Source: "bar",
-					Target: "/some-dir/foo",
+					UnresolvedSource: "bar",
+					Target:           "/some-dir/foo",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2508,20 +2508,20 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackDirectory(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "some-dir/",
-					Target: "/",
+					UnresolvedSource: "some-dir/",
+					Target:           "/",
 				}, {
-					Source: "some-dir/",
-					Target: "/other-dir/",
+					UnresolvedSource: "some-dir/",
+					Target:           "/other-dir/",
 				}, {
-					Source: "some-dir/nested",
-					Target: "/other-dir/nested/",
+					UnresolvedSource: "some-dir/nested",
+					Target:           "/other-dir/nested/",
 				}, {
-					Source: "bar",
-					Target: "/this/is/some/deep/nesting/",
+					UnresolvedSource: "bar",
+					Target:           "/this/is/some/deep/nesting/",
 				}, {
-					Source: "empty-dir/",
-					Target: "/lone-dir/",
+					UnresolvedSource: "empty-dir/",
+					Target:           "/lone-dir/",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2656,49 +2656,49 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
 				{
-					Source: "foo",
-					Target: "/foo-dir/",
+					UnresolvedSource: "foo",
+					Target:           "/foo-dir/",
 				}, {
 					// would overwrite /foo
-					Source: "foo",
-					Target: "/",
+					UnresolvedSource: "foo",
+					Target:           "/",
 				}, {
 					// nothing written, content is unchanged
-					Source: "foo",
-					Target: "/foo-same",
+					UnresolvedSource: "foo",
+					Target:           "/foo-same",
 				}, {
 					// preserved, but not present, will be
 					// written
-					Source: "bar",
-					Target: "/bar-name",
+					UnresolvedSource: "bar",
+					Target:           "/bar-name",
 				}, {
 					// some-dir/data is preserved, but not
 					// present, hence will be written
-					Source: "boot-assets/",
-					Target: "/",
+					UnresolvedSource: "boot-assets/",
+					Target:           "/",
 				}, {
 					// would overwrite /data-copy
-					Source: "boot-assets/some-dir/data",
-					Target: "/data-copy-preserved",
+					UnresolvedSource: "boot-assets/some-dir/data",
+					Target:           "/data-copy-preserved",
 				}, {
-					Source: "boot-assets/some-dir/data",
-					Target: "/data-copy",
+					UnresolvedSource: "boot-assets/some-dir/data",
+					Target:           "/data-copy",
 				}, {
 					// would overwrite /nested-copy/nested
-					Source: "boot-assets/nested-dir/",
-					Target: "/nested-copy/",
+					UnresolvedSource: "boot-assets/nested-dir/",
+					Target:           "/nested-copy/",
 				}, {
-					Source: "boot-assets",
-					Target: "/boot-assets-copy/",
+					UnresolvedSource: "boot-assets",
+					Target:           "/boot-assets-copy/",
 				}, {
-					Source: "/boot-assets/empty-dir/",
-					Target: "/lone-dir/nested/",
+					UnresolvedSource: "/boot-assets/empty-dir/",
+					Target:           "/lone-dir/nested/",
 				}, {
-					Source: "preserved/same-content",
-					Target: "preserved/same-content-for-list",
+					UnresolvedSource: "preserved/same-content",
+					Target:           "preserved/same-content-for-list",
 				}, {
-					Source: "preserved/same-content",
-					Target: "preserved/same-content-for-observer",
+					UnresolvedSource: "preserved/same-content",
+					Target:           "preserved/same-content-for-observer",
 				},
 			},
 			Update: gadget.VolumeUpdate{
@@ -2945,8 +2945,8 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterTrivialValidation(c *C) {
 		content gadget.VolumeContent
 		match   string
 	}{
-		{content: gadget.VolumeContent{Source: "", Target: "/"}, match: "internal error: source cannot be unset"},
-		{content: gadget.VolumeContent{Source: "/", Target: ""}, match: "internal error: target cannot be unset"},
+		{content: gadget.VolumeContent{UnresolvedSource: "", Target: "/"}, match: "internal error: source cannot be unset"},
+		{content: gadget.VolumeContent{UnresolvedSource: "/", Target: ""}, match: "internal error: target cannot be unset"},
 	} {
 		testPs := &gadget.LaidOutStructure{
 			VolumeStructure: &gadget.VolumeStructure{
@@ -2977,7 +2977,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterMountLookupFail(c *C) {
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 			Update: gadget.VolumeUpdate{
 				Edition: 1,
@@ -3012,7 +3012,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterNonFilePreserveError(c *C
 			Size:       2048,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "/", Target: "/"},
+				{UnresolvedSource: "/", Target: "/"},
 			},
 			Update: gadget.VolumeUpdate{
 				Preserve: []string{"foo"},
@@ -3061,9 +3061,9 @@ managed grub.cfg from disk`
 			Role:       gadget.SystemBoot,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "grubx64.efi", Target: "EFI/boot/grubx64.efi"},
-				{Source: "grub.conf", Target: "EFI/ubuntu/grub.cfg"},
-				{Source: "foo", Target: "foo"},
+				{UnresolvedSource: "grubx64.efi", Target: "EFI/boot/grubx64.efi"},
+				{UnresolvedSource: "grub.conf", Target: "EFI/ubuntu/grub.cfg"},
+				{UnresolvedSource: "foo", Target: "foo"},
 			},
 			Update: gadget.VolumeUpdate{
 				Preserve: []string{"foo"},
@@ -3139,7 +3139,7 @@ var (
 			Role:       gadget.SystemBoot,
 			Filesystem: "ext4",
 			Content: []gadget.VolumeContent{
-				{Source: "foo", Target: "foo"},
+				{UnresolvedSource: "foo", Target: "foo"},
 			},
 			Update: gadget.VolumeUpdate{
 				Edition: 1,

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -633,7 +633,7 @@ func updateDataSet(c *C) (oldData gadget.GadgetData, newData gadget.GadgetData, 
 		Size:       10 * quantity.SizeMiB,
 		Filesystem: "ext4",
 		Content: []gadget.VolumeContent{
-			{Source: "/second-content", Target: "/"},
+			{UnresolvedSource: "/second-content", Target: "/"},
 		},
 	}
 	lastStruct := gadget.VolumeStructure{
@@ -641,7 +641,7 @@ func updateDataSet(c *C) (oldData gadget.GadgetData, newData gadget.GadgetData, 
 		Size:       5 * quantity.SizeMiB,
 		Filesystem: "vfat",
 		Content: []gadget.VolumeContent{
-			{Source: "/third-content", Target: "/"},
+			{UnresolvedSource: "/third-content", Target: "/"},
 		},
 	}
 	// start with identical data for new and old infos, they get updated by
@@ -740,7 +740,7 @@ func (u *updateTestSuite) TestUpdateApplyHappy(c *C) {
 			c.Check(ps.StartOffset, Equals, (1+5)*quantity.SizeMiB)
 			c.Assert(ps.LaidOutContent, HasLen, 0)
 			c.Assert(ps.Content, HasLen, 1)
-			c.Check(ps.Content[0].Source, Equals, "/second-content")
+			c.Check(ps.Content[0].UnresolvedSource, Equals, "/second-content")
 			c.Check(ps.Content[0].Target, Equals, "/")
 		default:
 			c.Fatalf("unexpected call")
@@ -935,7 +935,7 @@ func (u *updateTestSuite) TestUpdateApplyErrorIllegalStructureUpdate(c *C) {
 		Filesystem: "ext4",
 		Size:       5 * quantity.SizeMiB,
 		Content: []gadget.VolumeContent{
-			{Source: "/", Target: "/"},
+			{UnresolvedSource: "/", Target: "/"},
 		},
 		Update: gadget.VolumeUpdate{Edition: 5},
 	}

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -216,7 +216,7 @@ func validateVolumeContentsPresence(gadgetSnapRootDir string, vol *LaidOutVolume
 			continue
 		}
 		for _, c := range s.Content {
-			// TODO: detect and skip Content with "$kernel:" style refs
+			// TODO: detect and skip Content with "$kernel:" style refs if there is no kernelSnapRootDir passed in as well
 			realSource := filepath.Join(gadgetSnapRootDir, c.UnresolvedSource)
 			if !osutil.FileExists(realSource) {
 				return fmt.Errorf("structure %v, content %v: source path does not exist", s, c)

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -216,11 +216,11 @@ func validateVolumeContentsPresence(gadgetSnapRootDir string, vol *LaidOutVolume
 			continue
 		}
 		for _, c := range s.Content {
-			realSource := filepath.Join(gadgetSnapRootDir, c.Source)
+			realSource := filepath.Join(gadgetSnapRootDir, c.UnresolvedSource)
 			if !osutil.FileExists(realSource) {
 				return fmt.Errorf("structure %v, content %v: source path does not exist", s, c)
 			}
-			if strings.HasSuffix(c.Source, "/") {
+			if strings.HasSuffix(c.UnresolvedSource, "/") {
 				// expecting a directory
 				if err := checkSourceIsDir(realSource + "/"); err != nil {
 					return fmt.Errorf("structure %v, content %v: %v", s, c, err)

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -216,11 +216,12 @@ func validateVolumeContentsPresence(gadgetSnapRootDir string, vol *LaidOutVolume
 			continue
 		}
 		for _, c := range s.Content {
+			// TODO: detect and skip Content with "$kernel:" style refs
 			realSource := filepath.Join(gadgetSnapRootDir, c.UnresolvedSource)
 			if !osutil.FileExists(realSource) {
 				return fmt.Errorf("structure %v, content %v: source path does not exist", s, c)
 			}
-			if strings.HasSuffix(c.UnresolvedSource, "/") {
+			if strings.HasSuffix(c.ResolvedSource(), "/") {
 				// expecting a directory
 				if err := checkSourceIsDir(realSource + "/"); err != nil {
 					return fmt.Errorf("structure %v, content %v: %v", s, c, err)

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1356,7 +1356,7 @@ volumes:
 							Size:       10 * quantity.SizeMiB,
 							Filesystem: "ext4",
 							Content: []gadget.VolumeContent{
-								{Source: "foo-content", Target: "/"},
+								{UnresolvedSource: "foo-content", Target: "/"},
 							},
 						}, {
 							Name: "bare-one",
@@ -1383,7 +1383,7 @@ volumes:
 							Size:       10 * quantity.SizeMiB,
 							Filesystem: "ext4",
 							Content: []gadget.VolumeContent{
-								{Source: "new-foo-content", Target: "/"},
+								{UnresolvedSource: "new-foo-content", Target: "/"},
 							},
 						}, {
 							Name: "bare-one",


### PR DESCRIPTION
Samuele asked for this in https://github.com/snapcore/snapd/pull/9149/files#r537628269 

The first commit renames gadget.VolumeContent.Source to "UnresolvedSource" and updates all the tests.

The second commit adds a "ResolvedSource()" accessor and updates the places that need resolved sources.
Note that this will all change further when the actual resolving is implemented. Right now a common pattern
is something like: 
```
	srcPath := filepath.Join(f.contentDir, source)
```
but after the solve is done this is no longer needed, ResolvedSource() will have contentDir already set.