### PR TITLE
overlord/snapstate, overlord/ifacestate: move late security profile removal to ifacestate

### DIFF
--- a/interfaces/ifacetest/backend.go
+++ b/interfaces/ifacetest/backend.go
@@ -111,3 +111,21 @@ func (b *TestSecurityBackendSetupMany) SetupMany(snaps []*snap.Info, confinement
 	}
 	return b.SetupManyCallback(snaps, confinement, repo, tm)
 }
+
+// TestSecurityBackendDiscardingLate implements RemoveLate on top of TestSecurityBackend.
+type TestSecurityBackendDiscardingLate struct {
+	TestSecurityBackend
+
+	RemoveLateCalledFor [][]string
+	RemoveLateCallback  func(snapName string, rev snap.Revision, typ snap.Type) error
+}
+
+func (b *TestSecurityBackendDiscardingLate) RemoveLate(snapName string, rev snap.Revision, typ snap.Type) error {
+	b.RemoveLateCalledFor = append(b.RemoveLateCalledFor, []string{
+		snapName, rev.String(), string(typ),
+	})
+	if b.RemoveLateCallback == nil {
+		return nil
+	}
+	return b.RemoveLateCallback(snapName, rev, typ)
+}

--- a/interfaces/ifacetest/backend.go
+++ b/interfaces/ifacetest/backend.go
@@ -87,7 +87,7 @@ func (b *TestSecurityBackend) SandboxFeatures() []string {
 	return b.SandboxFeaturesCallback()
 }
 
