### PR TITLE
daemon: add new accessChecker implementations

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -122,8 +122,8 @@ func (ac authenticatedAccess) CheckAccess(r *http.Request, ucred *ucrednet, user
 	}
 
 	// We check polkit last because it may result in the user
-	// being prompted for authorisation.  This should be avoided
-	// if access is otherwise granted.
+	// being prompted for authorisation. This should be avoided if
+	// access is otherwise granted.
 	if ac.Polkit != "" {
 		return checkPolkitAction(r, ucred, ac.Polkit)
 	}

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -1,0 +1,163 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/polkit"
+)
+
+type accessResult int
+
+const (
+	accessOK accessResult = iota
+	accessUnauthorized
+	accessForbidden
+	accessCancelled
+)
+
+var (
+	polkitCheckAuthorization = polkit.CheckAuthorization
+	checkPolkitAction        = checkPolkitActionImpl
+)
+
+func checkPolkitActionImpl(r *http.Request, ucred *ucrednet, action string) accessResult {
+	var flags polkit.CheckFlags
+	allowHeader := r.Header.Get(client.AllowInteractionHeader)
+	if allowHeader != "" {
+		if allow, err := strconv.ParseBool(allowHeader); err != nil {
+			logger.Noticef("error parsing %s header: %s", client.AllowInteractionHeader, err)
+		} else if allow {
+			flags |= polkit.CheckAllowInteraction
+		}
+	}
+	// Pass both pid and uid from the peer ucred to avoid pid race
+	switch authorized, err := polkitCheckAuthorization(ucred.Pid, ucred.Uid, action, nil, flags); err {
+	case nil:
+		if authorized {
+			// polkit says user is authorised
+			return accessOK
+		}
+	case polkit.ErrDismissed:
+		return accessCancelled
+	default:
+		logger.Noticef("polkit error: %s", err)
+	}
+	return accessUnauthorized
+}
+
+// accessChecker checks whether a particular request is allowed.
+//
+// An access checker will either allow a request, deny it, or return
+// accessUnknown, which indicates the decision should be delegated to
+// the next access checker.
+type accessChecker interface {
+	checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult
+}
+
+// requireSnapdSocket ensures the request was received via snapd.socket.
+func requireSnapdSocket(ucred *ucrednet) accessResult {
+	if ucred == nil {
+		return accessForbidden
+	}
+
+	if ucred.Socket != dirs.SnapdSocket {
+		return accessForbidden
+	}
+
+	return accessOK
+}
+
+// openAccess allows requests without authentication, provided they
+// have peer credentials and were not received on snapd-snap.socket
+type openAccess struct{}
+
+func (ac openAccess) checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
+	return requireSnapdSocket(ucred)
+}
+
+// authenticatedAccess allows requests from authenticated users,
+// provided they were not received on snapd-snap.socket
+//
+// A user is considered authenticated if they provide a macaroon, are
+// the root user according to peer credentials, or granted access by
+// Polkit.
+type authenticatedAccess struct {
+	Polkit string
+}
+
+func (ac authenticatedAccess) checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
+	if result := requireSnapdSocket(ucred); result != accessOK {
+		return result
+	}
+
+	if user != nil {
+		return accessOK
+	}
+
+	if ucred.Uid == 0 {
+		return accessOK
+	}
+
+	// We check polkit last because it may result in the user
+	// being prompted for authorisation.  This should be avoided
+	// if access is otherwise granted.
+	if ac.Polkit != "" {
+		return checkPolkitAction(r, ucred, ac.Polkit)
+	}
+
+	return accessUnauthorized
+}
+
+// rootAccess allows requests from the root uid, provided they
+// were not received on snapd-snap.socket
+type rootAccess struct{}
+
+func (ac rootAccess) checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
+	if result := requireSnapdSocket(ucred); result != accessOK {
+		return result
+	}
+
+	if ucred.Uid == 0 {
+		return accessOK
+	}
+	return accessForbidden
+}
+
+// snapAccess allows requests from the snapd-snap.socket
+type snapAccess struct{}
+
+func (ac snapAccess) checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
+	if ucred == nil {
+		return accessForbidden
+	}
+
+	if ucred.Socket == dirs.SnapSocket {
+		return accessOK
+	}
+	// FIXME: should snapctl access be allowed on the main socket?
+	return accessForbidden
+}

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -39,10 +39,9 @@ const (
 	accessCancelled
 )
 
