### PR TITLE
secboot,boot: provide fde-hooks v2 API interface to hooks

### DIFF
--- a/boot/seal.go
+++ b/boot/seal.go
@@ -171,10 +171,8 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 		if err := osutil.AtomicWriteFile(filepath.Join(skr.KeyFile), res.EncryptionKey, 0600, 0); err != nil {
 			return fmt.Errorf("cannot store key: %v", err)
 		}
-		if len(res.Handle) > 0 {
-			if err := osutil.AtomicWriteFile(filepath.Join(skr.KeyFile+".handle"), res.EncryptionKey, 0600, 0); err != nil {
-				return fmt.Errorf("cannot store key: %v", err)
-			}
+		if err := osutil.AtomicWriteFile(filepath.Join(skr.KeyFile+".handle"), res.Handle, 0600, 0); err != nil {
+			return fmt.Errorf("cannot store key: %v", err)
 		}
 
 	}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -162,10 +162,12 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 		// bytes and we still need to support this.
 		var res fdeSetupHookResult
 		if err := json.Unmarshal(hookOutput, &res); err != nil {
-			// TODO: check if size of hookOutput matches
-			// the size of the denver project key and only
-			// then assume it's v1 api
-			// if len(hookOutput) != sizeDenverKey { return err}
+			// If the input is not json and matches the
+			// size of the "denver" project encrypton key
+			// (64 bytes) we assume we deal with a v1 API.
+			if len(hookOutput) != len(secboot.EncryptionKey{}) {
+				return err
+			}
 			res.EncryptionKey = hookOutput
 		}
 		if err := osutil.AtomicWriteFile(filepath.Join(skr.KeyFile), res.EncryptionKey, 0600, 0); err != nil {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -74,8 +74,6 @@ type FDESetupHookParams struct {
 	Key     secboot.EncryptionKey
 	KeyName string
 
-	Models []*asserts.Model
-
 	//TODO:UC20: provide bootchains and a way to track measured
 	//boot-assets
 }
@@ -148,7 +146,6 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 		params := &FDESetupHookParams{
 			Key:     skr.Key,
 			KeyName: skr.KeyName,
-			Models:  []*asserts.Model{model},
 		}
 		sealedKey, err := RunFDESetupHook("initial-setup", params)
 		if err != nil {

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -1348,9 +1348,9 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way
 	c.Check(runFDESetupHookParams, DeepEquals, []*boot.FDESetupHookParams{
-		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data", Models: []*asserts.Model{model}},
-		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data", Models: []*asserts.Model{model}},
-		{Key: secboot.EncryptionKey{5, 6, 7, 8}, KeyName: "ubuntu-save", Models: []*asserts.Model{model}},
+		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data"},
+		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data"},
+		{Key: secboot.EncryptionKey{5, 6, 7, 8}, KeyName: "ubuntu-save"},
 	})
 	// check that the sealed keys got written to the expected places
 	for i, p := range []string{

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1526,15 +1526,6 @@ func (m *DeviceManager) runFDESetupHook(op string, params *boot.FDESetupHookPara
 		KeyName: params.KeyName,
 		// TODO: include boot chains
 	}
-	for _, model := range params.Models {
-		req.Models = append(req.Models, map[string]string{
-			"series":     model.Series(),
-			"brand-id":   model.BrandID(),
-			"model":      model.Model(),
-			"grade":      string(model.Grade()),
-			"signkey-id": model.SignKeyID(),
-		})
-	}
 	contextData := map[string]interface{}{
 		"fde-setup-request": req,
 	}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1329,7 +1329,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 
 	st.Lock()
 	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
-	mockModel := s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1355,15 +1355,6 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 			Op:      "initial-setup",
 			Key:     mockKey[:],
 			KeyName: "some-key-name",
-			Models: []map[string]string{
-				{
-					"series":     "16",
-					"brand-id":   "canonical",
-					"model":      "pc",
-					"grade":      "unset",
-					"signkey-id": mockModel.SignKeyID(),
-				},
-			},
 		})
 
 		// the snapctl fde-setup-result will set the data
@@ -1381,7 +1372,6 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 	params := &boot.FDESetupHookParams{
 		Key:     mockKey,
 		KeyName: "some-key-name",
-		Models:  []*asserts.Model{mockModel},
 	}
 	st.Lock()
 	data, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)
