### PR TITLE
packaging: fix arch-indep build on debian-sid

### DIFF
--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -222,6 +222,8 @@ override_dh_install-indep:
 	rm -f ${CURDIR}/debian/tmp/usr/bin/snappy
 	# chrorder generator
 	rm -f ${CURDIR}/debian/tmp/usr/bin/chrorder
+	# bootloader assets generator
+	rm -f ${CURDIR}/debian/tmp/usr/bin/genasset
 	# docs generator
 	rm -f ${CURDIR}/debian/tmp/usr/bin/docs
 

--- a/tests/nightly/sbuild/task.yaml
+++ b/tests/nightly/sbuild/task.yaml
@@ -5,7 +5,7 @@ priority: 500
 
 environment:
     BUILD_MODE/normal: normal
-    BUILD_MODE/any: any
+    BUILD_MODE/all: all
 
 systems: [debian-sid-*]
 
@@ -16,9 +16,9 @@ execute: |
     echo "Allow test user to run sbuild"
     sbuild-adduser test
 
-    BUILD_PARAM="--verbose --debug"
-    if [ "$BUILD_MODE" == "any" ]; then
-        BUILD_PARAM="$BUILD_PARAM --arch-any"
+    BUILD_PARAM="--verbose"
+    if [ "$BUILD_MODE" == "all" ]; then
+        BUILD_PARAM="$BUILD_PARAM --arch-all --no-arch-any"
     fi
 
     echo "Build mode: $BUILD_MODE"


### PR DESCRIPTION
The clean of override_dh_install-indep was missing to remove
```
tmp/usr/bin/genasset
```
this is fixed now. The nightly sbuild test also needs to be
tweaked to *only* build the arch:all packages to reproduce
this bug.

I also removed --debug from sbuild as it's *really* verbose.
