### PR TITLE
interfaces/udisks2: allow locking /run/mount/utab for udisks 2.8.4

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -100,7 +100,7 @@ umount /{,run/}media/**,
 /bin/umount ixr,
 
 # mount/umount (via libmount) track some mount info in these files
-/run/mount/utab* wrl,
+/run/mount/utab* wrlk,
 
 # Udisks2 needs to read the raw device for partition information. These rules
 # give raw read access to the system disks and therefore the entire system.


### PR DESCRIPTION
A uc20 project needs udisks2 to mount usb to obtain files. It needs to set a lock on /run/mount/utab but is currently denied. 
Since this interface already provides write access, adding lock would seem OK.
