### PR TITLE
userd: mock `systemd --version` in privilegedDesktopLauncherSuite

### DIFF
--- a/usersession/userd/privileged_desktop_launcher_test.go
+++ b/usersession/userd/privileged_desktop_launcher_test.go
@@ -28,6 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/usersession/userd"
 )
@@ -74,6 +75,11 @@ func (s *privilegedDesktopLauncherSuite) SetUpTest(c *C) {
 		filepath.Join(dirs.GlobalRootDir, "/usr/share"),
 		filepath.Dir(dirs.SnapDesktopFilesDir),
 	}, ":"))
+
+	restore := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		return []byte("systemd 246\n+PAM and more"), nil
+	})
+	s.AddCleanup(restore)
 }
 
 func (s *privilegedDesktopLauncherSuite) TearDownTest(c *C) {


### PR DESCRIPTION
The unit tests will fail right now on systems that do not have
systemd installed (like the trusty sbuild containers) because
`systemd --version` is called but not mocked.

This commit should fix this. I tested it in spread and manually removing systemd.
