### PR TITLE
data/env/snapd: use quoting in case PATH contains spaces

### DIFF
--- a/data/env/snapd.sh.in
+++ b/data/env/snapd.sh.in
@@ -3,7 +3,7 @@
 # Expand $PATH to include the directory where snappy applications go.
 snap_bin_path="@SNAP_MOUNT_DIR@/bin"
 if [ -n "${PATH##*${snap_bin_path}}" ] && [ -n "${PATH##*${snap_bin_path}:*}" ]; then
-    export PATH=$PATH:${snap_bin_path}
+    export PATH="$PATH:${snap_bin_path}"
 fi
 
 # Ensure base distro defaults xdg path are set if nothing filed up some


### PR DESCRIPTION
When PATH contain spaces, which is a really bad idea anyway, the export will
most likely set it to a value up to the first space. Use quoting to prevent
that.

Note, shellcheck does not complain about that, but try this:

```
sh-5.1$ export foo=foo bar baz
sh-5.1$ echo $foo
foo
sh-5.1$ export foo="foo bar baz"
sh-5.1$ echo $foo
foo bar baz
sh-5.1$
```

Supersedes #9682