### PR TITLE
interfaces/browser-support: allow sched_setaffinity with browser-sandbox: true

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -314,6 +314,11 @@ const browserSupportConnectedPlugSecCompWithSandbox = `
 chroot
 sched_setscheduler
 
+# Chromium will attempt to set the affinity of it's renderer threads, primarily
+# on android, but also on Linux where it is available. See 
+# https://github.com/chromium/chromium/blob/99314be8152e688bafbbf9a615536bdbb289ea87/content/common/android/cpu_affinity.cc#L51
+sched_setaffinity
+
 # TODO: fine-tune when seccomp arg filtering available in stable distro
 # releases
 setuid


### PR DESCRIPTION
This is used by chromium to try and optimize some render threads, and there are 
already more dangerous system calls allowed in the browser-sandbox: true policy.

Additionally, on some user's machines this system call is called relentlessly by
Chromium and thus ends up spamming the logs.

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1900679
