### PR TITLE
tests: update mount-ns test to support changes in the distro

### DIFF
--- a/tests/main/mount-ns/google.ubuntu-18.04-64/HOST.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/HOST.expected.txt
@@ -1,5 +1,5 @@
 0:0 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
-+0:+1 / /boot/efi rw,relatime shared:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
++0:+1 / /boot/efi rw,relatime shared:+1 - vfat /dev/sda15 rw,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:-1 / /dev rw,nosuid,relatime shared:+1 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime shared:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
 +0:+1 / /dev/mqueue rw,relatime shared:+1 - mqueue mqueue rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
@@ -61,7 +61,7 @@
 +0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw
 +0:+0 / /var/lib/snapd/hostfs rw,relatime master:+0 - ext4 /dev/sda1 rw
 +0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw
-+0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
++0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:+7 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+9 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:+1 - rpc_pipefs sunrpc rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
@@ -62,7 +62,7 @@
 +0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw
 +0:+0 / /var/lib/snapd/hostfs rw,relatime master:+0 - ext4 /dev/sda1 rw
 +0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw
-+0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
++0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:+7 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+9 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:+1 - rpc_pipefs sunrpc rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-C7.expected.txt
@@ -1,5 +1,5 @@
 0:0 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
-+0:+1 / /boot/efi rw,relatime shared:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
++0:+1 / /boot/efi rw,relatime shared:+1 - vfat /dev/sda15 rw,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:-1 / /dev rw,nosuid,relatime shared:+1 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime shared:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
 +0:+1 / /dev/mqueue rw,relatime shared:+1 - mqueue mqueue rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
@@ -61,7 +61,7 @@
 +0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw
 +0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw
 +0:+0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw
-+0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
++0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:+1 - vfat /dev/sda15 rw,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:+7 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+9 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:+1 - rpc_pipefs sunrpc rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
@@ -62,7 +62,7 @@
 +0:+0 /var/lib/snapd /var/lib/snapd rw,relatime master:+0 - ext4 /dev/sda1 rw
 +0:+0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw
 +0:+0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw
-+0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
++0:+1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:+1 - vfat /dev/sda15 rw,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:+7 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:+9 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 +0:+1 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:+1 - tmpfs tmpfs rw,size=VARIABLE
 +0:+1 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:+1 - rpc_pipefs sunrpc rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-C7.expected.txt
@@ -1,5 +1,5 @@
 0:0 / / rw,relatime shared:1 - ext4 /dev/sda1 rw
-+0:+1 / /boot/efi rw,relatime shared:+1 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
++0:+1 / /boot/efi rw,relatime shared:+1 - vfat /dev/sda15 rw,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
 +1:-1 / /dev rw,nosuid,relatime shared:+1 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
 +0:+1 / /dev/hugepages rw,relatime shared:+1 - hugetlbfs hugetlbfs rw,pagesize=2M
 +0:+1 / /dev/mqueue rw,relatime shared:+1 - mqueue mqueue rw


### PR DESCRIPTION
After the new ubuntu bionic is published, thenmount option on /boot/efi changed dmask= parameter in the distro
