### PR TITLE
packaging/deb, tests/main/lxd-postrm-purge: fix purge inside containers

### DIFF
--- a/packaging/debian-sid/snapd.postrm
+++ b/packaging/debian-sid/snapd.postrm
@@ -104,15 +104,6 @@ if [ "$1" = "purge" ]; then
     # generated readme files
     rm -f "/snap/README"
 
-    echo "Final directory cleanup"
-    for d in "/snap/bin" "/snap" "/var/snap"; do
-        # Force remove due to directories for old revisions could still exist
-        rm -rf "$d"
-        if [ -d "$d" ]; then
-            echo "Cannot remove directory $d"
-        fi
-    done
-
     echo "Discarding preserved snap namespaces"
     # opportunistic as those might not be actually mounted
     if [ -d /run/snapd/ns ]; then
@@ -131,6 +122,15 @@ if [ "$1" = "purge" ]; then
         echo "Unmount /snap inside a container"
         umount /snap || true
     fi
+
+    echo "Final directory cleanup"
+    for d in "/snap/bin" "/snap" "/var/snap"; do
+        # Force remove due to directories for old revisions could still exist
+        rm -rf "$d"
+        if [ -d "$d" ]; then
+            echo "Cannot remove directory $d"
+        fi
+    done
 
     echo "Removing extra snap-confine apparmor rules"
     rm -f /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -104,15 +104,6 @@ if [ "$1" = "purge" ]; then
     # generated readme files
     rm -f "/snap/README"
 
-    echo "Final directory cleanup"
-    for d in "/snap/bin" "/snap" "/var/snap"; do
-        # Force remove due to directories for old revisions could still exist
-        rm -rf "$d"
-        if [ -d "$d" ]; then
-            echo "Cannot remove directory $d"
-        fi
-    done
-
     echo "Discarding preserved snap namespaces"
     # opportunistic as those might not be actually mounted
     if [ -d /run/snapd/ns ]; then
@@ -131,6 +122,15 @@ if [ "$1" = "purge" ]; then
         echo "Unmount /snap inside a container"
         umount /snap || true
     fi
+
+    echo "Final directory cleanup"
+    for d in "/snap/bin" "/snap" "/var/snap"; do
+        # Force remove due to directories for old revisions could still exist
+        rm -rf "$d"
+        if [ -d "$d" ]; then
+            echo "Cannot remove directory $d"
+        fi
+    done
 
     echo "Removing extra snap-confine apparmor rules"
     rm -f /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -114,15 +114,6 @@ if [ "$1" = "purge" ]; then
     # generated readme files
     rm -f "/snap/README"
 
-    echo "Final directory cleanup"
-    for d in "/snap/bin" "/snap" "/var/snap"; do
-        # Force remove due to directories for old revisions could still exist
-        rm -rf "$d"
-        if [ -d "$d" ]; then
-            echo "Cannot remove directory $d"
-        fi
-    done
-
     echo "Discarding preserved snap namespaces"
     # opportunistic as those might not be actually mounted
     if [ -d /run/snapd/ns ]; then
@@ -141,6 +132,15 @@ if [ "$1" = "purge" ]; then
         echo "Unmount /snap inside a container"
         umount /snap || true
     fi
+
+    echo "Final directory cleanup"
+    for d in "/snap/bin" "/snap" "/var/snap"; do
+        # Force remove due to directories for old revisions could still exist
+        rm -rf "$d"
+        if [ -d "$d" ]; then
+            echo "Cannot remove directory $d"
+        fi
+    done
 
     echo "Removing extra snap-confine apparmor rules"
     rm -f /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine

--- a/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -ex
+
+# XXX: remove once the "umount /snap" change in postrm has propagated all
+#      the way to the image
+if [ -e /var/lib/dpkg/info/snapd.postrm ]; then
+    # ensure we can umount /snap
+    sed -i 's#echo "Final directory cleanup"#umount /snap || true#' /var/lib/dpkg/info/snapd.postrm
+fi
+
+# wait for cloud-init to finish before doing any apt operations, since it will
+# re-write the apt sources.list file and we will be racing with the re-write 
+# trying to do apt operations before cloud-init is done
+# TODO: we should eventually use `cloud-init status --wait`, but that doesn't work
+# in nested containers, see https://bugs.launchpad.net/cloud-init/+bug/1905493
+for _ in $(seq 1 60); do
+    if python3 -c "import apt;apt.apt_pkg.SourceList().read_main_list()"; then
+        break
+    fi
+    sleep 1
+done
+
+apt autoremove --purge -y snapd ubuntu-core-launcher
+apt update
+
+# requires the snapd deb to already have been "lxd file push"d into the 
+# container
+apt install -y /root/snapd_*.deb
+
+# reload to take effect of the proxy that may have been set before this script
+# XXX: systemctl daemon-reload times out in 16.04:my-nesting-lxd but every
+#      appears to be working normally
+systemctl daemon-reload || true
+systemctl restart snapd.service
+
+# wait for snapd to finish seeding
+snap wait system seed.loaded
+
+# for debugging
+cat /etc/environment

