### PR TITLE
gadget: improve error handling around resolving content sources

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -792,8 +792,11 @@ func validateFilesystemContent(vc *VolumeContent) error {
 	if vc.Image != "" || vc.Offset != nil || vc.OffsetWrite != nil || vc.Size != 0 {
 		return fmt.Errorf("cannot use image content for non-bare file system")
 	}
-	if vc.UnresolvedSource == "" || vc.Target == "" {
-		return fmt.Errorf("missing source or target")
+	if vc.UnresolvedSource == "" {
+		return fmt.Errorf("missing source")
+	}
+	if vc.Target == "" {
+		return fmt.Errorf("missing target")
 	}
 	return nil
 }

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -299,7 +299,7 @@ func resolveVolumeContent(gadgetRootDir, kernelRootDir string, kernelInfo *kerne
 	for idx := range ps.Content {
 		resolvedSource, err := resolveContentPathOrRef(gadgetRootDir, kernelRootDir, kernelInfo, ps.Content[idx].UnresolvedSource)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot resolve content for structure %v at index %v: %v", ps, idx, err)
 		}
 		content[idx] = ResolvedContent{
 			VolumeContent:  &ps.Content[idx],
@@ -314,9 +314,15 @@ func resolveVolumeContent(gadgetRootDir, kernelRootDir string, kernelInfo *kerne
 // content and populates VolumeContent.resolvedSource with absolute
 // paths.
 func resolveContentPathOrRef(gadgetRootDir, kernelRootDir string, kernelInfo *kernel.Info, pathOrRef string) (string, error) {
-	// TODO: what to here? we could error instead?
-	if pathOrRef == "" {
-		return "", nil
+
+	// TODO: add kernelRootDir == "" error too once all the higher
+	//       layers in devicestate call gadget.Update() with a
+	//       kernel dir set
+	switch {
+	case gadgetRootDir == "":
+		return "", fmt.Errorf("internal error: gadget root dir cannot beempty")
+	case pathOrRef == "":
+		return "", fmt.Errorf("cannot use empty source")
 	}
 
 	// content may refer to "$kernel:<name>/<content>"

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -1212,7 +1212,7 @@ func (p *layoutTestSuite) TestResolveContentPathsNotInWantedAssets(c *C) {
 
 	kernelSnapDir := c.MkDir()
 	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
-	c.Assert(err, ErrorMatches, `cannot find "dtbs" in kernel info from "/.*"`)
+	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find "dtbs" in kernel info from "/.*"`)
 }
 
 func (p *layoutTestSuite) TestResolveContentPathsErrorInKernelRef(c *C) {
@@ -1225,7 +1225,7 @@ func (p *layoutTestSuite) TestResolveContentPathsErrorInKernelRef(c *C) {
 
 	kernelSnapDir := c.MkDir()
 	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
-	c.Assert(err, ErrorMatches, `cannot parse kernel ref: invalid asset name in kernel ref "\$kernel:-invalid-kernel-ref/boot-assets/"`)
+	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot parse kernel ref: invalid asset name in kernel ref "\$kernel:-invalid-kernel-ref/boot-assets/"`)
 }
 
 func (p *layoutTestSuite) TestResolveContentPathsNotInWantedeContent(c *C) {
@@ -1243,7 +1243,7 @@ assets:
 	kernelSnapFiles := map[string]string{}
 	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
 	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
-	c.Assert(err, ErrorMatches, `cannot find wanted kernel content "boot-assets/" in "/.*"`)
+	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find wanted kernel content "boot-assets/" in "/.*"`)
 }
 
 func (p *layoutTestSuite) TestResolveContentPaths(c *C) {


### PR DESCRIPTION
This commit improves the error messages and the error detection
for incorrect gadget assets content sources.

Followup for https://github.com/snapcore/snapd/pull/9875#discussion_r568176099