### PR TITLE
tests: run unit tests in Focal instead of Xenial

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   snap-builds:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
         touch "$CACHE_RESULT_STAMP"
 
   unit-tests:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: off


### PR DESCRIPTION
The idea of this change is to test how long unit tests take in focal
compared with xenial. The test already done shows a very big diff.

Xenial times:
ok  	github.com/snapcore/snapd/cmd/snap	23.130s
ok  	github.com/snapcore/snapd/cmd/snap	23.151s
ok  	github.com/snapcore/snapd/cmd/snap	23.133s
ok  	github.com/snapcore/snapd/cmd/snap	23.188s
ok  	github.com/snapcore/snapd/cmd/snap	23.138s

Focal times:
ok  	github.com/snapcore/snapd/cmd/snap	3.636s
ok  	github.com/snapcore/snapd/cmd/snap	3.511s
ok  	github.com/snapcore/snapd/cmd/snap	3.528s
ok  	github.com/snapcore/snapd/cmd/snap	3.569s
ok  	github.com/snapcore/snapd/cmd/snap	3.520s
