### PR TITLE
interfaces: make the service naming entirely internal to systemd BE

### DIFF
--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -111,14 +111,14 @@ func (iface *gpioInterface) SystemdConnectedSlot(spec *systemd.Specification, pl
 		return err
 	}
 
-	serviceAffix := fmt.Sprintf("gpio-%d", gpioNum)
+	serviceSuffix := fmt.Sprintf("gpio-%d", gpioNum)
 	service := &systemd.Service{
 		Type:            "oneshot",
 		RemainAfterExit: true,
 		ExecStart:       fmt.Sprintf("/bin/sh -c 'test -e /sys/class/gpio/gpio%d || echo %d > /sys/class/gpio/export'", gpioNum, gpioNum),
 		ExecStop:        fmt.Sprintf("/bin/sh -c 'test ! -e /sys/class/gpio/gpio%d || echo %d > /sys/class/gpio/unexport'", gpioNum, gpioNum),
 	}
-	return spec.AddService(serviceAffix, service)
+	return spec.AddService(serviceSuffix, service)
 }
 
 func (iface *gpioInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -111,14 +111,14 @@ func (iface *gpioInterface) SystemdConnectedSlot(spec *systemd.Specification, pl
 		return err
 	}
 
-	serviceName := interfaces.InterfaceServiceName(slot.Snap().InstanceName(), fmt.Sprintf("gpio-%d", gpioNum))
+	serviceAffix := fmt.Sprintf("gpio-%d", gpioNum)
 	service := &systemd.Service{
 		Type:            "oneshot",
 		RemainAfterExit: true,
 		ExecStart:       fmt.Sprintf("/bin/sh -c 'test -e /sys/class/gpio/gpio%d || echo %d > /sys/class/gpio/export'", gpioNum, gpioNum),
 		ExecStop:        fmt.Sprintf("/bin/sh -c 'test ! -e /sys/class/gpio/gpio%d || echo %d > /sys/class/gpio/unexport'", gpioNum, gpioNum),
 	}
-	return spec.AddService(serviceName, service)
+	return spec.AddService(serviceAffix, service)
 }
 
 func (iface *gpioInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -138,7 +138,7 @@ func (s *GpioInterfaceSuite) TestSystemdConnectedSlot(c *C) {
 	err := spec.AddConnectedSlot(s.iface, s.gadgetPlug, s.gadgetGpioSlot)
 	c.Assert(err, IsNil)
 	c.Assert(spec.Services(), DeepEquals, map[string]*systemd.Service{
-		"snap.my-device.interface.gpio-100.service": {
+		"gpio-100": {
 			Type:            "oneshot",
 			RemainAfterExit: true,
 			ExecStart:       `/bin/sh -c 'test -e /sys/class/gpio/gpio100 || echo 100 > /sys/class/gpio/export'`,

--- a/interfaces/builtin/pwm.go
+++ b/interfaces/builtin/pwm.go
@@ -118,14 +118,14 @@ func (iface *pwmInterface) SystemdConnectedSlot(spec *systemd.Specification, plu
 		return err
 	}
 
-	serviceAffix := fmt.Sprintf("pwmchip%d-pwm%d", chipNum, channel)
+	serviceSuffix := fmt.Sprintf("pwmchip%d-pwm%d", chipNum, channel)
 	service := &systemd.Service{
 		Type:            "oneshot",
 		RemainAfterExit: true,
 		ExecStart:       fmt.Sprintf("/bin/sh -c 'test -e /sys/class/pwm/pwmchip%[1]d/pwm%[2]d || echo %[2]d > /sys/class/pwm/pwmchip%[1]d/export'", chipNum, channel),
 		ExecStop:        fmt.Sprintf("/bin/sh -c 'test ! -e /sys/class/pwm/pwmchip%[1]d/pwm%[2]d || echo %[2]d > /sys/class/pwm/pwmchip%[1]d/unexport'", chipNum, channel),
 	}
-	return spec.AddService(serviceAffix, service)
+	return spec.AddService(serviceSuffix, service)
 }
 
 func (iface *pwmInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {

--- a/interfaces/builtin/pwm.go
+++ b/interfaces/builtin/pwm.go
@@ -118,14 +118,14 @@ func (iface *pwmInterface) SystemdConnectedSlot(spec *systemd.Specification, plu
 		return err
 	}
 
-	serviceName := interfaces.InterfaceServiceName(slot.Snap().InstanceName(), fmt.Sprintf("pwmchip%d-pwm%d", chipNum, channel))
+	serviceAffix := fmt.Sprintf("pwmchip%d-pwm%d", chipNum, channel)
 	service := &systemd.Service{
 		Type:            "oneshot",
 		RemainAfterExit: true,
 		ExecStart:       fmt.Sprintf("/bin/sh -c 'test -e /sys/class/pwm/pwmchip%[1]d/pwm%[2]d || echo %[2]d > /sys/class/pwm/pwmchip%[1]d/export'", chipNum, channel),
 		ExecStop:        fmt.Sprintf("/bin/sh -c 'test ! -e /sys/class/pwm/pwmchip%[1]d/pwm%[2]d || echo %[2]d > /sys/class/pwm/pwmchip%[1]d/unexport'", chipNum, channel),
 	}
-	return spec.AddService(serviceName, service)
+	return spec.AddService(serviceAffix, service)
 }
 
 func (iface *pwmInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {

--- a/interfaces/builtin/pwm_test.go
+++ b/interfaces/builtin/pwm_test.go
@@ -164,7 +164,7 @@ func (s *PwmInterfaceSuite) TestSystemdConnectedSlot(c *C) {
 	err := spec.AddConnectedSlot(s.iface, s.gadgetPlug, s.gadgetPwmSlot)
 	c.Assert(err, IsNil)
 	c.Assert(spec.Services(), DeepEquals, map[string]*systemd.Service{
-		"snap.my-device.interface.pwmchip10-pwm100.service": {
+		"pwmchip10-pwm100": {
 			Type:            "oneshot",
 			RemainAfterExit: true,
 			ExecStart:       `/bin/sh -c 'test -e /sys/class/pwm/pwmchip10/pwm100 || echo 100 > /sys/class/pwm/pwmchip10/export'`,

--- a/interfaces/naming.go
+++ b/interfaces/naming.go
@@ -28,7 +28,3 @@ import (
 func SecurityTagGlob(snapName string) string {
 	return snap.AppSecurityTag(snapName, "*")
 }
-
-func InterfaceServiceName(snapName, uniqueName string) string {
-	return snap.ScopedSecurityTag(snapName, "interface", uniqueName) + ".service"
-}

--- a/interfaces/naming_test.go
+++ b/interfaces/naming_test.go
@@ -32,7 +32,3 @@ var _ = Suite(&NamingSuite{})
 func (s *NamingSuite) TestSecurityTagGlob(c *C) {
 	c.Check(SecurityTagGlob("http"), Equals, "snap.http.*")
 }
-
-func (s *NamingSuite) TestInterfaceServiceName(c *C) {
-	c.Check(InterfaceServiceName("http", "helper"), Equals, "snap.http.interface.helper.service")
-}

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -36,8 +36,8 @@ import (
 	"github.com/snapcore/snapd/timings"
 )
 
-func serviceName(snapName, distinctServiceAffix string) string {
-	return snap.ScopedSecurityTag(snapName, "interface", distinctServiceAffix) + ".service"
+func serviceName(snapName, distinctServiceSuffix string) string {
+	return snap.ScopedSecurityTag(snapName, "interface", distinctServiceSuffix) + ".service"
 }
 
 // Backend is responsible for maintaining apparmor profiles for ubuntu-core-launcher.
@@ -165,8 +165,8 @@ func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]osutil.F
 		return nil
 	}
 	content := make(map[string]osutil.FileState)
-	for affix, service := range services {
-		filename := serviceName(snapInfo.InstanceName(), affix)
+	for suffix, service := range services {
+		filename := serviceName(snapInfo.InstanceName(), suffix)
 		content[filename] = &osutil.MemoryFileState{
 			Content: []byte(service.String()),
 			Mode:    0644,

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -81,7 +81,7 @@ func (s *backendSuite) TestInstallingSnapWritesStartsServices(c *C) {
 	defer r()
 
 	s.Iface.SystemdPermanentSlotCallback = func(spec *systemd.Specification, slot *snap.SlotInfo) error {
-		return spec.AddService("snap.samba.interface.foo.service", &systemd.Service{ExecStart: "/bin/true"})
+		return spec.AddService("foo", &systemd.Service{ExecStart: "/bin/true"})
 	}
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 1)
 	service := filepath.Join(dirs.SnapServicesDir, "snap.samba.interface.foo.service")
@@ -100,7 +100,7 @@ func (s *backendSuite) TestInstallingSnapWritesStartsServices(c *C) {
 
 func (s *backendSuite) TestRemovingSnapRemovesAndStopsServices(c *C) {
 	s.Iface.SystemdPermanentSlotCallback = func(spec *systemd.Specification, slot *snap.SlotInfo) error {
-		return spec.AddService("snap.samba.interface.foo.service", &systemd.Service{ExecStart: "/bin/true"})
+		return spec.AddService("foo", &systemd.Service{ExecStart: "/bin/true"})
 	}
 	for _, opts := range testedConfinementOpts {
 		snapInfo := s.InstallSnap(c, opts, "", ifacetest.SambaYamlV1, 1)
@@ -122,11 +122,11 @@ func (s *backendSuite) TestRemovingSnapRemovesAndStopsServices(c *C) {
 
 func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 	s.Iface.SystemdPermanentSlotCallback = func(spec *systemd.Specification, slot *snap.SlotInfo) error {
-		err := spec.AddService("snap.samba.interface.foo.service", &systemd.Service{ExecStart: "/bin/true"})
+		err := spec.AddService("foo", &systemd.Service{ExecStart: "/bin/true"})
 		if err != nil {
 			return err
 		}
-		return spec.AddService("snap.samba.interface.bar.service", &systemd.Service{ExecStart: "/bin/false"})
+		return spec.AddService("bar", &systemd.Service{ExecStart: "/bin/false"})
 	}
 	snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 1)
 	s.systemctlArgs = nil
@@ -140,7 +140,7 @@ func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 
 	// Change what the interface returns to simulate some useful change
 	s.Iface.SystemdPermanentSlotCallback = func(spec *systemd.Specification, slot *snap.SlotInfo) error {
-		return spec.AddService("snap.samba.interface.foo.service", &systemd.Service{ExecStart: "/bin/true"})
+		return spec.AddService("foo", &systemd.Service{ExecStart: "/bin/true"})
 	}
 	// Update over to the same snap to regenerate security
 	s.UpdateSnap(c, snapInfo, interfaces.ConfinementOptions{}, ifacetest.SambaYamlV1, 0)
@@ -170,7 +170,7 @@ func (s *backendSuite) TestInstallingSnapWhenPreseeding(c *C) {
 	defer r()
 
 	s.Iface.SystemdPermanentSlotCallback = func(spec *systemd.Specification, slot *snap.SlotInfo) error {
-		return spec.AddService("snap.samba.interface.foo.service", &systemd.Service{ExecStart: "/bin/true"})
+		return spec.AddService("foo", &systemd.Service{ExecStart: "/bin/true"})
 	}
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 1)
 	service := filepath.Join(dirs.SnapServicesDir, "snap.samba.interface.foo.service")
@@ -190,7 +190,7 @@ func (s *backendSuite) TestRemovingSnapWhenPreseeding(c *C) {
 	s.Backend.Initialize(opts)
 
 	s.Iface.SystemdPermanentSlotCallback = func(spec *systemd.Specification, slot *snap.SlotInfo) error {
-		return spec.AddService("snap.samba.interface.foo.service", &systemd.Service{ExecStart: "/bin/true"})
+		return spec.AddService("foo", &systemd.Service{ExecStart: "/bin/true"})
 	}
 	for _, opts := range testedConfinementOpts {
 		snapInfo := s.InstallSnap(c, opts, "", ifacetest.SambaYamlV1, 1)

--- a/interfaces/systemd/spec.go
+++ b/interfaces/systemd/spec.go
@@ -45,11 +45,11 @@ type Specification struct {
 // distinctServiceSuffix is used to name the service and needs to be unique.
 // Different interfaces should use different suffixes and different
 // plugs/slots should also use distinct ones.
-// Uniqueness across snaps is taken care implicitly elsewhere.
+// Uniqueness across snaps is taken care of implicitly elsewhere.
 func (spec *Specification) AddService(distinctServiceSuffix string, s *Service) error {
 	if old, ok := spec.services[distinctServiceSuffix]; ok && old != nil && s != nil && *old.svc != *s {
 		if old.iface == spec.curIface {
-			return fmt.Errorf("internal error: interface %q has incosistent system needs: service for %q used to be defined as %#v, now re-defined as %#v", spec.curIface, distinctServiceSuffix, *old.svc, *s)
+			return fmt.Errorf("internal error: interface %q has inconsistent system needs: service for %q used to be defined as %#v, now re-defined as %#v", spec.curIface, distinctServiceSuffix, *old.svc, *s)
 		} else {
 			return fmt.Errorf("internal error: interface %q and %q have conflicting system needs: service for %q used to be defined as %#v by %q, now re-defined as %#v", spec.curIface, old.iface, distinctServiceSuffix, *old.svc, old.iface, *s)
 		}

--- a/interfaces/systemd/spec.go
+++ b/interfaces/systemd/spec.go
@@ -45,6 +45,7 @@ type Specification struct {
 // distinctServiceSuffix is used to name the service and needs to be unique.
 // Different interfaces should use different suffixes and different
 // plugs/slots should also use distinct ones.
+// Uniqueness across snaps is taken care implicitly elsewhere.
 func (spec *Specification) AddService(distinctServiceSuffix string, s *Service) error {
 	if old, ok := spec.services[distinctServiceSuffix]; ok && old != nil && s != nil && *old.svc != *s {
 		if old.iface == spec.curIface {

--- a/interfaces/systemd/spec.go
+++ b/interfaces/systemd/spec.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -42,28 +42,28 @@ type Specification struct {
 }
 
 // AddService adds a new systemd service unit.
-// distinctServiceAffix is used to name the service and needs to be unique.
-// Different interfaces should use different affixes and different
+// distinctServiceSuffix is used to name the service and needs to be unique.
+// Different interfaces should use different suffixes and different
 // plugs/slots should also use distinct ones.
-func (spec *Specification) AddService(distinctServiceAffix string, s *Service) error {
-	if old, ok := spec.services[distinctServiceAffix]; ok && old != nil && s != nil && *old.svc != *s {
+func (spec *Specification) AddService(distinctServiceSuffix string, s *Service) error {
+	if old, ok := spec.services[distinctServiceSuffix]; ok && old != nil && s != nil && *old.svc != *s {
 		if old.iface == spec.curIface {
-			return fmt.Errorf("internal error: interface %q has incosistent system needs: service for %q used to be defined as %#v, now re-defined as %#v", spec.curIface, distinctServiceAffix, *old.svc, *s)
+			return fmt.Errorf("internal error: interface %q has incosistent system needs: service for %q used to be defined as %#v, now re-defined as %#v", spec.curIface, distinctServiceSuffix, *old.svc, *s)
 		} else {
-			return fmt.Errorf("internal error: interface %q and %q have conflicting system needs: service for %q used to be defined as %#v by %q, now re-defined as %#v", spec.curIface, old.iface, distinctServiceAffix, *old.svc, old.iface, *s)
+			return fmt.Errorf("internal error: interface %q and %q have conflicting system needs: service for %q used to be defined as %#v by %q, now re-defined as %#v", spec.curIface, old.iface, distinctServiceSuffix, *old.svc, old.iface, *s)
 		}
 	}
 	if spec.services == nil {
 		spec.services = make(map[string]*addedService)
 	}
-	spec.services[distinctServiceAffix] = &addedService{
+	spec.services[distinctServiceSuffix] = &addedService{
 		svc:   s,
 		iface: spec.curIface,
 	}
 	return nil
 }
 
-// Services returns a deep copy of all the added services keyed by their service affix.
+// Services returns a deep copy of all the added services keyed by their service suffix.
 func (spec *Specification) Services() map[string]*Service {
 	if spec.services == nil {
 		return nil

--- a/interfaces/systemd/spec.go
+++ b/interfaces/systemd/spec.go
@@ -63,7 +63,7 @@ func (spec *Specification) AddService(distinctServiceAffix string, s *Service) e
 	return nil
 }
 
-// Services returns a deep copy of all the added service keyed by their service affix.
+// Services returns a deep copy of all the added services keyed by their service affix.
 func (spec *Specification) Services() map[string]*Service {
 	if spec.services == nil {
 		return nil

--- a/interfaces/systemd/spec_test.go
+++ b/interfaces/systemd/spec_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/interfaces/systemd/spec_test.go
+++ b/interfaces/systemd/spec_test.go
@@ -73,7 +73,7 @@ plugs:
 
 	spec := systemd.Specification{}
 	err := spec.AddPermanentPlug(iface, info1.Plugs["plug1"])
-	c.Assert(err, ErrorMatches, `internal error: interface "test" has incosistent system needs: service for "foo" used to be defined as .*, now re-defined as .*`)
+	c.Assert(err, ErrorMatches, `internal error: interface "test" has inconsistent system needs: service for "foo" used to be defined as .*, now re-defined as .*`)
 }
 
 func (s *specSuite) TestClashingTwoIfaces(c *C) {

--- a/interfaces/systemd/spec_test.go
+++ b/interfaces/systemd/spec_test.go
@@ -20,9 +20,15 @@
 package systemd_test
 
 import (
+	"fmt"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/systemd"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 type specSuite struct{}
@@ -33,14 +39,14 @@ func (s *specSuite) TestAddService(c *C) {
 	spec := systemd.Specification{}
 	c.Assert(spec.Services(), IsNil)
 	svc1 := &systemd.Service{ExecStart: "one"}
-	err := spec.AddService("svc1.service", svc1)
+	err := spec.AddService("svc1", svc1)
 	c.Assert(err, IsNil)
 	svc2 := &systemd.Service{ExecStart: "two"}
-	err = spec.AddService("svc2.service", svc2)
+	err = spec.AddService("svc2", svc2)
 	c.Assert(err, IsNil)
 	c.Assert(spec.Services(), DeepEquals, map[string]*systemd.Service{
-		"svc1.service": svc1,
-		"svc2.service": svc2,
+		"svc1": svc1,
+		"svc2": svc2,
 	})
 }
 
@@ -48,18 +54,78 @@ func (s *specSuite) TestClashing(c *C) {
 	svc1 := &systemd.Service{ExecStart: "one"}
 	svc2 := &systemd.Service{ExecStart: "two"}
 	spec := systemd.Specification{}
-	err := spec.AddService("foo.service", svc1)
+	err := spec.AddService("foo", svc1)
 	c.Assert(err, IsNil)
-	err = spec.AddService("foo.service", svc2)
-	c.Assert(err, ErrorMatches, `interface requires conflicting system needs: service "foo.service" used to be defined as .*, now re-defined as .*`)
+	err = spec.AddService("foo", svc2)
+	c.Assert(err, ErrorMatches, `internal error: interface has conflicting system needs: service for "foo" used to be defined as .*, now re-defined as .*`)
 }
 
 func (s *specSuite) TestDifferentObjectsNotClashing(c *C) {
 	svc1 := &systemd.Service{ExecStart: "one and the same"}
 	svc2 := &systemd.Service{ExecStart: "one and the same"}
 	spec := systemd.Specification{}
-	err := spec.AddService("foo.service", svc1)
+	err := spec.AddService("foo", svc1)
 	c.Assert(err, IsNil)
-	err = spec.AddService("foo.service", svc2)
+	err = spec.AddService("foo", svc2)
 	c.Assert(err, IsNil)
+}
+
+func (s *specSuite) TestAddMethods(c *C) {
+	info1 := snaptest.MockInfo(c, `name: snap1
+version: 0
+plugs:
+    plug1:
+        interface: test
+`, nil)
+	info2 := snaptest.MockInfo(c, `name: snap2
+version: 0
+slots:
+    slot2:
+        interface: test
+`, nil)
+	plugInfo := info1.Plugs["plug1"]
+	plug := interfaces.NewConnectedPlug(plugInfo, nil, nil)
+	slotInfo := info2.Slots["slot2"]
+	slot := interfaces.NewConnectedSlot(slotInfo, nil, nil)
+
+	spec := systemd.Specification{}
+
+	iface := &ifacetest.TestInterface{
+		InterfaceName: "test",
+		SystemdConnectedPlugCallback: func(spec *systemd.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+			spec.AddService(fmt.Sprintf("%s-%s", plug.Name(), slot.Name()), &systemd.Service{ExecStart: "connected-plug"})
+			return nil
+		},
+		SystemdConnectedSlotCallback: func(spec *systemd.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+			spec.AddService(fmt.Sprintf("%s-%s", slot.Name(), plug.Name()), &systemd.Service{ExecStart: "connected-slot"})
+			return nil
+		},
+		SystemdPermanentPlugCallback: func(spec *systemd.Specification, plug *snap.PlugInfo) error {
+			spec.AddService(plug.Name, &systemd.Service{ExecStart: "permanent-plug"})
+			return nil
+		},
+		SystemdPermanentSlotCallback: func(spec *systemd.Specification, slot *snap.SlotInfo) error {
+			spec.AddService(slot.Name, &systemd.Service{ExecStart: "permanent-slot"})
+			return nil
+		},
+	}
+
+	err := spec.AddPermanentSlot(iface, slotInfo)
+	c.Assert(err, IsNil)
+
+	err = spec.AddPermanentPlug(iface, plugInfo)
+	c.Assert(err, IsNil)
+
+	err = spec.AddConnectedSlot(iface, plug, slot)
+	c.Assert(err, IsNil)
+
+	err = spec.AddConnectedPlug(iface, plug, slot)
+	c.Assert(err, IsNil)
+
+	c.Check(spec.Services(), DeepEquals, map[string]*systemd.Service{
+		"plug1-slot2": {ExecStart: "connected-plug"},
+		"slot2-plug1": {ExecStart: "connected-slot"},
+		"plug1":       {ExecStart: "permanent-plug"},
+		"slot2":       {ExecStart: "permanent-slot"},
+	})
 }


### PR DESCRIPTION
this is somewhat simpler for the callers and more consistent because
the systemd backend needs to control the naming pattern to allow
update/removal anyway

also produce slightly more informative clashing def internal errors
