### PR TITLE
o/configstate/configcore: add hdmi_timings to pi-config

### DIFF
--- a/overlord/configstate/configcore/picfg.go
+++ b/overlord/configstate/configcore/picfg.go
@@ -46,6 +46,7 @@ var piConfigKeys = map[string]bool{
 	"display_rotate":           true,
 	"hdmi_group":               true,
 	"hdmi_mode":                true,
+	"hdmi_timings":             true,
 	"hdmi_drive":               true,
 	"avoid_warnings":           true,
 	"gpu_mem_256":              true,


### PR DESCRIPTION
Required for supporting custom resolutions/working with certain devices.
See https://www.raspberrypi.org/documentation/configuration/config-txt/video.md

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Yes, I did sign it before.
