### PR TITLE
gadget: remove resolvedSource from VolumeContent

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -55,6 +55,8 @@ var (
 	ParseRelativeOffset = parseRelativeOffset
 
 	SplitKernelRef = splitKernelRef
+
+	ResolveVolumeContent = resolveVolumeContent
 )
 
 func MockEvalSymlinks(mock func(path string) (string, error)) (restore func()) {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -184,20 +184,6 @@ type VolumeContent struct {
 	Size quantity.Size `yaml:"size"`
 
 	Unpack bool `yaml:"unpack"`
-
-	// resolvedSource is the absolute path of the Source after resolving
-	// any references (e.g. to a "$kernel:" snap)
-	resolvedSource string
-	// TODO: provide resolvedImage too
-}
-
-func (vc VolumeContent) ResolvedSource() string {
-	// TODO: ensure that sources are always resolved and only return
-	//       vc.resolvedSource(). This will come in the next PR.
-	if vc.resolvedSource != "" {
-		return vc.resolvedSource
-	}
-	return vc.UnresolvedSource
 }
 
 func (vc VolumeContent) String() string {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -939,7 +939,7 @@ func IsCompatible(current, new *Info) error {
 
 // LaidOutVolumeFromGadget takes a gadget rootdir and lays out the
 // partitions as specified.
-func LaidOutVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolume, error) {
+func LaidOutVolumeFromGadget(gadgetRoot, kernelRoot string, model Model) (*LaidOutVolume, error) {
 	info, err := ReadInfo(gadgetRoot, model)
 	if err != nil {
 		return nil, err
@@ -955,7 +955,7 @@ func LaidOutVolumeFromGadget(gadgetRoot string, model Model) (*LaidOutVolume, er
 	}
 
 	for _, vol := range info.Volumes {
-		pvol, err := LayoutVolume(gadgetRoot, vol, constraints)
+		pvol, err := LayoutVolume(gadgetRoot, kernelRoot, vol, constraints)
 		if err != nil {
 			return nil, err
 		}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1983,7 +1983,7 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumeFromGadgetMultiVolume(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, mockMultiVolumeGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
-	_, err = gadget.LaidOutVolumeFromGadget(s.dir, nil)
+	_, err = gadget.LaidOutVolumeFromGadget(s.dir, "", nil)
 	c.Assert(err, ErrorMatches, "cannot position multiple volumes yet")
 }
 
@@ -1995,7 +1995,7 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumeFromGadgetHappy(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	lv, err := gadget.LaidOutVolumeFromGadget(s.dir, nil)
+	lv, err := gadget.LaidOutVolumeFromGadget(s.dir, "", nil)
 	c.Assert(err, IsNil)
 	c.Assert(lv.Volume.Bootloader, Equals, "grub")
 	// mbr, bios-boot, efi-system

--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -238,7 +238,7 @@ func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 
 		// copy existing mock
 		m := mockOnDiskStructureSystemSeed
-		m.LaidOutContent = []gadget.LaidOutContent{
+		m.ResolvedContent = []gadget.ResolvedContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
 					UnresolvedSource: "grubx64.efi",

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -53,7 +53,7 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 
 // Run bootstraps the partitions of a device, by either creating
 // missing ones or recreating installed ones.
-func Run(model gadget.Model, gadgetRoot, device string, options Options, observer gadget.ContentObserver) (*InstalledSystemSideData, error) {
+func Run(model gadget.Model, gadgetRoot, kernelRoot, device string, options Options, observer gadget.ContentObserver) (*InstalledSystemSideData, error) {
 	logger.Noticef("installing a new system")
 	logger.Noticef("        gadget data from: %v", gadgetRoot)
 	if options.Encrypt {
@@ -67,6 +67,7 @@ func Run(model gadget.Model, gadgetRoot, device string, options Options, observe
 	if err != nil {
 		return nil, fmt.Errorf("cannot layout the volume: %v", err)
 	}
+	// TODO: resolve content paths from gadget here
 
 	// XXX: the only situation where auto-detect is not desired is
 	//      in (spread) testing - consider to remove forcing a device

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -63,7 +63,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, device string, options Opti
 		return nil, fmt.Errorf("cannot use empty gadget root directory")
 	}
 
-	lv, err := gadget.LaidOutVolumeFromGadget(gadgetRoot, model)
+	lv, err := gadget.LaidOutVolumeFromGadget(gadgetRoot, kernelRoot, model)
 	if err != nil {
 		return nil, fmt.Errorf("cannot layout the volume: %v", err)
 	}

--- a/gadget/install/install_dummy.go
+++ b/gadget/install/install_dummy.go
@@ -26,6 +26,6 @@ import (
 	"github.com/snapcore/snapd/gadget"
 )
 
-func Run(model gadget.Model, gadgetRoot, device string, options Options, _ gadget.ContentObserver) (*InstalledSystemSideData, error) {
+func Run(model gadget.Model, gadgetRoot, kernelRoot, device string, options Options, _ gadget.ContentObserver) (*InstalledSystemSideData, error) {
 	return nil, fmt.Errorf("build without secboot support")
 }

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -377,7 +377,7 @@ func layoutFromYaml(c *C, gadgetYaml string, model gadget.Model) *gadget.LaidOut
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetYaml), 0644)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(gadgetRoot, model)
+	pv, err := gadget.LaidOutVolumeFromGadget(gadgetRoot, "", model)
 	c.Assert(err, IsNil)
 	return pv
 }

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -55,7 +55,7 @@ func (s *installSuite) SetUpTest(c *C) {
 }
 
 func (s *installSuite) TestInstallRunError(c *C) {
-	sys, err := install.Run(nil, "", "", install.Options{}, nil)
+	sys, err := install.Run(nil, "", "", "", install.Options{}, nil)
 	c.Assert(err, ErrorMatches, "cannot use empty gadget root directory")
 	c.Check(sys, IsNil)
 }

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -232,7 +232,7 @@ func (s *partitionTestSuite) TestBuildPartitionList(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, "", uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -267,7 +267,7 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, "", uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -299,7 +299,7 @@ func (s *partitionTestSuite) TestRemovePartitionsTrivial(c *C) {
 
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, "", uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
@@ -363,7 +363,7 @@ echo '{
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, "", uc20Mod)
 	c.Assert(err, IsNil)
 
 	err = install.RemoveCreatedPartitions(pv, dl)
@@ -388,7 +388,7 @@ func (s *partitionTestSuite) TestRemovePartitionsError(c *C) {
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, "", uc20Mod)
 	c.Assert(err, IsNil)
 
 	err = install.RemoveCreatedPartitions(pv, dl)
@@ -550,7 +550,7 @@ echo '{
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, "", uc20Mod)
 	c.Assert(err, IsNil)
 
 	dl, err := gadget.OnDiskVolumeFromDevice("node")
@@ -671,7 +671,7 @@ echo '{
 
 	err = makeMockGadget(s.gadgetRoot, mbrGadgetContentWithSave)
 	c.Assert(err, IsNil)
-	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, uc20Mod)
+	pv, err := gadget.LaidOutVolumeFromGadget(s.gadgetRoot, "", uc20Mod)
 	c.Assert(err, IsNil)
 
 	list := install.CreatedDuringInstall(pv, dl)

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -56,7 +56,7 @@ func (p *layoutTestSuite) TestVolumeSize(c *C) {
 			{Size: 2 * quantity.SizeMiB},
 		},
 	}
-	v, err := gadget.LayoutVolume(p.dir, &vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", &vol, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -98,7 +98,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first-image")
 	c.Assert(vol.Structure, HasLen, 2)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -141,7 +141,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 4)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -198,7 +198,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 4)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -254,7 +254,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 4)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -301,7 +301,7 @@ volumes:
               - image: foo.img
 `
 	vol := mustParseVolume(c, gadgetYaml, "first")
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img":.*no such file or directory`)
 }
@@ -339,7 +339,7 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" does not fit in the structure`)
 }
@@ -366,7 +366,7 @@ volumes:
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
 		SectorSize:        512,
 	}
