### PR TITLE
cmd/snap-confine: make mount ns use check cgroup v2 compatible

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -57,6 +57,7 @@ endif
 new_format = \
 	 libsnap-confine-private/cgroup-support.c \
 	 libsnap-confine-private/cgroup-support.h \
+	 libsnap-confine-private/cgroup-support-test.c \
 	 libsnap-confine-private/infofile-test.c \
 	 libsnap-confine-private/infofile.c \
 	 libsnap-confine-private/infofile.h \
@@ -174,7 +175,9 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
 	libsnap-confine-private/unit-tests.h \
-	libsnap-confine-private/utils-test.c
+	libsnap-confine-private/utils-test.c \
+	libsnap-confine-private/cgroup-support-test.c
+
 libsnap_confine_private_unit_tests_CFLAGS = $(CHECK_CFLAGS) $(GLIB_CFLAGS)
 libsnap_confine_private_unit_tests_LDADD = $(GLIB_LIBS)
 libsnap_confine_private_unit_tests_CFLAGS += -D_ENABLE_FAULT_INJECTION

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -156,6 +156,7 @@ libsnap_confine_private_debug_a_CFLAGS = $(CHECK_CFLAGS) -DSNAP_CONFINE_DEBUG_BU
 if WITH_UNIT_TESTS
 noinst_PROGRAMS += libsnap-confine-private/unit-tests
 libsnap_confine_private_unit_tests_SOURCES = \
+	libsnap-confine-private/cgroup-support-test.c \
 	libsnap-confine-private/classic-test.c \
 	libsnap-confine-private/cleanup-funcs-test.c \
 	libsnap-confine-private/error-test.c \
@@ -175,8 +176,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
 	libsnap-confine-private/unit-tests.h \
-	libsnap-confine-private/utils-test.c \
-	libsnap-confine-private/cgroup-support-test.c
+	libsnap-confine-private/utils-test.c
 
 libsnap_confine_private_unit_tests_CFLAGS = $(CHECK_CFLAGS) $(GLIB_CFLAGS)
 libsnap_confine_private_unit_tests_LDADD = $(GLIB_LIBS)

