### PR TITLE
tests/lib/prepare.sh: add another console= to the reflash magic grub entry

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -994,7 +994,7 @@ EOF
 set default=0
 set timeout=2
 menuentry 'flash-all-snaps' {
-linux $DEVPREFIX/vmlinuz root=$ROOT ro init=$IMAGE_HOME/reflash.sh console=ttyS0
+linux $DEVPREFIX/vmlinuz root=$ROOT ro init=$IMAGE_HOME/reflash.sh console=tty1 console=ttyS0
 initrd $DEVPREFIX/initrd.img
 }
 EOF


### PR DESCRIPTION
This ensures that if you are running qemu locally with SPREAD_QEMU_GUI=1 you can
see the console output, it seems that things are busted right now trying to run
UC20 spread tests via QEMU locally, so this at least shows us that something is
segfaulting in reflash.sh since you can see the console.