### PR TITLE
tests/lib/fde-setup-hook: also verify that fde-reveal-key key data is base64

### DIFF
--- a/tests/lib/fde-setup-hook/fde-setup.go
+++ b/tests/lib/fde-setup-hook/fde-setup.go
@@ -38,25 +38,7 @@ type fdeSetupJSON struct {
 // as a string, which _must_ be a base64 encoded version of the same []byte Key
 // we have above, the handler below validates this as a test
 type fdeSetupJSONStrictBase64 struct {
-	Op string `json:"op"`
-
-	Key     string `json:"key,omitempty"`
-	KeyName string `json:"key-name,omitempty"`
-
-	Models []map[string]string `json:"models,omitempty"`
-}
-
-func byteSlicesEqual(b1, b2 []byte) error {
-	if len(b1) != len(b2) {
-		return fmt.Errorf("not same length")
-	}
-
-	for i, b := range b1 {
-		if b != b2[i] {
-			return fmt.Errorf("different bytes at position %d (%d vs %d)", i, b, b2[i])
-		}
-	}
-	return nil
+	Key string `json:"key,omitempty"`
 }
 
 func runFdeSetup() error {
@@ -80,8 +62,8 @@ func runFdeSetup() error {
 	if err != nil {
 		return fmt.Errorf("fde-setup-request is not valid base64: %v", err)
 	}
-	if err := byteSlicesEqual(decodedBase64Key, js.Key); err != nil {
-		return fmt.Errorf("fde-setup-request is not strictly the same base64 decoded as binary decoded: %v", err)
+	if !bytes.Equal(decodedBase64Key, js.Key) {
+		return fmt.Errorf("fde-setup-request is not strictly the same base64 decoded as binary decoded")
 	}
 
 	var fdeSetupResult []byte
@@ -111,8 +93,6 @@ type fdeRevealJSON struct {
 }
 
 type fdeRevealJSONStrict struct {
-	Op string `json:"op"`
-
 	SealedKey string `json:"sealed-key"`
 }
 
@@ -139,8 +119,8 @@ func runFdeRevealKey() error {
 	if err != nil {
 		return fmt.Errorf("fde-reveal-key input is not valid base64: %v", err)
 	}
-	if err := byteSlicesEqual(decodedBase64Key, js.SealedKey); err != nil {
-		return fmt.Errorf("fde-reveal-key input is not strictly the same base64 decoded as binary decoded: %v", err)
+	if !bytes.Equal(decodedBase64Key, js.SealedKey) {
+		return fmt.Errorf("fde-reveal-key input is not strictly the same base64 decoded as binary decoded")
 	}
 
 	switch js.Op {

--- a/tests/lib/fde-setup-hook/fde-setup.go
+++ b/tests/lib/fde-setup-hook/fde-setup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -109,20 +110,49 @@ type fdeRevealJSON struct {
 	SealedKey []byte `json:"sealed-key"`
 }
 
+type fdeRevealJSONStrict struct {
+	Op string `json:"op"`
+
+	SealedKey string `json:"sealed-key"`
+}
+
 func runFdeRevealKey() error {
 	var js fdeRevealJSON
+	var jsStrict fdeRevealJSONStrict
 
-	if err := json.NewDecoder(os.Stdin).Decode(&js); err != nil {
+	b, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
 		return err
+	}
+
+	if err := json.Unmarshal(b, &js); err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(b, &jsStrict); err != nil {
+		return err
+	}
+
+	// verify that the two de-coding mechanisms agree on the key, manually
+	// decoding the base64 string in the stricter case
+	decodedBase64Key, err := base64.StdEncoding.DecodeString(jsStrict.SealedKey)
+	if err != nil {
+		return fmt.Errorf("fde-reveal-key input is not valid base64: %v", err)
+	}
+	if err := byteSlicesEqual(decodedBase64Key, js.SealedKey); err != nil {
+		return fmt.Errorf("fde-reveal-key input is not strictly the same base64 decoded as binary decoded: %v", err)
 	}
 
 	switch js.Op {
 	case "reveal":
-		// "unseal"
 		unsealedKey := xor13(js.SealedKey)
 		fmt.Fprintf(os.Stdout, "%s", unsealedKey)
 	case "lock":
 		// nothing right now
+
+		// NOTE: when using this file as an example code for implementing a real
+		// world, production grade FDE hook, the lock operation must be
+		// implemented here to block decryption operations
 	case "features":
 		// XXX: Not used right now but might in the future?
 		fmt.Fprintf(os.Stdout, `{"features":[]}`)


### PR DESCRIPTION
The key data should be decodable both as a []byte in Go directly (using the
standard library's automatic conversion of base64 encoded strings into []byte),
as well as manually by reading the base64 string and decoding out of band from
the Go standard library.

We added code to do this for the fde-setup-request, but we should also do this
check for the fde-reveal-key structure too just to be extra safe around this
area.