### PR TITLE
cmd/snap-bootstrap/triggerwatch: fix returning wrong errors

### DIFF
--- a/cmd/snap-bootstrap/triggerwatch/evdev.go
+++ b/cmd/snap-bootstrap/triggerwatch/evdev.go
@@ -152,7 +152,7 @@ Loop:
 		case ev := <-evChan:
 			if ev.err != nil {
 				holdTimer.Stop()
-				ch <- keyEvent{Err: err, Dev: e}
+				ch <- keyEvent{Err: ev.err, Dev: e}
 				break Loop
 			}
 			kev := ev.kev

--- a/cmd/snap-bootstrap/triggerwatch/triggerwatch.go
+++ b/cmd/snap-bootstrap/triggerwatch/triggerwatch.go
@@ -75,7 +75,7 @@ func Wait(timeout time.Duration) error {
 	select {
 	case kev := <-detectKeyCh:
 		if kev.Err != nil {
-			return err
+			return kev.Err
 		}
 		// channel got closed without an error
 		logger.Noticef("%s: + got trigger key %v", kev.Dev, triggerFilter.Key)


### PR DESCRIPTION
While debugging an issue of input devices, I found that these returns don't use correct errors.
This PR is used to fix them.