### PR TITLE
tests: fix prepare-image-grub-core18 for arm devices

### DIFF
--- a/tests/main/prepare-image-grub-core18/task.yaml
+++ b/tests/main/prepare-image-grub-core18/task.yaml
@@ -5,12 +5,9 @@ backends: [-autopkgtest]
 systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
 
 environment:
-    ROOT: /tmp/root
-    IMAGE: /tmp/root/image
-    GADGET: /tmp/root/gadget
-
-restore: |
-    rm -rf "$ROOT"
+    ROOT: "$PWD/root"
+    IMAGE: "$PWD/root/image"
+    GADGET: "$PWD/root/gadget"
 
 execute: |
     echo Running prepare-image


### PR DESCRIPTION
This change is to avoid some out of disk space errors that are happening
on arm devices.

This is the error that is happening on rpi2/3/4:

Filesystem      Size  Used Avail Use% Mounted on
tmpfs           462M  4.0K  462M   1% /tmp

Filesystem      Size  Used Avail Use% Mounted on
/dev/mmcblk0p2   30G  752M   27G   3% /home

$TESTSLIB/assertions/ubuntu-core-18-amd64.model /tmp/root
Fetching snapd
Fetching pc-kernel
Fetching core18
Fetching pc
Fetching test-snapd-tools-core18
error: cannot extract "*" to "/tmp/root/kernel": failed: "Write on
output file failed because No space left on device", "writer: failed to
write data block 6", "Failed to write
/tmp/root/kernel/firmware/iwlwifi-8000C-13.ucode, skipping", "Write on
output file failed because No space left on device", and 18164 more
