### PR TITLE
boot: do not observe successful boot assets if not in run mode

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -830,6 +830,11 @@ func observeSuccessfulBootAssetsForBootloader(m *Modeenv, root string, opts *boo
 // after a successful boot. Returns a modified modeenv reflecting a new state,
 // and a list of assets that can be dropped from the cache.
 func observeSuccessfulBootAssets(m *Modeenv) (newM *Modeenv, drop []*trackedAsset, err error) {
+	// TODO:UC20 only care about run mode for now
+	if m.Mode != "run" {
+		return m, nil, nil
+	}
+
 	newM, err = m.Copy()
 	if err != nil {
 		return nil, nil, err

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -2305,6 +2305,27 @@ func (s *assetsSuite) TestObserveSuccessfulBootHashErr(c *C) {
 	c.Assert(err, ErrorMatches, "cannot calculate the digest of existing trusted asset: .*/asset: permission denied")
 }
 
+func (s *assetsSuite) TestObserveSuccessfulBootDifferentMode(c *C) {
+	s.bootloaderWithTrustedAssets(c, []string{"asset"})
+
+	m := &boot.Modeenv{
+		Mode: "recover",
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {"hash-1", "hash-2"},
+		},
+		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			"asset": {"hash-3", "hash-4"},
+		},
+	}
+
+	// if we were in run mode, this would error out because the assets don't
+	// exist, but we are not in run mode
+	newM, drop, err := boot.ObserveSuccessfulBootWithAssets(m)
+	c.Assert(err, IsNil)
+	c.Assert(newM, DeepEquals, m)
+	c.Assert(drop, IsNil)
+}
+
 func (s *assetsSuite) TestCopyBootAssetsCacheHappy(c *C) {
 	newRoot := c.MkDir()
 	// does not fail when dir does not exist


### PR DESCRIPTION
For consistency with command line handling, we should not try do anything with
boot assets we successfully booted with if the system is not in run mode.
