### PR TITLE
tests: force a proxy to use cache action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,7 +238,7 @@ jobs:
         npm config set http-proxy "$proxy"
     - name: Cache snapd test results
       id: cache-snapd-test-results
-      uses: actions/cache@v1z
+      uses: actions/cache@v2
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"
@@ -298,7 +298,7 @@ jobs:
         npm config set http-proxy "$proxy"
     - name: Cache snapd test results
       id: cache-snapd-test-results
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-nested-results"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -229,6 +229,10 @@ jobs:
       with:
         # spread uses tags as delta reference
         fetch-depth: 0
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
     - name: Configure npm proxy
       id: npm-cache-proxy
       run: |
@@ -289,6 +293,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
     - name: Configure npm proxy
       id: npm-cache-proxy
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -229,11 +229,16 @@ jobs:
       with:
         # spread uses tags as delta reference
         fetch-depth: 0
-    - name: Cache snapd test results with proxy
+    - name: Configure npm proxy
+      id: npm-cache-proxy
+      run: |
+        proxy="$(echo $HTTPS_PROXY)"
+        npm config set proxy "$proxy"
+        npm config set https-proxy "$proxy"
+        npm config set http-proxy "$proxy"
+    - name: Cache snapd test results
       id: cache-snapd-test-results
-      uses: actions/cache@v1
-      env:
-        HTTPS_PROXY: http://squid.internal:3128
+      uses: actions/cache@v1z
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"
@@ -284,11 +289,16 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Cache snapd test results with proxy
+    - name: Configure npm proxy
+      id: npm-cache-proxy
+      run: |
+        proxy="$(echo $HTTPS_PROXY)"
+        npm config set proxy "$proxy"
+        npm config set https-proxy "$proxy"
+        npm config set http-proxy "$proxy"
+    - name: Cache snapd test results
       id: cache-snapd-test-results
       uses: actions/cache@v1
-      env:
-        HTTPS_PROXY: http://squid.internal:3128
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-nested-results"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -235,6 +235,8 @@ jobs:
       env:
         https_proxy: http://squid.internal:3128
         http_proxy: http://squid.internal:3128
+        HTTPS_PROXY: http://squid.internal:3128
+        HTTP_PROXY: http://squid.internal:3128
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"
@@ -291,6 +293,8 @@ jobs:
       env:
         https_proxy: http://squid.internal:3128
         http_proxy: http://squid.internal:3128
+        HTTPS_PROXY: http://squid.internal:3128
+        HTTP_PROXY: http://squid.internal:3128
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-nested-results"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -229,9 +229,11 @@ jobs:
       with:
         # spread uses tags as delta reference
         fetch-depth: 0
-    - name: Cache snapd test results
+    - name: Cache snapd test results with proxy
       id: cache-snapd-test-results
       uses: actions/cache@v1
+      env:
+        https_proxy: http://squid.internal:3128
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"
@@ -282,9 +284,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Cache snapd test results
+    - name: Cache snapd test results with proxy
       id: cache-snapd-test-results
       uses: actions/cache@v1
+      env:
+        https_proxy: http://squid.internal:3128
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-nested-results"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -233,10 +233,7 @@ jobs:
       id: cache-snapd-test-results
       uses: actions/cache@v1
       env:
-        https_proxy: http://squid.internal:3128
-        http_proxy: http://squid.internal:3128
         HTTPS_PROXY: http://squid.internal:3128
-        HTTP_PROXY: http://squid.internal:3128
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"
@@ -291,10 +288,7 @@ jobs:
       id: cache-snapd-test-results
       uses: actions/cache@v1
       env:
-        https_proxy: http://squid.internal:3128
-        http_proxy: http://squid.internal:3128
         HTTPS_PROXY: http://squid.internal:3128
-        HTTP_PROXY: http://squid.internal:3128
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-nested-results"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -232,7 +232,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: 12
     - name: Configure npm proxy
       id: npm-cache-proxy
       run: |
@@ -296,7 +296,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: 12
     - name: Configure npm proxy
       id: npm-cache-proxy
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -234,6 +234,7 @@ jobs:
       uses: actions/cache@v1
       env:
         https_proxy: http://squid.internal:3128
+        http_proxy: http://squid.internal:3128
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"
@@ -289,6 +290,7 @@ jobs:
       uses: actions/cache@v1
       env:
         https_proxy: http://squid.internal:3128
+        http_proxy: http://squid.internal:3128
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-nested-results"


### PR DESCRIPTION
If that works then we could have a conditional step for canonistack and
a different for prodstack where there is proxy
