### PR TITLE
bootloader/assets: support injecting bootloader assets in testing builds of snapd

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,6 +168,11 @@ jobs:
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         ./run-checks --unit
+    - name: Test Go (withbootassetstesting)
+      if: steps.cached-results.outputs.already-ran != 'true'
+      run: |
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
+        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
     - name: Test Go (nosecboot)
       if: steps.cached-results.outputs.already-ran != 'true'
       run: |

--- a/bootloader/assets/assets_test.go
+++ b/bootloader/assets/assets_test.go
@@ -78,7 +78,7 @@ func (s *assetsTestSuite) TestRegisterSnippetPanics(c *C) {
 			{FirstEdition: 2, Snippet: []byte("two")},
 			{FirstEdition: 1, Snippet: []byte("one")},
 		})
-	}, PanicMatches, `edition snippets "unsorted" must be sorted in ascending edition number order`)
+	}, PanicMatches, `cannot validate snippets "unsorted": snippets must be sorted in ascending edition number order`)
 	// panics when edition is repeated
 	c.Assert(func() {
 		assets.RegisterSnippetForEditions("doubled edition", []assets.ForEditions{
@@ -88,7 +88,7 @@ func (s *assetsTestSuite) TestRegisterSnippetPanics(c *C) {
 			{FirstEdition: 3, Snippet: []byte("more tree")},
 			{FirstEdition: 4, Snippet: []byte("four")},
 		})
-	}, PanicMatches, `first edition 3 repeated in edition snippets "doubled edition"`)
+	}, PanicMatches, `cannot validate snippets "doubled edition": first edition 3 repeated`)
 	// mix unsorted with duplicate edition
 	c.Assert(func() {
 		assets.RegisterSnippetForEditions("unsorted and doubled edition", []assets.ForEditions{
@@ -98,7 +98,7 @@ func (s *assetsTestSuite) TestRegisterSnippetPanics(c *C) {
 			{FirstEdition: 3, Snippet: []byte("more tree")},
 			{FirstEdition: 4, Snippet: []byte("four")},
 		})
-	}, PanicMatches, `edition snippets "unsorted and doubled edition" must be sorted in ascending edition number order`)
+	}, PanicMatches, `cannot validate snippets "unsorted and doubled edition": snippets must be sorted in ascending edition number order`)
 }
 
 func (s *assetsTestSuite) TestEditionSnippets(c *C) {

--- a/bootloader/assets/assetstesting.go
+++ b/bootloader/assets/assetstesting.go
@@ -2,7 +2,7 @@
 // +build withbootassetstesting
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/bootloader/assets/assetstesting.go
+++ b/bootloader/assets/assetstesting.go
@@ -21,22 +21,22 @@
 package assets
 
 import (
-	"fmt"
+	"github.com/snapcore/snapd/logger"
 )
 
 // InjectInternal injects an internal asset under the given name.
 func InjectInternal(name string, data []byte) {
-	fmt.Printf("injecting bootloader asset %q\n", name)
+	logger.Noticef("injecting bootloader asset %q", name)
 	registeredAssets[name] = data
 }
 
-func InternalSnippets(name string) []ForEditions {
+func SnippetsForEditions(name string) []ForEditions {
 	return registeredEditionSnippets[name]
 }
 
 // InjectSnippetForEditions injects a set of snippets under a given key.
-func InjectSnippetForEditions(name string, snippets []ForEditions) {
-	fmt.Printf("injecting bootloader asset edition snippets for %q\n", name)
+func InjectSnippetsForEditions(name string, snippets []ForEditions) {
+	logger.Noticef("injecting bootloader asset edition snippets for %q", name)
 
 	if err := sanitizeSnippets(snippets); err != nil {
 		panic(err)

--- a/bootloader/assets/assetstesting.go
+++ b/bootloader/assets/assetstesting.go
@@ -1,0 +1,45 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build withbootassetstesting
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package assets
+
+import (
+	"fmt"
+)
+
+// InjectInternal injects an internal asset under the given name.
+func InjectInternal(name string, data []byte) {
+	fmt.Printf("injecting bootloader asset %q\n", name)
+	registeredAssets[name] = data
+}
+
+func InternalSnippets(name string) []ForEditions {
+	return registeredEditionSnippets[name]
+}
+
+// InjectSnippetForEditions injects a set of snippets under a given key.
+func InjectSnippetForEditions(name string, snippets []ForEditions) {
+	fmt.Printf("injecting bootloader asset edition snippets for %q\n", name)
+
+	if err := sanitizeSnippets(snippets); err != nil {
+		panic(err)
+	}
+	registeredEditionSnippets[name] = snippets
+}

--- a/bootloader/withbootassettesting.go
+++ b/bootloader/withbootassettesting.go
@@ -2,7 +2,7 @@
 // +build withbootassetstesting
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/bootloader/withbootassettesting.go
+++ b/bootloader/withbootassettesting.go
@@ -1,0 +1,108 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build withbootassetstesting
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package bootloader
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/bootloader/assets"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snapdenv"
+)
+
+var maybeInjectOsReadlink = os.Readlink
+
+func MockMaybeInjectOsReadlink(m func(string) (string, error)) (restore func()) {
+	old := maybeInjectOsReadlink
+	maybeInjectOsReadlink = m
+	return func() {
+		maybeInjectOsReadlink = old
+	}
+}
+
+func MaybeInjectTestingBootloaderAssets() {
+	// this code is ran only when snapd is built with specific testing tag
+
+	if !snapdenv.Testing() {
+		return
+	}
+
+	fmt.Printf("maybe inject boot assets?\n")
+
+	// is there a marker file at /usr/lib/snapd/ in the snap?
+	selfExe, err := maybeInjectOsReadlink("/proc/self/exe")
+	if err != nil {
+		panic(fmt.Sprintf("cannot readlink: %v", err))
+	}
+	if !osutil.FileExists(filepath.Join(filepath.Dir(selfExe), "bootassetstesting")) {
+		fmt.Printf("no boot asset testing marker\n")
+		return
+	}
+
+	// with boot assets testing enabled and the marker file present, inject
+	// a mock boot config update
+
+	grubBootconfig := assets.Internal("grub.cfg")
+	if grubBootconfig == nil {
+		panic("no bootconfig")
+	}
+	snippets := assets.InternalSnippets("grub.cfg:static-cmdline")
+	if len(snippets) == 0 {
+		panic(fmt.Sprintf("cannot obtain internal grub.cfg:static-cmdline snippets"))
+	}
+
+	internalEdition, err := editionFromConfigAsset(bytes.NewReader(grubBootconfig))
+	if err != nil {
+		panic(fmt.Sprintf("cannot inject boot config for asset: %v", err))
+	}
+	// bump he injected edition number
+	injectedEdition := internalEdition + 1
+
+	fmt.Printf("injecting grub boot assets for testing, edition: %v\n", injectedEdition)
+
+	lastSnippet := string(snippets[len(snippets)-1].Snippet)
+	injectedSnippet := lastSnippet + " bootassetstesting"
+	injectedSnippets := append(snippets,
+		assets.ForEditions{FirstEdition: injectedEdition, Snippet: []byte(injectedSnippet)})
+
+	assets.InjectSnippetForEditions("grub.cfg:static-cmdline", injectedSnippets)
+
+	origGrubBoot := string(grubBootconfig)
+	bumpedEdition := strings.Replace(origGrubBoot,
+		fmt.Sprintf("%s%d", editionHeader, internalEdition),
+		fmt.Sprintf("%s%d", editionHeader, injectedEdition),
+		1)
+	// see data/grub.cfg for reference
+	bumpedCmdlineAndEdition := strings.Replace(bumpedEdition,
+		fmt.Sprintf(`set snapd_static_cmdline_args='%s'`, lastSnippet),
+		fmt.Sprintf(`set snapd_static_cmdline_args='%s'`, injectedSnippet),
+		1)
+
+	assets.InjectInternal("grub.cfg", []byte(bumpedCmdlineAndEdition))
+}
+
+func init() {
+	MaybeInjectTestingBootloaderAssets()
+}

--- a/bootloader/withbootassettesting_test.go
+++ b/bootloader/withbootassettesting_test.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build withbootassetstesting
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package bootloader_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/assets"
+	"github.com/snapcore/snapd/snapdenv"
+)
+
+type withbootasetstestingTestSuite struct {
+	baseBootenvTestSuite
+}
+
+var _ = Suite(&withbootasetstestingTestSuite{})
+
+func (s *withbootasetstestingTestSuite) TestInjects(c *C) {
+	d := c.MkDir()
+	c.Assert(ioutil.WriteFile(filepath.Join(d, "bootassetstesting"), nil, 0644), IsNil)
+	restore := bootloader.MockMaybeInjectOsReadlink(func(_ string) (string, error) {
+		return filepath.Join(d, "foo"), nil
+	})
+	defer restore()
+	restore = snapdenv.MockTesting(true)
+	defer restore()
+	restore = assets.MockSnippetsForEdition("grub.cfg:static-cmdline", []assets.ForEditions{
+		{FirstEdition: 2, Snippet: []byte(`foo bar baz`)},
+	})
+	defer restore()
+	restore = assets.MockInternal("grub.cfg", []byte(`# Snapd-Boot-Config-Edition: 5
+set snapd_static_cmdline_args='foo bar baz'
+this is mocked grub-recovery.conf
+`))
+	defer restore()
+
+	os.Readlink("/proc/self/exe")
+
+	bootloader.MaybeInjectTestingBootloaderAssets()
+
+	bumped := assets.Internal("grub.cfg")
+	c.Check(string(bumped), Equals, `# Snapd-Boot-Config-Edition: 6
+set snapd_static_cmdline_args='foo bar baz bootassetstesting'
+this is mocked grub-recovery.conf
+`)
+	cmdline := bootloader.StaticCommandLineForGrubAssetEdition("grub.cfg", 6)
+	c.Check(cmdline, Equals, `foo bar baz bootassetstesting`)
+}

--- a/bootloader/withbootassettesting_test.go
+++ b/bootloader/withbootassettesting_test.go
@@ -2,7 +2,7 @@
 // +build withbootassetstesting
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -66,7 +66,8 @@ TAGS=
 SNAP_TAGS=
 # check if we need to include the testkeys in the binary
 ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
-	TAGS=-tags withtestkeys
+  # if enabled also enable bootloader assets testing
+	TAGS=-tags "withtestkeys withbootassetstesting"
 	SNAP_TAGS=-tags "nomanagers withtestkeys"
 else
 	SNAP_TAGS=-tags nomanagers


### PR DESCRIPTION
Add support for injecting bootloader assets and corresponding snippets in test
builds of snapd. The code is only picked up when building with
`withbootassetstesting `tag.

The snippets are injected only when a specific marker file is present in the
same directory as the snapd binary. This way it is possible to control when a
snapd snap update will trigger an update of boot config assets of the grub
bootloader.
