### PR TITLE
o/devicestate, sysconfig: refactor cloud-init config permission handling

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -989,7 +989,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitInDangerous(
 	})
 }
 
-func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitGadgetOnlyInSigned(c *C) {
+func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitGadgetAndSeedConfigSigned(c *C) {
 	// pretend we have a cloud-init config on the seed partition
 	cloudCfg := filepath.Join(boot.InitramfsUbuntuSeedDir, "data/etc/cloud/cloud.cfg.d")
 	err := os.MkdirAll(cloudCfg, 0755)
@@ -1008,18 +1008,18 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitGadgetOnlyIn
 
 	s.mockInstallModeChange(c, "signed", "")
 
-	// we didn't tell sysconfig about the ubuntu-seed cloud-init files, just
-	// the gadget ones
+	// sysconfig is told about both configs
 	c.Assert(s.ConfigureTargetSystemOptsPassed, DeepEquals, []*sysconfig.Options{
 		{
-			AllowCloudInit: true,
-			TargetRootDir:  boot.InstallHostWritableDir,
-			GadgetDir:      filepath.Join(dirs.SnapMountDir, "pc/1/"),
+			AllowCloudInit:  true,
+			TargetRootDir:   boot.InstallHostWritableDir,
+			GadgetDir:       filepath.Join(dirs.SnapMountDir, "pc/1/"),
+			CloudInitSrcDir: cloudCfg,
 		},
 	})
 }
 
-func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitBothGadgetAndUbuntuSeedInDangerous(c *C) {
+func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitBothGadgetAndUbuntuSeedDangerous(c *C) {
 	// pretend we have a cloud-init config on the seed partition
 	cloudCfg := filepath.Join(boot.InitramfsUbuntuSeedDir, "data/etc/cloud/cloud.cfg.d")
 	err := os.MkdirAll(cloudCfg, 0755)
@@ -1050,19 +1050,11 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeSupportsCloudInitBothGadgetAn
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeSignedNoUbuntuSeedCloudInit(c *C) {
-	// pretend we have a cloud-init config on the seed partition
-	cloudCfg := filepath.Join(boot.InitramfsUbuntuSeedDir, "data/etc/cloud/cloud.cfg.d")
-	err := os.MkdirAll(cloudCfg, 0755)
-	c.Assert(err, IsNil)
-	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {
-		err = ioutil.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
-		c.Assert(err, IsNil)
-	}
-
+	// pretend we have no cloud-init config anywhere
 	s.mockInstallModeChange(c, "signed", "")
 
-	// and did NOT tell sysconfig about the cloud-init file, but also did not
-	// explicitly disable cloud init
+	// we didn't pass any cloud-init src dir but still left cloud-init enabled
+	// if for example a CI-DATA USB drive was provided at runtime
 	c.Assert(s.ConfigureTargetSystemOptsPassed, DeepEquals, []*sysconfig.Options{
 		{
 			AllowCloudInit: true,
@@ -1095,7 +1087,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeSecuredGadgetCloudConfCloudIn
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeSecuredNoUbuntuSeedCloudInit(c *C) {
-	// pretend we have a cloud-init config on the seed partition
+	// pretend we have a cloud-init config on the seed partition with some files
 	cloudCfg := filepath.Join(boot.InitramfsUbuntuSeedDir, "data/etc/cloud/cloud.cfg.d")
 	err := os.MkdirAll(cloudCfg, 0755)
 	c.Assert(err, IsNil)
@@ -1109,13 +1101,15 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeSecuredNoUbuntuSeedCloudInit(
 	})
 	c.Assert(err, IsNil)
 
-	// and did NOT tell sysconfig about the cloud-init files, instead it was
-	// disabled because only gadget cloud-init is allowed
+	// we did tell sysconfig about the ubuntu-seed cloud config dir because it
+	// exists, but it is up to sysconfig to use the model to determine to ignore
+	// the files
 	c.Assert(s.ConfigureTargetSystemOptsPassed, DeepEquals, []*sysconfig.Options{
 		{
-			AllowCloudInit: false,
-			TargetRootDir:  boot.InstallHostWritableDir,
-			GadgetDir:      filepath.Join(dirs.SnapMountDir, "pc/1/"),
+			AllowCloudInit:  false,
+			TargetRootDir:   boot.InstallHostWritableDir,
+			GadgetDir:       filepath.Join(dirs.SnapMountDir, "pc/1/"),
+			CloudInitSrcDir: cloudCfg,
 		},
 	})
 }

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -144,7 +144,7 @@ func configureCloudInit(model *asserts.Model, opts *Options) (err error) {
 	// config from
 
 	// check if we should filter cloud-init config on ubuntu-seed, we do this
-	// for grade signed only (we don't allow any config for grade secued, and we
+	// for grade signed only (we don't allow any config for grade secured, and we
 	// allow any config on grade dangerous)
 
 	grade := model.Grade()

--- a/sysconfig/gadget_defaults_test.go
+++ b/sysconfig/gadget_defaults_test.go
@@ -56,6 +56,33 @@ var fakeModel = assertstest.FakeAssertion(map[string]interface{}{
 	"kernel":       "pc-kernel",
 }).(*asserts.Model)
 
+func fake20Model(grade string) *asserts.Model {
+	return assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        grade,
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "kernel",
+				"id":              "kerneldididididididididididididi",
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              "gadgetididididididididididididid",
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+		},
+	}).(*asserts.Model)
+}
+
 func (s *sysconfigSuite) TestGadgetDefaults(c *C) {
 	const gadgetDefaultsYaml = `
 defaults:

--- a/sysconfig/gadget_defaults_test.go
+++ b/sysconfig/gadget_defaults_test.go
@@ -83,6 +83,11 @@ func fake20Model(grade string) *asserts.Model {
 	}).(*asserts.Model)
 }
 
+func (s *sysconfigSuite) TestConfigureTargetSystemNonUC20(c *C) {
+	err := sysconfig.ConfigureTargetSystem(fakeModel, nil)
+	c.Assert(err, ErrorMatches, "internal error: ConfigureTargetSystem can only be used with a model with a grade")
+}
+
 func (s *sysconfigSuite) TestGadgetDefaults(c *C) {
 	const gadgetDefaultsYaml = `
 defaults:
@@ -116,7 +121,7 @@ defaults:
 	exists, _, _ := osutil.DirExists(journalPath)
 	c.Check(exists, Equals, false)
 
-	err := sysconfig.ConfigureTargetSystem(fakeModel, &sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(fake20Model("signed"), &sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 		GadgetDir:     snapInfo.MountDir(),
 	})
@@ -146,7 +151,7 @@ defaults:
 		{"meta/gadget.yaml", gadgetYaml + gadgetDefaultsYaml},
 	})
 
-	err := sysconfig.ConfigureTargetSystem(fakeModel, &sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(fake20Model("signed"), &sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 		GadgetDir:     snapInfo.MountDir(),
 	})
@@ -183,7 +188,7 @@ defaults:
 	exists, _, _ := osutil.DirExists(journalPath)
 	c.Check(exists, Equals, false)
 
-	err := sysconfig.ConfigureTargetSystem(fakeModel, &sysconfig.Options{
+	err := sysconfig.ConfigureTargetSystem(fake20Model("signed"), &sysconfig.Options{
 		TargetRootDir: boot.InstallHostWritableDir,
 		GadgetSnap:    snapContainer,
 	})

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -20,6 +20,7 @@
 package sysconfig
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/snapcore/snapd/asserts"
@@ -110,7 +111,13 @@ func ApplyFilesystemOnlyDefaults(model *asserts.Model, rootDir string, defaults 
 // cloud-init from the gadget).
 // It is okay to use both from install mode for run mode, as well as from the
 // initramfs for recover mode.
+// It is only meant to be used with models that have a grade (i.e. UC20+).
 func ConfigureTargetSystem(model *asserts.Model, opts *Options) error {
+	// check that we have a uc20 model
+	if model.Grade() == asserts.ModelGradeUnset {
+		return fmt.Errorf("internal error: ConfigureTargetSystem can only be used with a model with a grade")
+	}
+
 	if err := configureCloudInit(model, opts); err != nil {
 		return err
 	}

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -111,7 +111,7 @@ func ApplyFilesystemOnlyDefaults(model *asserts.Model, rootDir string, defaults 
 // It is okay to use both from install mode for run mode, as well as from the
 // initramfs for recover mode.
 func ConfigureTargetSystem(model *asserts.Model, opts *Options) error {
-	if err := configureCloudInit(opts); err != nil {
+	if err := configureCloudInit(model, opts); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Move more responsibility of handling cloud-init config permission handling to
sysconfig instead of devicestate since we now have access to the model in
ConfigureTargetSystem which we can use to get the model grade.

This also means we can refactor the functions which install cloud-init config
to be more straight forward and readable.

This is the first of a few PR's, it makes other PR's simpler and easier to review 
if I do this refactor first.