### PR TITLE
api: validation sets monitor mode

### DIFF
--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -358,9 +358,7 @@ func validationSetAssertFromDb(st *state.State, accountID, name string, sequence
 		"name":       name,
 		"sequence":   fmt.Sprintf("%d", sequence),
 	}
-	st.Lock()
 	db := assertstate.DB(st)
-	st.Unlock()
 	as, err := db.Find(asserts.ValidationSetType, headers)
 	if err != nil {
 		return nil, err
@@ -370,9 +368,7 @@ func validationSetAssertFromDb(st *state.State, accountID, name string, sequence
 }
 
 func validationSetForAssert(st *state.State, accountID, name string, sequence int) (*snapasserts.ValidationSets, error) {
-	st.Unlock()
 	as, err := validationSetAssertFromDb(st, accountID, name, sequence)
-	st.Lock()
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -307,7 +307,8 @@ func updateValidationSet(st *state.State, accountID, name string, reqMode string
 		userID = user.ID
 	}
 	pinned := sequence > 0
-	as, local, err := validationSetAssertionForMonitor(st, accountID, name, sequence, pinned, userID)
+	opts := assertstate.ResolveOptions{AllowLocalFallback: true}
+	as, local, err := validationSetAssertionForMonitor(st, accountID, name, sequence, pinned, userID, &opts)
 	if err != nil {
 		return BadRequest("cannot get validation set assertion for %v: %v", assertstate.ValidationSetKey(accountID, name), err)
 	}

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -572,11 +572,13 @@ func (s *apiValidationSetsSuite) TestGetValidationSetPinnedNotFound(c *check.C) 
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedLocalOnly(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error) {
+	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error) {
 		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 99)
 		c.Assert(pinned, check.Equals, true)
+		c.Assert(opts, check.NotNil)
+		c.Check(opts.AllowLocalFallback, check.Equals, true)
 
 		db := assertstate.DB(st)
 		headers, err := asserts.HeadersFromPrimaryKey(asserts.ValidationSetType, []string{release.Series, accountID, name, fmt.Sprintf("%d", sequence)})
@@ -647,7 +649,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedLocalOnl
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedUnresolved(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error) {
+	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error) {
 		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 99)
@@ -717,7 +719,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeUnpinnedRefres
 		"revision": "1",
 	}}
 
-	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error) {
+	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error) {
 		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 0)
@@ -792,7 +794,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeUnpinnedRefres
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeError(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error) {
+	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error) {
 		return nil, false, fmt.Errorf("boom")
 	})
 	defer restore()

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -29,12 +29,15 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 )
@@ -44,6 +47,10 @@ var _ = check.Suite(&apiValidationSetsSuite{})
 type apiValidationSetsSuite struct {
 	apiBaseSuite
 
+	storeSigning              *assertstest.StoreStack
+	dev1Signing               *assertstest.SigningDB
+	dev1acct                  *asserts.Account
+	acct1Key                  *asserts.AccountKey
 	mockSeqFormingAssertionFn func(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error)
 }
 
