### PR TITLE
interfaces/builtin/docker-support: allow /run/containerd/s/...

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -74,10 +74,11 @@ const dockerSupportConnectedPlugAppArmor = `
 /{,var/}run/runc/**     mrwklix,
 
 # Allow sockets/etc for containerd
-/{,var/}run/containerd/{,runc/,runc/k8s.io/,runc/k8s.io/*/} rw,
+/{,var/}run/containerd/{,s/,runc/,runc/k8s.io/,runc/k8s.io/*/} rw,
 /{,var/}run/containerd/runc/k8s.io/*/** rwk,
 /{,var/}run/containerd/{io.containerd*/,io.containerd*/k8s.io/,io.containerd*/k8s.io/*/} rw,
 /{,var/}run/containerd/io.containerd*/*/** rwk,
+/{,var/}run/containerd/s/** rwk,
 
 # Limit ipam-state to k8s
 /run/ipam-state/k8s-** rw,


### PR DESCRIPTION
This is a new path that docker 19.03.14 (with a new version of containerd) uses
to avoid containerd CVE issues around the unix socket.

See also CVE-2020-15257.
