### PR TITLE
tests: add simple sanity check for systemctl show --property=UnitFileState for unknown service

### DIFF
--- a/tests/main/snap-services/task.yaml
+++ b/tests/main/snap-services/task.yaml
@@ -10,6 +10,17 @@ restore: |
     snap unset system experimental.user-daemons
 
 execute: |
+    # sanity check of systemctl behavior for non-existing services;
+    # it is expected that the returned UnitFileState is empty.
+    systemctl show --property=Id foo.service | MATCH "foo.service"
+    systemctl show --property=ActiveState foo.service | MATCH "inactive"
+    UNIT_FILE_STATE=$(systemctl show --property=UnitFileState foo.service)
+    if [[ "$UNIT_FILE_STATE" != "UnitFileState=" ]]; then
+        echo "unexpected value of UnitFileState for non-existing service: $UNIT_FILE_STATE"
+        systemctl --version
+        exit 1
+    fi
+
     "$TESTSTOOLS"/snaps-state install-local test-snapd-service
     "$TESTSTOOLS"/snaps-state install-local socket-activation
     "$TESTSTOOLS"/snaps-state install-local test-snapd-timer-service


### PR DESCRIPTION
Add simple sanity check for systemctl show --property=UnitFileState output for non-existing service to catch any potential change in systemd behavior.

Related to #10083 