### PR TITLE
snap: fix unit tests on Go 1.16

### DIFF
--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1627,8 +1627,8 @@ apps:
        socket-mode: asdfasdf
 `)
 	_, err := snap.InfoFromSnapYaml(y)
-	c.Check(err.Error(), Equals, "cannot parse snap.yaml: yaml: unmarshal errors:\n"+
-		"  line 9: cannot unmarshal !!str `asdfasdf` into os.FileMode")
+	c.Check(err.Error(), Matches, "cannot parse snap.yaml: yaml: unmarshal errors:\n"+
+		"  line 9: cannot unmarshal !!str `asdfasdf` into (os|fs).FileMode")
 }
 
 func (s *YamlSuite) TestDaemonInvalidDaemonScope(c *C) {


### PR DESCRIPTION
Go 1.16 has moved some bits from the os to the fs package, os.FileMode was among
those. The test used a hardcoded type name which no longer matches the returned
error message.


