### PR TITLE
HACKING.md: update instructions for go1.16+

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -42,6 +42,14 @@ Add `$GOPATH/bin` to your `PATH`, so you can run the go programs you install:
 your `$GOPATH` is more complex than a single entry you'll need to adjust the
 above).
 
+Note that if you are using go 1.16 or newer you need to disable the
+go modules feature. Use:
+
+    export GO111MODULE=off
+
+for this.
+
+
 ### Getting the snapd sources
 
 The easiest way to get the source for `snapd` is to use the `go get` command.


### PR DESCRIPTION
With go1.16 we need to disable go modules or our instructions
will fail at the "go get" stage because go will try to init
using go modules.

This can be dropped once we move to go 1.13 but right now
out instructions do not work for people on Ubuntu 21.04 or
similar new distro releases.
