### PR TITLE
tests: skip main part of snap-advise test if 429 error is encountered

### DIFF
--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -27,7 +27,14 @@ execute: |
        fi
        sleep 1
     done
-    stat /var/cache/snapd/commands.db
+    if ! stat /var/cache/snapd/commands.db; then
+        # workaround for misbehaving store
+        if journalctl -u snapd | MATCH "429 Too Many Requests"; then
+            echo "Store is reporting 429 (too many requests), skipping the test"
+            exit 0
+        fi
+        exit 1
+    fi
     echo "Ensure the database is readable by a regular user"
     if [ "$(stat -c '%a' /var/cache/snapd/commands.db)" != "644" ]; then
         echo "incorrect permissions for /var/cache/snapd/commands.db"

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -29,7 +29,7 @@ execute: |
     done
     if ! stat /var/cache/snapd/commands.db; then
         # workaround for misbehaving store
-        if journalctl -u snapd | MATCH "429 Too Many Requests"; then
+        if "$TESTSTOOLS"/journal-state get-log -u snapd | MATCH "429 Too Many Requests"; then
             echo "Store is reporting 429 (too many requests), skipping the test"
             exit 0
         fi


### PR DESCRIPTION
snap-advise spread test fails a lot with "429 Too many requests". This workaround skips the rest of the test if 429 is encountered.
