### PR TITLE
tests: update layout for tests - part 2

### DIFF
--- a/tests/core/fsck-vfat/task.yaml
+++ b/tests/core/fsck-vfat/task.yaml
@@ -1,4 +1,5 @@
 summary: the boot base provides essential fsck programs
+
 details: |
   Snapd uses vfat on certain essential boot partitions, due to external
   requirements imposed by the bootloader architecture. This test verifies
@@ -7,8 +8,13 @@ details: |
 
   A separate test examines how fsck is automatically invoked during the boot
   process. This is not verified here.
+
 prepare: |
   tests.cleanup prepare
+
+restore: |
+  tests.cleanup restore
+
 execute: |
   echo "Essential fsck programs are in the boot base"
   test -n "$(command -v fsck.vfat)"
@@ -63,5 +69,3 @@ execute: |
   tests.cleanup defer umount /mnt
   dmesg -c | not MATCH "Volume was not properly unmounted. Some data may be corrupt. Please run fsck."
   tests.cleanup pop # unmount
-restore: |
-  tests.cleanup restore

--- a/tests/core/gadget-kernel-refs-update-pc/task.yaml
+++ b/tests/core/gadget-kernel-refs-update-pc/task.yaml
@@ -1,13 +1,5 @@
 summary: Exercise a gadget update with kernel refs on a PC
 
-environment:
-    BLOB_DIR: $(pwd)/fake-store-blobdir
-    # snap-id of 'pc' gadget snap
-    PC_SNAP_ID: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
-    # snap-id of 'pc-kernel' snap
-    PC_KERNEL_ID: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
-    START_REVISION: 1000
-
 # TODO:UC20: once LP: #1907056 is fixed and we have an updated
 #            pi gadget and pi-kernel snap this test should be
 #            replaced with a pi-only test. This test is artificial
@@ -16,6 +8,14 @@ environment:
 # the test is only meaningful on core devices
 # XXX: uc20
 systems: [ubuntu-core-1*]
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+    # snap-id of 'pc' gadget snap
+    PC_SNAP_ID: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    # snap-id of 'pc-kernel' snap
+    PC_KERNEL_ID: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    START_REVISION: 1000
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/core/kernel-snap-refresh-on-core/task.yaml
+++ b/tests/core/kernel-snap-refresh-on-core/task.yaml
@@ -1,12 +1,12 @@
 summary: Check that the kernel snap can be refreshed on a core device
 
-# TODO:UC20 enable for UC20/UC18
-systems: [ubuntu-core-16-64]
-
 details: |
     This test checks that the kernel snap can be refreshed from an installed
     revision to a new one. It expects to find a new snap revision in the
     channel pointed by the NEW_CORE_CHANNEL env var.
+
+# TODO:UC20 enable for UC20/UC18
+systems: [ubuntu-core-16-64]
 
 manual: true
 

--- a/tests/core/remodel-base/task.yaml
+++ b/tests/core/remodel-base/task.yaml
@@ -1,10 +1,11 @@
 summary: Test a remodel that switches to a new base
-environment:
-    OLD_BASE: core18
-    NEW_BASE: test-snapd-core18
 
 # TODO:UC20: enable on UC20
 systems: [ubuntu-core-18-64]
+
+environment:
+    OLD_BASE: core18
+    NEW_BASE: test-snapd-core18
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/core/remodel-gadget/task.yaml
+++ b/tests/core/remodel-gadget/task.yaml
@@ -1,10 +1,11 @@
 summary: Test a remodel that switches to a new gadget
-environment:
-    OLD_GADGET: pc
-    NEW_GADGET: test-snapd-pc
 
 # TODO:UC20: enable for UC20
 systems: [ubuntu-core-18-64]
+
+environment:
+    OLD_GADGET: pc
+    NEW_GADGET: test-snapd-pc
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/core/remodel-kernel/task.yaml
+++ b/tests/core/remodel-kernel/task.yaml
@@ -1,13 +1,13 @@
 summary: |
     Test a remodel that switches to a new kernel
 
-environment:
-    OLD_KERNEL: pc-kernel
-    NEW_KERNEL: test-snapd-pc-kernel
-
 # FIXME: add core18 test as well
 # TODO:UC20: enable for UC20
 systems: [ubuntu-core-16-64]
+
+environment:
+    OLD_KERNEL: pc-kernel
+    NEW_KERNEL: test-snapd-pc-kernel
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/core/snap-repair/task.yaml
+++ b/tests/core/snap-repair/task.yaml
@@ -9,6 +9,18 @@ prepare: |
     snap install jq
     tests.cleanup defer snap remove jq
 
+restore: |
+    tests.cleanup restore
+
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    teardown_fake_store "$BLOB_DIR"
+
 execute: |
     echo "Ensure the snap-repair timer is enabled"
     systemctl list-timers | MATCH snapd.snap-repair.timer
@@ -143,15 +155,3 @@ execute: |
             exit 1
         fi
     fi
