### PR TITLE
o/servicestate/servicemgr.go: add ensure loop for snap service units (2.50)

### DIFF
--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -142,6 +142,10 @@ func (s *appsSuite) SetUpTest(c *check.C) {
 	restoreServicestateCtrl := daemon.MockServicestateControl(s.fakeServiceControl)
 	s.AddCleanup(restoreServicestateCtrl)
 
+	// turn off ensuring snap services which will call systemctl automatically
+	r := servicestate.MockEnsuredSnapServices(s.d.Overlord().ServiceManager(), true)
+	s.AddCleanup(r)
+
 	s.infoA = s.mkInstalledInState(c, s.d, "snap-a", "dev", "v1", snap.R(1), true, "apps: {svc1: {daemon: simple}, svc2: {daemon: simple, reload-command: x}}")
 	s.infoB = s.mkInstalledInState(c, s.d, "snap-b", "dev", "v1", snap.R(1), false, "apps: {svc3: {daemon: simple}, cmd1: {}}")
 	s.infoC = s.mkInstalledInState(c, s.d, "snap-c", "dev", "v1", snap.R(1), true, "")

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -485,7 +485,7 @@ version: %s
 		"snap-sha3-384": string(dgst),
 		"snap-size":     "999",
 		"snap-id":       snapID,
-		"snap-revision": fmt.Sprintf("%s", revision),
+		"snap-revision": revision.String(), // this must be a string
 		"developer-id":  devAcct.AccountID(),
 		"timestamp":     time.Now().Format(time.RFC3339),
 	}, nil, "")
@@ -551,7 +551,7 @@ func (s *apiBaseSuite) jsonReq(c *check.C, req *http.Request, u *auth.UserState)
 
 func (s *apiBaseSuite) syncReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.Resp {
 	rsp := s.jsonReq(c, req, u)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeSync, check.Commentf("expected sync resp: %#v", rsp))
