### PR TITLE
many: move responsibilities down seboot -> kernel/fde and boot -> secboot

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -108,6 +108,14 @@ func MockSecbootSealKeys(f func(keys []secboot.SealKeyRequest, params *secboot.S
 	}
 }
 
+func MockSecbootSealKeysWithFDESetupHook(f func(runHook fde.RunSetupHookFunc, keys []secboot.SealKeyRequest) error) (restore func()) {
+	old := secbootSealKeysWithFDESetupHook
+	secbootSealKeysWithFDESetupHook = f
+	return func() {
+		secbootSealKeysWithFDESetupHook = old
+	}
+}
+
 func MockSecbootResealKeys(f func(params *secboot.ResealKeysParams) error) (restore func()) {
 	old := secbootResealKeys
 	secbootResealKeys = f

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -132,20 +132,9 @@ func fallbackKeySealRequests(key, saveKey secboot.EncryptionKey) []secboot.SealK
 }
 
 func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
-	// TODO: support full boot chains
-
-	for _, skr := range append(runKeySealRequests(key), fallbackKeySealRequests(key, saveKey)...) {
-		params := &fde.InitialSetupParams{
-			Key:     skr.Key,
-			KeyName: skr.KeyName,
-		}
-		res, err := fde.InitialSetup(RunFDESetupHook, params)
-		if err != nil {
-			return err
-		}
-		if err := osutil.AtomicWriteFile(skr.KeyFile, res.EncryptedKey, 0600, 0); err != nil {
-			return fmt.Errorf("cannot store key: %v", err)
-		}
+	skrs := append(runKeySealRequests(key), fallbackKeySealRequests(key, saveKey)...)
+	if err := secboot.SealKeysWithFDESetupHook(RunFDESetupHook, skrs); err != nil {
+		return err
 	}
 
 	if err := stampSealedKeys(InstallHostWritableDir, "fde-setup-hook"); err != nil {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -44,8 +44,9 @@ import (
 )
 
 var (
-	secbootSealKeys   = secboot.SealKeys
-	secbootResealKeys = secboot.ResealKeys
+	secbootSealKeys                 = secboot.SealKeys
+	secbootSealKeysWithFDESetupHook = secboot.SealKeysWithFDESetupHook
+	secbootResealKeys               = secboot.ResealKeys
 
 	seedReadSystemEssential = seed.ReadSystemEssential
 )
@@ -133,7 +134,7 @@ func fallbackKeySealRequests(key, saveKey secboot.EncryptionKey) []secboot.SealK
 
 func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
 	skrs := append(runKeySealRequests(key), fallbackKeySealRequests(key, saveKey)...)
-	if err := secboot.SealKeysWithFDESetupHook(RunFDESetupHook, skrs); err != nil {
+	if err := secbootSealKeysWithFDESetupHook(RunFDESetupHook, skrs); err != nil {
 		return err
 	}
 

--- a/kernel/fde/export_test.go
+++ b/kernel/fde/export_test.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fde
+
+import (
+	"time"
+)
+
+func MockFdeRevealKeyCommandExtra(args []string) (restore func()) {
+	oldFdeRevealKeyCommandExtra := fdeRevealKeyCommandExtra
+	fdeRevealKeyCommandExtra = args
+	return func() {
+		fdeRevealKeyCommandExtra = oldFdeRevealKeyCommandExtra
+	}
+}
+
+func MockFdeRevealKeyRuntimeMax(d time.Duration) (restore func()) {
+	oldFdeRevealKeyRuntimeMax := fdeRevealKeyRuntimeMax
+	fdeRevealKeyRuntimeMax = d
+	return func() {
+		fdeRevealKeyRuntimeMax = oldFdeRevealKeyRuntimeMax
+	}
+}
+
+func MockFdeRevealKeyPollWaitParanoiaFactor(n int) (restore func()) {
+	oldFdeRevealKeyPollWaitParanoiaFactor := fdeRevealKeyPollWaitParanoiaFactor
+	fdeRevealKeyPollWaitParanoiaFactor = n
+	return func() {
+		fdeRevealKeyPollWaitParanoiaFactor = oldFdeRevealKeyPollWaitParanoiaFactor
+	}
+}

--- a/kernel/fde/fde.go
+++ b/kernel/fde/fde.go
@@ -80,13 +80,6 @@ type SetupRequest struct {
 	// encode it automatically for us
 	Key     []byte `json:"key,omitempty"`
 	KeyName string `json:"key-name,omitempty"`
-
-	// List of models with their related fields, this will be set
-	// to follow the secboot:SnapModel interface.
-	Models []map[string]string `json:"models,omitempty"`
-
-	// TODO: provide LoadChains, KernelCmdline etc to support full
-	//       tpm sealing
 }
 
 // A RunSetupHookFunc implements running the fde-setup kernel hook.
@@ -96,9 +89,6 @@ type RunSetupHookFunc func(req *SetupRequest) ([]byte, error)
 type InitialSetupParams struct {
 	Key     []byte
 	KeyName string
-
-	//TODO:UC20: provide bootchains and a way to track measured
-	//boot-assets
 }
 
 // InitalSetupResult contains the outputs of the fde-setup hook

--- a/kernel/fde/fde.go
+++ b/kernel/fde/fde.go
@@ -62,7 +62,7 @@ func unmarshalInitialSetupResult(hookOutput []byte) (*InitialSetupResult, error)
 			return nil, fmt.Errorf("cannot decode hook output %q: %v", hookOutput, err)
 		}
 		// v1 hooks do not support a handle
-		handle := json.RawMessage("{v1-no-handle: true}")
+		handle := json.RawMessage(`{"v1-no-handle": true}`)
 		res.Handle = &handle
 		res.EncryptedKey = hookOutput
 	}

--- a/kernel/fde/fde_test.go
+++ b/kernel/fde/fde_test.go
@@ -25,19 +25,33 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/kernel/fde"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func TestFde(t *testing.T) { TestingT(t) }
 
-type fdeSuite struct{}
+type fdeSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&fdeSuite{})
+
+func (s *fdeSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+}
 
 func (s *fdeSuite) TestHasRevealKey(c *C) {
 	oldPath := os.Getenv("PATH")
@@ -150,4 +164,217 @@ func (s *fdeSuite) TestInitialSetupBadJSON(c *C) {
 	}
 	_, err := fde.InitialSetup(runSetupHook, params)
 	c.Check(err, ErrorMatches, `cannot decode hook output "bad json": invalid char.*`)
+}
+
+func checkSystemdRunOrSkip(c *C) {
+	// this test uses a real systemd-run --user so check here if that
+	// actually works
+	if output, err := exec.Command("systemd-run", "--user", "--wait", "--collect", "--service-type=exec", "/bin/true").CombinedOutput(); err != nil {
+		c.Skip(fmt.Sprintf("systemd-run not working: %v", osutil.OutputErr(output, err)))
+	}
+
+}
+
+func (s *fdeSuite) TestLockSealedKeysCallsFdeReveal(c *C) {
+	checkSystemdRunOrSkip(c)
+
+	restore := fde.MockFdeRevealKeyCommandExtra([]string{"--user"})
+	defer restore()
+	fdeRevealKeyStdin := filepath.Join(c.MkDir(), "stdin")
+	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", fmt.Sprintf(`
+cat - > %s
+`, fdeRevealKeyStdin))
+	defer mockSystemdRun.Restore()
+
+	err := fde.LockSealedKeys()
+	c.Assert(err, IsNil)
+	c.Check(mockSystemdRun.Calls(), DeepEquals, [][]string{
+		{"fde-reveal-key"},
+	})
+	c.Check(fdeRevealKeyStdin, testutil.FileEquals, `{"op":"lock"}`)
+
+	// ensure no tmp files are left behind
+	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
+}
+
+func (s *fdeSuite) TestLockSealedKeysHonorsRuntimeMax(c *C) {
+	checkSystemdRunOrSkip(c)
+
+	restore := fde.MockFdeRevealKeyCommandExtra([]string{"--user"})
+	defer restore()
+	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", "sleep 60")
+	defer mockSystemdRun.Restore()
+
+	restore = fde.MockFdeRevealKeyPollWaitParanoiaFactor(100)
+	defer restore()
+
+	restore = fde.MockFdeRevealKeyRuntimeMax(100 * time.Millisecond)
+	defer restore()
+
+	err := fde.LockSealedKeys()
+	c.Assert(err, ErrorMatches, `cannot run fde-reveal-key "lock": service result: timeout`)
+}
+
+func (s *fdeSuite) TestLockSealedKeysHonorsParanoia(c *C) {
+	checkSystemdRunOrSkip(c)
+
+	restore := fde.MockFdeRevealKeyCommandExtra([]string{"--user"})
+	defer restore()
+	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", "sleep 60")
+	defer mockSystemdRun.Restore()
+
+	restore = fde.MockFdeRevealKeyPollWaitParanoiaFactor(1)
+	defer restore()
+
+	// shorter than the fdeRevealKeyPollWait time
+	restore = fde.MockFdeRevealKeyRuntimeMax(1 * time.Millisecond)
+	defer restore()
+
+	err := fde.LockSealedKeys()
+	c.Assert(err, ErrorMatches, `cannot run fde-reveal-key "lock": internal error: systemd-run did not honor RuntimeMax=1ms setting`)
+}
+
+func (s *fdeSuite) TestReveal(c *C) {
+	checkSystemdRunOrSkip(c)
+
+	// fix randutil outcome
+	rand.Seed(1)
+
+	restore := fde.MockFdeRevealKeyCommandExtra([]string{"--user"})
+	defer restore()
+	fdeRevealKeyStdin := filepath.Join(c.MkDir(), "stdin")
+	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", fmt.Sprintf(`
+cat - > %s
+printf "unsealed-key-from-hook"
+`, fdeRevealKeyStdin))
+	defer mockSystemdRun.Restore()
+
+	sealedKey := []byte("sealed-key")
+	p := fde.RevealParams{
+		SealedKey: sealedKey,
+	}
+	res, err := fde.Reveal(&p)
+	c.Assert(err, IsNil)
+	c.Check(res, DeepEquals, []byte("unsealed-key-from-hook"))
+	c.Check(mockSystemdRun.Calls(), DeepEquals, [][]string{
+		{"fde-reveal-key"},
+	})
+	c.Check(fdeRevealKeyStdin, testutil.FileEquals, fmt.Sprintf(`{"op":"reveal","sealed-key":%q,"key-name":"deprecated-pw7MpXh0JB4P"}`, base64.StdEncoding.EncodeToString([]byte("sealed-key"))))
+
+	// ensure no tmp files are left behind
+	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
+}
+
+func (s *fdeSuite) TestedRevealTruncatesStreamFiles(c *C) {
+	checkSystemdRunOrSkip(c)
+
+	// fix randutil outcome
+	rand.Seed(1)
+
+	// create the temporary output file streams with garbage data to ensure that
+	// by the time the hook runs the files are emptied and recreated with the
+	// right permissions
+	streamFiles := []string{}
+	for _, stream := range []string{"stdin", "stdout", "stderr"} {
+		streamFile := filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key/fde-reveal-key."+stream)
+		streamFiles = append(streamFiles, streamFile)
+		// make the dir 0700
+		err := os.MkdirAll(filepath.Dir(streamFile), 0700)
+		c.Assert(err, IsNil)
+		// but make the file world-readable as it should be reset to 0600 before
+		// the hook is run
+		err = ioutil.WriteFile(streamFile, []byte("blah blah blah blah blah blah blah blah blah blah"), 0755)
+		c.Assert(err, IsNil)
+	}
+
+	// the hook script only verifies that the stdout file is empty since we
+	// need to write to the stderr file for performing the test, but we still
+	// check the stderr file for correct permissions
+	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", fmt.Sprintf(`
+# check that stdin has the right sealed key content
+if [ "$(cat %[1]s)" != "{\"op\":\"reveal\",\"sealed-key\":\"AQIDBA==\",\"key-name\":\"deprecated-pw7MpXh0JB4P\"}" ]; then
+	echo "test failed: stdin file has wrong content: $(cat %[1]s)" 1>&2
+else
+	echo "stdin file has correct content" 1>&2
+fi
+
+# check that stdout is empty
+if [ -n "$(cat %[2]s)" ]; then
+	echo "test failed: stdout file is not empty: $(cat %[2]s)" 1>&2
+else
+	echo "stdout file is correctly empty" 1>&2
+fi
+
+# check that stdin has the right 600 perms
+if [ "$(stat --format=%%a %[1]s)" != "600" ]; then
+	echo "test failed: stdin file has wrong permissions: $(stat --format=%%a %[1]s)" 1>&2
+else
+	echo "stdin file has correct 600 permissions" 1>&2
+fi
+
+# check that stdout has the right 600 perms
+if [ "$(stat --format=%%a %[2]s)" != "600" ]; then
+	echo "test failed: stdout file has wrong permissions: $(stat --format=%%a %[2]s)" 1>&2
+else
+	echo "stdout file has correct 600 permissions" 1>&2
+fi
+
+# check that stderr has the right 600 perms
+if [ "$(stat --format=%%a %[3]s)" != "600" ]; then
+	echo "test failed: stderr file has wrong permissions: $(stat --format=%%a %[3]s)" 1>&2
+else
+	echo "stderr file has correct 600 permissions" 1>&2
+fi
+
+echo "making the hook always fail for simpler test code" 1>&2
+
+# always make the hook exit 1 for simpler test code
+exit 1
+`, streamFiles[0], streamFiles[1], streamFiles[2]))
+	defer mockSystemdRun.Restore()
+	restore := fde.MockFdeRevealKeyCommandExtra([]string{"--user"})
+	defer restore()
+
+	sealedKey := []byte{1, 2, 3, 4}
+	p := fde.RevealParams{
+		SealedKey: sealedKey,
+	}
+	_, err := fde.Reveal(&p)
+	c.Assert(err, ErrorMatches, `(?s)cannot run fde-reveal-key "reveal": 
+-----
+stdin file has correct content
+stdout file is correctly empty
+stdin file has correct 600 permissions
+stdout file has correct 600 permissions
+stderr file has correct 600 permissions
+making the hook always fail for simpler test code
+service result: exit-code
+-----`)
+	// ensure no tmp files are left behind
+	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
+}
+
+func (s *fdeSuite) TestRevealErr(c *C) {
+	checkSystemdRunOrSkip(c)
+
+	// fix randutil outcome
+	rand.Seed(1)
+
+	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", `echo failed 1>&2; false`)
+	defer mockSystemdRun.Restore()
+	restore := fde.MockFdeRevealKeyCommandExtra([]string{"--user"})
+	defer restore()
+
+	sealedKey := []byte{1, 2, 3, 4}
+	p := fde.RevealParams{
+		SealedKey: sealedKey,
+	}
+	_, err := fde.Reveal(&p)
+	c.Assert(err, ErrorMatches, `(?s)cannot run fde-reveal-key "reveal": 
+-----
+failed
+service result: exit-code
+-----`)
+	// ensure no tmp files are left behind
+	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
 }

--- a/kernel/fde/fde_test.go
+++ b/kernel/fde/fde_test.go
@@ -129,7 +129,8 @@ func (s *fdeSuite) TestInitialSetupV1(c *C) {
 	}
 	res, err := fde.InitialSetup(runSetupHook, params)
 	c.Assert(err, IsNil)
-	expectedHandle := json.RawMessage(`{v1-no-handle: true}`)
+	expectedHandle := json.RawMessage(`{"v1-no-handle": true}`)
+	c.Assert(json.Valid(expectedHandle), Equals, true)
 	c.Check(res, DeepEquals, &fde.InitialSetupResult{
 		EncryptedKey: []byte("USK$sealed-key"),
 		Handle:       &expectedHandle,

--- a/kernel/fde/reavel_key.go
+++ b/kernel/fde/reavel_key.go
@@ -1,0 +1,219 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fde
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/randutil"
+)
+
+// RevealKeyRequest carries the operation parameters to the fde-reavel-key
+// helper that receives them serialized over stdin.
+type RevealKeyRequest struct {
+	Op string `json:"op"`
+
+	SealedKey []byte `json:"sealed-key,omitempty"`
+	KeyName   string `json:"key-name,omitempty"`
+
+	// TODO: add VolumeName,SourceDevicePath later
+}
+
+// fdeRevealKeyRuntimeMax is the maximum runtime a fde-reveal-key can execute
+// XXX: what is a reasonable default here?
+var fdeRevealKeyRuntimeMax = 2 * time.Minute
+
+// 50 ms means we check at a frequency 20 Hz, fast enough to not hold
+// up boot, but not too fast that we are hogging the CPU from the
+// thing we are waiting to finish running
+var fdeRevealKeyPollWait = 50 * time.Millisecond
+
+// fdeRevealKeyPollWaitParanoiaFactor controls much longer we wait
+// then fdeRevealKeyRuntimeMax before stopping to poll for results
+var fdeRevealKeyPollWaitParanoiaFactor = 2
+
+// overridden in tests
+var fdeRevealKeyCommandExtra []string
+
+// runFDERevealKeyCommand returns the output of fde-reveal-key run
+// with systemd.
+//
+// Note that systemd-run in the initrd can only talk to the private
+// systemd bus so this cannot use "--pipe" or "--wait", see
+// https://github.com/snapcore/core-initrd/issues/13
+func runFDERevealKeyCommand(req *RevealKeyRequest) (output []byte, err error) {
+	stdin, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf(`cannot build request for fde-reveal-key %q: %v`, req.Op, err)
+	}
+
+	runDir := filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")
+	if err := os.MkdirAll(runDir, 0700); err != nil {
+		return nil, fmt.Errorf("cannot create tmp dir for fde-reveal-key: %v", err)
+	}
+
+	// delete and re-create the std{in,out,err} stream files that we use for the
+	// hook to be robust against bugs where the files are created with too
+	// permissive permissions or not properly deleted afterwards since the hook
+	// will be invoked multiple times during the initrd and we want to be really
+	// careful since the stdout file will contain the unsealed encryption key
+	for _, stream := range []string{"stdin", "stdout", "stderr"} {
+		streamFile := filepath.Join(runDir, "fde-reveal-key."+stream)
+		// we want to make sure that the file permissions for stdout are always
+		// 0600, so to ensure this is the case and be robust against bugs, we
+		// always delete the file and re-create it with 0600
+
+		// note that if the file already exists, WriteFile will not change the
+		// permissions, so deleting first is the right thing to do
+		os.Remove(streamFile)
+		if stream == "stdin" {
+			err = ioutil.WriteFile(streamFile, stdin, 0600)
+		} else {
+			err = ioutil.WriteFile(streamFile, nil, 0600)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("cannot create %s for fde-reveal-key: %v", stream, err)
+		}
+	}
+
+	// TODO: put this into a new "systemd/run" package
+	cmd := exec.Command(
+		"systemd-run",
+		"--collect",
+		"--service-type=exec",
+		"--quiet",
+		// ensure we get some result from the hook within a
+		// reasonable timeout and output from systemd if
+		// things go wrong
+		fmt.Sprintf("--property=RuntimeMaxSec=%s", fdeRevealKeyRuntimeMax),
+		// Do not allow mounting, this ensures hooks in initrd
+		// can not mess around with ubuntu-data.
+		//
+		// Note that this is not about perfect confinement, more about
+		// making sure that people using the hook know that we do not
+		// want them to mess around outside of just providing unseal.
+		"--property=SystemCallFilter=~@mount",
+		// WORKAROUNDS
+		// workaround the lack of "--pipe"
+		fmt.Sprintf("--property=StandardInput=file:%s/fde-reveal-key.stdin", runDir),
+		// NOTE: these files are manually created above with 0600 because by
+		// default systemd will create them 0644 and we want to be paranoid here
+		fmt.Sprintf("--property=StandardOutput=file:%s/fde-reveal-key.stdout", runDir),
+		fmt.Sprintf("--property=StandardError=file:%s/fde-reveal-key.stderr", runDir),
+		// this ensures we get useful output for e.g. segfaults
+		fmt.Sprintf(`--property=ExecStopPost=/bin/sh -c 'if [ "$EXIT_STATUS" = 0 ]; then touch %[1]s/fde-reveal-key.success; else echo "service result: $SERVICE_RESULT" >%[1]s/fde-reveal-key.failed; fi'`, runDir),
+	)
+	if fdeRevealKeyCommandExtra != nil {
+		cmd.Args = append(cmd.Args, fdeRevealKeyCommandExtra...)
+	}
+	// fde-reveal-key is what we actually need to run
+	cmd.Args = append(cmd.Args, "fde-reveal-key")
+
+	// ensure we cleanup our tmp files
+	defer func() {
+		if err := os.RemoveAll(runDir); err != nil {
+			logger.Noticef("cannot remove tmp dir: %v", err)
+		}
+	}()
+
+	// run the command
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return output, err
+	}
+
+	// This loop will be terminate by systemd-run, either because
+	// fde-reveal-key exists or it gets killed when it reaches the
+	// fdeRevealKeyRuntimeMax defined above.
+	//
+	// However we are paranoid and exit this loop if systemd
+	// did not terminate the process after twice the allocated
+	// runtime
+	maxLoops := int(fdeRevealKeyRuntimeMax/fdeRevealKeyPollWait) * fdeRevealKeyPollWaitParanoiaFactor
+	for i := 0; i < maxLoops; i++ {
+		switch {
+		case osutil.FileExists(filepath.Join(runDir, "fde-reveal-key.failed")):
+			stderr, _ := ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.stderr"))
+			systemdErr, _ := ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.failed"))
+			buf := bytes.NewBuffer(stderr)
+			buf.Write(systemdErr)
+			return buf.Bytes(), fmt.Errorf("fde-reveal-key failed")
+		case osutil.FileExists(filepath.Join(runDir, "fde-reveal-key.success")):
+			return ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.stdout"))
+		default:
+			time.Sleep(fdeRevealKeyPollWait)
+		}
+	}
+
+	// this should never happen, the loop above should be terminated
+	// via systemd
+	return nil, fmt.Errorf("internal error: systemd-run did not honor RuntimeMax=%s setting", fdeRevealKeyRuntimeMax)
+}
+
+var runFDERevealKey = runFDERevealKeyCommand
+
+func MockRunFDERevealKey(mock func(*RevealKeyRequest) ([]byte, error)) (restore func()) {
+	oldRunFDERevealKey := runFDERevealKey
+	runFDERevealKey = mock
+	return func() {
+		runFDERevealKey = oldRunFDERevealKey
+	}
+}
+
+func LockSealedKeys() error {
+	req := &RevealKeyRequest{
+		Op: "lock",
+	}
+	if output, err := runFDERevealKey(req); err != nil {
+		return fmt.Errorf(`cannot run fde-reveal-key "lock": %v`, osutil.OutputErr(output, err))
+	}
+
+	return nil
+}
+
+// RevealParams contains the parameters for fde-reveal-key reveal operation.
+type RevealParams struct {
+	SealedKey []byte
+}
+
+// Reveal invokes the fde-reveal-key reveal operation.
+func Reveal(params *RevealParams) (payload []byte, err error) {
+	req := &RevealKeyRequest{
+		Op:        "reveal",
+		SealedKey: params.SealedKey,
+		// deprecated but needed for v1 hooks
+		KeyName: "deprecated-" + randutil.RandomString(12),
+	}
+	output, err := runFDERevealKey(req)
+	if err != nil {
+		return nil, fmt.Errorf(`cannot run fde-reveal-key "reveal": %v`, osutil.OutputErr(output, err))
+	}
+	return output, nil
+}

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -132,15 +132,6 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 		Op:      "initial-setup",
 		Key:     mockKey[:],
 		KeyName: "the-key-name",
-		Models: []map[string]string{
-			{
-				"series":     "16",
-				"brand-id":   "my-brand",
-				"model":      "my-model",
-				"grade":      "secured",
-				"signkey-id": "the-signkey-id",
-			},
-		},
 	}
 	s.mockContext.Lock()
 	s.mockContext.Set("fde-setup-request", fdeSetup)
@@ -152,7 +143,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
 	// the encryption key should be base64 encoded
 	encodedBase64Key := base64.StdEncoding.EncodeToString(mockKey[:])
 
-	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%q,"key-name":"the-key-name","models":[{"brand-id":"my-brand","grade":"secured","model":"my-model","series":"16","signkey-id":"the-signkey-id"}]}`+"\n", encodedBase64Key))
+	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"initial-setup","key":%q,"key-name":"the-key-name"}`+"\n", encodedBase64Key))
 	c.Check(string(stderr), Equals, "")
 }
 

--- a/secboot/export_test.go
+++ b/secboot/export_test.go
@@ -22,7 +22,6 @@ package secboot
 
 import (
 	"io"
-	"time"
 
 	sb "github.com/snapcore/secboot"
 )
@@ -185,29 +184,5 @@ func MockFDEHasRevealKey(f func() bool) (restore func()) {
 	fdeHasRevealKey = f
 	return func() {
 		fdeHasRevealKey = old
-	}
-}
-
-func MockFdeRevealKeyCommandExtra(args []string) (restore func()) {
-	oldFdeRevealKeyCommandExtra := fdeRevealKeyCommandExtra
-	fdeRevealKeyCommandExtra = args
-	return func() {
-		fdeRevealKeyCommandExtra = oldFdeRevealKeyCommandExtra
-	}
-}
-
-func MockFdeRevealKeyRuntimeMax(d time.Duration) (restore func()) {
-	oldFdeRevealKeyRuntimeMax := fdeRevealKeyRuntimeMax
-	fdeRevealKeyRuntimeMax = d
-	return func() {
-		fdeRevealKeyRuntimeMax = oldFdeRevealKeyRuntimeMax
-	}
-}
-
-func MockFdeRevealKeyPollWaitParanoiaFactor(n int) (restore func()) {
-	oldFdeRevealKeyPollWaitParanoiaFactor := fdeRevealKeyPollWaitParanoiaFactor
-	fdeRevealKeyPollWaitParanoiaFactor = n
-	return func() {
-		fdeRevealKeyPollWaitParanoiaFactor = oldFdeRevealKeyPollWaitParanoiaFactor
 	}
 }

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -2,7 +2,7 @@
 // +build nosecboot
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -22,6 +22,8 @@ package secboot
 
 import (
 	"errors"
+
+	"github.com/snapcore/snapd/kernel/fde"
 )
 
 var errBuildWithoutSecboot = errors.New("build without secboot support")
@@ -31,6 +33,10 @@ func CheckTPMKeySealingSupported() error {
 }
 
 func SealKeys(keys []SealKeyRequest, params *SealKeysParams) error {
+	return errBuildWithoutSecboot
+}
+
+func SealKeysWithFDESetupHook(runHook fde.RunSetupHookFunc, keys []SealKeyRequest) error {
 	return errBuildWithoutSecboot
 }
 

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -2,7 +2,7 @@
 // +build !nosecboot
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,176 +21,13 @@
 package secboot
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"time"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/kernel/fde"
-	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
 )
 
 var fdeHasRevealKey = fde.HasRevealKey
-
-func lockFDERevealSealedKeys() error {
-	buf, err := json.Marshal(FDERevealKeyRequest{
-		Op: "lock",
-	})
-	if err != nil {
-		return fmt.Errorf(`cannot build request for fde-reveal-key "lock": %v`, err)
-	}
-	if output, err := runFDERevealKeyCommand(buf); err != nil {
-		return fmt.Errorf(`cannot run fde-reveal-key "lock": %v`, osutil.OutputErr(output, err))
-	}
-
-	return nil
-}
-
-// TODO: move some of this to kernel/fde?
-
-// FDERevealKeyRequest carries the operation and parameters for the
-// fde-reveal-key binary to support unsealing keys that were sealed
-// with the "fde-setup" hook.
-type FDERevealKeyRequest struct {
-	Op string `json:"op"`
-
-	SealedKey []byte `json:"sealed-key,omitempty"`
-	KeyName   string `json:"key-name,omitempty"`
-
-	// TODO: add VolumeName,SourceDevicePath later
-}
-
-// fdeRevealKeyRuntimeMax is the maximum runtime a fde-reveal-key can execute
-// XXX: what is a reasonable default here?
-var fdeRevealKeyRuntimeMax = 2 * time.Minute
-
-// 50 ms means we check at a frequency 20 Hz, fast enough to not hold
-// up boot, but not too fast that we are hogging the CPU from the
-// thing we are waiting to finish running
-var fdeRevealKeyPollWait = 50 * time.Millisecond
-
-// fdeRevealKeyPollWaitParanoiaFactor controls much longer we wait
-// then fdeRevealKeyRuntimeMax before stopping to poll for results
-var fdeRevealKeyPollWaitParanoiaFactor = 2
-
-// overridden in tests
-var fdeRevealKeyCommandExtra []string
-
-// runFDERevealKeyCommand returns the output of fde-reveal-key run
-// with systemd.
-//
-// Note that systemd-run in the initrd can only talk to the private
-// systemd bus so this cannot use "--pipe" or "--wait", see
-// https://github.com/snapcore/core-initrd/issues/13
-func runFDERevealKeyCommand(stdin []byte) (output []byte, err error) {
-	runDir := filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")
-	if err := os.MkdirAll(runDir, 0700); err != nil {
-		return nil, fmt.Errorf("cannot create tmp dir for fde-reveal-key: %v", err)
-	}
-
-	// delete and re-create the std{in,out,err} stream files that we use for the
-	// hook to be robust against bugs where the files are created with too
-	// permissive permissions or not properly deleted afterwards since the hook
-	// will be invoked multiple times during the initrd and we want to be really
-	// careful since the stdout file will contain the unsealed encryption key
-	for _, stream := range []string{"stdin", "stdout", "stderr"} {
-		streamFile := filepath.Join(runDir, "fde-reveal-key."+stream)
-		// we want to make sure that the file permissions for stdout are always
-		// 0600, so to ensure this is the case and be robust against bugs, we
-		// always delete the file and re-create it with 0600
-
-		// note that if the file already exists, WriteFile will not change the
-		// permissions, so deleting first is the right thing to do
-		os.Remove(streamFile)
-		if stream == "stdin" {
-			err = ioutil.WriteFile(streamFile, stdin, 0600)
-		} else {
-			err = ioutil.WriteFile(streamFile, nil, 0600)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("cannot create %s for fde-reveal-key: %v", stream, err)
-		}
-	}
-
-	// TODO: put this into a new "systemd/run" package
-	cmd := exec.Command(
-		"systemd-run",
-		"--collect",
-		"--service-type=exec",
-		"--quiet",
-		// ensure we get some result from the hook within a
-		// reasonable timeout and output from systemd if
-		// things go wrong
-		fmt.Sprintf("--property=RuntimeMaxSec=%s", fdeRevealKeyRuntimeMax),
-		// Do not allow mounting, this ensures hooks in initrd
-		// can not mess around with ubuntu-data.
-		//
-		// Note that this is not about perfect confinement, more about
-		// making sure that people using the hook know that we do not
-		// want them to mess around outside of just providing unseal.
-		"--property=SystemCallFilter=~@mount",
-		// WORKAROUNDS
-		// workaround the lack of "--pipe"
-		fmt.Sprintf("--property=StandardInput=file:%s/fde-reveal-key.stdin", runDir),
-		// NOTE: these files are manually created above with 0600 because by
-		// default systemd will create them 0644 and we want to be paranoid here
-		fmt.Sprintf("--property=StandardOutput=file:%s/fde-reveal-key.stdout", runDir),
-		fmt.Sprintf("--property=StandardError=file:%s/fde-reveal-key.stderr", runDir),
-		// this ensures we get useful output for e.g. segfaults
-		fmt.Sprintf(`--property=ExecStopPost=/bin/sh -c 'if [ "$EXIT_STATUS" = 0 ]; then touch %[1]s/fde-reveal-key.success; else echo "service result: $SERVICE_RESULT" >%[1]s/fde-reveal-key.failed; fi'`, runDir),
-	)
-	if fdeRevealKeyCommandExtra != nil {
-		cmd.Args = append(cmd.Args, fdeRevealKeyCommandExtra...)
-	}
-	// fde-reveal-key is what we actually need to run
-	cmd.Args = append(cmd.Args, "fde-reveal-key")
-
-	// ensure we cleanup our tmp files
-	defer func() {
-		if err := os.RemoveAll(runDir); err != nil {
-			logger.Noticef("cannot remove tmp dir: %v", err)
-		}
-	}()
-
-	// run the command
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		return output, err
-	}
-
-	// This loop will be terminate by systemd-run, either because
-	// fde-reveal-key exists or it gets killed when it reaches the
-	// fdeRevealKeyRuntimeMax defined above.
-	//
-	// However we are paranoid and exit this loop if systemd
-	// did not terminate the process after twice the allocated
-	// runtime
-	maxLoops := int(fdeRevealKeyRuntimeMax/fdeRevealKeyPollWait) * fdeRevealKeyPollWaitParanoiaFactor
-	for i := 0; i < maxLoops; i++ {
-		switch {
-		case osutil.FileExists(filepath.Join(runDir, "fde-reveal-key.failed")):
-			stderr, _ := ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.stderr"))
-			systemdErr, _ := ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.failed"))
-			buf := bytes.NewBuffer(stderr)
-			buf.Write(systemdErr)
-			return buf.Bytes(), fmt.Errorf("fde-reveal-key failed")
-		case osutil.FileExists(filepath.Join(runDir, "fde-reveal-key.success")):
-			return ioutil.ReadFile(filepath.Join(runDir, "fde-reveal-key.stdout"))
-		default:
-			time.Sleep(fdeRevealKeyPollWait)
-		}
-	}
-
-	// this should never happen, the loop above should be terminated
-	// via systemd
-	return nil, fmt.Errorf("internal error: systemd-run did not honor RuntimeMax=%s setting", fdeRevealKeyRuntimeMax)
-}
 
 func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName string, opts *UnlockVolumeUsingSealedKeyOptions) (UnlockResult, error) {
 	res := UnlockResult{IsEncrypted: true, PartDevice: sourceDevice}
@@ -199,17 +36,13 @@ func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourc
 	if err != nil {
 		return res, fmt.Errorf("cannot read sealed key file: %v", err)
 	}
-	buf, err := json.Marshal(FDERevealKeyRequest{
-		Op:        "reveal",
+
+	p := fde.RevealParams{
 		SealedKey: sealedKey,
-		KeyName:   name,
-	})
-	if err != nil {
-		return res, fmt.Errorf("cannot build request for fde-reveal-key: %v", err)
 	}
-	output, err := runFDERevealKeyCommand(buf)
+	output, err := fde.Reveal(&p)
 	if err != nil {
-		return res, fmt.Errorf("cannot run fde-reveal-key: %v", osutil.OutputErr(output, err))
+		return res, err
 	}
 
 	// the output of fde-reveal-key is the unsealed key

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -27,6 +27,7 @@ import (
 	sb "github.com/snapcore/secboot"
 	"golang.org/x/xerrors"
 
+	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/disks"
 )
@@ -46,7 +47,7 @@ func init() {
 // given call is the last one to unlock a volume like in degraded recover mode.
 func LockSealedKeys() error {
 	if fdeHasRevealKey() {
-		return lockFDERevealSealedKeys()
+		return fde.LockSealedKeys()
 	}
 	return lockTPMSealedKeys()
 }

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -22,15 +22,12 @@ package secboot_test
 
 import (
 	"crypto/ecdsa"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"time"
 
 	"github.com/canonical/go-tpm2"
 	sb "github.com/snapcore/secboot"
@@ -40,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/efi"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
@@ -1155,123 +1153,15 @@ func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyErr(c *C) {
 	})
 }
 
-func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyTruncatesStreamFiles(c *C) {
-	// this test uses a real systemd-run --user so check here if that
-	// actually works
-	if output, err := exec.Command("systemd-run", "--user", "--wait", "--collect", "--service-type=exec", "true").CombinedOutput(); err != nil {
-		c.Skip(fmt.Sprintf("systemd-run not working: %v", osutil.OutputErr(output, err)))
-	}
-
-	// create the temporary output file streams with garbage data to ensure that
-	// by the time the hook runs the files are emptied and recreated with the
-	// right permissions
-	streamFiles := []string{}
-	for _, stream := range []string{"stdin", "stdout", "stderr"} {
-		streamFile := filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key/fde-reveal-key."+stream)
-		streamFiles = append(streamFiles, streamFile)
-		// make the dir 0700
-		err := os.MkdirAll(filepath.Dir(streamFile), 0700)
-		c.Assert(err, IsNil)
-		// but make the file world-readable as it should be reset to 0600 before
-		// the hook is run
-		err = ioutil.WriteFile(streamFile, []byte("blah blah blah blah blah blah blah blah blah blah"), 0755)
-		c.Assert(err, IsNil)
-	}
-
-	restore := secboot.MockFDEHasRevealKey(func() bool {
-		return true
-	})
-	defer restore()
-
-	// the hook script only verifies that the stdout file is empty since we
-	// need to write to the stderr file for performing the test, but we still
-	// check the stderr file for correct permissions
-	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", fmt.Sprintf(`
-# check that stdin has the right sealed key content 
-if [ "$(cat %[1]s)" != "{\"op\":\"reveal\",\"sealed-key\":\"AQIDBA==\",\"key-name\":\"name\"}" ]; then
-	echo "test failed: stdin file has wrong content: $(cat %[1]s)" 1>&2
-else
-	echo "stdin file has correct content" 1>&2
-fi
-
-# check that stdout is empty
-if [ -n "$(cat %[2]s)" ]; then
-	echo "test failed: stdout file is not empty: $(cat %[2]s)" 1>&2
-else
-	echo "stdout file is correctly empty" 1>&2
-fi
-
-# check that stdin has the right 600 perms
-if [ "$(stat --format=%%a %[1]s)" != "600" ]; then
-	echo "test failed: stdin file has wrong permissions: $(stat --format=%%a %[1]s)" 1>&2
-else 
-	echo "stdin file has correct 600 permissions" 1>&2
-fi
-
-# check that stdout has the right 600 perms
-if [ "$(stat --format=%%a %[2]s)" != "600" ]; then
-	echo "test failed: stdout file has wrong permissions: $(stat --format=%%a %[2]s)" 1>&2
-else 
-	echo "stdout file has correct 600 permissions" 1>&2
-fi
-
-# check that stderr has the right 600 perms
-if [ "$(stat --format=%%a %[3]s)" != "600" ]; then
-	echo "test failed: stderr file has wrong permissions: $(stat --format=%%a %[3]s)" 1>&2
-else 
-	echo "stderr file has correct 600 permissions" 1>&2
-fi
-
-echo "making the hook always fail for simpler test code" 1>&2
-
-# always make the hook exit 1 for simpler test code
-exit 1
-`, streamFiles[0], streamFiles[1], streamFiles[2]))
-	defer mockSystemdRun.Restore()
-	restore = secboot.MockFdeRevealKeyCommandExtra([]string{"--user"})
-	defer restore()
-
-	mockDiskWithEncDev := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"name-enc": "enc-dev-partuuid",
-		},
-	}
-	defaultDevice := "name"
-	mockSealedKeyFile := filepath.Join(c.MkDir(), "vanilla-keyfile")
-	err := ioutil.WriteFile(mockSealedKeyFile, []byte{1, 2, 3, 4}, 0600)
-	c.Assert(err, IsNil)
-
-	opts := &secboot.UnlockVolumeUsingSealedKeyOptions{}
-	_, err = secboot.UnlockVolumeUsingSealedKeyIfEncrypted(mockDiskWithEncDev, defaultDevice, mockSealedKeyFile, opts)
-	c.Assert(err, ErrorMatches, `(?s)cannot run fde-reveal-key: 
------
-stdin file has correct content
-stdout file is correctly empty
-stdin file has correct 600 permissions
-stdout file has correct 600 permissions
-stderr file has correct 600 permissions
-making the hook always fail for simpler test code
-service result: exit-code
------`)
-	// ensure no tmp files are left behind
-	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
-}
-
 func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyErr(c *C) {
-	// this test uses a real systemd-run --user so check here if that
-	// actually works
-	if output, err := exec.Command("systemd-run", "--user", "--wait", "--collect", "--service-type=exec", "/bin/true").CombinedOutput(); err != nil {
-		c.Skip(fmt.Sprintf("systemd-run not working: %v", osutil.OutputErr(output, err)))
-	}
-
-	restore := secboot.MockFDEHasRevealKey(func() bool {
-		return true
+	restore := fde.MockRunFDERevealKey(func(req *fde.RevealKeyRequest) ([]byte, error) {
+		return nil, fmt.Errorf("helper error")
 	})
 	defer restore()
 
-	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", `echo failed 1>&2; false`)
-	defer mockSystemdRun.Restore()
-	restore = secboot.MockFdeRevealKeyCommandExtra([]string{"--user"})
+	restore = secboot.MockFDEHasRevealKey(func() bool {
+		return true
+	})
 	defer restore()
 
 	mockDiskWithEncDev := &disks.MockDiskMapping{
@@ -1286,23 +1176,18 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyErr(
 
 	opts := &secboot.UnlockVolumeUsingSealedKeyOptions{}
 	_, err = secboot.UnlockVolumeUsingSealedKeyIfEncrypted(mockDiskWithEncDev, defaultDevice, mockSealedKeyFile, opts)
-	c.Assert(err, ErrorMatches, `(?s)cannot run fde-reveal-key: 
------
-failed
-service result: exit-code
------`)
-	// ensure no tmp files are left behind
-	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
+	c.Assert(err, ErrorMatches, `cannot run fde-reveal-key "reveal": helper error`)
 }
 
 func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKey(c *C) {
-	// this test uses a real systemd-run --user so check here if that
-	// actually works
-	if output, err := exec.Command("systemd-run", "--user", "--wait", "--collect", "--service-type=exec", "/bin/true").CombinedOutput(); err != nil {
-		c.Skip(fmt.Sprintf("systemd-run not working: %v", osutil.OutputErr(output, err)))
-	}
+	var reqs []*fde.RevealKeyRequest
+	restore := fde.MockRunFDERevealKey(func(req *fde.RevealKeyRequest) ([]byte, error) {
+		reqs = append(reqs, req)
+		return []byte("unsealed-key-from-hook"), nil
+	})
+	defer restore()
 
-	restore := secboot.MockFDEHasRevealKey(func() bool {
+	restore = secboot.MockFDEHasRevealKey(func() bool {
 		return true
 	})
 	defer restore()
@@ -1318,15 +1203,6 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKey(c *
 		},
 	}
 
-	restore = secboot.MockFdeRevealKeyCommandExtra([]string{"--user"})
-	defer restore()
-	fdeRevealKeyStdin := filepath.Join(c.MkDir(), "stdin")
-	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", fmt.Sprintf(`
-cat - > %s
-printf "unsealed-key-from-hook"
-`, fdeRevealKeyStdin))
-	defer mockSystemdRun.Restore()
-
 	restore = secboot.MockSbActivateVolumeWithKey(func(volumeName, sourceDevicePath string, key []byte, options *sb.ActivateVolumeOptions) error {
 		c.Check(string(key), Equals, "unsealed-key-from-hook")
 		return nil
@@ -1335,7 +1211,8 @@ printf "unsealed-key-from-hook"
 
 	defaultDevice := "name"
 	mockSealedKeyFile := filepath.Join(c.MkDir(), "vanilla-keyfile")
-	err := ioutil.WriteFile(mockSealedKeyFile, []byte("sealed-key"), 0600)
+	sealedKey := []byte("sealed-key")
+	err := ioutil.WriteFile(mockSealedKeyFile, sealedKey, 0600)
 	c.Assert(err, IsNil)
 
 	opts := &secboot.UnlockVolumeUsingSealedKeyOptions{}
@@ -1347,97 +1224,25 @@ printf "unsealed-key-from-hook"
 		PartDevice:   "/dev/disk/by-partuuid/enc-dev-partuuid",
 		FsDevice:     "/dev/mapper/name-random-uuid-for-test",
 	})
-	c.Check(mockSystemdRun.Calls(), DeepEquals, [][]string{
-		{"fde-reveal-key"},
-	})
-	c.Check(fdeRevealKeyStdin, testutil.FileEquals, fmt.Sprintf(`{"op":"reveal","sealed-key":%q,"key-name":"name"}`, base64.StdEncoding.EncodeToString([]byte("sealed-key"))))
-
-	// ensure no tmp files are left behind
-	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
+	c.Check(reqs, HasLen, 1)
+	c.Check(reqs[0].Op, Equals, "reveal")
+	c.Check(reqs[0].SealedKey, DeepEquals, sealedKey)
 }
 
 func (s *secbootSuite) TestLockSealedKeysCallsFdeReveal(c *C) {
-	// this test uses a real systemd-run --user so check here if that
-	// actually works
-	if output, err := exec.Command("systemd-run", "--user", "--wait", "--collect", "--service-type=exec", "/bin/true").CombinedOutput(); err != nil {
-		c.Skip(fmt.Sprintf("systemd-run not working: %v", osutil.OutputErr(output, err)))
-	}
-
-	restore := secboot.MockFDEHasRevealKey(func() bool {
+	var ops []string
+	restore := fde.MockRunFDERevealKey(func(req *fde.RevealKeyRequest) ([]byte, error) {
+		ops = append(ops, req.Op)
+		return nil, nil
+	})
+	defer restore()
+	restore = secboot.MockFDEHasRevealKey(func() bool {
 		return true
 	})
 	defer restore()
-
-	restore = secboot.MockFdeRevealKeyCommandExtra([]string{"--user"})
-	defer restore()
-	fdeRevealKeyStdin := filepath.Join(c.MkDir(), "stdin")
-	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", fmt.Sprintf(`
-cat - > %s
-`, fdeRevealKeyStdin))
-	defer mockSystemdRun.Restore()
 
 	err := secboot.LockSealedKeys()
 	c.Assert(err, IsNil)
-	c.Check(mockSystemdRun.Calls(), DeepEquals, [][]string{
-		{"fde-reveal-key"},
-	})
-	c.Check(fdeRevealKeyStdin, testutil.FileEquals, `{"op":"lock"}`)
 
-	// ensure no tmp files are left behind
-	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
-}
-
-func (s *secbootSuite) TestLockSealedKeysHonorsRuntimeMax(c *C) {
-	// this test uses a real systemd-run --user so check here if that
-	// actually works
-	if output, err := exec.Command("systemd-run", "--user", "--wait", "--collect", "--service-type=exec", "/bin/true").CombinedOutput(); err != nil {
-		c.Skip(fmt.Sprintf("systemd-run not working: %v", osutil.OutputErr(output, err)))
-	}
-
-	restore := secboot.MockFDEHasRevealKey(func() bool {
-		return true
-	})
-	defer restore()
-
-	restore = secboot.MockFdeRevealKeyCommandExtra([]string{"--user"})
-	defer restore()
-	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", "sleep 60")
-	defer mockSystemdRun.Restore()
-
-	restore = secboot.MockFdeRevealKeyPollWaitParanoiaFactor(100)
-	defer restore()
-
-	restore = secboot.MockFdeRevealKeyRuntimeMax(100 * time.Millisecond)
-	defer restore()
-
-	err := secboot.LockSealedKeys()
-	c.Assert(err, ErrorMatches, `cannot run fde-reveal-key "lock": service result: timeout`)
-}
-
-func (s *secbootSuite) TestLockSealedKeysHonorsParanoia(c *C) {
-	// this test uses a real systemd-run --user so check here if that
-	// actually works
-	if output, err := exec.Command("systemd-run", "--user", "--wait", "--collect", "--service-type=exec", "/bin/true").CombinedOutput(); err != nil {
-		c.Skip(fmt.Sprintf("systemd-run not working: %v", osutil.OutputErr(output, err)))
-	}
-
-	restore := secboot.MockFDEHasRevealKey(func() bool {
-		return true
-	})
-	defer restore()
-
-	restore = secboot.MockFdeRevealKeyCommandExtra([]string{"--user"})
-	defer restore()
-	mockSystemdRun := testutil.MockCommand(c, "fde-reveal-key", "sleep 60")
-	defer mockSystemdRun.Restore()
-
-	restore = secboot.MockFdeRevealKeyPollWaitParanoiaFactor(1)
-	defer restore()
-
-	// shorter than the fdeRevealKeyPollWait time
-	restore = secboot.MockFdeRevealKeyRuntimeMax(1 * time.Millisecond)
-	defer restore()
-
-	err := secboot.LockSealedKeys()
-	c.Assert(err, ErrorMatches, `cannot run fde-reveal-key "lock": internal error: systemd-run did not honor RuntimeMax=1ms setting`)
+	c.Check(ops, DeepEquals, []string{"lock"})
 }


### PR DESCRIPTION
This is another preparatory PR for the changes for fde-hooks-v2.

The first two commits are small cleanups, while the latter commits move responsibilities down respectively for:

* run fde-reveal-key to kernel/fde from secboot
* sealing keys with fde-setup hook to secboot from boot