### PR TITLE
tests: use op.paths tools instead of dirs.sh helper - part 1

### DIFF
--- a/tests/core/iio/task.yaml
+++ b/tests/core/iio/task.yaml
@@ -35,15 +35,13 @@ restore: |
     rm -f /dev/iio:device0
 
 execute: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
     fi
 
     echo "Checks the snap can read from the IIO device node"
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     test "$($SNAP_MOUNT_DIR/bin/iio-consumer.read)" = "iio-0"
 
     echo "Checks the snap can write to the IIO device node"

--- a/tests/core/iio/task.yaml
+++ b/tests/core/iio/task.yaml
@@ -42,8 +42,8 @@ execute: |
 
     echo "Checks the snap can read from the IIO device node"
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-    test "$($SNAP_MOUNT_DIR/bin/iio-consumer.read)" = "iio-0"
+    test "$("$SNAP_MOUNT_DIR"/bin/iio-consumer.read)" = "iio-0"
 
     echo "Checks the snap can write to the IIO device node"
-    $SNAP_MOUNT_DIR/bin/iio-consumer.write "hello"
-    test "$($SNAP_MOUNT_DIR/bin/iio-consumer.read)" = "hello"
+    "$SNAP_MOUNT_DIR"/bin/iio-consumer.write "hello"
+    test "$("$SNAP_MOUNT_DIR"/bin/iio-consumer.read)" = "hello"

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -8,10 +8,6 @@ set -e
 # shellcheck source=tests/lib/quiet.sh
 . "$TESTSLIB/quiet.sh"
 
-# XXX: dirs.sh has side-effects
-# shellcheck source=tests/lib/dirs.sh
-. "$TESTSLIB/dirs.sh"
-
 # shellcheck source=tests/lib/pkgdb.sh
 . "$TESTSLIB/pkgdb.sh"
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -2,8 +2,6 @@
 
 set -eux
 
-# shellcheck source=tests/lib/dirs.sh
-. "$TESTSLIB/dirs.sh"
 # shellcheck source=tests/lib/snaps.sh
 . "$TESTSLIB/snaps.sh"
 # shellcheck source=tests/lib/pkgdb.sh
