### PR TITLE
interfaces/builtin/firewall_control: allow ufw accesses

### DIFF
--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -99,6 +99,9 @@ unix (bind, listen) type=stream addr="@xtables",
 @{PROC}/sys/net/netfilter/** r,
 @{PROC}/sys/net/nf_conntrack_max r,
 
+# ufw
+/{,var/}run/ufw.lock rwk,
+
 # check the state of the Kmod modules
 /sys/module/arp_tables/               r,
 /sys/module/arp_tables/initstate      r,


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/snapd/+bug/1939711

