### PR TITLE
daemon: introduce apiBaseSuite.(json|sync|async|error)Req  (and some apiBaseSuite cosmetics)

### DIFF
--- a/daemon/api_aliases_test.go
+++ b/daemon/api_aliases_test.go
@@ -180,8 +180,7 @@ func (s *aliasesSuite) TestAliasErrors(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/aliases", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.req(c, req, nil).(*daemon.Resp)
-		c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+		rsp := s.errorReq(c, req, nil)
 		c.Check(rsp.Status, check.Equals, 400)
 		c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, scen.err)
 	}
@@ -549,8 +548,7 @@ func (s *aliasesSuite) TestAliases(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/aliases", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
+	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.DeepEquals, map[string]map[string]daemon.AliasStatus{
 		"alias-snap1": {

--- a/daemon/api_asserts_test.go
+++ b/daemon/api_asserts_test.go
@@ -72,9 +72,8 @@ func (s *assertsSuite) userAuth(req *http.Request) {
 func (s *assertsSuite) TestGetAsserts(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/assertions", nil)
 	c.Assert(err, check.IsNil)
-	resp := s.req(c, req, nil).(*daemon.Resp)
+	resp := s.syncReq(c, req, nil)
 	c.Check(resp.Status, check.Equals, 200)
-	c.Check(resp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(resp.Result, check.DeepEquals, map[string][]string{"types": asserts.TypeNames()})
 }
 
@@ -97,9 +96,8 @@ func (s *assertsSuite) TestAssertOK(c *check.C) {
 	// Execute
 	req, err := http.NewRequest("POST", "/v2/assertions", buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 	// Verify (external)
-	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Status, check.Equals, 200)
 	// Verify (internal)
 	st.Lock()
@@ -124,9 +122,8 @@ func (s *assertsSuite) TestAssertStreamOK(c *check.C) {
 	// Execute
 	req, err := http.NewRequest("POST", "/v2/assertions", buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 	// Verify (external)
-	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Status, check.Equals, 200)
 	// Verify (internal)
 	st.Lock()

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -254,7 +254,7 @@ func (s *apiBaseSuite) mockModel(c *check.C, st *state.State, model *asserts.Mod
 
 func (s *apiBaseSuite) daemonWithStore(c *check.C, sto snapstate.StoreService) *daemon.Daemon {
 	if s.d != nil {
-		panic("called Daemon*() twice")
+		panic("called daemon*() twice")
 	}
 	d, err := daemon.NewAndAddRoutes()
 	c.Assert(err, check.IsNil)
@@ -291,7 +291,7 @@ func (s *apiBaseSuite) daemon(c *check.C) *daemon.Daemon {
 
 func (s *apiBaseSuite) daemonWithOverlordMock(c *check.C) *daemon.Daemon {
 	if s.d != nil {
-		panic("called Daemon*() twice")
+		panic("called daemon*() twice")
 	}
 
 	o := overlord.Mock()
@@ -301,7 +301,7 @@ func (s *apiBaseSuite) daemonWithOverlordMock(c *check.C) *daemon.Daemon {
 
 func (s *apiBaseSuite) daemonWithOverlordMockAndStore(c *check.C) *daemon.Daemon {
 	if s.d != nil {
-		panic("called Daemon*() twice")
+		panic("called daemon*() twice")
 	}
 
 	o := overlord.Mock()
@@ -365,7 +365,7 @@ func (s *apiBaseSuite) mkInstalledDesktopFile(c *check.C, name, content string) 
 
 func (s *apiBaseSuite) mockSnap(c *check.C, yamlText string) *snap.Info {
 	if s.d == nil {
-		panic("call s.Daemon(c) etc in your test first")
+		panic("call s.daemon(c) etc in your test first")
 	}
 
 	snapInfo := snaptest.MockSnap(c, yamlText, &snap.SideInfo{Revision: snap.R(1)})
@@ -510,7 +510,7 @@ func handlerCommand(c *check.C, d *daemon.Daemon, req *http.Request) (cmd *daemo
 
 func (s *apiBaseSuite) checkGetOnly(c *check.C, req *http.Request) {
 	if s.d == nil {
-		panic("call s.Daemon(c) etc in your test first")
+		panic("call s.daemon(c) etc in your test first")
 	}
 
 	cmd, _ := handlerCommand(c, s.d, req)
@@ -521,7 +521,7 @@ func (s *apiBaseSuite) checkGetOnly(c *check.C, req *http.Request) {
 
 func (s *apiBaseSuite) req(c *check.C, req *http.Request, u *auth.UserState) daemon.Response {
 	if s.d == nil {
-		panic("call s.Daemon(c) etc in your test first")
+		panic("call s.daemon(c) etc in your test first")
 	}
 
 	cmd, vars := handlerCommand(c, s.d, req)
@@ -545,7 +545,7 @@ func (s *apiBaseSuite) req(c *check.C, req *http.Request, u *auth.UserState) dae
 
 func (s *apiBaseSuite) serveHTTP(c *check.C, w http.ResponseWriter, req *http.Request) {
 	if s.d == nil {
-		panic("call s.Daemon(c) etc in your test first")
+		panic("call s.daemon(c) etc in your test first")
 	}
 
 	cmd, vars := handlerCommand(c, s.d, req)
@@ -556,7 +556,7 @@ func (s *apiBaseSuite) serveHTTP(c *check.C, w http.ResponseWriter, req *http.Re
 
 func (s *apiBaseSuite) simulateConflict(name string) {
 	if s.d == nil {
-		panic("call s.Daemon(c) etc in your test first")
+		panic("call s.daemon(c) etc in your test first")
 	}
 
 	o := s.d.Overlord()

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -543,6 +543,30 @@ func (s *apiBaseSuite) req(c *check.C, req *http.Request, u *auth.UserState) dae
 	return f(cmd, req, u)
 }
 
+func (s *apiBaseSuite) jsonReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.Resp {
+	rsp, ok := s.req(c, req, u).(*daemon.Resp)
+	c.Assert(ok, check.Equals, true, check.Commentf("expected structured response"))
+	return rsp
+}
+
+func (s *apiBaseSuite) syncReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.Resp {
+	rsp := s.jsonReq(c, req, u)
+	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeSync, check.Commentf("expected sync resp: %#v", rsp))
+	return rsp
+}
+
+func (s *apiBaseSuite) asyncReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.Resp {
+	rsp := s.jsonReq(c, req, u)
+	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeAsync, check.Commentf("expected async resp: %#v", rsp))
+	return rsp
+}
+
+func (s *apiBaseSuite) errorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.Resp {
+	rsp := s.jsonReq(c, req, u)
+	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError, check.Commentf("expected error resp: %#v", rsp))
+	return rsp
+}
+
 func (s *apiBaseSuite) serveHTTP(c *check.C, w http.ResponseWriter, req *http.Request) {
 	if s.d == nil {
 		panic("call s.daemon(c) etc in your test first")

--- a/daemon/api_buy_unsupp_test.go
+++ b/daemon/api_buy_unsupp_test.go
@@ -186,7 +186,7 @@ func (s *buySuite) TestBuySnap(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/buy", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.req(c, req, user).(*daemon.Resp)
+		rsp := s.jsonReq(c, req, user)
 
 		c.Check(rsp.Status, check.Equals, test.expectedStatus)
 		c.Check(rsp.Type, check.Equals, test.expectedResponseType)
@@ -245,7 +245,7 @@ func (s *buySuite) TestReadyToBuy(c *check.C) {
 		req, err := http.NewRequest("GET", "/v2/buy/ready", nil)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.req(c, req, user).(*daemon.Resp)
+		rsp := s.jsonReq(c, req, user)
 		c.Check(rsp.Status, check.Equals, test.status)
 		c.Check(rsp.Type, check.Equals, test.respType)
 		c.Assert(rsp.Result, check.FitsTypeOf, test.response)

--- a/daemon/api_cohort_test.go
+++ b/daemon/api_cohort_test.go
@@ -64,36 +64,27 @@ func (s *cohortSuite) TestCreateCohort(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]}]`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 200,
-		Type:   "sync",
-		Result: s.coh,
-	})
+	rsp := s.syncReq(c, req, nil)
+	c.Check(rsp.Status, check.Equals, 200)
+	c.Check(rsp.Result, check.DeepEquals, s.coh)
 }
 
 func (s *cohortSuite) TestCreateCohortNoSnaps(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create"}]`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 200,
-		Type:   "sync",
-		Result: map[string]string{},
-	})
+	rsp := s.syncReq(c, req, nil)
+	c.Check(rsp.Status, check.Equals, 200)
+	c.Check(rsp.Result, check.DeepEquals, map[string]string{})
 }
 
 func (s *cohortSuite) TestCreateCohortBadAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "pupate", "snaps": ["foo","bar"]}]`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 400,
-		Type:   "error",
-		Result: &daemon.ErrorResult{Message: `unknown cohort action "pupate"`},
-	})
+	rsp := s.errorReq(c, req, nil)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `unknown cohort action "pupate"`})
 }
 
 func (s *cohortSuite) TestCreateCohortError(c *check.C) {
@@ -102,34 +93,25 @@ func (s *cohortSuite) TestCreateCohortError(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]}]`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 500,
-		Type:   "error",
-		Result: &daemon.ErrorResult{Message: `something went wrong`},
-	})
+	rsp := s.errorReq(c, req, nil)
+	c.Check(rsp.Status, check.Equals, 500)
+	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `something went wrong`})
 }
 
 func (s *cohortSuite) TestCreateBadBody1(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 400,
-		Type:   "error",
-		Result: &daemon.ErrorResult{Message: `cannot decode request body into cohort instruction: unexpected EOF`},
-	})
+	rsp := s.errorReq(c, req, nil)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `cannot decode request body into cohort instruction: unexpected EOF`})
 }
 
 func (s *cohortSuite) TestCreateBadBody2(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]}xx`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 400,
-		Type:   "error",
-		Result: &daemon.ErrorResult{Message: `spurious content after cohort instruction`},
-	})
+	rsp := s.errorReq(c, req, nil)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `spurious content after cohort instruction`})
 }

--- a/daemon/api_console_conf_test.go
+++ b/daemon/api_console_conf_test.go
@@ -53,8 +53,7 @@ func (s *consoleConfSuite) TestPostConsoleConfStartRoutine(c *C) {
 	c.Assert(err, IsNil)
 
 	// no changes in state, no changes in response
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Check(rsp.Type, Equals, daemon.ResponseTypeSync)
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Result, DeepEquals, &daemon.ConsoleConfStartRoutineResult{})
 
 	// we did set the refresh.hold time back 20 minutes though
@@ -102,8 +101,7 @@ func (s *consoleConfSuite) TestPostConsoleConfStartRoutine(c *C) {
 
 	req2, err := http.NewRequest("POST", "/v2/internal/console-conf-start", body)
 	c.Assert(err, IsNil)
-	rsp2 := s.req(c, req2, nil).(*daemon.Resp)
-	c.Check(rsp2.Type, Equals, daemon.ResponseTypeSync)
+	rsp2 := s.syncReq(c, req2, nil)
 	c.Assert(rsp2.Result, FitsTypeOf, &daemon.ConsoleConfStartRoutineResult{})
 	res := rsp2.Result.(*daemon.ConsoleConfStartRoutineResult)
 	sort.Strings(res.ActiveAutoRefreshChanges)

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -44,7 +44,7 @@ func (s *seedingDebugSuite) getSeedingDebug(c *C) interface{} {
 	req, err := http.NewRequest("GET", "/v2/debug?aspect=seeding", nil)
 	c.Assert(err, IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Type, Equals, daemon.ResponseTypeSync)
 	return rsp.Result
 }

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -189,13 +189,13 @@ func (s *snapDownloadSuite) TestDownloadSnapErrors(c *check.C) {
 
 		req, err := http.NewRequest("POST", "/v2/download", bytes.NewBuffer(data))
 		c.Assert(err, check.IsNil)
-		rsp := s.req(c, req, nil)
+		rsp := s.errorReq(c, req, nil)
 
-		c.Assert(rsp.(*daemon.Resp).Status, check.Equals, scen.status)
+		c.Assert(rsp.Status, check.Equals, scen.status)
 		if scen.err == "" {
 			c.Errorf("error was expected")
 		}
-		result := rsp.(*daemon.Resp).Result
+		result := rsp.Result
 		c.Check(result.(*daemon.ErrorResult).Message, check.Matches, scen.err)
 	}
 }

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -177,8 +177,7 @@ func (s *sideloadSuite) sideloadCheck(c *check.C, content string, head map[strin
 		req.Header.Set(k, v)
 	}
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeAsync)
+	rsp := s.asyncReq(c, req, nil)
 	n := 1
 	c.Assert(installQueue, check.HasLen, n)
 	c.Check(installQueue[n-1], check.Matches, "local::.*/"+regexp.QuoteMeta(dirs.LocalInstallBlobTempPrefix)+".*")
@@ -233,8 +232,7 @@ func (s *sideloadSuite) TestSideloadSnapJailModeAndDevmode(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, "cannot use devmode and jailmode flags together")
 }
 
@@ -258,8 +256,7 @@ func (s *sideloadSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
 	restore := sandbox.MockForceDevMode(true)
 	defer restore()
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, "this system cannot honour the jailmode flag")
 }
 
@@ -316,8 +313,7 @@ func (s *sideloadSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
 		return state.NewTaskSet(), &snap.Info{SuggestedName: "x"}, nil
 	})()
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeAsync)
+	rsp := s.asyncReq(c, req, nil)
 
 	st.Lock()
 	defer st.Unlock()
@@ -352,8 +348,7 @@ func (s *sideloadSuite) TestSideloadSnapNoSignaturesDangerOff(c *check.C) {
 	// this is the prefix used for tempfiles for sideloading
 	glob := filepath.Join(os.TempDir(), "snapd-sideload-pkg-*")
 	glbBefore, _ := filepath.Glob(glob)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, `cannot find signatures with metadata for snap "x"`)
 	glbAfter, _ := filepath.Glob(glob)
 	c.Check(len(glbBefore), check.Equals, len(glbAfter))
@@ -378,8 +373,7 @@ func (s *sideloadSuite) TestSideloadSnapNotValidFormFile(c *check.C) {
 		req.Header.Set(k, v)
 	}
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Assert(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot find "snap" file field in provided multipart/form-data payload`)
 }
 
@@ -408,8 +402,7 @@ func (s *sideloadSuite) TestSideloadSnapChangeConflict(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindSnapChangeConflict)
 }
 
@@ -454,8 +447,7 @@ func (s *sideloadSuite) TestSideloadSnapInstanceNameMismatch(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, `instance name "foo_instance" does not match snap name "bar"`)
 }
 
