### PR TITLE
tests/many: remove lxd systemd unit to prevent unexpected leftovers

### DIFF
--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -13,6 +13,14 @@ restore: |
     lxd.lxc delete ubuntu || true
     snap remove --purge lxd
 
+    # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to
+    # avoid systemd wiping lxd cgroups when snapd disables all lxd units during refresh
+    # TODO: remove this when lxd removes automatically the service
+    if systemctl is-active snap.lxd.workaround.service; then
+        systemctl stop snap.lxd.workaround.service
+        systemctl disable snap.lxd.workaround.service
+    fi
+
 execute: |
     echo "Install lxd"
     snap install lxd

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -18,7 +18,6 @@ restore: |
     # TODO: remove this when lxd removes automatically the service
     if systemctl is-active snap.lxd.workaround.service; then
         systemctl stop snap.lxd.workaround.service
-        systemctl disable snap.lxd.workaround.service
     fi
 
 execute: |

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -8,6 +8,14 @@ restore: |
     snap remove ---purge lxd
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
+    # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to
+    # avoid systemd wiping lxd cgroups when snapd disables all lxd units during refresh
+    # TODO: remove this when lxd removes automatically the service
+    if systemctl is-active snap.lxd.workaround.service; then
+        systemctl stop snap.lxd.workaround.service
+        systemctl disable snap.lxd.workaround.service
+    fi
+
 execute: |
     echo "Ensure we use the snap"
     apt autoremove -y lxd

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -13,7 +13,6 @@ restore: |
     # TODO: remove this when lxd removes automatically the service
     if systemctl is-active snap.lxd.workaround.service; then
         systemctl stop snap.lxd.workaround.service
-        systemctl disable snap.lxd.workaround.service
     fi
 
 execute: |

--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -72,7 +72,6 @@ restore: |
     # TODO: remove this when lxd removes automatically the service
     if systemctl is-active snap.lxd.workaround.service; then
         systemctl stop snap.lxd.workaround.service
-        systemctl disable snap.lxd.workaround.service
     fi
 
 debug: |

--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -67,6 +67,14 @@ restore: |
 
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
+    # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to
+    # avoid systemd wiping lxd cgroups when snapd disables all lxd units during refresh
+    # TODO: remove this when lxd removes automatically the service
+    if systemctl is-active snap.lxd.workaround.service; then
+        systemctl stop snap.lxd.workaround.service
+        systemctl disable snap.lxd.workaround.service
+    fi
+
 debug: |
     # debug output from lxd
     "$TESTSTOOLS"/journal-state get-log -u snap.lxd.daemon.service

--- a/tests/main/lxd-services-smoke/task.yaml
+++ b/tests/main/lxd-services-smoke/task.yaml
@@ -18,7 +18,6 @@ restore: |
   # TODO: remove this when lxd removes automatically the service
   if systemctl is-active snap.lxd.workaround.service; then
       systemctl stop snap.lxd.workaround.service
-      systemctl disable snap.lxd.workaround.service
   fi
 
 execute: |

--- a/tests/main/lxd-services-smoke/task.yaml
+++ b/tests/main/lxd-services-smoke/task.yaml
@@ -12,6 +12,15 @@ details: |
 
 systems: [ubuntu-18.04*, ubuntu-20.04*]
 
+restore: |
+  # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to
+  # avoid systemd wiping lxd cgroups when snapd disables all lxd units during refresh
+  # TODO: remove this when lxd removes automatically the service
+  if systemctl is-active snap.lxd.workaround.service; then
+      systemctl stop snap.lxd.workaround.service
+      systemctl disable snap.lxd.workaround.service
+  fi
+
 execute: |
   echo "Installing lxd snap"
   snap install lxd

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -13,7 +13,6 @@ restore: |
     # TODO: remove this when lxd removes automatically the service
     if systemctl is-active snap.lxd.workaround.service; then
         systemctl stop snap.lxd.workaround.service
