### PR TITLE
tests/main/fake-netplan-apply: disable test on xenial for now

### DIFF
--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -14,7 +14,13 @@ environment:
 #            defined for gid 103 (which on core is messagebus, but on classic is
 #            systemd-network), and thus the dbus daemon thinks it has the wrong
 #            permissions (well basically speaking it does)
-systems: [ubuntu-core-1*]
+
+# TODO: re-enable this on ubuntu-core-16-* when network-setup-control is updated
+# to allow running netplan directly from the base snap and we can update this
+# test to just using a simple shell script snap instead of building netplan from
+# source, as currently that is broken on xenial with test-snapd-netplan-apply
+# for some reason, see https://github.com/anonymouse64/test-snapd-netplan-apply/issues/1
+systems: [ubuntu-core-18-*]
 
 prepare: |
     snap install test-snapd-netplan-apply --edge

--- a/tests/main/fake-netplan-apply/task.yaml
+++ b/tests/main/fake-netplan-apply/task.yaml
@@ -18,6 +18,12 @@ systems:
     - -arch-*
     - -amazon-*
     - -centos-*
+    # TODO: re-enable this when network-setup-control is updated to allow
+    # running netplan directly from the base snap and we can update this test to
+    # just using a simple shell script snap instead of building netplan from
+    # source, as currently that is broken on xenial with
+    # test-snapd-netplan-apply for some reason, see https://github.com/anonymouse64/test-snapd-netplan-apply/issues/1
+    - -ubuntu-16*
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh


### PR DESCRIPTION
See the related issue for more context, but eventually we want to stop using
test-snapd-netplan-apply and use a much simpler snap that uses netplan from the
base snap instead but that requires changes to network-setup-control which may
take time to land into master.

This is meant temporarily until https://github.com/snapcore/snapd/pull/9784 gets full reviews and can re-enable the test