### PR TITLE
tests: update "spread: disable Go modules support in environment"

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -3,6 +3,9 @@ project: snapd
 environment:
     GOHOME: /home/gopath
     GOPATH: $GOHOME
+    # TODO: some distros started shipping Go 1.16 which defaults to having
+    # modules enabled, drop this when snapd starts supporting Go modules
+    GO111MODULE: "off"
     REUSE_PROJECT: '$(HOST: echo "$REUSE_PROJECT")'
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
     # /usr/lib/go-1.6/bin for trusty (needs to be last as we use

--- a/spread.yaml
+++ b/spread.yaml
@@ -3,9 +3,6 @@ project: snapd
 environment:
     GOHOME: /home/gopath
     GOPATH: $GOHOME
-    # TODO: some distros started shipping Go 1.16 which defaults to having
-    # modules enabled, drop this when snapd starts supporting Go modules
-    GO111MODULE: off
     REUSE_PROJECT: '$(HOST: echo "$REUSE_PROJECT")'
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
     # /usr/lib/go-1.6/bin for trusty (needs to be last as we use

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -216,10 +216,6 @@ install_dependencies_from_published(){
 ###
 
 prepare_project() {
-    # TODO: some distros started shipping Go 1.16 which defaults to having
-    # modules enabled, drop this when snapd starts supporting Go modules
-    export GO111MODULE=off
-
     if os.query is-ubuntu && os.query is-classic; then
         apt-get remove --purge -y lxd lxcfs || true
         apt-get autoremove --purge -y

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -216,6 +216,10 @@ install_dependencies_from_published(){
 ###
 
 prepare_project() {
+    # TODO: some distros started shipping Go 1.16 which defaults to having
+    # modules enabled, drop this when snapd starts supporting Go modules
+    export GO111MODULE=off
+
     if os.query is-ubuntu && os.query is-classic; then
         apt-get remove --purge -y lxd lxcfs || true
         apt-get autoremove --purge -y


### PR DESCRIPTION
This reverts commit e6a1f560b980615087f05ddd8e22b3b464286699.

For new systems, i.e. ubuntu 20.04 spread tests fail after latest refresh in case we set the var GO111MODULE: off in spread.yaml

It is failing in debian-sid, ubuntu-20.04, centos-8, arch-linux, etc
It works well in older systems like ubuntu-16.04, ubuntu-18.04

The error is the following:

+ best_golang=golang-1.10
+ quiet xargs -r eatmydata apt-get install -y
+ gdebi --quiet --apt-line ./debian/control
++ command -v go
+ '[' -z /usr/bin/go ']'
++ command -v govendor
+ '[' -z '' ']'
+ rm -rf /home/gopath/src/github.com/kardianos/govendor
+ go get -u github.com/kardianos/govendor
go: unknown environment setting GO111MODULE=false