### PR TITLE
{device,snap}state: skip kernel extraction in seeding

### DIFF
--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -227,6 +227,9 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 	for _, seedSnap := range essentialSeedSnaps {
 		flags := snapstate.Flags{
 			SkipConfigure: true,
+			// The kernel is already there either from ubuntu-image or from "install"
+			// mode so skip extract.
+			SkipKernelExtraction: true,
 			// for dangerous models, allow all devmode snaps
 			// XXX: eventually we may need to allow specific snaps to be devmode for
 			// non-dangerous models, we can do that here since that information will
@@ -243,15 +246,6 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 			// wait for the previous configTss
 			configTss = chainTs(configTss, configTs)
 		}
-		// XXX: put this into "snapstate.Flags" instead?
-		if info.Type() == snap.TypeKernel {
-			for _, t := range ts.Tasks() {
-				if t.Kind() == "mount-snap" {
-					t.Set("skip-kernel-extract", true)
-				}
-			}
-		}
-
 		infos = append(infos, info)
 		infoToTs[info] = ts
 	}

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -243,6 +243,15 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 			// wait for the previous configTss
 			configTss = chainTs(configTss, configTs)
 		}
+		// XXX: put this into "snapstate.Flags" instead?
+		if info.Type() == snap.TypeKernel {
+			for _, t := range ts.Tasks() {
+				if t.Kind() == "mount-snap" {
+					t.Set("skip-kernel-extract", true)
+				}
+			}
+		}
+
 		infos = append(infos, info)
 		infoToTs[info] = ts
 	}

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -334,6 +334,10 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv
 	_, err = snapstate.CurrentInfo(state, "pc")
 	c.Check(err, IsNil)
 
