### PR TITLE
interfaces/udisks2: Allow access to the login manager via dbus

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -69,7 +69,7 @@ dbus (receive)
     bus=system
     path=/org/freedesktop/login1
     interface=org.freedesktop.login1.Manager
-    member={PrepareForSleep}
+    member=PrepareForSleep
     peer=(label=unconfined),
 # do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -64,6 +64,20 @@ dbus (send)
     member="GetConnectionUnix{ProcessID,User}"
     peer=(label=unconfined),
 
+# Allow accessing logind services to reinitialise devices on resume
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/login1
+    interface=org.freedesktop.login1.Manager
+    member={PrepareForSleep}
+    peer=(label=unconfined),
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/login1
+    interface=org.freedesktop.login1.Manager
+    member=Inhibit,
+
 # Allow binding the service to the requested connection name
 dbus (bind)
     bus=system


### PR DESCRIPTION
References:
https://forum.snapcraft.io/t/udisks2-interface-extend-permissions/24073
