### PR TITLE
daemon: introduce StructuredResponse and apiError

### DIFF
--- a/daemon/api_aliases.go
+++ b/daemon/api_aliases.go
@@ -117,7 +117,7 @@ func changeAliases(c *Command, r *http.Request, user *auth.UserState) Response {
 	change := newChange(st, a.Action, summary, []*state.TaskSet{taskset}, []string{a.Snap})
 	st.EnsureBefore(0)
 
-	return AsyncResponse(nil, &Meta{Change: change.ID()})
+	return AsyncResponse(nil, change.ID())
 }
 
 type aliasStatus struct {

--- a/daemon/api_apps.go
+++ b/daemon/api_apps.go
@@ -66,9 +66,9 @@ func getAppsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("invalid select parameter: %q", sel)
 	}
 
-	appInfos, rsp := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
-	if rsp != nil {
-		return rsp
+	appInfos, ae := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
+	if ae != nil {
+		return ae
 	}
 
 	sd := servicestate.NewStatusDecorator(progress.Null)
@@ -103,12 +103,12 @@ func (opts appInfoOptions) String() string {
 // * An element of names can instead be snap.app, in which case that app is
 //   included in the result (and it's an error if the snap and app don't
 //   both exist, or if the app is not a wanted kind)
-// On error an appropriate error Response is returned; a nil Response means
+// On error an appropriate *apiError is returned; a nil *apiError means
 // no error.
 //
 // It's a programming error to call this with wanted having neither
 // services nor commands set.
-func appInfosFor(st *state.State, names []string, opts appInfoOptions) ([]*snap.AppInfo, Response) {
+func appInfosFor(st *state.State, names []string, opts appInfoOptions) ([]*snap.AppInfo, *apiError) {
 	snapNames := make(map[string]bool)
 	requested := make(map[string]bool)
 	for _, name := range names {
@@ -201,9 +201,9 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	// only services have logs for now
 	opts := appInfoOptions{service: true}
-	appInfos, rsp := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
-	if rsp != nil {
-		return rsp
+	appInfos, ae := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
+	if ae != nil {
+		return ae
 	}
 	if len(appInfos) == 0 {
 		return AppNotFound("no matching services")
@@ -241,9 +241,9 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	st := c.d.overlord.State()
-	appInfos, rsp := appInfosFor(st, inst.Names, appInfoOptions{service: true})
-	if rsp != nil {
-		return rsp
+	appInfos, ae := appInfosFor(st, inst.Names, appInfoOptions{service: true})
+	if ae != nil {
+		return ae
 	}
 	if len(appInfos) == 0 {
 		// can't happen: appInfosFor with a non-empty list of services

--- a/daemon/api_apps.go
+++ b/daemon/api_apps.go
@@ -66,9 +66,9 @@ func getAppsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("invalid select parameter: %q", sel)
 	}
 
-	appInfos, ae := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
-	if ae != nil {
-		return ae
+	appInfos, rspe := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
+	if rspe != nil {
+		return rspe
 	}
 
 	sd := servicestate.NewStatusDecorator(progress.Null)
@@ -201,9 +201,9 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	// only services have logs for now
 	opts := appInfoOptions{service: true}
-	appInfos, ae := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
-	if ae != nil {
-		return ae
+	appInfos, rspe := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
+	if rspe != nil {
+		return rspe
 	}
 	if len(appInfos) == 0 {
 		return AppNotFound("no matching services")
@@ -241,9 +241,9 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	st := c.d.overlord.State()
-	appInfos, ae := appInfosFor(st, inst.Names, appInfoOptions{service: true})
-	if ae != nil {
-		return ae
+	appInfos, rspe := appInfosFor(st, inst.Names, appInfoOptions{service: true})
+	if rspe != nil {
+		return rspe
 	}
 	if len(appInfos) == 0 {
 		// can't happen: appInfosFor with a non-empty list of services

--- a/daemon/api_apps.go
+++ b/daemon/api_apps.go
@@ -268,7 +268,7 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 	// extract the actual snap names before associating them with a change
 	chg := newChange(st, "service-control", "Running service command", tss, namesToSnapNames(&inst))
 	st.EnsureBefore(0)
-	return AsyncResponse(nil, &Meta{Change: chg.ID()})
+	return AsyncResponse(nil, chg.ID())
 }
 
 func namesToSnapNames(inst *servicestate.Instruction) []string {

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -335,8 +335,8 @@ func (s *appsSuite) TestGetAppsInfoBadName(c *check.C) {
 
 func (s *appsSuite) TestAppInfosForOne(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-a.svc1"}, daemon.AppInfoServiceTrue)
-	c.Assert(ae, check.IsNil)
+	appInfos, rspe := daemon.AppInfosFor(st, []string{"snap-a.svc1"}, daemon.AppInfoServiceTrue)
+	c.Assert(rspe, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 1)
 	c.Check(appInfos[0].Snap, check.DeepEquals, s.infoA)
 	c.Check(appInfos[0].Name, check.Equals, "svc1")
@@ -364,8 +364,8 @@ func (s *appsSuite) TestAppInfosForAll(c *check.C) {
 		c.Assert(len(t.names), check.Equals, len(t.snaps), check.Commentf("%s", t.opts))
 
 		st := s.d.Overlord().State()
-		appInfos, ae := daemon.AppInfosFor(st, nil, t.opts)
-		c.Assert(ae, check.IsNil, check.Commentf("%s", t.opts))
+		appInfos, rspe := daemon.AppInfosFor(st, nil, t.opts)
+		c.Assert(rspe, check.IsNil, check.Commentf("%s", t.opts))
 		names := make([]string, len(appInfos))
 		for i, appInfo := range appInfos {
 			names[i] = appInfo.Name
@@ -380,8 +380,8 @@ func (s *appsSuite) TestAppInfosForAll(c *check.C) {
 
 func (s *appsSuite) TestAppInfosForOneSnap(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-a"}, daemon.AppInfoServiceTrue)
-	c.Assert(ae, check.IsNil)
+	appInfos, rspe := daemon.AppInfosFor(st, []string{"snap-a"}, daemon.AppInfoServiceTrue)
+	c.Assert(rspe, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 2)
 	sort.Sort(snap.AppInfoBySnapApp(appInfos))
 
@@ -393,8 +393,8 @@ func (s *appsSuite) TestAppInfosForOneSnap(c *check.C) {
 
 func (s *appsSuite) TestAppInfosForMixedArgs(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-a", "snap-a.svc1"}, daemon.AppInfoServiceTrue)
-	c.Assert(ae, check.IsNil)
+	appInfos, rspe := daemon.AppInfosFor(st, []string{"snap-a", "snap-a.svc1"}, daemon.AppInfoServiceTrue)
+	c.Assert(rspe, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 2)
 	sort.Sort(snap.AppInfoBySnapApp(appInfos))
 
@@ -406,7 +406,7 @@ func (s *appsSuite) TestAppInfosForMixedArgs(c *check.C) {
 
 func (s *appsSuite) TestAppInfosCleanupAndSorted(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, ae := daemon.AppInfosFor(st, []string{
+	appInfos, rspe := daemon.AppInfosFor(st, []string{
 		"snap-b.svc3",
 		"snap-a.svc2",
 		"snap-a.svc1",
@@ -416,7 +416,7 @@ func (s *appsSuite) TestAppInfosCleanupAndSorted(c *check.C) {
 		"snap-b",
 		"snap-a",
 	}, daemon.AppInfoServiceTrue)
-	c.Assert(ae, check.IsNil)
+	c.Assert(rspe, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 3)
 	sort.Sort(snap.AppInfoBySnapApp(appInfos))
 
@@ -430,28 +430,28 @@ func (s *appsSuite) TestAppInfosCleanupAndSorted(c *check.C) {
 
 func (s *appsSuite) TestAppInfosForAppless(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-c"}, daemon.AppInfoServiceTrue)
-	c.Assert(ae, check.NotNil)
-	c.Check(ae.Status, check.Equals, 404)
-	c.Check(ae.Kind, check.Equals, client.ErrorKindAppNotFound)
+	appInfos, rspe := daemon.AppInfosFor(st, []string{"snap-c"}, daemon.AppInfoServiceTrue)
+	c.Assert(rspe, check.NotNil)
+	c.Check(rspe.Status, check.Equals, 404)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindAppNotFound)
 	c.Assert(appInfos, check.IsNil)
 }
 
 func (s *appsSuite) TestAppInfosForMissingApp(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-c.whatever"}, daemon.AppInfoServiceTrue)
-	c.Assert(ae, check.NotNil)
-	c.Check(ae.Status, check.Equals, 404)
-	c.Check(ae.Kind, check.Equals, client.ErrorKindAppNotFound)
+	appInfos, rspe := daemon.AppInfosFor(st, []string{"snap-c.whatever"}, daemon.AppInfoServiceTrue)
+	c.Assert(rspe, check.NotNil)
+	c.Check(rspe.Status, check.Equals, 404)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindAppNotFound)
 	c.Assert(appInfos, check.IsNil)
 }
 
 func (s *appsSuite) TestAppInfosForMissingSnap(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-x"}, daemon.AppInfoServiceTrue)
-	c.Assert(ae, check.NotNil)
-	c.Check(ae.Status, check.Equals, 404)
-	c.Check(ae.Kind, check.Equals, client.ErrorKindSnapNotFound)
+	appInfos, rspe := daemon.AppInfosFor(st, []string{"snap-x"}, daemon.AppInfoServiceTrue)
+	c.Assert(rspe, check.NotNil)
+	c.Check(rspe.Status, check.Equals, 404)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindSnapNotFound)
 	c.Assert(appInfos, check.IsNil)
 }
 

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -335,8 +335,8 @@ func (s *appsSuite) TestGetAppsInfoBadName(c *check.C) {
 
 func (s *appsSuite) TestAppInfosForOne(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, rsp := daemon.AppInfosFor(st, []string{"snap-a.svc1"}, daemon.AppInfoServiceTrue)
-	c.Assert(rsp, check.IsNil)
+	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-a.svc1"}, daemon.AppInfoServiceTrue)
+	c.Assert(ae, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 1)
 	c.Check(appInfos[0].Snap, check.DeepEquals, s.infoA)
 	c.Check(appInfos[0].Name, check.Equals, "svc1")
@@ -364,8 +364,8 @@ func (s *appsSuite) TestAppInfosForAll(c *check.C) {
 		c.Assert(len(t.names), check.Equals, len(t.snaps), check.Commentf("%s", t.opts))
 
 		st := s.d.Overlord().State()
-		appInfos, rsp := daemon.AppInfosFor(st, nil, t.opts)
-		c.Assert(rsp, check.IsNil, check.Commentf("%s", t.opts))
+		appInfos, ae := daemon.AppInfosFor(st, nil, t.opts)
+		c.Assert(ae, check.IsNil, check.Commentf("%s", t.opts))
 		names := make([]string, len(appInfos))
 		for i, appInfo := range appInfos {
 			names[i] = appInfo.Name
@@ -380,8 +380,8 @@ func (s *appsSuite) TestAppInfosForAll(c *check.C) {
 
 func (s *appsSuite) TestAppInfosForOneSnap(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, rsp := daemon.AppInfosFor(st, []string{"snap-a"}, daemon.AppInfoServiceTrue)
-	c.Assert(rsp, check.IsNil)
+	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-a"}, daemon.AppInfoServiceTrue)
+	c.Assert(ae, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 2)
 	sort.Sort(snap.AppInfoBySnapApp(appInfos))
 
@@ -393,8 +393,8 @@ func (s *appsSuite) TestAppInfosForOneSnap(c *check.C) {
 
 func (s *appsSuite) TestAppInfosForMixedArgs(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, rsp := daemon.AppInfosFor(st, []string{"snap-a", "snap-a.svc1"}, daemon.AppInfoServiceTrue)
-	c.Assert(rsp, check.IsNil)
+	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-a", "snap-a.svc1"}, daemon.AppInfoServiceTrue)
+	c.Assert(ae, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 2)
 	sort.Sort(snap.AppInfoBySnapApp(appInfos))
 
@@ -406,7 +406,7 @@ func (s *appsSuite) TestAppInfosForMixedArgs(c *check.C) {
 
 func (s *appsSuite) TestAppInfosCleanupAndSorted(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, rsp := daemon.AppInfosFor(st, []string{
+	appInfos, ae := daemon.AppInfosFor(st, []string{
 		"snap-b.svc3",
 		"snap-a.svc2",
 		"snap-a.svc1",
@@ -416,7 +416,7 @@ func (s *appsSuite) TestAppInfosCleanupAndSorted(c *check.C) {
 		"snap-b",
 		"snap-a",
 	}, daemon.AppInfoServiceTrue)
-	c.Assert(rsp, check.IsNil)
+	c.Assert(ae, check.IsNil)
 	c.Assert(appInfos, check.HasLen, 3)
 	sort.Sort(snap.AppInfoBySnapApp(appInfos))
 
@@ -430,28 +430,28 @@ func (s *appsSuite) TestAppInfosCleanupAndSorted(c *check.C) {
 
 func (s *appsSuite) TestAppInfosForAppless(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, rsp := daemon.AppInfosFor(st, []string{"snap-c"}, daemon.AppInfoServiceTrue)
-	c.Assert(rsp, check.FitsTypeOf, &daemon.Resp{})
-	c.Check(rsp.(*daemon.Resp).Status, check.Equals, 404)
-	c.Check(rsp.(*daemon.Resp).Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindAppNotFound)
+	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-c"}, daemon.AppInfoServiceTrue)
+	c.Assert(ae, check.NotNil)
+	c.Check(ae.Status, check.Equals, 404)
+	c.Check(ae.Kind, check.Equals, client.ErrorKindAppNotFound)
 	c.Assert(appInfos, check.IsNil)
 }
 
 func (s *appsSuite) TestAppInfosForMissingApp(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, rsp := daemon.AppInfosFor(st, []string{"snap-c.whatever"}, daemon.AppInfoServiceTrue)
-	c.Assert(rsp, check.FitsTypeOf, &daemon.Resp{})
-	c.Check(rsp.(*daemon.Resp).Status, check.Equals, 404)
-	c.Check(rsp.(*daemon.Resp).Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindAppNotFound)
+	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-c.whatever"}, daemon.AppInfoServiceTrue)
+	c.Assert(ae, check.NotNil)
+	c.Check(ae.Status, check.Equals, 404)
+	c.Check(ae.Kind, check.Equals, client.ErrorKindAppNotFound)
 	c.Assert(appInfos, check.IsNil)
 }
 
 func (s *appsSuite) TestAppInfosForMissingSnap(c *check.C) {
 	st := s.d.Overlord().State()
-	appInfos, rsp := daemon.AppInfosFor(st, []string{"snap-x"}, daemon.AppInfoServiceTrue)
-	c.Assert(rsp, check.FitsTypeOf, &daemon.Resp{})
-	c.Check(rsp.(*daemon.Resp).Status, check.Equals, 404)
-	c.Check(rsp.(*daemon.Resp).Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindSnapNotFound)
+	appInfos, ae := daemon.AppInfosFor(st, []string{"snap-x"}, daemon.AppInfoServiceTrue)
+	c.Assert(ae, check.NotNil)
+	c.Check(ae.Status, check.Equals, 404)
+	c.Check(ae.Kind, check.Equals, client.ErrorKindSnapNotFound)
 	c.Assert(appInfos, check.IsNil)
 }
 

--- a/daemon/api_asserts.go
+++ b/daemon/api_asserts.go
@@ -114,11 +114,8 @@ func doAssert(c *Command, r *http.Request, user *auth.UserState) Response {
 	}); err != nil {
 		return BadRequest("assert failed: %v", err)
 	}
-	// TODO: what more info do we want to return on success?
-	return &resp{
-		Type:   ResponseTypeSync,
-		Status: 200,
-	}
+
+	return SyncResponse(nil, nil)
 }
 
 func assertsFindOneRemote(c *Command, at *asserts.AssertionType, headers map[string]string, user *auth.UserState) ([]asserts.Assertion, error) {

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -637,9 +637,9 @@ func (s *apiBaseSuite) errorReq(c *check.C, req *http.Request, u *auth.UserState
 
 func (s *apiBaseSuite) apiErrorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.APIError {
 	rsp := s.req(c, req, u)
-	ae, ok := rsp.(*daemon.APIError)
+	rspe, ok := rsp.(*daemon.APIError)
 	c.Assert(ok, check.Equals, true, check.Commentf("expected apiError resp: %#v", rsp))
-	return ae
+	return rspe
 }
 
 func (s *apiBaseSuite) serveHTTP(c *check.C, w http.ResponseWriter, req *http.Request) {

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -635,6 +635,13 @@ func (s *apiBaseSuite) errorReq(c *check.C, req *http.Request, u *auth.UserState
 	return rsp
 }
 
+func (s *apiBaseSuite) apiErrorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.APIError {
+	rsp := s.req(c, req, u)
+	ae, ok := rsp.(*daemon.APIError)
+	c.Assert(ok, check.Equals, true, check.Commentf("expected apiError resp: %#v", rsp))
+	return ae
+}
+
 func (s *apiBaseSuite) serveHTTP(c *check.C, w http.ResponseWriter, req *http.Request) {
 	if s.d == nil {
 		panic("call s.daemon(c) etc in your test first")

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -611,25 +611,25 @@ func (s *apiBaseSuite) req(c *check.C, req *http.Request, u *auth.UserState) dae
 	return f(cmd, req, u)
 }
 
-func (s *apiBaseSuite) jsonReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.Resp {
-	rsp, ok := s.req(c, req, u).(*daemon.Resp)
+func (s *apiBaseSuite) jsonReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.RespJSON {
+	rsp, ok := s.req(c, req, u).(daemon.StructuredResponse)
 	c.Assert(ok, check.Equals, true, check.Commentf("expected structured response"))
-	return rsp
+	return rsp.JSON()
 }
 
-func (s *apiBaseSuite) syncReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.Resp {
+func (s *apiBaseSuite) syncReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.RespJSON {
 	rsp := s.jsonReq(c, req, u)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeSync, check.Commentf("expected sync resp: %#v, result: %+v", rsp, rsp.Result))
 	return rsp
 }
 
-func (s *apiBaseSuite) asyncReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.Resp {
+func (s *apiBaseSuite) asyncReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.RespJSON {
 	rsp := s.jsonReq(c, req, u)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeAsync, check.Commentf("expected async resp: %#v", rsp))
 	return rsp
 }
 
-func (s *apiBaseSuite) errorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.Resp {
+func (s *apiBaseSuite) errorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.RespJSON {
 	rsp := s.jsonReq(c, req, u)
 	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError, check.Commentf("expected error resp: %#v", rsp))
 	return rsp

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -275,7 +275,7 @@ func createRecovery(st *state.State, label string) Response {
 		return InternalError("cannot create recovery system %q: %v", label, err)
 	}
 	ensureStateSoon(st)
-	return AsyncResponse(nil, &Meta{Change: chg.ID()})
+	return AsyncResponse(nil, chg.ID())
 }
 
 func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -334,9 +334,9 @@ func (s *snapDownloadSuite) TestStreamOneSnap(c *check.C) {
 		rsp := s.req(c, req, nil)
 
 		if t.err != "" {
-			ae := rsp.(*daemon.APIError)
-			c.Check(ae.Status, check.Equals, t.status, check.Commentf("unexpected result for %v", t.dataJSON))
-			c.Check(ae.Message, check.Matches, t.err, check.Commentf("unexpected result for %v", t.dataJSON))
+			rspe := rsp.(*daemon.APIError)
+			c.Check(rspe.Status, check.Equals, t.status, check.Commentf("unexpected result for %v", t.dataJSON))
+			c.Check(rspe.Message, check.Matches, t.err, check.Commentf("unexpected result for %v", t.dataJSON))
 		} else {
 			c.Assert(rsp, check.FitsTypeOf, &daemon.SnapStream{}, check.Commentf("unexpected result for %v", t.dataJSON))
 			ss := rsp.(*daemon.SnapStream)

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -334,9 +334,9 @@ func (s *snapDownloadSuite) TestStreamOneSnap(c *check.C) {
 		rsp := s.req(c, req, nil)
 
 		if t.err != "" {
-			c.Check(rsp.(*daemon.Resp).Status, check.Equals, t.status, check.Commentf("unexpected result for %v", t.dataJSON))
-			result := rsp.(*daemon.Resp).Result
-			c.Check(result.(*daemon.ErrorResult).Message, check.Matches, t.err, check.Commentf("unexpected result for %v", t.dataJSON))
+			ae := rsp.(*daemon.APIError)
+			c.Check(ae.Status, check.Equals, t.status, check.Commentf("unexpected result for %v", t.dataJSON))
+			c.Check(ae.Message, check.Matches, t.err, check.Commentf("unexpected result for %v", t.dataJSON))
 		} else {
 			c.Assert(rsp, check.FitsTypeOf, &daemon.SnapStream{}, check.Commentf("unexpected result for %v", t.dataJSON))
 			ss := rsp.(*daemon.SnapStream)

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -377,8 +377,10 @@ func (s *generalSuite) TestStateChangesDefaultToInProgress(c *check.C) {
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Assert(rsp.Result, check.HasLen, 1)
 
-	res, err := rsp.MarshalJSON()
-	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, nil)
+	c.Assert(rec.Code, check.Equals, 200)
+	res := rec.Body.Bytes()
 
 	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"install","summary":"install...","status":"Do","tasks":\[{"id":"\w+","kind":"download","summary":"1...","status":"Do","log":\["2016-04-21T01:02:03Z INFO l11","2016-04-21T01:02:03Z INFO l12"],"progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}.*`)
 }
@@ -403,8 +405,10 @@ func (s *generalSuite) TestStateChangesInProgress(c *check.C) {
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Assert(rsp.Result, check.HasLen, 1)
 
-	res, err := rsp.MarshalJSON()
-	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, nil)
+	c.Assert(rec.Code, check.Equals, 200)
+	res := rec.Body.Bytes()
 
 	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"install","summary":"install...","status":"Do","tasks":\[{"id":"\w+","kind":"download","summary":"1...","status":"Do","log":\["2016-04-21T01:02:03Z INFO l11","2016-04-21T01:02:03Z INFO l12"],"progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}.*],"ready":false,"spawn-time":"2016-04-21T01:02:03Z"}.*`)
 }
@@ -429,8 +433,10 @@ func (s *generalSuite) TestStateChangesAll(c *check.C) {
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Assert(rsp.Result, check.HasLen, 2)
 
-	res, err := rsp.MarshalJSON()
-	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, nil)
+	c.Assert(rec.Code, check.Equals, 200)
+	res := rec.Body.Bytes()
 
 	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"install","summary":"install...","status":"Do","tasks":\[{"id":"\w+","kind":"download","summary":"1...","status":"Do","log":\["2016-04-21T01:02:03Z INFO l11","2016-04-21T01:02:03Z INFO l12"],"progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}.*],"ready":false,"spawn-time":"2016-04-21T01:02:03Z"}.*`)
 	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove..","status":"Error","tasks":\[{"id":"\w+","kind":"unlink","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR rm failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
@@ -456,8 +462,10 @@ func (s *generalSuite) TestStateChangesReady(c *check.C) {
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Assert(rsp.Result, check.HasLen, 1)
 
-	res, err := rsp.MarshalJSON()
-	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, nil)
+	c.Assert(rec.Code, check.Equals, 200)
+	res := rec.Body.Bytes()
 
 	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove..","status":"Error","tasks":\[{"id":"\w+","kind":"unlink","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR rm failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
 }
@@ -486,8 +494,9 @@ func (s *generalSuite) TestStateChangesForSnapName(c *check.C) {
 	c.Assert(res, check.HasLen, 1)
 	c.Check(res[0].Kind, check.Equals, `install`)
 
-	_, err = rsp.MarshalJSON()
-	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, nil)
+	c.Assert(rec.Code, check.Equals, 200)
 }
 
 func (s *generalSuite) TestStateChangesForSnapNameWithApp(c *check.C) {
@@ -520,8 +529,9 @@ func (s *generalSuite) TestStateChangesForSnapNameWithApp(c *check.C) {
 	c.Assert(res, check.HasLen, 1)
 	c.Check(res[0].Kind, check.Equals, `service-control`)
 
-	_, err = rsp.MarshalJSON()
-	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, nil)
+	c.Assert(rec.Code, check.Equals, 200)
 }
 
 func (s *generalSuite) TestStateChange(c *check.C) {

--- a/daemon/api_interfaces.go
+++ b/daemon/api_interfaces.go
@@ -193,7 +193,7 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 			if _, ok := err.(*ifacestate.ErrAlreadyConnected); ok {
 				change := newChange(st, a.Action+"-snap", summary, nil, affected)
 				change.SetStatus(state.DoneStatus)
-				return AsyncResponse(nil, &Meta{Change: change.ID()})
+				return AsyncResponse(nil, change.ID())
 			}
 			tasksets = append(tasksets, ts)
 		}
@@ -237,7 +237,7 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 	change := newChange(st, a.Action+"-snap", summary, tasksets, affected)
 	st.EnsureBefore(0)
 
-	return AsyncResponse(nil, &Meta{Change: change.ID()})
+	return AsyncResponse(nil, change.ID())
 }
 
 func snapNamesFromConns(conns []*interfaces.ConnRef) []string {

--- a/daemon/api_model.go
+++ b/daemon/api_model.go
@@ -82,7 +82,7 @@ func postModel(c *Command, r *http.Request, _ *auth.UserState) Response {
 	}
 	ensureStateSoon(st)
 
-	return AsyncResponse(nil, &Meta{Change: chg.ID()})
+	return AsyncResponse(nil, chg.ID())
 
 }
 

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -217,14 +217,11 @@ func trySnap(st *state.State, trydir string, flags snapstate.Flags) Response {
 	// the developer asked us to do this with a trusted snap dir
 	info, err := unsafeReadSnapInfo(trydir)
 	if _, ok := err.(snap.NotSnapError); ok {
-		return SyncResponse(&resp{
-			Type: ResponseTypeError,
-			Result: &errorResult{
-				Message: err.Error(),
-				Kind:    client.ErrorKindNotSnap,
-			},
-			Status: 400,
-		}, nil)
+		return &apiError{
+			Status:  400,
+			Message: err.Error(),
+			Kind:    client.ErrorKindNotSnap,
+		}
 	}
 	if err != nil {
 		return BadRequest("cannot read snap info for %s: %s", trydir, err)

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -200,7 +200,7 @@ out:
 	// but this is good enough
 	changeTriggered = true
 
-	return AsyncResponse(nil, &Meta{Change: chg.ID()})
+	return AsyncResponse(nil, chg.ID())
 }
 
 func trySnap(st *state.State, trydir string, flags snapstate.Flags) Response {
@@ -241,7 +241,7 @@ func trySnap(st *state.State, trydir string, flags snapstate.Flags) Response {
 
 	ensureStateSoon(st)
 
-	return AsyncResponse(nil, &Meta{Change: chg.ID()})
+	return AsyncResponse(nil, chg.ID())
 }
 
 var unsafeReadSnapInfo = unsafeReadSnapInfoImpl

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -613,18 +613,16 @@ func (s *trySuite) TestTrySnapRelative(c *check.C) {
 	d := s.daemon(c)
 	st := d.Overlord().State()
 
-	rsp := daemon.TrySnap(st, "relative-path", snapstate.Flags{}).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, "need an absolute path")
+	ae := daemon.TrySnap(st, "relative-path", snapstate.Flags{}).(*daemon.APIError)
+	c.Check(ae.Message, testutil.Contains, "need an absolute path")
 }
 
 func (s *trySuite) TestTrySnapNotDir(c *check.C) {
 	d := s.daemon(c)
 	st := d.Overlord().State()
 
-	rsp := daemon.TrySnap(st, "/does/not/exist", snapstate.Flags{}).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, "not a snap directory")
+	ae := daemon.TrySnap(st, "/does/not/exist", snapstate.Flags{}).(*daemon.APIError)
+	c.Check(ae.Message, testutil.Contains, "not a snap directory")
 }
 
 func (s *trySuite) TestTryChangeConflict(c *check.C) {
@@ -642,7 +640,6 @@ func (s *trySuite) TestTryChangeConflict(c *check.C) {
 		return nil, &snapstate.ChangeConflictError{Snap: "foo"}
 	})()
 
-	rsp := daemon.TrySnap(st, tryDir, snapstate.Flags{}).(*daemon.Resp)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindSnapChangeConflict)
+	ae := daemon.TrySnap(st, tryDir, snapstate.Flags{}).(*daemon.APIError)
+	c.Check(ae.Kind, check.Equals, client.ErrorKindSnapChangeConflict)
 }

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -613,16 +613,16 @@ func (s *trySuite) TestTrySnapRelative(c *check.C) {
 	d := s.daemon(c)
 	st := d.Overlord().State()
 
-	ae := daemon.TrySnap(st, "relative-path", snapstate.Flags{}).(*daemon.APIError)
-	c.Check(ae.Message, testutil.Contains, "need an absolute path")
+	rspe := daemon.TrySnap(st, "relative-path", snapstate.Flags{}).(*daemon.APIError)
+	c.Check(rspe.Message, testutil.Contains, "need an absolute path")
 }
 
 func (s *trySuite) TestTrySnapNotDir(c *check.C) {
 	d := s.daemon(c)
 	st := d.Overlord().State()
 
-	ae := daemon.TrySnap(st, "/does/not/exist", snapstate.Flags{}).(*daemon.APIError)
-	c.Check(ae.Message, testutil.Contains, "not a snap directory")
+	rspe := daemon.TrySnap(st, "/does/not/exist", snapstate.Flags{}).(*daemon.APIError)
+	c.Check(rspe.Message, testutil.Contains, "not a snap directory")
 }
 
 func (s *trySuite) TestTryChangeConflict(c *check.C) {
@@ -640,6 +640,6 @@ func (s *trySuite) TestTryChangeConflict(c *check.C) {
 		return nil, &snapstate.ChangeConflictError{Snap: "foo"}
 	})()
 
-	ae := daemon.TrySnap(st, tryDir, snapstate.Flags{}).(*daemon.APIError)
-	c.Check(ae.Kind, check.Equals, client.ErrorKindSnapChangeConflict)
+	rspe := daemon.TrySnap(st, tryDir, snapstate.Flags{}).(*daemon.APIError)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindSnapChangeConflict)
 }

--- a/daemon/api_snap_conf.go
+++ b/daemon/api_snap_conf.go
@@ -121,5 +121,5 @@ func setSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	st.EnsureBefore(0)
 
-	return AsyncResponse(nil, &Meta{Change: change.ID()})
+	return AsyncResponse(nil, change.ID())
 }

--- a/daemon/api_snap_file_test.go
+++ b/daemon/api_snap_file_test.go
@@ -80,9 +80,9 @@ func (s *snapFileSuite) TestGetFile(c *check.C) {
 		if scen.err == "" {
 			c.Check(string(rsp.(daemon.FileResponse)), check.Equals, filepath.Join(dirs.SnapBlobDir, "foo_x1.snap"), check.Commentf("%d", i))
 		} else {
-			ae, ok := rsp.(*daemon.APIError)
+			rspe, ok := rsp.(*daemon.APIError)
 			c.Assert(ok, check.Equals, true, check.Commentf("%d", i))
-			c.Check(ae.Message, check.Matches, scen.err, check.Commentf("%d", i))
+			c.Check(rspe.Message, check.Matches, scen.err, check.Commentf("%d", i))
 		}
 	}
 }

--- a/daemon/api_snap_file_test.go
+++ b/daemon/api_snap_file_test.go
@@ -80,10 +80,9 @@ func (s *snapFileSuite) TestGetFile(c *check.C) {
 		if scen.err == "" {
 			c.Check(string(rsp.(daemon.FileResponse)), check.Equals, filepath.Join(dirs.SnapBlobDir, "foo_x1.snap"), check.Commentf("%d", i))
 		} else {
-			c.Assert(rsp, check.FitsTypeOf, &daemon.Resp{}, check.Commentf("%d", i))
-			result := rsp.(*daemon.Resp).Result
-			c.Assert(result, check.FitsTypeOf, &daemon.ErrorResult{}, check.Commentf("%d", i))
-			c.Check(result.(*daemon.ErrorResult).Message, check.Matches, scen.err, check.Commentf("%d", i))
+			ae, ok := rsp.(*daemon.APIError)
+			c.Assert(ok, check.Equals, true, check.Commentf("%d", i))
+			c.Check(ae.Message, check.Matches, scen.err, check.Commentf("%d", i))
 		}
 	}
 }

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -451,7 +451,7 @@ func (inst *snapInstruction) dispatch() snapActionFunc {
 	return snapInstructionDispTable[inst.Action]
 }
 
-func (inst *snapInstruction) errToResponse(err error) Response {
+func (inst *snapInstruction) errToResponse(err error) *apiError {
 	if len(inst.Snaps) == 0 {
 		return errToResponse(err, nil, BadRequest, "cannot %s: %v", inst.Action)
 	}

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -150,7 +150,7 @@ func postSnap(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	ensureStateSoon(state)
 
-	return AsyncResponse(nil, &Meta{Change: chg.ID()})
+	return AsyncResponse(nil, chg.ID())
 }
 
 type snapRevisionOptions struct {
@@ -530,7 +530,7 @@ func snapOpMany(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	chg.Set("api-data", map[string]interface{}{"snap-names": res.Affected})
 
-	return AsyncResponse(res.Result, &Meta{Change: chg.ID()})
+	return AsyncResponse(res.Result, chg.ID())
 }
 
 type snapManyActionFunc func(*snapInstruction, *state.State) (*snapInstructionResult, error)

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1947,10 +1947,10 @@ func (s *snapsSuite) TestErrToResponseNoSnapsDoesNotPanic(c *check.C) {
 	}
 
 	for _, err := range errors {
-		ae := si.ErrToResponse(err)
+		rspe := si.ErrToResponse(err)
 		com := check.Commentf("%v", err)
-		c.Assert(ae, check.NotNil, com)
-		status := ae.Status
+		c.Assert(rspe, check.NotNil, com)
+		status := rspe.Status
 		c.Check(status/100 == 4 || status/100 == 5, check.Equals, true, com)
 	}
 }
@@ -1967,8 +1967,8 @@ func (s *snapsSuite) TestErrToResponseForRevisionNotAvailable(c *check.C) {
 			snaptest.MustParseChannel("beta", thisArch),
 		},
 	}
-	ae := si.ErrToResponse(err)
-	c.Check(ae, check.DeepEquals, &daemon.APIError{
+	rspe := si.ErrToResponse(err)
+	c.Check(rspe, check.DeepEquals, &daemon.APIError{
 		Status:  404,
 		Message: "no snap revision on specified channel",
 		Kind:    client.ErrorKindSnapChannelNotAvailable,
@@ -1990,8 +1990,8 @@ func (s *snapsSuite) TestErrToResponseForRevisionNotAvailable(c *check.C) {
 			snaptest.MustParseChannel("beta", "other-arch"),
 		},
 	}
-	ae = si.ErrToResponse(err)
-	c.Check(ae, check.DeepEquals, &daemon.APIError{
+	rspe = si.ErrToResponse(err)
+	c.Check(rspe, check.DeepEquals, &daemon.APIError{
 		Status:  404,
 		Message: "no snap revision on specified architecture",
 		Kind:    client.ErrorKindSnapArchitectureNotAvailable,
@@ -2007,8 +2007,8 @@ func (s *snapsSuite) TestErrToResponseForRevisionNotAvailable(c *check.C) {
 	})
 
 	err = &store.RevisionNotAvailableError{}
-	ae = si.ErrToResponse(err)
-	c.Check(ae, check.DeepEquals, &daemon.APIError{
+	rspe = si.ErrToResponse(err)
+	c.Check(rspe, check.DeepEquals, &daemon.APIError{
 		Status:  404,
 		Message: "no snap revision available as specified",
 		Kind:    client.ErrorKindSnapRevisionNotAvailable,
@@ -2020,8 +2020,8 @@ func (s *snapsSuite) TestErrToResponseForChangeConflict(c *check.C) {
 	si := &daemon.SnapInstruction{Action: "frobble", Snaps: []string{"foo"}}
 
 	err := &snapstate.ChangeConflictError{Snap: "foo", ChangeKind: "install"}
-	ae := si.ErrToResponse(err)
-	c.Check(ae, check.DeepEquals, &daemon.APIError{
+	rspe := si.ErrToResponse(err)
+	c.Check(rspe, check.DeepEquals, &daemon.APIError{
 		Status:  409,
 		Message: `snap "foo" has "install" change in progress`,
 		Kind:    client.ErrorKindSnapChangeConflict,
@@ -2033,8 +2033,8 @@ func (s *snapsSuite) TestErrToResponseForChangeConflict(c *check.C) {
 
 	// only snap
 	err = &snapstate.ChangeConflictError{Snap: "foo"}
-	ae = si.ErrToResponse(err)
-	c.Check(ae, check.DeepEquals, &daemon.APIError{
+	rspe = si.ErrToResponse(err)
+	c.Check(rspe, check.DeepEquals, &daemon.APIError{
 		Status:  409,
 		Message: `snap "foo" has changes in progress`,
 		Kind:    client.ErrorKindSnapChangeConflict,
@@ -2045,8 +2045,8 @@ func (s *snapsSuite) TestErrToResponseForChangeConflict(c *check.C) {
 
 	// only kind
 	err = &snapstate.ChangeConflictError{Message: "specific error msg", ChangeKind: "some-global-op"}
-	ae = si.ErrToResponse(err)
-	c.Check(ae, check.DeepEquals, &daemon.APIError{
+	rspe = si.ErrToResponse(err)
+	c.Check(rspe, check.DeepEquals, &daemon.APIError{
 		Status:  409,
 		Message: "specific error msg",
 		Kind:    client.ErrorKindSnapChangeConflict,

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1949,7 +1949,7 @@ func (s *snapsSuite) TestErrToResponseNoSnapsDoesNotPanic(c *check.C) {
 	for _, err := range errors {
 		ae := si.ErrToResponse(err)
 		com := check.Commentf("%v", err)
-		c.Check(ae, check.NotNil, com)
+		c.Assert(ae, check.NotNil, com)
 		status := ae.Status
 		c.Check(status/100 == 4 || status/100 == 5, check.Equals, true, com)
 	}

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1947,10 +1947,10 @@ func (s *snapsSuite) TestErrToResponseNoSnapsDoesNotPanic(c *check.C) {
 	}
 
 	for _, err := range errors {
-		rsp := si.ErrToResponse(err)
+		ae := si.ErrToResponse(err)
 		com := check.Commentf("%v", err)
-		c.Check(rsp, check.NotNil, com)
-		status := rsp.(*daemon.Resp).Status
+		c.Check(ae, check.NotNil, com)
+		status := ae.Status
 		c.Check(status/100 == 4 || status/100 == 5, check.Equals, true, com)
 	}
 }
@@ -1967,21 +1967,18 @@ func (s *snapsSuite) TestErrToResponseForRevisionNotAvailable(c *check.C) {
 			snaptest.MustParseChannel("beta", thisArch),
 		},
 	}
-	rsp := si.ErrToResponse(err).(*daemon.Resp)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 404,
-		Type:   daemon.ResponseTypeError,
-		Result: &daemon.ErrorResult{
-			Message: "no snap revision on specified channel",
-			Kind:    client.ErrorKindSnapChannelNotAvailable,
-			Value: map[string]interface{}{
-				"snap-name":    "foo",
-				"action":       "install",
-				"channel":      "stable",
-				"architecture": thisArch,
-				"releases": []map[string]interface{}{
-					{"architecture": thisArch, "channel": "beta"},
-				},
+	ae := si.ErrToResponse(err)
+	c.Check(ae, check.DeepEquals, &daemon.APIError{
+		Status:  404,
+		Message: "no snap revision on specified channel",
+		Kind:    client.ErrorKindSnapChannelNotAvailable,
+		Value: map[string]interface{}{
+			"snap-name":    "foo",
+			"action":       "install",
+			"channel":      "stable",
+			"architecture": thisArch,
+			"releases": []map[string]interface{}{
+				{"architecture": thisArch, "channel": "beta"},
 			},
 		},
 	})
@@ -1993,35 +1990,29 @@ func (s *snapsSuite) TestErrToResponseForRevisionNotAvailable(c *check.C) {
 			snaptest.MustParseChannel("beta", "other-arch"),
 		},
 	}
-	rsp = si.ErrToResponse(err).(*daemon.Resp)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 404,
-		Type:   daemon.ResponseTypeError,
-		Result: &daemon.ErrorResult{
-			Message: "no snap revision on specified architecture",
-			Kind:    client.ErrorKindSnapArchitectureNotAvailable,
-			Value: map[string]interface{}{
-				"snap-name":    "foo",
-				"action":       "install",
-				"channel":      "stable",
-				"architecture": thisArch,
-				"releases": []map[string]interface{}{
-					{"architecture": "other-arch", "channel": "beta"},
-				},
+	ae = si.ErrToResponse(err)
+	c.Check(ae, check.DeepEquals, &daemon.APIError{
+		Status:  404,
+		Message: "no snap revision on specified architecture",
+		Kind:    client.ErrorKindSnapArchitectureNotAvailable,
+		Value: map[string]interface{}{
+			"snap-name":    "foo",
+			"action":       "install",
+			"channel":      "stable",
+			"architecture": thisArch,
+			"releases": []map[string]interface{}{
+				{"architecture": "other-arch", "channel": "beta"},
 			},
 		},
 	})
 
 	err = &store.RevisionNotAvailableError{}
-	rsp = si.ErrToResponse(err).(*daemon.Resp)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 404,
-		Type:   daemon.ResponseTypeError,
-		Result: &daemon.ErrorResult{
-			Message: "no snap revision available as specified",
-			Kind:    client.ErrorKindSnapRevisionNotAvailable,
-			Value:   "foo",
-		},
+	ae = si.ErrToResponse(err)
+	c.Check(ae, check.DeepEquals, &daemon.APIError{
+		Status:  404,
+		Message: "no snap revision available as specified",
+		Kind:    client.ErrorKindSnapRevisionNotAvailable,
+		Value:   "foo",
 	})
 }
 
@@ -2029,47 +2020,38 @@ func (s *snapsSuite) TestErrToResponseForChangeConflict(c *check.C) {
 	si := &daemon.SnapInstruction{Action: "frobble", Snaps: []string{"foo"}}
 
 	err := &snapstate.ChangeConflictError{Snap: "foo", ChangeKind: "install"}
-	rsp := si.ErrToResponse(err).(*daemon.Resp)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 409,
-		Type:   daemon.ResponseTypeError,
-		Result: &daemon.ErrorResult{
-			Message: `snap "foo" has "install" change in progress`,
-			Kind:    client.ErrorKindSnapChangeConflict,
-			Value: map[string]interface{}{
-				"snap-name":   "foo",
-				"change-kind": "install",
-			},
+	ae := si.ErrToResponse(err)
+	c.Check(ae, check.DeepEquals, &daemon.APIError{
+		Status:  409,
+		Message: `snap "foo" has "install" change in progress`,
+		Kind:    client.ErrorKindSnapChangeConflict,
+		Value: map[string]interface{}{
+			"snap-name":   "foo",
+			"change-kind": "install",
 		},
 	})
 
 	// only snap
 	err = &snapstate.ChangeConflictError{Snap: "foo"}
-	rsp = si.ErrToResponse(err).(*daemon.Resp)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 409,
-		Type:   daemon.ResponseTypeError,
-		Result: &daemon.ErrorResult{
-			Message: `snap "foo" has changes in progress`,
-			Kind:    client.ErrorKindSnapChangeConflict,
-			Value: map[string]interface{}{
-				"snap-name": "foo",
-			},
+	ae = si.ErrToResponse(err)
+	c.Check(ae, check.DeepEquals, &daemon.APIError{
+		Status:  409,
+		Message: `snap "foo" has changes in progress`,
+		Kind:    client.ErrorKindSnapChangeConflict,
+		Value: map[string]interface{}{
+			"snap-name": "foo",
 		},
 	})
 
 	// only kind
 	err = &snapstate.ChangeConflictError{Message: "specific error msg", ChangeKind: "some-global-op"}
-	rsp = si.ErrToResponse(err).(*daemon.Resp)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 409,
-		Type:   daemon.ResponseTypeError,
-		Result: &daemon.ErrorResult{
-			Message: "specific error msg",
-			Kind:    client.ErrorKindSnapChangeConflict,
-			Value: map[string]interface{}{
-				"change-kind": "some-global-op",
-			},
+	ae = si.ErrToResponse(err)
+	c.Check(ae, check.DeepEquals, &daemon.APIError{
+		Status:  409,
+		Message: "specific error msg",
+		Kind:    client.ErrorKindSnapChangeConflict,
+		Value: map[string]interface{}{
+			"change-kind": "some-global-op",
 		},
 	})
 }

--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -162,7 +162,7 @@ func changeSnapshots(c *Command, r *http.Request, user *auth.UserState) Response
 	chg.Set("api-data", map[string]interface{}{"snap-names": affected})
 	ensureStateSoon(st)
 
-	return AsyncResponse(nil, &Meta{Change: chg.ID()})
+	return AsyncResponse(nil, chg.ID())
 }
 
 // getSnapshotExport streams an archive containing an export of existing snapshots.

--- a/daemon/api_themes.go
+++ b/daemon/api_themes.go
@@ -248,5 +248,5 @@ func installThemes(c *Command, r *http.Request, user *auth.UserState) Response {
 		ensureStateSoon(st)
 	}
 	chg.Set("api-data", map[string]interface{}{"snap-names": installed})
-	return AsyncResponse(nil, &Meta{Change: chg.ID()})
+	return AsyncResponse(nil, chg.ID())
 }

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -500,7 +500,9 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 }
 
 func (s *userSuite) TestNoUserAdminCreateUser(c *check.C) { s.testNoUserAdmin(c, "/v2/create-user") }
-func (s *userSuite) TestNoUserAdminPostUser(c *check.C)   { s.testNoUserAdmin(c, "/v2/users") }
+
+func (s *userSuite) TestNoUserAdminPostUser(c *check.C) { s.testNoUserAdmin(c, "/v2/users") }
+
 func (s *userSuite) testNoUserAdmin(c *check.C, endpoint string) {
 	defer daemon.MockHasUserAdmin(false)()
 
@@ -508,14 +510,14 @@ func (s *userSuite) testNoUserAdmin(c *check.C, endpoint string) {
 	req, err := http.NewRequest("POST", endpoint, buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
+	ae := s.apiErrorReq(c, req, nil)
 
 	const noUserAdmin = "system user administration via snapd is not allowed on this system"
 	switch endpoint {
 	case "/v2/users":
-		c.Check(rsp, check.DeepEquals, daemon.MethodNotAllowed(noUserAdmin))
+		c.Check(ae, check.DeepEquals, daemon.MethodNotAllowed(noUserAdmin))
 	case "/v2/create-user":
-		c.Check(rsp, check.DeepEquals, daemon.Forbidden(noUserAdmin))
+		c.Check(ae, check.DeepEquals, daemon.Forbidden(noUserAdmin))
 	default:
 		c.Fatalf("unknown endpoint %q", endpoint)
 	}
@@ -535,8 +537,8 @@ func (s *userSuite) TestPostUserBadAfterBody(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp, check.DeepEquals, daemon.BadRequest("spurious content after user action"))
+	ae := s.apiErrorReq(c, req, nil)
+	c.Check(ae, check.DeepEquals, daemon.BadRequest("spurious content after user action"))
 }
 
 func (s *userSuite) TestPostUserNoAction(c *check.C) {
@@ -544,8 +546,8 @@ func (s *userSuite) TestPostUserNoAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp, check.DeepEquals, daemon.BadRequest("missing user action"))
+	ae := s.apiErrorReq(c, req, nil)
+	c.Check(ae, check.DeepEquals, daemon.BadRequest("missing user action"))
 }
 
 func (s *userSuite) TestPostUserBadAction(c *check.C) {
@@ -553,8 +555,8 @@ func (s *userSuite) TestPostUserBadAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp, check.DeepEquals, daemon.BadRequest(`unsupported user action "patatas"`))
+	ae := s.apiErrorReq(c, req, nil)
+	c.Check(ae, check.DeepEquals, daemon.BadRequest(`unsupported user action "patatas"`))
 }
 
 func (s *userSuite) TestPostUserActionRemoveNoUsername(c *check.C) {
@@ -562,8 +564,8 @@ func (s *userSuite) TestPostUserActionRemoveNoUsername(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp, check.DeepEquals, daemon.BadRequest("need a username to remove"))
+	ae := s.apiErrorReq(c, req, nil)
+	c.Check(ae, check.DeepEquals, daemon.BadRequest("need a username to remove"))
 }
 
 func (s *userSuite) TestPostUserActionRemoveDelUserErr(c *check.C) {
@@ -624,8 +626,8 @@ func (s *userSuite) TestPostUserActionRemoveNoUserInState(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp, check.DeepEquals, daemon.BadRequest(`user "some-user" is not known`))
+	ae := s.apiErrorReq(c, req, nil)
+	c.Check(ae, check.DeepEquals, daemon.BadRequest(`user "some-user" is not known`))
 	c.Check(called, check.Equals, 0)
 }
 

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -510,14 +510,14 @@ func (s *userSuite) testNoUserAdmin(c *check.C, endpoint string) {
 	req, err := http.NewRequest("POST", endpoint, buf)
 	c.Assert(err, check.IsNil)
 
-	ae := s.apiErrorReq(c, req, nil)
+	rspe := s.apiErrorReq(c, req, nil)
 
 	const noUserAdmin = "system user administration via snapd is not allowed on this system"
 	switch endpoint {
 	case "/v2/users":
-		c.Check(ae, check.DeepEquals, daemon.MethodNotAllowed(noUserAdmin))
+		c.Check(rspe, check.DeepEquals, daemon.MethodNotAllowed(noUserAdmin))
 	case "/v2/create-user":
-		c.Check(ae, check.DeepEquals, daemon.Forbidden(noUserAdmin))
+		c.Check(rspe, check.DeepEquals, daemon.Forbidden(noUserAdmin))
 	default:
 		c.Fatalf("unknown endpoint %q", endpoint)
 	}
@@ -537,8 +537,8 @@ func (s *userSuite) TestPostUserBadAfterBody(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	ae := s.apiErrorReq(c, req, nil)
-	c.Check(ae, check.DeepEquals, daemon.BadRequest("spurious content after user action"))
+	rspe := s.apiErrorReq(c, req, nil)
+	c.Check(rspe, check.DeepEquals, daemon.BadRequest("spurious content after user action"))
 }
 
 func (s *userSuite) TestPostUserNoAction(c *check.C) {
@@ -546,8 +546,8 @@ func (s *userSuite) TestPostUserNoAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	ae := s.apiErrorReq(c, req, nil)
-	c.Check(ae, check.DeepEquals, daemon.BadRequest("missing user action"))
+	rspe := s.apiErrorReq(c, req, nil)
+	c.Check(rspe, check.DeepEquals, daemon.BadRequest("missing user action"))
 }
 
 func (s *userSuite) TestPostUserBadAction(c *check.C) {
@@ -555,8 +555,8 @@ func (s *userSuite) TestPostUserBadAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	ae := s.apiErrorReq(c, req, nil)
-	c.Check(ae, check.DeepEquals, daemon.BadRequest(`unsupported user action "patatas"`))
+	rspe := s.apiErrorReq(c, req, nil)
+	c.Check(rspe, check.DeepEquals, daemon.BadRequest(`unsupported user action "patatas"`))
 }
 
 func (s *userSuite) TestPostUserActionRemoveNoUsername(c *check.C) {
@@ -564,8 +564,8 @@ func (s *userSuite) TestPostUserActionRemoveNoUsername(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	ae := s.apiErrorReq(c, req, nil)
-	c.Check(ae, check.DeepEquals, daemon.BadRequest("need a username to remove"))
+	rspe := s.apiErrorReq(c, req, nil)
+	c.Check(rspe, check.DeepEquals, daemon.BadRequest("need a username to remove"))
 }
 
 func (s *userSuite) TestPostUserActionRemoveDelUserErr(c *check.C) {
@@ -626,8 +626,8 @@ func (s *userSuite) TestPostUserActionRemoveNoUserInState(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	ae := s.apiErrorReq(c, req, nil)
-	c.Check(ae, check.DeepEquals, daemon.BadRequest(`user "some-user" is not known`))
+	rspe := s.apiErrorReq(c, req, nil)
+	c.Check(rspe, check.DeepEquals, daemon.BadRequest(`user "some-user" is not known`))
 	c.Check(called, check.Equals, 0)
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -174,7 +174,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			st.Lock()
 			count, stamp := st.WarningsSummary()
 			st.Unlock()
-			rsp.addWarningsToMeta(count, stamp)
+			rsp.addWarningCount(count, stamp)
 		}
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -168,9 +168,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if rsp, ok := rsp.(*resp); ok {
 		_, rst := st.Restarting()
-		if rst != state.RestartUnset {
-			rsp.Maintenance = maintenanceForRestartType(rst)
-		}
+		rsp.addMaintenanceFromRestartType(rst)
 
 		if rsp.Type != ResponseTypeError {
 			st.Lock()

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -28,7 +28,7 @@ import (
 
 // XXX move more bits related to errors from response.go
 
-// apiError reprents an error meant for returning to the client.
+// apiError represents an error meant for returning to the client.
 // It can serialize itself to our standard JSON response format.
 type apiError struct {
 	// Status is the error HTTP status code.
@@ -40,13 +40,13 @@ type apiError struct {
 }
 
 func (ae *apiError) Error() string {
-	machine := "api"
+	kindOrStatus := "api"
 	if ae.Kind != "" {
-		machine = fmt.Sprintf("api: %s", ae.Kind)
+		kindOrStatus = fmt.Sprintf("api: %s", ae.Kind)
 	} else if ae.Status != 400 {
-		machine = fmt.Sprintf("api %d", ae.Status)
+		kindOrStatus = fmt.Sprintf("api %d", ae.Status)
 	}
-	return fmt.Sprintf("%s (%s)", ae.Message, machine)
+	return fmt.Sprintf("%s (%s)", ae.Message, kindOrStatus)
 }
 
 func (ae *apiError) JSON() *respJSON {

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -1,0 +1,69 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/snapcore/snapd/client"
+)
+
+// XXX move more bits related to errors from response.go
+
+// apiError reprents an error meant for returning to the client.
+// It can serialize itself to our standard JSON response format.
+type apiError struct {
+	// Status is the error HTTP status code.
+	Status  int
+	Message string
+	// Kind is the error kind. See client/errors.go
+	Kind  client.ErrorKind
+	Value errorValue
+}
+
+func (ae *apiError) Error() string {
+	machine := "api"
+	if ae.Kind != "" {
+		machine = fmt.Sprintf("api: %s", ae.Kind)
+	} else if ae.Status != 400 {
+		machine = fmt.Sprintf("api %d", ae.Status)
+	}
+	return fmt.Sprintf("%s (%s)", ae.Message, machine)
+}
+
+func (ae *apiError) JSON() *respJSON {
+	return &respJSON{
+		Status: ae.Status,
+		Type:   ResponseTypeError,
+		Result: &errorResult{
+			Message: ae.Message,
+			Kind:    ae.Kind,
+			Value:   ae.Value,
+		},
+	}
+}
+
+func (ae *apiError) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ae.JSON().ServeHTTP(w, r)
+}
+
+// check it implements StructuredResponse
+var _ StructuredResponse = (*apiError)(nil)

--- a/daemon/errors_test.go
+++ b/daemon/errors_test.go
@@ -90,3 +90,13 @@ func (s *errorsSuite) TestError(c *C) {
 	}
 	c.Check(ae.Error(), Equals, `internal error (api 500)`)
 }
+
+func (s *errorsSuite) TestThroughSyncResponse(c *C) {
+	ae := &daemon.APIError{
+		Status:  400,
+		Message: "req is wrong",
+	}
+
+	rsp := daemon.SyncResponse(ae, nil)
+	c.Check(rsp, Equals, ae)
+}

--- a/daemon/errors_test.go
+++ b/daemon/errors_test.go
@@ -1,0 +1,92 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/daemon"
+)
+
+type errorsSuite struct{}
+
+var _ = Suite(&errorsSuite{})
+
+func (s *errorsSuite) TestJSON(c *C) {
+	ae := &daemon.APIError{
+		Status:  400,
+		Message: "req is wrong",
+	}
+
+	c.Check(ae.JSON(), DeepEquals, &daemon.RespJSON{
+		Status: 400,
+		Type:   daemon.ResponseTypeError,
+		Result: &daemon.ErrorResult{
+			Message: "req is wrong",
+		},
+	})
+
+	ae = &daemon.APIError{
+		Status:  404,
+		Message: "snap not found",
+		Kind:    client.ErrorKindSnapNotFound,
+		Value: map[string]string{
+			"snap-name": "foo",
+		},
+	}
+	c.Check(ae.JSON(), DeepEquals, &daemon.RespJSON{
+		Status: 404,
+		Type:   daemon.ResponseTypeError,
+		Result: &daemon.ErrorResult{
+			Message: "snap not found",
+			Kind:    client.ErrorKindSnapNotFound,
+			Value: map[string]string{
+				"snap-name": "foo",
+			},
+		},
+	})
+}
+
+func (s *errorsSuite) TestError(c *C) {
+	ae := &daemon.APIError{
+		Status:  400,
+		Message: "req is wrong",
+	}
+
+	c.Check(ae.Error(), Equals, `req is wrong (api)`)
+
+	ae = &daemon.APIError{
+		Status:  404,
+		Message: "snap not found",
+		Kind:    client.ErrorKindSnapNotFound,
+		Value: map[string]string{
+			"snap-name": "foo",
+		},
+	}
+
+	c.Check(ae.Error(), Equals, `snap not found (api: snap-not-found)`)
+
+	ae = &daemon.APIError{
+		Status:  500,
+		Message: "internal error",
+	}
+	c.Check(ae.Error(), Equals, `internal error (api 500)`)
+}

--- a/daemon/errors_test.go
+++ b/daemon/errors_test.go
@@ -31,12 +31,12 @@ type errorsSuite struct{}
 var _ = Suite(&errorsSuite{})
 
 func (s *errorsSuite) TestJSON(c *C) {
-	ae := &daemon.APIError{
+	rspe := &daemon.APIError{
 		Status:  400,
 		Message: "req is wrong",
 	}
 
-	c.Check(ae.JSON(), DeepEquals, &daemon.RespJSON{
+	c.Check(rspe.JSON(), DeepEquals, &daemon.RespJSON{
 		Status: 400,
 		Type:   daemon.ResponseTypeError,
 		Result: &daemon.ErrorResult{
@@ -44,7 +44,7 @@ func (s *errorsSuite) TestJSON(c *C) {
 		},
 	})
 
-	ae = &daemon.APIError{
+	rspe = &daemon.APIError{
 		Status:  404,
 		Message: "snap not found",
 		Kind:    client.ErrorKindSnapNotFound,
@@ -52,7 +52,7 @@ func (s *errorsSuite) TestJSON(c *C) {
 			"snap-name": "foo",
 		},
 	}
-	c.Check(ae.JSON(), DeepEquals, &daemon.RespJSON{
+	c.Check(rspe.JSON(), DeepEquals, &daemon.RespJSON{
 		Status: 404,
 		Type:   daemon.ResponseTypeError,
 		Result: &daemon.ErrorResult{
@@ -66,14 +66,14 @@ func (s *errorsSuite) TestJSON(c *C) {
 }
 
 func (s *errorsSuite) TestError(c *C) {
-	ae := &daemon.APIError{
+	rspe := &daemon.APIError{
 		Status:  400,
 		Message: "req is wrong",
 	}
 
-	c.Check(ae.Error(), Equals, `req is wrong (api)`)
+	c.Check(rspe.Error(), Equals, `req is wrong (api)`)
 
-	ae = &daemon.APIError{
+	rspe = &daemon.APIError{
 		Status:  404,
 		Message: "snap not found",
 		Kind:    client.ErrorKindSnapNotFound,
@@ -82,21 +82,21 @@ func (s *errorsSuite) TestError(c *C) {
 		},
 	}
 
-	c.Check(ae.Error(), Equals, `snap not found (api: snap-not-found)`)
+	c.Check(rspe.Error(), Equals, `snap not found (api: snap-not-found)`)
 
-	ae = &daemon.APIError{
+	rspe = &daemon.APIError{
 		Status:  500,
 		Message: "internal error",
 	}
-	c.Check(ae.Error(), Equals, `internal error (api 500)`)
+	c.Check(rspe.Error(), Equals, `internal error (api 500)`)
 }
 
 func (s *errorsSuite) TestThroughSyncResponse(c *C) {
-	ae := &daemon.APIError{
+	rspe := &daemon.APIError{
 		Status:  400,
 		Message: "req is wrong",
 	}
 
-	rsp := daemon.SyncResponse(ae, nil)
-	c.Check(rsp, Equals, ae)
+	rsp := daemon.SyncResponse(rspe, nil)
+	c.Check(rsp, Equals, rspe)
 }

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -197,6 +197,7 @@ type (
 	Resp            = resp
 	RespJSON        = respJSON
 	FileResponse    = fileResponse
+	APIError        = apiError
 	ErrorResult     = errorResult
 	SnapInstruction = snapInstruction
 )

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -223,7 +223,7 @@ func (inst *snapInstruction) ModeFlags() (snapstate.Flags, error) {
 	return inst.modeFlags()
 }
 
-func (inst *snapInstruction) ErrToResponse(err error) Response {
+func (inst *snapInstruction) ErrToResponse(err error) *APIError {
 	return inst.errToResponse(err)
 }
 

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -55,9 +55,16 @@ const (
 	ResponseTypeError ResponseType = "error"
 )
 
-// Response knows how to serve itself, and how to find itself
+// Response knows how to serve itself.
 type Response interface {
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
+}
+
+// A StructuredResponse serializes itself to our standard JSON response format.
+type StructuredResponse interface {
+	Response
+
+	JSON() *respJSON
 }
 
 // XXX drop resp
@@ -88,6 +95,10 @@ type respJSON struct {
 	WarningTimestamp *time.Time   `json:"warning-timestamp,omitempty"`
 	WarningCount     int          `json:"warning-count,omitempty"`
 	Maintenance      *errorResult `json:"maintenance,omitempty"`
+}
+
+func (r *respJSON) JSON() *respJSON {
+	return r
 }
 
 func maintenanceForRestartType(rst state.RestartType) *errorResult {

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -191,12 +191,12 @@ type errorResult struct {
 
 // SyncResponse builds a "sync" response from the given result.
 func SyncResponse(result interface{}, meta *Meta) Response {
-	if err, ok := result.(error); ok {
-		return InternalError("internal error: %v", err)
-	}
-
 	if rsp, ok := result.(Response); ok {
 		return rsp
+	}
+
+	if err, ok := result.(error); ok {
+		return InternalError("internal error: %v", err)
 	}
 
 	return &resp{

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -102,6 +102,14 @@ func maintenanceForRestartType(rst state.RestartType) *errorResult {
 	return e
 }
 
+func (r *resp) addMaintenanceFromRestartType(rst state.RestartType) {
+	if rst == state.RestartUnset {
+		// nothing to do
+		return
+	}
+	r.Maintenance = maintenanceForRestartType(rst)
+}
+
 func (r *resp) addWarningsToMeta(count int, stamp time.Time) {
 	if r.Meta != nil && r.Meta.WarningCount != 0 {
 		return

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -144,9 +144,6 @@ func (r *respJSON) addMaintenanceFromRestartType(rst state.RestartType) {
 }
 
 func (r *respJSON) addWarningCount(count int, stamp time.Time) {
-	if r.WarningCount != 0 {
-		return
-	}
 	if count == 0 {
 		return
 	}

--- a/daemon/response_test.go
+++ b/daemon/response_test.go
@@ -216,8 +216,8 @@ func (s *responseSuite) TestErrToResponse(c *check.C) {
 
 	for _, t := range tests {
 		com := check.Commentf("%v", t.err)
-		ae := daemon.ErrToResponse(t.err, []string{"foo"}, daemon.BadRequest, "%s: %v", "ERR")
-		c.Check(ae, check.DeepEquals, t.expectedRsp, com)
+		rspe := daemon.ErrToResponse(t.err, []string{"foo"}, daemon.BadRequest, "%s: %v", "ERR")
+		c.Check(rspe, check.DeepEquals, t.expectedRsp, com)
 	}
 }
 
@@ -228,8 +228,8 @@ func (s *responseSuite) TestErrToResponseInsufficentSpace(c *check.C) {
 		Path:       "/path",
 		Message:    "specific error msg",
 	}
-	ae := daemon.ErrToResponse(err, nil, daemon.BadRequest, "%s: %v", "ERR")
-	c.Check(ae, check.DeepEquals, &daemon.APIError{
+	rspe := daemon.ErrToResponse(err, nil, daemon.BadRequest, "%s: %v", "ERR")
+	c.Check(rspe, check.DeepEquals, &daemon.APIError{
 		Status:  507,
 		Message: "specific error msg",
 		Kind:    client.ErrorKindInsufficientDiskSpace,

--- a/daemon/response_test.go
+++ b/daemon/response_test.go
@@ -178,12 +178,13 @@ func (s *responseSuite) TestErrToResponse(c *check.C) {
 	// this one can't happen (but fun to test):
 	saXe := &store.SnapActionError{Refresh: map[string]error{"foo": sa1e}}
 
-	makeErrorRsp := func(kind client.ErrorKind, err error, value interface{}) daemon.Response {
-		return daemon.SyncResponse(&daemon.Resp{
-			Type:   daemon.ResponseTypeError,
-			Result: &daemon.ErrorResult{Message: err.Error(), Kind: kind, Value: value},
-			Status: 400,
-		}, nil)
+	makeErrorRsp := func(kind client.ErrorKind, err error, value interface{}) *daemon.APIError {
+		return &daemon.APIError{
+			Status:  400,
+			Message: err.Error(),
+			Kind:    kind,
+			Value:   value,
+		}
 	}
 
 	tests := []struct {
@@ -215,8 +216,8 @@ func (s *responseSuite) TestErrToResponse(c *check.C) {
 
 	for _, t := range tests {
 		com := check.Commentf("%v", t.err)
-		rsp := daemon.ErrToResponse(t.err, []string{"foo"}, daemon.BadRequest, "%s: %v", "ERR")
-		c.Check(rsp, check.DeepEquals, t.expectedRsp, com)
+		ae := daemon.ErrToResponse(t.err, []string{"foo"}, daemon.BadRequest, "%s: %v", "ERR")
+		c.Check(ae, check.DeepEquals, t.expectedRsp, com)
 	}
 }
 
@@ -227,17 +228,14 @@ func (s *responseSuite) TestErrToResponseInsufficentSpace(c *check.C) {
 		Path:       "/path",
 		Message:    "specific error msg",
 	}
-	rsp := daemon.ErrToResponse(err, nil, daemon.BadRequest, "%s: %v", "ERR").(*daemon.Resp)
-	c.Check(rsp, check.DeepEquals, &daemon.Resp{
-		Status: 507,
-		Type:   daemon.ResponseTypeError,
-		Result: &daemon.ErrorResult{
-			Message: "specific error msg",
-			Kind:    client.ErrorKindInsufficientDiskSpace,
-			Value: map[string]interface{}{
-				"snap-names":  []string{"foo", "bar"},
-				"change-kind": "some-change",
-			},
+	ae := daemon.ErrToResponse(err, nil, daemon.BadRequest, "%s: %v", "ERR")
+	c.Check(ae, check.DeepEquals, &daemon.APIError{
+		Status:  507,
+		Message: "specific error msg",
+		Kind:    client.ErrorKindInsufficientDiskSpace,
+		Value: map[string]interface{}{
+			"snap-names":  []string{"foo", "bar"},
+			"change-kind": "some-change",
 		},
 	})
 }


### PR DESCRIPTION
This is the first branch in a series, the goal is to streamline how responses, also error responses in particular are built in daemon.

To achieve that this introduces a StructuredResponse interface and a apiError structure and then it starts changing/simplifying how response are built and the corresponding helpers.
