### PR TITLE
c/snap,o/hookstate/ctlcmd: add JSON/string strict processing flags to snap/snapctl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cmd/VERSION
 *~
 *.swp
 .vscode/
+.idea/
 vendor/*/
 .spread-reuse*.yaml
 po/snappy.pot

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -38,6 +38,9 @@ type setCommand struct {
 		PlugOrSlotSpec string   `positional-arg-name:":<plug|slot>"`
 		ConfValues     []string `positional-arg-name:"key=value"`
 	} `positional-args:"yes"`
+
+	String bool `short:"s" description:"parse the value as a string"`
+	Typed  bool `short:"t" description:"parse the value strictly as JSON document"`
 }
 
 var shortSetHelp = i18n.G("Changes configuration options")
@@ -76,7 +79,11 @@ func (s *setCommand) Execute(args []string) error {
 		return fmt.Errorf("cannot set without a context")
 	}
 
-	// treat PlugOrSlotSpec argument as key=value if it contans '=' or doesn't contain ':' - this is to support
+	if s.Typed && s.String {
+		return fmt.Errorf("cannot use -t and -s together")
+	}
+
+	// treat PlugOrSlotSpec argument as key=value if it contains '=' or doesn't contain ':' - this is to support
 	// values such as "device-service.url=192.168.0.1:5555" and error out on invalid key=value if only "key" is given.
 	if strings.Contains(s.Positional.PlugOrSlotSpec, "=") || !strings.Contains(s.Positional.PlugOrSlotSpec, ":") {
 		s.Positional.ConfValues = append([]string{s.Positional.PlugOrSlotSpec}, s.Positional.ConfValues[0:]...)
@@ -111,10 +118,19 @@ func (s *setCommand) setConfigSetting(context *hookstate.Context) error {
 			return fmt.Errorf(i18n.G("invalid parameter: %q (want key=value)"), patchValue)
 		}
 		key := parts[0]
+
 		var value interface{}
-		if err := jsonutil.DecodeWithNumber(strings.NewReader(parts[1]), &value); err != nil {
-			// Not valid JSON-- just save the string as-is.
+		if s.String {
 			value = parts[1]
+		} else {
+			if err := jsonutil.DecodeWithNumber(strings.NewReader(parts[1]), &value); err != nil {
+				if s.Typed {
+					return fmt.Errorf("failed to parse JSON: %w", err)
+				}
+
+				// Not valid JSON-- just save the string as-is.
+				value = parts[1]
+			}
 		}
 
 		tr.Set(s.context().InstanceName(), key, value)

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -21,6 +21,7 @@ package ctlcmd_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	. "gopkg.in/check.v1"
@@ -201,6 +202,55 @@ func (s *setSuite) TestSetNumbers(c *C) {
 
 	c.Check(tr.Get("test-snap", "bar", &value), IsNil)
 	c.Check(value, Equals, json.Number("123456.7890"))
+}
+
+func (s *setSuite) TestSetStrictJSON(c *C) {
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "-t", `key={"a":"b", "c": 1, "d": {"e":"f"}}`}, 0)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+
+	// Notify the context that we're done. This should save the config.
+	s.mockContext.Lock()
+	defer s.mockContext.Unlock()
+	c.Check(s.mockContext.Done(), IsNil)
+
+	// Verify that the global config has been updated.
+	var value interface{}
+	tr := config.NewTransaction(s.mockContext.State())
+	c.Assert(tr.Get("test-snap", "key", &value), IsNil)
+	c.Check(value, DeepEquals, map[string]interface{}{"a": "b", "c": json.Number("1"), "d": map[string]interface{}{"e": "f"}})
+}
+
+func (s *setSuite) TestSetFailWithStrictJSON(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"set", "-t", `key=a`}, 0)
+	c.Assert(err, ErrorMatches, "failed to parse JSON:.*")
+}
+
+func (s *setSuite) TestSetAsString(c *C) {
+	expected := `{"a":"b", "c": 1, "d": {"e": "f"}}`
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "-s", fmt.Sprintf("key=%s", expected)}, 0)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+
+	// Notify the context that we're done. This should save the config.
+	s.mockContext.Lock()
+	defer s.mockContext.Unlock()
+	c.Check(s.mockContext.Done(), IsNil)
+
+	// Verify that the global config has been updated.
+	var value interface{}
+	tr := config.NewTransaction(s.mockContext.State())
+	c.Assert(tr.Get("test-snap", "key", &value), IsNil)
+	c.Check(value, Equals, expected)
+}
+
+func (s *setSuite) TestSetErrorOnStrictJSONAndString(c *C) {
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "-s", "-t", `{"a":"b"}`}, 0)
+	c.Assert(err, ErrorMatches, "cannot use -t and -s together")
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
 }
 
 func (s *setSuite) TestCommandSavesDeltasOnly(c *C) {


### PR DESCRIPTION
Adds two flags, `-s` and `-t`, to enable strict processing of the `snap/snapctl set` arguments as string and JSON, respectively. When using `-s`, the argument will be taken as is and when using `-t`, the argument will be parsed as JSON (and fail if it's invalid). The default behavior remains the same, snap/snapctl will try to parse the argument as JSON and, if that fails, fallback to handling it as a string. .

Note: the .gitignore commit is already in PR #10584 (I was waiting for that to be merged to open this, but I'll just rebase this PR once that merges)