### PR TITLE
cmd/snap-update-ns: Revert "cmd/snap-update-ns: add SRCDIR to include search path"

### DIFF
--- a/cmd/snap-update-ns/bootstrap.go
+++ b/cmd/snap-update-ns/bootstrap.go
@@ -23,7 +23,6 @@ package main
 // golang creates threads at will and setns(..., CLONE_NEWNS) fails if any
 // threads apart from the main thread exist.
 
-// #cgo CFLAGS: -I${SRCDIR}
 /*
 
 #include <stdlib.h>


### PR DESCRIPTION
This reverts commit 08c2e6da1b72cb4d21436f1ba1f1c15f66a83187.

The launchpad builds are failing like so:

```
(cd _build/bin && GOPATH=$(pwd)/.. GO111MODULE=off GOCACHE=/tmp/go-build go build --ldflags '-extldflags "-static"'  github.com/snapcore/snapd/cmd/snap-update-ns)
can't load package: package github.com/snapcore/snapd/cmd/snap-update-ns: /<<BUILDDIR>>/snapd-2.51.1+git3058.84b3a3c8~ubuntu16.04.1/_build/src/github.com/snapcore/snapd/cmd/snap-update-ns/bootstrap.go: malformed #cgo argument: -I/<<BUILDDIR>>/snapd-2.51.1+git3058.84b3a3c8~ubuntu16.04.1/_build/src/github.com/snapcore/snapd/cmd/snap-update-ns
debian/rules:167: recipe for target 'override_dh_auto_build' failed
make[1]: *** [override_dh_auto_build] Error 1
make[1]: Leaving directory '/<<BUILDDIR>>/snapd-2.51.1+git3058.84b3a3c8~ubuntu16.04.1'
```

Note that <<BUILDDIR>> is expected to be an artifact of LP log filtering. It is
unclear whether such value could have been passed as -pkgdir. However, all
characters shoudl be part of the safe characters set:
https://github.com/golang/go/blob/fd129a6b0e6041da048b845e966be94bd718b9aa/src/go/build/build.go#L1759


