### PR TITLE
cmd/snap-confine, cmd/snapd-generator: fix issues identified by sparse

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -78,7 +78,7 @@ static const char *cgroup_dir = "/sys/fs/cgroup";
 // Detect if we are running in cgroup v2 unified mode (as opposed to
 // hybrid or legacy) The algorithm is described in
 // https://systemd.io/CGROUP_DELEGATION/
-bool sc_cgroup_is_v2() {
+bool sc_cgroup_is_v2(void) {
     static bool did_warn = false;
     struct statfs buf;
 

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -160,7 +160,7 @@ static void setup_private_pts(void)
 	// copied from /etc/default/devpts
 	sc_do_mount("devpts", "/dev/pts", "devpts", MS_MGC_VAL,
 		    "newinstance,ptmxmode=0666,mode=0620,gid=5");
-	sc_do_mount("/dev/pts/ptmx", "/dev/ptmx", "none", MS_BIND, 0);
+	sc_do_mount("/dev/pts/ptmx", "/dev/ptmx", "none", MS_BIND, NULL);
 }
 
 struct sc_mount {
@@ -758,7 +758,7 @@ void sc_ensure_shared_snap_mount(void)
 		// removed once we have a measurement and feedback mechanism that lets
 		// us decide based on measurable data.
 		sc_do_mount(SNAP_MOUNT_DIR, SNAP_MOUNT_DIR, "none",
-			    MS_BIND | MS_REC, 0);
+			    MS_BIND | MS_REC, NULL);
 		sc_do_mount("none", SNAP_MOUNT_DIR, NULL, MS_SHARED | MS_REC,
 			    NULL);
 	}
@@ -804,7 +804,7 @@ void sc_ensure_snap_dir_shared_mounts(void)
 			 * since snaps are already mounted, and it's not needed for
 			 * /var/snap.
 			 */
-			sc_do_mount(dir, dir, "none", MS_BIND | MS_REC, 0);
+			sc_do_mount(dir, dir, "none", MS_BIND | MS_REC, NULL);
 			sc_do_mount("none", dir, NULL, MS_REC | MS_SHARED,
 				    NULL);
 		}
@@ -827,10 +827,10 @@ void sc_setup_parallel_instance_classic_mounts(const char *snap_name,
 	sc_must_snprintf(src, sizeof src, "%s/%s", SNAP_MOUNT_DIR,
 			 snap_instance_name);
 	sc_must_snprintf(dst, sizeof dst, "%s/%s", SNAP_MOUNT_DIR, snap_name);
-	sc_do_mount(src, dst, "none", MS_BIND | MS_REC, 0);
+	sc_do_mount(src, dst, "none", MS_BIND | MS_REC, NULL);
 
 	/* Mount /var/snap/<snap>_<key> on /var/snap/<snap> */
 	sc_must_snprintf(src, sizeof src, "/var/snap/%s", snap_instance_name);
 	sc_must_snprintf(dst, sizeof dst, "/var/snap/%s", snap_name);
-	sc_do_mount(src, dst, "none", MS_BIND | MS_REC, 0);
+	sc_do_mount(src, dst, "none", MS_BIND | MS_REC, NULL);
 }

--- a/cmd/snapd-generator/main.c
+++ b/cmd/snapd-generator/main.c
@@ -43,7 +43,7 @@ static sc_mountinfo_entry *find_root_mountinfo(sc_mountinfo * mounts)
 	return root;
 }
 
-int ensure_root_fs_shared(const char *normal_dir)
+static int ensure_root_fs_shared(const char *normal_dir)
 {
 	// Load /proc/self/mountinfo so that we can inspect the root filesystem.
 	sc_mountinfo *mounts SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
@@ -161,7 +161,7 @@ static bool is_snap_try_snap_unit(const char *units_dir,
 	return stat(what, &st) == 0 && (st.st_mode & S_IFMT) == S_IFDIR;
 }
 
-int ensure_fusesquashfs_inside_container(const char *normal_dir)
+static int ensure_fusesquashfs_inside_container(const char *normal_dir)
 {
 	// check if we are running inside a container, systemd
 	// provides this file all the way back to trusty if run in a


### PR DESCRIPTION
Sparse identified the following issues:

```
libsnap-confine-private/cgroup-support-test.c: note: in included file:
libsnap-confine-private/cgroup-support.c:82:22: warning: non-ANSI function declaration of function 'sc_cgroup_is_v2'
snap-confine/mount-support.c:163:68: warning: Using plain integer as NULL pointer
snap-confine/mount-support.c:761:47: warning: Using plain integer as NULL pointer
snap-confine/mount-support.c:807:73: warning: Using plain integer as NULL pointer
snap-confine/mount-support.c:830:57: warning: Using plain integer as NULL pointer
snap-confine/mount-support.c:835:57: warning: Using plain integer as NULL pointer
snapd-generator/main.c:46:5: warning: symbol 'ensure_root_fs_shared' was not declared. Should it be static?
snapd-generator/main.c:164:5: warning: symbol 'ensure_fusesquashfs_inside_container' was not declared. Should it be static?
```

There is a couple of more problems that are picked up, eg:
```
libsnap-confine-private/snap-test.c:383:9: warning: Using plain integer as NULL pointer       
libsnap-confine-private/snap-test.c:396:9: warning: Using plain integer as NULL pointer                                                                                                        
libsnap-confine-private/snap-test.c:407:9: warning: Using plain integer as NULL pointer                                                                                                                                                                                                                                                                                                        
libsnap-confine-private/snap-test.c:418:9: warning: Using plain integer as NULL pointer                                                                                                        
libsnap-confine-private/snap-test.c:432:9: warning: Using plain integer as NULL pointer                                                                                                        
libsnap-confine-private/snap-test.c:474:9: warning: Using plain integer as NULL pointer                                                                                                                                                                                                                                                                                                        
libsnap-confine-private/snap-test.c:486:9: warning: Using plain integer as NULL pointer   
```

but that appears to be due to g_test_trap_assert_failed(), which is a macro with dragons inside.