### PR TITLE
interfaces/builtin: Allow DBus property access on org.freedesktop.Notifications

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -110,6 +110,22 @@ dbus (receive)
     member={ActionInvoked,NotificationClosed,NotificationReplied}
     peer=(label=unconfined),
 
+# KDE Plasma's Inhibited property indicating "do not disturb" mode
+# https://invent.kde.org/plasma/plasma-workspace/-/blob/master/libnotificationmanager/dbus/org.freedesktop.Notifications.xml#L42
+dbus (send)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}"
+    peer=(label=unconfined),
+
+dbus (receive)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
 # DesktopAppInfo Launched
 dbus (send)
     bus=session

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -337,6 +337,22 @@ dbus (receive)
     member={ActionInvoked,NotificationClosed,NotificationReplied}
     peer=(label=unconfined),
 
+# KDE Plasma's Inhibited property indicating "do not disturb" mode
+# https://invent.kde.org/plasma/plasma-workspace/-/blob/master/libnotificationmanager/dbus/org.freedesktop.Notifications.xml#L42
+dbus (send)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}"
+    peer=(label=unconfined),
+
+dbus (receive)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
 dbus (send)
     bus=session
     path=/org/ayatana/NotificationItem/*

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -468,6 +468,22 @@ dbus (receive)
     member={ActionInvoked,NotificationClosed,NotificationReplied}
     peer=(label=unconfined),
 
+# KDE Plasma's Inhibited property indicating "do not disturb" mode
+# https://invent.kde.org/plasma/plasma-workspace/-/blob/master/libnotificationmanager/dbus/org.freedesktop.Notifications.xml#L42
+dbus (send)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}"
+    peer=(label=unconfined),
+
+dbus (receive)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
 dbus (send)
     bus=session
     path=/org/ayatana/NotificationItem/*


### PR DESCRIPTION
This allows access to e.g. the "Inhibited" property in KDE Plasma 5.16+ that indicates
whether "Do not disturb" mode is enabled.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

---
This is for example used by Telegram to turn off own notification popups and sounds when notifications are inhibited.