### PR TITLE
tests/lib/prepare.sh: split reflash.sh into two parts

### DIFF
--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -38,7 +38,7 @@ type flags struct {
 	// coreOnlyConfig tells Run/FilesystemOnlyApply to apply the config on core
 	// systems only.
 	coreOnlyConfig bool
-	// validatedOnylStateConfig tells that the config requires only validation,
+	// validatedOnlyStateConfig tells that the config requires only validation,
 	// its options are applied dynamically elsewhere.
 	validatedOnlyStateConfig bool
 	// earlyConfigFilter expresses whether the handler supports


### PR DESCRIPTION
Splitting the script into two parts allows us to execute the second part where
we totally obliterate the hard disk without having any dangling reference to
/dev/{s,v}da from /bin/sh, because we use busybox in /tmp. Sometimes we see
problems locally with this reflash.sh script segfaulting because probably some
part of it's memory is mapped to a file or something that got deleted.

Using busybox, a static executable, entirely located in RAM via tmpfs avoids
this.
