### PR TITLE
tests: drop any-python wrapper

### DIFF
--- a/tests/bin/any-python
+++ b/tests/bin/any-python
@@ -1,1 +1,0 @@
-../lib/tools/any-python

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -496,6 +496,7 @@ distro_get_package_extension() {
 
 pkg_dependencies_ubuntu_generic(){
     echo "
+        python3
         autoconf
         automake
         autotools-dev
@@ -656,6 +657,7 @@ pkg_dependencies_ubuntu_core(){
 
 pkg_dependencies_fedora(){
     echo "
+        python3
         clang
         curl
         dbus-x11
@@ -688,6 +690,7 @@ pkg_dependencies_fedora(){
 
 pkg_dependencies_amazon(){
     echo "
+        python3
         curl
         dbus-x11
         expect
@@ -715,6 +718,7 @@ pkg_dependencies_amazon(){
 
 pkg_dependencies_opensuse(){
     echo "
+        python3
         apparmor-profiles
         audit
         bash-completion

--- a/tests/lib/tools/README
+++ b/tests/lib/tools/README
@@ -89,7 +89,6 @@ subcommands dealing with system state:
   [done] fix -h help
 
 [done] apt-tool -> tests/lib/tools/apt-state
-  use any-python?
   [done] fix no args
   [done] fix to have -h
 

--- a/tests/lib/tools/memory-observe-do
+++ b/tests/lib/tools/memory-observe-do
@@ -1,4 +1,4 @@
-#!/usr/bin/env any-python
+#!/usr/bin/env python3
 from __future__ import print_function, absolute_import, unicode_literals
 
 import os

--- a/tests/lib/tools/mountinfo.query
+++ b/tests/lib/tools/mountinfo.query
@@ -1,4 +1,4 @@
-#!/usr/bin/env any-python
+#!/usr/bin/env python3
 from __future__ import print_function, absolute_import, unicode_literals
 
 from argparse import Action, ArgumentParser, FileType, RawTextHelpFormatter, SUPPRESS

--- a/tests/lib/tools/retry
+++ b/tests/lib/tools/retry
@@ -1,4 +1,4 @@
-#!/usr/bin/env any-python
+#!/usr/bin/env python3
 from __future__ import print_function, absolute_import, unicode_literals
 
 import argparse

--- a/tests/lib/tools/suite/tests.session/task.yaml
+++ b/tests/lib/tools/suite/tests.session/task.yaml
@@ -85,6 +85,6 @@ execute: |
         # The -p option can be used to know the PID of the started program.
         # This is different from the pid of tests.session as there's a session
         # manager overlooking the termination of PAM stack (internally we use runuser).
-        tests.session -u "$USER" -p /tmp/outer.pid exec "$(command -v any-python)" -c 'from __future__ import print_function; import os; print(os.getpid())' >/tmp/inner.pid
+        tests.session -u "$USER" -p /tmp/outer.pid exec python3 -c 'import os; print(os.getpid())' >/tmp/inner.pid
         test "$(cat /tmp/outer.pid)" = "$(cat /tmp/inner.pid)"
     done

--- a/tests/lib/tools/user-state
+++ b/tests/lib/tools/user-state
@@ -1,4 +1,4 @@
-#!/usr/bin/env any-python
+#!/usr/bin/env python3
 from __future__ import print_function, absolute_import, unicode_literals
 
 import argparse

--- a/tests/lib/tools/version-compare
+++ b/tests/lib/tools/version-compare
@@ -1,4 +1,4 @@
-#!/usr/bin/env any-python
+#!/usr/bin/env python3
 from __future__ import print_function, absolute_import, unicode_literals
 
 from argparse import Action, ArgumentParser, RawTextHelpFormatter, SUPPRESS


### PR DESCRIPTION
Python 3 should be available everywhere at this point. Try dropping the wrapper.
