### PR TITLE
tests: use apiBaseSuite for snapshots tests, fix import endpoint path

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -301,6 +301,16 @@ func (s *apiBaseSuite) daemonWithOverlordMock(c *check.C) *daemon.Daemon {
 	}
 
 	o := overlord.Mock()
+	s.d = daemon.NewWithOverlord(o)
+	return s.d
+}
+
+func (s *apiBaseSuite) daemonWithOverlordMockAndStore(c *check.C) *daemon.Daemon {
+	if s.d != nil {
+		panic("called Daemon*() twice")
+	}
+
+	o := overlord.Mock()
 	d := daemon.NewWithOverlord(o)
 
 	st := d.Overlord().State()
@@ -335,7 +345,7 @@ func (m *fakeSnapManager) Ensure() error {
 var _ overlord.StateManager = (*fakeSnapManager)(nil)
 
 func (s *apiBaseSuite) daemonWithFakeSnapManager(c *check.C) *daemon.Daemon {
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	st := d.Overlord().State()
 	runner := d.Overlord().TaskRunner()
 	d.Overlord().AddManager(newFakeSnapManager(st, runner))

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -73,7 +73,7 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 		"revision": "2",
 	})
 
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -131,7 +131,7 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 
 func (s *modelSuite) TestGetModelNoModelAssertion(c *check.C) {
 
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -156,7 +156,7 @@ func (s *modelSuite) TestGetModelHasModelAssertion(c *check.C) {
 	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -199,7 +199,7 @@ func (s *modelSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -236,7 +236,7 @@ func (s *modelSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 
 func (s *modelSuite) TestGetModelNoSerialAssertion(c *check.C) {
 
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -266,7 +266,7 @@ func (s *modelSuite) TestGetModelHasSerialAssertion(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -334,7 +334,7 @@ func (s *modelSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -227,7 +227,7 @@ func (s *sideloadSuite) TestSideloadSnapJailModeAndDevmode(c *check.C) {
 		"\r\n" +
 		"true\r\n" +
 		"----hello--\r\n"
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMockAndStore(c)
 
 	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
 	c.Assert(err, check.IsNil)
@@ -249,7 +249,7 @@ func (s *sideloadSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
 		"\r\n" +
 		"true\r\n" +
 		"----hello--\r\n"
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMockAndStore(c)
 
 	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
 	c.Assert(err, check.IsNil)
@@ -264,7 +264,7 @@ func (s *sideloadSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
 }
 
 func (s *sideloadSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	// add the assertions first
 	st := d.Overlord().State()
 
@@ -343,7 +343,7 @@ func (s *sideloadSuite) TestSideloadSnapNoSignaturesDangerOff(c *check.C) {
 		"\r\n" +
 		"xyzzy\r\n" +
 		"----hello--\r\n"
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMockAndStore(c)
 
 	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
 	c.Assert(err, check.IsNil)
@@ -394,7 +394,7 @@ func (s *sideloadSuite) TestSideloadSnapChangeConflict(c *check.C) {
 		"\r\n" +
 		"true\r\n" +
 		"----hello--\r\n"
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMockAndStore(c)
 
 	defer daemon.MockUnsafeReadSnapInfo(func(path string) (*snap.Info, error) {
 		return &snap.Info{SuggestedName: "foo"}, nil
@@ -631,7 +631,7 @@ func (s *trySuite) TestTrySnapNotDir(c *check.C) {
 }
 
 func (s *trySuite) TestTryChangeConflict(c *check.C) {
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	st := d.Overlord().State()
 
 	// mock a try dir

--- a/daemon/api_snap_conf_test.go
+++ b/daemon/api_snap_conf_test.go
@@ -267,7 +267,7 @@ func (s *snapConfSuite) TestSetConfNumber(c *check.C) {
 }
 
 func (s *snapConfSuite) TestSetConfBadSnap(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMockAndStore(c)
 
 	text, err := json.Marshal(map[string]interface{}{"key": "value"})
 	c.Assert(err, check.IsNil)

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -420,7 +420,7 @@ func (s *snapsSuite) TestSnapsInfoFilterRemote(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapsVerifyMultiSnapInstruction(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMockAndStore(c)
 
 	buf := strings.NewReader(`{"action": "install","snaps":["ubuntu-core"]}`)
 	req, err := http.NewRequest("POST", "/v2/snaps", buf)
@@ -435,7 +435,7 @@ func (s *snapsSuite) TestPostSnapsVerifyMultiSnapInstruction(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapsUnsupportedMultiOp(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMockAndStore(c)
 
 	buf := strings.NewReader(`{"action": "switch","snaps":["foo"]}`)
 	req, err := http.NewRequest("POST", "/v2/snaps", buf)
@@ -450,7 +450,7 @@ func (s *snapsSuite) TestPostSnapsUnsupportedMultiOp(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapsNoWeirdses(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMockAndStore(c)
 
 	// one could add more actions here ... 🤷
 	for _, action := range []string{"install", "refresh", "remove"} {
@@ -493,7 +493,7 @@ func (s *snapsSuite) testPostSnapsOp(c *check.C, contentType string) {
 		return []string{"fake1", "fake2"}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 
 	buf := bytes.NewBufferString(`{"action": "refresh"}`)
 	req, err := http.NewRequest("POST", "/v2/snaps", buf)

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -46,9 +46,7 @@ type snapshotSuite struct {
 
 func (s *snapshotSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
-	d := s.daemonWithStore(c, s)
-	d.Overlord().Loop()
-	s.AddCleanup(func() { d.Overlord().Stop() })
+	s.daemonWithOverlordMock(c)
 }
 
 func (s *snapshotSuite) TestSnapshotMany(c *check.C) {

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -34,38 +34,21 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/daemon"
-	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/overlord"
-	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
-	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/store/storetest"
 )
 
 var _ = check.Suite(&snapshotSuite{})
 
 type snapshotSuite struct {
-	d *daemon.Daemon
-	o *overlord.Overlord
+	apiBaseSuite
 }
 
 func (s *snapshotSuite) SetUpTest(c *check.C) {
-	s.o = overlord.Mock()
-	s.d = daemon.NewWithOverlord(s.o)
-
-	st := s.o.State()
-	// adds an assertion db
-	assertstate.Manager(st, s.o.TaskRunner())
-	st.Lock()
-	defer st.Unlock()
-	snapstate.ReplaceStore(st, storetest.Store{})
-	dirs.SetRootDir(c.MkDir())
-}
-
-func (s *snapshotSuite) TearDownTest(c *check.C) {
-	s.o = nil
-	s.d = nil
+	s.apiBaseSuite.SetUpTest(c)
+	d := s.daemonWithStore(c, s)
+	d.Overlord().Loop()
+	s.AddCleanup(func() { d.Overlord().Stop() })
 }
 
 func (s *snapshotSuite) TestSnapshotMany(c *check.C) {
@@ -76,7 +59,7 @@ func (s *snapshotSuite) TestSnapshotMany(c *check.C) {
 	})()
 
 	inst := daemon.MustUnmarshalSnapInstruction(c, `{"action": "snapshot", "snaps": ["foo", "bar"]}`)
-	st := s.o.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	res, err := daemon.SnapshotMany(inst, st)
 	st.Unlock()
@@ -96,7 +79,7 @@ func (s *snapshotSuite) TestListSnapshots(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := daemon.ListSnapshots(daemon.SnapshotCmd, req, nil)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.DeepEquals, snapshots)
@@ -113,7 +96,7 @@ func (s *snapshotSuite) TestListSnapshotsFiltering(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots?set=42", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := daemon.ListSnapshots(daemon.SnapshotCmd, req, nil)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.DeepEquals, []client.SnapshotSet{{ID: 42}})
@@ -128,7 +111,7 @@ func (s *snapshotSuite) TestListSnapshotsBadFiltering(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots?set=no", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := daemon.ListSnapshots(daemon.SnapshotCmd, req, nil)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.ErrorResult().Message, check.Equals, `'set', if given, must be a positive base 10 number; got "no"`)
@@ -143,7 +126,7 @@ func (s *snapshotSuite) TestListSnapshotsListError(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := daemon.ListSnapshots(daemon.SnapshotCmd, req, nil)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 500)
 	c.Check(rsp.ErrorResult().Message, check.Equals, "no")
@@ -211,7 +194,7 @@ func (s *snapshotSuite) TestChangeSnapshots400(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snapshots", strings.NewReader(test.body))
 		c.Assert(err, check.IsNil, comm)
 
-		rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
+		rsp := s.req(c, req, nil).(*daemon.Resp)
 		c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError, comm)
 		c.Check(rsp.Status, check.Equals, 400, comm)
 		c.Check(rsp.ErrorResult().Message, check.Matches, test.error, comm)
@@ -241,7 +224,7 @@ func (s *snapshotSuite) TestChangeSnapshots404(c *check.C) {
 			req, err := http.NewRequest("POST", "/v2/snapshots", strings.NewReader(body))
 			c.Assert(err, check.IsNil, comm)
 
-			rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
+			rsp := s.req(c, req, nil).(*daemon.Resp)
 			c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError, comm)
 			c.Check(rsp.Status, check.Equals, 404, comm)
 			c.Check(rsp.ErrorResult().Message, check.Matches, expectedError.Error(), comm)
@@ -271,7 +254,7 @@ func (s *snapshotSuite) TestChangeSnapshots500(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snapshots", strings.NewReader(body))
 		c.Assert(err, check.IsNil, comm)
 
-		rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
+		rsp := s.req(c, req, nil).(*daemon.Resp)
 		c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError, comm)
 		c.Check(rsp.Status, check.Equals, 500, comm)
 		c.Check(rsp.ErrorResult().Message, check.Matches, expectedError.Error(), comm)
@@ -294,7 +277,7 @@ func (s *snapshotSuite) TestChangeSnapshot(c *check.C) {
 		return []string{"foo"}, state.NewTaskSet(), nil
 	})()
 
-	st := s.o.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
 	for _, action := range []string{"check", "restore", "forget"} {
@@ -305,7 +288,7 @@ func (s *snapshotSuite) TestChangeSnapshot(c *check.C) {
 		c.Assert(err, check.IsNil, comm)
 
 		st.Unlock()
-		rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
+		rsp := s.req(c, req, nil).(*daemon.Resp)
 		st.Lock()
 
 		c.Check(rsp.Type, check.Equals, daemon.ResponseTypeAsync, comm)
@@ -343,7 +326,7 @@ func (s *snapshotSuite) TestExportSnapshots(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots/1/export", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := daemon.ExportSnapshot(daemon.SnapshotExportCmd, req, nil)
+	rsp := s.req(c, req, nil)
 	c.Check(rsp, check.FitsTypeOf, &daemon.SnapshotExportResponse{})
 	c.Check(snapshotExportCalled, check.Equals, 1)
 }
@@ -357,7 +340,7 @@ func (s *snapshotSuite) TestExportSnapshotsBadRequestOnNonNumericID(c *check.C) 
 	req, err := http.NewRequest("GET", "/v2/snapshots/xxx/export", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := daemon.ExportSnapshot(daemon.SnapshotExportCmd, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `'id' must be a positive base 10 number; got "xxx"`})
@@ -378,7 +361,7 @@ func (s *snapshotSuite) TestExportSnapshotsBadRequestOnError(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots/1/export", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := daemon.ExportSnapshot(daemon.SnapshotExportCmd, req, nil).(*daemon.Resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `cannot export 1: boom`})
@@ -394,12 +377,12 @@ func (s *snapshotSuite) TestImportSnapshot(c *check.C) {
 		return setID, snapNames, nil
 	})()
 
-	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
+	req, err := http.NewRequest("POST", "/v2/snapshots", bytes.NewReader(data))
 	req.Header.Add("Content-Length", strconv.Itoa(len(data)))
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{"set-id": setID, "snaps": snapNames})
@@ -411,12 +394,12 @@ func (s *snapshotSuite) TestImportSnapshotError(c *check.C) {
 	})()
 
 	data := []byte("mocked snapshot export data file")
-	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
+	req, err := http.NewRequest("POST", "/v2/snapshots", bytes.NewReader(data))
 	req.Header.Add("Content-Length", strconv.Itoa(len(data)))
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.ErrorResult().Message, check.Equals, "no")
@@ -424,11 +407,11 @@ func (s *snapshotSuite) TestImportSnapshotError(c *check.C) {
 
 func (s *snapshotSuite) TestImportSnapshotNoContentLengthError(c *check.C) {
 	data := []byte("mocked snapshot export data file")
-	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
+	req, err := http.NewRequest("POST", "/v2/snapshots", bytes.NewReader(data))
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.ErrorResult().Message, check.Equals, `cannot parse Content-Length: strconv.ParseInt: parsing "": invalid syntax`)
@@ -445,13 +428,13 @@ func (s *snapshotSuite) TestImportSnapshotLimits(c *check.C) {
 	})()
 
 	data := []byte("much more data than expected from Content-Length")
-	req, err := http.NewRequest("POST", "/v2/snapshot/import", bytes.NewReader(data))
+	req, err := http.NewRequest("POST", "/v2/snapshots", bytes.NewReader(data))
 	// limit to 10 and check that this is really all that is read
 	req.Header.Add("Content-Length", "10")
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := daemon.ChangeSnapshots(daemon.SnapshotCmd, req, nil)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(dataRead, check.Equals, 10)

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -121,7 +121,7 @@ func (s *systemsSuite) TestSystemsGetSome(c *check.C) {
 	err := m.WriteTo("")
 	c.Assert(err, check.IsNil)
 
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -197,7 +197,7 @@ func (s *systemsSuite) TestSystemsGetNone(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -223,7 +223,7 @@ func (s *systemsSuite) TestSystemActionRequestErrors(c *check.C) {
 	err := m.WriteTo("")
 	c.Assert(err, check.IsNil)
 
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
@@ -518,7 +518,7 @@ func (s *systemsSuite) TestSystemActionBrokenSeed(c *check.C) {
 	err := m.WriteTo("")
 	c.Assert(err, check.IsNil)
 
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -546,7 +546,7 @@ func (s *systemsSuite) TestSystemActionBrokenSeed(c *check.C) {
 }
 
 func (s *systemsSuite) TestSystemActionNonRoot(c *check.C) {
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMockAndStore(c)
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)

--- a/daemon/export_api_snapshots_test.go
+++ b/daemon/export_api_snapshots_test.go
@@ -23,12 +23,10 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"net/http"
 
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
-	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -107,18 +105,6 @@ func MustUnmarshalSnapshotAction(c *check.C, jact string) *snapshotAction {
 
 func (rsp *resp) ErrorResult() *errorResult {
 	return rsp.Result.(*errorResult)
-}
-
-func ListSnapshots(c *Command, r *http.Request, user *auth.UserState) *resp {
-	return listSnapshots(c, r, user).(*resp)
-}
-
-func ChangeSnapshots(c *Command, r *http.Request, user *auth.UserState) *resp {
-	return changeSnapshots(c, r, user).(*resp)
-}
-
-func ExportSnapshot(c *Command, r *http.Request, user *auth.UserState) interface{} {
-	return getSnapshotExport(c, r, user)
 }
 
 var (


### PR DESCRIPTION
Import tests use wrong endpoint path (which isn't relevant for the test because it calls api command directly but is confusing). This PR fixes the path and also updates the test to use apiBaseTest (and with this, the endpoint path actually needs to be correct).