### PR TITLE
c/snap: more precise message for ErrorKindSystemRestart op != reboot

### DIFF
--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -51,7 +51,7 @@ type snapOpTestServer struct {
 	channel         string
 	trackingChannel string
 	confinement     string
-	rebooting       bool
+	restart         string
 	snap            string
 }
 
@@ -71,10 +71,10 @@ func (t *snapOpTestServer) handle(w http.ResponseWriter, r *http.Request) {
 	case 1:
 		t.c.Check(r.Method, check.Equals, "GET")
 		t.c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
-		if !t.rebooting {
+		if t.restart == "" {
 			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
 		} else {
-			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}, "maintenance": {"kind": "system-restart", "message": "system is restarting"}}}`)
+			fmt.Fprintln(w, fmt.Sprintf(`{"type": "sync", "result": {"status": "Doing"}, "maintenance": {"kind": "system-restart", "message": "system is %sing", "value": {"op": %q}}}}`, t.restart, t.restart))
 		}
 	case 2:
 		t.c.Check(r.Method, check.Equals, "GET")
@@ -1322,7 +1322,7 @@ func (s *SnapOpSuite) TestRefreshOneRebooting(c *check.C) {
 			"action": "refresh",
 		})
 	}
-	s.srv.rebooting = true
+	s.srv.restart = "reboot"
 
 	restore := mockArgs("snap", "refresh", "core")
 	defer restore()
@@ -1330,7 +1330,44 @@ func (s *SnapOpSuite) TestRefreshOneRebooting(c *check.C) {
 	err := snap.RunMain()
 	c.Check(err, check.IsNil)
 	c.Check(s.Stderr(), check.Equals, "snapd is about to reboot the system\n")
+}
 
+func (s *SnapOpSuite) TestRefreshOneHalting(c *check.C) {
+	s.RedirectClientToTestServer(s.srv.handle)
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/core")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action": "refresh",
+		})
+	}
+	s.srv.restart = "halt"
+
+	restore := mockArgs("snap", "refresh", "core")
+	defer restore()
+
+	err := snap.RunMain()
+	c.Check(err, check.IsNil)
+	c.Check(s.Stderr(), check.Equals, "snapd is about to halt the system\n")
+}
+
+func (s *SnapOpSuite) TestRefreshOnePoweringOff(c *check.C) {
+	s.RedirectClientToTestServer(s.srv.handle)
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/core")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action": "refresh",
+		})
+	}
+	s.srv.restart = "poweroff"
+
+	restore := mockArgs("snap", "refresh", "core")
+	defer restore()
+
+	err := snap.RunMain()
+	c.Check(err, check.IsNil)
+	c.Check(s.Stderr(), check.Equals, "snapd is about to power off the system\n")
 }
 
 func (s *SnapOpSuite) TestRefreshOneChanDeprecated(c *check.C) {

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -222,6 +222,18 @@ If you understand and want to proceed repeat the command including --classic.
 		isError = false
 		usesSnapName = false
 		msg = i18n.G("snapd is about to reboot the system")
+		values, ok := err.Value.(map[string]interface{})
+		if ok {
+			op, ok := values["op"].(string)
+			if ok {
+				switch op {
+				case "halt":
+					msg = i18n.G("snapd is about to halt the system")
+				case "poweroff":
+					msg = i18n.G("snapd is about to power off the system")
+				}
+			}
+		}
 	case client.ErrorKindInsufficientDiskSpace:
 		// this error carries multiple snap names
 		usesSnapName = false


### PR DESCRIPTION
This produces precise messages when a ErrorKindSystemRestart is for halt/poweroff.

follow-up to #10222