### PR TITLE
[WIP] overlord/servicestate/service_control: compare full service names

### DIFF
--- a/overlord/servicestate/service_control.go
+++ b/overlord/servicestate/service_control.go
@@ -149,6 +149,8 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 			if err != nil {
 				return err
 			}
+
+			snapDisabledServices = wrappers.GenServiceNames(info, snapDisabledServices)
 			// compute the list of disabled services, but if a service was
 			// mentioned explicitly, then this should overrule the disabled
 			// status

--- a/overlord/servicestate/service_control.go
+++ b/overlord/servicestate/service_control.go
@@ -150,7 +150,10 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 				return err
 			}
 
+			// QueryDisabledServices returns snap's service (app) names, we need to
+			// convert them to systemd unit names for proper matching below.
 			snapDisabledServices = wrappers.GenServiceNames(info, snapDisabledServices)
+
 			// compute the list of disabled services, but if a service was
 			// mentioned explicitly, then this should overrule the disabled
 			// status

--- a/tests/main/services-install-hook-can-run-svcs/task.yaml
+++ b/tests/main/services-install-hook-can-run-svcs/task.yaml
@@ -1,6 +1,15 @@
 summary: Check that install hooks in snaps can start services
 
+environment:
+  FLAGS/enable: --enable
+  FLAGS/none: ""
+
 execute: |
+  # setup the install hook with the right flags
+  sed ./test-snapd-install-hook-runs-svc/meta/hooks/install.in -e s/%%FLAGS%%/$FLAGS/ > ./test-snapd-install-hook-runs-svc/meta/hooks/install
+
+  chmod +x ./test-snapd-install-hook-runs-svc/meta/hooks/install
+
   echo "Verify that the snap installs"
   "$TESTSTOOLS"/snaps-state install-local test-snapd-install-hook-runs-svc
 

--- a/tests/main/services-install-hook-can-run-svcs/test-snapd-install-hook-runs-svc/meta/hooks/install.in
+++ b/tests/main/services-install-hook-can-run-svcs/test-snapd-install-hook-runs-svc/meta/hooks/install.in
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # start running
-snapctl start --enable "$SNAP_NAME.svc"
+snapctl start %%FLAGS%% "$SNAP_NAME.svc"
 
 # wait a bit, the service is only creating a file, so we don't need to bother
 # ourselves with waiting too long

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -942,6 +942,9 @@ func RemoveSnapServices(s *snap.Info, inter interacter) error {
 	return nil
 }
 
+// GenServiceNames converts the given appNames to full systemd service names.
+// It should only be called for actual services (doesn't check if app is a
+// service).
 func GenServiceNames(snap *snap.Info, appNames []string) []string {
 	names := make([]string, 0, len(appNames))
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -942,7 +942,7 @@ func RemoveSnapServices(s *snap.Info, inter interacter) error {
 	return nil
 }
 
-func genServiceNames(snap *snap.Info, appNames []string) []string {
+func GenServiceNames(snap *snap.Info, appNames []string) []string {
 	names := make([]string, 0, len(appNames))
 
 	for _, name := range appNames {
@@ -951,10 +951,6 @@ func genServiceNames(snap *snap.Info, appNames []string) []string {
 		}
 	}
 	return names
-}
-
-func GenServiceNames(snap *snap.Info, appNames []string) []string {
-	return genServiceNames(snap, appNames)
 }
 
 // TODO: this should not accept AddSnapServicesOptions, it should use some other
@@ -1158,8 +1154,8 @@ WantedBy={{.ServicesTarget}}
 		OOMAdjustScore: oomAdjustScore,
 		BusName:        busName,
 
-		Before: genServiceNames(appInfo.Snap, appInfo.Before),
-		After:  genServiceNames(appInfo.Snap, appInfo.After),
+		Before: GenServiceNames(appInfo.Snap, appInfo.Before),
+		After:  GenServiceNames(appInfo.Snap, appInfo.After),
 
 		// systemd runs as PID 1 so %h will not work.
 		Home: "/root",

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -953,6 +953,10 @@ func genServiceNames(snap *snap.Info, appNames []string) []string {
 	return names
 }
 
+func GenServiceNames(snap *snap.Info, appNames []string) []string {
+	return genServiceNames(snap, appNames)
+}
+
 // TODO: this should not accept AddSnapServicesOptions, it should use some other
 // subset of options, specifically it should not accept Preseeding as an option
 // here


### PR DESCRIPTION
We need to expand the service names to their full unit name, in order to
compare them with the names in the explicit service list.

This fixes the installation of the `edgexfoundry` snap with the latest master.

Keeping this as a draft. Probably a new branch needs to be created containing both this and https://github.com/snapcore/snapd/pull/10548
