### PR TITLE
tests/many: change all cloud-init passwords for ubuntu to use plain_test_passwd

### DIFF
--- a/tests/lib/cloud-init-seeds/attacker-user/user-data
+++ b/tests/lib/cloud-init-seeds/attacker-user/user-data
@@ -4,4 +4,4 @@ users:
   - name: attacker-user
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: false
-    passwd: $6$rounds=4096$PCrfo.ggdf4ubP$REjyaoY2tUWH2vjFJjvLs3rDxVTszGR9P7mhH9sHb2MsELfc53uV/v15jDDOJU/9WInfjjTKJPlD5URhX5Mix0
+    plain_text_passwd: "ubuntu"

--- a/tests/lib/cloud-init-seeds/normal-user/user-data
+++ b/tests/lib/cloud-init-seeds/normal-user/user-data
@@ -4,4 +4,4 @@ users:
   - name: normal-user
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: false
-    passwd: $6$rounds=4096$PCrfo.ggdf4ubP$REjyaoY2tUWH2vjFJjvLs3rDxVTszGR9P7mhH9sHb2MsELfc53uV/v15jDDOJU/9WInfjjTKJPlD5URhX5Mix0
+    plain_text_passwd: "ubuntu"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -778,8 +778,7 @@ users:
   - name: user1
     sudo: "ALL=(ALL) NOPASSWD:ALL"
     lock_passwd: false
-    # passwd is just "ubuntu"
-    passwd: "$6$rounds=4096$PCrfo.ggdf4ubP$REjyaoY2tUWH2vjFJjvLs3rDxVTszGR9P7mhH9sHb2MsELfc53uV/v15jDDOJU/9WInfjjTKJPlD5URhX5Mix0"
+    plain_text_passwd: "ubuntu"
 EOF
 }
 

--- a/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
+++ b/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
@@ -13,7 +13,7 @@ environment:
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
 
   # don't use cloud-init to create the user, we manually use cloud-init via
-  # NESTED_PARAM_CD in the test setup
+  # --param-cdrom in the test setup
   NESTED_USE_CLOUD_INIT: false
 
   # sign all the snaps we build for the image with fakestore


### PR DESCRIPTION
This is easier to read and tell what the password is, and since these are all
for test user accounts on walled off VM's the obscurity is more annoying than
anything else.

Also fix a typo