### PR TITLE
gadget: pass sector size in to mkfs family of functions, use to select block sz

### DIFF
--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/internal"
+	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
 )
 
@@ -38,11 +39,13 @@ func init() {
 }
 
 // makeFilesystem creates a filesystem on the on-disk structure, according
-// to the filesystem type defined in the gadget.
-func makeFilesystem(ds *gadget.OnDiskStructure) error {
+// to the filesystem type defined in the gadget. If sectorSize is specified,
+// that sector size is used when creating the filesystem, otherwise if it is
+// zero, automatic values are used instead.
+func makeFilesystem(ds *gadget.OnDiskStructure, sectorSize quantity.Size) error {
 	if ds.HasFilesystem() {
 		logger.Debugf("create %s filesystem on %s with label %q", ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label)
-		if err := internal.Mkfs(ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label, ds.Size); err != nil {
+		if err := internal.Mkfs(ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label, ds.Size, sectorSize); err != nil {
 			return err
 		}
 		if err := udevTrigger(ds.Node); err != nil {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -160,8 +160,8 @@ func Run(model gadget.Model, gadgetRoot, device string, options Options, observe
 			logger.Noticef("encrypted device %v", part.Node)
 		}
 
-		if err := makeFilesystem(&part); err != nil {
-			return nil, err
+		if err := makeFilesystem(&part, lv.SectorSize); err != nil {
+			return nil, fmt.Errorf("cannot make filesystem for partition %s: %v", part.Role, err)
 		}
 
 		if err := writeContent(&part, gadgetRoot, observer); err != nil {

--- a/gadget/internal/mkfs.go
+++ b/gadget/internal/mkfs.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-type MkfsFunc func(imgFile, label, contentsRootDir string, deviceSize quantity.Size) error
+type MkfsFunc func(imgFile, label, contentsRootDir string, deviceSize, sectorSize quantity.Size) error
 
 var (
 	mkfsHandlers = map[string]MkfsFunc{
@@ -40,42 +40,52 @@ var (
 )
 
 // Mkfs creates a filesystem of given type and provided label in the device or
-// file. The device size provides hints for additional tuning of the created
-// filesystem.
-func Mkfs(typ, img, label string, deviceSize quantity.Size) error {
-	return MkfsWithContent(typ, img, label, "", deviceSize)
+// file. The device size and sector size provides hints for additional tuning of
+// the created filesystem.
+func Mkfs(typ, img, label string, deviceSize, sectorSize quantity.Size) error {
+	return MkfsWithContent(typ, img, label, "", deviceSize, sectorSize)
 }
 
-// Mkfs creates a filesystem of given type and provided label in the device or
-// file. The filesystem is populated with contents of contentRootDir. The device
-// size provides hints for additional tuning of the created filesystem.
-func MkfsWithContent(typ, img, label, contentRootDir string, deviceSize quantity.Size) error {
+// MkfsWithContent creates a filesystem of given type and provided label in the
+// device or file. The filesystem is populated with contents of contentRootDir.
+// The device size provides hints for additional tuning of the created
+// filesystem.
+func MkfsWithContent(typ, img, label, contentRootDir string, deviceSize, sectorSize quantity.Size) error {
 	h, ok := mkfsHandlers[typ]
 	if !ok {
 		return fmt.Errorf("cannot create unsupported filesystem %q", typ)
 	}
-	return h(img, label, contentRootDir, deviceSize)
+	return h(img, label, contentRootDir, deviceSize, sectorSize)
 }
 
 // mkfsExt4 creates an EXT4 filesystem in given image file, with an optional
 // filesystem label, and populates it with the contents of provided root
 // directory.
-func mkfsExt4(img, label, contentsRootDir string, deviceSize quantity.Size) error {
+func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantity.Size) error {
 	// Originally taken from ubuntu-image
 	// Switched to use mkfs defaults for https://bugs.launchpad.net/snappy/+bug/1878374
 	// For caveats/requirements in case we need support for older systems:
 	// https://github.com/snapcore/snapd/pull/6997#discussion_r293967140
 	mkfsArgs := []string{"mkfs.ext4"}
+
 	const size32MiB = 32 * quantity.SizeMiB
 	if deviceSize != 0 && deviceSize <= size32MiB {
-		// With the default of 4096 bytes, the minimal journal size is
-		// 4M, meaning we loose a lot of usable space. Try to follow the
+		// With the default block size of 4096 bytes, the minimal journal size
+		// is 4M, meaning we loose a lot of usable space. Try to follow the
 		// e2fsprogs upstream and use a 1k block size for smaller
 		// filesystems, note that this may cause issues like
 		// https://bugs.launchpad.net/ubuntu/+source/lvm2/+bug/1817097
 		// if one migrates the filesystem to a device with a different
 		// block size
-		mkfsArgs = append(mkfsArgs, "-b", "1024")
+
+		// though note if the sector size was specified (i.e. non-zero) and
+		// larger than 1K, then we need to use that, since you can't create
+		// a filesystem with a block-size smaller than the sector-size
+		defaultSectorSize := 1 * quantity.SizeKiB
+		if sectorSize > 1024 {
+			defaultSectorSize = sectorSize
+		}
+		mkfsArgs = append(mkfsArgs, "-b", defaultSectorSize.String())
 	}
 	if contentsRootDir != "" {
 		// mkfs.ext4 can populate the filesystem with contents of given
@@ -106,11 +116,19 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize quantity.Size) erro
 // mkfsVfat creates a VFAT filesystem in given image file, with an optional
 // filesystem label, and populates it with the contents of provided root
 // directory.
-func mkfsVfat(img, label, contentsRootDir string, deviceSize quantity.Size) error {
+func mkfsVfat(img, label, contentsRootDir string, deviceSize, sectorSize quantity.Size) error {
 	// taken from ubuntu-image
+	// TODO: handle sector sizes other than 512, can't create a block size that
+	// is less than the sector size
+
+	// 512B logical sector size by default, unless the specified sector size is
+	// larger than 512, in which case use the sector size
+	defaultSectorSize := quantity.Size(512)
+	if sectorSize > defaultSectorSize {
+		defaultSectorSize = sectorSize
+	}
 	mkfsArgs := []string{
-		// 512B logical sector size
-		"-S", "512",
+		"-S", defaultSectorSize.String(),
 		// 1 sector per cluster
 		"-s", "1",
 		// 32b FAT size

--- a/gadget/internal/mkfs_test.go
+++ b/gadget/internal/mkfs_test.go
@@ -63,7 +63,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd := testutil.MockCommand(c, "fakeroot", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0)
+	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -78,7 +78,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd.ForgetCalls()
 
 	// empty label
-	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 0)
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -92,7 +92,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd.ForgetCalls()
 
 	// no content
-	err = internal.Mkfs("ext4", "foo.img", "my-label", 0)
+	err = internal.Mkfs("ext4", "foo.img", "my-label", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -109,7 +109,7 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 	cmd := testutil.MockCommand(c, "fakeroot", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 250*1024*1024)
+	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 250*1024*1024, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -124,7 +124,7 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 	cmd.ForgetCalls()
 
 	// empty label
-	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 32*1024*1024)
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 32*1024*1024, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -137,13 +137,44 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 	})
 
 	cmd.ForgetCalls()
+
+	// with sector size of 512
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 32*1024*1024, 512)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-b", "1024",
+			"-d", "contents",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
+	// with sector size of 4096
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 32*1024*1024, 4096)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-b", "4096",
+			"-d", "contents",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
 }
 
 func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
 	cmd := testutil.MockCommand(c, "fakeroot", "echo 'command failed'; exit 1")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0)
+	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0, 0)
 	c.Assert(err, ErrorMatches, "command failed")
 }
 
@@ -154,7 +185,7 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -170,7 +201,7 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd.ForgetCalls()
 
 	// empty label
-	err = internal.MkfsWithContent("vfat", "foo.img", "", d, 0)
+	err = internal.MkfsWithContent("vfat", "foo.img", "", d, 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -185,7 +216,7 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd.ForgetCalls()
 
 	// no content
-	err = internal.Mkfs("vfat", "foo.img", "my-label", 0)
+	err = internal.Mkfs("vfat", "foo.img", "my-label", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -205,7 +236,7 @@ func (m *mkfsSuite) TestMkfsVfatWithSize(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 32*1024*1024)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 32*1024*1024, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -217,6 +248,39 @@ func (m *mkfsSuite) TestMkfsVfatWithSize(c *C) {
 			"foo.img",
 		},
 	})
+
+	cmd.ForgetCalls()
+
+	// with sector size of 512
+	err = internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 32*1024*1024, 512)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"mkfs.vfat",
+			"-S", "512",
+			"-s", "1",
+			"-F", "32",
+			"-n", "my-label",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
+	// with sector size of 4096
+	err = internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 32*1024*1024, 4096)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"mkfs.vfat",
+			"-S", "4096",
+			"-s", "1",
+			"-F", "32",
+			"-n", "my-label",
+			"foo.img",
+		},
+	})
+
 }
 
 func (m *mkfsSuite) TestMkfsVfatHappyContents(c *C) {
@@ -230,7 +294,7 @@ func (m *mkfsSuite) TestMkfsVfatHappyContents(c *C) {
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "")
 	defer cmdMcopy.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 
@@ -245,7 +309,7 @@ func (m *mkfsSuite) TestMkfsVfatErrorSimpleFail(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "echo 'failed'; false")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0, 0)
 	c.Assert(err, ErrorMatches, "failed")
 }
 
