### PR TITLE
o/devicestate: require serial assertion before remodeling can be started

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -521,6 +521,14 @@ func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if _, err := findSerial(st, nil); err != nil {
+		if err == state.ErrNoState {
+			return nil, fmt.Errorf("cannot remodel without a serial")
+		}
+		return nil, err
+	}
+
 	if current.Series() != new.Series() {
 		return nil, fmt.Errorf("cannot remodel to different series yet")
 	}

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -126,9 +126,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelUnhappy(c *C) {
 		"kernel":       cur["kernel"],
 		"gadget":       cur["gadget"],
 	})
+	s.makeSerialAssertionInState(c, cur["brand"].(string), cur["model"].(string), "orig-serial")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: cur["brand"].(string),
-		Model: cur["model"].(string),
+		Brand:  cur["brand"].(string),
+		Model:  cur["model"].(string),
+		Serial: "orig-serial",
 	})
 
 	// ensure all error cases are checked
@@ -161,9 +163,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelNoUC20RemodelYet(c *C) {
 		"grade":        cur["grade"],
 		"snaps":        cur["snaps"],
 	})
+	s.makeSerialAssertionInState(c, cur["brand"].(string), cur["model"].(string), "orig-serial")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: cur["brand"].(string),
-		Model: cur["model"].(string),
+		Brand:  cur["brand"].(string),
+		Model:  cur["model"].(string),
+		Serial: "orig-serial",
 	})
 
 	// ensure all error cases are checked
@@ -183,6 +187,40 @@ func (s *deviceMgrRemodelSuite) TestRemodelNoUC20RemodelYet(c *C) {
 		c.Check(chg, IsNil)
 		c.Check(err, ErrorMatches, t.errStr)
 	}
+}
+
+func (s *deviceMgrRemodelSuite) TestRemodelRequiresSerial(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.state.Set("seeded", true)
+
+	// set a model assertion
+	cur := map[string]interface{}{
+		"brand":        "canonical",
+		"model":        "pc-model",
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+	}
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+	})
+	// no serial assertion, no serial in state
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-model",
+	})
+
+	newModelHdrs := map[string]interface{}{
+		"revision": "2",
+	}
+	mergeMockModelHeaders(cur, newModelHdrs)
+	new := s.brands.Model("canonical", "pc-model", newModelHdrs)
+	chg, err := devicestate.Remodel(s.state, new)
+	c.Check(chg, IsNil)
+	c.Check(err, ErrorMatches, "cannot remodel without a serial")
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchGadgetTrack(c *C) {
@@ -381,9 +419,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelRequiredSnaps(c *C) {
 		"gadget":       "pc",
 		"base":         "core18",
 	})
+	s.makeSerialAssertionInState(c, "canonical", "pc-model", "1234")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: "canonical",
-		Model: "pc-model",
+		Brand:  "canonical",
+		Model:  "pc-model",
+		Serial: "1234",
 	})
 
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
@@ -508,9 +548,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelSwitchKernelTrack(c *C) {
 		"gadget":       "pc",
 		"base":         "core18",
 	})
+	s.makeSerialAssertionInState(c, "canonical", "pc-model", "1234")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: "canonical",
-		Model: "pc-model",
+		Brand:  "canonical",
+		Model:  "pc-model",
+		Serial: "1234",
 	})
 
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
@@ -585,9 +627,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelLessRequiredSnaps(c *C) {
 		"base":           "core18",
 		"required-snaps": []interface{}{"some-required-snap"},
 	})
+	s.makeSerialAssertionInState(c, "canonical", "pc-model", "1234")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: "canonical",
-		Model: "pc-model",
+		Brand:  "canonical",
+		Model:  "pc-model",
+		Serial: "1234",
 	})
 
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
@@ -652,9 +696,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelStoreSwitch(c *C) {
 		"gadget":       "pc",
 		"base":         "core18",
 	})
+	s.makeSerialAssertionInState(c, "canonical", "pc-model", "1234")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: "canonical",
-		Model: "pc-model",
+		Brand:  "canonical",
+		Model:  "pc-model",
+		Serial: "1234",
 	})
 
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
@@ -794,9 +840,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelClash(c *C) {
 		"gadget":       "pc",
 		"base":         "core18",
 	})
