### PR TITLE
o/servicestate: introduce internal and servicestatetest

### DIFF
--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -107,9 +107,9 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 	return allGrps, nil
 }
 
-// CreateQuota creates a quota group with the given paremeters in the state.
-// It takes the current map of all quota groups.
-func CreateQuota(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, memoryLimit quantity.Size, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
+// CreateQuotaInState creates a quota group with the given paremeters
+// in the state.  It takes the current map of all quota groups.
+func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, memoryLimit quantity.Size, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
 	// make sure that the parent group exists if we are creating a sub-group
 	var grp *quota.Group
 	var err error

--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -1,0 +1,142 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap/quota"
+)
+
+// AllQuotas returns all currently tracked quota groups in the state. They are
+// validated for consistency using ResolveCrossReferences before being returned.
+func AllQuotas(st *state.State) (map[string]*quota.Group, error) {
+	var quotas map[string]*quota.Group
+	if err := st.Get("quotas", &quotas); err != nil {
+		if err != state.ErrNoState {
+			return nil, err
+		}
+		// otherwise there are no quotas so just return nil
+		return nil, nil
+	}
+
+	// quota groups are not serialized with all the necessary tracking
+	// information in the objects, so we need to thread some things around
+	if err := quota.ResolveCrossReferences(quotas); err != nil {
+		return nil, err
+	}
+
+	// quotas has now been properly initialized with unexported cross-references
+	return quotas, nil
+}
+
+// PatchQuotas will update the state quota group map with the provided quota
+// groups. It returns the full set of all quota groups after a successful
+// update for convenience. The groups provided will replace group states if
+// present or be added on top of the current set of quota groups in the state,
+// and verified for consistency before committed to state. When adding
+// sub-groups, both the parent and the sub-group must be added at once since the
+// sub-group needs to reference the parent group and vice versa to be fully
+// consistent.
+func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group, error) {
+	// get the current set of quotas
+	allGrps, err := AllQuotas(st)
+	if err != nil {
+		// AllQuotas() can't return ErrNoState, in that case it just returns a
+		// nil map, which we handle below
+		return nil, err
+	}
+	if allGrps == nil {
+		allGrps = make(map[string]*quota.Group)
+	}
+
+	// handle trivial case here to prevent panics below
+	if len(grps) == 0 {
+		return allGrps, nil
+	}
+
+	sort.SliceStable(grps, func(i, j int) bool {
+		return grps[i].Name < grps[j].Name
+	})
+
+	// add to the temporary state map
+	for _, grp := range grps {
+		allGrps[grp.Name] = grp
+	}
+
+	// make sure the full set is still resolved before saving it - this prevents
+	// easy errors like trying to add a sub-group quota without updating the
+	// parent with references to the sub-group, for cases like those, all
+	// related groups must be updated at the same time in one operation to
+	// prevent having inconsistent quota groups in state.json
+	if err := quota.ResolveCrossReferences(allGrps); err != nil {
+		// make a nice error message for this case
+		updated := ""
+		for _, grp := range grps[:len(grps)-1] {
+			updated += fmt.Sprintf("%q, ", grp.Name)
+		}
+		updated += fmt.Sprintf("%q", grps[len(grps)-1].Name)
+		plural := ""
+		if len(grps) > 1 {
+			plural = "s"
+		}
+		return nil, fmt.Errorf("cannot update quota%s %s: %v", plural, updated, err)
+	}
+
+	st.Set("quotas", allGrps)
+	return allGrps, nil
+}
+
+// CreateQuota creates a quota group with the given paremeters in the state.
+// It takes the current map of all quota groups.
+func CreateQuota(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, memoryLimit quantity.Size, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
+	// make sure that the parent group exists if we are creating a sub-group
+	var grp *quota.Group
+	var err error
+	updatedGrps := []*quota.Group{}
+	if parentGrp != nil {
+		grp, err = parentGrp.NewSubGroup(quotaName, memoryLimit)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		updatedGrps = append(updatedGrps, parentGrp)
+	} else {
+		// make a new group
+		grp, err = quota.NewGroup(quotaName, memoryLimit)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	updatedGrps = append(updatedGrps, grp)
+
+	// put the snaps in the group
+	grp.Snaps = snaps
+	// update the modified groups in state
+	newAllGrps, err := PatchQuotas(st, updatedGrps...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return grp, newAllGrps, nil
+}

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -1,0 +1,175 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/overlord/servicestate/internal"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap/quota"
+)
+
+func TestInternal(t *testing.T) { TestingT(t) }
+
+type servicestateQuotasSuite struct {
+	state *state.State
+}
+
+var _ = Suite(&servicestateQuotasSuite{})
+
+func (s *servicestateQuotasSuite) SetUpTest(c *C) {
+	s.state = state.New(nil)
+}
+
+func (s *servicestateQuotasSuite) TestQuotas(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// with nothing in state we don't get any quotas
+	quotaMap, err := internal.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(quotaMap, HasLen, 0)
+
+	// we can add some basic quotas to state
+	grp := &quota.Group{
+		Name:        "foogroup",
+		MemoryLimit: quantity.SizeGiB,
+	}
+	newGrps, err := internal.PatchQuotas(st, grp)
+	c.Assert(err, IsNil)
+	c.Assert(newGrps, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+	})
+
+	// now we get back the same quota
+	quotaMap, err = internal.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(quotaMap, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+	})
+
+	// adding a sub-group quota only works when we update the parent group to
+	// reference the sub-group at the same time
+	grp2 := &quota.Group{
+		Name:        "group-2",
+		MemoryLimit: quantity.SizeGiB,
+		ParentGroup: "foogroup",
+	}
+	_, err = internal.PatchQuotas(st, grp2)
+	c.Assert(err, ErrorMatches, `cannot update quota "group-2": group "foogroup" does not reference necessary child group "group-2"`)
+
+	// we also can't add a sub-group to the parent without adding the sub-group
+	// itself
+	grp.SubGroups = append(grp.SubGroups, "group-2")
+	_, err = internal.PatchQuotas(st, grp)
+	c.Assert(err, ErrorMatches, `cannot update quota "foogroup": missing group "group-2" referenced as the sub-group of group "foogroup"`)
+
+	// foogroup didn't get updated in the state to mention the sub-group
+	quotaMap, err = internal.AllQuotas(st)
+	c.Assert(err, IsNil)
+	foogrp, ok := quotaMap["foogroup"]
+	c.Assert(ok, Equals, true)
+	c.Assert(foogrp.SubGroups, HasLen, 0)
+
+	// but if we update them both at the same time we succeed
+	newGrps, err = internal.PatchQuotas(st, grp, grp2)
+	c.Assert(err, IsNil)
+	c.Assert(newGrps, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+		"group-2":  grp2,
+	})
+
+	// and now we see both in the state
+	quotaMap, err = internal.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(quotaMap, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+		"group-2":  grp2,
+	})
+
+	// adding multiple quotas that are invalid produces a nice error message
+	otherGrp := &quota.Group{
+		Name: "other-group",
+		// invalid memory limit
+	}
+
+	otherGrp2 := &quota.Group{
+		Name: "other-group2",
+		// invalid memory limit
+	}
+
+	_, err = internal.PatchQuotas(st, otherGrp2, otherGrp)
+	// either group can get checked first
+	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: group memory limit must be non-zero`)
+}
+
+func (s *servicestateQuotasSuite) TestCreateQuota(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// we can create a basic quota in state
+	grp := &quota.Group{
+		Name:        "foogroup",
+		MemoryLimit: quantity.SizeGiB,
+	}
+	grp1, newGrps, err := internal.CreateQuota(st, "foogroup", nil, nil, quantity.SizeGiB, nil)
+	c.Assert(err, IsNil)
+	c.Check(grp1, DeepEquals, grp)
+	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+	})
+
+	// now quota is really in state
+	quotaMap, err := internal.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(quotaMap, DeepEquals, map[string]*quota.Group{
+		"foogroup": grp,
+	})
+
+	// create a sub-group quota
+	grp2 := &quota.Group{
+		Name:        "group-2",
+		MemoryLimit: quantity.SizeGiB,
+		ParentGroup: "foogroup",
+		Snaps:       []string{"snap1", "snap2"},
+	}
+	grp3, newGrps, err := internal.CreateQuota(st, "group-2", grp1, []string{"snap1", "snap2"}, quantity.SizeGiB, nil)
+	c.Assert(err, IsNil)
+	c.Check(grp3.Name, Equals, grp2.Name)
+	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)
+	c.Check(grp3.ParentGroup, Equals, grp2.ParentGroup)
+	c.Check(grp3.Snaps, DeepEquals, grp2.Snaps)
+	c.Check(newGrps, HasLen, 2)
+	c.Check(newGrps["foogroup"].SubGroups, DeepEquals, []string{"group-2"})
+
+	// and now we see both in the state
+	quotaMap, err = internal.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(quotaMap, DeepEquals, map[string]*quota.Group{
+		"foogroup": newGrps["foogroup"],
+		"group-2":  grp3,
+	})
+}

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -125,7 +125,7 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: group memory limit must be non-zero`)
 }
 
