### PR TITLE
tests: use new path to find kernel.img in uc20 for arm devices

### DIFF
--- a/tests/core/uboot-unpacked-assets/task.yaml
+++ b/tests/core/uboot-unpacked-assets/task.yaml
@@ -3,13 +3,13 @@ summary: Ensure we have unpacked kernel.img/initrd.img on uboot systems
 systems: [ubuntu-core-*-arm-*]
 
 environment:
-    NAME/initrdimg: initrd.img*
-    NAME/kernelimg: kernel.img*
+    NAME/initrdimg: initrd.img
+    NAME/kernelimg: kernel.img
 
 execute: |
     if os.query is-core20; then
         # on UC20, the kernel snap is extracted onto ubuntu-seed, not on ubuntu-boot
-        output=$(find /run/mnt/ubuntu-seed/systems/*/kernel/*-kernel_*.snap/ -name "$NAME" )
+        output=$(find /run/mnt/ubuntu-seed/systems/*/kernel/ -name "$NAME" )
         if [ -z "$output" ]; then
             echo "Not found expected file $NAME in /run/mnt/ubuntu-seed/systems/*/kernel/*-kernel_*.snap/"
             exit 1


### PR DESCRIPTION
The idea is to get the kernel.img from
/run/mnt/ubuntu-seed/systems/*/kernel/

This is to fix the following error when using external backend

2021-02-17 05:16:45 Error executing
external:ubuntu-core-20-arm-32:tests/core/uboot-unpacked-assets:kernelimg
(external:ubuntu-core-20-arm-32) :

 os.query is-core20
 find '/run/mnt/ubuntu-seed/systems/*/kernel/*-kernel_*.snap/' -name
'kernel.img*'
find: ‘/run/mnt/ubuntu-seed/systems/*/kernel/*-kernel_*.snap/’: No such
file or directory
 output=