@@ -1396,7 +1386,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrors(c *C) {
 
 	st.Lock()
 	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
-	mockModel := s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1420,7 +1410,6 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrors(c *C) {
 	params := &boot.FDESetupHookParams{
 		Key:     secboot.EncryptionKey{1, 2, 3, 4},
 		KeyName: "some-key-name",
-		Models:  []*asserts.Model{mockModel},
 	}
 	st.Lock()
 	_, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)
@@ -1433,7 +1422,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrorResult(c *C) {
 
 	st.Lock()
 	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
-	mockModel := s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1464,7 +1453,6 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrorResult(c *C) {
 	params := &boot.FDESetupHookParams{
 		Key:     secboot.EncryptionKey{1, 2, 3, 4},
 		KeyName: "some-key-name",
-		Models:  []*asserts.Model{mockModel},
 	}
 	st.Lock()
 	_, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)

--- a/overlord/devicestate/fde/fde.go
+++ b/overlord/devicestate/fde/fde.go
@@ -57,10 +57,6 @@ type SetupRequest struct {
 	Key     []byte `json:"key,omitempty"`
 	KeyName string `json:"key-name,omitempty"`
 
-	// List of models with their related fields, this will be set
-	// to follow the secboot:SnapModel interface.
-	Models []map[string]string `json:"models,omitempty"`
-
 	// TODO: provide LoadChains, KernelCmdline etc to support full
 	//       tpm sealing
 }

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -132,15 +132,6 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 		Op:      "initial-setup",
 		Key:     mockKey[:],
 		KeyName: "the-key-name",
-		Models: []map[string]string{
-			{
-				"series":     "16",
-				"brand-id":   "my-brand",
-				"model":      "my-model",
-				"grade":      "secured",
-				"signkey-id": "the-signkey-id",
-			},
-		},
 	}
 	s.mockContext.Lock()
 	s.mockContext.Set("fde-setup-request", fdeSetup)
@@ -152,7 +143,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 	// the encryption key should be base64 encoded
 	encodedBase64Key := base64.StdEncoding.EncodeToString(mockKey[:])
 
-	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%q,"key-name":"the-key-name","models":[{"brand-id":"my-brand","grade":"secured","model":"my-model","series":"16","signkey-id":"the-signkey-id"}]}`+"\n", encodedBase64Key))
+	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%q,"key-name":"the-key-name"}`+"\n", encodedBase64Key))
 	c.Check(string(stderr), Equals, "")
 }
 

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -475,7 +475,7 @@ func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourc
 		// the "denver" project encrypton key (64 bytes) we
 		// assume we deal with a v1 API.
 		if len(output) != encryptionKeySize {
-			return res, fmt.Errorf("cannot decode fde-reveal-key result: %v", err)
+			return res, fmt.Errorf("cannot decode fde-reveal-key result %q: %v", output, err)
 		}
 		fdeRevealKeyResult.Key = output
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -471,10 +471,12 @@ func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourc
 	// need to support this.
 	var fdeRevealKeyResult fdeRevealKeyResult
 	if err := json.Unmarshal(output, &fdeRevealKeyResult); err != nil {
-		// TODO: check if size of hookOutput matches
-		// the size of the denver project key and only
-		// then assume it's v1 api
-		// if len(hookOutput) != sizeDenverKey { return err}
+		// If the input is not json and matches the size of
+		// the "denver" project encrypton key (64 bytes) we
+		// assume we deal with a v1 API.
+		if len(output) != encryptionKeySize {
+			return res, fmt.Errorf("cannot decode fde-reveal-key result: %v", err)
+		}
 		fdeRevealKeyResult.Key = output
 	}
 


### PR DESCRIPTION
This PR is the first step to the v2 API - it does change all the inputs/outputs to what we expect but it does not yet bind the model to the key nor does it create the new "aux-key" or store the payload of encrypted("disk-encryption-key", "aux-key") and "handle" into a single file.