### PR TITLE
o/snapstate: add AffectedByRefreshCandidates helper

### DIFF
--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -380,6 +380,22 @@ type AffectedSnapInfo struct {
 	AffectingSnaps map[string]bool
 }
 
+// AffectedByRefreshCandidates returns information about all snaps affected by
+// current refresh-candidates in the state.
+func AffectedByRefreshCandidates(st *state.State) (map[string]*AffectedSnapInfo, error) {
+	var candidates map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &candidates); err != nil && err != state.ErrNoState {
+		return nil, err
+	}
+
+	snaps := make([]string, 0, len(candidates))
+	for cand := range candidates {
+		snaps = append(snaps, cand)
+	}
+	affected, err := affectedByRefresh(st, snaps)
+	return affected, err
+}
+
 func affectedByRefresh(st *state.State, updates []string) (map[string]*AffectedSnapInfo, error) {
 	allSnaps, err := All(st)
 	if err != nil {

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -383,7 +383,9 @@ type AffectedSnapInfo struct {
 // AffectedByRefreshCandidates returns information about all snaps affected by
 // current refresh-candidates in the state.
 func AffectedByRefreshCandidates(st *state.State) (map[string]*AffectedSnapInfo, error) {
-	var candidates map[string]*refreshCandidate
+	// we care only about the keys so this can use
+	// *json.RawMessage instead of refreshCandidates
+	var candidates map[string]*json.RawMessage
 	if err := st.Get("refresh-candidates", &candidates); err != nil && err != state.ErrNoState {
 		return nil, err
 	}


### PR DESCRIPTION
Add AffectedByRefreshCandidates helper for use from hookstate. Having the helper avoids exporting of snapstate.refreshCandidate (there is a simplified version of refreshCandidate in hookstate, for gating hook only).



