### PR TITLE
many: fix quota groups for centos 7, amazon linux 2 w/ workaround for buggy systemd

### DIFF
--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -86,6 +86,9 @@ func NewGroup(name string, memLimit quantity.Size) (*Group, error) {
 	return grp, nil
 }
 
+// special value that systemd sometimes returns in buggy situations
+const sixteenExb = quantity.Size(1<<64 - 1)
+
 // CurrentMemoryUsage returns the current memory usage of the quota group. For
 // quota groups which do not yet have a backing systemd slice on the system (
 // i.e. quota groups without any snaps in them), the memory usage is reported as
@@ -103,22 +106,34 @@ func (grp *Group) CurrentMemoryUsage() (quantity.Size, error) {
 		return 0, nil
 	}
 
-	// also check how many tasks are in the group, it could exist and be active,
-	// but not have any active services running in it, and with systemd 219 on
-	// Amazon Linux 2 / Centos 7, there is a bug where the current memory usage
-	// for a unit in such a state is reported as being 16 exbibytes which is too
-	// large to fit into a 32-bit int and is obviously wrong (it should be 0)
+	// we also check how many tasks are in the group as this could indicate a
+	// bug we need to work around on older systems - specifically if there are
+	// no tasks in the cgroup, we could erroneously get the current memory usage
+	// from systemd back as 16 exbibytes (which is actually the max size of a
+	// 64-bit unsigned integer), and in this case we report the usage as 0
+	// instead.
+
+	// note that we specifically _don't_ treat 0 tasks in the group as implying
+	// that the usage is 0, since on some newer systems, a cgroup with 0 tasks
+	// but still active will have 4K memory usage always, so we only correct
+	// the memory usage when it is 16 exb and when there are no tasks in the
+	// group
+
 	numTasks, err := sysd.CurrentTasksCount(grp.SliceFileName())
 	if err != nil {
 		return 0, err
 	}
