### PR TITLE
store: extend context and action objects of SnapAction with validation-sets

### DIFF
--- a/store/store_action.go
+++ b/store/store_action.go
@@ -56,6 +56,7 @@ type CurrentSnap struct {
 	Block            []snap.Revision
 	Epoch            snap.Epoch
 	CohortKey        string
+	ValidationSets   [][]string
 }
 
 type AssertionQuery interface {
@@ -75,6 +76,7 @@ type currentSnapV2JSON struct {
 	RefreshedDate    *time.Time `json:"refreshed-date,omitempty"`
 	IgnoreValidation bool       `json:"ignore-validation,omitempty"`
 	CohortKey        string     `json:"cohort-key,omitempty"`
+	ValidationSets   [][]string `json:"validation-sets,omitempty"`
 }
 
 type SnapActionFlags int
@@ -93,6 +95,8 @@ type SnapAction struct {
 	CohortKey    string
 	Flags        SnapActionFlags
 	Epoch        snap.Epoch
+	// validation-sets primary keys (only for install action)
+	ValidationSets [][]string
 }
 
 func isValidAction(action string) bool {
@@ -123,8 +127,9 @@ type snapActionJSON struct {
 	// nil epoch is not an empty interface{}, you'll get the null in the json.
 	Epoch interface{} `json:"epoch,omitempty"`
 	// For assertions
-	Key        string        `json:"key,omitempty"`
-	Assertions []interface{} `json:"assertions,omitempty"`
+	Key            string        `json:"key,omitempty"`
+	Assertions     []interface{} `json:"assertions,omitempty"`
+	ValidationSets [][]string    `json:"validation-sets,omitempty"`
 }
 
 type assertAtJSON struct {
@@ -328,6 +333,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			RefreshedDate:    refreshedDate,
 			Epoch:            curSnap.Epoch,
 			CohortKey:        curSnap.CohortKey,
+			ValidationSets:   curSnap.ValidationSets,
 		}
 	}
 
@@ -376,6 +382,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			installNum++
 			instanceKey = fmt.Sprintf("install-%d", installNum)
 			installs[instanceKey] = a
+			aJSON.ValidationSets = a.ValidationSets
 		} else if a.Action == "download" {
 			downloadNum++
 			instanceKey = fmt.Sprintf("download-%d", downloadNum)

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -57,7 +57,7 @@ type CurrentSnap struct {
 	Epoch            snap.Epoch
 	CohortKey        string
 	// ValidationSets is an optional array of validation sets primary keys.
-	ValidationSets   [][]string
+	ValidationSets [][]string
 }
 
 type AssertionQuery interface {
@@ -78,7 +78,7 @@ type currentSnapV2JSON struct {
 	IgnoreValidation bool       `json:"ignore-validation,omitempty"`
 	CohortKey        string     `json:"cohort-key,omitempty"`
 	// ValidationSets is an optional array of validation sets primary keys.
-	ValidationSets   [][]string `json:"validation-sets,omitempty"`
+	ValidationSets [][]string `json:"validation-sets,omitempty"`
 }
 
 type SnapActionFlags int

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -56,6 +56,7 @@ type CurrentSnap struct {
 	Block            []snap.Revision
 	Epoch            snap.Epoch
 	CohortKey        string
+	// ValidationSets is an optional array of validation sets primary keys.
 	ValidationSets   [][]string
 }
 
@@ -76,6 +77,7 @@ type currentSnapV2JSON struct {
 	RefreshedDate    *time.Time `json:"refreshed-date,omitempty"`
 	IgnoreValidation bool       `json:"ignore-validation,omitempty"`
 	CohortKey        string     `json:"cohort-key,omitempty"`
+	// ValidationSets is an optional array of validation sets primary keys.
 	ValidationSets   [][]string `json:"validation-sets,omitempty"`
 }
 
@@ -95,7 +97,8 @@ type SnapAction struct {
 	CohortKey    string
 	Flags        SnapActionFlags
 	Epoch        snap.Epoch
-	// validation-sets primary keys (only for install action)
+	// ValidationSets is an optional array of validation sets primary keys
+	// (relevant only for install action).
 	ValidationSets [][]string
 }
 

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -1198,7 +1198,7 @@ func (s *storeActionSuite) TestSnapActionInstallRedirect(c *C) {
 func (s *storeActionSuite) TestSnapActionDownloadRedirect(c *C) {
 	s.testSnapActionGet("download", "", "2.0/candidate", nil, c)
 }
-func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel string, vsets [][]string, c *C) {
+func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel string, validationSets [][]string, c *C) {
 	// action here is one of install or download
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -1240,11 +1240,11 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 		if cohort != "" {
 			expectedAction["cohort-key"] = cohort
 		}
-		if vsets != nil {
+		if validationSets != nil {
 			// XXX: rewrite as otherwise DeepEquals complains about
 			// []interface {}{[]interface {}{..} vs expected [][]string{[]string{..}.
 			var sets []interface{}
-			for _, vs := range vsets {
+			for _, vs := range validationSets {
 				var vss []interface{}
 				for _, vv := range vs {
 					vss = append(vss, vv)
@@ -1295,7 +1295,7 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 				InstanceName:   "hello-world",
 				Channel:        "beta",
 				CohortKey:      cohort,
-				ValidationSets: vsets,
+				ValidationSets: validationSets,
 			},
 		}, nil, nil, nil)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Extend context and action objects of SnapAction with optional validation-sets arrays, they are going to be used with enforcing mode on refresh and install.

From validation-sets spec:

"The existing refresh context is an array of objects with mandatory: snap-id, revision, tracking-channel and instance-key fields. The context and action item fields will be extended to allow for passing the information about relevant validation sets governing the revision decision for the snap (multiple per snap are possible if they all specified the same revision):
- The context objects would gain an optional validation-sets field. This is relevant for snaps being refreshed.
The action object for an install action will accept an optional validation-sets field as well. 
In both cases the same format for the validation-sets field will be used: an array of arrays representing the assertions' primary keys. The top-level array must have at least one element. Eg. [["<series>", "<account-id>", "<name>", "<sequence>"], ...]"