-	v, err := gadget.LayoutVolume(p.dir, vol, constraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, constraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "bar.img" does not fit in the structure`)
 }
@@ -389,7 +389,7 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" does not fit in the structure`)
 }
@@ -411,7 +411,7 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot lay out structure #0: content "foo.img" size %v is larger than declared %v`, quantity.SizeMiB+1, quantity.SizeMiB))
 }
@@ -439,7 +439,7 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" overlaps with preceding image "bar.img"`)
 }
@@ -468,7 +468,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 1)
 	c.Assert(vol.Structure[0].Content, HasLen, 2)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -520,7 +520,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 1)
 	c.Assert(vol.Structure[0].Content, HasLen, 2)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -569,7 +569,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 1)
 	c.Assert(vol.Structure[0].Content, HasLen, 1)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -612,7 +612,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 1)
 	c.Assert(vol.Structure[0].Content, HasLen, 1)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -621,8 +621,17 @@ volumes:
 		RootDir:    p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
-				VolumeStructure: &vol.Structure[0],
 				StartOffset:     1 * quantity.OffsetMiB,
+				VolumeStructure: &vol.Structure[0],
+				ResolvedContent: []gadget.ResolvedContent{
+					{
+						VolumeContent: &gadget.VolumeContent{
+							UnresolvedSource: "foo.txt",
+							Target:           "/boot",
+						},
+						ResolvedSource: filepath.Join(p.dir, "foo.txt"),
+					},
+				},
 			},
 		},
 	})