-var (
-	polkitCheckAuthorization = polkit.CheckAuthorization
-	checkPolkitAction        = checkPolkitActionImpl
-)
+var polkitCheckAuthorization = polkit.CheckAuthorization
+
+var checkPolkitAction = checkPolkitActionImpl
 
 func checkPolkitActionImpl(r *http.Request, ucred *ucrednet, action string) accessResult {
 	var flags polkit.CheckFlags
@@ -75,7 +74,7 @@ func checkPolkitActionImpl(r *http.Request, ucred *ucrednet, action string) acce
 // accessUnknown, which indicates the decision should be delegated to
 // the next access checker.
 type accessChecker interface {
-	checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult
+	CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult
 }
 
 // requireSnapdSocket ensures the request was received via snapd.socket.
@@ -95,7 +94,7 @@ func requireSnapdSocket(ucred *ucrednet) accessResult {
 // have peer credentials and were not received on snapd-snap.socket
 type openAccess struct{}
 
-func (ac openAccess) checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
+func (ac openAccess) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
 	return requireSnapdSocket(ucred)
 }
 
@@ -109,7 +108,7 @@ type authenticatedAccess struct {
 	Polkit string
 }
 
-func (ac authenticatedAccess) checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
+func (ac authenticatedAccess) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
 	if result := requireSnapdSocket(ucred); result != accessOK {
 		return result
 	}
@@ -136,7 +135,7 @@ func (ac authenticatedAccess) checkAccess(r *http.Request, ucred *ucrednet, user
 // were not received on snapd-snap.socket
 type rootAccess struct{}
 
-func (ac rootAccess) checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
+func (ac rootAccess) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
 	if result := requireSnapdSocket(ucred); result != accessOK {
 		return result
 	}
@@ -150,7 +149,7 @@ func (ac rootAccess) checkAccess(r *http.Request, ucred *ucrednet, user *auth.Us
 // snapAccess allows requests from the snapd-snap.socket
 type snapAccess struct{}
 
-func (ac snapAccess) checkAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
+func (ac snapAccess) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) accessResult {
 	if ucred == nil {
 		return accessForbidden
 	}

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -1,0 +1,217 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/polkit"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type accessSuite struct{}
+
+var _ = Suite(&accessSuite{})
+
+func (s *accessSuite) TestOpenAccess(c *C) {
+	var ac accessChecker = openAccess{}
+
+	// openAccess denies access from snapd-snap.socket
+	ucred := &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.checkAccess(nil, ucred, nil), Equals, accessForbidden)
+
+	// Access allowed from other sockets
+	ucred.Socket = dirs.SnapdSocket
+	c.Check(ac.checkAccess(nil, ucred, nil), Equals, accessOK)
+
+	// Access forbidden without peer credentials.  This will need
+	// to be revisited if the API is ever exposed over TCP.
+	c.Check(ac.checkAccess(nil, nil, nil), Equals, accessForbidden)
+}
+
+func (s *accessSuite) TestAuthenticatedAccess(c *C) {
+	defer func() {
+		checkPolkitAction = checkPolkitActionImpl
+	}()
+	checkPolkitAction = func(r *http.Request, ucred *ucrednet, action string) accessResult {
+		// Polkit is not consulted if no action is specified
+		c.Fail()
+		return accessForbidden
+	}
+
+	var ac accessChecker = authenticatedAccess{}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	user := &auth.UserState{}
+
+	// authenticatedAccess denies access from snapd-snap.socket
+	ucred := &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.checkAccess(req, ucred, nil), Equals, accessForbidden)
+	c.Check(ac.checkAccess(req, ucred, user), Equals, accessForbidden)
+
+	// With macaroon auth, a normal user is granted access
+	ucred = &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.checkAccess(req, ucred, user), Equals, accessOK)
+
+	// Macaroon access requires peer credentials
+	c.Check(ac.checkAccess(req, nil, user), Equals, accessForbidden)
+
+	// Without macaroon auth, normal users are unauthorized
+	c.Check(ac.checkAccess(req, ucred, nil), Equals, accessUnauthorized)
+
+	// The root user is granted access without a macaroon
+	ucred = &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.checkAccess(req, ucred, nil), Equals, accessOK)
+}
+
+func (s *accessSuite) TestAuthenticatedAccessPolkit(c *C) {
+	defer func() {
+		checkPolkitAction = checkPolkitActionImpl
+	}()
+
+	var ac accessChecker = authenticatedAccess{Polkit: "action-id"}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	user := &auth.UserState{}
+	ucred := &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+
+	// polkit is not checked if any of:
+	//   * ucred is missing
+	//   * macaroon auth is provided
+	//   * user is root
+	checkPolkitAction = func(r *http.Request, ucred *ucrednet, action string) accessResult {
+		c.Fail()
+		return accessForbidden
+	}
+	c.Check(ac.checkAccess(req, nil, nil), Equals, accessForbidden)
+	c.Check(ac.checkAccess(req, nil, user), Equals, accessForbidden)
+	c.Check(ac.checkAccess(req, ucred, nil), Equals, accessOK)
+
+	// polkit is checked for regular users without macaroon auth
+	checkPolkitAction = func(r *http.Request, u *ucrednet, action string) accessResult {
+		c.Check(r, Equals, req)
+		c.Check(u, Equals, ucred)
+		c.Check(action, Equals, "action-id")
+		return accessOK
+	}
+	ucred = &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.checkAccess(req, ucred, nil), Equals, accessOK)
+}
+
+func (s *accessSuite) TestCheckPolkitActionImpl(c *C) {
+	defer func() {
+		polkitCheckAuthorization = polkit.CheckAuthorization
+	}()
+
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	req := httptest.NewRequest("GET", "/", nil)
+	ucred := &ucrednet{Uid: 42, Pid: 1000, Socket: dirs.SnapdSocket}
+
+	// Access granted if polkit authorizes the request
+	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+		c.Check(pid, Equals, int32(1000))
+		c.Check(uid, Equals, uint32(42))
+		c.Check(actionId, Equals, "action-id")
+		c.Check(details, IsNil)
+		c.Check(flags, Equals, polkit.CheckFlags(0))
+		return true, nil
+	}
+	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessOK)
+	c.Check(logbuf.String(), Equals, "")
+
+	// Unauthorized if polkit denies the request
+	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+		return false, nil
+	}
+	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessUnauthorized)
+	c.Check(logbuf.String(), Equals, "")
+
+	// Cancelled if the user dismisses the auth check
+	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+		return false, polkit.ErrDismissed
+	}
+	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessCancelled)
+	c.Check(logbuf.String(), Equals, "")
+
+	// The X-Allow-Interaction header can be set to tell polkitd
+	// that interaction with the user is allowed.
+	req.Header.Set(client.AllowInteractionHeader, "true")
+	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+		c.Check(flags, Equals, polkit.CheckFlags(polkit.CheckAllowInteraction))
+		return true, nil
+	}
+	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessOK)
+	c.Check(logbuf.String(), Equals, "")
+
+	// Bad values in the request header are logged
+	req.Header.Set(client.AllowInteractionHeader, "garbage")
+	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+		c.Check(flags, Equals, polkit.CheckFlags(0))
+		return true, nil
+	}
+	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessOK)
+	c.Check(logbuf.String(), testutil.Contains, "error parsing X-Allow-Interaction header:")
+}
+
+func (s *accessSuite) TestRootAccess(c *C) {
+	var ac accessChecker = rootAccess{}
+
+	user := &auth.UserState{}
+
+	// rootAccess denies access without ucred
+	c.Check(ac.checkAccess(nil, nil, nil), Equals, accessForbidden)
+	c.Check(ac.checkAccess(nil, nil, user), Equals, accessForbidden)
+
+	// rootAccess denies access from snapd-snap.socket
+	ucred := &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.checkAccess(nil, ucred, nil), Equals, accessForbidden)
+	c.Check(ac.checkAccess(nil, ucred, user), Equals, accessForbidden)
+
+	// Non-root users are forbidden, even with macaroon auth
+	ucred = &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.checkAccess(nil, ucred, nil), Equals, accessForbidden)
+	c.Check(ac.checkAccess(nil, ucred, user), Equals, accessForbidden)
+
+	// Root is granted access
+	ucred = &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.checkAccess(nil, ucred, nil), Equals, accessOK)
+}
+
+func (s *accessSuite) TestSnapAccess(c *C) {
+	var ac accessChecker = snapAccess{}
+
+	// snapAccess allows access from snapd-snap.socket
+	ucred := &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.checkAccess(nil, ucred, nil), Equals, accessOK)
+
+	// access is forbidden on the main socket or without peer creds
+	ucred.Socket = dirs.SnapdSocket
+	c.Check(ac.checkAccess(nil, ucred, nil), Equals, accessForbidden)
+	c.Check(ac.checkAccess(nil, nil, nil), Equals, accessForbidden)
+}

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon
+package daemon_test
 
 import (
 	"net/http"
@@ -26,6 +26,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -38,180 +39,177 @@ type accessSuite struct{}
 var _ = Suite(&accessSuite{})
 
 func (s *accessSuite) TestOpenAccess(c *C) {
-	var ac accessChecker = openAccess{}
+	var ac daemon.AccessChecker = daemon.OpenAccess{}
 
 	// openAccess denies access from snapd-snap.socket
-	ucred := &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, accessForbidden)
+	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, daemon.AccessForbidden)
 
 	// Access allowed from other sockets
 	ucred.Socket = dirs.SnapdSocket
