### PR TITLE
o/servicestate: stop setting DoneStatus prematurely for quota-control

### DIFF
--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -26,10 +26,21 @@ import (
 )
 
 var (
-	UpdateSnapstateServices = updateSnapstateServices
-	CheckSystemdVersion     = checkSystemdVersion
+	UpdateSnapstateServices  = updateSnapstateServices
+	CheckSystemdVersion      = checkSystemdVersion
+	QuotaStateAlreadyUpdated = quotaStateAlreadyUpdated
 )
 
 func (m *ServiceManager) DoQuotaControl(t *state.Task, to *tomb.Tomb) error {
 	return m.doQuotaControl(t, to)
+}
+
+func MockOsutilBootID(mockID string) (restore func()) {
+	old := osutilBootID
+	osutilBootID = func() (string, error) {
+		return mockID, nil
+	}
+	return func() {
+		osutilBootID = old
+	}
 }

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -92,46 +93,139 @@ func (m *ServiceManager) doQuotaControl(t *state.Task, _ *tomb.Tomb) error {
 
 	qc := qcs[0]
 
-	allGrps, err := AllQuotas(st)
+	updated, appsToRestartBySnap, err := quotaStateAlreadyUpdated(t)
 	if err != nil {
 		return err
 	}
 
-	var grp *quota.Group
-	switch qc.Action {
-	case "create":
-		grp, allGrps, err = quotaCreate(st, qc, allGrps)
-	case "remove":
-		grp, allGrps, err = quotaRemove(st, qc, allGrps)
-	case "update":
-		grp, allGrps, err = quotaUpdate(st, qc, allGrps)
-	default:
-		return fmt.Errorf("unknown action %q requested", qc.Action)
+	if !updated {
+		allGrps, err := AllQuotas(st)
+		if err != nil {
+			return err
+		}
+
+		var grp *quota.Group
+		switch qc.Action {
+		case "create":
+			grp, allGrps, err = quotaCreate(st, qc, allGrps)
+		case "remove":
+			grp, allGrps, err = quotaRemove(st, qc, allGrps)
+		case "update":
+			grp, allGrps, err = quotaUpdate(st, qc, allGrps)
+		default:
+			return fmt.Errorf("unknown action %q requested", qc.Action)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		// ensure service and slices on disk and their states are updated
+		opts := &ensureSnapServicesForGroupOptions{
+			allGrps: allGrps,
+		}
+		appsToRestartBySnap, err = ensureSnapServicesForGroup(st, t, grp, opts)
+		if err != nil {
+			return err
+		}
+
+		// after we have made all the persistent modifications
+		// to disk and state, remember that so to avoid
+		// failing redoing the non-idempotent parts of the
+		// task if snapd gets restarted before the end of the task.
+		// What remains for this task handler is just to
+		// restart services which will happen regardless if we
+		// get rebooted after unlocking the state - if we got
+		// rebooted before unlocking the state, none of the
+		// changes we made to state would be persisted and we
+		// would run through everything above here again, but
+		// the second time around EnsureSnapServices would end
+		// up doing nothing since it is idempotent.  So in the
+		// rare case that snapd gets restarted but is not a
+		// reboot also remember which service do need
+		// restarting. There is a small chance that services
+		// will be restarted again but is preferable to the
+		// quota not applying to them.
+		if err := rememberQuotaStateUpdated(t, appsToRestartBySnap); err != nil {
+			return err
+		}
+
 	}
 
-	if err != nil {
+	if err := restartSnapServices(st, t, appsToRestartBySnap, perfTimings); err != nil {
 		return err
 	}
-
-	// ensure service and slices on disk and their states are updated
-	opts := &ensureSnapServicesForGroupOptions{
-		allGrps: allGrps,
-	}
-	appsToRestartBySnap, err := ensureSnapServicesForGroup(st, t, grp, opts)
-	if err != nil {
-		return err
-	}
-
-	// after we have made all the persistent modifications to disk and state,
-	// set the task as done, what remains for this task handler is just to
-	// restart services which will happen regardless if we get rebooted after
-	// unlocking the state - if we got rebooted before unlocking the state, none
-	// of the changes we made to state would be persisted and we would run
-	// through everything above here again, but the second time around
-	// EnsureSnapServices would end up doing nothing since it is idempotent.
 	t.SetStatus(state.DoneStatus)
+	return nil
+}
 
-	return restartSnapServices(st, t, appsToRestartBySnap, perfTimings)
+var osutilBootID = osutil.BootID
+
+type quotaStateUpdated struct {
+	BootID              string              `json:"boot-id"`
+	AppsToRestartBySnap map[string][]string `json:"apps-to-restart,omitempty"`
+}
+
+func rememberQuotaStateUpdated(t *state.Task, appsToRestartBySnap map[*snap.Info][]*snap.AppInfo) error {
+	bootID, err := osutilBootID()
+	if err != nil {
+		return err
+	}
+	forUpdated := make(map[string][]string, len(appsToRestartBySnap))
+	for info, apps := range appsToRestartBySnap {
+		appNames := make([]string, len(apps))
+		for i, app := range apps {
+			appNames[i] = app.Name
+		}
+		forUpdated[info.InstanceName()] = appNames
+	}
+	t.Set("state-updated", quotaStateUpdated{
+		BootID:              bootID,
+		AppsToRestartBySnap: forUpdated,
+	})
+	return nil
+}
+
+func quotaStateAlreadyUpdated(t *state.Task) (ok bool, appsToRestartBySnap map[*snap.Info][]*snap.AppInfo, err error) {
+	var updated quotaStateUpdated
+	if err := t.Get("state-updated", &updated); err != nil {
+		if err == state.ErrNoState {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+
+	bootID, err := osutilBootID()
+	if err != nil {
+		return false, nil, err
+	}
+	if bootID != updated.BootID {
+		// rebooted => nothing to restart
+		return true, nil, nil
+	}
+
+	appsToRestartBySnap = make(map[*snap.Info][]*snap.AppInfo, len(updated.AppsToRestartBySnap))
+	st := t.State()
+	// best effor, ignore missing things
+	for instanceName, appNames := range updated.AppsToRestartBySnap {
+		info, err := snapstate.CurrentInfo(st, instanceName)
+		if err != nil {
+			if _, ok := err.(*snap.NotInstalledError); ok {
+				continue
+			}
+			return false, nil, err
+		}
+		apps := make([]*snap.AppInfo, 0, len(appNames))
+		for _, appName := range appNames {
+			app := info.Apps[appName]
+			if app == nil || !app.IsService() {
+				continue
+			}
+			apps = append(apps, app)
+		}
+		appsToRestartBySnap[info] = apps
+	}
+	return true, appsToRestartBySnap, nil
 }
 
 func quotaCreate(st *state.State, action QuotaControlAction, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {


### PR DESCRIPTION
instead remember that the non-idempotent updates were done and which
snaps need restarting, so to behave correctly if there is a reboot
or (more unlikely) just a snapd restart

see changed comments for more details