@@ -646,13 +655,23 @@ volumes:
               - source: foo.txt
                 target: /boot
 `
+	resolvedContent := []gadget.ResolvedContent{
+		{
+			VolumeContent: &gadget.VolumeContent{
+				UnresolvedSource: "foo.txt",
+				Target:           "/boot",
+			},
+			ResolvedSource: filepath.Join(p.dir, "foo.txt"),
+		},
+	}
+
 	makeSizedFile(c, filepath.Join(p.dir, "foo.txt"), 0, []byte("foobar\n"))
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 2)
 	c.Assert(vol.Structure[1].Content, HasLen, 1)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -669,6 +688,7 @@ volumes:
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     1 * quantity.OffsetMiB,
 				Index:           1,
+				ResolvedContent: resolvedContent,
 			},
 		},
 	})
@@ -679,7 +699,7 @@ volumes:
 		NonMBRStartOffset: 512 * quantity.OffsetKiB,
 		SectorSize:        512,
 	}
-	v, err = gadget.LayoutVolume(p.dir, vol, constraints)
+	v, err = gadget.LayoutVolume(p.dir, "", vol, constraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -696,6 +716,7 @@ volumes:
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     512 * quantity.OffsetKiB,
 				Index:           1,
+				ResolvedContent: resolvedContent,
 			},
 		},
 	})
@@ -707,7 +728,7 @@ volumes:
 		NonMBRStartOffset: 400,
 		SectorSize:        512,
 	}
-	v, err = gadget.LayoutVolume(p.dir, vol, constraintsBad)
+	v, err = gadget.LayoutVolume(p.dir, "", vol, constraintsBad)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -723,6 +744,7 @@ volumes:
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     446,
 				Index:           1,
+				ResolvedContent: resolvedContent,
 			},
 		},
 	})
@@ -732,7 +754,7 @@ volumes:
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
 		SectorSize:        1024,
 	}
-	v, err = gadget.LayoutVolume(p.dir, vol, constraintsSector)
+	v, err = gadget.LayoutVolume(p.dir, "", vol, constraintsSector)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -748,6 +770,7 @@ volumes:
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     1 * quantity.OffsetMiB,
 				Index:           1,
+				ResolvedContent: resolvedContent,
 			},
 		},
 	})
@@ -779,7 +802,7 @@ volumes:
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
 		SectorSize:        384,
 	}
-	_, err := gadget.LayoutVolume(p.dir, vol, constraintsBadSectorSize)
+	_, err := gadget.LayoutVolume(p.dir, "", vol, constraintsBadSectorSize)
 	c.Assert(err, ErrorMatches, "cannot lay out volume, structure #1 size is not a multiple of sector size 384")
 }
 
@@ -788,7 +811,7 @@ func (p *layoutTestSuite) TestLayoutVolumeConstraintsNeedsSectorSize(c *C) {
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
 		// SectorSize left unspecified
 	}
-	_, err := gadget.LayoutVolume(p.dir, &gadget.Volume{}, constraintsBadSectorSize)
+	_, err := gadget.LayoutVolume(p.dir, "", &gadget.Volume{}, constraintsBadSectorSize)
 	c.Assert(err, ErrorMatches, "cannot lay out volume, invalid constraints: sector size cannot be 0")
 }
 
@@ -810,7 +833,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 2)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -863,7 +886,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "pc")
 	c.Assert(vol.Structure, HasLen, 3)
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:     vol,
@@ -949,11 +972,11 @@ func (p *layoutTestSuite) TestLayoutVolumeOffsetWriteBadRelativeTo(c *C) {
 
 	makeSizedFile(c, filepath.Join(p.dir, "foo.img"), 200*quantity.SizeKiB, []byte(""))
 
-	v, err := gadget.LayoutVolume(p.dir, &volBadStructure, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", &volBadStructure, defaultConstraints)
 	c.Check(v, IsNil)
 	c.Check(err, ErrorMatches, `cannot resolve offset-write of structure #0 \("foo"\): refers to an unknown structure "bar"`)
 