@@ -59,12 +66,28 @@ func (s *apiValidationSetsSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
 	d := s.daemon(c)
 
+	restore := asserts.MockMaxSupportedFormat(asserts.ValidationSetType, 1)
+	s.AddCleanup(restore)
+
 	s.mockSeqFormingAssertionFn = nil
+
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 
 	st := d.Overlord().State()
 	st.Lock()
 	snapstate.ReplaceStore(st, s)
+	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
 	st.Unlock()
+
+	s.dev1acct = assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
+	c.Assert(s.storeSigning.Add(s.dev1acct), check.IsNil)
+
+	// developer signing
+	dev1PrivKey, _ := assertstest.GenerateKey(752)
+	s.acct1Key = assertstest.NewAccountKey(s.storeSigning, s.dev1acct, nil, dev1PrivKey.PublicKey(), "")
+
+	s.dev1Signing = assertstest.NewSigningDB(s.dev1acct.AccountID(), dev1PrivKey)
+	c.Assert(s.storeSigning.Add(s.acct1Key), check.IsNil)
 
 	d.Overlord().Loop()
 	s.AddCleanup(func() { d.Overlord().Stop() })
@@ -72,21 +95,43 @@ func (s *apiValidationSetsSuite) SetUpTest(c *check.C) {
 
 func mockValidationSetsTracking(st *state.State) {
 	st.Set("validation-sets", map[string]interface{}{
-		"foo/bar": map[string]interface{}{
-			"account-id": "foo",
-			"name":       "bar",
+		"can0nical/foo": map[string]interface{}{
+			"account-id": "can0nical",
+			"name":       "foo",
 			"mode":       assertstate.Enforce,
 			"pinned-at":  9,
-			"current":    12,
+			"current":    99,
 		},
-		"foo/baz": map[string]interface{}{
-			"account-id": "foo",
+		"can0nical/baz": map[string]interface{}{
+			"account-id": "can0nical",
 			"name":       "baz",
 			"mode":       assertstate.Monitor,
 			"pinned-at":  0,
 			"current":    2,
 		},
 	})
+}
+
+func (s *apiValidationSetsSuite) mockAssert(c *check.C, name, sequence string) asserts.Assertion {
+	snaps := []interface{}{map[string]interface{}{
+		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzz",
+		"name":     "snap-b",
+		"presence": "required",
+		"revision": "1",
+	}}
+	headers := map[string]interface{}{
+		"authority-id": "can0nical",
+		"account-id":   "can0nical",
+		"name":         name,
+		"series":       "16",
+		"sequence":     sequence,
+		"revision":     "5",
+		"timestamp":    "2030-11-06T09:16:26Z",
+		"snaps":        snaps,
+	}
+	as, err := s.storeSigning.Sign(asserts.ValidationSetType, headers, nil, "")
+	c.Assert(err, check.IsNil)
+	return as
 }
 
 func (s *apiValidationSetsSuite) SeqFormingAssertion(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error) {
@@ -170,54 +215,73 @@ func (s *apiValidationSetsSuite) TestGetValidationSetsNone(c *check.C) {
 }
 
 func (s *apiValidationSetsSuite) TestListValidationSets(c *check.C) {
-	req, err := http.NewRequest("GET", "/v2/validation-sets", nil)
-	c.Assert(err, check.IsNil)
-
 	st := s.d.Overlord().State()
 	st.Lock()
 	mockValidationSetsTracking(st)
+	as := s.mockAssert(c, "foo", "9")
+	err := assertstate.Add(st, as)
+	c.Check(err, check.IsNil)
+	as = s.mockAssert(c, "baz", "2")
+	err = assertstate.Add(st, as)
 	st.Unlock()
+	c.Assert(err, check.IsNil)
 
+	req, err := http.NewRequest("GET", "/v2/validation-sets", nil)
+	c.Assert(err, check.IsNil)
 	rsp := s.req(c, req, nil).(*daemon.Resp)
+	if rsp.Status != 200 {
+		fmt.Printf("%s\n", rsp.ErrorResult().Message)
+	}
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.([]daemon.ValidationSetResult)
 	c.Check(res, check.DeepEquals, []daemon.ValidationSetResult{
 		{
-			AccountID: "foo",
-			Name:      "bar",
-			PinnedAt:  9,
-			Mode:      "enforce",
-			Sequence:  12,
-			Valid:     false,
-		},
-		{
-			AccountID: "foo",
+			AccountID: "can0nical",
 			Name:      "baz",
 			Mode:      "monitor",
 			Sequence:  2,
+			Valid:     false,
+		},
+		{
+			AccountID: "can0nical",
+			Name:      "foo",
+			PinnedAt:  9,
+			Mode:      "enforce",
+			Sequence:  99,
 			Valid:     false,
 		},
 	})
 }
 
 func (s *apiValidationSetsSuite) TestGetValidationSetOne(c *check.C) {
-	req, err := http.NewRequest("GET", "/v2/validation-sets/foo/bar", nil)
-	c.Assert(err, check.IsNil)
+	s.mockSeqFormingAssertionFn = func(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error) {
+		return nil, &asserts.NotFoundError{
+			Type: assertType,
+		}
+	}
 
 	st := s.d.Overlord().State()
 	st.Lock()
 	mockValidationSetsTracking(st)
+	as := s.mockAssert(c, "baz", "2")
+	err := assertstate.Add(st, as)
 	st.Unlock()
+	c.Assert(err, check.IsNil)
+
+	req, err := http.NewRequest("GET", "/v2/validation-sets/can0nical/baz", nil)
+	c.Assert(err, check.IsNil)
 
 	rsp := s.req(c, req, nil).(*daemon.Resp)
+	if rsp.Status != 200 {
+		fmt.Printf("%s\n", rsp.ErrorResult().Message)
+	}
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.(daemon.ValidationSetResult)
 	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
-		AccountID: "foo",
-		Name:      "bar",
-		PinnedAt:  9,
-		Mode:      "enforce",
-		Sequence:  12,
+		AccountID: "can0nical",
+		Name:      "baz",
+		Mode:      "monitor",
+		Sequence:  2,
 		Valid:     false,
 	})
 }
@@ -225,23 +289,29 @@ func (s *apiValidationSetsSuite) TestGetValidationSetOne(c *check.C) {
 func (s *apiValidationSetsSuite) TestGetValidationSetPinned(c *check.C) {
 	q := url.Values{}
 	q.Set("sequence", "9")
-	req, err := http.NewRequest("GET", "/v2/validation-sets/foo/bar?"+q.Encode(), nil)
+	req, err := http.NewRequest("GET", "/v2/validation-sets/can0nical/foo?"+q.Encode(), nil)
 	c.Assert(err, check.IsNil)
 
 	st := s.d.Overlord().State()
 	st.Lock()
 	mockValidationSetsTracking(st)
+	as := s.mockAssert(c, "foo", "9")
+	err = assertstate.Add(st, as)
 	st.Unlock()
+	c.Assert(err, check.IsNil)
 
 	rsp := s.req(c, req, nil).(*daemon.Resp)
+	if rsp.Status != 200 {
+		fmt.Printf("%s\n", rsp.ErrorResult().Message)
+	}
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.(daemon.ValidationSetResult)
 	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
-		AccountID: "foo",
-		Name:      "bar",
+		AccountID: "can0nical",
+		Name:      "foo",
 		PinnedAt:  9,
 		Mode:      "enforce",
-		Sequence:  12,
+		Sequence:  99,
 		Valid:     false,
 	})
 }
@@ -287,7 +357,7 @@ var validationSetAssertion = []byte("type: validation-set\n" +
 	"    presence: required\n" +
 	"    revision: 1\n" +
 	"timestamp: 2020-11-06T09:16:26Z\n" +
-	"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+	"sign-key-sha3-384: 7bbncP0c4RcufwReeiylCe0S7IMCn-tHLNSCgeOVmV3K-7_MzpAHgJDYeOjldefE\n\n" +
 	"AXNpZw==")
 
 func (s *apiValidationSetsSuite) TestGetValidationSetLatestFromRemote(c *check.C) {
@@ -501,59 +571,239 @@ func (s *apiValidationSetsSuite) TestGetValidationSetPinnedNotFound(c *check.C) 
 	})
 }
 
-func (s *apiValidationSetsSuite) TestApplyValidationSet(c *check.C) {
+func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedLocalOnly(c *check.C) {
+	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error) {
+		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
+		c.Assert(name, check.Equals, "bar")
+		c.Assert(sequence, check.Equals, 99)
+		c.Assert(pinned, check.Equals, true)
+
+		db := assertstate.DB(st)
+		headers, err := asserts.HeadersFromPrimaryKey(asserts.ValidationSetType, []string{release.Series, accountID, name, fmt.Sprintf("%d", sequence)})
+		c.Assert(err, check.IsNil)
+		// validation set assertion available locally
+		vs, err := db.Find(asserts.ValidationSetType, headers)
+		c.Assert(err, check.IsNil)
+		return vs.(*asserts.ValidationSet), true, nil
+	})
+	defer restore()
+
 	st := s.d.Overlord().State()
 
