### PR TITLE
tests: fix snap-advise-command check for 429

### DIFF
--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -21,9 +21,7 @@ restore: |
 execute: |
     echo "wait for snapd to pull in the commands data"
     echo "(it will do that on startup)"
-    retry -n 120 --wait 1 sh -c 'stat /var/cache/snapd/commands.db'
-
-    if ! stat /var/cache/snapd/commands.db; then
+    if ! retry -n 120 --wait 1 sh -c 'stat /var/cache/snapd/commands.db'; then
         # workaround for misbehaving store
         if "$TESTSTOOLS"/journal-state get-log -u snapd | MATCH "429 Too Many Requests"; then
             echo "Store is reporting 429 (too many requests), skipping the test"


### PR DESCRIPTION
When we refactored to use retry-tool we accidently broke the
checks for 429 from the names endpoint. This commit fixes it.
