### PR TITLE
tests: update layout for tests - part 1

### DIFF
--- a/tests/main/apparmor-batch-reload/task.yaml
+++ b/tests/main/apparmor-batch-reload/task.yaml
@@ -1,7 +1,5 @@
 summary: Ensure that batch-reloading of AppArmor profiles works, including fallback.
 
-systems: [ubuntu-1*]
-
 details: |
     This test checks that apparmor profiles are re-generated on snapd startup in a batch,
     and that fallback logic of running apparmor parser for each individual snap takes
@@ -11,6 +9,8 @@ details: |
     The test checks system log for transient errors reported by snapd for apparmor failures
     and then verifies apparmor cache to ensure expected profiles were created by fallback
     logic.
+
+systems: [ubuntu-1*]
 
 environment:
     VARIANT/changed: changed

--- a/tests/main/auto-refresh-private/task.yaml
+++ b/tests/main/auto-refresh-private/task.yaml
@@ -1,14 +1,14 @@
 summary: Check that auto-refresh works with private snaps.
 
-# we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
-systems: [-ubuntu-core-*]
-
 details: |
     These tests rely on the existence of a snap in the remote store set to private.
 
     In order to do the full checks, it also needs the credentials of the owner of that
     snap set in the environment variables SPREAD_STORE_USER and SPREAD_STORE_PASSWORD, if
     they are not present then only the negative check is performed.
+
+# we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
+systems: [-ubuntu-core-*]
 
 restore: |
     snap logout || true

--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -1,4 +1,5 @@
 summary: A snap migrates from base "core" to "core18"
+
 environment:
     DIRECTION/forward: forward
     DIRECTION/back: back

--- a/tests/main/cgroup-devices/task.yaml
+++ b/tests/main/cgroup-devices/task.yaml
@@ -1,6 +1,6 @@
 summary: measuring basic properties of device cgroup
-# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which we don't support
 
+# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which we don't support
 systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-* ]
 
 execute: ./task.sh

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -1,12 +1,12 @@
 summary: Each snap process is moved to appropriate freezer cgroup
 
-# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which does not support
-# a separate freezer controller
-systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-*]
-
 details: |
     This test creates a snap process that suspends itself and ensures that it
     placed into the appropriate hierarchy under the freezer cgroup.
+
+# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which does not support
+# a separate freezer controller
+systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-*]
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh

--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -1,15 +1,18 @@
 summary: Each snap app and hook is tracked via cgroups
+
+details: |
+    This test creates a snap process that suspends itself and ensures that it
+    placed into the appropriate hierarchy.
+
 systems:
     # Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
     # This is covered in more depth in the sister cgroup-tracking-failure test.
     - -ubuntu-14.04-*
 
-details: |
-    This test creates a snap process that suspends itself and ensures that it
-    placed into the appropriate hierarchy.
 environment:
     USER/root: root
     USER/test: test
+
 prepare: |
     tests.cleanup prepare
 

--- a/tests/main/classic-confinement-not-supported/task.yaml
+++ b/tests/main/classic-confinement-not-supported/task.yaml
@@ -1,9 +1,9 @@
 summary: Ensure that classic confinement works
 
+systems: [ubuntu-core-*, fedora-*]
+
 environment:
     CLASSIC_SNAP: test-snapd-classic-confinement
-
-systems: [ubuntu-core-*, fedora-*]
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/classic-confinement/task.yaml
+++ b/tests/main/classic-confinement/task.yaml
@@ -1,10 +1,10 @@
 summary: Ensure that classic confinement works
 
-environment:
-    CLASSIC_SNAP: test-snapd-classic-confinement
-
 # Classic confinement isn't working yet on Fedora, Arch linux and Centos
 systems: [-ubuntu-core-*]
+
+environment:
+    CLASSIC_SNAP: test-snapd-classic-confinement
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -1,9 +1,9 @@
 summary: Check that prepare-image --classic works.
 
+backends: [-autopkgtest]
+
 # building images is only supported on classic ubuntu, but ubuntu 14.04 does not have systemd-run to perform the test
 systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*]
-
-backends: [-autopkgtest]
 
 environment:
     ROOT: /tmp/root

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -1,9 +1,9 @@
 summary: Check that prepare-image --classic works.
 
+backends: [-autopkgtest]
+
 # building images is only supported on classic ubuntu, but ubuntu 14.04 does not have systemd-run to perform the test
 systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*]
-
-backends: [-autopkgtest]
 
 environment:
     ROOT: /tmp/root

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -1,10 +1,10 @@
 summary: Check different completions
 
-# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
-
 # takes >6min to run in total
 backends: [-autopkgtest]
+
+# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
 environment:
     NAMES: /var/cache/snapd/names

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -1,12 +1,12 @@
 summary: trivial snap with classic confinement runs correctly
 
-systems: [-ubuntu-core-*]
-
 details: |
     This test checks that a very much trivial "hello-world"-like snap using
     classic confinement can be executed correctly. There are two variants of
     this test (classic and jailmode) and the snap (this particular one) should
     function correctly in both cases.
+
+systems: [-ubuntu-core-*]
 
 prepare: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/core18-with-hooks/task.yaml
+++ b/tests/main/core18-with-hooks/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensure that snaps with hooks work with base core18
 
+restore: |
+    snap remove --purge test-snapd-snapctl-core18
+
 execute: |
     # FIXME: we need at least beta of core18 for this to work
     snap install --beta core18
@@ -7,6 +10,3 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-snapctl-core18
 
     journalctl -u test-snapd-snapctl-core18.service
-
-restore: |
-    snap remove --purge test-snapd-snapctl-core18

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -1,11 +1,11 @@
 summary: Checks for snap create-key
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
 # amazon: requires extra gpg-agent setup
 systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -amazon-*, -centos-*]
-
-# slow in autopkgtest (>1m)
-backends: [-autopkgtest]
 
 prepare: |
     #shellcheck source=tests/lib/mkpinentry.sh

--- a/tests/main/cwd/task.yaml
+++ b/tests/main/cwd/task.yaml
@@ -13,6 +13,12 @@ prepare: |
 restore: |
     rmdir /tmp/test || true
 
+debug: |
+    # Much of what we do depends on permissions. If the permissions on those
+    # two essential (for this test) directories are wrong the test will
+    # misbehave.
+    ls -ld /root /var/lib/snapd/void
+
 execute: |
     # The current working directory that exists in the snap mount namespace and
     # represents the same inode is is preserved.
@@ -40,9 +46,3 @@ execute: |
     # place. The directory is sometimes created on demand so check for the
     # actual permissions at the end of the test.
     test "$(stat -c %a /var/lib/snapd/void)" = 111
-
-debug: |
-    # Much of what we do depends on permissions. If the permissions on those
-    # two essential (for this test) directories are wrong the test will
-    # misbehave.
-    ls -ld /root /var/lib/snapd/void

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -1,4 +1,5 @@
 summary: the desktop portal file choosers provide access to files
+
 details: |
     The xdg-desktop-portal file chooser interface provides a way for a
     confined application to request access to any file the user can
@@ -31,6 +32,14 @@ restore: |
     teardown_portals
     rm -f /tmp/file-to-read.txt
     rm -f /tmp/file-to-write.txt
+
+debug: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    ls -la "/run/user/$(id -u test)" || true
+    #shellcheck disable=SC2009
+    ps -ef | grep xdg || true
 
 execute: |
     echo "Install the portals test client"
@@ -68,11 +77,3 @@ execute: |
     # contents are not visible in the destination file.
     retry -n 5 test -s /tmp/file-to-write.txt
     MATCH "from-sandbox" < /tmp/file-to-write.txt
-
-debug: |
-    #shellcheck source=tests/lib/desktop-portal.sh
-    . "$TESTSLIB"/desktop-portal.sh
-
-    ls -la "/run/user/$(id -u test)" || true
-    #shellcheck disable=SC2009
-    ps -ef | grep xdg || true

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -1,4 +1,5 @@
 summary: the desktop portal allows confined apps to open local files
+
 details: |
     The xdg-desktop-portal "Open URI" interface provides a way for
     confined applications to open local files using the associated
@@ -46,6 +47,15 @@ restore: |
     rm -f ~test/.local/share/applications/test-editor.desktop
     rm -f "$EDITOR_HISTORY"
 
+debug: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    ls -la "/run/user/$(id -u test)" || true
+    #shellcheck disable=SC2009
+    ps -ef | grep xdg || true
+
+
 execute: |
     echo "Install the portals test client"
     snap install --edge test-snapd-portal-client
@@ -63,11 +73,3 @@ execute: |
     echo "The test-browser process was invoked with the URL"
     retry -n 4 --wait 0.5 test -e "$EDITOR_HISTORY"
     MATCH "$testfile" < "$EDITOR_HISTORY"
-
-debug: |
-    #shellcheck source=tests/lib/desktop-portal.sh
-    . "$TESTSLIB"/desktop-portal.sh
-
-    ls -la "/run/user/$(id -u test)" || true
-    #shellcheck disable=SC2009
-    ps -ef | grep xdg || true

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -1,4 +1,5 @@
 summary: the desktop portal allows confined apps to open URIs
+
 details: |
     The xdg-desktop-portal "Open URI" interface provides a way for
     confined applications to open URIs using the host system's
