### PR TITLE
tests: simplify the tests.cleanup tool

### DIFF
--- a/tests/core/fsck-on-boot/task.yaml
+++ b/tests/core/fsck-on-boot/task.yaml
@@ -7,12 +7,6 @@ details: |
   such file system is mounted. This is an essential property to ensure
   longevity of devices that rely on write to vfat to operate.
 
-prepare: |
-  tests.cleanup prepare
-
-restore: |
-  tests.cleanup restore
-
 execute: |
   unmount_vfat() {
     if os.query is-core16; then

--- a/tests/core/fsck-vfat/task.yaml
+++ b/tests/core/fsck-vfat/task.yaml
@@ -9,12 +9,6 @@ details: |
   A separate test examines how fsck is automatically invoked during the boot
   process. This is not verified here.
 
-prepare: |
-  tests.cleanup prepare
-
-restore: |
-  tests.cleanup restore
-
 execute: |
   echo "Essential fsck programs are in the boot base"
   test -n "$(command -v fsck.vfat)"

--- a/tests/core/snap-repair/task.yaml
+++ b/tests/core/snap-repair/task.yaml
@@ -5,13 +5,10 @@ environment:
     STORE_ADDR: localhost:11028
 
 prepare: |
-    tests.cleanup prepare
     snap install jq
     tests.cleanup defer snap remove jq
 
 restore: |
-    tests.cleanup restore
-
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -641,6 +641,9 @@ restore_suite_each() {
 
     rm -f "$RUNTIME_STATE_PATH/audit-stamp"
 
+    # Run the cleanup restore in case the commands have not been restored
+    tests.cleanup restore
+
     # restore test directory saved during prepare
     tests.backup restore
 

--- a/tests/lib/tools/suite/tests.cleanup/task.yaml
+++ b/tests/lib/tools/suite/tests.cleanup/task.yaml
@@ -9,8 +9,7 @@ execute: |
     shellcheck "$TESTSTOOLS"/tests.cleanup
 
     # Without any arguments a help message is printed.
-    tests.cleanup | MATCH "usage: tests.cleanup prepare"
-    tests.cleanup | MATCH "       tests.cleanup defer <cmd> \[args\]"
+    tests.cleanup | MATCH "usage: tests.cleanup defer <cmd> \[args\]"
     tests.cleanup | MATCH "       tests.cleanup pop"
     tests.cleanup | MATCH "       tests.cleanup restore"
 
@@ -22,9 +21,8 @@ execute: |
     tests.cleanup --foo 2>&1 | MATCH "tests.cleanup: unknown option --foo"
     tests.cleanup foo 2>&1 | MATCH "tests.cleanup: unknown command foo"
 
-    # Normal usage consists of a sequence of prepare, defer+, restore
+    # Normal usage consists of a sequence of defer+, restore
     # Note that restore runs the deferred commands in the opposite order.
-    tests.cleanup prepare
     tests.cleanup defer echo one
     tests.cleanup defer echo two
     tests.cleanup defer echo three
@@ -35,20 +33,11 @@ execute: |
     one
     EXPECTED
 
-    # Preparing twice is detected
-    tests.cleanup prepare
-    not tests.cleanup prepare
-    tests.cleanup prepare 2>&1 | MATCH "tests.cleanup: cannot prepare, already prepared"
+    # Restoring twice is possible
     tests.cleanup restore
-
-    # Restoring twice is detected
-    tests.cleanup prepare
     tests.cleanup restore
-    not tests.cleanup restore
-    tests.cleanup restore 2>&1 | MATCH "tests.cleanup: cannot restore, must call tests.cleanup prepare first"
 
     # Deferred commands are appended to defer.sh
-    tests.cleanup prepare
     test -e defer.sh
     tests.cleanup defer echo a b c
     tests.cleanup defer echo 1 2 3
@@ -61,7 +50,6 @@ execute: |
 
     # Deferred commands can fail their exit code is retained and the defer
     # stack is not purged.
-    tests.cleanup prepare
     tests.cleanup defer false
     not tests.cleanup restore
     tests.cleanup restore 2>&1 | MATCH 'tests.cleanup: deferred command "false" failed with exit code 1'
@@ -77,7 +65,6 @@ execute: |
     # Deferred commands can be popped and executed one by one. This is useful
     # to ensure correctness in case of failure while still allowing precise
     # resource management.
-    tests.cleanup prepare
     tests.cleanup defer echo popped
     tests.cleanup pop | MATCH popped
 
@@ -93,6 +80,5 @@ execute: |
     tests.cleanup restore
 
     # Popping a command when there isn't any fails with an appropriate message
-    tests.cleanup prepare
     tests.cleanup pop 2>&1 | MATCH 'tests.cleanup: cannot pop, cleanup stack is empty'
     not tests.cleanup pop

--- a/tests/lib/tools/suite/tests.cleanup/task.yaml
+++ b/tests/lib/tools/suite/tests.cleanup/task.yaml
@@ -38,7 +38,7 @@ execute: |
     tests.cleanup restore
 
     # Deferred commands are appended to defer.sh
-    test -e defer.sh
+    test ! -e defer.sh
     tests.cleanup defer echo a b c
     tests.cleanup defer echo 1 2 3
     diff -u defer.sh - <<EXPECTED

--- a/tests/lib/tools/suite/tests.invariant/task.yaml
+++ b/tests/lib/tools/suite/tests.invariant/task.yaml
@@ -1,8 +1,5 @@
 summary: tests.invariant is detecting problems
-prepare: |
-    tests.cleanup prepare
-restore: |
-    tests.cleanup restore
+
 execute: |
     # Invariant tool presents the usage screen when invoked without arguments
     # or with the -h or --help options.

--- a/tests/lib/tools/tests.cleanup
+++ b/tests/lib/tools/tests.cleanup
@@ -1,13 +1,11 @@
 #!/bin/bash -e
 
 show_help() {
-    echo "usage: tests.cleanup prepare"
-    echo "       tests.cleanup defer <cmd> [args]"
+    echo "usage: tests.cleanup defer <cmd> [args]"
     echo "       tests.cleanup pop"
     echo "       tests.cleanup restore"
     echo
     echo "COMMANDS:"
-    echo "  prepare: establishes a cleanup stack"
     echo "  restore: invokes all cleanup commands in reverse order"
     echo "  defer: pushes a command onto the cleanup stack"
     echo "  pop: invoke the most recently deferred command, discarding it"
@@ -16,19 +14,10 @@ show_help() {
     echo "cleanup handler and remove it, in the case of success"
 }
 
-cmd_prepare() {
-    if [ -e defer.sh ]; then
-        echo "tests.cleanup: cannot prepare, already prepared" >&2
-        exit 1
-    fi
-    truncate --size=0 defer.sh
-    chmod +x defer.sh
-}
-
 cmd_defer() {
     if [ ! -e defer.sh ]; then
-        echo "tests.cleanup: cannot defer, must call tests.cleanup prepare first" >&2
-        exit 1
+        truncate --size=0 defer.sh
+        chmod +x defer.sh
     fi
     echo "$*" >> defer.sh
 }
@@ -58,14 +47,12 @@ cmd_pop() {
 }
 
 cmd_restore() {
-    if [ ! -e defer.sh ]; then
-        echo "tests.cleanup: cannot restore, must call tests.cleanup prepare first" >&2
-        exit 1
+    if [ -e defer.sh ]; then
+        tac defer.sh | while read -r CMD; do
+            run_one_cmd "$CMD"
+        done
+        rm -f defer.sh
     fi
-    tac defer.sh | while read -r CMD; do
-        run_one_cmd "$CMD"
-    done
-    rm -f defer.sh
 }
 
 main() {
@@ -78,11 +65,6 @@ main() {
         case "$1" in
             -h|--help)
                 show_help
-                exit
-                ;;
-            prepare)
-                shift
-                cmd_prepare
                 exit
                 ;;
             defer)

--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -18,7 +18,6 @@ systems:
     - ubuntu-core-20-*  # tracking works correctly, for completeness
 
 prepare: |
-    tests.cleanup prepare
     # This feature depends on the release-app-awareness feature
     snap set core experimental.refresh-app-awareness=true
     tests.cleanup defer snap unset core experimental.refresh-app-awareness
@@ -26,7 +25,6 @@ prepare: |
     tests.cleanup defer snap remove --purge test-snapd-sh
 
 restore: |
-    tests.cleanup restore
     systemctl --user stop dbus.service || true
 
 debug: |

--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -14,8 +14,6 @@ environment:
     USER/test: test
 
 prepare: |
-    tests.cleanup prepare
-
     # This feature depends on the release-app-awareness feature
     snap set core experimental.refresh-app-awareness=true
     tests.cleanup defer snap unset core experimental.refresh-app-awareness
@@ -30,8 +28,6 @@ prepare: |
     tests.cleanup defer tests.session -u "$USER" restore
 
 restore: |
-    tests.cleanup restore
-
     rm -f /tmp/*.pid /tmp/*.stamp
 
     if [ "$USER" = root ]; then

--- a/tests/main/exitcodes/task.yaml
+++ b/tests/main/exitcodes/task.yaml
@@ -2,12 +2,6 @@ summary: Checks for snap exit codes
 
 systems: [ubuntu-1*, ubuntu-2*]
 
-prepare: |
-    tests.cleanup prepare
-
-restore: |
-    tests.cleanup restore
-
 execute: |
     echo "snap command with unknown command return exit code 5"
     set +e

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -10,8 +10,6 @@ environment:
     EXFAIL: "ubuntu-14"
 
 prepare: |
-    tests.cleanup prepare
-
     # Install pulseaudio.
     apt-get update
     apt-get install -y pulseaudio pulseaudio-utils
@@ -85,9 +83,6 @@ prepare: |
     tests.cleanup defer rm /etc/systemd/user/pulseaudio.service.d/no-start-limit.conf
     # reload user's systemd instance
     tests.session -u test exec systemctl daemon-reload --user
-
-restore: |
-    tests.cleanup restore
 
 debug: |
     echo "Files present in the test user's home directory"

--- a/tests/main/interfaces-desktop-document-portal/task.yaml
+++ b/tests/main/interfaces-desktop-document-portal/task.yaml
@@ -14,12 +14,10 @@ prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-desktop
     snap disconnect test-snapd-desktop:desktop
 
-    tests.cleanup prepare
     tests.session -u test prepare
     tests.cleanup defer tests.session -u test restore
 
 restore: |
-    tests.cleanup restore
     rm -f /tmp/check-doc-portal.sh
 
 execute: |

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -8,8 +8,6 @@ environment:
     PLAY_FILE: "/snap/test-snapd-pulseaudio/current/usr/share/sounds/alsa/Noise.wav"
 
 prepare: |
-    tests.cleanup prepare
-
     # Install pulseaudio.
     apt-get update
     apt-get install -y pulseaudio pulseaudio-utils
@@ -83,9 +81,6 @@ prepare: |
     tests.cleanup defer rm /etc/systemd/user/pulseaudio.service.d/no-start-limit.conf
     # reload user's systemd instance
     tests.session -u test exec systemctl daemon-reload --user
-
-restore: |
-    tests.cleanup restore
 
 debug: |
     echo "Files present in the test user's home directory"

--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -5,8 +5,6 @@ details: |
     can access timeserver information and update it.
 
 prepare: |
-    tests.cleanup prepare
-
     # This test requires busctl but on 14.04 we don't have one.
     # Let's pick the one from the core snap in such case.
     if [ -z "$(command -v busctl 2>/dev/null)" ]; then
@@ -44,9 +42,6 @@ prepare: |
     # Install a snap declaring a plug on timeserver-control
     "$TESTSTOOLS"/snaps-state install-local test-snapd-timedate-control-consumer
     tests.cleanup defer snap remove --purge test-snapd-timedate-control-consumer
-
-restore: |
-    tests.cleanup restore
 
 execute: |
     # If we cannot use network time protocol then the test is meaningless.

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -22,8 +22,6 @@ environment:
     STORE_TYPE/parallel_strict_remote,strict_remote,classic_remote: ${REMOTE_STORE}
 
 prepare: |
-    tests.cleanup prepare
-
     if [ "$STORE_TYPE" = "fake" ]; then
         if os.query is-core; then
             exit
@@ -63,8 +61,6 @@ prepare: |
     fi
 
 restore: |
-    tests.cleanup restore
-
     if [ "$STORE_TYPE" = "fake" ]; then
         if os.query is-core; then
             exit

--- a/tests/main/snapctl-is-connected-pid/task.yaml
+++ b/tests/main/snapctl-is-connected-pid/task.yaml
@@ -1,8 +1,6 @@
 summary: Ensure "snapctl is-connected" --pid and --apparmor-label options work.
 
 prepare: |
-    tests.cleanup prepare
-
     "$TESTSTOOLS"/snaps-state install-local test-snap1
     "$TESTSTOOLS"/snaps-state install-local test-snap2
 
@@ -16,9 +14,6 @@ prepare: |
             tests.cleanup defer rm -f /snap
         ;;
     esac
-
-restore: |
-    tests.cleanup restore
 
 execute: |
     echo "The test-snap1 service is running"

--- a/tests/regression/lp-1891371/task.yaml
+++ b/tests/regression/lp-1891371/task.yaml
@@ -1,12 +1,8 @@
 summary: mount changes can happen while a bind-mount file is open
 
 prepare: |
-    tests.cleanup prepare
     snap pack test-snapd-app
     snap pack test-snapd-extra-content
-
-restore: |
-    tests.cleanup restore
 
 execute: |
     # This starts a service that opens /opt/foo via bind-file layout.

--- a/tests/regression/lp-1898038/task.yaml
+++ b/tests/regression/lp-1898038/task.yaml
@@ -6,7 +6,6 @@ summary: docker-support and multipass-support should mount base /etc/apparmor.d
 systems: [-ubuntu-14.04-*, -ubuntu-core-16-*]
 
 prepare: |
-    tests.cleanup prepare
     snap pack test-snapd-docker-support-app
     snap install --dangerous ./test-snapd-docker-support-app_1_all.snap
 
@@ -25,9 +24,6 @@ prepare: |
     fi
     snap connect test-snapd-docker-support-app:docker-support
     snap connect test-snapd-multipass-support-app:multipass-support
-
-restore: |
-    tests.cleanup restore
 
 execute: |
     # now connect it and verify profile can be compiled

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -5,8 +5,6 @@ details: |
     Delegate=true snippet added to prevent CVE-2020-27352.
 
 prepare: |
-    tests.cleanup prepare
-
     # build and install the strict test snap
     snap pack container-mgr-snap
     snap install --dangerous test-snapd-container-mgrs*.snap
@@ -32,9 +30,6 @@ prepare: |
         snap pack classic-container-mgr-snap
         snap install --dangerous --classic test-snapd-classic-container-mgrs*.snap
     fi
-
-restore: |
-    tests.cleanup restore
 
 execute: |
     for confinement in classic strict; do


### PR DESCRIPTION
The idea of this change is to avoid preparing and make automatic
restoration of the defered commands.
In case it is required the restore can be invoqued manually.
