### PR TITLE
asserts: mode where Database only assumes cur time >= earliest time

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2016 Canonical Ltd
+ * Copyright (C) 2015-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -72,6 +72,26 @@ func (ak *AccountKey) isKeyValidAt(when time.Time) bool {
 		valid = when.Before(ak.until)
 	}
 	return valid
+}
+
+// isKeyValidAbout returns whether the account key is possibly valid
+// if the current time is known to be within [earliest, latest].
+// If latest is zero, then current time is assumed to be >=earliest.
+func (ak *AccountKey) isKeyValidAbout(earliest, latest time.Time) bool {
+	if !latest.IsZero() {
+		if latest.Before(earliest) {
+			return false
+		}
+		if earliest.Before(ak.since) && latest.Before(ak.since) {
+			return false
+		}
+	}
+	if !ak.until.IsZero() {
+		if earliest.After(ak.until) || earliest.Equal(ak.until) {
+			return false
+		}
+	}
+	return true
 }
 
 // publicKey returns the underlying public key of the account key.

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -332,8 +332,63 @@ func (chks *checkSuite) TestCheckMismatchedAccountIDandKey(c *C) {
 	err = db.Check(a)
 	c.Check(err, ErrorMatches, `error finding matching public key for signature: found public key ".*" from "canonical" but expected it from: random`)
 
-	err = asserts.CheckSignature(a, cfg.Trusted[0].(*asserts.AccountKey), db, time.Time{})
+	err = asserts.CheckSignature(a, cfg.Trusted[0].(*asserts.AccountKey), db, time.Time{}, time.Time{})
 	c.Check(err, ErrorMatches, `assertion authority "random" does not match public key from "canonical"`)
+}
+
+func (chks *checkSuite) TestCheckAndSetEarliestTime(c *C) {
+	trustedKey := testPrivKey0
+
+	ak := asserts.MakeAccountKeyForTest("canonical", trustedKey.PublicKey(), time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC), 2)
+
+	cfg := &asserts.DatabaseConfig{
+		Backstore: chks.bs,
+		Trusted:   []asserts.Assertion{ak},
+	}
+	db, err := asserts.OpenDatabase(cfg)
+	c.Assert(err, IsNil)
+
+	headers := map[string]interface{}{
+		"authority-id": "canonical",
+		"primary-key":  "0",
+	}
+	a, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, trustedKey)
+	c.Assert(err, IsNil)
+
+	// now is since + 1 year, key is valid
+	r := asserts.MockTimeNow(ak.Since().AddDate(1, 0, 0))
+	defer r()
+
+	err = db.Check(a)
+	c.Check(err, IsNil)
+
+	// now is since - 1 year, key is invalid
+	pastTime := ak.Since().AddDate(-1, 0, 0)
+	asserts.MockTimeNow(pastTime)
+
+	err = db.Check(a)
+	c.Check(err, ErrorMatches, `assertion is signed with expired public key .*`)
+
+	// now is ignored but known to be at least >= pastTime
+	// key is considered valid
+	db.SetEarliestTime(pastTime)
+	err = db.Check(a)
+	c.Check(err, IsNil)
+
+	// move earliest after until
+	db.SetEarliestTime(ak.Until().AddDate(0, 0, 1))
+	err = db.Check(a)
+	c.Check(err, ErrorMatches, `assertion is signed with expired public key .*`)
+
+	// check using now = since - 1 year again
+	db.SetEarliestTime(time.Time{})
+	err = db.Check(a)
+	c.Check(err, ErrorMatches, `assertion is signed with expired public key .*`)
+
+	// now is since + 1 month, key is valid
+	asserts.MockTimeNow(ak.Since().AddDate(0, 1, 0))
+	err = db.Check(a)
+	c.Check(err, IsNil)
 }
 
 type signAddFindSuite struct {

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -64,7 +64,7 @@ func BootstrapAccountForTest(authorityID string) *Account {
 	}
 }
 
-func makeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, validYears int) *AccountKey {
+func MakeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, since time.Time, validYears int) *AccountKey {
 	return &AccountKey{
 		assertionBase: assertionBase{
 			headers: map[string]interface{}{
@@ -74,18 +74,28 @@ func makeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, validYea
 				"public-key-sha3-384": openPGPPubKey.ID(),
 			},
 		},
-		since:  time.Time{},
-		until:  time.Time{}.UTC().AddDate(validYears, 0, 0),
+		since:  since.UTC(),
+		until:  since.UTC().AddDate(validYears, 0, 0),
 		pubKey: openPGPPubKey,
 	}
 }
 
 func BootstrapAccountKeyForTest(authorityID string, pubKey PublicKey) *AccountKey {
-	return makeAccountKeyForTest(authorityID, pubKey, 9999)
+	return MakeAccountKeyForTest(authorityID, pubKey, time.Time{}, 9999)
 }
 
 func ExpiredAccountKeyForTest(authorityID string, pubKey PublicKey) *AccountKey {
-	return makeAccountKeyForTest(authorityID, pubKey, 1)
+	return MakeAccountKeyForTest(authorityID, pubKey, time.Time{}, 1)
+}
+
+func MockTimeNow(t time.Time) (restore func()) {
+	oldTimeNow := timeNow
+	timeNow = func() time.Time {
+		return t
+	}
+	return func() {
+		timeNow = oldTimeNow
+	}
 }
 
 // define dummy assertion types to use in the tests
@@ -242,6 +252,11 @@ func init() {
 // AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests
 func AccountKeyIsKeyValidAt(ak *AccountKey, when time.Time) bool {
 	return ak.isKeyValidAt(when)
+}
+
+// AccountKeyIsKeyValidAt exposes isKeyValidAbout on AccountKey for tests
+func AccountKeyIsKeyValidAbout(ak *AccountKey, earliest, latest time.Time) bool {
+	return ak.isKeyValidAbout(earliest, latest)
 }
 
 type GPGRunner func(input []byte, args ...string) ([]byte, error)

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -660,7 +660,7 @@ func verifySignatures(a asserts.Assertion, workBS asserts.Backstore, trusted ass
 				return err
 			}
 		}
-		if err := asserts.CheckSignature(a, key.(*asserts.AccountKey), nil, time.Time{}); err != nil {
+		if err := asserts.CheckSignature(a, key.(*asserts.AccountKey), nil, time.Time{}, time.Time{}); err != nil {
 			return err
 		}
 		a = key


### PR DESCRIPTION
if current system time is unreliable have a mode where Database checks
for key expiry just based on assuming that current time is >= known
earliest time

this is set up via Database.SetEarliestTime

internally a new predicate AccountKey.isKeyValidAbout(earliest,
latest) is used to support this

I'm not sure the naming is great for what is conceptually being done here, so open to reasonable suggestions.