### PR TITLE
interface: allows reading sd cards internal info from `block-devices` interface

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -53,6 +53,7 @@ const blockDevicesConnectedPlugAppArmor = `
 /run/udev/data/b[0-9]*:[0-9]* r,
 /sys/block/ r,
 /sys/devices/**/block/** r,
+/sys/devices/platform/soc/**/mmc_host/** r,
 
 # Access to raw devices, not individual partitions
 /dev/hd[a-t] rw,                                          # IDE, MFM, RLL


### PR DESCRIPTION
Without this line:
	cat /sys/block/mmcblk0/device/date
results in this denial:
/sys/devices/platform/soc/3f202000.mmc/mmc_host/mmc0/mmc0:aaaa/date

See: https://forum.snapcraft.io/t/interface-for-read-info-about-sd-card/25202

After adding the line in the commit to my snap apparmor file it works:

root@srly-r7d8mg4oj4eo0go:/home/pi# sudo apparmor_parser -r /var/lib/snapd/apparmor/profiles/snap.screenly-client.submit-report 
Warning from /var/lib/snapd/apparmor/profiles/snap.screenly-client.submit-report (/var/lib/snapd/apparmor/profiles/snap.screenly-client.submit-report line 1297): Character # was quoted unnecessarily, dropped preceding quote ('\') character
root@srly-r7d8mg4oj4eo0go:/home/pi# snap run --shell screenly-client.submit-report
root@srly-r7d8mg4oj4eo0go:/home/pi# cat /sys/block/mmcblk0/device/date 
06/2017
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
yes
