### PR TITLE
o/snapstate: autorefresh phase1 for refresh-control

### DIFF
--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -668,12 +668,12 @@ func (s *autorefreshGatingSuite) TestAutoRefreshPhase1(c *C) {
 	c.Check(seenSnaps, DeepEquals, map[string]bool{"snap-a": true, "snap-b": true})
 
 	// check that refresh-candidates in the state were updated
-	var candidates []snapstate.RefreshCandidate
+	var candidates map[string]*snapstate.RefreshCandidate
 	c.Assert(st.Get("refresh-candidates", &candidates), IsNil)
 	c.Assert(candidates, HasLen, 3)
-	c.Check(candidates[0].InstanceName(), Equals, "snap-a")
-	c.Check(candidates[1].InstanceName(), Equals, "base-snap-b")
-	c.Check(candidates[2].InstanceName(), Equals, "snap-c")
+	c.Check(candidates["snap-a"], NotNil)
+	c.Check(candidates["base-snap-b"], NotNil)
+	c.Check(candidates["snap-c"], NotNil)
 }
 
 func (s *autorefreshGatingSuite) TestAutoRefreshPhase1ConflictsFilteredOut(c *C) {
@@ -732,11 +732,11 @@ func (s *autorefreshGatingSuite) TestAutoRefreshPhase1ConflictsFilteredOut(c *C)
 	c.Check(seenSnaps, DeepEquals, map[string]bool{"snap-a": true})
 
 	// check that refresh-candidates in the state were updated
-	var candidates []snapstate.RefreshCandidate
+	var candidates map[string]*snapstate.RefreshCandidate
 	c.Assert(st.Get("refresh-candidates", &candidates), IsNil)
 	c.Assert(candidates, HasLen, 2)
-	c.Check(candidates[0].InstanceName(), Equals, "snap-a")
-	c.Check(candidates[1].InstanceName(), Equals, "snap-c")
+	c.Check(candidates["snap-a"], NotNil)
+	c.Check(candidates["snap-c"], NotNil)
 }
 
 func (s *autorefreshGatingSuite) TestAutoRefreshPhase1NoHooks(c *C) {

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -603,6 +603,7 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	_, tss, err = snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
 	c.Assert(tss, HasLen, 2)
+	// TODO: verify conditional-auto-refresh task data
 	c.Check(tss[0].Tasks()[0].Kind(), Equals, "conditional-auto-refresh")
 	c.Check(tss[1].Tasks()[0].Kind(), Equals, "run-hook")
 }

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -318,4 +318,7 @@ func MockSecurityProfilesDiscardLate(fn func(snapName string, rev snap.Revision,
 // autorefresh gating
 type AffectedSnapInfo = affectedSnapInfo
 
-var CreateGateAutoRefreshHooks = createGateAutoRefreshHooks
+var (
+	CreateGateAutoRefreshHooks = createGateAutoRefreshHooks
+	AutoRefreshPhase1          = autoRefreshPhase1
+)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2969,6 +2969,12 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
+func (m *SnapManager) doAutoRefreshGate(t *state.Task, tomb *tomb.Tomb) error {
+	// TODO: autoRefreshPhase2 - create refresh tasks for snaps that are
+	// not held.
+	return nil
+}
+
 // InjectTasks makes all the halt tasks of the mainTask wait for extraTasks;
 // extraTasks join the same lane and change as the mainTask.
 func InjectTasks(mainTask *state.Task, extraTasks *state.TaskSet) {

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -140,7 +140,7 @@ func (r *refreshHints) Ensure() error {
 	return r.refresh()
 }
 
-func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreValidationByInstanceName map[string]bool, deviceCtx DeviceContext) ([]*refreshCandidate, error) {
+func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreValidationByInstanceName map[string]bool, deviceCtx DeviceContext) (map[string]*refreshCandidate, error) {
 	if ValidateRefreshes != nil && len(updates) != 0 {
 		userID := 0
 		var err error
@@ -150,7 +150,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 		}
 	}
 
-	hints := []*refreshCandidate{}
+	hints := make(map[string]*refreshCandidate)
 	for _, update := range updates {
 		var snapst SnapState
 		if err := Get(st, update.InstanceName(), &snapst); err != nil {
@@ -185,7 +185,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 			},
 			Version: update.Version,
 		}
-		hints = append(hints, snapsup)
+		hints[update.InstanceName()] = snapsup
 	}
 	return hints, nil
 }

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -150,7 +150,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 		}
 	}
 
