### PR TITLE
overlord/devicestate: task for updating boot configs, spread test

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -145,6 +145,9 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	// or gadget snaps. There are no further changes to the boot assets,
 	// unless a new gadget update is deployed.
 	runner.AddHandler("update-gadget-assets", m.doUpdateGadgetAssets, nil)
+	// There is no undo handler for successful boot config update. The
+	// config assets are assumed to be always backwards compatible.
+	runner.AddHandler("update-managed-boot-config", m.doUpdateManagedBootConfig, nil)
 
 	runner.AddBlocked(gadgetUpdateBlocked)
 

--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -119,6 +119,11 @@ func (s *deviceMgrBootconfigSuite) testBootConfigUpdateRun(c *C, updateAttempted
 			log := tsk.Log()
 			c.Assert(log, HasLen, 1)
 			c.Check(log[0], Matches, ".* updated boot config assets")
+			// update was applied, thus a restart was requested
+			c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystem})
+		} else {
+			// update was not applied or failed
+			c.Check(s.restartRequests, HasLen, 0)
 		}
 	} else {
 		c.Assert(s.managedbl.UpdateCalls, Equals, 0)

--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -1,0 +1,228 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestate_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+)
+
+type deviceMgrBootconfigSuite struct {
+	deviceMgrBaseSuite
+
+	managedbl *bootloadertest.MockTrustedAssetsBootloader
+}
+
+var _ = Suite(&deviceMgrBootconfigSuite{})
+
+func (s *deviceMgrBootconfigSuite) SetUpTest(c *C) {
+	s.deviceMgrBaseSuite.SetUpTest(c)
+
+	s.managedbl = bootloadertest.Mock("mock", c.MkDir()).WithTrustedAssets()
+	bootloader.Force(s.managedbl)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	devicestate.SetBootOkRan(s.mgr, true)
+	si := &snap.SideInfo{
+		RealName: "pc",
+		Revision: snap.R(33),
+		SnapID:   "foo-id",
+	}
+	snapstate.Set(s.state, "pc", &snapstate.SnapState{
+		SnapType: "gadget",
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		Active:   true,
+	})
+	s.state.Set("seeded", true)
+
+	// minimal mocking to reach the mocked bootloader API call
+	modeenv := boot.Modeenv{
+		Mode:           "run",
+		RecoverySystem: "",
+		CurrentKernelCommandLines: []string{
+			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+		},
+	}
+	err := modeenv.WriteTo("")
+	c.Assert(err, IsNil)
+}
+
+func (s *deviceMgrBootconfigSuite) setupUC20Model(c *C) *asserts.Model {
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc-model-20",
+		Serial: "didididi",
+	})
+	return s.makeModelAssertionInState(c, "canonical", "pc-model-20", mockCore20ModelHeaders)
+}
+
+func (s *deviceMgrBootconfigSuite) testBootConfigUpdateRun(c *C, updateAttempted, applied bool, errMatch string) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.state.Lock()
+	tsk := s.state.NewTask("update-managed-boot-config", "update boot config")
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(tsk)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(chg.IsReady(), Equals, true)
+	if errMatch == "" {
+		c.Check(chg.Err(), IsNil)
+		c.Check(tsk.Status(), Equals, state.DoneStatus)
+	} else {
+		c.Check(chg.Err(), ErrorMatches, errMatch)
+		c.Check(tsk.Status(), Equals, state.ErrorStatus)
+	}
+	if updateAttempted {
+		c.Assert(s.managedbl.UpdateCalls, Equals, 1)
+		if errMatch == "" && applied {
+			// we log on success
+			log := tsk.Log()
+			c.Assert(log, HasLen, 1)
+			c.Check(log[0], Matches, ".* updated boot config assets")
+		}
+	} else {
+		c.Assert(s.managedbl.UpdateCalls, Equals, 0)
+	}
+}
+
+func (s *deviceMgrBootconfigSuite) TestBootConfigUpdateRunSuccess(c *C) {
+	s.state.Lock()
+	s.setupUC20Model(c)
+	s.state.Unlock()
+
+	s.managedbl.Updated = true
+
+	updateAttempted := true
+	updateApplied := true
+	s.testBootConfigUpdateRun(c, updateAttempted, updateApplied, "")
+}
+
+func (s *deviceMgrBootconfigSuite) TestBootConfigUpdateRunButNotUpdated(c *C) {
+	s.state.Lock()
+	s.setupUC20Model(c)
+	s.state.Unlock()
+
+	s.managedbl.Updated = false
+
+	updateAttempted := true
+	updateApplied := false
+	s.testBootConfigUpdateRun(c, updateAttempted, updateApplied, "")
+}
+
+func (s *deviceMgrBootconfigSuite) TestBootConfigUpdateUpdateErr(c *C) {
+	s.state.Lock()
+	s.setupUC20Model(c)
+	s.state.Unlock()
+
+	s.managedbl.UpdateErr = errors.New("update fail")
+	// actually tried to update
+	updateAttempted := true
+	updateApplied := false
+	s.testBootConfigUpdateRun(c, updateAttempted, updateApplied,
+		`(?ms).*cannot update boot config assets: update fail\)`)
+
+}
+
+func (s *deviceMgrBootconfigSuite) TestBootConfigNoUC20(c *C) {
+	s.state.Lock()
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc-model",
+		Serial: "didididi",
+	})
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"base":         "core18",
+	})
+	s.state.Unlock()
+
+	updateAttempted := false
+	updateApplied := false
+	s.testBootConfigUpdateRun(c, updateAttempted, updateApplied, "")
+}
+
+func (s *deviceMgrBootconfigSuite) TestBootConfigRemodelDoNothing(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.state.Lock()
+
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc-model-20",
+		Serial: "didididi",
+	})
+
+	uc20Model := s.setupUC20Model(c)
+	// save the hassle and try a trivial remodel
+	newModel := s.brands.Model("canonical", "pc-model-20", map[string]interface{}{
+		"brand":        "canonical",
+		"model":        "pc-model-20",
+		"architecture": "amd64",
+		"grade":        "dangerous",
+		"base":         "core20",
+		"snaps":        mockCore20ModelSnaps,
+	})
+	remodCtx, err := devicestate.RemodelCtx(s.state, uc20Model, newModel)
+	c.Assert(err, IsNil)
+	// be extra sure
+	c.Check(remodCtx.ForRemodeling(), Equals, true)
+	tsk := s.state.NewTask("update-managed-boot-config", "update boot config")
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(tsk)
+	remodCtx.Init(chg)
+	// replace the bootloader with something that always fails
+	bootloader.ForceError(errors.New("unexpected call"))
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(chg.IsReady(), Equals, true)
+	c.Check(chg.Err(), IsNil)
+	c.Check(tsk.Status(), Equals, state.DoneStatus)
+}

