### PR TITLE
tests: fix debug section for postrm-purge test

### DIFF
--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -60,7 +60,7 @@ restore: |
     fi
 
 debug: |
-    systemctl --no-legend --full | grep -E 'snap\..*\.(service|timer|socket|slice)'
+    systemctl --no-legend --full | grep -E 'snap\..*\.(service|timer|socket|slice)' || true
 
 execute: |
     systemctl --no-legend --full | MATCH 'snap\..*\.(service|timer|socket|slice)'


### PR DESCRIPTION
The grep could not match any snap service due to them weres removed. So
the debug section will fail as in the following example:

2021-06-14 11:24:27 Error debugging
google:arch-linux-64:tests/main/postrm-purge (jun141057-913226) :

-----
+ grep -E 'snap\..*\.(service|timer|socket|slice)'
+ systemctl --no-legend --full
-----

If the debug fail for the test, then the debug each is not executed and
we can't see usefull information.