-
-restore: |
-    tests.cleanup restore
-
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
-    fi
-
-    #shellcheck source=tests/lib/store.sh
-    . "$TESTSLIB"/store.sh
-    teardown_fake_store "$BLOB_DIR"

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -17,6 +17,20 @@ prepare: |
     snap list snapd
     ls -l /snap/snapd/
 
+restore: |
+    if os.query is-core16; then
+        echo "ensuring we reverted fully to core snap system"
+        not test -d /snap/snapd
+        # cleanup the snapd-from-core snap we built
+        rm -f snapd-from-core.snap
+        rm -f /etc/systemd/user/snapd.session-agent.service
+        rm -f /etc/systemd/user/snapd.session-agent.socket
+        rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
+        systemctl --user daemon-reload
+        rm -f /etc/dbus-1/session.d/snapd.session-services.conf
+        rm -f /etc/dbus-1/system.d/snapd.system-services.conf
+    fi
+
 debug: |
     # dump failure data
     journalctl -u snapd.failure.service
@@ -31,20 +45,6 @@ debug: |
     cat /etc/systemd/system/usr-lib-snapd.mount
     /snap/snapd/x1/usr/bin/snap debug state /var/lib/snapd/state.json || true
     /snap/snapd/x1/usr/bin/snap debug state --change="$(/snap/snapd/x1/usr/bin/snap debug state /var/lib/snapd/state.json|tail -n1|awk '{print $1}')" /var/lib/snapd/state.json || true
-
-restore: |
-    if os.query is-core16; then
-        echo "ensuring we reverted fully to core snap system"
-        not test -d /snap/snapd
-        # cleanup the snapd-from-core snap we built
-        rm -f snapd-from-core.snap
-        rm -f /etc/systemd/user/snapd.session-agent.service
-        rm -f /etc/systemd/user/snapd.session-agent.socket
-        rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
-        systemctl --user daemon-reload
-        rm -f /etc/dbus-1/session.d/snapd.session-services.conf
-        rm -f /etc/dbus-1/system.d/snapd.system-services.conf
-    fi
 
 execute: |
     if [ "$SPREAD_REBOOT" = 0 ]; then

--- a/tests/core/snapd16/task.yaml
+++ b/tests/core/snapd16/task.yaml
@@ -8,6 +8,15 @@ prepare: |
     . "$TESTSLIB/snaps.sh"
     repack_installed_core_snap_into_snapd_snap
 
+restore: |
+    not test -d /snap/snapd
+    rm -f /etc/systemd/user/snapd.session-agent.service
+    rm -f /etc/systemd/user/snapd.session-agent.socket
+    rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
+    systemctl --user daemon-reload
+    rm -f /etc/dbus-1/session.d/snapd.session-services.conf
+    rm -f /etc/dbus-1/system.d/snapd.system-services.conf
+
 execute: |
     if [ "$SPREAD_REBOOT" = 0 ]; then
         echo "No snapd snap is installed"
@@ -65,11 +74,3 @@ execute: |
     snap remove snapd
     # and we can still run the rsync snap after the reboot
     rsync --help
-restore: |
-    not test -d /snap/snapd
-    rm -f /etc/systemd/user/snapd.session-agent.service
-    rm -f /etc/systemd/user/snapd.session-agent.socket
-    rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
-    systemctl --user daemon-reload
-    rm -f /etc/dbus-1/session.d/snapd.session-services.conf
-    rm -f /etc/dbus-1/system.d/snapd.system-services.conf

--- a/tests/core/upgrade/task.yaml
+++ b/tests/core/upgrade/task.yaml
@@ -8,10 +8,14 @@ systems: [ubuntu-core-16-*, ubuntu-core-18-32*, ubuntu-core-18-64*]
 # Start early as it takes a long time.
 priority: 100
 
-debug: |
-    snap list
-    "$TESTSTOOLS"/boot-state bootenv show
-    cat /proc/cmdline
+prepare: |
+    TARGET_SNAP=core
+    if os.query is-core18; then
+        TARGET_SNAP=core18
+    fi
+
+    snap list | awk "/^${TARGET_SNAP} / {print(\$3)}" > nextBoot
+    snap install test-snapd-sh
 
 restore: |
     systemctl restart snapd
@@ -23,14 +27,10 @@ restore: |
     snap remove core --revision=x2
     snap remove core --revision=x3
 
-prepare: |
-    TARGET_SNAP=core
-    if os.query is-core18; then
-        TARGET_SNAP=core18
-    fi
-
-    snap list | awk "/^${TARGET_SNAP} / {print(\$3)}" > nextBoot
-    snap install test-snapd-sh
+debug: |
+    snap list
+    "$TESTSTOOLS"/boot-state bootenv show
+    cat /proc/cmdline
 
 execute: |
     TARGET_SNAP=core

