### PR TITLE
cmd/snap: include locale when linting description being lower case

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -173,7 +173,7 @@ func lintDesc(cmdName, optName, desc, origDesc string) {
 		r, _ := utf8.DecodeRuneInString(desc)
 		// note IsLower != !IsUpper for runes with no upper/lower.
 		if unicode.IsLower(r) && !strings.HasPrefix(desc, "login.ubuntu.com") && !strings.HasPrefix(desc, cmdName) {
-			noticef("description of %s's %q is lowercase: %q", cmdName, optName, desc)
+			noticef("description of %s's %q is lowercase in locale %q: %q", cmdName, optName, i18n.CurrentLocale(), desc)
 		}
 	}
 }

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -342,9 +342,15 @@ func (s *SnapSuite) TestLintDesc(c *C) {
 	c.Check(log.String(), HasLen, 0)
 	log.Reset()
 
-	// LintDesc complains about lowercase description.
+	// LintDesc complains about lowercase description and mentions the locale
+	// that the system is currently in.
+	prevValue := os.Getenv("LC_MESSAGES")
+	os.Setenv("LC_MESSAGES", "en_US")
+	defer func() {
+		os.Setenv("LC_MESSAGES", prevValue)
+	}()
 	snap.LintDesc("command", "<option>", "description", "")
-	c.Check(log.String(), testutil.Contains, `description of command's "<option>" is lowercase: "description"`)
+	c.Check(log.String(), testutil.Contains, `description of command's "<option>" is lowercase in locale "en_US": "description"`)
 	log.Reset()
 
 	// LintDesc does not complain about lowercase description starting with login.ubuntu.com

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -83,16 +83,25 @@ func bindTextDomain(domain, dir string) {
 
 func setLocale(loc string) {
 	if loc == "" {
-		loc = os.Getenv("LC_MESSAGES")
-		if loc == "" {
-			loc = os.Getenv("LANG")
-		}
+		loc = CurrentLocale()
 	}
 	// de_DE.UTF-8, de_DE@euro all need to get simplified
 	loc = strings.Split(loc, "@")[0]
 	loc = strings.Split(loc, ".")[0]
 
 	locale = translations.Locale(loc)
+}
+
+func CurrentLocale() string {
+	loc := os.Getenv("LC_MESSAGES")
+	if loc == "" {
+		loc = os.Getenv("LANG")
+	}
+
+	loc = strings.Split(loc, "@")[0]
+	loc = strings.Split(loc, ".")[0]
+
+	return loc
 }
 
 // G is the shorthand for Gettext

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -83,25 +83,31 @@ func bindTextDomain(domain, dir string) {
 
 func setLocale(loc string) {
 	if loc == "" {
-		loc = CurrentLocale()
+		loc = localeFromEnv()
 	}
+
+	locale = translations.Locale(simplifyLocale(loc))
+}
+
+func simplifyLocale(loc string) string {
 	// de_DE.UTF-8, de_DE@euro all need to get simplified
 	loc = strings.Split(loc, "@")[0]
 	loc = strings.Split(loc, ".")[0]
 
-	locale = translations.Locale(loc)
+	return loc
 }
 
-func CurrentLocale() string {
+func localeFromEnv() string {
 	loc := os.Getenv("LC_MESSAGES")
 	if loc == "" {
 		loc = os.Getenv("LANG")
 	}
 
-	loc = strings.Split(loc, "@")[0]
-	loc = strings.Split(loc, ".")[0]
-
 	return loc
+}
+
+func CurrentLocale() string {
+	return simplifyLocale(localeFromEnv())
 }
 
 // G is the shorthand for Gettext

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -106,6 +106,7 @@ func localeFromEnv() string {
 	return loc
 }
 
+// CurrentLocale returns the current locale without encoding or variants.
 func CurrentLocale() string {
 	return simplifyLocale(localeFromEnv())
 }


### PR DESCRIPTION
This helps debug which translation is incorrect and needs to be adjusted when
users run into this and paste the output they see directly to i.e. the forum.