### PR TITLE
snap-bootstrap: implement bind mounts for kernel, base

### DIFF
--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -80,6 +80,10 @@ var (
 	// keys during the initramfs on ubuntu-boot.
 	InitramfsBootEncryptionKeyDir string
 
+	// InitramfsSysrootDir is the location where pivot-root will
+	// be performed to, aka the host system being booted.
+	InitramfsSysrootDir string
+
 	// snapBootFlagsFile is the location of the file that is used
 	// internally for saving the current boot flags active for this boot.
 	snapBootFlagsFile string
@@ -99,6 +103,7 @@ func setInitramfsDirVars(rootdir string) {
 	InitramfsWritableDir = filepath.Join(InitramfsDataDir, "system-data")
 	InitramfsSeedEncryptionKeyDir = filepath.Join(InitramfsUbuntuSeedDir, "device/fde")
 	InitramfsBootEncryptionKeyDir = filepath.Join(InitramfsUbuntuBootDir, "device/fde")
+	InitramfsSysrootDir = filepath.Join(rootdir, "sysroot")
 
 	snapBootFlagsFile = filepath.Join(dirs.SnapRunDir, "boot-flags")
 }

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
@@ -69,6 +70,8 @@ type systemdMountOptions struct {
 	// NoSuid indicates that the partition should be mounted with nosuid set on
 	// it to prevent suid execution.
 	NoSuid bool
+	// Bind indicates a bind mount
+	Bind bool
 }
 
 // doSystemdMount will mount "what" at "where" using systemd-mount(1) with
@@ -125,8 +128,15 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 		args = append(args, "--no-block")
 	}
 
+	var options []string
 	if opts.NoSuid {
-		args = append(args, "--options=nosuid")
+		options = append(options, "nosuid")
+	}
+	if opts.Bind {
+		options = append(options, "bind")
+	}
+	if len(options) > 0 {
+		args = append(args, "--options=" + strings.Join(options, ","))
 	}
 
 	// note that we do not currently parse any output from systemd-mount, but if

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -130,6 +130,37 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			expErr:  "cannot mount \"what\" at \"where\": impossible to fsck a tmpfs",
 			comment: "invalid tmpfs + fsck",
 		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				NoSuid: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy nosuid",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				Bind: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy bind",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				NoSuid: true,
+				Bind: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy nosuid+bind",
+		},
 	}
 
 	for _, t := range tt {
@@ -204,6 +235,14 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			if opts.NoWait {
 				args = append(args, "--no-block")
 			}
+			if opts.Bind && opts.NoSuid {
+				args = append(args, "--options=nosuid,bind")
+			} else if opts.NoSuid {
+				args = append(args, "--options=nosuid")
+			} else if opts.Bind {
+				args = append(args, "--options=bind")
+			}
+
 			c.Assert(cmd.Calls(), DeepEquals, [][]string{args})
 
 			// check that the overrides are present if opts.Ephemeral is false,


### PR DESCRIPTION
Note this is backwards compatible version with the current initrd. And is effectively a no-op, as nothing new happens unless the sysroot*.mount units are dropped from the core-initrd project.

I need this functionality to become dynamic, such that the same core-initrd & snap-bootstrap can be used by either classic encrypted systems, or UC20 encrypted systems.
