### PR TITLE
daemon: drop resp completely in favor of using respJSON consistently

### DIFF
--- a/daemon/api_asserts_test.go
+++ b/daemon/api_asserts_test.go
@@ -378,7 +378,7 @@ func (s *assertsSuite) TestAssertsFindManyJSONInvalidParam(c *check.C) {
 	c.Check(rec.Code, check.Equals, 400, check.Commentf("body %q", rec.Body))
 	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
 
-	var rsp daemon.Resp
+	var rsp daemon.RespJSON
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
@@ -422,7 +422,7 @@ func (s *assertsSuite) TestAssertsFindManyRemoteInvalidParam(c *check.C) {
 	// Verify
 	c.Check(rec.Code, check.Equals, 400, check.Commentf("body %q", rec.Body))
 	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
-	var rsp daemon.Resp
+	var rsp daemon.RespJSON
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -406,8 +406,8 @@ func (s *snapDownloadSuite) TestStreamRangeHeaderErrors(c *check.C) {
 		req.Header.Add("Range", t)
 
 		rsp := s.req(c, req, nil)
-		if dr, ok := rsp.(*daemon.Resp); ok {
-			c.Fatalf("unexpected daemon result (test broken): %v", dr.Result)
+		if dr, ok := rsp.(daemon.StructuredResponse); ok {
+			c.Fatalf("unexpected daemon result (test broken): %v", dr.JSON().Result)
 		}
 		w := httptest.NewRecorder()
 		ss := rsp.(*daemon.SnapStream)

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -64,7 +64,7 @@ func (s *generalSuite) TestRoot(c *check.C) {
 	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
 
 	expected := []interface{}{"TBD"}
-	var rsp daemon.Resp
+	var rsp daemon.RespJSON
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.DeepEquals, expected)
@@ -133,7 +133,7 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 		"virtualization":   "magic",
 		"system-mode":      "run",
 	}
-	var rsp daemon.Resp
+	var rsp daemon.RespJSON
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
@@ -214,7 +214,7 @@ func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
 		"virtualization": "kvm",
 		"system-mode":    "run",
 	}
-	var rsp daemon.Resp
+	var rsp daemon.RespJSON
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
@@ -292,7 +292,7 @@ func (s *generalSuite) testSysInfoSystemMode(c *check.C, mode string) {
 		"architecture": arch.DpkgArchitecture(),
 		"system-mode":  mode,
 	}
-	var rsp daemon.Resp
+	var rsp daemon.RespJSON
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -807,7 +807,7 @@ UnitFileState=enabled
 	c.Check(m.InstallDate, check.FitsTypeOf, time.Time{})
 	m.InstallDate = time.Time{}
 
-	expected := &daemon.Resp{
+	expected := &daemon.RespJSON{
 		Type:   daemon.ResponseTypeSync,
 		Status: 200,
 		Result: &client.Snap{

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018-2020 Canonical Ltd
+ * Copyright (C) 2018-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -194,7 +194,6 @@ func MockSnapstateRemoveMany(mock func(*state.State, []string) ([]string, []*sta
 }
 
 type (
-	Resp            = resp
 	RespJSON        = respJSON
 	FileResponse    = fileResponse
 	APIError        = apiError

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -202,7 +202,7 @@ type (
 )
 
 // XXX this is not used very consistently
-func (rsp *resp) ErrorResult() *errorResult {
+func (rsp *respJSON) ErrorResult() *errorResult {
 	return rsp.Result.(*errorResult)
 }
 

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -67,9 +67,6 @@ type StructuredResponse interface {
 	JSON() *respJSON
 }
 
-// XXX drop resp
-type resp = respJSON
-
 // respJSON represents our standard JSON response format.
 type respJSON struct {
 	Type ResponseType `json:"type"`

--- a/daemon/response_test.go
+++ b/daemon/response_test.go
@@ -45,7 +45,7 @@ var _ = check.Suite(&responseSuite{})
 func (s *responseSuite) TestRespSetsLocationIfAccepted(c *check.C) {
 	rec := httptest.NewRecorder()
 
-	rsp := &daemon.Resp{
+	rsp := &daemon.RespJSON{
 		Status: 202,
 		Result: map[string]interface{}{
 			"resource": "foo/bar",
@@ -60,7 +60,7 @@ func (s *responseSuite) TestRespSetsLocationIfAccepted(c *check.C) {
 func (s *responseSuite) TestRespSetsLocationIfCreated(c *check.C) {
 	rec := httptest.NewRecorder()
 
-	rsp := &daemon.Resp{
+	rsp := &daemon.RespJSON{
 		Status: 201,
 		Result: map[string]interface{}{
 			"resource": "foo/bar",
@@ -75,7 +75,7 @@ func (s *responseSuite) TestRespSetsLocationIfCreated(c *check.C) {
 func (s *responseSuite) TestRespDoesNotSetLocationIfOther(c *check.C) {
 	rec := httptest.NewRecorder()
 
-	rsp := &daemon.Resp{
+	rsp := &daemon.RespJSON{
 		Status: 418, // I'm a teapot
 		Result: map[string]interface{}{
 			"resource": "foo/bar",


### PR DESCRIPTION
The partly generic role of resp was taken over and extended by the StructuredResponse interface instead.