### PR TITLE
cmd/snap: support --ignore-validation with snap install client command

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -474,9 +474,10 @@ type cmdInstall struct {
 
 	Name string `long:"name"`
 
-	Cohort        string `long:"cohort"`
-	IgnoreRunning bool   `long:"ignore-running" hidden:"yes"`
-	Positional    struct {
+	Cohort           string `long:"cohort"`
+	IgnoreValidation bool   `long:"ignore-validation"`
+	IgnoreRunning    bool   `long:"ignore-running" hidden:"yes"`
+	Positional       struct {
 		Snaps []remoteSnapName `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
 }
@@ -597,6 +598,7 @@ func (x *cmdInstall) Execute([]string) error {
 		Dangerous:     dangerous,
 		Unaliased:     x.Unaliased,
 		CohortKey:     x.Cohort,
+		IgnoreValidation: x.IgnoreValidation,
 		IgnoreRunning: x.IgnoreRunning,
 	}
 	x.setModes(opts)
@@ -617,6 +619,9 @@ func (x *cmdInstall) Execute([]string) error {
 
 	if x.asksForMode() || x.asksForChannel() {
 		return errors.New(i18n.G("a single snap name is needed to specify mode or channel flags"))
+	}
+	if x.IgnoreValidation {
+		return errors.New(i18n.G("a single snap name must be specified when ignoring validation"))
 	}
 
 	if x.Name != "" {
@@ -1106,6 +1111,8 @@ func init() {
 			"name": i18n.G("Install the snap file under the given instance name"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"cohort": i18n.G("Install the snap in the given cohort"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"ignore-validation": i18n.G("Ignore validation by other snaps blocking the refresh"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"ignore-running": i18n.G("Ignore running hooks or applications blocking the installation"),
 		}), nil)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1627,6 +1627,26 @@ func (s *SnapOpSuite) TestInstallFromChannel(c *check.C) {
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
 
+func (s *SnapOpSuite) TestInstallOneIgnoreValidation(c *check.C) {
+	s.RedirectClientToTestServer(s.srv.handle)
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":            "install",
+			"ignore-validation": true,
+		})
+	}
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--ignore-validation", "one"})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *SnapOpSuite) TestInstallManyIgnoreValidation(c *check.C) {
+	s.RedirectClientToTestServer(nil)
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--ignore-validation", "one", "two"})
+	c.Assert(err, check.ErrorMatches, `a single snap name must be specified when ignoring validation`)
+}
+
 func (s *SnapOpSuite) TestEnable(c *check.C) {
 	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {


### PR DESCRIPTION
Allow --ignore-validation flag with snap install command.

This isn't hooked up yet in api - will be in a separate PR.