### PR TITLE
tests/main/system-usernames-microk8s: disable on centos 7 too

### DIFF
--- a/tests/main/system-usernames-microk8s/task.yaml
+++ b/tests/main/system-usernames-microk8s/task.yaml
@@ -1,10 +1,10 @@
 summary: ensure only approved snaps can use the microk8s system user
 
 # - not running on 14.04 as we have no real systemd here
-# - also exclude debian 10 because of old libseccomp (the system-usernames test
-#   is already checking which distributions have the needed support, so there's
-#   no need to replicate that code here)
-systems: [-ubuntu-14.04-*, -debian-10-*]
+# - also exclude debian 10 and centos 7 because of old libseccomp (the
+#   system-usernames test is already checking which distributions have the
+#   needed support, so there's no need to replicate that code here)
+systems: [-ubuntu-14.04-*, -debian-10-*, -centos-7-*]
 
 environment:
     STORE_DIR: $(pwd)/fake-store-blobdir


### PR DESCRIPTION
This test fails on centos 7 thusly:
```
Error: 2021-07-07 14:10:59 Error executing google:centos-7-64:tests/main/system-usernames-microk8s (jul071354-110681) :
-----
+ echo 'Try to install a snap which is not entitled to use the microk8s user'
Try to install a snap which is not entitled to use the microk8s user
++ snap install test-microk8s-username
++ true
+ OUT='error: cannot perform the following tasks:
- Mount snap "test-microk8s-username" (1) (snap "test-microk8s-username" system usernames require a snapd built against libseccomp >= 2.4)'
+ MATCH 'snap "test-microk8s-username" is not allowed to use the system user "snap_microk8s"'
+ echo 'error: cannot perform the following tasks:
- Mount snap "test-microk8s-username" (1) (snap "test-microk8s-username" system usernames require a snapd built against libseccomp >= 2.4)'
grep error: pattern not found, got:
error: cannot perform the following tasks:
- Mount snap "test-microk8s-username" (1) (snap "test-microk8s-username" system usernames require a snapd built against libseccomp >= 2.4)
-----
```
So we should disable it.