### PR TITLE
tests/nested/manual/preseed: fix for cloud images that ship without core18

### DIFF
--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -41,6 +41,13 @@ prepare: |
   mv snapd-from-deb.snap snapd.snap
   inject_snap_into_seed "$IMAGE_MOUNTPOINT" snapd
 
+  # test-postgres-system-usernames injected below uses core18 base, while the
+  # cloud image seed may already be shipping with core20 only
+  if [ "$(find "$IMAGE_MOUNTPOINT/var/lib/snapd/seed/snaps" -name 'core18*.snap' | wc -l)" = 0 ]; then
+      snap download --edge --basename=core18 core18
+      inject_snap_into_seed "$IMAGE_MOUNTPOINT" core18
+  fi
+
   # inject a snap that uses system-usernames into the seed to confirm that works
   # as expected
   # TODO: replace this snap with a simpler one instead that is smaller, this one


### PR DESCRIPTION
The core images may be shipping core20 only by now, but the
test-postgres-system-usernames snap that we use in the test requires core18
base. Make sure that the required base snap is present in the seed.
