### PR TITLE
overlord/servicestate: expose dbus activators of a service

### DIFF
--- a/client/clientutil/snapinfo.go
+++ b/client/clientutil/snapinfo.go
@@ -95,13 +95,15 @@ func ClientAppInfoNotes(app *client.AppInfo) string {
 	}
 
 	var notes = make([]string, 0, 2)
-	var seenTimer, seenSocket bool
+	var seenTimer, seenSocket, seenDbus bool
 	for _, act := range app.Activators {
 		switch act.Type {
 		case "timer":
 			seenTimer = true
 		case "socket":
 			seenSocket = true
+		case "dbus":
+			seenDbus = true
 		}
 	}
 	if seenTimer {
@@ -109,6 +111,9 @@ func ClientAppInfoNotes(app *client.AppInfo) string {
 	}
 	if seenSocket {
 		notes = append(notes, "socket-activated")
+	}
+	if seenDbus {
+		notes = append(notes, "dbus-activated")
 	}
 	if len(notes) == 0 {
 		return "-"

--- a/client/clientutil/snapinfo_test.go
+++ b/client/clientutil/snapinfo_test.go
@@ -266,21 +266,31 @@ func (*cmdSuite) TestAppStatusNotes(c *C) {
 	}
 	c.Check(clientutil.ClientAppInfoNotes(&ai), Equals, "socket-activated")
 
+	ai = client.AppInfo{
+		Daemon: "oneshot",
+		Activators: []client.AppActivator{
+			{Type: "dbus"},
+		},
+	}
+	c.Check(clientutil.ClientAppInfoNotes(&ai), Equals, "dbus-activated")
+
 	// check that the output is stable regardless of the order of activators
 	ai = client.AppInfo{
 		Daemon: "oneshot",
 		Activators: []client.AppActivator{
 			{Type: "timer"},
 			{Type: "socket"},
+			{Type: "dbus"},
 		},
 	}
-	c.Check(clientutil.ClientAppInfoNotes(&ai), Equals, "timer-activated,socket-activated")
+	c.Check(clientutil.ClientAppInfoNotes(&ai), Equals, "timer-activated,socket-activated,dbus-activated")
 	ai = client.AppInfo{
 		Daemon: "oneshot",
 		Activators: []client.AppActivator{
+			{Type: "dbus"},
 			{Type: "socket"},
 			{Type: "timer"},
 		},
 	}
-	c.Check(clientutil.ClientAppInfoNotes(&ai), Equals, "timer-activated,socket-activated")
+	c.Check(clientutil.ClientAppInfoNotes(&ai), Equals, "timer-activated,socket-activated,dbus-activated")
 }

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -228,6 +228,11 @@ func (sd *StatusDecorator) DecorateWithStatus(appInfo *client.AppInfo, snapApp *
 		// nothing to do
 		return nil
 	}
+	if snapApp.DaemonScope != snap.SystemDaemon {
+		// FIXME: the system instance of systemd can't tell us
+		// the state of user daemons, so bail out.
+		return nil
+	}
 
 	// collect all services for a single call to systemctl
 	extra := len(snapApp.Sockets)

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -278,6 +278,19 @@ func (sd *StatusDecorator) DecorateWithStatus(appInfo *client.AppInfo, snapApp *
 			})
 		}
 	}
+	// Decorate with D-Bus names that activate this service
+	for _, slot := range snapApp.ActivatesOn {
+		var busName string
+		if err := slot.Attr("name", &busName); err != nil {
+			return fmt.Errorf("cannot get D-Bus bus name of slot %q: %v", slot.Name, err)
+		}
+		appInfo.Activators = append(appInfo.Activators, client.AppActivator{
+			Name:    busName,
+			Enabled: true,
+			Active:  true,
+			Type:    "dbus",
+		})
+	}
 
 	return nil
 }

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -289,6 +289,11 @@ func (sd *StatusDecorator) DecorateWithStatus(appInfo *client.AppInfo, snapApp *
 		if err := slot.Attr("name", &busName); err != nil {
 			return fmt.Errorf("cannot get D-Bus bus name of slot %q: %v", slot.Name, err)
 		}
+		// D-Bus activators do not correspond to systemd
+		// units, so don't have the concept of being disabled
+		// or deactivated.  As the service activation file is
+		// created when the snap is installed, report as
+		// enabled/active.
 		appInfo.Activators = append(appInfo.Activators, client.AppActivator{
 			Name:    busName,
 			Enabled: true,

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -161,5 +161,36 @@ UnitFileState=%s
 			{Name: "socket1", Type: "socket", Active: enabled, Enabled: enabled},
 		})
 
+		// service with D-Bus activation
+		app = &client.AppInfo{
+			Snap:   snp.InstanceName(),
+			Name:   "svc",
+			Daemon: "simple",
+		}
+		snapApp = &snap.AppInfo{
+			Snap:        snp,
+			Name:        "svc",
+			Daemon:      "simple",
+			DaemonScope: snap.SystemDaemon,
+		}
+		snapApp.ActivatesOn = []*snap.SlotInfo{
+			{
+				Snap:      snp,
+				Name:      "dbus-slot",
+				Interface: "dbus",
+				Attrs: map[string]interface{}{
+					"bus":  "system",
+					"name": "org.example.Svc",
+				},
+			},
+		}
+
+		err = sd.DecorateWithStatus(app, snapApp)
+		c.Assert(err, IsNil)
+		c.Check(app.Active, Equals, enabled)
+		c.Check(app.Enabled, Equals, enabled)
+		c.Check(app.Activators, DeepEquals, []client.AppActivator{
+			{Name: "org.example.Svc", Type: "dbus", Active: true, Enabled: true},
+		})
 	}
 }

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -98,9 +98,10 @@ UnitFileState=%s
 			Daemon: "simple",
 		}
 		snapApp = &snap.AppInfo{
-			Snap:   snp,
-			Name:   "svc",
-			Daemon: "simple",
+			Snap:        snp,
+			Name:        "svc",
+			Daemon:      "simple",
+			DaemonScope: snap.SystemDaemon,
 		}
 
 		err = sd.DecorateWithStatus(app, snapApp)
