### PR TITLE
snap-seccomp: fix seccomp test on ppc64el

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -290,10 +290,17 @@ mprotect
 	}
 	switch {
 	case syscallNr == -101:
-		// "socket"
-		// see libseccomp: _s390x_sock_demux(), _x86_sock_demux()
-		// the -101 is translated to 359 (socket)
-		syscallNr = 359
+		// "socket" needs to be demuxed
+		switch arch.DpkgArchitecture() {
+		case "ppc64el":
+			// see libseccomp: _ppc64_syscall_demux()
+			syscallNr = 326
+		default:
+			// see libseccomp: _s390x_sock_demux(),
+			// _x86_sock_demux() the -101 is translated to
+			// 359 (socket)
+			syscallNr = 359
+		}
 	case syscallNr == -10165:
 		// "mknod" on arm64 is not available at all on arm64
 		// only "mknodat" but libseccomp will not generate a


### PR DESCRIPTION
The "socket" syscall on ppc64el needs to be de-multiplexed with
recent versions of libseccomp. This is similar to what we need
to do on i386 and s390x.

This fixes the build failure on hirsute:
https://launchpad.net/ubuntu/+source/snapd/2.49+21.04ubuntu1/+build/21197477

I tested this on ppc64el inside juju on hirsute and bionic and this PR works in both envs.
