### PR TITLE
boot,gadget,devicestate: create "aux-key" for fde-hooks v2

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -265,6 +265,9 @@ type TrustedAssetsInstallObserver struct {
 
 	dataEncryptionKey secboot.EncryptionKey
 	saveEncryptionKey secboot.EncryptionKey
+
+	// XXX: auxEncryptionKey will be "nil" for the TPM case currently
+	auxEncryptionKey *secboot.AuxKey
 }
 
 // Observe observes the operation related to the content of a given gadget
@@ -342,6 +345,10 @@ func (o *TrustedAssetsInstallObserver) currentTrustedRecoveryBootAssetsMap() boo
 func (o *TrustedAssetsInstallObserver) ChosenEncryptionKeys(key, saveKey secboot.EncryptionKey) {
 	o.dataEncryptionKey = key
 	o.saveEncryptionKey = saveKey
+}
+
+func (o *TrustedAssetsInstallObserver) SetAuxKey(key *secboot.AuxKey) {
+	o.auxEncryptionKey = key
 }
 
 // TrustedAssetsUpdateObserverForModel returns a new trusted assets observer for

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -389,7 +389,7 @@ func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 
 	if sealer != nil {
 		// seal the encryption key to the parameters specified in modeenv
-		if err := sealKeyToModeenv(sealer.dataEncryptionKey, sealer.saveEncryptionKey, model, modeenv); err != nil {
+		if err := sealKeyToModeenv(sealer.dataEncryptionKey, sealer.saveEncryptionKey, sealer.auxEncryptionKey, model, modeenv); err != nil {
 			return err
 		}
 	}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -91,7 +91,7 @@ func recoveryBootChainsFileUnder(rootdir string) string {
 // sealKeyToModeenv seals the supplied keys to the parameters specified
 // in modeenv.
 // It assumes to be invoked in install mode.
-func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
+func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, auxKey *secboot.AuxKey, model *asserts.Model, modeenv *Modeenv) error {
 	// make sure relevant locations exist
 	for _, p := range []string{
 		InitramfsSeedEncryptionKeyDir,
@@ -110,10 +110,10 @@ func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, 
 		return fmt.Errorf("cannot check for fde-setup hook %v", err)
 	}
 	if hasHook {
-		return sealKeyToModeenvUsingFDESetupHook(key, saveKey, model, modeenv)
+		return sealKeyToModeenvUsingFDESetupHook(key, saveKey, auxKey, model, modeenv)
 	}
 
-	return sealKeyToModeenvUsingSecboot(key, saveKey, model, modeenv)
+	return sealKeyToModeenvUsingSecboot(key, saveKey, auxKey, model, modeenv)
 }
 
 func runKeySealRequests(key secboot.EncryptionKey) []secboot.SealKeyRequest {
@@ -141,7 +141,7 @@ func fallbackKeySealRequests(key, saveKey secboot.EncryptionKey) []secboot.SealK
 	}
 }
 
