### PR TITLE
tests: disable delta download tests for now until the store is fixed

### DIFF
--- a/tests/main/refresh-delta-from-core/task.yaml
+++ b/tests/main/refresh-delta-from-core/task.yaml
@@ -21,6 +21,9 @@ restore: |
     fi
 
 execute: |
+    echo "SKIP (2021-07-06) because the store is unable to give us deltas"
+    exit 0
+
     echo "When the snap is refreshed"
     snap refresh --beta "$SNAP_NAME"
     echo "Then deltas are successfully applied"

--- a/tests/main/refresh-delta/task.yaml
+++ b/tests/main/refresh-delta/task.yaml
@@ -16,6 +16,9 @@ prepare: |
     snap install --edge "$SNAP_NAME"
 
 execute: |
+    echo "SKIP (2021-07-06) because the store is unable to give us deltas"
+    exit 0
+
     echo "When the snap is refreshed"
     snap refresh --beta "$SNAP_NAME"
 


### PR DESCRIPTION
This will unblock our tests.

I will open a PR that re-enables the test so that we can monitor the progress of the store team.