### PR TITLE
interfaces, interfaces/apparmor, overlord/snapstate: late removal of snap-confine apparmor profiles

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -225,7 +225,7 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 	//   snap-confine.core.111
 	patchedProfileName := snapConfineProfileName(info.InstanceName(), info.Revision)
 	// remove other generated profiles, which is only relevant for the
-	// 'core' snap on classic system where we reexec, on core system the
+	// 'core' snap on classic system where we reexec, on core systems the
 	// profile is already a part of the rootfs snap
 	patchedProfileGlob := fmt.Sprintf("snap-confine.%s.*", info.InstanceName())
 
@@ -235,9 +235,9 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 		// being removed, also on core devices the rootfs snap and the
 		// snapd snap are updated separately, so the profile needs to be
 		// around for as long as the given revision of the snapd snap is
-		// active, so we use the exact match such that we only only
-		// replace our own profile, which can happen if system was
-		// rebooted before task calling the backend was finished
+		// active, so we use the exact match such that we only replace
+		// our own profile, which can happen if system was rebooted
+		// before task calling the backend was finished
 		patchedProfileGlob = patchedProfileName
 	}
 
@@ -580,6 +580,8 @@ func (b *Backend) RemoveLate(snapName string, rev snap.Revision, typ snap.Type) 
 
 	globs := []string{snapConfineProfileName(snapName, rev)}
 	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dirs.SnapAppArmorDir, globs, nil)
+	// XXX: unloadProfiles() does not unload profiles from the kernel, but
+	// only removes profiles from the cache
 	errUnload := unloadProfiles(removed, apparmor_sandbox.CacheDir)
 	if errEnsure != nil {
 		return fmt.Errorf("cannot remove security profiles for snap %q (%s): %s", snapName, rev, errEnsure)

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -64,6 +64,10 @@ var (
 	isRootWritableOverlay = osutil.IsRootWritableOverlay
 	kernelFeatures        = apparmor_sandbox.KernelFeatures
 	parserFeatures        = apparmor_sandbox.ParserFeatures
+
+	// make sure that apparmor profile fulfills the late discarding backend
+	// interface
+	_ interfaces.SecurityBackendDiscardingLate = (*Backend)(nil)
 )
 
 // Backend is responsible for maintaining apparmor profiles for snaps and parts of snapd.
@@ -219,7 +223,7 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 	//   /snap/core/111/usr/lib/snapd/snap-confine
 	// becomes
 	//   snap-confine.core.111
-	patchedProfileName := fmt.Sprintf("snap-confine.%s.%s", info.InstanceName(), info.Revision)
+	patchedProfileName := snapConfineProfileName(info.InstanceName(), info.Revision)
 	// remove other generated profiles, which is only relevant for the
 	// 'core' snap on classic system where we reexec, on core system the
 	// profile is already a part of the rootfs snap
@@ -246,6 +250,10 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 	}
 
 	return dirs.SnapAppArmorDir, patchedProfileGlob, content, nil
+}
+
+func snapConfineProfileName(snapName string, rev snap.Revision) string {
+	return fmt.Sprintf("snap-confine.%s.%s", snapName, rev)
 }
 
 // setupSnapConfineReexec will setup apparmor profiles inside the host's
@@ -559,6 +567,22 @@ func (b *Backend) Remove(snapName string) error {
 	errUnload := unloadProfiles(removed, cache)
 	if errEnsure != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, errEnsure)
