### PR TITLE
boot: tweak resealing with fde-setup hooks

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -360,9 +360,10 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model, gadgetDir string)
 	switch {
 	case err == nil:
 		trackTrustedAssets = true
-	case err == errSealingNoKeys:
-		// nothing
-	case err != nil && err != errSealingNoKeys:
+	case err == errNoSealedKeys:
+		// nothing to do
+	case err != nil:
+		// all other errors
 		return nil, err
 	}
 

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -297,7 +297,7 @@ func stampSealedKeys(rootdir string, content sealingMethod) error {
 	return nil
 }
 
-var errSealingNoKeys = errors.New("no-sealed-keys")
+var errNoSealedKeys = errors.New("no sealed keys")
 
 // sealedKeysMethod return whether any keys were sealed at all
 func sealedKeysMethod(rootdir string) (sm sealingMethod, err error) {
@@ -306,7 +306,7 @@ func sealedKeysMethod(rootdir string) (sm sealingMethod, err error) {
 	stamp := filepath.Join(dirs.SnapFDEDirUnder(rootdir), "sealed-keys")
 	content, err := ioutil.ReadFile(stamp)
 	if os.IsNotExist(err) {
-		return sm, errSealingNoKeys
+		return sm, errNoSealedKeys
 	}
 	return sealingMethod(content), err
 }
@@ -315,7 +315,7 @@ func sealedKeysMethod(rootdir string) (sm sealingMethod, err error) {
 // parameters specified in modeenv.
 func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, expectReseal bool) error {
 	method, err := sealedKeysMethod(rootdir)
-	if err == errSealingNoKeys {
+	if err == errNoSealedKeys {
 		// nothing to do
 		return nil
 	}

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -997,7 +997,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookCalled(c *C) {
 	//       because of e.g. seeding. Longer term there will be
 	//       more, see TODO in resealKeyToModeenvUsingFDESetupHookImpl
 	restore = boot.MockHasFDESetupHook(func() (bool, error) {
-		return false, fmt.Errorf("hook may not available yet because e.g. seeding")
+		return false, fmt.Errorf("hook not available yet because e.g. seeding")
 	})
 	defer restore()
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -981,7 +981,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 	c.Check(marker, testutil.FileAbsent)
 }
 
-func (s *sealSuite) TestResealKeyToModeenvWithFdeHookSad(c *C) {
+func (s *sealSuite) TestResealKeyToModeenvWithFdeHookCalled(c *C) {
 	rootdir := c.MkDir()
 	dirs.SetRootDir(rootdir)
 	defer dirs.SetRootDir("")
@@ -1007,5 +1007,34 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookSad(c *C) {
 	expectReseal := false
 	err = boot.ResealKeyToModeenv(rootdir, model, modeenv, expectReseal)
 	c.Assert(err, IsNil)
+	c.Check(resealKeyToModeenvUsingFDESetupHookCalled, Equals, 1)
+}
+
+func (s *sealSuite) TestResealKeyToModeenvWithFdeHookVerySad(c *C) {
+	rootdir := c.MkDir()
+	dirs.SetRootDir(rootdir)
+	defer dirs.SetRootDir("")
+
+	resealKeyToModeenvUsingFDESetupHookCalled := 0
+	restore := boot.MockResealKeyToModeenvUsingFDESetupHook(func(string, *asserts.Model, *boot.Modeenv, bool) error {
+		resealKeyToModeenvUsingFDESetupHookCalled++
+		return fmt.Errorf("fde setup hook failed")
+	})
+	defer restore()
+
+	marker := filepath.Join(dirs.SnapFDEDirUnder(rootdir), "sealed-keys")
+	err := os.MkdirAll(filepath.Dir(marker), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(marker, []byte("fde-setup-hook"), 0644)
+	c.Assert(err, IsNil)
+
+	modeenv := &boot.Modeenv{
+		RecoverySystem: "20200825",
+	}
+
+	model := boottest.MakeMockUC20Model()
+	expectReseal := false
+	err = boot.ResealKeyToModeenv(rootdir, model, modeenv, expectReseal)
+	c.Assert(err, ErrorMatches, "fde setup hook failed")
 	c.Check(resealKeyToModeenvUsingFDESetupHookCalled, Equals, 1)
 }

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -993,6 +993,14 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookCalled(c *C) {
 	})
 	defer restore()
 
+	// TODO: this simulates that the hook is not available yet
+	//       because of e.g. seeding. Longer term there will be
+	//       more, see TODO in resealKeyToModeenvUsingFDESetupHookImpl
+	restore = boot.MockHasFDESetupHook(func() (bool, error) {
+		return false, fmt.Errorf("hook may not available yet because e.g. seeding")
+	})
+	defer restore()
+
 	marker := filepath.Join(dirs.SnapFDEDirUnder(rootdir), "sealed-keys")
 	err := os.MkdirAll(filepath.Dir(marker), 0755)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This is a small followup on #9783 to tweak/improve the error handling and tests.