### PR TITLE
asserts: introduce AtSequence

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -320,7 +320,7 @@ func (at *AtRevision) String() string {
 // (RevisionNotKnown).
 // Setting Pinned = true means pinning at the given sequence point (which must be
 // set, i.e. > 0). Pinned sequence forming assertion will be updated to the
-// latest revision within same sequence.
+// latest revision at the specified sequence point.
 type AtSequence struct {
 	Type        *AssertionType
 	SequenceKey []string
@@ -352,8 +352,6 @@ func (at *AtSequence) String() string {
 				sep = "="
 			}
 			pkStr = fmt.Sprintf("%s%s%d", pkStr, sep, at.Sequence)
-		} else {
-			pkStr = fmt.Sprintf("%s/?", pkStr)
 		}
 	}
 	sk := fmt.Sprintf("%s %s", at.Type.Name, pkStr)

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -995,12 +995,13 @@ func (as *assertsSuite) TestAtSequenceString(c *C) {
 	}
 	c.Check(atSeq.String(), Equals, "validation-set canonical/foo/8 at revision 2")
 
+	// Sequence number not set
 	atSeq = asserts.AtSequence{
 		Type:        asserts.ValidationSetType,
 		SequenceKey: []string{"16", "canonical", "foo"},
 		Revision:    asserts.RevisionNotKnown,
 	}
