### PR TITLE
cmd/libsnap-confine-private/cleanup-funcs-test.c: rm g_autofree usage

### DIFF
--- a/cmd/libsnap-confine-private/cleanup-funcs-test.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs-test.c
@@ -87,7 +87,7 @@ static void test_cleanup_endmntent(void)
 
 	/* It is safe to use with a non-NULL FILE. */
 	GError *err = NULL;
-	g_autofree char *mock_fstab = NULL;
+	char *mock_fstab = NULL;
 	gint mock_fstab_fd =
 	    g_file_open_tmp("s-c-test-fstab-mock.XXXXXX", &mock_fstab, &err);
 	g_assert_no_error(err);
@@ -104,6 +104,8 @@ static void test_cleanup_endmntent(void)
 	g_assert_null(f);
 
 	g_remove(mock_fstab);
+
+	g_free(mock_fstab);
 }
 
 static void test_cleanup_closedir(void)


### PR DESCRIPTION
The version of glib we compile against on Ubuntu 14.04 Trusty Tahr does not
support "g_autofree", so just manually free at the end of the test to get spread
tests running again on 14.04.

The test failure was introduced via https://github.com/snapcore/snapd/pull/9818, and was not caught because "skip spread" was used, so we didn't see that it made 14.04 fail.