### PR TITLE
spread, tests/main/lxd: no longer manual, switch to latest/stable

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -32,7 +32,10 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     MANAGED_DEVICE: "false"
-    LXD_SNAP_CHANNEL: "latest/candidate"
+    # TODO: since 2021.06.15 the tests/main/lxd test is failing, temporarily use
+    # a stable channel which seems to work, but switch back once the candidate
+    # channel is good again
+    LXD_SNAP_CHANNEL: "latest/stable"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -9,9 +9,6 @@ backends: [-autopkgtest]
 # TODO: enable for ubuntu-21+ once the lxd image is published
 systems: [ubuntu-16*, ubuntu-18*, ubuntu-20*, ubuntu-core-*]
 
-# manual until test failures are fixed.
-manual: true
-
 # Start before anything else as it can take a really long time.
 priority: 1000
 


### PR DESCRIPTION
On 2021.06.15 with LXD 4.15/candidate (rev 20717, latest/candidate at the time)
we've started observing failures related to starting nested LXD containers, with
the following errors:

```
create_inode: failed to create character device /var/snap/lxd/common/lxd/storage-pools/default/containers/my-inner-ubuntu/rootfs/dev/full, because Operation not permitted
create_inode: failed to create character device /var/snap/lxd/common/lxd/storage-pools/default/containers/my-inner-ubuntu/rootfs/dev/mapper/control, because Operation not permitted
create_inode: failed to create character device /var/snap/lxd/common/lxd/storage-pools/default/containers/my-inner-ubuntu/rootfs/dev/null, because Operation not permitted
create_inode: failed to create character device /var/snap/lxd/common/lxd/storage-pools/default/containers/my-inner-ubuntu/rootfs/dev/ptmx, because Operation not permitted
create_inode: failed to create character device /var/snap/lxd/common/lxd/storage-pools/default/containers/my-inner-ubuntu/rootfs/dev/random, because Operation not permitted
create_inode: failed to create character device /var/snap/lxd/common/lxd/storage-pools/default/containers/my-inner-ubuntu/rootfs/dev/tty, because Operation not permitted
create_inode: failed to create character device /var/snap/lxd/common/lxd/storage-pools/default/containers/my-inner-ubuntu/rootfs/dev/urandom, because Operation not permitted
create_inode: failed to create character device /var/snap/lxd/common/lxd/storage-pools/default/containers/my-inner-ubuntu/rootfs/dev/zero, because Operation not permitted.
```

Temporarily switch to latest/stable.
