### PR TITLE
cmd/snap, boot: add snapd_full_cmdline_args to dumped boot vars

### DIFF
--- a/boot/debug.go
+++ b/boot/debug.go
@@ -72,6 +72,7 @@ func DebugDumpBootVars(w io.Writer, dir string, uc20 bool) error {
 			"recovery_system_status",
 			"try_recovery_system",
 			"snapd_extra_cmdline_args",
+			"snapd_full_cmdline_args",
 		}
 	}
 	bloader, err := bootloader.Find(dir, opts)

--- a/cmd/snap/cmd_debug_bootvars_test.go
+++ b/cmd/snap/cmd_debug_bootvars_test.go
@@ -123,6 +123,7 @@ kernel_status=
 recovery_system_status=try
 try_recovery_system=9999
 snapd_extra_cmdline_args=
+snapd_full_cmdline_args=
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	s.ResetStdStreams()


### PR DESCRIPTION
Extend the output of `snap debug boot-vars` to include the full command line override.
