### PR TITLE
boot: derive boot variables for kernel command lines

### DIFF
--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -100,7 +100,10 @@ func getBootloaderManagingItsAssets(where string, opts *bootloader.Options) (boo
 	return mbl, nil
 }
 
-func bootVarsForcommandLineFromGadget(gadgetSnap string) (map[string]string, error) {
+// bootVarsForTrustedCommandLineFromGadget returns a set of boot variables that
+// carry the command line arguments requested by the gadget. This is only useful
+// if snapd is managing the boot config.
+func bootVarsForTrustedCommandLineFromGadget(gadgetSnap string) (map[string]string, error) {
 	sf, err := snapfile.Open(gadgetSnap)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open gadget snap: %v", err)

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -26,8 +26,10 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -96,6 +98,34 @@ func getBootloaderManagingItsAssets(where string, opts *bootloader.Options) (boo
 		return nil, errBootConfigNotManaged
 	}
 	return mbl, nil
+}
+
+func bootVarsForcommandLineFromGadget(gadgetSnap string) (map[string]string, error) {
+	sf, err := snapfile.Open(gadgetSnap)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open gadget snap: %v", err)
+	}
+	extraOrFull, full, err := gadget.KernelCommandLineFromGadget(sf)
+	if err != nil {
+		if err == gadget.ErrNoKernelCommandline {
+			// nothing set by the gadget, but we could have had
+			// arguments before, so make sure those are cleared now
+			clear := map[string]string{
+				"snapd_extra_cmdline_args": "",
+			}
+			return clear, nil
+		}
+		return nil, fmt.Errorf("cannot use kernel command line from gadget: %v", err)
+	}
+	// gadget has the kernel command line
+	// TODO:UC20: support full command lines
+	if full {
+		return nil, fmt.Errorf("full kernel command line provided by the gadget is not supported yet")
+	}
+	args := map[string]string{
+		"snapd_extra_cmdline_args": extraOrFull,
+	}
+	return args, nil
 }
 
 const (

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -212,4 +213,53 @@ func (s *kernelCommandLineSuite) TestComposeCandidateRecoveryCommandLineManagedH
 	cmdline, err = boot.ComposeCandidateRecoveryCommandLine(model, "")
 	c.Assert(err, ErrorMatches, "internal error: system is unset")
 	c.Check(cmdline, Equals, "")
+}
+
+const gadgetSnapYaml = `name: gadget
+version: 1.0
+type: gadget
+`
+
+func (s *kernelCommandLineSuite) TestBootVarsForGadgetCommandLine(c *C) {
+	for _, tc := range []struct {
+		errMsg       string
+		files        [][]string
+		expectedVars map[string]string
+	}{{
+		files: [][]string{
+			{"cmdline.extra", "foo bar baz"},
+		},
+		expectedVars: map[string]string{"snapd_extra_cmdline_args": "foo bar baz"},
+	}, {
+		files: [][]string{
+			{"cmdline.extra", "snapd.debug=1"},
+		},
+		expectedVars: map[string]string{"snapd_extra_cmdline_args": "snapd.debug=1"},
+	}, {
+		files: [][]string{
+			{"cmdline.extra", "snapd_foo"},
+		},
+		errMsg: `cannot use kernel command line from gadget: disallowed kernel argument \"snapd_foo\" in cmdline.extra`,
+	}, {
+		// TODO: enable full command line override
+		files: [][]string{
+			{"cmdline.full", "unhappy"},
+		},
+		errMsg: `full kernel command line provided by the gadget is not supported yet`,
+	}, {
+		// with no arguments boot variables should be cleared
+		files:        [][]string{},
+		expectedVars: map[string]string{"snapd_extra_cmdline_args": ""},
+	}} {
+		sf := snaptest.MakeTestSnapWithFiles(c, gadgetSnapYaml, append([][]string{
+			{"meta/snap.yaml", gadgetSnapYaml},
+		}, tc.files...))
+		vars, err := boot.BootVarsForcommandLineFromGadget(sf)
+		if tc.errMsg == "" {
+			c.Assert(err, IsNil)
+			c.Assert(vars, DeepEquals, tc.expectedVars)
+		} else {
+			c.Assert(err, ErrorMatches, tc.errMsg)
+		}
+	}
 }

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -254,7 +254,7 @@ func (s *kernelCommandLineSuite) TestBootVarsForGadgetCommandLine(c *C) {
 		sf := snaptest.MakeTestSnapWithFiles(c, gadgetSnapYaml, append([][]string{
 			{"meta/snap.yaml", gadgetSnapYaml},
 		}, tc.files...))
-		vars, err := boot.BootVarsForcommandLineFromGadget(sf)
+		vars, err := boot.BootVarsForTrustedCommandLineFromGadget(sf)
 		if tc.errMsg == "" {
 			c.Assert(err, IsNil)
 			c.Assert(vars, DeepEquals, tc.expectedVars)

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -66,7 +66,7 @@ var (
 	RecoveryBootChainsForSystems    = recoveryBootChainsForSystems
 	SealKeyModelParams              = sealKeyModelParams
 
-	BootVarsForcommandLineFromGadget = bootVarsForcommandLineFromGadget
+	BootVarsForTrustedCommandLineFromGadget = bootVarsForTrustedCommandLineFromGadget
 )
 
 type BootAssetsMap = bootAssetsMap

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -65,6 +65,8 @@ var (
 	ResealKeyToModeenv              = resealKeyToModeenv
 	RecoveryBootChainsForSystems    = recoveryBootChainsForSystems
 	SealKeyModelParams              = sealKeyModelParams
+
+	BootVarsForcommandLineFromGadget = bootVarsForcommandLineFromGadget
 )
 
 type BootAssetsMap = bootAssetsMap


### PR DESCRIPTION
Introduce a helper that derives which boot variables must be set for gadget
provided kernel command line component
