### PR TITLE
cmd/snap-repair: save base snap and mode in device info; other misc cleanups

### DIFF
--- a/cmd/snap-repair/cmd_run_test.go
+++ b/cmd/snap-repair/cmd_run_test.go
@@ -87,7 +87,7 @@ func (r *repairSuite) TestRunAlreadyLocked(c *C) {
 	c.Assert(err, IsNil)
 	err = flock.Lock()
 	c.Assert(err, IsNil)
-	defer flock.Unlock()
+	defer flock.Close() // Close unlocks too
 
 	err = repair.ParseArgs([]string{"run"})
 	c.Check(err, ErrorMatches, `cannot run, another snap-repair run already executing`)

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -170,6 +170,8 @@ func (r *Repair) Run() error {
 		env = append(env, "PATH=/usr/sbin:/usr/bin:/sbin:/bin:"+repairToolsDir)
 	}
 
+	// TODO:UC20: add SNAPD_RECOVER_MODE if the repair assertion is for uc20
+
 	workdir := filepath.Join(rundir, "work")
 	if err := os.MkdirAll(workdir, 0700); err != nil {
 		return err
@@ -866,6 +868,10 @@ func (run *Runner) Applicable(headers map[string]interface{}) bool {
 			return false
 		}
 	}
+
+	// TODO:UC20: need to consider filtering by bases and modes in the assertion
+	// here
+
 	return true
 }
 
@@ -986,7 +992,8 @@ func (run *Runner) makeReady(brandID string, sequenceNext int) (repair *asserts.
 	return repair, nil
 }
 
-// Next returns the next repair for the brand id sequence to run/retry or ErrRepairNotFound if there is none atm. It updates the state as required.
+// Next returns the next repair for the brand id sequence to run/retry or
+// ErrRepairNotFound if there is none atm. It updates the state as required.
 func (run *Runner) Next(brandID string) (*Repair, error) {
 	sequenceNext := run.sequenceNext[brandID]
 	if sequenceNext == 0 {

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -866,22 +866,6 @@ func (s *runnerSuite) TestVerify(c *C) {
 	c.Check(err, IsNil)
 }
 
-func (s *runnerSuite) signSeqRepairs(c *C, repairs []string) []string {
-	var seq []string
-	for _, rpr := range repairs {
-		decoded, err := asserts.Decode([]byte(rpr))
-		c.Assert(err, IsNil)
-		signed, err := s.repairsSigning.Sign(asserts.RepairType, decoded.Headers(), decoded.Body(), "")
-		c.Assert(err, IsNil)
-		buf := &bytes.Buffer{}
-		enc := asserts.NewEncoder(buf)
-		enc.Encode(signed)
-		enc.Encode(s.repairsAcctKey)
-		seq = append(seq, buf.String())
-	}
-	return seq
-}
-
 func (s *runnerSuite) loadSequences(c *C) map[string][]*repair.RepairState {
 	data, err := ioutil.ReadFile(dirs.SnapRepairStateFile)
 	c.Assert(err, IsNil)

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -154,7 +154,7 @@ func (s *baseRunnerSuite) signSeqRepairs(c *C, repairs []string) []string {
 	return seq
 }
 
-const freshStateJSON = `{"device":{"brand":"my-brand","model":"my-model"},"time-lower-bound":"2017-08-11T15:49:49Z"}`
+const freshStateJSON = `{"device":{"brand":"my-brand","model":"my-model","base":"","mode":""},"time-lower-bound":"2017-08-11T15:49:49Z"}`
 
 func (s *baseRunnerSuite) freshState(c *C) {
 	err := os.MkdirAll(dirs.SnapRepairDir, 0775)
@@ -660,7 +660,7 @@ func (s *runnerSuite) TestSaveState(c *C) {
 	err = runner.SaveState()
 	c.Assert(err, IsNil)
 
-	c.Check(dirs.SnapRepairStateFile, testutil.FileEquals, `{"device":{"brand":"my-brand","model":"my-model"},"sequences":{"canonical":[{"sequence":1,"revision":3,"status":0}]},"time-lower-bound":"2017-08-11T15:49:49Z"}`)
+	c.Check(dirs.SnapRepairStateFile, testutil.FileEquals, `{"device":{"brand":"my-brand","model":"my-model","base":"","mode":""},"sequences":{"canonical":[{"sequence":1,"revision":3,"status":0}]},"time-lower-bound":"2017-08-11T15:49:49Z"}`)
 }
 
 func (s *runnerSuite) TestApplicable(c *C) {
@@ -1364,7 +1364,7 @@ AXNpZw==`, len(script), script)
 }
 
 func verifyRepairStatus(c *C, status repair.RepairStatus) {
-	c.Check(dirs.SnapRepairStateFile, testutil.FileContains, fmt.Sprintf(`{"device":{"brand":"","model":""},"sequences":{"canonical":[{"sequence":1,"revision":0,"status":%d}`, status))
+	c.Check(dirs.SnapRepairStateFile, testutil.FileContains, fmt.Sprintf(`{"device":{"brand":"","model":"","base":"","mode":""},"sequences":{"canonical":[{"sequence":1,"revision":0,"status":%d}`, status))
 }
 
 // tests related to correct execution of script
@@ -1786,6 +1786,7 @@ var _ = Suite(&runner20Suite{})
 var mockModeenv = []byte(`
 mode=run
 model=my-brand/my-model-2
+base=core20_1.snap
 `)
 
 func (s *runner20Suite) SetUpTest(c *C) {


### PR DESCRIPTION
This information will be used in a follow-up when we actually filter repair assertions by their `bases` and `modes` settings in the headers.