### PR TITLE
o/assertstate: check for conflicts when refreshing and commiting validation set asserts

### DIFF
--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -1020,3 +1020,8 @@ func (p *Pool) ClearGroups() error {
 	p.curPhase = poolPhaseAdd
 	return nil
 }
+
+// Backstore returns the memory backstore of this pool.
+func (p *Pool) Backstore() Backstore {
+	return p.bs
+}

--- a/asserts/pool_test.go
+++ b/asserts/pool_test.go
@@ -1721,20 +1721,24 @@ func (s *poolSuite) TestBackstore(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.dev1Acct)
 	pool := asserts.NewPool(s.db, 64)
 
-	c.Assert(pool.AddUnresolved(s.rev1_1111.At(), "for_one"), IsNil)
+	at1111 := &asserts.AtRevision{
+		Ref:      asserts.Ref{Type: asserts.TestOnlyRevType, PrimaryKey: []string{"1111"}},
+		Revision: asserts.RevisionNotKnown,
+	}
+	c.Assert(pool.AddUnresolved(at1111, "for_one"), IsNil)
 	res, _, err := pool.ToResolve()
 	c.Assert(err, IsNil)
 	c.Assert(res, HasLen, 1)
 
 	// resolve (but do not commit)
-	ok, err := pool.Add(s.rev1_3333, asserts.MakePoolGrouping(0))
+	ok, err := pool.Add(s.rev1_1111, asserts.MakePoolGrouping(0))
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)
 
 	// the assertion should be available via pool's backstore
 	bs := pool.Backstore()
 	c.Assert(bs, NotNil)
