### PR TITLE
overlord: save fails with sockets in folder

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -396,6 +396,7 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 		"--create",
 		"--sparse", "--gzip",
 		"--format", "gnu",
+		"--warning", "no-file-ignored",
 		"--directory", parent,
 	}
 


### PR DESCRIPTION
When making snapshots, the snap will fail when socket files are in the directory:
```
error: cannot perform the following tasks:
- Save data of snap "rexroth-automationcore" in snapshot set #7 (cannot create archive: tar: 169/.datalayer/backend/2070: socket ignored (and 3 more))
- Save data of snap "rexroth-deviceadmin" in snapshot set #7 (cannot create archive: tar: x1/auth-service/token-validation.sock: socket ignored (and 2 more))
```

This PR will ignore such warnings and will not fail the tar run:

From https://www.gnu.org/software/tar/manual/html_section/tar_27.html
```
file-ignored
`%s: Unknown file type; file ignored'
`%s: socket ignored'
`%s: door ignored'
```

Fixes: https://bugs.launchpad.net/bugs/1915781