### PR TITLE
testutil: make DBusTest use a custom bus configuration file

### DIFF
--- a/testutil/dbustest.go
+++ b/testutil/dbustest.go
@@ -60,6 +60,11 @@ type DBusTest struct {
 	SessionBus *dbus.Conn
 }
 
+// sessionBusConfigTemplate is a minimal session dbus daemon
+// configuration template for use in the unit tests. In comparison to
+// the typical disto session config, it contains no <servicedir>
+// directives to avoid activating services installed on the test
+// system.
 const sessionBusConfigTemplate = `<busconfig>
   <type>session</type>
   <listen>unix:path=%s/user_bus_socket</listen>

--- a/testutil/dbustest_test.go
+++ b/testutil/dbustest_test.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/testutil"
+)
+
+type dbusSuite struct {
+	testutil.DBusTest
+}
+
+var _ = Suite(&dbusSuite{})
+
+func (s *dbusSuite) TestSessionBus(c *C) {
+	var names []string
+	err := s.SessionBus.BusObject().Call("org.freedesktop.DBus.ListNames", 0).Store(&names)
+	c.Assert(err, IsNil)
+	// Only two connections to the bus: the bus itself, and the test process
+	c.Check(names, HasLen, 2)
+}
+
+func (s *dbusSuite) TestNoActivatableNames(c *C) {
+	// The private session bus does not expose activatable
+	// services from the system the test suite is running on.
+	var names []string
+	err := s.SessionBus.BusObject().Call("org.freedesktop.DBus.ListActivatableNames", 0).Store(&names)
+	c.Assert(err, IsNil)
+	c.Check(names, DeepEquals, []string{
+		"org.freedesktop.DBus",
+	})
+}


### PR DESCRIPTION
The standard session bus configuration searches for service activation files found in /usr/share/dbus-1/services, and may load other custom local configuration.  This could cause the test suite to spawn arbitrary services installed on the system.

By using a custom daemon configuration file, without this servicedir configuration, we ensure that tests using the fixture only see names provided by the test suite.

This is important when testing against well known services: if we want to test what happens when there is no notification daemon installed, we don't want the test's behaviour to depend on whether there is a service activation file for that name installed.