### PR TITLE
secboot: add workaround for snapcore/core-initrd issue #13

### DIFF
--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -391,7 +391,10 @@ func runFDERevealKeyCommand(stdin []byte) (output []byte, err error) {
 		case osutil.FileExists(filepath.Join(runDir, "fde-reveal-key.success")):
 			return ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.stdout"))
 		default:
-			time.Sleep(1 * time.Second)
+			// 50 ms means we check at a frequency 20 Hz, fast enough to not
+			// hold up boot, but not too fast that we are hogging the CPU from
+			// the thing we are waiting to finish running
+			time.Sleep(50 * time.Millisecond)
 		}
 	}
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -356,6 +356,7 @@ func runFDERevealKeyCommand(stdin []byte) (output []byte, err error) {
 		fmt.Sprintf("--property=StandardInput=file:%s/fde-reveal-key.stdin", runDir),
 		fmt.Sprintf("--property=StandardOutput=file:%s/fde-reveal-key.stdout", runDir),
 		fmt.Sprintf("--property=StandardError=file:%s/fde-reveal-key.stderr", runDir),
+		// this ensures we get useful output for e.g. segfaults
 		fmt.Sprintf(`--property=ExecStopPost=/bin/sh -c 'if [ "$EXIT_STATUS" = 0 ]; then touch %[1]s/fde-reveal-key.success; else echo "service result: $SERVICE_RESULT" >%[1]s/fde-reveal-key.failed; fi'`, runDir),
 	)
 	if fdeRevealKeyCommandExtra != nil {

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/canonical/go-tpm2"
 	sb "github.com/snapcore/secboot"
@@ -38,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/efi"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
@@ -206,12 +208,10 @@ func lockFDERevealSealedKeys() error {
 	if err != nil {
 		return fmt.Errorf(`cannot build request for fde-reveal-key "lock": %v`, err)
 	}
-	cmd := fdeRevealKeyCommand()
-	cmd.Stdin = bytes.NewReader(buf)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
+	if output, err := runFDERevealKeyCommand(buf); err != nil {
 		return fmt.Errorf(`cannot run fde-reveal-key "lock": %v`, osutil.OutputErr(output, err))
 	}
+
 	return nil
 }
 
@@ -318,21 +318,32 @@ var fdeRevealKeyRuntimeMax = "2m"
 // overridden in tests
 var fdeRevealKeyCommandExtra []string
 
-// fdeRevealKeyCommand returns a *exec.Cmd that is suitable to run
-// fde-reveal-key using systemd-run
-func fdeRevealKeyCommand() *exec.Cmd {
+// runFDERevealKeyCommand returns the output of fde-reveal-key run
+// with systemd.
+//
+// Note that systemd-run in the initrd can only talk to the private
+// systemd bus so this cannot use "--pipe" or "--wait", see
+// https://github.com/snapcore/core-initrd/issues/13
+func runFDERevealKeyCommand(stdin []byte) (output []byte, err error) {
+	runDir := filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")
+	if err := os.MkdirAll(runDir, 0700); err != nil {
+		return nil, fmt.Errorf("cannot create tmp dir for fde-reveal-key: %v", err)
+	}
+	err = ioutil.WriteFile(filepath.Join(runDir, "fde-reveal-key.stdin"), stdin, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create stdin for fde-reveal-key: %v", err)
+	}
+
 	// TODO: put this into a new "systemd/run" package
 	cmd := exec.Command(
 		"systemd-run",
-		"--pipe", "--same-dir", "--wait", "--collect",
+		"--collect",
 		"--service-type=exec",
 		"--quiet",
 		// ensure we get some result from the hook within a
 		// reasonable timeout and output from systemd if
 		// things go wrong
 		fmt.Sprintf("--property=RuntimeMaxSec=%s", fdeRevealKeyRuntimeMax),
-		// this ensures we get useful output for e.g. segfaults
-		`--property=ExecStopPost=/bin/sh -c 'if [ "$EXIT_STATUS" != 0 ]; then echo "service result: $SERVICE_RESULT" 1>&2; fi'`,
 		// Do not allow mounting, this ensures hooks in initrd
 		// can not mess around with ubuntu-data.
 		//
@@ -340,13 +351,48 @@ func fdeRevealKeyCommand() *exec.Cmd {
 		// making sure that people using the hook know that we do not
 		// want them to mess around outside of just providing unseal.
 		"--property=SystemCallFilter=~@mount",
+		// WORKAROUNDS
+		// workaround the lack of "--pipe"
+		fmt.Sprintf("--property=StandardInput=file:%s/fde-reveal-key.stdin", runDir),
+		fmt.Sprintf("--property=StandardOutput=file:%s/fde-reveal-key.stdout", runDir),
+		fmt.Sprintf("--property=StandardError=file:%s/fde-reveal-key.stderr", runDir),
+		fmt.Sprintf(`--property=ExecStopPost=/bin/sh -c 'if [ "$EXIT_STATUS" = 0 ]; then touch %[1]s/fde-reveal-key.success; else echo "service result: $SERVICE_RESULT" >%[1]s/fde-reveal-key.failed; fi'`, runDir),
 	)
 	if fdeRevealKeyCommandExtra != nil {
 		cmd.Args = append(cmd.Args, fdeRevealKeyCommandExtra...)
 	}
 	// fde-reveal-key is what we actually need to run
 	cmd.Args = append(cmd.Args, "fde-reveal-key")
-	return cmd
+
+	// ensure we cleanup our tmp files
+	defer func() {
+		if err := os.RemoveAll(runDir); err != nil {
+			logger.Noticef("cannot remove tmp dir: %v", err)
+		}
+	}()
+
+	// run the command
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return output, err
+	}
+
+	// this will terminate eventually because of
+	// fdeRevealKeyRuntimeMax above
+	for {
+		switch {
+		case osutil.FileExists(filepath.Join(runDir, "fde-reveal-key.failed")):
+			stderr, _ := ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.stderr"))
+			systemdErr, _ := ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.failed"))
+			buf := bytes.NewBuffer(stderr)
+			buf.Write(systemdErr)
+			return buf.Bytes(), fmt.Errorf("fde-reveal-key failed")
+		case osutil.FileExists(filepath.Join(runDir, "fde-reveal-key.success")):
+			return ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.stdout"))
+		default:
+			time.Sleep(1 * time.Second)
+		}
+	}
 }
 
 func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName string, opts *UnlockVolumeUsingSealedKeyOptions) (UnlockResult, error) {
@@ -364,9 +410,7 @@ func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourc
 	if err != nil {
 		return res, fmt.Errorf("cannot build request for fde-reveal-key: %v", err)
 	}
-	cmd := fdeRevealKeyCommand()
-	cmd.Stdin = bytes.NewReader(buf)
-	output, err := cmd.CombinedOutput()
+	output, err := runFDERevealKeyCommand(buf)
 	if err != nil {
 		return res, fmt.Errorf("cannot run fde-reveal-key: %v", osutil.OutputErr(output, err))
 	}

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -1188,7 +1188,7 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyTrun
 
 	// the hook script only verifies that the stdout file is empty since we
 	// need to write to the stderr file for performing the test, but we still
-	// check the stderr file for correct permisison
+	// check the stderr file for correct permissions
 	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", fmt.Sprintf(`
 # check that stdin has the right sealed key content 
 if [ "$(cat %[1]s)" != "{\"op\":\"reveal\",\"sealed-key\":\"AQIDBA==\",\"key-name\":\"name\"}" ]; then

--- a/tests/nested/manual/uc20-fde-hooks/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks/task.yaml
@@ -23,14 +23,6 @@ prepare: |
   mkdir -p ./extra-initrd/usr/bin/
   go build -o ./extra-initrd/usr/bin/fde-reveal-key "$TESTSLIB"/fde-setup-hook/fde-setup.go
 
-  # FIXME: hack systemd-run to just run "fde-reveal-key" to workaround
-  # https://github.com/snapcore/core-initrd/issues/13
-  cat > ./extra-initrd/usr/bin/systemd-run <<'EOF'
-  #!/bin/sh
-  exec fde-reveal-key
-  EOF
-  chmod +x ./extra-initrd/usr/bin/systemd-run
-  
   # create fde-setup hook inside the kernel
   mkdir -p ./extra-kernel-snap/meta/hooks
   go build -o ./extra-kernel-snap/meta/hooks/fde-setup "$TESTSLIB"/fde-setup-hook/fde-setup.go


### PR DESCRIPTION
We can't have  nice things apparently, see https://github.com/snapcore/core-initrd/issues/13, i.e. we cannot run:

systemd-run --wait or --pipe in the initrd because there is no dbus there.

So this PR implements a workaround that uses polling to get the result and tmp files. Not nice but workable.

Alternatively we could simply run "fde-reveal-key" with exec.Command() but that would mean no basic seccomp and no max-runtime support and no isolation in a cgroup.

This is based on https://github.com/snapcore/snapd/pull/9769 and probably not fun to review until the other one has landed