### PR TITLE
o/servicestate: detect and forbid attempts to control user daemons

### DIFF
--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -415,6 +415,33 @@ func (s *serviceControlSuite) TestControlStopDisableMultipleInstruction(c *C) {
 	verifyControlTasks(c, chg.Tasks(), "stop", "disable", "snap.test-snap.foo.service", "snap.test-snap.bar.service")
 }
 
+func (s *serviceControlSuite) TestControlUserServices(c *C) {
+	st := s.state
+	st.Lock()
+
+	si := snap.SideInfo{RealName: "test-snap", Revision: snap.R(7)}
+	info := snaptest.MockSnap(c, `name: test-snap
+version: 1.0
+apps:
+  svc:
+    daemon: simple
+    daemon-scope: user
+`, &si)
+	snapstate.Set(st, "test-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si},
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	inst := &servicestate.Instruction{
+		Action: "start",
+		Names:  []string{"svc"},
+	}
+	_, err := servicestate.Control(st, []*snap.AppInfo{info.Apps["svc"]}, inst, nil, nil)
+	c.Check(err, ErrorMatches, `cannot perform action "start" on user daemon "test-snap.svc"`)
+}
+
 func (s *serviceControlSuite) TestNoServiceCommandError(c *C) {
 	st := s.state
 	st.Lock()

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -123,6 +123,12 @@ func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction, flags
 	var tts []*state.TaskSet
 	var ctlcmds []string
 
+	for _, app := range appInfos {
+		if app.DaemonScope != snap.SystemDaemon {
+			return nil, fmt.Errorf("cannot perform action %q on user daemon %q", inst.Action, app)
+		}
+	}
+
 	// create exec-command tasks for compatibility with old snapd
 	if flags != nil && flags.CreateExecCommandTasks {
 		switch {

--- a/tests/main/snap-user-service-control/task.yaml
+++ b/tests/main/snap-user-service-control/task.yaml
@@ -1,0 +1,38 @@
+summary: Check that service control commands fail for user services
+
+systems:
+    # Ubuntu 14.04 refuses to install snaps with user services
+    - -ubuntu-14.04-*
+
+prepare: |
+    snap set system experimental.user-daemons=true
+
+restore: |
+    snap unset system experimental.user-daemons
+    rm -f error.txt
+
+
+execute: |
+    echo "Install a service containing a user service"
+    "$TESTSTOOLS"/snaps-state install-local test-snap
+
+    echo "'snap start' fails for a user service"
+    not snap start test-snap.svc 2> error.txt
+    MATCH 'cannot perform action "start" on user daemon "test-snap.svc"' < error.txt
+
+    echo "The same goes for 'snap stop'"
+    not snap stop test-snap.svc 2> error.txt
+    MATCH 'cannot perform action "stop" on user daemon "test-snap.svc"' < error.txt
+
+    echo "And 'snap restart'"
+    not snap restart test-snap.svc 2> error.txt
+    MATCH 'cannot perform action "restart" on user daemon "test-snap.svc"' < error.txt
+
+    echo "The equivalent snapctl commands fail too"
+    not test-snap.snapctl start test-snap.svc 2> error.txt
+    MATCH 'cannot perform action "start" on user daemon "test-snap.svc"' < error.txt
+    not test-snap.snapctl stop test-snap.svc 2> error.txt
+    MATCH 'cannot perform action "stop" on user daemon "test-snap.svc"' < error.txt
+    not test-snap.snapctl restart test-snap.svc 2> error.txt
+    MATCH 'cannot perform action "restart" on user daemon "test-snap.svc"' < error.txt
+

--- a/tests/main/snap-user-service-control/test-snap/bin/service.sh
+++ b/tests/main/snap-user-service-control/test-snap/bin/service.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "service running"
+exec sleep infinity

--- a/tests/main/snap-user-service-control/test-snap/bin/snapctl.sh
+++ b/tests/main/snap-user-service-control/test-snap/bin/snapctl.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec snapctl "$@"

--- a/tests/main/snap-user-service-control/test-snap/meta/snap.yaml
+++ b/tests/main/snap-user-service-control/test-snap/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snap
+version: 1.0
+apps:
+  snapctl:
+    command: bin/snapctl.sh
+  svc:
+    command: bin/service.sh
+    daemon: simple
+    daemon-scope: user


### PR DESCRIPTION
This PR updates the service control commands to detect and refuse to operate on user daemons.  While we may eventually want to do something sensible for user daemons in future, for now it is better to return an error message rather than ask the system instance of systemd to try and control services it doesn't know about and see that fail.