### PR TITLE
ovelord/snapshotstate: keep a few of the last line tar prints before failing

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -444,7 +444,13 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 
 	cmd := tarAsUser(username, tarArgs...)
 	cmd.Stdout = io.MultiWriter(archiveWriter, hasher, &sz)
-	matchCounter := &strutil.MatchCounter{N: 1}
+	matchCounter := &strutil.MatchCounter{
+		// keep at most 6 matches
+		N: 6,
+		// keep the last lines only, those likely contain the reason for
+		// fatal errors
+		LastN: true,
+	}
 	cmd.Stderr = matchCounter
 	if isTesting {
 		matchCounter.N = -1
@@ -453,7 +459,13 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 	if err := osutil.RunWithContext(ctx, cmd); err != nil {
 		matches, count := matchCounter.Matches()
 		if count > 0 {
-			return fmt.Errorf("cannot create archive: %s (and %d earlier)", matches[len(matches)-1], count-1)
+			note := ""
+			if len(matches) > 5 {
+				matches = matches[len(matches)-5:]
+				note = fmt.Sprintf(" (showing last %d lines out of %d)", 5, count)
+			}
+			errStr := strings.Join(matches, "\n")
+			return fmt.Errorf("cannot create archive%s:\n%s", note, errStr)
 		}
 		return fmt.Errorf("tar failed: %v", err)
 	}

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -445,8 +445,8 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 	cmd := tarAsUser(username, tarArgs...)
 	cmd.Stdout = io.MultiWriter(archiveWriter, hasher, &sz)
 	matchCounter := &strutil.MatchCounter{
-		// keep at most 6 matches
-		N: 6,
+		// keep at most 5 matches
+		N: 5,
 		// keep the last lines only, those likely contain the reason for
 		// fatal errors
 		LastN: true,
@@ -460,10 +460,10 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 		matches, count := matchCounter.Matches()
 		if count > 0 {
 			note := ""
-			if len(matches) > 5 {
-				matches = matches[len(matches)-5:]
-				note = fmt.Sprintf(" (showing last %d lines out of %d)", 5, count)
+			if count > 5 {
+				note = fmt.Sprintf(" (showing last 5 lines out of %d)", count)
 			}
+			// we have at most 5 matches here
 			errStr := strings.Join(matches, "\n")
 			return fmt.Errorf("cannot create archive%s:\n%s", note, errStr)
 		}

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -805,7 +805,7 @@ exec /bin/tar "$@"
 	snaptest.MockSnap(c, "name: tar-fail-snap\nversion: v1", sideInfo)
 	c.Assert(os.MkdirAll(filepath.Join(homedir, "snap/tar-fail-snap/1/canary-tar-fail-snap"), 0755), check.IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(homedir, "snap/tar-fail-snap/common"), 0755), check.IsNil)
-	// this makes tar unhappy
+	// these dir permissions (000) make tar unhappy
 	c.Assert(os.Mkdir(filepath.Join(homedir, "snap/tar-fail-snap/common/common-tar-fail-snap"), 00), check.IsNil)
 
 	setID, saved, taskset, err := snapshotstate.Save(st, nil, []string{"a-user"})
@@ -817,7 +817,7 @@ exec /bin/tar "$@"
 	change.AddAll(taskset)
 
 	st.Unlock()
-	c.Assert(o.Settle(5*time.Second), check.IsNil)
+	c.Assert(o.Settle(testutil.HostScaledTimeout(5*time.Second)), check.IsNil)
 	st.Lock()
 	c.Check(change.Err(), check.NotNil)
 	tasks := change.Tasks()


### PR DESCRIPTION
Keep some last lines of the tar output.

This is an improvement over #9953 as it correctly handles a case when more than N lines are present in tar output, and correctly keeps the last couple of line.