-	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, accessOK)
+	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, daemon.AccessOK)
 
 	// Access forbidden without peer credentials.  This will need
 	// to be revisited if the API is ever exposed over TCP.
-	c.Check(ac.CheckAccess(nil, nil, nil), Equals, accessForbidden)
+	c.Check(ac.CheckAccess(nil, nil, nil), Equals, daemon.AccessForbidden)
 }
 
 func (s *accessSuite) TestAuthenticatedAccess(c *C) {
-	defer func() {
-		checkPolkitAction = checkPolkitActionImpl
-	}()
-	checkPolkitAction = func(r *http.Request, ucred *ucrednet, action string) accessResult {
+	restore := daemon.MockCheckPolkitAction(func(r *http.Request, ucred *daemon.Ucrednet, action string) daemon.AccessResult {
 		// Polkit is not consulted if no action is specified
 		c.Fail()
-		return accessForbidden
-	}
+		return daemon.AccessForbidden
+	})
+	defer restore()
 
-	var ac accessChecker = authenticatedAccess{}
+	var ac daemon.AccessChecker = daemon.AuthenticatedAccess{}
 
 	req := httptest.NewRequest("GET", "/", nil)
 	user := &auth.UserState{}
 
 	// authenticatedAccess denies access from snapd-snap.socket
-	ucred := &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(req, ucred, nil), Equals, accessForbidden)
-	c.Check(ac.CheckAccess(req, ucred, user), Equals, accessForbidden)
+	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.CheckAccess(req, ucred, nil), Equals, daemon.AccessForbidden)
+	c.Check(ac.CheckAccess(req, ucred, user), Equals, daemon.AccessForbidden)
 
 	// With macaroon auth, a normal user is granted access
