### PR TITLE
o/snapstate: fix populating of affectedSnapInfo.AffectingSnaps for marking self as affecting

### DIFF
--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1271,12 +1271,12 @@ func (s *autorefreshGatingSuite) TestAutoRefreshPhase1(c *C) {
 	c.Check(hs.Hook, Equals, "gate-auto-refresh")
 	seenSnaps[hs.Snap] = true
 	switch hs.Snap {
-		case "snap-a":
-			task.Get("hook-context", &snapAhookData)
-		case "snap-b":
-			task.Get("hook-context", &snapBhookData)
-		default:
-			c.Fatalf("unexpected snap %q", hs.Snap)
+	case "snap-a":
+		task.Get("hook-context", &snapAhookData)
+	case "snap-b":
+		task.Get("hook-context", &snapBhookData)
+	default:
+		c.Fatalf("unexpected snap %q", hs.Snap)
 	}
 
 	c.Check(snapAhookData["affecting-snaps"], DeepEquals, []interface{}{"snap-a"})

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1978,8 +1978,13 @@ func autoRefreshPhase1(ctx context.Context, st *state.State) ([]string, []*state
 		if err != nil {
 			return nil, nil, err
 		}
-		if affectedSnaps[up.InstanceName()] == nil && inf.Hooks[gateAutoRefreshHookName] != nil {
-			affectedSnaps[up.InstanceName()] = &affectedSnapInfo{}
+		if inf.Hooks[gateAutoRefreshHookName] != nil {
+			if affectedSnaps[up.InstanceName()] == nil {
+				affectedSnaps[up.InstanceName()] = &affectedSnapInfo{
+					AffectingSnaps: make(map[string]bool),
+				}
+			}
+			affectedSnaps[up.InstanceName()].AffectingSnaps[up.InstanceName()] = true
 		}
 	}
 


### PR DESCRIPTION
The special case for populating affectedSnapInfo for the snap that gets refreshed and may want to control his own refresh (hold itself) wasn't correct and didn't fill affectingSnaps. As a result, the gate-auto-refresh hook of such snap didn't have affecting-snaps set correctly and --hold or --proceed wouldn't update hold state for itself.
