### PR TITLE
interfaces/greengrass-support: back-port interface changes to 2.48

### DIFF
--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -20,8 +20,6 @@
 package builtin
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -412,8 +410,6 @@ func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 		// this is the process-mode version, it does not use as much privilege
 		// as the default "container" flavor
 		spec.AddSnippet(greengrassSupportProcessModeConnectedPlugAppArmor)
-	default:
-		return fmt.Errorf("cannot add apparmor plug policy: unsupported flavor attribute value %q for greengrass-support interface", flavor)
 	}
 
 	return nil
@@ -428,8 +424,6 @@ func (iface *greengrassSupportInterface) SecCompConnectedPlug(spec *seccomp.Spec
 		spec.AddSnippet(greengrassSupportConnectedPlugSeccomp)
 	case "process":
 		// process mode has no additional seccomp available to it
-	default:
-		return fmt.Errorf("cannot add seccomp plug policy: unsupported flavor attribute value %q for greengrass-support interface", flavor)
 	}
 
 	return nil
@@ -444,8 +438,6 @@ func (iface *greengrassSupportInterface) UDevConnectedPlug(spec *udev.Specificat
 		spec.SetControlsDeviceCgroup()
 	case "process":
 		// process mode does not control the device cgroup
-	default:
-		return fmt.Errorf("cannot add udev plug policy: unsupported flavor attribute value %q for greengrass-support interface", flavor)
 	}
 
 	return nil

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -392,12 +392,19 @@ mknod - |S_IFCHR -
 mknodat - - |S_IFCHR -
 `
 
+// XXX: decide on the final names and adjust tests too
+const (
+	flavorAttrStr   = "flavor"
+	flavorContainer = "container"
+	falvorProcess   = "process"
+)
+
 func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// check the flavor
 	var flavor string
-	_ = plug.Attr("flavor", &flavor)
+	_ = plug.Attr(flavorAttrStr, &flavor)
 	switch flavor {
-	case "", "container":
+	case "", flavorContainer:
 		// default, legacy version of the interface
 		if release.OnClassic {
 			spec.AddSnippet(greengrassSupportFullContainerConnectedPlugAppArmor)
@@ -406,9 +413,9 @@ func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 		}
 		// greengrass needs to use ptrace for controlling it's containers
 		spec.SetUsesPtraceTrace()
-	case "process":
+	case falvorProcess:
 		// this is the process-mode version, it does not use as much privilege
-		// as the default "container" flavor
+		// as the default flavorContainer flavor
 		spec.AddSnippet(greengrassSupportProcessModeConnectedPlugAppArmor)
 	}
 
@@ -418,11 +425,11 @@ func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 func (iface *greengrassSupportInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// check the flavor
 	var flavor string
-	_ = plug.Attr("flavor", &flavor)
+	_ = plug.Attr(flavorAttrStr, &flavor)
 	switch flavor {
-	case "", "container":
+	case "", flavorContainer:
 		spec.AddSnippet(greengrassSupportConnectedPlugSeccomp)
-	case "process":
+	case falvorProcess:
 		// process mode has no additional seccomp available to it
 	}
 
@@ -431,12 +438,12 @@ func (iface *greengrassSupportInterface) SecCompConnectedPlug(spec *seccomp.Spec
 
 func (iface *greengrassSupportInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	var flavor string
-	_ = plug.Attr("flavor", &flavor)
+	_ = plug.Attr(flavorAttrStr, &flavor)
 	switch flavor {
-	case "", "container":
+	case "", flavorContainer:
 		// default containerization controls the device cgroup
 		spec.SetControlsDeviceCgroup()
-	case "process":
+	case falvorProcess:
 		// process mode does not control the device cgroup
 	}
 

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -62,25 +62,25 @@ slots:
 const ggMockPlugSnapInfoYaml = `name: other
 version: 1.0
 plugs:
- greengrass-support-container-mode:
+ greengrass-support-legacy-container:
   interface: greengrass-support
-  flavor: container
+  flavor: legacy-container
 apps:
  app2:
   command: foo
