### PR TITLE
run-checks: update to match new argument syntax of ineffassign

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -246,7 +246,7 @@ if [ "$STATIC" = 1 ]; then
         go get -u github.com/gordonklaus/ineffassign
     fi
     # ineffassign knows about ignoring vendor/ \o/
-    ineffassign .
+    ineffassign ./...
 
     echo "Checking for naked returns"
     if ! command -v nakedret >/dev/null; then

--- a/run-checks
+++ b/run-checks
@@ -241,12 +241,14 @@ if [ "$STATIC" = 1 ]; then
     git ls-files -z -- . ':!:./po' ':!:./vendor' |
         xargs -0 misspell -error -i "$MISSPELL_IGNORE"
 
-    echo "Checking for ineffective assignments"
-    if ! command -v ineffassign >/dev/null; then
-        go get -u github.com/gordonklaus/ineffassign
+    if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.12; then
+        echo "Checking for ineffective assignments"
+        if ! command -v ineffassign >/dev/null; then
+            go get -u github.com/gordonklaus/ineffassign
+        fi
+        # ineffassign knows about ignoring vendor/ \o/
+        ineffassign ./...
     fi
-    # ineffassign knows about ignoring vendor/ \o/
-    ineffassign ./...
 
     echo "Checking for naked returns"
     if ! command -v nakedret >/dev/null; then


### PR DESCRIPTION
The ineffassign utility has changed its argument syntax so that the static checks fail with:

```
-: no Go files in .../src/github.com/snapcore/snapd
ineffassign: error during loading
```

To check the current package and all sub-packages, we now need to pass `./...` as the argument (as outlined in https://github.com/gordonklaus/ineffassign/pull/51).