### PR TITLE
packaging: disable Go modules in snapd.mk

### DIFF
--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -52,6 +52,10 @@ endif
 # The list of go binaries we are expected to build.
 go_binaries = snap snapctl snap-seccomp snap-update-ns snap-exec snapd
 
+# The snapd package does not support Go modules. Since Go 1.16 those are on by
+# default, so make sure to disable them.
+export GO111MODULE = off
+
 # NOTE: This *depends* on building out of tree. Some of the built binaries
 # conflict with directory names in the tree.
 .PHONY: all


### PR DESCRIPTION
The snapd.mk is a packaging helper that is currently used by openSUSE only. Once
Go 1.16, which defaults to expecting modules, lands and becomes default in
Tumbleweed, snapd builds will fail. Make sure to disable the modules
functionality before that happens.