-  plugs: [greengrass-support-container-mode, greengrass-support, network-control]
+  plugs: [greengrass-support-legacy-container, greengrass-support, network-control]
 `
 
 const ggProcessModeMockPlugSnapInfoYaml = `name: other
 version: 1.0
 plugs:
- greengrass-support-process-mode:
+ greengrass-support-no-container:
   interface: greengrass-support
-  flavor: process
+  flavor: no-container
 apps:
  app2:
   command: foo
-  plugs: [greengrass-support-process-mode, network-control]
+  plugs: [greengrass-support-no-container, network-control]
 `
 
 var _ = Suite(&GreengrassSupportInterfaceSuite{
@@ -93,9 +93,9 @@ func (s *GreengrassSupportInterfaceSuite) SetUpTest(c *C) {
 	s.extraPlug, s.extraPlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "network-control")
 	s.extraSlot, s.extraSlotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "network-control")
 
-	s.processModePlug, s.processModePlugInfo = MockConnectedPlug(c, ggProcessModeMockPlugSnapInfoYaml, nil, "greengrass-support-process-mode")
+	s.processModePlug, s.processModePlugInfo = MockConnectedPlug(c, ggProcessModeMockPlugSnapInfoYaml, nil, "greengrass-support-no-container")
 
-	s.containerModePlug, s.containerModePlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "greengrass-support-container-mode")
+	s.containerModePlug, s.containerModePlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "greengrass-support-legacy-container")
 
 }
 

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -42,6 +42,14 @@ type GreengrassSupportInterfaceSuite struct {
 	extraSlot     *interfaces.ConnectedSlot
 	extraPlugInfo *snap.PlugInfo
 	extraPlug     *interfaces.ConnectedPlug
+
+	// for the process flavor
+	processModePlugInfo *snap.PlugInfo
+	processModePlug     *interfaces.ConnectedPlug
+
+	// for the container flavor
+	containerModePlugInfo *snap.PlugInfo
+	containerModePlug     *interfaces.ConnectedPlug
 }
 
 const coreSlotYaml = `name: core
@@ -53,10 +61,26 @@ slots:
 `
 const ggMockPlugSnapInfoYaml = `name: other
 version: 1.0
+plugs:
+ greengrass-support-container-mode:
+  interface: greengrass-support
+  flavor: container
 apps:
  app2:
   command: foo
