### PR TITLE
tests: moving nested-state to tests.nested

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -891,10 +891,10 @@ suites:
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb
         prepare-each: |
             tests.backup prepare
-            "$TESTSTOOLS"/nested-state prepare
+            tests.nested prepare
         restore-each: |
-            "$TESTSTOOLS"/nested-state remove-vm
-            "$TESTSTOOLS"/nested-state restore
+            tests.nested remove-vm
+            tests.nested restore
             tests.backup restore
         restore: |
             #shellcheck source=tests/lib/pkgdb.sh
@@ -928,16 +928,16 @@ suites:
             # Install the snapd built
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb
 
-            "$TESTSTOOLS"/nested-state prepare
-            "$TESTSTOOLS"/nested-state build-image classic
+            tests.nested prepare
+            tests.nested build-image classic
         prepare-each: |
             tests.backup prepare
-            "$TESTSTOOLS"/nested-state create-vm classic
+            tests.nested create-vm classic
         restore-each: |
-            "$TESTSTOOLS"/nested-state remove-vm
+            tests.nested remove-vm
             tests.backup restore
         restore: |
-            "$TESTSTOOLS"/nested-state restore
+            tests.nested restore
 
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
@@ -970,16 +970,16 @@ suites:
             # Install the snapd built
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb
 
-            "$TESTSTOOLS"/nested-state prepare
-            "$TESTSTOOLS"/nested-state build-image core
+            tests.nested prepare
+            tests.nested build-image core
         prepare-each: |
             tests.backup prepare
-            "$TESTSTOOLS"/nested-state create-vm core
+            tests.nested create-vm core
         restore-each: |
-            "$TESTSTOOLS"/nested-state remove-vm
+            tests.nested remove-vm
             tests.backup restore
         restore: |
-            "$TESTSTOOLS"/nested-state restore
+            tests.nested restore
 
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh

--- a/spread.yaml
+++ b/spread.yaml
@@ -876,10 +876,6 @@ suites:
         manual: true
         warn-timeout: 10m
         kill-timeout: 60m
-        debug: |
-            #shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB/nested.sh"
-            nested_print_serial_log
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
@@ -914,10 +910,6 @@ suites:
             # Enable secure boot in the nested vm in case it is supported
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-false}")'
         manual: true
-        debug: |
-            #shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB/nested.sh"
-            nested_print_serial_log
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
@@ -956,10 +948,6 @@ suites:
             # Enable secure boot in the nested vm in case it is supported
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-}")'
         manual: true
-        debug: |
-            #shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB/nested.sh"
-            nested_print_serial_log
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh

--- a/spread.yaml
+++ b/spread.yaml
@@ -440,7 +440,7 @@ debug-each: |
                 # add another echo in case the serial log is missing a newline
                 echo
 
-            nested_exec sudo journalctl --no-pager -u snapd || true
+            tests.nested exec "sudo journalctl --no-pager -u snapd" || true
         fi
 
         echo '# journal messages for snapd'

--- a/tests/bin/tests.nested
+++ b/tests/bin/tests.nested
@@ -1,0 +1,1 @@
+../lib/tools/tests.nested

--- a/tests/lib/hotplug.sh
+++ b/tests/lib/hotplug.sh
@@ -29,12 +29,12 @@ hotplug_del_dev2() {
 check_slot_not_present() {
     SLOT_NAME="$1"
     for _ in $(seq 10); do
-        if ! nested_exec "snap connections system" | MATCH ":$SLOT_NAME"; then
+        if ! tests.nested exec "snap connections system" | MATCH ":$SLOT_NAME"; then
             break
         fi
         sleep 1
     done
-    if nested_exec "snap connections system" | MATCH ":$SLOT_NAME "; then
+    if tests.nested exec "snap connections system" | MATCH ":$SLOT_NAME "; then
         echo "slot $SLOT_NAME shouldn't be present anymore"
         exit 1
     fi
@@ -44,65 +44,65 @@ check_slot_not_present() {
 check_slot_present() {
     SLOT_NAME="$1"
     for _ in $(seq 10); do
-        if nested_exec "snap connections system" | MATCH "serial-port .* - .* :$SLOT_NAME"; then
+        if tests.nested exec "snap connections system" | MATCH "serial-port .* - .* :$SLOT_NAME"; then
             break
         fi
         sleep 1
     done
-    nested_exec "snap connections system" | MATCH "serial-port .* - .* :$SLOT_NAME"
+    tests.nested exec "snap connections system" | MATCH "serial-port .* - .* :$SLOT_NAME"
 }
 
 # Check that given slot has hotplug-gone=true, meaning the device was unplugged but there are connections remembered for it
 check_slot_gone() {
     SLOT_NAME="$1"
-    nested_exec 'sudo jq -r ".data[\"hotplug-slots\"][\"'"$SLOT_NAME"'\"][\"hotplug-gone\"]" /var/lib/snapd/state.json' | MATCH "true"
+    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"][\"'"$SLOT_NAME"'\"][\"hotplug-gone\"]" /var/lib/snapd/state.json' | MATCH "true"
 }
 
 # Check that given slot has hotplug-gone=false, meaning the device is plugged
 check_slot_not_gone() {
     SLOT_NAME="$1"
-    nested_exec 'sudo jq -r ".data[\"hotplug-slots\"][\"'"$SLOT_NAME"'\"][\"hotplug-gone\"]" /var/lib/snapd/state.json' | MATCH "false"
+    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"][\"'"$SLOT_NAME"'\"][\"hotplug-gone\"]" /var/lib/snapd/state.json' | MATCH "false"
 }
 
 # Check that given slot has no record in "hotplug-slots" map in the state
 check_slot_not_present_in_state() {
     SLOT_NAME="$1"
-    nested_exec 'sudo jq -r ".data[\"hotplug-slots\"][\"'"$SLOT_NAME"'\"] // \"missing\"" /var/lib/snapd/state.json' | MATCH "missing"
+    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"][\"'"$SLOT_NAME"'\"] // \"missing\"" /var/lib/snapd/state.json' | MATCH "missing"
 }
 
 check_slot_device_path() {
     SLOT_NAME="$1"
     DEVICE_PATH="$2"
-    nested_exec 'sudo jq -r ".data[\"hotplug-slots\"][\"'"$SLOT_NAME"'\"][\"static-attrs\"].path" /var/lib/snapd/state.json' | MATCH "$DEVICE_PATH"
+    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"][\"'"$SLOT_NAME"'\"][\"static-attrs\"].path" /var/lib/snapd/state.json' | MATCH "$DEVICE_PATH"
 }
 
 # Check that given slot is connected to the serial-port-hotplug snap, per 'snap connections' output
 check_slot_connected() {
     SLOT_NAME="$1"
     for _ in $(seq 10); do
-        if nested_exec "snap connections" | MATCH "serial-port .*serial-port-hotplug:serial-port .*$SLOT_NAME"; then
+        if tests.nested exec "snap connections" | MATCH "serial-port .*serial-port-hotplug:serial-port .*$SLOT_NAME"; then
             break
         fi
         sleep 1
     done
-    nested_exec "snap connections" | MATCH "serial-port .*serial-port-hotplug:serial-port .*$SLOT_NAME"
+    tests.nested exec "snap connections" | MATCH "serial-port .*serial-port-hotplug:serial-port .*$SLOT_NAME"
 }
 
 # Check that apparmor profile allows rw access to given device path.
 verify_apparmor_profile() {
     DEVPATH=$1
     for _ in $(seq 10); do
-        if nested_exec "cat /var/lib/snapd/apparmor/profiles/snap.serial-port-hotplug.consumer" | MATCH "$DEVPATH rwk,"; then
+        if tests.nested exec "cat /var/lib/snapd/apparmor/profiles/snap.serial-port-hotplug.consumer" | MATCH "$DEVPATH rwk,"; then
             break
         fi
         sleep 1
     done
-    nested_exec "cat /var/lib/snapd/apparmor/profiles/snap.serial-port-hotplug.consumer" | MATCH "$DEVPATH rwk,"
+    tests.nested exec "cat /var/lib/snapd/apparmor/profiles/snap.serial-port-hotplug.consumer" | MATCH "$DEVPATH rwk,"
 }
 
 wait_for_all_changes() {
     for _ in $(seq 10); do
-        if ! nested_exec "snap changes" | MATCH "Doing"; then
+        if ! tests.nested exec "snap changes" | MATCH "Doing"; then
             break
         fi
         sleep 1

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -24,15 +24,35 @@ NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS
 
 nested_wait_for_ssh() {
     # TODO:UC20: the retry count should be lowered to something more reasonable.
-    nested_retry_until_success 800 1 "true"
+    local retry=800
+    local wait=1
+
+    until nested_exec "true"; do
+        retry=$(( retry - 1 ))
+        if [ $retry -le 0 ]; then
+            echo "Timed out waiting for command '$*' to succeed. Aborting!"
+            return 1
+        fi
+        sleep "$wait"
+    done
 }
 
 nested_wait_for_no_ssh() {
-    nested_retry_while_success 200 1 "true"
+    local retry=200
+    local wait=1
+
+    while nested_exec "true"; do
+        retry=$(( retry - 1 ))
+        if [ $retry -le 0 ]; then
+            echo "Timed out waiting for command '$*' to fail. Aborting!"
+            return 1
+        fi
+        sleep "$wait"
+    done
 }
 
 nested_wait_for_snap_command() {
-    nested_retry_until_success 200 1 command -v snap
+    nested_retry "--wait 1 -n 200 sh -c 'command -v snap'"
 }
 
 nested_get_boot_id() {
@@ -70,36 +90,6 @@ nested_uc20_transition_to_system_mode() {
     if ! nested_exec "cat /proc/cmdline" | MATCH "snapd_recovery_mode=$mode"; then
         return 1
     fi
-}
-
-nested_retry_while_success() {
-    local retry="$1"
-    local wait="$2"
-    shift 2
-
-    while nested_exec "$@"; do
-        retry=$(( retry - 1 ))
-        if [ $retry -le 0 ]; then
-            echo "Timed out waiting for command '$*' to fail. Aborting!"
-            return 1
-        fi
-        sleep "$wait"
-    done
-}
-
-nested_retry_until_success() {
-    local retry="$1"
-    local wait="$2"
-    shift 2
-
-    until nested_exec "$@"; do
-        retry=$(( retry - 1 ))
-        if [ $retry -le 0 ]; then
-            echo "Timed out waiting for command '$*' to succeed. Aborting!"
-            return 1
-        fi
-        sleep "$wait"
-    done
 }
 
 nested_prepare_ssh() {
@@ -778,7 +768,8 @@ users:
   - name: user1
     sudo: "ALL=(ALL) NOPASSWD:ALL"
     lock_passwd: false
-    plain_text_passwd: "ubuntu"
+    # passwd is just "ubuntu"
+    passwd: "$6$rounds=4096$PCrfo.ggdf4ubP$REjyaoY2tUWH2vjFJjvLs3rDxVTszGR9P7mhH9sHb2MsELfc53uV/v15jDDOJU/9WInfjjTKJPlD5URhX5Mix0"
 EOF
 }
 
@@ -1219,15 +1210,19 @@ nested_destroy_vm() {
     rm -f "$CURRENT_IMAGE"
 }
 
-nested_exec() {
-    sshpass -p ubuntu ssh -p "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost "$@"
-}
-
 nested_exec_as() {
     local USER="$1"
     local PASSWD="$2"
     shift 2
     sshpass -p "$PASSWD" ssh -p "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$USER"@localhost "$@"
+}
+
+nested_retry() {
+    if ! nested_exec "test -e ./retry" &>/dev/null; then
+        nested_copy "$TESTSTOOLS/retry"
+        nested_exec "sed 's/any-python/python3/g' -i ./retry"
+    fi
+    nested_exec "./retry" "$@"
 }
 
 nested_copy() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1210,6 +1210,10 @@ nested_destroy_vm() {
     rm -f "$CURRENT_IMAGE"
 }
 
+nested_exec() {
+    sshpass -p ubuntu ssh -p "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost "$@"
+}
+
 nested_exec_as() {
     local USER="$1"
     local PASSWD="$2"

--- a/tests/lib/tools/tests.nested
+++ b/tests/lib/tools/tests.nested
@@ -5,6 +5,11 @@ show_help() {
     echo "       restore"
     echo "       build-image IMAGE-TYPE"
     echo "       create-vm IMAGE-TYPE [--param-cdrom PARAM] [--param-mem PARAM]"
+    echo "       exec <CMD>"
+    echo "       exec <USER> <PWD> <CMD>"
+    echo "       retry <CMD>"
+    echo "       copy <FILEPATH>"
+    echo "       wait-for <EVENT>"
     echo "       start-vm"
     echo "       stop-vm"
     echo "       remove-vm"
@@ -17,6 +22,11 @@ show_help() {
     echo "  restore:     removes all the directories and data used by nested tests"
     echo "  build-image: creates an image using ubuntu image tool"
     echo "  create-vm:   creates new virtual machine and leave it running"
+    echo "  exec:        executes a command in the vm"
+    echo "  exec-as:     executes a command in the vm as the specified user"
+    echo "  retry:       retries a command in the vm"
+    echo "  copy:        copies a file to the vm"
+    echo "  wait-for:    waits for an specified event"
     echo "  start-vm:    starts a stopped vm"
     echo "  stop-vm:     shutdowns a running vm"
     echo "  remove-vm:   removes a vm"
@@ -24,6 +34,12 @@ show_help() {
     echo "IMAGE-TYPES:"
     echo "  core: work with a core image"
     echo "  classic: work with a classic image"
+    echo ""
+    echo "EVENT:"
+    echo "  ssh: it is possible ssh to the vm"
+    echo "  no-ssh: is not possible to ssh to the vm"
+    echo "  snap-command: snap command is available in the vm"
+    echo "  reboot: reboot is done in the vm"
     echo ""
 }
 
@@ -51,7 +67,7 @@ build_image() {
                 exit
                 ;;
             *)
-                echo "nested-state: expected either classic or core as argument" >&2
+                echo "tests.nested: expected either classic or core as argument" >&2
                 exit 1
                 ;;
         esac
@@ -74,7 +90,7 @@ create_vm() {
             action=nested_start_core_vm
             ;;
         *)
-            echo "nested-state: unsupported parameter $1" >&2
+            echo "tests.nested: unsupported parameter $1" >&2
             exit 1
             ;;
     esac
@@ -90,7 +106,7 @@ create_vm() {
                 shift 2
                 ;;
             *)
-                echo "nested-state: unsupported parameter $1" >&2
+                echo "tests.nested: unsupported parameter $1" >&2
                 exit 1
                 ;;
         esac
@@ -99,6 +115,49 @@ create_vm() {
     "$action"
 }
 
+exec() {
+    nested_exec "$@"
+}
+
+exec_as() {
+    nested_exec_as "$@"
+}
+
+retry() {
+    nested_retry "$@"
+}
+
+copy() {
+    nested_copy "$@"
+}
+
+wait_for() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 1
+    fi
+    local action=
+    case "$1" in
+        ssh)
+            action=nested_wait_for_ssh
+            ;;
+        no-ssh)
+            action=nested_wait_for_no_ssh
+            ;;
+        snap-command)
+            action=nested_wait_for_snap_command
+            ;;
+        reboot)
+            action=nested_wait_for_reboot
+            ;;
+        *)
+            echo "tests.nested: unsupported parameter $1" >&2
+            exit 1
+            ;;
+    esac
+
+    "$action"
+}
 
 start_vm() {
     nested_start
@@ -135,7 +194,7 @@ main() {
     done
 
     if [ -z "$(declare -f "$action")" ]; then
-        echo "nested-state: no such command: $subcommand"
+        echo "tests.nested: no such command: $subcommand"
         show_help
         exit 1
     fi

--- a/tests/lib/tools/tests.nested
+++ b/tests/lib/tools/tests.nested
@@ -123,7 +123,7 @@ exec_as() {
     nested_exec_as "$@"
 }
 
-retry() {
+retrier() {
     nested_retry "$@"
 }
 
@@ -184,6 +184,11 @@ main() {
             -h|--help)
                 show_help
                 exit 0
+                ;;
+            retry)
+                action=retrier
+                shift
+                break
                 ;;
             *)
                 action=$(echo "$subcommand" | tr '-' '_')

--- a/tests/lib/tools/tests.nested
+++ b/tests/lib/tools/tests.nested
@@ -140,15 +140,19 @@ wait_for() {
     case "$1" in
         ssh)
             action=nested_wait_for_ssh
+            shift
             ;;
         no-ssh)
             action=nested_wait_for_no_ssh
+            shift
             ;;
         snap-command)
             action=nested_wait_for_snap_command
+            shift
             ;;
         reboot)
             action=nested_wait_for_reboot