-	a, err := bs.Get(s.rev1_3333.Type(), s.rev1_3333.At().PrimaryKey, s.rev1_3333.Type().MaxSupportedFormat())
+	a, err := bs.Get(s.rev1_1111.Type(), s.rev1_1111.At().PrimaryKey, s.rev1_1111.Type().MaxSupportedFormat())
 	c.Assert(err, IsNil)
 	c.Assert(a, NotNil)
 }

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -430,7 +430,7 @@ func RefreshValidationSetAssertions(s *state.State, userID int) error {
 
 	if err := bulkRefreshValidationSetAsserts(s, enforceModeSets, checkForConflicts, userID, deviceCtx); err != nil {
 		if _, ok := err.(*snapasserts.ValidationSetsConflictError); ok {
-			logger.Noticef("cannot refresh validation set assertions in enforce mode: %v", err)
+			logger.Noticef("cannot refresh to conflicting validation set assertions: %v", err)
 			return nil
 		}
 		return err

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -2656,7 +2656,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeConflict
 	c.Check(a.(*asserts.ValidationSet).Name(), Equals, "foo")
 	c.Check(a.Revision(), Equals, 1)
 
-	// new assertion wasn't commited to the database.
+	// new assertion wasn't committed to the database.
 	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
 		"account-id": s.dev1Acct.AccountID(),

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -880,13 +880,15 @@ func (s *assertMgrSuite) TestValidateSnapCrossCheckFail(c *C) {
 	c.Assert(chg.Err(), ErrorMatches, `(?s).*cannot install "f", snap "f" is undergoing a rename to "foo".*`)
 }
 
-func (s *assertMgrSuite) validationSetAssert(c *C, name, sequence, revision string) *asserts.ValidationSet {
+func (s *assertMgrSuite) validationSetAssert(c *C, name, sequence, revision string, snapPresence string) *asserts.ValidationSet {
 	snaps := []interface{}{map[string]interface{}{
 		"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 		"name":     "foo",
-		"presence": "required",
-		"revision": "1",
+		"presence": snapPresence,
 	}}
+	if snapPresence != "invalid" {
+		snaps[0].(map[string]interface{})["revision"] = "1"
+	}
 	headers := map[string]interface{}{
 		"series":       "16",
 		"account-id":   s.dev1Acct.AccountID(),
@@ -2164,10 +2166,10 @@ func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefresh(c *C) {
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
-	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3")
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	tr := assertstate.ValidationSetTracking{
@@ -2221,7 +2223,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsStoreError(c *C) {
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
 	tr := assertstate.ValidationSetTracking{
@@ -2250,10 +2252,10 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
-	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2")
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required")
 	err = s.storeSigning.Add(vsetAs2)
 	c.Assert(err, IsNil)
 
@@ -2283,7 +2285,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	})
 
 	// sequence changed in the store to 4
-	vsetAs3 := s.validationSetAssert(c, "bar", "4", "3")
+	vsetAs3 := s.validationSetAssert(c, "bar", "4", "3", "required")
 	err = s.storeSigning.Add(vsetAs3)
 	c.Assert(err, IsNil)
 
@@ -2335,10 +2337,10 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsPinned(c *C) {
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "2", "1")
+	vsetAs1 := s.validationSetAssert(c, "bar", "2", "1", "required")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
-	vsetAs2 := s.validationSetAssert(c, "bar", "2", "5")
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "5", "required")
 	err = s.storeSigning.Add(vsetAs2)
 	c.Assert(err, IsNil)
 
@@ -2370,7 +2372,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsPinned(c *C) {
 	})
 
 	// sequence changed in the store to 7
-	vsetAs3 := s.validationSetAssert(c, "bar", "7", "8")
+	vsetAs3 := s.validationSetAssert(c, "bar", "7", "8", "required")
 	err = s.storeSigning.Add(vsetAs3)
 	c.Assert(err, IsNil)
 
@@ -2412,13 +2414,13 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsLocalOnlyFailed(c *C)
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
 	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
-	vsetAs2 := s.validationSetAssert(c, "baz", "3", "1")
+	vsetAs2 := s.validationSetAssert(c, "baz", "3", "1", "required")
 	c.Assert(assertstate.Add(st, vsetAs2), IsNil)
 
 	// vset2 present and updated in the store
-	vsetAs2_2 := s.validationSetAssert(c, "baz", "3", "2")
+	vsetAs2_2 := s.validationSetAssert(c, "baz", "3", "2", "required")
 	err = s.storeSigning.Add(vsetAs2_2)
 	c.Assert(err, IsNil)
 
@@ -2470,6 +2472,204 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsLocalOnlyFailed(c *C)
 	c.Check(vs.Revision(), Equals, 2)
 }
 
+func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeHappyNotPinned(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err := s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	// store key already present
+	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+
+	vsetAs1 := s.validationSetAssert(c, "foo", "1", "1", "required")
+	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
+
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required")
+	c.Assert(assertstate.Add(s.state, vsetAs2), IsNil)
+
+	// in the store
+	vsetAs3 := s.validationSetAssert(c, "foo", "1", "2", "required")
+	c.Assert(s.storeSigning.Add(vsetAs3), IsNil)
+
+	vsetAs4 := s.validationSetAssert(c, "bar", "2", "3", "required")
+	c.Assert(s.storeSigning.Add(vsetAs4), IsNil)
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "foo",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+	tr = assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	c.Assert(err, IsNil)
+
+	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "foo",
+		"sequence":   "1",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.ValidationSet).Name(), Equals, "foo")
+	c.Check(a.Revision(), Equals, 2)
+
+	a, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "2",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.ValidationSet).Name(), Equals, "bar")
+	c.Check(a.(*asserts.ValidationSet).Sequence(), Equals, 2)
+	c.Check(a.Revision(), Equals, 3)
+
+	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
+		{"account", "account-key", "validation-set"},
+	})
+
+	// tracking current was updated
+	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
+	c.Check(tr.Current, Equals, 2)
+}
+
+func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeHappyPinned(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err := s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	// store key already present
+	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "2", "required")
+	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
+
+	// in the store
+	c.Assert(s.storeSigning.Add(vsetAs1), IsNil)
+
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required")
+	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  1,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	c.Assert(assertstate.RefreshValidationSetAssertions(s.state, 0), IsNil)
+
+	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "1",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.ValidationSet).Name(), Equals, "bar")
+	c.Check(a.(*asserts.ValidationSet).Sequence(), Equals, 1)
+	c.Check(a.Revision(), Equals, 2)
+
+	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
+		{"account", "account-key", "validation-set"},
+	})
+
+	// tracking current was updated
+	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
+	c.Check(tr.Current, Equals, 1)
+}
+
+func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeConflict(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err := s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	// store key already present
+	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+
+	vsetAs1 := s.validationSetAssert(c, "foo", "1", "1", "required")
+	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
+
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required")
+	c.Assert(assertstate.Add(s.state, vsetAs2), IsNil)
+
+	// in the store
+	vsetAs3 := s.validationSetAssert(c, "foo", "2", "2", "invalid")
+	c.Assert(s.storeSigning.Add(vsetAs3), IsNil)
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "foo",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+	tr = assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	c.Assert(err, ErrorMatches, `cannot refresh validation set assertions: validation sets are in conflict:\n- cannot constrain snap "foo" as both invalid .* and required at revision 1.*`)
+
+	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "foo",
+		"sequence":   "1",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.ValidationSet).Name(), Equals, "foo")
+	c.Check(a.Revision(), Equals, 1)
+
+	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "foo",
+		"sequence":   "2",
+	})
+	c.Assert(asserts.IsNotFound(err), Equals, true)
+
+	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
+		{"account", "account-key", "validation-set"},
+	})
+
+	// tracking current wasn't updated
+	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "foo", &tr), IsNil)
+	c.Check(tr.Current, Equals, 1)
+}
+
 func (s *assertMgrSuite) TestValidationSetAssertionForMonitorLocalFallbackForPinned(c *C) {
 	st := s.state
 
@@ -2484,7 +2684,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorLocalFallbackForPin
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
-	vsetAs := s.validationSetAssert(c, "bar", "1", "1")
+	vsetAs := s.validationSetAssert(c, "bar", "1", "1", "required")
 	c.Assert(assertstate.Add(st, vsetAs), IsNil)
 
 	opts := assertstate.ResolveOptions{AllowLocalFallback: true}
@@ -2508,11 +2708,11 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorPinnedRefreshedFrom
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
 	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
 
 	// newer revision available in the store
-	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2")
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0, nil)
@@ -2536,11 +2736,11 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorUnpinnedRefreshedFr
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
 	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
 
 	// newer assertion available in the store
