### PR TITLE
interfaces: allow reading the Xauthority file KDE Plasma writes for Wayland sessions

### DIFF
--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -134,6 +134,9 @@ owner /run/user/[0-9]*/.Xauthority r,
 owner /run/user/[0-9]*/.mutter-Xwaylandauth.* r,
 owner /run/user/[0-9]*/mutter/Xauthority r,
 
+# Allow reading KDE Plasma's Xwayland Xauth file
+owner /run/user/[0-9]*/xauth_* r,
+
 
 # Needed by QtSystems on X to detect mouse and keyboard. Note, the 'netlink
 # raw' rule is not finely mediated by apparmor so we mediate with seccomp arg


### PR DESCRIPTION
This is PR is based on discussions in this forum thread:

https://forum.snapcraft.io/t/firefox-wouldnt-run-on-plasma-wayland/22779/5?u=jamesh

Similar to the way GNOME's Wayland session works, KDE Plasma writes out an Xauthority file for its Xwayland instance using a randomly named file, and then points clients at it via the `XAUTHORITY` environment variable.  It uses files named like `$XDG_RUNTIME_DIR/xauth_*`:

https://github.com/KDE/kwin/blob/553b6d39c69fccbb6854bb4a35a6bba889ad342d/src/xwl/xwayland.cpp#L102-L104

This PR adjusts the `x11` interface's AppArmor rules to allow reading files matching this pattern, similar to what we do for GNOME.