+            shift
             ;;
         *)
             echo "tests.nested: unsupported parameter $1" >&2
@@ -156,7 +160,7 @@ wait_for() {
             ;;
     esac
 
-    "$action"
+    "$action" "$@"
 }
 
 start_vm() {

--- a/tests/nested/classic/hotplug/task.yaml
+++ b/tests/nested/classic/hotplug/task.yaml
@@ -47,7 +47,7 @@ execute: |
     hotplug_add_dev1
 
     # sanity checks to make sure qemu setup is correct
-    nested_retry "--wait 1 -n 5 sh -c 'udevadm info -e | grep -qE ID_MODEL=QEMU_USB_SERIAL'"
+    tests.nested retry "--wait 1 -n 5 sh -c 'udevadm info -e | grep -qE ID_MODEL=QEMU_USB_SERIAL'"
         if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
 
     tests.nested exec "ls /dev/tty*" | MATCH "ttyUSB0"

--- a/tests/nested/classic/hotplug/task.yaml
+++ b/tests/nested/classic/hotplug/task.yaml
@@ -32,7 +32,7 @@ debug: |
 execute: |
     #shellcheck source=tests/lib/hotplug.sh
     . "$TESTSLIB/hotplug.sh"
-    
+
     if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
         echo "USB serial already registered, exiting..."
         exit 1
@@ -48,7 +48,6 @@ execute: |
 
     # sanity checks to make sure qemu setup is correct
     tests.nested retry "--wait 1 -n 5 sh -c 'udevadm info -e | grep -qE ID_MODEL=QEMU_USB_SERIAL'"
-        if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
 
     tests.nested exec "ls /dev/tty*" | MATCH "ttyUSB0"
 

--- a/tests/nested/classic/hotplug/task.yaml
+++ b/tests/nested/classic/hotplug/task.yaml
@@ -1,68 +1,60 @@
 summary: Create ubuntu classic image, install snapd and test hotplug feature
 
 prepare: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-
     echo "Install snapd.deb in the nested vm"
-    nested_copy "${GOHOME}"/snapd_*.deb
-    nested_exec "sudo apt update"
-    nested_exec "sudo apt install -y ./snapd_*.deb"
+    tests.nested copy "${GOHOME}"/snapd_*.deb
+    tests.nested exec "sudo apt update"
+    tests.nested exec "sudo apt install -y ./snapd_*.deb"
     
     echo "Install linux-modules-extra package as it provides ftdi_sio and usbserial kernel modules"
     #shellcheck disable=SC2016
-    nested_exec 'DEBIAN_FRONTEND=noninteractive sudo -E apt install -y "linux-modules-extra-$(uname -r)"'
+    tests.nested exec 'DEBIAN_FRONTEND=noninteractive sudo -E apt install -y "linux-modules-extra-$(uname -r)"'
 
     snap pack "$TESTSLIB"/snaps/serial-port-hotplug
-    nested_copy serial-port-hotplug_1.0_all.snap
+    tests.nested copy serial-port-hotplug_1.0_all.snap
     echo "Add test user to dialout group required for ttyUSB* devices"
-    nested_exec "sudo usermod -a -G dialout user1"
+    tests.nested exec "sudo usermod -a -G dialout user1"
 
-    nested_exec "sudo snap install --devmode jq"
+    tests.nested exec "sudo snap install --devmode jq"
 
 restore: |
     rm -f /tmp/serialport{0,1}
 
 debug: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-
     set +e
-    nested_exec "snap connections --all"
-    nested_exec "snap list"
-    nested_exec "dmesg"
-    nested_exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
-    nested_exec 'lsmod'
+    tests.nested exec "snap connections --all"
+    tests.nested exec "snap list"
+    tests.nested exec "dmesg"
+    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
+    tests.nested exec 'lsmod'
     set -e
 
 execute: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
     #shellcheck source=tests/lib/hotplug.sh
     . "$TESTSLIB/hotplug.sh"
     
-    if nested_exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+    if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
         echo "USB serial already registered, exiting..."
         exit 1
     fi
 
-    nested_exec "sudo snap install hello-world"
+    tests.nested exec "sudo snap install hello-world"
 
     echo "Enabling hotplug"
-    nested_exec "sudo snap set core experimental.hotplug=true"
+    tests.nested exec "sudo snap set core experimental.hotplug=true"
 
     echo "Plugging the device"
     hotplug_add_dev1
 
     # sanity checks to make sure qemu setup is correct
     for _ in $(seq 5); do
-        if nested_exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+        if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
             break
         fi
         sleep 1
     done
 
-    nested_exec "ls /dev/tty*" | MATCH "ttyUSB0"
+    tests.nested exec "ls /dev/tty*" | MATCH "ttyUSB0"
 
     echo "Checking that qemuusbserial hotplug slot is present"
     check_slot_present qemuusbserial
@@ -74,13 +66,13 @@ execute: |
 
     # sanity check to make sure qemu event was triggered correctly
     for _ in $(seq 5); do
-        if nested_exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+        if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
             sleep 1
         else
             break
         fi
     done
-    if nested_exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+    if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
         echo "USB serial should not be registered anymore, exiting..."
         exit 1
     fi
@@ -96,16 +88,16 @@ execute: |
     check_slot_present qemuusbserial
 
     echo "Installing test snap with serial port plug"
-    nested_exec "sudo snap install --dangerous serial-port-hotplug_1.0_all.snap"
+    tests.nested exec "sudo snap install --dangerous serial-port-hotplug_1.0_all.snap"
 
     echo "Connecting hotplug slot of the first device"
-    nested_exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
+    tests.nested exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_connected qemuusbserial
 
     echo "Veryfing serial-port permissions of the snap"
     verify_apparmor_profile "/dev/ttyUSB0"
-    nested_exec "/snap/bin/serial-port-hotplug.consumer write-1" | MATCH "Access to /dev/ttyUSB0 ok"
-    nested_exec "/snap/bin/serial-port-hotplug.consumer write-2" | MATCH "Access to /dev/ttyUSB1 failed"
+    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-1" | MATCH "Access to /dev/ttyUSB0 ok"
+    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-2" | MATCH "Access to /dev/ttyUSB1 failed"
     MATCH "write-1 on /dev/ttyUSB0" < /tmp/serialport1
 
     echo "Unplugging the device"
@@ -141,23 +133,23 @@ execute: |
     echo "Veryfing serial-port permissions of the snap, the first device is now expected on ttyUSB1"
     check_slot_device_path qemuusbserial "/dev/ttyUSB1"
     verify_apparmor_profile "/dev/ttyUSB1"
-    nested_exec "/snap/bin/serial-port-hotplug.consumer write-3" | MATCH "Access to /dev/ttyUSB0 failed"
-    nested_exec "/snap/bin/serial-port-hotplug.consumer write-4" | MATCH "Access to /dev/ttyUSB1 ok"
+    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-3" | MATCH "Access to /dev/ttyUSB0 failed"
+    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-4" | MATCH "Access to /dev/ttyUSB1 ok"
     MATCH "write-3 on /dev/ttyUSB1" < /tmp/serialport1
 
     echo "Restarting snapd should restore both hotplug slots since devices are still present"
-    nested_exec "sudo systemctl stop snapd.service snapd.socket"
-    nested_exec "sudo systemctl start snapd.service snapd.socket"
+    tests.nested exec "sudo systemctl stop snapd.service snapd.socket"
+    tests.nested exec "sudo systemctl start snapd.service snapd.socket"
     check_slot_connected qemuusbserial
     check_slot_not_gone qemuusbserial
     check_slot_present qemuusbserial-1
-    nested_exec "/snap/bin/serial-port-hotplug.consumer write-5" | MATCH "Access to /dev/ttyUSB1 ok"
+    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-5" | MATCH "Access to /dev/ttyUSB1 ok"
     MATCH "write-5 on /dev/ttyUSB1" < /tmp/serialport1
 
     echo "Unplugging first device while snapd is stopped and then starting snapd remembers the slot internally due to connection"
-    nested_exec "sudo systemctl stop snapd.service snapd.socket"
+    tests.nested exec "sudo systemctl stop snapd.service snapd.socket"
     hotplug_del_dev1
-    nested_exec "sudo systemctl start snapd.service snapd.socket"
+    tests.nested exec "sudo systemctl start snapd.service snapd.socket"
     check_slot_not_present qemuusbserial
     check_slot_gone qemuusbserial
 
@@ -169,7 +161,7 @@ execute: |
     echo "Disconnecting first slot and then unplugging the device removes the slot completely"
     # manual snap disconnect doesn't implement retry and errors out if there are conflicting changes, so wait for hotplug changes to complete
     wait_for_all_changes
-    nested_exec "sudo snap disconnect serial-port-hotplug:serial-port :qemuusbserial"
+    tests.nested exec "sudo snap disconnect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_present qemuusbserial
     hotplug_del_dev1
     check_slot_not_present qemuusbserial
@@ -187,10 +179,10 @@ execute: |
     check_slot_device_path qemuusbserial "/dev/ttyUSB0"
 
     echo "Connecting hotplug slot of the first device again"
-    nested_exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
+    tests.nested exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_connected qemuusbserial
 
     echo "Hotplug slot stays after removing the snap"
-    nested_exec "sudo snap remove serial-port-hotplug"
+    tests.nested exec "sudo snap remove serial-port-hotplug"
     check_slot_present qemuusbserial
     check_slot_not_gone qemuusbserial

--- a/tests/nested/classic/snapshots-with-core-refresh-revert/task.yaml
+++ b/tests/nested/classic/snapshots-with-core-refresh-revert/task.yaml
@@ -13,6 +13,9 @@ prepare: |
     tests.nested exec "sudo snap install test-snapd-rsync"
 
 execute: |
+    # shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
     echo "Make sure the core in the nested vm is the correct one"
     tests.nested exec "sudo snap refresh core --${NESTED_CORE_CHANNEL}"
 

--- a/tests/nested/classic/snapshots-with-core-refresh-revert/task.yaml
+++ b/tests/nested/classic/snapshots-with-core-refresh-revert/task.yaml
@@ -1,56 +1,50 @@
 summary: test snapshots work when core snap is refreshed and reverted
 
 prepare: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-
     echo "Configure hosts file"
     # shellcheck disable=SC2016
-    nested_exec 'echo "127.0.1.1 $HOSTNAME" | sudo tee /etc/hosts'
+    tests.nested exec 'echo "127.0.1.1 $HOSTNAME" | sudo tee /etc/hosts'
 
     echo "Install snapd and snaps on nested vm"
-    nested_copy "${GOHOME}"/snapd_*.deb
-    nested_exec "sudo apt update"
-    nested_exec "sudo apt install -y ./snapd_*.deb"
-    nested_exec "sudo snap install test-snapd-sh"
-    nested_exec "sudo snap install test-snapd-rsync"
+    tests.nested copy "${GOHOME}"/snapd_*.deb
+    tests.nested exec "sudo apt update"
+    tests.nested exec "sudo apt install -y ./snapd_*.deb"
+    tests.nested exec "sudo snap install test-snapd-sh"
+    tests.nested exec "sudo snap install test-snapd-rsync"
 
 execute: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-
     echo "Make sure the core in the nested vm is the correct one"
-    nested_exec "sudo snap refresh core --${NESTED_CORE_CHANNEL}"
+    tests.nested exec "sudo snap refresh core --${NESTED_CORE_CHANNEL}"
 
     echo "Use the snaps, so they create the dirs:"
-    nested_exec "sudo test-snapd-sh.sh -c 'true'"
-    nested_exec "sudo test-snapd-rsync.rsync --version >/dev/null"
+    tests.nested exec "sudo test-snapd-sh.sh -c 'true'"
+    tests.nested exec "sudo test-snapd-rsync.rsync --version >/dev/null"
     for snap in test-snapd-sh test-snapd-rsync; do
-       nested_exec "echo "hello versioned $snap" | sudo tee /root/snap/$snap/current/canary.txt"
-       nested_exec "echo "hello common $snap" | sudo tee /root/snap/$snap/common/canary.txt"
+       tests.nested exec "echo "hello versioned $snap" | sudo tee /root/snap/$snap/current/canary.txt"
+       tests.nested exec "echo "hello common $snap" | sudo tee /root/snap/$snap/common/canary.txt"
     done
 
     echo "Create snapshot, grab its id"
-    SET_ID=$( nested_exec "sudo snap save test-snapd-sh test-snapd-rsync" | cut -d\  -f1 | tail -n1 )
+    SET_ID=$( tests.nested exec "sudo snap save test-snapd-sh test-snapd-rsync" | cut -d\  -f1 | tail -n1 )
 
     echo "Delete the canary files"
-    nested_exec "sudo rm /root/snap/test-snapd-sh/{current,common}/canary.txt"
-    nested_exec "sudo rm /root/snap/test-snapd-rsync/{current,common}/canary.txt"
+    tests.nested exec "sudo rm /root/snap/test-snapd-sh/{current,common}/canary.txt"
+    tests.nested exec "sudo rm /root/snap/test-snapd-rsync/{current,common}/canary.txt"
 
     echo "When the core is refreshed the snap snapshot can be restored"
-    nested_exec "sudo snap refresh core --${NESTED_CORE_REFRESH_CHANNEL}"
-    nested_exec "sudo snap restore $SET_ID test-snapd-rsync"
-    test "$( nested_exec "sudo cat /root/snap/test-snapd-rsync/current/canary.txt" )" = "hello versioned test-snapd-rsync"
-    test "$( nested_exec "sudo cat /root/snap/test-snapd-rsync/common/canary.txt" )" = "hello common test-snapd-rsync"
-    nested_exec "sudo test ! -f /root/snap/test-snapd-sh/common/canary.txt"
-    nested_exec "sudo test ! -f /root/snap/test-snapd-sh/current/canary.txt"
+    tests.nested exec "sudo snap refresh core --${NESTED_CORE_REFRESH_CHANNEL}"
+    tests.nested exec "sudo snap restore $SET_ID test-snapd-rsync"
+    test "$( tests.nested exec "sudo cat /root/snap/test-snapd-rsync/current/canary.txt" )" = "hello versioned test-snapd-rsync"
+    test "$( tests.nested exec "sudo cat /root/snap/test-snapd-rsync/common/canary.txt" )" = "hello common test-snapd-rsync"
+    tests.nested exec "sudo test ! -f /root/snap/test-snapd-sh/common/canary.txt"
+    tests.nested exec "sudo test ! -f /root/snap/test-snapd-sh/current/canary.txt"
 
     echo "When the core is reverted the snap snapshot can be restored"
-    nested_exec "sudo snap revert core"
-    nested_exec "sudo snap restore $SET_ID test-snapd-sh"
-    test "$( nested_exec "sudo cat /root/snap/test-snapd-sh/current/canary.txt" )" = "hello versioned test-snapd-sh"
-    test "$( nested_exec "sudo cat /root/snap/test-snapd-sh/common/canary.txt" )" = "hello common test-snapd-sh"
+    tests.nested exec "sudo snap revert core"
+    tests.nested exec "sudo snap restore $SET_ID test-snapd-sh"
+    test "$( tests.nested exec "sudo cat /root/snap/test-snapd-sh/current/canary.txt" )" = "hello versioned test-snapd-sh"
+    test "$( tests.nested exec "sudo cat /root/snap/test-snapd-sh/common/canary.txt" )" = "hello common test-snapd-sh"
 
     echo "And the snapshot can be removed"
-    nested_exec "sudo snap forget $SET_ID"
-    nested_exec "sudo snap saved --id=$SET_ID" | MATCH "No snapshots found"
+    tests.nested exec "sudo snap forget $SET_ID"
+    tests.nested exec "sudo snap saved --id=$SET_ID" | MATCH "No snapshots found"

--- a/tests/nested/core/core-revert/task.yaml
+++ b/tests/nested/core/core-revert/task.yaml
@@ -34,38 +34,38 @@ execute: |
     fi
 
     echo "Refresh the core snap to $NESTED_CORE_REFRESH_CHANNEL channel"
-    nested_exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_CHANNEL}"
-    nested_exec "sudo snap refresh --${NESTED_CORE_REFRESH_CHANNEL} core" || true
+    tests.nested exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_CHANNEL}"
+    tests.nested exec "sudo snap refresh --${NESTED_CORE_REFRESH_CHANNEL} core" || true
 
