### PR TITLE
boot: properly handle tried system model

### DIFF
--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -376,6 +376,27 @@ func (m *Modeenv) TryModelForSealing() secboot.ModelForSealing {
 	}
 }
 
+func (m *Modeenv) useThisModel(model *asserts.Model) {
+	m.Model = model.Model()
+	m.BrandID = model.BrandID()
+	m.Grade = string(model.Grade())
+	m.ModelSignKeyID = model.SignKeyID()
+}
+
+func (m *Modeenv) useThisTryModel(model *asserts.Model) {
+	m.TryModel = model.Model()
+	m.TryBrandID = model.BrandID()
+	m.TryGrade = string(model.Grade())
+	m.TryModelSignKeyID = model.SignKeyID()
+}
+
+func (m *Modeenv) clearTryModel() {
+	m.TryModel = ""
+	m.TryBrandID = ""
+	m.TryGrade = ""
+	m.TryModelSignKeyID = ""
+}
+
 type modeenvValueMarshaller interface {
 	MarshalModeenvValue() (string, error)
 }

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -376,14 +376,14 @@ func (m *Modeenv) TryModelForSealing() secboot.ModelForSealing {
 	}
 }
 
-func (m *Modeenv) useThisModel(model *asserts.Model) {
+func (m *Modeenv) setModel(model *asserts.Model) {
 	m.Model = model.Model()
 	m.BrandID = model.BrandID()
 	m.Grade = string(model.Grade())
 	m.ModelSignKeyID = model.SignKeyID()
 }
 
-func (m *Modeenv) useThisTryModel(model *asserts.Model) {
+func (m *Modeenv) setTryModel(model *asserts.Model) {
 	m.TryModel = model.Model()
 	m.TryBrandID = model.BrandID()
 	m.TryGrade = string(model.Grade())

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -99,19 +99,13 @@ func ClearTryRecoverySystem(dev Device, systemLabel string) error {
 // SetTryRecoverySystem sets up the boot environment for trying out a recovery
 // system with given label in the context of the provided device. The call adds
 // the new system to the list of current recovery systems in the modeenv, and
-// optionally sets a try model, if the device mode is different from the current
-// one, which typically can happen during a remodel. Once done, the caller
-// should request switching to the given recovery system.
+// optionally sets a try model, if the device model is different from the
+// current one, which typically can happen during a remodel. Once done, the
+// caller should request switching to the given recovery system.
 func SetTryRecoverySystem(dev Device, systemLabel string) (err error) {
 	if !dev.HasModeenv() {
 		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
 	}
-
-	// either the current device context, in which case the model will match
-	// the current model in the modeenv, or a remodel device context
-	// carrying a new model, for which we may need to set the try model in
-	// the modeenv
-	model := dev.Model()
 
 	m, err := loadModeenv()
 	if err != nil {
@@ -134,6 +128,11 @@ func SetTryRecoverySystem(dev Device, systemLabel string) (err error) {
 		modified = true
 
 	}
+	// we either have the current device context, in which case the model
+	// will match the current model in the modeenv, or a remodel device
+	// context carrying a new model, for which we may need to set the try
+	// model in the modeenv
+	model := dev.Model()
 	if modelUniqueID(model) != modelUniqueID(m.ModelForSealing()) {
 		// recovery system is tried with a matching model
 		m.setTryModel(model)

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -129,7 +129,7 @@ func SetTryRecoverySystem(dev Device, systemLabel string) (err error) {
 	}
 	if modelUniqueID(model) != modelUniqueID(m.ModelForSealing()) {
 		// recovery system is tried with a matching model
-		m.useThisTryModel(model)
+		m.setTryModel(model)
 		modified = true
 	}
 	if modified {

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -37,9 +37,10 @@ func dropFromRecoverySystemsList(systemsList []string, systemLabel string) (newL
 	return systemsList, false
 }
 
-// ClearTryRecoverySystem removes a given candidate recovery system from the
-// modeenv state file, reseals and clears related bootloader variables. An empty
-// system label can be passed when the boot variables state is inconsistent.
+// ClearTryRecoverySystem removes a given candidate recovery system and clears
+// the try model in the modeenv state file, then reseals and clears related
+// bootloader variables. An empty system label can be passed when the boot
+// variables state is inconsistent.
 func ClearTryRecoverySystem(dev Device, systemLabel string) error {
 	if !dev.HasModeenv() {
 		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
@@ -96,14 +97,20 @@ func ClearTryRecoverySystem(dev Device, systemLabel string) error {
 }
 
 // SetTryRecoverySystem sets up the boot environment for trying out a recovery
-// system with given label and adds the new system to the list of current
-// recovery systems in the modeenv. Once done, the caller should request
-// switching to the given recovery system.
+// system with given label in the context of the provided device. The call adds
+// the new system to the list of current recovery systems in the modeenv, and
+// optionally sets a try model, if the device mode is different from the current
+// one, which typically can happen during a remodel. Once done, the caller
+// should request switching to the given recovery system.
 func SetTryRecoverySystem(dev Device, systemLabel string) (err error) {
 	if !dev.HasModeenv() {
 		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
 	}
 
+	// either the current device context, in which case the model will match
+	// the current model in the modeenv, or a remodel device context
+	// carrying a new model, for which we may need to set the try model in
+	// the modeenv
 	model := dev.Model()
 
 	m, err := loadModeenv()

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -1198,8 +1198,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 	})
 	modeenvAfterCreate, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(modeenvAfterCreate.CurrentRecoverySystems, DeepEquals, []string{"othersystem", "1234"})
-	c.Check(modeenvAfterCreate.GoodRecoverySystems, DeepEquals, []string{"othersystem"})
+	c.Check(modeenvAfterCreate, testutil.JsonEquals, boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_3.snap",
+		CurrentKernels:         []string{"pc-kernel_2.snap"},
+		CurrentRecoverySystems: []string{"othersystem", "1234"},
+		GoodRecoverySystems:    []string{"othersystem"},
+	})
 	// verify that new files are tracked correctly
 	expectedFilesLog := &bytes.Buffer{}
 	// new snap files are logged in this order
@@ -1234,8 +1239,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 
 	modeenvAfterFinalize, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(modeenvAfterFinalize.CurrentRecoverySystems, DeepEquals, []string{"othersystem", "1234"})
-	c.Check(modeenvAfterFinalize.GoodRecoverySystems, DeepEquals, []string{"othersystem", "1234"})
+	c.Check(modeenvAfterFinalize, testutil.JsonEquals, boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_3.snap",
+		CurrentKernels:         []string{"pc-kernel_2.snap"},
+		CurrentRecoverySystems: []string{"othersystem", "1234"},
+		GoodRecoverySystems:    []string{"othersystem", "1234"},
+	})
 	// no more calls to the bootloader past creating the system
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 0)
 	c.Check(filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", "1234", "snapd-new-file-log"), testutil.FileAbsent)
@@ -1351,8 +1361,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 	})
 	modeenvAfterCreate, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(modeenvAfterCreate.CurrentRecoverySystems, DeepEquals, []string{"othersystem", "1234"})
-	c.Check(modeenvAfterCreate.GoodRecoverySystems, DeepEquals, []string{"othersystem"})
+	c.Check(modeenvAfterCreate, testutil.JsonEquals, boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_3.snap",
+		CurrentKernels:         []string{"pc-kernel_2.snap"},
+		CurrentRecoverySystems: []string{"othersystem", "1234"},
+		GoodRecoverySystems:    []string{"othersystem"},
+	})
 	// verify that new files are tracked correctly
 	expectedFilesLog := &bytes.Buffer{}
 	// new snap files are logged in this order
@@ -1391,10 +1406,15 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 
 	modeenvAfterFinalize, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	// the system is kept in the current list
-	c.Check(modeenvAfterFinalize.CurrentRecoverySystems, DeepEquals, []string{"othersystem", "1234"})
-	// but not promoted to good systems yet
-	c.Check(modeenvAfterFinalize.GoodRecoverySystems, DeepEquals, []string{"othersystem"})
+	c.Check(modeenvAfterFinalize, testutil.JsonEquals, boot.Modeenv{
+		Mode:           "run",
+		Base:           "core20_3.snap",
+		CurrentKernels: []string{"pc-kernel_2.snap"},
+		// the system is kept in the current list
+		CurrentRecoverySystems: []string{"othersystem", "1234"},
+		// but not promoted to good systems yet
+		GoodRecoverySystems: []string{"othersystem"},
+	})
 	// no more calls to the bootloader past creating the system
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 0)
 	c.Check(filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", "1234", "snapd-new-file-log"), testutil.FileAbsent)
@@ -1543,8 +1563,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 	})
 	modeenvAfterCreate, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(modeenvAfterCreate.CurrentRecoverySystems, DeepEquals, []string{"othersystem", "1234undo"})
-	c.Check(modeenvAfterCreate.GoodRecoverySystems, DeepEquals, []string{"othersystem"})
+	c.Check(modeenvAfterCreate, testutil.JsonEquals, boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_3.snap",
+		CurrentKernels:         []string{"pc-kernel_2.snap"},
+		CurrentRecoverySystems: []string{"othersystem", "1234undo"},
+		GoodRecoverySystems:    []string{"othersystem"},
+	})
 
 	// these things happen on snapd startup
 	state.MockRestarting(s.state, state.RestartUnset)
@@ -1571,8 +1596,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 
 	modeenvAfterFinalize, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(modeenvAfterFinalize.CurrentRecoverySystems, DeepEquals, []string{"othersystem"})
-	c.Check(modeenvAfterFinalize.GoodRecoverySystems, DeepEquals, []string{"othersystem"})
+	c.Check(modeenvAfterFinalize, testutil.JsonEquals, boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_3.snap",
+		CurrentKernels:         []string{"pc-kernel_2.snap"},
+		CurrentRecoverySystems: []string{"othersystem"},
+		GoodRecoverySystems:    []string{"othersystem"},
+	})
 	// no more calls to the bootloader
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 0)
 	// system directory was removed
