### PR TITLE
o/snapstate: remove refreshed snap from snaps-hold in snapstate.doInstall

### DIFF
--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -251,8 +251,8 @@ func ProceedWithRefresh(st *state.State, gatingSnap string) error {
 }
 
 // resetGatingForRefreshed resets gating information by removing refreshedSnaps
-// (they are not held anymore). This should be called for all successfully
-// refreshed snaps.
+// (they are not held anymore). This should be called for snaps about to be
+// refreshed.
 func resetGatingForRefreshed(st *state.State, refreshedSnaps ...string) error {
 	gating, err := refreshGating(st)
 	if err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1320,18 +1320,6 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		snapst.LastRefreshTime = &now
 	}
 
-	tr := config.NewTransaction(st)
-	gateAutoRefreshHook, err := features.Flag(tr, features.GateAutoRefreshHook)
-	if err != nil && !config.IsNoOption(err) {
-		return err
-	}
-	if gateAutoRefreshHook {
-		// If this snap was held, then remove it from snaps-hold.
-		if err := resetGatingForRefreshed(st, snapsup.InstanceName()); err != nil {
-			return err
-		}
-	}
-
 	if cand.SnapID != "" {
 		// write the auxiliary store info
 		aux := &auxStoreInfo{

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1320,6 +1320,18 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		snapst.LastRefreshTime = &now
 	}
 
+	tr := config.NewTransaction(st)
+	gateAutoRefreshHook, err := features.Flag(tr, features.GateAutoRefreshHook)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	if gateAutoRefreshHook {
+		// If this snap was held, then remove it from snaps-hold.
+		if err := resetGatingForRefreshed(st, snapsup.InstanceName()); err != nil {
+			return err
+		}
+	}
+
 	if cand.SnapID != "" {
 		// write the auxiliary store info
 		aux := &auxStoreInfo{

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1113,10 +1113,8 @@ func (s *snapmgrTestSuite) TestUpdateResetsHoldState(c *C) {
 		"other-snap": true,
 	})
 
-	chg := s.state.NewChange("refresh", "refresh a snap")
-	ts, err := snapstate.Update(s.state, "some-snap", nil, s.user.ID, snapstate.Flags{})
+	_, err = snapstate.Update(s.state, "some-snap", nil, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
-	chg.AddAll(ts)
 
 	// and it is not held anymore (but other-snap still is)
 	held, err = snapstate.HeldSnaps(s.state)


### PR DESCRIPTION
Remove installed snap from "snaps-hold" state so it's no longer held.