### PR TITLE
o/hookstate: dedicated handler for gate-auto-refresh hook

### DIFF
--- a/cmd/snaplock/runinhibit/inhibit.go
+++ b/cmd/snaplock/runinhibit/inhibit.go
@@ -50,6 +50,8 @@ type Hint string
 const (
 	// HintNotInhibited is used when "snap run" is not inhibited.
 	HintNotInhibited Hint = ""
+	// HintInhibitedGateRefresh represents inhibition of a "snap run" while gate-auto-refresh hook is run.
+	HintInhibitedGateRefresh Hint = "gate-refresh"
 	// HintInhibitedForRefresh represents inhibition of a "snap run" while a refresh change is being performed.
 	HintInhibitedForRefresh Hint = "refresh"
 )

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -246,6 +246,7 @@ func (h *gateAutoRefreshHookHandler) Error(hookErr error) (ignoreHookErr bool, e
 		// this handler, in both cases hookErr won't be logged by hook manager.
 		h.context.Errorf("error: %v (while handling previous hook error: %v)", err, hookErr)
 		if _, ok := err.(*snapstate.HoldError); ok {
+			// TODO: consider delaying for another hour.
 			return true, nil
 		}
 		// anything other than HoldError becomes an error of the handler.

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -21,8 +21,12 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"time"
 
+	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -70,6 +74,141 @@ func SetupPreRefreshHook(st *state.State, snapName string) *state.Task {
 	task := HookTask(st, summary, hooksup, nil)
 
 	return task
+}
+
+type gateAutoRefreshHookHandler struct {
+	context *Context
+	refreshAppAwareness bool
+}
+
+func (h *gateAutoRefreshHookHandler) Before() error {
+	st := h.context.State()
+	st.Lock()
+	defer st.Unlock()
+
+	tr := config.NewTransaction(st)
+	experimentalRefreshAppAwareness, err := features.Flag(tr, features.RefreshAppAwareness)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	if !experimentalRefreshAppAwareness {
+		return nil
+	}
+
+	h.refreshAppAwareness = true
+	if err := runinhibit.LockWithHint(h.context.InstanceName(), runinhibit.HintInhibitedGateRefresh); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *gateAutoRefreshHookHandler) Done() error {
+	ctx := h.context
+	st := ctx.State()
+	ctx.Lock()
+	defer ctx.Unlock()
+
+	snapName := h.context.InstanceName()
+
+	var action snapstate.GateAutoRefreshAction
+	a := ctx.Cached("action")
+	if a == nil {
+		// action is unset if the gate-auto-refresh hook exits 0 without
+		// invoking --hold/--proceed; this means proceed (except for respecting
+		// refresh inhibit).
+		if err := snapstate.ProceedWithRefresh(st, snapName); err != nil {
+			return err
+		}
+		action = snapstate.GateAutoRefreshProceed
+	} else {
+		var ok bool
+		action, ok = a.(snapstate.GateAutoRefreshAction)
+		if !ok {
+			return fmt.Errorf("internal error: unexpected action type %T", a)
+		}
+	}
+
+	if !h.refreshAppAwareness {
+		return nil
+	}
+
+	// action is set if snapctl refresh --hold/--proceed was called from the hook.
+	switch action {
+	case snapstate.GateAutoRefreshHold:
+		if err := runinhibit.Unlock(snapName); err != nil {
+			return fmt.Errorf("cannot release inhibit lock of snap %s: %v", snapName, err)
+		}
+	case snapstate.GateAutoRefreshProceed:
+		// we have HintInhibitedGateRefresh lock already when running the hook,
+		// change it to HintInhibitedForRefresh.
+		if err := runinhibit.LockWithHint(snapName, runinhibit.HintInhibitedForRefresh); err != nil {
+			return fmt.Errorf("cannot set inhibit lock for snap %s: %v", snapName, err)
+		}
+	default:
+		return fmt.Errorf("internal error: unexpected action %v", action)
+	}
+
+	return nil
+}
+
+// Error handles gate-auto-refresh hook failure; it assumes hold.
+func (h *gateAutoRefreshHookHandler) Error(hookErr error) error {
+	ctx := h.context
+	st := h.context.State()
+	ctx.Lock()
+	defer ctx.Unlock()
+
+	snapName := h.context.InstanceName()
+
+	// the refresh is going to be held, release runinhibit lock.
+	if h.refreshAppAwareness {
+		if err := runinhibit.Unlock(snapName); err != nil {
+			return fmt.Errorf("cannot release inhibit lock of snap %s: %v", snapName, err)
+		}
+	}
+
+	if a := ctx.Cached("action"); a != nil {
+		action, ok := a.(snapstate.GateAutoRefreshAction)
+		if !ok {
+			return fmt.Errorf("internal error: unexpected action type %T", a)
+		}
+		// nothing to do if the hook already requested hold.
+		if action == snapstate.GateAutoRefreshHold {
+			return nil
+		}
+	}
+
+	// the hook didn't request --hold, or it was --proceed. since the hook
+	// errored out, assume hold.
+
+	var affecting []string
+	if err := ctx.Get("affecting-snaps", &affecting); err != nil {
+		return fmt.Errorf("internal error: cannot get affecting-snaps")
+	}
+
+	// no duration specified, use maximum allowed for this gating snap.
+	var holdDuration time.Duration
+	if err := snapstate.HoldRefresh(st, snapName, holdDuration, affecting...); err != nil {
+		// note, previous hook error (hookErr) is going to be logged by hookmgr
+		// after this Error() handler, so only log the new error.
+		h.context.Errorf("error: %v (while handling previous hook error)", err)
+		if _, ok := err.(*snapstate.HoldError); ok {
+			return nil
+		}
+		// anything other than HoldError becomes an error of the handler.
+		return err
+	}
+
+	// TODO: consider assigning a special health state for the snap.
+
+	return nil
+}
+
+func NewGateAutoRefreshHookHandler(context *Context) *gateAutoRefreshHookHandler {
+	return &gateAutoRefreshHookHandler{
+		context: context,
+	}
 }
 
 func SetupGateAutoRefreshHook(st *state.State, snapName string, base, restart bool, affectingSnaps map[string]bool) *state.Task {
@@ -126,10 +265,13 @@ func setupHooks(hookMgr *HookManager) {
 	handlerGenerator := func(context *Context) Handler {
 		return &snapHookHandler{}
 	}
+	gateAutoRefreshHandlerGenerator := func(context *Context) Handler {
+		return NewGateAutoRefreshHookHandler(context)
+	}
 
 	hookMgr.Register(regexp.MustCompile("^install$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^post-refresh$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^pre-refresh$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^remove$"), handlerGenerator)
-	hookMgr.Register(regexp.MustCompile("^gate-auto-refresh$"), handlerGenerator)
+	hookMgr.Register(regexp.MustCompile("^gate-auto-refresh$"), gateAutoRefreshHandlerGenerator)
 }

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -209,7 +209,7 @@ func (h *gateAutoRefreshHookHandler) Error(hookErr error) (ignoreHookErr bool, e
 			return false, err
 		}
 		if err := lock.Lock(); err != nil {
-			return false,  err
+			return false, err
 		}
 		defer lock.Unlock()
 

--- a/overlord/hookstate/hooks_test.go
+++ b/overlord/hookstate/hooks_test.go
@@ -187,6 +187,59 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookHoldUnlocksRuninhibit(
 
 // Test that if gate-auto-refresh hook does nothing, the hook handler
 // assumes --proceed.
+func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookDefaultInhibited(c *C) {
+	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
+		// sanity, refresh is inhibited for snap-a.
+		hint, err := runinhibit.IsLocked("snap-a")
+		c.Assert(err, IsNil)
+		c.Check(hint, Equals, runinhibit.HintInhibitedGateRefresh)
+
+		// this hook does nothing (action not set to proceed/hold).
+		c.Check(ctx.HookName(), Equals, "gate-auto-refresh")
+		c.Check(ctx.InstanceName(), Equals, "snap-a")
+		return nil, nil
+	}
+	restore := hookstate.MockRunHook(hookInvoke)
+	defer restore()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// pretend that snap-a is initially held by itself.
+	c.Assert(snapstate.HoldRefresh(st, "snap-a", 0, "snap-a"), IsNil)
+	// sanity
+	checkIsHeld(c, st, "snap-a", "snap-a")
+
+	// enable refresh-app-awareness
+	tr := config.NewTransaction(st)
+	tr.Set("core", "experimental.refresh-app-awareness", true)
+	tr.Commit()
+
+	// pretend refresh of snap-a is inhibited
+	c.Assert(runinhibit.LockWithHint("snap-a", runinhibit.HintInhibitedForRefresh), IsNil)
+
+	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a", false, false, map[string]bool{"snap-a": true})
+	change := st.NewChange("kind", "summary")
+	change.AddTask(task)
+
+	st.Unlock()
+	s.settle(c)
+	st.Lock()
+
+	c.Assert(change.Err(), IsNil)
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	checkIsNotHeld(c, st, "snap-a")
+
+	// refresh for snap-a is still inhibited (old hint is restored).
+	hint, err := runinhibit.IsLocked("snap-a")
+	c.Assert(err, IsNil)
+	c.Check(hint, Equals, runinhibit.HintInhibitedForRefresh)
+}
+
+// Test that if gate-auto-refresh hook does nothing, the hook handler
+// assumes --proceed.
 func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookDefaultProceed(c *C) {
 	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
 		// no runinhibit because the refresh-app-awareness feature is disabled.

--- a/overlord/hookstate/hooks_test.go
+++ b/overlord/hookstate/hooks_test.go
@@ -1,0 +1,324 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hookstate_test
+
+import (
+	"fmt"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"gopkg.in/tomb.v2"
+)
+
+const snapaYaml = `name: snap-a
+version: 1
+hooks:
+    gate-auto-refresh:
+`
+
+const snapbYaml = `name: snap-b
+version: 1
+`
+
+type gateAutoRefreshHookSuite struct {
+	baseHookManagerSuite
+}
+
+var _ = Suite(&gateAutoRefreshHookSuite{})
+
+func (s *gateAutoRefreshHookSuite) SetUpTest(c *C) {
+	s.commonSetUpTest(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si := &snap.SideInfo{RealName: "snap-a", SnapID: "snap-a-id1", Revision: snap.R(1)}
+	snaptest.MockSnap(c, snapaYaml, si)
+	snapstate.Set(s.state, "snap-a", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  snap.R(1),
+	})
+
+	si2 := &snap.SideInfo{RealName: "snap-b", SnapID: "snap-b-id1", Revision: snap.R(1)}
+	snaptest.MockSnap(c, snapbYaml, si2)
+	snapstate.Set(s.state, "snap-b", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si2},
+		Current:  snap.R(1),
+	})
+}
+
+func (s *gateAutoRefreshHookSuite) TearDownTest(c *C) {
+	s.commonTearDownTest(c)
+}
+
+func (s *gateAutoRefreshHookSuite) settle(c *C) {
+	err := s.o.Settle(5 * time.Second)
+	c.Assert(err, IsNil)
+}
+
+func checkIsHeld(c *C, st *state.State, heldSnap, gatingSnap string) {
+	var held map[string]map[string]interface{}
+	c.Assert(st.Get("snaps-hold", &held), IsNil)
+	c.Check(held[heldSnap][gatingSnap], NotNil)
+}
+
+func checkIsNotHeld(c *C, st *state.State, heldSnap string) {
+	var held map[string]map[string]interface{}
+	c.Assert(st.Get("snaps-hold", &held), IsNil)
+	c.Check(held[heldSnap], IsNil)
+}
+
+func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookProceedRuninhibitLock(c *C) {
+	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
+		c.Check(ctx.HookName(), Equals, "gate-auto-refresh")
+		c.Check(ctx.InstanceName(), Equals, "snap-a")
+		ctx.Lock()
+		defer ctx.Unlock()
+
+		// check that runinhibit hint has been set by Before() hook handler.
+		hint, err := runinhibit.IsLocked("snap-a")
+		c.Assert(err, IsNil)
+		c.Check(hint, Equals, runinhibit.HintInhibitedGateRefresh)
+
+		// action is normally set via snapctl; pretend it is --proceed.
+		action := snapstate.GateAutoRefreshProceed
+		ctx.Cache("action", action)
+		return nil, nil
+	}
+	restore := hookstate.MockRunHook(hookInvoke)
+	defer restore()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// enable refresh-app-awareness
+	tr := config.NewTransaction(st)
+	tr.Set("core", "experimental.refresh-app-awareness", true)
+	tr.Commit()
+
+	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a", false, false, map[string]bool{"snap-b": true})
+	change := st.NewChange("kind", "summary")
+	change.AddTask(task)
+
+	st.Unlock()
+	s.settle(c)
+	st.Lock()
+
+	c.Assert(change.Err(), IsNil)
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	hint, err := runinhibit.IsLocked("snap-a")
+	c.Assert(err, IsNil)
+	c.Check(hint, Equals, runinhibit.HintInhibitedForRefresh)
+}
+
+func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookHoldUnlocksRuninhibit(c *C) {
+	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
+		c.Check(ctx.HookName(), Equals, "gate-auto-refresh")
+		c.Check(ctx.InstanceName(), Equals, "snap-a")
+		ctx.Lock()
+		defer ctx.Unlock()
+
+		// check that runinhibit hint has been set by Before() hook handler.
+		hint, err := runinhibit.IsLocked("snap-a")
+		c.Assert(err, IsNil)
+		c.Check(hint, Equals, runinhibit.HintInhibitedGateRefresh)
+
+		// action is normally set via snapctl; pretend it is --hold.
+		action := snapstate.GateAutoRefreshHold
+		ctx.Cache("action", action)
+		return nil, nil
+	}
+	restore := hookstate.MockRunHook(hookInvoke)
+	defer restore()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// enable refresh-app-awareness
+	tr := config.NewTransaction(st)
+	tr.Set("core", "experimental.refresh-app-awareness", true)
+	tr.Commit()
+
+	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a", false, false, map[string]bool{"snap-b": true})
+	change := st.NewChange("kind", "summary")
+	change.AddTask(task)
+
+	st.Unlock()
+	s.settle(c)
+	st.Lock()
+
+	c.Assert(change.Err(), IsNil)
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	hint, err := runinhibit.IsLocked("snap-a")
+	c.Assert(err, IsNil)
+	c.Check(hint, Equals, runinhibit.HintNotInhibited)
+}
+
+// Test that if gate-auto-refresh hook does nothing, the hook handler
+// assumes --proceed.
+func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookDefaultProceed(c *C) {
+	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
+		// no runinhibit because the refresh-app-awareness feature is disabled.
+		hint, err := runinhibit.IsLocked("snap-a")
+		c.Assert(err, IsNil)
+		c.Check(hint, Equals, runinhibit.HintNotInhibited)
+
+		// this hook does nothing (action not set to proceed/hold).
+		c.Check(ctx.HookName(), Equals, "gate-auto-refresh")
+		c.Check(ctx.InstanceName(), Equals, "snap-a")
+		return nil, nil
+	}
+	restore := hookstate.MockRunHook(hookInvoke)
+	defer restore()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// pretend that snap-b is initially held by snap-a.
+	c.Assert(snapstate.HoldRefresh(st, "snap-a", 0, "snap-b"), IsNil)
+	// sanity
+	checkIsHeld(c, st, "snap-b", "snap-a")
+
+	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a", false, false, map[string]bool{"snap-b": true})
+	change := st.NewChange("kind", "summary")
+	change.AddTask(task)
+
+	st.Unlock()
+	s.settle(c)
+	st.Lock()
+
+	c.Assert(change.Err(), IsNil)
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	checkIsNotHeld(c, st, "snap-b")
+
+	// no runinhibit because the refresh-app-awareness feature is disabled.
+	hint, err := runinhibit.IsLocked("snap-a")
+	c.Assert(err, IsNil)
+	c.Check(hint, Equals, runinhibit.HintNotInhibited)
+}
+
+// Test that if gate-auto-refresh hook errors out, the hook handler
+// assumes --hold.
+func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookError(c *C) {
+	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
+		// no runinhibit because the refresh-app-awareness feature is disabled.
+		hint, err := runinhibit.IsLocked("snap-a")
+		c.Assert(err, IsNil)
+		c.Check(hint, Equals, runinhibit.HintNotInhibited)
+
+		// this hook does nothing (action not set to proceed/hold).
+		c.Check(ctx.HookName(), Equals, "gate-auto-refresh")
+		c.Check(ctx.InstanceName(), Equals, "snap-a")
+		return []byte("fail"), fmt.Errorf("boom")
+	}
+	restore := hookstate.MockRunHook(hookInvoke)
+	defer restore()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a", false, false, map[string]bool{"snap-b": true})
+	change := st.NewChange("kind", "summary")
+	change.AddTask(task)
+
+	st.Unlock()
+	s.settle(c)
+	st.Lock()
+
+	c.Assert(change.Err(), ErrorMatches, `cannot perform the following tasks:\n- Run hook gate-auto-refresh of snap "snap-a" \(run hook "gate-auto-refresh": fail\)`)
+	c.Assert(change.Status(), Equals, state.ErrorStatus)
+
+	// and snap-b is now held.
+	checkIsHeld(c, st, "snap-b", "snap-a")
+
+	// no runinhibit because the refresh-app-awareness feature is disabled.
+	hint, err := runinhibit.IsLocked("snap-a")
+	c.Assert(err, IsNil)
+	c.Check(hint, Equals, runinhibit.HintNotInhibited)
+}
+
+func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookErrorHoldErrorLogged(c *C) {
+	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
+		// no runinhibit because the refresh-app-awareness feature is disabled.
+		hint, err := runinhibit.IsLocked("snap-a")
+		c.Assert(err, IsNil)
+		c.Check(hint, Equals, runinhibit.HintNotInhibited)
+
+		// this hook does nothing (action not set to proceed/hold).
+		c.Check(ctx.HookName(), Equals, "gate-auto-refresh")
+		c.Check(ctx.InstanceName(), Equals, "snap-a")
+
+		// simulate failing hook
+		return []byte("fail"), fmt.Errorf("boom")
+	}
+	restore := hookstate.MockRunHook(hookInvoke)
+	defer restore()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a", false, false, map[string]bool{"snap-b": true})
+	change := st.NewChange("kind", "summary")
+	change.AddTask(task)
+
+	// pretend snap-b wasn't updated for a very long time.
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(st, "snap-b", &snapst), IsNil)
+	t := time.Now().Add(-365 * 24 * time.Hour)
+	snapst.LastRefreshTime = &t
+	snapstate.Set(st, "snap-b", &snapst)
+
+	st.Unlock()
+	s.settle(c)
+	st.Lock()
+
+	c.Assert(change.Err(), ErrorMatches, `cannot perform the following tasks:
+- Run hook gate-auto-refresh of snap "snap-a" \(error: cannot hold some snaps:
+ - snap "snap-a" cannot hold snap "snap-b" anymore, maximum refresh postponement exceeded \(while handling previous hook error\)\)
+- Run hook gate-auto-refresh of snap "snap-a" \(run hook \"gate-auto-refresh\": fail\)`)
+	c.Assert(change.Status(), Equals, state.ErrorStatus)
+
+	// and snap-b is not held (due to hold error).
+	var held map[string]map[string]interface{}
+	c.Assert(st.Get("snaps-hold", &held), Equals, state.ErrNoState)
+
+	// no runinhibit because the refresh-app-awareness feature is disabled.
+	hint, err := runinhibit.IsLocked("snap-a")
+	c.Assert(err, IsNil)
+	c.Check(hint, Equals, runinhibit.HintNotInhibited)
+}

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -41,10 +41,10 @@ var gateAutoRefreshHookName = "gate-auto-refresh"
 // gateAutoRefreshAction represents the action executed by
 // snapctl refresh --hold or --proceed and stored in the context of
 // gate-auto-refresh hook.
-type gateAutoRefreshAction int
+type GateAutoRefreshAction int
 
 const (
-	GateAutoRefreshProceed gateAutoRefreshAction = iota
+	GateAutoRefreshProceed GateAutoRefreshAction = iota
 	GateAutoRefreshHold
 )
 


### PR DESCRIPTION
Dedicated handler for gate-auto-refresh hook. The handler implements the default behavior if the hook doesn't call snapctl refresh --hold/--proceed as well as error handling if the hook errors out. It also manipulates runinhibit lock.
