### PR TITLE
tests/regression/lp-1910456: cleanup the /snap symlink when done 

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # shellcheck source=tests/lib/dirs.sh
 . "$TESTSLIB/dirs.sh"

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -22,7 +22,7 @@ prepare: |
             classic-container-mgr-snap/meta/snap.yaml
         echo "confinement: classic" >> classic-container-mgr-snap/meta/snap.yaml
 
-        if os.query is-arch || os.query is-fedora || os.query is-centos; then
+        if os.query is-arch-linux || os.query is-fedora || os.query is-centos; then
             # need to enable /snap symlink to install classic snaps
             ln -s /var/lib/snapd/snap /snap
             # remove it when we are done

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -5,6 +5,8 @@ details: |
     Delegate=true snippet added to prevent CVE-2020-27352.
 
 prepare: |
+    tests.cleanup prepare
+
     # build and install the strict test snap
     snap pack container-mgr-snap
     snap install --dangerous test-snapd-container-mgrs*.snap
@@ -20,16 +22,19 @@ prepare: |
             classic-container-mgr-snap/meta/snap.yaml
         echo "confinement: classic" >> classic-container-mgr-snap/meta/snap.yaml
 
-        # TODO: use os.query is-arch on master; "is-arch" etc. sub-commands are
-        # unavailable on 2.48 branch
-        if [ "$SPREAD_SYSTEM" = "arch-linux-64" ] || [[ "$SPREAD_SYSTEM" == fedora-* ]] || [[ "$SPREAD_SYSTEM" == centos-* ]]; then
+        if os.query is-arch || os.query is-fedora || os.query is-centos; then
             # need to enable /snap symlink to install classic snaps
             ln -s /var/lib/snapd/snap /snap
+            # remove it when we are done
+            tests.cleanup defer rm -rf /snap
         fi
 
         snap pack classic-container-mgr-snap
         snap install --dangerous --classic test-snapd-classic-container-mgrs*.snap
     fi
+
+restore: |
+    tests.cleanup restore
 
 execute: |
     for confinement in classic strict; do
@@ -111,17 +116,19 @@ execute: |
     # only run this test on ubuntu since the docker snap is not guaranteed to 
     # work on non-ubuntu systems
 
-    if ! [[ "$SPREAD_SYSTEM" == ubuntu-* ]]; then
+    if os.query is-ubuntu; then
         echo "skipping docker test on non-ubuntu"
         exit 0
     fi
 
     snap install docker
+    tests.cleanup defer snap remove docker
 
     echo "Test that docker container cgroups on ubuntu are not moved when systemctl daemon-reload is executed"
 
     # start a docker container - need to wait until dockerd comes alive
     retry -n10 --wait 1 sh -c 'docker run -d --name test ubuntu:18.04 sleep infinity'
+    tests.cleanup defer docker kill test
 
     # make sure that docker top can see the process
     docker top test | MATCH "sleep infinity"

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -116,7 +116,7 @@ execute: |
     # only run this test on ubuntu since the docker snap is not guaranteed to 
     # work on non-ubuntu systems
 
-    if os.query is-ubuntu; then
+    if ! os.query is-ubuntu; then
         echo "skipping docker test on non-ubuntu"
         exit 0
     fi


### PR DESCRIPTION
This ensures that future tests that are run on the same system such as
tests/main/classic-confinement-not-supported do not fail since they expect the
/snap symlink to be absent by default.

Also cleanup some other things and address TODOs from when the test was written
for 2.48 since we have better os.query support on master now.

See for example https://pastebin.ubuntu.com/p/T3vT49KpFB/ where this failed.

Also make a script more verbose to aid future debugging like in https://pastebin.ubuntu.com/p/sMSy9FFRgy/ (although this specific failure is a bit of an orthogonal question if we should be saving /var/lib/snapd/save between test runs in UC20 spread, but the difficulty debugging remained).