### PR TITLE
store: switch to v2/assertions api

### DIFF
--- a/cmd/snap/cmd_known_test.go
+++ b/cmd/snap/cmd_known_test.go
@@ -138,7 +138,7 @@ func (s *SnapSuite) TestKnownRemoteDirect(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
-			c.Check(r.URL.Path, check.Equals, "/api/v1/snaps/assertions/model/16/canonical/pi99")
+			c.Check(r.URL.Path, check.Equals, "/v2/assertions/model/16/canonical/pi99")
 			fmt.Fprintln(w, mockModelAssertion)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
@@ -185,7 +185,7 @@ func (s *SnapSuite) TestKnownRemoteAutoFallback(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
-			c.Check(r.URL.Path, check.Equals, "/api/v1/snaps/assertions/model/16/canonical/pi99")
+			c.Check(r.URL.Path, check.Equals, "/v2/assertions/model/16/canonical/pi99")
 			fmt.Fprintln(w, mockModelAssertion)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)

--- a/store/store.go
+++ b/store/store.go
@@ -416,7 +416,7 @@ const (
 	deviceNonceEndpPath   = "api/v1/snaps/auth/nonces"
 	deviceSessionEndpPath = "api/v1/snaps/auth/sessions"
 
-	assertionsPath = "api/v1/snaps/assertions"
+	assertionsPath = "v2/assertions"
 )
 
 func (s *Store) newHTTPClient(opts *httputil.ClientOptions) *http.Client {

--- a/store/store_action_fetch_assertions_test.go
+++ b/store/store_action_fetch_assertions_test.go
@@ -111,7 +111,7 @@ func (s *storeActionFetchAssertionsSuite) TestFetch(c *C) {
      "result": "fetch-assertions",
      "key": "g1",
      "assertion-stream-urls": [
-        "https://api.snapcraft.io/api/v1/snaps/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5"
+        "https://api.snapcraft.io/v2/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5"
       ]
      }
    ]
@@ -150,7 +150,7 @@ func (s *storeActionFetchAssertionsSuite) TestFetch(c *C) {
 	c.Check(aresults, HasLen, 1)
 	c.Check(aresults[0].Grouping, Equals, asserts.Grouping("g1"))
 	c.Check(aresults[0].StreamURLs, DeepEquals, []string{
-		"https://api.snapcraft.io/api/v1/snaps/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
+		"https://api.snapcraft.io/v2/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
 	})
 }
 
@@ -218,7 +218,7 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateIfNewerThan(c *C) {
      "result": "fetch-assertions",
      "key": "g1",
      "assertion-stream-urls": [
-        "https://api.snapcraft.io/api/v1/snaps/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5"
+        "https://api.snapcraft.io/v2/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5"
       ]
      }, {
      "result": "fetch-assertions",
@@ -274,7 +274,7 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateIfNewerThan(c *C) {
 		if aresult.Grouping == asserts.Grouping("g1") {
 			seen++
 			c.Check(aresult.StreamURLs, DeepEquals, []string{
-				"https://api.snapcraft.io/api/v1/snaps/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
+				"https://api.snapcraft.io/v2/assertions/snap-declaration/16/iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
 			})
 		} else {
 			seen++

--- a/store/store_asserts.go
+++ b/store/store_asserts.go
@@ -45,13 +45,6 @@ func (s *Store) assertionsEndpointURL(p string, query url.Values) *url.URL {
 }
 
 type assertionSvcError struct {
-	// v1 error fields
-	// XXX: remove once switched to v2 API request.
-	Status int    `json:"status"`
-	Type   string `json:"type"`
-	Title  string `json:"title"`
-	Detail string `json:"detail"`
-
 	// v2 error list - the only field included in v2 error response.
 	// XXX: there is an overlap with searchV2Results (and partially with
 	// errorListEntry), we could share the definition.
@@ -62,7 +55,7 @@ type assertionSvcError struct {
 }
 
 func (e *assertionSvcError) isNotFound() bool {
-	return (len(e.ErrorList) > 0 && e.ErrorList[0].Code == "not-found" /* v2 error */) || e.Status == 404
+	return len(e.ErrorList) > 0 && e.ErrorList[0].Code == "not-found"
 }
 
 func (e *assertionSvcError) toError() error {
@@ -70,8 +63,7 @@ func (e *assertionSvcError) toError() error {
 	if len(e.ErrorList) > 0 {
 		return fmt.Errorf("assertion service error: %q", e.ErrorList[0].Message)
 	}
-	// v1 error
-	return fmt.Errorf("assertion service error: [%s] %q", e.Title, e.Detail)
+	return fmt.Errorf("unexpected assertion service error")
 }
 
 // Assertion retrieves the assertion for the given type and primary key.

--- a/store/store_asserts_test.go
+++ b/store/store_asserts_test.go
@@ -92,7 +92,7 @@ func (s *storeAssertsSuite) TestAssertion(c *C) {
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 88)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
+		assertRequest(c, r, "GET", "/v2/assertions/.*")
 		// check device authorization is set, implicitly checking doRequest was used
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
 
@@ -122,7 +122,7 @@ func (s *storeAssertsSuite) TestAssertionProxyStoreFromAuthContext(c *C) {
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 88)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
+		assertRequest(c, r, "GET", "/v2/assertions/.*")
 		// check device authorization is set, implicitly checking doRequest was used
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
 
@@ -155,40 +155,9 @@ func (s *storeAssertsSuite) TestAssertionProxyStoreFromAuthContext(c *C) {
 	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
 }
 
-func (s *storeAssertsSuite) TestAssertionNotFound(c *C) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
-		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
-		c.Check(r.URL.Path, Matches, ".*/snap-declaration/16/snapidfoo")
-		w.Header().Set("Content-Type", "application/problem+json")
-		w.WriteHeader(404)
-		io.WriteString(w, `{"status": 404,"title": "not found"}`)
-	}))
-
-	c.Assert(mockServer, NotNil)
-	defer mockServer.Close()
-
-	mockServerURL, _ := url.Parse(mockServer.URL)
-	cfg := store.Config{
-		AssertionsBaseURL: mockServerURL,
-	}
-	sto := store.New(&cfg, nil)
-
-	_, err := sto.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
-	c.Check(asserts.IsNotFound(err), Equals, true)
-	c.Check(err, DeepEquals, &asserts.NotFoundError{
-		Type: asserts.SnapDeclarationType,
-		Headers: map[string]string{
-			"series":  "16",
-			"snap-id": "snapidfoo",
-		},
-	})
-}
-
 func (s *storeAssertsSuite) TestAssertionNotFoundV2(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// XXX: update to v2 request
-		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
+		assertRequest(c, r, "GET", "/v2/assertions/.*")
 		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
 		c.Check(r.URL.Path, Matches, ".*/snap-declaration/16/snapidfoo")
 		w.Header().Set("Content-Type", "application/json")
@@ -219,7 +188,7 @@ func (s *storeAssertsSuite) TestAssertionNotFoundV2(c *C) {
 func (s *storeAssertsSuite) TestAssertion500(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
+		assertRequest(c, r, "GET", "/v2/assertions/.*")
 		n++
 		w.WriteHeader(500)
 	}))
@@ -403,7 +372,7 @@ func (s *storeAssertsSuite) TestDownloadAssertionsStreamNotFound(c *C) {
 		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(404)
-		io.WriteString(w, `{"status": 404,"title": "not found"}`)
+		io.WriteString(w, `{"error-list":[{"code":"not-found","message":"not found: no ..."}]}`)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -424,5 +393,5 @@ func (s *storeAssertsSuite) TestDownloadAssertionsStreamNotFound(c *C) {
 
 	b := asserts.NewBatch(nil)
 	err = sto.DownloadAssertions(urls, b, nil)
-	c.Assert(err, ErrorMatches, `assertion service error: \[not found\].*`)
+	c.Assert(err, ErrorMatches, `assertion service error: \"not found.*`)
 }

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -98,8 +98,8 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 	mux.HandleFunc("/api/v1/snaps/details/", store.detailsEndpoint)
 	mux.HandleFunc("/api/v1/snaps/metadata", store.bulkEndpoint)
 	mux.Handle("/download/", http.StripPrefix("/download/", http.FileServer(http.Dir(topDir))))
-	mux.HandleFunc("/api/v1/snaps/assertions/", store.assertionsEndpoint)
 	// v2
+	mux.HandleFunc("/v2/assertions/", store.assertionsEndpoint)
 	mux.HandleFunc("/v2/snaps/refresh", store.snapActionEndpoint)
 
 	return store
@@ -650,7 +650,7 @@ func (s *Store) retrieveAssertion(bs asserts.Backstore, assertType *asserts.Asse
 }
 
 func (s *Store) assertionsEndpoint(w http.ResponseWriter, req *http.Request) {
-	assertPath := strings.TrimPrefix(req.URL.Path, "/api/v1/snaps/assertions/")
+	assertPath := strings.TrimPrefix(req.URL.Path, "/v2/assertions/")
 
 	bs, err := s.collectAssertions()
 	if err != nil {
@@ -681,7 +681,7 @@ func (s *Store) assertionsEndpoint(w http.ResponseWriter, req *http.Request) {
 	if asserts.IsNotFound(err) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(404)
-		w.Write([]byte(`{"status": 404}`))
+		w.Write([]byte(`{"error-list":[{"code":"not-found","message":"not found"}]}`))
 		return
 	}
 	if err != nil {

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -403,7 +403,7 @@ AXNpZw=`
 
 func (s *storeTestSuite) TestAssertionsEndpointPreloaded(c *C) {
 	// something preloaded
-	resp, err := s.StoreGet(`/api/v1/snaps/assertions/account/testrootorg`)
+	resp, err := s.StoreGet(`/v2/assertions/account/testrootorg`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -424,7 +424,7 @@ func (s *storeTestSuite) TestAssertionsEndpointFromAssertsDir(c *C) {
 	err = ioutil.WriteFile(filepath.Join(s.store.assertDir, "foo_36.snap-revision"), []byte(exampleSnapRev), 0655)
 	c.Assert(err, IsNil)
 
-	resp, err := s.StoreGet(`/api/v1/snaps/assertions/snap-revision/` + rev.SnapSHA3_384())
+	resp, err := s.StoreGet(`/v2/assertions/snap-revision/` + rev.SnapSHA3_384())
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -436,7 +436,7 @@ func (s *storeTestSuite) TestAssertionsEndpointFromAssertsDir(c *C) {
 
 func (s *storeTestSuite) TestAssertionsEndpointNotFound(c *C) {
 	// something not found
-	resp, err := s.StoreGet(`/api/v1/snaps/assertions/account/not-an-account-id`)
+	resp, err := s.StoreGet(`/v2/assertions/account/not-an-account-id`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -446,7 +446,7 @@ func (s *storeTestSuite) TestAssertionsEndpointNotFound(c *C) {
 	var respObj map[string]interface{}
 	err = dec.Decode(&respObj)
 	c.Assert(err, IsNil)
-	c.Check(respObj["status"], Equals, float64(404))
+	c.Check(respObj["error-list"], DeepEquals, []interface{}{map[string]interface{}{"code":"not-found", "message":"not found"}})
 }
 
 func (s *storeTestSuite) TestSnapActionEndpoint(c *C) {


### PR DESCRIPTION
Switch to v2/assertions endpoint.
This has small regression potential (not just on our side, but also store - we weren't using this endpoint before).
