### PR TITLE
asserts: fix errors reported by linter

### DIFF
--- a/asserts/account_test.go
+++ b/asserts/account_test.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/snapcore/snapd/asserts"
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
 )
 
 var (

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -127,7 +127,7 @@ type RevisionError struct {
 func (e *RevisionError) Error() string {
 	if e.Used < 0 || e.Current < 0 {
 		// TODO: message may need tweaking once there's a use.
-		return fmt.Sprintf("assertion revision is unknown")
+		return "assertion revision is unknown"
 	}
 	if e.Used == e.Current {
 		return fmt.Sprintf("revision %d is already the current revision", e.Used)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -43,6 +43,7 @@ func Test(t *testing.T) { TestingT(t) }
 
 var _ = Suite(&openSuite{})
 var _ = Suite(&revisionErrorSuite{})
+var _ = Suite(&isUnacceptedUpdateSuite{})
 
 type openSuite struct{}
 

--- a/asserts/headers.go
+++ b/asserts/headers.go
@@ -274,7 +274,7 @@ func appendEntry(buf *bytes.Buffer, intro string, v interface{}, baseIndent int)
 	case string:
 		buf.WriteByte('\n')
 		buf.WriteString(intro)
-		if strings.IndexRune(x, '\n') != -1 {
+		if strings.ContainsRune(x, '\n') {
 			// multiline value => quote by 4-space indenting
 			buf.WriteByte('\n')
 			pfx := nestingPrefix(baseIndent, multilinePrefix)

--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -517,7 +517,7 @@ type nameMatcher interface {
 
 var (
 	// validates special name constraints like $INTERFACE
-	validSpecialNameConstraint = regexp.MustCompile("^\\$[A-Z][A-Z0-9_]*$")
+	validSpecialNameConstraint = regexp.MustCompile(`^\$[A-Z][A-Z0-9_]*$`)
 )
 
 func compileNameMatcher(whichName string, v interface{}) (nameMatcher, error) {
@@ -599,9 +599,9 @@ func (nc *NameConstraints) Check(whichName, name string, special map[string]stri
 // rules
 
 var (
-	validSnapType  = regexp.MustCompile("^(?:core|kernel|gadget|app)$")
-	validDistro    = regexp.MustCompile("^[-0-9a-z._]+$")
-	validPublisher = regexp.MustCompile("^(?:[a-z0-9A-Z]{32}|[-a-z0-9]{2,28}|\\$[A-Z][A-Z0-9_]*)$") // account ids look like snap-ids or are nice identifiers, support our own special markers $MARKER
+	validSnapType  = regexp.MustCompile(`^(?:core|kernel|gadget|app)$`)
+	validDistro    = regexp.MustCompile(`^[-0-9a-z._]+$`)
+	validPublisher = regexp.MustCompile(`^(?:[a-z0-9A-Z]{32}|[-a-z0-9]{2,28}|\$[A-Z][A-Z0-9_]*)$`) // account ids look like snap-ids or are nice identifiers, support our own special markers $MARKER
 
 	validIDConstraints = map[string]*regexp.Regexp{
 		"slot-snap-type":    validSnapType,

--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -73,8 +73,7 @@ func attrs(yml string) *attrerObject {
 		panic(err)
 	}
 
-	var ao attrerObject
-	ao = info.Plugs["plug"].Attrs
+	ao := attrerObject(info.Plugs["plug"].Attrs)
 	return &ao
 }
 

--- a/asserts/membackstore.go
+++ b/asserts/membackstore.go
@@ -146,7 +146,6 @@ func (br memBSBranch) search(hint []string, found func(Assertion), maxFormat int
 	if down != nil {
 		down.search(hint[1:], found, maxFormat)
 	}
-	return
 }
 
 func (leaf memBSLeaf) search(hint []string, found func(Assertion), maxFormat int) {

--- a/asserts/repair_test.go
+++ b/asserts/repair_test.go
@@ -27,8 +27,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/snapcore/snapd/asserts"
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
 )
 
 var (

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -329,7 +329,6 @@ func (v *ValidationSets) addSnap(sn *asserts.ValidationSetSnap, validationSetKey
 	}
 	// we are left with a combo of required and invalid => conflict
 	cs.presence = presConflict
-	return
 }
 
 // Conflict returns a non-nil error if the combination is in conflict,

--- a/asserts/system_user_test.go
+++ b/asserts/system_user_test.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/snapcore/snapd/asserts"
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
 )
 
 var (


### PR DESCRIPTION
Besides some trivial fixes, this also adds the (previously unused) class
`isUnacceptedUpdateSuite` to the tests suite.
