### PR TITLE
store/store_download.go: use system snap provided xdelta3 priority + fallback

### DIFF
--- a/store/export_test.go
+++ b/store/export_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os/exec"
 	"time"
 
 	"github.com/juju/ratelimit"
@@ -60,6 +61,14 @@ var (
 
 	Cancelled = cancelled
 )
+
+func MockSnapdtoolCommandFromSystemSnap(f func(name string, args ...string) (*exec.Cmd, error)) (restore func()) {
+	old := commandFromSystemSnap
+	commandFromSystemSnap = f
+	return func() {
+		commandFromSystemSnap = old
+	}
+}
 
 // MockDefaultRetryStrategy mocks the retry strategy used by several store requests
 func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
@@ -201,8 +210,8 @@ func (sto *Store) UseDeltas() bool {
 	return sto.useDeltas()
 }
 
-func (sto *Store) Xdelta3Cmd() string {
-	return sto.xdelta3CmdLocation
+func (sto *Store) Xdelta3Cmd(args ...string) *exec.Cmd {
+	return sto.xdelta3CmdFunc(args...)
 }
 
 func (cfg *Config) SetBaseURL(u *url.URL) error {

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -40,7 +40,6 @@ var (
 	ApiURL        = apiURL
 	Download      = download
 
-	UseDeltas  = useDeltas
 	ApplyDelta = applyDelta
 
 	AuthLocation      = authLocation
@@ -146,7 +145,7 @@ func MockDoDownloadReq(f func(ctx context.Context, storeURL *url.URL, cdnHeader 
 	}
 }
 
-func MockApplyDelta(f func(name string, deltaPath string, deltaInfo *snap.DeltaInfo, targetPath string, targetSha3_384 string) error) (restore func()) {
+func MockApplyDelta(f func(s *Store, name string, deltaPath string, deltaInfo *snap.DeltaInfo, targetPath string, targetSha3_384 string) error) (restore func()) {
 	origApplyDelta := applyDelta
 	applyDelta = f
 	return func() {
@@ -196,6 +195,14 @@ func (sto *Store) SessionUnlock() {
 
 func (sto *Store) FindFields() []string {
 	return sto.findFields
+}
+
+func (sto *Store) UseDeltas() bool {
+	return sto.useDeltas()
+}
+
+func (sto *Store) Xdelta3Cmd() string {
+	return sto.xdelta3CmdLocation
 }
 
 func (cfg *Config) SetBaseURL(u *url.URL) error {

--- a/store/store.go
+++ b/store/store.go
@@ -158,6 +158,12 @@ type Store struct {
 	proxyConnectHeader http.Header
 
 	userAgent string
+
+	xdeltaCheckLock sync.Mutex
+	// whether we should use deltas or not
+	shouldUseDeltas *bool
+	// which xdelta3 we picked when we checked the deltas
+	xdelta3CmdLocation string
 }
 
 var ErrTooManyRequests = errors.New("too many requests")

--- a/store/store.go
+++ b/store/store.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"strconv"
 	"strings"
@@ -163,7 +164,7 @@ type Store struct {
 	// whether we should use deltas or not
 	shouldUseDeltas *bool
 	// which xdelta3 we picked when we checked the deltas
-	xdelta3CmdLocation string
+	xdelta3CmdFunc func(args ...string) *exec.Cmd
 }
 
 var ErrTooManyRequests = errors.New("too many requests")

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -523,7 +523,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 		reqOptions.addHeader("Snap-Refresh-Reason", "scheduled")
 	}
 
-	if useDeltas() {
+	if s.useDeltas() {
 		logger.Debugf("Deltas enabled. Adding header Snap-Accept-Delta-Format: %v", s.deltaFormat)
 		reqOptions.addHeader("Snap-Accept-Delta-Format", s.deltaFormat)
 	}


### PR DESCRIPTION
Prefer using xdelta3 from the system snap if it is available and we are able to
run the config subcommand successfully. This ensures that we try to use a known
good xdelta3 command which should always work with what the store sends down,
but does still offer the fallback of using xdelta3 from the host system if for
some reason the xdelta3 command from the system snap becomes broken at some
point. In that case, attempt using the xdelta3 command from the host system,
performing the same config check before assuming that it is usable.

This has the effect that on older systems like Centos 7 and Amazon Linux 2,
where for example xdelta3 from the distro does not support LZMA, when a delta
generated using LZMA is encountered, we will first try the system snap provided
xdelta3 which should succeed.

We also cache the result of inspecting the available xdelta3 commands, to
prevent unnecessary commands.

Finally, log more messages, namely that if applying the delta fails, log the
error condition as a message so someone with log access can provide information
as well as log if we find an unsuitable xdelta3 somewhere (either from the
system snap, or from the host system). All of these should aid in debugging
future delta issues if they happen to crop up.

Marking as complex because retries are hard and the store download code is
also hard.