### PR TITLE
 boot: set extra kernel command line arguments when making a recovery system bootable

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -224,6 +224,16 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	recoveryBlVars := map[string]string{
 		"snapd_recovery_kernel": filepath.Join("/", kernelPath),
 	}
+	if _, ok := bl.(bootloader.TrustedAssetsBootloader); ok {
+		recoveryCmdlineArgs, err := bootVarsForTrustedCommandLineFromGadget(bootWith.UnpackedGadgetDir)
+		if err != nil {
+			return fmt.Errorf("cannot obtain recovery system command line: %v", err)
+		}
+		for k, v := range recoveryCmdlineArgs {
+			recoveryBlVars[k] = v
+		}
+	}
+
 	if err := rbl.SetRecoverySystemEnv(bootWith.RecoverySystemDir, recoveryBlVars); err != nil {
 		return fmt.Errorf("cannot set recovery system environment: %v", err)
 	}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -176,20 +176,20 @@ func (s *makeBootable20Suite) TestMakeBootableImage20(c *C) {
 	model := boottest.MakeMockUC20Model()
 
 	unpackedGadgetDir := c.MkDir()
-	grubRecoveryCfg := []byte("#grub-recovery cfg")
-	grubRecoveryCfgAsset := []byte("#grub-recovery cfg from assets")
-	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub-recovery.conf"), grubRecoveryCfg, 0644)
-	restore := assets.MockInternal("grub-recovery.cfg", grubRecoveryCfgAsset)
+	grubRecoveryCfg := "#grub-recovery cfg"
+	grubRecoveryCfgAsset := "#grub-recovery cfg from assets"
+	grubCfg := "#grub cfg"
+	snaptest.PopulateDir(unpackedGadgetDir, [][]string{
+		{"grub-recovery.conf", grubRecoveryCfg},
+		{"grub.conf", grubCfg},
+		{"meta/snap.yaml", gadgetSnapYaml},
+	})
+	restore := assets.MockInternal("grub-recovery.cfg", []byte(grubRecoveryCfgAsset))
 	defer restore()
-
-	c.Assert(err, IsNil)
-	grubCfg := []byte("#grub cfg")
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
-	c.Assert(err, IsNil)
 
 	// on uc20 the seed layout if different
 	seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
-	err = os.MkdirAll(seedSnapsDirs, 0755)
+	err := os.MkdirAll(seedSnapsDirs, 0755)
 	c.Assert(err, IsNil)
 
 	baseFn, baseInfo := makeSnap(c, "core20", `name: core20
@@ -245,6 +245,85 @@ version: 5.0
 	systemGenv := grubenv.NewEnv(filepath.Join(s.rootdir, recoverySystemDir, "grubenv"))
 	c.Assert(systemGenv.Load(), IsNil)
 	c.Check(systemGenv.Get("snapd_recovery_kernel"), Equals, "/snaps/pc-kernel_5.snap")
+}
+
+func (s *makeBootable20Suite) testMakeBootableImage20CustomKernelArgs(c *C, whichFile, content, errMsg string) {
+	bootloader.Force(nil)
+	model := boottest.MakeMockUC20Model()
+
+	unpackedGadgetDir := c.MkDir()
+	grubCfg := "#grub cfg"
+	snaptest.PopulateDir(unpackedGadgetDir, [][]string{
+		{"grub.conf", grubCfg},
+		{"meta/snap.yaml", gadgetSnapYaml},
+		{whichFile, content},
+	})
+
+	// on uc20 the seed layout if different
+	seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
+	err := os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
+
+	baseFn, baseInfo := makeSnap(c, "core20", `name: core20
+type: base
+version: 5.0
+`, snap.R(3))
+	baseInSeed := filepath.Join(seedSnapsDirs, baseInfo.Filename())
+	err = os.Rename(baseFn, baseInSeed)
+	c.Assert(err, IsNil)
+	kernelFn, kernelInfo := makeSnapWithFiles(c, "pc-kernel", `name: pc-kernel
+type: kernel
+version: 5.0
+`, snap.R(5), [][]string{
+		{"kernel.efi", "I'm a kernel.efi"},
+	})
+	kernelInSeed := filepath.Join(seedSnapsDirs, kernelInfo.Filename())
+	err = os.Rename(kernelFn, kernelInSeed)
+	c.Assert(err, IsNil)
+
+	label := "20191209"
+	recoverySystemDir := filepath.Join("/systems", label)
+	bootWith := &boot.BootableSet{
+		Base:                baseInfo,
+		BasePath:            baseInSeed,
+		Kernel:              kernelInfo,
+		KernelPath:          kernelInSeed,
+		RecoverySystemDir:   recoverySystemDir,
+		RecoverySystemLabel: label,
+		UnpackedGadgetDir:   unpackedGadgetDir,
+		Recovery:            true,
+	}
+
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
+	if errMsg != "" {
+		c.Assert(err, ErrorMatches, errMsg)
+		return
+	}
+	c.Assert(err, IsNil)
+
+	// ensure the correct recovery system configuration was set
+	seedGenv := grubenv.NewEnv(filepath.Join(s.rootdir, "EFI/ubuntu/grubenv"))
+	c.Assert(seedGenv.Load(), IsNil)
+	c.Check(seedGenv.Get("snapd_recovery_system"), Equals, label)
+	// and kernel command line
+	systemGenv := grubenv.NewEnv(filepath.Join(s.rootdir, recoverySystemDir, "grubenv"))
+	c.Assert(systemGenv.Load(), IsNil)
+	c.Check(systemGenv.Get("snapd_recovery_kernel"), Equals, "/snaps/pc-kernel_5.snap")
+	c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, content)
+}
+
+func (s *makeBootable20Suite) TestMakeBootableImage20CustomKernelExtraArgs(c *C) {
+	s.testMakeBootableImage20CustomKernelArgs(c, "cmdline.extra", "foo bar baz", "")
+}
+
+func (s *makeBootable20Suite) TestMakeBootableImage20CustomKernelFullArgs(c *C) {
+	errMsg := "cannot obtain recovery system command line: full kernel command line provided by the gadget is not supported yet"
+	s.testMakeBootableImage20CustomKernelArgs(c, "cmdline.full", "foo bar baz", errMsg)
+}
+
+func (s *makeBootable20Suite) TestMakeBootableImage20CustomKernelInvalidArgs(c *C) {
+	errMsg := `cannot obtain recovery system command line: cannot use kernel command line from gadget: disallowed kernel argument "snapd_foo=bar" in cmdline.extra`
+	s.testMakeBootableImage20CustomKernelArgs(c, "cmdline.extra", "snapd_foo=bar", errMsg)
 }
 
 func (s *makeBootable20Suite) TestMakeBootableImage20UnsetRecoverySystemLabelError(c *C) {

--- a/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
+++ b/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
@@ -1,0 +1,47 @@
+summary: Verify custom kernel command line handling in UC20
+
+systems: [ubuntu-20.04-64]
+
+environment:
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+    # TODO: enable TPM once resealing with custom kernel command lines lands
+    NESTED_ENABLE_TPM: false
+    NESTED_ENABLE_SECURE_BOOT: false
+
+details: |
+    This test checks support for customized kernel command line arguments in UC20
+
+prepare: |
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    echo "Grab and prepare the gadget snap"
+    snap download --basename=pc --channel="20/edge" pc
+    unsquashfs -d pc-gadget pc.snap
+
+    echo 'hello from test' > pc-gadget/cmdline.extra
+    snap pack pc-gadget/ extra-snaps/
+
+    "$TESTSTOOLS"/nested-state build-image core
+    "$TESTSTOOLS"/nested-state create-vm core
+
+execute: |
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    # TODO: verify /proc/cmdline has the right arguments when run system support
+    # lands
+
+    echo "Transition to recover mode to verify kernel command line"
+    boot_id="$(nested_get_boot_id)"
+    # shellcheck disable=SC2016
+    nested_exec 'sudo snap reboot --recover'
+    nested_wait_for_reboot "${boot_id}"
+
+    echo "Check the vm is in recover mode"
+    nested_exec 'sudo cat /proc/cmdline' > system.cmdline
+
+    echo "Verify that system is in recover mode"
+    MATCH snapd_recovery_mode=recover < system.cmdline
+
+    MATCH 'hello from test' < system.cmdline


### PR DESCRIPTION
The branch sets up kernel command line arguments for the seed system, which makes them appear in install & recovery modes. The PR includes a simple spread test to verify that recovery mode has the right command line arguments.

Based on top of #10120.