+	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeSync, check.Commentf("expected sync resp: %#v, result: %+v", rsp, rsp.Result))
 	return rsp
 }
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -64,6 +64,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -74,6 +75,7 @@ import (
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/wrappers"
 )
 
 var (
@@ -5886,6 +5888,449 @@ type: kernel`
 	})
 }
 
+func (s *mgrsSuite) TestUC18SnapdRefreshUpdatesSnapServiceUnitsAndRestartsKilledUnits(c *C) {
+	const snapdSnap = `
+name: snapd
+version: 1.0
+type: snapd`
+	snapPath := snaptest.MakeTestSnapWithFiles(c, snapdSnap, nil)
+	si := &snap.SideInfo{RealName: "snapd"}
+
+	st := s.o.State()
+	st.Lock()
+
+	// we must be seeded
+	st.Set("seeded", true)
+
+	// add the test snap service
+	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
+	snapstate.Set(st, "test-snap", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{testSnapSideInfo},
+		Current:  snap.R(42),
+		Active:   true,
+		SnapType: "app",
+	})
+	snaptest.MockSnapWithFiles(c, `name: test-snap
+version: v1
+apps:
+  svc1:
+    command: bin.sh
+    daemon: simple
+`, testSnapSideInfo, nil)
+
+	// add the snap service unit with Requires=
+	unitTempl := `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application test-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+%[3]s=usr-lib-snapd.mount
+After=usr-lib-snapd.mount
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run test-snap.svc1
+SyslogIdentifier=test-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/test-snap/42
+TimeoutStopSec=30
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	initialUnitFile := fmt.Sprintf(unitTempl,
+		systemd.EscapeUnitNamePath(filepath.Join(dirs.SnapMountDir, "test-snap", "42.mount")),
+		dirs.GlobalRootDir,
+		"Requires",
+	)
+
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap.test-snap.svc1.service"), []byte(initialUnitFile), 0644)
+	c.Assert(err, IsNil)
+
+	// we also need to setup the usr-lib-snapd.mount file too
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	// the modification time of the usr-lib-snapd.mount file is the first
+	// timestamp we use, then the stop time of the snap svc, then the stop time
+	// of usr-lib-snapd.mount
+	t0 := time.Now()
+	t1 := t0.Add(1 * time.Hour)
+	t2 := t0.Add(2 * time.Hour)
+
+	err = os.Chtimes(usrLibSnapdMountFile, t0, t0)
+	c.Assert(err, IsNil)
+
+	systemctlCalls := 0
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		systemctlCalls++
+
+		switch systemctlCalls {
+		// first 3 calls are for the snapd refresh itself
+		case 1:
+			c.Assert(cmd, DeepEquals, []string{"daemon-reload"})
+			return nil, nil
+		case 2:
+			c.Assert(cmd, DeepEquals, []string{"enable", "snap-snapd-x1.mount"})
+			return nil, nil
+		case 3:
+			c.Assert(cmd, DeepEquals, []string{"start", "snap-snapd-x1.mount"})
+			return nil, nil
+			// next we get the calls for the rewritten service files after snapd
+			// restarts
+		case 4:
+			c.Assert(cmd, DeepEquals, []string{"daemon-reload"})
+			return nil, nil
+		case 5:
+			c.Assert(cmd, DeepEquals, []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"})
+			return []byte("InactiveEnterTimestamp=" + t2.Format("Mon 2006-01-02 15:04:05 MST")), nil
+		case 6:
+			c.Assert(cmd, DeepEquals, []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"})
+			return []byte("InactiveEnterTimestamp=" + t1.Format("Mon 2006-01-02 15:04:05 MST")), nil
+		case 7:
+			c.Assert(cmd, DeepEquals, []string{"is-enabled", "snap.test-snap.svc1.service"})
+			return []byte("enabled"), nil
+		case 8:
+			c.Assert(cmd, DeepEquals, []string{"start", "snap.test-snap.svc1.service"})
+			return nil, nil
+		default:
+			c.Errorf("unexpected call to systemctl: %+v", cmd)
+			return nil, fmt.Errorf("broken test")
+		}
+	})
+	s.AddCleanup(r)
+	// make sure that we get the expected number of systemctl calls
+	s.AddCleanup(func() { c.Assert(systemctlCalls, Equals, 8) })
+
+	// also add the snapd snap to state which we will refresh
+	si1 := &snap.SideInfo{RealName: "snapd", Revision: snap.R(1)}
+	snapstate.Set(st, "snapd", &snapstate.SnapState{
+		SnapType: "snapd",
+		Active:   true,
+		Sequence: []*snap.SideInfo{si1},
+		Current:  si1.Revision,
+	})
+	snaptest.MockSnapWithFiles(c, "name: snapd\ntype: snapd\nversion: 123", si1, nil)
+
+	// setup model assertion
+	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+	devicestatetest.SetDevice(st, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+	// model := s.brands.Model("my-brand", "my-model", modelDefaults)
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"gadget":       "pc",
+		"kernel":       "kernel",
+		"architecture": "amd64",
+		"base":         "core18",
+	})
+	err = assertstate.Add(st, model)
+	c.Assert(err, IsNil)
+
+	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	chg := st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	// make sure we don't try to ensure snap services before the restart
+	r = servicestate.MockEnsuredSnapServices(s.o.ServiceManager(), true)
+	defer r()
+
+	// run, this will trigger wait for restart
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	// check the snapd task state
+	c.Check(chg.Status(), Equals, state.DoingStatus)
+	restarting, kind := st.Restarting()
+	c.Check(restarting, Equals, true)
+	c.Assert(kind, Equals, state.RestartDaemon)
+
+	// now we do want the ensure loop to run though
+	r = servicestate.MockEnsuredSnapServices(s.o.ServiceManager(), false)
+	defer r()
+
+	// mock a restart of snapd to progress with the change
+	state.MockRestarting(st, state.RestartUnset)
+
+	// let the change run its course
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	defer st.Unlock()
+	c.Assert(err, IsNil)
+
+	c.Check(chg.Status(), Equals, state.DoneStatus, Commentf("change failed: %v", chg.Err()))
+
+	// we don't restart since the unit file was just rewritten, no services were
+	// killed
+	restarting, _ = st.Restarting()
+	c.Check(restarting, Equals, false)
+
+	// the unit file was rewritten to use Wants= now
+	rewrittenUnitFile := fmt.Sprintf(unitTempl,
+		systemd.EscapeUnitNamePath(filepath.Join(dirs.SnapMountDir, "test-snap", "42.mount")),
+		dirs.GlobalRootDir,
+		"Wants",
+	)
+	c.Assert(filepath.Join(dirs.SnapServicesDir, "snap.test-snap.svc1.service"), testutil.FileEquals, rewrittenUnitFile)
+}
+
+func (s *mgrsSuite) TestUC18SnapdRefreshUpdatesSnapServiceUnitsAndAttemptsToRestartsKilledUnitsButFails(c *C) {
+	const snapdSnap = `
+name: snapd
+version: 1.0
+type: snapd`
+	snapPath := snaptest.MakeTestSnapWithFiles(c, snapdSnap, nil)
+	si := &snap.SideInfo{RealName: "snapd"}
+
+	st := s.o.State()
+	st.Lock()
+
+	// we must be seeded
+	st.Set("seeded", true)
+
+	// add the test snap service
+	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
+	snapstate.Set(st, "test-snap", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{testSnapSideInfo},
+		Current:  snap.R(42),
+		Active:   true,
+		SnapType: "app",
+	})
+	snaptest.MockSnapWithFiles(c, `name: test-snap
+version: v1
+apps:
+  svc1:
+    command: bin.sh
+    daemon: simple
+`, testSnapSideInfo, nil)
+
+	// add the snap service unit with Requires=
+	unitTempl := `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application test-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+%[3]s=usr-lib-snapd.mount
+After=usr-lib-snapd.mount
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run test-snap.svc1
+SyslogIdentifier=test-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/test-snap/42
+TimeoutStopSec=30
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	initialUnitFile := fmt.Sprintf(unitTempl,
+		systemd.EscapeUnitNamePath(filepath.Join(dirs.SnapMountDir, "test-snap", "42.mount")),
+		dirs.GlobalRootDir,
+		"Requires",
+	)
+
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap.test-snap.svc1.service"), []byte(initialUnitFile), 0644)
+	c.Assert(err, IsNil)
+
+	// we also need to setup the usr-lib-snapd.mount file too
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	// the modification time of the usr-lib-snapd.mount file is the first
+	// timestamp we use, then the stop time of the snap svc, then the stop time
+	// of usr-lib-snapd.mount
+	t0 := time.Now()
+	t1 := t0.Add(1 * time.Hour)
+	t2 := t0.Add(2 * time.Hour)
+
+	err = os.Chtimes(usrLibSnapdMountFile, t0, t0)
+	c.Assert(err, IsNil)
+
+	systemctlCalls := 0
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		systemctlCalls++
+
+		switch systemctlCalls {
+		// first 3 calls are for the snapd refresh itself
+		case 1:
+			c.Assert(cmd, DeepEquals, []string{"daemon-reload"})
+			return nil, nil
+		case 2:
+			c.Assert(cmd, DeepEquals, []string{"enable", "snap-snapd-x1.mount"})
+			return nil, nil
+		case 3:
+			c.Assert(cmd, DeepEquals, []string{"start", "snap-snapd-x1.mount"})
+			return nil, nil
+			// next we get the calls for the rewritten service files after snapd
+			// restarts
+		case 4:
+			c.Assert(cmd, DeepEquals, []string{"daemon-reload"})
+			return nil, nil
+		case 5:
+			c.Assert(cmd, DeepEquals, []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"})
+			return []byte("InactiveEnterTimestamp=" + t2.Format("Mon 2006-01-02 15:04:05 MST")), nil
+		case 6:
+			c.Assert(cmd, DeepEquals, []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"})
+			return []byte("InactiveEnterTimestamp=" + t1.Format("Mon 2006-01-02 15:04:05 MST")), nil
+		case 7:
+			c.Assert(cmd, DeepEquals, []string{"is-enabled", "snap.test-snap.svc1.service"})
+			return []byte("enabled"), nil
+		case 8:
+			// starting the snap fails
+			c.Assert(cmd, DeepEquals, []string{"start", "snap.test-snap.svc1.service"})
+			return nil, fmt.Errorf("the snap service is having a bad day")
+		case 9:
+			// because starting the snap fails, we will automatically try to
+			// undo the starting of the snap by stopping it, hence the request
+			// to stop it
+			// TODO: is this desirable? in the field, what if stopping the
+			// service also dies?
+			c.Assert(cmd, DeepEquals, []string{"stop", "snap.test-snap.svc1.service"})
+			return nil, fmt.Errorf("the snap service is still having a bad day")
+		default:
+			c.Errorf("unexpected call to systemctl: %+v", cmd)
+			return nil, fmt.Errorf("broken test")
+		}
+	})
+	s.AddCleanup(r)
+	// make sure that we get the expected number of systemctl calls
+	s.AddCleanup(func() { c.Assert(systemctlCalls, Equals, 9) })
+
+	// also add the snapd snap to state which we will refresh
+	si1 := &snap.SideInfo{RealName: "snapd", Revision: snap.R(1)}
+	snapstate.Set(st, "snapd", &snapstate.SnapState{
+		SnapType: "snapd",
+		Active:   true,
+		Sequence: []*snap.SideInfo{si1},
+		Current:  si1.Revision,
+	})
+	snaptest.MockSnapWithFiles(c, "name: snapd\ntype: snapd\nversion: 123", si1, nil)
+
+	// setup model assertion
+	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+	devicestatetest.SetDevice(st, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+	// model := s.brands.Model("my-brand", "my-model", modelDefaults)
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"gadget":       "pc",
+		"kernel":       "kernel",
+		"architecture": "amd64",
+		"base":         "core18",
+	})
+	err = assertstate.Add(st, model)
+	c.Assert(err, IsNil)
+
+	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	chg := st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	// make sure we don't try to ensure snap services before the restart
+	r = servicestate.MockEnsuredSnapServices(s.o.ServiceManager(), true)
+	defer r()
+
+	// run, this will trigger wait for restart
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	// check the snapd task state
+	c.Check(chg.Status(), Equals, state.DoingStatus)
+	restarting, kind := st.Restarting()
+	c.Check(restarting, Equals, true)
+	c.Assert(kind, Equals, state.RestartDaemon)
+
+	// now we do want the ensure loop to run though
+	r = servicestate.MockEnsuredSnapServices(s.o.ServiceManager(), false)
+	defer r()
+
+	// mock a restart of snapd to progress with the change
+	state.MockRestarting(st, state.RestartUnset)
+
+	// let the change try to run its course
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, ErrorMatches, `state ensure errors: \[error trying to restart killed services, immediately rebooting: the snap service is having a bad day\]`)
+
+	// the change is still in doing status
+	c.Check(chg.Status(), Equals, state.DoingStatus)
+
+	// we do end up restarting now, since we tried to restart the service but
+	// failed and so to be safe as possible we reboot the system immediately
+	restarting, kind = st.Restarting()
+	c.Check(restarting, Equals, true)
+	c.Assert(kind, Equals, state.RestartSystemNow)
+
+	// the unit file was rewritten to use Wants= now
+	rewrittenUnitFile := fmt.Sprintf(unitTempl,
+		systemd.EscapeUnitNamePath(filepath.Join(dirs.SnapMountDir, "test-snap", "42.mount")),
+		dirs.GlobalRootDir,
+		"Wants",
+	)
+	c.Assert(filepath.Join(dirs.SnapServicesDir, "snap.test-snap.svc1.service"), testutil.FileEquals, rewrittenUnitFile)
+
+	// simulate a final restart to demonstrate that the change still finishes
+	// properly - note that this isn't a fully honest test, since in reality it
+	// should be done with a real overlord.RestartBehavior implemented like what
+	// daemon actually provides and here we are using nil, but for the purposes
+	// of this test it's enough to ensure that 1) a restart is requested and 2)
+	// the manager ensure loop doesn't fail after we restart since the unit
+	// files don't need to be rewritten
+	state.MockRestarting(st, state.RestartUnset)
+
+	// we want the service ensure loop to run again to show it doesn't break
+	// anything
+	r = servicestate.MockEnsuredSnapServices(s.o.ServiceManager(), false)
+	defer r()
+
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	defer st.Unlock()
+	c.Assert(err, IsNil)
+
+	// the change is now fully done
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+}
+
 func (s *mgrsSuite) testUC20RunUpdateManagedBootConfig(c *C, snapPath string, si *snap.SideInfo, bl bootloader.Bootloader, updated bool) {
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -5943,6 +6388,7 @@ func (s *mgrsSuite) testUC20RunUpdateManagedBootConfig(c *C, snapPath string, si
 	si2 := &snap.SideInfo{RealName: "core20", Revision: snap.R(1)}
 	snapstate.Set(st, "core20", &snapstate.SnapState{
 		SnapType: "base",
+
 		Active:   true,
 		Sequence: []*snap.SideInfo{si2},
 		Current:  si2.Revision,

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -591,6 +591,12 @@ func (o *Overlord) SnapManager() *snapstate.SnapManager {
 	return o.snapMgr
 }
 
+// ServiceManager returns the manager responsible for services
+// under the overlord.
+func (o *Overlord) ServiceManager() *servicestate.ServiceManager {
+	return o.serviceMgr
+}
+
 // AssertManager returns the assertion manager enforcing assertions
 // under the overlord.
 func (o *Overlord) AssertManager() *assertstate.AssertManager {

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -107,6 +107,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	c.Check(o.StateEngine(), NotNil)
 	c.Check(o.TaskRunner(), NotNil)
 	c.Check(o.SnapManager(), NotNil)
+	c.Check(o.ServiceManager(), NotNil)
 	c.Check(o.AssertManager(), NotNil)
 	c.Check(o.InterfaceManager(), NotNil)
 	c.Check(o.HookManager(), NotNil)

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -50,6 +50,7 @@ func (m *ServiceManager) Ensure() error {
 func delayedCrossMgrInit() {
 	// hook into conflict checks mechanisms
 	snapstate.AddAffectedSnapsByAttr("service-action", serviceControlAffectedSnaps)
+	snapstate.SnapServiceOptions = SnapServiceOptions
 }
 
 func serviceControlAffectedSnaps(t *state.Task) ([]string, error) {

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,14 +21,30 @@ package servicestate
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
 
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/timings"
+	"github.com/snapcore/snapd/wrappers"
 )
 
 // ServiceManager is responsible for starting and stopping snap services.
 type ServiceManager struct {
 	state *state.State
+
+	ensuredSnapSvcs bool
 }
 
 // Manager returns a new service manager.
@@ -42,8 +58,128 @@ func Manager(st *state.State, runner *state.TaskRunner) *ServiceManager {
 	return m
 }
 
+func MockEnsuredSnapServices(mgr *ServiceManager, ensured bool) (restore func()) {
+	osutil.MustBeTestBinary("ensured snap services can only be mocked from tests")
+	old := mgr.ensuredSnapSvcs
+	mgr.ensuredSnapSvcs = ensured
+	return func() {
+		mgr.ensuredSnapSvcs = old
+	}
+}
+
+func (m *ServiceManager) ensureSnapServicesUpdated() (err error) {
+	m.state.Lock()
+	defer m.state.Unlock()
+	if m.ensuredSnapSvcs {
+		return nil
+	}
+
+	// only run after we are seeded
+	var seeded bool
+	err = m.state.Get("seeded", &seeded)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	if !seeded {
+		return nil
+	}
+
+	// we are seeded, now we need to find all snap services and re-generate
+	// services as necessary
+
+	// ensure all snap services are updated
+	allStates, err := snapstate.All(m.state)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+
+	// if we have no snaps we can exit early
+	if len(allStates) == 0 {
+		m.ensuredSnapSvcs = true
+		return nil
+	}
+
+	snapsMap := map[*snap.Info]*wrappers.SnapServiceOptions{}
+
+	for _, snapSt := range allStates {
+		info, err := snapSt.CurrentInfo()
+		if err != nil {
+			return err
+		}
+
+		// don't use EnsureSnapServices with the snapd snap
+		if info.Type() == snap.TypeSnapd {
+			continue
+		}
+
+		snapSvcOpts, err := SnapServiceOptions(m.state, info.InstanceName())
+		if err != nil {
+			return err
+		}
+		snapsMap[info] = snapSvcOpts
+	}
+
+	// setup ensure options
+	ensureOpts := &wrappers.EnsureSnapServicesOptions{
+		Preseeding: snapdenv.Preseeding(),
+	}
+
+	// set RequireMountedSnapdSnap if we are on UC18+ only
+	deviceCtx, err := snapstate.DeviceCtx(m.state, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	if !deviceCtx.Classic() && deviceCtx.Model().Base() != "" {
+		ensureOpts.RequireMountedSnapdSnap = true
+	}
+
+	rewrittenServices := make(map[*snap.Info][]*snap.AppInfo)
+	serviceKillingMightHaveOccurred := false
+	observeChange := func(app *snap.AppInfo, unitType, name string, old, new string) {
+		if unitType == "service" {
+			rewrittenServices[app.Snap] = append(rewrittenServices[app.Snap], app)
+			if !serviceKillingMightHaveOccurred {
+				if strings.Contains(old, "\nRequires=usr-lib-snapd.mount\n") {
+					serviceKillingMightHaveOccurred = true
+				}
+			}
+		}
+	}
+
+	err = wrappers.EnsureSnapServices(snapsMap, ensureOpts, observeChange, progress.Null)
+	if err != nil {
+		return err
+	}
+
+	// if nothing was modified or we are not on UC18+, we are done
+	if len(rewrittenServices) == 0 || deviceCtx.Classic() || deviceCtx.Model().Base() == "" || !serviceKillingMightHaveOccurred {
+		m.ensuredSnapSvcs = true
+		return nil
+	}
+
+	// otherwise, we know now that we have rewritten some snap services, we need
+	// to handle the case of LP #1924805, and restart any services that were
+	// accidentally killed when we refreshed snapd
+	if err := restartServicesKilledInSnapdSnapRefresh(rewrittenServices); err != nil {
+		// we failed to restart services that were killed by a snapd refresh, so
+		// we need to immediately reboot in the hopes that this restores
+		// services to a functioning state
+
+		m.state.RequestRestart(state.RestartSystemNow)
+		return fmt.Errorf("error trying to restart killed services, immediately rebooting: %v", err)
+	}
+
+	m.ensuredSnapSvcs = true
+
+	return nil
+}
+
 // Ensure implements StateManager.Ensure.
 func (m *ServiceManager) Ensure() error {
+	if err := m.ensureSnapServicesUpdated(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -59,4 +195,151 @@ func serviceControlAffectedSnaps(t *state.Task) ([]string, error) {
 		return nil, fmt.Errorf("internal error: cannot obtain service action from task: %s", t.Summary())
 	}
 	return []string{serviceAction.SnapName}, nil
+}
+
+func getBootTime() (time.Time, error) {
+	cmd := exec.Command("uptime", "-s")
+	cmd.Env = append(cmd.Env, "TZ=UTC")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return time.Time{}, osutil.OutputErr(out, err)
+	}
+
+	// parse the output from the command as a time
+	t, err := time.ParseInLocation("2006-01-02 15:04:05", strings.TrimSpace(string(out)), time.UTC)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return t, nil
+}
+
+func restartServicesKilledInSnapdSnapRefresh(modified map[*snap.Info][]*snap.AppInfo) error {
+	// we decide on which services to restart by identifying (out of the set of
+	// services we just modified) services that were stopped after
+	// usr-lib-snapd.mount was written, but before usr-lib-snapd.mount was last
+	// stopped - this is the time window in which snapd (accidentally) killed
+	// all snap services using Requires=, see LP #1924805 for full details, so
+	// we need to undo that by restarting those snaps
+
+	st, err := os.Stat(filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit))
+	if err != nil {
+		return err
+	}
+
+	// always truncate all times to second precision, since that is the least
+	// precise time we have of all the times we consider, due to using systemctl
+	// for getting the InactiveEnterTimestamp for systemd units
+	// TODO: we should switch back to using D-Bus for this, where we get much
+	// more accurate times, down to the microsecond, which is the same precision
+	// we have for the modification time here, and thus we can more easily avoid
+	// the truncation issue, and we can ensure that we are minimizing the risk
+	// of inadvertently starting services that just so happened to have been
+	// stopped in the same second that we modified and usr-lib-snapd.mount.
+	lowerTimeBound := st.ModTime().Truncate(time.Second)
+
+	// if the time that the usr-lib-snapd.mount was modified is before the time
+	// that this device was booted up, then we can skip this since we know we
+	// that a refresh is not being performed
+	bootTime, err := getBootTime()
+	if err != nil {
+		// don't fail if we can't get the boot time, if we don't get it the
+		// below check will be always false (no time can be before zero time)
+		logger.Noticef("error getting boot time: %v", err)
+	}
+
+	if lowerTimeBound.Before(bootTime) {
+		return nil
+	}
+
+	// Get the InactiveEnterTimestamp property for the usr-lib-snapd.mount unit,
+	// this is the time that usr-lib-snapd.mount was transitioned from
+	// deactivating to inactive and was done being started. This is the correct
+	// upper bound for our window in which systemd killed snap services because
+	// systemd orders the transactions when we stop usr-lib-snapd.mount thusly:
+	//
+	// 1. Find all units which have Requires=usr-lib-snapd.mount (all snap
+	//    services which would have been refreshed during snapd 2.49.2)
+	// 2. Stop all such services found in 1.
+	// 3. Stop usr-lib-snapd.mount itself.
+	//
+	// Thus the time after all the services were killed is given by the time
+	// that systemd transitioned usr-lib-snapd.mount to inactive, which is given
+	// by InactiveEnterTimestamp.
+
+	// TODO: pass a real interactor here?
+	sysd := systemd.New(systemd.SystemMode, progress.Null)
+
+	upperTimeBound, err := sysd.InactiveEnterTimestamp(wrappers.SnapdToolingMountUnit)
+	if err != nil {
+		return err
+	}
+
+	if upperTimeBound.IsZero() {
+		// this means that the usr-lib-snapd.mount unit never exited during this
+		// boot, which means we are done in this ensure because the bug we care
+		// about (LP #1924805) here was never triggered
+		return nil
+	}
+
+	upperTimeBound = upperTimeBound.Truncate(time.Second)
+
+	// if the lower time bound is ever in the future past the upperTimeBound,
+	// then  just use the upperTimeBound as both limits, since we know that the
+	// upper bound and the time for each service being stopped are of the same
+	// precision
+	if lowerTimeBound.After(upperTimeBound) {
+		lowerTimeBound = upperTimeBound
+	}
+
+	candidateAppsToRestartBySnap := make(map[*snap.Info][]*snap.AppInfo)
+
+	for sn, apps := range modified {
+		for _, app := range apps {
+			// get the InactiveEnterTimestamp for the service
+			t, err := sysd.InactiveEnterTimestamp(app.ServiceName())
+			if err != nil {
+				return err
+			}
+
+			// always truncate to second precision
+			t = t.Truncate(time.Second)
+
+			// check if this unit entered the inactive state between the time
+			// range, but be careful about time precision here, we want an
+			// inclusive range i.e. [lower,upper] not (lower,upper) in case the
+			// time that systemd saves these events as is imprecise or slow and
+			// things get saved as having happened at the exact same time
+			if !t.Before(lowerTimeBound) && !t.After(upperTimeBound) {
+				candidateAppsToRestartBySnap[sn] = append(candidateAppsToRestartBySnap[sn], app)
+			}
+		}
+	}
+
+	// Second loop actually restarts the services per-snap by sorting them and
+	// removing disabled services. Note that we could have disabled services
+	// here because a service could have been running, but disabled when snapd
+	// was refreshed, hence it got killed, but we don't want to restart it,
+	// since it is disabled, and so that disabled running service is just SOL.
+	for sn, apps := range candidateAppsToRestartBySnap {
+		// TODO: should we try to start as many services as possible here before
+		// giving up given the severity of the bug?
+		disabledSvcs, err := wrappers.QueryDisabledServices(sn, progress.Null)
+		if err != nil {
+			return err
+		}
+
+		startupOrdered, err := snap.SortServices(apps)
+		if err != nil {
+			return err
+		}
+
+		// TODO: what to do about timings here?
+		nullPerfTimings := &timings.Timings{}
+		if err := wrappers.StartServices(startupOrdered, disabledSvcs, nil, progress.Null, nullPerfTimings); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -1,0 +1,1364 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package servicestate_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/wrappers"
+)
+
+type expectedSystemctl struct {
+	expArgs []string
+	output  string
+	err     error
+}
+
+type ensureSnapServiceSuite struct {
+	testutil.BaseTest
+
+	mgr *servicestate.ServiceManager
+
+	o     *overlord.Overlord
+	se    *overlord.StateEngine
+	state *state.State
+
+	restartRequests []state.RestartType
+	restartObserve  func()
+
+	uc18Model *asserts.Model
+	uc16Model *asserts.Model
+
+	testSnapState    *snapstate.SnapState
+	testSnapSideInfo *snap.SideInfo
+}
+
+var (
+	unitTempl = `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application test-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+%[3]sX-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run test-snap.svc1
+SyslogIdentifier=test-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/test-snap/42
+TimeoutStopSec=30
+Type=simple
+%[4]s
+[Install]
+WantedBy=multi-user.target
+`
+
+	testYaml = `name: test-snap
+version: v1
+apps:
+  svc1:
+    command: bin.sh
+    daemon: simple
+`
+
+	systemdTimeFormat = "Mon 2006-01-02 15:04:05 MST"
+)
+
+type unitOptions struct {
+	usrLibSnapdOrderVerb string
+	snapName             string
+	snapRev              string
+	oomScore             string
+}
+
+func mkUnitFile(c *C, opts *unitOptions) string {
+	if opts == nil {
+		opts = &unitOptions{}
+	}
+	usrLibSnapdSnippet := ""
+	if opts.usrLibSnapdOrderVerb != "" {
+		usrLibSnapdSnippet = fmt.Sprintf(`%[1]s=usr-lib-snapd.mount
+After=usr-lib-snapd.mount
+`,
+			opts.usrLibSnapdOrderVerb)
+	}
+	oomScoreAdjust := ""
+	if opts.oomScore != "" {
+		oomScoreAdjust = fmt.Sprintf(`OOMScoreAdjust=%s
+`,
+			opts.oomScore,
+		)
+	}
+
+	return fmt.Sprintf(unitTempl,
+		systemd.EscapeUnitNamePath(filepath.Join(dirs.SnapMountDir, opts.snapName, opts.snapRev+".mount")),
+		dirs.GlobalRootDir,
+		usrLibSnapdSnippet,
+		oomScoreAdjust,
+	)
+}
+
+var _ = Suite(&ensureSnapServiceSuite{})
+
+func (s *ensureSnapServiceSuite) mockSystemctlCalls(c *C, expCalls []expectedSystemctl) (restore func()) {
+	systemctlCalls := 0
+	r := systemd.MockSystemctl(func(args ...string) ([]byte, error) {
+		if systemctlCalls < len(expCalls) {
+			res := expCalls[systemctlCalls]
+			c.Assert(args, DeepEquals, res.expArgs)
+			systemctlCalls++
+			return []byte(res.output), res.err
+		}
+		c.Errorf("unexpected and unhandled systemctl command: %+v", args)
+		return nil, fmt.Errorf("broken test")
+	})
+
+	return func() {
+		r()
+		// double-check at the end of the test that we got as many systemctl calls
+		// as were mocked and that we didn't get less, then re-set it for the next
+		// test
+		c.Assert(systemctlCalls, Equals, len(expCalls))
+	}
+}
+
+func (s *ensureSnapServiceSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+
+	s.restartRequests = nil
+
+	s.restartObserve = nil
+	s.o = overlord.MockWithStateAndRestartHandler(nil, func(req state.RestartType) {
+		s.restartRequests = append(s.restartRequests, req)
+		if s.restartObserve != nil {
+			s.restartObserve()
+		}
+	})
+
+	s.state = s.o.State()
+	s.state.Lock()
+	s.state.VerifyReboot("boot-id-0")
+	s.state.Unlock()
+	s.se = s.o.StateEngine()
+
+	s.mgr = servicestate.Manager(s.state, s.o.TaskRunner())
+	s.o.AddManager(s.mgr)
+	s.o.AddManager(s.o.TaskRunner())
+
+	err := s.o.StartUp()
+	c.Assert(err, IsNil)
+
+	s.uc18Model = assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "canonical",
+		"series":       "16",
+		"brand-id":     "canonical",
+		"model":        "pc",
+		"gadget":       "pc",
+		"kernel":       "kernel",
+		"architecture": "amd64",
+		"base":         "core18",
+	}).(*asserts.Model)
+
+	s.uc16Model = assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "canonical",
+		"series":       "16",
+		"brand-id":     "canonical",
+		"model":        "pc",
+		"gadget":       "pc",
+		"kernel":       "kernel",
+		"architecture": "amd64",
+		// no base
+	}).(*asserts.Model)
+
+	// by default mock that we are uc18
+	s.AddCleanup(snapstatetest.MockDeviceModel(s.uc18Model))
+
+	// setup a test-snap with a service that can be easily injected into
+	// snapstate to be setup as needed
+	s.testSnapSideInfo = &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
+	s.testSnapState = &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{s.testSnapSideInfo},
+		Current:  snap.R(42),
+		Active:   true,
+		SnapType: "app",
+	}
+
+	// by default we are seeded
+	s.state.Lock()
+	s.state.Set("seeded", true)
+	s.state.Unlock()
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesNoSnapsDoesNothing(c *C) {
+	// don't mock any snaps in snapstate
+	err := s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we didn't write any services
+	c.Assert(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service"), testutil.FileAbsent)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesNotSeeded(c *C) {
+	s.state.Lock()
+	// we are not seeded but we do have a service which needs to be generated
+	s.state.Set("seeded", false)
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	s.state.Unlock()
+
+	err := s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we didn't write any services
+	c.Assert(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service"), testutil.FileAbsent)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleWritesServicesFilesUC16(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	// mock the device context as uc16
+	s.AddCleanup(snapstatetest.MockDeviceModel(s.uc16Model))
+
+	s.state.Unlock()
+
+	// don't add a usr-lib-snapd.mount unit since we won't read it, since we are
+	// on uc16
+
+	// we will only trigger a daemon-reload once after generating the service
+	// file
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+	})
+	defer r()
+
+	err := s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we wrote a service unit file
+	content := mkUnitFile(c, &unitOptions{
+		snapName: "test-snap",
+		snapRev:  "42",
+	})
+	c.Assert(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service"), testutil.FileEquals, content)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSkipsSnapdSnap(c *C) {
+	s.state.Lock()
+	// add an unexpected snapd snap which has services in it, but we
+	// specifically skip the snapd snap when considering services to add since
+	// it is special
+	sideInfo := &snap.SideInfo{RealName: "snapd", Revision: snap.R(42)}
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{sideInfo},
+		Current:  snap.R(42),
+		Active:   true,
+		SnapType: string(snap.TypeSnapd),
+	})
+	snaptest.MockSnapCurrent(c, `name: snapd
+type: snapd
+version: v1
+apps:
+  svc1:
+    command: bin.sh
+    daemon: simple
+`, sideInfo)
+
+	s.state.Unlock()
+
+	// don't need to mock usr-lib-snapd.mount since we will skip before that
+	// with snapd as the only snap
+
+	err := s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we didn't write a snap service file for snapd
+	c.Assert(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.snapd.svc1.service"), testutil.FileAbsent)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesUC18(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we wrote the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service"), testutil.FileEquals, content)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesVitalityRankUC18(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	// also set vitality-hint for this snap
+	t := config.NewTransaction(s.state)
+	err := t.Set("core", "resilience.vitality-hint", "bar,test-snap")
+	c.Assert(err, IsNil)
+	t.Commit()
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err = os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we wrote the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+		oomScore:             "-898",
+	})
+	c.Assert(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service"), testutil.FileEquals, content)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndDoesNotRestartIfBootTimeAfterModTime(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	logbuf, r := logger.MockLogger()
+	defer r()
+
+	// TZ's are important for the boot time specifically, we need to output the
+	// UTC time from the uptime script below, otherwise using local time here
+	// but not elsewhere leads to errors
+	future := now.Add(30 * time.Minute).UTC()
+
+	// we won't try to start services if the current boot time is ahead of the
+	// modification time
+
+	// mock the uptime command
+	cmd := testutil.MockCommand(c, "uptime", fmt.Sprintf(`
+#!/bin/sh
+
+if [ "$TZ" != "UTC" ]; then
+	echo "unexpected TZ env value: $TZ (expected UTC)"
+	exit 1
+fi
+
+if [ "$*" != "-s" ]; then
+	echo "arguments $* were unexpected"
+	exit 1
+fi
+
+echo %[1]q
+`, future.Format("2006-01-02 15:04:05")))
+	defer cmd.Restore()
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	r = s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we wrote the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	c.Assert(cmd.Calls(), DeepEquals, [][]string{
+		{"uptime", "-s"},
+	})
+
+	c.Assert(logbuf.String(), Equals, "")
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndIgnoresBootTimeErrors(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	// if the boot time can't be determined, we log a message and continue on
+	// considering whether or not the service should be restarted based on when
+	// it exited
+	cmd := testutil.MockCommand(c, "uptime", `
+#!/bin/sh
+echo "boot time broken"
+exit 1
+`)
+	defer cmd.Restore()
+
+	logbuf, r := logger.MockLogger()
+	defer r()
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	r = s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount has never been stopped though so we skip out
+			// anyways
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  "InactiveEnterTimestamp=",
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we wrote the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	c.Assert(cmd.Calls(), DeepEquals, [][]string{
+		{"uptime", "-s"},
+	})
+
+	c.Assert(logbuf.String(), Matches, ".*error getting boot time: boot time broken\n")
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRestarts(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	slightFuture := now.Add(30 * time.Minute).Format(systemdTimeFormat)
+	theFuture := now.Add(1 * time.Hour).Format(systemdTimeFormat)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount was stopped "far in the future"
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", theFuture),
+		},
+		{
+			// but the snap.test-snap.svc1 was stopped only slightly in the
+			// future (hence before the usr-lib-snapd.mount unit was stopped and
+			// after usr-lib-snapd.mount file was modified)
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", slightFuture),
+		},
+		{
+			expArgs: []string{"is-enabled", "snap.test-snap.svc1.service"},
+			output:  "enabled",
+		},
+		{
+			expArgs: []string{"start", "snap.test-snap.svc1.service"},
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we wrote the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+type systemctlDisabledServicError struct{}
+
+func (s systemctlDisabledServicError) Msg() []byte   { return []byte("disabled") }
+func (s systemctlDisabledServicError) ExitCode() int { return 1 }
+func (s systemctlDisabledServicError) Error() string { return "disabled service" }
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesButDoesNotRestartDisabledServices(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	slightFuture := now.Add(30 * time.Minute).Format(systemdTimeFormat)
+	theFuture := now.Add(1 * time.Hour).Format(systemdTimeFormat)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount was stopped "far in the future"
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", theFuture),
+		},
+		{
+			// but the snap.test-snap.svc1 was stopped only slightly in the
+			// future (hence before the usr-lib-snapd.mount unit was stopped and
+			// after usr-lib-snapd.mount file was modified)
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", slightFuture),
+		},
+		// the service is disabled
+		{
+			expArgs: []string{"is-enabled", "snap.test-snap.svc1.service"},
+			output:  "disabled",
+			err:     systemctlDisabledServicError{},
+		},
+		// then we don't restart the service even though it was killed
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we wrote the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKilledBeforeSnapdRefresh(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	theFuture := now.Add(1 * time.Hour).Format(systemdTimeFormat)
+	thePast := now.Add(-30 * time.Minute).Format(systemdTimeFormat)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount was stopped "far in the future"
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", theFuture),
+		},
+		{
+			// but the snap.test-snap.svc1 was stopped before that, so it isn't
+			// restarted
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", thePast),
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we wrote the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKilledAfterSnapdRefresh(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	theFuture := now.Add(1 * time.Hour).Format(systemdTimeFormat)
+	thePast := now.Add(-30 * time.Minute).Format(systemdTimeFormat)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount was stopped in the past
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", thePast),
+		},
+		{
+			// but the snap.test-snap.svc1 was stopped after that, so it isn't
+			// restarted
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", theFuture),
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// we wrote the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFilesAndRestartsTimePrecisionSilly(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	// this test is about the specific scenario we have now when using systemctl
+	// show --property where the time precision of the InactiveEnterTimestamp's
+	// is much lower than that of the modification file time, so we need to
+	// set the inactive enter time for both the usr-lib-snapd.mount and the snap
+	// service to be the same time, which is actually _in the past_ compared to
+	// the file modification time
+
+	// truncate the current time and add 500 milliseconds
+	t0 := time.Now().Truncate(time.Second).Add(500 * time.Millisecond)
+	err = os.Chtimes(usrLibSnapdMountFile, t0, t0)
+	c.Assert(err, IsNil)
+
+	// drop the milliseconds
+	t1 := t0.Truncate(time.Second)
+	t1Str := t1.Format(systemdTimeFormat)
+
+	// double check our math for the times is correct
+	c.Assert(t1.Before(t0), Equals, true)
+	c.Assert(t0.After(t1), Equals, true)
+	c.Assert(t1.Equal(t0), Equals, false)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount was stopped "far in the future"
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", t1Str),
+		},
+		{
+			// but the snap.test-snap.svc1 was stopped only slightly in the
+			// future
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", t1Str),
+		},
+		{
+			expArgs: []string{"is-enabled", "snap.test-snap.svc1.service"},
+			output:  "enabled",
+		},
+		{
+			expArgs: []string{"start", "snap.test-snap.svc1.service"},
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// the file was rewritten to use Wants instead now
+	wantsContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service"), testutil.FileEquals, wantsContent)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFilesAndRestartsTimePrecisionMoreSilly(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	// this test is like TestEnsureSnapServicesSimpleRewritesServicesFilesAndRestartsTimePrecisionSilly,
+	// but more extreme, in that we don't have precision problems of less than a
+	// second, we have some more critical error where the lower timestamp range
+	// is somehow way in the future and we want our system to act rationally and
+	// pick the upper time bound as the lower time bound when the initially
+	// identified lower time bound is nonsensical
+
+	// truncate the current time and add 500 minutes
+	now := time.Now().Truncate(time.Second)
+	t0 := now.Add(500 * time.Minute)
+	err = os.Chtimes(usrLibSnapdMountFile, t0, t0)
+	c.Assert(err, IsNil)
+
+	t1 := now
+	t1Str := t1.Format(systemdTimeFormat)
+
+	// double check our math for the times is correct
+	c.Assert(t1.Before(t0), Equals, true)
+	c.Assert(t0.After(t1), Equals, true)
+	c.Assert(t1.Equal(t0), Equals, false)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount was stopped "far in the future"
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", t1Str),
+		},
+		{
+			// but the snap.test-snap.svc1 was stopped only slightly in the
+			// future
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", t1Str),
+		},
+		{
+			expArgs: []string{"is-enabled", "snap.test-snap.svc1.service"},
+			output:  "enabled",
+		},
+		{
+			expArgs: []string{"start", "snap.test-snap.svc1.service"},
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// the file was rewritten to use Wants instead now
+	wantsContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service"), testutil.FileEquals, wantsContent)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFilesAndRestartsUC18(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	slightFuture := now.Add(30 * time.Minute).Format(systemdTimeFormat)
+	theFuture := now.Add(1 * time.Hour).Format(systemdTimeFormat)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount was stopped "far in the future"
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", theFuture),
+		},
+		{
+			// but the snap.test-snap.svc1 was stopped only slightly in the
+			// future
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", slightFuture),
+		},
+		{
+			expArgs: []string{"is-enabled", "snap.test-snap.svc1.service"},
+			output:  "enabled",
+		},
+		{
+			expArgs: []string{"start", "snap.test-snap.svc1.service"},
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// the file was rewritten to use Wants instead now
+	wantsContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service"), testutil.FileEquals, wantsContent)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesNoChangeServiceFileDoesNothingUC18(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Wants
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(content), 0644)
+	c.Assert(err, IsNil)
+
+	// we don't use systemctl at all because we didn't change anything
+	// s.systemctlReturns = []expectedSystemctl{}
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	// the file was not modified
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesWhenUsrLibSnapdWasNeverInactive(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	os.Chtimes(usrLibSnapdMountFile, now, now)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount has never been stopped this boot, thus has
+			// always been active
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  "InactiveEnterTimestamp=",
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	// we did not request a restart
+	c.Assert(s.restartRequests, HasLen, 0)
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRestartsButThenFallsbackToReboot(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	slightFuture := now.Add(30 * time.Minute).Format(systemdTimeFormat)
+	theFuture := now.Add(1 * time.Hour).Format(systemdTimeFormat)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount was stopped "far in the future"
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", theFuture),
+		},
+		{
+			// but the snap.test-snap.svc1 was stopped only slightly in the
+			// future (hence before the usr-lib-snapd.mount unit was stopped and
+			// after usr-lib-snapd.mount file was modified)
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", slightFuture),
+		},
+		{
+			expArgs: []string{"is-enabled", "snap.test-snap.svc1.service"},
+			output:  "enabled",
+		},
+		{
+			expArgs: []string{"start", "snap.test-snap.svc1.service"},
+			err:     fmt.Errorf("this service is having a bad day"),
+		},
+		{
+			expArgs: []string{"stop", "snap.test-snap.svc1.service"},
+			err:     fmt.Errorf("this service is still having a bad day"),
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, ErrorMatches, "error trying to restart killed services, immediately rebooting: this service is having a bad day")
+
+	// we did write the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	// we requested a restart
+	c.Assert(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
+}
+
+func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndTriesRestartButFailsButThenFallsbackToReboot(c *C) {
+	s.state.Lock()
+	// there is a snap in snap state that needs a service generated for it
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	s.state.Unlock()
+
+	// add the usr-lib-snapd.mount unit
+	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
+	c.Assert(err, IsNil)
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+	err = os.Chtimes(usrLibSnapdMountFile, now, now)
+	c.Assert(err, IsNil)
+
+	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
+
+	// add the initial state of the service file using Requires
+	requiresContent := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Requires",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	c.Assert(err, IsNil)
+
+	slightFuture := now.Add(30 * time.Minute).Format(systemdTimeFormat)
+	theFuture := now.Add(1 * time.Hour).Format(systemdTimeFormat)
+
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// usr-lib-snapd.mount was stopped "far in the future"
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "usr-lib-snapd.mount"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", theFuture),
+		},
+		{
+			// but the snap.test-snap.svc1 was stopped only slightly in the
+			// future (hence before the usr-lib-snapd.mount unit was stopped and
+			// after usr-lib-snapd.mount file was modified)
+			expArgs: []string{"show", "--property", "InactiveEnterTimestamp", "snap.test-snap.svc1.service"},
+			output:  fmt.Sprintf("InactiveEnterTimestamp=%s", slightFuture),
+		},
+		{
+			expArgs: []string{"is-enabled", "snap.test-snap.svc1.service"},
+			err:     fmt.Errorf("systemd is having a bad day"),
+		},
+	})
+	defer r()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, ErrorMatches, "error trying to restart killed services, immediately rebooting: systemd is having a bad day")
+
+	// we did write the service unit file
+	content := mkUnitFile(c, &unitOptions{
+		usrLibSnapdOrderVerb: "Wants",
+		snapName:             "test-snap",
+		snapRev:              "42",
+	})
+	c.Assert(svcFile, testutil.FileEquals, content)
+
+	// we requested a restart
+	c.Assert(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
+}

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -40,9 +40,8 @@ type LinkContext struct {
 	// installed
 	FirstInstall bool
 
-	// VitalityRank is used to hint how much the services should be
-	// protected from the OOM killer
-	VitalityRank int
+	// ServiceOptions is used to configure services.
+	ServiceOptions *wrappers.SnapServiceOptions
 
 	// RunInhibitHint is used only in Unlink snap, and can be used to
 	// establish run inhibition lock for refresh operations.
@@ -192,12 +191,17 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapBinaries)
 
+	vitalityRank := 0
+	if linkCtx.ServiceOptions != nil {
+		vitalityRank = linkCtx.ServiceOptions.VitalityRank
+	}
 	// add the daemons from the snap.yaml
 	opts := &wrappers.AddSnapServicesOptions{
+		VitalityRank:            vitalityRank,
 		Preseeding:              b.preseed,
-		VitalityRank:            linkCtx.VitalityRank,
 		RequireMountedSnapdSnap: linkCtx.RequireMountedSnapdSnap,
 	}
+	// TODO: switch to EnsureSnapServices
 	if err = wrappers.AddSnapServices(s, opts, progress.Null); err != nil {
 		return err
 	}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -760,7 +760,7 @@ apps:
 	_, err := s.be.LinkSnap(info, mockDev, linkCtxWithTooling, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(filepath.Join(dirs.SnapServicesDir, "snap.hello.svc.service"), testutil.FileContains,
-		`Requires=usr-lib-snapd.mount
+		`Wants=usr-lib-snapd.mount
 After=usr-lib-snapd.mount`)
 
 	// remove it now

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -889,11 +889,16 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev boot.Device, linkCtx b
 		<-f.linkSnapWaitCh
 	}
 
