### PR TITLE
daemon: move the last api_foo_test.go to daemon_test

### DIFF
--- a/daemon/api_debug_pprof_test.go
+++ b/daemon/api_debug_pprof_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon
+package daemon_test
 
 import (
 	"bytes"
@@ -31,15 +31,19 @@ import (
 var _ = check.Suite(&pprofDebugSuite{})
 
 type pprofDebugSuite struct {
-	APIBaseSuite
+	apiBaseSuite
 }
 
 func (s *pprofDebugSuite) TestGetPprofCmdline(c *check.C) {
+	s.daemon(c)
+
 	req, err := http.NewRequest("GET", "/v2/debug/pprof/cmdline", nil)
 	c.Assert(err, check.IsNil)
+	// as root
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
 
 	rr := httptest.NewRecorder()
-	getPprof(debugPprofCmd, req, nil).ServeHTTP(rr, req)
+	s.serveHTTP(c, rr, req)
 
 	rsp := rr.Result()
 	c.Assert(rsp, check.NotNil)

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon
+package daemon_test
 
 import (
 	"net/http"
@@ -25,17 +25,18 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
 var _ = Suite(&seedingDebugSuite{})
 
 type seedingDebugSuite struct {
-	APIBaseSuite
+	apiBaseSuite
 }
 
 func (s *seedingDebugSuite) SetUpTest(c *C) {
-	s.APIBaseSuite.SetUpTest(c)
+	s.apiBaseSuite.SetUpTest(c)
 	s.daemonWithOverlordMock(c)
 }
 
@@ -43,15 +44,15 @@ func (s *seedingDebugSuite) getSeedingDebug(c *C) interface{} {
 	req, err := http.NewRequest("GET", "/v2/debug?aspect=seeding", nil)
 	c.Assert(err, IsNil)
 
-	rsp := getDebug(debugCmd, req, nil).(*resp)
-	c.Assert(rsp.Type, Equals, ResponseTypeSync)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
+	c.Assert(rsp.Type, Equals, daemon.ResponseTypeSync)
 	return rsp.Result
 }
 
 func (s *seedingDebugSuite) TestNoData(c *C) {
 	data := s.getSeedingDebug(c)
 	c.Check(data, NotNil)
-	c.Check(data, DeepEquals, &seedingInfo{})
+	c.Check(data, DeepEquals, &daemon.SeedingInfo{})
 }
 
 func (s *seedingDebugSuite) TestSeedingDebug(c *C) {
@@ -69,7 +70,7 @@ func (s *seedingDebugSuite) TestSeedingDebug(c *C) {
 	seedTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:07Z")
 	c.Assert(err, IsNil)
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 
 	st.Set("preseeded", preseeded)
@@ -87,7 +88,7 @@ func (s *seedingDebugSuite) TestSeedingDebug(c *C) {
 	st.Unlock()
 
 	data := s.getSeedingDebug(c)
-	c.Check(data, DeepEquals, &seedingInfo{
+	c.Check(data, DeepEquals, &daemon.SeedingInfo{
 		Seeded:               true,
 		Preseeded:            true,
 		PreseedSystemKey:     "foo",
@@ -103,7 +104,7 @@ func (s *seedingDebugSuite) TestSeedingDebugSeededNoTimes(c *C) {
 	seedTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:07Z")
 	c.Assert(err, IsNil)
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 
 	// only set seed-time and seeded
@@ -113,7 +114,7 @@ func (s *seedingDebugSuite) TestSeedingDebugSeededNoTimes(c *C) {
 	st.Unlock()
 
 	data := s.getSeedingDebug(c)
-	c.Check(data, DeepEquals, &seedingInfo{
+	c.Check(data, DeepEquals, &daemon.SeedingInfo{
 		Seeded:   true,
 		SeedTime: &seedTime,
 	})
@@ -127,7 +128,7 @@ func (s *seedingDebugSuite) TestSeedingDebugPreseededStillSeeding(c *C) {
 	seedRestartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:03Z")
 	c.Assert(err, IsNil)
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 
 	st.Set("preseeded", true)
@@ -144,7 +145,7 @@ func (s *seedingDebugSuite) TestSeedingDebugPreseededStillSeeding(c *C) {
 	st.Unlock()
 
 	data := s.getSeedingDebug(c)
-	c.Check(data, DeepEquals, &seedingInfo{
+	c.Check(data, DeepEquals, &daemon.SeedingInfo{
 		Seeded:               false,
 		Preseeded:            true,
 		PreseedSystemKey:     "foo",
@@ -163,7 +164,7 @@ func (s *seedingDebugSuite) TestSeedingDebugPreseededSeedError(c *C) {
 	seedRestartTime, err := time.Parse(time.RFC3339, "2020-01-01T10:00:03Z")
 	c.Assert(err, IsNil)
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 
 	st.Set("preseeded", true)
@@ -203,7 +204,7 @@ func (s *seedingDebugSuite) TestSeedingDebugPreseededSeedError(c *C) {
 	st.Unlock()
 
 	data := s.getSeedingDebug(c)
-	c.Check(data, DeepEquals, &seedingInfo{
+	c.Check(data, DeepEquals, &daemon.SeedingInfo{
 		Seeded:               false,
 		Preseeded:            true,
 		PreseedSystemKey:     "foo",

--- a/daemon/api_debug_test.go
+++ b/daemon/api_debug_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon
+package daemon_test
 
 import (
 	"bytes"
@@ -26,6 +26,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
@@ -34,25 +35,27 @@ import (
 var _ = check.Suite(&postDebugSuite{})
 
 type postDebugSuite struct {
-	APIBaseSuite
+	apiBaseSuite
 }
 
 func (s *postDebugSuite) TestPostDebugEnsureStateSoon(c *check.C) {
 	s.daemonWithOverlordMock(c)
 
 	soon := 0
-	ensureStateSoon = func(st *state.State) {
+	var origEnsureStateSoon func(*state.State)
+	origEnsureStateSoon, restore := daemon.MockEnsureStateSoon(func(st *state.State) {
 		soon++
-		ensureStateSoonImpl(st)
-	}
+		origEnsureStateSoon(st)
+	})
+	defer restore()
 
 	buf := bytes.NewBufferString(`{"action": "ensure-state-soon"}`)
 	req, err := http.NewRequest("POST", "/v2/debug", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postDebug(debugCmd, req, nil).(*resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result, check.Equals, true)
 	c.Check(soon, check.Equals, 1)
 }
@@ -64,9 +67,9 @@ func (s *postDebugSuite) TestPostDebugGetBaseDeclaration(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/debug", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := postDebug(debugCmd, req, nil).(*resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result.(map[string]interface{})["base-declaration"],
 		testutil.Contains, "type: base-declaration")
 }
@@ -79,22 +82,22 @@ func (s *postDebugSuite) testDebugConnectivityHappy(c *check.C, post bool) {
 		"another.good.host.com": true,
 	}
 
-	var rsp *resp
+	var rsp *daemon.Resp
 	if post {
 		buf := bytes.NewBufferString(`{"action": "connectivity"}`)
 		req, err := http.NewRequest("POST", "/v2/debug", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp = postDebug(debugCmd, req, nil).(*resp)
+		rsp = s.req(c, req, nil).(*daemon.Resp)
 	} else {
-		req, err := http.NewRequest("POST", "/v2/debug?aspect=connectivity", nil)
+		req, err := http.NewRequest("GET", "/v2/debug?aspect=connectivity", nil)
 		c.Assert(err, check.IsNil)
-		rsp = getDebug(debugCmd, req, nil).(*resp)
+		rsp = s.req(c, req, nil).(*daemon.Resp)
 
 	}
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
-	c.Check(rsp.Result, check.DeepEquals, ConnectivityStatus{
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
+	c.Check(rsp.Result, check.DeepEquals, daemon.ConnectivityStatus{
 		Connectivity: true,
 		Unreachable:  []string(nil),
 	})
@@ -116,21 +119,21 @@ func (s *postDebugSuite) testDebugConnectivityUnhappy(c *check.C, post bool) {
 		"bad.host.com":  false,
 	}
 
-	var rsp *resp
+	var rsp *daemon.Resp
 	if post {
 		buf := bytes.NewBufferString(`{"action": "connectivity"}`)
 		req, err := http.NewRequest("POST", "/v2/debug", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp = postDebug(debugCmd, req, nil).(*resp)
+		rsp = s.req(c, req, nil).(*daemon.Resp)
 	} else {
 		req, err := http.NewRequest("GET", "/v2/debug?aspect=connectivity", nil)
 		c.Assert(err, check.IsNil)
-		rsp = getDebug(debugCmd, req, nil).(*resp)
+		rsp = s.req(c, req, nil).(*daemon.Resp)
 	}
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
-	c.Check(rsp.Result, check.DeepEquals, ConnectivityStatus{
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
+	c.Check(rsp.Result, check.DeepEquals, daemon.ConnectivityStatus{
 		Connectivity: false,
 		Unreachable:  []string{"bad.host.com"},
 	})
@@ -150,9 +153,9 @@ func (s *postDebugSuite) TestGetDebugBaseDeclaration(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/debug?aspect=base-declaration", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := getDebug(debugCmd, req, nil).(*resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 
-	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Result.(map[string]interface{})["base-declaration"],
 		testutil.Contains, "type: base-declaration")
 }
@@ -174,7 +177,7 @@ func (s *postDebugSuite) getDebugTimings(c *check.C, request string) []interface
 	req, err := http.NewRequest("GET", request, nil)
 	c.Assert(err, check.IsNil)
 
-	st := s.d.overlord.State()
+	st := s.d.Overlord().State()
 	st.Lock()
 
 	chg1 := st.NewChange("foo", "...")
@@ -212,13 +215,13 @@ func (s *postDebugSuite) getDebugTimings(c *check.C, request string) []interface
 
 	st.Unlock()
 
-	rsp := getDebug(debugCmd, req, nil).(*resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	data, err := json.Marshal(rsp.Result)
 	c.Assert(err, check.IsNil)
 	var dataJSON []interface{}
 	json.Unmarshal(data, &dataJSON)
 
-	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	return dataJSON
 }
 
@@ -261,12 +264,12 @@ func (s *postDebugSuite) TestGetDebugTimingsError(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/debug?aspect=change-timings&ensure=unknown", nil)
 	c.Assert(err, check.IsNil)
-	rsp := getDebug(debugCmd, req, nil).(*resp)
+	rsp := s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Status, check.Equals, 400)
 
 	req, err = http.NewRequest("GET", "/v2/debug?aspect=change-timings&change-id=9999", nil)
 	c.Assert(err, check.IsNil)
-	rsp = getDebug(debugCmd, req, nil).(*resp)
+	rsp = s.req(c, req, nil).(*daemon.Resp)
 	c.Check(rsp.Status, check.Equals, 400)
 }
 
@@ -276,15 +279,15 @@ func (s *postDebugSuite) TestMinLane(c *check.C) {
 	defer st.Unlock()
 
 	t := st.NewTask("bar", "")
-	c.Check(MinLane(t), check.Equals, 0)
+	c.Check(daemon.MinLane(t), check.Equals, 0)
 
 	lane1 := st.NewLane()
 	t.JoinLane(lane1)
-	c.Check(MinLane(t), check.Equals, lane1)
+	c.Check(daemon.MinLane(t), check.Equals, lane1)
 
 	lane2 := st.NewLane()
 	t.JoinLane(lane2)
-	c.Check(MinLane(t), check.Equals, lane1)
+	c.Check(daemon.MinLane(t), check.Equals, lane1)
 
 	// sanity
 	c.Check(t.Lanes(), check.DeepEquals, []int{lane1, lane2})

--- a/daemon/export_api_debug_seeding_test.go
+++ b/daemon/export_api_debug_seeding_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+type (
+	SeedingInfo = seedingInfo
+)

--- a/daemon/export_api_debug_test.go
+++ b/daemon/export_api_debug_test.go
@@ -19,7 +19,6 @@
 
 package daemon
 
-
 var (
 	MinLane = minLane
 )

--- a/daemon/export_api_debug_test.go
+++ b/daemon/export_api_debug_test.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+
+var (
+	MinLane = minLane
+)

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-var MinLane = minLane
-
 func NewAndAddRoutes() (*Daemon, error) {
 	d, err := New()
 	if err != nil {


### PR DESCRIPTION
still todo later: clean up what is left in api.go and api_test.go

there are other non api_ tests also still in daemon