@@ -43,6 +44,14 @@ restore: |
     rm -f ~test/.local/share/applications/test-browser.desktop
     rm -f "$BROWSER_HISTORY"
 
+debug: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    ls -la "/run/user/$(id -u test)" || true
+    #shellcheck disable=SC2009
+    ps -ef | grep xdg || true
+
 execute: |
     echo "Install the portals test client"
     snap install --edge test-snapd-portal-client
@@ -53,11 +62,3 @@ execute: |
     echo "The test-browser process was invoked with the URL"
     retry -n 4 --wait 0.5 test -e "$BROWSER_HISTORY"
     MATCH http://www.example.org < "$BROWSER_HISTORY"
-
-debug: |
-    #shellcheck source=tests/lib/desktop-portal.sh
-    . "$TESTSLIB"/desktop-portal.sh
-
-    ls -la "/run/user/$(id -u test)" || true
-    #shellcheck disable=SC2009
-    ps -ef | grep xdg || true

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -1,4 +1,5 @@
 summary: the desktop portal screenshot API works for snap applications
+
 details: |
     The xdg-desktop-portal screenshot interface provides a way for
     confined applications to take screenshots with the consent of the
@@ -35,6 +36,14 @@ restore: |
     teardown_portals
     rm -f /tmp/screenshot.txt
 
+debug: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    ls -la "/run/user/$(id -u test)" || true
+    #shellcheck disable=SC2009
+    ps -ef | grep xdg || true
+
 execute: |
     echo "Install the portals test client"
     snap install --edge test-snapd-portal-client
@@ -46,11 +55,3 @@ execute: |
     # AppArmor policy uses the @owner restriction.
     chown test:test /tmp/screenshot.txt
     tests.session -u test exec test-snapd-portal-client screenshot | MATCH "my screenshot"
-
-debug: |
-    #shellcheck source=tests/lib/desktop-portal.sh
-    . "$TESTSLIB"/desktop-portal.sh
-
-    ls -la "/run/user/$(id -u test)" || true
-    #shellcheck disable=SC2009
-    ps -ef | grep xdg || true

--- a/tests/main/dirs-not-shared-with-host/task.yaml
+++ b/tests/main/dirs-not-shared-with-host/task.yaml
@@ -7,12 +7,12 @@ details: |
   are actually, bind-mounted from the core snap for a more
   consistent behaviour across various distributions.
 
-environment:
-    DIRECTORY/apparmord: /etc/apparmor.d
-
 # This test only applies to classic systems
 # fedora, centos, amazon: do not have /etc/apparmor.d
 systems: [-ubuntu-core-*, -fedora-*, -centos-*, -amazon-linux-*]
+
+environment:
+    DIRECTORY/apparmord: /etc/apparmor.d
 
 prepare: |
     echo "Having installed the test snap"

--- a/tests/main/disk-space-awareness/task.yaml
+++ b/tests/main/disk-space-awareness/task.yaml
@@ -1,11 +1,11 @@
 summary: Check that basic snap operation are aware of low disk space.
 
-# this test is remounts /var/lib/snapd which is too intrusive for core.
-systems: [-ubuntu-core-*]
-
 details: |
   Check that operations such as snap installation or snap removal (with an
   automatic snapshot) error out early if there is not enough disk space.
+
+# this test is remounts /var/lib/snapd which is too intrusive for core.
+systems: [-ubuntu-core-*]
 
 environment:
   TMPFSMOUNT: /var/lib/snapd

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -1,4 +1,5 @@
 summary: Check that the document portal is activated when needed
+
 details: |
     In order for xdg-document-portal to securely share files with a
     confined applications, it must be started prior to setting up the

--- a/tests/main/download-timeout/task.yaml
+++ b/tests/main/download-timeout/task.yaml
@@ -24,6 +24,14 @@ prepare: |
   systemctl daemon-reload
   systemctl restart snapd.{socket,service}
 
+restore: |
+  tc filter del dev ens4
+  tc qdisc del dev ens4 ingress
+
+  rm -f "$OVERRIDES_FILE"
+  systemctl daemon-reload
+  systemctl restart snapd.{socket,service}
+
 execute: |
   tc qdisc add dev ens4 ingress
   tc filter add dev ens4 root protocol ip u32 match u32 0 0 police rate 32kbit burst 16k drop flowid :1
@@ -34,11 +42,3 @@ execute: |
 
   echo "Downloading a large snap fails too"
   snap download lxd 2>&1 | MATCH "download too slow:"
-
-restore: |
-  tc filter del dev ens4
-  tc qdisc del dev ens4 ingress
-
-  rm -f "$OVERRIDES_FILE"
-  systemctl daemon-reload
-  systemctl restart snapd.{socket,service}

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -3,16 +3,6 @@ summary: Ensure that ECONNRESET is handled
 # no iptables on core18+
 systems: [-ubuntu-core-18-*, -ubuntu-core-2*]
 
-debug: |
-    echo "Partial download status"
-    ls -lh test-snapd-huge_* || true
-    echo "other dir content"
-    ls -lh
-    echo "download log:"
-    cat snap-download.log
-    echo "iptables rules and counters"
-    iptables -L -n -v
-
 restore: |
     echo "Stop the snap download command"
     kill -9 "$(pgrep -f 'snap download')" || true
@@ -22,6 +12,16 @@ restore: |
     echo "Remove ingress traffic policing rule"
     iptables -D INPUT -p tcp --match hashlimit --hashlimit-mode srcip,dstip,srcport,dstport --hashlimit-above 512kb/s \
              --hashlimit-name 'econnreset' -j DROP
+
+debug: |
+    echo "Partial download status"
+    ls -lh test-snapd-huge_* || true
+    echo "other dir content"
+    ls -lh
+    echo "download log:"
+    cat snap-download.log
+    echo "iptables rules and counters"
+    iptables -L -n -v
 
 execute: |
     echo "Downloading a large snap in the background"

--- a/tests/main/experimental-features/task.yaml
+++ b/tests/main/experimental-features/task.yaml
@@ -1,8 +1,10 @@
 summary: Experimental features are exported by snapd
+
 details: |
     Some of the experimental features are exported as flag files that can be
     easily read by snap-confine and snap-update-ns that otherwise don't have
     access to the system state.
+
 execute: |
     # When a feature that is exported is enabled, a file is created.
     snap set core experimental.per-user-mount-namespace=true

--- a/tests/main/fake-netplan-apply/task.yaml
+++ b/tests/main/fake-netplan-apply/task.yaml
@@ -3,9 +3,6 @@ summary: Ensure that netplan apply works with network-setup-control
 details: |
     Netplan apply is used to apply network configuration to the system
 
-environment:
-    NETPLAN: io.netplan.Netplan
-
 # Only run on ubuntu lts's which match ubuntu core series
 # We don't run this test on core since there we can't setup the fake dbus
 # service there, but we have a core specific spread test in tests/core/netplan
@@ -20,6 +17,9 @@ systems:
     - ubuntu-16.04*
     - ubuntu-18.04*
     - ubuntu-20.04*
+
+environment:
+    NETPLAN: io.netplan.Netplan
 
 prepare: |
     # build the netplan snap for this system

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -1,8 +1,5 @@
 summary: Check that find works with private snaps.
 
-# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-systems: [-ubuntu-*-ppc64el]
-
 details: |
     These tests rely on the existence of a snap in the remote store set to private.
 
@@ -12,11 +9,13 @@ details: |
     the find results without specifying private search or without the owner logged) is
     performed.
 
+# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
+systems: [-ubuntu-*-ppc64el]
+
 restore: |
     snap logout || true
 
 execute: |
-
     echo "When a snap is private it doesn't show up in the find without login and without specifying private search"
     snap find test-snapd-private | not MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
 

--- a/tests/main/help/task.yaml
+++ b/tests/main/help/task.yaml
@@ -1,6 +1,6 @@
 summary: Check commands help
 
-systems: [+fedora-*]
+systems: [fedora-*]
 
 execute: |
     bad=""

--- a/tests/main/install-fontconfig-cache-gen/task.yaml
+++ b/tests/main/install-fontconfig-cache-gen/task.yaml
@@ -4,11 +4,6 @@ summary: Check that install works
 # to install so that actual caches get generated
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64]
 
-debug: |
-    ls -lah /var/cache/fontconfig/
-    dpkg-reconfigure fontconfig
-    ls -lah /var/cache/fontconfig/
-
 prepare: |
     if os.query is-xenial; then
         PKG=fonts-kiloji
@@ -33,6 +28,11 @@ restore: |
     fi
 
     apt autoremove -y "$PKG" || true
+
+debug: |
+    ls -lah /var/cache/fontconfig/
+    dpkg-reconfigure fontconfig
+    ls -lah /var/cache/fontconfig/
 
 execute: |
     if os.query is-xenial; then

--- a/tests/main/interfaces-alsa/task.yaml
+++ b/tests/main/interfaces-alsa/task.yaml
@@ -1,8 +1,5 @@
 summary: Ensure that the alsa interface works.
 
-# Spread system for Fedora, openSUSE and AMZN2 don't seem to provide any /dev/snd entries
-systems: [-fedora-*, -opensuse-*, -amazon-*, -centos-*]
-
 details: |
     The alsa interface allows connected plugs to access raw ALSA devices.
 
@@ -15,6 +12,9 @@ details: |
     specific devices under /dev/snd, a cgroup if needed and the ALSA state dir,
     exercising in each caase the read or read-write permissions that must be in
     place.
