### PR TITLE
snap: change `snap login --help` to not mention "buy"

### DIFF
--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -45,8 +45,8 @@ credentials into the ~/.snap/auth.json file. Further communication with snapd
 will then be made using those credentials.
 
 It's not necessary to log in to interact with snapd. Doing so, however, enables
-purchasing of snaps using 'snap buy', as well as some some developer-oriented
-features as detailed in the help for the find, install and refresh commands.
+interactions without sudo, as well as some some developer-oriented features as
+detailed in the help for the find, install and refresh commands.
 
 An account can be set up at https://login.ubuntu.com
 `)


### PR DESCRIPTION
We mention the "snap buy" feature in our "snap login" output. We
currently do not support "buy" so it's best to remove this from
our docs.