-// TestSecurityBackendSetupMany is a security backend that implements SetupMany on top of TestSecurityBackend.s
+// TestSecurityBackendSetupMany is a security backend that implements SetupMany on top of TestSecurityBackend.
 type TestSecurityBackendSetupMany struct {
 	TestSecurityBackend
 

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -1244,3 +1244,16 @@ func findConnsForHotplugKey(conns map[string]*connState, ifaceName string, hotpl
 	sort.Strings(connsForDevice)
 	return connsForDevice
 }
+
+func (m *InterfaceManager) discardSecurityProfilesLate(name string, rev snap.Revision, typ snap.Type) error {
+	for _, backend := range m.repo.Backends() {
+		lateDiscardBackend, ok := backend.(interfaces.SecurityBackendDiscardingLate)
+		if !ok {
+			continue
+		}
+		if err := lateDiscardBackend.RemoveLate(name, rev, typ); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -727,3 +727,45 @@ func (s *helpersSuite) TestAddHotplugSlotValidationErrors(c *C) {
 	// sanitization failure
 	c.Assert(ifacestate.AddHotplugSlot(s.st, repo, stateSlots, iface, slot), ErrorMatches, `cannot sanitize hotplug slot \"slot\" for interface test: fail`)
 }
+
+func (s *helpersSuite) TestDiscardLateBackendViaSnapstate(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+
+	// security profiles do not need regeneration when crating the manager
+	restore := ifacestate.MockProfilesNeedRegeneration(func() bool { return false })
+	defer restore()
+
+	backend := &ifacetest.TestSecurityBackendDiscardingLate{
+		RemoveLateCallback: func(snapName string, rev snap.Revision, typ snap.Type) error {
+			if snapName == "this-fails" {
+				return fmt.Errorf("remove late fails")
+			}
+			return nil
+		},
+	}
+	restore = ifacestate.MockSecurityBackends([]interfaces.SecurityBackend{backend})
+	defer restore()
+
+	// mock overlord
+	ovld := overlord.Mock()
+	st := ovld.State()
+	// manager
+	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	c.Assert(err, IsNil)
+	// installs the ifacemgr helper
+	err = mgr.StartUp()
+	c.Assert(err, IsNil)
+
+	// call via the snapstate hook
+	err = snapstate.SecurityProfilesRemoveLateHook("snapd", snap.R(1234), snap.TypeSnapd)
+	c.Assert(err, IsNil)
+	err = snapstate.SecurityProfilesRemoveLateHook("this-fails", snap.R(12), snap.TypeApp)
+	c.Assert(err, ErrorMatches, "remove late fails")
+	c.Check(backend.RemoveLateCalledFor, DeepEquals, [][]string{
+		{"snapd", "1234", "snapd"},
+		{"this-fails", "12", "app"},
+	})
+}

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -760,9 +760,9 @@ func (s *helpersSuite) TestDiscardLateBackendViaSnapstate(c *C) {
 	c.Assert(err, IsNil)
 
 	// call via the snapstate hook
-	err = snapstate.SecurityProfilesRemoveLateHook("snapd", snap.R(1234), snap.TypeSnapd)
+	err = snapstate.SecurityProfilesRemoveLate("snapd", snap.R(1234), snap.TypeSnapd)
 	c.Assert(err, IsNil)
-	err = snapstate.SecurityProfilesRemoveLateHook("this-fails", snap.R(12), snap.TypeApp)
+	err = snapstate.SecurityProfilesRemoveLate("this-fails", snap.R(12), snap.TypeApp)
 	c.Assert(err, ErrorMatches, "remove late fails")
 	c.Check(backend.RemoveLateCalledFor, DeepEquals, [][]string{
 		{"snapd", "1234", "snapd"},

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -177,9 +177,8 @@ func (m *InterfaceManager) StartUp() error {
 
 	ifacerepo.Replace(s, m.repo)
 
-	// XXX: replaces current callback with one from the current ifacemgr
-	// instance
-	snapstate.SecurityProfilesRemoveLateHook = m.discardSecurityProfilesLate
+	// wire late profile removal support into snapstate
+	snapstate.SecurityProfilesRemoveLate = m.discardSecurityProfilesLate
 
 	perfTimings.Save(s)
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snapdenv"
@@ -175,6 +176,10 @@ func (m *InterfaceManager) StartUp() error {
 	}
 
 	ifacerepo.Replace(s, m.repo)
+
+	// XXX: replaces current callback with one from the current ifacemgr
+	// instance
+	snapstate.SecurityProfilesRemoveLateHook = m.discardSecurityProfilesLate
 
 	perfTimings.Save(s)
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -304,9 +304,9 @@ func (m *autoRefresh) EnsureRefreshHoldAtLeast(d time.Duration) error {
 }
 
 func MockSecurityProfilesDiscardLate(fn func(snapName string, rev snap.Revision, typ snap.Type) error) (restore func()) {
-	old := SecurityProfilesRemoveLateHook
-	SecurityProfilesRemoveLateHook = fn
+	old := SecurityProfilesRemoveLate
+	SecurityProfilesRemoveLate = fn
 	return func() {
-		SecurityProfilesRemoveLateHook = old
+		SecurityProfilesRemoveLate = old
 	}
 }

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -302,3 +302,11 @@ func MockGenericRefreshCheck(fn func(info *snap.Info, canAppRunDuringRefresh fun
 func (m *autoRefresh) EnsureRefreshHoldAtLeast(d time.Duration) error {
 	return m.ensureRefreshHoldAtLeast(d)
 }
+
+func MockSecurityProfilesDiscardLate(fn func(snapName string, rev snap.Revision, typ snap.Type) error) (restore func()) {
+	old := SecurityProfilesRemoveLateHook
+	SecurityProfilesRemoveLateHook = fn
+	return func() {
+		SecurityProfilesRemoveLateHook = old
+	}
+}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -52,7 +52,7 @@ import (
 	"github.com/snapcore/snapd/timings"
 )
 
-var SecurityProfilesRemoveLateHook = func(snapName string, rev snap.Revision, typ snap.Type) error {
+var SecurityProfilesRemoveLate = func(snapName string, rev snap.Revision, typ snap.Type) error {
 	panic("internal error: snapstate.SecurityProfilesRemoveLate is unset")
 }
 
@@ -2280,7 +2280,7 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err = config.DiscardRevisionConfig(st, snapsup.InstanceName(), snapsup.Revision()); err != nil {
 		return err
 	}
-	if err = SecurityProfilesRemoveLateHook(snapsup.InstanceName(), snapsup.Revision(), snapsup.Type); err != nil {
+	if err = SecurityProfilesRemoveLate(snapsup.InstanceName(), snapsup.Revision(), snapsup.Type); err != nil {
 		return err
 	}
 	Set(st, snapsup.InstanceName(), snapst)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -37,13 +37,11 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/settings"
-	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
@@ -53,6 +51,10 @@ import (
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timings"
 )
+
+var SecurityProfilesRemoveLateHook = func(snapName string, rev snap.Revision, typ snap.Type) error {
+	panic("internal error: snapstate.SecurityProfilesRemoveLate is unset")
+}
 
 // TaskSnapSetup returns the SnapSetup with task params hold by or referred to by the task.
 func TaskSnapSetup(t *state.Task) (*SnapSetup, error) {
@@ -2193,20 +2195,6 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) discardSecurityProfilesLate(st *state.State, name string, rev snap.Revision, typ snap.Type) error {
-	repo := ifacerepo.Get(st)
-	for _, backend := range repo.Backends() {
-		lateDiscardBackend, ok := backend.(interfaces.SecurityBackendDiscardingLate)
-		if !ok {
-			continue
-		}
-		if err := lateDiscardBackend.RemoveLate(name, rev, typ); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
@@ -2292,7 +2280,7 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err = config.DiscardRevisionConfig(st, snapsup.InstanceName(), snapsup.Revision()); err != nil {
 		return err
 	}
-	if err = m.discardSecurityProfilesLate(st, snapsup.InstanceName(), snapsup.Revision(), snapsup.Type); err != nil {
+	if err = SecurityProfilesRemoveLateHook(snapsup.InstanceName(), snapsup.Revision(), snapsup.Type); err != nil {
 		return err
 	}
 	Set(st, snapsup.InstanceName(), snapst)

--- a/overlord/snapstate/handlers_prepare_test.go
+++ b/overlord/snapstate/handlers_prepare_test.go
@@ -76,6 +76,11 @@ func (s *baseHandlerSuite) setup(c *C, b state.Backend) {
 
 	restoreCheckFreeSpace := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error { return nil })
 	s.AddCleanup(restoreCheckFreeSpace)
+
+	restoreSecurityProfilesDiscardLate := snapstate.MockSecurityProfilesDiscardLate(func(snapName string, rev snap.Revision, typ snap.Type) error {
+		return nil
+	})
+	s.AddCleanup(restoreSecurityProfilesDiscardLate)
 }
 
 func (s *baseHandlerSuite) SetUpTest(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -221,6 +221,10 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil
 	}
+
+	s.AddCleanup(snapstate.MockSecurityProfilesDiscardLate(func(snapName string, rev snap.Revision, typ snap.Type) error {
+		return nil
+	}))
 }
 
 func (s *snapmgrTestSuite) TearDownTest(c *C) {


### PR DESCRIPTION
Followup to #10081. The branch moves the security profile removal to ifacestate.