### PR TITLE
tests/lib/reset.sh: fix removing disabled snaps

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -201,10 +201,8 @@ reset_all_snap() {
 # snapd 2.49.2 installed
 #
 
-snap list --all | grep disabled | while read -r line ; do
-    name=$(echo "$line" | awk '{print $1}')
-    rev=$(echo "$line" | awk '{print $3}')
-    snap remove "$name" --revision="$rev"
+snap list --all | grep disabled | while read -r name _ revision _ ; do
+    snap remove "$name" --revision="$revision"
 done
 
 

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -201,9 +201,9 @@ reset_all_snap() {
 # snapd 2.49.2 installed
 #
 
-for snListLine in $(snap list --all | grep disabled); do
-    name="$(echo "$snListLine" | awk '{print $1}')"
-    rev="$(echo "$snListLine" | awk '{print $3}')"
+snap list --all | grep disabled | while read -r line ; do
+    name=$(echo "$line" | awk '{print $1}')
+    rev=$(echo "$line" | awk '{print $3}')
     snap remove "$name" --revision="$rev"
 done
 


### PR DESCRIPTION
This was actually not even parsing correctly, since each word in every line is
what we would loop over, not each line. Shell scripts, much like boulders, are
hard.

This is needed to make the snapd-failover, snapd-refresh-vs-services and 
snapd-refresh-vs-services-reboots tests more robust.