### PR TITLE
o/servicestate/quota_control.go: introduce basic group manipulation methods

### DIFF
--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -174,7 +174,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 
 	grp.Snaps = []string{"test-snap"}
 
-	err = servicestate.UpdateQuotas(s.state, grp)
+	_, err = servicestate.PatchQuotasState(s.state, grp)
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -1,0 +1,344 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package servicestate
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/quota"
+	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/wrappers"
+)
+
+func ensureSnapServicesForGroup(st *state.State, grp *quota.Group, allGrps map[string]*quota.Group) error {
+	// build the map of snap infos to options to provide to EnsureSnapServices
+	snapSvcMap := map[*snap.Info]*wrappers.SnapServiceOptions{}
+	for _, sn := range grp.Snaps {
+		info, err := snapstate.CurrentInfo(st, sn)
+		if err != nil {
+			return err
+		}
+
+		opts, err := SnapServiceOptions(st, sn, allGrps)
+		if err != nil {
+			return err
+		}
+
+		snapSvcMap[info] = opts
+	}
+
+	ensureOpts := &wrappers.EnsureSnapServicesOptions{
+		Preseeding: snapdenv.Preseeding(),
+	}
+
+	// set RequireMountedSnapdSnap if we are on UC18+ only
+	deviceCtx, err := snapstate.DeviceCtx(st, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	if !deviceCtx.Classic() && deviceCtx.Model().Base() != "" {
+		ensureOpts.RequireMountedSnapdSnap = true
+	}
+
+	// TODO: do we need to restart modified services ?
+	return wrappers.EnsureSnapServices(snapSvcMap, ensureOpts, nil, progress.Null)
+}
+
+// CreateQuota attempts to create the specified quota group with the specified
+// snaps in it.
+// TODO: should this use something like QuotaGroupUpdate with fewer fields?
+func (mgr *ServiceManager) CreateQuota(name string, parentName string, snaps []string, memoryLimit quantity.Size) error {
+	st := mgr.state
+	st.Lock()
+	defer st.Unlock()
+
+	// ensure that the quota group exists
+	allGrps, err := AllQuotas(st)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := allGrps[name]; ok {
+		return fmt.Errorf("group %q already exists", name)
+	}
+
+	// make sure the specified snaps exist and aren't currently in another group
+	for _, sn := range snaps {
+		if err := validateSnapForAddingToGroup(st, sn, allGrps); err != nil {
+			return fmt.Errorf("cannot use snap %q in group %q: %v", sn, name, err)
+		}
+	}
+
+	// make sure that the parent group exists if we are creating a sub-group
+	var grp, parentGrp *quota.Group
+	if parentName != "" {
+		var ok bool
+		parentGrp, ok = allGrps[parentName]
+		if !ok {
+			return fmt.Errorf("cannot create group under non-existent parent group %q", parentName)
+		}
+
+		grp, err = parentGrp.NewSubGroup(name, memoryLimit)
+		if err != nil {
+			return err
+		}
+	} else {
+		// make a new group
+		grp, err = quota.NewGroup(name, memoryLimit)
+		if err != nil {
+			return err
+		}
+	}
+
+	// put the snaps in the group
+	grp.Snaps = snaps
+
+	updatedGrps := []*quota.Group{grp}
+	if parentName != "" {
+		updatedGrps = append(updatedGrps, parentGrp)
+	}
+
+	// update the modified groups in state
+	allGrps, err = PatchQuotasState(st, updatedGrps...)
+	if err != nil {
+		return err
+	}
+
+	// ensure the snap services with the group
+	if err := ensureSnapServicesForGroup(st, grp, allGrps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RemoveQuota deletes the specific quota group.
+// TODO: currently this only supports removing leaf sub-group groups, it doesn't
+// support removing parent quotas, but probably it makes sense to allow that too
+func (mgr *ServiceManager) RemoveQuota(name string) error {
+	st := mgr.state
+	st.Lock()
+	defer st.Unlock()
+
+	allGrps, err := AllQuotas(st)
+	if err != nil {
+		return err
+	}
+
+	// first get the group for later before it is deleted from state
+	grp, ok := allGrps[name]
+	if !ok {
+		return fmt.Errorf("cannot remove non-existent quota group %q", name)
+	}
+
+	// XXX: remove this limitation eventually
+	if len(grp.SubGroups) != 0 {
+		return fmt.Errorf("cannot remove quota group with sub-groups, remove the sub-groups first")
+	}
+
+	// now delete the group from state - do this first for convenience to ensure
+	// that we can just use SnapServiceOptions below and since it operates via
+	// state, it will immediately reflect the deletion
+	delete(allGrps, name)
+	st.Set("quotas", allGrps)
+
+	if err := ensureSnapServicesForGroup(st, grp, allGrps); err != nil {
+		return err
+	}
+
+	// separately delete the slice unit, EnsureSnapServices does not do this for
+	// us
+	if err := wrappers.RemoveQuotaGroup(grp, progress.Null); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateSnapForAddingToGroup(st *state.State, name string, allGrps map[string]*quota.Group) error {
+	// validate that the snap exists
+	_, err := snapstate.CurrentInfo(st, name)
+	if err != nil {
+		return err
+	}
+
+	// check that the snap is not already in a group
+	for _, grp := range allGrps {
+		if strutil.ListContains(grp.Snaps, name) {
+			return fmt.Errorf("snap already in quota group %q", grp.Name)
+		}
+	}
+	return nil
+}
+
+// QuotaGroupUpdate reflects all of the modifications that can be performed on
+// a quota group in one operation.
+type QuotaGroupUpdate struct {
+	// AddSnaps is the set of snaps to add to the quota group. These are
+	// instance names of snaps, and either are appended to the existing snaps in
+	// the quota group or fully replace the existing set of snaps in the quota
+	// group depending on the ReplaceSnaps setting.
+	AddSnaps []string
+
+	// NewMemoryLimit is the new memory limit to be used for the quota group. If
+	// zero, then the quota group's memory limit is not changed.
+	NewMemoryLimit quantity.Size
+
+	// ReplaceSnaps is whether or not the AddSnaps field replaces the existing
+	// list of snaps in the quota group or not. By default with this setting
+	// false, snaps in AddSnaps are appended to the existing list of snaps in
+	// the quota group.
+	ReplaceSnaps bool
+
+	// NewParentGroup is the new parent group to move this quota group
+	// underneath as a sub-group.
+	NewParentGroup string
+
+	// OrphanSubGroup is whether or not to move the group out from underneath
+	// the existing parent group as it's own group without a parent.
+	OrphanSubGroup bool
+}
+
+// UpdateQuota updates the quota as per the options.
+func (mgr *ServiceManager) UpdateQuota(name string, updateOpts QuotaGroupUpdate) error {
+	st := mgr.state
+	st.Lock()
+	defer st.Unlock()
+
+	// ensure that the quota group exists
+	allGrps, err := AllQuotas(st)
+	if err != nil {
+		return err
+	}
+
+	grp, ok := allGrps[name]
+	if !ok {
+		return fmt.Errorf("group %q does not exist", name)
+	}
+
+	modifiedGrps := []*quota.Group{grp}
+
+	// if we are orphaning this sub-group, make sure it is indeed a sub-group
+	if updateOpts.OrphanSubGroup && grp.ParentGroup == "" {
+		return fmt.Errorf("cannot orphan a sub-group already without a parent")
+	}
+
+	if updateOpts.OrphanSubGroup && updateOpts.NewParentGroup != "" {
+		return fmt.Errorf("cannot both orphan a sub-group and move to a new parent group")
+	}
+
+	if updateOpts.NewParentGroup != "" {
+		if _, ok := allGrps[updateOpts.NewParentGroup]; !ok {
+			return fmt.Errorf("cannot move quota group %q to non-existent parent group %q", name, updateOpts.NewParentGroup)
+		}
+	}
+
+	// now ensure that all of the snaps mentioned in AddSnaps exist as snaps and
+	// that they aren't already in an existing quota group
+	for _, sn := range updateOpts.AddSnaps {
+		if err := validateSnapForAddingToGroup(st, name, allGrps); err != nil {
+			return fmt.Errorf("cannot add snap %q to group %q: %v", sn, name, err)
+		}
+	}
+
+	// either update or append the snaps list in the group
+	if updateOpts.ReplaceSnaps {
+		grp.Snaps = updateOpts.AddSnaps
+	} else {
+		grp.Snaps = append(grp.Snaps, updateOpts.AddSnaps...)
+	}
+
+	// if the memory limit is not zero then change it too
+	if updateOpts.NewMemoryLimit != 0 {
+		grp.MemoryLimit = updateOpts.NewMemoryLimit
+	}
+
+	if updateOpts.OrphanSubGroup {
+		// orphaning
+
+		// then we need to get the parent group and remove the links for the
+		// parent group from that one
+
+		oldParent, ok := allGrps[grp.ParentGroup]
+		if !ok {
+			return fmt.Errorf("internal error: existing parent group %q of group %q does not exist", grp.ParentGroup, name)
+		}
+
+		// remove the group from the parent's sub-groups
+		newSubGroups := make([]string, 0, len(oldParent.SubGroups))
+		for _, sub := range oldParent.SubGroups {
+			if sub != name {
+				newSubGroups = append(newSubGroups, sub)
+			}
+		}
+
+		oldParent.SubGroups = newSubGroups
+		grp.ParentGroup = ""
+
+		modifiedGrps = append(modifiedGrps, oldParent)
+	} else if updateOpts.NewParentGroup != "" {
+		// adoption
+
+		// first check if the existing group already has a parent, in which case
+		// we need to remove it from that one and include that group in the list
+		// of modified groups to patch state with
+		if grp.ParentGroup != "" {
+			origParent, ok := allGrps[grp.ParentGroup]
+			if !ok {
+				return fmt.Errorf("internal error: existing parent group %q to group %q not found", grp.ParentGroup, name)
+			}
+
+			// remove this group as a sub-group from the original parent
+			newSubGroups := make([]string, 0, len(origParent.SubGroups))
+			for _, sub := range origParent.SubGroups {
+				if sub != name {
+					newSubGroups = append(newSubGroups, sub)
+				}
+			}
+
+			origParent.SubGroups = newSubGroups
+
+			modifiedGrps = append(modifiedGrps, origParent)
+		}
+
+		// get the new parent and set it up
+		newParent := allGrps[updateOpts.NewParentGroup]
+		newParent.SubGroups = append(newParent.SubGroups, name)
+		grp.ParentGroup = updateOpts.NewParentGroup
+
+		modifiedGrps = append(modifiedGrps, newParent)
+	}
+
+	// update the quota group state
+	allGrps, err = PatchQuotasState(st, modifiedGrps...)
+	if err != nil {
+		return err
+	}
+
+	// ensure service states are updated
+	return ensureSnapServicesForGroup(st, grp, allGrps)
+}

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -1,0 +1,200 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package servicestate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	_ "github.com/snapcore/snapd/overlord/devicestate"
+	_ "github.com/snapcore/snapd/overlord/state"
+
+	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/snap/snaptest"
+)
+
+type quotaControlSuite struct {
+	baseServiceMgrTestSuite
+}
+
+var _ = Suite(&quotaControlSuite{})
+
+func (s *quotaControlSuite) SetUpTest(c *C) {
+	s.baseServiceMgrTestSuite.SetUpTest(c)
+
+	// we don't need the EnsureSnapServices ensure loop to run by default
+	servicestate.MockEnsuredSnapServices(s.mgr, true)
+}
+
+func (s *quotaControlSuite) TestCreateQuota(c *C) {
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			// called for new slice unit written by CreateQuota after we create
+			// the snap in state
+			expArgs: []string{"daemon-reload"},
+		},
+	})
+	defer r()
+
+	// trying to create a quota with a snap that doesn't exist fails
+
+	err := s.mgr.CreateQuota("foo", "", []string{"test-snap"}, quantity.SizeGiB)
+	c.Assert(err, ErrorMatches, `cannot use snap "test-snap" in group "foo": snap "test-snap" is not installed`)
+
+	st := s.state
+	st.Lock()
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	st.Unlock()
+
+	// now we can create the quota group
+	err = s.mgr.CreateQuota("foo", "", []string{"test-snap"}, quantity.SizeGiB)
+	c.Assert(err, IsNil)
+
+	// we can't add the same snap to a different group though
+	err = s.mgr.CreateQuota("foo2", "", []string{"test-snap"}, quantity.SizeGiB)
+	c.Assert(err, ErrorMatches, `cannot use snap "test-snap" in group "foo2": snap already in quota group "foo"`)
+
+	// check that the quota groups were created in the state
+	st.Lock()
+	defer st.Unlock()
+	m, err := servicestate.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(m, HasLen, 1)
+	for name, grp := range m {
+		switch name {
+		case "foo":
+			c.Assert(grp.Snaps, DeepEquals, []string{"test-snap"})
+			c.Assert(grp.SubGroups, HasLen, 0)
+			c.Assert(grp.ParentGroup, Equals, "")
+		default:
+			c.Errorf("unexpected group %q in state", name)
+		}
+	}
+}
+
+func (s *quotaControlSuite) TestCreateSubGroupQuota(c *C) {
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			// called for new slice unit written by CreateQuota after we create
+			// the snap in state
+			expArgs: []string{"daemon-reload"},
+		},
+	})
+	defer r()
+
+	st := s.state
+	st.Lock()
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	st.Unlock()
+
+	// create a quota group with no snaps to be the parent
+	err := s.mgr.CreateQuota("foo", "", nil, quantity.SizeGiB)
+	c.Assert(err, IsNil)
+
+	// now we can create a sub-quota
+	err = s.mgr.CreateQuota("foo2", "foo", []string{"test-snap"}, quantity.SizeGiB)
+	c.Assert(err, IsNil)
+
+	// check that the quota groups were created in the state
+	st.Lock()
+	defer st.Unlock()
+	m, err := servicestate.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(m, HasLen, 2)
+	for name, grp := range m {
+		switch name {
+		case "foo":
+			c.Assert(grp.Snaps, HasLen, 0)
+			c.Assert(grp.SubGroups, DeepEquals, []string{"foo2"})
+			c.Assert(grp.ParentGroup, Equals, "")
+		case "foo2":
+			c.Assert(grp.Snaps, DeepEquals, []string{"test-snap"})
+			c.Assert(grp.SubGroups, HasLen, 0)
+			c.Assert(grp.ParentGroup, Equals, "foo")
+		default:
+			c.Errorf("unexpected group %q in state", name)
+		}
+	}
+}
+
+func (s *quotaControlSuite) TestRemoveQuota(c *C) {
+	r := s.mockSystemctlCalls(c, []expectedSystemctl{
+		{
+			// called for new slice unit written by CreateQuota after we create
+			// the snap in state
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// called for the deleted slice unit from RemoveQuota
+			expArgs: []string{"daemon-reload"},
+		},
+		{
+			// called for the modified service unit files from EnsureSnapServices
+			// TODO: this call should go away?
+			expArgs: []string{"daemon-reload"},
+		},
+	})
+	defer r()
+
+	st := s.state
+	st.Lock()
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	st.Unlock()
+
+	// create a quota
+	err := s.mgr.CreateQuota("foo", "", []string{"test-snap"}, quantity.SizeGiB)
+	c.Assert(err, IsNil)
+
+	// check that the quota groups was created in the state
+	st.Lock()
+	defer st.Unlock()
+	m, err := servicestate.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(m, HasLen, 1)
+	for name, grp := range m {
+		switch name {
+		case "foo":
+			c.Assert(grp.Snaps, DeepEquals, []string{"test-snap"})
+			c.Assert(grp.SubGroups, HasLen, 0)
+			c.Assert(grp.ParentGroup, Equals, "")
+		default:
+			c.Errorf("unexpected group %q in state", name)
+		}
+	}
+
+	// remove the quota from the state
+	st.Unlock()
+	defer st.Lock()
+	err = s.mgr.RemoveQuota("foo")
+	c.Assert(err, IsNil)
+
+	st.Lock()
+	defer st.Unlock()
+	m, err = servicestate.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(m, HasLen, 0)
+}

