### PR TITLE
interfaces: add acrn interface for launching virtual machines on ACRN

### DIFF
--- a/interfaces/builtin/acrn.go
+++ b/interfaces/builtin/acrn.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 Intel Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/kmod"
+)
+
+const acrnSummary = `allows access to the ACRN device`
+
+const acrnBaseDeclarationPlugs = `
+  acrn:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const acrnBaseDeclarationSlots = `
+  acrn:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const acrnConnectedPlugAppArmor = `
+# Description: Allow access to resources required by ACRN.
+#
+# allow setting certain CPU cores offline
+/sys/devices/system/cpu/cpu[0-9]*/online w,
+
+# allow write access to ACRN Virtio and Hypervisor service Module
+/dev/acrn_vhm rw,
+/dev/acrn_hsm rw,
+`
+
+var acrnConnectedPlugUDev = []string{
+	`SUBSYSTEM=="vhm"`,
+	`SUBSYSTEM=="hsm"`,
+}
+
+type acrnInterface struct {
+	commonInterface
+}
+
+func (iface *acrnInterface) KModConnectedPlug(spec *kmod.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	/* ACRN Hypervisor Service Module (HSM) is supported since kernel 5.12 */
+	_ = spec.AddModule("acrn")
+	return nil
+}
+
+func init() {
+	registerIface(&acrnInterface{commonInterface{
+		name:                  "acrn",
+		summary:               acrnSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationPlugs:  acrnBaseDeclarationPlugs,
+		baseDeclarationSlots:  acrnBaseDeclarationSlots,
+		connectedPlugAppArmor: acrnConnectedPlugAppArmor,
+		connectedPlugUDev:     acrnConnectedPlugUDev,
+	}})
+}

--- a/interfaces/builtin/acrn_test.go
+++ b/interfaces/builtin/acrn_test.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2021 Intel Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type acrnInterfaceSuite struct {
+	testutil.BaseTest
+
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&acrnInterfaceSuite{
+	iface: builtin.MustInterface("acrn"),
+})
+
+const acrnConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [acrn]
+`
+
+const acrnGadgetYaml = `name: gadget
+version: 0
+type: gadget
+slots:
+  acrn:
+`
+
+func (s *acrnInterfaceSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.plug, s.plugInfo = MockConnectedPlug(c, acrnConsumerYaml, nil, "acrn")
+	s.slot, s.slotInfo = MockConnectedSlot(c, acrnGadgetYaml, nil, "acrn")
+}
+
+func (s *acrnInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "acrn")
+}
+
+func (s *acrnInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *acrnInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *acrnInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/sys/devices/system/cpu/cpu[0-9]*/online w,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/acrn_vhm rw,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/acrn_hsm rw,")
+}
+
+func (s *acrnInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 3)
+	c.Assert(spec.Snippets(), testutil.Contains, `# acrn
+SUBSYSTEM=="vhm", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *acrnInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to the ACRN device`)
+	c.Assert(si.BaseDeclarationPlugs, testutil.Contains, "acrn")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "acrn")
+}
+
+func (s *acrnInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *acrnInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/hugepages_control.go
+++ b/interfaces/builtin/hugepages_control.go
@@ -42,6 +42,9 @@ const hugepagesControlConnectedPlugAppArmor = `
 /sys/devices/system/node/node[0-9]*/hugepages/{,hugepages-[0-9]*}/nr_hugepages w,
 @{PROC}/sys/vm/nr_{hugepages,hugepages_mempolicy,overcommit_hugepages} rw,
 
+# Allow mounting hugetlbfs
+mount fstype=hugetlbfs,
+
 # Observe which group can create shm segments using hugetlb pages
 @{PROC}/sys/vm/hugetlb_shm_group r,
 

--- a/interfaces/builtin/hugepages_control.go
+++ b/interfaces/builtin/hugepages_control.go
@@ -43,7 +43,7 @@ const hugepagesControlConnectedPlugAppArmor = `
 @{PROC}/sys/vm/nr_{hugepages,hugepages_mempolicy,overcommit_hugepages} rw,
 
 # Allow mounting hugetlbfs
-mount fstype=hugetlbfs,
+mount fstype=hugetlbfs none -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,
 
 # Observe which group can create shm segments using hugetlb pages
 @{PROC}/sys/vm/hugetlb_shm_group r,

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -8,6 +8,9 @@ apps:
   account-control:
     command: bin/run
     plugs: [ account-control ]
+  acrn:
+    command: bin/run
+    plugs: [ acrn ]
   adb-support:
     command: bin/run
     plugs: [ adb-support ]


### PR DESCRIPTION
This commit adds a new interface for launching VMs on ACRN.

[ACRN](https://projectacrn.org/) is a Type 1 hypervisor designed for embedded devices, which provides a lightweight, real-time, and safety-critical virtualization environment for launching virtual machines on bare-metal devices. We have packaged the [hypervisor](https://github.com/projectacrn/acrn-hypervisor), [ACRN kernel](https://github.com/projectacrn/acrn-kernel), and utilities in the ACRN gadget and kernel snaps in the [acrn-snap](https://github.com/gvancuts/acrn-snap) repository for launching VMs on Ubuntu Core, but still requires some apparmor permissions to access the required resources.

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>