### PR TITLE
gadget: enable multi-volume uc20 gadgets in  LaidOutSystemVolumeFromGadget; rename too

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -937,32 +937,45 @@ func IsCompatible(current, new *Info) error {
 	return nil
 }
 
-// LaidOutVolumeFromGadget takes a gadget rootdir and lays out the
-// partitions as specified.
-func LaidOutVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolume, error) {
-	info, err := ReadInfo(gadgetRoot, model)
+// LaidOutUbuntuVolumeFromGadget takes a gadget rootdir and lays out the
+// partitions as specified. It returns one specific volume, which is the volume
+// on which ubuntu-* roles/partitions exist, all other volumes are assumed to
+// already be flashed and managed separately at image build/flash time, while
+// the ubuntu-* roles can be manipulated on the returned volume during install
+// mode.
+func LaidOutUbuntuVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolume, error) {
+	// rely on the basic validation from ReadInfo to ensure that the ubuntu-*
+	// roles are all on the same volume for example
+	info, err := ReadInfoAndValidate(gadgetRoot, model, nil)
 	if err != nil {
 		return nil, err
-	}
-	// Limit ourselves to just one volume for now.
-	if len(info.Volumes) != 1 {
-		return nil, fmt.Errorf("cannot position multiple volumes yet")
 	}
 
 	constraints := LayoutConstraints{
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-		SectorSize:        512,
+		// TODO:UC20: make SectorSize dynamic, either through config in the
+		//            gadget or by dynamic detection
+		SectorSize: sectorSize,
 	}
 
+	// find the volume with the ubuntu-boot role on it, we already validated
+	// that the ubuntu-* roles are all on the same volume
 	for _, vol := range info.Volumes {
-		pvol, err := LayoutVolume(gadgetRoot, vol, constraints)
-		if err != nil {
-			return nil, err
+		for _, structure := range vol.Structure {
+			// use the system-boot role
+			if structure.Role == SystemBoot || structure.Label == SystemBoot {
+				pvol, err := LayoutVolume(gadgetRoot, vol, constraints)
+				if err != nil {
+					return nil, err
+				}
+
+				return pvol, nil
+			}
 		}
-		// we know  info.Volumes map has size 1 so we can return here
-		return pvol, nil
 	}
-	return nil, fmt.Errorf("internal error in PositionedVolumeFromGadget: this line cannot be reached")
+
+	// this should be impossible, the validation above should ensure this
+	return nil, fmt.Errorf("internal error: gadget passed validation but does not have ubuntu-* roles on any volume")
 }
 
 func flatten(path string, cfg interface{}, out map[string]interface{}) {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -958,8 +958,8 @@ func LaidOutSystemVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolu
 		SectorSize: sectorSize,
 	}
 
-	// find the volume with the ubuntu-boot role on it, we already validated
-	// that the ubuntu-* roles are all on the same volume
+	// find the volume with the system-boot role on it, we already validated
+	// that the system-* roles are all on the same volume
 	for _, vol := range info.Volumes {
 		for _, structure := range vol.Structure {
 			// use the system-boot role

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -944,6 +944,10 @@ func IsCompatible(current, new *Info) error {
 // the ubuntu-* roles can be manipulated on the returned volume during install
 // mode.
 func LaidOutSystemVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolume, error) {
+	// model should never be nil here
+	if model == nil {
+		return nil, fmt.Errorf("internal error: must have model to lay out system volumes from a gadget")
+	}
 	// rely on the basic validation from ReadInfo to ensure that the ubuntu-*
 	// roles are all on the same volume for example
 	info, err := ReadInfoAndValidate(gadgetRoot, model, nil)
@@ -963,7 +967,7 @@ func LaidOutSystemVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolu
 	for _, vol := range info.Volumes {
 		for _, structure := range vol.Structure {
 			// use the system-boot role
-			if structure.Role == SystemBoot || structure.Label == SystemBoot {
+			if structure.Role == SystemBoot {
 				pvol, err := LayoutVolume(gadgetRoot, vol, constraints)
 				if err != nil {
 					return nil, err

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -937,13 +937,13 @@ func IsCompatible(current, new *Info) error {
 	return nil
 }
 
-// LaidOutUbuntuVolumeFromGadget takes a gadget rootdir and lays out the
+// LaidOutSystemVolumeFromGadget takes a gadget rootdir and lays out the
 // partitions as specified. It returns one specific volume, which is the volume
-// on which ubuntu-* roles/partitions exist, all other volumes are assumed to
+// on which system-* roles/partitions exist, all other volumes are assumed to
 // already be flashed and managed separately at image build/flash time, while
 // the ubuntu-* roles can be manipulated on the returned volume during install
 // mode.
-func LaidOutUbuntuVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolume, error) {
+func LaidOutSystemVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolume, error) {
 	// rely on the basic validation from ReadInfo to ensure that the ubuntu-*
 	// roles are all on the same volume for example
 	info, err := ReadInfoAndValidate(gadgetRoot, model, nil)
@@ -975,7 +975,7 @@ func LaidOutUbuntuVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolu
 	}
 
 	// this should be impossible, the validation above should ensure this
-	return nil, fmt.Errorf("internal error: gadget passed validation but does not have ubuntu-* roles on any volume")
+	return nil, fmt.Errorf("internal error: gadget passed validation but does not have system-* roles on any volume")
 }
 
 func flatten(path string, cfg interface{}, out map[string]interface{}) {

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2017,11 +2017,11 @@ func (s *gadgetYamlTestSuite) TestGadgetFromMetaEmpty(c *C) {
 	c.Assert(giCore, IsNil)
 }
 
-func (s *gadgetYamlTestSuite) TestLaidOutUbuntuVolumeFromGadgetMultiVolume(c *C) {
+func (s *gadgetYamlTestSuite) TestLaidOutSystemVolumeFromGadgetMultiVolume(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, mockMultiVolumeUC20GadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
-	lv, err := gadget.LaidOutUbuntuVolumeFromGadget(s.dir, uc20Mod)
+	lv, err := gadget.LaidOutSystemVolumeFromGadget(s.dir, uc20Mod)
 	c.Assert(err, IsNil)
 
 	c.Assert(lv.Volume.Bootloader, Equals, "u-boot")
@@ -2029,7 +2029,7 @@ func (s *gadgetYamlTestSuite) TestLaidOutUbuntuVolumeFromGadgetMultiVolume(c *C)
 	c.Assert(lv.LaidOutStructure, HasLen, 4)
 }
 
-func (s *gadgetYamlTestSuite) TestLaidOutUbuntuVolumeFromGadgetHappy(c *C) {
+func (s *gadgetYamlTestSuite) TestLaidOutSystemVolumeFromGadgetHappy(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
 	c.Assert(err, IsNil)
 	for _, fn := range []string{"pc-boot.img", "pc-core.img"} {
@@ -2037,14 +2037,14 @@ func (s *gadgetYamlTestSuite) TestLaidOutUbuntuVolumeFromGadgetHappy(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	lv, err := gadget.LaidOutUbuntuVolumeFromGadget(s.dir, nil)
+	lv, err := gadget.LaidOutSystemVolumeFromGadget(s.dir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(lv.Volume.Bootloader, Equals, "grub")
 	// mbr, bios-boot, efi-system
 	c.Assert(lv.LaidOutStructure, HasLen, 3)
 }
 
-func (s *gadgetYamlTestSuite) TestLaidOutUbuntuVolumeFromGadgetUC20Happy(c *C) {
+func (s *gadgetYamlTestSuite) TestLaidOutSystemVolumeFromGadgetUC20Happy(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlUC20PC, 0644)
 	c.Assert(err, IsNil)
 	for _, fn := range []string{"pc-boot.img", "pc-core.img"} {
@@ -2052,7 +2052,7 @@ func (s *gadgetYamlTestSuite) TestLaidOutUbuntuVolumeFromGadgetUC20Happy(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	lv, err := gadget.LaidOutUbuntuVolumeFromGadget(s.dir, uc20Mod)
+	lv, err := gadget.LaidOutSystemVolumeFromGadget(s.dir, uc20Mod)
 	c.Assert(err, IsNil)
 	c.Assert(lv.Volume.Bootloader, Equals, "grub")
 	// mbr, bios-boot, ubuntu-seed, ubuntu-save, ubuntu-boot, and ubuntu-data

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2037,11 +2037,25 @@ func (s *gadgetYamlTestSuite) TestLaidOutSystemVolumeFromGadgetHappy(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	lv, err := gadget.LaidOutSystemVolumeFromGadget(s.dir, nil)
+	lv, err := gadget.LaidOutSystemVolumeFromGadget(s.dir, coreMod)
 	c.Assert(err, IsNil)
 	c.Assert(lv.Volume.Bootloader, Equals, "grub")
 	// mbr, bios-boot, efi-system
 	c.Assert(lv.LaidOutStructure, HasLen, 3)
+}
+
+func (s *gadgetYamlTestSuite) TestLaidOutSystemVolumeFromGadgetNeedsModel(c *C) {
+	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
+	c.Assert(err, IsNil)
+	for _, fn := range []string{"pc-boot.img", "pc-core.img"} {
+		err = ioutil.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
+		c.Assert(err, IsNil)
+	}
+
+	// need the model in order to lay out system volumes due to the verification
+	// and other metadata we use with the gadget
+	_, err = gadget.LaidOutSystemVolumeFromGadget(s.dir, nil)
+	c.Assert(err, ErrorMatches, "internal error: must have model to lay out system volumes from a gadget")
 }
 
 func (s *gadgetYamlTestSuite) TestLaidOutSystemVolumeFromGadgetUC20Happy(c *C) {

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -20,11 +20,9 @@
 package install
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/snapcore/snapd/gadget"
-	"github.com/snapcore/snapd/gadget/quantity"
 )
 
 var (
@@ -70,34 +68,4 @@ func MockEnsureNodesExist(f func(dss []gadget.OnDiskStructure, timeout time.Dura
 	return func() {
 		ensureNodesExist = old
 	}
-}
-
-// LaidOutVolumeFromGadget takes a gadget rootdir and lays out the
-// partitions as specified. This function does not handle multiple volumes and
-// is meant for test helpers only. For runtime users, with multiple volumes
-// handled by choosing the ubuntu-* role volume, see LaidOutUbuntuVolumeFromGadget
-func LaidOutVolumeFromGadget(gadgetRoot string, model gadget.Model) (*gadget.LaidOutVolume, error) {
-	info, err := gadget.ReadInfo(gadgetRoot, model)
-	if err != nil {
-		return nil, err
-	}
-	// Limit ourselves to just one volume for now.
-	if len(info.Volumes) != 1 {
-		return nil, fmt.Errorf("cannot position multiple volumes yet")
-	}
-
-	constraints := gadget.LayoutConstraints{
-		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-		SectorSize:        512,
-	}
-
-	for _, vol := range info.Volumes {
-		pvol, err := gadget.LayoutVolume(gadgetRoot, vol, constraints)
-		if err != nil {
-			return nil, err
-		}
-		// we know  info.Volumes map has size 1 so we can return here
-		return pvol, nil
-	}
-	return nil, fmt.Errorf("internal error in PositionedVolumeFromGadget: this line cannot be reached")
 }

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -20,9 +20,11 @@
 package install
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/quantity"
 )
 
 var (
@@ -68,4 +70,34 @@ func MockEnsureNodesExist(f func(dss []gadget.OnDiskStructure, timeout time.Dura
 	return func() {
 		ensureNodesExist = old
 	}
+}
+
+// LaidOutVolumeFromGadget takes a gadget rootdir and lays out the
+// partitions as specified. This function does not handle multiple volumes and
+// is meant for test helpers only. For runtime users, with multiple volumes
+// handled by choosing the ubuntu-* role volume, see LaidOutUbuntuVolumeFromGadget
+func LaidOutVolumeFromGadget(gadgetRoot string, model gadget.Model) (*gadget.LaidOutVolume, error) {
+	info, err := gadget.ReadInfo(gadgetRoot, model)
+	if err != nil {
+		return nil, err
+	}
+	// Limit ourselves to just one volume for now.
+	if len(info.Volumes) != 1 {
+		return nil, fmt.Errorf("cannot position multiple volumes yet")
+	}
+
+	constraints := gadget.LayoutConstraints{
+		NonMBRStartOffset: 1 * quantity.OffsetMiB,
+		SectorSize:        512,
+	}
+
+	for _, vol := range info.Volumes {
+		pvol, err := gadget.LayoutVolume(gadgetRoot, vol, constraints)
+		if err != nil {
+			return nil, err
+		}
+		// we know  info.Volumes map has size 1 so we can return here
+		return pvol, nil
+	}
+	return nil, fmt.Errorf("internal error in PositionedVolumeFromGadget: this line cannot be reached")
 }

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -63,7 +63,7 @@ func Run(model gadget.Model, gadgetRoot, device string, options Options, observe
 		return nil, fmt.Errorf("cannot use empty gadget root directory")
 	}
 
-	lv, err := gadget.LaidOutUbuntuVolumeFromGadget(gadgetRoot, model)
+	lv, err := gadget.LaidOutSystemVolumeFromGadget(gadgetRoot, model)
 	if err != nil {
 		return nil, fmt.Errorf("cannot layout the volume: %v", err)
 	}

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -63,7 +63,7 @@ func Run(model gadget.Model, gadgetRoot, device string, options Options, observe
 		return nil, fmt.Errorf("cannot use empty gadget root directory")
 	}
 
-	lv, err := gadget.LaidOutVolumeFromGadget(gadgetRoot, model)
+	lv, err := gadget.LaidOutUbuntuVolumeFromGadget(gadgetRoot, model)
 	if err != nil {
 		return nil, fmt.Errorf("cannot layout the volume: %v", err)
 	}

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -377,7 +377,7 @@ func layoutFromYaml(c *C, gadgetYaml string, model gadget.Model) *gadget.LaidOut
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetYaml), 0644)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(gadgetRoot, model)
+	pv, err := install.LaidOutVolumeFromGadget(gadgetRoot, model)
 	c.Assert(err, IsNil)
 	return pv
 }
@@ -399,6 +399,11 @@ const mockUC20GadgetYaml = `volumes:
         filesystem: vfat
         # UEFI will boot the ESP partition by default first
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        size: 1200M
+      - name: ubuntu-boot
+        role: system-boot
+        filesystem: ext4
+        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 1200M
       - name: ubuntu-data
         role: system-data

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -377,7 +377,7 @@ func layoutFromYaml(c *C, gadgetYaml string, model gadget.Model) *gadget.LaidOut
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetYaml), 0644)
 	c.Assert(err, IsNil)
-	pv, err := install.LaidOutVolumeFromGadget(gadgetRoot, model)
+	pv, err := mustLayOutVolumeFromGadget(c, gadgetRoot, model)
 	c.Assert(err, IsNil)
 	return pv
 }

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -232,7 +232,7 @@ func (s *partitionTestSuite) TestBuildPartitionList(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -267,7 +267,7 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -299,7 +299,7 @@ func (s *partitionTestSuite) TestRemovePartitionsTrivial(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -363,7 +363,7 @@ echo '{
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	err = install.RemoveCreatedPartitions(pv, dl)
@@ -388,7 +388,7 @@ func (s *partitionTestSuite) TestRemovePartitionsError(c *C) {
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	err = install.RemoveCreatedPartitions(pv, dl)
@@ -550,7 +550,7 @@ echo '{
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("node")
@@ -671,7 +671,7 @@ echo '{
 
 	err = makeMockGadget(s.gadgetRoot, mbrGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	list := install.CreatedDuringInstall(pv, dl)

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -216,6 +216,32 @@ var mockOnDiskStructureWritableAfterSave = gadget.OnDiskStructure{
 	Size: 2*quantity.SizeGiB + 717*quantity.SizeMiB + 1031680,
 }
 
+// mustLayOutVolumeFromGadget takes a gadget rootdir and lays out the
+// partitions as specified. This function does not handle multiple volumes and
+// is meant for test helpers only. For runtime users, with multiple volumes
+// handled by choosing the ubuntu-* role volume, see LaidOutSystemVolumeFromGadget
+func mustLayOutVolumeFromGadget(c *C, gadgetRoot string, model gadget.Model) (*gadget.LaidOutVolume, error) {
+	info, err := gadget.ReadInfo(gadgetRoot, model)
+	c.Assert(err, IsNil)
+
+	c.Assert(info.Volumes, HasLen, 1, Commentf("only single volumes supported in test helper"))
+
+	constraints := gadget.LayoutConstraints{
+		NonMBRStartOffset: 1 * quantity.OffsetMiB,
+		SectorSize:        512,
+	}
+
+	for _, vol := range info.Volumes {
+		pvol, err := gadget.LayoutVolume(gadgetRoot, vol, constraints)
+		c.Assert(err, IsNil)
+		// we know  info.Volumes map has size 1 so we can return here
+		return pvol, nil
+	}
+	// this is impossible to reach, we already asserted that info.Volumes has a
+	// length of 1
+	panic("impossible test error")
+}
+
 type uc20Model struct{}
 
 func (c uc20Model) Classic() bool             { return false }
@@ -232,7 +258,7 @@ func (s *partitionTestSuite) TestBuildPartitionList(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := mustLayOutVolumeFromGadget(c, s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -267,7 +293,7 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := mustLayOutVolumeFromGadget(c, s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -299,7 +325,7 @@ func (s *partitionTestSuite) TestRemovePartitionsTrivial(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := mustLayOutVolumeFromGadget(c, s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -363,7 +389,7 @@ echo '{
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := mustLayOutVolumeFromGadget(c, s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	err = install.RemoveCreatedPartitions(pv, dl)
@@ -388,7 +414,7 @@ func (s *partitionTestSuite) TestRemovePartitionsError(c *C) {
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := mustLayOutVolumeFromGadget(c, s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	err = install.RemoveCreatedPartitions(pv, dl)
@@ -550,7 +576,7 @@ echo '{
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := mustLayOutVolumeFromGadget(c, s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("node")
@@ -671,7 +697,7 @@ echo '{
 
 	err = makeMockGadget(s.gadgetRoot, mbrGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := mustLayOutVolumeFromGadget(c, s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	list := install.CreatedDuringInstall(pv, dl)


### PR DESCRIPTION
Rename LaidOutVolumeFromGadget to LaidOutSystemVolumeFromGadget, since now the
function returns the specific volume with all the ubuntu roles on it.
Additionally, allow multiple volumes and choose the right one by searching for
the SystemSeed role/partition.

Also move the old implementation of LaidOutVolumeFromGadget to a test-only
helper in the gadget/install package, since there are many tests in the install
package which use this helper with invalid gadget.yaml's that don't contain any
ubuntu roles and porting all of those tests to also include ubuntu roles is a
bit of a fool's errand.

This will fully enable using multiple volumes with UC20, albeit with all the ubuntu-*
roles/partitions on the same volume.