### PR TITLE
overlord/snapshotstate: include the last message printed by tar in the error

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -453,7 +453,7 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 	if err := osutil.RunWithContext(ctx, cmd); err != nil {
 		matches, count := matchCounter.Matches()
 		if count > 0 {
-			return fmt.Errorf("cannot create archive: %s (and %d more)", matches[0], count-1)
+			return fmt.Errorf("cannot create archive: %s (and %d earlier)", matches[len(matches)-1], count-1)
 		}
 		return fmt.Errorf("tar failed: %v", err)
 	}

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -730,7 +730,7 @@ exec /bin/tar "$@"
 	// task 1 (for "too-snap") will have errored
 	c.Check(tasks[1].Summary(), testutil.Contains, `"too-snap"`) // sanity check: task 1 is too-snap's
 	c.Check(tasks[1].Status(), check.Equals, state.ErrorStatus)
-	c.Check(strings.Join(tasks[1].Log(), "\n"), check.Matches, `\S+ ERROR cannot create archive: .* Permission denied .and \d+ more.`)
+	c.Check(strings.Join(tasks[1].Log(), "\n"), check.Matches, `\S+ ERROR cannot create archive: /bin/tar: common/common-too-snap: .* Permission denied \(and 1 earlier\)`)
 
 	// task 2 (for "tri-snap") will have errored as well, hopefully, but it's a race (see the "tar" comment above)
 	c.Check(tasks[2].Summary(), testutil.Contains, `"tri-snap"`) // sanity check: task 2 is tri-snap's


### PR DESCRIPTION
When tar fails with a fatal error, include the last message it prints, as it
will likely contain the actual error.

Related to https://bugs.launchpad.net/stuttgart/+bug/1915781, where the root
cause of the problem was caused by the directory getting modified while tar was
processing it.

Supersedes #9941