### PR TITLE
interfaces/wayland: rm Xwayland Xauth file access from wayland slot 

### DIFF
--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -59,11 +59,6 @@ owner /run/user/[0-9]*/wayland-[0-9]* rwk,
 # to the server. Although they are passed by FD we still need rw access to the file.
 /run/user/[0-9]*/snap.*/{wayland-cursor,xwayland}-shared-* rw,
 
-# Allow reading an Xwayland Xauth file
-# (see https://gitlab.gnome.org/GNOME/mutter/merge_requests/626)
-/run/user/[0-9]*/.mutter-Xwaylandauth.* r,
-/run/user/[0-9]*/mutter/Xauthority r,
-
 # Allow write access to create /run/user/* to create XDG_RUNTIME_DIR (until
 # lp:1738197 is fixed). Note this is not needed if creating a session using
 # logind (as provided by the login-session-control snapd interface).

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -83,6 +83,9 @@ unix (bind, listen, accept)
 # For Xorg to detect screens
 /sys/devices/pci**/boot_vga r,
 /sys/devices/pci**/resources r,
+
+# TODO: enable rules for writing Xwayland Xauth files for clients to read when
+# something like gnome-shell is running confined with an x11 slot
 `
 
 const x11PermanentSlotSecComp = `


### PR DESCRIPTION
Xwayland was the expected user of these rules, however that was based on a
misunderstanding, since the compositor will instead be the one writing out Xauth
cookie before running XWayland.

These rules should instead be provided to the x11 slot implementation, such that
the Wayland compositor (such as mutter) would write this file would slot x11 and
then be provided write access to these files. 

However, we don't add those files yet since it's unclear what a real user like
gnome-shell will actually need to do, so instead just leave a TODO in the 
policy about adding such rules.

See discussion at https://github.com/snapcore/snapd/pull/9952#discussion_r580839553
