### PR TITLE
tests: add spread test for snap validate against store assertions

### DIFF
--- a/tests/main/snap-validate-basic/task.yaml
+++ b/tests/main/snap-validate-basic/task.yaml
@@ -1,6 +1,4 @@
-summary: Ensure `snap validate` commands work.
-
-# TODO: add tests using store when snapcraft is ready.
+summary: Ensure `snap validate` commands work with local assertions.
 
 # This test uses a local validation set assertion (vs1.json) signed upfront
 # with my (stolowski) private store key (account-id: xSfWKGdLoQBoQx88vIM1MpbFNMq53t1f,

--- a/tests/main/snap-validate-with-store/task.yaml
+++ b/tests/main/snap-validate-with-store/task.yaml
@@ -1,0 +1,58 @@
+summary: |
+  Ensure `snap validate --monitor` works with validation-sets from the store.
+
+# This test uses validation set assertions from the store uploaded upfront
+# with my (stolowski) private store key (account-id: xSfWKGdLoQBoQx88vIM1MpbFNMq53t1f,
+# public-key-sha3: o_x83A3wpIvJznIHBJIK7jRmRZKLlqx5jOr30HUsloFfBseXNF0ztoj18EvNualy);
+# the input assertion provided with the test is testset1-seq1.yaml and testset1-seq2.yaml;
+# they are included for reference and in case this needs to be recreated with another
+# developer account, but otherwise are not used in the test.
+#
+# If this needs to be redone with another developer account, the steps are:
+# 1. update account-id in the testset1-*.yaml files for the developer to use.
+# 2. upload validation-set assertions to the store (repeat for sequence 1 and sequence 2,
+#    paste respective testseq1-seqN.yaml file when snapcraft opens up the editor):
+#    snapcraft edit-validation-sets <account-id> testset1 1
+#    snapcraft edit-validation-sets <account-id> testset1 2
+# 3. change account-ids in the test with the desired developer key.
+
+environment:
+  ACCOUNT_ID: xSfWKGdLoQBoQx88vIM1MpbFNMq53t1f
+
+execute: |
+  # sanity
+  snap validate 2>&1 | MATCH "No validations are available"
+
+  echo "Setting validation set in monitor mode (pinned at sequence 1)"
+  snap validate --monitor "$ACCOUNT_ID"/testset1=1
+  snap validate | MATCH "^$ACCOUNT_ID/testset1=1 +monitor +1 +invalid"
+
+  snap known validation-set | MATCH "name: testset1"
+
+  echo "Installing the required snap satisfies validation-set assertion"
+  snap install hello-world
+  snap validate | MATCH "^$ACCOUNT_ID/testset1=1 +monitor +1 +valid"
+
+  echo "But installing a snap with presence=invalid makes it invalid again"
+  snap install test-snapd-base-bare
+  snap validate | MATCH "^$ACCOUNT_ID/testset1=1 +monitor +1 +invalid"
+
+  echo "After removing both snaps it is still invalid"
+  snap remove --purge hello-world
+  snap remove --purge test-snapd-base-bare
+  snap validate | MATCH "^$ACCOUNT_ID/testset1=1 +monitor +1 +invalid"
+
+  echo "Setting monitor mode, unpinned updates it to sequence 2"
+  snap validate --monitor "$ACCOUNT_ID"/testset1
+  snap validate | MATCH "^$ACCOUNT_ID/testset1 +monitor +2 +invalid"
+
+  echo "And it's valid after installing the required snap"
+  snap install hello-world
+  snap validate | MATCH "^$ACCOUNT_ID/testset1 +monitor +2 +valid"
+  # test-snapd-base-bare is now optional in sequence 2.
+  snap install test-snapd-base-bare
+  snap validate | MATCH "^$ACCOUNT_ID/testset1 +monitor +2 +valid"
+
+  snap validate --forget "$ACCOUNT_ID"/testset1
+  snap validate 2>&1 | MATCH "No validations are available"
+

--- a/tests/main/snap-validate-with-store/testset1-seq1.yaml
+++ b/tests/main/snap-validate-with-store/testset1-seq1.yaml
@@ -1,0 +1,13 @@
+account-id: xSfWKGdLoQBoQx88vIM1MpbFNMq53t1f
+name: testset1
+sequence: 1
+snaps:
+   - name: hello-world
+     id: buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ
+     presence: required
+   - name: test-snapd-base-bare
+     id: oXC9AkhtCxhlY80KZA3peZzWbnO4xPOT
+     presence: invalid
+   - name: bare
+     id: EISPgh06mRh1vordZY9OZ34QHdd7OrdR
+     presence: optional

--- a/tests/main/snap-validate-with-store/testset1-seq2.yaml
+++ b/tests/main/snap-validate-with-store/testset1-seq2.yaml
@@ -1,0 +1,13 @@
+account-id: xSfWKGdLoQBoQx88vIM1MpbFNMq53t1f
+name: testset1
+sequence: 2
+snaps:
+   - name: hello-world
+     id: buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ
+     presence: required
+   - name: test-snapd-base-bare
+     id: oXC9AkhtCxhlY80KZA3peZzWbnO4xPOT
+     presence: optional
+   - name: bare
+     id: EISPgh06mRh1vordZY9OZ34QHdd7OrdR
+     presence: optional


### PR DESCRIPTION
Spread test for validation sets assertion fetched from the store. It's separate from existing snap-validate-basic test for clarity and also to check that prerequisite developer assertion is fetched automatically.

Assertions were uploaded to the store with snapcraft from a private channel, I've included instruction in the test comments in case we want/need to recreate it with another dev account.