### PR TITLE
seed: ReadSystemEssentialAndBetterEarliestTime

### DIFF
--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -139,7 +139,6 @@ func (s *batchSuite) TestCommitToAndObserve(c *C) {
 
 	// this is the order they needed to be added
 	c.Check(seen, DeepEquals, []*asserts.Ref{
-
 		{Type: asserts.AccountKeyType, PrimaryKey: []string{s.storeSigning.StoreAccountKey("").PublicKeyID()}},
 		{Type: asserts.AccountType, PrimaryKey: []string{s.dev1Acct.AccountID()}},
 	})

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2020 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -41,7 +41,7 @@ func MockTrusted(mockTrusted []asserts.Assertion) (restore func()) {
 	}
 }
 
-func newMemAssertionsDB() (db asserts.RODatabase, commitTo func(*asserts.Batch) error, err error) {
+func newMemAssertionsDB(commitObserve func(verified asserts.Assertion)) (db *asserts.Database, commitTo func(*asserts.Batch) error, err error) {
 	memDB, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
 		Backstore: asserts.NewMemoryBackstore(),
 		Trusted:   trusted,
@@ -51,7 +51,7 @@ func newMemAssertionsDB() (db asserts.RODatabase, commitTo func(*asserts.Batch) 
 	}
 
 	commitTo = func(b *asserts.Batch) error {
-		return b.CommitTo(memDB, nil)
+		return b.CommitToAndObserve(memDB, commitObserve, nil)
 	}
 
 	return memDB, commitTo, nil

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2020 Canonical Ltd
+ * Copyright (C) 2019-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/seed/internal"
@@ -152,4 +153,63 @@ func ReadSystemEssential(seedDir, label string, essentialTypes []snap.Type, tm t
 	}
 
 	return seed20.Model(), seed20.EssentialSnaps(), nil
+}
+
+// ReadSystemEssentialAndBetterEarliestTime retrieves in one go
+// information about the model and essential snaps of the given types
+// for the Core 20 recovery system seed specified by seedDir and label
+// (which cannot be empty).
+// It can operate even if current system time is unreliable by taking
+// a earliestTime lower bound for current time.
+// It returns as well an improved lower bound by considering
+// appropriate assertions in the seed.
+func ReadSystemEssentialAndBetterEarliestTime(seedDir, label string, essentialTypes []snap.Type, earliestTime time.Time, tm timings.Measurer) (*asserts.Model, []*Snap, time.Time, error) {
+	if label == "" {
+		return nil, nil, time.Time{}, fmt.Errorf("system label cannot be empty")
+	}
+	seed20, err := Open(seedDir, label)
+	if err != nil {
+		return nil, nil, time.Time{}, err
+
+	}
+
+	improve := func(a asserts.Assertion) {
+		// we consider only snap-revisions as they are stored-signed
+		// and more recent than snap-declarations anyway,
+		// other assertions are ignored as they might be added
+		// with unreliable times
+		if a.Type() == asserts.SnapRevisionType {
+			sr := a.(*asserts.SnapRevision)
+			if sr.Timestamp().After(earliestTime) {
+				earliestTime = sr.Timestamp()
+			}
+		}
+	}
+
+	// create a temporary database, commitTo will invoke improve
+	db, commitTo, err := newMemAssertionsDB(improve)
+	if err != nil {
+		return nil, nil, time.Time{}, err
+	}
+	// set up the database to check for key expiry only assuming
+	// earliestTime (if not zero)
+	db.SetEarliestTime(earliestTime)
+
+	// load assertions into the temporary database
+	if err := seed20.LoadAssertions(db, commitTo); err != nil {
+		return nil, nil, time.Time{}, err
+	}
+
+	// load and verify info about essential snaps
+	if err := seed20.LoadEssentialMeta(essentialTypes, tm); err != nil {
+		return nil, nil, time.Time{}, err
+	}
+
+	// consider model own timestamp as well
+	mod := seed20.Model()
+	if mod.Timestamp().After(earliestTime) {
+		earliestTime = mod.Timestamp()
+	}
+
+	return mod, seed20.EssentialSnaps(), earliestTime, nil
 }

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -64,7 +64,7 @@ func (s *seed16) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Ba
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
-		db, commitTo, err = newMemAssertionsDB()
+		db, commitTo, err = newMemAssertionsDB(nil)
 		if err != nil {
 			return err
 		}

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -77,7 +77,7 @@ func (s *seed20) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Ba
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
-		db, commitTo, err = newMemAssertionsDB()
+		db, commitTo, err = newMemAssertionsDB(nil)
 		if err != nil {
 			return err
 		}

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -936,7 +936,6 @@ func (s *seed20Suite) TestReadSystemEssentialAndBetterEarliestTime(c *C) {
 			c.Check(essSnaps, DeepEquals, t.expected)
 			c.Check(betterTime.Equal(improvedTime), Equals, true, Commentf("%v expected: %v", betterTime, improvedTime))
 		}
-
 	}
 
 	revsTime := s.AssertedSnapRevision("required18").Timestamp()

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -832,6 +832,131 @@ func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
 	}
 }
 
