### PR TITLE
asserts,interfaces,snap: fix imports order (according to gci)

### DIFF
--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -24,8 +24,12 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	_ "crypto/sha256" // be explicit about supporting SHA256
-	_ "crypto/sha512" // be explicit about needing SHA512
+
+	// be explicit about supporting SHA256
+	_ "crypto/sha256"
+
+	// be explicit about needing SHA512
+	_ "crypto/sha512"
 	"encoding/base64"
 	"fmt"
 	"io"

--- a/asserts/fetcher_test.go
+++ b/asserts/fetcher_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/sha3"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -28,9 +28,8 @@ import (
 	"os"
 	"time"
 
-	. "gopkg.in/check.v1"
-
 	"golang.org/x/crypto/openpgp/packet"
+	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"

--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/snap"
-
 	"github.com/snapcore/snapd/testutil"
 )
 

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -25,7 +25,8 @@ import (
 	"fmt"
 	"time"
 
-	_ "golang.org/x/crypto/sha3" // expected for digests
+	// expected for digests
+	_ "golang.org/x/crypto/sha3"
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/sha3"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"

--- a/asserts/store_asserts_test.go
+++ b/asserts/store_asserts_test.go
@@ -24,9 +24,10 @@ import (
 	"strings"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
-	. "gopkg.in/check.v1"
 )
 
 var _ = Suite(&storeSuite{})

--- a/asserts/sysdb/sysdb_test.go
+++ b/asserts/sysdb/sysdb_test.go
@@ -27,11 +27,10 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
-
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/dirs"
 )
 
 func TestSysDB(t *testing.T) { TestingT(t) }

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-
 	"github.com/snapcore/snapd/testutil"
 )
 

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -24,6 +24,8 @@ import (
 	"reflect"
 	"strings"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -36,8 +38,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-
-	. "gopkg.in/check.v1"
 )
 
 type AllSuite struct{}

