### PR TITLE
overlord/servicestate: mv ensureSnapServicesForGroup to new file

### DIFF
--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -139,7 +139,11 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 	}
 
 	// ensure the snap services with the group
-	if err := ensureSnapServicesForGroup(st, grp, allGrps, nil); err != nil {
+	opts := &ensureSnapServicesForGroupOptions{
+		grp:     grp,
+		allGrps: allGrps,
+	}
+	if err := ensureSnapServicesForGroup(st, opts, nil, nil); err != nil {
 		return err
 	}
 
@@ -216,7 +220,11 @@ func RemoveQuota(st *state.State, name string) error {
 
 	// update snap service units that may need to be re-written because they are
 	// not in a slice anymore
-	if err := ensureSnapServicesForGroup(st, grp, allGrps, nil); err != nil {
+	opts := &ensureSnapServicesForGroupOptions{
+		grp:     grp,
+		allGrps: allGrps,
+	}
+	if err := ensureSnapServicesForGroup(st, opts, nil, nil); err != nil {
 		return err
 	}
 
@@ -286,7 +294,11 @@ func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) erro
 	}
 
 	// ensure service states are updated
-	return ensureSnapServicesForGroup(st, grp, allGrps, nil)
+	opts := &ensureSnapServicesForGroupOptions{
+		grp:     grp,
+		allGrps: allGrps,
+	}
+	return ensureSnapServicesForGroup(st, opts, nil, nil)
 }
 
 // EnsureSnapAbsentFromQuota ensures that the specified snap is not present
