### PR TITLE
cmd/snap: print logs in local timezone

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -108,8 +108,22 @@ type Log struct {
 	PID       string    `json:"pid"`       // The process identifier
 }
 
+// String will format the log entry with the timestamp in the local timezone
 func (l Log) String() string {
-	return fmt.Sprintf("%s %s[%s]: %s", l.Timestamp.Format(time.RFC3339), l.SID, l.PID, l.Message)
+	return l.fmtLog(time.Local)
+}
+
+// StringInUTC will format the log entry with the timestamp in UTC
+func (l Log) StringInUTC() string {
+	return l.fmtLog(time.UTC)
+}
+
+func (l Log) fmtLog(timezone *time.Location) string {
+	if timezone == nil {
+		timezone = time.Local
+	}
+
+	return fmt.Sprintf("%s %s[%s]: %s", l.Timestamp.In(timezone).Format(time.RFC3339), l.SID, l.PID, l.Message)
 }
 
 // Logs asks for the logs of a series of services, by name.

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -40,6 +40,7 @@ type svcStatus struct {
 
 type svcLogs struct {
 	clientMixin
+	timeMixin
 	N          string `short:"n" default:"10"`
 	Follow     bool   `short:"f"`
 	Positional struct {
@@ -84,12 +85,12 @@ func init() {
 	}}
 	addCommand("services", shortServicesHelp, longServicesHelp, func() flags.Commander { return &svcStatus{} }, nil, argdescs)
 	addCommand("logs", shortLogsHelp, longLogsHelp, func() flags.Commander { return &svcLogs{} },
-		map[string]string{
+		timeDescs.also(map[string]string{
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"n": i18n.G("Show only the given number of lines, or 'all'."),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"f": i18n.G("Wait for new lines and print them as they come in."),
-		}, argdescs)
+		}), argdescs)
 
 	addCommand("start", shortStartHelp, longStartHelp, func() flags.Commander { return &svcStart{} },
 		waitDescs.also(map[string]string{
@@ -173,7 +174,11 @@ func (s *svcLogs) Execute(args []string) error {
 	}
 
 	for log := range logs {
-		fmt.Fprintln(Stdout, log)
+		if s.AbsTime {
+			fmt.Fprintln(Stdout, log.StringInUTC())
+		} else {
+			fmt.Fprintln(Stdout, log)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Sets the default timezone for the 'snap logs' command to the local timezone. Adds an --abs-time flag to display the timestamps in UTC.
https://bugs.launchpad.net/snapd/+bug/1934686