@@ -192,5 +193,28 @@ UnitFileState=%s
 		c.Check(app.Activators, DeepEquals, []client.AppActivator{
 			{Name: "org.example.Svc", Type: "dbus", Active: true, Enabled: true},
 		})
+
+		// No state is currently extracted for user daemons
+		app = &client.AppInfo{
+			Snap:   snp.InstanceName(),
+			Name:   "svc",
+			Daemon: "simple",
+		}
+		snapApp = &snap.AppInfo{
+			Snap:        snp,
+			Name:        "svc",
+			Daemon:      "simple",
+			DaemonScope: snap.UserDaemon,
+		}
+		snapApp.Timer = &snap.TimerInfo{
+			App:   snapApp,
+			Timer: "10:00",
+		}
+
+		err = sd.DecorateWithStatus(app, snapApp)
+		c.Assert(err, IsNil)
+		c.Check(app.Active, Equals, false)
+		c.Check(app.Enabled, Equals, false)
+		c.Check(app.Activators, HasLen, 0)
 	}
 }

--- a/tests/main/snap-services/task.yaml
+++ b/tests/main/snap-services/task.yaml
@@ -1,7 +1,13 @@
 summary: verify the output of 'snap services' command
 
+prepare: |
+    snap set system experimental.user-daemons=true
+    snap set system experimental.dbus-activation=true
+
 restore: |
     rm -f ./*.out
+    snap unset system experimental.dbus-activation
+    snap unset system experimental.user-daemons
 
 execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-service
@@ -17,3 +23,11 @@ execute: |
 
     snap services test-snapd-service > test-snapd-service.out
     MATCH '^test-snapd-service.test-snapd-service\s+ enabled\s+ active\s+ -$' < test-snapd-service.out
+
+    if tests.session has-system-systemd-and-dbus; then
+        # Only run this part of the test on systems supporting systemd
+        # activation n the D-Bus system bus
+        snap install --edge test-snapd-dbus-service
+        snap services test-snapd-dbus-service > dbus-service.out
+        MATCH '^test-snapd-dbus-service.system\s+ disabled\s+ (in)?active\s+ dbus-activated$' < dbus-service.out
+    fi

--- a/tests/main/snap-services/task.yaml
+++ b/tests/main/snap-services/task.yaml
@@ -26,7 +26,7 @@ execute: |
 
     if tests.session has-system-systemd-and-dbus; then
         # Only run this part of the test on systems supporting systemd
-        # activation n the D-Bus system bus
+        # activation on the D-Bus system bus
         snap install --edge test-snapd-dbus-service
         snap services test-snapd-dbus-service > dbus-service.out
         MATCH '^test-snapd-dbus-service.system\s+ disabled\s+ (in)?active\s+ dbus-activated$' < dbus-service.out


### PR DESCRIPTION
The primary purpose of this branch is to add a "dbus-activated" note to services in the output of `snap services`.  This involved a bit of extra work behind the scenes:

1. update ServiceDecorator in `overlord/servicestate` to add AppActivator entries for each bus name the service activates on.  I've set the Name field to the bus name and Type to "dbus".  I'm setting Enabled and Active to true, since we always install the D-Bus service activation files for the snap, and there is no real equivalent to systemd's "installed but not enabled" state.
2. update ClientAppInfoNotes in `client/clientutil` to convert the presence of a "dbus" activator to a "dbus-activated" note.

I've also updated ServiceDecorator to only try to decorate system daemons, since the current code will fail in the presence of user daemons as the system instance of systemd has no knowledge of them.  This is obviously not the desired final behaviour, but not blowing up is an incremental improvement.  I've left a FIXME comment noting this.