### PR TITLE
tests: ack assertions by default, add --noack option

### DIFF
--- a/tests/core/gadget-kernel-refs-update-pc/task.yaml
+++ b/tests/core/gadget-kernel-refs-update-pc/task.yaml
@@ -56,8 +56,10 @@ prepare: |
     cat <<EOF > rev-headers.json
     {"snap-id": "$PC_KERNEL_ID", "snap-revision": "$START_REVISION"}
     EOF
-    new_snap_declaration "$BLOB_DIR" pc-kernel_x1.snap --snap-decl-json decl-headers.json
-    new_snap_revision "$BLOB_DIR" pc-kernel_x1.snap --snap-rev-json rev-headers.json
+    p=$(new_snap_declaration "$BLOB_DIR" pc-kernel_x1.snap --snap-decl-json decl-headers.json)
+    snap ack "$p"
+    p=$(new_snap_revision "$BLOB_DIR" pc-kernel_x1.snap --snap-rev-json rev-headers.json)
+    snap ack "$p"
     # new gadget
     cp /var/lib/snapd/snaps/pc_*.snap gadget.snap
     unsquashfs -d pc-snap gadget.snap
@@ -76,8 +78,10 @@ prepare: |
     cat <<EOF > rev-headers.json
     {"snap-id": "$PC_SNAP_ID", "snap-revision": "$START_REVISION"}
     EOF
-    new_snap_declaration "$BLOB_DIR" pc_x1.snap --snap-decl-json decl-headers.json
-    new_snap_revision "$BLOB_DIR" pc_x1.snap --snap-rev-json rev-headers.json
+    p=$(new_snap_declaration "$BLOB_DIR" pc_x1.snap --snap-decl-json decl-headers.json)
+    snap ack "$p"
+    p=$(new_snap_revision "$BLOB_DIR" pc_x1.snap --snap-rev-json rev-headers.json)
+    snap ack "$p"
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"

--- a/tests/core/gadget-update-pc/task.yaml
+++ b/tests/core/gadget-update-pc/task.yaml
@@ -47,8 +47,10 @@ prepare: |
     {"snap-id": "$PC_SNAP_ID", "snap-revision": "$START_REVISION"}
     EOF
 
-    new_snap_declaration "$BLOB_DIR" pc_x1.snap --snap-decl-json decl-headers.json
-    new_snap_revision "$BLOB_DIR" pc_x1.snap --snap-rev-json rev-headers.json
+    p=$(new_snap_declaration "$BLOB_DIR" pc_x1.snap --snap-decl-json decl-headers.json)
+    snap ack "$p"
+    p=$(new_snap_revision "$BLOB_DIR" pc_x1.snap --snap-rev-json rev-headers.json)
+    snap ack "$p"
 
     cp pc-snap/meta/gadget.yaml gadget.yaml.orig
 
@@ -139,8 +141,10 @@ execute: |
 
     if [[ "$SPREAD_REBOOT" == 0 ]]; then
 
-        new_snap_declaration "$BLOB_DIR" pc_x2.snap --snap-decl-json decl-headers.json
-        new_snap_revision "$BLOB_DIR" pc_x2.snap --snap-rev-json rev-headers-2.json
+        p=$(new_snap_declaration "$BLOB_DIR" pc_x2.snap --snap-decl-json decl-headers.json)
+        snap ack "$p"
+        p=$(new_snap_revision "$BLOB_DIR" pc_x2.snap --snap-rev-json rev-headers-2.json)
+        snap ack "$p"
 
         snap install pc_x2.snap
 
@@ -173,8 +177,10 @@ execute: |
         fi
 
         # prepare & install the next update