-    if ! nested_wait_for_ssh; then
+    if ! tests.nested wait-for ssh; then
         echo "ssh not stablished, exiting..."
         exit 1
     fi
 
     echo "Wait until the refresh is completed"
-    while ! nested_exec "snap changes" | MATCH "Done.*Refresh \"core\" snap from \"${NESTED_CORE_REFRESH_CHANNEL}\" channel"; do
+    while ! tests.nested exec "snap changes" | MATCH "Done.*Refresh \"core\" snap from \"${NESTED_CORE_REFRESH_CHANNEL}\" channel"; do
         sleep 1
     done
-    nested_exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_REFRESH_CHANNEL}"
+    tests.nested exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_REFRESH_CHANNEL}"
 
     echo "Sanity check, no refresh should be done here but the command shouldn't fail"
-    nested_exec "sudo snap refresh"
+    tests.nested exec "sudo snap refresh"
 
     echo "Revert the core snap"
-    nested_exec "sudo snap revert core" || true
+    tests.nested exec "sudo snap revert core" || true
 
-    if ! nested_wait_for_ssh; then
+    if ! tests.nested wait-for ssh; then
         echo "ssh not stablished, exiting..."
         exit 1
     fi
 
     echo "Wait until the revert is completed"
-    while ! nested_exec "snap changes" | MATCH "Done.*Revert \"core\" snap"; do sleep 1 ; done
+    while ! tests.nested exec "snap changes" | MATCH "Done.*Revert \"core\" snap"; do sleep 1 ; done
 
     echo "Check the revert was done properly"
-    nested_exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_REFRESH_CHANNEL}"
-    nested_exec "ifconfig" | MATCH eth0
+    tests.nested exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_REFRESH_CHANNEL}"
+    tests.nested exec "ifconfig" | MATCH eth0
 
 
-    nested_exec "sudo snap refresh"
-    nested_exec "sudo cat /var/log/syslog" | NOMATCH "hsearch_r failed for.* No such process"
+    tests.nested exec "sudo snap refresh"
+    tests.nested exec "sudo cat /var/log/syslog" | NOMATCH "hsearch_r failed for.* No such process"

--- a/tests/nested/core/core-snap-refresh-on-core/task.yaml
+++ b/tests/nested/core/core-snap-refresh-on-core/task.yaml
@@ -20,21 +20,21 @@ execute: |
     fi
 
     echo "Install test snap"
-    nested_exec "sudo snap install test-snapd-sh"
+    tests.nested exec "sudo snap install test-snapd-sh"
 
     echo "Ensure we have a good starting place"
-    nested_exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
+    tests.nested exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
 
     echo "Go to known good starting place"
-    nested_exec "snap download core --${NESTED_CORE_CHANNEL}"
-    nested_exec "sudo snap ack core_*.assert"
-    nested_exec "sudo snap install core_*.snap"
+    tests.nested exec "snap download core --${NESTED_CORE_CHANNEL}"
+    tests.nested exec "sudo snap ack core_*.assert"
+    tests.nested exec "sudo snap install core_*.snap"
 
     echo "Check the initial core is installed and snaps can be executed"
     test "$(get_nested_core_revision_installed)" = "${INITIAL_REV}"
 
     echo "Ensure test-snapd-sh works"
-    nested_exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
+    tests.nested exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
 
     echo "Refresh core snap to $NESTED_CORE_REFRESH_CHANNEL"
     refresh_to_new_core "$NESTED_CORE_REFRESH_CHANNEL"
@@ -43,15 +43,15 @@ execute: |
     test "$(get_nested_core_revision_installed)" = "${NEW_REV}"
 
     echo "Ensure test-snapd-sh works"
-    nested_exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
+    tests.nested exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
 
     echo "Revert core"
-    nested_exec "sudo snap revert core" || true
-    nested_nested_wait_for_no_ssh
-    nested_nested_wait_for_ssh
+    tests.nested exec "sudo snap revert core" || true
+    tests.nested wait-for no-ssh
+    tests.nested wait-for ssh
 
     echo "After revert, check initial core is installed"
     test "$(get_nested_core_revision_installed)" = "${INITIAL_REV}"
 
     echo "Ensure test-snapd-sh works"
-    nested_exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
+    tests.nested exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello

--- a/tests/nested/core/core20-basic/task.yaml
+++ b/tests/nested/core/core20-basic/task.yaml
@@ -10,49 +10,49 @@ execute: |
     . "$TESTSLIB/nested.sh"
 
     echo "Wait for the system to be seeded first"
-    nested_exec "sudo snap wait system seed.loaded"
+    tests.nested exec "sudo snap wait system seed.loaded"
 
     echo "Ensure 'snap install' works"
     # The install command could cause a ssh break, so || true is used
     # and then we check the installation was completed successfully
-    nested_exec "sudo snap install test-snapd-sh" || true
+    tests.nested exec "sudo snap install test-snapd-sh" || true
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is installed"
-    nested_exec "snap list" | MATCH test-snapd-sh
+    tests.nested exec "snap list" | MATCH test-snapd-sh
 
     echo "Ensure 'snap find' works"
-    nested_exec "snap find test-snapd-sh" | MATCH ^test-snapd-sh
+    tests.nested exec "snap find test-snapd-sh" | MATCH ^test-snapd-sh
 
     echo "Ensure 'snap info' works"
-    nested_exec "snap info test-snapd-sh" | MATCH '^name:\ +test-snapd-sh'
+    tests.nested exec "snap info test-snapd-sh" | MATCH '^name:\ +test-snapd-sh'
 
     echo "Ensure 'snap remove' works"
     # The install command could cause a ssh break, so || true is used
     # and then we check the removal was completed successfully
-    nested_exec "sudo snap remove test-snapd-sh" || true
+    tests.nested exec "sudo snap remove test-snapd-sh" || true
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is removed"
-    nested_exec "! snap list test-snapd-sh"
+    tests.nested exec "! snap list test-snapd-sh"
 
     echo "Ensure 'snap debug show-keys' works as root"
-    nested_exec "sudo snap recovery --show-keys" | MATCH 'recovery:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}'
-    nested_exec "sudo snap recovery --show-keys" | MATCH 'reinstall:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}'
+    tests.nested exec "sudo snap recovery --show-keys" | MATCH 'recovery:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}'
+    tests.nested exec "sudo snap recovery --show-keys" | MATCH 'reinstall:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}'
     echo "But not as user (normal file permissions prevent this)"
-    if nested_exec "snap recovery --show-key"; then
+    if tests.nested exec "snap recovery --show-key"; then
         echo "snap recovery --show-key should not work as a user"
         exit 1
     fi
 
     echo "Wait for device initialisation to be done"
-    nested_retry_until_success 10 5 "snap changes | grep -q 'Done.*Initialize device'"
+    tests.nested retry_until_success 10 5 "snap changes | grep -q 'Done.*Initialize device'"
 
     echo "Check that the serial backed up to save is as expected"
-    nested_exec 'cat /var/lib/snapd/save/device/asserts-v0/serial/'"$(nested_model_authority)"'/pc/*/active' >serial.saved
-    nested_exec snap model --serial --assertion >serial
+    tests.nested exec 'cat /var/lib/snapd/save/device/asserts-v0/serial/'"$(nested_model_authority)"'/pc/*/active' >serial.saved
+    tests.nested exec snap model --serial --assertion >serial
     cmp serial serial.saved
 
     echo "Check that we go the install log after the transition to run mode"
-    nested_exec "test -e /var/log/install-mode.log.gz"
+    tests.nested exec "test -e /var/log/install-mode.log.gz"
 
     echo "Transparently verify that the format is gzip"
-    nested_exec "zcat /var/log/install-mode.log.gz" | MATCH 'installing a new system'
+    tests.nested exec "zcat /var/log/install-mode.log.gz" | MATCH 'installing a new system'

--- a/tests/nested/core/core20-create-recovery/task.yaml
+++ b/tests/nested/core/core20-create-recovery/task.yaml
@@ -6,21 +6,21 @@ prepare: |
     # shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
-    nested_exec sudo snap install http
+    tests.nested exec sudo snap install http
 
 execute: |
     # shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
     boot_id="$( nested_get_boot_id )"
-    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | nested_exec sudo http POST snapd:///v2/debug > change.out
+    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | tests.nested exec sudo http POST snapd:///v2/debug > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
-    nested_wait_for_reboot "${boot_id}"
-    nested_exec sudo snap watch "${REMOTE_CHG_ID}"
+    tests.nested wait-for reboot "${boot_id}"
+    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
 
     echo "Verify the system is back in run mode"
-    nested_exec "sudo cat /proc/cmdline" | MATCH snapd_recovery_mode=run
+    tests.nested exec "sudo cat /proc/cmdline" | MATCH snapd_recovery_mode=run
 
-    nested_exec "test -f /run/mnt/ubuntu-seed/systems/1234/model"
-    nested_exec "sudo cat /var/lib/snapd/modeenv" > modeenv
+    tests.nested exec "test -f /run/mnt/ubuntu-seed/systems/1234/model"
+    tests.nested exec "sudo cat /var/lib/snapd/modeenv" > modeenv
     MATCH 'current_recovery_systems=.*,1234' < modeenv
     MATCH 'good_recovery_systems=.*,1234' < modeenv

--- a/tests/nested/core/core20-degraded/task.yaml
+++ b/tests/nested/core/core20-degraded/task.yaml
@@ -11,41 +11,41 @@ execute: |
 
   # wait for the system to be seeded first
 
-  nested_wait_for_snap_command
-  nested_exec "sudo snap wait system seed.loaded"
+  tests.nested wait-for snap-command
+  tests.nested exec "sudo snap wait system seed.loaded"
 
   echo "Install jq in the host environment"
   snap install jq
 
   echo "Move the run key for ubuntu-save out of the way so we use the fallback key to unlock ubuntu-save"
-  nested_exec "sudo mv /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk"
+  tests.nested exec "sudo mv /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk"
 
-  recoverySystem=$(nested_exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
+  recoverySystem=$(tests.nested exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
 
   echo "Transition to recover mode"
   nested_uc20_transition_to_system_mode "$recoverySystem" recover
 
-  nested_wait_for_snap_command
-  nested_exec "sudo snap wait system seed.loaded"
+  tests.nested wait-for snap-command
+  tests.nested exec "sudo snap wait system seed.loaded"
 
   echo "Check degraded.json exists and has the unlock-key for ubuntu-save as the fallback key"
-  nested_exec "test -f $DEGRADED_JSON"
-  test "$(nested_exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-save" | ."unlock-key"')" = fallback
+  tests.nested exec "test -f $DEGRADED_JSON"
+  test "$(tests.nested exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-save" | ."unlock-key"')" = fallback
 
   echo "Move the run object key for ubuntu-save back and go back to run mode"
-  nested_exec "sudo mv /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key"
+  tests.nested exec "sudo mv /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key"
   nested_uc20_transition_to_system_mode "$recoverySystem" run
 
-  nested_wait_for_snap_command
-  nested_exec "sudo snap wait system seed.loaded"
+  tests.nested wait-for snap-command
+  tests.nested exec "sudo snap wait system seed.loaded"
 
   echo "Now move the run object key on ubuntu-boot out of the way so we use the fallback key to unlock ubuntu-data"
-  nested_exec "sudo mv /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key.bk"
+  tests.nested exec "sudo mv /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key.bk"
   nested_uc20_transition_to_system_mode "$recoverySystem" recover
 
-  nested_wait_for_snap_command
-  nested_exec "sudo snap wait system seed.loaded"
+  tests.nested wait-for snap-command
+  tests.nested exec "sudo snap wait system seed.loaded"
 
   echo "Check degraded.json exists and has the unlock-key for ubuntu-data as the fallback key"
-  nested_exec "test -f $DEGRADED_JSON"
-  test "$(nested_exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-data" | ."unlock-key"')" = fallback
+  tests.nested exec "test -f $DEGRADED_JSON"
+  test "$(tests.nested exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-data" | ."unlock-key"')" = fallback

--- a/tests/nested/core/core20-gadget-reseal/task.yaml
+++ b/tests/nested/core/core20-gadget-reseal/task.yaml
@@ -5,19 +5,19 @@ systems: [ubuntu-20.04-64]
 execute: |
     # shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
-    SEALED_KEY_MTIME_1="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
-    RESEAL_COUNT_1="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+    SEALED_KEY_MTIME_1="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+    RESEAL_COUNT_1="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
     
     echo "Install new (unasserted) gadget without changes and wait for change without reboot"
     boot_id="$( nested_get_boot_id )"
-    REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous /var/lib/snapd/snaps/pc_*.snap --no-wait)
+    REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous /var/lib/snapd/snaps/pc_*.snap --no-wait)
     # no reboot here, no gadget changes
-    nested_exec sudo snap watch "${REMOTE_CHG_ID}"
+    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
   
     echo "Check nothing in the gadget has changed so no reseal was needed"
-    SEALED_KEY_MTIME_2="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+    SEALED_KEY_MTIME_2="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
     test "$SEALED_KEY_MTIME_2" -eq "$SEALED_KEY_MTIME_1"
-    RESEAL_COUNT_2="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+    RESEAL_COUNT_2="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
     test "$RESEAL_COUNT_2" = "$RESEAL_COUNT_1"
 
     echo "Create modified boot assets"
@@ -44,16 +44,16 @@ execute: |
     snap pack pc-gadget/
 
     echo "Install newly created gadget (which will trigger a reboot)"
