### PR TITLE
interfaces/seccomp: allow copy_file_range by default

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -108,6 +108,9 @@ close
 # needed by ls -l
 connect
 
+# efficient file copying, used by libuv/nodejs and others
+copy_file_range
+
 chroot
 
 creat


### PR DESCRIPTION
Add copy_file_range(2) to the base template. This syscall is used for copying
files in an efficient manner. From what we have observed in the wild, it is used
by libuv/nodejs tandem in fs.copyfile().

See the corresponding forum topic for more details:
https://forum.snapcraft.io/t/snap-no-longer-has-write-permission/22686