### PR TITLE
devicestate: implement checkFDEFeatures()

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1450,23 +1450,17 @@ func (m *DeviceManager) checkFDEFeatures(st *state.State) error {
 	if err != nil {
 		return err
 	}
-
-	// first check for an error
-	var errRes struct {
-		Error string `json:"error"`
-	}
-	if err := json.Unmarshal(output, &errRes); err == nil && errRes.Error != "" {
-		return fmt.Errorf("cannot use hook, it returned error: %v", errRes.Error)
-	}
-	// then check  for features, any feature reply is considered good
-	var featuresRes struct {
+	var res struct {
 		Features []string `json:"features"`
+		Error    string   `json:"error"`
 	}
-	if err := json.Unmarshal(output, &featuresRes); err == nil {
-		return nil
+	if err := json.Unmarshal(output, &res); err != nil {
+		return fmt.Errorf("cannot parse hook output %q: %v", output, err)
 	}
-	// unexpected result are an error
-	return fmt.Errorf("cannot parse hook output: %q", string(output))
+	if res.Error != "" {
+		return fmt.Errorf("cannot use hook, it returned error: %v", res.Error)
+	}
+	return nil
 }
 
 func hasFDESetupHookInKernel(kernelInfo *snap.Info) bool {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1457,8 +1457,11 @@ func (m *DeviceManager) checkFDEFeatures(st *state.State) error {
 	if err := json.Unmarshal(output, &res); err != nil {
 		return fmt.Errorf("cannot parse hook output %q: %v", output, err)
 	}
+	if res.Features == nil && res.Error == "" {
+		return fmt.Errorf(`cannot use hook: neither "features" nor "error" returned`)
+	}
 	if res.Error != "" {
-		return fmt.Errorf("cannot use hook, it returned error: %v", res.Error)
+		return fmt.Errorf("cannot use hook: it returned error: %v", res.Error)
 	}
 	return nil
 }

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -987,9 +987,9 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedFDEHook(c *C) {
 		expectedErr string
 	}{
 		// invalid json
-		{"xxx", `cannot parse hook output: "xxx"`},
+		{"xxx", `cannot parse hook output "xxx": invalid character 'x' looking for beginning of value`},
 		// no output is invalid
-		{"", `cannot parse hook output: ""`},
+		{"", `cannot parse hook output "": unexpected end of JSON input`},
 		// specific error
 		{`{"error":"failed"}`, `cannot use hook, it returned error: failed`},
 		// valid
@@ -997,7 +997,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedFDEHook(c *C) {
 		{`{"features":["a"]}`, ""},
 		{`{"features":["a","b"]}`, ""},
 		// features must be list of strings
-		{`{"features":[1]}`, "cannot parse hook output:.*"},
+		{`{"features":[1]}`, `cannot parse hook output ".*": json: cannot unmarshal number into Go struct.*`},
 	} {
 		hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
 			ctx.Lock()

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -991,13 +991,16 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedFDEHook(c *C) {
 		// no output is invalid
 		{"", `cannot parse hook output "": unexpected end of JSON input`},
 		// specific error
-		{`{"error":"failed"}`, `cannot use hook, it returned error: failed`},
+		{`{"error":"failed"}`, `cannot use hook: it returned error: failed`},
+		{`{}`, `cannot use hook: neither "features" nor "error" returned`},
 		// valid
 		{`{"features":[]}`, ""},
 		{`{"features":["a"]}`, ""},
 		{`{"features":["a","b"]}`, ""},
 		// features must be list of strings
 		{`{"features":[1]}`, `cannot parse hook output ".*": json: cannot unmarshal number into Go struct.*`},
+		{`{"features":1}`, `cannot parse hook output ".*": json: cannot unmarshal number into Go struct.*`},
+		{`{"features":"1"}`, `cannot parse hook output ".*": json: cannot unmarshal string into Go struct.*`},
 	} {
 		hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
 			ctx.Lock()

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
@@ -38,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -805,33 +807,52 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncrypted(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	mockModel := s.brands.Model("canonical", "pc", map[string]interface{}{
+	mockModel := s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
 	})
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc",
+	})
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: mockModel}
 
 	for _, tc := range []struct {
-		kernelYaml string
-		tpmErr     error
-		encrypt    bool
+		hasFDESetupHook bool
+		hasTPM          bool
+		encrypt         bool
 	}{
 		// unhappy: no tpm, no hook
-		{kernelYamlNoFdeSetup, fmt.Errorf("tpm says no"), false},
+		{false, false, false},
 		// happy: either tpm or hook or both
-		{kernelYamlWithFdeSetup, nil, true},
-		{kernelYamlNoFdeSetup, nil, true},
-		{kernelYamlWithFdeSetup, fmt.Errorf("tpm says no"), true},
+		{false, true, true},
+		{true, false, true},
+		{true, true, true},
 	} {
-		// TODO: right now having the hook in the kernel is enough
-		//       to trigger encryption, soon the code will try to
-		//       actually run the hook with "op":"features"
-		makeInstalledMockKernelSnap(c, st, tc.kernelYaml)
-		restore := devicestate.MockSecbootCheckKeySealingSupported(func() error { return tc.tpmErr })
+		hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
+			ctx.Lock()
+			defer ctx.Unlock()
+			ctx.Set("fde-setup-result", []byte(`{"features":[]}`))
+			return nil, nil
+		}
+		rhk := hookstate.MockRunHook(hookInvoke)
+		defer rhk()
+
+		if tc.hasFDESetupHook {
+			makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
+		} else {
+			makeInstalledMockKernelSnap(c, st, kernelYamlNoFdeSetup)
+		}
+		restore := devicestate.MockSecbootCheckKeySealingSupported(func() error {
+			if tc.hasTPM {
+				return nil
+			}
+			return fmt.Errorf("tpm says no")
+		})
 		defer restore()
 
-		encrypt, err := devicestate.CheckEncryption(st, deviceCtx)
+		encrypt, err := devicestate.DeviceManagerCheckEncryption(s.mgr, st, deviceCtx)
 		c.Assert(err, IsNil)
 		c.Check(encrypt, Equals, tc.encrypt, Commentf("%v", tc))
 	}
@@ -884,7 +905,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedStorageSafety(c *C)
 		})
 		deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: mockModel}
 
