### PR TITLE
boot: use a common helper for mocking boot assets in cache

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -86,6 +86,22 @@ func (s *baseBootenvSuite) mockCmdline(c *C, cmdline string) {
 	c.Assert(ioutil.WriteFile(s.cmdlineFile, []byte(cmdline), 0644), IsNil)
 }
 
+// mockAssetsCache mock boot assets in cache, a list of (path, data) tuples,
+// where if data is omitted an empty files gets created.
+func mockAssetsCache(c *C, rootdir, bootloaderName string, cachedAssets [][]string) {
+	p := filepath.Join(dirs.SnapBootAssetsDirUnder(rootdir), bootloaderName)
+	err := os.MkdirAll(p, 0755)
+	c.Assert(err, IsNil)
+	for _, cachedAsset := range cachedAssets {
+		var content []byte
+		if len(cachedAsset) == 2 {
+			content = []byte(cachedAsset[1])
+		}
+		err = ioutil.WriteFile(filepath.Join(p, cachedAsset[0]), content, 0644)
+		c.Assert(err, IsNil)
+	}
+}
+
 type bootenvSuite struct {
 	baseBootenvSuite
 
@@ -850,12 +866,9 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	for _, name := range []string{
-		"asset-" + dataHash,
-	} {
-		c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"asset-" + dataHash},
+	})
 
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
@@ -961,12 +974,9 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	for _, name := range []string{
-		"asset-" + dataHash,
-	} {
-		c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"asset-" + dataHash},
+	})
 
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.ukern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
@@ -1072,12 +1082,9 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	for _, name := range []string{
-		"asset-" + dataHash,
-	} {
-		c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"asset-" + dataHash},
+	})
 
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
 
@@ -1188,12 +1195,9 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	for _, name := range []string{
-		"asset-" + dataHash,
-	} {
-		c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"asset-" + dataHash},
+	})
 
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.ukern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
 
@@ -1858,12 +1862,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	for _, name := range []string{
-		"asset-" + dataHash,
-	} {
-		c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"asset-" + dataHash},
+	})
 
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
@@ -2059,16 +2060,13 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	for _, name := range []string{
-		"shim-recoveryshimhash",
-		"shim-" + shimHash,
-		"asset-assethash",
-		"asset-recoveryassethash",
-		"asset-" + dataHash,
-	} {
-		c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"shim-recoveryshimhash"},
+		{"shim-" + shimHash},
+		{"asset-assethash"},
+		{"asset-recoveryassethash"},
+		{"asset-" + dataHash},
+	})
 
 	shimBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("shim-%s", shimHash)), bootloader.RoleRecovery)
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRecovery)
@@ -2205,13 +2203,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	for _, name := range []string{
-		"shim-" + shimHash,
-		"asset-" + dataHash,
-	} {
-		c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"shim-" + shimHash},
+		{"asset-" + dataHash},
+	})
 
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
 	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
@@ -2368,13 +2363,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	for _, name := range []string{
-		"shim-" + shimHash,
-		"asset-" + dataHash,
-	} {
-		c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"shim-" + shimHash},
+		{"asset-" + dataHash},
+	})
 
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.ukern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
 	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
@@ -2523,10 +2515,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/asset"), data, 0644), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/asset"), data, 0644), IsNil)
 	// mock some state in the cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	for _, name := range []string{"asset-one", "asset-two"} {
