### PR TITLE
o/configstate/configcore: simple refactors in preparation for new function

### DIFF
--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -193,8 +193,7 @@ func (s *applyCfgSuite) TestEmptyRootDir(c *C) {
 }
 
 func (s *applyCfgSuite) TestSmoke(c *C) {
-	conf := &mockConf{}
-	c.Assert(configcore.FilesystemOnlyApply(s.tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(s.tmpDir, map[string]interface{}{}, nil), IsNil)
 }
 
 func (s *applyCfgSuite) TestPlainCoreConfigGetErrorIfNotCore(c *C) {

--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -46,7 +46,7 @@ type flags struct {
 	// set before even seeding is finished).
 	// If set the function should copy such options from values
 	// to early.
-	earlyConfigFilter func(values, early map[string]interface{})
+	earlyConfigFilter filterFunc
 }
 
 type fsOnlyHandler struct {

--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -95,7 +95,7 @@ func init() {
 	addFSOnlyHandler(validateTimezoneSettings, handleTimezoneConfiguration, coreOnly)
 
 	sysconfig.ApplyFilesystemOnlyDefaultsImpl = func(rootDir string, defaults map[string]interface{}, options *sysconfig.FilesystemOnlyApplyOptions) error {
-		return filesystemOnlyApply(rootDir, plainCoreConfig(defaults), options)
+		return filesystemOnlyApply(rootDir, defaults, options)
 	}
 }
 
@@ -141,12 +141,20 @@ func (h *fsOnlyHandler) handle(cfg config.ConfGetter, opts *fsOnlyContext) error
 // early during boot, before all the configuration is applied as part of
 // normal execution of configure hook.
 // Exposed for use via sysconfig.ApplyFilesystemOnlyDefaults.
-func filesystemOnlyApply(rootDir string, cfg config.ConfGetter, opts *sysconfig.FilesystemOnlyApplyOptions) error {
+func filesystemOnlyApply(rootDir string, values map[string]interface{}, opts *sysconfig.FilesystemOnlyApplyOptions) error {
 	if rootDir == "" {
 		return fmt.Errorf("internal error: root directory for configcore.FilesystemOnlyApply() not set")
 	}
 
-	ctx := &fsOnlyContext{RootDir: rootDir}
+	if opts == nil {
+		opts = &sysconfig.FilesystemOnlyApplyOptions{}
+	}
+
+	cfg := plainCoreConfig(values)
+
+	ctx := &fsOnlyContext{
+		RootDir: rootDir,
+	}
 	for _, h := range handlers {
 		if h.needsState() {
 			continue

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -139,19 +139,9 @@ func applyHandlers(cfg config.Conf, handlers []configHandler) error {
 }
 
 func Early(cfg config.Conf, values map[string]interface{}) error {
-	early := make(map[string]interface{})
-	// keep track of which handlers have early config to process
-	var relevant []configHandler
-	for _, h := range handlers {
-		flt := h.flags().earlyConfigFilter
-		if flt != nil {
-			cur := len(early)
-			flt(values, early)
-			if len(early) > cur {
-				relevant = append(relevant, h)
-			}
-		}
-	}
+	early, relevant := applyFilters(func(f flags) filterFunc {
+		return f.earlyConfigFilter
+	}, values)
 
 	if err := config.Patch(cfg, "core", early); err != nil {
 		return err


### PR DESCRIPTION
See individual commit messages for full details, but these changes are broken out from https://github.com/snapcore/snapd/pull/9965, specifically to make it easier to review the refactors present in that PR.