### PR TITLE
tests: fix core-early-config test to use tests.nested tool

### DIFF
--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -65,4 +65,4 @@ execute: |
     tests.nested exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
 
     # hostname is set
-    execute_remote "cat /etc/hostname" | MATCH "foo"
+    tests.nested exec "cat /etc/hostname" | MATCH "foo"


### PR DESCRIPTION
The execute_remove is not used anymore, it was replaced by tests.nested
