### PR TITLE
tests: fix tests expecting cgroup v1/hybrid on openSUSE Tumbleweed

### DIFF
--- a/tests/main/cgroup-devices/task.yaml
+++ b/tests/main/cgroup-devices/task.yaml
@@ -1,6 +1,7 @@
 summary: measuring basic properties of device cgroup
 
-# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which we don't support
-systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-* ]
+# fedora-32, fedora-33, debian-sid, arch, opensuse TW use cgroupv2, which we
+# don't support
+systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-*, -opensuse-tumbleweed-*]
 
 execute: ./task.sh

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -4,9 +4,9 @@ details: |
     This test creates a snap process that suspends itself and ensures that it
     placed into the appropriate hierarchy under the freezer cgroup.
 
-# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which does not support
-# a separate freezer controller
-systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-*]
+# fedora-32, fedora-33, debian-sid, arch, opensuse TW use cgroupv2, which does
+# not support a separate freezer controller
+systems: [ -fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-*, -opensuse-tumbleweed-*]
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh

--- a/tests/main/snap-device-helper-nvme/task.yaml
+++ b/tests/main/snap-device-helper-nvme/task.yaml
@@ -3,8 +3,9 @@ summary: |
   devices by simulating how udev calls snap-device-helper with prototypical 
   paths, including the various types of nvme devices.
 
-# fedora-32, fedora-33, debian-sid, arch use cgroupv2, which we don't support
-systems: [-fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-*]
+# fedora-32, fedora-33, debian-sid, arch, opensuse TW use cgroupv2, which we
+# don't support
+systems: [-fedora-32-*, -fedora-33-*, -debian-sid-*, -arch-*, -opensuse-tumbleweed-*]
 
 execute: |
   # make a fake snap devices cgroup

--- a/tests/main/snapctl-is-connected/task.yaml
+++ b/tests/main/snapctl-is-connected/task.yaml
@@ -12,7 +12,7 @@ execute: |
     local OUT="$1"
     case "$SPREAD_SYSTEM" in
         # special case systems using unified cgroup v2 hierarchy
-        fedora-32-*|fedora-33-*|debian-sid-*|arch-*)
+        fedora-32-*|fedora-33-*|debian-sid-*|arch-*|opensuse-tumbleweed-*)
             echo "$OUT" | MATCH '^WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement$'
             ;;
         *)


### PR DESCRIPTION
OpenSUSE Tumbleweed has been updated to systemd 248 which defaults to cgroup v2
now. Account for that in the tests.

