### PR TITLE
tests: force snapd-session-agent.socket to be re-generated

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -12,6 +12,10 @@ reset_classic() {
     systemctl daemon-reload
     systemd_stop_units snapd.service snapd.socket
 
+    # none of the purge steps stop the user services, we need to do it
+    # explicitly, at least for the root user
+    systemctl --user stop snapd.session-agent.socket || true
+
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -1,3 +1,4 @@
+
 #!/bin/bash -x
 
 # shellcheck source=tests/lib/state.sh
@@ -86,6 +87,9 @@ reset_classic() {
 
         # force all profiles to be re-generated
         rm -f /var/lib/snapd/system-key
+
+        # force snapd-session-agent.socket fto be re-generated
+        rm -f /run/user/0/snapd-session-agent.socket
     fi
 
     if [ "$1" != "--keep-stopped" ]; then

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash -x
 
 # shellcheck source=tests/lib/state.sh


### PR DESCRIPTION
This is to prevent errors installing snaps with daemons for test users
like the following example.

/home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/snaps-state
install-local test-snapd-user-service
error: cannot perform the following tasks:
- Make snap "test-snapd-user-service" (unset) available to the system
(Post http://0/v1/service-control: dial unix
/run/user/0/snapd-session-agent.socket: connect: connection refused)

This happens when snap the test does "set system
experimental.user-daemons=true"

To reproduce the error run:
google:ubuntu-20.04-64:tests/main/cgroup-tracking:root
google:ubuntu-20.04-64:tests/main/snap-services
