### PR TITLE
gadget,secboot: add support to specify KDF options in the gadget

### DIFF
--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -70,8 +70,8 @@ func newEncryptedDevice(part *gadget.OnDiskStructure, key secboot.EncryptionKey,
 	return dev, nil
 }
 
-func (dev *encryptedDevice) AddRecoveryKey(key secboot.EncryptionKey, rkey secboot.RecoveryKey) error {
-	return secbootAddRecoveryKey(key, rkey, dev.parent.Node)
+func (dev *encryptedDevice) AddRecoveryKey(key secboot.EncryptionKey, rkey secboot.RecoveryKey, kdf *gadget.KDF) error {
+	return secbootAddRecoveryKey(key, rkey, dev.parent.Node, kdf)
 }
 
 func (dev *encryptedDevice) Close() error {

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -146,7 +146,7 @@ func (s *encryptSuite) TestAddRecoveryKey(c *C) {
 		defer restore()
 
 		calls := 0
-		restore = install.MockSecbootAddRecoveryKey(func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string) error {
+		restore = install.MockSecbootAddRecoveryKey(func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string, kdf *gadget.KDF) error {
 			calls++
 			c.Assert(key, DeepEquals, s.mockedEncryptionKey)
 			c.Assert(rkey, DeepEquals, s.mockedRecoveryKey)
@@ -158,7 +158,7 @@ func (s *encryptSuite) TestAddRecoveryKey(c *C) {
 		dev, err := install.NewEncryptedDevice(&mockDeviceStructure, s.mockedEncryptionKey, "some-label")
 		c.Assert(err, IsNil)
 
-		err = dev.AddRecoveryKey(s.mockedEncryptionKey, s.mockedRecoveryKey)
+		err = dev.AddRecoveryKey(s.mockedEncryptionKey, s.mockedRecoveryKey, nil)
 		c.Assert(calls, Equals, 1)
 		if tc.expectedErr == "" {
 			c.Assert(err, IsNil)

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -21,6 +21,7 @@
 package install
 
 import (
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/secboot"
 )
 
@@ -38,7 +39,7 @@ func MockSecbootFormatEncryptedDevice(f func(key secboot.EncryptionKey, label, n
 	}
 }
 
-func MockSecbootAddRecoveryKey(f func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string) error) (restore func()) {
+func MockSecbootAddRecoveryKey(f func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string, kdf *gadget.KDF) error) (restore func()) {
 	old := secbootAddRecoveryKey
 	secbootAddRecoveryKey = f
 	return func() {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -76,6 +76,10 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, device string, options Opti
 	if gadgetRoot == "" {
 		return nil, fmt.Errorf("cannot use empty gadget root directory")
 	}
+	info, err := gadget.ReadInfo(gadgetRoot, model)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read gadget: %v", err)
+	}
 
 	lv, err := gadget.LaidOutSystemVolumeFromGadget(gadgetRoot, kernelRoot, model)
 	if err != nil {
@@ -172,7 +176,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, device string, options Opti
 			}
 
 			timings.Run(perfTimings, fmt.Sprintf("add-recovery-key[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Adding recovery key for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
-				err = dataPart.AddRecoveryKey(keys.Key, keys.RecoveryKey)
+				err = dataPart.AddRecoveryKey(keys.Key, keys.RecoveryKey, info.Machine.KDF)
 			})
 			if err != nil {
 				return nil, err

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -99,7 +99,7 @@ func (s *encryptSuite) TestAddRecoveryKey(c *C) {
 		})
 		defer restore()
 
-		err := secboot.AddRecoveryKey(myKey, myRecoveryKey, "/dev/node")
+		err := secboot.AddRecoveryKey(myKey, myRecoveryKey, "/dev/node", nil)
 		c.Assert(calls, Equals, 1)
 		if tc.err == "" {
 			c.Assert(err, IsNil)


### PR DESCRIPTION
When deploying Ubuntu Core on specific boards the cost of benchmarking
what KDF parameters to use can be quite high. On one specific board
this benchmark adds ~20sec to the install. One possible solution
to avoid this delay is to measure the parameters in advance and then
put it into the gadget.yaml. This commit does that.

The downside of this approach is that it could lead to weak security
if people copy/paste gadget.yaml between boards that are differently
fast. So this branch also implements a mandatory "machine" line in
the gadget that much match something in /proc/cpuinfo. An alternative
approach would be to hash /proc/cpuinfo but it seems like there is
a bunch of things that are potentially unstable (bogoMIPS, fequency
scaling). It also does not look at /proc/meminfo:MemTotal but that
would be trivial to add.

With that the `gadget.yaml` on a Pi3 would look like this:
```
machine:
 kdf:
  memory-kib: 30000
  iterations: 4
  machine: "Model:Raspberry Pi 3 Model B Plus Rev 1.3"

```

This is a draft, tests are missing etc, it's really there as a
discussion point.