-    nested_copy ./pc_*.snap
-    REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous ./pc_*.snap --no-wait)
-    nested_wait_for_reboot "${boot_id}"
-    nested_exec sudo snap watch "${REMOTE_CHG_ID}"
+    tests.nested copy ./pc_*.snap
+    REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous ./pc_*.snap --no-wait)
+    tests.nested wait-for reboot "${boot_id}"
+    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
 
     echo "Check that the gadget asset was changed"
-    nested_exec sudo grep -q -a "This program cannot be run in XXX mode" /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+    tests.nested exec sudo grep -q -a "This program cannot be run in XXX mode" /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
 
     echo "The gadget has changed, we should see resealing"
-    SEALED_KEY_MTIME_3="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+    SEALED_KEY_MTIME_3="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
     test "$SEALED_KEY_MTIME_3" -gt "$SEALED_KEY_MTIME_2"
-    RESEAL_COUNT_3="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+    RESEAL_COUNT_3="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
     test "$RESEAL_COUNT_3" -gt "1"

--- a/tests/nested/core/core20-kernel-failover/task.yaml
+++ b/tests/nested/core/core20-kernel-failover/task.yaml
@@ -26,12 +26,12 @@ execute: |
   . "$TESTSLIB/nested.sh"
 
   echo "Copy the broken initramfs kernel snap to the UC20 VM"
-  nested_copy panicking-initramfs-kernel.snap
+  tests.nested copy panicking-initramfs-kernel.snap
 
   echo "Wait for snapd to be available"
   retry=120
   wait=1
-  until nested_exec command -v snap; do
+  until tests.nested exec command -v snap; do
       retry=$(( retry - 1 ))
       if [ $retry -le 0 ]; then
           echo "Timed out waiting for no snap command. Aborting!"
@@ -41,11 +41,11 @@ execute: |
   done
 
   echo "Wait for snapd to be seeded"
-  nested_exec sudo snap wait system seed.loaded
+  tests.nested exec sudo snap wait system seed.loaded
 
   # Get the current revision of the kernel snap
   # TODO:UC20: enable for pi-kernel, etc. when used with external systems
-  startRevision=$(nested_exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')
+  startRevision=$(tests.nested exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')
   if [ -z "${startRevision}" ]; then
     echo "missing pc-kernel revision"
     exit 1
@@ -54,39 +54,39 @@ execute: |
   boot_id="$( nested_get_boot_id )"
 
   echo "Install it and get the ID for the change"
-  REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous panicking-initramfs-kernel.snap --no-wait)
+  REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous panicking-initramfs-kernel.snap --no-wait)
 
   # wait for a reboot
-  nested_wait_for_reboot "${boot_id}"
+  tests.nested wait-for reboot "${boot_id}"
 
   # Wait for the change to finish - note it will exit with non-zero since the 
   # change will fail, so don't let that kill the test here
-  if nested_exec sudo snap watch "${REMOTE_CHG_ID}"; then 
+  if tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"; then 
     echo "remote snap change ${REMOTE_CHG_ID} for broken kernel snap refresh should have failed!"
     exit 1
   fi
 
   echo "Check that the refresh failed"
-  nested_exec sudo snap changes | grep "${REMOTE_CHG_ID}" | MATCH Error
-  nested_exec sudo snap tasks "${REMOTE_CHG_ID}" | MATCH "cannot finish .* installation, there was a rollback across reboot"
+  tests.nested exec sudo snap changes | grep "${REMOTE_CHG_ID}" | MATCH Error
+  tests.nested exec sudo snap tasks "${REMOTE_CHG_ID}" | MATCH "cannot finish .* installation, there was a rollback across reboot"
 
   echo "Check We should be on the same revision of the kernel snap"
-  if [ "$(nested_exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')" != "${startRevision}" ]; then
+  if [ "$(tests.nested exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')" != "${startRevision}" ]; then
     echo "pc-kernel is on the wrong revision"
     exit 1
   fi
 
   echo "Check we don't have leftover bootenv"
-  nested_exec sudo snap debug boot-vars --uc20 | MATCH '^kernel_status=$'
+  tests.nested exec sudo snap debug boot-vars --uc20 | MATCH '^kernel_status=$'
 
   echo "Check that we don't have extra assets in the ubuntu-boot dir and that the currently enabled kernel is the original kernel"
 
   # kernel.efi symlink should point to the original kernel
-  nested_exec readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi | MATCH "pc-kernel_${startRevision}.snap/kernel.efi"
+  tests.nested exec readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi | MATCH "pc-kernel_${startRevision}.snap/kernel.efi"
   # should still have pc-kernel_$rev.snap dir
-  nested_exec test -d "/run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_${startRevision}.snap"
-  if [ "$(nested_exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap | wc -l)" != 1 ]; then
+  tests.nested exec test -d "/run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_${startRevision}.snap"
+  if [ "$(tests.nested exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap | wc -l)" != 1 ]; then
     echo "Extra leftover pc-kernel assets in ubuntu-boot:"
-    nested_exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap
+    tests.nested exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap
     exit 1
   fi

--- a/tests/nested/core/core20-kernel-reseal/task.yaml
+++ b/tests/nested/core/core20-kernel-reseal/task.yaml
@@ -26,30 +26,30 @@ prepare: |
   snap pack pc-kernel
   rm -rf pc-kernel
   mv pc-kernel_*.snap new-pc-kernel.snap
-  nested_copy new-pc-kernel.snap
+  tests.nested copy new-pc-kernel.snap
 
 execute: |
   # shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
-  SEALED_KEY_MTIME_1="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
-  RESEAL_COUNT_1="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+  SEALED_KEY_MTIME_1="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  RESEAL_COUNT_1="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
 
   echo "Install new (unasserted) kernel and wait for reboot/change finishing"
   boot_id="$( nested_get_boot_id )"
-  REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous new-pc-kernel.snap --no-wait)
-  nested_wait_for_reboot "${boot_id}"
-  nested_exec sudo snap watch "${REMOTE_CHG_ID}"
+  REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous new-pc-kernel.snap --no-wait)
+  tests.nested wait-for reboot "${boot_id}"
+  tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
 
   echo "Check that we are using the right kernel"
-  nested_exec sudo grep -q -a "This program cannot be run in XXX mode" /boot/grub/kernel.efi
+  tests.nested exec sudo grep -q -a "This program cannot be run in XXX mode" /boot/grub/kernel.efi
 
   echo "Check ubuntu-data.sealed-key mtime is newer"
-  SEALED_KEY_MTIME_2="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  SEALED_KEY_MTIME_2="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
   test "$SEALED_KEY_MTIME_2" -gt "$SEALED_KEY_MTIME_1"
 
   echo "Check that we have boot chains"
-  nested_exec sudo test -e /var/lib/snapd/device/fde/boot-chains
+  tests.nested exec sudo test -e /var/lib/snapd/device/fde/boot-chains
 
-  RESEAL_COUNT_2="$(nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+  RESEAL_COUNT_2="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
   test "$RESEAL_COUNT_2" -gt "$RESEAL_COUNT_1"

--- a/tests/nested/core/core20-tpm/task.yaml
+++ b/tests/nested/core/core20-tpm/task.yaml
@@ -14,28 +14,28 @@ execute: |
     . "$TESTSLIB/nested.sh"
 
     echo "Verifying tpm working on the nested vm"
-    nested_exec "dmesg | grep -i tpm" | MATCH "efi: +SMBIOS=.* +TPMFinalLog=.*"
-    nested_exec "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
+    tests.nested exec "dmesg | grep -i tpm" | MATCH "efi: +SMBIOS=.* +TPMFinalLog=.*"
+    tests.nested exec "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
 
     echo "and secure boot is enabled on the nested vm"
-    nested_exec "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
+    tests.nested exec "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
 
     echo "and the recovery key is available"
-    nested_exec "test -e /var/lib/snapd/device/fde/recovery.key"
+    tests.nested exec "test -e /var/lib/snapd/device/fde/recovery.key"
     echo "and has the expected size"
-    nested_exec "stat --printf=%s /var/lib/snapd/device/fde/recovery.key" | MATCH '^16$'
+    tests.nested exec "stat --printf=%s /var/lib/snapd/device/fde/recovery.key" | MATCH '^16$'
     echo "and has the expected owner and permissions"
-    nested_exec "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$'
+    tests.nested exec "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$'
 
     echo "and the tpm-{policy-auth-key,lockout-auth} files are in ubuntu-save"
-    nested_exec "test -e /var/lib/snapd/save/device/fde/tpm-policy-auth-key"
-    nested_exec "test -e /var/lib/snapd/save/device/fde/tpm-lockout-auth"
+    tests.nested exec "test -e /var/lib/snapd/save/device/fde/tpm-policy-auth-key"
+    tests.nested exec "test -e /var/lib/snapd/save/device/fde/tpm-lockout-auth"
 
     echo "Grab modeenv content and checksums"
-    nested_exec "cat /var/lib/snapd/modeenv" > modeenv
-    boot_grub_sha3="$(nested_exec "cat /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
-    seed_grub_sha3="$(nested_exec "cat /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
-    seed_shim_sha3="$(nested_exec "cat /run/mnt/ubuntu-seed/EFI/boot/bootx64.efi" | "$TESTSLIB"/tools/sha3-384)"
+    tests.nested exec "cat /var/lib/snapd/modeenv" > modeenv
+    boot_grub_sha3="$(tests.nested exec "cat /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
+    seed_grub_sha3="$(tests.nested exec "cat /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
+    seed_shim_sha3="$(tests.nested exec "cat /run/mnt/ubuntu-seed/EFI/boot/bootx64.efi" | "$TESTSLIB"/tools/sha3-384)"
 
     # modeenv entries look like this:
     # current_trusted_boot_assets={"grubx64.efi":["2e03571ce08de6cdde8a0ad80db8777c411af66073b795e514ad365da842920c9d50eaa0c3b45e878b9c8723cb22e0df"]}
@@ -47,19 +47,19 @@ execute: |
     grep current_trusted_recovery_boot_assets= < modeenv  | MATCH "\"bootx64.efi\":\[\"$seed_shim_sha3\"\]"
 
     echo "Check that files exist too"
-    nested_exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${boot_grub_sha3}" | \
+    tests.nested exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${boot_grub_sha3}" | \
         "$TESTSLIB"/tools/sha3-384 | MATCH "^$boot_grub_sha3\$"
-    nested_exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${seed_grub_sha3}" | \
+    tests.nested exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${seed_grub_sha3}" | \
         "$TESTSLIB"/tools/sha3-384 | MATCH "^$seed_grub_sha3\$"
-    nested_exec "cat /var/lib/snapd/boot-assets/grub/bootx64.efi-${seed_shim_sha3}" | \
+    tests.nested exec "cat /var/lib/snapd/boot-assets/grub/bootx64.efi-${seed_shim_sha3}" | \
         "$TESTSLIB"/tools/sha3-384 | MATCH "^$seed_shim_sha3\$"
 
     echo "Check for sealed keys marker"
-    nested_exec "test -f /var/lib/snapd/device/fde/sealed-keys"
+    tests.nested exec "test -f /var/lib/snapd/device/fde/sealed-keys"
 
     echo "Check that kernel command line is properly recorded"
     cmdline_modeenv="$(grep current_kernel_command_lines= < modeenv  | sed -e 's/current_kernel_command_lines=//' | jq -r '.[0]')"
-    cmdline="$(nested_exec "cat /proc/cmdline")"
+    cmdline="$(tests.nested exec "cat /proc/cmdline")"
     test "$cmdline" = "$cmdline_modeenv"
     echo "$cmdline" | MATCH "snapd_recovery_mode=run "
 
@@ -71,16 +71,16 @@ execute: |
 
     echo "Check compatibility scenarios:"
     echo "1. that kernel command lines is restored when booted successfully"
-    nested_exec "sudo sed -i -e 's/current_kernel_command_lines=.*/current_kernel_command_lines=/' /var/lib/snapd/modeenv"
+    tests.nested exec "sudo sed -i -e 's/current_kernel_command_lines=.*/current_kernel_command_lines=/' /var/lib/snapd/modeenv"
     echo "2. good recovery systems is populated with current systems"
-    nested_exec "sudo sed -i -e 's/good_recovery_systems=.*/good_recovery_systems=/' /var/lib/snapd/modeenv"
+    tests.nested exec "sudo sed -i -e 's/good_recovery_systems=.*/good_recovery_systems=/' /var/lib/snapd/modeenv"
 
     boot_id="$( nested_get_boot_id )"
-    nested_exec "sudo reboot" || true
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested exec "sudo reboot" || true
+    tests.nested wait-for reboot "${boot_id}"
     echo "Check the test will race with snapd updating the modeenv, wait for the modenv to have a good state"
-    nested_retry_until_success 10 5 "grep -E \"current_kernel_command_lines=.*snapd_recovery_mode=run\" < /var/lib/snapd/modeenv"
-    nested_exec "cat /var/lib/snapd/modeenv" > modeenv.after-reboot
+    tests.nested retry_until_success 10 5 "grep -E \"current_kernel_command_lines=.*snapd_recovery_mode=run\" < /var/lib/snapd/modeenv"
+    tests.nested exec "cat /var/lib/snapd/modeenv" > modeenv.after-reboot
     echo "Check the kernel command line is restored"
     cmdline_modeenv_restored="$(grep current_kernel_command_lines= < modeenv.after-reboot  | sed -e 's/current_kernel_command_lines=//' | jq -r '.[0]')"
     test "$cmdline_modeenv_restored" = "$cmdline_modeenv"

--- a/tests/nested/core/coreconfig-services/task.yaml
+++ b/tests/nested/core/coreconfig-services/task.yaml
@@ -5,17 +5,17 @@ systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 execute: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
-  nested_exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"
+  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"
 
   echo "Disabling systemd-resolved service"
-  nested_exec "sudo snap set system service.systemd-resolved.disable=true"
-  nested_exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
+  tests.nested exec "sudo snap set system service.systemd-resolved.disable=true"
+  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
 
   current_boot_id=$(nested_get_boot_id)
-  nested_exec "sudo reboot" || true
-  nested_wait_for_reboot "$current_boot_id"
+  tests.nested exec "sudo reboot" || true
+  tests.nested wait-for reboot "$current_boot_id"
 
   echo "Enabling systemd-resolved service back"
-  nested_exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
-  nested_exec "sudo snap set system service.systemd-resolved.disable=false"
-  nested_exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"
+  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
+  tests.nested exec "sudo snap set system service.systemd-resolved.disable=false"
+  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"

--- a/tests/nested/core/extra-snaps-assertions/task.yaml
+++ b/tests/nested/core/extra-snaps-assertions/task.yaml
@@ -7,10 +7,10 @@ execute: |
     . "$TESTSLIB/nested.sh"
 
     echo "Wait for first boot to be done"
-    while ! nested_exec "snap changes" | MATCH "Done.*Initialize system state"; do sleep 1; done
+    while ! tests.nested exec "snap changes" | MATCH "Done.*Initialize system state"; do sleep 1; done
 
     echo "We have a model assertion"
-    nested_exec "snap known model" | MATCH "series: 16"
+    tests.nested exec "snap known model" | MATCH "series: 16"
 
     EXPRESSION="^core .* +latest/$NESTED_CORE_CHANNEL +canonical\\* +core"
     if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "true" ]; then
@@ -18,4 +18,4 @@ execute: |
     fi
 
     echo "Make sure core has an actual revision"
