### PR TITLE
network-setup-control: add netplan generate D-Bus rules (LP: #1926442)

### DIFF
--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -38,8 +38,6 @@ const networkSetupControlConnectedPlugAppArmor = `
 /usr/sbin/netplan ixr,
 # core18+ has /usr/sbin/netplan as a symlink to this script
 /usr/share/netplan/netplan.script ixr,
-# the C binary is used to generate actual configuration from the YAML
-/usr/lib/netplan/generate Uxr,
 # netplan related files
 /usr/share/netplan/ r,
 /usr/share/netplan/** r,

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -39,7 +39,7 @@ const networkSetupControlConnectedPlugAppArmor = `
 # core18+ has /usr/sbin/netplan as a symlink to this script
 /usr/share/netplan/netplan.script ixr,
 # the C binary is used to generate actual configuration from the YAML
-/usr/lib/netplan/generate ixr,
+/usr/lib/netplan/generate Uxr,
 # netplan related files
 /usr/share/netplan/ r,
 /usr/share/netplan/** r,
@@ -54,11 +54,7 @@ const networkSetupControlConnectedPlugAppArmor = `
 # netplan generate
 /run/ r,
 /run/systemd/network/{,**} r,
-/run/systemd/system/{,**} r,
-/run/systemd/system/systemd-networkd.service.wants/{,**} r,
 /run/systemd/network/*-netplan-* w,
-/run/systemd/system/netplan-* w,
-/run/systemd/system/systemd-networkd.service.wants/netplan-* w,
 /run/NetworkManager/conf.d/{,**} r,
 /run/NetworkManager/conf.d/*netplan*.conf* w,
 

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -63,6 +63,14 @@ const networkSetupControlConnectedPlugAppArmor = `
 
 #include <abstractions/dbus-strict>
 
+# Allow use of Netplan Generate API, used to generate network configuration
+dbus (send)
+	bus=system
+	interface=io.netplan.Netplan
+	path=/io/netplan/Netplan
+	member=Generate
+	peer=(label=unconfined),
+
 # Allow use of Netplan Apply API, used to apply network configuration
 dbus (send)
     bus=system

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -38,6 +38,8 @@ const networkSetupControlConnectedPlugAppArmor = `
 /usr/sbin/netplan ixr,
 # core18+ has /usr/sbin/netplan as a symlink to this script
 /usr/share/netplan/netplan.script ixr,
+# the C binary is used to generate actual configuration from the YAML
+/usr/lib/netplan/generate ixr,
 # netplan related files
 /usr/share/netplan/ r,
 /usr/share/netplan/** r,

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -54,7 +54,11 @@ const networkSetupControlConnectedPlugAppArmor = `
 # netplan generate
 /run/ r,
 /run/systemd/network/{,**} r,
+/run/systemd/system/{,**} r,
+/run/systemd/system/systemd-networkd.service.wants/{,**} r,
 /run/systemd/network/*-netplan-* w,
+/run/systemd/system/netplan-* w,
+/run/systemd/system/systemd-networkd.service.wants/netplan-* w,
 /run/NetworkManager/conf.d/{,**} r,
 /run/NetworkManager/conf.d/*netplan*.conf* w,
 

--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -44,6 +44,12 @@ execute: |
             exit 1
         fi
 
+        echo "Running netplan generate without network-setup-control fails"
+        if netplan-snap.netplan generate; then
+            echo "Expected access denied error for netplan generate"
+            exit 1
+        fi
+
         echo "Count how many network service restarts happened before calling netplan apply"
         stopped_before="$("$TESTSTOOLS"/journal-state get-log -u systemd-networkd | grep -c 'Stopped Network Service.' || true)"
         started_before="$("$TESTSTOOLS"/journal-state get-log -u systemd-networkd | grep -c 'Started Network Service.' || true)"
@@ -56,6 +62,12 @@ execute: |
         echo "Running netplan apply now works"
         if ! netplan-snap.netplan --debug apply; then
             echo "Unexpected error running netplan apply"
+            exit 1
+        fi
+
+        echo "Running netplan generate now works"
+        if ! netplan-snap.netplan generate; then
+            echo "Unexpected error running netplan generate"
             exit 1
         fi
 

--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -44,10 +44,14 @@ execute: |
             exit 1
         fi
 
-        echo "Running netplan generate without network-setup-control fails"
-        if netplan-snap.netplan generate; then
-            echo "Expected access denied error for netplan generate"
-            exit 1
+        if ! os.query is-core16; then
+            echo "Running netplan generate without network-setup-control fails"
+            if netplan-snap.netplan generate; then
+                echo "Expected access denied error for netplan generate"
+                exit 1
+            fi
+        else
+            echo "Skipping netplan generate on UC16"
         fi
 
         echo "Count how many network service restarts happened before calling netplan apply"
@@ -65,10 +69,14 @@ execute: |
             exit 1
         fi
 
-        echo "Running netplan generate now works"
-        if ! netplan-snap.netplan generate; then
-            echo "Unexpected error running netplan generate"
-            exit 1
+        if ! os.query is-core16; then
+            echo "Running netplan generate now works"
+            if ! netplan-snap.netplan generate; then
+                echo "Unexpected error running netplan generate"
+                exit 1
+            fi
+        else
+            echo "Skipping netplan generate on UC16"
         fi
 
         echo "Ensure that network config was stopped and restarted from netplan"

--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -44,7 +44,7 @@ execute: |
             exit 1
         fi
 
-        if ! os.query is-core16; then
+        if ! os.query is-core16 && test "$rel" -ne 16; then
             echo "Running netplan generate without network-setup-control fails"
             if netplan-snap.netplan generate; then
                 echo "Expected access denied error for netplan generate"
@@ -69,7 +69,7 @@ execute: |
             exit 1
         fi
 
-        if ! os.query is-core16; then
+        if ! os.query is-core16 && test "$rel" -ne 16; then
             echo "Running netplan generate now works"
             if ! netplan-snap.netplan generate; then
                 echo "Unexpected error running netplan generate"


### PR DESCRIPTION
Execution of the netplan generator in `/usr/lib/netplan/generate` is prohibited in strictly confined snaps, therefore the `io.netplan.Netplan.Generate()` DBus API was implemented on the neptlan side (https://github.com/canonical/netplan/pull/208).

This new DBus API proxies the call to `netplan generate` and calls it in an unconfined way on the (trusted) system/base side instead.

[LP: #1926442](https://pad.lv/1926442)