### PR TITLE
o/{device,hook}state: encode fde-setup-request key as base64 string 

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1511,7 +1511,7 @@ func (m *DeviceManager) runFDESetupHook(op string, params *boot.FDESetupHookPara
 	}
 	req := &fde.SetupRequest{
 		Op:      op,
-		Key:     &params.Key,
+		Key:     params.Key[:],
 		KeyName: params.KeyName,
 		// TODO: include boot chains
 	}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1353,7 +1353,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 		ctx.Get("fde-setup-request", &fdeSetup)
 		c.Check(fdeSetup, DeepEquals, fde.SetupRequest{
 			Op:      "initial-setup",
-			Key:     &mockKey,
+			Key:     mockKey[:],
 			KeyName: "some-key-name",
 			Models: []map[string]string{
 				{

--- a/overlord/devicestate/fde/fde.go
+++ b/overlord/devicestate/fde/fde.go
@@ -52,8 +52,10 @@ type SetupRequest struct {
 	// XXX: make "op" a type: "features", "initial-setup", "update" ?
 	Op string `json:"op"`
 
-	Key     *secboot.EncryptionKey `json:"key,omitempty"`
-	KeyName string                 `json:"key-name,omitempty"`
+	// This needs to be a []byte so that Go's standard library will base64
+	// encode it automatically for us
+	Key     []byte `json:"key,omitempty"`
+	KeyName string `json:"key-name,omitempty"`
 
 	// List of models with their related fields, this will be set
 	// to follow the secboot:SnapModel interface.


### PR DESCRIPTION
The spec states that the encryption key in the fde-setup-request JSON structure
that is passed to the hook via `snapctl` should be a string encoded as base64.

We missed the fact that this code was not doing that, since it was refactored
rather late in the cycle, and the existing test (and also the real world hook)
are both written in Go, and thus take advantage of Go's advanced JSON decoding
which handles both the case of

```json
{
   ...
   "key": [96, 34, 56, 54, ... ],
   ...
}
```

```json
{
   ...
   "key": "ABCDE==",
   ...
}
```

the same when decoding. Actually because of this fact, we can in fact change the
request we send to conform to the spec without breaking the existing client and
test.

Also expand the existing spread test to check that the JSON sent to the hook via snapctl is indeed decodable both as a []byte directly using Go's standard JSON library, and as a string and manually decoding the base64.