### PR TITLE
packaging: build without dwarf debugging data

### DIFF
--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -63,7 +63,7 @@ all: $(go_binaries)
 
 snap: GO_TAGS += nomanagers
 snap snap-seccomp:
-	go build $(if $(GO_TAGS),-tags $(GO_TAGS)) -buildmode=pie $(import_path)/cmd/$@
+	go build $(if $(GO_TAGS),-tags $(GO_TAGS)) -buildmode=pie -ldflags=-w $(import_path)/cmd/$@
 
 # Those three need to be built as static binaries. They run on the inside of a
 # nearly-arbitrary mount namespace that does not contain anything we can depend
@@ -77,9 +77,9 @@ snap-update-ns snap-exec snapctl:
 # suite to add test assertions. Do not enable this in distribution packages.
 snapd:
 ifeq ($(with_testkeys),1)
-	go build -buildmode=pie -tags withtestkeys $(import_path)/cmd/$@
+	go build -buildmode=pie -ldflags=-w -tags withtestkeys $(import_path)/cmd/$@
 else
-	go build -buildmode=pie $(import_path)/cmd/$@
+	go build -buildmode=pie -ldflags=-w $(import_path)/cmd/$@
 endif
 
 # Know how to create certain directories.

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -41,6 +41,7 @@ SYSTEMD_UNITS_DESTDIR="lib/systemd/system/"
 GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 
 BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
+BUILDFLAGS+=-ldflags=-w
 # Disable -buildmode=pie mode on all our 32bit platforms
 # (i386 and armhf). For i386 because of LP: #1711052 and for
 # armhf because of LP: #1822738


### PR DESCRIPTION
Pass -ldflags=-w to the go compiler to avoid adding DWARF debugging
meta-data. This saves quite a lot of megabytes across all the binaries,
at least on x86_64:

    $ go build -buildmode=pie
    $ ls -lh snapd
    -rwxrwxr-x 1 zyga zyga  28M Apr 15 16:26 snapd

    $ go build -buildmode=pie -ldflags=-w
    $ ls -lh snapd
    -rwxrwxr-x  1 zyga zyga  23M Apr 15 16:26 snapd

This is based on the golang FAQ
https://golang.org/doc/faq#Why_is_my_trivial_program_such_a_large_binary

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
