### PR TITLE
clang-format: stop breaking my includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: Google
 IndentWidth: 4
 ColumnLimit: 120
+IncludeBlocks: Preserve


### PR DESCRIPTION
Configure clang-format such that include blocks (groups of #include separated by
newlines) are preserved. This will prevent clang-format from reordering includes
in a silly way, for instance moving config.h to a place where it breaks the
build as _GNU_SOURCE is no longer defined early enough.

See https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details on the
option used.