### PR TITLE
snap: rename gdbserver option to `snap run --gdbserver`

### DIFF
--- a/cmd/snap-gdb-shim/snap-gdbserver-shim.c
+++ b/cmd/snap-gdb-shim/snap-gdbserver-shim.c
@@ -45,8 +45,7 @@ int main(int argc, char **argv) {
 
     // signal gdb to stop here
     printf("\n\n");
-    printf("THIS OPTION IS EXPERIMENTAL\n\n");
-    printf("Welcome to `snap run --gdb`.\n");
+    printf("Welcome to `snap run --gdbserver`.\n");
     printf("You are right before your application is execed():\n");
     printf("- set any options you may need\n");
     printf("- (optionally) set a breakpoint in 'main'\n");

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -111,7 +111,6 @@ and environment.
 			"gdb": i18n.G("Run the command with gdb"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"gdbserver": i18n.G("Run the command with gdbserver"),
-			// TRANSLATORS: This should not start with a lowercase letter.
 			"experimental-gdbserver": "",
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"timer": i18n.G("Run as a timer service with given schedule"),

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -75,10 +75,11 @@ type cmdRun struct {
 	// This options is both a selector (use or don't use strace) and it
 	// can also carry extra options for strace. This is why there is
 	// "default" and "optional-value" to distinguish this.
-	Strace    string `long:"strace" optional:"true" optional-value:"with-strace" default:"no-strace" default-mask:"-"`
-	Gdb       bool   `long:"gdb"`
-	Gdbserver string `long:"experimental-gdbserver" default:"no-gdbserver" optional-value:":0" optional:"true"`
-	TraceExec bool   `long:"trace-exec"`
+	Strace                string `long:"strace" optional:"true" optional-value:"with-strace" default:"no-strace" default-mask:"-"`
+	Gdb                   bool   `long:"gdb"`
+	Gdbserver             string `long:"gdbserver" default:"no-gdbserver" optional-value:":0" optional:"true"`
+	ExperimentalGdbserver string `long:"experimental-gdbserver" default:"no-gdbserver" optional-value:":0" optional:"true" hidden:"yes"`
+	TraceExec             bool   `long:"trace-exec"`
 
 	// not a real option, used to check if cmdRun is initialized by
 	// the parser
@@ -109,7 +110,9 @@ and environment.
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"gdb": i18n.G("Run the command with gdb"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"experimental-gdbserver": i18n.G("Run the command with gdbserver (experimental)"),
+			"gdbserver": i18n.G("Run the command with gdbserver"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"experimental-gdbserver": "",
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"timer": i18n.G("Run as a timer service with given schedule"),
 			// TRANSLATORS: This should not start with a lowercase letter.
@@ -779,6 +782,11 @@ func racyFindFreePort() (int, error) {
 }
 
 func (x *cmdRun) useGdbserver() bool {
+	// compatibility, can be removed after 2021
+	if x.ExperimentalGdbserver != "no-gdbserver" {
+		x.Gdbserver = x.ExperimentalGdbserver
+	}
+
 	// make sure the go-flag parser ran and assigned default values
 	return x.ParserRan == 1 && x.Gdbserver != "no-gdbserver"
 }

--- a/tests/main/snap-run-gdbserver/task.yaml
+++ b/tests/main/snap-run-gdbserver/task.yaml
@@ -3,6 +3,10 @@ summary: Check that `snap run --gdbserver` works
 # testing only here to avoid having to install gdb/gdbserver everywhere
 systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-2*]
 
+environment:
+    OPT/normal: --gdbserver
+    OPT/deprecated: --experimental-gdbserver
+
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     apt install -y gdbserver gdb
@@ -16,7 +20,7 @@ execute: |
     # run the gdbserver command as a user
     # XXX: use "systemd-run --user -p StandardOutput=file:$(pwd)/stdout"
     # shellcheck disable=SC2016
-    su -c 'snap run --gdbserver test-snapd-sh.sh -c "echo hello-hello-hello uid:$UID"' test >stdout &
+    su -c 'snap run "$OPT" test-snapd-sh.sh -c "echo hello-hello-hello uid:$UID"' test >stdout &
 
     # wait for the instructions that gdb is ready to get attached
     retry -n60 grep '^gdb -ex' stdout

--- a/tests/main/snap-run-gdbserver/task.yaml
+++ b/tests/main/snap-run-gdbserver/task.yaml
@@ -1,4 +1,4 @@
-summary: Check that `snap run --experimental-gdbserver` works
+summary: Check that `snap run --gdbserver` works
 
 # testing only here to avoid having to install gdb/gdbserver everywhere
 systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-2*]
@@ -11,12 +11,12 @@ restore: |
     apt autoremove -y gdbserver gdb
 
 execute: |
-    echo "Test snap run --experimental-gdbserver works"
+    echo "Test snap run --gdbserver works"
 
     # run the gdbserver command as a user
     # XXX: use "systemd-run --user -p StandardOutput=file:$(pwd)/stdout"
     # shellcheck disable=SC2016
-    su -c 'snap run --experimental-gdbserver test-snapd-sh.sh -c "echo hello-hello-hello uid:$UID"' test >stdout &
+    su -c 'snap run --gdbserver test-snapd-sh.sh -c "echo hello-hello-hello uid:$UID"' test >stdout &
 
     # wait for the instructions that gdb is ready to get attached
     retry -n60 grep '^gdb -ex' stdout


### PR DESCRIPTION
The `snap run --experimental-gdbserver` option is available
since a while and we got no negative feedback so far. Given
that it's also superior to the `snap run --gdb` option this
PR make it available with the *experimental* prefix.

The old `snap run --experimental-gdbserver` option is still
available for compatbility and can be removed after some
releases.
