### PR TITLE
o/snapstate: store refresh-candidates in the state

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -58,6 +58,30 @@ var (
 // refreshRetryDelay specified the minimum time to retry failed refreshes
 var refreshRetryDelay = 20 * time.Minute
 
+// refreshCandidate carries information about a single snap to update as part
+// of auto-refresh.
+type refreshCandidate struct {
+	SnapSetup
+}
+
+func (rh *refreshCandidate) Type() snap.Type {
+	return rh.SnapSetup.Type
+}
+
+func (rh *refreshCandidate) Base() string {
+	return rh.SnapSetup.Base
+}
+
+func (rh *refreshCandidate) MakeSnapSetup(st *state.State, snapst *SnapState, revnoOpts *RevisionOptions, snapUserID int) (*SnapSetup, error) {
+	rh.Channel = revnoOpts.Channel
+	rh.CohortKey = revnoOpts.CohortKey
+	return &rh.SnapSetup, nil
+}
+
+func (rh *refreshCandidate) Size() int64 {
+	return rh.DownloadInfo.Size
+}
+
 // autoRefresh will ensure that snaps are refreshed automatically
 // according to the refresh schedule.
 type autoRefresh struct {

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -64,20 +64,20 @@ type refreshCandidate struct {
 	SnapSetup
 }
 
-func (rh *refreshCandidate) Type() snap.Type {
-	return rh.SnapSetup.Type
+func (rc *refreshCandidate) Type() snap.Type {
+	return rc.SnapSetup.Type
 }
 
-func (rh *refreshCandidate) Base() string {
-	return rh.SnapSetup.Base
+func (rc *refreshCandidate) Base() string {
+	return rc.SnapSetup.Base
 }
 
-func (rh *refreshCandidate) MakeSnapSetup(*state.State, *SnapState) (*SnapSetup, error) {
-	return &rh.SnapSetup, nil
+func (rc *refreshCandidate) MakeSnapSetup(*state.State, *SnapState) (*SnapSetup, error) {
+	return &rc.SnapSetup, nil
 }
 
-func (rh *refreshCandidate) Size() int64 {
-	return rh.DownloadInfo.Size
+func (rc *refreshCandidate) Size() int64 {
+	return rc.DownloadInfo.Size
 }
 
 // autoRefresh will ensure that snaps are refreshed automatically

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -72,9 +72,7 @@ func (rh *refreshCandidate) Base() string {
 	return rh.SnapSetup.Base
 }
 
-func (rh *refreshCandidate) MakeSnapSetup(st *state.State, snapst *SnapState, revnoOpts *RevisionOptions, snapUserID int) (*SnapSetup, error) {
-	rh.Channel = revnoOpts.Channel
-	rh.CohortKey = revnoOpts.CohortKey
+func (rh *refreshCandidate) MakeSnapSetup(*state.State, *SnapState) (*SnapSetup, error) {
 	return &rh.SnapSetup, nil
 }
 

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -596,6 +596,19 @@ func earlyEpochCheck(info *snap.Info, snapst *SnapState) error {
 	return checkEpochs(nil, info, cur, nil, Flags{}, nil)
 }
 
+func earlyChecks(st *state.State, snapst *SnapState, update *snap.Info, flags Flags) (Flags, error) {
+	var err error
+	flags, err = ensureInstallPreconditions(st, update, flags, snapst)
+	if err != nil {
+		return flags, err
+	}
+
+	if err := earlyEpochCheck(update, snapst); err != nil {
+		return flags, err
+	}
+	return flags, nil
+}
+
 // check that the listed system users are valid
 var osutilEnsureUserGroup = osutil.EnsureUserGroup
 

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -597,8 +597,7 @@ func earlyEpochCheck(info *snap.Info, snapst *SnapState) error {
 }
 
 func earlyChecks(st *state.State, snapst *SnapState, update *snap.Info, flags Flags) (Flags, error) {
-	var err error
-	flags, err = ensureInstallPreconditions(st, update, flags, snapst)
+	flags, err := ensureInstallPreconditions(st, update, flags, snapst)
 	if err != nil {
 		return flags, err
 	}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -286,6 +286,8 @@ var (
 	MaxInhibition  = maxInhibition
 )
 
+type RefreshCandidate = refreshCandidate
+
 func NewBusySnapError(info *snap.Info, pids []int, busyAppNames, busyHookNames []string) *BusySnapError {
 	return &BusySnapError{
 		SnapInfo:      info,

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -168,11 +168,12 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 				Prereq:       defaultContentPlugProviders(st, update),
 				Channel:      snapst.TrackingChannel,
 				CohortKey:    snapst.CohortKey,
+				// UserID not set
+				Flags:        flags.ForSnapSetup(),
 				DownloadInfo: &update.DownloadInfo,
 				SideInfo:     &update.SideInfo,
 				Type:         update.Type(),
 				PlugsOnly:    len(update.Slots) == 0,
-				Flags:        flags.ForSnapSetup(),
 				InstanceKey:  update.InstanceKey,
 				auxStoreInfo: auxStoreInfo{
 					Website: update.Website,

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -162,10 +162,6 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 			continue
 		}
 
-		if err := earlyEpochCheck(update, &snapst); err != nil {
-			logger.Debugf("update hint for %q is not applicable: %v", update.InstanceName(), err)
-			continue
-		}
 		snapsup := &refreshCandidate{
 			SnapSetup{
 				Base:         update.Base,

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -82,17 +82,19 @@ func (r *refreshHints) refresh() error {
 	// error. In the future we may retry with a backoff.
 	r.state.Set("last-refresh-hints", time.Now())
 
-	if err == nil {
-		deviceCtx, err := DeviceCtxFromState(r.state, nil)
-		if err != nil {
-			return err
-		}
-		hints, err := refreshHintsFromCandidates(r.state, updates, ignoreValidationByInstanceName, deviceCtx)
-		if err == nil {
-			r.state.Set("refresh-candidates", hints)
-		}
+	if err != nil {
+		return err
 	}
-	return err
+	deviceCtx, err := DeviceCtxFromState(r.state, nil)
+	if err != nil {
+		return err
+	}
+	hints, err := refreshHintsFromCandidates(r.state, updates, ignoreValidationByInstanceName, deviceCtx)
+	if err != nil {
+		return err
+	}
+	r.state.Set("refresh-candidates", hints)
+	return nil
 }
 
 // AtSeed configures hints refresh policies at end of seeding.

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -22,9 +22,11 @@ package snapstate
 import (
 	"time"
 
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/timings"
 )
@@ -71,12 +73,25 @@ func (r *refreshHints) refresh() error {
 	perfTimings := timings.New(map[string]string{"ensure": "refresh-hints"})
 	defer perfTimings.Save(r.state)
 
+	var updates []*snap.Info
+	var ignoreValidationByInstanceName map[string]bool
 	timings.Run(perfTimings, "refresh-candidates", "query store for refresh candidates", func(tm timings.Measurer) {
-		_, _, _, err = refreshCandidates(auth.EnsureContextTODO(), r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
+		updates, _, ignoreValidationByInstanceName, err = refreshCandidates(auth.EnsureContextTODO(), r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
 	})
 	// TODO: we currently set last-refresh-hints even when there was an
 	// error. In the future we may retry with a backoff.
 	r.state.Set("last-refresh-hints", time.Now())
+
+	if err == nil {
+		deviceCtx, err := DeviceCtxFromState(r.state, nil)
+		if err != nil {
+			return err
+		}
+		hints, err := refreshHintsFromCandidates(r.state, updates, ignoreValidationByInstanceName, deviceCtx)
+		if err == nil {
+			r.state.Set("refresh-candidates", hints)
+		}
+	}
 	return err
 }
 
@@ -120,4 +135,53 @@ func (r *refreshHints) Ensure() error {
 		return nil
 	}
 	return r.refresh()
+}
+
+func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreValidationByInstanceName map[string]bool, deviceCtx DeviceContext) ([]*refreshCandidate, error) {
+	if ValidateRefreshes != nil && len(updates) != 0 {
+		userID := 0
+		var err error
+		updates, err = ValidateRefreshes(st, updates, ignoreValidationByInstanceName, userID, deviceCtx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	hints := []*refreshCandidate{}
+	for _, update := range updates {
+		var snapst SnapState
+		if err := Get(st, update.InstanceName(), &snapst); err != nil {
+			return nil, err
+		}
+
+		flags := snapst.Flags
+		flags.IsAutoRefresh = true
+		flags, err := earlyChecks(st, &snapst, update, flags)
+		if err != nil {
+			logger.Noticef("cannot update %q: %v", update.InstanceName(), err)
+			continue
+		}
+
+		if err := earlyEpochCheck(update, &snapst); err != nil {
+			logger.Noticef("cannot update %q: %v", update.InstanceName(), err)
+			continue
+		}
+		snapsup := &refreshCandidate{
+			SnapSetup{
+				Base:         update.Base,
+				Prereq:       defaultContentPlugProviders(st, update),
+				DownloadInfo: &update.DownloadInfo,
+				SideInfo:     &update.SideInfo,
+				Type:         update.Type(),
+				PlugsOnly:    len(update.Slots) == 0,
+				Flags:        flags.ForSnapSetup(),
+				InstanceKey:  update.InstanceKey,
+				auxStoreInfo: auxStoreInfo{
+					Website: update.Website,
+					Media:   update.Media,
+				},
+			}}
+		hints = append(hints, snapsup)
+	}
+	return hints, nil
 }

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -158,18 +158,20 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 		flags.IsAutoRefresh = true
 		flags, err := earlyChecks(st, &snapst, update, flags)
 		if err != nil {
-			logger.Noticef("cannot update %q: %v", update.InstanceName(), err)
+			logger.Debugf("update hint for %q is not applicable: %v", update.InstanceName(), err)
 			continue
 		}
 
 		if err := earlyEpochCheck(update, &snapst); err != nil {
-			logger.Noticef("cannot update %q: %v", update.InstanceName(), err)
+			logger.Debugf("update hint for %q is not applicable: %v", update.InstanceName(), err)
 			continue
 		}
 		snapsup := &refreshCandidate{
 			SnapSetup{
 				Base:         update.Base,
 				Prereq:       defaultContentPlugProviders(st, update),
+				Channel:      snapst.TrackingChannel,
+				CohortKey:    snapst.CohortKey,
 				DownloadInfo: &update.DownloadInfo,
 				SideInfo:     &update.SideInfo,
 				Type:         update.Type(),

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -164,10 +164,10 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 
 		snapsup := &refreshCandidate{
 			SnapSetup{
-				Base:         update.Base,
-				Prereq:       defaultContentPlugProviders(st, update),
-				Channel:      snapst.TrackingChannel,
-				CohortKey:    snapst.CohortKey,
+				Base:      update.Base,
+				Prereq:    defaultContentPlugProviders(st, update),
+				Channel:   snapst.TrackingChannel,
+				CohortKey: snapst.CohortKey,
 				// UserID not set
 				Flags:        flags.ForSnapSetup(),
 				DownloadInfo: &update.DownloadInfo,

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1193,16 +1193,8 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 		revnoOpts, flags, snapst := params(update)
 		flags.IsAutoRefresh = globalFlags.IsAutoRefresh
 
-		flags, err := ensureInstallPreconditions(st, update, flags, snapst)
+		flags, err := earlyChecks(st, snapst, update, flags)
 		if err != nil {
-			if refreshAll {
-				logger.Noticef("cannot update %q: %v", update.InstanceName(), err)
-				continue
-			}
-			return nil, nil, err
-		}
-
-		if err := earlyEpochCheck(update, snapst); err != nil {
 			if refreshAll {
 				logger.Noticef("cannot update %q: %v", update.InstanceName(), err)
 				continue


### PR DESCRIPTION
Store "refresh-candidates" in state during refresh-hints.