### PR TITLE
interfaces: builtin: update permitted paths to be compatible with UC20

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -468,7 +468,7 @@ var defaultCoreRuntimeTemplateRules = `
   # Default rules for core base runtimes
 
   # The base abstraction doesn't yet have this
-  /lib/terminfo/** rk,
+  /{,usr/}lib/terminfo/** rk,
   /usr/share/terminfo/** k,
   /usr/share/zoneinfo/** k,
 
@@ -652,20 +652,20 @@ var defaultOtherBaseTemplateRules = `
   # - /lib/modules
   #
   # Everything but /lib/firmware and /lib/modules
-  /lib/ r,
-  /lib/[^fm]** mrklix,
-  /lib/{f[^i],m[^o]}** mrklix,
-  /lib/{fi[^r],mo[^d]}** mrklix,
-  /lib/{fir[^m],mod[^u]}** mrklix,
-  /lib/{firm[^w],modu[^l]}** mrklix,
-  /lib/{firmw[^a],modul[^e]}** mrklix,
-  /lib/{firmwa[^r],module[^s]}** mrklix,
-  /lib/modules[^/]** mrklix,
-  /lib/firmwar[^e]** mrklix,
-  /lib/firmware[^/]** mrklix,
+  /{,usr/}lib/ r,
+  /{,usr/}lib/[^fm]** mrklix,
+  /{,usr/}lib/{f[^i],m[^o]}** mrklix,
+  /{,usr/}lib/{fi[^r],mo[^d]}** mrklix,
+  /{,usr/}lib/{fir[^m],mod[^u]}** mrklix,
+  /{,usr/}lib/{firm[^w],modu[^l]}** mrklix,
+  /{,usr/}lib/{firmw[^a],modul[^e]}** mrklix,
+  /{,usr/}lib/{firmwa[^r],module[^s]}** mrklix,
+  /{,usr/}lib/modules[^/]** mrklix,
+  /{,usr/}lib/firmwar[^e]** mrklix,
+  /{,usr/}lib/firmware[^/]** mrklix,
 
   # /lib64, etc
-  /lib[^/]** mrklix,
+  /{,usr/}lib[^/]** mrklix,
 
   # /opt
   /opt/ r,
@@ -686,18 +686,12 @@ var defaultOtherBaseTemplateRules = `
   /usr/{lib,src}[^/]** mrklix,
   # Everything in /usr/lib except /usr/lib/firmware, /usr/lib/modules and
   # /usr/lib/snapd, which are handled elsewhere.
-  /usr/lib/ r,
   /usr/lib/[^fms]** mrklix,
   /usr/lib/{f[^i],m[^o],s[^n]}** mrklix,
   /usr/lib/{fi[^r],mo[^d],sn[^a]}** mrklix,
   /usr/lib/{fir[^m],mod[^u],sna[^p]}** mrklix,
   /usr/lib/{firm[^w],modu[^l],snap[^d]}** mrklix,
   /usr/lib/snapd[^/]** mrklix,
-  /usr/lib/{firmw[^a],modul[^e]}** mrklix,
-  /usr/lib/{firmwa[^r],module[^s]}** mrklix,
-  /usr/lib/modules[^/]** mrklix,
-  /usr/lib/firmwar[^e]** mrklix,
-  /usr/lib/firmware[^/]** mrklix,
 
   # /var - the mount setup may bind mount in:
   #

--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -55,7 +55,7 @@ const accountControlConnectedPlugAppArmor = `
 /etc/pam.d/{,*} r,
 
 # Needed by chpasswd
