### PR TITLE
tests: update test pkg for fedora and centos

### DIFF
--- a/tests/lib/tools/tests.pkgs.dnf-yum.sh
+++ b/tests/lib/tools/tests.pkgs.dnf-yum.sh
@@ -15,11 +15,7 @@ remap_one() {
             echo "python3-gobject"
             ;;
         test-snapd-pkg-1)
-            if [ "$(command -v dnf)" != "" ]; then
-                echo "robotfindskitten"
-            else
-                echo "libXft"
-            fi
+            echo "freeglut"
             ;;
         test-snapd-pkg-2)
             echo "texlive-base"


### PR DESCRIPTION
New using freeglut instead of libXft. freeglut is not installed by
default and it is available in all the systems.

This change is to fix:
+ dnf install -y robotfindskitten
...
No match for argument: robotfindskitten
Error: Unable to find a match: robotfindskitten