### PR TITLE
packaging: drop 99-snapd.conf via dpkg-maintscript-helper

### DIFF
--- a/packaging/debian-sid/snapd.maintscript
+++ b/packaging/debian-sid/snapd.maintscript
@@ -3,3 +3,4 @@
 rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
 rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~
 rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~ snap-confine
+rm_conffile /etc/sudoers.d/99-snapd.conf 2.50~

--- a/packaging/ubuntu-14.04/snapd.maintscript
+++ b/packaging/ubuntu-14.04/snapd.maintscript
@@ -3,3 +3,4 @@ rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
 rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~
 # on trusty /etc/apparmor.d/usr.lib.snapd.snap-confine was never renamed
 # so we don't need to handle this file here (unlike in xenial+)
+rm_conffile /etc/sudoers.d/99-snapd.conf 2.50~

--- a/packaging/ubuntu-16.04/snapd.maintscript
+++ b/packaging/ubuntu-16.04/snapd.maintscript
@@ -3,3 +3,4 @@
 rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
 rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~
 rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~
+rm_conffile /etc/sudoers.d/99-snapd.conf 2.50~

--- a/tests/main/upgrade-sudoers-conffile-removal/task.yaml
+++ b/tests/main/upgrade-sudoers-conffile-removal/task.yaml
@@ -1,0 +1,27 @@
+summary: Ensure conffile removal from upgrades <2.46 works
+
+description: |
+    Ensure that upgrading from 2.45.1 works and conffile cleanup for
+    /etc/sudoers.d/99-snapd.conf happens.
+    
+    The exact version of snapd is a bit arbitrary (anything before
+    2.46 is fine).
+
+systems: [ubuntu-20.04-64]
+
+execute: |
+    #shellcheck source=tests/lib/systemd.sh
+    . "$TESTSLIB"/systemd.sh
+
+    echo "download snapd 2.37.4"
+    wget https://launchpad.net/ubuntu/+source/snapd/2.45.1/+build/19499801/+files/snapd_2.45.1_amd64.deb
+    apt install -y --allow-downgrades ./snapd_2.45*_amd64.deb
+
+    echo "Check that the sudoers.d conffile is there"
+    test -e /etc/sudoers.d/99-snapd.conf
+    
+    echo "upgrade to current snapd"
+    apt install -y "$GOHOME"/snapd*.deb
+
+    echo "Check that the conffile is gone after the upgrade (LP: 1915156)"
+    test ! -e /etc/sudoers.d/99-snapd.conf

--- a/tests/upgrade/sudoers-conffile-removal/task.yaml
+++ b/tests/upgrade/sudoers-conffile-removal/task.yaml
@@ -10,10 +10,7 @@ description: |
 systems: [ubuntu-20.04-64]
 
 execute: |
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB"/systemd.sh
-
-    echo "download snapd 2.37.4"
+    echo "download snapd 2.45.1"
     wget https://launchpad.net/ubuntu/+source/snapd/2.45.1/+build/19499801/+files/snapd_2.45.1_amd64.deb
     apt install -y --allow-downgrades ./snapd_2.45*_amd64.deb
 


### PR DESCRIPTION
We dropped shipping /etc/sudoers.d/99-snapd.conf in PR#8885 but
did not clean up properly in the debian/* packaging. This is a
conffile in debian packaging terms so it needs special handling.

Fortunately the dpkg-maintscript-helper makes this easy(ish)
now with debian/<pkg>.maintscript

This fixes LP: #1915156

