### PR TITLE
daemon: add a Daemon argument to AccessChecker.CheckAccess

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -65,7 +65,7 @@ func checkPolkitActionImpl(r *http.Request, ucred *ucrednet, action string) *api
 // accessUnknown, which indicates the decision should be delegated to
 // the next access checker.
 type accessChecker interface {
-	CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError
+	CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError
 }
 
 // requireSnapdSocket ensures the request was received via snapd.socket.
@@ -85,7 +85,7 @@ func requireSnapdSocket(ucred *ucrednet) *apiError {
 // have peer credentials and were not received on snapd-snap.socket
 type openAccess struct{}
 
-func (ac openAccess) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac openAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 	return requireSnapdSocket(ucred)
 }
 
@@ -99,7 +99,7 @@ type authenticatedAccess struct {
 	Polkit string
 }
 
-func (ac authenticatedAccess) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac authenticatedAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 	if rspe := requireSnapdSocket(ucred); rspe != nil {
 		return rspe
 	}
@@ -126,7 +126,7 @@ func (ac authenticatedAccess) CheckAccess(r *http.Request, ucred *ucrednet, user
 // were not received on snapd-snap.socket
 type rootAccess struct{}
 
-func (ac rootAccess) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac rootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 	if rspe := requireSnapdSocket(ucred); rspe != nil {
 		return rspe
 	}
@@ -140,7 +140,7 @@ func (ac rootAccess) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.Us
 // snapAccess allows requests from the snapd-snap.socket
 type snapAccess struct{}
 
-func (ac snapAccess) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac snapAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 	if ucred == nil {
 		return Forbidden("access denied")
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -150,7 +150,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if rspe := access.CheckAccess(r, ucred, user); rspe != nil {
+	if rspe := access.CheckAccess(c.d, r, ucred, user); rspe != nil {
 		rspe.ServeHTTP(w, r)
 		return
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -356,10 +356,10 @@ func (s *daemonSuite) TestFillsWarnings(c *check.C) {
 	c.Check(rst.WarningTimestamp, check.NotNil)
 }
 
-type accessCheckFunc func(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError
+type accessCheckFunc func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError
 
-func (f accessCheckFunc) CheckAccess(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
-	return f(r, ucred, user)
+func (f accessCheckFunc) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	return f(d, r, ucred, user)
 }
 
 func (s *daemonSuite) TestReadAccess(c *check.C) {
@@ -368,8 +368,9 @@ func (s *daemonSuite) TestReadAccess(c *check.C) {
 		return SyncResponse(nil)
 	}
 	var accessCalled bool
-	cmd.ReadAccess = accessCheckFunc(func(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.ReadAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 		accessCalled = true
+		c.Check(d, check.Equals, cmd.d)
 		c.Check(r, check.NotNil)
 		c.Assert(ucred, check.NotNil)
 		c.Check(ucred.Uid, check.Equals, uint32(42))
@@ -378,7 +379,7 @@ func (s *daemonSuite) TestReadAccess(c *check.C) {
 		c.Check(user, check.IsNil)
 		return nil
 	})
-	cmd.WriteAccess = accessCheckFunc(func(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.WriteAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 		c.Fail()
 		return Forbidden("")
 	})
@@ -399,13 +400,14 @@ func (s *daemonSuite) TestWriteAccess(c *check.C) {
 	cmd.POST = func(*Command, *http.Request, *auth.UserState) Response {
 		return SyncResponse(nil)
 	}
-	cmd.ReadAccess = accessCheckFunc(func(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.ReadAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 		c.Fail()
 		return Forbidden("")
 	})
 	var accessCalled bool
-	cmd.WriteAccess = accessCheckFunc(func(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.WriteAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 		accessCalled = true
+		c.Check(d, check.Equals, cmd.d)
 		c.Check(r, check.NotNil)
 		c.Assert(ucred, check.NotNil)
 		c.Check(ucred.Uid, check.Equals, uint32(42))
@@ -446,13 +448,14 @@ func (s *daemonSuite) TestWriteAccessWithUser(c *check.C) {
 	cmd.POST = func(*Command, *http.Request, *auth.UserState) Response {
 		return SyncResponse(nil)
 	}
-	cmd.ReadAccess = accessCheckFunc(func(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.ReadAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 		c.Fail()
 		return Forbidden("")
 	})
 	var accessCalled bool
-	cmd.WriteAccess = accessCheckFunc(func(r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.WriteAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 		accessCalled = true
+		c.Check(d, check.Equals, cmd.d)
 		c.Check(r, check.NotNil)
 		c.Assert(ucred, check.NotNil)
 		c.Check(ucred.Uid, check.Equals, uint32(1001))


### PR DESCRIPTION
We want to make the theme installation REST API available to selected snaps over the `snapd-snap.socket` socket.  At present, the idea is to control which snaps have access to these calls through a marker interface. That means the access checker will need to be able to check whether a given snap has a connected plug of the marker interface.  I've done this by passing the `Daemon` as an argument to the`CheckAccess` method.

There are some alternatives that could be used instead:
* We really want the `Overlord` to perform the interface connection check, so we could pass that instead. There may be other future use cases that need more than the Overlord though.
* `Command` would also be usable here, since it holds a pointer to the `Daemon`.  It's not clear what other information in that struct could be useful to an access checker though.