### PR TITLE
secboot: use secboot.{ActivateVolumeWithKeyData,SnapModelChecker}

### DIFF
--- a/boot/seal.go
+++ b/boot/seal.go
@@ -185,7 +185,7 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 			res.Handle = nil
 			res.EncryptedKey = hookOutput
 		}
-		if err := secboot.WriteKeyData(skr.KeyName, skr.KeyFile, res.EncryptedKey, auxKey[:], res.Handle); err != nil {
+		if err := secboot.WriteKeyData(skr.KeyName, skr.KeyFile, res.EncryptedKey, auxKey[:], res.Handle, model); err != nil {
 			return err
 		}
 	}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -171,10 +171,8 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 		if err := osutil.AtomicWriteFile(filepath.Join(skr.KeyFile), res.EncryptionKey, 0600, 0); err != nil {
 			return fmt.Errorf("cannot store key: %v", err)
 		}
-		if len(res.Handle) > 0 {
-			if err := osutil.AtomicWriteFile(filepath.Join(skr.KeyFile+".handle"), res.EncryptionKey, 0600, 0); err != nil {
-				return fmt.Errorf("cannot store key: %v", err)
-			}
+		if err := osutil.AtomicWriteFile(filepath.Join(skr.KeyFile+".handle"), res.Handle, 0600, 0); err != nil {
+			return fmt.Errorf("cannot store key: %v", err)
 		}
 
 	}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -159,9 +159,9 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 	}
 
 	for _, skr := range append(runKeySealRequests(key), fallbackKeySealRequests(key, saveKey)...) {
-		encryptedPayload := secboot.MarshalKeys(skr.Key[:], auxKey[:])
+		unencryptedPayload := secboot.MarshalKeys(skr.Key[:], auxKey[:])
 		params := &FDESetupHookParams{
-			Key:     encryptedPayload,
+			Key:     unencryptedPayload,
 			KeyName: skr.KeyName,
 		}
 		hookOutput, err := RunFDESetupHook("initial-setup", params)
@@ -178,7 +178,7 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 			// size of the input encrypton key we assume
 			// we deal with a v1 hook that passes us back
 			// raw binary data instead of json.
-			if len(hookOutput) != len(encryptedPayload) {
+			if len(hookOutput) != len(unencryptedPayload) {
 				return fmt.Errorf("cannot decode hook output for key %s %q: %v", skr.KeyFile, hookOutput, err)
 			}
 			// v1 hooks do not support a handle

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -162,10 +162,12 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 		// bytes and we still need to support this.
 		var res fdeSetupHookResult
 		if err := json.Unmarshal(hookOutput, &res); err != nil {
-			// TODO: check if size of hookOutput matches
-			// the size of the denver project key and only
-			// then assume it's v1 api
-			// if len(hookOutput) != sizeDenverKey { return err}
+			// If the input is not json and matches the
+			// size of the "denver" project encrypton key
+			// (64 bytes) we assume we deal with a v1 API.
+			if len(hookOutput) != len(secboot.EncryptionKey{}) {
+				return err
+			}
 			res.EncryptionKey = hookOutput
 		}
 		if err := osutil.AtomicWriteFile(filepath.Join(skr.KeyFile), res.EncryptionKey, 0600, 0); err != nil {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -74,8 +74,6 @@ type FDESetupHookParams struct {
 	Key     secboot.EncryptionKey
 	KeyName string
 
-	Models []*asserts.Model
-
 	//TODO:UC20: provide bootchains and a way to track measured
 	//boot-assets
 }
@@ -148,7 +146,6 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model
 		params := &FDESetupHookParams{
 			Key:     skr.Key,
 			KeyName: skr.KeyName,
-			Models:  []*asserts.Model{model},
 		}
 		sealedKey, err := RunFDESetupHook("initial-setup", params)
 		if err != nil {

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -1348,9 +1348,9 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way
 	c.Check(runFDESetupHookParams, DeepEquals, []*boot.FDESetupHookParams{
-		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data", Models: []*asserts.Model{model}},
-		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data", Models: []*asserts.Model{model}},
-		{Key: secboot.EncryptionKey{5, 6, 7, 8}, KeyName: "ubuntu-save", Models: []*asserts.Model{model}},
+		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data"},
+		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data"},
+		{Key: secboot.EncryptionKey{5, 6, 7, 8}, KeyName: "ubuntu-save"},
 	})
 	// check that the sealed keys got written to the expected places
 	for i, p := range []string{

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -1351,9 +1351,9 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappyV1(c *C) {
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way
 	c.Check(runFDESetupHookParams, DeepEquals, []*boot.FDESetupHookParams{
-		{Key: key, KeyName: "ubuntu-data"},
-		{Key: key, KeyName: "ubuntu-data"},
-		{Key: secboot.EncryptionKey{5, 6, 7, 8}, KeyName: "ubuntu-save"},
+		{Key: key[:], KeyName: "ubuntu-data"},
+		{Key: key[:], KeyName: "ubuntu-data"},
+		{Key: saveKey[:], KeyName: "ubuntu-save"},
 	})
 	// check that the sealed keys got written to the expected places
 	for i, p := range []string{
@@ -1497,9 +1497,9 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappyV2(c *C) {
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way
 	c.Check(runFDESetupHookParams, DeepEquals, []*boot.FDESetupHookParams{
-		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data"},
-		{Key: secboot.EncryptionKey{1, 2, 3, 4}, KeyName: "ubuntu-data"},
-		{Key: secboot.EncryptionKey{5, 6, 7, 8}, KeyName: "ubuntu-save"},
+		{Key: key[:], KeyName: "ubuntu-data"},
+		{Key: key[:], KeyName: "ubuntu-data"},
+		{Key: saveKey[:], KeyName: "ubuntu-save"},
 	})
 	// check that the sealed keys got written to the expected places
 	for i, p := range []string{

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
@@ -39,7 +39,7 @@ func init() {
 	secbootMeasureSnapModelWhenPossible = func(_ func() (*asserts.Model, error)) error {
 		return errNotImplemented
 	}
-	secbootUnlockVolumeUsingSealedKeyIfEncrypted = func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	secbootUnlockVolumeUsingSealedKeyIfEncrypted = func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		return secboot.UnlockResult{}, errNotImplemented
 	}
 	secbootUnlockEncryptedVolumeUsingKey = func(disk disks.Disk, name string, key []byte) (secboot.UnlockResult, error) {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -234,7 +234,7 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 		c.Check(f, NotNil)
 		return nil
 	}))
-	s.AddCleanup(main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	s.AddCleanup(main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		return foundUnencrypted(name), nil
 	}))
 	s.AddCleanup(main.MockSecbootLockSealedKeys(func() error {
@@ -1167,7 +1167,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeNoSaveHappyRealSyst
 	defer restore()
 
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		// this test doesn't use ubuntu-save, so we need to return an
 		// unencrypted ubuntu-data the first time, but not found the second time
 		unlockVolumeWithSealedKeyCalls++
@@ -1859,7 +1859,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C
 	c.Assert(err, IsNil)
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
 		c.Assert(opts, DeepEquals, &secboot.UnlockVolumeUsingSealedKeyOptions{
@@ -1972,7 +1972,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyNoS
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		dataActivated = true
 		// return true because we are using an encrypted device
@@ -2050,7 +2050,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyUnl
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		dataActivated = true
 		// return true because we are using an encrypted device
@@ -2934,7 +2934,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappyEncrypted(c *C
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
 
@@ -3065,7 +3065,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 	dataActivated := false
 	saveActivated := false
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 
@@ -3231,7 +3231,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 	dataActivated := false
 	saveActivationAttempted := false
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 
@@ -3411,7 +3411,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 
 	dataActivated := false
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 		case 1:
@@ -3568,7 +3568,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 
 	dataActivated := false
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 		case 1:
@@ -3716,7 +3716,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 	dataActivationAttempts := 0
 	saveActivated := false
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 
@@ -3923,7 +3923,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedAbsentDataU
 
 	dataActivated := false
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 
@@ -4106,7 +4106,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedUnencrypted
 
 	dataActivated := false
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 
@@ -4238,7 +4238,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedEncryptedDa
 	defer restore()
 
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 
@@ -4371,7 +4371,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeUnencryptedDataUnen
 	defer restore()
 
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 
@@ -4495,7 +4495,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 	dataActivated := false
 	saveActivated := false
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 
@@ -4681,7 +4681,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 	dataActivationAttempts := 0
 	saveUnsealActivationAttempted := false
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 
@@ -4876,7 +4876,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedMismatched
 	defer restore()
 
 	dataActivated := false
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"))
 
@@ -5074,7 +5074,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	defer restore()
 
 	activated := false
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		c.Assert(name, Equals, "ubuntu-data")
 		encDevPartUUID, err := disk.FindMatchingPartitionUUIDWithFsLabel(name + "-enc")
 		c.Assert(err, IsNil)
@@ -5587,7 +5587,7 @@ func (s *initramfsMountsSuite) testInitramfsMountsTryRecoveryDegraded(c *C, expe
 	restore = disks.MockMountPointDisksToPartitionMapping(mountMappings)
 	defer restore()
 	unlockVolumeWithSealedKeyCalls := 0
-	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
 		unlockVolumeWithSealedKeyCalls++
 		switch unlockVolumeWithSealedKeyCalls {
 

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -98,7 +98,7 @@ func MockDefaultMarkerFile(p string) (restore func()) {
 	}
 }
 
-func MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(f func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error)) (restore func()) {
+func MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(f func(disk disks.Disk, name string, sealedEncryptionKeyFile string, findModel func() (*asserts.Model, error), opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error)) (restore func()) {
 	old := secbootUnlockVolumeUsingSealedKeyIfEncrypted
 	secbootUnlockVolumeUsingSealedKeyIfEncrypted = f
 	return func() {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1526,15 +1526,6 @@ func (m *DeviceManager) runFDESetupHook(op string, params *boot.FDESetupHookPara
 		KeyName: params.KeyName,
 		// TODO: include boot chains
 	}
-	for _, model := range params.Models {
-		req.Models = append(req.Models, map[string]string{
-			"series":     model.Series(),
-			"brand-id":   model.BrandID(),
-			"model":      model.Model(),
-			"grade":      string(model.Grade()),
-			"signkey-id": model.SignKeyID(),
-		})
-	}
 	contextData := map[string]interface{}{
 		"fde-setup-request": req,
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1521,9 +1521,8 @@ func (m *DeviceManager) runFDESetupHook(op string, params *boot.FDESetupHookPara
 		Timeout: 5 * time.Minute,
 	}
 	req := &fde.SetupRequest{
-		Op:      op,
-		Key:     params.Key[:],
-		KeyName: params.KeyName,
+		Op:  op,
+		Key: params.Key[:],
 		// TODO: include boot chains
 	}
 	contextData := map[string]interface{}{

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1329,7 +1329,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 
 	st.Lock()
 	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
-	mockModel := s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1355,15 +1355,6 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 			Op:      "initial-setup",
 			Key:     mockKey[:],
 			KeyName: "some-key-name",
-			Models: []map[string]string{
-				{
-					"series":     "16",
-					"brand-id":   "canonical",
-					"model":      "pc",
-					"grade":      "unset",
-					"signkey-id": mockModel.SignKeyID(),
-				},
-			},
 		})
 
 		// the snapctl fde-setup-result will set the data
@@ -1381,7 +1372,6 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 	params := &boot.FDESetupHookParams{
 		Key:     mockKey,
 		KeyName: "some-key-name",
-		Models:  []*asserts.Model{mockModel},
 	}
 	st.Lock()
 	data, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)
@@ -1396,7 +1386,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrors(c *C) {
 
 	st.Lock()
 	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
-	mockModel := s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1420,7 +1410,6 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrors(c *C) {
 	params := &boot.FDESetupHookParams{
 		Key:     secboot.EncryptionKey{1, 2, 3, 4},
 		KeyName: "some-key-name",
-		Models:  []*asserts.Model{mockModel},
 	}
 	st.Lock()
 	_, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)
@@ -1433,7 +1422,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrorResult(c *C) {
 
 	st.Lock()
 	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
-	mockModel := s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1464,7 +1453,6 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrorResult(c *C) {
 	params := &boot.FDESetupHookParams{
 		Key:     secboot.EncryptionKey{1, 2, 3, 4},
 		KeyName: "some-key-name",
-		Models:  []*asserts.Model{mockModel},
 	}
 	st.Lock()
 	_, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -1352,11 +1351,10 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 		c.Check(ctx.HookName(), Equals, "fde-setup")
 		var fdeSetup fde.SetupRequest
 		ctx.Get("fde-setup-request", &fdeSetup)
-		c.Check(fdeSetup.Op, Equals, "initial-setup")
-		c.Check(fdeSetup.Key, DeepEquals, mockKey[:])
-		c.Check(strings.HasPrefix(fdeSetup.KeyName, "deprecated-"), Equals, true)
-		c.Check(fdeSetup.KeyName, HasLen, len("deprecated-")+12)
-
+		c.Check(fdeSetup, DeepEquals, fde.SetupRequest{
+			Op:  "initial-setup",
+			Key: mockKey[:],
+		})
 		// the snapctl fde-setup-result will set the data
 		ctx.Set("fde-setup-result", []byte("sealed-key"))
 		hookCalled = append(hookCalled, ctx.InstanceName())

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -1351,11 +1352,10 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 		c.Check(ctx.HookName(), Equals, "fde-setup")
 		var fdeSetup fde.SetupRequest
 		ctx.Get("fde-setup-request", &fdeSetup)
-		c.Check(fdeSetup, DeepEquals, fde.SetupRequest{
-			Op:      "initial-setup",
-			Key:     mockKey[:],
-			KeyName: "some-key-name",
-		})
+		c.Check(fdeSetup.Op, Equals, "initial-setup")
+		c.Check(fdeSetup.Key, DeepEquals, mockKey[:])
+		c.Check(strings.HasPrefix(fdeSetup.KeyName, "deprecated-"), Equals, true)
+		c.Check(fdeSetup.KeyName, HasLen, len("deprecated-")+12)
 
 		// the snapctl fde-setup-result will set the data
 		ctx.Set("fde-setup-result", []byte("sealed-key"))
@@ -1370,8 +1370,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 	defer s.o.Stop()
 
 	params := &boot.FDESetupHookParams{
-		Key:     mockKey[:],
-		KeyName: "some-key-name",
+		Key: mockKey[:],
 	}
 	st.Lock()
 	data, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)
@@ -1409,8 +1408,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrors(c *C) {
 
 	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
 	params := &boot.FDESetupHookParams{
-		Key:     mockKey[:],
-		KeyName: "some-key-name",
+		Key: mockKey[:],
 	}
 	st.Lock()
 	_, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)
@@ -1453,8 +1451,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrorResult(c *C) {
 
 	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
 	params := &boot.FDESetupHookParams{
-		Key:     mockKey[:],
-		KeyName: "some-key-name",
+		Key: mockKey[:],
 	}
 	st.Lock()
 	_, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, "initial-setup", params)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1370,7 +1370,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetup(c *C) {
 	defer s.o.Stop()
 
 	params := &boot.FDESetupHookParams{
-		Key:     mockKey,
+		Key:     mockKey[:],
 		KeyName: "some-key-name",
 	}
 	st.Lock()
@@ -1407,8 +1407,9 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrors(c *C) {
 	s.o.Loop()
 	defer s.o.Stop()
 
+	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
 	params := &boot.FDESetupHookParams{
-		Key:     secboot.EncryptionKey{1, 2, 3, 4},
+		Key:      mockKey[:],
 		KeyName: "some-key-name",
 	}
 	st.Lock()
@@ -1450,8 +1451,9 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrorResult(c *C) {
 	s.o.Loop()
 	defer s.o.Stop()
 
+	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
 	params := &boot.FDESetupHookParams{
-		Key:     secboot.EncryptionKey{1, 2, 3, 4},
+		Key:     mockKey[:],
 		KeyName: "some-key-name",
 	}
 	st.Lock()

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1409,7 +1409,7 @@ func (s *deviceMgrSuite) TestRunFdeSetupHookOpInitialSetupErrors(c *C) {
 
 	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
 	params := &boot.FDESetupHookParams{
-		Key:      mockKey[:],
+		Key:     mockKey[:],
 		KeyName: "some-key-name",
 	}
 	st.Lock()

--- a/overlord/devicestate/fde/fde.go
+++ b/overlord/devicestate/fde/fde.go
@@ -54,8 +54,7 @@ type SetupRequest struct {
 
 	// This needs to be a []byte so that Go's standard library will base64
 	// encode it automatically for us
-	Key     []byte `json:"key,omitempty"`
-	KeyName string `json:"key-name,omitempty"`
+	Key []byte `json:"key,omitempty"`
 
 	// TODO: provide LoadChains, KernelCmdline etc to support full
 	//       tpm sealing

--- a/overlord/devicestate/fde/fde.go
+++ b/overlord/devicestate/fde/fde.go
@@ -57,10 +57,6 @@ type SetupRequest struct {
 	Key     []byte `json:"key,omitempty"`
 	KeyName string `json:"key-name,omitempty"`
 
-	// List of models with their related fields, this will be set
-	// to follow the secboot:SnapModel interface.
-	Models []map[string]string `json:"models,omitempty"`
-
 	// TODO: provide LoadChains, KernelCmdline etc to support full
 	//       tpm sealing
 }

--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -52,7 +52,7 @@ $ echo '{"error":"hardware-unsupported"}' | snapctl fde-setup-result
 And then it is called again with a request to do the initial key setup:
 $ snapctl fde-setup-request
 {"op":"initial-setup", "key": "key-to-seal", "key-name":"key-for-ubuntu-data"}
-$ echo "$sealed_key" | snapctl fde-setup-result
+$ echo "{\"key\":\"$base64_encoded_sealed_key\"}" | snapctl fde-setup-result
 `)
 
 func init() {
@@ -107,7 +107,7 @@ When the fde-setup hook is called with "op":"features:
 $ echo "[]" | snapctl fde-setup-result
 
 When the fde-setup hook is called with "op":"initial-setup":
-$ echo "sealed-key" | snapctl fde-setup-result
+$ echo "{\"key\":\"$base64_encoded_sealed_key\"}" | snapctl fde-setup-result
 `)
 
 func init() {

--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -51,7 +51,7 @@ $ echo '{"error":"hardware-unsupported"}' | snapctl fde-setup-result
 
 And then it is called again with a request to do the initial key setup:
 $ snapctl fde-setup-request
-{"op":"initial-setup", "key": "key-to-seal", "key-name":"key-for-ubuntu-data"}
+{"op":"initial-setup", "key": "key-to-seal"}
 $ echo "{\"key\":\"$base64_encoded_sealed_key\"}" | snapctl fde-setup-result
 `)
 

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -129,9 +129,8 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpFeatures(c *C) {
 func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
 	fdeSetup := &fde.SetupRequest{
-		Op:      "initial-setup",
-		Key:     mockKey[:],
-		KeyName: "the-key-name",
+		Op:  "initial-setup",
+		Key: mockKey[:],
 	}
 	s.mockContext.Lock()
 	s.mockContext.Set("fde-setup-request", fdeSetup)
@@ -143,7 +142,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 	// the encryption key should be base64 encoded
 	encodedBase64Key := base64.StdEncoding.EncodeToString(mockKey[:])
 
-	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%q,"key-name":"the-key-name"}`+"\n", encodedBase64Key))
+	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%q}`+"\n", encodedBase64Key))
 	c.Check(string(stderr), Equals, "")
 }
 

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -132,15 +132,6 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 		Op:      "initial-setup",
 		Key:     mockKey[:],
 		KeyName: "the-key-name",
-		Models: []map[string]string{
-			{
-				"series":     "16",
-				"brand-id":   "my-brand",
-				"model":      "my-model",
-				"grade":      "secured",
-				"signkey-id": "the-signkey-id",
-			},
-		},
 	}
 	s.mockContext.Lock()
 	s.mockContext.Set("fde-setup-request", fdeSetup)
@@ -152,7 +143,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 	// the encryption key should be base64 encoded
 	encodedBase64Key := base64.StdEncoding.EncodeToString(mockKey[:])
 
-	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%q,"key-name":"the-key-name","models":[{"brand-id":"my-brand","grade":"secured","model":"my-model","series":"16","signkey-id":"the-signkey-id"}]}`+"\n", encodedBase64Key))
+	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%q,"key-name":"the-key-name"}`+"\n", encodedBase64Key))
 	c.Check(string(stderr), Equals, "")
 }
 

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -43,13 +43,16 @@ const (
 	auxKeySize = 32
 )
 
+// used in tests
+var randRead = rand.Read
+
 // EncryptionKey is the key used to encrypt the data partition.
 type EncryptionKey [encryptionKeySize]byte
 
 func NewEncryptionKey() (EncryptionKey, error) {
 	var key EncryptionKey
 	// rand.Read() is protected against short reads
-	_, err := rand.Read(key[:])
+	_, err := randRead(key[:])
 	// On return, n == len(b) if and only if err == nil
 	return key, err
 }
@@ -69,7 +72,7 @@ type RecoveryKey [recoveryKeySize]byte
 func NewRecoveryKey() (RecoveryKey, error) {
 	var key RecoveryKey
 	// rand.Read() is protected against short reads
-	_, err := rand.Read(key[:])
+	_, err := randRead(key[:])
 	// On return, n == len(b) if and only if err == nil
 	return key, err
 }
@@ -111,7 +114,7 @@ type AuxKey [auxKeySize]byte
 func NewAuxKey() (AuxKey, error) {
 	var key AuxKey
 	// rand.Read() is protected against short reads
-	_, err := rand.Read(key[:])
+	_, err := randRead(key[:])
 	// On return, n == len(b) if and only if err == nil
 	return key, err
 }

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -38,6 +38,9 @@ const (
 	//      github.com/snapcore/secboot/crypto.go:"type RecoveryKey"
 	// Size of the recovery key.
 	recoveryKeySize = 16
+
+	// The auxiliary key is used to bind keys to models
+	auxKeySize = 32
 )
 
 // EncryptionKey is the key used to encrypt the data partition.
@@ -98,4 +101,17 @@ func RecoveryKeyFromFile(recoveryKeyFile string) (*RecoveryKey, error) {
 		return nil, fmt.Errorf("cannot read recovery key: %v", err)
 	}
 	return &rkey, nil
+}
+
+// AuxKey is the key to bind models to keys
+//
+// Note that there is no Save() here as the read/write is done via secboot
+type AuxKey [auxKeySize]byte
+
+func NewAuxKey() (AuxKey, error) {
+	var key AuxKey
+	// rand.Read() is protected against short reads
+	_, err := rand.Read(key[:])
+	// On return, n == len(b) if and only if err == nil
+	return key, err
 }

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -227,3 +227,11 @@ func MockRandRead(f func(p []byte) (int, error)) (restore func()) {
 		randRead = oldRandRead
 	}
 }
+
+func MockSbActivateVolumeWithKeyData(f func(volumeName, sourceDevicePath string, key *sb.KeyData, options *sb.ActivateVolumeOptions) (sb.SnapModelChecker, error)) (restore func()) {
+	oldSbActivateVolumeWithKeyData := sbActivateVolumeWithKeyData
+	sbActivateVolumeWithKeyData = f
+	return func() {
+		sbActivateVolumeWithKeyData = oldSbActivateVolumeWithKeyData
+	}
+}

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -211,3 +211,11 @@ func MockFdeRevealKeyPollWaitParanoiaFactor(n int) (restore func()) {
 		fdeRevealKeyPollWaitParanoiaFactor = oldFdeRevealKeyPollWaitParanoiaFactor
 	}
 }
+
+func MockRandRead(f func(p []byte) (int, error)) (restore func()) {
+	oldRandRead := randRead
+	randRead = f
+	return func() {
+		randRead = oldRandRead
+	}
+}

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -155,6 +155,14 @@ func MockRandomKernelUUID(f func() string) (restore func()) {
 	}
 }
 
+func MockRandutilRandomString(f func(n int) string) (restore func()) {
+	old := randutilRandomString
+	randutilRandomString = f
+	return func() {
+		randutilRandomString = old
+	}
+}
+
 func MockSbInitializeLUKS2Container(f func(devicePath, label string, key []byte,
 	opts *sb.InitializeLUKS2ContainerOptions) error) (restore func()) {
 	old := sbInitializeLUKS2Container

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -26,6 +26,7 @@ package secboot
 
 import (
 	"crypto/ecdsa"
+	"errors"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
@@ -156,3 +157,7 @@ var FDEHasRevealKey = func() bool { return false }
 func EncryptedPartitionName(name string) string {
 	return name + "-enc"
 }
+
+// BuildWithoutSecbootErr is returned by many functions if the package
+// was build without real secboot support. Mostly useful for tests.
+var BuildWithoutSecbootErr = errors.New("build without secboot support")

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -36,12 +36,11 @@ func ResealKeys(params *ResealKeysParams) error {
 	return fmt.Errorf("build without secboot support")
 }
 
-func MarshalKeys(key []byte, auxKey []byte) []byte {
-	panic("not implemented")
-	return nil
+func WriteKeyData(name, path string, encryptedPayload, auxKey, rawhandle []byte) error {
+	return fmt.Errorf("build without secboot support")
 }
 
-func WriteKeyData(name, path string, encryptedPayload, auxKey, rawhandle []byte) error {
-	panic("not implemented")
+func MarshalKeys(key []byte, auxKey []byte) []byte {
+	panic("build without secboot support")
 	return nil
 }

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -22,6 +22,8 @@ package secboot
 
 import (
 	"fmt"
+
+	"github.com/snapcore/snapd/asserts"
 )
 
 func CheckKeySealingSupported() error {
@@ -36,7 +38,7 @@ func ResealKeys(params *ResealKeysParams) error {
 	return fmt.Errorf("build without secboot support")
 }
 
-func WriteKeyData(name, path string, encryptedPayload, auxKey, rawhandle []byte) error {
+func WriteKeyData(name, path string, encryptedPayload, auxKey, rawhandle []byte, model *asserts.Model) error {
 	return fmt.Errorf("build without secboot support")
 }
 

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -35,3 +35,13 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) error {
 func ResealKeys(params *ResealKeysParams) error {
 	return fmt.Errorf("build without secboot support")
 }
+
+func MarshalKeys(key []byte, auxKey []byte) []byte {
+	panic("not implemented")
+	return nil
+}
+
+func WriteKeyData(name, path string, encryptedPayload, auxKey, rawhandle []byte) error {
+	panic("not implemented")
+	return nil
+}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -475,7 +475,7 @@ func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourc
 		// the "denver" project encrypton key (64 bytes) we
 		// assume we deal with a v1 API.
 		if len(output) != encryptionKeySize {
-			return res, fmt.Errorf("cannot decode fde-reveal-key result: %v", err)
+			return res, fmt.Errorf("cannot decode fde-reveal-key result %q: %v", output, err)
 		}
 		fdeRevealKeyResult.Key = output
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -484,12 +484,10 @@ func unlockVolumeUsingSealedKeyFDERevealKeyV2(name, sealedEncryptionKeyFile, sou
 		}
 		return res, err
 	}
-	logger.Noticef("using unlockVolumeUsingSealedKeyFDERevealKeyV2")
 	keyData, err := sb.ReadKeyData(f)
 	if err != nil {
 		return res, xerrors.Errorf("cannot read key-data: %w", err)
 	}
-	logger.Noticef("keydata %v", keyData)
 	key, _, err := keyData.RecoverKeys()
 	if err != nil {
 		return res, err
@@ -553,7 +551,6 @@ func (fh *fdeHookV2DataHandler) RecoverKeys(data *sb.PlatformKeyData) (sb.KeyPay
 		// notice that the handler is unset for v1 hooks
 		fdeRevealKeyResult.Key = output
 	}
-	logger.Noticef("RecoverKeys returns %v", fdeRevealKeyResult.Key)
 	return fdeRevealKeyResult.Key, nil
 }
 

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -486,7 +486,8 @@ func unlockVolumeUsingSealedKeyFDERevealKeyV2(name, sealedEncryptionKeyFile, sou
 	}
 	keyData, err := sb.ReadKeyData(f)
 	if err != nil {
-		return res, xerrors.Errorf("cannot read key-data: %w", err)
+		fmt := "cannot read key-data: %w"
+		return res, xerrors.Errorf(fmt, err)
 	}
 	key, _, err := keyData.RecoverKeys()
 	if err != nil {
@@ -517,7 +518,8 @@ func (fh *fdeHookV2DataHandler) RecoverKeys(data *sb.PlatformKeyData) (sb.KeyPay
 	var handle []byte
 	if len(data.Handle) > 0 {
 		if err := json.Unmarshal(data.Handle, &handle); err != nil {
-			return nil, xerrors.Errorf("unmarshal error: %w", err)
+			fmt := "unmarshal error: %w"
+			return nil, xerrors.Errorf(fmt, err)
 		}
 	}
 

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -471,10 +471,12 @@ func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourc
 	// need to support this.
 	var fdeRevealKeyResult fdeRevealKeyResult
 	if err := json.Unmarshal(output, &fdeRevealKeyResult); err != nil {
-		// TODO: check if size of hookOutput matches
-		// the size of the denver project key and only
-		// then assume it's v1 api
-		// if len(hookOutput) != sizeDenverKey { return err}
+		// If the input is not json and matches the size of
+		// the "denver" project encrypton key (64 bytes) we
+		// assume we deal with a v1 API.
+		if len(output) != encryptionKeySize {
+			return res, fmt.Errorf("cannot decode fde-reveal-key result: %v", err)
+		}
 		fdeRevealKeyResult.Key = output
 	}
 

--- a/tests/lib/fde-setup-hook/export_test.go
+++ b/tests/lib/fde-setup-hook/export_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"io"
+)
+
+var (
+	RunFdeSetup     = runFdeSetup
+	RunFdeRevealKey = runFdeRevealKey
+
+	TestKeyHandle = testKeyHandle
+	Xor13         = xor13
+)
+
+func MockStdinStdout(mockedStdin io.Reader, mockedStdout io.Writer) (restore func()) {
+	oldOsStdin := osStdin
+	oldOsStdout := osStdout
+	osStdin = mockedStdin
+	osStdout = mockedStdout
+	return func() {
+		osStdin = oldOsStdin
+		osStdout = oldOsStdout
+	}
+}

--- a/tests/lib/fde-setup-hook/fde-setup.go
+++ b/tests/lib/fde-setup-hook/fde-setup.go
@@ -31,8 +31,7 @@ func xor13(bs []byte) []byte {
 type fdeSetupJSON struct {
 	Op string `json:"op"`
 
-	Key     []byte `json:"key,omitempty"`
-	KeyName string `json:"key-name,omitempty"`
+	Key []byte `json:"key,omitempty"`
 }
 
 type fdeSetupResultJSON struct {

--- a/tests/lib/fde-setup-hook/fde-setup_test.go
+++ b/tests/lib/fde-setup-hook/fde-setup_test.go
@@ -1,0 +1,80 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	fdeHook "github.com/snapcore/snapd/tests/lib/fde-setup-hook"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type fdeSetupSuite struct{}
+
+var _ = Suite(&fdeSetupSuite{})
+
+var (
+	// there is a static handle used in the test fde-hook
+	b64testKeyHandle = base64.StdEncoding.EncodeToString(fdeHook.TestKeyHandle)
+
+	// the test hook uses simple xor13 encryption
+	mockKey          = []byte("encrypted-payload")
+	b64Key           = base64.StdEncoding.EncodeToString(mockKey)
+	mockEncryptedKey = fdeHook.Xor13(mockKey)
+	b64EncryptedKey  = base64.StdEncoding.EncodeToString(mockEncryptedKey)
+)
+
+func (r *fdeSetupSuite) TestRunFdeSetup(c *C) {
+	fdeSetupResultStdin := filepath.Join(c.MkDir(), "stdin")
+	mockedSnapctl := testutil.MockCommand(c, "snapctl", fmt.Sprintf(`
+if [ "$1" = "fde-setup-request" ]; then
+    echo '{"op":"initial-setup","key":"%s","key-name":"key-name"}'
+elif [ "$1" = "fde-setup-result" ]; then
+    cat - > "%s"
+else
+    echo "Unexpected argument $1"
+    exit 1
+fi
+`, b64Key, fdeSetupResultStdin))
+	defer mockedSnapctl.Restore()
+	err := fdeHook.RunFdeSetup()
+	c.Assert(err, IsNil)
+	c.Check(fdeSetupResultStdin, testutil.FileEquals, fmt.Sprintf(`{"encrypted-key":"%s","handle":"%s"}`, b64EncryptedKey, b64testKeyHandle))
+}
+
+func (r *fdeSetupSuite) TestRunFdeRevealKey(c *C) {
+	// strings are base64 encoded
+	mockedStdin := bytes.NewBufferString(fmt.Sprintf(`{"op":"reveal","handle":"%s","sealed-key":"%s"}`, b64testKeyHandle, b64EncryptedKey))
+	mockedStdout := bytes.NewBuffer(nil)
+	restore := fdeHook.MockStdinStdout(mockedStdin, mockedStdout)
+	defer restore()
+
+	err := fdeHook.RunFdeRevealKey()
+	c.Assert(err, IsNil)
+	c.Check(mockedStdout.String(), Equals, fmt.Sprintf(`{"key":"%s"}`, b64Key)+"\n")
+}

--- a/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
@@ -1,0 +1,42 @@
+summary: Check that the fde-setup hooks work
+
+# this is a UC20 specific test
+systems: [ubuntu-20.04-64]
+
+environment:
+    NESTED_IMAGE_ID: core20-fde-setup
+    NESTED_ENABLE_TPM: false
+    NESTED_ENABLE_SECURE_BOOT: false
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+    NESTED_ENABLE_OVMF: true
+    GO111MODULE: off
+
+prepare: |
+  echo "Build a kernel snap with the fde-setup hook"
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB/prepare.sh"
+  # shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+  mkdir ./extra-snaps
+  # build fde-reveal-key hook into the "extra-initrd" dir so that the
+  # nested_create_core_vm picks this up
+  mkdir -p ./extra-initrd/usr/bin/
+  go build -o ./extra-initrd/usr/bin/fde-reveal-key "$TESTSLIB"/fde-setup-hook-v1/fde-setup.go
+
+  # create fde-setup hook inside the kernel
+  mkdir -p ./extra-kernel-snap/meta/hooks
+  go build -o ./extra-kernel-snap/meta/hooks/fde-setup "$TESTSLIB"/fde-setup-hook-v1/fde-setup.go
+  nested_create_core_vm
+  # start it
+  nested_start_core_vm
+
+execute: |
+  # shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+
+  echo "Check that we have an encrypted system"
+  nested_exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
+  nested_exec "test -e /var/lib/snapd/device/fde/recovery.key"
+  nested_exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
+  nested_exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
+  nested_exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -124,16 +124,22 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "bxXH0CTVNCUVJ1uSTO+2mxHb7Mw=",
+			"checksumSHA1": "wJ2txvI2LCJnAZm8RFKxqz6pAYc=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "68eced9638f2d44eb7dbc88884d002dc1b294a92",
-			"revisionTime": "2021-04-09T12:47:43Z"
+			"revision": "796680a13b94250ac53d4866a3da572adf42e021",
+			"revisionTime": "2021-04-15T18:54:04Z"
 		},
 		{
 			"checksumSHA1": "c7jHLQSWFWbymTcFWZMQH0C5Wik=",
 			"path": "github.com/snapcore/secboot/internal/efi",
 			"revision": "122bca1e162df761510e82be1bc9043250fe0bc7",
 			"revisionTime": "2021-02-12T23:46:08Z"
+		},
+		{
+			"checksumSHA1": "o06IvYmSoopV6w9Cz940QcCbYLc=",
+			"path": "github.com/snapcore/secboot/internal/keyring",
+			"revision": "e5de476efb1124816ef452e667d34200e034d0cd",
+			"revisionTime": "2021-04-15T09:56:33Z"
 		},
 		{
 			"checksumSHA1": "loFEiH6evGaDnDSlQgk3ugemkcU=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,6 +7,14 @@
 			"revision": ""
 		},
 		{
+			"checksumSHA1": "CT15zzEmXx3dQ7/PJCSwZhqSV/o=",
+			"path": "github.com/canonical/go-sp800.90a-drbg",
+			"revision": "6eeb1040d6c3a6b618a8da5e42ef66b35e7a3ddd",
+			"revisionTime": "2021-03-12T20:55:53Z",
+			"version": "main",
+			"versionExact": "main"
+		},
+		{
 			"checksumSHA1": "k/AaLsIMOYZr/PALamIsOMiI66U=",
 			"path": "github.com/canonical/go-tpm2",
 			"revision": "32171bd353b113ff4793dc3c65a019d749674bc6",
@@ -116,10 +124,10 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "yektq9faqx9Eo/qUb3GAsM+vQlU=",
+			"checksumSHA1": "bxXH0CTVNCUVJ1uSTO+2mxHb7Mw=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "122bca1e162df761510e82be1bc9043250fe0bc7",
-			"revisionTime": "2021-02-12T23:46:08Z"
+			"revision": "68eced9638f2d44eb7dbc88884d002dc1b294a92",
+			"revisionTime": "2021-04-09T12:47:43Z"
 		},
 		{
 			"checksumSHA1": "c7jHLQSWFWbymTcFWZMQH0C5Wik=",


### PR DESCRIPTION
This commit adds the new secboot.ActivateVolumeWithKeyData and
uses the secboot.SnapModelChecker to ensure we only unlock if
the key is bound to the model. 

The needed secboot code was added in https://github.com/snapcore/secboot/pull/134

Build on top of https://github.com/snapcore/snapd/pull/10149

Draft for now and mostly opening for spread run and to show the (hopefully) final result of the fde-hooks v2 journey.