### PR TITLE
o/snapstate: affectedByRefresh tweaks

### DIFF
--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -380,11 +380,12 @@ type AffectedSnapInfo struct {
 	AffectingSnaps map[string]bool
 }
 
-func affectedByRefresh(st *state.State, updates []*snap.Info) (map[string]*AffectedSnapInfo, error) {
-	all, err := All(st)
+func affectedByRefresh(st *state.State, updates []string) (map[string]*AffectedSnapInfo, error) {
+	allSnaps, err := All(st)
 	if err != nil {
 		return nil, err
 	}
+	snapsWithHook := make(map[string]*SnapState)
 
 	var bootBase string
 	if !release.OnClassic {
@@ -400,9 +401,9 @@ func affectedByRefresh(st *state.State, updates []*snap.Info) (map[string]*Affec
 	}
 
 	byBase := make(map[string][]string)
-	for name, snapSt := range all {
+	for name, snapSt := range allSnaps {
 		if !snapSt.Active {
-			delete(all, name)
+			delete(allSnaps, name)
 			continue
 		}
 		inf, err := snapSt.CurrentInfo()
@@ -411,9 +412,9 @@ func affectedByRefresh(st *state.State, updates []*snap.Info) (map[string]*Affec
 		}
 		// optimization: do not consider snaps that don't have gate-auto-refresh hook.
 		if inf.Hooks[gateAutoRefreshHookName] == nil {
-			delete(all, name)
 			continue
 		}
+		snapsWithHook[name] = snapSt
 
 		base := inf.Base
 		if base == "none" {
@@ -422,7 +423,7 @@ func affectedByRefresh(st *state.State, updates []*snap.Info) (map[string]*Affec
 		if inf.Base == "" {
 			base = "core"
 		}
-		byBase[base] = append(byBase[base], inf.InstanceName())
+		byBase[base] = append(byBase[base], snapSt.InstanceName())
 	}
 
 	affected := make(map[string]*AffectedSnapInfo)
@@ -443,15 +444,26 @@ func affectedByRefresh(st *state.State, updates []*snap.Info) (map[string]*Affec
 		affectedInfo.AffectingSnaps[affectedBy] = true
 	}
 
-	for _, up := range updates {
-		// the snap affects itself (as long as it's in all list i.e. has the hook)
-		if snapSt := all[up.InstanceName()]; snapSt != nil {
+	for _, snapName := range updates {
+		snapSt := allSnaps[snapName]
+		if snapSt == nil {
+			// this could happen if an update for inactive snap was requested (those
+			// are filtered out above).
+			return nil, fmt.Errorf("internal error: no state for snap %q", snapName)
+		}
+		up, err := snapSt.CurrentInfo()
+		if err != nil {
+			return nil, err
+		}
+
+		// the snap affects itself (as long as it has the hook)
+		if snapSt := snapsWithHook[up.InstanceName()]; snapSt != nil {
 			addAffected(up.InstanceName(), up.InstanceName(), false, false)
 		}
 
 		// on core system, affected by update of boot base
 		if bootBase != "" && up.InstanceName() == bootBase {
-			for _, snapSt := range all {
+			for _, snapSt := range snapsWithHook {
 				addAffected(snapSt.InstanceName(), up.InstanceName(), true, false)
 			}
 		}
@@ -459,7 +471,7 @@ func affectedByRefresh(st *state.State, updates []*snap.Info) (map[string]*Affec
 		// snaps that can trigger reboot
 		// XXX: gadget refresh doesn't always require reboot, refine this
 		if up.Type() == snap.TypeKernel || up.Type() == snap.TypeGadget {
-			for _, snapSt := range all {
+			for _, snapSt := range snapsWithHook {
 				addAffected(snapSt.InstanceName(), up.InstanceName(), true, false)
 			}
 			continue
@@ -484,7 +496,7 @@ func affectedByRefresh(st *state.State, updates []*snap.Info) (map[string]*Affec
 				}
 				for _, cref := range conns {
 					// affected only if it wasn't optimized out above
-					if all[cref.PlugRef.Snap] != nil {
+					if snapsWithHook[cref.PlugRef.Snap] != nil {
 						addAffected(cref.PlugRef.Snap, up.InstanceName(), true, false)
 					}
 				}
@@ -508,7 +520,7 @@ func affectedByRefresh(st *state.State, updates []*snap.Info) (map[string]*Affec
 					return nil, err
 				}
 				for _, cref := range conns {
-					if all[cref.PlugRef.Snap] != nil {
+					if snapsWithHook[cref.PlugRef.Snap] != nil {
 						addAffected(cref.PlugRef.Snap, up.InstanceName(), true, false)
 					}
 				}
@@ -527,7 +539,7 @@ func affectedByRefresh(st *state.State, updates []*snap.Info) (map[string]*Affec
 				return nil, err
 			}
 			for _, cref := range conns {
-				if all[cref.SlotRef.Snap] != nil {
+				if snapsWithHook[cref.SlotRef.Snap] != nil {
 					addAffected(cref.SlotRef.Snap, up.InstanceName(), true, false)
 				}
 			}

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -747,7 +747,7 @@ func (s *autorefreshGatingSuite) TestAffectedByBase(c *C) {
 
 	c.Assert(s.repo.AddSnap(snapB), IsNil)
 
-	updates := []*snap.Info{baseSnapA}
+	updates := []string{baseSnapA.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
@@ -774,7 +774,7 @@ func (s *autorefreshGatingSuite) TestAffectedByCore(c *C) {
 	c.Assert(s.repo.AddSnap(snapB), IsNil)
 	c.Assert(s.repo.AddSnap(snapC), IsNil)
 
-	updates := []*snap.Info{core}
+	updates := []string{core.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
@@ -797,7 +797,7 @@ func (s *autorefreshGatingSuite) TestAffectedByKernel(c *C) {
 	mockInstalledSnap(c, s.state, snapCyaml, useHook)
 	mockInstalledSnap(c, s.state, snapByaml, noHook)
 
-	updates := []*snap.Info{kernel}
+	updates := []string{kernel.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
@@ -818,7 +818,7 @@ func (s *autorefreshGatingSuite) TestAffectedBySelf(c *C) {
 	defer st.Unlock()
 
 	snapC := mockInstalledSnap(c, s.state, snapCyaml, useHook)
-	updates := []*snap.Info{snapC}
+	updates := []string{snapC.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
@@ -840,7 +840,7 @@ func (s *autorefreshGatingSuite) TestAffectedByGadget(c *C) {
 	mockInstalledSnap(c, s.state, snapCyaml, useHook)
 	mockInstalledSnap(c, s.state, snapByaml, noHook)
 
-	updates := []*snap.Info{kernel}
+	updates := []string{kernel.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
@@ -872,7 +872,7 @@ func (s *autorefreshGatingSuite) TestAffectedBySlot(c *C) {
 	_, err := s.repo.Connect(cref, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	updates := []*snap.Info{snapD}
+	updates := []string{snapD.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
@@ -904,7 +904,7 @@ func (s *autorefreshGatingSuite) TestNotAffectedByCoreOrSnapdSlot(c *C) {
 	_, err := s.repo.Connect(cref, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	updates := []*snap.Info{core}
+	updates := []string{core.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, HasLen, 0)
@@ -932,7 +932,7 @@ func (s *autorefreshGatingSuite) TestAffectedByPlugWithMountBackend(c *C) {
 	c.Assert(err, IsNil)
 
 	// snapE has a plug using mount backend and is refreshed, this affects slot of snap-d.
-	updates := []*snap.Info{snapE}
+	updates := []string{snapE.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
@@ -965,7 +965,7 @@ func (s *autorefreshGatingSuite) TestAffectedByPlugWithMountBackendSnapdSlot(c *
 	c.Assert(err, IsNil)
 
 	// snapE has a plug using mount backend, refreshing snapd affects snapE.
-	updates := []*snap.Info{snapdSnap}
+	updates := []string{snapdSnap.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
@@ -995,7 +995,7 @@ func (s *autorefreshGatingSuite) TestAffectedByPlugWithMountBackendCoreSlot(c *C
 	c.Assert(err, IsNil)
 
 	// snapG has a plug using mount backend, refreshing core affects snapE.
-	updates := []*snap.Info{coreSnap}
+	updates := []string{coreSnap.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
@@ -1023,7 +1023,7 @@ func (s *autorefreshGatingSuite) TestAffectedByBootBase(c *C) {
 	mockInstalledSnap(c, s.state, snapEyaml, useHook)
 	core18 := mockInstalledSnap(c, s.state, core18Yaml, noHook)
 
-	updates := []*snap.Info{core18}
+	updates := []string{core18.InstanceName()}
 	affected, err := snapstate.AffectedByRefresh(st, updates)
 	c.Assert(err, IsNil)
 	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -808,6 +808,26 @@ func (s *autorefreshGatingSuite) TestAffectedByKernel(c *C) {
 			}}})
 }
 
+func (s *autorefreshGatingSuite) TestAffectedBySelf(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	snapC := mockInstalledSnap(c, s.state, snapCyaml, useHook)
+	updates := []*snap.Info{snapC}
+	affected, err := snapstate.AffectedByRefresh(st, updates)
+	c.Assert(err, IsNil)
+	c.Check(affected, DeepEquals, map[string]*snapstate.AffectedSnapInfo{
+		"snap-c": {
+			AffectingSnaps: map[string]bool{
+				"snap-c": true,
+			}}})
+}
+
 func (s *autorefreshGatingSuite) TestAffectedByGadget(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
@@ -840,7 +860,7 @@ func (s *autorefreshGatingSuite) TestAffectedBySlot(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	snapD := mockInstalledSnap(c, s.state, snapDyaml, useHook)
+	snapD := mockInstalledSnap(c, s.state, snapDyaml, noHook)
 	snapE := mockInstalledSnap(c, s.state, snapEyaml, useHook)
 	// unrelated snap
 	snapF := mockInstalledSnap(c, s.state, snapFyaml, useHook)
@@ -900,7 +920,7 @@ func (s *autorefreshGatingSuite) TestAffectedByPlugWithMountBackend(c *C) {
 	defer st.Unlock()
 
 	snapD := mockInstalledSnap(c, s.state, snapDyaml, useHook)
-	snapE := mockInstalledSnap(c, s.state, snapEyaml, useHook)
+	snapE := mockInstalledSnap(c, s.state, snapEyaml, noHook)
 	// unrelated snap
 	snapF := mockInstalledSnap(c, s.state, snapFyaml, useHook)
 
@@ -932,7 +952,7 @@ func (s *autorefreshGatingSuite) TestAffectedByPlugWithMountBackendSnapdSlot(c *
 	st.Lock()
 	defer st.Unlock()
 
-	snapdSnap := mockInstalledSnap(c, s.state, snapdYaml, useHook)
+	snapdSnap := mockInstalledSnap(c, s.state, snapdYaml, noHook)
 	snapG := mockInstalledSnap(c, s.state, snapGyaml, useHook)
 	// unrelated snap
 	snapF := mockInstalledSnap(c, s.state, snapFyaml, useHook)

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1399,6 +1399,12 @@ func (s *autorefreshGatingSuite) TestAffectedByRefreshUsesCurrentSnapInfo(c *C) 
 	c.Assert(task.Get("hook-setup", &hs), IsNil)
 	c.Check(hs.Hook, Equals, "gate-auto-refresh")
 	c.Check(hs.Snap, Equals, "snap-b")
+	var data interface{}
+	c.Assert(task.Get("hook-context", &data), IsNil)
+	c.Check(data, DeepEquals, map[string]interface{}{
+		"base":            true,
+		"restart":         false,
+		"affecting-snaps": []interface{}{"base-snap-b", "snap-b"}})
 
 	// check that refresh-candidates in the state were updated
 	var candidates map[string]*snapstate.RefreshCandidate

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -319,9 +319,6 @@ func MockSecurityProfilesDiscardLate(fn func(snapName string, rev snap.Revision,
 	}
 }
 
-// autorefresh gating
-type AffectedSnapInfo = affectedSnapInfo
-
 type HoldState = holdState
 
 var (


### PR DESCRIPTION
Some changes to preapare affectedByRefresh for reusing when called from hookstate:

- Change affectedByRefresh implementation to consider the snap being updated as affecting itself instead of adding self-dependency explicitly (externally by the caller).
- Make affectedSnapInfo exported
- Pass current snap infos rather than upcoming updates infos to affectedByRefresh.

The hookstate will use another helper instead of calling affectedByRefresh directly, therefore it's not exported.