### PR TITLE
interface/modem-manager: add support for MBIM/QMI proxy clients

### DIFF
--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -173,6 +173,12 @@ dbus (receive, send)
 
 # Allow to determine whether a tty device is a serial port or not.
 @{PROC}/tty/drivers r,
+
+# allow communicating with the mbim and qmi proxy servers, which provide
+# support for talking to WWAN modems and devices which speak the Mobile
+# Interface Broadband Model (MBIM) and Qualcomm MSM Interface (QMI)
+# protocols respectively
+unix (connect, receive, send) type=stream peer=(addr="@{mbim,qmi}-proxy"),
 `
 
 const modemManagerConnectedPlugAppArmorClassic = `


### PR DESCRIPTION
The mbim-proxy daemon is started by the ModemManager service.
The modem's app which wants to send MBIM messages will
connect to the mbim-proxy daemon via the unix socket.

The mbim-proxy daemon uses the the abstract socket path
"mbim-proxy". The modem-manager interface needs a
corresponding update. This provides that update.

References:
https://bugs.launchpad.net/austin/+bug/1936374

This is really just https://github.com/snapcore/snapd/pull/10543/files squashed and commited with `--author " Jerry Lee <jerry.lee@canonical.com>"` so that the CLA checker is happy.