### PR TITLE
daemon/api_quotas.go: support updating quotas with ensure action

### DIFF
--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -64,6 +64,7 @@ type quotaGroupResultJSON struct {
 
 var (
 	servicestateCreateQuota = servicestate.CreateQuota
+	servicestateUpdateQuota = servicestate.UpdateQuota
 	servicestateRemoveQuota = servicestate.RemoveQuota
 )
 
@@ -149,11 +150,29 @@ func postQuotaGroup(c *Command, r *http.Request, _ *auth.UserState) Response {
 
 	switch data.Action {
 	case "ensure":
-		// TODO: quota updates
-		if err := servicestateCreateQuota(st, data.GroupName, data.Parent, data.Snaps, quantity.Size(data.MaxMemory)); err != nil {
-			// XXX: dedicated error type?
-			return BadRequest(err.Error())
+		// check if the quota group exists first, if it does then we need to
+		// update it instead of create it
+		_, err := servicestate.GetQuota(st, data.GroupName)
+		if err != nil && err != servicestate.ErrQuotaNotFound {
+			return InternalError(err.Error())
 		}
+		if err == servicestate.ErrQuotaNotFound {
+			// then we need to create the quota
+			if err := servicestateCreateQuota(st, data.GroupName, data.Parent, data.Snaps, quantity.Size(data.MaxMemory)); err != nil {
+				// XXX: dedicated error type?
+				return BadRequest(err.Error())
+			}
+		} else if err == nil {
+			// the quota group already exists, update it
+			updateOpts := servicestate.QuotaGroupUpdate{
+				AddSnaps:       data.Snaps,
+				NewMemoryLimit: quantity.Size(data.MaxMemory),
+			}
+			if err := servicestateUpdateQuota(st, data.GroupName, updateOpts); err != nil {
+				return BadRequest(err.Error())
+			}
+		}
+
 	case "remove":
 		if err := servicestateRemoveQuota(st, data.GroupName); err != nil {
 			return BadRequest(err.Error())

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -143,7 +143,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestate.CreateQuota(st, "ginger-ale", "", nil, 9000)
+	err := servicestate.CreateQuota(st, "ginger-ale", "", nil, 1000)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -159,7 +159,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:       []string{"some-snap"},
-			NewMemoryLimit: 1000,
+			NewMemoryLimit: 9000,
 		})
 		return nil
 	})
@@ -169,7 +169,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 		Action:    "ensure",
 		GroupName: "ginger-ale",
 		Snaps:     []string{"some-snap"},
-		MaxMemory: 1000,
+		MaxMemory: 9000,
 	})
 	c.Assert(err, check.IsNil)
 

--- a/daemon/export_api_quotas_test.go
+++ b/daemon/export_api_quotas_test.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -34,6 +35,14 @@ func MockServicestateCreateQuota(f func(st *state.State, name string, parentName
 	servicestateCreateQuota = f
 	return func() {
 		servicestateCreateQuota = old
+	}
+}
+
+func MockServicestateUpdateQuota(f func(st *state.State, name string, opts servicestate.QuotaGroupUpdate) error) func() {
+	old := servicestateUpdateQuota
+	servicestateUpdateQuota = f
+	return func() {
+		servicestateUpdateQuota = old
 	}
 }
 


### PR DESCRIPTION
This is needed in order to support quota group updates.