### PR TITLE
tests/main/lxd/prep-snapd-in-lxd.sh: dump contents of sources.list

### DIFF
--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -21,11 +21,14 @@ for _ in $(seq 1 60); do
     sleep 1
 done
 
+cat /etc/apt/sources.list
 apt autoremove --purge -y snapd ubuntu-core-launcher
+cat /etc/apt/sources.list
 apt update
 
 # requires the snapd deb to already have been "lxd file push"d into the 
 # container
+cat /etc/apt/sources.list
 apt install -y /root/snapd_*.deb
 
 # reload to take effect of the proxy that may have been set before this script


### PR DESCRIPTION
We _still_ continue to see errors like
```
+ apt update

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

E: Type 'xenial-security' is not known on line 50 in source list /etc/apt/sources.list
E: The list of sources could not be read.
```
executing this test, so rather than just be confused about what apt says is
wrong about the file, instead just dump that file before every apt operation, in
the hopes that it eventually fails again and we can see what the output was
right before the apt operation fails.