### PR TITLE
cmd/snapctl: Add --ask argument and documents portal support to user-launch

### DIFF
--- a/cmd/snapctl/main.go
+++ b/cmd/snapctl/main.go
@@ -29,6 +29,8 @@ import (
 	"github.com/snapcore/snapd/usersession/xdgopenproxy"
 )
 
+type launcherModifiers = xdgopenproxy.LauncherModifiers
+
 var clientConfig = client.Config{
 	// snapctl should not try to read $HOME/.snap/auth.json, this will
 	// result in apparmor denials and configure task failures
@@ -48,8 +50,25 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
 	if len(os.Args) == 3 && os.Args[1] == "user-open" {
-		if err := xdgopenproxy.Run(os.Args[2]); err != nil {
+		if err := xdgopenproxy.Run(os.Args[2], launcherModifiers{}); err != nil {
+			fmt.Fprintf(os.Stderr, "user-open error: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	// There's no present need to use full argument parsing but maybe there will be in the future
+	// Hence impersonate a proper --argument on the offchance more might be needed later.
+	if len(os.Args) == 4 && os.Args[1] == "user-open" {
+		var path string
+		if os.Args[2] != "--ask" {
+			path = os.Args[2]
+		} else {
+			path = os.Args[3]
+		}
+
+		if err := xdgopenproxy.Run(path, launcherModifiers{Ask: true}); err != nil {
 			fmt.Fprintf(os.Stderr, "user-open error: %v\n", err)
 			os.Exit(1)
 		}

--- a/usersession/xdgopenproxy/export_test.go
+++ b/usersession/xdgopenproxy/export_test.go
@@ -52,9 +52,9 @@ func MakeResponseError(msg string) error {
 }
 
 func MockPortalTimeout(t time.Duration) (restore func()) {
-	old := defaultPortalRequestTimeout
-	defaultPortalRequestTimeout = t
+	old := defaultDesktopPortalRequestTimeout
+	defaultDesktopPortalRequestTimeout = t
 	return func() {
-		defaultPortalRequestTimeout = old
+		defaultDesktopPortalRequestTimeout = old
 	}
 }

--- a/usersession/xdgopenproxy/portal_launcher_test.go
+++ b/usersession/xdgopenproxy/portal_launcher_test.go
@@ -84,11 +84,12 @@ func (s *portalSuite) SetUpTest(c *C) {
 
 func (s *portalSuite) TestOpenFile(c *C) {
 	launcher := &xdgopenproxy.PortalLauncher{}
+	var options launcherModifiers
 
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
-	err := launcher.OpenFile(s.SessionBus, path)
+	err := launcher.OpenFile(s.SessionBus, path, options)
 	c.Check(err, IsNil)
 	c.Check(s.calls, DeepEquals, []string{
 		"OpenFile",
@@ -99,11 +100,12 @@ func (s *portalSuite) TestOpenFileCallError(c *C) {
 	s.openError = dbus.MakeFailedError(fmt.Errorf("failure"))
 
 	launcher := &xdgopenproxy.PortalLauncher{}
+	var options launcherModifiers
 
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
-	err := launcher.OpenFile(s.SessionBus, path)
+	err := launcher.OpenFile(s.SessionBus, path, options)
 	c.Check(err, FitsTypeOf, dbus.Error{})
 	c.Check(err, ErrorMatches, "failure")
 	c.Check(s.calls, DeepEquals, []string{
@@ -115,11 +117,12 @@ func (s *portalSuite) TestOpenFileResponseError(c *C) {
 	s.openResponse = 2
 
 	launcher := &xdgopenproxy.PortalLauncher{}
+	var options launcherModifiers
 
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
-	err := launcher.OpenFile(s.SessionBus, path)
+	err := launcher.OpenFile(s.SessionBus, path, options)
 	c.Check(err, FitsTypeOf, (*xdgopenproxy.ResponseError)(nil))
 	c.Check(err, ErrorMatches, `request declined by the user \(code 2\)`)
 	c.Check(s.calls, DeepEquals, []string{
@@ -133,11 +136,12 @@ func (s *portalSuite) TestOpenFileTimeout(c *C) {
 	defer restore()
 
 	launcher := &xdgopenproxy.PortalLauncher{}
+	var options launcherModifiers
 
 	file := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(file, []byte("hello world"), 0644), IsNil)
-
-	err := launcher.OpenFile(s.SessionBus, file)
+	
+	err := launcher.OpenFile(s.SessionBus, file, options)
 	c.Check(err, FitsTypeOf, (*xdgopenproxy.ResponseError)(nil))
 	c.Check(err, ErrorMatches, "timeout waiting for user response")
 	c.Check(s.calls, DeepEquals, []string{
@@ -148,9 +152,10 @@ func (s *portalSuite) TestOpenFileTimeout(c *C) {
 
 func (s *portalSuite) TestOpenDir(c *C) {
 	launcher := &xdgopenproxy.PortalLauncher{}
+	var options launcherModifiers
 
 	dir := c.MkDir()
-	err := launcher.OpenFile(s.SessionBus, dir)
+	err := launcher.OpenFile(s.SessionBus, dir, options)
 	c.Check(err, IsNil)
 	c.Check(s.calls, DeepEquals, []string{
 		"OpenFile",
@@ -159,29 +164,32 @@ func (s *portalSuite) TestOpenDir(c *C) {
 
 func (s *portalSuite) TestOpenMissingFile(c *C) {
 	launcher := &xdgopenproxy.PortalLauncher{}
+	var options launcherModifiers
 
 	path := filepath.Join(c.MkDir(), "no-such-file.txt")
-	err := launcher.OpenFile(s.SessionBus, path)
-	c.Check(err, ErrorMatches, "no such file or directory")
+	err := launcher.OpenFile(s.SessionBus, path, options)
+	c.Check(err, ErrorMatches, "*. no such file or directory")
 	c.Check(s.calls, HasLen, 0)
 }
 
 func (s *portalSuite) TestOpenUnreadableFile(c *C) {
 	launcher := &xdgopenproxy.PortalLauncher{}
+	var options launcherModifiers
 
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
 	c.Assert(os.Chmod(path, 0), IsNil)
 
-	err := launcher.OpenFile(s.SessionBus, path)
+	err := launcher.OpenFile(s.SessionBus, path, options)
 	c.Check(err, ErrorMatches, "permission denied")
 	c.Check(s.calls, HasLen, 0)
 }
 
 func (s *portalSuite) TestOpenURI(c *C) {
 	launcher := &xdgopenproxy.PortalLauncher{}
+	var options launcherModifiers
 
-	err := launcher.OpenURI(s.SessionBus, "http://example.com")
+	err := launcher.OpenURI(s.SessionBus, "http://example.com", options)
 	c.Check(err, IsNil)
 	c.Check(s.calls, DeepEquals, []string{
 		"OpenURI http://example.com",
@@ -192,7 +200,8 @@ func (s *portalSuite) TestOpenURICallError(c *C) {
 	s.openError = dbus.MakeFailedError(fmt.Errorf("failure"))
 
 	launcher := &xdgopenproxy.PortalLauncher{}
-	err := launcher.OpenURI(s.SessionBus, "http://example.com")
+	var options launcherModifiers
+	err := launcher.OpenURI(s.SessionBus, "http://example.com", options)
 	c.Check(err, FitsTypeOf, dbus.Error{})
 	c.Check(err, ErrorMatches, "failure")
 	c.Check(s.calls, DeepEquals, []string{
@@ -204,7 +213,8 @@ func (s *portalSuite) TestOpenURIResponseError(c *C) {
 	s.openResponse = 2
 
 	launcher := &xdgopenproxy.PortalLauncher{}
-	err := launcher.OpenURI(s.SessionBus, "http://example.com")
+	var options launcherModifiers
+	err := launcher.OpenURI(s.SessionBus, "http://example.com", options)
 	c.Check(err, FitsTypeOf, (*xdgopenproxy.ResponseError)(nil))
 	c.Check(err, ErrorMatches, `request declined by the user \(code 2\)`)
 	c.Check(s.calls, DeepEquals, []string{
@@ -218,7 +228,8 @@ func (s *portalSuite) TestOpenURITimeout(c *C) {
 	defer restore()
 
 	launcher := &xdgopenproxy.PortalLauncher{}
-	err := launcher.OpenURI(s.SessionBus, "http://example.com")
+	var options launcherModifiers
+	err := launcher.OpenURI(s.SessionBus, "http://example.com", options)
 	c.Check(err, FitsTypeOf, (*xdgopenproxy.ResponseError)(nil))
 	c.Check(err, ErrorMatches, "timeout waiting for user response")
 	c.Check(s.calls, DeepEquals, []string{

--- a/usersession/xdgopenproxy/userd_launcher.go
+++ b/usersession/xdgopenproxy/userd_launcher.go
@@ -34,7 +34,7 @@ const (
 // userdLauncher is a launcher that forwards the requests to `snap userd` DBus API
 type userdLauncher struct{}
 
-func (s *userdLauncher) OpenFile(bus *dbus.Conn, filename string) error {
+func (s *userdLauncher) OpenFile(bus *dbus.Conn, filename string, options LauncherModifiers) error {
 	fd, err := syscall.Open(filename, syscall.O_RDONLY, 0)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func (s *userdLauncher) OpenFile(bus *dbus.Conn, filename string) error {
 	return launcher.Call(userdLauncherIface+".OpenFile", 0, "", dbus.UnixFD(fd)).Store()
 }
 
-func (s *userdLauncher) OpenURI(bus *dbus.Conn, path string) error {
+func (s *userdLauncher) OpenURI(bus *dbus.Conn, path string, options LauncherModifiers) error {
 	launcher := bus.Object(userdLauncherBusName, userdLauncherObjectPath)
 	return launcher.Call("io.snapcraft.Launcher.OpenURL", 0, path).Store()
 }

--- a/usersession/xdgopenproxy/userd_launcher_test.go
+++ b/usersession/xdgopenproxy/userd_launcher_test.go
@@ -73,11 +73,12 @@ func (s *userdSuite) SetUpTest(c *C) {
 
 func (s *userdSuite) TestOpenFile(c *C) {
 	launcher := &xdgopenproxy.UserdLauncher{}
+	var options launcherModifiers
 
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
-	err := launcher.OpenFile(s.SessionBus, path)
+	err := launcher.OpenFile(s.SessionBus, path, options)
 	c.Check(err, IsNil)
 	c.Check(s.calls, DeepEquals, []string{
 		"OpenFile",
@@ -88,11 +89,12 @@ func (s *userdSuite) TestOpenFileError(c *C) {
 	s.openError = dbus.MakeFailedError(fmt.Errorf("failure"))
 
 	launcher := &xdgopenproxy.UserdLauncher{}
+	var options launcherModifiers
 
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
-	err := launcher.OpenFile(s.SessionBus, path)
+	err := launcher.OpenFile(s.SessionBus, path, options)
 	c.Check(err, FitsTypeOf, dbus.Error{})
 	c.Check(err, ErrorMatches, "failure")
 	c.Check(s.calls, DeepEquals, []string{
@@ -102,9 +104,10 @@ func (s *userdSuite) TestOpenFileError(c *C) {
 
 func (s *userdSuite) TestOpenDir(c *C) {
 	launcher := &xdgopenproxy.UserdLauncher{}
+	var options launcherModifiers
 
 	dir := c.MkDir()
-	err := launcher.OpenFile(s.SessionBus, dir)
+	err := launcher.OpenFile(s.SessionBus, dir, options)
 	c.Check(err, IsNil)
 	c.Check(s.calls, DeepEquals, []string{
 		"OpenFile",
@@ -113,29 +116,32 @@ func (s *userdSuite) TestOpenDir(c *C) {
 
 func (s *userdSuite) TestOpenMissingFile(c *C) {
 	launcher := &xdgopenproxy.UserdLauncher{}
+	var options launcherModifiers
 
 	path := filepath.Join(c.MkDir(), "no-such-file.txt")
-	err := launcher.OpenFile(s.SessionBus, path)
+	err := launcher.OpenFile(s.SessionBus, path, options)
 	c.Check(err, ErrorMatches, "no such file or directory")
 	c.Check(s.calls, HasLen, 0)
 }
 
 func (s *userdSuite) TestOpenUnreadableFile(c *C) {
 	launcher := &xdgopenproxy.UserdLauncher{}
+	var options launcherModifiers
 
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
 	c.Assert(os.Chmod(path, 0), IsNil)
 
-	err := launcher.OpenFile(s.SessionBus, path)
+	err := launcher.OpenFile(s.SessionBus, path, options)
 	c.Check(err, ErrorMatches, "permission denied")
 	c.Check(s.calls, HasLen, 0)
 }
 
 func (s *userdSuite) TestOpenURI(c *C) {
 	launcher := &xdgopenproxy.UserdLauncher{}
+	var options launcherModifiers
 
-	err := launcher.OpenURI(s.SessionBus, "http://example.com")
+	err := launcher.OpenURI(s.SessionBus, "http://example.com", options)
 	c.Check(err, IsNil)
 	c.Check(s.calls, DeepEquals, []string{
 		"OpenURI http://example.com",
@@ -146,7 +152,8 @@ func (s *userdSuite) TestOpenURIError(c *C) {
 	s.openError = dbus.MakeFailedError(fmt.Errorf("failure"))
 
 	launcher := &xdgopenproxy.UserdLauncher{}
-	err := launcher.OpenURI(s.SessionBus, "http://example.com")
+	var options launcherModifiers
+	err := launcher.OpenURI(s.SessionBus, "http://example.com", options)
 	c.Check(err, FitsTypeOf, dbus.Error{})
 	c.Check(err, ErrorMatches, "failure")
 	c.Check(s.calls, DeepEquals, []string{


### PR DESCRIPTION
Where possible, snapctl user-open and by extension /bin/xdg-open
will attempt to use the documents portal, such that if a file
is writable by the snap sending the request, it is writable by the
application receiving the request.
This requires xdg-desktop-portal >= 1.8.1 to work snap to snap
but should work with earlier versions snap to flatpak.

The --ask flag enables the snap to request that the portals UI
is shown unconditionally, ignoring for example previously learnt
associations.