### PR TITLE
test/lib/prepare-restore: try to catch when snap.lxd.workaround.service appears

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -637,6 +637,13 @@ prepare_suite_each() {
 }
 
 restore_suite_each() {
+    if [ -e /etc/systemd/system/snap.lxd.workaround.service ]; then
+        echo 'unexpected service'
+        systemctl status snap.lxd.workaround.service || true
+        systemctl cat snap.lxd.workaround.service || true
+        exit 1
+    fi
+
     local variant="$1"
 
     rm -f "$RUNTIME_STATE_PATH/audit-stamp"


### PR DESCRIPTION
The postrm-purge test fails printing this log:
```
Skipping non-snapd systemd unit snap.lxd.workaround.service
```

Meaning that a snap.lxd.workaround.service is left behind by one of the earlier
tests. Try to find out which one.