-	for _, tc := range []struct {
-		mode         string
-		sequence     int
-		expectedMode assertstate.ValidationSetMode
-	}{
-		{
-			mode:         "enforce",
-			sequence:     12,
-			expectedMode: assertstate.Enforce,
-		},
-		{
-			mode:         "monitor",
-			sequence:     99,
-			expectedMode: assertstate.Monitor,
-		},
-		{
-			mode:         "enforce",
-			expectedMode: assertstate.Enforce,
-		},
-		{
-			mode:         "monitor",
-			expectedMode: assertstate.Monitor,
-		},
-	} {
-		var body string
-		if tc.sequence != 0 {
-			body = fmt.Sprintf(`{"action":"apply","mode":"%s", "sequence":%d}`, tc.mode, tc.sequence)
-		} else {
-			body = fmt.Sprintf(`{"action":"apply","mode":"%s"}`, tc.mode)
-		}
+	st.Lock()
+	c.Assert(assertstate.Add(st, s.dev1acct), check.IsNil)
+	c.Assert(assertstate.Add(st, s.acct1Key), check.IsNil)
+	st.Unlock()
 
-		req, err := http.NewRequest("POST", "/v2/validation-sets/foo/bar", strings.NewReader(body))
-		c.Assert(err, check.IsNil)
-
-		rsp := s.req(c, req, nil).(*daemon.Resp)
-		c.Assert(rsp.Status, check.Equals, 200)
-
-		var tr assertstate.ValidationSetTracking
-
-		st.Lock()
-		err = assertstate.GetValidationSet(st, "foo", "bar", &tr)
-		st.Unlock()
-		c.Assert(err, check.IsNil)
-		c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
-			AccountID: "foo",
-			Name:      "bar",
-			PinnedAt:  tc.sequence,
-			Mode:      tc.expectedMode,
-		})
+	snaps := []interface{}{map[string]interface{}{
+		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzz",
+		"name":     "snap-b",
+		"presence": "required",
+		"revision": "1",
+	}}
+	headers := map[string]interface{}{
+		"authority-id": s.dev1acct.AccountID(),
+		"account-id":   s.dev1acct.AccountID(),
+		"name":         "bar",
+		"series":       "16",
+		"sequence":     "99",
+		"revision":     "5",
+		"timestamp":    "2030-11-06T09:16:26Z",
+		"snaps":        snaps,
 	}
