### PR TITLE
snap: fix TestInstallNoPATH unit test failure when SUDO_UID is set

### DIFF
--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -229,6 +229,12 @@ func (s *SnapOpSuite) TestInstallIgnoreRunning(c *check.C) {
 func (s *SnapOpSuite) TestInstallNoPATH(c *check.C) {
 	// PATH restored by test tear down
 	os.Setenv("PATH", "/bin:/usr/bin:/sbin:/usr/sbin")
+	// SUDO_UID env must be unset in this test
+	if sudoUidEnv, isSet := os.LookupEnv("SUDO_UID"); isSet {
+		os.Unsetenv("SUDO_UID")
+		defer os.Setenv("SUDO_UID", sudoUidEnv)
+	}
+
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{


### PR DESCRIPTION
The TestInstallNoPATH unit test is currently failing when the SUDO_UID
environment is set. This happens e.g. in a pbuilder environment.

To reproduce:
```
$ SUDO_UID=100 go test -check.f TestInstallNoPATH

FAIL: cmd_snap_op_test.go:229: SnapOpSuite.TestInstallNoPATH

cmd_snap_op_test.go:252:
    c.Check(s.Stderr(), testutil.MatchesWrapped, `Warning: \S+/bin was not found in your \$PATH.*`)
... wrapped string = ""
... expected string = "Warning: \\S+/bin was not found in your \\$PATH.*"
```

The fix is to ensure that SUDO_UID is unset in this test.
