### PR TITLE
wrappers: measure time to enable services in StartServices()

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -286,7 +286,9 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs []string, flags *StartServ
 		}
 	}
 
-	disableEnabledServices, err = enableServices(toEnable, inter)
+	timings.Run(tm, "enable-services", fmt.Sprintf("enable services %q", toEnable), func(nested timings.Measurer) {
+		disableEnabledServices, err = enableServices(toEnable, inter)
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `startSnapServices()` measurements are currently missing a
good chunk of where the time is spend. Here is an example from
the `test-snapd-service` snap:
```
39545  Done         4125ms            -  Start snap "test-snapd-service" (2) services
 ^                     5ms            -    start service "snap.test-snapd-service.test-snapd-sigterm-all-service.service"
 ^                     5ms            -    start service "snap.test-snapd-service.test-snapd-service.service"
 ^                     6ms            -    start service "snap.test-snapd-service.test-snapd-service-refuses-to-stop.service"
 ^                     6ms            -    start service "snap.test-snapd-service.test-snapd-endure-service.service"
 ^                    18ms            -    start service "snap.test-snapd-service.test-snapd-other-service.service"
 ^                     6ms            -    start service "snap.test-snapd-service.test-snapd-sighup-all-service.service"
 ^                     6ms            -    start service "snap.test-snapd-service.test-snapd-sigusr1-service.service"
 ^                     6ms            -    start service "snap.test-snapd-service.test-snapd-sigusr2-all-service.service"
 ^                     6ms            -    start service "snap.test-snapd-service.test-snapd-sigterm-service.service"
 ^                     8ms            -    start service "snap.test-snapd-service.test-snapd-sigusr1-all-service.service"
 ^                     6ms            -    start service "snap.test-snapd-service.test-snapd-sigusr2-service.service"
 ^                     6ms            -    start service "snap.test-snapd-service.test-snapd-sighup-service.service"
```
The task takes ~4s but only a tiny fraction is accounted for.

With this commit we get a better picture, i.e.:
```
39519  Done         4029ms            -  Start snap "test-snapd-service" (2) services
 ^                  3892ms            -    enable services ["test-snapd-service.test-snapd-sighup-all-service" "test-snapd-service.test-snapd-sigusr1-all-service" "test-snapd-service.test-snapd-sigusr2-all-service" "test-snapd-service.test-snapd-service-refuses-to-stop" "test-snapd-service.test-snapd-sigterm-service" "test-snapd-service.test-snapd-endure-service" "test-snapd-service.test-snapd-other-service" "test-snapd-service.test-snapd-sigusr1-service" "test-snapd-service.test-snapd-sigusr2-service" "test-snapd-service" "test-snapd-service.test-snapd-sighup-service" "test-snapd-service.test-snapd-sigterm-all-service"]
 ^                     5ms            -    start service "snap.test-snapd-service.test-snapd-sigusr1-all-service.service"
 ^                     7ms            -    start service "snap.test-snapd-service.test-snapd-service-refuses-to-stop.service"
 ^                     6ms            -    start service "snap.test-snapd-service.test-snapd-sigterm-service.service"
 ^                     7ms            -    start service "snap.test-snapd-service.test-snapd-endure-service.service"
 ^                    10ms            -    start service "snap.test-snapd-service.test-snapd-other-service.service"
 ^                    21ms            -    start service "snap.test-snapd-service.test-snapd-sigusr1-service.service"
 ^                     8ms            -    start service "snap.test-snapd-service.test-snapd-sigusr2-service.service"
 ^                     5ms            -    start service "snap.test-snapd-service.test-snapd-service.service"
 ^                     7ms            -    start service "snap.test-snapd-service.test-snapd-sighup-service.service"
 ^                     7ms            -    start service "snap.test-snapd-service.test-snapd-sigterm-all-service.service"
```
