### PR TITLE
cmd/snap-preseed: initialize snap.SanitizePlugsSlots for gadget in seeds

### DIFF
--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -64,10 +64,6 @@ func Parser() *flags.Parser {
 }
 
 func main() {
-	// real validation of plugs and slots; needs to be set
-	// for processing of seeds with gadget because of readInfo().
-	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
-
 	parser := Parser()
 	if err := run(parser, os.Args[1:]); err != nil {
 		fmt.Fprintf(Stderr, "error: %v\n", err)
@@ -76,6 +72,10 @@ func main() {
 }
 
 func run(parser *flags.Parser, args []string) error {
+	// real validation of plugs and slots; needs to be set
+	// for processing of seeds with gadget because of readInfo().
+	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
+
 	if osGetuid() != 0 {
 		return fmt.Errorf("must be run as root")
 	}

--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -26,6 +26,10 @@ import (
 	"path/filepath"
 
 	"github.com/jessevdk/go-flags"
+
+	// for SanitizePlugsSlots
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
 )
 
 const (
@@ -60,6 +64,10 @@ func Parser() *flags.Parser {
 }
 
 func main() {
+	// real validation of plugs and slots; needs to be set
+	// for processing of seeds with gadget because of readInfo().
+	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
+
 	parser := Parser()
 	if err := run(parser, os.Args[1:]); err != nil {
 		fmt.Fprintf(Stderr, "error: %v\n", err)

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -680,3 +680,26 @@ func (s *startPreseedSuite) TestReset(c *C) {
 	}
 
 }
+
+func (s *startPreseedSuite) TestReadInfoSanity(c *C) {
+	var called bool
+	inf := &snap.Info{
+		BadInterfaces: make(map[string]string),
+		Plugs: map[string]*snap.PlugInfo{
+			"foo": {
+				Interface: "bad"},
+		},
+	}
+
+	// set a dummy sanitize method.
+	snap.SanitizePlugsSlots = func(*snap.Info) { called = true }
+
+	parser := testParser(c)
+	tmpDir := c.MkDir()
+	_ = main.Run(parser, []string{tmpDir})
+
+	// real sanitize method should be set after Run()
+	snap.SanitizePlugsSlots(inf)
+	c.Assert(called, Equals, false)
+	c.Assert(inf.BadInterfaces, HasLen, 1)
+}


### PR DESCRIPTION
Initialize SanitizePlugsSlots method, otherwise we panic on readInfo if gadget is present, e.g.

```
panic: SanitizePlugsSlots function not set

goroutine 1 [running]:
github.com/snapcore/snapd/snap.glob..func1(0xc4200b2000)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/snap/info.go:1133 +0x3b
github.com/snapcore/snapd/snap.infoFromSnapYaml(0xc42012e000, 0x14c, 0x34c, 0xc420127a68, 0x0, 0x0, 0x55571e6392b0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/snap/info_snap_yaml.go:227 +0x8cb
github.com/snapcore/snapd/snap.infoFromSnapYamlWithSideInfo(0xc42012e000, 0x14c, 0x34c, 0xc4204b2100, 0xc420127a68, 0x34c, 0x0, 0x0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/snap/info.go:1074 +0x4f
github.com/snapcore/snapd/snap.ReadInfoFromSnapFile(0x55571e9a6380, 0xc42004c610, 0xc4204b2100, 0xc42004c610, 0x0, 0x0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/snap/info.go:1212 +0x9d
github.com/snapcore/snapd/seed.readInfo(0xc42001a240, 0x3f, 0xc4204b2100, 0x0, 0x55571e64d0f1, 0x6)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/seed/helpers.go:102 +0x89
github.com/snapcore/snapd/seed.(*seed16).LoadMeta(0xc4201940a0, 0x55571e9a1880, 0xc420213460, 0xc420186240, 0x0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/seed/seed16.go:265 +0x5f1
main.glob..func1(0x55571e64c34c, 0x1, 0x0, 0x0, 0x55571e64c74b, 0x4)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/cmd/snap-preseed/preseed_linux.go:115 +0x16b
main.prepareChroot(0x7fff5943e342, 0x31, 0x0, 0x0, 0x0, 0x0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/cmd/snap-preseed/preseed_linux.go:220 +0x28b
main.run(0xc420177c00, 0xc42000c090, 0x1, 0x1, 0x0, 0xc42000e2c0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/cmd/snap-preseed/main.go:102 +0x130
main.main()
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/cmd/snap-preseed/main.go:64 +0x72
```