### PR TITLE
o/snapstate: update default provider if missing required content

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -329,6 +329,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 
 	typ := snap.TypeApp
 	epoch := snap.E("1*")
+
 	switch cand.snapID {
 	case "":
 		panic("store refresh APIs expect snap-ids")
@@ -379,6 +380,10 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		typ = snap.TypeGadget
 	case "alias-snap-id":
 		name = "snap-id"
+	case "outdated-consumer-id":
+		name = "outdated-consumer"
+	case "outdated-producer-id":
+		name = "outdated-producer"
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}
@@ -416,6 +421,28 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		Architectures: []string{"all"},
 		Epoch:         epoch,
 	}
+
+	if name == "outdated-consumer" {
+		info.Plugs = map[string]*snap.PlugInfo{
+			"content-plug": {
+				Snap:      info,
+				Interface: "content",
+				Attrs: map[string]interface{}{
+					"content":          "some-content",
+					"default-provider": "outdated-producer",
+				},
+			},
+		}
+	} else if name == "outdated-producer" {
+		info.Slots = map[string]*snap.SlotInfo{
+			"content-slot": {
+				Snap:      info,
+				Interface: "content",
+				Attrs:     map[string]interface{}{"content": "some-content"},
+			},
+		}
+	}
+
 	switch cand.channel {
 	case "channel-for-layout/stable":
 		info.Layout = map[string]*snap.Layout{

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -34,7 +34,9 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -94,6 +96,11 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 		return nil, nil
 	}
 	bs.restore = snapstatetest.MockDeviceModel(DefaultModel())
+
+	bs.state.Lock()
+	repo := interfaces.NewRepository()
+	ifacerepo.Replace(bs.state, repo)
+	bs.state.Unlock()
 
 	oldSnapServiceOptions := snapstate.SnapServiceOptions
 	snapstate.SnapServiceOptions = servicestate.SnapServiceOptions

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -98,7 +98,7 @@ var (
 
 	CurrentSnaps = currentSnaps
 
-	DefaultContentPlugProviders = defaultContentPlugProviders
+	DefaultProviderContentAttrs = defaultProviderContentAttrs
 
 	HasOtherInstances = hasOtherInstances
 
@@ -148,6 +148,9 @@ var (
 	SoftCheckNothingRunningForRefresh     = softCheckNothingRunningForRefresh
 	HardEnsureNothingRunningDuringRefresh = hardEnsureNothingRunningDuringRefresh
 )
+
+// install
+var HasAllContentAttrs = hasAllContentAttrs
 
 func MockNextRefresh(ar *autoRefresh, when time.Time) {
 	ar.nextRefresh = when

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -43,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/settings"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
@@ -196,7 +198,7 @@ func defaultPrereqSnapsChannel() string {
 	return channel
 }
 
-func linkSnapInFlight(st *state.State, snapName string) (bool, error) {
+func findLinkSnapTask(st *state.State, snapName string) (*state.Task, error) {
 	for _, chg := range st.Changes() {
 		if chg.Status().Ready() {
 			continue
@@ -208,16 +210,16 @@ func linkSnapInFlight(st *state.State, snapName string) (bool, error) {
 			if tc.Kind() == "link-snap" {
 				snapsup, err := TaskSnapSetup(tc)
 				if err != nil {
-					return false, err
+					return nil, err
 				}
 				if snapsup.InstanceName() == snapName {
-					return true, nil
+					return tc, nil
 				}
 			}
 		}
 	}
 
-	return false, nil
+	return nil, nil
 }
 
 func isInstalled(st *state.State, snapName string) (bool, error) {
@@ -264,14 +266,26 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 		base = snapsup.Base
 	}
 
-	if err := m.installPrereqs(t, base, snapsup.Prereq, snapsup.UserID, perfTimings); err != nil {
+	// if a previous version of snapd persisted Prereq only, fill the contentAttrs.
+	// There will be not content attrs, so it will not update an outdated default provider
+	if len(snapsup.PrereqContentAttrs) == 0 && len(snapsup.Prereq) != 0 {
+		snapsup.PrereqContentAttrs = make(map[string][]string, len(snapsup.Prereq))
+
+		for _, prereq := range snapsup.Prereq {
+			snapsup.PrereqContentAttrs[prereq] = nil
+		}
+	}
+
+	if err := m.installPrereqs(t, base, snapsup.PrereqContentAttrs, snapsup.UserID, perfTimings, snapsup.Flags); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (m *SnapManager) installOneBaseOrRequired(st *state.State, snapName string, requireTypeBase bool, channel string, onInFlight error, userID int) (*state.TaskSet, error) {
+func (m *SnapManager) installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []string, requireTypeBase bool, channel string, onInFlight error, userID int, flags Flags) (*state.TaskSet, error) {
+	st := t.State()
+
 	// The core snap provides everything we need for core16.
 	coreInstalled, err := isInstalled(st, "core")
 	if err != nil {
@@ -287,14 +301,13 @@ func (m *SnapManager) installOneBaseOrRequired(st *state.State, snapName string,
 		return nil, err
 	}
 	if isInstalled {
-		return nil, nil
+		return updatePrereqIfOutdated(t, snapName, contentAttrs, userID, flags)
 	}
+
 	// in progress?
-	inFlight, err := linkSnapInFlight(st, snapName)
-	if err != nil {
+	if linkTask, err := findLinkSnapTask(st, snapName); err != nil {
 		return nil, err
-	}
-	if inFlight {
+	} else if linkTask != nil {
 		return nil, onInFlight
 	}
 
@@ -310,20 +323,122 @@ func (m *SnapManager) installOneBaseOrRequired(st *state.State, snapName string,
 	return ts, err
 }
 
-func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string, userID int, tm timings.Measurer) error {
+// updates a prerequisite, if it's not providing a content interface that a plug expects it to
+func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []string, userID int, flags Flags) (*state.TaskSet, error) {
+	if len(contentAttrs) == 0 {
+		return nil, nil
+	}
+
+	st := t.State()
+
+	// check if the default provider has all expected content tags
+	if ok, err := hasAllContentAttrs(st, snapName, contentAttrs); err != nil {
+		return nil, err
+	} else if ok {
+		return nil, nil
+	}
+
+	// this is an optimization since the Update would also detect a conflict
+	// but only after accessing the store
+	if ok, err := shouldSkipToAvoidConflict(t, snapName); err != nil {
+		return nil, err
+	} else if ok {
+		return nil, nil
+	}
+
+	// default provider is missing some content tags (likely outdated) so update it
+	ts, err := Update(st, snapName, nil, userID, flags)
+	if err != nil {
+		if conflErr, ok := err.(*ChangeConflictError); ok {
+			// there's already an update for the same snap in this change,
+			// just skip this one
+			if conflErr.ChangeID == t.Change().ID() {
+				return nil, nil
+			}
+
+			return nil, &state.Retry{After: prerequisitesRetryTimeout}
+		}
+
+		// don't propagate error to avoid failing the main install since the
+		// content provider is (for now) a soft dependency
+		t.Logf("failed to update %q, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), err)
+		return nil, nil
+	}
+
+	return ts, nil
+}
+
+// Checks for conflicting tasks. Returns true if the operation should be skipped. The error
+// can be a state.Retry if the operation should be retried later.
+func shouldSkipToAvoidConflict(task *state.Task, snapName string) (bool, error) {
+	otherTask, err := findLinkSnapTask(task.State(), snapName)
+	if err != nil {
+		return false, err
+	}
+
+	if otherTask == nil {
+		return false, nil
+	}
+
+	// it's in the same change, so the snap is already going to be installed
+	if otherTask.Change().ID() == task.Change().ID() {
+		return true, nil
+	}
+
+	// it's not in the same change, so retry to avoid conflicting changes to the snap
+	return true, &state.Retry{
+		After:  prerequisitesRetryTimeout,
+		Reason: fmt.Sprintf("conflicting changes on snap %q by task %q", snapName, otherTask.Kind()),
+	}
+}
+
+// Checks if the snap has slots with "content" attributes matching the
+// ones that the snap being installed requires
+func hasAllContentAttrs(st *state.State, snapName string, requiredContentAttrs []string) (bool, error) {
+	providedContentAttrs := make(map[string]bool)
+	repo := ifacerepo.Get(st)
+
+	for _, slot := range repo.Slots(snapName) {
+		if slot.Interface != "content" {
+			continue
+		}
+
+		val, ok := slot.Lookup("content")
+		if !ok {
+			continue
+		}
+
+		contentAttr, ok := val.(string)
+		if !ok {
+			return false, fmt.Errorf("expected 'content' attribute of slot '%s' (snap: '%s') to be string but was %s", slot.Name, snapName, reflect.TypeOf(val))
+		}
+
+		providedContentAttrs[contentAttr] = true
+	}
+
+	for _, contentAttr := range requiredContentAttrs {
+		if _, ok := providedContentAttrs[contentAttr]; !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq map[string][]string, userID int, tm timings.Measurer, flags Flags) error {
 	st := t.State()
 
 	// We try to install all wanted snaps. If one snap cannot be installed
 	// because of change conflicts or similar we retry. Only if all snaps
 	// can be installed together we add the tasks to the change.
 	var tss []*state.TaskSet
-	for _, prereqName := range prereq {
+	for prereqName, contentAttrs := range prereq {
 		var onInFlightErr error = nil
 		var err error
 		var ts *state.TaskSet
 		timings.Run(tm, "install-prereq", fmt.Sprintf("install %q", prereqName), func(timings.Measurer) {
 			noTypeBaseCheck := false
-			ts, err = m.installOneBaseOrRequired(st, prereqName, noTypeBaseCheck, defaultPrereqSnapsChannel(), onInFlightErr, userID)
+			ts, err = m.installOneBaseOrRequired(t, prereqName, contentAttrs, noTypeBaseCheck, defaultPrereqSnapsChannel(), onInFlightErr, userID, flags)
 		})
 		if err != nil {
 			return prereqError("prerequisite", prereqName, err)
@@ -343,7 +458,7 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 	if base != "none" {
 		timings.Run(tm, "install-prereq", fmt.Sprintf("install base %q", base), func(timings.Measurer) {
 			requireTypeBase := true
-			tsBase, err = m.installOneBaseOrRequired(st, base, requireTypeBase, defaultBaseSnapsChannel(), onInFlightErr, userID)
+			tsBase, err = m.installOneBaseOrRequired(t, base, nil, requireTypeBase, defaultBaseSnapsChannel(), onInFlightErr, userID, Flags{})
 		})
 		if err != nil {
 			return prereqError("snap base", base, err)
@@ -364,7 +479,7 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 	if base != "core" && !snapdSnapInstalled && !coreSnapInstalled {
 		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
 			noTypeBaseCheck := false
-			tsSnapd, err = m.installOneBaseOrRequired(st, "snapd", noTypeBaseCheck, defaultSnapdSnapsChannel(), onInFlightErr, userID)
+			tsSnapd, err = m.installOneBaseOrRequired(t, "snapd", nil, noTypeBaseCheck, defaultSnapdSnapsChannel(), onInFlightErr, userID, Flags{})
 		})
 		if err != nil {
 			return prereqError("system snap", "snapd", err)

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -28,12 +28,15 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type prereqSuite struct {
@@ -54,6 +57,9 @@ func (s *prereqSuite) SetUpTest(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	snapstate.ReplaceStore(s.state, s.fakeStore)
+
+	repo := interfaces.NewRepository()
+	ifacerepo.Replace(s.state, repo)
 
 	s.state.Set("seeded", true)
 	s.state.Set("refresh-privacy-key", "privacy-key")
@@ -113,8 +119,8 @@ func (s *prereqSuite) TestDoPrereqWithBaseNone(c *C) {
 			RealName: "foo",
 			Revision: snap.R(33),
 		},
-		Base:   "none",
-		Prereq: []string{"prereq1"},
+		Base:               "none",
+		PrereqContentAttrs: map[string][]string{"prereq1": {"some-content"}},
 	})
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
@@ -158,9 +164,9 @@ func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {
 			RealName: "foo",
 			Revision: snap.R(33),
 		},
-		Channel: "beta",
-		Base:    "some-base",
-		Prereq:  []string{"prereq1", "prereq2"},
+		Channel:            "beta",
+		Base:               "some-base",
+		PrereqContentAttrs: map[string][]string{"prereq1": {"some-content"}, "prereq2": {"other-content"}},
 	})
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
@@ -171,7 +177,7 @@ func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
+	c.Assert(s.fakeBackend.ops, testutil.DeepUnsortedMatches, fakeOps{
 		{
 			op: "storesvc-snap-action",
 		},
@@ -221,7 +227,7 @@ func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {
 			linkedSnaps = append(linkedSnaps, snapsup.InstanceName())
 		}
 	}
-	c.Check(linkedSnaps, DeepEquals, expectedLinkedSnaps)
+	c.Check(linkedSnaps, testutil.DeepUnsortedMatches, expectedLinkedSnaps)
 }
 
 func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
@@ -331,9 +337,9 @@ func (s *prereqSuite) TestDoPrereqChannelEnvvars(c *C) {
 			RealName: "foo",
 			Revision: snap.R(33),
 		},
-		Channel: "beta",
-		Base:    "some-base",
-		Prereq:  []string{"prereq1", "prereq2"},
+		Channel:            "beta",
+		Base:               "some-base",
+		PrereqContentAttrs: map[string][]string{"prereq1": {"some-content"}, "prereq2": {"other-content"}},
 	})
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
@@ -344,7 +350,7 @@ func (s *prereqSuite) TestDoPrereqChannelEnvvars(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
+	c.Assert(s.fakeBackend.ops, testutil.DeepUnsortedMatches, fakeOps{
 		{
 			op: "storesvc-snap-action",
 		},
@@ -544,9 +550,9 @@ func (s *prereqSuite) TestDoPrereqBaseIsNotBase(c *C) {
 			RealName: "foo",
 			Revision: snap.R(33),
 		},
-		Channel: "beta",
-		Base:    "app-snap",
-		Prereq:  []string{"prereq1"},
+		Channel:            "beta",
+		Base:               "app-snap",
+		PrereqContentAttrs: map[string][]string{"prereq1": {"some-content"}},
 	})
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
@@ -573,9 +579,9 @@ func (s *prereqSuite) TestDoPrereqBaseNoRevision(c *C) {
 			RealName: "foo",
 			Revision: snap.R(33),
 		},
-		Channel: "beta",
-		Base:    "some-base",
-		Prereq:  []string{"prereq1"},
+		Channel:            "beta",
+		Base:               "some-base",
+		PrereqContentAttrs: map[string][]string{"prereq1": {"some-content"}},
 	})
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
@@ -602,8 +608,8 @@ func (s *prereqSuite) TestDoPrereqNoRevision(c *C) {
 			RealName: "foo",
 			Revision: snap.R(33),
 		},
-		Channel: "beta",
-		Prereq:  []string{"prereq1"},
+		Channel:            "beta",
+		PrereqContentAttrs: map[string][]string{"prereq1": {"some-content"}},
 	})
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -165,12 +165,14 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 			continue
 		}
 
+		providerContentAttrs := defaultProviderContentAttrs(st, update)
 		snapsup := &refreshCandidate{
 			SnapSetup: SnapSetup{
-				Base:      update.Base,
-				Prereq:    defaultContentPlugProviders(st, update),
-				Channel:   snapst.TrackingChannel,
-				CohortKey: snapst.CohortKey,
+				Base:               update.Base,
+				Prereq:             getKeys(providerContentAttrs),
+				PrereqContentAttrs: providerContentAttrs,
+				Channel:            snapst.TrackingChannel,
+				CohortKey:          snapst.CohortKey,
 				// UserID not set
 				Flags:        flags.ForSnapSetup(),
 				DownloadInfo: &update.DownloadInfo,

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -310,9 +310,10 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 			RealName: "other-snap",
 			Revision: snap.R(2),
 		},
-		Prereq:    []string{"foo-snap"},
-		PlugsOnly: true,
-		Channel:   "devel",
+		Prereq:             []string{"foo-snap"},
+		PrereqContentAttrs: map[string][]string{"foo-snap": {"some-content"}},
+		PlugsOnly:          true,
+		Channel:            "devel",
 		Flags: snapstate.Flags{
 			IsAutoRefresh: true,
 		},

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -84,8 +84,12 @@ type SnapSetup struct {
 	//
 	// Prereq is a list of snap-names that need to get installed
 	// together with this snap. Typically used when installing
-	// content-snaps with default-providers.
+	// content-snaps with default-providers. Should be set along
+	// with PrereqContentAttrs (and match its keys) for forward-compatibility.
 	Prereq []string `json:"prereq,omitempty"`
+
+	// PrereqContentAttrs maps default providers snap names to the content they provide.
+	PrereqContentAttrs map[string][]string `json:"prereq-content-attrs,omitempty"`
 
 	Flags
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -119,7 +119,7 @@ func (ins installSnapInfo) SnapBase() string {
 }
 
 func (ins installSnapInfo) Prereq(st *state.State) []string {
-	return defaultContentPlugProviders(st, ins.Info)
+	return getKeys(defaultProviderContentAttrs(st, ins.Info))
 }
 
 func (ins installSnapInfo) SnapSetupForUpdate(st *state.State, params updateParamsFunc, userID int, globalFlags *Flags) (*SnapSetup, *SnapState, error) {
@@ -138,18 +138,20 @@ func (ins installSnapInfo) SnapSetupForUpdate(st *state.State, params updatePara
 		return nil, nil, err
 	}
 
+	providerContentAttrs := defaultProviderContentAttrs(st, update)
 	snapsup := SnapSetup{
-		Base:         update.Base,
-		Prereq:       defaultContentPlugProviders(st, update),
-		Channel:      revnoOpts.Channel,
-		CohortKey:    revnoOpts.CohortKey,
-		UserID:       snapUserID,
-		Flags:        flags.ForSnapSetup(),
-		DownloadInfo: &update.DownloadInfo,
-		SideInfo:     &update.SideInfo,
-		Type:         update.Type(),
-		PlugsOnly:    len(update.Slots) == 0,
-		InstanceKey:  update.InstanceKey,
+		Base:               update.Base,
+		Prereq:             getKeys(providerContentAttrs),
+		PrereqContentAttrs: providerContentAttrs,
+		Channel:            revnoOpts.Channel,
+		CohortKey:          revnoOpts.CohortKey,
+		UserID:             snapUserID,
+		Flags:              flags.ForSnapSetup(),
+		DownloadInfo:       &update.DownloadInfo,
+		SideInfo:           &update.SideInfo,
+		Type:               update.Type(),
+		PlugsOnly:          len(update.Slots) == 0,
+		InstanceKey:        update.InstanceKey,
 		auxStoreInfo: auxStoreInfo{
 			Website: update.Website,
 			Media:   update.Media,
@@ -689,6 +691,7 @@ func contentAttr(attrer interfaces.Attrer) string {
 	return s
 }
 
+// returns a map populated with content tags for which there is a content snap in the system
 func contentIfaceAvailable(st *state.State) map[string]bool {
 	repo := ifacerepo.Get(st)
 	contentSlots := repo.AllSlots("content")
@@ -703,24 +706,35 @@ func contentIfaceAvailable(st *state.State) map[string]bool {
 	return avail
 }
 
-// defaultContentPlugProviders takes a snap.Info and returns what
-// default providers there are.
-func defaultContentPlugProviders(st *state.State, info *snap.Info) []string {
+// defaultProviderContentAttrs takes a snap.Info and returns a map of
+// default providers to the value of content attributes they should
+// provide. Content attributes already provided by a snap in the system are omitted.
+func defaultProviderContentAttrs(st *state.State, info *snap.Info) map[string][]string {
 	needed := snap.NeededDefaultProviders(info)
 	if len(needed) == 0 {
 		return nil
 	}
 	avail := contentIfaceAvailable(st)
-	out := []string{}
-	for snapInstance, contentTags := range needed {
-		for _, contentTag := range contentTags {
-			if !avail[contentTag] {
-				out = append(out, snapInstance)
-				break
+
+	out := make(map[string][]string)
+	for snapInstance, contentValues := range needed {
+		for _, content := range contentValues {
+			if !avail[content] {
+				out[snapInstance] = append(out[snapInstance], content)
 			}
 		}
 	}
 	return out
+}
+
+func getKeys(kv map[string][]string) []string {
+	keys := make([]string, 0, len(kv))
+
+	for key := range kv {
+		keys = append(keys, key)
+	}
+
+	return keys
 }
 
 // validateFeatureFlags validates the given snap only uses experimental
@@ -885,16 +899,18 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		return nil, nil, err
 	}
 
+	providerContentAttrs := defaultProviderContentAttrs(st, info)
 	snapsup := &SnapSetup{
-		Base:        info.Base,
-		Prereq:      defaultContentPlugProviders(st, info),
-		SideInfo:    si,
-		SnapPath:    path,
-		Channel:     channel,
-		Flags:       flags.ForSnapSetup(),
-		Type:        info.Type(),
-		PlugsOnly:   len(info.Slots) == 0,
-		InstanceKey: info.InstanceKey,
+		Base:               info.Base,
+		Prereq:             getKeys(providerContentAttrs),
+		PrereqContentAttrs: providerContentAttrs,
+		SideInfo:           si,
+		SnapPath:           path,
+		Channel:            channel,
+		Flags:              flags.ForSnapSetup(),
+		Type:               info.Type(),
+		PlugsOnly:          len(info.Slots) == 0,
+		InstanceKey:        info.InstanceKey,
 	}
 
 	ts, err := doInstall(st, &snapst, snapsup, instFlags, "", inUseFor(deviceCtx))
@@ -994,17 +1010,19 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 		}
 	}
 
+	providerContentAttrs := defaultProviderContentAttrs(st, info)
 	snapsup := &SnapSetup{
-		Channel:      opts.Channel,
-		Base:         info.Base,
-		Prereq:       defaultContentPlugProviders(st, info),
-		UserID:       userID,
-		Flags:        flags.ForSnapSetup(),
-		DownloadInfo: &info.DownloadInfo,
-		SideInfo:     &info.SideInfo,
-		Type:         info.Type(),
-		PlugsOnly:    len(info.Slots) == 0,
-		InstanceKey:  info.InstanceKey,
+		Channel:            opts.Channel,
+		Base:               info.Base,
+		Prereq:             getKeys(providerContentAttrs),
+		PrereqContentAttrs: providerContentAttrs,
+		UserID:             userID,
+		Flags:              flags.ForSnapSetup(),
+		DownloadInfo:       &info.DownloadInfo,
+		SideInfo:           &info.SideInfo,
+		Type:               info.Type(),
+		PlugsOnly:          len(info.Slots) == 0,
+		InstanceKey:        info.InstanceKey,
 		auxStoreInfo: auxStoreInfo{
 			Media:   info.Media,
 			Website: info.Website,
@@ -1103,17 +1121,19 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 			channel = sar.RedirectChannel
 		}
 
+		providerContentAttrs := defaultProviderContentAttrs(st, info)
 		snapsup := &SnapSetup{
-			Channel:      channel,
-			Base:         info.Base,
-			Prereq:       defaultContentPlugProviders(st, info),
-			UserID:       userID,
-			Flags:        flags.ForSnapSetup(),
-			DownloadInfo: &info.DownloadInfo,
-			SideInfo:     &info.SideInfo,
-			Type:         info.Type(),
-			PlugsOnly:    len(info.Slots) == 0,
-			InstanceKey:  info.InstanceKey,
+			Channel:            channel,
+			Base:               info.Base,
+			Prereq:             getKeys(providerContentAttrs),
+			PrereqContentAttrs: providerContentAttrs,
+			UserID:             userID,
+			Flags:              flags.ForSnapSetup(),
+			DownloadInfo:       &info.DownloadInfo,
+			SideInfo:           &info.SideInfo,
+			Type:               info.Type(),
+			PlugsOnly:          len(info.Slots) == 0,
+			InstanceKey:        info.InstanceKey,
 		}
 
 		ts, err := doInstall(st, &snapst, snapsup, 0, "", inUseFor(deviceCtx))

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -3907,4 +3908,115 @@ func (s *validationSetsSuite) TestInstallManyRequiredRevisionForValidationSetOK(
 		revno: snap.R(2),
 	}}
 	c.Assert(s.fakeBackend.ops[1:], DeepEquals, expectedOps)
+}
+
+func (s *snapmgrTestSuite) TestInstallWithOutdatedPrereq(c *C) {
+	s.state.Lock()
+	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
+
+	info := &snap.SideInfo{
+		Revision: snap.R(1),
+		SnapID:   "snap-content-slot-id",
+		RealName: "content-snap",
+	}
+	snapstate.Set(s.state, "snap-content-slot", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{info},
+		Current:  info.Revision,
+		Active:   true,
+	})
+
+	chg := s.state.NewChange("install", "install a snap")
+	ts, err := snapstate.Install(context.Background(), s.state, "snap-content-plug", nil, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.Status(), Equals, state.DoneStatus)
+
+	c.Check(ts.Tasks(), NotNil)
+	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
+		{macaroon: s.user.StoreMacaroon, name: "snap-content-plug", target: filepath.Join(dirs.SnapBlobDir, "snap-content-plug_11.snap")},
+		{macaroon: s.user.StoreMacaroon, name: "snap-content-slot", target: filepath.Join(dirs.SnapBlobDir, "snap-content-slot_11.snap")},
+	})
+}
+
+func (s *snapmgrTestSuite) TestHasAllContentAttributes(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	mySnap := &snap.Info{
+		SuggestedName: "some-snap",
+		Version:       "1",
+		Slots:         make(map[string]*snap.SlotInfo, 3),
+	}
+
+	// create slots (content type and others) that the snap will provide
+	slots := []*snap.SlotInfo{
+		{
+			Name:      "some-content-slot",
+			Snap:      mySnap,
+			Interface: "content",
+			Attrs:     map[string]interface{}{"content": "some"},
+		},
+		{
+			Name:      "wrong-tag-slot",
+			Snap:      mySnap,
+			Interface: "content",
+			Attrs:     map[string]interface{}{"stuff": "wrong-tag"},
+		},
+		{
+			Name:      "wrong-iface-slot",
+			Snap:      mySnap,
+			Interface: "diff",
+			Attrs:     map[string]interface{}{"content": "wrong-iface"},
+		},
+	}
+
+	for _, slot := range slots {
+		mySnap.Slots[slot.Name] = slot
+	}
+
+	// add slots to repo
+	repo := interfaces.NewRepository()
+	c.Assert(repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "content"}), IsNil)
+	c.Assert(repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "diff"}), IsNil)
+	ifacerepo.Replace(s.state, repo)
+	c.Assert(repo.AddSnap(mySnap), IsNil)
+
+	// check snap provides all content tags required
+	ok, err := snapstate.HasAllContentAttrs(s.state, "some-snap", []string{"some"})
+	c.Check(err, IsNil)
+	c.Assert(ok, Equals, true)
+
+	// shouldn't find "wrong-iface" because interface type isn't 'content'
+	ok, err = snapstate.HasAllContentAttrs(s.state, "some-snap", []string{"some", "wrong-iface"})
+	c.Check(err, IsNil)
+	c.Assert(ok, Equals, false)
+
+	// shouldn't find "wrong-tag" because it's not keyed by "content" attr
+	ok, err = snapstate.HasAllContentAttrs(s.state, "some-snap", []string{"some", "wrong-tag"})
+	c.Check(err, IsNil)
+	c.Assert(ok, Equals, false)
+
+	// check that non-existent snap returns false
+	ok, err = snapstate.HasAllContentAttrs(s.state, "other-snap", []string{"some"})
+	c.Check(err, IsNil)
+	c.Assert(ok, Equals, false)
+
+	// check that content attr of non-string type returns error
+	err = repo.AddSlot(&snap.SlotInfo{
+		Name:      "bad-content-slot",
+		Snap:      mySnap,
+		Interface: "content",
+		Attrs:     map[string]interface{}{"content": 123},
+	})
+	c.Assert(err, IsNil)
+
+	_, err = snapstate.HasAllContentAttrs(s.state, "some-snap", []string{"some"})
+	c.Assert(err.Error(), Equals, `expected 'content' attribute of slot 'bad-content-slot' (snap: 'some-snap') to be string but was int`)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -3984,11 +3984,10 @@ func (s *snapStateSuite) TestCurrentSideInfoInconsistentWithCurrent(c *C) {
 	c.Check(func() { snapst.CurrentSideInfo() }, PanicMatches, `cannot find snapst.Current in the snapst.Sequence`)
 }
 
-func (snapStateSuite) TestDefaultContentPlugProviders(c *C) {
+func (snapStateSuite) TestDefaultProviderContentTags(c *C) {
 	info := &snap.Info{
 		Plugs: map[string]*snap.PlugInfo{},
 	}
-
 	info.Plugs["foo"] = &snap.PlugInfo{
 		Snap:      info,
 		Name:      "sound-themes",
@@ -4016,9 +4015,13 @@ func (snapStateSuite) TestDefaultContentPlugProviders(c *C) {
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(st, repo)
 
-	providers := snapstate.DefaultContentPlugProviders(st, info)
-	sort.Strings(providers)
-	c.Check(providers, DeepEquals, []string{"common-themes", "some-snap"})
+	providerContentAttrs := snapstate.DefaultProviderContentAttrs(st, info)
+
+	c.Check(providerContentAttrs, HasLen, 2)
+	sort.Strings(providerContentAttrs["common-themes"])
+	c.Check(providerContentAttrs["common-themes"], DeepEquals, []string{"bar", "foo"})
+	c.Check(providerContentAttrs["common-themes"], DeepEquals, []string{"bar", "foo"})
+	c.Check(providerContentAttrs["some-snap"], DeepEquals, []string{"baz"})
 }
 
 func (s *snapmgrTestSuite) testRevertSequence(c *C, opts *opSeqOpts) *state.TaskSet {


### PR DESCRIPTION
Updates a default provider when installing a snap if it's already installed but missing a required content attribute.


