### PR TITLE
asserts: repeat the authority cross-check in CheckSignature as well

### DIFF
--- a/asserts/database.go
+++ b/asserts/database.go
@@ -682,6 +682,9 @@ func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, c
 	var pubKey PublicKey
 	if signingKey != nil {
 		pubKey = signingKey.publicKey()
+		if assert.AuthorityID() != signingKey.AccountID() {
+			return fmt.Errorf("assertion authority %q does not match public key from %q", assert.AuthorityID(), signingKey.AccountID())
+		}
 	} else {
 		custom, ok := assert.(customSigner)
 		if !ok {


### PR DESCRIPTION
findAccountKey was alread checking this but
this is an additional defense and makes CheckSignature a more
robust standalone helper if used that way