-	ucred = &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(req, ucred, user), Equals, accessOK)
+	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.CheckAccess(req, ucred, user), Equals, daemon.AccessOK)
 
 	// Macaroon access requires peer credentials
-	c.Check(ac.CheckAccess(req, nil, user), Equals, accessForbidden)
+	c.Check(ac.CheckAccess(req, nil, user), Equals, daemon.AccessForbidden)
 
 	// Without macaroon auth, normal users are unauthorized
-	c.Check(ac.CheckAccess(req, ucred, nil), Equals, accessUnauthorized)
+	c.Check(ac.CheckAccess(req, ucred, nil), Equals, daemon.AccessUnauthorized)
 
 	// The root user is granted access without a macaroon
-	ucred = &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(req, ucred, nil), Equals, accessOK)
+	ucred = &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.CheckAccess(req, ucred, nil), Equals, daemon.AccessOK)
 }
 
 func (s *accessSuite) TestAuthenticatedAccessPolkit(c *C) {
-	defer func() {
-		checkPolkitAction = checkPolkitActionImpl
-	}()
-
-	var ac accessChecker = authenticatedAccess{Polkit: "action-id"}
+	var ac daemon.AccessChecker = daemon.AuthenticatedAccess{Polkit: "action-id"}
 
 	req := httptest.NewRequest("GET", "/", nil)
 	user := &auth.UserState{}
-	ucred := &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
 
 	// polkit is not checked if any of:
 	//   * ucred is missing
 	//   * macaroon auth is provided
 	//   * user is root
-	checkPolkitAction = func(r *http.Request, ucred *ucrednet, action string) accessResult {
+	restore := daemon.MockCheckPolkitAction(func(r *http.Request, ucred *daemon.Ucrednet, action string) daemon.AccessResult {
 		c.Fail()
-		return accessForbidden
-	}
-	c.Check(ac.CheckAccess(req, nil, nil), Equals, accessForbidden)
-	c.Check(ac.CheckAccess(req, nil, user), Equals, accessForbidden)
-	c.Check(ac.CheckAccess(req, ucred, nil), Equals, accessOK)
+		return daemon.AccessForbidden
+	})
+	defer restore()
+	c.Check(ac.CheckAccess(req, nil, nil), Equals, daemon.AccessForbidden)
+	c.Check(ac.CheckAccess(req, nil, user), Equals, daemon.AccessForbidden)
+	c.Check(ac.CheckAccess(req, ucred, nil), Equals, daemon.AccessOK)
 
 	// polkit is checked for regular users without macaroon auth
-	checkPolkitAction = func(r *http.Request, u *ucrednet, action string) accessResult {
+	restore = daemon.MockCheckPolkitAction(func(r *http.Request, u *daemon.Ucrednet, action string) daemon.AccessResult {
 		c.Check(r, Equals, req)
 		c.Check(u, Equals, ucred)
 		c.Check(action, Equals, "action-id")
-		return accessOK
-	}
-	ucred = &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(req, ucred, nil), Equals, accessOK)
+		return daemon.AccessOK
+	})
+	defer restore()
+	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.CheckAccess(req, ucred, nil), Equals, daemon.AccessOK)
 }
 
 func (s *accessSuite) TestCheckPolkitActionImpl(c *C) {
-	defer func() {
-		polkitCheckAuthorization = polkit.CheckAuthorization
-	}()
-
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
 	req := httptest.NewRequest("GET", "/", nil)
-	ucred := &ucrednet{Uid: 42, Pid: 1000, Socket: dirs.SnapdSocket}
+	ucred := &daemon.Ucrednet{Uid: 42, Pid: 1000, Socket: dirs.SnapdSocket}
 
 	// Access granted if polkit authorizes the request
-	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+	restore = daemon.MockPolkitCheckAuthorization(func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
 		c.Check(pid, Equals, int32(1000))
 		c.Check(uid, Equals, uint32(42))
 		c.Check(actionId, Equals, "action-id")
 		c.Check(details, IsNil)
 		c.Check(flags, Equals, polkit.CheckFlags(0))
 		return true, nil
-	}
-	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessOK)
+	})
+	defer restore()
+	c.Check(daemon.CheckPolkitActionImpl(req, ucred, "action-id"), Equals, daemon.AccessOK)
 	c.Check(logbuf.String(), Equals, "")
 
 	// Unauthorized if polkit denies the request
