### PR TITLE
cmd/snap: Fix errors reported by linter

### DIFF
--- a/cmd/snap/cmd_debug_state.go
+++ b/cmd/snap/cmd_debug_state.go
@@ -28,14 +28,13 @@ import (
 	"text/tabwriter"
 
 	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
 type cmdDebugState struct {
 	timeMixin
-
-	st *state.State
 
 	Changes  bool   `long:"changes"`
 	TaskID   string `long:"task"`
@@ -289,7 +288,7 @@ func (c *cmdDebugState) Execute(args []string) error {
 	if c.TaskID != "" {
 		cmds = append(cmds, "--task=")
 	}
-	if c.IsSeeded != false {
+	if c.IsSeeded {
 		cmds = append(cmds, "--is-seeded")
 	}
 	if len(cmds) > 1 {

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -555,7 +555,6 @@ func (iw *infoWriter) maybePrintNotes() {
 	}
 
 	fmt.Fprintf(iw, "  ignore-validation:\t%t\n", iw.localSnap.IgnoreValidation)
-	return
 }
 
 func (iw *infoWriter) maybePrintCohortKey() {

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -95,7 +95,7 @@ func requestLoginWith2faRetry(cli *client.Client, email, password string) error 
 }
 
 func requestLogin(cli *client.Client, email string) error {
-	fmt.Fprint(Stdout, fmt.Sprintf(i18n.G("Password of %q: "), email))
+	fmt.Fprintf(Stdout, i18n.G("Password of %q: "), email)
 	password, err := ReadPassword(0)
 	fmt.Fprint(Stdout, "\n")
 	if err != nil {

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 
 	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/strutil"

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -25,8 +25,9 @@ import (
 	"net/http"
 	"strings"
 
-	main "github.com/snapcore/snapd/cmd/snap"
 	"gopkg.in/check.v1"
+
+	main "github.com/snapcore/snapd/cmd/snap"
 )
 
 type quotaSuite struct {

--- a/cmd/snap/cmd_routine_console_conf.go
+++ b/cmd/snap/cmd_routine_console_conf.go
@@ -26,9 +26,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/snapcore/snapd/client"
-
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 )
 

--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -97,9 +97,9 @@ func splitValidationSetArg(arg string) (account, name string, seq int, err error
 
 func fmtValid(res *client.ValidationSetResult) string {
 	if res.Valid {
-		return fmt.Sprint("valid")
+		return "valid"
 	}
-	return fmt.Sprint("invalid")
+	return "invalid"
 }
 
 func fmtValidationSet(res *client.ValidationSetResult) string {

--- a/cmd/snap/cmd_validate_test.go
+++ b/cmd/snap/cmd_validate_test.go
@@ -55,7 +55,7 @@ func makeFakeValidationSetPostHandler(c *check.C, body, action string, sequence 
 		case sequence != 0 && action == "forget":
 			c.Check(string(buf), check.DeepEquals, fmt.Sprintf("{\"action\":\"forget\",\"sequence\":%d}\n", sequence))
 		case action == "forget":
-			c.Check(string(buf), check.DeepEquals, fmt.Sprintf("{\"action\":\"forget\"}\n"))
+			c.Check(string(buf), check.DeepEquals, "{\"action\":\"forget\"}\n")
 		default:
 			c.Fatalf("unexpected action: %s", action)
 		}


### PR DESCRIPTION
This fixes some of the errors reported for `cmd/snap`. The ones that are left are:

```
cmd/snap/cmd_run.go:114: File is not `gofmt`-ed with `-s` (gofmt)
			"gdbserver": i18n.G("Run the command with gdbserver"),
cmd/snap/cmd_run_test.go:783: File is not `gofmt`-ed with `-s` (gofmt)
		"99", // COMP_TYPE (no change)
		"99", // COMP_KEY (no change)
		"11", // COMP_POINT (+1 because "an-app" is one longer than "alias")
		"2",  // COMP_CWORD (no change)
		" ",  // COMP_WORDBREAKS (no change)
cmd/snap/cmd_debug_timings_test.go:29: File is not `goimports`-ed with -local github.com/snapcore/snapd (goimports)

	"github.com/snapcore/snapd/cmd/snap"
cmd/snap/cmd_validate_test.go:29: File is not `goimports`-ed with -local github.com/snapcore/snapd (goimports)
	"github.com/snapcore/snapd/cmd/snap"
cmd/snap/color_test.go:24: File is not `goimports`-ed with -local github.com/snapcore/snapd (goimports)
	"runtime"
cmd/snap/cmd_wait_test.go:42:3: S1038: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
		fmt.Fprintln(w, fmt.Sprintf(`{"type":"sync", "status-code": 200, "result": {"seed.loaded":%v}}`, n > 1))
		^
cmd/snap/cmd_wait_test.go:152:3: S1038: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
		fmt.Fprintln(w, fmt.Sprintf(`{"type":"sync", "status-code": 200, "result": {"test.value":%v}}`, testValue))
		^
```

but it's not clear to me how (and if!) they should be fixed.