### PR TITLE
interfaces/builtin: introduce raw-input interface

### DIFF
--- a/interfaces/builtin/raw_input.go
+++ b/interfaces/builtin/raw_input.go
@@ -1,0 +1,86 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/udev"
+)
+
+const rawInputSummary = `allows access to raw input devices`
+
+const rawInputBaseDeclarationSlots = `
+  raw-input:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const rawInputConnectedPlugSecComp = `
+# Description: Allow handling input devices.
+# for udev
+bind
+socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
+`
+
+const rawInputConnectedPlugAppArmor = `
+# Description: Allow reading and writing to raw input devices
+
+/dev/input/* rw,
+
+# Allow reading for supported event reports for all input devices. See
+# https://www.kernel.org/doc/Documentation/input/event-codes.txt
+/sys/devices/**/input[0-9]*/capabilities/* r,
+
+# For using udev
+network netlink raw,
+/run/udev/data/c13:[0-9]* r,
+/run/udev/data/+input:input[0-9]* r,
+`
+
+var rawInputConnectedPlugUDev = []string{
+	`KERNEL=="event[0-9]*", SUBSYSTEM=="input"`,
+	`KERNEL=="mice"`,
+	`KERNEL=="mouse[0-9]*"`,
+	`KERNEL=="ts[0-9]*"`,
+}
+
+type rawInputInterface struct {
+	commonInterface
+}
+
+func (iface *rawInputInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.TriggerSubsystem("input")
+	return iface.commonInterface.UDevConnectedPlug(spec, plug, slot)
+}
+
+func init() {
+	registerIface(&rawInputInterface{commonInterface{
+		name:                  "raw-input",
+		summary:               rawInputSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  rawInputBaseDeclarationSlots,
+		connectedPlugSecComp:  rawInputConnectedPlugSecComp,
+		connectedPlugAppArmor: rawInputConnectedPlugAppArmor,
+		connectedPlugUDev:     rawInputConnectedPlugUDev,
+	}})
+}

--- a/interfaces/builtin/raw_input_test.go
+++ b/interfaces/builtin/raw_input_test.go
@@ -1,0 +1,128 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type RawInputInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&RawInputInterfaceSuite{
+	iface: builtin.MustInterface("raw-input"),
+})
+
+const rawInputConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [raw-input]
+`
+
+const rawInputCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  raw-input:
+`
+
+func (s *RawInputInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, rawInputConsumerYaml, nil, "raw-input")
+	s.slot, s.slotInfo = MockConnectedSlot(c, rawInputCoreYaml, nil, "raw-input")
+}
+
+func (s *RawInputInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "raw-input")
+}
+
+func (s *RawInputInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *RawInputInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *RawInputInterfaceSuite) TestSecCompSpec(c *C) {
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "bind\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "socket AF_NETLINK - NETLINK_KOBJECT_UEVENT\n")
+}
+
+func (s *RawInputInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/input/* rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/devices/**/input[0-9]*/capabilities/* r,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/run/udev/data/c13:[0-9]* r,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/run/udev/data/+input:input[0-9]* r,`)
+}
+
+func (s *RawInputInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 5)
+	c.Assert(spec.Snippets(), testutil.Contains, `# raw-input
+KERNEL=="event[0-9]*", SUBSYSTEM=="input", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# raw-input
+KERNEL=="mice", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# raw-input
+KERNEL=="mouse[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# raw-input
+KERNEL=="ts[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.TriggeredSubsystems(), DeepEquals, []string{"input"})
+}
+
+func (s *RawInputInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to raw input devices`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "raw-input")
+}
+
+func (s *RawInputInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *RawInputInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -344,6 +344,9 @@ apps:
   pulseaudio:
     command: bin/run
     plugs: [ pulseaudio ]
+  raw-input:
+    command: bin/run
+    plugs: [ raw-input ]
   raw-usb:
     command: bin/run
     plugs: [ raw-usb ]

--- a/tests/main/interfaces-input/task.yaml
+++ b/tests/main/interfaces-input/task.yaml
@@ -1,0 +1,64 @@
+summary: Ensure that the raw-input interface works.
+
+details: |
+    The raw-input interface allows enumerating, monitoring and reading input devices.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+    # Create device files which are going to be used so simulate a real device and input data
+    # In case the device already exists, it is going to be backed up
+    # Devices used following documentation:
+    # the https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt#L408
+    "$TESTSTOOLS"/fs-state mock-file /dev/input/js31
+    "$TESTSTOOLS"/fs-state mock-file /dev/input/mouse30
+    "$TESTSTOOLS"/fs-state mock-file /run/udev/data/c13:31
+    "$TESTSTOOLS"/fs-state mock-file /run/udev/data/c13:62
+    "$TESTSTOOLS"/fs-state mock-file /run/udev/data/c13:67
+    "$TESTSTOOLS"/fs-state mock-file /dev/input/event67
+
+restore: |
+    # Delete the created device files and restore backed up files
+    "$TESTSTOOLS"/fs-state restore-file /dev/input/js31
+    "$TESTSTOOLS"/fs-state restore-file /dev/input/mouse30
+    "$TESTSTOOLS"/fs-state restore-file /run/udev/data/c13:31
+    "$TESTSTOOLS"/fs-state restore-file /run/udev/data/c13:62
+    "$TESTSTOOLS"/fs-state restore-file /run/udev/data/c13:67
+    "$TESTSTOOLS"/fs-state restore-file /dev/input/event67
+
+execute: |
+    echo "The interface is not connected by default"
+    snap interfaces -i raw-input | MATCH "\\- +test-snapd-sh:raw-input"
+
+    echo "When the interface is connected"
+    snap connect test-snapd-sh:raw-input
+
+    echo "Then the snap is able to access the device input for the old interface"
+    test-snapd-sh.with-input-plug -c "echo test >> /dev/input/js31"
+    test-snapd-sh.with-input-plug -c "echo test >> /dev/input/mouse30"
+    test-snapd-sh.with-input-plug -c "cat /run/udev/data/c13:31"
+    test-snapd-sh.with-input-plug -c "cat /run/udev/data/c13:62"
+
+    echo "Then the snap is able to access the device input for the new interface"
+    test-snapd-sh.with-input-plug -c "cat /run/udev/data/c13:67"
+    test-snapd-sh.with-input-plug -c "echo test >> /dev/input/event67"
+
+    echo "Then the snap is able to read the supported event reports for the input device"
+    capabilities="$(find /sys/devices/ -type d -name capabilities | grep -E "/sys/devices/.*/input[0-9].*/capabilities" | head -n1)"
+    if [ -n "$capabilities" ]; then
+        test-snapd-sh.with-input-plug -c "ls $capabilities"
+    fi
+
+    if [ "$(snap debug confinement)" = partial ] ; then
+        exit 0
+    fi
+
+    echo "When the plug is disconnected"
+    snap disconnect test-snapd-sh:raw-input
+
+    echo "Then the snap is not able to read the input device"
+    if test-snapd-sh.with-input-plug -c "cat /dev/input/mouse30" 2> call.error; then
+        echo "Expected permission error accessing to input device"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error

