### PR TITLE
cmd: fix imports order (according to gci)

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -37,14 +37,14 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+
+	// to set sysconfig.ApplyFilesystemOnlyDefaultsImpl
+	_ "github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/sysconfig"
-
-	// to set sysconfig.ApplyFilesystemOnlyDefaultsImpl
-	_ "github.com/snapcore/snapd/overlord/configstate/configcore"
 )
 
 func init() {

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -24,12 +24,12 @@ import (
 	"path/filepath"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	main "github.com/snapcore/snapd/cmd/snap-bootstrap"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
-
-	. "gopkg.in/check.v1"
 )
 
 type doSystemdMountSuite struct {

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -29,14 +29,13 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	snapExec "github.com/snapcore/snapd/cmd/snap-exec"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
-
-	snapExec "github.com/snapcore/snapd/cmd/snap-exec"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
 	"testing"
 
 	"github.com/jessevdk/go-flags"

--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -180,9 +180,7 @@ import (
 	"strings"
 	"syscall"
 
-	// FIXME: we want github.com/seccomp/libseccomp-golang but that
-	// will not work with trusty because libseccomp-golang checks
-	// for the seccomp version and errors if it find one < 2.2.0
+	// FIXME: we want github.com/seccomp/libseccomp-golang but that will not work with trusty because libseccomp-golang checks for the seccomp version and errors if it find one < 2.2.0
 	"github.com/mvo5/libseccomp-golang"
 
 	"github.com/snapcore/snapd/arch"

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -30,9 +30,8 @@ import (
 	"strings"
 	"testing"
 
-	. "gopkg.in/check.v1"
-
 	"github.com/mvo5/libseccomp-golang"
+	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/arch"
 	main "github.com/snapcore/snapd/cmd/snap-seccomp"

--- a/cmd/snap-seccomp/versioninfo_test.go
+++ b/cmd/snap-seccomp/versioninfo_test.go
@@ -23,9 +23,8 @@ import (
 	"fmt"
 	"strings"
 
-	. "gopkg.in/check.v1"
-
 	"github.com/mvo5/libseccomp-golang"
+	. "gopkg.in/check.v1"
 
 	main "github.com/snapcore/snapd/cmd/snap-seccomp"
 	"github.com/snapcore/snapd/osutil"

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
-
-	"github.com/jessevdk/go-flags"
 )
 
 var shortBuyHelp = i18n.G("Buy a snap")

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -24,10 +24,10 @@ import (
 	"regexp"
 	"sort"
 
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
-
-	"github.com/jessevdk/go-flags"
 )
 
 var shortChangesHelp = i18n.G("List system changes")

--- a/cmd/snap/cmd_confinement.go
+++ b/cmd/snap/cmd_confinement.go
@@ -20,11 +20,11 @@
 package main
 
 import (
-	"github.com/snapcore/snapd/i18n"
-
 	"fmt"
 
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
 )
 
 var shortConfinementHelp = i18n.G("Print the confinement mode the system operates in")

--- a/cmd/snap/cmd_connect.go
+++ b/cmd/snap/cmd_connect.go
@@ -20,9 +20,9 @@
 package main
 
 import (
-	"github.com/snapcore/snapd/i18n"
-
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
 )
 
 type cmdConnect struct {

--- a/cmd/snap/cmd_disconnect.go
+++ b/cmd/snap/cmd_disconnect.go
@@ -22,10 +22,10 @@ package main
 import (
 	"fmt"
 
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
-
-	"github.com/jessevdk/go-flags"
 )
 
 type cmdDisconnect struct {

--- a/cmd/snap/cmd_interface.go
+++ b/cmd/snap/cmd_interface.go
@@ -26,10 +26,10 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
-
-	"github.com/jessevdk/go-flags"
 )
 
 type cmdInterface struct {

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -22,10 +22,10 @@ package main
 import (
 	"fmt"
 
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
-
-	"github.com/jessevdk/go-flags"
 )
 
 type cmdInterfaces struct {

--- a/cmd/snap/cmd_keys.go
+++ b/cmd/snap/cmd_keys.go
@@ -23,10 +23,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/i18n"
-
-	"github.com/jessevdk/go-flags"
 )
 
 type cmdKeys struct {

--- a/cmd/snap/cmd_known_test.go
+++ b/cmd/snap/cmd_known_test.go
@@ -29,9 +29,8 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
-	"github.com/snapcore/snapd/store"
-
 	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/store"
 )
 
 // acquire example data via:

--- a/cmd/snap/cmd_managed.go
+++ b/cmd/snap/cmd_managed.go
@@ -22,9 +22,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/i18n"
-
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
 )
 
 var shortIsManagedHelp = i18n.G("Print whether the system is managed")

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -23,16 +23,15 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/jessevdk/go-flags"
 	"golang.org/x/xerrors"
 
-	"github.com/jessevdk/go-flags"
-
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/pack"
 
 	// for SanitizePlugsSlots
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/pack"
 )
 
 type packCmd struct {

--- a/cmd/snap/cmd_prefer.go
+++ b/cmd/snap/cmd_prefer.go
@@ -20,9 +20,9 @@
 package main
 
 import (
-	"github.com/snapcore/snapd/i18n"
-
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
 )
 
 type cmdPrefer struct {

--- a/cmd/snap/cmd_remove_user.go
+++ b/cmd/snap/cmd_remove_user.go
@@ -22,10 +22,10 @@ package main
 import (
 	"fmt"
 
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
-
-	"github.com/jessevdk/go-flags"
 )
 
 var shortRemoveUserHelp = i18n.G("Remove a local system user")

--- a/cmd/snap/cmd_sign_build.go
+++ b/cmd/snap/cmd_sign_build.go
@@ -23,9 +23,10 @@ import (
 	"fmt"
 	"time"
 
-	_ "golang.org/x/crypto/sha3" // expected for digests
-
 	"github.com/jessevdk/go-flags"
+
+	// expected for digests
+	_ "golang.org/x/crypto/sha3"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/i18n"

--- a/cmd/snap/cmd_sign_test.go
+++ b/cmd/snap/cmd_sign_test.go
@@ -26,7 +26,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
-
 	snap "github.com/snapcore/snapd/cmd/snap"
 )
 

--- a/cmd/snap/cmd_unalias.go
+++ b/cmd/snap/cmd_unalias.go
@@ -20,9 +20,9 @@
 package main
 
 import (
-	"github.com/snapcore/snapd/i18n"
-
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
 )
 
 type cmdUnalias struct {

--- a/cmd/snap/cmd_whoami.go
+++ b/cmd/snap/cmd_whoami.go
@@ -22,9 +22,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/i18n"
-
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
 )
 
 var shortWhoAmIHelp = i18n.G("Show the email the user is logged in with")

--- a/cmd/snap/cmd_whoami_test.go
+++ b/cmd/snap/cmd_whoami_test.go
@@ -22,11 +22,10 @@ package main_test
 import (
 	"net/http"
 
-	"github.com/snapcore/snapd/osutil"
-
 	. "gopkg.in/check.v1"
 
 	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/osutil"
 )
 
 func (s *SnapSuite) TestWhoamiLoggedInUser(c *C) {

--- a/cmd/snap/color_test.go
+++ b/cmd/snap/color_test.go
@@ -22,8 +22,6 @@ package main_test
 import (
 	"os"
 	"runtime"
-	// "fmt"
-	// "net/http"
 
 	"gopkg.in/check.v1"
 

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -30,11 +30,9 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"golang.org/x/xerrors"
-
 	"github.com/jessevdk/go-flags"
-
 	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/xerrors"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -35,14 +35,13 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 	. "gopkg.in/check.v1"
 
+	snap "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/testutil"
-
-	snap "github.com/snapcore/snapd/cmd/snap"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/cmd/snapctl/main_test.go
+++ b/cmd/snapctl/main_test.go
@@ -30,9 +30,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/snapcore/snapd/client"
-
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/client"
 )
 
 func TestT(t *testing.T) { TestingT(t) }

--- a/cmd/snapd/main_test.go
+++ b/cmd/snapd/main_test.go
@@ -30,14 +30,13 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
+	snapd "github.com/snapcore/snapd/cmd/snapd"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/testutil"
-
-	snapd "github.com/snapcore/snapd/cmd/snapd"
 )
 
 // Hook up check.v1 into the "go test" runner


### PR DESCRIPTION
gci needed cmd/snap-seccomp/main.go import comment to made one long line otherwise it keeps only the last line :(

cmd/snap/color_test.go needed some manual cleanup of commented out imports