+
+# Spread system for Fedora, openSUSE and AMZN2 don't seem to provide any /dev/snd entries
+systems: [-fedora-*, -opensuse-*, -amazon-*, -centos-*]
 
 prepare: |
     echo "Given a snap declaring a plug on the alsa interface is installed"

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -86,6 +86,9 @@ prepare: |
     # reload user's systemd instance
     tests.session -u test exec systemctl daemon-reload --user
 
+restore: |
+    tests.cleanup restore
+
 debug: |
     echo "Files present in the test user's home directory"
     test -d /home/test && find /home/test
@@ -97,9 +100,6 @@ debug: |
     ps -u test
     echo "Pulseaudio log"
     tests.session -u test exec journalctl --user -u pulseaudio.service || true
-
-restore: |
-    tests.cleanup restore
 
 execute: |
     echo "The unconfined user can play audio"

--- a/tests/main/interfaces-broadcom-asic-control/task.yaml
+++ b/tests/main/interfaces-broadcom-asic-control/task.yaml
@@ -1,14 +1,14 @@
 summary: Ensure that the broadcom-asic-control interface works.
 
+details: |
+    The broadcom-asic-control interface allow access to broadcom asic kernel module.
+
 # We need to run the broadcom-asic-control test very early. The reason is
 # that this test will modprobe linux-*-bde which will try to allocate a
 # huge page. One the system ran for a while no chunk of memory like this
 # will be not be available and the kernel will oops with:
 #   "modprobe: page allocation failure: order:7, mode:0xxxx"
 priority: 200
-
-details: |
-    The broadcom-asic-control interface allow access to broadcom asic kernel module.
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -1,5 +1,14 @@
 summary: Ensure that the calendar-service interface works
 
+# fails in the autopkgtest env with:
+# [Wed Aug 15 16:34:12 2018] audit: type=1400
+# audit(1534350852.923:58499): apparmor="DENIED" operation="connect"
+# profile="snap.test-snapd-eds.calendar" pid=19219 comm="calendar"
+# family="unix" sock_type="stream" protocol=0 requested_mask="send
+# receive connect" denied_mask="send connect" addr=none
+# peer_addr="@/tmp/dbus-5FUilMiW8U" peer="unconfined"
+backends: [-autopkgtest]
+
 # Only test on classic systems.  Don't test on Ubuntu 14.04, which
 # does not ship a new enough evolution-data-server. Don't test on AMZN2.
 #
@@ -21,15 +30,6 @@ systems:
     - -ubuntu-14.04-*  # no tests.session support, eds is too old
     - -ubuntu-2*  # test-snapd-eds is incompatible with eds shipped with the distro
     - -ubuntu-core-*  # EDS is unsupported on core systems
-
-# fails in the autopkgtest env with:
-# [Wed Aug 15 16:34:12 2018] audit: type=1400
-# audit(1534350852.923:58499): apparmor="DENIED" operation="connect"
-# profile="snap.test-snapd-eds.calendar" pid=19219 comm="calendar"
-# family="unix" sock_type="stream" protocol=0 requested_mask="send
-# receive connect" denied_mask="send connect" addr=none
-# peer_addr="@/tmp/dbus-5FUilMiW8U" peer="unconfined"
-backends: [-autopkgtest]
 
 prepare: |
     tests.session -u test prepare

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -1,5 +1,14 @@
 summary: Ensure that the contacts-service interface works
 
+# fails in autopkgtest environment with:
+# [Wed Aug 15 16:08:23 2018] audit: type=1400
+# audit(1534349304.173:1681): apparmor="DENIED" operation="connect"
+# profile="snap.test-snapd-eds.contacts" pid=18321 comm="contacts"
+# family="unix" sock_type="stream" protocol=0 requested_mask="send
+# receive connect" denied_mask="send connect" addr=none
+# peer_addr="@/tmp/dbus-GZTRALrYYm" peer="unconfined"
+backends: [-autopkgtest]
+
 # TODO: teach snapd about host's EDS support so that the interface can be
 # genuinely unsupported or versioned and tested appropriately.
 systems:
@@ -14,15 +23,6 @@ systems:
     - -ubuntu-14.04-*  # no tests.session support, eds is too old
     - -ubuntu-2*  # test-snapd-eds is incompatible with eds shipped with the distro
     - -ubuntu-core-*  # EDS is unsupported on core systems
-
-# fails in autopkgtest environment with:
-# [Wed Aug 15 16:08:23 2018] audit: type=1400
-# audit(1534349304.173:1681): apparmor="DENIED" operation="connect"
-# profile="snap.test-snapd-eds.contacts" pid=18321 comm="contacts"
-# family="unix" sock_type="stream" protocol=0 requested_mask="send
-# receive connect" denied_mask="send connect" addr=none
-# peer_addr="@/tmp/dbus-GZTRALrYYm" peer="unconfined"
-backends: [-autopkgtest]
 
 prepare: |
     tests.session -u test prepare

--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -1,8 +1,5 @@
 summary: Ensure that the content sharing interface works.
 
-# slow in autopkgtest (>4m)
-backends: [-autopkgtest]
-
 details: |
     The content-sharing interface interface allows a snap to access contents from
     other snap
@@ -10,6 +7,9 @@ details: |
     A snap which defines the content sharing plug must be shown in the interfaces list.
     The plug must be autoconnected on install and, as usual, must be able to be
     reconnected.
+
+# slow in autopkgtest (>4m)
+backends: [-autopkgtest]
 
 # This test purges the state which causes the device to reinitialize
 # with (potentially) a different core snap. Running this on core will

--- a/tests/main/interfaces-cups/task.yaml
+++ b/tests/main/interfaces-cups/task.yaml
@@ -1,12 +1,12 @@
 summary: Ensure that the cups interfaces work with app providers
 
-systems: [ubuntu-*]
-
 details: |
     A snap providing the cups-control and cups interfaces should be able to
     create the control socket, with connecting consuming snaps able to use it.
     This intentionally does not test the mediation properties of the cupsd
     server.
+
+systems: [ubuntu-*]
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-provider

--- a/tests/main/interfaces-daemon-notify/task.yaml
+++ b/tests/main/interfaces-daemon-notify/task.yaml
@@ -2,12 +2,13 @@
 # https://forum.snapcraft.io/t/its-a-little-bit-hard-to-use-daemon-notify-for-sd-notify/6366
 summary: Ensure that the daemon-notify interface works.
 
-# test is timing dependant and may fail on very slow systems
-backends: [-autopkgtest]
-
 details: |
     The daemon-notify interface allows sending notification messages 
     to systemd through the notify socket
+
+
+# test is timing dependant and may fail on very slow systems
+backends: [-autopkgtest]
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-daemon-notify

--- a/tests/main/interfaces-desktop-host-fonts/task.yaml
+++ b/tests/main/interfaces-desktop-host-fonts/task.yaml
@@ -11,15 +11,6 @@ systems:
     - -ubuntu-14.04-*
     - -ubuntu-core-*
 
-restore: |
-    tests.session -u test restore
-    rm -f /usr/share/fonts/dist-font.txt
-    rm -f /usr/local/share/fonts/local-font.txt
-    rm -f /home/test/.fonts/user-font1.txt
-    rm -f /home/test/.local/share/fonts/user-font2.txt
-    rm -f /var/cache/fontconfig/cache.txt
-    rm -f /usr/lib/fontconfig/cache/cache.txt
-
 prepare: |
     tests.session -u test prepare
 
@@ -46,6 +37,15 @@ prepare: |
 
     echo "Install the test-snapd-desktop snap"
     snap try "$TESTSLIB"/snaps/test-snapd-desktop
+
+restore: |
+    tests.session -u test restore
+    rm -f /usr/share/fonts/dist-font.txt
+    rm -f /usr/local/share/fonts/local-font.txt
+    rm -f /home/test/.fonts/user-font1.txt
+    rm -f /home/test/.local/share/fonts/user-font2.txt
+    rm -f /var/cache/fontconfig/cache.txt
+    rm -f /usr/lib/fontconfig/cache/cache.txt
 
 execute: |
     echo "The plug is connected by default"

--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -1,8 +1,5 @@
 summary: Ensure that the firewall-control interface works.
 
-# ubuntu-14.04: systemd-run not supported
-systems: [-fedora-*, -opensuse-*, -arch-*, -ubuntu-14.04*]
-
 details: |
     The firewall-control interface allows a snap to configure the firewall.
 
@@ -15,6 +12,9 @@ details: |
     localhost to a given IP can be added by the snap, ensuring that a generic client can
     access a generic service listening on localhost through the IP set up in the firewall
     rule.
+
+# ubuntu-14.04: systemd-run not supported
+systems: [-fedora-*, -opensuse-*, -arch-*, -ubuntu-14.04*]
 
 environment:
     PORT: 8081

--- a/tests/main/interfaces-hardware-random-control/task.yaml
+++ b/tests/main/interfaces-hardware-random-control/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that the hardware-random-control interface works.
 
-summary: |
+details: |
     The hardware-observe interface allows a snap to access hardware-random information.
 
     A snap which access to the hardware-random information must be shown in the interfaces list.

--- a/tests/main/interfaces-hardware-random-observe/task.yaml
+++ b/tests/main/interfaces-hardware-random-observe/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that the hardware-random-observe interface works.
 
