### PR TITLE
o/hookstate: add "refresh" command to snapctl (hidden, not complete yet)

### DIFF
--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -56,8 +56,10 @@ The 'pending' flag can be "ready", "none" or "inhibited". It is set to "none" if
 there are no pending refreshes for the snap. It is set to "ready" if there are,
 and to inhibited if there are but are inhibited because some of the snap
 applications are running and "refresh app awareness" feature is enabled.
-The "base" and "restart" flags indicate whether a base snap is going to be
-updated and/or if restart will occur, both of which are disruptive.
+The "base" and "restart" flags indicate whether the base snap is going to be
+updated and/or if restart will occur, both of which are disruptive. A base snap
+update can disrupt temporarily the starting of applications or hooks from the
+snap.
 
 To tell snapd to proceed with pending refreshes:
     $ snapctl refresh --pending --proceed
@@ -65,7 +67,7 @@ To tell snapd to proceed with pending refreshes:
 Note, a snap using --proceed cannot assume that the updates will occur as they
 might be held by other snaps.
 
-To hold refresh for up to 90 days:
+To hold refresh for up to 90 days for the calling snap:
     $ snapctl refresh --pending --hold
 `)
 
@@ -113,7 +115,7 @@ type updateDetails struct {
 	channel  string
 	version  string
 	revision snap.Revision
-	epoch    snap.Epoch
+	// TODO: epoch
 	base     bool
 	restart  bool
 }
@@ -153,9 +155,6 @@ func (c *refreshCommand) printPendingInfo() {
 	}
 	if !details.revision.Unset() {
 		c.printf("revision: %s\n", details.revision)
-	}
-	if !details.epoch.IsZero() {
-		c.printf("epoch: %s", details.epoch)
 	}
 	c.printf("base: %v\n", details.base)
 	c.printf("restart: %v\n", details.restart)

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -1,0 +1,162 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/snap"
+)
+
+type refreshCommand struct {
+	baseCommand
+
+	Pending bool `long:"pending" description:"Show pending refreshes of the calling snap"`
+	// these two options are mutually exclusive
+	Proceed bool `long:"proceed" description:"Proceed with potentially disruptive refreshes"`
+	Hold    bool `long:"hold" description:"Do not proceed with potentially disruptive refreshes"`
+}
+
+var shortRefreshHelp = i18n.G("The refresh command prints pending refreshes and can hold disruptive ones.")
+var longRefreshHelp = i18n.G(`
+The refresh command prints pending refreshes of the calling snap and can hold
+disruptive refreshes of other snaps, such as refreshes of kernel or
+base snaps that can trigger restart. This command can be used from
+gate-auto-refresh hook. The hook is only run during auto-refresh.
+
+Snap can query pending refreshes with:
+    $ snapctl refresh --pending
+    pending: ready
+    channel: stable
+    version: 2
+    revision: 2
+    base: false
+    restart: false
+
+The 'pending' flag can be "ready", "none" or "inhibited". It is set to "none" if
+there are no pending refreshes for the snap. It is set to "ready" if there are,
+and to inhibited if there are but are inhibited because some of the snap
+applications are running and "refresh app awareness" feature is enabled.
+The "base" and "restart" flags indicate whether a base snap is going to be
+updated and/or if restart will occur, both of which are disruptive.
+
+To tell snapd to proceed with pending refreshes:
+    $ snapctl refresh --pending --proceed
+
+Note, a snap using --proceed cannot assume that the updates will occur as they
+might be held by other snaps.
+
+To hold refresh for up to 90 days:
+    $ snapctl refresh --pending --hold
+`)
+
+func init() {
+	cmd := addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() command {
+		return &refreshCommand{}
+	})
+	cmd.hidden = true
+}
+
+func (c *refreshCommand) Execute(args []string) error {
+	context := c.context()
+	if context == nil {
+		return fmt.Errorf("cannot run without a context")
+	}
+	if context.IsEphemeral() {
+		// TODO: handle this
+		return fmt.Errorf("cannot run outside of gate-auto-refresh hook")
+	}
+
+	if context.HookName() != "gate-auto-refresh" {
+		return fmt.Errorf("can only be used from gate-auto-refresh hook")
+	}
+
+	if c.Proceed && c.Hold {
+		return fmt.Errorf("cannot use --proceed and --hold together")
+	}
+
+	if c.Pending {
+		c.printPendingInfo()
+	}
+
+	if c.Proceed {
+		return fmt.Errorf("not implemented yet")
+	}
+	if c.Hold {
+		return fmt.Errorf("not implemented yet")
+	}
+
+	return nil
+}
+
+type updateDetails struct {
+	pending  string
+	channel  string
+	version  string
+	revision snap.Revision
+	epoch    snap.Epoch
+	base     bool
+	restart  bool
+}
+
+func getUpdateDetails(context *hookstate.Context) *updateDetails {
+	context.Lock()
+	defer context.Unlock()
+
+	if context.IsEphemeral() {
+		// TODO: support ephemeral context
+		return nil
+	}
+
+	var base, restart bool
+	context.Get("base", &base)
+	context.Get("restart", &restart)
+
+	// TODO: get revision, version etc. from refresh-candidates.
+
+	up := updateDetails{
+		base:    base,
+		restart: restart,
+	}
+	return &up
+}
+
+func (c *refreshCommand) printPendingInfo() {
+	details := getUpdateDetails(c.context())
+	// XXX: remove when ephemeral context is supported.
+	if details == nil {
+		return
+	}
+	c.printf("pending: %s\n", details.pending)
+	c.printf("channel: %s\n", details.channel)
+	if details.version != "" {
+		c.printf("version: %s\n", details.version)
+	}
+	if !details.revision.Unset() {
+		c.printf("revision: %s\n", details.revision)
+	}
+	if !details.epoch.IsZero() {
+		c.printf("epoch: %s", details.epoch)
+	}
+	c.printf("base: %v\n", details.base)
+	c.printf("restart: %v\n", details.restart)
+}

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -36,12 +36,12 @@ type refreshCommand struct {
 	Hold    bool `long:"hold" description:"Do not proceed with potentially disruptive refreshes"`
 }
 
-var shortRefreshHelp = i18n.G("The refresh command prints pending refreshes and can hold disruptive ones.")
+var shortRefreshHelp = i18n.G("The refresh command prints pending refreshes and can hold back disruptive ones.")
 var longRefreshHelp = i18n.G(`
 The refresh command prints pending refreshes of the calling snap and can hold