--- a/interfaces/builtin/display_control_test.go
+++ b/interfaces/builtin/display_control_test.go
@@ -20,11 +20,11 @@
 package builtin_test
 
 import (
-	. "gopkg.in/check.v1"
-
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"

--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -20,13 +20,13 @@
 package builtin
 
 import (
+	"strings"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
-
-	"strings"
 )
 
 const waylandSummary = `allows access to compositors supporting wayland protocol`

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -26,8 +26,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
-	// TODO: eliminate this import and just use interfaces import directly
-	. "github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/snap"
@@ -62,7 +60,7 @@ func (s *CoreSuite) TestValidateDBusBusName(c *C) {
 		"a-a.b", "a-a.b-b.c-c", "a-a.b-b1", "a-a.b-b1.c-c2d-d",
 	}
 	for _, name := range validNames {
-		err := ValidateDBusBusName(name)
+		err := interfaces.ValidateDBusBusName(name)
 		c.Assert(err, IsNil)
 	}
 
@@ -87,12 +85,12 @@ func (s *CoreSuite) TestValidateDBusBusName(c *C) {
 		"a.b.",
 	}
 	for _, name := range invalidNames {
-		err := ValidateDBusBusName(name)
+		err := interfaces.ValidateDBusBusName(name)
 		c.Assert(err, ErrorMatches, `invalid DBus bus name: ".*"`)
 	}
 
 	// must not be empty
-	err := ValidateDBusBusName("")
+	err := interfaces.ValidateDBusBusName("")
 	c.Assert(err, ErrorMatches, `DBus bus name must be set`)
 
 	// must not exceed maximum length
@@ -103,48 +101,48 @@ func (s *CoreSuite) TestValidateDBusBusName(c *C) {
 	// make it look otherwise valid (a.bbbb...)
 	longName[0] = 'a'
 	longName[1] = '.'
-	err = ValidateDBusBusName(string(longName))
+	err = interfaces.ValidateDBusBusName(string(longName))
 	c.Assert(err, ErrorMatches, `DBus bus name is too long \(must be <= 255\)`)
 }
 
 // PlugRef.String works as expected
 func (s *CoreSuite) TestPlugRefString(c *C) {
-	ref := PlugRef{Snap: "snap", Name: "plug"}
+	ref := interfaces.PlugRef{Snap: "snap", Name: "plug"}
 	c.Check(ref.String(), Equals, "snap:plug")
-	refPtr := &PlugRef{Snap: "snap", Name: "plug"}
+	refPtr := &interfaces.PlugRef{Snap: "snap", Name: "plug"}
 	c.Check(refPtr.String(), Equals, "snap:plug")
 }
 
 // SlotRef.String works as expected
 func (s *CoreSuite) TestSlotRefString(c *C) {
-	ref := SlotRef{Snap: "snap", Name: "slot"}
+	ref := interfaces.SlotRef{Snap: "snap", Name: "slot"}
 	c.Check(ref.String(), Equals, "snap:slot")
-	refPtr := &SlotRef{Snap: "snap", Name: "slot"}
+	refPtr := &interfaces.SlotRef{Snap: "snap", Name: "slot"}
 	c.Check(refPtr.String(), Equals, "snap:slot")
 }
 
 // ConnRef.ID works as expected
 func (s *CoreSuite) TestConnRefID(c *C) {
-	conn := &ConnRef{
-		PlugRef: PlugRef{Snap: "consumer", Name: "plug"},
-		SlotRef: SlotRef{Snap: "producer", Name: "slot"},
+	conn := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"},
 	}
 	c.Check(conn.ID(), Equals, "consumer:plug producer:slot")
 }
 
 // ParseConnRef works as expected
 func (s *CoreSuite) TestParseConnRef(c *C) {
-	ref, err := ParseConnRef("consumer:plug producer:slot")
+	ref, err := interfaces.ParseConnRef("consumer:plug producer:slot")
 	c.Assert(err, IsNil)
-	c.Check(ref, DeepEquals, &ConnRef{
-		PlugRef: PlugRef{Snap: "consumer", Name: "plug"},
-		SlotRef: SlotRef{Snap: "producer", Name: "slot"},
+	c.Check(ref, DeepEquals, &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"},
 	})
-	_, err = ParseConnRef("garbage")
+	_, err = interfaces.ParseConnRef("garbage")
 	c.Assert(err, ErrorMatches, `malformed connection identifier: "garbage"`)
-	_, err = ParseConnRef("snap:plug:garbage snap:slot")
+	_, err = interfaces.ParseConnRef("snap:plug:garbage snap:slot")
 	c.Assert(err, ErrorMatches, `malformed connection identifier: ".*"`)
-	_, err = ParseConnRef("snap:plug snap:slot:garbage")
+	_, err = interfaces.ParseConnRef("snap:plug snap:slot:garbage")
 	c.Assert(err, ErrorMatches, `malformed connection identifier: ".*"`)
 }
 
@@ -249,14 +247,14 @@ plugs:
     interface: iface
 `, nil)
 	plug := info.Plugs["plug"]
-	c.Assert(BeforePreparePlug(&ifacetest.TestInterface{
+	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
 		InterfaceName: "iface",
 	}, plug), IsNil)
-	c.Assert(BeforePreparePlug(&ifacetest.TestInterface{
+	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
 		InterfaceName:             "iface",
 		BeforePreparePlugCallback: func(plug *snap.PlugInfo) error { return fmt.Errorf("broken") },
 	}, plug), ErrorMatches, "broken")
-	c.Assert(BeforePreparePlug(&ifacetest.TestInterface{
+	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
 		InterfaceName: "other",
 	}, plug), ErrorMatches, `cannot sanitize plug "snap:plug" \(interface "iface"\) using interface "other"`)
 }
@@ -270,14 +268,14 @@ slots:
     interface: iface
 `, nil)
 	slot := info.Slots["slot"]
-	c.Assert(BeforePrepareSlot(&ifacetest.TestInterface{
+	c.Assert(interfaces.BeforePrepareSlot(&ifacetest.TestInterface{
 		InterfaceName: "iface",
 	}, slot), IsNil)
-	c.Assert(BeforePrepareSlot(&ifacetest.TestInterface{
+	c.Assert(interfaces.BeforePrepareSlot(&ifacetest.TestInterface{
 		InterfaceName:             "iface",
 		BeforePrepareSlotCallback: func(slot *snap.SlotInfo) error { return fmt.Errorf("broken") },
 	}, slot), ErrorMatches, "broken")
-	c.Assert(BeforePrepareSlot(&ifacetest.TestInterface{
+	c.Assert(interfaces.BeforePrepareSlot(&ifacetest.TestInterface{
 		InterfaceName: "other",
 	}, slot), ErrorMatches, `cannot sanitize slot "snap:slot" \(interface "iface"\) using interface "other"`)
 }

--- a/interfaces/dbus/dbus_test.go
+++ b/interfaces/dbus/dbus_test.go
@@ -22,9 +22,9 @@ package dbus_test
 import (
 	"testing"
 
-	"github.com/snapcore/snapd/interfaces/dbus"
-
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/dbus"
 )
 
 func Test(t *testing.T) {

--- a/interfaces/hotplug/udevadm_test.go
+++ b/interfaces/hotplug/udevadm_test.go
@@ -20,9 +20,9 @@
 package hotplug
 
 import (
-	"github.com/snapcore/snapd/testutil"
-
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 type udevadmSuite struct {

--- a/interfaces/policy/helpers_test.go
+++ b/interfaces/policy/helpers_test.go
@@ -20,12 +20,12 @@
 package policy_test
 
 import (
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/policy"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-
-	. "gopkg.in/check.v1"
 )
 
 type helpersSuite struct{}

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/systemd"
 	"github.com/snapcore/snapd/snap"
-
 	sysd "github.com/snapcore/snapd/systemd"
 )
 

--- a/snap/container_test.go
+++ b/snap/container_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
-
 	"github.com/snapcore/snapd/testutil"
 )
 

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -21,10 +21,11 @@ package snap_test
 
 import (
 	"encoding/json"
-	"github.com/snapcore/snapd/snap"
 
 	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
+
+	"github.com/snapcore/snapd/snap"
 )
 
 type epochSuite struct{}

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -28,9 +28,8 @@ import (
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
-	"github.com/snapcore/snapd/timeout"
-
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timeout"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/snap/naming/validate_test.go
+++ b/snap/naming/validate_test.go
@@ -25,7 +25,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/snap/naming"
-
 	"github.com/snapcore/snapd/testutil"
 )
 

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -33,13 +33,13 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+
+	// for SanitizePlugsSlots
+	_ "github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/pack"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/testutil"
-
-	// for SanitizePlugsSlots
-	_ "github.com/snapcore/snapd/interfaces/builtin"
 )
 
 func Test(t *testing.T) { TestingT(t) }

--- a/snap/revision_test.go
+++ b/snap/revision_test.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 
 	. "gopkg.in/check.v1"
-
 	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/snap"

--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -28,11 +28,11 @@ import (
 	"testing"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
-
-	. "gopkg.in/check.v1"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/snap/types_test.go
+++ b/snap/types_test.go
@@ -22,9 +22,9 @@ package snap
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 )
 
 type typeSuite struct{}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -28,7 +28,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	. "github.com/snapcore/snapd/snap"
-
 	"github.com/snapcore/snapd/testutil"
 )
 


### PR DESCRIPTION
interfaces/core_test.go had an extra "." import of interfaces that needed manual fixing.