### PR TITLE
boot: drop gadget snap yaml which is already defined elsewhere in the tests

### DIFF
--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -58,11 +58,6 @@ func (s *sealSuite) SetUpTest(c *C) {
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
 }
 
-const gadgetSnapYaml = `name: gadget
-version: 1.0
-type: gadget
-`
-
 func mockKernelSeedSnap(c *C, rev snap.Revision) *seed.Snap {
 	return mockNamedKernelSeedSnap(c, rev, "pc-kernel")
 }


### PR DESCRIPTION
Due to merging of 2 separate branches which introduced a mock gadget snap yaml
using the same const name, we now have a name clash.

