### PR TITLE
Clarify error message

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -501,9 +501,9 @@ int main(int argc, char **argv)
 			die("setuid failed");
 
 		if (real_gid != 0 && (getuid() == 0 || geteuid() == 0))
-			die("permanently dropping privs did not work");
+			die("permanently dropping privs did not work. you must use sudo but you must NOT be logged in as root.");
 		if (real_uid != 0 && (getgid() == 0 || getegid() == 0))
-			die("permanently dropping privs did not work");
+			die("permanently dropping privs did not work. you must use sudo but you must NOT be logged in as root.");
 	}
 	// Now that we've permanently dropped, regain SYS_ADMIN
 	if (keep_sys_admin) {


### PR DESCRIPTION
As a user, this error is pretty hard to figure out on its own. Attempted to clarify the error message so that the user can immediately resolve if they run into this.

To trigger this error, `sudo su -` to root, then run any command of a snap-installed program. Specific commands to reproduce (yes, I realize sudo doesn't do much as root ;) but I'm copy/pasting from tutorials):

1. > sudo su -
2. > sudo snap refresh core
3. > sudo snap install --classic certbot
4. > sudo ln -s /snap/bin/certbot /usr/bin/certbot
5. > sudo snap set certbot trust-plugin-with-root=ok
6. > sudo certbot --apache
`permanently dropping privs did not work`

This has to be done the first time. After I've successfully installed/run certbot once as a non-root user, then it works from that point onwards even if I'm root.

I have signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md).