-summary: |
+details: |
     The hardware-observe interface allows a snap to access hardware-random information.
 
     A snap which access to the hardware-random information must be shown in the interfaces list.

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -1,12 +1,5 @@
 summary: Ensure that the kernel-module-control interface works.
 
-# the s390x kernel has no minix module
-systems: [-fedora-*, -opensuse-*, -ubuntu-*-s390x, -arch-*, -amazon-*, -centos-*]
-
-environment:
-    MODULE: minix
-    MODULE_PATH: /lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko
-
 details: |
     The kernel-module-control interface allows insertion, removal and querying
     of modules.
@@ -17,6 +10,13 @@ details: |
 
     A snap declaring a plug on this interface must be able to list the modules
     loaded, insert and remove a module. For the test we use the $MODULE module.
+
+# the s390x kernel has no minix module
+systems: [-fedora-*, -opensuse-*, -ubuntu-*-s390x, -arch-*, -amazon-*, -centos-*]
+
+environment:
+    MODULE: minix
+    MODULE_PATH: /lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko
 
 prepare: |
     echo "Given a snap declaring a plug on the kernel-module-control interface is installed"

--- a/tests/main/interfaces-locale-control/task.yaml
+++ b/tests/main/interfaces-locale-control/task.yaml
@@ -1,8 +1,6 @@
 summary: Ensure that the locale-control interface works.
 
-systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
-
-summary: |
+details: |
     The locale-control interface allows a snap to access the locale configuration.
 
     A snap which defines the locale-control plug must be shown in the interfaces list.
@@ -11,6 +9,8 @@ summary: |
 
     A snap declaring a plug on this interface must be able to access the /etc/default/locale
     file both for reading and writing. This path doesn't exist on the excluded distributions.
+
+systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
 
 prepare: |
     if os.query is-core; then

--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -6,6 +6,9 @@ details: |
     functionality itself). This will help catch things like AppArmor 
     policy syntax errors, seccomp policy parsing, udev querying bugs, etc.
 
+# memory issue inside the adt environment
+backends: [-autopkgtest]
+
 # Ideally we would run this everywhere, but on systems with full security
 # support, it takes a while, which leads to travis timeouts. Limit to:
 # - Ubuntu Core 16 amd64
@@ -18,19 +21,11 @@ details: |
 # - TODO: All Fedora systems (for classic-only; unrelated error elsewhere)
 systems: [ubuntu-core-1*-64, ubuntu-14.04-32, ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-18.04-32, ubuntu-*-amd64, ubuntu-*-armhf, ubuntu-*-arm64, ubuntu-*-i386, ubuntu-*-ppc64el, debian-*]
 
-# memory issue inside the adt environment
-backends: [-autopkgtest]
-
 # Start early as it takes a long time.
 priority: 100
 
 environment:
     CONSUMER_SNAP: test-snapd-policy-app-consumer
-
-debug: |
-    # get the full journal to see any out-of-memory errors
-    # shellcheck disable=SC2119
-    "$TESTSTOOLS"/journal-state get-log
 
 prepare: |
     echo "Given a snap is installed"
@@ -50,6 +45,11 @@ restore: |
     if tests.session has-session-systemd-and-dbus; then
         tests.session -u test restore
     fi
+
+debug: |
+    # get the full journal to see any out-of-memory errors
+    # shellcheck disable=SC2119
+    "$TESTSTOOLS"/journal-state get-log
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/interfaces-many-snap-provided/task.yaml
+++ b/tests/main/interfaces-many-snap-provided/task.yaml
@@ -6,6 +6,9 @@ details: |
     functionality itself). This will help catch things like AppArmor 
     policy syntax errors, seccomp policy parsing, udev querying bugs, etc.
 
+# memory issue inside the adt environment
+backends: [-autopkgtest]
+
 # Ideally we would run this everywhere, but on systems with full security
 # support, it takes a while, which leads to travis timeouts. Limit to:
 # - Ubuntu Core 16 amd64
@@ -18,19 +21,11 @@ details: |
 # - TODO: All Fedora systems (for classic-only; unrelated error elsewhere)
 systems: [ubuntu-core-1*-64, ubuntu-14.04-32, ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-18.04-32, ubuntu-*-amd64, ubuntu-*-armhf, ubuntu-*-arm64, ubuntu-*-i386, ubuntu-*-ppc64el, debian-*]
 
-# memory issue inside the adt environment
-backends: [-autopkgtest]
-
 # Start early as it takes a long time.
 priority: 100
 
 environment:
     CONSUMER_SNAP: test-snapd-policy-app-consumer
-
-debug: |
-    # get the full journal to see any out-of-memory errors
-    # shellcheck disable=SC2119
-    "$TESTSTOOLS"/journal-state get-log
 
 restore: |
     # Remove the snaps to avoid timeout in next test
@@ -40,6 +35,11 @@ restore: |
     fi
     snap remove --purge "$PROVIDER_SNAP"
     snap remove --purge "$CONSUMER_SNAP"
+
+debug: |
+    # get the full journal to see any out-of-memory errors
+    # shellcheck disable=SC2119
+    "$TESTSTOOLS"/journal-state get-log
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/interfaces-network-observe/task.yaml
+++ b/tests/main/interfaces-network-observe/task.yaml
@@ -1,8 +1,5 @@
 summary: Ensure that the network-observe interface works
 
-# ubuntu-14.04: systemd-run not supported
-systems: [-fedora-*, -opensuse-*, -ubuntu-14.04*]
-
 details: |
     The network-observe interface allows a snap to query the network status information.
 
@@ -12,6 +9,9 @@ details: |
 
     A snap declaring a plug on this interface must be able to access read the network status,
     the test sets up a network service to establish a known state in the network to be queried.
+
+# ubuntu-14.04: systemd-run not supported
+systems: [-fedora-*, -opensuse-*, -ubuntu-14.04*]
 
 environment:
     PORT: 8081

--- a/tests/main/interfaces-packagekit-control/task.yaml
+++ b/tests/main/interfaces-packagekit-control/task.yaml
@@ -8,6 +8,9 @@ systems:
     # PackageKit is buggy https://bugzilla.redhat.com/show_bug.cgi?id=1807864
     - -centos-8-*
 
+restore: |
+    snap remove --purge test-snapd-packagekit
+
 execute: |
     echo "Installing test-snapd-packagekit"
     snap install --edge test-snapd-packagekit
@@ -26,6 +29,3 @@ execute: |
     echo "With the plug connected it is possible to communicate with packagekit"
     test-snapd-packagekit.pkcon backend-details | MATCH "Name:"
     test-snapd-packagekit.pkcon resolve snapd | MATCH "Installed[[:space:]]+snapd"
-
-restore: |
-    snap remove --purge test-snapd-packagekit

--- a/tests/main/interfaces-process-control/task.yaml
+++ b/tests/main/interfaces-process-control/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that the process-control interface works.
 
-summary: |
+details: |
     The process-control interface allows a snap to control other processes via signals
     and nice.
 

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -84,6 +84,9 @@ prepare: |
     # reload user's systemd instance
     tests.session -u test exec systemctl daemon-reload --user
 
+restore: |
+    tests.cleanup restore
+
 debug: |
     echo "Files present in the test user's home directory"
     test -d /home/test && find /home/test
@@ -95,9 +98,6 @@ debug: |
     ps -u test
     echo "Pulseaudio log"
     tests.session -u test exec journalctl --user -u pulseaudio.service || true
-
-restore: |
-    tests.cleanup restore
 
 execute: |
     echo "The unconfined user can play audio"

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -1,12 +1,12 @@
 summary: Ensures that introspection of login1 of the shutdown interface works.
 
-#debian: no confinement (AppArmor, Seccomp) available on these systems
-#ubuntu-core: unity7 implicit classic slot needed (used to access dbus-send) not available on core
-systems: [-debian-*, -ubuntu-core-*]
-
 details: |
     A snap declaring the shutdown plug is defined, its command just calls
     the Introspect method on org.freedesktop.login1.
+
+#debian: no confinement (AppArmor, Seccomp) available on these systems
+#ubuntu-core: unity7 implicit classic slot needed (used to access dbus-send) not available on core
+systems: [-debian-*, -ubuntu-core-*]
 
 prepare: |
     echo "Given a snap declaring a plug on the shutdown interface is installed"

--- a/tests/main/interfaces-system-observe/task.yaml
+++ b/tests/main/interfaces-system-observe/task.yaml
@@ -1,8 +1,5 @@
 summary: Ensures that the system-observe interface works.
 
-# on s390x we do not have a serial port to observe
-systems: [-ubuntu-*-s390x]
-
 details: |
     A snap declaring the system-observe plug is defined, its command
     just calls ps -ax.
@@ -10,6 +7,9 @@ details: |
     The test itself checks for the lack of autoconnect and then tries
     to execute the snap command with the plug connected (it must succeed)
     and disconnected (it must fail).
+
+# on s390x we do not have a serial port to observe
+systems: [-ubuntu-*-s390x]
 
 prepare: |
     echo "Given a snap declaring a plug on the system-observe interface is installed"

--- a/tests/main/interfaces-system-packages-doc/task.yaml
+++ b/tests/main/interfaces-system-packages-doc/task.yaml
@@ -1,14 +1,18 @@
 summary: Ensure that the system-packages-doc interface works.
+
 systems: [-ubuntu-core-*]
