### PR TITLE
cmd/snap-bootstrap/initramfs-mounts: move time forward using assertion times

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -65,6 +65,8 @@ type initramfsMountsSuite struct {
 	model    *asserts.Model
 	tmpDir   string
 
+	snapDeclAssertsTime time.Time
+
 	kernel   snap.PlaceInfo
 	kernelr2 snap.PlaceInfo
 	core20   snap.PlaceInfo
@@ -128,7 +130,7 @@ func (m *mockedWrappedError) Unwrap() error { return m.err }
 
 func (m *mockedWrappedError) Error() string { return fmt.Sprintf(m.fmt, m.err) }
 
-func (s *initramfsMountsSuite) setupSeed(c *C, gadgetSnapFiles [][]string) {
+func (s *initramfsMountsSuite) setupSeed(c *C, modelAssertTime time.Time, gadgetSnapFiles [][]string) {
 	// pretend /run/mnt/ubuntu-seed has a valid seed
 	s.seedDir = boot.InitramfsUbuntuSeedDir
 
@@ -143,17 +145,27 @@ func (s *initramfsMountsSuite) setupSeed(c *C, gadgetSnapFiles [][]string) {
 		"verification": "verified",
 	})
 
+	// make sure all the assertions use the same time
+	seed20.SetSnapAssertionNow(s.snapDeclAssertsTime)
+
 	// add a bunch of snaps
 	seed20.MakeAssertedSnap(c, "name: snapd\nversion: 1\ntype: snapd", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: pc\nversion: 1\ntype: gadget\nbase: core20", gadgetSnapFiles, snap.R(1), "canonical", seed20.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: pc-kernel\nversion: 1\ntype: kernel", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: core20\nversion: 1\ntype: base", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 
+	// pretend that by default, the model uses an older timestamp than the
+	// snap assertions
+	if modelAssertTime.IsZero() {
+		modelAssertTime = s.snapDeclAssertsTime.Add(-30 * time.Minute)
+	}
+
 	s.sysLabel = "20191118"
 	s.model = seed20.MakeSeed(c, s.sysLabel, "my-brand", "my-model", map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
+		"timestamp":    modelAssertTime.Format(time.RFC3339),
 		"snaps": []interface{}{
 			map[string]interface{}{
 				"name":            "pc-kernel",
@@ -168,7 +180,6 @@ func (s *initramfsMountsSuite) setupSeed(c *C, gadgetSnapFiles [][]string) {
 				"default-channel": "20",
 			}},
 	}, nil)
-
 }
 
 func (s *initramfsMountsSuite) SetUpTest(c *C) {
@@ -186,8 +197,13 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 	restore = func() { dirs.SetRootDir("") }
 	s.AddCleanup(restore)
 
+	// use a specific time for all the assertions, in the future so that we can
+	// set the timestamp of the model assertion to something newer than now, but
+	// still older than the snap declarations by default
+	s.snapDeclAssertsTime = time.Now().Add(60 * time.Minute)
+
 	// setup the seed
-	s.setupSeed(c, nil)
+	s.setupSeed(c, time.Time{}, nil)
 
 	// make test snap PlaceInfo's for various boot functionality
 	var err error
@@ -222,6 +238,71 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 	s.AddCleanup(main.MockSecbootLockSealedKeys(func() error {
 		return nil
 	}))
+
+	s.AddCleanup(main.MockOsutilSetTime(func(time.Time) error {
+		return nil
+	}))
+}
+
+// static test cases for time test variants shared across the different modes
+
+type timeTestCase struct {
+	now       time.Time
+	modelTime time.Time
+	expT      time.Time
+	comment   string
+}
+
+func (s *initramfsMountsSuite) timeTestCases() []timeTestCase {
+	// epoch time
+	epoch := time.Time{}
+
+	// t1 is the kernel initrd build time
+	t1 := s.snapDeclAssertsTime.Add(-30 * 24 * time.Hour)
+	// technically there is another time here between t1 and t2, that is the
+	// default model sign time, but since it's older than the snap assertion
+	// sign time (t2) it's not actually used in the test
+
+	// t2 is the time that snap-revision / snap-declaration assertions will be
+	// signed with
+	t2 := s.snapDeclAssertsTime
+
+	// t3 is a time after the snap-declarations are signed
+	t3 := s.snapDeclAssertsTime.Add(30 * 24 * time.Hour)
+
+	// t4 and t5 are both times after the the snap declarations are signed
+	t4 := s.snapDeclAssertsTime.Add(60 * 24 * time.Hour)
+	t5 := s.snapDeclAssertsTime.Add(120 * 24 * time.Hour)
+
+	return []timeTestCase{
+		{
+			now:     epoch,
+			expT:    t2,
+			comment: "now() is epoch",
+		},
+		{
+			now:     t1,
+			expT:    t2,
+			comment: "now() is kernel initrd sign time",
+		},
+		{
+			now:     t3,
+			expT:    t3,
+			comment: "now() is newer than snap assertion",
+		},
+		{
+			now:       t3,
+			modelTime: t4,
+			expT:      t4,
+			comment:   "model time is newer than now(), which is newer than snap asserts",
+		},
+		{
+			now:       t5,
+			modelTime: t4,
+			expT:      t5,
+			comment:   "model time is newest, but older than now()",
+		},
+	}
 }
 
 // helpers to create consistent UnlockResult values
@@ -462,6 +543,56 @@ grade=signed
 	c.Check(sealedKeysLocked, Equals, true)
 }
 
+func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeTimeMovesForwardHappy(c *C) {
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install snapd_recovery_system="+s.sysLabel)
+
+	for _, tc := range s.timeTestCases() {
+		comment := Commentf(tc.comment)
+		cleanups := []func(){}
+
+		// always remove the ubuntu-seed dir, otherwise setupSeed complains the
+		// model file already exists and can't setup the seed
+		err := os.RemoveAll(filepath.Join(boot.InitramfsUbuntuSeedDir))
+		c.Assert(err, IsNil, comment)
+		s.setupSeed(c, tc.modelTime, nil)
+
+		restore := main.MockTimeNow(func() time.Time {
+			return tc.now
+		})
+		cleanups = append(cleanups, restore)
+
+		// check what time we try to move forward to
+		restore = main.MockOsutilSetTime(func(t time.Time) error {
+			// make sure the timestamps are within 1 second of each other, they
+			// won't be equal since the timestamp is serialized to an assertion and
+			// read back
+			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			return nil
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = s.mockSystemdMountSequence(c, []systemdMount{
+			ubuntuLabelMount("ubuntu-seed", "install"),
+			s.makeSeedSnapSystemdMount(snap.TypeSnapd),
+			s.makeSeedSnapSystemdMount(snap.TypeKernel),
+			s.makeSeedSnapSystemdMount(snap.TypeBase),
+			{
+				"tmpfs",
+				boot.InitramfsDataDir,
+				tmpfsMountOpts,
+			},
+		}, nil)
+		cleanups = append(cleanups, restore)
+
+		_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+		c.Assert(err, IsNil, comment)
+
+		for _, r := range cleanups {
+			r()
+		}
+	}
+}
+
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeGadgetDefaultsHappy(c *C) {
 	// setup a seed with default gadget yaml
 	const gadgetYamlDefaults = `
@@ -475,7 +606,7 @@ defaults:
 `
 	c.Assert(os.RemoveAll(s.seedDir), IsNil)
 
-	s.setupSeed(c, [][]string{
+	s.setupSeed(c, time.Time{}, [][]string{
 		{"meta/gadget.yaml", gadgetYamlDefaults},
 	})
 
@@ -608,6 +739,81 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUnencryptedWithSaveHapp
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
+}
+
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeTimeMovesForwardHappy(c *C) {
+
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
+
+	for _, tc := range s.timeTestCases() {
+		comment := Commentf(tc.comment)
+		cleanups := []func(){}
+
+		// always remove the ubuntu-seed dir, otherwise setupSeed complains the
+		// model file already exists and can't setup the seed
+		err := os.RemoveAll(filepath.Join(boot.InitramfsUbuntuSeedDir))
+		c.Assert(err, IsNil, comment)
+		s.setupSeed(c, tc.modelTime, nil)
+
+		restore := main.MockTimeNow(func() time.Time {
+			return tc.now
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = disks.MockMountPointDisksToPartitionMapping(
+			map[disks.Mountpoint]*disks.MockDiskMapping{
+				{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultBootDisk,
+				{Mountpoint: boot.InitramfsDataDir}:       defaultBootDisk,
+			},
+		)
+		cleanups = append(cleanups, restore)
+
+		// check what time we try to move forward to
+		restore = main.MockOsutilSetTime(func(t time.Time) error {
+			// make sure the timestamps are within 1 second of each other, they
+			// won't be equal since the timestamp is serialized to an assertion and
+			// read back
+			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			return nil
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = s.mockSystemdMountSequence(c, []systemdMount{
+			ubuntuLabelMount("ubuntu-boot", "run"),
+			ubuntuPartUUIDMount("ubuntu-seed-partuuid", "run"),
+			ubuntuPartUUIDMount("ubuntu-data-partuuid", "run"),
+			s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
+			s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+		}, nil)
+		cleanups = append(cleanups, restore)
+
+		// mock a bootloader
+		bloader := boottest.MockUC20RunBootenv(bootloadertest.Mock("mock", c.MkDir()))
+		bootloader.Force(bloader)
+		cleanups = append(cleanups, func() { bootloader.Force(nil) })
+
+		// set the current kernel
+		restore = bloader.SetEnabledKernel(s.kernel)
+		cleanups = append(cleanups, restore)
+
+		makeSnapFilesOnEarlyBootUbuntuData(c, s.kernel, s.core20)
+
+		// write modeenv
+		modeEnv := boot.Modeenv{
+			Mode:           "run",
+			Base:           s.core20.Filename(),
+			CurrentKernels: []string{s.kernel.Filename()},
+		}
+		err = modeEnv.WriteTo(boot.InitramfsWritableDir)
+		c.Assert(err, IsNil, comment)
+
+		_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+		c.Assert(err, IsNil, comment)
+
+		for _, r := range cleanups {
+			r()
+		}
+	}
 }
 
 func (s *initramfsMountsSuite) testInitramfsMountsRunModeNoSaveUnencrypted(c *C) error {
@@ -2413,6 +2619,90 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappy(c *C) {
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "degraded.json"), testutil.FileAbsent)
 }
 
+func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeTimeMovesForwardHappy(c *C) {
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=recover snapd_recovery_system="+s.sysLabel)
+
+	for _, tc := range s.timeTestCases() {
+		comment := Commentf(tc.comment)
+		cleanups := []func(){}
+
+		// always remove the ubuntu-seed dir, otherwise setupSeed complains the
+		// model file already exists and can't setup the seed
+		err := os.RemoveAll(filepath.Join(boot.InitramfsUbuntuSeedDir))
+		c.Assert(err, IsNil, comment)
+
+		// also always remove the data dir, since we need to copy state.json
+		// there, so if the file already exists the initramfs code dies
+		err = os.RemoveAll(filepath.Join(boot.InitramfsDataDir))
+		c.Assert(err, IsNil, comment)
+
+		s.setupSeed(c, tc.modelTime, nil)
+
+		restore := main.MockTimeNow(func() time.Time {
+			return tc.now
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = disks.MockMountPointDisksToPartitionMapping(
+			map[disks.Mountpoint]*disks.MockDiskMapping{
+				{Mountpoint: boot.InitramfsUbuntuSeedDir}:     defaultBootWithSaveDisk,
+				{Mountpoint: boot.InitramfsUbuntuBootDir}:     defaultBootWithSaveDisk,
+				{Mountpoint: boot.InitramfsHostUbuntuDataDir}: defaultBootWithSaveDisk,
+				{Mountpoint: boot.InitramfsUbuntuSaveDir}:     defaultBootWithSaveDisk,
+			},
+		)
+		cleanups = append(cleanups, restore)
+
+		// check what time we try to move forward to
+		restore = main.MockOsutilSetTime(func(t time.Time) error {
+			// make sure the timestamps are within 1 second of each other, they
+			// won't be equal since the timestamp is serialized to an assertion and
+			// read back
+			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			return nil
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = s.mockSystemdMountSequence(c, []systemdMount{
+			ubuntuLabelMount("ubuntu-seed", "recover"),
+			s.makeSeedSnapSystemdMount(snap.TypeSnapd),
+			s.makeSeedSnapSystemdMount(snap.TypeKernel),
+			s.makeSeedSnapSystemdMount(snap.TypeBase),
+			{
+				"tmpfs",
+				boot.InitramfsDataDir,
+				tmpfsMountOpts,
+			},
+			{
+				"/dev/disk/by-partuuid/ubuntu-boot-partuuid",
+				boot.InitramfsUbuntuBootDir,
+				needsFsckDiskMountOpts,
+			},
+			{
+				"/dev/disk/by-partuuid/ubuntu-data-partuuid",
+				boot.InitramfsHostUbuntuDataDir,
+				nil,
+			},
+			{
+				"/dev/disk/by-partuuid/ubuntu-save-partuuid",
+				boot.InitramfsUbuntuSaveDir,
+				nil,
+			},
+		}, nil)
+		cleanups = append(cleanups, restore)
+
+		bloader := bootloadertest.Mock("mock", c.MkDir())
+		bootloader.Force(bloader)
+		cleanups = append(cleanups, func() { bootloader.Force(nil) })
+
+		s.testRecoverModeHappy(c)
+
+		for _, r := range cleanups {
+			r()
+		}
+	}
+}
+
 func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeGadgetDefaultsHappy(c *C) {
 	// setup a seed with default gadget yaml
 	const gadgetYamlDefaults = `
@@ -2426,7 +2716,7 @@ defaults:
 `
 	c.Assert(os.RemoveAll(s.seedDir), IsNil)
 
-	s.setupSeed(c, [][]string{
+	s.setupSeed(c, time.Time{}, [][]string{
 		{"meta/gadget.yaml", gadgetYamlDefaults},
 	})
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -571,11 +571,12 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeTimeMovesForwardHap
 		// check what time we try to move forward to
 		restore = main.MockOsutilSetTime(func(t time.Time) error {
 			osutilSetTimeCalls++
-
 			// make sure the timestamps are within 1 second of each other, they
 			// won't be equal since the timestamp is serialized to an assertion and
 			// read back
-			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			tTrunc := t.Truncate(2 * time.Second)
+			expTTrunc := tc.expT.Truncate(2 * time.Second)
+			c.Assert(tTrunc.Equal(expTTrunc), Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
 			return nil
 		})
 		cleanups = append(cleanups, restore)
@@ -787,7 +788,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeTimeMovesForwardHappy(c
 				// make sure the timestamps are within 1 second of each other, they
 				// won't be equal since the timestamp is serialized to an assertion and
 				// read back
-				c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+				tTrunc := t.Truncate(2 * time.Second)
+				expTTrunc := tc.expT.Truncate(2 * time.Second)
+				c.Assert(tTrunc.Equal(expTTrunc), Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
 				return nil
 			})
 			cleanups = append(cleanups, restore)
@@ -841,6 +844,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeTimeMovesForwardHappy(c
 			if isFirstBoot {
 				c.Assert(osutilSetTimeCalls, Equals, tc.setTimeCalls, comment)
 			} else {
+				// non-first boot should not have moved the time at all since it
+				// doesn't read assertions
 				c.Assert(osutilSetTimeCalls, Equals, 0, comment)
 			}
 
@@ -2695,7 +2700,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeTimeMovesForwardHap
 			// make sure the timestamps are within 1 second of each other, they
 			// won't be equal since the timestamp is serialized to an assertion and
 			// read back
-			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			tTrunc := t.Truncate(2 * time.Second)
+			expTTrunc := tc.expT.Truncate(2 * time.Second)
+			c.Assert(tTrunc.Equal(expTTrunc), Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
 			return nil
 		})
 		cleanups = append(cleanups, restore)

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -56,6 +56,14 @@ func MockTimeNow(f func() time.Time) (restore func()) {
 	}
 }
 
+func MockOsutilSetTime(f func(t time.Time) error) (restore func()) {
+	old := osutilSetTime
+	osutilSetTime = f
+	return func() {
+		osutilSetTime = old
+	}
+}
+
 func MockOsutilIsMounted(f func(string) (bool, error)) (restore func()) {
 	old := osutilIsMounted
 	osutilIsMounted = f

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -75,11 +75,14 @@ func (mst *initramfsMountsState) ReadEssential(recoverySystem string, essentialT
 		return nil, nil, err
 	}
 
-	// set the time on the system to move forward
-	if err := osutilSetTime(newTrustedEarliestTime); err != nil {
-		// log the error but don't fail on it, we should be able to continue
-		// even if the time can't be moved forward
-		logger.Noticef("failed to move time forward from %s to %s: %v", now, newTrustedEarliestTime, err)
+	// set the time on the system to move forward if it is in the future - never
+	// move the time backwards
+	if newTrustedEarliestTime.After(now) {
+		if err := osutilSetTime(newTrustedEarliestTime); err != nil {
+			// log the error but don't fail on it, we should be able to continue
+			// even if the time can't be moved forward
+			logger.Noticef("failed to move time forward from %s to %s: %v", now, newTrustedEarliestTime, err)
+		}
 	}
 
 	return model, snaps, nil

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -27,9 +27,15 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
+)
+
+var (
+	osutilSetTime = osutil.SetTime
 )
 
 // initramfsMountsState helps tracking the state and progress
@@ -53,7 +59,30 @@ func (mst *initramfsMountsState) ReadEssential(recoverySystem string, essentialT
 	}
 
 	perf := timings.New(nil)
-	return seed.ReadSystemEssential(boot.InitramfsUbuntuSeedDir, recoverySystem, essentialTypes, perf)
+
+	// get the current time to pass to ReadSystemEssentialAndBetterEarliestTime
+	// note that we trust the time we have from the system, because that time
+	// comes from either:
+	// * a RTC on the system that the kernel/systemd consulted and used to move
+	//   time forward
+	// * systemd using a built-in timestamp from the initrd which was stamped
+	//   when the initrd was built, giving a lower bound on the current time if
+	//   the RTC does not have a battery or is otherwise unreliable, etc.
+	now := timeNow()
+
+	model, snaps, newTrustedEarliestTime, err := seed.ReadSystemEssentialAndBetterEarliestTime(boot.InitramfsUbuntuSeedDir, recoverySystem, essentialTypes, now, perf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// set the time on the system to move forward
+	if err := osutilSetTime(newTrustedEarliestTime); err != nil {
+		// log the error but don't fail on it, we should be able to continue
+		// even if the time can't be moved forward
+		logger.Noticef("failed to move time forward from %s to %s: %v", now, newTrustedEarliestTime, err)
+	}
+
+	return model, snaps, nil
 }
 
 // UnverifiedBootModel returns the unverified model from the

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -811,7 +811,7 @@ nested_start_core_vm_unit() {
         exit 1
     fi
 
-    local PARAM_DISPLAY PARAM_NETWORK PARAM_MONITOR PARAM_USB PARAM_CD PARAM_RANDOM PARAM_CPU PARAM_TRACE PARAM_LOG PARAM_SERIAL
+    local PARAM_DISPLAY PARAM_NETWORK PARAM_MONITOR PARAM_USB PARAM_CD PARAM_RANDOM PARAM_CPU PARAM_TRACE PARAM_LOG PARAM_SERIAL PARAM_RTC
     PARAM_DISPLAY="-nographic"
     PARAM_NETWORK="-net nic,model=virtio -net user,hostfwd=tcp::$NESTED_SSH_PORT-:22"
     PARAM_MONITOR="-monitor tcp:127.0.0.1:$NESTED_MON_PORT,server,nowait"
@@ -821,6 +821,8 @@ nested_start_core_vm_unit() {
     PARAM_CPU=""
     PARAM_TRACE="-d cpu_reset"
     PARAM_LOG="-D $NESTED_LOGS_DIR/qemu.log"
+    PARAM_RTC="${NESTED_PARAM_RTC:-}"
+
     # Open port 7777 on the host so that failures in the nested VM (e.g. to
     # create users) can be debugged interactively via
     # "telnet localhost 7777". Also keeps the logs
@@ -928,6 +930,7 @@ nested_start_core_vm_unit() {
         ${PARAM_MEM} \
         ${PARAM_TRACE} \
         ${PARAM_LOG} \
+        ${PARAM_RTC} \
         ${PARAM_MACHINE} \
         ${PARAM_DISPLAY} \
         ${PARAM_NETWORK} \

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -504,7 +504,15 @@ nested_create_core_vm() {
 
                 elif nested_is_core_20_system; then
                     snap download --basename=pc-kernel --channel="20/edge" pc-kernel
-                    uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+
+                    # set the unix bump time if the NESTED_* var is set, 
+                    # otherwise leave it empty
+                    local epochBumpTime
+                    epochBumpTime=${NESTED_CORE20_INITRAMFS_EPOCH_TIMESTAMP:-}
+                    if [ -n "$epochBumpTime" ]; then
+                        epochBumpTime="--epoch-bump-time=$epochBumpTime"
+                    fi
+                    uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR" "$epochBumpTime"
                     rm -f "$PWD/pc-kernel.snap"
 
                     # Prepare the pc kernel snap

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -523,6 +523,7 @@ uc20_build_initramfs_kernel_snap() {
             # also copy the time for the clock-epoch to system-data, this is 
             # used by a specific test but doesn't hurt anything to do this for 
             # all tests
+            echo "if test -f /run/mnt/data/system-data/clock-epoch; then rm -r /run/mnt/data/system-data/clock-epoch; fi"
             echo "if test -d /run/mnt/data/system-data; then cp -a /usr/lib/clock-epoch /run/mnt/data/system-data/clock-epoch; fi"
             echo "if test -d /run/mnt/data/system-data; then echo \"\$beforeDate\" > /run/mnt/data/system-data/before-snap-bootstrap-date; fi"
             echo "if test -d /run/mnt/data/system-data; then date --utc '+%s' > /run/mnt/data/system-data/after-snap-bootstrap-date; fi"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -523,10 +523,11 @@ uc20_build_initramfs_kernel_snap() {
             # also copy the time for the clock-epoch to system-data, this is 
             # used by a specific test but doesn't hurt anything to do this for 
             # all tests
-            echo "if test -f /run/mnt/data/system-data/clock-epoch; then rm -r /run/mnt/data/system-data/clock-epoch; fi"
-            echo "if test -d /run/mnt/data/system-data; then cp -a /usr/lib/clock-epoch /run/mnt/data/system-data/clock-epoch; fi"
-            echo "if test -d /run/mnt/data/system-data; then echo \"\$beforeDate\" > /run/mnt/data/system-data/before-snap-bootstrap-date; fi"
-            echo "if test -d /run/mnt/data/system-data; then date --utc '+%s' > /run/mnt/data/system-data/after-snap-bootstrap-date; fi"
+            echo "mode=\$(grep -Eo 'snapd_recovery_mode=([a-z]+)' /proc/cmdline)"
+            echo "mode=\${mode##snapd_recovery_mode=}"
+            echo "stat -c '%Y' /usr/lib/clock-epoch >> /run/mnt/ubuntu-seed/\${mode}-clock-epoch"
+            echo "echo \"\$beforeDate\" > /run/mnt/ubuntu-seed/\${mode}-before-snap-bootstrap-date"
+            echo "date --utc '+%s' > /run/mnt/ubuntu-seed/\${mode}-after-snap-bootstrap-date"
         } >> "$skeletondir/main/usr/lib/the-tool"
 
         if [ "$injectKernelPanic" = "true" ]; then

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -1,0 +1,36 @@
+summary: Test that time moves forward when the RTC is broken/unavailable in UC20
+
+systems: [ubuntu-20.04-64]
+
+environment:
+  NESTED_IMAGE_ID: core20-initramfs-time-moves-forward
+  NESTED_BUILD_SNAPD_FROM_CURRENT: true
+  NESTED_USE_CLOUD_INIT: true
+
+  # disable the real time clock and effectively break it so it returns unix
+  # epoch to simulate devices like the rpi which do not have RTC
+  NESTED_PARAM_RTC: "-rtc base=1970-01-01"
+
+  # this is the unix time timestamp we want the initramfs to use, 1 here is just
+  # 1 second after the unix epoch
+  NESTED_CORE20_INITRAMFS_EPOCH_TIMESTAMP: 1
+
+prepare: |
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  "$TESTSTOOLS"/nested-state build-image core
+  "$TESTSTOOLS"/nested-state create-vm core
+
+execute: |
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  echo "Verify that the clock-epoch time is the unix epoch"
+  test "$(nested_exec "stat -c %Y /run/mnt/data/system-data/clock-epoch")" = 180000
+
+  echo "Verify that the timestamp from after snap-bootstrap ran is greater than the time from the model assertion"
+  # this is the timestamp from the model assertion, minus 1 second
+  # note that if the model assertion ever gets resigned, the timestamp should 
+  # not move backward so this will still be true / valid
+  test "$(nested_exec "cat /run/mnt/data/system-data/after-snap-bootstrap-date")" -ge 1606490999

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -15,6 +15,12 @@ environment:
   # 1 second after the unix epoch
   NESTED_CORE20_INITRAMFS_EPOCH_TIMESTAMP: 1
 
+  # this is one second before the model assertion timestamp, this should be
+  # bumped if the model assertion is ever resigned with a newer timestamp in it,
+  # but doesn't strictly need to be updated every time as long as the timestamp
+  # increases monotonically the test is still valid
+  MODEL_ASSERTION_SIGN_TIME: 1606490999
+
 prepare: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
@@ -26,11 +32,8 @@ execute: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
-  echo "Verify that the clock-epoch time is the unix epoch"
-  test "$(nested_exec "stat -c %Y /run/mnt/data/system-data/clock-epoch")" = 180000
+  echo "Verify that the current time in the VM is newer than the model assertion sign time"
+  test "$(nested_exec date --utc '+%s')" -ge "$MODEL_ASSERTION_SIGN_TIME"
 
   echo "Verify that the timestamp from after snap-bootstrap ran is greater than the time from the model assertion"
-  # this is the timestamp from the model assertion, minus 1 second
-  # note that if the model assertion ever gets resigned, the timestamp should 
-  # not move backward so this will still be true / valid
-  test "$(nested_exec "cat /run/mnt/data/system-data/after-snap-bootstrap-date")" -ge 1606490999
+  test "$(nested_exec "cat /run/mnt/ubuntu-seed/install-after-snap-bootstrap-date")" -ge "$MODEL_ASSERTION_SIGN_TIME"

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -9,7 +9,7 @@ environment:
 
   # disable the real time clock and effectively break it so it returns unix
   # epoch to simulate devices like the rpi which do not have RTC
-  NESTED_PARAM_RTC: "-rtc base=1970-01-01"
+  NESTED_PARAM_RTC: "-rtc base=1970-01-01,clock=vm"
 
   # this is the unix time timestamp we want the initramfs to use, 1 here is just
   # 1 second after the unix epoch


### PR DESCRIPTION
This uses ReadSystemEssentialAndBetterEarliestTime in order to get a trusted
time that the system can be moved forward to, providing as input the current
time from the system, which should be trusted, as it is either from a RTC, or
from systemd moving the time forward to when the initrd was built.

Also add tests for the various different relative times that can exist during
the initramfs for each mode.

Also add a nested spread test simulating this sort of device. If folks want I could break out the spread test to a followup.