### PR TITLE
systemd: enrich UnitStatus returned by systemd.Status() with Installed flag

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -442,10 +442,10 @@ func (*systemd) LogReader(serviceNames []string, n int, follow bool) (io.ReadClo
 var statusregex = regexp.MustCompile(`(?m)^(?:(.+?)=(.*)|(.*))?$`)
 
 type UnitStatus struct {
-	Daemon    string
-	UnitName  string
-	Enabled   bool
-	Active    bool
+	Daemon   string
+	UnitName string
+	Enabled  bool
+	Active   bool
 	// Installed is false if the queried unit doesn't exist.
 	Installed bool
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -446,6 +446,7 @@ type UnitStatus struct {
 	UnitName  string
 	Enabled   bool
 	Active    bool
+	// Installed is false if the queried unit doesn't exist.
 	Installed bool
 }
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -205,6 +205,11 @@ Type=potato
 Id=baz.service
 ActiveState=inactive
 UnitFileState=disabled
+
+Type=
+Id=missing.service
+ActiveState=inactive
+UnitFileState=
 `[1:]),
 		[]byte(`
 Id=some.timer
@@ -217,37 +222,48 @@ UnitFileState=disabled
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New(SystemMode, s.rep).Status("foo.service", "bar.service", "baz.service", "some.timer", "other.socket")
+	out, err := New(SystemMode, s.rep).Status("foo.service", "bar.service", "baz.service", "missing.service", "some.timer", "other.socket")
 	c.Assert(err, IsNil)
 	c.Check(out, DeepEquals, []*UnitStatus{
 		{
-			Daemon:   "simple",
-			UnitName: "foo.service",
-			Active:   true,
-			Enabled:  true,
+			Daemon:    "simple",
+			UnitName:  "foo.service",
+			Active:    true,
+			Enabled:   true,
+			Installed: true,
 		}, {
-			Daemon:   "simple",
-			UnitName: "bar.service",
-			Active:   true,
-			Enabled:  true,
+			Daemon:    "simple",
+			UnitName:  "bar.service",
+			Active:    true,
+			Enabled:   true,
+			Installed: true,
 		}, {
-			Daemon:   "potato",
-			UnitName: "baz.service",
-			Active:   false,
-			Enabled:  false,
+			Daemon:    "potato",
+			UnitName:  "baz.service",
+			Active:    false,
+			Enabled:   false,
+			Installed: true,
 		}, {
-			UnitName: "some.timer",
-			Active:   true,
-			Enabled:  true,
+			Daemon:    "",
+			UnitName:  "missing.service",
+			Active:    false,
+			Enabled:   false,
+			Installed: false,
 		}, {
-			UnitName: "other.socket",
-			Active:   true,
-			Enabled:  false,
+			UnitName:  "some.timer",
+			Active:    true,
+			Enabled:   true,
+			Installed: true,
+		}, {
+			UnitName:  "other.socket",
+			Active:    true,
+			Enabled:   false,
+			Installed: true,
 		},
 	})
 	c.Check(s.rep.msgs, IsNil)
 	c.Assert(s.argses, DeepEquals, [][]string{
-		{"show", "--property=Id,ActiveState,UnitFileState,Type", "foo.service", "bar.service", "baz.service"},
+		{"show", "--property=Id,ActiveState,UnitFileState,Type", "foo.service", "bar.service", "baz.service", "missing.service"},
 		{"show", "--property=Id,ActiveState,UnitFileState", "some.timer", "other.socket"},
 	})
 }


### PR DESCRIPTION
Rely on empty value of UnitFileState property to determine if the requested service is installed. This seems to work consistently across 16.04 - 18.04 - 20.04, e.g.

```
$ systemctl show --property=ActiveState,UnitFileState,Type,Id foo.service
Type=
Id=foo.service
ActiveState=inactive
UnitFileState=
```

(and exit status is 0 on all systems).

**Alternative** is to use `systemctl status ..` but this behaves differently on 16.04 vs newer systems -on 16.04:
```
$ systemctl status foo.service
● foo.service
   Loaded: not-found (Reason: No such file or directory)
   Active: inactive (dead)
vagrant@xenial:~$ echo $?
3
```

On 18.04 and 20.04:
```
$ systemctl status foo.service
Unit foo.service could not be found.
vagrant@bionic:~$ echo $?
4
```

The exit status = 4 seems to be conforming to https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic.html#INISCRPTACT ; on 16.04 however 3 is unclear and might be ambiguous.

This is needed for #10068 

Note, there is currently one user of this code (DecorateWithStatus in servicestate.go) that we may consider updating for this change - before it would error out on unknown service (we shouldn't get there, that would be an internal error I think), with this change it would report inactive/disabled status.
