### PR TITLE
snapstate: error is "snap refresh" has no updates because of conflicts

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1281,7 +1281,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 	if refreshAll && len(tasksets) == 0 {
 		for _, err := range updateErrs {
 			if _, ok := err.(*ChangeConflictError); ok {
-				return nil, nil, &ChangeConflictError{ChangeKind: "refresh", Message: "auto-refresh has conflicting changes in progress"}
+				return nil, nil, &ChangeConflictError{Message: "auto-refresh has conflicting changes in progress"}
 			}
 		}
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1230,7 +1230,6 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 		ts, err := doInstall(st, snapst, snapsup, 0, fromChange, inUseFor(deviceCtx))
 		if err != nil {
 			if refreshAll {
-				// XXX: should this be a map instead?
 				updateErrs = append(updateErrs, err)
 				// doing "refresh all", just skip this snap
 				logger.Noticef("cannot refresh snap %q: %v", update.InstanceName(), err)
@@ -1276,12 +1275,13 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 		updated = append(updated, name)
 	}
 
-	// Report a useful error if nothing can be updated and we have at
-	// least one auto-refresh change in progress.
+	// Report a useful error for auto-refresh if nothing can be
+	// updated and we have at least one conflicting change in
+	// progress.
 	if refreshAll && len(tasksets) == 0 {
 		for _, err := range updateErrs {
 			if _, ok := err.(*ChangeConflictError); ok {
-				return nil, nil, fmt.Errorf("auto-refresh has conflicting changes in progress")
+				return nil, nil, &ChangeConflictError{ChangeKind: "refresh", Message: "auto-refresh has conflicting changes in progress"}
 			}
 		}
 	}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -5336,8 +5336,8 @@ func (s *snapmgrTestSuite) TestStopSnapServicesFirstSavesSnapSetupLastActiveDisa
 		Sequence: []*snap.SideInfo{
 			{RealName: "services-snap", Revision: snap.R(11)},
 		},
-		Current:                    snap.R(11),
-		Active:                     true,
+		Current: snap.R(11),
+		Active:  true,
 		LastActiveDisabledServices: []string{"svc2"},
 	})
 


### PR DESCRIPTION
When a `snap refresh` is running a subsequent `snap refresh`
will report:
```
All snaps are up to date.
```

This is misleading and caused confusion and bugreports by
customers.

This PR fixes this by reporting that some refreshes could not be
done because of conflicting changes. Something like:
```
error: cannot refresh: auto-refresh has conflicting changes in progress
```

Happy to tweak the message.