+	vitalityRank := 0
+	if linkCtx.ServiceOptions != nil {
+		vitalityRank = linkCtx.ServiceOptions.VitalityRank
+	}
+
 	op := fakeOp{
 		op:   "link-snap",
 		path: info.MountDir(),
 
-		vitalityRank:        linkCtx.VitalityRank,
+		vitalityRank:        vitalityRank,
 		requireSnapdTooling: linkCtx.RequireMountedSnapdSnap,
 	}
 

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -93,6 +94,12 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 		return nil, nil
 	}
 	bs.restore = snapstatetest.MockDeviceModel(DefaultModel())
+
+	oldSnapServiceOptions := snapstate.SnapServiceOptions
+	snapstate.SnapServiceOptions = servicestate.SnapServiceOptions
+	bs.AddCleanup(func() {
+		snapstate.SnapServiceOptions = oldSnapServiceOptions
+	})
 }
 
 func (bs *bootedSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -50,7 +50,13 @@ import (
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timings"
+	"github.com/snapcore/snapd/wrappers"
 )
+
+// SnapServiceOptions is a hook set by servicestate.
+var SnapServiceOptions = func(st *state.State, instanceName string) (opts *wrappers.SnapServiceOptions, err error) {
+	panic("internal error: snapstate.SanpServiceOptions is unset")
+}
 
 var SecurityProfilesRemoveLate = func(snapName string, rev snap.Revision, typ snap.Type) error {
 	panic("internal error: snapstate.SecurityProfilesRemoveLate is unset")
@@ -891,13 +897,13 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	snapst.Active = true
-	vitalityRank, err := vitalityRank(st, snapsup.InstanceName())
+	opts, err := SnapServiceOptions(st, snapsup.InstanceName())
 	if err != nil {
 		return err
 	}
 	linkCtx := backend.LinkContext{
-		FirstInstall: false,
-		VitalityRank: vitalityRank,
+		FirstInstall:   false,
+		ServiceOptions: opts,
 	}
 	reboot, err := m.backend.LinkSnap(oldInfo, deviceCtx, linkCtx, perfTimings)
 	if err != nil {
@@ -1082,22 +1088,6 @@ func missingDisabledServices(svcs []string, info *snap.Info) ([]string, []string
 	return foundSvcs, missingSvcs, nil
 }
 
-func vitalityRank(st *state.State, instanceName string) (rank int, err error) {
-	tr := config.NewTransaction(st)
-
-	var vitalityStr string
-	err = tr.GetMaybe("core", "resilience.vitality-hint", &vitalityStr)
-	if err != nil {
-		return 0, err
-	}
-	for i, s := range strings.Split(vitalityStr, ",") {
-		if s == instanceName {
-			return i + 1, nil
-		}
-	}
-	return 0, nil
-}
-
 // LinkSnapParticipant is an interface for interacting with snap link/unlink
 // operations.
 //
@@ -1240,14 +1230,14 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		return err
 	}
 
-	vitalityRank, err := vitalityRank(st, snapsup.InstanceName())
+	opts, err := SnapServiceOptions(st, snapsup.InstanceName())
 	if err != nil {
 		return err
 	}
 	firstInstall := oldCurrent.Unset()
 	linkCtx := backend.LinkContext{
-		FirstInstall: firstInstall,
-		VitalityRank: vitalityRank,
+		FirstInstall:   firstInstall,
+		ServiceOptions: opts,
 	}
 	// on UC18+, snap tooling comes from the snapd snap so we need generated
 	// mount units to depend on the snapd snap mount units
@@ -2130,13 +2120,13 @@ func (m *SnapManager) undoUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.Active = true
 	Set(st, snapsup.InstanceName(), snapst)
 
-	vitalityRank, err := vitalityRank(st, snapsup.InstanceName())
+	opts, err := SnapServiceOptions(st, snapsup.InstanceName())
 	if err != nil {
 		return err
 	}
 	linkCtx := backend.LinkContext{
-		FirstInstall: false,
-		VitalityRank: vitalityRank,
+		FirstInstall:   false,
+		ServiceOptions: opts,
 	}
 	reboot, err := m.backend.LinkSnap(info, deviceCtx, linkCtx, perfTimings)
 	if err != nil {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -73,6 +74,12 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 	s.setup(c, s.stateBackend)
 
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
+
+	oldSnapServiceOptions := snapstate.SnapServiceOptions
+	snapstate.SnapServiceOptions = servicestate.SnapServiceOptions
+	s.AddCleanup(func() {
+		snapstate.SnapServiceOptions = oldSnapServiceOptions
+	})
 }
 
 func checkHasCookieForSnap(c *C, st *state.State, instanceName string) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -121,10 +122,12 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	oldSetupPreRefreshHook := snapstate.SetupPreRefreshHook
 	oldSetupPostRefreshHook := snapstate.SetupPostRefreshHook
 	oldSetupRemoveHook := snapstate.SetupRemoveHook
+	oldSnapServiceOptions := snapstate.SnapServiceOptions
 	snapstate.SetupInstallHook = hookstate.SetupInstallHook
 	snapstate.SetupPreRefreshHook = hookstate.SetupPreRefreshHook
 	snapstate.SetupPostRefreshHook = hookstate.SetupPostRefreshHook
 	snapstate.SetupRemoveHook = hookstate.SetupRemoveHook
+	snapstate.SnapServiceOptions = servicestate.SnapServiceOptions
 
 	var err error
 	s.snapmgr, err = snapstate.Manager(s.state, s.o.TaskRunner())
@@ -155,6 +158,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 		snapstate.SetupPreRefreshHook = oldSetupPreRefreshHook
 		snapstate.SetupPostRefreshHook = oldSetupPostRefreshHook
 		snapstate.SetupRemoveHook = oldSetupRemoveHook
+		snapstate.SnapServiceOptions = oldSnapServiceOptions
 
 		dirs.SetRootDir("/")
 	})

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -90,6 +90,10 @@ func (s *emulation) Status(units ...string) ([]*UnitStatus, error) {
 	return nil, errNotImplemented
 }
 
