### PR TITLE
sandbox/cgroup, tess/main: fix unit tests on v2 system, disable broken tests on sid

### DIFF
--- a/sandbox/cgroup/process_test.go
+++ b/sandbox/cgroup/process_test.go
@@ -36,21 +36,27 @@ func (s *cgroupSuite) mockPidCgroup(c *C, text string) int {
 	return 333
 }
 
-func (s *cgroupSuite) TestSnapNameFromPidHappy(c *C) {
+func (s *cgroupSuite) TestV1SnapNameFromPidHappy(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
 	pid := s.mockPidCgroup(c, string(mockCgroup)) // defined in cgroup_test.go
 	name, err := cgroup.SnapNameFromPid(pid)
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "hello-world")
 }
 
-func (s *cgroupSuite) TestSnapNameFromPidUnhappy(c *C) {
+func (s *cgroupSuite) TestV1SnapNameFromPidUnhappy(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
 	pid := s.mockPidCgroup(c, "1:freezer:/\n")
 	name, err := cgroup.SnapNameFromPid(pid)
 	c.Assert(err, ErrorMatches, "cannot find a snap for pid .*")
 	c.Check(name, Equals, "")
 }
 
-func (s *cgroupSuite) TestSnapNameFromPidEmptyName(c *C) {
+func (s *cgroupSuite) TestV1SnapNameFromPidEmptyName(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
 	pid := s.mockPidCgroup(c, "1:freezer:/snap./\n")
 	name, err := cgroup.SnapNameFromPid(pid)
 	c.Assert(err, ErrorMatches, "snap name in cgroup path is empty")

--- a/tests/main/cgroup-devices/task.yaml
+++ b/tests/main/cgroup-devices/task.yaml
@@ -1,7 +1,8 @@
 summary: measuring basic properties of device cgroup
 # fedora-32: uses cgroupv2, which we don't support
 # fedora-33: uses cgroupv2, which we don't support
-systems: [ -fedora-32-*, -fedora-33-* ]
+# debian-sid: uses cgroupv2, which we don't support
+systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-* ]
 execute: ./task.sh
 restore: |
     rm -f test-snapd-service_1.0_all.snap

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -1,7 +1,8 @@
 summary: Each snap process is moved to appropriate freezer cgroup
 # fedora-32: uses cgroupv2, which does not support a separate freezer controller
 # fedora-33: uses cgroupv2, which does not support a separate freezer controller
-systems: [ -fedora-32-*, -fedora-33-*]
+# debian-sid: uses cgroupv2, which does not support a separate freezer controller
+systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*]
 
 details: |
     This test creates a snap process that suspends itself and ensures that it

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -1,8 +1,9 @@
 summary: Ensure that the security rules related to device cgroups work.
 
-# We don't run the native kernel on these distributions yet so we can't
-# load kernel modules coming from distribution packages yet.
-systems: [-fedora-*, -opensuse-*]
+# fedora, opensuse: we don't run the native kernel on these distributions yet so
+#                   we can't load kernel modules coming from distribution packages yet
+# debian-sid: cgroup v2 which we do not fully support yet
+systems: [-fedora-*, -opensuse-*, -debian-sid-*]
 
 environment:
     DEVICE_NAME/kmsg: kmsg

--- a/tests/main/snap-device-helper-nvme/task.yaml
+++ b/tests/main/snap-device-helper-nvme/task.yaml
@@ -5,7 +5,8 @@ summary: |
 
 # fedora-32: uses cgroupv2, which we don't support
 # fedora-33: uses cgroupv2, which we don't support
-systems: [-fedora-32-*, -fedora-33-*]
+# debian-sid: uses cgroupv2, which we don't support
+systems: [-fedora-32-*, -fedora-33-*, -debian-sid-*]
 
 execute: |
   # make a fake snap devices cgroup

--- a/tests/main/snapctl-is-connected/task.yaml
+++ b/tests/main/snapctl-is-connected/task.yaml
@@ -10,14 +10,18 @@ restore: |
 execute: |
   check_empty() {
     local OUT="$1"
-    if [[ "$SPREAD_SYSTEM" == fedora-32-* ]] || [[ "$SPREAD_SYSTEM" == fedora-33-* ]]; then
-      echo "$OUT" | MATCH '^WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement$'
-    else
-      if [ -n "$OUT" ]; then
-        echo "Expected no output, but got: $OUT"
-        exit 1
-      fi
-    fi
+    case "$SPREAD_SYSTEM" in
+        # special case systems using unified cgroup v2 hierarchy
+        fedora-32-*|fedora-33-*|debian-sid-*)
+            echo "$OUT" | MATCH '^WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement$'
+            ;;
+        *)
+            if [ -n "$OUT" ]; then
+                echo "Expected no output, but got: $OUT"
+                exit 1
+            fi
+      ;;
+    esac
   }
 
   # network is connected by default


### PR DESCRIPTION
Since 21.12.2020 (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=943981)
Debian Sid is using a unified cgroup hierarchy (v2). Disable tests that fail on
such system. Fix sandbox/cgroup unit tests to apply proper mocking of v1 support.