### PR TITLE
cmd/libsnap-confine-private: fix issues identified by coverity

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -115,8 +115,9 @@ bool sc_cgroup_freezer_occupied(const char *snap_name)
 			if (errno != ENOENT) {
 				die("cannot stat /proc/%s", line_buf);
 			}
+			continue;
 		}
-		debug("found process %s belonging to user %d",
+		debug("found live process %s belonging to user %d",
 		      line_buf, statbuf.st_uid);
 		return true;
 	}

--- a/cmd/libsnap-confine-private/cgroup-support-test.c
+++ b/cmd/libsnap-confine-private/cgroup-support-test.c
@@ -41,6 +41,7 @@ static void cgroupv2_is_tracking_set_up(cgroupv2_is_tracking_fixture *fixture, g
     GError *err = NULL;
     int fd = g_file_open_tmp("s-c-unit-is-tracking-self-group.XXXXXX", &fixture->self_cgroup, &err);
     g_assert_no_error(err);
+    g_assert_cmpint(fd, >=, 0);
     g_close(fd, &err);
     g_assert_no_error(err);
     sc_set_self_cgroup_path(fixture->self_cgroup);

--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -35,7 +35,7 @@ static void mock_os_release(const char *mocked)
 	const char *old = os_release;
 	if (mocked != NULL) {
 		os_release = "os-release.test";
-		g_file_set_contents(os_release, mocked, -1, NULL);
+		g_assert_true(g_file_set_contents(os_release, mocked, -1, NULL));
 	} else {
 		os_release = "os-release.missing";
 	}

--- a/cmd/libsnap-confine-private/cleanup-funcs-test.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs-test.c
@@ -91,6 +91,7 @@ static void test_cleanup_endmntent(void)
 	gint mock_fstab_fd =
 	    g_file_open_tmp("s-c-test-fstab-mock.XXXXXX", &mock_fstab, &err);
 	g_assert_no_error(err);
+	g_assert_cmpint(mock_fstab_fd, >=, 0);
 	g_assert_true(g_close(mock_fstab_fd, NULL));
 	/* XXX: not strictly needed as the test only calls setmntent */
 	const char *mock_fstab_data = "/dev/foo / ext4 defaults 0 1";


### PR DESCRIPTION
Another batch of fixes, mostly trivial ones. Commit https://github.com/snapcore/snapd/commit/3d356a183241677c10ec11723150348012db0dcf is potentially interesting as we seem to have had a bug in handling of processes that go away when the cgroup v1 freezer was checked for being occupied by processes. The problem wasn't a big deal as it only executed if the base snap was changed while an application was already running. Since the processes can die at any time while we are listing the contents of cgroup.procs, we did a special check to verify that the process in question still exists. In this scenario, we would have incorrectly identified the base snap as being in use.