@@ -575,9 +567,8 @@ func (s *trySuite) TestTrySnap(c *check.C) {
 
 		// try the snap (without an installed core)
 		st.Unlock()
-		rsp := s.req(c, reqForFlags(t.flags), nil).(*daemon.Resp)
+		rsp := s.asyncReq(c, reqForFlags(t.flags), nil)
 		st.Lock()
-		c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeAsync, check.Commentf(t.desc))
 		c.Assert(tryWasCalled, check.Equals, true, check.Commentf(t.desc))
 
 		chg := st.Change(rsp.Change)

--- a/daemon/api_snapctl_test.go
+++ b/daemon/api_snapctl_test.go
@@ -44,7 +44,7 @@ func (s *snapctlSuite) TestSnapctlGetNoUID(c *check.C) {
 	buf := bytes.NewBufferString(`{"context-id": "some-context", "args": ["get", "something"]}`)
 	req, err := http.NewRequest("POST", "/v2/snapctl", buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.errorReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 403)
 }
 
@@ -62,7 +62,7 @@ func (s *snapctlSuite) TestSnapctlForbiddenError(c *check.C) {
 	buf := bytes.NewBufferString(fmt.Sprintf(`{"context-id": "some-context", "args": [%q, %q]}`, "set", "foo=bar"))
 	req, err := http.NewRequest("POST", "/v2/snapctl", buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.errorReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 403)
 }
 
