### PR TITLE
 wrappers/services.go: introduce EnsureSnapServices() (2.50)

### DIFF
--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -50,6 +50,7 @@ func (m *ServiceManager) Ensure() error {
 func delayedCrossMgrInit() {
 	// hook into conflict checks mechanisms
 	snapstate.AddAffectedSnapsByAttr("service-action", serviceControlAffectedSnaps)
+	snapstate.SnapServiceOptions = SnapServiceOptions
 }
 
 func serviceControlAffectedSnaps(t *state.Task) ([]string, error) {

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -40,9 +40,8 @@ type LinkContext struct {
 	// installed
 	FirstInstall bool
 
-	// VitalityRank is used to hint how much the services should be
-	// protected from the OOM killer
-	VitalityRank int
+	// ServiceOptions is used to configure services.
+	ServiceOptions *wrappers.SnapServiceOptions
 
 	// RunInhibitHint is used only in Unlink snap, and can be used to
 	// establish run inhibition lock for refresh operations.
@@ -192,12 +191,17 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapBinaries)
 
+	vitalityRank := 0
+	if linkCtx.ServiceOptions != nil {
+		vitalityRank = linkCtx.ServiceOptions.VitalityRank
+	}
 	// add the daemons from the snap.yaml
 	opts := &wrappers.AddSnapServicesOptions{
+		VitalityRank:            vitalityRank,
 		Preseeding:              b.preseed,
-		VitalityRank:            linkCtx.VitalityRank,
 		RequireMountedSnapdSnap: linkCtx.RequireMountedSnapdSnap,
 	}
+	// TODO: switch to EnsureSnapServices
 	if err = wrappers.AddSnapServices(s, opts, progress.Null); err != nil {
 		return err
 	}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -889,11 +889,16 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev boot.Device, linkCtx b
 		<-f.linkSnapWaitCh
 	}
 
+	vitalityRank := 0
+	if linkCtx.ServiceOptions != nil {
+		vitalityRank = linkCtx.ServiceOptions.VitalityRank
+	}
+
 	op := fakeOp{
 		op:   "link-snap",
 		path: info.MountDir(),
 
-		vitalityRank:        linkCtx.VitalityRank,
+		vitalityRank:        vitalityRank,
 		requireSnapdTooling: linkCtx.RequireMountedSnapdSnap,
 	}
 

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -93,6 +94,12 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 		return nil, nil
 	}
 	bs.restore = snapstatetest.MockDeviceModel(DefaultModel())
