### PR TITLE
tests: fix classic-prepare-image test

### DIFF
--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -52,7 +52,6 @@ restore: |
     systemctl stop snapd.service snapd.socket fakedevicesvc
 
     rm -rf "$SEED_DIR"
-    systemctl start snapd.socket snapd.service
 
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh

--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -35,7 +35,7 @@ prepare: |
     echo Running prepare-image
     #shellcheck disable=SC2086
     ARCH="$(dpkg-architecture -qDEB_HOST_ARCH)"
-    SNAPPY_USE_STAGING_STORE="$SNAPPY_USE_STAGING_STORE" snap prepare-image --classic --arch "$ARCH" --channel "$CORE_CHANNEL" --snap basic18_*.snap  --snap classic-gadget-18_*.snap "$TESTSLIB"/assertions/developer1-my-classic-w-gadget-18.model "$ROOT"
+    snap prepare-image --classic --arch "$ARCH" --channel "$CORE_CHANNEL" --snap basic18_*.snap  --snap classic-gadget-18_*.snap "$TESTSLIB"/assertions/developer1-my-classic-w-gadget-18.model "$ROOT"
 
     "$TESTSLIB/reset.sh" --keep-stopped
     cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"

--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -35,7 +35,7 @@ prepare: |
     echo Running prepare-image
     #shellcheck disable=SC2086
     ARCH="$(dpkg-architecture -qDEB_HOST_ARCH)"
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --channel $CORE_CHANNEL --snap basic18_*.snap  --snap classic-gadget-18_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget-18.model $ROOT"
+    SNAPPY_USE_STAGING_STORE="$SNAPPY_USE_STAGING_STORE" snap prepare-image --classic --arch "$ARCH" --channel "$CORE_CHANNEL" --snap basic18_*.snap  --snap classic-gadget-18_*.snap "$TESTSLIB"/assertions/developer1-my-classic-w-gadget-18.model "$ROOT"
 
     "$TESTSLIB/reset.sh" --keep-stopped
     cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -35,7 +35,7 @@ prepare: |
     echo Running prepare-image
     #shellcheck disable=SC2086
     ARCH="$(dpkg-architecture -qDEB_HOST_ARCH)"
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --channel $CORE_CHANNEL --snap basic_*.snap  --snap classic-gadget_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT"
+    SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --channel $CORE_CHANNEL --snap basic_*.snap  --snap classic-gadget_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT
 
     "$TESTSLIB/reset.sh" --keep-stopped
     cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"
@@ -52,7 +52,7 @@ restore: |
     systemctl stop snapd.service snapd.socket fakedevicesvc
 
     rm -rf "$SEED_DIR"
-    systemctl start snapd.socket snapd.service
+    systemctl start snapd.socket
 
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh
@@ -92,7 +92,7 @@ execute: |
     test -f "$SEED_DIR/snaps/classic-gadget_"*.snap
 
     # test regression
-    if journalctl -u snapd | MATCH "missing file /snap/classic-gadget/unset/meta/snap.yaml"; then
+    if "$TESTSTOOLS"/journal-state get-log -u snapd | MATCH "missing file /snap/classic-gadget/unset/meta/snap.yaml"; then
          echo "snapd is still reading the gadget too early"
          exit 1
     fi

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -35,7 +35,7 @@ prepare: |
     echo Running prepare-image
     #shellcheck disable=SC2086
     ARCH="$(dpkg-architecture -qDEB_HOST_ARCH)"
-    SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --channel $CORE_CHANNEL --snap basic_*.snap  --snap classic-gadget_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT
+    SNAPPY_USE_STAGING_STORE="$SNAPPY_USE_STAGING_STORE" snap prepare-image --classic --arch "$ARCH" --channel "$CORE_CHANNEL" --snap basic_*.snap  --snap classic-gadget_*.snap "$TESTSLIB"/assertions/developer1-my-classic-w-gadget.model "$ROOT"
 
     "$TESTSLIB/reset.sh" --keep-stopped
     cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -52,7 +52,6 @@ restore: |
     systemctl stop snapd.service snapd.socket fakedevicesvc
 
     rm -rf "$SEED_DIR"
-    systemctl start snapd.socket
 
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -35,7 +35,7 @@ prepare: |
     echo Running prepare-image
     #shellcheck disable=SC2086
     ARCH="$(dpkg-architecture -qDEB_HOST_ARCH)"
-    SNAPPY_USE_STAGING_STORE="$SNAPPY_USE_STAGING_STORE" snap prepare-image --classic --arch "$ARCH" --channel "$CORE_CHANNEL" --snap basic_*.snap  --snap classic-gadget_*.snap "$TESTSLIB"/assertions/developer1-my-classic-w-gadget.model "$ROOT"
+    snap prepare-image --classic --arch "$ARCH" --channel "$CORE_CHANNEL" --snap basic_*.snap  --snap classic-gadget_*.snap "$TESTSLIB"/assertions/developer1-my-classic-w-gadget.model "$ROOT"
 
     "$TESTSLIB/reset.sh" --keep-stopped
     cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"


### PR DESCRIPTION
Ruuning with su the command "snap prepare image" is making followins
tests fail when them try to access to
/run/user/0/snapd-session-agent.socket

This happens when the su -c command is used without the test user

To reproduce the isse run:
> spread-debug -order -debug -single-worker
google:ubuntu-20.04-64:tests/main/classic-prepare-image
google:ubuntu-20.04-64:tests/main/snap-user-service-start-on-install

Like this example
>2021-06-18 14:36:25 Error executing
google:ubuntu-20.04-64:tests/main/snap-user-service-start-on-install
(jun181711-404796) :
>echo 'Install the a snap with user services while a user session is
active'
>Install the a snap with user services while a user session is active
/home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/snaps-state
>install-local test-snapd-user-service
error: cannot perform the following tasks:
>Make snap "test-snapd-user-service" (unset) available to the system
(Post http://0/v1/service-control: dial unix
/run/user/0/snapd-session-agent.socket: connect: connection refused)
