### PR TITLE
tests: update check to verify is the current system is arm

### DIFF
--- a/tests/lib/tools/os.query
+++ b/tests/lib/tools/os.query
@@ -100,7 +100,7 @@ is_pc_i386() {
 }
 
 is_arm() {
-    uname -m | grep -qx '^arm.*'
+    uname -m | grep -Eq '(^arm.*|^aarch*)'
 }
 
 is_armhf() {


### PR DESCRIPTION
Include now aarch as part of the possibilities when checking if the current system is arm
