### PR TITLE
interfaces: remove leftover debug print

### DIFF
--- a/interfaces/builtin/dsp.go
+++ b/interfaces/builtin/dsp.go
@@ -20,8 +20,6 @@
 package builtin
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
@@ -79,7 +77,6 @@ func (iface *dspInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 
 	var flavor string
 	_ = slot.Attr("flavor", &flavor)
-	fmt.Println("slot flavor", flavor)
 	switch flavor {
 	// only supported flavor for now
 	case "ambarella":


### PR DESCRIPTION
It seems we accidentally merged the dsp interface with a debug printf left intact. Let's remove it.