### PR TITLE
tests/lib/reset: make nc exit after a while when connection is idle

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -88,7 +88,7 @@ reset_classic() {
 
         EXTRA_NC_ARGS="-q 1"
         case "$SPREAD_SYSTEM" in
-            fedora-34*)
+            fedora-34-*|debian-10-*)
                 # Param -q is not available on fedora 34
                 EXTRA_NC_ARGS="-w 1"
                 ;;


### PR DESCRIPTION
We have observed nc to get stuck on Debian 10 when snapd socket is restart. The
problem can also reproduced locally at random. Try to apply the workaround we
have for Fedora 34 on Debian.
