### PR TITLE
cmd/libsnap-confine-private: fix coverity issues in tests, tweak uses of g_assert()

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support-test.c
+++ b/cmd/libsnap-confine-private/cgroup-support-test.c
@@ -53,7 +53,7 @@ static void cgroupv2_is_tracking_tear_down(cgroupv2_is_tracking_fixture *fixture
     GError *err = NULL;
 
     sc_set_self_cgroup_path("/proc/self/cgroup");
-    /* file mocked file may have been removed by the test */
+    /* mocked file may have been removed by the test */
     (void)g_remove(fixture->self_cgroup);
     g_free(fixture->self_cgroup);
 

--- a/cmd/libsnap-confine-private/cgroup-support-test.c
+++ b/cmd/libsnap-confine-private/cgroup-support-test.c
@@ -53,7 +53,8 @@ static void cgroupv2_is_tracking_tear_down(cgroupv2_is_tracking_fixture *fixture
     GError *err = NULL;
 
     sc_set_self_cgroup_path("/proc/self/cgroup");
-    g_remove(fixture->self_cgroup);
+    /* file mocked file may have been removed by the test */
+    (void)g_remove(fixture->self_cgroup);
     g_free(fixture->self_cgroup);
 
     sc_set_cgroup_root("/sys/fs/cgroup");
@@ -87,26 +88,20 @@ static void _test_sc_cgroupv2_is_tracking_happy(cgroupv2_is_tracking_fixture *fi
 }
 
 static void test_sc_cgroupv2_is_tracking_happy_scope(cgroupv2_is_tracking_fixture *fixture, gconstpointer user_data) {
-    GError *err = NULL;
-    g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, NULL));
 
     _test_sc_cgroupv2_is_tracking_happy(fixture);
 }
 
 static void test_sc_cgroupv2_is_tracking_happy_service(cgroupv2_is_tracking_fixture *fixture, gconstpointer user_data) {
-    GError *err = NULL;
-    g_file_set_contents(fixture->self_cgroup, "0::/system.slice/snap.foo.svc.service", -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, "0::/system.slice/snap.foo.svc.service", -1, NULL));
 
     _test_sc_cgroupv2_is_tracking_happy(fixture);
 }
 
 static void test_sc_cgroupv2_is_tracking_just_own_group(cgroupv2_is_tracking_fixture *fixture,
                                                         gconstpointer user_data) {
-    GError *err = NULL;
-    g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, NULL));
 
     /* our group is the only one for this snap */
     const char *dirs[] = {
@@ -129,9 +124,7 @@ static void test_sc_cgroupv2_is_tracking_just_own_group(cgroupv2_is_tracking_fix
 }
 
 static void test_sc_cgroupv2_is_tracking_other_snaps(cgroupv2_is_tracking_fixture *fixture, gconstpointer user_data) {
-    GError *err = NULL;
-    g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, NULL));
 
     /* our group is the only one for this snap */
     const char *dirs[] = {
@@ -154,9 +147,7 @@ static void test_sc_cgroupv2_is_tracking_other_snaps(cgroupv2_is_tracking_fixtur
 }
 
 static void test_sc_cgroupv2_is_tracking_no_dirs(cgroupv2_is_tracking_fixture *fixture, gconstpointer user_data) {
-    GError *err = NULL;
-    g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.scope", -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.scope", -1, NULL));
 
     bool is_tracking = sc_cgroup_v2_is_tracking_snap("foo");
     g_assert_false(is_tracking);
