### PR TITLE
release-tools/changelog.py: add function to generate github release template

### DIFF
--- a/release-tools/changelog.py
+++ b/release-tools/changelog.py
@@ -174,8 +174,9 @@ See https://forum.snapcraft.io/t/the-snapd-roadmap/1973 for high-level overview.
         # write the rest of the actual changelog
         for line in new_changelog_entry.splitlines():
             # strip the first 4 characters which are space characters so
-            # that we no leading prefix
-            fh.write(line[4:] + "\n")
+            # that there's no leading prefix
+            fh.write(line.lstrip())
+            fh.write("\n")
 
 
 def main(opts):

--- a/release-tools/changelog.py
+++ b/release-tools/changelog.py
@@ -160,6 +160,24 @@ def update_opensuse_changlog(
         fh.write(current)
 
 
+def write_github_release_entry(opts, new_changelog_entry):
+    with open(f"snapd-{opts.version}-github-release.md", "w") as fh:
+        # write the prefix header
+        fh.write(
+            f"""New snapd release {opts.version}
+
+See https://forum.snapcraft.io/t/the-snapd-roadmap/1973 for high-level overview.
+
+"""
+        )
+
+        # write the rest of the actual changelog
+        for line in new_changelog_entry.splitlines():
+            # strip the first 4 characters which are space characters so
+            # that we no leading prefix
+            fh.write(line[4:] + "\n")
+
+
 def main(opts):
     this_script = os.path.realpath(__file__)
     snapd_root_git_dir = os.path.dirname(os.path.dirname(this_script))
@@ -232,6 +250,8 @@ def main(opts):
             update_opensuse_changlog(
                 opts, snapd_packaging_dir, new_changelog_entry, maintainer
             )
+
+    write_github_release_entry(opts, new_changelog_entry)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This just basically adds a basic templated header to the changelog entries and
makes the changelog entries align with proper markdown lists etc.

Eventually it would be super nice to be able to use the GitHub API to actually
create the release after it has been tagged and pushed, etc. with this included
automatically, but that will require an API key and also code, so it is left as
a future improvement.

See https://github.com/snapcore/snapd/releases/tag/2.51 for an example of what it looks like IRL