### PR TITLE
tests: new buckets for snapd-spread project on gce

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -226,19 +226,19 @@ nested_qemu_name() {
 nested_get_google_image_url_for_vm() {
     case "${1:-$SPREAD_SYSTEM}" in
         ubuntu-16.04-64)
-            echo "https://storage.googleapis.com/spread-snapd-tests/images/cloudimg/xenial-server-cloudimg-amd64-disk1.img"
+            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/xenial-server-cloudimg-amd64-disk1.img"
             ;;
         ubuntu-18.04-64)
-            echo "https://storage.googleapis.com/spread-snapd-tests/images/cloudimg/bionic-server-cloudimg-amd64.img"
+            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/bionic-server-cloudimg-amd64.img"
             ;;
         ubuntu-20.04-64)
-            echo "https://storage.googleapis.com/spread-snapd-tests/images/cloudimg/focal-server-cloudimg-amd64.img"
+            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/focal-server-cloudimg-amd64.img"
             ;;
         ubuntu-20.10-64*)
-            echo "https://storage.googleapis.com/spread-snapd-tests/images/cloudimg/groovy-server-cloudimg-amd64.img"
+            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/groovy-server-cloudimg-amd64.img"
             ;;
         ubuntu-21.04-64*)
-            echo "https://storage.googleapis.com/spread-snapd-tests/images/cloudimg/hirsute-server-cloudimg-amd64.img"
+            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/hirsute-server-cloudimg-amd64.img"
             ;;
         *)
             echo "unsupported system"

--- a/tests/nested/manual/snapd-refresh-from-old/task.yaml
+++ b/tests/nested/manual/snapd-refresh-from-old/task.yaml
@@ -13,8 +13,8 @@ environment:
   VARIANT/edge_first: edge_first
   NESTED_BUILD_SNAPD_FROM_CURRENT: false
   NESTED_IMAGE_ID: snapd-refresh-from-old
-  SNAPD_SNAP_URL: https://storage.googleapis.com/spread-snapd-tests/snaps/snapd_2.45.2_5760.snap
-  CORE18_SNAP_URL: https://storage.googleapis.com/spread-snapd-tests/snaps/core18_20191126_1279.snap
+  SNAPD_SNAP_URL: https://storage.googleapis.com/snapd-spread-tests/snaps/snapd_2.45.2_5760.snap
+  CORE18_SNAP_URL: https://storage.googleapis.com/snapd-spread-tests/snaps/core18_20191126_1279.snap
 
 prepare: |
   #shellcheck source=tests/lib/nested.sh


### PR DESCRIPTION
There are new data buckets in the new project in gce
 snapd-spread-tests (used to store tests data) and snapd-spread-images (used to store spread images)