### PR TITLE
daemon: have apiBaseSuite.errorReq return *apiError directly 

### DIFF
--- a/daemon/api_aliases_test.go
+++ b/daemon/api_aliases_test.go
@@ -180,9 +180,9 @@ func (s *aliasesSuite) TestAliasErrors(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/aliases", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, 400)
-		c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, scen.err)
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 400)
+		c.Check(rspe.Message, check.Matches, scen.err)
 	}
 }
 

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -321,16 +321,16 @@ func (s *appsSuite) TestGetAppsInfoBadSelect(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/apps?select=potato", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 400)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 400)
 }
 
 func (s *appsSuite) TestGetAppsInfoBadName(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/apps?names=potato", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 404)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 404)
 }
 
 func (s *appsSuite) TestAppInfosForOne(c *check.C) {
@@ -575,51 +575,51 @@ func (s *appsSuite) TestPostAppsDisableNow(c *check.C) {
 func (s *appsSuite) TestPostAppsBadJSON(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`'junk`))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, ".*cannot decode request body.*")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Matches, ".*cannot decode request body.*")
 }
 
 func (s *appsSuite) TestPostAppsBadOp(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"random": "json"}`))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, ".*cannot perform operation on services without a list of services.*")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Matches, ".*cannot perform operation on services without a list of services.*")
 }
 
 func (s *appsSuite) TestPostAppsBadSnap(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "stop", "names": ["snap-c"]}`))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 404)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, `snap "snap-c" has no services`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 404)
+	c.Check(rspe.Message, check.Equals, `snap "snap-c" has no services`)
 }
 
 func (s *appsSuite) TestPostAppsBadApp(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "stop", "names": ["snap-a.what"]}`))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 404)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, `snap "snap-a" has no service "what"`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 404)
+	c.Check(rspe.Message, check.Equals, `snap "snap-a" has no service "what"`)
 }
 
 func (s *appsSuite) TestPostAppsServiceControlError(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "start", "names": ["snap-a.svc1"]}`))
 	c.Assert(err, check.IsNil)
 	s.serviceControlError = fmt.Errorf("total failure")
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, `total failure`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `total failure`)
 }
 
 func (s *appsSuite) TestPostAppsConflict(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "start", "names": ["snap-a.svc1"]}`))
 	c.Assert(err, check.IsNil)
 	s.serviceControlError = &snapstate.ChangeConflictError{Snap: "snap-a", ChangeKind: "enable"}
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, `snap "snap-a" has "enable" change in progress`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `snap "snap-a" has "enable" change in progress`)
 }
 
 func (s *appsSuite) expectLogsAccess() {
@@ -693,8 +693,8 @@ func (s *appsSuite) TestLogsBadN(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/logs?n=hello", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 400)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 400)
 }
 
 func (s *appsSuite) TestLogsFollow(c *check.C) {
@@ -727,8 +727,8 @@ func (s *appsSuite) TestLogsBadFollow(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/logs?follow=hello", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 400)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 400)
 }
 
 func (s *appsSuite) TestLogsBadName(c *check.C) {
@@ -737,8 +737,8 @@ func (s *appsSuite) TestLogsBadName(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/logs?names=hello", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 404)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 404)
 }
 
 func (s *appsSuite) TestLogsSad(c *check.C) {
@@ -748,8 +748,8 @@ func (s *appsSuite) TestLogsSad(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/logs", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 500)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 500)
 }
 
 func (s *appsSuite) TestLogsNoServices(c *check.C) {
@@ -764,6 +764,6 @@ func (s *appsSuite) TestLogsNoServices(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/logs", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 404)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 404)
 }

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -630,10 +630,6 @@ func (s *apiBaseSuite) asyncReq(c *check.C, req *http.Request, u *auth.UserState
 }
 
 func (s *apiBaseSuite) errorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.APIError {
-	return s.apiErrorReq(c, req, u)
-}
-
-func (s *apiBaseSuite) apiErrorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.APIError {
 	rsp := s.req(c, req, u)
 	rspe, ok := rsp.(*daemon.APIError)
 	c.Assert(ok, check.Equals, true, check.Commentf("expected apiError resp: %#v", rsp))

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2014-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -629,10 +629,8 @@ func (s *apiBaseSuite) asyncReq(c *check.C, req *http.Request, u *auth.UserState
 	return rsp
 }
 
-func (s *apiBaseSuite) errorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.RespJSON {
-	rsp := s.jsonReq(c, req, u)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeError, check.Commentf("expected error resp: %#v", rsp))
-	return rsp
+func (s *apiBaseSuite) errorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.APIError {
+	return s.apiErrorReq(c, req, u)
 }
 
 func (s *apiBaseSuite) apiErrorReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.APIError {

--- a/daemon/api_cohort_test.go
+++ b/daemon/api_cohort_test.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 
 	"gopkg.in/check.v1"
-
-	"github.com/snapcore/snapd/daemon"
 )
 
 var _ = check.Suite(&cohortSuite{})
@@ -82,9 +80,9 @@ func (s *cohortSuite) TestCreateCohortBadAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "pupate", "snaps": ["foo","bar"]}]`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `unknown cohort action "pupate"`})
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `unknown cohort action "pupate"`)
 }
 
 func (s *cohortSuite) TestCreateCohortError(c *check.C) {
@@ -93,25 +91,25 @@ func (s *cohortSuite) TestCreateCohortError(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]}]`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 500)
-	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `something went wrong`})
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 500)
+	c.Check(rspe.Message, check.Equals, `something went wrong`)
 }
 
 func (s *cohortSuite) TestCreateBadBody1(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `cannot decode request body into cohort instruction: unexpected EOF`})
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `cannot decode request body into cohort instruction: unexpected EOF`)
 }
 
 func (s *cohortSuite) TestCreateBadBody2(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]}xx`))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `spurious content after cohort instruction`})
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `spurious content after cohort instruction`)
 }

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -189,14 +189,13 @@ func (s *snapDownloadSuite) TestDownloadSnapErrors(c *check.C) {
 
 		req, err := http.NewRequest("POST", "/v2/download", bytes.NewBuffer(data))
 		c.Assert(err, check.IsNil)
-		rsp := s.errorReq(c, req, nil)
+		rspe := s.errorReq(c, req, nil)
 
-		c.Assert(rsp.Status, check.Equals, scen.status)
+		c.Assert(rspe.Status, check.Equals, scen.status)
 		if scen.err == "" {
 			c.Errorf("error was expected")
 		}
-		result := rsp.Result
-		c.Check(result.(*daemon.ErrorResult).Message, check.Matches, scen.err)
+		c.Check(rspe.Message, check.Matches, scen.err)
 	}
 }
 