@@ -319,10 +331,11 @@ func EnsureSnapAbsentFromQuota(st *state.State, snap string) error {
 				// group and thus won't be considered just by looking at the
 				// group pointer directly
 				opts := &ensureSnapServicesForGroupOptions{
+					grp:        grp,
+					allGrps:    allGrps,
 					extraSnaps: []string{snap},
 				}
-				return ensureSnapServicesForGroup(st, grp, allGrps, opts)
-
+				return ensureSnapServicesForGroup(st, opts, nil, nil)
 			}
 		}
 	}

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -21,24 +21,16 @@ package servicestate
 
 import (
 	"fmt"
-	"sort"
-	"time"
 
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
-	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/progress"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snapdenv"
-	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
-	"github.com/snapcore/snapd/timings"
-	"github.com/snapcore/snapd/wrappers"
 )
 
 var (
@@ -85,199 +77,6 @@ func quotaGroupsAvailable(st *state.State) error {
 	}
 	if !enableQuotaGroups {
 		return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.quota-groups' to true")
-	}
-
-	return nil
-}
-
-func ensureSnapServicesForGroup(st *state.State, grp *quota.Group, allGrps map[string]*quota.Group, extraSnaps []string) error {
-	// build the map of snap infos to options to provide to EnsureSnapServices
-	snapSvcMap := map[*snap.Info]*wrappers.SnapServiceOptions{}
-	for _, sn := range append(grp.Snaps, extraSnaps...) {
-		info, err := snapstate.CurrentInfo(st, sn)
-		if err != nil {
-			return err
-		}
-
-		opts, err := SnapServiceOptions(st, sn, allGrps)
-		if err != nil {
-			return err
-		}
-
-		snapSvcMap[info] = opts
-	}
-
-	// TODO: the following lines should maybe be EnsureOptionsForDevice() or
-	// something since it is duplicated a few places
-	ensureOpts := &wrappers.EnsureSnapServicesOptions{
-		Preseeding: snapdenv.Preseeding(),
-	}
-
-	// set RequireMountedSnapdSnap if we are on UC18+ only
-	deviceCtx, err := snapstate.DeviceCtx(st, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	if !deviceCtx.Classic() && deviceCtx.Model().Base() != "" {
-		ensureOpts.RequireMountedSnapdSnap = true
-	}
-
-	grpsToStart := []*quota.Group{}
-	appsToRestartBySnap := map[*snap.Info][]*snap.AppInfo{}
-
-	collectModifiedUnits := func(app *snap.AppInfo, grp *quota.Group, unitType string, name, old, new string) {
-		switch unitType {
-		case "slice":
-			// this slice was either modified or written for the first time
-
-			// There are currently 3 possible cases that have different
-			// operations required, but we ignore one of them, so there really
-			// are just 2 cases we care about:
-			// 1. If this slice was initially written, we just need to systemctl
-			//    start it
-			// 2. If the slice was modified to be given more resources (i.e. a
-			//    higher memory limit), then we just need to do a daemon-reload
-			//    which causes systemd to modify the cgroup which will always
-			//    work since a cgroup can be atomically given more resources
-			//    without issue since the cgroup can't be using more than the
-			//    current limit.
-			// 3. If the slice was modified to be given _less_ resources (i.e. a
-			//    lower memory limit), then we need to stop the services before
-			//    issuing the daemon-reload to systemd, then do the
-			//    daemon-reload which will succeed in modifying the cgroup, then
-			//    start the services we stopped back up again. This is because
-			//    otherwise if the services are currently running and using more
-			//    resources than they would be allowed after the modification is
-			//    applied by systemd to the cgroup, the kernel responds with
-			//    EBUSY, and it isn't clear if the modification is then properly
-			//    in place or not.
-			//
-			// We will already have called daemon-reload at the end of
-			// EnsureSnapServices directly, so handling case 3 is difficult, and
-			// for now we disallow making this sort of change to a quota group,
-			// that logic is handled at a higher level than this function.
-			// Thus the only decision we really have to make is if the slice was
-			// newly written or not, and if it was save it for later
-			if old == "" {
-				grpsToStart = append(grpsToStart, grp)
-			}
-
-		case "service":
-			// in this case, the only way that a service could have been changed
-			// was if it was moved into or out of a slice, in both cases we need
-			// to restart the service
-			sn := app.Snap
-			appsToRestartBySnap[sn] = append(appsToRestartBySnap[sn], app)
-
-			// TODO: what about sockets and timers? activation units just start
-			// the full unit, so as long as the full unit is restarted we should
-			// be okay?
-		}
-	}
-	if err := wrappers.EnsureSnapServices(snapSvcMap, ensureOpts, collectModifiedUnits, progress.Null); err != nil {
-		return err
-	}
-
-	if ensureOpts.Preseeding {
-		return nil
-	}
-
-	// TODO: should this logic move to wrappers in wrappers.RestartGroups()?
-	systemSysd := systemd.New(systemd.SystemMode, progress.Null)
-
-	// now start the slices
-	for _, grp := range grpsToStart {
-		// TODO: what should these timeouts for stopping/restart slices be?
-		if err := systemSysd.Start(grp.SliceFileName()); err != nil {
-			return err
-		}
-	}
-
-	// after starting all the grps that we modified from EnsureSnapServices,
-	// we need to handle the case where a quota was removed, this will only
-	// happen one at a time and can be identified by the grp provided to us
-	// not existing in the state
-	if _, ok := allGrps[grp.Name]; !ok {
-		// stop the quota group, then remove it
-		if !ensureOpts.Preseeding {
-			if err := systemSysd.Stop(grp.SliceFileName(), 5*time.Second); err != nil {
-				logger.Noticef("unable to stop systemd slice while removing group %q: %v", grp.Name, err)
-			}
-		}
-
-		// TODO: this results in a second systemctl daemon-reload which is
-		// undesirable, we should figure out how to do this operation with a
-		// single daemon-reload
-		if err := wrappers.RemoveQuotaGroup(grp, progress.Null); err != nil {
-			return err
-		}
-	}
-
-	// now restart the services for each snap that was newly moved into a quota
-	// group
-	nullPerfTimings := &timings.Timings{}
-	// iterate in a sorted order over the snaps to restart their apps for easy
-	// tests
-	snaps := make([]*snap.Info, 0, len(appsToRestartBySnap))
-	for sn := range appsToRestartBySnap {
-		snaps = append(snaps, sn)
-	}
-
-	sort.Slice(snaps, func(i, j int) bool {
-		return snaps[i].InstanceName() < snaps[j].InstanceName()
-	})
-
-	for _, sn := range snaps {
-		disabledSvcs, err := wrappers.QueryDisabledServices(sn, progress.Null)
-		if err != nil {
-			return err
-		}
-
-		isDisabledSvc := make(map[string]bool, len(disabledSvcs))
-		for _, svc := range disabledSvcs {
-			isDisabledSvc[svc] = true
-		}
-
-		startupOrdered, err := snap.SortServices(appsToRestartBySnap[sn])
-		if err != nil {
-			return err
-		}
-
-		// drop disabled services from the startup ordering
-		startupOrderedMinusDisabled := make([]*snap.AppInfo, 0, len(startupOrdered)-len(disabledSvcs))
-
-		for _, svc := range startupOrdered {
-			if !isDisabledSvc[svc.ServiceName()] {
-				startupOrderedMinusDisabled = append(startupOrderedMinusDisabled, svc)
-			}
-		}
-
-		st.Unlock()
-		err = wrappers.RestartServices(startupOrderedMinusDisabled, nil, progress.Null, nullPerfTimings)
-		st.Lock()
-
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func validateSnapForAddingToGroup(st *state.State, snaps []string, group string, allGrps map[string]*quota.Group) error {
-	for _, name := range snaps {
-		// validate that the snap exists
-		_, err := snapstate.CurrentInfo(st, name)
-		if err != nil {
-			return fmt.Errorf("cannot use snap %q in group %q: %v", name, group, err)
-		}
-
-		// check that the snap is not already in a group
-		for _, grp := range allGrps {
-			if strutil.ListContains(grp.Snaps, name) {
-				return fmt.Errorf("cannot add snap %q to group %q: snap already in quota group %q", name, group, grp.Name)
-			}
-		}
 	}
 
 	return nil
@@ -519,7 +318,10 @@ func EnsureSnapAbsentFromQuota(st *state.State, snap string) error {
 				// snap as an extra snap to ensure since it was removed from the
 				// group and thus won't be considered just by looking at the
 				// group pointer directly
-				return ensureSnapServicesForGroup(st, grp, allGrps, []string{snap})
+				opts := &ensureSnapServicesForGroupOptions{
+					extraSnaps: []string{snap},
+				}
+				return ensureSnapServicesForGroup(st, grp, allGrps, opts)
 
 			}
 		}

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -140,10 +140,9 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 
 	// ensure the snap services with the group
 	opts := &ensureSnapServicesForGroupOptions{
-		grp:     grp,
 		allGrps: allGrps,
 	}
-	if err := ensureSnapServicesForGroup(st, opts, nil, nil); err != nil {
+	if err := ensureSnapServicesForGroup(st, grp, opts, nil, nil); err != nil {
 		return err
 	}
 
@@ -221,10 +220,9 @@ func RemoveQuota(st *state.State, name string) error {
 	// update snap service units that may need to be re-written because they are
 	// not in a slice anymore
 	opts := &ensureSnapServicesForGroupOptions{
-		grp:     grp,
 		allGrps: allGrps,
 	}
-	if err := ensureSnapServicesForGroup(st, opts, nil, nil); err != nil {
+	if err := ensureSnapServicesForGroup(st, grp, opts, nil, nil); err != nil {
 		return err
 	}
 
@@ -295,10 +293,9 @@ func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) erro
 
 	// ensure service states are updated
 	opts := &ensureSnapServicesForGroupOptions{
-		grp:     grp,
 		allGrps: allGrps,
 	}
-	return ensureSnapServicesForGroup(st, opts, nil, nil)
+	return ensureSnapServicesForGroup(st, grp, opts, nil, nil)
 }
 
 // EnsureSnapAbsentFromQuota ensures that the specified snap is not present
@@ -331,11 +328,10 @@ func EnsureSnapAbsentFromQuota(st *state.State, snap string) error {
 				// group and thus won't be considered just by looking at the
 				// group pointer directly
 				opts := &ensureSnapServicesForGroupOptions{
-					grp:        grp,
 					allGrps:    allGrps,
 					extraSnaps: []string{snap},
 				}
-				return ensureSnapServicesForGroup(st, opts, nil, nil)
+				return ensureSnapServicesForGroup(st, grp, opts, nil, nil)
 			}
 		}
 	}

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -1,0 +1,262 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package servicestate
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/quota"
+	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/timings"
+	"github.com/snapcore/snapd/wrappers"
+)
+
+type ensureSnapServicesForGroupOptions struct {
+	// extraSnaps is the set of extra snaps to consider when ensuring services,
+	// mainly only used when snaps are removed from quota groups
+	extraSnaps []string
+
+	// meter is the progress meter used by the systemd package for reporting
+	// changes and progress
+	meter progress.Meter
+
+	// perfTimings is the timings for this task
+	perfTimings *timings.Timings
+}
+
+func ensureSnapServicesForGroup(st *state.State, grp *quota.Group, allGrps map[string]*quota.Group, opts *ensureSnapServicesForGroupOptions) error {
+	if opts == nil {
+		opts = &ensureSnapServicesForGroupOptions{}
+	}
+
+	if opts.meter == nil {
+		opts.meter = progress.Null
+	}
+
+	if opts.perfTimings == nil {
+		opts.perfTimings = &timings.Timings{}
+	}
+
+	// extraSnaps []string, meter progress.Meter, perfTimings *timings.Timings
+	// build the map of snap infos to options to provide to EnsureSnapServices
+	snapSvcMap := map[*snap.Info]*wrappers.SnapServiceOptions{}
+	for _, sn := range append(grp.Snaps, opts.extraSnaps...) {
+		info, err := snapstate.CurrentInfo(st, sn)
+		if err != nil {
+			return err
+		}
+
+		opts, err := SnapServiceOptions(st, sn, allGrps)
+		if err != nil {
+			return err
+		}
+
+		snapSvcMap[info] = opts
+	}
+
+	// TODO: the following lines should maybe be EnsureOptionsForDevice() or
+	// something since it is duplicated a few places
+	ensureOpts := &wrappers.EnsureSnapServicesOptions{
+		Preseeding: snapdenv.Preseeding(),
+	}
+
+	// set RequireMountedSnapdSnap if we are on UC18+ only
+	deviceCtx, err := snapstate.DeviceCtx(st, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	if !deviceCtx.Classic() && deviceCtx.Model().Base() != "" {
+		ensureOpts.RequireMountedSnapdSnap = true
+	}
+
+	grpsToStart := []*quota.Group{}
+	appsToRestartBySnap := map[*snap.Info][]*snap.AppInfo{}
+
+	collectModifiedUnits := func(app *snap.AppInfo, grp *quota.Group, unitType string, name, old, new string) {
+		switch unitType {
+		case "slice":
+			// this slice was either modified or written for the first time
+
+			// There are currently 3 possible cases that have different
+			// operations required, but we ignore one of them, so there really
+			// are just 2 cases we care about:
+			// 1. If this slice was initially written, we just need to systemctl
+			//    start it
+			// 2. If the slice was modified to be given more resources (i.e. a
+			//    higher memory limit), then we just need to do a daemon-reload
+			//    which causes systemd to modify the cgroup which will always
+			//    work since a cgroup can be atomically given more resources
+			//    without issue since the cgroup can't be using more than the
+			//    current limit.
+			// 3. If the slice was modified to be given _less_ resources (i.e. a
+			//    lower memory limit), then we need to stop the services before
+			//    issuing the daemon-reload to systemd, then do the
+			//    daemon-reload which will succeed in modifying the cgroup, then
+			//    start the services we stopped back up again. This is because
+			//    otherwise if the services are currently running and using more
+			//    resources than they would be allowed after the modification is
+			//    applied by systemd to the cgroup, the kernel responds with
+			//    EBUSY, and it isn't clear if the modification is then properly
+			//    in place or not.
+			//
+			// We will already have called daemon-reload at the end of
+			// EnsureSnapServices directly, so handling case 3 is difficult, and
+			// for now we disallow making this sort of change to a quota group,
+			// that logic is handled at a higher level than this function.
+			// Thus the only decision we really have to make is if the slice was
+			// newly written or not, and if it was save it for later
+			if old == "" {
+				grpsToStart = append(grpsToStart, grp)
+			}
+
+		case "service":
+			// in this case, the only way that a service could have been changed
+			// was if it was moved into or out of a slice, in both cases we need
+			// to restart the service
+			sn := app.Snap
+			appsToRestartBySnap[sn] = append(appsToRestartBySnap[sn], app)
+
+			// TODO: what about sockets and timers? activation units just start
+			// the full unit, so as long as the full unit is restarted we should
+			// be okay?
+		}
+	}
+	if err := wrappers.EnsureSnapServices(snapSvcMap, ensureOpts, collectModifiedUnits, opts.meter); err != nil {
+		return err
+	}
+
+	if ensureOpts.Preseeding {
+		return nil
+	}
+
+	// TODO: should this logic move to wrappers in wrappers.RestartGroups()?
+	systemSysd := systemd.New(systemd.SystemMode, opts.meter)
+
+	// now start the slices
+	for _, grp := range grpsToStart {
+		// TODO: what should these timeouts for stopping/restart slices be?
+		if err := systemSysd.Start(grp.SliceFileName()); err != nil {
+			return err
+		}
+	}
+
+	// after starting all the grps that we modified from EnsureSnapServices,
+	// we need to handle the case where a quota was removed, this will only
+	// happen one at a time and can be identified by the grp provided to us
+	// not existing in the state
+	if _, ok := allGrps[grp.Name]; !ok {
+		// stop the quota group, then remove it
+		if !ensureOpts.Preseeding {
+			if err := systemSysd.Stop(grp.SliceFileName(), 5*time.Second); err != nil {
+				logger.Noticef("unable to stop systemd slice while removing group %q: %v", grp.Name, err)
+			}
+		}
+
+		// TODO: this results in a second systemctl daemon-reload which is
+		// undesirable, we should figure out how to do this operation with a
+		// single daemon-reload
+		st.Unlock()
+		err := wrappers.RemoveQuotaGroup(grp, opts.meter)
+		st.Lock()
+		if err != nil {
+			return err
+		}
+	}
+
+	// now restart the services for each snap that was newly moved into a quota
+	// group
+
+	// iterate in a sorted order over the snaps to restart their apps for easy
+	// tests
+	snaps := make([]*snap.Info, 0, len(appsToRestartBySnap))
+	for sn := range appsToRestartBySnap {
+		snaps = append(snaps, sn)
+	}
+
+	sort.Slice(snaps, func(i, j int) bool {
+		return snaps[i].InstanceName() < snaps[j].InstanceName()
+	})
+
+	for _, sn := range snaps {
+		st.Unlock()
+		disabledSvcs, err := wrappers.QueryDisabledServices(sn, opts.meter)
+		st.Lock()
+		if err != nil {
+			return err
+		}
+
+		isDisabledSvc := make(map[string]bool, len(disabledSvcs))
+		for _, svc := range disabledSvcs {
+			isDisabledSvc[svc] = true
+		}
+
+		startupOrdered, err := snap.SortServices(appsToRestartBySnap[sn])
+		if err != nil {
+			return err
+		}
+
+		// drop disabled services from the startup ordering
+		startupOrderedMinusDisabled := make([]*snap.AppInfo, 0, len(startupOrdered)-len(disabledSvcs))
+
+		for _, svc := range startupOrdered {
+			if !isDisabledSvc[svc.ServiceName()] {
+				startupOrderedMinusDisabled = append(startupOrderedMinusDisabled, svc)
+			}
+		}
+
+		st.Unlock()
+		err = wrappers.RestartServices(startupOrderedMinusDisabled, nil, opts.meter, opts.perfTimings)
+		st.Lock()
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSnapForAddingToGroup(st *state.State, snaps []string, group string, allGrps map[string]*quota.Group) error {
+	for _, name := range snaps {
+		// validate that the snap exists
+		_, err := snapstate.CurrentInfo(st, name)
+		if err != nil {
+			return fmt.Errorf("cannot use snap %q in group %q: %v", name, group, err)
+		}
+
+		// check that the snap is not already in a group
+		for _, grp := range allGrps {
+			if strutil.ListContains(grp.Snaps, name) {
+				return fmt.Errorf("cannot add snap %q to group %q: snap already in quota group %q", name, group, grp.Name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -38,10 +38,6 @@ import (
 )
 
 type ensureSnapServicesForGroupOptions struct {
-	// group is the primary group to consider when re-generating slices and
-	// services
-	grp *quota.Group
-
 	// allGrps is the updated set of quota groups
 	allGrps map[string]*quota.Group
 
@@ -50,12 +46,11 @@ type ensureSnapServicesForGroupOptions struct {
 	extraSnaps []string
 }
 
-func ensureSnapServicesForGroup(st *state.State, opts *ensureSnapServicesForGroupOptions, meter progress.Meter, perfTimings *timings.Timings) error {
+func ensureSnapServicesForGroup(st *state.State, grp *quota.Group, opts *ensureSnapServicesForGroupOptions, meter progress.Meter, perfTimings *timings.Timings) error {
 	if opts == nil {
 		return fmt.Errorf("internal error: unset group information for ensuring")
 	}
 
-	grp := opts.grp
 	allGrps := opts.allGrps
 
 	if meter == nil {


### PR DESCRIPTION
This new file will be the home of the new handlers we execute as tasks for the
change based quota group modifications.

Also slightly refactor to use an options struct instead of defaulting to empty
things. 

The only real code change here is introducing the options struct and initializing
it, the rest of the function's implementation should be the same.

This is mainly to reduce the diff in other PR's since this function's more natural 
home I think is alongside the handlers rather than the top-level functions creating
the tasks for the handlers.

Broken out from #10347 