### PR TITLE
seed: add LoadEssentialMeta to seed16 and allow all of its implementations to be called multiple times

### DIFF
--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -328,6 +328,10 @@ func (fs *Fake16Seed) Brand() (*asserts.Account, error) {
 	return assertstest.FakeAssertion(headers, nil).(*asserts.Account), nil
 }
 
+func (fs *Fake16Seed) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error {
+	panic("unexpected")
+}
+
 func (fs *Fake16Seed) LoadMeta(tm timings.Measurer) error {
 	return fs.LoadMetaErr
 }

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -88,6 +88,9 @@ type Seed interface {
 	// It will panic if called before LoadAssertions.
 	Brand() (*asserts.Account, error)
 
+	// XXX
+	LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error
+
 	// LoadMeta loads the seed and seed's snaps metadata while
 	// verifying the underlying snaps against assertions. It can
 	// return ErrNoMeta if there is no metadata nor snaps in the
@@ -120,7 +123,8 @@ type EssentialMetaLoaderSeed interface {
 	// legitimate only on classic. It is an error to mix it with
 	// LoadMeta.
 	// It will panic if called before LoadAssertions.
-	LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error
+
+	// XXX LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error
 }
 
 // Open returns a Seed implementation for the seed at seedDir.


### PR DESCRIPTION
Consequently drop EssentialMetaLoaderSeed.

Use caching to avoid re-verifying the essential snaps many times.

