### PR TITLE
packaging/fedora/snapd.spec: correct date format in changelog

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -942,7 +942,7 @@ fi
 
 
 %changelog
-* Thu 27 May 2021 Ian Johnson <ian.johnson@canonical.com>
+* Thu May 27 2021 Ian Johnson <ian.johnson@canonical.com>
 - New upstream release 2.51
  - cmd/snap: stacktraces debug endpoint
  - secboot: deactivate volume again when model checker fails


### PR DESCRIPTION
This was generated incorrectly by release-tools/changelog.py, but is now fixed
in https://github.com/snapcore/snapd/pull/10315.

This is https://github.com/snapcore/snapd/pull/10319, but for release/2.51.