### PR TITLE
sysconfig/cloudinit.go: add functions for filtering cloud-init config

### DIFF
--- a/sysconfig/export_test.go
+++ b/sysconfig/export_test.go
@@ -19,6 +19,10 @@
 
 package sysconfig
 
+var (
+	FilterCloudCfgFile = filterCloudCfgFile
+)
+
 func CloudDatasourcesInUse(configFile string) (*CloudDatasourcesInUseResult, error) {
 	res, err := cloudDatasourcesInUse(configFile)
 	if err != nil {


### PR DESCRIPTION
This will filter out the config we allow on ubuntu-seed to a subset of
cloud-init configuration.

Currently, this just allows configuration as required by MAAS to setup a device
with cloud-init, but this could be expanded in the future.

Next and final PR (hopefully) for cloud-init MAAS support is https://github.com/snapcore/snapd/pull/10573 to see the context of how this is put together.