### PR TITLE
github, run-checks: do not collect coverage data on subsequent test runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -172,7 +172,7 @@ jobs:
       if: steps.cached-results.outputs.already-ran != 'true'
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
+        SKIP_COVERAGE=1 SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
     - name: Test Go (nosecboot)
       if: steps.cached-results.outputs.already-ran != 'true'
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -177,7 +177,8 @@ jobs:
         # install secboot again
         ${{ github.workspace }}/bin/govendor remove github.com/snapcore/secboot
         ${{ github.workspace }}/bin/govendor remove +unused
-        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
+        # we don't need coverage anymore
+        SKIP_COVERAGE=1 SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
     - name: Cache successful run
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")

--- a/run-checks
+++ b/run-checks
@@ -303,7 +303,7 @@ if [ "$UNIT" = 1 ]; then
             echo "Skipping test coverage"
         fi
 
-        if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
+        if command -v dpkg >/dev/null && dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
             # shellcheck disable=SC2046,SC2086
             GOTRACEBACK=1 $goctest $tags -timeout 5m $coverage $(go list ./... | grep -v '/vendor/' )
         else

--- a/run-checks
+++ b/run-checks
@@ -292,21 +292,29 @@ if [ "$UNIT" = 1 ]; then
             # shellcheck disable=SC2046,SC2086
             GOTRACEBACK=1 $goctest $tags -short -timeout 5m $(go list ./... | grep -v '/vendor/' )
     else
-        # Prepare the coverage output profile.
-        rm -rf .coverage
-        mkdir .coverage
-        echo "mode: $COVERMODE" > .coverage/coverage.out
+        coverage=""
+        if [ -z "${SKIP_COVERAGE-}" ]; then
+            coverage="-coverprofile=.coverage/coverage.out -covermode=$COVERMODE"
+            # Prepare the coverage output profile.
+            rm -rf .coverage
+            mkdir .coverage
+            echo "mode: $COVERMODE" > .coverage/coverage.out
+        else
+            echo "Skipping test coverage"
+        fi
 
         if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
             # shellcheck disable=SC2046,SC2086
-            GOTRACEBACK=1 $goctest $tags -timeout 5m -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
+            GOTRACEBACK=1 $goctest $tags -timeout 5m $coverage $(go list ./... | grep -v '/vendor/' )
         else
             for pkg in $(go list ./... | grep -v '/vendor/' ); do
                 # shellcheck disable=SC2086
                 GOTRACEBACK=1 go test $tags -timeout 5m -i "$pkg"
-                # shellcheck disable=SC2086
-                GOTRACEBACK=1 $goctest $tags -timeout 5m -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
-                append_coverage .coverage/profile.out
+                if [ -z "${SKIP_COVERAGE-}" ]; then
+                    # shellcheck disable=SC2086
+                    GOTRACEBACK=1 $goctest $tags -timeout 5m $coverage "$pkg"
+                    append_coverage .coverage/profile.out
+                fi
             done
         fi
     fi


### PR DESCRIPTION
Collecting test coverage data has significant time cost, as we're rerunning the
same test suite twice. There is no need to do so on subsequent test runs. even
with changed build tags.

