### PR TITLE
store: make the log with download size a debug one

### DIFF
--- a/store/store_download.go
+++ b/store/store_download.go
@@ -479,7 +479,7 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 		if resp.ContentLength == 0 {
 			logger.Noticef("Unexpected Content-Length: 0 for %s", downloadURL)
 		} else {
-			logger.Noticef("Download size for %s: %d", downloadURL, resp.ContentLength)
+			logger.Debugf("Download size for %s: %d", downloadURL, resp.ContentLength)
 		}
 		pbar.Start(name, dlSize)
 		mw := io.MultiWriter(w, h, pbar, tc)


### PR DESCRIPTION
The log appears is visible in the user's terminal when running `snap download`
command.

Reported in the forum: https://forum.snapcraft.io/t/snap-download-slips-in-extra-logging-with-download-size/25151