### PR TITLE
tests/main/cohorts: replace yq with a Python snippet

### DIFF
--- a/tests/lib/snaps/test-snapd-sh/bin/cmd
+++ b/tests/lib/snaps/test-snapd-sh/bin/cmd
@@ -1,0 +1,6 @@
+#!/bin/sh
+PS1='$ '
+command="$1"
+shift
+
+exec "$command" "$@"

--- a/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
@@ -5,3 +5,5 @@ version: 1.0
 apps:
     sh:
         command: bin/sh
+    cmd:
+        command: bin/cmd

--- a/tests/main/cohorts/task.yaml
+++ b/tests/main/cohorts/task.yaml
@@ -1,13 +1,19 @@
 summary: Check that cohorts work
 
 prepare: |
-    snap install yq
-    snap connect yq:home
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+debug: |
+    cat coh.yml || true
 
 execute: |
     echo "Test we can create chorts:"
     snap create-cohort test-snapd-tools > coh.yml
-    COHORT=$( yq r coh.yml cohorts.test-snapd-tools.cohort-key )
+    # the YAML looks like this:
+    # cohorts:
+    #   test-snapd-tools:
+    #     cohort-key: <key>
+    COHORT=$(test-snapd-sh.cmd python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["cohorts"]["test-snapd-tools"]["cohort-key"])' < coh.yml)
     test -n "$COHORT"
 
     echo "Test we can install from there:"


### PR DESCRIPTION
The `yq` tool changed its command line arguments and the test broke. Try not to
depend on external tools and use a simple Python snippet to extract the cohort key.
