### PR TITLE
gadget: use "sealed-keys" to determine what method to use for reseal

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -355,7 +355,10 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model, gadgetDir string)
 	}
 	// trusted assets need tracking only when the system is using encryption
 	// for its data partitions
-	trackTrustedAssets := hasSealedKeys(dirs.GlobalRootDir)
+	var trackTrustedAssets bool
+	if _, err := sealedKeysMethod(dirs.GlobalRootDir); err == nil {
+		trackTrustedAssets = true
+	}
 
 	// see what we need to observe for the run bootloader
 	runBl, runTrusted, runManaged, err := gadgetMaybeTrustedBootloaderAndAssets(gadgetDir, InitramfsUbuntuBootDir,

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -356,8 +356,14 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model, gadgetDir string)
 	// trusted assets need tracking only when the system is using encryption
 	// for its data partitions
 	trackTrustedAssets := false
-	if _, err := sealedKeysMethod(dirs.GlobalRootDir); err == nil {
+	_, err := sealedKeysMethod(dirs.GlobalRootDir)
+	switch {
+	case err == nil:
 		trackTrustedAssets = true
+	case err == errSealingNoKeys:
+		// nothing
+	case err != nil && err != errSealingNoKeys:
+		return nil, err
 	}
 
 	// see what we need to observe for the run bootloader

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -355,7 +355,7 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model, gadgetDir string)
 	}
 	// trusted assets need tracking only when the system is using encryption
 	// for its data partitions
-	var trackTrustedAssets bool
+	trackTrustedAssets := false
 	if _, err := sealedKeysMethod(dirs.GlobalRootDir); err == nil {
 		trackTrustedAssets = true
 	}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -181,3 +181,11 @@ func MockRunFDESetupHook(f func(string, *FDESetupHookParams) ([]byte, error)) (r
 	RunFDESetupHook = f
 	return func() { RunFDESetupHook = oldRunFDESetupHook }
 }
+
+func MockResealKeyToModeenvUsingFDESetupHook(f func(string, *asserts.Model, *Modeenv, bool) error) (restore func()) {
+	old := resealKeyToModeenvUsingFDESetupHook
+	resealKeyToModeenvUsingFDESetupHook = f
+	return func() {
+		resealKeyToModeenvUsingFDESetupHook = old
+	}
+}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -336,13 +336,18 @@ var resealKeyToModeenvUsingFDESetupHook = resealKeyToModeenvUsingFDESetupHookImp
 
 func resealKeyToModeenvUsingFDESetupHookImpl(rootdir string, model *asserts.Model, modeenv *Modeenv, expectReseal bool) error {
 	// TODO: Implement reseal using the fde-setup hook. This will
-	//       require a helper like "shouldResealUsinHook()" that
-	//       will be set by devicestate and returns (bool, error).
-	//       It needs to return "false" during seeding because then
-	//       there is no kernel available yet. It will also need to
-	//       run HasFDESetupHook internally and return an error if
-	//       the hook goes missing (e.g. because a kernel refresh losses
-	//       the hook by accident).
+	//       require a helper like "FDEShouldResealUsingSetupHook"
+	//       that will be set by devicestate and returns (bool,
+	//       error).  It needs to return "false" during seeding
+	//       because then there is no kernel available yet.  It
+	//       can though return true as soon as there's an active
+	//       kernel if seeded is false
+	//
+	//       It will also need to run HasFDESetupHook internally
+	//       and return an error if the hook goes missing
+	//       (e.g. because a kernel refresh losses the hook by
+	//       accident). It could also run features directly and
+	//       check for "reseal" in features.
 	return nil
 }
 

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -326,7 +326,9 @@ func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, 
 	}
 }
 
-func resealKeyToModeenvUsingFDESetupHook(rootdir string, model *asserts.Model, modeenv *Modeenv, expectReseal bool) error {
+var resealKeyToModeenvUsingFDESetupHook = resealKeyToModeenvUsingFDESetupHookImpl
+
+func resealKeyToModeenvUsingFDESetupHookImpl(rootdir string, model *asserts.Model, modeenv *Modeenv, expectReseal bool) error {
 	// TODO: Implement reseal using the fde-setup hook. This will
 	//       require a helper like "shouldResealUsinHook()" that
 	//       will be set by devicestate and returns (bool, error).


### PR DESCRIPTION
This commit adds code so that resealKeyToModeenv() will read the
sealed-keys file and use either "tpm" or "fde-setup-hook" for
resealing. This also unbreaks master because this no longer
runs HasFDESetupHook during seeding.
