### PR TITLE
boot: drop model from resealing and boostate

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -672,7 +672,7 @@ func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
 		return nil
 	}
 	const expectReseal = true
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.model, o.modeenv, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.modeenv, expectReseal); err != nil {
 		return err
 	}
 	return nil
@@ -738,7 +738,7 @@ func (o *TrustedAssetsUpdateObserver) Canceled() error {
 	}
 
 	const expectReseal = true
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.model, o.modeenv, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.modeenv, expectReseal); err != nil {
 		return fmt.Errorf("while canceling gadget update: %v", err)
 	}
 	return nil

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -1567,10 +1567,41 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnapNoReseal(c *C) {
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
+	// set up all the bits required for an encrypted system
 	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	data := []byte("foobar")
+	// SHA3-384
+	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	// mock the files in cache
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
+	})
+	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
+	// write boot-chains for current state that will stay unchanged even
+	// though base is changed
+	bootChains := []boot.BootChain{{
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{{
+			Role: bootloader.RoleRunMode, Name: "asset", Hashes: []string{
+				"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+			},
+		}},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}}
+
+	err := boot.WriteBootChains(boot.ToPredictableBootChains(bootChains), filepath.Join(dirs.SnapFDEDir, "boot-chains"), 0)
+	c.Assert(err, IsNil)
 
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
+	model := coreDev.Model()
 
 	resealCalls := 0
 	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
@@ -1579,13 +1610,24 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnapNoReseal(c *C) {
 	})
 	defer restore()
 
-	// we should not even need to build boot chains
-	tab.BootChainErr = errors.New("boom")
+	tab.BootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
+		runKernelBf,
+	}
 
 	// default state
 	m := &boot.Modeenv{
-		Mode: "run",
-		Base: s.base1.Filename(),
+		Mode:           "run",
+		Base:           s.base1.Filename(),
+		CurrentKernels: []string{s.kern1.Filename()},
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {dataHash},
+		},
+
+		Model:          model.Model(),
+		BrandID:        model.BrandID(),
+		Grade:          string(model.Grade()),
+		ModelSignKeyID: model.SignKeyID(),
 	}
 	r := setupUC20Bootenv(
 		c,
@@ -1872,9 +1914,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
-	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -1882,11 +1922,11 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	})
 
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
-	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
+	newRunKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
 
 	tab.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
-		runKernelBf,
+		newRunKernelBf,
 	}
 
 	coreDev := boottest.MockUC20Device("", nil)
@@ -1918,6 +1958,39 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	)
 	defer r()
 
+	// write boot-chains that describe a state in which we have a new kernel
+	// candidate (pc-kernel_2)
+	bootChains := []boot.BootChain{{
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{{
+			Role: bootloader.RoleRunMode, Name: "asset", Hashes: []string{
+				"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+			},
+		}},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}, {
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{{
+			Role: bootloader.RoleRunMode, Name: "asset", Hashes: []string{
+				"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+			},
+		}},
+		Kernel:         "pc-kernel",
+		KernelRevision: "2",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}}
+
+	err := boot.WriteBootChains(boot.ToPredictableBootChains(bootChains), filepath.Join(dirs.SnapFDEDir, "boot-chains"), 0)
+	c.Assert(err, IsNil)
+
 	resealCalls := 0
 	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
@@ -1930,16 +2003,17 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 		}
 		c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
 			secboot.NewLoadChain(assetBf,
-				secboot.NewLoadChain(runKernelBf)),
+				secboot.NewLoadChain(newRunKernelBf)),
 		})
 		return nil
 	})
 	defer restore()
 
 	// mark successful
-	err := boot.MarkBootSuccessful(coreDev)
+	err = boot.MarkBootSuccessful(coreDev)
 	c.Assert(err, IsNil)
 
+	c.Check(resealCalls, Equals, 1)
 	// check the bootloader variables
 	expected := map[string]string{
 		"kernel_status":   boot.DefaultStatus,
@@ -1947,13 +2021,12 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 		"snap_try_kernel": boot.DefaultStatus,
 	}
 	c.Assert(tab.BootVars, DeepEquals, expected)
+	c.Check(tab.BootChainKernelPath, DeepEquals, []string{s.kern2.MountFile()})
 
 	// check that the new kernel is the only one in modeenv
 	m2, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern2.Filename()})