-func (s *servicestateQuotasSuite) TestCreateQuota(c *C) {
+func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -135,7 +135,7 @@ func (s *servicestateQuotasSuite) TestCreateQuota(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	grp1, newGrps, err := internal.CreateQuota(st, "foogroup", nil, nil, quantity.SizeGiB, nil)
+	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quantity.SizeGiB, nil)
 	c.Assert(err, IsNil)
 	c.Check(grp1, DeepEquals, grp)
 	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
@@ -156,7 +156,7 @@ func (s *servicestateQuotasSuite) TestCreateQuota(c *C) {
 		ParentGroup: "foogroup",
 		Snaps:       []string{"snap1", "snap2"},
 	}
-	grp3, newGrps, err := internal.CreateQuota(st, "group-2", grp1, []string{"snap1", "snap2"}, quantity.SizeGiB, nil)
+	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quantity.SizeGiB, nil)
 	c.Assert(err, IsNil)
 	c.Check(grp3.Name, Equals, grp2.Name)
 	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/servicestate/internal"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
@@ -194,7 +195,7 @@ func EnsureSnapAbsentFromQuota(st *state.State, snap string) error {
 				grp.Snaps = grp.Snaps[:len(grp.Snaps)-1]
 
 				// update the quota group state
-				allGrps, err = patchQuotas(st, grp)
+				allGrps, err = internal.PatchQuotas(st, grp)
 				if err != nil {
 					return err
 				}

--- a/overlord/servicestate/quotas.go
+++ b/overlord/servicestate/quotas.go
@@ -21,9 +21,8 @@ package servicestate
 
 import (
 	"errors"
-	"fmt"
-	"sort"
 
+	"github.com/snapcore/snapd/overlord/servicestate/internal"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/quota"
 )
@@ -33,28 +32,12 @@ var ErrQuotaNotFound = errors.New("quota not found")
 // AllQuotas returns all currently tracked quota groups in the state. They are
 // validated for consistency using ResolveCrossReferences before being returned.
 func AllQuotas(st *state.State) (map[string]*quota.Group, error) {
-	var quotas map[string]*quota.Group
-	if err := st.Get("quotas", &quotas); err != nil {
-		if err != state.ErrNoState {
-			return nil, err
-		}
-		// otherwise there are no quotas so just return nil
-		return nil, nil
-	}
-
-	// quota groups are not serialized with all the necessary tracking
-	// information in the objects, so we need to thread some things around
-	if err := quota.ResolveCrossReferences(quotas); err != nil {
-		return nil, err
-	}
-
-	// quotas has now been properly initialized with unexported cross-references
-	return quotas, nil
+	return internal.AllQuotas(st)
 }
 
 // GetQuota returns an individual quota group by name.
 func GetQuota(st *state.State, name string) (*quota.Group, error) {
-	allGrps, err := AllQuotas(st)
+	allGrps, err := internal.AllQuotas(st)
 	if err != nil {
 		return nil, err
 	}
@@ -65,61 +48,4 @@ func GetQuota(st *state.State, name string) (*quota.Group, error) {
 	}
 
 	return group, nil
-}
-
-// patchQuotas will update the state quota group map with the provided quota
-// groups. It returns the full set of all quota groups after a successful
-// update for convenience. The groups provided will replace group states if
-// present or be added on top of the current set of quota groups in the state,
-// and verified for consistency before committed to state. When adding
-// sub-groups, both the parent and the sub-group must be added at once since the
-// sub-group needs to reference the parent group and vice versa to be fully
-// consistent.
-func patchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group, error) {
-	// get the current set of quotas
-	allGrps, err := AllQuotas(st)
-	if err != nil {
-		// AllQuotas() can't return ErrNoState, in that case it just returns a
-		// nil map, which we handle below
-		return nil, err
-	}
-	if allGrps == nil {
-		allGrps = make(map[string]*quota.Group)
-	}
-
-	// handle trivial case here to prevent panics below
-	if len(grps) == 0 {
-		return allGrps, nil
-	}
-
-	sort.SliceStable(grps, func(i, j int) bool {
-		return grps[i].Name < grps[j].Name
-	})
-
-	// add to the temporary state map
-	for _, grp := range grps {
-		allGrps[grp.Name] = grp
-	}
-
-	// make sure the full set is still resolved before saving it - this prevents
-	// easy errors like trying to add a sub-group quota without updating the
-	// parent with references to the sub-group, for cases like those, all
-	// related groups must be updated at the same time in one operation to
-	// prevent having inconsistent quota groups in state.json
-	if err := quota.ResolveCrossReferences(allGrps); err != nil {
-		// make a nice error message for this case
-		updated := ""
-		for _, grp := range grps[:len(grps)-1] {
-			updated += fmt.Sprintf("%q, ", grp.Name)
-		}
-		updated += fmt.Sprintf("%q", grps[len(grps)-1].Name)
-		plural := ""
-		if len(grps) > 1 {
-			plural = "s"
-		}
-		return nil, fmt.Errorf("cannot update quota%s %s: %v", plural, updated, err)
-	}
-
-	st.Set("quotas", allGrps)
-	return allGrps, nil
 }

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
@@ -312,7 +313,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	grp.Snaps = []string{"foosnap"}
 
 	// add it into the state
