### PR TITLE
 cmd/snap-bootstrap/initramfs-mounts: move time forward using assertion times (2.49)

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -76,7 +76,7 @@ func (ak *AccountKey) isKeyValidAt(when time.Time) bool {
 
 // isKeyValidAssumingCurTimeWithin returns whether the account key is
 // possibly valid if the current time is known to be within [earliest,
-// latest]. That means the interesction of possible current times and
+// latest]. That means the intersection of possible current times and
 // validity is not empty.
 // If latest is zero, then current time is assumed to be >=earliest.
 // If earliest == latest this is equivalent to isKeyValidAt().

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -74,15 +74,19 @@ func (ak *AccountKey) isKeyValidAt(when time.Time) bool {
 	return valid
 }
 
-// isKeyValidAbout returns whether the account key is possibly valid
-// if the current time is known to be within [earliest, latest].
+// isKeyValidAssumingCurTimeWithin returns whether the account key is
+// possibly valid if the current time is known to be within [earliest,
+// latest]. That means the interesction of possible current times and
+// validity is not empty.
 // If latest is zero, then current time is assumed to be >=earliest.
-func (ak *AccountKey) isKeyValidAbout(earliest, latest time.Time) bool {
+// If earliest == latest this is equivalent to isKeyValidAt().
+func (ak *AccountKey) isKeyValidAssumingCurTimeWithin(earliest, latest time.Time) bool {
 	if !latest.IsZero() {
+		// impossible input => false
 		if latest.Before(earliest) {
 			return false
 		}
-		if earliest.Before(ak.since) && latest.Before(ak.since) {
+		if latest.Before(ak.since) {
 			return false
 		}
 	}

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2016 Canonical Ltd
+ * Copyright (C) 2015-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -72,6 +72,26 @@ func (ak *AccountKey) isKeyValidAt(when time.Time) bool {
 		valid = when.Before(ak.until)
 	}
 	return valid
+}
+
+// isKeyValidAbout returns whether the account key is possibly valid
+// if the current time is known to be within [earliest, latest].
+// If latest is zero, then current time is assumed to be >=earliest.
+func (ak *AccountKey) isKeyValidAbout(earliest, latest time.Time) bool {
+	if !latest.IsZero() {
+		if latest.Before(earliest) {
+			return false
+		}
+		if earliest.Before(ak.since) && latest.Before(ak.since) {
+			return false
+		}
+	}
+	if !ak.until.IsZero() {
+		if earliest.After(ak.until) || earliest.Equal(ak.until) {
+			return false
+		}
+	}
+	return true
 }
 
 // publicKey returns the underlying public key of the account key.

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -627,7 +627,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinWithUntilPu
 }
 
 func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinNoUntilPunctual(c *C) {
-	// With since and until, i.e. signing account-key expires.
+	// With since but no until, i.e. signing account-key never expires.
 	// Key is valid for time >= since.
 	encoded := "type: account-key\n" +
 		"authority-id: canonical\n" +
@@ -702,6 +702,12 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinWithUntilIn
 		{aks.since.AddDate(0, -3, 0), z, true},
 		{aks.until, z, false},
 		{aks.until.AddDate(0, 1, 0), z, false},
+		// with earliest set to time.Time zero
+		{z, aks.since, true},
+		{z, aks.since.AddDate(0, 1, 0), true},
+		{z, aks.since.AddDate(0, -2, 0), false},
+		{z, aks.until.AddDate(0, 1, 0), true},
+		{z, z, true},
 	}
 
 	for _, t := range tests {
@@ -711,7 +717,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinWithUntilIn
 }
 
 func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinNoUntilInterval(c *C) {
-	// With since and until, i.e. signing account-key expires.
+	// With since but no until, i.e. signing account-key never expires.
 	// Key is valid for time >= since.
 	encoded := "type: account-key\n" +
 		"authority-id: canonical\n" +
@@ -751,6 +757,12 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinNoUntilInte
 		{aks.since.AddDate(0, -3, 0), z, true},
 		{later, z, true},
 		{later.AddDate(0, 1, 0), z, true},
+		// with earliest set to time.Time zero
+		{z, aks.since, true},
+		{z, aks.since.AddDate(0, 1, 0), true},
+		{z, aks.since.AddDate(0, -2, 0), false},
+		{z, later.AddDate(0, 1, 0), true},
+		{z, z, true},
 	}
 
 	for _, t := range tests {

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -590,7 +590,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAt(c *C) {
 	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.until.AddDate(0, 1, 0)), Equals, false)
 }
 
-func (aks *accountKeySuite) TestPublicKeyIsValidAboutWithUntilPunctual(c *C) {
+func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinWithUntilPunctual(c *C) {
 	// With since and until, i.e. signing account-key expires.
 	// Key is valid over [since, until)
 	encoded := "type: account-key\n" +
@@ -622,11 +622,11 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAboutWithUntilPunctual(c *C) {
 	}
 
 	for _, t := range tests {
-		c.Check(asserts.AccountKeyIsKeyValidAbout(accKey, t.timePt, t.timePt), Equals, t.valid)
+		c.Check(asserts.AccountKeyIsKeyValidAssumingCurTimeWithin(accKey, t.timePt, t.timePt), Equals, t.valid)
 	}
 }
 
-func (aks *accountKeySuite) TestPublicKeyIsValidAboutNoUntilPunctual(c *C) {
+func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinNoUntilPunctual(c *C) {
 	// With since and until, i.e. signing account-key expires.
 	// Key is valid for time >= since.
 	encoded := "type: account-key\n" +
@@ -657,11 +657,11 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAboutNoUntilPunctual(c *C) {
 	}
 
 	for _, t := range tests {
-		c.Check(asserts.AccountKeyIsKeyValidAbout(accKey, t.timePt, t.timePt), Equals, t.valid)
+		c.Check(asserts.AccountKeyIsKeyValidAssumingCurTimeWithin(accKey, t.timePt, t.timePt), Equals, t.valid)
 	}
 }
 
-func (aks *accountKeySuite) TestPublicKeyIsValidAboutWithUntilInterval(c *C) {
+func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinWithUntilInterval(c *C) {
 	// With since and until, i.e. signing account-key expires.
 	// Key is valid over [since, until)
 	encoded := "type: account-key\n" +
@@ -705,12 +705,12 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAboutWithUntilInterval(c *C) {
 	}
 
 	for _, t := range tests {
-		c.Check(asserts.AccountKeyIsKeyValidAbout(accKey, t.earliest, t.latest), Equals, t.valid)
+		c.Check(asserts.AccountKeyIsKeyValidAssumingCurTimeWithin(accKey, t.earliest, t.latest), Equals, t.valid)
 	}
 
 }
 
-func (aks *accountKeySuite) TestPublicKeyIsValidAboutNoUntilInterval(c *C) {
+func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinNoUntilInterval(c *C) {
 	// With since and until, i.e. signing account-key expires.
 	// Key is valid for time >= since.
 	encoded := "type: account-key\n" +
@@ -754,7 +754,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAboutNoUntilInterval(c *C) {
 	}
 
 	for _, t := range tests {
-		c.Check(asserts.AccountKeyIsKeyValidAbout(accKey, t.earliest, t.latest), Equals, t.valid)
+		c.Check(asserts.AccountKeyIsKeyValidAssumingCurTimeWithin(accKey, t.earliest, t.latest), Equals, t.valid)
 	}
 
 }

--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2019 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -101,6 +101,47 @@ func (s *batchSuite) TestAddStream(c *C) {
 	})
 	c.Assert(err, IsNil)
 	c.Check(devAcct.(*asserts.Account).Username(), Equals, "developer1")
+}
+
+func (s *batchSuite) TestCommitToAndObserve(c *C) {
+	b := &bytes.Buffer{}
+	enc := asserts.NewEncoder(b)
+	// wrong order is ok
+	err := enc.Encode(s.dev1Acct)
+	c.Assert(err, IsNil)
+	enc.Encode(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+	refs, err := batch.AddStream(b)
+	c.Assert(err, IsNil)
+	c.Check(refs, DeepEquals, []*asserts.Ref{
+		{Type: asserts.AccountType, PrimaryKey: []string{s.dev1Acct.AccountID()}},
+		{Type: asserts.AccountKeyType, PrimaryKey: []string{s.storeSigning.StoreAccountKey("").PublicKeyID()}},
+	})
+
+	// noop
+	err = batch.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	var seen []*asserts.Ref
+	obs := func(verified asserts.Assertion) {
+		seen = append(seen, verified.Ref())
+	}
+	err = batch.CommitToAndObserve(s.db, obs, nil)
+	c.Assert(err, IsNil)
+
+	devAcct, err := s.db.Find(asserts.AccountType, map[string]string{
+		"account-id": s.dev1Acct.AccountID(),
+	})
+	c.Assert(err, IsNil)
+	c.Check(devAcct.(*asserts.Account).Username(), Equals, "developer1")
+
+	// this is the order they needed to be added
+	c.Check(seen, DeepEquals, []*asserts.Ref{
+		{Type: asserts.AccountKeyType, PrimaryKey: []string{s.storeSigning.StoreAccountKey("").PublicKeyID()}},
+		{Type: asserts.AccountType, PrimaryKey: []string{s.dev1Acct.AccountID()}},
+	})
 }
 
 func (s *batchSuite) TestAddEmptyStream(c *C) {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -682,6 +682,9 @@ func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, c
 	var pubKey PublicKey
 	if signingKey != nil {
 		pubKey = signingKey.publicKey()
+		if assert.AuthorityID() != signingKey.AccountID() {
+			return fmt.Errorf("assertion authority %q does not match public key from %q", assert.AuthorityID(), signingKey.AccountID())
+		}
 	} else {
 		custom, ok := assert.(customSigner)
 		if !ok {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -688,7 +688,7 @@ func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, roDB 
 		// (e.g. account-key-request)
 		return nil
 	}
-	if !signingKey.isKeyValidAbout(checkTimeEarliest, checkTimeLatest) {
+	if !signingKey.isKeyValidAssumingCurTimeWithin(checkTimeEarliest, checkTimeLatest) {
 		return fmt.Errorf("assertion is signed with expired public key %q from %q", assert.SignKeyID(), assert.AuthorityID())
 	}
 	return nil

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2020 Canonical Ltd
+ * Copyright (C) 2015-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -200,7 +200,7 @@ type RODatabase interface {
 // A Checker defines a check on an assertion considering aspects such as
 // the signing key, and consistency with other
 // assertions in the database.
-type Checker func(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error
+type Checker func(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error
 
 // Database holds assertions and can be used to sign or check
 // further assertions.
@@ -215,7 +215,8 @@ type Database struct {
 	// backstores of dbs this was built on by stacking
 	stackedOn []Backstore
 
-	checkers []Checker
+	checkers     []Checker
+	earliestTime time.Time
 }
 
 // OpenDatabase opens the assertion database based on the configuration.
@@ -373,6 +374,15 @@ func (db *Database) IsTrustedAccount(accountID string) bool {
 	return err == nil
 }
 
+var timeNow = time.Now
+
+// SetEarliestTime affects how key expiration is checked.
+// Instead of considering current system time, only assume that current time
+// is >= earliest. If earliest is zero reset to considering current system time.
+func (db *Database) SetEarliestTime(earliest time.Time) {
+	db.earliestTime = earliest
+}
+
 // Check tests whether the assertion is properly signed and consistent with all the stored knowledge.
 func (db *Database) Check(assert Assertion) error {
 	if !assert.SupportedFormat() {
@@ -380,7 +390,14 @@ func (db *Database) Check(assert Assertion) error {
 	}
 
 	typ := assert.Type()
-	now := time.Now()
+	// assume current time is >= earliestTime and <= latestTime
+	earliestTime := db.earliestTime
+	var latestTime time.Time
+	if earliestTime.IsZero() {
+		// use the current system time by setting both to it
+		earliestTime = timeNow()
+		latestTime = earliestTime
+	}
 
 	var accKey *AccountKey
 	var err error
@@ -400,7 +417,7 @@ func (db *Database) Check(assert Assertion) error {
 	}
 
 	for _, checker := range db.checkers {
-		err := checker(assert, accKey, db, now)
+		err := checker(assert, accKey, db, earliestTime, latestTime)
 		if err != nil {
 			return err
 		}
@@ -663,7 +680,7 @@ func (db *Database) FindSequence(assertType *AssertionType, sequenceHeaders map[
 // assertion checkers
 
 // CheckSigningKeyIsNotExpired checks that the signing key is not expired.
-func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error {
+func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error {
 	if signingKey == nil {
 		// assert isn't signed with an account-key key, CheckSignature
 		// will fail anyway unless we teach it more stuff,
@@ -671,14 +688,14 @@ func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, roDB 
 		// (e.g. account-key-request)
 		return nil
 	}
-	if !signingKey.isKeyValidAt(checkTime) {
+	if !signingKey.isKeyValidAbout(checkTimeEarliest, checkTimeLatest) {
 		return fmt.Errorf("assertion is signed with expired public key %q from %q", assert.SignKeyID(), assert.AuthorityID())
 	}
 	return nil
 }
 
 // CheckSignature checks that the signature is valid.
-func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error {
+func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error {
 	var pubKey PublicKey
 	if signingKey != nil {
 		pubKey = signingKey.publicKey()
@@ -710,7 +727,7 @@ type timestamped interface {
 
 // CheckTimestampVsSigningKeyValidity verifies that the timestamp of
 // the assertion is within the signing key validity.
-func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error {
+func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error {
 	if signingKey == nil {
 		// assert isn't signed with an account-key key, CheckSignature
 		// will fail anyway unless we teach it more stuff.
@@ -740,7 +757,7 @@ type consistencyChecker interface {
 }
 
 // CheckCrossConsistency verifies that the assertion is consistent with the other statements in the database.
-func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error {
+func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error {
 	// see if the assertion requires further checks
 	if checker, ok := assert.(consistencyChecker); ok {
 		return checker.checkConsistency(roDB, signingKey)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -332,8 +332,63 @@ func (chks *checkSuite) TestCheckMismatchedAccountIDandKey(c *C) {
 	err = db.Check(a)
 	c.Check(err, ErrorMatches, `error finding matching public key for signature: found public key ".*" from "canonical" but expected it from: random`)
 
-	err = asserts.CheckSignature(a, cfg.Trusted[0].(*asserts.AccountKey), db, time.Time{})
+	err = asserts.CheckSignature(a, cfg.Trusted[0].(*asserts.AccountKey), db, time.Time{}, time.Time{})
 	c.Check(err, ErrorMatches, `assertion authority "random" does not match public key from "canonical"`)
+}
+
+func (chks *checkSuite) TestCheckAndSetEarliestTime(c *C) {
+	trustedKey := testPrivKey0
+
+	ak := asserts.MakeAccountKeyForTest("canonical", trustedKey.PublicKey(), time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC), 2)
+
+	cfg := &asserts.DatabaseConfig{
+		Backstore: chks.bs,
+		Trusted:   []asserts.Assertion{ak},
+	}
+	db, err := asserts.OpenDatabase(cfg)
+	c.Assert(err, IsNil)
+
+	headers := map[string]interface{}{
+		"authority-id": "canonical",
+		"primary-key":  "0",
+	}
+	a, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, trustedKey)
+	c.Assert(err, IsNil)
+
+	// now is since + 1 year, key is valid
+	r := asserts.MockTimeNow(ak.Since().AddDate(1, 0, 0))
+	defer r()
+
+	err = db.Check(a)
+	c.Check(err, IsNil)
+
+	// now is since - 1 year, key is invalid
+	pastTime := ak.Since().AddDate(-1, 0, 0)
+	asserts.MockTimeNow(pastTime)
+
+	err = db.Check(a)
+	c.Check(err, ErrorMatches, `assertion is signed with expired public key .*`)
+
+	// now is ignored but known to be at least >= pastTime
+	// key is considered valid
+	db.SetEarliestTime(pastTime)
+	err = db.Check(a)
+	c.Check(err, IsNil)
+
+	// move earliest after until
+	db.SetEarliestTime(ak.Until().AddDate(0, 0, 1))
+	err = db.Check(a)
+	c.Check(err, ErrorMatches, `assertion is signed with expired public key .*`)
+
+	// check using now = since - 1 year again
+	db.SetEarliestTime(time.Time{})
+	err = db.Check(a)
+	c.Check(err, ErrorMatches, `assertion is signed with expired public key .*`)
+
+	// now is since + 1 month, key is valid
+	asserts.MockTimeNow(ak.Since().AddDate(0, 1, 0))
+	err = db.Check(a)
+	c.Check(err, IsNil)
 }
 
 type signAddFindSuite struct {

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -254,9 +254,9 @@ func AccountKeyIsKeyValidAt(ak *AccountKey, when time.Time) bool {
 	return ak.isKeyValidAt(when)
 }
 
-// AccountKeyIsKeyValidAt exposes isKeyValidAbout on AccountKey for tests
-func AccountKeyIsKeyValidAbout(ak *AccountKey, earliest, latest time.Time) bool {
-	return ak.isKeyValidAbout(earliest, latest)
+// AccountKeyIsKeyValidAssumingCurTimeWithin exposes isKeyValidAssumingCurTimeWithin on AccountKey for tests
+func AccountKeyIsKeyValidAssumingCurTimeWithin(ak *AccountKey, earliest, latest time.Time) bool {
+	return ak.isKeyValidAssumingCurTimeWithin(earliest, latest)
 }
 
 type GPGRunner func(input []byte, args ...string) ([]byte, error)

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -64,7 +64,7 @@ func BootstrapAccountForTest(authorityID string) *Account {
 	}
 }
 
-func makeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, validYears int) *AccountKey {
+func MakeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, since time.Time, validYears int) *AccountKey {
 	return &AccountKey{
 		assertionBase: assertionBase{
 			headers: map[string]interface{}{
@@ -74,18 +74,28 @@ func makeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, validYea
 				"public-key-sha3-384": openPGPPubKey.ID(),
 			},
 		},
-		since:  time.Time{},
-		until:  time.Time{}.UTC().AddDate(validYears, 0, 0),
+		since:  since.UTC(),
+		until:  since.UTC().AddDate(validYears, 0, 0),
 		pubKey: openPGPPubKey,
 	}
 }
 
 func BootstrapAccountKeyForTest(authorityID string, pubKey PublicKey) *AccountKey {
-	return makeAccountKeyForTest(authorityID, pubKey, 9999)
+	return MakeAccountKeyForTest(authorityID, pubKey, time.Time{}, 9999)
 }
 
 func ExpiredAccountKeyForTest(authorityID string, pubKey PublicKey) *AccountKey {
-	return makeAccountKeyForTest(authorityID, pubKey, 1)
+	return MakeAccountKeyForTest(authorityID, pubKey, time.Time{}, 1)
+}
+
+func MockTimeNow(t time.Time) (restore func()) {
+	oldTimeNow := timeNow
+	timeNow = func() time.Time {
+		return t
+	}
+	return func() {
+		timeNow = oldTimeNow
+	}
 }
 
 // define dummy assertion types to use in the tests
@@ -242,6 +252,11 @@ func init() {
 // AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests
 func AccountKeyIsKeyValidAt(ak *AccountKey, when time.Time) bool {
 	return ak.isKeyValidAt(when)
+}
+
+// AccountKeyIsKeyValidAt exposes isKeyValidAbout on AccountKey for tests
+func AccountKeyIsKeyValidAbout(ak *AccountKey, earliest, latest time.Time) bool {
+	return ak.isKeyValidAbout(earliest, latest)
 }
 
 type GPGRunner func(input []byte, args ...string) ([]byte, error)

--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -27,7 +27,7 @@ import (
 )
 
 // A Grouping identifies opaquely a grouping of assertions.
-// Pool uses it to label the interesection between a set of groups.
+// Pool uses it to label the intersection between a set of groups.
 type Grouping string
 
 // A pool helps holding and tracking a set of assertions and their

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -65,6 +65,8 @@ type initramfsMountsSuite struct {
 	model    *asserts.Model
 	tmpDir   string
 
+	snapDeclAssertsTime time.Time
+
 	kernel   snap.PlaceInfo
 	kernelr2 snap.PlaceInfo
 	core20   snap.PlaceInfo
@@ -128,7 +130,7 @@ func (m *mockedWrappedError) Unwrap() error { return m.err }
 
 func (m *mockedWrappedError) Error() string { return fmt.Sprintf(m.fmt, m.err) }
 
-func (s *initramfsMountsSuite) setupSeed(c *C, gadgetSnapFiles [][]string) {
+func (s *initramfsMountsSuite) setupSeed(c *C, modelAssertTime time.Time, gadgetSnapFiles [][]string) {
 	// pretend /run/mnt/ubuntu-seed has a valid seed
 	s.seedDir = boot.InitramfsUbuntuSeedDir
 
@@ -143,17 +145,27 @@ func (s *initramfsMountsSuite) setupSeed(c *C, gadgetSnapFiles [][]string) {
 		"verification": "verified",
 	})
 
+	// make sure all the assertions use the same time
+	seed20.SetSnapAssertionNow(s.snapDeclAssertsTime)
+
 	// add a bunch of snaps
 	seed20.MakeAssertedSnap(c, "name: snapd\nversion: 1\ntype: snapd", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: pc\nversion: 1\ntype: gadget\nbase: core20", gadgetSnapFiles, snap.R(1), "canonical", seed20.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: pc-kernel\nversion: 1\ntype: kernel", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: core20\nversion: 1\ntype: base", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 
+	// pretend that by default, the model uses an older timestamp than the
+	// snap assertions
+	if modelAssertTime.IsZero() {
+		modelAssertTime = s.snapDeclAssertsTime.Add(-30 * time.Minute)
+	}
+
 	s.sysLabel = "20191118"
 	s.model = seed20.MakeSeed(c, s.sysLabel, "my-brand", "my-model", map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
+		"timestamp":    modelAssertTime.Format(time.RFC3339),
 		"snaps": []interface{}{
 			map[string]interface{}{
 				"name":            "pc-kernel",
@@ -168,7 +180,6 @@ func (s *initramfsMountsSuite) setupSeed(c *C, gadgetSnapFiles [][]string) {
 				"default-channel": "20",
 			}},
 	}, nil)
-
 }
 
 func (s *initramfsMountsSuite) SetUpTest(c *C) {
@@ -186,8 +197,13 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 	restore = func() { dirs.SetRootDir("") }
 	s.AddCleanup(restore)
 
+	// use a specific time for all the assertions, in the future so that we can
+	// set the timestamp of the model assertion to something newer than now, but
+	// still older than the snap declarations by default
+	s.snapDeclAssertsTime = time.Now().Add(60 * time.Minute)
+
 	// setup the seed
-	s.setupSeed(c, nil)
+	s.setupSeed(c, time.Time{}, nil)
 
 	// make test snap PlaceInfo's for various boot functionality
 	var err error
@@ -222,6 +238,71 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 	s.AddCleanup(main.MockSecbootLockSealedKeys(func() error {
 		return nil
 	}))
+
+	s.AddCleanup(main.MockOsutilSetTime(func(time.Time) error {
+		return nil
+	}))
+}
+
+// static test cases for time test variants shared across the different modes
+
+type timeTestCase struct {
+	now       time.Time
+	modelTime time.Time
+	expT      time.Time
+	comment   string
+}
+
+func (s *initramfsMountsSuite) timeTestCases() []timeTestCase {
+	// epoch time
+	epoch := time.Time{}
+
+	// t1 is the kernel initrd build time
+	t1 := s.snapDeclAssertsTime.Add(-30 * 24 * time.Hour)
+	// technically there is another time here between t1 and t2, that is the
+	// default model sign time, but since it's older than the snap assertion
+	// sign time (t2) it's not actually used in the test
+
+	// t2 is the time that snap-revision / snap-declaration assertions will be
+	// signed with
+	t2 := s.snapDeclAssertsTime
+
+	// t3 is a time after the snap-declarations are signed
+	t3 := s.snapDeclAssertsTime.Add(30 * 24 * time.Hour)
+
+	// t4 and t5 are both times after the the snap declarations are signed
+	t4 := s.snapDeclAssertsTime.Add(60 * 24 * time.Hour)
+	t5 := s.snapDeclAssertsTime.Add(120 * 24 * time.Hour)
+
+	return []timeTestCase{
+		{
+			now:     epoch,
+			expT:    t2,
+			comment: "now() is epoch",
+		},
+		{
+			now:     t1,
+			expT:    t2,
+			comment: "now() is kernel initrd sign time",
+		},
+		{
+			now:     t3,
+			expT:    t3,
+			comment: "now() is newer than snap assertion",
+		},
+		{
+			now:       t3,
+			modelTime: t4,
+			expT:      t4,
+			comment:   "model time is newer than now(), which is newer than snap asserts",
+		},
+		{
+			now:       t5,
+			modelTime: t4,
+			expT:      t5,
+			comment:   "model time is newest, but older than now()",
+		},
+	}
 }
 
 // helpers to create consistent UnlockResult values
@@ -462,6 +543,56 @@ grade=signed
 	c.Check(sealedKeysLocked, Equals, true)
 }
 
+func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeTimeMovesForwardHappy(c *C) {
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install snapd_recovery_system="+s.sysLabel)
+
+	for _, tc := range s.timeTestCases() {
+		comment := Commentf(tc.comment)
+		cleanups := []func(){}
+
+		// always remove the ubuntu-seed dir, otherwise setupSeed complains the
+		// model file already exists and can't setup the seed
+		err := os.RemoveAll(filepath.Join(boot.InitramfsUbuntuSeedDir))
+		c.Assert(err, IsNil, comment)
+		s.setupSeed(c, tc.modelTime, nil)
+
+		restore := main.MockTimeNow(func() time.Time {
+			return tc.now
+		})
+		cleanups = append(cleanups, restore)
+
+		// check what time we try to move forward to
+		restore = main.MockOsutilSetTime(func(t time.Time) error {
+			// make sure the timestamps are within 1 second of each other, they
+			// won't be equal since the timestamp is serialized to an assertion and
+			// read back
+			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			return nil
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = s.mockSystemdMountSequence(c, []systemdMount{
+			ubuntuLabelMount("ubuntu-seed", "install"),
+			s.makeSeedSnapSystemdMount(snap.TypeSnapd),
+			s.makeSeedSnapSystemdMount(snap.TypeKernel),
+			s.makeSeedSnapSystemdMount(snap.TypeBase),
+			{
+				"tmpfs",
+				boot.InitramfsDataDir,
+				tmpfsMountOpts,
+			},
+		}, nil)
+		cleanups = append(cleanups, restore)
+
+		_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+		c.Assert(err, IsNil, comment)
+
+		for _, r := range cleanups {
+			r()
+		}
+	}
+}
+
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeGadgetDefaultsHappy(c *C) {
 	// setup a seed with default gadget yaml
 	const gadgetYamlDefaults = `
@@ -475,7 +606,7 @@ defaults:
 `
 	c.Assert(os.RemoveAll(s.seedDir), IsNil)
 
-	s.setupSeed(c, [][]string{
+	s.setupSeed(c, time.Time{}, [][]string{
 		{"meta/gadget.yaml", gadgetYamlDefaults},
 	})
 
@@ -608,6 +739,81 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUnencryptedWithSaveHapp
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
+}
+
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeTimeMovesForwardHappy(c *C) {
+
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
+
+	for _, tc := range s.timeTestCases() {
+		comment := Commentf(tc.comment)
+		cleanups := []func(){}
+
+		// always remove the ubuntu-seed dir, otherwise setupSeed complains the
+		// model file already exists and can't setup the seed
+		err := os.RemoveAll(filepath.Join(boot.InitramfsUbuntuSeedDir))
+		c.Assert(err, IsNil, comment)
+		s.setupSeed(c, tc.modelTime, nil)
+
+		restore := main.MockTimeNow(func() time.Time {
+			return tc.now
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = disks.MockMountPointDisksToPartitionMapping(
+			map[disks.Mountpoint]*disks.MockDiskMapping{
+				{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultBootDisk,
+				{Mountpoint: boot.InitramfsDataDir}:       defaultBootDisk,
+			},
+		)
+		cleanups = append(cleanups, restore)
+
+		// check what time we try to move forward to
+		restore = main.MockOsutilSetTime(func(t time.Time) error {
+			// make sure the timestamps are within 1 second of each other, they
+			// won't be equal since the timestamp is serialized to an assertion and
+			// read back
+			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			return nil
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = s.mockSystemdMountSequence(c, []systemdMount{
+			ubuntuLabelMount("ubuntu-boot", "run"),
+			ubuntuPartUUIDMount("ubuntu-seed-partuuid", "run"),
+			ubuntuPartUUIDMount("ubuntu-data-partuuid", "run"),
+			s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
+			s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+		}, nil)
+		cleanups = append(cleanups, restore)
+
+		// mock a bootloader
+		bloader := boottest.MockUC20RunBootenv(bootloadertest.Mock("mock", c.MkDir()))
+		bootloader.Force(bloader)
+		cleanups = append(cleanups, func() { bootloader.Force(nil) })
+
+		// set the current kernel
+		restore = bloader.SetEnabledKernel(s.kernel)
+		cleanups = append(cleanups, restore)
+
+		makeSnapFilesOnEarlyBootUbuntuData(c, s.kernel, s.core20)
+
+		// write modeenv
+		modeEnv := boot.Modeenv{
+			Mode:           "run",
+			Base:           s.core20.Filename(),
+			CurrentKernels: []string{s.kernel.Filename()},
+		}
+		err = modeEnv.WriteTo(boot.InitramfsWritableDir)
+		c.Assert(err, IsNil, comment)
+
+		_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+		c.Assert(err, IsNil, comment)
+
+		for _, r := range cleanups {
+			r()
+		}
+	}
 }
 
 func (s *initramfsMountsSuite) testInitramfsMountsRunModeNoSaveUnencrypted(c *C) error {
@@ -2413,6 +2619,90 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappy(c *C) {
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "degraded.json"), testutil.FileAbsent)
 }
 
+func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeTimeMovesForwardHappy(c *C) {
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=recover snapd_recovery_system="+s.sysLabel)
+
+	for _, tc := range s.timeTestCases() {
+		comment := Commentf(tc.comment)
+		cleanups := []func(){}
+
+		// always remove the ubuntu-seed dir, otherwise setupSeed complains the
+		// model file already exists and can't setup the seed
+		err := os.RemoveAll(filepath.Join(boot.InitramfsUbuntuSeedDir))
+		c.Assert(err, IsNil, comment)
+
+		// also always remove the data dir, since we need to copy state.json
+		// there, so if the file already exists the initramfs code dies
+		err = os.RemoveAll(filepath.Join(boot.InitramfsDataDir))
+		c.Assert(err, IsNil, comment)
+
+		s.setupSeed(c, tc.modelTime, nil)
+
+		restore := main.MockTimeNow(func() time.Time {
+			return tc.now
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = disks.MockMountPointDisksToPartitionMapping(
+			map[disks.Mountpoint]*disks.MockDiskMapping{
+				{Mountpoint: boot.InitramfsUbuntuSeedDir}:     defaultBootWithSaveDisk,
+				{Mountpoint: boot.InitramfsUbuntuBootDir}:     defaultBootWithSaveDisk,
+				{Mountpoint: boot.InitramfsHostUbuntuDataDir}: defaultBootWithSaveDisk,
+				{Mountpoint: boot.InitramfsUbuntuSaveDir}:     defaultBootWithSaveDisk,
+			},
+		)
+		cleanups = append(cleanups, restore)
+
+		// check what time we try to move forward to
+		restore = main.MockOsutilSetTime(func(t time.Time) error {
+			// make sure the timestamps are within 1 second of each other, they
+			// won't be equal since the timestamp is serialized to an assertion and
+			// read back
+			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			return nil
+		})
+		cleanups = append(cleanups, restore)
+
+		restore = s.mockSystemdMountSequence(c, []systemdMount{
+			ubuntuLabelMount("ubuntu-seed", "recover"),
+			s.makeSeedSnapSystemdMount(snap.TypeSnapd),
+			s.makeSeedSnapSystemdMount(snap.TypeKernel),
+			s.makeSeedSnapSystemdMount(snap.TypeBase),
+			{
+				"tmpfs",
+				boot.InitramfsDataDir,
+				tmpfsMountOpts,
+			},
+			{
+				"/dev/disk/by-partuuid/ubuntu-boot-partuuid",
+				boot.InitramfsUbuntuBootDir,
+				needsFsckDiskMountOpts,
+			},
+			{
+				"/dev/disk/by-partuuid/ubuntu-data-partuuid",
+				boot.InitramfsHostUbuntuDataDir,
+				nil,
+			},
+			{
+				"/dev/disk/by-partuuid/ubuntu-save-partuuid",
+				boot.InitramfsUbuntuSaveDir,
+				nil,
+			},
+		}, nil)
+		cleanups = append(cleanups, restore)
+
+		bloader := bootloadertest.Mock("mock", c.MkDir())
+		bootloader.Force(bloader)
+		cleanups = append(cleanups, func() { bootloader.Force(nil) })
+
+		s.testRecoverModeHappy(c)
+
+		for _, r := range cleanups {
+			r()
+		}
+	}
+}
+
 func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeGadgetDefaultsHappy(c *C) {
 	// setup a seed with default gadget yaml
 	const gadgetYamlDefaults = `
@@ -2426,7 +2716,7 @@ defaults:
 `
 	c.Assert(os.RemoveAll(s.seedDir), IsNil)
 
-	s.setupSeed(c, [][]string{
+	s.setupSeed(c, time.Time{}, [][]string{
 		{"meta/gadget.yaml", gadgetYamlDefaults},
 	})
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -571,11 +571,12 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeTimeMovesForwardHap
 		// check what time we try to move forward to
 		restore = main.MockOsutilSetTime(func(t time.Time) error {
 			osutilSetTimeCalls++
-
 			// make sure the timestamps are within 1 second of each other, they
 			// won't be equal since the timestamp is serialized to an assertion and
 			// read back
-			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			tTrunc := t.Truncate(2 * time.Second)
+			expTTrunc := tc.expT.Truncate(2 * time.Second)
+			c.Assert(tTrunc.Equal(expTTrunc), Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
 			return nil
 		})
 		cleanups = append(cleanups, restore)
@@ -787,7 +788,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeTimeMovesForwardHappy(c
 				// make sure the timestamps are within 1 second of each other, they
 				// won't be equal since the timestamp is serialized to an assertion and
 				// read back
-				c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+				tTrunc := t.Truncate(2 * time.Second)
+				expTTrunc := tc.expT.Truncate(2 * time.Second)
+				c.Assert(tTrunc.Equal(expTTrunc), Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
 				return nil
 			})
 			cleanups = append(cleanups, restore)
@@ -841,6 +844,8 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeTimeMovesForwardHappy(c
 			if isFirstBoot {
 				c.Assert(osutilSetTimeCalls, Equals, tc.setTimeCalls, comment)
 			} else {
+				// non-first boot should not have moved the time at all since it
+				// doesn't read assertions
 				c.Assert(osutilSetTimeCalls, Equals, 0, comment)
 			}
 
@@ -2695,7 +2700,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeTimeMovesForwardHap
 			// make sure the timestamps are within 1 second of each other, they
 			// won't be equal since the timestamp is serialized to an assertion and
 			// read back
-			c.Assert(t.Sub(tc.expT) < time.Second, Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
+			tTrunc := t.Truncate(2 * time.Second)
+			expTTrunc := tc.expT.Truncate(2 * time.Second)
+			c.Assert(tTrunc.Equal(expTTrunc), Equals, true, Commentf("%s, exp %s, got %s", tc.comment, t, s.snapDeclAssertsTime))
 			return nil
 		})
 		cleanups = append(cleanups, restore)

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -56,6 +56,14 @@ func MockTimeNow(f func() time.Time) (restore func()) {
 	}
 }
 
+func MockOsutilSetTime(f func(t time.Time) error) (restore func()) {
+	old := osutilSetTime
+	osutilSetTime = f
+	return func() {
+		osutilSetTime = old
+	}
+}
+
 func MockOsutilIsMounted(f func(string) (bool, error)) (restore func()) {
 	old := osutilIsMounted
 	osutilIsMounted = f

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -75,11 +75,14 @@ func (mst *initramfsMountsState) ReadEssential(recoverySystem string, essentialT
 		return nil, nil, err
 	}
 
-	// set the time on the system to move forward
-	if err := osutilSetTime(newTrustedEarliestTime); err != nil {
-		// log the error but don't fail on it, we should be able to continue
-		// even if the time can't be moved forward
-		logger.Noticef("failed to move time forward from %s to %s: %v", now, newTrustedEarliestTime, err)
+	// set the time on the system to move forward if it is in the future - never
+	// move the time backwards
+	if newTrustedEarliestTime.After(now) {
+		if err := osutilSetTime(newTrustedEarliestTime); err != nil {
+			// log the error but don't fail on it, we should be able to continue
+			// even if the time can't be moved forward
+			logger.Noticef("failed to move time forward from %s to %s: %v", now, newTrustedEarliestTime, err)
+		}
 	}
 
 	return model, snaps, nil

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -27,9 +27,15 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
+)
+
+var (
+	osutilSetTime = osutil.SetTime
 )
 
 // initramfsMountsState helps tracking the state and progress
@@ -53,7 +59,30 @@ func (mst *initramfsMountsState) ReadEssential(recoverySystem string, essentialT
 	}
 
 	perf := timings.New(nil)
-	return seed.ReadSystemEssential(boot.InitramfsUbuntuSeedDir, recoverySystem, essentialTypes, perf)
+
+	// get the current time to pass to ReadSystemEssentialAndBetterEarliestTime
+	// note that we trust the time we have from the system, because that time
+	// comes from either:
+	// * a RTC on the system that the kernel/systemd consulted and used to move
+	//   time forward
+	// * systemd using a built-in timestamp from the initrd which was stamped
+	//   when the initrd was built, giving a lower bound on the current time if
+	//   the RTC does not have a battery or is otherwise unreliable, etc.
+	now := timeNow()
+
+	model, snaps, newTrustedEarliestTime, err := seed.ReadSystemEssentialAndBetterEarliestTime(boot.InitramfsUbuntuSeedDir, recoverySystem, essentialTypes, now, perf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// set the time on the system to move forward
+	if err := osutilSetTime(newTrustedEarliestTime); err != nil {
+		// log the error but don't fail on it, we should be able to continue
+		// even if the time can't be moved forward
+		logger.Noticef("failed to move time forward from %s to %s: %v", now, newTrustedEarliestTime, err)
+	}
+
+	return model, snaps, nil
 }
 
 // UnverifiedBootModel returns the unverified model from the

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -328,6 +328,10 @@ func (fs *Fake16Seed) Brand() (*asserts.Account, error) {
 	return assertstest.FakeAssertion(headers, nil).(*asserts.Account), nil
 }
 
+func (fs *Fake16Seed) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error {
+	panic("unexpected")
+}
+
 func (fs *Fake16Seed) LoadMeta(tm timings.Measurer) error {
 	return fs.LoadMetaErr
 }

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -655,7 +655,7 @@ func verifySignatures(a asserts.Assertion, workBS asserts.Backstore, trusted ass
 				return err
 			}
 		}
-		if err := asserts.CheckSignature(a, key.(*asserts.AccountKey), nil, time.Time{}); err != nil {
+		if err := asserts.CheckSignature(a, key.(*asserts.AccountKey), nil, time.Time{}, time.Time{}); err != nil {
 			return err
 		}
 		a = key

--- a/osutil/chdir_test.go
+++ b/osutil/chdir_test.go
@@ -17,12 +17,13 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"fmt"
 	"os"
 
+	"github.com/snapcore/snapd/osutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -36,7 +37,7 @@ func (ts *ChdirTestSuite) TestChdir(c *C) {
 	cwd, err := os.Getwd()
 	c.Assert(err, IsNil)
 	c.Assert(cwd, Not(Equals), tmpdir)
-	ChDir(tmpdir, func() error {
+	osutil.ChDir(tmpdir, func() error {
 		cwd, err := os.Getwd()
 		c.Assert(err, IsNil)
 		c.Assert(cwd, Equals, tmpdir)
@@ -45,14 +46,14 @@ func (ts *ChdirTestSuite) TestChdir(c *C) {
 }
 
 func (ts *ChdirTestSuite) TestChdirErrorNoDir(c *C) {
-	err := ChDir("random-dir-that-does-not-exist", func() error {
+	err := osutil.ChDir("random-dir-that-does-not-exist", func() error {
 		return nil
 	})
 	c.Assert(err, ErrorMatches, "chdir .*: no such file or directory")
 }
 
 func (ts *ChdirTestSuite) TestChdirErrorFromFunc(c *C) {
-	err := ChDir("/", func() error {
+	err := osutil.ChDir("/", func() error {
 		return fmt.Errorf("meep")
 	})
 	c.Assert(err, ErrorMatches, "meep")

--- a/osutil/cp_linux_test.go
+++ b/osutil/cp_linux_test.go
@@ -17,21 +17,22 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"os"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/testutil"
 )
 
 func (s *cpSuite) TestCpMulti(c *C) {
-	maxcp = 2
-	defer func() { maxcp = maxint }()
+	r := osutil.MockMaxCp(2)
+	defer r()
 
-	c.Check(CopyFile(s.f1, s.f2, CopyFlagDefault), IsNil)
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagDefault), IsNil)
 	c.Check(s.f2, testutil.FileEquals, s.data)
 }
 
@@ -41,5 +42,5 @@ func (s *cpSuite) TestDoCpErr(c *C) {
 	st, err := f1.Stat()
 	c.Assert(err, IsNil)
 	// force an error by asking it to write to a readonly stream
-	c.Check(doCopyFile(f1, os.Stdin, st), NotNil)
+	c.Check(osutil.DoCopyFile(f1, os.Stdin, st), NotNil)
 }

--- a/osutil/exitcode_test.go
+++ b/osutil/exitcode_test.go
@@ -17,11 +17,13 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"os"
 	"os/exec"
+
+	"github.com/snapcore/snapd/osutil"
 
 	. "gopkg.in/check.v1"
 )
@@ -38,19 +40,19 @@ func (ts *ExitCodeTestSuite) TestExitCode(c *C) {
 	cmd = exec.Command("false")
 	err = cmd.Run()
 	c.Assert(err, NotNil)
-	e, err := ExitCode(err)
+	e, err := osutil.ExitCode(err)
 	c.Assert(err, IsNil)
 	c.Assert(e, Equals, 1)
 
 	cmd = exec.Command("sh", "-c", "exit 7")
 	err = cmd.Run()
-	e, err = ExitCode(err)
+	e, err = osutil.ExitCode(err)
 	c.Assert(err, IsNil)
 	c.Assert(e, Equals, 7)
 
 	// ensure that non exec.ExitError values give a error
 	_, err = os.Stat("/random/file/that/is/not/there")
 	c.Assert(err, NotNil)
-	_, err = ExitCode(err)
+	_, err = osutil.ExitCode(err)
 	c.Assert(err, NotNil)
 }

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -37,7 +37,34 @@ var (
 	StreamsEqualChunked  = streamsEqualChunked
 	FilesAreEqualChunked = filesAreEqualChunked
 	SudoersFile          = sudoersFile
+	DoCopyFile           = doCopyFile
 )
+
+type Fileish = fileish
+
+func MockMaxCp(new int64) (restore func()) {
+	old := maxcp
+	maxcp = new
+	return func() {
+		maxcp = old
+	}
+}
+
+func MockCopyFile(new func(fileish, fileish, os.FileInfo) error) (restore func()) {
+	old := copyfile
+	copyfile = new
+	return func() {
+		copyfile = old
+	}
+}
+
+func MockOpenFile(new func(string, int, os.FileMode) (fileish, error)) (restore func()) {
+	old := openfile
+	openfile = new
+	return func() {
+		openfile = old
+	}
+}
 
 func MockUserLookup(mock func(name string) (*user.User, error)) func() {
 	realUserLookup := userLookup
@@ -102,6 +129,14 @@ func MockChown(f func(*os.File, sys.UserID, sys.GroupID) error) func() {
 	chown = f
 	return func() {
 		chown = oldChown
+	}
+}
+
+func MockLookPath(new func(string) (string, error)) (restore func()) {
+	old := lookPath
+	lookPath = new
+	return func() {
+		lookPath = old
 	}
 }
 

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -66,6 +66,14 @@ func MockOpenFile(new func(string, int, os.FileMode) (fileish, error)) (restore 
 	}
 }
 
+func MockSyscallSettimeofday(f func(*syscall.Timeval) error) (restore func()) {
+	old := syscallSettimeofday
+	syscallSettimeofday = f
+	return func() {
+		syscallSettimeofday = old
+	}
+}
+
 func MockUserLookup(mock func(name string) (*user.User, error)) func() {
 	realUserLookup := userLookup
 	userLookup = mock

--- a/osutil/fshelpers_test.go
+++ b/osutil/fshelpers_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"io/ioutil"
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/snapcore/snapd/osutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -37,15 +38,15 @@ func (s *groupFindGidOwningSuite) TestSelfOwnedFile(c *C) {
 	err := ioutil.WriteFile(name, nil, 0644)
 	c.Assert(err, IsNil)
 
-	gid, err := FindGidOwning(name)
+	gid, err := osutil.FindGidOwning(name)
 	c.Check(err, IsNil)
 
-	self, err := UserMaybeSudoUser()
+	self, err := osutil.UserMaybeSudoUser()
 	c.Assert(err, IsNil)
 	c.Check(strconv.FormatUint(gid, 10), Equals, self.Gid)
 }
 
 func (s *groupFindGidOwningSuite) TestNoOwnedFile(c *C) {
-	_, err := FindGidOwning("/tmp/filedoesnotexistbutwhy")
+	_, err := osutil.FindGidOwning("/tmp/filedoesnotexistbutwhy")
 	c.Assert(err, DeepEquals, os.ErrNotExist)
 }

--- a/osutil/outputerr_test.go
+++ b/osutil/outputerr_test.go
@@ -17,11 +17,12 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"fmt"
 
+	"github.com/snapcore/snapd/osutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -32,14 +33,14 @@ var _ = Suite(&outputErrSuite{})
 func (ts *outputErrSuite) TestOutputErrOutputWithoutNewlines(c *C) {
 	output := "test output"
 	err := fmt.Errorf("test error")
-	formattedErr := OutputErr([]byte(output), err)
+	formattedErr := osutil.OutputErr([]byte(output), err)
 	c.Check(formattedErr, ErrorMatches, output)
 }
 
 func (ts *outputErrSuite) TestOutputErrOutputWithNewlines(c *C) {
 	output := "output line1\noutput line2"
 	err := fmt.Errorf("test error")
-	formattedErr := OutputErr([]byte(output), err)
+	formattedErr := osutil.OutputErr([]byte(output), err)
 	c.Check(formattedErr.Error(), Equals, `
 -----
 output line1
@@ -49,6 +50,6 @@ output line2
 
 func (ts *outputErrSuite) TestOutputErrNoOutput(c *C) {
 	err := fmt.Errorf("test error")
-	formattedErr := OutputErr([]byte{}, err)
+	formattedErr := osutil.OutputErr([]byte{}, err)
 	c.Check(formattedErr, Equals, err)
 }

--- a/osutil/settime.go
+++ b/osutil/settime.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"time"
+)
+
+// exposed for different 32-bit vs 64-bit definitions of syscall.Timeval
+var timeToTimeval func(time.Time) *syscall.Timeval
+
+// exposed for mocking, since we can't actually call this without being root
+// on system running tests
+var syscallSettimeofday = syscall.Settimeofday
+
+// SetTime sets the time of the system using settimeofday(). This syscall needs
+// to be performed as root or with CAP_SYS_TIME.
+func SetTime(t time.Time) error {
+	tv := timeToTimeval(t)
+
+	return syscallSettimeofday(tv)
+}

--- a/osutil/settime_32bit.go
+++ b/osutil/settime_32bit.go
@@ -34,6 +34,6 @@ func init() {
 func timeToTimeval32(t time.Time) *syscall.Timeval {
 	return &syscall.Timeval{
 		Sec:  int32(t.Unix()),
-		Usec: int32(t.UnixNano() / 1000 % 1000),
+		Usec: int32(t.Nanosecond() / 1000),
 	}
 }

--- a/osutil/settime_32bit.go
+++ b/osutil/settime_32bit.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// +build 386 arm
+// +build linux
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"time"
+)
+
+func init() {
+	timeToTimeval = timeToTimeval32
+}
+
+func timeToTimeval32(t time.Time) *syscall.Timeval {
+	return &syscall.Timeval{
+		Sec:  int32(t.Unix()),
+		Usec: int32(t.UnixNano() / 1000 % 1000),
+	}
+}

--- a/osutil/settime_64bit.go
+++ b/osutil/settime_64bit.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// +build !386
+// +build !arm
+// +build linux
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"time"
+)
+
+func init() {
+	timeToTimeval = timeToTimeval64
+}
+
+func timeToTimeval64(t time.Time) *syscall.Timeval {
+	return &syscall.Timeval{
+		Sec:  int64(t.Unix()),
+		Usec: int64(t.UnixNano() / 1000 % 1000),
+	}
+}

--- a/osutil/settime_64bit.go
+++ b/osutil/settime_64bit.go
@@ -35,6 +35,6 @@ func init() {
 func timeToTimeval64(t time.Time) *syscall.Timeval {
 	return &syscall.Timeval{
 		Sec:  int64(t.Unix()),
-		Usec: int64(t.UnixNano() / 1000 % 1000),
+		Usec: int64(t.Nanosecond() / 1000),
 	}
 }

--- a/osutil/settime_test.go
+++ b/osutil/settime_test.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"syscall"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type settimeTestSuite struct{}
+
+var _ = Suite(&settimeTestSuite{})
+
+func (s *settimeTestSuite) TestSetTime(c *C) {
+	timeIn, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Mon Jan 2 15:04:05 -0700 MST 2006")
+	c.Assert(err, IsNil)
+
+	r := osutil.MockSyscallSettimeofday(func(t *syscall.Timeval) error {
+		c.Assert(int64(t.Sec), Equals, timeIn.Unix())
+		c.Assert(int64(t.Usec), Equals, timeIn.UnixNano()/1000%1000)
+		return nil
+	})
+	defer r()
+
+	err = osutil.SetTime(timeIn)
+	c.Assert(err, IsNil)
+}

--- a/osutil/stat.go
+++ b/osutil/stat.go
@@ -124,3 +124,12 @@ func DirExists(fn string) (exists bool, isDir bool, err error) {
 	}
 	return true, st.IsDir(), nil
 }
+
+// RegularFileExists checks whether a given path exists, and if so whether it is a regular file.
+func RegularFileExists(fn string) (exists, isReg bool, err error) {
+	fileStat, err := os.Lstat(fn)
+	if err != nil {
+		return false, false, err
+	}
+	return true, fileStat.Mode().IsRegular(), nil
+}

--- a/osutil/stat_test.go
+++ b/osutil/stat_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"fmt"
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/snapcore/snapd/osutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -35,7 +36,7 @@ type StatTestSuite struct{}
 var _ = Suite(&StatTestSuite{})
 
 func (ts *StatTestSuite) TestFileDoesNotExist(c *C) {
-	c.Assert(FileExists("/i-do-not-exist"), Equals, false)
+	c.Assert(osutil.FileExists("/i-do-not-exist"), Equals, false)
 }
 
 func (ts *StatTestSuite) TestFileExistsSimple(c *C) {
@@ -43,7 +44,7 @@ func (ts *StatTestSuite) TestFileExistsSimple(c *C) {
 	err := ioutil.WriteFile(fname, []byte(fname), 0644)
 	c.Assert(err, IsNil)
 
-	c.Assert(FileExists(fname), Equals, true)
+	c.Assert(osutil.FileExists(fname), Equals, true)
 }
 
 func (ts *StatTestSuite) TestFileExistsExistsOddPermissions(c *C) {
@@ -51,11 +52,11 @@ func (ts *StatTestSuite) TestFileExistsExistsOddPermissions(c *C) {
 	err := ioutil.WriteFile(fname, []byte(fname), 0100)
 	c.Assert(err, IsNil)
 
-	c.Assert(FileExists(fname), Equals, true)
+	c.Assert(osutil.FileExists(fname), Equals, true)
 }
 
 func (ts *StatTestSuite) TestIsDirectoryDoesNotExist(c *C) {
-	c.Assert(IsDirectory("/i-do-not-exist"), Equals, false)
+	c.Assert(osutil.IsDirectory("/i-do-not-exist"), Equals, false)
 }
 
 func (ts *StatTestSuite) TestIsDirectorySimple(c *C) {
@@ -63,7 +64,7 @@ func (ts *StatTestSuite) TestIsDirectorySimple(c *C) {
 	err := os.Mkdir(dname, 0700)
 	c.Assert(err, IsNil)
 
-	c.Assert(IsDirectory(dname), Equals, true)
+	c.Assert(osutil.IsDirectory(dname), Equals, true)
 }
 
 func (ts *StatTestSuite) TestIsSymlink(c *C) {
@@ -71,11 +72,11 @@ func (ts *StatTestSuite) TestIsSymlink(c *C) {
 	err := os.Symlink("/", sname)
 	c.Assert(err, IsNil)
 
-	c.Assert(IsSymlink(sname), Equals, true)
+	c.Assert(osutil.IsSymlink(sname), Equals, true)
 }
 
 func (ts *StatTestSuite) TestIsSymlinkNoSymlink(c *C) {
-	c.Assert(IsSymlink(c.MkDir()), Equals, false)
+	c.Assert(osutil.IsSymlink(c.MkDir()), Equals, false)
 }
 
 func (ts *StatTestSuite) TestExecutableExists(c *C) {
@@ -83,24 +84,26 @@ func (ts *StatTestSuite) TestExecutableExists(c *C) {
 	defer os.Setenv("PATH", oldPath)
 	d := c.MkDir()
 	os.Setenv("PATH", d)
-	c.Check(ExecutableExists("xyzzy"), Equals, false)
+	c.Check(osutil.ExecutableExists("xyzzy"), Equals, false)
 
 	fname := filepath.Join(d, "xyzzy")
 	c.Assert(ioutil.WriteFile(fname, []byte{}, 0644), IsNil)
-	c.Check(ExecutableExists("xyzzy"), Equals, false)
+	c.Check(osutil.ExecutableExists("xyzzy"), Equals, false)
 
 	c.Assert(os.Chmod(fname, 0755), IsNil)
-	c.Check(ExecutableExists("xyzzy"), Equals, true)
+	c.Check(osutil.ExecutableExists("xyzzy"), Equals, true)
 }
 
-func (s *StatTestSuite) TestLookPathDefaultGivesCorrectPath(c *C) {
-	lookPath = func(name string) (string, error) { return "/bin/true", nil }
-	c.Assert(LookPathDefault("true", "/bin/foo"), Equals, "/bin/true")
+func (ts *StatTestSuite) TestLookPathDefaultGivesCorrectPath(c *C) {
+	r := osutil.MockLookPath(func(name string) (string, error) { return "/bin/true", nil })
+	defer r()
+	c.Assert(osutil.LookPathDefault("true", "/bin/foo"), Equals, "/bin/true")
 }
 
-func (s *StatTestSuite) TestLookPathDefaultReturnsDefaultWhenNotFound(c *C) {
-	lookPath = func(name string) (string, error) { return "", fmt.Errorf("Not found") }
-	c.Assert(LookPathDefault("bar", "/bin/bla"), Equals, "/bin/bla")
+func (ts *StatTestSuite) TestLookPathDefaultReturnsDefaultWhenNotFound(c *C) {
+	r := osutil.MockLookPath(func(name string) (string, error) { return "", fmt.Errorf("Not found") })
+	defer r()
+	c.Assert(osutil.LookPathDefault("bar", "/bin/bla"), Equals, "/bin/bla")
 }
 
 func makeTestPath(c *C, path string, mode os.FileMode) string {
@@ -123,7 +126,7 @@ func makeTestPathInDir(c *C, dir, path string, mode os.FileMode) string {
 	return path
 }
 
-func (s *StatTestSuite) TestIsWritableDir(c *C) {
+func (ts *StatTestSuite) TestIsWritableDir(c *C) {
 	for _, t := range []struct {
 		path       string
 		mode       os.FileMode
@@ -143,12 +146,12 @@ func (s *StatTestSuite) TestIsWritableDir(c *C) {
 		{"file", 0600, true},
 		{"file", 0400, false},
 	} {
-		writable := IsWritable(makeTestPath(c, t.path, t.mode))
+		writable := osutil.IsWritable(makeTestPath(c, t.path, t.mode))
 		c.Check(writable, Equals, t.isWritable, Commentf("incorrect result for %q (%s), got %v, expected %v", t.path, t.mode, writable, t.isWritable))
 	}
 }
 
-func (s *StatTestSuite) TestIsDirNotExist(c *C) {
+func (ts *StatTestSuite) TestIsDirNotExist(c *C) {
 	for _, e := range []error{
 		os.ErrNotExist,
 		syscall.ENOENT,
@@ -160,18 +163,18 @@ func (s *StatTestSuite) TestIsDirNotExist(c *C) {
 		&os.SyscallError{Err: syscall.ENOENT},
 		&os.SyscallError{Err: syscall.ENOTDIR},
 	} {
-		c.Check(IsDirNotExist(e), Equals, true, Commentf("%#v (%v)", e, e))
+		c.Check(osutil.IsDirNotExist(e), Equals, true, Commentf("%#v (%v)", e, e))
 	}
 
 	for _, e := range []error{
 		nil,
 		fmt.Errorf("hello"),
 	} {
-		c.Check(IsDirNotExist(e), Equals, false)
+		c.Check(osutil.IsDirNotExist(e), Equals, false)
 	}
 }
 
-func (s *StatTestSuite) TestDirExists(c *C) {
+func (ts *StatTestSuite) TestDirExists(c *C) {
 	for _, t := range []struct {
 		make   string
 		path   string
@@ -189,7 +192,7 @@ func (s *StatTestSuite) TestDirExists(c *C) {
 		if t.make != "" {
 			makeTestPathInDir(c, base, t.make, 0755)
 		}
-		exists, isDir, err := DirExists(filepath.Join(base, t.path))
+		exists, isDir, err := osutil.DirExists(filepath.Join(base, t.path))
 		c.Check(exists, Equals, t.exists, comm)
 		c.Check(isDir, Equals, t.isDir, comm)
 		c.Check(err, IsNil, comm)
@@ -198,17 +201,17 @@ func (s *StatTestSuite) TestDirExists(c *C) {
 	p := makeTestPath(c, "foo/bar", 0)
 	c.Assert(os.Chmod(filepath.Dir(p), 0), IsNil)
 	defer os.Chmod(filepath.Dir(p), 0755)
-	exists, isDir, err := DirExists(p)
+	exists, isDir, err := osutil.DirExists(p)
 	c.Check(exists, Equals, false)
 	c.Check(isDir, Equals, false)
 	c.Check(err, NotNil)
 }
 
-func (s *StatTestSuite) TestIsExecutable(c *C) {
-	c.Check(IsExecutable("non-existent"), Equals, false)
-	c.Check(IsExecutable("."), Equals, false)
+func (ts *StatTestSuite) TestIsExecutable(c *C) {
+	c.Check(osutil.IsExecutable("non-existent"), Equals, false)
+	c.Check(osutil.IsExecutable("."), Equals, false)
 	dir := c.MkDir()
-	c.Check(IsExecutable(dir), Equals, false)
+	c.Check(osutil.IsExecutable(dir), Equals, false)
 
 	for _, tc := range []struct {
 		mode os.FileMode
@@ -230,7 +233,7 @@ func (s *StatTestSuite) TestIsExecutable(c *C) {
 
 		err = ioutil.WriteFile(p, []byte(""), tc.mode)
 		c.Assert(err, IsNil)
-		c.Check(IsExecutable(p), Equals, tc.is)
+		c.Check(osutil.IsExecutable(p), Equals, tc.is)
 	}
 }
 
@@ -282,7 +285,7 @@ func (ts *StatTestSuite) TestRegularFileExists(c *C) {
 			}
 		}
 
-		exists, isReg, err := RegularFileExists(fullpath)
+		exists, isReg, err := osutil.RegularFileExists(fullpath)
 		if t.expErr != "" {
 			c.Assert(err, ErrorMatches, t.expErr, comment)
 			continue

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2020 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -41,7 +41,7 @@ func MockTrusted(mockTrusted []asserts.Assertion) (restore func()) {
 	}
 }
 
-func newMemAssertionsDB() (db asserts.RODatabase, commitTo func(*asserts.Batch) error, err error) {
+func newMemAssertionsDB(commitObserve func(verified asserts.Assertion)) (db *asserts.Database, commitTo func(*asserts.Batch) error, err error) {
 	memDB, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
 		Backstore: asserts.NewMemoryBackstore(),
 		Trusted:   trusted,
@@ -51,7 +51,7 @@ func newMemAssertionsDB() (db asserts.RODatabase, commitTo func(*asserts.Batch) 
 	}
 
 	commitTo = func(b *asserts.Batch) error {
-		return b.CommitTo(memDB, nil)
+		return b.CommitToAndObserve(memDB, commitObserve, nil)
 	}
 
 	return memDB, commitTo, nil

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -88,6 +88,9 @@ type Seed interface {
 	// It will panic if called before LoadAssertions.
 	Brand() (*asserts.Account, error)
 
+	// XXX
+	LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error
+
 	// LoadMeta loads the seed and seed's snaps metadata while
 	// verifying the underlying snaps against assertions. It can
 	// return ErrNoMeta if there is no metadata nor snaps in the
@@ -120,7 +123,8 @@ type EssentialMetaLoaderSeed interface {
 	// legitimate only on classic. It is an error to mix it with
 	// LoadMeta.
 	// It will panic if called before LoadAssertions.
-	LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error
+
+	// XXX LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error
 }
 
 // Open returns a Seed implementation for the seed at seedDir.

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -64,7 +64,7 @@ func (s *seed16) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Ba
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
-		db, commitTo, err = newMemAssertionsDB()
+		db, commitTo, err = newMemAssertionsDB(nil)
 		if err != nil {
 			return err
 		}

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -77,7 +77,7 @@ func (s *seed20) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Ba
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
-		db, commitTo, err = newMemAssertionsDB()
+		db, commitTo, err = newMemAssertionsDB(nil)
 		if err != nil {
 			return err
 		}

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -832,6 +832,130 @@ func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
 	}
 }
 
+func (s *seed20Suite) TestReadSystemEssentialAndBetterEarliestTime(c *C) {
+	r := seed.MockTrusted(s.StoreSigning.Trusted)
+	defer r()
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "core18", "")
+	t0 := time.Now().UTC().Truncate(time.Second)
+	s.SetSnapAssertionNow(t0.Add(2 * time.Second))
+	s.makeSnap(c, "required18", "developerid")
+	s.SetSnapAssertionNow(time.Time{})
+
+	snapdSnap := &seed.Snap{
+		Path:          s.expectedPath("snapd"),
+		SideInfo:      &s.AssertedSnapInfo("snapd").SideInfo,
+		EssentialType: snap.TypeSnapd,
+		Essential:     true,
+		Required:      true,
+		Channel:       "latest/stable",
+	}
+	pcKernelSnap := &seed.Snap{
+		Path:          s.expectedPath("pc-kernel"),
+		SideInfo:      &s.AssertedSnapInfo("pc-kernel").SideInfo,
+		EssentialType: snap.TypeKernel,
+		Essential:     true,
+		Required:      true,
+		Channel:       "20",
+	}
+	core20Snap := &seed.Snap{Path: s.expectedPath("core20"),
+		SideInfo:      &s.AssertedSnapInfo("core20").SideInfo,
+		EssentialType: snap.TypeBase,
+		Essential:     true,
+		Required:      true,
+		Channel:       "latest/stable",
+	}
+	pcSnap := &seed.Snap{
+		Path:          s.expectedPath("pc"),
+		SideInfo:      &s.AssertedSnapInfo("pc").SideInfo,
+		EssentialType: snap.TypeGadget,
+		Essential:     true,
+		Required:      true,
+		Channel:       "20",
+	}
+
+	tests := []struct {
+		onlyTypes []snap.Type
+		expected  []*seed.Snap
+	}{
+		{[]snap.Type{snap.TypeSnapd}, []*seed.Snap{snapdSnap}},
+		{[]snap.Type{snap.TypeKernel}, []*seed.Snap{pcKernelSnap}},
+		{[]snap.Type{snap.TypeBase}, []*seed.Snap{core20Snap}},
+		{[]snap.Type{snap.TypeGadget}, []*seed.Snap{pcSnap}},
+		{[]snap.Type{snap.TypeSnapd, snap.TypeKernel, snap.TypeBase}, []*seed.Snap{snapdSnap, pcKernelSnap, core20Snap}},
+		// the order in essentialTypes is not relevant
+		{[]snap.Type{snap.TypeGadget, snap.TypeKernel}, []*seed.Snap{pcKernelSnap, pcSnap}},
+		// degenerate case
+		{[]snap.Type{}, []*seed.Snap(nil)},
+	}
+
+	baseLabel := "20210315"
+
+	testReadSystemEssentialAndBetterEarliestTime := func(sysLabel string, earliestTime, modelTime, improvedTime time.Time) {
+		s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+			"display-name": "my model",
+			"timestamp":    modelTime.Format(time.RFC3339),
+			"architecture": "amd64",
+			"base":         "core20",
+			"snaps": []interface{}{
+				map[string]interface{}{
+					"name":            "pc-kernel",
+					"id":              s.AssertedSnapID("pc-kernel"),
+					"type":            "kernel",
+					"default-channel": "20",
+				},
+				map[string]interface{}{
+					"name":            "pc",
+					"id":              s.AssertedSnapID("pc"),
+					"type":            "gadget",
+					"default-channel": "20",
+				},
+				map[string]interface{}{
+					"name": "core18",
+					"id":   s.AssertedSnapID("core18"),
+					"type": "base",
+				},
+				map[string]interface{}{
+					"name": "required18",
+					"id":   s.AssertedSnapID("required18"),
+				}},
+		}, nil)
+
+		for _, t := range tests {
+			// test short-cut helper as well
+			mod, essSnaps, betterTime, err := seed.ReadSystemEssentialAndBetterEarliestTime(s.SeedDir, sysLabel, t.onlyTypes, earliestTime, s.perfTimings)
+			c.Assert(err, IsNil)
+			c.Check(mod.BrandID(), Equals, "my-brand")
+			c.Check(mod.Model(), Equals, "my-model")
+			c.Check(mod.Timestamp().Equal(modelTime), Equals, true)
+			c.Check(essSnaps, HasLen, len(t.expected))
+			c.Check(essSnaps, DeepEquals, t.expected)
+			c.Check(betterTime.Equal(improvedTime), Equals, true, Commentf("%v expected: %v", betterTime, improvedTime))
+		}
+	}
+
+	revsTime := s.AssertedSnapRevision("required18").Timestamp()
+	t2 := revsTime.Add(1 * time.Second)
+
+	timeCombos := []struct {
+		earliestTime, modelTime, improvedTime time.Time
+	}{
+		{time.Time{}, t0, revsTime},
+		{t2.AddDate(-1, 0, 0), t0, revsTime},
+		{t2.AddDate(-1, 0, 0), t2, t2},
+		{t2.AddDate(0, 1, 0), t2, t2.AddDate(0, 1, 0)},
+	}
+
+	for i, c := range timeCombos {
+		label := fmt.Sprintf("%s%d", baseLabel, i)
+		testReadSystemEssentialAndBetterEarliestTime(label, c.earliestTime, c.modelTime, c.improvedTime)
+	}
+}
+
 func (s *seed20Suite) TestLoadEssentialAndMetaCore20(c *C) {
 	r := seed.MockTrusted(s.StoreSigning.Trusted)
 	defer r()

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -46,6 +46,8 @@ type SeedSnaps struct {
 	snaps map[string]string
 	infos map[string]*snap.Info
 
+	snapAssertNow time.Time
+
 	snapRevs map[string]*asserts.SnapRevision
 }
 
@@ -63,6 +65,17 @@ func (ss *SeedSnaps) AssertedSnapID(snapName string) string {
 	return snaptest.AssertedSnapID(snapName)
 }
 
+func (ss *SeedSnaps) snapAssertionNow() time.Time {
+	if ss.snapAssertNow.IsZero() {
+		return time.Now()
+	}
+	return ss.snapAssertNow
+}
+
+func (ss *SeedSnaps) SetSnapAssertionNow(t time.Time) {
+	ss.snapAssertNow = t
+}
+
 func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string, dbs ...*asserts.Database) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
 	info, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
@@ -76,7 +89,7 @@ func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, r
 		"snap-id":      snapID,
 		"publisher-id": developerID,
 		"snap-name":    snapName,
-		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+		"timestamp":    ss.snapAssertionNow().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
 
@@ -89,7 +102,7 @@ func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, r
 		"snap-id":       snapID,
 		"developer-id":  developerID,
 		"snap-revision": revision.String(),
-		"timestamp":     time.Now().UTC().Format(time.RFC3339),
+		"timestamp":     ss.snapAssertionNow().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -806,7 +806,7 @@ nested_start_core_vm_unit() {
         exit 1
     fi
 
-    local PARAM_DISPLAY PARAM_NETWORK PARAM_MONITOR PARAM_USB PARAM_CD PARAM_RANDOM PARAM_CPU PARAM_TRACE PARAM_LOG PARAM_SERIAL
+    local PARAM_DISPLAY PARAM_NETWORK PARAM_MONITOR PARAM_USB PARAM_CD PARAM_RANDOM PARAM_CPU PARAM_TRACE PARAM_LOG PARAM_SERIAL PARAM_RTC
     PARAM_DISPLAY="-nographic"
     PARAM_NETWORK="-net nic,model=virtio -net user,hostfwd=tcp::$NESTED_SSH_PORT-:22"
     PARAM_MONITOR="-monitor tcp:127.0.0.1:$NESTED_MON_PORT,server,nowait"
@@ -816,6 +816,8 @@ nested_start_core_vm_unit() {
     PARAM_CPU=""
     PARAM_TRACE="-d cpu_reset"
     PARAM_LOG="-D $NESTED_LOGS_DIR/qemu.log"
+    PARAM_RTC="${NESTED_PARAM_RTC:-}"
+
     # Open port 7777 on the host so that failures in the nested VM (e.g. to
     # create users) can be debugged interactively via
     # "telnet localhost 7777". Also keeps the logs
@@ -923,6 +925,7 @@ nested_start_core_vm_unit() {
         ${PARAM_MEM} \
         ${PARAM_TRACE} \
         ${PARAM_LOG} \
+        ${PARAM_RTC} \
         ${PARAM_MACHINE} \
         ${PARAM_DISPLAY} \
         ${PARAM_NETWORK} \

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -499,7 +499,15 @@ nested_create_core_vm() {
 
                 elif nested_is_core_20_system; then
                     snap download --basename=pc-kernel --channel="20/edge" pc-kernel
-                    uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+
+                    # set the unix bump time if the NESTED_* var is set, 
+                    # otherwise leave it empty
+                    local epochBumpTime
+                    epochBumpTime=${NESTED_CORE20_INITRAMFS_EPOCH_TIMESTAMP:-}
+                    if [ -n "$epochBumpTime" ]; then
+                        epochBumpTime="--epoch-bump-time=$epochBumpTime"
+                    fi
+                    uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR" "$epochBumpTime"
                     rm -f "$PWD/pc-kernel.snap"
 
                     # Prepare the pc kernel snap

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -519,10 +519,11 @@ uc20_build_initramfs_kernel_snap() {
             # also copy the time for the clock-epoch to system-data, this is 
             # used by a specific test but doesn't hurt anything to do this for 
             # all tests
-            echo "if test -f /run/mnt/data/system-data/clock-epoch; then rm -r /run/mnt/data/system-data/clock-epoch; fi"
-            echo "if test -d /run/mnt/data/system-data; then cp -a /usr/lib/clock-epoch /run/mnt/data/system-data/clock-epoch; fi"
-            echo "if test -d /run/mnt/data/system-data; then echo \"\$beforeDate\" > /run/mnt/data/system-data/before-snap-bootstrap-date; fi"
-            echo "if test -d /run/mnt/data/system-data; then date --utc '+%s' > /run/mnt/data/system-data/after-snap-bootstrap-date; fi"
+            echo "mode=\$(grep -Eo 'snapd_recovery_mode=([a-z]+)' /proc/cmdline)"
+            echo "mode=\${mode##snapd_recovery_mode=}"
+            echo "stat -c '%Y' /usr/lib/clock-epoch >> /run/mnt/ubuntu-seed/\${mode}-clock-epoch"
+            echo "echo \"\$beforeDate\" > /run/mnt/ubuntu-seed/\${mode}-before-snap-bootstrap-date"
+            echo "date --utc '+%s' > /run/mnt/ubuntu-seed/\${mode}-after-snap-bootstrap-date"
         } >> "$skeletondir/main/usr/lib/the-tool"
 
         if [ "$injectKernelPanic" = "true" ]; then

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -464,15 +464,25 @@ uc20_build_initramfs_kernel_snap() {
     local ORIG_SNAP="$1"
     local TARGET="$2"
 
+    # TODO proper option support here would be nice but bash is hard and this is
+    # easier, and likely we won't need to both inject a panic and set the epoch
+    # bump simultaneously
     local injectKernelPanic=false
-    injectKernelPanicArg=${3:-}
-    if [ "$injectKernelPanicArg" = "--inject-kernel-panic-in-initramfs" ]; then
-        injectKernelPanic=true
-    fi
+    local initramfsEpochBumpTime
+    initramfsEpochBumpTime=$(date '+%s')
+    optArg=${3:-}
+    case "$optArg" in
+        --inject-kernel-panic-in-initramfs)
+            injectKernelPanic=true
+            ;;
+        --epoch-bump-time=*)
+            # this strips the option and just gives us the value
+            initramfsEpochBumpTime="${optArg#--epoch-bump-time=}"
+            ;;
+    esac
     
     # kernel snap is huge, unpacking to current dir
     unsquashfs -d repacked-kernel "$ORIG_SNAP"
-
 
     # repack initrd magic, beware
     # assumptions: initrd is compressed with LZ4, cpio block size 512, microcode
@@ -501,14 +511,23 @@ uc20_build_initramfs_kernel_snap() {
         # modify the-tool to verify that our version is used when booting - this
         # is verified in the tests/core/basic20 spread test
         sed -i -e 's/set -e/set -ex/' "$skeletondir/main/usr/lib/the-tool"
-        echo "" >> "$skeletondir/main/usr/lib/the-tool"
-        echo "if test -d /run/mnt/data/system-data; then touch /run/mnt/data/system-data/the-tool-ran; fi" >> \
-            "$skeletondir/main/usr/lib/the-tool"
+        {
+            echo "" 
+            echo "if test -d /run/mnt/data/system-data; then touch /run/mnt/data/system-data/the-tool-ran; fi" 
+            # also copy the time for the clock-epoch to system-data, this is 
+            # used by a specific test but doesn't hurt anything to do this for 
+            # all tests
+            echo "if test -d /run/mnt/data/system-data; then cp -ar /usr/lib/clock-epoch /run/mnt/data/system-data/clock-epoch; fi"
+            echo "if test -d /run/mnt/data/system-data; then date --utc '+%s' > /run/mnt/data/system-data/after-snap-bootstrap-date; fi"
+        } >> "$skeletondir/main/usr/lib/the-tool"
 
         if [ "$injectKernelPanic" = "true" ]; then
             # add a kernel panic to the end of the-tool execution
             echo "echo 'forcibly panicing'; echo c > /proc/sysrq-trigger" >> "$skeletondir/main/usr/lib/the-tool"
         fi
+
+        # bump the epoch time
+        touch -t "$(date --utc "--date=@$initramfsEpochBumpTime" '+%Y%m%d%H%M')" "$skeletondir/main/usr/lib/clock-epoch"
 
         # copy any extra files to the same location inside the initrd
         if [ -d ../extra-initrd/ ]; then

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -511,13 +511,16 @@ uc20_build_initramfs_kernel_snap() {
         # modify the-tool to verify that our version is used when booting - this
         # is verified in the tests/core/basic20 spread test
         sed -i -e 's/set -e/set -ex/' "$skeletondir/main/usr/lib/the-tool"
+        # also save the time before snap-bootstrap runs
+        sed -i -e "s@/usr/lib/snapd/snap-bootstrap@beforeDate=\$(date --utc \'+%s\'); /usr/lib/snapd/snap-bootstrap@"  "$skeletondir/main/usr/lib/the-tool"
         {
             echo "" 
             echo "if test -d /run/mnt/data/system-data; then touch /run/mnt/data/system-data/the-tool-ran; fi" 
             # also copy the time for the clock-epoch to system-data, this is 
             # used by a specific test but doesn't hurt anything to do this for 
             # all tests
-            echo "if test -d /run/mnt/data/system-data; then cp -ar /usr/lib/clock-epoch /run/mnt/data/system-data/clock-epoch; fi"
+            echo "if test -d /run/mnt/data/system-data; then cp -a /usr/lib/clock-epoch /run/mnt/data/system-data/clock-epoch; fi"
+            echo "if test -d /run/mnt/data/system-data; then echo \"\$beforeDate\" > /run/mnt/data/system-data/before-snap-bootstrap-date; fi"
             echo "if test -d /run/mnt/data/system-data; then date --utc '+%s' > /run/mnt/data/system-data/after-snap-bootstrap-date; fi"
         } >> "$skeletondir/main/usr/lib/the-tool"
 
@@ -526,7 +529,8 @@ uc20_build_initramfs_kernel_snap() {
             echo "echo 'forcibly panicing'; echo c > /proc/sysrq-trigger" >> "$skeletondir/main/usr/lib/the-tool"
         fi
 
-        # bump the epoch time
+        # bump the epoch time file timestamp, converting unix timestamp to 
+        # touch's date format
         touch -t "$(date --utc "--date=@$initramfsEpochBumpTime" '+%Y%m%d%H%M')" "$skeletondir/main/usr/lib/clock-epoch"
 
         # copy any extra files to the same location inside the initrd

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -519,6 +519,7 @@ uc20_build_initramfs_kernel_snap() {
             # also copy the time for the clock-epoch to system-data, this is 
             # used by a specific test but doesn't hurt anything to do this for 
             # all tests
+            echo "if test -f /run/mnt/data/system-data/clock-epoch; then rm -r /run/mnt/data/system-data/clock-epoch; fi"
             echo "if test -d /run/mnt/data/system-data; then cp -a /usr/lib/clock-epoch /run/mnt/data/system-data/clock-epoch; fi"
             echo "if test -d /run/mnt/data/system-data; then echo \"\$beforeDate\" > /run/mnt/data/system-data/before-snap-bootstrap-date; fi"
             echo "if test -d /run/mnt/data/system-data; then date --utc '+%s' > /run/mnt/data/system-data/after-snap-bootstrap-date; fi"

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -1,0 +1,36 @@
+summary: Test that time moves forward when the RTC is broken/unavailable in UC20
+
+systems: [ubuntu-20.04-64]
+
+environment:
+  NESTED_IMAGE_ID: core20-initramfs-time-moves-forward
+  NESTED_BUILD_SNAPD_FROM_CURRENT: true
+  NESTED_USE_CLOUD_INIT: true
+
+  # disable the real time clock and effectively break it so it returns unix
+  # epoch to simulate devices like the rpi which do not have RTC
+  NESTED_PARAM_RTC: "-rtc base=1970-01-01"
+
+  # this is the unix time timestamp we want the initramfs to use, 1 here is just
+  # 1 second after the unix epoch
+  NESTED_CORE20_INITRAMFS_EPOCH_TIMESTAMP: 1
+
+prepare: |
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  "$TESTSTOOLS"/nested-state build-image core
+  "$TESTSTOOLS"/nested-state create-vm core
+
+execute: |
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  echo "Verify that the clock-epoch time is the unix epoch"
+  test "$(nested_exec "stat -c %Y /run/mnt/data/system-data/clock-epoch")" = 180000
+
+  echo "Verify that the timestamp from after snap-bootstrap ran is greater than the time from the model assertion"
+  # this is the timestamp from the model assertion, minus 1 second
+  # note that if the model assertion ever gets resigned, the timestamp should 
+  # not move backward so this will still be true / valid
+  test "$(nested_exec "cat /run/mnt/data/system-data/after-snap-bootstrap-date")" -ge 1606490999

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -15,6 +15,12 @@ environment:
   # 1 second after the unix epoch
   NESTED_CORE20_INITRAMFS_EPOCH_TIMESTAMP: 1
 
+  # this is one second before the model assertion timestamp, this should be
+  # bumped if the model assertion is ever resigned with a newer timestamp in it,
+  # but doesn't strictly need to be updated every time as long as the timestamp
+  # increases monotonically the test is still valid
+  MODEL_ASSERTION_SIGN_TIME: 1606490999
+
 prepare: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
@@ -26,11 +32,8 @@ execute: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
-  echo "Verify that the clock-epoch time is the unix epoch"
-  test "$(nested_exec "stat -c %Y /run/mnt/data/system-data/clock-epoch")" = 180000
+  echo "Verify that the current time in the VM is newer than the model assertion sign time"
+  test "$(nested_exec date --utc '+%s')" -ge "$MODEL_ASSERTION_SIGN_TIME"
 
   echo "Verify that the timestamp from after snap-bootstrap ran is greater than the time from the model assertion"
-  # this is the timestamp from the model assertion, minus 1 second
-  # note that if the model assertion ever gets resigned, the timestamp should 
-  # not move backward so this will still be true / valid
-  test "$(nested_exec "cat /run/mnt/data/system-data/after-snap-bootstrap-date")" -ge 1606490999
+  test "$(nested_exec "cat /run/mnt/ubuntu-seed/install-after-snap-bootstrap-date")" -ge "$MODEL_ASSERTION_SIGN_TIME"

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -9,7 +9,7 @@ environment:
 
   # disable the real time clock and effectively break it so it returns unix
   # epoch to simulate devices like the rpi which do not have RTC
-  NESTED_PARAM_RTC: "-rtc base=1970-01-01"
+  NESTED_PARAM_RTC: "-rtc base=1970-01-01,clock=vm"
 
   # this is the unix time timestamp we want the initramfs to use, 1 here is just
   # 1 second after the unix epoch


### PR DESCRIPTION
This is PR https://github.com/snapcore/snapd/pull/10051 and it's prerequisites for 2.49. It also includes:

https://github.com/snapcore/snapd/pull/9866
https://github.com/snapcore/snapd/pull/9879
https://github.com/snapcore/snapd/pull/9973
https://github.com/snapcore/snapd/pull/9931
https://github.com/snapcore/snapd/pull/9887
https://github.com/snapcore/snapd/pull/10004
https://github.com/snapcore/snapd/pull/10005

So that things can be clearly cherry-picked.