### PR TITLE
tests/lib/store.sh: fix make_snap_installable_with_id()

### DIFF
--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -82,8 +82,8 @@ EOF
 }
 EOF
 
-    fakestore new-snap-declaration --dir "$dir" --snap-decl-json=/tmp/snap-decl.json "$snap_path"
-    fakestore new-snap-revision --dir "$dir" --snap-rev-json=/tmp/snap-rev.json "$snap_path"
+    new_snap_declaration "$dir" "$snap_path" --snap-decl-json=/tmp/snap-decl.json
+    new_snap_revision "$dir" "$snap_path" --snap-rev-json=/tmp/snap-rev.json
 
     rm -rf /tmp/snap-decl.json
     rm -rf /tmp/snap-rev.json


### PR DESCRIPTION
The make_snap_installable_with_id() was not actually copying the snap
binary into the fake store archive, because that's a step performed by
the new_snap_declaration() function, which was not invoked here.

By using that function we ensure that the snap binaries are made
available to the store. It also automatically acks the assertions.

For consistency, we also use new_snap_revision(), which apart from the
extra "ack" on the assertion is equivalent to the previous
implementation.

