### PR TITLE
tests/lib/store.sh: revert #10470

### DIFF
--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -82,8 +82,8 @@ EOF
 }
 EOF
 
-    new_snap_declaration "$dir" "$snap_path" --snap-decl-json=/tmp/snap-decl.json
-    new_snap_revision "$dir" "$snap_path" --snap-rev-json=/tmp/snap-rev.json
+    fakestore new-snap-declaration --dir "$dir" --snap-decl-json=/tmp/snap-decl.json "$snap_path"
+    fakestore new-snap-revision --dir "$dir" --snap-rev-json=/tmp/snap-rev.json "$snap_path"
 
     rm -rf /tmp/snap-decl.json
     rm -rf /tmp/snap-rev.json


### PR DESCRIPTION
This reverts commit 69fe30426bc737c46b2e995a84f0617cd135887c.

We don't want to ack the assertions when building the image simply because we
don't need to as we are only building an image at that point to put the
assertions into the image, and we actually use/ack the assertions at runtime
inside the VM.

See https://paste.ubuntu.com/p/Dcfqhy2vwK/ for an example failure that this
commit caused.

As mentioned in https://github.com/snapcore/snapd/pull/10470#issuecomment-874322823, we can refactor this
function if need be to make other tests easier by acking and perhaps make the 
nested tests that need to not ack the assertions use an option/flag to prevent
this function from ack'ing the assertions, but let's do that as a follow-up to unblock
other "run nested" PR's which are currently failing from this change.

cc @bboozzoo 