### PR TITLE
overlord, overlord/devicestate: allow for reloading modeenv in devicemgr when testing

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -699,8 +699,22 @@ func (m *DeviceManager) ensureSeeded() error {
 
 // ResetBootOk is only useful for integration testing
 func (m *DeviceManager) ResetBootOk() {
+	osutil.MustBeTestBinary("ResetBootOk can only be called from tests")
 	m.bootOkRan = false
 	m.bootRevisionsUpdated = false
+}
+
+// ReloadModeenv is only useful for integration testing
+func (m *DeviceManager) ReloadModeenv() error {
+	osutil.MustBeTestBinary("ReloadModeenv can only be called from tests")
+	modeEnv, err := maybeReadModeenv()
+	if err != nil {
+		return err
+	}
+	if modeEnv != nil {
+		m.systemMode = modeEnv.Mode
+	}
+	return nil
 }
 
 func (m *DeviceManager) ensureBootOk() error {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -197,6 +197,19 @@ func maybeReadModeenv() (*boot.Modeenv, error) {
 	return modeEnv, nil
 }
 
+// ReloadModeenv is only useful for integration testing
+func (m *DeviceManager) ReloadModeenv() error {
+	osutil.MustBeTestBinary("ReloadModeenv can only be called from tests")
+	modeEnv, err := maybeReadModeenv()
+	if err != nil {
+		return err
+	}
+	if modeEnv != nil {
+		m.systemMode = modeEnv.Mode
+	}
+	return nil
+}
+
 // StartUp implements StateStarterUp.Startup.
 func (m *DeviceManager) StartUp() error {
 	// system mode is explicitly set on UC20
@@ -702,19 +715,6 @@ func (m *DeviceManager) ResetBootOk() {
 	osutil.MustBeTestBinary("ResetBootOk can only be called from tests")
 	m.bootOkRan = false
 	m.bootRevisionsUpdated = false
-}
-
-// ReloadModeenv is only useful for integration testing
-func (m *DeviceManager) ReloadModeenv() error {
-	osutil.MustBeTestBinary("ReloadModeenv can only be called from tests")
-	modeEnv, err := maybeReadModeenv()
-	if err != nil {
-		return err
-	}
-	if modeEnv != nil {
-		m.systemMode = modeEnv.Mode
-	}
-	return nil
 }
 
 func (m *DeviceManager) ensureBootOk() error {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -2202,6 +2202,7 @@ type: kernel`
 	}
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
+	c.Assert(s.o.DeviceManager().ReloadModeenv(), IsNil)
 
 	st := s.o.State()
 	st.Lock()
@@ -2369,6 +2370,7 @@ type: kernel`
 	}
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
+	c.Assert(s.o.DeviceManager().ReloadModeenv(), IsNil)
 
 	st := s.o.State()
 	st.Lock()
@@ -6503,6 +6505,7 @@ func (s *mgrsSuite) testUC20RunUpdateManagedBootConfig(c *C, snapPath string, si
 	}
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
+	c.Assert(s.o.DeviceManager().ReloadModeenv(), IsNil)
 
 	st := s.o.State()
 	st.Lock()
@@ -6856,6 +6859,7 @@ func (s *mgrsSuite) testGadgetKernelCommandLine(c *C, gadgetPath string, gadgetS
 	}
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
+	c.Assert(s.o.DeviceManager().ReloadModeenv(), IsNil)
 
 	st := s.o.State()
 	st.Lock()


### PR DESCRIPTION
When running managers tests, the device manager is created as part of the test
setup. The modeenv is only read once, when the manager is created, thus making
it problematic for tests that modify the modeenv to observe the desired changes.
Add a helper that allows for reloading the modeenv in tests.


