### PR TITLE
interfaces/opengl: allow RPi MMAL video decoding

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -74,6 +74,8 @@ unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),
 
 # VideoCore/EGL (shared device with VideoCore camera)
 /dev/vchiq rw,
+# VideoCore Video decoding (required for accelerated MMAL video playback)
+/dev/vcsm-cma rw,
 
 # va-api
 /dev/dri/renderD[0-9]* rw,

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -134,6 +134,7 @@ unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
 var openglConnectedPlugUDev = []string{
 	`SUBSYSTEM=="drm", KERNEL=="card[0-9]*"`,
 	`KERNEL=="vchiq"`,
+	`KERNEL=="vcsm-cma"`,
 	`KERNEL=="renderD[0-9]*"`,
 	`KERNEL=="nvhost-*"`,
 	`KERNEL=="nvmap"`,

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -84,7 +84,7 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *OpenglInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 8)
+	c.Assert(spec.Snippets(), HasLen, 9)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl


### PR DESCRIPTION
To use the Raspberry Pi multimedia abstraction layer libraries (MMAL [1]) for hardware accelerated video decoding applications do additionally to the existing access to /dev/vchiq need also read/write access to the Contiguous Memory Allocator [2] through the /dev/vcsm-cma device node provided by the newer VideoCore drivers. 
In combination with the closed source GPU libraries from broadcom this allows fully accelerated Video playback on Raspberry Pi devices.

This pull requests adds the needed read/write permission to /dev/vcsm-cma to the opengl interface.

[1] http://www.jvcref.com/files/PI/documentation/html/index.html
[2] https://lwn.net/Articles/486301/
