### PR TITLE
o/servicestate: detect conflicts for quota group operations

### DIFF
--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -31,6 +31,8 @@ var (
 	QuotaStateAlreadyUpdated = quotaStateAlreadyUpdated
 )
 
+type QuotaStateUpdated = quotaStateUpdated
+
 func (m *ServiceManager) DoQuotaControl(t *state.Task, to *tomb.Tomb) error {
 	return m.doQuotaControl(t, to)
 }

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
@@ -90,7 +91,10 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 		return nil, err
 	}
 
-	// TODO: conflict checking for other changes with this quota group
+	// TODO: check quota conflict
+	if err := snapstate.CheckChangeConflictMany(st, snaps, ""); err != nil {
+		return nil, err
+	}
 
 	allGrps, err := AllQuotas(st)
 	if err != nil {
@@ -148,8 +152,6 @@ func RemoveQuota(st *state.State, name string) (*state.TaskSet, error) {
 		return nil, fmt.Errorf("removing quota groups not supported while preseeding")
 	}
 
-	// TODO: conflict checking for other changes with this quota group
-
 	allGrps, err := AllQuotas(st)
 	if err != nil {
 		return nil, err
@@ -164,6 +166,11 @@ func RemoveQuota(st *state.State, name string) (*state.TaskSet, error) {
 	// XXX: remove this limitation eventually
 	if len(grp.SubGroups) != 0 {
 		return nil, fmt.Errorf("cannot remove quota group with sub-groups, remove the sub-groups first")
+	}
+
+	// TODO: check quota conflict
+	if err := snapstate.CheckChangeConflictMany(st, grp.Snaps, ""); err != nil {
+		return nil, err
 	}
 
 	qc := QuotaControlAction{
@@ -203,7 +210,10 @@ func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) (*st
 		return nil, err
 	}
 
-	// TODO: conflict checking for other changes with this quota group
+	// TODO: check quota conflict
+	if err := snapstate.CheckChangeConflictMany(st, updateOpts.AddSnaps, ""); err != nil {
+		return nil, err
+	}
 
 	allGrps, err := AllQuotas(st)
 	if err != nil {

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -666,7 +666,7 @@ func (s *quotaControlSuite) TestRemoveQuotaSnapOpConflict(c *C) {
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	ts, err = snapstate.Disable(st, "test-snap")
+	_, err = snapstate.Disable(st, "test-snap")
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "quota-control" change in progress`)
 }
 
@@ -705,6 +705,6 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 		},
 	})
 
-	ts, err = snapstate.Disable(st, "test-snap")
+	_, err = snapstate.Disable(st, "test-snap")
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "quota-control" change in progress`)
 }

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -333,7 +333,7 @@ func quotaRemove(st *state.State, action QuotaControlAction, allGrps map[string]
 	// make sure that the group set is consistent before saving it - we may need
 	// to delete old links from this group's parent to the child
 	if err := quota.ResolveCrossReferences(allGrps); err != nil {
-		return nil, nil, fmt.Errorf("cannot remove quota %q: %v", action.QuotaName, err)
+		return nil, nil, fmt.Errorf("cannot remove quota group %q: %v", action.QuotaName, err)
 	}
 
 	// now set it in state

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -60,6 +60,8 @@ func Manager(st *state.State, runner *state.TaskRunner) *ServiceManager {
 	// TODO: undo handler
 	runner.AddHandler("quota-control", m.doQuotaControl, nil)
 
+	snapstate.AddAffectedSnapsByKind("quota-control", quotaControlAffectedSnaps)
+
 	return m
 }
 


### PR DESCRIPTION
This is done for the involved snaps plugging into the snapstate mechanisms.

And for quota themselves introducing a new servicestate.CheckQuotaChangeConflictMany.

TODO: we need to surface the new error properly over the API.
