### PR TITLE
daemon: fix signing key validity timestamp in unit tests

### DIFF
--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -1075,13 +1075,13 @@ func (s *userSuite) TestPostCreateUserFromAssertionNoModel(c *check.C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
+	s.makeSystemUsers(c, []map[string]interface{}{serialUser})
 	model := s.Brands.Model("my-brand", "other-model", map[string]interface{}{
 		"architecture":          "amd64",
 		"gadget":                "pc",
 		"kernel":                "pc-kernel",
 		"system-user-authority": []interface{}{"my-brand", "partner"},
 	})
-	s.makeSystemUsers(c, []map[string]interface{}{serialUser})
 
 	st := s.d.Overlord().State()
 	st.Lock()


### PR DESCRIPTION
Occasionally in the Github test runs we observe this problem:

```
----------------------------------------------------------------------
PANIC: api_users_test.go:1074: userSuite.TestPostCreateUserFromAssertionNoModel

... Panic: cannot add test assertions: model assertion timestamp "2021-03-23 22:31:21 +0000 UTC" outside of signing key validity (key valid since "2021-03-23 22:31:22 +0000 UTC") (PC=0x439C58)

/snap/go/7221/src/runtime/panic.go:965
  in gopanic
/home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/assertstate/assertstatetest/add_many.go:38
  in AddMany
api_users_test.go:1088
  in userSuite.TestPostCreateUserFromAssertionNoModel
/snap/go/7221/src/reflect/value.go:337
  in Value.Call
/snap/go/7221/src/runtime/asm_amd64.s:1371
  in goexit
OOPS: 444 passed, 1 PANICKED
--- FAIL: Test (11.20s)
FAIL
FAIL	github.com/snapcore/snapd/daemon	11.374s
```

The offending tests generates the model of a mocked my-brand whic gets sine with
they brand key, before the account key assertion of a given brand is generated.
If the code happens to run at the second boundary, it is possible that the model
timestamp will be before the account key assertion timestamp.


