### PR TITLE
tests: fix restore for security-dev-input-event-denied test

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -33,6 +33,11 @@ reset_classic() {
             exit 1
             ;;
     esac
+
+    # purge may have removed udev rules, retrigger device events
+    udevadm trigger
+    udevadm settle
+
     # purge has removed units, reload the state now
     systemctl daemon-reload
 
@@ -155,6 +160,10 @@ reset_all_snap() {
             fi
         done
     fi
+
+    # purge may have removed udev rules, retrigger device events
+    udevadm trigger
+    udevadm settle
 
     # ensure we have the same state as initially
     systemctl stop snapd.service snapd.socket

--- a/tests/main/security-dev-input-event-denied/task.yaml
+++ b/tests/main/security-dev-input-event-denied/task.yaml
@@ -19,12 +19,6 @@ prepare: |
     echo "Given the test-snapd-event snap is installed"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-event
 
-restore: |
-    echo "Removing the snap and requesting kernel events"
-    snap remove test-snapd-event
-    udevadm settle
-    udevadm trigger
-
 execute: |
     if [ -z "$(find /dev/input/by-path -name '*-event-kbd')" ]; then
         if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ]; then

--- a/tests/main/security-dev-input-event-denied/task.yaml
+++ b/tests/main/security-dev-input-event-denied/task.yaml
@@ -19,6 +19,12 @@ prepare: |
     echo "Given the test-snapd-event snap is installed"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-event
 
+restore: |
+    echo "Removing the snap and requesting kernel events"
+    snap remove test-snapd-event
+    udevadm settle
+    udevadm trigger
+
 execute: |
     if [ -z "$(find /dev/input/by-path -name '*-event-kbd')" ]; then
         if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ]; then


### PR DESCRIPTION
Force group events are processed after uninstall the test-snapd-event snap


To check the test is fixed, run:
> spread -debug -repeat 20 google:ubuntu-core-18-64:tests/main/security-dev-input-event-denied