### PR TITLE
wrappers: don't generate an [Install] section for timer or dbus activated services

### DIFF
--- a/tests/main/snap-services/task.yaml
+++ b/tests/main/snap-services/task.yaml
@@ -9,8 +9,8 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-timer-service
 
     snap services test-snapd-timer-service > timer-service.out
-    MATCH '^test-snapd-timer-service.random-timer\s+ disabled\s+ (in)?active\s+ timer-activated$' < timer-service.out
-    MATCH '^test-snapd-timer-service.regular-timer\s+ disabled\s+ (in)?active\s+ timer-activated$' < timer-service.out
+    MATCH '^test-snapd-timer-service.random-timer\s+ enabled\s+ (in)?active\s+ timer-activated$' < timer-service.out
+    MATCH '^test-snapd-timer-service.regular-timer\s+ enabled\s+ (in)?active\s+ timer-activated$' < timer-service.out
 
     snap services socket-activation > socket-activation.out
     MATCH '^socket-activation.sleep-daemon\s+ enabled\s+ inactive\s+ socket-activated$' < socket-activation.out

--- a/tests/main/snap-services/task.yaml
+++ b/tests/main/snap-services/task.yaml
@@ -29,5 +29,5 @@ execute: |
         # activation on the D-Bus system bus
         snap install --edge test-snapd-dbus-service
         snap services test-snapd-dbus-service > dbus-service.out
-        MATCH '^test-snapd-dbus-service.system\s+ disabled\s+ (in)?active\s+ dbus-activated$' < dbus-service.out
+        MATCH '^test-snapd-dbus-service.system\s+ enabled\s+ (in)?active\s+ dbus-activated$' < dbus-service.out
     fi

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -727,7 +727,7 @@ KillSignal={{.KillSignal}}
 {{- if .OOMAdjustScore }}
 OOMScoreAdjust={{.OOMAdjustScore}}
 {{- end}}
-{{- if not .App.Sockets}}
+{{- if not (or .App.Sockets .App.Timer .App.ActivatesOn) }}
 
 [Install]
 WantedBy={{.ServicesTarget}}

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -63,7 +63,9 @@ ExecReload=/usr/bin/snap run --command=reload snap.app
 ExecStopPost=/usr/bin/snap run --command=post-stop snap.app
 TimeoutStopSec=10
 Type=%s
+%s`
 
+const expectedInstallSection = `
 [Install]
 WantedBy=multi-user.target
 `
@@ -94,9 +96,9 @@ var (
 )
 
 var (
-	expectedAppService     = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "simple")
-	expectedDbusService    = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "dbus\nBusName=foo.bar.baz")
-	expectedOneshotService = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "no", "oneshot\nRemainAfterExit=yes")
+	expectedAppService     = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "simple", expectedInstallSection)
+	expectedDbusService    = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "dbus\nBusName=foo.bar.baz", "")
+	expectedOneshotService = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "no", "oneshot\nRemainAfterExit=yes", expectedInstallSection)
 	expectedUserAppService = fmt.Sprintf(expectedUserServiceFmt, "on-failure", "simple")
 )
 
@@ -121,7 +123,7 @@ ExecStopPost=/usr/bin/snap run --command=post-stop xkcd-webserver
 TimeoutStopSec=30
 Type=%s
 %s`
-	expectedTypeForkingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, mountUnitPrefix, mountUnitPrefix, "forking", "\n[Install]\nWantedBy=multi-user.target\n")
+	expectedTypeForkingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, mountUnitPrefix, mountUnitPrefix, "forking", expectedInstallSection)
 )
 
 func (s *servicesWrapperGenSuite) SetUpTest(c *C) {
@@ -249,7 +251,6 @@ func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileIllegalChars(c *C) 
 }
 
 func (s *servicesWrapperGenSuite) TestGenServiceFileWithBusName(c *C) {
-
 	yamlText := `
 name: snap
 version: 1.0
@@ -305,6 +306,7 @@ apps:
 	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app, nil)
 	c.Assert(err, IsNil)
 
+	expectedDbusService := fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "dbus\nBusName=foo.bar.baz", expectedInstallSection)
 	c.Assert(string(generatedWrapper), Equals, expectedDbusService)
 }
 
@@ -646,9 +648,6 @@ Restart=%s
 WorkingDirectory=/var/snap/snap/44
 TimeoutStopSec=30
 Type=%s
-
-[Install]
-WantedBy=multi-user.target
 `
 
 	expectedService := fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "simple")


### PR DESCRIPTION
Breaking out from PR #9872, this PR removes the `[Install]` section of timer and dbus activated services.  While snapd never tried to enable these services, the presence of the section meant that systemd would report the units to be in the `disabled` state instead of `static`.

Removing the `[Install]` section also reduces the chance of unexpected behaviour should a user call `systemctl enable` on one of these units.