### PR TITLE
osutil/stat.go: add RegularFileExists

### DIFF
--- a/osutil/stat.go
+++ b/osutil/stat.go
@@ -124,3 +124,12 @@ func DirExists(fn string) (exists bool, isDir bool, err error) {
 	}
 	return true, st.IsDir(), nil
 }
+
+// RegularFileExists checks whether a given path exists, and if so whether it is a regular file.
+func RegularFileExists(fn string) (exists, isReg bool, err error) {
+	fileStat, err := os.Lstat(fn)
+	if err != nil {
+		return false, false, err
+	}
+	return true, fileStat.Mode().IsRegular(), nil
+}


### PR DESCRIPTION
This can be used like DirExists, to determine if a file exists and is
definitively a regular file and not a socket or a symlink, etc.

Broken out from https://github.com/snapcore/snapd/pull/8699 and added unit tests