-    nested_exec "snap list --unicode=never" | MATCH "$EXPRESSION"
+    tests.nested exec "snap list --unicode=never" | MATCH "$EXPRESSION"

--- a/tests/nested/core/hotplug/task.yaml
+++ b/tests/nested/core/hotplug/task.yaml
@@ -53,7 +53,7 @@ execute: |
     hotplug_add_dev1
 
     # sanity checks to make sure qemu setup is correct
-    nested_retry "--wait 1 -n 5 sh -c 'udevadm info -e | grep -qE ID_MODEL=QEMU_USB_SERIAL'"
+    tests.nested retry "--wait 1 -n 5 sh -c 'udevadm info -e | grep -qE ID_MODEL=QEMU_USB_SERIAL'"
 
     tests.nested exec "ls /dev/tty*" | MATCH "ttyUSB0"
 

--- a/tests/nested/core/hotplug/task.yaml
+++ b/tests/nested/core/hotplug/task.yaml
@@ -7,13 +7,13 @@ prepare: |
     . "$TESTSLIB/nested.sh"
 
     snap pack "$TESTSLIB"/snaps/serial-port-hotplug
-    nested_copy serial-port-hotplug_1.0_all.snap
+    tests.nested copy serial-port-hotplug_1.0_all.snap
 
     if nested_is_core_18_system; then
-        nested_exec "sudo snap install --devmode jq-core18"
-        nested_exec "sudo snap alias jq-core18.jq jq"
+        tests.nested exec "sudo snap install --devmode jq-core18"
+        tests.nested exec "sudo snap alias jq-core18.jq jq"
     else
-        nested_exec "sudo snap install --devmode jq"
+        tests.nested exec "sudo snap install --devmode jq"
     fi
 
 restore: |
@@ -24,10 +24,10 @@ debug: |
     . "$TESTSLIB/nested.sh"
 
     set +e
-    nested_exec "snap connections --all"
-    nested_exec "snap list"
-    nested_exec "dmesg"
-    nested_exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
+    tests.nested exec "snap connections --all"
+    tests.nested exec "snap list"
+    tests.nested exec "dmesg"
+    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
     set -e
 
 execute: |
@@ -41,26 +41,26 @@ execute: |
         refresh_to_new_core "$NESTED_CORE_REFRESH_CHANNEL"
     fi
 
-    if nested_exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+    if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
         echo "USB serial already registered, exiting..."
         exit 1
     fi
 
     echo "Enabling hotplug"
-    nested_exec "sudo snap set core experimental.hotplug=true"
+    tests.nested exec "sudo snap set core experimental.hotplug=true"
 
     echo "Plugging the device"
     hotplug_add_dev1
 
     # sanity checks to make sure qemu setup is correct
     for _ in $(seq 5); do
-        if nested_exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+        if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
             break
         fi
         sleep 1
     done
 
-    nested_exec "ls /dev/tty*" | MATCH "ttyUSB0"
+    tests.nested exec "ls /dev/tty*" | MATCH "ttyUSB0"
 
     echo "Checking that qemuusbserial hotplug slot is present"
     check_slot_present qemuusbserial
@@ -72,13 +72,13 @@ execute: |
 
     # sanity check to make sure qemu event was triggered correctly
     for _ in $(seq 5); do
-        if nested_exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+        if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
             sleep 1
         else
             break
         fi
     done
-    if nested_exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+    if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
         echo "USB serial should not be registered anymore, exiting..."
         exit 1
     fi
@@ -94,10 +94,10 @@ execute: |
     check_slot_present qemuusbserial
 
     echo "Installing test snap with serial port plug"
-    nested_exec "sudo snap install --dangerous serial-port-hotplug_1.0_all.snap"
+    tests.nested exec "sudo snap install --dangerous serial-port-hotplug_1.0_all.snap"
 
     echo "Connecting hotplug slot of the first device"
-    nested_exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
+    tests.nested exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_connected qemuusbserial
 
     echo "Veryfing serial-port permissions of the snap"
@@ -138,16 +138,16 @@ execute: |
     verify_apparmor_profile "/dev/ttyUSB1"
 
     echo "Restarting snapd should restore both hotplug slots since devices are still present"
-    nested_exec "sudo systemctl stop snapd.service snapd.socket"
-    nested_exec "sudo systemctl start snapd.service snapd.socket"
+    tests.nested exec "sudo systemctl stop snapd.service snapd.socket"
+    tests.nested exec "sudo systemctl start snapd.service snapd.socket"
     check_slot_connected qemuusbserial
     check_slot_not_gone qemuusbserial
     check_slot_present qemuusbserial-1
 
     echo "Unplugging first device while snapd is stopped and then starting snapd remembers the slot internally due to connection"
-    nested_exec "sudo systemctl stop snapd.service snapd.socket"
+    tests.nested exec "sudo systemctl stop snapd.service snapd.socket"
     hotplug_del_dev1
-    nested_exec "sudo systemctl start snapd.service snapd.socket"
+    tests.nested exec "sudo systemctl start snapd.service snapd.socket"
     check_slot_not_present qemuusbserial
     check_slot_gone qemuusbserial
 
@@ -159,7 +159,7 @@ execute: |
     echo "Disconnecting first slot and then unplugging the device removes the slot completely"
     # manual snap disconnect doesn't implement retry and errors out if there are conflicting changes, so wait for hotplug changes to complete
     wait_for_all_changes
-    nested_exec "sudo snap disconnect serial-port-hotplug:serial-port :qemuusbserial"
+    tests.nested exec "sudo snap disconnect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_present qemuusbserial
     hotplug_del_dev1
     check_slot_not_present qemuusbserial
@@ -177,10 +177,10 @@ execute: |
     check_slot_device_path qemuusbserial "/dev/ttyUSB0"
 
     echo "Connecting hotplug slot of the first device again"
-    nested_exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
+    tests.nested exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_connected qemuusbserial
 
     echo "Hotplug slot stays after removing the snap"
-    nested_exec "sudo snap remove serial-port-hotplug"
+    tests.nested exec "sudo snap remove serial-port-hotplug"
     check_slot_present qemuusbserial
     check_slot_not_gone qemuusbserial

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -23,11 +23,11 @@ prepare: |
     # build the attacker cloud-init NoCloud cdrom drive
     nested_build_seed_cdrom "$TESTSLIB/cloud-init-seeds/attacker-user" seed2.iso cidata user-data meta-data
 
-    "$TESTSTOOLS"/nested-state build-image core 
+    tests.nested build-image core 
 
     # first boot will use seed1 which is empty, but the same file name will be 
     # replace while the VM is shutdown to use the second attacker iso
-    "$TESTSTOOLS"/nested-state create-vm core --param-cdrom "-cdrom $(pwd)/seed.iso"
+    tests.nested create-vm core --param-cdrom "-cdrom $(pwd)/seed.iso"
 
 debug: |
     if [ -f snapd-before-reboot.logs ]; then
@@ -37,7 +37,7 @@ debug: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
     echo "logs from current nested VM boot snapd"
-    nested_exec "sudo journalctl -e --no-pager -u snapd" || true
+    tests.nested exec "sudo journalctl -e --no-pager -u snapd" || true
 
 execute: |
     #shellcheck source=tests/lib/nested.sh
@@ -50,7 +50,7 @@ execute: |
     # cloud-init when it is installed
 
     echo "Wait for done seeding"
-    nested_exec "sudo snap wait system seed.loaded"
+    tests.nested exec "sudo snap wait system seed.loaded"
 
     echo "Prepare snapd snapto install with the fix"
     # if we are not building from current, then we need to prep the snapd snap
@@ -60,22 +60,22 @@ execute: |
         if nested_is_core_16_system; then
             # build the core snap for this run
             repack_snapd_deb_into_core_snap "$PWD"
-            nested_copy "$PWD/core-from-snapd-deb.snap"
+            tests.nested copy "$PWD/core-from-snapd-deb.snap"
 
             # install the core snap
-            nested_exec "sudo snap install core-from-snapd-deb.snap --dangerous"
+            tests.nested exec "sudo snap install core-from-snapd-deb.snap --dangerous"
 
             # now we wait for the reboot for the new core snap
-            nested_wait_for_no_ssh
-            nested_wait_for_ssh
+            tests.nested wait-for no-ssh
+            tests.nested wait-for ssh
             
         else
             # build the snapd snap for this run
             repack_snapd_deb_into_snapd_snap "$PWD"
-            nested_copy "$PWD/snapd-from-deb.snap"
+            tests.nested copy "$PWD/snapd-from-deb.snap"
 
             # install the snapd snap
-            nested_exec "sudo snap install snapd-from-deb.snap --dangerous"
+            tests.nested exec "sudo snap install snapd-from-deb.snap --dangerous"
         fi
     fi
 
@@ -93,7 +93,7 @@ execute: |
     # not have been triggered. 
 
     echo "Waiting for cloud-init..."
-    nested_exec "cloud-init status --wait"
+    tests.nested exec "cloud-init status --wait"
 
     # TODO: is there a better thing we can wait for here instead? maybe the log
     # message from snapd directly via journalctl ?
@@ -102,37 +102,37 @@ execute: |
 
     # ensure that snapd disabled cloud-init with the cloud-init.disabled file
     echo "Ensuring that snapd restricted cloud-init"
-    nested_exec "cloud-init status" | MATCH "status: disabled"
-    nested_exec "test -f /etc/cloud/cloud-init.disabled"
-    nested_exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+    tests.nested exec "cloud-init status" | MATCH "status: disabled"
+    tests.nested exec "test -f /etc/cloud/cloud-init.disabled"
+    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
 
     echo "Save snapd logs before continuing as the logs are not persistent"
-    nested_exec "sudo journalctl -e --no-pager -u snapd" > snapd-before-reboot.logs
+    tests.nested exec "sudo journalctl -e --no-pager -u snapd" > snapd-before-reboot.logs
 
     echo "Gracefully shutting down the nested VM to prepare a simulated attack"
     boot_id="$(nested_get_boot_id)"
-    "$TESTSTOOLS"/nested-state stop-vm
+    tests.nested stop-vm
 
     echo "Replace the empty seed.iso with the new attacker iso"
     mv seed2.iso seed.iso
 
     echo "Restarting nested VM with attacker cloud-init CD-ROM drive"
-    "$TESTSTOOLS"/nested-state start-vm
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested start-vm
+    tests.nested wait-for reboot "${boot_id}"
 
     # cloud-init should not actually run, since it was disabled, but in case the
     # test fails, for a better error, we will wait for cloud-init to report that
     # it is "done" or at least steady before ensuring that the attacker-user was
     # not created.
     echo "Waiting for cloud-init..."
-    nested_exec "cloud-init status --wait"
+    tests.nested exec "cloud-init status --wait"
 
     # the attacker-user should not have been created
     echo "The cloud-init user was not created"
-    nested_exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
+    tests.nested exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
 
     # cloud-init should still be disabled
     echo "cloud-init is still disabled"
-    nested_exec "cloud-init status" | MATCH "status: disabled"
-    nested_exec "test -f /etc/cloud/cloud-init.disabled"
-    nested_exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+    tests.nested exec "cloud-init status" | MATCH "status: disabled"
+    tests.nested exec "test -f /etc/cloud/cloud-init.disabled"
+    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -96,7 +96,7 @@ execute: |
     tests.nested exec "cloud-init status --wait"
 
     echo "Waiting for snapd to react to cloud-init"
-    nested_retry "--wait 1 -n 60 sh -c 'cloud-init status | MATCH \"status: disabled\"'"
+    tests.nested retry "--wait 1 -n 60 sh -c 'cloud-init status | MATCH \"status: disabled\"'"
     
     # ensure that snapd disabled cloud-init with the cloud-init.disabled file
     echo "Ensuring that snapd restricted cloud-init"

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -96,7 +96,7 @@ execute: |
     tests.nested exec "cloud-init status --wait"
 
     echo "Waiting for snapd to react to cloud-init"
-    tests.nested retry "--wait 1 -n 60 sh -c 'cloud-init status | MATCH \"status: disabled\"'"
+    tests.nested retry "--wait 1 -n 60 sh -c 'cloud-init status | grep -qE \"status: disabled\"'"
     
     # ensure that snapd disabled cloud-init with the cloud-init.disabled file
     echo "Ensuring that snapd restricted cloud-init"

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -26,11 +26,11 @@ prepare: |
     # second boot - attacker drive
     nested_build_seed_cdrom "$TESTSLIB/cloud-init-seeds/attacker-user" seed2.iso cidata user-data meta-data
 
-    "$TESTSTOOLS"/nested-state build-image core 
+    tests.nested build-image core 
 
     # first boot uses seed1 to create the normal-user in addition to the 
     # system-user assertion
-    "$TESTSTOOLS"/nested-state create-vm core --param-cdrom "-cdrom $(pwd)/seed.iso"
+    tests.nested create-vm core --param-cdrom "-cdrom $(pwd)/seed.iso"
 
 debug: |
     if [ -f snapd-before-reboot.logs ]; then
@@ -40,7 +40,7 @@ debug: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
     echo "logs from current nested VM boot snapd"
-    nested_exec "sudo journalctl -e --no-pager -u snapd" || true
+    tests.nested exec "sudo journalctl -e --no-pager -u snapd" || true
 
 execute: |
     #shellcheck source=tests/lib/nested.sh
@@ -54,13 +54,13 @@ execute: |
     # the legitimate cloud-init user is the normal-user user
 
     # wait for cloud-init to finish importing the first seed
-    nested_exec "sudo cloud-init status --wait"
+    tests.nested exec "sudo cloud-init status --wait"
 
     echo "The initial cloud-init user was created"
-    nested_exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
+    tests.nested exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
 
     # wait for snap seeding to be done
-    nested_exec "sudo snap wait system seed.loaded"
+    tests.nested exec "sudo snap wait system seed.loaded"
 
     # if we are not building from current, then we need to prep the snapd snap
     # to install with the fix, this simulates/verifies that devices in the field
@@ -70,21 +70,21 @@ execute: |
         if is_core_16_nested_system; then
             # build the core snap for this run
             repack_snapd_deb_into_core_snap "$PWD"
-            nested_copy "$PWD/core-from-snapd-deb.snap"
+            tests.nested copy "$PWD/core-from-snapd-deb.snap"
 
             # install the core snap
-            nested_exec "sudo snap install core-from-snapd-deb.snap --dangerous"
+            tests.nested exec "sudo snap install core-from-snapd-deb.snap --dangerous"
 
             # now we wait for the reboot for the new core snap
-            nested_wait_for_no_ssh
-            nested_wait_for_ssh        
+            tests.nested wait-for no-ssh
+            tests.nested wait-for ssh        
         else
             # build the snapd snap for this run
             repack_snapd_deb_into_snapd_snap "$PWD"
-            nested_copy "$PWD/snapd-from-deb.snap"
+            tests.nested copy "$PWD/snapd-from-deb.snap"
 
             # install the snapd snap
-            nested_exec "sudo snap install snapd-from-deb.snap --dangerous"
+            tests.nested exec "sudo snap install snapd-from-deb.snap --dangerous"
         fi
     fi
 
@@ -100,7 +100,7 @@ execute: |
     # action that we can test for.
 
     echo "Waiting for cloud-init..."
-    nested_exec "cloud-init status --wait"
+    tests.nested exec "cloud-init status --wait"
 
     # TODO: is there a better thing we can wait for here instead? maybe the log
     # message from snapd directly via journalctl ?
