### PR TITLE
tests: update spread url

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -150,7 +150,7 @@ To run the spread tests locally via QEMU, you need the latest version of
 build tools to build QEMU images with:
 
     $ sudo apt update && sudo apt install -y qemu-kvm autopkgtest
-    $ curl https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz | tar -xz -C $GOPATH/bin
+    $ curl https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xz -C $GOPATH/bin
 
 #### Building spread VM images
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1272,7 +1272,7 @@ nested_get_core_revision_installed() {
 nested_fetch_spread() {
     if [ ! -f "$NESTED_WORK_DIR/spread" ]; then
         mkdir -p "$NESTED_WORK_DIR"
-        curl https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz | tar -xzv -C "$NESTED_WORK_DIR"
+        curl https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xzv -C "$NESTED_WORK_DIR"
         # make sure spread really exists
         test -x "$NESTED_WORK_DIR/spread"
         echo "$NESTED_WORK_DIR/spread"


### PR DESCRIPTION
The old aws url is not longer available, now the spread binary is stored in gce bucket