@@ -80,7 +80,7 @@ func (s *snapctlSuite) TestSnapctlUnsuccesfulError(c *check.C) {
 	buf := bytes.NewBufferString(fmt.Sprintf(`{"context-id": "some-context", "args": [%q, %q]}`, "is-connected", "plug"))
 	req, err := http.NewRequest("POST", "/v2/snapctl", buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindUnsuccessful)
 	c.Check(rsp.Result.(*daemon.ErrorResult).Value, check.DeepEquals, map[string]interface{}{

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -76,8 +76,7 @@ func (s *snapshotSuite) TestListSnapshots(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
+	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.DeepEquals, snapshots)
 }
@@ -93,8 +92,7 @@ func (s *snapshotSuite) TestListSnapshotsFiltering(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots?set=42", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
+	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.DeepEquals, []client.SnapshotSet{{ID: 42}})
 }
@@ -108,8 +106,7 @@ func (s *snapshotSuite) TestListSnapshotsBadFiltering(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots?set=no", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.ErrorResult().Message, check.Equals, `'set', if given, must be a positive base 10 number; got "no"`)
 }
@@ -122,8 +119,7 @@ func (s *snapshotSuite) TestListSnapshotsListError(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 500)
 	c.Check(rsp.ErrorResult().Message, check.Equals, "no")
 }
