### PR TITLE
o/snapstate: bump max postponement from 60 to 95 days

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -43,7 +43,7 @@ import (
 const defaultRefreshSchedule = "00:00~24:00/4"
 
 // cannot keep without refreshing for more than maxPostponement
-const maxPostponement = 60 * 24 * time.Hour
+const maxPostponement = 95 * 24 * time.Hour
 
 // cannot inhibit refreshes for more than maxInhibition
 const maxInhibition = 14 * 24 * time.Hour

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -677,19 +677,19 @@ func (s *autoRefreshTestSuite) TestEffectiveRefreshHold(c *C) {
 	tr.Set("core", "refresh.hold", holdTime)
 	tr.Commit()
 
-	seedTime := holdTime.Add(-70 * 24 * time.Hour)
+	seedTime := holdTime.Add(-100 * 24 * time.Hour)
 	s.state.Set("seed-time", seedTime)
 
 	t1, err := af.EffectiveRefreshHold()
 	c.Assert(err, IsNil)
-	c.Check(t1.Equal(seedTime.Add(60*24*time.Hour)), Equals, true)
+	c.Check(t1.Equal(seedTime.Add(95*24*time.Hour)), Equals, true)
 
-	lastRefresh := holdTime.Add(-65 * 24 * time.Hour)
+	lastRefresh := holdTime.Add(-99 * 24 * time.Hour)
 	s.state.Set("last-refresh", lastRefresh)
 
 	t1, err = af.EffectiveRefreshHold()
 	c.Assert(err, IsNil)
-	c.Check(t1.Equal(lastRefresh.Add(60*24*time.Hour)), Equals, true)
+	c.Check(t1.Equal(lastRefresh.Add(95*24*time.Hour)), Equals, true)
 
 	s.state.Set("last-refresh", holdTime.Add(-6*time.Hour))
 	t1, err = af.EffectiveRefreshHold()
@@ -857,9 +857,9 @@ func (s *autoRefreshTestSuite) TestRefreshOnMeteredConnIsMetered(c *C) {
 
 	c.Check(af.NextRefresh(), DeepEquals, time.Time{})
 
-	// last refresh over 60 days ago, new one is launched regardless of
+	// last refresh over 96 days ago, new one is launched regardless of
 	// connection being metered
-	s.state.Set("last-refresh", time.Now().Add(-61*24*time.Hour))
+	s.state.Set("last-refresh", time.Now().Add(-96*24*time.Hour))
 	s.state.Unlock()
 	err = af.Ensure()
 	s.state.Lock()


### PR DESCRIPTION
Bump max postponement for refreshes from 60 to 95 days, Loosely related to refresh control feature, proposed separately to slightly reduce the diff of other PR.

This aligns maximum holding to what can be done with cohorts which allow already for 90 days.