-	v, err = gadget.LayoutVolume(p.dir, &volBadContent, defaultConstraints)
+	v, err = gadget.LayoutVolume(p.dir, "", &volBadContent, defaultConstraints)
 	c.Check(v, IsNil)
 	c.Check(err, ErrorMatches, `cannot resolve offset-write of structure #0 \("foo"\) content "foo.img": refers to an unknown structure "bar"`)
 }
@@ -977,7 +1000,7 @@ volumes:
 `
 	vol := mustParseVolume(c, gadgetYamlStructure, "pc")
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	// offset-write is at 1GB
 	c.Check(v.Size, Equals, 1*quantity.SizeGiB+gadget.SizeLBA48Pointer)
@@ -1012,7 +1035,7 @@ volumes:
 
 	vol = mustParseVolume(c, gadgetYamlContent, "pc")
 
-	v, err = gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err = gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	// foo.img offset-write is at 3GB
 	c.Check(v.Size, Equals, 3*quantity.SizeGiB+gadget.SizeLBA48Pointer)
@@ -1071,7 +1094,7 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYamlContent, "pc")
 
-	v, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v.LaidOutStructure, HasLen, 1)
 	c.Assert(v.LaidOutStructure[0].LaidOutContent, HasLen, 2)
@@ -1184,23 +1207,15 @@ var gadgetYamlWithKernelRef = `
 `
 
 func (p *layoutTestSuite) TestResolveContentPathsNotInWantedAssets(c *C) {
-	kernelYaml := ""
-
 	vol := mustParseVolume(c, gadgetYamlWithKernelRef, "pi")
 	c.Assert(vol.Structure, HasLen, 1)
 
-	kernelSnapFiles := map[string]string{}
-	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
-	lv, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
-	c.Assert(err, IsNil)
-
-	err = gadget.ResolveContentPaths(lv, p.dir, kernelSnapDir)
+	kernelSnapDir := c.MkDir()
+	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
 	c.Assert(err, ErrorMatches, `cannot find "dtbs" in kernel info from "/.*"`)
 }
 
 func (p *layoutTestSuite) TestResolveContentPathsErrorInKernelRef(c *C) {
-	kernelYaml := ""
-
 	// create invalid kernel ref
 	s := strings.Replace(gadgetYamlWithKernelRef, "$kernel:dtbs", "$kernel:-invalid-kernel-ref", -1)
 	// Note that mustParseVolume does not call ValidateContent() which
@@ -1208,12 +1223,8 @@ func (p *layoutTestSuite) TestResolveContentPathsErrorInKernelRef(c *C) {
 	vol := mustParseVolume(c, s, "pi")
 	c.Assert(vol.Structure, HasLen, 1)
 
-	kernelSnapFiles := map[string]string{}
-	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
-	lv, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
-	c.Assert(err, IsNil)
-
-	err = gadget.ResolveContentPaths(lv, p.dir, kernelSnapDir)
+	kernelSnapDir := c.MkDir()
+	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
 	c.Assert(err, ErrorMatches, `cannot parse kernel ref: invalid asset name in kernel ref "\$kernel:-invalid-kernel-ref/boot-assets/"`)
 }
 
@@ -1231,10 +1242,7 @@ assets:
 
 	kernelSnapFiles := map[string]string{}
 	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
-	lv, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
-	c.Assert(err, IsNil)
-
-	err = gadget.ResolveContentPaths(lv, p.dir, kernelSnapDir)
+	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
 	c.Assert(err, ErrorMatches, `cannot find wanted kernel content "boot-assets/" in "/.*"`)
 }
 
@@ -1254,10 +1262,11 @@ assets:
 		"boot-assets/foo": "foo-content",
 	}
 	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
-	lv, err := gadget.LayoutVolume(p.dir, vol, defaultConstraints)
+	lv, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
 	c.Assert(err, IsNil)
-	content := lv.Volume.Structure[0].Content
-	c.Assert(content, DeepEquals, []gadget.VolumeContent{
+	// Volume.Content is unchanged
+	c.Assert(lv.Structure, HasLen, 1)
+	c.Check(lv.Structure[0].Content, DeepEquals, []gadget.VolumeContent{
 		{
 			UnresolvedSource: "$kernel:dtbs/boot-assets/",
 			Target:           "/",
@@ -1275,19 +1284,24 @@ assets:
 			Target:           "/",
 		},
 	})
-
-	// now resolve the kernel references
-	err = gadget.ResolveContentPaths(lv, p.dir, kernelSnapDir)
-	c.Assert(err, IsNil)
-
-	c.Assert(lv.Volume.Structure, HasLen, 1)
-	c.Check(content, HasLen, 4)
-	// note the trailing "/" here
-	c.Check(content[0].ResolvedSource(), Equals, filepath.Join(kernelSnapDir, "boot-assets/")+"/")
-	// no trailing "/" here
-	c.Check(content[1].ResolvedSource(), Equals, filepath.Join(kernelSnapDir, "some-file"))
-	// from gadget, no trailing "/" here
-	c.Check(content[2].ResolvedSource(), Equals, filepath.Join(p.dir, "file-from-gadget"))
-	// note the trailing "/" here
-	c.Check(content[3].ResolvedSource(), Equals, filepath.Join(p.dir, "dir-from-gadget")+"/")
+	// and the LaidOutSturctures ResolvedContent has the correct paths
+	c.Assert(lv.LaidOutStructure, HasLen, 1)
+	c.Check(lv.LaidOutStructure[0].ResolvedContent, DeepEquals, []gadget.ResolvedContent{
+		{
+			VolumeContent:  &lv.Structure[0].Content[0],
+			ResolvedSource: filepath.Join(kernelSnapDir, "boot-assets/") + "/",
+		},
+		{
+			VolumeContent:  &lv.Structure[0].Content[1],
+			ResolvedSource: filepath.Join(kernelSnapDir, "some-file"),
+		},
+		{
+			VolumeContent:  &lv.Structure[0].Content[2],
+			ResolvedSource: filepath.Join(p.dir, "file-from-gadget"),
+		},
+		{
+			VolumeContent:  &lv.Structure[0].Content[3],
+			ResolvedSource: filepath.Join(p.dir, "dir-from-gadget") + "/",
+		},
+	})
 }

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -145,6 +145,12 @@ func verifyDirContents(c *C, where string, expected map[string]contentType) {
 	}
 }
 
+func (s *mountedfilesystemTestSuite) mustResolveVolumeContent(c *C, ps *gadget.LaidOutStructure) {
+	rc, err := gadget.ResolveVolumeContent(s.dir, "", nil, ps)
+	c.Assert(err, IsNil)
+	ps.ResolvedContent = rc
+}
+
 func (s *mountedfilesystemTestSuite) TestWriteFile(c *C) {
 	makeSizedFile(c, filepath.Join(s.dir, "foo"), 0, []byte("foo foo foo"))
 
@@ -344,6 +350,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterHappy(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	outDir := c.MkDir()
 
@@ -418,6 +425,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterNonDirectory(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	outDir := c.MkDir()
 
@@ -443,6 +451,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorMissingSource(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	outDir := c.MkDir()
 
@@ -474,6 +483,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorBadDestination(c *C) 
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	outDir := c.MkDir()
 
@@ -511,6 +521,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterConflictingDestinationDire
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, psOverwritesDirectoryWithFile)
 
 	outDir := c.MkDir()
 
@@ -545,6 +556,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterConflictingDestinationFile
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, psOverwritesFile)
 
 	outDir := c.MkDir()
 
@@ -579,6 +591,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterErrorNested(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	outDir := c.MkDir()
 
@@ -664,6 +677,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterPreserve(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
@@ -784,6 +798,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterImplicitDir(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	outDir := c.MkDir()
 
@@ -835,6 +850,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterTrivialValidation(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err = gadget.NewMountedFilesystemWriter("", ps, nil)
 	c.Assert(err, ErrorMatches, `internal error: gadget content directory cannot be unset`)
@@ -850,7 +866,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterTrivialValidation(c *C) {
 	err = rw.Write(d, nil)
 	c.Assert(err, ErrorMatches, "cannot write filesystem content .* source cannot be unset")
 
-	ps.Content[0].UnresolvedSource = "/"
+	ps.ResolvedContent[0].UnresolvedSource = "/"
 	err = rw.Write(d, nil)
 	c.Assert(err, ErrorMatches, "cannot write filesystem content .* target cannot be unset")
 }
@@ -876,6 +892,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterSymlinks(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemWriter(s.dir, ps, nil)
 	c.Assert(err, IsNil)
@@ -1008,6 +1025,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupSimple(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	muo := &mockContentUpdateObserver{
 		c:              c,
@@ -1104,6 +1122,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterObserverErr(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	outDir := c.MkDir()
 	obs := &mockWriteObserver{
@@ -1167,6 +1186,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupWithDirectories(c *
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1221,6 +1241,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupNonexistent(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1259,6 +1280,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnBackupDirErr
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1309,6 +1331,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnDestinationE
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1354,6 +1377,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFailsOnBadSrcCompar
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1406,6 +1430,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFunnyNamesConflictB
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	backupBar := filepath.Join(s.backup, "backup-bar")
 	backupFoo := filepath.Join(s.backup, "backup-foo")
@@ -1468,6 +1493,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupFunnyNamesOk(c *C) 
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1514,6 +1540,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupErrorOnSymlinkFile(
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1551,6 +1578,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupErrorOnSymlinkInPre
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1655,6 +1683,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterUpdate(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	muo := &mockContentUpdateObserver{
 		c:              c,
@@ -1790,6 +1819,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterDirContents(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1845,6 +1875,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterExpectsBackup(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1903,6 +1934,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEmptyDir(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -1960,6 +1992,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterSameFileSkipped(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2013,6 +2046,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterLonePrefix(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2049,6 +2083,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterUpdateErrorOnSymlinkToFil
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2087,6 +2122,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterBackupErrorOnSymlinkToDir
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2135,6 +2171,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackFromBackup(c *C) 
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	muo := &mockContentUpdateObserver{
 		c:              c,
@@ -2202,6 +2239,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackSkipSame(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	muo := &mockContentUpdateObserver{
 		c:              c,
@@ -2255,6 +2293,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackSkipPreserved(c *
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	muo := &mockContentUpdateObserver{
 		c:              c,
@@ -2313,6 +2352,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackNewFiles(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	muo := &mockContentUpdateObserver{
 		c:              c,
@@ -2387,6 +2427,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackRestoreFails(c *C
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -2446,6 +2487,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackNotWritten(c *C) 
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	muo := &mockContentUpdateObserver{
 		c:              c,
@@ -2529,6 +2571,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterRollbackDirectory(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	muo := &mockContentUpdateObserver{
 		c:              c,
@@ -2707,6 +2750,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterEndToEndOne(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	muo := &mockContentUpdateObserver{
 		c:              c,
@@ -2920,6 +2964,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterTrivialValidation(c *C) {
 			Content:    []gadget.VolumeContent{},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err = gadget.NewMountedFilesystemUpdater("", ps, s.backup, lookupFail, nil)
 	c.Assert(err, ErrorMatches, `internal error: gadget content directory cannot be unset`)
@@ -2955,6 +3000,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterTrivialValidation(c *C) {
 				Content:    []gadget.VolumeContent{tc.content},
 			},
 		}
+		s.mustResolveVolumeContent(c, testPs)
 
 		rw, err := gadget.NewMountedFilesystemUpdater(s.dir, testPs, s.backup, lookupOk, nil)
 		c.Assert(err, IsNil)
@@ -2984,6 +3030,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterMountLookupFail(c *C) {
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	lookupFail := func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -3020,6 +3067,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterNonFilePreserveError(c *C
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
 
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, ps, s.backup, func(to *gadget.LaidOutStructure) (string, error) {
 		c.Check(to, DeepEquals, ps)
@@ -3071,6 +3119,8 @@ managed grub.cfg from disk`
 			},
 		},
 	}
