### PR TITLE
overlord/servicestate: omit service list if only snap given

### DIFF
--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -85,7 +85,7 @@ type serviceControlArgs struct {
 	names   []string
 }
 
-func (s *appsSuite) fakeServiceControl(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
+func (s *appsSuite) fakeServiceControl(st *state.State, appInfos []*servicestate.ResolvedAppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
 	if flags != nil {
 		panic("flags are not expected")
 	}
@@ -383,7 +383,7 @@ func (s *appsSuite) TestAppInfosForOneSnap(c *check.C) {
 	appInfos, rsp := daemon.AppInfosFor(st, []string{"snap-a"}, daemon.AppInfoServiceTrue)
 	c.Assert(rsp, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 2)
-	sort.Sort(snap.AppInfoBySnapApp(appInfos))
+	sort.Sort(servicestate.ResolvedAppInfos(appInfos))
 
 	c.Check(appInfos[0].Snap, check.DeepEquals, s.infoA)
 	c.Check(appInfos[0].Name, check.Equals, "svc1")
@@ -396,7 +396,7 @@ func (s *appsSuite) TestAppInfosForMixedArgs(c *check.C) {
 	appInfos, rsp := daemon.AppInfosFor(st, []string{"snap-a", "snap-a.svc1"}, daemon.AppInfoServiceTrue)
 	c.Assert(rsp, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 2)
-	sort.Sort(snap.AppInfoBySnapApp(appInfos))
+	sort.Sort(servicestate.ResolvedAppInfos(appInfos))
 
 	c.Check(appInfos[0].Snap, check.DeepEquals, s.infoA)
 	c.Check(appInfos[0].Name, check.Equals, "svc1")
@@ -418,7 +418,7 @@ func (s *appsSuite) TestAppInfosCleanupAndSorted(c *check.C) {
 	}, daemon.AppInfoServiceTrue)
 	c.Assert(rsp, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 3)
-	sort.Sort(snap.AppInfoBySnapApp(appInfos))
+	sort.Sort(servicestate.ResolvedAppInfos(appInfos))
 
 	c.Check(appInfos[0].Snap, check.DeepEquals, s.infoA)
 	c.Check(appInfos[0].Name, check.Equals, "svc1")

--- a/daemon/export_api_apps_test.go
+++ b/daemon/export_api_apps_test.go
@@ -23,10 +23,9 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/snap"
 )
 
-func MockServicestateControl(f func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error)) (restore func()) {
+func MockServicestateControl(f func(st *state.State, appInfos []*servicestate.ResolvedAppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error)) (restore func()) {
 	old := servicestateControl
 	servicestateControl = f
 	return func() {

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/snap"
 )
 
 const (
@@ -36,7 +35,7 @@ const (
 
 var AttributesTask = attributesTask
 
-func MockServicestateControlFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction, *servicestate.Flags, *hookstate.Context) ([]*state.TaskSet, error)) (restore func()) {
+func MockServicestateControlFunc(f func(*state.State, []*servicestate.ResolvedAppInfo, *servicestate.Instruction, *servicestate.Flags, *hookstate.Context) ([]*state.TaskSet, error)) (restore func()) {
 	old := servicestateControl
 	servicestateControl = f
 	return func() { servicestateControl = old }

--- a/overlord/hookstate/ctlcmd/services.go
+++ b/overlord/hookstate/ctlcmd/services.go
@@ -52,7 +52,7 @@ type servicesCommand struct {
 
 var errNoContextForServices = errors.New(i18n.G("cannot query services without a context"))
 
-type byApp []*snap.AppInfo
+type byApp []*servicestate.ResolvedAppInfo
 
 func (a byApp) Len() int      { return len(a) }
 func (a byApp) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
@@ -75,7 +75,11 @@ func (c *servicesCommand) Execute([]string) error {
 
 	sd := servicestate.NewStatusDecorator(progress.Null)
 
-	services, err := clientutil.ClientAppInfosFromSnapAppInfos(svcInfos, sd)
+	appInfos := make([]*snap.AppInfo, 0, len(svcInfos))
+	for _, svcInfo := range svcInfos {
+		appInfos = append(appInfos, &svcInfo.AppInfo)
+	}
+	services, err := clientutil.ClientAppInfosFromSnapAppInfos(appInfos, sd)
 	if err != nil || len(services) == 0 {
 		return err
 	}

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -133,8 +133,8 @@ apps:
   reload-command: bin/reload
 `
 
-func mockServiceChangeFunc(testServiceControlInputs func(appInfos []*snap.AppInfo, inst *servicestate.Instruction)) func() {
-	return ctlcmd.MockServicestateControlFunc(func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
+func mockServiceChangeFunc(testServiceControlInputs func(appInfos []*servicestate.ResolvedAppInfo, inst *servicestate.Instruction)) func() {
+	return ctlcmd.MockServicestateControlFunc(func(st *state.State, appInfos []*servicestate.ResolvedAppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
 		testServiceControlInputs(appInfos, inst)
 		return nil, fmt.Errorf("forced error")
 	})
@@ -204,7 +204,7 @@ func (s *servicectlSuite) SetUpTest(c *C) {
 
 func (s *servicectlSuite) TestStopCommand(c *C) {
 	var serviceChangeFuncCalled bool
-	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
+	restore := mockServiceChangeFunc(func(appInfos []*servicestate.ResolvedAppInfo, inst *servicestate.Instruction) {
 		serviceChangeFuncCalled = true
 		c.Assert(appInfos, HasLen, 1)
 		c.Assert(appInfos[0].Name, Equals, "test-service")
@@ -226,7 +226,7 @@ func (s *servicectlSuite) TestStopCommand(c *C) {
 
 func (s *servicectlSuite) TestStopCommandUnknownService(c *C) {
 	var serviceChangeFuncCalled bool
-	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
+	restore := mockServiceChangeFunc(func(appInfos []*servicestate.ResolvedAppInfo, inst *servicestate.Instruction) {
 		serviceChangeFuncCalled = true
 	})
 	defer restore()
@@ -238,7 +238,7 @@ func (s *servicectlSuite) TestStopCommandUnknownService(c *C) {
 
 func (s *servicectlSuite) TestStopCommandFailsOnOtherSnap(c *C) {
 	var serviceChangeFuncCalled bool
-	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
+	restore := mockServiceChangeFunc(func(appInfos []*servicestate.ResolvedAppInfo, inst *servicestate.Instruction) {
 		serviceChangeFuncCalled = true
 	})
 	defer restore()
@@ -251,7 +251,7 @@ func (s *servicectlSuite) TestStopCommandFailsOnOtherSnap(c *C) {
 
 func (s *servicectlSuite) TestStartCommand(c *C) {
 	var serviceChangeFuncCalled bool
-	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
+	restore := mockServiceChangeFunc(func(appInfos []*servicestate.ResolvedAppInfo, inst *servicestate.Instruction) {
 		serviceChangeFuncCalled = true
 		c.Assert(appInfos, HasLen, 1)
 		c.Assert(appInfos[0].Name, Equals, "test-service")
@@ -273,7 +273,7 @@ func (s *servicectlSuite) TestStartCommand(c *C) {
 
 func (s *servicectlSuite) TestRestartCommand(c *C) {
 	var serviceChangeFuncCalled bool
-	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
+	restore := mockServiceChangeFunc(func(appInfos []*servicestate.ResolvedAppInfo, inst *servicestate.Instruction) {
 		serviceChangeFuncCalled = true
 		c.Assert(appInfos, HasLen, 1)
 		c.Assert(appInfos[0].Name, Equals, "test-service")

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -49,8 +49,40 @@ type Instruction struct {
 
 type ServiceActionConflictError struct{ error }
 
+type ResolvedAppInfo struct {
+	snap.AppInfo
+	ExplicitlyRequested bool
+}
+
+func NewResolvedAppInfo(app *snap.AppInfo) *ResolvedAppInfo {
+	resolvedAppInfo := new(ResolvedAppInfo)
+	resolvedAppInfo.AppInfo = *app
+	return resolvedAppInfo
+}
+
+type ResolvedAppInfos []*ResolvedAppInfo
+
+func NewResolvedAppInfos(appInfos []*snap.AppInfo) ResolvedAppInfos {
+	resolvedAppInfos := make(ResolvedAppInfos, 0, len(appInfos))
+	for _, app := range appInfos {
+		resolvedAppInfos = append(resolvedAppInfos, NewResolvedAppInfo(app))
+	}
+	return resolvedAppInfos
+}
+
+func (a ResolvedAppInfos) Len() int      { return len(a) }
+func (a ResolvedAppInfos) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ResolvedAppInfos) Less(i, j int) bool {
+	iName := a[i].Snap.InstanceName()
+	jName := a[j].Snap.InstanceName()
+	if iName == jName {
+		return a[i].Name < a[j].Name
+	}
+	return iName < jName
+}
+
 // serviceControlTs creates "service-control" task for every snap derived from appInfos.
-func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.TaskSet, error) {
+func serviceControlTs(st *state.State, appInfos []*ResolvedAppInfo, inst *Instruction) (*state.TaskSet, error) {
 	servicesBySnap := make(map[string][]string, len(appInfos))
 	sortedNames := make([]string, 0, len(appInfos))
 
@@ -60,7 +92,14 @@ func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instructi
 		if _, ok := servicesBySnap[snapName]; !ok {
 			sortedNames = append(sortedNames, snapName)
 		}
-		servicesBySnap[snapName] = append(servicesBySnap[snapName], app.Name)
+		if app.ExplicitlyRequested {
+			servicesBySnap[snapName] = append(servicesBySnap[snapName], app.Name)
+		} else {
+			// Don't populate the list if the service was not explicitly
+			// requested; but we still need to allocate the map entry because
+			// it's used to keep the sortedNames list unique.
+			servicesBySnap[snapName] = nil
+		}
 	}
 	sort.Strings(sortedNames)
 
@@ -101,7 +140,12 @@ func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instructi
 		sort.Strings(svcs)
 		cmd.Services = svcs
 
-		summary := fmt.Sprintf("Run service command %q for services %q of snap %q", cmd.Action, svcs, cmd.SnapName)
+		var summary string
+		if len(cmd.Services) > 0 {
+			summary = fmt.Sprintf("Run service command %q for services %q of snap %q", cmd.Action, svcs, cmd.SnapName)
+		} else {
+			summary = fmt.Sprintf("Run service command %q for all services of snap %q", cmd.Action, cmd.SnapName)
+		}
 		task := st.NewTask("service-control", summary)
 		task.Set("service-action", cmd)
 		if prev != nil {
@@ -124,7 +168,7 @@ type Flags struct {
 // The appInfos and inst define the services and the command to execute.
 // Context is used to determine change conflicts - we will not conflict with
 // tasks from same change as that of context's.
-func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction, flags *Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
+func Control(st *state.State, appInfos []*ResolvedAppInfo, inst *Instruction, flags *Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
 	var tts []*state.TaskSet
 	var ctlcmds []string
 


### PR DESCRIPTION
This is an alternate solution to the same problem addressed by
https://github.com/snapcore/snapd/pull/10282


If only the snap name is given on the command line, do not always treat
it as if all services were mentioned, but rather pass the information
down to the command executors: they will decide whether the service list
needs to be computed or not.
