### PR TITLE
github: enable gofmt for Go 1.13 jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -166,8 +166,8 @@ jobs:
       if: steps.cached-results.outputs.already-ran != 'true'
       run: |
           cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-          # run gofmt checks only with Go 1.9 and 1.10
-          if ! echo "${{ matrix.gochannel }}" | grep -E '1\.(9|10)' ; then
+          # run gofmt checks only with Go 1.13
+          if ! echo "${{ matrix.gochannel }}" | grep -E '1\.13' ; then
               # and skip with other versions
               export SKIP_GOFMT=1
               echo "Formatting checks will be skipped due to the use of Go version ${{ matrix.gochannel }}"


### PR DESCRIPTION
We should run gofmt for 1.13 unit test jobs.
