### PR TITLE
tests/nested/cloud-init-{never-used,nocloud}-not-vuln: fix tests, use 2.45

### DIFF
--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -7,10 +7,14 @@ systems: [ubuntu-18.04-64, ubuntu-16.04-64]
 environment:
     # this test ensures that existing images without the fix are no longer
     # vulnerable after refreshing to a version of snapd with the fix
-    NESTED_BUILD_FROM_CURRENT/refresh: false
-    NESTED_BUILD_FROM_CURRENT/firstboot: true
+    NESTED_BUILD_SNAPD_FROM_CURRENT/refresh: false
+    NESTED_BUILD_SNAPD_FROM_CURRENT/firstboot: true
     NESTED_USE_CLOUD_INIT: false
-    NESTED_IMAGE_ID: cloud-init-never-$NESTED_BUILD_FROM_CURRENT
+    NESTED_IMAGE_ID: cloud-init-never-$NESTED_BUILD_SNAPD_FROM_CURRENT
+
+    # this test is only running on nested systems, so only amd64 for now
+    SNAPD_2_45_SNAPD_SNAP: https://storage.googleapis.com/snapd-spread-tests/snaps/snapd_2.45_7777.snap
+    SNAPD_2_45_CORE_SNAP: https://storage.googleapis.com/snapd-spread-tests/snaps/core_2.45_9289.snap
 
 prepare: |
     #shellcheck source=tests/lib/nested.sh
@@ -22,6 +26,27 @@ prepare: |
 
     # build the attacker cloud-init NoCloud cdrom drive
     nested_build_seed_cdrom "$TESTSLIB/cloud-init-seeds/attacker-user" seed2.iso cidata user-data meta-data
+
+    # if we are not building from current, then we need to seed the specific,
+    # old version of snapd that was vulnerable into the image to start there,
+    # otherwise we will start from stable or edge which already has the fix and
+    # thus this test would no longer be testing that old vulnerable devices 
+    # become safe after refreshing to the fix
+    if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "false" ]; then
+        snap install http --devmode # devmode so it can save to any dir
+
+        mkdir -p "$(nested_get_extra_snaps_path)"
+
+        if os.query is-xenial; then
+            # uc16 uses core snap
+            http --quiet --download --output core_2.45.snap GET "$SNAPD_2_45_CORE_SNAP"
+            cp core_2.45.snap "$(nested_get_extra_snaps_path)"
+        else 
+            # uc18 uses snapd snap
+            http --quiet --download --output snapd_2.45.snap GET "$SNAPD_2_45_SNAPD_SNAP"
+            cp snapd_2.45.snap "$(nested_get_extra_snaps_path)"
+        fi
+    fi
 
     tests.nested build-image core 
 
@@ -56,8 +81,8 @@ execute: |
     # if we are not building from current, then we need to prep the snapd snap
     # to install with the fix, this simulates/verifies that devices in the field
     # without the fix will actually be fixed after they refresh
-    if [ "$NESTED_BUILD_FROM_CURRENT" = "false" ]; then
-        if nested_is_core_16_system; then
+    if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "false" ]; then
+        if os.query is-xenial; then
             # build the core snap for this run
             repack_snapd_deb_into_core_snap "$PWD"
             tests.nested copy "$PWD/core-from-snapd-deb.snap"
@@ -96,12 +121,19 @@ execute: |
     tests.nested exec "cloud-init status --wait"
 
     echo "Waiting for snapd to react to cloud-init"
+    seen=0
     for i in $(seq 60); do
-        if tests.nested exec "journalctl --no-pager -u snapd" | MATCH "Cloud-init reported"; then
+        if tests.nested exec "sudo journalctl --no-pager -u snapd" | MATCH "cloud-init reported"; then
+            seen=1
             break
         fi
         sleep 1
     done
+
+    if [ "$seen" = "0" ]; then
+        echo "snapd did not restrict cloud-init, test failed"
+        exit 1
+    fi
 
     # ensure that snapd disabled cloud-init with the cloud-init.disabled file
     echo "Ensuring that snapd restricted cloud-init"

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -11,10 +11,14 @@ environment:
     NESTED_USE_CLOUD_INIT: false
     # this variant ensures that existing images without the fix are no longer
     # vulnerable after refreshing to a version of snapd with the fix
-    NESTED_BUILD_FROM_CURRENT/refresh: false
+    NESTED_BUILD_SNAPD_FROM_CURRENT/refresh: false
     # this variant ensures that new images with the fix are not vulnerable
-    NESTED_BUILD_FROM_CURRENT/firstboot: true
-    NESTED_IMAGE_ID: cloud-init-nocloud-$NESTED_BUILD_FROM_CURRENT
+    NESTED_BUILD_SNAPD_FROM_CURRENT/firstboot: true
+    NESTED_IMAGE_ID: cloud-init-nocloud-$NESTED_BUILD_SNAPD_FROM_CURRENT
+
+    # this test is only running on nested systems, so only amd64 for now
+    SNAPD_2_45_SNAPD_SNAP: https://storage.googleapis.com/snapd-spread-tests/snaps/snapd_2.45_7777.snap
+    SNAPD_2_45_CORE_SNAP: https://storage.googleapis.com/snapd-spread-tests/snaps/core_2.45_9289.snap
 
 prepare: |
     #shellcheck source=tests/lib/nested.sh