--- a/overlord/servicestate/quotas_test.go
+++ b/overlord/servicestate/quotas_test.go
@@ -55,8 +55,11 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	err = servicestate.UpdateQuotas(st, grp)
+	newGrps, err := servicestate.PatchQuotasState(st, grp)
 	c.Assert(err, IsNil)
+	c.Assert(newGrps, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+	})
 
 	// now we get back the same quota
 	quotaMap, err = servicestate.AllQuotas(st)
@@ -72,13 +75,13 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 		MemoryLimit: quantity.SizeGiB,
 		ParentGroup: "foogroup",
 	}
-	err = servicestate.UpdateQuotas(st, grp2)
+	_, err = servicestate.PatchQuotasState(st, grp2)
 	c.Assert(err, ErrorMatches, `cannot update quota "group-2": group "foogroup" does not reference necessary child group "group-2"`)
 
 	// we also can't add a sub-group to the parent without adding the sub-group
 	// itself
 	grp.SubGroups = append(grp.SubGroups, "group-2")
-	err = servicestate.UpdateQuotas(st, grp)
+	_, err = servicestate.PatchQuotasState(st, grp)
 	c.Assert(err, ErrorMatches, `cannot update quota "foogroup": missing group "group-2" referenced as the sub-group of group "foogroup"`)
 
 	// foogroup didn't get updated in the state to mention the sub-group
