### PR TITLE
packaging: stop snapd.{socket,service} before purging data

### DIFF
--- a/packaging/debian-sid/snapd.postrm
+++ b/packaging/debian-sid/snapd.postrm
@@ -96,6 +96,10 @@ if [ "$1" = "purge" ]; then
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
     done
 
+    # now stop snapd itself to ensure we can clearly remove all snapd data
+    systemctl_stop snapd.socket || true
+    systemctl_stop snapd.service || true
+
     # snapd session-agent
     rm -f /etc/systemd/user/snapd.session-agent.socket
     rm -f /etc/systemd/user/snapd.session-agent.service

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -96,6 +96,10 @@ if [ "$1" = "purge" ]; then
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
     done
 
+    # now stop snapd itself to ensure we can clearly remove all snapd data
+    systemctl_stop snapd.socket || true
+    systemctl_stop snapd.service || true
+
     # snapd session-agent
     rm -f /etc/systemd/user/snapd.session-agent.socket
     rm -f /etc/systemd/user/snapd.session-agent.service

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -102,6 +102,10 @@ if [ "$1" = "purge" ]; then
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
     done
 
+    # now stop snapd itself to ensure we can clearly remove all snapd data
+    systemctl_stop snapd.socket || true
+    systemctl_stop snapd.service || true
+
     # snapd session-agent
     rm -f /etc/systemd/user/snapd.session-agent.socket
     rm -f /etc/systemd/user/snapd.session-agent.service

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -371,11 +371,12 @@ prepare_project() {
 
             # first abort all ongoing changes and wait for them all to be done
             for chg in $(snap changes | tail -n +2 | grep Do | grep -v Done | awk '{print $1}'); do
-                snap abort "$chg"
+                snap abort "$chg" || true
+                snap watch "$chg" || true
             done
 
             # now remove all snaps that aren't a base, core or snapd
-            for sn in $(snap list | tail -n +2 | awk '{print $1,$6}' | grep -Po '(.+)\s+.*(?!base).*' | awk '{print $1}'); do
+            for sn in $(snap list | tail -n +2 | awk '{print $1,$6}' | grep -Po '(.+)\s+(?!base)' | awk '{print $1}'); do
                 if [ "$sn" != snapd ] && [ "$sn" != core ]; then
                     snap remove "$sn" || true
                 fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -370,7 +370,7 @@ prepare_project() {
             # to purge it
 
             # first abort all ongoing changes and wait for them all to be done
-            for chg in $(snap changes | tail -n +2 | grep Do); do
+            for chg in $(snap changes | tail -n +2 | grep Do | grep -v Done); do
                 snap abort "$chg"
             done
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -377,8 +377,14 @@ prepare_project() {
             if [ -d /var/lib/snapd ]; then
                 echo "# /var/lib/snapd"
                 ls -lR /var/lib/snapd || true
-                journalctl -b | tail -100 || true
+                journalctl --no-pager || true
                 cat /var/lib/snapd/state.json || true
+                snap debug state /var/lib/snapd/state.json || true
+                (
+                    for chg in $(snap debug state /var/lib/snapd/state.json | tail -n +2 | awk '{print $1}'); do
+                        snap debug state --abs-time "--change=$chg" /var/lib/snapd/state.json || true
+                    done
+                ) || true
                 exit 1
             fi
             ;;

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -370,12 +370,11 @@ prepare_project() {
             # to purge it
 
             # first abort all ongoing changes and wait for them all to be done
-            for chg in $(snap changes | tail -n +2 | grep Do | grep -v Done); do
+            for chg in $(snap changes | tail -n +2 | grep Do | grep -v Done | awk '{print $1}'); do
                 snap abort "$chg"
             done
 
-            # now remove all snaps that aren't base snaps and are not snapd and
-            # not core
+            # now remove all snaps that aren't a base, core or snapd
             for sn in $(snap list | tail -n +2 | awk '{print $1,$6}' | grep -Po '(.+)\s+.*(?!base).*' | awk '{print $1}'); do
                 if [ "$sn" != snapd ] && [ "$sn" != core ]; then
                     snap remove "$sn" || true


### PR DESCRIPTION
This commit will ensure that snapd is properly stopped before
the data is removed. If we don't do that there is a race when
e.g. a refresh is in progress while "dpkg --purge snapd" is
running. The postrm will remove a bunch of data but because
snapd is still running it will write out some files like
state.json.
