### PR TITLE
cmd/snap/quota: refactor quota CLI as per new design 

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -36,11 +36,12 @@ type postQuotaData struct {
 }
 
 type QuotaGroupResult struct {
-	GroupName string   `json:"group-name"`
-	Parent    string   `json:"parent,omitempty"`
-	Subgroups []string `json:"subgroups,omitempty"`
-	Snaps     []string `json:"snaps,omitempty"`
-	MaxMemory uint64   `json:"max-memory"`
+	GroupName     string   `json:"group-name"`
+	Parent        string   `json:"parent,omitempty"`
+	Subgroups     []string `json:"subgroups,omitempty"`
+	Snaps         []string `json:"snaps,omitempty"`
+	MaxMemory     uint64   `json:"max-memory"`
+	CurrentMemory uint64   `json:"current-memory"`
 }
 
 // EnsureQuota creates a quota group or updates an existing group.

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -72,7 +72,7 @@ func (cs *clientSuite) TestGetQuotaGroup(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
 		"status-code": 200,
-		"result": {"group-name":"foo", "parent":"bar", "subgroups":["foo-subgrp"], "snaps":["snap-a"], "max-memory":999}
+		"result": {"group-name":"foo", "parent":"bar", "subgroups":["foo-subgrp"], "snaps":["snap-a"], "max-memory":999, "current-memory":450}
 	}`
 
 	grp, err := cs.cli.GetQuotaGroup("foo")
@@ -80,11 +80,12 @@ func (cs *clientSuite) TestGetQuotaGroup(c *check.C) {
 	c.Check(cs.req.Method, check.Equals, "GET")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/quotas/foo")
 	c.Check(grp, check.DeepEquals, &client.QuotaGroupResult{
-		GroupName: "foo",
-		Parent:    "bar",
-		Subgroups: []string{"foo-subgrp"},
-		MaxMemory: 999,
-		Snaps:     []string{"snap-a"},
+		GroupName:     "foo",
+		Parent:        "bar",
+		Subgroups:     []string{"foo-subgrp"},
+		MaxMemory:     999,
+		CurrentMemory: 450,
+		Snaps:         []string{"snap-a"},
 	})
 }
 

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/servicestate"
@@ -55,15 +56,6 @@ type postQuotaGroupData struct {
 	Snaps     []string `json:"snaps,omitempty"`
 }
 
-type quotaGroupResultJSON struct {
-	GroupName     string   `json:"group-name"`
-	MaxMemory     uint64   `json:"max-memory"`
-	CurrentMemory uint64   `json:"current-memory"`
-	Parent        string   `json:"parent,omitempty"`
-	Snaps         []string `json:"snaps,omitempty"`
-	SubGroups     []string `json:"subgroups,omitempty"`
-}
-
 var (
 	servicestateCreateQuota = servicestate.CreateQuota
 	servicestateUpdateQuota = servicestate.UpdateQuota
@@ -93,7 +85,7 @@ func getQuotaGroups(c *Command, r *http.Request, _ *auth.UserState) Response {
 	}
 	sort.Strings(names)
 
-	results := make([]quotaGroupResultJSON, len(quotas))
+	results := make([]client.QuotaGroupResult, len(quotas))
 	for i, name := range names {
 		qt := quotas[name]
 
@@ -102,10 +94,10 @@ func getQuotaGroups(c *Command, r *http.Request, _ *auth.UserState) Response {
 			return InternalError(err.Error())
 		}
 
-		results[i] = quotaGroupResultJSON{
+		results[i] = client.QuotaGroupResult{
 			GroupName:     qt.Name,
 			Parent:        qt.ParentGroup,
-			SubGroups:     qt.SubGroups,
+			Subgroups:     qt.SubGroups,
 			Snaps:         qt.Snaps,
 			MaxMemory:     uint64(qt.MemoryLimit),
 			CurrentMemory: uint64(memoryUsage),
@@ -139,11 +131,11 @@ func getQuotaGroupInfo(c *Command, r *http.Request, _ *auth.UserState) Response 
 		return InternalError(err.Error())
 	}
 
-	res := quotaGroupResultJSON{
+	res := client.QuotaGroupResult{
 		GroupName:     group.Name,
 		Parent:        group.ParentGroup,
 		Snaps:         group.Snaps,
-		SubGroups:     group.SubGroups,
+		Subgroups:     group.SubGroups,
 		MaxMemory:     uint64(group.MemoryLimit),
 		CurrentMemory: uint64(memoryUsage),
 	}

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -28,6 +28,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -279,9 +280,9 @@ func (s *apiQuotaSuite) TestListQuotas(c *check.C) {
 	c.Assert(err, check.IsNil)
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
-	c.Assert(rsp.Result, check.FitsTypeOf, []daemon.QuotaGroupResultJSON{})
-	res := rsp.Result.([]daemon.QuotaGroupResultJSON)
-	c.Check(res, check.DeepEquals, []daemon.QuotaGroupResultJSON{
+	c.Assert(rsp.Result, check.FitsTypeOf, []client.QuotaGroupResult{})
+	res := rsp.Result.([]client.QuotaGroupResult)
+	c.Check(res, check.DeepEquals, []client.QuotaGroupResult{
 		{
 			GroupName:     "bar",
 			Parent:        "foo",
@@ -296,7 +297,7 @@ func (s *apiQuotaSuite) TestListQuotas(c *check.C) {
 		},
 		{
 			GroupName:     "foo",
-			SubGroups:     []string{"bar", "baz"},
+			Subgroups:     []string{"bar", "baz"},
 			MaxMemory:     9000,
 			CurrentMemory: 5000,
 		},
@@ -324,9 +325,9 @@ func (s *apiQuotaSuite) TestGetQuota(c *check.C) {
 	c.Assert(err, check.IsNil)
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
-	c.Assert(rsp.Result, check.FitsTypeOf, daemon.QuotaGroupResultJSON{})
-	res := rsp.Result.(daemon.QuotaGroupResultJSON)
-	c.Check(res, check.DeepEquals, daemon.QuotaGroupResultJSON{
+	c.Assert(rsp.Result, check.FitsTypeOf, client.QuotaGroupResult{})
+	res := rsp.Result.(client.QuotaGroupResult)
+	c.Check(res, check.DeepEquals, client.QuotaGroupResult{
 		GroupName:     "bar",
 		Parent:        "foo",
 		MaxMemory:     1000,

--- a/daemon/export_api_quotas_test.go
+++ b/daemon/export_api_quotas_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 type (
-	PostQuotaGroupData   = postQuotaGroupData
-	QuotaGroupResultJSON = quotaGroupResultJSON
+	PostQuotaGroupData = postQuotaGroupData
 )
 
 func MockServicestateCreateQuota(f func(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) error) func() {

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -148,32 +148,18 @@ execute: |
   echo "Creating a quota group with no actual services in it still has logical memory usage reported for it"
   snap set-quota group-four --memory=100MB
   # putting a snap inside this one, even a snap with no services will trigger us
-  # to write out the slice unit definition and activate it
+  # to write out the slice unit definition and activate it which triggers a bug
+  # in reporting it's memory usage on old systemd versions
   snap set-quota group-five --memory=10MB --parent=group-four hello-world
 
-  sliceName=snap.$(systemd-escape --path group-four/group-five).slice
-
-  # TODO: the v2 path here is probably wrong
-  cgroupsV1OldSystemdMemFile="/sys/fs/cgroup/memory/$sliceName/memory.usage_in_bytes"
-  cgroupsV1MemFile="/sys/fs/cgroup/memory/$sliceName/memory.usage_in_bytes"
-  cgroupsV2MemFile="/sys/fs/cgroup/$sliceName/memory.current"
-  if [ -e "$cgroupsV2MemFile" ]; then
-      cgroupMemFile="$cgroupsV2MemFile"
-  elif [ -e "$cgroupsV1OldSystemdMemFile" ]; then
-      cgroupMemFile="$cgroupsV1OldSystemdMemFile"
-  elif [ -e "$cgroupsV1MemFile" ]; then
-      cgroupMemFile="$cgroupsV1MemFile"
-  else
-      echo "cannot detect cgroup memory file"
-      exit 1
+  snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-five | jq -r '.result."current-memory"')"
+  if [ "$snapdSaysMemUsage" != 0 ]
+    echo "unexpected memory usage for empty quota group group-five, snapd says: $snapdSaysMemUsage"
+    exit 1
   fi
 
-  snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-five | jq -r '.result."current-memory"')"
-  kernelSaysMemUsage="$(cat "$cgroupMemFile/memory.usage_in_bytes")"
-
-  if [ "$snapdSaysMemUsage" = 0 ] && [ "$kernelSaysMemUsage" = 0 ]; then
-    echo "expected output, both are zero"
-  else
-    echo "unexpected memory usage for an empty quota group, kernel says: $kernelSaysMemUsage, snapd says: $snapdSaysMemUsage"
+  snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-four | jq -r '.result."current-memory"')"
+  if [ "$snapdSaysMemUsage" != 0 ]
+    echo "unexpected memory usage for empty quota group group-four, snapd says: $snapdSaysMemUsage"
     exit 1
   fi

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -5,7 +5,7 @@ details: |
   effective in practice.
 
 # Memory accounting is not functional without workarounds on these old systemd
-# systems, so disable the test until we make it functional. The issue is that 
+# systems, so disable the test until we make it functional. The issue is that
 # we now will report memory usage information in the daemon response, but due to
 # bugs in systemd, this fails without workarounds, and so any quota information
 # command will fail trying to get this memory information.
@@ -17,7 +17,7 @@ prepare: |
   if os.query is-trusty; then
     exit 0
   fi
-  snap install go-example-webserver jq remarshal
+  snap install go-example-webserver jq remarshal http hello-world
   snap set system experimental.quota-groups=true
   tests.cleanup defer snap unset system experimental.quota-groups
 
@@ -68,7 +68,36 @@ execute: |
   # the group is double escaped
   systemctl show --property=ControlGroup snap.go-example-webserver.webserver.service | MATCH 'ControlGroup=/snap.group(.*)one.slice/snap.go-example-webserver.webserver.service'
 
-  # TODO: check that systemctl says the memory usage is the same as "snap quota group-one"
+  # snap quota group-one formats the memory usage as a nice human readable 
+  # string, which complicates the comparison here, so instead just grab the 
+  # memory usage in raw bytes from the REST API instead
+  echo "The memory usage reported for the slice from snapd is within 10% of what the kernel reports"
+
+  # TODO: the v2 path here is probably wrong
+  cgroupsV1OldSystemdMemFile="/sys/fs/cgroup/memory/$sliceName/memory.usage_in_bytes"
+  cgroupsV1MemFile="/sys/fs/cgroup/memory/$sliceName/memory.usage_in_bytes"
+  cgroupsV2MemFile="/sys/fs/cgroup/$sliceName/memory.current"
+  if [ -e "$cgroupsV2MemFile" ]; then
+      cgroupMemFile="$cgroupsV2MemFile"
+  elif [ -e "$cgroupsV1OldSystemdMemFile" ]; then
+      cgroupMemFile="$cgroupsV1OldSystemdMemFile"
+  elif [ -e "$cgroupsV1MemFile" ]; then
+      cgroupMemFile="$cgroupsV1MemFile"
+  else
+      echo "cannot detect cgroup memory file"
+      exit 1
+  fi
+
+
+  snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-one | jq -r '.result."current-memory"')"
+  kernelSaysMemUsage="$(cat "$cgroupMemFile")"
+
+  percentChg="$(python3 -c "import math; print(math.ceil(abs($snapdSaysMemUsage - $kernelSaysMemUsage) / $snapdSaysMemUsage * 100))")"
+
+  if [ "$percentChg" -gt 10 ]; then
+    echo "memory usage reported by snapd differs from that of the kernel by more than 10%"
+    exit 1
+  fi
 
   echo "Removing the quota will stop the slice and the service will be restarted"
   snap remove-quota group-one
@@ -115,3 +144,36 @@ execute: |
   snap remove go-example-webserver
   snap quota group-three | yaml2json | jq -r '.snaps' | MATCH null
   snap remove-quota group-three
+
+  echo "Creating a quota group with no actual services in it still has logical memory usage reported for it"
+  snap set-quota group-four --memory=100MB
+  # putting a snap inside this one, even a snap with no services will trigger us
+  # to write out the slice unit definition and activate it
+  snap set-quota group-five --memory=10MB --parent=group-four hello-world
+
+  sliceName=snap.$(systemd-escape --path group-four/group-five).slice
+
+  # TODO: the v2 path here is probably wrong
+  cgroupsV1OldSystemdMemFile="/sys/fs/cgroup/memory/$sliceName/memory.usage_in_bytes"
+  cgroupsV1MemFile="/sys/fs/cgroup/memory/$sliceName/memory.usage_in_bytes"
+  cgroupsV2MemFile="/sys/fs/cgroup/$sliceName/memory.current"
+  if [ -e "$cgroupsV2MemFile" ]; then
+      cgroupMemFile="$cgroupsV2MemFile"
+  elif [ -e "$cgroupsV1OldSystemdMemFile" ]; then
+      cgroupMemFile="$cgroupsV1OldSystemdMemFile"
+  elif [ -e "$cgroupsV1MemFile" ]; then
+      cgroupMemFile="$cgroupsV1MemFile"
+  else
+      echo "cannot detect cgroup memory file"
+      exit 1
+  fi
+
+  snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-five | jq -r '.result."current-memory"')"
+  kernelSaysMemUsage="$(cat "$cgroupMemFile/memory.usage_in_bytes")"
+
+  if [ "$snapdSaysMemUsage" = 0 ] && [ "$kernelSaysMemUsage" = 0 ]; then
+    echo "expected output, both are zero"
+  else
+    echo "unexpected memory usage for an empty quota group, kernel says: $kernelSaysMemUsage, snapd says: $snapdSaysMemUsage"
+    exit 1
+  fi

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -153,13 +153,17 @@ execute: |
   snap set-quota group-five --memory=10MB --parent=group-four hello-world
 
   snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-five | jq -r '.result."current-memory"')"
-  if [ "$snapdSaysMemUsage" != 0 ]; then
+  # both 0 and 4096 values are expected here, 0 is for older systemd/kernels 
+  # where an empty cgroup has exactly 0, but on newer systems there is some 
+  # minimum amount of accounting memory for an empty cgroup, so it shows up as 
+  # 4K
+  if [ "$snapdSaysMemUsage" != 0 ] && [ "$snapdSaysMemUsage" = 4096 ] ; then
     echo "unexpected memory usage for empty quota group group-five, snapd says: $snapdSaysMemUsage"
     exit 1
   fi
 
   snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-four | jq -r '.result."current-memory"')"
-  if [ "$snapdSaysMemUsage" != 0 ]; then
+  if [ "$snapdSaysMemUsage" != 0 ] && [ "$snapdSaysMemUsage" = 4096 ]; then
     echo "unexpected memory usage for empty quota group group-four, snapd says: $snapdSaysMemUsage"
     exit 1
   fi

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -92,7 +92,12 @@ execute: |
   snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-one | jq -r '.result."current-memory"')"
   kernelSaysMemUsage="$(cat "$cgroupMemFile")"
 
-  percentChg="$(python3 -c "import math; print(math.ceil(abs($snapdSaysMemUsage - $kernelSaysMemUsage) / $snapdSaysMemUsage * 100))")"
+  pyCmd="import math; print(math.ceil(abs($snapdSaysMemUsage - $kernelSaysMemUsage) / $snapdSaysMemUsage * 100))"
+  if command -v python3 > /dev/null; then
+    percentChg="$(python3 -c "$pyCmd")"
+  else 
+    percentChg="$(python -c "$pyCmd")"
+  fi
 
   if [ "$percentChg" -gt 10 ]; then
     echo "memory usage reported by snapd differs from that of the kernel by more than 10%"

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -56,7 +56,8 @@ execute: |
       echo "cannot detect cgroup procs file"
       exit 1
   fi
-  wc -l < "$cgroupProcsFile" | MATCH '^1$'
+
+  retry --wait 1 -n 100 sh -c "test $(wc -l < "$cgroupProcsFile") = 1"
   SERVER_PID=$(cat "$cgroupProcsFile")
 
   echo "And that process is the main PID for the example webserver"

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -26,12 +26,12 @@ execute: |
     # just check that we can't do anything with quota groups on trusty, systemd
     # there is 204, but we need at least 205 for slice units
 
-    snap quota foobar --max-memory=1MB 2>&1 | MATCH "systemd version too old: snap quotas requires systemd 205 and newer \(currently have 204\)"
+    snap set-quota foobar --memory=1MB 2>&1 | MATCH "systemd version too old: snap quotas requires systemd 205 and newer \(currently have 204\)"
     exit 0
   fi
 
   echo "Create a group with a snap in it"
-  snap quota group-one --max-memory=100MB go-example-webserver
+  snap set-quota group-one --memory=100MB go-example-webserver
 
   echo "The systemd slice should be active now"
   sliceName="snap.$(systemd-escape --path group-one).slice"
@@ -81,7 +81,7 @@ execute: |
   systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
 
   echo "Creating a quota with a very small memory limit results in the service being unable to start"
-  snap quota too-small --max-memory=1KB go-example-webserver
+  snap set-quota too-small --memory=1KB go-example-webserver
   # clear "oom-killer" message from dmesg or prepare-restore.sh will fail here.
   tests.cleanup defer dmesg -c
 
@@ -109,7 +109,7 @@ execute: |
   retry --wait 1 -n 10 sh -c 'snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"'
 
   echo "Removing a snap ensures that the snap is not in the quota group anymore"
-  snap quota group-three --max-memory=100MB go-example-webserver
+  snap set-quota group-three --memory=100MB go-example-webserver
   snap quota group-three | yaml2json | jq -r '.snaps | .[]' | MATCH go-example-webserver
   snap remove go-example-webserver
   snap quota group-three | yaml2json | jq -r '.snaps' | MATCH null

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -153,13 +153,13 @@ execute: |
   snap set-quota group-five --memory=10MB --parent=group-four hello-world
 
   snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-five | jq -r '.result."current-memory"')"
-  if [ "$snapdSaysMemUsage" != 0 ]
+  if [ "$snapdSaysMemUsage" != 0 ]; then
     echo "unexpected memory usage for empty quota group group-five, snapd says: $snapdSaysMemUsage"
     exit 1
   fi
 
   snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-four | jq -r '.result."current-memory"')"
-  if [ "$snapdSaysMemUsage" != 0 ]
+  if [ "$snapdSaysMemUsage" != 0 ]; then
     echo "unexpected memory usage for empty quota group group-four, snapd says: $snapdSaysMemUsage"
     exit 1
   fi

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -157,13 +157,13 @@ execute: |
   # where an empty cgroup has exactly 0, but on newer systems there is some 
   # minimum amount of accounting memory for an empty cgroup, so it shows up as 
   # 4K
-  if [ "$snapdSaysMemUsage" != 0 ] && [ "$snapdSaysMemUsage" = 4096 ] ; then
+  if [ "$snapdSaysMemUsage" != 0 ] && [ "$snapdSaysMemUsage" != 4096 ] ; then
     echo "unexpected memory usage for empty quota group group-five, snapd says: $snapdSaysMemUsage"
     exit 1
   fi
 
   snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-four | jq -r '.result."current-memory"')"
-  if [ "$snapdSaysMemUsage" != 0 ] && [ "$snapdSaysMemUsage" = 4096 ]; then
+  if [ "$snapdSaysMemUsage" != 0 ] && [ "$snapdSaysMemUsage" != 4096 ] ; then
     echo "unexpected memory usage for empty quota group group-four, snapd says: $snapdSaysMemUsage"
     exit 1
   fi

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -49,7 +49,10 @@ execute: |
   MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
   MATCH "     2\s+group-top1\s+memory=400MB\s+memory=[0-9.a-zA-Z]+$" < quotas.txt
   MATCH "     3\s+group-one\s+group-top1\s+memory=100MB\s+memory=[0-9.a-zA-Z]+$" < quotas.txt
-  MATCH "     4\s+group-sub-one\s+group-one\s+memory=500B\s*$" < quotas.txt
+  # this line could be either for memory=0 in the current column, in which case
+  # it is omitted entirely, or it could be memory=4096 on some systems where 
+  # empty cgroups have 4K memory usage even on empty cgroups
+  MATCH "     4\s+group-sub-one\s+group-one\s+memory=500B(?:\s*|\s*memory=4096B)\s*$" < quotas.txt
   MATCH "     5\s+group-sub-sub-one\s+group-sub-one\s+memory=500B\s*$" < quotas.txt
   MATCH "     6\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt
   MATCH "     7\s+group-top2\s+memory=500MB\s*$" < quotas.txt

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -27,39 +27,42 @@ execute: |
   fi
 
   echo "Creating top-level quota groups (no snaps)"
-  snap quota group-top1 --max-memory=4MB
-  snap quota group-top2 --max-memory=500MB
+  snap set-quota group-top1 --memory=4MB
+  snap set-quota group-top2 --memory=500MB
 
   echo "Creating groups with snaps in them"
-  snap quota group-one --parent=group-top1 --max-memory=1MB hello-world
-  snap quota group-two --parent=group-top1 --max-memory=2MB test-snapd-tools
+  snap set-quota group-one --parent=group-top1 --memory=1MB hello-world
+  snap set-quota group-two --parent=group-top1 --memory=2MB test-snapd-tools
 
   echo "Creating some more nested empty quota groups"
-  snap quota group-sub-one --parent=group-one --max-memory=500B
-  snap quota group-sub-sub-one --parent=group-sub-one --max-memory=500B
+  snap set-quota group-sub-one --parent=group-one --memory=500B
+  snap set-quota group-sub-sub-one --parent=group-sub-one --memory=500B
 
   echo "Trying to add snap to more than one group fails"
-  snap quota group-bad --max-memory=1MB hello-world 2>&1 | MATCH 'error: cannot create or update quota group: cannot add snap "hello-world" to group "group-bad": snap already in quota group "group-one"'
+  snap set-quota group-bad --memory=1MB hello-world 2>&1 | MATCH 'error: cannot create or update quota group: cannot add snap "hello-world" to group "group-bad": snap already in quota group "group-one"'
 
   echo "Checking that all quotas can be listed"
   snap quotas | cat -n > quotas.txt
-  MATCH ".*1.*Quota.*Parent.*Max-Memory$" < quotas.txt
-  MATCH ".*2.*group-top1.*4.00MB$" < quotas.txt
-  MATCH ".*3.*group-one.*group-top1.*1.00MB$" < quotas.txt
-  MATCH ".*4.*group-sub-one.*group-one.*500B$" < quotas.txt
-  MATCH ".*5.*group-sub-sub-one.*group-sub-one.*500B$" < quotas.txt
-  MATCH ".*6.*group-two.*group-top1.*2.00MB$" < quotas.txt
-  MATCH ".*7.*group-top2.*500MB$" < quotas.txt
+  MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
+  MATCH "     2\s+group-top1\s+memory=4.00MB\s+memory=[0-9.a-zA-Z]+$" < quotas.txt
+  MATCH "     3\s+group-one\s+group-top1\s+memory=1.00MB\s*$" < quotas.txt
+  MATCH "     4\s+group-sub-one\s+group-one\s+memory=500B\s*$" < quotas.txt
+  MATCH "     5\s+group-sub-sub-one\s+group-sub-one\s+memory=500B\s*$" < quotas.txt
+  MATCH "     6\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt
+  MATCH "     7\s+group-top2\s+memory=500MB\s*$" < quotas.txt
 
   echo "Checking quota group details"
   snap quota group-one | cat -n > details.txt
-  MATCH ".*1.*name:.*group-one$" < details.txt
-  MATCH ".*2.*parent:.*group-top1$" < details.txt
-  MATCH ".*3.*subgroups:$" < details.txt
-  MATCH ".*4.* - group-sub-one$" < details.txt
-  MATCH ".*5.*max-memory: 1.00MB$" < details.txt
-  MATCH ".*6.*snaps:$" < details.txt
-  MATCH ".*7.*- hello-world$" < details.txt
+  MATCH "     1\s+name:\s+group-one$" < details.txt
+  MATCH "     2\s+parent:\s+group-top1$" < details.txt
+  MATCH "     3\s+constraints:$" < details.txt
+  MATCH "     4\s+memory:\s+1.00MB$" < details.txt
+  MATCH "     5\s+current:$" < details.txt
+  MATCH "     6\s+memory:\s+0B$" < details.txt
+  MATCH "     7\s+subgroups:$" < details.txt
+  MATCH "     8\s+- group-sub-one$" < details.txt
+  MATCH "     9\s+snaps:$" < details.txt
+  MATCH "    10\s+-\s+hello-world$" < details.txt
 
   echo "Checking that quota groups can be removed"
   snap remove-quota group-two

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -52,7 +52,7 @@ execute: |
   # this line could be either for memory=0 in the current column, in which case
   # it is omitted entirely, or it could be memory=4096 on some systems where 
   # empty cgroups have 4K memory usage even on empty cgroups
-  MATCH "     4\s+group-sub-one\s+group-one\s+memory=500B(?:\s*|\s*memory=4096B)\s*$" < quotas.txt
+  MATCH "     4\s+group-sub-one\s+group-one\s+memory=500B(\s*|\s*memory=4096B)\s*$" < quotas.txt
   MATCH "     5\s+group-sub-sub-one\s+group-sub-one\s+memory=500B\s*$" < quotas.txt
   MATCH "     6\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt
   MATCH "     7\s+group-top2\s+memory=500MB\s*$" < quotas.txt

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -27,11 +27,11 @@ execute: |
   fi
 
   echo "Creating top-level quota groups (no snaps)"
-  snap set-quota group-top1 --memory=4MB
+  snap set-quota group-top1 --memory=400MB
   snap set-quota group-top2 --memory=500MB
 
   echo "Creating groups with snaps in them"
-  snap set-quota group-one --parent=group-top1 --memory=1MB hello-world
+  snap set-quota group-one --parent=group-top1 --memory=100MB hello-world
   snap set-quota group-two --parent=group-top1 --memory=2MB test-snapd-tools
 
   echo "Creating some more nested empty quota groups"
@@ -47,7 +47,7 @@ execute: |
   echo "Checking that all quotas can be listed"
   snap quotas | cat -n > quotas.txt
   MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
-  MATCH "     2\s+group-top1\s+memory=4.00MB\s+memory=[0-9.a-zA-Z]+$" < quotas.txt
+  MATCH "     2\s+group-top1\s+memory=400MB\s+memory=[0-9.a-zA-Z]+$" < quotas.txt
   MATCH "     3\s+group-one\s+group-top1\s+memory=1.00MB\s*$" < quotas.txt
   MATCH "     4\s+group-sub-one\s+group-one\s+memory=500B\s*$" < quotas.txt
   MATCH "     5\s+group-sub-sub-one\s+group-sub-one\s+memory=500B\s*$" < quotas.txt
@@ -59,7 +59,7 @@ execute: |
   MATCH "     1\s+name:\s+group-one$" < details.txt
   MATCH "     2\s+parent:\s+group-top1$" < details.txt
   MATCH "     3\s+constraints:$" < details.txt
-  MATCH "     4\s+memory:\s+1.00MB$" < details.txt
+  MATCH "     4\s+memory:\s+100MB$" < details.txt
   MATCH "     5\s+current:$" < details.txt
   MATCH "     6\s+memory:\s+[0-9.a-zA-Z]+B$" < details.txt
   MATCH "     7\s+subgroups:$" < details.txt

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -35,8 +35,8 @@ execute: |
   snap set-quota group-two --parent=group-top1 --memory=2MB test-snapd-tools
 
   echo "Creating some more nested empty quota groups"
-  snap set-quota group-sub-one --parent=group-one --memory=500B
-  snap set-quota group-sub-sub-one --parent=group-sub-one --memory=500B
+  snap set-quota group-sub-one --parent=group-one --memory=10KB
+  snap set-quota group-sub-sub-one --parent=group-sub-one --memory=5KB
 
   echo "Trying to add snap to more than one group fails"
   snap set-quota group-bad --memory=1MB hello-world 2>&1 | MATCH 'error: cannot create or update quota group: cannot add snap "hello-world" to group "group-bad": snap already in quota group "group-one"'
@@ -52,8 +52,8 @@ execute: |
   # this line could be either for memory=0 in the current column, in which case
   # it is omitted entirely, or it could be memory=4096 on some systems where 
   # empty cgroups have 4K memory usage even on empty cgroups
-  MATCH "     4\s+group-sub-one\s+group-one\s+memory=500B(\s*|\s*memory=4096B)\s*$" < quotas.txt
-  MATCH "     5\s+group-sub-sub-one\s+group-sub-one\s+memory=500B\s*$" < quotas.txt
+  MATCH "     4\s+group-sub-one\s+group-one\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
+  MATCH "     5\s+group-sub-sub-one\s+group-sub-one\s+memory=5000B\s*$" < quotas.txt
   MATCH "     6\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt
   MATCH "     7\s+group-top2\s+memory=500MB\s*$" < quotas.txt
 

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -22,7 +22,7 @@ execute: |
     # just check that we can't do anything with quota groups on trusty, systemd
     # there is 204, but we need at least 205 for slice units
 
-    snap quota foobar --max-memory=1MB 2>&1 | MATCH "systemd version too old: snap quotas requires systemd 205 and newer \(currently have 204\)"
+    snap set-quota foobar --memory=1MB 2>&1 | MATCH "systemd version too old: snap quotas requires systemd 205 and newer \(currently have 204\)"
     exit 0
   fi
 

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -15,7 +15,7 @@ systems:
 prepare: |
   snap install hello-world go-example-webserver test-snapd-tools
   snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset experimental.quota-groups
+  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   if os.query is-trusty; then
@@ -48,7 +48,7 @@ execute: |
   snap quotas | cat -n > quotas.txt
   MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
   MATCH "     2\s+group-top1\s+memory=400MB\s+memory=[0-9.a-zA-Z]+$" < quotas.txt
-  MATCH "     3\s+group-one\s+group-top1\s+memory=1.00MB\s*$" < quotas.txt
+  MATCH "     3\s+group-one\s+group-top1\s+memory=100MB\s+memory=[0-9.a-zA-Z]+$" < quotas.txt
   MATCH "     4\s+group-sub-one\s+group-one\s+memory=500B\s*$" < quotas.txt
   MATCH "     5\s+group-sub-sub-one\s+group-sub-one\s+memory=500B\s*$" < quotas.txt
   MATCH "     6\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -13,9 +13,9 @@ systems:
   - -amazon-*
 
 prepare: |
-  snap install hello-world
-  snap install test-snapd-tools
+  snap install hello-world go-example-webserver test-snapd-tools
   snap set system experimental.quota-groups=true
+  tests.cleanup defer snap unset experimental.quota-groups
 
 execute: |
   if os.query is-trusty; then
@@ -41,6 +41,9 @@ execute: |
   echo "Trying to add snap to more than one group fails"
   snap set-quota group-bad --memory=1MB hello-world 2>&1 | MATCH 'error: cannot create or update quota group: cannot add snap "hello-world" to group "group-bad": snap already in quota group "group-one"'
 
+  echo "Adding a snap to group-one"
+  snap set-quota group-one go-example-webserver
+
   echo "Checking that all quotas can be listed"
   snap quotas | cat -n > quotas.txt
   MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
@@ -58,11 +61,12 @@ execute: |
   MATCH "     3\s+constraints:$" < details.txt
   MATCH "     4\s+memory:\s+1.00MB$" < details.txt
   MATCH "     5\s+current:$" < details.txt
-  MATCH "     6\s+memory:\s+0B$" < details.txt
+  MATCH "     6\s+memory:\s+[0-9.a-zA-Z]+B$" < details.txt
   MATCH "     7\s+subgroups:$" < details.txt
   MATCH "     8\s+- group-sub-one$" < details.txt
   MATCH "     9\s+snaps:$" < details.txt
   MATCH "    10\s+-\s+hello-world$" < details.txt
+  MATCH "    11\s+-\s+go-example-webserver$" < details.txt
 
   echo "Checking that quota groups can be removed"
   snap remove-quota group-two


### PR DESCRIPTION
* Make quota command only responsible for showing/displaying quota group
  information.
* Introduce new set-quota command which creates or updates quota groups
* Move the display of memory limit under a map section "constraints" which then
  has a memory key to allow future resource types to live under this section.
* Display current memory usage for quota groups under a new section "current",
  which like "constraints" can be expanded for future resource types too.

Also update the spread test to check that memory usage reported by snapd is 
approximately that of what the kernel reports. 

THE SPREAD TESTS ARE FINALLY HAPPY :tada: :t-rex: :tada: :taco: :shipit: 