### PR TITLE
tests: new os.paths tool

### DIFF
--- a/tests/bin/os.paths
+++ b/tests/bin/os.paths
@@ -1,0 +1,1 @@
+../lib/tools/os.paths

--- a/tests/lib/tools/os.paths
+++ b/tests/lib/tools/os.paths
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+show_help() {
+    echo "usage: snap-mount-dir, media-dir, libexec-dir"
+    echo ""
+    echo "Get paths information for the current system"
+}
+
+snap_mount_dir() {
+    local SNAP_MOUNT_DIR=/snap
+
+    case "$SPREAD_SYSTEM" in
+        fedora-*|amazon-*|centos-*|arch-*)
+            SNAP_MOUNT_DIR=/var/lib/snapd/snap
+            ;;
+        *)
+            ;;
+    esac
+    echo "$SNAP_MOUNT_DIR"
+}
+
+media_dir() {
+    local MEDIA_DIR=/media
+
+    case "$SPREAD_SYSTEM" in
+        fedora-*|amazon-*|centos-*|arch-*|opensuse-*)
+            MEDIA_DIR=/run/media
+            ;;
+        *)
+            ;;
+    esac
+    echo "$MEDIA_DIR"
+}
+
+libexec_dir() {
+    local LIBEXEC_DIR=/usr/lib
+
+    case "$SPREAD_SYSTEM" in
+        fedora-*|amazon-*|centos-*|opensuse-tumbleweed-*)
+            LIBEXEC_DIR=/usr/libexec
+            ;;
+        *)
+            ;;
+    esac
+    echo "$LIBEXEC_DIR"
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 0
+    fi
+
+    local subcommand="$1"
+    local action=
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                action=$(echo "$subcommand" | tr '-' '_')
+                shift
+                break
+                ;;
+        esac
+    done
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "os.paths: no such command $subcommand" >&2
+        show_help
+        exit 1
+    fi
+
+    "$action" "$@"
+}
+
+main "$@"

--- a/tests/main/os.paths/task.yaml
+++ b/tests/main/os.paths/task.yaml
@@ -1,0 +1,44 @@
+summary: smoke test for the os.paths tool
+
+execute: |
+    # Check help
+    os.paths | MATCH "usage: snap-mount-dir, media-dir, libexec-dir"
+    os.paths -h | MATCH "usage: snap-mount-dir, media-dir, libexec-dir"
+    os.paths --help | MATCH "usage: snap-mount-dir, media-dir, libexec-dir"
+
+    # Validate the ubuntu systems
+    case "$SPREAD_SYSTEM" in
+        ubuntu-*)
+            os.paths snap-mount-dir | MATCH '/snap'
+            os.paths media-dir | MATCH  '/media'
+            os.paths libexec-dir | MATCH '/usr/lib'
+            ;;
+        arch-*)
+            os.paths snap-mount-dir | MATCH '/var/lib/snapd/snap'
+            os.paths media-dir | MATCH '/run/media'
+            os.paths libexec-dir | MATCH '/usr/lib'
+            ;;
+        fedora-*|amazon-*|centos-*)
+            os.paths snap-mount-dir | MATCH '/var/lib/snapd/snap'
+            os.paths media-dir | MATCH '/run/media'
+            os.paths libexec-dir | MATCH '/usr/libexec'
+            ;;
+        opensuse-tumbleweed-*)
+            os.paths snap-mount-dir | MATCH '/snap'
+            os.paths media-dir | MATCH '/run/media'
+            os.paths libexec-dir | MATCH '/usr/libexec'
+            ;;
+        opensuse-*)
+            os.paths snap-mount-dir | MATCH '/snap'
+            os.paths media-dir | MATCH '/run/media'
+            os.paths libexec-dir | MATCH '/usr/lib'
+            ;;
+    esac
+
+    # Validate the directories exist on the system
+    # Media dir is not created by default on opensuse-* and amazon-* systems
+    test -d "$(os.paths snap-mount-dir)"
+    test -d "$(os.paths libexec-dir)"
+
+    # Validate other commands are not supported 
+    os.paths noexist 2>&1 | MATCH 'os.paths: no such command noexist'


### PR DESCRIPTION
The idea of this tool is to replace the dirs.sh helper
Also should be nice to add here other paths which currently are being resolved in the scripts.
