### PR TITLE
tests/nested/manual: add test for install-device + snapctl reboot

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1005,14 +1005,19 @@ nested_start_core_vm_unit() {
     # wait for the nested-vm service to appear active
     wait_for_service "$NESTED_VM"
 
-    # Wait until ssh is ready
-    nested_wait_for_ssh
-    # Wait for the snap command to be available
-    nested_wait_for_snap_command
-    # Wait for snap seeding to be done
-    nested_exec "sudo snap wait system seed.loaded"
-    # Wait for cloud init to be done
-    nested_exec "cloud-init status --wait"
+    local EXPECT_SHUTDOWN
+    EXPECT_SHUTDOWN=${NESTED_EXPECT_SHUTDOWN:-}
+
+    if [ "$EXPECT_SHUTDOWN" != "1" ]; then
+        # Wait until ssh is ready
+        nested_wait_for_ssh
+        # Wait for the snap command to be available
+        nested_wait_for_snap_command
+        # Wait for snap seeding to be done
+        nested_exec "sudo snap wait system seed.loaded"
+        # Wait for cloud init to be done
+        nested_exec "cloud-init status --wait"
+    fi
 }
 
 nested_get_current_image_name() {
@@ -1184,7 +1189,8 @@ nested_start_classic_vm() {
     # save logs from previous runs
     nested_save_serial_log
 
-    # Systemd unit is created, it is important to respect the qemu parameters order
+    # Systemd unit is created, it is important to respect the qemu parameters 
+    # order
     systemd_create_and_start_unit "$NESTED_VM" "${QEMU}  \
         ${PARAM_SMP} \
         ${PARAM_CPU} \

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -961,10 +961,10 @@ nested_start_core_vm_unit() {
         fi
 
         if nested_is_tpm_enabled; then
-            if snap list swtpm-mvo; then
+            if snap list swtpm-mvo >/dev/null; then
                 # reset the tpm state
                 rm /var/snap/swtpm-mvo/current/tpm2-00.permall
-                snap restart swtpm-mvo
+                snap restart swtpm-mvo > /dev/null
             else
                 snap install swtpm-mvo --beta
             fi

--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/install-device
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/install-device
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapctl reboot --poweroff

--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -41,6 +41,9 @@ execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
+    #shellcheck source=tests/lib/systemd.sh
+    . "$TESTSLIB/systemd.sh"
+
     # we expect the VM to shut itself down so don't wait for SSH, etc. to become
     # available
     echo "Start the VM, which should automatically shut itself down"
@@ -57,7 +60,7 @@ execute: |
     NESTED_EXPECT_SHUTDOWN=1 nested_start_core_vm_unit "$IMAGE_FILE"
 
     echo "Wait for the VM to become inactive as it installs and shuts itself down"
-    retry -n 200 --wait 1 sh -c '! systemctl is-active nested-vm'
+    wait_for_service "$NESTED_VM" inactive
 
     echo "Check that the partitions were created on the VM's disk"
     sfdisk --json "$IMAGE_FILE" | jq -r '.partitiontable.partitions | .[].name' > partitions.txt

--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -16,8 +16,11 @@ prepare: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
+    tests.cleanup prepare
+
     # needed for inspecting the partitions
     snap install jq
+    tests.cleanup defer snap remove jq
 
     KEY_NAME=$(nested_get_snakeoil_key)
     SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
@@ -36,6 +39,9 @@ prepare: |
     snap pack pc-gadget/ extra-snaps/
 
     "$TESTSTOOLS"/nested-state build-image core
+
+restore: |
+    tests.cleanup restore
 
 execute: |
     #shellcheck source=tests/lib/nested.sh

--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -1,0 +1,91 @@
+summary: Verify snapctl poweroff install-device hook usage
+
+systems: [ubuntu-20.04-64]
+
+environment:
+    NESTED_IMAGE_ID: core20-install-device
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+    NESTED_ENABLE_TPM: true
+    NESTED_ENABLE_SECURE_BOOT: true
+
+details: |
+    This test checks support for shutting down the device at the end of install
+    mode via the install-device hook
+
+prepare: |
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    # needed for inspecting the partitions
+    snap install jq
+
+    KEY_NAME=$(nested_get_snakeoil_key)
+    SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+    SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+
+    echo "Grab and prepare the gadget snap"
+    snap download --basename=pc --channel="20/edge" pc
+    unsquashfs -d pc-gadget pc.snap
+
+    echo "Sign the shim binary"
+    nested_secboot_sign_gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+
+    echo "Add the install-device hook"
+    mkdir -p pc-gadget/meta/hooks
+    cp install-device pc-gadget/meta/hooks/install-device
+    snap pack pc-gadget/ extra-snaps/
+
+    "$TESTSTOOLS"/nested-state build-image core
+
+execute: |
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    # we expect the VM to shut itself down so don't wait for SSH, etc. to become
+    # available
+    echo "Start the VM, which should automatically shut itself down"
+
+    # below is extracted from nested_start_core_vm, we don't want the 
+    # nested_prepare_ssh to run yet, since it will fail when the VM shuts itself
+    # down, we need to manually run it later
+    CURRENT_NAME="$(nested_get_current_image_name)"
+    CURRENT_IMAGE="$NESTED_IMAGES_DIR/$CURRENT_NAME"
+    IMAGE_NAME="$(nested_get_image_name core)"
+    IMAGE_FILE="$NESTED_IMAGES_DIR/$IMAGE_NAME"
+    cp -v "$IMAGE_FILE" "$CURRENT_IMAGE"
+
+    NESTED_EXPECT_SHUTDOWN=1 nested_start_core_vm_unit "$IMAGE_FILE"
+
+    echo "Wait for the VM to become inactive as it installs and shuts itself down"
+    retry -n 200 --wait 1 sh -c '! systemctl is-active nested-vm'
+
+    echo "Check that the partitions were created on the VM's disk"
+    sfdisk --json "$IMAGE_FILE" | jq -r '.partitiontable.partitions | .[].name' > partitions.txt
+    # note that ubuntu-data and ubuntu-save have partition labels without the 
+    # -enc suffix, but have filesystem labels of ubuntu-data-enc etc, here we
+    # are just seeing the partition labels, we check the filesystem labels and
+    # thus whether encryption happened below when the VM boots up
+    MATCH "BIOS Boot" < partitions.txt
+    MATCH "ubuntu-seed" < partitions.txt
+    MATCH "ubuntu-boot" < partitions.txt
+    MATCH "ubuntu-save" < partitions.txt
+    MATCH "ubuntu-data" < partitions.txt
+
+    echo "Now starting the VM again will proceed to run mode appropriately"
+    "$TESTSTOOLS"/nested-state start-vm
+
+    # setup SSH since that was not done with the previous stage, as the device
+    # shut down while still in install mode, we need to manually do this stage
+    nested_prepare_ssh
+
+    # the start-vm command just waits for SSH, it doesn't wait for the other 
+    # things here, so wait for those too
+    nested_wait_for_snap_command
+    # Wait for snap seeding to be done
+    nested_exec "sudo snap wait system seed.loaded"
+    # Wait for cloud init to be done
+    nested_exec "cloud-init status --wait"
+
+    echo "The device is using encrypted ubuntu-data and is in run mode now"
+    nested_exec test -L /dev/disk/by-label/ubuntu-data-enc
+    nested_exec cat /proc/cmdline | MATCH "snapd_recovery_mode=run"


### PR DESCRIPTION
This test exercises the install-device hook with the snapctl reboot command to
create a UC20 device which shuts itself down after install mode has finished,
such that we can then reboot it later on and it proceeds to run mode normally.

This needs a little bit of support in nested.sh and nested-state for VM's that shut
themselves down.