### PR TITLE
asserts: use Fetcher in AddSequenceToUpdate

### DIFF
--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -624,21 +624,12 @@ func (p *Pool) Add(a Assertion, grouping Grouping) (ok bool, err error) {
 func (p *Pool) addToGrouping(a Assertion, grouping Grouping, deserializeGrouping func(string) (*internal.Grouping, error)) (ok bool, err error) {
 	var uniq string
 	ref := a.Ref()
-	// deal with sequence key
-	if !ref.Type.SequenceForming() {
-		uniq = ref.Unique()
-	} else {
-		atseq := AtSequence{
-			Type:        ref.Type,
-			SequenceKey: ref.PrimaryKey[:len(ref.PrimaryKey)-1],
-		}
-		uniq = atseq.Unique()
-	}
 	var u unresolvedAssertRecord
 	var extrag *internal.Grouping
 	var unresolved map[string]unresolvedAssertRecord
 
 	if !ref.Type.SequenceForming() {
+		uniq = ref.Unique()
 		if u = p.unresolved[uniq]; u != nil {
 			unresolved = p.unresolved
 		} else if u = p.prerequisites[uniq]; u != nil {
@@ -665,6 +656,11 @@ func (p *Pool) addToGrouping(a Assertion, grouping Grouping, deserializeGrouping
 			u = rec
 		}
 	} else {
+		atseq := AtSequence{
+			Type:        ref.Type,
+			SequenceKey: ref.PrimaryKey[:len(ref.PrimaryKey)-1],
+		}
+		uniq = atseq.Unique()
 		if u = p.unresolvedSequences[uniq]; u != nil {
 			unresolved = p.unresolvedSequences
 		} else {

--- a/asserts/pool_test.go
+++ b/asserts/pool_test.go
@@ -563,6 +563,7 @@ func (s *poolSuite) TestPushSuggestionForNewSeqForming(c *C) {
 	a, err := s.seq2_1111r7.Ref().Resolve(s.db.Find)
 	c.Assert(err, IsNil)
 	c.Check(a.(*asserts.TestOnlySeq).N(), Equals, "1111")
+	c.Check(a.Revision(), Equals, 7)
 }
 
 func (s *poolSuite) TestPushSuggestionForNewViaBatch(c *C) {
@@ -755,7 +756,7 @@ func (s *poolSuite) TestAddCurrentRevision(c *C) {
 	c.Check(toResolveSeq, HasLen, 0)
 
 	// re-adding of current revisions, is not what we expect
-	// but needs not to produce unneeded roundtrips
+	// but needs to not produce unnecessary roundtrips
 
 	ok, err := pool.Add(s.hub.StoreAccountKey(""), asserts.MakePoolGrouping(0))
 	c.Assert(err, IsNil)
@@ -805,7 +806,7 @@ func (s *poolSuite) TestAddCurrentRevisionSeqForming(c *C) {
 	})
 
 	// re-adding of current revisions, is not what we expect
-	// but needs not to produce unneeded roundtrips
+	// but needs to not produce unnecessary roundtrips
 
 	ok, err := pool.Add(s.hub.StoreAccountKey(""), asserts.MakePoolGrouping(0))
 	c.Assert(err, IsNil)
@@ -886,8 +887,8 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedNewerSequence(c *C) {
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
 		SequenceKey: []string{"1111"},
-		Sequence:    s.seq1_1111r5.Sequence(),
-		Revision:    s.seq1_1111r5.Revision(),
+		Sequence:    1,
+		Revision:    5,
 	}
 	err := pool.AddSequenceToUpdate(atseq, "for_one") // group num: 0
 	c.Assert(err, IsNil)
@@ -909,7 +910,7 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedNewerSequence(c *C) {
 
 	c.Check(pool.Err("for_one"), IsNil)
 
-	// resolve
+	// resolve with sequence 3
 	ok, err := pool.Add(s.seq3_1111r5, asserts.MakePoolGrouping(0))
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)
@@ -942,8 +943,8 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedSameSequenceNewerRev(c *C) {
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
 		SequenceKey: []string{"1111"},
-		Sequence:    s.seq1_1111r5.Sequence(),
-		Revision:    s.seq1_1111r5.Revision(),
+		Sequence:    1,
+		Revision:    5,
 	}
 	err := pool.AddSequenceToUpdate(atseq, "for_one") // group num: 0
 	c.Assert(err, IsNil)
@@ -998,8 +999,8 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedSameSequenceSameRevNoop(c *C) {
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
 		SequenceKey: []string{"1111"},
-		Sequence:    s.seq1_1111r5.Sequence(),
-		Revision:    s.seq1_1111r5.Revision(),
+		Sequence:    1,
+		Revision:    5,
 	}
 	err := pool.AddSequenceToUpdate(atseq, "for_one") // group num: 0
 	c.Assert(err, IsNil)
@@ -1049,8 +1050,8 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceSameRevisionNoop(c *C
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
 		SequenceKey: []string{"1111"},
-		Sequence:    s.seq1_1111r5.Sequence(),
-		Revision:    s.seq1_1111r5.Revision(),
+		Sequence:    1,
+		Revision:    5,
 		Pinned:      true,
 	}
 	err := pool.AddSequenceToUpdate(atseq, "for_one") // group num: 0
@@ -1106,8 +1107,8 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceNewerRevisionNoop(c *
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
 		SequenceKey: []string{"1111"},
-		Sequence:    s.seq1_1111r5.Sequence(),
-		Revision:    s.seq1_1111r5.Revision(),
+		Sequence:    1,
+		Revision:    5,
 		Pinned:      true,
 	}
 	err := pool.AddSequenceToUpdate(atseq, "for_one") // group num: 0
@@ -1151,14 +1152,13 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceNewerRevisionNoop(c *
 
 func (s *poolSuite) TestUpdateSeqFormingPinnedSameSequenceNewerRevision(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
-
 	pool := asserts.NewPool(s.db, 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
 		SequenceKey: []string{"1111"},
-		Sequence:    s.seq1_1111r5.Sequence(),
-		Revision:    s.seq1_1111r5.Revision(),
+		Sequence:    1,
+		Revision:    5,
 		Pinned:      true,
 	}
 	err := pool.AddSequenceToUpdate(atseq, "for_one") // group num: 0
@@ -1169,7 +1169,6 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedSameSequenceNewerRevision(c *C) {
 	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
 		asserts.MakePoolGrouping(0): {s.hub.StoreAccountKey(s.dev1Acct.SignKeyID()).At()},
 	})
-	//c.Check(toResolve, HasLen, 0)
 	c.Check(toResolveSeq, DeepEquals, map[asserts.Grouping][]*asserts.AtSequence{
 		asserts.MakePoolGrouping(0): {
 			&asserts.AtSequence{

--- a/asserts/pool_test.go
+++ b/asserts/pool_test.go
@@ -894,7 +894,9 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedNewerSequence(c *C) {
 
 	toResolve, toResolveSeq, err := pool.ToResolve()
 	c.Assert(err, IsNil)
-	c.Check(toResolve, HasLen, 0)
+	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
+		asserts.MakePoolGrouping(0): {s.hub.StoreAccountKey(s.dev1Acct.SignKeyID()).At()},
+	})
 	c.Check(toResolveSeq, DeepEquals, map[asserts.Grouping][]*asserts.AtSequence{
 		asserts.MakePoolGrouping(0): {
 			&asserts.AtSequence{
@@ -915,9 +917,7 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedNewerSequence(c *C) {
 	toResolve, toResolveSeq, err = pool.ToResolve()
 	c.Assert(err, IsNil)
 
-	storeKey := s.hub.StoreAccountKey("")
-	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
-		asserts.MakePoolGrouping(0): {storeKey.At()}})
+	c.Check(toResolve, HasLen, 0)
 	c.Check(toResolveSeq, HasLen, 0)
 	c.Check(pool.Err("for_one"), IsNil)
 
@@ -950,7 +950,9 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedSameSequenceNewerRev(c *C) {
 
 	toResolve, toResolveSeq, err := pool.ToResolve()
 	c.Assert(err, IsNil)
-	c.Check(toResolve, HasLen, 0)
+	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
+		asserts.MakePoolGrouping(0): {s.hub.StoreAccountKey(s.dev1Acct.SignKeyID()).At()},
+	})
 	c.Check(toResolveSeq, DeepEquals, map[asserts.Grouping][]*asserts.AtSequence{
 		asserts.MakePoolGrouping(0): {
 			&asserts.AtSequence{
@@ -971,9 +973,7 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedSameSequenceNewerRev(c *C) {
 	toResolve, toResolveSeq, err = pool.ToResolve()
 	c.Assert(err, IsNil)
 
-	storeKey := s.hub.StoreAccountKey("")
-	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
-		asserts.MakePoolGrouping(0): {storeKey.At()}})
+	c.Check(toResolve, HasLen, 0)
 	c.Check(toResolveSeq, HasLen, 0)
 	c.Check(pool.Err("for_one"), IsNil)
 
@@ -1006,7 +1006,9 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedSameSequenceSameRevNoop(c *C) {
 
 	toResolve, toResolveSeq, err := pool.ToResolve()
 	c.Assert(err, IsNil)
-	c.Check(toResolve, HasLen, 0)
+	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
+		asserts.MakePoolGrouping(0): {s.hub.StoreAccountKey(s.dev1Acct.SignKeyID()).At()},
+	})
 	c.Check(toResolveSeq, DeepEquals, map[asserts.Grouping][]*asserts.AtSequence{
 		asserts.MakePoolGrouping(0): {
 			&asserts.AtSequence{
@@ -1056,7 +1058,9 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceSameRevisionNoop(c *C
 
 	toResolve, toResolveSeq, err := pool.ToResolve()
 	c.Assert(err, IsNil)
-	c.Check(toResolve, HasLen, 0)
+	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
+		asserts.MakePoolGrouping(0): {s.hub.StoreAccountKey(s.dev1Acct.SignKeyID()).At()},
+	})
 	c.Check(toResolveSeq, DeepEquals, map[asserts.Grouping][]*asserts.AtSequence{
 		asserts.MakePoolGrouping(0): {
 			&asserts.AtSequence{
@@ -1111,7 +1115,9 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceNewerRevisionNoop(c *
 
 	toResolve, toResolveSeq, err := pool.ToResolve()
 	c.Assert(err, IsNil)
-	c.Check(toResolve, HasLen, 0)
+	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
+		asserts.MakePoolGrouping(0): {s.hub.StoreAccountKey(s.dev1Acct.SignKeyID()).At()},
+	})
 	c.Check(toResolveSeq, DeepEquals, map[asserts.Grouping][]*asserts.AtSequence{
 		asserts.MakePoolGrouping(0): {
 			&asserts.AtSequence{
@@ -1160,7 +1166,10 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedSameSequenceNewerRevision(c *C) {
 
 	toResolve, toResolveSeq, err := pool.ToResolve()
 	c.Assert(err, IsNil)
-	c.Check(toResolve, HasLen, 0)
+	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
+		asserts.MakePoolGrouping(0): {s.hub.StoreAccountKey(s.dev1Acct.SignKeyID()).At()},
+	})
+	//c.Check(toResolve, HasLen, 0)
 	c.Check(toResolveSeq, DeepEquals, map[asserts.Grouping][]*asserts.AtSequence{
 		asserts.MakePoolGrouping(0): {
 			&asserts.AtSequence{
@@ -1186,6 +1195,38 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedSameSequenceNewerRevision(c *C) {
 	// sequence point 1, revision 6 is in db.
 	_, err = s.seq1_1111r6.Ref().Resolve(s.db.Find)
 	c.Assert(err, IsNil)
+}
+
+func (s *poolSuite) TestUpdateSeqFormingUseAssertRevision(c *C) {
+	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
+
+	pool := asserts.NewPool(s.db, 64)
+
+	atseq := &asserts.AtSequence{
+		Type:        s.seq1_1111r5.Type(),
+		SequenceKey: []string{"1111"},
+		Sequence:    1,
+		Revision:    0, // intentionaly unset
+	}
+	err := pool.AddSequenceToUpdate(atseq, "for_one") // group num: 0
+	c.Assert(err, IsNil)
+
+	toResolve, toResolveSeq, err := pool.ToResolve()
+	c.Assert(err, IsNil)
+	c.Check(toResolve, DeepEquals, map[asserts.Grouping][]*asserts.AtRevision{
+		asserts.MakePoolGrouping(0): {s.hub.StoreAccountKey(s.dev1Acct.SignKeyID()).At()},
+	})
+
+	// verify that revision number from the existing assertion to update was used.
+	c.Check(toResolveSeq, DeepEquals, map[asserts.Grouping][]*asserts.AtSequence{
+		asserts.MakePoolGrouping(0): {
+			&asserts.AtSequence{
+				Type:        s.seq1_1111r5.Type(),
+				SequenceKey: []string{"1111"},
+				Sequence:    1,
+				Revision:    5,
+			}},
+	})
 }
 
 func (s *poolSuite) TestAddSequenceToUpdateMissingSequenceError(c *C) {
@@ -1251,6 +1292,7 @@ func (s *poolSuite) TestAddUnresolvedSeqOnce(c *C) {
 }
 
 func (s *poolSuite) TestAddSeqToUpdateOnce(c *C) {
+	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
 	pool := asserts.NewPool(s.db, 64)
 
 	atseq := &asserts.AtSequence{
@@ -1266,6 +1308,19 @@ func (s *poolSuite) TestAddSeqToUpdateOnce(c *C) {
 	atseq.Revision = 3
 	err = pool.AddSequenceToUpdate(atseq, "for_one")
 	c.Assert(err, ErrorMatches, `internal error: sequence \[1111\] is already being resolved`)
+}
+
+func (s *poolSuite) TestAddSeqToUpdateNotFound(c *C) {
+	pool := asserts.NewPool(s.db, 64)
+
+	atseq := &asserts.AtSequence{
+		Type:        s.seq1_1111r5.Type(),
+		SequenceKey: []string{"1111"},
+		Revision:    2,
+		Sequence:    1,
+	}
+	err := pool.AddSequenceToUpdate(atseq, "for_one")
+	c.Assert(asserts.IsNotFound(err), Equals, true)
 }
 
 var errBoom = errors.New("boom")


### PR DESCRIPTION
Use Fetcher in AddSequenceToUpdate. Fix addUnresolvedSeq not returning error. Also addresses some cleanups suggested by @anonymouse64 in #9930 

This replaces #9964 to have clean history.