--- a/daemon/api_find_test.go
+++ b/daemon/api_find_test.go
@@ -29,7 +29,6 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
-	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -386,9 +385,9 @@ func (s *findSuite) TestFindRefreshNotOther(c *check.C) {
 		req, err := http.NewRequest("GET", "/v2/find?select=refresh&"+other+"=foo*", nil)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, 400)
-		c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, "cannot use '"+other+"' with 'select=refresh'")
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 400)
+		c.Check(rspe.Message, check.Equals, "cannot use '"+other+"' with 'select=refresh'")
 	}
 }
 
@@ -405,11 +404,11 @@ func (s *findSuite) TestFindNotTogether(c *check.C) {
 			req, err := http.NewRequest("GET", fmt.Sprintf("/v2/find?%s=%s&%s=%s", ki, vi, kj, vj), nil)
 			c.Assert(err, check.IsNil)
 
-			rsp := s.errorReq(c, req, nil)
-			c.Check(rsp.Status, check.Equals, 400)
+			rspe := s.errorReq(c, req, nil)
+			c.Check(rspe.Status, check.Equals, 400)
 			exp1 := "cannot use '" + ki + "' and '" + kj + "' together"
 			exp2 := "cannot use '" + kj + "' and '" + ki + "' together"
-			c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, exp1+"|"+exp2)
+			c.Check(rspe.Message, check.Matches, exp1+"|"+exp2)
 		}
 	}
 }
