### PR TITLE
RFC: introduce alternate snap-confine for classic exec transitions (LP: #1849753)

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -85,11 +85,13 @@ fmt:: $(filter-out $(addprefix %,$(new_format)),$(foreach dir,$(subdirs),$(wildc
 # The hack target helps developers work on snap-confine on their live system by
 # installing a fresh copy of snap confine and the appropriate apparmor profile.
 .PHONY: hack
-hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-update-ns/snap-update-ns snap-seccomp/snap-seccomp snap-discard-ns/snap-discard-ns
+hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-confine/snap-confine-classic.apparmor snap-update-ns/snap-update-ns snap-seccomp/snap-seccomp snap-discard-ns/snap-discard-ns
 	sudo install -D -m 4755 snap-confine/snap-confine-debug $(DESTDIR)$(libexecdir)/snap-confine
 	if [ -d /etc/apparmor.d ]; then sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine.real; fi
+	if [ -d /etc/apparmor.d ]; then sudo install -m 644 snap-confine/snap-confine-classic.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine-classic.real; fi
 	sudo install -d -m 755 $(DESTDIR)/var/lib/snapd/apparmor/snap-confine/
 	if [ "$$(command -v apparmor_parser)" != "" ]; then sudo apparmor_parser -r snap-confine/snap-confine.apparmor; fi
+	if [ "$$(command -v apparmor_parser)" != "" ]; then sudo apparmor_parser -r snap-confine/snap-confine-classic.apparmor; fi
 	sudo install -m 755 snap-update-ns/snap-update-ns $(DESTDIR)$(libexecdir)/snap-update-ns
 	sudo install -m 755 snap-discard-ns/snap-discard-ns $(DESTDIR)$(libexecdir)/snap-discard-ns
 	sudo install -m 755 snap-seccomp/snap-seccomp $(DESTDIR)$(libexecdir)/snap-seccomp
@@ -358,15 +360,19 @@ endif
 snap-confine/snap-confine.apparmor: snap-confine/snap-confine.apparmor.in Makefile
 	sed -e 's,[@]LIBEXECDIR[@],$(libexecdir),g' -e 's,[@]SNAP_MOUNT_DIR[@],$(SNAP_MOUNT_DIR),g' <$< >$@
 
+snap-confine/snap-confine-classic.apparmor: snap-confine/snap-confine.apparmor.in Makefile
+	sed -e 's,[@]LIBEXECDIR[@]/snap-confine (attach_disconnected),profile snap-confine-classic (attach_disconnected),g' -e 's,peer=[@]LIBEXECDIR[@]/snap-confine,peer=snap-confine-classic,g' -e 's,[@]SNAP_MOUNT_DIR[@],$(SNAP_MOUNT_DIR),g' -e 's;^};\n    # file-inherit accesses for classic snaps (LP: #1849753, #1850552)\n    unix,\n    owner /** rw,\n    ptrace readby peer=unconfined,\n};' <$< >$@
+
 # Install the apparmor profile
 #
 # NOTE: the funky make functions here just convert /foo/bar/froz into
 # foo.bar.froz The inner subst replaces slashes with dots and the outer
 # patsubst strips the leading dot
-install-data-local:: snap-confine/snap-confine.apparmor
+install-data-local:: snap-confine/snap-confine.apparmor snap-confine/snap-confine-classic.apparmor
 if APPARMOR
 	install -d -m 755 $(DESTDIR)/etc/apparmor.d/
 	install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine
+	install -m 644 snap-confine/snap-confine-classic.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine
 endif
 	install -d -m 755 $(DESTDIR)/var/lib/snapd/apparmor/snap-confine/
 

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -562,16 +562,6 @@
     mount options=(rw rbind) /var/lib/jenkins/ -> /tmp/snap.rootfs_*/var/lib/jenkins/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/jenkins/,
 
-    # Suppress noisy file_inherit denials (LP: #1850552) until LP: #1849753 is
-    # fixed.
-    deny /dev/shm/.org.chromium.Chromium.* rw,
-
-    # While snap-confine itself doesn't require unix rules and therefore all
-    # unix rules are implicitly denied, adding an explicit deny for unix to
-    # silence noisy denials breaks nested lxd. Until the cause is determined,
-    # do not use an explicit deny for unix. (LP: #1855355)
-    #deny unix,
-
     # Explicitly deny these accesses which show up on Arch to silence the
     # denials for this unneeded access.
     deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_files-[0-9]*.so* mr,

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -650,6 +650,19 @@ func addContent(securityTag string, snapInfo *snap.Info, cmdName string, opts in
 				}
 			}
 			return "change_profile,"
+		case "###SNAP_CONFINE_EXEC_RULES###":
+			// TODO: choose based on snapConfineFromSnapProfile().
+			// Importantly, this path may not have globs in it
+			// otherwise there will be a 'conflicting x modifier'.
+			return `
+# When executing applications, we want to transition to a matching apparmor
+# profile (via binary attachment) or inherit the current policy if there
+# isn't a matching profile. The exception is for snap-confine where we want
+# to transition to a tailored snap-confine profile that has workarounds for
+# file-inherit denials (LP: #1849753)
+/** pix,
+/usr/lib/snapd/snap-confine Px -> snap-confine-classic,
+`
 		case "###SNIPPETS###":
 			var tagSnippets string
 			if opts.Classic && opts.JailMode {

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -818,7 +818,7 @@ var classicTemplate = `
   # already a profile for it (eg, snap-confine)
   / rwkl,
   /** rwlkm,
-  /** pix,
+  ###SNAP_CONFINE_EXEC_RULES###
 
   capability,
   ###CHANGEPROFILE_RULE###


### PR DESCRIPTION
LP: #1849753 describes how classic snap policy doesn't account for
file-inherit denials when a classic snap execs another snap. Many see
this as noise in their logs but it also breaks real-world scenarios such
as using the go snap inside of an LXD container (or a classic snap
calling another snap).

At this time, the identified additional rules are:

  ptrace readby peer=unconfined,
  unix,
  owner /** rw,

The ptrace rule simply allows an unconfined process (eg, systemd) to
read some info from /proc associated with this process. The 'unix' rule
was observed as needed with the go snap, et al. The broad file rule is
unfortunate, but needed by the go snap for /tmp files, files in HOME,
etc and by chromium content API classic snaps access to shared memory
files. While unfortunate, the file-inherit denials cause noisy logs and
in the case of (at least) compiler snaps, broken functionality (see bugs
in the References, below).

A workaround is to add a file to /var/lib/snapd/apparmor/snap-confine
with these rules and reloading all the snap-confine profiles. However,
snap refreshes will remove the file so this doesn't work very well.
There is currently no proper solution as the proper solution would be
fuller delegation support in AppArmor. Several workarounds are possible:

1. change the snap-confine policy to allow more access
2. introduce separate snap-confine policy that is wider than the normal
   and let snap-confine decide what to do
3. introduce separate snap-confine policy and adjust the classic
   template to transition to this policy if it is executing snap-confine

All cases weaken the security protections afforded by AppArmor for
snap-confine to varying degrees, though snap-confine's design does not
rely on AppArmor being present (ie, it is meant to be securely coded).

Option '1' weakens the policy for everyone and is not desirable since
only classic snaps need snap-confine to have additional access
(since a strict mode snap isn't allowed to execute other snaps, by
design).

'2' is better but means that if there was a vulnerability in
snap-confine, snap-confine could potentially change to the weaker
profile.

'3' is better still since snap-confine keeps its normal policy
except in the case where the classic snap's profile chooses to
transition snap-confine to a more lenient policy.

A problem with '2' and '3' is that there is an additional profile on the
system that users may use with 'aa-exec -p' to run snap-confine under
(eg, 'SNAP_INSTANCE_NAME=app aa-exec -p &lt;some other policy&gt;
/usr/lib/snapd/snap-confine snap.app.thing &lt;blah&gt;') to avoid the binary
attachment and try to exploit a bug in snap-confine to escalate, but '2'
and '3' isn't appreciably worse on a system with a classic snap
installed since today that classic's snap's profile can be specified
during the attack attempt.

This commit is a PoC and is barely tested. I suggest the following be
added:

* spread tests
* fixing addContent() to use snapConfineFromSnapProfile() so it will
  work in the re-exec case (see TODO in code)
* only loading the alternate profile if there is a classic snap
  installed on the system (addresses the "main problem with '2' and '3'"
  since a system without a classic snap doesn't have the extra profile
  to leverage in a local privilege escalation attack attempt and a
  system with a classic snap installed already can use the nearly wide
  open classic policy (eg, aa-exec -p snap.classic.thing). Ie, if
  conditionally loading the classic profile, there is no difference with
  today)
* deb/etc packaging: don't install snap-confine-classic.apparmor in
  /etc/apparmor.d
* core snap: do install snap-confine-classic.core.&lt;REVISION&gt; in
  /var/lib/snapd/apparmor/profiles
* snapd snap: do install snap-confine-classic.snapd.&lt;REVISION&gt; in
  /var/lib/snapd/apparmor/profiles

When full delegation support is available in AppArmor, this workaround
alternate-classic-profile approach can be removed.

References:
- https://launchpad.net/bugs/1849753
- https://launchpad.net/bugs/1850552