-disruptive refreshes of other snaps, such as refreshes of kernel or
-base snaps that can trigger restart. This command can be used from
-gate-auto-refresh hook. The hook is only run during auto-refresh.
+back disruptive refreshes of other snaps, such as refreshes of the kernel or
+base snaps that can trigger a restart. This command can be used from the
+gate-auto-refresh hook which is only run during auto-refresh.
 
 Snap can query pending refreshes with:
     $ snapctl refresh --pending
@@ -52,20 +52,22 @@ Snap can query pending refreshes with:
     base: false
     restart: false
 
-The 'pending' flag can be "ready", "none" or "inhibited". It is set to "none" if
-there are no pending refreshes for the snap. It is set to "ready" if there are,
-and to inhibited if there are but are inhibited because some of the snap
-applications are running and "refresh app awareness" feature is enabled.
+The 'pending' flag can be "ready", "none" or "inhibited". It is set to "none"
+when a snap has no pending refreshes. It is set to "ready" when there are
+pending refreshes and to ”inhibited” when pending refreshes are being
+held back because more or more snap applications are running with the
+“refresh app awareness” feature enabled.
+
 The "base" and "restart" flags indicate whether the base snap is going to be
-updated and/or if restart will occur, both of which are disruptive. A base snap
-update can disrupt temporarily the starting of applications or hooks from the
-snap.
+updated and/or if a restart will occur, both of which are disruptive. A base
+snap update can temporarily disrupt the starting of applications or hooks from
+the snap.
 
 To tell snapd to proceed with pending refreshes:
     $ snapctl refresh --pending --proceed
 
 Note, a snap using --proceed cannot assume that the updates will occur as they
-might be held by other snaps.
+might be held back by other snaps.
 
 To hold refresh for up to 90 days for the calling snap:
     $ snapctl refresh --pending --hold
