### PR TITLE
interfaces: opengl: add Xilinx zocl bits

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -110,6 +110,10 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 /dev/tegra_dc_ctrl rw,
 /dev/tegra_dc_[0-9]* rw,
 
+# Xilinx zocl DRM driver
+# https://github.com/Xilinx/XRT/tree/master/src/runtime_src/core/edge/drm
+/sys/devices/platform/amba_pl@[0-9]*/amba_pl@[0-9]*:zyxclmm_drm/* r,
+
 # OpenCL ICD files
 /etc/OpenCL/vendors/ r,
 /etc/OpenCL/vendors/** r,


### PR DESCRIPTION
Add read access to sysfs bits from the Xilinx zocl DRM driver, which
are used to retrieve information about the hardware. See
https://github.com/Xilinx/XRT/tree/master/src/runtime_src/core/edge/drm.