### PR TITLE
devicestate: log checkEncryption errors via logger.Noticef

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -1057,5 +1057,5 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrorsLogs(c *C) {
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: mockModel}
 	_, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx)
 	c.Check(err, IsNil)
-	c.Check(logbuf.String(), Matches, "(?s).*: ignoring error from check encryption: tpm says no\n")
+	c.Check(logbuf.String(), Matches, "(?s).*: not encrypting device storage as checking TPM gave: tpm says no\n")
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -350,6 +350,9 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 			return false, fmt.Errorf("cannot encrypt device storage as mandated by encrypted storage-safety model option: %v", checkEncryptionErr)
 		}
 
+		// log any errors even if they are not fatal
+		logger.Noticef("ignoring error from check encryption: %v", checkEncryptionErr)
+
 		// not required, go without
 		return false, nil
 	}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -350,8 +350,11 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 			return false, fmt.Errorf("cannot encrypt device storage as mandated by encrypted storage-safety model option: %v", checkEncryptionErr)
 		}
 
-		// log any errors even if they are not fatal
-		logger.Noticef("ignoring error from check encryption: %v", checkEncryptionErr)
+		if hasFDESetupHook {
+			logger.Noticef("not encrypting device storage as querying kernel fde-setup hook did not succeed: %v", checkEncryptionErr)
+		} else {
+			logger.Noticef("not encrypting device storage as checking TPM gave: %v", checkEncryptionErr)
+		}
 
 		// not required, go without
 		return false, nil


### PR DESCRIPTION
This is a followup for PR#9791 that logs errors from
checkEncryption to the logger during install.