@@ -190,8 +186,7 @@ func (s *snapshotSuite) TestChangeSnapshots400(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snapshots", strings.NewReader(test.body))
 		c.Assert(err, check.IsNil, comm)
 
-		rsp := s.req(c, req, nil).(*daemon.Resp)
-		c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError, comm)
+		rsp := s.errorReq(c, req, nil)
 		c.Check(rsp.Status, check.Equals, 400, comm)
 		c.Check(rsp.ErrorResult().Message, check.Matches, test.error, comm)
 	}
@@ -220,8 +215,7 @@ func (s *snapshotSuite) TestChangeSnapshots404(c *check.C) {
 			req, err := http.NewRequest("POST", "/v2/snapshots", strings.NewReader(body))
 			c.Assert(err, check.IsNil, comm)
 
-			rsp := s.req(c, req, nil).(*daemon.Resp)
-			c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError, comm)
+			rsp := s.errorReq(c, req, nil)
 			c.Check(rsp.Status, check.Equals, 404, comm)
 			c.Check(rsp.ErrorResult().Message, check.Matches, expectedError.Error(), comm)
 			c.Check(done, check.Equals, action, comm)
@@ -250,8 +244,7 @@ func (s *snapshotSuite) TestChangeSnapshots500(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snapshots", strings.NewReader(body))
 		c.Assert(err, check.IsNil, comm)
 
-		rsp := s.req(c, req, nil).(*daemon.Resp)
-		c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError, comm)
+		rsp := s.errorReq(c, req, nil)
 		c.Check(rsp.Status, check.Equals, 500, comm)
 		c.Check(rsp.ErrorResult().Message, check.Matches, expectedError.Error(), comm)
 		c.Check(done, check.Equals, action, comm)
