### PR TITLE
tests: reset the system while preparing the test suite

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -564,6 +564,10 @@ prepare_suite() {
     else
         prepare_classic
     fi
+
+    # Make sure the suite starts with a clean environment and with the snapd state restored
+    # shellcheck source=tests/lib/reset.sh
+    "$TESTSLIB"/reset.sh --reuse-core
 }
 
 install_snap_profiler(){


### PR DESCRIPTION
This is important to make sure the first test for each suite will run
with the clean environment and with the snapd state restored.
This prevents errors that happen in the first tests of the second test suite executed.