### PR TITLE
tests: add new command to snaps-state to get current core, kernel and gadget

### DIFF
--- a/tests/lib/tools/snaps-state
+++ b/tests/lib/tools/snaps-state
@@ -65,7 +65,8 @@ install_local_as() {
 show_name() {
     case "${1:-}" in
             core)
-                local core_name="$(snap model --verbose | grep -Po "^base:\\s+\\K.*" || true)"
+                local core_name
+                core_name="$(snap model --verbose | grep -Po "^base:\\s+\\K.*" || true)"
                 if [ -z "$core_name" ]; then
                     core_name="core"
                 fi

--- a/tests/lib/tools/snaps-state
+++ b/tests/lib/tools/snaps-state
@@ -63,15 +63,14 @@ install_local_as() {
 }
 
 show_name() {
-    local snap="$1"
-
     case "${1:-}" in
             core)
                 local core_name="$(snap model --verbose | grep -Po "^base:\\s+\\K.*" || true)"
                 if [ -z "$core_name" ]; then
                     core_name="core"
-                ;;
+                fi
                 echo "$core_name"
+                ;;
             kernel)
                 snap list | grep 'kernel$' | awk '{ print $1 }'
                 ;;

--- a/tests/lib/tools/snaps-state
+++ b/tests/lib/tools/snaps-state
@@ -4,9 +4,12 @@ show_help() {
     echo "usage: pack-local <snap-name>"
     echo "       install-local <snap-name> [OPTIONS]"
     echo "       install-local-as <snap-name> <dest-name> [OPTIONS]"
+    echo "       show-name <snap>"
     echo ""
     echo "Available options:"
     echo "  --devmode --jailmode --classic"
+    echo "Supported names:"
+    echo "  core kernel gadget"
     echo ""
     echo "Pack and install commands save the packed snap for future uses,"
     echo "which is reused on the following calls."
@@ -57,6 +60,30 @@ install_local_as() {
     local name="$2"
     shift 2
     install_local "$snap" --name "$name" "$@"
+}
+
+show_name() {
+    local snap="$1"
+
+    case "${1:-}" in
+            core)
+                local core_name="$(snap model --verbose | grep -Po "^base:\\s+\\K.*" || true)"
+                if [ -z "$core_name" ]; then
+                    core_name="core"
+                ;;
+                echo "$core_name"
+            kernel)
+                snap list | grep 'kernel$' | awk '{ print $1 }'
+                ;;
+            gadget)
+                snap list | grep 'gadget$' | awk '{ print $1 }'
+                ;;
+            *)
+                echo "snaps-state: unsupported snap $1" >&2
+                show_help
+                exit 1
+                ;;
+        esac
 }
 
 main() {

--- a/tests/main/snaps-state/task.yaml
+++ b/tests/main/snaps-state/task.yaml
@@ -74,3 +74,18 @@ execute: |
         snap remove "$SNAP_JAILMODE"
         rm -f "$TESTSLIB/snaps/${SNAP_JAILMODE}/${SNAP_JAILMODE}_1.0_all.snap"
     fi
+
+    # Check the core, kernel and gadget snap name
+    core_name=$("$TESTSTOOLS"/snaps-state show-name core)
+    kernel_name=$("$TESTSTOOLS"/snaps-state show-name kernel)
+    gadget_name=$("$TESTSTOOLS"/snaps-state show-name gadget)
+
+    # Check the core, kernel and gadget snaps
+    snap list "$core_name"
+    if os.query is-core; then
+        snap list "$kernel_name"
+        snap list "$gadget_name"
+    else
+        test -z "$kernel_name"
+        test -z "$gadget_name"
+    fi


### PR DESCRIPTION
This is going to be used to replace the names.sh helper
