### PR TITLE
boot,tests: move where we write boot-flags one level up

### DIFF
--- a/boot/flags.go
+++ b/boot/flags.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -196,11 +196,11 @@ func InitramfsActiveBootFlags(mode string) ([]string, error) {
 func InitramfsExposeBootFlagsForSystem(flags []string) error {
 	s := serializeBootFlags(flags)
 
-	if err := os.MkdirAll(dirs.SnapBootstrapRunDir, 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(snapBootFlagsFile), 0755); err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(snapBootstrapBootFlagsFile, []byte(s), 0644)
+	return ioutil.WriteFile(snapBootFlagsFile, []byte(s), 0644)
 }
 
 // BootFlags returns the current set of boot flags active for this boot. It uses
@@ -220,7 +220,7 @@ func BootFlags(dev Device) ([]string, error) {
 	// bootenv are for this boot or the next one, but the initramfs will always
 	// copy the flags that were set into /run, so we always know the current
 	// boot's flags are written in /run
-	b, err := ioutil.ReadFile(snapBootstrapBootFlagsFile)
+	b, err := ioutil.ReadFile(snapBootFlagsFile)
 	if err != nil {
 		return nil, err
 	}

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -258,7 +258,7 @@ func (s *bootFlagsSuite) TestInitramfsSetBootFlags(c *C) {
 	for _, t := range tt {
 		err := boot.InitramfsExposeBootFlagsForSystem(t.flags)
 		c.Assert(err, IsNil)
-		c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "boot-flags"), testutil.FileEquals, t.expFlagFile)
+		c.Assert(filepath.Join(dirs.SnapRunDir, "boot-flags"), testutil.FileEquals, t.expFlagFile)
 
 		// also read the flags as if from user space to make sure they match
 		flags, err := boot.BootFlags(uc20Dev)

--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -80,9 +80,9 @@ var (
 	// keys during the initramfs on ubuntu-boot.
 	InitramfsBootEncryptionKeyDir string
 
-	// snapBootstrapBootFlagsFile is the location of the file that is used
+	// snapBootFlagsFile is the location of the file that is used
 	// internally for saving the current boot flags active for this boot.
-	snapBootstrapBootFlagsFile string
+	snapBootFlagsFile string
 )
 
 func setInitramfsDirVars(rootdir string) {
@@ -100,7 +100,7 @@ func setInitramfsDirVars(rootdir string) {
 	InitramfsSeedEncryptionKeyDir = filepath.Join(InitramfsUbuntuSeedDir, "device/fde")
 	InitramfsBootEncryptionKeyDir = filepath.Join(InitramfsUbuntuBootDir, "device/fde")
 
-	snapBootstrapBootFlagsFile = filepath.Join(dirs.SnapBootstrapRunDir, "boot-flags")
+	snapBootFlagsFile = filepath.Join(dirs.SnapRunDir, "boot-flags")
 }
 
 func init() {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -603,7 +603,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeBootFlagsSet(c *C) 
 		c.Assert(err, IsNil)
 
 		// check that we wrote the /run file with the boot flags in it
-		c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "boot-flags"), testutil.FileEquals, t.expBootFlagsFile)
+		c.Assert(filepath.Join(dirs.SnapRunDir, "boot-flags"), testutil.FileEquals, t.expBootFlagsFile)
 	}
 }
 
@@ -677,7 +677,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBootFlagsSet(c *C) {
 		c.Assert(err, IsNil)
 
 		// check that we wrote the /run file with the boot flags in it
-		c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "boot-flags"), testutil.FileEquals, t.expBootFlagsFile)
+		c.Assert(filepath.Join(dirs.SnapRunDir, "boot-flags"), testutil.FileEquals, t.expBootFlagsFile)
 	}
 }
 
@@ -2797,7 +2797,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappy(c *C) {
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "degraded.json"), testutil.FileAbsent)
 
 	// we also should have written an empty boot-flags file
-	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "boot-flags"), testutil.FileEquals, "")
+	c.Assert(filepath.Join(dirs.SnapRunDir, "boot-flags"), testutil.FileEquals, "")
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeTimeMovesForwardHappy(c *C) {

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -78,3 +78,6 @@ execute: |
         BRAND_ID="$BRAND_ID\*"
     fi
     snap recovery --unicode=never | MATCH "[0-9]+ +$BRAND_ID +$MODEL +current"
+
+    # check that we have a boot-flags file
+    test -f /run/snapd/boot-flags


### PR DESCRIPTION
/run/snapd/snap-bootstrap is a scratch directory and user space shouldn't care a lot about it
