### PR TITLE
secboot: switch encryption key size to 32 byte (thanks to Chris)

### DIFF
--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -32,8 +32,7 @@ import (
 const (
 	// The encryption key size is set so it has the same entropy as the derived
 	// key.
-	// XXX Chris suggest we could reduce this to 32?
-	encryptionKeySize = 64
+	encryptionKeySize = 32
 
 	// XXX: needs to be in sync with
 	//      github.com/snapcore/secboot/crypto.go:"type RecoveryKey"

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -107,11 +107,11 @@ execute: |
     # keep for later
 
     echo "Check that the ubuntu-data key files were created"
-    test "$(stat --printf=%s unsealed-key)" -eq 64
+    test "$(stat --printf=%s unsealed-key)" -eq 32
     # recovery key is 16 bytes long
     test "$(stat --printf=%s recovery-key)" -eq 16
     echo "Check that the ubuntu-save key files were created"
-    test "$(stat --printf=%s save-key)" -eq 64
+    test "$(stat --printf=%s save-key)" -eq 32
     # recovery key is 16 bytes long
     test "$(stat --printf=%s reinstall-key)" -eq 16
 


### PR DESCRIPTION
We are using an incorrect size for encryption key in secboot. @chrisccoulson 
mentioned this a while ago and this commit fixes it and moves to
a 32 byte key instead of the 64 byte key.