-	vsetAs2 := s.validationSetAssert(c, "bar", "3", "1")
+	vsetAs2 := s.validationSetAssert(c, "bar", "3", "1", "required")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0, nil)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -2644,7 +2644,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeConflict
 	assertstate.UpdateValidationSet(s.state, &tr)
 
 	c.Assert(assertstate.RefreshValidationSetAssertions(s.state, 0), IsNil)
-	c.Assert(logbuf.String(), Matches, `.*cannot refresh validation set assertions in enforce mode: validation sets are in conflict:\n- cannot constrain snap "foo" as both invalid .* and required at revision 1.*\n`)
+	c.Assert(logbuf.String(), Matches, `.*cannot refresh to conflicting validation set assertions: validation sets are in conflict:\n- cannot constrain snap "foo" as both invalid .* and required at revision 1.*\n`)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",

--- a/overlord/assertstate/bulk.go
+++ b/overlord/assertstate/bulk.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -177,6 +178,10 @@ func bulkRefreshValidationSetAsserts(s *state.State, vsets map[string]*Validatio
 	err := resolvePoolNoFallback(s, pool, beforeCommitChecker, userID, deviceCtx)
 	if err == nil {
 		return nil
+	}
+
+	if _, ok := err.(*snapasserts.ValidationSetsConflictError); ok {
+		return err
 	}
 
 	if rerr, ok := err.(*resolvePoolError); ok {


### PR DESCRIPTION
Refresh validation sets in enforcing mode and check for conflicts before committing them to asserts db.