+
 prepare: |
     snap pack test-snapd-app
     snap install --dangerous ./test-snapd-app_1_all.snap
     mkdir -p /usr/share/doc/system-packages-doc-iface
     echo text >/usr/share/doc/system-packages-doc-iface/content
+
 restore: |
     snap remove --purge test-snapd-app
     rm -f test-snapd-app_1_all.snap
     rm -rf /usr/share/doc/system-packages-doc-iface
+
 execute: |
     # The interface is not auto-connected
     not test-snapd-app.sh -c 'test -e /usr/share/doc/system-packages-doc-iface/content'

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -8,12 +8,12 @@ details: |
 #   Object /org/freedesktop/UDisks2/block_devices/loop200 is not a mountable filesystem.
 systems: [-ubuntu-core-*, -arch-linux-*]
 
-prepare: |
-    snap install test-snapd-udisks2
-
 environment:
     FS_PATH: "$(pwd)/dev0-fake0"
     MMCBLK_PATH: /dev/mmcblk-fake0
+
+prepare: |
+    snap install test-snapd-udisks2
 
 restore: |
     losetup -d "$MMCBLK_PATH" || true

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -8,6 +8,11 @@ details: |
 # TODO: enable for ubuntu-21+ once the lxd image is published
 systems: [ubuntu-20*]
 
+restore: |
+    lxd.lxc stop ubuntu --force || true
+    lxd.lxc delete ubuntu || true
+    snap remove --purge lxd
+
 execute: |
     echo "Install lxd"
     snap install lxd
@@ -60,8 +65,3 @@ execute: |
         echo "Actual: $MOUNT_OPTS"
         exit 1
     fi
-
-restore: |
-    lxd.lxc stop ubuntu --force || true
-    lxd.lxc delete ubuntu || true
-    snap remove --purge lxd

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -3,6 +3,11 @@ summary: Check that we give a useful error when fuse is missing in lxd
 # we just need a single system to verify this
 systems: [ubuntu-18.04-64]
 
+restore: |
+    lxc delete --force my-ubuntu
+    snap remove ---purge lxd
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
+
 execute: |
     echo "Ensure we use the snap"
     apt autoremove -y lxd
@@ -49,8 +54,3 @@ execute: |
         exit 1
     fi
     MATCH 'The "fuse" filesystem is required' < err.txt
-
-restore: |
-    lxc delete --force my-ubuntu
-    snap remove ---purge lxd
-    "$TESTSTOOLS"/lxd-state undo-mount-changes

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -2,6 +2,11 @@ summary: Check that try command works inside lxd container
 
 systems: [ubuntu-20.04-*, ubuntu-20.10-*]
 
+restore: |
+  lxd.lxc stop ubuntu --force || true
+  lxd.lxc delete ubuntu || true
+  snap remove --purge lxd
+
 prepare: |
   echo "Install lxd"
   snap install lxd
@@ -36,8 +41,3 @@ prepare: |
 execute: |
   lxd.lxc exec ubuntu -- snap try /root/test-snapd-tools
   lxd.lxc exec ubuntu -- snap list | MATCH '^test-snapd-tools .* try'
-
-restore: |
-  lxd.lxc stop ubuntu --force || true
-  lxd.lxc delete ubuntu || true
-  snap remove --purge lxd

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -1,13 +1,13 @@
 summary: Ensure that lxd works
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
 # TODO: enable for ubuntu-21+ once the lxd image is published
 systems: [ubuntu-16*, ubuntu-18*, ubuntu-20*, ubuntu-core-*]
-
-# autopkgtest run only a subset of tests that deals with the integration
-# with the distro
-backends: [-autopkgtest]
 
 # lxd downloads can be quite slow
 kill-timeout: 25m

--- a/tests/main/media-sharing/task.yaml
+++ b/tests/main/media-sharing/task.yaml
@@ -14,13 +14,6 @@ prepare: |
     mkdir -p ${MEDIA_DIR}/dst
     touch ${MEDIA_DIR}/src/canary
 
-execute: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-    test ! -e ${MEDIA_DIR}/dst/canary
-    test-snapd-tools.cmd mount --bind ${MEDIA_DIR}/src ${MEDIA_DIR}/dst
-    test -e ${MEDIA_DIR}/dst/canary
-
 restore: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
@@ -29,3 +22,10 @@ restore: |
     rm -f ${MEDIA_DIR}/src/canary
     rmdir ${MEDIA_DIR}/src
     rmdir ${MEDIA_DIR}/dst
+
+execute: |
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+    test ! -e ${MEDIA_DIR}/dst/canary
+    test-snapd-tools.cmd mount --bind ${MEDIA_DIR}/src ${MEDIA_DIR}/dst
+    test -e ${MEDIA_DIR}/dst/canary

--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -1,17 +1,5 @@
 summary: The shape of the mount namespace on classic systems for non-classic snaps
 
-# Temporary, exclude on ubuntu-16.04-64 until mount ns changes on 16.04 are understood/fixed
-systems: [ubuntu-18.04-64]
-# The test itself works perfectly fine but in conjunction with our leaky test
-# suite it often fails because it detects cruft left over by other tests in a
-# way that was not detected before. Classic systems should be clear of mount
-# side-effects now. The test should be _eventually_ enabled on
-# ubuntu-core-16-64 and ubuntu-core-18-64.
-
-# The test is sensitive to backend type, which designates the used image.
-# Backends are enabled one-by-one along with the matching data set.
-backends: [google]
-
 details: |
     This test measures the mount table of the host, of the mount namespace for
     a simple core16-based snap for the per-user mount namespace of a simple
@@ -55,6 +43,18 @@ details: |
     If you see this test randomly failing it may be because it has observed
     state leaked by another test that ran on the same machine earlier in the
     spread  execution chain.
+
+# The test is sensitive to backend type, which designates the used image.
+# Backends are enabled one-by-one along with the matching data set.
+backends: [google]
+
+# Temporary, exclude on ubuntu-16.04-64 until mount ns changes on 16.04 are understood/fixed
+systems: [ubuntu-18.04-64]
+# The test itself works perfectly fine but in conjunction with our leaky test
+# suite it often fails because it detects cruft left over by other tests in a
+# way that was not detected before. Classic systems should be clear of mount
+# side-effects now. The test should be _eventually_ enabled on
+# ubuntu-core-16-64 and ubuntu-core-18-64.
 
 environment:
     MACHINE_STATE/inherit: inherit

--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -5,14 +5,14 @@ details: |
     initializes a workaround mode where all snaps gain minimal amount of network
     permissions sufficient for NFS to operate.
 
+# takes >1.5min to run
+backends: [-autopkgtest]
+
 # ubuntu-core: nfs service not available on core
 # opensuse: the test is failing after retry several times the snapd service reaching the systemd start-limit.
 # fedora, centos: disable until we figure out how to handle NFS and SELinux
 #                 labels, labels can only be exported for NFSv4.2+ with security_label option
 systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -centos-*]
-
-# takes >1.5min to run
-backends: [-autopkgtest]
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh

--- a/tests/main/parallel-install-basic/task.yaml
+++ b/tests/main/parallel-install-basic/task.yaml
@@ -7,6 +7,9 @@ prepare: |
 
     snap set system experimental.parallel-instances=true
 
+restore: |
+    snap set system experimental.parallel-instances=null
+
 execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_foo
@@ -77,6 +80,3 @@ execute: |
 
     su -l -c "test-snapd-sh_foo.sh -c 'cat \$SNAP_USER_COMMON/canary'" test | MATCH canary-instance-common
     su -l -c "test-snapd-sh_foo.sh -c 'cat \$SNAP_USER_DATA/canary'" test | MATCH canary-instance-snap
-
-restore: |
-    snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-common-dirs-undo/task.yaml
+++ b/tests/main/parallel-install-common-dirs-undo/task.yaml
@@ -3,6 +3,9 @@ summary: Checks handling of common snap directories of parallel installed snaps
 prepare: |
     snap set system experimental.parallel-instances=true
 
+restore: |
+    snap set system experimental.parallel-instances=null
+
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
@@ -30,6 +33,3 @@ execute: |
     echo "Shared snap directories are cleaned up as well"
     not test -d "$SNAP_MOUNT_DIR/test-snapd-service"
     not test -d "/var/snap/test-snapd-service"
-
-restore: |
-    snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-common-dirs/task.yaml
+++ b/tests/main/parallel-install-common-dirs/task.yaml
@@ -6,6 +6,9 @@ backends: [-autopkgtest]
 prepare: |
     snap set system experimental.parallel-instances=true
 
+restore: |
+    snap set system experimental.parallel-instances=null
+
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
@@ -78,5 +81,3 @@ execute: |
     not test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
     not test -d "/var/snap/test-snapd-sh"
 
-restore: |
-    snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -1,5 +1,8 @@
 summary: Checks for parallel installation of sideloaded snaps containing desktop applications
 
+restore: |
+    snap set system experimental.parallel-instances=null
+
 execute: |
     echo "Sideload the regular snap"
     "$TESTSTOOLS"/snaps-state install-local basic-desktop
@@ -37,6 +40,3 @@ execute: |
 
     snap remove --purge basic-desktop
     test -f /var/lib/snapd/desktop/applications/basic-desktop+longname_echo.desktop
-
-restore: |
-    snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-layout/task.yaml
+++ b/tests/main/parallel-install-layout/task.yaml
@@ -1,4 +1,5 @@
 summary: Ensure that snap layouts work with parallel installed snaps
