### PR TITLE
overlord/snapstate: make sure that snapd current symlink is not removed during refresh

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -838,10 +838,10 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	snapst.Active = false
 
+	// snapd current symlink on the refresh path can only replaced by a
+	// symlink to a new revision of the snapd snap, so only do the actual
+	// unlink if we're not working on the snapd snap
 	if oldInfo.Type() != snap.TypeSnapd {
-		// snapd current symlink on the refresh path can only replaced
-		// by a symlink to a new revision of the snapd snap
-
 		// do the final unlink
 		linkCtx := backend.LinkContext{
 			FirstInstall: false,


### PR DESCRIPTION
When snap is refreshed, the current symlink would briefly go away between
unlink-current-snap and link-snap tasks. If the system gets rebooted at this
time, during startup all services from snaps will fail to start. This is caused
by the fact that /usr/bin/snap, which on Core is linked to
/snap/snapd/current/usr/bin/snap will be dangling, as /snap/snapd/current was
removed.

Address the problem by not removing current of the snapd snap, unless unlinking
is called during removal for the first install of the snapd snap on core or a
general snapd snap removal. In the snapd on core scenario, the /usr/bin/snap
will be invoked from the core snap anyway.

Supersedes #10066 