### PR TITLE
tests: fix for preseed and dbus tests on 21.04

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -590,6 +590,11 @@ pkg_dependencies_ubuntu_classic(){
                 qemu-utils
                 "
             ;;
+        ubuntu-21.04-64)
+            echo "
+                qemu-utils
+                "
+            ;;
         ubuntu-*)
             echo "
                 squashfs-tools

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -592,6 +592,7 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-21.04-64)
             echo "
+                dbus-user-session
                 qemu-utils
                 "
             ;;

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -13,7 +13,7 @@ prepare: |
   # a cloud image url matching current $SPREAD_SYSTEM.
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
-  wget "$(nested_get_image_url_for_vm)" -O cloudimg.img
+  wget --quiet "$(nested_get_image_url_for_vm)" -O cloudimg.img
   mkdir -p "$IMAGE_MOUNTPOINT"
 
   #shellcheck source=tests/lib/preseed.sh

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -19,11 +19,6 @@ prepare: |
   #shellcheck source=tests/lib/preseed.sh
   . "$TESTSLIB/preseed.sh"
 
-  # qemu-utils is not installed by default on google images which are not
-  # updated by snapd like the current 21.04 image.
-  if ! dpkg -l qemu-utils; then
-      apt install -y qemu-utils
-  fi
   mount_ubuntu_image "$(pwd)/cloudimg.img" "$IMAGE_MOUNTPOINT"
 
   # for images that are already preseeded, we need to undo the preseeding there

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -18,6 +18,12 @@ prepare: |
 
   #shellcheck source=tests/lib/preseed.sh
   . "$TESTSLIB/preseed.sh"
+
+  # qemu-utils is not installed by default on google images which are not
+  # updated by snapd like the current 21.04 image.
+  if ! dpkg -l qemu-utils; then
+      apt install -y qemu-utils
+  fi
   mount_ubuntu_image "$(pwd)/cloudimg.img" "$IMAGE_MOUNTPOINT"
 
   # for images that are already preseeded, we need to undo the preseeding there

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -19,12 +19,6 @@ prepare: |
   #shellcheck source=tests/lib/preseed.sh
   . "$TESTSLIB/preseed.sh"
 
-  # qemu-utils is not installed by default on google images which are not
-  # updated by snapd like the current 21.04 image.
-  if ! dpkg -l qemu-utils; then
-      apt install -y qemu-utils
-  fi
-
   wget --quiet "$(nested_get_image_url_for_vm)" -O cloudimg.img
   mkdir -p "$IMAGE_MOUNTPOINT"
 

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -19,7 +19,13 @@ prepare: |
   #shellcheck source=tests/lib/preseed.sh
   . "$TESTSLIB/preseed.sh"
 
-  wget "$(nested_get_image_url_for_vm)" -O cloudimg.img
+  # qemu-utils is not installed by default on google images which are not
+  # updated by snapd like the current 21.04 image.
+  if ! dpkg -l qemu-utils; then
+      apt install -y qemu-utils
+  fi
+
+  wget --quiet "$(nested_get_image_url_for_vm)" -O cloudimg.img
   mkdir -p "$IMAGE_MOUNTPOINT"
 
   #shellcheck source=tests/lib/preseed.sh


### PR DESCRIPTION
This is a simple fix for preseed and dbus tests on 21.04
