### PR TITLE
 many: use changes + tasks for quota group operations

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -46,9 +46,9 @@ type QuotaGroupResult struct {
 
 // EnsureQuota creates a quota group or updates an existing group.
 // The list of snaps can be empty.
-func (client *Client) EnsureQuota(groupName string, parent string, snaps []string, maxMemory uint64) error {
+func (client *Client) EnsureQuota(groupName string, parent string, snaps []string, maxMemory uint64) (changeID string, err error) {
 	if groupName == "" {
-		return xerrors.Errorf("cannot create or update quota group without a name")
+		return "", xerrors.Errorf("cannot create or update quota group without a name")
 	}
 	// TODO: use naming.ValidateQuotaGroup()
 
@@ -62,13 +62,15 @@ func (client *Client) EnsureQuota(groupName string, parent string, snaps []strin
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(data); err != nil {
-		return err
+		return "", err
 	}
-	if _, err := client.doSync("POST", "/v2/quotas", nil, nil, &body, nil); err != nil {
+	chgID, err := client.doAsync("POST", "/v2/quotas", nil, nil, &body)
+
+	if err != nil {
 		fmt := "cannot create or update quota group: %w"
-		return xerrors.Errorf(fmt, err)
+		return "", xerrors.Errorf(fmt, err)
 	}
-	return nil
+	return chgID, nil
 }
 
 func (client *Client) GetQuotaGroup(groupName string) (*QuotaGroupResult, error) {
@@ -84,9 +86,9 @@ func (client *Client) GetQuotaGroup(groupName string) (*QuotaGroupResult, error)
 	return res, nil
 }
 
-func (client *Client) RemoveQuotaGroup(groupName string) error {
+func (client *Client) RemoveQuotaGroup(groupName string) (changeID string, err error) {
 	if groupName == "" {
-		return xerrors.Errorf("cannot remove quota group without a name")
+		return "", xerrors.Errorf("cannot remove quota group without a name")
 	}
 	data := &postQuotaData{
 		Action:    "remove",
@@ -95,12 +97,9 @@ func (client *Client) RemoveQuotaGroup(groupName string) error {
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(data); err != nil {
-		return err
+		return "", err
 	}
-	if _, err := client.doSync("POST", "/v2/quotas", nil, nil, &body, nil); err != nil {
-		return err
-	}
-	return nil
+	return client.doAsync("POST", "/v2/quotas", nil, nil, &body)
 }
 
 func (client *Client) Quotas() ([]*QuotaGroupResult, error) {

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -29,17 +29,21 @@ import (
 )
 
 func (cs *clientSuite) TestCreateQuotaGroupInvalidName(c *check.C) {
-	err := cs.cli.EnsureQuota("", "", nil, 0)
+	_, err := cs.cli.EnsureQuota("", "", nil, 0)
 	c.Check(err, check.ErrorMatches, `cannot create or update quota group without a name`)
 }
 
 func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
-		"type": "sync",
-		"status-code": 200
+		"type": "async",
+		"status-code": 202,
+		"change": "42"
 	}`
 
-	c.Assert(cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, 1001), check.IsNil)
+	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, 1001)
+	c.Assert(err, check.IsNil)
+	c.Assert(chgID, check.Equals, "42")
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/quotas")
 	body, err := ioutil.ReadAll(cs.req.Body)
@@ -59,7 +63,7 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 func (cs *clientSuite) TestEnsureQuotaGroupError(c *check.C) {
 	cs.status = 500
 	cs.rsp = `{"type": "error"}`
-	err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a"}, 1)
+	_, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a"}, 1)
 	c.Check(err, check.ErrorMatches, `cannot create or update quota group: server error: "Internal Server Error"`)
 }
 
@@ -97,13 +101,16 @@ func (cs *clientSuite) TestGetQuotaGroupError(c *check.C) {
 }
 
 func (cs *clientSuite) TestRemoveQuotaGroup(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
-		"type": "sync",
-		"status-code": 200
+		"type": "async",
+		"status-code": 202,
+		"change": "42"
 	}`
 
-	err := cs.cli.RemoveQuotaGroup("foo")
+	chgID, err := cs.cli.RemoveQuotaGroup("foo")
 	c.Assert(err, check.IsNil)
+	c.Assert(chgID, check.Equals, "42")
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/quotas")
 	body, err := ioutil.ReadAll(cs.req.Body)
@@ -120,6 +127,6 @@ func (cs *clientSuite) TestRemoveQuotaGroup(c *check.C) {
 func (cs *clientSuite) TestRemoveQuotaGroupError(c *check.C) {
 	cs.status = 500
 	cs.rsp = `{"type": "error"}`
-	err := cs.cli.RemoveQuotaGroup("foo")
+	_, err := cs.cli.RemoveQuotaGroup("foo")
 	c.Check(err, check.ErrorMatches, `server error: "Internal Server Error"`)
 }

--- a/daemon/export_api_quotas_test.go
+++ b/daemon/export_api_quotas_test.go
@@ -30,7 +30,7 @@ type (
 	PostQuotaGroupData = postQuotaGroupData
 )
 
-func MockServicestateCreateQuota(f func(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) error) func() {
+func MockServicestateCreateQuota(f func(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) (*state.TaskSet, error)) func() {
 	old := servicestateCreateQuota
 	servicestateCreateQuota = f
 	return func() {
@@ -38,7 +38,7 @@ func MockServicestateCreateQuota(f func(st *state.State, name string, parentName
 	}
 }
 
-func MockServicestateUpdateQuota(f func(st *state.State, name string, opts servicestate.QuotaGroupUpdate) error) func() {
+func MockServicestateUpdateQuota(f func(st *state.State, name string, opts servicestate.QuotaGroupUpdate) (*state.TaskSet, error)) func() {
 	old := servicestateUpdateQuota
 	servicestateUpdateQuota = f
 	return func() {
@@ -46,7 +46,7 @@ func MockServicestateUpdateQuota(f func(st *state.State, name string, opts servi
 	}
 }
 
-func MockServicestateRemoveQuota(f func(st *state.State, name string) error) func() {
+func MockServicestateRemoveQuota(f func(st *state.State, name string) (*state.TaskSet, error)) func() {
 	old := servicestateRemoveQuota
 	servicestateRemoveQuota = f
 	return func() {

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -163,7 +163,7 @@ func RemoveQuota(st *state.State, name string) (*state.TaskSet, error) {
 
 	// XXX: remove this limitation eventually
 	if len(grp.SubGroups) != 0 {
-		return nil, fmt.Errorf("cannot remove quota group with sub-groups, remove the sub-groups first")
+		return nil, fmt.Errorf("cannot remove quota group %q with sub-groups, remove the sub-groups first", name)
 	}
 
 	qc := QuotaControlAction{

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -85,18 +85,41 @@ func quotaGroupsAvailable(st *state.State) error {
 // CreateQuota attempts to create the specified quota group with the specified
 // snaps in it.
 // TODO: should this use something like QuotaGroupUpdate with fewer fields?
-func CreateQuota(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) error {
+func CreateQuota(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) (*state.TaskSet, error) {
 	if err := quotaGroupsAvailable(st); err != nil {
-		return err
+		return nil, err
 	}
+
+	// TODO: conflict checking for other changes with this quota group
 
 	allGrps, err := AllQuotas(st)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// TODO: switch to returning a taskset with the right handler instead of
-	// executing this directly
+	// make sure the group does not exist yet
+	if _, ok := allGrps[name]; ok {
+		return nil, fmt.Errorf("group %q already exists", name)
+	}
+
+	if memoryLimit == 0 {
+		return nil, fmt.Errorf("cannot create quota group with no memory limit set")
+	}
+
+	// make sure the memory limit is at least 4K, that is the minimum size
+	// to allow nesting, otherwise groups with less than 4K will trigger the
+	// oom killer to be invoked when a new group is added as a sub-group to the
+	// larger group.
+	if memoryLimit <= 4*quantity.SizeKiB {
+		return nil, fmt.Errorf("memory limit for group %q is too small: size must be larger than 4KB", name)
+	}
+
+	// make sure the specified snaps exist and aren't currently in another group
+	if err := validateSnapForAddingToGroup(st, snaps, name, allGrps); err != nil {
+		return nil, err
+	}
+
+	// create the task with the action in it
 	qc := QuotaControlAction{
 		Action:      "create",
 		QuotaName:   name,
@@ -105,14 +128,14 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 		ParentName:  parentName,
 	}
 
-	grp, allGrps, err := quotaCreate(st, qc, allGrps)
-	if err != nil {
-		return err
-	}
-	opts := &ensureSnapServicesForGroupOptions{
-		allGrps: allGrps,
-	}
-	return ensureSnapServicesStateForGroup(st, grp, opts)
+	ts := state.NewTaskSet()
+
+	summary := fmt.Sprintf("Create quota group %q", name)
+	task := st.NewTask("quota-control", summary)
+	task.Set("quota-control-actions", []QuotaControlAction{qc})
+	ts.AddTask(task)
+
+	return ts, nil
 }
 
 // RemoveQuota deletes the specific quota group. Any snaps currently in the
@@ -120,31 +143,42 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 // removed is a sub-group.
 // TODO: currently this only supports removing leaf sub-group groups, it doesn't
 // support removing parent quotas, but probably it makes sense to allow that too
-func RemoveQuota(st *state.State, name string) error {
+func RemoveQuota(st *state.State, name string) (*state.TaskSet, error) {
 	if snapdenv.Preseeding() {
-		return fmt.Errorf("removing quota groups not supported while preseeding")
+		return nil, fmt.Errorf("removing quota groups not supported while preseeding")
 	}
+
+	// TODO: conflict checking for other changes with this quota group
 
 	allGrps, err := AllQuotas(st)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// TODO: switch to returning a taskset with the right handler instead of
-	// executing this directly
+	// make sure the group exists
+	grp, ok := allGrps[name]
+	if !ok {
+		return nil, fmt.Errorf("cannot remove non-existent quota group %q", name)
+	}
+
+	// XXX: remove this limitation eventually
+	if len(grp.SubGroups) != 0 {
+		return nil, fmt.Errorf("cannot remove quota group with sub-groups, remove the sub-groups first")
+	}
+
 	qc := QuotaControlAction{
 		Action:    "remove",
 		QuotaName: name,
 	}
 
-	grp, allGrps, err := quotaRemove(st, qc, allGrps)
-	if err != nil {
-		return err
-	}
-	opts := &ensureSnapServicesForGroupOptions{
-		allGrps: allGrps,
-	}
-	return ensureSnapServicesStateForGroup(st, grp, opts)
+	ts := state.NewTaskSet()
+
+	summary := fmt.Sprintf("Remove quota group %q", name)
+	task := st.NewTask("quota-control", summary)
+	task.Set("quota-control-actions", []QuotaControlAction{qc})
+	ts.AddTask(task)
+
+	return ts, nil
 }
 
 // QuotaGroupUpdate reflects all of the modifications that can be performed on
@@ -164,18 +198,41 @@ type QuotaGroupUpdate struct {
 // TODO: this should support more kinds of updates such as moving groups between
 // parents, removing sub-groups from their parents, and removing snaps from
 // the group.
-func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) error {
+func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) (*state.TaskSet, error) {
 	if err := quotaGroupsAvailable(st); err != nil {
-		return err
+		return nil, err
 	}
+
+	// TODO: conflict checking for other changes with this quota group
 
 	allGrps, err := AllQuotas(st)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// TODO: switch to returning a taskset with the right handler instead of
-	// executing this directly
+	grp, ok := allGrps[name]
+	if !ok {
+		return nil, fmt.Errorf("group %q does not exist", name)
+	}
+
+	// check that the memory limit is not being decreased
+	if updateOpts.NewMemoryLimit != 0 {
+		// we disallow decreasing the memory limit because it is difficult to do
+		// so correctly with the current state of our code in
+		// EnsureSnapServices, see comment in ensureSnapServicesForGroup for
+		// full details
+		if updateOpts.NewMemoryLimit < grp.MemoryLimit {
+			return nil, fmt.Errorf("cannot decrease memory limit of existing quota-group, remove and re-create it to decrease the limit")
+		}
+	}
+
+	// now ensure that all of the snaps mentioned in AddSnaps exist as snaps and
+	// that they aren't already in an existing quota group
+	if err := validateSnapForAddingToGroup(st, updateOpts.AddSnaps, name, allGrps); err != nil {
+		return nil, err
+	}
+
+	// create the action and the correspoding task set
 	qc := QuotaControlAction{
 		Action:      "update",
 		QuotaName:   name,
@@ -183,14 +240,14 @@ func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) erro
 		AddSnaps:    updateOpts.AddSnaps,
 	}
 
-	grp, allGrps, err := quotaUpdate(st, qc, allGrps)
-	if err != nil {
-		return err
-	}
-	opts := &ensureSnapServicesForGroupOptions{
-		allGrps: allGrps,
-	}
-	return ensureSnapServicesStateForGroup(st, grp, opts)
+	ts := state.NewTaskSet()
+
+	summary := fmt.Sprintf("Update quota group %q", name)
+	task := st.NewTask("quota-control", summary)
+	task.Set("quota-control-actions", []QuotaControlAction{qc})
+	ts.AddTask(task)
+
+	return ts, nil
 }
 
 // EnsureSnapAbsentFromQuota ensures that the specified snap is not present

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -618,10 +618,6 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
 
-	// creating the same group again will fail
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, 4*quantity.SizeKiB+1)
-	c.Assert(err, ErrorMatches, `group "foo" already exists`)
-
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
@@ -997,18 +993,6 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 		"foo":  expFooGroupState,
 		"foo2": expFoo2GroupState,
 	})
-}
-
-func (s *quotaHandlersSuite) TestUpdateQuotaGroupNotEnabled(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", false)
-	tr.Commit()
-
-	opts := servicestate.QuotaGroupUpdate{}
-	_, err := servicestate.UpdateQuota(s.state, "foo", opts)
-	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
 }
 
 func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -251,14 +251,29 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
-	err := servicestate.CreateQuota(st, "foo-group", "", []string{"test-snap"}, quantity.SizeGiB)
+	t := st.NewTask("create-quota", "...")
+
+	qcs := []servicestate.QuotaControlAction{
+		{
+			Action:      "create",
+			QuotaName:   "foo-group",
+			MemoryLimit: quantity.SizeGiB,
+			AddSnaps:    []string{"test-snap"},
+		},
+	}
+
+	t.Set("quota-control-actions", &qcs)
+
+	st.Unlock()
+	err := s.o.ServiceManager().DoQuotaControl(t, nil)
+	st.Lock()
 	c.Assert(err, IsNil)
 
 	// create a task for updating the quota group
-	t := st.NewTask("update-quota", "...")
+	t = st.NewTask("update-quota", "...")
 
 	// update the memory limit to be double
-	qcs := []servicestate.QuotaControlAction{
+	qcs = []servicestate.QuotaControlAction{
 		{
 			Action:      "update",
 			QuotaName:   "foo-group",
@@ -303,14 +318,29 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
-	err := servicestate.CreateQuota(st, "foo-group", "", []string{"test-snap"}, quantity.SizeGiB)
+	t := st.NewTask("create-quota", "...")
+
+	qcs := []servicestate.QuotaControlAction{
+		{
+			Action:      "create",
+			QuotaName:   "foo-group",
+			MemoryLimit: quantity.SizeGiB,
+			AddSnaps:    []string{"test-snap"},
+		},
+	}
+
+	t.Set("quota-control-actions", &qcs)
+
+	st.Unlock()
+	err := s.o.ServiceManager().DoQuotaControl(t, nil)
+	st.Lock()
 	c.Assert(err, IsNil)
 
 	// create a task for updating the quota group
-	t := st.NewTask("update-quota", "...")
+	t = st.NewTask("update-quota", "...")
 
 	// update the memory limit to be double
-	qcs := []servicestate.QuotaControlAction{
+	qcs = []servicestate.QuotaControlAction{
 		{
 			Action:      "update",
 			QuotaName:   "foo-group",
@@ -370,14 +400,29 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemove(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
-	err := servicestate.CreateQuota(st, "foo-group", "", []string{"test-snap"}, quantity.SizeGiB)
+	t := st.NewTask("create-quota", "...")
+
+	qcs := []servicestate.QuotaControlAction{
+		{
+			Action:      "create",
+			QuotaName:   "foo-group",
+			MemoryLimit: quantity.SizeGiB,
+			AddSnaps:    []string{"test-snap"},
+		},
+	}
+
+	t.Set("quota-control-actions", &qcs)
+
+	st.Unlock()
+	err := s.o.ServiceManager().DoQuotaControl(t, nil)
+	st.Lock()
 	c.Assert(err, IsNil)
 
 	// create a task for removing the quota group
-	t := st.NewTask("remove-quota", "...")
+	t = st.NewTask("remove-quota", "...")
 
-	// update the memory limit to be double
-	qcs := []servicestate.QuotaControlAction{
+	// remove quota group
+	qcs = []servicestate.QuotaControlAction{
 		{
 			Action:    "remove",
 			QuotaName: "foo-group",
@@ -421,14 +466,29 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemoveRestartOK(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
-	err := servicestate.CreateQuota(st, "foo-group", "", []string{"test-snap"}, quantity.SizeGiB)
+	t := st.NewTask("create-quota", "...")
+
+	qcs := []servicestate.QuotaControlAction{
+		{
+			Action:      "create",
+			QuotaName:   "foo-group",
+			MemoryLimit: quantity.SizeGiB,
+			AddSnaps:    []string{"test-snap"},
+		},
+	}
+
+	t.Set("quota-control-actions", &qcs)
+
+	st.Unlock()
+	err := s.o.ServiceManager().DoQuotaControl(t, nil)
+	st.Lock()
 	c.Assert(err, IsNil)
 
 	// create a task for removing the quota group
-	t := st.NewTask("remove-quota", "...")
+	t = st.NewTask("remove-quota", "...")
 
-	// update the memory limit to be double
-	qcs := []servicestate.QuotaControlAction{
+	// remove quota group
+	qcs = []servicestate.QuotaControlAction{
 		{
 			Action:    "remove",
 			QuotaName: "foo-group",
@@ -559,7 +619,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	c.Assert(err, IsNil)
 
 	// creating the same group again will fail
-	err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, 4*quantity.SizeKiB+1)
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, 4*quantity.SizeKiB+1)
 	c.Assert(err, ErrorMatches, `group "foo" already exists`)
 
 	// check that the quota groups were created in the state
@@ -947,7 +1007,7 @@ func (s *quotaHandlersSuite) TestUpdateQuotaGroupNotEnabled(c *C) {
 	tr.Commit()
 
 	opts := servicestate.QuotaGroupUpdate{}
-	err := servicestate.UpdateQuota(s.state, "foo", opts)
+	_, err := servicestate.UpdateQuota(s.state, "foo", opts)
 	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
 }
 

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -56,6 +56,10 @@ func Manager(st *state.State, runner *state.TaskRunner) *ServiceManager {
 	}
 	// TODO: undo handler
 	runner.AddHandler("service-control", m.doServiceControl, nil)
+
+	// TODO: undo handler
+	runner.AddHandler("quota-control", m.doQuotaControl, nil)
+
 	return m
 }
 

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -29,7 +29,7 @@ execute: |
   systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=active"
 
   echo "The service should also still be active"
-  snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"
+  retry -n 10 --wait 1 sh -c 'snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"'
 
   # systemd/kernel have three different locations for the cgroup pids depending
   # on version
@@ -97,7 +97,7 @@ execute: |
   echo "Removing the quota will stop the slice and the service will be restarted"
   snap remove-quota group-one
   systemctl show --property=MainPID snap.go-example-webserver.webserver.service | NOMATCH "MainPID=$SERVER_PID"
-  snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"
+  retry -n 10 --wait 1 sh -c 'snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"'
 
   echo "And the service is not in a slice anymore"
   systemctl show --property=ControlGroup snap.go-example-webserver.webserver.service | NOMATCH "/$sliceName/snap.go-example-webserver.webserver.service"

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -29,7 +29,7 @@ execute: |
   systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=active"
 
   echo "The service should also still be active"
-  retry -n 10 --wait 1 sh -c 'snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"'
+  snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"
 
   # systemd/kernel have three different locations for the cgroup pids depending
   # on version
@@ -97,7 +97,7 @@ execute: |
   echo "Removing the quota will stop the slice and the service will be restarted"
   snap remove-quota group-one
   systemctl show --property=MainPID snap.go-example-webserver.webserver.service | NOMATCH "MainPID=$SERVER_PID"
-  retry -n 10 --wait 1 sh -c 'snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"'
+  snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"
 
   echo "And the service is not in a slice anymore"
   systemctl show --property=ControlGroup snap.go-example-webserver.webserver.service | NOMATCH "/$sliceName/snap.go-example-webserver.webserver.service"


### PR DESCRIPTION
The exported methods from the servicestate package all return tasksets now, 
which is expected to be put into changes that are executed by the overlord 
loop. This involves changes in many parts that use quotas, such as the tests,
where a new mock function to create a quota group in state without running any
servicectl commands as well as changes to the client side.
