### PR TITLE
snap-seccomp: add new `close_range` syscall

### DIFF
--- a/cmd/snap-seccomp/syscalls/syscalls.go
+++ b/cmd/snap-seccomp/syscalls/syscalls.go
@@ -64,6 +64,7 @@ var SeccompSyscalls = []string{
 	"clone",
 	"clone3",
 	"close",
+	"close_range",
 	"connect",
 	"copy_file_range",
 	"creat",


### PR DESCRIPTION
The snap-seccomp helper maintains a list of all know syscalls supported by
libseccomp. We catch when the internal list diverges from upstream
libseccomp in a tests/main/snap-seccomp-syscalls spread test.

Upstream libseccomp has been updated with close_range syscall [1],
update the internal list.

[1] https://github.com/seccomp/libseccomp/commit/c305ef351bc9b254f3f65359ca2e6435bb920752
