### PR TITLE
osutil: skip TestReadBuildGo inside sbuild

### DIFF
--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -129,6 +129,15 @@ func (s *buildIDSuite) TestMyBuildID(c *C) {
 }
 
 func (s *buildIDSuite) TestReadBuildGo(c *C) {
+	if os.Getenv("DH_GOPKG") != "" {
+		// Failure reason is unknown but only reproducible
+		// inside the any 21.04+ sbuild/pbuilder build
+		// environment during the build (with dh-golang).
+		//
+		// Not reproducible outside of dpkg-buildpackage.
+		c.Skip("This `go build` fails inside the dpkg-buildpackage environemnt with `loadinternal: cannot find runtime/cgo`")
+	}
+
 	tmpdir := c.MkDir()
 	goTruth := filepath.Join(tmpdir, "true")
 	err := ioutil.WriteFile(goTruth+".go", []byte(`package main; func main(){}`), 0644)

--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -135,7 +135,7 @@ func (s *buildIDSuite) TestReadBuildGo(c *C) {
 		// environment during the build (with dh-golang).
 		//
 		// Not reproducible outside of dpkg-buildpackage.
-		c.Skip("This `go build` fails inside the dpkg-buildpackage environemnt with `loadinternal: cannot find runtime/cgo`")
+		c.Skip("This `go build` fails inside the dpkg-buildpackage environment with `loadinternal: cannot find runtime/cgo`")
 	}
 
 	tmpdir := c.MkDir()


### PR DESCRIPTION
The TestReadBuildGo test started to fail recently inside an
hirsute build environment with:
```
----------------------------------------------------------------------
FAIL: buildid_test.go:131: buildIDSuite.TestReadBuildGo

buildid_test.go:142:
    c.Assert(string(output), Equals, "")
... obtained string = "" +
...     "# command-line-arguments\n" +
...     "loadinternal: cannot find runtime/cgo\n"
... expected string = ""
```

Failure reason is unknown but only reproducible inside the particular
a dpkg-buildpackage build on 21.04 (with dh-golang).

Not reproducible outside the dpkg-buildpackage when running tests
in a normal hirsute environment.

This is a first stop-gap to fix the FTBFS until the root cause is
found.

Test build: https://launchpad.net/~mvo/+archive/ubuntu/tmp/+build/20976408