### PR TITLE
overlord: fix imports ordering (according to gci)

### DIFF
--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2020 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -33,8 +33,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/sha3"
-
-	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -2408,15 +2406,15 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsLocalOnlyFailed(c *C)
 	c.Assert(err, IsNil)
 
 	// store key already present
-	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), check.IsNil)
-	c.Assert(assertstate.Add(st, s.dev1Acct), check.IsNil)
-	c.Assert(assertstate.Add(st, s.dev1AcctKey), check.IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
 	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
-	c.Assert(assertstate.Add(st, vsetAs1), check.IsNil)
+	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
 	vsetAs2 := s.validationSetAssert(c, "baz", "3", "1")
-	c.Assert(assertstate.Add(st, vsetAs2), check.IsNil)
+	c.Assert(assertstate.Add(st, vsetAs2), IsNil)
 
 	// vset2 present and updated in the store
 	vsetAs2_2 := s.validationSetAssert(c, "baz", "3", "2")
@@ -2479,14 +2477,14 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorLocalFallbackForPin
 
 	// have a model and the store assertion available
 	storeAs := s.setupModelAndStore(c)
-	c.Assert(s.storeSigning.Add(storeAs), check.IsNil)
-	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), check.IsNil)
-	c.Assert(assertstate.Add(st, s.dev1Acct), check.IsNil)
-	c.Assert(assertstate.Add(st, s.dev1AcctKey), check.IsNil)
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
 	vsetAs := s.validationSetAssert(c, "bar", "1", "1")
-	c.Assert(assertstate.Add(st, vsetAs), check.IsNil)
+	c.Assert(assertstate.Add(st, vsetAs), IsNil)
 
 	opts := assertstate.ResolveOptions{AllowLocalFallback: true}
 	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0, &opts)
@@ -2503,18 +2501,18 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorPinnedRefreshedFrom
 
 	// have a model and the store assertion available
 	storeAs := s.setupModelAndStore(c)
-	c.Assert(s.storeSigning.Add(storeAs), check.IsNil)
-	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), check.IsNil)
-	c.Assert(assertstate.Add(st, s.dev1Acct), check.IsNil)
-	c.Assert(assertstate.Add(st, s.dev1AcctKey), check.IsNil)
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
 	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
-	c.Assert(assertstate.Add(st, vsetAs1), check.IsNil)
+	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
 
 	// newer revision available in the store
 	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2")
-	c.Assert(s.storeSigning.Add(vsetAs2), check.IsNil)
+	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0, nil)
 	c.Assert(err, IsNil)
@@ -2531,18 +2529,18 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorUnpinnedRefreshedFr
 
 	// have a model and the store assertion available
 	storeAs := s.setupModelAndStore(c)
-	c.Assert(s.storeSigning.Add(storeAs), check.IsNil)
-	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), check.IsNil)
-	c.Assert(assertstate.Add(st, s.dev1Acct), check.IsNil)
-	c.Assert(assertstate.Add(st, s.dev1AcctKey), check.IsNil)
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
 	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
-	c.Assert(assertstate.Add(st, vsetAs1), check.IsNil)
+	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
 
 	// newer assertion available in the store
 	vsetAs2 := s.validationSetAssert(c, "bar", "3", "1")
-	c.Assert(s.storeSigning.Add(vsetAs2), check.IsNil)
+	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0, nil)
 	c.Assert(err, IsNil)
@@ -2559,8 +2557,8 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorUnpinnedNotFound(c 
 
 	// have a model and the store assertion available
 	storeAs := s.setupModelAndStore(c)
-	c.Assert(s.storeSigning.Add(storeAs), check.IsNil)
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
 
 	_, _, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0, nil)