+func (s *emulation) InactiveEnterTimestamp(unit string) (time.Time, error) {
+	return time.Time{}, errNotImplemented
+}
+
 func (s *emulation) IsEnabled(service string) (bool, error) {
 	return false, errNotImplemented
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -95,6 +95,8 @@ func (m *extMutex) Taken(errMsg string) {
 
 // systemctlCmd calls systemctl with the given args, returning its standard output (and wrapped error)
 var systemctlCmd = func(args ...string) ([]byte, error) {
+	// TODO: including stderr here breaks many things when systemd is in debug
+	// output mode, see LP #1885597
 	bs, err := exec.Command("systemctl", args...).CombinedOutput()
 	if err != nil {
 		exitCode, _ := osutil.ExitCode(err)
@@ -231,6 +233,17 @@ type Systemd interface {
 	// returned in the same order as unit names passed in
 	// argument.
 	Status(units ...string) ([]*UnitStatus, error)
+	// InactiveEnterTimestamp returns the time that the given unit entered the
+	// inactive state as defined by the systemd docs. Specifically, this time is
+	// the most recent time in which the unit transitioned from deactivating
+	// ("Stopping") to dead ("Stopped"). It may be the zero time if this has
+	// never happened during the current boot, since this property is only
+	// tracked during the current boot. It specifically does not return a time
+	// that is monotonic, so the time returned here may be subject to bugs if
+	// there was a discontinuous time jump on the system before or during the
+	// unit's transition to inactive.
+	// TODO: incorporate this result into Status instead?
+	InactiveEnterTimestamp(unit string) (time.Time, error)
 	// IsEnabled checks whether the given service is enabled.
 	IsEnabled(service string) (bool, error)
 	// IsActive checks whether the given service is Active
@@ -623,6 +636,35 @@ func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
 	}
 
 	return sts, nil
+}
+
+func (s *systemd) InactiveEnterTimestamp(unit string) (time.Time, error) {
+	// XXX: ignore stderr of systemctl command to avoid further infractions
+	//      around LP #1885597
+	out, err := s.systemctl("show", "--property", "InactiveEnterTimestamp", unit)
+	if err != nil {
+		return time.Time{}, osutil.OutputErr(out, err)
+	}
+	// the time returned by systemctl here will be formatted like so:
+	// InactiveEnterTimestamp=Fri 2021-04-16 15:32:21 UTC
+	// so we have to parse the time with a matching Go time format
+	splitVal := strings.SplitN(strings.TrimSpace(string(out)), "=", 2)
+	if len(splitVal) != 2 {
+		// then we don't have an equals sign in the output, so systemctl must be
+		// broken
+		return time.Time{}, fmt.Errorf("internal error: systemctl output (%s) is malformed", string(out))
+	}
+
+	if splitVal[1] == "" {
+		return time.Time{}, nil
+	}
+
+	// finally parse the time string
+	inactiveEnterTime, err := time.Parse("Mon 2006-01-02 15:04:05 MST", splitVal[1])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("internal error: systemctl time output (%s) is malformed", splitVal[1])
+	}
+	return inactiveEnterTime, nil
 }
 
 func (s *systemd) IsEnabled(serviceName string) (bool, error) {

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1389,3 +1389,75 @@ func (s *SystemdTestSuite) TestUmountErr(c *C) {
 		{"systemd-mount", "--umount", "bar"},
 	})
 }
+
+func (s *SystemdTestSuite) TestInactiveEnterTimestampZero(c *C) {
+	s.outs = [][]byte{
+		[]byte(`InactiveEnterTimestamp=`),
+	}
+	sysd := New(SystemMode, s.rep)
+	stamp, err := sysd.InactiveEnterTimestamp("bar.service")
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{
+		{"show", "--property", "InactiveEnterTimestamp", "bar.service"},
+	})
+	c.Check(stamp.IsZero(), Equals, true)
+}
+
+func (s *SystemdTestSuite) TestInactiveEnterTimestampValidWhitespace(c *C) {
+	s.outs = [][]byte{
+		[]byte(`InactiveEnterTimestamp=Fri 2021-04-16 15:32:21 UTC
+`),
+	}
+
+	stamp, err := New(SystemMode, s.rep).InactiveEnterTimestamp("bar.service")
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{
+		{"show", "--property", "InactiveEnterTimestamp", "bar.service"},
+	})
+	c.Check(stamp.Equal(time.Date(2021, time.April, 16, 15, 32, 21, 0, time.UTC)), Equals, true)
+}
+
+func (s *SystemdTestSuite) TestInactiveEnterTimestampValid(c *C) {
+	s.outs = [][]byte{
+		[]byte(`InactiveEnterTimestamp=Fri 2021-04-16 15:32:21 UTC`),
+	}
+
+	stamp, err := New(SystemMode, s.rep).InactiveEnterTimestamp("bar.service")
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{
+		{"show", "--property", "InactiveEnterTimestamp", "bar.service"},
+	})
+	c.Check(stamp.Equal(time.Date(2021, time.April, 16, 15, 32, 21, 0, time.UTC)), Equals, true)
+}
+
+func (s *SystemdTestSuite) TestInactiveEnterTimestampFailure(c *C) {
+	s.outs = [][]byte{
+		[]byte(`mocked failure`),
+	}
+	s.errors = []error{
+		fmt.Errorf("mocked failure"),
+	}
+	stamp, err := New(SystemMode, s.rep).InactiveEnterTimestamp("bar.service")
+	c.Assert(err, ErrorMatches, "mocked failure")
+	c.Check(stamp.IsZero(), Equals, true)
+}
+
+func (s *SystemdTestSuite) TestInactiveEnterTimestampMalformed(c *C) {
+	s.outs = [][]byte{
+		[]byte(`InactiveEnterTimestamp`),
+		[]byte(``),
+		[]byte(`some random garbage
+with newlines`),
+		[]byte(`InactiveEnterTimestamp=0`), // 0 is valid for InactiveEnterTimestampMonotonic
+	}
+	sysd := New(SystemMode, s.rep)
+	for i := 0; i < len(s.outs); i++ {
+		s.argses = nil
+		stamp, err := sysd.InactiveEnterTimestamp("bar.service")
+		c.Assert(err, ErrorMatches, `(?s)internal error: systemctl (time )?output \(.*\) is malformed`)
+		c.Check(s.argses, DeepEquals, [][]string{
+			{"show", "--property", "InactiveEnterTimestamp", "bar.service"},
+		})
+		c.Check(stamp.IsZero(), Equals, true)
+	}
+}

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -44,7 +44,7 @@ var snapdServiceStopTimeout = time.Duration(timeout.DefaultTimeout)
 var execStartRe = regexp.MustCompile(`(?m)^ExecStart=(/usr/bin/snap\s+.*|/usr/lib/snapd/.*)$`)
 
 // snapdToolingMountUnit is the name of the mount unit that makes the
