### PR TITLE
tests: simplify the reset.sh logic by removing not needed command

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -677,7 +677,12 @@ restore_suite_each() {
 
 restore_suite() {
     # shellcheck source=tests/lib/reset.sh
-    "$TESTSLIB"/reset.sh --store
+    if [ "$REMOTE_STORE" = staging ]; then
+        # shellcheck source=tests/lib/store.sh
+        . "$TESTSLIB"/store.sh
+        teardown_staging_store
+    fi
+
     if os.query is-classic; then
         # shellcheck source=tests/lib/pkgdb.sh
         . "$TESTSLIB"/pkgdb.sh

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -189,9 +189,3 @@ if [ -d /run/snapd/ns ]; then
     done
     find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' -o -name '*.info' \) -delete
 fi
-
-if [ "$REMOTE_STORE" = staging ] && [ "$1" = "--store" ]; then
-    # shellcheck source=tests/lib/store.sh
-    . "$TESTSLIB"/store.sh
-    teardown_staging_store
-fi


### PR DESCRIPTION
After the reset.sh use was moved to the restore of each test, then it is
not needed anymore to run it restoring the test suite.

Also the --store parameter won't be used and it can be removed.
