### PR TITLE
o/assertstate: fix missing 'scheduled' header when auto refreshing assertions

### DIFF
--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -336,7 +336,7 @@ func snapUpdate(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 	}
 
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can
-	if err = assertstateRefreshSnapDeclarations(st, inst.userID); err != nil {
+	if err = assertstateRefreshSnapDeclarations(st, inst.userID, nil); err != nil {
 		return "", nil, err
 	}
 
@@ -585,7 +585,7 @@ func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionRe
 
 func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can, this also ensures that snap-declarations and their prerequisite assertions are updated regularly
-	if err := assertstateRefreshSnapDeclarations(st, inst.userID); err != nil {
+	if err := assertstateRefreshSnapDeclarations(st, inst.userID, nil); err != nil {
 		return nil, err
 	}
 

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -478,7 +478,7 @@ func (s *snapsSuite) TestPostSnapsOpMoreComplexContentType(c *check.C) {
 }
 
 func (s *snapsSuite) testPostSnapsOp(c *check.C, contentType string) {
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(*state.State, int) error { return nil })()
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(*state.State, int, *assertstate.RefreshAssertionsOptions) error { return nil })()
 	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
 		c.Check(names, check.HasLen, 0)
 		t := s.NewTask("fake-refresh-all", "Refreshing everything")
@@ -519,9 +519,9 @@ func (s *snapsSuite) TestPostSnapsOpInvalidCharset(c *check.C) {
 
 func (s *snapsSuite) TestRefreshAll(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		refreshSnapDecls = true
-		return assertstate.RefreshSnapDeclarations(s, userID)
+		return assertstate.RefreshSnapDeclarations(s, userID, opts)
 	})()
 
 	d := s.daemon(c)
@@ -555,9 +555,9 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 
 func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		refreshSnapDecls = true
-		return assertstate.RefreshSnapDeclarations(s, userID)
+		return assertstate.RefreshSnapDeclarations(s, userID, opts)
 	})()
 
 	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
@@ -578,7 +578,7 @@ func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 
 func (s *snapsSuite) TestRefreshMany(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
 		refreshSnapDecls = true
 		return nil
 	})()
@@ -603,7 +603,7 @@ func (s *snapsSuite) TestRefreshMany(c *check.C) {
 
 func (s *snapsSuite) TestRefreshMany1(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
 		refreshSnapDecls = true
 		return nil
 	})()
@@ -1434,7 +1434,7 @@ func (s *snapsSuite) TestInstallIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-install-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1600,7 +1600,7 @@ func (s *snapsSuite) TestRefresh(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		assertstateCalledUserID = userID
 		return nil
 	})()
