### PR TITLE
tests: avoid using os.query tool while preparing the project in spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -540,7 +540,8 @@ prepare: |
         restorecon -v /etc/gai.conf
     fi
 
-    if os.query is-fedora; then
+    # Note that os.query or any other tool cannot be used here before the current.delta file is unpacked
+    if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
         # The Fedora archive mirror seems to be unreliable.
         # Switch to the main archive by commenting out metalink and uncommenting
         # baseurl with a tweak to go to dl.fedoraproject.org which doens't redirect
@@ -554,7 +555,8 @@ prepare: |
         # enable audit daemon
         systemctl enable --now auditd.service
     fi
-    if os.query is-opensuse; then
+
+    if [[ "$SPREAD_SYSTEM" == opensuse-* ]]; then
         # refresh metadatadata
         # Auto import gpg keys needed for could repository added to support google backend
         zypper --gpg-auto-import-keys ref
@@ -570,7 +572,7 @@ prepare: |
         sed 's/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/g' -i /etc/zypp/zypp.conf
     fi
 
-    if os.query is-arch-linux; then
+    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
         # Possible that AppArmor was not started and is not enabled in the
         # image, do both now
         if systemctl show -p LoadState apparmor.service | MATCH 'LoadState=loaded' ; then
@@ -583,16 +585,16 @@ prepare: |
         fi
     fi
 
-    if os.query is-debian; then
+    if [[ "$SPREAD_SYSTEM" == debian-* ]]; then
         apt-get update && apt-get install -y eatmydata
     fi
 
-    if os.query is-centos; then
+    if [[ "$SPREAD_SYSTEM" == centos-* ]]; then
         # make sure EPEL is enabled
         yum install -y epel-release
     fi
 
-    if os.query is-ubuntu; then
+    if [[ "$SPREAD_SYSTEM" == ubuntu-* ]]; then
         # make sure unattended-upgrades does not get in the way
         if systemctl is-enabled unattended-upgrades.service; then
             systemctl stop unattended-upgrades.service


### PR DESCRIPTION
The idea is to avoid using any tool until the code is unpacked. The
os.query tool is being used but it fails and the systems are not
properly configured.

This is an example of the content of the bin directory included in path
before unpack the current.delta file

sergio@cachiomachine:~/workspace/snapcore/snapd$ spread -debug
google:fedora-32-64:tests/regression/rhbz-1708991
2021-03-08 22:19:29 Project content is packed for delivery (208.03KB).
2021-03-08 22:19:29 If killed, discard servers with: spread
-reuse-pid=477473 -discard
...
2021-03-08 22:20:18 Starting shell to debug...
google:fedora-32-64 ...# os.query is-fedora && echo pepe
bash: os.query: command not found

google:fedora-32-64 ...# echo $PATH
/home/gopath/bin:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/lib/go-1.6/bin:/var/lib/snapd/snap/bin:/home/gopath/src/github.com/snapcore/snapd/tests/bin

google:fedora-32-64 ...# ls
/home/gopath/src/github.com/snapcore/snapd/tests/bin
ls: cannot access
'/home/gopath/src/github.com/snapcore/snapd/tests/bin': No such file or
directory

google:fedora-32-64 ...# ls /home/gopath/src/github.com/snapcore/snapd/
current.delta