### PR TITLE
asserts: include the assertion timestamp in error message when outside of signing key validity range

### DIFF
--- a/asserts/account_test.go
+++ b/asserts/account_test.go
@@ -152,7 +152,7 @@ func (s *accountSuite) TestCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(account)
-	c.Assert(err, ErrorMatches, `account assertion timestamp outside of signing key validity \(key valid since.*\)`)
+	c.Assert(err, ErrorMatches, `account assertion timestamp "2011-01-01 14:00:00 \+0000 UTC" outside of signing key validity \(key valid since.*\)`)
 }
 
 func (s *accountSuite) TestCheckUntrustedAuthority(c *C) {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -725,7 +725,8 @@ func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey
 			if !signingKey.Until().IsZero() {
 				until = fmt.Sprintf(" until %q", signingKey.Until())
 			}
-			return fmt.Errorf("%s assertion timestamp outside of signing key validity (key valid since %q%s)", assert.Type().Name, signingKey.Since(), until)
+			return fmt.Errorf("%s assertion timestamp %q outside of signing key validity (key valid since %q%s)",
+				assert.Type().Name, checkTime, signingKey.Since(), until)
 		}
 	}
 	return nil

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -521,7 +521,7 @@ func (mods *modelSuite) TestModelCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(model)
-	c.Assert(err, ErrorMatches, `model assertion timestamp outside of signing key validity \(key valid since.*\)`)
+	c.Assert(err, ErrorMatches, `model assertion timestamp "2011-01-01 14:00:00 \+0000 UTC" outside of signing key validity \(key valid since.*\)`)
 }
 
 func (mods *modelSuite) TestClassicDecodeOK(c *C) {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -805,7 +805,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(snapBuild)
-	c.Assert(err, ErrorMatches, `snap-build assertion timestamp outside of signing key validity \(key valid since.*\)`)
+	c.Assert(err, ErrorMatches, `snap-build assertion timestamp "2013-01-01 14:00:00 \+0000 UTC" outside of signing key validity \(key valid since.*\)`)
 }
 
 type snapRevSuite struct {
@@ -942,7 +942,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(snapRev)
-	c.Assert(err, ErrorMatches, `snap-revision assertion timestamp outside of signing key validity \(key valid since.*\)`)
+	c.Assert(err, ErrorMatches, `snap-revision assertion timestamp "2013-01-01 14:00:00 \+0000 UTC" outside of signing key validity \(key valid since.*\)`)
 }
 
 func (srs *snapRevSuite) TestSnapRevisionCheckUntrustedAuthority(c *C) {


### PR DESCRIPTION
We occasionally get the following backtrace in the tests:

```
----------------------------------------------------------------------
PANIC: api_users_test.go:762: userSuite.TestPostCreateUserFromAssertionNoModel

... Panic: cannot add test assertions: model assertion timestamp outside of signing key validity (key valid since "2021-02-23 11:10:41 +0000 UTC") (PC=0x45CF4A)

/snap/go/2117/src/runtime/panic.go:491
  in gopanic
/home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/assertstate/assertstatetest/add_many.go:38
  in AddMany
api_users_test.go:776
  in userSuite.TestPostCreateUserFromAssertionNoModel
/snap/go/2117/src/reflect/value.go:302
  in Value.Call
/snap/go/2117/src/runtime/asm_amd64.s:2337
  in goexit
OOPS: 439 passed, 1 skipped, 1 PANICKED
--- FAIL: Test (9.62s)
FAIL
coverage: 86.4% of statements
FAIL	github.com/snapcore/snapd/daemon	9.786s
```

Adding a timestamp of the assertion, will help it to debug the problem further.