@@ -421,10 +420,10 @@ func (s *findSuite) TestFindBadQueryReturnsCorrectErrorKind(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/find?q=return-bad-query-please", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, "bad query")
-	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindBadQuery)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Matches, "bad query")
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindBadQuery)
 }
 
 func (s *findSuite) TestFindNetworkErrorsReturnCorrectErrorKind(c *check.C) {
@@ -459,10 +458,10 @@ func (s *findSuite) TestFindNetworkErrorsReturnCorrectErrorKind(c *check.C) {
 	for _, t := range tests {
 		s.err = t.err
 
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, 400)
-		c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, t.expected)
-		c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, t.kind)
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 400)
+		c.Check(rspe.Message, check.Equals, t.expected)
+		c.Check(rspe.Kind, check.Equals, t.kind)
 	}
 }
 

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -688,14 +688,13 @@ func (s *generalSuite) TestStateChangeAbortIsReady(c *check.C) {
 	// Execute
 	req, err := http.NewRequest("POST", "/v2/changes/"+ids[0], buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
+	rspe := s.errorReq(c, req, nil)
 	rec := httptest.NewRecorder()
-	rsp.ServeHTTP(rec, req)
+	rspe.ServeHTTP(rec, req)
 
 	// Verify
 	c.Check(rec.Code, check.Equals, 400)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.NotNil)
+	c.Check(rspe.Status, check.Equals, 400)
 
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -63,9 +63,9 @@ func (s *modelSuite) TestPostRemodelUnhappy(c *check.C) {
 
 	req, err := http.NewRequest("POST", "/v2/model", bytes.NewBuffer(data))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, "cannot decode new model assertion: .*")
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Matches, "cannot decode new model assertion: .*")
 }
 
 func (s *modelSuite) TestPostRemodel(c *check.C) {
@@ -143,13 +143,11 @@ func (s *modelSuite) TestGetModelNoModelAssertion(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/model", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 404)
-	c.Assert(rsp.Result, check.FitsTypeOf, &daemon.ErrorResult{})
-	errRes := rsp.Result.(*daemon.ErrorResult)
-	c.Assert(errRes.Kind, check.Equals, client.ErrorKindAssertionNotFound)
-	c.Assert(errRes.Value, check.Equals, "model")
-	c.Assert(errRes.Message, check.Equals, "no model assertion yet")
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 404)
+	c.Assert(rspe.Kind, check.Equals, client.ErrorKindAssertionNotFound)
+	c.Assert(rspe.Value, check.Equals, "model")
+	c.Assert(rspe.Message, check.Equals, "no model assertion yet")
 }
 
 func (s *modelSuite) TestGetModelHasModelAssertion(c *check.C) {
@@ -242,13 +240,11 @@ func (s *modelSuite) TestGetModelNoSerialAssertion(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/model/serial", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 404)
-	c.Assert(rsp.Result, check.FitsTypeOf, &daemon.ErrorResult{})
-	errRes := rsp.Result.(*daemon.ErrorResult)
-	c.Assert(errRes.Kind, check.Equals, client.ErrorKindAssertionNotFound)
-	c.Assert(errRes.Value, check.Equals, "serial")
-	c.Assert(errRes.Message, check.Equals, "no serial assertion yet")
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 404)
+	c.Assert(rspe.Kind, check.Equals, client.ErrorKindAssertionNotFound)
+	c.Assert(rspe.Value, check.Equals, "serial")
+	c.Assert(rspe.Message, check.Equals, "no serial assertion yet")
 }
 
 func (s *modelSuite) TestGetModelHasSerialAssertion(c *check.C) {

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -76,9 +76,9 @@ func (s *apiQuotaSuite) TestPostQuotaUnknownAction(c *check.C) {
 
 	req, err := http.NewRequest("POST", "/v2/quotas", bytes.NewBuffer(data))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, `unknown quota action "foo"`)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `unknown quota action "foo"`)
 }
 
 func (s *apiQuotaSuite) TestPostQuotaInvalidGroupName(c *check.C) {
@@ -87,9 +87,9 @@ func (s *apiQuotaSuite) TestPostQuotaInvalidGroupName(c *check.C) {
 
 	req, err := http.NewRequest("POST", "/v2/quotas", bytes.NewBuffer(data))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `invalid quota group name: .*`)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Matches, `invalid quota group name: .*`)
 }
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
@@ -112,9 +112,9 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
 
 	req, err := http.NewRequest("POST", "/v2/quotas", bytes.NewBuffer(data))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `boom`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Matches, `boom`)
 }
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
@@ -222,9 +222,9 @@ func (s *apiQuotaSuite) TestPostRemoveQuotaUnhappy(c *check.C) {
 
 	req, err := http.NewRequest("POST", "/v2/quotas", bytes.NewBuffer(data))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `boom`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Matches, `boom`)
 }
 
 func (s *systemsSuite) TestPostQuotaRequiresRoot(c *check.C) {
@@ -343,15 +343,15 @@ func (s *apiQuotaSuite) TestGetQuotaInvalidName(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/quotas/000", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `invalid quota group name: .*`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Matches, `invalid quota group name: .*`)
 }
 
 func (s *apiQuotaSuite) TestGetQuotaNotFound(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/quotas/unknown", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 404)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot find quota group "unknown"`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 404)
+	c.Check(rspe.Message, check.Matches, `cannot find quota group "unknown"`)
 }

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -238,8 +238,8 @@ func (s *sideloadSuite) TestSideloadSnapJailModeAndDevmode(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, "cannot use devmode and jailmode flags together")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Equals, "cannot use devmode and jailmode flags together")
 }
 
 func (s *sideloadSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
@@ -262,8 +262,8 @@ func (s *sideloadSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
 	restore := sandbox.MockForceDevMode(true)
 	defer restore()
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, "this system cannot honour the jailmode flag")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Equals, "this system cannot honour the jailmode flag")
 }
 
 func (s *sideloadSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
@@ -354,8 +354,8 @@ func (s *sideloadSuite) TestSideloadSnapNoSignaturesDangerOff(c *check.C) {
 	// this is the prefix used for tempfiles for sideloading
 	glob := filepath.Join(os.TempDir(), "snapd-sideload-pkg-*")
 	glbBefore, _ := filepath.Glob(glob)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, `cannot find signatures with metadata for snap "x"`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Equals, `cannot find signatures with metadata for snap "x"`)
 	glbAfter, _ := filepath.Glob(glob)
 	c.Check(len(glbBefore), check.Equals, len(glbAfter))
 }
