### PR TITLE
snap/snaptest: helper that mocks both the squashfs file and a snap directory

### DIFF
--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -238,6 +238,26 @@ func MakeTestSnapInfoWithFiles(c *check.C, snapYamlContent string, files [][]str
 
 }
 
+// MakeSnapFileWithDir makes a squashfs snap file and a directory under
+// /snaps/<snap>/<rev> with the given contents. It's a combined effect of
+// MakeTestSnapInfoWithFiles and MockSnapWithFiles.
+func MakeSnapFileAndDir(c *check.C, snapYamlContent string, files [][]string, si *snap.SideInfo) *snap.Info {
+	info := MockSnapWithFiles(c, snapYamlContent, si, files)
+
+	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	defer restoreSanitize()
+
+	err := osutil.ChDir(info.MountDir(), func() error {
+		snapName, err := pack.Snap(info.MountDir(), &pack.Options{
+			SnapName: info.MountFile(),
+		})
+		c.Check(snapName, check.Equals, info.MountFile())
+		return err
+	})
+	c.Assert(err, check.IsNil)
+	return info
+}
+
 // MustParseChannel parses a string representing a store channel and
 // includes the given architecture, if architecture is "" the system
 // architecture is included. It panics on error.


### PR DESCRIPTION
Introduce a helper that can mock a snap such that both the mount directory of
the snap and the squashfs file can be obtained.