### PR TITLE
o/devicestate,o/hookstate/ctlcmd: introduce SystemModeInfo methods and snapctl system-mode

### DIFF
--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -324,7 +324,7 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		"snaps": []interface{}{
 			map[string]interface{}{
 				"name":            "pc-kernel",
-				"id":              snaptest.AssertedSnapID("oc-kernel"),
+				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -114,3 +114,8 @@ func (dc *modelDeviceContext) Store() snapstate.StoreService {
 
 // sanity
 var _ snapstate.DeviceContext = &modelDeviceContext{}
+
+// SystemModeInfoFromState returns details about the system mode the device is in.
+func SystemModeInfoFromState(st *state.State) (*SystemModeInfo, error) {
+	return deviceMgr(st).SystemModeInfo()
+}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1242,6 +1242,52 @@ func (m *DeviceManager) Serial() (*asserts.Serial, error) {
 	return findSerial(m.state, nil)
 }
 
+type SystemModeInfo struct {
+	Mode              string
+	HasModeenv        bool
+	Seeded            bool
+	BootFlags         []string
+	HostDataLocations []string
+}
+
+// SystemModeInfo returns details about the current system mode the device is in.
+func (m *DeviceManager) SystemModeInfo() (*SystemModeInfo, error) {
+	deviceCtx, err := DeviceCtx(m.state, nil, nil)
+	if err == state.ErrNoState {
+		return nil, fmt.Errorf("cannot report system mode information before device model is acknowledged")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var seeded bool
+	err = m.state.Get("seeded", &seeded)
+	if err != nil && err != state.ErrNoState {
+		return nil, err
+	}
+
+	mode := m.SystemMode()
+	smi := SystemModeInfo{
+		Mode:       mode,
+		HasModeenv: deviceCtx.HasModeenv(),
+		Seeded:     seeded,
+	}
+	if smi.HasModeenv {
+		bootFlags, err := boot.BootFlags(deviceCtx)
+		if err != nil {
+			return nil, err
+		}
+		smi.BootFlags = bootFlags
+
+		hostDataLocs, err := boot.HostUbuntuDataForMode(mode)
+		if err != nil {
+			return nil, err
+		}
+		smi.HostDataLocations = hostDataLocs
+	}
+	return &smi, nil
+}
+
 type SystemAction struct {
 	Title string
 	Mode  string

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -1921,7 +1921,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationUC20Happy(c *C) {
 		"snaps": []interface{}{
 			map[string]interface{}{
 				"name":            "pc-kernel",
-				"id":              snaptest.AssertedSnapID("oc-kernel"),
+				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -75,7 +75,7 @@ func (s *deviceMgrSystemsSuite) SetUpTest(c *C) {
 		"snaps": []interface{}{
 			map[string]interface{}{
 				"name":            "pc-kernel",
-				"id":              snaptest.AssertedSnapID("oc-kernel"),
+				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1340,6 +1340,17 @@ func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoUC20Run(c *C) {
 		BootFlags:         []string{},
 		HostDataLocations: []string{boot.InitramfsDataDir, dirs.GlobalRootDir},
 	})
+
+	// given state only
+	smi, err = devicestate.SystemModeInfoFromState(s.state)
+	c.Assert(err, IsNil)
+	c.Check(smi, DeepEquals, &devicestate.SystemModeInfo{
+		Mode:              "run",
+		HasModeenv:        true,
+		Seeded:            false,
+		BootFlags:         []string{},
+		HostDataLocations: []string{boot.InitramfsDataDir, dirs.GlobalRootDir},
+	})
 }
 
 const (

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1239,7 +1239,7 @@ func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoUC20Install(c *C) {
 		"snaps": []interface{}{
 			map[string]interface{}{
 				"name":            "pc-kernel",
-				"id":              snaptest.AssertedSnapID("oc-kernel"),
+				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
@@ -1309,7 +1309,7 @@ func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoUC20Run(c *C) {
 		"snaps": []interface{}{
 			map[string]interface{}{
 				"name":            "pc-kernel",
-				"id":              snaptest.AssertedSnapID("oc-kernel"),
+				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -1164,6 +1165,181 @@ func (s *deviceMgrSuite) TestDeviceManagerEmptySystemModeRun(c *C) {
 
 	// empty is returned as "run"
 	c.Check(s.mgr.SystemMode(), Equals, "run")
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoTooEarly(c *C) {
+	runner := s.o.TaskRunner()
+	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	_, err = mgr.SystemModeInfo()
+	c.Check(err, ErrorMatches, `cannot report system mode information before device model is acknowledged`)
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoUC18(c *C) {
+	runner := s.o.TaskRunner()
+	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"base:":        "core18",
+	})
+
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc",
+	})
+
+	smi, err := mgr.SystemModeInfo()
+	c.Assert(err, IsNil)
+	c.Check(smi, DeepEquals, &devicestate.SystemModeInfo{
+		Mode:   "run",
+		Seeded: false,
+	})
+
+	// seeded
+	s.state.Set("seeded", true)
+
+	smi, err = mgr.SystemModeInfo()
+	c.Assert(err, IsNil)
+	c.Check(smi, DeepEquals, &devicestate.SystemModeInfo{
+		Mode:   "run",
+		Seeded: true,
+	})
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoUC20Install(c *C) {
+	modeEnv := &boot.Modeenv{Mode: "install"}
+	err := modeEnv.WriteTo("")
+	c.Assert(err, IsNil)
+
+	runner := s.o.TaskRunner()
+	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model
+	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+		"architecture": "amd64",
+		// UC20
+		"grade": "dangerous",
+		"base":  "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              snaptest.AssertedSnapID("oc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              snaptest.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+		},
+	})
+
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-20",
+	})
+
+	// seeded
+	s.state.Set("seeded", true)
+	// no flags
+	c.Assert(boot.InitramfsExposeBootFlagsForSystem(nil), IsNil)
+	// data present
+	ubuntuData := filepath.Dir(boot.InstallHostWritableDir)
+	c.Assert(os.MkdirAll(ubuntuData, 0755), IsNil)
+
+	smi, err := mgr.SystemModeInfo()
+	c.Assert(err, IsNil)
+	c.Check(smi, DeepEquals, &devicestate.SystemModeInfo{
+		Mode:              "install",
+		HasModeenv:        true,
+		Seeded:            true,
+		BootFlags:         []string{},
+		HostDataLocations: []string{ubuntuData},
+	})
+
+	// factory
+	c.Assert(boot.InitramfsExposeBootFlagsForSystem([]string{"factory"}), IsNil)
+	smi, err = mgr.SystemModeInfo()
+	c.Assert(err, IsNil)
+	c.Check(smi, DeepEquals, &devicestate.SystemModeInfo{
+		Mode:              "install",
+		HasModeenv:        true,
+		Seeded:            true,
+		BootFlags:         []string{"factory"},
+		HostDataLocations: []string{ubuntuData},
+	})
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoUC20Run(c *C) {
+	modeEnv := &boot.Modeenv{Mode: "run"}
+	err := modeEnv.WriteTo("")
+	c.Assert(err, IsNil)
+
+	runner := s.o.TaskRunner()
+	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model
+	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+		"architecture": "amd64",
+		// UC20
+		"grade": "dangerous",
+		"base":  "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              snaptest.AssertedSnapID("oc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              snaptest.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+		},
+	})
+
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-20",
+	})
+
+	// not seeded
+	// no flags
+	c.Assert(boot.InitramfsExposeBootFlagsForSystem(nil), IsNil)
+
+	smi, err := mgr.SystemModeInfo()
+	c.Assert(err, IsNil)
+	c.Check(smi, DeepEquals, &devicestate.SystemModeInfo{
+		Mode:              "run",
+		HasModeenv:        true,
+		Seeded:            false,
+		BootFlags:         []string{},
+		HostDataLocations: []string{boot.InitramfsDataDir, dirs.GlobalRootDir},
+	})
 }
 
 const (

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -22,6 +22,7 @@ package ctlcmd
 import (
 	"fmt"
 
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -39,6 +40,12 @@ func MockServicestateControlFunc(f func(*state.State, []*snap.AppInfo, *services
 	old := servicestateControl
 	servicestateControl = f
 	return func() { servicestateControl = old }
+}
+
+func MockDevicestateSystemModeInfoFromState(f func(*state.State) (*devicestate.SystemModeInfo, error)) (restore func()) {
+	old := devicestateSystemModeInfoFromState
+	devicestateSystemModeInfoFromState = f
+	return func() { devicestateSystemModeInfoFromState = old }
 }
 
 func AddMockCommand(name string) *MockCommand {

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -32,14 +32,14 @@ type systemModeCommand struct {
 	baseCommand
 }
 
-var shortSystemModeHelp = i18n.G("Get the current system mode information")
+var shortSystemModeHelp = i18n.G("Get the current system mode and associated details")
 
 var longSystemModeHelp = i18n.G(`
-The system-mode command returns information about the system mode the device is in.
+The system-mode command returns information about the device's current system mode.
 
-This information includes the mode itself, whether the model snaps have been installed from the seed (seed-loaded). The system mode will be one of run, recover, or install.
+This information includes the mode itself and whether the model snaps have been installed from the seed (seed-loaded). The system mode is either run, recover, or install.
 
-The information can also include (factory: true) whether the device booted an image flagged as for factory use ("factory mode"). This can be set for convenience when building the image but no security sensitive decisions should be based on this bit alone.
+Retrieved information can also include "factory mode" details: 'factory: true' declares whether the device booted an image flagged as for factory use. This flag can be set for convenience when building the image. No security sensitive decisions should be based on this bit alone.
 
 The output is in YAML format. Example output:
     $ snapctl system-mode

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -1,0 +1,93 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/strutil"
+	"gopkg.in/yaml.v2"
+)
+
+type systemModeCommand struct {
+	baseCommand
+}
+
+var shortSystemModeHelp = i18n.G("Get the current system mode information")
+
+var longSystemModeHelp = i18n.G(` The system-mode command returns
+ information about system mode the device is in, including the mode
+ itself, whether the model snaps have been seeded, and whether the
+ device is in factory mode. Its output is in YAML format.  The system
+ mode will be one of run, recover, or install.
+ Example output:
+
+ $ snapctl system-mode
+ system-mode: install
+ seeded: true
+ factory: true
+`)
+
+func init() {
+	addCommand("system-mode", shortSystemModeHelp, longSystemModeHelp, func() command { return &systemModeCommand{} })
+}
+
+var devicestateSystemModeInfoFromState = devicestate.SystemModeInfoFromState
+
+type systemModeResult struct {
+	SystemMode string `yaml:"system-mode,omitempty"`
+	Seeded     bool   `yaml:"seeded"`
+	Factory    bool   `yaml:"factory,omitempty"`
+}
+
+func (c *systemModeCommand) Execute(args []string) error {
+	context := c.context()
+	if context == nil {
+		return fmt.Errorf("cannot run system-mode without a context")
+	}
+
+	st := context.State()
+	st.Lock()
+	defer st.Unlock()
+
+	smi, err := devicestateSystemModeInfoFromState(st)
+	if err != nil {
+		return err
+	}
+
+	res := systemModeResult{
+		SystemMode: smi.Mode,
+		Seeded:     smi.Seeded,
+	}
+	if strutil.ListContains(smi.BootFlags, "factory") {
+		res.Factory = true
+	}
+
+	b, err := yaml.Marshal(res)
+	if err != nil {
+		return err
+	}
+
+	c.printf("%s", string(b))
+
+	return nil
+}

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -37,7 +37,9 @@ var shortSystemModeHelp = i18n.G("Get the current system mode information")
 var longSystemModeHelp = i18n.G(`
 The system-mode command returns information about the system mode the device is in.
 
-This information includes the mode itself, whether the model snaps have been installed from the seed (seed-loaded), and whether the device is in factory mode. The system mode will be one of run, recover, or install.
+This information includes the mode itself, whether the model snaps have been installed from the seed (seed-loaded). The system mode will be one of run, recover, or install.
+
+The information can also include (factory: true) whether the device booted an image flagged as for factory use ("factory mode"). This can be set for convenience when building the image but no security sensitive decisions should be based on this bit alone.
 
 The output is in YAML format. Example output:
     $ snapctl system-mode

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -34,17 +34,16 @@ type systemModeCommand struct {
 
 var shortSystemModeHelp = i18n.G("Get the current system mode information")
 
-var longSystemModeHelp = i18n.G(` The system-mode command returns
- information about system mode the device is in, including the mode
- itself, whether the model snaps have been seeded, and whether the
- device is in factory mode. Its output is in YAML format.  The system
- mode will be one of run, recover, or install.
- Example output:
+var longSystemModeHelp = i18n.G(`
+The system-mode command returns information about the system mode the device is in.
 
- $ snapctl system-mode
- system-mode: install
- seeded: true
- factory: true
+This information includes the mode itself, whether the model snaps have been installed from the seed (seed-loaded), and whether the device is in factory mode. The system mode will be one of run, recover, or install.
+
+The output is in YAML format. Example output:
+    $ snapctl system-mode
+    system-mode: install
+    seed-loaded: true
+    factory: true
 `)
 
 func init() {
@@ -55,7 +54,7 @@ var devicestateSystemModeInfoFromState = devicestate.SystemModeInfoFromState
 
 type systemModeResult struct {
 	SystemMode string `yaml:"system-mode,omitempty"`
-	Seeded     bool   `yaml:"seeded"`
+	Seeded     bool   `yaml:"seed-loaded"`
 	Factory    bool   `yaml:"factory,omitempty"`
 }
 

--- a/overlord/hookstate/ctlcmd/system_mode_test.go
+++ b/overlord/hookstate/ctlcmd/system_mode_test.go
@@ -74,9 +74,9 @@ func (s *systemModeSuite) TestSystemMode(c *C) {
 		exitCode            int
 	}{
 		{smiErr: fmt.Errorf("too early"), err: "too early"},
-		{smi: devicestate.SystemModeInfo{Mode: "run", Seeded: true}, stdout: "system-mode: run\nseeded: true\n"},
-		{smi: devicestate.SystemModeInfo{Mode: "install", HasModeenv: true, Seeded: true, BootFlags: []string{"factory"}}, stdout: "system-mode: install\nseeded: true\nfactory: true\n"},
-		{smi: devicestate.SystemModeInfo{Mode: "run", HasModeenv: true, Seeded: false}, stdout: "system-mode: run\nseeded: false\n"},
+		{smi: devicestate.SystemModeInfo{Mode: "run", Seeded: true}, stdout: "system-mode: run\nseed-loaded: true\n"},
+		{smi: devicestate.SystemModeInfo{Mode: "install", HasModeenv: true, Seeded: true, BootFlags: []string{"factory"}}, stdout: "system-mode: install\nseed-loaded: true\nfactory: true\n"},
+		{smi: devicestate.SystemModeInfo{Mode: "run", HasModeenv: true, Seeded: false}, stdout: "system-mode: run\nseed-loaded: false\n"},
 	}
 
 	for _, test := range tests {

--- a/overlord/hookstate/ctlcmd/system_mode_test.go
+++ b/overlord/hookstate/ctlcmd/system_mode_test.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+)
+
+type systemModeSuite struct {
+	testutil.BaseTest
+	st          *state.State
+	mockHandler *hooktest.MockHandler
+}
+
+var _ = Suite(&systemModeSuite{})
+
+func (s *systemModeSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+	s.st = state.New(nil)
+	s.mockHandler = hooktest.NewMockHandler()
+}
+
+func (s *systemModeSuite) TestSystemMode(c *C) {
+	s.st.Lock()
+	task := s.st.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(1), Hook: "gate-auto-refresh"}
+	mockContext, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
+	c.Check(err, IsNil)
+	s.st.Unlock()
+
+	var smi *devicestate.SystemModeInfo
+	var smiErr error
+	r := ctlcmd.MockDevicestateSystemModeInfoFromState(func(s *state.State) (*devicestate.SystemModeInfo, error) {
+		s.Unlock()
+		defer s.Lock()
+		return smi, smiErr
+	})
+	defer r()
+
+	tests := []struct {
+		smi                 devicestate.SystemModeInfo
+		smiErr              error
+		stdout, stderr, err string
+		exitCode            int
+	}{
+		{smiErr: fmt.Errorf("too early"), err: "too early"},
+		{smi: devicestate.SystemModeInfo{Mode: "run", Seeded: true}, stdout: "system-mode: run\nseeded: true\n"},
+		{smi: devicestate.SystemModeInfo{Mode: "install", HasModeenv: true, Seeded: true, BootFlags: []string{"factory"}}, stdout: "system-mode: install\nseeded: true\nfactory: true\n"},
+		{smi: devicestate.SystemModeInfo{Mode: "run", HasModeenv: true, Seeded: false}, stdout: "system-mode: run\nseeded: false\n"},
+	}
+
+	for _, test := range tests {
+		smi = &test.smi
+		smiErr = test.smiErr
+
+		stdout, stderr, err := ctlcmd.Run(mockContext, []string{"system-mode"}, 0)
+		comment := Commentf("%v", test)
+		if test.exitCode > 0 {
+			c.Check(err, DeepEquals, &ctlcmd.UnsuccessfulError{ExitCode: test.exitCode}, comment)
+		} else {
+			if test.err == "" {
+				c.Check(err, IsNil, comment)
+			} else {
+				c.Check(err, ErrorMatches, test.err, comment)
+			}
+		}
+
+		c.Check(string(stdout), Equals, test.stdout, comment)
+		c.Check(string(stderr), Equals, "", comment)
+	}
+}

--- a/overlord/hookstate/ctlcmd/system_mode_test.go
+++ b/overlord/hookstate/ctlcmd/system_mode_test.go
@@ -53,7 +53,7 @@ func (s *systemModeSuite) SetUpTest(c *C) {
 func (s *systemModeSuite) TestSystemMode(c *C) {
 	s.st.Lock()
 	task := s.st.NewTask("test-task", "my test task")
-	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(1), Hook: "gate-auto-refresh"}
+	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(1), Hook: "test-hook"}
 	mockContext, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
 	c.Check(err, IsNil)
 	s.st.Unlock()


### PR DESCRIPTION
Have ways to get general details about the system mode the device is in from DeviceManager.

Use this to implement a first pass at `snapctl system-mode`.