+
 details: |
     This test installs a test snap that uses layout declarations. The snap is
     installed under its regular name as well as a parallel instance. The test

--- a/tests/main/parallel-install-store/task.yaml
+++ b/tests/main/parallel-install-store/task.yaml
@@ -1,5 +1,8 @@
 summary: Checks for parallel installation of snaps from the store
 
+restore: |
+    snap set system experimental.parallel-instances=
+
 execute: |
     not snap install test-snapd-tools_foo 2> run.err
     MATCH 'experimental feature disabled' < run.err
@@ -26,6 +29,3 @@ execute: |
 
     echo "Installing more than one instance at a time works too"
     snap install test-snapd-tools_baz test-snapd-tools_zed
-
-restore: |
-    snap set system experimental.parallel-instances=

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -2,14 +2,6 @@ summary: Check that package remove and purge removes everything related to snaps
 
 systems: [-ubuntu-core-*]
 
-restore: |
-    #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB/pkgdb.sh"
-    if [ -e pkg-removed ]; then
-        distro_install_build_snapd
-        rm pkg-removed
-    fi
-
 prepare: |
     # TODO: unify this with tests/main/snap-mgmt/task.yaml
     echo "When some snaps are installed"
@@ -49,6 +41,14 @@ prepare: |
         test "$(find /etc/systemd/user -name 'snap.*.service' | wc -l)" -gt 0
         test "$(find /etc/systemd/user -name 'snap.*.timer' | wc -l)" -gt 0
         test "$(find /etc/systemd/user -name 'snap.*.socket' | wc -l)" -gt 0
+    fi
+
+restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
+    if [ -e pkg-removed ]; then
+        distro_install_build_snapd
+        rm pkg-removed
     fi
 
 debug: |

--- a/tests/main/prepare-image-grub-core18/task.yaml
+++ b/tests/main/prepare-image-grub-core18/task.yaml
@@ -1,8 +1,8 @@
 summary: Check that prepare-image works for grub-systems
 
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
-
 backends: [-autopkgtest]
+
+systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
 
 environment:
     ROOT: /tmp/root

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -1,9 +1,9 @@
 summary: Check that prepare-image works for grub-systems
 
+backends: [-autopkgtest]
+
 # building images is only supported on classic ubuntu, but ubuntu 14.04 does not have systemd-run to perform the test
 systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*]
-
-backends: [-autopkgtest]
 
 # TODO: use the real stores with proper assertions fully as well once possible
 environment:

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -1,4 +1,5 @@
 summary: Check that preseeding of current ubuntu cloud image works under lxd.
+
 details: |
   This test checks that preseeding of Ubuntu cloud images with snap-preseed
   command works in lxc container and that the resulting image can be run

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -1,4 +1,5 @@
 summary: Check that preseeded chroot can be re-set.
+
 details: |
   This test checks that preseeding of Ubuntu cloud images with snap-preseed
   can be undone with --reset flag.

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -1,4 +1,5 @@
 summary: Check that preseeding of current ubuntu cloud image works.
+
 details: |
   This test checks that preseeding of Ubuntu cloud images with snap-preseed
   command works, up to the point where the image is ready to be booted.

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -1,12 +1,12 @@
 summary: Check that more than one snap is refreshed.
 
-# ubuntu-14.04: systemd-run not supported
-systems: [-ubuntu-core-*, -ubuntu-14.04*]
-
 details: |
     We use only the fake store for this test because we currently
     have only one controlled snap in the remote stores, when we will
     have more we can update the test to use them
+
+# ubuntu-14.04: systemd-run not supported
+systems: [-ubuntu-core-*, -ubuntu-14.04*]
 
 environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir

--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -1,11 +1,15 @@
 summary: Ensure that foreground applications block app refresh.
 
-# Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
-systems: [-ubuntu-14.04-*]
-
 details: |
     When the refresh-app-awareness feature is enabled running snap processes,
     mainly foreground applications, will block the refresh of said snap.
+
+# Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
+systems: [-ubuntu-14.04-*]
+
+environment:
+    CONFINEMENT/classic: classic
+    CONFINEMENT/strict: strict
 
 prepare: |
     # This feature depends on the release-app-awareness feature
@@ -15,10 +19,6 @@ prepare: |
     snap pack test-snapd-refresh.v1
     snap pack test-snapd-refresh.v2
     tests.session -u test prepare
-
-environment:
-    CONFINEMENT/classic: classic
-    CONFINEMENT/strict: strict
 
 restore: |
     snap remove --purge test-snapd-refresh

--- a/tests/main/regression-home-snap-root-owned/task.yaml
+++ b/tests/main/regression-home-snap-root-owned/task.yaml
@@ -1,14 +1,18 @@
 summary: Regression test that ensures that $HOME/snap is not root owned for sudo commands
+
 systems:
     - -ubuntu-14.04-*  # no support for tests.session
+
 prepare: |
     # ensure we have no snap user data directory yet
     rm -rf /home/test/snap
     rm -rf /root/snap
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     tests.session -u test prepare
+
 restore: |
     tests.session -u test restore
+
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -1,11 +1,11 @@
 summary: Check snap search
 
-# s390x,ppc64el have nothing featured
-systems: [-ubuntu-*-ppc64el, -ubuntu-*-s390x]
-
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro
 backends: [-autopkgtest]
+
+# s390x,ppc64el have nothing featured
+systems: [-ubuntu-*-ppc64el, -ubuntu-*-s390x]
 
 execute: |
     echo "List all featured snaps"

--- a/tests/main/selinux-classic-confinement/task.yaml
+++ b/tests/main/selinux-classic-confinement/task.yaml
@@ -5,10 +5,10 @@ details: |
     should the user enable support. Focus on snaps with services and hooks as
     those are run under targeted policy.
 
+systems: [fedora-*, centos-*]
+
 environment:
     CLASSIC_SNAP: test-snapd-classic-service-hooks
-
-systems: [fedora-*, centos-*]
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -8,6 +8,7 @@ details: |
     management tasks on snaps.
 
 systems: [fedora-*, centos-*]
+
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh

--- a/tests/main/selinux-snap-restorecon/task.yaml
+++ b/tests/main/selinux-snap-restorecon/task.yaml
@@ -4,6 +4,7 @@ details: |
     Verify that snap run automatically restores the SELinux context of $HOME/snap.
 
 systems: [fedora-*, centos-*]
+
 prepare: |
     snap install test-snapd-sh
     if [ -d /home/test/snap ]; then

--- a/tests/main/server-snap/task.yaml
+++ b/tests/main/server-snap/task.yaml
@@ -3,6 +3,8 @@ summary: Check snap web servers
 # arch: there is no ip6-localhost
 systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
 
+warn-timeout: 3m
+
 environment:
     SNAP_NAME/pythonServer: test-snapd-python-webserver
     IP_VERSION/pythonServer: 4
@@ -14,8 +16,6 @@ environment:
     PORT/goServer: 8081
     TEXT/goServer: Hello World
     LOCALHOST/goServer: ip6-localhost
-
-warn-timeout: 3m
 
 prepare: |
     snap install "$SNAP_NAME"

--- a/tests/main/services-after-before-install/task.yaml
+++ b/tests/main/services-after-before-install/task.yaml
@@ -3,18 +3,18 @@ summary: Check that snap install respects after/before ordering of services
 # slow in autopkgtest (>3m)
 backends: [-autopkgtest]
 
+prepare: |
+    snap set system experimental.parallel-instances=true
+
+restore: |
+    snap set system experimental.parallel-instances=null
+
 debug: |
     for name in $(snap list | grep '^test-snapd-after-before-service' | awk '{print $1}'); do
         for service in before-middle middle after-middle; do
             systemctl status "snap.$name.$service" || true
         done
     done
-
-prepare: |
-    snap set system experimental.parallel-instances=true
-
-restore: |
-    snap set system experimental.parallel-instances=null
 
 execute: |
     echo "When the service snap is installed"

--- a/tests/main/services-snapctl/task.yaml
+++ b/tests/main/services-snapctl/task.yaml
@@ -1,9 +1,9 @@
 summary: Check that own services can be controlled by snapctl
 
-kill-timeout: 5m
-
 # takes >1.5min to run
 backends: [-autopkgtest]
+
+kill-timeout: 5m
 
 environment:
     SERVICEOPTIONFILE: /var/snap/test-snapd-service/current/service-option

--- a/tests/main/services-stop-mode-sigkill/task.yaml
+++ b/tests/main/services-stop-mode-sigkill/task.yaml
@@ -1,9 +1,9 @@
 summary: "Check that refresh-modes sigkill works"
 
-kill-timeout: 5m
-
 # slow in autopkgtest (>1m)
 backends: [-autopkgtest]
+
+kill-timeout: 5m
 
 restore: |
     # remove to ensure all services are stopped

--- a/tests/main/services-stop-mode/task.yaml
+++ b/tests/main/services-stop-mode/task.yaml
@@ -1,12 +1,12 @@
 summary: "Check that stop-modes works"
 
-kill-timeout: 5m
+# takes >1.5min to run
+backends: [-autopkgtest]
 
 # journald in ubuntu-14.04 not reliable
 systems: [-ubuntu-14.04-*]
 