--- a/overlord/devicestate/handlers_bootconfig.go
+++ b/overlord/devicestate/handlers_bootconfig.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/devicestate/handlers_bootconfig.go
+++ b/overlord/devicestate/handlers_bootconfig.go
@@ -74,6 +74,7 @@ func (m *DeviceManager) doUpdateManagedBootConfig(t *state.Task, _ *tomb.Tomb) e
 		st.RequestRestart(state.RestartSystem)
 	}
 
+	// minimize wasteful redos
 	t.SetStatus(state.DoneStatus)
 	return nil
 }

--- a/overlord/devicestate/handlers_bootconfig.go
+++ b/overlord/devicestate/handlers_bootconfig.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestate
+
+import (
+	"fmt"
+
+	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
+)
+
+func (m *DeviceManager) doUpdateManagedBootConfig(t *state.Task, _ *tomb.Tomb) error {
+	if release.OnClassic {
+		return fmt.Errorf("cannot run update boot config task on a classic system")
+	}
+
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var seeded bool
+	err := st.Get("seeded", &seeded)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	if !seeded {
+		// do nothing during first boot & seeding
+		return nil
+	}
+	devCtx, err := DeviceCtx(st, t, nil)
+	if err != nil {
+		return err
+	}
+
+	if devCtx.Model().Grade() == asserts.ModelGradeUnset {
+		// pre UC20 system, do nothing
+		return nil
+	}
+	if devCtx.ForRemodeling() {
+		// TODO:UC20: we may need to update the boot config when snapd
+		// channel is changed during remodel
+		return nil
+	}
+	// TODO:UC20 update recovery boot config
+	updated, err := boot.UpdateManagedBootConfigs(devCtx)
+	if err != nil {
+		return fmt.Errorf("cannot update boot config assets: %v", err)
+	}
+	if updated {
+		t.Logf("updated boot config assets")
+		// XXX: request a system reboot now?
+	}
+
+	t.SetStatus(state.DoneStatus)
+	return nil
+}

