### PR TITLE
gadget: multi line support in gadget's cmdline file

### DIFF
--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -264,7 +264,7 @@ func (s *kernelCommandLineSuite) TestComposeCommandLineWithGadget(c *C) {
 		files: [][]string{
 			{"cmdline.extra", `bad-quote="`},
 		},
-		errMsg: `cannot use kernel command line from gadget: invalid kernel command line "bad-quote=\\"" in cmdline.extra: unbalanced quoting`,
+		errMsg: `cannot use kernel command line from gadget: invalid kernel command line in cmdline.extra: unbalanced quoting`,
 	}} {
 		sf := snaptest.MakeTestSnapWithFiles(c, gadgetSnapYaml, append([][]string{
 			{"meta/snap.yaml", gadgetSnapYaml},
@@ -333,7 +333,7 @@ func (s *kernelCommandLineSuite) TestComposeRecoveryCommandLineWithGadget(c *C) 
 		files: [][]string{
 			{"cmdline.extra", `bad-quote="`},
 		},
-		errMsg: `cannot use kernel command line from gadget: invalid kernel command line "bad-quote=\\"" in cmdline.extra: unbalanced quoting`,
+		errMsg: `cannot use kernel command line from gadget: invalid kernel command line in cmdline.extra: unbalanced quoting`,
 	}} {
 		sf := snaptest.MakeTestSnapWithFiles(c, gadgetSnapYaml, append([][]string{
 			{"meta/snap.yaml", gadgetSnapYaml},
@@ -382,7 +382,7 @@ func (s *kernelCommandLineSuite) TestBootVarsForGadgetCommandLine(c *C) {
 		files: [][]string{
 			{"cmdline.extra", "snapd_foo"},
 		},
-		errMsg: `cannot use kernel command line from gadget: disallowed kernel argument \"snapd_foo\" in cmdline.extra`,
+		errMsg: `cannot use kernel command line from gadget: invalid kernel command line in cmdline.extra: disallowed kernel argument \"snapd_foo\"`,
 	}, {
 		files: [][]string{
 			{"cmdline.full", "full foo bar baz"},

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -328,7 +328,7 @@ func (s *makeBootable20Suite) TestMakeBootableImage20CustomKernelFullArgs(c *C) 
 }
 
 func (s *makeBootable20Suite) TestMakeBootableImage20CustomKernelInvalidArgs(c *C) {
-	errMsg := `cannot obtain recovery system command line: cannot use kernel command line from gadget: disallowed kernel argument "snapd_foo=bar" in cmdline.extra`
+	errMsg := `cannot obtain recovery system command line: cannot use kernel command line from gadget: invalid kernel command line in cmdline.extra: disallowed kernel argument "snapd_foo=bar"`
 	s.testMakeBootableImage20CustomKernelArgs(c, "cmdline.extra", "snapd_foo=bar", errMsg)
 }
 
@@ -1093,7 +1093,7 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable20WithCustomKernelFullArgs(c
 }
 
 func (s *makeBootable20Suite) TestMakeSystemRunnable20WithCustomKernelInvalidArgs(c *C) {
-	errMsg := `cannot compose the candidate command line: cannot use kernel command line from gadget: disallowed kernel argument "snapd=unhappy" in cmdline.extra`
+	errMsg := `cannot compose the candidate command line: cannot use kernel command line from gadget: invalid kernel command line in cmdline.extra: disallowed kernel argument "snapd=unhappy"`
 	s.testMakeSystemRunnable20WithCustomKernelArgs(c, "cmdline.extra", "foo bar snapd=unhappy", errMsg, "", "")
 }
 

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1091,7 +1091,7 @@ func parseCommandLineFromGadget(content []byte, whichFile string) (string, error
 	}
 	for _, argValue := range kargs {
 		if strings.HasPrefix(argValue, "#") {
-			return "", fmt.Errorf("incorrect use of # in argument %q", argValue)
+			return "", fmt.Errorf("unexpected or invalid use of # in argument %q", argValue)
 		}
 		split := strings.SplitN(argValue, "=", 2)
 		if !isKernelArgumentAllowed(split[0]) {

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2459,10 +2459,10 @@ func (s *gadgetYamlTestSuite) TestKernelCommandLineBasic(c *C) {
 		err: "no kernel command line in the gadget",
 	}, {
 		files: [][]string{{"cmdline.full", " # error"}},
-		full:  true, err: `invalid kernel command line in cmdline\.full: incorrect use of # in argument "#"`,
+		full:  true, err: `invalid kernel command line in cmdline\.full: unexpected or invalid use of # in argument "#"`,
 	}, {
 		files: [][]string{{"cmdline.full", "foo bar baz #error"}},
-		full:  true, err: `invalid kernel command line in cmdline\.full: incorrect use of # in argument "#error"`,
+		full:  true, err: `invalid kernel command line in cmdline\.full: unexpected or invalid use of # in argument "#error"`,
 	}, {
 		files: [][]string{
 			{"cmdline.full", "foo bad =\n"},

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2402,6 +2402,22 @@ volumes:
 	c.Check(err, IsNil)
 }
 
+const cmdlineMultiLineWithComments = `
+# reboot 5 seconds after panic
+panic=5
+# reserve range
+reserve=0x300,32
+foo=bar     baz=baz
+# random op
+                                  random=op
+debug
+# snapd logging level to debug (does not trip the disallowed argument check)
+# or this snapd_ or this snapd.
+snapd.debug=1
+# this is valid
+memmap=100M@2G,100M#3G,1G!1024G
+`
+
 func (s *gadgetYamlTestSuite) TestKernelCommandLineBasic(c *C) {
 	for _, tc := range []struct {
 		files [][]string
@@ -2420,6 +2436,18 @@ func (s *gadgetYamlTestSuite) TestKernelCommandLineBasic(c *C) {
 		},
 		cmdline: "foo bar baz full", full: true,
 	}, {
+		files: [][]string{
+			{"cmdline.full", cmdlineMultiLineWithComments},
+		},
+		cmdline: "panic=5 reserve=0x300,32 foo=bar baz=baz random=op debug snapd.debug=1 memmap=100M@2G,100M#3G,1G!1024G",
+		full:    true,
+	}, {
+		files: [][]string{
+			{"cmdline.full", ""},
+		},
+		cmdline: "",
+		full:    true,
+	}, {
 		// no cmdline
 		files: nil,
 		err:   "no kernel command line in the gadget",
@@ -2430,15 +2458,21 @@ func (s *gadgetYamlTestSuite) TestKernelCommandLineBasic(c *C) {
 		},
 		err: "no kernel command line in the gadget",
 	}, {
+		files: [][]string{{"cmdline.full", " # error"}},
+		full:  true, err: `invalid kernel command line in cmdline\.full: incorrect use of # in argument "#"`,
+	}, {
+		files: [][]string{{"cmdline.full", "foo bar baz #error"}},
+		full:  true, err: `invalid kernel command line in cmdline\.full: incorrect use of # in argument "#error"`,
+	}, {
 		files: [][]string{
 			{"cmdline.full", "foo bad =\n"},
 		},
-		full: true, err: `invalid kernel command line "foo bad =" in cmdline.full: unexpected assignment`,
+		full: true, err: `invalid kernel command line in cmdline\.full: unexpected assignment`,
 	}, {
 		files: [][]string{
 			{"cmdline.extra", "foo bad ="},
 		},
-		full: false, err: `invalid kernel command line "foo bad =" in cmdline.extra: unexpected assignment`,
+		full: false, err: `invalid kernel command line in cmdline\.extra: unexpected assignment`,
 	}, {
 		files: [][]string{
 			{"cmdline.extra", `extra`},
@@ -2501,7 +2535,7 @@ func (s *gadgetYamlTestSuite) testKernelCommandLineArgs(c *C, whichCmdline strin
 		c.Assert(err, IsNil)
 
 		cmdline, _, err := gadget.KernelCommandLineFromGadget(info.MountDir())
-		c.Assert(err, ErrorMatches, fmt.Sprintf(`disallowed kernel argument ".*" in %s`, whichCmdline))
+		c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid kernel command line in %v: disallowed kernel argument ".*"`, whichCmdline))
 		c.Check(cmdline, Equals, "")
 	}
 }

--- a/spread.yaml
+++ b/spread.yaml
@@ -176,7 +176,7 @@ backends:
             - ubuntu-20.04-64:
                   image: ubuntu-2004-64-virt-enabled
                   storage: 20G
-                  workers: 6
+                  workers: 7
             - ubuntu-20.10-64:
                   image: ubuntu-2010-64-virt-enabled
                   storage: 20G

--- a/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
+++ b/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
@@ -38,7 +38,13 @@ prepare: |
 
     rm pc-gadget/cmdline.extra
     # keep the console so that we get some logging
-    echo 'snapd.debug=1 console=ttyS0 full hello from test' > pc-gadget/cmdline.full
+    cat <<'EOF' > pc-gadget/cmdline.full
+    snapd.debug=1
+    # keep the console
+    console=ttyS0
+    full hello from
+    test
+    EOF
     snap pack pc-gadget --filename=pc-gadget-cmdline-full.snap
 
     rm pc-gadget/cmdline.full


### PR DESCRIPTION
Support a multiline format of the cmdline file shipped by the gadget. Now it is valid to have a content like this:
```
# comment
paramter parameter
# more
# comments
panic=-1
```