### PR TITLE
usersession/agent: change ~/snap perms to 0700 on startup

### DIFF
--- a/usersession/agent/export_test.go
+++ b/usersession/agent/export_test.go
@@ -20,6 +20,8 @@
 package agent
 
 import (
+	"fmt"
+	"os/user"
 	"syscall"
 	"time"
 )
@@ -49,4 +51,20 @@ func MockUcred(ucred *syscall.Ucred, err error) (restore func()) {
 	return func() {
 		sysGetsockoptUcred = old
 	}
+}
+
+func MockUserCurrent(f func() (*user.User, error)) (restore func()) {
+	old := userCurrent
+	userCurrent = f
+	return func() {
+		userCurrent = old
+	}
+}
+
+// when export_test.go is included in tests, override userCurrent to return an
+// error so we don't accidentally operate on the host's user dirs
+func init() {
+	MockUserCurrent(func() (*user.User, error) {
+		return nil, fmt.Errorf("user.Current not mocked in a test yet")
+	})
 }


### PR DESCRIPTION
Use the user session agent to change the permissions on ~/snap to protect all
files and data that snaps store in $SNAP_USER_DATA or $SNAP_USER_COMMON. Using
the user session agent means that we are already running as the right user to
perform this fix, and also means that the fix is applied whenever the system is
started.

Fixes: https://bugs.launchpad.net/snapd/+bug/1910298

Spread test to follow...

I made the choice not to create the snap dir if it doesn't already exist here mainly just to
avoid creating it for folks who don't use snaps, which AIUI the user session agent will still
run for them, even if they don't have any snaps.