### PR TITLE
many: pass device/model info to configcore via sysconfig.Device interface

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1337,7 +1337,7 @@ func generateMountsCommonInstallRecover(mst *initramfsMountsState) (model *asser
 		TargetRootDir:  boot.InitramfsWritableDir,
 		GadgetSnap:     gadgetSnap,
 	}
-	if err := sysconfig.ConfigureTargetSystem(configOpts); err != nil {
+	if err := sysconfig.ConfigureTargetSystem(model, configOpts); err != nil {
 		return nil, nil, err
 	}
 

--- a/daemon/api_snap_conf_test.go
+++ b/daemon/api_snap_conf_test.go
@@ -22,12 +22,16 @@ package daemon_test
 import (
 	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -184,9 +188,11 @@ func (s *snapConfSuite) TestSetConfCoreSystemAlias(c *check.C) {
 name: core
 version: 1
 `)
-	// Mock the hook runner
-	hookRunner := testutil.MockCommand(c, "snap", "")
-	defer hookRunner.Restore()
+
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
+	c.Assert(err, check.IsNil)
+	err = ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/etc/environment"), nil, 0644)
+	c.Assert(err, check.IsNil)
 
 	d.Overlord().Loop()
 	defer d.Overlord().Stop()
@@ -217,8 +223,6 @@ version: 1
 
 	st.Lock()
 	err = chg.Err()
-	c.Assert(err, check.IsNil)
-
 	tr := config.NewTransaction(st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
@@ -226,7 +230,6 @@ version: 1
 	var value string
 	tr.Get("core", "proxy.ftp", &value)
 	c.Assert(value, check.Equals, "value")
-
 }
 
 func (s *snapConfSuite) TestSetConfNumber(c *check.C) {

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -527,8 +527,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 			if err := os.MkdirAll(sysconfig.WritableDefaultsDir(rootDir, "/etc"), 0755); err != nil {
 				return err
 			}
-			applyOpts := &sysconfig.FilesystemOnlyApplyOptions{Classic: opts.Classic}
-			return sysconfig.ApplyFilesystemOnlyDefaults(defaultsDir, defaults, applyOpts)
+			return sysconfig.ApplyFilesystemOnlyDefaults(model, defaultsDir, defaults)
 		}
 
 		customizeImage(rootDir, defaultsDir, &opts.Customizations)

--- a/overlord/configstate/configcore/backlight.go
+++ b/overlord/configstate/configcore/backlight.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -45,7 +46,7 @@ func (l *backlightSysdLogger) Notify(status string) {
 // systemd-backlight service has no installation config. It's started when needed via udev.
 // So, systemctl enable/disable/start/stop are invalid commands. After masking/unmasking
 // the service, rebooting is required for making new setting work
-func handleBacklightServiceConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handleBacklightServiceConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	var sysd systemd.Systemd
 	const serviceName = "systemd-backlight@.service"
 	if opts != nil {

--- a/overlord/configstate/configcore/backlight_test.go
+++ b/overlord/configstate/configcore/backlight_test.go
@@ -82,7 +82,7 @@ func (s *backlightSuite) TestFilesystemOnlyApply(c *C) {
 		"system.disable-backlight-service": "true",
 	})
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
 		{"--root", tmpDir, "mask", "systemd-backlight@.service"},

--- a/overlord/configstate/configcore/backlight_test.go
+++ b/overlord/configstate/configcore/backlight_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 )
 
 type backlightSuite struct {
@@ -44,9 +43,6 @@ func (s *backlightSuite) SetUpTest(c *C) {
 }
 
 func (s *backlightSuite) TestConfigureBacklightServiceMaskIntegration(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	s.systemctlArgs = nil
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
@@ -61,9 +57,6 @@ func (s *backlightSuite) TestConfigureBacklightServiceMaskIntegration(c *C) {
 }
 
 func (s *backlightSuite) TestConfigureBacklightServiceUnmaskIntegration(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	s.systemctlArgs = nil
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,

--- a/overlord/configstate/configcore/backlight_test.go
+++ b/overlord/configstate/configcore/backlight_test.go
@@ -48,7 +48,7 @@ func (s *backlightSuite) TestConfigureBacklightServiceMaskIntegration(c *C) {
 	defer restore()
 
 	s.systemctlArgs = nil
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"system.disable-backlight-service": true,
@@ -65,7 +65,7 @@ func (s *backlightSuite) TestConfigureBacklightServiceUnmaskIntegration(c *C) {
 	defer restore()
 
 	s.systemctlArgs = nil
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"system.disable-backlight-service": false,

--- a/overlord/configstate/configcore/certs_test.go
+++ b/overlord/configstate/configcore/certs_test.go
@@ -36,7 +36,7 @@ type certsSuite struct {
 var _ = Suite(&certsSuite{})
 
 func (s *certsSuite) TestConfigureCertsUnhappyName(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"store-certs.cert-illegal-!": "xxx",
@@ -73,7 +73,7 @@ jVaMaA==
 `
 
 func (s *certsSuite) TestConfigureCertsHappy(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"store-certs.cert1": mockCert,
@@ -85,7 +85,7 @@ func (s *certsSuite) TestConfigureCertsHappy(c *C) {
 
 func (s *certsSuite) TestConfigureCertsSimulteRevert(c *C) {
 	// do a normal "snap set"
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"store-certs.cert1": mockCert,
@@ -94,7 +94,7 @@ func (s *certsSuite) TestConfigureCertsSimulteRevert(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(filepath.Join(dirs.SnapdStoreSSLCertsDir, "cert1.pem"), testutil.FilePresent)
 	// and one more with a new cert that will be reverted
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"store-certs.cert1": mockCert,
@@ -110,7 +110,7 @@ func (s *certsSuite) TestConfigureCertsSimulteRevert(c *C) {
 	// now simulate a "snap revert core" where "cert1" will stay in
 	// the state but "cert-that-will-be-reverted" is part of the config
 	// of the reverted core
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"store-certs.cert1": mockCert,
@@ -127,7 +127,7 @@ jVaMaA==
 `
 
 func (s *certsSuite) TestConfigureCertsFailsToParse(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"store-certs.cert1": certThatFailsToParse,
@@ -137,7 +137,7 @@ func (s *certsSuite) TestConfigureCertsFailsToParse(c *C) {
 }
 
 func (s *certsSuite) TestConfigureCertsUnhappyContent(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"store-certs.cert-bad": "xxx",

--- a/overlord/configstate/configcore/cloud_test.go
+++ b/overlord/configstate/configcore/cloud_test.go
@@ -166,7 +166,7 @@ func (s *cloudSuite) TestHandleCloud(c *C) {
 		tr := &mockConf{
 			state: s.state,
 		}
-		err := configcore.Run(tr)
+		err := configcore.Run(classicDev, tr)
 		c.Assert(err, IsNil)
 
 		var cloudInfo auth.CloudInfo
@@ -200,7 +200,7 @@ func (s *cloudSuite) TestHandleCloudAlreadySeeded(c *C) {
 	tr := &mockConf{
 		state: s.state,
 	}
-	err = configcore.Run(tr)
+	err = configcore.Run(classicDev, tr)
 	c.Assert(err, IsNil)
 
 	var cloudInfo auth.CloudInfo

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -187,6 +187,17 @@ func (r *runCfgSuite) TestConfigureUnknownOption(c *C) {
 	c.Check(err, ErrorMatches, `cannot set "core.unknown.option": unsupported system option`)
 }
 
+type mockDev struct{}
+
+func (d mockDev) RunMode() bool    { return true }
+func (d mockDev) Classic() bool    { return false }
+func (d mockDev) Kernel() string   { return "pc-kernel" }
+func (d mockDev) HasModeenv() bool { return false }
+
+var (
+	coreDev = mockDev{}
+)
+
 // applyCfgSuite tests configcore.Apply()
 type applyCfgSuite struct {
 	tmpDir string
@@ -204,12 +215,12 @@ func (s *applyCfgSuite) TearDownTest(c *C) {
 }
 
 func (s *applyCfgSuite) TestEmptyRootDir(c *C) {
-	err := configcore.FilesystemOnlyApply("", nil, nil)
+	err := configcore.FilesystemOnlyApply(coreDev, "", nil)
 	c.Check(err, ErrorMatches, `internal error: root directory for configcore.FilesystemOnlyApply\(\) not set`)
 }
 
 func (s *applyCfgSuite) TestSmoke(c *C) {
-	c.Assert(configcore.FilesystemOnlyApply(s.tmpDir, map[string]interface{}{}, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, s.tmpDir, map[string]interface{}{}), IsNil)
 }
 
 func (s *applyCfgSuite) TestPlainCoreConfigGetErrorIfNotCore(c *C) {

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -168,7 +168,7 @@ func (s *configcoreSuite) SetUpTest(c *C) {
 	s.AddCleanup(restore)
 }
 
-// runCfgSuite tests configcore.Run()
+// runCfgSuite tests configcore.Run
 type runCfgSuite struct {
 	configcoreSuite
 }
@@ -183,19 +183,22 @@ func (r *runCfgSuite) TestConfigureUnknownOption(c *C) {
 		},
 	}
 
-	err := configcore.Run(conf)
+	err := configcore.Run(coreDev, conf)
 	c.Check(err, ErrorMatches, `cannot set "core.unknown.option": unsupported system option`)
 }
 
-type mockDev struct{}
+type mockDev struct {
+	classic bool
+}
 
 func (d mockDev) RunMode() bool    { return true }
-func (d mockDev) Classic() bool    { return false }
+func (d mockDev) Classic() bool    { return d.classic }
 func (d mockDev) Kernel() string   { return "pc-kernel" }
 func (d mockDev) HasModeenv() bool { return false }
 
 var (
-	coreDev = mockDev{}
+	coreDev    = mockDev{classic: false}
+	classicDev = mockDev{classic: true}
 )
 
 // applyCfgSuite tests configcore.Apply()

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -188,13 +188,24 @@ func (r *runCfgSuite) TestConfigureUnknownOption(c *C) {
 }
 
 type mockDev struct {
+	mode    string
 	classic bool
+	kernel  string
+	uc20    bool
 }
 
-func (d mockDev) RunMode() bool    { return true }
+func (d mockDev) RunMode() bool    { return d.mode == "" || d.mode == "run" }
 func (d mockDev) Classic() bool    { return d.classic }
-func (d mockDev) Kernel() string   { return "pc-kernel" }
-func (d mockDev) HasModeenv() bool { return false }
+func (d mockDev) HasModeenv() bool { return d.uc20 }
+func (d mockDev) Kernel() string {
+	if d.Classic() {
+		return ""
+	}
+	if d.kernel == "" {
+		return "pc-kernel"
+	}
+	return d.kernel
+}
 
 var (
 	coreDev    = mockDev{classic: false}

--- a/overlord/configstate/configcore/early_test.go
+++ b/overlord/configstate/configcore/early_test.go
@@ -39,7 +39,7 @@ func (s *earlySuite) TestEarly(c *C) {
 		"services.ssh.disable":            true,
 	}
 	tr := &mockConf{state: s.state}
-	err := configcore.Early(tr, patch)
+	err := configcore.Early(coreDev, tr, patch)
 	c.Assert(err, IsNil)
 
 	// only early options as described by flags earlyConfigFilters

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 )
 
 func init() {
@@ -56,7 +57,7 @@ func validateExperimentalSettings(tr config.ConfGetter) error {
 	return nil
 }
 
-func doExportExperimentalFlags(tr config.ConfGetter, opts *fsOnlyContext) error {
+func doExportExperimentalFlags(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	var dir string
 	if opts != nil {
 		dir = dirs.FeaturesDirUnder(opts.RootDir)
@@ -85,5 +86,5 @@ func doExportExperimentalFlags(tr config.ConfGetter, opts *fsOnlyContext) error 
 }
 
 func ExportExperimentalFlags(tr config.ConfGetter) error {
-	return doExportExperimentalFlags(tr, nil)
+	return doExportExperimentalFlags(nil, tr, nil)
 }

--- a/overlord/configstate/configcore/experimental_test.go
+++ b/overlord/configstate/configcore/experimental_test.go
@@ -47,7 +47,7 @@ func (s *experimentalSuite) TestConfigureExperimentalSettingsInvalid(c *C) {
 			state:   s.state,
 			changes: map[string]interface{}{featureConf(feature): "foo"},
 		}
-		err := configcore.Run(conf)
+		err := configcore.Run(classicDev, conf)
 		c.Check(err, ErrorMatches, fmt.Sprintf(`%s can only be set to 'true' or 'false'`, featureConf(feature)))
 	}
 }
@@ -59,7 +59,7 @@ func (s *experimentalSuite) TestConfigureExperimentalSettingsHappy(c *C) {
 				state: s.state,
 				conf:  map[string]interface{}{featureConf(feature): t},
 			}
-			err := configcore.Run(conf)
+			err := configcore.Run(classicDev, conf)
 			c.Check(err, IsNil)
 		}
 	}
@@ -70,12 +70,12 @@ func (s *experimentalSuite) TestExportedFeatures(c *C) {
 		state: s.state,
 		conf:  map[string]interface{}{featureConf(features.PerUserMountNamespace): true},
 	}
-	err := configcore.Run(conf)
+	err := configcore.Run(classicDev, conf)
 	c.Assert(err, IsNil)
 	c.Check(features.PerUserMountNamespace.ControlFile(), testutil.FilePresent)
 
 	delete(conf.changes, "experimental.per-user-mount-namespace")
-	err = configcore.Run(conf)
+	err = configcore.Run(classicDev, conf)
 	c.Assert(err, IsNil)
 	c.Check(features.PerUserMountNamespace.ControlFile(), testutil.FilePresent)
 }
@@ -85,7 +85,7 @@ func (s *experimentalSuite) TestFilesystemOnlyApply(c *C) {
 		"experimental.refresh-app-awareness": "true",
 	})
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(classicDev, tmpDir, conf), IsNil)
 	c.Check(osutil.FileExists(filepath.Join(tmpDir, "/var/lib/snapd/features/refresh-app-awareness")), Equals, true)
 }
 
@@ -94,5 +94,5 @@ func (s *experimentalSuite) TestFilesystemOnlyApplyValidationFails(c *C) {
 		"experimental.refresh-app-awareness": 1,
 	})
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), ErrorMatches, `experimental.refresh-app-awareness can only be set to 'true' or 'false'`)
+	c.Assert(configcore.FilesystemOnlyApply(classicDev, tmpDir, conf), ErrorMatches, `experimental.refresh-app-awareness can only be set to 'true' or 'false'`)
 }

--- a/overlord/configstate/configcore/experimental_test.go
+++ b/overlord/configstate/configcore/experimental_test.go
@@ -85,7 +85,7 @@ func (s *experimentalSuite) TestFilesystemOnlyApply(c *C) {
 		"experimental.refresh-app-awareness": "true",
 	})
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 	c.Check(osutil.FileExists(filepath.Join(tmpDir, "/var/lib/snapd/features/refresh-app-awareness")), Equals, true)
 }
 
@@ -94,5 +94,5 @@ func (s *experimentalSuite) TestFilesystemOnlyApplyValidationFails(c *C) {
 		"experimental.refresh-app-awareness": 1,
 	})
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), ErrorMatches, `experimental.refresh-app-awareness can only be set to 'true' or 'false'`)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), ErrorMatches, `experimental.refresh-app-awareness can only be set to 'true' or 'false'`)
 }

--- a/overlord/configstate/configcore/journal.go
+++ b/overlord/configstate/configcore/journal.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -42,7 +43,7 @@ func validateJournalSettings(tr config.ConfGetter) error {
 	return validateBoolFlag(tr, "journal.persistent")
 }
 
-func handleJournalConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handleJournalConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	output, err := coreCfg(tr, "journal.persistent")
 	if err != nil {
 		return nil

--- a/overlord/configstate/configcore/journal_test.go
+++ b/overlord/configstate/configcore/journal_test.go
@@ -192,7 +192,7 @@ func (s *journalSuite) TestFilesystemOnlyApply(c *C) {
 		"journal.persistent": "true",
 	})
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 	c.Check(s.systemctlArgs, HasLen, 0)
 
 	exists, _, err := osutil.DirExists(filepath.Join(tmpDir, "/var/log/journal"))

--- a/overlord/configstate/configcore/journal_test.go
+++ b/overlord/configstate/configcore/journal_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -79,9 +78,6 @@ func (s *journalSuite) TestConfigurePersistentJournalInvalid(c *C) {
 }
 
 func (s *journalSuite) TestConfigurePersistentJournalOnCore(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{"journal.persistent": "true"},
@@ -100,9 +96,6 @@ func (s *journalSuite) TestConfigurePersistentJournalOnCore(c *C) {
 }
 
 func (s *journalSuite) TestConfigurePersistentJournalOldSystemd(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	s.systemdVersion = "235"
 
 	err := configcore.Run(coreDev, &mockConf{
@@ -122,9 +115,6 @@ func (s *journalSuite) TestConfigurePersistentJournalOldSystemd(c *C) {
 }
 
 func (s *journalSuite) TestConfigurePersistentJournalOnCoreNoopIfExists(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// existing journal directory, not created by snapd (no marker file)
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/var/log/journal"), 0755), IsNil)
 
@@ -146,9 +136,6 @@ func (s *journalSuite) TestConfigurePersistentJournalOnCoreNoopIfExists(c *C) {
 }
 
 func (s *journalSuite) TestDisablePersistentJournalNotManagedBySnapdError(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// journal directory exists, but no marker file
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/var/log/journal"), 0755), IsNil)
 
@@ -162,9 +149,6 @@ func (s *journalSuite) TestDisablePersistentJournalNotManagedBySnapdError(c *C) 
 }
 
 func (s *journalSuite) TestDisablePersistentJournalOnCore(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/var/log/journal"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/log/journal/.snapd-created"), nil, 0755), IsNil)
 
@@ -185,9 +169,6 @@ func (s *journalSuite) TestDisablePersistentJournalOnCore(c *C) {
 }
 
 func (s *journalSuite) TestFilesystemOnlyApply(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	conf := configcore.PlainCoreConfig(map[string]interface{}{
 		"journal.persistent": "true",
 	})

--- a/overlord/configstate/configcore/journal_test.go
+++ b/overlord/configstate/configcore/journal_test.go
@@ -71,7 +71,7 @@ func (s *journalSuite) SetUpTest(c *C) {
 }
 
 func (s *journalSuite) TestConfigurePersistentJournalInvalid(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{"journal.persistent": "foo"},
 	})
@@ -82,7 +82,7 @@ func (s *journalSuite) TestConfigurePersistentJournalOnCore(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{"journal.persistent": "true"},
 	})
@@ -105,7 +105,7 @@ func (s *journalSuite) TestConfigurePersistentJournalOldSystemd(c *C) {
 
 	s.systemdVersion = "235"
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{"journal.persistent": "true"},
 	})
@@ -128,7 +128,7 @@ func (s *journalSuite) TestConfigurePersistentJournalOnCoreNoopIfExists(c *C) {
 	// existing journal directory, not created by snapd (no marker file)
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/var/log/journal"), 0755), IsNil)
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{"journal.persistent": "true"},
 	})
@@ -152,7 +152,7 @@ func (s *journalSuite) TestDisablePersistentJournalNotManagedBySnapdError(c *C) 
 	// journal directory exists, but no marker file
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/var/log/journal"), 0755), IsNil)
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{"journal.persistent": "false"},
 	})
@@ -168,7 +168,7 @@ func (s *journalSuite) TestDisablePersistentJournalOnCore(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/var/log/journal"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/log/journal/.snapd-created"), nil, 0755), IsNil)
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{"journal.persistent": "false"},
 	})

--- a/overlord/configstate/configcore/network.go
+++ b/overlord/configstate/configcore/network.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 )
 
 func init() {
@@ -39,7 +40,7 @@ func validateNetworkSettings(tr config.ConfGetter) error {
 	return validateBoolFlag(tr, "network.disable-ipv6")
 }
 
-func handleNetworkConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handleNetworkConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	root := dirs.GlobalRootDir
 	if opts != nil {
 		root = opts.RootDir

--- a/overlord/configstate/configcore/network_test.go
+++ b/overlord/configstate/configcore/network_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -43,7 +42,6 @@ var _ = Suite(&networkSuite{})
 
 func (s *networkSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
-	s.AddCleanup(release.MockOnClassic(false))
 
 	s.mockSysctl = testutil.MockCommand(c, "sysctl", "")
 	s.AddCleanup(s.mockSysctl.Restore)

--- a/overlord/configstate/configcore/network_test.go
+++ b/overlord/configstate/configcore/network_test.go
@@ -114,7 +114,7 @@ func (s *networkSuite) TestFilesystemOnlyApply(c *C) {
 
 	tmpDir := c.MkDir()
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "/etc/sysctl.d/"), 0755), IsNil)
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 
 	networkSysctlPath := filepath.Join(tmpDir, "/etc/sysctl.d/10-snapd-network.conf")
 	c.Check(networkSysctlPath, testutil.FileEquals, "net.ipv6.conf.all.disable_ipv6=1\n")
@@ -129,5 +129,5 @@ func (s *networkSuite) TestFilesystemOnlyApplyValidationFails(c *C) {
 	})
 
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), ErrorMatches, `network.disable-ipv6 can only be set to 'true' or 'false'`)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), ErrorMatches, `network.disable-ipv6 can only be set to 'true' or 'false'`)
 }

--- a/overlord/configstate/configcore/network_test.go
+++ b/overlord/configstate/configcore/network_test.go
@@ -54,7 +54,7 @@ func (s *networkSuite) SetUpTest(c *C) {
 
 func (s *networkSuite) TestConfigureNetworkIntegrationIPv6(c *C) {
 	// disable ipv6
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"network.disable-ipv6": true,
@@ -69,7 +69,7 @@ func (s *networkSuite) TestConfigureNetworkIntegrationIPv6(c *C) {
 	s.mockSysctl.ForgetCalls()
 
 	// enable it again
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"network.disable-ipv6": false,
@@ -84,7 +84,7 @@ func (s *networkSuite) TestConfigureNetworkIntegrationIPv6(c *C) {
 	s.mockSysctl.ForgetCalls()
 
 	// enable it yet again, this does not trigger another syscall
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"network.disable-ipv6": false,
@@ -95,7 +95,7 @@ func (s *networkSuite) TestConfigureNetworkIntegrationIPv6(c *C) {
 }
 
 func (s *networkSuite) TestConfigureNetworkIntegrationNoSetting(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{},
 	})

--- a/overlord/configstate/configcore/picfg.go
+++ b/overlord/configstate/configcore/picfg.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 )
 
 // valid pi config keys
@@ -118,7 +119,7 @@ func piConfigFile(opts *fsOnlyContext) (string, error) {
 	return filepath.Join(rootDir, subdir, "config.txt"), nil
 }
 
-func handlePiConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handlePiConfiguration(dev sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	configFile, err := piConfigFile(opts)
 	if err != nil && err != errPiConfigNotSupported {
 		return err

--- a/overlord/configstate/configcore/picfg.go
+++ b/overlord/configstate/configcore/picfg.go
@@ -96,21 +96,19 @@ var (
 	errPiConfigNotSupported = fmt.Errorf("configuring pi-config not supported in current mode")
 )
 
-func piConfigFile(opts *fsOnlyContext) (string, error) {
+func piConfigFile(dev sysconfig.Device, opts *fsOnlyContext) (string, error) {
 	rootDir := dirs.GlobalRootDir
 	subdir := "/boot/uboot"
 	if opts != nil {
 		rootDir = opts.RootDir
-	} else {
+	} else if dev.HasModeenv() {
 		// not a filesystem only apply, so we may be operating on a run system
 		// on UC20, in which case we shouldn't use the /boot/uboot/ option and
 		// instead should use /run/mnt/ubuntu-seed/
-		mode, _, _ := boot.ModeAndRecoverySystemFromKernelCommandLine()
-		switch mode {
-		case boot.ModeRun:
+		if dev.RunMode() {
 			rootDir = boot.InitramfsUbuntuSeedDir
 			subdir = ""
-		case boot.ModeInstall, boot.ModeRecover:
+		} else {
 			// we don't support configuring pi-config in these modes as it is
 			// unclear what the right behavior is
 			return "", errPiConfigNotSupported
@@ -120,7 +118,7 @@ func piConfigFile(opts *fsOnlyContext) (string, error) {
 }
 
 func handlePiConfiguration(dev sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
-	configFile, err := piConfigFile(opts)
+	configFile, err := piConfigFile(dev, opts)
 	if err != nil && err != errPiConfigNotSupported {
 		return err
 	}

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -264,7 +264,7 @@ func (s *piCfgSuite) TestFilesystemOnlyApply(c *C) {
 	piCfg := filepath.Join(tmpDir, "/boot/uboot/config.txt")
 	c.Assert(ioutil.WriteFile(piCfg, []byte(mockConfigTxt), 0644), IsNil)
 
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 
 	expected := strings.Replace(mockConfigTxt, "#gpu_mem_512=true", "gpu_mem_512=true", -1)
 	c.Check(piCfg, testutil.FileEquals, expected)

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -131,7 +131,7 @@ func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"pi-config.disable-overscan": 1,
@@ -142,7 +142,7 @@ func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
 	expected := strings.Replace(mockConfigTxt, "#disable_overscan=1", "disable_overscan=1", -1)
 	s.checkMockConfig(c, expected)
 
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"pi-config.disable-overscan": "",
@@ -157,7 +157,7 @@ func (s *piCfgSuite) TestConfigurePiConfigRegression(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"pi-config.gpu-mem-512": true,
@@ -195,7 +195,7 @@ func (s *piCfgSuite) TestUpdateConfigUC20RunMode(c *C) {
 	c.Assert(err, IsNil)
 
 	// apply the config
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"pi-config.gpu-mem-512": true,
@@ -232,7 +232,7 @@ func (s *piCfgSuite) testUpdateConfigUC20NonRunMode(c *C, mode string) {
 	c.Assert(err, IsNil)
 
 	// apply the config
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"pi-config.gpu-mem-512": true,

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -128,9 +127,6 @@ func (s *piCfgSuite) TestConfigurePiConfigNoChangeSet(c *C) {
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
@@ -154,9 +150,6 @@ func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigRegression(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
@@ -169,14 +162,11 @@ func (s *piCfgSuite) TestConfigurePiConfigRegression(c *C) {
 }
 
 func (s *piCfgSuite) TestUpdateConfigUC20RunMode(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// mock the device as uc20 run mode
 	mockCmdline := filepath.Join(dirs.GlobalRootDir, "cmdline")
 	err := ioutil.WriteFile(mockCmdline, []byte("snapd_recovery_mode=run"), 0644)
 	c.Assert(err, IsNil)
-	restore = osutil.MockProcCmdline(mockCmdline)
+	restore := osutil.MockProcCmdline(mockCmdline)
 	defer restore()
 
 	// write default config at both the uc18 style runtime location and uc20 run
@@ -213,14 +203,11 @@ func (s *piCfgSuite) TestUpdateConfigUC20RunMode(c *C) {
 }
 
 func (s *piCfgSuite) testUpdateConfigUC20NonRunMode(c *C, mode string) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// mock the device as the specified uc20 mode
 	mockCmdline := filepath.Join(dirs.GlobalRootDir, "cmdline")
 	err := ioutil.WriteFile(mockCmdline, []byte("snapd_recovery_mode="+mode), 0644)
 	c.Assert(err, IsNil)
-	restore = osutil.MockProcCmdline(mockCmdline)
+	restore := osutil.MockProcCmdline(mockCmdline)
 	defer restore()
 
 	piCfg := filepath.Join(boot.InitramfsUbuntuSeedDir, "config.txt")

--- a/overlord/configstate/configcore/powerbtn.go
+++ b/overlord/configstate/configcore/powerbtn.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 )
 
 func init() {
@@ -71,7 +72,7 @@ HandlePowerKey=%s
 	return osutil.AtomicWriteFile(powerBtnCfg(opts), []byte(content), 0644, 0)
 }
 
-func handlePowerButtonConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handlePowerButtonConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	output, err := coreCfg(tr, "system.power-key-action")
 	if err != nil {
 		return err

--- a/overlord/configstate/configcore/powerbtn_test.go
+++ b/overlord/configstate/configcore/powerbtn_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -53,9 +52,6 @@ func (s *powerbtnSuite) TestConfigurePowerButtonInvalid(c *C) {
 }
 
 func (s *powerbtnSuite) TestConfigurePowerIntegration(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	for _, action := range []string{"ignore", "poweroff", "reboot", "halt", "kexec", "suspend", "hibernate", "hybrid-sleep", "lock"} {
 
 		err := configcore.Run(coreDev, &mockConf{

--- a/overlord/configstate/configcore/powerbtn_test.go
+++ b/overlord/configstate/configcore/powerbtn_test.go
@@ -78,7 +78,7 @@ func (s *powerbtnSuite) TestFilesystemOnlyApply(c *C) {
 		"system.power-key-action": "reboot",
 	})
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 
 	powerBtnCfg := filepath.Join(tmpDir, "/etc/systemd/logind.conf.d/00-snap-core.conf")
 	c.Check(powerBtnCfg, testutil.FileEquals, "[Login]\nHandlePowerKey=reboot\n")

--- a/overlord/configstate/configcore/powerbtn_test.go
+++ b/overlord/configstate/configcore/powerbtn_test.go
@@ -58,7 +58,7 @@ func (s *powerbtnSuite) TestConfigurePowerIntegration(c *C) {
 
 	for _, action := range []string{"ignore", "poweroff", "reboot", "halt", "kexec", "suspend", "hibernate", "hybrid-sleep", "lock"} {
 
-		err := configcore.Run(&mockConf{
+		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				"system.power-key-action": action,

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -80,9 +79,6 @@ PATH="/usr/bin"
 }
 
 func (s *proxySuite) TestConfigureProxyUnhappy(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	dirs.SetRootDir(c.MkDir())
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
@@ -94,9 +90,6 @@ func (s *proxySuite) TestConfigureProxyUnhappy(c *C) {
 }
 
 func (s *proxySuite) TestConfigureProxy(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	for _, proto := range []string{"http", "https", "ftp"} {
 		// populate with content
 		s.makeMockEtcEnvironment(c)
@@ -116,9 +109,6 @@ PATH="/usr/bin"
 }
 
 func (s *proxySuite) TestConfigureNoProxy(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// populate with content
 	s.makeMockEtcEnvironment(c)
 	err := configcore.Run(coreDev, &mockConf{

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -84,7 +84,7 @@ func (s *proxySuite) TestConfigureProxyUnhappy(c *C) {
 	defer restore()
 
 	dirs.SetRootDir(c.MkDir())
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"proxy.http": "http://example.com",
@@ -101,7 +101,7 @@ func (s *proxySuite) TestConfigureProxy(c *C) {
 		// populate with content
 		s.makeMockEtcEnvironment(c)
 
-		err := configcore.Run(&mockConf{
+		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				fmt.Sprintf("proxy.%s", proto): fmt.Sprintf("%s://example.com", proto),
@@ -121,7 +121,7 @@ func (s *proxySuite) TestConfigureNoProxy(c *C) {
 
 	// populate with content
 	s.makeMockEtcEnvironment(c)
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"proxy.no-proxy": "example.com,bar.com",
@@ -136,7 +136,7 @@ no_proxy=example.com,bar.com`)
 
 func (s *proxySuite) TestConfigureProxyStore(c *C) {
 	// set to ""
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"proxy.store": "",
@@ -152,7 +152,7 @@ func (s *proxySuite) TestConfigureProxyStore(c *C) {
 		},
 	}
 
-	err = configcore.Run(conf)
+	err = configcore.Run(classicDev, conf)
 	c.Check(err, ErrorMatches, `cannot set proxy.store to "foo" without a matching store assertion`)
 
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
@@ -170,7 +170,7 @@ func (s *proxySuite) TestConfigureProxyStore(c *C) {
 		assertstatetest.AddMany(s.state, operatorAcct, stoAs)
 	}()
 
-	err = configcore.Run(conf)
+	err = configcore.Run(classicDev, conf)
 	c.Check(err, IsNil)
 }
 
@@ -196,6 +196,6 @@ func (s *proxySuite) TestConfigureProxyStoreNoURL(c *C) {
 		assertstatetest.AddMany(s.state, operatorAcct, stoAs)
 	}()
 
-	err = configcore.Run(conf)
+	err = configcore.Run(coreDev, conf)
 	c.Check(err, ErrorMatches, `cannot set proxy.store to "foo" with a matching store assertion with url unset`)
 }

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -34,7 +34,7 @@ type refreshSuite struct {
 var _ = Suite(&refreshSuite{})
 
 func (s *refreshSuite) TestConfigureRefreshTimerHappy(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.timer": "8:00~12:00/2",
@@ -44,7 +44,7 @@ func (s *refreshSuite) TestConfigureRefreshTimerHappy(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureRefreshTimerRejected(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.timer": "invalid",
@@ -65,7 +65,7 @@ func (s *refreshSuite) TestConfigureRefreshTimerManagedIgnored(c *C) {
 		s.state.Lock()
 		s.state.OkayWarnings(time.Now())
 		s.state.Unlock()
-		err := configcore.Run(cfg)
+		err := configcore.Run(classicDev, cfg)
 		c.Assert(err, IsNil)
 
 		s.state.Lock()
@@ -86,7 +86,7 @@ func (s *refreshSuite) TestConfigureRefreshTimerManagedChangeError(c *C) {
 				opt: "managed",
 			},
 		}
-		err := configcore.Run(cfg)
+		err := configcore.Run(classicDev, cfg)
 		c.Assert(err, ErrorMatches, `cannot set schedule to managed`)
 		// old value still present
 		c.Check(cfg.conf[opt], Equals, "fri")
@@ -94,7 +94,7 @@ func (s *refreshSuite) TestConfigureRefreshTimerManagedChangeError(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureLegacyRefreshScheduleHappy(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.schedule": "8:00-12:00",
@@ -104,7 +104,7 @@ func (s *refreshSuite) TestConfigureLegacyRefreshScheduleHappy(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureLegacyRefreshScheduleRejected(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.schedule": "invalid",
@@ -113,7 +113,7 @@ func (s *refreshSuite) TestConfigureLegacyRefreshScheduleRejected(c *C) {
 	c.Assert(err, ErrorMatches, `cannot parse "invalid": not a valid interval`)
 
 	// check that refresh.schedule is verified against legacy parser
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.schedule": "8:00~12:00/2",
@@ -123,7 +123,7 @@ func (s *refreshSuite) TestConfigureLegacyRefreshScheduleRejected(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureRefreshHoldHappy(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.hold": "2018-08-18T15:00:00Z",
@@ -133,7 +133,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldHappy(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureRefreshHoldInvalid(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.hold": "invalid",
@@ -143,7 +143,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldInvalid(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredInvalid(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.metered": "invalid",
@@ -153,7 +153,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredInvalid(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredHappy(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.metered": "hold",
@@ -161,7 +161,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredHappy(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.metered": "",
@@ -171,7 +171,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredHappy(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureRefreshRetainHappy(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.retain": "4",
@@ -181,7 +181,7 @@ func (s *refreshSuite) TestConfigureRefreshRetainHappy(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureRefreshRetainUnderRange(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.retain": "1",
@@ -191,7 +191,7 @@ func (s *refreshSuite) TestConfigureRefreshRetainUnderRange(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureRefreshRetainOverRange(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.retain": "100",
@@ -201,7 +201,7 @@ func (s *refreshSuite) TestConfigureRefreshRetainOverRange(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureRefreshRetainInvalid(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.retain": "invalid",

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/overlord/configstate/config"
-	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/sysconfig"
 )
 
 func init() {
@@ -104,11 +104,11 @@ func addWithStateHandler(validate func(config.Conf) error, handle func(config.Co
 	handlers = append(handlers, h)
 }
 
-func Run(cfg config.Conf) error {
-	return applyHandlers(cfg, handlers)
+func Run(dev sysconfig.Device, cfg config.Conf) error {
+	return applyHandlers(dev, cfg, handlers)
 }
 
-func applyHandlers(cfg config.Conf, handlers []configHandler) error {
+func applyHandlers(dev sysconfig.Device, cfg config.Conf, handlers []configHandler) error {
 	// check if the changes
 	for _, k := range cfg.Changes() {
 		switch {
@@ -128,7 +128,7 @@ func applyHandlers(cfg config.Conf, handlers []configHandler) error {
 	}
 
 	for _, h := range handlers {
-		if h.flags().coreOnlyConfig && release.OnClassic {
+		if h.flags().coreOnlyConfig && dev.Classic() {
 			continue
 		}
 		if err := h.handle(cfg, nil); err != nil {
@@ -138,7 +138,7 @@ func applyHandlers(cfg config.Conf, handlers []configHandler) error {
 	return nil
 }
 
-func Early(cfg config.Conf, values map[string]interface{}) error {
+func Early(dev sysconfig.Device, cfg config.Conf, values map[string]interface{}) error {
 	early, relevant := applyFilters(func(f flags) filterFunc {
 		return f.earlyConfigFilter
 	}, values)
@@ -147,5 +147,5 @@ func Early(cfg config.Conf, values map[string]interface{}) error {
 		return err
 	}
 
-	return applyHandlers(cfg, relevant)
+	return applyHandlers(dev, cfg, relevant)
 }

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -72,7 +72,7 @@ func (h *withStateHandler) validate(cfg config.ConfGetter) error {
 	return nil
 }
 
-func (h *withStateHandler) handle(cfg config.ConfGetter, opts *fsOnlyContext) error {
+func (h *withStateHandler) handle(dev sysconfig.Device, cfg config.ConfGetter, opts *fsOnlyContext) error {
 	conf := cfg.(config.Conf)
 	if h.handleFunc != nil {
 		return h.handleFunc(conf, opts)
@@ -131,7 +131,7 @@ func applyHandlers(dev sysconfig.Device, cfg config.Conf, handlers []configHandl
 		if h.flags().coreOnlyConfig && dev.Classic() {
 			continue
 		}
-		if err := h.handle(cfg, nil); err != nil {
+		if err := h.handle(dev, cfg, nil); err != nil {
 			return err
 		}
 	}

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -200,7 +201,7 @@ func switchDisableService(serviceName string, disabled bool, opts *fsOnlyContext
 }
 
 // services that can be disabled
-func handleServiceDisableConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handleServiceDisableConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	for _, service := range services {
 		optionName := fmt.Sprintf("service.%s.disable", service.configName)
 		outputStr, err := coreCfg(tr, optionName)

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -111,6 +111,7 @@ func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName string, d
 		// XXX: instead of this hack we should look at the config
 		//      defaults and compare with the setting and exit if
 		//      they are the same but that requires some more changes.
+		// TODO: leverage sysconfig.Device instead
 		mode, _, _ := boot.ModeAndRecoverySystemFromKernelCommandLine()
 		if mode == boot.ModeInstall {
 			return nil

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -70,7 +70,7 @@ func (s *servicesSuite) TestConfigureServiceInvalidValue(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"service.ssh.disable": "xxx",
@@ -123,7 +123,7 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 	} {
 		s.systemctlArgs = nil
 		s.serviceInstalled = service.installed
-		err := configcore.Run(&mockConf{
+		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				fmt.Sprintf("service.%s.disable", service.cfgName): true,
@@ -200,7 +200,7 @@ func (s *servicesSuite) TestConfigureConsoleConfEnableNotAtRuntime(c *C) {
 	c.Assert(err, IsNil)
 
 	// now enable it
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"service.console-conf.disable": false,
@@ -217,7 +217,7 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableNotAtRuntime(c *C) {
 	// "/var/lib/console-conf/complete" file
 
 	// now try to enable it
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"service.console-conf.disable": true,
@@ -233,7 +233,7 @@ func (s *servicesSuite) TestConfigureConsoleConfEnableAlreadyEnabledIsFine(c *C)
 	// Note that we have no
 	//        /var/lib/console-conf/complete
 	// file. So console-conf is already enabled
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"service.console-conf.disable": false,
@@ -253,7 +253,7 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableAlreadyDisabledIsFine(c *
 	err = ioutil.WriteFile(canary, nil, 0644)
 	c.Assert(err, IsNil)
 
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"service.console-conf.disable": true,
@@ -272,7 +272,7 @@ func (s *servicesSuite) TestConfigureConsoleConfEnableDuringInstallMode(c *C) {
 	restore = osutil.MockProcCmdline(mockProcCmdline)
 	defer restore()
 
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"service.console-conf.disable": true,
@@ -303,7 +303,7 @@ func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
 	} {
 		s.systemctlArgs = nil
 		s.serviceInstalled = service.installed
-		err := configcore.Run(&mockConf{
+		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				fmt.Sprintf("service.%s.disable", service.cfgName): false,
@@ -343,7 +343,7 @@ func (s *servicesSuite) TestConfigureServiceUnsupportedService(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"service.snapd.disable": true,

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -67,9 +66,6 @@ func (s *servicesSuite) SetUpTest(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureServiceInvalidValue(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
@@ -103,9 +99,6 @@ func (s *servicesSuite) TestConfigureServiceDisabled(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/ssh"), 0755)
 	c.Assert(err, IsNil)
 
@@ -159,9 +152,6 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureConsoleConfDisableFSOnly(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	conf := configcore.PlainCoreConfig(map[string]interface{}{
 		"service.console-conf.disable": true,
 	})
@@ -174,9 +164,6 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableFSOnly(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureConsoleConfEnabledFSOnly(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	conf := configcore.PlainCoreConfig(map[string]interface{}{
 		"service.console-conf.disable": false,
 	})
@@ -189,9 +176,6 @@ func (s *servicesSuite) TestConfigureConsoleConfEnabledFSOnly(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureConsoleConfEnableNotAtRuntime(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// pretend that console-conf is disabled
 	canary := filepath.Join(dirs.GlobalRootDir, "/var/lib/console-conf/complete")
 	err := os.MkdirAll(filepath.Dir(canary), 0755)
@@ -210,9 +194,6 @@ func (s *servicesSuite) TestConfigureConsoleConfEnableNotAtRuntime(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureConsoleConfDisableNotAtRuntime(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// console-conf is not disabled, i.e. there is no
 	// "/var/lib/console-conf/complete" file
 
@@ -227,9 +208,6 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableNotAtRuntime(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureConsoleConfEnableAlreadyEnabledIsFine(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// Note that we have no
 	//        /var/lib/console-conf/complete
 	// file. So console-conf is already enabled
@@ -243,9 +221,6 @@ func (s *servicesSuite) TestConfigureConsoleConfEnableAlreadyEnabledIsFine(c *C)
 }
 
 func (s *servicesSuite) TestConfigureConsoleConfDisableAlreadyDisabledIsFine(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// pretend that console-conf is disabled
 	canary := filepath.Join(dirs.GlobalRootDir, "/var/lib/console-conf/complete")
 	err := os.MkdirAll(filepath.Dir(canary), 0755)
@@ -263,13 +238,10 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableAlreadyDisabledIsFine(c *
 }
 
 func (s *servicesSuite) TestConfigureConsoleConfEnableDuringInstallMode(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	mockProcCmdline := filepath.Join(c.MkDir(), "cmdline")
 	err := ioutil.WriteFile(mockProcCmdline, []byte("snapd_recovery_mode=install snapd_recovery_system=20201212\n"), 0644)
 	c.Assert(err, IsNil)
-	restore = osutil.MockProcCmdline(mockProcCmdline)
+	restore := osutil.MockProcCmdline(mockProcCmdline)
 	defer restore()
 
 	err = configcore.Run(coreDev, &mockConf{
@@ -283,9 +255,6 @@ func (s *servicesSuite) TestConfigureConsoleConfEnableDuringInstallMode(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/ssh"), 0755)
 	c.Assert(err, IsNil)
 
@@ -340,9 +309,6 @@ func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureServiceUnsupportedService(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -167,7 +167,7 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableFSOnly(c *C) {
 	})
 
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 
 	consoleConfDisabled := filepath.Join(tmpDir, "/var/lib/console-conf/complete")
 	c.Check(consoleConfDisabled, testutil.FileEquals, "console-conf has been disabled by the snapd system configuration\n")
@@ -182,7 +182,7 @@ func (s *servicesSuite) TestConfigureConsoleConfEnabledFSOnly(c *C) {
 	})
 
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 
 	consoleConfDisabled := filepath.Join(tmpDir, "/var/lib/console-conf/complete")
 	c.Check(consoleConfDisabled, testutil.FileAbsent)
@@ -364,7 +364,7 @@ func (s *servicesSuite) TestFilesystemOnlyApply(c *C) {
 		"service.ssh.disable":     "true",
 		"service.rsyslog.disable": "true",
 	})
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
 		{"--root", tmpDir, "mask", "rsyslog.service"},
 	})

--- a/overlord/configstate/configcore/snapshots_test.go
+++ b/overlord/configstate/configcore/snapshots_test.go
@@ -32,7 +32,7 @@ type snapshotsSuite struct {
 var _ = Suite(&snapshotsSuite{})
 
 func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsExpirationHappy(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"snapshots.automatic.retention": "40h",
@@ -42,7 +42,7 @@ func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsExpirationHappy(c *C) {
 }
 
 func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsExpirationTooLow(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"snapshots.automatic.retention": "10m",
@@ -52,7 +52,7 @@ func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsExpirationTooLow(c *C) {
 }
 
 func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsDisable(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"snapshots.automatic.retention": "no",
@@ -62,7 +62,7 @@ func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsDisable(c *C) {
 }
 
 func (s *refreshSuite) TestConfigureAutomaticSnapshotsExpirationInvalid(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"snapshots.automatic.retention": "invalid",

--- a/overlord/configstate/configcore/swap.go
+++ b/overlord/configstate/configcore/swap.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -75,7 +76,7 @@ func parseAndValidateSwapSize(szString string) (quantity.Size, error) {
 	return sz, nil
 }
 
-func handlesystemSwapConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handlesystemSwapConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	var pristineSwapSize, newSwapSize string
 	if err := tr.GetPristine("core", "swap.size", &pristineSwapSize); err != nil && !config.IsNoOption(err) {
 		return err

--- a/overlord/configstate/configcore/swap_test.go
+++ b/overlord/configstate/configcore/swap_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -55,9 +54,6 @@ func (s *swapCfgSuite) SetUpTest(c *C) {
 }
 
 func (s *swapCfgSuite) TestConfigureSwapSizeOnlyWhenChanged(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// set it to 1M initially
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
@@ -99,9 +95,6 @@ SIZE=1
 }
 
 func (s *swapCfgSuite) TestConfigureSwapSize(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// set it to 1M initially
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,

--- a/overlord/configstate/configcore/swap_test.go
+++ b/overlord/configstate/configcore/swap_test.go
@@ -59,7 +59,7 @@ func (s *swapCfgSuite) TestConfigureSwapSizeOnlyWhenChanged(c *C) {
 	defer restore()
 
 	// set it to 1M initially
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"swap.size": "1048576",
@@ -80,7 +80,7 @@ SIZE=1
 	s.systemctlArgs = nil
 
 	// running it with the same changes as conf results in no calls to systemd
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"swap.size": "1048576",
@@ -103,7 +103,7 @@ func (s *swapCfgSuite) TestConfigureSwapSize(c *C) {
 	defer restore()
 
 	// set it to 1M initially
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"swap.size": "1048576",
@@ -124,7 +124,7 @@ SIZE=1
 	s.systemctlArgs = nil
 
 	// now change it to empty
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"swap.size": "1048576",

--- a/overlord/configstate/configcore/swap_test.go
+++ b/overlord/configstate/configcore/swap_test.go
@@ -190,7 +190,7 @@ func (s *swapCfgSuite) TestSwapSizeNumberFormats(c *C) {
 			"swap.size": t.sizeStr,
 		})
 
-		err := configcore.FilesystemOnlyApply(dirs.GlobalRootDir, conf, nil)
+		err := configcore.FilesystemOnlyApply(coreDev, dirs.GlobalRootDir, conf)
 		if t.err != "" {
 			c.Assert(err, ErrorMatches, t.err)
 		} else {
@@ -211,7 +211,7 @@ func (s *swapCfgSuite) TestSwapSizeFilesystemOnlyApply(c *C) {
 	err := os.MkdirAll(filepath.Dir(s.configSwapFile), 0755)
 	c.Assert(err, IsNil)
 
-	c.Assert(configcore.FilesystemOnlyApply(dirs.GlobalRootDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, dirs.GlobalRootDir, conf), IsNil)
 
 	c.Check(s.configSwapFile, testutil.FileEquals, `FILE=/var/tmp/swapfile.swp
 SIZE=1024
@@ -232,7 +232,7 @@ func (s *swapCfgSuite) TestSwapSizeFilesystemOnlyApplyExistingConfig(c *C) {
 SIZE=0`), 0644)
 	c.Assert(err, IsNil)
 
-	err = configcore.FilesystemOnlyApply(dirs.GlobalRootDir, conf, nil)
+	err = configcore.FilesystemOnlyApply(coreDev, dirs.GlobalRootDir, conf)
 	c.Assert(err, IsNil)
 
 	c.Check(s.configSwapFile, testutil.FileEquals, `FILE=/var/tmp/other-swapfile.swp

--- a/overlord/configstate/configcore/sysctl.go
+++ b/overlord/configstate/configcore/sysctl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -62,7 +63,7 @@ func validateSysctlOptions(tr config.ConfGetter) error {
 	return nil
 }
 
-func handleSysctlConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handleSysctlConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	root := dirs.GlobalRootDir
 	if opts != nil {
 		root = opts.RootDir

--- a/overlord/configstate/configcore/sysctl_test.go
+++ b/overlord/configstate/configcore/sysctl_test.go
@@ -130,7 +130,7 @@ func (s *sysctlSuite) TestFilesystemOnlyApply(c *C) {
 	})
 
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 
 	networkSysctlPath := filepath.Join(tmpDir, "/etc/sysctl.d/99-snapd.conf")
 	c.Check(networkSysctlPath, testutil.FileEquals, "kernel.printk = 4 4 1 7\n")

--- a/overlord/configstate/configcore/sysctl_test.go
+++ b/overlord/configstate/configcore/sysctl_test.go
@@ -55,7 +55,7 @@ func (s *sysctlSuite) TearDownTest(c *C) {
 }
 
 func (s *sysctlSuite) TestConfigureSysctlIntegration(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"system.kernel.printk.console-loglevel": "2",
@@ -69,7 +69,7 @@ func (s *sysctlSuite) TestConfigureSysctlIntegration(c *C) {
 	s.systemdSysctlArgs = nil
 
 	// Unset console-loglevel and restore default vaule
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"system.kernel.printk.console-loglevel": "",
@@ -83,7 +83,7 @@ func (s *sysctlSuite) TestConfigureSysctlIntegration(c *C) {
 }
 
 func (s *sysctlSuite) TestConfigureLoglevelUnderRange(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"system.kernel.printk.console-loglevel": "-1",
@@ -94,7 +94,7 @@ func (s *sysctlSuite) TestConfigureLoglevelUnderRange(c *C) {
 }
 
 func (s *sysctlSuite) TestConfigureLoglevelOverRange(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"system.kernel.printk.console-loglevel": "8",
@@ -105,7 +105,7 @@ func (s *sysctlSuite) TestConfigureLoglevelOverRange(c *C) {
 }
 
 func (s *sysctlSuite) TestConfigureLevelRejected(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"system.kernel.printk.console-loglevel": "invalid",
@@ -116,7 +116,7 @@ func (s *sysctlSuite) TestConfigureLevelRejected(c *C) {
 }
 
 func (s *sysctlSuite) TestConfigureSysctlIntegrationNoSetting(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{},
 	})

--- a/overlord/configstate/configcore/sysctl_test.go
+++ b/overlord/configstate/configcore/sysctl_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -43,7 +42,6 @@ var _ = Suite(&sysctlSuite{})
 func (s *sysctlSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
-	s.AddCleanup(release.MockOnClassic(false))
 
 	s.mockSysctlConfPath = filepath.Join(dirs.GlobalRootDir, "/etc/sysctl.d/99-snapd.conf")
 	c.Assert(os.MkdirAll(filepath.Dir(s.mockSysctlConfPath), 0755), IsNil)

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 )
 
 func init() {
@@ -52,7 +53,7 @@ func validateTimezoneSettings(tr config.ConfGetter) error {
 	return nil
 }
 
-func handleTimezoneConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handleTimezoneConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	// TODO: convert to "virtual" configuration nodes once we have support
 	// for this. The current code is not ideal because if one calls
 	// `snap get system system.hostname` the answer can be ""

--- a/overlord/configstate/configcore/timezone_test.go
+++ b/overlord/configstate/configcore/timezone_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -61,9 +60,6 @@ func (s *timezoneSuite) TestConfigureTimezoneInvalid(c *C) {
 }
 
 func (s *timezoneSuite) TestConfigureTimezoneIntegration(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	mockedTimedatectl := testutil.MockCommand(c, "timedatectl", "")
 	defer mockedTimedatectl.Restore()
 

--- a/overlord/configstate/configcore/timezone_test.go
+++ b/overlord/configstate/configcore/timezone_test.go
@@ -93,7 +93,7 @@ func (s *timezoneSuite) TestFilesystemOnlyApply(c *C) {
 		"system.timezone": "Europe/Berlin",
 	})
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 
 	c.Check(filepath.Join(tmpDir, "/etc/writable/timezone"), testutil.FileEquals, "Europe/Berlin\n")
 	p, err := os.Readlink(filepath.Join(tmpDir, "/etc/writable/localtime"))

--- a/overlord/configstate/configcore/timezone_test.go
+++ b/overlord/configstate/configcore/timezone_test.go
@@ -50,7 +50,7 @@ func (s *timezoneSuite) TestConfigureTimezoneInvalid(c *C) {
 	}
 
 	for _, tz := range invalidTimezones {
-		err := configcore.Run(&mockConf{
+		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				"system.timezone": tz,
@@ -74,7 +74,7 @@ func (s *timezoneSuite) TestConfigureTimezoneIntegration(c *C) {
 	}
 
 	for _, tz := range validTimezones {
-		err := configcore.Run(&mockConf{
+		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				"system.timezone": tz,

--- a/overlord/configstate/configcore/users_test.go
+++ b/overlord/configstate/configcore/users_test.go
@@ -36,7 +36,7 @@ func (s *usersSuite) TestUsersCreateAutomaticEarly(c *C) {
 		"users.create.automatic": "false",
 	}
 	tr := &mockConf{state: s.state}
-	err := configcore.Early(tr, patch)
+	err := configcore.Early(classicDev, tr, patch)
 	c.Assert(err, IsNil)
 
 	c.Check(tr.conf, DeepEquals, map[string]interface{}{
@@ -45,7 +45,7 @@ func (s *usersSuite) TestUsersCreateAutomaticEarly(c *C) {
 }
 
 func (s *usersSuite) TestUsersCreateAutomaticInvalid(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{"users.create.automatic": "foo"},
 	})
@@ -69,7 +69,7 @@ func (s *usersSuite) TestUsersCreateAutomaticConfigure(c *C) {
 			conf:  map[string]interface{}{"users.create.automatic": t.value},
 		}
 
-		err := configcore.Run(conf)
+		err := configcore.Run(classicDev, conf)
 		c.Assert(err, IsNil)
 
 		c.Check(conf.conf["users.create.automatic"], Equals, t.expected)

--- a/overlord/configstate/configcore/vitality.go
+++ b/overlord/configstate/configcore/vitality.go
@@ -110,6 +110,7 @@ func handleVitalityConfiguration(tr config.Conf, opts *fsOnlyContext) error {
 
 		// first get the device context to decide if we need to set
 		// RequireMountedSnapdSnap
+		// TODO: use sysconfig.Device instead
 		deviceCtx, err := snapstate.DeviceCtx(st, nil, nil)
 		if err != nil {
 			return err

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -68,7 +68,7 @@ func (s *vitalitySuite) SetUpTest(c *C) {
 }
 
 func (s *vitalitySuite) TestConfigureVitalityUnhappyName(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"resilience.vitality-hint": "-invalid-snap-name!yf",
@@ -78,7 +78,7 @@ func (s *vitalitySuite) TestConfigureVitalityUnhappyName(c *C) {
 }
 
 func (s *vitalitySuite) TestConfigureVitalityNoSnapd(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"resilience.vitality-hint": "snapd",
@@ -88,7 +88,7 @@ func (s *vitalitySuite) TestConfigureVitalityNoSnapd(c *C) {
 }
 
 func (s *vitalitySuite) TestConfigureVitalityhappyName(c *C) {
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"resilience.vitality-hint": "valid-snapname",
@@ -139,7 +139,7 @@ func (s *vitalitySuite) testConfigureVitalityWithValidSnap(c *C, uc18 bool) {
 	})
 	s.state.Unlock()
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"resilience.vitality-hint": "unrelated,test-snap",
@@ -197,7 +197,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 
 	s.state.Unlock()
 
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"resilience.vitality-hint": "unrelated,test-snap",
@@ -222,7 +222,7 @@ func (s *vitalitySuite) TestConfigureVitalityHintTooMany(c *C) {
 		l[i] = strconv.Itoa(i)
 	}
 	manyStr := strings.Join(l, ",")
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"resilience.vitality-hint": manyStr,
@@ -246,7 +246,7 @@ func (s *vitalitySuite) TestConfigureVitalityManySnaps(c *C) {
 	}
 
 	// snap1,snap2,snap3
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"resilience.vitality-hint": "snap1,snap2,snap3",
@@ -277,7 +277,7 @@ func (s *vitalitySuite) TestConfigureVitalityManySnapsDelta(c *C) {
 	}
 
 	// snap1,snap2,snap3 switch to snap3,snap1
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"resilience.vitality-hint": "snap1,snap2,snap3",
@@ -312,7 +312,7 @@ func (s *vitalitySuite) TestConfigureVitalityManySnapsOneRemovedOneUnchanged(c *
 	}
 
 	// first run generates the snap1,snap2 configs
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"resilience.vitality-hint": "snap1,snap2",
@@ -328,7 +328,7 @@ func (s *vitalitySuite) TestConfigureVitalityManySnapsOneRemovedOneUnchanged(c *
 	s.systemctlArgs = nil
 
 	// now we change the configuration and set snap1,snap3
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"resilience.vitality-hint": "snap1,snap2",
@@ -368,7 +368,7 @@ func (s *vitalitySuite) TestConfigureVitalityNotActiveSnap(c *C) {
 	})
 	s.state.Unlock()
 
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
 			"resilience.vitality-hint": "unrelated,test-snap",

--- a/overlord/configstate/configcore/watchdog.go
+++ b/overlord/configstate/configcore/watchdog.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -85,7 +86,7 @@ func updateWatchdogConfig(config map[string]uint, opts *fsOnlyContext) error {
 	return nil
 }
 
-func handleWatchdogConfiguration(tr config.ConfGetter, opts *fsOnlyContext) error {
+func handleWatchdogConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	config := map[string]uint{}
 
 	for _, key := range []string{"runtime-timeout", "shutdown-timeout"} {

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -55,7 +55,7 @@ func (s *watchdogSuite) TestConfigureWatchdog(c *C) {
 
 	for option, val := range map[string]string{"runtime-timeout": "10", "shutdown-timeout": "60"} {
 
-		err := configcore.Run(&mockConf{
+		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				fmt.Sprintf("watchdog.%s", option): val + "s",
@@ -91,7 +91,7 @@ func (s *watchdogSuite) TestConfigureWatchdogUnits(c *C) {
 	}
 
 	for _, tunit := range []timeUnit{{"s", 1}, {"m", 60}, {"h", 3600}} {
-		err := configcore.Run(&mockConf{
+		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				"watchdog.runtime-timeout":  fmt.Sprintf("%d", times[0]) + tunit.unit,
@@ -110,7 +110,7 @@ func (s *watchdogSuite) TestConfigureWatchdogAll(c *C) {
 	defer restore()
 
 	times := []int{10, 100}
-	err := configcore.Run(&mockConf{
+	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"watchdog.runtime-timeout":  fmt.Sprintf("%ds", times[0]),
@@ -136,7 +136,7 @@ func (s *watchdogSuite) TestConfigureWatchdogAllConfDirExistsAlready(c *C) {
 	defer restore()
 
 	times := []int{10, 100}
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"watchdog.runtime-timeout":  fmt.Sprintf("%ds", times[0]),
@@ -164,7 +164,7 @@ func (s *watchdogSuite) TestConfigureWatchdogBadFormat(c *C) {
 	for _, badVal := range []badValErr{{"BAD", ".*invalid duration.*"},
 		{"-5s", ".*negative duration.*"},
 		{"34k", ".*unknown unit.*"}} {
-		err := configcore.Run(&mockConf{
+		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				"watchdog.runtime-timeout": badVal.val,
@@ -197,7 +197,7 @@ func (s *watchdogSuite) TestConfigureWatchdogNoFileUpdate(c *C) {
 	// To make sure the times will defer if the file is newly written
 	time.Sleep(100 * time.Millisecond)
 
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"watchdog.runtime-timeout":  fmt.Sprintf("%ds", times[0]),
@@ -232,7 +232,7 @@ ShutdownWatchdogSec=20
 	err = ioutil.WriteFile(s.mockEtcEnvironment, []byte(content), 0644)
 	c.Assert(err, IsNil)
 
-	err = configcore.Run(&mockConf{
+	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"watchdog.runtime-timeout":  0,

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -258,7 +258,7 @@ func (s *watchdogSuite) TestFilesystemOnlyApply(c *C) {
 	})
 
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 
 	watchdogCfg := filepath.Join(tmpDir, "/etc/systemd/system.conf.d/10-snapd-watchdog.conf")
 	c.Check(watchdogCfg, testutil.FileEquals, "[Manager]\nRuntimeWatchdogSec=4\n")
@@ -270,5 +270,5 @@ func (s *watchdogSuite) TestFilesystemOnlyApplyValidationFails(c *C) {
 	})
 
 	tmpDir := c.MkDir()
-	c.Assert(configcore.FilesystemOnlyApply(tmpDir, conf, nil), ErrorMatches, `cannot parse "foo": time: invalid duration \"?foo\"?`)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), ErrorMatches, `cannot parse "foo": time: invalid duration \"?foo\"?`)
 }

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -50,9 +49,6 @@ func (s *watchdogSuite) SetUpTest(c *C) {
 }
 
 func (s *watchdogSuite) TestConfigureWatchdog(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	for option, val := range map[string]string{"runtime-timeout": "10", "shutdown-timeout": "60"} {
 
 		err := configcore.Run(coreDev, &mockConf{
@@ -81,9 +77,6 @@ func (s *watchdogSuite) TestConfigureWatchdog(c *C) {
 }
 
 func (s *watchdogSuite) TestConfigureWatchdogUnits(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	times := []int{56, 432}
 	type timeUnit struct {
 		unit  string
@@ -106,9 +99,6 @@ func (s *watchdogSuite) TestConfigureWatchdogUnits(c *C) {
 }
 
 func (s *watchdogSuite) TestConfigureWatchdogAll(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	times := []int{10, 100}
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
@@ -132,9 +122,6 @@ func (s *watchdogSuite) TestConfigureWatchdogAllConfDirExistsAlready(c *C) {
 	err := os.MkdirAll(dirs.SnapSystemdConfDir, 0755)
 	c.Assert(err, IsNil)
 
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	times := []int{10, 100}
 	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
@@ -154,9 +141,6 @@ func (s *watchdogSuite) TestConfigureWatchdogAllConfDirExistsAlready(c *C) {
 }
 
 func (s *watchdogSuite) TestConfigureWatchdogBadFormat(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	type badValErr struct {
 		val string
 		err string
@@ -177,9 +161,6 @@ func (s *watchdogSuite) TestConfigureWatchdogBadFormat(c *C) {
 }
 
 func (s *watchdogSuite) TestConfigureWatchdogNoFileUpdate(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	err := os.MkdirAll(dirs.SnapSystemdConfDir, 0755)
 	c.Assert(err, IsNil)
 	times := []int{10, 100}
@@ -215,9 +196,6 @@ func (s *watchdogSuite) TestConfigureWatchdogNoFileUpdate(c *C) {
 }
 
 func (s *watchdogSuite) TestConfigureWatchdogRemovesIfEmpty(c *C) {
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	err := os.MkdirAll(dirs.SnapSystemdConfDir, 0755)
 	c.Assert(err, IsNil)
 	// add canary to ensure we don't touch other files

--- a/overlord/configstate/export_test.go
+++ b/overlord/configstate/export_test.go
@@ -21,6 +21,7 @@ package configstate
 
 import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/sysconfig"
 )
 
 var NewConfigureHandler = newConfigureHandler
@@ -33,7 +34,7 @@ func MockConfigcoreExportExperimentalFlags(mock func(tr config.ConfGetter) error
 	}
 }
 
-func MockConfigcoreEarly(mock func(cfg config.Conf, values map[string]interface{}) error) (restore func()) {
+func MockConfigcoreEarly(mock func(dev sysconfig.Device, cfg config.Conf, values map[string]interface{}) error) (restore func()) {
 	old := configcoreEarly
 	configcoreEarly = mock
 	return func() {

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -48,10 +48,7 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	}
 
 	devMgr := deviceMgr(st)
-	return &modelDeviceContext{groundDeviceContext{
-		model:      modelAs,
-		systemMode: devMgr.SystemMode(SysAny),
-	}}, nil
+	return newModelDeviceContext(devMgr, modelAs), nil
 }
 
 type groundDeviceContext struct {
@@ -106,6 +103,13 @@ var _ snapstate.DeviceContext = &groundDeviceContext{}
 
 type modelDeviceContext struct {
 	groundDeviceContext
+}
+
+func newModelDeviceContext(devMgr *DeviceManager, modelAs *asserts.Model) *modelDeviceContext {
+	return &modelDeviceContext{groundDeviceContext{
+		model:      modelAs,
+		systemMode: devMgr.SystemMode(SysAny),
+	}}
 }
 
 func (dc *modelDeviceContext) Store() snapstate.StoreService {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -659,10 +659,7 @@ func (m *DeviceManager) preloadGadget() (sysconfig.Device, *gadget.Info, error) 
 		return nil, nil, state.ErrNoState
 	}
 
-	dev := &modelDeviceContext{groundDeviceContext{
-		model:      model,
-		systemMode: m.SystemMode(SysAny),
-	}}
+	dev := newModelDeviceContext(m, model)
 	return dev, gi, nil
 }
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -66,7 +66,7 @@ var (
 
 // EarlyConfig is a hook set by configstate that can process early configuration
 // during managers' startup.
-var EarlyConfig func(st *state.State, preloadGadget func() (*gadget.Info, error)) error
+var EarlyConfig func(st *state.State, preloadGadget func() (sysconfig.Device, *gadget.Info, error)) error
 
 // DeviceManager is responsible for managing the device identity and device
 // policies.
@@ -590,11 +590,11 @@ func (m *DeviceManager) seedStart() (*timings.Timings, error) {
 	return perfTimings, nil
 }
 
-func (m *DeviceManager) preloadGadget() (*gadget.Info, error) {
+func (m *DeviceManager) preloadGadget() (sysconfig.Device, *gadget.Info, error) {
 	var sysLabel string
 	modeEnv, err := maybeReadModeenv()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if modeEnv != nil {
 		sysLabel = modeEnv.RecoverySystem
@@ -604,7 +604,7 @@ func (m *DeviceManager) preloadGadget() (*gadget.Info, error) {
 	// under --ensure=seed
 	tm, err := m.seedStart()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// cached for first ensureSeeded
 	m.seedTimings = tm
@@ -630,12 +630,12 @@ func (m *DeviceManager) preloadGadget() (*gadget.Info, error) {
 		if err != seed.ErrNoAssertions {
 			logger.Debugf("early import assertions from seed failed: %v", err)
 		}
-		return nil, state.ErrNoState
+		return nil, nil, state.ErrNoState
 	}
 	model := deviceSeed.Model()
 	if model.Gadget() == "" {
 		// no gadget
-		return nil, state.ErrNoState
+		return nil, nil, state.ErrNoState
 	}
 	var gi *gadget.Info
 	timings.Run(tm, "preload-verified-gadget-metadata", "preload verified gadget metadata from seed", func(nested timings.Measurer) {
@@ -656,9 +656,14 @@ func (m *DeviceManager) preloadGadget() (*gadget.Info, error) {
 	})
 	if err != nil {
 		logger.Noticef("preload verified gadget metadata from seed failed: %v", err)
-		return nil, state.ErrNoState
+		return nil, nil, state.ErrNoState
 	}
-	return gi, nil
+
+	dev := &modelDeviceContext{groundDeviceContext{
+		model:      model,
+		systemMode: m.SystemMode(SysAny),
+	}}
+	return dev, gi, nil
 }
 
 var populateStateFromSeed = populateStateFromSeedImpl

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -76,7 +76,8 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 
 	s.ConfigureTargetSystemOptsPassed = nil
 	s.ConfigureTargetSystemErr = nil
-	restore := devicestate.MockSysconfigConfigureTargetSystem(func(opts *sysconfig.Options) error {
+	restore := devicestate.MockSysconfigConfigureTargetSystem(func(mod *asserts.Model, opts *sysconfig.Options) error {
+		c.Check(mod, NotNil)
 		s.ConfigureTargetSystemOptsPassed = append(s.ConfigureTargetSystemOptsPassed, opts)
 		return s.ConfigureTargetSystemErr
 	})

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -200,7 +200,7 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	hookMgr, err := hookstate.Manager(s.state, s.o.TaskRunner())
 	c.Assert(err, IsNil)
 
-	devicestate.EarlyConfig = func(*state.State, func() (*gadget.Info, error)) error {
+	devicestate.EarlyConfig = func(*state.State, func() (sysconfig.Device, *gadget.Info, error)) error {
 		return nil
 	}
 	s.AddCleanup(func() { devicestate.EarlyConfig = nil })

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -121,7 +121,7 @@ func SetTimeOnce(m *DeviceManager, name string, t time.Time) error {
 	return m.setTimeOnce(name, t)
 }
 
-func PreloadGadget(m *DeviceManager) (*gadget.Info, error) {
+func PreloadGadget(m *DeviceManager) (sysconfig.Device, *gadget.Info, error) {
 	return m.preloadGadget()
 }
 

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -284,7 +284,7 @@ func MockHttputilNewHTTPClient(f func(opts *httputil.ClientOptions) *http.Client
 	}
 }
 
-func MockSysconfigConfigureTargetSystem(f func(opts *sysconfig.Options) error) (restore func()) {
+func MockSysconfigConfigureTargetSystem(f func(mod *asserts.Model, opts *sysconfig.Options) error) (restore func()) {
 	old := sysconfigConfigureTargetSystem
 	sysconfigConfigureTargetSystem = f
 	return func() {

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -128,7 +128,7 @@ func (t *firstBootBaseTest) startOverlord(c *C) {
 	ovld.InterfaceManager().DisableUDevMonitor()
 	// avoid gadget preload in the general tests cases
 	// it requires a proper seed to be available
-	devicestate.EarlyConfig = func(st *state.State, preloadGadget func() (*gadget.Info, error)) error {
+	devicestate.EarlyConfig = func(st *state.State, preloadGadget func() (sysconfig.Device, *gadget.Info, error)) error {
 		return nil
 	}
 	t.AddCleanup(func() { devicestate.EarlyConfig = nil })
@@ -228,7 +228,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoop(c *C) {
 	err := os.Remove(filepath.Join(dirs.SnapSeedDir, "assertions"))
 	c.Assert(err, IsNil)
 
-	_, err = devicestate.PreloadGadget(s.overlord.DeviceManager())
+	_, _, err = devicestate.PreloadGadget(s.overlord.DeviceManager())
 	c.Check(err, Equals, state.ErrNoState)
 
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, nil, s.perfTimings)
@@ -269,7 +269,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	_, err = devicestate.PreloadGadget(ovld.DeviceManager())
+	_, _, err = devicestate.PreloadGadget(ovld.DeviceManager())
 	c.Check(err, Equals, state.ErrNoState)
 
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, nil, s.perfTimings)
@@ -838,9 +838,13 @@ snaps:
 	st.Lock()
 	defer st.Unlock()
 
-	gi, err := devicestate.PreloadGadget(s.overlord.DeviceManager())
+	dev, gi, err := devicestate.PreloadGadget(s.overlord.DeviceManager())
 	c.Assert(err, IsNil)
 	c.Check(gi.Defaults, HasLen, 4)
+	c.Check(dev.RunMode(), Equals, true)
+	c.Check(dev.Classic(), Equals, false)
+	c.Check(dev.HasModeenv(), Equals, false)
+	c.Check(dev.Kernel(), Equals, "pc-kernel")
 
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, nil, s.perfTimings)
 	c.Assert(err, IsNil)
@@ -871,7 +875,7 @@ snaps:
 	defer rhk()
 
 	// ensure we have something that captures the core config
-	restore := configstate.MockConfigcoreRun(func(config.Conf) error {
+	restore := configstate.MockConfigcoreRun(func(sysconfig.Device, config.Conf) error {
 		configured = append(configured, "configcore")
 		return nil
 	})

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -252,7 +252,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	opts := &sysconfig.Options{TargetRootDir: boot.InstallHostWritableDir, GadgetDir: gadgetDir}
 	// configure cloud init
 	setSysconfigCloudOptions(opts, gadgetDir, model)
-	if err := sysconfigConfigureTargetSystem(opts); err != nil {
+	if err := sysconfigConfigureTargetSystem(model, opts); err != nil {
 		return err
 	}
 

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -99,7 +99,7 @@ func (s *sysconfigSuite) TestEphemeralModeInitramfsCloudInitDisables(c *C) {
 }
 
 func (s *sysconfigSuite) TestInstallModeCloudInitDisablesByDefaultRunMode(c *C) {
-	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(nil, &sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 	})
 	c.Assert(err, IsNil)
@@ -112,7 +112,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitDisallowedIgnoresOtherOptions(c
 	cloudCfgSrcDir := s.makeCloudCfgSrcDirFiles(c)
 	gadgetDir := s.makeGadgetCloudConfFile(c)
 
-	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(nil, &sysconfig.Options{
 		AllowCloudInit:  false,
 		CloudInitSrcDir: cloudCfgSrcDir,
 		GadgetDir:       gadgetDir,
@@ -133,7 +133,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitDisallowedIgnoresOtherOptions(c
 }
 
 func (s *sysconfigSuite) TestInstallModeCloudInitAllowedDoesNotDisable(c *C) {
-	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(nil, &sysconfig.Options{
 		AllowCloudInit: true,
 		TargetRootDir:  boot.InstallHostWritableDir,
 	})
@@ -150,7 +150,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitAllowedDoesNotDisable(c *C) {
 func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunMode(c *C) {
 	cloudCfgSrcDir := s.makeCloudCfgSrcDirFiles(c)
 
-	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(nil, &sysconfig.Options{
 		AllowCloudInit:  true,
 		CloudInitSrcDir: cloudCfgSrcDir,
 		TargetRootDir:   boot.InstallHostWritableDir,
@@ -165,7 +165,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunMode(c *C) {
 
 func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunModeWithGadgetCloudConf(c *C) {
 	gadgetDir := s.makeGadgetCloudConfFile(c)
-	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(nil, &sysconfig.Options{
 		AllowCloudInit: true,
 		GadgetDir:      gadgetDir,
 		TargetRootDir:  boot.InstallHostWritableDir,
@@ -181,7 +181,7 @@ func (s *sysconfigSuite) TestInstallModeCloudInitInstallsOntoHostRunModeWithGadg
 	cloudCfgSrcDir := s.makeCloudCfgSrcDirFiles(c)
 	gadgetDir := s.makeGadgetCloudConfFile(c)
 
-	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(nil, &sysconfig.Options{
 		AllowCloudInit:  true,
 		CloudInitSrcDir: cloudCfgSrcDir,
 		GadgetDir:       gadgetDir,

--- a/sysconfig/gadget_defaults_test.go
+++ b/sysconfig/gadget_defaults_test.go
@@ -24,6 +24,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/osutil"
 
@@ -41,6 +43,18 @@ volumes:
   pc:
     bootloader: grub
 `
+
+var fakeModel = assertstest.FakeAssertion(map[string]interface{}{
+	"type":         "model",
+	"authority-id": "my-brand",
+	"series":       "16",
+	"brand-id":     "my-brand",
+	"model":        "my-model",
+	"architecture": "amd64",
+	"base":         "core18",
+	"gadget":       "pc",
+	"kernel":       "pc-kernel",
+}).(*asserts.Model)
 
 func (s *sysconfigSuite) TestGadgetDefaults(c *C) {
 	const gadgetDefaultsYaml = `
@@ -75,7 +89,7 @@ defaults:
 	exists, _, _ := osutil.DirExists(journalPath)
 	c.Check(exists, Equals, false)
 
-	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(fakeModel, &sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 		GadgetDir:     snapInfo.MountDir(),
 	})
@@ -105,7 +119,7 @@ defaults:
 		{"meta/gadget.yaml", gadgetYaml + gadgetDefaultsYaml},
 	})
 
-	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(fakeModel, &sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 		GadgetDir:     snapInfo.MountDir(),
 	})
@@ -142,7 +156,7 @@ defaults:
 	exists, _, _ := osutil.DirExists(journalPath)
 	c.Check(exists, Equals, false)
 
-	err := sysconfig.ConfigureTargetSystem(&sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(fakeModel, &sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 		GadgetSnap:    snapContainer,
 	})

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -68,24 +68,26 @@ type Device interface {
 	//Model() *asserts.Model
 }
 
-type deviceInfo struct {
+type configedDevice struct {
 	model *asserts.Model
 }
 
-func (di *deviceInfo) RunMode() bool {
+func (di *configedDevice) RunMode() bool {
+	// the functions in sysconfig are used to configure not yet
+	// running systems.
 	return false
 }
 
-func (di *deviceInfo) Classic() bool {
-	return di.model.Classic()
+func (d *configedDevice) Classic() bool {
+	return d.model.Classic()
 }
 
-func (di *deviceInfo) Kernel() string {
-	return di.model.Kernel()
+func (d *configedDevice) Kernel() string {
+	return d.model.Kernel()
 }
 
-func (di *deviceInfo) HasModeenv() bool {
-	return di.model.Grade() != asserts.ModelGradeUnset
+func (d *configedDevice) HasModeenv() bool {
+	return d.model.Grade() != asserts.ModelGradeUnset
 }
 
 // ApplyFilesystemOnlyDefaultsImpl is initialized by init() of configcore.
@@ -99,7 +101,7 @@ var ApplyFilesystemOnlyDefaultsImpl = func(dev Device, rootDir string, defaults 
 // early during boot, before all the configuration is applied as part of
 // normal execution of configure hook.
 func ApplyFilesystemOnlyDefaults(model *asserts.Model, rootDir string, defaults map[string]interface{}) error {
-	dev := &deviceInfo{model: model}
+	dev := &configedDevice{model: model}
 	return ApplyFilesystemOnlyDefaultsImpl(dev, rootDir, defaults)
 }
 

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -22,6 +22,7 @@ package sysconfig
 import (
 	"path/filepath"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/snap"
 )
@@ -53,15 +54,42 @@ type Options struct {
 	GadgetSnap snap.Container
 }
 
-// FilesystemOnlyApplyOptions is the set of options for
-// ApplyFilesystemOnlyDefaults.
-type FilesystemOnlyApplyOptions struct {
-	// Classic is true when the system in rootdir is a classic system
-	Classic bool
+// Device carries information about the device model and mode that is
+// relevant to sysconfig.
+type Device interface {
+	RunMode() bool
+	Classic() bool
+
+	Kernel() string
+	//Base() string
+
+	HasModeenv() bool
+
+	//Model() *asserts.Model
+}
+
+type deviceInfo struct {
+	model *asserts.Model
+}
+
+func (di *deviceInfo) RunMode() bool {
+	return false
+}
+
+func (di *deviceInfo) Classic() bool {
+	return di.model.Classic()
+}
+
+func (di *deviceInfo) Kernel() string {
+	return di.model.Kernel()
+}
+
+func (di *deviceInfo) HasModeenv() bool {
+	return di.model.Grade() != asserts.ModelGradeUnset
 }
 
 // ApplyFilesystemOnlyDefaultsImpl is initialized by init() of configcore.
-var ApplyFilesystemOnlyDefaultsImpl = func(rootDir string, defaults map[string]interface{}, options *FilesystemOnlyApplyOptions) error {
+var ApplyFilesystemOnlyDefaultsImpl = func(dev Device, rootDir string, defaults map[string]interface{}) error {
 	panic("ApplyFilesystemOnlyDefaultsImpl is unset, import overlord/configstate/configcore")
 }
 
@@ -70,8 +98,9 @@ var ApplyFilesystemOnlyDefaultsImpl = func(rootDir string, defaults map[string]i
 // This is a subset of core config options that is important
 // early during boot, before all the configuration is applied as part of
 // normal execution of configure hook.
-func ApplyFilesystemOnlyDefaults(rootDir string, defaults map[string]interface{}, options *FilesystemOnlyApplyOptions) error {
-	return ApplyFilesystemOnlyDefaultsImpl(rootDir, defaults, options)
+func ApplyFilesystemOnlyDefaults(model *asserts.Model, rootDir string, defaults map[string]interface{}) error {
+	dev := &deviceInfo{model: model}
+	return ApplyFilesystemOnlyDefaultsImpl(dev, rootDir, defaults)
 }
 
 // ConfigureTargetSystem configures the ubuntu-data partition with
@@ -79,7 +108,7 @@ func ApplyFilesystemOnlyDefaults(rootDir string, defaults map[string]interface{}
 // cloud-init from the gadget).
 // It is okay to use both from install mode for run mode, as well as from the
 // initramfs for recover mode.
-func ConfigureTargetSystem(opts *Options) error {
+func ConfigureTargetSystem(model *asserts.Model, opts *Options) error {
 	if err := configureCloudInit(opts); err != nil {
 		return err
 	}
@@ -103,9 +132,7 @@ func ConfigureTargetSystem(opts *Options) error {
 	if gadgetInfo != nil {
 		defaults := gadget.SystemDefaults(gadgetInfo.Defaults)
 		if len(defaults) > 0 {
-			// options are nil which implies core system
-			var options *FilesystemOnlyApplyOptions
-			if err := ApplyFilesystemOnlyDefaults(WritableDefaultsDir(opts.TargetRootDir), defaults, options); err != nil {
+			if err := ApplyFilesystemOnlyDefaults(model, WritableDefaultsDir(opts.TargetRootDir), defaults); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This is similar to boot.Device.

Use this which is cleaner and delivers more information in the pi options code as well.

Leaves a couple of TODO about where this could also be leveraged as well.
