### PR TITLE
o/snapstate: make conditional-auto-refresh conflict with other tasks via affected snaps

### DIFF
--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -20,6 +20,7 @@
 package snapstate
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -588,12 +589,13 @@ func createGateAutoRefreshHooks(st *state.State, affectedSnaps map[string]*affec
 }
 
 func conditionalAutoRefreshAffectedSnaps(t *state.Task) ([]string, error) {
-	var snaps map[string]*refreshCandidate
+	var snaps map[string]*json.RawMessage
 	if err := t.Get("snaps", &snaps); err != nil {
 		return nil, fmt.Errorf("internal error: cannot get snaps to update for %s task %s", t.Kind(), t.ID())
 	}
 	names := make([]string, 0, len(snaps))
 	for sn := range snaps {
+		// TODO: drop snaps once we know the outcome of gate-auto-refresh hooks.
 		names = append(names, sn)
 	}
 	return names, nil

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -587,6 +587,18 @@ func createGateAutoRefreshHooks(st *state.State, affectedSnaps map[string]*affec
 	return ts
 }
 
+func conditionalAutoRefreshAffectedSnaps(t *state.Task) ([]string, error) {
+	var snaps map[string]*refreshCandidate
+	if err := t.Get("snaps", &snaps); err != nil {
+		return nil, fmt.Errorf("internal error: cannot get snaps to update for %s task %s", t.Kind(), t.ID())
+	}
+	names := make([]string, 0, len(snaps))
+	for sn := range snaps {
+		names = append(names, sn)
+	}
+	return names, nil
+}
+
 // snapsToRefresh returns all snaps that should proceed with refresh considering
 // hold behavior.
 var snapsToRefresh = func(gatingTask *state.Task) ([]*refreshCandidate, error) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3019,7 +3019,7 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 		return nil
 	}
 
-	tss, err := autoRefreshPhase2(context.TODO(), st, snaps)
+	tss, err := autoRefreshPhase2(context.TODO(), st, snaps, t.Change().ID())
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -468,6 +468,8 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	// control serialisation
 	runner.AddBlocked(m.blockedTask)
 
+	AddAffectedSnapsByKind("conditional-auto-refresh", conditionalAutoRefreshAffectedSnaps)
+
 	return m, nil
 }
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2015,8 +2015,7 @@ func autoRefreshPhase1(ctx context.Context, st *state.State) ([]string, []*state
 }
 
 // autoRefreshPhase2 creates tasks for refreshing snaps from updates.
-func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshCandidate) ([]*state.TaskSet, error) {
-	fromChange := ""
+func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshCandidate, fromChange string) ([]*state.TaskSet, error) {
 	flags := &Flags{IsAutoRefresh: true}
 	userID := 0
 


### PR DESCRIPTION
Make conditional-auto-refresh task conflict with other tasks via affected snaps.
