### PR TITLE
packaging: changelog for 2.51.5 to master

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.51.4
+pkgver=2.51.5
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,29 @@
+snapd (2.51.5-1) unstable; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - snap/squashfs: handle squashfs-tools 4.5+
+    - tests/core20-install-device-file-install-via-hook-hack: adjust
+      test for 2.51
+    - o/devicestate/handlers_install.go: add workaround to create dirs
+      for install
+    - tests: fix linter warning
+    - tests: update other spread tests for new behaviour
+    - tests: ack assertions by default, add --noack option
+    - release-tools/changelog.py: also fix opensuse changelog date
+      format
+    - release-tools/changelog.py: fix typo in function name
+    - release-tools/changelog.py: fix fedora date format
+    - release-tools/changelog.py: handle case where we don't have a TZ
+    - release-tools/changelog.py: fix line length check
+    - release-tools/changelog.py: specify the LP bug for the release as
+      an arg too
+    - interface/modem-manager: add support for MBIM/QMI proxy
+      clients
+    - .github/workflows/test.yaml: use snapcraft 4.x to build the snapd
+      snap
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 16 Aug 2021 15:02:40 -0500
+
 snapd (2.51.4-1) unstable; urgency=medium
 
   * New upstream release, LP: #1929842

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -97,7 +97,7 @@
 %endif
 
 Name:           snapd
-Version:        2.51.4
+Version:        2.51.5
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -971,6 +971,29 @@ fi
 
 
 %changelog
+* Mon Aug 16 2021 Ian Johnson <ian.johnson@canonical.com>
+- New upstream release 2.51.5
+ - snap/squashfs: handle squashfs-tools 4.5+
+ - tests/core20-install-device-file-install-via-hook-hack: adjust
+   test for 2.51
+ - o/devicestate/handlers_install.go: add workaround to create dirs
+   for install
+ - tests: fix linter warning
+ - tests: update other spread tests for new behaviour
+ - tests: ack assertions by default, add --noack option
+ - release-tools/changelog.py: also fix opensuse changelog date
+   format
+ - release-tools/changelog.py: fix typo in function name
+ - release-tools/changelog.py: fix fedora date format
+ - release-tools/changelog.py: handle case where we don't have a TZ
+ - release-tools/changelog.py: fix line length check
+ - release-tools/changelog.py: specify the LP bug for the release as
+   an arg too
+ - interface/modem-manager: add support for MBIM/QMI proxy
+   clients
+ - .github/workflows/test.yaml: use snapcraft 4.x to build the snapd
+   snap
+
 * Mon Aug 09 2021 Ian Johnson <ian.johnson@canonical.com>
 - New upstream release 2.51.4
  - {device,snap}state: skip kernel extraction in seeding

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Aug 16 20:02:40 UTC 2021 - ian.johnson@canonical.com
+
+- Update to upstream release 2.51.5
+
+-------------------------------------------------------------------
 Mon Aug 09 23:38:57 UTC 2021 - ian.johnson@canonical.com
 
 - Update to upstream release 2.51.4

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -83,7 +83,7 @@
 
 
 Name:           snapd
-Version:        2.51.4
+Version:        2.51.5
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,29 @@
+snapd (2.51.5~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - snap/squashfs: handle squashfs-tools 4.5+
+    - tests/core20-install-device-file-install-via-hook-hack: adjust
+      test for 2.51
+    - o/devicestate/handlers_install.go: add workaround to create dirs
+      for install
+    - tests: fix linter warning
+    - tests: update other spread tests for new behaviour
+    - tests: ack assertions by default, add --noack option
+    - release-tools/changelog.py: also fix opensuse changelog date
+      format
+    - release-tools/changelog.py: fix typo in function name
+    - release-tools/changelog.py: fix fedora date format
+    - release-tools/changelog.py: handle case where we don't have a TZ
+    - release-tools/changelog.py: fix line length check
+    - release-tools/changelog.py: specify the LP bug for the release as
+      an arg too
+    - interface/modem-manager: add support for MBIM/QMI proxy
+      clients
+    - .github/workflows/test.yaml: use snapcraft 4.x to build the snapd
+      snap
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 16 Aug 2021 15:02:40 -0500
+
 snapd (2.51.4~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #1929842

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,29 @@
+snapd (2.51.5) xenial; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - snap/squashfs: handle squashfs-tools 4.5+
+    - tests/core20-install-device-file-install-via-hook-hack: adjust
+      test for 2.51
+    - o/devicestate/handlers_install.go: add workaround to create dirs
+      for install
+    - tests: fix linter warning
+    - tests: update other spread tests for new behaviour
+    - tests: ack assertions by default, add --noack option
+    - release-tools/changelog.py: also fix opensuse changelog date
+      format
+    - release-tools/changelog.py: fix typo in function name
+    - release-tools/changelog.py: fix fedora date format
+    - release-tools/changelog.py: handle case where we don't have a TZ
+    - release-tools/changelog.py: fix line length check
+    - release-tools/changelog.py: specify the LP bug for the release as
+      an arg too
+    - interface/modem-manager: add support for MBIM/QMI proxy
+      clients
+    - .github/workflows/test.yaml: use snapcraft 4.x to build the snapd
+      snap
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 16 Aug 2021 15:02:40 -0500
+
 snapd (2.51.4) xenial; urgency=medium
 
   * New upstream release, LP: #1929842


### PR DESCRIPTION
Changelog for 2.51.5 to prevent the edge core builds from rolling back in version number to 2.51.4.