### PR TITLE
packaging: merge 2.51.4 changelog back to master

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.51.3
+pkgver=2.51.4
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,17 @@
+snapd (2.51.4-1) unstable; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - {device,snap}state: skip kernel extraction in seeding
+    - vendor: move to snapshot-4c814e1 branch and set fixed KDF options
+    - tests/interfaces/tee: fix HasLen check for udev snippets
+    - interfaces/tee: add support for Qualcomm qseecom device node
+    - gadget: check for system-save with multi volumes if encrypting
+      correctly
+    - gadget: drive-by: drop unnecessary/supported passthrough in test
+      gadget.yaml
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 09 Aug 2021 18:56:18 -0500
+
 snapd (2.51.3-1) unstable; urgency=medium
 
   * New upstream release, LP: #1929842

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -97,7 +97,7 @@
 %endif
 
 Name:           snapd
-Version:        2.51.3
+Version:        2.51.4
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -971,6 +971,17 @@ fi
 
 
 %changelog
+* Mon Aug 09 2021 Ian Johnson <ian.johnson@canonical.com>
+- New upstream release 2.51.4
+ - {device,snap}state: skip kernel extraction in seeding
+ - vendor: move to snapshot-4c814e1 branch and set fixed KDF options
+ - tests/interfaces/tee: fix HasLen check for udev snippets
+ - interfaces/tee: add support for Qualcomm qseecom device node
+ - gadget: check for system-save with multi volumes if encrypting
+   correctly
+ - gadget: drive-by: drop unnecessary/supported passthrough in test
+   gadget.yaml
+
 * Wed Jul 14 2021 Ian Johnson <ian.johnson@canonical.com>
 - New upstream release 2.51.3
  - interfaces/builtin: add sd-control interface

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Aug 09 23:38:57 UTC 2021 - ian.johnson@canonical.com
+
+- Update to upstream release 2.51.4
+
+-------------------------------------------------------------------
 Wed Jul 14 20:26:54 UTC 2021 - ian.johnson@canonical.com
 
 - Update to upstream release 2.51.3

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -83,7 +83,7 @@
 
 
 Name:           snapd
-Version:        2.51.3
+Version:        2.51.4
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,17 @@
+snapd (2.51.4~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - {device,snap}state: skip kernel extraction in seeding
+    - vendor: move to snapshot-4c814e1 branch and set fixed KDF options
+    - tests/interfaces/tee: fix HasLen check for udev snippets
+    - interfaces/tee: add support for Qualcomm qseecom device node
+    - gadget: check for system-save with multi volumes if encrypting
+      correctly
+    - gadget: drive-by: drop unnecessary/supported passthrough in test
+      gadget.yaml
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 09 Aug 2021 18:56:18 -0500
+
 snapd (2.51.3~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #1929842

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,17 @@
+snapd (2.51.4) xenial; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - {device,snap}state: skip kernel extraction in seeding
+    - vendor: move to snapshot-4c814e1 branch and set fixed KDF options
+    - tests/interfaces/tee: fix HasLen check for udev snippets
+    - interfaces/tee: add support for Qualcomm qseecom device node
+    - gadget: check for system-save with multi volumes if encrypting
+      correctly
+    - gadget: drive-by: drop unnecessary/supported passthrough in test
+      gadget.yaml
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 09 Aug 2021 18:56:18 -0500
+
 snapd (2.51.3) xenial; urgency=medium
 
   * New upstream release, LP: #1929842


### PR DESCRIPTION
So that edge core snap builds have the right version number.