### PR TITLE
interfaces/apparmor: limit the number of jobs when running with a single CPU

### DIFF
--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -76,15 +76,16 @@ func maybeSetNumberOfJobs() string {
 	if cpus > 2 {
 		// otherwise spare 2
 		cpus = cpus - 2
-	} else if cpus == 2 {
-		// systems with only two CPUs, spare 1
-		cpus = cpus - 1
+	} else {
+		// Systems with only two CPUs, spare 1.
+		//
+		// When there is a a single CPU, pass -j1 to allow a single
+		// compilation job only. Note, we could pass -j0 in such case
+		// for further improvement, but that has incompatible meaning
+		// between apparmor 2.x (automatic job count, equivalent to
+		// -jauto) and 3.x (compile everything in the main process).
+		cpus = 1
 	}
-	// When there is a a single CPU, which could be beefy, but likely isn't,
-	// pass -j1 to allow a single compilation job only. Note, we could pass
-	// -j0 in such case for further improvement, but that has incompatible
-	// meaning between apparmor 2.x (automatic job count, equivalent to -jauto)
-	// and 3.x (compile everything in the main process).
 
 	return fmt.Sprintf("-j%d", cpus)
 }

--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -75,13 +75,18 @@ func maybeSetNumberOfJobs() string {
 	// Do not use all CPUs as this may have negative impact when booting.
 	if cpus > 2 {
 		// otherwise spare 2
-		return fmt.Sprintf("-j%d", cpus-2)
+		cpus = cpus - 2
+	} else if cpus == 2 {
+		// systems with only two CPUs, spare 1
+		cpus = cpus - 1
 	}
-	// On Systems with only two CPUs, spare 1. When there is a a single CPU,
-	// which could be beefy, but likely isn't, pass -j0 which has a special
-	// meaning so that the main apparmor_parser process is used for
-	// compilation without spawning additional workers.
-	return fmt.Sprintf("-j%d", cpus-1)
+	// When there is a a single CPU, which could be beefy, but likely isn't,
+	// pass -j1 to allow a single compilation job only. Note, we could pass
+	// -j0 in such case for further improvement, but that has incompatible
+	// meaning between apparmor 2.x (automatic job count, equivalent to -jauto)
+	// and 3.x (compile everything in the main process).
+
+	return fmt.Sprintf("-j%d", cpus)
 }
 
 // loadProfiles loads apparmor profiles from the given files.

--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -72,8 +72,7 @@ var runtimeNumCPU = runtime.NumCPU
 
 func maybeSetNumberOfJobs() string {
 	cpus := runtimeNumCPU()
-	// Do not use all CPUs as this may have negative impact when booting. Note, -j0 has special meaning
-	// so we don't want to pass it to apparmor parser.
+	// Do not use all CPUs as this may have negative impact when booting.
 	if cpus > 1 {
 		if cpus == 2 {
 			// systems with only two CPUs, spare 1
@@ -83,7 +82,10 @@ func maybeSetNumberOfJobs() string {
 			return fmt.Sprintf("-j%d", cpus-2)
 		}
 	}
-	return ""
+	// We have a single CPU, which could be beefy, but likely isn't, pass
+	// -j0 which has a special meaning so that the main apparmor_parser
+	// process is used for compilation.
+	return "-j0"
 }
 
 // loadProfiles loads apparmor profiles from the given files.

--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -73,19 +73,15 @@ var runtimeNumCPU = runtime.NumCPU
 func maybeSetNumberOfJobs() string {
 	cpus := runtimeNumCPU()
 	// Do not use all CPUs as this may have negative impact when booting.
-	if cpus > 1 {
-		if cpus == 2 {
-			// systems with only two CPUs, spare 1
-			return fmt.Sprintf("-j%d", cpus-1)
-		} else {
-			// otherwise spare 2
-			return fmt.Sprintf("-j%d", cpus-2)
-		}
+	if cpus > 2 {
+		// otherwise spare 2
+		return fmt.Sprintf("-j%d", cpus-2)
 	}
-	// We have a single CPU, which could be beefy, but likely isn't, pass
-	// -j0 which has a special meaning so that the main apparmor_parser
-	// process is used for compilation.
-	return "-j0"
+	// On Systems with only two CPUs, spare 1. When there is a a single CPU,
+	// which could be beefy, but likely isn't, pass -j0 which has a special
+	// meaning so that the main apparmor_parser process is used for
+	// compilation without spawning additional workers.
+	return fmt.Sprintf("-j%d", cpus-1)
 }
 
 // loadProfiles loads apparmor profiles from the given files.

--- a/interfaces/apparmor/apparmor_test.go
+++ b/interfaces/apparmor/apparmor_test.go
@@ -247,5 +247,5 @@ func (s *appArmorSuite) TestMaybeSetNumberOfJobs(c *C) {
 	c.Check(apparmor.MaybeSetNumberOfJobs(), Equals, "-j1")
 
 	cpus = 1
-	c.Check(apparmor.MaybeSetNumberOfJobs(), Equals, "")
+	c.Check(apparmor.MaybeSetNumberOfJobs(), Equals, "-j0")
 }

--- a/interfaces/apparmor/apparmor_test.go
+++ b/interfaces/apparmor/apparmor_test.go
@@ -247,5 +247,5 @@ func (s *appArmorSuite) TestMaybeSetNumberOfJobs(c *C) {
 	c.Check(apparmor.MaybeSetNumberOfJobs(), Equals, "-j1")
 
 	cpus = 1
-	c.Check(apparmor.MaybeSetNumberOfJobs(), Equals, "-j0")
+	c.Check(apparmor.MaybeSetNumberOfJobs(), Equals, "-j1")
 }


### PR DESCRIPTION
When the system has a single CPU, snapd would not pass any jobs flags to
apparmor_parser. In such case, the defaults would be used, which allow for up to
8 jobs to be started in parallel. What means, that with the way we pass the
flags, in a system with a single CPU would run the same number of jobs as 10 CPU
one (as we use #CPU - 2 there). Since the system has just 1 CPU, set the number of jobs
to 1 (same also for 2 CPUs).

There is an apparmor 3.x feature [1] that makes -j0 mean use the main process and don't fork but is not backward compatible (-j0 in apparmor 2.x means auto).

1. https://gitlab.com/apparmor/apparmor/-/blob/7dcf013bcab9548582734db244ba74f09449f9c1/parser/parser_main.c