+func (s *seed20Suite) TestReadSystemEssentialAndBetterEarliestTime(c *C) {
+	r := seed.MockTrusted(s.StoreSigning.Trusted)
+	defer r()
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "core18", "")
+	t0 := time.Now().UTC().Truncate(time.Second)
+	s.SetSnapAssertionNow(t0.Add(2 * time.Second))
+	s.makeSnap(c, "required18", "developerid")
+	s.SetSnapAssertionNow(time.Time{})
+
+	snapdSnap := &seed.Snap{
+		Path:          s.expectedPath("snapd"),
+		SideInfo:      &s.AssertedSnapInfo("snapd").SideInfo,
+		EssentialType: snap.TypeSnapd,
+		Essential:     true,
+		Required:      true,
+		Channel:       "latest/stable",
+	}
+	pcKernelSnap := &seed.Snap{
+		Path:          s.expectedPath("pc-kernel"),
+		SideInfo:      &s.AssertedSnapInfo("pc-kernel").SideInfo,
+		EssentialType: snap.TypeKernel,
+		Essential:     true,
+		Required:      true,
+		Channel:       "20",
+	}
+	core20Snap := &seed.Snap{Path: s.expectedPath("core20"),
+		SideInfo:      &s.AssertedSnapInfo("core20").SideInfo,
+		EssentialType: snap.TypeBase,
+		Essential:     true,
+		Required:      true,
+		Channel:       "latest/stable",
+	}
+	pcSnap := &seed.Snap{
+		Path:          s.expectedPath("pc"),
+		SideInfo:      &s.AssertedSnapInfo("pc").SideInfo,
+		EssentialType: snap.TypeGadget,
+		Essential:     true,
+		Required:      true,
+		Channel:       "20",
+	}
+
+	tests := []struct {
+		onlyTypes []snap.Type
+		expected  []*seed.Snap
+	}{
+		{[]snap.Type{snap.TypeSnapd}, []*seed.Snap{snapdSnap}},
+		{[]snap.Type{snap.TypeKernel}, []*seed.Snap{pcKernelSnap}},
+		{[]snap.Type{snap.TypeBase}, []*seed.Snap{core20Snap}},
+		{[]snap.Type{snap.TypeGadget}, []*seed.Snap{pcSnap}},
+		{[]snap.Type{snap.TypeSnapd, snap.TypeKernel, snap.TypeBase}, []*seed.Snap{snapdSnap, pcKernelSnap, core20Snap}},
+		// the order in essentialTypes is not relevant
+		{[]snap.Type{snap.TypeGadget, snap.TypeKernel}, []*seed.Snap{pcKernelSnap, pcSnap}},
+		// degenerate case
+		{[]snap.Type{}, []*seed.Snap(nil)},
+	}
+
+	baseLabel := "20210315"
+
+	testReadSystemEssentialAndBetterEarliestTime := func(sysLabel string, earliestTime, modelTime, improvedTime time.Time) {
+		s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+			"display-name": "my model",
+			"timestamp":    modelTime.Format(time.RFC3339),
+			"architecture": "amd64",
+			"base":         "core20",
+			"snaps": []interface{}{
+				map[string]interface{}{
+					"name":            "pc-kernel",
+					"id":              s.AssertedSnapID("pc-kernel"),
+					"type":            "kernel",
+					"default-channel": "20",
+				},
+				map[string]interface{}{
+					"name":            "pc",
+					"id":              s.AssertedSnapID("pc"),
+					"type":            "gadget",
+					"default-channel": "20",
+				},
+				map[string]interface{}{
+					"name": "core18",
+					"id":   s.AssertedSnapID("core18"),
+					"type": "base",
+				},
+				map[string]interface{}{
+					"name": "required18",
+					"id":   s.AssertedSnapID("required18"),
+				}},
+		}, nil)
+
+		for _, t := range tests {
+			// test short-cut helper as well
+			mod, essSnaps, betterTime, err := seed.ReadSystemEssentialAndBetterEarliestTime(s.SeedDir, sysLabel, t.onlyTypes, earliestTime, s.perfTimings)
+			c.Assert(err, IsNil)
+			c.Check(mod.BrandID(), Equals, "my-brand")
+			c.Check(mod.Model(), Equals, "my-model")
+			c.Check(mod.Timestamp().Equal(modelTime), Equals, true)
+			c.Check(essSnaps, HasLen, len(t.expected))
+			c.Check(essSnaps, DeepEquals, t.expected)
+			c.Check(betterTime.Equal(improvedTime), Equals, true, Commentf("%v expected: %v", betterTime, improvedTime))
+		}
+
+	}
+
+	revsTime := s.AssertedSnapRevision("required18").Timestamp()
+	t2 := revsTime.Add(1 * time.Second)
+
+	timeCombos := []struct {
+		earliestTime, modelTime, improvedTime time.Time
+	}{
+		{time.Time{}, t0, revsTime},
+		{t2.AddDate(-1, 0, 0), t0, revsTime},
+		{t2.AddDate(-1, 0, 0), t2, t2},
+		{t2.AddDate(0, 1, 0), t2, t2.AddDate(0, 1, 0)},
+	}
+
+	for i, c := range timeCombos {
+		label := fmt.Sprintf("%s%d", baseLabel, i)
+		testReadSystemEssentialAndBetterEarliestTime(label, c.earliestTime, c.modelTime, c.improvedTime)
+	}
+}
+
 func (s *seed20Suite) TestLoadEssentialAndMetaCore20(c *C) {
 	r := seed.MockTrusted(s.StoreSigning.Trusted)
 	defer r()

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -46,6 +46,8 @@ type SeedSnaps struct {
 	snaps map[string]string
 	infos map[string]*snap.Info
 
+	snapAssertNow time.Time
+
 	snapRevs map[string]*asserts.SnapRevision
 }
 
@@ -63,6 +65,17 @@ func (ss *SeedSnaps) AssertedSnapID(snapName string) string {
 	return snaptest.AssertedSnapID(snapName)
 }
 
+func (ss *SeedSnaps) snapAssertionNow() time.Time {
+	if ss.snapAssertNow.IsZero() {
+		return time.Now()
+	}
+	return ss.snapAssertNow
+}
+
+func (ss *SeedSnaps) SetSnapAssertionNow(t time.Time) {
+	ss.snapAssertNow = t
+}
+
 func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string, dbs ...*asserts.Database) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
 	info, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
@@ -76,7 +89,7 @@ func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, r
 		"snap-id":      snapID,
 		"publisher-id": developerID,
 		"snap-name":    snapName,
-		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+		"timestamp":    ss.snapAssertionNow().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
 
@@ -89,7 +102,7 @@ func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, r
 		"snap-id":       snapID,
 		"developer-id":  developerID,
 		"snap-revision": revision.String(),
-		"timestamp":     time.Now().UTC().Format(time.RFC3339),
+		"timestamp":     ss.snapAssertionNow().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
ReadSystemEssentialAndBetterEarliestTime retrieves in one go
information about the model and essential snaps of the given types
for the Core 20 recovery system seed specified by seedDir and label
(which cannot be empty).
It can operate even if current system time is unreliable by taking
a earliestTime lower bound for current time.
It returns as well an improved lower bound by considering appropriate
assertions in the seed.