### PR TITLE
tests/main/interfaces-ssh-keys: tweak checks for openSUSE Tumbleweed

### DIFF
--- a/interfaces/builtin/ssh_keys.go
+++ b/interfaces/builtin/ssh_keys.go
@@ -29,6 +29,10 @@ const sshKeysBaseDeclarationSlots = `
     deny-auto-connection: true
 `
 
+// TODO: some distributions, namely openSUSE Tumbleweed with ssh 8.4p1, have
+// started moving the vendor ssh configuration to other locations not included,
+// eg. /usr/etc/ssh. The new location isn't made available inside the snap mount
+// namespace either.
 const sshKeysConnectedPlugAppArmor = `
 # Description: Can read ssh user configuration as well as public and private
 # keys.

--- a/tests/main/interfaces-ssh-keys/task.yaml
+++ b/tests/main/interfaces-ssh-keys/task.yaml
@@ -36,7 +36,14 @@ execute: |
     echo "And the snap is able to read public/private keys and ssh configuration files as well"
     test-snapd-sh.with-ssh-keys-plug -c "cat $TESTKEY"
     test-snapd-sh.with-ssh-keys-plug -c "cat $TESTKEY.pub"
-    test-snapd-sh.with-ssh-keys-plug -c "cat /etc/ssh/ssh_config"
+    if ! os.query is-opensuse-tumbleweed; then
+        test-snapd-sh.with-ssh-keys-plug -c "cat /etc/ssh/ssh_config"
+    else
+        # Tumbleweed: since updating to openssh 8.4p1, the vendor config files
+        # are at /usr/etc/ssh which is not accessible to snaps;
+        # make sure that is still the case
+        test -f /usr/etc/ssh/ssh_config
+    fi
     test-snapd-sh.with-ssh-keys-plug -c "cat /etc/ssh/ssh_config.d/test.conf"
 
     if [ "$(snap debug confinement)" = partial ] ; then


### PR DESCRIPTION
Since the 8.4p1 version of the openssh package, the vendor config files were
moved to /usr/etc/ssh.