### PR TITLE
boot: export bootAssetsMap as AssetsMap

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -232,11 +232,11 @@ type trackedAsset struct {
 	blName, name, hash string
 }
 
-func isAssetAlreadyTracked(bam bootAssetsMap, newAsset *trackedAsset) bool {
+func isAssetAlreadyTracked(bam AssetsMap, newAsset *trackedAsset) bool {
 	return isAssetHashTrackedInMap(bam, newAsset.name, newAsset.hash)
 }
 
-func isAssetHashTrackedInMap(bam bootAssetsMap, assetName, assetHash string) bool {
+func isAssetHashTrackedInMap(bam AssetsMap, assetName, assetHash string) bool {
 	if bam == nil {
 		return false
 	}
@@ -257,11 +257,11 @@ type TrustedAssetsInstallObserver struct {
 	blName        string
 	managedAssets []string
 	trustedAssets []string
-	trackedAssets bootAssetsMap
+	trackedAssets AssetsMap
 
 	recoveryBlName        string
 	trustedRecoveryAssets []string
-	trackedRecoveryAssets bootAssetsMap
+	trackedRecoveryAssets AssetsMap
 
 	dataEncryptionKey secboot.EncryptionKey
 	saveEncryptionKey secboot.EncryptionKey
@@ -296,7 +296,7 @@ func (o *TrustedAssetsInstallObserver) Observe(op gadget.ContentOperation, affec
 	// structure content, so make sure we are not tracking it yet
 	if !isAssetAlreadyTracked(o.trackedAssets, ta) {
 		if o.trackedAssets == nil {
-			o.trackedAssets = bootAssetsMap{}
+			o.trackedAssets = AssetsMap{}
 		}
 		if len(o.trackedAssets[ta.name]) > 0 {
 			return gadget.ChangeAbort, fmt.Errorf("cannot reuse asset name %q", ta.name)
@@ -320,7 +320,7 @@ func (o *TrustedAssetsInstallObserver) ObserveExistingTrustedRecoveryAssets(reco
 		}
 		if !isAssetAlreadyTracked(o.trackedRecoveryAssets, ta) {
 			if o.trackedRecoveryAssets == nil {
-				o.trackedRecoveryAssets = bootAssetsMap{}
+				o.trackedRecoveryAssets = AssetsMap{}
 			}
 			if len(o.trackedRecoveryAssets[ta.name]) > 0 {
 				return fmt.Errorf("cannot reuse recovery asset name %q", ta.name)
@@ -331,11 +331,11 @@ func (o *TrustedAssetsInstallObserver) ObserveExistingTrustedRecoveryAssets(reco
 	return nil
 }
 
-func (o *TrustedAssetsInstallObserver) currentTrustedBootAssetsMap() bootAssetsMap {
+func (o *TrustedAssetsInstallObserver) currentTrustedBootAssetsMap() AssetsMap {
 	return o.trackedAssets
 }
 
-func (o *TrustedAssetsInstallObserver) currentTrustedRecoveryBootAssetsMap() bootAssetsMap {
+func (o *TrustedAssetsInstallObserver) currentTrustedRecoveryBootAssetsMap() AssetsMap {
 	return o.trackedRecoveryAssets
 }
 
@@ -562,7 +562,7 @@ func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, re
 	*changedAssets = append(*changedAssets, ta)
 
 	if *trustedAssets == nil {
-		*trustedAssets = bootAssetsMap{}
+		*trustedAssets = AssetsMap{}
 	}
 
 	if taBefore != nil && !isAssetAlreadyTracked(*trustedAssets, taBefore) {

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -361,7 +361,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootRealGrub(c *C) {
 
 	// let's see what the observer has tracked
 	tracked := obs.CurrentTrustedBootAssetsMap()
-	c.Check(tracked, DeepEquals, boot.BootAssetsMap{
+	c.Check(tracked, DeepEquals, boot.AssetsMap{
 		"grubx64.efi": []string{dataHash},
 	})
 }
@@ -421,7 +421,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootMocked(c *C) {
 	})
 	// let's see what the observer has tracked
 	tracked := obs.CurrentTrustedBootAssetsMap()
-	c.Check(tracked, DeepEquals, boot.BootAssetsMap{
+	c.Check(tracked, DeepEquals, boot.AssetsMap{
 		"asset":       []string{dataHash},
 		"other-asset": []string{dataHash},
 	})
@@ -577,7 +577,7 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryMocked(c *C) {
 	c.Check(tab.TrustedAssetsCalls, Equals, 2)
 	// let's see what the observer has tracked
 	tracked := obs.CurrentTrustedRecoveryBootAssetsMap()
-	c.Check(tracked, DeepEquals, boot.BootAssetsMap{
+	c.Check(tracked, DeepEquals, boot.AssetsMap{
 		"asset":       []string{dataHash},
 		"other-asset": []string{dataHash},
 		"shim":        []string{shimHash},
@@ -699,11 +699,11 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {beforeHash},
 			"shim":  {"shim-hash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {beforeHash},
 		},
 	}
@@ -763,11 +763,11 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 	// check modeenv
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {beforeHash, dataHash},
 		"shim":  {"shim-hash", shimHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset":       {beforeHash, dataHash},
 		"shim":        {shimHash},
 		"other-asset": {dataHash},
@@ -827,10 +827,10 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"asset-hash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			// shim with same hash is listed as trusted, but missing
 			// from cache
 			"shim": {shimHash},
@@ -866,10 +866,10 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	// check modeenv
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {"asset-hash", dataHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 		"shim":  {shimHash},
 	})
@@ -940,10 +940,10 @@ func (s *assetsSuite) TestUpdateObserverUpdateNothingTrackedMocked(c *C) {
 	// check modeenv
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 	})
 
@@ -1068,10 +1068,10 @@ func (s *assetsSuite) TestUpdateObserverUpdateRepeatedAssetErr(c *C) {
 	// we are already tracking 2 assets, this is an unexpected state for observing content updates
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"one", "two"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"one", "two"},
 		},
 	}
@@ -1125,10 +1125,10 @@ func (s *assetsSuite) TestUpdateObserverUpdateAfterSuccessfulBootMocked(c *C) {
 	// and similarly, only the new asset in modeenv
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
 	}
@@ -1167,11 +1167,11 @@ func (s *assetsSuite) TestUpdateObserverUpdateAfterSuccessfulBootMocked(c *C) {
 	// check modeenv
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		// original asset is restored, listed first
 		"asset": {beforeHash, dataHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		// same here
 		"asset": {beforeHash, dataHash},
 	})
@@ -1229,11 +1229,11 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			// new version added during update
 			"asset": {dataHash, "newhash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			// no new version added during update
 			"asset": {dataHash},
 			// new version added during update
@@ -1288,10 +1288,10 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 	// check modeenv
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 		"shim":  {shimHash},
 	})
@@ -1310,11 +1310,11 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileSanity(c *C) {
 	// sane state of modeenv before rollback
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			// only one hash is listed, indicating it's a new file
 			"asset": {"newhash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			// same thing
 			"asset": {"newhash"},
 		},
@@ -1341,11 +1341,11 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileSanity(c *C) {
 	obs, _ = s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 	m = boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			// only one hash is listed, indicating it's a new file
 			"asset": {"newhash", "bogushash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			// same thing
 			"asset": {"newhash", "bogushash"},
 		},
@@ -1463,10 +1463,10 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 	// current files are tracked
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"grubx64.efi": {"0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"grubx64.efi": {"6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d"},
 			"bootx64.efi": {"c0437507ac094a7e9c699725cc0a4726cd10799af9eb79bbeaa136c2773163c80432295c2a04d3aa2ddd535ce8f1a12b"},
 		},
@@ -1514,7 +1514,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 	// and modeenv contents
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"grubx64.efi": {
 			// old hash
 			"0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389",
@@ -1522,7 +1522,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 			"f9554844308e89b565c1cdbcbdb9b09b8210dd2f1a11cb3b361de0a59f780ae3d4bd6941729a60e0f8ce15b2edef605d",
 		},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"grubx64.efi": {
 			// old hash
 			"6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d",
@@ -1568,11 +1568,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 			"shim":  {"shimhash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"recoveryhash"},
 		},
 	}
@@ -1633,11 +1633,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 	// check modeenv
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {"assethash", dataHash},
 		"shim":  {"shimhash", shimHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {"recoveryhash", dataHash},
 		"shim":  {shimHash},
 	})
@@ -1700,11 +1700,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 			"shim":  {"shimhash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"shim": {shimHash},
 		},
 	}
@@ -1735,11 +1735,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 	// check modeenv
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {"assethash", dataHash},
 		"shim":  {"shimhash", shimHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 		"shim":  {shimHash},
 	})
@@ -1769,11 +1769,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 			"shim":  {"shimhash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"recoveryhash"},
 		},
 	}
@@ -1894,10 +1894,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledAfterRollback(c *C) {
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 		},
 	}
@@ -1954,10 +1954,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"recoveryhash"},
 		},
 	}
@@ -1999,11 +1999,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 	// and the file is added to the assets map
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {"assethash"},
 		"shim":  {shimHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {"recoveryhash"},
 		"shim":  {shimHash},
 	})
@@ -2047,10 +2047,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootNoAssetsOnDisk(c *C) {
 
 	m := &boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 		},
 	}
@@ -2082,10 +2082,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootAfterUpdate(c *C) {
 
 	m := &boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash", dataHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"recoveryassethash", dataHash},
 			"shim":  {"recoveryshimhash", shimHash},
 		},
@@ -2094,10 +2094,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootAfterUpdate(c *C) {
 	newM, drop, err := boot.ObserveSuccessfulBootWithAssets(m)
 	c.Assert(err, IsNil)
 	c.Assert(newM, NotNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 		"shim":  {shimHash},
 	})
@@ -2130,10 +2130,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootWithUnexpected(c *C) {
 
 	m := &boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash", dataHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"recoveryassethash", dataHash},
 		},
 	}
@@ -2172,10 +2172,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootSingleEntries(c *C) {
 
 	m := &boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 			"shim":  {shimHash},
 		},
@@ -2208,10 +2208,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootDropCandidateUsedByOtherBootloade
 
 	m := &boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {maybeDropHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {maybeDropHash, dataHash},
 		},
 	}
@@ -2220,10 +2220,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootDropCandidateUsedByOtherBootloade
 	newM, drop, err := boot.ObserveSuccessfulBootWithAssets(m)
 	c.Assert(err, IsNil)
 	c.Assert(newM, NotNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {maybeDropHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 	})
 	// nothing get dropped, maybe-drop asset is still used by the
@@ -2250,10 +2250,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootParallelUpdate(c *C) {
 
 	m := &boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"oldhash", dataHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"oldhash", dataHash},
 			"shim":  {shimHash},
 		},
@@ -2262,10 +2262,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootParallelUpdate(c *C) {
 	newM, drop, err := boot.ObserveSuccessfulBootWithAssets(m)
 	c.Assert(err, IsNil)
 	c.Assert(newM, NotNil)
-	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 	})
-	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 		"shim":  {shimHash},
 	})
@@ -2292,10 +2292,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootHashErr(c *C) {
 
 	m := &boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
 	}
@@ -2310,10 +2310,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootDifferentMode(c *C) {
 
 	m := &boot.Modeenv{
 		Mode: "recover",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"hash-1", "hash-2"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"hash-3", "hash-4"},
 		},
 	}
