### PR TITLE
o/snapstate: introduce minimalInstallInfo interface

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -69,7 +69,7 @@ func (rc *refreshCandidate) Type() snap.Type {
 	return rc.SnapSetup.Type
 }
 
-func (rc *refreshCandidate) Base() string {
+func (rc *refreshCandidate) SnapBase() string {
 	return rc.SnapSetup.Base
 }
 
@@ -77,7 +77,7 @@ func (rc *refreshCandidate) MakeSnapSetup(*state.State, *SnapState) (*SnapSetup,
 	return &rc.SnapSetup, nil
 }
 
-func (rc *refreshCandidate) Size() int64 {
+func (rc *refreshCandidate) DownloadSize() int64 {
 	return rc.DownloadInfo.Size
 }
 

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -73,13 +73,24 @@ func (rc *refreshCandidate) SnapBase() string {
 	return rc.SnapSetup.Base
 }
 
-func (rc *refreshCandidate) MakeSnapSetup(*state.State, *SnapState) (*SnapSetup, error) {
-	return &rc.SnapSetup, nil
-}
-
 func (rc *refreshCandidate) DownloadSize() int64 {
 	return rc.DownloadInfo.Size
 }
+
+func (rc *refreshCandidate) Prereq(st *state.State) []string {
+	return rc.SnapSetup.Prereq
+}
+
+func (rc *refreshCandidate) SnapSetupForUpdate(st *state.State, params updateParamsFunc, userID int, globalFlags *Flags) (*SnapSetup, *SnapState, error) {
+	var snapst SnapState
+	if err := Get(st, rc.InstanceName(), &snapst); err != nil {
+		return nil, nil, err
+	}
+	return &rc.SnapSetup, &snapst, nil
+}
+
+// soundness check
+var _ readyUpdateInfo = (*refreshCandidate)(nil)
 
 // autoRefresh will ensure that snaps are refreshed automatically
 // according to the refresh schedule.

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -33,6 +33,7 @@ type ManagerBackend managerBackend
 
 type MinimalInstallInfo = minimalInstallInfo
 type InstallSnapInfo = installSnapInfo
+type ByType = byType
 
 func SetSnapManagerBackend(s *SnapManager, b ManagerBackend) {
 	s.backend = b

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -32,7 +32,7 @@ import (
 type ManagerBackend managerBackend
 
 type MinimalInstallInfo = minimalInstallInfo
-type ManualUpdateInfo = manualUpdateInfo
+type InstallSnapInfo = installSnapInfo
 
 func SetSnapManagerBackend(s *SnapManager, b ManagerBackend) {
 	s.backend = b

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -31,6 +31,9 @@ import (
 
 type ManagerBackend managerBackend
 
+type MinimalInstallInfo = minimalInstallInfo
+type ManualUpdateInfo = manualUpdateInfo
+
 func SetSnapManagerBackend(s *SnapManager, b ManagerBackend) {
 	s.backend = b
 }
@@ -260,7 +263,7 @@ func MockCurrentSnaps(f func(st *state.State) ([]*store.CurrentSnap, error)) fun
 	}
 }
 
-func MockInstallSize(f func(st *state.State, snaps []*snap.Info, userID int) (uint64, error)) func() {
+func MockInstallSize(f func(st *state.State, snaps []minimalInstallInfo, userID int) (uint64, error)) func() {
 	old := installSize
 	installSize = f
 	return func() {

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -61,7 +61,7 @@ func (s *prereqSuite) SetUpTest(c *C) {
 	restoreCheckFreeSpace := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error { return nil })
 	s.AddCleanup(restoreCheckFreeSpace)
 
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.MinimalInstallInfo, userID int) (uint64, error) {
 		return 0, nil
 	})
 	s.AddCleanup(restoreInstallSize)

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -260,17 +260,17 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 	cand1 := candidates["some-snap"]
 	c.Assert(cand1, NotNil)
 	c.Check(cand1.InstanceName(), Equals, "some-snap")
-	c.Check(cand1.Base(), Equals, "some-base")
+	c.Check(cand1.SnapBase(), Equals, "some-base")
 	c.Check(cand1.Type(), Equals, snap.TypeApp)
-	c.Check(cand1.Size(), Equals, int64(99))
+	c.Check(cand1.DownloadSize(), Equals, int64(99))
 	c.Check(cand1.Version, Equals, "2")
 
 	cand2 := candidates["other-snap"]
 	c.Assert(cand2, NotNil)
 	c.Check(cand2.InstanceName(), Equals, "other-snap")
-	c.Check(cand2.Base(), Equals, "")
+	c.Check(cand2.SnapBase(), Equals, "")
 	c.Check(cand2.Type(), Equals, snap.TypeApp)
-	c.Check(cand2.Size(), Equals, int64(88))
+	c.Check(cand2.DownloadSize(), Equals, int64(88))
 	c.Check(cand2.Version, Equals, "v1")
 
 	var snapst snapstate.SnapState

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -273,9 +273,11 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 	c.Check(cand2.DownloadSize(), Equals, int64(88))
 	c.Check(cand2.Version, Equals, "v1")
 
-	var snapst snapstate.SnapState
+	var snapst1 snapstate.SnapState
+	err = snapstate.Get(s.state, "some-snap", &snapst1)
+	c.Assert(err, IsNil)
 
-	sup, err := cand1.MakeSnapSetup(s.state, &snapst)
+	sup, snapst, err := cand1.SnapSetupForUpdate(s.state, nil, 0, nil)
 	c.Assert(err, IsNil)
 	c.Check(sup, DeepEquals, &snapstate.SnapSetup{
 		Base: "some-base",
@@ -294,8 +296,13 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 			Size: int64(99),
 		},
 	})
+	c.Check(snapst, DeepEquals, &snapst1)
 
-	sup, err = cand2.MakeSnapSetup(s.state, &snapst)
+	var snapst2 snapstate.SnapState
+	err = snapstate.Get(s.state, "other-snap", &snapst2)
+	c.Assert(err, IsNil)
+
+	sup, snapst, err = cand2.SnapSetupForUpdate(s.state, nil, 0, nil)
 	c.Assert(err, IsNil)
 	c.Check(sup, DeepEquals, &snapstate.SnapSetup{
 		Type: "app",
@@ -313,6 +320,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 			Size: int64(88),
 		},
 	})
+	c.Check(snapst, DeepEquals, &snapst2)
 }
 
 func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongArch(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -74,29 +74,20 @@ var ErrNothingToDo = errors.New("nothing to do")
 
 var osutilCheckFreeSpace = osutil.CheckFreeSpace
 
-type manualUpdateInfo struct {
-	snap.Info
-}
-
-func (up *manualUpdateInfo) DownloadSize() int64 {
-	return up.DownloadInfo.Size
-}
-
-// SnapBase returns the base snap of the snap.
-func (s *manualUpdateInfo) SnapBase() string {
-	return s.Base
-}
-
-func (up *manualUpdateInfo) Prereq(st *state.State) []string {
-	return defaultContentPlugProviders(st, &up.Info)
-}
-
 type minimalInstallInfo interface {
 	InstanceName() string
 	Type() snap.Type
 	SnapBase() string
 	DownloadSize() int64
 	Prereq(st *state.State) []string
+}
+
+type updateParamsFunc func(*snap.Info) (*RevisionOptions, Flags, *SnapState)
+
+type readyUpdateInfo interface {
+	minimalInstallInfo
+
+	SnapSetupForUpdate(st *state.State, params updateParamsFunc, userID int, globalFlags *Flags) (*SnapSetup, *SnapState, error)
 }
 
 // ByType supports sorting by snap type. The most important types come first.
@@ -107,6 +98,62 @@ func (r byType) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
 func (r byType) Less(i, j int) bool {
 	return r[i].Type().SortsBefore(r[j].Type())
 }
+
+type installSnapInfo struct {
+	*snap.Info
+}
+
+func (ins installSnapInfo) DownloadSize() int64 {
+	return ins.DownloadInfo.Size
+}
+
+// SnapBase returns the base snap of the snap.
+func (ins installSnapInfo) SnapBase() string {
+	return ins.Base
+}
+
+func (ins installSnapInfo) Prereq(st *state.State) []string {
+	return defaultContentPlugProviders(st, ins.Info)
+}
+
+func (ins installSnapInfo) SnapSetupForUpdate(st *state.State, params updateParamsFunc, userID int, globalFlags *Flags) (*SnapSetup, *SnapState, error) {
+	update := ins.Info
+
+	revnoOpts, flags, snapst := params(update)
+	flags.IsAutoRefresh = globalFlags.IsAutoRefresh
+
+	flags, err := earlyChecks(st, snapst, update, flags)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	snapUserID, err := userIDForSnap(st, snapst, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	snapsup := SnapSetup{
+		Base:         update.Base,
+		Prereq:       defaultContentPlugProviders(st, update),
+		Channel:      revnoOpts.Channel,
+		CohortKey:    revnoOpts.CohortKey,
+		UserID:       snapUserID,
+		Flags:        flags.ForSnapSetup(),
+		DownloadInfo: &update.DownloadInfo,
+		SideInfo:     &update.SideInfo,
+		Type:         update.Type(),
+		PlugsOnly:    len(update.Slots) == 0,
+		InstanceKey:  update.InstanceKey,
+		auxStoreInfo: auxStoreInfo{
+			Website: update.Website,
+			Media:   update.Media,
+		},
+	}
+	return &snapsup, snapst, nil
+}
+
+// soundness check
+var _ readyUpdateInfo = installSnapInfo{}
 
 // InsufficientSpaceError represents an error where there is not enough disk
 // space to perform an operation.
@@ -901,7 +948,7 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 	if checkDiskSpaceInstall {
 		// check if there is enough disk space for requested snap and its
 		// prerequisites.
-		totalSize, err := installSize(st, []minimalInstallInfo{&manualUpdateInfo{*info}}, userID)
+		totalSize, err := installSize(st, []minimalInstallInfo{installSnapInfo{info}}, userID)
 		if err != nil {
 			return nil, err
 		}
@@ -991,7 +1038,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 		// prerequisites.
 		snapInfos := make([]minimalInstallInfo, len(installs))
 		for i, sar := range installs {
-			snapInfos[i] = &manualUpdateInfo{*sar.Info}
+			snapInfos[i] = installSnapInfo{sar.Info}
 		}
 		totalSize, err := installSize(st, snapInfos, userID)
 		if err != nil {
@@ -1131,6 +1178,11 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 
 	}
 
+	toUpdate := make([]minimalInstallInfo, len(updates))
+	for i, up := range updates {
+		toUpdate[i] = installSnapInfo{up}
+	}
+
 	tr := config.NewTransaction(st)
 	checkDiskSpaceRefresh, err := features.Flag(tr, features.CheckDiskSpaceRefresh)
 	if err != nil && !config.IsNoOption(err) {
@@ -1139,10 +1191,6 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 	if checkDiskSpaceRefresh {
 		// check if there is enough disk space for requested snap and its
 		// prerequisites.
-		toUpdate := make([]minimalInstallInfo, len(updates))
-		for i, up := range updates {
-			toUpdate[i] = &manualUpdateInfo{*up}
-		}
 		totalSize, err := installSize(st, toUpdate, userID)
 		if err != nil {
 			return nil, nil, err
@@ -1165,7 +1213,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 		}
 	}
 
-	updated, tasksets, err := doUpdate(ctx, st, names, updates, params, userID, flags, deviceCtx, fromChange)
+	updated, tasksets, err := doUpdate(ctx, st, names, toUpdate, params, userID, flags, deviceCtx, fromChange)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1173,7 +1221,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 	return updated, tasksets, nil
 }
 
-func doUpdate(ctx context.Context, st *state.State, names []string, updates []*snap.Info, params func(*snap.Info) (*RevisionOptions, Flags, *SnapState), userID int, globalFlags *Flags, deviceCtx DeviceContext, fromChange string) ([]string, []*state.TaskSet, error) {
+func doUpdate(ctx context.Context, st *state.State, names []string, updates []minimalInstallInfo, params updateParamsFunc, userID int, globalFlags *Flags, deviceCtx DeviceContext, fromChange string) ([]string, []*state.TaskSet, error) {
 	if globalFlags == nil {
 		globalFlags = &Flags{}
 	}
@@ -1189,11 +1237,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 		}
 	}
 
-	toUpdate := make([]minimalInstallInfo, len(updates))
-	for i, up := range updates {
-		toUpdate[i] = &manualUpdateInfo{*up}
-	}
-	newAutoAliases, mustPruneAutoAliases, transferTargets, err := autoAliasesUpdate(st, names, toUpdate)
+	newAutoAliases, mustPruneAutoAliases, transferTargets, err := autoAliasesUpdate(st, names, updates)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1223,7 +1267,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 	}
 
 	// first snapd, core, bases, then rest
-	sort.Stable(snap.ByType(updates))
+	sort.Stable(byType(updates))
 	prereqs := make(map[string]*state.TaskSet)
 	waitPrereq := func(ts *state.TaskSet, prereqName string) {
 		preTs := prereqs[prereqName]
@@ -1236,39 +1280,13 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 	// updates is sorted by kind so this will process first core
 	// and bases and then other snaps
 	for _, update := range updates {
-		revnoOpts, flags, snapst := params(update)
-		flags.IsAutoRefresh = globalFlags.IsAutoRefresh
-
-		flags, err := earlyChecks(st, snapst, update, flags)
+		snapsup, snapst, err := update.(readyUpdateInfo).SnapSetupForUpdate(st, params, userID, globalFlags)
 		if err != nil {
 			if refreshAll {
 				logger.Noticef("cannot update %q: %v", update.InstanceName(), err)
 				continue
 			}
 			return nil, nil, err
-		}
-
-		snapUserID, err := userIDForSnap(st, snapst, userID)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		snapsup := &SnapSetup{
-			Base:         update.Base,
-			Prereq:       defaultContentPlugProviders(st, update),
-			Channel:      revnoOpts.Channel,
-			CohortKey:    revnoOpts.CohortKey,
-			UserID:       snapUserID,
-			Flags:        flags.ForSnapSetup(),
-			DownloadInfo: &update.DownloadInfo,
-			SideInfo:     &update.SideInfo,
-			Type:         update.Type(),
-			PlugsOnly:    len(update.Slots) == 0,
-			InstanceKey:  update.InstanceKey,
-			auxStoreInfo: auxStoreInfo{
-				Website: update.Website,
-				Media:   update.Media,
-			},
 		}
 
 		ts, err := doInstall(st, snapst, snapsup, 0, fromChange, inUseFor(deviceCtx))
@@ -1296,8 +1314,8 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 			// snaps
 			waitPrereq(ts, defaultCoreSnapName)
 			waitPrereq(ts, "snapd")
-			if update.Base != "" {
-				waitPrereq(ts, update.Base)
+			if update.SnapBase() != "" {
+				waitPrereq(ts, update.SnapBase())
 			}
 		}
 		// keep track of kernel/gadget udpates
@@ -1707,6 +1725,11 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 		return nil, infoErr
 	}
 
+	toUpdate := make([]minimalInstallInfo, len(updates))
+	for i, up := range updates {
+		toUpdate[i] = installSnapInfo{up}
+	}
+
 	tr := config.NewTransaction(st)
 	checkDiskSpaceRefresh, err := features.Flag(tr, features.CheckDiskSpaceRefresh)
 	if err != nil && !config.IsNoOption(err) {
@@ -1715,10 +1738,6 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 	if checkDiskSpaceRefresh {
 		// check if there is enough disk space for requested snap and its
 		// prerequisites.
-		toUpdate := make([]minimalInstallInfo, len(updates))
-		for i, up := range updates {
-			toUpdate[i] = &manualUpdateInfo{*up}
-		}
 		totalSize, err := installSize(st, toUpdate, userID)
 		if err != nil {
 			return nil, err
@@ -1745,7 +1764,7 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 		return opts, flags, &snapst
 	}
 
-	_, tts, err := doUpdate(context.TODO(), st, []string{name}, updates, params, userID, &flags, deviceCtx, fromChange)
+	_, tts, err := doUpdate(context.TODO(), st, []string{name}, toUpdate, params, userID, &flags, deviceCtx, fromChange)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1775,7 +1775,7 @@ func (s *snapmgrTestSuite) TestInstallFirstLocalRunThrough(c *C) {
 	// use the real thing for this one
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.MinimalInstallInfo, userID int) (uint64, error) {
 		c.Fatalf("installSize shouldn't be hit with local install")
 		return 0, nil
 	})
@@ -2899,7 +2899,7 @@ func (s *snapmgrTestSuite) TestInstallDiskSpaceError(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestInstallSizeError(c *C) {
-	restore := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restore := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.MinimalInstallInfo, userID int) (uint64, error) {
 		return 0, fmt.Errorf("boom")
 	})
 	defer restore()

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -6594,3 +6594,47 @@ func (s *snapmgrTestSuite) TestSnapdRefreshTasks(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Current, Equals, snap.R(11))
 }
+
+type installTestType struct {
+	t snap.Type
+}
+
+func (t *installTestType) InstanceName() string {
+	panic("not expected")
+}
+
+func (t *installTestType) Type() snap.Type {
+	return t.t
+}
+
+func (t *installTestType) SnapBase() string {
+	panic("not expected")
+}
+
+func (t *installTestType) DownloadSize() int64 {
+	panic("not expected")
+}
+
+func (t *installTestType) Prereq(st *state.State) []string {
+	panic("not expected")
+}
+
+func (s *snapmgrTestSuite) TestMinimalInstallInfoSortByType(c *C) {
+	snaps := []snapstate.MinimalInstallInfo{
+		&installTestType{snap.TypeApp},
+		&installTestType{snap.TypeBase},
+		&installTestType{snap.TypeApp},
+		&installTestType{snap.TypeSnapd},
+		&installTestType{snap.TypeKernel},
+		&installTestType{snap.TypeGadget},
+	}
+
+	sort.Sort(snapstate.ByType(snaps))
+	c.Check(snaps, DeepEquals, []snapstate.MinimalInstallInfo{
+		&installTestType{snap.TypeSnapd},
+		&installTestType{snap.TypeKernel},
+		&installTestType{snap.TypeBase},
+		&installTestType{snap.TypeGadget},
+		&installTestType{snap.TypeApp},
+		&installTestType{snap.TypeApp}})
+}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -175,7 +175,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	snapstate.EstimateSnapshotSize = func(st *state.State, instanceName string, users []string) (uint64, error) {
 		return 1, nil
 	}
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.MinimalInstallInfo, userID int) (uint64, error) {
 		return 0, nil
 	})
 	s.AddCleanup(restoreInstallSize)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -5005,7 +5005,7 @@ func (s *snapmgrTestSuite) testUpdateManyDiskSpaceCheck(c *C, featureFlag, failD
 	})
 	defer restore()
 
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.MinimalInstallInfo, userID int) (uint64, error) {
 		installSizeCalled = true
 		if failInstallSize {
 			return 0, fmt.Errorf("boom")
@@ -5631,7 +5631,7 @@ func (s *snapmgrTestSuite) testUpdateDiskSpaceCheck(c *C, featureFlag, failInsta
 
 	var installSizeCalled bool
 
-	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+	restoreInstallSize := snapstate.MockInstallSize(func(st *state.State, snaps []snapstate.MinimalInstallInfo, userID int) (uint64, error) {
 		installSizeCalled = true
 		if failInstallSize {
 			return 0, fmt.Errorf("boom")

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -89,7 +89,7 @@ func refreshOptions(st *state.State, origOpts *store.RefreshOptions) (*store.Ref
 // potentially more than once. It assumes the initial list of snaps already has
 // download infos set.
 // The state must be locked by the caller.
-var installSize = func(st *state.State, snaps []*snap.Info, userID int) (uint64, error) {
+var installSize = func(st *state.State, snaps []minimalInstallInfo, userID int) (uint64, error) {
 	curSnaps, err := currentSnaps(st)
 	if err != nil {
 		return 0, err
@@ -107,21 +107,21 @@ var installSize = func(st *state.State, snaps []*snap.Info, userID int) (uint64,
 
 	var prereqs []string
 
-	resolveBaseAndContentProviders := func(snapInfo *snap.Info) {
-		if snapInfo.SnapType != snap.TypeApp {
+	resolveBaseAndContentProviders := func(inst minimalInstallInfo) {
+		if inst.Type() != snap.TypeApp {
 			return
 		}
-		if snapInfo.Base != "none" {
+		if inst.SnapBase() != "none" {
 			base := defaultCoreSnapName
-			if snapInfo.Base != "" {
-				base = snapInfo.Base
+			if inst.SnapBase() != "" {
+				base = inst.SnapBase()
 			}
 			if !accountedSnaps[base] {
 				prereqs = append(prereqs, base)
 				accountedSnaps[base] = true
 			}
 		}
-		for _, snapName := range defaultContentPlugProviders(st, snapInfo) {
+		for _, snapName := range inst.Prereq(st) {
 			if !accountedSnaps[snapName] {
 				prereqs = append(prereqs, snapName)
 				accountedSnaps[snapName] = true
@@ -130,12 +130,12 @@ var installSize = func(st *state.State, snaps []*snap.Info, userID int) (uint64,
 	}
 
 	snapSizes := map[string]uint64{}
-	for _, snapInfo := range snaps {
-		if snapInfo.DownloadInfo.Size == 0 {
-			return 0, fmt.Errorf("internal error: download info missing for %q", snapInfo.InstanceName())
+	for _, inst := range snaps {
+		if inst.DownloadSize() == 0 {
+			return 0, fmt.Errorf("internal error: download info missing for %q", inst.InstanceName())
 		}
-		snapSizes[snapInfo.InstanceName()] = uint64(snapInfo.Size)
-		resolveBaseAndContentProviders(snapInfo)
+		snapSizes[inst.InstanceName()] = uint64(inst.DownloadSize())
+		resolveBaseAndContentProviders(inst)
 	}
 
 	opts, err := refreshOptions(st, nil)
@@ -170,7 +170,7 @@ var installSize = func(st *state.State, snaps []*snap.Info, userID int) (uint64,
 		for _, res := range results {
 			snapSizes[res.InstanceName()] = uint64(res.Size)
 			// results may have new base or content providers
-			resolveBaseAndContentProviders(res.Info)
+			resolveBaseAndContentProviders(&manualUpdateInfo{*res.Info})
 		}
 	}
 

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -170,7 +170,7 @@ var installSize = func(st *state.State, snaps []minimalInstallInfo, userID int) 
 		for _, res := range results {
 			snapSizes[res.InstanceName()] = uint64(res.Size)
 			// results may have new base or content providers
-			resolveBaseAndContentProviders(&manualUpdateInfo{*res.Info})
+			resolveBaseAndContentProviders(installSnapInfo{res.Info})
 		}
 	}
 

--- a/overlord/snapstate/storehelpers_test.go
+++ b/overlord/snapstate/storehelpers_test.go
@@ -190,7 +190,7 @@ func (s *snapmgrTestSuite) TestInstallSizeSimple(c *C) {
 	})
 	snap2.Size = snap2Size
 
-	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{snapstate.InstallSnapInfo{snap1}, snapstate.InstallSnapInfo{snap2}}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{snapstate.InstallSnapInfo{Info: snap1}, snapstate.InstallSnapInfo{Info: snap2}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size))
 }
@@ -233,10 +233,10 @@ func (s *snapmgrTestSuite) TestInstallSizeWithBases(c *C) {
 	})
 
 	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{
-		snapstate.InstallSnapInfo{snap1},
-		snapstate.InstallSnapInfo{snap2},
-		snapstate.InstallSnapInfo{snap3},
-		snapstate.InstallSnapInfo{snap4}}, 0)
+		snapstate.InstallSnapInfo{Info: snap1},
+		snapstate.InstallSnapInfo{Info: snap2},
+		snapstate.InstallSnapInfo{Info: snap3},
+		snapstate.InstallSnapInfo{Info: snap4}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+snap3Size+snap4Size+someBaseSize+otherBaseSize))
 }
@@ -267,7 +267,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithContentProviders(c *C) {
 
 	// both snaps have same content providers and base
 	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{
-		snapstate.InstallSnapInfo{snap1}, snapstate.InstallSnapInfo{snap2}}, 0)
+		snapstate.InstallSnapInfo{Info: snap1}, snapstate.InstallSnapInfo{Info: snap2}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+someBaseSize+snapContentSlotSize))
 }
@@ -289,7 +289,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithNestedDependencies(c *C) {
 
 	s.mockCoreSnap(c)
 
-	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{snapstate.InstallSnapInfo{snap1}}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{snapstate.InstallSnapInfo{Info: snap1}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize+snapOtherContentSlotSize+someOtherBaseSize))
 }
@@ -329,7 +329,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithOtherChangeAffectingSameSnaps(c *C
 	snap3.Size = snap3Size
 
 	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{
-		snapstate.InstallSnapInfo{snap1}, snapstate.InstallSnapInfo{snap3}}, 0)
+		snapstate.InstallSnapInfo{Info: snap1}, snapstate.InstallSnapInfo{Info: snap3}}, 0)
 	c.Assert(err, IsNil)
 	// snap3 and its base installed by another change, not counted here
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize))
@@ -348,6 +348,6 @@ func (s *snapmgrTestSuite) TestInstallSizeErrorNoDownloadInfo(c *C) {
 			RealName: "snap",
 		}}
 
-	_, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{snapstate.InstallSnapInfo{snap1}}, 0)
+	_, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{snapstate.InstallSnapInfo{Info: snap1}}, 0)
 	c.Assert(err, ErrorMatches, `internal error: download info missing.*`)
 }

--- a/overlord/snapstate/storehelpers_test.go
+++ b/overlord/snapstate/storehelpers_test.go
@@ -190,7 +190,7 @@ func (s *snapmgrTestSuite) TestInstallSizeSimple(c *C) {
 	})
 	snap2.Size = snap2Size
 
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap2}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{&snapstate.ManualUpdateInfo{*snap1}, &snapstate.ManualUpdateInfo{*snap2}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size))
 }
