### PR TITLE
tests: update os.query check to match new bullseye codename used on sid images

### DIFF
--- a/tests/lib/tools/os.query
+++ b/tests/lib/tools/os.query
@@ -64,7 +64,8 @@ is_debian() {
 }
 
 is_debian_sid() {
-    grep -qFx 'ID=debian' /etc/os-release && grep -qx 'PRETTY_NAME=".*/sid"' /etc/os-release
+    #TODO: remove check for bullseye codename once the os-release file is updated with sid pretty name again
+    grep -qFx 'ID=debian' /etc/os-release && ( grep -qx 'PRETTY_NAME=".*/sid"' /etc/os-release || grep -qFx  'VERSION_CODENAME=bullseye' /etc/os-release )
 }
 
 is_fedora() {


### PR DESCRIPTION
This is needed because temporarily the os-release for sid systems is showing the following info:

# cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
 
Being the apt sources used:
deb     http://deb.debian.org/debian/ sid main contrib non-free
deb-src http://deb.debian.org/debian/ sid main contrib non-free
