### PR TITLE
overlord/servicestate: avoid unnecessary computation of disabled services

### DIFF
--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -150,10 +150,6 @@ func systemctlCallsForServiceRestart(name string) []expectedSystemctl {
 	svc := "snap." + name + ".svc1.service"
 	return []expectedSystemctl{
 		{
-			expArgs: []string{"is-enabled", svc},
-			output:  "enabled",
-		},
-		{
 			expArgs: []string{"show", "--property=Id,ActiveState,UnitFileState,Type", svc},
 			output:  fmt.Sprintf("Id=%s\nActiveState=active\nUnitFileState=enabled\nType=simple\n", svc),
 		},

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -488,18 +488,6 @@ func ensureSnapServicesForGroup(st *state.State, t *state.Task, grp *quota.Group
 	})
 
 	for _, sn := range snaps {
-		st.Unlock()
-		disabledSvcs, err := wrappers.QueryDisabledServices(sn, meter)
-		st.Lock()
-		if err != nil {
-			return err
-		}
-
-		isDisabledSvc := make(map[string]bool, len(disabledSvcs))
-		for _, svc := range disabledSvcs {
-			isDisabledSvc[svc] = true
-		}
-
 		startupOrdered, err := snap.SortServices(appsToRestartBySnap[sn])
 		if err != nil {
 			return err


### PR DESCRIPTION
The variables produced by this bit of code are not used anymore.

Reference: https://github.com/snapcore/snapd/pull/10266#discussion_r653622039