@@ -232,7 +232,11 @@ func (s *snapmgrTestSuite) TestInstallSizeWithBases(c *C) {
 		Current: snap.R(1),
 	})
 
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap2, snap3, snap4}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{
+		&snapstate.ManualUpdateInfo{*snap1},
+		&snapstate.ManualUpdateInfo{*snap2},
+		&snapstate.ManualUpdateInfo{*snap3},
+		&snapstate.ManualUpdateInfo{*snap4}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+snap3Size+snap4Size+someBaseSize+otherBaseSize))
 }
@@ -262,7 +266,8 @@ func (s *snapmgrTestSuite) TestInstallSizeWithContentProviders(c *C) {
 	s.mockCoreSnap(c)
 
 	// both snaps have same content providers and base
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap2}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{
+		&snapstate.ManualUpdateInfo{*snap1}, &snapstate.ManualUpdateInfo{*snap2}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+someBaseSize+snapContentSlotSize))
 }
@@ -284,7 +289,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithNestedDependencies(c *C) {
 
 	s.mockCoreSnap(c)
 
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{&snapstate.ManualUpdateInfo{*snap1}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize+snapOtherContentSlotSize+someOtherBaseSize))
 }
@@ -323,7 +328,8 @@ func (s *snapmgrTestSuite) TestInstallSizeWithOtherChangeAffectingSameSnaps(c *C
 	})
 	snap3.Size = snap3Size
 