-		c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"asset-one"},
+		{"asset-two"},
+	})
 
 	// we were trying an update of boot assets
 	m := &boot.Modeenv{
@@ -2574,8 +2566,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 
 func (s *bootenv20Suite) setupMarkBootSuccessful20CommandLine(c *C, mode string, cmdlines boot.BootCommandLines) *boot.Modeenv {
 	// mock some state in the cache
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", "asset-one"), nil, 0644), IsNil)
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"asset-one"},
+	})
 	// a pending kernel command line change
 	m := &boot.Modeenv{
 		Mode:           mode,
@@ -2902,8 +2895,9 @@ func (s *bootConfigSuite) TestBootConfigUpdateHappyWithReseal(c *C) {
 
 	runKernelBf := bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
 	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", "asset-hash-1"), nil, 0644), IsNil)
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
+		{"asset-hash-1"},
+	})
 
 	s.bootloader.TrustedAssetsList = []string{"asset"}
 	s.bootloader.BootChainList = []bootloader.BootFile{

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -86,7 +86,7 @@ func (s *baseBootenvSuite) mockCmdline(c *C, cmdline string) {
 	c.Assert(ioutil.WriteFile(s.cmdlineFile, []byte(cmdline), 0644), IsNil)
 }
 
-// mockAssetsCache mock boot assets in cache, a list of (path, data) tuples,
+// mockAssetsCache mocks boot assets in cache, a list of (path, data) tuples,
 // where if data is omitted an empty files gets created.
 func mockAssetsCache(c *C, rootdir, bootloaderName string, cachedAssets [][]string) {
 	p := filepath.Join(dirs.SnapBootAssetsDirUnder(rootdir), bootloaderName)
@@ -95,6 +95,7 @@ func mockAssetsCache(c *C, rootdir, bootloaderName string, cachedAssets [][]stri
 	for _, cachedAsset := range cachedAssets {
 		var content []byte
 		if len(cachedAsset) == 2 {
+			// we have a (path, data) tuple
 			content = []byte(cachedAsset[1])
 		}
 		err = ioutil.WriteFile(filepath.Join(p, cachedAsset[0]), content, 0644)

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -86,19 +86,14 @@ func (s *baseBootenvSuite) mockCmdline(c *C, cmdline string) {
 	c.Assert(ioutil.WriteFile(s.cmdlineFile, []byte(cmdline), 0644), IsNil)
 }
 
-// mockAssetsCache mocks boot assets in cache, a list of (path, data) tuples,
-// where if data is omitted an empty files gets created.
-func mockAssetsCache(c *C, rootdir, bootloaderName string, cachedAssets [][]string) {
+// mockAssetsCache mocks the listed assets in the boot assets cache by creating
+// an empty file each.
+func mockAssetsCache(c *C, rootdir, bootloaderName string, cachedAssets []string) {
 	p := filepath.Join(dirs.SnapBootAssetsDirUnder(rootdir), bootloaderName)
 	err := os.MkdirAll(p, 0755)
 	c.Assert(err, IsNil)
 	for _, cachedAsset := range cachedAssets {
-		var content []byte
-		if len(cachedAsset) == 2 {
-			// we have a (path, data) tuple
-			content = []byte(cachedAsset[1])
-		}
-		err = ioutil.WriteFile(filepath.Join(p, cachedAsset[0]), content, 0644)
+		err = ioutil.WriteFile(filepath.Join(p, cachedAsset), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 }
@@ -867,8 +862,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"asset-" + dataHash},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
 	})
 
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
@@ -975,8 +970,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"asset-" + dataHash},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
 	})
 
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
@@ -1083,8 +1078,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"asset-" + dataHash},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
 	})
 
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
@@ -1196,8 +1191,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"asset-" + dataHash},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
 	})
 
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.ukern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
@@ -1863,8 +1858,8 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"asset-" + dataHash},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
 	})
 
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
@@ -2061,12 +2056,12 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"shim-recoveryshimhash"},
-		{"shim-" + shimHash},
-		{"asset-assethash"},
-		{"asset-recoveryassethash"},
-		{"asset-" + dataHash},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"shim-recoveryshimhash",
+		"shim-" + shimHash,
+		"asset-assethash",
+		"asset-recoveryassethash",
+		"asset-" + dataHash,
 	})
 
 	shimBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("shim-%s", shimHash)), bootloader.RoleRecovery)
@@ -2204,9 +2199,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"shim-" + shimHash},
-		{"asset-" + dataHash},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"shim-" + shimHash,
+		"asset-" + dataHash,
 	})
 
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
@@ -2364,9 +2359,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"shim-" + shimHash},
-		{"asset-" + dataHash},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"shim-" + shimHash,
+		"asset-" + dataHash,
 	})
 
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.ukern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
@@ -2516,9 +2511,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/asset"), data, 0644), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/asset"), data, 0644), IsNil)
 	// mock some state in the cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"asset-one"},
-		{"asset-two"},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-one",
+		"asset-two",
 	})
 
 	// we were trying an update of boot assets
