### PR TITLE
cmd/snap: use less aggressive client timeouts in unit tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -221,8 +221,8 @@ func (cs *clientSuite) TestClientDoRetryWorks(c *C) {
 	c.Check(err, ErrorMatches, "cannot communicate with server: borken")
 	// best effort checking given that execution could be slow
 	// on some machines
-	c.Assert(cs.doCalls > 500, Equals, true)
-	c.Assert(cs.doCalls < 1100, Equals, true)
+	c.Assert(cs.doCalls > 100, Equals, true, Commentf("got only %v calls", cs.doCalls))
+	c.Assert(cs.doCalls < 1100, Equals, true, Commentf("got %v calls", cs.doCalls))
 }
 
 func (cs *clientSuite) TestClientUnderstandsStatusCode(c *C) {

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -42,7 +42,7 @@ var _ = check.Suite(&appOpSuite{})
 func (s *appOpSuite) SetUpTest(c *check.C) {
 	s.BaseSnapSuite.SetUpTest(c)
 
-	restoreClientRetry := client.MockDoTimings(time.Millisecond, 100*time.Millisecond)
+	restoreClientRetry := client.MockDoTimings(time.Millisecond, time.Second)
 	restorePollTime := snap.MockPollTime(time.Millisecond)
 	s.AddCleanup(restoreClientRetry)
 	s.AddCleanup(restorePollTime)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -101,7 +101,7 @@ type SnapOpSuite struct {
 func (s *SnapOpSuite) SetUpTest(c *check.C) {
 	s.BaseSnapSuite.SetUpTest(c)
 
-	restoreClientRetry := client.MockDoTimings(time.Millisecond, 100*time.Millisecond)
+	restoreClientRetry := client.MockDoTimings(time.Millisecond, time.Second)
 	restorePollTime := snap.MockPollTime(time.Millisecond)
 	s.restoreAll = func() {
 		restoreClientRetry()


### PR DESCRIPTION
The client timeouts in unit tests are too aggressive. Specifically when running
on OBS, I often see a bunch of failures due to client timeouts being exceeded.