-	sz, err := snapstate.InstallSize(st, []*snap.Info{snap1, snap3}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{
+		&snapstate.ManualUpdateInfo{*snap1}, &snapstate.ManualUpdateInfo{*snap3}}, 0)
 	c.Assert(err, IsNil)
 	// snap3 and its base installed by another change, not counted here
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize))
@@ -342,6 +348,6 @@ func (s *snapmgrTestSuite) TestInstallSizeErrorNoDownloadInfo(c *C) {
 			RealName: "snap",
 		}}
 
-	_, err := snapstate.InstallSize(st, []*snap.Info{snap1}, 0)
+	_, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{&snapstate.ManualUpdateInfo{*snap1}}, 0)
 	c.Assert(err, ErrorMatches, `internal error: download info missing.*`)
 }

--- a/overlord/snapstate/storehelpers_test.go
+++ b/overlord/snapstate/storehelpers_test.go
@@ -190,7 +190,7 @@ func (s *snapmgrTestSuite) TestInstallSizeSimple(c *C) {
 	})
 	snap2.Size = snap2Size
 
-	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{&snapstate.ManualUpdateInfo{*snap1}, &snapstate.ManualUpdateInfo{*snap2}}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{snapstate.InstallSnapInfo{snap1}, snapstate.InstallSnapInfo{snap2}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size))
 }
