### PR TITLE
o/ifacestate: do not visit same halt tasks in waitChainSearch to avoid cycles

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -977,16 +977,21 @@ func inSameChangeWaitChain(startT, searchT *state.Task) bool {
 	if startT.Change() != searchT.Change() {
 		return false
 	}
+	seen := make(map[string]bool)
 	// Do a recursive check if its in the same change
-	return waitChainSearch(startT, searchT)
+	return waitChainSearch(startT, searchT, seen)
 }
 
-func waitChainSearch(startT, searchT *state.Task) bool {
+func waitChainSearch(startT, searchT *state.Task, seen map[string]bool) bool {
+	if seen[startT.ID()] {
+		return false
+	}
+	seen[startT.ID()] = true
 	for _, cand := range startT.HaltTasks() {
 		if cand == searchT {
 			return true
 		}
-		if waitChainSearch(cand, searchT) {
+		if waitChainSearch(cand, searchT, seen) {
 			return true
 		}
 	}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -977,21 +977,21 @@ func inSameChangeWaitChain(startT, searchT *state.Task) bool {
 	if startT.Change() != searchT.Change() {
 		return false
 	}
-	seen := make(map[string]bool)
+	seenTasks := make(map[string]bool)
 	// Do a recursive check if its in the same change
-	return waitChainSearch(startT, searchT, seen)
+	return waitChainSearch(startT, searchT, seenTasks)
 }
 
-func waitChainSearch(startT, searchT *state.Task, seen map[string]bool) bool {
-	if seen[startT.ID()] {
+func waitChainSearch(startT, searchT *state.Task, seenTasks map[string]bool) bool {
+	if seenTasks[startT.ID()] {
 		return false
 	}
-	seen[startT.ID()] = true
+	seenTasks[startT.ID()] = true
 	for _, cand := range startT.HaltTasks() {
 		if cand == searchT {
 			return true
 		}
-		if waitChainSearch(cand, searchT, seen) {
+		if waitChainSearch(cand, searchT, seenTasks) {
 			return true
 		}
 	}

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -70,6 +70,8 @@ func (s *handlersSuite) TestInSameChangeWaitChainWithCycles(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
+	// cycles like this are unexpected in practice but are easier to test than
+	// the exponential paths situation that e.g. seed changes present.
 	startT := st.NewTask("start", "...start")
 	task1 := st.NewTask("task1", "...")
 	task1.WaitFor(startT)

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -64,3 +64,23 @@ func (s *handlersSuite) TestInSameChangeWaitChainDifferentChanges(c *C) {
 	t2.WaitFor(t1)
 	c.Check(ifacestate.InSameChangeWaitChain(t1, t2), Equals, false)
 }
+
+func (s *handlersSuite) TestInSameChangeWaitChainWithCycles(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	startT := st.NewTask("start", "...start")
+	task1 := st.NewTask("task1", "...")
+	task1.WaitFor(startT)
+	task2 := st.NewTask("task2", "...")
+	task2.WaitFor(task1)
+	task3 := st.NewTask("task3", "...")
+	task3.WaitFor(task2)
+
+	startT.WaitFor(task2)
+	startT.WaitFor(task3)
+
+	unrelated := st.NewTask("unrelated", "...")
+	c.Check(ifacestate.InSameChangeWaitChain(startT, unrelated), Equals, false)
+}


### PR DESCRIPTION
Following #10461, avoid visiting same halt task in waitChainSearch helper in ifacestate to avoid slow convergence where the wait graphs might have an exponential number of paths (or very unlikely cycles).