### PR TITLE
o/hookstate: allow snapctl refresh --proceed from snaps

### DIFF
--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -108,3 +108,11 @@ func MockCgroupSnapNameFromPid(f func(int) (string, error)) (restore func()) {
 		cgroupSnapNameFromPid = old
 	}
 }
+
+func MockAutoRefreshForGatingSnap(f func(st *state.State, gatingSnap string) error) (restore func()) {
+	old := autoRefreshForGatingSnap
+	autoRefreshForGatingSnap = f
+	return func() {
+		autoRefreshForGatingSnap = old
+	}
+}

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -246,6 +246,7 @@ func (c *refreshCommand) proceed() error {
 
 	// running outside of hook
 	if ctx.IsEphemeral() {
+		// TODO: consider having a permission via an interface for this before making this not experimental
 		st := ctx.State()
 		// we need to check if GateAutoRefreshHook feature is enabled when
 		// running by the snap (we don't need to do this when running from the


### PR DESCRIPTION
Allow snapctl refresh --proceed outside of hooks.