### PR TITLE
interfaces/builtin: introduce dsp interface

### DIFF
--- a/interfaces/builtin/dsp.go
+++ b/interfaces/builtin/dsp.go
@@ -1,0 +1,107 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/udev"
+)
+
+const dspSummary = `allows controlling digital signal processors on certain boards`
+
+const dspBaseDeclarationSlots = `
+  dsp:
+    allow-installation:
+      slot-snap-type:
+        - gadget
+        - core
+    deny-auto-connection: true
+`
+
+const ambarellaDspConnectedPlugApparmor = `
+# Description: can manage and control the integrated digital signal processor on
+# the ambarella device. This allows privileged access to hardware and kernel 
+# drivers related to the digital signal processor and thus is super-privileged.
+
+# The ucode device node corresponds to the firmware on the digital signal 
+# processor
+/dev/ucode rw,
+
+# The iav device node is the device node exposed for the specific IAV linux
+# device driver used on the ambarella device
+/dev/iav rw,
+
+# another DSP device node
+/dev/lens rw,
+
+# also needed for interfacing with the DSP
+/proc/ambarella/vin0_idsp rw,
+`
+
+var ambarellaDspConnectedPlugUDev = []string{
+	`KERNEL=="iav"`,
+	`KERNEL=="ucode"`,
+	`KERNEL=="lens"`,
+}
+
+type dspInterface struct {
+	commonInterface
+}
+
+func (iface *dspInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// check the flavor of the slot
+
+	var flavor string
+	_ = slot.Attr("flavor", &flavor)
+	fmt.Println("slot flavor", flavor)
+	switch flavor {
+	// only supported flavor for now
+	case "ambarella":
+		spec.AddSnippet(ambarellaDspConnectedPlugApparmor)
+	}
+
+	return nil
+}
+
+func (iface *dspInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// check the flavor of the slot
+	var flavor string
+	_ = slot.Attr("flavor", &flavor)
+	switch flavor {
+	// only supported flavor for now
+	case "ambarella":
+		for _, rule := range ambarellaDspConnectedPlugUDev {
+			spec.TagDevice(rule)
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	registerIface(&dspInterface{commonInterface{
+		name:                 "dsp",
+		summary:              dspSummary,
+		baseDeclarationSlots: dspBaseDeclarationSlots,
+	}})
+}

--- a/interfaces/builtin/dsp.go
+++ b/interfaces/builtin/dsp.go
@@ -41,7 +41,9 @@ const dspBaseDeclarationSlots = `
 const ambarellaDspConnectedPlugApparmor = `
 # Description: can manage and control the integrated digital signal processor on
 # the ambarella device. This allows privileged access to hardware and kernel 
-# drivers related to the digital signal processor and thus is super-privileged.
+# drivers related to the digital signal processor and thus is only allowed on
+# specific devices providing the slot via a gadget and is also not auto-
+# connected.
 
 # The ucode device node corresponds to the firmware on the digital signal 
 # processor

--- a/interfaces/builtin/dsp_test.go
+++ b/interfaces/builtin/dsp_test.go
@@ -1,0 +1,130 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type dspSuite struct {
+	iface interfaces.Interface
+
+	ambarellaSlotInfo *snap.SlotInfo
+	ambarellaSlot     *interfaces.ConnectedSlot
+	noFlavorSlotInfo  *snap.SlotInfo
+	noFlavorSlot      *interfaces.ConnectedSlot
+	plugInfo          *snap.PlugInfo
+	plug              *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&dspSuite{
+	iface: builtin.MustInterface("dsp"),
+})
+
+const dspMockPlugSnapInfoYaml = `
+name: my-device
+version: 1.0
+apps:
+  svc:
+    command: bin/foo.sh
+    plugs:
+      - dsp
+`
+
+const gadgetDspSlotYaml = `
+name: my-gadget
+version: 1.0
+type: gadget
+slots:
+  dsp-ambarella:
+    interface: dsp
+    flavor: ambarella
+  dsp-no-flavor:
+    interface: dsp
+`
+
+func (s *dspSuite) SetUpTest(c *C) {
+	s.noFlavorSlot, s.noFlavorSlotInfo = MockConnectedSlot(c, gadgetDspSlotYaml, nil, "dsp-no-flavor")
+	s.ambarellaSlot, s.ambarellaSlotInfo = MockConnectedSlot(c, gadgetDspSlotYaml, nil, "dsp-ambarella")
+	s.plug, s.plugInfo = MockConnectedPlug(c, dspMockPlugSnapInfoYaml, nil, "dsp")
+
+}
+
+func (s *dspSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "dsp")
+}
+
+func (s *dspSuite) TestSanitizeSlotNoFlavor(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.noFlavorSlotInfo), IsNil)
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.ambarellaSlotInfo), IsNil)
+}
+
+func (s *dspSuite) TestSanitizeSlotAmbarella(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.ambarellaSlotInfo), IsNil)
+}
+
+func (s *dspSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *dspSuite) TestApparmorConnectedPlugAmbarella(c *C) {
+	spec := &apparmor.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.ambarellaSlot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.SnippetForTag("snap.my-device.svc"), testutil.Contains, "/proc/ambarella/vin0_idsp rw,\n")
+}
+
+func (s *dspSuite) TestUDevConnectedPlugAmbarella(c *C) {
+	spec := &udev.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.ambarellaSlot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.Snippets(), HasLen, 4)
+	c.Assert(spec.Snippets(), testutil.Contains, `# dsp
+KERNEL=="iav", TAG+="snap_my-device_svc"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_my-device_svc", RUN+="%v/snap-device-helper $env{ACTION} snap_my-device_svc $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *dspSuite) TestUDevConnectedPlugNoFlavor(c *C) {
+	spec := &udev.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.noFlavorSlot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.Snippets(), HasLen, 0)
+}
+
+func (s *dspSuite) TestApparmorConnectedPlugNoFlavor(c *C) {
+	spec := &apparmor.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.noFlavorSlot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.Snippets(), HasLen, 0)
+}
+
+func (s *dspSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -599,6 +599,7 @@ var (
 		"cups-control":            {"app", "core"},
 		"dbus":                    {"app"},
 		"docker-support":          {"core"},
+		"dsp":                     {"core", "gadget"},
 		"dummy":                   {"app"},
 		"fwupd":                   {"app", "core"},
 		"gpio":                    {"core", "gadget"},

--- a/run-checks
+++ b/run-checks
@@ -102,7 +102,7 @@ missing_interface_spread_test() {
     for iface in $(go run ./tests/lib/list-interfaces.go) ; do
         search="plugs: \\[ $iface \\]"
         case "$iface" in
-            bool-file|gpio|pwm|hidraw|i2c|iio|serial-port|spi)
+            bool-file|gpio|pwm|dsp|hidraw|i2c|iio|serial-port|spi)
                 # skip gadget provided interfaces for now
                 continue
                 ;;

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -110,6 +110,9 @@ apps:
   docker-support:
     command: bin/run
     plugs: [ docker-support ]
+  dsp-control:
+    command: bin/run
+    plugs: [ dsp-control ]
   fpga:
     command: bin/run
     plugs: [ fpga ]


### PR DESCRIPTION
This interface will be used by specific devices with plugs that have flavor
attributes identifying which will provide board specific access to digital
signal processor devices which are very specific to a particular BSP or board.

The initial accesses here are sufficient for the software that we have tested 
and have access to, we will likely need to expand this set after getting more
feedback from the customer, but in the meantime we have agreement to move
forward with merging just this for now and add things as followups.

cc @woodrow-shen 