### PR TITLE
[RFC] systemd, many: no reload when enabling or disabling services

### DIFF
--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -92,7 +92,7 @@ func (s *backendSuite) TestInstallingSnapWritesStartsServices(c *C) {
 	// the service was also started (whee)
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"daemon-reload"},
-		{"enable", "snap.samba.interface.foo.service"},
+		{"--no-reload", "enable", "snap.samba.interface.foo.service"},
 		{"stop", "snap.samba.interface.foo.service"},
 		{"show", "--property=ActiveState", "snap.samba.interface.foo.service"},
 		{"start", "snap.samba.interface.foo.service"},
@@ -113,7 +113,7 @@ func (s *backendSuite) TestRemovingSnapRemovesAndStopsServices(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// the service was stopped
 		c.Check(s.systemctlArgs, DeepEquals, [][]string{
-			{"systemctl", "disable", "snap.samba.interface.foo.service"},
+			{"systemctl", "--no-reload", "disable", "snap.samba.interface.foo.service"},
 			{"systemctl", "stop", "snap.samba.interface.foo.service"},
 			{"systemctl", "show", "--property=ActiveState", "snap.samba.interface.foo.service"},
 			{"systemctl", "daemon-reload"},
@@ -147,7 +147,7 @@ func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 	s.UpdateSnap(c, snapInfo, interfaces.ConfinementOptions{}, ifacetest.SambaYamlV1, 0)
 	// The bar service should have been stopped
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
-		{"systemctl", "disable", "snap.samba.interface.bar.service"},
+		{"systemctl", "--no-reload", "disable", "snap.samba.interface.bar.service"},
 		{"systemctl", "stop", "snap.samba.interface.bar.service"},
 		{"systemctl", "show", "--property=ActiveState", "snap.samba.interface.bar.service"},
 		{"systemctl", "daemon-reload"},
@@ -180,7 +180,7 @@ func (s *backendSuite) TestInstallingSnapWhenPreseeding(c *C) {
 	c.Check(err, IsNil)
 	// the service was enabled but not started
 	c.Check(sysdLog, DeepEquals, [][]string{
-		{"--root", dirs.GlobalRootDir, "enable", "snap.samba.interface.foo.service"},
+		{"--root", dirs.GlobalRootDir, "--no-reload", "enable", "snap.samba.interface.foo.service"},
 	})
 }
 
@@ -203,7 +203,7 @@ func (s *backendSuite) TestRemovingSnapWhenPreseeding(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// the service was disabled (but no other systemctl calls)
 		c.Check(s.systemctlArgs, DeepEquals, [][]string{
-			{"systemctl", "--root", dirs.GlobalRootDir, "disable", "snap.samba.interface.foo.service"},
+			{"systemctl", "--root", dirs.GlobalRootDir, "--no-reload", "disable", "snap.samba.interface.foo.service"},
 		})
 	}
 }

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -70,7 +70,7 @@ func (s *servicesSuite) TestConfigureServiceNotDisabled(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
 		{"--root", dirs.GlobalRootDir, "unmask", "sshd.service"},
-		{"--root", dirs.GlobalRootDir, "enable", "sshd.service"},
+		{"--root", dirs.GlobalRootDir, "--no-reload", "enable", "sshd.service"},
 		{"start", "sshd.service"},
 	})
 }
