### PR TITLE
tests/main/services-install-hook-can-run-svcs: add variant w/o --enable

### DIFF
--- a/tests/main/services-install-hook-can-run-svcs/task.yaml
+++ b/tests/main/services-install-hook-can-run-svcs/task.yaml
@@ -1,6 +1,15 @@
 summary: Check that install hooks in snaps can start services
 
+environment:
+  FLAGS/enable: --enable
+  FLAGS/none: ""
+
 execute: |
+  # setup the install hook with the right flags
+  sed ./test-snapd-install-hook-runs-svc/meta/hooks/install.in -e s/%%FLAGS%%/$FLAGS/ > ./test-snapd-install-hook-runs-svc/meta/hooks/install
+
+  chmod +x ./test-snapd-install-hook-runs-svc/meta/hooks/install
+
   echo "Verify that the snap installs"
   "$TESTSTOOLS"/snaps-state install-local test-snapd-install-hook-runs-svc
 

--- a/tests/main/services-install-hook-can-run-svcs/test-snapd-install-hook-runs-svc/meta/hooks/install.in
+++ b/tests/main/services-install-hook-can-run-svcs/test-snapd-install-hook-runs-svc/meta/hooks/install.in
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # start running
-snapctl start --enable "$SNAP_NAME.svc"
+snapctl start %%FLAGS%% "$SNAP_NAME.svc"
 
 # wait a bit, the service is only creating a file, so we don't need to bother
 # ourselves with waiting too long


### PR DESCRIPTION
This test currently fails on master.