### PR TITLE
store/store_download.go: make snapd resilient on slow network

### DIFF
--- a/store/store_download.go
+++ b/store/store_download.go
@@ -50,12 +50,11 @@ import (
 	"github.com/snapcore/snapd/snapdtool"
 )
 
-var downloadRetryStrategy = retry.LimitCount(7, retry.LimitTime(90*time.Second,
-	retry.Exponential{
-		Initial: 500 * time.Millisecond,
-		Factor:  2.5,
-	},
-))
+var downloadRetryStrategy = retry.LimitCount(7, retry.Exponential{
+	Initial: 500 * time.Millisecond,
+	Factor:  2.0,
+},
+)
 
 var downloadSpeedMeasureWindow = 5 * time.Minute
 


### PR DESCRIPTION
Snapd uses `LimitTime(90*time.Second)` as a retry policy. For
this reason, it only recovers from network errors occurring
within initial 90 seconds.

This policy makes snapd unusable on slow network. For example,
suppose that a WFH user, with an intermittent home network,
are trying to do this:

    $ snap install libreoffice

this command can take a few hours. And if any (temporal) network
occurs midway, snapd would just abort the task, throwing away all
the `.partial` snap files it fetched so far.

This removes the LimitTime() policy, so that snapd can recover
from any temporal error on a long downloading task.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>

