### PR TITLE
o/servicestate: move SetStatus to doQuotaControl

### DIFF
--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -28,9 +28,6 @@ import (
 var (
 	UpdateSnapstateServices = updateSnapstateServices
 	CheckSystemdVersion     = checkSystemdVersion
-	QuotaCreate             = quotaCreate
-	QuotaRemove             = quotaRemove
-	QuotaUpdate             = quotaUpdate
 )
 
 func (m *ServiceManager) DoQuotaControl(t *state.Task, to *tomb.Tomb) error {

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -105,7 +105,14 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 		ParentName:  parentName,
 	}
 
-	return quotaCreate(st, nil, qc, allGrps, nil)
+	grp, allGrps, err := quotaCreate(st, qc, allGrps)
+	if err != nil {
+		return err
+	}
+	opts := &ensureSnapServicesForGroupOptions{
+		allGrps: allGrps,
+	}
+	return ensureSnapServicesForGroup(st, nil, grp, opts, nil)
 }
 
 // RemoveQuota deletes the specific quota group. Any snaps currently in the
@@ -130,7 +137,14 @@ func RemoveQuota(st *state.State, name string) error {
 		QuotaName: name,
 	}
 
-	return quotaRemove(st, nil, qc, allGrps, nil)
+	grp, allGrps, err := quotaRemove(st, qc, allGrps)
+	if err != nil {
+		return err
+	}
+	opts := &ensureSnapServicesForGroupOptions{
+		allGrps: allGrps,
+	}
+	return ensureSnapServicesForGroup(st, nil, grp, opts, nil)
 }
 
 // QuotaGroupUpdate reflects all of the modifications that can be performed on
@@ -169,7 +183,14 @@ func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) erro
 		AddSnaps:    updateOpts.AddSnaps,
 	}
 
-	return quotaUpdate(st, nil, qc, allGrps, nil)
+	grp, allGrps, err := quotaUpdate(st, qc, allGrps)
+	if err != nil {
+		return err
+	}
+	opts := &ensureSnapServicesForGroupOptions{
+		allGrps: allGrps,
+	}
+	return ensureSnapServicesForGroup(st, nil, grp, opts, nil)
 }
 
 // EnsureSnapAbsentFromQuota ensures that the specified snap is not present

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -112,7 +112,7 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 	opts := &ensureSnapServicesForGroupOptions{
 		allGrps: allGrps,
 	}
-	return ensureSnapServicesForGroup(st, nil, grp, opts, nil)
+	return ensureSnapServicesStateForGroup(st, grp, opts)
 }
 
 // RemoveQuota deletes the specific quota group. Any snaps currently in the
@@ -144,7 +144,7 @@ func RemoveQuota(st *state.State, name string) error {
 	opts := &ensureSnapServicesForGroupOptions{
 		allGrps: allGrps,
 	}
-	return ensureSnapServicesForGroup(st, nil, grp, opts, nil)
+	return ensureSnapServicesStateForGroup(st, grp, opts)
 }
 
 // QuotaGroupUpdate reflects all of the modifications that can be performed on
@@ -190,7 +190,7 @@ func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) erro
 	opts := &ensureSnapServicesForGroupOptions{
 		allGrps: allGrps,
 	}
-	return ensureSnapServicesForGroup(st, nil, grp, opts, nil)
+	return ensureSnapServicesStateForGroup(st, grp, opts)
 }
 
 // EnsureSnapAbsentFromQuota ensures that the specified snap is not present
@@ -231,7 +231,7 @@ func EnsureSnapAbsentFromQuota(st *state.State, snap string) error {
 				}
 				// TODO: we could pass timing and progress here from the task we
 				// are executing as eventually
-				return ensureSnapServicesForGroup(st, nil, grp, opts, nil)
+				return ensureSnapServicesStateForGroup(st, grp, opts)
 			}
 		}
 	}


### PR DESCRIPTION
This is done by splitting ensureSnapServicesForGroup and separating out restartSnapServices.

The reason for this refactoring is that we need to swap out the SetStatus(DoneStatus) with some other state handling to track the work done and to do. The effect of the current code is that a change using this, is considered Done before the services are restarted which we don't want. We still need to track things such in the case of a restart (panic for example) or reboot we do the right thing, the actual fix for that will come in a separate PR.


