### PR TITLE
tests: run spread tests in ubuntu bionic 32bits

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -240,6 +240,7 @@ jobs:
         - ubuntu-14.04-64
         - ubuntu-16.04-32
         - ubuntu-16.04-64
+        - ubuntu-18.04-32
         - ubuntu-18.04-64
         - ubuntu-20.04-64
         - ubuntu-20.10-64

--- a/spread.yaml
+++ b/spread.yaml
@@ -85,6 +85,8 @@ backends:
                   workers: 6
             - ubuntu-16.04-64:
                   workers: 8
+            - ubuntu-18.04-32:
+                  workers: 6
             - ubuntu-18.04-64:
                   workers: 8
             - ubuntu-20.04-64:

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -550,7 +550,7 @@ pkg_dependencies_ubuntu_classic(){
         ubuntu-14.04-*)
                 pkg_linux_image_extra
             ;;
-        ubuntu-16.04-32)
+        ubuntu-16.04-32|ubuntu-18.04-32)
             echo "
                 dbus-user-session
                 gccgo-6

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -17,7 +17,7 @@ details: |
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
 # ubuntu-18.04-*: Ships xdg-desktop-portal 0.11
-systems: [ubuntu-18.04-*, ubuntu-2*]
+systems: [ubuntu-18.04-64, ubuntu-2*]
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -10,7 +10,7 @@ details: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems: [ubuntu-18.04-*, ubuntu-2*]
+systems: [ubuntu-18.04-64, ubuntu-2*]
 
 environment:
     EDITOR_HISTORY: /tmp/editor-history.txt

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -7,7 +7,7 @@ details: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems: [ubuntu-18.04-*, ubuntu-2*]
+systems: [ubuntu-18.04-64, ubuntu-2*]
 
 environment:
     BROWSER_HISTORY: /tmp/browser-history.txt

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -21,7 +21,7 @@ details: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems: [ubuntu-18.04-*, ubuntu-2*]
+systems: [ubuntu-18.04-64, ubuntu-2*]
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -5,9 +5,9 @@ details: |
   command works in lxc container and that the resulting image can be run
   in a container and seeding finishes successfully.
 
-# this test works only on 18.04 because it requires lxd from deb (lxd snap
+# this test works only on 18.04-64 because it requires lxd from deb (lxd snap
 # as it wouldn't allow mount) and tries to replicate launchpad builder setup.
-systems: [ubuntu-18.04-*]
+systems: [ubuntu-18.04-64]
 
 environment:
   IMAGE_MOUNTPOINT: /mnt/cloudimg


### PR DESCRIPTION
Changes to support running spread tests in ubuntu-18.04-32 system

The idea is then to remove ubuntu-16.04-32 in a following PR