@@ -25,6 +29,27 @@ prepare: |
 
     # second boot - attacker drive
     nested_build_seed_cdrom "$TESTSLIB/cloud-init-seeds/attacker-user" seed2.iso cidata user-data meta-data
+
+    # if we are not building from current, then we need to seed the specific,
+    # old version of snapd that was vulnerable into the image to start there,
+    # otherwise we will start from stable or edge which already has the fix and
+    # thus this test would no longer be testing that old vulnerable devices 
+    # become safe after refreshing to the fix
+    if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "false" ]; then
+        snap install http --devmode # devmode so it can save to any dir
+
+        mkdir -p "$(nested_get_extra_snaps_path)"
+
+        if os.query is-xenial; then
+            # uc16 uses core snap
+            http --quiet --download --output core_2.45.snap GET "$SNAPD_2_45_CORE_SNAP"
+            cp core_2.45.snap "$(nested_get_extra_snaps_path)"
+        else 
+            # uc18 uses snapd snap
+            http --quiet --download --output snapd_2.45.snap GET "$SNAPD_2_45_SNAPD_SNAP"
+            cp snapd_2.45.snap "$(nested_get_extra_snaps_path)"
+        fi
+    fi
 
     tests.nested build-image core 
 
@@ -65,9 +90,9 @@ execute: |
     # if we are not building from current, then we need to prep the snapd snap
     # to install with the fix, this simulates/verifies that devices in the field
     # without the fix will actually be fixed after they refresh
-    if [ "$NESTED_BUILD_FROM_CURRENT" = "false" ]; then
+    if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "false" ]; then
         echo "Refreshing to a version of snapd with the fix"
-        if is_core_16_nested_system; then
+        if os.query is-xenial; then
             # build the core snap for this run
             repack_snapd_deb_into_core_snap "$PWD"
             tests.nested copy "$PWD/core-from-snapd-deb.snap"
@@ -103,12 +128,19 @@ execute: |
     tests.nested exec "cloud-init status --wait"
 
     echo "Waiting for snapd to react to cloud-init"
+    seen=0
     for i in $(seq 60); do
-        if tests.nested exec "journalctl --no-pager -u snapd" | MATCH "Cloud-init reported"; then
+        if tests.nested exec "sudo journalctl --no-pager -u snapd" | MATCH "cloud-init reported"; then
+            seen=1
             break
         fi
         sleep 1
     done
+
+    if [ "$seen" = "0" ]; then
+        echo "snapd did not restrict cloud-init, test failed"
+        exit 1
+    fi
 
     # ensure that snapd restricted cloud-init with the zzzz_snapd.cfg file
     echo "Ensuring that snapd restricted cloud-init"

--- a/tests/nested/manual/core20-gadget-cloud-conf/task.yaml
+++ b/tests/nested/manual/core20-gadget-cloud-conf/task.yaml
@@ -138,12 +138,19 @@ execute: |
   tests.nested exec_as normal-user ubuntu "sudo true"
 
   echo "Waiting for snapd to react to cloud-init"
+  seen=0
   for i in $(seq 60); do
-    if tests.nested exec "journalctl --no-pager -u snapd" | MATCH "Cloud-init reported"; then
-        break
-    fi
-    sleep 1
+      if tests.nested exec "sudo journalctl --no-pager -u snapd" | MATCH "cloud-init reported"; then
+          seen=1
+          break
+      fi
+      sleep 1
   done
+
+  if [ "$seen" = "0" ]; then
+      echo "snapd did not restrict cloud-init, test failed"
+      exit 1
+  fi
 
   echo "Ensuring that cloud-init got disabled after running"
   tests.nested exec "cloud-init status" | MATCH "status: disabled"

--- a/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
+++ b/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
@@ -140,12 +140,19 @@ execute: |
   # of this test
 
   echo "Waiting for snapd to react to cloud-init"
+  seen=0
   for i in $(seq 60); do
-    if tests.nested exec "journalctl --no-pager -u snapd" | MATCH "Cloud-init reported"; then
-        break
-    fi
-    sleep 1
+      if tests.nested exec "sudo journalctl --no-pager -u snapd" | MATCH "cloud-init reported"; then
+          seen=1
+          break
+      fi
+      sleep 1
   done
+
+  if [ "$seen" = "0" ]; then
+      echo "snapd did not restrict cloud-init, test failed"
+      exit 1
+  fi
 
   echo "Ensuring that cloud-init got disabled after running"
   tests.nested exec "cloud-init status" | MATCH "status: disabled"


### PR DESCRIPTION
Use snapd 2.45 as the baseline snapd version in the image that we build for the
refresh case, since this test variant is about old devices that were built 
before the fix was merged. 

Additionally, fix the environment variables which were subtly wrong (missing 
the _SNAPD_), and also replace the nested_is_core_16_system with the equivalent
os.query call.

Finally, fix the cloud-init journal check to actually fail if we don't see the
message after 60 seconds, and check for the right message (which is lower-case)

This should be thought of as a pre-requisite for https://github.com/snapcore/snapd/pull/10409, since
it fixes the tests which were causing some issues in the review there so that they are
in the right shape on master before we merge that PR, and can better reason about the
changes there with known good tests. The current state of these tests is a bit abysmal, they were
not really testing the right thing on the refresh variants, and it's unclear to me they were even 
testing the right thing on the firstboot variant, they were doing a test mainly of edge and not the
PR due to the wrong environment variable.