--- a/tests/cross/go-build/task.yaml
+++ b/tests/cross/go-build/task.yaml
@@ -21,13 +21,6 @@ environment:
     X_GCC/ppc64el: gcc-powerpc64le-linux-gnu
     X_CC/ppc64el: powerpc64le-linux-gnu-gcc
 
-restore: |
-    rm -rf /tmp/cross-build
-    dpkg -l | awk "/^ii.*$X_DEBARCH/{print \$2}" | xargs apt --yes --quiet -o Dpkg::Progress-Fancy=false autoremove --purge
-    dpkg --remove-architecture "$X_DEBARCH"
-    mv /etc/apt/sources.list.orig /etc/apt/sources.list
-    apt --quiet -o Dpkg::Progress-Fancy=false update
-
 prepare: |
     . /etc/os-release
     mkdir -p /tmp/cross-build/src/github.com/snapcore
@@ -54,6 +47,13 @@ prepare: |
     dpkg --add-architecture "$X_DEBARCH"
     apt --quiet -o Dpkg::Progress-Fancy=false update
     apt --yes --quiet -o Dpkg::Progress-Fancy=false install "$X_GCC" libseccomp2:"$X_DEBARCH" libseccomp-dev:"$X_DEBARCH"
+
+restore: |
+    rm -rf /tmp/cross-build
+    dpkg -l | awk "/^ii.*$X_DEBARCH/{print \$2}" | xargs apt --yes --quiet -o Dpkg::Progress-Fancy=false autoremove --purge
+    dpkg --remove-architecture "$X_DEBARCH"
+    mv /etc/apt/sources.list.orig /etc/apt/sources.list
+    apt --quiet -o Dpkg::Progress-Fancy=false update
 
 execute: |
     cd /tmp/cross-build/src/github.com/snapcore/snapd

--- a/tests/nested/core/core-revert/task.yaml
+++ b/tests/nested/core/core-revert/task.yaml
@@ -1,8 +1,8 @@
 summary: core revert test
 
-kill-timeout: 30m
-
 systems: [ubuntu-16.04-64]
+
+kill-timeout: 30m
 
 environment:
     IMAGE_FILE: /tmp/work-dir/images/ubuntu-core-new.img

--- a/tests/nested/core/core20-basic/task.yaml
+++ b/tests/nested/core/core20-basic/task.yaml
@@ -1,9 +1,9 @@
 summary: Run a smoke test on UC20 with encryption enabled
 
-systems: [ubuntu-20.04-64]
-
 details: |
     This test checks basic snapd commands on UC20 with secure boot and encryption enabled
+
+systems: [ubuntu-20.04-64]
 
 execute: |
     #shellcheck source=tests/lib/nested.sh

--- a/tests/nested/core/core20-tpm/task.yaml
+++ b/tests/nested/core/core20-tpm/task.yaml
@@ -1,9 +1,9 @@
 summary: Check that tpm works properly on UC20
 
-systems: [ubuntu-20.04-64]
-
 details: |
     This test check UC20 can boot with secure boot successfully
+
+systems: [ubuntu-20.04-64]
 
 debug: |
     cat modeenv || true

--- a/tests/nested/manual/snapd-refresh-from-old/task.yaml
+++ b/tests/nested/manual/snapd-refresh-from-old/task.yaml
@@ -1,4 +1,5 @@
 summary: Test snapd refresh from a very old snapd snap.
+
 details: |
   Test that a refresh from a very old snapd and core18 to a recent one succeeds.
 

--- a/tests/nightly/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/nightly/classic-ubuntu-core-transition-auth/task.yaml
@@ -1,24 +1,17 @@
 summary: Ensure that the ubuntu-core -> core transition works with auth.json
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 # we never test on core because the transition can only happen on "classic"
 # we disable on ppc64el because the downloads are very slow there
 # Fedora, openSUSE and Arch are disabled at the moment as there is something
 # fishy going on and the snapd service gets terminated during the process.
 systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -arch-*]
 
-# autopkgtest run only a subset of tests that deals with the integration
-# with the distro
-backends: [-autopkgtest]
-
 warn-timeout: 1m
-
 kill-timeout: 5m
-
-debug: |
-    snap changes
-    #shellcheck source=tests/lib/changes.sh
-    . "$TESTSLIB/changes.sh"
-    snap change "$(change_id 'Transition ubuntu-core to core')" || true
 
 restore: |
     "$TESTSTOOLS"/fs-state restore-file /root/.snap/auth.json
@@ -26,6 +19,12 @@ restore: |
 
     "$TESTSTOOLS"/fs-state restore-file /home/test/.snap/auth.json
     "$TESTSTOOLS"/fs-state restore-dir /home/test/.snap
+
+debug: |
+    snap changes
+    #shellcheck source=tests/lib/changes.sh
+    . "$TESTSLIB/changes.sh"
+    snap change "$(change_id 'Transition ubuntu-core to core')" || true
 
 execute: |
     #shellcheck source=tests/lib/pkgdb.sh

