### PR TITLE
c/snap,asserts: start supporting ExternalKeypairManager in the snap key-related commands

### DIFF
--- a/asserts/extkeypairmgr_test.go
+++ b/asserts/extkeypairmgr_test.go
@@ -272,3 +272,30 @@ func (s *extKeypairMgrSuite) TestExport(c *C) {
 		c.Check(exported, DeepEquals, expected)
 	}
 }
+
+func (s *extKeypairMgrSuite) TestList(c *C) {
+	kmgr, err := asserts.NewExternalKeypairManager("keymgr")
+	c.Assert(err, IsNil)
+
+	keys, err := kmgr.List()
+	c.Assert(err, IsNil)
+
+	defaultID := asserts.RSAPublicKey(s.defaultPub).ID()
+	modelsID := asserts.RSAPublicKey(s.modelsPub).ID()
+
+	c.Check(keys, DeepEquals, []asserts.ExternalKeyInfo{
+		{Name: "default", ID: defaultID},
+		{Name: "models", ID: modelsID},
+	})
+}
+
+func (s *extKeypairMgrSuite) TestListError(c *C) {
+	kmgr, err := asserts.NewExternalKeypairManager("keymgr")
+	c.Assert(err, IsNil)
+
+	pgm := testutil.MockCommand(c, "keymgr", `exit 1`)
+	defer pgm.Restore()
+
+	_, err = kmgr.List()
+	c.Check(err, ErrorMatches, `cannot get all external keypair manager key names:.*exit status 1.*`)
+}

--- a/asserts/gpgkeypairmgr.go
+++ b/asserts/gpgkeypairmgr.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -364,4 +364,19 @@ func (gkm *GPGKeypairManager) Delete(name string) error {
 		return err
 	}
 	return nil
+}
+
+func (gkm *GPGKeypairManager) List() (res []ExternalKeyInfo, err error) {
+	collect := func(privk PrivateKey, fpr string, uid string) error {
+		key := ExternalKeyInfo{
+			Name: uid,
+			ID:   privk.PublicKey().ID(),
+		}
+		res = append(res, key)
+		return nil
+	}
+	if err := gkm.Walk(collect); err != nil {
+		return nil, err
+	}
+	return res, nil
 }

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -327,4 +327,14 @@ Preferences: SHA512
 		parameters := gpgKeypairMgr.ParametersForGenerate(test.passphrase, "test-key")
 		c.Check(parameters, Equals, baseParameters+test.extraParameters)
 	}
+}
+
+func (gkms *gpgKeypairMgrSuite) TestList(c *C) {
+	gpgKeypairMgr := gkms.keypairMgr.(*asserts.GPGKeypairManager)
+
+	keys, err := gpgKeypairMgr.List()
+	c.Assert(err, IsNil)
+	c.Check(keys, HasLen, 1)
+	c.Check(keys[0].ID, Equals, assertstest.DevKeyID)
+	c.Check(keys[0].Name, Not(Equals), "")
 }

--- a/cmd/snap/cmd_export_key.go
+++ b/cmd/snap/cmd_export_key.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -66,9 +66,12 @@ func (x *cmdExportKey) Execute(args []string) error {
 		keyName = "default"
 	}
 
-	manager := asserts.NewGPGKeypairManager()
+	keypairMgr, err := getKeypairManager()
+	if err != nil {
+		return err
+	}
 	if x.Account != "" {
-		privKey, err := manager.GetByName(keyName)
+		privKey, err := keypairMgr.GetByName(keyName)
 		if err != nil {
 			return err
 		}
@@ -90,7 +93,7 @@ func (x *cmdExportKey) Execute(args []string) error {
 		}
 		fmt.Fprint(Stdout, string(asserts.Encode(assertion)))
 	} else {
-		encoded, err := manager.Export(keyName)
+		encoded, err := keypairMgr.Export(keyName)
 		if err != nil {
 			return err
 		}

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,7 +25,6 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/signtool"
 	"github.com/snapcore/snapd/i18n"
 )
@@ -81,7 +80,10 @@ func (x *cmdSign) Execute(args []string) error {
 		return fmt.Errorf(i18n.G("cannot read assertion input: %v"), err)
 	}
 
