### PR TITLE
o/configstate/configcore/picfg.go: add hdmi_cvt support

### DIFF
--- a/overlord/configstate/configcore/picfg.go
+++ b/overlord/configstate/configcore/picfg.go
@@ -44,6 +44,7 @@ var piConfigKeys = map[string]bool{
 	"overscan_bottom":          true,
 	"overscan_scale":           true,
 	"display_rotate":           true,
+	"hdmi_cvt":                 true,
 	"hdmi_group":               true,
 	"hdmi_mode":                true,
 	"hdmi_timings":             true,


### PR DESCRIPTION
This is used in conjunctino with hdmi_mode, hdmi_group, and hdmi_drive in order
to use a custom specified HDMI mode. See
https://www.raspberrypi.org/documentation/configuration/config-txt/video.md
for full documentation.

See also https://forum.snapcraft.io/t/system-boot-config-txt-from-rpi-3-on-ubuntu-core-18-gets-overwritten/23620
where this was first requested.