+	vs, err := s.dev1Signing.Sign(asserts.ValidationSetType, headers, nil, "")
+	c.Assert(err, check.IsNil)
+
+	st.Lock()
+	// add validation set assertion to the local db
+	c.Assert(assertstate.Add(st, vs), check.IsNil)
+	st.Unlock()
+
+	body := `{"action":"apply","mode":"monitor", "sequence":99}`
+	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
+	c.Assert(err, check.IsNil)
+
+	rsp := s.req(c, req, nil).(*daemon.Resp)
+	if rsp.Status != 200 {
+		fmt.Printf("%s\n", rsp.ErrorResult().Message)
+	}
+	c.Assert(rsp.Status, check.Equals, 200)
+
+	var tr assertstate.ValidationSetTracking
+
+	// verify tracking information
+	st.Lock()
+	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
+		Mode:      assertstate.Monitor,
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		PinnedAt:  99,
+		Current:   99,
+		LocalOnly: true,
+	})
+}
+
+func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedUnresolved(c *check.C) {
+	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error) {
+		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
+		c.Assert(name, check.Equals, "bar")
+		c.Assert(sequence, check.Equals, 99)
+		c.Assert(pinned, check.Equals, true)
+
+		snaps := []interface{}{map[string]interface{}{
+			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzz",
+			"name":     "snap-b",
+			"presence": "required",
+			"revision": "1",
+		}}
+		headers := map[string]interface{}{
+			"authority-id": s.dev1acct.AccountID(),
+			"account-id":   s.dev1acct.AccountID(),
+			"name":         "bar",
+			"series":       "16",
+			"sequence":     "99",
+			"revision":     "5",
+			"timestamp":    "2030-11-06T09:16:26Z",
+			"snaps":        snaps,
+		}
+		// validation set assertion coming from the store
+		vs, err := s.dev1Signing.Sign(asserts.ValidationSetType, headers, nil, "")
+		c.Assert(err, check.IsNil)
+		return vs.(*asserts.ValidationSet), false, nil
+	})
+	defer restore()
+
+	st := s.d.Overlord().State()
+
+	st.Lock()
+	c.Assert(assertstate.Add(st, s.dev1acct), check.IsNil)
+	c.Assert(assertstate.Add(st, s.acct1Key), check.IsNil)
+	st.Unlock()
+
+	body := `{"action":"apply","mode":"monitor", "sequence":99}`
+	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
+	c.Assert(err, check.IsNil)
+
+	rsp := s.req(c, req, nil).(*daemon.Resp)
+	if rsp.Status != 200 {
+		fmt.Printf("%s\n", rsp.ErrorResult().Message)
+	}
+	c.Assert(rsp.Status, check.Equals, 200)
+
+	var tr assertstate.ValidationSetTracking
+
+	// verify tracking information
+	st.Lock()
+	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
+		Mode:      assertstate.Monitor,
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		PinnedAt:  99,
+		Current:   99,
+	})
+}
+
+func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeUnpinnedRefreshed(c *check.C) {
+	snaps := []interface{}{map[string]interface{}{
+		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzz",
+		"name":     "snap-b",
+		"presence": "required",
+		"revision": "1",
+	}}
+
+	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error) {
+		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
+		c.Assert(name, check.Equals, "bar")
+		c.Assert(sequence, check.Equals, 0)
+		c.Assert(pinned, check.Equals, false)
+
+		// new sequence
+		headers := map[string]interface{}{
+			"authority-id": s.dev1acct.AccountID(),
+			"account-id":   s.dev1acct.AccountID(),
+			"name":         "bar",
+			"series":       "16",
+			"sequence":     "2",
+			"revision":     "1",
+			"timestamp":    "2030-11-06T09:16:26Z",
+			"snaps":        snaps,
+		}
+		// updated validation set assertion coming from the store
+		vs, err := s.dev1Signing.Sign(asserts.ValidationSetType, headers, nil, "")
+		c.Assert(err, check.IsNil)
+		return vs.(*asserts.ValidationSet), false, nil
+	})
+	defer restore()
+
+	st := s.d.Overlord().State()
+
+	st.Lock()
+	c.Assert(assertstate.Add(st, s.dev1acct), check.IsNil)
+	c.Assert(assertstate.Add(st, s.acct1Key), check.IsNil)
+	st.Unlock()
+
+	headers := map[string]interface{}{
+		"authority-id": s.dev1acct.AccountID(),
+		"account-id":   s.dev1acct.AccountID(),
+		"name":         "bar",
+		"series":       "16",
+		"sequence":     "1",
+		"revision":     "1",
+		"timestamp":    "2030-11-06T09:16:26Z",
+		"snaps":        snaps,
+	}
+	vs, err := s.dev1Signing.Sign(asserts.ValidationSetType, headers, nil, "")
+	c.Assert(err, check.IsNil)
+
+	st.Lock()
+	// add validation set assertion to the local db
+	c.Assert(assertstate.Add(st, vs), check.IsNil)
+	st.Unlock()
+
+	body := `{"action":"apply","mode":"monitor"}`
+	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
+	c.Assert(err, check.IsNil)
+
+	rsp := s.req(c, req, nil).(*daemon.Resp)
+	if rsp.Status != 200 {
+		fmt.Printf("%s\n", rsp.ErrorResult().Message)
+	}
+	c.Assert(rsp.Status, check.Equals, 200)
+
+	var tr assertstate.ValidationSetTracking
+
+	// verify tracking information
+	st.Lock()
+	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
+		Mode:      assertstate.Monitor,
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Current:   2,
+	})
+}
+
+func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeError(c *check.C) {
+	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error) {
+		return nil, false, fmt.Errorf("boom")
+	})
+	defer restore()
+
+	body := `{"action":"apply","mode":"monitor"}`
+	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
+	c.Assert(err, check.IsNil)
+
+	rsp := s.req(c, req, nil).(*daemon.Resp)
+	c.Assert(rsp.Status, check.Equals, 400)
+	c.Check(rsp.ErrorResult().Message, check.Equals, fmt.Sprintf(`cannot get validation set assertion for %s/bar: boom`, s.dev1acct.AccountID()))
 }
 
 func (s *apiValidationSetsSuite) TestForgetValidationSet(c *check.C) {
@@ -575,25 +825,25 @@ func (s *apiValidationSetsSuite) TestForgetValidationSet(c *check.C) {
 
 		st.Lock()
 		// sanity, it exists before removing
-		err := assertstate.GetValidationSet(st, "foo", "bar", &tr)
+		err := assertstate.GetValidationSet(st, "can0nical", "foo", &tr)
 		st.Unlock()
 		c.Assert(err, check.IsNil)
-		c.Check(tr.AccountID, check.Equals, "foo")
-		c.Check(tr.Name, check.Equals, "bar")
+		c.Check(tr.AccountID, check.Equals, "can0nical")
+		c.Check(tr.Name, check.Equals, "foo")
 
-		req, err := http.NewRequest("POST", "/v2/validation-sets/foo/bar", strings.NewReader(body))
+		req, err := http.NewRequest("POST", "/v2/validation-sets/can0nical/foo", strings.NewReader(body))
 		c.Assert(err, check.IsNil)
 		rsp := s.req(c, req, nil).(*daemon.Resp)
 		c.Assert(rsp.Status, check.Equals, 200, check.Commentf("case #%d", i))
 
 		// after forget it's removed
 		st.Lock()
-		err = assertstate.GetValidationSet(st, "foo", "bar", &tr)
+		err = assertstate.GetValidationSet(st, "can0nical", "foo", &tr)
 		st.Unlock()
 		c.Assert(err, check.Equals, state.ErrNoState)
 
 		// and forget again fails
-		req, err = http.NewRequest("POST", "/v2/validation-sets/foo/bar", strings.NewReader(body))
+		req, err = http.NewRequest("POST", "/v2/validation-sets/can0nical/foo", strings.NewReader(body))
 		c.Assert(err, check.IsNil)
 		rsp = s.req(c, req, nil).(*daemon.Resp)
 		c.Assert(rsp.Status, check.Equals, 404, check.Commentf("case #%d", i))
@@ -642,6 +892,13 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetsErrors(c *check.C) {
 			validationSet: "foo/bar",
 			mode:          "bad",
 			message:       `invalid mode "bad"`,
+			status:        400,
+		},
+		// XXX: enable when enforcing is implemented.
+		{
+			validationSet: "foo/bar",
+			mode:          "enforce",
+			message:       `invalid mode "enforce"`,
 			status:        400,
 		},
 		{

--- a/daemon/export_api_validate_test.go
+++ b/daemon/export_api_validate_test.go
@@ -20,7 +20,9 @@
 package daemon
 
 import (
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/overlord/state"
 )
 
 type (
@@ -32,5 +34,13 @@ func MockCheckInstalledSnaps(f func(vsets *snapasserts.ValidationSets, snaps []*
 	checkInstalledSnaps = f
 	return func() {
 		checkInstalledSnaps = old
+	}
+}
+
+func MockValidationSetAssertionForMonitor(f func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error)) func() {
+	old := validationSetAssertionForMonitor
+	validationSetAssertionForMonitor = f
+	return func() {
+		validationSetAssertionForMonitor = old
 	}
 }

--- a/daemon/export_api_validate_test.go
+++ b/daemon/export_api_validate_test.go
@@ -22,6 +22,7 @@ package daemon
 import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -37,7 +38,7 @@ func MockCheckInstalledSnaps(f func(vsets *snapasserts.ValidationSets, snaps []*
 	}
 }
 
-func MockValidationSetAssertionForMonitor(f func(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (*asserts.ValidationSet, bool, error)) func() {
+func MockValidationSetAssertionForMonitor(f func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error)) func() {
 	old := validationSetAssertionForMonitor
 	validationSetAssertionForMonitor = f
 	return func() {

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -363,8 +363,8 @@ type ResolveOptions struct {
 
 // ValidationSetAssertionForMonitor tries to fetch or refresh the validation
 // set assertion with accountID/name/sequence (sequence is optional) using pool.
-// If pinned is true and the assertion cannot be updated but exists locally,
-// then the local one is returned
+// If assertion cannot be fetched but exists locally and opts.AllowLocalFallback
+// is set then the local one is returned
 func ValidationSetAssertionForMonitor(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *ResolveOptions) (as *asserts.ValidationSet, local bool, err error) {
 	if opts == nil {
 		opts = &ResolveOptions{}

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -336,3 +336,108 @@ func delayedCrossMgrInit() {
 func AutoRefreshAssertions(s *state.State, userID int) error {
 	return RefreshSnapDeclarations(s, userID)
 }
+
+// RefreshValidationSetAssertions tries to refresh all validation set
+// assertions.
+func RefreshValidationSetAssertions(s *state.State, userID int) error {
+	deviceCtx, err := snapstate.DevicePastSeeding(s, nil)
+	if err != nil {
+		return err
+	}
+
+	vsets, err := ValidationSets(s)
+	if err != nil {
+		return err
+	}
+	if len(vsets) == 0 {
+		return nil
+	}
+
+	return bulkRefreshValidationSetAsserts(s, vsets, userID, deviceCtx)
+}
+
+// ValidationSetAssertionForMonitor tries to fetch or refresh the validation
+// set assertion with accountID/name/sequence (sequence is optional) using pool.
+// If pinned is true and the assertion cannot be updated but exists locally,
+// then the local one is returned
+func ValidationSetAssertionForMonitor(st *state.State, accountID, name string, sequence int, pinned bool, userID int) (as *asserts.ValidationSet, local bool, err error) {
+	deviceCtx, err := snapstate.DevicePastSeeding(st, nil)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var vs asserts.Assertion
+	headers := map[string]string{
+		"series":     release.Series,
+		"account-id": accountID,
+		"name":       name,
+	}
+
+	db := cachedDB(st)
+
+	// try to get existing one from db
+	if sequence > 0 {
+		headers["sequence"] = fmt.Sprintf("%d", sequence)
+		vs, err = db.Find(asserts.ValidationSetType, headers)
+	} else {
+		// find latest
+		vs, err = db.FindSequence(asserts.ValidationSetType, headers, -1, -1)
+	}
+	if err != nil && !asserts.IsNotFound(err) {
+		return nil, false, err
+	}
+	if err == nil {
+		as = vs.(*asserts.ValidationSet)
+	}
+
+	// try to resolve or update with pool
+	pool := asserts.NewPool(db, maxGroups)
+	atSeq := &asserts.AtSequence{
+		Type:        asserts.ValidationSetType,
+		SequenceKey: []string{release.Series, accountID, name},
+		Sequence:    sequence,
+		Pinned:      pinned,
+	}
+	if as != nil {
+		atSeq.Revision = as.Revision()
+	} else {
+		atSeq.Revision = asserts.RevisionNotKnown
+	}
+
+	// resolve if not found locally, otherwise add for update
+	if as == nil {
+		if err := pool.AddUnresolvedSequence(atSeq, atSeq.Unique()); err != nil {
+			return nil, false, err
+		}
+	} else {
+		atSeq.Sequence = as.Sequence()
+		// found locally, try to update
+		atSeq.Revision = as.Revision()
+		if err := pool.AddSequenceToUpdate(atSeq, atSeq.Unique()); err != nil {
+			return nil, false, err
+		}
+	}
+
+	if err := resolvePool(st, pool, userID, deviceCtx); err != nil {
+		rerr, ok := err.(*resolvePoolError)
+		if ok && pinned && as != nil {
+			if e := rerr.errors[atSeq.Unique()]; asserts.IsNotFound(e) {
+				// fallback: support the scenario of local assertion (snap ack)
+				// not available in the store.
+				return as, true, nil
+			}
+		}
+		return nil, false, err
+	}
+
+	// fetch the requested assertion again
+	if pinned {
+		vs, err = db.Find(asserts.ValidationSetType, headers)
+	} else {
+		vs, err = db.FindSequence(asserts.ValidationSetType, headers, -1, asserts.ValidationSetType.MaxSupportedFormat())
+	}
+	if err == nil {
+		as = vs.(*asserts.ValidationSet)
+	}
+	return as, false, err
+}

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -2422,7 +2422,8 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorLocalFallbackForPin
 	vsetAs := s.validationSetAssert(c, "bar", "1", "1")
 	c.Assert(assertstate.Add(st, vsetAs), check.IsNil)
 
-	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0)
+	opts := assertstate.ResolveOptions{AllowLocalFallback: true}
+	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0, &opts)
 	c.Assert(err, IsNil)
 	c.Assert(vs, NotNil)
 	c.Assert(local, Equals, true)
@@ -2449,7 +2450,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorPinnedRefreshedFrom
 	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2")
 	c.Assert(s.storeSigning.Add(vsetAs2), check.IsNil)
 
-	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0)
+	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0, nil)
 	c.Assert(err, IsNil)
 	c.Assert(local, Equals, false)
 	c.Check(vs.Revision(), Equals, 2)
@@ -2477,7 +2478,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorUnpinnedRefreshedFr
 	vsetAs2 := s.validationSetAssert(c, "bar", "3", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), check.IsNil)
 
-	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0)
+	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0, nil)
 	c.Assert(err, IsNil)
 	c.Assert(local, Equals, false)
 	c.Check(vs.Revision(), Equals, 1)
@@ -2494,6 +2495,6 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorUnpinnedNotFound(c 
 	storeAs := s.setupModelAndStore(c)
 	c.Assert(s.storeSigning.Add(storeAs), check.IsNil)
 
-	_, _, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0)
+	_, _, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0, nil)
 	c.Assert(err, check.ErrorMatches, fmt.Sprintf(`cannot fetch and resolve assertions:\n - validation-set/16/%s/bar: validation-set assertion not found.*`, s.dev1Acct.AccountID()))
 }

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -34,6 +34,7 @@ import (
 
 	"golang.org/x/crypto/sha3"
 
+	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -67,6 +68,7 @@ type assertMgrSuite struct {
 
 	storeSigning *assertstest.StoreStack
 	dev1Acct     *asserts.Account
+	dev1AcctKey  *asserts.AccountKey
 	dev1Signing  *assertstest.SigningDB
 
 	fakeStore        snapstate.StoreService
@@ -77,9 +79,10 @@ var _ = Suite(&assertMgrSuite{})
 
 type fakeStore struct {
 	storetest.Store
-	state                  *state.State
-	db                     asserts.RODatabase
-	maxDeclSupportedFormat int
+	state                           *state.State
+	db                              asserts.RODatabase
+	maxDeclSupportedFormat          int
+	maxValidationSetSupportedFormat int
 
 	requestedTypes [][]string
 
@@ -111,8 +114,7 @@ func (sto *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.Curren
 		panic("only assertion query supported")
 	}
 
-	// TODO: sequence-forming
-	toResolve, _, err := assertQuery.ToResolve()
+	toResolve, toResolveSeq, err := assertQuery.ToResolve()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -124,8 +126,11 @@ func (sto *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.Curren
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, sto.maxDeclSupportedFormat)
 	defer restore()
 
+	restoreSeq := asserts.MockMaxSupportedFormat(asserts.ValidationSetType, sto.maxValidationSetSupportedFormat)
+	defer restoreSeq()
+
 	reqTypes := make(map[string]bool)
-	ares := make([]store.AssertionResult, 0, len(toResolve))
+	ares := make([]store.AssertionResult, 0, len(toResolve)+len(toResolveSeq))
 	for g, ats := range toResolve {
 		urls := make([]string, 0, len(ats))
 		for _, at := range ats {
@@ -144,6 +149,36 @@ func (sto *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.Curren
 			StreamURLs: urls,
 		})
 	}
+
+	for g, ats := range toResolveSeq {
+		urls := make([]string, 0, len(ats))
+		for _, at := range ats {
+			reqTypes[at.Type.Name] = true
+			var a asserts.Assertion
+			headers, err := asserts.HeadersFromSequenceKey(at.Type, at.SequenceKey)
+			if err != nil {
+				return nil, nil, err
+			}
+			if !at.Pinned {
+				a, err = sto.db.FindSequence(at.Type, headers, -1, asserts.ValidationSetType.MaxSupportedFormat())
+			} else {
+				a, err = at.Resolve(sto.db.Find)
+			}
+			if err != nil {
+				assertQuery.AddSequenceError(err, at)
+				continue
+			}
+			storeVs := a.(*asserts.ValidationSet)
+			if storeVs.Sequence() > at.Sequence || (storeVs.Sequence() == at.Sequence && storeVs.Revision() >= at.Revision) {
+				urls = append(urls, fmt.Sprintf("/assertions/%s/%s", a.Type().Name, strings.Join(a.At().PrimaryKey, "/")))
+			}
+		}
+		ares = append(ares, store.AssertionResult{
+			Grouping:   asserts.Grouping(g),
+			StreamURLs: urls,
+		})
+	}
+
 	// behave like the actual SnapAction if there are no results
 	if len(ares) == 0 {
 		return nil, ares, &store.SnapActionError{
@@ -171,6 +206,9 @@ func (sto *fakeStore) DownloadAssertions(urls []string, b *asserts.Batch, user *
 	resolve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, sto.maxDeclSupportedFormat)
 		defer restore()
+
+		restoreSeq := asserts.MockMaxSupportedFormat(asserts.ValidationSetType, sto.maxValidationSetSupportedFormat)
+		defer restoreSeq()
 		return ref.Resolve(sto.db.Find)
 	}
 
@@ -211,8 +249,8 @@ func (s *assertMgrSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// developer signing
-	dev1AcctKey := assertstest.NewAccountKey(s.storeSigning, s.dev1Acct, nil, dev1PrivKey.PublicKey(), "")
-	err = s.storeSigning.Add(dev1AcctKey)
+	s.dev1AcctKey = assertstest.NewAccountKey(s.storeSigning, s.dev1Acct, nil, dev1PrivKey.PublicKey(), "")
+	err = s.storeSigning.Add(s.dev1AcctKey)
 	c.Assert(err, IsNil)
 
 	s.dev1Signing = assertstest.NewSigningDB(s.dev1Acct.AccountID(), dev1PrivKey)
@@ -230,7 +268,8 @@ func (s *assertMgrSuite) SetUpTest(c *C) {
 	s.fakeStore = &fakeStore{
 		state: s.state,
 		db:    s.storeSigning,
-		maxDeclSupportedFormat: asserts.SnapDeclarationType.MaxSupportedFormat(),
+		maxDeclSupportedFormat:          asserts.SnapDeclarationType.MaxSupportedFormat(),
+		maxValidationSetSupportedFormat: asserts.ValidationSetType.MaxSupportedFormat(),
 	}
 	s.trivialDeviceCtx = &snapstatetest.TrivialDeviceContext{
 		CtxStore: s.fakeStore,
@@ -840,6 +879,29 @@ func (s *assertMgrSuite) TestValidateSnapCrossCheckFail(c *C) {
 	s.state.Lock()
 
 	c.Assert(chg.Err(), ErrorMatches, `(?s).*cannot install "f", snap "f" is undergoing a rename to "foo".*`)
+}
+
+func (s *assertMgrSuite) validationSetAssert(c *C, name, sequence, revision string) *asserts.ValidationSet {
+	snaps := []interface{}{map[string]interface{}{
+		"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
+		"name":     "foo",
+		"presence": "required",
+		"revision": "1",
+	}}
+	headers := map[string]interface{}{
+		"series":       "16",
+		"account-id":   s.dev1Acct.AccountID(),
+		"authority-id": s.dev1Acct.AccountID(),
+		"publisher-id": s.dev1Acct.AccountID(),
+		"name":         name,
+		"sequence":     sequence,
+		"snaps":        snaps,
+		"timestamp":    time.Now().Format(time.RFC3339),
+		"revision":     revision,
+	}
+	a, err := s.dev1Signing.Sign(asserts.ValidationSetType, headers, nil, "")
+	c.Assert(err, IsNil)
+	return a.(*asserts.ValidationSet)
 }
 
 func (s *assertMgrSuite) snapDecl(c *C, name string, extraHeaders map[string]interface{}) *asserts.SnapDeclaration {
@@ -2076,4 +2138,362 @@ func (s *assertMgrSuite) TestStore(c *C) {
 	store, err := assertstate.Store(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(store.Store(), Equals, "foo")
+}
+
+// validation-sets related tests
+
+func (s *assertMgrSuite) TestRefreshValidationSetAssertionsNop(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setModel(sysdb.GenericClassicModel())
+
+	err := assertstate.RefreshValidationSetAssertions(s.state, 0)
+	c.Assert(err, IsNil)
+}
+
+func (s *assertMgrSuite) TestRefreshValidationSetAssertionsStoreError(c *C) {
+	s.fakeStore.(*fakeStore).snapActionErr = &store.UnexpectedHTTPStatusError{StatusCode: 400}
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setModel(sysdb.GenericClassicModel())
+
+	// store key already present
+	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	err := assertstate.RefreshValidationSetAssertions(s.state, 0)
+	c.Assert(err, ErrorMatches, `cannot refresh validation set assertions: cannot : got unexpected HTTP status code 400.*`)
+}
+
+func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err := s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	// store key already present
+	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
+
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2")
+	err = s.storeSigning.Add(vsetAs2)
+	c.Assert(err, IsNil)
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	c.Assert(err, IsNil)
+
+	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "1",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.ValidationSet).Name(), Equals, "bar")
+	c.Check(a.Revision(), Equals, 2)
+
+	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
+		{"account", "account-key", "validation-set"},
+	})
+
+	// sequence changed in the store to 4
+	vsetAs3 := s.validationSetAssert(c, "bar", "4", "3")
+	err = s.storeSigning.Add(vsetAs3)
+	c.Assert(err, IsNil)
+
+	// sanity check - sequence 4 not available locally yet
+	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "4",
+	})
+	c.Assert(asserts.IsNotFound(err), Equals, true)
+
+	s.fakeStore.(*fakeStore).requestedTypes = nil
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	c.Assert(err, IsNil)
+
+	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
+		{"account", "account-key", "validation-set"},
+	})
+
+	// new sequence is available in the db
+	a, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "4",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.ValidationSet).Name(), Equals, "bar")
+}
+
+func (s *assertMgrSuite) TestRefreshValidationSetAssertionsPinned(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err := s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	// store key already present
+	err = assertstate.Add(s.state, s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+
+	vsetAs1 := s.validationSetAssert(c, "bar", "2", "1")
+	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
+
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "5")
+	err = s.storeSigning.Add(vsetAs2)
+	c.Assert(err, IsNil)
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		Current:   2,
+		PinnedAt:  2,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	c.Assert(err, IsNil)
+
+	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "2",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.ValidationSet).Name(), Equals, "bar")
+	c.Check(a.(*asserts.ValidationSet).Sequence(), Equals, 2)
+	c.Check(a.Revision(), Equals, 5)
+
+	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
+		{"account", "account-key", "validation-set"},
+	})
+
+	// sequence changed in the store to 7
+	vsetAs3 := s.validationSetAssert(c, "bar", "7", "8")
+	err = s.storeSigning.Add(vsetAs3)
+	c.Assert(err, IsNil)
+
+	s.fakeStore.(*fakeStore).requestedTypes = nil
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	c.Assert(err, IsNil)
+
+	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
+		{"account", "account-key", "validation-set"},
+	})
+
+	// new sequence is available in the db
+	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "7",
+	})
+	c.Assert(asserts.IsNotFound(err), Equals, true)
+}
+
+func (s *assertMgrSuite) TestRefreshValidationSetAssertionsLocalOnlyFailed(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err := s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	// store key already present
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), check.IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), check.IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), check.IsNil)
+
+	// add to local database
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	c.Assert(assertstate.Add(st, vsetAs1), check.IsNil)
+	vsetAs2 := s.validationSetAssert(c, "baz", "3", "1")
+	c.Assert(assertstate.Add(st, vsetAs2), check.IsNil)
+
+	// vset2 present and updated in the store
+	vsetAs2_2 := s.validationSetAssert(c, "baz", "3", "2")
+	err = s.storeSigning.Add(vsetAs2_2)
+	c.Assert(err, IsNil)
+
+	tr1 := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+		PinnedAt:  1,
+		LocalOnly: true,
+	}
+	tr2 := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "baz",
+		Mode:      assertstate.Monitor,
+		Current:   3,
+		PinnedAt:  3,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr1)
+	assertstate.UpdateValidationSet(s.state, &tr2)
+
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	c.Assert(err, IsNil)
+
+	// sanity - local assertion vsetAs1 is the latest
+	a, err := assertstate.DB(s.state).FindSequence(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "1",
+	}, -1, -1)
+	c.Assert(err, IsNil)
+	vs := a.(*asserts.ValidationSet)
+	c.Check(vs.Name(), Equals, "bar")
+	c.Check(vs.Sequence(), Equals, 1)
+	c.Check(vs.Revision(), Equals, 1)
+
+	// but vsetAs2 was updated with vsetAs2_2
+	a, err = assertstate.DB(s.state).FindSequence(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "baz",
+		"sequence":   "1",
+	}, -1, -1)
+	c.Assert(err, IsNil)
+	vs = a.(*asserts.ValidationSet)
+	c.Check(vs.Name(), Equals, "baz")
+	c.Check(vs.Sequence(), Equals, 3)
+	c.Check(vs.Revision(), Equals, 2)
+}
+
+func (s *assertMgrSuite) TestValidationSetAssertionForMonitorLocalFallbackForPinned(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	c.Assert(s.storeSigning.Add(storeAs), check.IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), check.IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), check.IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), check.IsNil)
+
+	// add to local database
+	vsetAs := s.validationSetAssert(c, "bar", "1", "1")
+	c.Assert(assertstate.Add(st, vsetAs), check.IsNil)
+
+	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0)
+	c.Assert(err, IsNil)
+	c.Assert(vs, NotNil)
+	c.Assert(local, Equals, true)
+}
+
+func (s *assertMgrSuite) TestValidationSetAssertionForMonitorPinnedRefreshedFromStore(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	c.Assert(s.storeSigning.Add(storeAs), check.IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), check.IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), check.IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), check.IsNil)
+
+	// add to local database
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	c.Assert(assertstate.Add(st, vsetAs1), check.IsNil)
+
+	// newer revision available in the store
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2")
+	c.Assert(s.storeSigning.Add(vsetAs2), check.IsNil)
+
+	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0)
+	c.Assert(err, IsNil)
+	c.Assert(local, Equals, false)
+	c.Check(vs.Revision(), Equals, 2)
+	c.Check(vs.Sequence(), Equals, 1)
+}
+
+func (s *assertMgrSuite) TestValidationSetAssertionForMonitorUnpinnedRefreshedFromStore(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	c.Assert(s.storeSigning.Add(storeAs), check.IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), check.IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), check.IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), check.IsNil)
+
+	// add to local database
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	c.Assert(assertstate.Add(st, vsetAs1), check.IsNil)
+
+	// newer assertion available in the store
+	vsetAs2 := s.validationSetAssert(c, "bar", "3", "1")
+	c.Assert(s.storeSigning.Add(vsetAs2), check.IsNil)
+
+	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0)
+	c.Assert(err, IsNil)
+	c.Assert(local, Equals, false)
+	c.Check(vs.Revision(), Equals, 1)
+	c.Check(vs.Sequence(), Equals, 3)
+}
+
+func (s *assertMgrSuite) TestValidationSetAssertionForMonitorUnpinnedNotFound(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	c.Assert(s.storeSigning.Add(storeAs), check.IsNil)
+
+	_, _, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0)
+	c.Assert(err, check.ErrorMatches, fmt.Sprintf(`cannot fetch and resolve assertions:\n - validation-set/16/%s/bar: validation-set assertion not found.*`, s.dev1Acct.AccountID()))
 }

