### PR TITLE
cmd/snap: packaging: move snap binary to /usr/lib/snapd/snap, fix invocation of internal tools

### DIFF
--- a/packaging/ubuntu-16.04/snapd.install
+++ b/packaging/ubuntu-16.04/snapd.install
@@ -1,4 +1,4 @@
-usr/bin/snap
+usr/bin/snap /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/
 usr/lib/snapd/system-shutdown
 usr/bin/snap-exec /usr/lib/snapd/

--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -1,5 +1,6 @@
 /usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
 usr/lib/snapd/snapctl usr/bin/snapctl
+usr/lib/snapd/snap usr/bin/snap
 
 # This should be removed once we can rely on debhelper >= 11.5:
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678

--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -217,6 +217,19 @@ func IsReexecd() (bool, error) {
 	return false, nil
 }
 
+// IsFromSnapdSnap returns true when the current process binary is running from
+// the snapd snap.
+func IsFromSnapdSnap() (bool, error) {
+	exe, err := osReadlink(selfExe)
+	if err != nil {
+		return false, err
+	}
+	if !strings.HasPrefix(exe, filepath.Join(dirs.SnapMountDir, "snapd")) {
+		return false, nil
+	}
+	return true, nil
+}
+
 // MockOsReadlink is for use in tests
 func MockOsReadlink(f func(string) (string, error)) func() {
 	realOsReadlink := osReadlink

--- a/snapdtool/tool_other.go
+++ b/snapdtool/tool_other.go
@@ -47,3 +47,11 @@ func InternalToolPath(tool string) (string, error) {
 func IsReexecd() (bool, error) {
 	return false, errUnsupported
 }
+
+// IsFromSnapdSnap returns true when the current process binary is running from
+// the snapd snap.
+//
+// On this OS this is a stub and always returns an error.
+func IsFromSnapdSnap() (bool, error) {
+	return false, errUnsupported
+}

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -334,6 +334,8 @@ repack_snapd_snap_with_deb_content() {
     # file in place. Its called usr.lib.snapd.snap-confine on 14.04 but
     # usr.lib.snapd.snap-confine.real everywhere else
     rm -f "$UNPACK_DIR"/etc/apparmor.d/*
+    rm -f "$UNPACK_DIR"/usr/bin/snap
+    rm -f "$UNPACK_DIR"/usr/lib/snapd/*
 
     dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
     cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/snapd

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -43,6 +43,9 @@ var snapdServiceStopTimeout = time.Duration(timeout.DefaultTimeout)
 // catches units that run /usr/bin/snap (with args), or things in /usr/lib/snapd/
 var execStartRe = regexp.MustCompile(`(?m)^ExecStart=(/usr/bin/snap\s+.*|/usr/lib/snapd/.*)$`)
 
+// snapdToolingMountUnit is the name of the mount unit that makes the
+const snapdToolingMountUnit = "usr-lib-snapd.mount"
+
 func snapdSkipStart(content []byte) bool {
 	return bytes.Contains(content, []byte("X-Snapd-Snap: do-not-start"))
 }
@@ -77,8 +80,7 @@ Options=bind
 [Install]
 WantedBy=snapd.service
 `, prefix))
-	unit := "usr-lib-snapd.mount"
-	fullPath := filepath.Join(dirs.SnapServicesDir, unit)
+	fullPath := filepath.Join(dirs.SnapServicesDir, snapdToolingMountUnit)
 
 	err := osutil.EnsureFileState(fullPath,
 		&osutil.MemoryFileState{
@@ -95,11 +97,11 @@ WantedBy=snapd.service
 	if err := sysd.DaemonReload(); err != nil {
 		return err
 	}
-	if err := sysd.Enable(unit); err != nil {
+	if err := sysd.Enable(snapdToolingMountUnit); err != nil {
 		return err
 	}
 
-	if err := sysd.Restart(unit, 5*time.Second); err != nil {
+	if err := sysd.Restart(snapdToolingMountUnit, 5*time.Second); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
On Core systems with the snapd snap, /usr/bin/snap is a symlink pointing to
/snap/snapd/current/usr/bin/snap. However, while the snapd snap is being
refreshed, the current symlink becomes invalid for a short while. Should a
reboot occur while this happens, the existing snap services will be unable to
start as /usr/bin/snap points to an invalid location.

To address this, we move the snap binary to /usr/lib/snapd/snap, as /usr/lib/snapd gets exported as the usr-lib-snapd.mount. Then the core18/20 snap has /usr/bin/snap which is a wrapper script that picks /snap/snap/current/usr/lib/snap or /usr/lib/snapd/snap.