### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: move time forward using ref files

### DIFF
--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -56,6 +56,14 @@ func MockTimeNow(f func() time.Time) (restore func()) {
 	}
 }
 
+func MockOsutilSetTime(f func(time.Time) error) (restore func()) {
+	old := osutilSetTime
+	osutilSetTime = f
+	return func() {
+		osutilSetTime = old
+	}
+}
+
 func MockOsutilIsMounted(f func(string) (bool, error)) (restore func()) {
 	old := osutilIsMounted
 	osutilIsMounted = f

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -66,6 +66,14 @@ func MockOpenFile(new func(string, int, os.FileMode) (fileish, error)) (restore 
 	}
 }
 
+func MockSyscallSettimeofday(f func(*syscall.Timeval) error) (restore func()) {
+	old := syscallSettimeofday
+	syscallSettimeofday = f
+	return func() {
+		syscallSettimeofday = old
+	}
+}
+
 func MockUserLookup(mock func(name string) (*user.User, error)) func() {
 	realUserLookup := userLookup
 	userLookup = mock

--- a/osutil/settime.go
+++ b/osutil/settime.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"time"
+)
+
+// exposed for different 32-bit vs 64-bit definitions of syscall.Timeval
+var timeToTimeval func(time.Time) *syscall.Timeval
+
+// exposed for mocking, since we can't actually call this without being root
+// on system running tests
+var syscallSettimeofday = syscall.Settimeofday
+
+// SetTime sets the time of the system using settimeofday(). This syscall needs
+// to be performed as root or with CAP_SYS_TIME.
+func SetTime(t time.Time) error {
+	tv := timeToTimeval(t)
+
+	return syscallSettimeofday(tv)
+}

--- a/osutil/settime_32bit.go
+++ b/osutil/settime_32bit.go
@@ -34,6 +34,6 @@ func init() {
 func timeToTimeval32(t time.Time) *syscall.Timeval {
 	return &syscall.Timeval{
 		Sec:  int32(t.Unix()),
-		Usec: int32(t.UnixNano() / 1000 % 1000),
+		Usec: int32(t.Nanosecond() / 1000),
 	}
 }

--- a/osutil/settime_32bit.go
+++ b/osutil/settime_32bit.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// +build 386 arm
+// +build linux
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"time"
+)
+
+func init() {
+	timeToTimeval = timeToTimeval32
+}
+
+func timeToTimeval32(t time.Time) *syscall.Timeval {
+	return &syscall.Timeval{
+		Sec:  int32(t.Unix()),
+		Usec: int32(t.UnixNano() / 1000 % 1000),
+	}
+}

--- a/osutil/settime_64bit.go
+++ b/osutil/settime_64bit.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// +build !386
+// +build !arm
+// +build linux
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"time"
+)
+
+func init() {
+	timeToTimeval = timeToTimeval64
+}
+
+func timeToTimeval64(t time.Time) *syscall.Timeval {
+	return &syscall.Timeval{
+		Sec:  int64(t.Unix()),
+		Usec: int64(t.UnixNano() / 1000 % 1000),
+	}
+}

--- a/osutil/settime_64bit.go
+++ b/osutil/settime_64bit.go
@@ -35,6 +35,6 @@ func init() {
 func timeToTimeval64(t time.Time) *syscall.Timeval {
 	return &syscall.Timeval{
 		Sec:  int64(t.Unix()),
-		Usec: int64(t.UnixNano() / 1000 % 1000),
+		Usec: int64(t.Nanosecond() / 1000),
 	}
 }

--- a/osutil/settime_test.go
+++ b/osutil/settime_test.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"syscall"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type settimeTestSuite struct{}
+
+var _ = Suite(&settimeTestSuite{})
+
+func (s *settimeTestSuite) TestSetTime(c *C) {
+	timeIn, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Mon Jan 2 15:04:05 -0700 MST 2006")
+	c.Assert(err, IsNil)
+
+	r := osutil.MockSyscallSettimeofday(func(t *syscall.Timeval) error {
+		c.Assert(int64(t.Sec), Equals, timeIn.Unix())
+		c.Assert(int64(t.Usec), Equals, timeIn.UnixNano()/1000%1000)
+		return nil
+	})
+	defer r()
+
+	err = osutil.SetTime(timeIn)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Based on top of https://github.com/snapcore/snapd/pull/9973

Move the time of the system forward in the initrd monotonically, using a kernel
initrd timestamp file which will be included in the filesystem of the initrd and
is thus signed/trusted, as well as using the modification time of the systems
directory in ubuntu-seed.

Don't move the time forward at all if we don't have the kernel initrd timestamp
file to protect against doing anything unexpected on old kernels that happen to
get built with this version of snap-bootstrap, and also don't ever move the time
backwards if the current time the kernel already has is newer than the 
timestamps in the initrd file or the ubuntu-seed systems directory.

Partially fixes: https://bugs.launchpad.net/snapd/+bug/1878422

Marking as blocked until we have agreement on which file in the initrd we should
check, I used `/var/lib/systemd/timesync/clock` since that's what systemd uses 
with timesyncd, but timesyncd is not actually shipped in the initrd, so maybe it makes
sense to use some other snapd or ubuntu specific time file. Then we wouldn't be
confusing folks who see this file in the initrd but don't see the systemd.timesync 
service.