@@ -233,10 +233,10 @@ func (s *snapmgrTestSuite) TestInstallSizeWithBases(c *C) {
 	})
 
 	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{
-		&snapstate.ManualUpdateInfo{*snap1},
-		&snapstate.ManualUpdateInfo{*snap2},
-		&snapstate.ManualUpdateInfo{*snap3},
-		&snapstate.ManualUpdateInfo{*snap4}}, 0)
+		snapstate.InstallSnapInfo{snap1},
+		snapstate.InstallSnapInfo{snap2},
+		snapstate.InstallSnapInfo{snap3},
+		snapstate.InstallSnapInfo{snap4}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+snap3Size+snap4Size+someBaseSize+otherBaseSize))
 }
@@ -267,7 +267,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithContentProviders(c *C) {
 
 	// both snaps have same content providers and base
 	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{
-		&snapstate.ManualUpdateInfo{*snap1}, &snapstate.ManualUpdateInfo{*snap2}}, 0)
+		snapstate.InstallSnapInfo{snap1}, snapstate.InstallSnapInfo{snap2}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+snap2Size+someBaseSize+snapContentSlotSize))
 }
@@ -289,7 +289,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithNestedDependencies(c *C) {
 
 	s.mockCoreSnap(c)
 
-	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{&snapstate.ManualUpdateInfo{*snap1}}, 0)
+	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{snapstate.InstallSnapInfo{snap1}}, 0)
 	c.Assert(err, IsNil)
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize+snapOtherContentSlotSize+someOtherBaseSize))
 }
