### PR TITLE
tests: fix test-snapd-user-service-sockets test removing snap

### DIFF
--- a/tests/main/snap-user-service-socket-activation/task.yaml
+++ b/tests/main/snap-user-service-socket-activation/task.yaml
@@ -15,6 +15,7 @@ prepare: |
     tests.session kill-leaked
 
 restore: |
+    snap remove test-snapd-user-service-sockets --purge
     tests.session -u test restore
     snap unset system experimental.user-daemons
 

--- a/tests/main/snap-user-service-socket-activation/task.yaml
+++ b/tests/main/snap-user-service-socket-activation/task.yaml
@@ -15,6 +15,7 @@ prepare: |
     tests.session kill-leaked
 
 restore: |
+    # Remove the snap before the tests.session is restored to make sure the socket is properly freed
     snap remove test-snapd-user-service-sockets --purge
     tests.session -u test restore
     snap unset system experimental.user-daemons


### PR DESCRIPTION
The test is failing when we executed twice in a row:
> spread -repeat 2 -debug
google:ubuntu-20.04-64:tests/main/test-snapd-user-service-sockets

The idea is to remove the snap before the user session is restore so the
socket is properly clean.
