### PR TITLE
sandbox/cgroup: do not be so eager to fail when paths do not exist

### DIFF
--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -34,6 +34,8 @@ var (
 	ErrDBusSpawnChildExited = errDBusSpawnChildExited
 
 	SecurityTagFromCgroupPath = securityTagFromCgroupPath
+
+	ApplyToSnap = applyToSnap
 )
 
 func MockFsTypeForPath(mock func(string) (int64, error)) (restore func()) {

--- a/sandbox/cgroup/freezer.go
+++ b/sandbox/cgroup/freezer.go
@@ -123,14 +123,19 @@ func thawSnapProcessesImplV1(snapName string) error {
 	return nil
 }
 
-func applyToSnap(snapName string, action func(groupName string) error, skipErrs bool) error {
+func applyToSnap(snapName string, action func(groupName string) error, skipError func(err error) bool) error {
 	canary := fmt.Sprintf("snap.%s.", snapName)
 	cgroupRoot := filepath.Join(rootPath, cgroupMountPoint)
 	if _, dir, _ := osutil.DirExists(cgroupRoot); !dir {
 		return nil
 	}
 	return filepath.Walk(filepath.Join(rootPath, cgroupMountPoint), func(name string, info os.FileInfo, err error) error {
-		if err != nil && !skipErrs {
+		if err != nil {
+			if skipError != nil && skipError(err) {
+				// we don't know whether it's a file or
+				// directory, so just return nil instead
+				return nil
+			}
 			return err
 		}
 		if !info.IsDir() {
@@ -140,11 +145,27 @@ func applyToSnap(snapName string, action func(groupName string) error, skipErrs 
 			return nil
 		}
 		// found a group
-		if err := action(name); err != nil && !skipErrs {
+		if err := action(name); err != nil && (skipError == nil || !skipError(err)) {
 			return err
 		}
 		return filepath.SkipDir
 	})
+}
+
+// writeFile can be used as a drop-in replacement for ioutil.WriteFile, but does
+// not create a file when does not exist
+func writeFile(where string, data []byte, mode os.FileMode) error {
+	f, err := os.OpenFile(where, os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	_, errW := f.Write(data)
+	errC := f.Close()
+	// pick the right error
+	if errC != nil && errW == nil {
+		return errC
+	}
+	return errW
 }
 
 // freezeSnapProcessesImplV2 freezes all the processes originating from the
@@ -166,15 +187,20 @@ func freezeSnapProcessesImplV2(snapName string) error {
 			return nil
 		}
 		fname := filepath.Join(dir, "cgroup.freeze")
-		if err := ioutil.WriteFile(fname, []byte("1"), 0644); err != nil && os.IsNotExist(err) {
-			//  the group may be gone already
-			return nil
-		} else if err != nil {
+		if err := writeFile(fname, []byte("1"), 0644); err != nil {
+			if os.IsNotExist(err) {
+				//  the group may be gone already
+				return nil
+			}
 			return fmt.Errorf("cannot freeze processes of snap %q, %v", snapName, err)
 		}
 		for i := 0; i < 30; i++ {
 			data, err := ioutil.ReadFile(fname)
 			if err != nil {
+				if os.IsNotExist(err) {
+					// group may be gone
+					return nil
+				}
 				return fmt.Errorf("cannot determine the freeze state of processes of snap %q, %v", snapName, err)
 			}
 			// If the cgroup is still freezing then wait a moment and try again.
@@ -187,35 +213,37 @@ func freezeSnapProcessesImplV2(snapName string) error {
 		}
 		return fmt.Errorf("cannot freeze processes of snap %q in group %v", snapName, filepath.Base(dir))
 	}
-	const skipFreezeErrs = false
-	err = applyToSnap(snapName, freezeOne, skipFreezeErrs)
+	// freeze skipping ENOENT errors
+	err = applyToSnap(snapName, freezeOne, os.IsNotExist)
 	if err == nil {
 		return nil
 	}
 	// we either got here because we hit a timeout freezing snap processes
 	// or some other error
-	const skipThawErrs = true
-	thawSnapProcessesV2(snapName, skipThawErrs) // ignore the error, this is best-effort.
+
+	// ignore errors when thawing processes, this is best-effort.
+	alwaysSkipError := func(_ error) bool { return true }
+	thawSnapProcessesV2(snapName, alwaysSkipError)
 	return fmt.Errorf("cannot finish freezing processes of snap %q: %v", snapName, err)
 }
 
-func thawSnapProcessesV2(snapName string, skipErrs bool) error {
+func thawSnapProcessesV2(snapName string, skipError func(error) bool) error {
 	thawOne := func(dir string) error {
 		fname := filepath.Join(dir, "cgroup.freeze")
-		if err := ioutil.WriteFile(fname, []byte("0"), 0644); err != nil && os.IsNotExist(err) {
+		if err := writeFile(fname, []byte("0"), 0644); err != nil && os.IsNotExist(err) {
 			//  the group may be gone already
 			return nil
-		} else if err != nil && !skipErrs {
+		} else if err != nil && (skipError == nil || !skipError(err)) {
 			return fmt.Errorf("cannot thaw processes of snap %q, %v", snapName, err)
 		}
 		return nil
 	}
-	return applyToSnap(snapName, thawOne, skipErrs)
+	return applyToSnap(snapName, thawOne, skipError)
 }
 
 func thawSnapProcessesImplV2(snapName string) error {
-	const skipErrs = false
-	return thawSnapProcessesV2(snapName, skipErrs)
+	// thaw skipping ENOENT errors
+	return thawSnapProcessesV2(snapName, os.IsNotExist)
 }
 
 // MockFreezing replaces the real implementation of freeze and thaw.

--- a/sandbox/cgroup/freezer_test.go
+++ b/sandbox/cgroup/freezer_test.go
@@ -24,6 +24,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -368,4 +370,63 @@ func (s *freezerV2Suite) TestFreezeThawSnapProcessesV2ErrNotFound(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(g1, testutil.FileAbsent)
 	c.Check(g2, testutil.FileAbsent)
+}
+
+func (s *freezerV2Suite) TestApplyToSnapCallbacks(c *C) {
+	defer cgroup.MockVersion(cgroup.V2, nil)()
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+
+	c.Check(cgroup.ApplyToSnap("foo", nil, nil), ErrorMatches, "internal error: action is nil")
+	nop := func(_ string) error { return nil }
+	c.Check(cgroup.ApplyToSnap("foo", nop, nil), ErrorMatches, "internal error: skip error is nil")
+
+	g := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/system.slice/snap.foo.app.1234-1234-1234.scope/cgroup.freeze")
+	gErr := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/system.slice/snap.foo.app.fail.scope/cgroup.freeze")
+
+	for _, p := range []string{g, gErr} {
+		c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
+		// groups aren't frozen
+		c.Assert(ioutil.WriteFile(p, []byte("0"), 0644), IsNil)
+	}
+
+	var visited []string
+	err := cgroup.ApplyToSnap("foo",
+		func(p string) error {
+			visited = append(visited, p)
+			return nil
+		},
+		func(err error) bool {
+			return true
+		})
+	c.Assert(err, IsNil)
+	sort.Strings(visited)
+	c.Check(visited, DeepEquals, []string{filepath.Dir(g), filepath.Dir(gErr)})
+
+	visited = nil
+	skip := true
+	var errors []string
+	maybeFail := func(p string) error {
+		visited = append(visited, p)
+		if strings.HasSuffix(p, "fail.scope") {
+			return fmt.Errorf("do not skip")
+		}
+		return nil
+	}
+	maybeSkip := func(err error) bool {
+		errors = append(errors, err.Error())
+		return skip
+	}
+	err = cgroup.ApplyToSnap("foo", maybeFail, maybeSkip)
+	c.Assert(err, IsNil)
+	c.Check(visited, DeepEquals, []string{filepath.Dir(g), filepath.Dir(gErr)})
+	c.Check(errors, DeepEquals, []string{"do not skip"})
+
+	skip = false
+	visited = nil
+	errors = nil
+	err = cgroup.ApplyToSnap("foo", maybeFail, maybeSkip)
+	c.Assert(err, ErrorMatches, "do not skip")
+	c.Check(visited, DeepEquals, []string{filepath.Dir(g), filepath.Dir(gErr)})
+	c.Check(errors, DeepEquals, []string{"do not skip"})
 }


### PR DESCRIPTION
The groups that we walk through may be going away at any time. Try to be more
robust in such scenarios.