@@ -284,10 +277,9 @@ func (s *snapshotSuite) TestChangeSnapshot(c *check.C) {
 		c.Assert(err, check.IsNil, comm)
 
 		st.Unlock()
-		rsp := s.req(c, req, nil).(*daemon.Resp)
+		rsp := s.asyncReq(c, req, nil)
 		st.Lock()
 
-		c.Check(rsp.Type, check.Equals, daemon.ResponseTypeAsync, comm)
 		c.Check(rsp.Status, check.Equals, 202, comm)
 		c.Check(done, check.Equals, action, comm)
 
@@ -327,8 +319,7 @@ func (s *snapshotSuite) TestExportSnapshotsBadRequestOnNonNumericID(c *check.C) 
 	req, err := http.NewRequest("GET", "/v2/snapshots/xxx/export", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `'id' must be a positive base 10 number; got "xxx"`})
 }
@@ -344,8 +335,7 @@ func (s *snapshotSuite) TestExportSnapshotsBadRequestOnError(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots/1/export", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `cannot export 1: boom`})
 	c.Check(snapshotExportCalled, check.Equals, 1)
@@ -365,8 +355,7 @@ func (s *snapshotSuite) TestImportSnapshot(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
+	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{"set-id": setID, "snaps": snapNames})
 }
