### PR TITLE
snap-confine.apparmor.in: support tmp and log dirs on Yocto/Poky

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -180,6 +180,7 @@
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/snap/,
 
     mount options=(rw rbind) /var/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
+    # /var/volatile is the default volatile location on Yocto/Poky, typically used with read-only rootfs setups
     mount options=(rw rbind) /var/volatile/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/tmp/,
 
@@ -196,6 +197,7 @@
     mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
 
     mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
+    # /var/volatile is the default volatile location on Yocto/Poky, typically used with read-only rootfs setups
     mount options=(rw rbind) /var/volatile/log/ -> /tmp/snap.rootfs_*/var/log/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/log/,
 

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -180,6 +180,7 @@
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/snap/,
 
     mount options=(rw rbind) /var/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
+    mount options=(rw rbind) /var/volatile/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/tmp/,
 
     mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
@@ -195,6 +196,7 @@
     mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
 
     mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
+    mount options=(rw rbind) /var/volatile/log/ -> /tmp/snap.rootfs_*/var/log/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/log/,
 
     mount options=(rw rbind) /usr/src/ -> /tmp/snap.rootfs_*/usr/src/,


### PR DESCRIPTION
On Yocto/Poky `/var/log` and `/var/tmp` are symlinks to `/var/volatile/log` and `/var/volatile/tmp` respectively. Which obviously means that snapd is not able to write to those directories.

We have been using this patch https://github.com/s-things/meta-snappy/blob/master/recipes-support/snapd/files/0001-poky-apparmor-fix.patch for 4 months without a problem. Without this, snaps don't really work.