### PR TITLE
tests: backport netplan workarounds from #9785 (2.48)

### DIFF
--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -14,7 +14,13 @@ environment:
 #            defined for gid 103 (which on core is messagebus, but on classic is
 #            systemd-network), and thus the dbus daemon thinks it has the wrong
 #            permissions (well basically speaking it does)
-systems: [ubuntu-core-1*]
+
+# TODO: re-enable this on ubuntu-core-16-* when network-setup-control is updated
+# to allow running netplan directly from the base snap and we can update this
+# test to just using a simple shell script snap instead of building netplan from
+# source, as currently that is broken on xenial with test-snapd-netplan-apply
+# for some reason, see https://github.com/anonymouse64/test-snapd-netplan-apply/issues/1
+systems: [ubuntu-core-18-*]
 
 prepare: |
     snap install test-snapd-netplan-apply --edge

--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -6,9 +6,14 @@ details: |
 environment:
     NETPLAN: io.netplan.Netplan
 
-# the test is only meaningful on core devices
 # TODO:UC20: enable, fails right now with: "The permission of the
-#            setuid helper is not correct"
+#            setuid helper is not correct", the issue is with the permissions of
+#            /usr/lib/dbus-1.0/dbus-daemon-launch-helper - it shows up as not
+#            being in the right group because the /etc/group from the classic
+#            host that we use to prepare the core system has a different group
+#            defined for gid 103 (which on core is messagebus, but on classic is
+#            systemd-network), and thus the dbus daemon thinks it has the wrong
+#            permissions (well basically speaking it does)
 systems: [ubuntu-core-1*]
 
 prepare: |

--- a/tests/main/fake-netplan-apply/task.yaml
+++ b/tests/main/fake-netplan-apply/task.yaml
@@ -18,6 +18,12 @@ systems:
     - -arch-*
     - -amazon-*
     - -centos-*
+    # TODO: re-enable this when network-setup-control is updated to allow
+    # running netplan directly from the base snap and we can update this test to
+    # just using a simple shell script snap instead of building netplan from
+    # source, as currently that is broken on xenial with
+    # test-snapd-netplan-apply for some reason, see https://github.com/anonymouse64/test-snapd-netplan-apply/issues/1
+    - -ubuntu-16*
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/9785 for 2.48. Had to do an extra cherry pick so that it applies cleanly.