-  plugs: [greengrass-support, network-control]
+  plugs: [greengrass-support-container-mode, greengrass-support, network-control]
+`
+
+const ggProcessModeMockPlugSnapInfoYaml = `name: other
+version: 1.0
+plugs:
+ greengrass-support-process-mode:
+  interface: greengrass-support
+  flavor: process
+apps:
+ app2:
+  command: foo
+  plugs: [greengrass-support-process-mode, network-control]
 `
 
 var _ = Suite(&GreengrassSupportInterfaceSuite{
@@ -68,6 +92,10 @@ func (s *GreengrassSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slot, s.slotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "greengrass-support")
 	s.extraPlug, s.extraPlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "network-control")
 	s.extraSlot, s.extraSlotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "network-control")
+
+	s.processModePlug, s.processModePlugInfo = MockConnectedPlug(c, ggProcessModeMockPlugSnapInfoYaml, nil, "greengrass-support-process-mode")
+
+	s.containerModePlug, s.containerModePlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "greengrass-support-container-mode")
 
 }
 
@@ -84,39 +112,86 @@ func (s *GreengrassSupportInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestAppArmorSpec(c *C) {
+
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		spec := &apparmor.Specification{}
+		c.Assert(spec.AddConnectedPlug(s.iface, plug, s.slot), IsNil)
+		c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+		c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "mount options=(rw, bind) /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,\n")
+		c.Check(spec.UsesPtraceTrace(), Equals, true)
+	}
+}
+
+func (s *GreengrassSupportInterfaceSuite) TestProcessModeAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.processModePlug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
-	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "mount options=(rw, bind) /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,\n")
-	c.Check(spec.UsesPtraceTrace(), Equals, true)
+	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "/ ix,\n")
+	c.Check(spec.SnippetForTag("snap.other.app2"), Not(testutil.Contains), "mount options=(rw, bind) /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,\n")
+	c.Check(spec.UsesPtraceTrace(), Equals, false)
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestSecCompSpec(c *C) {
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		spec := &seccomp.Specification{}
+		c.Assert(spec.AddConnectedPlug(s.iface, plug, s.slot), IsNil)
+		c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "# for overlayfs and various bind mounts\nmount\numount2\npivot_root\n")
+	}
+}
+
+func (s *GreengrassSupportInterfaceSuite) TestProcessModeSecCompSpec(c *C) {
 	spec := &seccomp.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "# for overlayfs and various bind mounts\nmount\numount2\npivot_root\n")
+	c.Assert(spec.AddConnectedPlug(s.iface, s.processModePlug, s.slot), IsNil)
+	c.Check(spec.SnippetForTag("snap.other.app2"), Not(testutil.Contains), "# for overlayfs and various bind mounts\nmount\numount2\npivot_root\n")
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestUdevTaggingDisablingRemoveLast(c *C) {
-	// make a spec with network-control that has udev tagging
-	spec := &udev.Specification{}
-	c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), s.extraPlug, s.extraSlot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 3)
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		// make a spec with network-control that has udev tagging
+		spec := &udev.Specification{}
+		c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), s.extraPlug, s.extraSlot), IsNil)
+		c.Assert(spec.Snippets(), HasLen, 3)
 
-	// connect the greengrass-support interface and ensure the spec is now nil
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+		// connect the greengrass-support interface and ensure the spec is now nil
+		c.Assert(spec.AddConnectedPlug(s.iface, plug, s.slot), IsNil)
+		c.Check(spec.Snippets(), HasLen, 0)
+	}
+}
+
+func (s *GreengrassSupportInterfaceSuite) TestProcessModeUdevTaggingWorks(c *C) {
+	spec := &udev.Specification{}
+	// connect the greengrass-support interface and ensure the spec is nil
+	c.Assert(spec.AddConnectedPlug(s.iface, s.processModePlug, s.slot), IsNil)
 	c.Check(spec.Snippets(), HasLen, 0)
+
+	// add network-control and now the spec is not nil
+	c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), s.extraPlug, s.extraSlot), IsNil)
+	c.Assert(spec.Snippets(), Not(HasLen), 0)
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestUdevTaggingDisablingRemoveFirst(c *C) {
-	spec := &udev.Specification{}
-	// connect the greengrass-support interface and ensure the spec is nil
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Check(spec.Snippets(), HasLen, 0)
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		spec := &udev.Specification{}
+		// connect the greengrass-support interface and ensure the spec is nil
+		c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+		c.Check(spec.Snippets(), HasLen, 0)
 
-	// add network-control and ensure the spec is still nil
-	c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), s.extraPlug, s.extraSlot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 0)
+		// add network-control and ensure the spec is still nil
+		c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), plug, s.extraSlot), IsNil)
+		c.Assert(spec.Snippets(), HasLen, 0)
+	}
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestInterfaces(c *C) {
@@ -127,24 +202,34 @@ func (s *GreengrassSupportInterfaceSuite) TestPermanentSlotAppArmorSessionNative
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		apparmorSpec := &apparmor.Specification{}
+		err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
+		c.Assert(err, IsNil)
+		c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 
-	// verify core rule present
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "# /system-data/var/snap/greengrass/x1/ggc-writable/packages/1.7.0/var/worker/overlays/$UUID/upper/\n")
+		// verify core rule present
+		c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "# /system-data/var/snap/greengrass/x1/ggc-writable/packages/1.7.0/var/worker/overlays/$UUID/upper/\n")
+	}
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestPermanentSlotAppArmorSessionClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
-	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	for _, plug := range []*interfaces.ConnectedPlug{
+		s.plug,
+		s.containerModePlug,
+	} {
+		apparmorSpec := &apparmor.Specification{}
+		err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
+		c.Assert(err, IsNil)
+		c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 
-	// verify core rule not present
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), Not(testutil.Contains), "# /system-data/var/snap/greengrass/x1/ggc-writable/packages/1.7.0/var/worker/overlays/$UUID/upper/\n")
+		// verify core rule not present
+		c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), Not(testutil.Contains), "# /system-data/var/snap/greengrass/x1/ggc-writable/packages/1.7.0/var/worker/overlays/$UUID/upper/\n")
+	}
 }

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -117,6 +117,13 @@ dbus (send)
     interface=org.freedesktop.DBus.Peer
     member=GetMachineId
     peer=(label=unconfined),
+
+# Allow reading if protected hardlinks are enabled, but don't allow enabling or
+# disabling them
+@{PROC}/sys/fs/protected_hardlinks r,
+@{PROC}/sys/fs/protected_symlinks r,
+@{PROC}/sys/fs/protected_fifos r,
+@{PROC}/sys/fs/protected_regular r,
 `
 
 const systemObserveConnectedPlugSecComp = `

--- a/run-checks
+++ b/run-checks
@@ -246,7 +246,7 @@ if [ "$STATIC" = 1 ]; then
         go get -u github.com/gordonklaus/ineffassign
     fi
     # ineffassign knows about ignoring vendor/ \o/
-    ineffassign .
+    ineffassign ./...
 
     echo "Checking for naked returns"
     if ! command -v nakedret >/dev/null; then

--- a/run-checks
+++ b/run-checks
@@ -241,12 +241,14 @@ if [ "$STATIC" = 1 ]; then
     git ls-files -z -- . ':!:./po' ':!:./vendor' |
         xargs -0 misspell -error -i "$MISSPELL_IGNORE"
 
-    echo "Checking for ineffective assignments"
-    if ! command -v ineffassign >/dev/null; then
-        go get -u github.com/gordonklaus/ineffassign
+    if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.12; then
+        echo "Checking for ineffective assignments"
+        if ! command -v ineffassign >/dev/null; then
+            go get -u github.com/gordonklaus/ineffassign
+        fi
+        # ineffassign knows about ignoring vendor/ \o/
+        ineffassign ./...
     fi
-    # ineffassign knows about ignoring vendor/ \o/
-    ineffassign ./...
 
     echo "Checking for naked returns"
     if ! command -v nakedret >/dev/null; then

--- a/tests/lib/snaps/test-snapd-sh/bin/cmd
+++ b/tests/lib/snaps/test-snapd-sh/bin/cmd
@@ -1,0 +1,6 @@
+#!/bin/sh
+PS1='$ '
+command="$1"
+shift
+
+exec "$command" "$@"

--- a/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
@@ -5,3 +5,5 @@ version: 1.0
 apps:
     sh:
         command: bin/sh
+    cmd:
+        command: bin/cmd

--- a/tests/main/cohorts/task.yaml
+++ b/tests/main/cohorts/task.yaml
@@ -1,13 +1,19 @@
 summary: Check that cohorts work
 
 prepare: |
-    snap install yq
-    snap connect yq:home
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+debug: |
+    cat coh.yml || true
 
 execute: |
     echo "Test we can create chorts:"
     snap create-cohort test-snapd-tools > coh.yml
-    COHORT=$( yq r coh.yml cohorts.test-snapd-tools.cohort-key )
+    # the YAML looks like this:
+    # cohorts:
+    #   test-snapd-tools:
+    #     cohort-key: <key>
+    COHORT=$(test-snapd-sh.cmd python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["cohorts"]["test-snapd-tools"]["cohort-key"])' < coh.yml)
     test -n "$COHORT"
 
     echo "Test we can install from there:"


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/9595 and https://github.com/snapcore/snapd/pull/9639, back-ported to 2.48.

This also includes https://github.com/snapcore/snapd/pull/9806 and https://github.com/snapcore/snapd/pull/9807 in order to get unit tests + spread tests to run.