-	c.Check(atSeq.String(), Equals, "validation-set canonical/foo/?")
+	c.Check(atSeq.String(), Equals, "validation-set canonical/foo")
 
 	atSeq = asserts.AtSequence{
 		Type:        asserts.ValidationSetType,

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -981,21 +981,30 @@ func (as *assertsSuite) TestAtSequenceString(c *C) {
 		Sequence:    8,
 		Revision:    2,
 	}
-	c.Check(atSeq.String(), Equals, "validation-set (foo; series:16 account-id:canonical name:foo sequence:8) at revision 2")
+	c.Check(atSeq.String(), Equals, "validation-set canonical/foo/8 at revision 2")
 
 	atSeq = asserts.AtSequence{
 		Type:        asserts.ValidationSetType,
 		SequenceKey: []string{"16", "canonical", "foo"},
 		Revision:    asserts.RevisionNotKnown,
 	}
-	c.Check(atSeq.String(), Equals, "validation-set (foo; series:16 account-id:canonical name:foo)")
+	c.Check(atSeq.String(), Equals, "validation-set canonical/foo/?")
+
+	atSeq = asserts.AtSequence{
+		Type:        asserts.ValidationSetType,
+		SequenceKey: []string{"16", "canonical", "foo"},
+		Sequence:    8,
+		Pinned:      true,
+		Revision:    2,
+	}
+	c.Check(atSeq.String(), Equals, "validation-set canonical/foo=8 at revision 2")
 
 	atSeq = asserts.AtSequence{
 		Type:        asserts.ValidationSetType,
 		SequenceKey: []string{"16", "canonical"},
 		Revision:    2,
 	}
-	c.Check(atSeq.String(), Equals, "validation-set (???) at revision 2")
+	c.Check(atSeq.String(), Equals, "validation-set ??? at revision 2")
 }
 
 func (as *assertsSuite) TestAtSequenceUnique(c *C) {

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -979,6 +979,9 @@ func (as *assertsSuite) TestHeadersFromSequenceKey(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(headers, DeepEquals, map[string]string{"n": "one"})
 
+	_, err = asserts.HeadersFromSequenceKey(asserts.TestOnlySeqType, []string{"one", "two"})
+	c.Check(err, ErrorMatches, `sequence key has wrong length for "test-only-seq" assertion`)
+
 	_, err = asserts.HeadersFromSequenceKey(asserts.TestOnlySeqType, []string{})
 	c.Check(err, ErrorMatches, `sequence key has wrong length for "test-only-seq" assertion`)
 
@@ -1028,6 +1031,13 @@ func (as *assertsSuite) TestAtSequenceUnique(c *C) {
 		Revision:    2,
 	}
 	c.Check(atSeq.Unique(), Equals, "validation-set/16/canonical/foo")
+
+	// not a valid sequence-key (but Unique() doesn't care).
+	atSeq = asserts.AtSequence{
+		Type:        asserts.ValidationSetType,
+		SequenceKey: []string{"16", "canonical"},
+	}
+	c.Check(atSeq.Unique(), Equals, "validation-set/16/canonical")
 }
 
 func (as *assertsSuite) TestAtSequenceResolveError(c *C) {

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -973,3 +973,76 @@ func (as *assertsSuite) TestSequenceForming(c *C) {
 
 	c.Check(asserts.SnapDeclarationType.SequenceForming(), Equals, false)
 }
+
+func (as *assertsSuite) TestAtSequenceString(c *C) {
+	atSeq := asserts.AtSequence{
+		Type:        asserts.ValidationSetType,
+		SequenceKey: []string{"16", "canonical", "foo"},
+		Sequence:    8,
+		Revision:    2,
+	}
+	c.Check(atSeq.String(), Equals, "validation-set (foo; series:16 account-id:canonical name:foo sequence:8) at revision 2")
+
+	atSeq = asserts.AtSequence{
+		Type:        asserts.ValidationSetType,
+		SequenceKey: []string{"16", "canonical", "foo"},
+		Revision:    asserts.RevisionNotKnown,
+	}
+	c.Check(atSeq.String(), Equals, "validation-set (foo; series:16 account-id:canonical name:foo)")
+
+	atSeq = asserts.AtSequence{
+		Type:        asserts.ValidationSetType,
+		SequenceKey: []string{"16", "canonical"},
+		Revision:    2,
+	}
+	c.Check(atSeq.String(), Equals, "validation-set (???) at revision 2")
+}
+
+func (as *assertsSuite) TestAtSequenceUnique(c *C) {
+	atSeq := asserts.AtSequence{
+		Type:        asserts.ValidationSetType,
+		SequenceKey: []string{"16", "canonical", "foo"},
+		Sequence:    8,
+		Revision:    2,
+	}
+	c.Check(atSeq.Unique(), Equals, "validation-set/16/canonical/foo")
+}
+
+func (as *assertsSuite) TestAtSequenceResolveError(c *C) {
+	atSeq := asserts.AtSequence{
+		Type:        asserts.ValidationSetType,
+		SequenceKey: []string{"abc"},
+		Sequence:    1,
+	}
+	_, err := atSeq.Resolve(nil)
+	c.Check(err, ErrorMatches, `"validation-set" assertion reference primary key has the wrong length \(expected \[series account-id name sequence\]\): \[abc 1\]`)
+}
+
+func (as *assertsSuite) TestAtSequenceResolve(c *C) {
+	atSeq := asserts.AtSequence{
+		Type:        asserts.TestOnlySeqType,
+		SequenceKey: []string{"foo"},
+		Sequence:    3,
+	}
+	a, err := atSeq.Resolve(func(atype *asserts.AssertionType, hdrs map[string]string) (asserts.Assertion, error) {
+		c.Assert(atype, Equals, asserts.TestOnlySeqType)
+		c.Assert(hdrs, DeepEquals, map[string]string{
+			"n":        "foo",
+			"sequence": "3",
+		})
+		encoded := []byte("type: test-only-seq\n" +
+			"format: 1\n" +
+			"authority-id: auth-id2\n" +
+			"n: abc\n" +
+			"revision: 5\n" +
+			"sequence: 3\n" +
+			"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+			"\n\n" +
+			"AXNpZw==")
+		a, err := asserts.Decode(encoded)
+		return a, err
+	})
+	c.Assert(err, IsNil)
+	c.Assert(a, NotNil)
+	c.Check(a.Type().Name, Equals, "test-only-seq")
+}


### PR DESCRIPTION
Introduce AtSequence struct that will get passed to new Pool functions, and will be an input for store actions (via ToResolve()). This resembles AtRevision except it is tailored for sequence assertions where we have sequence key only and sequence number is optional (sequence key is a primary key minus sequence number).
