### PR TITLE
daemon,o/c/configcore: introduce users.create.automatic

### DIFF
--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -851,10 +851,12 @@ func (s *userSuite) TestPostCreateUserAutomaticDisabled(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	defer daemon.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
+		// we should not reach here
 		panic("no user should be created")
 	})()
 	// make sure we report them as non-existing until created
 	defer daemon.MockUserLookup(func(username string) (*user.User, error) {
+		// this error would simply be interpreted as need to create
 		return nil, fmt.Errorf("not created yet")
 	})()
 

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/store"
@@ -835,6 +836,47 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwned(c *check.C) 
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
+}
+
+func (s *userSuite) TestPostCreateUserAutomaticDisabled(c *check.C) {
+	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
+
+	// disable automatic user creation
+	st := s.d.Overlord().State()
+	st.Lock()
+	tr := config.NewTransaction(st)
+	err := tr.Set("core", "users.create.automatic", false)
+	tr.Commit()
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+
+	defer daemon.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
+		panic("no user should be created")
+	})()
+	// make sure we report them as non-existing until created
+	defer daemon.MockUserLookup(func(username string) (*user.User, error) {
+		return nil, fmt.Errorf("not created yet")
+	})()
+
+	// do it!
+	buf := bytes.NewBufferString(`{"automatic": true}`)
+	req, err := http.NewRequest("POST", "/v2/create-user", buf)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.req(c, req, nil).(*daemon.Resp)
+
+	// empty result
+	expected := []daemon.UserResponseData{}
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
+	c.Check(rsp.Result, check.FitsTypeOf, expected)
+	c.Check(rsp.Result, check.DeepEquals, expected)
+
+	// ensure no user was added to the state
+	st.Lock()
+	users, err := auth.Users(st)
+	c.Assert(err, check.IsNil)
+	st.Unlock()
+	c.Check(users, check.HasLen, 0)
 }
 
 func (s *userSuite) TestUsersEmpty(c *check.C) {

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -49,6 +49,9 @@ func init() {
 	// store-certs.*
 	addWithStateHandler(validateCertSettings, handleCertConfiguration, nil)
 
+	// users.create.automatic
+	addWithStateHandler(validateUsersSettings, handleUserSettings, &flags{earlyConfigFilter: earlyUsersSettingsFilter})
+
 	validateOnly := &flags{validatedOnlyStateConfig: true}
 	addWithStateHandler(validateRefreshSchedule, nil, validateOnly)
 	addWithStateHandler(validateRefreshRateLimit, nil, validateOnly)

--- a/overlord/configstate/configcore/users.go
+++ b/overlord/configstate/configcore/users.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"strings"
+
+	"github.com/snapcore/snapd/overlord/configstate/config"
+)
+
+func init() {
+	supportedConfigurations["core.users.create.automatic"] = true
+}
+
+func earlyUsersSettingsFilter(values, early map[string]interface{}) {
+	for key, v := range values {
+		if strings.HasPrefix(key, "users.") && supportedConfigurations["core."+key] {
+			early[key] = v
+		}
+	}
+}
+
+func validateUsersSettings(tr config.Conf) error {
+	return validateBoolFlag(tr, "users.create.automatic")
+}
+
+func handleUserSettings(tr config.Conf, opts *fsOnlyContext) error {
+	output, err := coreCfg(tr, "users.create.automatic")
+	if err != nil {
+		return nil
+	}
+
+	// normalize the value in case
+	switch output {
+	case "true":
+		tr.Set("core", "users.create.automatic", true)
+	case "false":
+		tr.Set("core", "users.create.automatic", false)
+	}
+
+	return nil
+}

--- a/overlord/configstate/configcore/users_test.go
+++ b/overlord/configstate/configcore/users_test.go
@@ -1,0 +1,77 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+)
+
+type usersSuite struct {
+	configcoreSuite
+}
+
+var _ = Suite(&usersSuite{})
+
+func (s *usersSuite) TestUsersCreateAutomaticEarly(c *C) {
+	patch := map[string]interface{}{
+		"users.create.automatic": "false",
+	}
+	tr := &mockConf{state: s.state}
+	err := configcore.Early(tr, patch)
+	c.Assert(err, IsNil)
+
+	c.Check(tr.conf, DeepEquals, map[string]interface{}{
+		"users.create.automatic": false,
+	})
+}
+
+func (s *usersSuite) TestUsersCreateAutomaticInvalid(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf:  map[string]interface{}{"users.create.automatic": "foo"},
+	})
+	c.Assert(err, ErrorMatches, `users.create.automatic can only be set to 'true' or 'false'`)
+}
+
+func (s *usersSuite) TestUsersCreateAutomaticConfigure(c *C) {
+	tests := []struct {
+		value    interface{}
+		expected bool
+	}{
+		{"true", true},
+		{"false", false},
+		{true, true},
+		{false, false},
+	}
+
+	for _, t := range tests {
+		conf := &mockConf{
+			state: s.state,
+			conf:  map[string]interface{}{"users.create.automatic": t.value},
+		}
+
+		err := configcore.Run(conf)
+		c.Assert(err, IsNil)
+
+		c.Check(conf.conf["users.create.automatic"], Equals, t.expected)
+	}
+}


### PR DESCRIPTION
the option if set to false disables automatic user creation on assertion
auto-import

it is processed early which means its setting available
before snapd starts serving users API requests

