### PR TITLE
testutil: fix typo in json checker unit tests

### DIFF
--- a/testutil/jsonchecker_test.go
+++ b/testutil/jsonchecker_test.go
@@ -64,7 +64,7 @@ func (*jsonCheckerSuite) TestFilePresent(c *check.C) {
 				// this is transparent to the checker
 				hidden: true,
 			},
-			// this is transparent to the chekcker
+			// this is transparent to the checker
 			hidden: true,
 		})
 	testCheck(c, JsonEquals, true, "",


### PR DESCRIPTION
Thanks to @anonymouse64 for spotting this


