### PR TITLE
many: fix imports order (according to gci)

### DIFF
--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -25,13 +25,14 @@ import (
 	"os"
 	"path/filepath"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/grubenv"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/testutil"
-	. "gopkg.in/check.v1"
 )
 
 type bootFlagsSuite struct {

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -26,13 +26,14 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/xerrors"
+
 	"github.com/snapcore/snapd/bootloader/lkenv"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/snap"
-	"golang.org/x/xerrors"
 )
 
 const (

--- a/client/asserts.go
+++ b/client/asserts.go
@@ -29,7 +29,8 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/snapcore/snapd/asserts" // for parsing
+	// for parsing
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/snap"
 )
 

--- a/client/asserts_test.go
+++ b/client/asserts_test.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 
 	"golang.org/x/xerrors"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"

--- a/client/cohort_test.go
+++ b/client/cohort_test.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 
 	"golang.org/x/xerrors"
-
 	"gopkg.in/check.v1"
 )
 

--- a/client/icons_test.go
+++ b/client/icons_test.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 
 	"golang.org/x/xerrors"
-
 	. "gopkg.in/check.v1"
 )
 

--- a/client/model_test.go
+++ b/client/model_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 
 	"golang.org/x/xerrors"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"

--- a/client/snapctl_test.go
+++ b/client/snapctl_test.go
@@ -24,9 +24,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
-	"github.com/snapcore/snapd/client"
-
 	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/client"
 )
 
 func (cs *clientSuite) TestClientRunSnapctlCallsEndpoint(c *check.C) {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -20,9 +20,8 @@
 package daemon
 
 import (
-	"fmt"
-
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -32,9 +32,8 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/mgo.v2/bson"
-
 	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -29,15 +29,15 @@ import (
 	"syscall"
 	"time"
 
-	// to set sysconfig.ApplyFilesystemOnlyDefaults hook
-	_ "github.com/snapcore/snapd/overlord/configstate/configcore"
-
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil"
+
+	// to set sysconfig.ApplyFilesystemOnlyDefaults hook
+	_ "github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"

--- a/sanity/squashfs.go
+++ b/sanity/squashfs.go
@@ -21,15 +21,14 @@ package sanity
 
 import (
 	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	"compress/gzip"
-	"encoding/base64"
 
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -21,9 +21,8 @@
 package store
 
 import (
-	"reflect"
-
 	"encoding/json"
+	"reflect"
 	"strings"
 
 	. "gopkg.in/check.v1"

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -20,9 +20,8 @@
 package store
 
 import (
-	"io"
-
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"

--- a/sysconfig/gadget_defaults_test.go
+++ b/sysconfig/gadget_defaults_test.go
@@ -29,7 +29,6 @@ import (
 
 	// to set ApplyFilesystemOnlyDefaults hook
 	_ "github.com/snapcore/snapd/overlord/configstate/configcore"
-
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snap/squashfs"

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -38,9 +38,8 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/squashfs"
 	"github.com/snapcore/snapd/sandbox/selinux"
-	"github.com/snapcore/snapd/testutil"
-
 	. "github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type testreporter struct {

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -29,12 +29,12 @@ import (
 	"testing"
 	"text/template"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/systestkeys"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap/snaptest"
-
-	. "gopkg.in/check.v1"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -29,9 +29,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/godbus/dbus"
 	. "gopkg.in/check.v1"
 
-	"github.com/godbus/dbus"
 	"github.com/snapcore/snapd/desktop/notification"
 	"github.com/snapcore/snapd/desktop/notification/notificationtest"
 	"github.com/snapcore/snapd/dirs"

--- a/usersession/userd/launcher_test.go
+++ b/usersession/userd/launcher_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/godbus/dbus"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil/sys"

--- a/usersession/userd/ui/zenity_test.go
+++ b/usersession/userd/ui/zenity_test.go
@@ -20,9 +20,8 @@
 package ui_test
 
 import (
-	"time"
-
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 

--- a/usersession/xdgopenproxy/xdgopenproxy_test.go
+++ b/usersession/xdgopenproxy/xdgopenproxy_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/godbus/dbus"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/usersession/xdgopenproxy"

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -33,14 +33,13 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/snap/quota"
 
-	// imported to ensure actual interfaces are defined,
-	// in production this is guaranteed by ifacestate
+	// imported to ensure actual interfaces are defined (in production this is guaranteed by ifacestate)
 	_ "github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"


### PR DESCRIPTION
had to make the comment in wrappers/services_test.go a one-liner
otherwise half of it is lost

last set of files needing changing (as per current master)
