### PR TITLE
boot: reseal given keys when the respective boot chain has changed

### DIFF
--- a/boot/seal.go
+++ b/boot/seal.go
@@ -353,6 +353,7 @@ func resealKeyToModeenvUsingFDESetupHookImpl(rootdir string, model *asserts.Mode
 	return nil
 }
 
+// TODO:UC20: allow more than one model to accommodate the remodel scenario
 func resealKeyToModeenvSecboot(rootdir string, model *asserts.Model, modeenv *Modeenv, expectReseal bool) error {
 	// build the recovery mode boot chain
 	rbl, err := bootloader.Find(InitramfsUbuntuSeedDir, &bootloader.Options{
@@ -447,7 +448,7 @@ func resealKeyToModeenvSecboot(rootdir string, model *asserts.Model, modeenv *Mo
 	}
 	if needed {
 		rpbcJSON, _ := json.Marshal(rpbc)
-		logger.Debugf("resealing (%d) to recovery boot chains: %s", nextCount, rpbcJSON)
+		logger.Debugf("resealing (%d) to recovery boot chains: %s", nextFallbackCount, rpbcJSON)
 
 		if err := resealFallbackObjectKeys(rpbc, authKeyFile, roleToBlName); err != nil {
 			return err
@@ -514,6 +515,8 @@ func resealFallbackObjectKeys(pbc predictableBootChains, authKeyFile string, rol
 	return nil
 }
 
+// TODO:UC20: this needs to take more than one model to accommodate the remodel
+// scenario
 func recoveryBootChainsForSystems(systems []string, trbl bootloader.TrustedAssetsBootloader, model *asserts.Model, modeenv *Modeenv) (chains []bootChain, err error) {
 	for _, system := range systems {
 		// get kernel and gadget information from seed
@@ -674,7 +677,7 @@ func sealKeyModelParams(pbc predictableBootChains, roleToBlName map[bootloader.R
 
 // isResealNeeded returns true when the predictable boot chains provided as
 // input do not match the cached boot chains on disk under rootdir.
-// It also returns the next value for the reasel count that is saved
+// It also returns the next value for the reseal count that is saved
 // together with the boot chains.
 // A hint expectReseal can be provided, it is used when the matching
 // is ambigous because the boot chains contain unrevisioned kernels.

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -329,18 +329,25 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 // TODO:UC20: also test fallback reseal
 func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 	var prevPbc boot.PredictableBootChains
+	var prevRecoveryPbc boot.PredictableBootChains
 
-	for _, tc := range []struct {
-		sealedKeys bool
-		prevPbc    bool
-		resealErr  error
-		err        string
+	for idx, tc := range []struct {
+		sealedKeys       bool
+		reuseRunPbc      bool
+		reuseRecoveryPbc bool
+		resealErr        error
+		err              string
 	}{
 		{sealedKeys: false, resealErr: nil, err: ""},
 		{sealedKeys: true, resealErr: nil, err: ""},
 		{sealedKeys: true, resealErr: errors.New("reseal error"), err: "cannot reseal the encryption key: reseal error"},
-		{prevPbc: true, sealedKeys: true, resealErr: nil, err: ""},
+		{reuseRunPbc: true, reuseRecoveryPbc: true, sealedKeys: true, resealErr: nil, err: ""},
+		// recovery boot chain is unchanged
+		{reuseRunPbc: false, reuseRecoveryPbc: true, sealedKeys: true, resealErr: nil, err: ""},
+		// run boot chain is unchanged
+		{reuseRunPbc: true, reuseRecoveryPbc: false, sealedKeys: true, resealErr: nil, err: ""},
 	} {
+		c.Logf("tc: %v", idx)
 		rootdir := c.MkDir()
 		dirs.SetRootDir(rootdir)
 		defer dirs.SetRootDir("")
@@ -376,8 +383,12 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 			},
 		}
 
-		if tc.prevPbc {
+		if tc.reuseRunPbc {
 			err := boot.WriteBootChains(prevPbc, filepath.Join(dirs.SnapFDEDir, "boot-chains"), 9)
+			c.Assert(err, IsNil)
+		}
+		if tc.reuseRecoveryPbc {
+			err = boot.WriteBootChains(prevRecoveryPbc, filepath.Join(dirs.SnapFDEDir, "recovery-boot-chains"), 9)
 			c.Assert(err, IsNil)
 		}
 
@@ -410,54 +421,38 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 
 			// shared parameters
 			c.Assert(params.ModelParams[0].Model.DisplayName(), Equals, "My Model")
-			switch resealKeysCalls {
-			case 1:
-				c.Assert(params.KeyFiles, DeepEquals, []string{
-					filepath.Join(boot.InitramfsBootEncryptionKeyDir, "ubuntu-data.sealed-key"),
-				})
-				c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
-					"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
-					"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
-				})
-				// load chains
-				c.Assert(params.ModelParams[0].EFILoadChains, HasLen, 6)
-			case 2:
-				c.Assert(params.KeyFiles, DeepEquals, []string{
-					filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-data.recovery.sealed-key"),
-					filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key"),
-				})
-				c.Assert(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
-					"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
-				})
-				// load chains
-				c.Assert(params.ModelParams[0].EFILoadChains, HasLen, 2)
-			default:
-				c.Errorf("unexpected additional call to secboot.ResealKeys (call # %d)", resealKeysCalls)
-			}
 
 			// recovery parameters
 			shim := bootloader.NewBootFile("", filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-1"), bootloader.RoleRecovery)
 			shim2 := bootloader.NewBootFile("", filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/bootx64.efi-shim-hash-2"), bootloader.RoleRecovery)
 			grub := bootloader.NewBootFile("", filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/grubx64.efi-grub-hash-1"), bootloader.RoleRecovery)
 			kernel := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
-
-			c.Assert(params.ModelParams[0].EFILoadChains[:2], DeepEquals, []*secboot.LoadChain{
-				secboot.NewLoadChain(shim,
-					secboot.NewLoadChain(grub,
-						secboot.NewLoadChain(kernel))),
-				secboot.NewLoadChain(shim2,
-					secboot.NewLoadChain(grub,
-						secboot.NewLoadChain(kernel))),
-			})
-
 			// run mode parameters
 			runGrub := bootloader.NewBootFile("", filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-1"), bootloader.RoleRunMode)
 			runGrub2 := bootloader.NewBootFile("", filepath.Join(rootdir, "var/lib/snapd/boot-assets/grub/grubx64.efi-run-grub-hash-2"), bootloader.RoleRunMode)
 			runKernel := bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_500.snap"), "kernel.efi", bootloader.RoleRunMode)
 			runKernel2 := bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_600.snap"), "kernel.efi", bootloader.RoleRunMode)
 
-			switch resealKeysCalls {
-			case 1:
+			checkRunParams := func() {
+				c.Check(params.KeyFiles, DeepEquals, []string{
+					filepath.Join(boot.InitramfsBootEncryptionKeyDir, "ubuntu-data.sealed-key"),
+				})
+				c.Check(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
+					"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+					"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+				})
+				// load chains
+				c.Assert(params.ModelParams[0].EFILoadChains, HasLen, 6)
+				// recovery load chains
+				c.Assert(params.ModelParams[0].EFILoadChains[:2], DeepEquals, []*secboot.LoadChain{
+					secboot.NewLoadChain(shim,
+						secboot.NewLoadChain(grub,
+							secboot.NewLoadChain(kernel))),
+					secboot.NewLoadChain(shim2,
+						secboot.NewLoadChain(grub,
+							secboot.NewLoadChain(kernel))),
+				})
+				// run load chains
 				c.Assert(params.ModelParams[0].EFILoadChains[2:4], DeepEquals, []*secboot.LoadChain{
 					secboot.NewLoadChain(shim,
 						secboot.NewLoadChain(grub,
@@ -493,6 +488,46 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 				})
 			}
 
+			checkRecoveryParams := func() {
+				c.Check(params.KeyFiles, DeepEquals, []string{
+					filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-data.recovery.sealed-key"),
+					filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key"),
+				})
+				c.Check(params.ModelParams[0].KernelCmdlines, DeepEquals, []string{
+					"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+				})
+				// load chains
+				c.Assert(params.ModelParams[0].EFILoadChains, HasLen, 2)
+				// recovery load chains
+				c.Assert(params.ModelParams[0].EFILoadChains[:2], DeepEquals, []*secboot.LoadChain{
+					secboot.NewLoadChain(shim,
+						secboot.NewLoadChain(grub,
+							secboot.NewLoadChain(kernel))),
+					secboot.NewLoadChain(shim2,
+						secboot.NewLoadChain(grub,
+							secboot.NewLoadChain(kernel))),
+				})
+			}
+
+			switch resealKeysCalls {
+			case 1:
+				if !tc.reuseRunPbc {
+					checkRunParams()
+				} else if !tc.reuseRecoveryPbc {
+					checkRecoveryParams()
+				} else {
+					c.Errorf("unexpected call to secboot.ResealKeys (call # %d)", resealKeysCalls)
+				}
+			case 2:
+				if !tc.reuseRecoveryPbc {
+					checkRecoveryParams()
+				} else {
+					c.Errorf("unexpected call to secboot.ResealKeys (call # %d)", resealKeysCalls)
+				}
+			default:
+				c.Errorf("unexpected additional call to secboot.ResealKeys (call # %d)", resealKeysCalls)
+			}
+
 			return tc.resealErr
 		})
 		defer restore()
@@ -503,7 +538,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 		// boot_test.go specific tests
 		const expectReseal = false
 		err = boot.ResealKeyToModeenv(rootdir, model, modeenv, expectReseal)
-		if !tc.sealedKeys || tc.prevPbc {
+		if !tc.sealedKeys || (tc.reuseRunPbc && tc.reuseRecoveryPbc) {
 			// did nothing
 			c.Assert(err, IsNil)
 			c.Assert(resealKeysCalls, Equals, 0)
@@ -515,9 +550,15 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 			c.Assert(err, ErrorMatches, tc.err)
 		}
 		if tc.resealErr != nil {
+			// mocked error is returned on first reseal
 			c.Assert(resealKeysCalls, Equals, 1)
-		} else {
+		} else if !tc.reuseRecoveryPbc && !tc.reuseRunPbc {
+			// none of the boot chains is reused, so 2 reseals are
+			// observed
 			c.Assert(resealKeysCalls, Equals, 2)
+		} else {
+			// one of the boot chains is reused, only one reseal
+			c.Assert(resealKeysCalls, Equals, 1)
 		}
 		if tc.err != "" {
 			continue
@@ -526,8 +567,8 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 		// verify the boot chains data file
 		pbc, cnt, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDir, "boot-chains"))
 		c.Assert(err, IsNil)
-		if tc.prevPbc {
-			c.Assert(cnt, Equals, 10)
+		if tc.reuseRunPbc {
+			c.Assert(cnt, Equals, 9)
 		} else {
 			c.Assert(cnt, Equals, 1)
 		}
@@ -613,6 +654,14 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 			},
 		})
 		prevPbc = pbc
+		recoveryPbc, cnt, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDir, "recovery-boot-chains"))
+		c.Assert(err, IsNil)
+		if tc.reuseRecoveryPbc {
+			c.Check(cnt, Equals, 9)
+		} else {
+			c.Check(cnt, Equals, 1)
+		}
+		prevRecoveryPbc = recoveryPbc
 	}
 }
 


### PR DESCRIPTION
It is possible that only the recovery boot chain will be changed when we add a
tried recovery system to the set of tested recovery systems. In this case, the
reseal of fallback objects should still be carried out, even if the run boot
chain has not changed.
