### PR TITLE
vendor: move to snapshot-4c814e1 branch and set fixed KDF options

### DIFF
--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -49,7 +49,7 @@ func FormatEncryptedDevice(key EncryptionKey, label, node string) error {
 // volume created with FormatEncryptedDevice on the block device given by node.
 // The existing key to the encrypted volume is provided in the key argument.
 func AddRecoveryKey(key EncryptionKey, rkey RecoveryKey, node string) error {
-	return sbAddRecoveryKeyToLUKS2Container(node, key[:], sb.RecoveryKey(rkey))
+	return sbAddRecoveryKeyToLUKS2Container(node, key[:], sb.RecoveryKey(rkey), nil)
 }
 
 func (k RecoveryKey) String() string {

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -41,6 +41,14 @@ func FormatEncryptedDevice(key EncryptionKey, label, node string) error {
 		// enough room
 		MetadataKiBSize:     metadataKiBSize,
 		KeyslotsAreaKiBSize: keyslotsAreaKiBSize,
+
+		// Use fixed parameters for the KDF to avoid the
+		// benchmark. This is okay because we have a high
+		// entropy key and the KDF does not gain us much.
+		KDFOptions: &sb.KDFOptions{
+			MemoryKiB:       32 * 1024,
+			ForceIterations: 4,
+		},
 	}
 	return sbInitializeLUKS2Container(node, label, key[:], opts)
 }

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -53,6 +53,10 @@ func (s *encryptSuite) TestFormatEncryptedDevice(c *C) {
 			c.Assert(opts, DeepEquals, &sb.InitializeLUKS2ContainerOptions{
 				MetadataKiBSize:     2048,
 				KeyslotsAreaKiBSize: 2560,
+				KDFOptions: &sb.KDFOptions{
+					MemoryKiB: 32768, TargetDuration: 0,
+					ForceIterations: 4, Parallel: 0,
+				},
 			})
 			return tc.initErr
 		})

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -85,11 +85,12 @@ func (s *encryptSuite) TestAddRecoveryKey(c *C) {
 		myRecoveryKey := secboot.RecoveryKey{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
 
 		calls := 0
-		restore := secboot.MockSbAddRecoveryKeyToLUKS2Container(func(devicePath string, key []byte, recoveryKey sb.RecoveryKey) error {
+		restore := secboot.MockSbAddRecoveryKeyToLUKS2Container(func(devicePath string, key []byte, recoveryKey sb.RecoveryKey, opts *sb.KDFOptions) error {
 			calls++
 			c.Assert(devicePath, Equals, "/dev/node")
 			c.Assert(recoveryKey[:], DeepEquals, myRecoveryKey[:])
 			c.Assert(key, DeepEquals, []byte(myKey))
+			c.Assert(opts, IsNil)
 			return tc.addErr
 		})
 		defer restore()

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -171,7 +171,7 @@ func MockSbInitializeLUKS2Container(f func(devicePath, label string, key []byte,
 	}
 }
 
-func MockSbAddRecoveryKeyToLUKS2Container(f func(devicePath string, key []byte, recoveryKey sb.RecoveryKey) error) (restore func()) {
+func MockSbAddRecoveryKeyToLUKS2Container(f func(devicePath string, key []byte, recoveryKey sb.RecoveryKey, opts *sb.KDFOptions) error) (restore func()) {
 	old := sbAddRecoveryKeyToLUKS2Container
 	sbAddRecoveryKeyToLUKS2Container = f
 	return func() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -124,10 +124,12 @@
 			"revisionTime": "2017-09-28T14:21:59Z"
 		},
 		{
-			"checksumSHA1": "uZ8BMhEjx/S92zmTxgHHPQ2OdGI=",
+			"checksumSHA1": "y23HtP/cMIz+v5xqAI3vlDTC0E0=",
 			"path": "github.com/snapcore/secboot",
-			"revision": "4c814e19258b95e671599097451fb98915d2b737",
-			"revisionTime": "2021-04-27T10:08:53Z"
+			"revision": "c9f2139ee92b282b7ae0f58d38958a9e2c0fc871",
+			"revisionTime": "2021-08-05T18:45:55Z",
+			"version": "snapshot-4c814e1",
+			"versionExact": "snapshot-4c814e1"
 		},
 		{
 			"checksumSHA1": "c7jHLQSWFWbymTcFWZMQH0C5Wik=",


### PR DESCRIPTION
This commit moves our secboot code to the `snapshot-4c814e1` branch
that contains fixes around the KDF benchmarking. This will improve
the install performance.