+	s.makeSerialAssertionInState(c, "canonical", "pc-model", "1234")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: "canonical",
-		Model: "pc-model",
+		Brand:  "canonical",
+		Model:  "pc-model",
+		Serial: "1234",
 	})
 
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
@@ -823,8 +871,9 @@ func (s *deviceMgrRemodelSuite) TestRemodelClash(c *C) {
 
 	// reset
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: "canonical",
-		Model: "pc-model",
+		Brand:  "canonical",
+		Model:  "pc-model",
+		Serial: "1234",
 	})
 	clashing = new
 	_, err = devicestate.Remodel(s.state, new)
@@ -861,9 +910,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelClashInProgress(c *C) {
 		"gadget":       "pc",
 		"base":         "core18",
 	})
+	s.makeSerialAssertionInState(c, "canonical", "pc-model", "1234")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: "canonical",
-		Model: "pc-model",
+		Brand:  "canonical",
+		Model:  "pc-model",
+		Serial: "1234",
 	})
 
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
@@ -1280,6 +1331,7 @@ volumes:
 		"gadget":       "pc",
 		"base":         "core18",
 	})
+	s.makeSerialAssertionInState(c, "canonical", "pc-model", "serial")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc-model",
@@ -1403,7 +1455,7 @@ volumes:
 	defer restore()
 
 	chg, err := devicestate.Remodel(s.state, new)
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 	s.state.Unlock()
 
 	s.settle(c)
@@ -1435,6 +1487,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelGadgetAssetsParanoidCheck(c *C) {
 		"gadget":       "pc",
 		"base":         "core18",
 	})
+	s.makeSerialAssertionInState(c, "canonical", "pc-model", "serial")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc-model",
@@ -1494,7 +1547,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelGadgetAssetsParanoidCheck(c *C) {
 	defer restore()
 
 	chg, err := devicestate.Remodel(s.state, new)
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 	s.state.Unlock()
 
 	s.settle(c)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -441,6 +441,23 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	s.logbuf = logbuf
 }
 
+func (s *baseMgrsSuite) makeSerialAssertionInState(c *C, st *state.State, brandID, model, serialN string) *asserts.Serial {
+	encDevKey, err := asserts.EncodePublicKey(deviceKey.PublicKey())
+	c.Assert(err, IsNil)
+	serial, err := s.brands.Signing(brandID).Sign(asserts.SerialType, map[string]interface{}{
+		"brand-id":            brandID,
+		"model":               model,
+		"serial":              serialN,
+		"device-key":          string(encDevKey),
+		"device-key-sha3-384": deviceKey.PublicKey().ID(),
+		"timestamp":           time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = assertstate.Add(st, serial)
+	c.Assert(err, IsNil)
+	return serial.(*asserts.Serial)
+}
+
 type mgrsSuite struct {
 	baseMgrsSuite
 }
@@ -4164,6 +4181,7 @@ func (s *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
+	s.makeSerialAssertionInState(c, st, "my-brand", "my-model", "serialserialserial")
 
 	// create a new model
 	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
@@ -4263,6 +4281,7 @@ func (s *mgrsSuite) TestRemodelRequiredSnapsAddedUndo(c *C) {
 	})
 	err := assertstate.Add(st, curModel)
 	c.Assert(err, IsNil)
+	s.makeSerialAssertionInState(c, st, "my-brand", "my-model", "serialserialserial")
 
 	// create a new model
 	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
@@ -4332,6 +4351,7 @@ type: base`
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
+	s.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
 	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
@@ -4415,6 +4435,7 @@ version: 20.04`
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
+	ms.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
 	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
@@ -4556,6 +4577,7 @@ version: 20.04`
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
+	ms.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
 	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
@@ -4695,6 +4717,7 @@ version: 20.04`
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
+	ms.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
 	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
@@ -4791,6 +4814,7 @@ func (s *kernelSuite) SetUpTest(c *C) {
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
+	s.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// make a mock "pc-kernel" kernel
 	si := &snap.SideInfo{RealName: "pc-kernel", SnapID: fakeSnapID("pc-kernel"), Revision: snap.R(1)}
@@ -5249,6 +5273,7 @@ volumes:
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
+	s.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
 	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
@@ -5381,6 +5406,7 @@ volumes:
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
+	s.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
 	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
@@ -5507,6 +5533,7 @@ volumes:
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
+	s.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
 	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{


### PR DESCRIPTION
By agreement, we will require a serial assertion to be present before remodeling
can be started. The change adds relevant checks and updates the tests.

Remodel spread tests may fail at this point.