@@ -109,37 +109,37 @@ execute: |
 
     # ensure that snapd restricted cloud-init with the zzzz_snapd.cfg file
     echo "Ensuring that snapd restricted cloud-init"
-    nested_exec "cloud-init status" | MATCH "status: done"
-    nested_exec "test ! -f /etc/cloud/cloud-init.disabled"
-    nested_exec "test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
-    nested_exec "cat /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg" | MATCH "manual_cache_clean: true"
+    tests.nested exec "cloud-init status" | MATCH "status: done"
+    tests.nested exec "test ! -f /etc/cloud/cloud-init.disabled"
+    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+    tests.nested exec "cat /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg" | MATCH "manual_cache_clean: true"
 
     # save snapd logs before continuing as the logs are not persistent
-    nested_exec "sudo journalctl -e --no-pager -u snapd" > snapd-before-reboot.logs
+    tests.nested exec "sudo journalctl -e --no-pager -u snapd" > snapd-before-reboot.logs
 
     # gracefully shutdown so that we don't have file corruption
     echo "Gracefully shutting down the nested VM to prepare a simulated attack"
     boot_id="$(nested_get_boot_id)"
-    "$TESTSTOOLS"/nested-state stop-vm
+    tests.nested stop-vm
 
     # replace the seed.iso with the new attacker iso
     mv seed2.iso seed.iso
 
     echo "Restarting nested VM with attacker cloud-init CD-ROM drive"
-    "$TESTSTOOLS"/nested-state start-vm
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested start-vm
+    tests.nested wait-for reboot "${boot_id}"
 
     # cloud-init will actually still run because it was not disabled and we
     # provided a cloud-init drive but importantly, it will not import the drive,
     # so wait for cloud-init to settle down before continuing
     echo "Waiting for cloud-init..."
-    nested_exec "cloud-init status --wait"
+    tests.nested exec "cloud-init status --wait"
 
     # the attacker-user should not have been created
     echo "The cloud-init attacker user was not created"
-    nested_exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
+    tests.nested exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
 
     echo "cloud-init is still restricted"
-    nested_exec "cloud-init status" | MATCH "status: done"
-    nested_exec "test ! -f /etc/cloud/cloud-init.disabled"
-    nested_exec "test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+    tests.nested exec "cloud-init status" | MATCH "status: done"
+    tests.nested exec "test ! -f /etc/cloud/cloud-init.disabled"
+    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -103,7 +103,7 @@ execute: |
     tests.nested exec "cloud-init status --wait"
 
     echo "Waiting for snapd to react to cloud-init"
-    nested_retry "--wait 1 -n 60 sh -c 'cloud-init status | MATCH \"status: disabled\"'"
+    tests.nested retry "--wait 1 -n 60 sh -c 'cloud-init status | MATCH \"status: disabled\"'"
 
     # ensure that snapd restricted cloud-init with the zzzz_snapd.cfg file
     echo "Ensuring that snapd restricted cloud-init"

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -103,7 +103,7 @@ execute: |
     tests.nested exec "cloud-init status --wait"
 
     echo "Waiting for snapd to react to cloud-init"
-    tests.nested retry "--wait 1 -n 60 sh -c 'cloud-init status | MATCH \"status: disabled\"'"
+    tests.nested retry "--wait 1 -n 60 sh -c 'cloud-init status | grep -qE \"status: disabled\"'"
 
     # ensure that snapd restricted cloud-init with the zzzz_snapd.cfg file
     echo "Ensuring that snapd restricted cloud-init"

--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -28,7 +28,7 @@ prepare: |
     KERNEL_SNAP=$(ls pc-kernel_*.snap)
     mv "$KERNEL_SNAP" extra-snaps/
 
-    "$TESTSTOOLS"/nested-state build-image core 
+    tests.nested build-image core 
 
     # Modify seed to use devmode for pc gadget snap. This is needed for the
     # install hook to have access to /etc/systemd. Ideally we would use
@@ -43,23 +43,23 @@ prepare: |
     kpartx -d "$NESTED_IMAGES_DIR/$IMAGE_NAME"
     rmdir "$tmp"
 
-    "$TESTSTOOLS"/nested-state create-vm core
+    tests.nested create-vm core
 
 execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
-    nested_exec "sudo snap wait system seed.loaded"
+    tests.nested exec "sudo snap wait system seed.loaded"
 
     echo "Test that rsyslog was disabled early."
     # early config is witnessed by install hook of the pc gadget
-    nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
-    nested_exec "test -L /etc/systemd/system/rsyslog.service"
+    tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
+    tests.nested exec "test -L /etc/systemd/system/rsyslog.service"
 
     echo "Check that the timezone is set"
-    nested_exec "cat /etc/timezone" | MATCH "Europe/Malta"
-    nested_exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
-    nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
+    tests.nested exec "cat /etc/timezone" | MATCH "Europe/Malta"
+    tests.nested exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
+    tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
 
     echo "Check that console-conf is disabled"
-    nested_exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
+    tests.nested exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"

--- a/tests/nested/manual/core20-boot-config-update/task.yaml
+++ b/tests/nested/manual/core20-boot-config-update/task.yaml
@@ -62,10 +62,10 @@ prepare: |
     snap pack pc-gadget/ extra-snaps/
   fi
 
-  "$TESTSTOOLS"/nested-state build-image core
-  "$TESTSTOOLS"/nested-state create-vm core
+  tests.nested build-image core
+  tests.nested create-vm core
 
-  nested_copy snapd-boot-config-update.snap
+  tests.nested copy snapd-boot-config-update.snap
 
 debug: |
   cat boot-chains-before.json || true
@@ -80,8 +80,8 @@ execute: |
   # shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
-  nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-before.json
-  SEALED_KEY_MTIME_1="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-before.json
+  SEALED_KEY_MTIME_1="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
   RESEAL_COUNT_1="$(jq -r '.["reseal-count"]' < boot-chains-before.json )"
   jq -r '.["boot-chains"][]["kernel-cmdlines"][]' < boot-chains-before.json | NOMATCH ' bootassetstesting'
   case "$VARIANT" in
@@ -98,21 +98,21 @@ execute: |
 
   echo "Install new (unasserted) snapd and wait for reboot/change finishing"
   boot_id="$( nested_get_boot_id )"
-  REMOTE_CHG_ID=$(nested_exec sudo snap install --dangerous snapd-boot-config-update.snap --no-wait)
-  nested_exec sudo snap watch "${REMOTE_CHG_ID}"
+  REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous snapd-boot-config-update.snap --no-wait)
+  tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
   if [ "$VARIANT" != "gadget-full" ]; then
     # reboot is automatically requested by snapd only if part of the command
     # line is changed, in case of gadget overriding the command line fully
     # (gadget-full variant) the static part of the command line from new snapd
     # is not used, hence there is no resealing and no reboot
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested wait-for reboot "${boot_id}"
   fi
   
   echo "check boot assets have been updated"
-  nested_exec "sudo cat /boot/grub/grub.cfg" | MATCH "Snapd-Boot-Config-Edition: 2"
-  nested_exec "sudo cat /boot/grub/grub.cfg" | MATCH "set snapd_static_cmdline_args='.*bootassetstesting'"
+  tests.nested exec "sudo cat /boot/grub/grub.cfg" | MATCH "Snapd-Boot-Config-Edition: 2"
+  tests.nested exec "sudo cat /boot/grub/grub.cfg" | MATCH "set snapd_static_cmdline_args='.*bootassetstesting'"
 
-  nested_exec "cat /proc/cmdline" > system.cmdline
+  tests.nested exec "cat /proc/cmdline" > system.cmdline
 
   case "$VARIANT" in
     no-gadget)
@@ -132,7 +132,7 @@ execute: |
   esac
 
   echo "Check ubuntu-data.sealed-key mtime is newer or not depending on test variant"
-  SEALED_KEY_MTIME_2="$(nested_exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  SEALED_KEY_MTIME_2="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
   case "$VARIANT" in
     no-gadget|gadget-extra)
       test "$SEALED_KEY_MTIME_2" -gt "$SEALED_KEY_MTIME_1"
@@ -142,7 +142,7 @@ execute: |
       ;;
   esac
 
-  nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-after.json
+  tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-after.json
   RESEAL_COUNT_2="$(jq -r '.["reseal-count"]' < boot-chains-after.json )"
   case "$VARIANT" in
     no-gadget|gadget-extra)

--- a/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
+++ b/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
@@ -46,11 +46,11 @@ prepare: |
     rm pc-gadget/cmdline.full
     snap pack pc-gadget --filename=pc-gadget-cmdline-none.snap
 
-    "$TESTSTOOLS"/nested-state build-image core
-    "$TESTSTOOLS"/nested-state create-vm core
+    tests.nested build-image core
+    tests.nested create-vm core
 
     for f in pc-gadget-cmdline-extra-updated.snap pc-gadget-cmdline-full.snap pc-gadget-cmdline-none.snap; do
-        nested_copy "$f"
+        tests.nested copy "$f"
     done
 
 debug: |
@@ -65,49 +65,49 @@ execute: |
 
     echo "Make sure the system is encrypted"
     # in which case the boot chains must exist
-    nested_exec sudo cat /var/lib/snapd/device/fde/boot-chains
+    tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains
 
     # system is in run mode
     echo "Make sure the system is in run mode"
-    nested_exec 'sudo cat /proc/cmdline' > system.cmdline.run
+    tests.nested exec 'sudo cat /proc/cmdline' > system.cmdline.run
     MATCH snapd_recovery_mode=run < system.cmdline.run
 
     echo "Verify kernel command line in run mode"
     MATCH 'snapd_recovery_mode=run .* hello from test$' < system.cmdline.run
 
     echo "Perform an update of the gadget"
