### PR TITLE
cmd/snap/model: support storage-safety and snaps headers too

### DIFF
--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -331,20 +331,14 @@ func (x *cmdModel) Execute(args []string) error {
 					}
 					// iterate over all keys in the map in a stable, visually
 					// appealing ordering
-					// first do snap name, which will always be present
-					name, ok := snMap["name"]
-					if !ok {
-						// TODO: more specific error ?
-						return invalidTypeErr
-					}
-					nameStr, ok := name.(string)
-					if !ok {
-						return invalidTypeErr
-					}
-					fmt.Fprintf(w, "  - name:\t%s\n", nameStr)
+					// first do snap name, which will always be present since we
+					// parsed a valid assertion
+					name := snMap["name"].(string)
+					fmt.Fprintf(w, "  - name:\t%s\n", name)
 
-					// the rest of these may be absent,
-					for _, snKey := range []string{"type", "default-channel", "id"} {
+					// the rest of these may be absent, but they are all still
+					// simple strings
+					for _, snKey := range []string{"id", "type", "default-channel", "presence"} {
 						snValue, ok := snMap[snKey]
 						if !ok {
 							continue
@@ -370,14 +364,17 @@ func (x *cmdModel) Execute(args []string) error {
 					if len(modesSlice) == 0 {
 						continue
 					}
-					fmt.Fprintf(w, "    modes:\n")
+
+					modeStrSlice := make([]string, 0, len(modesSlice))
 					for _, mode := range modesSlice {
 						modeStr, ok := mode.(string)
 						if !ok {
 							return invalidTypeErr
 						}
-						fmt.Fprintf(w, "      - %s\n", modeStr)
+						modeStrSlice = append(modeStrSlice, modeStr)
 					}
+					modesSliceYamlStr := "[" + strings.Join(modeStrSlice, ", ") + "]"
+					fmt.Fprintf(w, "    modes:\t%s\n", modesSliceYamlStr)
 				}
 
 			// long base64 key we can rewrap safely

--- a/cmd/snap/cmd_model_test.go
+++ b/cmd/snap/cmd_model_test.go
@@ -66,7 +66,8 @@ brand-id: testrootorg
 model: test-snapd-core-20-amd64
 architecture: amd64
 base: core20
-grade: secured
+storage-safety: prefer-encrypted
+grade: dangerous
 snaps:
   -
     default-channel: 20/edge
@@ -78,6 +79,12 @@ snaps:
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
+  -
+    name: app-snap
+    default-channel: foo
+    modes:
+      - recover
+      - run
   -
     default-channel: latest/stable
     id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
@@ -354,10 +361,11 @@ serial  serialserial
 			modelF:  simpleHappyResponder(happyUC20ModelAssertionResponse),
 			serialF: simpleHappyResponder(happySerialUC20AssertionResponse),
 			outText: `
-brand   MeMeMe (meuser*)
-model   test-snapd-core-20-amd64
-grade   secured
-serial  7777
+brand           MeMeMe (meuser*)
+model           test-snapd-core-20-amd64
+grade           dangerous
+storage-safety  prefer-encrypted
+serial          7777
 `[1:],
 		},
 		{
@@ -424,6 +432,52 @@ timestamp:       2017-07-27T00:00:00Z
 required-snaps:  
   - core
   - hello-world
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestModelVerboseUC20(c *check.C) {
+	s.RedirectClientToTestServer(
+		makeHappyTestServerHandler(
+			c,
+			simpleHappyResponder(happyUC20ModelAssertionResponse),
+			simpleHappyResponder(happySerialAssertionResponse),
+			simpleAssertionAccountResponder(happyAccountAssertionResponse),
+		))
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"model", "--verbose", "--abs-time"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, `
+brand-id:        testrootorg
+model:           test-snapd-core-20-amd64
+grade:           dangerous
+storage-safety:  prefer-encrypted
+serial:          serialserial
+architecture:    amd64
+base:            core20
+timestamp:       2018-09-11T22:00:00Z
+snaps:
+  - name:             pc
+    type:             gadget
+    default-channel:  20/edge
+    id:               UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+  - name:             pc-kernel
+    type:             kernel
+    default-channel:  20/edge
+    id:               pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+  - name:             app-snap
+    default-channel:  foo
+    modes:
+      - recover
+      - run
+  - name:             core20
+    type:             base
+    default-channel:  latest/stable
+    id:               DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
+  - name:             snapd
+    type:             snapd
+    default-channel:  latest/stable
+    id:               PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_model_test.go
+++ b/cmd/snap/cmd_model_test.go
@@ -82,6 +82,7 @@ snaps:
   -
     name: app-snap
     default-channel: foo
+    presence: optional
     modes:
       - recover
       - run
@@ -458,26 +459,25 @@ base:            core20
 timestamp:       2018-09-11T22:00:00Z
 snaps:
   - name:             pc
+    id:               UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
     type:             gadget
     default-channel:  20/edge
-    id:               UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
   - name:             pc-kernel
+    id:               pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     type:             kernel
     default-channel:  20/edge
-    id:               pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
   - name:             app-snap
     default-channel:  foo
-    modes:
-      - recover
-      - run
+    presence:         optional
+    modes:            [recover, run]
   - name:             core20
+    id:               DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
     type:             base
     default-channel:  latest/stable
-    id:               DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
   - name:             snapd
+    id:               PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     type:             snapd
     default-channel:  latest/stable
-    id:               PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }


### PR DESCRIPTION
The snaps header is only shown in verbose, while the storage-safety header is
shown in all modes when not empty.

To be honest, I'm not super satisfied with the modes header indention/formatting,
I tried a few different ways and I couldn't decide what looks best, so opinions 
welcome on this critical subject of how much whitespace to put in the output.