+	}
+	return errUnload
+}
+
+func (b *Backend) RemoveLate(snapName string, rev snap.Revision, typ snap.Type) error {
+	logger.Noticef("remove late for snap %v (%s) type %v", snapName, rev, typ)
+	if typ != snap.TypeSnapd {
+		// late remove is relevant only for snap confine profiles
+		return nil
+	}
+
+	globs := []string{snapConfineProfileName(snapName, rev)}
+	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dirs.SnapAppArmorDir, globs, nil)
+	errUnload := unloadProfiles(removed, apparmor_sandbox.CacheDir)
+	if errEnsure != nil {
+		return fmt.Errorf("cannot remove security profiles for snap %q (%s): %s", snapName, rev, errEnsure)
 	}
 	return errUnload
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1171,7 +1171,7 @@ func (s *backendSuite) TestSnapConfineProfileFromSnapdSnap(c *C) {
 	// We expect to see the same profile, just anchored at a different directory.
 	expectedProfileDir := filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/apparmor/profiles")
 	expectedProfileName := "snap-confine.snapd.222"
-	expectedProfileGlob := "snap-confine.snapd.*"
+	expectedProfileGlob := "snap-confine.snapd.222"
 	expectedProfileText := fmt.Sprintf(`#include <tunables/global>
 %s/usr/lib/snapd/snap-confine (attach_disconnected) {
     # We run privileged, so be fanatical about what we include and don't use
@@ -1226,7 +1226,7 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecCleans(c *C) {
 	// install the new core snap on classic triggers cleanup
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", coreYaml, 111)
 
-	c.Check(osutil.FileExists(canary), Equals, false)
+	c.Check(canary, testutil.FileAbsent)
 }
 
 func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) {

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -112,7 +112,7 @@ type SecurityBackendSetupMany interface {
 	SetupMany(snaps []*snap.Info, confinement func(snapName string) ConfinementOptions, repo *Repository, tm timings.Measurer) []error
 }
 
-// SecurityBackendDiscardingLate interface may be implemented by backend that
+// SecurityBackendDiscardingLate interface may be implemented by backends that
 // support removal snap profiles late during the very last step of the snap
 // remove process, typically long after the SecuityBackend.Remove() has been
 // invoked.

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -111,3 +111,13 @@ type SecurityBackendSetupMany interface {
 	// on errors of individual snaps.
 	SetupMany(snaps []*snap.Info, confinement func(snapName string) ConfinementOptions, repo *Repository, tm timings.Measurer) []error
 }
+
+// SecurityBackendDiscardingLate interface may be implemented by backend that
+// support removal snap profiles late during the very last step of the snap
+// remove process, typically long after the SecuityBackend.Remove() has been
+// invoked.
+type SecurityBackendDiscardingLate interface {
+	// RemoveLate removes the security profiles of a snap at the very last
+	// step of the remove change.
+	RemoveLate(snapName string, rev snap.Revision, typ snap.Type) error
+}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -37,11 +37,13 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/settings"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
@@ -2186,6 +2188,20 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
+func (m *SnapManager) discardSecurityProfilesLate(st *state.State, name string, rev snap.Revision, typ snap.Type) error {
+	repo := ifacerepo.Get(st)
+	for _, backend := range repo.Backends() {
+		lateDiscardBackend, ok := backend.(interfaces.SecurityBackendDiscardingLate)
+		if !ok {
+			continue
+		}
+		if err := lateDiscardBackend.RemoveLate(name, rev, typ); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
@@ -2269,6 +2285,9 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		// XXX: also remove sequence files?
 	}
 	if err = config.DiscardRevisionConfig(st, snapsup.InstanceName(), snapsup.Revision()); err != nil {
+		return err
+	}
+	if err = m.discardSecurityProfilesLate(st, snapsup.InstanceName(), snapsup.Revision(), snapsup.Type); err != nil {
 		return err
 	}
 	Set(st, snapsup.InstanceName(), snapst)

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -20,12 +20,17 @@
 package snapstate_test
 
 import (
+	"fmt"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/timings"
 )
 
 type discardSnapSuite struct {
@@ -36,6 +41,11 @@ var _ = Suite(&discardSnapSuite{})
 
 func (s *discardSnapSuite) SetUpTest(c *C) {
 	s.setup(c, nil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	repo := interfaces.NewRepository()
+	ifacerepo.Replace(s.state, repo)
 
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
 }
@@ -174,4 +184,78 @@ func (s *discardSnapSuite) TestDoDiscardSnapNoErrorsForActive(c *C) {
 	c.Check(snapst.Sequence, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(33))
 	c.Check(t.Status(), Equals, state.DoneStatus)
+}
+
+type MockSecurityBackend struct {
+	removeCalls     int
+	removeLateCalls int
+	calls           [][]string
+}
+
+func (m *MockSecurityBackend) Initialize(*interfaces.SecurityBackendOptions) error {
+	return fmt.Errorf("not called")
+}
+func (m *MockSecurityBackend) Name() interfaces.SecuritySystem { return "mock" }
+func (m *MockSecurityBackend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
+	return fmt.Errorf("not called")
+}
+
+func (m *MockSecurityBackend) Remove(_ string) error {
+	return fmt.Errorf("not called")
+}
+
+func (m *MockSecurityBackend) NewSpecification() interfaces.Specification { return nil }
+
+func (m *MockSecurityBackend) SandboxFeatures() []string { return nil }
+
+func (m *MockSecurityBackend) RemoveLate(snapName string, rev snap.Revision, typ snap.Type) error {
+	m.calls = append(m.calls, []string{snapName, rev.String(), string(typ)})
+	m.removeLateCalls++
+	return nil
+}
+
+func (s *discardSnapSuite) TestDoDiscardSnapdRemovesLate(c *C) {
+	s.state.Lock()
+
+	repo := ifacerepo.Get(s.state)
+	m := &MockSecurityBackend{}
+	repo.AddBackend(m)
+
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "snapd", Revision: snap.R(3)},
+			{RealName: "snapd", Revision: snap.R(33)},
+		},
+		Current:  snap.R(33),
+		SnapType: "snapd",
+	})
+	t := s.state.NewTask("discard-snap", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "snapd",
+			Revision: snap.R(33),
+		},
+		Type: snap.TypeSnapd,
+	})
+	s.state.NewChange("dummy", "...").AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "snapd", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Current, Equals, snap.R(3))
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	c.Check(m.removeCalls, Equals, 0)
+	c.Check(m.removeLateCalls, Equals, 1)
+	c.Check(m.calls, DeepEquals, [][]string{
+		{"snapd", "33", "snapd"},
+	})
 }

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -337,6 +337,7 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 					SnapID:   "some-snap-id",
 					Revision: snap.R(7),
 				},
+				Type: snap.TypeApp,
 			}
 		default:
 			expSnapSetup = &snapstate.SnapSetup{
@@ -481,6 +482,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 					Revision: snap.R(7),
 				},
 				InstanceKey: "instance",
+				Type:        snap.TypeApp,
 			}
 		default:
 			expSnapSetup = &snapstate.SnapSetup{
@@ -752,6 +754,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 					RealName: "some-snap",
 					Revision: revnos[whichRevno],
 				},
+				Type: snap.TypeApp,
 			}
 		default:
 			expSnapSetup = &snapstate.SnapSetup{
@@ -845,6 +848,7 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
 				RealName: "some-snap",
 				Revision: snap.R(3),
 			},
+			Type: snap.TypeApp,
 		}
 
 		c.Check(snapsup, DeepEquals, expSnapSetup, Commentf(t.Kind()))
@@ -945,10 +949,11 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 		}
 		if t.Kind() != "discard-conns" {
 			expSnapSetup.SideInfo.Revision = snap.R(2)
+			expSnapSetup.Type = snap.TypeApp
 		}
 		if t.Kind() == "auto-disconnect" {
 			expSnapSetup.PlugsOnly = true
-			expSnapSetup.Type = "app"
+			expSnapSetup.Type = snap.TypeApp
 		}
 
 		c.Check(snapsup, DeepEquals, expSnapSetup, Commentf(t.Kind()))

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -213,6 +213,9 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
+
+	repo := interfaces.NewRepository()
+	ifacerepo.Replace(s.state, repo)
 	s.state.Unlock()
 
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {


### PR DESCRIPTION
When a snapd snap is refreshed on an Ubuntu Core device, the setup-security-profiles task *replaced* the AppArmor profile of snap-confine from the old revision of snapd, with one for the new revision. Then an unexpected reboot occurs after the task has run, but before the 'current' symlink of the snapd snap has been replaced, any attempts to start the snap applications going through /usr/bin/snap end up invoking `/snap/snapd/<old-revision>/usr/lib/snapd/snap-confine`. However, at the time it happens, the AppArmor profile for snap-confine is already gone and replaced with one for the new revision. Thus s-c would ends up running as an `unconfined` process, and we intentionally exit with an error such this happen.

The branch attempts to not remove the snap-confine apparmor profiles when security profiles of the snapd snap are generated. The profiles of snap-confine from old revisions of snapd remain for as long as those revisions are present in the system. Eventually, when old revisions of the snap are removed, the profiles go away with them.