### PR TITLE
o/hookstate: return bool flag from Error function of hook handler to ignore hook errors

### DIFF
--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -129,6 +129,6 @@ func (h *configureHandler) Done() error {
 
 // Error is called by the HookManager after the configure hook has exited
 // non-zero, and includes the error.
-func (h *configureHandler) Error(err error) error {
-	return nil
+func (h *configureHandler) Error(err error) (bool, error) {
+	return false, nil
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -183,9 +183,9 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 
 type genericHook struct{}
 
-func (h genericHook) Before() error         { return nil }
-func (h genericHook) Done() error           { return nil }
-func (h genericHook) Error(err error) error { return nil }
+func (h genericHook) Before() error                 { return nil }
+func (h genericHook) Done() error                   { return nil }
+func (h genericHook) Error(err error) (bool, error) { return false, nil }
 
 func newBasicHookStateHandler(context *hookstate.Context) hookstate.Handler {
 	return genericHook{}
@@ -1783,8 +1783,8 @@ func (h fdeSetupHandler) Done() error {
 	return nil
 }
 
-func (h fdeSetupHandler) Error(err error) error {
-	return nil
+func (h fdeSetupHandler) Error(err error) (bool, error) {
+	return false, nil
 }
 
 // ResetToPostBootState is only useful for integration testing.

--- a/overlord/healthstate/healthstate.go
+++ b/overlord/healthstate/healthstate.go
@@ -145,8 +145,8 @@ func (h *healthHandler) Done() error {
 	return h.appendHealth(&health)
 }
 
-func (h *healthHandler) Error(err error) error {
-	return h.appendHealth(&HealthState{
+func (h *healthHandler) Error(err error) (bool, error) {
+	return false, h.appendHealth(&HealthState{
 		Revision:  h.context.SnapRevision(),
 		Timestamp: time.Now(),
 		Status:    UnknownStatus,

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -72,7 +72,7 @@ type Handler interface {
 	// Error is called if the hook encounters an error while running.
 	// The returned bool flag indicates if the original hook error should be
 	// ignored by hook manager.
-	Error(hookErr error) (ignoreHookError bool, err error)
+	Error(hookErr error) (ignoreHookErr bool, err error)
 }
 
 // HandlerGenerator is the function signature required to register for hooks.

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -70,7 +70,9 @@ type Handler interface {
 	Done() error
 
 	// Error is called if the hook encounters an error while running.
-	Error(err error) error
+	// The returned bool flag indicates if the original hook error should be
+	// ignored by hook manager.
+	Error(err error) (bool, error)
 }
 
 // HandlerGenerator is the function signature required to register for hooks.
@@ -399,8 +401,12 @@ func (m *HookManager) runHook(context *Context, snapst *snapstate.SnapState, hoo
 			context.Errorf("ignoring failure in hook %q: %v", hooksup.Hook, err)
 			context.Unlock()
 		} else {
-			if handlerErr := context.Handler().Error(err); handlerErr != nil {
+			ignoreOriginalErr, handlerErr := context.Handler().Error(err)
+			if handlerErr != nil {
 				return handlerErr
+			}
+			if ignoreOriginalErr {
+				return nil
 			}
 
 			return fmt.Errorf("run hook %q: %v", hooksup.Hook, err)

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -72,7 +72,7 @@ type Handler interface {
 	// Error is called if the hook encounters an error while running.
 	// The returned bool flag indicates if the original hook error should be
 	// ignored by hook manager.
-	Error(err error) (bool, error)
+	Error(hookErr error) (ignoreHookError bool, err error)
 }
 
 // HandlerGenerator is the function signature required to register for hooks.

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -104,8 +104,8 @@ func (h *snapHookHandler) Done() error {
 	return nil
 }
 
-func (h *snapHookHandler) Error(err error) error {
-	return nil
+func (h *snapHookHandler) Error(err error) (bool, error) {
+	return false, nil
 }
 
 func SetupRemoveHook(st *state.State, snapName string) *state.Task {

--- a/overlord/hookstate/hooktest/handler.go
+++ b/overlord/hookstate/hooktest/handler.go
@@ -73,7 +73,7 @@ func (h *MockHandler) Error(err error) (bool, error) {
 	h.Err = err
 	h.ErrorCalled = true
 	if h.ErrorError {
-		return h.IgnoreOriginalErr, fmt.Errorf("Error failed at user request")
+		return false, fmt.Errorf("Error failed at user request")
 	}
 	return h.IgnoreOriginalErr, nil
 }

--- a/overlord/hookstate/hooktest/handler.go
+++ b/overlord/hookstate/hooktest/handler.go
@@ -29,9 +29,10 @@ type MockHandler struct {
 	DoneCalled bool
 	DoneError  bool
 
-	ErrorCalled bool
-	ErrorError  bool
-	Err         error
+	ErrorCalled       bool
+	ErrorError        bool
+	IgnoreOriginalErr bool
+	Err               error
 
 	// callbacks useful for testing
 	BeforeCallback func()
@@ -68,11 +69,11 @@ func (h *MockHandler) Done() error {
 }
 
 // Error satisfies hookstate.Handler.Error
-func (h *MockHandler) Error(err error) error {
+func (h *MockHandler) Error(err error) (bool, error) {
 	h.Err = err
 	h.ErrorCalled = true
 	if h.ErrorError {
-		return fmt.Errorf("Error failed at user request")
+		return h.IgnoreOriginalErr, fmt.Errorf("Error failed at user request")
 	}
-	return nil
+	return h.IgnoreOriginalErr, nil
 }

--- a/overlord/hookstate/hooktest/handler_test.go
+++ b/overlord/hookstate/hooktest/handler_test.go
@@ -77,7 +77,9 @@ func (s *hooktestSuite) TestDoneError(c *C) {
 func (s *hooktestSuite) TestError(c *C) {
 	err := fmt.Errorf("test error")
 	c.Check(s.mockHandler.ErrorCalled, Equals, false)
-	c.Check(s.mockHandler.Error(err), IsNil)
+	ignore, herr := s.mockHandler.Error(err)
+	c.Check(ignore, Equals, false)
+	c.Check(herr, IsNil)
 	c.Check(s.mockHandler.ErrorCalled, Equals, true)
 	c.Check(s.mockHandler.Err, Equals, err)
 }
@@ -85,7 +87,19 @@ func (s *hooktestSuite) TestError(c *C) {
 func (s *hooktestSuite) TestErrorError(c *C) {
 	s.mockHandler.ErrorError = true
 	err := fmt.Errorf("test error")
-	c.Check(s.mockHandler.Error(err), NotNil)
+	ignore, herr := s.mockHandler.Error(err)
+	c.Check(ignore, Equals, false)
+	c.Check(herr, NotNil)
+	c.Check(s.mockHandler.ErrorCalled, Equals, true)
+	c.Check(s.mockHandler.Err, Equals, err)
+}
+
+func (s *hooktestSuite) TestIgnoreError(c *C) {
+	s.mockHandler.IgnoreOriginalErr = true
+	err := fmt.Errorf("test error")
+	ignore, herr := s.mockHandler.Error(err)
+	c.Check(ignore, Equals, true)
+	c.Check(herr, IsNil)
 	c.Check(s.mockHandler.ErrorCalled, Equals, true)
 	c.Check(s.mockHandler.Err, Equals, err)
 }

--- a/overlord/ifacestate/hooks.go
+++ b/overlord/ifacestate/hooks.go
@@ -37,8 +37,8 @@ func (h *interfaceHookHandler) Done() error {
 	return nil
 }
 
-func (h *interfaceHookHandler) Error(err error) error {
-	return nil
+func (h *interfaceHookHandler) Error(err error) (bool, error) {
+	return false, nil
 }
 
 // setupHooks sets hooks of InterfaceManager up


### PR DESCRIPTION
Return bool flag from Error() function of hook handler to indicate to the hook manager that hook task should not error out with 
the original hook error.

This is needed for gate-auto-refresh hook handler to handle errors and not fail the entire change.