-	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+	restore = daemon.MockPolkitCheckAuthorization(func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
 		return false, nil
-	}
-	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessUnauthorized)
+	})
+	defer restore()
+	c.Check(daemon.CheckPolkitActionImpl(req, ucred, "action-id"), Equals, daemon.AccessUnauthorized)
 	c.Check(logbuf.String(), Equals, "")
 
 	// Cancelled if the user dismisses the auth check
-	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+	restore = daemon.MockPolkitCheckAuthorization(func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
 		return false, polkit.ErrDismissed
-	}
-	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessCancelled)
+	})
+	defer restore()
+	c.Check(daemon.CheckPolkitActionImpl(req, ucred, "action-id"), Equals, daemon.AccessCancelled)
 	c.Check(logbuf.String(), Equals, "")
 
 	// The X-Allow-Interaction header can be set to tell polkitd
 	// that interaction with the user is allowed.
 	req.Header.Set(client.AllowInteractionHeader, "true")
-	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+	restore = daemon.MockPolkitCheckAuthorization(func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
 		c.Check(flags, Equals, polkit.CheckFlags(polkit.CheckAllowInteraction))
 		return true, nil
-	}
-	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessOK)
+	})
+	defer restore()
+	c.Check(daemon.CheckPolkitActionImpl(req, ucred, "action-id"), Equals, daemon.AccessOK)
 	c.Check(logbuf.String(), Equals, "")
 
 	// Bad values in the request header are logged
 	req.Header.Set(client.AllowInteractionHeader, "garbage")