@@ -79,7 +79,7 @@ func (s *servicesSuite) TestConfigureServiceDisabled(c *C) {
 	err := configcore.SwitchDisableService("sshd.service", true, nil)
 	c.Assert(err, IsNil)
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
-		{"--root", dirs.GlobalRootDir, "disable", "sshd.service"},
+		{"--root", dirs.GlobalRootDir, "--no-reload", "disable", "sshd.service"},
 		{"--root", dirs.GlobalRootDir, "mask", "sshd.service"},
 		{"stop", "sshd.service"},
 		{"show", "--property=ActiveState", "sshd.service"},
@@ -121,7 +121,7 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 			})
 		default:
 			c.Check(s.systemctlArgs, DeepEquals, [][]string{
-				{"--root", dirs.GlobalRootDir, "disable", srv},
+				{"--root", dirs.GlobalRootDir, "--no-reload", "disable", srv},
 				{"--root", dirs.GlobalRootDir, "mask", srv},
 				{"stop", srv},
 				{"show", "--property=ActiveState", srv},
@@ -291,7 +291,7 @@ func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
 		default:
 			c.Check(s.systemctlArgs, DeepEquals, [][]string{
 				{"--root", dirs.GlobalRootDir, "unmask", srv},
-				{"--root", dirs.GlobalRootDir, "enable", srv},
+				{"--root", dirs.GlobalRootDir, "--no-reload", "enable", srv},
 				{"start", srv},
 			})
 		}

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -102,7 +102,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithValidSnap(c *C) {
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
 		{"is-enabled", "snap.test-snap.foo.service"},
 		{"daemon-reload"},
-		{"enable", "snap.test-snap.foo.service"},
+		{"--no-reload", "enable", "snap.test-snap.foo.service"},
 		{"start", "snap.test-snap.foo.service"},
 	})
 	svcPath := filepath.Join(dirs.SnapServicesDir, svcName)

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -610,7 +610,7 @@ func (s *serviceControlSuite) TestStartEnableServices(c *C) {
 
 	c.Assert(t.Status(), Equals, state.DoneStatus)
 	c.Check(s.sysctlArgs, DeepEquals, [][]string{
-		{"enable", "snap.test-snap.foo.service"},
+		{"--no-reload", "enable", "snap.test-snap.foo.service"},
 		{"start", "snap.test-snap.foo.service"},
 	})
 }