+
+	oldSnapServiceOptions := snapstate.SnapServiceOptions
+	snapstate.SnapServiceOptions = servicestate.SnapServiceOptions
+	bs.AddCleanup(func() {
+		snapstate.SnapServiceOptions = oldSnapServiceOptions
+	})
 }
 
 func (bs *bootedSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -50,7 +50,13 @@ import (
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timings"
+	"github.com/snapcore/snapd/wrappers"
 )
+
+// SnapServiceOptions is a hook set by servicestate.
+var SnapServiceOptions = func(st *state.State, instanceName string) (opts *wrappers.SnapServiceOptions, err error) {
+	panic("internal error: snapstate.SanpServiceOptions is unset")
+}
 
 var SecurityProfilesRemoveLate = func(snapName string, rev snap.Revision, typ snap.Type) error {
 	panic("internal error: snapstate.SecurityProfilesRemoveLate is unset")
@@ -891,13 +897,13 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	snapst.Active = true
-	vitalityRank, err := vitalityRank(st, snapsup.InstanceName())
+	opts, err := SnapServiceOptions(st, snapsup.InstanceName())
 	if err != nil {
 		return err
 	}
 	linkCtx := backend.LinkContext{
-		FirstInstall: false,
-		VitalityRank: vitalityRank,
+		FirstInstall:   false,
+		ServiceOptions: opts,
 	}
 	reboot, err := m.backend.LinkSnap(oldInfo, deviceCtx, linkCtx, perfTimings)
 	if err != nil {
@@ -1082,22 +1088,6 @@ func missingDisabledServices(svcs []string, info *snap.Info) ([]string, []string
 	return foundSvcs, missingSvcs, nil
 }
 
-func vitalityRank(st *state.State, instanceName string) (rank int, err error) {
-	tr := config.NewTransaction(st)
-
-	var vitalityStr string
-	err = tr.GetMaybe("core", "resilience.vitality-hint", &vitalityStr)
-	if err != nil {
-		return 0, err
-	}
-	for i, s := range strings.Split(vitalityStr, ",") {
-		if s == instanceName {
-			return i + 1, nil
-		}
-	}
-	return 0, nil
-}
-
 // LinkSnapParticipant is an interface for interacting with snap link/unlink
 // operations.
 //
@@ -1240,14 +1230,14 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		return err
 	}
 
-	vitalityRank, err := vitalityRank(st, snapsup.InstanceName())
+	opts, err := SnapServiceOptions(st, snapsup.InstanceName())
 	if err != nil {
 		return err
 	}
 	firstInstall := oldCurrent.Unset()
 	linkCtx := backend.LinkContext{
-		FirstInstall: firstInstall,
-		VitalityRank: vitalityRank,
+		FirstInstall:   firstInstall,
+		ServiceOptions: opts,
 	}
 	// on UC18+, snap tooling comes from the snapd snap so we need generated
 	// mount units to depend on the snapd snap mount units
@@ -2130,13 +2120,13 @@ func (m *SnapManager) undoUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.Active = true
 	Set(st, snapsup.InstanceName(), snapst)
 
-	vitalityRank, err := vitalityRank(st, snapsup.InstanceName())
+	opts, err := SnapServiceOptions(st, snapsup.InstanceName())
 	if err != nil {
 		return err
 	}
 	linkCtx := backend.LinkContext{
-		FirstInstall: false,
-		VitalityRank: vitalityRank,
+		FirstInstall:   false,
+		ServiceOptions: opts,
 	}
 	reboot, err := m.backend.LinkSnap(info, deviceCtx, linkCtx, perfTimings)
 	if err != nil {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -73,6 +74,12 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 	s.setup(c, s.stateBackend)
 
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
+
+	oldSnapServiceOptions := snapstate.SnapServiceOptions
+	snapstate.SnapServiceOptions = servicestate.SnapServiceOptions
+	s.AddCleanup(func() {
+		snapstate.SnapServiceOptions = oldSnapServiceOptions
+	})
 }
 
 func checkHasCookieForSnap(c *C, st *state.State, instanceName string) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -121,10 +122,12 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	oldSetupPreRefreshHook := snapstate.SetupPreRefreshHook
 	oldSetupPostRefreshHook := snapstate.SetupPostRefreshHook
 	oldSetupRemoveHook := snapstate.SetupRemoveHook
+	oldSnapServiceOptions := snapstate.SnapServiceOptions
 	snapstate.SetupInstallHook = hookstate.SetupInstallHook
 	snapstate.SetupPreRefreshHook = hookstate.SetupPreRefreshHook
 	snapstate.SetupPostRefreshHook = hookstate.SetupPostRefreshHook
 	snapstate.SetupRemoveHook = hookstate.SetupRemoveHook
+	snapstate.SnapServiceOptions = servicestate.SnapServiceOptions
 
 	var err error
 	s.snapmgr, err = snapstate.Manager(s.state, s.o.TaskRunner())
@@ -155,6 +158,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 		snapstate.SetupPreRefreshHook = oldSetupPreRefreshHook
 		snapstate.SetupPostRefreshHook = oldSetupPostRefreshHook
 		snapstate.SetupRemoveHook = oldSetupRemoveHook
+		snapstate.SnapServiceOptions = oldSnapServiceOptions
 
 		dirs.SetRootDir("/")
 	})

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2016 Canonical Ltd
+ * Copyright (C) 2014-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -379,7 +379,7 @@ func userDaemonReload() error {
 	return cli.ServicesDaemonReload(ctx)
 }
 
