### PR TITLE
snapstate: do not allow installing the same snap revision via InstallPath

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -182,6 +182,10 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 				return nil, err
 			}
 		}
+
+		if info.Revision == snapsup.Revision() {
+			return nil, fmt.Errorf("snap %q revision %v already installed and current", info.InstanceName(), info.Revision)
+		}
 	}
 
 	ts := state.NewTaskSet()


### PR DESCRIPTION
We got a bugreport that we leave leftover files in
`/var/lib/snapd/snaps/.local-install*` when doing:
```
1. snap download test-snapd-tools
2. snap ack test-snapd-tools_6.assert
3. snap install ./test-snapd-tools_6.snap
4. ls -la /var/lib/snapd/snaps/.lo*
<empty>
5. snap install ./test-snapd-tools_6.snap
6. ls -la /var/lib/snapd/snaps/.lo*
-rw------- 1 root root 8192 Mai 7 21:08 /var/lib/snapd/snaps/.local-install-896758973
```

The issue is that the codepath in doInstall() for asserted snaps that are
already installed will not generate the mount-snap task which is
responsible for the cleanup.

So either we need to resurrect the cleanup task to do this or we generate
an error that the same revision is already installed or current. Given
that it does not make a lot of sense to install the same revision
again if it is already current this commit returns an error.