@@ -638,9 +638,9 @@ func (s *serviceControlSuite) TestStartEnableMultipleServices(c *C) {
 
 	c.Assert(t.Status(), Equals, state.DoneStatus)
 	c.Check(s.sysctlArgs, DeepEquals, [][]string{
-		{"enable", "snap.test-snap.foo.service"},
-		{"enable", "snap.test-snap.bar.service"},
-		{"enable", "snap.test-snap.abc.service"},
+		{"--no-reload", "enable", "snap.test-snap.foo.service"},
+		{"--no-reload", "enable", "snap.test-snap.bar.service"},
+		{"--no-reload", "enable", "snap.test-snap.abc.service"},
 		{"start", "snap.test-snap.foo.service"},
 		{"start", "snap.test-snap.bar.service"},
 		{"start", "snap.test-snap.abc.service"},
@@ -701,7 +701,7 @@ func (s *serviceControlSuite) TestStopDisableServices(c *C) {
 	c.Check(s.sysctlArgs, DeepEquals, [][]string{
 		{"stop", "snap.test-snap.foo.service"},
 		{"show", "--property=ActiveState", "snap.test-snap.foo.service"},
-		{"disable", "snap.test-snap.foo.service"},
+		{"--no-reload", "disable", "snap.test-snap.foo.service"},
 	})
 }
 

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -49,12 +49,12 @@ func (s *emulation) DaemonReexec() error {
 }
 
 func (s *emulation) Enable(service string) error {
-	_, err := systemctlCmd("--root", s.rootDir, "enable", service)
+	_, err := systemctlCmd("--root", s.rootDir, "--no-reload", "enable", service)
 	return err
 }
 
 func (s *emulation) Disable(service string) error {
-	_, err := systemctlCmd("--root", s.rootDir, "disable", service)
+	_, err := systemctlCmd("--root", s.rootDir, "--no-reload", "disable", service)
 	return err
 }
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -365,9 +365,9 @@ func (s *systemd) DaemonReexec() error {
 func (s *systemd) Enable(serviceName string) error {
 	var err error
 	if s.rootDir != "" {
-		_, err = s.systemctl("--root", s.rootDir, "enable", serviceName)
+		_, err = s.systemctl("--root", s.rootDir, "--no-reload", "enable", serviceName)
 	} else {
-		_, err = s.systemctl("enable", serviceName)
+		_, err = s.systemctl("--no-reload", "enable", serviceName)
 	}
 	return err
 }
@@ -385,9 +385,9 @@ func (s *systemd) Unmask(serviceName string) error {
 func (s *systemd) Disable(serviceName string) error {
 	var err error
 	if s.rootDir != "" {
-		_, err = s.systemctl("--root", s.rootDir, "disable", serviceName)
+		_, err = s.systemctl("--root", s.rootDir, "--no-reload", "disable", serviceName)
 	} else {
-		_, err = s.systemctl("disable", serviceName)
+		_, err = s.systemctl("--no-reload", "disable", serviceName)
 	}
 	return err
 }

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -388,13 +388,13 @@ func (s *SystemdTestSuite) TestStopTimeout(c *C) {
 func (s *SystemdTestSuite) TestDisable(c *C) {
 	err := New(SystemMode, s.rep).Disable("foo")
 	c.Assert(err, IsNil)
-	c.Check(s.argses, DeepEquals, [][]string{{"disable", "foo"}})
+	c.Check(s.argses, DeepEquals, [][]string{{"--no-reload", "disable", "foo"}})
 }
 
 func (s *SystemdTestSuite) TestUnderRootDisable(c *C) {
 	err := NewUnderRoot("xyzzy", SystemMode, s.rep).Disable("foo")
 	c.Assert(err, IsNil)
-	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "disable", "foo"}})
+	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "--no-reload", "disable", "foo"}})
 }
 
 func (s *SystemdTestSuite) TestAvailable(c *C) {
@@ -442,13 +442,13 @@ func (s *SystemdTestSuite) TestVersion(c *C) {
 func (s *SystemdTestSuite) TestEnable(c *C) {
 	err := New(SystemMode, s.rep).Enable("foo")
 	c.Assert(err, IsNil)
-	c.Check(s.argses, DeepEquals, [][]string{{"enable", "foo"}})
+	c.Check(s.argses, DeepEquals, [][]string{{"--no-reload", "enable", "foo"}})
 }
 
 func (s *SystemdTestSuite) TestEnableUnderRoot(c *C) {
 	err := NewUnderRoot("xyzzy", SystemMode, s.rep).Enable("foo")
 	c.Assert(err, IsNil)
-	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "enable", "foo"}})
+	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "--no-reload", "enable", "foo"}})
 }
 
 func (s *SystemdTestSuite) TestMask(c *C) {
@@ -600,7 +600,7 @@ WantedBy=multi-user.target
 
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
-		{"--root", rootDir, "enable", "snap-snapname-123.mount"},
+		{"--root", rootDir, "--no-reload", "enable", "snap-snapname-123.mount"},
 		{"start", "snap-snapname-123.mount"},
 	})
 }
@@ -633,7 +633,7 @@ WantedBy=multi-user.target
 
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
-		{"enable", "snap-snapname-x1.mount"},
+		{"--no-reload", "enable", "snap-snapname-x1.mount"},
 		{"start", "snap-snapname-x1.mount"},
 	})
 }
@@ -858,7 +858,7 @@ func (s *SystemdTestSuite) TestRemoveMountUnit(c *C) {
 	c.Check(osutil.FileExists(mountUnit), Equals, false)
 	// and the unit is disabled and the daemon reloaded
 	c.Check(s.argses, DeepEquals, [][]string{
-		{"--root", rootDir, "disable", "snap-foo-42.mount"},
+		{"--root", rootDir, "--no-reload", "disable", "snap-foo-42.mount"},
 		{"daemon-reload"},
 	})
 }
