### PR TITLE
sandbox/seccomp: use snap-seccomp's stdout for getting version info

### DIFF
--- a/sandbox/seccomp/compiler.go
+++ b/sandbox/seccomp/compiler.go
@@ -72,8 +72,11 @@ func NewCompiler(lookupTool func(name string) (string, error)) (*Compiler, error
 // libseccomp library.
 func (c *Compiler) VersionInfo() (VersionInfo, error) {
 	cmd := exec.Command(c.snapSeccomp, "version-info")
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && len(exitErr.Stderr) > 0 {
+			output = exitErr.Stderr
+		}
 		return "", osutil.OutputErr(output, err)
 	}
 	raw := bytes.TrimSpace(output)


### PR DESCRIPTION
Some distributions set up a preload of some optimized libraries that can trigger
ld.so to output errors to stderr. For example on Raspbian the output of
snap-seccomp version-info can look like this (with the error written to stderr);

```
ERROR: ld.so: object ‘#/usr/lib/arm-linux-gnueabihf/libarmmem-${PLATFORM}.so’ from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
0528cb62afe0b3d7be81b1ea0b9e60361ec8fd80 2.4.3 9b218ef9a4e508dd8a7f848095cb8875d10a4bf28428ad81fdc3f8dac89108f7 bpf-actlog
```

Improve the code to collect version-info from stderr only, but still show stderr
if snap-seccomp version-info exits with non-0 status.

Originally reported in the forum: https://forum.snapcraft.io/t/snapd-has-failed/21462/3

Fixes: https://bugs.launchpad.net/snapd/+bug/1907237
