### PR TITLE
o/snapstate/check_snap.go: add support for many subversions in assumes snapdX..

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -196,14 +196,16 @@ func checkAssumes(si *snap.Info) error {
 	return nil
 }
 
-var versionExp = regexp.MustCompile(`^([1-9][0-9]*)(?:\.([0-9]+)(?:\.([0-9]+))?)?`)
+var versionExp = regexp.MustCompile(`^(?:[1-9][0-9]*)(?:\.(?:[0-9]+))*`)
 
 func checkVersion(version string) bool {
 	// double check that the input looks like a snapd version
-	req := versionExp.FindStringSubmatch(version)
-	if req == nil || req[0] != version {
+	reqVersionNumMatch := versionExp.FindStringSubmatch(version)
+	if reqVersionNumMatch == nil || reqVersionNumMatch[0] != version {
 		return false
 	}
+
+	req := strings.Split(reqVersionNumMatch[0], ".")
 
 	if snapdtool.Version == "unknown" {
 		return true // Development tree.
@@ -213,16 +215,19 @@ func checkVersion(version string) bool {
 	// this code (see PR#7344). However this would change current
 	// behavior, i.e. "2.41~pre1" would *not* match [snapd2.41] anymore
 	// (which the code below does).
-	cur := versionExp.FindStringSubmatch(snapdtool.Version)
-	if cur == nil {
+	curVersionNumMatch := versionExp.FindStringSubmatch(snapdtool.Version)
+	if curVersionNumMatch == nil {
 		return false
 	}
+	cur := strings.Split(curVersionNumMatch[0], ".")
 
 	for i := 1; i < len(req); i++ {
-		if req[i] == "" {
-			return true
-		}
-		if cur[i] == "" {
+		if i == len(cur) {
+			// we hit the end of the elements of the current version number and have
+			// more required version numbers left, so this doesn't match, if the
+			// previous element was higher we would have broken out already, so the
+			// only case left here is where we have version requirements that are
+			// not met
 			return false
 		}
 		reqN, err1 := strconv.Atoi(req[i])

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -119,6 +119,10 @@ var assumesTests = []struct {
 	version: "unknown",
 	error:   `.* unsupported features: snapd2.15nono .*`,
 }, {
+	assumes: "[snapd2.15~pre1]",
+	version: "unknown",
+	error:   `.* unsupported features: snapd2.15~pre1 .*`,
+}, {
 	assumes: "[snapd2.15]",
 	version: "2.15",
 }, {
@@ -156,8 +160,18 @@ var assumesTests = []struct {
 	assumes: "[snapd2.15.2]",
 	version: "2.16.1",
 }, {
+	assumes: "[snapd2.1000]",
+	version: "3.1",
+}, {
 	assumes: "[snapd3]",
 	version: "3.1",
+}, {
+	assumes: "[snapd2]",
+	version: "3.1",
+}, {
+	assumes: "[snapd3]",
+	version: "2.48",
+	error:   `.* unsupported features: snapd3 .*`,
 }, {
 	assumes: "[snapd2.15.1.2]",
 	version: "2.15.1.1",


### PR DESCRIPTION
This came up recently when we ended up doing a sub version release of snapd
2.48.2.1, and we wanted snaps to depend on this, but we couldn't make them do it
because the parsing regex gode gave up after 2.48.2. So make it fully support
any number of subversions in the hope that we never have to use this.

If folks think this will never become a problem, I call to the stand runC's release 
page: https://github.com/opencontainers/runc/releases . I hope and pray we never
get there, but who knows, it is better to have more support and never use it than 
need the support and not have it.