@@ -2441,10 +2441,10 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {beforeHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {beforeHash},
 		},
 		CurrentRecoverySystems: []string{"recovery-system-label"},
@@ -2575,11 +2575,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 
 	m := boot.Modeenv{
 		Mode: "run",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 			"shim":  {"shimhash"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"assethash"},
 			"shim":  {"shimhash"},
 		},

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -883,7 +883,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 		Mode:           "run",
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
 	}
@@ -992,7 +992,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 		Mode:           "run",
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.ukern1.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
 	}
@@ -1097,7 +1097,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 		Mode:           "run",
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
 		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
@@ -1210,7 +1210,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 		Mode:           "run",
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.ukern1.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
 		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
@@ -1875,7 +1875,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 		Mode:           "run",
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename(), s.kern2.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
 	}
@@ -2099,10 +2099,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 		Mode:           "run",
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"assethash", dataHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"recoveryassethash", dataHash},
 			"shim":  {"recoveryshimhash", shimHash},
 		},
@@ -2163,10 +2163,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	// update assets are in the list
-	c.Check(m2.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(m2.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 	})
-	c.Check(m2.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Check(m2.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"asset": {dataHash},
 		"shim":  {shimHash},
 	})
@@ -2237,10 +2237,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 		Mode:           "run",
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 			"shim":  {shimHash},
 		},
