### PR TITLE
cmd: a bunch of tweaks and updates

### DIFF
--- a/cmd/.clangd
+++ b/cmd/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Add: -I/usr/include/glib-2.0 -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wno-missing-field-initializers -Wno-unused-parameter

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -97,7 +97,8 @@ hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-up
 
 # for the hack target also:
 snap-update-ns/snap-update-ns: snap-update-ns/*.go snap-update-ns/*.[ch]
-	cd snap-update-ns && GOPATH=$(or $(GOPATH),$(realpath $(srcdir)/../../../../..)) go build -v
+	cd snap-update-ns && GOPATH=$(or $(GOPATH),$(realpath $(srcdir)/../../../../..)) go build \
+		-ldflags='-extldflags=-static -linkmode=external' -v
 snap-seccomp/snap-seccomp: snap-seccomp/*.go
 	cd snap-seccomp && GOPATH=$(or $(GOPATH),$(realpath $(srcdir)/../../../../..)) go build -v
 

--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -44,7 +44,10 @@ case "$ID" in
 	fedora|centos|rhel)
 		extra_opts="--libexecdir=/usr/libexec/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-merged-usr --disable-apparmor --enable-selinux"
 		;;
-	opensuse|opensuse-tumbleweed)
+	opensuse-tumbleweed)
+		  extra_opts="--libexecdir=/usr/libexec/snapd --enable-nvidia-biarch --with-32bit-libdir=/usr/lib --enable-merged-usr"
+		  ;;
+	opensuse)
 		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-biarch --with-32bit-libdir=/usr/lib --enable-merged-usr"
 		;;
 	solus)


### PR DESCRIPTION
An assorted bunch of tweaks and updates for our C code, which has not been well taken care of until recently.

The patches fix the use of `make hack` such that it builds the snap-update-ns in a correct way. autogen has been fixed to work on openSUSE Tumbleweed and use a proper libexecdir there. Lastly, I've added a config file for [clangd](https://clangd.llvm.org/) which should be valid for most systems.