### PR TITLE
tests/main/snapd-snap: install 4.x snapcraft to build the snapd snap

### DIFF
--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -50,8 +50,8 @@ prepare: |
         tests.cleanup defer rm -f /snap
     fi
 
-    echo "Install snapcraft from candidate"
-    snap install snapcraft --candidate --classic
+    echo "Install snapcraft from 4.x/candidate"
+    snap install snapcraft --channel=4.x/candidate --classic
     tests.cleanup defer snap remove --purge snapcraft
 
     if [ "$SNAPCRAFT_BUILD_ENVIRONMENT" = "lxd" ]; then


### PR DESCRIPTION
The snapd snap does not yet specify a base, so it is no longer buildable with
snapcraft 5.x, which drops support for baseless and base: core snaps.

Instead, use 4.x channel of snapcraft which does still support this scenario.