### PR TITLE
boot, gadget: move opening the snap container into the gadget helper

### DIFF
--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -29,7 +29,6 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -103,12 +102,8 @@ func getBootloaderManagingItsAssets(where string, opts *bootloader.Options) (boo
 // bootVarsForTrustedCommandLineFromGadget returns a set of boot variables that
 // carry the command line arguments requested by the gadget. This is only useful
 // if snapd is managing the boot config.
-func bootVarsForTrustedCommandLineFromGadget(gadgetSnap string) (map[string]string, error) {
-	sf, err := snapfile.Open(gadgetSnap)
-	if err != nil {
-		return nil, fmt.Errorf("cannot open gadget snap: %v", err)
-	}
-	extraOrFull, full, err := gadget.KernelCommandLineFromGadget(sf)
+func bootVarsForTrustedCommandLineFromGadget(gadgetDirOrSnapPath string) (map[string]string, error) {
+	extraOrFull, full, err := gadget.KernelCommandLineFromGadget(gadgetDirOrSnapPath)
 	if err != nil {
 		if err == gadget.ErrNoKernelCommandline {
 			// nothing set by the gadget, but we could have had
@@ -176,11 +171,7 @@ func composeCommandLine(model *asserts.Model, currentOrCandidate int, mode, syst
 		return "", err
 	}
 	if gadgetDirOrSnapPath != "" {
-		sf, err := snapfile.Open(gadgetDirOrSnapPath)
-		if err != nil {
-			return "", fmt.Errorf("cannot open gadget snap: %v", err)
-		}
-		extraOrFull, full, err := gadget.KernelCommandLineFromGadget(sf)
+		extraOrFull, full, err := gadget.KernelCommandLineFromGadget(gadgetDirOrSnapPath)
 		if err != nil && err != gadget.ErrNoKernelCommandline {
 			return "", fmt.Errorf("cannot use kernel command line from gadget: %v", err)
 		}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -1022,12 +1023,16 @@ var ErrNoKernelCommandline = errors.New("no kernel command line in the gadget")
 // line or just the extra parameters that will be appended to the static ones.
 // An ErrNoKernelCommandline is returned when thea gadget does not set any
 // kernel command line.
-func KernelCommandLineFromGadget(snapf snap.Container) (cmdline string, full bool, err error) {
-	contentExtra, err := snapf.ReadFile("cmdline.extra")
+func KernelCommandLineFromGadget(gadgetDirOrSnapPath string) (cmdline string, full bool, err error) {
+	sf, err := snapfile.Open(gadgetDirOrSnapPath)
+	if err != nil {
+		return "", false, fmt.Errorf("cannot open gadget snap: %v", err)
+	}
+	contentExtra, err := sf.ReadFile("cmdline.extra")
 	if err != nil && !os.IsNotExist(err) {
 		return "", false, err
 	}
-	contentFull, err := snapf.ReadFile("cmdline.full")
+	contentFull, err := sf.ReadFile("cmdline.full")
 	if err != nil && !os.IsNotExist(err) {
 		return "", false, err
 	}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2448,10 +2448,7 @@ func (s *gadgetYamlTestSuite) TestKernelCommandLineBasic(c *C) {
 	}} {
 		c.Logf("files: %q", tc.files)
 		snapPath := snaptest.MakeTestSnapWithFiles(c, string(mockSnapYaml), tc.files)
-		snapf, err := snapfile.Open(snapPath)
-		c.Assert(err, IsNil)
-
-		cmdline, full, err := gadget.KernelCommandLineFromGadget(snapf)
+		cmdline, full, err := gadget.KernelCommandLineFromGadget(snapPath)
 		if tc.err != "" {
 			c.Assert(err, ErrorMatches, tc.err)
 			c.Check(cmdline, Equals, "")
@@ -2472,8 +2469,6 @@ func (s *gadgetYamlTestSuite) testKernelCommandLineArgs(c *C, whichCmdline strin
 		[][]string{
 			{whichCmdline, "## TO BE FILLED BY TEST ##"},
 		})
-	snapf, err := snapfile.Open(info.MountDir())
-	c.Assert(err, IsNil)
 
 	allowedArgs := []string{
 		"debug", "panic", "panic=-1",
@@ -2486,7 +2481,7 @@ func (s *gadgetYamlTestSuite) testKernelCommandLineArgs(c *C, whichCmdline strin
 		err := ioutil.WriteFile(filepath.Join(info.MountDir(), whichCmdline), []byte(arg), 0644)
 		c.Assert(err, IsNil)
 
-		cmdline, _, err := gadget.KernelCommandLineFromGadget(snapf)
+		cmdline, _, err := gadget.KernelCommandLineFromGadget(info.MountDir())
 		c.Assert(err, IsNil)
 		c.Check(cmdline, Equals, arg)
 	}
@@ -2505,7 +2500,7 @@ func (s *gadgetYamlTestSuite) testKernelCommandLineArgs(c *C, whichCmdline strin
 		err := ioutil.WriteFile(filepath.Join(info.MountDir(), whichCmdline), []byte(arg), 0644)
 		c.Assert(err, IsNil)
 
-		cmdline, _, err := gadget.KernelCommandLineFromGadget(snapf)
+		cmdline, _, err := gadget.KernelCommandLineFromGadget(info.MountDir())
 		c.Assert(err, ErrorMatches, fmt.Sprintf(`disallowed kernel argument ".*" in %s`, whichCmdline))
 		c.Check(cmdline, Equals, "")
 	}


### PR DESCRIPTION
Since it was not very useful when done externally, the opening of a snap
container for the gadget snap was rolled back into the gadget helper.

