### PR TITLE
tests: use bigger storage on ubuntu 21.10

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -107,6 +107,7 @@ backends:
                   workers: 8
             - ubuntu-21.10-64:
                   image: ubuntu-os-cloud-devel/ubuntu-2110
+                  storage: 12G
                   workers: 8
 
             - debian-9-64:


### PR DESCRIPTION
This is needed to make test snapd-snap:lxd pass in 21.10

The test is currently failing due to out of space after hte test was
moved to snapcraft v4

