### PR TITLE
tests/main/uc20-create-partitions: fix tests cleanup

### DIFF
--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -13,20 +13,23 @@ debug: |
     cat /proc/partitions
 
 restore: |
-    if [[ -d ./mnt ]]; then
-        umount ./mnt || true
+    for m in ubuntu-seed ubuntu-save ubuntu-data ubuntu-boot; do
+        if mountpoint "/run/mnt/$m"; then
+            umount "/run/mnt/$m"
+        fi
+    done
+    if mountpoint ./mnt; then
+        umount ./mnt
     fi
-    umount /run/mnt/ubuntu-seed || true
-    umount /dev/mapper/ubuntu-save || true
-    umount /dev/mapper/ubuntu-data || true
-    umount /dev/mapper/test-udata || true
 
     cryptsetup close /dev/mapper/ubuntu-save || true
     cryptsetup close /dev/mapper/ubuntu-data || true
     cryptsetup close /dev/mapper/test-udata || true
 
     if [ -f loop.txt ]; then
-        losetup -d "$(cat loop.txt)"
+        LOOP="$(cat loop.txt)"
+        losetup -d "$LOOP"
+        losetup -l | NOMATCH "$LOOP"
     fi
     apt autoremove -y cryptsetup
 

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -13,13 +13,19 @@ debug: |
     cat /proc/partitions
 
 restore: |
+    for label in ubuntu-seed ubuntu-save ubuntu-data ubuntu-boot; do
+        if mountpoint "/run/mnt/$label"; then
+            umount "/run/mnt/$label"
+        fi
+        if mountpoint "./$label"; then
+            umount "./$label"
+        fi
+    done
     if [ -f loop.txt ]; then
-        losetup -d "$(cat loop.txt)"
+        LOOP="$(cat loop.txt)"
+        losetup -d "$LOOP"
+        losetup -l | NOMATCH "$LOOP"
     fi
-    umount ./ubuntu-seed || true
-    umount ./ubuntu-boot || true
-    umount ./ubuntu-save || true
-    umount ./ubuntu-data || true
 
 prepare: |
     echo "Create a fake block device image that looks like an image from u-i"

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -13,12 +13,23 @@ debug: |
     cat /proc/partitions
 
 restore: |
+    for label in ubuntu-seed ubuntu-save ubuntu-data ubuntu-boot other-ext4; do
+        if mountpoint "/run/mnt/$label"; then
+            umount "/run/mnt/$label"
+        fi
+        if mountpoint "./$label"; then
+            umount "./$label"
+        fi
+    done
+    if mountpoint ./mnt; then
+        umount ./mnt
+    fi
+    # sanity check
+    mount | NOMATCH /run/mnt
     if [ -f loop.txt ]; then
         LOOP="$(cat loop.txt)"
         losetup -d "$LOOP"
-        umount "${LOOP}p3"
-        umount "${LOOP}p4"
-        umount "${LOOP}p5"
+        losetup -l | NOMATCH "$LOOP"
     fi
 
 prepare: |
@@ -144,7 +155,6 @@ execute: |
     mount | MATCH /run/mnt/other-ext4
     df -T "${LOOP}p6" | MATCH ext4
     file -s "${LOOP}p6" | MATCH 'volume name "other-ext4"'
-    umount /run/mnt/other-ext4
 
     echo "Make sure the filesystem was redeployed"
     ls /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi


### PR DESCRIPTION
Fix the cleanup after a bunch of uc20-create-partitions tests. Make sure that
mountpoints are unmounted before trying to remove the loopback device. Verify
that loopback device is gone.

Ideally we should write a test invariant that verifies that no new mounts or loopback devices are present.