--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -1,0 +1,82 @@
+summary: Check that package remove and purge works inside LXD containers
+
+# Since it's only apt remove --purge and lxd tests are rather long, limit to a
+# couple of systems only. The postrm purge is more thoroughly checked in
+# tests/main/postrm-purge.
+systems: [ubuntu-18.04-*, ubuntu-20.04-*]
+
+# lxd downloads can be quite slow
+kill-timeout: 25m
+
+# start early
+priority: 1000
+
+prepare: |
+    # using apt here is ok because this test only runs on ubuntu
+    echo "Remove any installed debs (some images carry them) to ensure we test the snap"
+    # apt -v to test if apt is usable (its not on ubuntu-core)
+    if command -v apt && apt -v; then
+        apt autoremove -y lxd
+    fi
+    echo "Install lxd"
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
+
+    echo "Create a trivial container using the lxd snap"
+    snap set lxd waitready.timeout=240
+    lxd waitready
+    lxd init --auto
+
+    # the snapd package we build as part of the tests will only run on the
+    # distro we build on. So we need to launch the right ubuntu version.
+    VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
+    lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-ubuntu
+    # sanity check
+    if [ "$(uname -m)" = x86_64 ] && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then
+        echo "LXD spawned 32bit userspace container on a 64bit host, WAT?"
+        snap info lxd
+        exit 1
+    fi
+
+    echo "Ensure we can run things inside"
+    lxd.lxc exec my-ubuntu echo hello | MATCH hello
+
+    echo "Push snapd into container"
+    lxd.lxc file push --quiet prep-snapd-in-lxd.sh "my-ubuntu/root/"
+    lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "my-ubuntu/root/"
+
+    echo "Setting up proxy *inside* the container"
+    if [ -n "${http_proxy:-}" ]; then
+        lxd.lxc exec my-ubuntu -- sh -c "echo http_proxy=$http_proxy >> /etc/environment"
+    fi
+    if [ -n "${https_proxy:-}" ]; then
+        lxd.lxc exec my-ubuntu -- sh -c "echo https_proxy=$https_proxy >> /etc/environment"
+    fi
+
+    echo "Install snapd in container"
+    lxd.lxc exec my-ubuntu -- /root/prep-snapd-in-lxd.sh
+
+restore: |
+    if  [[ "$(find "$GOHOME" -name 'snapd_*.deb' | wc -l || echo 0)" -eq 0 ]]; then
+        exit
+    fi
+
+    lxd.lxc stop my-ubuntu --force || true
+    lxd.lxc delete my-ubuntu || true
+    snap remove --purge lxd
+    snap remove --purge lxd-demo-server
+
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
+
+debug: |
+    # debug output from lxd
+    "$TESTSTOOLS"/journal-state get-log -u snap.lxd.daemon.service
+
+execute: |
+    lxd.lxc exec my-ubuntu -- snap install hello-world
+    lxd.lxc exec my-ubuntu -- hello-world
+    # purge completes successfully
+    lxd.lxc exec my-ubuntu -- apt remove --purge -y snapd
+    # sanity check that potentially problematic directories are gone
+    lxd.lxc exec my-ubuntu -- test ! -d /snap
+    lxd.lxc exec my-ubuntu -- test ! -d /var/snap
+    lxd.lxc exec my-ubuntu -- test ! -d /var/lib/snapd


### PR DESCRIPTION
When executing inside the containers, / is not mounted with shared propagation,
thus snap-confine bind mounts /snap to itself and sets the MS_SHARED propagation
flag accordingly.

During postrm purge, the final directly cleanup must be done after we have dealt
with the /snap mount.

Add a spread that to verify that purge inside LXD works correctly.