### PR TITLE
tests: turn modules off explicitly in spread go unti test (2.49)

### DIFF
--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -31,7 +31,6 @@ execute: |
         ./run-checks --static" test
 
     su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
-        TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST \
         PATH=$PATH \
         GOPATH=/tmp/static-unit-tests \
         SKIP_COVERAGE=1 \

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -26,11 +26,14 @@ execute: |
     fi
 
     su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
-        PATH=$PATH GOPATH=/tmp/static-unit-tests \
+        GO111MODULE=off \
+        PATH=$PATH \
+        GOPATH=/tmp/static-unit-tests \
         ${skip:-} \
         ./run-checks --static" test
 
     su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
+        GO111MODULE=off\
         PATH=$PATH \
         GOPATH=/tmp/static-unit-tests \
         SKIP_COVERAGE=1 \

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -31,17 +31,8 @@ execute: |
         ./run-checks --static" test
 
     su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
-        TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER \
-        TRAVIS_BRANCH=$TRAVIS_BRANCH \
-        TRAVIS_COMMIT=$TRAVIS_COMMIT \
-        TRAVIS_JOB_NUMBER=$TRAVIS_JOB_NUMBER \
         TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST \
-        TRAVIS_JOB_ID=$TRAVIS_JOB_ID \
-        TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG \
-        TRAVIS_TAG=$TRAVIS_TAG \
         PATH=$PATH \
-        COVERMODE=$COVERMODE \
-        TRAVIS=true \
-        CI=true \
         GOPATH=/tmp/static-unit-tests \
+        SKIP_COVERAGE=1 \
         ./run-checks --unit" test


### PR DESCRIPTION
This is a backport of PR#9979 to 2.49. The second commit did not cleanly cherry-pick so I included the relevant parts.

Pushing as a PR to get a full spread run to ensure there are no other test fixes missing for 2.49