### PR TITLE
interfaces/builtin: allow access to per-user GTK CSS overrides

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -66,6 +66,7 @@ owner @{HOME}/.local/share/fonts/{,**} r,
 # subset of gnome abstraction
 /etc/gtk-3.0/settings.ini r,
 owner @{HOME}/.config/gtk-3.0/settings.ini r,
+owner @{HOME}/.config/gtk-3.0/*.css r,
 # Note: this leaks directory names that wouldn't otherwise be known to the snap
 owner @{HOME}/.config/gtk-3.0/bookmarks r,
 


### PR DESCRIPTION
This is intended to help support colour scheme customisations for GTK apps on KDE desktops.

KDE tries to make GTK apps follow the user's chosen colour scheme by writing a `~/.config/gtk-3.0/colors.css` file that defines a number of symbolic colour names that are referenced by the Breeze-gtk theme (a theme they provide that matches their Qt theme). It also creates or updates `~/.config/gtk-3.0/gtk.css` to include the `colors.css` file. We want snapped applications to have read access for these CSS files.

In addition to this snapd change, the Snapcraft gnome-* extensions will require changes to symlink these CSS files into the snap's private `$HOME`. More details can be found here:

https://forum.snapcraft.io/t/very-ugly-cursor-for-spotify-and-kde-snaps/17118/31?u=jamesh