### PR TITLE
c/snap,asserts: create/delete-key external keypair manager interaction 

### DIFF
--- a/asserts/extkeypairmgr.go
+++ b/asserts/extkeypairmgr.go
@@ -190,8 +190,26 @@ func (em *ExternalKeypairManager) GetByName(keyName string) (PrivateKey, error) 
 	return em.privateKey(cachedKey), nil
 }
 
+// ExternalUnsupportedOpError represents the error situation of operations
+// that are not supported/mediated via ExternalKeypairManager.
+type ExternalUnsupportedOpError struct {
+	msg string
+}
+
+func (euoe *ExternalUnsupportedOpError) Error() string {
+	return euoe.msg
+}
+
 func (em *ExternalKeypairManager) Put(privKey PrivateKey) error {
-	return fmt.Errorf("cannot import private key into external keypair manager")
+	return &ExternalUnsupportedOpError{"cannot import private key into external keypair manager"}
+}
+
+func (em *ExternalKeypairManager) Delete(keyName string) error {
+	return &ExternalUnsupportedOpError{"no support to delete external keypair manager keys"}
+}
+
+func (em *ExternalKeypairManager) Generate(keyName string) error {
+	return &ExternalUnsupportedOpError{"no support to mediate generating an external keypair manager key"}
 }
 
 func (em *ExternalKeypairManager) loadAllKeys() ([]string, error) {

--- a/asserts/extkeypairmgr_test.go
+++ b/asserts/extkeypairmgr_test.go
@@ -299,3 +299,22 @@ func (s *extKeypairMgrSuite) TestListError(c *C) {
 	_, err = kmgr.List()
 	c.Check(err, ErrorMatches, `cannot get all external keypair manager key names:.*exit status 1.*`)
 }
+
+func (s *extKeypairMgrSuite) TestDeleteUnsupported(c *C) {
+	kmgr, err := asserts.NewExternalKeypairManager("keymgr")
+	c.Assert(err, IsNil)
+
+	err = kmgr.Delete("key")
+	c.Check(err, ErrorMatches, `no support to delete external keypair manager keys`)
+	c.Check(err, FitsTypeOf, &asserts.ExternalUnsupportedOpError{})
+
+}
+
+func (s *extKeypairMgrSuite) TestGenerateUnsupported(c *C) {
+	kmgr, err := asserts.NewExternalKeypairManager("keymgr")
+	c.Assert(err, IsNil)
+
+	err = kmgr.Generate("key")
+	c.Check(err, ErrorMatches, `no support to mediate generating an external keypair manager key`)
+	c.Check(err, FitsTypeOf, &asserts.ExternalUnsupportedOpError{})
+}

--- a/cmd/snap/cmd_create_key.go
+++ b/cmd/snap/cmd_create_key.go
@@ -20,11 +20,9 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/jessevdk/go-flags"
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/i18n"
@@ -68,25 +66,9 @@ func (x *cmdCreateKey) Execute(args []string) error {
 		return fmt.Errorf(i18n.G("key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"), keyName)
 	}
 
-	fmt.Fprint(Stdout, i18n.G("Passphrase: "))
-	passphrase, err := terminal.ReadPassword(0)
-	fmt.Fprint(Stdout, "\n")
+	keypairMgr, err := getKeypairManager()
 	if err != nil {
 		return err
 	}
-	fmt.Fprint(Stdout, i18n.G("Confirm passphrase: "))
-	confirmPassphrase, err := terminal.ReadPassword(0)
-	fmt.Fprint(Stdout, "\n")
-	if err != nil {
-		return err
-	}
-	if string(passphrase) != string(confirmPassphrase) {
-		return errors.New("passphrases do not match")
-	}
-	if err != nil {
-		return err
-	}
-
-	manager := asserts.NewGPGKeypairManager()
-	return manager.Generate(string(passphrase), keyName)
+	return generateKey(keypairMgr, keyName)
 }

--- a/cmd/snap/cmd_delete_key.go
+++ b/cmd/snap/cmd_delete_key.go
@@ -20,6 +20,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/asserts"
@@ -56,6 +58,13 @@ func (x *cmdDeleteKey) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	manager := asserts.NewGPGKeypairManager()
-	return manager.Delete(string(x.Positional.KeyName))
+	keypairMgr, err := getKeypairManager()
+	if err != nil {
+		return err
+	}
+	err = keypairMgr.Delete(string(x.Positional.KeyName))
+	if _, ok := err.(*asserts.ExternalUnsupportedOpError); ok {
+		return fmt.Errorf(i18n.G("cannot delete external keypair manager key via snap command, use the appropriate external procedure"))
+	}
+	return err
 }

