### PR TITLE
testutil: introduce a checker which compares the type after having passed them through a JSON marshaller

### DIFF
--- a/testutil/jsonchecker.go
+++ b/testutil/jsonchecker.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/check.v1"
+)
+
+type jsonEqualChecker struct {
+	*check.CheckerInfo
+}
+
+// JsonEquals compares the obtained and expected values after having serialized
+// them to JSON and deserialized to a generic interface{} type. This avoids
+// trouble comparing types with unexported fields that otherwise would be
+// problematic to set in external packages.
+var JsonEquals check.Checker = &jsonEqualChecker{
+	&check.CheckerInfo{Name: "JsonEqual", Params: []string{"obtained", "expected"}},
+}
+
+func (c *jsonEqualChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	toComparableMap := func(what interface{}) interface{} {
+		b, err := json.Marshal(what)
+		if err != nil {
+			panic("cannot marshal")
+		}
+		var back interface{}
+		if err := json.Unmarshal(b, &back); err != nil {
+			panic(fmt.Sprintf("cannot unmarshal from: %s", string(b)))
+		}
+		return back
+	}
+
+	obtained := toComparableMap(params[0])
+	ref := toComparableMap(params[1])
+
+	return check.DeepEquals.Check([]interface{}{obtained, ref}, names)
+}

--- a/testutil/jsonchecker_test.go
+++ b/testutil/jsonchecker_test.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil_test
+
+import (
+	"gopkg.in/check.v1"
+
+	. "github.com/snapcore/snapd/testutil"
+)
+
+type jsonCheckerSuite struct{}
+
+var _ = check.Suite(&jsonCheckerSuite{})
+
+func (*jsonCheckerSuite) TestFilePresent(c *check.C) {
+	testInfo(c, JsonEquals, "JsonEqual", []string{"obtained", "expected"})
+
+	type subRef struct {
+		Foo    string    `json:"foo"`
+		Baz    []float32 `json:"baz"`
+		hidden bool
+	}
+	type ref struct {
+		Number int      `json:"number"`
+		String string   `json:"string,omitempty"`
+		List   []string `json:"list"`
+		Map    *subRef  `json:"map,omitempty"`
+		hidden bool
+	}
+
+	testCheck(c, JsonEquals, true, "",
+		map[string]interface{}{
+			"number": 42,
+			"string": "foo",
+			"list":   []string{"123", "456"},
+			"map": map[string]interface{}{
+				"foo": "bar",
+				"baz": []interface{}{0.2, 0.3},
+			},
+		}, ref{
+			Number: 42,
+			String: "foo",
+			List:   []string{"123", "456"},
+			Map: &subRef{
+				Foo: "bar",
+				Baz: []float32{0.2, 0.3},
+				// this is transparent to the checker
+				hidden: true,
+			},
+			// this is transparent to the chekcker
+			hidden: true,
+		})
+	testCheck(c, JsonEquals, true, "",
+		map[string]interface{}{
+			"number": 42,
+			"string": "foo",
+			"list":   []interface{}(nil),
+		}, ref{
+			Number: 42,
+			String: "foo",
+		})
+	testCheck(c, JsonEquals, true, "",
+		map[string]interface{}{
+			"number": 42,
+			"list":   []interface{}(nil),
+		}, ref{
+			Number: 42,
+		})
+	testCheck(c, JsonEquals, false, "", 12, "12")
+	testCheck(c, JsonEquals, false, "Difference:\n...     [0]: 12 != 24\n", []int{12}, []int{24})
+	testCheck(c, JsonEquals, false, "Difference:\n...     [0]: string != float64\n", []string{"abc"}, []int{24})
+}


### PR DESCRIPTION
This is useful when comparing more complex structure from external packages,
when the structures may have unexported fields that would otherwise be picked up
by check.DeepEquals.

This becomes more useful when doing `c.Check(m, testutil.JsonEquals, &boot.Modeenv{ ... })`, which doesn't work with DeepEquals and moddenv that was read from the disk.