@@ -2397,10 +2397,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 		Mode:           "run",
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.ukern1.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {dataHash},
 			"shim":  {shimHash},
 		},
@@ -2522,11 +2522,11 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 		Mode:           "run",
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			// hash will not match
 			"asset": {"one", "two"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"one", "two"},
 		},
 	}
@@ -2571,10 +2571,10 @@ func (s *bootenv20Suite) setupMarkBootSuccessful20CommandLine(c *C, mode string,
 		Mode:           mode,
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": {"one"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": {"one"},
 		},
 		CurrentKernelCommandLines: cmdlines,
@@ -2984,10 +2984,10 @@ func (s *bootConfigSuite) TestBootConfigUpdateHappyWithReseal(c *C) {
 		CurrentKernelCommandLines: boot.BootCommandLines{
 			"snapd_recovery_mode=run this is mocked panic=-1",
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": []string{"hash-1"},
 		},
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": []string{"hash-1"},
 		},
 	}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -67,7 +67,6 @@ var (
 	SealKeyModelParams              = sealKeyModelParams
 )
 
-type BootAssetsMap = bootAssetsMap
 type BootCommandLines = bootCommandLines
 type TrackedAsset = trackedAsset
 
@@ -81,11 +80,11 @@ func (t *TrackedAsset) Equals(blName, name, hash string) error {
 	return nil
 }
 
