### PR TITLE
systemd: improve systemctl error reporting

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -100,8 +100,8 @@ var systemctlCmd = func(args ...string) ([]byte, error) {
 	// output mode, see LP #1885597
 	bs, err := exec.Command("systemctl", args...).CombinedOutput()
 	if err != nil {
-		exitCode, exitCodeErr := osutil.ExitCode(err)
-		return nil, &Error{cmd: args, exitCode: exitCode, exitCodeErr: exitCodeErr, msg: bs}
+		exitCode, runErr := osutil.ExitCode(err)
+		return nil, &Error{cmd: args, exitCode: exitCode, runErr: runErr, msg: bs}
 	}
 
 	return bs, nil
@@ -823,10 +823,10 @@ type systemctlError interface {
 
 // Error is returned if the systemd action failed
 type Error struct {
-	cmd         []string
-	msg         []byte
-	exitCode    int
-	exitCodeErr error
+	cmd      []string
+	msg      []byte
+	exitCode int
+	runErr   error
 }
 
 func (e *Error) Msg() []byte {
@@ -842,8 +842,8 @@ func (e *Error) Error() string {
 	if len(e.msg) > 0 {
 		msg = fmt.Sprintf(": %s", e.msg)
 	}
-	if e.exitCodeErr != nil {
-		return fmt.Sprintf("systemctl command %v failed with: %v%s", e.cmd, e.exitCodeErr, msg)
+	if e.runErr != nil {
+		return fmt.Sprintf("systemctl command %v failed with: %v%s", e.cmd, e.runErr, msg)
 	}
 	return fmt.Sprintf("systemctl command %v failed with exit status %d%s", e.cmd, e.exitCode, msg)
 }


### PR DESCRIPTION
We recently had a build failure on trusty in a schroot environment.
It turned out that the issue was that no systemctl binary was installed
there. But the error was a bit misleading:
```
[--version] failed with exit status 0:
```

This commit improves the error reporting for non-exit code errors
and errors that do not have an associated exit status.
