### PR TITLE
tests/lib/reset.sh: add workaround from refresh-vs-services tests for all tests

### DIFF
--- a/tests/core/snapd-refresh-vs-services-reboots/task.yaml
+++ b/tests/core/snapd-refresh-vs-services-reboots/task.yaml
@@ -33,40 +33,6 @@ prepare: |
   tests.cleanup defer snap revert snapd --revision="$INITIAL_REV"
   snap version | MATCH 2.49.2
 
-restore: |
-  # We need special restore code here for the snapd snap because of the multiple
-  # variants of this test and existing subtle bugs in our restore code. The issue
-  # is that when we install a new revision of the snapd snap dangerously without
-  # store assertions, at the
-  # end of the test to ensure that other tests use the snapd version that we
-  # started with, we revert the snapd snap to the original revision without 
-  # triggering a garbage collection of the revisions we reverted away from (i.e.
-  # the new revisions we installed as part of this test execution). This is 
-  # problematic because it leaves those old revisions mounted at /snap/snapd/x2
-  # for example and now at the end of the test the active revision of snapd is 
-  # x1. Then during the next test execution that tries to install a dangerous 
-  # local revision of snapd, it will have lost any reference to the previous x2
-  # revision (since we clear state.json at the end of the test execution in 
-  # reset.sh), and now snapd is trying to install and make active x2 again, and
-  # it will copy all the right files, but when it comes time to mount the new x2
-  # revision of snapd, there will already be an existing active mount unit for 
-  # the previous revision at /snap/snapd/x2, and so the bits of code that try
-  # to mount the .snap file there will effectively just silently fail since the
-  # is already a snapd snap mounted there, it is just the wrong one mounted 
-  # there. 
-
-  # We remedy this here, temporarily, by first manually executing all cleanups
-  # that were deferred, since one of those deferred cleanups is likely the 
-  # revert to the previous revision of the snapd snap, and then we manually 
-  # remove all disabled revisions of the snapd snap - this manual removal will
-  # in fact unmount the mount units for /snap/snapd/x2 for example, avoiding the
-  # bug.
-
-  tests.cleanup restore
-  for rev in $(snap list snapd --all | grep disabled | awk '{print $3}'); do
-    snap remove snapd --revision="$rev"
-  done
-
 execute: |
   if ! os.query is-pc-amd64 && ! os.query is-arm; then
     echo "architecture not supported for this variant"

--- a/tests/core/snapd-refresh-vs-services/task.yaml
+++ b/tests/core/snapd-refresh-vs-services/task.yaml
@@ -37,40 +37,6 @@ prepare: |
   snap set system refresh.retain=5
   tests.cleanup defer snap unset system refresh.retain
 
-restore: |
-  # We need special restore code here for the snapd snap because of the multiple
-  # variants of this test and existing subtle bugs in our restore code. The issue
-  # is that when we install a new revision of the snapd snap dangerously without
-  # store assertions, at the
-  # end of the test to ensure that other tests use the snapd version that we
-  # started with, we revert the snapd snap to the original revision without 
-  # triggering a garbage collection of the revisions we reverted away from (i.e.
-  # the new revisions we installed as part of this test execution). This is 
-  # problematic because it leaves those old revisions mounted at /snap/snapd/x2
-  # for example and now at the end of the test the active revision of snapd is 
-  # x1. Then during the next test execution that tries to install a dangerous 
-  # local revision of snapd, it will have lost any reference to the previous x2
-  # revision (since we clear state.json at the end of the test execution in 
-  # reset.sh), and now snapd is trying to install and make active x2 again, and
-  # it will copy all the right files, but when it comes time to mount the new x2
-  # revision of snapd, there will already be an existing active mount unit for 
-  # the previous revision at /snap/snapd/x2, and so the bits of code that try
-  # to mount the .snap file there will effectively just silently fail since the
-  # is already a snapd snap mounted there, it is just the wrong one mounted 
-  # there. 
-
-  # We remedy this here, temporarily, by first manually executing all cleanups
-  # that were deferred, since one of those deferred cleanups is likely the 
-  # revert to the previous revision of the snapd snap, and then we manually 
-  # remove all disabled revisions of the snapd snap - this manual removal will
-  # in fact unmount the mount units for /snap/snapd/x2 for example, avoiding the
-  # bug.
-
-  tests.cleanup restore
-  for rev in $(snap list snapd --all | grep disabled | awk '{print $3}'); do
-    snap remove snapd --revision="$rev"
-  done
-
 execute: |
   # check if snapd 2.49.2 is the current latest/stable release as it simplifies
   # some of the logic below

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -182,6 +182,32 @@ reset_all_snap() {
 
 }
 
+# Before resetting all snapd state, specifically remove all disabled snaps that
+# are not from the store, since otherwise their revision number will remain
+# mounted at /snap/<name>/x<rev>/ and if we execute multiple tests that use this
+# same snap, the previous mount unit for x2 for example will stay around if we
+# simply revert to x1 and then delete state.json, since x2 is still mounted if
+# we then again install that snap again twice (i.e. to get to x2), the mount 
+# unit will still be active and thus the previous iteration of this snap at 
+# revision x2 will be used as this new revision's files for x2. This is 
+# particularly damaging for the snapd snap when we are installing different 
+# versions such as in the snapd-refresh-vs-services (and the -reboots variant) 
+# test, since the bug manifests as us trying to refresh to a particular revision
+# of snapd, but that revision is still mounted from the previous iteration of
+# the test and thus gets the wrong version, as displayed in this output:
+#
+# + snap install --dangerous snapd_2.49.1.snap
+# 2021-04-23T20:11:20Z INFO Waiting for automatic snapd restart...
+# snapd 2.49.2 installed
+#
+
+for snListLine in $(snap list --all | grep disabled); do
+    name="$(echo "$snListLine" | awk '{print $1}')"
+    rev="$(echo "$snListLine" | awk '{print $3}')"
+    snap remove "$name" --revision="$rev"
+done
+
+
 # When the variable REUSE_SNAPD is set to 1, we don't remove and purge snapd.
 # In that case we just cleanup the environment by removing installed snaps as
 # it is done for core systems.


### PR DESCRIPTION
This workaround for the tests/core/refresh-vs-services tests should be done
globally for all tests, since other tests may have the same problem of reusing
multiple unasserted revisions of the same snap but with different content in
the second (or later) revisions of the snap.