### PR TITLE
.github/workflows/labeler.yaml: try work-around to not sync labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,5 +4,5 @@
 # - https://github.com/actions/labeler/issues/104
 
 # Add 'Run nested' label to either any change on nested lib or nested test
-#Run nested:
-#- any: ['tests/lib/nested.sh', 'tests/nested/**/*']
+Run nested:
+  - any: ["tests/lib/nested.sh", "tests/nested/**/*"]

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,3 +9,4 @@ jobs:
       - uses: actions/labeler@main
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: ""

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,11 +1,11 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  - pull_request_target
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@main
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This was suggested in the upstream bug at https://github.com/actions/labeler/issues/104

Also apply the YAML linter that my editor applies to every YAML file :-)