### PR TITLE
spread: temporarily fix the ownership of /home/ubuntu/.ssh on 21.10

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -640,6 +640,11 @@ prepare: |
         rmdir "$DELTA_PREFIX"
     fi
 
+    # TODO: drop once 21.10 images are fixed
+    if [[ "$SPREAD_SYSTEM" == ubuntu-21.10-* ]] && [[ -e /home/ubuntu/.ssh ]]; then
+        chown -R ubuntu:ubuntu /home/ubuntu/.ssh
+    fi
+
     # Take the MATCH and REBOOT functions from spread and allow our shell
     # scripts to use them as shell commands. The replacements are real
     # executables in tests/lib/bin (which is on PATH) but they source


### PR DESCRIPTION
It appears that /home/ubuntu/.ssh is owned by root:root. Apply a temporary fix
until the images are updated.

@sergiocazzolato is this something we can fix in our image build process?