### PR TITLE
cmd/snap-update-ns: fix linter errors

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -72,12 +72,12 @@ var changePerform func(*Change, *Assumptions) ([]*Change, error)
 //
 // The returned path is the location where a mimic should be constructed.
 func mimicRequired(err error) (needsMimic bool, path string) {
-	switch err.(type) {
+	switch err := err.(type) {
 	case *ReadOnlyFsError:
-		rofsErr := err.(*ReadOnlyFsError)
+		rofsErr := err
 		return true, rofsErr.Path
 	case *TrespassingError:
-		tErr := err.(*TrespassingError)
+		tErr := err
 		return true, tErr.ViolatedPath
 	}
 	return false, ""

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"strings"
 	"syscall"
 
 	. "gopkg.in/check.v1"
@@ -747,14 +746,6 @@ func (s *changeSuite) TestNeededChangesParallelInstancesInsideMountNew(c *C) {
 		{Entry: osutil.MountEntry{Dir: "/snap/foo", Name: "/snap/foo_bar", Options: []string{osutil.XSnapdOriginOvername()}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Dir: "/foo/bar/baz"}, Action: update.Mount},
 	})
-}
-
-func mustReadProfile(profileStr string) *osutil.MountProfile {
-	profile, err := osutil.ReadMountProfile(strings.NewReader(profileStr))
-	if err != nil {
-		panic(err)
-	}
-	return profile
 }
 
 func (s *changeSuite) TestRuntimeUsingSymlinksOld(c *C) {


### PR DESCRIPTION
This error has not been addressed:
```
cmd/snap-update-ns/sorting_test.go:20:9: package should be `main_test` instead of `main` (testpackage)
package main
        ^
```
The reason is that if I change the package name as advised, a few symbols are not getting resolved anymore:
```
cmd/snap-update-ns/sorting_test.go:42:12: undeclared name: `byOriginAndMagicDir` (typecheck)
	sort.Sort(byOriginAndMagicDir(entries))
	          ^
cmd/snap-update-ns/sorting_test.go:63:12: undeclared name: `byOriginAndMagicDir` (typecheck)
	sort.Sort(byOriginAndMagicDir(entries))
	          ^
cmd/snap-update-ns/sorting_test.go:89:12: undeclared name: `byOriginAndMagicDir` (typecheck)
	sort.Sort(byOriginAndMagicDir(entries))
	          ^
cmd/snap-update-ns/sorting_test.go:91:12: undeclared name: `byOriginAndMagicDir` (typecheck)
	sort.Sort(byOriginAndMagicDir(entriesRev))
	          ^
cmd/snap-update-ns/sorting_test.go:112:12: undeclared name: `byOriginAndMagicDir` (typecheck)
	sort.Sort(byOriginAndMagicDir(entries))
	          ^
```
Suggestions welcome :-)