--- a/overlord/assertstate/bulk.go
+++ b/overlord/assertstate/bulk.go
@@ -139,6 +139,67 @@ func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstat
 	return nil
 }
 
+func bulkRefreshValidationSetAsserts(s *state.State, vsets map[string]*ValidationSetTracking, userID int, deviceCtx snapstate.DeviceContext) error {
+	db := cachedDB(s)
+	pool := asserts.NewPool(db, maxGroups)
+
+	ignoreNotFound := make(map[string]bool)
+
+	for _, vs := range vsets {
+		var atSeq *asserts.AtSequence
+		if vs.PinnedAt > 0 {
+			// pinned to specific sequence, update to latest revision for same
+			// sequence.
+			atSeq = &asserts.AtSequence{
+				Type:        asserts.ValidationSetType,
+				SequenceKey: []string{release.Series, vs.AccountID, vs.Name},
+				Sequence:    vs.PinnedAt,
+				Pinned:      true,
+			}
+		} else {
+			// not pinned, update to latest sequence
+			atSeq = &asserts.AtSequence{
+				Type:        asserts.ValidationSetType,
+				SequenceKey: []string{release.Series, vs.AccountID, vs.Name},
+				Sequence:    vs.Current,
+			}
+		}
+		// every sequence to resolve has own group
+		group := atSeq.Unique()
+		if vs.LocalOnly {
+			ignoreNotFound[group] = true
+		}
+		if err := pool.AddSequenceToUpdate(atSeq, group); err != nil {
+			return err
+		}
+	}
+
+	err := resolvePool(s, pool, userID, deviceCtx)
+	if err == nil {
+		return nil
+	}
+
+	if rerr, ok := err.(*resolvePoolError); ok {
+		// ignore resolving errors for validation sets that are local only (no
+		// assertion in the store).
+		for group := range ignoreNotFound {
+			if e := rerr.errors[group]; asserts.IsNotFound(e) || e == asserts.ErrUnresolved {
+				delete(rerr.errors, group)
+			}
+		}
+		if len(rerr.errors) == 0 {
+			return nil
+		}
+	}
+
+	// no fallback for validation-sets, report inner error.
+	if ferr, ok := err.(*bulkAssertionFallbackError); ok {
+		err = ferr.err
+	}
+
+	return fmt.Errorf("cannot refresh validation set assertions: %v", err)
+}
+
 // marker error to request falling back to the old implemention for assertion
 // refreshes
 type bulkAssertionFallbackError struct {

--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -46,6 +46,12 @@ type ValidationSetTracking struct {
 
 	// Current is the current sequence point.
 	Current int `json:"current,omitempty"`
+
+	// LocalOnly indicates that the assertion was only available locally at the
+	// time it was applied for monitor mode. This tells bulk refresh logic not
+	// to error out on such assertion if it's not in the store.
+	// This flag makes sense only in monitor mode and if pinned.
+	LocalOnly bool `json:"local-only,omitempty"`
 }
 
 // ValidationSetKey formats the given account id and name into a validation set key.

--- a/tests/main/snap-validate-basic/task.yaml
+++ b/tests/main/snap-validate-basic/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure `snap validate` commands work.
 
-# XXX: this functionality doesn't rely on store yet and as such this test
-# doesn't do much. Extend once all the functionality is available.
+# XXX: enable and enhance once monitor mode for validation sets is fully implemented
+manual: true
 
 systems:
   # go-flags panics when showing --help for a hidden command on Fedora 32/33


### PR DESCRIPTION
Handle `snap validate --monitor ...`. This isn't full monitor mode implementation yet, e.g. refreshing of assertions via pool is missing and will be done separately.

Disable snap-validate-basic spread test for now as it was only usable with early (dummy) implementation, it will need to be fleshed out and enabled once all the branches land and the feature is usable.