### PR TITLE
o/hookstate/ctlcmd: add a new exit code for is-connected for cases when the peer is from the same snap

### DIFF
--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -31,6 +31,7 @@ import (
 const (
 	NotASnapCode    = notASnapCode
 	ClassicSnapCode = classicSnapCode
+	PeerIsSelfCode  = peerIsSelfCode
 )
 
 var AttributesTask = attributesTask

--- a/overlord/hookstate/ctlcmd/is_connected.go
+++ b/overlord/hookstate/ctlcmd/is_connected.go
@@ -36,6 +36,7 @@ var cgroupSnapNameFromPid = cgroup.SnapNameFromPid
 const (
 	classicSnapCode = 10
 	notASnapCode    = 11
+	peerIsSelfCode  = 12
 )
 
 type isConnectedCommand struct {
@@ -64,7 +65,8 @@ The --pid and --aparmor-label options can be used to determine whether
 a plug or slot is connected to the snap identified by the given
 process ID or AppArmor label.  In this mode, additional failure exit
 codes may be returned: 10 if the other snap is not connected but uses
-classic confinement, or 11 if the other process is not snap confined.
+classic confinement, 11 if the other process is not snap confined, or
+12 if the other process belongs to the same snap.
 
 The --pid and --apparmor-label options may only be used with slots of
 interface type "pulseaudio", "audio-record", or "cups-control".
@@ -171,6 +173,10 @@ func (c *isConnectedCommand) Execute(args []string) error {
 				return nil
 			}
 		}
+	}
+
+	if otherSnap != nil && otherSnap.InstanceName() == snapName {
+		return &UnsuccessfulError{ExitCode: peerIsSelfCode}
 	}
 
 	if otherSnap != nil && otherSnap.Confinement == snap.ClassicConfinement {

--- a/overlord/hookstate/ctlcmd/is_connected_test.go
+++ b/overlord/hookstate/ctlcmd/is_connected_test.go
@@ -105,6 +105,10 @@ var isConnectedTests = []struct {
 	args:     []string{"is-connected", "--pid", "1005", "audio-record"},
 	exitCode: ctlcmd.ClassicSnapCode,
 }, {
+	// snap1:audio-record slot is not connected to snap1 (self)
+	args:     []string{"is-connected", "--pid", "1001", "audio-record"},
+	exitCode: ctlcmd.PeerIsSelfCode,
+}, {
 	// snap1:plug1 does not use an allowed interface
 	args: []string{"is-connected", "--apparmor-label", "snap.snap2.app", "plug1"},
 	err:  `cannot use --apparmor-label check with snap1:plug1`,
@@ -132,6 +136,10 @@ var isConnectedTests = []struct {
 	// snap1:audio-record slot is not connected to classic snap5
 	args:     []string{"is-connected", "--apparmor-label", "snap.snap5.app", "audio-record"},
 	exitCode: ctlcmd.ClassicSnapCode,
+}, {
+	// snap1:audio-record slot is not connected to snap1 (self)
+	args:     []string{"is-connected", "--apparmor-label", "snap.snap1.app", "audio-record"},
+	exitCode: ctlcmd.PeerIsSelfCode,
 }}
 
 func mockInstalledSnap(c *C, st *state.State, snapYaml string) {

--- a/tests/main/snapctl-is-connected-pid/task.yaml
+++ b/tests/main/snapctl-is-connected-pid/task.yaml
@@ -25,7 +25,11 @@ restore: |
 execute: |
     echo "The test-snap1 service is running"
     systemctl is-active snap.test-snap1.svc.service
-    svc_pid=$(systemctl show --property=MainPID snap.test-snap1.svc.service | cut -d = -f 2)
+    svc1_pid=$(systemctl show --property=MainPID snap.test-snap1.svc.service | cut -d = -f 2)
+
+    echo "The test-snap2 service is running"
+    systemctl is-active snap.test-snap2.svc.service
+    svc2_pid=$(systemctl show --property=MainPID snap.test-snap2.svc.service | cut -d = -f 2)
 
     expect_status() {
         expected="$1"
@@ -39,7 +43,7 @@ execute: |
     not test-snap2.snapctl is-connected foo-slot
 
     echo "Disconnected interfaces are not connected to a snap process"
-    expect_status 1 test-snap2.snapctl is-connected --pid "$svc_pid" foo-slot
+    expect_status 1 test-snap2.snapctl is-connected --pid "$svc1_pid" foo-slot
 
     echo "Disconnected interfaces are not connected to non-snap process"
     expect_status 11 test-snap2.snapctl is-connected --pid 1 foo-slot
@@ -48,18 +52,25 @@ execute: |
     snap connect test-snap1:foo-plug test-snap2:foo-slot
 
     echo "Connected interfaces report as connected to snap process"
-    test-snap2.snapctl is-connected --pid "$svc_pid" foo-slot
+    test-snap2.snapctl is-connected --pid "$svc1_pid" foo-slot
 
     echo "Interfaces still not connected to non-snap process"
     expect_status 11 test-snap2.snapctl is-connected --pid 1 foo-slot
 
+    echo "A special exit code is returned for connections from the same snap"
+    expect_status 12 test-snap2.snapctl is-connected --pid "$svc2_pid" foo-slot
+
     if [[ "$(snap debug confinement)" = strict ]]; then
-      svc_label=$(sed 's/ (.*)$//' < "/proc/$svc_pid/attr/current")
+      svc1_label=$(sed 's/ (.*)$//' < "/proc/$svc1_pid/attr/current")
+      svc2_label=$(sed 's/ (.*)$//' < "/proc/$svc2_pid/attr/current")
 
       echo "We can detect connected interfaces by AppArmor label too"
       test-snap2.snapctl is-connected --apparmor-label "$svc_label" foo-slot
       snap disconnect test-snap1:foo-plug test-snap2:foo-slot
-      expect_status 1 test-snap2.snapctl is-connected --apparmor-label "$svc_label" foo-slot
+      expect_status 1 test-snap2.snapctl is-connected --apparmor-label "$svc1_label" foo-slot
+
+      echo "Without an interface connection, labels for the same snap return a special exit code"
+      expect_status 12 test-snap2.snapctl is-connected --apparmor-label "$svc2_label" foo-slot
 
       echo "Non-snap AppArmor labels return a special exit code"
       expect_status 11 test-snap2.snapctl is-connected --apparmor-label /usr/bin/evince foo-slot

--- a/tests/main/snapctl-is-connected-pid/task.yaml
+++ b/tests/main/snapctl-is-connected-pid/task.yaml
@@ -65,7 +65,7 @@ execute: |
       svc2_label=$(sed 's/ (.*)$//' < "/proc/$svc2_pid/attr/current")
 
       echo "We can detect connected interfaces by AppArmor label too"
-      test-snap2.snapctl is-connected --apparmor-label "$svc_label" foo-slot
+      test-snap2.snapctl is-connected --apparmor-label "$svc1_label" foo-slot
       snap disconnect test-snap1:foo-plug test-snap2:foo-slot
       expect_status 1 test-snap2.snapctl is-connected --apparmor-label "$svc1_label" foo-slot
 

--- a/tests/main/snapctl-is-connected-pid/test-snap2/bin/service.sh
+++ b/tests/main/snapctl-is-connected-pid/test-snap2/bin/service.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "service running"
+exec sleep infinity

--- a/tests/main/snapctl-is-connected-pid/test-snap2/meta/snap.yaml
+++ b/tests/main/snapctl-is-connected-pid/test-snap2/meta/snap.yaml
@@ -9,3 +9,6 @@ slots:
 apps:
   snapctl:
     command: bin/run-snapctl.sh
+  svc:
+    command: bin/service.sh
+    daemon: simple


### PR DESCRIPTION
This PR grew out of discussions about the CUPS snap on the forum:

https://forum.snapcraft.io/t/request-cups-snap-cups-auto-connection-to-of-cups-cups-control-to-cups-admin-and-also-of-the-network-manager-observe-interface/22802/25?u=jamesh

At present, Till's CUPS snap has both a plug and slot for the `cups-control` interface, with a request that they be auto-connected.  At present the plug is not actually necessary to connect to the CUPS socket (that permission comes with the slot), but is needed to verify that utilities like lpadmin to pass the `snapctl is-connected` check.

As discussed in the forum thread, we could avoid the need for the extra plug if `snapctl is-connected` grew a new exit code representing "peer is not connected, but belongs to the same snap".  So that is what this PR implements.