@@ -909,7 +909,7 @@ func (s *SystemdTestSuite) TestUserMode(c *C) {
 	sysd := NewUnderRoot(rootDir, UserMode, nil)
 
 	c.Assert(sysd.Enable("foo"), IsNil)
-	c.Check(s.argses[0], DeepEquals, []string{"--user", "--root", rootDir, "enable", "foo"})
+	c.Check(s.argses[0], DeepEquals, []string{"--user", "--root", rootDir, "--no-reload", "enable", "foo"})
 	c.Assert(sysd.Start("foo"), IsNil)
 	c.Check(s.argses[1], DeepEquals, []string{"--user", "start", "foo"})
 }
@@ -919,9 +919,9 @@ func (s *SystemdTestSuite) TestGlobalUserMode(c *C) {
 	sysd := NewUnderRoot(rootDir, GlobalUserMode, nil)
 
 	c.Assert(sysd.Enable("foo"), IsNil)
-	c.Check(s.argses[0], DeepEquals, []string{"--user", "--global", "--root", rootDir, "enable", "foo"})
+	c.Check(s.argses[0], DeepEquals, []string{"--user", "--global", "--root", rootDir, "--no-reload", "enable", "foo"})
 	c.Assert(sysd.Disable("foo"), IsNil)
-	c.Check(s.argses[1], DeepEquals, []string{"--user", "--global", "--root", rootDir, "disable", "foo"})
+	c.Check(s.argses[1], DeepEquals, []string{"--user", "--global", "--root", rootDir, "--no-reload", "disable", "foo"})
 	c.Assert(sysd.Mask("foo"), IsNil)
 	c.Check(s.argses[2], DeepEquals, []string{"--user", "--global", "--root", rootDir, "mask", "foo"})
 	c.Assert(sysd.Unmask("foo"), IsNil)
@@ -1096,8 +1096,8 @@ func (s *SystemdTestSuite) TestEnableInEmulationMode(c *C) {
 	sysd = NewEmulationMode("")
 	c.Assert(sysd.Enable("bar"), IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{
-		{"--root", "/path", "enable", "foo"},
-		{"--root", dirs.GlobalRootDir, "enable", "bar"}})
+		{"--root", "/path", "--no-reload", "enable", "foo"},
+		{"--root", dirs.GlobalRootDir, "--no-reload", "enable", "bar"}})
 }
 
 func (s *SystemdTestSuite) TestDisableInEmulationMode(c *C) {
@@ -1105,7 +1105,7 @@ func (s *SystemdTestSuite) TestDisableInEmulationMode(c *C) {
 	c.Assert(sysd.Disable("foo"), IsNil)
 
 	c.Check(s.argses, DeepEquals, [][]string{
-		{"--root", "/path", "disable", "foo"}})
+		{"--root", "/path", "--no-reload", "disable", "foo"}})
 }
 
 func (s *SystemdTestSuite) TestMaskInEmulationMode(c *C) {

--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -175,7 +175,7 @@ WantedBy=snapd.service
 	// check the systemctl calls
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"daemon-reload"},
-		{"enable", "usr-lib-snapd.mount"},
+		{"--no-reload", "enable", "usr-lib-snapd.mount"},
 		{"stop", "usr-lib-snapd.mount"},
 		{"show", "--property=ActiveState", "usr-lib-snapd.mount"},
 		{"start", "usr-lib-snapd.mount"},
@@ -185,7 +185,7 @@ WantedBy=snapd.service
 		{"is-enabled", "snapd.snap-repair.timer"},
 		// test pretends snapd.socket is disabled and needs enabling
 		{"is-enabled", "snapd.socket"},
-		{"enable", "snapd.socket"},
+		{"--no-reload", "enable", "snapd.socket"},
 		{"is-enabled", "snapd.system-shutdown.service"},
 		{"is-active", "snapd.autoimport.service"},
 		{"stop", "snapd.autoimport.service"},
@@ -199,10 +199,10 @@ WantedBy=snapd.service
 		{"start", "snapd.service"},
 		{"start", "--no-block", "snapd.seeded.service"},
 		{"start", "--no-block", "snapd.autoimport.service"},
