### PR TITLE
boot/flags.go: add SetNextBootFlags, NextBootFlags for snapd_next_boot_flags bootenv

### DIFF
--- a/boot/flags.go
+++ b/boot/flags.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/bootloader"
+)
+
+func blForDev(dev Device) (bootloader.Bootloader, error) {
+	opts := &bootloader.Options{}
+	dir := ""
+	if dev.RunMode() {
+		opts.Role = bootloader.RoleRunMode
+	} else {
+		opts.Role = bootloader.RoleRecovery
+		// meh this isn't being used in the initramfs but it's probably fine
+		dir = InitramfsUbuntuSeedDir
+	}
+
+	return bootloader.Find(dir, opts)
+}
+// NextBootFlags returns the set of boot flags for the current active boot and
+// possibly for the next boot. By default, the flags should only be used on one
+// boot ever after being set and the system being rebooted with the flags
+// cleared by snapd in userspace when that boot happens. The mode parameter is
+// necessary to determine the current active bootloader. Only to be used on
+// UC20+ on systems with recovery systems.
+func NextBootFlags(dev Device) ([]string, error) {
+	if !dev.HasModeenv() {
+		return nil, fmt.Errorf("cannot get boot flags on non-UC20 device")
+	}
+
+	bl, err := blForDev(dev)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := bl.GetBootVars("snapd_next_boot_flags")
+	if err != nil {
+		return nil, err
+	}
+
+	// remove empty flags from the bootenv
+	flags := []string{}
+	for _, flag := range strings.Split(m["snapd_next_boot_flags"], ",") {
+		if flag != "" {
+			flags = append(flags, flag)
+		}
+	}
+
+	// TODO: is this the right format? (comma separated values)
+	return flags, nil
+}

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -1,0 +1,149 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/boot/boottest"
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/grubenv"
+	"github.com/snapcore/snapd/dirs"
+	. "gopkg.in/check.v1"
+)
+
+type bootFlagsSuite struct {
+	baseBootenvSuite
+}
+
+var _ = Suite(&bootFlagsSuite{})
+
+func (s *bootFlagsSuite) TestNextBootFlagsClassic(c *C) {
+	classicDev := boottest.MockDevice("")
+
+	// make bootloader.Find fail but shouldn't matter
+	bootloader.ForceError(errors.New("broken bootloader"))
+	defer bootloader.ForceError(nil)
+
+	_, err := boot.NextBootFlags(classicDev)
+	c.Assert(err, ErrorMatches, "cannot get boot flags on non-UC20 device")
+}
+
+func (s *bootFlagsSuite) TestNextBootFlagsUC16(c *C) {
+	coreDev := boottest.MockDevice("some-snap")
+
+	// make bootloader.Find fail but shouldn't matter
+	bootloader.ForceError(errors.New("broken bootloader"))
+	defer bootloader.ForceError(nil)
+
+	_, err := boot.NextBootFlags(coreDev)
+	c.Assert(err, ErrorMatches, "cannot get boot flags on non-UC20 device")
+}
+
+func setupRealGrub(c *C, rootDir, baseDir string, opts *bootloader.Options) bootloader.Bootloader {
+	if rootDir == "" {
+		rootDir = dirs.GlobalRootDir
+	}
+	grubCfg := filepath.Join(rootDir, baseDir, "grub.cfg")
+	err := os.MkdirAll(filepath.Dir(grubCfg), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(grubCfg, nil, 0644)
+	c.Assert(err, IsNil)
+
+	genv := grubenv.NewEnv(filepath.Join(rootDir, baseDir, "grubenv"))
+	err = genv.Save()
+	c.Assert(err, IsNil)
+
+	grubBl, err := bootloader.Find(rootDir, opts)
+	c.Assert(err, IsNil)
+	c.Assert(grubBl.Name(), Equals, "grub")
+
+	return grubBl
+}
+
+func (s *bootFlagsSuite) TestNextBootFlagsUC20Happy(c *C) {
+
+	tt := []struct {
+		mode      string
+		blDirFunc func() string
+		baseDir   string
+		blOpts    *bootloader.Options
+	}{
+		{
+			mode:    boot.ModeRun,
+			baseDir: "boot/grub",
+		},
+		{
+			mode:      boot.ModeRecover,
+			blDirFunc: func() string { return boot.InitramfsUbuntuSeedDir },
+			baseDir:   "EFI/ubuntu",
+			blOpts:    &bootloader.Options{Role: bootloader.RoleRecovery},
+		},
+		{
+			mode:      boot.ModeInstall,
+			blDirFunc: func() string { return boot.InitramfsUbuntuSeedDir },
+			baseDir:   "EFI/ubuntu",
+			blOpts:    &bootloader.Options{Role: bootloader.RoleRecovery},
+		},
+	}
+	for _, t := range tt {
+		dir := c.MkDir()
+
+		dirs.SetRootDir(dir)
+		defer func() { dirs.SetRootDir("") }()
+
+		// mock a grubenv bootloader on the specified dir, this allows us to
+		// more specifically test that the right options are passed down from
+		// NextBootFlags to find the right bootloader
+
+		blDir := dirs.GlobalRootDir
+		if t.blDirFunc != nil {
+			blDir = t.blDirFunc()
+		}
+
+		grubBl := setupRealGrub(c, blDir, t.baseDir, t.blOpts)
+
+		coreDev := boottest.MockDevice("some-snap@" + t.mode)
+
+		flags, err := boot.NextBootFlags(coreDev)
+		c.Assert(err, IsNil)
+		c.Assert(flags, HasLen, 0)
+
+		err = grubBl.SetBootVars(map[string]string{"snapd_next_boot_flags": "factory"})
+		c.Assert(err, IsNil)
+
+		// if we set some flags then we get them back
+		flags, err = boot.NextBootFlags(coreDev)
+		c.Assert(err, IsNil)
+		c.Assert(flags, DeepEquals, []string{"factory"})
+
+		err = grubBl.SetBootVars(map[string]string{"snapd_next_boot_flags": "some-other,factory,"})
+		c.Assert(err, IsNil)
+
+		flags, err = boot.NextBootFlags(coreDev)
+		c.Assert(err, IsNil)
+		c.Assert(flags, DeepEquals, []string{"some-other", "factory"})
+	}
+}


### PR DESCRIPTION
This function will be used by snap system-mode to get the current boot flags
from the bootenv - which may be for this current boot or may be for the next
boot depending on the context in which the function is called.

The only current flag we will support is "factory", but to be robust, this var
can be a comma separated list, but with the caveat that it should be kept to the
maximum length of a lk bootenv variable value which is 256 characters (including
a NUL at the end).

The "factory" boot flag will mainly be set from ubuntu-image, and be cleared
during install mode at the end.

Alternatively to this PR, we could get rid of these helpers and manually manipulate 
the bootenv from the appropriate locations...