### PR TITLE
daemon,o/devicestate: have DeviceManager.SystemMode take an expectation on the system

### DIFF
--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox"
@@ -141,7 +142,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		},
 		"refresh":      refreshInfo,
 		"architecture": arch.DpkgArchitecture(),
-		"system-mode":  deviceMgr.SystemMode(),
+		"system-mode":  deviceMgr.SystemMode(devicestate.SysAny),
 	}
 	if systemdVirt != "" {
 		m["virtualization"] = systemdVirt

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -50,7 +50,7 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	devMgr := deviceMgr(st)
 	return &modelDeviceContext{groundDeviceContext{
 		model:      modelAs,
-		systemMode: devMgr.SystemMode(),
+		systemMode: devMgr.SystemMode(SysAny),
 	}}, nil
 }
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -390,10 +390,12 @@ const (
 )
 
 // SystemMode returns the current mode of the system.
-// An expecation about the system should be passed in, if it's SysAny
-// and the system is pre-UC20 where there is no explicitly mode
-// "run" is returned, if it's SysHasModeenv on such systems it returns
-// simply "".
+// An expectation about the system controls the returned mode when
+// none is set explicitly, as it's the case on pre-UC20 systems. In
+// which case, with SysAny, the mode defaults to implicit "run", thus
+// covering pre-UC20 systems. With SysHasModeeenv, as there is always
+// an explicit mode in systems that use modeenv, no implicit default
+// is used and thus "" is returned for pre-UC20 systems.
 func (m *DeviceManager) SystemMode(sysExpect SysExpectation) string {
 	if m.sysMode == "" {
 		if sysExpect == SysHasModeenv {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -71,7 +71,9 @@ var EarlyConfig func(st *state.State, preloadGadget func() (*gadget.Info, error)
 // DeviceManager is responsible for managing the device identity and device
 // policies.
 type DeviceManager struct {
-	systemMode string
+	// sysMode is the system mode from modeenv or "" on pre-UC20,
+	// use SystemMode instead
+	sysMode string
 	// saveAvailable keeps track whether /var/lib/snapd/save
 	// is available, i.e. exists and is mounted from ubuntu-save
 	// if the latter exists.
@@ -127,7 +129,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 		return nil, err
 	}
 	if modeEnv != nil {
-		m.systemMode = modeEnv.Mode
+		m.sysMode = modeEnv.Mode
 	}
 
 	s.Lock()
@@ -205,16 +207,16 @@ func (m *DeviceManager) ReloadModeenv() error {
 		return err
 	}
 	if modeEnv != nil {
-		m.systemMode = modeEnv.Mode
+		m.sysMode = modeEnv.Mode
 	}
 	return nil
 }
 
 // StartUp implements StateStarterUp.Startup.
 func (m *DeviceManager) StartUp() error {
-	// system mode is explicitly set on UC20
 	// TODO:UC20: ubuntu-save needs to be mounted for recover too
-	if !release.OnClassic && m.systemMode == "run" {
+	if !release.OnClassic && m.SystemMode(SysHasModeenv) == "run" {
+		// UC20 and run mode => setup /var/lib/snapd/save
 		if err := m.maybeSetupUbuntuSave(); err != nil {
 			return fmt.Errorf("cannot set up ubuntu-save: %v", err)
 		}
@@ -378,21 +380,35 @@ func setClassicFallbackModel(st *state.State, device *auth.DeviceState) error {
 	return nil
 }
 
-// SystemMode returns the current mode of the system. Note, that for pre-UC20
-// systems, the mode is not explicitly set and a default "run" mode is always
-// returned.
-func (m *DeviceManager) SystemMode() string {
-	if m.systemMode == "" {
+type SysExpectation int
+
+const (
+	// SysAny indicates any system is appropriate.
+	SysAny SysExpectation = iota
+	// SysHasModeenv indicates only systems with modeenv are appropriate.
+	SysHasModeenv
+)
+
+// SystemMode returns the current mode of the system.
+// An expecation about the system should be passed in, if it's SysAny
+// and the system is pre-UC20 where there is no explicitly mode
+// "run" is returned, if it's SysHasModeenv on such systems it returns
+// simply "".
+func (m *DeviceManager) SystemMode(sysExpect SysExpectation) string {
+	if m.sysMode == "" {
+		if sysExpect == SysHasModeenv {
+			return ""
+		}
 		return "run"
 	}
-	return m.systemMode
+	return m.sysMode
 }
 
 func (m *DeviceManager) ensureOperational() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	if m.SystemMode() != "run" {
+	if m.SystemMode(SysAny) != "run" {
 		// avoid doing registration in ephemeral mode
 		// note: this also stop auto-refreshes indirectly
 		return nil
@@ -682,7 +698,7 @@ func (m *DeviceManager) ensureSeeded() error {
 		}
 		if modeEnv != nil {
 			opts = &populateStateFromSeedOptions{
-				Mode:  m.systemMode,
+				Mode:  modeEnv.Mode,
 				Label: modeEnv.RecoverySystem,
 			}
 		}
@@ -726,7 +742,7 @@ func (m *DeviceManager) ensureBootOk() error {
 	}
 
 	// boot-ok/update-boot-revision is only relevant in run-mode
-	if m.SystemMode() != "run" {
+	if m.SystemMode(SysAny) != "run" {
 		return nil
 	}
 
@@ -924,7 +940,7 @@ func (m *DeviceManager) ensureInstalled() error {
 		return nil
 	}
 
-	if m.SystemMode() != "install" {
+	if m.SystemMode(SysHasModeenv) != "install" {
 		return nil
 	}
 
@@ -1098,9 +1114,8 @@ func (m *DeviceManager) ensureTriedRecoverySystem() error {
 	if release.OnClassic {
 		return nil
 	}
-	// use direct check rather than though a getter, so that we know that
-	// the mode was explicitly set like it is on UC20 devices
-	if m.systemMode != "run" {
+	// nothing to do if not UC20 and run mode
+	if m.SystemMode(SysHasModeenv) != "run" {
 		return nil
 	}
 	if m.ensureTriedRecoverySystemRan {
@@ -1368,7 +1383,7 @@ func (m *DeviceManager) SystemModeInfo() (*SystemModeInfo, error) {
 		return nil, err
 	}
 
-	mode := m.SystemMode()
+	mode := deviceCtx.SystemMode()
 	smi := SystemModeInfo{
 		Mode:       mode,
 		HasModeenv: deviceCtx.HasModeenv(),
@@ -1428,7 +1443,7 @@ var ErrNoSystems = errors.New("no systems seeds")
 // systems, ErrNoSystems when no systems seeds were found or other error.
 func (m *DeviceManager) Systems() ([]*System, error) {
 	// it's tough luck when we cannot determine the current system seed
-	systemMode := m.SystemMode()
+	systemMode := m.SystemMode(SysAny)
 	currentSys, _ := currentSystemForMode(m.state, systemMode)
 
 	systemLabels, err := filepath.Glob(filepath.Join(dirs.SnapSeedDir, "systems", "*"))
@@ -1484,7 +1499,7 @@ func (m *DeviceManager) Reboot(systemLabel, mode string) error {
 
 	// no systemLabel means "current" so get the current system label
 	if systemLabel == "" {
-		systemMode := m.SystemMode()
+		systemMode := m.SystemMode(SysAny)
 		currentSys, err := currentSystemForMode(m.state, systemMode)
 		if err != nil {
 			return fmt.Errorf("cannot get current system: %v", err)
@@ -1528,7 +1543,7 @@ func (m *DeviceManager) switchToSystemAndMode(systemLabel, mode string, sameSyst
 		return err
 	}
 
-	systemMode := m.SystemMode()
+	systemMode := m.SystemMode(SysAny)
 	// ignore the error to be robust in scenarios that
 	// dont' stricly require currentSys to be carried through.
 	// make sure that currentSys == nil does not break

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1172,15 +1172,18 @@ func (s *deviceMgrSuite) TestDeviceManagerReadsModeenv(c *C) {
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
 	c.Assert(err, IsNil)
 	c.Assert(mgr, NotNil)
-	c.Assert(mgr.SystemMode(), Equals, "install")
+	c.Assert(mgr.SystemMode(devicestate.SysAny), Equals, "install")
+	c.Assert(mgr.SystemMode(devicestate.SysHasModeenv), Equals, "install")
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerEmptySystemModeRun(c *C) {
 	// set empty system mode
 	devicestate.SetSystemMode(s.mgr, "")
 
-	// empty is returned as "run"
-	c.Check(s.mgr.SystemMode(), Equals, "run")
+	// empty is returned as "run" for SysAny
+	c.Check(s.mgr.SystemMode(devicestate.SysAny), Equals, "run")
+	// empty is returned as itself for SysHasModeenv
+	c.Check(s.mgr.SystemMode(devicestate.SysHasModeenv), Equals, "")
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoTooEarly(c *C) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -114,7 +114,7 @@ func SetLastBecomeOperationalAttempt(m *DeviceManager, t time.Time) {
 }
 
 func SetSystemMode(m *DeviceManager, mode string) {
-	m.systemMode = mode
+	m.sysMode = mode
 }
 
 func SetTimeOnce(m *DeviceManager, name string, t time.Time) error {

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -137,7 +137,7 @@ func remodelCtx(st *state.State, oldModel, newModel *asserts.Model) (remodelCont
 		// simple context for the simple case
 		groundCtx := groundDeviceContext{
 			model:      newModel,
-			systemMode: devMgr.SystemMode(),
+			systemMode: devMgr.SystemMode(SysAny),
 		}
 		remodCtx = &updateRemodelContext{baseRemodelContext{groundCtx, oldModel}}
 	case StoreSwitchRemodel:
@@ -287,7 +287,7 @@ func newNewStoreRemodelContext(st *state.State, devMgr *DeviceManager, newModel,
 	rc := &newStoreRemodelContext{}
 	groundCtx := groundDeviceContext{
 		model:      newModel,
-		systemMode: devMgr.SystemMode(),
+		systemMode: devMgr.SystemMode(SysAny),
 	}
 	rc.baseRemodelContext = baseRemodelContext{groundCtx, oldModel}
 	rc.st = st


### PR DESCRIPTION
the expectations control whether to report "run" or "" on non-UC20
systems.

this is an idea discussed with @bboozzoo, it avoids having to resort to
use the cached value field directly sometimes which is confusing.
