### PR TITLE
tests/core/fsck-on-boot: unmount /run/mnt/snapd directly on uc20

### DIFF
--- a/tests/core/fsck-on-boot/task.yaml
+++ b/tests/core/fsck-on-boot/task.yaml
@@ -48,7 +48,7 @@ execute: |
       # seeding anymore
 
       if mountpoint /run/mnt/snapd >/dev/null; then
-        umount /run/mnt/ubuntu-seed/snaps/snapd_*.snap
+        umount /run/mnt/snapd
       fi
       umount /var/lib/snapd/seed
       umount /run/mnt/ubuntu-seed


### PR DESCRIPTION
If the snapd snap was mounted in the initrd because this is the first boot with
of a UC20 system, then /run/mnt/snapd will be mounted either from the
`/run/mnt/ubuntu-seed/snaps/snapd_*.snap` or possibly from
`/run/mnt/ubuntu-seed/systems/<sys>/snaps/snapd_*.snap` depending on how the
system was constructed. To handle this ambiguity, just unmount the mountpoint
directly and avoid issues like:
```
Error: 2021-03-18 16:42:18 Error executing google:ubuntu-core-20-64:tests/core/fsck-on-boot (mar181546-879259) :
-----
+ os.query is-core16
+ os.query is-core18
+ os.query is-core20
+ LABEL=ubuntu-seed
+ case "$SPREAD_REBOOT" in
+ echo 'We can corrupt the boot partition'
We can corrupt the boot partition
+ unmount_vfat
+ os.query is-core16
+ os.query is-core18
+ os.query is-core20
+ mountpoint /run/mnt/snapd
+ umount '/run/mnt/ubuntu-seed/snaps/snapd_*.snap'
umount: /run/mnt/ubuntu-seed/snaps/snapd_*.snap: no mount point specified.
-----
```