--- a/overlord/devicestate/handlers_bootconfig.go
+++ b/overlord/devicestate/handlers_bootconfig.go
@@ -68,7 +68,10 @@ func (m *DeviceManager) doUpdateManagedBootConfig(t *state.Task, _ *tomb.Tomb) e
 	}
 	if updated {
 		t.Logf("updated boot config assets")
-		// XXX: request a system reboot now?
+		// boot assets were updated, request a restart now so that the
+		// situation does not end up more complicated if more updates of
+		// boot assets were to be applied
+		st.RequestRestart(state.RestartSystem)
 	}
 
 	t.SetStatus(state.DoneStatus)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -295,6 +295,14 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	addTask(setupAliases)
 	prev = setupAliases
 
+	if !release.OnClassic && snapsup.Type == snap.TypeSnapd {
+		// only run for core devices and the snapd snap, run late enough
+		// so that the task is executed by the new snapd
+		bootConfigUpdate := st.NewTask("update-managed-boot-config", fmt.Sprintf(i18n.G("Update managed boot config assets from %q%s"), snapsup.InstanceName(), revisionStr))
+		addTask(bootConfigUpdate)
+		prev = bootConfigUpdate
+	}
+
 	if runRefreshHooks {
 		postRefreshHook := SetupPostRefreshHook(st, snapsup.InstanceName())
 		addTask(postRefreshHook)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -380,6 +380,7 @@ const (
 	runCoreConfigure
 	doesReRefresh
 	updatesGadget
+	updatesBootConfig
 	noConfigure
 )
 

--- a/tests/nested/core20/boot-config-update/task.yaml
+++ b/tests/nested/core20/boot-config-update/task.yaml
@@ -1,0 +1,47 @@
+summary: Check that a kernel refresh reseals
+
+systems: [ubuntu-20.04-64]
+
+prepare: |
+  # shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  # repack the snapd snap with a marker file
+  unsquashfs -d snapd-snap snapd-from-deb.snap
+
+  # leave a marker file that triggers boot config assets to be injected
+  echo 'bootassetstesting' > snapd-snap/usr/lib/snapd/bootassetstesting
+
+  snap pack snapd-snap --filename=snapd-boot-config-update.snap
+  rm -rf snapd-snap
+  nested_copy snapd-boot-config-update.snap
+
+execute: |
+  # shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  SEALED_KEY_MTIME_1="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  RESEAL_COUNT_1="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+
+  # Install new (unasserted) kernel and wait for reboot/change finishing
+  boot_id="$( nested_get_boot_id )"
+  REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous snapd-boot-config-update.snap --no-wait)
+  nested_exec sudo snap watch "${REMOTE_CHG_ID}"
+  # boot assets have been updated
+  nested_exec "sudo cat /boot/grub/grub.cfg" | MATCH "Snapd-Boot-Config-Edition: 2"
+  nested_exec "sudo cat /boot/grub/grub.cfg" | MATCH "set snapd_static_cmdline_args='.*bootassetstesting'"
+  # TODO: this should be automatically requested by snapd
+  nested_exec "sudo reboot" || true
+  nested_wait_for_reboot "${boot_id}"
+
+  nested_exec "cat /proc/cmdline" | MATCH bootassetstesting
+
+  # ensure ubuntu-data.sealed-key mtime is newer
+  SEALED_KEY_MTIME_2="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  test "$SEALED_KEY_MTIME_2" -gt "$SEALED_KEY_MTIME_1"
+
+  # check that we have boot chains
+  nested_exec sudo test -e /var/lib/snapd/device/fde/boot-chains
+
+  RESEAL_COUNT_2="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+  test "$RESEAL_COUNT_2" -gt "$RESEAL_COUNT_1"

