### PR TITLE
o/hookstate/ctlcmd: allow snapctl refresh --pending --proceed syntax.

### DIFF
--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -102,7 +102,9 @@ func (c *refreshCommand) Execute(args []string) error {
 		return fmt.Errorf("cannot use --proceed and --hold together")
 	}
 
-	if c.Pending {
+	// --pending --proceed is a verbose way of saying --proceed, so only
+	// print pending if proceed wasn't requested.
+	if c.Pending && !c.Proceed {
 		if err := c.printPendingInfo(); err != nil {
 			return err
 		}

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -205,9 +205,10 @@ version: 1
 	c.Assert(s.st.Get("snaps-hold", &gating), IsNil)
 	c.Check(gating["foo"]["snap1"], NotNil)
 
+	mockContext.Cache("action", nil)
+
 	mockContext.Unlock()
 	defer mockContext.Lock()
-	mockContext.Cache("action", nil)
 
 	// refresh --pending --proceed is the same as just saying --proceed.
 	stdout, stderr, err = ctlcmd.Run(mockContext, []string{"refresh", "--proceed"}, 0)

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -177,13 +177,16 @@ version: 1
 `)
 
 	// pretend snap foo is held initially
-	c.Assert(snapstate.HoldRefresh(s.st, "snap1", 0, "foo"), IsNil)
+	c.Check(snapstate.HoldRefresh(s.st, "snap1", 0, "foo"), IsNil)
+	s.st.Unlock()
+
 	// sanity check
 	var gating map[string]map[string]interface{}
-	c.Assert(s.st.Get("snaps-hold", &gating), IsNil)
-	c.Check(gating["foo"]["snap1"], NotNil)
-
+	s.st.Lock()
+	snapsHold := s.st.Get("snaps-hold", &gating)
 	s.st.Unlock()
+	c.Assert(snapsHold, IsNil)
+	c.Check(gating["foo"]["snap1"], NotNil)
 
 	mockContext.Lock()
 	mockContext.Set("affecting-snaps", []string{"foo"})

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -204,6 +204,22 @@ version: 1
 	gating = nil
 	c.Assert(s.st.Get("snaps-hold", &gating), IsNil)
 	c.Check(gating["foo"]["snap1"], NotNil)
+
+	mockContext.Unlock()
+	defer mockContext.Lock()
+	mockContext.Cache("action", nil)
+
+	// refresh --pending --proceed is the same as just saying --proceed.
+	stdout, stderr, err = ctlcmd.Run(mockContext, []string{"refresh", "--proceed"}, 0)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+
+	mockContext.Lock()
+	defer mockContext.Unlock()
+	action = mockContext.Cached("action")
+	c.Assert(action, NotNil)
+	c.Check(action, Equals, snapstate.GateAutoRefreshProceed)
 }
 
 func (s *refreshSuite) TestRefreshFromUnsupportedHook(c *C) {

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -211,7 +211,7 @@ version: 1
 	defer mockContext.Lock()
 
 	// refresh --pending --proceed is the same as just saying --proceed.
-	stdout, stderr, err = ctlcmd.Run(mockContext, []string{"refresh", "--proceed"}, 0)
+	stdout, stderr, err = ctlcmd.Run(mockContext, []string{"refresh", "--pending", "--proceed"}, 0)
 	c.Assert(err, IsNil)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")


### PR DESCRIPTION
`snapctl refresh --pending --proceed` is a verbose way of saying "proceed" and should be allowed per spec.