### PR TITLE
interfaces/builtin/gpio_test.go: actually test the generated gpio apparmor

### DIFF
--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -163,7 +163,7 @@ func (s *GpioInterfaceSuite) TestApparmorConnectedPlugIgnoresMissingSymlink(c *C
 	c.Assert(log.String(), testutil.Contains, "cannot export not existing gpio /sys/class/gpio/gpio100")
 }
 
-func (s *GpioInterfaceSuite) TestApparmorConnectedSlot(c *C) {
+func (s *GpioInterfaceSuite) TestApparmorConnectedPlug(c *C) {
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		c.Assert(path, Equals, "/sys/class/gpio/gpio100")
 		// TODO: what is this actually a symlink to on a real device?


### PR DESCRIPTION
This was never actually being tested, and in addition the IgnoresMissingSymlink
test was evaluating symlinks on the host, and so the test would have failed if
run on a Raspberry Pi for example with gpio pins available.

Discovered while debugging https://github.com/snapcore/snapd/pull/10061