-		encrypt, err := devicestate.CheckEncryption(s.state, deviceCtx)
+		encrypt, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx)
 		c.Assert(err, IsNil)
 		c.Check(encrypt, Equals, tc.expectedEncryption)
 	}
@@ -940,7 +961,58 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrors(c *C) {
 				}},
 		})
 		deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: mockModel}
-		_, err := devicestate.CheckEncryption(s.state, deviceCtx)
+		_, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx)
 		c.Check(err, ErrorMatches, tc.expectedErr, Commentf("%s %s", tc.grade, tc.storageSafety))
+	}
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedFDEHook(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+	})
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc",
+	})
+	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
+
+	for _, tc := range []struct {
+		hookOutput  string
+		expectedErr string
+	}{
+		// invalid json
+		{"xxx", `cannot parse hook output: "xxx"`},
+		// no output is invalid
+		{"", `cannot parse hook output: ""`},
+		// specific error
+		{`{"error":"failed"}`, `cannot use hook, it returned error: failed`},
+		// valid
+		{`{"features":[]}`, ""},
+		{`{"features":["a"]}`, ""},
+		{`{"features":["a","b"]}`, ""},
+		// features must be list of strings
+		{`{"features":[1]}`, "cannot parse hook output:.*"},
+	} {
+		hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
+			ctx.Lock()
+			defer ctx.Unlock()
+			ctx.Set("fde-setup-result", []byte(tc.hookOutput))
+			return nil, nil
+		}
+		rhk := hookstate.MockRunHook(hookInvoke)
+		defer rhk()
+
+		err := devicestate.DeviceManagerCheckFDEFeatures(s.mgr, st)
+		if tc.expectedErr != "" {
+			c.Check(err, ErrorMatches, tc.expectedErr, Commentf("%v", tc))
+		} else {
+			c.Check(err, IsNil, Commentf("%v", tc))
+		}
 	}
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -214,8 +214,6 @@ var (
 	PendingGadgetInfo   = pendingGadgetInfo
 
 	CriticalTaskEdges = criticalTaskEdges
-
-	CheckEncryption = checkEncryption
 )
 
 func MockGadgetUpdate(mock func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc, observer gadget.ContentUpdateObserver) error) (restore func()) {
@@ -296,4 +294,12 @@ func DeviceManagerHasFDESetupHook(mgr *DeviceManager) (bool, error) {
 
 func DeviceManagerRunFDESetupHook(mgr *DeviceManager, op string, params *boot.FDESetupHookParams) ([]byte, error) {
 	return mgr.runFDESetupHook(op, params)
+}
+
+func DeviceManagerCheckEncryption(mgr *DeviceManager, st *state.State, deviceCtx snapstate.DeviceContext) (bool, error) {
+	return mgr.checkEncryption(st, deviceCtx)
+}
+
+func DeviceManagerCheckFDEFeatures(mgr *DeviceManager, st *state.State) error {
+	return mgr.checkFDEFeatures(st)
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -126,7 +126,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	bopts := install.Options{
 		Mount: true,
 	}
-	useEncryption, err := checkEncryption(st, deviceCtx)
+	useEncryption, err := m.checkEncryption(st, deviceCtx)
 	if err != nil {
 		return err
 	}
@@ -303,7 +303,7 @@ var secbootCheckKeySealingSupported = secboot.CheckKeySealingSupported
 // checkEncryption verifies whether encryption should be used based on the
 // model grade and the availability of a TPM device or a fde-setup hook
 // in the kernel.
-func checkEncryption(st *state.State, deviceCtx snapstate.DeviceContext) (res bool, err error) {
+func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.DeviceContext) (res bool, err error) {
 	model := deviceCtx.Model()
 	secured := model.Grade() == asserts.ModelSecured
 	dangerous := model.Grade() == asserts.ModelDangerous
@@ -330,7 +330,7 @@ func checkEncryption(st *state.State, deviceCtx snapstate.DeviceContext) (res bo
 	)
 	if kernelInfo, err := snapstate.KernelInfo(st, deviceCtx); err == nil {
 		if hasFDESetupHook = hasFDESetupHookInKernel(kernelInfo); hasFDESetupHook {
-			checkEncryptionErr = checkFDEFeatures(st, kernelInfo)
+			checkEncryptionErr = m.checkFDEFeatures(st)
 		}
 	}
 	// Note that having a fde-setup hook will disable the build-in


### PR DESCRIPTION
Run the fde-setup hook with "op":"features" as part of the install
to ensure that we test that the hardware actually supports
encryption. Later this features operation may also alter the way
that the install happens.
