### PR TITLE
ci: set the accept-existing-contributors parameter for the cla-check action

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1
+        with:
+          accept-existing-contributors: true


### PR DESCRIPTION
One area where the new cla-check workflow differs from the old one is that it does not whitelist contributions from previous committers to the repository, so it ends up hitting Launchpad triggering more OOPS reports than we used to see.  This is most likely affecting core contributors who have not configured git to commit with an `@canonical.com` email address.

It does have an `accept-existing-contributors` input parameter, so this PR turns that on.