@@ -1622,8 +1652,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 	})
 	modeenvAfterCreate, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(modeenvAfterCreate.CurrentRecoverySystems, DeepEquals, []string{"othersystem", "1234"})
-	c.Check(modeenvAfterCreate.GoodRecoverySystems, DeepEquals, []string{"othersystem"})
+	c.Check(modeenvAfterCreate, testutil.JsonEquals, boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_3.snap",
+		CurrentKernels:         []string{"pc-kernel_2.snap"},
+		CurrentRecoverySystems: []string{"othersystem", "1234"},
+		GoodRecoverySystems:    []string{"othersystem"},
+	})
 
 	// these things happen on snapd startup
 	state.MockRestarting(s.state, state.RestartUnset)
@@ -1653,8 +1688,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 
 	modeenvAfterFinalize, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(modeenvAfterFinalize.CurrentRecoverySystems, DeepEquals, []string{"othersystem"})
-	c.Check(modeenvAfterFinalize.GoodRecoverySystems, DeepEquals, []string{"othersystem"})
+	c.Check(modeenvAfterFinalize, testutil.JsonEquals, boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_3.snap",
+		CurrentKernels:         []string{"pc-kernel_2.snap"},
+		CurrentRecoverySystems: []string{"othersystem"},
+		GoodRecoverySystems:    []string{"othersystem"},
+	})
 	// no more calls to the bootloader
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 0)
 	// seed directory was removed