+	// No kernel extraction happens during seeding, the kernel is already
+	// there either from ubuntu-image or from "install" mode.
+	c.Check(bloader.ExtractKernelAssetsCalls, HasLen, 0)
+
 	// ensure required flag is set on all essential snaps
 	var snapst snapstate.SnapState
 	for _, reqName := range []string{"snapd", "core20", "pc-kernel", "pc"} {

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -70,7 +70,7 @@ type StoreService interface {
 
 type managerBackend interface {
 	// install related
-	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
+	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, opts *backend.SetupSnapOpts, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 	LinkSnap(info *snap.Info, dev boot.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootRequired bool, err error)
 	StartServices(svcs []*snap.AppInfo, disabledSvcs []string, meter progress.Meter, tm timings.Measurer) error

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -70,7 +70,7 @@ type StoreService interface {
 
 type managerBackend interface {
 	// install related
-	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, opts *backend.SetupSnapOpts, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
+	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, opts *backend.SetupSnapOptions, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 	LinkSnap(info *snap.Info, dev boot.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootRequired bool, err error)
 	StartServices(svcs []*snap.AppInfo, disabledSvcs []string, meter progress.Meter, tm timings.Measurer) error

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -39,14 +39,14 @@ type InstallRecord struct {
 	TargetSnapExisted bool `json:"target-snap-existed,omitempty"`
 }
 
-type SetupSnapOpts struct {
+type SetupSnapOptions struct {
 	SkipKernelExtraction bool
 }
 
 // SetupSnap does prepare and mount the snap for further processing.
-func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.SideInfo, dev boot.Device, setupOpts *SetupSnapOpts, meter progress.Meter) (snapType snap.Type, installRecord *InstallRecord, err error) {
+func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.SideInfo, dev boot.Device, setupOpts *SetupSnapOptions, meter progress.Meter) (snapType snap.Type, installRecord *InstallRecord, err error) {
 	if setupOpts == nil {
-		setupOpts = &SetupSnapOpts{}
+		setupOpts = &SetupSnapOptions{}
 	}
 
 	// This assumes that the snap was already verified or --dangerous was used.

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -39,8 +39,16 @@ type InstallRecord struct {
 	TargetSnapExisted bool `json:"target-snap-existed,omitempty"`
 }
 
+type SetupSnapOpts struct {
+	SkipKernelExtraction bool
+}
+
 // SetupSnap does prepare and mount the snap for further processing.
-func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.SideInfo, dev boot.Device, meter progress.Meter) (snapType snap.Type, installRecord *InstallRecord, err error) {
+func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.SideInfo, dev boot.Device, setupOpts *SetupSnapOpts, meter progress.Meter) (snapType snap.Type, installRecord *InstallRecord, err error) {
+	if setupOpts == nil {
+		setupOpts = &SetupSnapOpts{}
+	}
+
 	// This assumes that the snap was already verified or --dangerous was used.
 
 	s, snapf, oErr := OpenSnapFile(snapFilePath, sideInfo)
@@ -92,8 +100,10 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 	}
 
 	t := s.Type()
-	if err := boot.Kernel(s, t, dev).ExtractKernelAssets(snapf); err != nil {
-		return snapType, nil, fmt.Errorf("cannot install kernel: %s", err)
+	if !setupOpts.SkipKernelExtraction {
+		if err := boot.Kernel(s, t, dev).ExtractKernelAssets(snapf); err != nil {
+			return snapType, nil, fmt.Errorf("cannot install kernel: %s", err)
+		}
 	}
 
 	installRecord = &InstallRecord{TargetSnapExisted: didNothing}

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -91,7 +91,7 @@ func (s *setupSuite) TestSetupDoUndoSimple(c *C) {
 		Revision: snap.R(14),
 	}
 
-	snapType, installRecord, err := s.be.SetupSnap(snapPath, "hello", &si, mockDev, progress.Null)
+	snapType, installRecord, err := s.be.SetupSnap(snapPath, "hello", &si, mockDev, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Assert(installRecord, NotNil)
 	c.Check(snapType, Equals, snap.TypeApp)
@@ -128,7 +128,7 @@ func (s *setupSuite) TestSetupDoUndoInstance(c *C) {
 		Revision: snap.R(14),
 	}
 
-	snapType, installRecord, err := s.be.SetupSnap(snapPath, "hello_instance", &si, mockDev, progress.Null)
+	snapType, installRecord, err := s.be.SetupSnap(snapPath, "hello_instance", &si, mockDev, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Assert(installRecord, NotNil)
 	c.Check(snapType, Equals, snap.TypeApp)
@@ -181,7 +181,7 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	snapType, installRecord, err := s.be.SetupSnap(snapPath, "kernel", &si, mockDevWithKernel, progress.Null)
+	snapType, installRecord, err := s.be.SetupSnap(snapPath, "kernel", &si, mockDevWithKernel, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Check(snapType, Equals, snap.TypeKernel)
 	c.Assert(installRecord, NotNil)
@@ -225,14 +225,14 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	_, installRecord, err := s.be.SetupSnap(snapPath, "kernel", &si, mockDevWithKernel, progress.Null)
+	_, installRecord, err := s.be.SetupSnap(snapPath, "kernel", &si, mockDevWithKernel, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Assert(installRecord, NotNil)
 	c.Assert(bloader.ExtractKernelAssetsCalls, HasLen, 1)
 	c.Assert(bloader.ExtractKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
 
 	// retry run
-	_, installRecord, err = s.be.SetupSnap(snapPath, "kernel", &si, mockDevWithKernel, progress.Null)
+	_, installRecord, err = s.be.SetupSnap(snapPath, "kernel", &si, mockDevWithKernel, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Assert(installRecord, NotNil)
 	c.Assert(bloader.ExtractKernelAssetsCalls, HasLen, 2)
@@ -276,7 +276,7 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	_, installRecord, err := s.be.SetupSnap(snapPath, "kernel", &si, mockDevWithKernel, progress.Null)
+	_, installRecord, err := s.be.SetupSnap(snapPath, "kernel", &si, mockDevWithKernel, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Assert(installRecord, NotNil)
 
@@ -310,7 +310,7 @@ func (s *setupSuite) TestSetupUndoKeepsTargetSnapIfSymlink(c *C) {
 	c.Assert(os.Symlink(snapPath, tmpPath), IsNil)
 
 	si := snap.SideInfo{RealName: "hello", Revision: snap.R(14)}
-	_, installRecord, err := s.be.SetupSnap(snapPath, "hello", &si, mockDev, progress.Null)
+	_, installRecord, err := s.be.SetupSnap(snapPath, "hello", &si, mockDev, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Assert(installRecord, NotNil)
 	c.Check(installRecord.TargetSnapExisted, Equals, true)
@@ -338,7 +338,7 @@ func (s *setupSuite) TestSetupUndoKeepsTargetSnapIgnoredIfNotSymlink(c *C) {
 	c.Assert(osutil.CopyFile(snapPath, tmpPath, 0), IsNil)
 
 	si := snap.SideInfo{RealName: "hello", Revision: snap.R(14)}
-	_, installRecord, err := s.be.SetupSnap(snapPath, "hello", &si, mockDev, progress.Null)
+	_, installRecord, err := s.be.SetupSnap(snapPath, "hello", &si, mockDev, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Assert(installRecord, NotNil)
 	c.Check(installRecord.TargetSnapExisted, Equals, true)
@@ -370,7 +370,7 @@ func (s *setupSuite) TestSetupCleanupAfterFail(c *C) {
 	})
 	defer r()
 
-	_, installRecord, err := s.be.SetupSnap(snapPath, "hello", &si, mockDev, progress.Null)
+	_, installRecord, err := s.be.SetupSnap(snapPath, "hello", &si, mockDev, nil, progress.Null)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Check(installRecord, IsNil)
 
@@ -392,7 +392,7 @@ func (s *setupSuite) TestRemoveSnapFilesDir(c *C) {
 		Revision: snap.R(14),
 	}
 
-	snapType, installRecord, err := s.be.SetupSnap(snapPath, "hello_instance", &si, mockDev, progress.Null)
+	snapType, installRecord, err := s.be.SetupSnap(snapPath, "hello_instance", &si, mockDev, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Assert(installRecord, NotNil)
 	c.Check(snapType, Equals, snap.TypeApp)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -763,7 +763,7 @@ apps:
     before: [svc2]
 `
 
-func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, opts *backend.SetupSnapOpts, p progress.Meter) (snap.Type, *backend.InstallRecord, error) {
+func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, opts *backend.SetupSnapOptions, p progress.Meter) (snap.Type, *backend.InstallRecord, error) {
 	p.Notify("setup-snap")
 	revno := snap.R(0)
 	if si != nil {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -69,6 +69,7 @@ type fakeOp struct {
 
 	otherInstances         bool
 	unlinkFirstInstallUndo bool
+	skipKernelExtraction   bool
 
 	services         []string
 	disabledServices []string
@@ -762,7 +763,7 @@ apps:
     before: [svc2]
 `
 
-func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, p progress.Meter) (snap.Type, *backend.InstallRecord, error) {
+func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, opts *backend.SetupSnapOpts, p progress.Meter) (snap.Type, *backend.InstallRecord, error) {
 	p.Notify("setup-snap")
 	revno := snap.R(0)
 	if si != nil {
@@ -773,6 +774,8 @@ func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *sna
 		name:  instanceName,
 		path:  snapFilePath,
 		revno: revno,
+
+		skipKernelExtraction: opts != nil && opts.SkipKernelExtraction,
 	})
 	snapType := snap.TypeApp
 	switch si.RealName {

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -56,6 +56,10 @@ type Flags struct {
 	// running the configure hook should be skipped.
 	SkipConfigure bool `json:"skip-configure,omitempty"`
 
+	// SkipKernelExtraction is used with InstallPath to flag that the
+	// kernel extraction should be skipped. This is useful during seeding.
+	SkipKernelExtraction bool `json:"skip-kernel-extraction,omitempty"`
+
 	// Unaliased is set to request that no automatic aliases are created
 	// installing the snap.
 	Unaliased bool `json:"unaliased,omitempty"`

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -690,7 +690,7 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	}
 
-	setupOpts := &backend.SetupSnapOpts{
+	setupOpts := &backend.SetupSnapOptions{
 		SkipKernelExtraction: snapsup.SkipKernelExtraction,
 	}
 	pb := NewTaskProgressAdapterUnlocked(t)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -690,12 +690,8 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	}
 
-	setupOpts := &backend.SetupSnapOpts{}
-	st.Lock()
-	err = t.Get("skip-kernel-extract", &setupOpts.SkipKernelExtraction)
-	st.Unlock()
-	if err != nil && err != state.ErrNoState {
-		return err
+	setupOpts := &backend.SetupSnapOpts{
+		SkipKernelExtraction: snapsup.SkipKernelExtraction,
 	}
 	pb := NewTaskProgressAdapterUnlocked(t)
 	// TODO Use snapsup.Revision() to obtain the right info to mount

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -690,21 +690,19 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	}
 
+	setupOpts := &backend.SetupSnapOpts{}
+	st.Lock()
+	err = t.Get("skip-kernel-extract", &setupOpts.SkipKernelExtraction)
+	st.Unlock()
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
 	pb := NewTaskProgressAdapterUnlocked(t)
 	// TODO Use snapsup.Revision() to obtain the right info to mount
 	//      instead of assuming the candidate is the right one.
 	var snapType snap.Type
 	var installRecord *backend.InstallRecord
 	timings.Run(perfTimings, "setup-snap", fmt.Sprintf("setup snap %q", snapsup.InstanceName()), func(timings.Measurer) {
-		st.Lock()
-		isSeedChange := t.Change().Kind() == "seed"
-		st.Unlock()
-		setupOpts := &backend.SetupSnapOpts{
-			// Skip kernel extraction when seeding, the
-			// kernel was already extracted during image
-			// build or partition create time.
-			SkipKernelExtraction: isSeedChange,
-		}
 		snapType, installRecord, err = m.backend.SetupSnap(snapsup.SnapPath, snapsup.InstanceName(), snapsup.SideInfo, deviceCtx, setupOpts, pb)
 	})
 	if err != nil {


### PR DESCRIPTION
When seeding the device we currently extract the kernel. This is
unneeded because the kernel is already in place (without it the
system would not have been booted). Either ubuntu-image or "install"
mode extracted the kernel into the right place already.

This commit changes the code to skip kernel extraction when seeding.

This is an alternative and kind of complementary way to #10594. We
probably want to make the low-level bits also a bit more robust but this
high level approach is hopefully simpler.