### PR TITLE
tests: use os-query tool to check debian, trusty and tumbleweed

### DIFF
--- a/tests/lib/dirs.sh
+++ b/tests/lib/dirs.sh
@@ -17,7 +17,7 @@ case "$SPREAD_SYSTEM" in
     opensuse-*)
         export SNAP_MOUNT_DIR=/snap
         export MEDIA_DIR=/run/media
-        if [ "$( . /etc/os-release ; echo "$ID")" = "opensuse-tumbleweed" ]; then
+        if os.query is-opensuse-tumbleweed; then
             # Tumbleweed since snapshot 20200827 is using /usr/libexec as libexecdir
             export LIBEXECDIR=/usr/libexec
         fi

--- a/tests/lib/tools/tests.pkgs.apt.sh
+++ b/tests/lib/tools/tests.pkgs.apt.sh
@@ -3,14 +3,14 @@
 remap_one() {
     case "$1" in
         man)
-            if [ "$(cat /etc/os-release && echo "$ID")" = debian ]; then
+            if os.query is-debian; then
                 echo "man-db"
             else
                 echo "$1"
             fi
             ;;
         printer-driver-cups-pdf)
-            if [ "$(cat /etc/os-release && echo "$ID")" = debian ] || [ "$(cat /etc/os-release && echo "$ID/$ID_VERSION")" = ubuntu/14.04 ]; then
+            if os.query is-debian || os.query is-trusty; then
                 echo "cups-pdf"
             else
                 echo "$1"


### PR DESCRIPTION
This change updates some missing uses of the os.query tool to check the os
