### PR TITLE
snap/quota: add CurrentMemoryUsage for current memory usage of a quota group

### DIFF
--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -674,11 +674,11 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRes
 	c.Assert(s.restartRequests, HasLen, 0)
 }
 
-type systemctlDisabledServicError struct{}
+type systemctlDisabledServiceError struct{}
 
-func (s systemctlDisabledServicError) Msg() []byte   { return []byte("disabled") }
-func (s systemctlDisabledServicError) ExitCode() int { return 1 }
-func (s systemctlDisabledServicError) Error() string { return "disabled service" }
+func (s systemctlDisabledServiceError) Msg() []byte   { return []byte("disabled") }
+func (s systemctlDisabledServiceError) ExitCode() int { return 1 }
+func (s systemctlDisabledServiceError) Error() string { return "disabled service" }
 
 func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesButDoesNotRestartDisabledServices(c *C) {
 	s.state.Lock()
@@ -733,7 +733,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesButDoe
 		{
 			expArgs: []string{"is-enabled", "snap.test-snap.svc1.service"},
 			output:  "disabled",
-			err:     systemctlDisabledServicError{},
+			err:     systemctlDisabledServiceError{},
 		},
 		// then we don't restart the service even though it was killed
 	})

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -28,6 +28,7 @@ import (
 
 	// TODO: move this to snap/quantity? or similar
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/systemd"
 )
@@ -83,6 +84,26 @@ func NewGroup(name string, memLimit quantity.Size) (*Group, error) {
 	}
 
 	return grp, nil
+}
+
+// CurrentMemoryUsage returns the current memory usage of the quota group. For
+// quota groups which do not yet have a backing systemd slice on the system (
+// i.e. quota groups without any snaps in them), the memory usage is reported as
+// 0.
+func (grp *Group) CurrentMemoryUsage() (quantity.Size, error) {
+	sysd := systemd.New(systemd.SystemMode, progress.Null)
+
+	// check if this group is actually active, it could not physically exist yet
+	// since it has no snaps in it
+	isActive, err := sysd.IsActive(grp.SliceFileName())
+	if err != nil {
+		return 0, err
+	}
+	if !isActive {
+		return 0, nil
+	}
+
+	return sysd.CurrentMemoryUsage(grp.SliceFileName())
 }
 
 // SliceFileName returns the name of the slice file that should be used for this

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/squashfs"
 )
@@ -92,6 +93,10 @@ func (s *emulation) Status(units ...string) ([]*UnitStatus, error) {
 
 func (s *emulation) InactiveEnterTimestamp(unit string) (time.Time, error) {
 	return time.Time{}, errNotImplemented
+}
+
+func (s *emulation) CurrentMemoryUsage(unit string) (quantity.Size, error) {
+	return 0, errNotImplemented
 }
 
 func (s *emulation) IsEnabled(service string) (bool, error) {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -734,9 +734,9 @@ func (s *systemd) IsActive(serviceName string) (bool, error) {
 	// services, the stderr output may be `inactive\n` for services that are
 	// inactive (or not found), or `failed\n` for services that are in a
 	// failed state; nevertheless make sure to check any non-0 exit code
-	sysdErr, ok := err.(*Error)
+	sysdErr, ok := err.(systemctlError)
 	if ok {
-		switch strings.TrimSpace(string(sysdErr.msg)) {
+		switch strings.TrimSpace(string(sysdErr.Msg())) {
 		case "inactive", "failed":
 			return false, nil
 		}


### PR DESCRIPTION
Based on top of #10304. 

The function returns 0 for slices that don't currently exist.