@@ -111,6 +109,8 @@ update_core_snap_for_classic_reexec() {
     # we re-exec by default.
     # To accomplish that, we'll just unpack the core we just grabbed,
     # shove the new snap-exec and snapctl in there, and repack it.
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    LIBEXEC_DIR="$(os.paths libexec-dir)"
 
     # First of all, unmount the core
     core="$(readlink -f "$SNAP_MOUNT_DIR/core/current" || readlink -f "$SNAP_MOUNT_DIR/ubuntu-core/current")"
@@ -122,7 +122,7 @@ update_core_snap_for_classic_reexec() {
     # clean the old snapd binaries, just in case
     rm squashfs-root/usr/lib/snapd/* squashfs-root/usr/bin/snap
     # and copy in the current libexec
-    cp -a "$LIBEXECDIR"/snapd/* squashfs-root/usr/lib/snapd/
+    cp -a "$LIBEXEC_DIR"/snapd/* squashfs-root/usr/lib/snapd/
     # also the binaries themselves
     cp -a /usr/bin/snap squashfs-root/usr/bin/
     # make sure bin/snapctl is a symlink to lib/
@@ -185,7 +185,7 @@ update_core_snap_for_classic_reexec() {
     }
 
     # Make sure we're running with the correct copied bits
-    for p in "$LIBEXECDIR/snapd/snap-exec" "$LIBEXECDIR/snapd/snap-confine" "$LIBEXECDIR/snapd/snap-discard-ns" "$LIBEXECDIR/snapd/snapd" "$LIBEXECDIR/snapd/snap-update-ns"; do
+    for p in "$LIBEXEC_DIR/snapd/snap-exec" "$LIBEXEC_DIR/snapd/snap-confine" "$LIBEXEC_DIR/snapd/snap-discard-ns" "$LIBEXEC_DIR/snapd/snapd" "$LIBEXEC_DIR/snapd/snap-update-ns"; do
         check_file "$p" "$core/usr/lib/snapd/$(basename "$p")"
     done
     for p in /usr/bin/snapctl /usr/bin/snap; do

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -x
 
-# shellcheck source=tests/lib/dirs.sh
-. "$TESTSLIB/dirs.sh"
 # shellcheck source=tests/lib/state.sh
 . "$TESTSLIB/state.sh"
 # shellcheck source=tests/lib/systemd.sh
@@ -14,6 +12,7 @@ reset_classic() {
     systemctl daemon-reload
     systemd_stop_units snapd.service snapd.socket
 
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)
             sh -x "${SPREAD_PATH}/debian/snapd.prerm" remove
@@ -109,7 +108,7 @@ reset_all_snap() {
 
     # shellcheck source=tests/lib/names.sh
     . "$TESTSLIB/names.sh"
-
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     remove_bases=""
     # remove all app snaps first
     for snap in "$SNAP_MOUNT_DIR"/*; do

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -5,9 +5,6 @@ SNAPD_STATE_FILE="$SPREAD_PATH/tests/snapd-state/snapd-state.tar"
 RUNTIME_STATE_PATH="$SPREAD_PATH/tests/runtime-state"
 SNAPD_ACTIVE_UNITS="$RUNTIME_STATE_PATH/snapd-active-units"
 
-# shellcheck source=tests/lib/dirs.sh
-. "$TESTSLIB/dirs.sh"
-
 # shellcheck source=tests/lib/systemd.sh
 . "$TESTSLIB/systemd.sh"
 
@@ -46,6 +43,7 @@ save_snapd_state() {
         cp -a /var/snap/* "$SNAPD_STATE_PATH"/var-snap/
     else
         systemctl daemon-reload
+        SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
         escaped_snap_mount_dir="$(systemd-escape --path "$SNAP_MOUNT_DIR")"
         units="$(systemctl list-unit-files --full | grep -e "^${escaped_snap_mount_dir}[-.].*\\.mount" -e "^${escaped_snap_mount_dir}[-.].*\\.service" | cut -f1 -d ' ')"
         for unit in $units; do

--- a/tests/lib/tools/snapd.tool
+++ b/tests/lib/tools/snapd.tool
@@ -47,9 +47,8 @@ main() {
 		esac
 	done
 
-	# shellcheck source=tests/lib/dirs.sh
-	. "$TESTSLIB/dirs.sh"
-	exec "$LIBEXECDIR/snapd/$tool" "$@"
+	LIBEXEC_DIR="$(os.paths libexec-dir)"
+	exec "$LIBEXEC_DIR/snapd/$tool" "$@"
 }
 
 main "$@"

--- a/tests/nightly/install-snaps/task.yaml
+++ b/tests/nightly/install-snaps/task.yaml
@@ -74,8 +74,7 @@ prepare: |
     systemctl restart snapd.socket
 
     if [ ! -d '/snap' ]; then
-        #shellcheck source=tests/lib/dirs.sh
-        . "$TESTSLIB/dirs.sh"
+        SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"        
         ln -s "$SNAP_MOUNT_DIR" /snap
     fi
 

--- a/tests/regression/lp-1630479/task.yaml
+++ b/tests/regression/lp-1630479/task.yaml
@@ -12,8 +12,6 @@ prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-tools --devmode
 
 execute: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB/dirs.sh"
     echo "We can observe the value of PATH twice"
     #shellcheck disable=SC2016
     one="$(test-snapd-tools.cmd sh -c 'echo $PATH')"
@@ -24,6 +22,7 @@ execute: |
     echo "We can make sure that it has the right value"
     [ "$one" = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" ]
     # NOTE: the following parts are notably absent from PATH
+    #  - SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     #  - $SNAP_MOUNT_DIR/test-snapd-tools/$revision/bin
     #  - $SNAP_MOUNT_DIR/test-snapd-tools/$revision/usr/bin
     #

--- a/tests/regression/lp-1644439/task.yaml
+++ b/tests/regression/lp-1644439/task.yaml
@@ -37,10 +37,9 @@ execute: |
         exit 0
     fi
 
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB/dirs.sh"
     echo "We can now run a snap command from the namespace of a snap command and see it work"
     test-snapd-tools.cmd /bin/true
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     test-snapd-tools.cmd /bin/sh -c "SNAP_CONFINE_DEBUG=yes $SNAP_MOUNT_DIR/bin/test-snapd-tools.cmd /bin/true"
     echo "We can now discard the namespace and repeat the test as a non-root user"
     /usr/lib/snapd/snap-discard-ns test-snapd-tools

--- a/tests/regression/lp-1805838/task.yaml
+++ b/tests/regression/lp-1805838/task.yaml
@@ -6,8 +6,6 @@ details: |
     but should prevent snapd from writing the system key.
 
 prepare: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
     "$TESTSTOOLS"/snaps-state install-local network-consumer
 
     version_info="$(sed -n '2 s/# //p' < /var/lib/snapd/seccomp/bpf/snap.network-consumer.network-consumer.src)"
@@ -22,7 +20,10 @@ prepare: |
     EOF
     chmod +x bad-snap-seccomp
 
-    mount --bind "$PWD/bad-snap-seccomp" "$LIBEXECDIR/snapd/snap-seccomp"
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    LIBEXEC_DIR="$(os.paths libexec-dir)"
+
+    mount --bind "$PWD/bad-snap-seccomp" "$LIBEXEC_DIR/snapd/snap-seccomp"
     test -d "$SNAP_MOUNT_DIR/core" && mount --bind "$PWD/bad-snap-seccomp" "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-seccomp"
     test -d "$SNAP_MOUNT_DIR/snapd" && mount --bind "$PWD/bad-snap-seccomp" "$SNAP_MOUNT_DIR/snapd/current/usr/lib/snapd/snap-seccomp"
     mv /var/lib/snapd/system-key /var/lib/snapd/system-key.orig
@@ -30,9 +31,10 @@ prepare: |
     echo '{}' > /var/lib/snapd/system-key
 
 restore: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-    umount "$LIBEXECDIR/snapd/snap-seccomp" || true
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    LIBEXEC_DIR="$(os.paths libexec-dir)"
+
+    umount "$LIBEXEC_DIR/snapd/snap-seccomp" || true
     test -d "$SNAP_MOUNT_DIR/core" && ( umount "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-seccomp" || true )
     test -d "$SNAP_MOUNT_DIR/snapd" && ( umount "$SNAP_MOUNT_DIR/snapd/current/usr/lib/snapd/snap-seccomp" || true )
     mv /var/lib/snapd/system-key.orig /var/lib/snapd/system-key || true

--- a/tests/regression/lp-1813963/task.yaml
+++ b/tests/regression/lp-1813963/task.yaml
@@ -5,8 +5,6 @@ systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 backends: [-external]
 
 prepare: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
     # Install the versatile test snap.
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     # Discard the mount namespace in case the snap has any hooks. We rely on
@@ -29,11 +27,14 @@ prepare: |
     systemctl stop snapd.service
     echo "snapd has been stopped" | systemd-cat
 
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    LIBEXEC_DIR="$(os.paths libexec-dir)"
+
     # Replace snap-update-ns with a fake version that waits for the given
     # amount of time before doing its real work. Since snap-update-ns doesn't
     # have access to real environment craft the script with appropriate paths
     # baked-in from the outside.
-    cp "$LIBEXECDIR/snapd/snap-update-ns" ./real-snap-update-ns
+    cp "$LIBEXEC_DIR/snapd/snap-update-ns" ./real-snap-update-ns
 
     # We could install our own go here via `snap install go --classic`
     # but instead we just run this on systems (via systems above) that
@@ -48,7 +49,7 @@ prepare: |
     go build fake-snap-update-ns.go
 
     # Replace snap-update-ns in all the places it might exist in.
-    mount --bind ./fake-snap-update-ns "$LIBEXECDIR/snapd/snap-update-ns"
+    mount --bind ./fake-snap-update-ns "$LIBEXEC_DIR/snapd/snap-update-ns"
     if [ -e "$SNAP_MOUNT_DIR/core/current/" ]; then
         mount --bind ./fake-snap-update-ns "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-update-ns"
     fi
@@ -58,9 +59,10 @@ prepare: |
     echo "snap-update-ns has been replaced" | systemd-cat
 
 restore: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-    umount "$LIBEXECDIR/snapd/snap-update-ns" || true
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    LIBEXEC_DIR="$(os.paths libexec-dir)"
+
+    umount "$LIBEXEC_DIR/snapd/snap-update-ns" || true
     if [ -e "$SNAP_MOUNT_DIR/core/current/" ]; then
         umount "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-update-ns" || true
     fi

--- a/tests/smoke/remove/task.yaml
+++ b/tests/smoke/remove/task.yaml
@@ -3,8 +3,7 @@ summary: Check that install/remove works
 execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB/dirs.sh"
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
 
     echo "Ensure remove works"

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -127,12 +127,10 @@ execute: |
     snapdver=$(snap --version|grep "snapd ")
     [ "$snapdver" != "$(cat prevsnapdver)" ]
 
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*)
             # All mount units should have been patched on upgrade
+            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
             unit_prefix="$(systemd-escape -p ${SNAP_MOUNT_DIR})"
             for unit in /etc/systemd/system/"$unit_prefix"-*.mount; do
                 MATCH 'Options=.*context=system_u:object_r:snappy_snap_t:s0' "$unit"

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -131,7 +131,7 @@ execute: |
         fedora-*|centos-*)
             # All mount units should have been patched on upgrade
             SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            unit_prefix="$(systemd-escape -p ${SNAP_MOUNT_DIR})"
+            unit_prefix="$(systemd-escape -p "${SNAP_MOUNT_DIR}")"
             for unit in /etc/systemd/system/"$unit_prefix"-*.mount; do
                 MATCH 'Options=.*context=system_u:object_r:snappy_snap_t:s0' "$unit"
             done

--- a/tests/upgrade/selinux-relabel/task.yaml
+++ b/tests/upgrade/selinux-relabel/task.yaml
@@ -9,8 +9,6 @@ execute: |
 
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB/dirs.sh"
     pkg_extension="$(distro_get_package_extension)"
 
     echo "Remove snapd and related packages"
@@ -21,13 +19,14 @@ execute: |
 
     distro_install_local_package --allow-downgrades "$GOHOME"/snap*."$pkg_extension"
 
-    ls -Z /usr/bin/snap "$LIBEXECDIR"/snapd/* > labels
+    LIBEXEC_DIR="$(os.paths libexec-dir)"
+    ls -Z /usr/bin/snap "$LIBEXEC_DIR"/snapd/* > labels
 
     MATCH "^.*system_u:object_r:snappy_cli_exec_t:s0 /usr/bin/snap$"                       < labels
-    MATCH "^.*system_u:object_r:snappy_cli_exec_t:s0 $LIBEXECDIR/snapd/snapctl$"           < labels
-    MATCH "^.*system_u:object_r:snappy_confine_exec_t:s0 $LIBEXECDIR/snapd/snap-confine$"  < labels
-    MATCH "^.*system_u:object_r:snappy_mount_exec_t:s0 $LIBEXECDIR/snapd/snap-update-ns$"  < labels
-    MATCH "^.*system_u:object_r:snappy_mount_exec_t:s0 $LIBEXECDIR/snapd/snap-discard-ns$" < labels
-    MATCH "^.*system_u:object_r:snappy_exec_t:s0 $LIBEXECDIR/snapd/snap-device-helper$"    < labels
-    MATCH "^.*system_u:object_r:snappy_exec_t:s0 $LIBEXECDIR/snapd/snap-seccomp$"          < labels
-    MATCH "^.*system_u:object_r:snappy_exec_t:s0 $LIBEXECDIR/snapd/snapd$"                 < labels
+    MATCH "^.*system_u:object_r:snappy_cli_exec_t:s0 $LIBEXEC_DIR/snapd/snapctl$"           < labels
+    MATCH "^.*system_u:object_r:snappy_confine_exec_t:s0 $LIBEXEC_DIR/snapd/snap-confine$"  < labels
+    MATCH "^.*system_u:object_r:snappy_mount_exec_t:s0 $LIBEXEC_DIR/snapd/snap-update-ns$"  < labels
+    MATCH "^.*system_u:object_r:snappy_mount_exec_t:s0 $LIBEXEC_DIR/snapd/snap-discard-ns$" < labels
+    MATCH "^.*system_u:object_r:snappy_exec_t:s0 $LIBEXEC_DIR/snapd/snap-device-helper$"    < labels
+    MATCH "^.*system_u:object_r:snappy_exec_t:s0 $LIBEXEC_DIR/snapd/snap-seccomp$"          < labels
+    MATCH "^.*system_u:object_r:snappy_exec_t:s0 $LIBEXEC_DIR/snapd/snapd$"                 < labels


### PR DESCRIPTION
The first part of the migration from dirs.sh helper to os.paths tool