### PR TITLE
cgroup-support: allow to hide cgroupv2 warning via ENV

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -80,6 +80,7 @@ static const char *cgroup_dir = "/sys/fs/cgroup";
 // hybrid or legacy) The algorithm is described in
 // https://systemd.io/CGROUP_DELEGATION/
 bool sc_cgroup_is_v2(void) {
+    char *hide_warning = getenv("SNAPD_HIDE_CGROUPV2_WARNING");
     static bool did_warn = false;
     struct statfs buf;
 
@@ -90,12 +91,13 @@ bool sc_cgroup_is_v2(void) {
         die("cannot statfs %s", cgroup_dir);
     }
     if (buf.f_type == CGROUP2_SUPER_MAGIC) {
-        if (!did_warn) {
+        if (!did_warn && !hide_warning) {
             fprintf(stderr, "WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement\n");
             did_warn = true;
         }
         return true;
     }
+    free(hide_warning);
     return false;
 }
 

--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -80,7 +80,7 @@ static const char *cgroup_dir = "/sys/fs/cgroup";
 // hybrid or legacy) The algorithm is described in
 // https://systemd.io/CGROUP_DELEGATION/
 bool sc_cgroup_is_v2(void) {
-    char *hide_warning = getenv("SNAPD_HIDE_CGROUPV2_WARNING");
+    bool hide_warning = getenv_bool("SNAPD_HIDE_CGROUPV2_WARNING", false);
     static bool did_warn = false;
     struct statfs buf;
 

--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -97,7 +97,6 @@ bool sc_cgroup_is_v2(void) {
         }
         return true;
     }
-    free(hide_warning);
     return false;
 }
 

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -86,7 +86,7 @@ static int parse_bool(const char *text, bool *value, bool default_value)
  * printed to stderr. If the environment variable is unset, set value to the
  * default_value as if the environment variable was set to default_value.
  **/
-static bool getenv_bool(const char *name, bool default_value)
+bool getenv_bool(const char *name, bool default_value)
 {
 	const char *str_value = getenv(name);
 	bool value = default_value;

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -28,6 +28,16 @@ __attribute__((format(printf, 1, 2)))
 void debug(const char *fmt, ...);
 
 /**
+ * Get an environment variable and convert it to a boolean.
+ *
+ * Supported values are those of parse_bool(), namely "yes", "no" as well as "1"
+ * and "0". All other values are treated as false and a diagnostic message is
+ * printed to stderr. If the environment variable is unset, set value to the
+ * default_value as if the environment variable was set to default_value.
+ **/
+bool getenv_bool(const char *name, bool default_value);
+
+/**
  * Return true if debugging is enabled.
  *
  * This can used to avoid costly computation that is only useful for debugging.


### PR DESCRIPTION
Allow to hide the cgroup v2 warning by passing any value to `SNAPD_HIDE_CGROUPV2_WARNING`.
This warning to stderr makes systemd autopkgtests (and probably many others) fail and it would be handy if we could somehow disable it.