### PR TITLE
tests: skip interfaces-openvswitch spread test on debian sid

### DIFF
--- a/tests/nightly/interfaces-openvswitch/task.yaml
+++ b/tests/nightly/interfaces-openvswitch/task.yaml
@@ -1,8 +1,9 @@
 summary: Ensure that the openvswitch interface works.
 
 # Openvswitch getting stuck during installation sporadically on ubuntu-14.04-64
+# Openvswitch service fails to start on debian-sid
 # Openvswitch service not available on the following systems
-systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -arch-linux-*, -centos-*, -ubuntu-14.04-64]
+systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -arch-linux-*, -centos-*, -debian-sid-*, -ubuntu-14.04-64]
 
 details: |
     The openvswitch interface allows to task to the openvswitch socket (rw mode).


### PR DESCRIPTION
The service openvswitch-switch.service cannot be started due to an error
on debian sid.

+ systemctl enable --now openvswitch-switch.service
Synchronizing state of openvswitch-switch.service with SysV service
script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable openvswitch-switch
Failed to start openvswitch-switch.service: Unit
openvswitch-nonetwork.service not found.

The test si still being executed on debian-9
