### PR TITLE
o/servicestate: use snap app names for ExplicitServices of ServiceAction

### DIFF
--- a/overlord/servicestate/service_control.go
+++ b/overlord/servicestate/service_control.go
@@ -112,6 +112,8 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
+	// ExplicitServices are snap app names; obtain names of systemd units
+	// expected by wrappers.
 	var explicitServicesSystemdUnits []string
 	for _, name := range sc.ExplicitServices {
 		if app := info.Apps[name]; app != nil {

--- a/overlord/servicestate/service_control.go
+++ b/overlord/servicestate/service_control.go
@@ -34,7 +34,8 @@ import (
 // stopping or restarting) run against services of a given snap. The action is
 // run for services listed in services attribute, or for all services of the
 // snap if services list is empty.
-// The names of services are app names (as defined in snap yaml).
+// The names of services and explicit-services are app names (as defined in snap
+// yaml).
 type ServiceAction struct {
 	SnapName       string   `json:"snap-name"`
 	Action         string   `json:"action"`
@@ -111,6 +112,13 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
+	var explicitServicesSystemdUnits []string
+	for _, name := range sc.ExplicitServices {
+		if app := info.Apps[name]; app != nil {
+			explicitServicesSystemdUnits = append(explicitServicesSystemdUnits, app.ServiceName())
+		}
+	}
+
 	// Note - state must be unlocked when calling wrappers below.
 	switch sc.Action {
 	case "stop":
@@ -163,13 +171,13 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 		}
 	case "restart":
 		st.Unlock()
-		err := wrappers.RestartServices(startupOrdered, sc.ExplicitServices, nil, meter, perfTimings)
+		err := wrappers.RestartServices(startupOrdered, explicitServicesSystemdUnits, nil, meter, perfTimings)
 		st.Lock()
 		return err
 	case "reload-or-restart":
 		flags := &wrappers.RestartServicesFlags{Reload: true}
 		st.Unlock()
-		err := wrappers.RestartServices(startupOrdered, sc.ExplicitServices, flags, meter, perfTimings)
+		err := wrappers.RestartServices(startupOrdered, explicitServicesSystemdUnits, flags, meter, perfTimings)
 		st.Lock()
 		return err
 	default:

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -132,15 +132,26 @@ func verifyControlTasks(c *C, tasks []*state.Task, expectedAction, actionModifie
 	// sanity, ensures test checks below are hit
 	c.Assert(len(tasks) > 0, Equals, true)
 
-	// group service names by snaps
-	bySnap := make(map[string][]string)
-	for _, name := range expectedServices {
+	splitServiceName := func(name string) (snapName, serviceName string) {
 		// split service name, e.g. snap.test-snap.foo.service
 		parts := strings.Split(name, ".")
 		c.Assert(parts, HasLen, 4)
-		snapName := parts[1]
-		serviceName := parts[2]
+		snapName = parts[1]
+		serviceName = parts[2]
+		return snapName, serviceName
+	}
+
+	// group service names by snaps
+	bySnap := make(map[string][]string)
+	for _, name := range expectedServices {
+		snapName, serviceName := splitServiceName(name)
 		bySnap[snapName] = append(bySnap[snapName], serviceName)
+	}
+
+	expectedExplicitServicesAppNames := make(map[string][]string)
+	for _, name := range expectedExplicitServices {
+		snapName, serviceName := splitServiceName(name)
+		expectedExplicitServicesAppNames[snapName] = append(expectedExplicitServicesAppNames[snapName], serviceName)
 	}
 
 	var execCommandTasks int
@@ -220,7 +231,10 @@ func verifyControlTasks(c *C, tasks []*state.Task, expectedAction, actionModifie
 			sort.Strings(obtainedServices)
 			sort.Strings(bySnap[sa.SnapName])
 			c.Assert(obtainedServices, DeepEquals, bySnap[sa.SnapName])
-			c.Assert(sa.ExplicitServices, DeepEquals, expectedExplicitServices)
+			obtainedExplicitServices := sa.ExplicitServices
+			sort.Strings(obtainedExplicitServices)
+			sort.Strings(expectedExplicitServicesAppNames[sa.SnapName])
+			c.Assert(obtainedExplicitServices, DeepEquals, expectedExplicitServicesAppNames[sa.SnapName])
 		} else {
 			c.Fatalf("unexpected task: %s", tasks[i].Kind())
 		}
@@ -866,7 +880,7 @@ func (s *serviceControlSuite) TestRestartWithSomeExplicitServices(c *C) {
 	srvFoo := "snap.test-snap.foo.service"
 	srvBar := "snap.test-snap.bar.service"
 	s.testRestartWithExplicitServicesCommon(c,
-		[]string{srvFoo},
+		[]string{"foo"},
 		[][]string{
 			{"stop", srvFoo},
 			{"show", "--property=ActiveState", srvFoo},
@@ -882,7 +896,7 @@ func (s *serviceControlSuite) TestRestartWithAllExplicitServices(c *C) {
 	srvFoo := "snap.test-snap.foo.service"
 	srvBar := "snap.test-snap.bar.service"
 	s.testRestartWithExplicitServicesCommon(c,
-		[]string{srvAbc, srvBar, srvFoo},
+		[]string{"abc", "bar", "foo"},
 		[][]string{
 			{"stop", srvFoo},
 			{"show", "--property=ActiveState", srvFoo},

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -74,8 +74,6 @@ func computeExplicitServices(appInfos []*snap.AppInfo, names []string) map[strin
 // serviceControlTs creates "service-control" task for every snap derived from appInfos.
 func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.TaskSet, error) {
 	servicesBySnap := make(map[string][]string, len(appInfos))
-	// note, this may be called with service names of different snaps
-	// XXX: this doesn't support service names from snapctl (i.e. without snap prefix).
 	explicitServices := computeExplicitServices(appInfos, inst.Names)
 	sortedNames := make([]string, 0, len(appInfos))
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1586,6 +1586,8 @@ type RestartServicesFlags struct {
 // restarted no matter it's state, it should be included in the
 // explicitServices list.
 // The list of explicitServices needs to use systemd unit names.
+// TODO: change explicitServices format to be less unusual, more consistent
+// (introduce AppRef?)
 func RestartServices(svcs []*snap.AppInfo, explicitServices []string,
 	flags *RestartServicesFlags, inter interacter, tm timings.Measurer) error {
 	sysd := systemd.New(systemd.SystemMode, inter)

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1585,6 +1585,7 @@ type RestartServicesFlags struct {
 // are only restarted if they are active, so if a service is meant to be
 // restarted no matter it's state, it should be included in the
 // explicitServices list.
+// The list of explicitServices needs to use systemd unit names.
 func RestartServices(svcs []*snap.AppInfo, explicitServices []string,
 	flags *RestartServicesFlags, inter interacter, tm timings.Measurer) error {
 	sysd := systemd.New(systemd.SystemMode, inter)


### PR DESCRIPTION
Use snap app names for ExplicitServices of ServiceAction. This keeps it consistent with existing Service field.