-    REMOTE_CHG_ID=$(nested_exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-extra-updated.snap')
+    REMOTE_CHG_ID=$(tests.nested exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-extra-updated.snap')
 
     echo "Wait for reboot"
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested wait-for reboot "${boot_id}"
     boot_id="$(nested_get_boot_id)"
-    nested_exec 'sudo cat /proc/cmdline' | MATCH 'snapd_recovery_mode=run .* updated hello from test'
+    tests.nested exec 'sudo cat /proc/cmdline' | MATCH 'snapd_recovery_mode=run .* updated hello from test'
     # wait for previous change to finish before proceeding
-    nested_exec sudo snap watch "$REMOTE_CHG_ID"
+    tests.nested exec sudo snap watch "$REMOTE_CHG_ID"
 
     echo "Update to gadget with no command line"
-    REMOTE_CHG_ID=$(nested_exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-none.snap')
-    nested_wait_for_reboot "${boot_id}"
+    REMOTE_CHG_ID=$(tests.nested exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-none.snap')
+    tests.nested wait-for reboot "${boot_id}"
     boot_id="$(nested_get_boot_id)"
     echo "Verify that custom command line elements are not present"
-    nested_exec 'sudo cat /proc/cmdline' | NOMATCH 'hello from test'
+    tests.nested exec 'sudo cat /proc/cmdline' | NOMATCH 'hello from test'
     # wait for previous change to finish before proceeding
-    nested_exec sudo snap watch "$REMOTE_CHG_ID"
+    tests.nested exec sudo snap watch "$REMOTE_CHG_ID"
 
     echo "Update to gadget with full command line"
-    REMOTE_CHG_ID=$(nested_exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-full.snap')
-    nested_wait_for_reboot "${boot_id}"
+    REMOTE_CHG_ID=$(tests.nested exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-full.snap')
+    tests.nested wait-for reboot "${boot_id}"
     boot_id="$(nested_get_boot_id)"
-    nested_exec 'sudo cat /proc/cmdline' | MATCH 'snapd_recovery_mode=run snapd.debug=1 console=ttyS0 full hello from test'
+    tests.nested exec 'sudo cat /proc/cmdline' | MATCH 'snapd_recovery_mode=run snapd.debug=1 console=ttyS0 full hello from test'
     # wait for previous change to finish before proceeding
-    nested_exec sudo snap watch "$REMOTE_CHG_ID"
+    tests.nested exec sudo snap watch "$REMOTE_CHG_ID"
 
     echo "Transition to recover mode to verify kernel command line"
-    nested_exec 'sudo snap reboot --recover'
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested exec 'sudo snap reboot --recover'
+    tests.nested wait-for reboot "${boot_id}"
 
     echo "Check the vm is in recover mode"
-    nested_exec 'sudo cat /proc/cmdline' > system.cmdline.recover
+    tests.nested exec 'sudo cat /proc/cmdline' > system.cmdline.recover
     MATCH snapd_recovery_mode=recover < system.cmdline.recover
 
     MATCH 'snapd_recovery_mode=recover snapd_recovery_system=.* .* hello from test$' < system.cmdline.recover

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -32,8 +32,8 @@ prepare: |
 
     rm -f "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
 
-    "$TESTSTOOLS"/nested-state build-image core
-    "$TESTSTOOLS"/nested-state create-vm core
+    tests.nested build-image core
+    tests.nested create-vm core
 
 execute: |
     #shellcheck source=tests/lib/nested.sh
@@ -43,30 +43,30 @@ execute: |
         # sanity - check that defaults were applied; note this doesn't guarantee
         # that defaults were applied early - that is checked further down.
         echo "Sanity check of the gadget defaults"
-        nested_exec "sudo snap get system service.rsyslog.disable" | MATCH "true"
-        nested_exec "sudo snap get system watchdog.runtime-timeout" | MATCH "13m"
-        nested_exec "sudo snap get system system.power-key-action" | MATCH "ignore"
-        nested_exec "sudo snap get system system.disable-backlight-service" | MATCH "true"
+        tests.nested exec "sudo snap get system service.rsyslog.disable" | MATCH "true"
+        tests.nested exec "sudo snap get system watchdog.runtime-timeout" | MATCH "13m"
+        tests.nested exec "sudo snap get system system.power-key-action" | MATCH "ignore"
+        tests.nested exec "sudo snap get system system.disable-backlight-service" | MATCH "true"
 
-        nested_exec "test -L /etc/systemd/system/rsyslog.service"
-        nested_exec "cat /etc/systemd/logind.conf.d/00-snap-core.conf" | MATCH "HandlePowerKey=ignore"
-        nested_exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=780"
-        nested_exec "test -L /etc/systemd/system/systemd-backlight@.service"
+        tests.nested exec "test -L /etc/systemd/system/rsyslog.service"
+        tests.nested exec "cat /etc/systemd/logind.conf.d/00-snap-core.conf" | MATCH "HandlePowerKey=ignore"
+        tests.nested exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=780"
+        tests.nested exec "test -L /etc/systemd/system/systemd-backlight@.service"
 
         echo "Test that defaults were applied early."
         # early config is witnessed by install hook of the pc gadget. Note we can
         # only check rsyslog/backlight symlinks as other core settings cannot be
         # inspected from install hook of the gadget.
-        nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
-        nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "backlight symlink: /dev/null"
+        tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
+        tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "backlight symlink: /dev/null"
 
         # timezone is set
-        nested_exec "cat /etc/timezone" | MATCH "Europe/Malta"
-        nested_exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
-        nested_exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
+        tests.nested exec "cat /etc/timezone" | MATCH "Europe/Malta"
+        tests.nested exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
+        tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
 
         # check console-conf disabled
-        nested_exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
+        tests.nested exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
     }
 
     check_core20_early_config
@@ -74,16 +74,16 @@ execute: |
     echo "Transition to recover mode and check it again"
     boot_id="$(nested_get_boot_id)"
     # shellcheck disable=SC2016
-    nested_exec 'sudo snap reboot --recover'
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested exec 'sudo snap reboot --recover'
+    tests.nested wait-for reboot "${boot_id}"
 
     echo "Check the vm is in recover mode"
-    nested_exec 'sudo cat /proc/cmdline' | MATCH snapd_recovery_mode=recover
+    tests.nested exec 'sudo cat /proc/cmdline' | MATCH snapd_recovery_mode=recover
 
     echo "Wait for the snap command to be available since recover mode needs to seed itself"
-    nested_wait_for_snap_command
+    tests.nested wait-for snap-command
 
     echo "Wait for snap seeding to be done"
-    nested_exec "sudo snap wait system seed.loaded"
+    tests.nested exec "sudo snap wait system seed.loaded"
 
     check_core20_early_config

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -25,15 +25,15 @@ prepare: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
-  "$TESTSTOOLS"/nested-state build-image core
-  "$TESTSTOOLS"/nested-state create-vm core
+  tests.nested build-image core
+  tests.nested create-vm core
 
 execute: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
   echo "Verify that the current time in the VM is newer than the model assertion sign time"
-  test "$(nested_exec date --utc '+%s')" -ge "$MODEL_ASSERTION_SIGN_TIME"
+  test "$(tests.nested exec date --utc '+%s')" -ge "$MODEL_ASSERTION_SIGN_TIME"
 
   echo "Verify that the timestamp from after snap-bootstrap ran is greater than the time from the model assertion"
-  test "$(nested_exec "cat /run/mnt/ubuntu-seed/install-after-snap-bootstrap-date")" -ge "$MODEL_ASSERTION_SIGN_TIME"
+  test "$(tests.nested exec "cat /run/mnt/ubuntu-seed/install-after-snap-bootstrap-date")" -ge "$MODEL_ASSERTION_SIGN_TIME"

--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -36,7 +36,7 @@ prepare: |
     cp install-device pc-gadget/meta/hooks/install-device
     snap pack pc-gadget/ extra-snaps/
 
-    "$TESTSTOOLS"/nested-state build-image core
+    tests.nested build-image core
 
 restore: |
     # Cleanup restore is needed in this case because nested tests are not
@@ -81,7 +81,7 @@ execute: |
     MATCH "ubuntu-data" < partitions.txt
 
     echo "Now starting the VM again will proceed to run mode appropriately"
-    "$TESTSTOOLS"/nested-state start-vm
+    tests.nested start-vm
 
     # setup SSH since that was not done with the previous stage, as the device
     # shut down while still in install mode, we need to manually do this stage
@@ -89,12 +89,12 @@ execute: |
 
     # the start-vm command just waits for SSH, it doesn't wait for the other 
     # things here, so wait for those too
-    nested_wait_for_snap_command
+    tests.nested wait-for snap-command
     # Wait for snap seeding to be done
-    nested_exec "sudo snap wait system seed.loaded"
+    tests.nested exec "sudo snap wait system seed.loaded"
     # Wait for cloud init to be done
-    nested_exec "cloud-init status --wait"
+    tests.nested exec "cloud-init status --wait"
 
     echo "The device is using encrypted ubuntu-data and is in run mode now"
-    nested_exec test -L /dev/disk/by-label/ubuntu-data-enc
-    nested_exec cat /proc/cmdline | MATCH "snapd_recovery_mode=run"
+    tests.nested exec test -L /dev/disk/by-label/ubuntu-data-enc
+    tests.nested exec cat /proc/cmdline | MATCH "snapd_recovery_mode=run"

--- a/tests/nested/manual/core20-save/task.yaml
+++ b/tests/nested/manual/core20-save/task.yaml
@@ -28,9 +28,9 @@ environment:
 
 prepare: |
     # NESTED_ENABLE_TPM and NESTED_UBUNTU_SAVE are used by build-image
-    "$TESTSTOOLS"/nested-state build-image core
+    tests.nested build-image core
     # NESTED_ENABLE_TPM is used by create-vm
-    "$TESTSTOOLS"/nested-state create-vm core
+    tests.nested create-vm core
 
 debug: |
     env | sort | grep NESTED_ || true
@@ -48,14 +48,14 @@ execute: |
 
     if [ "${NESTED_UBUNTU_SAVE:-}" != "add" ] && ! nested_is_tpm_enabled; then
         echo "Check that ubuntu-save is not mounted"
-        nested_exec "! mountpoint /run/mnt/ubuntu-save"
-        nested_exec "! mountpoint /var/lib/snapd/save"
+        tests.nested exec "! mountpoint /run/mnt/ubuntu-save"
+        tests.nested exec "! mountpoint /var/lib/snapd/save"
     else
         echo "Check that ubuntu-save is mounted and has a reasonable amount of free space"
         #example df output:
         # Filesystem                                                   1B-blocks  Used Available Use% Mounted on
         # /dev/mapper/ubuntu-save-0bed13ef-f71f-418f-b046-b1ce32dd04a7   5079040 28672   4390912   1% /run/mnt/ubuntu-save
-        save_out="$(nested_exec "df -B1 /run/mnt/ubuntu-save | tail -1")"
+        save_out="$(tests.nested exec "df -B1 /run/mnt/ubuntu-save | tail -1")"
         if nested_is_tpm_enabled; then
             # when encrypted, ubuntu-save is mounted from a dm device
             echo "$save_out" | MATCH '^/dev/mapper/ubuntu-save-[0-9a-z-]+\s+'
@@ -69,27 +69,27 @@ execute: |
         test "$save_size" -gt "$((6*1024*1024))"
 
         # leave a canary
-        nested_exec "sudo touch /run/mnt/ubuntu-save/canary"
+        tests.nested exec "sudo touch /run/mnt/ubuntu-save/canary"
 
-        nested_exec mountpoint /var/lib/snapd/save
+        tests.nested exec mountpoint /var/lib/snapd/save
         # we know that save is mounted using a systemd unit
-        nested_exec systemctl status var-lib-snapd-save.mount
+        tests.nested exec systemctl status var-lib-snapd-save.mount
         # and a canary exists
-        nested_exec "test -f /var/lib/snapd/save/canary"
+        tests.nested exec "test -f /var/lib/snapd/save/canary"
     fi
 
     echo "Transition to recovery mode and check again"
-    recovery_system=$(nested_exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
+    recovery_system=$(tests.nested exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
     nested_uc20_transition_to_system_mode "$recovery_system" "recover"
 
     # happily running in recover mode
 
     if [ "${NESTED_UBUNTU_SAVE:-}" != "add" ] && ! nested_is_tpm_enabled; then
         # no ubuntu-save
-        nested_exec "! mountpoint /run/mnt/ubuntu-save"
-        nested_exec "! mountpoint /var/lib/snapd/save"
+        tests.nested exec "! mountpoint /run/mnt/ubuntu-save"
+        tests.nested exec "! mountpoint /var/lib/snapd/save"
     else
-        recover_save_out="$(nested_exec "df -B1 /run/mnt/ubuntu-save | tail -1")"
+        recover_save_out="$(tests.nested exec "df -B1 /run/mnt/ubuntu-save | tail -1")"
         if nested_is_tpm_enabled; then
             # when encrypted, ubuntu-save is mounted from a dm device
             echo "$recover_save_out" | MATCH '^/dev/mapper/ubuntu-save-[0-9a-z-]+\s+'
@@ -98,5 +98,5 @@ execute: |
             echo "$recover_save_out" | MATCH '^/dev/vda[0-9]\s+'
         fi
         # and a canary exists
-        nested_exec "test -f /run/mnt/ubuntu-save/canary"
+        tests.nested exec "test -f /run/mnt/ubuntu-save/canary"
     fi

--- a/tests/nested/manual/devmode-snap-seeded-dangerous/task.yaml
+++ b/tests/nested/manual/devmode-snap-seeded-dangerous/task.yaml
@@ -24,9 +24,9 @@ execute: |
   . "$TESTSLIB/nested.sh"
 
   echo "Check that the devmode snap is installed"
-  nested_exec "snap list test-snapd-devmode-core20"
-  nested_exec "snap info --verbose test-snapd-devmode-core20" | MATCH "confinement:\s+devmode"
-  nested_exec "snap info --verbose test-snapd-devmode-core20" | MATCH "devmode:\s+true"
+  tests.nested exec "snap list test-snapd-devmode-core20"
+  tests.nested exec "snap info --verbose test-snapd-devmode-core20" | MATCH "confinement:\s+devmode"
+  tests.nested exec "snap info --verbose test-snapd-devmode-core20" | MATCH "devmode:\s+true"
   
   echo "Check that the devmode snap can be run"
-  nested_exec test-snapd-devmode-core20
+  tests.nested exec test-snapd-devmode-core20

--- a/tests/nested/manual/grade-signed-above-testkeys-boot/task.yaml
+++ b/tests/nested/manual/grade-signed-above-testkeys-boot/task.yaml
@@ -99,8 +99,8 @@ prepare: |
   # #shellcheck disable=SC2148
   #  systemd-run --unit fakedevicesvc fakedevicesvc localhost:11029
 
-  "$TESTSTOOLS"/nested-state build-image core
-  "$TESTSTOOLS"/nested-state create-vm core
+  tests.nested build-image core
+  tests.nested create-vm core
 
 restore: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -125,8 +125,8 @@ execute: |
   . "$TESTSLIB/nested.sh"
 
   echo "Check we have the right model from snap model"
-  nested_exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-${MODEL_GRADE}-core-20-amd64"
-  nested_exec "sudo snap model --verbose" | MATCH "grade:\s+${MODEL_GRADE}"
+  tests.nested exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-${MODEL_GRADE}-core-20-amd64"
+  tests.nested exec "sudo snap model --verbose" | MATCH "grade:\s+${MODEL_GRADE}"
 
   # TODO: check that we got a serial assertion via the fakedevicesvc
   # for now we just don't get a serial assertion which is fine for the purposes

--- a/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
+++ b/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
@@ -140,7 +140,7 @@ execute: |
   # of this test
 
   echo "Waiting for snapd to react to cloud-init"
-  nested_retry "--wait 1 -n 60 sh -c 'cloud-init status | grep -qE \"status: disabled\"'"
+  tests.nested retry "--wait 1 -n 60 sh -c 'cloud-init status | grep -qE \"status: disabled\"'"
   
   echo "Ensuring that cloud-init got disabled after running"
   tests.nested exec "test -f /etc/cloud/cloud-init.disabled"

--- a/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
+++ b/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
@@ -102,10 +102,10 @@ prepare: |
   # second boot - attacker drive
   nested_build_seed_cdrom "$TESTSLIB/cloud-init-seeds/attacker-user" seed2.iso cidata user-data meta-data
 
-  "$TESTSTOOLS"/nested-state build-image core
+  tests.nested build-image core
   # first boot will use seed1 to create the normal-user in addition to the 
   # system-user assertion
-  "$TESTSTOOLS"/nested-state create-vm core --param-cdrom "-cdrom $(pwd)/seed.iso"
+  tests.nested create-vm core --param-cdrom "-cdrom $(pwd)/seed.iso"
 
 restore: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -130,10 +130,10 @@ execute: |
   . "$TESTSLIB/nested.sh"
 
   echo "The initial cloud-init user was created"
-  nested_exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
+  tests.nested exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
 
   echo "And we can run things as the normal user"
-  nested_exec_as normal-user ubuntu "sudo true"
+  tests.nested exec-as normal-user ubuntu "sudo true"
 
   # TODO: check that we got a serial assertion via the fakedevicesvc
   # for now we just don't get a serial assertion which is fine for the purposes
@@ -145,9 +145,9 @@ execute: |
   sleep 60
 
   echo "Ensuring that cloud-init got disabled after running"
-  nested_exec "cloud-init status" | MATCH "status: disabled"
-  nested_exec "test -f /etc/cloud/cloud-init.disabled"
-  nested_exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+  tests.nested exec "cloud-init status" | MATCH "status: disabled"
+  tests.nested exec "test -f /etc/cloud/cloud-init.disabled"
+  tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
 
   # gracefully shutdown so that we don't have file corruption
   echo "Gracefully shutting down the nested VM to prepare a simulated attack"
@@ -159,12 +159,12 @@ execute: |
 
   echo "Restarting nested VM with attacker cloud-init CD-ROM drive"
   nested_force_start_vm
-  nested_wait_for_reboot "${boot_id}"
+  tests.nested wait-for reboot "${boot_id}"
 
   echo "The cloud-init attacker user was not created"
-  nested_exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
+  tests.nested exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
 
   echo "cloud-init is still disabled"
-  nested_exec "cloud-init status" | MATCH "status: disabled"
-  nested_exec "test -f /etc/cloud/cloud-init.disabled"
-  nested_exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+  tests.nested exec "cloud-init status" | MATCH "status: disabled"
+  tests.nested exec "test -f /etc/cloud/cloud-init.disabled"
+  tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"

--- a/tests/nested/manual/minimal-smoke/task.yaml
+++ b/tests/nested/manual/minimal-smoke/task.yaml
@@ -12,7 +12,7 @@ prepare: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
     nested_fetch_spread
-    "$TESTSTOOLS"/nested-state build-image core
+    tests.nested build-image core
 
 execute: |
     #shellcheck source=tests/lib/nested.sh
@@ -39,7 +39,7 @@ execute: |
         exit 1
     fi
 
-    "$TESTSTOOLS"/nested-state create-vm core --param-mem "-m $MINIMAL_MEM"
+    tests.nested create-vm core --param-mem "-m $MINIMAL_MEM"
 
     echo "Run spread smoke tests using mem: $MINIMAL_MEM"
     set +x

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -25,7 +25,7 @@ prepare: |
   dpkg -i "$SPREAD_PATH"/../snapd_*.deb
 
   # create a VM and mount a cloud image
-  "$TESTSTOOLS"/nested-state build-image classic
+  tests.nested build-image classic
   mkdir -p "$IMAGE_MOUNTPOINT"
   IMAGE_NAME=$(nested_get_image_name classic)
   mount_ubuntu_image "$NESTED_IMAGES_DIR/$IMAGE_NAME" "$IMAGE_MOUNTPOINT"
@@ -82,14 +82,14 @@ execute: |
   . "$TESTSLIB/preseed.sh"
   umount_ubuntu_image "$IMAGE_MOUNTPOINT"
 
-  "$TESTSTOOLS"/nested-state create-vm classic
+  tests.nested create-vm classic
 
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
   
   echo "Waiting for firstboot seeding to finish"
-  nested_exec "sudo snap wait system seed.loaded"
-  nested_exec "snap changes" | MATCH "Done .+ Initialize system state"
+  tests.nested exec "sudo snap wait system seed.loaded"
+  tests.nested exec "snap changes" | MATCH "Done .+ Initialize system state"
 
   echo "Checking that the system-key after first boot is the same as that from preseeding"
 
@@ -102,41 +102,41 @@ execute: |
     # the test is run against a vm image with ubuntu release matching that from spread host;
     # system-key check can fail if the nested vm image differs too much from the spread host system,
     # e.g. when the list of apparmor features differs due to significant kernel update.
-    nested_exec "cat /var/lib/snapd/system-key" > system-key.real
+    tests.nested exec "cat /var/lib/snapd/system-key" > system-key.real
     diff -u -w system-key.real system-key.preseeded
 
     # also check the system-key diff using snap debug seeding
 
     # we should not have had any system-key difference as per above, so we 
     # shouldn't output the preseed system-key or the seed-restart-system-key
-    nested_exec "snap debug seeding" | NOMATCH "preseed-system-key:"
-    nested_exec "snap debug seeding" | NOMATCH "seed-restart-system-key:"
+    tests.nested exec "snap debug seeding" | NOMATCH "preseed-system-key:"
+    tests.nested exec "snap debug seeding" | NOMATCH "seed-restart-system-key:"
   fi
 
-  nested_exec "snap debug seeding" | MATCH "preseeded:\s+true"
-  nested_exec "snap debug seeding" | MATCH "seeded:\s+true"
+  tests.nested exec "snap debug seeding" | MATCH "preseeded:\s+true"
+  tests.nested exec "snap debug seeding" | MATCH "seeded:\s+true"
   # FIXME: this just checks that the time is of the form "xxx.xxxs", which could
   # break if the preseeding takes more than 60s and golang formats the 
   # time.Duration as "1m2.03s", etc. but for now this should be good enough
-  nested_exec "snap debug seeding" | MATCH "image-preseeding:\s+[0-9]+\.[0-9]+s"
-  nested_exec "snap debug seeding" | MATCH "seed-completion:\s+[0-9]+\.[0-9]+s"
+  tests.nested exec "snap debug seeding" | MATCH "image-preseeding:\s+[0-9]+\.[0-9]+s"
+  tests.nested exec "snap debug seeding" | MATCH "seed-completion:\s+[0-9]+\.[0-9]+s"
 
   echo "Checking that lxd snap is operational"
-  nested_exec "snap list" | NOMATCH "broken"
-  nested_exec "snap services" | MATCH "lxd.activate +enabled +inactive"
-  nested_exec "snap services" | MATCH "lxd.daemon +enabled +inactive +socket-activated"
-  nested_exec "sudo lxd init --auto"
-  nested_exec "snap services" | MATCH "+lxd.daemon +enabled +active +socket-activated"
+  tests.nested exec "snap list" | NOMATCH "broken"
+  tests.nested exec "snap services" | MATCH "lxd.activate +enabled +inactive"
+  tests.nested exec "snap services" | MATCH "lxd.daemon +enabled +inactive +socket-activated"
+  tests.nested exec "sudo lxd init --auto"
+  tests.nested exec "snap services" | MATCH "+lxd.daemon +enabled +active +socket-activated"
 
   echo "Checking that the test-postgres-system-usernames snap is operational"
-  nested_exec "sudo snap start --enable test-postgres-system-usernames.postgres"
+  tests.nested exec "sudo snap start --enable test-postgres-system-usernames.postgres"
   # wait for postgres to come online
   sleep 10
-  nested_exec "snap services" | MATCH "+test-postgres-system-usernames.postgres +enabled +active"
+  tests.nested exec "snap services" | MATCH "+test-postgres-system-usernames.postgres +enabled +active"
 
   echo "Checking that mark-seeded task was executed last"
   # snap debug timings are sorts by read-time, mark-seeded should be last
-  nested_exec "sudo snap debug timings 1" | tail -2 | MATCH "Mark system seeded"
+  tests.nested exec "sudo snap debug timings 1" | tail -2 | MATCH "Mark system seeded"
   # no task should have ready time after mark-seeded
   # shellcheck disable=SC2046
   MARK_SEEDED_TIME=$(date -d $(snap change 1 --abs-time | grep "Mark system seeded" | awk '{print $3}') "+%s")

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -42,13 +42,13 @@ prepare: |
         exit
     fi
 
-    "$TESTSTOOLS"/nested-state build-image core
-    "$TESTSTOOLS"/nested-state create-vm core
+    tests.nested build-image core
+    tests.nested create-vm core
 
 debug: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
-    nested_exec "snap changes" || true
+    tests.nested exec "snap changes" || true
 
 execute: |
     #shellcheck source=tests/lib/nested.sh
@@ -61,11 +61,11 @@ execute: |
     FROM_REV="$(nested_get_snap_rev_for_channel "$SNAP" $TRACK/$NESTED_CORE_CHANNEL)"
     TO_REV="$(nested_get_snap_rev_for_channel "$SNAP" $TRACK/$NESTED_CORE_REFRESH_CHANNEL)"
 
-    nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_CHANNEL}.*"
+    tests.nested exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_CHANNEL}.*"
     
     echo "Refresh the snap $SNAP"
     INITIAL_BOOT_ID=$(nested_get_boot_id)
-    REFRESH_ID=$(nested_exec "sudo snap refresh --no-wait --channel $NESTED_CORE_REFRESH_CHANNEL $SNAP")
+    REFRESH_ID=$(tests.nested exec "sudo snap refresh --no-wait --channel $NESTED_CORE_REFRESH_CHANNEL $SNAP")
 
     case "$SNAP" in
         snapd|pc)
@@ -73,34 +73,34 @@ execute: |
             # resealing took place we are still able to boot
             # The following commands could fails in case the connection is suddenly
             # stopped because of the reboot in the nested machine
-            nested_exec "snap watch $REFRESH_ID" || true
-            nested_exec "sudo reboot" || true
+            tests.nested exec "snap watch $REFRESH_ID" || true
+            tests.nested exec "sudo reboot" || true
             ;;
         pc-kernel|core20)
             # don't manually reboot, wait for automatic snapd reboot
             ;;
     esac
-    nested_wait_for_reboot "$INITIAL_BOOT_ID"
+    tests.nested wait-for reboot "$INITIAL_BOOT_ID"
     SECOND_BOOT_ID=$(nested_get_boot_id)
 
     echo "Check the new version of the snaps is correct after the system reboot"
-    nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${TO_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
+    tests.nested exec "snap list $SNAP" | MATCH "^${SNAP}.*${TO_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
 
     echo "Check the change is completed"
     case "$SNAP" in
         pc-kernel|core20)
             for _ in $(seq 10); do
-                if nested_exec "snap changes" | MATCH "$REFRESH_ID\s+Done\s+.*"; then
+                if tests.nested exec "snap changes" | MATCH "$REFRESH_ID\s+Done\s+.*"; then
                     break
                 fi
                 sleep 1
             done
-            nested_exec "snap changes" | MATCH "$REFRESH_ID\s+Done\s+.*"
+            tests.nested exec "snap changes" | MATCH "$REFRESH_ID\s+Done\s+.*"
             ;;
     esac
 
     echo "Revert the snap $SNAP"
-    REVERT_ID=$(nested_exec "sudo snap revert --no-wait $SNAP")
+    REVERT_ID=$(tests.nested exec "sudo snap revert --no-wait $SNAP")
 
     case "$SNAP" in
         snapd|pc)
@@ -108,27 +108,27 @@ execute: |
             # resealing took place we are still able to boot
             # The following commands could fails in case the connection is suddenly
             # stopped because of the reboot in the nested machine
-            nested_exec "snap watch $REVERT_ID" || true
-            nested_exec "sudo reboot" || true
+            tests.nested exec "snap watch $REVERT_ID" || true
+            tests.nested exec "sudo reboot" || true
             ;;
         pc-kernel|core20)
             # don't manually reboot, wait for automatic snapd reboot
             ;;
     esac
-    nested_wait_for_reboot "$SECOND_BOOT_ID"
+    tests.nested wait-for reboot "$SECOND_BOOT_ID"
 
     echo "Check the version of the snaps after the revert is correct"
-    nested_exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
+    tests.nested exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
 
     echo "Check the change is completed"
     case "$SNAP" in
         pc-kernel|core20)
             for _ in $(seq 10); do