-	newGrps, err := servicestate.PatchQuotas(st, grp)
+	newGrps, err := servicestatetest.PatchQuotas(st, grp)
 	c.Assert(err, IsNil)
 	c.Assert(newGrps, DeepEquals, map[string]*quota.Group{
 		"foogroup": grp,
@@ -331,7 +332,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 
 	// modify state to use an instance name instead now
 	grp.Snaps = []string{"foosnap_instance"}
-	newGrps, err = servicestate.PatchQuotas(st, grp)
+	newGrps, err = servicestatetest.PatchQuotas(st, grp)
 	c.Assert(err, IsNil)
 	c.Assert(newGrps, DeepEquals, map[string]*quota.Group{
 		"foogroup": grp,

--- a/overlord/servicestate/servicestatetest/quotas.go
+++ b/overlord/servicestate/servicestatetest/quotas.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,22 +17,16 @@
  *
  */
 
-package servicestate
+package servicestatetest
 
 import (
-	tomb "gopkg.in/tomb.v2"
-
+	"github.com/snapcore/snapd/overlord/servicestate/internal"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap/quota"
 )
 
-var (
-	UpdateSnapstateServices = updateSnapstateServices
-	CheckSystemdVersion     = checkSystemdVersion
-	QuotaCreate             = quotaCreate
-	QuotaRemove             = quotaRemove
-	QuotaUpdate             = quotaUpdate
-)
-
-func (m *ServiceManager) DoQuotaControl(t *state.Task, to *tomb.Tomb) error {
-	return m.doQuotaControl(t, to)
+// PatchQuotas will update the state quota group map with the provided quota
+// groups. It exposes internal.PatchQuotas for use in tests.
+func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group, error) {
+	return internal.PatchQuotas(st, grps...)
 }


### PR DESCRIPTION
this splits most of quotas.go into an internal package and
introduces a dedicated servicestatetest package exposing PatchQuotas

this should allow to  have in servicestattest a clean test-only
API to mock quotas in state

