### PR TITLE
release-tool/changelog.py: misc fixes from real world usage

### DIFF
--- a/release-tools/changelog.py
+++ b/release-tools/changelog.py
@@ -12,6 +12,7 @@ import debian.changelog
 def parse_arguments():
     parser = argparse.ArgumentParser(description="automatic changelog writer for snapd")
     parser.add_argument("version", type=str, help="new snapd version")
+    parser.add_argument("lpbug", type=str, help="new snapd major release LP bug")
     parser.add_argument(
         "changelog",
         type=argparse.FileType("r"),
@@ -206,7 +207,7 @@ def main(opts):
         # add the new changelog entry with our standard header
         # the spacing here is manually adjusted, the top of the comment is always
         # the same
-        templ = "\n  * New upstream release, LP: #1926005\n" + new_changelog_entry
+        templ = f"\n  * New upstream release, LP: #{opts.lpbug}\n" + new_changelog_entry
         ch.add_change(templ)
 
         # write it out back to the changelog file

--- a/release-tools/changelog.py
+++ b/release-tools/changelog.py
@@ -128,7 +128,7 @@ def update_fedora_changelog(opts, snapd_packaging_dir, new_changelog_entry, main
         fh.write(spec_file_content[idx + len(changelog_section) :])
 
 
-def update_opensuse_changlog(
+def update_opensuse_changelog(
     opts, snapd_packaging_dir, new_changelog_entry, maintainer
 ):
     spec_file = os.path.join(snapd_packaging_dir, "opensuse", "snapd.spec")
@@ -237,7 +237,7 @@ def main(opts):
             )
 
         elif distro == "opensuse":
-            update_opensuse_changlog(
+            update_opensuse_changelog(
                 opts, snapd_packaging_dir, new_changelog_entry, maintainer
             )
 

--- a/release-tools/changelog.py
+++ b/release-tools/changelog.py
@@ -141,8 +141,15 @@ def update_opensuse_changlog(
         True,
     )
 
-    # add a template changelog to the changes file
-    date = datetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S %z")
+    # add a template changelog to the changes file, with special handling for
+    # timezones if we somehow don't have one
+
+    # check if we have a timezone
+    if datetime.datetime.now().strftime("%z") == "":
+        # need to use utc time with a manually specified UTC timezone string
+        date = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S +0000")
+    else:
+        date = datetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S %z")
 
     email = maintainer[1]
     templ = f"""-------------------------------------------------------------------

--- a/release-tools/changelog.py
+++ b/release-tools/changelog.py
@@ -98,7 +98,7 @@ def update_fedora_changelog(opts, snapd_packaging_dir, new_changelog_entry, main
         # that we only have one single whitespace
         dedented_changelog_lines.append(line[3:] + "\n")
 
-    date = datetime.datetime.now().strftime("%a %d %b %Y")
+    date = datetime.datetime.now().strftime("%a %b %d %Y")
 
     date_and_maintainer_header = f"* {date} {maintainer[0]} <{maintainer[1]}>\n"
     changelog_header = f"- New upstream release {opts.version}\n"

--- a/release-tools/changelog.py
+++ b/release-tools/changelog.py
@@ -177,7 +177,7 @@ def main(opts):
             raise RuntimeError(
                 f"unexpected changelog line format in line {line_number}"
             )
-        if len(line) >= 72:
+        if len(line) > 72:
             raise RuntimeError(
                 f"line {line_number} too long, should wrap properly to next line"
             )

--- a/release-tools/changelog.py
+++ b/release-tools/changelog.py
@@ -141,15 +141,10 @@ def update_opensuse_changelog(
         True,
     )
 
-    # add a template changelog to the changes file, with special handling for
-    # timezones if we somehow don't have one
-
-    # check if we have a timezone
-    if datetime.datetime.now().strftime("%z") == "":
-        # need to use utc time with a manually specified UTC timezone string
-        date = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S +0000")
-    else:
-        date = datetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S %z")
+    # add a template changelog to the changes file
+    date = datetime.datetime.now(tz=datetime.timezone.utc).strftime(
+        "%a %b %d %H:%M:%S %Z %Y"
+    )
 
     email = maintainer[1]
     templ = f"""-------------------------------------------------------------------


### PR DESCRIPTION
Miscellaneous little fixes I needed to apply to actually use the script for the 2.51 release. 

* The LP SRU bug release needs to be different for major releases, eventually for minor releases we can probably(?) auto-detect the right bug number, but for new major releases it should always be a new LP bug
* The line length check was incorrect
* For some weird reason I see that on my machine I don't get a %z timezone format string specified, so use UTC if this ends up the case
* Fix the Fedora *.spec file date format generation, I had switched around the order of the name of the month and the day of the month.