### PR TITLE
boot: fix model inconsistency check in modeenv, extend unit tests

### DIFF
--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -293,11 +293,11 @@ func (m *Modeenv) WriteTo(rootdir string) error {
 	// TODO: complain when grade or key are unset
 	marshalModeenvEntryTo(buf, "grade", m.Grade)
 	marshalModeenvEntryTo(buf, "model_sign_key_id", m.ModelSignKeyID)
-	if m.TryModel != "" || m.TryBrandID != "" {
-		if m.Model == "" {
+	if m.TryModel != "" || m.TryGrade != "" {
+		if m.TryModel == "" {
 			return fmt.Errorf("internal error: try model is unset")
 		}
-		if m.BrandID == "" {
+		if m.TryBrandID == "" {
 			return fmt.Errorf("internal error: try brand is unset")
 		}
 		marshalModeenvEntryTo(buf, "try_model", &modeenvModel{brandID: m.TryBrandID, model: m.TryModel})

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -566,6 +566,33 @@ func (s *modeenvSuite) TestWriteFreshError(c *C) {
 	c.Assert(err, ErrorMatches, `internal error: must use WriteTo with modeenv not read from disk`)
 }
 
+func (s *modeenvSuite) TestWriteIncompleteModelBrand(c *C) {
+	modeenv := &boot.Modeenv{
+		Mode:  "run",
+		Grade: "dangerous",
+	}
+
+	err := modeenv.WriteTo(s.tmpdir)
+	c.Assert(err, ErrorMatches, `internal error: model is unset`)
+
+	modeenv.Model = "bar"
+	err = modeenv.WriteTo(s.tmpdir)
+	c.Assert(err, ErrorMatches, `internal error: brand is unset`)
+
+	modeenv.BrandID = "foo"
+	modeenv.TryGrade = "dangerous"
+	err = modeenv.WriteTo(s.tmpdir)
+	c.Assert(err, ErrorMatches, `internal error: try model is unset`)
+
+	modeenv.TryModel = "bar"
+	err = modeenv.WriteTo(s.tmpdir)
+	c.Assert(err, ErrorMatches, `internal error: try brand is unset`)
+
+	modeenv.TryBrandID = "foo"
+	err = modeenv.WriteTo(s.tmpdir)
+	c.Assert(err, IsNil)
+}
+
 func (s *modeenvSuite) TestWriteToNonExistingFull(c *C) {
 	c.Assert(s.mockModeenvPath, testutil.FileAbsent)
 


### PR DESCRIPTION
A small bug landed with #10377. The checks for try model data inside modeenv were not consistent with the existing checks for current model. 
Also added some unit tests to cover consistency checks as suggested in https://github.com/snapcore/snapd/pull/10377#pullrequestreview-681679483