### PR TITLE
interfaces: remove apparmor downgrade feature

### DIFF
--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -30,7 +30,6 @@ var (
 	NsProfile                       = nsProfile
 	ProfileGlobs                    = profileGlobs
 	SnapConfineFromSnapProfile      = snapConfineFromSnapProfile
-	DowngradeConfinement            = downgradeConfinement
 	LoadProfiles                    = loadProfiles
 	UnloadProfiles                  = unloadProfiles
 	MaybeSetNumberOfJobs            = maybeSetNumberOfJobs


### PR DESCRIPTION
Apparmor downgrade was automatically enabled when the running kernel
supported some, but not all of the features. Since the complete set was
never upstreamed, this effectively meant that users had less features
than they otherwise would have.

Since apparmor is still reported as "partial", nothing changes from the
point of view of not sending any misleading messages. For certain
classes of snap packages, this improves the effective confinement on
systems such as Debian or openSUSE Leap.

Perfect confinement is still way off, this doesn't change that.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