-	hints := make(map[string]*refreshCandidate)
+	hints := make(map[string]*refreshCandidate, len(updates))
 	for _, update := range updates {
 		var snapst SnapState
 		if err := Get(st, update.InstanceName(), &snapst); err != nil {

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -254,17 +254,19 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	var candidates []snapstate.RefreshCandidate
+	var candidates map[string]*snapstate.RefreshCandidate
 	c.Assert(s.state.Get("refresh-candidates", &candidates), IsNil)
 	c.Assert(candidates, HasLen, 2)
-	cand1 := candidates[0]
+	cand1 := candidates["some-snap"]
+	c.Assert(cand1, NotNil)
 	c.Check(cand1.InstanceName(), Equals, "some-snap")
 	c.Check(cand1.Base(), Equals, "some-base")
 	c.Check(cand1.Type(), Equals, snap.TypeApp)
 	c.Check(cand1.Size(), Equals, int64(99))
 	c.Check(cand1.Version, Equals, "2")
 
-	cand2 := candidates[1]
+	cand2 := candidates["other-snap"]
+	c.Assert(cand2, NotNil)
 	c.Check(cand2.InstanceName(), Equals, "other-snap")
 	c.Check(cand2.Base(), Equals, "")
 	c.Check(cand2.Type(), Equals, snap.TypeApp)
@@ -347,10 +349,10 @@ func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongArch(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	var candidates []snapstate.RefreshCandidate
+	var candidates map[string]*snapstate.RefreshCandidate
 	c.Assert(s.state.Get("refresh-candidates", &candidates), IsNil)
 	c.Assert(candidates, HasLen, 1)
-	c.Check(candidates[0].InstanceName(), Equals, "some-snap")
+	c.Check(candidates["some-snap"], NotNil)
 }
 
 const otherSnapYaml = `name: other-snap
@@ -395,9 +397,9 @@ func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongEpoch(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	var candidates []snapstate.RefreshCandidate
+	var candidates map[string]*snapstate.RefreshCandidate
 	c.Assert(s.state.Get("refresh-candidates", &candidates), IsNil)
 	c.Assert(candidates, HasLen, 1)
 	// other-snap ignored due to epoch
-	c.Check(candidates[0].InstanceName(), Equals, "some-snap")
+	c.Check(candidates["some-snap"], NotNil)
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -434,6 +434,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	runner.AddHandler("switch-snap-channel", m.doSwitchSnapChannel, nil)
 	runner.AddHandler("toggle-snap-flags", m.doToggleSnapFlags, nil)
 	runner.AddHandler("check-rerefresh", m.doCheckReRefresh, nil)
+	runner.AddHandler("conditional-auto-refresh", m.doAutoRefreshGate, nil)
 
 	// FIXME: drop the task entirely after a while
 	// (having this wart here avoids yet-another-patch)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1867,6 +1867,10 @@ func autoRefreshPhase1(ctx context.Context, st *state.State) ([]string, []*state
 		if err := checkChangeConflictIgnoringOneChange(st, up.InstanceName(), snapst, fromChange); err != nil {
 			logger.Noticef("cannot refresh snap %q: %v", up.InstanceName(), err)
 		} else {
+			// all snaps in updates are now considered to be operated on and should
+			// provoke conflicts until updated or until we know (after running
+			// gate-auto-refresh hooks) that some are not going to be updated
+			// and can stop conflicting.
 			updates = append(updates, up)
 		}
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1867,10 +1867,6 @@ func autoRefreshPhase1(ctx context.Context, st *state.State) ([]string, []*state
 		if err := checkChangeConflictIgnoringOneChange(st, up.InstanceName(), snapst, fromChange); err != nil {
 			logger.Noticef("cannot refresh snap %q: %v", up.InstanceName(), err)
 		} else {
-			// all snaps in updates are now considered to be operated on and should
-			// provoke conflicts until updated or until we know (after running
-			// gate-auto-refresh hooks) that some are not going to be updated
-			// and can stop conflicting.
 			updates = append(updates, up)
 		}
 	}
@@ -1878,6 +1874,11 @@ func autoRefreshPhase1(ctx context.Context, st *state.State) ([]string, []*state
 	if len(updates) == 0 {
 		return nil, nil, nil
 	}
+
+	// all snaps in updates are now considered to be operated on and should
+	// provoke conflicts until updated or until we know (after running
+	// gate-auto-refresh hooks) that some are not going to be updated
+	// and can stop conflicting.
 
 	affectedSnaps, err := affectedByRefresh(st, updates)
 	if err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1828,6 +1828,7 @@ func AutoRefresh(ctx context.Context, st *state.State) ([]string, []*state.TaskS
 		return UpdateMany(ctx, st, nil, userID, &Flags{IsAutoRefresh: true})
 	}
 
+	// TODO: rename to autoRefreshTasks when old auto refresh logic gets removed.
 	return autoRefreshPhase1(ctx, st)
 }
 


### PR DESCRIPTION
Implement autorefresh method that initiates auto-refresh: updates refresh-candidates, creates hooks and a new gating task ("conditional-auto-refresh"). Phase 2 will be handled by doAutoRefreshGate.