### PR TITLE
spread: add Fedora 34, leave a TODO about dropping Fedora 32

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -207,8 +207,10 @@ jobs:
         - centos-8-64
         - debian-9-64
         - debian-sid-64
+        # TODO: drop Fedora 32 once it goes EOL on 25.05.2021
         - fedora-32-64
         - fedora-33-64
+        - fedora-34-64
         - opensuse-15.1-64
         - opensuse-15.2-64
         - opensuse-tumbleweed-64

--- a/spread.yaml
+++ b/spread.yaml
@@ -115,9 +115,12 @@ backends:
             - debian-sid-64:
                   workers: 6
 
+            # TODO: drop Fedora 32 once it goes EOL on 25.05.2021
             - fedora-32-64:
                   workers: 6
             - fedora-33-64:
+                  workers: 6
+            - fedora-34-64:
                   workers: 6
 
             - arch-linux-64:


### PR DESCRIPTION
Fedora 34 was released on 24.04.2021, we should add to the test suite.

@sergiocazzolato we'll need an image of Fedora 34, can you look into add it?