-	keypairMgr := asserts.NewGPGKeypairManager()
+	keypairMgr, err := getKeypairManager()
+	if err != nil {
+		return err
+	}
 	privKey, err := keypairMgr.GetByName(string(x.KeyName))
 	if err != nil {
 		// TRANSLATORS: %q is the key name, %v the error message

--- a/cmd/snap/cmd_sign_build.go
+++ b/cmd/snap/cmd_sign_build.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -84,8 +84,11 @@ func (x *cmdSignBuild) Execute(args []string) error {
 		return err
 	}
 
-	gkm := asserts.NewGPGKeypairManager()
-	privKey, err := gkm.GetByName(string(x.KeyName))
+	keypairMgr, err := getKeypairManager()
+	if err != nil {
+		return err
+	}
+	privKey, err := keypairMgr.GetByName(string(x.KeyName))
 	if err != nil {
 		// TRANSLATORS: %q is the key name, %v the error message
 		return fmt.Errorf(i18n.G("cannot use %q key: %v"), x.KeyName, err)
@@ -105,7 +108,7 @@ func (x *cmdSignBuild) Execute(args []string) error {
 	}
 
 	adb, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
-		KeypairManager: gkm,
+		KeypairManager: keypairMgr,
 	})
 	if err != nil {
 		return fmt.Errorf(i18n.G("cannot open the assertions database: %v"), err)

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -192,9 +192,11 @@ func (s keyName) Complete(match string) []flags.Completion {
 	if err != nil {
 		return nil
 	}
-	res := make([]flags.Completion, len(keys))
-	for i, k := range keys {
-		res[i].Item = k.Name
+	var res []flags.Completion
+	for _, k := range keys {
+		if strings.HasPrefix(k.Name, match) {
+			res = append(res, flags.Completion{Item: k.Name})
+		}
 	}
 	return res
 }

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -28,7 +28,6 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
@@ -185,13 +184,18 @@ func (n assertTypeName) Complete(match string) []flags.Completion {
 type keyName string
 
 func (s keyName) Complete(match string) []flags.Completion {
-	var res []flags.Completion
-	asserts.NewGPGKeypairManager().Walk(func(_ asserts.PrivateKey, _ string, uid string) error {
-		if strings.HasPrefix(uid, match) {
-			res = append(res, flags.Completion{Item: uid})
-		}
+	keypairManager, err := getKeypairManager()
+	if err != nil {
 		return nil
-	})
+	}
+	keys, err := keypairManager.List()
+	if err != nil {
+		return nil
+	}
+	res := make([]flags.Completion, len(keys))
+	for i, k := range keys {
+		res[i].Item = k.Name
+	}
 	return res
 }
 

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -91,6 +91,8 @@ var (
 	PrintInstallHint = printInstallHint
 
 	IsStopping = isStopping
+
+	GetKeypairManager = getKeypairManager
 )
 
 func HiddenCmd(descr string, completeHidden bool) *cmdInfo {

--- a/cmd/snap/keymgr.go
+++ b/cmd/snap/keymgr.go
@@ -32,6 +32,7 @@ type KeypairManager interface {
 
 	GetByName(keyNname string) (asserts.PrivateKey, error)
 	Export(keyName string) ([]byte, error)
+	List() ([]asserts.ExternalKeyInfo, error)
 }
 
 func getKeypairManager() (KeypairManager, error) {

--- a/cmd/snap/keymgr.go
+++ b/cmd/snap/keymgr.go
@@ -20,7 +20,11 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/i18n"
 )
 
 type KeypairManager interface {
@@ -31,6 +35,14 @@ type KeypairManager interface {
 }
 
 func getKeypairManager() (KeypairManager, error) {
+	keymgrPath := os.Getenv("SNAPD_EXT_KEYMGR")
+	if keymgrPath != "" {
+		keypairMgr, err := asserts.NewExternalKeypairManager(keymgrPath)
+		if err != nil {
+			return nil, fmt.Errorf(i18n.G("cannot setup external keypair manager: %v"), err)
+		}
+		return keypairMgr, nil
+	}
 	keypairMgr := asserts.NewGPGKeypairManager()
 	return keypairMgr, nil
 }

--- a/cmd/snap/keymgr.go
+++ b/cmd/snap/keymgr.go
@@ -1,0 +1,36 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/asserts"
+)
+
+type KeypairManager interface {
+	asserts.KeypairManager
+
+	GetByName(keyNname string) (asserts.PrivateKey, error)
+	Export(keyName string) ([]byte, error)
+}
+
+func getKeypairManager() (KeypairManager, error) {
+	keypairMgr := asserts.NewGPGKeypairManager()
+	return keypairMgr, nil
+}

--- a/cmd/snap/keymgr_test.go
+++ b/cmd/snap/keymgr_test.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"os"
+
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type keymgrSuite struct{}
+
+var _ = check.Suite(&keymgrSuite{})
+
+func (keymgrSuite) TestGPGKeypairManager(c *check.C) {
+	keypairMgr, err := snap.GetKeypairManager()
+	c.Check(err, check.IsNil)
+	c.Check(keypairMgr, check.FitsTypeOf, &asserts.GPGKeypairManager{})
+}
+
+func (keymgrSuite) TestExternalKeypairManager(c *check.C) {
+	os.Setenv("SNAPD_EXT_KEYMGR", "keymgr")
+	defer os.Unsetenv("SNAPD_EXT_KEYMGR")
+
+	pgm := testutil.MockCommand(c, "keymgr", `
+if [ "$1" == "features" ]; then
+  echo '{"signing":["RSA-PKCS"] , "public-keys":["DER"]}'
+  exit 0
+fi
+exit 1
+`)
+	defer pgm.Restore()
+
+	keypairMgr, err := snap.GetKeypairManager()
+	c.Check(err, check.IsNil)
+	c.Check(keypairMgr, check.FitsTypeOf, &asserts.ExternalKeypairManager{})
+	c.Check(pgm.Calls(), check.HasLen, 1)
+}

--- a/cmd/snap/keymgr_test.go
+++ b/cmd/snap/keymgr_test.go
@@ -57,3 +57,16 @@ exit 1
 	c.Check(keypairMgr, check.FitsTypeOf, &asserts.ExternalKeypairManager{})
 	c.Check(pgm.Calls(), check.HasLen, 1)
 }
+
+func (keymgrSuite) TestExternalKeypairManagerError(c *check.C) {
+	os.Setenv("SNAPD_EXT_KEYMGR", "keymgr")
+	defer os.Unsetenv("SNAPD_EXT_KEYMGR")
+
+	pgm := testutil.MockCommand(c, "keymgr", `
+exit 1
+`)
+	defer pgm.Restore()
+
+	_, err := snap.GetKeypairManager()
+	c.Check(err, check.ErrorMatches, `cannot setup external keypair manager: external keypair manager "keymgr" \[features\] failed: exit status 1.*`)
+}


### PR DESCRIPTION
This is done by centralizing keypair manager creation and a common KeypairManager interface.
