### PR TITLE
interfaces/builtin: update unit tests to use proper distro's libexecdir

### DIFF
--- a/interfaces/builtin/allegro_vcu_test.go
+++ b/interfaces/builtin/allegro_vcu_test.go
@@ -20,8 +20,11 @@
 package builtin_test
 
 import (
+	"fmt"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -92,7 +95,8 @@ SUBSYSTEM=="allegro_decode_class", KERNEL=="allegroDecodeIP", TAG+="snap_consume
 SUBSYSTEM=="allegro_encode_class", KERNEL=="allegroIP", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# allegro-vcu
 SUBSYSTEM=="char", KERNEL=="dmaproxy", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(
+		`TAG=="snap_consumer_app", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }
 
 func (s *AllegroVcuInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/media_control_test.go
+++ b/interfaces/builtin/media_control_test.go
@@ -20,8 +20,11 @@
 package builtin_test
 
 import (
+	"fmt"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -89,7 +92,8 @@ func (s *MediacontrolInterfaceSuite) TestUDevSpec(c *C) {
 SUBSYSTEM=="media", KERNEL=="media[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# media-control
 SUBSYSTEM=="video4linux", KERNEL=="v4l-subdev[0-9]*", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
+	c.Assert(spec.Snippets(), testutil.Contains,
+		fmt.Sprintf(`TAG=="snap_consumer_app", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }
 
 func (s *MediacontrolInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
Fix running the interfaces unit tests on a distro that uses /usr/libexec/snapd.
Instead of mocking it in test set up, fix it in the tests, so we know that the
tests use proper paths.