-const snapdToolingMountUnit = "usr-lib-snapd.mount"
+const SnapdToolingMountUnit = "usr-lib-snapd.mount"
 
 func snapdSkipStart(content []byte) bool {
 	return bytes.Contains(content, []byte("X-Snapd-Snap: do-not-start"))
@@ -65,8 +65,12 @@ func snapdUnitSkipStart(unitPath string) (skip bool, err error) {
 }
 
 func writeSnapdToolingMountUnit(sysd systemd.Systemd, prefix string) error {
+
+	// TODO: the following comment is wrong, we don't need RequiredBy=snapd here?
+
 	// Not using AddMountUnitFile() because we need
 	// "RequiredBy=snapd.service"
+
 	content := []byte(fmt.Sprintf(`[Unit]
 Description=Make the snapd snap tooling available for the system
 Before=snapd.service
@@ -80,7 +84,7 @@ Options=bind
 [Install]
 WantedBy=snapd.service
 `, prefix))
-	fullPath := filepath.Join(dirs.SnapServicesDir, snapdToolingMountUnit)
+	fullPath := filepath.Join(dirs.SnapServicesDir, SnapdToolingMountUnit)
 
 	err := osutil.EnsureFileState(fullPath,
 		&osutil.MemoryFileState{
@@ -97,11 +101,14 @@ WantedBy=snapd.service
 	if err := sysd.DaemonReload(); err != nil {
 		return err
 	}
-	if err := sysd.Enable(snapdToolingMountUnit); err != nil {
+	if err := sysd.Enable(SnapdToolingMountUnit); err != nil {
 		return err
 	}
 
-	if err := sysd.Restart(snapdToolingMountUnit, 5*time.Second); err != nil {
+	// meh this is killing snap services that use Requires=<this-unit> because
+	// it doesn't use verbatim systemctl restart, it instead does it with
+	// a systemctl stop and then a systemctl start, which triggers LP #1924805
+	if err := sysd.Restart(SnapdToolingMountUnit, 5*time.Second); err != nil {
 		return err
 	}
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2016 Canonical Ltd
+ * Copyright (C) 2014-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -379,7 +379,7 @@ func userDaemonReload() error {
 	return cli.ServicesDaemonReload(ctx)
 }
 
-func tryFileUpdate(path string, desiredContent []byte) (old *osutil.FileState, modified bool, err error) {
+func tryFileUpdate(path string, desiredContent []byte) (old *osutil.MemoryFileState, modified bool, err error) {
 	newFileState := osutil.MemoryFileState{
 		Content: desiredContent,
 		Mode:    os.FileMode(0644),
@@ -403,8 +403,7 @@ func tryFileUpdate(path string, desiredContent []byte) (old *osutil.FileState, m
 		newFileState.Mode = st.Mode()
 
 		// save the old state of the file
-		st := osutil.FileState(&oldFileState)
-		old = &st
+		old = &oldFileState
 	}
 
 	if mkdirErr := os.MkdirAll(filepath.Dir(path), 0755); mkdirErr != nil {
@@ -430,6 +429,11 @@ type SnapServiceOptions struct {
 	VitalityRank int
 }
 
+// ObserveChangeCallback can be invoked by EnsureSnapServices to observe
+// the previous content of a unit and the new on a change.
+// unitType can be "service", "socket", "timer". name is empty for a timer.
+type ObserveChangeCallback func(app *snap.AppInfo, unitType string, name, old, new string)
+
 // EnsureSnapServicesOptions is the set of options applying to the
 // EnsureSnapServices operation. It does not include per-snap specific options
 // such as VitalityRank or RequireMountedSnapdSnap from AddSnapServiceOptions,
@@ -453,16 +457,16 @@ type EnsureSnapServicesOptions struct {
 // There are two sets of options; there are global options which apply to the
 // entire transaction and to every snap service that is ensured, and options
 // which are per-snap service and specified in the map argument.
-// The return value is a map of the snap's Info the a list of App's that were
-// updated or modified. Apps in a snap that did not have their service
-// definitions change are not included in the map's list value.
 // If any errors are encountered trying to update systemd units, then all
 // changes performed up to that point are rolled back, meaning newly written
 // units are deleted and modified units are attempted to be restored to their
-// previous state. In this case the modified return value is nil.
-func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSnapServicesOptions, inter interacter) (modified map[*snap.Info][]*snap.AppInfo, err error) {
-	modified = make(map[*snap.Info][]*snap.AppInfo)
-
+// previous state.
+// To observe which units were added or modified a
+// ObserveChangeCallback calllback can be provided. The callback is
+// invoked while processing the changes. Because of that it should not
+// produce immediate side-effects, as the changes are in effect only
+// if the function did not return an error.
+func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSnapServicesOptions, observeChange ObserveChangeCallback, inter interacter) (err error) {
 	// note, sysd is not used when preseeding
 	sysd := systemd.New(systemd.SystemMode, inter)
 
@@ -483,7 +487,7 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 	// updated and some may have been rolled back, higher level tasks/changes
 	// should have do/undo handlers to properly handle the case where this
 	// function is interrupted midway
-	modifiedUnitsPreviousState := make(map[string]*osutil.FileState)
+	modifiedUnitsPreviousState := make(map[string]*osutil.MemoryFileState)
 	var modifiedSystem, modifiedUser bool
 
 	defer func() {
@@ -499,7 +503,7 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 				}
 			} else {
 				// rollback the file to the previous state
-				if e := osutil.EnsureFileState(file, *state); e != nil {
+				if e := osutil.EnsureFileState(file, state); e != nil {
 					inter.Notify(fmt.Sprintf("while trying to rollback %s due to previous failure: %v", file, e))
 				}
 			}
@@ -516,15 +520,21 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 		}
 	}()
 
-	handleFileModification := func(s *snap.Info, app *snap.AppInfo, path string, content []byte) error {
+	handleFileModification := func(app *snap.AppInfo, unitType string, name, path string, content []byte) error {
 		old, modifiedFile, err := tryFileUpdate(path, content)
 		if err != nil {
 			return err
 		}
 
 		if modifiedFile {
+			if observeChange != nil {
+				var oldContent []byte
+				if old != nil {
+					oldContent = old.Content
+				}
+				observeChange(app, unitType, name, string(oldContent), string(content))
+			}
 			modifiedUnitsPreviousState[path] = old
-			modified[s] = append(modified[s], app)
 
 			// also mark that we need to reload either the system or
 			// user instance of systemd
@@ -541,7 +551,7 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 
 	for s, snapSvcOpts := range snaps {
 		if s.Type() == snap.TypeSnapd {
-			return nil, fmt.Errorf("internal error: adding explicit services for snapd snap is unexpected")
+			return fmt.Errorf("internal error: adding explicit services for snapd snap is unexpected")
 		}
 
 		// always use RequireMountedSnapdSnap options from the global options
@@ -566,32 +576,33 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 			path := app.ServiceFile()
 			content, err := generateSnapServiceFile(app, genServiceOpts)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
-			if err := handleFileModification(s, app, path, content); err != nil {
-				return nil, err
+			if err := handleFileModification(app, "service", app.Name, path, content); err != nil {
+				return err
 			}
 
 			// Generate systemd .socket files if needed
 			socketFiles, err := generateSnapSocketFiles(app)
 			if err != nil {
-				return nil, err
+				return err
 			}
-			for path, content := range socketFiles {
-				if err := handleFileModification(s, app, path, content); err != nil {
-					return nil, err
+			for name, content := range socketFiles {
+				path := app.Sockets[name].File()
+				if err := handleFileModification(app, "socket", name, path, content); err != nil {
+					return err
 				}
 			}
 
 			if app.Timer != nil {
 				content, err := generateSnapTimerFile(app)
 				if err != nil {
-					return nil, err
+					return err
 				}
 				path := app.Timer.File()
-				if err := handleFileModification(s, app, path, content); err != nil {
-					return nil, err
+				if err := handleFileModification(app, "timer", "", path, content); err != nil {
+					return err
 				}
 			}
 		}
@@ -600,17 +611,17 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 	if !preseeding {
 		if modifiedSystem {
 			if err = sysd.DaemonReload(); err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if modifiedUser {
 			if err = userDaemonReload(); err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
 
-	return modified, nil
+	return nil
 }
 
 // AddSnapServicesOptions is a struct for controlling the generated service
@@ -649,8 +660,7 @@ func AddSnapServices(s *snap.Info, opts *AddSnapServicesOptions, inter interacte
 		ensureOpts.RequireMountedSnapdSnap = opts.RequireMountedSnapdSnap
 	}
 
-	_, err := EnsureSnapServices(m, ensureOpts, inter)
-	return err
+	return EnsureSnapServices(m, ensureOpts, nil, inter)
 }
 
 // StopServicesFlags carries extra flags for StopServices.
@@ -1134,8 +1144,8 @@ func generateSnapSocketFiles(app *snap.AppInfo) (map[string][]byte, error) {
 	}
 
 	socketFiles := make(map[string][]byte)
-	for name, socket := range app.Sockets {
-		socketFiles[socket.File()] = genServiceSocketFile(app, name)
+	for name := range app.Sockets {
+		socketFiles[name] = genServiceSocketFile(app, name)
 	}
 	return socketFiles, nil
 }

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -892,7 +892,7 @@ After={{ stringsJoin .After " " }}
 Before={{ stringsJoin .Before " "}}
 {{- end}}
 {{- if .CoreMountedSnapdSnapDep}}
-Requires={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
+Wants={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
 After={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
 {{- end}}
 X-Snappy=yes
@@ -1068,7 +1068,7 @@ WantedBy={{.ServicesTarget}}
 		// into the host system via a special mount unit, which
 		// also adds an implicit dependency on the snapd snap
 		// mount thus /usr/bin/snap points
-		wrapperData.CoreMountedSnapdSnapDep = []string{snapdToolingMountUnit}
+		wrapperData.CoreMountedSnapdSnapDep = []string{SnapdToolingMountUnit}
 	}
 
 	if err := t.Execute(&templateOut, wrapperData); err != nil {

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -552,9 +552,8 @@ WantedBy=sockets.target
 
 	generatedSockets, err := wrappers.GenerateSnapSocketFiles(service)
 	c.Assert(err, IsNil)
-	c.Assert(generatedSockets, Not(IsNil))
-	c.Assert(*generatedSockets, HasLen, 2)
-	c.Assert(*generatedSockets, DeepEquals, map[string][]byte{
+	c.Assert(generatedSockets, HasLen, 2)
+	c.Assert(generatedSockets, DeepEquals, map[string][]byte{
 		sock1Path: []byte(sock1Expected),
 		sock2Path: []byte(sock2Expected),
 	})

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -222,7 +222,7 @@ Description=Service for snap application foo.app
 Requires=snap-foo-44.mount
 Wants=network.target
 After=snap-foo-44.mount network.target snapd.apparmor.service
-Requires=usr-lib-snapd.mount
+Wants=usr-lib-snapd.mount
 After=usr-lib-snapd.mount
 X-Snappy=yes
 

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -540,8 +539,6 @@ WantedBy=sockets.target
 	service.Sockets["sock1"].App = service
 	service.Sockets["sock2"].App = service
 
-	sock1Path := filepath.Join(dirs.SnapServicesDir, "snap.some-snap.app.sock1.socket")
-	sock2Path := filepath.Join(dirs.SnapServicesDir, "snap.some-snap.app.sock2.socket")
 	sock1Expected := fmt.Sprintf(sock1ExpectedFmt, mountUnitPrefix, mountUnitPrefix, si.DataDir())
 	sock2Expected := fmt.Sprintf(sock2ExpectedFmt, mountUnitPrefix, mountUnitPrefix, si.DataDir())
 
@@ -554,8 +551,8 @@ WantedBy=sockets.target
 	c.Assert(err, IsNil)
 	c.Assert(generatedSockets, HasLen, 2)
 	c.Assert(generatedSockets, DeepEquals, map[string][]byte{
-		sock1Path: []byte(sock1Expected),
-		sock2Path: []byte(sock2Expected),
+		"sock1": []byte(sock1Expected),
+		"sock2": []byte(sock2Expected),
 	})
 }
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -212,7 +212,7 @@ WantedBy=multi-user.target
 }
 
 func (s *servicesTestSuite) TestEnsureSnapServicesAddsNewSvc(c *C) {
-	// test that with an existing service unit defintion, it is not changed
+	// test that with an existing service unit definition, it is not changed
 	// but we do add the new one
 	info := snaptest.MockSnap(c, packageHello+` svc2:
   command: bin/hello

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -350,7 +350,7 @@ Description=Service for snap application %[1]s.svc1
 Requires=%[2]s
 Wants=network.target
 After=%[2]s network.target snapd.apparmor.service
-Requires=usr-lib-snapd.mount
+Wants=usr-lib-snapd.mount
 After=usr-lib-snapd.mount
 X-Snappy=yes
 


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/10164 for 2.50 - it includes the pre-reqs from https://github.com/snapcore/snapd/pull/10183