### PR TITLE
boot: track model's sign key ID, prepare infra for tracking candidate model

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -344,6 +344,7 @@ func MarkBootSuccessful(dev Device) error {
 			trustedAssetsBootState(dev),
 			trustedCommandLineBootState(dev),
 			recoverySystemsBootState(dev),
+			modelBootState(dev),
 		} {
 			var err error
 			u, err = bs.markSuccessful(u)

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -2386,10 +2386,11 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 		CurrentRecoverySystems:    []string{"system"},
 		GoodRecoverySystems:       []string{"system"},
 		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
-		Model:                     "my-model-uc20",
-		BrandID:                   "my-brand",
-		Grade:                     "dangerous",
-		SignKeyID:                 "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		// leave this comment to keep old gofmt happy
+		Model:     "my-model-uc20",
+		BrandID:   "my-brand",
+		Grade:     "dangerous",
+		SignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
 	}
 	r := setupUC20Bootenv(
 		c,

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -2387,10 +2387,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 		GoodRecoverySystems:       []string{"system"},
 		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
 		// leave this comment to keep old gofmt happy
-		Model:     "my-model-uc20",
-		BrandID:   "my-brand",
-		Grade:     "dangerous",
-		SignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		Model:          "my-model-uc20",
+		BrandID:        "my-brand",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
 	}
 	r := setupUC20Bootenv(
 		c,
@@ -2934,7 +2934,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20ModelSignKeyIDPopulated(c *C) {
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	// model's sign key ID has been set
-	c.Check(m2.SignKeyID, Equals, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")
+	c.Check(m2.ModelSignKeyID, Equals, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")
 	c.Check(m2.Model, Equals, "my-model-uc20")
 	c.Check(m2.BrandID, Equals, "my-brand")
 	c.Check(m2.Grade, Equals, "dangerous")

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -784,13 +784,11 @@ func (brs20 *bootState20Model) markSuccessful(update bootStateUpdate) (bootState
 
 	// sign key ID was not being populated in earlier versions of snapd, try
 	// to remedy that
-	if u20.writeModeenv.SignKeyID == "" {
-		newM, err := u20.writeModeenv.Copy()
+	if u20.modeenv.SignKeyID == "" {
 		if err != nil {
 			return nil, err
 		}
-		newM.SignKeyID = brs20.dev.Model().SignKeyID()
-		u20.writeModeenv = newM
+		u20.writeModeenv.SignKeyID = brs20.dev.Model().SignKeyID()
 	}
 	return u20, nil
 }

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -769,3 +769,32 @@ func (brs20 *bootState20RecoverySystem) markSuccessful(update bootStateUpdate) (
 func recoverySystemsBootState(dev Device) *bootState20RecoverySystem {
 	return &bootState20RecoverySystem{dev: dev}
 }
+
+// bootState20Model implements the successfulBootState interface for device
+// model related bookkeeping
+type bootState20Model struct {
+	dev Device
+}
+
+func (brs20 *bootState20Model) markSuccessful(update bootStateUpdate) (bootStateUpdate, error) {
+	u20, err := toBootStateUpdate20(update)
+	if err != nil {
+		return nil, err
+	}
+
+	// sign key ID was not being populated in earlier versions of snapd, try
+	// to remedy that
+	if u20.writeModeenv.SignKeyID == "" {
+		newM, err := u20.writeModeenv.Copy()
+		if err != nil {
+			return nil, err
+		}
+		newM.SignKeyID = brs20.dev.Model().SignKeyID()
+		u20.writeModeenv = newM
+	}
+	return u20, nil
+}
+
+func modelBootState(dev Device) *bootState20Model {
+	return &bootState20Model{dev: dev}
+}

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -784,11 +784,11 @@ func (brs20 *bootState20Model) markSuccessful(update bootStateUpdate) (bootState
 
 	// sign key ID was not being populated in earlier versions of snapd, try
 	// to remedy that
-	if u20.modeenv.SignKeyID == "" {
+	if u20.modeenv.ModelSignKeyID == "" {
 		if err != nil {
 			return nil, err
 		}
-		u20.writeModeenv.SignKeyID = brs20.dev.Model().SignKeyID()
+		u20.writeModeenv.ModelSignKeyID = brs20.dev.Model().SignKeyID()
 	}
 	return u20, nil
 }

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -363,7 +363,7 @@ func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 		BrandID:        model.BrandID(),
 		Model:          model.Model(),
 		Grade:          string(model.Grade()),
-		SignKeyID:      model.SignKeyID(),
+		ModelSignKeyID: model.SignKeyID(),
 	}
 
 	// get the ubuntu-boot bootloader and extract the kernel there

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -363,6 +363,7 @@ func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 		BrandID:        model.BrandID(),
 		Model:          model.Model(),
 		Grade:          string(model.Grade()),
+		SignKeyID:      model.SignKeyID(),
 	}
 
 	// get the ubuntu-boot bootloader and extract the kernel there

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -669,6 +669,7 @@ base=core20_3.snap
 current_kernels=pc-kernel_5.snap
 model=my-brand/my-model-uc20
 grade=dangerous
+sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 current_trusted_boot_assets={"grubx64.efi":["5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"]}
 current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"],"grubx64.efi":["aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"]}
 current_kernel_command_lines=["snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1"]
@@ -1133,6 +1134,7 @@ base=core20_3.snap
 current_kernels=pc-kernel_5.snap
 model=my-brand/my-model-uc20
 grade=dangerous
+sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 current_trusted_boot_assets={"grubx64.efi":["5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"]}
 current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"],"grubx64.efi":["aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"]}
 current_kernel_command_lines=["%v"]
@@ -1386,6 +1388,7 @@ base=core20_3.snap
 current_kernels=arm-kernel_5.snap
 model=my-brand/my-model-uc20
 grade=dangerous
+sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 `)
 }
 

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -669,7 +669,7 @@ base=core20_3.snap
 current_kernels=pc-kernel_5.snap
 model=my-brand/my-model-uc20
 grade=dangerous
-sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+model_sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 current_trusted_boot_assets={"grubx64.efi":["5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"]}
 current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"],"grubx64.efi":["aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"]}
 current_kernel_command_lines=["snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1"]
@@ -1134,7 +1134,7 @@ base=core20_3.snap
 current_kernels=pc-kernel_5.snap
 model=my-brand/my-model-uc20
 grade=dangerous
-sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+model_sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 current_trusted_boot_assets={"grubx64.efi":["5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"]}
 current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"],"grubx64.efi":["aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"]}
 current_kernel_command_lines=["%v"]
@@ -1388,7 +1388,7 @@ base=core20_3.snap
 current_kernels=arm-kernel_5.snap
 model=my-brand/my-model-uc20
 grade=dangerous
-sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+model_sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 `)
 }
 

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -59,9 +59,12 @@ type Modeenv struct {
 	TryBase             string   `key:"try_base"`
 	BaseStatus          string   `key:"base_status"`
 	CurrentKernels      []string `key:"current_kernels"`
-	Model               string   `key:"model"`
-	BrandID             string   `key:"model,secondary"`
-	Grade               string   `key:"grade"`
+	// Model, BrandID, Grade, SignKeyID describe the properties of current
+	// device model.
+	Model     string `key:"model"`
+	BrandID   string `key:"model,secondary"`
+	Grade     string `key:"grade"`
+	SignKeyID string `key:"sign_key_id"`
 	// BootFlags is the set of boot flags. Whether this applies for the current
 	// or next boot is not indicated in the modeenv. When the modeenv is read in
 	// the initramfs these flags apply to the current boot and are copied into
@@ -176,6 +179,7 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 	m.Model = bm.model
 	// expect the caller to validate the grade
 	unmarshalModeenvValueFromCfg(cfg, "grade", &m.Grade)
+	unmarshalModeenvValueFromCfg(cfg, "sign_key_id", &m.SignKeyID)
 	unmarshalModeenvValueFromCfg(cfg, "current_trusted_boot_assets", &m.CurrentTrustedBootAssets)
 	unmarshalModeenvValueFromCfg(cfg, "current_trusted_recovery_boot_assets", &m.CurrentTrustedRecoveryBootAssets)
 	unmarshalModeenvValueFromCfg(cfg, "current_kernel_command_lines", &m.CurrentKernelCommandLines)
@@ -274,6 +278,7 @@ func (m *Modeenv) WriteTo(rootdir string) error {
 		marshalModeenvEntryTo(buf, "model", &modeenvModel{brandID: m.BrandID, model: m.Model})
 	}
 	marshalModeenvEntryTo(buf, "grade", m.Grade)
+	marshalModeenvEntryTo(buf, "sign_key_id", m.SignKeyID)
 	marshalModeenvEntryTo(buf, "current_trusted_boot_assets", m.CurrentTrustedBootAssets)
 	marshalModeenvEntryTo(buf, "current_trusted_recovery_boot_assets", m.CurrentTrustedRecoveryBootAssets)
 	marshalModeenvEntryTo(buf, "current_kernel_command_lines", m.CurrentKernelCommandLines)

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -61,16 +61,16 @@ type Modeenv struct {
 	CurrentKernels      []string `key:"current_kernels"`
 	// Model, BrandID, Grade, SignKeyID describe the properties of current
 	// device model.
-	Model     string `key:"model"`
-	BrandID   string `key:"model,secondary"`
-	Grade     string `key:"grade"`
-	SignKeyID string `key:"sign_key_id"`
+	Model          string `key:"model"`
+	BrandID        string `key:"model,secondary"`
+	Grade          string `key:"grade"`
+	ModelSignKeyID string `key:"model_sign_key_id"`
 	// TryModel, TryBrandID, TryGrade, TrySignKeyID describe the properties
 	// of the candidate model.
-	TryModel     string `key:"try_model"`
-	TryBrandID   string `key:"try_model,secondary"`
-	TryGrade     string `key:"try_grade"`
-	TrySignKeyID string `key:"try_sign_key_id"`
+	TryModel          string `key:"try_model"`
+	TryBrandID        string `key:"try_model,secondary"`
+	TryGrade          string `key:"try_grade"`
+	TryModelSignKeyID string `key:"try_model_sign_key_id"`
 	// BootFlags is the set of boot flags. Whether this applies for the current
 	// or next boot is not indicated in the modeenv. When the modeenv is read in
 	// the initramfs these flags apply to the current boot and are copied into
@@ -185,13 +185,13 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 	m.Model = bm.model
 	// expect the caller to validate the grade
 	unmarshalModeenvValueFromCfg(cfg, "grade", &m.Grade)
-	unmarshalModeenvValueFromCfg(cfg, "sign_key_id", &m.SignKeyID)
+	unmarshalModeenvValueFromCfg(cfg, "model_sign_key_id", &m.ModelSignKeyID)
 	var tryBm modeenvModel
 	unmarshalModeenvValueFromCfg(cfg, "try_model", &tryBm)
 	m.TryBrandID = tryBm.brandID
 	m.TryModel = tryBm.model
 	unmarshalModeenvValueFromCfg(cfg, "try_grade", &m.TryGrade)
-	unmarshalModeenvValueFromCfg(cfg, "try_sign_key_id", &m.TrySignKeyID)
+	unmarshalModeenvValueFromCfg(cfg, "try_model_sign_key_id", &m.TryModelSignKeyID)
 
 	unmarshalModeenvValueFromCfg(cfg, "current_trusted_boot_assets", &m.CurrentTrustedBootAssets)
 	unmarshalModeenvValueFromCfg(cfg, "current_trusted_recovery_boot_assets", &m.CurrentTrustedRecoveryBootAssets)
@@ -292,7 +292,7 @@ func (m *Modeenv) WriteTo(rootdir string) error {
 	}
 	// TODO: complain when grade or key are unset
 	marshalModeenvEntryTo(buf, "grade", m.Grade)
-	marshalModeenvEntryTo(buf, "sign_key_id", m.SignKeyID)
+	marshalModeenvEntryTo(buf, "model_sign_key_id", m.ModelSignKeyID)
 	if m.TryModel != "" || m.TryBrandID != "" {
 		if m.Model == "" {
 			return fmt.Errorf("internal error: try model is unset")
@@ -303,7 +303,7 @@ func (m *Modeenv) WriteTo(rootdir string) error {
 		marshalModeenvEntryTo(buf, "try_model", &modeenvModel{brandID: m.TryBrandID, model: m.TryModel})
 	}
 	marshalModeenvEntryTo(buf, "try_grade", m.TryGrade)
-	marshalModeenvEntryTo(buf, "try_sign_key_id", m.TrySignKeyID)
+	marshalModeenvEntryTo(buf, "try_model_sign_key_id", m.TryModelSignKeyID)
 	marshalModeenvEntryTo(buf, "current_trusted_boot_assets", m.CurrentTrustedBootAssets)
 	marshalModeenvEntryTo(buf, "current_trusted_recovery_boot_assets", m.CurrentTrustedRecoveryBootAssets)
 	marshalModeenvEntryTo(buf, "current_kernel_command_lines", m.CurrentKernelCommandLines)

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -60,16 +60,16 @@ func (s *modeenvSuite) TestKnownKnown(c *C) {
 		"good_recovery_systems":    true,
 		"boot_flags":               true,
 		// keep this comment to make old go fmt happy
-		"base":            true,
-		"try_base":        true,
-		"base_status":     true,
-		"current_kernels": true,
-		"model":           true,
-		"grade":           true,
-		"sign_key_id":     true,
-		"try_model":       true,
-		"try_grade":       true,
-		"try_sign_key_id": true,
+		"base":                  true,
+		"try_base":              true,
+		"base_status":           true,
+		"current_kernels":       true,
+		"model":                 true,
+		"grade":                 true,
+		"model_sign_key_id":     true,
+		"try_model":             true,
+		"try_grade":             true,
+		"try_model_sign_key_id": true,
 		// keep this comment to make old go fmt happy
 		"current_kernel_command_lines":         true,
 		"current_trusted_boot_assets":          true,
@@ -237,10 +237,10 @@ func (s *modeenvSuite) TestDeepEquals(c *C) {
 		BaseStatus:     "try",
 		CurrentKernels: []string{"k1", "k2"},
 
-		Model:     "model",
-		BrandID:   "brand",
-		Grade:     "secured",
-		SignKeyID: "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn",
+		Model:          "model",
+		BrandID:        "brand",
+		Grade:          "secured",
+		ModelSignKeyID: "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn",
 
 		BootFlags: []string{"foo", "factory"},
 
@@ -266,10 +266,10 @@ func (s *modeenvSuite) TestDeepEquals(c *C) {
 		BaseStatus:     "try",
 		CurrentKernels: []string{"k1", "k2"},
 
-		Model:     "model",
-		BrandID:   "brand",
-		Grade:     "secured",
-		SignKeyID: "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn",
+		Model:          "model",
+		BrandID:        "brand",
+		Grade:          "secured",
+		ModelSignKeyID: "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn",
 
 		BootFlags: []string{"foo", "factory"},
 
@@ -341,7 +341,7 @@ func (s *modeenvSuite) TestDeepEquals(c *C) {
 	modeenv2.GoodRecoverySystems = modeenv2.GoodRecoverySystems[:len(modeenv2.GoodRecoverySystems)-1]
 
 	// change the sign key ID
-	modeenv2.SignKeyID = "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu"
+	modeenv2.ModelSignKeyID = "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu"
 	c.Assert(modeenv1.DeepEqual(modeenv2), Equals, false)
 }
 
@@ -769,10 +769,10 @@ func (s *modeenvSuite) TestModeenvWithModelGradeSignKeyID(c *C) {
 	s.makeMockModeenvFile(c, `mode=run
 model=canonical/ubuntu-core-20-amd64
 grade=dangerous
-sign_key_id=9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+model_sign_key_id=9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 try_model=developer1/testkeys-snapd-secured-core-20-amd64
 try_grade=secured
-try_sign_key_id=EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
+try_model_sign_key_id=EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
 `)
 
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
@@ -780,23 +780,23 @@ try_sign_key_id=EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
 	c.Check(modeenv.Model, Equals, "ubuntu-core-20-amd64")
 	c.Check(modeenv.BrandID, Equals, "canonical")
 	c.Check(modeenv.Grade, Equals, "dangerous")
-	c.Check(modeenv.SignKeyID, Equals, "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn")
+	c.Check(modeenv.ModelSignKeyID, Equals, "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn")
 	// candidate model
 	c.Check(modeenv.TryModel, Equals, "testkeys-snapd-secured-core-20-amd64")
 	c.Check(modeenv.TryBrandID, Equals, "developer1")
 	c.Check(modeenv.TryGrade, Equals, "secured")
-	c.Check(modeenv.TrySignKeyID, Equals, "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu")
+	c.Check(modeenv.TryModelSignKeyID, Equals, "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu")
 
 	// change some model data now
 	modeenv.Model = "testkeys-snapd-signed-core-20-amd64"
 	modeenv.BrandID = "developer1"
 	modeenv.Grade = "signed"
-	modeenv.SignKeyID = "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu"
+	modeenv.ModelSignKeyID = "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu"
 
 	modeenv.TryModel = "bar"
 	modeenv.TryBrandID = "foo"
 	modeenv.TryGrade = "dangerous"
-	modeenv.TrySignKeyID = "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn"
+	modeenv.TryModelSignKeyID = "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn"
 
 	// and write it
 	c.Assert(modeenv.Write(), IsNil)
@@ -804,9 +804,9 @@ try_sign_key_id=EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, `mode=run
 model=developer1/testkeys-snapd-signed-core-20-amd64
 grade=signed
-sign_key_id=EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
+model_sign_key_id=EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
 try_model=foo/bar
 try_grade=dangerous
-try_sign_key_id=9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+try_model_sign_key_id=9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 `)
 }

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -67,6 +67,9 @@ func (s *modeenvSuite) TestKnownKnown(c *C) {
 		"model":           true,
 		"grade":           true,
 		"sign_key_id":     true,
+		"try_model":       true,
+		"try_grade":       true,
+		"try_sign_key_id": true,
 		// keep this comment to make old go fmt happy
 		"current_kernel_command_lines":         true,
 		"current_trusted_boot_assets":          true,
@@ -767,6 +770,9 @@ func (s *modeenvSuite) TestModeenvWithModelGradeSignKeyID(c *C) {
 model=canonical/ubuntu-core-20-amd64
 grade=dangerous
 sign_key_id=9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+try_model=developer1/testkeys-snapd-secured-core-20-amd64
+try_grade=secured
+try_sign_key_id=EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
 `)
 
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
@@ -775,12 +781,23 @@ sign_key_id=9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 	c.Check(modeenv.BrandID, Equals, "canonical")
 	c.Check(modeenv.Grade, Equals, "dangerous")
 	c.Check(modeenv.SignKeyID, Equals, "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn")
+	// candidate model
+	c.Check(modeenv.TryModel, Equals, "testkeys-snapd-secured-core-20-amd64")
+	c.Check(modeenv.TryBrandID, Equals, "developer1")
+	c.Check(modeenv.TryGrade, Equals, "secured")
+	c.Check(modeenv.TrySignKeyID, Equals, "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu")
 
 	// change some model data now
 	modeenv.Model = "testkeys-snapd-signed-core-20-amd64"
 	modeenv.BrandID = "developer1"
 	modeenv.Grade = "signed"
 	modeenv.SignKeyID = "EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu"
+
+	modeenv.TryModel = "bar"
+	modeenv.TryBrandID = "foo"
+	modeenv.TryGrade = "dangerous"
+	modeenv.TrySignKeyID = "9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn"
+
 	// and write it
 	c.Assert(modeenv.Write(), IsNil)
 
@@ -788,5 +805,8 @@ sign_key_id=9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 model=developer1/testkeys-snapd-signed-core-20-amd64
 grade=signed
 sign_key_id=EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
+try_model=foo/bar
+try_grade=dangerous
+try_sign_key_id=9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 `)
 }


### PR DESCRIPTION
A preparatory PR for further remodel work. Improve tracking of current model in the modeenv by adding all properties that are measured by secboot (model, brand, sign-key-id, and implicit series which is fixed now). Add fields that will describe the candidate model.