### PR TITLE
tests: fix issue when checking the udev tag on test security-device-cgroups

### DIFF
--- a/tests/main/security-device-cgroups-serial-port/task.yaml
+++ b/tests/main/security-device-cgroups-serial-port/task.yaml
@@ -20,36 +20,54 @@ restore: |
     udevadm trigger
 
 execute: |
-    echo "Given a snap is installed"
-    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        echo "Given a snap is installed"
+        "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
-    echo "Then the device is not assigned to that snap"
-    if udevadm info /dev/ttyS4 > info.txt; then
-        not MATCH "E: TAGS=.*snap_test-snapd-sh_sh" < info.txt
-    else
-        echo "No hardware for node /dev/ttyS4"
-        exit 0
+        echo "Then the device is not assigned to that snap"
+        if udevadm info /dev/ttyS4 > info.txt; then
+            not MATCH "E: TAGS=.*snap_test-snapd-sh_sh" < info.txt
+        else
+            echo "No hardware for node /dev/ttyS4"
+            exit 0
+        fi
+
+        echo "And the device is not shown in the snap device list"
+        # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
+        if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
+            not MATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+        fi
+
+        echo "When a udev rule assigning the device to the snap is added"
+        content="SUBSYSTEM==\"tty\", KERNEL==\"ttyS4\", TAG+=\"snap_test-snapd-sh_sh\""
+        echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+        udevadm control --reload-rules
+        udevadm settle
+        udevadm trigger
+        udevadm settle
+
+        echo "Then the device is shown as assigned to the snap"
+        udevadm info /dev/ttyS4 | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+        # CURRENT_TAGS just available on systemd 247+
+        if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+            udevadm info /dev/ttyS4 | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+        fi
+
+        echo "When a snap command is called"
+        test-snapd-sh.sh -c 'true'
+
+        echo "Then the device is shown in the snap device list"
+        MATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+        echo "Once the snap is removed, the current tags are automatically removed"
+        snap remove test-snapd-sh
+        udevadm info /dev/ttyS4 | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+        test ! -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+
+        # Reboot needed just on systemd 247+
+        if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+            REBOOT
+        fi
     fi
 
-    echo "And the device is not shown in the snap device list"
-    # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
-    if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
-        not MATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-    fi
-
-    echo "When a udev rule assigning the device to the snap is added"
-    content="SUBSYSTEM==\"tty\", KERNEL==\"ttyS4\", TAG+=\"snap_test-snapd-sh_sh\""
-    echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
-    udevadm control --reload-rules
-    udevadm settle
-    udevadm trigger
-    udevadm settle
-
-    echo "Then the device is shown as assigned to the snap"
-    udevadm info /dev/ttyS4 | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-
-    echo "When a snap command is called"
-    test-snapd-sh.sh -c 'true'
-
-    echo "Then the device is shown in the snap device list"
-    MATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+    udevadm info /dev/ttyS4 | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -85,13 +85,13 @@ execute: |
         "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
         echo "Then the device is not assigned to that snap"
-        udevadm info "$UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-        udevadm info "$UDEVADM_PATH" | not MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+        udevadm info "$UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+        udevadm info "$UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
 
         echo "And the device is not shown in the snap device list"
         # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
         if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
-            not MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+            NOMATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
         fi
 
         echo "When a udev rule assigning the device to the snap is added"
@@ -104,11 +104,14 @@ execute: |
 
         echo "Then the device is shown as assigned to the snap"
         udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-        udevadm info "$UDEVADM_PATH" | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+        # CURRENT_TAGS just available on systemc 247+
+        if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+            udevadm info "$UDEVADM_PATH" | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+        fi
 
         echo "And other devices are not shown as assigned to the snap"
-        udevadm info "$OTHER_UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-        udevadm info "$OTHER_UDEVADM_PATH" | not MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+        udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+        udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
 
         echo "When a snap command is called"
         test-snapd-sh.sh -c 'true'
@@ -117,7 +120,7 @@ execute: |
         MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
         echo "And other devices are not shown in the snap device list"
-        not MATCH "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+        NOMATCH "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
         echo "But existing nvidia devices are in the snap's device cgroup"
         MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
@@ -125,17 +128,17 @@ execute: |
         MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
         echo "But nonexisting nvidia devices are not"
-        not MATCH "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+        NOMATCH "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
         echo "But the existing uhid device is in the snap's device cgroup"
         MATCH "c 10:239 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
         echo "Once the snap is removed, the current tags are automatically removed"
         snap remove test-snapd-sh
-        udevadm info "$UDEVADM_PATH" | not MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+        udevadm info "$UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
 
         rm -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
         REBOOT
     fi
 
-    udevadm info "$UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    udevadm info "$UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -104,7 +104,7 @@ execute: |
 
         echo "Then the device is shown as assigned to the snap"
         udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-        # CURRENT_TAGS just available on systemc 247+
