### PR TITLE
o/assertstate: Implement EnforcedValidationSets helper

### DIFF
--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -330,6 +330,8 @@ func delayedCrossMgrInit() {
 	snapstate.AutoRefreshAssertions = AutoRefreshAssertions
 	// hook retrieving auto-aliases into snapstate logic
 	snapstate.AutoAliases = AutoAliases
+	// hook the helper for getting enforced validation sets
+	snapstate.EnforcedValidationSets = EnforcedValidationSets
 }
 
 // AutoRefreshAssertions tries to refresh all assertions

--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -135,7 +135,7 @@ func ValidationSets(st *state.State) (map[string]*ValidationSetTracking, error) 
 }
 
 // EnforcedValidationSets returns ValidationSets object with all currently tracked
-// validation sets in enforcing mode.
+// validation sets that are in enforcing mode.
 func EnforcedValidationSets(st *state.State) (*snapasserts.ValidationSets, error) {
 	valsets, err := ValidationSets(st)
 	if err != nil {

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -249,7 +249,7 @@ func (s *validationSetTrackingSuite) TestEnforcedValidationSets(c *C) {
 	valsets, err := assertstate.EnforcedValidationSets(s.st)
 	c.Assert(err, IsNil)
 
-	// foo and bar are in conflict, use this is an indirect way of checking
+	// foo and bar are in conflict, use this as an indirect way of checking
 	// that both were added to valsets.
 	err = valsets.Conflict()
 	c.Check(err, ErrorMatches, `validation sets are in conflict:\n- cannot constrain snap "snap-b" as both invalid \(.*/bar\) and required at any revision \(.*/foo\)`)

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -22,18 +22,47 @@ package assertstate_test
 import (
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
 type validationSetTrackingSuite struct {
 	st *state.State
+	//storeSigning *assertstest.StoreStack
+	dev1Signing *assertstest.SigningDB
+	dev1acct    *asserts.Account
 }
 
 var _ = Suite(&validationSetTrackingSuite{})
 
 func (s *validationSetTrackingSuite) SetUpTest(c *C) {
 	s.st = state.New(nil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+	storeSigning := assertstest.NewStoreStack("can0nical", nil)
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   storeSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(db.Add(storeSigning.StoreAccountKey("")), IsNil)
+	assertstate.ReplaceDB(s.st, db)
+
+	s.dev1acct = assertstest.NewAccount(storeSigning, "developer1", nil, "")
+	c.Assert(storeSigning.Add(s.dev1acct), IsNil)
+
+	dev1PrivKey, _ = assertstest.GenerateKey(752)
+	acct1Key := assertstest.NewAccountKey(storeSigning, s.dev1acct, nil, dev1PrivKey.PublicKey(), "")
+
+	assertstatetest.AddMany(s.st, storeSigning.StoreAccountKey(""), s.dev1acct, acct1Key)
+
+	s.dev1Signing = assertstest.NewSigningDB(s.dev1acct.AccountID(), dev1PrivKey)
+	c.Check(s.dev1Signing, NotNil)
+	c.Assert(storeSigning.Add(acct1Key), IsNil)
 }
 
 func (s *validationSetTrackingSuite) TestUpdate(c *C) {
@@ -156,4 +185,72 @@ func (s *validationSetTrackingSuite) TestGet(c *C) {
 	// non-existing
 	err = assertstate.GetValidationSet(s.st, "foo", "baz", &res)
 	c.Assert(err, Equals, state.ErrNoState)
+}
+
+func (s *validationSetTrackingSuite) mockAssert(c *C, name, sequence, presence string) asserts.Assertion {
+	snaps := []interface{}{map[string]interface{}{
+		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzz",
+		"name":     "snap-b",
+		"presence": presence,
+	}}
+	headers := map[string]interface{}{
+		"authority-id": s.dev1acct.AccountID(),
+		"account-id":   s.dev1acct.AccountID(),
+		"name":         name,
+		"series":       "16",
+		"sequence":     sequence,
+		"revision":     "5",
+		"timestamp":    "2030-11-06T09:16:26Z",
+		"snaps":        snaps,
+	}
+	as, err := s.dev1Signing.Sign(asserts.ValidationSetType, headers, nil, "")
+	c.Assert(err, IsNil)
+	return as
+}
+
+func (s *validationSetTrackingSuite) TestEnforcedValidationSets(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "foo",
+		Mode:      assertstate.Enforce,
+		Current:   2,
+	}
+	assertstate.UpdateValidationSet(s.st, &tr)
+
+	tr = assertstate.ValidationSetTracking{
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  1,
+		Current:   3,
+	}
+	assertstate.UpdateValidationSet(s.st, &tr)
+
+	tr = assertstate.ValidationSetTracking{
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "baz",
+		Mode:      assertstate.Monitor,
+		Current:   5,
+	}
+	assertstate.UpdateValidationSet(s.st, &tr)
+
+	vs1 := s.mockAssert(c, "foo", "2", "required")
+	c.Assert(assertstate.Add(s.st, vs1), IsNil)
+
+	vs2 := s.mockAssert(c, "bar", "1", "invalid")
+	c.Assert(assertstate.Add(s.st, vs2), IsNil)
+
+	vs3 := s.mockAssert(c, "baz", "5", "invalid")
+	c.Assert(assertstate.Add(s.st, vs3), IsNil)
+
+	valsets, err := assertstate.EnforcedValidationSets(s.st)
+	c.Assert(err, IsNil)
+
+	// foo and bar are in conflict, use this is an indirect way of checking
+	// that both were added to valsets.
+	err = valsets.Conflict()
+	c.Check(err, ErrorMatches, `validation sets are in conflict:\n- cannot constrain snap "snap-b" as both invalid \(.*/bar\) and required at any revision \(.*/foo\)`)
 }

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -251,6 +251,7 @@ func (s *validationSetTrackingSuite) TestEnforcedValidationSets(c *C) {
 
 	// foo and bar are in conflict, use this as an indirect way of checking
 	// that both were added to valsets.
+	// XXX: switch to CheckPresenceInvalid / CheckPresenceRequired once available.
 	err = valsets.Conflict()
 	c.Check(err, ErrorMatches, `validation sets are in conflict:\n- cannot constrain snap "snap-b" as both invalid \(.*/bar\) and required at any revision \(.*/foo\)`)
 }

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -35,6 +35,9 @@ import (
 
 var currentSnaps = currentSnapsImpl
 
+// EnforcedValidationSets allows to hook getting of validation sets in enforce
+// mode into installation/refresh/removal of snaps. It gets hooked from
+// assertstate.
 var EnforcedValidationSets func(st *state.State) (*snapasserts.ValidationSets, error)
 
 func userIDForSnap(st *state.State, snapst *SnapState, fallbackUserID int) (int, error) {

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
@@ -33,6 +34,8 @@ import (
 )
 
 var currentSnaps = currentSnapsImpl
+
+var EnforcedValidationSets func(st *state.State) (*snapasserts.ValidationSets, error)
 
 func userIDForSnap(st *state.State, snapst *SnapState, fallbackUserID int) (int, error) {
 	userID := snapst.UserID


### PR DESCRIPTION
Implement a helper for getting ValidationSets object for all currently tracked validation sets in Enforce mode.
