### PR TITLE
snapstate: reduce reRefreshRetryTimeout to 1/2 second

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2879,7 +2879,7 @@ func reRefreshFilter(update *snap.Info, snapst *SnapState) bool {
 	return !update.Epoch.Equal(&cur.Epoch)
 }
 
-var reRefreshRetryTimeout = time.Second / 10
+var reRefreshRetryTimeout = time.Second / 2
 
 func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 	st := t.State()


### PR DESCRIPTION
We got some reports that snapd during download consumes a lot of
CPU. It turns out this was introduced with PR#6356 when we add
re-refresh on epoch bumps. This commit mitigates the effect.

Fixing this for good will require some work in the taskrunner.
But with this change I see on my machine that download only
takes ~14% compared to the 56% it took before.
