### PR TITLE
boot: split out a helper for making recovery system bootable

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -195,9 +195,10 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	}
 
 	return MakeRecoverySystemBootable(rootdir, bootWith.RecoverySystemDir, &RecoverySystemBootableSet{
-		Kernel:          bootWith.Kernel,
-		KernelPath:      bootWith.KernelPath,
-		GadgetSnapOrDir: bootWith.UnpackedGadgetDir,
+		Kernel:           bootWith.Kernel,
+		KernelPath:       bootWith.KernelPath,
+		GadgetSnapOrDir:  bootWith.UnpackedGadgetDir,
+		PrepareImageTime: true,
 	})
 }
 
@@ -207,6 +208,9 @@ type RecoverySystemBootableSet struct {
 	Kernel          *snap.Info
 	KernelPath      string
 	GadgetSnapOrDir string
+	// PrepareImageTime is true when the structure is being used when
+	// preparing a bootable system image.
+	PrepareImageTime bool
 }
 
 // MakeRecoverySystemBootable prepares a recovery system under a path relative
@@ -214,8 +218,10 @@ type RecoverySystemBootableSet struct {
 func MakeRecoverySystemBootable(rootdir string, relativeRecoverySystemDir string, bootWith *RecoverySystemBootableSet) error {
 	opts := &bootloader.Options{
 		// XXX: this is only needed by LK, it is unclear whether LK does
-		// too much when extracting recovery kernel assets
-		PrepareImageTime: true,
+		// too much when extracting recovery kernel assets, in the end
+		// it is currently not possible to create a recovery system at
+		// runtime when using LK.
+		PrepareImageTime: bootWith.PrepareImageTime,
 		// setup the recovery bootloader
 		Role: bootloader.RoleRecovery,
 	}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -1322,7 +1322,7 @@ grade=dangerous
 `)
 }
 
-func (s *makeBootable20Suite) TestMakeRecoverySystemBootable20(c *C) {
+func (s *makeBootable20Suite) TestMakeRecoverySystemBootableAtRuntime20(c *C) {
 	bootloader.Force(nil)
 
 	// on uc20 the seed layout if different
@@ -1366,6 +1366,8 @@ version: 5.0
 		KernelPath: kernelInSeed,
 		// use gadget revision 1
 		GadgetSnapOrDir: gadgets["1"],
+		// like it's called when creating a new recovery system
+		PrepareImageTime: false,
 	})
 	c.Assert(err, IsNil)
 	// the recovery partition grubenv was not modified
@@ -1385,6 +1387,8 @@ version: 5.0
 		Kernel:          kernelInfo,
 		KernelPath:      kernelInSeed,
 		GadgetSnapOrDir: gadgets["5"],
+		// like it's called when creating a new recovery system
+		PrepareImageTime: false,
 	})
 	c.Assert(err, IsNil)
 

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -1321,3 +1321,76 @@ model=my-brand/my-model-uc20
 grade=dangerous
 `)
 }
+
+func (s *makeBootable20Suite) TestMakeRecoverySystemBootable20(c *C) {
+	bootloader.Force(nil)
+
+	// on uc20 the seed layout if different
+	seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
+	err := os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
+
+	kernelFn, kernelInfo := makeSnapWithFiles(c, "pc-kernel", `name: pc-kernel
+type: kernel
+version: 5.0
+`, snap.R(5), [][]string{
+		{"kernel.efi", "I'm a kernel.efi"},
+	})
+	kernelInSeed := filepath.Join(seedSnapsDirs, kernelInfo.Filename())
+	err = os.Rename(kernelFn, kernelInSeed)
+	c.Assert(err, IsNil)
+
+	gadgets := map[string]string{}
+	for _, rev := range []snap.Revision{snap.R(1), snap.R(5)} {
+		gadgetFn, gadgetInfo := makeSnapWithFiles(c, "pc", gadgetSnapYaml, rev, [][]string{
+			{"grub.conf", ""},
+			{"meta/snap.yaml", gadgetSnapYaml},
+			{"cmdline.full", fmt.Sprintf("args from gadget rev %s", rev.String())},
+		})
+		gadgetInSeed := filepath.Join(seedSnapsDirs, gadgetInfo.Filename())
+		err = os.Rename(gadgetFn, gadgetInSeed)
+		c.Assert(err, IsNil)
+		// keep track of the gadgets
+		gadgets[rev.String()] = gadgetInSeed
+	}
+
+	snaptest.PopulateDir(s.rootdir, [][]string{
+		{"EFI/ubuntu/grub.cfg", "this is grub"},
+		{"EFI/ubuntu/grubenv", "canary"},
+	})
+
+	label := "20191209"
+	recoverySystemDir := filepath.Join("/systems", label)
+	err = boot.MakeRecoverySystemBootable(s.rootdir, recoverySystemDir, &boot.RecoverySystemBootableSet{
+		Kernel:     kernelInfo,
+		KernelPath: kernelInSeed,
+		// use gadget revision 1
+		GadgetSnapOrDir: gadgets["1"],
+	})
+	c.Assert(err, IsNil)
+	// the recovery partition grubenv was not modified
+	c.Check(filepath.Join(s.rootdir, "EFI/ubuntu/grubenv"), testutil.FileEquals, "canary")
+
+	systemGenv := grubenv.NewEnv(filepath.Join(s.rootdir, recoverySystemDir, "grubenv"))
+	c.Assert(systemGenv.Load(), IsNil)
+	c.Check(systemGenv.Get("snapd_recovery_kernel"), Equals, "/snaps/pc-kernel_5.snap")
+	c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
+	c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, "args from gadget rev 1")
+
+	// create another system under a new label
+	newLabel := "20210420"
+	newRecoverySystemDir := filepath.Join("/systems", newLabel)
+	// with a different gadget revision, but same kernel
+	err = boot.MakeRecoverySystemBootable(s.rootdir, newRecoverySystemDir, &boot.RecoverySystemBootableSet{
+		Kernel:          kernelInfo,
+		KernelPath:      kernelInSeed,
+		GadgetSnapOrDir: gadgets["5"],
+	})
+	c.Assert(err, IsNil)
+
+	systemGenv = grubenv.NewEnv(filepath.Join(s.rootdir, newRecoverySystemDir, "grubenv"))
+	c.Assert(systemGenv.Load(), IsNil)
+	c.Check(systemGenv.Get("snapd_recovery_kernel"), Equals, "/snaps/pc-kernel_5.snap")
+	c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
+	c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, "args from gadget rev 5")
+}

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -361,9 +361,9 @@ func (l *lk) ExtractRecoveryKernelAssets(recoverySystemDir string, sn snap.Place
 		// error case, we cannot be extracting a recovery kernel and also be
 		// called with !opts.PrepareImageTime (yet)
 
-		// TODO:UC20: however this codepath will likely be exercised when we
-		//            support creating new recovery systems from runtime
-		return fmt.Errorf("internal error: ExtractRecoveryKernelAssets not yet implemented for a runtime lk bootloader")
+		// TODO:UC20: this codepath is exercised when creating new
+		// recovery systems from runtime
+		return fmt.Errorf("internal error: extracting recovery kernel assets is not supported for a runtime lk bootloader")
 	}
 
 	env, err := l.newenv()


### PR DESCRIPTION
Split out bits that make the recovery system bootable. Those will be used
independently when creating a recovery system and setting it up for boot.


