### PR TITLE
tests: update nested wait for snapd command

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -52,7 +52,7 @@ nested_wait_for_no_ssh() {
 }
 
 nested_wait_for_snap_command() {
-    # In this function cannot be used the remote retry command because it could
+    # In this function the remote retry command cannot be used because it could
     # be executed before the tool is deployed.
     local retry=200
     local wait=1

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -57,7 +57,7 @@ nested_wait_for_snap_command() {
     local retry=200
     local wait=1
 
-    while not nested_exec "command -v snap"; do
+    while ! nested_exec "command -v snap"; do
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
             echo "Timed out waiting for command 'command -v snap' to success. Aborting!"
@@ -1019,10 +1019,10 @@ nested_start_core_vm_unit() {
         nested_wait_for_snap_command
         # Wait for snap seeding to be done
         nested_exec "sudo snap wait system seed.loaded"
-        # Wait for cloud init to be done
-        nested_exec "retry --wait 1 -n 5 sh -c 'cloud-init status --wait'"
         # Copy tools to be used on tests
         nested_prepare_tools
+        # Wait for cloud init to be done
+        nested_exec "retry --wait 1 -n 5 sh -c 'cloud-init status --wait'"
     fi
 }
 


### PR DESCRIPTION
I see that sometimes the uc20 nested tests fail because of a disconnection
with the remote vm. The problem seems to be a race because the snpad
snap is installed while the tools are being prepared.

To fix that the idea is to prepare the tools after we check snap command
is ready.

error in test:
2021-07-30T02:21:20.4738952Z Warning: Permanently added
'[localhost]:8022' (ECDSA) to the list of known hosts.
2021-07-30T02:21:20.4740233Z
PATH=/writable/test-tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
2021-07-30T02:21:20.4741638Z Warning: Permanently added
'[localhost]:8022' (ECDSA) to the list of known hosts.
2021-07-30T02:21:20.4742645Z Connection to localhost closed by remote
host.
2021-07-30T02:21:20.4743582Z -----

vm journal log:
[   23.550890] systemd-logind[878]: New session 21 of user user1.
[   23.554706] systemd[1]: Started Session 21 of user user1.
[   24.088541] systemd[1]: Created slice system-console\x2dconf.slice.
[   24.095905] systemd[1]: Created slice
system-serial\x2dconsole\x2dconf.slice.
[   24.318152] sshd[1527]: Connection closed by 10.0.2.2 port 50750
[preauth]
[   24.462615] systemd[1]: Reloading.
[   24.674621] systemd[1]: emergency.target: Requested dependency
OnFailure=reboot.target ignored (target units cannot fail).
[   24.869609] systemd[1]: Reloading.
[   25.070768] systemd[1]: emergency.target: Requested dependency
OnFailure=reboot.target ignored (target units cannot fail).
[   25.238908] systemd[1]: Mounting Mount unit for snapd, revision x1...
[   25.299687] systemd[1]: Mounted Mount unit for snapd, revision x1.
[   25.763110] systemd[1]: Reloading.
[   25.991015] systemd[1]: emergency.target: Requested dependency
OnFailure=reboot.target ignored (target units cannot fail).
[   26.164923] systemd[1]: Reloading.