### PR TITLE
bootloader: fix double extract of the kernel assets

### DIFF
--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -223,4 +223,6 @@ var (
 	EditionFromConfigAsset               = editionFromConfigAsset
 	ConfigAssetFrom                      = configAssetFrom
 	StaticCommandLineForGrubAssetEdition = staticCommandLineForGrubAssetEdition
+	ExtractKernelAssetsToBootDir         = extractKernelAssetsToBootDir
+	RemoveKernelAssetsFromBootDir        = removeKernelAssetsFromBootDir
 )

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -205,7 +205,7 @@ func (g *grub) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error
 }
 
 func (g *grub) RemoveKernelAssets(s snap.PlaceInfo) error {
-	return removeKernelAssetsFromBootDir(g.dir(), s)
+	return removeKernelAssetsFromBootDir(filepath.Join(g.dir(), s.Filename()))
 }
 
 // ExtractedRunKernelImageBootloader helper methods

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -201,5 +201,5 @@ func (u *uboot) ExtractRecoveryKernelAssets(recoverySystemDir string, s snap.Pla
 }
 
 func (u *uboot) RemoveKernelAssets(s snap.PlaceInfo) error {
-	return removeKernelAssetsFromBootDir(u.dir(), s)
+	return removeKernelAssetsFromBootDir(filepath.Join(u.dir(), s.Filename()))
 }


### PR DESCRIPTION
The current extractKernelAssetsToBootDir() code will overwrite
existing directories in an unsafe way. After "install" mode
ran the kernel will get extracted again overwriting the existing
kernel. This takes unnecessary time and is also risky as a
reboot in the middle may leave half written data.

This commit fixes this by extracting into a tmp dir first and
then atomically move the dir into place. If the final target
directory already exists the code will just do nothing. This is
safe because each kernel gets extracted into it's own
`${snap}_${rev}.unpacking` style directory now and only at
the end there is an atomic rename.
So either the dir is complete (the list of extracted assets is
static) or it does not exist. The other reason to do nothing is
that there is no good option what else to do. Removing the
final dest dir would make the system potentially unbootable,
unpacking into a tmpdir would use space during the unpack and
risk running out of diskspace for no gain and would
also mean we would need an atomic exchange of tmpdir and destDir
(using RENAME_EXCHANGE) and then delete the existing (now renamed dir).

The removeKernelAssetsFromBootDir() got also updated to remove
both the extracted and temporary unpack dir. This ensures that
the cleanup code that runs for failed extractions will DTRT.

Another way to fix this double extract issue is to add a flag for Backend.SetupSnap()
like `SkipKernelExtraction` and the `doMountSnap()` handler would set this if it
is called from a seeding change. Happy to pursue this path too if it is considered
nicer/cleaner. 