@@ -116,8 +118,8 @@ type updateDetails struct {
 	version  string
 	revision snap.Revision
 	// TODO: epoch
-	base     bool
-	restart  bool
+	base    bool
+	restart bool
 }
 
 func getUpdateDetails(context *hookstate.Context) *updateDetails {

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -1,0 +1,142 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+)
+
+type refreshSuite struct {
+	testutil.BaseTest
+	st          *state.State
+	mockHandler *hooktest.MockHandler
+}
+
+var _ = Suite(&refreshSuite{})
+
+func (s *refreshSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+	s.st = state.New(nil)
+	s.mockHandler = hooktest.NewMockHandler()
+}
+
+var refreshFromHookTests = []struct {
+	args                []string
+	base, restart       bool
+	stdout, stderr, err string
+	exitCode            int
+}{{
+	args: []string{"refresh", "--proceed", "--hold"},
+	err:  "cannot use --proceed and --hold together",
+}, {
+	args: []string{"refresh", "--proceed"},
+	err:  "not implemented yet",
+}, {
+	args: []string{"refresh", "--hold"},
+	err:  "not implemented yet",
+}, {
+	args:   []string{"refresh", "--pending"},
+	stdout: "pending: \nchannel: \nbase: false\nrestart: false\n",
+}, {
+	args:    []string{"refresh", "--pending"},
+	base:    true,
+	restart: true,
+	stdout:  "pending: \nchannel: \nbase: true\nrestart: true\n",
+}}
+
+func (s *refreshSuite) TestRefreshFromHook(c *C) {
+	s.st.Lock()
+	task := s.st.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(1), Hook: "gate-auto-refresh"}
+	mockContext, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
+	c.Check(err, IsNil)
+	s.st.Unlock()
+
+	for _, test := range refreshFromHookTests {
+		mockContext.Lock()
+		mockContext.Set("base", test.base)
+		mockContext.Set("restart", test.restart)
+		mockContext.Unlock()
+
+		stdout, stderr, err := ctlcmd.Run(mockContext, test.args, 0)
+		comment := Commentf("%s", test.args)
+		if test.exitCode > 0 {
+			c.Check(err, DeepEquals, &ctlcmd.UnsuccessfulError{ExitCode: test.exitCode}, comment)
+		} else {
+			if test.err == "" {
+				c.Check(err, IsNil, comment)
+			} else {
+				c.Check(err, ErrorMatches, test.err, comment)
+			}
+		}
+
+		c.Check(string(stdout), Equals, test.stdout, comment)
+		c.Check(string(stderr), Equals, "", comment)
+	}
+}
+
+func (s *refreshSuite) TestRefreshFromUnsupportedHook(c *C) {
+	s.st.Lock()
+
+	task := s.st.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "snap", Revision: snap.R(1), Hook: "install"}
+	mockContext, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
+	c.Check(err, IsNil)
+	s.st.Unlock()
+
+	_, _, err = ctlcmd.Run(mockContext, []string{"refresh"}, 0)
+	c.Check(err, ErrorMatches, `can only be used from gate-auto-refresh hook`)
+}
+
+// TODO: support this case
+func (s *refreshSuite) TestRefreshFromApp(c *C) {
+	s.st.Lock()
+
+	setup := &hookstate.HookSetup{Snap: "snap", Revision: snap.R(1)}
+	mockContext, err := hookstate.NewContext(nil, s.st, setup, s.mockHandler, "")
+	c.Check(err, IsNil)
+	s.st.Unlock()
+
+	_, _, err = ctlcmd.Run(mockContext, []string{"refresh"}, 0)
+	c.Check(err, ErrorMatches, `cannot run outside of gate-auto-refresh hook`)
+}
+
+func (s *refreshSuite) TestRefreshRegularUserForbidden(c *C) {
+	s.st.Lock()
+	setup := &hookstate.HookSetup{Snap: "snap", Revision: snap.R(1)}
+	s.st.Unlock()
+
+	mockContext, err := hookstate.NewContext(nil, s.st, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	_, _, err = ctlcmd.Run(mockContext, []string{"refresh"}, 1000)
+	c.Assert(err, ErrorMatches, `cannot use "refresh" with uid 1000, try with sudo`)
+	forbidden, _ := err.(*ctlcmd.ForbiddenCommandError)
+	c.Assert(forbidden, NotNil)
+}


### PR DESCRIPTION
Basic scaffolding for `snapctl refresh` command. The command is hidden until the feature gets implemented. There are some TODOs marked in the code:
- use refresh-candidates from state (after #10167)
- support --available flag.
- support for running outside of hooks

For running from hook, hook context will have base/restart flags set upfront when all gate-auto-refresh hooks get created.
For running outside of hooks the idea is to re-use  affectedByRefresh from #10053 and re-calculate this on demand.
