### PR TITLE
client: protect against reading too much data from stdin

### DIFF
--- a/client/export_test.go
+++ b/client/export_test.go
@@ -53,3 +53,11 @@ func UnmarshalSnapshotAction(body io.Reader) (act snapshotAction, err error) {
 }
 
 type DownloadAction = downloadAction
+
+func MockStdinReadLimit(new int64) (restore func()) {
+	oldStdinReadLimit := stdinReadLimit
+	stdinReadLimit = new
+	return func() {
+		stdinReadLimit = oldStdinReadLimit
+	}
+}

--- a/client/snapctl.go
+++ b/client/snapctl.go
@@ -71,13 +71,13 @@ func (client *Client) RunSnapctl(options *SnapCtlOptions, stdin io.Reader) (stdo
 	//       the daemon eventually
 	var stdinData []byte
 	if stdin != nil {
-		limitedStdin := &io.LimitedReader{R: stdin, N: stdinReadLimit}
+		limitedStdin := &io.LimitedReader{R: stdin, N: stdinReadLimit + 1}
 		stdinData, err = ioutil.ReadAll(limitedStdin)
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot read stdin: %v", err)
 		}
 		if limitedStdin.N <= 0 {
-			return nil, nil, fmt.Errorf("cannot read more than %v bytes of data from stdin", stdinReadLimit-1)
+			return nil, nil, fmt.Errorf("cannot read more than %v bytes of data from stdin", stdinReadLimit)
 		}
 	}
 

--- a/client/snapctl_test.go
+++ b/client/snapctl_test.go
@@ -83,7 +83,7 @@ func (cs *clientSuite) TestInternalSnapctlCmdNeedsStdin(c *check.C) {
 	}
 }
 
-func (cs *clientSuite) TestClientRunSnapctlReadLimit(c *check.C) {
+func (cs *clientSuite) TestClientRunSnapctlReadLimitOneTooMuch(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
         "status-code": 200,
@@ -91,7 +91,7 @@ func (cs *clientSuite) TestClientRunSnapctlReadLimit(c *check.C) {
 		}
 	}`
 
-	restore := client.MockStdinReadLimit(11)
+	restore := client.MockStdinReadLimit(10)
 	defer restore()
 
 	mockStdin := bytes.NewBufferString("12345678901")
@@ -102,4 +102,25 @@ func (cs *clientSuite) TestClientRunSnapctlReadLimit(c *check.C) {
 
 	_, _, err := cs.cli.RunSnapctl(options, mockStdin)
 	c.Check(err, check.ErrorMatches, "cannot read more than 10 bytes of data from stdin")
+}
+
+func (cs *clientSuite) TestClientRunSnapctlReadLimitExact(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+        "status-code": 200,
+		"result": {
+		}
+	}`
+
+	restore := client.MockStdinReadLimit(10)
+	defer restore()
+
+	mockStdin := bytes.NewBufferString("1234567890")
+	options := &client.SnapCtlOptions{
+		ContextID: "1234ABCD",
+		Args:      []string{"foo", "bar"},
+	}
+
+	_, _, err := cs.cli.RunSnapctl(options, mockStdin)
+	c.Check(err, check.IsNil)
 }

--- a/client/snapctl_test.go
+++ b/client/snapctl_test.go
@@ -82,3 +82,24 @@ func (cs *clientSuite) TestInternalSnapctlCmdNeedsStdin(c *check.C) {
 		c.Check(res, check.Equals, false)
 	}
 }
+
+func (cs *clientSuite) TestClientRunSnapctlReadLimit(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+        "status-code": 200,
+		"result": {
+		}
+	}`
+
+	restore := client.MockStdinReadLimit(11)
+	defer restore()
+
+	mockStdin := bytes.NewBufferString("12345678901")
+	options := &client.SnapCtlOptions{
+		ContextID: "1234ABCD",
+		Args:      []string{"foo", "bar"},
+	}
+
+	_, _, err := cs.cli.RunSnapctl(options, mockStdin)
+	c.Check(err, check.ErrorMatches, "cannot read more than 10 bytes of data from stdin")
+}


### PR DESCRIPTION
This is a followup for PR#9692 where it was suggested that the
new "snapctl" support for reading from stdin should have some
protection against reading too much data. See
https://github.com/snapcore/snapd/pull/9692#discussion_r530255566

This starts with a 4MB limit.

