### PR TITLE
o/servicestate: test has internal ordering issues, consider both cases

### DIFF
--- a/overlord/servicestate/quotas_test.go
+++ b/overlord/servicestate/quotas_test.go
@@ -119,5 +119,6 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 	}
 
 	err = servicestate.UpdateQuotas(st, otherGrp2, otherGrp)
-	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group" is invalid: group memory limit must be non-zero`)
+	// either group can get checked first
+	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: group memory limit must be non-zero`)
 }

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -198,6 +198,8 @@ func (grp *Group) NewSubGroup(name string, memLimit quantity.Size) (*Group, erro
 // cross references amongst them using the unexported fields which are not
 // serialized.
 func ResolveCrossReferences(grps map[string]*Group) error {
+	// TODO: consider returning a form of multi-error instead?
+
 	// iterate over all groups, looking for sub-groups which need to be threaded
 	// together with their respective parent groups from the set
 	for name, grp := range grps {


### PR DESCRIPTION
any of the two groups can end up being checked first and produce the error seen

maybe the underlying function should use a multi-error but as we maintain the state there it might be overkill