-func tryFileUpdate(path string, desiredContent []byte) (old *osutil.FileState, modified bool, err error) {
+func tryFileUpdate(path string, desiredContent []byte) (old *osutil.MemoryFileState, modified bool, err error) {
 	newFileState := osutil.MemoryFileState{
 		Content: desiredContent,
 		Mode:    os.FileMode(0644),
@@ -403,8 +403,7 @@ func tryFileUpdate(path string, desiredContent []byte) (old *osutil.FileState, m
 		newFileState.Mode = st.Mode()
 
 		// save the old state of the file
-		st := osutil.FileState(&oldFileState)
-		old = &st
+		old = &oldFileState
 	}
 
 	if mkdirErr := os.MkdirAll(filepath.Dir(path), 0755); mkdirErr != nil {
@@ -430,6 +429,11 @@ type SnapServiceOptions struct {
 	VitalityRank int
 }
 
+// ObserveChangeCallback can be invoked by EnsureSnapServices to observe
+// the previous content of a unit and the new on a change.
+// unitType can be "service", "socket", "timer". name is empty for a timer.
+type ObserveChangeCallback func(app *snap.AppInfo, unitType string, name, old, new string)
+
 // EnsureSnapServicesOptions is the set of options applying to the
 // EnsureSnapServices operation. It does not include per-snap specific options
 // such as VitalityRank or RequireMountedSnapdSnap from AddSnapServiceOptions,
@@ -453,16 +457,16 @@ type EnsureSnapServicesOptions struct {
 // There are two sets of options; there are global options which apply to the
 // entire transaction and to every snap service that is ensured, and options
 // which are per-snap service and specified in the map argument.
-// The return value is a map of the snap's Info the a list of App's that were
-// updated or modified. Apps in a snap that did not have their service
-// definitions change are not included in the map's list value.
 // If any errors are encountered trying to update systemd units, then all
 // changes performed up to that point are rolled back, meaning newly written
 // units are deleted and modified units are attempted to be restored to their
-// previous state. In this case the modified return value is nil.
-func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSnapServicesOptions, inter interacter) (modified map[*snap.Info][]*snap.AppInfo, err error) {
-	modified = make(map[*snap.Info][]*snap.AppInfo)
-
+// previous state.
+// To observe which units were added or modified a
+// ObserveChangeCallback calllback can be provided. The callback is
+// invoked while processing the changes. Because of that it should not
+// produce immediate side-effects, as the changes are in effect only
+// if the function did not return an error.
+func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSnapServicesOptions, observeChange ObserveChangeCallback, inter interacter) (err error) {
 	// note, sysd is not used when preseeding
 	sysd := systemd.New(systemd.SystemMode, inter)
 
@@ -483,7 +487,7 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 	// updated and some may have been rolled back, higher level tasks/changes
 	// should have do/undo handlers to properly handle the case where this
 	// function is interrupted midway
-	modifiedUnitsPreviousState := make(map[string]*osutil.FileState)
+	modifiedUnitsPreviousState := make(map[string]*osutil.MemoryFileState)
 	var modifiedSystem, modifiedUser bool
 
 	defer func() {
@@ -499,7 +503,7 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 				}
 			} else {
 				// rollback the file to the previous state
-				if e := osutil.EnsureFileState(file, *state); e != nil {
+				if e := osutil.EnsureFileState(file, state); e != nil {
 					inter.Notify(fmt.Sprintf("while trying to rollback %s due to previous failure: %v", file, e))
 				}
 			}
@@ -516,15 +520,21 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 		}
 	}()
 
-	handleFileModification := func(s *snap.Info, app *snap.AppInfo, path string, content []byte) error {
+	handleFileModification := func(app *snap.AppInfo, unitType string, name, path string, content []byte) error {
 		old, modifiedFile, err := tryFileUpdate(path, content)
 		if err != nil {
 			return err
 		}
 
 		if modifiedFile {
+			if observeChange != nil {
+				var oldContent []byte
+				if old != nil {
+					oldContent = old.Content
+				}
+				observeChange(app, unitType, name, string(oldContent), string(content))
+			}
 			modifiedUnitsPreviousState[path] = old
-			modified[s] = append(modified[s], app)
 
 			// also mark that we need to reload either the system or
 			// user instance of systemd
@@ -541,7 +551,7 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 
 	for s, snapSvcOpts := range snaps {
 		if s.Type() == snap.TypeSnapd {
-			return nil, fmt.Errorf("internal error: adding explicit services for snapd snap is unexpected")
+			return fmt.Errorf("internal error: adding explicit services for snapd snap is unexpected")
 		}
 
 		// always use RequireMountedSnapdSnap options from the global options
@@ -566,32 +576,33 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 			path := app.ServiceFile()
 			content, err := generateSnapServiceFile(app, genServiceOpts)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
-			if err := handleFileModification(s, app, path, content); err != nil {
-				return nil, err
+			if err := handleFileModification(app, "service", app.Name, path, content); err != nil {
+				return err
 			}
 
 			// Generate systemd .socket files if needed
 			socketFiles, err := generateSnapSocketFiles(app)
 			if err != nil {
-				return nil, err
+				return err
 			}
-			for path, content := range socketFiles {
-				if err := handleFileModification(s, app, path, content); err != nil {
-					return nil, err
+			for name, content := range socketFiles {
+				path := app.Sockets[name].File()
+				if err := handleFileModification(app, "socket", name, path, content); err != nil {
+					return err
 				}
 			}
 
 			if app.Timer != nil {
 				content, err := generateSnapTimerFile(app)
 				if err != nil {
-					return nil, err
+					return err
 				}
 				path := app.Timer.File()
-				if err := handleFileModification(s, app, path, content); err != nil {
-					return nil, err
+				if err := handleFileModification(app, "timer", "", path, content); err != nil {
+					return err
 				}
 			}
 		}
@@ -600,17 +611,17 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 	if !preseeding {
 		if modifiedSystem {
 			if err = sysd.DaemonReload(); err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if modifiedUser {
 			if err = userDaemonReload(); err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
 
-	return modified, nil
+	return nil
 }
 
 // AddSnapServicesOptions is a struct for controlling the generated service
@@ -649,8 +660,7 @@ func AddSnapServices(s *snap.Info, opts *AddSnapServicesOptions, inter interacte
 		ensureOpts.RequireMountedSnapdSnap = opts.RequireMountedSnapdSnap
 	}
 
-	_, err := EnsureSnapServices(m, ensureOpts, inter)
-	return err
+	return EnsureSnapServices(m, ensureOpts, nil, inter)
 }
 
 // StopServicesFlags carries extra flags for StopServices.
@@ -1134,8 +1144,8 @@ func generateSnapSocketFiles(app *snap.AppInfo) (map[string][]byte, error) {
 	}
 
 	socketFiles := make(map[string][]byte)
-	for name, socket := range app.Sockets {
-		socketFiles[socket.File()] = genServiceSocketFile(app, name)
+	for name := range app.Sockets {
+		socketFiles[name] = genServiceSocketFile(app, name)
 	}
 	return socketFiles, nil
 }

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -552,9 +552,8 @@ WantedBy=sockets.target
 
 	generatedSockets, err := wrappers.GenerateSnapSocketFiles(service)
 	c.Assert(err, IsNil)
-	c.Assert(generatedSockets, Not(IsNil))
-	c.Assert(*generatedSockets, HasLen, 2)
-	c.Assert(*generatedSockets, DeepEquals, map[string][]byte{
+	c.Assert(generatedSockets, HasLen, 2)
+	c.Assert(generatedSockets, DeepEquals, map[string][]byte{
 		sock1Path: []byte(sock1Expected),
 		sock2Path: []byte(sock2Expected),
 	})

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -540,8 +539,6 @@ WantedBy=sockets.target
 	service.Sockets["sock1"].App = service
 	service.Sockets["sock2"].App = service
 
-	sock1Path := filepath.Join(dirs.SnapServicesDir, "snap.some-snap.app.sock1.socket")
-	sock2Path := filepath.Join(dirs.SnapServicesDir, "snap.some-snap.app.sock2.socket")
 	sock1Expected := fmt.Sprintf(sock1ExpectedFmt, mountUnitPrefix, mountUnitPrefix, si.DataDir())
 	sock2Expected := fmt.Sprintf(sock2ExpectedFmt, mountUnitPrefix, mountUnitPrefix, si.DataDir())
 
@@ -554,8 +551,8 @@ WantedBy=sockets.target
 	c.Assert(err, IsNil)
 	c.Assert(generatedSockets, HasLen, 2)
 	c.Assert(generatedSockets, DeepEquals, map[string][]byte{
-		sock1Path: []byte(sock1Expected),
-		sock2Path: []byte(sock2Expected),
+		"sock1": []byte(sock1Expected),
+		"sock2": []byte(sock2Expected),
 	})
 }
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -212,7 +212,7 @@ WantedBy=multi-user.target
 }
 
 func (s *servicesTestSuite) TestEnsureSnapServicesAddsNewSvc(c *C) {
-	// test that with an existing service unit defintion, it is not changed
+	// test that with an existing service unit definition, it is not changed
 	// but we do add the new one
 	info := snaptest.MockSnap(c, packageHello+` svc2:
   command: bin/hello


### PR DESCRIPTION
Backport of https://github.com/snapcore/snapd/pull/10133 for 2.50 - with that we can cherry-pick PR #10164 (commit  406dbc0 from master).

As suggested this now also includes #10151 and  #10171