### PR TITLE
store: set ResponseHeaderTimeout on the default transport

### DIFF
--- a/httputil/client.go
+++ b/httputil/client.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 )
 
 // CertData contains the raw data of a certificate and the origin of
@@ -182,5 +183,14 @@ func NewHTTPClient(opts *ClientOptions) *http.Client {
 		},
 		Timeout:       opts.Timeout,
 		CheckRedirect: checkRedirect,
+	}
+}
+
+func MockResponseHeaderTimeout(d time.Duration) (restore func()) {
+	osutil.MustBeTestBinary("cannot mock ResponseHeaderTimeout outside of tests")
+	old := responseHeaderTimeout
+	responseHeaderTimeout = d
+	return func() {
+		responseHeaderTimeout = old
 	}
 }

--- a/httputil/transport.go
+++ b/httputil/transport.go
@@ -25,6 +25,7 @@ import (
 )
 
 var origDefaultTransport *http.Transport = http.DefaultTransport.(*http.Transport)
+var responseHeaderTimeout = 10 * time.Second
 
 // newDefaultTransport makes a fresh modifiable instance of Transport
 // with the same parameters as http.DefaultTransport.
@@ -37,5 +38,6 @@ func newDefaultTransport() *http.Transport {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: responseHeaderTimeout,
 	}
 }

--- a/httputil/transport.go
+++ b/httputil/transport.go
@@ -25,10 +25,11 @@ import (
 )
 
 var origDefaultTransport *http.Transport = http.DefaultTransport.(*http.Transport)
-var responseHeaderTimeout = 10 * time.Second
+var responseHeaderTimeout = 15 * time.Second
 
 // newDefaultTransport makes a fresh modifiable instance of Transport
-// with the same parameters as http.DefaultTransport.
+// with the same parameters as http.DefaultTransport but we also set
+// ResponseHeaderTimeout which is not set by default.
 func newDefaultTransport() *http.Transport {
 	// based on https://github.com/golang/go/blob/release-branch.go1.7/src/net/http/transport.go#L38
 	return &http.Transport{

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1043,7 +1043,7 @@ func (s *storeDownloadSuite) TestTransferSpeedMonitoringWriterUnhappy(c *C) {
 }
 
 func (s *storeDownloadSuite) TestDownloadTimeoutOnHeaders(c *C) {
-	restore := httputil.MockResponseHeaderTimeout(time.Second)
+	restore := httputil.MockResponseHeaderTimeout(250 * time.Millisecond)
 	defer restore()
 
 	var mockServer *httptest.Server

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1053,7 +1053,7 @@ func (s *storeDownloadSuite) TestDownloadTimeoutOnHeaders(c *C) {
 		// block the handler, do not send response headers.
 		select {
 		case <-quit:
-		case <-time.After(5 * time.Second):
+		case <-time.After(30 * time.Second):
 			// we expect to hit ResponseHeaderTimeout first
 			c.Fatalf("unexpected")
 		}

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -38,6 +38,7 @@ import (
 	"gopkg.in/retry.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/progress"
@@ -1039,4 +1040,37 @@ func (s *storeDownloadSuite) TestTransferSpeedMonitoringWriterUnhappy(c *C) {
 	terr, _ := store.IsTransferSpeedError(w.Err())
 	c.Assert(terr, Equals, true)
 	c.Check(w.Err(), ErrorMatches, "download too slow: .* bytes/sec")
+}
+
+func (s *storeDownloadSuite) TestDownloadTimeoutOnHeaders(c *C) {
+	restore := httputil.MockResponseHeaderTimeout(time.Second)
+	defer restore()
+
+	var mockServer *httptest.Server
+
+	quit := make(chan bool)
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// block the handler, do not send response headers.
+		select {
+		case <-quit:
+		case <-time.After(5 * time.Second):
+			// we expect to hit ResponseHeaderTimeout first
+			c.Fatalf("unexpected")
+		}
+		mockServer.CloseClientConnections()
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	snap := &snap.Info{}
+	snap.RealName = "foo"
+	snap.AnonDownloadURL = mockServer.URL
+	snap.DownloadURL = "AUTH-URL"
+	snap.Sha3_384 = "1234"
+	snap.Size = 50000
+
+	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
+	err := s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
+	close(quit)
+	c.Assert(err, ErrorMatches, `.*net/http: timeout awaiting response headers`)
 }


### PR DESCRIPTION
It appears that ResponseHeaderTimeout needs to be set explicitly, no headers response from the server doesn't seem to be covered by any other timeout. 

This should fix the download getting stuck issue.

For more context, see the stacktrace obtained from a system where download got stuck: https://pastebin.canonical.com/p/nZkRMTBbv3/
(the affected goroutine seems to be sitting inside for-select loop of  /usr/lib/go-1.10/src/net/http/transport.go:2033)

(to play with it comment out `ResponseHeaderTimeout: ...` from transport.go and modify test timeout from 5 * time.Second to a huge value and it should be stuck)