@@ -329,7 +329,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithOtherChangeAffectingSameSnaps(c *C
 	snap3.Size = snap3Size
 
 	sz, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{
-		&snapstate.ManualUpdateInfo{*snap1}, &snapstate.ManualUpdateInfo{*snap3}}, 0)
+		snapstate.InstallSnapInfo{snap1}, snapstate.InstallSnapInfo{snap3}}, 0)
 	c.Assert(err, IsNil)
 	// snap3 and its base installed by another change, not counted here
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize))
@@ -348,6 +348,6 @@ func (s *snapmgrTestSuite) TestInstallSizeErrorNoDownloadInfo(c *C) {
 			RealName: "snap",
 		}}
 
-	_, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{&snapstate.ManualUpdateInfo{*snap1}}, 0)
+	_, err := snapstate.InstallSize(st, []snapstate.MinimalInstallInfo{snapstate.InstallSnapInfo{snap1}}, 0)
 	c.Assert(err, ErrorMatches, `internal error: download info missing.*`)
 }


### PR DESCRIPTION
Extracted from #10261 

Introduce minimalInstallInfo interface and manualUpdateInfo that implements it, plus update refreshCandidate to implement it. This allows for reusing some of the existing logic where previously we would be passing full snap.Info (such as installSize helper).