### PR TITLE
systemd: add CurrentMemoryUsage to get current memory usage for a unit

### DIFF
--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/squashfs"
 )
@@ -92,6 +93,10 @@ func (s *emulation) Status(units ...string) ([]*UnitStatus, error) {
 
 func (s *emulation) InactiveEnterTimestamp(unit string) (time.Time, error) {
 	return time.Time{}, errNotImplemented
+}
+
+func (s *emulation) CurrentMemoryUsage(unit string) (quantity.Size, error) {
+	return 0, errNotImplemented
 }
 
 func (s *emulation) IsEnabled(service string) (bool, error) {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -601,7 +601,7 @@ func (s *systemd) CurrentMemoryUsage(unit string) (quantity.Size, error) {
 	// strip the MemoryCurrent= from the output
 	splitVal := strings.SplitN(strings.TrimSpace(string(out)), "=", 2)
 	if len(splitVal) != 2 {
-		return 0, fmt.Errorf("invalid format from systemd")
+		return 0, fmt.Errorf("invalid property format from systemd for MemoryCurrent")
 	}
 
 	trimmedVal := strings.TrimSpace(splitVal[1])
@@ -614,7 +614,7 @@ func (s *systemd) CurrentMemoryUsage(unit string) (quantity.Size, error) {
 
 	intVal, err := strconv.Atoi(trimmedVal)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("invalid property format for memory: cannot parse %q as an integer", trimmedVal)
 	}
 
 	return quantity.Size(intVal), nil

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -614,7 +614,7 @@ func (s *systemd) CurrentMemoryUsage(unit string) (quantity.Size, error) {
 
 	intVal, err := strconv.Atoi(trimmedVal)
 	if err != nil {
-		return 0, fmt.Errorf("invalid property format for memory: cannot parse %q as an integer", trimmedVal)
+		return 0, fmt.Errorf("invalid property value from systemd for MemoryCurrent: cannot parse %q as an integer", trimmedVal)
 	}
 
 	return quantity.Size(intVal), nil

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1415,7 +1415,7 @@ func (s *SystemdTestSuite) TestCurrentMemoryUsageInvalid(c *C) {
 	}
 	sysd := New(SystemMode, s.rep)
 	_, err := sysd.CurrentMemoryUsage("bar.service")
-	c.Assert(err, ErrorMatches, `invalid property format for memory: cannot parse "blahhhhhhhhhhhh" as an integer`)
+	c.Assert(err, ErrorMatches, `invalid property value from systemd for MemoryCurrent: cannot parse "blahhhhhhhhhhhh" as an integer`)
 	c.Check(s.argses, DeepEquals, [][]string{
 		{"show", "--property", "MemoryCurrent", "bar.service"},
 	})

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1409,6 +1409,18 @@ func (s *SystemdTestSuite) TestCurrentMemoryUsageInactive(c *C) {
 	})
 }
 
+func (s *SystemdTestSuite) TestCurrentMemoryUsageInvalid(c *C) {
+	s.outs = [][]byte{
+		[]byte(`MemoryCurrent=blahhhhhhhhhhhh`),
+	}
+	sysd := New(SystemMode, s.rep)
+	_, err := sysd.CurrentMemoryUsage("bar.service")
+	c.Assert(err, ErrorMatches, `invalid property format for memory: cannot parse "blahhhhhhhhhhhh" as an integer`)
+	c.Check(s.argses, DeepEquals, [][]string{
+		{"show", "--property", "MemoryCurrent", "bar.service"},
+	})
+}
+
 func (s *SystemdTestSuite) TestCurrentMemoryUsage(c *C) {
 	s.outs = [][]byte{
 		[]byte(`MemoryCurrent=1024`),


### PR DESCRIPTION
The unit can be a service or a slice. If the unit or slice doesn't exist or is
not active, then an error is returned.

This is needed for daemon to get the current memory usage for a quota
group.