### PR TITLE
boot: pass gadget path to command line helpers, load gadget from seed

### DIFF
--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -2493,14 +2493,7 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	})
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
-			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 1},
-				RealName: "pc-kernel",
-			},
-		}
-		return uc20model, []*seed.Snap{kernelSnap}, nil
+		return uc20model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -2633,14 +2626,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 	c.Check(res, Equals, gadget.ChangeApply)
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
-			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 1},
-				RealName: "pc-kernel",
-			},
-		}
-		return uc20model, []*seed.Snap{kernelSnap}, nil
+		return uc20model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -2067,7 +2067,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	shimBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("shim-%s", shimHash)), bootloader.RoleRecovery)
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRecovery)
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
-	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
+	recoveryKernelBf := bootloader.NewBootFile("pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
 
 	tab.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "shim", bootloader.RoleRecovery),
@@ -2083,14 +2083,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	uc20Model := boottest.MakeMockUC20Model()
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-linux_1.snap",
-			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 1},
-				RealName: "pc-linux",
-			},
-		}
-		return uc20Model, []*seed.Snap{kernelSnap}, nil
+		return uc20Model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -2137,10 +2130,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 			c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
 				secboot.NewLoadChain(shimBf,
 					secboot.NewLoadChain(assetBf,
-						secboot.NewLoadChain(runKernelBf))),
+						secboot.NewLoadChain(recoveryKernelBf))),
 				secboot.NewLoadChain(shimBf,
 					secboot.NewLoadChain(assetBf,
-						secboot.NewLoadChain(recoveryKernelBf))),
+						secboot.NewLoadChain(runKernelBf))),
 			})
 		case 2:
 			c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
