### PR TITLE
interfaces/apparmor: allow reading /proc/sys/kernel/random/entropy_avail

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -272,6 +272,7 @@ var templateCommon = `
   @{PROC}/sys/fs/inotify/max_* r,
   @{PROC}/sys/kernel/pid_max r,
   @{PROC}/sys/kernel/random/boot_id r,
+  @{PROC}/sys/kernel/random/entropy_avail r,
   @{PROC}/sys/kernel/random/uuid r,
   # Allow access to the uuidd daemon (this daemon is a thin wrapper around
   # time and getrandom()/{,u}random and, when available, runs under an


### PR DESCRIPTION
Allow reading how much entropy is available in the kernel. This is a
miscellaneous access that some applications, eg. those that generate random data
may need. Note that the AppArmor base abstraction already allows reading from
/dev/{u,}random, and our base template allows writing to it. Thus, even without
knowing how much entropy is available, it is possible to drain it.

See [1] for more details.

1. https://forum.snapcraft.io/t/allow-access-to-proc-sys-kernel-random-entropy-avail/23275