@@ -87,8 +90,12 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 	c.Assert(foogrp.SubGroups, HasLen, 0)
 
 	// but if we update them both at the same time we succeed
-	err = servicestate.UpdateQuotas(st, grp, grp2)
+	newGrps, err = servicestate.PatchQuotasState(st, grp, grp2)
 	c.Assert(err, IsNil)
+	c.Assert(newGrps, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+		"group-2":  grp2,
+	})
 
 	// and now we see both in the state
 	quotaMap, err = servicestate.AllQuotas(st)
@@ -118,7 +125,7 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 		// invalid memory limit
 	}
 
-	err = servicestate.UpdateQuotas(st, otherGrp2, otherGrp)
+	_, err = servicestate.PatchQuotasState(st, otherGrp2, otherGrp)
 	// either group can get checked first
 	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: group memory limit must be non-zero`)
 }

--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -56,6 +56,12 @@ type baseServiceMgrTestSuite struct {
 
 	restartRequests []state.RestartType
 	restartObserve  func()
+
+	uc18Model *asserts.Model
+	uc16Model *asserts.Model
+
+	testSnapState    *snapstate.SnapState
+	testSnapSideInfo *snap.SideInfo
 }
 
 func (s *baseServiceMgrTestSuite) SetUpTest(c *C) {
@@ -91,6 +97,43 @@ func (s *baseServiceMgrTestSuite) SetUpTest(c *C) {
 	s.state.Lock()
 	s.state.Set("seeded", true)
 	s.state.Unlock()
+
+	s.uc18Model = assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "canonical",
+		"series":       "16",
+		"brand-id":     "canonical",
+		"model":        "pc",
+		"gadget":       "pc",
+		"kernel":       "kernel",
+		"architecture": "amd64",
+		"base":         "core18",
+	}).(*asserts.Model)
+
+	s.uc16Model = assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "canonical",
+		"series":       "16",
+		"brand-id":     "canonical",
+		"model":        "pc",
+		"gadget":       "pc",
+		"kernel":       "kernel",
+		"architecture": "amd64",
+		// no base
+	}).(*asserts.Model)
+
+	// by default mock that we are uc18
+	s.AddCleanup(snapstatetest.MockDeviceModel(s.uc18Model))
+
+	// setup a test-snap with a service that can be easily injected into
+	// snapstate to be setup as needed
+	s.testSnapSideInfo = &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
+	s.testSnapState = &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{s.testSnapSideInfo},
+		Current:  snap.R(42),
+		Active:   true,
+		SnapType: "app",
+	}
 }
 
 type expectedSystemctl struct {
@@ -101,12 +144,6 @@ type expectedSystemctl struct {
 
 type ensureSnapServiceSuite struct {
 	baseServiceMgrTestSuite
-
-	uc18Model *asserts.Model
-	uc16Model *asserts.Model
-
-	testSnapState    *snapstate.SnapState
-	testSnapSideInfo *snap.SideInfo
 }
 
 var (
@@ -178,7 +215,7 @@ After=usr-lib-snapd.mount
 
 var _ = Suite(&ensureSnapServiceSuite{})
 
-func (s *ensureSnapServiceSuite) mockSystemctlCalls(c *C, expCalls []expectedSystemctl) (restore func()) {
+func (s *baseServiceMgrTestSuite) mockSystemctlCalls(c *C, expCalls []expectedSystemctl) (restore func()) {
 	systemctlCalls := 0
 	r := systemd.MockSystemctl(func(args ...string) ([]byte, error) {
 		if systemctlCalls < len(expCalls) {
@@ -202,43 +239,6 @@ func (s *ensureSnapServiceSuite) mockSystemctlCalls(c *C, expCalls []expectedSys
 
 func (s *ensureSnapServiceSuite) SetUpTest(c *C) {
 	s.baseServiceMgrTestSuite.SetUpTest(c)
-
-	s.uc18Model = assertstest.FakeAssertion(map[string]interface{}{
-		"type":         "model",
-		"authority-id": "canonical",
-		"series":       "16",
-		"brand-id":     "canonical",
-		"model":        "pc",
-		"gadget":       "pc",
-		"kernel":       "kernel",
-		"architecture": "amd64",
-		"base":         "core18",
-	}).(*asserts.Model)
-
-	s.uc16Model = assertstest.FakeAssertion(map[string]interface{}{
-		"type":         "model",
-		"authority-id": "canonical",
-		"series":       "16",
-		"brand-id":     "canonical",
-		"model":        "pc",
-		"gadget":       "pc",
-		"kernel":       "kernel",
-		"architecture": "amd64",
-		// no base
-	}).(*asserts.Model)
-
-	// by default mock that we are uc18
-	s.AddCleanup(snapstatetest.MockDeviceModel(s.uc18Model))
-
-	// setup a test-snap with a service that can be easily injected into
-	// snapstate to be setup as needed
-	s.testSnapSideInfo = &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
-	s.testSnapState = &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{s.testSnapSideInfo},
-		Current:  snap.R(42),
-		Active:   true,
-		SnapType: "app",
-	}
 }
 
 func (s *ensureSnapServiceSuite) TestEnsureSnapServicesNoSnapsDoesNothing(c *C) {

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -312,8 +312,11 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	grp.Snaps = []string{"foosnap"}
 
 	// add it into the state
-	err = servicestate.UpdateQuotas(st, grp)
+	newGrps, err := servicestate.PatchQuotasState(st, grp)
 	c.Assert(err, IsNil)
+	c.Assert(newGrps, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+	})
 
 	opts, err := servicestate.SnapServiceOptions(st, "foosnap", nil)
 	c.Assert(err, IsNil)
@@ -328,8 +331,11 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 
 	// modify state to use an instance name instead now
 	grp.Snaps = []string{"foosnap_instance"}
-	err = servicestate.UpdateQuotas(st, grp)
+	newGrps, err = servicestate.PatchQuotasState(st, grp)
 	c.Assert(err, IsNil)
+	c.Assert(newGrps, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+	})
 
 	// we can still get the quota group using the local map we got before
 	// modifying state

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -801,6 +801,5 @@ apps:
 	_, err = s.be.LinkSnap(info, mockDev, linkCtxWithGroup, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(filepath.Join(dirs.SnapServicesDir, "snap.hello.svc.service"), testutil.FileContains,
-		`Slice=snap.foogroup.slice
-`)
+		"\nSlice=snap.foogroup.slice\n")
 }

--- a/snap/quota/export_test.go
+++ b/snap/quota/export_test.go
@@ -22,3 +22,15 @@ package quota
 func (grp *Group) SetInternalSubGroups(grps []*Group) {
 	grp.subGroups = grps
 }
+
+func (grp *Group) SetInternalParent(parent *Group) {
+	grp.parentGroup = parent
+}
+
+func (grp *Group) InternalSubGroups() []*Group {
+	return grp.subGroups
+}
+
+func (grp *Group) InternalParent() *Group {
+	return grp.parentGroup
+}

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -253,7 +253,6 @@ func ResolveCrossReferences(grps map[string]*Group) error {
 		// now thread any child links from this group to any children
 		if len(grp.SubGroups) != 0 {
 			// re-build the internal sub group list
-			fmt.Println("for group", grp.Name, "Subgroups", grp.SubGroups, "subgroups", grp.subGroups)
 			grp.subGroups = make([]*Group, len(grp.SubGroups))
 			for i, subName := range grp.SubGroups {
 				sub, ok := grps[subName]

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -78,7 +78,7 @@ func NewGroup(name string, memLimit quantity.Size) (*Group, error) {
 		MemoryLimit: memLimit,
 	}
 
-	if err := grp.validate(); err != nil {
+	if err := grp.validate(true); err != nil {
 		return nil, err
 	}
 
@@ -115,7 +115,7 @@ func (grp *Group) SliceFileName() string {
 	return buf.String()
 }
 
-func (grp *Group) validate() error {
+func (grp *Group) validate(internallyResolved bool) error {
 	if err := naming.ValidateQuotaGroup(grp.Name); err != nil {
 		return err
 	}
@@ -145,22 +145,32 @@ func (grp *Group) validate() error {
 		}
 	}
 
-	// check that if this is a sub-group, then the parent group has enough space
-	// to accommodate this new group (we assume that other existing sub-groups
-	// in the parent group have already been validated)
-	if grp.parentGroup != nil {
-		alreadyUsed := quantity.Size(0)
-		for _, child := range grp.parentGroup.subGroups {
-			if child.Name == grp.Name {
-				continue
-			}
-			alreadyUsed += child.MemoryLimit
+	if internallyResolved {
+		if len(grp.subGroups) != len(grp.SubGroups) {
+			return fmt.Errorf("group's sub-groups are not internally resolved")
 		}
-		// careful arithmetic here in case we somehow overflow the max size of
-		// quantity.Size
-		if grp.parentGroup.MemoryLimit-alreadyUsed < grp.MemoryLimit {
-			remaining := grp.parentGroup.MemoryLimit - alreadyUsed
-			return fmt.Errorf("sub-group memory limit of %s is too large to fit inside remaining quota space %s for parent group %s", grp.MemoryLimit.IECString(), remaining.IECString(), grp.parentGroup.Name)
+
+		if (grp.parentGroup == nil) != (grp.ParentGroup == "") {
+			return fmt.Errorf("group's parent group is not internally resolved")
+		}
+
+		// check that if this is a sub-group, then the parent group has enough space
+		// to accommodate this new group (we assume that other existing sub-groups
+		// in the parent group have already been validated)
+		if grp.parentGroup != nil {
+			alreadyUsed := quantity.Size(0)
+			for _, child := range grp.parentGroup.subGroups {
+				if child.Name == grp.Name {
+					continue
+				}
+				alreadyUsed += child.MemoryLimit
+			}
+			// careful arithmetic here in case we somehow overflow the max size of
+			// quantity.Size
+			if grp.parentGroup.MemoryLimit-alreadyUsed < grp.MemoryLimit {
+				remaining := grp.parentGroup.MemoryLimit - alreadyUsed
+				return fmt.Errorf("sub-group memory limit of %s is too large to fit inside remaining quota space %s for parent group %s", grp.MemoryLimit.IECString(), remaining.IECString(), grp.parentGroup.Name)
+			}
 		}
 	}
 
@@ -185,7 +195,7 @@ func (grp *Group) NewSubGroup(name string, memLimit quantity.Size) (*Group, erro
 		return nil, fmt.Errorf("cannot use same name %q for sub group as parent group", name)
 	}
 
-	if err := subGrp.validate(); err != nil {
+	if err := subGrp.validate(true); err != nil {
 		return nil, err
 	}
 
@@ -210,8 +220,8 @@ func ResolveCrossReferences(grps map[string]*Group) error {
 			return fmt.Errorf("group has name %q, but is referenced as %q", grp.Name, name)
 		}
 
-		// validate the group, assuming it is unresolved
-		if err := grp.validate(); err != nil {
+		// validate the group assuming it is not resolved
+		if err := grp.validate(false); err != nil {
 			return fmt.Errorf("group %q is invalid: %v", name, err)
 		}
 
@@ -234,10 +244,16 @@ func ResolveCrossReferences(grps map[string]*Group) error {
 			if !found {
 				return fmt.Errorf("group %q does not reference necessary child group %q", parent.Name, grp.Name)
 			}
+		} else {
+			// there is not a parent group for this group, so clear the parent
+			// reference
+			grp.parentGroup = nil
 		}
 
 		// now thread any child links from this group to any children
 		if len(grp.SubGroups) != 0 {
+			// re-build the internal sub group list
+			fmt.Println("for group", grp.Name, "Subgroups", grp.SubGroups, "subgroups", grp.subGroups)
 			grp.subGroups = make([]*Group, len(grp.SubGroups))
 			for i, subName := range grp.SubGroups {
 				sub, ok := grps[subName]
@@ -253,6 +269,18 @@ func ResolveCrossReferences(grps map[string]*Group) error {
 
 				grp.subGroups[i] = sub
 			}
+		} else {
+			// there are no sub-groups for this group so clear the sub-group
+			// list
+			grp.subGroups = nil
+		}
+	}
+
+	// perform a final validation assuming that all groups are internally
+	// resolved
+	for name, grp := range grps {
+		if err := grp.validate(true); err != nil {
+			return fmt.Errorf("group %q is invalid: %v", name, err)
 		}
 	}
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -592,8 +592,7 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 			genServiceOpts.QuotaGroup = snapSvcOpts.QuotaGroup
 
 			if snapSvcOpts.QuotaGroup != nil {
-				err := neededQuotaGrps.AddAllNecessaryGroups(snapSvcOpts.QuotaGroup)
-				if err != nil {
+				if err := neededQuotaGrps.AddAllNecessaryGroups(snapSvcOpts.QuotaGroup); err != nil {
 					// this error can basically only be a circular reference
 					// in the quota group tree
 					return fmt.Errorf("internal error: %v", err)

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -595,7 +595,7 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 				if err := neededQuotaGrps.AddAllNecessaryGroups(snapSvcOpts.QuotaGroup); err != nil {
 					// this error can basically only be a circular reference
 					// in the quota group tree
-					return fmt.Errorf("internal error: %v", err)
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
cc @stolowski these methods (or something very close to them hopefully) are what the daemon backend will need to use

I still need to write tests for these methods, but wanted to get alignment on the set of functions here... Also was wondering if we should be creating tasks / changes for these operations to match i.e. `snap set` and `snap start`. Arguably we could, but also maybe we want to avoid that complexity.

Based on top of https://github.com/snapcore/snapd/pull/10153