### PR TITLE
snapstate: add "kernel-assets" to featureSet (2.50)

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -46,6 +46,9 @@ var featureSet = map[string]bool{
 	"snap-env": true,
 	// Support for the "command-chain" feature for apps and hooks in snap.yaml
 	"command-chain": true,
+	// Support for "kernel-assets" in gadget.yaml. I.e. having volume
+	// content of the style $kernel:ref`
+	"kernel-assets": true,
 }
 
 // supportedSystemUsernames for now contains the hardcoded list of system

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -199,7 +199,10 @@ var assumesTests = []struct {
 	version: "2.15~pre1",
 }, {
 	assumes: "[command-chain]",
-}}
+}, {
+	assumes: "[kernel-assets]",
+},
+}
 
 func (s *checkSnapSuite) TestCheckSnapAssumes(c *C) {
 	restore := snapdtool.MockVersion("2.15")


### PR DESCRIPTION
This adds the "kernel-assets" string to the feature set of snapd.

With that snaps can use: `assumes: [kernel-assets]` and snapd will
ensure that the snaps that need this feature (like the new gadget
and kernel) will only be installed when there is an updated version
of snapd.

