### PR TITLE
cmd/libsnap-confine-private: bump max depth of groups hierarchy to 32

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support-test.c
+++ b/cmd/libsnap-confine-private/cgroup-support-test.c
@@ -198,7 +198,7 @@ static void test_sc_cgroupv2_is_tracking_bad_nesting(cgroupv2_is_tracking_fixtur
     }
     g_test_trap_subprocess(NULL, 0, 0);
     g_test_trap_assert_failed();
-    g_test_trap_assert_stderr("cannot traverse cgroups hierarchy deeper than 20 levels\n");
+    g_test_trap_assert_stderr("cannot traverse cgroups hierarchy deeper than 32 levels\n");
 }
 
 static void test_sc_cgroupv2_is_tracking_dir_permissions(cgroupv2_is_tracking_fixture *fixture,

--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -99,7 +99,7 @@ bool sc_cgroup_is_v2(void) {
     return false;
 }
 
-static const size_t max_traversal_depth = 20;
+static const size_t max_traversal_depth = 32;
 
 static bool traverse_looking_for_prefix_in_dir(DIR *root, const char *prefix, const char *skip, size_t depth) {
     if (depth > max_traversal_depth) {


### PR DESCRIPTION
Bump the maximum depth of cgorups hierarchy tree to 32.

As requested in https://github.com/snapcore/snapd/pull/10436#discussion_r658613399
