### PR TITLE
mkversion: check that version from changelog is set before overriding the output version

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -86,7 +86,8 @@ fi
 # it in a packaging recipe. We take the debian version from the changelog
 # and append the git revno and commit hash. A simpler approach would be
 # to git tag all pre/rc releases.
-if [ -z "$version_from_user" ] && [ "$version_from_git" != "" ] && [ "$version_from_git" != "$version_from_changelog" ]; then
+if [ -z "$version_from_user" ] && [ "$version_from_git" != "" ] && \
+       [ -n "$version_from_changelog" ] && [ "$version_from_git" != "$version_from_changelog" ]; then
     # if the changelog version has "git" in it and we also have a git version
     # directly, that is a bad changelog version, so fail, otherwise the below
     # code will produce a duplicated git info


### PR DESCRIPTION
The logic around concatenating the version from dpkg changelog and git revision
seems to be incorrect on systems where dpkg-parsechangelog is not installed. For
instance, on Arch, the version would end up being: `+git1000.gb5e86eb`. With the
fix it is `2.49+git472.gb9c4e04220-dirty`.

