### PR TITLE
boot, seed/seedtest: tweak test helpers

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -116,14 +116,6 @@ func MockSecbootSealKeysWithFDESetupHook(f func(runHook fde.RunSetupHookFunc, ke
 	}
 }
 
-func MockSecbootResealKeys(f func(params *secboot.ResealKeysParams) error) (restore func()) {
-	old := secbootResealKeys
-	secbootResealKeys = f
-	return func() {
-		secbootResealKeys = old
-	}
-}
-
 func MockSeedReadSystemEssential(f func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error)) (restore func()) {
 	old := seedReadSystemEssential
 	seedReadSystemEssential = f

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -71,6 +71,16 @@ const (
 	sealingMethodFDESetupHook = sealingMethod("fde-setup-hook")
 )
 
+// MockSecbootResealKeys is only useful in testing
+func MockSecbootResealKeys(f func(params *secboot.ResealKeysParams) error) (restore func()) {
+	osutil.MustBeTestBinary("secbootResealKeys only can be mocked in tests")
+	old := secbootResealKeys
+	secbootResealKeys = f
+	return func() {
+		secbootResealKeys = old
+	}
+}
+
 func bootChainsFileUnder(rootdir string) string {
 	return filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains")
 }

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -234,9 +234,18 @@ type TestingSeed20 struct {
 	SeedDir string
 }
 
+// MakeSeed creates the seed with given label and generates model assertions
 func (s *TestingSeed20) MakeSeed(c *C, label, brandID, modelID string, modelHeaders map[string]interface{}, optSnaps []*seedwriter.OptionsSnap) *asserts.Model {
 	model := s.Brands.Model(brandID, modelID, modelHeaders)
 
+	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys(brandID)...)
+
+	s.MakeSeedWithModel(c, label, model, optSnaps)
+	return model
+}
+
+// MakeSeedWithModel creates the seed with given label for a given model
+func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Model, optSnaps []*seedwriter.OptionsSnap) {
 	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
 		Backstore: asserts.NewMemoryBackstore(),
 		Trusted:   s.StoreSigning.Trusted,
@@ -260,7 +269,6 @@ func (s *TestingSeed20) MakeSeed(c *C, label, brandID, modelID string, modelHead
 		}
 		return asserts.NewFetcher(db, retrieve, save2)
 	}
-	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys(brandID)...)
 
 	opts := seedwriter.Options{
 		SeedDir: s.SeedDir,
@@ -336,8 +344,6 @@ func (s *TestingSeed20) MakeSeed(c *C, label, brandID, modelID string, modelHead
 
 	err = w.WriteMeta()
 	c.Assert(err, IsNil)
-
-	return model
 }
 
 func ValidateSeed(c *C, root, label string, usesSnapd bool, trusted []asserts.Assertion) seed.Seed {


### PR DESCRIPTION
Tweak test helpers to enable better testing. The seedtest change specifically allows creating seeds when the model has already been created and signed, as in the case of testing the remodel in managers suite.
