### PR TITLE
interfaces/docker-support: add autobind unix rules to docker-support

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -202,6 +202,15 @@ ptrace (read, trace) peer=cri-containerd.apparmor.d,
 # snap), but in deployments where the control plane is not a snap, it will tell
 # containerd to use this path for various account information for pods.
 /run/secrets/kubernetes.io/{,**} rk,
+
+# Allow using the 'autobind' feature of bind() (eg, for journald via go-systemd)
+# unix (bind) type=dgram addr=auto,
+# TODO: when snapd vendors in AppArmor userspace, then enable the new syntax
+# above which allows only "empty"/automatic addresses, for now we simply permit
+# all addresses with SOCK_DGRAM type, which leaks info for other addresses than
+# what docker tries to use
+# see https://bugs.launchpad.net/snapd/+bug/1867216
+unix (bind) type=dgram,
 `
 
 const dockerSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -215,12 +215,13 @@ const kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun = `
 // go.etcd.io/etcd/clientv3. See:
 // https://github.com/coreos/go-systemd/blob/master/journal/journal.go#L211
 const kubernetesSupportConnectedPlugAppArmorAutobindUnix = `
-# Allow using the 'autobind' feature of bind() (eg, for journald).
-#unix (bind) type=dgram addr=none,
-# Due to LP: 1867216, we cannot use the above rule and must instead use this
-# less specific rule that allows bind() to arbitrary SOCK_DGRAM abstract socket
-# names (separate send and receive rules are still required for communicating
-# over the socket).
+# Allow using the 'autobind' feature of bind() (eg, for journald via go-systemd)
+# unix (bind) type=dgram addr=auto,
+# TODO: when snapd vendors in AppArmor userspace, then enable the new syntax
+# above which allows only "empty"/automatic addresses, for now we simply permit
+# all addresses with SOCK_DGRAM type, which leaks info for other addresses than
+# what docker tries to use
+# see https://bugs.launchpad.net/snapd/+bug/1867216
 unix (bind) type=dgram,
 `
 

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -169,7 +169,7 @@ func (s *KubernetesSupportInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Allow running as the kubeproxy service\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Common rules for kubernetes use of systemd_run\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# kubelet mount rules\n")
-	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Allow using the 'autobind' feature of bind() (eg, for journald).\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Allow using the 'autobind' feature of bind() (eg, for journald via go-systemd)\n")
 	c.Check(spec.UsesPtraceTrace(), Equals, true)
 
 	// kubeproxy should have its rules and autobind rules
@@ -182,7 +182,7 @@ func (s *KubernetesSupportInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), Not(testutil.Contains), "# Allow running as the kubelet service\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), testutil.Contains, "# Common rules for kubernetes use of systemd_run\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), Not(testutil.Contains), "# kubelet mount rules\n")
-	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), testutil.Contains, "# Allow using the 'autobind' feature of bind() (eg, for journald).\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), testutil.Contains, "# Allow using the 'autobind' feature of bind() (eg, for journald via go-systemd)\n")
 	c.Check(spec.UsesPtraceTrace(), Equals, false)
 
 	// kubelet should have its rules and autobind rules
@@ -195,7 +195,7 @@ func (s *KubernetesSupportInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), Not(testutil.Contains), "# Allow running as the kubeproxy service\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), testutil.Contains, "# Common rules for kubernetes use of systemd_run\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), testutil.Contains, "# kubelet mount rules\n")
-	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), testutil.Contains, "# Allow using the 'autobind' feature of bind() (eg, for journald).\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), testutil.Contains, "# Allow using the 'autobind' feature of bind() (eg, for journald via go-systemd)\n")
 	c.Check(spec.UsesPtraceTrace(), Equals, true)
 
 	// kube-autobind-unix should have only its autobind rules
@@ -208,7 +208,7 @@ func (s *KubernetesSupportInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kube-autobind-unix"), Not(testutil.Contains), "# Allow running as the kubeproxy service\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kube-autobind-unix"), Not(testutil.Contains), "# Common rules for kubernetes use of systemd_run\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kube-autobind-unix"), Not(testutil.Contains), "# kubelet mount rules\n")
-	c.Check(spec.SnippetForTag("snap.kubernetes-support.kube-autobind-unix"), testutil.Contains, "# Allow using the 'autobind' feature of bind() (eg, for journald).\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kube-autobind-unix"), testutil.Contains, "# Allow using the 'autobind' feature of bind() (eg, for journald via go-systemd)\n")
 	c.Check(spec.UsesPtraceTrace(), Equals, false)
 }
 


### PR DESCRIPTION
This will enable new versions of docker to use the new version of go-systemd
which communicates with journald via an automatic/empty address specification on
a SOCK_DGRAM socket.

This access already exists in the kubernetes-support interface as the
autobind-unix flavor, so update that comment to reflect that we should only use
the new syntax when AppArmor userspace is vendored into snapd.

See also https://github.com/coreos/go-systemd/issues/331