### PR TITLE
interface/modem-manager: add support for MBIM/QMI proxy clients

### DIFF
--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -174,7 +174,10 @@ dbus (receive, send)
 # Allow to determine whether a tty device is a serial port or not.
 @{PROC}/tty/drivers r,
 
-# allow communicating with mbim-proxy server
+# allow communicating with the mbim and qmi proxy servers, which provide
+# support for talking to WWAN modems and devices which speak the Mobile
+# Interface Broadband Model (MBIM) and Qualcomm MSM Interface (QMI)
+# protocols respectively
 unix (connect, receive, send) type=stream peer=(addr="@{mbim,qmi}-proxy"),
 `
 

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -202,9 +202,6 @@ dbus (send)
     path=/org/freedesktop/ModemManager1{,/**}
     interface=org.freedesktop.DBus.Properties
     member="Get{,All}",
-
-# allow communicating with mbim-proxy server
-unix (connect, receive, send) type=stream peer=(addr="@{mbim,qmi}-proxy"),
 `
 
 const modemManagerPermanentSlotSecComp = `

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -173,6 +173,9 @@ dbus (receive, send)
 
 # Allow to determine whether a tty device is a serial port or not.
 @{PROC}/tty/drivers r,
+
+# allow communicating with mbim-proxy server
+unix (connect, receive, send) type=stream peer=(addr="@{mbim,qmi}-proxy"),
 `
 
 const modemManagerConnectedPlugAppArmorClassic = `
@@ -199,6 +202,9 @@ dbus (send)
     path=/org/freedesktop/ModemManager1{,/**}
     interface=org.freedesktop.DBus.Properties
     member="Get{,All}",
+
+# allow communicating with mbim-proxy server
+unix (connect, receive, send) type=stream peer=(addr="@{mbim,qmi}-proxy"),
 `
 
 const modemManagerPermanentSlotSecComp = `


### PR DESCRIPTION
The modem's app which wants to send MBIM messages will
connect to the mbim-proxy daemon via the unix socket.

The mbim-proxy daemon uses the the abstract socket path
"mbim-proxy". The modem-manager interface needs a
corresponding update. This provides that update.

References:
https://bugs.launchpad.net/austin/+bug/1936374