@@ -379,8 +379,8 @@ func (s *sideloadSuite) TestSideloadSnapNotValidFormFile(c *check.C) {
 		req.Header.Set(k, v)
 	}
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot find "snap" file field in provided multipart/form-data payload`)
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Message, check.Matches, `cannot find "snap" file field in provided multipart/form-data payload`)
 }
 
 func (s *sideloadSuite) TestSideloadSnapChangeConflict(c *check.C) {
@@ -408,8 +408,8 @@ func (s *sideloadSuite) TestSideloadSnapChangeConflict(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindSnapChangeConflict)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindSnapChangeConflict)
 }
 
 func (s *sideloadSuite) TestSideloadSnapInstanceName(c *check.C) {
@@ -453,8 +453,8 @@ func (s *sideloadSuite) TestSideloadSnapInstanceNameMismatch(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, `instance name "foo_instance" does not match snap name "bar"`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Equals, `instance name "foo_instance" does not match snap name "bar"`)
 }
 
 func (s *sideloadSuite) TestInstallPathUnaliased(c *check.C) {

--- a/daemon/api_snapctl_test.go
+++ b/daemon/api_snapctl_test.go
@@ -86,10 +86,10 @@ func (s *snapctlSuite) TestSnapctlUnsuccesfulError(c *check.C) {
 	buf := bytes.NewBufferString(fmt.Sprintf(`{"context-id": "some-context", "args": [%q, %q]}`, "is-connected", "plug"))
 	req, err := http.NewRequest("POST", "/v2/snapctl", buf)
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 200)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindUnsuccessful)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Value, check.DeepEquals, map[string]interface{}{
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 200)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindUnsuccessful)
+	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
 		"stdout":    "",
 		"stderr":    "",
 		"exit-code": 123,

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -425,9 +425,9 @@ func (s *snapsSuite) TestPostSnapsVerifyMultiSnapInstruction(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "application/json")
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, `cannot install "ubuntu-core", please use "core" instead`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, testutil.Contains, `cannot install "ubuntu-core", please use "core" instead`)
 }
 
 func (s *snapsSuite) TestPostSnapsUnsupportedMultiOp(c *check.C) {
@@ -438,9 +438,9 @@ func (s *snapsSuite) TestPostSnapsUnsupportedMultiOp(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "application/json")
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, `unsupported multi-snap operation "switch"`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, testutil.Contains, `unsupported multi-snap operation "switch"`)
 }
 
 func (s *snapsSuite) TestPostSnapsNoWeirdses(c *check.C) {
@@ -462,9 +462,9 @@ func (s *snapsSuite) TestPostSnapsNoWeirdses(c *check.C) {
 			c.Assert(err, check.IsNil)
 			req.Header.Set("Content-Type", "application/json")
 
-			rsp := s.errorReq(c, req, nil)
-			c.Check(rsp.Status, check.Equals, 400)
-			c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, `unsupported option provided for multi-snap operation`)
+			rspe := s.errorReq(c, req, nil)
+			c.Check(rspe.Status, check.Equals, 400)
+			c.Check(rspe.Message, testutil.Contains, `unsupported option provided for multi-snap operation`)
 		}
 	}
 }
@@ -512,9 +512,9 @@ func (s *snapsSuite) TestPostSnapsOpInvalidCharset(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "application/json; charset=iso-8859-1")
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, "unknown charset in content type")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, testutil.Contains, "unknown charset in content type")
 }
 
 func (s *snapsSuite) TestRefreshAll(c *check.C) {
@@ -937,9 +937,9 @@ func (s *snapsSuite) TestSnapInfoIgnoresRemoteErrors(c *check.C) {
 
 	req, err := http.NewRequest("GET", "/v2/snaps/gfoo", nil)
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 404)
-	c.Check(rsp.Result, check.NotNil)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 404)
+	c.Check(rspe.Message, check.Not(check.Equals), "")
 }
 
 func (s *snapsSuite) TestMapLocalFields(c *check.C) {
@@ -1076,9 +1076,9 @@ func (s *snapsSuite) TestPostSnapBadRequest(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/snaps/hello-world", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.NotNil)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Not(check.Equals), "")
 }
 
 func (s *snapsSuite) TestPostSnapBadAction(c *check.C) {
@@ -1088,9 +1088,9 @@ func (s *snapsSuite) TestPostSnapBadAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/snaps/hello-world", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.NotNil)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Not(check.Equals), "")
 }
 
 func (s *snapsSuite) TestPostSnapBadChannel(c *check.C) {
@@ -1100,9 +1100,9 @@ func (s *snapsSuite) TestPostSnapBadChannel(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/snaps/hello-world", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.NotNil)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Not(check.Equals), "")
 }
 
 func (s *snapsSuite) TestPostSnap(c *check.C) {
@@ -1177,9 +1177,9 @@ func (s *snapsSuite) TestPostSnapVerifySnapInstruction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/snaps/ubuntu-core", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, `cannot install "ubuntu-core", please use "core" instead`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, testutil.Contains, `cannot install "ubuntu-core", please use "core" instead`)
 }
 
 func (s *snapsSuite) TestPostSnapCohortUnsupportedAction(c *check.C) {
@@ -1191,9 +1191,9 @@ func (s *snapsSuite) TestPostSnapCohortUnsupportedAction(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snaps/some-snap", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, 400, check.Commentf("%q", action))
-		c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, expectedErr, check.Commentf("%q", action))
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 400, check.Commentf("%q", action))
+		c.Check(rspe.Message, check.Equals, expectedErr, check.Commentf("%q", action))
 	}
 }
 
@@ -1206,9 +1206,9 @@ func (s *snapsSuite) TestPostSnapLeaveCohortUnsupportedAction(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snaps/some-snap", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, 400, check.Commentf("%q", action))
-		c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, expectedErr, check.Commentf("%q", action))
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 400, check.Commentf("%q", action))
+		c.Check(rspe.Message, check.Equals, expectedErr, check.Commentf("%q", action))
 	}
 }
 
@@ -1228,9 +1228,9 @@ func (s *snapsSuite) TestPostSnapCohortIncompat(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snaps/some-snap", buf)
 		c.Assert(err, check.IsNil, check.Commentf("%d (%s)", i, t.opts))
 
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, 400, check.Commentf("%d (%s)", i, t.opts))
-		c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, t.errmsg, check.Commentf("%d (%s)", i, t.opts))
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 400, check.Commentf("%d (%s)", i, t.opts))
+		c.Check(rspe.Message, check.Equals, t.errmsg, check.Commentf("%d (%s)", i, t.opts))
 	}
 }
 
@@ -1276,9 +1276,9 @@ func (s *snapsSuite) TestPostSnapEnableDisableSwitchRevision(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snaps/hello-world", buf)
 		c.Assert(err, check.IsNil)
 
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, 400)
-		c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, "takes no revision")
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 400)
+		c.Check(rspe.Message, testutil.Contains, "takes no revision")
 	}
 }
 

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -114,9 +114,9 @@ func (s *snapshotSuite) TestListSnapshotsBadFiltering(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots?set=no", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.ErrorResult().Message, check.Equals, `'set', if given, must be a positive base 10 number; got "no"`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `'set', if given, must be a positive base 10 number; got "no"`)
 }
 
 func (s *snapshotSuite) TestListSnapshotsListError(c *check.C) {
@@ -129,9 +129,9 @@ func (s *snapshotSuite) TestListSnapshotsListError(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 500)
-	c.Check(rsp.ErrorResult().Message, check.Equals, "no")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 500)
+	c.Check(rspe.Message, check.Equals, "no")
 }
 
 func (s *snapshotSuite) TestFormatSnapshotAction(c *check.C) {
@@ -196,9 +196,9 @@ func (s *snapshotSuite) TestChangeSnapshots400(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snapshots", strings.NewReader(test.body))
 		c.Assert(err, check.IsNil, comm)
 
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, 400, comm)
-		c.Check(rsp.ErrorResult().Message, check.Matches, test.error, comm)
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 400, comm)
+		c.Check(rspe.Message, check.Matches, test.error, comm)
 	}
 }
 
@@ -225,9 +225,9 @@ func (s *snapshotSuite) TestChangeSnapshots404(c *check.C) {
 			req, err := http.NewRequest("POST", "/v2/snapshots", strings.NewReader(body))
 			c.Assert(err, check.IsNil, comm)
 
-			rsp := s.errorReq(c, req, nil)
-			c.Check(rsp.Status, check.Equals, 404, comm)
-			c.Check(rsp.ErrorResult().Message, check.Matches, expectedError.Error(), comm)
+			rspe := s.errorReq(c, req, nil)
+			c.Check(rspe.Status, check.Equals, 404, comm)
+			c.Check(rspe.Message, check.Matches, expectedError.Error(), comm)
 			c.Check(done, check.Equals, action, comm)
 		}
 	}
@@ -254,9 +254,9 @@ func (s *snapshotSuite) TestChangeSnapshots500(c *check.C) {
 		req, err := http.NewRequest("POST", "/v2/snapshots", strings.NewReader(body))
 		c.Assert(err, check.IsNil, comm)
 
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, 500, comm)
-		c.Check(rsp.ErrorResult().Message, check.Matches, expectedError.Error(), comm)
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 500, comm)
+		c.Check(rspe.Message, check.Matches, expectedError.Error(), comm)
 		c.Check(done, check.Equals, action, comm)
 	}
 }
@@ -329,9 +329,9 @@ func (s *snapshotSuite) TestExportSnapshotsBadRequestOnNonNumericID(c *check.C) 
 	req, err := http.NewRequest("GET", "/v2/snapshots/xxx/export", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `'id' must be a positive base 10 number; got "xxx"`})
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `'id' must be a positive base 10 number; got "xxx"`)
 }
 
 func (s *snapshotSuite) TestExportSnapshotsBadRequestOnError(c *check.C) {
@@ -345,9 +345,9 @@ func (s *snapshotSuite) TestExportSnapshotsBadRequestOnError(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snapshots/1/export", nil)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.DeepEquals, &daemon.ErrorResult{Message: `cannot export 1: boom`})
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `cannot export 1: boom`)
 	c.Check(snapshotExportCalled, check.Equals, 1)
 }
 
@@ -381,9 +381,9 @@ func (s *snapshotSuite) TestImportSnapshotError(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.ErrorResult().Message, check.Equals, "no")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, "no")
 }
 
 func (s *snapshotSuite) TestImportSnapshotNoContentLengthError(c *check.C) {
@@ -392,9 +392,9 @@ func (s *snapshotSuite) TestImportSnapshotNoContentLengthError(c *check.C) {
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", client.SnapshotExportMediaType)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.ErrorResult().Message, check.Equals, `cannot parse Content-Length: strconv.ParseInt: parsing "": invalid syntax`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, `cannot parse Content-Length: strconv.ParseInt: parsing "": invalid syntax`)
 }
 
 func (s *snapshotSuite) TestImportSnapshotLimits(c *check.C) {

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -309,9 +309,9 @@ func (s *systemsSuite) TestSystemActionRequestErrors(c *check.C) {
 		c.Logf("tc: %#v", tc)
 		req, err := http.NewRequest("POST", path.Join("/v2/systems", tc.label), strings.NewReader(tc.body))
 		c.Assert(err, check.IsNil)
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, tc.status)
-		c.Check(rsp.ErrorResult().Message, check.Matches, tc.error)
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, tc.status)
+		c.Check(rspe.Message, check.Matches, tc.error)
 	}
 }
 
@@ -552,9 +552,9 @@ func (s *systemsSuite) TestSystemActionBrokenSeed(c *check.C) {
 	body := `{"action":"do","title":"reinstall","mode":"install"}`
 	req, err := http.NewRequest("POST", "/v2/systems/20191119", strings.NewReader(body))
 	c.Assert(err, check.IsNil)
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 500)
-	c.Check(rsp.ErrorResult().Message, check.Matches, `cannot load seed system: cannot load assertions: .*`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 500)
+	c.Check(rspe.Message, check.Matches, `cannot load seed system: cannot load assertions: .*`)
 }
 
 func (s *systemsSuite) TestSystemActionNonRoot(c *check.C) {

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -362,9 +362,9 @@ func (s *userSuite) TestLoginUserBadRequest(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/login", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result, check.NotNil)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Not(check.Equals), "")
 }
 
 func (s *userSuite) TestLoginUserNotEmailish(c *check.C) {
@@ -374,9 +374,9 @@ func (s *userSuite) TestLoginUserNotEmailish(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/login", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, "please use a valid email address")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, testutil.Contains, "please use a valid email address")
 }
 
 func (s *userSuite) TestLoginUserDeveloperAPIError(c *check.C) {
@@ -387,9 +387,9 @@ func (s *userSuite) TestLoginUserDeveloperAPIError(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/login", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 401)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, testutil.Contains, "error-from-login-user")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 401)
+	c.Check(rspe.Message, testutil.Contains, "error-from-login-user")
 }
 
 func (s *userSuite) TestLoginUserTwoFactorRequiredError(c *check.C) {
@@ -400,9 +400,9 @@ func (s *userSuite) TestLoginUserTwoFactorRequiredError(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/login", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 401)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindTwoFactorRequired)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 401)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindTwoFactorRequired)
 }
 
 func (s *userSuite) TestLoginUserTwoFactorFailedError(c *check.C) {
@@ -413,9 +413,9 @@ func (s *userSuite) TestLoginUserTwoFactorFailedError(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/login", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 401)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindTwoFactorFailed)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 401)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindTwoFactorFailed)
 }
 
 func (s *userSuite) TestLoginUserInvalidCredentialsError(c *check.C) {
@@ -426,9 +426,9 @@ func (s *userSuite) TestLoginUserInvalidCredentialsError(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/login", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 401)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, "invalid credentials")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 401)
+	c.Check(rspe.Message, check.Equals, "invalid credentials")
 }
 
 func (s *userSuite) TestLoginUserInvalidAuthDataError(c *check.C) {
@@ -439,10 +439,10 @@ func (s *userSuite) TestLoginUserInvalidAuthDataError(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/login", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindInvalidAuthData)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Value, check.DeepEquals, s.err)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindInvalidAuthData)
+	c.Check(rspe.Value, check.DeepEquals, s.err)
 }
 
 func (s *userSuite) TestLoginUserPasswordPolicyError(c *check.C) {
@@ -453,10 +453,10 @@ func (s *userSuite) TestLoginUserPasswordPolicyError(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/login", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 401)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Kind, check.Equals, client.ErrorKindPasswordPolicy)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Value, check.DeepEquals, s.err)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 401)
+	c.Check(rspe.Kind, check.Equals, client.ErrorKindPasswordPolicy)
+	c.Check(rspe.Value, check.DeepEquals, s.err)
 }
 
 func (s *userSuite) TestPostCreateUserNoSSHKeys(c *check.C) {
@@ -469,8 +469,8 @@ func (s *userSuite) TestPostCreateUserNoSSHKeys(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot create user for "popper@lse.ac.uk": no ssh keys found`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Matches, `cannot create user for "popper@lse.ac.uk": no ssh keys found`)
 }
 
 func (s *userSuite) TestPostCreateUser(c *check.C) {
@@ -568,8 +568,8 @@ func (s *userSuite) TestPostUserBadBody(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, "cannot decode user action data from request body: .*")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Matches, "cannot decode user action data from request body: .*")
 }
 
 func (s *userSuite) TestPostUserBadAfterBody(c *check.C) {
@@ -626,9 +626,9 @@ func (s *userSuite) TestPostUserActionRemoveDelUserErr(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 500)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Equals, "wat")
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 500)
+	c.Check(rspe.Message, check.Equals, "wat")
 	c.Check(called, check.Equals, 1)
 }
 
