### PR TITLE
packaging/debian-sid: update snap-seccomp patches for latest master

### DIFF
--- a/packaging/debian-sid/patches/0001-cmd-snap-seccomp-use-upstream-seccomp-package.patch
+++ b/packaging/debian-sid/patches/0001-cmd-snap-seccomp-use-upstream-seccomp-package.patch
@@ -1,4 +1,4 @@
-From cb851cfe883af568e56e50b492579b49869928ab Mon Sep 17 00:00:00 2001
+From b699fd17fa7ec5191901ea116369b1b963b58e14 Mon Sep 17 00:00:00 2001
 From: Zygmunt Krynicki <me@zygoon.pl>
 Date: Thu, 17 Jan 2019 15:48:46 +0200
 Subject: [PATCH 1/9] cmd/snap-seccomp: use upstream seccomp package
@@ -15,45 +15,43 @@ snapd, we need to switch to the regular, non-forked package name.
 Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
 Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>
 ---
- cmd/snap-seccomp/main.go             | 5 +----
+ cmd/snap-seccomp/main.go             | 3 +--
  cmd/snap-seccomp/main_test.go        | 2 +-
  cmd/snap-seccomp/versioninfo.go      | 2 +-
  cmd/snap-seccomp/versioninfo_test.go | 2 +-
- 4 files changed, 4 insertions(+), 7 deletions(-)
+ 4 files changed, 4 insertions(+), 5 deletions(-)
 
-Index: snapd/cmd/snap-seccomp/main.go
-===================================================================
---- snapd.orig/cmd/snap-seccomp/main.go
-+++ snapd/cmd/snap-seccomp/main.go
-@@ -180,10 +180,7 @@ import (
+diff --git a/cmd/snap-seccomp/main.go b/cmd/snap-seccomp/main.go
+index 1f56f5876f62637cd99e3adab177d15fa8a941af..f7b5b8b62b5c511f3710a6bdd23367c0641144ae 100644
+--- a/cmd/snap-seccomp/main.go
++++ b/cmd/snap-seccomp/main.go
+@@ -180,8 +180,7 @@ import (
  	"strings"
  	"syscall"
  
--	// FIXME: we want github.com/seccomp/libseccomp-golang but that
--	// will not work with trusty because libseccomp-golang checks
--	// for the seccomp version and errors if it find one < 2.2.0
+-	// FIXME: we want github.com/seccomp/libseccomp-golang but that will not work with trusty because libseccomp-golang checks for the seccomp version and errors if it find one < 2.2.0
 -	"github.com/mvo5/libseccomp-golang"
 +	"github.com/seccomp/libseccomp-golang"
  
  	"github.com/snapcore/snapd/arch"
  	"github.com/snapcore/snapd/osutil"
-Index: snapd/cmd/snap-seccomp/main_test.go
-===================================================================
---- snapd.orig/cmd/snap-seccomp/main_test.go
-+++ snapd/cmd/snap-seccomp/main_test.go
-@@ -32,7 +32,7 @@ import (
- 
- 	. "gopkg.in/check.v1"
+diff --git a/cmd/snap-seccomp/main_test.go b/cmd/snap-seccomp/main_test.go
+index 90590e5d89901e7298fbfe37c818ff6d6d2c7874..6933649ea743d9422321f772967c8dfe2054c432 100644
+--- a/cmd/snap-seccomp/main_test.go
++++ b/cmd/snap-seccomp/main_test.go
+@@ -30,7 +30,7 @@ import (
+ 	"strings"
+ 	"testing"
  
 -	"github.com/mvo5/libseccomp-golang"
 +	"github.com/seccomp/libseccomp-golang"
+ 	. "gopkg.in/check.v1"
  
  	"github.com/snapcore/snapd/arch"
- 	main "github.com/snapcore/snapd/cmd/snap-seccomp"
-Index: snapd/cmd/snap-seccomp/versioninfo.go
-===================================================================
---- snapd.orig/cmd/snap-seccomp/versioninfo.go
-+++ snapd/cmd/snap-seccomp/versioninfo.go
+diff --git a/cmd/snap-seccomp/versioninfo.go b/cmd/snap-seccomp/versioninfo.go
+index b206d9b8c732d8b116e700f0e343ad4377fb19d2..2ddba5fd0becfbbc1eae1ac92b3711a8e4c69704 100644
+--- a/cmd/snap-seccomp/versioninfo.go
++++ b/cmd/snap-seccomp/versioninfo.go
 @@ -25,7 +25,7 @@ import (
  	"os"
  	"strings"
@@ -63,16 +61,19 @@ Index: snapd/cmd/snap-seccomp/versioninfo.go
  
  	"github.com/snapcore/snapd/cmd/snap-seccomp/syscalls"
  	"github.com/snapcore/snapd/osutil"
-Index: snapd/cmd/snap-seccomp/versioninfo_test.go
-===================================================================
---- snapd.orig/cmd/snap-seccomp/versioninfo_test.go
-+++ snapd/cmd/snap-seccomp/versioninfo_test.go
-@@ -25,7 +25,7 @@ import (
- 
- 	. "gopkg.in/check.v1"
+diff --git a/cmd/snap-seccomp/versioninfo_test.go b/cmd/snap-seccomp/versioninfo_test.go
+index fadfaf10ca4aa2a631f7d8b0a342fde2b2436412..ea20c306c5031bbd6eab912a35070436fc52e74d 100644
+--- a/cmd/snap-seccomp/versioninfo_test.go
++++ b/cmd/snap-seccomp/versioninfo_test.go
+@@ -23,7 +23,7 @@ import (
+ 	"fmt"
+ 	"strings"
  
 -	"github.com/mvo5/libseccomp-golang"
 +	"github.com/seccomp/libseccomp-golang"
+ 	. "gopkg.in/check.v1"
  
  	main "github.com/snapcore/snapd/cmd/snap-seccomp"
- 	"github.com/snapcore/snapd/osutil"
+-- 
+2.32.0
+


### PR DESCRIPTION
Update the patches so that they can be applied on latest master.