--- a/cmd/snap/cmd_delete_key_test.go
+++ b/cmd/snap/cmd_delete_key_test.go
@@ -62,3 +62,14 @@ func (s *SnapKeysSuite) TestDeleteKey(c *C) {
 	c.Check(obtainedResponse, DeepEquals, expectedResponse)
 	c.Check(s.Stderr(), Equals, "")
 }
+
+func (s *SnapKeysSuite) TestDeleteKeyExternalUnsupported(c *C) {
+	_, restore := mockNopExtKeyMgr(c)
+	defer restore()
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"delete-key", "key"})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "cannot delete external keypair manager key via snap command, use the appropriate external procedure")
+	c.Check(s.Stdout(), Equals, "")
+	c.Check(s.Stderr(), Equals, "")
+}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -93,6 +93,7 @@ var (
 	IsStopping = isStopping
 
 	GetKeypairManager = getKeypairManager
+	GenerateKey       = generateKey
 )
 
 func HiddenCmd(descr string, completeHidden bool) *cmdInfo {

--- a/cmd/snap/keymgr.go
+++ b/cmd/snap/keymgr.go
@@ -20,8 +20,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/i18n"
@@ -33,6 +36,7 @@ type KeypairManager interface {
 	GetByName(keyNname string) (asserts.PrivateKey, error)
 	Export(keyName string) ([]byte, error)
 	List() ([]asserts.ExternalKeyInfo, error)
+	Delete(keyName string) error
 }
 
 func getKeypairManager() (KeypairManager, error) {
@@ -46,4 +50,50 @@ func getKeypairManager() (KeypairManager, error) {
 	}
 	keypairMgr := asserts.NewGPGKeypairManager()
 	return keypairMgr, nil
+}
+
+type takingPassKeyGen interface {
+	Generate(passphrase string, keyName string) error
+}
+
+type ownSecuringKeyGen interface {
+	Generate(keyName string) error
+}
+
+func generateKey(keypairMgr KeypairManager, keyName string) error {
+	switch keyGen := keypairMgr.(type) {
+	case takingPassKeyGen:
+		return takePassGenKey(keyGen, keyName)
+	case ownSecuringKeyGen:
+		err := keyGen.Generate(keyName)
+		if _, ok := err.(*asserts.ExternalUnsupportedOpError); ok {
+			return fmt.Errorf(i18n.G("cannot generate external keypair manager key via snap command, use the appropriate external procedure to create a 4096-bit RSA key under the name/label %q"), keyName)
+		}
+		return err
+	default:
+		return fmt.Errorf("internal error: unsupported keypair manager %T", keypairMgr)
+	}
+}
+
+func takePassGenKey(keyGen takingPassKeyGen, keyName string) error {
+	fmt.Fprint(Stdout, i18n.G("Passphrase: "))
+	passphrase, err := terminal.ReadPassword(0)
+	fmt.Fprint(Stdout, "\n")
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(Stdout, i18n.G("Confirm passphrase: "))
+	confirmPassphrase, err := terminal.ReadPassword(0)
+	fmt.Fprint(Stdout, "\n")
+	if err != nil {
+		return err
+	}
+	if string(passphrase) != string(confirmPassphrase) {
+		return errors.New(i18n.G("passphrases do not match"))
+	}
+	if err != nil {
+		return err
+	}
+
+	return keyGen.Generate(string(passphrase), keyName)
 }

--- a/cmd/snap/keymgr.go
+++ b/cmd/snap/keymgr.go
@@ -91,9 +91,6 @@ func takePassGenKey(keyGen takingPassKeyGen, keyName string) error {
 	if string(passphrase) != string(confirmPassphrase) {
 		return errors.New(i18n.G("passphrases do not match"))
 	}
-	if err != nil {
-		return err
-	}
 
 	return keyGen.Generate(string(passphrase), keyName)
 }


### PR DESCRIPTION
at least initially we don't support using snap commands to create/delete
keys under an external keypair manager, organize things such that though
we can produce appropriate error messages and we can implement
supporting this later if required