@@ -1722,8 +1762,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemErrCl
 	})
 	modeenvAfterCreate, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(modeenvAfterCreate.CurrentRecoverySystems, DeepEquals, []string{"othersystem"})
-	c.Check(modeenvAfterCreate.GoodRecoverySystems, DeepEquals, []string{"othersystem"})
+	c.Check(modeenvAfterCreate, testutil.JsonEquals, boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_3.snap",
+		CurrentKernels:         []string{"pc-kernel_2.snap"},
+		CurrentRecoverySystems: []string{"othersystem"},
+		GoodRecoverySystems:    []string{"othersystem"},
+	})
 }
 
 func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemReboot(c *C) {
@@ -1811,8 +1856,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemReboo
 	})
 	modeenvAfterCreate, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
-	c.Check(modeenvAfterCreate.CurrentRecoverySystems, DeepEquals, []string{"othersystem"})
-	c.Check(modeenvAfterCreate.GoodRecoverySystems, DeepEquals, []string{"othersystem"})
+	c.Check(modeenvAfterCreate, testutil.JsonEquals, boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_3.snap",
+		CurrentKernels:         []string{"pc-kernel_2.snap"},
+		CurrentRecoverySystems: []string{"othersystem"},
+		GoodRecoverySystems:    []string{"othersystem"},
+	})
 	var triedSystems []string
 	s.state.Get("tried-systems", &triedSystems)
 	c.Check(triedSystems, HasLen, 0)

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -130,6 +130,11 @@ func (s *deviceMgrSystemsBaseSuite) SetUpTest(c *C) {
 	modeenv := boot.Modeenv{
 		Mode:           "run",
 		RecoverySystem: "",
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	}
 	err := modeenv.WriteTo("")
 	s.state.Set("seeded", true)
@@ -1158,6 +1163,11 @@ func (s *deviceMgrSystemsCreateSuite) mockStandardSnapsModeenvAndBootloaderState
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem"},
 		GoodRecoverySystems:    []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	}
 	err = modeenv.WriteTo("")
 	c.Assert(err, IsNil)