--- a/tests/main/interfaces-input/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-input/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/interfaces-input/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-input/test-snapd-sh/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: test-snapd-sh
+summary: A no-strings-attached, no-fuss shell for writing tests
+version: 1.0
+
+apps:
+    with-input-plug:
+        command: bin/sh
+        plugs: [raw-input]


### PR DESCRIPTION
Context: https://forum.snapcraft.io/t/what-interface-provides-access-to-dev-input/22657/11

You can use [this libinput snap](https://gitlab.com/mardy/snaps/-/tree/master/libinput/snap) to manually test this interface. The snap runs correctly, but the following denials are found in the audit log:
```
[104642.241275] audit: type=1400 audit(1620727863.291:2670): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/+usb:3-4.1:1.0" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[104642.241399] audit: type=1400 audit(1620727863.291:2671): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/c189:265" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[104642.241559] audit: type=1400 audit(1620727863.291:2672): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/c189:257" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[104642.241603] audit: type=1400 audit(1620727863.291:2673): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/c189:256" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[104642.241688] audit: type=1400 audit(1620727863.291:2674): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/+pci:0000:0b:00.3" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[104642.241753] audit: type=1400 audit(1620727863.291:2675): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/+pci:0000:00:08.1" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[104642.309204] audit: type=1400 audit(1620727863.359:2676): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/+usb:3-4.1:1.1" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[104642.309328] audit: type=1400 audit(1620727863.359:2677): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/c189:265" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[104642.309415] audit: type=1400 audit(1620727863.359:2678): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/c189:257" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[104642.309501] audit: type=1400 audit(1620727863.359:2679): apparmor="DENIED" operation="open" profile="snap.libinput-tool.libinput-debug-events" name="/run/udev/data/c189:256" pid=475087 comm="libinput-debug-" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```