@@ -2567,8 +2562,8 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 
 func (s *bootenv20Suite) setupMarkBootSuccessful20CommandLine(c *C, mode string, cmdlines boot.BootCommandLines) *boot.Modeenv {
 	// mock some state in the cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"asset-one"},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-one",
 	})
 	// a pending kernel command line change
 	m := &boot.Modeenv{
@@ -2896,8 +2891,8 @@ func (s *bootConfigSuite) TestBootConfigUpdateHappyWithReseal(c *C) {
 
 	runKernelBf := bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
 	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", [][]string{
-		{"asset-hash-1"},
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-hash-1",
 	})
 
 	s.bootloader.TrustedAssetsList = []string{"asset"}

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -87,7 +87,7 @@ func (s *baseBootenvSuite) mockCmdline(c *C, cmdline string) {
 }
 
 // mockAssetsCache mocks the listed assets in the boot assets cache by creating
-// an empty file each.
+// an empty file for each.
 func mockAssetsCache(c *C, rootdir, bootloaderName string, cachedAssets []string) {
 	p := filepath.Join(dirs.SnapBootAssetsDirUnder(rootdir), bootloaderName)
 	err := os.MkdirAll(p, 0755)

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -1094,15 +1094,15 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 	}
 
 	// mock relevant files in cache