@@ -164,10 +155,8 @@ static void test_sc_cgroupv2_is_tracking_no_dirs(cgroupv2_is_tracking_fixture *f
 
 static void test_sc_cgroupv2_is_tracking_bad_self_group(cgroupv2_is_tracking_fixture *fixture,
                                                         gconstpointer user_data) {
-    GError *err = NULL;
     /* trigger a failure in own group handling */
-    g_file_set_contents(fixture->self_cgroup, "", -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, "", -1, NULL));
 
     if (g_test_subprocess()) {
         sc_cgroup_v2_is_tracking_snap("foo");
@@ -178,9 +167,7 @@ static void test_sc_cgroupv2_is_tracking_bad_self_group(cgroupv2_is_tracking_fix
 }
 
 static void test_sc_cgroupv2_is_tracking_bad_nesting(cgroupv2_is_tracking_fixture *fixture, gconstpointer user_data) {
-    GError *err = NULL;
-    g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.scope", -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.scope", -1, NULL));
 
     /* create a hierarchy so deep that it triggers the nesting error */
     char *prev_path = g_build_filename(fixture->root, NULL);
@@ -207,9 +194,7 @@ static void test_sc_cgroupv2_is_tracking_dir_permissions(cgroupv2_is_tracking_fi
         g_test_skip("the test will not work when running as root");
         return;
     }
-    GError *err = NULL;
-    g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, NULL));
 
     /* there exist 2 groups with processes from a given snap */
     const char *dirs[] = {
@@ -238,9 +223,7 @@ static void test_sc_cgroupv2_is_tracking_dir_permissions(cgroupv2_is_tracking_fi
 
 static void test_sc_cgroupv2_is_tracking_no_cgroup_root(cgroupv2_is_tracking_fixture *fixture,
                                                         gconstpointer user_data) {
-    GError *err = NULL;
-    g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, "0::/foo/bar/baz/snap.foo.app.1234-1234.scope", -1, NULL));
 
     sc_set_cgroup_root("/does/not/exist");
 
@@ -272,29 +255,23 @@ static void cgroupv2_own_group_tear_down(cgroupv2_own_group_fixture *fixture, gc
 
 static void test_sc_cgroupv2_own_group_path_simple_happy_scope(cgroupv2_own_group_fixture *fixture,
                                                                gconstpointer user_data) {
-    GError *err = NULL;
     char *p SC_CLEANUP(sc_cleanup_string) = NULL;
-    g_file_set_contents(fixture->self_cgroup, (char *)user_data, -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, (char *)user_data, -1, NULL));
     p = sc_cgroup_v2_own_path_full();
     g_assert_cmpstr(p, ==, "/foo/bar/baz.slice/snap.foo.bar.1234-1234.scope");
 }
 
 static void test_sc_cgroupv2_own_group_path_simple_happy_service(cgroupv2_own_group_fixture *fixture,
                                                                  gconstpointer user_data) {
-    GError *err = NULL;
     char *p SC_CLEANUP(sc_cleanup_string) = NULL;
-    g_file_set_contents(fixture->self_cgroup, (char *)user_data, -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, (char *)user_data, -1, NULL));
     p = sc_cgroup_v2_own_path_full();
     g_assert_cmpstr(p, ==, "/system.slice/snap.foo.bar.service");
 }
 
 static void test_sc_cgroupv2_own_group_path_empty(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
-    GError *err = NULL;
     char *p SC_CLEANUP(sc_cleanup_string) = NULL;
-    g_file_set_contents(fixture->self_cgroup, (char *)user_data, -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, (char *)user_data, -1, NULL));
     p = sc_cgroup_v2_own_path_full();
     g_assert_null(p);
 }
@@ -311,14 +288,13 @@ static void _test_sc_cgroupv2_own_group_path_die_with_message(const char *msg) {
 }
 
 static void test_sc_cgroupv2_own_group_path_die(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
-    GError *err = NULL;
-    g_file_set_contents(fixture->self_cgroup, (char *)user_data, -1, &err);
-    g_assert_no_error(err);
+    g_assert_true(g_file_set_contents(fixture->self_cgroup, (char *)user_data, -1, NULL));
     _test_sc_cgroupv2_own_group_path_die_with_message("unexpected content of group entry 0::\n");
 }
 
 static void test_sc_cgroupv2_own_group_path_no_file(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
-    g_remove(fixture->self_cgroup);
+    /* make sure that the file is removed if it exists */
+    (void)g_remove(fixture->self_cgroup);
     _test_sc_cgroupv2_own_group_path_die_with_message("cannot open *\n");
 }
 

--- a/cmd/libsnap-confine-private/cleanup-funcs-test.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs-test.c
@@ -91,12 +91,11 @@ static void test_cleanup_endmntent(void)
 	gint mock_fstab_fd =
 	    g_file_open_tmp("s-c-test-fstab-mock.XXXXXX", &mock_fstab, &err);
 	g_assert_no_error(err);
-	g_close(mock_fstab_fd, &err);
-	g_assert_no_error(err);
+	g_assert_true(g_close(mock_fstab_fd, NULL));
 	/* XXX: not strictly needed as the test only calls setmntent */
 	const char *mock_fstab_data = "/dev/foo / ext4 defaults 0 1";
-	g_file_set_contents(mock_fstab, mock_fstab_data, -1, &err);
-	g_assert_no_error(err);
+	g_assert_true(g_file_set_contents
+		      (mock_fstab, mock_fstab_data, -1, NULL));
 
 	f = setmntent(mock_fstab, "rt");
 	g_assert_nonnull(f);

--- a/cmd/libsnap-confine-private/feature-test.c
+++ b/cmd/libsnap-confine-private/feature-test.c
@@ -54,14 +54,14 @@ static void test_feature_enabled__missing_dir(void)
 	char subd[PATH_MAX];
 	sc_must_snprintf(subd, sizeof subd, "%s/absent", d);
 	sc_mock_feature_flag_dir(subd);
