### PR TITLE
o/servicestate/quotas: add functions for getting and setting quotas in state

### DIFF
--- a/overlord/servicestate/quotas.go
+++ b/overlord/servicestate/quotas.go
@@ -28,8 +28,7 @@ import (
 )
 
 // AllQuotas returns all currently tracked quota groups in the state. They are
-// validated for consistency before returned and internally updated using
-// ResolveCrossReferences before returned.
+// validated for consistency using ResolveCrossReferences before being returned.
 func AllQuotas(st *state.State) (map[string]*quota.Group, error) {
 	var quotas map[string]*quota.Group
 	if err := st.Get("quotas", &quotas); err != nil {
@@ -62,11 +61,11 @@ func GetQuota(st *state.State, name string) (*quota.Group, error) {
 }
 
 // UpdateQuotas will update the state quota group map with the provided quota
-// groups. The groups provided will be added on top of the current set of quota
-// groups in the state, and verified for consistency before committed to state.
-// When adding sub-groups, both the parent and the sub-group must be added at
-// once since the sub-group needs to reference the parent group and vice versa
-// to be fully consistent.
+// groups. The groups provided will replace group states if present or be added
+// on top of the current set of quota groups in the state, and verified for
+// consistency before committed to state. When adding sub-groups, both the
+// parent and the sub-group must be added at once since the sub-group needs to
+// reference the parent group and vice versa to be fully consistent.
 func UpdateQuotas(st *state.State, grps ...*quota.Group) error {
 	// get the current set of quotas
 	allGrps, err := AllQuotas(st)

--- a/overlord/servicestate/quotas.go
+++ b/overlord/servicestate/quotas.go
@@ -1,0 +1,117 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package servicestate
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap/quota"
+)
+
+// AllQuotas returns all currently tracked quota groups in the state. They are
+// validated for consistency before returned and internally updated using
+// ResolveCrossReferences before returned.
+func AllQuotas(st *state.State) (map[string]*quota.Group, error) {
+	var quotas map[string]*quota.Group
+	if err := st.Get("quotas", &quotas); err != nil {
+		if err != state.ErrNoState {
+			return nil, err
+		}
+		// otherwise there are no quotas so just return nil
+		return nil, nil
+	}
+
+	// quota groups are not serialized with all the necessary tracking
+	// information in the objects, so we need to thread some things around
+	if err := quota.ResolveCrossReferences(quotas); err != nil {
+		return nil, err
+	}
+
+	// quotas has now been properly initialized with unexported cross-references
+	return quotas, nil
+}
+
+// GetQuota returns an individual quota group by name.
+func GetQuota(st *state.State, name string) (*quota.Group, error) {
+	allGrps, err := AllQuotas(st)
+	if err != nil {
+		return nil, err
+	}
+
+	// if the referenced group does not exist we return a nil group
+	return allGrps[name], nil
+}
+
+// UpdateQuotas will update the state quota group map with the provided quota
+// groups. The groups provided will be added on top of the current set of quota
+// groups in the state, and verified for consistency before committed to state.
+// When adding sub-groups, both the parent and the sub-group must be added at
+// once since the sub-group needs to reference the parent group and vice versa
+// to be fully consistent.
+func UpdateQuotas(st *state.State, grps ...*quota.Group) error {
+	// get the current set of quotas
+	allGrps, err := AllQuotas(st)
+	if err != nil {
+		// AllQuotas() can't return ErrNoState, in that case it just returns a
+		// nil map, which we handle below
+		return err
+	}
+	if allGrps == nil {
+		allGrps = make(map[string]*quota.Group)
+	}
+
+	// handle trivial case here to prevent panics below
+	if len(grps) == 0 {
+		return nil
+	}
+
+	sort.SliceStable(grps, func(i, j int) bool {
+		return grps[i].Name < grps[j].Name
+	})
+
+	// add to the temporary state map
+	for _, grp := range grps {
+		allGrps[grp.Name] = grp
+	}
+
+	// make sure the full set is still resolved before saving it - this prevents
+	// easy errors like trying to add a sub-group quota without updating the
+	// parent with references to the sub-group, for cases like those, all
+	// related groups must be updated at the same time in one operation to
+	// prevent having inconsistent quota groups in state.json
+	if err := quota.ResolveCrossReferences(allGrps); err != nil {
+		// make a nice error message for this case
+		updated := ""
+		for _, grp := range grps[:len(grps)-1] {
+			updated += fmt.Sprintf("%q, ", grp.Name)
+		}
+		updated += fmt.Sprintf("%q", grps[len(grps)-1].Name)
+		plural := ""
+		if len(grps) > 1 {
+			plural = "s"
+		}
+		return fmt.Errorf("cannot update quota%s %s: %v", plural, updated, err)
+	}
+
+	st.Set("quotas", allGrps)
+	return nil
+}

--- a/overlord/servicestate/quotas_test.go
+++ b/overlord/servicestate/quotas_test.go
@@ -1,0 +1,123 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package servicestate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/snap/quota"
+)
+
+type servicestateQuotasSuite struct {
+	baseServiceMgrTestSuite
+}
+
+var _ = Suite(&servicestateQuotasSuite{})
+
+func (s *servicestateQuotasSuite) SetUpTest(c *C) {
+	s.baseServiceMgrTestSuite.SetUpTest(c)
+
+	// we don't need the EnsureSnapServices ensure loop to run by default
+	servicestate.MockEnsuredSnapServices(s.mgr, true)
+}
+
+func (s *servicestateQuotasSuite) TestQuotas(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// with nothing in state we don't get any quotas
+	quotaMap, err := servicestate.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(quotaMap, HasLen, 0)
+
+	// we can add some basic quotas to state
+	grp := &quota.Group{
+		Name:        "foogroup",
+		MemoryLimit: quantity.SizeGiB,
+	}
+	err = servicestate.UpdateQuotas(st, grp)
+	c.Assert(err, IsNil)
+
+	// now we get back the same quota
+	quotaMap, err = servicestate.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(quotaMap, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+	})
+
+	// adding a sub-group quota only works when we update the parent group to
+	// reference the sub-group at the same time
+	grp2 := &quota.Group{
+		Name:        "group-2",
+		MemoryLimit: quantity.SizeGiB,
+		ParentGroup: "foogroup",
+	}
+	err = servicestate.UpdateQuotas(st, grp2)
+	c.Assert(err, ErrorMatches, `cannot update quota "group-2": group "foogroup" does not reference necessary child group "group-2"`)
+
+	// we also can't add a sub-group to the parent without adding the sub-group
+	// itself
+	grp.SubGroups = append(grp.SubGroups, "group-2")
+	err = servicestate.UpdateQuotas(st, grp)
+	c.Assert(err, ErrorMatches, `cannot update quota "foogroup": missing group "group-2" referenced as the sub-group of group "foogroup"`)
+
+	// foogroup didn't get updated in the state to mention the sub-group
+	foogrp, err := servicestate.GetQuota(st, "foogroup")
+	c.Assert(err, IsNil)
+	c.Assert(foogrp.SubGroups, HasLen, 0)
+
+	// but if we update them both at the same time we succeed
+	err = servicestate.UpdateQuotas(st, grp, grp2)
+	c.Assert(err, IsNil)
+
+	// and now we see both in the state
+	quotaMap, err = servicestate.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(quotaMap, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+		"group-2":  grp2,
+	})
+
+	// and we can get individual quotas too
+	res, err := servicestate.GetQuota(st, "foogroup")
+	c.Assert(err, IsNil)
+	c.Assert(res, DeepEquals, grp)
+
+	res2, err := servicestate.GetQuota(st, "group-2")
+	c.Assert(err, IsNil)
+	c.Assert(res2, DeepEquals, grp2)
+
+	// adding multiple quotas that are invalid produces a nice error message
+	otherGrp := &quota.Group{
+		Name: "other-group",
+		// invalid memory limit
+	}
+
+	otherGrp2 := &quota.Group{
+		Name: "other-group2",
+		// invalid memory limit
+	}
+
+	err = servicestate.UpdateQuotas(st, otherGrp2, otherGrp)
+	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group" is invalid: group memory limit must be non-zero`)
+}


### PR DESCRIPTION
* Add AllQuotas for getting all quotas from the state
* Add GetQuota for getting an individual quota group from the state by name
* Add UpdateQuotas for updating one or many quotas in the state in a single 
  transaction
* Add some units for this, including refactoring to share some of the overlord
  setup with the servicemgr_test.go tests via baseServiceMgrTestSuite

This is orthogonal to https://github.com/snapcore/snapd/pull/10198