### PR TITLE
configcore: register virtual config for timezone reading

### DIFF
--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -546,6 +546,8 @@ var (
 // This is useful for e.g. the system.hostname configuration where the
 // authoritative value is coming from the kernel and can be changed
 // outside of snapd.
+//
+// XXX: rename to "RegisterExternalConfig"
 func RegisterVirtualConfig(snapName, key string, vf VirtualCfgFunc) error {
 	virtualMu.Lock()
 	defer virtualMu.Unlock()

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -81,7 +81,7 @@ func handleTimezoneConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts 
 	if timezone == currentTimezone {
 		return nil
 	}
-	
+
 	// runtime system
 	if opts == nil {
 		output, err := exec.Command("timedatectl", "set-timezone", timezone).CombinedOutput()
@@ -115,7 +115,10 @@ func getTimezoneFromSystemVC(key string) (interface{}, error) {
 
 func getTimezoneFromSystem() (string, error) {
 	// We cannot use "timedatectl show" here because it is only
-	// available on UC20
+	// available on UC20.
+	//
+	// Note that this code only runs on UbuntuCore systems which all
+	// have /etc/writable/localtime
 	link, err := os.Readlink(filepath.Join(dirs.GlobalRootDir, "/etc/writable/localtime"))
 	// see localtime(5)
 	// "If /etc/localtime is missing, the default "UTC" timezone is used."

--- a/overlord/configstate/configcore/timezone_test.go
+++ b/overlord/configstate/configcore/timezone_test.go
@@ -39,7 +39,10 @@ var _ = Suite(&timezoneSuite{})
 func (s *timezoneSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
 
-	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/writable"), 0755)
+	c.Assert(err, IsNil)
+	localtimePath := filepath.Join(dirs.GlobalRootDir, "/etc/writable/localtime")
+	err = os.Symlink("/usr/share/zoneinfo/WET", localtimePath)
 	c.Assert(err, IsNil)
 }
 
@@ -79,7 +82,7 @@ func (s *timezoneSuite) TestConfigureTimezoneIntegration(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(mockedTimedatectl.Calls(), DeepEquals, [][]string{
 			{"timedatectl", "set-timezone", tz},
-		})
+		}, Commentf("tested timezone: %v", tz))
 		mockedTimedatectl.ForgetCalls()
 	}
 }

--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -126,5 +126,20 @@ execute: |
     echo "setting the timezone works"
     cat /etc/timezone > current-timezone
     snap set system system.timezone=Europe/Malta
-    MATCH "Europe/Malta" /etc/timezone
+    MATCH "Europe/Malta" < /etc/timezone
     test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/Europe/Malta"
+
+    echo "and timezone setting shows up in the document"
+    snap get system -d | MATCH "Europe/Malta"
+    echo "but the timezone is not stored in the config state"
+    python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); print(j["data"]["config"]);' < /var/lib/snapd/state.json | NOMATCH Europe/Malta
+
+    echo "and setting it again in snapd also works"
+    snap set system system.timezone=Europe/Berlin
+    MATCH "Europe/Berlin" < /etc/timezone
+    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/Europe/Berlin"
+    
+    echo "and setting the timezone outside of snapd is reflected by snap get"
+    timedatectl set-timezone "America/Denver"
+    snap get system system.timezone | MATCH "America/Denver"
+    snap get system -d | MATCH "America/Denver"


### PR DESCRIPTION
This commit uses the new virtual configuration mechanism to make
the `snap get core system.timezone` output look at the system
setting instead of at what is stored in the state. It also adds
a test that ensures that writing the timezone will not store it
in the state.


