### PR TITLE
tests: fix cgroup-tracking test

### DIFF
--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -165,9 +165,11 @@ execute: |
 
     echo "Because the script above used \"sleep 1m\" instead of \"exec sleep 1m\" there"
     echo "are now two processes: the shell and sleep."
-    test "$(wc -l < "${base_cg_path}${pid3_tracking_cg_path}/cgroup.procs")" -eq 2
+    cgroup_procs_path="${base_cg_path}${pid3_tracking_cg_path}/cgroup.procs"
+    test "$(wc -l < "$cgroup_procs_path")" -eq 2
     kill "$pid3_sh"
-    test "$(wc -l < "${base_cg_path}${pid3_tracking_cg_path}/cgroup.procs")" -eq 1
-    wait "$session3_pid" || true  # same as above
+    #shellcheck disable=SC2016
+    cgroup_procs_path="$cgroup_procs_path" retry -n 10 --wait 0.5 sh -c 'test "$(wc -l < $cgroup_procs_path)" -eq 1'
 
+    wait "$session3_pid" || true  # same as above
     retry -n 10 test ! -e "${base_cg_path}${pid3_tracking_cg_path}"


### PR DESCRIPTION
The test needs to retry a bit to make sure the process is removed.

Sometimes it takes just a bit and if we check the number of cgroup
processes right after the process is killed then it fails.

The error is easy to reproduce on centos8.

The tests sequence which makes the test fail is the following:
https://paste.ubuntu.com/p/r7CxTVYb5B/ 