### PR TITLE
overlord/snapstate: skip catalog refresh when snappy testing is enabled

### DIFF
--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -135,7 +135,9 @@ var newCmdDB = advisor.Create
 var errSkipCatalogRefreshWhenTesting = errors.New("skipping when testing is enabled")
 
 func refreshCatalogs(st *state.State, theStore StoreService) error {
-	if snapdenv.Testing() {
+	if snapdenv.Testing() && !osutil.GetenvBool("SNAPD_CATALOG_REFRESH") {
+		// with snapd testing enabled, SNAPD_CATALOG_REFRESH is gating
+		// the catalog refresh
 		return errSkipCatalogRefreshWhenTesting
 	}
 

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/storetest"
 	"github.com/snapcore/snapd/testutil"
@@ -249,4 +250,27 @@ func (s *catalogRefreshTestSuite) TestCatalogRefreshUC20InstallMode(c *C) {
 	c.Check(osutil.FileExists(dirs.SnapSectionsFile), Equals, false)
 	c.Check(osutil.FileExists(dirs.SnapNamesFile), Equals, false)
 	c.Check(osutil.FileExists(dirs.SnapCommandsDB), Equals, false)
+}
+
+func (s *catalogRefreshTestSuite) TestCatalogRefreshSkipWhenTesting(c *C) {
+	restore := snapdenv.MockTesting(true)
+	defer restore()
+
+	// start with no catalog
+	c.Check(dirs.SnapSectionsFile, testutil.FileAbsent)
+	c.Check(dirs.SnapNamesFile, testutil.FileAbsent)
+	c.Check(dirs.SnapCommandsDB, testutil.FileAbsent)
+
+	cr7 := snapstate.NewCatalogRefresh(s.state)
+	// next is initially zero
+	c.Check(snapstate.NextCatalogRefresh(cr7).IsZero(), Equals, true)
+
+	err := cr7.Ensure()
+	c.Check(err, IsNil)
+
+	c.Check(s.store.ops, HasLen, 0)
+
+	c.Check(dirs.SnapSectionsFile, testutil.FileAbsent)
+	c.Check(dirs.SnapNamesFile, testutil.FileAbsent)
+	c.Check(dirs.SnapCommandsDB, testutil.FileAbsent)
 }

--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -5,8 +5,12 @@ systems: [ubuntu-18.04-64, ubuntu-2*-64]
 
 prepare: |
     cp /etc/systemd/system/snapd.service.d/local.conf /etc/systemd/system/snapd.service.d/local.conf.bak
-    # disable testing so that catalog refresh requests are sent out
-    sed 's/SNAPPY_TESTING=1/SNAPPY_TESTING=0/g' -i /etc/systemd/system/snapd.service.d/local.conf
+    # enable catalog refresh requests
+    cat <<EOF >> /etc/systemd/system/snapd.service.d/local.conf
+    # added by apt-hooks test
+    [Service]
+    Environment=SNAPD_CATALOG_REFRESH=1
+    EOF
     systemctl daemon-reload
     systemctl restart snapd.socket
 

--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -3,6 +3,18 @@ summary: Ensure apt hooks work
 # apt hook only available on 18.04+ and aws-cli only for amd64
 systems: [ubuntu-18.04-64, ubuntu-2*-64]
 
+prepare: |
+    cp /etc/systemd/system/snapd.service.d/local.conf /etc/systemd/system/snapd.service.d/local.conf.bak
+    # disable testing so that catalog refresh requests are sent out
+    sed 's/SNAPPY_TESTING=1/SNAPPY_TESTING=0/g' -i /etc/systemd/system/snapd.service.d/local.conf
+    systemctl daemon-reload
+    systemctl restart snapd.socket
+
+restore: |
+    mv /etc/systemd/system/snapd.service.d/local.conf.bak /etc/systemd/system/snapd.service.d/local.conf
+    systemctl daemon-reload
+    systemctl restart snapd.socket
+
 debug: |
     ls -lh /var/cache/snapd
     # low tech dump of db

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -12,11 +12,19 @@ prepare: |
     if ! os.query is-core16 && [ -e /usr/lib/command-not-found ]; then
         mv /usr/lib/command-not-found /usr/lib/command-not-found.orig
     fi
+    cp /etc/systemd/system/snapd.service.d/local.conf /etc/systemd/system/snapd.service.d/local.conf.bak
+    # disable testing so that catalog refresh requests are sent out
+    sed 's/SNAPPY_TESTING=1/SNAPPY_TESTING=0/g' -i /etc/systemd/system/snapd.service.d/local.conf
+    systemctl daemon-reload
+    systemctl restart snapd.socket
 
 restore: |
     if [ -e /usr/lib/command-not-found.orig ]; then
         mv /usr/lib/command-not-found.orig /usr/lib/command-not-found
     fi
+    mv /etc/systemd/system/snapd.service.d/local.conf.bak /etc/systemd/system/snapd.service.d/local.conf
+    systemctl daemon-reload
+    systemctl restart snapd.socket
 
 execute: |
     echo "wait for snapd to pull in the commands data"

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -13,8 +13,12 @@ prepare: |
         mv /usr/lib/command-not-found /usr/lib/command-not-found.orig
     fi
     cp /etc/systemd/system/snapd.service.d/local.conf /etc/systemd/system/snapd.service.d/local.conf.bak
-    # disable testing so that catalog refresh requests are sent out
-    sed 's/SNAPPY_TESTING=1/SNAPPY_TESTING=0/g' -i /etc/systemd/system/snapd.service.d/local.conf
+    # enable catalog refresh requests
+    cat <<EOF >> /etc/systemd/system/snapd.service.d/local.conf
+    # added by snap-advise-command test
+    [Service]
+    Environment=SNAPD_CATALOG_REFRESH=1
+    EOF
     systemctl daemon-reload
     systemctl restart snapd.socket
 


### PR DESCRIPTION
The branch implements the idea from @anonymouse64 about enabling catalog refresh selectively in specific tests that exercise the functionality, but leave it disabled for the others so that we do not hit the store ratelimiting.

Hopefully, we should see fewer failures in tests/main/apt-hooks and tests/main/snap-advise.