### PR TITLE
cmd/snap-preseed: provide more error info if snap-preseed fails early on mount

### DIFF
--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -130,6 +130,33 @@ func (s *startPreseedSuite) TestChrootValidationUnhappy(c *C) {
 	c.Check(main.Run(parser, []string{tmpDir}), ErrorMatches, "cannot preseed without the following mountpoints:\n - .*/dev\n - .*/proc\n - .*/sys/kernel/security")
 }
 
+func (s *startPreseedSuite) TestRunPreseedMountUnhappy(c *C) {
+	tmpDir := c.MkDir()
+	dirs.SetRootDir(tmpDir)
+	defer mockChrootDirs(c, tmpDir, true)()
+
+	restoreOsGuid := main.MockOsGetuid(func() int { return 0 })
+	defer restoreOsGuid()
+
+	restoreSyscallChroot := main.MockSyscallChroot(func(path string) error { return nil })
+	defer restoreSyscallChroot()
+
+	mockMountCmd := testutil.MockCommand(c, "mount", `echo "something went wrong"
+exit 32
+`)
+	defer mockMountCmd.Restore()
+
+	targetSnapdRoot := filepath.Join(tmpDir, "target-core-mounted-here")
+	restoreMountPath := main.MockSnapdMountPath(targetSnapdRoot)
+	defer restoreMountPath()
+
+	restoreSystemSnapFromSeed := main.MockSystemSnapFromSeed(func(string) (string, error) { return "/a/core.snap", nil })
+	defer restoreSystemSnapFromSeed()
+
+	parser := testParser(c)
+	c.Check(main.Run(parser, []string{tmpDir}), ErrorMatches, `cannot mount .+ at .+ in preseed mode: exit status 32\n'mount -t squashfs -o ro,x-gdu.hide,x-gvfs-hide /a/core.snap .*/target-core-mounted-here' failed with: something went wrong\n`)
+}
+
 func (s *startPreseedSuite) TestChrootValidationUnhappyNoApparmor(c *C) {
 	restore := main.MockOsGetuid(func() int { return 0 })
 	defer restore()

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -235,10 +235,11 @@ func prepareChroot(preseedChroot string) (*targetSnapdInfo, func(), error) {
 	}
 
 	fstype, fsopts := squashfs.FsType()
-	cmd := exec.Command("mount", "-t", fstype, "-o", strings.Join(fsopts, ","), coreSnapPath, where)
-	if err := cmd.Run(); err != nil {
+	mountArgs := []string{"-t", fstype, "-o", strings.Join(fsopts, ","), coreSnapPath, where}
+	cmd := exec.Command("mount", mountArgs...)
+	if out, err := cmd.CombinedOutput(); err != nil {
 		removeMountpoint()
-		return nil, nil, fmt.Errorf("cannot mount %s at %s in preseed mode: %v ", coreSnapPath, where, err)
+		return nil, nil, fmt.Errorf("cannot mount %s at %s in preseed mode: %v\n'mount %s' failed with: %s", coreSnapPath, where, err, strings.Join(mountArgs, " "), out)
 	}
 
 	unmount := func() {


### PR DESCRIPTION
Include actual mount command and error output if snap-preseed fails early when mounting core/snapd snaps.

At the moment the error is just:
```
+ /usr/lib/snapd/snap-preseed /tmp/tmp.1HOxEDtVav
error: cannot mount /var/lib/snapd/seed/snaps/snapd_11843.snap at /tmp/snapd-preseed in preseed mode: exit status 32 
```