### PR TITLE
tests/lib/nested: do not compress images, return early when restored from pristine image

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -518,6 +518,7 @@ nested_create_core_vm() {
 
     if [ -f "$NESTED_IMAGES_DIR/$IMAGE_NAME.pristine" ]; then
         cp -v "$NESTED_IMAGES_DIR/$IMAGE_NAME.pristine" "$NESTED_IMAGES_DIR/$IMAGE_NAME"
+        return
 
     elif [ ! -f "$NESTED_IMAGES_DIR/$IMAGE_NAME" ]; then
         if [ -n "$NESTED_CUSTOM_IMAGE_URL" ]; then

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1109,7 +1109,7 @@ nested_create_classic_vm() {
     fi
 
     # Save a copy of the image
-    cp -v "$IMAGE_NAME" "$IMAGE_NAME.pristine"
+    cp -v "$NESTED_IMAGES_DIR/$IMAGE_NAME" "$NESTED_IMAGES_DIR/$IMAGE_NAME.pristine"
 }
 
 nested_start_classic_vm() {
@@ -1118,7 +1118,7 @@ nested_start_classic_vm() {
     IMAGE_NAME="$(nested_get_image_name classic)"
 
     if [ ! -f "$NESTED_IMAGES_DIR/$IMAGE_NAME" ] ; then
-        cp -v "$IMAGE_NAME.pristine" "$IMAGE_NAME"
+        cp -v "$NESTED_IMAGES_DIR/$IMAGE_NAME.pristine" "$IMAGE_NAME"
     fi
 
     # Now qemu parameters are defined


### PR DESCRIPTION
Stop compressing the images as it seems to be a waste of time. Analyzing some
UC20 runs, the image built by ubuntu-image is 199MB (10GB apparent size, since
those are sparse files). Compressing that image with xz -0 takes ~2 minutes,
inflating it takes another ~30s. The compressed image is 195MB (vs 199MB
initially).

Instead of compression, use simple cp to keep track of the pristine versions of
the images and preserve the sparse file property.