@@ -2221,14 +2214,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	uc20Model := boottest.MakeMockUC20Model()
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-kernel-recovery_1.snap",
-			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 1},
-				RealName: "pc-kernel-recovery",
-			},
-		}
-		return uc20Model, []*seed.Snap{kernelSnap}, nil
+		return uc20Model, []*seed.Snap{mockNamedKernelSeedSnap(c, snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -2381,14 +2367,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	uc20Model := boottest.MakeMockUC20Model()
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-kernel-recovery_1.snap",
-			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 1},
-				RealName: "pc-kernel-recovery",
-			},
-		}
-		return uc20Model, []*seed.Snap{kernelSnap}, nil
+		return uc20Model, []*seed.Snap{mockNamedKernelSeedSnap(c, snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -103,7 +103,7 @@ const (
 	candidateEdition
 )
 
-func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, system, gadgetSnap string) (string, error) {
+func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, system, gadgetDirOrSnapPath string) (string, error) {
 	if model.Grade() == asserts.ModelGradeUnset {
 		return "", nil
 	}
@@ -147,28 +147,28 @@ func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, syst
 
 // ComposeRecoveryCommandLine composes the kernel command line used when booting
 // a given system in recover mode.
-func ComposeRecoveryCommandLine(model *asserts.Model, system, gadgetSnap string) (string, error) {
-	return composeCommandLine(model, currentEdition, ModeRecover, system, gadgetSnap)
+func ComposeRecoveryCommandLine(model *asserts.Model, system, gadgetDirOrSnapPath string) (string, error) {
+	return composeCommandLine(model, currentEdition, ModeRecover, system, gadgetDirOrSnapPath)
 }
 
 // ComposeCommandLine composes the kernel command line used when booting the
 // system in run mode.
-func ComposeCommandLine(model *asserts.Model, gadgetDirOrSnap string) (string, error) {
-	return composeCommandLine(model, currentEdition, ModeRun, "", gadgetDirOrSnap)
+func ComposeCommandLine(model *asserts.Model, gadgetDirOrSnapPath string) (string, error) {
+	return composeCommandLine(model, currentEdition, ModeRun, "", gadgetDirOrSnapPath)
 }
 
 // ComposeCandidateCommandLine composes the kernel command line used when
 // booting the system in run mode with the current built-in edition of managed
 // boot assets.
-func ComposeCandidateCommandLine(model *asserts.Model, gadgetDirOrSnap string) (string, error) {
-	return composeCommandLine(model, candidateEdition, ModeRun, "", gadgetDirOrSnap)
+func ComposeCandidateCommandLine(model *asserts.Model, gadgetDirOrSnapPath string) (string, error) {
+	return composeCommandLine(model, candidateEdition, ModeRun, "", gadgetDirOrSnapPath)
 }
 
 // ComposeCandidateRecoveryCommandLine composes the kernel command line used
 // when booting the given system in recover mode with the current built-in
 // edition of managed boot assets.
-func ComposeCandidateRecoveryCommandLine(model *asserts.Model, system, gadgetDirOrSnap string) (string, error) {
-	return composeCommandLine(model, candidateEdition, ModeRecover, system, gadgetDirOrSnap)
+func ComposeCandidateRecoveryCommandLine(model *asserts.Model, system, gadgetDirOrSnapPath string) (string, error) {
+	return composeCommandLine(model, candidateEdition, ModeRecover, system, gadgetDirOrSnapPath)
 }
 
 // observeSuccessfulCommandLine observes a successful boot with a command line

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -103,7 +103,7 @@ const (
 	candidateEdition
 )
 
-func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, system string) (string, error) {
+func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, system, gadgetSnap string) (string, error) {
 	if model.Grade() == asserts.ModelGradeUnset {
 		return "", nil
 	}
@@ -147,28 +147,28 @@ func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, syst
 
 // ComposeRecoveryCommandLine composes the kernel command line used when booting
 // a given system in recover mode.
-func ComposeRecoveryCommandLine(model *asserts.Model, system string) (string, error) {
-	return composeCommandLine(model, currentEdition, ModeRecover, system)
+func ComposeRecoveryCommandLine(model *asserts.Model, system, gadgetSnap string) (string, error) {
+	return composeCommandLine(model, currentEdition, ModeRecover, system, gadgetSnap)
 }
 
 // ComposeCommandLine composes the kernel command line used when booting the
 // system in run mode.
-func ComposeCommandLine(model *asserts.Model) (string, error) {
-	return composeCommandLine(model, currentEdition, ModeRun, "")
+func ComposeCommandLine(model *asserts.Model, gadgetDirOrSnap string) (string, error) {
+	return composeCommandLine(model, currentEdition, ModeRun, "", gadgetDirOrSnap)
 }
 
 // ComposeCandidateCommandLine composes the kernel command line used when
 // booting the system in run mode with the current built-in edition of managed
 // boot assets.
-func ComposeCandidateCommandLine(model *asserts.Model) (string, error) {
-	return composeCommandLine(model, candidateEdition, ModeRun, "")
+func ComposeCandidateCommandLine(model *asserts.Model, gadgetDirOrSnap string) (string, error) {
+	return composeCommandLine(model, candidateEdition, ModeRun, "", gadgetDirOrSnap)
 }
 
 // ComposeCandidateRecoveryCommandLine composes the kernel command line used
 // when booting the given system in recover mode with the current built-in
 // edition of managed boot assets.
-func ComposeCandidateRecoveryCommandLine(model *asserts.Model, system string) (string, error) {
-	return composeCommandLine(model, candidateEdition, ModeRecover, system)
+func ComposeCandidateRecoveryCommandLine(model *asserts.Model, system, gadgetDirOrSnap string) (string, error) {
+	return composeCommandLine(model, candidateEdition, ModeRecover, system, gadgetDirOrSnap)
 }
 
 // observeSuccessfulCommandLine observes a successful boot with a command line
@@ -225,7 +225,7 @@ func observeSuccessfulCommandLineUpdate(m *Modeenv) (*Modeenv, error) {
 // expected kernel command line matches the one the system booted with and
 // populates modeenv kernel command line list accordingly.
 func observeSuccessfulCommandLineCompatBoot(model *asserts.Model, m *Modeenv) (*Modeenv, error) {
-	cmdlineExpected, err := ComposeCommandLine(model)
+	cmdlineExpected, err := ComposeCommandLine(model, "")
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func observeCommandLineUpdate(model *asserts.Model) error {
 	// bootstate
 	cmdline := m.CurrentKernelCommandLines[0]
 	// this is the new expected command line
-	candidateCmdline, err := ComposeCandidateCommandLine(model)
+	candidateCmdline, err := ComposeCandidateCommandLine(model, "")
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func kernelCommandLinesForResealWithFallback(model *asserts.Model, modeenv *Mode
 	}
 	// fallback for when reseal is called before mark boot successful set a
 	// default during snapd update
-	cmdline, err := ComposeCommandLine(model)
+	cmdline, err := ComposeCommandLine(model, "")
 	if err != nil {
 		return nil, err
 	}

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -121,22 +121,22 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineNotManagedHappy(c *C) {
 	bootloader.Force(bl)
 	defer bootloader.Force(nil)
 
-	cmdline, err := boot.ComposeRecoveryCommandLine(model, "20200314")
+	cmdline, err := boot.ComposeRecoveryCommandLine(model, "20200314", "")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "")
 
-	cmdline, err = boot.ComposeCommandLine(model)
+	cmdline, err = boot.ComposeCommandLine(model, "")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "")
 
 	tbl := bl.WithTrustedAssets()
 	bootloader.Force(tbl)
 
-	cmdline, err = boot.ComposeRecoveryCommandLine(model, "20200314")
+	cmdline, err = boot.ComposeRecoveryCommandLine(model, "20200314", "")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=recover snapd_recovery_system=20200314")
 
-	cmdline, err = boot.ComposeCommandLine(model)
+	cmdline, err = boot.ComposeCommandLine(model, "")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=run")
 }
@@ -147,11 +147,11 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineNotUC20(c *C) {
 	bl := bootloadertest.Mock("btloader", c.MkDir())
 	bootloader.Force(bl)
 	defer bootloader.Force(nil)
-	cmdline, err := boot.ComposeRecoveryCommandLine(model, "20200314")
+	cmdline, err := boot.ComposeRecoveryCommandLine(model, "20200314", "")
 	c.Assert(err, IsNil)
 	c.Check(cmdline, Equals, "")
 
-	cmdline, err = boot.ComposeCommandLine(model)
+	cmdline, err = boot.ComposeCommandLine(model, "")
 	c.Assert(err, IsNil)
 	c.Check(cmdline, Equals, "")
 }
@@ -165,17 +165,17 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineManagedHappy(c *C) {
 
 	tbl.StaticCommandLine = "panic=-1"
 
-	cmdline, err := boot.ComposeRecoveryCommandLine(model, "20200314")
+	cmdline, err := boot.ComposeRecoveryCommandLine(model, "20200314", "")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=recover snapd_recovery_system=20200314 panic=-1")
-	cmdline, err = boot.ComposeCommandLine(model)
+	cmdline, err = boot.ComposeCommandLine(model, "")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=run panic=-1")
 
-	cmdline, err = boot.ComposeRecoveryCommandLine(model, "20200314")
+	cmdline, err = boot.ComposeRecoveryCommandLine(model, "20200314", "")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=recover snapd_recovery_system=20200314 panic=-1")
-	cmdline, err = boot.ComposeCommandLine(model)
+	cmdline, err = boot.ComposeCommandLine(model, "")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=run panic=-1")
 }
@@ -190,7 +190,7 @@ func (s *kernelCommandLineSuite) TestComposeCandidateCommandLineManagedHappy(c *
 	tbl.StaticCommandLine = "panic=-1"
 	tbl.CandidateStaticCommandLine = "candidate panic=0"
 
-	cmdline, err := boot.ComposeCandidateCommandLine(model)
+	cmdline, err := boot.ComposeCandidateCommandLine(model, "")
 	c.Assert(err, IsNil)
 	c.Assert(cmdline, Equals, "snapd_recovery_mode=run candidate panic=0")
 }
@@ -205,11 +205,11 @@ func (s *kernelCommandLineSuite) TestComposeCandidateRecoveryCommandLineManagedH
 	tbl.StaticCommandLine = "panic=-1"
 	tbl.CandidateStaticCommandLine = "candidate panic=0"
 
-	cmdline, err := boot.ComposeCandidateRecoveryCommandLine(model, "1234")
+	cmdline, err := boot.ComposeCandidateRecoveryCommandLine(model, "1234", "")
 	c.Assert(err, IsNil)
 	c.Check(cmdline, Equals, "snapd_recovery_mode=recover snapd_recovery_system=1234 candidate panic=0")
 
-	cmdline, err = boot.ComposeCandidateRecoveryCommandLine(model, "")
+	cmdline, err = boot.ComposeCandidateRecoveryCommandLine(model, "", "")
 	c.Assert(err, ErrorMatches, "internal error: system is unset")
 	c.Check(cmdline, Equals, "")
 }

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -374,7 +374,7 @@ func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 			return fmt.Errorf("cannot install managed bootloader assets: %v", err)
 		}
 		// determine the expected command line
-		cmdline, err := ComposeCandidateCommandLine(model)
+		cmdline, err := ComposeCandidateCommandLine(model, bootWith.UnpackedGadgetDir)
 		if err != nil {
 			return fmt.Errorf("cannot compose the candidate command line: %v", err)
 		}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -329,21 +329,19 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable20(c *C) {
 	unpackedGadgetDir := c.MkDir()
 	grubRecoveryCfg := []byte("#grub-recovery cfg")
 	grubRecoveryCfgAsset := []byte("#grub-recovery cfg from assets")
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub-recovery.conf"), grubRecoveryCfg, 0644)
-	c.Assert(err, IsNil)
+	grubCfg := []byte("#grub cfg")
+	grubCfgAsset := []byte("# Snapd-Boot-Config-Edition: 1\n#grub cfg from assets")
+	snaptest.PopulateDir(unpackedGadgetDir, [][]string{
+		{"grub-recovery.conf", string(grubRecoveryCfg)},
+		{"grub.conf", string(grubCfg)},
+		{"bootx64.efi", "shim content"},
+		{"grubx64.efi", "grub content"},
+		{"meta/snap.yaml", gadgetSnapYaml},
+	})
 	restore := assets.MockInternal("grub-recovery.cfg", grubRecoveryCfgAsset)
 	defer restore()
-	grubCfg := []byte("#grub cfg")
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
-	c.Assert(err, IsNil)
-	grubCfgAsset := []byte("# Snapd-Boot-Config-Edition: 1\n#grub cfg from assets")
 	restore = assets.MockInternal("grub.cfg", grubCfgAsset)
 	defer restore()
-
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "bootx64.efi"), []byte("shim content"), 0644)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grubx64.efi"), []byte("grub content"), 0644)
-	c.Assert(err, IsNil)
 
 	// make the snaps symlinks so that we can ensure that makebootable follows
 	// the symlinks and copies the files and not the symlinks
@@ -409,14 +407,7 @@ version: 5.0
 	readSystemEssentialCalls := 0
 	restore = boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		readSystemEssentialCalls++
-		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
-			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 1},
-				RealName: "pc-kernel",
-			},
-		}
-		return model, []*seed.Snap{kernelSnap}, nil
+		return model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -677,21 +668,19 @@ func (s *makeBootable20Suite) TestMakeRunnableSystem20RunModeSealKeyErr(c *C) {
 	unpackedGadgetDir := c.MkDir()
 	grubRecoveryCfg := []byte("#grub-recovery cfg")
 	grubRecoveryCfgAsset := []byte("#grub-recovery cfg from assets")
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub-recovery.conf"), grubRecoveryCfg, 0644)
-	c.Assert(err, IsNil)
+	grubCfg := []byte("#grub cfg")
+	grubCfgAsset := []byte("# Snapd-Boot-Config-Edition: 1\n#grub cfg from assets")
+	snaptest.PopulateDir(unpackedGadgetDir, [][]string{
+		{"grub-recovery.conf", string(grubRecoveryCfg)},
+		{"grub.conf", string(grubCfg)},
+		{"bootx64.efi", "shim content"},
+		{"grubx64.efi", "grub content"},
+		{"meta/snap.yaml", gadgetSnapYaml},
+	})
 	restore := assets.MockInternal("grub-recovery.cfg", grubRecoveryCfgAsset)
 	defer restore()
-	grubCfg := []byte("#grub cfg")
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
-	c.Assert(err, IsNil)
-	grubCfgAsset := []byte("# Snapd-Boot-Config-Edition: 1\n#grub cfg from assets")
 	restore = assets.MockInternal("grub.cfg", grubCfgAsset)
 	defer restore()
-
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "bootx64.efi"), []byte("shim content"), 0644)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grubx64.efi"), []byte("grub content"), 0644)
-	c.Assert(err, IsNil)
 
 	// make the snaps symlinks so that we can ensure that makebootable follows
 	// the symlinks and copies the files and not the symlinks
@@ -757,14 +746,7 @@ version: 5.0
 	readSystemEssentialCalls := 0
 	restore = boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		readSystemEssentialCalls++
-		kernelSnap := &seed.Snap{
-			Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
-			SideInfo: &snap.SideInfo{
-				Revision: snap.Revision{N: 0},
-				RealName: "pc-kernel",
-			},
-		}
-		return model, []*seed.Snap{kernelSnap}, nil
+		return model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -516,7 +516,7 @@ func resealFallbackObjectKeys(pbc predictableBootChains, authKeyFile string, rol
 func recoveryBootChainsForSystems(systems []string, trbl bootloader.TrustedAssetsBootloader, model *asserts.Model, modeenv *Modeenv) (chains []bootChain, err error) {
 	for _, system := range systems {
 		// get the command line
-		cmdline, err := ComposeRecoveryCommandLine(model, system)
+		cmdline, err := ComposeRecoveryCommandLine(model, system, "")
 		if err != nil {
 			return nil, fmt.Errorf("cannot obtain recovery kernel command line: %v", err)
 		}

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -55,6 +55,7 @@ type systemsSuite struct {
 	runKernelBf      bootloader.BootFile
 	recoveryKernelBf bootloader.BootFile
 	seedKernelSnap   *seed.Snap
+	seedGadgetSnap   *seed.Snap
 }
 
 var _ = Suite(&systemsSuite{})
@@ -94,13 +95,8 @@ func (s *systemsSuite) SetUpTest(c *C) {
 	s.recoveryKernelBf = bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 		"kernel.efi", bootloader.RoleRecovery)
 
-	s.seedKernelSnap = &seed.Snap{
-		Path: "/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
-		SideInfo: &snap.SideInfo{
-			RealName: "pc-kernel",
-			Revision: snap.Revision{N: 1},
-		},
-	}
+	s.seedKernelSnap = mockKernelSeedSnap(c, snap.R(1))
+	s.seedGadgetSnap = mockGadgetSeedSnap(c, nil)
 }
 
 func (s *systemsSuite) TestSetTryRecoverySystemEncrypted(c *C) {
@@ -135,7 +131,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemEncrypted(c *C) {
 		// the mock bootloader can only mock a single recovery boot
 		// chain, so pretend both seeds use the same kernel, but keep track of the labels
 		readSeedSeenLabels = append(readSeedSeenLabels, label)
-		return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+		return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 	})
 	defer restore()
 
@@ -327,7 +323,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorBeforeReseal(c *C) 
 			// called for the first system
 			c.Assert(label, Equals, "20200825")
 			c.Check(mtbl.SetBootVarsCalls, Equals, 1)
-			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 		case 2:
 			// called for the 'try' system
 			c.Assert(label, Equals, "1234")
@@ -350,7 +346,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorBeforeReseal(c *C) 
 			c.Assert(label, Equals, "20200825")
 			// boot variables already updated
 			c.Check(mtbl.SetBootVarsCalls, Equals, 2)
-			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 		default:
 			return nil, nil, fmt.Errorf("unexpected call %v", readSeedCalls)
 		}
@@ -424,7 +420,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorAfterReseal(c *C) {
 			// called for the first system
 			c.Assert(label, Equals, "20200825")
 			c.Check(mtbl.SetBootVarsCalls, Equals, 1)
-			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 		case 2:
 			// called for the 'try' system
 			c.Assert(label, Equals, "1234")
@@ -436,7 +432,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorAfterReseal(c *C) {
 			})
 			c.Check(mtbl.SetBootVarsCalls, Equals, 1)
 			// still good
-			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 		case 3:
 			// recovery boot chains for a good recovery system
 			c.Check(mtbl.SetBootVarsCalls, Equals, 1)
@@ -452,7 +448,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorAfterReseal(c *C) {
 			if readSeedCalls >= 4 {
 				c.Check(mtbl.SetBootVarsCalls, Equals, 2)
 			}
-			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 		default:
 			return nil, nil, fmt.Errorf("unexpected call %v", readSeedCalls)
 		}
@@ -532,12 +528,12 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupError(c *C) {
 		case 1:
 			// called for the first system
 			c.Assert(label, Equals, "20200825")
-			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 		case 2:
 			// called for the 'try' system
 			c.Assert(label, Equals, "1234")
 			// still good
-			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 		case 3:
 			// recovery boot chains for a good recovery system
 			fallthrough
@@ -548,7 +544,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupError(c *C) {
 		case 5:
 			// (cleanup) recovery boot chains for recovery keys
 			c.Assert(label, Equals, "20200825")
-			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+			return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 		default:
 			return nil, nil, fmt.Errorf("unexpected call %v", readSeedCalls)
 		}
@@ -743,7 +739,7 @@ func (s *systemsSuite) testClearRecoverySystem(c *C, mtbl *bootloadertest.MockTr
 		// the mock bootloader can only mock a single recovery boot
 		// chain, so pretend both seeds use the same kernel, but keep track of the labels
 		readSeedSeenLabels = append(readSeedSeenLabels, label)
-		return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+		return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 	})
 	defer restore()
 
@@ -950,7 +946,7 @@ func (s *systemsSuite) TestClearRecoverySystemReboot(c *C) {
 		// the mock bootloader can only mock a single recovery boot
 		// chain, so pretend both seeds use the same kernel, but keep track of the labels
 		readSeedSeenLabels = append(readSeedSeenLabels, label)
-		return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap}, nil
+		return s.uc20dev.Model(), []*seed.Snap{s.seedKernelSnap, s.seedGadgetSnap}, nil
 	})
 	defer restore()
 


### PR DESCRIPTION
Two patches that prepare the stage for the things to come. The first one adjusts the API of command line helpers to take a path to the gadget directory or snap. The next one loads the gadget from the recovery system seed.

Effectively nothing changes when the keys are (re-)sealed as the boot code does not load the command line from the snap yet.