### PR TITLE
overlord/snapstate: lock the mutex before returning from stop snap services undo

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -682,6 +682,19 @@ type fakeSnappyBackend struct {
 	servicesCurrentlyDisabled []string
 
 	lockDir string
+
+	// TODO cleanup triggers above
+	maybeInjectErr func(*fakeOp) error
+}
+
+func (f *fakeSnappyBackend) maybeErrForLastOp() error {
+	if f.maybeInjectErr == nil {
+		return nil
+	}
+	if len(f.ops) == 0 {
+		return nil
+	}
+	return f.maybeInjectErr(&f.ops[len(f.ops)-1])
 }
 
 func (f *fakeSnappyBackend) OpenSnapFile(snapFilePath string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
@@ -879,7 +892,7 @@ func (f *fakeSnappyBackend) CopySnapData(newInfo, oldInfo *snap.Info, p progress
 		path: newInfo.MountDir(),
 		old:  old,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev boot.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootRequired bool, err error) {
@@ -942,7 +955,7 @@ func (f *fakeSnappyBackend) StartServices(svcs []*snap.AppInfo, disabledSvcs []s
 		op.disabledServices = disabledSvcs
 	}
 	f.appendOp(&op)
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) StopServices(svcs []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter, tm timings.Measurer) error {
@@ -950,7 +963,7 @@ func (f *fakeSnappyBackend) StopServices(svcs []*snap.AppInfo, reason snap.Servi
 		op:   fmt.Sprintf("stop-snap-services:%s", reason),
 		path: svcSnapMountDir(svcs),
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) ServicesEnableState(info *snap.Info, meter progress.Meter) (map[string]bool, error) {
@@ -965,7 +978,7 @@ func (f *fakeSnappyBackend) ServicesEnableState(info *snap.Info, meter progress.
 		disabledServices: f.servicesCurrentlyDisabled,
 	})
 
-	return m, nil
+	return m, f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) QueryDisabledServices(info *snap.Info, meter progress.Meter) ([]string, error) {
@@ -997,7 +1010,7 @@ func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, insta
 	if s.InstanceName() == "borken-undo-setup" {
 		return errors.New(`cannot undo setup of "borken-undo-setup" snap`)
 	}
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) UndoCopySnapData(newInfo *snap.Info, oldInfo *snap.Info, p progress.Meter) error {
@@ -1011,7 +1024,7 @@ func (f *fakeSnappyBackend) UndoCopySnapData(newInfo *snap.Info, oldInfo *snap.I
 		path: newInfo.MountDir(),
 		old:  old,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, linkCtx backend.LinkContext, meter progress.Meter) error {
@@ -1022,7 +1035,7 @@ func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, linkCtx backend.LinkCont
 
 		unlinkFirstInstallUndo: linkCtx.FirstInstall,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, meter progress.Meter) error {
@@ -1032,7 +1045,7 @@ func (f *fakeSnappyBackend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, ins
 		path:  s.MountDir(),
 		stype: typ,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RemoveSnapData(info *snap.Info) error {
@@ -1040,7 +1053,7 @@ func (f *fakeSnappyBackend) RemoveSnapData(info *snap.Info) error {
 		op:   "remove-snap-data",
 		path: info.MountDir(),
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RemoveSnapCommonData(info *snap.Info) error {
@@ -1048,7 +1061,7 @@ func (f *fakeSnappyBackend) RemoveSnapCommonData(info *snap.Info) error {
 		op:   "remove-snap-common-data",
 		path: info.MountDir(),
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bool) error {
@@ -1058,7 +1071,7 @@ func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bo
 		path:           snap.BaseDataDir(info.SnapName()),
 		otherInstances: otherInstances,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RemoveSnapDir(s snap.PlaceInfo, otherInstances bool) error {
@@ -1068,7 +1081,7 @@ func (f *fakeSnappyBackend) RemoveSnapDir(s snap.PlaceInfo, otherInstances bool)
 		path:           snap.BaseDir(s.SnapName()),
 		otherInstances: otherInstances,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) DiscardSnapNamespace(snapName string) error {
@@ -1076,7 +1089,7 @@ func (f *fakeSnappyBackend) DiscardSnapNamespace(snapName string) error {
 		op:   "discard-namespace",
 		name: snapName,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RemoveSnapInhibitLock(snapName string) error {
@@ -1084,7 +1097,7 @@ func (f *fakeSnappyBackend) RemoveSnapInhibitLock(snapName string) error {
 		op:   "remove-inhibit-lock",
 		name: snapName,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) Candidate(sideInfo *snap.SideInfo) {
@@ -1139,7 +1152,7 @@ func (f *fakeSnappyBackend) UpdateAliases(add []*backend.Alias, remove []*backen
 		aliases:   add,
 		rmAliases: remove,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RemoveSnapAliases(snapName string) error {
@@ -1147,7 +1160,7 @@ func (f *fakeSnappyBackend) RemoveSnapAliases(snapName string) error {
 		op:   "remove-snap-aliases",
 		name: snapName,
 	})
-	return nil
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RunInhibitSnapForUnlink(info *snap.Info, hint runinhibit.Hint, decision func() error) (lock *osutil.FileLock, err error) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2032,11 +2032,11 @@ func (m *SnapManager) undoStopSnapServices(t *state.Task, _ *tomb.Tomb) error {
 
 	st.Unlock()
 	err = m.backend.StartServices(startupOrdered, disabledServices, progress.Null, perfTimings)
+	st.Lock()
 	if err != nil {
 		return err
 	}
 
-	st.Lock()
 	return nil
 }
 


### PR DESCRIPTION
The mutex needs to be locked after backend.StartServices() returns, but before
returning from the function such that the state of the mutex matches was earlier
defers expect.

Observed in the wild:
```
fatal error: sync: unlock of unlocked mutex
goroutine 84 [running]:
runtime.throw(0x55faf19fed79, 0x1e)
        /usr/lib/go-1.10/src/runtime/panic.go:616 +0x83 fp=0xc42068f9f0 sp=0xc42068f9d0 pc=0x55faf11713a3
sync.throw(0x55faf19fed79, 0x1e)
        /usr/lib/go-1.10/src/runtime/panic.go:605 +0x37 fp=0xc42068fa10 sp=0xc42068f9f0 pc=0x55faf1171317
sync.(*Mutex).Unlock(0xc42039f3b0)
        /usr/lib/go-1.10/src/sync/mutex.go:184 +0xc4 fp=0xc42068fa38 sp=0xc42068fa10 pc=0x55faf11b6264
github.com/snapcore/snapd/overlord/state.(*State).unlock(0xc42039f3b0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/overlord/state/state.go:162 +0x37 fp=0xc42068fa50 sp=0xc42068fa38 pc=0x55faf173e0a7
github.com/snapcore/snapd/overlord/state.(*State).Unlock(0xc42039f3b0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/overlord/state/state.go:239 +0x297 fp=0xc42068fb08 sp=0xc42068fa50 pc=0x55faf173e8a7
runtime.call32(0x0, 0x55faf20ba838, 0xc42007c070, 0x800000008)
        /usr/lib/go-1.10/src/runtime/asm_amd64.s:573 +0x3d fp=0xc42068fb38 sp=0xc42068fb08 pc=0x55faf119e77d
panic(0x55faf1f433a0, 0x55faf20bcf00)
        /usr/lib/go-1.10/src/runtime/panic.go:502 +0x22d fp=0xc42068fbd8 sp=0xc42068fb38 pc=0x55faf1170d6d
github.com/snapcore/snapd/overlord/state.(*State).reading(0xc42039f3b0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/overlord/state/state.go:149 +0x52 fp=0xc42068fbf8 sp=0xc42068fbd8 pc=0x55faf173e002
github.com/snapcore/snapd/overlord/state.(*State).Get(0xc42039f3b0, 0x55faf19dfe8c, 0x7, 0x55faf1f06e40, 0xc4205d6be0, 0x20, 0x55faf1f2af00)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/overlord/state/state.go:332 +0x2d fp=0xc42068fc40 sp=0xc42068fbf8 pc=0x55faf173ed8d
github.com/snapcore/snapd/overlord/state.(*State).GetMaybeTimings(0xc42039f3b0, 0x55faf1f06e40, 0xc4205d6be0, 0x6, 0xc420040a88)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/overlord/state/state.go:518 +0x5a fp=0xc42068fc98 sp=0xc42068fc40 pc=0x55faf174037a
github.com/snapcore/snapd/timings.(*Timings).Save(0xc42066a180, 0x55faf20c7240, 0xc42039f3b0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/timings/state.go:135 +0x76 fp=0xc42068fd50 sp=0xc42068fc98 pc=0x55faf16727f6
github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).undoStopSnapServices(0xc4203cb090, 0xc420410360, 0xc4202e6e60, 0x55faf20c2880, 0xc42007d000)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/overlord/snapstate/handlers.go:2031 +0x464 fp=0xc42068fe30 sp=0xc42068fd50 pc=0x55faf17ee924
github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).(github.com/snapcore/snapd/overlord/snapstate.undoStopSnapServices)-fm(0xc420410360, 0xc4202e6e60, 0x55faf2547380, 0xc42042a6f8)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/overlord/snapstate/snapmgr.go:445 +0x40 fp=0xc42068fe68 sp=0xc42068fe30 pc=0x55faf1820040
github.com/snapcore/snapd/overlord/state.(*TaskRunner).run.func1(0x0, 0x0)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/overlord/state/taskrunner.go:203 +0xbe fp=0xc42068ff98 sp=0xc42068fe68 pc=0x55faf1747a2e
github.com/snapcore/snapd/vendor/gopkg.in/tomb%2ev2.(*Tomb).run(0xc4202e6e60, 0xc4205e1c80)
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x2d fp=0xc42068ffd0 sp=0xc42068ff98 pc=0x55faf142456d
runtime.goexit()
        /usr/lib/go-1.10/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc42068ffd8 sp=0xc42068ffd0 pc=0x55faf11a0f81
created by github.com/snapcore/snapd/vendor/gopkg.in/tomb%2ev2.(*Tomb).Go
        /build/snapd/parts/snapd-deb/build/_build/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0xbb
```

See: https://forum.snapcraft.io/t/cannot-remove-snap-when-it-has-change-in-progress/24808/7
