### PR TITLE
o/snapstate: helper for creating gate-auto-refresh hooks

### DIFF
--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -31,6 +31,7 @@ func init() {
 	snapstate.SetupPreRefreshHook = SetupPreRefreshHook
 	snapstate.SetupPostRefreshHook = SetupPostRefreshHook
 	snapstate.SetupRemoveHook = SetupRemoveHook
+	snapstate.SetupAutoRefreshGatingHook = SetupAutoRefreshGatingHook
 }
 
 func SetupInstallHook(st *state.State, snapName string) *state.Task {
@@ -67,6 +68,22 @@ func SetupPreRefreshHook(st *state.State, snapName string) *state.Task {
 	summary := fmt.Sprintf(i18n.G("Run pre-refresh hook of %q snap if present"), hooksup.Snap)
 	task := HookTask(st, summary, hooksup, nil)
 
+	return task
+}
+
+func SetupAutoRefreshGatingHook(st *state.State, snapName string, base, restart bool) *state.Task {
+	hookSup := &HookSetup{
+		Snap:     snapName,
+		Hook:     "gate-auto-refresh",
+		Optional: true,
+		IgnoreError: true,
+	}
+	summary := fmt.Sprintf(i18n.G("Run hook %s of snap %q"), hookSup.Hook, hookSup.Snap)
+	hookCtx := map[string]interface{}{
+		"base": base,
+		"restart": restart,
+	}
+	task := HookTask(st, summary, hookSup, hookCtx)
 	return task
 }
 

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -31,7 +31,7 @@ func init() {
 	snapstate.SetupPreRefreshHook = SetupPreRefreshHook
 	snapstate.SetupPostRefreshHook = SetupPostRefreshHook
 	snapstate.SetupRemoveHook = SetupRemoveHook
-	snapstate.SetupAutoRefreshGatingHook = SetupAutoRefreshGatingHook
+	snapstate.SetupGateAutoRefreshHook = SetupGateAutoRefreshHook
 }
 
 func SetupInstallHook(st *state.State, snapName string) *state.Task {
@@ -71,12 +71,11 @@ func SetupPreRefreshHook(st *state.State, snapName string) *state.Task {
 	return task
 }
 
-func SetupAutoRefreshGatingHook(st *state.State, snapName string, base, restart bool) *state.Task {
+func SetupGateAutoRefreshHook(st *state.State, snapName string, base, restart bool) *state.Task {
 	hookSup := &HookSetup{
 		Snap:     snapName,
 		Hook:     "gate-auto-refresh",
 		Optional: true,
-		IgnoreError: true,
 	}
 	summary := fmt.Sprintf(i18n.G("Run hook %s of snap %q"), hookSup.Hook, hookSup.Snap)
 	hookCtx := map[string]interface{}{

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -79,7 +79,7 @@ func SetupGateAutoRefreshHook(st *state.State, snapName string, base, restart bo
 	}
 	summary := fmt.Sprintf(i18n.G("Run hook %s of snap %q"), hookSup.Hook, hookSup.Snap)
 	hookCtx := map[string]interface{}{
-		"base": base,
+		"base":    base,
 		"restart": restart,
 	}
 	task := HookTask(st, summary, hookSup, hookCtx)

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -220,3 +220,17 @@ func usesMountBackend(iface interfaces.Interface) bool {
 	}
 	return false
 }
+
+func createAutoRefreshGateHooks(st *state.State, affectedSnaps map[string]*affectedSnapInfo) *state.TaskSet {
+	ts := state.NewTaskSet()
+	var prev *state.Task
+	for snapName, affected := range affectedSnaps {
+		hookTask := SetupAutoRefreshGatingHook(st, snapName, affected.Base, affected.Restart)
+		if prev != nil {
+			hookTask.WaitFor(prev)
+		}
+		ts.AddTask(hookTask)
+		prev = hookTask
+	}
+	return ts
+}

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -221,11 +221,15 @@ func usesMountBackend(iface interfaces.Interface) bool {
 	return false
 }
 
-func createAutoRefreshGateHooks(st *state.State, affectedSnaps map[string]*affectedSnapInfo) *state.TaskSet {
+// createGateAutoRefreshHooks creates gate-auto-refresh hooks for all affectedSnaps.
+// The hooks will have their context data set from affectedSnapInfo flags (base, restart).
+// Hook tasks will be chained to run sequentially.
+func createGateAutoRefreshHooks(st *state.State, affectedSnaps map[string]*affectedSnapInfo) *state.TaskSet {
 	ts := state.NewTaskSet()
 	var prev *state.Task
 	for snapName, affected := range affectedSnaps {
-		hookTask := SetupAutoRefreshGatingHook(st, snapName, affected.Base, affected.Restart)
+		hookTask := SetupGateAutoRefreshHook(st, snapName, affected.Base, affected.Restart)
+		// XXX: it should be fine to run the hooks in parallel
 		if prev != nil {
 			hookTask.WaitFor(prev)
 		}

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -493,7 +493,7 @@ func (s *autorefreshGatingSuite) TestCreateAutoRefreshGateHooks(c *C) {
 		"snap-b": {},
 	}
 
-	ts := snapstate.CreateAutoRefreshGateHooks(st, affected)
+	ts := snapstate.CreateGateAutoRefreshHooks(st, affected)
 	c.Assert(ts.Tasks(), HasLen, 2)
 	t := ts.Tasks()[0]
 	c.Assert(t.Kind(), Equals, "run-hook")

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -315,3 +315,5 @@ func MockSecurityProfilesDiscardLate(fn func(snapName string, rev snap.Revision,
 
 // autorefresh gating
 type AffectedSnapInfo = affectedSnapInfo
+
+var CreateAutoRefreshGateHooks = createAutoRefreshGateHooks

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -316,4 +316,4 @@ func MockSecurityProfilesDiscardLate(fn func(snapName string, rev snap.Revision,
 // autorefresh gating
 type AffectedSnapInfo = affectedSnapInfo
 
-var CreateAutoRefreshGateHooks = createAutoRefreshGateHooks
+var CreateGateAutoRefreshHooks = createGateAutoRefreshHooks

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -471,6 +471,10 @@ var CheckHealthHook = func(st *state.State, snapName string, rev snap.Revision) 
 	panic("internal error: snapstate.CheckHealthHook is unset")
 }
 
+var SetupAutoRefreshGatingHook = func(st *state.State, snapName string, base, restart bool) *state.Task {
+	panic("internal error: snapstate.SetupAutoRefreshGatingHook is unset")
+}
+
 var generateSnapdWrappers = backend.GenerateSnapdWrappers
 
 // FinishRestart will return a Retry error if there is a pending restart

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -471,7 +471,7 @@ var CheckHealthHook = func(st *state.State, snapName string, rev snap.Revision) 
 	panic("internal error: snapstate.CheckHealthHook is unset")
 }
 
-var SetupAutoRefreshGatingHook = func(st *state.State, snapName string, base, restart bool) *state.Task {
+var SetupGateAutoRefreshHook = func(st *state.State, snapName string, base, restart bool) *state.Task {
 	panic("internal error: snapstate.SetupAutoRefreshGatingHook is unset")
 }
 


### PR DESCRIPTION
Helper function for creating gate-auto-refresh hooks.

Base/restart flags are set on the hook context since they will be readily available when hooks get created.
Version/revision/channel values be obtained from "refresh-candidates" from state (TODO in followups).

Based on #10053 
