### PR TITLE
tests: remove tests.cleanup prepare from nested test

### DIFF
--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -16,8 +16,6 @@ prepare: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
-    tests.cleanup prepare
-
     # needed for inspecting the partitions
     snap install jq
     tests.cleanup defer snap remove jq
@@ -41,6 +39,8 @@ prepare: |
     "$TESTSTOOLS"/nested-state build-image core
 
 restore: |
+    # Cleanup restore is needed in this case because nested tests are not
+    # doint automatic cleanups
     tests.cleanup restore
 
 execute: |


### PR DESCRIPTION
This tool has not prepeare subcommand anymore and this test was not
updated in the original change
