### PR TITLE
secboot: add extra paranoia when waiting for that fde-reveal-key

### DIFF
--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -22,6 +22,7 @@ package secboot
 
 import (
 	"io"
+	"time"
 
 	sb "github.com/snapcore/secboot"
 )
@@ -192,5 +193,21 @@ func MockFdeRevealKeyCommandExtra(args []string) (restore func()) {
 	fdeRevealKeyCommandExtra = args
 	return func() {
 		fdeRevealKeyCommandExtra = oldFdeRevealKeyCommandExtra
+	}
+}
+
+func MockFdeRevealKeyRuntimeMax(d time.Duration) (restore func()) {
+	oldFdeRevealKeyRuntimeMax := fdeRevealKeyRuntimeMax
+	fdeRevealKeyRuntimeMax = d
+	return func() {
+		fdeRevealKeyRuntimeMax = oldFdeRevealKeyRuntimeMax
+	}
+}
+
+func MockFdeRevealKeyPollWaitParanoiaFactor(n int) (restore func()) {
+	oldFdeRevealKeyPollWaitParanoiaFactor := fdeRevealKeyPollWaitParanoiaFactor
+	fdeRevealKeyPollWaitParanoiaFactor = n
+	return func() {
+		fdeRevealKeyPollWaitParanoiaFactor = oldFdeRevealKeyPollWaitParanoiaFactor
 	}
 }

--- a/secboot/secboot_tpm_test.go
+++ b/secboot/secboot_tpm_test.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/canonical/go-tpm2"
 	sb "github.com/snapcore/secboot"
@@ -1388,4 +1389,31 @@ cat - > %s
 
 	// ensure no tmp files are left behind
 	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
+}
+
+func (s *secbootSuite) TestLockSealedKeysHonorsRuntimeMax(c *C) {
+	// this test uses a real systemd-run --user so check here if that
+	// actually works
+	if output, err := exec.Command("systemd-run", "--user", "--wait", "--collect", "true").CombinedOutput(); err != nil {
+		c.Skip(fmt.Sprintf("systemd-run not working: %v", osutil.OutputErr(output, err)))
+	}
+
+	restore := secboot.MockFDEHasRevealKey(func() bool {
+		return true
+	})
+	defer restore()
+
+	restore = secboot.MockFdeRevealKeyCommandExtra([]string{"--user"})
+	defer restore()
+	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", "sleep 60")
+	defer mockSystemdRun.Restore()
+
+	restore = secboot.MockFdeRevealKeyPollWaitParanoiaFactor(100)
+	defer restore()
+
+	restore = secboot.MockFdeRevealKeyRuntimeMax(100 * time.Millisecond)
+	defer restore()
+
+	err := secboot.LockSealedKeys()
+	c.Assert(err, ErrorMatches, `cannot run fde-reveal-key "lock": service result: timeout`)
 }


### PR DESCRIPTION
This commit ensures that the loop that waits for fde-reveal-key
terminates even if systemd-run for some reason does not honor
the MaxRuntimeSec timeout.
