### PR TITLE
tests: use 6 spread workers for centos8

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -135,7 +135,7 @@ backends:
                   workers: 6
                   manual: true
             - centos-8-64:
-                  workers: 4
+                  workers: 6
                   storage: preserve-size
                   image: centos-8-64
 


### PR DESCRIPTION
Centos 8 is taking more than 60 minutes to run, we need more workers as
we have for the other systems.
