### PR TITLE
tests: adding golang packages as dependency for hirsuite

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -594,6 +594,7 @@ pkg_dependencies_ubuntu_classic(){
         ubuntu-21.04-64)
             echo "
                 dbus-user-session
+                golang
                 qemu-utils
                 "
             ;;


### PR DESCRIPTION
This is to prevent the error:
+ go get -u github.com/kardianos/govendor
/home/gopath/src/github.com/snapcore/snapd/tests/lib/prepare-restore.sh:
line 493: go: command not found
