### PR TITLE
interfaces/pwm: add PWM interface

### DIFF
--- a/interfaces/builtin/pwm.go
+++ b/interfaces/builtin/pwm.go
@@ -1,0 +1,144 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/systemd"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/snap"
+)
+
+// https://www.kernel.org/doc/Documentation/pwm.txt
+const pwmSummary = `allows access to specifc PWM channel`
+
+const pwmBaseDeclarationSlots = `
+  pwm:
+    allow-installation:
+      slot-snap-type:
+        - core
+        - gadget
+    deny-auto-connection: true
+`
+
+var pwmSysfsPwmChipBase = "/sys/class/pwm/pwmchip%d"
+
+// pwmInterface type
+type pwmInterface struct {
+	commonInterface
+}
+
+// BeforePrepareSlot checks the slot definition is valid
+func (iface *pwmInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
+	// must have a PWM channel
+	channel, ok := slot.Attrs["channel"]
+	if !ok {
+		return fmt.Errorf("pwm slot must have a channel attribute")
+	}
+
+	// valid values of channel
+	if _, ok := channel.(int64); !ok {
+		return fmt.Errorf("pwm slot channel attribute must be an int")
+	}
+
+	// must have a PWM chip number
+	chipNum, ok := slot.Attrs["chip-number"]
+	if !ok {
+		return fmt.Errorf("pwm slot must have a chip-number attribute")
+	}
+
+	// valid values of chip number
+	if _, ok := chipNum.(int64); !ok {
+		return fmt.Errorf("pwm slot chip-number attribute must be an int")
+	}
+
+	// slot is good
+	return nil
+}
+
+func (iface *pwmInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	var chipNum int64
+	if err := slot.Attr("chip-number", &chipNum); err != nil {
+		return err
+	}
+
+	var channel int64
+	if err := slot.Attr("channel", &channel); err != nil {
+		return err
+	}
+	path := fmt.Sprintf(pwmSysfsPwmChipBase, chipNum)
+	// Entries in /sys/class/pwm for PWM chips are just symlinks
+	// to their correct device part in the sysfs tree. Given AppArmor
+	// requires symlinks to be dereferenced, evaluate the PWM
+	// path and add the correct absolute path to the AppArmor snippet.
+	dereferencedPath, err := evalSymlinks(path)
+	if err != nil && os.IsNotExist(err) {
+		// If the specific pwm is not available there is no point
+		// exporting it, we should also not fail because this
+		// will block snapd updates (LP: 1866424)
+		logger.Noticef("cannot find not existing pwm chipbase %s", path)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	spec.AddSnippet(fmt.Sprintf("%s/pwm%d/* rwk,", dereferencedPath, channel))
+	return nil
+}
+
+func (iface *pwmInterface) SystemdConnectedSlot(spec *systemd.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	var chipNum int64
+	if err := slot.Attr("chip-number", &chipNum); err != nil {
+		return err
+	}
+
+	var channel int64
+	if err := slot.Attr("channel", &channel); err != nil {
+		return err
+	}
+
+	serviceName := interfaces.InterfaceServiceName(slot.Snap().InstanceName(), fmt.Sprintf("pwmchip%d-pwm%d", chipNum, channel))
+	service := &systemd.Service{
+		Type:            "oneshot",
+		RemainAfterExit: true,
+		ExecStart:       fmt.Sprintf("/bin/sh -c 'test -e /sys/class/pwm/pwmchip%[1]d/pwm%[2]d || echo %[2]d > /sys/class/pwm/pwmchip%[1]d/export'", chipNum, channel),
+		ExecStop:        fmt.Sprintf("/bin/sh -c 'test ! -e /sys/class/pwm/pwmchip%[1]d/pwm%[2]d || echo %[2]d > /sys/class/pwm/pwmchip%[1]d/unexport'", chipNum, channel),
+	}
+	return spec.AddService(serviceName, service)
+}
+
+func (iface *pwmInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
+func init() {
+	registerIface(&pwmInterface{commonInterface{
+		name:                 "pwm",
+		summary:              pwmSummary,
+		implicitOnCore:       true,
+		implicitOnClassic:    true,
+		baseDeclarationSlots: pwmBaseDeclarationSlots,
+	}})
+}

--- a/interfaces/builtin/pwm_test.go
+++ b/interfaces/builtin/pwm_test.go
@@ -1,0 +1,207 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/systemd"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type PwmInterfaceSuite struct {
+	testutil.BaseTest
+
+	iface                           interfaces.Interface
+	gadgetPwmSlotInfo               *snap.SlotInfo
+	gadgetPwmSlot                   *interfaces.ConnectedSlot
+	gadgetMissingChannelSlotInfo    *snap.SlotInfo
+	gadgetMissingChannelSlot        *interfaces.ConnectedSlot
+	gadgetBadChannelSlotInfo        *snap.SlotInfo
+	gadgetBadChannelSlot            *interfaces.ConnectedSlot
+	gadgetMissingChipNumberSlotInfo *snap.SlotInfo
+	gadgetMissingChipNumberSlot     *interfaces.ConnectedSlot
+	gadgetBadChipNumberSlotInfo     *snap.SlotInfo
+	gadgetBadChipNumberSlot         *interfaces.ConnectedSlot
+	gadgetBadInterfaceSlotInfo      *snap.SlotInfo
+	gadgetBadInterfaceSlot          *interfaces.ConnectedSlot
+	gadgetPlugInfo                  *snap.PlugInfo
+	gadgetPlug                      *interfaces.ConnectedPlug
+	gadgetBadInterfacePlugInfo      *snap.PlugInfo
+	gadgetBadInterfacePlug          *interfaces.ConnectedPlug
+	osPwmSlotInfo                   *snap.SlotInfo
+	osPwmSlot                       *interfaces.ConnectedSlot
+}
+
+var _ = Suite(&PwmInterfaceSuite{
+	iface: builtin.MustInterface("pwm"),
+})
+
+func (s *PwmInterfaceSuite) SetUpTest(c *C) {
+	gadgetInfo := snaptest.MockInfo(c, `
+name: my-device
+version: 0
+type: gadget
+slots:
+    my-pin:
+        interface: pwm
+        chip-number: 10
+        channel: 100
+    missing-channel:
+        interface: pwm
+        chip-number: 10
+    bad-channel:
+        interface: pwm
+        chip-number: 10
+        channel: forty-two
+    missing-chip-number:
+        interface: pwm
+        channel: 100
+    bad-chip-number:
+        interface: pwm
+        chip-number: forty-two
+        channel: 100
+    bad-interface-slot: other-interface
+plugs:
+    plug: pwm
+    bad-interface-plug: other-interface
+apps:
+    svc:
+        command: bin/foo.sh
+`, nil)
+	s.gadgetPwmSlotInfo = gadgetInfo.Slots["my-pin"]
+	s.gadgetPwmSlot = interfaces.NewConnectedSlot(s.gadgetPwmSlotInfo, nil, nil)
+	s.gadgetMissingChannelSlotInfo = gadgetInfo.Slots["missing-channel"]
+	s.gadgetMissingChannelSlot = interfaces.NewConnectedSlot(s.gadgetMissingChannelSlotInfo, nil, nil)
+	s.gadgetBadChannelSlotInfo = gadgetInfo.Slots["bad-channel"]
+	s.gadgetBadChannelSlot = interfaces.NewConnectedSlot(s.gadgetBadChannelSlotInfo, nil, nil)
+	s.gadgetMissingChipNumberSlotInfo = gadgetInfo.Slots["missing-chip-number"]
+	s.gadgetMissingChipNumberSlot = interfaces.NewConnectedSlot(s.gadgetMissingChipNumberSlotInfo, nil, nil)
+	s.gadgetBadChipNumberSlotInfo = gadgetInfo.Slots["bad-chip-number"]
+	s.gadgetBadChipNumberSlot = interfaces.NewConnectedSlot(s.gadgetBadChipNumberSlotInfo, nil, nil)
+	s.gadgetBadInterfaceSlotInfo = gadgetInfo.Slots["bad-interface-slot"]
+	s.gadgetBadInterfaceSlot = interfaces.NewConnectedSlot(s.gadgetBadInterfaceSlotInfo, nil, nil)
+	s.gadgetPlugInfo = gadgetInfo.Plugs["plug"]
+	s.gadgetPlug = interfaces.NewConnectedPlug(s.gadgetPlugInfo, nil, nil)
+	s.gadgetBadInterfacePlugInfo = gadgetInfo.Plugs["bad-interface-plug"]
+	s.gadgetBadInterfacePlug = interfaces.NewConnectedPlug(s.gadgetBadInterfacePlugInfo, nil, nil)
+
+	osInfo := snaptest.MockInfo(c, `
+name: my-core
+version: 0
+type: os
+slots:
+    my-pin:
+        interface: pwm
+        chip-number: 10
+        channel: 7
+`, nil)
+	s.osPwmSlotInfo = osInfo.Slots["my-pin"]
+	s.osPwmSlot = interfaces.NewConnectedSlot(s.osPwmSlotInfo, nil, nil)
+}
+
+func (s *PwmInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "pwm")
+}
+
+func (s *PwmInterfaceSuite) TestSanitizeSlotGadgetSnap(c *C) {
+	// pwm slot on gadget accepeted
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.gadgetPwmSlotInfo), IsNil)
+
+	// slots without channel attribute are rejected
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.gadgetMissingChannelSlotInfo), ErrorMatches,
+		"pwm slot must have a channel attribute")
+
+	// slots with channel attribute that isnt a number
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.gadgetBadChannelSlotInfo), ErrorMatches,
+		"pwm slot channel attribute must be an int")
+
+	// slots without chip-number attribute are rejected
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.gadgetMissingChipNumberSlotInfo), ErrorMatches,
+		"pwm slot must have a chip-number attribute")
+
+	// slots with chip-number attribute that isnt a number
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.gadgetBadChipNumberSlotInfo), ErrorMatches,
+		"pwm slot chip-number attribute must be an int")
+}
+
+func (s *PwmInterfaceSuite) TestSanitizeSlotOsSnap(c *C) {
+	// pwm slot on OS accepted
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.osPwmSlotInfo), IsNil)
+}
+
+func (s *PwmInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.gadgetPlugInfo), IsNil)
+}
+
+func (s *PwmInterfaceSuite) TestSystemdConnectedSlot(c *C) {
+	spec := &systemd.Specification{}
+	err := spec.AddConnectedSlot(s.iface, s.gadgetPlug, s.gadgetPwmSlot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.Services(), DeepEquals, map[string]*systemd.Service{
+		"snap.my-device.interface.pwmchip10-pwm100.service": {
+			Type:            "oneshot",
+			RemainAfterExit: true,
+			ExecStart:       `/bin/sh -c 'test -e /sys/class/pwm/pwmchip10/pwm100 || echo 100 > /sys/class/pwm/pwmchip10/export'`,
+			ExecStop:        `/bin/sh -c 'test ! -e /sys/class/pwm/pwmchip10/pwm100 || echo 100 > /sys/class/pwm/pwmchip10/unexport'`,
+		},
+	})
+}
+
+func (s *PwmInterfaceSuite) TestApparmorConnectedPlugIgnoresMissingSymlink(c *C) {
+	log, restore := logger.MockLogger()
+	defer restore()
+
+	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
+		c.Assert(path, Equals, "/sys/class/pwm/pwmchip10")
+		return "", os.ErrNotExist
+	})
+
+	spec := &apparmor.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.gadgetPlug, s.gadgetPwmSlot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.Snippets(), HasLen, 0)
+	c.Assert(log.String(), testutil.Contains, "cannot find not existing pwm chipbase /sys/class/pwm/pwmchip10")
+}
+
+func (s *PwmInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *PwmInterfaceSuite) TestApparmorConnectedPlug(c *C) {
+	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
+		c.Assert(path, Equals, "/sys/class/pwm/pwmchip10")
+		// TODO: what is this actually a symlink to on a real device?
+		return "/sys/dev/foo/class/pwm/pwmchip10", nil
+	})
+
+	spec := &apparmor.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.gadgetPlug, s.gadgetPwmSlot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.SnippetForTag("snap.my-device.svc"), testutil.Contains, `/sys/dev/foo/class/pwm/pwmchip10/pwm100/* rwk`)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -624,6 +624,7 @@ var (
 		"power-control":           {"core"},
 		"ppp":                     {"core"},
 		"pulseaudio":              {"app", "core"},
+		"pwm":                     {"core", "gadget"},
 		"raw-volume":              {"core", "gadget"},
 		"serial-port":             {"core", "gadget"},
 		"spi":                     {"core", "gadget"},

--- a/run-checks
+++ b/run-checks
@@ -102,7 +102,7 @@ missing_interface_spread_test() {
     for iface in $(go run ./tests/lib/list-interfaces.go) ; do
         search="plugs: \\[ $iface \\]"
         case "$iface" in
-            bool-file|gpio|hidraw|i2c|iio|serial-port|spi)
+            bool-file|gpio|pwm|hidraw|i2c|iio|serial-port|spi)
                 # skip gadget provided interfaces for now
                 continue
                 ;;

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -341,6 +341,9 @@ apps:
   pulseaudio:
     command: bin/run
     plugs: [ pulseaudio ]
+  pwm:
+    command: bin/run
+    plugs: [ pwm ]
   raw-usb:
     command: bin/run
     plugs: [ raw-usb ]

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -341,9 +341,6 @@ apps:
   pulseaudio:
     command: bin/run
     plugs: [ pulseaudio ]
-  pwm:
-    command: bin/run
-    plugs: [ pwm ]
   raw-usb:
     command: bin/run
     plugs: [ raw-usb ]


### PR DESCRIPTION
PWM interface is often used to control device's LED, fan or heater and
its sysfs can allow user space to expose PWM under /sys/class/pwm/pwmchipN
where N is the base of PWM chip and each chip may have multiple channels
used for application. The access path for the specific channel should be
specified at /sys/class/pwm/pwmchipN/pwm? and that channel needs to be
exported via /sys/class/pwm/pwmchipN/export, so its behavior is similar
to GPIO interface.

Reference:
https://www.kernel.org/doc/Documentation/pwm.txt
