### PR TITLE
osutil: add SetTime() w/ 32-bit and 64-bit implementations

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -66,6 +66,14 @@ func MockOpenFile(new func(string, int, os.FileMode) (fileish, error)) (restore 
 	}
 }
 
+func MockSyscallSettimeofday(f func(*syscall.Timeval) error) (restore func()) {
+	old := syscallSettimeofday
+	syscallSettimeofday = f
+	return func() {
+		syscallSettimeofday = old
+	}
+}
+
 func MockUserLookup(mock func(name string) (*user.User, error)) func() {
 	realUserLookup := userLookup
 	userLookup = mock

--- a/osutil/settime.go
+++ b/osutil/settime.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"time"
+)
+
+// exposed for different 32-bit vs 64-bit definitions of syscall.Timeval
+var timeToTimeval func(time.Time) *syscall.Timeval
+
+// exposed for mocking, since we can't actually call this without being root
+// on system running tests
+var syscallSettimeofday = syscall.Settimeofday
+
+// SetTime sets the time of the system using settimeofday(). This syscall needs
+// to be performed as root or with CAP_SYS_TIME.
+func SetTime(t time.Time) error {
+	tv := timeToTimeval(t)
+
+	return syscallSettimeofday(tv)
+}

--- a/osutil/settime_32bit.go
+++ b/osutil/settime_32bit.go
@@ -34,6 +34,6 @@ func init() {
 func timeToTimeval32(t time.Time) *syscall.Timeval {
 	return &syscall.Timeval{
 		Sec:  int32(t.Unix()),
-		Usec: int32(t.UnixNano() / 1000 % 1000),
+		Usec: int32(t.Nanosecond() / 1000),
 	}
 }

--- a/osutil/settime_32bit.go
+++ b/osutil/settime_32bit.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// +build 386 arm
+// +build linux
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"time"
+)
+
+func init() {
+	timeToTimeval = timeToTimeval32
+}
+
+func timeToTimeval32(t time.Time) *syscall.Timeval {
+	return &syscall.Timeval{
+		Sec:  int32(t.Unix()),
+		Usec: int32(t.UnixNano() / 1000 % 1000),
+	}
+}

--- a/osutil/settime_64bit.go
+++ b/osutil/settime_64bit.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// +build !386
+// +build !arm
+// +build linux
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"time"
+)
+
+func init() {
+	timeToTimeval = timeToTimeval64
+}
+
+func timeToTimeval64(t time.Time) *syscall.Timeval {
+	return &syscall.Timeval{
+		Sec:  int64(t.Unix()),
+		Usec: int64(t.UnixNano() / 1000 % 1000),
+	}
+}

--- a/osutil/settime_64bit.go
+++ b/osutil/settime_64bit.go
@@ -35,6 +35,6 @@ func init() {
 func timeToTimeval64(t time.Time) *syscall.Timeval {
 	return &syscall.Timeval{
 		Sec:  int64(t.Unix()),
-		Usec: int64(t.UnixNano() / 1000 % 1000),
+		Usec: int64(t.Nanosecond() / 1000),
 	}
 }

--- a/osutil/settime_test.go
+++ b/osutil/settime_test.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"syscall"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type settimeTestSuite struct{}
+
+var _ = Suite(&settimeTestSuite{})
+
+func (s *settimeTestSuite) TestSetTime(c *C) {
+	timeIn, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Mon Jan 2 15:04:05 -0700 MST 2006")
+	c.Assert(err, IsNil)
+
+	r := osutil.MockSyscallSettimeofday(func(t *syscall.Timeval) error {
+		c.Assert(int64(t.Sec), Equals, timeIn.Unix())
+		c.Assert(int64(t.Usec), Equals, timeIn.UnixNano()/1000%1000)
+		return nil
+	})
+	defer r()
+
+	err = osutil.SetTime(timeIn)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
We need to use syscall.Settimeofday to set the time of day from snap-bootstrap
in the initrd, but syscall.Timeval has architecture dependent definitions, on
32-bit systems it uses int32's, but on 64-bit systems it uses int64's, so we
have to split up the actual implementation between two files.

The unit testing here is a bit pointless, since we can't actually run the real syscall 
without being root or having CAP_SYS_TIME, so the unit test really just confirms
that our logic of changing time.Time{} into syscall.Timeval{} is correct.