+        # CURRENT_TAGS just available on systemd 247+
         if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
             udevadm info "$UDEVADM_PATH" | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
         fi
@@ -136,9 +136,12 @@ execute: |
         echo "Once the snap is removed, the current tags are automatically removed"
         snap remove test-snapd-sh
         udevadm info "$UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+        test ! -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
 
-        rm -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
-        REBOOT
+        # Reboot needed just on systemd 247+
+        if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+            REBOOT
+        fi
     fi
 
     udevadm info "$UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -66,9 +66,12 @@ restore: |
     if [ -e /dev/uhid.spread ]; then
         rm -f /dev/uhid /dev/uhid.spread
     fi
-    rm -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
-    udevadm control --reload-rules
-    udevadm trigger
+
+    if [ -e /etc/udev/rules.d/70-snap.test-snapd-sh.rules ]; then
+        rm /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+        udevadm control --reload-rules
+        udevadm trigger
+    fi
 
 execute: |
     # some systems (like s390x) do not have support for this
@@ -77,50 +80,62 @@ execute: |
         exit 0
     fi
 
-    echo "Given a snap is installed"
-    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        echo "Given a snap is installed"
+        "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
-    echo "Then the device is not assigned to that snap"
-    udevadm info "$UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+        echo "Then the device is not assigned to that snap"
+        udevadm info "$UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+        udevadm info "$UDEVADM_PATH" | not MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
 
-    echo "And the device is not shown in the snap device list"
-    # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
-    if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
-        not MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+        echo "And the device is not shown in the snap device list"
+        # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
+        if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
+            not MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+        fi
+
+        echo "When a udev rule assigning the device to the snap is added"
+        content="KERNEL==\"$DEVICE_NAME\", TAG+=\"snap_test-snapd-sh_sh\""
+        echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+        udevadm control --reload-rules
+        udevadm settle
+        udevadm trigger
+        udevadm settle
+
+        echo "Then the device is shown as assigned to the snap"
+        udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+        udevadm info "$UDEVADM_PATH" | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+
+        echo "And other devices are not shown as assigned to the snap"
+        udevadm info "$OTHER_UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+        udevadm info "$OTHER_UDEVADM_PATH" | not MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+
+        echo "When a snap command is called"
+        test-snapd-sh.sh -c 'true'
+
+        echo "Then the device is shown in the snap device list"
+        MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+        echo "And other devices are not shown in the snap device list"
+        not MATCH "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+        echo "But existing nvidia devices are in the snap's device cgroup"
+        MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+        MATCH "c 195:255 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+        MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+        echo "But nonexisting nvidia devices are not"
+        not MATCH "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+        echo "But the existing uhid device is in the snap's device cgroup"
+        MATCH "c 10:239 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+        echo "Once the snap is removed, the current tags are automatically removed"
+        snap remove test-snapd-sh
+        udevadm info "$UDEVADM_PATH" | not MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+
+        rm -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+        REBOOT
     fi
 
-    echo "When a udev rule assigning the device to the snap is added"
-    content="KERNEL==\"$DEVICE_NAME\", TAG+=\"snap_test-snapd-sh_sh\""
-    echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
-    udevadm control --reload-rules
-    udevadm settle
-    udevadm trigger
-    udevadm settle
-
-    echo "Then the device is shown as assigned to the snap"
-    udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-
-    echo "And other devices are not shown as assigned to the snap"
-    udevadm info "$OTHER_UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-
-    echo "When a snap command is called"
-    test-snapd-sh.sh -c 'true'
-
-    echo "Then the device is shown in the snap device list"
-    MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-    echo "And other devices are not shown in the snap device list"
-    not MATCH "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-    echo "But existing nvidia devices are in the snap's device cgroup"
-    MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-    MATCH "c 195:255 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-    MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-    echo "But nonexisting nvidia devices are not"
-    not MATCH "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-    echo "But the existing uhid device is in the snap's device cgroup"
-    MATCH "c 10:239 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-    # TODO: check device unassociated after removing the udev file and rebooting
+    udevadm info "$UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-sh_sh"


### PR DESCRIPTION
This change includes:
. When the rule is added, then teh TAGS and CURRENT_TAGS are updated
. Remove the snap and check the udev CURRENT_TAGS is remove
. After rebooting the system the udev TAGS is removed as well

To reproduce the error run:
google:ubuntu-21.04-64:tests/main/security-device-cgroups:uinput
google:ubuntu-21.04-64:tests/main/security-device-cgroups:kmsg

The error:
+ echo 'And other devices are not shown as assigned to the snap'
And other devices are not shown as assigned to the snap
+ not MATCH 'E: TAGS=.*snap_test-snapd-sh_sh'
+ udevadm info /sys/devices/virtual/misc/uinput

Full log: https://paste.ubuntu.com/p/CCtdrNTXPC/
