### PR TITLE
browser-support: Allow firefox to run correctly under wayland

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -63,6 +63,10 @@ owner /{dev,run}/shm/{,.}org.chromium.* mrw,
 owner /{dev,run}/shm/{,.}com.google.Chrome.* mrw,
 owner /{dev,run}/shm/.io.nwjs.* mrw,
 
+# Firefox should also be modified to use snap.$SNAP_INSTANCE_NAME.* or the snap
+# packaging adjusted to use LD_PRELOAD technique from LP: #1577514
+owner /{dev,run}/shm/wayland.mozilla.ipc.[0-9]* mrw,
+
 # Chrome's Singleton API sometimes causes an ouid/fsuid mismatch denial, so
 # for now, allow non-owner read on the singleton socket (LP: #1731012). See
 # https://forum.snapcraft.io/t/electron-snap-killed-when-using-app-makesingleinstance-api/2667/20


### PR DESCRIPTION
After upgrading to 21.04 today (which uses wayland by default), the firefox snap
failed to run properly with the following denials seen from AppArmor:

AVC apparmor="DENIED" operation="mknod" profile="snap.firefox.firefox" name="/dev/shm/wayland.mozilla.ipc.3437" pid=8799 comm="Compositor" requested_mask="c" denied_mask="c" fsuid=1000 ouid=1000

Fix this by adding an appropriate rule to the browser-support interface.
