### PR TITLE
github: temporarily disable action labeler due to issues with labels being removed

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,4 @@
-# Add 'Run nested' label to either any change on nested lib or nested test 
-Run nested: 
-- any: ['tests/lib/nested.sh', 'tests/nested/**/*']
+# 18.02.2021: temporarily disabled as labeler keeps removing the labels
+# Add 'Run nested' label to either any change on nested lib or nested test
+#Run nested:
+#- any: ['tests/lib/nested.sh', 'tests/nested/**/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,8 @@
 # 18.02.2021: temporarily disabled as labeler keeps removing the labels
+# possible related issues:
+# - https://github.com/actions/labeler/issues/112
+# - https://github.com/actions/labeler/issues/104
+
 # Add 'Run nested' label to either any change on nested lib or nested test
 #Run nested:
 #- any: ['tests/lib/nested.sh', 'tests/nested/**/*']


### PR DESCRIPTION
Auto labeler seems to be removing the labels unexpectedly, see:

- https://github.com/snapcore/snapd/pull/9940#event-4345279407 label was added
  manually when opening a PR and later removed by bot

- https://github.com/snapcore/snapd/pull/9943#event-4346822699 modified files
  match the label, but labeler removed 'Run nested' label


