### PR TITLE
o/hookstate/ctlcmd: do not call ProceedWithRefresh immediately from snapctl

### DIFF
--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -238,14 +238,11 @@ func (c *refreshCommand) proceed() error {
 	ctx := c.context()
 	ctx.Lock()
 	defer ctx.Unlock()
-	st := ctx.State()
 
-	// cache the action so that hook handler can implement default behavior
+	// cache the action, hook handler will trigger proceed logic; we cannot
+	// call snapstate.ProceedWithRefresh() immediately as this would reset
+	// holdState, allowing the snap to --hold with fresh duration limit.
 	ctx.Cache("action", snapstate.GateAutoRefreshProceed)
-
-	if err := snapstate.ProceedWithRefresh(st, ctx.InstanceName()); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -200,8 +200,7 @@ version: 1
 	c.Assert(action, NotNil)
 	c.Check(action, Equals, snapstate.GateAutoRefreshProceed)
 
-	// and it is still held anymore (for hook handler to execute actual
-	// proceed logic).
+	// and it is still held (for hook handler to execute actual proceed logic).
 	gating = nil
 	c.Assert(s.st.Get("snaps-hold", &gating), IsNil)
 	c.Check(gating["foo"]["snap1"], NotNil)

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -200,10 +200,11 @@ version: 1
 	c.Assert(action, NotNil)
 	c.Check(action, Equals, snapstate.GateAutoRefreshProceed)
 
-	// and it is not held anymore
+	// and it is still held anymore (for hook handler to execute actual
+	// proceed logic).
 	gating = nil
 	c.Assert(s.st.Get("snaps-hold", &gating), IsNil)
-	c.Check(gating["foo"]["snap1"], IsNil)
+	c.Check(gating["foo"]["snap1"], NotNil)
 }
 
 func (s *refreshSuite) TestRefreshFromUnsupportedHook(c *C) {


### PR DESCRIPTION
Do not call ProceedWithRefresh immediately from snapctl as this would allow snap to abuse it to reset its holdState and then follow it with --hold, bypassing existing hold start time (and hold duration limit). Instead, only cache proceed action on the context - the actual proceed logic will be executed by the hook handler.