-	if numTasks == 0 {
-		return 0, nil
+
+	mem, err := sysd.CurrentMemoryUsage(grp.SliceFileName())
+	if err != nil {
+		return 0, err
 	}
 
-	// otherwise we have tasks and it is active and so we should actually query
-	// the memory usage directly
-	return sysd.CurrentMemoryUsage(grp.SliceFileName())
+	if mem == sixteenExb && numTasks == 0 {
+		// this is the bug situation, return the memory as 0
+		mem = 0
+	}
+	return mem, nil
 }
 
 // SliceFileName returns the name of the slice file that should be used for this

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -655,33 +655,73 @@ func (ts *quotaTestSuite) TestCurrentMemoryUsage(c *C) {
 	r := systemd.MockSystemctl(func(args ...string) ([]byte, error) {
 		systemctlCalls++
 		switch systemctlCalls {
+
+		// inactive case, memory is 0
 		case 1:
 			// first time pretend the service is inactive
 			c.Assert(args, DeepEquals, []string{"is-active", "snap.group.slice"})
 			return []byte("inactive"), systemctlInactiveServiceError{}
+
+		// active but no tasks, but we still return the memory usage because it
+		// can be valid on some systems to have non-zero memory usage for a
+		// group without any tasks in it, such as on hirsute, arch, fedora 33+,
+		// and debian sid
 		case 2:
 			// now pretend it is active
 			c.Assert(args, DeepEquals, []string{"is-active", "snap.group.slice"})
 			return []byte("active"), nil
 		case 3:
-			// since it is active, we will query the tasks count - 0 task count
-			// means it cannot have any memory usage
+			// since it is active, we will query the tasks count too
 			c.Assert(args, DeepEquals, []string{"show", "--property", "TasksCurrent", "snap.group.slice"})
 			return []byte("TasksCurrent=0"), nil
 		case 4:
+			// and the memory count can be non-zero like
+			c.Assert(args, DeepEquals, []string{"show", "--property", "MemoryCurrent", "snap.group.slice"})
+			return []byte("MemoryCurrent=4096"), nil
+
+		// normal case, has tasks + memory usage
+		case 5:
 			// now pretend it is active again - third time is the charm
 			c.Assert(args, DeepEquals, []string{"is-active", "snap.group.slice"})
 			return []byte("active"), nil
-		case 5:
-			// since it is active, we will query the tasks count, non zero
-			// number here means that we will finally actually perform the check
-			// for memory usage below
+		case 6:
+			// since it is active, we will query the tasks count too
 			c.Assert(args, DeepEquals, []string{"show", "--property", "TasksCurrent", "snap.group.slice"})
 			return []byte("TasksCurrent=1"), nil
-		case 6:
-			// now since it is active, we will query the current memory usage
+		case 7:
+			// since it is active, we will query the current memory usage
 			c.Assert(args, DeepEquals, []string{"show", "--property", "MemoryCurrent", "snap.group.slice"})
 			return []byte("MemoryCurrent=1024"), nil
+
+		// bug case where 16 exb is erroneous
+		case 8:
+			// the cgroup is active, has no tasks and has 16 exb usage
+			c.Assert(args, DeepEquals, []string{"is-active", "snap.group.slice"})
+			return []byte("active"), nil
+		case 9:
+			// since it is active, we will query the tasks count too
+			c.Assert(args, DeepEquals, []string{"show", "--property", "TasksCurrent", "snap.group.slice"})
+			return []byte("TasksCurrent=0"), nil
+		case 10:
+			// since it is active, we will query the current memory usage,
+			// this time return an obviously wrong number
+			c.Assert(args, DeepEquals, []string{"show", "--property", "MemoryCurrent", "snap.group.slice"})
+			return []byte("MemoryCurrent=18446744073709551615"), nil
+
+		// not bug case where 16 exb is real usage
+		case 11:
+			// not the bug case, the cgroup is active, has tasks and has 16 exb
+			// usage but we treat it as normal and report 16 exb
+			c.Assert(args, DeepEquals, []string{"is-active", "snap.group.slice"})
+			return []byte("active"), nil
+		case 12:
+			// since it is active, we will query the tasks count too
+			c.Assert(args, DeepEquals, []string{"show", "--property", "TasksCurrent", "snap.group.slice"})
+			return []byte("TasksCurrent=1"), nil
+		case 13:
+			// since it is active, we will query the current memory usage
+			c.Assert(args, DeepEquals, []string{"show", "--property", "MemoryCurrent", "snap.group.slice"})
+			return []byte("MemoryCurrent=18446744073709551615"), nil
 		default:
 			c.Errorf("too many systemctl calls (%d) (current call is %+v)", systemctlCalls, args)
 			return []byte("broken test"), fmt.Errorf("broken test")
@@ -697,15 +737,26 @@ func (ts *quotaTestSuite) TestCurrentMemoryUsage(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(currentMem, Equals, quantity.Size(0))
 
-	// group next time is active, but has no tasks, so it has no current memory
-	// usage
+	// now with systemctl mocked as active but no tasks in the group, it still
+	// can have memory usage
+	currentMem, err = grp1.CurrentMemoryUsage()
+	c.Assert(err, IsNil)
+	c.Assert(currentMem, Equals, 4*quantity.SizeKiB)
+
+	// with tasks in the group and a normal memory value, we just report back
+	// the memory value
+	currentMem, err = grp1.CurrentMemoryUsage()
+	c.Assert(err, IsNil)
+	c.Assert(currentMem, Equals, quantity.SizeKiB)
+
+	// with no tasks and the special 16 exb value reported by systemd we get 0
 	currentMem, err = grp1.CurrentMemoryUsage()
 	c.Assert(err, IsNil)
 	c.Assert(currentMem, Equals, quantity.Size(0))
 
-	// now with systemctl mocked as active and some tasks in the group, it has
-	// memory usage
+	// but the special value with tasks in the group reports the huge value
 	currentMem, err = grp1.CurrentMemoryUsage()
 	c.Assert(err, IsNil)
-	c.Assert(currentMem, Equals, quantity.SizeKiB)
+	const sixteenExb = quantity.Size(1<<64 - 1)
+	c.Assert(currentMem, Equals, sixteenExb)
 }

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -99,6 +99,10 @@ func (s *emulation) CurrentMemoryUsage(unit string) (quantity.Size, error) {
 	return 0, errNotImplemented
 }
 
+func (s *emulation) CurrentTasksCount(unit string) (int, error) {
+	return 0, errNotImplemented
+}
+
 func (s *emulation) IsEnabled(service string) (bool, error) {
 	return false, errNotImplemented
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -647,7 +647,7 @@ func (s *systemd) CurrentMemoryUsage(unit string) (quantity.Size, error) {
 		return 0, fmt.Errorf("memory usage unavailable")
 	}
 
-	intVal, err := strconv.Atoi(memStr)
+	intVal, err := strconv.ParseUint(memStr, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid property value from systemd for MemoryCurrent: cannot parse %q as an integer", memStr)
 	}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -266,6 +266,10 @@ type Systemd interface {
 	// CurrentMemoryUsage returns the current memory usage for the specified
 	// unit.
 	CurrentMemoryUsage(unit string) (quantity.Size, error)
+	// CurrentTasksCount returns the number of tasks (processes, threads, kernel
+	// threads if enabled, etc) part of the unit, which can be a service or a
+	// slice.
+	CurrentTasksCount(unit string) (int, error)
 }
 
 // A Log is a single entry in the systemd journal.
@@ -593,31 +597,80 @@ func (s *systemd) getGlobalUserStatus(unitNames ...string) ([]*UnitStatus, error
 	return sts, nil
 }
 
-func (s *systemd) CurrentMemoryUsage(unit string) (quantity.Size, error) {
-	out, err := s.systemctl("show", "--property", "MemoryCurrent", unit)
+func (s *systemd) getPropertyStringValue(unit, key string) (string, error) {
+	// XXX: ignore stderr of systemctl command to avoid further infractions
+	//      around LP #1885597
+	out, err := s.systemctl("show", "--property", key, unit)
 	if err != nil {
-		return 0, osutil.OutputErr(out, err)
+		return "", osutil.OutputErr(out, err)
 	}
-	// strip the MemoryCurrent= from the output
-	splitVal := strings.SplitN(strings.TrimSpace(string(out)), "=", 2)
+	cleanVal := strings.TrimSpace(string(out))
+
+	// strip the TasksCurrent= from the output
+	splitVal := strings.SplitN(cleanVal, "=", 2)
 	if len(splitVal) != 2 {
-		return 0, fmt.Errorf("invalid property format from systemd for MemoryCurrent")
+		return "", fmt.Errorf("invalid property format from systemd for %s (got %s)", key, cleanVal)
 	}
 
-	trimmedVal := strings.TrimSpace(splitVal[1])
+	return strings.TrimSpace(splitVal[1]), nil
+}
+
+func (s *systemd) CurrentTasksCount(unit string) (int, error) {
+	tasksStr, err := s.getPropertyStringValue(unit, "TasksCurrent")
+	if err != nil {
+		return 0, err
+	}
+
+	// if the unit is inactive or doesn't exist, the tasks current can be
+	// reported as "[not set]"
+	if tasksStr == "[not set]" {
+		return 0, fmt.Errorf("tasks count unavailable")
+	}
+
+	intVal, err := strconv.Atoi(tasksStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid property value from systemd for TasksCurrent: cannot parse %q as an integer", tasksStr)
+	}
+
+	return intVal, nil
+}
+
+func (s *systemd) CurrentMemoryUsage(unit string) (quantity.Size, error) {
+	memStr, err := s.getPropertyStringValue(unit, "MemoryCurrent")
+	if err != nil {
+		return 0, err
+	}
 
 	// if the unit is inactive or doesn't exist, the memory usage can be
 	// reported as "[not set]"
-	if trimmedVal == "[not set]" {
+	if memStr == "[not set]" {
 		return 0, fmt.Errorf("memory usage unavailable")
 	}
 
-	intVal, err := strconv.Atoi(trimmedVal)
+	intVal, err := strconv.Atoi(memStr)
 	if err != nil {
-		return 0, fmt.Errorf("invalid property value from systemd for MemoryCurrent: cannot parse %q as an integer", trimmedVal)
+		return 0, fmt.Errorf("invalid property value from systemd for MemoryCurrent: cannot parse %q as an integer", memStr)
 	}
 
 	return quantity.Size(intVal), nil
+}
+
+func (s *systemd) InactiveEnterTimestamp(unit string) (time.Time, error) {
+	timeStr, err := s.getPropertyStringValue(unit, "InactiveEnterTimestamp")
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if timeStr == "" {
+		return time.Time{}, nil
+	}
+
+	// finally parse the time string
+	inactiveEnterTime, err := time.Parse("Mon 2006-01-02 15:04:05 MST", timeStr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("internal error: systemctl time output (%s) is malformed", timeStr)
+	}
+	return inactiveEnterTime, nil
 }
 
 func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
@@ -667,35 +720,6 @@ func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
 	}
 
 	return sts, nil
-}
-
-func (s *systemd) InactiveEnterTimestamp(unit string) (time.Time, error) {
-	// XXX: ignore stderr of systemctl command to avoid further infractions
-	//      around LP #1885597
-	out, err := s.systemctl("show", "--property", "InactiveEnterTimestamp", unit)
-	if err != nil {
-		return time.Time{}, osutil.OutputErr(out, err)
-	}
-	// the time returned by systemctl here will be formatted like so:
-	// InactiveEnterTimestamp=Fri 2021-04-16 15:32:21 UTC
-	// so we have to parse the time with a matching Go time format
-	splitVal := strings.SplitN(strings.TrimSpace(string(out)), "=", 2)
-	if len(splitVal) != 2 {
-		// then we don't have an equals sign in the output, so systemctl must be
-		// broken
-		return time.Time{}, fmt.Errorf("internal error: systemctl output (%s) is malformed", string(out))
-	}
-
-	if splitVal[1] == "" {
-		return time.Time{}, nil
-	}
-
-	// finally parse the time string
-	inactiveEnterTime, err := time.Parse("Mon 2006-01-02 15:04:05 MST", splitVal[1])
-	if err != nil {
-		return time.Time{}, fmt.Errorf("internal error: systemctl time output (%s) is malformed", splitVal[1])
-	}
-	return inactiveEnterTime, nil
 }
 
 func (s *systemd) IsEnabled(serviceName string) (bool, error) {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -730,14 +730,15 @@ func (s *systemd) IsActive(serviceName string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	// "systemctl is-active <name>" returns exit code 3 for inactive
-	// services, the stderr output may be `inactive\n` for services that are
-	// inactive (or not found), or `failed\n` for services that are in a
-	// failed state; nevertheless make sure to check any non-0 exit code
+	// "systemctl is-active <name>" returns exit code 3 for inactive services,
+	// the stderr output may be `unknown\n` for services that were not found,
+	// `inactive\n` for services that are inactive (or not found for some
+	// systemd versions), or `failed\n` for services that are in a failed state;
+	// nevertheless make sure to check any non-0 exit code
 	sysdErr, ok := err.(systemctlError)
 	if ok {
 		switch strings.TrimSpace(string(sysdErr.Msg())) {
-		case "inactive", "failed":
+		case "inactive", "failed", "unknown":
 			return false, nil
 		}
 	}

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -983,6 +983,21 @@ func (s *SystemdTestSuite) TestIsActiveIsInactive(c *C) {
 	c.Check(s.argses, DeepEquals, [][]string{{"is-active", "foo"}})
 }
 
+func (s *SystemdTestSuite) TestIsActiveIsInactiveAlternativeMessage(c *C) {
+	sysErr := &Error{}
+	// on Centos 7, with systemd 219 we see "unknown" returned when querying the
+	// active state for a slice unit which does not exist, check that we handle
+	// this case properly as well
+	sysErr.SetExitCode(3)
+	sysErr.SetMsg([]byte("unknown\n"))
+	s.errors = []error{sysErr}
+
+	active, err := New(SystemMode, s.rep).IsActive("foo")
+	c.Assert(active, Equals, false)
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"is-active", "foo"}})
+}
+
 func (s *SystemdTestSuite) TestIsActiveIsFailed(c *C) {
 	sysErr := &Error{}
 	// seen in the wild to be reported for a 'failed' service

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1412,41 +1412,70 @@ func (s *SystemdTestSuite) TestUmountErr(c *C) {
 	})
 }
 
-func (s *SystemdTestSuite) TestCurrentMemoryUsageInactive(c *C) {
+func (s *SystemdTestSuite) TestCurrentUsageFamilyReallyInvalid(c *C) {
+	s.outs = [][]byte{
+		[]byte(`gahstringsarehard`),
+		[]byte(`gahstringsarehard`),
+	}
+	sysd := New(SystemMode, s.rep)
+	_, err := sysd.CurrentMemoryUsage("bar.service")
+	c.Assert(err, ErrorMatches, `invalid property format from systemd for MemoryCurrent \(got gahstringsarehard\)`)
+	_, err = sysd.CurrentTasksCount("bar.service")
+	c.Assert(err, ErrorMatches, `invalid property format from systemd for TasksCurrent \(got gahstringsarehard\)`)
+	c.Check(s.argses, DeepEquals, [][]string{
+		{"show", "--property", "MemoryCurrent", "bar.service"},
+		{"show", "--property", "TasksCurrent", "bar.service"},
+	})
+}
+
+func (s *SystemdTestSuite) TestCurrentUsageFamilyInactive(c *C) {
 	s.outs = [][]byte{
 		[]byte(`MemoryCurrent=[not set]`),
+		[]byte(`TasksCurrent=[not set]`),
 	}
 	sysd := New(SystemMode, s.rep)
 	_, err := sysd.CurrentMemoryUsage("bar.service")
 	c.Assert(err, ErrorMatches, "memory usage unavailable")
+	_, err = sysd.CurrentTasksCount("bar.service")
+	c.Assert(err, ErrorMatches, "tasks count unavailable")
 	c.Check(s.argses, DeepEquals, [][]string{
 		{"show", "--property", "MemoryCurrent", "bar.service"},
+		{"show", "--property", "TasksCurrent", "bar.service"},
 	})
 }
 
-func (s *SystemdTestSuite) TestCurrentMemoryUsageInvalid(c *C) {
+func (s *SystemdTestSuite) TestCurrentUsageFamilyInvalid(c *C) {
 	s.outs = [][]byte{
-		[]byte(`MemoryCurrent=blahhhhhhhhhhhh`),
+		[]byte(`MemoryCurrent=blahhhhhhhhhhhhhh`),
+		[]byte(`TasksCurrent=blahhhhhhhhhhhhhh`),
 	}
 	sysd := New(SystemMode, s.rep)
 	_, err := sysd.CurrentMemoryUsage("bar.service")
-	c.Assert(err, ErrorMatches, `invalid property value from systemd for MemoryCurrent: cannot parse "blahhhhhhhhhhhh" as an integer`)
+	c.Assert(err, ErrorMatches, `invalid property value from systemd for MemoryCurrent: cannot parse "blahhhhhhhhhhhhhh" as an integer`)
+	_, err = sysd.CurrentTasksCount("bar.service")
+	c.Assert(err, ErrorMatches, `invalid property value from systemd for TasksCurrent: cannot parse "blahhhhhhhhhhhhhh" as an integer`)
 	c.Check(s.argses, DeepEquals, [][]string{
 		{"show", "--property", "MemoryCurrent", "bar.service"},
+		{"show", "--property", "TasksCurrent", "bar.service"},
 	})
 }
 
-func (s *SystemdTestSuite) TestCurrentMemoryUsage(c *C) {
+func (s *SystemdTestSuite) TestCurrentUsageFamilyHappy(c *C) {
 	s.outs = [][]byte{
 		[]byte(`MemoryCurrent=1024`),
+		[]byte(`TasksCurrent=10`),
 	}
 	sysd := New(SystemMode, s.rep)
-	usage, err := sysd.CurrentMemoryUsage("bar.service")
+	memUsage, err := sysd.CurrentMemoryUsage("bar.service")
+	c.Assert(err, IsNil)
+	c.Assert(memUsage, Equals, quantity.SizeKiB)
+	tasksUsage, err := sysd.CurrentTasksCount("bar.service")
+	c.Assert(tasksUsage, Equals, 10)
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{
 		{"show", "--property", "MemoryCurrent", "bar.service"},
+		{"show", "--property", "TasksCurrent", "bar.service"},
 	})
-	c.Check(usage, Equals, quantity.SizeKiB)
 }
 
 func (s *SystemdTestSuite) TestInactiveEnterTimestampZero(c *C) {
@@ -1507,18 +1536,32 @@ func (s *SystemdTestSuite) TestInactiveEnterTimestampMalformed(c *C) {
 		[]byte(``),
 		[]byte(`some random garbage
 with newlines`),
-		[]byte(`InactiveEnterTimestamp=0`), // 0 is valid for InactiveEnterTimestampMonotonic
 	}
 	sysd := New(SystemMode, s.rep)
 	for i := 0; i < len(s.outs); i++ {
 		s.argses = nil
 		stamp, err := sysd.InactiveEnterTimestamp("bar.service")
-		c.Assert(err, ErrorMatches, `(?s)internal error: systemctl (time )?output \(.*\) is malformed`)
+		c.Assert(err.Error(), testutil.Contains, `invalid property format from systemd for InactiveEnterTimestamp (got`)
 		c.Check(s.argses, DeepEquals, [][]string{
 			{"show", "--property", "InactiveEnterTimestamp", "bar.service"},
 		})
 		c.Check(stamp.IsZero(), Equals, true)
 	}
+}
+
+func (s *SystemdTestSuite) TestInactiveEnterTimestampMalformedMore(c *C) {
+	s.outs = [][]byte{
+		[]byte(`InactiveEnterTimestamp=0`), // 0 is valid for InactiveEnterTimestampMonotonic
+	}
+	sysd := New(SystemMode, s.rep)
+
+	stamp, err := sysd.InactiveEnterTimestamp("bar.service")
+
+	c.Assert(err, ErrorMatches, `internal error: systemctl time output \(0\) is malformed`)
+	c.Check(s.argses, DeepEquals, [][]string{
+		{"show", "--property", "InactiveEnterTimestamp", "bar.service"},
+	})
+	c.Check(stamp.IsZero(), Equals, true)
 }
 
 type systemdErrorSuite struct{}

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -4,15 +4,6 @@ details: |
   Functional test for snap quota group commands ensuring that they are 
   effective in practice.
 
-# Memory accounting is not functional without workarounds on these old systemd
-# systems, so disable the test until we make it functional. The issue is that
-# we now will report memory usage information in the daemon response, but due to
-# bugs in systemd, this fails without workarounds, and so any quota information
-# command will fail trying to get this memory information.
-systems:
-  - -centos-7-64
-  - -amazon-*
-
 prepare: |
   if os.query is-trusty; then
     exit 0
@@ -87,7 +78,6 @@ execute: |
       echo "cannot detect cgroup memory file"
       exit 1
   fi
-
 
   snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-one | jq -r '.result."current-memory"')"
   kernelSaysMemUsage="$(cat "$cgroupMemFile")"

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -3,15 +3,6 @@ summary: Basic test for quota-related snap commands.
 details: |
   Basic test for snap quota, remove-quota and quotas commands.
 
-# Memory accounting is not functional without workarounds on these old systemd
-# systems, so disable the test until we make it functional. The issue is that
-# we now will report memory usage information in the daemon response, but due to
-# bugs in systemd, this fails without workarounds, and so any quota information
-# command will fail trying to get this memory information.
-systems:
-  - -centos-7-64
-  - -amazon-*
-
 prepare: |
   snap install hello-world go-example-webserver test-snapd-tools
   snap set system experimental.quota-groups=true

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -90,6 +90,10 @@ MemoryAccounting=true
 MemoryMax=%[2]d
 # for compatibility with older versions of systemd
 MemoryLimit=%[2]d
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 
 	fmt.Fprintf(&buf, template, grp.Name, grp.MemoryLimit)

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -264,6 +264,10 @@ MemoryAccounting=true
 MemoryMax=%[2]s
 # for compatibility with older versions of systemd
 MemoryLimit=%[2]s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 
 	sliceContent := fmt.Sprintf(sliceTempl, grp.Name, memLimit.String())
@@ -369,6 +373,10 @@ MemoryAccounting=true
 MemoryMax=%[2]s
 # for compatibility with older versions of systemd
 MemoryLimit=%[2]s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
 
@@ -460,6 +468,10 @@ MemoryAccounting=true
 MemoryMax=%[2]s
 # for compatibility with older versions of systemd
 MemoryLimit=%[2]s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
 
@@ -618,6 +630,10 @@ MemoryAccounting=true
 MemoryMax=%[2]s
 # for compatibility with older versions of systemd
 MemoryLimit=%[2]s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 
 	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", memLimit.String())
@@ -785,6 +801,10 @@ MemoryAccounting=true
 MemoryMax=%[2]s
 # for compatibility with older versions of systemd
 MemoryLimit=%[2]s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
 `
 
 	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", memLimit.String()))


### PR DESCRIPTION
This PR implements what I think is a reasonable compromise around supporting these older systems by identifying the specific buggy situation and changing the memory usage from 16 exbibytes to 0 in that specific scenario only, using code that should be easy to read and reason about. 

It also re-enables the spread tests which demonstrate that the work-around works, specifically that on these buggy systems:
- [x] memory usage for empty cgroups is 0 on all systems (except those that have 4K usage like hirsute and arch for cgroups with nested groups within them) :sparkles: 
- [x] we can enforce the memory limit for services by observing that a service with a really low memory limit dies and is unable to start up again :sparkles: 
- [x] we can accurately measure the memory usage of a real snap service in a slice, with the reported value not deviating from that of what the kernel reports for the memory cgroup underlying the slice by more than 10% :sparkles: 
- [x] we can use the CLI without errors :sparkles: 