--- a/cmd/libsnap-confine-private/cgroup-support-test.c
+++ b/cmd/libsnap-confine-private/cgroup-support-test.c
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "cgroup-support.c"
+
+#include <fcntl.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/test-utils.h"
+#include "cgroup-support.h"
+
+static void sc_set_self_cgroup_path(const char *mock);
+
+static void sc_set_cgroup_root(const char *mock) { cgroup_dir = mock; }
+
+typedef struct _cgroupv2_is_tracking_fixture {
+    char *p;
+    char *root;
+} cgroupv2_is_tracking_fixture;
+
+static void cgroupv2_is_tracking_set_up(cgroupv2_is_tracking_fixture *fixture, gconstpointer user_data) {
+    GError *err = NULL;
+    int fd = g_file_open_tmp("s-c-unit-is-tracking-self-group.XXXXXX", &fixture->p, &err);
+    g_assert_no_error(err);
+    g_close(fd, &err);
+    g_assert_no_error(err);
+    sc_set_self_cgroup_path(fixture->p);
+
+    fixture->root = g_dir_make_tmp("s-c-unit-test-root.XXXXXX", &err);
+    sc_set_cgroup_root(fixture->root);
+}
+
+static void cgroupv2_is_tracking_tear_down(cgroupv2_is_tracking_fixture *fixture, gconstpointer user_data) {
+    GError *err = NULL;
+
+    sc_set_self_cgroup_path("/proc/self/cgroup");
+    g_remove(fixture->p);
+    g_free(fixture->p);
+
+    sc_set_cgroup_root("/sys/fs/cgroup");
+    char *cmd = g_strdup_printf("rm -rf %s", fixture->root);
+    g_debug("cleanup command: %s", cmd);
+    g_spawn_command_line_sync(cmd, NULL, NULL, NULL, &err);
+    g_assert_no_error(err);
+    g_free(cmd);
+    g_free(fixture->root);
+}
+
+static void test_sc_cgroupv2_is_tracking_happy(cgroupv2_is_tracking_fixture *fixture, gconstpointer user_data) {
+    GError *err = NULL;
+    g_file_set_contents(fixture->p, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, &err);
+    g_assert_no_error(err);
+
+    /* there exist 2 groups with processes from a given snap */
+    const char *dirs[] = {
+        "/foo/bar/baz/snap.foo.app.1234-1234.scope",
+        "/foo/bar/snap.foo.app.1111-1111.scope",
+        "/foo/bar/bad",
+        "/system.slice/some/app/other",
+        "/user/slice/other/app",
+    };
+
+    for (size_t i = 0; i < sizeof dirs / sizeof dirs[0]; i++) {
+        g_autofree const char *np = g_build_filename(fixture->root, dirs[i], NULL);
+        int ret = g_mkdir_with_parents(np, 0755);
+        g_assert_cmpint(ret, ==, 0);
+    }
+
+    bool is_tracking = sc_cgroup_v2_is_tracking_snap("foo");
+    g_assert_true(is_tracking);
+}
+
+static void test_sc_cgroupv2_is_tracking_just_own_group(cgroupv2_is_tracking_fixture *fixture,
+                                                        gconstpointer user_data) {
+    GError *err = NULL;
+    g_file_set_contents(fixture->p, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, &err);
+    g_assert_no_error(err);
+
+    /* our group is the only one for this snap */
+    const char *dirs[] = {
+        "/foo/bar/baz/snap.foo.app.1234-1234.scope",
+        "/foo/bar/bad",
+        "/system.slice/some/app/other",
+        "/user/slice/other/app",
+    };
+
+    for (size_t i = 0; i < sizeof dirs / sizeof dirs[0]; i++) {
+        g_autofree const char *np = g_build_filename(fixture->root, dirs[i], NULL);
+        int ret = g_mkdir_with_parents(np, 0755);
+        g_assert_cmpint(ret, ==, 0);
+    }
+
+    bool is_tracking = sc_cgroup_v2_is_tracking_snap("foo");
+    /* our own group is skipped */
+    g_assert_false(is_tracking);
+}
+
+static void test_sc_cgroupv2_is_tracking_no_dirs(cgroupv2_is_tracking_fixture *fixture, gconstpointer user_data) {
+    GError *err = NULL;
+    g_file_set_contents(fixture->p, "0::/foo/bar/baz/snap.foo.app.scope", -1, &err);
+    g_assert_no_error(err);
+
+    bool is_tracking = sc_cgroup_v2_is_tracking_snap("foo");
+    g_assert_false(is_tracking);
+}
+
+static void test_sc_cgroupv2_is_tracking_bad_self_group(cgroupv2_is_tracking_fixture *fixture,
+                                                        gconstpointer user_data) {
+    GError *err = NULL;
+    /* trigger a failure in own group handling */
+    g_file_set_contents(fixture->p, "", -1, &err);
+    g_assert_no_error(err);
+
+    if (g_test_subprocess()) {
+        sc_cgroup_v2_is_tracking_snap("foo");
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot obtain own group path\n");
+}
+
+static void test_sc_cgroupv2_is_tracking_dir_permissions(cgroupv2_is_tracking_fixture *fixture,
+                                                         gconstpointer user_data) {
+    if (geteuid() == 0) {
+        g_test_skip("the test will not work when running as root");
+        return;
+    }
+    GError *err = NULL;
+    g_file_set_contents(fixture->p, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, &err);
+    g_assert_no_error(err);
+
+    /* there exist 2 groups with processes from a given snap */
+    const char *dirs[] = {
+        "/foo/bar/bad",
+        "/foo/bar/bad/badperm",
+    };
+    for (size_t i = 0; i < sizeof dirs / sizeof dirs[0]; i++) {
+        int mode = 0755;
+        if (g_str_has_suffix(dirs[i], "/badperm")) {
+            mode = 0000;
+        }
+        g_autofree const char *np = g_build_filename(fixture->root, dirs[i], NULL);
+        int ret = g_mkdir_with_parents(np, mode);
+        g_assert_cmpint(ret, ==, 0);
+    }
+
+    /* dies when hitting an error traversing the hierarchy */
+    if (g_test_subprocess()) {
+        sc_cgroup_v2_is_tracking_snap("foo");
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot open directory entry \"badperm\": Permission denied\n");
+}
+
+static void sc_set_self_cgroup_path(const char *mock) { self_cgroup = mock; }
+
+typedef struct _cgroupv2_own_group_fixture {
+    char *p;
+} cgroupv2_own_group_fixture;
+
+static void cgroupv2_own_group_set_up(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
+    GError *err = NULL;
+    int fd = g_file_open_tmp("s-c-unit-test.XXXXXX", &fixture->p, &err);
+    g_assert_no_error(err);
+    g_close(fd, &err);
+    g_assert_no_error(err);
+    sc_set_self_cgroup_path(fixture->p);
+}
+
+static void cgroupv2_own_group_tear_down(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
+    sc_set_self_cgroup_path("/proc/self/cgroup");
+    g_remove(fixture->p);
+    g_free(fixture->p);
+}
+
+static void test_sc_cgroupv2_own_group_path_simple_happy(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
+    GError *err = NULL;
+    g_autofree const char *p = NULL;
+    g_file_set_contents(fixture->p, (char *)user_data, -1, &err);
+    g_assert_no_error(err);
+    p = sc_cgroup_v2_own_path_full();
+    g_assert_cmpstr(p, ==, "/foo/bar/baz.slice");
+}
+
+static void test_sc_cgroupv2_own_group_path_empty(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
+    GError *err = NULL;
+    g_autofree const char *p = NULL;
+    g_file_set_contents(fixture->p, (char *)user_data, -1, &err);
+    g_assert_no_error(err);
+    p = sc_cgroup_v2_own_path_full();
+    g_assert_null(p);
+}
+
+static void _test_sc_cgroupv2_own_group_path_die_with_message(const char *msg) {
+    if (g_test_subprocess()) {
+        g_autofree const char *p = NULL;
+        p = sc_cgroup_v2_own_path_full();
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr(msg);
+}
+
+static void test_sc_cgroupv2_own_group_path_die(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
+    GError *err = NULL;
+    g_file_set_contents(fixture->p, (char *)user_data, -1, &err);
+    g_assert_no_error(err);
+    _test_sc_cgroupv2_own_group_path_die_with_message("unexpected content of group entry 0::\n");
+}
+
+static void test_sc_cgroupv2_own_group_path_no_file(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
+    g_remove(fixture->p);
+    _test_sc_cgroupv2_own_group_path_die_with_message("cannot open *\n");
+}
+
+static void test_sc_cgroupv2_own_group_path_permission(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
+    if (geteuid() == 0) {
+        g_test_skip("the test will not work when running as root");
+        return;
+    }
+    int ret = g_chmod(fixture->p, 0000);
+    g_assert_cmpint(ret, ==, 0);
+    _test_sc_cgroupv2_own_group_path_die_with_message("cannot open *: Permission denied\n");
+}
+
+static void __attribute__((constructor)) init(void) {
+    g_test_add("/cgroup/v2/own_path_full_newline", cgroupv2_own_group_fixture, "0::/foo/bar/baz.slice\n",
+               cgroupv2_own_group_set_up, test_sc_cgroupv2_own_group_path_simple_happy, cgroupv2_own_group_tear_down);
+    g_test_add("/cgroup/v2/own_path_full_no_newline", cgroupv2_own_group_fixture, "0::/foo/bar/baz.slice",
+               cgroupv2_own_group_set_up, test_sc_cgroupv2_own_group_path_simple_happy, cgroupv2_own_group_tear_down);
+    g_test_add("/cgroup/v2/own_path_full_firstline", cgroupv2_own_group_fixture,
+               "0::/foo/bar/baz.slice\n"
+               "0::/bad\n",
+               cgroupv2_own_group_set_up, test_sc_cgroupv2_own_group_path_simple_happy, cgroupv2_own_group_tear_down);
+    g_test_add("/cgroup/v2/own_path_full_ignore_non_unified", cgroupv2_own_group_fixture,
+               "1::/ignored\n"
+               "0::/foo/bar/baz.slice\n",
+               cgroupv2_own_group_set_up, test_sc_cgroupv2_own_group_path_simple_happy, cgroupv2_own_group_tear_down);
+    g_test_add("/cgroup/v2/own_path_full_empty", cgroupv2_own_group_fixture, "", cgroupv2_own_group_set_up,
+               test_sc_cgroupv2_own_group_path_empty, cgroupv2_own_group_tear_down);
+    g_test_add("/cgroup/v2/own_path_full_not_found", cgroupv2_own_group_fixture,
+               /* missing 0:: group */
+               "1::/ignored\n"
+               "2::/foo/bar/baz.slice\n",
+               cgroupv2_own_group_set_up, test_sc_cgroupv2_own_group_path_empty, cgroupv2_own_group_tear_down);
+    g_test_add("/cgroup/v2/own_path_full_die", cgroupv2_own_group_fixture, "0::", cgroupv2_own_group_set_up,
+               test_sc_cgroupv2_own_group_path_die, cgroupv2_own_group_tear_down);
+    g_test_add("/cgroup/v2/own_path_full_no_file", cgroupv2_own_group_fixture, NULL, cgroupv2_own_group_set_up,
+               test_sc_cgroupv2_own_group_path_no_file, cgroupv2_own_group_tear_down);
+    g_test_add("/cgroup/v2/own_path_full_permission", cgroupv2_own_group_fixture, NULL, cgroupv2_own_group_set_up,
+               test_sc_cgroupv2_own_group_path_permission, cgroupv2_own_group_tear_down);
+
+    g_test_add("/cgroup/v2/is_tracking_happy", cgroupv2_is_tracking_fixture, NULL, cgroupv2_is_tracking_set_up,
+               test_sc_cgroupv2_is_tracking_happy, cgroupv2_is_tracking_tear_down);
+    g_test_add("/cgroup/v2/is_tracking_just_own", cgroupv2_is_tracking_fixture, NULL, cgroupv2_is_tracking_set_up,
+               test_sc_cgroupv2_is_tracking_just_own_group, cgroupv2_is_tracking_tear_down);
+    g_test_add("/cgroup/v2/is_tracking_empty_groups", cgroupv2_is_tracking_fixture, NULL, cgroupv2_is_tracking_set_up,
+               test_sc_cgroupv2_is_tracking_no_dirs, cgroupv2_is_tracking_tear_down);
+    g_test_add("/cgroup/v2/is_tracking_bad_self_group", cgroupv2_is_tracking_fixture, NULL, cgroupv2_is_tracking_set_up,
+               test_sc_cgroupv2_is_tracking_bad_self_group, cgroupv2_is_tracking_tear_down);
+    g_test_add("/cgroup/v2/is_tracking_bad_dir_permissions", cgroupv2_is_tracking_fixture, NULL,
+               cgroupv2_is_tracking_set_up, test_sc_cgroupv2_is_tracking_dir_permissions,
+               cgroupv2_is_tracking_tear_down);
+}

--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -113,29 +113,29 @@ static bool traverse_looking_for_prefix_in_dir(DIR *root, const char *prefix, co
             continue;
         }
         if (sc_streq(ent->d_name, "..") || sc_streq(ent->d_name, ".")) {
-            /* we don't want to go up or process the current directory again */
+            // we don't want to go up or process the current directory again
             continue;
         }
         if (sc_streq(ent->d_name, skip)) {
+            // we were asked to skip this group
             continue;
         }
         if (sc_startswith(ent->d_name, prefix)) {
             debug("found matching prefix in \"%s\"", ent->d_name);
-            /* the directory starts with our prefix */
+            // the directory starts with our prefix
             return true;
         }
+        // entfd is consumed by fdopendir() and freed with closedir()
         int entfd = openat(dirfd(root), ent->d_name, O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
         if (entfd == -1) {
             die("cannot open directory entry \"%s\"", ent->d_name);
         }
-        debug("got directory fd: %d", entfd);
-        /* takes ownership o the file descriptor? */
+        // takes ownership of the file descriptor
         DIR *entdir SC_CLEANUP(sc_cleanup_closedir) = fdopendir(entfd);
         if (entdir == NULL) {
             die("cannot fdopendir directory \"%s\"", ent->d_name);
         }
-        debug("descend into %s", ent->d_name);
-        int found = traverse_looking_for_prefix_in_dir(entdir, prefix, skip);
+        bool found = traverse_looking_for_prefix_in_dir(entdir, prefix, skip);
         if (found == true) {
             return true;
         }
@@ -146,35 +146,42 @@ static bool traverse_looking_for_prefix_in_dir(DIR *root, const char *prefix, co
 bool sc_cgroup_v2_is_tracking_snap(const char *snap_instance) {
     debug("is cgroup tracking snap %s?", snap_instance);
     char tracking_group_name[PATH_MAX] = {0};
+    // tracking groups created by snap run chain have a format:
+    // snap.<name>.<app>.<uuid>.scope, while the groups corresponding to snap
+    // services created by systemd are named like this:
+    // snap.<name>.<svc>.service
     sc_must_snprintf(tracking_group_name, sizeof tracking_group_name, "snap.%s.", snap_instance);
 
+    // when running with cgroup v2, the snap run chain or systemd would create a
+    // tracking cgroup which the current process would execute in and would
+    // match the pattern we are looking for, thus it needs to be skipped
     char *own_group SC_CLEANUP(sc_cleanup_string) = sc_cgroup_v2_own_path_full();
     if (own_group == NULL) {
-        die("cannot obtain own group path");
+        die("cannot obtain own cgroup v2 group path");
     }
     debug("own group: %s", own_group);
     char *just_leaf = strrchr(own_group, '/');
     if (just_leaf == NULL) {
         die("cannot obtain the leaf group path");
     }
-    /* pointing at /, advance to the next char */
+    // pointing at /, advance to the next char
     just_leaf += 1;
-    debug("leap group: %s", just_leaf);
 
     // this would otherwise be inherently racy, but the caller is expected to
     // keep the snap instance lock, thus preventing new apps of that snap from
-    // starting; not we can still return false positive if the currently running
-    // process exits but we look at the hierarchy before systemd has cleaned up
-    // the group
+    // starting; note that we can still return false positive if the currently
+    // running process exits but we look at the hierarchy before systemd has
+    // cleaned up the group
 
-    bool found = false;
-    debug("opening %s", cgroup_dir);
+    debug("opening cgroup root dir at %s", cgroup_dir);
     DIR *root SC_CLEANUP(sc_cleanup_closedir) = opendir(cgroup_dir);
     if (root == NULL) {
         die("cannot open cgroup root dir");
     }
-    found = traverse_looking_for_prefix_in_dir(root, tracking_group_name, just_leaf);
-    return found;
+    // traverse the cgroup hierarchy tree looking for other groups that
+    // correspond to the snap (i.e. their name matches the pattern), but skip
+    // our own group in the process
+    return traverse_looking_for_prefix_in_dir(root, tracking_group_name, just_leaf);
 }
 
 static const char *self_cgroup = "/proc/self/cgroup";
@@ -199,7 +206,6 @@ char *sc_cgroup_v2_own_path_full(void) {
                 die("cannot read line from %s", self_cgroup);
             }
         }
-        debug("got line: \'%s\'", line);
         if (!sc_startswith(line, "0::")) {
             continue;
         }
@@ -207,8 +213,8 @@ char *sc_cgroup_v2_own_path_full(void) {
         if (len <= 3) {
             die("unexpected content of group entry %s", line);
         }
-        /* \n does not normally appear inside the group path, but if it did, it
-         * would be escaped anyway */
+        // \n does not normally appear inside the group path, but if it did, it
+        // would be escaped anyway
         char *newline = strchr(line, '\n');
         if (newline != NULL) {
             *newline = '\0';

--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -15,12 +15,13 @@
  *
  */
 
-// For AT_EMPTY_PATH and O_PATH
 #define _GNU_SOURCE
 
 #include "cgroup-support.h"
 
+#include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -96,4 +97,124 @@ bool sc_cgroup_is_v2() {
         return true;
     }
     return false;
+}
+
+static bool traverse_looking_for_prefix_in_dir(DIR *root, const char *prefix, const char *skip) {
+    while (true) {
+        errno = 0;
+        struct dirent *ent = readdir(root);
+        if (ent == NULL) {
+            if (errno != 0) {
+                die("cannot read directory entry");
+            }
+            break;
+        }
+        if (ent->d_type != DT_DIR) {
+            continue;
+        }
+        if (sc_streq(ent->d_name, "..") || sc_streq(ent->d_name, ".")) {
+            /* we don't want to go up or process the current directory again */
+            continue;
+        }
+        if (sc_streq(ent->d_name, skip)) {
+            continue;
+        }
+        if (sc_startswith(ent->d_name, prefix)) {
+            debug("found matching prefix in \"%s\"", ent->d_name);
+            /* the directory starts with our prefix */
+            return true;
+        }
+        int entfd = openat(dirfd(root), ent->d_name, O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+        if (entfd == -1) {
+            die("cannot open directory entry \"%s\"", ent->d_name);
+        }
+        debug("got directory fd: %d", entfd);
+        /* takes ownership o the file descriptor? */
+        DIR *entdir SC_CLEANUP(sc_cleanup_closedir) = fdopendir(entfd);
+        if (entdir == NULL) {
+            die("cannot fdopendir directory \"%s\"", ent->d_name);
+        }
+        debug("descend into %s", ent->d_name);
+        int found = traverse_looking_for_prefix_in_dir(entdir, prefix, skip);
+        if (found == true) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool sc_cgroup_v2_is_tracking_snap(const char *snap_instance) {
+    debug("is cgroup tracking snap %s?", snap_instance);
+    char tracking_group_name[PATH_MAX] = {0};
+    sc_must_snprintf(tracking_group_name, sizeof tracking_group_name, "snap.%s.", snap_instance);
+
+    char *own_group SC_CLEANUP(sc_cleanup_string) = sc_cgroup_v2_own_path_full();
+    if (own_group == NULL) {
+        die("cannot obtain own group path");
+    }
+    debug("own group: %s", own_group);
+    char *just_leaf = strrchr(own_group, '/');
+    if (just_leaf == NULL) {
+        die("cannot obtain the leaf group path");
+    }
+    /* pointing at /, advance to the next char */
+    just_leaf += 1;
+    debug("leap group: %s", just_leaf);
+
+    // this would otherwise be inherently racy, but the caller is expected to
+    // keep the snap instance lock, thus preventing new apps of that snap from
+    // starting; not we can still return false positive if the currently running
+    // process exits but we look at the hierarchy before systemd has cleaned up
+    // the group
+
+    bool found = false;
+    debug("opening %s", cgroup_dir);
+    DIR *root SC_CLEANUP(sc_cleanup_closedir) = opendir(cgroup_dir);
+    if (root == NULL) {
+        die("cannot open cgroup root dir");
+    }
+    found = traverse_looking_for_prefix_in_dir(root, tracking_group_name, just_leaf);
+    return found;
+}
+
+static const char *self_cgroup = "/proc/self/cgroup";
+
+char *sc_cgroup_v2_own_path_full(void) {
+    FILE *in SC_CLEANUP(sc_cleanup_file) = fopen(self_cgroup, "r");
+    if (in == NULL) {
+        die("cannot open %s", self_cgroup);
+    }
+
+    char *own_group = NULL;
+
+    while (true) {
+        char *line SC_CLEANUP(sc_cleanup_string) = NULL;
+        size_t linesz = 0;
+        ssize_t sz = getline(&line, &linesz, in);
+        if (sz == -1) {
+            if (feof(in)) {
+                break;
+            }
+            if (ferror(in)) {
+                die("cannot read line from %s", self_cgroup);
+            }
+        }
+        debug("got line: \'%s\'", line);
+        if (!sc_startswith(line, "0::")) {
+            continue;
+        }
+        size_t len = strlen(line);
+        if (len <= 3) {
+            die("unexpected content of group entry %s", line);
+        }
+        /* \n does not normally appear inside the group path, but if it did, it
+         * would be escaped anyway */
+        char *newline = strchr(line, '\n');
+        if (newline != NULL) {
+            *newline = '\0';
+        }
+        own_group = sc_strdup(line + 3);
+        break;
+    }
+    return own_group;
 }

--- a/cmd/libsnap-confine-private/cgroup-support.h
+++ b/cmd/libsnap-confine-private/cgroup-support.h
@@ -38,15 +38,16 @@ void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid);
 bool sc_cgroup_is_v2(void);
 
 /**
- * sc_cgroup_is_tracking_snap checks whether the snap process are being
- * currently tracked in a cgroup.
+ * sc_cgroup_is_tracking_snap checks whether any snap process other than the
+ * caller are currently being tracked in a cgroup.
  *
- * Note that sc_cgroup_is_tracking_snap will traverse the cgroups hierarchy
- * looking for a group name with a specific prefix. This is inherently racy. The
- * caller must have take the per snap instance lock to prevent new applications
- * of that snap from being started. However, it is still possible that the
- * application may exit but the cgroup has not been cleaned up yet, in which
- * case this call will return a false positive.
+ * Note that this call will traverse the cgroups hierarchy looking for a group
+ * name with a specific prefix corresponding to the snap name. This is
+ * inherently racy. The caller must have taken the per snap instance lock to
+ * prevent new applications of that snap from being started. However, it is
+ * still possible that the application may exit but the cgroup has not been
+ * cleaned up yet, in which case this call will return a false positive.
+ *
  * It is possible that the current process is already being tracked in cgroup,
  * in which case the code will skip its own group.
  */

--- a/cmd/libsnap-confine-private/cgroup-support.h
+++ b/cmd/libsnap-confine-private/cgroup-support.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -36,5 +36,29 @@ void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid);
  *
  **/
 bool sc_cgroup_is_v2(void);
+
+/**
+ * sc_cgroup_is_tracking_snap checks whether the snap process are being
+ * currently tracked in a cgroup.
+ *
+ * Note that sc_cgroup_is_tracking_snap will traverse the cgroups hierarchy
+ * looking for a group name with a specific prefix. This is inherently racy. The
+ * caller must have take the per snap instance lock to prevent new applications
+ * of that snap from being started. However, it is still possible that the
+ * application may exit but the cgroup has not been cleaned up yet, in which
+ * case this call will return a false positive.
+ * It is possible that the current process is already being tracked in cgroup,
+ * in which case the code will skip its own group.
+ */
+bool sc_cgroup_v2_is_tracking_snap(const char *snap_instance);
+
+/**
+ * sc_cgroup_v2_own_path_full return the full path of the owning cgroup as
+ * reported by the kernel.
+ *
+ * Returns the full path of the group in the unified hierarchy relative to its
+ * root. The string is owned by the caller.
+ */
+char *sc_cgroup_v2_own_path_full(void);
 
 #endif

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -67,6 +67,11 @@
     /sys/fs/cgroup/freezer/ r,
     /sys/fs/cgroup/freezer/snap.*/ w,
     /sys/fs/cgroup/freezer/snap.*/cgroup.procs rw,
+    /sys/fs/cgroup/ r,
+    /sys/fs/cgroup/** r,
+
+    # cgroup: reading own cgroup
+    @{PROC}/@{pid}/cgroup r,
 
     # querying udev
     /etc/udev/udev.conf r,

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -713,14 +713,19 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 			}
 		}
 	}
-	// Associate each snap process with a dedicated snap freezer cgroup and
-	// snap pids cgroup. All snap processes belonging to one snap share the
-	// freezer cgroup. All snap processes belonging to one app or one hook
-	// share the pids cgroup.
+	// With cgroups v1, associate each snap process with a dedicated
+	// snap freezer cgroup and snap pids cgroup. All snap processes
+	// belonging to one snap share the freezer cgroup. All snap
+	// processes belonging to one app or one hook share the pids cgroup.
 	//
 	// This simplifies testing if any processes belonging to a given snap are
 	// still alive as well as to properly account for each application and
 	// service.
+	//
+	// Note that with cgroups v2 there is no separate freeezer controller,
+	// but the freezer is associated with each group. The call chain when
+	// starting the snap application has already ensure that the process has
+	// been put in a dedicated group.
 	if (!sc_cgroup_is_v2()) {
 		sc_cgroup_freezer_join(inv->snap_instance, getpid());
 	}

--- a/tests/main/stale-base-snap/task.yaml
+++ b/tests/main/stale-base-snap/task.yaml
@@ -62,18 +62,6 @@ execute: |
     snap install --dangerous ./core-customized.snap
     snap list | MATCH customized
 
-    if is_cgroupv2 ; then
-        # stale mount namespace is always discarded with cgroupv2, because we
-        # cannot currently determine whether there are processes using it
-        test-snapd-sh.sh -c "test -e /customized"
-
-        # Kill our helper process.
-        kill -9 "$pid"
-        wait -n || true
-
-        exit 0
-    fi
-
     # Now we are in a situation where the core snap is stale but our sleeper
     # application is still alive so we cannot use it.
     test-snapd-sh.sh -c "test ! -e /customized"


### PR DESCRIPTION
Fix the mount namespace usage check to work with a cgroup v2 setup. Previously,
the snap processes would end up in a separate group under the freezer
controller, making the check simple and efficient.

With cgroups v2, there is are separate controllers. However, each snap process
is moved to a tracking group (systemd scope) created by snap run early in the
call chain. We can use that property to locate processes from a given snap. The
groups are managed externally by systemd, which takes care of the cleanup once
the last process exits. A slight detour is that snap-confine is no longer
responsible for placing the process inside the group, as the step has been done
early on by either the system or user systemd instance.

The patch refactors the code to be aware of the tracking group, and moves
through the group hierarchy to find one which is named after a snap. In the
process, we must be aware of our own group, such that it can be skipped.

Another PR based on the same idea is: https://github.com/snapcore/snapd/pull/10423