### PR TITLE
interfaces/builtin/raw_usb: fix platform typo, fix access to usb devices accessible through platform

### DIFF
--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -44,7 +44,8 @@ const rawusbConnectedPlugAppArmor = `
 # Allow detection of usb devices. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,
 /sys/devices/pci**/usb[0-9]** r,
-/sys/devices/platform/{sbc,soc}/*.usb/usb[0-9]** r,
+/sys/devices/platform/soc/*.usb/usb[0-9]** r,
+/sys/devices/platform/scb/*.pcie/pci**/usb[0-9]** r,
 
 /run/udev/data/c16[67]:[0-9] r, # ACM USB modems
 /run/udev/data/b180:*    r, # various USB block devices


### PR DESCRIPTION
Commit ac28b0a437a7b251b107aac3549d40f71848e0c3 introduced a typo in the allowed
path, it should be /sys/devices/platform/scb instead of ../sbc, even though the
actual commit message references the correct path.

While at it, on raspberry Pi 3 the usb hub appears right under the soc platform
device, eg.: /sys/devices/platform/soc/3f980000.usb, while on Pi 4, there is a
PCIe controller under the SCB device, eg:
/sys/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1.4/idVendor

See https://forum.snapcraft.io/t/openhab-3-0-no-access-to-z-wave-usb-stick/26044
for additional details.