@@ -253,7 +317,7 @@ func (m *mkfsSuite) TestMkfsVfatErrorUnreadableDir(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "dir-does-not-exist", 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "dir-does-not-exist", 0, 0)
 	c.Assert(err, ErrorMatches, "cannot list directory contents: .* no such file or directory")
 	c.Assert(cmd.Calls(), HasLen, 1)
 }
@@ -268,7 +332,7 @@ func (m *mkfsSuite) TestMkfsVfatErrorInMcopy(c *C) {
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "echo 'hard fail'; exit 1")
 	defer cmdMcopy.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0, 0)
 	c.Assert(err, ErrorMatches, "cannot populate vfat filesystem with contents: hard fail")
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 	c.Assert(cmdMcopy.Calls(), HasLen, 1)
@@ -281,7 +345,7 @@ func (m *mkfsSuite) TestMkfsVfatHappyNoContents(c *C) {
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "")
 	defer cmdMcopy.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "", 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "", 0, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 	// mcopy was not called
@@ -289,10 +353,10 @@ func (m *mkfsSuite) TestMkfsVfatHappyNoContents(c *C) {
 }
 
 func (m *mkfsSuite) TestMkfsInvalidFs(c *C) {
-	err := internal.MkfsWithContent("no-fs", "foo.img", "my-label", "", 0)
+	err := internal.MkfsWithContent("no-fs", "foo.img", "my-label", "", 0, 0)
 	c.Assert(err, ErrorMatches, `cannot create unsupported filesystem "no-fs"`)
 
-	err = internal.Mkfs("no-fs", "foo.img", "my-label", 0)
+	err = internal.Mkfs("no-fs", "foo.img", "my-label", 0, 0)
 	c.Assert(err, ErrorMatches, `cannot create unsupported filesystem "no-fs"`)
 }
 


### PR DESCRIPTION
If we are creating partitions that are small such as ubuntu-save, then we have
code to specify the block size, but on some devices where the sector size is
not the default of 512 (and is instead 4K for example), we need to adjust the
block size when creating the filesystem to something that is at least the same
as the sector size. This is confirmed looking at the source of e2fsprogs at
https://github.com/tytso/e2fsprogs/blob/master/misc/mke2fs.c#L2151-L2156.

As such, pass the sector size along to where we call mkfs, and adjust the
specified block size to be the same as the sector size if the sector size is
larger than 1K when creating ext4 partitions. Similar code will be needed for
vfat partitions eventually as well.

This branch will be useful and necessary regardless of the direction we go with
supporting additional sector sizes in Ubuntu Core.