### PR TITLE
interfaces: opengl: change path for Xilinx zocl driver

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -112,7 +112,7 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 
 # Xilinx zocl DRM driver
 # https://github.com/Xilinx/XRT/tree/master/src/runtime_src/core/edge/drm
-/sys/devices/platform/amba_pl@[0-9]*/amba_pl@[0-9]*:zyxclmm_drm/* r,
+/sys/devices/platform/amba{,_pl@[0-9]*}/amba{,_pl@[0-9]*}:zyxclmm_drm/* r,
 
 # OpenCL ICD files
 /etc/OpenCL/vendors/ r,


### PR DESCRIPTION
In some boards, the path to access Xilinx zocl DRM driver is
/sys/devices/platform/amba/amba:zyxclmm_drm/
, without the _pl* postfix. Change appamor path to make it accessible
from confined apps.

Details of the driver in
https://github.com/Xilinx/XRT/tree/master/src/runtime_src/core/edge/drm.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