-/lib/@{multiarch}/security/* ixr,
+/{,usr/}lib/@{multiarch}/security/* ixr,
 
 # Useradd needs netlink
 network netlink raw,

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -144,7 +144,7 @@ pivot_root,
 
 # Docker needs to be able to create and load the profile it applies to
 # containers ("docker-default")
-/sbin/apparmor_parser ixr,
+/{,usr/}sbin/apparmor_parser ixr,
 /etc/apparmor.d/cache/ r,            # apparmor 2.12 and below
 /etc/apparmor.d/cache/.features r,
 /etc/apparmor.d/{,cache/}docker* rw,

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -45,8 +45,8 @@ const greengrassSupportBaseDeclarationSlots = `
 `
 
 const greengrassSupportConnectedPlugAppArmorCore = `
-# these accesses are necessary for Ubuntu Core 16, likely due to the version 
-# of apparmor or the kernel which doesn't resolve the upper layer of an 
+# these accesses are necessary for Ubuntu Core 16, likely due to the version
+# of apparmor or the kernel which doesn't resolve the upper layer of an
 # overlayfs mount correctly
 # the accesses show up as runc trying to read from
 # /system-data/var/snap/greengrass/x1/ggc-writable/packages/1.7.0/var/worker/overlays/$UUID/upper/
@@ -56,9 +56,9 @@ const greengrassSupportConnectedPlugAppArmorCore = `
 
 const greengrassSupportProcessModeConnectedPlugAppArmor = `
 # Description: can manage greengrass 'things' and their sandboxes. This policy
-# is meant currently only to enable Greengrass to run _only_ process-mode or 
+# is meant currently only to enable Greengrass to run _only_ process-mode or
 # "no container" lambdas.
-# needed by older versions of cloneBinary.ensureSelfCloned() to avoid 
+# needed by older versions of cloneBinary.ensureSelfCloned() to avoid
 # CVE-2019-5736
 / ix,
 # newer versions of runC have this denial instead of "/ ix" above
@@ -117,7 +117,7 @@ capability dac_override,  # for various overlayfs accesses
 
 # cgroup accesses
 # greengrassd extensively uses cgroups to confine it's containers (AKA lambdas)
-# and needs to read what cgroups are available; we allow reading any cgroup, 
+# and needs to read what cgroups are available; we allow reading any cgroup,
 # but limit writes below
 # also note that currently greengrass is not implemented in such a way that it
 # can stack it's cgroups inside the cgroup that snapd would normally enforce
@@ -143,7 +143,7 @@ owner /old_rootfs/sys/fs/cgroup/cpu,cpuacct/system.slice/snap.@{SNAP_NAME}.green
 # specific rule for cpuset files
 owner /old_rootfs/sys/fs/cgroup/cpuset/{,system.slice/}cpuset.{cpus,mems} rw,
 
-# the wrapper scripts need to use mount/umount and pivot_root from the 
+# the wrapper scripts need to use mount/umount and pivot_root from the
 # core snap
 /bin/{,u}mount ixr,
 /sbin/pivot_root ixr,
@@ -187,9 +187,9 @@ mount options=ro /dev/loop[0-9]* -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME
 # completeness allow SNAP_INSTANCE_NAME too
 mount options=(rw, bind) /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,
 mount options=(rw, rbind) /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,
-# also allow mounting new files anywhere underneath the rootfs of the target 
+# also allow mounting new files anywhere underneath the rootfs of the target
 # overlayfs directory, which is the rootfs of the container
-# this is for allowing local resource access which first makes a mount at 
+# this is for allowing local resource access which first makes a mount at
 # the target destination and then a bind mount from the source to the destination
 # the source destination mount will be allowed under the above rule
 mount -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/*/ggc-writable/packages/*/rootfs/merged/**,
@@ -236,7 +236,7 @@ mount options=(rw, bind) /dev/urandom -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE
 mount options=(rw, bind) /run/ -> /run/,
 
 # mounts for resolv.conf inside the container
-# we have to manually do this otherwise the go DNS resolver fails to work, because it isn't configured to 
+# we have to manually do this otherwise the go DNS resolver fails to work, because it isn't configured to
 # use the system DNS server and attempts to do DNS resolution itself, manually inspecting /etc/resolv.conf
 mount options=(ro, bind) /run/systemd/resolve/stub-resolv.conf -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/*/rootfs/etc/resolv.conf,
 mount options=(ro, bind) /run/resolvconf/resolv.conf -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/*/rootfs/etc/resolv.conf,
@@ -245,7 +245,7 @@ mount options=(ro, remount, bind) -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAM
 # pivot_root for the container initialization into the rootfs
 # note that the actual syscall is pivotroot(".",".")
 # so the oldroot is the same as the new root
-pivot_root 
+pivot_root
 	oldroot=/var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/*/ggc-writable/packages/*/rootfs/merged/
 	/var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/*/ggc-writable/packages/*/rootfs/merged/,
 
@@ -281,12 +281,12 @@ capability mknod,
 # and /run is explicitly disallowed for use by layouts
 # also note that technically this access is post-pivot_root, but during the setup
 # for the mount ns that the snap performs (not snapd), /var/run is bind mounted
-# from outside the pivot_root to inside the pivot_root, so this will always 
+# from outside the pivot_root to inside the pivot_root, so this will always
 # access the same files inside or outside the pivot_root
 owner /{var/,}run/greengrassd.pid rw,
 
-# all of the rest of the accesses are made by child containers and as such are 
-# "post-pivot_root", meaning that they aren't accessing these files on the 
+# all of the rest of the accesses are made by child containers and as such are
+# "post-pivot_root", meaning that they aren't accessing these files on the
 # host root filesystem, but rather somewhere inside $SNAP_DATA/rootfs/
 # Note: eventually greengrass will gain the ability to specify child profiles
 # for it's containers and include these rules in that profile so they won't
@@ -386,7 +386,7 @@ sethostname
 # by greengrassd.
 keyctl
 
-# special character device creation is necessary for creating the overlayfs 
+# special character device creation is necessary for creating the overlayfs
 # mounts
 # Unfortunately this grants device ownership to the snap.
 mknod - |S_IFCHR -

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -145,8 +145,8 @@ owner /old_rootfs/sys/fs/cgroup/cpuset/{,system.slice/}cpuset.{cpus,mems} rw,
 
 # the wrapper scripts need to use mount/umount and pivot_root from the
 # core snap
-/bin/{,u}mount ixr,
-/sbin/pivot_root ixr,
+/{,usr/}bin/{,u}mount ixr,
+/{,usr/}sbin/pivot_root ixr,
 
 # allow pivot_root'ing into the rootfs prepared for the greengrass daemon
 # parallel-installs: SNAP_{DATA,COMMON} are remapped, need to use SNAP_NAME, for

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -43,7 +43,7 @@ capability sys_rawio,
 # used by lspci
 capability sys_admin,
 /etc/modprobe.d/{,*} r,
-/lib/modprobe.d/{,*} r,
+/{,usr/}lib/modprobe.d/{,*} r,
 
 # files in /sys pertaining to hardware (eg, 'lspci -A linux-sysfs')
 /sys/{block,bus,class,devices,firmware}/{,**} r,

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -56,7 +56,7 @@ capability syslog,
 # Allow reading information about loaded kernel modules
 /sys/module/{,**} r,
 /etc/modprobe.d/{,**} r,
-/lib/modprobe.d/{,**} r,
+/{,usr/}lib/modprobe.d/{,**} r,
 `
 
 const kernelModuleControlConnectedPlugSecComp = `

--- a/interfaces/builtin/kernel_module_observe.go
+++ b/interfaces/builtin/kernel_module_observe.go
@@ -44,7 +44,7 @@ capability syslog,
 # Allow reading information about loaded kernel modules
 /sys/module/{,**} r,
 /etc/modprobe.d/{,**} r,
-/lib/modprobe.d/{,**} r,
+/{,usr/}lib/modprobe.d/{,**} r,
 `
 
 func init() {

--- a/interfaces/builtin/multipass_support.go
+++ b/interfaces/builtin/multipass_support.go
@@ -56,7 +56,7 @@ const multipassSupportBaseDeclarationSlots = `
 const multipassSupportConnectedPlugAppArmor = `
 # Description: this policy intentionally allows the Multipass daemon to configure AppArmor
 # as Multipass generates AppArmor profiles for the utility processes it spawns.
-/sbin/apparmor_parser ixr,
+/{,usr/}sbin/apparmor_parser ixr,
 /etc/apparmor{,.d}/{,**} r,
 /sys/kernel/security/apparmor/{,**} r,
 /sys/kernel/security/apparmor/.remove w,

--- a/interfaces/builtin/multipass_support_test.go
+++ b/interfaces/builtin/multipass_support_test.go
@@ -86,7 +86,7 @@ func (s *MultipassSupportInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.multipass.app"})
-	c.Assert(apparmorSpec.SnippetForTag("snap.multipass.app"), testutil.Contains, "/sbin/apparmor_parser ixr,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.multipass.app"), testutil.Contains, "/{,usr/}sbin/apparmor_parser ixr,\n")
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -168,7 +168,7 @@ capability setuid,
 /run/resolvconf/{,**} rk,
 /run/resolvconf/** w,
 /etc/resolvconf/{,**} r,
-/lib/resolvconf/* ix,
+/{,usr/}lib/resolvconf/* ix,
 # Required by resolvconf
 /{,usr/}bin/run-parts ixr,
 /etc/resolvconf/update.d/* ix,

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -164,13 +164,13 @@ capability setuid,
 /etc/hosts w,
 
 # resolvconf
-/sbin/resolvconf ixr,
+/{,usr/}sbin/resolvconf ixr,
 /run/resolvconf/{,**} rk,
 /run/resolvconf/** w,
 /etc/resolvconf/{,**} r,
 /lib/resolvconf/* ix,
 # Required by resolvconf
-/bin/run-parts ixr,
+/{,usr/}bin/run-parts ixr,
 /etc/resolvconf/update.d/* ix,
 
 # wpa_suplicant

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -103,7 +103,7 @@ network packet,
 /etc/machine-id r,
 
 # Needed to use resolvconf from core
-/sbin/resolvconf ixr,
+/{,usr/}sbin/resolvconf ixr,
 /run/resolvconf/{,**} rk,
 /run/resolvconf/** w,
 /etc/resolvconf/{,**} r,
@@ -111,7 +111,7 @@ network packet,
 # NM peeks into ifupdown configuration
 /run/network/ifstate* r,
 # Required by resolvconf
-/bin/run-parts ixr,
+/{,usr/}bin/run-parts ixr,
 /etc/resolvconf/update.d/* ix,
 
 #include <abstractions/nameservice>

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -107,7 +107,7 @@ network packet,
 /run/resolvconf/{,**} rk,
 /run/resolvconf/** w,
 /etc/resolvconf/{,**} r,
-/lib/resolvconf/* ix,
+/{,usr/}lib/resolvconf/* ix,
 # NM peeks into ifupdown configuration
 /run/network/ifstate* r,
 # Required by resolvconf

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -42,7 +42,7 @@ const pppConnectedPlugAppArmor = `
 /run/ppp* rwk,
 /var/run/ppp* rwk,
 /var/log/ppp* rw,
-/bin/run-parts ix,
+/{,usr/}bin/run-parts ix,
 @{PROC}/@{pid}/loginuid r,
 capability setgid,
 capability setuid,

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -99,7 +99,7 @@ capability sys_time,
 # write to the audit subsystem. We omit 'capability audit_write'
 # and 'capability net_admin' here. Applications requiring audit
 # logging should plug 'netlink-audit'.
-/sbin/hwclock ixr,
+/{,usr/}sbin/hwclock ixr,
 `
 
 const timeControlConnectedPlugSecComp = `

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -96,8 +96,8 @@ umount /{,run/}media/**,
 /run/udisks2/{,**} rw,
 
 # udisksd execs mount/umount to do the actual operations
-/bin/mount ixr,
-/bin/umount ixr,
+/{,usr/}bin/mount ixr,
+/{,usr/}bin/umount ixr,
 
 # mount/umount (via libmount) track some mount info in these files
 /run/mount/utab* wrlk,


### PR DESCRIPTION
Core20 does not have populated `/bin` and `/sbin` directories, instead those are symbolic links to `/usr/bin` and `/usr/sbin` respectively.
Apparmor profiles need to reflect this, otherwise we have disparity what is allowed on pre uc20 and uc20 systems
