### PR TITLE
osutil: update go-udev package

### DIFF
--- a/osutil/udev/.travis.yml
+++ b/osutil/udev/.travis.yml
@@ -1,7 +1,7 @@
 language: go
-  
+
 go:
-  - 1.9.x
+  - 1.x
   - master
 
 script:

--- a/osutil/udev/go.mod
+++ b/osutil/udev/go.mod
@@ -1,0 +1,5 @@
+module github.com/pilebones/go-udev
+
+go 1.15
+
+require github.com/kr/pretty v0.2.1

--- a/osutil/udev/netlink/conn.go
+++ b/osutil/udev/netlink/conn.go
@@ -41,7 +41,6 @@ func (c *UEventConn) Connect(mode Mode) (err error) {
 	c.Addr = syscall.SockaddrNetlink{
 		Family: syscall.AF_NETLINK,
 		Groups: uint32(mode),
-		Pid:    uint32(os.Getpid()),
 	}
 
 	if err = syscall.Bind(c.Fd, &c.Addr); err != nil {

--- a/osutil/udev/netlink/conn_test.go
+++ b/osutil/udev/netlink/conn_test.go
@@ -18,9 +18,8 @@ func TestConnect(t *testing.T) {
 	defer conn.Close()
 
 	conn2 := new(UEventConn)
-	if err := conn2.Connect(UdevEvent); err == nil {
-		// see issue: https://github.com/pilebones/go-udev/issues/3 by @stolowski
-		t.Fatal("can't subscribing a second time to netlink socket with PID", conn2.Addr.Pid)
+	if err := conn2.Connect(UdevEvent); err != nil {
+		t.Fatal("unable to subscribe to netlink uevent a second time, err:", err)
 	}
 	defer conn2.Close()
 }


### PR DESCRIPTION
Update go-udev package with upstream; the project isn't very active and in fact there are just 3 commits since we imported it into osutil, but they just fixed https://github.com/pilebones/go-udev/issues/3 which is good too have.

Updated with:
```
git subtree pull --prefix=osutil/udev http://github.com/pilebones/go-udev master
```