### PR TITLE
cmd/recovery: small fix for `snap recovery` tab output

### DIFF
--- a/cmd/snap/cmd_recovery.go
+++ b/cmd/snap/cmd_recovery.go
@@ -100,7 +100,7 @@ func (x *cmdRecovery) Execute(args []string) error {
 		return nil
 	}
 
-	fmt.Fprintf(w, i18n.G("Label\tBrand\tModel\tNotes\n"))
+	fmt.Fprintf(w, i18n.G("Label\tBrand%s\tModel\tNotes\n"), fillerPublisher(esc))
 	for _, sys := range systems {
 		// doing it this way because otherwise it's a sea of %s\t%s\t%s
 		line := []string{


### PR DESCRIPTION
Fixes tab output error in 'snap recovery' (due to potential special character) by adding call to _fillerPublisher_ function.

Old output:
```
$ sudo snap recovery
Label     Brand                Model                      Notes
20201202  canonical✓  ubuntu-core-20-amd64-beta  current
```

New output:
```
$ sudo ./snap.new recovery
Label     Brand       Model                      Notes
20201202  canonical✓  ubuntu-core-20-amd64-beta  current
```