### PR TITLE
tests/main/services-install-hook-can-run-svcs: make variants more obvious

### DIFF
--- a/tests/main/services-install-hook-can-run-svcs/task.yaml
+++ b/tests/main/services-install-hook-can-run-svcs/task.yaml
@@ -1,8 +1,8 @@
 summary: Check that install hooks in snaps can start services
 
 environment:
-  FLAGS/enable: --enable
-  FLAGS/none: ""
+  FLAGS/enableflag: --enable
+  FLAGS/noflag: ""
 
 execute: |
   # setup the install hook with the right flags


### PR DESCRIPTION
Thanks to Samuele for pointing this out, it is much more clear in spread
output:

google: ubuntu-core-16-64:tests/main/services-install-hook-can-run-svcs:enableflag
google: ubuntu-core-16-64:tests/main/services-install-hook-can-run-svcs:noflag
