### PR TITLE
snap-bootstrap: test the new bind mounts

### DIFF
--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -80,6 +80,10 @@ var (
 	// keys during the initramfs on ubuntu-boot.
 	InitramfsBootEncryptionKeyDir string
 
+	// InitramfsSysrootDir is the location where pivot-root will
+	// be performed to, aka the host system being booted.
+	InitramfsSysrootDir string
+
 	// snapBootFlagsFile is the location of the file that is used
 	// internally for saving the current boot flags active for this boot.
 	snapBootFlagsFile string
@@ -99,6 +103,7 @@ func setInitramfsDirVars(rootdir string) {
 	InitramfsWritableDir = filepath.Join(InitramfsDataDir, "system-data")
 	InitramfsSeedEncryptionKeyDir = filepath.Join(InitramfsUbuntuSeedDir, "device/fde")
 	InitramfsBootEncryptionKeyDir = filepath.Join(InitramfsUbuntuBootDir, "device/fde")
+	InitramfsSysrootDir = filepath.Join(rootdir, "sysroot")
 
 	snapBootFlagsFile = filepath.Join(dirs.SnapRunDir, "boot-flags")
 }

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -82,6 +82,9 @@ var (
 		Tmpfs:  true,
 		NoSuid: true,
 	}
+	needsBindMountOpts = &main.SystemdMountOptions{
+		Bind: true,
+	}
 	needsFsckDiskMountOpts = &main.SystemdMountOptions{
 		NeedsFsck: true,
 	}
@@ -128,18 +131,6 @@ var (
 
 	mockStateContent = `{"data":{"auth":{"users":[{"id":1,"name":"mvo"}],"macaroon-key":"not-a-cookie","last-id":1}},"some":{"other":"stuff"}}`
 )
-
-func makeOldCoreInitrdUnits(c *C) () {
-	// fake old core-initrd bind-mounts
-	systemPath := filepath.Join(dirs.GlobalRootDir, "/usr/lib/systemd/system")
-	os.MkdirAll(systemPath, os.ModePerm)
-	for _, unit := range []string{"sysroot.mount", "sysroot-usr-lib-modules.mount", "sysroot-usr-lib-firmware.mount"} {
-		f, err := os.Create(filepath.Join(systemPath, unit))
-		c.Assert(err, IsNil)
-		f.Close()
-	}
-
-}
 
 func (s *initramfsMountsSuite) setupSeed(c *C, modelAssertTime time.Time, gadgetSnapFiles [][]string) {
 	// pretend /run/mnt/ubuntu-seed has a valid seed
@@ -206,7 +197,6 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 
 	// mock /run/mnt
 	dirs.SetRootDir(s.tmpDir)
-	makeOldCoreInitrdUnits(c)
 	restore = func() { dirs.SetRootDir("") }
 	s.AddCleanup(restore)
 
@@ -463,6 +453,24 @@ func ubuntuPartUUIDMount(partuuid string, mode string) systemdMount {
 	return mnt
 }
 
+func makeBindMount(purpose string) systemdMount {
+	mnt := systemdMount{
+		opts: needsBindMountOpts,
+	}
+	switch purpose {
+	case "base":
+		mnt.what = filepath.Join(boot.InitramfsRunMntDir, "base")
+		mnt.where = boot.InitramfsSysrootDir
+	case "firmware":
+		mnt.what = filepath.Join(boot.InitramfsRunMntDir, "kernel/firmware")
+		mnt.where = filepath.Join(boot.InitramfsSysrootDir, "usr/lib/firmware")
+	case "modules":
+		mnt.what = filepath.Join(boot.InitramfsRunMntDir, "kernel/modules")
+		mnt.where = filepath.Join(boot.InitramfsSysrootDir, "usr/lib/modules")
+	}
+	return mnt
+}
+
 func (s *initramfsMountsSuite) makeSeedSnapSystemdMount(typ snap.Type) systemdMount {
 	mnt := systemdMount{}
 	var name, dir string
@@ -662,6 +670,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeBootFlagsSet(c *C) {
 			ubuntuPartUUIDMount("ubuntu-save-partuuid", "run"),
 			s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 			s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+			makeBindMount("base"),
+			makeBindMount("firmware"),
+			makeBindMount("modules"),
 		}, nil)
 		defer restore()
 
@@ -871,6 +882,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUnencryptedWithSaveHapp
 		ubuntuPartUUIDMount("ubuntu-save-partuuid", "run"),
 		s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 		s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+		makeBindMount("base"),
+		makeBindMount("firmware"),
+		makeBindMount("modules"),
 	}, nil)
 	defer restore()
 