-
-	c.Check(resealCalls, Equals, 1)
 }
 
 func (s *bootenv20EnvRefKernelSuite) TestMarkBootSuccessful20KernelUpdate(c *C) {
@@ -3862,6 +3935,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	resealPanic := false
 	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		s.resealCalls++
+		c.Logf("reseal call %v", s.resealCalls)
 		c.Assert(params, NotNil)
 		c.Assert(params.ModelParams, HasLen, 1)
 		s.resealCommandLines = append(s.resealCommandLines, params.ModelParams[0].KernelCmdlines)

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -1922,7 +1922,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	})
 
 	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
-	newRunKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
+	newRunKernelBf := bootloader.NewBootFile(filepath.Join(s.kern2.Filename()), "kernel.efi", bootloader.RoleRunMode)
 
 	tab.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
@@ -96,9 +95,6 @@ type bootStateUpdate20 struct {
 
 	// tasks to run after the modeenv has been written
 	postModeenvTasks []bootCommitTask
-
-	// model set if a reseal might be necessary
-	resealModel *asserts.Model
 }
 
 func (u20 *bootStateUpdate20) preModeenv(task bootCommitTask) {
@@ -107,10 +103,6 @@ func (u20 *bootStateUpdate20) preModeenv(task bootCommitTask) {
 
 func (u20 *bootStateUpdate20) postModeenv(task bootCommitTask) {
 	u20.postModeenvTasks = append(u20.postModeenvTasks, task)
-}
-
-func (u20 *bootStateUpdate20) resealForModel(model *asserts.Model) {
-	u20.resealModel = model
 }
 
 func newBootStateUpdate20(m *Modeenv) (*bootStateUpdate20, error) {
@@ -166,15 +158,14 @@ func (u20 *bootStateUpdate20) commit() error {
 	// post-modeenv tasks so if we are rebooted at any point after
 	// the reseal even before the post tasks are completed, we
 	// still boot properly
-	if u20.resealModel != nil {
-		// if there is ambiguity whether the boot chains have
-		// changed because of unasserted kernels, then pass a
-		// flag as hint whether to reseal based on whether we
-		// wrote the modeenv
-		expectReseal := modeenvRewritten
-		if err := resealKeyToModeenv(dirs.GlobalRootDir, u20.resealModel, u20.writeModeenv, expectReseal); err != nil {
-			return err
-		}
+
+	// if there is ambiguity whether the boot chains have
+	// changed because of unasserted kernels, then pass a
+	// flag as hint whether to reseal based on whether we
+	// wrote the modeenv
+	expectReseal := modeenvRewritten
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, u20.writeModeenv, expectReseal); err != nil {
+		return err
 	}
 
 	// finally handle any post-modeenv writing tasks
@@ -290,9 +281,6 @@ func (ks20 *bootState20Kernel) markSuccessful(update bootStateUpdate) (bootState
 		// On commit, set CurrentKernels as just this kernel because that is the
 		// successful kernel we booted
 		u20.writeModeenv.CurrentKernels = []string{sn.Filename()}
-
-		// keep track of the model for resealing
-		u20.resealForModel(ks20.dev.Model())
 	}
 
 	return u20, nil
@@ -326,9 +314,6 @@ func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo) (rebootRequired bool
 	// because the modeenv doesn't "trust" or expect the new kernel that booted.
 	// As such, set the next kernel as a post modeenv task.
 	u20.postModeenv(func() error { return ks20.bks.setNextKernel(next, nextStatus) })
-
-	// keep track of the model for resealing
-	u20.resealForModel(ks20.dev.Model())
 
 	return rebootRequired, u20, nil
 }
@@ -692,8 +677,6 @@ func (ba20 *bootState20BootAssets) markSuccessful(update bootStateUpdate) (bootS
 	}
 	// update modeenv
 	u20.writeModeenv = newM
-	// keep track of the model for resealing
-	u20.resealForModel(ba20.dev.Model())
 
 	if len(dropAssets) == 0 {
 		// nothing to drop, we're done

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -358,7 +358,7 @@ func observeCommandLineUpdate(model *asserts.Model, reason commandLineUpdateReas
 	}
 
 	expectReseal := true
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, model, m, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -311,7 +311,7 @@ func sealedKeysMethod(rootdir string) (sm sealingMethod, err error) {
 
 // resealKeyToModeenv reseals the existing encryption key to the
 // parameters specified in modeenv.
-func resealKeyToModeenv(rootdir string, model *asserts.Model, modeenv *Modeenv, expectReseal bool) error {
+func resealKeyToModeenv(rootdir string, modeenv *Modeenv, expectReseal bool) error {
 	method, err := sealedKeysMethod(rootdir)
 	if err == errNoSealedKeys {
 		// nothing to do

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -545,7 +545,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 		// the behavior with unasserted kernel is tested in
 		// boot_test.go specific tests
 		const expectReseal = false
-		err = boot.ResealKeyToModeenv(rootdir, model, modeenv, expectReseal)
+		err = boot.ResealKeyToModeenv(rootdir, modeenv, expectReseal)
 		if !tc.sealedKeys || (tc.reuseRunPbc && tc.reuseRecoveryPbc) {
 			// did nothing
 			c.Assert(err, IsNil)
@@ -819,7 +819,7 @@ func (s *sealSuite) TestResealKeyToModeenvRecoveryKeysForGoodSystemsOnly(c *C) {
 	// the behavior with unasserted kernel is tested in
 	// boot_test.go specific tests
 	const expectReseal = false
-	err = boot.ResealKeyToModeenv(rootdir, model, modeenv, expectReseal)
+	err = boot.ResealKeyToModeenv(rootdir, modeenv, expectReseal)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 2)
 
@@ -1027,7 +1027,7 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 	defer restore()
 
 	const expectReseal = false
-	err = boot.ResealKeyToModeenv(rootdir, model, modeenv, expectReseal)
+	err = boot.ResealKeyToModeenv(rootdir, modeenv, expectReseal)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 2)
 
@@ -1557,13 +1557,16 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookCalled(c *C) {
 	err = ioutil.WriteFile(marker, []byte("fde-setup-hook"), 0644)
 	c.Assert(err, IsNil)
 
+	model := boottest.MakeMockUC20Model()
 	modeenv := &boot.Modeenv{
 		RecoverySystem: "20200825",
+		Model:          model.Model(),
+		BrandID:        model.BrandID(),
+		Grade:          string(model.Grade()),
+		ModelSignKeyID: model.SignKeyID(),
 	}
-
-	model := boottest.MakeMockUC20Model()
 	expectReseal := false
-	err = boot.ResealKeyToModeenv(rootdir, model, modeenv, expectReseal)
+	err = boot.ResealKeyToModeenv(rootdir, modeenv, expectReseal)
 	c.Assert(err, IsNil)
 	c.Check(resealKeyToModeenvUsingFDESetupHookCalled, Equals, 1)
 }
@@ -1586,13 +1589,16 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookVerySad(c *C) {
 	err = ioutil.WriteFile(marker, []byte("fde-setup-hook"), 0644)
 	c.Assert(err, IsNil)
 
+	model := boottest.MakeMockUC20Model()
 	modeenv := &boot.Modeenv{
 		RecoverySystem: "20200825",
+		Model:          model.Model(),
+		BrandID:        model.BrandID(),
+		Grade:          string(model.Grade()),
+		ModelSignKeyID: model.SignKeyID(),
 	}
-
-	model := boottest.MakeMockUC20Model()
 	expectReseal := false
-	err = boot.ResealKeyToModeenv(rootdir, model, modeenv, expectReseal)
+	err = boot.ResealKeyToModeenv(rootdir, modeenv, expectReseal)
 	c.Assert(err, ErrorMatches, "fde setup hook failed")
 	c.Check(resealKeyToModeenvUsingFDESetupHookCalled, Equals, 1)
 }

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -77,7 +77,7 @@ func ClearTryRecoverySystem(dev Device, systemLabel string) error {
 	// but we still want to reseal, in case the cleanup did not reach this
 	// point before
 	const expectReseal = true
-	resealErr := resealKeyToModeenv(dirs.GlobalRootDir, dev.Model(), m, expectReseal)
+	resealErr := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal)
 
 	if resealErr != nil {
 		return resealErr
@@ -141,7 +141,7 @@ func SetTryRecoverySystem(dev Device, systemLabel string) (err error) {
 	// tried system, data will still be inaccessible and the system will be
 	// considered as nonoperational
 	const expectReseal = true
-	return resealKeyToModeenv(dirs.GlobalRootDir, dev.Model(), m, expectReseal)
+	return resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal)
 }
 
 type errInconsistentRecoverySystemState struct {
@@ -380,7 +380,7 @@ func PromoteTriedRecoverySystem(dev Device, systemLabel string, triedSystems []s
 	}
 
 	const expectReseal = true
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, dev.Model(), m, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal); err != nil {
 		if cleanupErr := DropRecoverySystem(dev, systemLabel); cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup failed: %v)", err, cleanupErr)
 		}
@@ -418,5 +418,5 @@ func DropRecoverySystem(dev Device, systemLabel string) error {
 	}
 
 	const expectReseal = true
-	return resealKeyToModeenv(dirs.GlobalRootDir, dev.Model(), m, expectReseal)
+	return resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal)
 }


### PR DESCRIPTION
The last 2 patches addressing unnecessary use of model in reseal and bootstate code.
