### PR TITLE
interfaces/dbus: allow claiming 'well-known' D-Bus names with a wildcard suffix

### DIFF
--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -89,6 +89,13 @@ dbus (bind)
     bus=###DBUS_BUS###
     name=###DBUS_NAME###{_,-}[1-9]{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9]}{,_[1-9]{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9]}},
 
+# For Firefox, support using org.mozilla.firefox.<id> as the 'well-known' name
+# where <id> is the base64-encoded profile name.
+# See https://bugzilla.mozilla.org/1441894 for a discussion and details.
+dbus (bind)
+    bus=###DBUS_BUS###
+    name="###DBUS_NAME###.*",
+
 # Allow us to talk to dbus-daemon
 dbus (receive)
     bus=###DBUS_BUS###

--- a/interfaces/builtin/dbus_test.go
+++ b/interfaces/builtin/dbus_test.go
@@ -303,6 +303,7 @@ func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSession(c *C) {
 
 	// verify individual bind rules
 	c.Check(snippet, testutil.Contains, "dbus (bind)\n    bus=session\n    name=org.test-session-slot,\n")
+	c.Check(snippet, testutil.Contains, "dbus (bind)\n    bus=session\n    name=\"org.test-session-slot.*\",\n")
 
 	// verify individual path in rules
 	c.Check(snippet, testutil.Contains, "path=\"/org/test-session-slot{,/**}\"\n")
@@ -349,6 +350,7 @@ func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSystem(c *C) {
 
 	// verify bind rule
 	c.Check(snippet, testutil.Contains, "dbus (bind)\n    bus=system\n    name=org.test-system-slot,\n")
+	c.Check(snippet, testutil.Contains, "dbus (bind)\n    bus=system\n    name=\"org.test-system-slot.*\",\n")
 
 	// verify path in rule
 	c.Check(snippet, testutil.Contains, "path=\"/org/test-system-slot{,/**}\"\n")


### PR DESCRIPTION
This is to accommodate for Firefox claiming one name per running instance, where the suffix is the base64-encoded profile name (https://bugzilla.mozilla.org/1441894).