### PR TITLE
many: introduce Store.SnapExists and use it in /v2/accessories/themes

### DIFF
--- a/daemon/api_themes.go
+++ b/daemon/api_themes.go
@@ -35,7 +35,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -135,16 +135,17 @@ func collectThemeStatusForPrefix(ctx context.Context, theStore snapstate.StoreSe
 		}
 		status[theme] = themeUnavailable
 		for _, name := range themePackageCandidates(prefix, theme) {
-			var info *snap.Info
+			var ch *channel.Channel
 			var err error
-			if info, err = theStore.SnapInfo(ctx, store.SnapSpec{Name: name}, user); err == store.ErrSnapNotFound {
+			if _, ch, err = theStore.SnapExists(ctx, store.SnapSpec{Name: name}, user); err == store.ErrSnapNotFound {
 				continue
 			} else if err != nil {
 				return err
 			}
 			// Only mark the theme as available if it has
-			// been published to the stable channel.
-			if info.Channel == "stable" {
+			// been published to a stable channel
+			// (latest or default track).
+			if ch.Risk == "stable" {
 				status[theme] = themeAvailable
 				candidateSnaps[name] = true
 				break

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http/httptest"
 
 	. "gopkg.in/check.v1"
@@ -34,6 +35,8 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -52,12 +55,16 @@ func (s *themesSuite) SetUpTest(c *C) {
 	s.err = store.ErrSnapNotFound
 }
 
-func (s *themesSuite) SnapInfo(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
+func (s *themesSuite) SnapExists(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (naming.SnapRef, *channel.Channel, error) {
 	s.pokeStateLock()
 	if info := s.available[spec.Name]; info != nil {
-		return info, nil
+		ch, err := channel.Parse(info.Channel, "")
+		if err != nil {
+			panic(fmt.Sprintf("bad Info Channel: %v", err))
+		}
+		return info, &ch, nil
 	}
-	return nil, s.err
+	return nil, nil, s.err
 }
 
 func (s *themesSuite) daemon(c *C) *daemon.Daemon {

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -32,6 +32,8 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/timings"
 )
@@ -41,6 +43,7 @@ type StoreService interface {
 	EnsureDeviceSession() (*auth.DeviceState, error)
 
 	SnapInfo(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
+	SnapExists(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (naming.SnapRef, *channel.Channel, error)
 	Find(ctx context.Context, search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 
 	SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error)

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -26,6 +26,8 @@ import (
 
 	"github.com/snapcore/snapd/jsonutil/safejson"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -150,6 +152,26 @@ func infoFromStoreInfo(si *storeInfo) (*snap.Info, error) {
 	}
 
 	return info, nil
+}
+
+func minimalFromStoreInfo(si *storeInfo) (naming.SnapRef, *channel.Channel, error) {
+	if len(si.ChannelMap) == 0 {
+		// if a snap has no released revisions, it _could_ be returned
+		// (currently no, but spec is purposely ambiguous)
+		// we treat it as a 'not found' for now at least
+		return nil, nil, ErrSnapNotFound
+	}
+
+	snapRef := naming.NewSnapRef(si.Name, si.SnapID)
+	first := si.ChannelMap[0].Channel
+	ch := channel.Channel{
+		Architecture: first.Architecture,
+		Name:         first.Name,
+		Track:        first.Track,
+		Risk:         first.Risk,
+	}
+	ch = ch.Clean()
+	return snapRef, &ch, nil
 }
 
 // copy non-zero fields from src to dst

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -29,6 +29,8 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -47,6 +49,10 @@ func (Store) EnsureDeviceSession() (*auth.DeviceState, error) {
 
 func (Store) SnapInfo(context.Context, store.SnapSpec, *auth.UserState) (*snap.Info, error) {
 	panic("Store.SnapInfo not expected")
+}
+
+func (Store) SnapExists(context.Context, store.SnapSpec, *auth.UserState) (naming.SnapRef, *channel.Channel, error) {
+	panic("Store.SnapExists not expected")
 }
 
 func (Store) Find(context.Context, *store.Search, *auth.UserState) ([]*snap.Info, error) {


### PR DESCRIPTION
Try to minimize the amount of data requested from the store when just mostly checking for a snap existence.