-func (o *TrustedAssetsInstallObserver) CurrentTrustedBootAssetsMap() BootAssetsMap {
+func (o *TrustedAssetsInstallObserver) CurrentTrustedBootAssetsMap() AssetsMap {
 	return o.currentTrustedBootAssetsMap()
 }
 
-func (o *TrustedAssetsInstallObserver) CurrentTrustedRecoveryBootAssetsMap() BootAssetsMap {
+func (o *TrustedAssetsInstallObserver) CurrentTrustedRecoveryBootAssetsMap() AssetsMap {
 	return o.currentTrustedRecoveryBootAssetsMap()
 }
 

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -262,8 +262,8 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 		return fmt.Errorf("cannot replicate boot assets cache: %v", err)
 	}
 
-	var currentTrustedBootAssets bootAssetsMap
-	var currentTrustedRecoveryBootAssets bootAssetsMap
+	var currentTrustedBootAssets AssetsMap
+	var currentTrustedRecoveryBootAssets AssetsMap
 	if sealer != nil {
 		currentTrustedBootAssets = sealer.currentTrustedBootAssetsMap()
 		currentTrustedRecoveryBootAssets = sealer.currentTrustedRecoveryBootAssetsMap()

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -36,7 +36,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-type bootAssetsMap map[string][]string
+type AssetsMap map[string][]string
 
 // bootCommandLines is a list of kernel command lines. The command lines are
 // marshalled as JSON as a comma can be present in the module parameters.
@@ -68,11 +68,11 @@ type Modeenv struct {
 	// expected to have booted with). The second entry, if present, is the
 	// hash of an entry added when an update of the asset was being applied
 	// and will become the sole entry after a successful boot.
-	CurrentTrustedBootAssets bootAssetsMap `key:"current_trusted_boot_assets"`
+	CurrentTrustedBootAssets AssetsMap `key:"current_trusted_boot_assets"`
 	// CurrentTrustedRecoveryBootAssetsMap is a map of a recovery bootloader's
 	// asset names to a list of hashes of the asset contents. Used similarly
 	// to CurrentTrustedBootAssets.
-	CurrentTrustedRecoveryBootAssets bootAssetsMap `key:"current_trusted_recovery_boot_assets"`
+	CurrentTrustedRecoveryBootAssets AssetsMap `key:"current_trusted_recovery_boot_assets"`
 	// CurrentKernelCommandLines is a list of the expected kernel command
 	// lines when booting into run mode. It will typically only be one
 	// element for normal operations, but may contain two elements during
@@ -408,17 +408,17 @@ func (m *modeenvModel) UnmarshalModeenvValue(brandSlashModel string) error {
 	return nil
 }
 
-func (b bootAssetsMap) MarshalJSON() ([]byte, error) {
+func (b AssetsMap) MarshalJSON() ([]byte, error) {
 	asMap := map[string][]string(b)
 	return json.Marshal(asMap)
 }
 
-func (b *bootAssetsMap) UnmarshalJSON(data []byte) error {
+func (b *AssetsMap) UnmarshalJSON(data []byte) error {
 	var asMap map[string][]string
 	if err := json.Unmarshal(data, &asMap); err != nil {
 		return err
 	}
-	*b = bootAssetsMap(asMap)
+	*b = AssetsMap(asMap)
 	return nil
 }
 

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -147,7 +147,7 @@ current_kernel_command_lines=["foo", "bar"]
 		Base:           "core20_123.snap",
 		TryBase:        "core20_124.snap",
 		BaseStatus:     "try",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"thing1": {"hash1", "hash2"},
 			"thing2": {"hash3"},
 		},
@@ -236,7 +236,7 @@ func (s *modeenvSuite) TestDeepEquals(c *C) {
 		BrandID: "brand",
 		Grade:   "secured",
 
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"thing1": {"hash1", "hash2"},
 			"thing2": {"hash3"},
 		},
@@ -262,7 +262,7 @@ func (s *modeenvSuite) TestDeepEquals(c *C) {
 		BrandID: "brand",
 		Grade:   "secured",
 
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"thing1": {"hash1", "hash2"},
 			"thing2": {"hash3"},
 		},
@@ -385,10 +385,10 @@ a_key=other
 		RecoverySystem: "20191126",
 		TryBase:        "core20_124.snap",
 		BaseStatus:     boot.TryStatus,
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"grubx64.efi": []string{"hash1", "hash2"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"bootx64.efi": []string{"shimhash1", "shimhash2"},
 			"grubx64.efi": []string{"recovery-hash1"},
 		},
@@ -693,10 +693,10 @@ func (s *modeenvSuite) TestMarshalCurrentTrustedBootAssets(c *C) {
 	modeenv := &boot.Modeenv{
 		Mode:           "run",
 		RecoverySystem: "20191128",
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"grubx64.efi": []string{"hash1", "hash2"},
 		},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"grubx64.efi": []string{"recovery-hash1"},
 			"bootx64.efi": []string{"shimhash1", "shimhash2"},
 		},
@@ -712,10 +712,10 @@ current_trusted_recovery_boot_assets={"bootx64.efi":["shimhash1","shimhash2"],"g
 
 	modeenvRead, err := boot.ReadModeenv(s.tmpdir)
 	c.Assert(err, IsNil)
-	c.Assert(modeenvRead.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Assert(modeenvRead.CurrentTrustedBootAssets, DeepEquals, boot.AssetsMap{
 		"grubx64.efi": []string{"hash1", "hash2"},
 	})
-	c.Assert(modeenvRead.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
+	c.Assert(modeenvRead.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.AssetsMap{
 		"grubx64.efi": []string{"recovery-hash1"},
 		"bootx64.efi": []string{"shimhash1", "shimhash2"},
 	})

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -77,12 +77,12 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 
 		modeenv := &boot.Modeenv{
 			RecoverySystem: "20200825",
-			CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 				"grubx64.efi": []string{"grub-hash-1"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},
 
-			CurrentTrustedBootAssets: boot.BootAssetsMap{
+			CurrentTrustedBootAssets: boot.AssetsMap{
 				"grubx64.efi": []string{"run-grub-hash-1"},
 			},
 
@@ -334,12 +334,12 @@ func (s *sealSuite) TestResealKeyToModeenv(c *C) {
 
 		modeenv := &boot.Modeenv{
 			CurrentRecoverySystems: []string{"20200825"},
-			CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 				"grubx64.efi": []string{"grub-hash-1"},
 				"bootx64.efi": []string{"shim-hash-1", "shim-hash-2"},
 			},
 
-			CurrentTrustedBootAssets: boot.BootAssetsMap{
+			CurrentTrustedBootAssets: boot.AssetsMap{
 				"grubx64.efi": []string{"run-grub-hash-1", "run-grub-hash-2"},
 			},
 
@@ -601,11 +601,11 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 
 	modeenv := &boot.Modeenv{
 		CurrentRecoverySystems: []string{"20200825"},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 
@@ -731,7 +731,7 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 
 func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 	for _, tc := range []struct {
-		assetsMap          boot.BootAssetsMap
+		assetsMap          boot.AssetsMap
 		recoverySystems    []string
 		undefinedKernel    bool
 		expectedAssets     []boot.BootAsset
@@ -741,7 +741,7 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 		{
 			// transition sequences
 			recoverySystems: []string{"20200825"},
-			assetsMap: boot.BootAssetsMap{
+			assetsMap: boot.AssetsMap{
 				"grubx64.efi": []string{"grub-hash-1", "grub-hash-2"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},
@@ -754,7 +754,7 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 		{
 			// two systems
 			recoverySystems: []string{"20200825", "20200831"},
-			assetsMap: boot.BootAssetsMap{
+			assetsMap: boot.AssetsMap{
 				"grubx64.efi": []string{"grub-hash-1", "grub-hash-2"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},
@@ -767,7 +767,7 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 		{
 			// non-transition sequence
 			recoverySystems: []string{"20200825"},
-			assetsMap: boot.BootAssetsMap{
+			assetsMap: boot.AssetsMap{
 				"grubx64.efi": []string{"grub-hash-1"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -109,11 +109,11 @@ func (s *systemsSuite) TestSetTryRecoverySystemEncrypted(c *C) {
 		Mode: "run",
 		// keep this comment to make old gofmt happy
 		CurrentRecoverySystems: []string{"20200825"},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 	}
@@ -163,11 +163,11 @@ func (s *systemsSuite) TestSetTryRecoverySystemEncrypted(c *C) {
 		Mode: "run",
 		// keep this comment to make old gofmt happy
 		CurrentRecoverySystems: []string{"20200825", "1234"},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 	}), Equals, true)
@@ -274,11 +274,11 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorBeforeReseal(c *C) 
 		Mode: "run",
 		// keep this comment to make old gofmt happy
 		CurrentRecoverySystems: []string{"20200825"},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 	}
@@ -375,11 +375,11 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorAfterReseal(c *C) {
 		Mode: "run",
 		// keep this comment to make old gofmt happy
 		CurrentRecoverySystems: []string{"20200825"},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 	}
@@ -481,11 +481,11 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupError(c *C) {
 		Mode: "run",
 		// keep this comment to make old gofmt happy
 		CurrentRecoverySystems: []string{"20200825"},
-		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+		CurrentTrustedRecoveryBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 
-		CurrentTrustedBootAssets: boot.BootAssetsMap{
+		CurrentTrustedBootAssets: boot.AssetsMap{
 			"asset": []string{"asset-hash-1"},
 		},
 	}


### PR DESCRIPTION
We need this to be exported to be able to serialize a trusted asset observer
across multiple tasks during UC20 install mode. The only state that is not
currently observable from filesystem state are the keys and the boot asset maps
for tracked assets here. The keys can easily be saved in state.json to
serialize, but the boot asset map needs to be exported to be able to serialize
it in the state.json across tasks.

This is the first of 4+ PR's which will enable adding an factory hook to be run 
during install mode.