### PR TITLE
tests/lib/snaps/test-snapd-policy-app-consumer: remove dsp-control interface

### DIFF
--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -116,9 +116,6 @@ apps:
   docker-support:
     command: bin/run
     plugs: [ docker-support ]
-  dsp-control:
-    command: bin/run
-    plugs: [ dsp-control ]
   fpga:
     command: bin/run
     plugs: [ fpga ]


### PR DESCRIPTION
This interface only existed temporarily during the lifetime of
snapcore/snapd#10110.