@@ -1639,7 +1639,7 @@ func (s *snapsSuite) TestRefreshDevMode(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1673,7 +1673,7 @@ func (s *snapsSuite) TestRefreshClassic(c *check.C) {
 		calledFlags = flags
 		return nil, nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1707,7 +1707,7 @@ func (s *snapsSuite) TestRefreshIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1746,7 +1746,7 @@ func (s *snapsSuite) TestRefreshIgnoreRunning(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1781,7 +1781,7 @@ func (s *snapsSuite) TestRefreshCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1811,7 +1811,7 @@ func (s *snapsSuite) TestRefreshLeaveCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -105,7 +106,7 @@ func MockUnsafeReadSnapInfo(mock func(string) (*snap.Info, error)) (restore func
 	}
 }
 
-func MockAssertstateRefreshSnapDeclarations(mock func(*state.State, int) error) (restore func()) {
+func MockAssertstateRefreshSnapDeclarations(mock func(*state.State, int, *assertstate.RefreshAssertionsOptions) error) (restore func()) {
 	oldAssertstateRefreshSnapDeclarations := assertstateRefreshSnapDeclarations
 	assertstateRefreshSnapDeclarations = mock
 	return func() {

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -55,8 +55,16 @@ func findError(format string, ref *asserts.Ref, err error) error {
 	}
 }
 
+type RefreshAssertionsOptions struct {
+	IsAutoRefresh bool
+}
+
 // RefreshSnapDeclarations refetches all the current snap declarations and their prerequisites.
-func RefreshSnapDeclarations(s *state.State, userID int) error {
+func RefreshSnapDeclarations(s *state.State, userID int, opts *RefreshAssertionsOptions) error {
+	if opts == nil {
+		opts = &RefreshAssertionsOptions{}
+	}
+
 	deviceCtx, err := snapstate.DevicePastSeeding(s, nil)
 	if err != nil {
 		return err
@@ -67,7 +75,7 @@ func RefreshSnapDeclarations(s *state.State, userID int) error {
 		return nil
 	}
 
-	err = bulkRefreshSnapDeclarations(s, snapStates, userID, deviceCtx)
+	err = bulkRefreshSnapDeclarations(s, snapStates, userID, deviceCtx, opts)
 	if err == nil {
 		// done
 		return nil
@@ -336,15 +344,20 @@ func delayedCrossMgrInit() {
 
 // AutoRefreshAssertions tries to refresh all assertions
 func AutoRefreshAssertions(s *state.State, userID int) error {
-	if err := RefreshSnapDeclarations(s, userID); err != nil {
+	opts := &RefreshAssertionsOptions{IsAutoRefresh: true}
+	if err := RefreshSnapDeclarations(s, userID, opts); err != nil {
 		return err
 	}
-	return RefreshValidationSetAssertions(s, userID)
+	return RefreshValidationSetAssertions(s, userID, opts)
 }
 
 // RefreshValidationSetAssertions tries to refresh all validation set
 // assertions.
-func RefreshValidationSetAssertions(s *state.State, userID int) error {
+func RefreshValidationSetAssertions(s *state.State, userID int, opts *RefreshAssertionsOptions) error {
+	if opts == nil {
+		opts = &RefreshAssertionsOptions{}
+	}
+
 	deviceCtx, err := snapstate.DevicePastSeeding(s, nil)
 	if err != nil {
 		return err
@@ -391,7 +404,7 @@ func RefreshValidationSetAssertions(s *state.State, userID int) error {
 		return nil
 	}
 
-	if err := bulkRefreshValidationSetAsserts(s, monitorModeSets, nil, userID, deviceCtx); err != nil {
+	if err := bulkRefreshValidationSetAsserts(s, monitorModeSets, nil, userID, deviceCtx, opts); err != nil {
 		return err
 	}
 	if err := updateTracking(monitorModeSets); err != nil {
@@ -430,7 +443,7 @@ func RefreshValidationSetAssertions(s *state.State, userID int) error {
 		return vsets.Conflict()
 	}
 
-	if err := bulkRefreshValidationSetAsserts(s, enforceModeSets, checkForConflicts, userID, deviceCtx); err != nil {
+	if err := bulkRefreshValidationSetAsserts(s, enforceModeSets, checkForConflicts, userID, deviceCtx, opts); err != nil {
 		if _, ok := err.(*snapasserts.ValidationSetsConflictError); ok {
 			logger.Noticef("cannot refresh to conflicting validation set assertions: %v", err)
 			return nil
@@ -514,7 +527,8 @@ func ValidationSetAssertionForMonitor(st *state.State, accountID, name string, s
 		}
 	}
 
-	if err := resolvePoolNoFallback(st, pool, nil, userID, deviceCtx); err != nil {
+	refreshOpts := &RefreshAssertionsOptions{IsAutoRefresh: false}
+	if err := resolvePoolNoFallback(st, pool, nil, userID, deviceCtx, refreshOpts); err != nil {
 		rerr, ok := err.(*resolvePoolError)
 		if ok && as != nil && opts.AllowLocalFallback {
 			if e := rerr.errors[atSeq.Unique()]; asserts.IsNotFound(e) {
@@ -549,9 +563,11 @@ func ValidationSetAssertionForEnforce(st *state.State, accountID, name string, s
 		return nil, err
 	}
 
+	opts := &RefreshAssertionsOptions{IsAutoRefresh: false}
+
 	// refresh all currently tracked validation set assertions (this may or may not
 	// include the one requested by the caller).
-	if err = RefreshValidationSetAssertions(st, userID); err != nil {
+	if err = RefreshValidationSetAssertions(st, userID, opts); err != nil {
 		return nil, err
 	}
 
@@ -664,7 +680,7 @@ func ValidationSetAssertionForEnforce(st *state.State, accountID, name string, s
 		return nil
 	}
 
-	if err := resolvePoolNoFallback(st, pool, checkBeforeCommit, userID, deviceCtx); err != nil {
+	if err := resolvePoolNoFallback(st, pool, checkBeforeCommit, userID, deviceCtx, opts); err != nil {
 		return nil, err
 	}
 

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -84,6 +84,7 @@ type fakeStore struct {
 	maxValidationSetSupportedFormat int
 
 	requestedTypes [][]string
+	opts           *store.RefreshOptions
 
 	snapActionErr         error
 	downloadAssertionsErr error
@@ -121,6 +122,8 @@ func (sto *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.Curren
 	if sto.snapActionErr != nil {
 		return nil, nil, sto.snapActionErr
 	}
+
+	sto.opts = opts
 
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, sto.maxDeclSupportedFormat)
 	defer restore()
@@ -951,7 +954,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsTooEarly(c *C) {
 	r := snapstatetest.MockDeviceModel(nil)
 	defer r()
 
-	err := assertstate.RefreshSnapDeclarations(s.state, 0)
+	err := assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Check(err, FitsTypeOf, &snapstate.ChangeConflictError{})
 }
 
@@ -961,8 +964,9 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsNop(c *C) {
 
 	s.setModel(sysdb.GenericClassicModel())
 
-	err := assertstate.RefreshSnapDeclarations(s.state, 0)
+	err := assertstate.RefreshSnapDeclarations(s.state, 0, &assertstate.RefreshAssertionsOptions{IsAutoRefresh: true})
 	c.Assert(err, IsNil)
+	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, true)
 }
 
 func (s *assertMgrSuite) TestRefreshSnapDeclarationsNoStore(c *C) {
@@ -1008,7 +1012,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsNoStore(c *C) {
 	err = s.storeSigning.Add(snapDeclFoo1)
 	c.Assert(err, IsNil)
 
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
@@ -1028,7 +1032,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsNoStore(c *C) {
 	err = s.storeSigning.Add(dev1Acct1)
 	c.Assert(err, IsNil)
 
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	a, err = assertstate.DB(s.state).Find(asserts.AccountType, map[string]string{
@@ -1060,7 +1064,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsNoStore(c *C) {
 	})()
 
 	// no error, kept the old one
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	a, err = assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
@@ -1118,7 +1122,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsChangingKey(c *C) {
 	_, err = storeKey2.Ref().Resolve(assertstate.DB(s.state).Find)
 	c.Check(asserts.IsNotFound(err), Equals, true)
 
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
@@ -1167,7 +1171,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsWithStore(c *C) {
 	c.Assert(err, IsNil)
 
 	// store assertion is missing
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
@@ -1195,7 +1199,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsWithStore(c *C) {
 	err = s.storeSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	a, err = assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
@@ -1224,7 +1228,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsWithStore(c *C) {
 	err = s.storeSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, IsNil)
 	a, err = assertstate.DB(s.state).Find(asserts.StoreType, map[string]string{
 		"store": "my-brand-store",
@@ -1267,7 +1271,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsDownloadError(c *C) {
 
 	s.fakeStore.(*fakeStore).downloadAssertionsErr = errors.New("download error")
 
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, ErrorMatches, `cannot refresh snap-declarations for snaps:
  - foo: download error`)
 }
@@ -1307,7 +1311,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsPersistentNetworkError(c *C)
 	pne := new(httputil.PersistentNetworkError)
 	s.fakeStore.(*fakeStore).snapActionErr = pne
 
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, Equals, pne)
 }
 
@@ -1393,7 +1397,7 @@ func (s *assertMgrSuite) testRefreshSnapDeclarationsMany(c *C, n int) error {
 		c.Assert(err, IsNil)
 	}
 
-	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	if err != nil {
 		// fot the caller to check
 		return err
@@ -2150,7 +2154,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsNop(c *C) {
 
 	s.setModel(sysdb.GenericClassicModel())
 
-	err := assertstate.RefreshValidationSetAssertions(s.state, 0)
+	err := assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -2182,6 +2186,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefresh(c *C) {
 	assertstate.UpdateValidationSet(s.state, &tr)
 
 	c.Assert(assertstate.AutoRefreshAssertions(s.state, 0), IsNil)
+	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, true)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
@@ -2235,7 +2240,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsStoreError(c *C) {
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 
-	err := assertstate.RefreshValidationSetAssertions(s.state, 0)
+	err := assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
 	c.Assert(err, ErrorMatches, `cannot refresh validation set assertions: cannot : got unexpected HTTP status code 400.*`)
 }
 
@@ -2268,7 +2273,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 
-	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0, &assertstate.RefreshAssertionsOptions{IsAutoRefresh: true})
 	c.Assert(err, IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
@@ -2284,6 +2289,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
 		{"account", "account-key", "validation-set"},
 	})
+	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, true)
 
 	// sequence changed in the store to 4
 	vsetAs3 := s.validationSetAssert(c, "bar", "4", "3", "required")
@@ -2300,7 +2306,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	c.Assert(asserts.IsNotFound(err), Equals, true)
 
 	s.fakeStore.(*fakeStore).requestedTypes = nil
-	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
@@ -2354,7 +2360,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsPinned(c *C) {
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 
-	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
@@ -2378,7 +2384,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsPinned(c *C) {
 	c.Assert(err, IsNil)
 
 	s.fakeStore.(*fakeStore).requestedTypes = nil
-	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
@@ -2443,7 +2449,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsLocalOnlyFailed(c *C)
 	assertstate.UpdateValidationSet(s.state, &tr1)
 	assertstate.UpdateValidationSet(s.state, &tr2)
 
-	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	// sanity - local assertion vsetAs1 is the latest
@@ -2515,7 +2521,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeHappyNot
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 
-	err = assertstate.RefreshValidationSetAssertions(s.state, 0)
+	err = assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
@@ -2580,7 +2586,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeHappyPin
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 
-	c.Assert(assertstate.RefreshValidationSetAssertions(s.state, 0), IsNil)
+	c.Assert(assertstate.RefreshValidationSetAssertions(s.state, 0, nil), IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
@@ -2644,7 +2650,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeConflict
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 
-	c.Assert(assertstate.RefreshValidationSetAssertions(s.state, 0), IsNil)
+	c.Assert(assertstate.RefreshValidationSetAssertions(s.state, 0, nil), IsNil)
 	c.Assert(logbuf.String(), Matches, `.*cannot refresh to conflicting validation set assertions: validation sets are in conflict:\n- cannot constrain snap "foo" as both invalid .* and required at revision 1.*\n`)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
@@ -2844,6 +2850,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforcePinnedHappy(c *C) {
 		"sequence":   "2",
 	})
 	c.Assert(err, IsNil)
+	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
 }
 
 func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyMissingSnap(c *C) {

--- a/overlord/assertstate/bulk.go
+++ b/overlord/assertstate/bulk.go
@@ -44,14 +44,14 @@ const storeGroup = "store assertion"
 // that. Most systems should be done in one request anyway.
 var maxGroups = 256
 
-func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstate.SnapState, userID int, deviceCtx snapstate.DeviceContext) error {
+func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstate.SnapState, userID int, deviceCtx snapstate.DeviceContext, opts *RefreshAssertionsOptions) error {
 	db := cachedDB(s)
 
 	pool := asserts.NewPool(db, maxGroups)
 
 	var mergedRPErr *resolvePoolError
 	tryResolvePool := func() error {
-		err := resolvePool(s, pool, nil, userID, deviceCtx)
+		err := resolvePool(s, pool, nil, userID, deviceCtx, opts)
 		if rpe, ok := err.(*resolvePoolError); ok {
 			if mergedRPErr == nil {
 				mergedRPErr = rpe
@@ -140,7 +140,7 @@ func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstat
 	return nil
 }
 
-func bulkRefreshValidationSetAsserts(s *state.State, vsets map[string]*ValidationSetTracking, beforeCommitChecker func(*asserts.Database, asserts.Backstore) error, userID int, deviceCtx snapstate.DeviceContext) error {
+func bulkRefreshValidationSetAsserts(s *state.State, vsets map[string]*ValidationSetTracking, beforeCommitChecker func(*asserts.Database, asserts.Backstore) error, userID int, deviceCtx snapstate.DeviceContext, opts *RefreshAssertionsOptions) error {
 	db := cachedDB(s)
 	pool := asserts.NewPool(db, maxGroups)
 
@@ -175,7 +175,7 @@ func bulkRefreshValidationSetAsserts(s *state.State, vsets map[string]*Validatio
 		}
 	}
 
-	err := resolvePoolNoFallback(s, pool, beforeCommitChecker, userID, deviceCtx)
+	err := resolvePoolNoFallback(s, pool, beforeCommitChecker, userID, deviceCtx, opts)
 	if err == nil {
 		return nil
 	}
@@ -242,7 +242,7 @@ func (rpe *resolvePoolError) Error() string {
 	return strings.Join(s, "\n")
 }
 
-func resolvePool(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*asserts.Database, asserts.Backstore) error, userID int, deviceCtx snapstate.DeviceContext) error {
+func resolvePool(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*asserts.Database, asserts.Backstore) error, userID int, deviceCtx snapstate.DeviceContext, opts *RefreshAssertionsOptions) error {
 	user, err := userFromUserID(s, userID)
 	if err != nil {
 		return err
@@ -252,9 +252,9 @@ func resolvePool(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*ass
 	unsupported := handleUnsupported(db)
 
 	for {
-		// TODO: pass refresh options?
+		storeOpts := &store.RefreshOptions{IsAutoRefresh: opts.IsAutoRefresh}
 		s.Unlock()
-		_, aresults, err := sto.SnapAction(context.TODO(), nil, nil, pool, user, nil)
+		_, aresults, err := sto.SnapAction(context.TODO(), nil, nil, pool, user, storeOpts)
 		s.Lock()
 		if err != nil {
 			// request fallback on
@@ -313,8 +313,8 @@ func resolvePool(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*ass
 	return nil
 }
 
-func resolvePoolNoFallback(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*asserts.Database, asserts.Backstore) error, userID int, deviceCtx snapstate.DeviceContext) error {
-	err := resolvePool(s, pool, checkBeforeCommit, userID, deviceCtx)
+func resolvePoolNoFallback(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*asserts.Database, asserts.Backstore) error, userID int, deviceCtx snapstate.DeviceContext, opts *RefreshAssertionsOptions) error {
+	err := resolvePool(s, pool, checkBeforeCommit, userID, deviceCtx, opts)
 	if err != nil {
 		// no fallback, report inner error.
 		if ferr, ok := err.(*bulkAssertionFallbackError); ok {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3149,7 +3149,7 @@ apps:
 	s.serveSnap(fooPath, "15")
 
 	// refresh all
-	err = assertstate.RefreshSnapDeclarations(st, 0)
+	err = assertstate.RefreshSnapDeclarations(st, 0, nil)
 	c.Assert(err, IsNil)
 
 	updated, tss, err := snapstate.UpdateMany(context.TODO(), st, nil, 0, nil)
@@ -3754,7 +3754,7 @@ version: @VERSION@`
 	c.Assert(repo.AddSnap(coreInfo), IsNil)
 
 	// refresh all
-	err := assertstate.RefreshSnapDeclarations(st, 0)
+	err := assertstate.RefreshSnapDeclarations(st, 0, nil)
 	c.Assert(err, IsNil)
 
 	updates, tts, err := snapstate.UpdateMany(context.TODO(), st, []string{"core", "some-snap", "other-snap"}, 0, nil)
@@ -3856,7 +3856,7 @@ version: 1`
 	c.Assert(repo.AddSnap(coreInfo), IsNil)
 
 	// refresh all
-	err := assertstate.RefreshSnapDeclarations(st, 0)
+	err := assertstate.RefreshSnapDeclarations(st, 0, nil)
 	c.Assert(err, IsNil)
 
 	updates, tts, err := snapstate.UpdateMany(context.TODO(), st, []string{"some-snap"}, 0, nil)
@@ -3936,7 +3936,7 @@ func (s *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, removeS
 	c.Assert(repo.AddSnap(otherInfo), IsNil)
 
 	// refresh all
-	err := assertstate.RefreshSnapDeclarations(st, 0)
+	err := assertstate.RefreshSnapDeclarations(st, 0, nil)
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Update(st, updateSnapName, nil, 0, snapstate.Flags{})
@@ -6704,7 +6704,7 @@ func (s *mgrsSuite) TestCheckRefreshFailureWithConcurrentRemoveOfConnectedSnap(c
 	c.Assert(err, IsNil)
 
 	// refresh all
-	c.Assert(assertstate.RefreshSnapDeclarations(st, 0), IsNil)
+	c.Assert(assertstate.RefreshSnapDeclarations(st, 0, nil), IsNil)
 
 	ts, err := snapstate.Update(st, "some-snap", nil, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)


### PR DESCRIPTION
When making requests to the snap store, some refresh requests with the 'fetch assertion' action were missing the "Snap-Refresh-Reason: scheduled" header. This was due to an unset RefreshOption when the assertions were auto refreshed. This PR sets the RefreshOptions when calling the store to make the refresh request.

https://bugs.launchpad.net/snapd/+bug/1937309