-		{"--user", "--global", "disable", "snapd.session-agent.service"},
-		{"--user", "--global", "enable", "snapd.session-agent.service"},
-		{"--user", "--global", "disable", "snapd.session-agent.socket"},
-		{"--user", "--global", "enable", "snapd.session-agent.socket"},
+		{"--user", "--global", "--no-reload", "disable", "snapd.session-agent.service"},
+		{"--user", "--global", "--no-reload", "enable", "snapd.session-agent.service"},
+		{"--user", "--global", "--no-reload", "disable", "snapd.session-agent.socket"},
+		{"--user", "--global", "--no-reload", "enable", "snapd.session-agent.socket"},
 	})
 }
 
@@ -349,14 +349,14 @@ func (s *servicesTestSuite) TestRemoveSnapServicesForFirstInstallSnapdOnCore(c *
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		// pretend snapd socket needs enabling
 		{"--root", dirs.GlobalRootDir, "is-enabled", "snapd.socket"},
-		{"--root", dirs.GlobalRootDir, "enable", "snapd.socket"},
+		{"--root", dirs.GlobalRootDir, "--no-reload", "enable", "snapd.socket"},
 
 		{"--root", dirs.GlobalRootDir, "is-enabled", "snapd.autoimport.service"},
 		{"--root", dirs.GlobalRootDir, "is-active", "snapd.autoimport.service"},
 		{"stop", "snapd.autoimport.service"},
 		{"show", "--property=ActiveState", "snapd.autoimport.service"},
 		{"start", "snapd.autoimport.service"},
-		{"--root", dirs.GlobalRootDir, "disable", "snapd.not-in-core.service"},
+		{"--root", dirs.GlobalRootDir, "--no-reload", "disable", "snapd.not-in-core.service"},
 		{"stop", "snapd.not-in-core.service"},
 		{"show", "--property=ActiveState", "snapd.not-in-core.service"},
 		{"--root", dirs.GlobalRootDir, "is-enabled", "snapd.service"},
@@ -366,11 +366,11 @@ func (s *servicesTestSuite) TestRemoveSnapServicesForFirstInstallSnapdOnCore(c *
 		{"stop", "snapd.snap-repair.timer"},
 		{"show", "--property=ActiveState", "snapd.snap-repair.timer"},
 		{"start", "snapd.snap-repair.timer"},
-		{"--user", "--global", "--root", dirs.GlobalRootDir, "disable", "snapd.session-agent.service"},
-		{"--user", "--global", "--root", dirs.GlobalRootDir, "enable", "snapd.session-agent.service"},
-		{"--user", "--global", "--root", dirs.GlobalRootDir, "disable", "snapd.session-agent.socket"},
-		{"--user", "--global", "--root", dirs.GlobalRootDir, "enable", "snapd.session-agent.socket"},
-		{"--root", dirs.GlobalRootDir, "disable", "usr-lib-snapd.mount"},
+		{"--user", "--global", "--root", dirs.GlobalRootDir, "--no-reload", "disable", "snapd.session-agent.service"},
+		{"--user", "--global", "--root", dirs.GlobalRootDir, "--no-reload", "enable", "snapd.session-agent.service"},
+		{"--user", "--global", "--root", dirs.GlobalRootDir, "--no-reload", "disable", "snapd.session-agent.socket"},
+		{"--user", "--global", "--root", dirs.GlobalRootDir, "--no-reload", "enable", "snapd.session-agent.socket"},
+		{"--root", dirs.GlobalRootDir, "--no-reload", "disable", "usr-lib-snapd.mount"},
 		{"stop", "usr-lib-snapd.mount"},
 		{"show", "--property=ActiveState", "usr-lib-snapd.mount"},
 	})


### PR DESCRIPTION
Daemon reload is a very expensive operation, that comprises of systemd dumping
all of its state and performing a cold start, by reloading everything from disk
and rerunning all generators. On a slow device it can easily take significant
time, rendering the system barely usable.

While installing snaps or adding snap services, snapd would perform multiple
implicit reloads by calling systemctl enable/disable without --no-reload flag.

cc @kubiko 
