### PR TITLE
o/snapshotstate: fix returning of snap names when duplicated snapshot is detected

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -692,7 +692,8 @@ func writeOneSnapshotFile(targetPath string, tr io.Reader) error {
 }
 
 type DuplicatedSnapshotImportError struct {
-	SetID uint64
+	SetID     uint64
+	SnapNames []string
 }
 
 func (e DuplicatedSnapshotImportError) Error() string {
@@ -721,7 +722,11 @@ func checkDuplicatedSnapshotSetWithContentHash(ctx context.Context, contentHash 
 			return fmt.Errorf("cannot calculate content hash for %v: %v", setID, err)
 		}
 		if bytes.Equal(h, contentHash) {
-			return DuplicatedSnapshotImportError{setID}
+			var snapNames []string
+			for _, snapshot := range ss.Snapshots {
+				snapNames = append(snapNames, snapshot.Snap)
+			}
+			return DuplicatedSnapshotImportError{SetID: setID, SnapNames: snapNames}
 		}
 	}
 	return nil

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -1016,7 +1016,7 @@ func (s *snapshotSuite) TestImportDuplicated(c *check.C) {
 	_, err = backend.Import(ctx, 123, buf)
 	dupErr, ok := err.(backend.DuplicatedSnapshotImportError)
 	c.Assert(ok, check.Equals, true)
-	c.Assert(dupErr, check.DeepEquals, backend.DuplicatedSnapshotImportError{SetID: shID})
+	c.Assert(dupErr, check.DeepEquals, backend.DuplicatedSnapshotImportError{SetID: shID, SnapNames: []string{"hello-snap"}})
 }
 
 func (s *snapshotSuite) TestImportExportRoundtrip(c *check.C) {

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -338,7 +338,7 @@ func Import(ctx context.Context, st *state.State, r io.Reader) (setID uint64, sn
 			if err := removeSnapshotState(st, dupErr.SetID); err != nil {
 				return 0, nil, err
 			}
-			return dupErr.SetID, snapNames, nil
+			return dupErr.SetID, dupErr.SnapNames, nil
 		}
 		return 0, nil, err
 	}

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -1641,7 +1641,7 @@ func (snapshotSuite) TestImportSnapshotDuplicate(c *check.C) {
 	st := state.New(nil)
 
 	restore := snapshotstate.MockBackendImport(func(ctx context.Context, id uint64, r io.Reader) ([]string, error) {
-		return nil, backend.DuplicatedSnapshotImportError{SetID: 3}
+		return nil, backend.DuplicatedSnapshotImportError{SetID: 3, SnapNames: []string{"foo-snap"}}
 	})
 	defer restore()
 
@@ -1652,9 +1652,10 @@ func (snapshotSuite) TestImportSnapshotDuplicate(c *check.C) {
 	})
 	st.Unlock()
 
-	sid, _, err := snapshotstate.Import(context.TODO(), st, bytes.NewBufferString(""))
+	sid, snapNames, err := snapshotstate.Import(context.TODO(), st, bytes.NewBufferString(""))
 	c.Assert(err, check.IsNil)
 	c.Check(sid, check.Equals, uint64(3))
+	c.Check(snapNames, check.DeepEquals, []string{"foo-snap"})
 
 	st.Lock()
 	defer st.Unlock()


### PR DESCRIPTION
The detection and handling of duplicated snapshot and returning the id of the original snapshot has a subtle bug, it doesn't return affected snap names correctly. This wasn't noticed because unit test wasn't good enough, and on the outside (snapshotstate.go line 341) it looked like it did return snap names. This PR fixes this.