### PR TITLE
tests: check files and dirs are cleaned for each test

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -591,6 +591,7 @@ pkg_dependencies_ubuntu_classic(){
         ubuntu-20.04-64)
             echo "
                 evolution-data-server
+                inotify-tools
                 gccgo-9
                 packagekit
                 qemu-utils
@@ -665,6 +666,7 @@ pkg_dependencies_fedora(){
         fwupd
         git
         golang
+        inotify-tools
         jq
         iptables-services
         man


### PR DESCRIPTION
This is a new check to make sure all the files/dirs created are deleted
after the test is reset.

In a following PR the code could be moved to a test tool.
