### PR TITLE
o/snapstate: consider held snaps in autoRefreshPhase2

### DIFF
--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -527,15 +528,22 @@ func createGateAutoRefreshHooks(st *state.State, affectedSnaps map[string]*affec
 // snapsToRefresh returns all snaps that should proceed with refresh considering
 // hold behavior.
 var snapsToRefresh = func(gatingTask *state.Task) ([]*refreshCandidate, error) {
-	// TODO: consider holding (responses from gating hooks) here.
-	// Return all refresh candidates for now.
 	var snaps map[string]*refreshCandidate
 	if err := gatingTask.Get("snaps", &snaps); err != nil {
 		return nil, err
 	}
+
+	held, err := heldSnaps(gatingTask.State())
+	if err != nil {
+		return nil, err
+	}
 	var candidates []*refreshCandidate
 	for _, s := range snaps {
-		candidates = append(candidates, s)
+		if !held[s.InstanceName()] {
+			candidates = append(candidates, s)
+		} else {
+			logger.Noticef("skipping refresh of snap %q", s.InstanceName())
+		}
 	}
 	return candidates, nil
 }

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -537,13 +537,21 @@ var snapsToRefresh = func(gatingTask *state.Task) ([]*refreshCandidate, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	var skipped []string
 	var candidates []*refreshCandidate
 	for _, s := range snaps {
 		if !held[s.InstanceName()] {
 			candidates = append(candidates, s)
 		} else {
-			logger.Noticef("skipping refresh of snap %q", s.InstanceName())
+			skipped = append(skipped, s.InstanceName())
 		}
 	}
+
+	if len(skipped) > 0 {
+		sort.Strings(skipped)
+		logger.Noticef("skipping refresh of held snaps: %s", strings.Join(skipped, ","))
+	}
+
 	return candidates, nil
 }

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1431,7 +1431,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2Held(c *C) {
 		c.Assert(snapstate.HoldRefresh(s.state, "snap-b", 0, "base-snap-b"), IsNil)
 	}, expected)
 
-	c.Assert(logbuf.String(), testutil.Contains, `skipping refresh of snap "base-snap-b"`)
+	c.Assert(logbuf.String(), testutil.Contains, `skipping refresh of held snaps: base-snap-b`)
 }
 
 func (s *snapmgrTestSuite) TestAutoRefreshPhase2AllHeld(c *C) {
@@ -1453,8 +1453,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2AllHeld(c *C) {
 		c.Assert(snapstate.HoldRefresh(s.state, "snap-a", 0, "snap-a"), IsNil)
 	}, expected)
 
-	c.Assert(logbuf.String(), testutil.Contains, `skipping refresh of snap "base-snap-b"`)
-	c.Assert(logbuf.String(), testutil.Contains, `skipping refresh of snap "snap-a"`)
+	c.Assert(logbuf.String(), testutil.Contains, `skipping refresh of held snaps: base-snap-b,snap-a`)
 }
 
 func (s *snapmgrTestSuite) testAutoRefreshPhase2DiskSpaceCheck(c *C, fail bool) {


### PR DESCRIPTION
Wire up HeldSnaps helper with snapsToRefresh and only refresh snaps that are not held in autoRefreshPhase2.
