### PR TITLE
testutil: support referencing files in FileEquals checker

### DIFF
--- a/testutil/filecontentchecker.go
+++ b/testutil/filecontentchecker.go
@@ -35,7 +35,7 @@ type fileContentChecker struct {
 }
 
 // FileEquals verifies that the given file's content is equal to the string (or
-// fmt.Stringer), []byte provided, or the contents of a ReferenceFile.
+// fmt.Stringer), []byte provided, or the contents referred by a FileContentRef.
 var FileEquals check.Checker = &fileContentChecker{
 	CheckerInfo: &check.CheckerInfo{Name: "FileEquals", Params: []string{"filename", "contents"}},
 	exact:       true,
@@ -53,8 +53,9 @@ var FileMatches check.Checker = &fileContentChecker{
 	CheckerInfo: &check.CheckerInfo{Name: "FileMatches", Params: []string{"filename", "regex"}},
 }
 
-// ReferenceFile wraps a file with reference contents.
-type ReferenceFile string
+// FileContentRef refers to the content of file by its name, to use in
+// conjunction with FileEquals.
+type FileContentRef string
 
 func (c *fileContentChecker) Check(params []interface{}, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
@@ -90,7 +91,7 @@ func fileContentCheck(filename string, content interface{}, exact bool) (result 
 			presentableBuf = "<binary data>"
 		case fmt.Stringer:
 			result = presentableBuf == content.String()
-		case ReferenceFile:
+		case FileContentRef:
 			referenceFilename := string(content)
 			reference, err := ioutil.ReadFile(referenceFilename)
 			if err != nil {
@@ -115,7 +116,7 @@ func fileContentCheck(filename string, content interface{}, exact bool) (result 
 			result = content.Match(buf)
 		case fmt.Stringer:
 			result = strings.Contains(presentableBuf, content.String())
-		case ReferenceFile:
+		case FileContentRef:
 			error = "Non-exact match with reference file is not supported"
 		default:
 			error = fmt.Sprintf("Cannot compare file contents with something of type %T", content)

--- a/testutil/filecontentchecker_test.go
+++ b/testutil/filecontentchecker_test.go
@@ -52,8 +52,8 @@ func (s *fileContentCheckerSuite) TestFileEquals(c *check.C) {
 	testCheck(c, FileEquals, true, "", filename, content)
 	testCheck(c, FileEquals, true, "", filename, []byte(content))
 	testCheck(c, FileEquals, true, "", filename, myStringer{content})
-	testCheck(c, FileEquals, true, "", filename, ReferenceFile(filename))
-	testCheck(c, FileEquals, true, "", filename, ReferenceFile(equalRefereceFilename))
+	testCheck(c, FileEquals, true, "", filename, FileContentRef(filename))
+	testCheck(c, FileEquals, true, "", filename, FileContentRef(equalRefereceFilename))
 
 	twofer := content + content
 	testCheck(c, FileEquals, false, "Failed to match with file contents:\nnot-so-random-string", filename, twofer)
@@ -65,7 +65,7 @@ func (s *fileContentCheckerSuite) TestFileEquals(c *check.C) {
 	testCheck(c, FileEquals, false, "Cannot compare file contents with something of type int", filename, 1)
 	testCheck(c, FileEquals, false,
 		fmt.Sprintf("Failed to match contents with reference file \"%s\":\nnot-so-random-string", notEqualRefereceFilename),
-		filename, ReferenceFile(notEqualRefereceFilename))
+		filename, FileContentRef(notEqualRefereceFilename))
 }
 
 func (s *fileContentCheckerSuite) TestFileContains(c *check.C) {
@@ -92,7 +92,7 @@ func (s *fileContentCheckerSuite) TestFileContains(c *check.C) {
 	testCheck(c, FileContains, false, "Filename must be a string", 42, "")
 	testCheck(c, FileContains, false, "Cannot compare file contents with something of type int", filename, 1)
 	testCheck(c, FileContains, false, `Non-exact match with reference file is not supported`,
-		filename, ReferenceFile(filename))
+		filename, FileContentRef(filename))
 }
 
 func (s *fileContentCheckerSuite) TestFileMatches(c *check.C) {
@@ -112,5 +112,5 @@ func (s *fileContentCheckerSuite) TestFileMatches(c *check.C) {
 	testCheck(c, FileMatches, false, "Filename must be a string", 42, ".*")
 	testCheck(c, FileMatches, false, "Regex must be a string", filename, 1)
 	testCheck(c, FileContains, false, `Non-exact match with reference file is not supported`,
-		filename, ReferenceFile(filename))
+		filename, FileContentRef(filename))
 }


### PR DESCRIPTION
The FileEquals checker can verify that the file content is equal to strings,
byte slices or something that implements fmt.Stringer. Extend the functionality
to allow checking that file contents are the same as of a referenced file
with FileContentRef.