-        new_snap_declaration "$BLOB_DIR" pc_x3.snap --snap-decl-json decl-headers.json
-        new_snap_revision "$BLOB_DIR" pc_x3.snap --snap-rev-json rev-headers-3.json
+        p=$(new_snap_declaration "$BLOB_DIR" pc_x3.snap --snap-decl-json decl-headers.json)
+        snap ack "$p"
+        p=$(new_snap_revision "$BLOB_DIR" pc_x3.snap --snap-rev-json rev-headers-3.json)
+        snap ack "$p"
 
         snap install pc_x3.snap
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -549,7 +549,7 @@ nested_create_core_vm() {
                     repack_core_snap_with_tweaks "core18.snap" "new-core18.snap"
 
                     if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
-                        make_snap_installable_with_id "$NESTED_FAKESTORE_BLOB_DIR" "$PWD/new-core18.snap" "CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6"
+                        make_snap_installable_with_id --noack "$NESTED_FAKESTORE_BLOB_DIR" "$PWD/new-core18.snap" "CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6"
                     fi
 
                 elif nested_is_core_20_system; then
@@ -573,7 +573,7 @@ nested_create_core_vm() {
 
                     # sign the pc-kernel snap with fakestore if requested
                     if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
-                        make_snap_installable_with_id "$NESTED_FAKESTORE_BLOB_DIR" "$KERNEL_SNAP" "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+                        make_snap_installable_with_id --noack "$NESTED_FAKESTORE_BLOB_DIR" "$KERNEL_SNAP" "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
                     fi
 
                     # Prepare the pc gadget snap (unless provided by extra-snaps)
@@ -624,7 +624,7 @@ EOF
                     fi
                     # sign the pc gadget snap with fakestore if requested
                     if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
-                        make_snap_installable_with_id "$NESTED_FAKESTORE_BLOB_DIR" "$GADGET_SNAP" "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+                        make_snap_installable_with_id --noack "$NESTED_FAKESTORE_BLOB_DIR" "$GADGET_SNAP" "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
                     fi
 
                     # repack the snapd snap
@@ -634,7 +634,7 @@ EOF
 
                     # sign the snapd snap with fakestore if requested
                     if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
-                        make_snap_installable_with_id "$NESTED_FAKESTORE_BLOB_DIR" "$PWD/snapd-from-deb.snap" "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+                        make_snap_installable_with_id --noack "$NESTED_FAKESTORE_BLOB_DIR" "$PWD/snapd-from-deb.snap" "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
                     fi
 
                     # which channel?
@@ -644,7 +644,7 @@ EOF
 
                     # sign the snapd snap with fakestore if requested
                     if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
-                        make_snap_installable_with_id "$NESTED_FAKESTORE_BLOB_DIR" "$PWD/new-core20.snap" "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q"
+                        make_snap_installable_with_id --noack "$NESTED_FAKESTORE_BLOB_DIR" "$PWD/new-core20.snap" "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q"
                     fi
 
                 else

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -37,14 +37,34 @@ init_fake_refreshes(){
 }
 
 make_snap_installable(){
+    ACK=true
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            (--noack) ACK=false; shift;;
+            (*) break;;
+        esac
+    done
+
     local dir="$1"
     local snap_path="$2"
 
-    new_snap_declaration "$dir" "$snap_path"
-    new_snap_revision "$dir" "$snap_path"
+    p_decl=$(new_snap_declaration "$dir" "$snap_path")
+    p_rev=$(new_snap_revision "$dir" "$snap_path")
+    if [ $ACK = true ]; then
+        snap ack "$p_decl"
+        snap ack "$p_rev"
+    fi
 }
 
 make_snap_installable_with_id(){
+    ACK=true
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            (--noack) ACK=false; shift;;
+            (*) break;;
+        esac
+    done
+
     local dir="$1"
     local snap_path="$2"
     local snap_id="$3"
@@ -82,8 +102,12 @@ EOF
 }
 EOF
 
-    fakestore new-snap-declaration --dir "$dir" --snap-decl-json=/tmp/snap-decl.json "$snap_path"
-    fakestore new-snap-revision --dir "$dir" --snap-rev-json=/tmp/snap-rev.json "$snap_path"
+    p_decl=$(new_snap_declaration "$dir" "$snap_path" --snap-decl-json=/tmp/snap-decl.json)
+    p_rev=$(new_snap_revision "$dir" "$snap_path" --snap-rev-json=/tmp/snap-rev.json)
+    if [ $ACK = true ]; then
+        snap ack "$p_decl"
+        snap ack "$p_rev"
+    fi
 
     rm -rf /tmp/snap-decl.json
     rm -rf /tmp/snap-rev.json
@@ -95,8 +119,7 @@ new_snap_declaration(){
     shift 2
 
     cp -a "$snap_path" "$dir"
-    p=$(fakestore new-snap-declaration --dir "$dir" "$@" "${snap_path}" )
-    snap ack "$p"
+    fakestore new-snap-declaration --dir "$dir" "$@" "${snap_path}"
 }
 
 new_snap_revision(){
@@ -104,8 +127,7 @@ new_snap_revision(){
     local snap_path="$2"
     shift 2
 
-    p=$(fakestore new-snap-revision --dir "$dir" "$@" "${snap_path}")
-    snap ack "$p"
+    fakestore new-snap-revision --dir "$dir" "$@" "${snap_path}"
 }
 
 new_repair(){

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -135,7 +135,7 @@ new_repair(){
     local script_path="$2"
     shift 2
 
-    p=$(fakestore new-repair --dir "$dir" "$@" "${script_path}")
+    fakestore new-repair --dir "$dir" "$@" "${script_path}" > /dev/null
 }
 
 setup_fake_store(){


### PR DESCRIPTION
Restore the default behaviour of acking the newly created assertions by
default, but add a --noack option to prevent this from happening. Use
this option in the nested tests.