@@ -382,8 +371,7 @@ func (s *snapshotSuite) TestImportSnapshotError(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.ErrorResult().Message, check.Equals, "no")
 }
@@ -394,8 +382,7 @@ func (s *snapshotSuite) TestImportSnapshotNoContentLengthError(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.ErrorResult().Message, check.Equals, `cannot parse Content-Length: strconv.ParseInt: parsing "": invalid syntax`)
 }
@@ -417,8 +404,7 @@ func (s *snapshotSuite) TestImportSnapshotLimits(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeSync)
+	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(dataRead, check.Equals, 10)
 }

--- a/daemon/api_system_recovery_keys_test.go
+++ b/daemon/api_system_recovery_keys_test.go
@@ -30,7 +30,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
-	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/secboot"
 )
@@ -69,7 +68,7 @@ func (s *recoveryKeysSuite) TestSystemGetRecoveryKeysAsRootHappy(c *C) {
 	req, err := http.NewRequest("GET", "/v2/system-recovery-keys", nil)
 	c.Assert(err, IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, Equals, 200)
 	srk := rsp.Result.(*client.SystemRecoveryKeysResponse)
 	c.Assert(srk, DeepEquals, &client.SystemRecoveryKeysResponse{

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -142,7 +142,7 @@ func (s *systemsSuite) TestSystemsGetSome(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/systems", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 
 	c.Assert(rsp.Status, check.Equals, 200)
 	sys := rsp.Result.(*daemon.SystemsResponse)
@@ -207,7 +207,7 @@ func (s *systemsSuite) TestSystemsGetNone(c *check.C) {
 	// no system seeds
 	req, err := http.NewRequest("GET", "/v2/systems", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 
 	c.Assert(rsp.Status, check.Equals, 200)
 	sys := rsp.Result.(*daemon.SystemsResponse)
@@ -299,8 +299,7 @@ func (s *systemsSuite) TestSystemActionRequestErrors(c *check.C) {
 		c.Logf("tc: %#v", tc)
 		req, err := http.NewRequest("POST", path.Join("/v2/systems", tc.label), strings.NewReader(tc.body))
 		c.Assert(err, check.IsNil)
-		rsp := s.req(c, req, nil).(*daemon.Resp)
-		c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
+		rsp := s.errorReq(c, req, nil)
 		c.Check(rsp.Status, check.Equals, tc.status)
 		c.Check(rsp.ErrorResult().Message, check.Matches, tc.error)
 	}
@@ -540,7 +539,7 @@ func (s *systemsSuite) TestSystemActionBrokenSeed(c *check.C) {
 	body := `{"action":"do","title":"reinstall","mode":"install"}`
 	req, err := http.NewRequest("POST", "/v2/systems/20191119", strings.NewReader(body))
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 500)
 	c.Check(rsp.ErrorResult().Message, check.Matches, `cannot load seed system: cannot load assertions: .*`)
 }

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -340,8 +340,7 @@ func (s *themesSuite) TestThemesCmdGet(c *C) {
 	}
 
 	req := httptest.NewRequest("GET", "/v2/accessories/themes?gtk-theme=Foo-gtk&gtk-theme=Bar&icon-theme=Foo-icons&sound-theme=Foo-sounds", nil)
-	rsp, ok := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(ok, Equals, true)
+	rsp := s.syncReq(c, req, nil)
 
 	c.Check(rsp.Type, Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Status, Equals, 200)
@@ -411,10 +410,7 @@ func (s *themesSuite) TestThemesCmdPost(c *C) {
 
 	buf := bytes.NewBufferString(`{"gtk-themes":["Foo-gtk"],"icon-themes":["Foo-icons"],"sound-themes":["Foo-sounds"]}`)
 	req := httptest.NewRequest("POST", "/v2/accessories/themes", buf)
-	rsp, ok := s.req(c, req, nil).(*daemon.Resp)
-	c.Assert(ok, Equals, true)
-
-	c.Check(rsp.Type, Equals, daemon.ResponseTypeAsync)
+	rsp := s.asyncReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 202)
 
 	st := s.d.Overlord().State()

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -198,8 +198,7 @@ func (s *apiValidationSetsSuite) TestQueryValidationSetsErrors(c *check.C) {
 		}
 		req, err := http.NewRequest("GET", fmt.Sprintf("/v2/validation-sets/%s?%s", tc.validationSet, q.Encode()), nil)
 		c.Assert(err, check.IsNil)
-		rsp := s.req(c, req, nil).(*daemon.Resp)
-		c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError, check.Commentf("case #%d", i))
+		rsp := s.errorReq(c, req, nil)
 		c.Check(rsp.Status, check.Equals, tc.status, check.Commentf("case #%d", i))
 		c.Check(rsp.ErrorResult().Message, check.Matches, tc.message)
 	}
@@ -209,7 +208,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetsNone(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/validation-sets", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.([]daemon.ValidationSetResult)
 	c.Check(res, check.HasLen, 0)
@@ -230,10 +229,7 @@ func (s *apiValidationSetsSuite) TestListValidationSets(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/validation-sets", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	if rsp.Status != 200 {
-		fmt.Printf("%s\n", rsp.ErrorResult().Message)
-	}
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.([]daemon.ValidationSetResult)
 	c.Check(res, check.DeepEquals, []daemon.ValidationSetResult{
@@ -272,10 +268,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetOne(c *check.C) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("/v2/validation-sets/%s/baz", s.dev1acct.AccountID()), nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	if rsp.Status != 200 {
-		fmt.Printf("%s\n", rsp.ErrorResult().Message)
-	}
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.(daemon.ValidationSetResult)
 	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
@@ -301,10 +294,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetPinned(c *check.C) {
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	if rsp.Status != 200 {
-		fmt.Printf("%s\n", rsp.ErrorResult().Message)
-	}
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.(daemon.ValidationSetResult)
 	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
@@ -332,7 +322,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetNotFound(c *check.C) {
 	s.mockValidationSetsTracking(st)
 	st.Unlock()
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.errorReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 404)
 	res := rsp.Result.(*daemon.ErrorResult)
 	c.Assert(res, check.NotNil)
@@ -413,7 +403,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetLatestFromRemote(c *check.C
 
 	st.Unlock()
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.(daemon.ValidationSetResult)
 	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
@@ -437,7 +427,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetLatestFromRemoteValidationF
 
 	req, err := http.NewRequest("GET", "/v2/validation-sets/foo/other", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 
 	res := rsp.Result.(daemon.ValidationSetResult)
@@ -477,7 +467,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetLatestFromRemoteRealValidat
 
 		req, err := http.NewRequest("GET", "/v2/validation-sets/foo/other", nil)
 		c.Assert(err, check.IsNil)
-		rsp := s.req(c, req, nil).(*daemon.Resp)
+		rsp := s.syncReq(c, req, nil)
 		c.Assert(rsp.Status, check.Equals, 200)
 
 		res := rsp.Result.(daemon.ValidationSetResult)
@@ -532,7 +522,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetSpecificSequenceFromRemote(
 
 	st.Unlock()
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.(daemon.ValidationSetResult)
 	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
@@ -568,7 +558,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetFromRemoteFallbackToLocalAs
 	req, err := http.NewRequest("GET", fmt.Sprintf("/v2/validation-sets/%s/bar?%s", s.dev1acct.AccountID(), q.Encode()), nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 	res := rsp.Result.(daemon.ValidationSetResult)
 	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
@@ -596,7 +586,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetPinnedNotFound(c *check.C) 
 	s.mockValidationSetsTracking(st)
 	st.Unlock()
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.errorReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 404)
 	res := rsp.Result.(*daemon.ErrorResult)
 	c.Assert(res, check.NotNil)
@@ -639,10 +629,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedLocalOnl
 	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	if rsp.Status != 200 {
-		fmt.Printf("%s\n", rsp.ErrorResult().Message)
-	}
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 
 	var tr assertstate.ValidationSetTracking
@@ -702,10 +689,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedUnresolv
 	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	if rsp.Status != 200 {
-		fmt.Printf("%s\n", rsp.ErrorResult().Message)
-	}
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 
 	var tr assertstate.ValidationSetTracking
@@ -784,10 +768,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeUnpinnedRefres
 	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	if rsp.Status != 200 {
-		fmt.Printf("%s\n", rsp.ErrorResult().Message)
-	}
+	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
 
 	var tr assertstate.ValidationSetTracking
@@ -815,7 +796,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeError(c *check
 	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
+	rsp := s.errorReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 400)
 	c.Check(rsp.ErrorResult().Message, check.Equals, fmt.Sprintf(`cannot get validation set assertion for %s/bar: boom`, s.dev1acct.AccountID()))
 }
@@ -847,7 +828,7 @@ func (s *apiValidationSetsSuite) TestForgetValidationSet(c *check.C) {
 
 		req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/foo", s.dev1acct.AccountID()), strings.NewReader(body))
 		c.Assert(err, check.IsNil)
-		rsp := s.req(c, req, nil).(*daemon.Resp)
+		rsp := s.syncReq(c, req, nil)
 		c.Assert(rsp.Status, check.Equals, 200, check.Commentf("case #%d", i))
 
 		// after forget it's removed
@@ -859,7 +840,7 @@ func (s *apiValidationSetsSuite) TestForgetValidationSet(c *check.C) {
 		// and forget again fails
 		req, err = http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/foo", s.dev1acct.AccountID()), strings.NewReader(body))
 		c.Assert(err, check.IsNil)
-		rsp = s.req(c, req, nil).(*daemon.Resp)
+		rsp = s.errorReq(c, req, nil)
 		c.Assert(rsp.Status, check.Equals, 404, check.Commentf("case #%d", i))
 	}
 }
@@ -931,9 +912,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetsErrors(c *check.C) {
 		}
 		req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s", tc.validationSet), strings.NewReader(body))
 		c.Assert(err, check.IsNil)
-		rsp := s.req(c, req, nil).(*daemon.Resp)
-
-		c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError, check.Commentf("case #%d", i))
+		rsp := s.errorReq(c, req, nil)
 		c.Check(rsp.Status, check.Equals, tc.status, check.Commentf("case #%d", i))
 		c.Check(rsp.ErrorResult().Message, check.Matches, tc.message)
 	}
@@ -945,8 +924,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetUnsupportedAction(c *chec
 	req, err := http.NewRequest("POST", "/v2/validation-sets/foo/bar", strings.NewReader(body))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.req(c, req, nil).(*daemon.Resp)
-	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.ErrorResult().Message, check.Matches, `unsupported action "baz"`)
 }


### PR DESCRIPTION
these test a daemon request and check the expected response type
before returning the response for further specific checks

this simplifies away some checks in the tests but the bigger win is
avoiding the .(*daemon.Resp) casts everywhere, in particular
this will reduce the number of affected places if we change
somewhat the internal types used to produce responses