### PR TITLE
o/hookstate, o/snapstate: print revision, version, channel with snapctl --pending

### DIFF
--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -78,15 +78,15 @@ var refreshFromHookTests = []struct {
 }, {
 	args:              []string{"refresh", "--pending"},
 	refreshCandidates: map[string]interface{}{"snap1": mockRefreshCandidate("snap1", "", "edge", "v1", snap.Revision{N: 3})},
-	stdout:            "pending: \nchannel: edge\nversion: v1\nrevision: 3\nbase: false\nrestart: false\n",
+	stdout:            "channel: edge\nversion: v1\nrevision: 3\nbase: false\nrestart: false\n",
 }, {
 	args:   []string{"refresh", "--pending"},
-	stdout: "pending: \nchannel: stable\nbase: false\nrestart: false\n",
+	stdout: "channel: stable\nbase: false\nrestart: false\n",
 }, {
 	args:    []string{"refresh", "--pending"},
 	base:    true,
 	restart: true,
-	stdout:  "pending: \nchannel: stable\nbase: true\nrestart: true\n",
+	stdout:  "channel: stable\nbase: true\nrestart: true\n",
 }}
 
 func (s *refreshSuite) TestRefreshFromHook(c *C) {

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -63,7 +63,7 @@ func (s *refreshSuite) SetUpTest(c *C) {
 var refreshFromHookTests = []struct {
 	args                []string
 	base, restart       bool
-	refreshCandidates   []interface{}
+	refreshCandidates   map[string]interface{}
 	stdout, stderr, err string
 	exitCode            int
 }{{
@@ -77,7 +77,7 @@ var refreshFromHookTests = []struct {
 	err:  "not implemented yet",
 }, {
 	args:              []string{"refresh", "--pending"},
-	refreshCandidates: []interface{}{mockRefreshCandidate("snap1", "", "edge", "v1", snap.Revision{N: 3})},
+	refreshCandidates: map[string]interface{}{"snap1": mockRefreshCandidate("snap1", "", "edge", "v1", snap.Revision{N: 3})},
 	stdout:            "pending: \nchannel: edge\nversion: v1\nrevision: 3\nbase: false\nrestart: false\n",
 }, {
 	args:   []string{"refresh", "--pending"},

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -39,6 +40,18 @@ type refreshSuite struct {
 
 var _ = Suite(&refreshSuite{})
 
+func mockRefreshCandidate(snapName, instanceKey, channel, version string, revision snap.Revision) interface{} {
+	sup := &snapstate.SnapSetup{
+		Channel:     channel,
+		InstanceKey: instanceKey,
+		SideInfo: &snap.SideInfo{
+			Revision: revision,
+			RealName: snapName,
+		},
+	}
+	return snapstate.MockRefreshCandidate(sup, version)
+}
+
 func (s *refreshSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
@@ -50,6 +63,7 @@ func (s *refreshSuite) SetUpTest(c *C) {
 var refreshFromHookTests = []struct {
 	args                []string
 	base, restart       bool
+	refreshCandidates   []interface{}
 	stdout, stderr, err string
 	exitCode            int
 }{{
@@ -62,13 +76,17 @@ var refreshFromHookTests = []struct {
 	args: []string{"refresh", "--hold"},
 	err:  "not implemented yet",
 }, {
+	args:              []string{"refresh", "--pending"},
+	refreshCandidates: []interface{}{mockRefreshCandidate("snap1", "", "edge", "v1", snap.Revision{N: 3})},
+	stdout:            "pending: \nchannel: edge\nversion: v1\nrevision: 3\nbase: false\nrestart: false\n",
+}, {
 	args:   []string{"refresh", "--pending"},
-	stdout: "pending: \nchannel: \nbase: false\nrestart: false\n",
+	stdout: "pending: \nchannel: stable\nbase: false\nrestart: false\n",
 }, {
 	args:    []string{"refresh", "--pending"},
 	base:    true,
 	restart: true,
-	stdout:  "pending: \nchannel: \nbase: true\nrestart: true\n",
+	stdout:  "pending: \nchannel: stable\nbase: true\nrestart: true\n",
 }}
 
 func (s *refreshSuite) TestRefreshFromHook(c *C) {
@@ -77,12 +95,19 @@ func (s *refreshSuite) TestRefreshFromHook(c *C) {
 	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(1), Hook: "gate-auto-refresh"}
 	mockContext, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
 	c.Check(err, IsNil)
+	snapstate.Set(s.st, "snap1", &snapstate.SnapState{
+		Active:          true,
+		Sequence:        []*snap.SideInfo{{RealName: "snap1", Revision: snap.R(1)}},
+		Current:         snap.R(2),
+		TrackingChannel: "stable",
+	})
 	s.st.Unlock()
 
 	for _, test := range refreshFromHookTests {
 		mockContext.Lock()
 		mockContext.Set("base", test.base)
 		mockContext.Set("restart", test.restart)
+		s.st.Set("refresh-candidates", test.refreshCandidates)
 		mockContext.Unlock()
 
 		stdout, stderr, err := ctlcmd.Run(mockContext, test.args, 0)

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -62,6 +62,7 @@ var refreshRetryDelay = 20 * time.Minute
 // of auto-refresh.
 type refreshCandidate struct {
 	SnapSetup
+	Version string `json:"version,omitempty"`
 }
 
 func (rc *refreshCandidate) Type() snap.Type {
@@ -642,4 +643,12 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 	// Send the notification asynchronously to avoid holding the state lock.
 	asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
 	return checkerErr
+}
+
+// for testing outside of snapstate
+func MockRefreshCandidate(snapSetup *SnapSetup, version string) interface{} {
+	return &refreshCandidate{
+		SnapSetup: *snapSetup,
+		Version:   version,
+	}
 }

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -20,6 +20,7 @@
 package snapstate
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/snapcore/snapd/logger"
@@ -91,7 +92,7 @@ func (r *refreshHints) refresh() error {
 	}
 	hints, err := refreshHintsFromCandidates(r.state, updates, ignoreValidationByInstanceName, deviceCtx)
 	if err != nil {
-		return err
+		return fmt.Errorf("internal error: cannot get refresh-candidates: %v", err)
 	}
 	r.state.Set("refresh-candidates", hints)
 	return nil
@@ -165,7 +166,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 		}
 
 		snapsup := &refreshCandidate{
-			SnapSetup{
+			SnapSetup: SnapSetup{
 				Base:      update.Base,
 				Prereq:    defaultContentPlugProviders(st, update),
 				Channel:   snapst.TrackingChannel,
@@ -181,7 +182,9 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 					Website: update.Website,
 					Media:   update.Media,
 				},
-			}}
+			},
+			Version: update.Version,
+		}
 		hints = append(hints, snapsup)
 	}
 	return hints, nil

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -207,6 +207,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 	s.state.Unlock()
 
 	info2 := &snap.Info{
+		Version:       "v1",
 		Architectures: []string{"all"},
 		SnapType:      snap.TypeApp,
 		SideInfo: snap.SideInfo{
@@ -232,6 +233,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 	info2.Plugs = plugs
 
 	s.store.refreshedSnaps = []*snap.Info{{
+		Version:       "2",
 		Architectures: []string{"all"},
 		Base:          "some-base",
 		SnapType:      snap.TypeApp,
@@ -260,12 +262,14 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 	c.Check(cand1.Base(), Equals, "some-base")
 	c.Check(cand1.Type(), Equals, snap.TypeApp)
 	c.Check(cand1.Size(), Equals, int64(99))
+	c.Check(cand1.Version, Equals, "2")
 
 	cand2 := candidates[1]
 	c.Check(cand2.InstanceName(), Equals, "other-snap")
 	c.Check(cand2.Base(), Equals, "")
 	c.Check(cand2.Type(), Equals, snap.TypeApp)
 	c.Check(cand2.Size(), Equals, int64(88))
+	c.Check(cand2.Version, Equals, "v1")
 
 	var snapst snapstate.SnapState
 


### PR DESCRIPTION
Flesh out snapctl --pending: print version, revision and channel info. Enhanced refreshCandidate struct with version string.

Handles running from hook only at the moment.