### PR TITLE
tests: skip udp protocol on latest ubuntus

### DIFF
--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -184,7 +184,8 @@ execute: |
     # Skip udp protocol on arch-linux and debian-sid because it is not supported. Error displayed:
     # - arch: mount.nfs: requested NFS version or transport protocol is not supported
     # - debian-sid: mount.nfs: an incorrect mount option was specified
-    if not os.query is-arch-linux && not os.query is-debian-sid; then
+    # - ubuntu-2*: mount.nfs: an incorrect mount option was specified
+    if not os.query is-arch-linux && not os.query is-debian-sid && [[ "$SPREAD_SYSTEM" != ubuntu-2* ]]; then
         # Mount NFS-exported /home over real /home using NFSv3 and UDP transport
         mount -t nfs localhost:/home /home -o nfsvers=3,proto=udp
 


### PR DESCRIPTION
Using udp protocol on mount for ubuntu 20.04, 21.04 and 21.10 is not
supported anymore.

+ mount -t nfs localhost:/home /home -o nfsvers=3,proto=udp
mount.nfs: an incorrect mount option was specified

The test nfs-support is skipping those systems
