### PR TITLE
.github/workflows/test.yaml: use snapcraft 4.x to build the snapd snap

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,8 @@ jobs:
     - name: Build snapd snap
       if: steps.cached-results.outputs.already-ran != 'true'
       uses: snapcore/action-build@v1
+      with:
+        snapcraft-channel: 4.x/candidate
     - name: Cache built artifact
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")


### PR DESCRIPTION
5.x doesn't support the snapd snap as currently supported, so we need to build
with 4.x for the time being.