### PR TITLE
many: do not re-check snaps on disk during uc20 install

### DIFF
--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -230,6 +230,8 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 			// The kernel is already there either from ubuntu-image or from "install"
 			// mode so skip extract.
 			SkipKernelExtraction: true,
+			// Skip verifying snap if it exists already
+			SkipOnDiskSnapValidation: true,
 			// for dangerous models, allow all devmode snaps
 			// XXX: eventually we may need to allow specific snaps to be devmode for
 			// non-dangerous models, we can do that here since that information will

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -40,7 +40,8 @@ type InstallRecord struct {
 }
 
 type SetupSnapOptions struct {
-	SkipKernelExtraction bool
+	SkipKernelExtraction     bool
+	SkipOnDiskSnapValidation bool
 }
 
 // SetupSnap does prepare and mount the snap for further processing.
@@ -84,7 +85,9 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 	}
 
 	// in uc20 run mode, all snaps must be on the same device
-	opts := &snap.InstallOptions{}
+	opts := &snap.InstallOptions{
+		SkipOnDiskSnapValidation: setupOpts.SkipOnDiskSnapValidation,
+	}
 	if dev.HasModeenv() && dev.RunMode() {
 		opts.MustNotCrossDevices = true
 	}

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -60,6 +60,10 @@ type Flags struct {
 	// kernel extraction should be skipped. This is useful during seeding.
 	SkipKernelExtraction bool `json:"skip-kernel-extraction,omitempty"`
 
+	// SkipOnDiskSnapValidation skips validating the snap if it exists
+	// on disk already in SetupSnap. XXX: explain better
+	SkipOnDiskSnapValidation bool `json:"skip-on-disk-snap-validation,omitempty"`
+
 	// Unaliased is set to request that no automatic aliases are created
 	// installing the snap.
 	Unaliased bool `json:"unaliased,omitempty"`

--- a/snap/container.go
+++ b/snap/container.go
@@ -69,6 +69,9 @@ type InstallOptions struct {
 	// an installation on ubuntu-data that does not depend or reference
 	// ubuntu-seed at all.
 	MustNotCrossDevices bool
+
+	// Do not validate existing snaps
+	SkipOnDiskSnapValidation bool
 }
 
 var (

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -92,6 +92,9 @@ var snapdtoolCommandFromSystemSnap = snapdtool.CommandFromSystemSnap
 
 // Install installs a squashfs snap file through an appropriate method.
 func (s *Snap) Install(targetPath, mountDir string, opts *snap.InstallOptions) (bool, error) {
+	if opts == nil {
+		opts = &snap.InstallOptions{}
+	}
 
 	// ensure mount-point and blob target dir.
 	for _, dir := range []string{mountDir, filepath.Dir(targetPath)} {
@@ -108,6 +111,11 @@ func (s *Snap) Install(targetPath, mountDir string, opts *snap.InstallOptions) (
 		if err := s.Unpack("*", mountDir); err != nil {
 			return false, err
 		}
+	}
+
+	if opts.SkipOnDiskSnapValidation && osutil.FileExists(targetPath) {
+		didNothing := true
+		return didNothing, nil
 	}
 
 	// nothing to do, happens on e.g. first-boot when we already


### PR DESCRIPTION
During the UC20 install the kernel and core20 snaps are put onto
the ubuntu-data partition by the MakeRunnableSystem() so that the
system can boot.

Then during seed both snaps are compared bit-by-bit with the
coresponding snaps in the seed partition by SetupSnap() and the
snapf.Install() call in there. This comparison is expensive, on
my test Pi3 it's almost 30s for the kernel and 22s for core20
(a really slow sd card though). And this check is also slightly
pointless because we used both snaps to boot. On encrypted systems
they are on the encrypted storage so there is little risk anyway.

So this commit adds a new "SkipOnDiskSnapValidation" (better name
suggestions welcome) that will simply do nothing if the target
snaps exist during seeding.

Mostly a PoC at this point to gather some real word data. Also
maybe not holistic enough in the approach.
