### PR TITLE
api: local assertion fallback when it's not in the store

### DIFF
--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -364,10 +364,14 @@ func validationSetAssertFromDb(st *state.State, accountID, name string, sequence
 }
 
 func validateAgainstStore(st *state.State, accountID, name string, sequence int, user *auth.UserState) Response {
-	// not available locally, try to find in the store.
+	// get from the store
 	as, err := getSingleSeqFormingAssertion(st, accountID, name, sequence, user)
 	if _, ok := err.(*asserts.NotFoundError); ok {
-		return validationSetNotFound(accountID, name, sequence)
+		// not in the store - try to find in the database
+		as, err = validationSetAssertFromDb(st, accountID, name, sequence)
+		if _, ok := err.(*asserts.NotFoundError); ok {
+			return validationSetNotFound(accountID, name, sequence)
+		}
 	}
 	if err != nil {
 		return InternalError(err.Error())


### PR DESCRIPTION
Followup to #9922 suggested by @pedronis: fallback for `snap validate account/name=seq` if the assertion is not in the store, but was ack'ed locally.