### PR TITLE
overlord, o/devicestate: use a single test helper for resetting to a post boot state

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1218,6 +1218,14 @@ func (m *DeviceManager) Ensure() error {
 	return nil
 }
 
+// ResetToPostBootState is only useful for integration testing.
+func (m *DeviceManager) ResetToPostBootState() {
+	osutil.MustBeTestBinary("ResetToPostBootState can only be called from tests")
+	m.bootOkRan = false
+	m.bootRevisionsUpdated = false
+	m.ensureTriedRecoverySystemRan = false
+}
+
 var errNoSaveSupport = errors.New("no save directory before UC20")
 
 // withSaveDir invokes a function making sure save dir is available.
@@ -1772,12 +1780,4 @@ func (h fdeSetupHandler) Done() error {
 
 func (h fdeSetupHandler) Error(err error) error {
 	return nil
-}
-
-// ResetToPostBootState is only useful for integration testing.
-func (m *DeviceManager) ResetToPostBootState() {
-	osutil.MustBeTestBinary("ResetToPostBootState can only be called from tests")
-	m.bootOkRan = false
-	m.bootRevisionsUpdated = false
-	m.ensureTriedRecoverySystemRan = false
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -728,13 +728,6 @@ func (m *DeviceManager) ensureSeeded() error {
 	return nil
 }
 
-// ResetBootOk is only useful for integration testing
-func (m *DeviceManager) ResetBootOk() {
-	osutil.MustBeTestBinary("ResetBootOk can only be called from tests")
-	m.bootOkRan = false
-	m.bootRevisionsUpdated = false
-}
-
 func (m *DeviceManager) ensureBootOk() error {
 	m.state.Lock()
 	defer m.state.Unlock()
@@ -1110,12 +1103,6 @@ func (m *DeviceManager) appendTriedRecoverySystem(label string) error {
 	triedSystems = append(triedSystems, label)
 	m.state.Set("tried-systems", triedSystems)
 	return nil
-}
-
-// ResetTriedRecoverySystemsRan is only useful for integration testing
-func (m *DeviceManager) ResetTriedRecoverySystemsRan() {
-	osutil.MustBeTestBinary("ResetTriedRecoverySystemsRan can only be called from tests")
-	m.ensureTriedRecoverySystemRan = false
 }
 
 func (m *DeviceManager) ensureTriedRecoverySystem() error {
@@ -1789,6 +1776,8 @@ func (h fdeSetupHandler) Error(err error) error {
 
 // ResetToPostBootState is only useful for integration testing.
 func (m *DeviceManager) ResetToPostBootState() {
-	m.ResetBootOk()
-	m.ResetTriedRecoverySystemsRan()
+	osutil.MustBeTestBinary("ResetToPostBootState can only be called from tests")
+	m.bootOkRan = false
+	m.bootRevisionsUpdated = false
+	m.ensureTriedRecoverySystemRan = false
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1952,7 +1952,7 @@ func (s *baseMgrsSuite) mockSuccessfulReboot(c *C, be rebootEnv, which []snap.Ty
 	state.MockRestarting(st, state.RestartUnset)
 	err := be.SetTryingDuringReboot(which)
 	c.Assert(err, IsNil)
-	s.o.DeviceManager().ResetBootOk()
+	s.o.DeviceManager().ResetToPostBootState()
 	st.Unlock()
 	defer st.Lock()
 	err = s.o.DeviceManager().Ensure()
@@ -1967,7 +1967,7 @@ func (s *baseMgrsSuite) mockRollbackAcrossReboot(c *C, be rebootEnv, which []sna
 	state.MockRestarting(st, state.RestartUnset)
 	err := be.SetRollbackAcrossReboot(which)
 	c.Assert(err, IsNil)
-	s.o.DeviceManager().ResetBootOk()
+	s.o.DeviceManager().ResetToPostBootState()
 	st.Unlock()
 	s.o.Settle(settleTimeout)
 	st.Lock()
@@ -7253,7 +7253,7 @@ func (s *mgrsSuite) testGadgetKernelCommandLine(c *C, gadgetPath string, gadgetS
 		// reset bootstate, so that after-reboot command line is
 		// asserted
 		st.Unlock()
-		s.o.DeviceManager().ResetBootOk()
+		s.o.DeviceManager().ResetToPostBootState()
 		err = s.o.DeviceManager().Ensure()
 		st.Lock()
 		c.Assert(err, IsNil)


### PR DESCRIPTION
Followup to https://github.com/snapcore/snapd/pull/10361 I promised to @pedronis 