### PR TITLE
tests: fix umount for snapd snap on fsck-on-boot test

### DIFF
--- a/tests/core/fsck-on-boot/task.yaml
+++ b/tests/core/fsck-on-boot/task.yaml
@@ -19,7 +19,7 @@ execute: |
       # Refer to the core 16 gadgets for details:
       # https://github.com/snapcore/pc-amd64-gadget/blob/16/gadget.yaml
       # https://github.com/snapcore/pi2-gadget/blob/master/gadget.yaml
-      if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-arm-* ]]; then
+      if os.query is-arm; then
         umount /boot/uboot
       else
         umount /boot/efi
@@ -29,7 +29,7 @@ execute: |
       # Refer to the core 18 gadgets for details:
       # https://github.com/snapcore/pc-amd64-gadget/blob/18/gadget.yaml
       # https://github.com/snapcore/pi2-gadget/blob/18/gadget.yaml
-      if [[ "$SPREAD_SYSTEM" == ubuntu-core-18-arm-* ]]; then
+      if os.query is-arm; then
         umount /boot/uboot
       else
         umount /boot/efi
@@ -47,22 +47,19 @@ execute: |
       # unset RecoverySystem in the modeenv, and it's not necessary for
       # seeding anymore
 
-      # Refer to the core 20 gadgets for details:
-      # https://github.com/snapcore/pc-amd64-gadget/blob/20/gadget.yaml
-      # https://github.com/snapcore/pi-gadget/blob/20-arm64/gadget.yaml
       if mountpoint /run/mnt/snapd >/dev/null; then
-        if [[ "$SPREAD_SYSTEM" == ubuntu-core-20-arm-* ]]; then
           umount /run/mnt/ubuntu-seed/snaps/snapd_*.snap
-        else
-          umount /run/mnt/ubuntu-seed/systems/*/snaps/snapd_*.snap
-        fi
       fi
       umount /var/lib/snapd/seed
       umount /run/mnt/ubuntu-seed
-      if [[ "$SPREAD_SYSTEM" == ubuntu-core-20-arm-* ]]; then
-        umount /boot/uboot
+
+      # Refer to the core 20 gadgets for details:
+      # https://github.com/snapcore/pc-amd64-gadget/blob/20/gadget.yaml
+      # https://github.com/snapcore/pi-gadget/blob/20-arm64/gadget.yaml
+      if os.query is-arm; then
+          umount /boot/uboot
       else
-        umount /boot/efi
+          umount /boot/efi
       fi
     else
       echo "Please adjust the test to support this core system"

--- a/tests/core/fsck-on-boot/task.yaml
+++ b/tests/core/fsck-on-boot/task.yaml
@@ -48,7 +48,7 @@ execute: |
       # seeding anymore
 
       if mountpoint /run/mnt/snapd >/dev/null; then
-          umount /run/mnt/ubuntu-seed/snaps/snapd_*.snap
+        umount /run/mnt/ubuntu-seed/snaps/snapd_*.snap
       fi
       umount /var/lib/snapd/seed
       umount /run/mnt/ubuntu-seed
@@ -57,9 +57,9 @@ execute: |
       # https://github.com/snapcore/pc-amd64-gadget/blob/20/gadget.yaml
       # https://github.com/snapcore/pi-gadget/blob/20-arm64/gadget.yaml
       if os.query is-arm; then
-          umount /boot/uboot
+        umount /boot/uboot
       else
-          umount /boot/efi
+        umount /boot/efi
       fi
     else
       echo "Please adjust the test to support this core system"


### PR DESCRIPTION
This error is faced running beta validation

+ [[ ubuntu-core-20-64 == ubuntu-core-20-arm-* ]]
+ umount '/run/mnt/ubuntu-seed/systems/*/snaps/snapd_*.snap'
umount: /run/mnt/ubuntu-seed/systems/*/snaps/snapd_*.snap: no mount
point specified.

Also, the test now is using the os-query to determine is the system is
running on arm
