### PR TITLE
cmd/snap-update-ns: add SRCDIR to include search path

### DIFF
--- a/cmd/snap-update-ns/bootstrap.go
+++ b/cmd/snap-update-ns/bootstrap.go
@@ -23,6 +23,7 @@ package main
 // golang creates threads at will and setns(..., CLONE_NEWNS) fails if any
 // threads apart from the main thread exist.
 
+// #cgo CFLAGS: -I${SRCDIR}
 /*
 
 #include <stdlib.h>


### PR DESCRIPTION
With newer go (1.16) and some refactoring tools such as gorename, a rename or
refactor in the whole source tree may be invoked from an external directory. In
this case, the include search path does not necessarily include the package
source directory. Make sure that the path is included.

