### PR TITLE
o/snapstate: install snap after prereq snaps are done installing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cmd/VERSION
 *~
 *.swp
 .vscode/
+.idea/
 vendor/*/
 .spread-reuse*.yaml
 po/snappy.pot

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -334,8 +334,8 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 		// make the dependencies of the "prerequisite" task wait for the install tasks. Otherwise, the main snap will be
 		// installed in parallel with its prerequisites, resulting in a race condition. Waiting for the last task is
 		// enough since tasks wait for the previous one to be done before running
+		lastPrereqTask := ts.Tasks()[len(ts.Tasks())-1]
 		for _, dep := range t.HaltTasks() {
-			lastPrereqTask := ts.Tasks()[len(ts.Tasks())-1]
 			dep.WaitFor(lastPrereqTask)
 		}
 		tss = append(tss, ts)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -327,12 +327,13 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 		if err != nil {
 			return prereqError("prerequisite", prereqName, err)
 		}
-		if ts == nil {
+		if ts == nil || len(ts.Tasks()) == 0 {
 			continue
 		}
 
 		// make the dependencies of the "prerequisite" task wait for the install tasks. Otherwise, the main snap will be
-		// installed in parallel with its prerequisites, resulting in a race condition
+		// installed in parallel with its prerequisites, resulting in a race condition. Waiting for the last task is
+		// enough since tasks wait for the previous one to be done before running
 		for _, dep := range t.HaltTasks() {
 			lastPrereqTask := ts.Tasks()[len(ts.Tasks())-1]
 			dep.WaitFor(lastPrereqTask)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -330,6 +330,13 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 		if ts == nil {
 			continue
 		}
+
+		// make the dependencies of the "prerequisite" task wait for the install tasks. Otherwise, the main snap will be
+		// installed in parallel with its prerequisites, resulting in a race condition
+		for _, dep := range t.HaltTasks() {
+			lastPrereqTask := ts.Tasks()[len(ts.Tasks())-1]
+			dep.WaitFor(lastPrereqTask)
+		}
 		tss = append(tss, ts)
 	}
 

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -130,21 +130,21 @@ func (s *prereqSuite) TestDoPrereqDependenciesWaitForPrereqInstall(c *C) {
 	c.Check(preReq.Status(), Equals, state.DoneStatus)
 
 	// find last task in the prerequisite's installation
-	var depEnd *state.Task
+	var prereqLastTask *state.Task
 	for _, t := range chg.Tasks() {
 		if t.Kind() == "run-hook" {
 			setup := &hookstate.HookSetup{}
 			c.Assert(t.Get("hook-setup", setup), IsNil)
 
 			if setup.Snap == "dep" && setup.Hook == "check-health" {
-				depEnd = t
+				prereqLastTask = t
 				break
 			}
 		}
 	}
 
 	// check that the "prerequisite" task's dependencies wait for the tasks scheduled by "prerequisite" to be installed
-	c.Check(depEnd.HaltTasks(), testutil.Contains, afterPrereq)
+	c.Check(afterPrereq.WaitTasks(), testutil.Contains, prereqLastTask)
 }
 
 func (s *prereqSuite) TestDoPrereqWithBaseNone(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1460,8 +1460,8 @@ func (s *snapmgrTestSuite) TestUpdateWithNewDefaultProvider(c *C) {
 	s.state.Lock()
 
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
-		{macaroon: s.user.StoreMacaroon, name: "snap-content-plug", target: filepath.Join(dirs.SnapBlobDir, "snap-content-plug_11.snap")},
 		{macaroon: s.user.StoreMacaroon, name: "snap-content-slot", target: filepath.Join(dirs.SnapBlobDir, "snap-content-slot_11.snap")},
+		{macaroon: s.user.StoreMacaroon, name: "snap-content-plug", target: filepath.Join(dirs.SnapBlobDir, "snap-content-plug_11.snap")},
 	})
 }
 


### PR DESCRIPTION
This PR mitigates the issue described in this [forum post](https://forum.snapcraft.io/t/installation-of-snap-with-content-snap-as-dependency/16103). In short, snaps that depend on a content interface and specify a content snap as default-provider are made available to the system before the content snap is installed. Since the content snap might take a bit to install, there's a fair amount of time in which the snap is available but the default-provider it specified isn't installed yet. This is due to the fact that during the installation, the "prerequisite" task schedules tasks to install the content snap but doesn't wait for them to be done. This commit makes the prerequisite's dependants wait for installation of the content snap to be completed. 
In my manual testing, the amount of time the snap is available but failing is reduced from 30 seconds to 1 or 2 seconds. The issue isn't fully resolved because the content snap's interface slot still needs to be auto-connected to the snap's plug and this only happens after the "link-snap" task has made the snap available. 