-	g_assert(!sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
+	g_assert_false(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
 
 static void test_feature_enabled__missing_file(void)
 {
 	const char *d = sc_testdir();
 	sc_mock_feature_flag_dir(d);
-	g_assert(!sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
+	g_assert_false(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
 
 static void test_feature_enabled__present_file(void)
@@ -72,7 +72,7 @@ static void test_feature_enabled__present_file(void)
 	sc_must_snprintf(pname, sizeof pname, "%s/per-user-mount-namespace", d);
 	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
-	g_assert(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
+	g_assert_true(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
 
 static void test_feature_parallel_instances(void)
@@ -80,13 +80,13 @@ static void test_feature_parallel_instances(void)
 	const char *d = sc_testdir();
 	sc_mock_feature_flag_dir(d);
 
-	g_assert(!sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
+	g_assert_false(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
 
 	char pname[PATH_MAX];
 	sc_must_snprintf(pname, sizeof pname, "%s/parallel-instances", d);
 	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
-	g_assert(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
+	g_assert_true(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
 }
 
 static void test_feature_hidden_snap_folder(void)
@@ -94,13 +94,13 @@ static void test_feature_hidden_snap_folder(void)
 	const char *d = sc_testdir();
 	sc_mock_feature_flag_dir(d);
 
-	g_assert(!sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
+	g_assert_false(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
 
 	char pname[PATH_MAX];
 	sc_must_snprintf(pname, sizeof pname, "%s/hidden-snap-folder", d);
 	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
-	g_assert(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
+	g_assert_true(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
 }
 
 static void __attribute__((constructor)) init(void)

--- a/cmd/libsnap-confine-private/feature-test.c
+++ b/cmd/libsnap-confine-private/feature-test.c
@@ -70,7 +70,7 @@ static void test_feature_enabled__present_file(void)
 	sc_mock_feature_flag_dir(d);
 	char pname[PATH_MAX];
 	sc_must_snprintf(pname, sizeof pname, "%s/per-user-mount-namespace", d);
-	g_file_set_contents(pname, "", -1, NULL);
+	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
 	g_assert(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
@@ -84,7 +84,7 @@ static void test_feature_parallel_instances(void)
 
 	char pname[PATH_MAX];
 	sc_must_snprintf(pname, sizeof pname, "%s/parallel-instances", d);
-	g_file_set_contents(pname, "", -1, NULL);
+	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
 	g_assert(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
 }
@@ -98,7 +98,7 @@ static void test_feature_hidden_snap_folder(void)
 
 	char pname[PATH_MAX];
 	sc_must_snprintf(pname, sizeof pname, "%s/hidden-snap-folder", d);
-	g_file_set_contents(pname, "", -1, NULL);
+	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
 	g_assert(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
 }

--- a/cmd/libsnap-confine-private/mount-opt-test.c
+++ b/cmd/libsnap-confine-private/mount-opt-test.c
@@ -216,7 +216,8 @@ static void test_sc_do_mount(gconstpointer snap_debug)
 	if (g_test_subprocess()) {
 		sc_break("mount", broken_mount);
 		if (GPOINTER_TO_INT(snap_debug) == 1) {
-			g_setenv("SNAP_CONFINE_DEBUG", "1", true);
+			g_assert_true(g_setenv
+				      ("SNAP_CONFINE_DEBUG", "1", true));
 		}
 		sc_do_mount("/foo", "/bar", "ext4", MS_RDONLY, NULL);
 
@@ -251,7 +252,8 @@ static void test_sc_do_umount(gconstpointer snap_debug)
 	if (g_test_subprocess()) {
 		sc_break("umount", broken_umount);
 		if (GPOINTER_TO_INT(snap_debug) == 1) {
-			g_setenv("SNAP_CONFINE_DEBUG", "1", true);
+			g_assert_true(g_setenv
+				      ("SNAP_CONFINE_DEBUG", "1", true));
 		}
 		sc_do_umount("/foo", MNT_DETACH);
 
@@ -294,7 +296,8 @@ static void test_sc_do_optional_mount_failure(gconstpointer snap_debug)
 	if (g_test_subprocess()) {
 		sc_break("mount", broken_mount);
 		if (GPOINTER_TO_INT(snap_debug) == 1) {
-			g_setenv("SNAP_CONFINE_DEBUG", "1", true);
+			g_assert_true(g_setenv
+				      ("SNAP_CONFINE_DEBUG", "1", true));
 		}
 		(void)sc_do_optional_mount("/foo", "/bar", "ext4", MS_RDONLY,
 					   NULL);


### PR DESCRIPTION
The latest coverity scan has identified issues like this:

```
*** CID 1506495:  Error handling issues  (CHECKED_RETURN)
/libsnap-confine-private/feature-test.c: 73 in
...
>>>     CID 1506495:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "g_file_set_contents(pname, "", -1L, NULL)" without checking return value. This library function may fail and return an error code.
73      g_file_set_contents(pname, "", -1, NULL);
```

which is a pattern we use commonly in the test code.

Also, the glib developer manual states that g_assert_true/g_assert_false should be over g_assert() in test code. See: https://docs.gtk.org/glib/func.assert_true.html