### PR TITLE
cmd/snap-confine: handle CURRENT_TAGS on systems that support it

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -270,7 +270,7 @@ snap_confine_snap_confine_STATIC =
 # all external libraries, this way it can be reused in
 # snap_confine_snap_confine_debug_LDADD withouth applying any text
 # transformations
-snap_confine_snap_confine_extra_libs = $(LIBUDEV_LIBS)
+snap_confine_snap_confine_extra_libs = $(LIBUDEV_LIBS) -ldl
 
 if STATIC_LIBCAP
 snap_confine_snap_confine_STATIC += -lcap

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -24,6 +24,7 @@
 #include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <dlfcn.h>
 
 #include <libudev.h>
 
@@ -172,72 +173,50 @@ static void sc_udev_allow_dev_net_tun(int devices_allow_fd)
  * tags corresponding to snap applications. Here we interrogate udev and allow
  * access to all assigned devices.
  **/
-static void sc_udev_allow_assigned(int devices_allow_fd, struct udev *udev,
-				   struct udev_list_entry *assigned)
+static void sc_udev_allow_assigned_device(int devices_allow_fd,
+					  struct udev_device *device)
 {
-	for (struct udev_list_entry * entry = assigned; entry != NULL;
-	     entry = udev_list_entry_get_next(entry)) {
-		const char *path = udev_list_entry_get_name(entry);
-		if (path == NULL) {
-			die("udev_list_entry_get_name failed");
-		}
-		struct udev_device *device =
-		    udev_device_new_from_syspath(udev, path);
-		/** This is a non-fatal error as devices can disappear asynchronously
-		 * and on slow devices we may indeed observe a device that no longer
-		 * exists.
-		 *
-		 * Similar debug + continue pattern repeats in all the udev calls in
-		 * this function. Related to LP: #1881209 */
-		if (device == NULL) {
-			debug("cannot find device from syspath %s", path);
-			continue;
-		}
-		dev_t devnum = udev_device_get_devnum(device);
-		unsigned int major = major(devnum);
-		unsigned int minor = minor(devnum);
-		/* The manual page of udev_device_get_devnum says:
-		 * > On success, udev_device_get_devnum() returns the device type of
-		 * > the passed device. On failure, a device type with minor and major
-		 * > number set to 0 is returned. */
-		if (major == 0 && minor == 0) {
-			debug("cannot get major/minor numbers for syspath %s",
-			      path);
-			continue;
-		}
-		/* devnode is bound to the lifetime of the device and we cannot release
-		 * it separately. */
-		const char *devnode = udev_device_get_devnode(device);
-		if (devnode == NULL) {
-			debug("cannot find /dev node from udev device");
-			continue;
-		}
-		debug("inspecting type of device: %s", devnode);
-		struct stat file_info;
-		if (stat(devnode, &file_info) < 0) {
-			debug("cannot stat %s", devnode);
-			continue;
-		}
-		switch (file_info.st_mode & S_IFMT) {
-		case S_IFBLK:
-			dprintf(devices_allow_fd, "b %u:%u rwm\n", major,
-				minor);
-			break;
-		case S_IFCHR:
-			dprintf(devices_allow_fd, "c %u:%u rwm\n", major,
-				minor);
-			break;
-		default:
-			/* Not a device, ignore it. */
-			break;
-		}
-		udev_device_unref(device);
+	const char *path = udev_device_get_syspath(device);
+	dev_t devnum = udev_device_get_devnum(device);
+	unsigned int major = major(devnum);
+	unsigned int minor = minor(devnum);
+	/* The manual page of udev_device_get_devnum says:
+	 * > On success, udev_device_get_devnum() returns the device type of
+	 * > the passed device. On failure, a device type with minor and major
+	 * > number set to 0 is returned. */
+	if (major == 0 && minor == 0) {
+		debug("cannot get major/minor numbers for syspath %s", path);
+		return;
+	}
+	/* devnode is bound to the lifetime of the device and we cannot release
+	 * it separately. */
+	const char *devnode = udev_device_get_devnode(device);
+	if (devnode == NULL) {
+		debug("cannot find /dev node from udev device");
+		return;
+	}
+	debug("inspecting type of device: %s", devnode);
+	struct stat file_info;
+	if (stat(devnode, &file_info) < 0) {
+		debug("cannot stat %s", devnode);
+		return;
+	}
+	switch (file_info.st_mode & S_IFMT) {
+	case S_IFBLK:
+		dprintf(devices_allow_fd, "b %u:%u rwm\n", major, minor);
+		break;
+	case S_IFCHR:
+		dprintf(devices_allow_fd, "c %u:%u rwm\n", major, minor);
+		break;
+	default:
+		/* Not a device, ignore it. */
+		break;
 	}
 }
 
-static void sc_udev_setup_acls(int devices_allow_fd, int devices_deny_fd,
-			       struct udev *udev,
-			       struct udev_list_entry *assigned)
+static void sc_udev_setup_acls_common(int devices_allow_fd, int devices_deny_fd,
+				      struct udev *udev,
+				      struct udev_list_entry *assigned)
 {
 	/* Deny device access by default.
 	 *
@@ -253,7 +232,6 @@ static void sc_udev_setup_acls(int devices_allow_fd, int devices_deny_fd,
 	sc_udev_allow_nvidia(devices_allow_fd);
 	sc_udev_allow_uhid(devices_allow_fd);
 	sc_udev_allow_dev_net_tun(devices_allow_fd);
-	sc_udev_allow_assigned(devices_allow_fd, udev, assigned);
 }
 
 static char *sc_security_to_udev_tag(const char *security_tag)
@@ -386,6 +364,31 @@ static void sc_cleanup_cgroup_fds(sc_cgroup_fds * fds)
 	}
 }
 
+/* __sc_udev_device_has_current_tag will be filled at runtime if the libudev has
+ * this symbol */
+static int (*__sc_udev_device_has_current_tag)(struct udev_device * udev_device,
+					       const char *tag) = NULL;
+
+static void setup_current_tags_support(void)
+{
+	void *lib = dlopen("libudev.so.1", RTLD_NOW);
+	if (lib == NULL) {
+		debug("cannot load libudev.so.1: %s", dlerror());
+		/* bit unexpected as we use the library from the host and it's stable */
+		return;
+	}
+	/* check whether we have the symbol introduced in systemd v247 to inspect
+	 * the CURRENT_TAGS property */
+	void *sym = dlsym(lib, "udev_device_has_current_tag");
+	if (sym == NULL) {
+		debug("cannot find current tags symbol: %s", dlerror());
+		/* symbol is not found in the library version */
+		return;
+	}
+	debug("libudev has current tags support");
+	__sc_udev_device_has_current_tag = sym;
+}
+
 void sc_setup_device_cgroup(const char *security_tag)
 {
 	debug("setting up device cgroup");
@@ -394,6 +397,8 @@ void sc_setup_device_cgroup(const char *security_tag)
 		 * rounds of iteration. */
 		return;
 	}
+
+	setup_current_tags_support();
 
 	/* Derive the udev tag from the snap security tag.
 	 *
@@ -443,9 +448,40 @@ void sc_setup_device_cgroup(const char *security_tag)
 		return;
 	}
 	/* Setup the device group access control list */
-	sc_udev_setup_acls(fds.devices_allow_fd, fds.devices_deny_fd,
-			   udev, assigned);
+	sc_udev_setup_acls_common(fds.devices_allow_fd, fds.devices_deny_fd,
+				  udev, assigned);
+	for (struct udev_list_entry * entry = assigned; entry != NULL;
+	     entry = udev_list_entry_get_next(entry)) {
+		const char *path = udev_list_entry_get_name(entry);
+		if (path == NULL) {
+			die("udev_list_entry_get_name failed");
+		}
+		struct udev_device *device =
+		    udev_device_new_from_syspath(udev, path);
+		/** This is a non-fatal error as devices can disappear asynchronously
+		 * and on slow devices we may indeed observe a device that no longer
+		 * exists.
+		 *
+		 * Similar debug + continue pattern repeats in all the udev calls in
+		 * this function. Related to LP: #1881209 */
+		if (device == NULL) {
+			debug("cannot find device from syspath %s", path);
+			continue;
+		}
+		if (__sc_udev_device_has_current_tag != NULL) {
+			if (__sc_udev_device_has_current_tag
+			    (device, udev_tag) <= 0) {
+				debug("device %s has no matching current tag",
+				      path);
+				udev_device_unref(device);
+				continue;
+			}
+			debug("device %s has matching current tag", path);
+		}
 
+		sc_udev_allow_assigned_device(fds.devices_allow_fd, device);
+		udev_device_unref(device);
+	}
 	/* Move ourselves to the device cgroup */
 	sc_dprintf(fds.cgroup_procs_fd, "%i\n", getpid());
 	debug("associated snap application process %i with device cgroup %s",

--- a/tests/main/security-device-cgroups-serial-port/task.yaml
+++ b/tests/main/security-device-cgroups-serial-port/task.yaml
@@ -16,58 +16,59 @@ restore: |
         rm -f /dev/ttyS4 /dev/ttyS4.spread
     fi
 
+    systemctl restart systemd-udevd
     udevadm control --reload-rules
     udevadm trigger
 
 execute: |
-    if [ "$SPREAD_REBOOT" = 0 ]; then
-        echo "Given a snap is installed"
-        "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+    echo "Given a snap is installed"
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
-        echo "Then the device is not assigned to that snap"
-        if udevadm info /dev/ttyS4 > info.txt; then
-        NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh" < info.txt
-        else
-            echo "No hardware for node /dev/ttyS4"
-            exit 0
-        fi
-
-        echo "And the device is not shown in the snap device list"
-        # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
-        if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
-        NOMATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-        fi
-
-        echo "When a udev rule assigning the device to the snap is added"
-        content="SUBSYSTEM==\"tty\", KERNEL==\"ttyS4\", TAG+=\"snap_test-snapd-sh_sh\""
-        echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
-        udevadm control --reload-rules
-        udevadm settle
-        udevadm trigger
-        udevadm settle
-
-        echo "Then the device is shown as assigned to the snap"
-        udevadm info /dev/ttyS4 | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-        # CURRENT_TAGS just available on systemd 247+
-        if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
-            udevadm info /dev/ttyS4 | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
-        fi
-
-        echo "When a snap command is called"
-        test-snapd-sh.sh -c 'true'
-
-        echo "Then the device is shown in the snap device list"
-        MATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-        echo "Once the snap is removed, the current tags are automatically removed"
-        snap remove test-snapd-sh
-        udevadm info /dev/ttyS4 | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
-        test ! -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
-
-        # Reboot needed just on systemd 247+
-        if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
-            REBOOT
-        fi
+    echo "Then the device is not assigned to that snap"
+    if udevadm info /dev/ttyS4 > info.txt; then
+    NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh" < info.txt
+    else
+        echo "No hardware for node /dev/ttyS4"
+        exit 0
     fi
 
-    udevadm info /dev/ttyS4 | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    echo "And the device is not shown in the snap device list"
+    # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
+    if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
+    NOMATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+    fi
+
+    echo "When a udev rule assigning the device to the snap is added"
+    content="SUBSYSTEM==\"tty\", KERNEL==\"ttyS4\", TAG+=\"snap_test-snapd-sh_sh\""
+    echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+    udevadm control --reload-rules
+    udevadm settle
+    udevadm trigger
+    udevadm settle
+
+    echo "Then the device is shown as assigned to the snap"
+    udevadm info /dev/ttyS4 | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    # CURRENT_TAGS just available on systemd 247+
+    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+        udevadm info /dev/ttyS4 | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+    fi
+
+    echo "When a snap command is called"
+    test-snapd-sh.sh -c 'true'
+
+    echo "Then the device is shown in the snap device list"
+    MATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+    echo "Once the snap is removed, the current tags are automatically removed"
+    snap remove test-snapd-sh
+    udevadm info /dev/ttyS4 | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+    test ! -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+
+    # Reboot needed just on systemd 247+
+    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+        # with systemd versions 247+, the TAGS are sticky, but CURRENT_TAGS has
+        # been updated updated and checked
+        udevadm info /dev/ttyS4 | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    else
+        udevadm info /dev/ttyS4 | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    fi

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -69,6 +69,7 @@ restore: |
 
     if [ -e /etc/udev/rules.d/70-snap.test-snapd-sh.rules ]; then
         rm /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+        systemctl restart systemd-udevd
         udevadm control --reload-rules
         udevadm trigger
     fi
@@ -80,68 +81,67 @@ execute: |
         exit 0
     fi
 
-    if [ "$SPREAD_REBOOT" = 0 ]; then
-        echo "Given a snap is installed"
-        "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+    echo "Given a snap is installed"
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
-        echo "Then the device is not assigned to that snap"
-        udevadm info "$UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-        udevadm info "$UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+    echo "Then the device is not assigned to that snap"
+    udevadm info "$UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    udevadm info "$UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
 
-        echo "And the device is not shown in the snap device list"
-        # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
-        if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
-            NOMATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-        fi
-
-        echo "When a udev rule assigning the device to the snap is added"
-        content="KERNEL==\"$DEVICE_NAME\", TAG+=\"snap_test-snapd-sh_sh\""
-        echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
-        udevadm control --reload-rules
-        udevadm settle
-        udevadm trigger
-        udevadm settle
-
-        echo "Then the device is shown as assigned to the snap"
-        udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-        # CURRENT_TAGS just available on systemd 247+
-        if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
-            udevadm info "$UDEVADM_PATH" | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
-        fi
-
-        echo "And other devices are not shown as assigned to the snap"
-        udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-        udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
-
-        echo "When a snap command is called"
-        test-snapd-sh.sh -c 'true'
-
-        echo "Then the device is shown in the snap device list"
-        MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-        echo "And other devices are not shown in the snap device list"
-        NOMATCH "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-        echo "But existing nvidia devices are in the snap's device cgroup"
-        MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-        MATCH "c 195:255 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-        MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-        echo "But nonexisting nvidia devices are not"
-        NOMATCH "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-        echo "But the existing uhid device is in the snap's device cgroup"
-        MATCH "c 10:239 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
-
-        echo "Once the snap is removed, the current tags are automatically removed"
-        snap remove test-snapd-sh
-        udevadm info "$UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
-        test ! -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
-
-        # Reboot needed just on systemd 247+
-        if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
-            REBOOT
-        fi
+    echo "And the device is not shown in the snap device list"
+    # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
+    if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
+        NOMATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
     fi
 
-    udevadm info "$UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    echo "When a udev rule assigning the device to the snap is added"
+    content="KERNEL==\"$DEVICE_NAME\", TAG+=\"snap_test-snapd-sh_sh\""
+    echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+    udevadm control --reload-rules
+    udevadm settle
+    udevadm trigger
+    udevadm settle
+
+    echo "Then the device is shown as assigned to the snap"
+    udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    # CURRENT_TAGS just available on systemd 247+
+    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+        udevadm info "$UDEVADM_PATH" | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+    fi
+
+    echo "And other devices are not shown as assigned to the snap"
+    udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+
+    echo "When a snap command is called"
+    test-snapd-sh.sh -c 'true'
+
+    echo "Then the device is shown in the snap device list"
+    MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+    echo "And other devices are not shown in the snap device list"
+    NOMATCH "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+    echo "But existing nvidia devices are in the snap's device cgroup"
+    MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+    MATCH "c 195:255 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+    MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+    echo "But nonexisting nvidia devices are not"
+    NOMATCH "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+    echo "But the existing uhid device is in the snap's device cgroup"
+    MATCH "c 10:239 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+
+    echo "Once the snap is removed, the current tags are automatically removed"
+    snap remove test-snapd-sh
+    udevadm info "$UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+    test ! -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
+
+    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+        # with systemd versions 247+, the TAGS are sticky, but CURRENT_TAGS has
+        # been updated updated and checked
+        udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    else
+        udevadm info "$UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    fi


### PR DESCRIPTION
Try to determine whether the libudev/libsystemd supports CURRENT_TAGS which has
been introduced in systemd v247:
https://github.com/systemd/systemd/blob/f6278558da0304ec6b646bb172ce4688c7f162a5/NEWS#L1037-L1119
This comes in pair with TAGS becoming sticky, what means that our checks no
longer behave correctly as the tags do not go away.

If the library supports current tags, use the dynamically collected symbol to
double check that the device is really currently tagged for a snap. The
implementation introduced in v247 correctly checks whether the running systemd
supports current tags and otherwise falls back to looking at TAGS property.