+	s.mustResolveVolumeContent(c, ps)
+
 	obs := &mockContentUpdateObserver{
 		c:               c,
 		expectedStruct:  ps,
@@ -3164,6 +3214,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterObserverPreserveNewFile(c
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, psForObserver, s.backup,
 		func(to *gadget.LaidOutStructure) (string, error) {
 			c.Check(to, DeepEquals, psForObserver)
+			s.mustResolveVolumeContent(c, psForObserver)
 			return outDir, nil
 		},
 		obs)
@@ -3222,6 +3273,7 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterObserverPreserveExistingF
 	rw, err := gadget.NewMountedFilesystemUpdater(s.dir, psForObserver, s.backup,
 		func(to *gadget.LaidOutStructure) (string, error) {
 			c.Check(to, DeepEquals, psForObserver)
+			s.mustResolveVolumeContent(c, psForObserver)
 			return outDir, nil
 		},
 		obs)

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -152,7 +152,7 @@ func Update(old, new GadgetData, rollbackDirPath string, updatePolicy UpdatePoli
 	}
 
 	// layout new
-	pNew, err := LayoutVolume(new.RootDir, newVol, defaultConstraints)
+	pNew, err := LayoutVolume(new.RootDir, new.KernelRootDir, newVol, defaultConstraints)
 	if err != nil {
 		return fmt.Errorf("cannot lay out the new volume: %v", err)
 	}

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -43,8 +43,12 @@ var (
 type GadgetData struct {
 	// Info is the gadget metadata
 	Info *Info
+	// XXX: should be GadgetRootDir
 	// RootDir is the root directory of gadget snap data
 	RootDir string
+
+	// KernelRootDir is the root directory of kernel snap data
+	KernelRootDir string
 }
 
 // UpdatePolicyFunc is a callback that evaluates the provided pair of structures

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -344,7 +344,10 @@ func ValidateContent(info *Info, gadgetSnapRootDir string) error {
 	// the gadget uses and as such there cannot be more than one
 	// such bootloader
 	for name, vol := range info.Volumes {
-		lv, err := LayoutVolume(gadgetSnapRootDir, vol, defaultConstraints)
+		// At this point we don't know what kernel will be used
+		// with the gadget we we need to pass an empty kernel root
+		kernelRootDir := ""
+		lv, err := LayoutVolume(gadgetSnapRootDir, kernelRootDir, vol, defaultConstraints)
 		if err != nil {
 			return fmt.Errorf("invalid layout of volume %q: %v", name, err)
 		}

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -325,7 +325,7 @@ func validateVolumeContentsPresence(gadgetSnapRootDir string, vol *LaidOutVolume
 			if !osutil.FileExists(realSource) {
 				return fmt.Errorf("structure %v, content %v: source path does not exist", s, c)
 			}
-			if strings.HasSuffix(c.ResolvedSource(), "/") {
+			if strings.HasSuffix(c.UnresolvedSource, "/") {
 				// expecting a directory
 				if err := checkSourceIsDir(realSource + "/"); err != nil {
 					return fmt.Errorf("structure %v, content %v: %v", s, c, err)

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -194,7 +194,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	var brOpts install.Options
 	var installRunCalled int
 	var installSealingObserver gadget.ContentObserver
-	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, device string, options install.Options, obs gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
+	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, obs gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		// ensure we can grab the lock here, i.e. that it's not taken
 		s.state.Lock()
 		s.state.Unlock()
@@ -341,7 +341,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
+	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		return nil, fmt.Errorf("The horror, The horror")
 	})
 	defer restore()
@@ -519,7 +519,7 @@ func (s *deviceMgrInstallModeSuite) testInstallEncryptionSanityChecks(c *C, errM
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoKeys(c *C) {
-	restore := devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
+	restore := devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		c.Check(options.Encrypt, Equals, true)
 		// no keys set
 		return &install.InstalledSystemSideData{}, nil
@@ -530,7 +530,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoKeys(c *C
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoSystemDataKey(c *C) {
-	restore := devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
+	restore := devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		c.Check(options.Encrypt, Equals, true)
 		// no keys set
 		return &install.InstalledSystemSideData{
@@ -547,7 +547,7 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade, gadg
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
+	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		return nil, nil
 	})
 	defer restore()
@@ -761,7 +761,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithEncryptionValidatesGadgetErr(
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
+	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		return nil, fmt.Errorf("unexpected call")
 	})
 	defer restore()
@@ -786,7 +786,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithoutEncryptionValidatesGadgetW
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
+	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver) (*install.InstalledSystemSideData, error) {
 		return nil, nil
 	})
 	defer restore()

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -264,7 +264,7 @@ func MockSysconfigConfigureTargetSystem(f func(opts *sysconfig.Options) error) (
 	}
 }
 
-func MockInstallRun(f func(model gadget.Model, gadgetRoot, device string, options install.Options, observer gadget.ContentObserver) (*install.InstalledSystemSideData, error)) (restore func()) {
+func MockInstallRun(f func(model gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, observer gadget.ContentObserver) (*install.InstalledSystemSideData, error)) (restore func()) {
 	old := installRun
 	installRun = f
 	return func() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -113,6 +113,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		return fmt.Errorf("cannot get kernel info: %v", err)
 	}
+	kernelDir := kernelInfo.MountDir()
 
 	modeEnv, err := maybeReadModeenv()
 	if err != nil {
@@ -168,7 +169,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	func() {
 		st.Unlock()
 		defer st.Lock()
-		installedSystem, err = installRun(model, gadgetDir, "", bopts, installObserver)
+		installedSystem, err = installRun(model, gadgetDir, kernelDir, "", bopts, installObserver)
 	}()
 	if err != nil {
 		return fmt.Errorf("cannot install system: %v", err)

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -39,6 +39,7 @@ type cmdCreatePartitions struct {
 
 	Positional struct {
 		GadgetRoot string `positional-arg-name:"<gadget-root>"`
+		KernelRoot string `positional-arg-name:"<kernel-root>"`
 		Device     string `positional-arg-name:"<device>"`
 	} `positional-args:"yes"`
 }
@@ -58,8 +59,8 @@ func (o *simpleObserver) ChosenEncryptionKey(key secboot.EncryptionKey) {}
 
 type uc20Constraints struct{}
 
-func (c uc20Constraints) Classic() bool  { return false }
-func (c uc20Constraints) Grade() asserts.ModelGrade  { return asserts.ModelSigned }
+func (c uc20Constraints) Classic() bool             { return false }
+func (c uc20Constraints) Grade() asserts.ModelGrade { return asserts.ModelSigned }
 
 func main() {
 	args := &cmdCreatePartitions{}
@@ -74,7 +75,7 @@ func main() {
 		Mount:   args.Mount,
 		Encrypt: args.Encrypt,
 	}
-	installSideData, err := installRun(uc20Constraints{}, args.Positional.GadgetRoot, args.Positional.Device, options, obs)
+	installSideData, err := installRun(uc20Constraints{}, args.Positional.GadgetRoot, args.Positional.KernelRoot, args.Positional.Device, options, obs)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -92,12 +92,15 @@ execute: |
     sbverify --list "$seedbootdir"/bootx64.efi
     sbverify --list "$seedbootdir"/grubx64.efi
     sbverify --list "$bootdir"/grubx64.efi
+    # TODO:UC20: make kernel-dir non-empty once we have a gadget that has a
+    #            "$kernel:" style ref in the meta/gadget.yaml
+    kerneldir=""
 
     echo "Run the snap-bootstrap tool"
     go get ../../lib/uc20-create-partitions
     uc20-create-partitions \
         --encrypt \
-        ./gadget-dir "$LOOP"
+        ./gadget-dir "$kerneldir" "$LOOP"
     # keep for later
 
     echo "Check that the ubuntu-data key files were created"

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -57,7 +57,10 @@ execute: |
 
     echo "Run the snap-bootstrap tool in auto-detect mode"
     go get ../../lib/uc20-create-partitions
-    uc20-create-partitions ./gadget-dir
+    # TODO:UC20: make kernel-dir non-empty once we have a gadget that has a
+    #            "$kernel:" style ref in the meta/gadget.yaml
+    kerneldir=""
+    uc20-create-partitions ./gadget-dir "$kerneldir"
 
     echo "And check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'
@@ -79,7 +82,7 @@ execute: |
 
     # re-create partitions on a new install attempt
     echo "Run the snap-bootstrap again"
-    uc20-create-partitions ./gadget-dir
+    uc20-create-partitions ./gadget-dir "$kerneldir"
 
     echo "And check that the partitions are there"
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -54,7 +54,10 @@ execute: |
 
     echo "Run the snap-bootstrap tool"
     go get ../../lib/uc20-create-partitions
-    uc20-create-partitions ./gadget-dir "$LOOP"
+    # TODO:UC20: make kernel-dir non-empty once we have a gadget that has a
+    #            "$kernel:" style ref in the meta/gadget.yaml
+    kerneldir=""
+    uc20-create-partitions ./gadget-dir "$kerneldir" "$LOOP"
 
     echo "And check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '750M Linux filesystem'
@@ -124,7 +127,7 @@ execute: |
             filesystem-label: other-ext4
             size: 110M
     EOF
-    uc20-create-partitions --mount ./gadget-dir "$LOOP"
+    uc20-create-partitions --mount ./gadget-dir "$kerneldir" "$LOOP"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p1 .* 1M\s* BIOS boot"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p2 .* 1.2G\s* EFI System"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p3 .* 750M\s* Linux filesystem"


### PR DESCRIPTION
The resolving of paths/references is now happening with the new
ResolvedContent struct. This means that the "resolvedSource"
from VolumeContent can be removed.
    
This also undoes the use of "ResolvedSource()" in
MountedFilesystemWriter and moves back to UnresolvedSource. In
a followup this will be changed to "ResolvedSource" again.


Based on https://github.com/snapcore/snapd/pull/9873
