### PR TITLE
tests: apply workaround done for snap-advise-command to apt-hooks test

### DIFF
--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -16,7 +16,15 @@ execute: |
         fi
         sleep 1
     done
-    test -s /var/cache/snapd/commands.db
+
+    if ! stat /var/cache/snapd/commands.db; then
+        # workaround for misbehaving store
+        if "$TESTSTOOLS"/journal-state get-log -u snapd | MATCH "429 Too Many Requests"; then
+            echo "Store is reporting 429 (too many requests), skipping the test"
+            exit 0
+        fi
+        exit 1
+    fi
 
     echo "Creating expected file"
     cat > expected <<EOF


### PR DESCRIPTION
The same issue is faced on both tests: snap-advise-command and apt-hooks. 

The idea is to work around this when the store is misbehaving.
