### PR TITLE
interfaces/dsp: add /dev/cavalry into dsp interface

### DIFF
--- a/interfaces/builtin/dsp.go
+++ b/interfaces/builtin/dsp.go
@@ -50,8 +50,11 @@ const ambarellaDspConnectedPlugApparmor = `
 /dev/ucode rw,
 
 # The iav device node is the device node exposed for the specific IAV linux
-# device driver used on the ambarella device
+# device driver used with the CV2x / S6Lm cores on an ambarella device
 /dev/iav rw,
+
+# The cavalry device node is used for managing the CV2x vector processor (VP).
+/dev/cavalry rw,
 
 # another DSP device node
 /dev/lens rw,
@@ -62,6 +65,7 @@ const ambarellaDspConnectedPlugApparmor = `
 
 var ambarellaDspConnectedPlugUDev = []string{
 	`KERNEL=="iav"`,
+	`KERNEL=="cavalry`,
 	`KERNEL=="ucode"`,
 	`KERNEL=="lens"`,
 }

--- a/interfaces/builtin/dsp_test.go
+++ b/interfaces/builtin/dsp_test.go
@@ -105,7 +105,7 @@ func (s *dspSuite) TestUDevConnectedPlugAmbarella(c *C) {
 	spec := &udev.Specification{}
 	err := spec.AddConnectedPlug(s.iface, s.plug, s.ambarellaSlot)
 	c.Assert(err, IsNil)
-	c.Assert(spec.Snippets(), HasLen, 4)
+	c.Assert(spec.Snippets(), HasLen, 5)
 	c.Assert(spec.Snippets(), testutil.Contains, `# dsp
 KERNEL=="iav", TAG+="snap_my-device_svc"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_my-device_svc", RUN+="%v/snap-device-helper $env{ACTION} snap_my-device_svc $devpath $major:$minor"`, dirs.DistroLibExecDir))


### PR DESCRIPTION
The /dev/cavalry is required to enable vector processor featuers when
flavor is from Ambarella chip.

Signed-off-by: Hsieh-Tseng Shen <woodrow.shen@canonical.com>
