### PR TITLE
[RFC] gadget: enable sector-sizes in gadget.yaml; refactor SectorSize handling

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -937,32 +937,45 @@ func IsCompatible(current, new *Info) error {
 	return nil
 }
 
-// LaidOutVolumeFromGadget takes a gadget rootdir and lays out the
-// partitions as specified.
-func LaidOutVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolume, error) {
-	info, err := ReadInfo(gadgetRoot, model)
+// LaidOutUbuntuVolumeFromGadget takes a gadget rootdir and lays out the
+// partitions as specified. It returns one specific volume, which is the volume
+// on which ubuntu-* roles/partitions exist, all other volumes are assumed to
+// already be flashed and managed separately at image build/flash time, while
+// the ubuntu-* roles can be manipulated on the returned volume during install
+// mode.
+func LaidOutUbuntuVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolume, error) {
+	// rely on the basic validation from ReadInfo to ensure that the ubuntu-*
+	// roles are all on the same volume for example
+	info, err := ReadInfoAndValidate(gadgetRoot, model, nil)
 	if err != nil {
 		return nil, err
-	}
-	// Limit ourselves to just one volume for now.
-	if len(info.Volumes) != 1 {
-		return nil, fmt.Errorf("cannot position multiple volumes yet")
 	}
 
 	constraints := LayoutConstraints{
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-		SectorSize:        512,
+		// TODO:UC20: make SectorSize dynamic, either through config in the
+		//            gadget or by dynamic detection
+		SectorSize: sectorSize,
 	}
 
+	// find the volume with the ubuntu-boot role on it, we already validated
+	// that the ubuntu-* roles are all on the same volume
 	for _, vol := range info.Volumes {
-		pvol, err := LayoutVolume(gadgetRoot, vol, constraints)
-		if err != nil {
-			return nil, err
+		for _, structure := range vol.Structure {
+			// use the system-boot role
+			if structure.Role == SystemBoot || structure.Label == SystemBoot {
+				pvol, err := LayoutVolume(gadgetRoot, vol, constraints)
+				if err != nil {
+					return nil, err
+				}
+
+				return pvol, nil
+			}
 		}
-		// we know  info.Volumes map has size 1 so we can return here
-		return pvol, nil
 	}
-	return nil, fmt.Errorf("internal error in PositionedVolumeFromGadget: this line cannot be reached")
+
+	// this should be impossible, the validation above should ensure this
+	return nil, fmt.Errorf("internal error: gadget passed validation but does not have ubuntu-* roles on any volume")
 }
 
 func flatten(path string, cfg interface{}, out map[string]interface{}) {

--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/internal"
+	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
 )
 
@@ -38,11 +39,13 @@ func init() {
 }
 
 // makeFilesystem creates a filesystem on the on-disk structure, according
-// to the filesystem type defined in the gadget.
-func makeFilesystem(ds *gadget.OnDiskStructure) error {
+// to the filesystem type defined in the gadget. If sectorSize is specified,
+// that sector size is used when creating the filesystem, otherwise if it is
+// zero, automatic values are used instead.
+func makeFilesystem(ds *gadget.OnDiskStructure, sectorSize quantity.Size) error {
 	if ds.HasFilesystem() {
 		logger.Debugf("create %s filesystem on %s with label %q", ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label)
-		if err := internal.Mkfs(ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label, ds.Size); err != nil {
+		if err := internal.Mkfs(ds.VolumeStructure.Filesystem, ds.Node, ds.VolumeStructure.Label, ds.Size, sectorSize); err != nil {
 			return err
 		}
 		if err := udevTrigger(ds.Node); err != nil {

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -20,9 +20,11 @@
 package install
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/quantity"
 )
 
 var (
@@ -68,4 +70,34 @@ func MockEnsureNodesExist(f func(dss []gadget.OnDiskStructure, timeout time.Dura
 	return func() {
 		ensureNodesExist = old
 	}
+}
+
+// LaidOutVolumeFromGadget takes a gadget rootdir and lays out the
+// partitions as specified. This function does not handle multiple volumes and
+// is meant for test helpers only. For runtime users, with multiple volumes
+// handled by choosing the ubuntu-* role volume, see LaidOutUbuntuVolumeFromGadget
+func LaidOutVolumeFromGadget(gadgetRoot string, model gadget.Model) (*gadget.LaidOutVolume, error) {
+	info, err := gadget.ReadInfo(gadgetRoot, model)
+	if err != nil {
+		return nil, err
+	}
+	// Limit ourselves to just one volume for now.
+	if len(info.Volumes) != 1 {
+		return nil, fmt.Errorf("cannot position multiple volumes yet")
+	}
+
+	constraints := gadget.LayoutConstraints{
+		NonMBRStartOffset: 1 * quantity.OffsetMiB,
+		SectorSize:        512,
+	}
+
+	for _, vol := range info.Volumes {
+		pvol, err := gadget.LayoutVolume(gadgetRoot, vol, constraints)
+		if err != nil {
+			return nil, err
+		}
+		// we know  info.Volumes map has size 1 so we can return here
+		return pvol, nil
+	}
+	return nil, fmt.Errorf("internal error in PositionedVolumeFromGadget: this line cannot be reached")
 }

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -63,7 +63,7 @@ func Run(model gadget.Model, gadgetRoot, device string, options Options, observe
 		return nil, fmt.Errorf("cannot use empty gadget root directory")
 	}
 
-	lv, err := gadget.LaidOutVolumeFromGadget(gadgetRoot, model)
+	lv, err := gadget.LaidOutUbuntuVolumeFromGadget(gadgetRoot, model)
 	if err != nil {
 		return nil, fmt.Errorf("cannot layout the volume: %v", err)
 	}

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -160,8 +160,8 @@ func Run(model gadget.Model, gadgetRoot, device string, options Options, observe
 			logger.Noticef("encrypted device %v", part.Node)
 		}
 
-		if err := makeFilesystem(&part); err != nil {
-			return nil, err
+		if err := makeFilesystem(&part, lv.SectorSize); err != nil {
+			return nil, fmt.Errorf("cannot make filesystem for partition %s: %v", part.Role, err)
 		}
 
 		if err := writeContent(&part, gadgetRoot, observer); err != nil {

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -377,7 +377,7 @@ func layoutFromYaml(c *C, gadgetYaml string, model gadget.Model) *gadget.LaidOut
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetYaml), 0644)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(gadgetRoot, model)
+	pv, err := install.LaidOutVolumeFromGadget(gadgetRoot, model)
 	c.Assert(err, IsNil)
 	return pv
 }
@@ -399,6 +399,11 @@ const mockUC20GadgetYaml = `volumes:
         filesystem: vfat
         # UEFI will boot the ESP partition by default first
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        size: 1200M
+      - name: ubuntu-boot
+        role: system-boot
+        filesystem: ext4
+        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 1200M
       - name: ubuntu-data
         role: system-data

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -232,7 +232,7 @@ func (s *partitionTestSuite) TestBuildPartitionList(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -267,7 +267,7 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -299,7 +299,7 @@ func (s *partitionTestSuite) TestRemovePartitionsTrivial(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -363,7 +363,7 @@ echo '{
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	err = install.RemoveCreatedPartitions(pv, dl)
@@ -388,7 +388,7 @@ func (s *partitionTestSuite) TestRemovePartitionsError(c *C) {
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	err = install.RemoveCreatedPartitions(pv, dl)
@@ -550,7 +550,7 @@ echo '{
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("node")
@@ -671,7 +671,7 @@ echo '{
 
 	err = makeMockGadget(s.gadgetRoot, mbrGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := install.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
 	c.Assert(err, IsNil)
 
 	list := install.CreatedDuringInstall(pv, dl)

--- a/gadget/internal/mkfs.go
+++ b/gadget/internal/mkfs.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-type MkfsFunc func(imgFile, label, contentsRootDir string, deviceSize quantity.Size) error
+type MkfsFunc func(imgFile, label, contentsRootDir string, deviceSize, sectorSize quantity.Size) error
 
 var (
 	mkfsHandlers = map[string]MkfsFunc{
@@ -40,42 +40,52 @@ var (
 )
 
 // Mkfs creates a filesystem of given type and provided label in the device or
-// file. The device size provides hints for additional tuning of the created
-// filesystem.
-func Mkfs(typ, img, label string, deviceSize quantity.Size) error {
-	return MkfsWithContent(typ, img, label, "", deviceSize)
+// file. The device size and sector size provides hints for additional tuning of
+// the created filesystem.
+func Mkfs(typ, img, label string, deviceSize, sectorSize quantity.Size) error {
+	return MkfsWithContent(typ, img, label, "", deviceSize, sectorSize)
 }
 
-// Mkfs creates a filesystem of given type and provided label in the device or
-// file. The filesystem is populated with contents of contentRootDir. The device
-// size provides hints for additional tuning of the created filesystem.
-func MkfsWithContent(typ, img, label, contentRootDir string, deviceSize quantity.Size) error {
+// MkfsWithContent creates a filesystem of given type and provided label in the
+// device or file. The filesystem is populated with contents of contentRootDir.
+// The device size provides hints for additional tuning of the created
+// filesystem.
+func MkfsWithContent(typ, img, label, contentRootDir string, deviceSize, sectorSize quantity.Size) error {
 	h, ok := mkfsHandlers[typ]
 	if !ok {
 		return fmt.Errorf("cannot create unsupported filesystem %q", typ)
 	}
-	return h(img, label, contentRootDir, deviceSize)
+	return h(img, label, contentRootDir, deviceSize, sectorSize)
 }
 
 // mkfsExt4 creates an EXT4 filesystem in given image file, with an optional
 // filesystem label, and populates it with the contents of provided root
 // directory.
-func mkfsExt4(img, label, contentsRootDir string, deviceSize quantity.Size) error {
+func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantity.Size) error {
 	// Originally taken from ubuntu-image
 	// Switched to use mkfs defaults for https://bugs.launchpad.net/snappy/+bug/1878374
 	// For caveats/requirements in case we need support for older systems:
 	// https://github.com/snapcore/snapd/pull/6997#discussion_r293967140
 	mkfsArgs := []string{"mkfs.ext4"}
+
 	const size32MiB = 32 * quantity.SizeMiB
 	if deviceSize != 0 && deviceSize <= size32MiB {
-		// With the default of 4096 bytes, the minimal journal size is
-		// 4M, meaning we loose a lot of usable space. Try to follow the
+		// With the default block size of 4096 bytes, the minimal journal size
+		// is 4M, meaning we loose a lot of usable space. Try to follow the
 		// e2fsprogs upstream and use a 1k block size for smaller
 		// filesystems, note that this may cause issues like
 		// https://bugs.launchpad.net/ubuntu/+source/lvm2/+bug/1817097
 		// if one migrates the filesystem to a device with a different
 		// block size
-		mkfsArgs = append(mkfsArgs, "-b", "1024")
+
+		// though note if the sector size was specified (i.e. non-zero) and
+		// larger than 1K, then we need to use that, since you can't create
+		// a filesystem with a block-size smaller than the sector-size
+		defaultSectorSize := 1 * quantity.SizeKiB
+		if sectorSize > 1024 {
+			defaultSectorSize = sectorSize
+		}
+		mkfsArgs = append(mkfsArgs, "-b", defaultSectorSize.String())
 	}
 	if contentsRootDir != "" {
 		// mkfs.ext4 can populate the filesystem with contents of given
@@ -106,11 +116,19 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize quantity.Size) erro
 // mkfsVfat creates a VFAT filesystem in given image file, with an optional
 // filesystem label, and populates it with the contents of provided root
 // directory.
-func mkfsVfat(img, label, contentsRootDir string, deviceSize quantity.Size) error {
+func mkfsVfat(img, label, contentsRootDir string, deviceSize, sectorSize quantity.Size) error {
 	// taken from ubuntu-image
+	// TODO: handle sector sizes other than 512, can't create a block size that
+	// is less than the sector size
+
+	// 512B logical sector size by default, unless the specified sector size is
+	// larger than 512, in which case use the sector size
+	defaultSectorSize := quantity.Size(512)
+	if sectorSize > defaultSectorSize {
+		defaultSectorSize = sectorSize
+	}
 	mkfsArgs := []string{
-		// 512B logical sector size
-		"-S", "512",
+		"-S", defaultSectorSize.String(),
 		// 1 sector per cluster
 		"-s", "1",
 		// 32b FAT size

--- a/gadget/internal/mkfs_test.go
+++ b/gadget/internal/mkfs_test.go
@@ -63,7 +63,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd := testutil.MockCommand(c, "fakeroot", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0)
+	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -78,7 +78,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd.ForgetCalls()
 
 	// empty label
-	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 0)
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -92,7 +92,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 	cmd.ForgetCalls()
 
 	// no content
-	err = internal.Mkfs("ext4", "foo.img", "my-label", 0)
+	err = internal.Mkfs("ext4", "foo.img", "my-label", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -109,7 +109,7 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 	cmd := testutil.MockCommand(c, "fakeroot", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 250*1024*1024)
+	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 250*1024*1024, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -124,7 +124,7 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 	cmd.ForgetCalls()
 
 	// empty label
-	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 32*1024*1024)
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 32*1024*1024, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -137,13 +137,44 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 	})
 
 	cmd.ForgetCalls()
+
+	// with sector size of 512
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 32*1024*1024, 512)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-b", "1024",
+			"-d", "contents",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
+	// with sector size of 4096
+	err = internal.MkfsWithContent("ext4", "foo.img", "", "contents", 32*1024*1024, 4096)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-b", "4096",
+			"-d", "contents",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
 }
 
 func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
 	cmd := testutil.MockCommand(c, "fakeroot", "echo 'command failed'; exit 1")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0)
+	err := internal.MkfsWithContent("ext4", "foo.img", "my-label", "contents", 0, 0)
 	c.Assert(err, ErrorMatches, "command failed")
 }
 
@@ -154,7 +185,7 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -170,7 +201,7 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd.ForgetCalls()
 
 	// empty label
-	err = internal.MkfsWithContent("vfat", "foo.img", "", d, 0)
+	err = internal.MkfsWithContent("vfat", "foo.img", "", d, 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -185,7 +216,7 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd.ForgetCalls()
 
 	// no content
-	err = internal.Mkfs("vfat", "foo.img", "my-label", 0)
+	err = internal.Mkfs("vfat", "foo.img", "my-label", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -205,7 +236,7 @@ func (m *mkfsSuite) TestMkfsVfatWithSize(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 32*1024*1024)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 32*1024*1024, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -217,6 +248,39 @@ func (m *mkfsSuite) TestMkfsVfatWithSize(c *C) {
 			"foo.img",
 		},
 	})
+
+	cmd.ForgetCalls()
+
+	// with sector size of 512
+	err = internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 32*1024*1024, 512)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"mkfs.vfat",
+			"-S", "512",
+			"-s", "1",
+			"-F", "32",
+			"-n", "my-label",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
+	// with sector size of 4096
+	err = internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 32*1024*1024, 4096)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"mkfs.vfat",
+			"-S", "4096",
+			"-s", "1",
+			"-F", "32",
+			"-n", "my-label",
+			"foo.img",
+		},
+	})
+
 }
 
 func (m *mkfsSuite) TestMkfsVfatHappyContents(c *C) {
@@ -230,7 +294,7 @@ func (m *mkfsSuite) TestMkfsVfatHappyContents(c *C) {
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "")
 	defer cmdMcopy.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 
@@ -245,7 +309,7 @@ func (m *mkfsSuite) TestMkfsVfatErrorSimpleFail(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "echo 'failed'; false")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0, 0)
 	c.Assert(err, ErrorMatches, "failed")
 }
 
@@ -253,7 +317,7 @@ func (m *mkfsSuite) TestMkfsVfatErrorUnreadableDir(c *C) {
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
 	defer cmd.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "dir-does-not-exist", 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "dir-does-not-exist", 0, 0)
 	c.Assert(err, ErrorMatches, "cannot list directory contents: .* no such file or directory")
 	c.Assert(cmd.Calls(), HasLen, 1)
 }
@@ -268,7 +332,7 @@ func (m *mkfsSuite) TestMkfsVfatErrorInMcopy(c *C) {
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "echo 'hard fail'; exit 1")
 	defer cmdMcopy.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", d, 0, 0)
 	c.Assert(err, ErrorMatches, "cannot populate vfat filesystem with contents: hard fail")
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 	c.Assert(cmdMcopy.Calls(), HasLen, 1)
@@ -281,7 +345,7 @@ func (m *mkfsSuite) TestMkfsVfatHappyNoContents(c *C) {
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "")
 	defer cmdMcopy.Restore()
 
-	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "", 0)
+	err := internal.MkfsWithContent("vfat", "foo.img", "my-label", "", 0, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 	// mcopy was not called
@@ -289,10 +353,10 @@ func (m *mkfsSuite) TestMkfsVfatHappyNoContents(c *C) {
 }
 
 func (m *mkfsSuite) TestMkfsInvalidFs(c *C) {
-	err := internal.MkfsWithContent("no-fs", "foo.img", "my-label", "", 0)
+	err := internal.MkfsWithContent("no-fs", "foo.img", "my-label", "", 0, 0)
 	c.Assert(err, ErrorMatches, `cannot create unsupported filesystem "no-fs"`)
 
-	err = internal.Mkfs("no-fs", "foo.img", "my-label", 0)
+	err = internal.Mkfs("no-fs", "foo.img", "my-label", 0, 0)
 	c.Assert(err, ErrorMatches, `cannot create unsupported filesystem "no-fs"`)
 }
 

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -50,6 +50,33 @@ var defaultConstraints = gadget.LayoutConstraints{
 	SectorSize:        512,
 }
 
+func (p *layoutTestSuite) TestSectorSize(c *C) {
+	vol := gadget.Volume{
+		SectorSize: 512,
+		Structure: []gadget.VolumeStructure{
+			{Size: 2 * quantity.SizeMiB},
+		},
+	}
+	v, err := gadget.LayoutVolume(p.dir, &vol, defaultConstraints)
+	c.Assert(err, IsNil)
+
+	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
+		Volume: &gadget.Volume{
+			SectorSize: 512,
+			Structure: []gadget.VolumeStructure{
+				{Size: 2 * quantity.SizeMiB},
+			},
+		},
+		SectorSize: 512,
+		Size:       3 * quantity.SizeMiB,
+		RootDir:    p.dir,
+		LaidOutStructure: []gadget.LaidOutStructure{{
+			VolumeStructure: &gadget.VolumeStructure{Size: 2 * quantity.SizeMiB},
+			StartOffset:     1 * quantity.OffsetMiB,
+		}},
+	})
+}
+
 func (p *layoutTestSuite) TestVolumeSize(c *C) {
 	vol := gadget.Volume{
 		Structure: []gadget.VolumeStructure{
@@ -65,9 +92,8 @@ func (p *layoutTestSuite) TestVolumeSize(c *C) {
 				{Size: 2 * quantity.SizeMiB},
 			},
 		},
-		Size:       3 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Size:    3 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{{
 			VolumeStructure: &gadget.VolumeStructure{Size: 2 * quantity.SizeMiB},
 			StartOffset:     1 * quantity.OffsetMiB,
@@ -102,10 +128,9 @@ volumes:
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       501 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    501 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -145,10 +170,9 @@ volumes:
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       1101 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    1101 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -202,10 +226,9 @@ volumes:
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       1300 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    1300 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[3],
@@ -258,10 +281,9 @@ volumes:
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       1200 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    1200 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[3],
@@ -471,10 +493,9 @@ volumes:
 	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       3 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    3 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -523,10 +544,9 @@ volumes:
 	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       3 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    3 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -572,10 +592,9 @@ volumes:
 	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       3 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    3 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -615,10 +634,9 @@ volumes:
 	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       3 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    3 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -655,10 +673,9 @@ volumes:
 	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       3 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    3 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -672,6 +689,10 @@ volumes:
 			},
 		},
 	})
+
+	// for the rest of the test cases, assume that the volume had a sector-size
+	// specified
+	vol.SectorSize = 512
 
 	// still valid
 	constraints := gadget.LayoutConstraints{
@@ -726,6 +747,8 @@ volumes:
 			},
 		},
 	})
+
+	vol.SectorSize = 1024
 
 	// sector size is properly recorded
 	constraintsSector := gadget.LayoutConstraints{
@@ -783,13 +806,25 @@ volumes:
 	c.Assert(err, ErrorMatches, "cannot lay out volume, structure #1 size is not a multiple of sector size 384")
 }
 
-func (p *layoutTestSuite) TestLayoutVolumeConstraintsNeedsSectorSize(c *C) {
+func (p *layoutTestSuite) TestLayoutVolumeConstraintsSectorSizeOptional(c *C) {
 	constraintsBadSectorSize := gadget.LayoutConstraints{
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-		// SectorSize left unspecified
 	}
 	_, err := gadget.LayoutVolume(p.dir, &gadget.Volume{}, constraintsBadSectorSize)
-	c.Assert(err, ErrorMatches, "cannot lay out volume, invalid constraints: sector size cannot be 0")
+	c.Assert(err, IsNil)
+}
+
+func (p *layoutTestSuite) TestLayoutVolumeConstraintsSectorSizeMustMatchVolumeSectorSize(c *C) {
+	constraintsBadSectorSize := gadget.LayoutConstraints{
+		NonMBRStartOffset: 1 * quantity.OffsetMiB,
+		SectorSize:        512,
+	}
+	vol := &gadget.Volume{
+		SectorSize: 1024,
+	}
+	// this shouldn't happen in practice, but just to be sure
+	_, err := gadget.LayoutVolume(p.dir, vol, constraintsBadSectorSize)
+	c.Assert(err, ErrorMatches, "internal error: volume has sector-size of 1024 but constraint of 512 specified")
 }
 
 func (p *layoutTestSuite) TestLayoutVolumeMBRImplicitConstraints(c *C) {
@@ -813,10 +848,9 @@ volumes:
 	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       2 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    2 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				// MBR
@@ -866,10 +900,9 @@ volumes:
 	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:     vol,
-		Size:       3 * quantity.SizeMiB,
-		SectorSize: 512,
-		RootDir:    p.dir,
+		Volume:  vol,
+		Size:    3 * quantity.SizeMiB,
+		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				// mbr
@@ -1036,8 +1069,7 @@ volumes:
 
 	v, err := gadget.LayoutVolumePartially(vol, defaultConstraints)
 	c.Assert(v, DeepEquals, &gadget.PartiallyLaidOutVolume{
-		Volume:     vol,
-		SectorSize: 512,
+		Volume: vol,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				VolumeStructure: &vol.Structure[0],

--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -30,10 +30,6 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-const (
-	sectorSize quantity.Size = 512
-)
-
 // sfdiskDeviceDump represents the sfdisk --dump JSON output format.
 type sfdiskDeviceDump struct {
 	PartitionTable sfdiskPartitionTable `json:"partitiontable"`
@@ -130,19 +126,29 @@ func fromSfdiskPartitionType(st string, sfdiskLabel string) (string, error) {
 	}
 }
 
-func blockDeviceSizeInSectors(devpath string) (quantity.Size, error) {
-	// the size is reported in 512-byte sectors
-	// XXX: consider using /sys/block/<dev>/size directly
-	out, err := exec.Command("blockdev", "--getsz", devpath).CombinedOutput()
+func blockdevCmd(cmd, devpath string) (quantity.Size, error) {
+	out, err := exec.Command("blockdev", cmd, devpath).CombinedOutput()
 	if err != nil {
 		return 0, osutil.OutputErr(out, err)
 	}
 	nospace := strings.TrimSpace(string(out))
 	sz, err := strconv.Atoi(nospace)
 	if err != nil {
-		return 0, fmt.Errorf("cannot parse device size %q: %v", nospace, err)
+		return 0, fmt.Errorf("cannot parse blockdev size %q: %v", nospace, err)
 	}
 	return quantity.Size(sz), nil
+}
+
+func blockDeviceSizeInSectors(devpath string) (quantity.Size, error) {
+	// the size is always reported in 512-byte sectors, even if the device does
+	// not have a physical sector size of 512
+	// XXX: consider using /sys/block/<dev>/size directly
+	return blockdevCmd("--getsz", devpath)
+}
+
+func blockDeviceSectorSize(devpath string) (quantity.Size, error) {
+	// the size is reported in raw bytes
+	return blockdevCmd("--getbsz", devpath)
 }
 
 // onDiskVolumeFromPartitionTable takes an sfdisk dump partition table and returns
@@ -154,6 +160,11 @@ func onDiskVolumeFromPartitionTable(ptable sfdiskPartitionTable) (*OnDiskVolume,
 
 	structure := make([]VolumeStructure, len(ptable.Partitions))
 	ds := make([]OnDiskStructure, len(ptable.Partitions))
+
+	sectorSize, err := blockDeviceSectorSize(ptable.Device)
+	if err != nil {
+		return nil, err
+	}
 
 	for i, p := range ptable.Partitions {
 		info, err := filesystemInfo(p.Node)
@@ -203,7 +214,16 @@ func onDiskVolumeFromPartitionTable(ptable sfdiskPartitionTable) (*OnDiskVolume,
 		if err != nil {
 			return nil, fmt.Errorf("cannot obtain the size of device %q: %v", ptable.Device, err)
 		}
-		numSectors = sz
+
+		// since blockdev always reports the size in 512-byte sectors, if for
+		// some reason we are on a disk that does not 512-byte sectors, we will
+		// get confused, so in this case, multiply the number of 512-byte
+		// sectors by 512, then divide by the actual sector size to get the
+		// number of sectors
+
+		// note this assumes that the real sector size is a multiple of 512
+
+		numSectors = sz * 512 / sectorSize
 	}
 
 	dl := &OnDiskVolume{

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -35,7 +35,6 @@ var (
 	// default positioning constraints that match ubuntu-image
 	defaultConstraints = LayoutConstraints{
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-		SectorSize:        512,
 	}
 )
 
@@ -224,7 +223,7 @@ func isSameRelativeOffset(one *RelativeOffset, two *RelativeOffset) bool {
 func isLegacyMBRTransition(from *LaidOutStructure, to *LaidOutStructure) bool {
 	// legacy MBR could have been specified by setting type: mbr, with no
 	// role
-	return from.Type == schemaMBR && to.Role == schemaMBR
+	return from.Type == SchemaMBR && to.Role == SchemaMBR
 }
 
 func canUpdateStructure(from *LaidOutStructure, to *LaidOutStructure, schema string) error {
@@ -302,7 +301,7 @@ func defaultPolicy(from, to *LaidOutStructure) bool {
 // RemodelUpdatePolicy implements the update policy of a remodel scenario. The
 // policy selects all non-MBR structures for the update.
 func RemodelUpdatePolicy(from, _ *LaidOutStructure) bool {
-	if from.Role == schemaMBR {
+	if from.Role == SchemaMBR {
 		return false
 	}
 	return true


### PR DESCRIPTION
This implements option 2, where we allow gadget.yaml's to specify sector-size, but don't require it. 

This is based on top of #9854 and #9852 

I still need to double-check that this code works as advertised on my 4096K device, but I'm fairly confident it will.