### PR TITLE
data/selinux: allow system dbus to watch /var/lib/snapd/dbus-1

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -844,3 +844,10 @@ gen_require(`
 # system dbus may look info /var/lib/snapd/dbus-1
 snappy_search_lib(system_dbusd_t)
 snappy_read_lib(system_dbusd_t)
+optional_policy(`
+  gen_require(`
+    # watch permission is defined only in recent versions of refpolicy
+    class dir { watch };
+  ')
+  allow system_dbusd_t  snappy_var_lib_t:dir watch;
+')


### PR DESCRIPTION
The SELinux reference policy has a new set of access vectors for watch*. The
support in core policy landed in
https://github.com/fedora-selinux/selinux-policy/pull/546 on 07.02.2021.

Snapd sets up /var/lib/snapd/dbus-1/services to be watched by the system dbus.
However, dbus trying to watch those directories triggers new watch permissions
to be checked. The snappy.te policy does not allow this access, thus on Rawhide
dbus fails like this:

```
systemd[1]: Starting D-Bus System Message Bus...
dbus-broker-launch[7728]: ERROR dirwatch_add @ ../src/util/dirwatch.c +122: Permission denied
dbus-broker-launch[7728]:       launcher_load_service_dir @ ../src/launch/launcher.c +763
dbus-broker-launch[7728]:       launcher_load_services @ ../src/launch/launcher.c +978
dbus-broker-launch[7728]:       launcher_run @ ../src/launch/launcher.c +1306
dbus-broker-launch[7728]:       run @ ../src/launch/main.c +152
dbus-broker-launch[7728]:       main @ ../src/launch/main.c +178
dbus-broker-launch[7728]: Exiting due to fatal error: -13
systemd[1]: dbus-broker.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: dbus-broker.service: Failed with result 'exit-code'.
```

Triggering the following denial:

```
type=AVC msg=audit(1613393808.456:478): avc:  denied  { watch } for
         pid=7728 comm="dbus-broker-lau"
         path="/var/lib/snapd/dbus-1/system-services" ...
         scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023
         tcontext=system_u:object_r:snappy_var_lib_t:s0
         tclass=dir permissive=0
```

Fixes: https://bugs.launchpad.net/snappy/+bug/1915642

cc @Conan-Kudo I'll cherry pick this as a distro patch to Fedora