### PR TITLE
snap/info.go: ignore unknown daemons in SortSnapServices

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -1318,12 +1318,16 @@ func SortServices(apps []*AppInfo) (sorted []*AppInfo, err error) {
 
 	for _, app := range apps {
 		for _, other := range app.After {
-			predecessors[app.Name]++
-			successors[other] = append(successors[other], app)
+			if _, ok := nameToApp[other]; ok {
+				predecessors[app.Name]++
+				successors[other] = append(successors[other], app)
+			}
 		}
 		for _, other := range app.Before {
-			predecessors[other]++
-			successors[app.Name] = append(successors[app.Name], nameToApp[other])
+			if _, ok := nameToApp[other]; ok {
+				predecessors[other]++
+				successors[app.Name] = append(successors[app.Name], nameToApp[other])
+			}
 		}
 	}
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1684,6 +1684,28 @@ func (s *infoSuite) TestSortApps(c *C) {
 	}{{
 		apps: []*snap.AppInfo{
 			{Name: "bar", Before: []string{"baz"}},
+			{Name: "foo"},
+		},
+		sorted: []string{"bar", "foo"},
+	}, {
+		apps: []*snap.AppInfo{
+			{Name: "bar", Before: []string{"foo"}},
+			{Name: "foo", Before: []string{"baz"}},
+		},
+		sorted: []string{"bar", "foo"},
+	}, {
+		apps: []*snap.AppInfo{
+			{Name: "bar", Before: []string{"foo"}},
+		},
+		sorted: []string{"bar"},
+	}, {
+		apps: []*snap.AppInfo{
+			{Name: "bar", After: []string{"foo"}},
+		},
+		sorted: []string{"bar"},
+	}, {
+		apps: []*snap.AppInfo{
+			{Name: "bar", Before: []string{"baz"}},
 			{Name: "baz", After: []string{"bar", "foo"}},
 			{Name: "foo"},
 		},

--- a/tests/main/services-after-before/task.yaml
+++ b/tests/main/services-after-before/task.yaml
@@ -45,3 +45,22 @@ execute: |
     snap restart test-snapd-after-before-service
 
     check_order
+
+    echo "Restarting a single service works even when there are before/after directives for the single service"
+    snap restart test-snapd-after-before-service.before-middle
+    snap restart test-snapd-after-before-service.middle
+    snap restart test-snapd-after-before-service.after-middle
+
+    check_order
+
+    echo "Restarting a subset of services that have before/after works and orders them properly"
+    snap restart test-snapd-after-before-service.before-middle test-snapd-after-before-service.middle
+    # this one is just to keep the check_order helper simple
+    snap restart test-snapd-after-before-service.after-middle
+
+    check_order
+
+    echo "Restarting all of services that have before/after works and orders them properly"
+    snap restart test-snapd-after-before-service.after-middle test-snapd-after-before-service.before-middle test-snapd-after-before-service.middle
+
+    check_order

--- a/tests/main/snap-service-install-mode/task.yaml
+++ b/tests/main/snap-service-install-mode/task.yaml
@@ -1,4 +1,4 @@
-summary: "Check that snap services with 'instal-mode: disable'"
+summary: "Check that snap services with 'install-mode: disable'"
 
 restore: |
     snap remove svc


### PR DESCRIPTION
When a snap has daemons that use before/after, and a hook tries to specify
snapctl restart of a single daemon, then the code here is subtly wrong in that
it thinks that there is an ordering cycle because we couldn't dequeue the other
services since they don't exist in the list of services provided to
SortSnapServices. As such, we should only sort the services that actually exist
in the list we were provided, we will handle errors around unknown services that
don't exist at all in the snap elsewhere in the stack before we get here.
