### PR TITLE
wrappers, packaging, snap-mgmt: handle removing slices on purge too

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -55,7 +55,9 @@ purge() {
     mounts=$(echo "$units" | grep "^${SNAP_UNIT_PREFIX}[-.].*\\.mount" | cut -f1 -d ' ')
     # services from snaps
     services=$(echo "$units" | grep '^snap\..*\.service' | cut -f1 -d ' ')
-    for unit in $services $mounts; do
+    # slices from snaps
+    slices=$(echo "$units" | grep '^snap\..*\.slice' | cut -f1 -d ' ')
+    for unit in $services $mounts $slices; do
         # ensure its really a snap mount unit or systemd unit
         if ! grep -q 'What=/var/lib/snapd/snaps/' "/etc/systemd/system/$unit" && ! grep -q 'X-Snappy=yes' "/etc/systemd/system/$unit"; then
             echo "Skipping non-snapd systemd unit $unit"

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -36,8 +36,9 @@ if [ "$1" = "purge" ]; then
     units=$(systemctl list-unit-files --full | grep '^snap[-.]' | cut -f1 -d ' ' | grep -vF snap.mount.service || true)
     mounts=$(echo "$units" | grep '^snap[-.].*\.mount$' || true)
     services=$(echo "$units" | grep '^snap[-.].*\.service$' || true)
+    slices=$(echo "$units" | grep '^snap[-.].*\.slice$' || true)
 
-    for unit in $services $mounts; do
+    for unit in $services $mounts $slices; do
         # ensure its really a snap mount unit or systemd unit
         if ! grep -q 'What=/var/lib/snapd/snaps/' "/etc/systemd/system/$unit" && ! grep -q 'X-Snappy=yes' "/etc/systemd/system/$unit"; then
             echo "Skipping non-snapd systemd unit $unit"

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -4,11 +4,14 @@ systems: [-ubuntu-core-*]
 
 prepare: |
     # TODO: unify this with tests/main/snap-mgmt/task.yaml
+
+    # note: no need to unset these since this spread test purges snapd totally
+    # and snapd won't be around to respond, much less remove any state since
+    # the state should be removed by the test
+    snap set system experimental.user-daemons=true
+    snap set system experimental.quota-groups=true
+
     echo "When some snaps are installed"
-
-
-    snap set core experimental.user-daemons=true
-
     # Install a number of snaps that contain various features that have
     # representation in the file system.
     for name in test-snapd-service test-snapd-timer-service socket-activation \
@@ -30,6 +33,11 @@ prepare: |
     snap install --edge test-snapd-dbus-provider
     snap list | MATCH test-snapd-dbus-provider
 
+    if ! os.query is-trusty; then
+        # create a quota with a service in it
+        snap set-quota group1 test-snapd-service --memory=100MB
+    fi
+
     # expecting to find various files that snap installation produced
     test "$(find /etc/udev/rules.d -name '*-snap.*.rules' | wc -l)" -gt 0
     test "$(find /etc/dbus-1/system.d -name 'snap.*.conf' | wc -l)" -gt 0
@@ -37,7 +45,7 @@ prepare: |
     test "$(find /etc/systemd/system -name 'snap.*.service' | wc -l)" -gt 0
     test "$(find /etc/systemd/system -name 'snap.*.timer' | wc -l)" -gt 0
     test "$(find /etc/systemd/system -name 'snap.*.socket' | wc -l)" -gt 0
-    if echo "$SPREAD_SYSTEM" | grep -vqF ubuntu-14.04; then
+    if ! os.query is-trusty; then
         test "$(find /etc/systemd/user -name 'snap.*.service' | wc -l)" -gt 0
         test "$(find /etc/systemd/user -name 'snap.*.timer' | wc -l)" -gt 0
         test "$(find /etc/systemd/user -name 'snap.*.socket' | wc -l)" -gt 0
@@ -52,10 +60,10 @@ restore: |
     fi
 
 debug: |
-    systemctl --no-legend --full | grep -E 'snap\..*\.(service|timer|socket)'
+    systemctl --no-legend --full | grep -E 'snap\..*\.(service|timer|socket|slice)'
 
 execute: |
-    systemctl --no-legend --full | MATCH 'snap\..*\.(service|timer|socket)'
+    systemctl --no-legend --full | MATCH 'snap\..*\.(service|timer|socket|slice)'
 
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh
@@ -73,7 +81,7 @@ execute: |
         fi
     done
 
-    if not os.query is-trusty; then
+    if ! os.query is-trusty; then
         # ubuntu-14.04: systemctl does not list not-found & failed units properly
 
         # test-snapd-service-refuses-to-stop gets forcefully killed by systemd,
@@ -94,7 +102,7 @@ execute: |
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"
     test -z "$(find /etc/systemd/system/sockets.target.wants/ -name 'snap.*')"
     test -z "$(find /etc/systemd/system/timers.target.wants/ -name 'snap.*')"
-    if echo "$SPREAD_SYSTEM" | grep -vqF ubuntu-14.04; then
+    if ! os.query is-trusty; then
         test -z "$(find /etc/systemd/user/default.target.wants/ -name 'snap.*')"
         test -z "$(find /etc/systemd/user/sockets.target.wants/ -name 'snap.*')"
         test -z "$(find /etc/systemd/user/timers.target.wants/ -name 'snap.*')"
@@ -106,7 +114,7 @@ execute: |
     test "$(find /etc/systemd/system -name 'snap.*.service' -a ! -name "snap.mount.service" | wc -l)" -eq 0
     test "$(find /etc/systemd/system -name 'snap.*.timer' | wc -l)" -eq 0
     test "$(find /etc/systemd/system -name 'snap.*.socket' | wc -l)" -eq 0
-    if echo "$SPREAD_SYSTEM" | grep -vqF ubuntu-14.04; then
+    if ! os.query is-trusty; then
         test "$(find /etc/systemd/user -name 'snap.*.service' | wc -l)" -eq 0
         test "$(find /etc/systemd/user -name 'snap.*.timer' | wc -l)" -eq 0
         test "$(find /etc/systemd/user -name 'snap.*.socket' | wc -l)" -eq 0

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -8,7 +8,12 @@ systems: [-ubuntu-core-*]
 
 prepare: |
     # TODO: unify this with tests/main/postrm-purge/task.yaml
-    snap set core experimental.user-daemons=true
+
+    # note: no need to unset these since this spread test purges snapd totally
+    # and snapd won't be around to respond, much less remove any state since
+    # the state should be removed by the test
+    snap set system experimental.user-daemons=true
+    snap set system experimental.quota-groups=true
 
     # Install a number of snaps that contain various features that have
     # representation in the file system.
@@ -34,6 +39,9 @@ prepare: |
     if echo "$SPREAD_SYSTEM" | grep -vqF ubuntu-14.04; then
         snap install --edge test-snapd-dbus-service
         snap list | MATCH test-snapd-dbus-service
+
+        # create a quota with a service in it
+        snap set-quota group1 test-snapd-service --memory=100MB
     fi
 
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
@@ -59,6 +67,7 @@ prepare: |
         test "$(find /etc/systemd/user -name 'snap.*.socket' | wc -l)" -gt 0
         test "$(find /var/lib/snapd/dbus-1/services -name '*.service' | wc -l)" -gt 0
         test "$(find /var/lib/snapd/dbus-1/system-services -name '*.service' | wc -l)" -gt 0
+        test "$(find /etc/systemd/system -name 'snap.*.slice' | wc -l)" -gt 0
     fi
 
 execute: |
@@ -96,11 +105,14 @@ execute: |
     not test -f /var/lib/snapd/system-key
 
     echo "Preserved namespaces directory is not mounted"
-    not MATCH "/run/snapd/ns" < /proc/mounts
+    NOMATCH "/run/snapd/ns" < /proc/mounts
 
     systemctl daemon-reload
     echo "Snap *.service files are removed"
-    systemctl list-unit-files --type service | not MATCH '^snap.test-snapd-service.*\.service'
+    systemctl list-unit-files --type service | NOMATCH '^snap.test-snapd-service.*\.service'
+
+    echo "Snap quota group slice files are removed"
+    systemctl list-unit-files --type slice | NOMATCH '^snap.group.slice'
 
     echo "No dangling service symlinks are left behind"
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -83,6 +83,7 @@ func generateGroupSliceFile(grp *quota.Group) ([]byte, error) {
 	template := `[Unit]
 Description=Slice for snap quota group %[1]s
 Before=slices.target
+X-Snappy=yes
 
 [Slice]
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -257,6 +257,7 @@ WantedBy=multi-user.target
 	sliceTempl := `[Unit]
 Description=Slice for snap quota group %s
 Before=slices.target
+X-Snappy=yes
 
 [Slice]
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
@@ -362,6 +363,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRewritesQuotaSlices(c *C) {
 	sliceTempl := `[Unit]
 Description=Slice for snap quota group %s
 Before=slices.target
+X-Snappy=yes
 
 [Slice]
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
@@ -453,6 +455,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesDoesNotRewriteQuotaSlicesOnNoo
 	sliceTempl := `[Unit]
 Description=Slice for snap quota group %s
 Before=slices.target
+X-Snappy=yes
 
 [Slice]
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
@@ -541,6 +544,7 @@ func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 	sliceTempl := `[Unit]
 Description=Slice for snap quota group %s
 Before=slices.target
+X-Snappy=yes
 
 [Slice]
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
@@ -611,6 +615,7 @@ apps:
 	sliceTempl := `[Unit]
 Description=Slice for snap quota group %s
 Before=slices.target
+X-Snappy=yes
 
 [Slice]
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
@@ -778,6 +783,7 @@ WantedBy=multi-user.target
 	templ := `[Unit]
 Description=Slice for snap quota group %s
 Before=slices.target
+X-Snappy=yes
 
 [Slice]
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.


### PR DESCRIPTION
Removing slice units when we purge snapd requires us to add `X-Snappy` to the slice units we generate.