### PR TITLE
spread: tentative workaround for arch failure caused by libc upgrade and cgroups v2

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -624,10 +624,11 @@ prepare: |
                 zypper -q install -y xdelta3 curl &> "$tf" || (cat "$tf"; exit 1)
                 ;;
             arch-*)
-                # NOTE: we ought to do pacman -Syu, but this may update the
+                # XXX: there may be a libc upgrade which only -Syu handles;
+                # we shouldn't do pacman -Syu, as this may update the
                 # kernel which we will not detect at this stage and fail to
-                # reboot; actual distro upgrade is done later in prepare
-                pacman -Sy --noconfirm xdelta3 curl &> "$tf" || (cat "$tf"; exit 1)
+                # reboot; actual distro upgrade is done later in prepare.
+                pacman -Syu --noconfirm xdelta3 curl &> "$tf" || (cat "$tf"; exit 1)
                 ;;
         esac
         rm -f "$tf"

--- a/tests/main/cgroup-devices/task.yaml
+++ b/tests/main/cgroup-devices/task.yaml
@@ -1,9 +1,7 @@
 summary: measuring basic properties of device cgroup
-# fedora-32: uses cgroupv2, which we don't support
-# fedora-33: uses cgroupv2, which we don't support
-# debian-sid: uses cgroupv2, which we don't support
+# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which we don't support
 
-systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-* ]
+systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-* ]
 execute: ./task.sh
 restore: |
     rm -f test-snapd-service_1.0_all.snap

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -1,9 +1,8 @@
 summary: Each snap process is moved to appropriate freezer cgroup
 
-# fedora-32: uses cgroupv2, which does not support a separate freezer controller
-# fedora-33: uses cgroupv2, which does not support a separate freezer controller
-# debian-sid: uses cgroupv2, which does not support a separate freezer controller
-systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*]
+# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which does not support
+# a separate freezer controller
+systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-*]
 
 details: |
     This test creates a snap process that suspends itself and ensures that it

--- a/tests/main/security-device-cgroups-serial-port/task.yaml
+++ b/tests/main/security-device-cgroups-serial-port/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the device cgroup works properly for serial-port.
 
 # We don't run the native kernel on these distributions yet so we can't
 # load kernel modules coming from distribution packages yet.
-systems: [-fedora-*, -opensuse-*, -debian-*]
+systems: [-fedora-*, -opensuse-*, -debian-*, -arch-*]
 
 prepare: |
     # create serial devices if they don't exist

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -2,8 +2,8 @@ summary: Ensure that the security rules related to device cgroups work.
 
 # fedora, opensuse: we don't run the native kernel on these distributions yet so
 #                   we can't load kernel modules coming from distribution packages yet
-# debian-sid: cgroup v2 which we do not fully support yet
-systems: [-fedora-*, -opensuse-*, -debian-sid-*]
+# debian-sid, arch: cgroup v2 which we do not fully support yet
+systems: [-fedora-*, -opensuse-*, -debian-sid-*, -arch-* ]
 
 environment:
     DEVICE_NAME/kmsg: kmsg

--- a/tests/main/snap-device-helper-nvme/task.yaml
+++ b/tests/main/snap-device-helper-nvme/task.yaml
@@ -3,10 +3,8 @@ summary: |
   devices by simulating how udev calls snap-device-helper with prototypical 
   paths, including the various types of nvme devices.
 
-# fedora-32: uses cgroupv2, which we don't support
-# fedora-33: uses cgroupv2, which we don't support
-# debian-sid: uses cgroupv2, which we don't support
-systems: [-fedora-32-*, -fedora-33-*, -debian-sid-*]
+# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which we don't support
+systems: [-fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-*]
 
 execute: |
   # make a fake snap devices cgroup

--- a/tests/main/snapctl-is-connected/task.yaml
+++ b/tests/main/snapctl-is-connected/task.yaml
@@ -12,7 +12,7 @@ execute: |
     local OUT="$1"
     case "$SPREAD_SYSTEM" in
         # special case systems using unified cgroup v2 hierarchy
-        fedora-32-*|fedora-33-*|debian-sid-*)
+        fedora-32-*|fedora-33-*|debian-sid-*|arch-*)
             echo "$OUT" | MATCH '^WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement$'
             ;;
         *)


### PR DESCRIPTION
Tentative workaround for arch failures - use `pacman -Syu` as apparently there is a libc update and -Sy isn't enough to handle this (when this happens, even pacman doesn't work anymore because it depends on libcurl).

The failure is:
```
curl -sS -o - https://codeload.github.com/snapcore/snapd/tar.gz/2.49
curl: /usr/lib/libc.so.6: version `GLIBC_2.33' not found (required by curl)
curl: /usr/lib/libc.so.6: version `GLIBC_2.33' not found (required by /usr/lib/libcurl.so.4)

gzip: stdin: unexpected end of file
```

Also, arch now apparently uses cgroup v2, so this PR updates the affected tests.
