### PR TITLE
tests: use a pre built govendor dependencies for opensuse tumbleweed

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -492,13 +492,21 @@ prepare_project() {
         rm -rf "${GOPATH%%:*}/src/github.com/kardianos/govendor"
         go get -u github.com/kardianos/govendor
     fi
-    # Retry govendor sync to minimize the number of connection errors during the sync
-    for _ in $(seq 10); do
-        if quiet govendor sync; then
-            break
-        fi
-        sleep 1
-    done
+
+    if [[ "$SPREAD_SYSTEM" == opensuse-tumbleweed-* ]]; then
+        wget -q "https://storage.googleapis.com/spread-snapd-tests/dependencies/govendor/vendor.zip"
+        rm -rf "${GOPATH%%:*}/src/github.com/snapcore/snapd/vendor"
+        unzip vendor.zip -d /
+        rm vendor.zip
+    else
+        # Retry govendor sync to minimize the number of connection errors during the sync
+        for _ in $(seq 10); do
+            if quiet govendor sync; then
+                break
+            fi
+            sleep 1
+        done
+    fi
     # govendor runs as root and will leave strange permissions
     chown test.test -R "$SPREAD_PATH"
 

--- a/tests/lib/tools/os.query
+++ b/tests/lib/tools/os.query
@@ -88,7 +88,7 @@ is_opensuse() {
 }
 
 is_opensuse_tumbleweed() {
-    grep -qFx 'ID="opensuse-tumbleweed"'
+    grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
 }
 
 is_pc_amd64() {


### PR DESCRIPTION
The idea is to use spread-cron to sync govendor dependencies and store
that in the gce spread bucket. The dependencies will be updated daily.

This change is to workaround govendor sync command getting stuck on opensuse tumbleweed. 