-# takes >1.5min to run
-backends: [-autopkgtest]
+kill-timeout: 5m
 
 restore: |
     # remove to ensure all services are stopped

--- a/tests/main/snap-cli-no-managers/task.yaml
+++ b/tests/main/snap-cli-no-managers/task.yaml
@@ -1,4 +1,5 @@
 summary: Check that snap binary does not inadvertently import snapstate.
+
 details: |
   This test checks that snap binary does not import snapstate when built
   with -tags nomanagers.

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -1,10 +1,10 @@
 summary: Check that snap-mgmt.sh works
 
-# purging everything on core devices will not work
-systems: [-ubuntu-core-*]
-
 # slow in autopkgtest (>1m)
 backends: [-autopkgtest]
+
+# purging everything on core devices will not work
+systems: [-ubuntu-core-*]
 
 prepare: |
     # TODO: unify this with tests/main/postrm-purge/task.yaml

--- a/tests/main/snap-pack/task.yaml
+++ b/tests/main/snap-pack/task.yaml
@@ -1,4 +1,5 @@
 summary: check that snap pack creates squashfs files
+
 details: |
     Verify that snap pack creates squashfs files or fails in a predictable
     manner.

--- a/tests/main/snap-routine-file-access/task.yaml
+++ b/tests/main/snap-routine-file-access/task.yaml
@@ -1,4 +1,5 @@
 summary: The file-access command provides information about access to file paths
+
 details: |
     The "snap routine file-access" command is intended to be a helper for
     xdg-document-portal.  When xdg-document-portal is asked to make a

--- a/tests/main/snap-user-service-socket-activation/task.yaml
+++ b/tests/main/snap-user-service-socket-activation/task.yaml
@@ -18,6 +18,11 @@ restore: |
     tests.session -u test restore
     snap unset system experimental.user-daemons
 
+debug: |
+    tests.session dump
+    tests.session -u test exec systemctl --user status snapd.session-agent.service || true
+    tests.session -u test exec journalctl --user || true
+
 execute: |
     echo "When the service snap is installed"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-user-service-sockets
@@ -35,8 +40,3 @@ execute: |
     USER_RUNTIME_DIR="/run/user/$(id -u test)"
     [ -S "$USER_RUNTIME_DIR"/snap.test-snapd-user-service-sockets/run.sock ]
     nc -w 30 -U "$USER_RUNTIME_DIR"/snap.test-snapd-user-service-sockets/run.sock | MATCH "Connected to runtime"
-
-debug: |
-    tests.session dump
-    tests.session -u test exec systemctl --user status snapd.session-agent.service || true
-    tests.session -u test exec journalctl --user || true

--- a/tests/main/snap-user-service-start-on-install/task.yaml
+++ b/tests/main/snap-user-service-start-on-install/task.yaml
@@ -31,6 +31,11 @@ restore: |
         rm agent-was-enabled
     fi
 
