### PR TITLE
interfaces/interfaces/ion-memory-control: add: add interface for ion buf

### DIFF
--- a/interfaces/builtin/ion_memory_control.go
+++ b/interfaces/builtin/ion_memory_control.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const ionMemoryControlSummary = `allows access to The Android ION memory allocator`
+
+const ionMemoryControlBaseDeclarationSlots = `
+  ion-memory-control:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const ionMemoryControlBaseDeclarationPlugs = `
+  ion-memory-control:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const ionMemoryControlConnectedPlugAppArmor = `
+# Description: for those who need to talk to the Android ION memory allocator
+# /dev/ion
+
+/dev/ion rw,
+`
+
+var ionMemoryControlConnectedPlugUDev = []string{
+	`KERNEL=="ion"`,
+}
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "ion-memory-control",
+		summary:               ionMemoryControlSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  ionMemoryControlBaseDeclarationSlots,
+		baseDeclarationPlugs:  ionMemoryControlBaseDeclarationPlugs,
+		connectedPlugAppArmor: ionMemoryControlConnectedPlugAppArmor,
+		connectedPlugUDev:     ionMemoryControlConnectedPlugUDev,
+	})
+}

--- a/interfaces/builtin/ion_memory_control_test.go
+++ b/interfaces/builtin/ion_memory_control_test.go
@@ -1,0 +1,111 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type IonMemoryControlInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&IonMemoryControlInterfaceSuite{
+	iface: builtin.MustInterface("ion-memory-control"),
+})
+
+const ionMemoryControlConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [ion-memory-control]
+`
+
+const ionMemoryControlCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  ion-memory-control:
+`
+
+func (s *IonMemoryControlInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, ionMemoryControlConsumerYaml, nil, "ion-memory-control")
+	s.slot, s.slotInfo = MockConnectedSlot(c, ionMemoryControlCoreYaml, nil, "ion-memory-control")
+}
+
+func (s *IonMemoryControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "ion-memory-control")
+}
+
+func (s *IonMemoryControlInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *IonMemoryControlInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *IonMemoryControlInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/ion")
+}
+
+func (s *IonMemoryControlInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `# ion-memory-control
+KERNEL=="ion", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains,
+		fmt.Sprintf(`TAG=="snap_consumer_app", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *IonMemoryControlInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to The Android ION memory allocator`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "ion-memory-control")
+	c.Assert(si.BaseDeclarationPlugs, testutil.Contains, "allow-installation: false")
+}
+
+func (s *IonMemoryControlInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *IonMemoryControlInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}


### PR DESCRIPTION
Add interface for the Android ION memory allocator

device node: /dev/ion
```
$ udevadm info --query property /dev/ion
DEVPATH=/devices/virtual/misc/ion
DEVNAME=/dev/ion
MAJOR=10
MINOR=62
SUBSYSTEM=misc
```

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
