### PR TITLE
tests/nested: add test for gadget default config values being available early

### DIFF
--- a/tests/nested/manual/core-gadget-config-during-seeding/defaults.yaml
+++ b/tests/nested/manual/core-gadget-config-during-seeding/defaults.yaml
@@ -1,0 +1,3 @@
+defaults:
+  K1GSEUyXvEg9Yxs0a3CXVTk4R42SyeYk:
+    key: mykeyval

--- a/tests/nested/manual/core-gadget-config-during-seeding/install
+++ b/tests/nested/manual/core-gadget-config-during-seeding/install
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# rsyslog.service is expected to be a symlink at this point, and apparmor
+# doesn't control readlink, so this should work even without devmode or
+# system-files plug.
+RSYSLOG=$(readlink /etc/systemd/system/rsyslog.service)
+echo "rsyslog symlink: $RSYSLOG" > "$SNAP_COMMON"/debug.txt || true
+
+LOCALTIME=$(readlink /etc/writable/localtime)
+echo "localtime symlink: $LOCALTIME"  >> "$SNAP_COMMON"/debug.txt  2>&1 || true

--- a/tests/nested/manual/core-gadget-config-during-seeding/task.yaml
+++ b/tests/nested/manual/core-gadget-config-during-seeding/task.yaml
@@ -1,0 +1,67 @@
+summary: Test defaults set for snaps from gadget.yaml are available during seeding
+
+# TODO: enable for classic?
+# TODO: enable for uc16?
+systems: [ubuntu-18.04-64, ubuntu-20.04-64]
+
+environment:
+    NESTED_IMAGE_ID: core-gadget-config-during-seeding
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+
+prepare: |
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    mkdir extra-snaps
+
+    snap download test-snapd-install-snapctl --edge --basename=test-snapd-install-snapctl
+    mv test-snapd-install-snapctl.snap extra-snaps/
+
+    if os.query is-core18; then
+        # modify and repack 18 gadget snap (add defaults section)
+        snap download --channel=18/stable pc
+        GADGET_SNAP=$(ls pc_*.snap)
+        unsquashfs -no-progress "$GADGET_SNAP"
+        rm -f "$GADGET_SNAP"
+
+        cat defaults.yaml >> squashfs-root/meta/gadget.yaml
+
+        snap pack squashfs-root --filename="$GADGET_SNAP"
+        rm -rf squashfs-root
+        mv "$GADGET_SNAP" extra-snaps/
+
+    elif os.query is-core20; then
+        # Get the snakeoil key and cert
+        KEY_NAME=$(nested_get_snakeoil_key)
+        SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+        SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+
+        # modify and repack gadget snap (add defaults section)
+        snap download --basename=pc --channel="20/edge" pc
+        unsquashfs -d pc-gadget pc.snap
+
+        cat defaults.yaml >> pc-gadget/meta/gadget.yaml
+
+        nested_secboot_sign_gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+        snap pack pc-gadget/ extra-snaps/
+
+        rm -f "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+    fi
+
+    "$TESTSTOOLS"/nested-state build-image core 
+    "$TESTSTOOLS"/nested-state create-vm core
+
+execute: |
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    nested_exec "sudo snap wait system seed.loaded"
+
+    echo "Test that the config value is set for the snap."
+    nested_exec "sudo snap get test-snapd-install-snapctl key" | MATCH mykeyval
+
+    echo "Test when the install hook ran the config value was set."
+    nested_exec "sudo cat /var/snap/test-snapd-install-snapctl/current/snapctl-output.txt" | MATCH mykeyval
+
+    echo "Test when the service started the config value was set."
+    nested_exec "sudo snap logs test-snapd-install-snapctl" | MATCH 'test-snapd-install-snapctl.daemon.* echo mykeyval'


### PR DESCRIPTION
This test exercises whether snaps when initially seeding can access gadget
config values or not (hint: currently they cannot, we have a bug).