### PR TITLE
osutil: a helper to find out the total amount of memory in the system

### DIFF
--- a/osutil/meminfo.go
+++ b/osutil/meminfo.go
@@ -1,0 +1,74 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var (
+	procMeminfo = "/proc/meminfo"
+)
+
+// TotalSystemMemory returns the total memory in the system in bytes.
+func TotalSystemMemory() (totalMem uint64, err error) {
+	f, err := os.Open(procMeminfo)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	for {
+		if !s.Scan() {
+			break
+		}
+		l := strings.TrimSpace(s.Text())
+		if !strings.HasPrefix(l, "MemTotal:") {
+			continue
+		}
+		fields := strings.Fields(l)
+		if len(fields) != 3 || fields[2] != "kB" {
+			return 0, fmt.Errorf("cannot process unexpected meminfo entry %q", l)
+		}
+		totalMem, err = strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot convert memory size value: %v", err)
+		}
+		// got it
+		return totalMem * 1024, nil
+	}
+	if err := s.Err(); err != nil {
+		return 0, err
+	}
+	return 0, fmt.Errorf("cannot determine the total amount of memory in the system from %s", procMeminfo)
+}
+
+func MockProcMeminfo(newPath string) (restore func()) {
+	MustBeTestBinary("mocking can only be done from tests")
+	oldProcMeminfo := procMeminfo
+	procMeminfo = newPath
+	return func() {
+		procMeminfo = oldProcMeminfo
+	}
+}

--- a/osutil/meminfo_test.go
+++ b/osutil/meminfo_test.go
@@ -103,12 +103,23 @@ func (s *meminfoSuite) TestMemInfoHappy(c *C) {
 	mem, err = osutil.TotalSystemMemory()
 	c.Assert(err, IsNil)
 	c.Check(mem, Equals, uint64(1234)*1024)
+
+	const meminfoReorderedWithEmptyLine = `MemAvailable:   20527370 kB
+
+MemTotal:       32876699 kB
+MemFree:         3478104 kB
+`
+	c.Assert(ioutil.WriteFile(p, []byte(meminfoReorderedWithEmptyLine), 0644), IsNil)
+
+	mem, err = osutil.TotalSystemMemory()
+	c.Assert(err, IsNil)
+	c.Check(mem, Equals, uint64(32876699)*1024)
 }
 
 func (s *meminfoSuite) TestMemInfoFromHost(c *C) {
 	mem, err := osutil.TotalSystemMemory()
 	c.Assert(err, IsNil)
-	c.Check(mem > uint64(128*1024*1024),
+	c.Check(mem > uint64(32*1024*1024),
 		Equals, true, Commentf("unexpected system memory %v", mem))
 }
 

--- a/osutil/meminfo_test.go
+++ b/osutil/meminfo_test.go
@@ -1,0 +1,159 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type meminfoSuite struct{}
+
+var _ = Suite(&meminfoSuite{})
+
+const meminfoExampleFromLiveSystem = `MemTotal:       32876680 kB
+MemFree:         3478104 kB
+MemAvailable:   20527364 kB
+Buffers:         1584432 kB
+Cached:         14550292 kB
+SwapCached:            0 kB
+Active:          8344864 kB
+Inactive:       16209412 kB
+Active(anon):     139828 kB
+Inactive(anon):  8944656 kB
+Active(file):    8205036 kB
+Inactive(file):  7264756 kB
+Unevictable:        2152 kB
+Mlocked:            2152 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+Dirty:               804 kB
+Writeback:             4 kB
+AnonPages:       8201352 kB
+Mapped:          1223272 kB
+Shmem:            697812 kB
+KReclaimable:    2043404 kB
+Slab:            2423344 kB
+SReclaimable:    2043404 kB
+SUnreclaim:       379940 kB
+KernelStack:       37392 kB
+PageTables:        97644 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    16438340 kB
+Committed_AS:   30191756 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:      160500 kB
+VmallocChunk:          0 kB
+Percpu:            24256 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:    120832 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+FileHugePages:         0 kB
+FilePmdMapped:         0 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:               0 kB
+DirectMap4k:     3059376 kB
+DirectMap2M:    23089152 kB
+DirectMap1G:     8388608 kB
+`
+
+func (s *meminfoSuite) TestMemInfoHappy(c *C) {
+	p := filepath.Join(c.MkDir(), "meminfo")
+	restore := osutil.MockProcMeminfo(p)
+	defer restore()
+
+	c.Assert(ioutil.WriteFile(p, []byte(meminfoExampleFromLiveSystem), 0644), IsNil)
+
+	mem, err := osutil.TotalSystemMemory()
+	c.Assert(err, IsNil)
+	c.Check(mem, Equals, uint64(32876680)*1024)
+
+	c.Assert(ioutil.WriteFile(p, []byte(`MemTotal:    1234 kB`), 0644), IsNil)
+
+	mem, err = osutil.TotalSystemMemory()
+	c.Assert(err, IsNil)
+	c.Check(mem, Equals, uint64(1234)*1024)
+}
+
+func (s *meminfoSuite) TestMemInfoFromHost(c *C) {
+	mem, err := osutil.TotalSystemMemory()
+	c.Assert(err, IsNil)
+	c.Check(mem > uint64(128*1024*1024),
+		Equals, true, Commentf("unexpected system memory %v", mem))
+}
+
+func (s *meminfoSuite) TestMemInfoUnhappy(c *C) {
+	p := filepath.Join(c.MkDir(), "meminfo")
+	restore := osutil.MockProcMeminfo(p)
+	defer restore()
+
+	const noTotalMem = `MemFree:         3478104 kB
+MemAvailable:   20527364 kB
+Buffers:         1584432 kB
+Cached:         14550292 kB
+`
+	const notkBTotalMem = `MemTotal:         3478104 MB
+`
+	const missingFieldsTotalMem = `MemTotal:  1234
+`
+	const badTotalMem = `MemTotal:  abcdef kB
+`
+	const hexTotalMem = `MemTotal:  0xabcdef kB
+`
+
+	for _, tc := range []struct {
+		content, err string
+	}{
+		{
+			content: noTotalMem,
+			err:     `cannot determine the total amount of memory in the system from .*/meminfo`,
+		}, {
+			content: notkBTotalMem,
+			err:     `cannot process unexpected meminfo entry "MemTotal:         3478104 MB"`,
+		}, {
+			content: missingFieldsTotalMem,
+			err:     `cannot process unexpected meminfo entry "MemTotal:  1234"`,
+		}, {
+			content: badTotalMem,
+			err:     `cannot convert memory size value: strconv.ParseUint: parsing "abcdef": invalid syntax`,
+		}, {
+			content: hexTotalMem,
+			err:     `cannot convert memory size value: strconv.ParseUint: parsing "0xabcdef": invalid syntax`,
+		},
+	} {
+		c.Assert(ioutil.WriteFile(p, []byte(tc.content), 0644), IsNil)
+		mem, err := osutil.TotalSystemMemory()
+		c.Assert(err, ErrorMatches, tc.err)
+		c.Check(mem, Equals, uint64(0))
+	}
+}


### PR DESCRIPTION
Introduce a helper to determine the total amount of memory in the system by
inspecting the contents of /proc/meminfo.

So that we can extend the idea in #10295 and look at memory too.