### PR TITLE
snap/quota, systemd, wrappers: misc set of fixes for quota groups on Centos, AL2

### DIFF
--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -99,6 +99,10 @@ func (s *emulation) CurrentMemoryUsage(unit string) (quantity.Size, error) {
 	return 0, errNotImplemented
 }
 
+func (s *emulation) CurrentTasksCount(unit string) (int, error) {
+	return 0, errNotImplemented
+}
+
 func (s *emulation) IsEnabled(service string) (bool, error) {
 	return false, errNotImplemented
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -754,14 +754,15 @@ func (s *systemd) IsActive(serviceName string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	// "systemctl is-active <name>" returns exit code 3 for inactive
-	// services, the stderr output may be `inactive\n` for services that are
-	// inactive (or not found), or `failed\n` for services that are in a
-	// failed state; nevertheless make sure to check any non-0 exit code
+	// "systemctl is-active <name>" returns exit code 3 for inactive services,
+	// the stderr output may be `unknown\n` for services that were not found,
+	// `inactive\n` for services that are inactive (or not found for some
+	// systemd versions), or `failed\n` for services that are in a failed state;
+	// nevertheless make sure to check any non-0 exit code
 	sysdErr, ok := err.(systemctlError)
 	if ok {
 		switch strings.TrimSpace(string(sysdErr.Msg())) {
-		case "inactive", "failed":
+		case "inactive", "failed", "unknown":
 			return false, nil
 		}
 	}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -266,6 +266,10 @@ type Systemd interface {
 	// CurrentMemoryUsage returns the current memory usage for the specified
 	// unit.
 	CurrentMemoryUsage(unit string) (quantity.Size, error)
+	// CurrentTasksCount returns the number of tasks (processes, threads, kernel
+	// threads if enabled, etc) part of the unit, which can be a service or a
+	// slice.
+	CurrentTasksCount(unit string) (int, error)
 }
 
 // A Log is a single entry in the systemd journal.
@@ -593,31 +597,80 @@ func (s *systemd) getGlobalUserStatus(unitNames ...string) ([]*UnitStatus, error
 	return sts, nil
 }
 
-func (s *systemd) CurrentMemoryUsage(unit string) (quantity.Size, error) {
-	out, err := s.systemctl("show", "--property", "MemoryCurrent", unit)
+func (s *systemd) getPropertyStringValue(unit, key string) (string, error) {
+	// XXX: ignore stderr of systemctl command to avoid further infractions
+	//      around LP #1885597
+	out, err := s.systemctl("show", "--property", key, unit)
 	if err != nil {
-		return 0, osutil.OutputErr(out, err)
+		return "", osutil.OutputErr(out, err)
 	}
-	// strip the MemoryCurrent= from the output
-	splitVal := strings.SplitN(strings.TrimSpace(string(out)), "=", 2)
+	cleanVal := strings.TrimSpace(string(out))
+
+	// strip the TasksCurrent= from the output
+	splitVal := strings.SplitN(cleanVal, "=", 2)
 	if len(splitVal) != 2 {
-		return 0, fmt.Errorf("invalid property format from systemd for MemoryCurrent")
+		return "", fmt.Errorf("invalid property format from systemd for %s (got %s)", key, cleanVal)
 	}
 
-	trimmedVal := strings.TrimSpace(splitVal[1])
+	return strings.TrimSpace(splitVal[1]), nil
+}
+
+func (s *systemd) CurrentTasksCount(unit string) (int, error) {
+	tasksStr, err := s.getPropertyStringValue(unit, "TasksCurrent")
+	if err != nil {
+		return 0, err
+	}
+
+	// if the unit is inactive or doesn't exist, the tasks current can be
+	// reported as "[not set]"
+	if tasksStr == "[not set]" {
+		return 0, fmt.Errorf("tasks count unavailable")
+	}
+
+	intVal, err := strconv.Atoi(tasksStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid property value from systemd for TasksCurrent: cannot parse %q as an integer", tasksStr)
+	}
+
+	return intVal, nil
+}
+
+func (s *systemd) CurrentMemoryUsage(unit string) (quantity.Size, error) {
+	memStr, err := s.getPropertyStringValue(unit, "MemoryCurrent")
+	if err != nil {
+		return 0, err
+	}
 
 	// if the unit is inactive or doesn't exist, the memory usage can be
 	// reported as "[not set]"
-	if trimmedVal == "[not set]" {
+	if memStr == "[not set]" {
 		return 0, fmt.Errorf("memory usage unavailable")
 	}
 
-	intVal, err := strconv.Atoi(trimmedVal)
+	intVal, err := strconv.Atoi(memStr)
 	if err != nil {
-		return 0, fmt.Errorf("invalid property value from systemd for MemoryCurrent: cannot parse %q as an integer", trimmedVal)
+		return 0, fmt.Errorf("invalid property value from systemd for MemoryCurrent: cannot parse %q as an integer", memStr)
 	}
 
 	return quantity.Size(intVal), nil
+}
+
+func (s *systemd) InactiveEnterTimestamp(unit string) (time.Time, error) {
+	timeStr, err := s.getPropertyStringValue(unit, "InactiveEnterTimestamp")
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if timeStr == "" {
+		return time.Time{}, nil
+	}
+
+	// finally parse the time string
+	inactiveEnterTime, err := time.Parse("Mon 2006-01-02 15:04:05 MST", timeStr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("internal error: systemctl time output (%s) is malformed", timeStr)
+	}
+	return inactiveEnterTime, nil
 }
 
 func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
@@ -667,35 +720,6 @@ func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
 	}
 
 	return sts, nil
-}
-
-func (s *systemd) InactiveEnterTimestamp(unit string) (time.Time, error) {
-	// XXX: ignore stderr of systemctl command to avoid further infractions
-	//      around LP #1885597
-	out, err := s.systemctl("show", "--property", "InactiveEnterTimestamp", unit)
-	if err != nil {
-		return time.Time{}, osutil.OutputErr(out, err)
-	}
-	// the time returned by systemctl here will be formatted like so:
-	// InactiveEnterTimestamp=Fri 2021-04-16 15:32:21 UTC
-	// so we have to parse the time with a matching Go time format
-	splitVal := strings.SplitN(strings.TrimSpace(string(out)), "=", 2)
-	if len(splitVal) != 2 {
-		// then we don't have an equals sign in the output, so systemctl must be
-		// broken
-		return time.Time{}, fmt.Errorf("internal error: systemctl output (%s) is malformed", string(out))
-	}
-
-	if splitVal[1] == "" {
-		return time.Time{}, nil
-	}
-
-	// finally parse the time string
-	inactiveEnterTime, err := time.Parse("Mon 2006-01-02 15:04:05 MST", splitVal[1])
-	if err != nil {
-		return time.Time{}, fmt.Errorf("internal error: systemctl time output (%s) is malformed", splitVal[1])
-	}
-	return inactiveEnterTime, nil
 }
 
 func (s *systemd) IsEnabled(serviceName string) (bool, error) {

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -983,6 +983,21 @@ func (s *SystemdTestSuite) TestIsActiveIsInactive(c *C) {
 	c.Check(s.argses, DeepEquals, [][]string{{"is-active", "foo"}})
 }
 
+func (s *SystemdTestSuite) TestIsActiveIsInactiveAlternativeMessage(c *C) {
+	sysErr := &Error{}
+	// on Centos 7, with systemd 219 we see "unknown" returned when querying the
+	// active state for a slice unit which does not exist, check that we handle
+	// this case properly as well
+	sysErr.SetExitCode(3)
+	sysErr.SetMsg([]byte("unknown\n"))
+	s.errors = []error{sysErr}
+
+	active, err := New(SystemMode, s.rep).IsActive("foo")
+	c.Assert(active, Equals, false)
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"is-active", "foo"}})
+}
+
 func (s *SystemdTestSuite) TestIsActiveIsFailed(c *C) {
 	sysErr := &Error{}
 	// seen in the wild to be reported for a 'failed' service

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -88,6 +88,10 @@ Before=slices.target
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 MemoryMax=%[2]d
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 
 	fmt.Fprintf(&buf, template, grp.Name, grp.MemoryLimit)

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -262,6 +262,10 @@ Before=slices.target
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 MemoryMax=%s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 
 	sliceContent := fmt.Sprintf(sliceTempl, grp.Name, memLimit.String())
@@ -365,6 +369,10 @@ Before=slices.target
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 MemoryMax=%s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
 
@@ -454,6 +462,10 @@ Before=slices.target
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 MemoryMax=%s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
 
@@ -608,6 +620,10 @@ Before=slices.target
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 MemoryMax=%s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 
 	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", memLimit.String())
@@ -773,6 +789,10 @@ Before=slices.target
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 MemoryMax=%s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 
 	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", memLimit.String()))


### PR DESCRIPTION
These changes all taken together enable quota group memory usage tracking to now work correctly in conjunction with https://github.com/snapcore/snapd/pull/10316 and https://github.com/snapcore/snapd/pull/10287.

Specifically, we can avoid the bugs that version of systemd has around memory reporting by checking if the group has any tasks in it and also expanding the cases we consider a unit as inactive in IsActive. 

This should go in _before_ #10316 in order to make the spread test there pass on CentOS and AL2.