### PR TITLE
o/snapstate: unlock the state before calling backend in undoStartSnapServices

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1907,7 +1907,9 @@ func (m *SnapManager) undoStartSnapServices(t *state.Task, _ *tomb.Tomb) error {
 	var stopReason snap.ServiceStopReason
 
 	// stop the services
+	st.Unlock()
 	err = m.backend.StopServices(svcs, stopReason, progress.Null, perfTimings)
+	st.Lock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Looking at that code wrt Maciek's fix in https://github.com/snapcore/snapd/pull/10357, I noticed undoStartSnapServices is not unlocking the state before calling the backend to stop services.
