### PR TITLE
o/hookstate: handle snapctl refresh --proceed and --hold

### DIFF
--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -21,6 +21,7 @@ package ctlcmd
 
 import (
 	"fmt"
+	"time"
 
 	"gopkg.in/yaml.v2"
 
@@ -107,11 +108,11 @@ func (c *refreshCommand) Execute(args []string) error {
 		}
 	}
 
-	if c.Proceed {
-		return fmt.Errorf("not implemented yet")
-	}
-	if c.Hold {
-		return fmt.Errorf("not implemented yet")
+	switch {
+	case c.Proceed:
+		return c.proceed()
+	case c.Hold:
+		return c.hold()
 	}
 
 	return nil
@@ -206,5 +207,51 @@ func (c *refreshCommand) printPendingInfo() error {
 		return err
 	}
 	c.printf("%s", string(out))
+	return nil
+}
+
+func (c *refreshCommand) hold() error {
+	ctx := c.context()
+	ctx.Lock()
+	defer ctx.Unlock()
+	st := ctx.State()
+
+	// cache the action so that hook handler can implement default behavior
+	ctx.Cache("action", hookstate.HoldRefresh)
+
+	var affecting []string
+	if err := ctx.Get("affecting-snaps", &affecting); err != nil {
+		return fmt.Errorf("internal error: cannot get affecting-snaps")
+	}
+
+	// no duration specified, use maximum allowed for this gating snap.
+	var holdDuration time.Duration
+	if err := snapstate.HoldRefresh(st, ctx.InstanceName(), holdDuration, affecting...); err != nil {
+		// XXX: should we do something else here if we cannot hold anymore?
+		return err
+	}
+
+	// TODO: consider inhibit lock - release it, we're holding the refresh so it
+	// won't be attempted after conditional-auto-refresh task.
+
+	return nil
+}
+
+func (c *refreshCommand) proceed() error {
+	ctx := c.context()
+	ctx.Lock()
+	defer ctx.Unlock()
+	st := ctx.State()
+
+	// cache the action so that hook handler can implement default behavior
+	ctx.Cache("action", hookstate.ProceedWithRefresh)
+
+	if err := snapstate.ProceedWithRefresh(st, ctx.InstanceName()); err != nil {
+		return err
+	}
+
+	// TODO: consider inhibit lock - keep the lock, it's going to be released
+	// when the snap gets refreshed.
+
 	return nil
 }

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -217,7 +217,7 @@ func (c *refreshCommand) hold() error {
 	st := ctx.State()
 
 	// cache the action so that hook handler can implement default behavior
-	ctx.Cache("action", hookstate.HoldRefresh)
+	ctx.Cache("action", snapstate.GateAutoRefreshHold)
 
 	var affecting []string
 	if err := ctx.Get("affecting-snaps", &affecting); err != nil {
@@ -227,12 +227,9 @@ func (c *refreshCommand) hold() error {
 	// no duration specified, use maximum allowed for this gating snap.
 	var holdDuration time.Duration
 	if err := snapstate.HoldRefresh(st, ctx.InstanceName(), holdDuration, affecting...); err != nil {
-		// XXX: should we do something else here if we cannot hold anymore?
+		// TODO: let a snap hold again once for 1h.
 		return err
 	}
-
-	// TODO: consider inhibit lock - release it, we're holding the refresh so it
-	// won't be attempted after conditional-auto-refresh task.
 
 	return nil
 }
@@ -244,14 +241,11 @@ func (c *refreshCommand) proceed() error {
 	st := ctx.State()
 
 	// cache the action so that hook handler can implement default behavior
-	ctx.Cache("action", hookstate.ProceedWithRefresh)
+	ctx.Cache("action", snapstate.GateAutoRefreshProceed)
 
 	if err := snapstate.ProceedWithRefresh(st, ctx.InstanceName()); err != nil {
 		return err
 	}
-
-	// TODO: consider inhibit lock - keep the lock, it's going to be released
-	// when the snap gets refreshed.
 
 	return nil
 }

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -158,7 +158,7 @@ version: 1
 	defer mockContext.Unlock()
 	action := mockContext.Cached("action")
 	c.Assert(action, NotNil)
-	c.Check(action, Equals, hookstate.HoldRefresh)
+	c.Check(action, Equals, snapstate.GateAutoRefreshHold)
 
 	var gating map[string]map[string]interface{}
 	c.Assert(s.st.Get("snaps-hold", &gating), IsNil)
@@ -198,7 +198,7 @@ version: 1
 	defer mockContext.Unlock()
 	action := mockContext.Cached("action")
 	c.Assert(action, NotNil)
-	c.Check(action, Equals, hookstate.ProceedWithRefresh)
+	c.Check(action, Equals, snapstate.GateAutoRefreshProceed)
 
 	// and it is not held anymore
 	gating = nil

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -72,13 +72,6 @@ func SetupPreRefreshHook(st *state.State, snapName string) *state.Task {
 	return task
 }
 
-type gateAutoRefreshAction int
-
-const (
-	ProceedWithRefresh gateAutoRefreshAction = iota
-	HoldRefresh
-)
-
 func SetupGateAutoRefreshHook(st *state.State, snapName string, base, restart bool, affectingSnaps map[string]bool) *state.Task {
 	hookSup := &HookSetup{
 		Snap:     snapName,

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -503,7 +503,7 @@ func createGateAutoRefreshHooks(st *state.State, affectedSnaps map[string]*affec
 	sort.Strings(names)
 	for _, snapName := range names {
 		affected := affectedSnaps[snapName]
-		hookTask := SetupGateAutoRefreshHook(st, snapName, affected.Base, affected.Restart)
+		hookTask := SetupGateAutoRefreshHook(st, snapName, affected.Base, affected.Restart, affected.AffectingSnaps)
 		// XXX: it should be fine to run the hooks in parallel
 		if prev != nil {
 			hookTask.WaitFor(prev)

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -36,6 +36,16 @@ import (
 
 var gateAutoRefreshHookName = "gate-auto-refresh"
 
+// gateAutoRefreshAction represents the action executed by
+// snapctl refresh --hold or --proceed and stored in the context of
+// gate-auto-refresh hook.
+type gateAutoRefreshAction int
+
+const (
+	GateAutoRefreshProceed gateAutoRefreshAction = iota
+	GateAutoRefreshHold
+)
+
 // cumulative hold time for snaps other than self
 const maxOtherHoldDuration = time.Hour * 48
 

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -933,8 +933,17 @@ func (s *autorefreshGatingSuite) TestCreateAutoRefreshGateHooks(c *C) {
 		"snap-a": {
 			Base:    true,
 			Restart: true,
+			AffectingSnaps: map[string]bool{
+				"snap-c": true,
+				"snap-d": true,
+			},
 		},
-		"snap-b": {},
+		"snap-b": {
+			AffectingSnaps: map[string]bool{
+				"snap-e": true,
+				"snap-f": true,
+			},
+		},
 	}
 
 	seenSnaps := make(map[string]bool)
@@ -955,10 +964,16 @@ func (s *autorefreshGatingSuite) TestCreateAutoRefreshGateHooks(c *C) {
 
 		// the order of hook tasks is not deterministic
 		if hs.Snap == "snap-a" {
-			c.Check(data, DeepEquals, map[string]interface{}{"base": true, "restart": true})
+			c.Check(data, DeepEquals, map[string]interface{}{
+				"base": true,
+				"restart": true,
+				"affecting-snaps": []interface{}{"snap-c", "snap-d"}})
 		} else {
 			c.Assert(hs.Snap, Equals, "snap-b")
-			c.Check(data, DeepEquals, map[string]interface{}{"base": false, "restart": false})
+			c.Check(data, DeepEquals, map[string]interface{}{
+				"base": false,
+				"restart": false,
+				"affecting-snaps": []interface{}{"snap-e", "snap-f"}})
 		}
 	}
 

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -965,14 +965,14 @@ func (s *autorefreshGatingSuite) TestCreateAutoRefreshGateHooks(c *C) {
 		// the order of hook tasks is not deterministic
 		if hs.Snap == "snap-a" {
 			c.Check(data, DeepEquals, map[string]interface{}{
-				"base": true,
-				"restart": true,
+				"base":            true,
+				"restart":         true,
 				"affecting-snaps": []interface{}{"snap-c", "snap-d"}})
 		} else {
 			c.Assert(hs.Snap, Equals, "snap-b")
 			c.Check(data, DeepEquals, map[string]interface{}{
-				"base": false,
-				"restart": false,
+				"base":            false,
+				"restart":         false,
 				"affecting-snaps": []interface{}{"snap-e", "snap-f"}})
 		}
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -552,7 +552,7 @@ var CheckHealthHook = func(st *state.State, snapName string, rev snap.Revision) 
 	panic("internal error: snapstate.CheckHealthHook is unset")
 }
 
-var SetupGateAutoRefreshHook = func(st *state.State, snapName string, base, restart bool) *state.Task {
+var SetupGateAutoRefreshHook = func(st *state.State, snapName string, base, restart bool, affectingSnaps map[string]bool) *state.Task {
 	panic("internal error: snapstate.SetupAutoRefreshGatingHook is unset")
 }
 


### PR DESCRIPTION
Handle snapctl refresh --proceed and --hold actions. In addition to updating holdState via respective helpers, the action is also cached on the hook context, so that hook handler can know if the hook did anything, and implement a default behavior if needed.