@@ -946,6 +960,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeTimeMovesForwardHappy(c
 				ubuntuPartUUIDMount("ubuntu-data-partuuid", "run"),
 				s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 				s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+				makeBindMount("base"),
+				makeBindMount("firmware"),
+				makeBindMount("modules"),
 			}
 
 			if isFirstBoot {
@@ -1019,6 +1036,9 @@ func (s *initramfsMountsSuite) testInitramfsMountsRunModeNoSaveUnencrypted(c *C)
 		ubuntuPartUUIDMount("ubuntu-data-partuuid", "run"),
 		s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 		s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+		makeBindMount("base"),
+		makeBindMount("firmware"),
+		makeBindMount("modules"),
 	}, nil)
 	defer restore()
 
@@ -1607,6 +1627,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeHappyNoSaveRealSystemdM
 
 	baseMnt := filepath.Join(boot.InitramfsRunMntDir, "base")
 	kernelMnt := filepath.Join(boot.InitramfsRunMntDir, "kernel")
+	sysrootMnt := boot.InitramfsSysrootDir
+	firmwareMnt := filepath.Join(boot.InitramfsSysrootDir, "usr/lib/firmware")
+	modulesMnt := filepath.Join(boot.InitramfsSysrootDir, "usr/lib/modules")
 
 	// don't do anything from systemd-mount, we verify the arguments passed at
 	// the end with cmd.Calls
@@ -1636,6 +1659,15 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeHappyNoSaveRealSystemdM
 			return n%2 == 0, nil
 		case 9, 10:
 			c.Assert(where, Equals, kernelMnt)
+			return n%2 == 0, nil
+		case 11, 12:
+			c.Assert(where, Equals, sysrootMnt)
+			return n%2 == 0, nil
+		case 13, 14:
+			c.Assert(where, Equals, firmwareMnt)
+			return n%2 == 0, nil
+		case 15, 16:
+			c.Assert(where, Equals, modulesMnt)
 			return n%2 == 0, nil
 		default:
 			c.Errorf("unexpected IsMounted check on %s", where)
@@ -1691,8 +1723,8 @@ After=%[1]s
 		}
 	}
 
