### PR TITLE
o/snapshotstate: create snapshots directory on import

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -666,6 +666,10 @@ type ImportFlags struct {
 
 // Import a snapshot from the export file format
 func Import(ctx context.Context, id uint64, r io.Reader, flags *ImportFlags) (snapNames []string, err error) {
+	if err := os.MkdirAll(dirs.SnapshotsDir, 0700); err != nil {
+		return nil, err
+	}
+
 	errPrefix := fmt.Sprintf("cannot import snapshot %d", id)
 
 	tr := newImportTransaction(id)

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -938,10 +938,10 @@ func (s *snapshotSuite) TestImport(c *check.C) {
 		// reset
 		err = os.RemoveAll(dirs.SnapshotsDir)
 		c.Assert(err, check.IsNil, comm)
-		err := os.MkdirAll(dirs.SnapshotsDir, 0700)
-		c.Assert(err, check.IsNil, comm)
 		importingFile := filepath.Join(dirs.SnapshotsDir, fmt.Sprintf("%d_importing", t.setID))
 		if t.inProgress {
+			err := os.MkdirAll(dirs.SnapshotsDir, 0700)
+			c.Assert(err, check.IsNil, comm)
 			err = ioutil.WriteFile(importingFile, nil, 0644)
 			c.Assert(err, check.IsNil)
 		} else {

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -84,6 +84,11 @@ execute: |
     [[ "$RESTORE_ID" == "$IMPORTED_ID" ]]
     [[ "$NUM_SAVED" == $(snap saved | wc -l) ]]
 
+    snap forget "$RESTORE_ID"
+    echo "Import re-creates snapshots directory if misssing"
+    rm -rf /var/lib/snapd/snapshots
+    RESTORE_ID=$( snap import-snapshot "${SET_ID}_export.snapshot" | head -n1 | cut -f2 -d'#' )
+
     # remove the exports and import
     rm "${SET_ID}"_export*.snapshot
     snap forget "$RESTORE_ID"

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -86,6 +86,8 @@ execute: |
 
     snap forget "$RESTORE_ID"
     echo "Import re-creates snapshots directory if misssing"
+    # sanity check
+    test -d /var/lib/snapd/snapshots
     rm -rf /var/lib/snapd/snapshots
     RESTORE_ID=$( snap import-snapshot "${SET_ID}_export.snapshot" | head -n1 | cut -f2 -d'#' )
 


### PR DESCRIPTION
Create snapshots directory (in case it doesn't exist, which is a case on a virgin device) on import.

Fixes LP: #1917617

