### PR TITLE
interfaces: make cups interface implicit on classic

### DIFF
--- a/interfaces/builtin/cups.go
+++ b/interfaces/builtin/cups.go
@@ -39,7 +39,9 @@ const cupsBaseDeclarationSlots = `
     allow-installation:
       slot-snap-type:
         - app
-    deny-connection: true
+        - core
+    deny-connection:
+      on-classic: false
     deny-auto-connection: true
 `
 
@@ -55,7 +57,7 @@ func init() {
 		name:                  "cups",
 		summary:               cupsSummary,
 		implicitOnCore:        false,
-		implicitOnClassic:     false,
+		implicitOnClassic:     true,
 		baseDeclarationSlots:  cupsBaseDeclarationSlots,
 		connectedPlugAppArmor: cupsConnectedPlugAppArmor,
 	})

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -595,7 +595,7 @@ var (
 		"browser-support":         {"core"},
 		"content":                 {"app", "gadget"},
 		"core-support":            {"core"},
-		"cups":                    {"app"},
+		"cups":                    {"app", "core"},
 		"cups-control":            {"app", "core"},
 		"dbus":                    {"app"},
 		"docker-support":          {"core"},
@@ -754,7 +754,6 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 	// case-by-case basis
 	noconnect := map[string]bool{
 		"content":          true,
-		"cups":             true,
 		"docker":           true,
 		"fwupd":            true,
 		"location-control": true,


### PR DESCRIPTION
If we want to convince application snaps that only want to print to switch from the `cups-control` interface to the `cups` interface, then that interface should be usable on systems without a snapped version of CUPS.  Currently that is not possible because there isn't an implicit `system:cups` slot on classic systems.  This PR works to fix that.