### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: write realistic modeenv for recover+install

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -157,7 +157,7 @@ func generateMountsModeInstall(mst *initramfsMountsState) error {
 
 	// 3. final step: write modeenv to tmpfs data dir and disable cloud-init in
 	//   install mode
-	modeEnv, err := mst.ModeenvFromModel(model, snaps)
+	modeEnv, err := mst.EphemeralModeenvForModel(model, snaps)
 	if err != nil {
 		return err
 	}
@@ -1046,7 +1046,7 @@ func generateMountsModeRecover(mst *initramfsMountsState) error {
 		}
 	}
 
-	modeEnv, err := mst.ModeenvFromModel(model, snaps)
+	modeEnv, err := mst.EphemeralModeenvForModel(model, snaps)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -150,15 +150,16 @@ func generateInitramfsMounts() (err error) {
 // no longer generates more mount points and just returns an empty output.
 func generateMountsModeInstall(mst *initramfsMountsState) error {
 	// steps 1 and 2 are shared with recover mode
-	if _, err := generateMountsCommonInstallRecover(mst); err != nil {
+	model, snaps, err := generateMountsCommonInstallRecover(mst)
+	if err != nil {
 		return err
 	}
 
 	// 3. final step: write modeenv to tmpfs data dir and disable cloud-init in
 	//   install mode
-	modeEnv := &boot.Modeenv{
-		Mode:           "install",
-		RecoverySystem: mst.recoverySystem,
+	modeEnv, err := mst.ModeenvFromModel(model, snaps)
+	if err != nil {
+		return err
 	}
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
@@ -957,7 +958,7 @@ func (m *recoverModeStateMachine) mountSave() (stateFunc, error) {
 
 func generateMountsModeRecover(mst *initramfsMountsState) error {
 	// steps 1 and 2 are shared with install mode
-	model, err := generateMountsCommonInstallRecover(mst)
+	model, snaps, err := generateMountsCommonInstallRecover(mst)
 	if err != nil {
 		return err
 	}
@@ -1045,9 +1046,9 @@ func generateMountsModeRecover(mst *initramfsMountsState) error {
 		}
 	}
 
-	modeEnv := &boot.Modeenv{
-		Mode:           "recover",
-		RecoverySystem: mst.recoverySystem,
+	modeEnv, err := mst.ModeenvFromModel(model, snaps)
+	if err != nil {
+		return err
 	}
 	if err := modeEnv.WriteTo(boot.InitramfsWritableDir); err != nil {
 		return err
@@ -1108,18 +1109,18 @@ func mountPartitionMatchingKernelDisk(dir, fallbacklabel string) error {
 	return doSystemdMount(partSrc, dir, opts)
 }
 
-func generateMountsCommonInstallRecover(mst *initramfsMountsState) (*asserts.Model, error) {
+func generateMountsCommonInstallRecover(mst *initramfsMountsState) (model *asserts.Model, sysSnaps map[snap.Type]snap.PlaceInfo, err error) {
 	// 1. always ensure seed partition is mounted first before the others,
 	//      since the seed partition is needed to mount the snap files there
 	if err := mountPartitionMatchingKernelDisk(boot.InitramfsUbuntuSeedDir, "ubuntu-seed"); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// load model and verified essential snaps metadata
 	typs := []snap.Type{snap.TypeBase, snap.TypeKernel, snap.TypeSnapd, snap.TypeGadget}
 	model, essSnaps, err := mst.ReadEssential("", typs)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load metadata and verify essential bootstrap snaps %v: %v", typs, err)
+		return nil, nil, fmt.Errorf("cannot load metadata and verify essential bootstrap snaps %v: %v", typs, err)
 	}
 
 	// 2.1. measure model
@@ -1129,7 +1130,7 @@ func generateMountsCommonInstallRecover(mst *initramfsMountsState) (*asserts.Mod
 		})
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// at this point on a system with TPM-based encryption
 	// data can be open only if the measured model matches the actual
@@ -1140,16 +1141,21 @@ func generateMountsCommonInstallRecover(mst *initramfsMountsState) (*asserts.Mod
 
 	// 2.2. (auto) select recovery system and mount seed snaps
 	// TODO:UC20: do we need more cross checks here?
+
+	systemSnaps := make(map[snap.Type]snap.PlaceInfo)
+
 	for _, essentialSnap := range essSnaps {
 		if essentialSnap.EssentialType == snap.TypeGadget {
 			// don't need to mount the gadget anywhere, but we use the snap
 			// later hence it is loaded
 			continue
 		}
+		systemSnaps[essentialSnap.EssentialType] = essentialSnap.PlaceInfo()
+
 		dir := snapTypeToMountDir[essentialSnap.EssentialType]
 		// TODO:UC20: we need to cross-check the kernel path with snapd_recovery_kernel used by grub
 		if err := doSystemdMount(essentialSnap.Path, filepath.Join(boot.InitramfsRunMntDir, dir), nil); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -1172,7 +1178,7 @@ func generateMountsCommonInstallRecover(mst *initramfsMountsState) (*asserts.Mod
 	}
 	err = doSystemdMount("tmpfs", boot.InitramfsDataDir, mntOpts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// finally get the gadget snap from the essential snaps and use it to
@@ -1199,10 +1205,10 @@ func generateMountsCommonInstallRecover(mst *initramfsMountsState) (*asserts.Mod
 		GadgetSnap:     gadgetSnap,
 	}
 	if err := sysconfig.ConfigureTargetSystem(configOpts); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return model, err
+	return model, systemSnaps, err
 }
 
 func maybeMountSave(disk disks.Disk, rootdir string, encrypted bool, mountOpts *systemdMountOptions) (haveSave bool, err error) {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -452,6 +452,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeHappy(c *C) {
 	modeEnv := dirs.SnapModeenvFileUnder(boot.InitramfsWritableDir)
 	c.Check(modeEnv, testutil.FileEquals, `mode=install
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 	cloudInitDisable := filepath.Join(boot.InitramfsWritableDir, "_writable_defaults/etc/cloud/cloud-init.disabled")
 	c.Check(cloudInitDisable, testutil.FilePresent)
@@ -506,6 +509,9 @@ defaults:
 	modeEnv := dirs.SnapModeenvFileUnder(boot.InitramfsWritableDir)
 	c.Check(modeEnv, testutil.FileEquals, `mode=install
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 
 	cloudInitDisable := filepath.Join(boot.InitramfsWritableDir, "_writable_defaults/etc/cloud/cloud-init.disabled")
@@ -550,6 +556,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeBootedKernelPartiti
 	modeEnv := dirs.SnapModeenvFileUnder(boot.InitramfsWritableDir)
 	c.Check(modeEnv, testutil.FileEquals, `mode=install
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 	cloudInitDisable := filepath.Join(boot.InitramfsWritableDir, "_writable_defaults/etc/cloud/cloud-init.disabled")
 	c.Check(cloudInitDisable, testutil.FilePresent)
@@ -2315,6 +2324,9 @@ func (s *initramfsMountsSuite) testRecoverModeHappy(c *C) {
 	modeEnv := filepath.Join(ephemeralUbuntuData, "/system-data/var/lib/snapd/modeenv")
 	c.Check(modeEnv, testutil.FileEquals, `mode=recover
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 	for _, p := range mockUnrelatedFiles {
 		c.Check(filepath.Join(ephemeralUbuntuData, p), testutil.FileAbsent)
@@ -3478,6 +3490,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 	modeEnv := filepath.Join(boot.InitramfsWritableDir, "var/lib/snapd/modeenv")
 	c.Check(modeEnv, testutil.FileEquals, `mode=recover
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 
 	checkDegradedJSON(c, map[string]interface{}{
@@ -3675,6 +3690,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedAbsentDataS
 	modeEnv := filepath.Join(boot.InitramfsWritableDir, "var/lib/snapd/modeenv")
 	c.Check(modeEnv, testutil.FileEquals, `mode=recover
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 
 	checkDegradedJSON(c, map[string]interface{}{
@@ -4022,6 +4040,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 	modeEnv := filepath.Join(boot.InitramfsWritableDir, "var/lib/snapd/modeenv")
 	c.Check(modeEnv, testutil.FileEquals, `mode=recover
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 
 	checkDegradedJSON(c, map[string]interface{}{
@@ -4216,6 +4237,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 	modeEnv := filepath.Join(boot.InitramfsRunMntDir, "data/system-data/var/lib/snapd/modeenv")
 	c.Check(modeEnv, testutil.FileEquals, `mode=recover
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 
 	checkDegradedJSON(c, map[string]interface{}{
@@ -4387,6 +4411,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedMismatched
 	modeEnv := filepath.Join(boot.InitramfsWritableDir, "var/lib/snapd/modeenv")
 	c.Check(modeEnv, testutil.FileEquals, `mode=recover
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 
 	checkDegradedJSON(c, map[string]interface{}{
@@ -4670,6 +4697,9 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallRecoverModeMeasure(c *C
 		modeEnv := filepath.Join(boot.InitramfsDataDir, "/system-data/var/lib/snapd/modeenv")
 		c.Check(modeEnv, testutil.FileEquals, `mode=install
 recovery_system=20191118
+base=core20_1.snap
+model=my-brand/my-model
+grade=signed
 `)
 	}
 

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -81,9 +81,9 @@ func (mst *initramfsMountsState) UnverifiedBootModel() (*asserts.Model, error) {
 	return ma.(*asserts.Model), nil
 }
 
-// ModeenvFromModel generates a modeenv given the model and the snaps for the
+// EphemeralModeenvForModel generates a modeenv given the model and the snaps for the
 // current mode and recovery system of the initramfsMountsState.
-func (mst *initramfsMountsState) ModeenvFromModel(model *asserts.Model, snaps map[snap.Type]snap.PlaceInfo) (*boot.Modeenv, error) {
+func (mst *initramfsMountsState) EphemeralModeenvForModel(model *asserts.Model, snaps map[snap.Type]snap.PlaceInfo) (*boot.Modeenv, error) {
 	if mst.mode == "run" {
 		return nil, fmt.Errorf("internal error: initramfs should not write modeenv in run mode")
 	}

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -80,3 +80,21 @@ func (mst *initramfsMountsState) UnverifiedBootModel() (*asserts.Model, error) {
 	}
 	return ma.(*asserts.Model), nil
 }
+
+// ModeenvFromModel generates a modeenv given the model and the snaps for the
+// current mode and recovery system of the initramfsMountsState.
+func (mst *initramfsMountsState) ModeenvFromModel(model *asserts.Model, snaps map[snap.Type]snap.PlaceInfo) (*boot.Modeenv, error) {
+	if mst.mode == "run" {
+		return nil, fmt.Errorf("internal error: initramfs should not write modeenv in run mode")
+	}
+	return &boot.Modeenv{
+		Mode:           mst.mode,
+		RecoverySystem: mst.recoverySystem,
+		Base:           snaps[snap.TypeBase].Filename(),
+		Model:          model.Model(),
+		BrandID:        model.BrandID(),
+		Grade:          string(model.Grade()),
+		// TODO:UC20: what about current kernel snaps, trusted boot assets and
+		//            kernel command lines?
+	}, nil
+}


### PR DESCRIPTION
The current modeenv that is written from the initramfs is incomplete to the
extent that it doesn't accurately reflect what base and model are booted on the
system so when things like snap-repair try to determine device information using
only the modeenv, they fail.

This adds as much information as can be trivially gained from the initramfs
about the device/system. The current kernel snaps, trusted boot assets and 
kernel command lines can probably also be determined at this point and included
in the modeenv as well, but it's unclear if that's the direction we want to go
with the modeenv we write here.

This will unblock us from enabling the recover portion off the snap-repair test in https://github.com/snapcore/snapd/pull/9884

I milestoned this for 2.49 so that we could get this picked up in the initramfs debian package sooner rather than later, but strictly speaking it could probably be pushed out to 2.50 if this ends up being contentious or more complicated than I think...