### PR TITLE
tests: find files before using cat command when checking broadcom-asic-control interface

### DIFF
--- a/tests/main/interfaces-broadcom-asic-control/task.yaml
+++ b/tests/main/interfaces-broadcom-asic-control/task.yaml
@@ -45,11 +45,11 @@ execute: |
 
     echo "Then the snap is able to read pci devices info"
     if [ -d "/sys/devices/pci0000:00/" ]; then
-        config="$(find /sys/devices/pci0000:00/ -name config | head -n1)"
-        vendor="$(find /sys/devices/pci0000:00/ -name vendor | head -n1)"
-        device="$(find /sys/devices/pci0000:00/ -name device | head -n1)"
-        subsystem_vendor="$(find /sys/devices/pci0000:00/ -name subsystem_vendor | head -n1)"
-        subsystem_device="$(find /sys/devices/pci0000:00/ -name subsystem_device | head -n1)"
+        config="$(find /sys/devices/pci0000:00/ -name config -type f | head -n1)"
+        vendor="$(find /sys/devices/pci0000:00/ -name vendor -type f | head -n1)"
+        device="$(find /sys/devices/pci0000:00/ -name device -type f | head -n1)"
+        subsystem_vendor="$(find /sys/devices/pci0000:00/ -name subsystem_vendor -type f | head -n1)"
+        subsystem_device="$(find /sys/devices/pci0000:00/ -name subsystem_device -type f | head -n1)"
 
         for file in "$config" "$vendor" "$device" "$subsystem_vendor" "$subsystem_device"; do
             if [ -n "$file" ]; then


### PR DESCRIPTION
This is because using external backend the test is failing like this:
+ for file in "$config" "$vendor" "$device" "$subsystem_vendor"
"$subsystem_device"
+ '[' -n
/sys/devices/pci0000:00/0000:00:1f.2/ata1/link1/ata_link/link1/device
']'
+ test-snapd-sh.with-broadcom-asic-control-plug -c 'cat
/sys/devices/pci0000:00/0000:00:1f.2/ata1/link1/ata_link/link1/device'
cat:
'/sys/devices/pci0000:00/0000:00:1f.2/ata1/link1/ata_link/link1/device':
Is a directory
