### PR TITLE
gadget: support creating vfat partitions during bootstrap

### DIFF
--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -36,6 +36,7 @@ var (
 	EnsureNodesExist        = ensureNodesExist
 
 	CreatedDuringInstall = createdDuringInstall
+	CreationSupported    = creationSupported
 )
 
 func MockContentMountpoint(new string) (restore func()) {

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -41,6 +41,7 @@ var (
 var createdPartitionGUID = []string{
 	"0FC63DAF-8483-4772-8E79-3D69D8477DE4", // Linux filesystem data
 	"0657FD6D-A4AB-43C4-84E5-0933C84B4F4F", // Linux swap partition
+	"EBD0A0A2-B9E5-4433-87C0-68B6B72699C7", // Windows Basic Data Partition
 }
 
 // creationSupported returns whether we support and expect to create partitions

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -725,3 +725,10 @@ exit 1
 	list := install.CreatedDuringInstall(pv, dl)
 	c.Assert(list, DeepEquals, []string{"/dev/node2", "/dev/node3", "/dev/node4"})
 }
+
+func (s *partitionTestSuite) TestCreationSupported(c *C) {
+	winBasic := "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7"
+
+	c.Check(install.CreationSupported(winBasic), Equals, true)
+	c.Check(install.CreationSupported("invalid-partion-uuid"), Equals, false)
+}


### PR DESCRIPTION
This commit allows creating the "Windows Basic Data Partition"
as part of the gadget.yaml. This is needed so that the ubuntu-boot
partition can be put on a gpt vfat partition. Note that we already
support this for non-gpt partition layouts.
