### PR TITLE
build-aux: build with go-1.13 in the snapcraft build too

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ parts:
   snapd-deb:
     plugin: nil
     source: .
-    build-snaps: [go/1.10/stable]
+    build-snaps: [go/1.13/stable]
     override-pull: |
       snapcraftctl pull
       # install build dependencies


### PR DESCRIPTION
Broken out from #10559 thanks to Ian for spotting this.