+debug: |
+    tests.session dump
+    tests.session -u test exec systemctl --user status snapd.session-agent.service || true
+    tests.session -u test exec journalctl --user || true
+
 execute: |
     function systemctl_user() {
       tests.session -u test exec systemctl --user "$@"
@@ -50,8 +55,3 @@ execute: |
     if systemctl_user is-active snap.test-snapd-user-service.test-snapd-user-service; then
       exit 1
     fi
-
-debug: |
-    tests.session dump
-    tests.session -u test exec systemctl --user status snapd.session-agent.service || true
-    tests.session -u test exec journalctl --user || true

--- a/tests/main/snap-user-service/task.yaml
+++ b/tests/main/snap-user-service/task.yaml
@@ -18,6 +18,11 @@ restore: |
     tests.session -u test restore
     snap unset system experimental.user-daemons
 
+debug: |
+    tests.session dump
+    tests.session -u test exec systemctl --user status snapd.session-agent.service || true
+    tests.session -u test exec journalctl --user || true
+
 execute: |
     echo "When the service snap is installed"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-user-service
@@ -27,8 +32,3 @@ execute: |
 
     echo "We can see the service running"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.test-snapd-user-service
-
-debug: |
-    tests.session dump
-    tests.session -u test exec systemctl --user status snapd.session-agent.service || true
-    tests.session -u test exec journalctl --user || true

--- a/tests/main/snap-userd-reexec/task.yaml
+++ b/tests/main/snap-userd-reexec/task.yaml
@@ -3,6 +3,15 @@ summary: Check that core refresh will create the userd dbus serivce file
 # only run on systems that re-exec
 systems: [ubuntu-16*, ubuntu-17*]
 
+restore: |
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+    # Remove the locale revision of core, if we installed one.
+    if [ "$(readlink "$SNAP_MOUNT_DIR/core/current")" = x1 ]; then
+        snap revert core
+        snap remove --revision=x1 core
+    fi
+
 execute: |
     snap list | awk "/^core / {print(\$3)}" > prevBoot
 
@@ -15,11 +24,3 @@ execute: |
     echo "Ensure the dbus service file got created"
     test -f /usr/share/dbus-1/services/io.snapcraft.Launcher.service
     diff -u /usr/share/dbus-1/services/io.snapcraft.Launcher.service.orig /usr/share/dbus-1/services/io.snapcraft.Launcher.service
-restore: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-    # Remove the locale revision of core, if we installed one.
-    if [ "$(readlink "$SNAP_MOUNT_DIR/core/current")" = x1 ]; then
-        snap revert core
-        snap remove --revision=x1 core
-    fi

--- a/tests/main/snapd-snap-auto-install/task.yaml
+++ b/tests/main/snapd-snap-auto-install/task.yaml
@@ -3,6 +3,9 @@ summary: Ensure the snapd gets auto installed when needed
 # not testing on ubuntu-core because we have core/snapd installed there
 systems: [-ubuntu-core-*]
 
+restore: |
+    snap remove --purge test-snapd-sh-core18
+
 execute: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh
@@ -21,6 +24,3 @@ execute: |
     snap list | MATCH ^snapd
     snap list | MATCH ^core18
     snap list | MATCH ^test-snapd-sh
-
-restore: |
-    snap remove --purge test-snapd-sh-core18

--- a/tests/main/stale-base-snap/task.yaml
+++ b/tests/main/stale-base-snap/task.yaml
@@ -1,8 +1,5 @@
 summary: when the base snap changes revision apps are not stuck on the stale one
 
-# slow in autopkgtest (>1m)
-backends: [-autopkgtest]
-
 details: |
     When a snap application starts running the mount namespace it inhabits is
     preserved and cached across all the applications belonging to a given snap.
@@ -13,6 +10,9 @@ details: |
     process inhabit the old mount namespace it will stay as is. When the last
     process dies the subsequently started process will detect those two facts
     (stale and unused mount namespace) and discard it.
+
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
 
 # This test doesn't run on core because there snapd will reboot the machine as
 # soon as the new core snap is installed. A variant of this using a non-core

--- a/tests/main/sudo-env/task.yaml
+++ b/tests/main/sudo-env/task.yaml
@@ -5,23 +5,23 @@ details: |
     under sudo to some predefined set of locations. Make sure to account for all
     distros supported by snapd that have sudo set up this way.
 
+# ubuntu-14.04: no support for user sessions used by test helpers
+systems: [ -ubuntu-14.04-* ]
+
 environment:
     # list of regular expressions that match systems where sudo is set up to use
     # secure_path without snap bindir
     SECURE_PATH_SUDO_NO_SNAP: "centos-.* amazon-linux-2-64 opensuse-.* debian-.*"
-
-# ubuntu-14.04: no support for user sessions used by test helpers
-systems: [ -ubuntu-14.04-* ]
-
-debug: |
-    cat sudo.path || true
-    cat sudo-login.path || true
 
 prepare: |
     tests.session -u test prepare
 
 restore: |
     tests.session -u test restore
+
+debug: |
+    cat sudo.path || true
+    cat sudo-login.path || true
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/try-snap-goes-away/task.yaml
+++ b/tests/main/try-snap-goes-away/task.yaml
@@ -1,4 +1,5 @@
 summary: Check that snaps vanishing are handled gracefully
+
 details: |
     Note that this test is subtly different from tests/regression/lp-1764977.
     See the description of that test for details.

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -9,32 +9,6 @@ environment:
     # need to disable go modules support for this test
     GO111MODULE: off
 
-debug: |
-    cat /proc/partitions
-
-restore: |
-    for m in ubuntu-seed ubuntu-save ubuntu-data ubuntu-boot; do
-        if mountpoint "/run/mnt/$m"; then
-            umount "/run/mnt/$m"
-        fi
-    done
-    if mountpoint ./mnt; then
-        umount ./mnt
-    fi
-
-    cryptsetup close /dev/mapper/ubuntu-save || true
-    cryptsetup close /dev/mapper/ubuntu-data || true
-    cryptsetup close /dev/mapper/test-udata || true
-
-    if [ -f loop.txt ]; then
-        LOOP="$(cat loop.txt)"
-        losetup -d "$LOOP"
-        losetup -l | NOMATCH "$LOOP"
-    fi
-    apt autoremove -y cryptsetup
-
-    rm -Rf /run/mnt
-
 prepare: |
     echo "Create a fake block device image that looks like an image from u-i"
     truncate --size=10GB fake.img
@@ -71,6 +45,32 @@ prepare: |
     echo "Get the UC20 gadget"
     snap download --channel=20/edge pc
     unsquashfs -d gadget-dir pc_*.snap
+
+restore: |
+    for m in ubuntu-seed ubuntu-save ubuntu-data ubuntu-boot; do
+        if mountpoint "/run/mnt/$m"; then
+            umount "/run/mnt/$m"
+        fi
+    done
+    if mountpoint ./mnt; then
+        umount ./mnt
+    fi
+
+    cryptsetup close /dev/mapper/ubuntu-save || true
+    cryptsetup close /dev/mapper/ubuntu-data || true
+    cryptsetup close /dev/mapper/test-udata || true
+
+    if [ -f loop.txt ]; then
+        LOOP="$(cat loop.txt)"
+        losetup -d "$LOOP"
+        losetup -l | NOMATCH "$LOOP"
+    fi
+    apt autoremove -y cryptsetup
+
+    rm -Rf /run/mnt
+
+debug: |
+    cat /proc/partitions
 
 execute: |
     # this test simulates a reinstall, to clear the TPM this requires

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -9,24 +9,6 @@ environment:
     # need to disable go modules support for this test
     GO111MODULE: off
 
-debug: |
-    cat /proc/partitions
-
-restore: |
-    for label in ubuntu-seed ubuntu-save ubuntu-data ubuntu-boot; do
-        if mountpoint "/run/mnt/$label"; then
-            umount "/run/mnt/$label"
-        fi
-        if mountpoint "./$label"; then
-            umount "./$label"
-        fi
-    done
-    if [ -f loop.txt ]; then
-        LOOP="$(cat loop.txt)"
-        losetup -d "$LOOP"
-        losetup -l | NOMATCH "$LOOP"
-    fi
-
 prepare: |
     echo "Create a fake block device image that looks like an image from u-i"
     truncate --size=20GB fake.img
@@ -54,6 +36,24 @@ prepare: |
     echo "Get the UC20 gadget"
     snap download --channel=20/edge pc
     unsquashfs -d gadget-dir pc_*.snap
+
+restore: |
+    for label in ubuntu-seed ubuntu-save ubuntu-data ubuntu-boot; do
+        if mountpoint "/run/mnt/$label"; then
+            umount "/run/mnt/$label"
+        fi
+        if mountpoint "./$label"; then
+            umount "./$label"
+        fi
+    done
+    if [ -f loop.txt ]; then
+        LOOP="$(cat loop.txt)"
+        losetup -d "$LOOP"
+        losetup -l | NOMATCH "$LOOP"
+    fi
+
+debug: |
+    cat /proc/partitions
 
 execute: |
     LOOP="$(cat loop.txt)"

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -9,29 +9,6 @@ environment:
     # need to disable go modules support for this test
     GO111MODULE: off
 
-debug: |
-    cat /proc/partitions
-
-restore: |
-    for label in ubuntu-seed ubuntu-save ubuntu-data ubuntu-boot other-ext4; do
-        if mountpoint "/run/mnt/$label"; then
-            umount "/run/mnt/$label"
-        fi
-        if mountpoint "./$label"; then
-            umount "./$label"
-        fi
-    done
-    if mountpoint ./mnt; then
-        umount ./mnt
-    fi
-    # sanity check
-    mount | NOMATCH /run/mnt
-    if [ -f loop.txt ]; then
-        LOOP="$(cat loop.txt)"
-        losetup -d "$LOOP"
-        losetup -l | NOMATCH "$LOOP"
-    fi
-
 prepare: |
     echo "Create a fake block device image that looks like an image from u-i"
     truncate --size=20GB fake.img
@@ -59,6 +36,29 @@ prepare: |
     echo "Get the UC20 gadget"
     snap download --channel=20/edge pc
     unsquashfs -d gadget-dir pc_*.snap
+
+restore: |
+    for label in ubuntu-seed ubuntu-save ubuntu-data ubuntu-boot other-ext4; do
+        if mountpoint "/run/mnt/$label"; then
+            umount "/run/mnt/$label"
+        fi
+        if mountpoint "./$label"; then
+            umount "./$label"
+        fi
+    done
+    if mountpoint ./mnt; then
+        umount ./mnt
+    fi
+    # sanity check
+    mount | NOMATCH /run/mnt
+    if [ -f loop.txt ]; then
+        LOOP="$(cat loop.txt)"
+        losetup -d "$LOOP"
+        losetup -l | NOMATCH "$LOOP"
+    fi
+
+debug: |
+    cat /proc/partitions
 
 execute: |
     LOOP="$(cat loop.txt)"

--- a/tests/main/umask/task.yaml
+++ b/tests/main/umask/task.yaml
@@ -1,12 +1,16 @@
 summary: directories created by snap-confine are immune from umask
+
 details: |
     The setting of umask is inherited across the snap-{run,confine,exec} chain
     but does not hinder execution of snap-confine itself.
+
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
 restore: |
     snap remove test-snapd-sh
     rm -rf ~/snap
+
 execute: |
     # See if umask 777 is respected.
     ( umask 777 && test-snapd-sh.sh -c /bin/true )

--- a/tests/main/xdg-open-compat/task.yaml
+++ b/tests/main/xdg-open-compat/task.yaml
@@ -15,20 +15,6 @@ environment:
     DISPLAY: :0
     XDG_OPEN_OUTPUT: /tmp/xdg-open-output
 
-restore: |
-    tests.session -u test restore
-
-    rm -f /usr/bin/xdg-open
-    rm -f "$XDG_OPEN_OUTPUT"
-    dpkg -r snapd-xdg-open
-    rm -f /usr/share/applications/defaults.list
-    rm -f /usr/share/applications/xdg-open.desktop
-
-    # restore original xdg-open
-    if [ -e /usr/bin/xdg-open.orig ]; then
-        mv /usr/bin/xdg-open.orig /usr/bin/xdg-open
-    fi
-
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-desktop
 
@@ -81,6 +67,20 @@ prepare: |
     EOF
 
     chmod +x /usr/bin/xdg-open
+
+restore: |
+    tests.session -u test restore
+
+    rm -f /usr/bin/xdg-open
+    rm -f "$XDG_OPEN_OUTPUT"
+    dpkg -r snapd-xdg-open
+    rm -f /usr/share/applications/defaults.list
+    rm -f /usr/share/applications/xdg-open.desktop
+
+    # restore original xdg-open
+    if [ -e /usr/bin/xdg-open.orig ]; then
+        mv /usr/bin/xdg-open.orig /usr/bin/xdg-open
+    fi
 
 execute: |
     xdg_open_url() {

--- a/tests/main/xdg-open-portal/task.yaml
+++ b/tests/main/xdg-open-portal/task.yaml
@@ -72,6 +72,9 @@ restore: |
     rm -f "$EDITOR_HISTORY"
     rm -f "$BROWSER_HISTORY"
 
+debug: |
+    ls -la /run/user/12345/ || true
+
 execute: |
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
@@ -93,6 +96,3 @@ execute: |
     tests.session -u test exec test-snapd-desktop.cmd xdg-open /home/test/snap/test-snapd-desktop/common/test.txt
     retry -n 4 --wait 0.5 test -e "$EDITOR_HISTORY"
     MATCH /home/test/snap/test-snapd-desktop/common/test.txt < "$EDITOR_HISTORY"
-
-debug: |
-    ls -la /run/user/12345/ || true

--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -12,15 +12,6 @@ environment:
     # XXX: why is this here?
     DISPLAY: :0
 
-restore: |
-    tests.session -u test restore
-
-    umount /usr/bin/xdg-open
-    rm /usr/bin/xdg-open
-    if [ -e /usr/bin/xdg-open.orig ]; then
-        mv /usr/bin/xdg-open.orig /usr/bin/xdg-open
-    fi
-
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-desktop
 
@@ -47,6 +38,15 @@ prepare: |
     fi
     touch /usr/bin/xdg-open
     mount --bind /tmp/xdg-open /usr/bin/xdg-open
+
+restore: |
+    tests.session -u test restore
+
+    umount /usr/bin/xdg-open
+    rm /usr/bin/xdg-open
+    if [ -e /usr/bin/xdg-open.orig ]; then
+        mv /usr/bin/xdg-open.orig /usr/bin/xdg-open
+    fi
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/xdg-settings/task.yaml
+++ b/tests/main/xdg-settings/task.yaml
@@ -8,11 +8,6 @@ systems:
     - -ubuntu-14.04-*  # not supported as desktop OS, systemd too old for tests.session
     - -ubuntu-core-*  # test exercises regular xdg-settings, not the custom one in ubuntu-core
 
-restore: |
-    tests.session -u test restore
-    umount -f /usr/bin/xdg-settings || true
-    umount -f /usr/bin/zenity || true
-
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-xdg-settings
 
@@ -38,6 +33,11 @@ prepare: |
     chmod +x /tmp/xdg-settings
     touch /usr/bin/xdg-settings
     mount --bind /tmp/xdg-settings /usr/bin/xdg-settings
+
+restore: |
+    tests.session -u test restore
+    umount -f /usr/bin/xdg-settings || true
+    umount -f /usr/bin/zenity || true
 
 execute: |
     #shellcheck source=tests/lib/systems.sh


### PR DESCRIPTION
The change updates the layout of the tests following a proposed order which should make the test easier to read and understand

More tests and documentation about the order is coming in the part2.

The proposed order is:
summary
details

backends
systems

manual
priority
warn-timeout
kill-timeout

environment
prepare
restore
debug
execute