--- a/tests/nested/core20/boot-config-update/task.yaml
+++ b/tests/nested/core20/boot-config-update/task.yaml
@@ -30,8 +30,7 @@ execute: |
   # boot assets have been updated
   nested_exec "sudo cat /boot/grub/grub.cfg" | MATCH "Snapd-Boot-Config-Edition: 2"
   nested_exec "sudo cat /boot/grub/grub.cfg" | MATCH "set snapd_static_cmdline_args='.*bootassetstesting'"
-  # TODO: this should be automatically requested by snapd
-  nested_exec "sudo reboot" || true
+  # reboot is automatically requested by snapd
   nested_wait_for_reboot "${boot_id}"
 
   nested_exec "cat /proc/cmdline" | MATCH bootassetstesting

--- a/tests/nested/core20/boot-config-update/task.yaml
+++ b/tests/nested/core20/boot-config-update/task.yaml
@@ -5,7 +5,10 @@ systems: [ubuntu-20.04-64]
 prepare: |
   # shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
+  #shellcheck source=tests/lib/snaps.sh
+  . "$TESTSLIB/snaps.sh"
 
+  repack_snapd_deb_into_snapd_snap "$PWD"
   # repack the snapd snap with a marker file
   unsquashfs -d snapd-snap snapd-from-deb.snap
 

--- a/tests/nested/core20/boot-config-update/task.yaml
+++ b/tests/nested/core20/boot-config-update/task.yaml
@@ -16,14 +16,20 @@ prepare: |
   rm -rf snapd-snap
   nested_copy snapd-boot-config-update.snap
 
+debug: |
+  cat boot-chains-before.json || true
+  cat boot-chains-after.json || true
+
 execute: |
   # shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
+  nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-before.json
   SEALED_KEY_MTIME_1="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
-  RESEAL_COUNT_1="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+  RESEAL_COUNT_1="$(jq -r '.["reseal-count"]' < boot-chains-before.json )"
+  jq -r '.["boot-chains"][]["kernel-cmdlines"][]' < boot-chains-before.json | not MATCH ' bootassetstesting'
 
-  # Install new (unasserted) kernel and wait for reboot/change finishing
+  # Install new (unasserted) snapd and wait for reboot/change finishing
   boot_id="$( nested_get_boot_id )"
   REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous snapd-boot-config-update.snap --no-wait)
   nested_exec sudo snap watch "${REMOTE_CHG_ID}"
@@ -42,5 +48,7 @@ execute: |
   # check that we have boot chains
   nested_exec sudo test -e /var/lib/snapd/device/fde/boot-chains
 
-  RESEAL_COUNT_2="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+  nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-after.json
+  RESEAL_COUNT_2="$(jq -r '.["reseal-count"]' < boot-chains-after.json )"
   test "$RESEAL_COUNT_2" -gt "$RESEAL_COUNT_1"
+  jq -r '.["boot-chains"][]["kernel-cmdlines"][]' < boot-chains-after.json | MATCH ' bootassetstesting'

--- a/tests/nested/core20/boot-config-update/task.yaml
+++ b/tests/nested/core20/boot-config-update/task.yaml
@@ -1,4 +1,4 @@
-summary: Check that a kernel refresh reseals
+summary: Check that the boot config is correctly updated when snapd is refreshed
 
 systems: [ubuntu-20.04-64]
 
@@ -36,11 +36,11 @@ execute: |
   boot_id="$( nested_get_boot_id )"
   REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous snapd-boot-config-update.snap --no-wait)
   nested_exec sudo snap watch "${REMOTE_CHG_ID}"
+  # reboot is automatically requested by snapd
+  nested_wait_for_reboot "${boot_id}"
   # boot assets have been updated
   nested_exec "sudo cat /boot/grub/grub.cfg" | MATCH "Snapd-Boot-Config-Edition: 2"
   nested_exec "sudo cat /boot/grub/grub.cfg" | MATCH "set snapd_static_cmdline_args='.*bootassetstesting'"
-  # reboot is automatically requested by snapd
-  nested_wait_for_reboot "${boot_id}"
 
   nested_exec "cat /proc/cmdline" | MATCH bootassetstesting
 


### PR DESCRIPTION
This is the final branch for updating the run time boot config. It adds a new task that performs the actual update. There's a related spread test that injects a new boot config asset and runs through the update.