### PR TITLE
tests: disable lxd tests for 21.04 until the lxd images are published for the system

### DIFF
--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -5,7 +5,8 @@ details: |
     are correct for snapfuse.
 
 # only 20.04+, we want lxd images that come with snaps preinstalled.
-systems: [ubuntu-2*]
+# TODO: enable for ubuntu-21+ once the lxd image is published
+systems: [ubuntu-20*]
 
 execute: |
     echo "Install lxd"
@@ -23,10 +24,6 @@ execute: |
     fi
 
     VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
-    # TODO: enable for ubuntu-21.04-64 when the image is available
-    if [ "$VERSION_ID" = "21.04" ]; then
-        VERSION_ID="20.10"
-    fi
     lxd.lxc launch --quiet "ubuntu:$VERSION_ID" ubuntu
 
     echo "Setting up proxy *inside* the container"

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -2,8 +2,8 @@ summary: Ensure that lxd works
 
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
-# TODO: enable for ubuntu-16-32 again
-systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*, ubuntu-core-*]
+# TODO: enable for ubuntu-21+ once the lxd image is published
+systems: [ubuntu-16*, ubuntu-18*, ubuntu-20*, ubuntu-core-*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro
@@ -90,10 +90,6 @@ execute: |
     # my-nesting-ubuntu nesting container
 
     VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
-    # TODO: enable for ubuntu-21.04-64 when the image is available
-    if [ "$VERSION_ID" = "21.04" ]; then
-        VERSION_ID="20.10"
-    fi
     lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-ubuntu
     lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-nesting-ubuntu -c security.nesting=true
     if [ "$(uname -m)" = x86_64 ] && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then


### PR DESCRIPTION
Currently the lxd image for 21.04 is not published and when we use the
image for 20.10 then the snapd cannot be built because dependencies
constrains like:
The following packages have unmet dependencies:
 snapd : Depends: libc6 (>= 2.33) but 2.32-0ubuntu3 is to be installed
E: Unable to correct problems, you have held broken packages.
