### PR TITLE
api: provide meaningful error message on connect/disconnect for non-installed snap

### DIFF
--- a/daemon/api_interfaces.go
+++ b/daemon/api_interfaces.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -150,11 +151,33 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 	st.Lock()
 	defer st.Unlock()
 
+	checkInstalled := func(snapName string) error {
+		// empty snap name is fine, ResolveConnect/ResolveDisconnect handles it.
+		if snapName == "" {
+			return nil
+		}
+		var snapst snapstate.SnapState
+		err := snapstate.Get(st, snapName, &snapst)
+		if (err == nil && !snapst.IsInstalled()) || err == state.ErrNoState {
+			return fmt.Errorf("snap %q is not installed", snapName)
+		}
+		if err == nil {
+			return nil
+		}
+		return fmt.Errorf("internal error: cannot get state of snap %q: %v", snapName, err)
+	}
+
 	for i := range a.Plugs {
 		a.Plugs[i].Snap = ifacestate.RemapSnapFromRequest(a.Plugs[i].Snap)
+		if err := checkInstalled(a.Plugs[i].Snap); err != nil {
+			return errToResponse(err, nil, BadRequest, "%v")
+		}
 	}
 	for i := range a.Slots {
 		a.Slots[i].Snap = ifacestate.RemapSnapFromRequest(a.Slots[i].Snap)
+		if err := checkInstalled(a.Slots[i].Snap); err != nil {
+			return errToResponse(err, nil, BadRequest, "%v")
+		}
 	}
 
 	switch a.Action {

--- a/daemon/api_interfaces_test.go
+++ b/daemon/api_interfaces_test.go
@@ -340,13 +340,16 @@ func (s *interfacesSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	c.Assert(ifaces.Connections, check.HasLen, 0)
 }
 
-func (s *interfacesSuite) testConnectFailureNoSnap(c *check.C, consumer, producer bool) {
+func (s *interfacesSuite) testConnectFailureNoSnap(c *check.C, installedSnap string) {
 	// sanity, either consumer or producer needs to be enabled
-	c.Assert(consumer, check.Equals, !producer)
+	consumer := installedSnap == "consumer"
+	producer := installedSnap == "producer"
+	c.Assert(consumer || producer, check.Equals, true, check.Commentf("installed snap must be consumer or producer"))
 
 	d := s.daemon(c)
 
 	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
+
 	if consumer {
 		s.mockSnap(c, consumerYaml)
 	}
@@ -393,11 +396,11 @@ func (s *interfacesSuite) testConnectFailureNoSnap(c *check.C, consumer, produce
 }
 
 func (s *interfacesSuite) TestConnectPlugFailureNoPlugSnap(c *check.C) {
-	s.testConnectFailureNoSnap(c, false, true)
+	s.testConnectFailureNoSnap(c, "producer")
 }
 
 func (s *interfacesSuite) TestConnectPlugFailureNoSlotSnap(c *check.C) {
-	s.testConnectFailureNoSnap(c, true, false)
+	s.testConnectFailureNoSnap(c, "consumer")
 }
 
 func (s *interfacesSuite) TestConnectPlugChangeConflict(c *check.C) {
@@ -602,9 +605,11 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	})
 }
 
-func (s *interfacesSuite) testDisconnectFailureNoSnap(c *check.C, consumer, producer bool) {
+func (s *interfacesSuite) testDisconnectFailureNoSnap(c *check.C, installedSnap string) {
 	// sanity, either consumer or producer needs to be enabled
-	c.Assert(consumer, check.Equals, !producer)
+	consumer := installedSnap == "consumer"
+	producer := installedSnap == "producer"
+	c.Assert(consumer || producer, check.Equals, true, check.Commentf("installed snap must be consumer or producer"))
 
 	revert := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer revert()
@@ -656,11 +661,11 @@ func (s *interfacesSuite) testDisconnectFailureNoSnap(c *check.C, consumer, prod
 }
 
 func (s *interfacesSuite) TestDisconnectPlugFailureNoPlugSnap(c *check.C) {
-	s.testDisconnectFailureNoSnap(c, true, false)
+	s.testDisconnectFailureNoSnap(c, "producer")
 }
 
 func (s *interfacesSuite) TestDisconnectPlugFailureNoSlotSnap(c *check.C) {
-	s.testDisconnectFailureNoSnap(c, false, true)
+	s.testDisconnectFailureNoSnap(c, "consumer")
 }
 
 func (s *interfacesSuite) TestDisconnectPlugNothingToDo(c *check.C) {

--- a/tests/main/snap-connect/task.yaml
+++ b/tests/main/snap-connect/task.yaml
@@ -9,7 +9,7 @@ prepare: |
     fi
 
 execute: |
-    echo "Connect and disconnect provides meaningful error is plug or slot snap is not installed"
+    echo "Connect and disconnect provides meaningful error if plug or slot snap is not installed"
     snap connect home-consumer:home foo:home 2>&1 | MATCH 'error: snap "foo" is not installed'
     snap connect foo:home 2>&1 | MATCH 'error: snap "foo" is not installed'
     snap disconnect foo:home 2>&1 | MATCH 'error: snap "foo" is not installed'

--- a/tests/main/snap-connect/task.yaml
+++ b/tests/main/snap-connect/task.yaml
@@ -9,6 +9,12 @@ prepare: |
     fi
 
 execute: |
+    echo "Connect and disconnect provides meaningful error is plug or slot snap is not installed"
+    snap connect home-consumer:home foo:home 2>&1 | MATCH 'error: snap "foo" is not installed'
+    snap connect foo:home 2>&1 | MATCH 'error: snap "foo" is not installed'
+    snap disconnect foo:home 2>&1 | MATCH 'error: snap "foo" is not installed'
+    snap disconnect home-consumer:home foo:home 2>&1 | MATCH 'error: snap "foo" is not installed'
+
     CONNECTED_PATTERN=':home .*home-consumer'
 
     echo "The plug can be connected to a matching slot of OS snap without snap:slot argument"


### PR DESCRIPTION
Provide meaningful error message (snap "foo" is not installed) when referencing a non-installed snap via snap connect/disconnect. In the existing code we simply call ResolveConnect/ResolveDisconnect which unfortunately produce a misleading error message if snap is not installed. Note, repository only knows about plugs/slots (doesn't know about snaps that don't have plugs/slots), so the case needs to be handled outside of repo.

Fixes LP: #1921152
