### PR TITLE
many: fix new ineffassign warnings

### DIFF
--- a/interfaces/hotplug/deviceinfo_test.go
+++ b/interfaces/hotplug/deviceinfo_test.go
@@ -85,11 +85,11 @@ func (s *hotplugSuite) TestPropertiesMissing(c *C) {
 		"ACTION":  "add", "SUBSYSTEM": "usb",
 	}
 
-	di, err := NewHotplugDeviceInfo(map[string]string{})
+	_, err := NewHotplugDeviceInfo(map[string]string{})
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `missing device path attribute`)
 
-	di, err = NewHotplugDeviceInfo(env)
+	di, err := NewHotplugDeviceInfo(env)
 	c.Assert(err, IsNil)
 
 	c.Assert(di.DeviceName(), Equals, "")

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -2085,13 +2085,13 @@ func (s *RepositorySuite) TestConnection(c *C) {
 
 	connRef := NewConnRef(s.plug, s.slot)
 
-	conn, err := s.testRepo.Connection(connRef)
+	_, err := s.testRepo.Connection(connRef)
 	c.Assert(err, ErrorMatches, `no connection from consumer:plug to producer:slot`)
 
 	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	conn, err = s.testRepo.Connection(connRef)
+	conn, err := s.testRepo.Connection(connRef)
 	c.Assert(err, IsNil)
 	c.Assert(conn.Plug.Name(), Equals, "plug")
 	c.Assert(conn.Slot.Name(), Equals, "slot")

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -661,7 +661,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C)
 	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.DoingStatus)
-	device, err := devicestatetest.Device(s.state)
+	_, err := devicestatetest.Device(s.state)
 	c.Check(err, IsNil)
 	_, err = s.db.Find(asserts.SerialType, map[string]string{
 		"brand-id": "canonical",
@@ -678,7 +678,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C)
 	// Repeated handler run but set original serial.
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 	c.Check(chg.Err(), IsNil)
-	device, err = devicestatetest.Device(s.state)
+	device, err := devicestatetest.Device(s.state)
 	c.Check(err, IsNil)
 	c.Check(device.Serial, Equals, "9999")
 }


### PR DESCRIPTION
For some reason all of a sudden these were flagged by the latest/stable go snap
in CI:

Checking for ineffective assignments
/home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/interfaces/repo_test.go:2088:2: ineffectual assignment to conn
/home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/interfaces/hotplug/deviceinfo_test.go:88:2: ineffectual assignment to di
/home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/devicestate/devicestate_serial_test.go:664:2: ineffectual assignment to device

No idea why these all of a sudden starting failing, but see https://github.com/snapcore/snapd/runs/1983645493?check_suite_focus=true for an example failure