-        systemctl disable snap.lxd.workaround.service
     fi
 
 

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -8,6 +8,15 @@ restore: |
     snap remove ---purge lxd
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
+    # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to
+    # avoid systemd wiping lxd cgroups when snapd disables all lxd units during refresh
+    # TODO: remove this when lxd removes automatically the service
+    if systemctl is-active snap.lxd.workaround.service; then
+        systemctl stop snap.lxd.workaround.service
+        systemctl disable snap.lxd.workaround.service
+    fi
+
+
 execute: |
     echo "Ensure we use the snap"
     apt autoremove -y lxd

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -43,7 +43,6 @@ restore: |
   # TODO: remove this when lxd removes automatically the service
   if systemctl is-active snap.lxd.workaround.service; then
     systemctl stop snap.lxd.workaround.service
-    systemctl disable snap.lxd.workaround.service
   fi
   
 execute: |

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -38,6 +38,14 @@ restore: |
   lxd.lxc delete ubuntu || true
   snap remove --purge lxd
 
+  # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to
+  # avoid systemd wiping lxd cgroups when snapd disables all lxd units during refresh
+  # TODO: remove this when lxd removes automatically the service
+  if systemctl is-active snap.lxd.workaround.service; then
+    systemctl stop snap.lxd.workaround.service
+    systemctl disable snap.lxd.workaround.service
+  fi
+  
 execute: |
   lxd.lxc exec ubuntu -- snap try /root/test-snapd-tools
   lxd.lxc exec ubuntu -- snap list | MATCH '^test-snapd-tools .* try'

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -63,7 +63,6 @@ restore: |
     # TODO: remove this when lxd removes automatically the service
     if systemctl is-active snap.lxd.workaround.service; then
         systemctl stop snap.lxd.workaround.service
-        systemctl disable snap.lxd.workaround.service
     fi
 
 debug: |

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -58,6 +58,14 @@ restore: |
     # invariant checker.
     systemctl --user stop dbus.service || true
 
+    # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to
+    # avoid systemd wiping lxd cgroups when snapd disables all lxd units during refresh
+    # TODO: remove this when lxd removes automatically the service
+    if systemctl is-active snap.lxd.workaround.service; then
+        systemctl stop snap.lxd.workaround.service
+        systemctl disable snap.lxd.workaround.service
+    fi
+
 debug: |
     # debug output from lxd
     "$TESTSTOOLS"/journal-state get-log -u snap.lxd.daemon.service

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -28,6 +28,14 @@ restore: |
 
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
+    # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to
+    # avoid systemd wiping lxd cgroups when snapd disables all lxd units during refresh
+    # TODO: remove this when lxd removes automatically the service
+    if systemctl is-active snap.lxd.workaround.service; then
+        systemctl stop snap.lxd.workaround.service
+        systemctl disable snap.lxd.workaround.service
+    fi
+
 debug: |
     if [ -e avc-after ]; then
         echo "AVC log from the test"

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -33,7 +33,6 @@ restore: |
     # TODO: remove this when lxd removes automatically the service
     if systemctl is-active snap.lxd.workaround.service; then
         systemctl stop snap.lxd.workaround.service
-        systemctl disable snap.lxd.workaround.service
     fi
 
 debug: |


### PR DESCRIPTION
This is a temporal, at some point it should be automatically removed
when lxd is uninstalled.

The explanation about this service is:
"The snap.lxd.workaround.service unit is needed by lxd to avoid systemd
wiping the cgroups when snapd disables all the lxd units during refresh
Effectively an empty unit with Delegate=yes which snapd doesn't know
about and so won't be disabled during refresh"

This is to prevent the spread error on postrm-purge test
+ systemctl --no-legend --full
+ grep -E 'snap\..*\.(service|timer|socket)'
snap.lxd.workaround.service                                                                  loaded active exited    /bin/true                                                                    
+ echo 'found unexpected leftovers'
found unexpected leftovers
+ exit 1
-----