-	c.Assert(err, check.ErrorMatches, fmt.Sprintf(`cannot fetch and resolve assertions:\n - validation-set/16/%s/bar: validation-set assertion not found.*`, s.dev1Acct.AccountID()))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot fetch and resolve assertions:\n - validation-set/16/%s/bar: validation-set assertion not found.*`, s.dev1Acct.AccountID()))
 }

--- a/overlord/hookstate/context_test.go
+++ b/overlord/hookstate/context_test.go
@@ -20,9 +20,9 @@
 package hookstate
 
 import (
-	. "gopkg.in/check.v1"
-
 	"encoding/json"
+
+	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -20,6 +20,10 @@
 package ctlcmd_test
 
 import (
+	"strings"
+
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -28,10 +32,6 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
-
-	"strings"
-
-	. "gopkg.in/check.v1"
 )
 
 type getSuite struct {

--- a/overlord/hookstate/ctlcmd/is_connected_test.go
+++ b/overlord/hookstate/ctlcmd/is_connected_test.go
@@ -22,6 +22,8 @@ package ctlcmd_test
 import (
 	"fmt"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
@@ -31,8 +33,6 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
-
-	. "gopkg.in/check.v1"
 )
 
 type isConnectedSuite struct {

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -22,6 +22,8 @@ package ctlcmd_test
 import (
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
@@ -30,8 +32,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
-
-	. "gopkg.in/check.v1"
 )
 
 type refreshSuite struct {

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
@@ -30,8 +32,6 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
-
-	. "gopkg.in/check.v1"
 )
 
 type setSuite struct {

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -22,10 +22,11 @@ package ctlcmd
 import (
 	"fmt"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/strutil"
-	"gopkg.in/yaml.v2"
 )
 
 type systemModeCommand struct {

--- a/overlord/hookstate/ctlcmd/system_mode_test.go
+++ b/overlord/hookstate/ctlcmd/system_mode_test.go
@@ -22,6 +22,8 @@ package ctlcmd_test
 import (
 	"fmt"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
@@ -30,8 +32,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
-
-	. "gopkg.in/check.v1"
 )
 
 type systemModeSuite struct {

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -22,14 +22,14 @@ package ctlcmd_test
 import (
 	"strings"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
-
-	. "gopkg.in/check.v1"
 )
 
 type unsetSuite struct {

--- a/overlord/hookstate/hooktest/handler_test.go
+++ b/overlord/hookstate/hooktest/handler_test.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
-
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 )
 
 func Test(t *testing.T) { TestingT(t) }

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -26,6 +26,8 @@ import (
 	"path/filepath"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -42,8 +44,6 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
-
-	. "gopkg.in/check.v1"
 )
 
 type hotplugSuite struct {

--- a/overlord/ifacestate/implicit_test.go
+++ b/overlord/ifacestate/implicit_test.go
@@ -20,13 +20,13 @@
 package ifacestate_test
 
 import (
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-
-	. "gopkg.in/check.v1"
 )
 
 type implicitSuite struct{}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -35,7 +35,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/cmdstate"
 	"github.com/snapcore/snapd/overlord/configstate"

--- a/overlord/servicestate/service_control.go
+++ b/overlord/servicestate/service_control.go
@@ -22,12 +22,12 @@ package servicestate
 import (
 	"fmt"
 
+	tomb "gopkg.in/tomb.v2"
+
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/wrappers"
-
-	tomb "gopkg.in/tomb.v2"
 )
 
 // ServiceAction encapsulates a single service-related action (such as starting,

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -27,6 +27,8 @@ import (
 	"path/filepath"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -44,8 +46,6 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
-
-	. "gopkg.in/check.v1"
 )
 
 type autoRefreshGatingStore struct {

--- a/overlord/snapstate/backend/aliases_test.go
+++ b/overlord/snapstate/backend/aliases_test.go
@@ -27,7 +27,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
-
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 )
 

--- a/overlord/snapstate/backend/backend_test.go
+++ b/overlord/snapstate/backend/backend_test.go
@@ -24,11 +24,10 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snap/squashfs"
-
-	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/testutil"
 )
 

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -31,12 +31,11 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
-
-	"github.com/snapcore/snapd/overlord/snapstate/backend"
 )
 
 type copydataSuite struct {

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -47,8 +48,6 @@ import (
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 	"github.com/snapcore/snapd/wrappers"
-
-	"github.com/snapcore/snapd/overlord/snapstate/backend"
 )
 
 type linkSuiteCommon struct {

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -27,10 +27,9 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-
-	"github.com/snapcore/snapd/overlord/snapstate/backend"
 )
 
 type snapdataSuite struct {

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
@@ -36,9 +38,6 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/testutil"
-
-	"github.com/snapcore/snapd/overlord/snapstate"
-	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 )
 
 type checkSnapSuite struct {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -34,6 +34,9 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
+
+	// So it registers Configure.
+	_ "github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
@@ -46,9 +49,6 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
-
-	// So it registers Configure.
-	_ "github.com/snapcore/snapd/overlord/configstate"
 )
 
 func verifyInstallTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.State) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -44,6 +44,9 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
+
+	// So it registers Configure.
+	_ "github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
@@ -59,9 +62,6 @@ import (
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timeutil"
-
-	// So it registers Configure.
-	_ "github.com/snapcore/snapd/overlord/configstate"
 )
 
 func TestSnapManager(t *testing.T) { TestingT(t) }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -34,6 +34,9 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
+
+	// So it registers Configure.
+	_ "github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -44,9 +47,6 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
-
-	// So it registers Configure.
-	_ "github.com/snapcore/snapd/overlord/configstate"
 )
 
 func verifyUpdateTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.State) {

--- a/overlord/state/change_test.go
+++ b/overlord/state/change_test.go
@@ -26,9 +26,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/snapcore/snapd/overlord/state"
-
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/state"
 )
 
 type changeSuite struct{}

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 
 	"github.com/snapcore/snapd/logger"
-
 	"github.com/snapcore/snapd/overlord/state"
 )
 


### PR DESCRIPTION
assertstate_test.go was importing go-check both as check
and with . ??, this confused gci, I had to clean that up manually