-	polkitCheckAuthorization = func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
+	restore = daemon.MockPolkitCheckAuthorization(func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
 		c.Check(flags, Equals, polkit.CheckFlags(0))
 		return true, nil
-	}
-	c.Check(checkPolkitActionImpl(req, ucred, "action-id"), Equals, accessOK)
+	})
+	defer restore()
+	c.Check(daemon.CheckPolkitActionImpl(req, ucred, "action-id"), Equals, daemon.AccessOK)
 	c.Check(logbuf.String(), testutil.Contains, "error parsing X-Allow-Interaction header:")
 }
 
 func (s *accessSuite) TestRootAccess(c *C) {
-	var ac accessChecker = rootAccess{}
+	var ac daemon.AccessChecker = daemon.RootAccess{}
 
 	user := &auth.UserState{}
 
 	// rootAccess denies access without ucred
-	c.Check(ac.CheckAccess(nil, nil, nil), Equals, accessForbidden)
-	c.Check(ac.CheckAccess(nil, nil, user), Equals, accessForbidden)
+	c.Check(ac.CheckAccess(nil, nil, nil), Equals, daemon.AccessForbidden)
+	c.Check(ac.CheckAccess(nil, nil, user), Equals, daemon.AccessForbidden)
 
 	// rootAccess denies access from snapd-snap.socket
-	ucred := &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, accessForbidden)
-	c.Check(ac.CheckAccess(nil, ucred, user), Equals, accessForbidden)
+	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, daemon.AccessForbidden)
+	c.Check(ac.CheckAccess(nil, ucred, user), Equals, daemon.AccessForbidden)
 
 	// Non-root users are forbidden, even with macaroon auth
-	ucred = &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, accessForbidden)
-	c.Check(ac.CheckAccess(nil, ucred, user), Equals, accessForbidden)
+	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, daemon.AccessForbidden)
+	c.Check(ac.CheckAccess(nil, ucred, user), Equals, daemon.AccessForbidden)
 
 	// Root is granted access
-	ucred = &ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, accessOK)
+	ucred = &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, daemon.AccessOK)
 }
 
 func (s *accessSuite) TestSnapAccess(c *C) {
-	var ac accessChecker = snapAccess{}
+	var ac daemon.AccessChecker = daemon.SnapAccess{}
 
 	// snapAccess allows access from snapd-snap.socket
-	ucred := &ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, accessOK)
+	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, daemon.AccessOK)
 
 	// access is forbidden on the main socket or without peer creds
 	ucred.Socket = dirs.SnapdSocket
