### PR TITLE
tests: add 20.04 to systems for nested/core

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -943,7 +943,7 @@ suites:
     tests/nested/core/:
         summary: Tests for nested images
         backends: [google-nested, qemu-nested]
-        systems: [ubuntu-16.04-64, ubuntu-18.04-64]
+        systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64]
         environment:
             NESTED_TYPE: "core"
             # Enable kvm in the qemu command line


### PR DESCRIPTION
Followup to https://github.com/snapcore/snapd/pull/10086, it missed 20.04 in spread.yaml.