### PR TITLE
o/configstate: deal with no longer valid refresh.timer=managed

### DIFF
--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -115,6 +115,10 @@ execute: |
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
     systemctl start snapd.socket snapd.service
 
+    # unset because 'managed' will not be rejected if is already set in state.
+    snap unset core refresh.schedule
+    snap unset core refresh.timer
+
     echo "When the snapd-control-with-manage plug is disconnected"
     snap disconnect test-snapd-control-consumer:snapd-control-with-manage
 


### PR DESCRIPTION
Deal with no longer valid refresh.timer=managed / refresh.schedule=managed in the state when validating refresh config option of core. This option may become invalid if the snap managing refreshes is not signed anymore (i.e. devicestate.CanManageRefreshes returns false). The idea is to detect whether the value came in the transaction changes or became invalid in the existing config; if it's the latter, then it's ignored and doesn't interrupt the processing of remaining options. refreshScheduleManaged() handles this correctly and if "managed" cannot be supported anymore, we log it.

This isn't ideal. Ideally config infra would handle this for all options (but this probably needs discussion and is a larger piece of work). If this fix seems acceptable, then I'll try to work on a spread test.

Related bug: https://bugs.launchpad.net/snapd/+bug/1899992
