### PR TITLE
interfaces/builtin: more drive by fixes, import ordering, removing dead code

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/release"
-	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -654,10 +653,6 @@ func (iface *dockerSupportInterface) StaticInfo() interfaces.StaticInfo {
 		BaseDeclarationSlots: dockerSupportBaseDeclarationSlots,
 	}
 }
-
-var (
-	parserFeatures = apparmor_sandbox.ParserFeatures
-)
 
 func (iface *dockerSupportInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	spec.SetControlsDeviceCgroup()

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -21,6 +21,7 @@ package builtin
 
 import (
 	"fmt"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/snap"

--- a/interfaces/builtin/kernel_module_observe_test.go
+++ b/interfaces/builtin/kernel_module_observe_test.go
@@ -19,12 +19,13 @@
 package builtin_test
 
 import (
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
-	. "gopkg.in/check.v1"
 )
 
 type KernelModuleObserveInterfaceSuite struct {

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -115,18 +115,6 @@ func (s *MirInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "/run/mir_socket rw,")
 }
 
-const mirMockSlotSnapInfoYaml = `name: mir-server
-version: 1.0
-slots:
- mir-server:
-  interface: mir
-apps:
- mir:
-  command: foo
-  slots:
-   - mir-server
-`
-
 func (s *MirInterfaceSuite) TestSecComp(c *C) {
 	seccompSpec := &seccomp.Specification{}
 	err := seccompSpec.AddPermanentSlot(s.iface, s.coreSlotInfo)

--- a/interfaces/builtin/ptp_test.go
+++ b/interfaces/builtin/ptp_test.go
@@ -20,14 +20,14 @@
 package builtin_test
 
 import (
-	"github.com/snapcore/snapd/interfaces/apparmor"
-	"github.com/snapcore/snapd/interfaces/udev"
-	"github.com/snapcore/snapd/testutil"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type PTPInterfaceSuite struct {

--- a/interfaces/builtin/raw_volume_test.go
+++ b/interfaces/builtin/raw_volume_test.go
@@ -20,8 +20,9 @@
 package builtin_test
 
 import (
-	. "gopkg.in/check.v1"
 	"strings"
+
+	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"

--- a/interfaces/builtin/raw_volume_test.go
+++ b/interfaces/builtin/raw_volume_test.go
@@ -66,20 +66,6 @@ var _ = Suite(&rawVolumeInterfaceSuite{
 	iface: builtin.MustInterface("raw-volume"),
 })
 
-const rawVolumeConsumerYaml = `name: consumer
-version: 0
-apps:
- app:
-  plugs: [raw-volume]
-`
-
-const rawVolumeCoreYaml = `name: core
-version: 0
-type: os
-slots:
-  raw-volume:
-`
-
 func (s *rawVolumeInterfaceSuite) SetUpTest(c *C) {
 	// Mock for OS snap
 	osSnapInfo := snaptest.MockInfo(c, `

--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -21,6 +21,7 @@ package builtin
 
 import (
 	"fmt"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/udev"
 )

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -200,14 +200,6 @@ func (s *UPowerObserveInterfaceSuite) TestPermanentSlotSnippetAppArmor(c *C) {
 	c.Check(apparmorSpec.SnippetForTag("snap.upowerd.app"), testutil.Contains, "org.freedesktop.UPower")
 }
 
-const upowerObserveMockSlotSnapInfoYaml = `name: upower
-version: 1.0
-apps:
- app1:
-  command: foo
-  slots: [upower-observe]
-`
-
 func (s *UPowerObserveInterfaceSuite) TestPermanentSlotSnippetSecComp(c *C) {
 	seccompSpec := &seccomp.Specification{}
 	err := seccompSpec.AddPermanentSlot(s.iface, s.coreSlotInfo)


### PR DESCRIPTION
golangci-lint was unhappy so I had a go at fixing some of those.