### PR TITLE
tests/main/snap-validate-basic: disable test on Fedora due to go-flags panics

### DIFF
--- a/tests/main/snap-validate-basic/task.yaml
+++ b/tests/main/snap-validate-basic/task.yaml
@@ -3,6 +3,10 @@ summary: Ensure `snap validate` commands work.
 # XXX: this functionality doesn't rely on store yet and as such this test
 # doesn't do much. Extend once all the functionality is available.
 
+systems:
+  # go-flags panics when showing --help for a hidden command on Fedora 32/33
+  - -fedora-*
+
 execute: |
   snap validate --help | MATCH "The validate command lists or applies validations sets"
   snap validate > list.txt


### PR DESCRIPTION
go-flags on Fedora 32/33 panics when showing --help of a hidden command. Git bisect indicates that breakage is due to this commit in go-flags https://github.com/jessevdk/go-flags/commit/71064e1638ea2c34ad561fd1ec92a23944673ff4 which got triggered by this commit https://github.com/snapcore/snapd/commit/85900470da735d61e7c520b27dfc82172a6af911 in the snapd tree.