-	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, accessForbidden)
-	c.Check(ac.CheckAccess(nil, nil, nil), Equals, accessForbidden)
+	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, daemon.AccessForbidden)
+	c.Check(ac.CheckAccess(nil, nil, nil), Equals, daemon.AccessForbidden)
 }

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -45,7 +45,7 @@ func (s *accessSuite) TestOpenAccess(c *C) {
 	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
 	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, daemon.AccessForbidden)
 
-	// Access allowed from other sockets
+	// Access allowed from snapd.socket
 	ucred.Socket = dirs.SnapdSocket
 	c.Check(ac.CheckAccess(nil, ucred, nil), Equals, daemon.AccessOK)
 
@@ -71,6 +71,10 @@ func (s *accessSuite) TestAuthenticatedAccess(c *C) {
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
 	c.Check(ac.CheckAccess(req, ucred, nil), Equals, daemon.AccessForbidden)
 	c.Check(ac.CheckAccess(req, ucred, user), Equals, daemon.AccessForbidden)
+
+	// the same for unknown sockets
+	ucred = &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: "unexpected.socket"}
+	c.Check(ac.CheckAccess(req, ucred, nil), Equals, daemon.AccessForbidden)
 
 	// With macaroon auth, a normal user is granted access
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -441,7 +441,7 @@ func (s *daemonSuite) TestPolkitAccessForGet(c *check.C) {
 	// for UserOK commands, polkit is not consulted
 	cmd.UserOK = true
 	restore := MockPolkitCheckAuthorization(func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error) {
-		c.Fatal("polkit.CheckAuthorization called")
+		panic("polkit.CheckAuthorization called")
 	})
 	defer restore()
 	c.Check(cmd.canAccess(get, nil), check.Equals, accessOK)

--- a/daemon/export_access_test.go
+++ b/daemon/export_access_test.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"net/http"
+
+	"github.com/snapcore/snapd/polkit"
+)
+
+type (
+	AccessChecker = accessChecker
+	AccessResult  = accessResult
+
+	OpenAccess          = openAccess
+	AuthenticatedAccess = authenticatedAccess
+	RootAccess          = rootAccess
+	SnapAccess          = snapAccess
+)
+
+const (
+	AccessOK           = accessOK
+	AccessUnauthorized = accessUnauthorized
+	AccessForbidden    = accessForbidden
+	AccessCancelled    = accessCancelled
+)
+
+var CheckPolkitActionImpl = checkPolkitActionImpl
+
+func MockCheckPolkitAction(new func(r *http.Request, ucred *Ucrednet, action string) AccessResult) (restore func()) {
+	old := checkPolkitAction
+	checkPolkitAction = new
+	return func() {
+		checkPolkitAction = old
+	}
+}
+
+func MockPolkitCheckAuthorization(new func(pid int32, uid uint32, actionId string, details map[string]string, flags polkit.CheckFlags) (bool, error)) (restore func()) {
+	old := polkitCheckAuthorization
+	polkitCheckAuthorization = new
+	return func() {
+		polkitCheckAuthorization = old
+	}
+}


### PR DESCRIPTION
This has been extracted from PR #9043, and builds on top of PR #10126.

This PR includes the four implementations of the new `accessChecker` interface, without the changes to actually plumb them into the REST server.  The four checkers are intended to represent the different levels of access used by the REST API:

1. `openAccess` allows unrestricted access on the main `/run/snapd.socket` socket.
2. `authenticatedAccess` allows access on `/run/snapd.socket` provided one of the following is true:
    * The user has provided a macaroon login token.
    * The user is root
    * The user is granted access by polkitd
3. `rootAccess` allows access on `/run/snapd.socket` if the user is root.
4. `snapAccess` allows access on `/run/snapd-snap.socket` (for use by `/v2/snapctl`).

The branch also updates the existing `Command.canAccess` method to use the factored out `checkPolkitAction` helper function that was part of #9043.