### PR TITLE
interfaces/camera: allow devices in /sys/devices/platform/**/usb*

### DIFF
--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -49,6 +49,7 @@ const cameraConnectedPlugAppArmor = `
 /run/udev/data/+usb:* r,
 /sys/class/video4linux/ r,
 /sys/devices/pci**/usb*/**/video4linux/** r,
+/sys/devices/platform/**/usb*/**/video4linux/** r,
 `
 
 var cameraConnectedPlugUDev = []string{


### PR DESCRIPTION
On Arm and embedded platforms, the USB buses are usually under
/sys/devices/platform. This commit allows this type of path.

Some example paths for reference:
 - Raspberry Pi 3b+:
    /sys/devices/platform/soc/3f980000.usb/usb1/1-1/1-1.4/1-1.4:1.0/video4linux/video0
 - Raspberry Pi 4b+:
    /devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1:1.0/video4linux/video0
 - Qualcomm SA8155:
    /sys/devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb1/1-1/1-1:1.0/video4linux/video0
 - NXP i.MX6 Ultralight:
    /sys/devices/platform/soc/2100000.aips-bus/2184000.usb/ci_hdrc.0/usb1/1-1/1-1:1.0/video4linux/video0
