### PR TITLE
cmd/snap: introduce 'snap quota' command

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -28,10 +28,11 @@ import (
 )
 
 type postQuotaData struct {
+	Action    string   `json:"action"`
 	GroupName string   `json:"group-name"`
 	Parent    string   `json:"parent,omitempty"`
 	Snaps     []string `json:"snaps,omitempty"`
-	MaxMemory uint64    `json:"max-memory"`
+	MaxMemory uint64   `json:"max-memory"`
 }
 
 type QuotaGroupResult struct {
@@ -39,18 +40,19 @@ type QuotaGroupResult struct {
 	Parent    string   `json:"parent,omitempty"`
 	Subgroups []string `json:"subgroups,omitempty"`
 	Snaps     []string `json:"snaps,omitempty"`
-	MaxMemory uint64    `json:"max-memory"`
+	MaxMemory uint64   `json:"max-memory"`
 }
 
-// CreateOrUpdateQuota creates a quota group or updates an existing group.
+// EnsureQuota creates a quota group or updates an existing group.
 // The list of snaps can be empty.
-func (client *Client) CreateOrUpdateQuota(groupName string, parent string, snaps []string, maxMemory uint64) error {
+func (client *Client) EnsureQuota(groupName string, parent string, snaps []string, maxMemory uint64) error {
 	if groupName == "" {
 		return xerrors.Errorf("cannot create or update quota group without a name")
 	}
 	// TODO: use naming.ValidateQuotaGroup()
 
 	data := &postQuotaData{
+		Action:    "ensure",
 		GroupName: groupName,
 		Parent:    parent,
 		Snaps:     snaps,
@@ -61,7 +63,7 @@ func (client *Client) CreateOrUpdateQuota(groupName string, parent string, snaps
 	if err := json.NewEncoder(&body).Encode(data); err != nil {
 		return err
 	}
-	if _, err := client.doSync("POST", "/v2/quota", nil, nil, &body, nil); err != nil {
+	if _, err := client.doSync("POST", "/v2/quotas", nil, nil, &body, nil); err != nil {
 		fmt := "cannot create or update quota group: %w"
 		return xerrors.Errorf(fmt, err)
 	}
@@ -74,7 +76,7 @@ func (client *Client) GetQuotaGroup(groupName string) (*QuotaGroupResult, error)
 	}
 
 	var res *QuotaGroupResult
-	path := fmt.Sprintf("/v2/quota/%s", groupName)
+	path := fmt.Sprintf("/v2/quotas/%s", groupName)
 	if _, err := client.doSync("GET", path, nil, nil, nil, &res); err != nil {
 		fmt := "cannot get quota group: %w"
 		return nil, xerrors.Errorf(fmt, err)

--- a/client/quota.go
+++ b/client/quota.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"golang.org/x/xerrors"
+)
+
+type postQuotaData struct {
+	GroupName string   `json:"group-name"`
+	Parent    string   `json:"parent,omitempty"`
+	Snaps     []string `json:"snaps,omitempty"`
+	MaxMemory int64    `json:"max-memory"`
+}
+
+type QuotaGroupResult struct {
+	GroupName string   `json:"group-name"`
+	Parent    string   `json:"parent,omitempty"`
+	Subgroups []string `json:"subgroups,omitempty"`
+	Snaps     []string `json:"snaps,omitempty"`
+	MaxMemory int64    `json:"max-memory"`
+}
+
+// CreateOrUpdateQuota creates a quota group or updates an existing group.
+// The list of snaps can be empty.
+func (client *Client) CreateOrUpdateQuota(groupName string, parent string, snaps []string, maxMemory int64) error {
+	if groupName == "" {
+		return xerrors.Errorf("cannot create or update quota group without a name")
+	}
+	// TODO: use naming.ValidateQuotaGroup()
+
+	data := &postQuotaData{
+		GroupName: groupName,
+		Parent:    parent,
+		Snaps:     snaps,
+		MaxMemory: maxMemory,
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(data); err != nil {
+		return err
+	}
+	if _, err := client.doSync("POST", "/v2/quota", nil, nil, &body, nil); err != nil {
+		fmt := "cannot create or update quota group: %w"
+		return xerrors.Errorf(fmt, err)
+	}
+	return nil
+}
+
+func (client *Client) GetQuotaGroup(groupName string) (*QuotaGroupResult, error) {
+	if groupName == "" {
+		return nil, xerrors.Errorf("cannot get quota group without a name")
+	}
+
+	var res *QuotaGroupResult
+	path := fmt.Sprintf("/v2/quota/%s", groupName)
+	if _, err := client.doSync("GET", path, nil, nil, nil, &res); err != nil {
+		fmt := "cannot get quota group: %w"
+		return nil, xerrors.Errorf(fmt, err)
+	}
+	return res, nil
+}

--- a/client/quota.go
+++ b/client/quota.go
@@ -31,7 +31,7 @@ type postQuotaData struct {
 	GroupName string   `json:"group-name"`
 	Parent    string   `json:"parent,omitempty"`
 	Snaps     []string `json:"snaps,omitempty"`
-	MaxMemory int64    `json:"max-memory"`
+	MaxMemory uint64    `json:"max-memory"`
 }
 
 type QuotaGroupResult struct {
@@ -39,12 +39,12 @@ type QuotaGroupResult struct {
 	Parent    string   `json:"parent,omitempty"`
 	Subgroups []string `json:"subgroups,omitempty"`
 	Snaps     []string `json:"snaps,omitempty"`
-	MaxMemory int64    `json:"max-memory"`
+	MaxMemory uint64    `json:"max-memory"`
 }
 
 // CreateOrUpdateQuota creates a quota group or updates an existing group.
 // The list of snaps can be empty.
-func (client *Client) CreateOrUpdateQuota(groupName string, parent string, snaps []string, maxMemory int64) error {
+func (client *Client) CreateOrUpdateQuota(groupName string, parent string, snaps []string, maxMemory uint64) error {
 	if groupName == "" {
 		return xerrors.Errorf("cannot create or update quota group without a name")
 	}

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/snapcore/snapd/client"
+	"gopkg.in/check.v1"
+)
+
+func (cs *clientSuite) TestCreateQuotaGroupInvalidName(c *check.C) {
+	err := cs.cli.CreateOrUpdateQuota("", "", nil, 0)
+	c.Check(err, check.ErrorMatches, `cannot create or update quota group without a name`)
+}
+
+func (cs *clientSuite) TestCreateQuotaGroup(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200
+	}`
+
+	c.Assert(cs.cli.CreateOrUpdateQuota("foo", "bar", []string{"snap-a", "snap-b"}, 1001), check.IsNil)
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/quota")
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+	var req map[string]interface{}
+	err = json.Unmarshal(body, &req)
+	c.Assert(err, check.IsNil)
+	c.Assert(req, check.DeepEquals, map[string]interface{}{
+		"group-name": "foo",
+		"parent":     "bar",
+		"snaps":      []interface{}{"snap-a", "snap-b"},
+		"max-memory": float64(1001),
+	})
+}
+
+func (cs *clientSuite) TestCreateQuotaGroupError(c *check.C) {
+	cs.status = 500
+	cs.rsp = `{"type": "error"}`
+	err := cs.cli.CreateOrUpdateQuota("foo", "bar", []string{"snap-a"}, 1)
+	c.Check(err, check.ErrorMatches, `cannot create or update quota group: server error: "Internal Server Error"`)
+}
+
+func (cs *clientSuite) TestGetQuotaGroupInvalidName(c *check.C) {
+	_, err := cs.cli.GetQuotaGroup("")
+	c.Assert(err, check.ErrorMatches, `cannot get quota group without a name`)
+}
+
+func (cs *clientSuite) TestGetQuotaGroup(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200,
+		"result": {"group-name":"foo", "parent":"bar", "subgroups":["foo-subgrp"], "snaps":["snap-a"], "max-memory":999}
+	}`
+
+	grp, err := cs.cli.GetQuotaGroup("foo")
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.Method, check.Equals, "GET")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/quota/foo")
+	c.Check(grp, check.DeepEquals, &client.QuotaGroupResult{
+		GroupName: "foo",
+		Parent:    "bar",
+		Subgroups: []string{"foo-subgrp"},
+		MaxMemory: 999,
+		Snaps:     []string{"snap-a"},
+	})
+}
+
+func (cs *clientSuite) TestGetQuotaGroupError(c *check.C) {
+	cs.status = 500
+	cs.rsp = `{"type": "error"}`
+	_, err := cs.cli.GetQuotaGroup("foo")
+	c.Check(err, check.ErrorMatches, `cannot get quota group: server error: "Internal Server Error"`)
+}

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -28,25 +28,26 @@ import (
 )
 
 func (cs *clientSuite) TestCreateQuotaGroupInvalidName(c *check.C) {
-	err := cs.cli.CreateOrUpdateQuota("", "", nil, 0)
+	err := cs.cli.EnsureQuota("", "", nil, 0)
 	c.Check(err, check.ErrorMatches, `cannot create or update quota group without a name`)
 }
 
-func (cs *clientSuite) TestCreateQuotaGroup(c *check.C) {
+func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
 		"status-code": 200
 	}`
 
-	c.Assert(cs.cli.CreateOrUpdateQuota("foo", "bar", []string{"snap-a", "snap-b"}, 1001), check.IsNil)
+	c.Assert(cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, 1001), check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "POST")
-	c.Check(cs.req.URL.Path, check.Equals, "/v2/quota")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/quotas")
 	body, err := ioutil.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
 	var req map[string]interface{}
 	err = json.Unmarshal(body, &req)
 	c.Assert(err, check.IsNil)
 	c.Assert(req, check.DeepEquals, map[string]interface{}{
+		"action":     "ensure",
 		"group-name": "foo",
 		"parent":     "bar",
 		"snaps":      []interface{}{"snap-a", "snap-b"},
@@ -54,10 +55,10 @@ func (cs *clientSuite) TestCreateQuotaGroup(c *check.C) {
 	})
 }
 
-func (cs *clientSuite) TestCreateQuotaGroupError(c *check.C) {
+func (cs *clientSuite) TestEnsureQuotaGroupError(c *check.C) {
 	cs.status = 500
 	cs.rsp = `{"type": "error"}`
-	err := cs.cli.CreateOrUpdateQuota("foo", "bar", []string{"snap-a"}, 1)
+	err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a"}, 1)
 	c.Check(err, check.ErrorMatches, `cannot create or update quota group: server error: "Internal Server Error"`)
 }
 
@@ -76,7 +77,7 @@ func (cs *clientSuite) TestGetQuotaGroup(c *check.C) {
 	grp, err := cs.cli.GetQuotaGroup("foo")
 	c.Assert(err, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "GET")
-	c.Check(cs.req.URL.Path, check.Equals, "/v2/quota/foo")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/quotas/foo")
 	c.Check(grp, check.DeepEquals, &client.QuotaGroupResult{
 		GroupName: "foo",
 		Parent:    "bar",

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -76,16 +76,13 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 		return fmt.Errorf("missing required --max-memory argument")
 	}
 
-	var mem int64
-	if maxMemory != "" {
-		mem, err = strutil.ParseByteSize(maxMemory)
-		if err != nil {
-			return err
-		}
+	mem, err := strutil.ParseByteSize(maxMemory)
+	if err != nil {
+		return err
 	}
 
 	names := installedSnapNames(x.Positional.Snaps)
-	return x.client.CreateOrUpdateQuota(x.Positional.GroupName, x.Parent, names, mem)
+	return x.client.CreateOrUpdateQuota(x.Positional.GroupName, x.Parent, names, uint64(mem))
 }
 
 func (x *cmdQuota) showQuotaGroupInfo(groupName string) error {
@@ -94,6 +91,8 @@ func (x *cmdQuota) showQuotaGroupInfo(groupName string) error {
 	if err != nil {
 		return err
 	}
+
+	// TODO: show current quota usage
 
 	fmt.Fprintf(w, "name: %s\n", group.GroupName)
 	if group.Parent != "" {
@@ -105,7 +104,7 @@ func (x *cmdQuota) showQuotaGroupInfo(groupName string) error {
 			fmt.Fprintf(w, "  - %s\n", name)
 		}
 	}
-	fmt.Fprintf(w, "max-memory: %s\n", fmtSize(group.MaxMemory))
+	fmt.Fprintf(w, "max-memory: %s\n", fmtSize(int64(group.MaxMemory)))
 	if len(group.Snaps) > 0 {
 		fmt.Fprint(w, "snaps:\n")
 		for _, snapName := range group.Snaps {

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -71,6 +71,8 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 	}
 
 	// TODO: update without max-memory (i.e. append snaps operation).
+	// Also how do we remove snaps from a group? Should the default be append?
+	// Do we want a "reset" operation to start from scratch?
 	if maxMemory == "" {
 		return fmt.Errorf("missing required --max-memory argument")
 	}

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -32,8 +32,8 @@ var longQuotaHelp = i18n.G(`
 The quota command creates, updates or shows quota groups for a a set of snaps.
 
 A quota group sets resource limits (currently maximum memory only) on the set of
-snaps that belong to it. Quotas groups are controlled by systemd slice units.
-Snaps can be at most in one quota group. Quota groups can be nested.
+snaps that belong to it. Snaps can be at most in one quota group. Quota groups
+can be nested.
 `)
 
 type cmdQuota struct {
@@ -70,8 +70,7 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 		return x.showQuotaGroupInfo(x.Positional.GroupName)
 	}
 
-	// XXX: we could support update without max-memory (i.e. the list of
-	// snaps/parent gets updated).
+	// TODO: update without max-memory (i.e. append snaps operation).
 	if maxMemory == "" {
 		return fmt.Errorf("missing required --max-memory argument")
 	}
@@ -82,7 +81,7 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 	}
 
 	names := installedSnapNames(x.Positional.Snaps)
-	return x.client.CreateOrUpdateQuota(x.Positional.GroupName, x.Parent, names, uint64(mem))
+	return x.client.EnsureQuota(x.Positional.GroupName, x.Parent, names, uint64(mem))
 }
 
 func (x *cmdQuota) showQuotaGroupInfo(groupName string) error {

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -1,0 +1,117 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/strutil"
+)
+
+var shortQuotaHelp = i18n.G("Create, update or show quota group for a set of snaps")
+var longQuotaHelp = i18n.G(`
+The quota command creates, updates or shows quota groups for a a set of snaps.
+
+A quota group sets resource limits (currently maximum memory only) on the set of
+snaps that belong to it. Quotas groups are controlled by systemd slice units.
+Snaps can be at most in one quota group. Quota groups can be nested.
+`)
+
+type cmdQuota struct {
+	clientMixin
+	// MaxMemory and MemoryMax are mutually exclusive and provided for
+	// convienience, they mean the same.
+	MaxMemory  string `long:"max-memory" optional:"true"`
+	MemoryMax  string `long:"memory-max" optional:"true"`
+	Parent     string `long:"parent" optional:"true"`
+	Positional struct {
+		GroupName string              `positional-arg-name:"<group-name>" required:"true"`
+		Snaps     []installedSnapName `positional-arg-name:"<snap>" optional:"true"`
+	} `positional-args:"yes"`
+}
+
+func init() {
+	cmd := addCommand("quota", shortQuotaHelp, longQuotaHelp, func() flags.Commander { return &cmdQuota{} }, nil, nil)
+	// XXX: unhide
+	cmd.hidden = true
+}
+
+func (x *cmdQuota) Execute(args []string) (err error) {
+	var maxMemory string
+	switch {
+	case x.MaxMemory != "" && x.MemoryMax != "":
+		return fmt.Errorf("cannot use --max-memory and --memory-max together")
+	case x.MaxMemory != "":
+		maxMemory = x.MaxMemory
+	case x.MemoryMax != "":
+		maxMemory = x.MemoryMax
+	}
+
+	if maxMemory == "" && x.Parent == "" && len(x.Positional.Snaps) == 0 {
+		return x.showQuotaGroupInfo(x.Positional.GroupName)
+	}
+
+	// XXX: we could support update without max-memory (i.e. the list of
+	// snaps/parent gets updated).
+	if maxMemory == "" {
+		return fmt.Errorf("missing required --max-memory argument")
+	}
+
+	var mem int64
+	if maxMemory != "" {
+		mem, err = strutil.ParseByteSize(maxMemory)
+		if err != nil {
+			return err
+		}
+	}
+
+	names := installedSnapNames(x.Positional.Snaps)
+	return x.client.CreateOrUpdateQuota(x.Positional.GroupName, x.Parent, names, mem)
+}
+
+func (x *cmdQuota) showQuotaGroupInfo(groupName string) error {
+	w := Stdout
+	group, err := x.client.GetQuotaGroup(x.Positional.GroupName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "name: %s\n", group.GroupName)
+	if group.Parent != "" {
+		fmt.Fprintf(w, "parent: %s\n", group.Parent)
+	}
+	if len(group.Subgroups) > 0 {
+		fmt.Fprint(w, "subgroups:\n")
+		for _, name := range group.Subgroups {
+			fmt.Fprintf(w, "  - %s\n", name)
+		}
+	}
+	fmt.Fprintf(w, "max-memory: %s\n", fmtSize(group.MaxMemory))
+	if len(group.Snaps) > 0 {
+		fmt.Fprint(w, "snaps:\n")
+		for _, snapName := range group.Snaps {
+			fmt.Fprintf(w, "  - %s\n", snapName)
+		}
+	}
+
+	return nil
+}

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -79,16 +79,16 @@ func (s *quotaSuite) TestQuotaInvalidArgs(c *check.C) {
 		args []string
 		err  string
 	}{
-		{[]string{""}, `cannot get quota group without a name`},
-		{[]string{"--memory-max=99B"}, "the required argument `<group-name>` was not provided"},
-		{[]string{"--memory-max=99B", "--max-memory=88B", "foo"}, `cannot use --max-memory and --memory-max together`},
-		{[]string{"--memory-max=99", "foo"}, `cannot parse "99": need a number with a unit as input`},
-		{[]string{"--memory-max=888X", "foo"}, `cannot parse "888X\": try 'kB' or 'MB'`},
+		{[]string{"quota"}, "the required argument `<group-name>` was not provided"},
+		{[]string{"quota", "--memory-max=99B"}, "the required argument `<group-name>` was not provided"},
+		{[]string{"quota", "--memory-max=99B", "--max-memory=88B", "foo"}, `cannot use --max-memory and --memory-max together`},
+		{[]string{"quota", "--memory-max=99", "foo"}, `cannot parse "99": need a number with a unit as input`},
+		{[]string{"quota", "--memory-max=888X", "foo"}, `cannot parse "888X\": try 'kB' or 'MB'`},
 	} {
 		s.stdout.Reset()
 		s.stderr.Reset()
 
-		_, err := main.Parser(main.Client()).ParseArgs(append([]string{"quota"}, args.args...))
+		_, err := main.Parser(main.Client()).ParseArgs(args.args)
 		c.Assert(err, check.ErrorMatches, args.err)
 	}
 }

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -42,7 +42,7 @@ func makeFakeGetQuotaGroupHandler(c *check.C, body string) func(w http.ResponseW
 			c.Fatalf("expected a single request")
 		}
 		called = true
-		c.Check(r.URL.Path, check.Equals, "/v2/quota/foo")
+		c.Check(r.URL.Path, check.Equals, "/v2/quotas/foo")
 		c.Check(r.Method, check.Equals, "GET")
 		w.WriteHeader(200)
 		fmt.Fprintln(w, body)
@@ -56,7 +56,7 @@ func makeFakeQuotaPostHandler(c *check.C, body, groupName, parentName string, sn
 			c.Fatalf("expected a single request")
 		}
 		called = true
-		c.Check(r.URL.Path, check.Equals, "/v2/quota")
+		c.Check(r.URL.Path, check.Equals, "/v2/quotas")
 		c.Check(r.Method, check.Equals, "POST")
 
 		buf, err := ioutil.ReadAll(r.Body)
@@ -67,7 +67,7 @@ func makeFakeQuotaPostHandler(c *check.C, body, groupName, parentName string, sn
 			snapNames = append(snapNames, fmt.Sprintf("%q", sn))
 		}
 		snapsStr := strings.Join(snapNames, ",")
-		c.Check(string(buf), check.DeepEquals, fmt.Sprintf("{\"group-name\":%q,\"parent\":%q,\"snaps\":[%s],\"max-memory\":%d}\n", groupName, parentName, snapsStr, maxMemory))
+		c.Check(string(buf), check.DeepEquals, fmt.Sprintf("{\"action\":\"ensure\",\"group-name\":%q,\"parent\":%q,\"snaps\":[%s],\"max-memory\":%d}\n", groupName, parentName, snapsStr, maxMemory))
 
 		w.WriteHeader(200)
 		fmt.Fprintln(w, body)

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -1,0 +1,138 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	main "github.com/snapcore/snapd/cmd/snap"
+	"gopkg.in/check.v1"
+)
+
+type quotaSuite struct {
+	BaseSnapSuite
+}
+
+var _ = check.Suite(&quotaSuite{})
+
+func makeFakeGetQuotaGroupHandler(c *check.C, body string) func(w http.ResponseWriter, r *http.Request) {
+	var called bool
+	return func(w http.ResponseWriter, r *http.Request) {
+		if called {
+			c.Fatalf("expected a single request")
+		}
+		called = true
+		c.Check(r.URL.Path, check.Equals, "/v2/quota/foo")
+		c.Check(r.Method, check.Equals, "GET")
+		w.WriteHeader(200)
+		fmt.Fprintln(w, body)
+	}
+}
+
+func makeFakeQuotaPostHandler(c *check.C, body, groupName, parentName string, snaps []string, maxMemory int64) func(w http.ResponseWriter, r *http.Request) {
+	var called bool
+	return func(w http.ResponseWriter, r *http.Request) {
+		if called {
+			c.Fatalf("expected a single request")
+		}
+		called = true
+		c.Check(r.URL.Path, check.Equals, "/v2/quota")
+		c.Check(r.Method, check.Equals, "POST")
+
+		buf, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, check.IsNil)
+
+		var snapNames []string
+		for _, sn := range snaps {
+			snapNames = append(snapNames, fmt.Sprintf("%q", sn))
+		}
+		snapsStr := strings.Join(snapNames, ",")
+		c.Check(string(buf), check.DeepEquals, fmt.Sprintf("{\"group-name\":%q,\"parent\":%q,\"snaps\":[%s],\"max-memory\":%d}\n", groupName, parentName, snapsStr, maxMemory))
+
+		w.WriteHeader(200)
+		fmt.Fprintln(w, body)
+	}
+}
+
+func (s *quotaSuite) TestQuotaInvalidArgs(c *check.C) {
+	for _, args := range []struct {
+		args []string
+		err  string
+	}{
+		{[]string{""}, `cannot get quota group without a name`},
+		{[]string{"--memory-max=99B"}, "the required argument `<group-name>` was not provided"},
+		{[]string{"--memory-max=99B", "--max-memory=88B", "foo"}, `cannot use --max-memory and --memory-max together`},
+		{[]string{"--memory-max=99", "foo"}, `cannot parse "99": need a number with a unit as input`},
+		{[]string{"--memory-max=888X", "foo"}, `cannot parse "888X\": try 'kB' or 'MB'`},
+	} {
+		s.stdout.Reset()
+		s.stderr.Reset()
+
+		_, err := main.Parser(main.Client()).ParseArgs(append([]string{"quota"}, args.args...))
+		c.Assert(err, check.ErrorMatches, args.err)
+	}
+}
+
+func (s *quotaSuite) TestGetQuotaGroup(c *check.C) {
+	restore := main.MockIsStdinTTY(true)
+	defer restore()
+
+	s.RedirectClientToTestServer(makeFakeGetQuotaGroupHandler(c, `{"type": "sync", "status-code": 200, "result": {"group-name":"foo","parent":"bar","subgroups":["subgrp1"],"snaps":["snap-a","snap-b"],"max-memory":1000}}`))
+
+	rest, err := main.Parser(main.Client()).ParseArgs([]string{"quota", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "name: foo\n"+
+		"parent: bar\n"+
+		"subgroups:\n"+
+		"  - subgrp1\n"+
+		"max-memory:  1000B\n"+
+		"snaps:\n"+
+		"  - snap-a\n"+
+		"  - snap-b\n")
+}
+
+func (s *quotaSuite) TestGetQuotaGroupSimple(c *check.C) {
+	restore := main.MockIsStdinTTY(true)
+	defer restore()
+
+	s.RedirectClientToTestServer(makeFakeGetQuotaGroupHandler(c, `{"type": "sync", "status-code": 200, "result": {"group-name":"foo","max-memory":1000}}`))
+
+	rest, err := main.Parser(main.Client()).ParseArgs([]string{"quota", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "name: foo\n"+
+		"max-memory:  1000B\n")
+}
+
+func (s *validateSuite) TestCreateQuotaGroup(c *check.C) {
+	s.RedirectClientToTestServer(makeFakeQuotaPostHandler(c, `{"type": "sync", "status-code": 200, "result": []}`, "foo", "bar", []string{"snap-a"}, 999))
+
+	rest, err := main.Parser(main.Client()).ParseArgs([]string{"quota", "foo", "--max-memory=999B", "--parent=bar", "snap-a"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "")
+}


### PR DESCRIPTION
Introduce 'snap quota' command along with client methods with support for creating/updating and querying info for single quota group.
