### PR TITLE
gadget: be more flexible with kernel content resolving

### DIFF
--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/kernel"
-	"github.com/snapcore/snapd/strutil"
 )
 
 // LayoutConstraints defines the constraints for arranging structures within a
@@ -336,7 +335,15 @@ func resolveContentPathOrRef(gadgetRootDir, kernelRootDir string, kernelInfo *ke
 		if !ok {
 			return "", false, fmt.Errorf("cannot find %q in kernel info from %q", wantedAsset, kernelRootDir)
 		}
-		if !strutil.ListContains(kernelAsset.Content, wantedContent) {
+		// look for content prefix
+		found := false
+		for _, kcontent := range kernelAsset.Content {
+			if strings.HasPrefix(wantedContent, kcontent) {
+				found = true
+				break
+			}
+		}
+		if !found {
 			return "", false, fmt.Errorf("cannot find wanted kernel content %q in %q", wantedContent, kernelRootDir)
 		}
 		resolvedSource = filepath.Join(kernelRootDir, wantedContent)

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -335,10 +335,19 @@ func resolveContentPathOrRef(gadgetRootDir, kernelRootDir string, kernelInfo *ke
 		if !ok {
 			return "", false, fmt.Errorf("cannot find %q in kernel info from %q", wantedAsset, kernelRootDir)
 		}
-		// look for content prefix
+		// look for exact content match or for a directory prefix match
 		found := false
 		for _, kcontent := range kernelAsset.Content {
-			if strings.HasPrefix(wantedContent, kcontent) {
+			if wantedContent == kcontent {
+				found = true
+				break
+			}
+			// ensure we only check subdirs
+			suffix := ""
+			if !strings.HasSuffix(kcontent, "/") {
+				suffix = "/"
+			}
+			if strings.HasPrefix(wantedContent, kcontent+suffix) {
 				found = true
 				break
 			}

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -1223,3 +1223,73 @@ assets:
 		},
 	})
 }
+
+func (p *layoutTestSuite) TestResolveContentPathsLp1907056(c *C) {
+	var gadgetYamlWithKernelRef = `
+ volumes:
+  pi:
+    schema: mbr
+    bootloader: u-boot
+    structure:
+      - name: ubuntu-seed
+        role: system-seed
+        filesystem: vfat
+        type: 0C
+        size: 1200M
+        content:
+          - source: $kernel:pidtbs/dtbs/broadcom/
+            target: /
+          - source: $kernel:pidtbs/dtbs/overlays/
+            target: /overlays
+          - source: boot-assets/
+            target: /
+`
+
+	kernelYaml := `
+assets:
+  pidtbs:
+    update: true
+    content:
+      - dtbs/
+`
+	vol := mustParseVolume(c, gadgetYamlWithKernelRef, "pi")
+	c.Assert(vol.Structure, HasLen, 1)
+
+	kernelSnapDir := mockKernel(c, kernelYaml, nil)
+	lv, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
+	c.Assert(err, IsNil)
+	// Volume.Content is unchanged
+	c.Assert(lv.Structure, HasLen, 1)
+	c.Check(lv.Structure[0].Content, DeepEquals, []gadget.VolumeContent{
+		{
+			UnresolvedSource: "$kernel:pidtbs/dtbs/broadcom/",
+			Target:           "/",
+		},
+		{
+			UnresolvedSource: "$kernel:pidtbs/dtbs/overlays/",
+			Target:           "/overlays",
+		},
+		{
+			UnresolvedSource: "boot-assets/",
+			Target:           "/",
+		},
+	})
+	// and the LaidOutSturctures ResolvedContent has the correct paths
+	c.Assert(lv.LaidOutStructure, HasLen, 1)
+	c.Check(lv.LaidOutStructure[0].ResolvedContent, DeepEquals, []gadget.ResolvedContent{
+		{
+			VolumeContent:  &lv.Structure[0].Content[0],
+			ResolvedSource: filepath.Join(kernelSnapDir, "dtbs/broadcom/") + "/",
+			KernelUpdate:   true,
+		},
+		{
+			VolumeContent:  &lv.Structure[0].Content[1],
+			ResolvedSource: filepath.Join(kernelSnapDir, "dtbs/overlays") + "/",
+			KernelUpdate:   true,
+		},
+		{
+			VolumeContent:  &lv.Structure[0].Content[2],
+			ResolvedSource: filepath.Join(p.dir, "boot-assets") + "/",
+		},
+	})
+}


### PR DESCRIPTION
The `$kernel:ref/` resolving was a bit too restricted and would
not allow writing something like: `$kernel:ref/dir` unless the
"ref" and the "dir" are part of kernel.yaml.

This commit fixes this so that you can have a kernel.yaml that
contains only:
```
assets:
  pidtbs:
    update: true
    content:
      - dtbs/
```

And the gadget.yaml resolves deeper paths like:
```
 volumes:
  pi:
    schema: mbr
    bootloader: u-boot
    structure:
      - name: ubuntu-seed
        role: system-seed
        filesystem: vfat
        type: 0C
        size: 1200M
        content:
          - source: $kernel:pidtbs/dtbs/broadcom/
            target: /
          - source: $kernel:pidtbs/dtbs/overlays/
            target: /overlays
          - source: boot-assets/
            target: /
```
This came up during the review of LP:1907056