-                if nested_exec "snap changes" | MATCH "$REVERT_ID\s+Done\s+.*"; then
+                if tests.nested exec "snap changes" | MATCH "$REVERT_ID\s+Done\s+.*"; then
                     break
                 fi
                 sleep 1
             done
-            nested_exec "snap changes" | MATCH "$REVERT_ID\s+Done\s+.*"
+            tests.nested exec "snap changes" | MATCH "$REVERT_ID\s+Done\s+.*"
             ;;
     esac

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -117,6 +117,6 @@ execute: |
     echo "Check the change is completed"
     case "$SNAP" in
         pc-kernel|core20)
-            REVERT_ID="$REVERT_ID" nested_retry "--wait 1 -n 10 sh -c 'snap changes | MATCH \"$REVERT_ID\s+Done\s+.*\"'"
+            REVERT_ID="$REVERT_ID" tests.nested retry "--wait 1 -n 10 sh -c 'snap changes | MATCH \"$REVERT_ID\s+Done\s+.*\"'"
             ;;
     esac

--- a/tests/nested/manual/snapd-refresh-from-old/task.yaml
+++ b/tests/nested/manual/snapd-refresh-from-old/task.yaml
@@ -55,8 +55,8 @@ execute: |
     fi
 
     # this change is not immediately done and needs a retry
-    REFRESH_ID="$REFRESH_ID" nested_retry "--wait 1 -n 10 sh -c 'snap changes | grep -qE \".* Done .* Refresh snaps.*"snapd"\"'"
-    REFRESH_ID="$REFRESH_ID" nested_retry "--wait 1 -n 10 sh -c 'snap changes | grep -qE \".* Done .* Refresh snaps.*"core18"\"'"
+    REFRESH_ID="$REFRESH_ID" tests.nested retry "--wait 1 -n 10 sh -c 'snap changes | grep -qE \".* Done .* Refresh snaps.*"snapd"\"'"
+    REFRESH_ID="$REFRESH_ID" tests.nested retry "--wait 1 -n 10 sh -c 'snap changes | grep -qE \".* Done .* Refresh snaps.*"core18"\"'"
   fi
 
   echo "Now refresh snapd with current tree"

--- a/tests/nested/manual/snapd-refresh-from-old/task.yaml
+++ b/tests/nested/manual/snapd-refresh-from-old/task.yaml
@@ -27,8 +27,8 @@ prepare: |
   wget -P extra-snaps "$SNAPD_SNAP_URL" "$CORE18_SNAP_URL"
 
   # create core image with old snapd & core18
-  "$TESTSTOOLS"/nested-state build-image core
-  "$TESTSTOOLS"/nested-state create-vm core
+  tests.nested build-image core
+  tests.nested create-vm core
 
   # for refresh in later step of the test
   repack_snapd_deb_into_snapd_snap "$PWD"
@@ -37,36 +37,36 @@ execute: |
   #shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
 
-  nested_exec "sudo snap wait system seed.loaded"
-  nested_exec "snap list" | MATCH "snapd.*5760"
-  nested_exec "snap list" | MATCH "core18.*1279"
+  tests.nested exec "sudo snap wait system seed.loaded"
+  tests.nested exec "snap list" | MATCH "snapd.*5760"
+  tests.nested exec "snap list" | MATCH "core18.*1279"
 
   INITIAL_BOOT_ID=$(nested_get_boot_id)
 
   if [ "$SPREAD_VARIANT" = "edge_first" ]; then
     # refresh to latest snapd from store, this will drop from ssh.
     echo "Refreshing snapd and core18 from the store"
-    nested_exec "sudo snap refresh" || true
+    tests.nested exec "sudo snap refresh" || true
 
-    nested_wait_for_reboot "$INITIAL_BOOT_ID"
-    if nested_exec "snap list snapd" | MATCH "snapd.*5760"; then
+    tests.nested wait-for reboot "$INITIAL_BOOT_ID"
+    if tests.nested exec "snap list snapd" | MATCH "snapd.*5760"; then
       echo "unexpected snapd rev 5760"
       exit 1
     fi
 
     # this change is not immediately done and needs a retry
     for _ in $(seq 1 10); do
-      if nested_exec "snap changes" | MATCH ".* Done .* Refresh snaps.*\"snapd\""; then
+      if tests.nested exec "snap changes" | MATCH ".* Done .* Refresh snaps.*\"snapd\""; then
         break
       fi
       sleep 1
     done
 
-    nested_exec "snap changes" | MATCH ".* Done .* Refresh snaps.*\"snapd\""
-    nested_exec "snap changes" | MATCH ".* Done .* Refresh snaps.*\"core18\""
+    tests.nested exec "snap changes" | MATCH ".* Done .* Refresh snaps.*\"snapd\""
+    tests.nested exec "snap changes" | MATCH ".* Done .* Refresh snaps.*\"core18\""
   fi
 
   echo "Now refresh snapd with current tree"
-  nested_copy "snapd-from-deb.snap"
-  nested_exec "sudo snap install snapd-from-deb.snap --dangerous" || true
-  nested_exec "snap list snapd" | MATCH "snapd .* x1 "
+  tests.nested copy "snapd-from-deb.snap"
+  tests.nested exec "sudo snap install snapd-from-deb.snap --dangerous" || true
+  tests.nested exec "snap list snapd" | MATCH "snapd .* x1 "

--- a/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
@@ -35,8 +35,8 @@ execute: |
   . "$TESTSLIB/nested.sh"
 
   echo "Check that we have an encrypted system"
-  nested_exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
-  nested_exec "test -e /var/lib/snapd/device/fde/recovery.key"
-  nested_exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
-  nested_exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
-  nested_exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"
+  tests.nested exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
+  tests.nested exec "test -e /var/lib/snapd/device/fde/recovery.key"
+  tests.nested exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
+  tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
+  tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"

--- a/tests/nested/manual/uc20-fde-hooks/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks/task.yaml
@@ -35,8 +35,8 @@ execute: |
   . "$TESTSLIB/nested.sh"
 
   echo "Check that we have an encrypted system"
-  nested_exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
-  nested_exec "test -e /var/lib/snapd/device/fde/recovery.key"
-  nested_exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
-  nested_exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
-  nested_exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"
+  tests.nested exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
+  tests.nested exec "test -e /var/lib/snapd/device/fde/recovery.key"
+  tests.nested exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
+  tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
+  tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"

--- a/tests/nested/manual/uc20-storage-safety/task.yaml
+++ b/tests/nested/manual/uc20-storage-safety/task.yaml
@@ -39,8 +39,8 @@ prepare: |
     cp "$TESTSLIB"/assertions/developer1.account "$NESTED_FAKESTORE_BLOB_DIR/asserts"
     cp "$TESTSLIB"/assertions/developer1.account-key "$NESTED_FAKESTORE_BLOB_DIR/asserts"
 
-    "$TESTSTOOLS"/nested-state build-image core
-    "$TESTSTOOLS"/nested-state create-vm core
+    tests.nested build-image core
+    tests.nested create-vm core
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -62,10 +62,10 @@ execute: |
     . "$TESTSLIB/nested.sh"
 
     echo "Verify that no fde keys are generated"
-    nested_exec "test ! -d /var/lib/snapd/device/fde"
+    tests.nested exec "test ! -d /var/lib/snapd/device/fde"
 
     # TODO: once we have a install-mode log (PR#9545) we could grep
     #       "installing system unencrypted because of ..."
 
     echo "Check that data is mounted from a regular device, not a mapper"
-    nested_exec "mount" | MATCH "/dev/[svh]da[45] on /run/mnt/data"
+    tests.nested exec "mount" | MATCH "/dev/[svh]da[45] on /run/mnt/data"


### PR DESCRIPTION
The idea is to add more commands to the nested tool, and to make more
simple to read and write the tested tests this change also includes a
new name for the tool:

"$TESTSTOOLS"/nested-state exec -> tests.nested exec

The tool includes also these new commands:
  exec:        executes a command in the vm
  exec-as:     executes a command in the vm as the specified user
  retry:       retries a command in the vm
  copy:        copies a file to the vm
  wait-for:    waits for an specified event

Also the tests have been updated to start using the new tool commands

The idea is make a following or decoupling the vars from the nested.sh helper and start moving the implementation to the tests.nested tool
The final idea is to just use the nested tool in tests.