### PR TITLE
cmd/libsnap-confine-private: g_spawn_check_exit_status is deprecated since glib 2.69

### DIFF
--- a/cmd/libsnap-confine-private/test-utils.c
+++ b/cmd/libsnap-confine-private/test-utils.c
@@ -23,6 +23,11 @@
 
 #include <glib.h>
 
+#if !GLIB_CHECK_VERSION(2, 69, 0)
+// g_spawn_check_exit_status is considered deprecated since 2.69
+#define g_spawn_check_wait_status(x, y) (g_spawn_check_exit_status (x, y))
+#endif
+
 void rm_rf_tmp(const char *dir)
 {
 	// Sanity check, don't remove anything that's not in the temporary
@@ -60,7 +65,7 @@ void rm_rf_tmp(const char *dir)
 		      (working_directory, argv, envp, flags, child_setup,
 		       user_data, standard_output, standard_error, &exit_status,
 		       &error));
-	g_assert_true(g_spawn_check_exit_status(exit_status, NULL));
+	g_assert_true(g_spawn_check_wait_status(exit_status, NULL));
 	if (error != NULL) {
 		g_test_message("cannot remove temporary directory: %s\n",
 			       error->message);


### PR DESCRIPTION
With https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1967 the
g_spawn_check_exit_status call is flagged as deprecated now. This also broke in
F35 mass rebuild in Rawhide:

```
make[1]: Leaving directory '/builddir/build/BUILD/snapd-2.51/cmd'
libsnap-confine-private/test-utils.c: In function 'rm_rf_tmp':
libsnap-confine-private/test-utils.c:63:9: error: 'g_spawn_check_exit_status' is deprecated: Use 'g_spawn_check_wait_status' instead [-Werror=deprecated-declarations]
   63 |         g_assert_true(g_spawn_check_exit_status(exit_status, NULL));
      |         ^~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/glib.h:81,
                 from libsnap-confine-private/test-utils.c:24:
/usr/include/glib-2.0/glib/gspawn.h:280:10: note: declared here
  280 | gboolean g_spawn_check_exit_status (gint      wait_status,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:2705: libsnap-confine-private/libsnap_confine_private_unit_tests-test-utils.o] Error 1
make[1]: *** Waiting for unfinished jobs....
```
