### PR TITLE
 o/devicestate/handlers_install.go: add workaround to create dirs for install

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -943,6 +943,12 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfig(c *C) {
 			GadgetDir:      filepath.Join(dirs.SnapMountDir, "pc/1/"),
 		},
 	})
+
+	// and the special dirs in _writable_defaults were created
+	for _, dir := range []string{"/etc/udev/rules.d/", "/etc/modules-load.d/", "/etc/modprobe.d/"} {
+		fullDir := filepath.Join(sysconfig.WritableDefaultsDir(boot.InstallHostWritableDir), dir)
+		c.Assert(fullDir, testutil.FilePresent)
+	}
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeRunSysconfigErr(c *C) {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -20,6 +20,7 @@ NESTED_CUSTOM_MODEL="${NESTED_CUSTOM_MODEL:-}"
 NESTED_CUSTOM_AUTO_IMPORT_ASSERTION="${NESTED_CUSTOM_AUTO_IMPORT_ASSERTION:-}"
 NESTED_FAKESTORE_BLOB_DIR="${NESTED_FAKESTORE_BLOB_DIR:-$NESTED_WORK_DIR/fakestore/blobs}"
 NESTED_SIGN_SNAPS_FAKESTORE="${NESTED_SIGN_SNAPS_FAKESTORE:-false}"
+NESTED_FAKESTORE_SNAP_DECL_PC_GADGET="${NESTED_FAKESTORE_SNAP_DECL_PC_GADGET:-}"
 NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL:-}"
 
 nested_wait_for_ssh() {
@@ -629,7 +630,11 @@ EOF
                     fi
                     # sign the pc gadget snap with fakestore if requested
                     if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
-                        make_snap_installable_with_id --noack "$NESTED_FAKESTORE_BLOB_DIR" "$GADGET_SNAP" "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+                        # XXX: this is a bit of a hack, but some nested tests 
+                        # need extra bits in their snap declaration, so inject
+                        # that here, it could end up being empty in which case
+                        # it is ignored
+                        make_snap_installable_with_id --noack --extra-decl-json "$NESTED_FAKESTORE_SNAP_DECL_PC_GADGET" "$NESTED_FAKESTORE_BLOB_DIR" "$GADGET_SNAP" "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
                     fi
 
                     # repack the snapd snap

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/defaults.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/defaults.yaml
@@ -1,0 +1,6 @@
+defaults:
+  system:
+    refresh:
+      hold: "HOLD-TIME"
+    journal:
+      persistent: true

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/install-device
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/install-device
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# install the files the same way the specific device does this - note we don't
+# create the directories since that requires extra permissions we don't have 
+# here, system-files only allows us access to the specific files
+
+# add modprobe.d config
+cat << EOF > /run/mnt/ubuntu-data/system-data/_writable_defaults/etc/modprobe.d/my-modprobe.conf
+# configure modprobe here
+EOF
+
+# add modules-load.d config
+cat << EOF > /run/mnt/ubuntu-data/system-data/_writable_defaults/etc/modules-load.d/my-modules-load.conf
+# load modules here
+EOF
+
+# add a udev rule
+cat << EOF > /run/mnt/ubuntu-data/system-data/_writable_defaults/etc/udev/rules.d/09-my-custom-udev.rules
+# do udev rules things here
+EOF

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/pc-snap-decl-extras.json
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/pc-snap-decl-extras.json
@@ -1,0 +1,9 @@
+{
+    "plugs": {
+        "system-files": {
+            "allow-installation": "true",
+            "allow-auto-connection": "true"
+        }
+    },
+    "format": "1"
+}

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/prepare-device
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/prepare-device
@@ -1,0 +1,3 @@
+#!/bin/sh
+# 10.0.2.2 is the host from a nested VM
+snapctl set device-service.url=http://10.0.2.2:11029

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/snap-yaml-extras.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/snap-yaml-extras.yaml
@@ -1,0 +1,20 @@
+hooks:
+  install-device:
+    plugs:
+      - modprobe-conf
+      - modules-load-conf
+      - udev-rules-conf
+
+plugs:
+  modprobe-conf:
+    interface: system-files
+    write:
+      - /run/mnt/ubuntu-data/system-data/_writable_defaults/etc/modprobe.d/my-modprobe.conf
+  modules-load-conf:
+    interface: system-files
+    write:
+      - /run/mnt/ubuntu-data/system-data/_writable_defaults/etc/modules-load.d/my-modules-load.conf
+  udev-rules-conf:
+    interface: system-files
+    write:
+      - /run/mnt/ubuntu-data/system-data/_writable_defaults/etc/udev/rules.d/09-my-custom-udev.rules

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -1,0 +1,154 @@
+summary: Verify that install-device with system-files works with specific device
+
+details: |
+    This test checks that the workaround put in place for a specific device
+    continues to work. This specific device needs to install configuration files
+    onto the run system ubuntu-data on UC20 during install mode to avoid an
+    additional reboot during the first boot process.
+
+systems: [ubuntu-20.04-64]
+
+environment:
+    NESTED_IMAGE_ID: core20-install-device-system-files-hack
+
+    # use snapd from the spread run so that we have testkeys trusted in the
+    # snapd run
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+
+    # use secure boot and TPM to enable encryption
+    NESTED_ENABLE_TPM: true
+    NESTED_ENABLE_SECURE_BOOT: true
+
+    # don't use cloud-init it doesn't work with grade secured
+    NESTED_USE_CLOUD_INIT: false
+
+    # sign all the snaps we build for the image with fakestore
+    NESTED_SIGN_SNAPS_FAKESTORE: true
+
+    # use the testrootorg auto-import assertion
+    # TODO: commit the Go code used to create this assertion from the json file
+    NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/developer1-auto-import.assert
+    NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-20-secured.model
+
+    # for the fake store
+    NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
+    NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
+
+    # unset this otherwise ubuntu-image complains about overriding the channel for
+    # a model with grade higher than dangerous when building the image
+    NESTED_CORE_CHANNEL: ""
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # install pre-reqs which we need to adjust various bits
+    snap install jq remarshal
+    tests.cleanup defer snap remove remarshal
+    tests.cleanup defer snap remove jq
+
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+
+    # setup the fakestore, but don't use it for our snapd here on the host VM, so
+    # tear down the staging_store immediately afterwards so that only the SAS is 
+    # running and our snapd is not pointed at it, ubuntu-image is the only thing 
+    # that actually needs to use the fakestore, and we will manually point it at
+    # the fakestore below using NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL
+    setup_fake_store "$NESTED_FAKESTORE_BLOB_DIR"
+    teardown_staging_store
+
+    echo Expose the needed assertions through the fakestore
+    cp "$TESTSLIB"/assertions/developer1.account "$NESTED_FAKESTORE_BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account-key "$NESTED_FAKESTORE_BLOB_DIR/asserts"
+
+    KEY_NAME=$(nested_get_snakeoil_key)
+    SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+    SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+
+    echo "Grab and prepare the gadget snap"
+    snap download --basename=pc --channel="20/edge" pc
+    unsquashfs -d pc-gadget pc.snap
+
+    echo "Sign the shim binary"
+    nested_secboot_sign_gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+
+    echo "Add the install-device and prepare-device hooks"
+    mkdir -p pc-gadget/meta/hooks
+    cp install-device pc-gadget/meta/hooks/install-device
+    cp prepare-device pc-gadget/meta/hooks/prepare-device
+
+    echo "Add the extra hooks definition to the snap.yaml"
+    # convert our yaml files to json (yaml is easier to write and maintain in VCS)
+    yaml2json < pc-gadget/meta/snap.yaml | tee pc-gadget/meta/snap.json > /dev/null
+    yaml2json < snap-yaml-extras.yaml | tee snap-yaml-extras.json > /dev/null
+    # slurp our two json files together into one json document, then convert 
+    # back to yaml and write out to the snap.yaml in the unpacked gadget snap
+    jq -s '.[0] * .[1]' <(cat snap-yaml-extras.json) <(cat pc-gadget/meta/snap.json) | json2yaml | tee pc-gadget/meta/snap.yaml
+
+    # delay all refreshes for a week from now, as otherwise refreshes for our 
+    # snaps (which are asserted by the testrootorg authority-id) may happen, which
+    # will break things because the signing keys won't match, etc. and 
+    # specifically snap-bootstrap in the kernel snap from the store won't trust
+    # the seed keys to unlock the encrypted data partition in the initramfs
+    sed defaults.yaml -e "s/HOLD-TIME/$(date --date="next week" +%Y-%m-%dT%H:%M:%S%:z)/" >> \
+      pc-gadget/meta/gadget.yaml
+
+    snap pack pc-gadget/ extra-snaps/
+
+    # start fake device svc
+    systemd-run --collect --unit fakedevicesvc fakedevicesvc localhost:11029
+    tests.cleanup defer systemctl stop fakedevicesvc
+
+    # include the extra snap declaration bits we need to auto-connect the 
+    # system-files plugs for the install-device hook
+    # XXX: this is a bit of a hack, we want the snap to be able to use the
+    # system-files interface from the install-device hook, so here we just allow
+    # any system-files interface plug to be used with the snap, in reality this
+    # rule would be much more specific
+
+    NESTED_FAKESTORE_SNAP_DECL_PC_GADGET="pc-snap-decl-extras.json"
+    export NESTED_FAKESTORE_SNAP_DECL_PC_GADGET
+    tests.nested build-image core
+    unset NESTED_FAKESTORE_SNAP_DECL_PC_GADGET
+
+    tests.nested create-vm core
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    teardown_fake_store "$NESTED_FAKESTORE_BLOB_DIR"
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    echo "Check we have the right model from snap model"
+    tests.nested exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-secured-core-20-amd64"
+    tests.nested exec "sudo snap model --verbose" | MATCH "grade:\s+secured"
+    tests.nested exec "sudo snap model --verbose --serial" | MATCH "serial:\s+7777"
+
+    echo "Check that the files from install-device were installed"
+    tests.nested exec "cat /etc/modprobe.d/my-modprobe.conf" | MATCH '# configure modprobe here'
+    tests.nested exec "cat /etc/modules-load.d/my-modules-load.conf" | MATCH '# load modules here'
+    tests.nested exec "cat /etc/udev/rules.d/09-my-custom-udev.rules" | MATCH  '# do udev rules things here'
+
+    echo "Check that the system-files interface is connected for the pc snap"
+    tests.nested exec "snap connections pc" | MATCH 'system-files\s+pc:modprobe-conf\s+:system-files'
+    tests.nested exec "snap connections pc" | MATCH 'system-files\s+pc:modules-load-conf\s+:system-files'
+    tests.nested exec "snap connections pc" | MATCH 'system-files\s+pc:udev-rules-conf\s+:system-files'

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -135,20 +135,22 @@ execute: |
         exit
     fi
 
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-
     echo "Check we have the right model from snap model"
     tests.nested exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-secured-core-20-amd64"
     tests.nested exec "sudo snap model --verbose" | MATCH "grade:\s+secured"
     tests.nested exec "sudo snap model --verbose --serial" | MATCH "serial:\s+7777"
 
-    echo "Check that the files from install-device were installed"
-    tests.nested exec "cat /etc/modprobe.d/my-modprobe.conf" | MATCH '# configure modprobe here'
-    tests.nested exec "cat /etc/modules-load.d/my-modules-load.conf" | MATCH '# load modules here'
-    tests.nested exec "cat /etc/udev/rules.d/09-my-custom-udev.rules" | MATCH  '# do udev rules things here'
-
     echo "Check that the system-files interface is connected for the pc snap"
     tests.nested exec "snap connections pc" | MATCH 'system-files\s+pc:modprobe-conf\s+:system-files'
     tests.nested exec "snap connections pc" | MATCH 'system-files\s+pc:modules-load-conf\s+:system-files'
     tests.nested exec "snap connections pc" | MATCH 'system-files\s+pc:udev-rules-conf\s+:system-files'
+
+    echo "Check that the directories have the right permissions"
+    tests.nested exec "stat /etc/modprobe.d/ -c %a" | MATCH 755
+    tests.nested exec "stat /etc/modules-load.d/ -c %a" | MATCH 755
+    tests.nested exec "stat /etc/udev/rules.d/ -c %a" | MATCH 755
+
+    echo "Check that the files from install-device were installed"
+    tests.nested exec "cat /etc/modprobe.d/my-modprobe.conf" | MATCH '# configure modprobe here'
+    tests.nested exec "cat /etc/modules-load.d/my-modules-load.conf" | MATCH '# load modules here'
+    tests.nested exec "cat /etc/udev/rules.d/09-my-custom-udev.rules" | MATCH  '# do udev rules things here'


### PR DESCRIPTION
For UC20 install mode, we have devices which need to install files into the run
mode system before rebooting into install mode. The temporary solution designed
for this was to use the install-device hook with system-files providing write
access to the /run/mnt/ubuntu-data/system-data/_writable_defaults/... directory
where ubuntu-data is mounted during install mode. That seemed to work fine in
devmode, but the issue in strict mode is that system-files only grants
permissions to create that specific file, it doesn't grant permission to create
any of the parent directories the file lives in.

So, temporarily for this device to be released and shipped, create those
directories at the end of the setup-run-system task, which runs before the
install-device hook, thus ensuring that the hook is successful.

Also add a spread test for this situation.

cc @woodrow-shen 