### PR TITLE
cgroup-support.c: fix link to CGROUP DELEGATION

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -77,7 +77,7 @@ static const char *cgroup_dir = "/sys/fs/cgroup";
 
 // Detect if we are running in cgroup v2 unified mode (as opposed to
 // hybrid or legacy) The algorithm is described in
-// https://systemd.io/CGROUP_DELEGATION.html
+// https://systemd.io/CGROUP_DELEGATION/
 bool sc_cgroup_is_v2() {
     static bool did_warn = false;
     struct statfs buf;


### PR DESCRIPTION
The old one lead to 404.