-	mockAssetsCache(c, s.rootDir, "recovery-bl", [][]string{
-		{"shim-hash0"},
-		{"shim-hash1"},
-		{"loader-recovery-hash0"},
-		{"loader-recovery-hash1"},
+	mockAssetsCache(c, s.rootDir, "recovery-bl", []string{
+		"shim-hash0",
+		"shim-hash1",
+		"loader-recovery-hash0",
+		"loader-recovery-hash1",
 	})
-	mockAssetsCache(c, s.rootDir, "run-bl", [][]string{
-		{"loader-run-hash0"},
-		{"loader-run-hash1"},
+	mockAssetsCache(c, s.rootDir, "run-bl", []string{
+		"loader-run-hash0",
+		"loader-run-hash1",
 	})
 
 	blNames := map[bootloader.Role]string{

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -1094,17 +1094,16 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 	}
 
 	// mock relevant files in cache
-	for _, name := range []string{
-		"recovery-bl/shim-hash0", "recovery-bl/shim-hash1",
-		"recovery-bl/loader-recovery-hash0",
-		"recovery-bl/loader-recovery-hash1",
-		"run-bl/loader-run-hash0",
-		"run-bl/loader-run-hash1",
-	} {
-		p := filepath.Join(dirs.SnapBootAssetsDir, name)
-		c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(p, nil, 0644), IsNil)
-	}
+	mockAssetsCache(c, s.rootDir, "recovery-bl", [][]string{
+		{"shim-hash0"},
+		{"shim-hash1"},
+		{"loader-recovery-hash0"},
+		{"loader-recovery-hash1"},
+	})
+	mockAssetsCache(c, s.rootDir, "run-bl", [][]string{
+		{"loader-run-hash0"},
+		{"loader-run-hash1"},
+	})
 
 	blNames := map[bootloader.Role]string{
 		bootloader.RoleRecovery: "recovery-bl",

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -94,15 +94,11 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		}
 
 		// mock asset cache
-		p := filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-1")
-		err = os.MkdirAll(filepath.Dir(p), 0755)
-		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(p, nil, 0644)
-		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/grubx64.efi-grub-hash-1"), nil, 0644)
-		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-1"), nil, 0644)
-		c.Assert(err, IsNil)
+		mockAssetsCache(c, rootdir, "grub", [][]string{
+			{"bootx64.efi-shim-hash-1"},
+			{"grubx64.efi-grub-hash-1"},
+			{"grubx64.efi-run-grub-hash-1"},
+		})
 
 		// set encryption key
 		myKey := secboot.EncryptionKey{}
@@ -360,19 +356,13 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 		}
 
 		// mock asset cache
-		p := filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-1")
-		err = os.MkdirAll(filepath.Dir(p), 0755)
-		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(p, nil, 0644)
-		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-2"), nil, 0644)
-		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/grubx64.efi-grub-hash-1"), nil, 0644)
-		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-1"), nil, 0644)
-		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-2"), nil, 0644)
-		c.Assert(err, IsNil)
+		mockAssetsCache(c, rootdir, "grub", [][]string{
+			{"bootx64.efi-shim-hash-1"},
+			{"bootx64.efi-shim-hash-2"},
+			{"grubx64.efi-grub-hash-1"},
+			{"grubx64.efi-run-grub-hash-1"},
+			{"grubx64.efi-run-grub-hash-2"},
+		})
 
 		model := boottest.MakeMockUC20Model()
 
@@ -628,10 +618,9 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 	err = boot.WriteBootChains(nil, filepath.Join(dirs.SnapFDEDir, "boot-chains"), 9)
 	c.Assert(err, IsNil)
 	// mock asset cache
-	err = os.MkdirAll(filepath.Join(rootdir, "var/lib/snapd/boot-assets/trusted"), 0755)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(rootdir, "var/lib/snapd/boot-assets/trusted/asset-asset-hash-1"), nil, 0644)
-	c.Assert(err, IsNil)
+	mockAssetsCache(c, rootdir, "trusted", [][]string{
+		{"asset-asset-hash-1"},
+	})
 
 	// match one of current kernels
 	runKernelBf := bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_500.snap", "kernel.efi", bootloader.RoleRunMode)
@@ -872,15 +861,11 @@ func (s *sealSuite) TestSealKeyModelParams(c *C) {
 		bootloader.RoleRunMode:  "grub",
 	}
 	// mock asset cache
-	p := filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/shim-shim-hash")
-	err := os.MkdirAll(filepath.Dir(p), 0755)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(p, nil, 0644)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/loader-loader-hash1"), nil, 0644)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/loader-loader-hash2"), nil, 0644)
-	c.Assert(err, IsNil)
+	mockAssetsCache(c, rootdir, "grub", [][]string{
+		{"shim-shim-hash"},
+		{"loader-loader-hash1"},
+		{"loader-loader-hash2"},
+	})
 
 	oldmodel := boottest.MakeMockUC20Model(map[string]interface{}{
 		"model":     "old-model-uc20",

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -94,10 +94,10 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		}
 
 		// mock asset cache
-		mockAssetsCache(c, rootdir, "grub", [][]string{
-			{"bootx64.efi-shim-hash-1"},
-			{"grubx64.efi-grub-hash-1"},
-			{"grubx64.efi-run-grub-hash-1"},
+		mockAssetsCache(c, rootdir, "grub", []string{
+			"bootx64.efi-shim-hash-1",
+			"grubx64.efi-grub-hash-1",
+			"grubx64.efi-run-grub-hash-1",
 		})
 
 		// set encryption key
@@ -356,12 +356,12 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 		}
 
 		// mock asset cache
-		mockAssetsCache(c, rootdir, "grub", [][]string{
-			{"bootx64.efi-shim-hash-1"},
-			{"bootx64.efi-shim-hash-2"},
-			{"grubx64.efi-grub-hash-1"},
-			{"grubx64.efi-run-grub-hash-1"},
-			{"grubx64.efi-run-grub-hash-2"},
+		mockAssetsCache(c, rootdir, "grub", []string{
+			"bootx64.efi-shim-hash-1",
+			"bootx64.efi-shim-hash-2",
+			"grubx64.efi-grub-hash-1",
+			"grubx64.efi-run-grub-hash-1",
+			"grubx64.efi-run-grub-hash-2",
 		})
 
 		model := boottest.MakeMockUC20Model()
@@ -618,8 +618,8 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 	err = boot.WriteBootChains(nil, filepath.Join(dirs.SnapFDEDir, "boot-chains"), 9)
 	c.Assert(err, IsNil)
 	// mock asset cache
-	mockAssetsCache(c, rootdir, "trusted", [][]string{
-		{"asset-asset-hash-1"},
+	mockAssetsCache(c, rootdir, "trusted", []string{
+		"asset-asset-hash-1",
 	})
 
 	// match one of current kernels
@@ -861,10 +861,10 @@ func (s *sealSuite) TestSealKeyModelParams(c *C) {
 		bootloader.RoleRunMode:  "grub",
 	}
 	// mock asset cache
-	mockAssetsCache(c, rootdir, "grub", [][]string{
-		{"shim-shim-hash"},
-		{"loader-loader-hash1"},
-		{"loader-loader-hash2"},
+	mockAssetsCache(c, rootdir, "grub", []string{
+		"shim-shim-hash",
+		"loader-loader-hash1",
+		"loader-loader-hash2",
 	})
 
 	oldmodel := boottest.MakeMockUC20Model(map[string]interface{}{


### PR DESCRIPTION
Use a common helper for mocking boot assets in cache. Cherry picked from recovery systems management branch.
