### PR TITLE
daemon, o/snapstate: handle IgnoreValidation flag on install (2/3)

### DIFF
--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -294,6 +294,10 @@ func snapInstall(inst *snapInstruction, st *state.State) (string, []*state.TaskS
 		return "", nil, err
 	}
 
+	if inst.IgnoreValidation {
+		flags.IgnoreValidation = true
+	}
+
 	var ckey string
 	if inst.CohortKey == "" {
 		logger.Noticef("Installing snap %q revision %s", inst.Snaps[0], inst.Revision)

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -225,6 +225,9 @@ func (inst *snapInstruction) installFlags() (snapstate.Flags, error) {
 	if inst.IgnoreRunning {
 		flags.IgnoreRunning = true
 	}
+	if inst.IgnoreValidation {
+		flags.IgnoreValidation = true
+	}
 
 	return flags, nil
 }
@@ -292,10 +295,6 @@ func snapInstall(inst *snapInstruction, st *state.State) (string, []*state.TaskS
 	flags, err := inst.installFlags()
 	if err != nil {
 		return "", nil, err
-	}
-
-	if inst.IgnoreValidation {
-		flags.IgnoreValidation = true
 	}
 
 	var ckey string

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -521,7 +521,7 @@ func installInfoUnlocked(st *state.State, snapsup *SnapSetup, deviceCtx DeviceCo
 	st.Lock()
 	defer st.Unlock()
 	opts := &RevisionOptions{Channel: snapsup.Channel, CohortKey: snapsup.CohortKey, Revision: snapsup.Revision()}
-	return installInfo(context.TODO(), st, snapsup.InstanceName(), opts, snapsup.UserID, deviceCtx)
+	return installInfo(context.TODO(), st, snapsup.InstanceName(), opts, snapsup.UserID, Flags{}, deviceCtx)
 }
 
 // autoRefreshRateLimited returns the rate limit of auto-refreshes or 0 if

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -947,7 +947,7 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 		return nil, fmt.Errorf("invalid instance name: %v", err)
 	}
 
-	sar, err := installInfo(ctx, st, name, opts, userID, deviceCtx)
+	sar, err := installInfo(ctx, st, name, opts, userID, flags, deviceCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -2659,7 +2659,7 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 	}
 	if !newSnapst.IsInstalled() {
 		var userID int
-		newInfo, err := installInfo(context.TODO(), st, newName, &RevisionOptions{Channel: oldSnapst.TrackingChannel}, userID, nil)
+		newInfo, err := installInfo(context.TODO(), st, newName, &RevisionOptions{Channel: oldSnapst.TrackingChannel}, userID, Flags{}, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -201,8 +201,8 @@ var installSize = func(st *state.State, snaps []minimalInstallInfo, userID int) 
 	return total, nil
 }
 
-func installInfo(ctx context.Context, st *state.State, name string, revOpts *RevisionOptions, userID int, deviceCtx DeviceContext) (store.SnapActionResult, error) {
-	// TODO: support ignore-validation?
+func installInfo(ctx context.Context, st *state.State, name string, revOpts *RevisionOptions, userID int, flags Flags, deviceCtx DeviceContext) (store.SnapActionResult, error) {
+	// TODO: support ignore-validation
 
 	curSnaps, err := currentSnaps(st)
 	if err != nil {


### PR DESCRIPTION
Handle IgnoreValidation flag on snap install; followup to #10544.

TODO: installInfo function. Once wired up, snapstate test can be updated to verify the flag is passed with snap actions to the store.