### PR TITLE
o/configstate: fix panic with a sequence of config unset ops over same path

### DIFF
--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -115,8 +115,8 @@ func (t *Transaction) Set(instanceName, key string, value interface{}) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	config, ok := t.changes[instanceName]
-	if !ok {
+	config := t.changes[instanceName]
+	if config == nil {
 		config = make(map[string]interface{})
 	}
 
@@ -141,6 +141,9 @@ func (t *Transaction) Set(instanceName, key string, value interface{}) error {
 		}
 	}
 
+	// config here is never nil and PatchConfig always operates
+	// directly on and returns config if it's a
+	// map[string]interface{}
 	_, err = PatchConfig(instanceName, subkeys, 0, config, &raw)
 	if err != nil {
 		return err

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -140,6 +140,7 @@ func (t *Transaction) Set(instanceName, key string, value interface{}) error {
 			return err
 		}
 	}
+
 	_, err = PatchConfig(instanceName, subkeys, 0, config, &raw)
 	if err != nil {
 		return err

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -212,6 +212,64 @@ var setGetTests = [][]setGetOp{{
 	`commit`,
 	`get x=-`,
 }, {
+	// Nulls, set then unset and set back over same partial path
+	`set doc.x.a=1`,
+	`commit`,
+	`set doc.x.a=null`,
+	`get doc={"x":{}}}`,
+	`set doc.x.a=6`,
+	`get doc={"x":{"a":6}}`,
+	`commit`,
+	`get doc={"x":{"a":6}}`,
+	`getrootunder ={"doc":{"x":{"a":6}}}`,
+}, {
+	// Nulls, set then unset and set back over same path
+	`set doc.x.a=1`,
+	`commit`,
+	`set doc.x=null`,
+	`get doc={}`,
+	`set doc.x.a=3`,
+	`get doc={"x":{"a":3}}`,
+	`commit`,
+	`get doc={"x":{"a":3}}`,
+	`getrootunder ={"doc":{"x":{"a":3}}}`,
+}, {
+	// Nulls, set then unset and set back root element
+	`set doc.x.a=1`,
+	`commit`,
+	`set doc.x=null`,
+	`get doc={}`,
+	`set doc=null`,
+	`get doc=-`,
+	`set doc=99`,
+	`commit`,
+	`get doc=99`,
+	`getrootunder ={"doc":99}`,
+}, {
+	// Nulls, set then unset over same path
+	`set doc.x.a=1 doc.x.b=2`,
+	`commit`,
+	`set doc.x=null`,
+	`set doc.x.a=null`,
+	`set doc.x.b=null`,
+	`get doc={"x":{}}`,
+	`commit`,
+	`get doc={"x":{}}`,
+	`getrootunder ={"doc":{"x":{}}}`,
+}, {
+	// Nulls, set then unset and set back over same path
+	`set doc.x.a=1`,
+	`commit`,
+	`set doc.x=null`,
+	`set doc.x.a=null`,
+	`get doc={"x":{}}`,
+	`set doc={"x":{"a":9}}`,
+	`set doc.x.a=1`,
+	`get doc={"x":{"a":1}}`,
+	`commit`,
+	`get doc={"x":{"a":1}}`,
+	`getrootunder ={"doc":{"x":{"a":1}}}`,
+}, {
 	// Root doc
 	`set doc={"one":1,"two":2}`,
 	`changes core.doc.one core.doc.two`,

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -119,6 +119,31 @@ func (s *unsetSuite) TestUnsetMany(c *C) {
 	c.Check(value, Equals, "c")
 }
 
+func (s *unsetSuite) TestSetThenUnset(c *C) {
+	// Setup an initial configuration
+	s.mockContext.State().Lock()
+	tr := config.NewTransaction(s.mockContext.State())
+	tr.Set("test-snap", "agent.x.a", "1")
+	tr.Set("test-snap", "agent.x.b", "2")
+	tr.Commit()
+	s.mockContext.State().Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "agent.x!", "agent.x.a!", "agent.x.b!"}, 0)
+	c.Check(err, IsNil)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+
+	// Notify the context that we're done. This should save the config.
+	s.mockContext.Lock()
+	defer s.mockContext.Unlock()
+	c.Check(s.mockContext.Done(), IsNil)
+
+	// Verify that the global config has been updated.
+	var value interface{}
+	tr = config.NewTransaction(s.mockContext.State())
+	c.Check(tr.Get("test-snap", "agent.x.a", &value), ErrorMatches, `snap "test-snap" has no "agent.x.a" configuration option`)
+}
+
 func (s *unsetSuite) TestUnsetRegularUserForbidden(c *C) {
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"unset", "key"}, 1000)
 	c.Assert(err, ErrorMatches, `cannot use "unset" with uid 1000, try with sudo`)


### PR DESCRIPTION
Fix panic with a sequence of config unset operations over same path in same transaction by creating an empty map if necessary. 

Also fix a very closely related problem (a variation of the first scenario) where setting a config path that was previously set to null in same transaction would have no result (config would remain at null).

Fixes LP #1920773