### PR TITLE
Revert "cgroup-support: allow to hide cgroupv2 warning via ENV"

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -80,7 +80,6 @@ static const char *cgroup_dir = "/sys/fs/cgroup";
 // hybrid or legacy) The algorithm is described in
 // https://systemd.io/CGROUP_DELEGATION/
 bool sc_cgroup_is_v2(void) {
-    bool hide_warning = getenv_bool("SNAPD_HIDE_CGROUPV2_WARNING", false);
     static bool did_warn = false;
     struct statfs buf;
 
@@ -91,7 +90,7 @@ bool sc_cgroup_is_v2(void) {
         die("cannot statfs %s", cgroup_dir);
     }
     if (buf.f_type == CGROUP2_SUPER_MAGIC) {
-        if (!did_warn && !hide_warning) {
+        if (!did_warn) {
             fprintf(stderr, "WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement\n");
             did_warn = true;
         }


### PR DESCRIPTION
Revert "cgroup-support: allow to hide cgroupv2 warning via ENV" – as discussed in #10589
    
    This reverts commit 90bdc99deb74445a4892e8dca430769354bf4e52.
    This reverts commit 9880059c70ffcb3bd4e9776767386f0745e72fb0.

commit 9880059c70ffcb3bd4e9776767386f0745e72fb0 (slyon/slyon/hide-cgroupsv2-warning, slyon/hide-cgroupsv2-warning)
Author: Lukas Märdian <slyon@ubuntu.com>
Date:   Fri Aug 13 16:50:44 2021 +0200

    cgroup-support: make use of getenv_bool()

commit 90bdc99deb74445a4892e8dca430769354bf4e52
Author: Lukas Märdian <slyon@ubuntu.com>
Date:   Thu Aug 5 18:05:33 2021 +0200

    cgroup-support: allow to hide cgroupv2 warning via ENV