### PR TITLE
tests: allow to set a specific PROJECT_PATH

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -4,7 +4,7 @@ environment:
     GOHOME: /home/gopath
     GOPATH: $GOHOME
     REUSE_PROJECT: '$(HOST: echo "$REUSE_PROJECT")'
-    PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
+    PROJECT_PATH: '$(HOST: echo "${SPREAD_PROJECT_PATH:-"$GOHOME/src/github.com/snapcore/snapd"}")'
     # /usr/lib/go-1.6/bin for trusty (needs to be last as we use
     # a different go in gccgo tests)
     PATH: $GOHOME/bin:/snap/bin:$PATH:/usr/lib/go-1.6/bin:/var/lib/snapd/snap/bin:$PROJECT_PATH/tests/bin

--- a/spread.yaml
+++ b/spread.yaml
@@ -4,7 +4,7 @@ environment:
     GOHOME: /home/gopath
     GOPATH: $GOHOME
     REUSE_PROJECT: '$(HOST: echo "$REUSE_PROJECT")'
-    PROJECT_PATH: '$(HOST: echo "${SPREAD_PROJECT_PATH:-"$GOHOME/src/github.com/snapcore/snapd"}")'
+    PROJECT_PATH: '$(HOST: echo "${SPREAD_PROJECT_PATH:-"/home/gopath/src/github.com/snapcore/snapd"}")'
     # /usr/lib/go-1.6/bin for trusty (needs to be last as we use
     # a different go in gccgo tests)
     PATH: $GOHOME/bin:/snap/bin:$PATH:/usr/lib/go-1.6/bin:/var/lib/snapd/snap/bin:$PROJECT_PATH/tests/bin


### PR DESCRIPTION
In case the PROJECT_PATH is not in $GOHOME/src/github.com/snapcore/snapd
the pkgdb script fails to find the os.query binary and other scripts.

The idea is to allow to define a specific PROJECT_PATH on spread cron
jobs where we clone the snpad code and run tests.
