### PR TITLE
cmd/snap/pack: unhide the compression option

### DIFF
--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -38,7 +38,7 @@ import (
 type packCmd struct {
 	CheckSkeleton bool   `long:"check-skeleton"`
 	Filename      string `long:"filename"`
-	Compression   string `long:"compression" hidden:"yes"`
+	Compression   string `long:"compression"`
 	Positional    struct {
 		SnapDir   string `positional-arg-name:"<snap-dir>"`
 		TargetDir string `positional-arg-name:"<target-dir>"`
@@ -76,7 +76,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"filename": i18n.G("Output to this filename"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"compression": i18n.G("Compression to use (e.g. xz)"),
+			"compression": i18n.G("Compression to use (e.g. xz or lzo)"),
 		}, nil)
 	cmd.extra = func(cmd *flags.Command) {
 		// TRANSLATORS: this describes the default filename for a snap, e.g. core_16-2.35.2_amd64.snap


### PR DESCRIPTION
We now fully support using compression lzo and not just xz, so there's no
reason to continue to hide the compression option here.