### PR TITLE
bootloader/lkenv: add recovery systems related variables

### DIFF
--- a/bootloader/lkenv/lkenv_test.go
+++ b/bootloader/lkenv/lkenv_test.go
@@ -216,9 +216,11 @@ func (l *lkenvTestSuite) TestSave(c *C) {
 		{
 			lkenv.V2Recovery,
 			map[string]string{
-				"snapd_recovery_mode":   "recover",
-				"snapd_recovery_system": "11192020",
-				"bootimg_file_name":     "boot.img",
+				"snapd_recovery_mode":    "recover",
+				"snapd_recovery_system":  "11192020",
+				"bootimg_file_name":      "boot.img",
+				"try_recovery_system":    "1234",
+				"recovery_system_status": "tried",
 			},
 			"lkenv v2 recovery",
 		},

--- a/bootloader/lkenv/lkenv_v2.go
+++ b/bootloader/lkenv/lkenv_v2.go
@@ -101,6 +101,19 @@ type SnapBootSelect_v2_recovery struct {
 	when not defined or empty, default boot.img will be used */
 	Bootimg_file_name [SNAP_FILE_NAME_MAX_LEN]byte
 
+	/** try_recovery_system contains the label of a recovery system to be
+	 *  tried. This entry is completely transparent to the bootloader and is
+	 *  only modified by snapd or snap-bootstrap.
+	 */
+	Try_recovery_system [SNAP_FILE_NAME_MAX_LEN]byte
+
+	/** recovery_system_status contains the status of a tried recovery
+	 *  systems, which is one of "", "try", "tried". This entry is completely
+	 *  transparent to the bootloader and is only modified by snapd or
+	 *  snap-bootstrap
+	 */
+	Recovery_system_status [SNAP_FILE_NAME_MAX_LEN]byte
+
 	/* unused placeholders for additional parameters in the future */
 	Unused_key_01 [SNAP_FILE_NAME_MAX_LEN]byte
 	Unused_key_02 [SNAP_FILE_NAME_MAX_LEN]byte
@@ -120,8 +133,6 @@ type SnapBootSelect_v2_recovery struct {
 	Unused_key_16 [SNAP_FILE_NAME_MAX_LEN]byte
 	Unused_key_17 [SNAP_FILE_NAME_MAX_LEN]byte
 	Unused_key_18 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_19 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_20 [SNAP_FILE_NAME_MAX_LEN]byte
 
 	/* unused array of 10 key value pairs */
 	Key_value_pairs [10][2][SNAP_FILE_NAME_MAX_LEN]byte
@@ -149,6 +160,10 @@ func (v2recovery *SnapBootSelect_v2_recovery) get(key string) string {
 		return cToGoString(v2recovery.Snapd_recovery_system[:])
 	case "bootimg_file_name":
 		return cToGoString(v2recovery.Bootimg_file_name[:])
+	case "try_recovery_system":
+		return cToGoString(v2recovery.Try_recovery_system[:])
+	case "recovery_system_status":
+		return cToGoString(v2recovery.Recovery_system_status[:])
 	}
 	return ""
 }
@@ -161,6 +176,10 @@ func (v2recovery *SnapBootSelect_v2_recovery) set(key, value string) {
 		copyString(v2recovery.Snapd_recovery_system[:], value)
 	case "bootimg_file_name":
 		copyString(v2recovery.Bootimg_file_name[:], value)
+	case "try_recovery_system":
+		copyString(v2recovery.Try_recovery_system[:], value)
+	case "recovery_system_status":
+		copyString(v2recovery.Recovery_system_status[:], value)
 	}
 }
 

--- a/include/lk/snappy_boot_v2.h
+++ b/include/lk/snappy_boot_v2.h
@@ -196,6 +196,19 @@ typedef struct SNAP_RECOVERY_BOOT_SELECTION {
        when not defined or empty, default boot.img will be used */
     char bootimg_file_name[SNAP_NAME_MAX_LEN];
 
+    /** try_recovery_system contains the label of a recovery system to be
+     *  tried. This entry is completely transparent to the bootloader and is
+     *  only modified by snapd or snap-bootstrap.
+     */
+    char try_recovery_system[SNAP_NAME_MAX_LEN];
+
+    /** recovery_system_status contains the status of a tried recovery
+     *  systems, which is one of "", "try", "tried". This entry is completely
+     *  transparent to the bootloader and is only modified by snapd or
+     *  snap-bootstrap
+     */
+    char recovery_system_status[SNAP_NAME_MAX_LEN];
+
     /* unused placeholders for additional parameters to be used  in the future */
     char unused_key_01[SNAP_NAME_MAX_LEN];
     char unused_key_02[SNAP_NAME_MAX_LEN];
@@ -215,8 +228,6 @@ typedef struct SNAP_RECOVERY_BOOT_SELECTION {
     char unused_key_16[SNAP_NAME_MAX_LEN];
     char unused_key_17[SNAP_NAME_MAX_LEN];
     char unused_key_18[SNAP_NAME_MAX_LEN];
-    char unused_key_19[SNAP_NAME_MAX_LEN];
-    char unused_key_20[SNAP_NAME_MAX_LEN];
 
     /* unused array of 10 key - value pairs */
     char key_value_pairs[10][2][SNAP_NAME_MAX_LEN];


### PR DESCRIPTION
Add try_recovery_system and recovery_system_status to the boot variables tracked inside
little kernel bootloader's environment.

As suggested in https://github.com/snapcore/snapd/pull/9942#discussion_r583916600