### PR TITLE
daemon: make ucrednetGet() return a *ucrednet structure

### DIFF
--- a/daemon/api_snapctl.go
+++ b/daemon/api_snapctl.go
@@ -52,7 +52,7 @@ func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("snapctl cannot run without args")
 	}
 
-	_, uid, _, err := ucrednetGet(r.RemoteAddr)
+	ucred, err := ucrednetGet(r.RemoteAddr)
 	if err != nil {
 		return Forbidden("cannot get remote user: %s", err)
 	}
@@ -69,7 +69,7 @@ func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
 		context.Unlock()
 	}
 
-	stdout, stderr, err := ctlcmdRun(context, snapctlPostData.Args, uid)
+	stdout, stderr, err := ctlcmdRun(context, snapctlPostData.Args, ucred.Uid)
 	if err != nil {
 		if e, ok := err.(*ctlcmd.UnsuccessfulError); ok {
 			result := map[string]interface{}{

--- a/daemon/api_snapctl_test.go
+++ b/daemon/api_snapctl_test.go
@@ -52,7 +52,7 @@ func (s *snapctlSuite) TestSnapctlForbiddenError(c *check.C) {
 	s.daemon(c)
 
 	defer daemon.MockUcrednetGet(func(string) (*daemon.Ucrednet, error) {
-		return &daemon.Ucrednet{100, 9999, dirs.SnapSocket}, nil
+		return &daemon.Ucrednet{Uid: 100, Pid: 9999, Socket: dirs.SnapSocket}, nil
 	})()
 
 	defer daemon.MockCtlcmdRun(func(ctx *hookstate.Context, arg []string, uid uint32) ([]byte, []byte, error) {
@@ -70,7 +70,7 @@ func (s *snapctlSuite) TestSnapctlUnsuccesfulError(c *check.C) {
 	s.daemon(c)
 
 	defer daemon.MockUcrednetGet(func(string) (*daemon.Ucrednet, error) {
-		return &daemon.Ucrednet{100, 9999, dirs.SnapSocket}, nil
+		return &daemon.Ucrednet{Uid: 100, Pid: 9999, Socket: dirs.SnapSocket}, nil
 	})()
 
 	defer daemon.MockCtlcmdRun(func(ctx *hookstate.Context, arg []string, uid uint32) ([]byte, []byte, error) {

--- a/daemon/api_snapctl_test.go
+++ b/daemon/api_snapctl_test.go
@@ -51,8 +51,8 @@ func (s *snapctlSuite) TestSnapctlGetNoUID(c *check.C) {
 func (s *snapctlSuite) TestSnapctlForbiddenError(c *check.C) {
 	s.daemon(c)
 
-	defer daemon.MockUcrednetGet(func(string) (int32, uint32, string, error) {
-		return 100, 9999, dirs.SnapSocket, nil
+	defer daemon.MockUcrednetGet(func(string) (*daemon.Ucrednet, error) {
+		return &daemon.Ucrednet{100, 9999, dirs.SnapSocket}, nil
 	})()
 
 	defer daemon.MockCtlcmdRun(func(ctx *hookstate.Context, arg []string, uid uint32) ([]byte, []byte, error) {
@@ -69,8 +69,8 @@ func (s *snapctlSuite) TestSnapctlForbiddenError(c *check.C) {
 func (s *snapctlSuite) TestSnapctlUnsuccesfulError(c *check.C) {
 	s.daemon(c)
 
-	defer daemon.MockUcrednetGet(func(string) (int32, uint32, string, error) {
-		return 100, 9999, dirs.SnapSocket, nil
+	defer daemon.MockUcrednetGet(func(string) (*daemon.Ucrednet, error) {
+		return &daemon.Ucrednet{100, 9999, dirs.SnapSocket}, nil
 	})()
 
 	defer daemon.MockCtlcmdRun(func(ctx *hookstate.Context, arg []string, uid uint32) ([]byte, []byte, error) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -148,15 +148,13 @@ func (c *Command) canAccess(r *http.Request, user *auth.UserState) accessResult 
 		return accessOK
 	}
 
-	// isUser means we have a UID for the request
-	isUser := false
 	ucred, err := ucrednetGet(r.RemoteAddr)
-	if err == nil {
-		isUser = true
-	} else if err != errNoID {
+	if err != nil && err != errNoID {
 		logger.Noticef("unexpected error when attempting to get UID: %s", err)
 		return accessForbidden
 	}
+	// isUser means we have a UID for the request
+	isUser := ucred != nil
 	isSnap := (ucred != nil && ucred.Socket == dirs.SnapSocket)
 
 	// ensure that snaps can only access SnapOK things

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -150,14 +150,14 @@ func (c *Command) canAccess(r *http.Request, user *auth.UserState) accessResult 
 
 	// isUser means we have a UID for the request
 	isUser := false
-	pid, uid, socket, err := ucrednetGet(r.RemoteAddr)
+	ucred, err := ucrednetGet(r.RemoteAddr)
 	if err == nil {
 		isUser = true
 	} else if err != errNoID {
 		logger.Noticef("unexpected error when attempting to get UID: %s", err)
 		return accessForbidden
 	}
-	isSnap := (socket == dirs.SnapSocket)
+	isSnap := (ucred != nil && ucred.Socket == dirs.SnapSocket)
 
 	// ensure that snaps can only access SnapOK things
 	if isSnap {
@@ -184,7 +184,7 @@ func (c *Command) canAccess(r *http.Request, user *auth.UserState) accessResult 
 		return accessUnauthorized
 	}
 
-	if uid == 0 {
+	if ucred.Uid == 0 {
 		// Superuser does anything.
 		return accessOK
 	}
@@ -204,7 +204,7 @@ func (c *Command) canAccess(r *http.Request, user *auth.UserState) accessResult 
 			}
 		}
 		// Pass both pid and uid from the peer ucred to avoid pid race
-		if authorized, err := polkitCheckAuthorization(pid, uid, c.PolkitOK, nil, flags); err == nil {
+		if authorized, err := polkitCheckAuthorization(ucred.Pid, ucred.Uid, c.PolkitOK, nil, flags); err == nil {
 			if authorized {
 				// polkit says user is authorised
 				return accessOK

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -63,7 +63,9 @@ func (d *Daemon) RequestedRestart() state.RestartType {
 	return d.requestedRestart
 }
 
-func MockUcrednetGet(mock func(remoteAddr string) (pid int32, uid uint32, socket string, err error)) (restore func()) {
+type Ucrednet = ucrednet
+
+func MockUcrednetGet(mock func(remoteAddr string) (ucred *Ucrednet, err error)) (restore func()) {
 	oldUcrednetGet := ucrednetGet
 	ucrednetGet = mock
 	return func() {

--- a/daemon/ucrednet_test.go
+++ b/daemon/ucrednet_test.go
@@ -74,10 +74,10 @@ func (s *ucrednetSuite) TestAcceptConnRemoteAddrString(c *check.C) {
 
 	remoteAddr := conn.RemoteAddr().String()
 	c.Check(remoteAddr, check.Matches, "pid=100;uid=42;.*")
-	pid, uid, _, err := ucrednetGet(remoteAddr)
-	c.Check(pid, check.Equals, int32(100))
-	c.Check(uid, check.Equals, uint32(42))
-	c.Check(err, check.IsNil)
+	u, err := ucrednetGet(remoteAddr)
+	c.Assert(err, check.IsNil)
+	c.Check(u.Pid, check.Equals, int32(100))
+	c.Check(u.Uid, check.Equals, uint32(42))
 }
 
 func (s *ucrednetSuite) TestNonUnix(c *check.C) {
@@ -101,9 +101,8 @@ func (s *ucrednetSuite) TestNonUnix(c *check.C) {
 
 	remoteAddr := conn.RemoteAddr().String()
 	c.Check(remoteAddr, check.Matches, "pid=;uid=;.*")
-	pid, uid, _, err := ucrednetGet(remoteAddr)
-	c.Check(pid, check.Equals, ucrednetNoProcess)
-	c.Check(uid, check.Equals, ucrednetNobody)
+	u, err := ucrednetGet(remoteAddr)
+	c.Check(u, check.IsNil)
 	c.Check(err, check.Equals, errNoID)
 }
 
@@ -157,45 +156,39 @@ func (s *ucrednetSuite) TestIdempotentClose(c *check.C) {
 }
 
 func (s *ucrednetSuite) TestGetNoUid(c *check.C) {
-	pid, uid, _, err := ucrednetGet("pid=100;uid=;socket=;")
+	u, err := ucrednetGet("pid=100;uid=;socket=;")
 	c.Check(err, check.Equals, errNoID)
-	c.Check(pid, check.Equals, ucrednetNoProcess)
-	c.Check(uid, check.Equals, ucrednetNobody)
+	c.Check(u, check.IsNil)
 }
 
 func (s *ucrednetSuite) TestGetBadUid(c *check.C) {
-	pid, uid, _, err := ucrednetGet("pid=100;uid=4294967296;socket=;")
-	c.Check(err, check.NotNil)
-	c.Check(pid, check.Equals, int32(100))
-	c.Check(uid, check.Equals, ucrednetNobody)
+	u, err := ucrednetGet("pid=100;uid=4294967296;socket=;")
+	c.Check(err, check.Equals, errNoID)
+	c.Check(u, check.IsNil)
 }
 
 func (s *ucrednetSuite) TestGetNonUcrednet(c *check.C) {
-	pid, uid, _, err := ucrednetGet("hello")
+	u, err := ucrednetGet("hello")
 	c.Check(err, check.Equals, errNoID)
-	c.Check(pid, check.Equals, ucrednetNoProcess)
-	c.Check(uid, check.Equals, ucrednetNobody)
+	c.Check(u, check.IsNil)
 }
 
 func (s *ucrednetSuite) TestGetNothing(c *check.C) {
-	pid, uid, _, err := ucrednetGet("")
+	u, err := ucrednetGet("")
 	c.Check(err, check.Equals, errNoID)
-	c.Check(pid, check.Equals, ucrednetNoProcess)
-	c.Check(uid, check.Equals, ucrednetNobody)
+	c.Check(u, check.IsNil)
 }
 
 func (s *ucrednetSuite) TestGet(c *check.C) {
-	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket;")
-	c.Check(err, check.IsNil)
-	c.Check(pid, check.Equals, int32(100))
-	c.Check(uid, check.Equals, uint32(42))
-	c.Check(socket, check.Equals, "/run/snap.socket")
+	u, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket;")
+	c.Assert(err, check.IsNil)
+	c.Check(u.Pid, check.Equals, int32(100))
+	c.Check(u.Uid, check.Equals, uint32(42))
+	c.Check(u.Socket, check.Equals, "/run/snap.socket")
 }
 
 func (s *ucrednetSuite) TestGetSneak(c *check.C) {
-	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket;pid=0;uid=0;socket=/tmp/my.socket")
+	u, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket;pid=0;uid=0;socket=/tmp/my.socket")
 	c.Check(err, check.Equals, errNoID)
-	c.Check(pid, check.Equals, ucrednetNoProcess)
-	c.Check(uid, check.Equals, ucrednetNobody)
-	c.Check(socket, check.Equals, "")
+	c.Check(u, check.IsNil)
 }


### PR DESCRIPTION
This PR extracts the ucrednet cleanup from PR #9043 into its own pull request.  It updates the `ucrednetGet` helper to return a `ucrednet` struct rather than return the three credentials separately.