### PR TITLE
tests/main/snap-network-errors: skip flushing dns cache on centos-7

### DIFF
--- a/tests/main/snap-network-errors/task.yaml
+++ b/tests/main/snap-network-errors/task.yaml
@@ -20,12 +20,15 @@ execute: |
 
     echo "Disabling DNS queries"
     iptables -I OUTPUT -p udp --dport 53 -j REJECT --reject-with icmp-port-unreachable
-    if systemctl is-active systemd-resolved; then
-        if command -v resolvectl ; then
-            resolvectl flush-caches
-        else
-            # before systemd 239, the tool was named systemd-resolve
-            systemd-resolve --flush-caches
+    # centos 7 doesn't support caching dns, so no flushing required
+    if [ "$SPREAD_SYSTEM" != "centos-7-64" ]; then
+        if systemctl is-active systemd-resolved; then
+            if command -v resolvectl ; then
+                resolvectl flush-caches
+            else
+                # before systemd 239, the tool was named systemd-resolve
+                systemd-resolve --flush-caches
+            fi
         fi
     fi
 


### PR DESCRIPTION
Centos 7 doesn't seem to have any local DNS caching, so just skip the part of
the test that flushes the cache.