### PR TITLE
configcore: fix a bunch of incorrect error returns

### DIFF
--- a/overlord/configstate/configcore/backlight.go
+++ b/overlord/configstate/configcore/backlight.go
@@ -56,7 +56,7 @@ func handleBacklightServiceConfiguration(_ sysconfig.Device, tr config.ConfGette
 	}
 	output, err := coreCfg(tr, "system.disable-backlight-service")
 	if err != nil {
-		return nil
+		return err
 	}
 	if output != "" {
 		switch output {

--- a/overlord/configstate/configcore/journal.go
+++ b/overlord/configstate/configcore/journal.go
@@ -46,7 +46,7 @@ func validateJournalSettings(tr config.ConfGetter) error {
 func handleJournalConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
 	output, err := coreCfg(tr, "journal.persistent")
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if output == "" {

--- a/overlord/configstate/configcore/network.go
+++ b/overlord/configstate/configcore/network.go
@@ -51,7 +51,7 @@ func handleNetworkConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *
 
 	output, err := coreCfg(tr, "network.disable-ipv6")
 	if err != nil {
-		return nil
+		return err
 	}
 
 	var sysctl string

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -67,7 +67,7 @@ func handleTimezoneConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts 
 	// that was written not using `snap set system system.hostname`.
 	timezone, err := coreCfg(tr, "system.timezone")
 	if err != nil {
-		return nil
+		return err
 	}
 	// nothing to do
 	if timezone == "" {


### PR DESCRIPTION
It looks like there was some copy/paste in the error handling
of the coreCfg() calls and an incorrect error handling is
used in some of the handle* functions.

This commit fixes this.
