### PR TITLE
interfaces/tee: add support for Qualcomm qseecom device node

### DIFF
--- a/interfaces/builtin/tee.go
+++ b/interfaces/builtin/tee.go
@@ -41,11 +41,15 @@ const teeConnectedPlugAppArmor = `
 
 /dev/tee[0-9]* rw,
 /dev/teepriv[0-9]* rw,
+
+# Qualcomm equivalent qseecom (Qualcomm Secure Execution Environment Communicator)
+/dev/qseecom rw,
 `
 
 var teeConnectedPlugUDev = []string{
 	`KERNEL=="tee[0-9]*"`,
 	`KERNEL=="teepriv[0-9]*"`,
+	`KERNEL=="qseecom"`,
 }
 
 func init() {

--- a/interfaces/builtin/tee_test.go
+++ b/interfaces/builtin/tee_test.go
@@ -87,7 +87,7 @@ func (s *TeeInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *TeeInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 3)
+	c.Assert(spec.Snippets(), HasLen, 4)
 	c.Assert(spec.Snippets(), testutil.Contains, `# tee
 KERNEL=="tee[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# tee

--- a/interfaces/builtin/tee_test.go
+++ b/interfaces/builtin/tee_test.go
@@ -81,6 +81,7 @@ func (s *TeeInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/tee[0-9]*")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/qseecom")
 }
 
 func (s *TeeInterfaceSuite) TestUDevSpec(c *C) {
@@ -91,6 +92,8 @@ func (s *TeeInterfaceSuite) TestUDevSpec(c *C) {
 KERNEL=="tee[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# tee
 KERNEL=="teepriv[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# tee
+KERNEL=="qseecom", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains,
 		fmt.Sprintf(`TAG=="snap_consumer_app", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }


### PR DESCRIPTION
Add support for /dev/qseecom device node, equivalent of /dev/tee on Qualcomm SoC