@@ -1204,6 +1214,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem", "1234"},
 		GoodRecoverySystems:    []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
+		// try model is unset as its measured properties are identical
+		// to current
 	})
 	// verify that new files are tracked correctly
 	expectedFilesLog := &bytes.Buffer{}
@@ -1245,6 +1262,11 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem", "1234"},
 		GoodRecoverySystems:    []string{"othersystem", "1234"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	})
 	// no more calls to the bootloader past creating the system
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 0)
@@ -1367,6 +1389,12 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem", "1234"},
 		GoodRecoverySystems:    []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
+		// try model is unset as its measured properties are identical
 	})
 	// verify that new files are tracked correctly
 	expectedFilesLog := &bytes.Buffer{}
@@ -1414,6 +1442,11 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 		CurrentRecoverySystems: []string{"othersystem", "1234"},
 		// but not promoted to good systems yet
 		GoodRecoverySystems: []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	})
 	// no more calls to the bootloader past creating the system
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 0)
@@ -1569,6 +1602,11 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem", "1234undo"},
 		GoodRecoverySystems:    []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	})
 
 	// these things happen on snapd startup
@@ -1602,6 +1640,11 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem"},
 		GoodRecoverySystems:    []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	})
 	// no more calls to the bootloader
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 0)
@@ -1658,6 +1701,11 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem", "1234"},
 		GoodRecoverySystems:    []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	})
 
 	// these things happen on snapd startup
@@ -1694,6 +1742,11 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem"},
 		GoodRecoverySystems:    []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	})
 	// no more calls to the bootloader
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 0)
@@ -1768,6 +1821,11 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemErrCl
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem"},
 		GoodRecoverySystems:    []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	})
 }
 
@@ -1862,6 +1920,11 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemReboo
 		CurrentKernels:         []string{"pc-kernel_2.snap"},
 		CurrentRecoverySystems: []string{"othersystem"},
 		GoodRecoverySystems:    []string{"othersystem"},
+
+		Model:          s.model.Model(),
+		BrandID:        s.model.BrandID(),
+		Grade:          string(s.model.Grade()),
+		ModelSignKeyID: s.model.SignKeyID(),
 	})
 	var triedSystems []string
 	s.state.Get("tried-systems", &triedSystems)


### PR DESCRIPTION
When we create a try system, its model may not match the expected measurements done during boot and thus will prevent unsealing the data and the tried system will be marked as failed.

Based on #10477 with some helpers from #10469, the relevant commit is https://github.com/snapcore/snapd/commit/8d22ebeaf8b2f1c4740d7035088615b7917502c9

~~Marking as blocked at least until #10477 lands~~