### PR TITLE
[RFC] o/snapstate: handle refresh hints

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -58,6 +58,38 @@ var (
 // refreshRetryDelay specified the minimum time to retry failed refreshes
 var refreshRetryDelay = 20 * time.Minute
 
+// refreshCandidate carries information about a single snap to update as a part
+// of auto-refresh.
+type refreshCandidate struct {
+	SnapSetup
+}
+
+func (rh *refreshCandidate) Type() snap.Type {
+	return rh.SnapSetup.Type
+}
+
+func (rh *refreshCandidate) Base() string {
+	return rh.SnapSetup.Base
+}
+
+func (rh *refreshCandidate) InstanceName() string {
+	return rh.SnapSetup.InstanceName()
+}
+
+func (rh *refreshCandidate) MakeSnapSetup(st *state.State, snapst *SnapState, revnoOpts *RevisionOptions, snapUserID int) (*SnapSetup, error) {
+	rh.Channel = revnoOpts.Channel
+	rh.CohortKey = revnoOpts.CohortKey
+	return &rh.SnapSetup, nil
+}
+
+func (rh *refreshCandidate) Size() int64 {
+	return rh.DownloadInfo.Size
+}
+
+func (rh *refreshCandidate) DefaultContentPlugProviders(st *state.State) []string {
+	return rh.Prereq
+}
+
 // autoRefresh will ensure that snaps are refreshed automatically
 // according to the refresh schedule.
 type autoRefresh struct {

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -233,6 +233,10 @@ var (
 
 type AuxStoreInfo = auxStoreInfo
 
+type ManualUpdateInfo = manualUpdateInfo
+
+var NewManualUpdateInfo = newManualUpdateInfo
+
 // link, misc handlers
 var (
 	MissingDisabledServices = missingDisabledServices
@@ -258,7 +262,7 @@ func MockCurrentSnaps(f func(st *state.State) ([]*store.CurrentSnap, error)) fun
 	}
 }
 
-func MockInstallSize(f func(st *state.State, snaps []*snap.Info, userID int) (uint64, error)) func() {
+func MockInstallSize(f func(st *state.State, snaps []UpdateInfo, userID int) (uint64, error)) func() {
 	old := installSize
 	installSize = f
 	return func() {

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -61,7 +61,7 @@ func (s *prereqSuite) SetUpTest(c *C) {
 	restoreCheckFreeSpace := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error { return nil })
 	s.AddCleanup(restoreCheckFreeSpace)
 
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.UpdateInfo, userID int) (uint64, error) {
 		return 0, nil
 	})
 	s.AddCleanup(restoreInstallSize)

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -63,6 +64,7 @@ type refreshHintsTestSuite struct {
 	state *state.State
 
 	store *recordingStore
+	restoreModel func()
 }
 
 var _ = Suite(&refreshHintsTestSuite{})
@@ -91,11 +93,14 @@ func (s *refreshHintsTestSuite) SetUpTest(c *C) {
 	}
 
 	s.state.Set("refresh-privacy-key", "privacy-key")
+
+	s.restoreModel = snapstatetest.MockDeviceModel(DefaultModel())
 }
 
 func (s *refreshHintsTestSuite) TearDownTest(c *C) {
 	snapstate.CanAutoRefresh = nil
 	snapstate.AutoAliases = nil
+	s.restoreModel()
 }
 
 func (s *refreshHintsTestSuite) TestLastRefresh(c *C) {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1773,7 +1773,7 @@ func (s *snapmgrTestSuite) TestInstallFirstLocalRunThrough(c *C) {
 	// use the real thing for this one
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.UpdateInfo, userID int) (uint64, error) {
 		c.Fatalf("installSize shouldn't be hit with local install")
 		return 0, nil
 	})
@@ -2897,7 +2897,7 @@ func (s *snapmgrTestSuite) TestInstallDiskSpaceError(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestInstallSizeError(c *C) {
-	restore := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restore := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.UpdateInfo, userID int) (uint64, error) {
 		return 0, fmt.Errorf("boom")
 	})
 	defer restore()

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -168,7 +168,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	snapstate.EstimateSnapshotSize = func(st *state.State, instanceName string, users []string) (uint64, error) {
 		return 1, nil
 	}
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.UpdateInfo, userID int) (uint64, error) {
 		return 0, nil
 	})
 	s.AddCleanup(restoreInstallSize)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -5003,7 +5003,7 @@ func (s *snapmgrTestSuite) testUpdateManyDiskSpaceCheck(c *C, featureFlag, failD
 	})
 	defer restore()
 
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.UpdateInfo, userID int) (uint64, error) {
 		installSizeCalled = true
 		if failInstallSize {
 			return 0, fmt.Errorf("boom")
@@ -5628,7 +5628,7 @@ func (s *snapmgrTestSuite) testUpdateDiskSpaceCheck(c *C, featureFlag, failInsta
 
 	var installSizeCalled bool
 
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.UpdateInfo, userID int) (uint64, error) {
 		installSizeCalled = true
 		if failInstallSize {
 			return 0, fmt.Errorf("boom")

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -89,7 +89,7 @@ func refreshOptions(st *state.State, origOpts *store.RefreshOptions) (*store.Ref
 // potentially more than once. It assumes the initial list of snaps already has
 // download infos set.
 // The state must be locked by the caller.
-var installSize = func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+var installSize = func(st *state.State, snaps []UpdateInfo, userID int) (uint64, error) {
 	curSnaps, err := currentSnaps(st)
 	if err != nil {
 		return 0, err
@@ -107,21 +107,21 @@ var installSize = func(st *state.State, snaps []*snap.Info, userID int) (uint64,
 
 	var prereqs []string
 
-	resolveBaseAndContentProviders := func(snapInfo *snap.Info) {
-		if snapInfo.SnapType != snap.TypeApp {
+	resolveBaseAndContentProviders := func(inst UpdateInfo) {
+		if inst.Type() != snap.TypeApp {
 			return
 		}
-		if snapInfo.Base != "none" {
+		if inst.Base() != "none" {
 			base := defaultCoreSnapName
-			if snapInfo.Base != "" {
-				base = snapInfo.Base
+			if inst.Base() != "" {
+				base = inst.Base()
 			}
 			if !accountedSnaps[base] {
 				prereqs = append(prereqs, base)
 				accountedSnaps[base] = true
 			}
 		}
-		for _, snapName := range defaultContentPlugProviders(st, snapInfo) {
+		for _, snapName := range inst.DefaultContentPlugProviders(st) {
 			if !accountedSnaps[snapName] {
 				prereqs = append(prereqs, snapName)
 				accountedSnaps[snapName] = true
@@ -130,12 +130,12 @@ var installSize = func(st *state.State, snaps []*snap.Info, userID int) (uint64,
 	}
 
 	snapSizes := map[string]uint64{}
-	for _, snapInfo := range snaps {
-		if snapInfo.DownloadInfo.Size == 0 {
-			return 0, fmt.Errorf("internal error: download info missing for %q", snapInfo.InstanceName())
+	for _, inst := range snaps {
+		if inst.Size() == 0 {
+			return 0, fmt.Errorf("internal error: download info missing for %q", inst.InstanceName())
 		}
-		snapSizes[snapInfo.InstanceName()] = uint64(snapInfo.Size)
-		resolveBaseAndContentProviders(snapInfo)
+		snapSizes[inst.InstanceName()] = uint64(inst.Size())
+		resolveBaseAndContentProviders(inst)
 	}
 
 	opts, err := refreshOptions(st, nil)
@@ -170,7 +170,7 @@ var installSize = func(st *state.State, snaps []*snap.Info, userID int) (uint64,
 		for _, res := range results {
 			snapSizes[res.InstanceName()] = uint64(res.Size)
 			// results may have new base or content providers
-			resolveBaseAndContentProviders(res.Info)
+			resolveBaseAndContentProviders(newManualUpdateInfo(res.Info, nil))
 		}
 	}
 

--- a/overlord/snapstate/storehelpers_test.go
+++ b/overlord/snapstate/storehelpers_test.go
@@ -190,7 +190,7 @@ func (s *snapmgrTestSuite) TestInstallSizeSimple(c *C) {
 	})
 	snap2.Size = snap2Size
 
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap2}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.UpdateInfo{snapstate.NewManualUpdateInfo(snap1, nil), snapstate.NewManualUpdateInfo(snap2, nil)}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size))
 }
@@ -232,7 +232,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithBases(c *C) {
 		Current: snap.R(1),
 	})
 
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap2, snap3, snap4}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.UpdateInfo{snapstate.NewManualUpdateInfo(snap1, nil), snapstate.NewManualUpdateInfo(snap2, nil), snapstate.NewManualUpdateInfo(snap3, nil), snapstate.NewManualUpdateInfo(snap4, nil)}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+snap3Size+snap4Size+someBaseSize+otherBaseSize))
 }
@@ -262,7 +262,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithContentProviders(c *C) {
 	s.mockCoreSnap(c)
 
 	// both snaps have same content providers and base
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap2}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.UpdateInfo{snapstate.NewManualUpdateInfo(snap1, nil), snapstate.NewManualUpdateInfo(snap2, nil)}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+someBaseSize+snapContentSlotSize))
 }
@@ -284,7 +284,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithNestedDependencies(c *C) {
 
 	s.mockCoreSnap(c)
 
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.UpdateInfo{snapstate.NewManualUpdateInfo(snap1, nil)}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize+snapOtherContentSlotSize+someOtherBaseSize))
 }
@@ -323,7 +323,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithOtherChangeAffectingSameSnaps(c *C
 	})
 	snap3.Size = snap3Size
 
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap3}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.UpdateInfo{snapstate.NewManualUpdateInfo(snap1, nil), snapstate.NewManualUpdateInfo(snap3, nil)}, 0)
 	c.Assert(err, IsNil)
 	// snap3 and its base installed by another change, not counted here
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize))
@@ -342,6 +342,6 @@ func (s *snapmgrTestSuite) TestInstallSizeErrorNoDownloadInfo(c *C) {
 			RealName: "snap",
 		}}
 
-	_, err := snapstate.InstallSize(st, []*snap.Info{snap1}, 0)
+	_, err := snapstate.InstallSize(st, []snapstate.UpdateInfo{snapstate.NewManualUpdateInfo(snap1, nil)}, 0)
 	c.Assert(err, ErrorMatches, `internal error: download info missing.*`)
 }


### PR DESCRIPTION
This is WIP.

Refactor part of update logic for refresh-hints. This means introduction of new helper interface to abstract snap.Info / SnapSetup in doUpdate. Naming is almost definitely terrible and TBD.

There are a couple of XXXs to address, tests are missing and existing tests will fail.
TODO: refresh-hints need to be forgotten at certain places (e.g. when switching channels) and need to be updated once again right before auto refresh.