### PR TITLE
tests: fix gadget-kernel-refs-update-pc test on arm and when $TRUST_TEST_KEY is false

### DIFF
--- a/tests/core/gadget-kernel-refs-update-pc/task.yaml
+++ b/tests/core/gadget-kernel-refs-update-pc/task.yaml
@@ -22,6 +22,10 @@ prepare: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+    if os.query is-arm; then
+        echo "Test not supported on arm architecture, skipping..."
+        exit
+    fi
     snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh
@@ -79,6 +83,10 @@ restore: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+    if os.query is-arm; then
+        echo "Test not supported on arm architecture, skipping..."
+        exit
+    fi
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh
     teardown_fake_store "$BLOB_DIR"
@@ -86,6 +94,15 @@ restore: |
     #      restore requires a reboot :/
     
 execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    if os.query is-arm; then
+        echo "Test not supported on arm architecture, skipping..."
+        exit
+    fi
+
     if [ "$SPREAD_REBOOT" = 0 ]; then
         # first install the gadget that knows about the kernel
         # (but no edition bump so this will install fine)


### PR DESCRIPTION
This test is failing on all the devices for beta validation
The error in all cases is:
+ snap install pc_x1.snap
error: cannot open: "pc_x1.snap"