### PR TITLE
overlord/devicestate, overlord/assertstate: use a temporary DB when creating recovery systems

### DIFF
--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -479,15 +479,9 @@ func ValidationSetAssertionForMonitor(st *state.State, accountID, name string, s
 	return as, false, err
 }
 
-// TemporaryDBWithModel returns a temporary database stacked on top of the
-// assertions database, with the provided model added to it. This is useful
-// during remodel, when the new model is not added to the main database until
-// the very last stage of the process.
-func TemporaryDBWithModel(st *state.State, model *asserts.Model) (asserts.RODatabase, error) {
+// TemporaryDB returns a temporary database stacked on top of the assertions
+// database. Writing to it will not affect the assertions database.
+func TemporaryDB(st *state.State) *asserts.Database {
 	db := cachedDB(st)
-	temp := db.WithStackedBackstore(asserts.NewMemoryBackstore())
-	if err := temp.Add(model); err != nil {
-		return nil, err
-	}
-	return temp, nil
+	return db.WithStackedBackstore(asserts.NewMemoryBackstore())
 }

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -478,3 +478,16 @@ func ValidationSetAssertionForMonitor(st *state.State, accountID, name string, s
 	}
 	return as, false, err
 }
+
+// TemporaryDBWithModel returns a temporary database stacked on top of the
+// assertions database, with the provided model added to it. This is useful
+// during remodel, when the new model is not added to the main database until
+// the very last stage of the process.
+func TemporaryDBWithModel(st *state.State, model *asserts.Model) (asserts.RODatabase, error) {
+	db := cachedDB(st)
+	temp := db.WithStackedBackstore(asserts.NewMemoryBackstore())
+	if err := temp.Add(model); err != nil {
+		return nil, err
+	}
+	return temp, nil
+}

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -61,6 +61,7 @@ type deviceMgrSystemsBaseSuite struct {
 	logbuf            *bytes.Buffer
 	mockedSystemSeeds []mockedSystemSeed
 	ss                *seedtest.SeedSnaps
+	model             *asserts.Model
 }
 
 type deviceMgrSystemsSuite struct {
@@ -83,7 +84,7 @@ func (s *deviceMgrSystemsBaseSuite) SetUpTest(c *C) {
 		Brands:       s.brands,
 	}
 
-	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
 		"architecture": "amd64",
 		// UC20
 		"grade": "dangerous",
@@ -1188,7 +1189,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
 
-	validateCore20Seed(c, "1234", s.storeSigning.Trusted)
+	validateCore20Seed(c, "1234", s.model, s.storeSigning.Trusted)
 	m, err := s.bootloader.GetBootVars("try_recovery_system", "recovery_system_status")
 	c.Assert(err, IsNil)
 	c.Check(m, DeepEquals, map[string]string{
@@ -1341,7 +1342,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
 
-	validateCore20Seed(c, "1234", s.storeSigning.Trusted)
+	validateCore20Seed(c, "1234", newModel, s.storeSigning.Trusted, "foo", "bar")
 	m, err := s.bootloader.GetBootVars("try_recovery_system", "recovery_system_status")
 	c.Assert(err, IsNil)
 	c.Check(m, DeepEquals, map[string]string{
@@ -1533,7 +1534,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 		filepath.Join(boot.InitramfsUbuntuSeedDir, "snaps/some-snap_1.snap"),
 	})
 	// do more extensive validation
-	validateCore20Seed(c, "1234undo", s.storeSigning.Trusted)
+	validateCore20Seed(c, "1234undo", s.model, s.storeSigning.Trusted)
 	m, err := s.bootloader.GetBootVars("try_recovery_system", "recovery_system_status")
 	c.Assert(err, IsNil)
 	c.Check(m, DeepEquals, map[string]string{
@@ -1612,7 +1613,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
 
-	validateCore20Seed(c, "1234", s.storeSigning.Trusted)
+	validateCore20Seed(c, "1234", s.model, s.storeSigning.Trusted)
 	m, err := s.bootloader.GetBootVars("try_recovery_system", "recovery_system_status")
 	c.Assert(err, IsNil)
 	c.Check(m, DeepEquals, map[string]string{

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -209,10 +209,11 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 		// during remodel, the model assertion is not yet present in the
 		// database, hence we need to use a temporary one to which the
 		// assertion has been explicitly added
-		db, err = assertstate.TemporaryDBWithModel(st, model)
-		if err != nil {
+		tempDB := assertstate.TemporaryDB(st)
+		if err := tempDB.Add(model); err != nil {
 			return fmt.Errorf("cannot create a temporary database with model: %v", err)
 		}
+		db = tempDB
 	} else {
 		db = assertstate.DB(st)
 	}

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -204,7 +204,18 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 		return logNewSystemSnapFile(filepath.Join(recoverySystemDir, "snapd-new-file-log"), where)
 	}
 
-	db := assertstate.DB(st)
+	var db asserts.RODatabase
+	if isRemodel {
+		// during remodel, the model assertion is not yet present in the
+		// database, hence we need to use a temporary one to which the
+		// assertion has been explicitly added
+		db, err = assertstate.TemporaryDBWithModel(st, model)
+		if err != nil {
+			return fmt.Errorf("cannot create a temporary database with model: %v", err)
+		}
+	} else {
+		db = assertstate.DB(st)
+	}
 	defer func() {
 		if err == nil {
 			return

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -207,8 +207,10 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 	var db asserts.RODatabase
 	if isRemodel {
 		// during remodel, the model assertion is not yet present in the
-		// database, hence we need to use a temporary one to which the
-		// assertion has been explicitly added
+		// assertstate database, hence we need to use a temporary one to
+		// which we explicitly add the new model assertion, as
+		// createSystemForModelFromValidatedSnaps expects all relevant
+		// assertions to be present in the passed db
 		tempDB := assertstate.TemporaryDB(st)
 		if err := tempDB.Add(model); err != nil {
 			return fmt.Errorf("cannot create a temporary database with model: %v", err)

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -118,7 +118,7 @@ func (s *createSystemSuite) makeEssentialSnapInfos(c *C) map[string]*snap.Info {
 	return infos
 }
 
-func validateCore20Seed(c *C, name string, trusted []asserts.Assertion, runModeSnapNames ...string) {
+func validateCore20Seed(c *C, name string, expectedModel *asserts.Model, trusted []asserts.Assertion, runModeSnapNames ...string) {
 	const usesSnapd = true
 	sd := seedtest.ValidateSeed(c, boot.InitramfsUbuntuSeedDir, name, usesSnapd, trusted)
 
@@ -135,6 +135,8 @@ func validateCore20Seed(c *C, name string, trusted []asserts.Assertion, runModeS
 	} else {
 		c.Check(seenSnaps, HasLen, 0)
 	}
+
+	c.Assert(sd.Model(), DeepEquals, expectedModel)
 }
 
 func (s *createSystemSuite) TestCreateSystemFromAssertedSnaps(c *C) {
@@ -249,7 +251,7 @@ func (s *createSystemSuite) TestCreateSystemFromAssertedSnaps(c *C) {
 		"snapd_recovery_kernel":    "/snaps/pc-kernel_1.snap",
 	})
 	// load the seed
-	validateCore20Seed(c, "1234", s.storeSigning.Trusted,
+	validateCore20Seed(c, "1234", model, s.storeSigning.Trusted,
 		"other-core18", "core18", "other-present", "other-required")
 }
 
@@ -337,7 +339,7 @@ func (s *createSystemSuite) TestCreateSystemFromUnassertedSnaps(c *C) {
 		}
 	}
 	// load the seed
-	validateCore20Seed(c, "1234", s.storeSigning.Trusted, "other-unasserted")
+	validateCore20Seed(c, "1234", model, s.storeSigning.Trusted, "other-unasserted")
 	// we have unasserted snaps, so a warning should have been logged
 	c.Check(s.logbuf.String(), testutil.Contains, `system "1234" contains unasserted snaps "other-unasserted"`)
 }
@@ -420,7 +422,7 @@ func (s *createSystemSuite) TestCreateSystemWithSomeSnapsAlreadyExisting(c *C) {
 		"snapd_recovery_kernel":    "/snaps/pc-kernel_1.snap",
 	})
 	// load the seed
-	validateCore20Seed(c, "1234", s.storeSigning.Trusted)
+	validateCore20Seed(c, "1234", model, s.storeSigning.Trusted)
 
 	// add an unasserted snap
 	infos["other-unasserted"] = s.makeSnap(c, "other-unasserted", snap.R(-1))
@@ -730,7 +732,7 @@ func (s *createSystemSuite) TestCreateSystemImplicitSnaps(c *C) {
 	})
 	c.Check(dir, Equals, filepath.Join(boot.InitramfsUbuntuSeedDir, "systems/1234"))
 	// validate the seed
-	validateCore20Seed(c, "1234", s.ss.StoreSigning.Trusted)
+	validateCore20Seed(c, "1234", model, s.ss.StoreSigning.Trusted)
 }
 
 func (s *createSystemSuite) TestCreateSystemObserverErr(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -6080,7 +6080,8 @@ func (s *mgrsSuite) TestRemodelUC20WithRecoverySystem(c *C) {
 	c.Assert(tasks, HasLen, i+1)
 
 	const usesSnapd = true
-	seedtest.ValidateSeed(c, boot.InitramfsUbuntuSeedDir, expectedLabel, usesSnapd, s.storeSigning.Trusted)
+	sd := seedtest.ValidateSeed(c, boot.InitramfsUbuntuSeedDir, expectedLabel, usesSnapd, s.storeSigning.Trusted)
+	c.Assert(sd.Model(), DeepEquals, newModel)
 }
 
 func (s *mgrsSuite) TestCheckRefreshFailureWithConcurrentRemoveOfConnectedSnap(c *C) {


### PR DESCRIPTION
During a remodel, the model assertion isn't added to the DB until the very last stage of the process, however when a recovery system is being assembled, the seedwriter pulls the model assertion from the database. Because of this we need to use a temporary database that is stacked on top of the main one in this process.