--- a/tests/nightly/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/nightly/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -1,15 +1,14 @@
 summary: Ensure that the ubuntu-core -> core transition works with two cores
 
-# we never test on core because the transition can only happen on "classic"
-# we disable on ppc64el because the downloads are very slow there
-systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
-
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro
 backends: [-autopkgtest]
 
-warn-timeout: 1m
+# we never test on core because the transition can only happen on "classic"
+# we disable on ppc64el because the downloads are very slow there
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
+warn-timeout: 1m
 kill-timeout: 5m
 
 debug: |

--- a/tests/nightly/classic-ubuntu-core-transition/task.yaml
+++ b/tests/nightly/classic-ubuntu-core-transition/task.yaml
@@ -1,14 +1,14 @@
 summary: Ensure that the ubuntu-core -> core transition works
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 # we never test on core because the transition can only happen on "classic" we
 # disable on ppc64el because the downloads are very slow there Fedora, openSUSE,
 # Arch, CentOS are disabled at the moment as there is something fishy going on
 # and the snapd service gets terminated during the process.
 systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -ubuntu-*-i386, -arch-*, -amazon-*, -centos-*, -debian-sid-*]
-
-# autopkgtest run only a subset of tests that deals with the integration
-# with the distro
-backends: [-autopkgtest]
 
 warn-timeout: 1m
 kill-timeout: 5m

--- a/tests/nightly/interfaces-openvswitch/task.yaml
+++ b/tests/nightly/interfaces-openvswitch/task.yaml
@@ -1,10 +1,5 @@
 summary: Ensure that the openvswitch interface works.
 
-# Openvswitch getting stuck during installation sporadically on ubuntu-14.04-64
-# Openvswitch service fails to start on debian-sid
-# Openvswitch service not available on the following systems
-systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -arch-linux-*, -centos-*, -debian-sid-*, -ubuntu-14.04-64]
-
 details: |
     The openvswitch interface allows to task to the openvswitch socket (rw mode).
 
@@ -15,6 +10,11 @@ details: |
     A snap declaring a plug on this interface must be able to do all the operations that
     are carried through the socket, in this test we exercise bridge and port creation,
     list and deletion.
+
+# Openvswitch getting stuck during installation sporadically on ubuntu-14.04-64
+# Openvswitch service fails to start on debian-sid
+# Openvswitch service not available on the following systems
+systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -arch-linux-*, -centos-*, -debian-sid-*, -ubuntu-14.04-64]
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh

--- a/tests/nightly/sbuild/task.yaml
+++ b/tests/nightly/sbuild/task.yaml
@@ -1,5 +1,7 @@
 summary: Ensure snapd builds correctly in sbuild
 
+systems: [debian-sid-*]
+
 # takes a while
 priority: 500
 
@@ -13,23 +15,6 @@ environment:
     # Only build arch:all
     BUILD_MODE/all: all
     ARCH/all: amd64
-
-systems: [debian-sid-*]
-
-execute: |
-    echo "Create a sid sbuild env"
-    eatmydata sbuild-createchroot --include=eatmydata,ccache,gnupg --arch="$ARCH" sid /srv/chroot/"sid-$ARCH-sbuild" http://deb.debian.org/debian
-
-    echo "Allow test user to run sbuild"
-    sbuild-adduser test
-
-    BUILD_PARAM="--verbose"
-    if [ "$BUILD_MODE" == "all" ]; then
-        BUILD_PARAM="$BUILD_PARAM --arch-all --no-arch-any"
-    fi
-
-    echo "Build mode: $BUILD_MODE"
-    su -c "sbuild $BUILD_PARAM --arch=$ARCH -d sid --run-autopkgtest $SPREAD_PATH/../*.dsc" test
 
 restore: |
     rm --recursive --one-file-system /srv/chroot/"sid-$ARCH-sbuild"
@@ -49,3 +34,18 @@ debug: |
     In particular note that the source code exists twice in the build tree,
     and only the specific copy is being used.
     EOM
+
+execute: |
+    echo "Create a sid sbuild env"
+    eatmydata sbuild-createchroot --include=eatmydata,ccache,gnupg --arch="$ARCH" sid /srv/chroot/"sid-$ARCH-sbuild" http://deb.debian.org/debian
+
+    echo "Allow test user to run sbuild"
+    sbuild-adduser test
+
+    BUILD_PARAM="--verbose"
+    if [ "$BUILD_MODE" == "all" ]; then
+        BUILD_PARAM="$BUILD_PARAM --arch-all --no-arch-any"
+    fi
+
+    echo "Build mode: $BUILD_MODE"
+    su -c "sbuild $BUILD_PARAM --arch=$ARCH -d sid --run-autopkgtest $SPREAD_PATH/../*.dsc" test

--- a/tests/regression/lp-1597842/task.yaml
+++ b/tests/regression/lp-1597842/task.yaml
@@ -17,11 +17,11 @@ prepare: |
     mkdir -p /usr/src
     echo canary > /usr/src/.canary
 
