### PR TITLE
interfaces: fix linter issues

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1076,36 +1076,6 @@ profile "snap.foo.hook.configure" (attach_disconnected,mediate_deleted) {
 	s.RemoveSnap(c, snapInfo)
 }
 
-func mockPartalAppArmorOnDistro(c *C, kernelVersion string, releaseID string, releaseIDLike ...string) (restore func()) {
-	restore1 := apparmor_sandbox.MockLevel(apparmor_sandbox.Partial)
-	restore2 := release.MockReleaseInfo(&release.OS{ID: releaseID, IDLike: releaseIDLike})
-	restore3 := osutil.MockKernelVersion(kernelVersion)
-	restore4 := apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
-	restore5 := apparmor.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
-	// Replace the real template with a shorter variant that is easier to test.
-	restore6 := apparmor.MockTemplate("\n" +
-		"###VAR###\n" +
-		"###PROFILEATTACH### (attach_disconnected) {\n" +
-		"###SNIPPETS###\n" +
-		"}\n")
-	restore7 := apparmor.MockClassicTemplate("\n" +
-		"#classic\n" +
-		"###VAR###\n" +
-		"###PROFILEATTACH### (attach_disconnected) {\n" +
-		"###SNIPPETS###\n" +
-		"}\n")
-
-	return func() {
-		restore1()
-		restore2()
-		restore3()
-		restore4()
-		restore5()
-		restore6()
-		restore7()
-	}
-}
-
 const coreYaml = `name: core
 version: 1
 type: os

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -39,9 +39,7 @@ type I2cInterfaceSuite struct {
 	iface interfaces.Interface
 
 	// OS Snap
-	testSlot1           *interfaces.ConnectedSlot
 	testSlot1Info       *snap.SlotInfo
-	testSlotCleaned     *interfaces.ConnectedSlot
 	testSlotCleanedInfo *snap.SlotInfo
 
 	// Gadget Snap
@@ -67,7 +65,6 @@ type I2cInterfaceSuite struct {
 	testUDevBadValue6Info      *snap.SlotInfo
 	testUDevBadValue7          *interfaces.ConnectedSlot
 	testUDevBadValue7Info      *snap.SlotInfo
-	testUDevBadInterface1      *interfaces.ConnectedSlot
 	testUDevBadInterface1Info  *snap.SlotInfo
 	testSysfsNameBadValue1     *interfaces.ConnectedSlot
 	testSysfsNameBadValue1Info *snap.SlotInfo

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -40,8 +40,6 @@ type IioInterfaceSuite struct {
 
 	// OS Snap
 	testSlot1Info       *snap.SlotInfo
-	testSlot2Info       *snap.SlotInfo
-	testSlotCleaned     *interfaces.ConnectedSlot
 	testSlotCleanedInfo *snap.SlotInfo
 
 	// Gadget Snap

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -96,7 +96,6 @@ type SerialPortInterfaceSuite struct {
 	testUDev3Info         *snap.SlotInfo
 	testUDevBadValue1     *interfaces.ConnectedSlot
 	testUDevBadValue1Info *snap.SlotInfo
-	testUDevBadValue2     *interfaces.ConnectedSlot
 	testUDevBadValue2Info *snap.SlotInfo
 	testUDevBadValue3     *interfaces.ConnectedSlot
 	testUDevBadValue3Info *snap.SlotInfo

--- a/interfaces/kmod/backend_test.go
+++ b/interfaces/kmod/backend_test.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/snapcore/snapd/testutil"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
@@ -32,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
 

--- a/interfaces/kmod/kmod_test.go
+++ b/interfaces/kmod/kmod_test.go
@@ -20,11 +20,12 @@
 package kmod_test
 
 import (
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/testutil"
-	. "gopkg.in/check.v1"
 )
 
 type kmodSuite struct {

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -580,8 +580,6 @@ plugs:
 // ATM a nil entry means even stricter rules that would need be tested
 // separately and whose implementation is in flux for now
 var (
-	unconstrained = []string{"core", "kernel", "gadget", "app"}
-
 	slotInstallation = map[string][]string{
 		// other
 		"adb-support":             {"core"},

--- a/interfaces/seccomp/spec.go
+++ b/interfaces/seccomp/spec.go
@@ -52,9 +52,7 @@ func (spec *Specification) Snippets() map[string][]string {
 	result := make(map[string][]string, len(spec.snippets))
 	for k, v := range spec.snippets {
 		vCopy := make([]string, 0, len(v))
-		for _, vElem := range v {
-			vCopy = append(vCopy, vElem)
-		}
+		vCopy = append(vCopy, v...)
 		result[k] = vCopy
 	}
 	return result

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -158,10 +158,7 @@ func (b *Backend) Remove(snapName string) error {
 }
 
 func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (content []string) {
-	for _, snippet := range spec.Snippets() {
-		content = append(content, snippet)
-	}
-
+	content = append(content, spec.Snippets()...)
 	return content
 }
 


### PR DESCRIPTION
Running the linter in the `interfaces/` directory tree.