-	// 2 IsMounted calls per mount point, so 10 total IsMounted calls
-	c.Assert(n, Equals, 10)
+	// 2 IsMounted calls per mount point, so 16 total IsMounted calls
+	c.Assert(n, Equals, 16)
 
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
 		{
@@ -1731,11 +1763,209 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+		}, {
+			"systemd-mount",
+			baseMnt,
+			sysrootMnt,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=no",
+			"--options=bind",
+		}, {
+			"systemd-mount",
+			filepath.Join(kernelMnt, "firmware"),
+			firmwareMnt,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=no",
+			"--options=bind",
+		}, {
+			"systemd-mount",
+			filepath.Join(kernelMnt, "modules"),
+			modulesMnt,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=no",
+			"--options=bind",
 		},
 	})
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeWithSaveHappyRealSystemdMount(c *C) {
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
+
+	restore := disks.MockMountPointDisksToPartitionMapping(
+		map[disks.Mountpoint]*disks.MockDiskMapping{
+			{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultBootWithSaveDisk,
+			{Mountpoint: boot.InitramfsDataDir}:       defaultBootWithSaveDisk,
+			{Mountpoint: boot.InitramfsUbuntuSaveDir}: defaultBootWithSaveDisk,
+		},
+	)
+	defer restore()
+
+	baseMnt := filepath.Join(boot.InitramfsRunMntDir, "base")
+	kernelMnt := filepath.Join(boot.InitramfsRunMntDir, "kernel")
+	sysrootMnt := boot.InitramfsSysrootDir
+	firmwareMnt := filepath.Join(boot.InitramfsSysrootDir, "usr/lib/firmware")
+	modulesMnt := filepath.Join(boot.InitramfsSysrootDir, "usr/lib/modules")
+
+	// don't do anything from systemd-mount, we verify the arguments passed at
+	// the end with cmd.Calls
+	cmd := testutil.MockCommand(c, "systemd-mount", ``)
+	defer cmd.Restore()
+
+	isMountedChecks := []string{}
+	restore = main.MockOsutilIsMounted(func(where string) (bool, error) {
+		isMountedChecks = append(isMountedChecks, where)
+		return true, nil
+	})
+	defer restore()
+
+	// mock a bootloader
+	bloader := boottest.MockUC20RunBootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+
+	// set the current kernel
+	restore = bloader.SetEnabledKernel(s.kernel)
+	defer restore()
+
+	makeSnapFilesOnEarlyBootUbuntuData(c, s.kernel, s.core20)
+
+	// write modeenv
+	modeEnv := boot.Modeenv{
+		Mode:           "run",
+		Base:           s.core20.Filename(),
+		CurrentKernels: []string{s.kernel.Filename()},
+	}
+	err := modeEnv.WriteTo(boot.InitramfsWritableDir)
+	c.Assert(err, IsNil)
+
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout.String(), Equals, "")
+
+	// check that all of the override files are present
+	for _, initrdUnit := range []string{
+		"initrd.target",
+		"initrd-fs.target",
+		"initrd-switch-root.target",
+		"local-fs.target",
+	} {
+
+		mountUnit := systemd.EscapeUnitNamePath(boot.InitramfsUbuntuSaveDir)
+		fname := fmt.Sprintf("snap_bootstrap_%s.conf", mountUnit)
+		unitFile := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d", fname)
+		c.Assert(unitFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
+Requires=%[1]s
+After=%[1]s
+`, mountUnit+".mount"))
+	}
+
+	c.Check(isMountedChecks, DeepEquals, []string{
+		boot.InitramfsUbuntuBootDir,
+		boot.InitramfsUbuntuSeedDir,
+		boot.InitramfsDataDir,
+		boot.InitramfsUbuntuSaveDir,
+		baseMnt,
+		kernelMnt,
+		sysrootMnt,
+		firmwareMnt,
+		modulesMnt,
+	})
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"systemd-mount",
+			"/dev/disk/by-label/ubuntu-boot",
+			boot.InitramfsUbuntuBootDir,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=yes",
+		}, {
+			"systemd-mount",
+			"/dev/disk/by-partuuid/ubuntu-seed-partuuid",
+			boot.InitramfsUbuntuSeedDir,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=yes",
+		}, {
+			"systemd-mount",
+			"/dev/disk/by-partuuid/ubuntu-data-partuuid",
+			boot.InitramfsDataDir,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=yes",
+			"--options=nosuid",
+		}, {
+			"systemd-mount",
+			"/dev/disk/by-partuuid/ubuntu-save-partuuid",
+			boot.InitramfsUbuntuSaveDir,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=yes",
+		}, {
+			"systemd-mount",
+			filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), s.core20.Filename()),
+			baseMnt,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=no",
+		}, {
+			"systemd-mount",
+			filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), s.kernel.Filename()),
+			kernelMnt,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=no",
+		}, {
+			"systemd-mount",
+			baseMnt,
+			sysrootMnt,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=no",
+			"--options=bind",
+		}, {
+			"systemd-mount",
+			filepath.Join(kernelMnt, "firmware"),
+			firmwareMnt,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=no",
+			"--options=bind",
+		}, {
+			"systemd-mount",
+			filepath.Join(kernelMnt, "modules"),
+			modulesMnt,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=no",
+			"--options=bind",
+		},
+	})
+}
+
+func makeLegacyBindMounts(c *C) () {
+	systemPath := filepath.Join(dirs.GlobalRootDir, "/usr/lib/systemd/system")
+	os.MkdirAll(systemPath, os.ModePerm)
+	for _, unit := range []string{"sysroot.mount", "sysroot-usr-lib-modules.mount", "sysroot-usr-lib-firmware.mount"} {
+		f, err := os.Create(filepath.Join(systemPath, unit))
+		c.Assert(err, IsNil)
+		f.Close()
+	}
+
+}
+
+func (s *initramfsMountsSuite) TestInitramfsMountsRunModeWithSaveHappyRealSystemdMountLegacyBindMounts(c *C) {
+	// Create the Legacy Bind mounts, like they were present in
+	// the old core-initrds. This means that we assert that
+	// snap-bootstrap does not create sysroot, firmware, modules
+	// bind mounts with old core-initrds and thus remains
+	// backwards compatible with any core-initrd. Otherwise the
+	// testcase is identical to
+	// TestInitramfsMountsRunModeWithSaveHappyRealSystemdMount
+	makeLegacyBindMounts(c)
+
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	restore := disks.MockMountPointDisksToPartitionMapping(
@@ -1878,6 +2108,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeFirstBootRecoverySystem
 		ubuntuPartUUIDMount("ubuntu-save-partuuid", "run"),
 		s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 		s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+		makeBindMount("base"),
+		makeBindMount("firmware"),
+		makeBindMount("modules"),
 		// RecoverySystem set makes us mount the snapd snap here
 		s.makeSeedSnapSystemdMount(snap.TypeSnapd),
 	}, nil)
@@ -1935,6 +2168,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeWithBootedKernelPartUUI
 		ubuntuPartUUIDMount("ubuntu-data-partuuid", "run"),
 		s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 		s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+		makeBindMount("base"),
+		makeBindMount("firmware"),
+		makeBindMount("modules"),
 	}, nil)
 	defer restore()
 
@@ -1996,6 +2232,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C
 		},
 		s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 		s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+		makeBindMount("base"),
+		makeBindMount("firmware"),
+		makeBindMount("modules"),
 	}, nil)
 	defer restore()
 
@@ -2366,6 +2605,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 				return []systemdMount{
 					s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 					s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+					makeBindMount("base"),
+					makeBindMount("firmware"),
+					makeBindMount("modules"),
 				}
 			},
 			enableKernel: s.kernel,
@@ -2384,6 +2626,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 				return []systemdMount{
 					s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 					s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernelr2),
+					makeBindMount("base"),
+					makeBindMount("firmware"),
+					makeBindMount("modules"),
 				}
 			},
 			kernelStatus:    boot.TryingStatus,
@@ -2404,6 +2649,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 				return []systemdMount{
 					s.makeRunSnapSystemdMount(snap.TypeBase, s.core20r2),
 					s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+					makeBindMount("base"),
+					makeBindMount("firmware"),
+					makeBindMount("modules"),
 				}
 			},
 			enableKernel: s.kernel,
@@ -2429,6 +2677,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 				return []systemdMount{
 					s.makeRunSnapSystemdMount(snap.TypeBase, s.core20r2),
 					s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernelr2),
+					makeBindMount("base"),
+					makeBindMount("firmware"),
+					makeBindMount("modules"),
 				}
 			},
 			enableKernel:    s.kernel,
@@ -2458,6 +2709,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 				return []systemdMount{
 					s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 					s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+					makeBindMount("base"),
+					makeBindMount("firmware"),
+					makeBindMount("modules"),
 				}
 			},
 			enableKernel: s.kernel,
@@ -2476,6 +2730,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 				return []systemdMount{
 					s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 					s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+					makeBindMount("base"),
+					makeBindMount("firmware"),
+					makeBindMount("modules"),
 				}
 			},
 			enableKernel: s.kernel,
@@ -2494,6 +2751,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 				return []systemdMount{
 					s.makeRunSnapSystemdMount(snap.TypeBase, s.core20),
 					s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+					makeBindMount("base"),
+					makeBindMount("firmware"),
+					makeBindMount("modules"),
 				}
 			},
 			enableKernel: s.kernel,
@@ -2577,7 +2837,6 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 		rootDir := c.MkDir()
 		cleanups = append(cleanups, func() { dirs.SetRootDir(dirs.GlobalRootDir) })
 		dirs.SetRootDir(rootDir)
-		makeOldCoreInitrdUnits(c)
 
 		restore := disks.MockMountPointDisksToPartitionMapping(
 			map[disks.Mountpoint]*disks.MockDiskMapping{

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -129,6 +129,18 @@ var (
 	mockStateContent = `{"data":{"auth":{"users":[{"id":1,"name":"mvo"}],"macaroon-key":"not-a-cookie","last-id":1}},"some":{"other":"stuff"}}`
 )
 
+func makeOldCoreInitrdUnits(c *C) () {
+	// fake old core-initrd bind-mounts
+	systemPath := filepath.Join(dirs.GlobalRootDir, "/usr/lib/systemd/system")
+	os.MkdirAll(systemPath, os.ModePerm)
+	for _, unit := range []string{"sysroot.mount", "sysroot-usr-lib-modules.mount", "sysroot-usr-lib-firmware.mount"} {
+		f, err := os.Create(filepath.Join(systemPath, unit))
+		c.Assert(err, IsNil)
+		f.Close()
+	}
+
+}
+
 func (s *initramfsMountsSuite) setupSeed(c *C, modelAssertTime time.Time, gadgetSnapFiles [][]string) {
 	// pretend /run/mnt/ubuntu-seed has a valid seed
 	s.seedDir = boot.InitramfsUbuntuSeedDir
@@ -194,6 +206,7 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 
 	// mock /run/mnt
 	dirs.SetRootDir(s.tmpDir)
+	makeOldCoreInitrdUnits(c)
 	restore = func() { dirs.SetRootDir("") }
 	s.AddCleanup(restore)
 
@@ -2564,6 +2577,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 		rootDir := c.MkDir()
 		cleanups = append(cleanups, func() { dirs.SetRootDir(dirs.GlobalRootDir) })
 		dirs.SetRootDir(rootDir)
+		makeOldCoreInitrdUnits(c)
 
 		restore := disks.MockMountPointDisksToPartitionMapping(
 			map[disks.Mountpoint]*disks.MockDiskMapping{

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
@@ -69,6 +70,8 @@ type systemdMountOptions struct {
 	// NoSuid indicates that the partition should be mounted with nosuid set on
 	// it to prevent suid execution.
 	NoSuid bool
+	// Bind indicates a bind mount
+	Bind bool
 }
 
 // doSystemdMount will mount "what" at "where" using systemd-mount(1) with
@@ -125,8 +128,15 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 		args = append(args, "--no-block")
 	}
 
+	var options []string
 	if opts.NoSuid {
-		args = append(args, "--options=nosuid")
+		options = append(options, "nosuid")
+	}
+	if opts.Bind {
+		options = append(options, "bind")
+	}
+	if len(options) > 0 {
+		args = append(args, "--options=" + strings.Join(options, ","))
 	}
 
 	// note that we do not currently parse any output from systemd-mount, but if

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -130,6 +130,37 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			expErr:  "cannot mount \"what\" at \"where\": impossible to fsck a tmpfs",
 			comment: "invalid tmpfs + fsck",
 		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				NoSuid: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy nosuid",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				Bind: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy bind",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
+				NoSuid: true,
+				Bind: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{true},
+			comment:          "happy nosuid+bind",
+		},
 	}
 
 	for _, t := range tt {
@@ -204,6 +235,14 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			if opts.NoWait {
 				args = append(args, "--no-block")
 			}
+			if opts.Bind && opts.NoSuid {
+				args = append(args, "--options=nosuid,bind")
+			} else if opts.NoSuid {
+				args = append(args, "--options=nosuid")
+			} else if opts.Bind {
+				args = append(args, "--options=bind")
+			}
+
 			c.Assert(cmd.Calls(), DeepEquals, [][]string{args})
 
 			// check that the overrides are present if opts.Ephemeral is false,


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

This incorporates https://github.com/snapcore/snapd/pull/10349 , then incorporates https://github.com/snapcore/snapd/pull/10350

The above pull requests can be merged first, or one can just merge this one. Note that 10350 tests must pass, and this one tests must pass to ensure we maintain compatible with old core-initrds.