### PR TITLE
boot, cmd/snap: include extra cmdline args in debug boot-vars output

### DIFF
--- a/boot/debug.go
+++ b/boot/debug.go
@@ -71,6 +71,7 @@ func DebugDumpBootVars(w io.Writer, dir string, uc20 bool) error {
 			"kernel_status",
 			"recovery_system_status",
 			"try_recovery_system",
+			"snapd_extra_cmdline_args",
 		}
 	}
 	bloader, err := bootloader.Find(dir, opts)

--- a/cmd/snap/cmd_debug_bootvars_test.go
+++ b/cmd/snap/cmd_debug_bootvars_test.go
@@ -122,6 +122,7 @@ snap_try_kernel=
 kernel_status=
 recovery_system_status=try
 try_recovery_system=9999
+snapd_extra_cmdline_args=
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	s.ResetStdStreams()


### PR DESCRIPTION
Include snapd_extra_cmdline_args in snap debug boot-vars output on UC20 systems.