-func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
+func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, auxKey *secboot.AuxKey, model *asserts.Model, modeenv *Modeenv) error {
 	// TODO: support full boot chains
 
 	for _, skr := range append(runKeySealRequests(key), fallbackKeySealRequests(key, saveKey)...) {
@@ -166,7 +166,7 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 	return nil
 }
 
-func sealKeyToModeenvUsingSecboot(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
+func sealKeyToModeenvUsingSecboot(key, saveKey secboot.EncryptionKey, auxKey *secboot.AuxKey, model *asserts.Model, modeenv *Modeenv) error {
 	// build the recovery mode boot chain
 	rbl, err := bootloader.Find(InitramfsUbuntuSeedDir, &bootloader.Options{
 		Role: bootloader.RoleRecovery,

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -193,7 +193,7 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		})
 		defer restore()
 
-		err = boot.SealKeyToModeenv(myKey, myKey2, model, modeenv)
+		err = boot.SealKeyToModeenv(myKey, myKey2, nil, model, modeenv)
 		if tc.sealErr != nil {
 			c.Assert(sealKeysCalls, Equals, 1)
 		} else {
@@ -1344,7 +1344,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 	saveKey := secboot.EncryptionKey{5, 6, 7, 8}
 
 	model := boottest.MakeMockUC20Model()
-	err := boot.SealKeyToModeenv(key, saveKey, model, modeenv)
+	err := boot.SealKeyToModeenv(key, saveKey, nil, model, modeenv)
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way
 	c.Check(runFDESetupHookParams, DeepEquals, []*boot.FDESetupHookParams{
@@ -1386,7 +1386,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 	saveKey := secboot.EncryptionKey{5, 6, 7, 8}
 
 	model := boottest.MakeMockUC20Model()
-	err := boot.SealKeyToModeenv(key, saveKey, model, modeenv)
+	err := boot.SealKeyToModeenv(key, saveKey, nil, model, modeenv)
 	c.Assert(err, ErrorMatches, "hook failed")
 	marker := filepath.Join(dirs.SnapFDEDirUnder(boot.InstallHostWritableDir), "sealed-keys")
 	c.Check(marker, testutil.FileAbsent)

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -181,8 +181,24 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, device string, options Opti
 		}
 	}
 
+	// XXX: In the future we will always create the auxKey, for now
+	//      it is only used when using FDE
+	var auxKey *secboot.AuxKey
+	hasHook, err := boot.HasFDESetupHook()
+	if err != nil {
+		return nil, fmt.Errorf("cannot check for fde-hook: %v", err)
+	}
+	if options.Encrypt && hasHook {
+		k, err := secboot.NewAuxKey()
+		if err != nil {
+			return nil, fmt.Errorf("cannot create aux-key: %v", err)
+		}
+		auxKey = &k
+	}
+
 	return &InstalledSystemSideData{
 		KeysForRoles: keysForRoles,
+		AuxKey:       auxKey,
 	}, nil
 }
 

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -41,4 +41,7 @@ type EncryptionKeySet struct {
 type InstalledSystemSideData struct {
 	// KeysForRoles contains key sets for the relevant structure roles.
 	KeysForRoles map[string]*EncryptionKeySet
+
+	// The AuxKey is used system-wide
+	AuxKey *secboot.AuxKey
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -218,7 +218,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 
 		// make note of the encryption keys
 		trustedInstallObserver.ChosenEncryptionKeys(dataKeySet.Key, saveKeySet.Key)
-
+		trustedInstallObserver.SetAuxKey(installedSystem.AuxKey)
 		// keep track of recovery assets
 		if err := trustedInstallObserver.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir); err != nil {
 			return fmt.Errorf("cannot observe existing trusted recovery assets: err")

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -38,6 +38,9 @@ const (
 	//      github.com/snapcore/secboot/crypto.go:"type RecoveryKey"
 	// Size of the recovery key.
 	recoveryKeySize = 16
+
+	// The auxiliary key is used to bind keys to models
+	auxKeySize = 32
 )
 
 // EncryptionKey is the key used to encrypt the data partition.
@@ -98,4 +101,17 @@ func RecoveryKeyFromFile(recoveryKeyFile string) (*RecoveryKey, error) {
 		return nil, fmt.Errorf("cannot read recovery key: %v", err)
 	}
 	return &rkey, nil
+}
+
+// AuxKey is the key to bind models to keys
+//
+// Note that there is no Save() here as the read/write is done via secboot
+type AuxKey [auxKeySize]byte
+
+func NewAuxKey() (AuxKey, error) {
+	var key AuxKey
+	// rand.Read() is protected against short reads
+	_, err := rand.Read(key[:])
+	// On return, n == len(b) if and only if err == nil
+	return key, err
 }


### PR DESCRIPTION
The new secboot code will needs an additional key called "aux-key"
that is used to bind a model to the disk encryption key. This
commit creates such a key when we use FDE hooks and pases it
around from install to the fde-hook.

It also prepares for TPM to use the aux-key but it is not used
there yet.