-execute: |
-    echo "The canary file in /usr/src can be read"
-    [ "$(test-snapd-tools.cmd cat /usr/src/.canary)" = "canary" ]
-
 restore: |
     rm -f /usr/src/.canary
     rm -f -d /usr/src
     mv /usr/src.orig /usr/src || true
+
+execute: |
+    echo "The canary file in /usr/src can be read"
+    [ "$(test-snapd-tools.cmd cat /usr/src/.canary)" = "canary" ]

--- a/tests/regression/lp-1607796/task.yaml
+++ b/tests/regression/lp-1607796/task.yaml
@@ -6,9 +6,9 @@ prepare: |
     echo "Having added a canary file in /root"
     echo "test" > /root/canary
 
+restore: |
+    rm -f /root/canary
+
 execute: |
     echo "We can see the canary file in /root"
     [ "$(test-snapd-tools.cmd cat /root/canary)" = "test" ]
-
-restore: |
-    rm -f /root/canary

--- a/tests/regression/lp-1641885/task.yaml
+++ b/tests/regression/lp-1641885/task.yaml
@@ -1,8 +1,5 @@
 summary: snaps installed with --jailmode are not in devmode
 
-# No confinement (AppArmor, Seccomp) available on these systems
-systems: [-debian-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
-
 details: |
     Users found that a snap that uses "confinement: devmode", even when
     installed with "snap install --jailmode" is effectively in devmode (the
@@ -10,10 +7,19 @@ details: |
     "jailmode".
     This has been reported as https://bugs.launchpad.net/snappy/+bug/1641885
 
+# No confinement (AppArmor, Seccomp) available on these systems
+systems: [-debian-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
+
 prepare: |
     snap pack "$TESTSLIB/snaps/test-snapd-devmode"
     echo "Install a test snap that uses 'confinement: devmode' in jailmode"
     snap install --jailmode --dangerous ./test-snapd-devmode_1.0_all.snap
+
+debug: |
+    echo "Apparmor profile (first 30 lines)"
+    head -n 30 /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode || true
+    echo "Seccomp profile (first 30 lines)"
+    head -n 30 /var/lib/snapd/seccomp/bpf/snap.test-snapd-devmode.test-snapd-devmode.src || true
 
 execute: |
     echo "Ensure that the snap is installed in jailmode"
@@ -22,9 +28,3 @@ execute: |
     grep attach_disconnected /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode | not MATCH complain
     echo "Ensure that the seccomp profile doesn't use the complain mode"
     not MATCH '@complain' < /var/lib/snapd/seccomp/bpf/snap.test-snapd-devmode.test-snapd-devmode.src
-
-debug: |
-    echo "Apparmor profile (first 30 lines)"
-    head -n 30 /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode || true
-    echo "Seccomp profile (first 30 lines)"
-    head -n 30 /var/lib/snapd/seccomp/bpf/snap.test-snapd-devmode.test-snapd-devmode.src || true

--- a/tests/regression/lp-1644439/task.yaml
+++ b/tests/regression/lp-1644439/task.yaml
@@ -1,12 +1,4 @@
 summary: Regression test for https://bugs.launchpad.net/snap-confine/+bug/1644439
-# This test fails on Ubuntu 18.04 and later because snap-confine, along all of
-# snapd is built in a distribution from the future (ubuntu 18.04 for example)
-# and the injected into a ubuntu 16.04-based chroot. This cannot work in
-# general. We discussed this in the past and we'd have to change how we do our
-# CI so that we can always build each branch against ubuntu 16.04 container and
-# only then repackage and test on a given distribution.
-
-systems: [ubuntu-14.04-64, ubuntu-16.04-32, ubuntu-16.04-64]
 
 details: |
     snap-confine uses privately-shared /run/snapd/ns to store bind-mounted
@@ -18,6 +10,14 @@ details: |
     another namespace in which the /run/snapd/ns directory is visible.
     The most obvious candidate is pid one, which definitely doesn't run in a
     snap-specific namespace, has a predictable PID and is long lived.
+
+# This test fails on Ubuntu 18.04 and later because snap-confine, along all of
+# snapd is built in a distribution from the future (ubuntu 18.04 for example)
+# and the injected into a ubuntu 16.04-based chroot. This cannot work in
+# general. We discussed this in the past and we'd have to change how we do our
+# CI so that we can always build each branch against ubuntu 16.04 container and
+# only then repackage and test on a given distribution.
+systems: [ubuntu-14.04-64, ubuntu-16.04-32, ubuntu-16.04-64]
 
 prepare: |
     echo "Having installed the test snap in devmode"

--- a/tests/regression/lp-1704860/task.yaml
+++ b/tests/regression/lp-1704860/task.yaml
@@ -1,7 +1,5 @@
 summary: Work-in-progress on reproducing lp:1704860
 
-systems: [ubuntu-16.04-64]
-
 details: |
     In this bug, an app belonging go a snap using classic confinement confuses
     the re-execution system in a way that causes distribution version of
@@ -17,6 +15,8 @@ details: |
     --shell.  Since neither snap-confine nor snap-exec re-execute themselves
     (instead they rely on snap run to run the right tool in the first place)
     this is safe to do.
+
+systems: [ubuntu-16.04-64]
 
 execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-classic-confinement --classic

--- a/tests/regression/lp-1797556/task.yaml
+++ b/tests/regression/lp-1797556/task.yaml
@@ -1,17 +1,21 @@
 summary: snaps cannot write to ~/bin
+
 details: |
     On some distributions the ~/bin directory is in the default PATH for the
     user. To avoid hijacking commands and allow sandbox escape, writing to this
     directory is denied.
+
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     su -l -c 'mkdir -p /home/test/bin/' test
     su -l -c 'mkdir -p /home/test/snap/test-snapd-sh/common/' test
     su -l -c 'touch /home/test/snap/test-snapd-sh/common/evil-2' test
     sysctl -w kernel.printk_ratelimit=0
+
 restore: |
     su -l -c 'rmdir /home/test/bin/ || true' test
     sysctl -w kernel.printk_ratelimit=5
+
 execute: |
     test -d /home/test/bin
     test ! -e /home/test/bin/evil-1

--- a/tests/regression/lp-1803535/task.yaml
+++ b/tests/regression/lp-1803535/task.yaml
@@ -1,6 +1,8 @@
 summary: regression test for https://bugs.launchpad.net/snapd/+bug/1803535
+
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-lp-1803535
+
 execute: |
     # If we can construct the layout and execute /bin/true we are fine.
     test-snapd-lp-1803535.sh -c /bin/true

--- a/tests/regression/lp-1805838/task.yaml
+++ b/tests/regression/lp-1805838/task.yaml
@@ -1,8 +1,10 @@
 summary: system key is not written if security setup fails
+
 details: |
     When snapd is started up and the system key needs regeneration errors from
     establishing the new security profiles should not stop snapd from running
     but should prevent snapd from writing the system key.
+
 prepare: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh

--- a/tests/regression/lp-1808821/task.yaml
+++ b/tests/regression/lp-1808821/task.yaml
@@ -1,4 +1,5 @@
 summary: refreshing a snap with particular layout over itself
+
 details: |
     This bug was hiding two separate bugs in snap-update-ns. The first
     one is that Keep changes were not tracked in filesystem
@@ -10,7 +11,9 @@ details: |
     create prefix, passed a directory name of the prefix with the
     trailing slash, which would not match the restrictive trespassing
     detection code.
-execute: ./task.sh
+
 restore: |
     snap remove --purge test-snapd-app
     rm -f test-snapd-app_1_all.snap
+
+execute: ./task.sh

--- a/tests/regression/lp-1812973/task.yaml
+++ b/tests/regression/lp-1812973/task.yaml
@@ -1,16 +1,20 @@
 summary: regression test for https://bugs.launchpad.net/snappy/+bug/1812973
+
 # Skip core as we don't have a compiler there.
 # Skip -32 bit arches as the blacklist is not useful there.
 systems: [-ubuntu-core-*, -*-32]
+
 prepare: |
     make DESTDIR=test-snapd-lp-1812973 install
     snap pack ./test-snapd-lp-1812973
     snap install --dangerous ./test-snapd-lp-1812973_1_all.snap
+
 restore: |
     make clean
     snap remove --purge test-snapd-lp-1812973
     rm -f ./test-snapd-lp-1812973_1_all.snap
     rm -f ./test-snapd-lp-1812973/usr/bin/lp-1812973
+
 execute: |
     test-snapd-lp-1812973 --good
     test-snapd-lp-1812973 --good-high

--- a/tests/regression/lp-1813365/task.yaml
+++ b/tests/regression/lp-1813365/task.yaml
@@ -1,14 +1,18 @@
 summary: Regression check for https://bugs.launchpad.net/snapd/+bug/1813365
+
 systems: [ubuntu-1*, ubuntu-2*, ubuntu-core-*, debian-*]
+
 prepare: |
     mount --bind logger "$(command -v adduser)"
     mount --bind logger "$(command -v passwd)"
     mount --bind logger "$(command -v usermod)"
+
 restore: |
     umount "$(command -v adduser)"
     umount "$(command -v passwd)"
     umount "$(command -v usermod)"
     rm -f /tmp/logger.log
+
 execute: |
     su -l -c "$(pwd)/helper" test
     not test -e /tmp/logger.log

--- a/tests/regression/lp-1815722/task.yaml
+++ b/tests/regression/lp-1815722/task.yaml
@@ -1,8 +1,10 @@
 summary: regression test for https://bugs.launchpad.net/snapd/+bug/1815722
+
+restore: |
+    snapd.tool exec snap-discard-ns snap-hooks-bad-install
+
 execute: |
     "$TESTSTOOLS"/snaps-state install-local snap-hooks-bad-install || true
 
     test ! -e /var/lib/snapd/ns/snap-hooks-bad-install.mnt
     test ! -e /var/lib/snapd/ns/snap.snap-hooks-bad-install.fstab
-restore: |
-    snapd.tool exec snap-discard-ns snap-hooks-bad-install

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -1,5 +1,7 @@
 summary: Regression test for https://bugs.launchpad.net/snapd/+bug/1815869
+
 systems: [ubuntu-16.04-64]
+
 prepare: |
     # Ensure that we don't have LXD installed as a deb
     apt autoremove -y lxd || :

--- a/tests/regression/lp-1849845/task.yaml
+++ b/tests/regression/lp-1849845/task.yaml
@@ -1,9 +1,11 @@
 summary: regression test for LP:#1849845
+
 details: |
   This test verifies that apparmor permissions for de-conflicted overlapping
   mount entries resulting from connecting two content slots to one plug in
   direct mode (as opposed to spool mode) doesn't fail because of missing
   permissions to create and mount the package-assets-2 directory.
+
 prepare: |
   snap pack test-snapd-app
   snap pack test-snapd-assets-foo
@@ -15,6 +17,16 @@ prepare: |
 
   snap connect test-snapd-app:package-assets test-snapd-assets-foo:package-assets
   snap connect test-snapd-app:package-assets test-snapd-assets-bar:package-assets
+
+restore: |
+  snap remove --purge test-snapd-app
+  snap remove --purge test-snapd-assets-foo
+  snap remove --purge test-snapd-assets-bar
+
+  rm -f test-snapd-app_1_all.snap
+  rm -f test-snapd-assets-foo_1_all.snap
+  rm -f test-snapd-assets-bar_1_all.snap
+
 execute: |
   # The directories are present
   #shellcheck disable=SC2016
@@ -37,11 +49,3 @@ execute: |
   else
     false
   fi
-restore: |
-  snap remove --purge test-snapd-app
-  snap remove --purge test-snapd-assets-foo
-  snap remove --purge test-snapd-assets-bar
-
-  rm -f test-snapd-app_1_all.snap
-  rm -f test-snapd-assets-foo_1_all.snap
-  rm -f test-snapd-assets-bar_1_all.snap

--- a/tests/regression/lp-1867193/task.yaml
+++ b/tests/regression/lp-1867193/task.yaml
@@ -1,5 +1,7 @@
 summary: certain refresh sequence on the maas snap breaks the layout system
+
 systems: [ubuntu-18.04-64] # tight coupling with container guest
+
 prepare: |
     snap install lxd --channel="$LXD_SNAP_CHANNEL"
     snap set lxd waitready.timeout=240
@@ -12,13 +14,15 @@ prepare: |
     lxc file push --quiet "$GOHOME"/snapd_*.deb "bionic/$GOHOME/"
     lxc exec bionic -- apt install -y "$GOHOME"/snapd_*.deb
     lxc exec bionic -- snap set core experimental.robust-mount-namespace-updates=true
-execute: |
-    # first command is done twice due to https://bugs.launchpad.net/snapd/+bug/1865503
-    lxc exec bionic -- snap install maas --channel=2.7/edge
-    lxc exec bionic -- snap install maas --channel=2.7/edge
-    lxc exec bionic -- snap refresh maas --channel=edge
+
 restore: |
     lxc stop --force bionic
     lxc delete bionic
     snap remove --purge lxd
     "$TESTSTOOLS"/lxd-state undo-mount-changes
+
+execute: |
+    # first command is done twice due to https://bugs.launchpad.net/snapd/+bug/1865503
+    lxc exec bionic -- snap install maas --channel=2.7/edge
+    lxc exec bionic -- snap install maas --channel=2.7/edge
+    lxc exec bionic -- snap refresh maas --channel=edge

--- a/tests/regression/lp-1867752/task.yaml
+++ b/tests/regression/lp-1867752/task.yaml
@@ -1,5 +1,7 @@
 summary: certain layout configuration prevents snapd from removing a snap
+
 systems: [ubuntu-18.04-64] # tight coupling with container guest
+
 prepare: |
     snap install lxd --channel="$LXD_SNAP_CHANNEL"
     snap set lxd waitready.timeout=240
@@ -12,15 +14,18 @@ prepare: |
     lxc file push --quiet "$GOHOME"/snapd_*.deb "bionic/$GOHOME/"
     lxc exec bionic -- apt install -y "$GOHOME"/snapd_*.deb
     lxc exec bionic -- snap set core experimental.robust-mount-namespace-updates=true
-execute: |
-    # first command is done twice due to https://bugs.launchpad.net/snapd/+bug/1865503
-    lxc exec bionic -- snap install maas --channel=2.7/edge
-    lxc exec bionic -- snap install maas --channel=2.7/edge
-    lxc exec bionic -- snap remove maas
+
 restore: |
     lxc stop --force bionic
     lxc delete bionic
     snap remove --purge lxd
     "$TESTSTOOLS"/lxd-state undo-mount-changes
+
 debug: |
     lxc exec bionic -- bash -c "SNAPD_DEBUG=1 /usr/lib/snapd/snap-update-ns maas"
+
+execute: |
+    # first command is done twice due to https://bugs.launchpad.net/snapd/+bug/1865503
+    lxc exec bionic -- snap install maas --channel=2.7/edge
+    lxc exec bionic -- snap install maas --channel=2.7/edge
+    lxc exec bionic -- snap remove maas

--- a/tests/regression/lp-1871652/task.yaml
+++ b/tests/regression/lp-1871652/task.yaml
@@ -1,6 +1,8 @@
 summary: system key mismatch is ignored on reboot/shutdown
+
 # Run on a system matching the guest container.
 systems: [ubuntu-18.04-64]
+
 prepare: |
     snap install lxd --channel="$LXD_SNAP_CHANNEL"
     lxd init --auto
@@ -47,6 +49,13 @@ prepare: |
     # Put our special systemctl and make it executable
     lxc file push systemctl bionic/usr/local/bin/systemctl
     lxc exec bionic -- chmod +x /usr/local/bin/systemctl
+
+restore: |
+    lxc exec bionic -- chmod -x /usr/local/bin/systemctl
+    lxc stop --force bionic
+    snap remove --purge lxd
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
+
 execute: |
     # Try to stop LXD in a way that matches what happens when we are shutting
     # down. Use the special variable controlling retry count, so that we don't
@@ -56,8 +65,3 @@ execute: |
     # then fail, with the fix it should be under one second but we allow for up
     # to five. The comparison is performed in milliseconds.
     test "$(LC_NUMERIC=C awk '/real/ { print($2 * 1000); exit(0);}' < stop.time)" -lt 5000
-restore: |
-    lxc exec bionic -- chmod -x /usr/local/bin/systemctl
-    lxc stop --force bionic
-    snap remove --purge lxd
-    "$TESTSTOOLS"/lxd-state undo-mount-changes

--- a/tests/regression/lp-1899664/task.yaml
+++ b/tests/regression/lp-1899664/task.yaml
@@ -1,8 +1,15 @@
 summary: Test that read-only filesystem on /etc/dbus-1/session.d doesn't prevent snapd refresh.
+
 systems: [ubuntu-core-18-64]
 
 prepare: |
   mount -t tmpfs tmptfs -o ro /etc/dbus-1/session.d
+
+restore: |
+  umount /etc/dbus-1/session.d
+
+  # restore snapd installed originally
+  snap revert snapd
 
 execute: |
   # we are running current snapd build, re-install it to trigger core18
@@ -11,8 +18,3 @@ execute: |
   snap install --dangerous "/var/lib/snapd/seed/snaps/snapd_${current}.snap"
   journalctl -u snapd | MATCH "appears to be read-only, could not write snapd dbus config files"
 
-restore: |
-  umount /etc/dbus-1/session.d
-
-  # restore snapd installed originally
-  snap revert snapd

--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -1,16 +1,16 @@
 summary: Check that installing and running a snap works
 
-debug: |
-    if test -e stderr.log; then
-        echo "content of stderr.log"
-        cat stderr.log
-    fi
-
 restore: |
     rm -f stderr.log
     rm -f stdout.log
     # requied! in autopkgtest no suite restore is run at all
     snap remove --purge test-snapd-sh
+
+debug: |
+    if test -e stderr.log; then
+        echo "content of stderr.log"
+        cat stderr.log
+    fi
 
 execute: |
     #shellcheck source=tests/lib/systems.sh

--- a/tests/unit/shell-traps/task.yaml
+++ b/tests/unit/shell-traps/task.yaml
@@ -1,9 +1,11 @@
 summary: shell is tricky
+
 details: |
     shell can be surprisingly tricky, this test captures some of the things
     we've learned and now guard against. The test is expected to pass all the
     time, it simply contains "executable documentation" that is meant to
     illustrate how non-obvious some behavior is.
+
 # 1: increment if you had to read this or edit this
 execute: |
     # NOTE: Disable set -e that was implicitly provided by spread and check for

--- a/tests/upgrade/sudoers-conffile-removal/task.yaml
+++ b/tests/upgrade/sudoers-conffile-removal/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure conffile removal from upgrades <2.46 works
 
-description: |
+details: |
     Ensure that upgrading from 2.45.1 works and conffile cleanup for
     /etc/sudoers.d/99-snapd.conf happens.
     


### PR DESCRIPTION
The change updates the layout of the tests (other than main suite tests) following a proposed order which should make the test easier to read and understand

The proposed order is:
summary
details

backends
systems

manual
priority
warn-timeout
kill-timeout

environment
prepare
restore
debug
execute