@@ -648,9 +648,9 @@ func (s *userSuite) TestPostUserActionRemoveStateErr(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 500)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `internal error: could not unmarshal state entry "auth": .*`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 500)
+	c.Check(rspe.Message, check.Matches, `internal error: could not unmarshal state entry "auth": .*`)
 	c.Check(called, check.Equals, 0)
 }
 
@@ -1043,8 +1043,8 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownClassicErrors(c *chec
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot create user: device is a classic system`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Matches, `cannot create user: device is a classic system`)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwnedErrors(c *check.C) {
@@ -1061,8 +1061,8 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwnedErrors(c *che
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot create user: device already managed`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Matches, `cannot create user: device already managed`)
 }
 
 func (s *userSuite) TestPostCreateUserAutomaticManagedDoesNotActOrError(c *check.C) {
@@ -1103,8 +1103,8 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownNoModelError(c *check
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot create user: cannot get model assertion: no state entry for key`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Matches, `cannot create user: cannot get model assertion: no state entry for key`)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionNoModel(c *check.C) {
@@ -1135,8 +1135,8 @@ func (s *userSuite) TestPostCreateUserFromAssertionNoModel(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/create-user", buf)
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Result.(*daemon.ErrorResult).Message, check.Matches, `cannot add system-user "serial@bar.com": bound to serial assertion but device not yet registered`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Message, check.Matches, `cannot add system-user "serial@bar.com": bound to serial assertion but device not yet registered`)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwned(c *check.C) {

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -550,7 +550,7 @@ func (s *userSuite) testNoUserAdmin(c *check.C, endpoint string) {
 	req, err := http.NewRequest("POST", endpoint, buf)
 	c.Assert(err, check.IsNil)
 
-	rspe := s.apiErrorReq(c, req, nil)
+	rspe := s.errorReq(c, req, nil)
 
 	const noUserAdmin = "system user administration via snapd is not allowed on this system"
 	switch endpoint {
@@ -577,7 +577,7 @@ func (s *userSuite) TestPostUserBadAfterBody(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rspe := s.apiErrorReq(c, req, nil)
+	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe, check.DeepEquals, daemon.BadRequest("spurious content after user action"))
 }
 
@@ -586,7 +586,7 @@ func (s *userSuite) TestPostUserNoAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rspe := s.apiErrorReq(c, req, nil)
+	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe, check.DeepEquals, daemon.BadRequest("missing user action"))
 }
 
@@ -595,7 +595,7 @@ func (s *userSuite) TestPostUserBadAction(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rspe := s.apiErrorReq(c, req, nil)
+	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe, check.DeepEquals, daemon.BadRequest(`unsupported user action "patatas"`))
 }
 
@@ -604,7 +604,7 @@ func (s *userSuite) TestPostUserActionRemoveNoUsername(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rspe := s.apiErrorReq(c, req, nil)
+	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe, check.DeepEquals, daemon.BadRequest("need a username to remove"))
 }
 
@@ -666,7 +666,7 @@ func (s *userSuite) TestPostUserActionRemoveNoUserInState(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
-	rspe := s.apiErrorReq(c, req, nil)
+	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe, check.DeepEquals, daemon.BadRequest(`user "some-user" is not known`))
 	c.Check(called, check.Equals, 0)
 }

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -200,9 +200,9 @@ func (s *apiValidationSetsSuite) TestQueryValidationSetsErrors(c *check.C) {
 		}
 		req, err := http.NewRequest("GET", fmt.Sprintf("/v2/validation-sets/%s?%s", tc.validationSet, q.Encode()), nil)
 		c.Assert(err, check.IsNil)
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, tc.status, check.Commentf("case #%d", i))
-		c.Check(rsp.ErrorResult().Message, check.Matches, tc.message)
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, tc.status, check.Commentf("case #%d", i))
+		c.Check(rspe.Message, check.Matches, tc.message)
 	}
 }
 
@@ -324,12 +324,10 @@ func (s *apiValidationSetsSuite) TestGetValidationSetNotFound(c *check.C) {
 	s.mockValidationSetsTracking(st)
 	st.Unlock()
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 404)
-	res := rsp.Result.(*daemon.ErrorResult)
-	c.Assert(res, check.NotNil)
-	c.Check(string(res.Kind), check.Equals, "validation-set-not-found")
-	c.Check(res.Value, check.DeepEquals, map[string]interface{}{
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 404)
+	c.Check(string(rspe.Kind), check.Equals, "validation-set-not-found")
+	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
 		"account-id": "foo",
 		"name":       "other",
 	})
@@ -588,12 +586,10 @@ func (s *apiValidationSetsSuite) TestGetValidationSetPinnedNotFound(c *check.C) 
 	s.mockValidationSetsTracking(st)
 	st.Unlock()
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 404)
-	res := rsp.Result.(*daemon.ErrorResult)
-	c.Assert(res, check.NotNil)
-	c.Check(string(res.Kind), check.Equals, "validation-set-not-found")
-	c.Check(res.Value, check.DeepEquals, map[string]interface{}{
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 404)
+	c.Check(string(rspe.Kind), check.Equals, "validation-set-not-found")
+	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
 		"account-id": "foo",
 		"name":       "bar",
 		"sequence":   333,
@@ -798,9 +794,9 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeError(c *check
 	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 400)
-	c.Check(rsp.ErrorResult().Message, check.Equals, fmt.Sprintf(`cannot get validation set assertion for %s/bar: boom`, s.dev1acct.AccountID()))
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Equals, fmt.Sprintf(`cannot get validation set assertion for %s/bar: boom`, s.dev1acct.AccountID()))
 }
 
 func (s *apiValidationSetsSuite) TestForgetValidationSet(c *check.C) {
@@ -842,8 +838,8 @@ func (s *apiValidationSetsSuite) TestForgetValidationSet(c *check.C) {
 		// and forget again fails
 		req, err = http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/foo", s.dev1acct.AccountID()), strings.NewReader(body))
 		c.Assert(err, check.IsNil)
-		rsp = s.errorReq(c, req, nil)
-		c.Assert(rsp.Status, check.Equals, 404, check.Commentf("case #%d", i))
+		rspe := s.errorReq(c, req, nil)
+		c.Assert(rspe.Status, check.Equals, 404, check.Commentf("case #%d", i))
 	}
 }
 
@@ -914,9 +910,9 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetsErrors(c *check.C) {
 		}
 		req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s", tc.validationSet), strings.NewReader(body))
 		c.Assert(err, check.IsNil)
-		rsp := s.errorReq(c, req, nil)
-		c.Check(rsp.Status, check.Equals, tc.status, check.Commentf("case #%d", i))
-		c.Check(rsp.ErrorResult().Message, check.Matches, tc.message)
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, tc.status, check.Commentf("case #%d", i))
+		c.Check(rspe.Message, check.Matches, tc.message)
 	}
 }
 
@@ -926,7 +922,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetUnsupportedAction(c *chec
 	req, err := http.NewRequest("POST", "/v2/validation-sets/foo/bar", strings.NewReader(body))
 	c.Assert(err, check.IsNil)
 
-	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.ErrorResult().Message, check.Matches, `unsupported action "baz"`)
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, check.Equals, 400)
+	c.Check(rspe.Message, check.Matches, `unsupported action "baz"`)
 }

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -201,11 +201,6 @@ type (
 	SnapInstruction = snapInstruction
 )
 
-// XXX this is not used very consistently
-func (rsp *respJSON) ErrorResult() *errorResult {
-	return rsp.Result.(*errorResult)
-}
-
 func (inst *snapInstruction) Dispatch() snapActionFunc {
 	return inst.dispatch()
 }


### PR DESCRIPTION
This is possible now that apiError is used everywhere to return errors.

This contains also some final cleanups, for example dropping now superfluous apiBaseSuite.apiErrorReq.