### PR TITLE
sysconfig/cloudinit.go: add "manual_cache_clean: true" to cloud-init restrict file

### DIFF
--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -155,8 +155,11 @@ datasource:
 manual_cache_clean: true
 `)
 
+	// don't use manual_cache_clean for real cloud datasources, the setting is
+	// used with ubuntu core only for sources where we can only get the
+	// instance_id through the fs_label for NoCloud and None (since we disable
+	// importing using the fs_label after the initial run).
 	genericCloudRestrictYamlPattern = `datasource_list: [%s]
-manual_cache_clean: true
 `
 
 	localDatasources = []string{"NoCloud", "None"}

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -151,9 +151,13 @@ var (
 	nocloudRestrictYaml = []byte(`datasource_list: [NoCloud]
 datasource:
   NoCloud:
-    fs_label: null`)
+    fs_label: null
+manual_cache_clean: true
+`)
 
-	genericCloudRestrictYamlPattern = `datasource_list: [%s]`
+	genericCloudRestrictYamlPattern = `datasource_list: [%s]
+manual_cache_clean: true
+`
 
 	localDatasources = []string{"NoCloud", "None"}
 )

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -148,6 +148,18 @@ var (
 	cloudInitSnapdRestrictFile = "/etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
 	cloudInitDisabledFile      = "/etc/cloud/cloud-init.disabled"
 
+	// for NoCloud datasource, we need to specify "manual_cache_clean: true"
+	// because the default is false, and this key being true essentially informs
+	// cloud-init that it should always trust the instance-id it has cached in
+	// the image, and shouldn't assume that there is a new one on every boot, as
+	// otherwise we have bugs like https://bugs.launchpad.net/snapd/+bug/1905983
+	// where subsequent boots after cloud-init runs and gets restricted it will
+	// try to detect the instance_id by reading from the NoCloud datasource
+	// fs_label, but we set that to "null" so it fails to read anything and thus
+	// can't detect the effective instance_id and assumes it is different and
+	// applies default config which can overwrite valid config from the initial
+	// boot if that is not the default config
+	// see also https://cloudinit.readthedocs.io/en/latest/topics/boot.html?highlight=manual_cache_clean#first-boot-determination
 	nocloudRestrictYaml = []byte(`datasource_list: [NoCloud]
 datasource:
   NoCloud:

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -443,7 +443,6 @@ func (s *sysconfigSuite) TestRestrictCloudInit(c *C) {
 			expDatasource:       "GCE",
 			expAction:           "restrict",
 			expRestrictYamlWritten: `datasource_list: [GCE]
-manual_cache_clean: true
 `,
 		},
 		{

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -370,7 +370,9 @@ var lxdNoCloudCloudInitStatusJSON = `{
 var restrictNoCloudYaml = `datasource_list: [NoCloud]
 datasource:
   NoCloud:
-    fs_label: null`
+    fs_label: null
+manual_cache_clean: true
+`
 
 func (s *sysconfigSuite) TestRestrictCloudInit(c *C) {
 	tt := []struct {
@@ -435,12 +437,14 @@ func (s *sysconfigSuite) TestRestrictCloudInit(c *C) {
 			expDisableFile: true,
 		},
 		{
-			comment:                "gce done",
-			state:                  sysconfig.CloudInitDone,
-			cloudInitStatusJSON:    gceCloudInitStatusJSON,
-			expDatasource:          "GCE",
-			expAction:              "restrict",
-			expRestrictYamlWritten: "datasource_list: [GCE]",
+			comment:             "gce done",
+			state:               sysconfig.CloudInitDone,
+			cloudInitStatusJSON: gceCloudInitStatusJSON,
+			expDatasource:       "GCE",
+			expAction:           "restrict",
+			expRestrictYamlWritten: `datasource_list: [GCE]
+manual_cache_clean: true
+`,
 		},
 		{
 			comment:                "nocloud done",

--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -81,6 +81,6 @@ execute: |
         # checking that it was restricted?
         echo "Test that cloud-init restrict file was written"
         test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg
-        echo "Test that cloud-init restrict file has manual_cache_clean set"
-        MATCH "manual_cache_clean: true" < /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg
+        echo "Test that cloud-init restrict file does NOT have manual_cache_clean set"
+        NOMATCH "manual_cache_clean: true" < /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg
     fi

--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -81,4 +81,6 @@ execute: |
         # checking that it was restricted?
         echo "Test that cloud-init restrict file was written"
         test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg
+        echo "Test that cloud-init restrict file has manual_cache_clean set"
+        MATCH "manual_cache_clean: true" < /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg
     fi

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -112,6 +112,7 @@ execute: |
     nested_exec "cloud-init status" | MATCH "status: done"
     nested_exec "test ! -f /etc/cloud/cloud-init.disabled"
     nested_exec "test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+    nested_exec "cat /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg" | MATCH "manual_cache_clean: true"
 
     # save snapd logs before continuing as the logs are not persistent
     nested_exec "sudo journalctl -e --no-pager -u snapd" > snapd-before-reboot.logs


### PR DESCRIPTION
Without this key in the cloud-init restrict file, cloud-init on subsequent boots
will not know what instance-id to trust, as in multipass and other NoCloud
deployments the instance-id will only be available via the NoCloud CIDATA
filesystem label, but the snapd restriction file will not allow reading or
importing that filesystem label and so cloud-init will not know whether it is in
a new first boot like in the cloud where a "golden image" is booted with a given
cloud-init and then saved and rebooted with a new instance-id.

When cloud-init is unable to detect the instance-id of the current boot, it
assumes that it is booting a "golden image" and will search for new
configuration input and thus a new instance-id, but in the case of multipass,
where all cloud-init configuration is provided via NoCloud CIDATA filesystem
label drives, subsequent boots will "undo" the initial networking configuration
because cloud-init does not trust it's cached data and as such will do the
default configuration which overwrites the previous boot's cloud-init specified
configuration.

This additional key instructs cloud-init to trust it's cache of the instance-id,
thus not overwriting previous configuration.

Fixes: https://bugs.launchpad.net/snapd/+bug/1905983

Ideally I would also propose a nested regression test here, but I was unable to get the cloud-init configuration drive provided in the reproducer in the bug to work with cloud-init, so when I have a working version of that then I will propose separately a nested regression test for this new behavior. We did get confirmation that adding this key to zzzz_snapd.cfg is sufficient for multipass's usage of cloud-init though so I think the fix is verified to work.