### PR TITLE
tests: adding debug info for create user tests

### DIFF
--- a/tests/core/create-user-2/task.yaml
+++ b/tests/core/create-user-2/task.yaml
@@ -10,6 +10,12 @@ restore: |
     fi
     snap remove-user "$USER_NAME"
 
+debug: |
+    if [ -e managed.device ]; then
+        ls -al /home/"$USER_NAME" || true
+        cat /var/lib/extrausers/passwd || true
+    fi
+
 execute: |
     echo "snap create-user -- ensure failure when run as non-root user without sudo"
     expected="error: while creating user: access denied"
@@ -19,15 +25,15 @@ execute: |
     [[ "$obtained" =~ $expected ]]
 
     if [ "$(snap managed)" = "true" ]; then
+        # Leave a file indicating the device was initially managed
+        touch managed.device
+
         echo "snap create-user -- not success when run as non-root user with sudo on managed device"
         if su - test /bin/sh -c "sudo snap create-user --sudoer $USER_EMAIL" 2>create.error; then
             echo "Did not get expected error creating user in managed device"
             exit 1
         fi
         MATCH "cannot create user: device already managed" < create.error
-
-        # Leave a file indicating the device was initially managed
-        touch managed.device
 
         exit 0
     fi

--- a/tests/core/create-user/task.yaml
+++ b/tests/core/create-user/task.yaml
@@ -11,19 +11,26 @@ restore: |
     fi
     snap remove-user "$USER_NAME"
 
+debug: |
+    if [ -e managed.device ]; then
+        ls -al /home/"$USER_NAME" || true
+        cat /var/lib/extrausers/passwd || true
+    fi
+
 execute: |
     if [ "$MANAGED_DEVICE" = "true" ]; then
+        # Leave a file indicating the device was initially managed
+        touch managed.device
+
         if snap create-user --sudoer "$USER_EMAIL" 2>create.error; then
             echo "Did not get expected error creating user in managed device"
             exit 1
         fi
         MATCH "cannot create user: device already managed" < create.error
 
-        # Leave a file indicating the device was initially managed
-        touch managed.device
-
         exit 0
     fi
+
     echo "Adding invalid user"
     expected='error: while creating user: cannot create user "nosuchuser@example.com"'
     if output=$(snap create-user nosuchuser@example.com 2>&1); then


### PR DESCRIPTION
This is to add extra info when the test fails during beta validation

Error executing external:ubuntu-core-20-64:tests/core/create-user
(external:ubuntu-core-20-64) :

+ '[' true = true ']'
+ snap create-user --sudoer mvo@ubuntu.com
created user "mvo"
+ echo 'Did not get expected error creating user in managed device'
Did not get expected error creating user in managed device
+ exit 1
