### PR TITLE
spread.yaml: update the gce project to start using snapd-spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -75,7 +75,7 @@ environment:
 backends:
     google:
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: computeengine/us-east1-b
+        location: snapd-spread/us-east1-b
         halt-timeout: 2h
         systems:
             - ubuntu-14.04-64:
@@ -146,7 +146,7 @@ backends:
     google-sru:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: computeengine/us-east1-b
+        location: snapd-spread/us-east1-b
         halt-timeout: 2h
         systems:
             - ubuntu-16.04-64:
@@ -161,7 +161,7 @@ backends:
     google-nested:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: computeengine/us-east1-b
+        location: snapd-spread/us-east1-b
         plan: n1-standard-2
         halt-timeout: 2h
         systems:


### PR DESCRIPTION
The compueengine project will be disable and the new project is snapd-spread under canonical organization.
