### PR TITLE
seed/seedtest, overlord/devicestate: move seed validation helper to seedtest

### DIFF
--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -1184,7 +1184,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
 
-	validateSeed(c, "1234", s.storeSigning.Trusted)
+	validateCore20Seed(c, "1234", s.storeSigning.Trusted)
 	m, err := s.bootloader.GetBootVars("try_recovery_system", "recovery_system_status")
 	c.Assert(err, IsNil)
 	c.Check(m, DeepEquals, map[string]string{
@@ -1280,7 +1280,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 		filepath.Join(boot.InitramfsUbuntuSeedDir, "snaps/some-snap_1.snap"),
 	})
 	// do more extensive validation
-	validateSeed(c, "1234undo", s.storeSigning.Trusted)
+	validateCore20Seed(c, "1234undo", s.storeSigning.Trusted)
 	m, err := s.bootloader.GetBootVars("try_recovery_system", "recovery_system_status")
 	c.Assert(err, IsNil)
 	c.Check(m, DeepEquals, map[string]string{
@@ -1359,7 +1359,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
 
-	validateSeed(c, "1234", s.storeSigning.Trusted)
+	validateCore20Seed(c, "1234", s.storeSigning.Trusted)
 	m, err := s.bootloader.GetBootVars("try_recovery_system", "recovery_system_status")
 	c.Assert(err, IsNil)
 	c.Check(m, DeepEquals, map[string]string{

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -118,8 +118,9 @@ func (s *createSystemSuite) makeEssentialSnapInfos(c *C) map[string]*snap.Info {
 	return infos
 }
 
-func validateSeed(c *C, name string, trusted []asserts.Assertion, runModeSnapNames ...string) {
-	sd := seedtest.ValidateSeed(c, boot.InitramfsUbuntuSeedDir, name, trusted)
+func validateCore20Seed(c *C, name string, trusted []asserts.Assertion, runModeSnapNames ...string) {
+	const usesSnapd = true
+	sd := seedtest.ValidateSeed(c, boot.InitramfsUbuntuSeedDir, name, usesSnapd, trusted)
 
 	snaps, err := sd.ModeSnaps(boot.ModeRun)
 	c.Assert(err, IsNil)
@@ -248,7 +249,7 @@ func (s *createSystemSuite) TestCreateSystemFromAssertedSnaps(c *C) {
 		"snapd_recovery_kernel":    "/snaps/pc-kernel_1.snap",
 	})
 	// load the seed
-	validateSeed(c, "1234", s.storeSigning.Trusted,
+	validateCore20Seed(c, "1234", s.storeSigning.Trusted,
 		"other-core18", "core18", "other-present", "other-required")
 }
 
@@ -336,7 +337,7 @@ func (s *createSystemSuite) TestCreateSystemFromUnassertedSnaps(c *C) {
 		}
 	}
 	// load the seed
-	validateSeed(c, "1234", s.storeSigning.Trusted, "other-unasserted")
+	validateCore20Seed(c, "1234", s.storeSigning.Trusted, "other-unasserted")
 	// we have unasserted snaps, so a warning should have been logged
 	c.Check(s.logbuf.String(), testutil.Contains, `system "1234" contains unasserted snaps "other-unasserted"`)
 }
@@ -419,7 +420,7 @@ func (s *createSystemSuite) TestCreateSystemWithSomeSnapsAlreadyExisting(c *C) {
 		"snapd_recovery_kernel":    "/snaps/pc-kernel_1.snap",
 	})
 	// load the seed
-	validateSeed(c, "1234", s.storeSigning.Trusted)
+	validateCore20Seed(c, "1234", s.storeSigning.Trusted)
 
 	// add an unasserted snap
 	infos["other-unasserted"] = s.makeSnap(c, "other-unasserted", snap.R(-1))
@@ -729,7 +730,7 @@ func (s *createSystemSuite) TestCreateSystemImplicitSnaps(c *C) {
 	})
 	c.Check(dir, Equals, filepath.Join(boot.InitramfsUbuntuSeedDir, "systems/1234"))
 	// validate the seed
-	validateSeed(c, "1234", s.ss.StoreSigning.Trusted)
+	validateCore20Seed(c, "1234", s.ss.StoreSigning.Trusted)
 }
 
 func (s *createSystemSuite) TestCreateSystemObserverErr(c *C) {

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -340,7 +340,7 @@ func (s *TestingSeed20) MakeSeed(c *C, label, brandID, modelID string, modelHead
 	return model
 }
 
-func ValidateSeed(c *C, root, label string, trusted []asserts.Assertion) seed.Seed {
+func ValidateSeed(c *C, root, label string, usesSnapd bool, trusted []asserts.Assertion) seed.Seed {
 	tm := &timings.Timings{}
 	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
 		Backstore: asserts.NewMemoryBackstore(),
@@ -359,10 +359,15 @@ func ValidateSeed(c *C, root, label string, trusted []asserts.Assertion) seed.Se
 
 	err = sd.LoadMeta(tm)
 	c.Assert(err, IsNil)
-	// uc20 recovery systems use snapd
-	c.Check(sd.UsesSnapdSnap(), Equals, true)
-	// XXX: more extensive seed validation?
 
-	c.Check(sd.EssentialSnaps(), HasLen, 4)
+	// core18/core20 use the snapd snap, old core does not
+	c.Check(sd.UsesSnapdSnap(), Equals, usesSnapd)
+	if usesSnapd {
+		// core*, kernel, gadget, snapd
+		c.Check(sd.EssentialSnaps(), HasLen, 4)
+	} else {
+		// core, kernel, gadget
+		c.Check(sd.EssentialSnaps(), HasLen, 3)
+	}
 	return sd
 }

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -760,6 +760,115 @@ func (s *writerSuite) TestDownloadedCheckTypeCore(c *C) {
 	c.Check(err, ErrorMatches, `core snap has unexpected type: base`)
 }
 
+func (s *writerSuite) TestSeedSnapsWriteMetaCore16(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"gadget":       "pc",
+		"kernel":       "pc-kernel",
+	})
+
+	// the minimum set of snaps
+	s.makeSnap(c, "core", "")
+	s.makeSnap(c, "pc-kernel", "")
+	s.makeSnap(c, "pc", "")
+
+	w, err := seedwriter.New(model, s.opts)
+	c.Assert(err, IsNil)
+
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
+	c.Assert(err, IsNil)
+
+	_, err = w.Start(s.db, s.newFetcher)
+	c.Assert(err, IsNil)
+
+	snaps, err := w.SnapsToDownload()
+	c.Assert(err, IsNil)
+	c.Check(snaps, HasLen, 3)
+
+	for _, sn := range snaps {
+		s.fillDownloadedSnap(c, w, sn)
+	}
+
+	complete, err := w.Downloaded()
+	c.Assert(err, IsNil)
+	c.Check(complete, Equals, true)
+
+	err = w.SeedSnaps(nil)
+	c.Assert(err, IsNil)
+
+	err = w.WriteMeta()
+	c.Assert(err, IsNil)
+
+	// check seed
+	seedYaml, err := seedwriter.InternalReadSeedYaml(filepath.Join(s.opts.SeedDir, "seed.yaml"))
+	c.Assert(err, IsNil)
+
+	c.Check(seedYaml.Snaps, HasLen, 3)
+
+	// check the files are in place
+	for i, name := range []string{"core", "pc-kernel", "pc"} {
+		info := s.AssertedSnapInfo(name)
+
+		fn := info.Filename()
+		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
+		c.Check(p, testutil.FilePresent)
+
+		channel := "stable"
+		if name == "pc" {
+			channel = "edge"
+		}
+
+		c.Check(seedYaml.Snaps[i], DeepEquals, &seedwriter.InternalSnap16{
+			Name:    info.SnapName(),
+			SnapID:  info.SnapID,
+			Channel: channel,
+			File:    fn,
+			Contact: info.Contact,
+		})
+	}
+
+	l, err := ioutil.ReadDir(filepath.Join(s.opts.SeedDir, "snaps"))
+	c.Assert(err, IsNil)
+	c.Check(l, HasLen, 3)
+
+	// check assertions
+	seedAssertsDir := filepath.Join(s.opts.SeedDir, "assertions")
+	storeAccountKeyPK := s.StoreSigning.StoreAccountKey("").PublicKeyID()
+	brandAcctKeyPK := s.Brands.AccountKey("my-brand").PublicKeyID()
+
+	for _, fn := range []string{"model", brandAcctKeyPK + ".account-key", "my-brand.account", storeAccountKeyPK + ".account-key"} {
+		p := filepath.Join(seedAssertsDir, fn)
+		c.Check(p, testutil.FilePresent)
+	}
+
+	c.Check(filepath.Join(seedAssertsDir, "model"), testutil.FileEquals, asserts.Encode(model))
+
+	acct := seedtest.ReadAssertions(c, filepath.Join(seedAssertsDir, "my-brand.account"))
+	c.Assert(acct, HasLen, 1)
+	c.Check(acct[0].Type(), Equals, asserts.AccountType)
+	c.Check(acct[0].HeaderString("account-id"), Equals, "my-brand")
+
+	// check the snap assertions are also in place
+	for _, snapName := range []string{"pc-kernel", "core", "pc"} {
+		p := filepath.Join(seedAssertsDir, fmt.Sprintf("16,%s.snap-declaration", s.AssertedSnapID(snapName)))
+		decl := seedtest.ReadAssertions(c, p)
+		c.Assert(decl, HasLen, 1)
+		c.Check(decl[0].Type(), Equals, asserts.SnapDeclarationType)
+		c.Check(decl[0].HeaderString("snap-name"), Equals, snapName)
+		p = filepath.Join(seedAssertsDir, fmt.Sprintf("%s.snap-revision", s.AssertedSnapRevision(snapName).SnapSHA3_384()))
+		rev := seedtest.ReadAssertions(c, p)
+		c.Assert(rev, HasLen, 1)
+		c.Check(rev[0].Type(), Equals, asserts.SnapRevisionType)
+		c.Check(rev[0].HeaderString("snap-id"), Equals, s.AssertedSnapID(snapName))
+	}
+
+	// sanity check of seedtest helper
+	const usesSnapd = false
+	// core seeds do not use system labels
+	seedtest.ValidateSeed(c, s.opts.SeedDir, "", usesSnapd, s.StoreSigning.Trusted)
+}
+
 func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
 		"display-name":   "my model",
@@ -870,6 +979,11 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 		c.Check(rev[0].Type(), Equals, asserts.SnapRevisionType)
 		c.Check(rev[0].HeaderString("snap-id"), Equals, s.AssertedSnapID(snapName))
 	}
+
+	// sanity check of seedtest helper
+	const usesSnapd = true
+	// core18 seeds do not use system labels
+	seedtest.ValidateSeed(c, s.opts.SeedDir, "", usesSnapd, s.StoreSigning.Trusted)
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore18StoreAssertion(c *C) {
@@ -1948,6 +2062,11 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20(c *C) {
 	})
 
 	c.Check(filepath.Join(systemDir, "options.yaml"), testutil.FileAbsent)
+
+	// sanity check of seedtest helper
+	const usesSnapd = true
+	seedtest.ValidateSeed(c, s.opts.SeedDir, s.opts.Label, usesSnapd,
+		s.StoreSigning.Trusted)
 }
 
 func (s *writerSuite) TestCore20InvalidLabel(c *C) {


### PR DESCRIPTION
In preparation for managers level tests using the helper, move it around to the seedtest package.