### PR TITLE
tests: spread test for snapctl refresh --pending/--proceed from the snap

### DIFF
--- a/tests/lib/snaps/store/test-snapd-refresh-control.v1/bin/pending
+++ b/tests/lib/snaps/store/test-snapd-refresh-control.v1/bin/pending
@@ -1,0 +1,2 @@
+#!/bin/sh
+snapctl refresh --pending

--- a/tests/lib/snaps/store/test-snapd-refresh-control.v1/bin/proceed
+++ b/tests/lib/snaps/store/test-snapd-refresh-control.v1/bin/proceed
@@ -1,0 +1,2 @@
+#!/bin/sh
+snapctl refresh --proceed

--- a/tests/lib/snaps/store/test-snapd-refresh-control.v1/build-aux/snap/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-refresh-control.v1/build-aux/snap/snapcraft.yaml
@@ -12,9 +12,16 @@ architectures:
   - build-on: amd64
     run-on: all
 
+apps:
+  pending:
+    command: pending
+  proceed:
+    command: proceed
+
 parts:
   test-snapd-refresh-control:
-    plugin: nil
+    plugin: dump
+    source: bin
 
 plugs:
   content:

--- a/tests/lib/snaps/store/test-snapd-refresh-control.v2/bin/pending
+++ b/tests/lib/snaps/store/test-snapd-refresh-control.v2/bin/pending
@@ -1,0 +1,2 @@
+#!/bin/sh
+snapctl refresh --pending

--- a/tests/lib/snaps/store/test-snapd-refresh-control.v2/bin/proceed
+++ b/tests/lib/snaps/store/test-snapd-refresh-control.v2/bin/proceed
@@ -1,0 +1,2 @@
+#!/bin/sh
+snapctl refresh --proceed

--- a/tests/lib/snaps/store/test-snapd-refresh-control.v2/build-aux/snap/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-refresh-control.v2/build-aux/snap/snapcraft.yaml
@@ -12,9 +12,16 @@ architectures:
   - build-on: amd64
     run-on: all
 
+apps:
+  pending:
+    command: pending
+  proceed:
+    command: proceed
+
 parts:
   test-snapd-refresh-control:
-    plugin: nil
+    plugin: dump
+    source: bin
 
 plugs:
   content:

--- a/tests/main/auto-refresh-gating-from-snap/task.yaml
+++ b/tests/main/auto-refresh-gating-from-snap/task.yaml
@@ -1,0 +1,125 @@
+summary: Check that snapctl refresh --pending/--proceed can be used outside of
+  hooks.
+
+details: |
+  XXX
+
+environment:
+  SNAP_NAME: test-snapd-refresh-control
+  CONTENT_SNAP_NAME: test-snapd-refresh-control-provider
+  CONTROL_FILE: /var/snap/test-snapd-refresh-control/common/control
+  DEBUG_LOG_FILE: /var/snap/test-snapd-refresh-control/common/debug.log
+
+prepare: |
+  snap install --devmode jq
+  snap set system experimental.gate-auto-refresh-hook=true
+
+debug: |
+  jq -r '.data["snaps-hold"]' < /var/lib/snapd/state.json || true
+
+execute: |
+  force_autorefresh() {
+    echo "And force auto-refresh to happen"
+    jq ".data[\"last-refresh\"] = \"2007-08-22T09:30:44.449455783+01:00\"" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
+  }
+
+  wait_for_autorefresh() {
+    local LAST_CHANGE_ID="$1"
+    local CHANGE_ID="$1"
+    for _ in $(seq 200); do
+      # get last 2 lines of snap changes (the last one is always empty), match
+      # auto-refresh change; only proceed if the change has greater change id
+      # than the previously matched auto-refresh (this way we can match
+      # consecutive auto-refreshes).
+      if CHANGES=$(snap changes | tail -2 | grep "Done.*Auto-refresh"); then
+        CHANGE_ID=$(echo "$CHANGES" | awk '{print $1}')
+        if [ "$CHANGE_ID" -gt "$LAST_CHANGE_ID" ]; then
+          break
+        fi
+      fi
+      snap debug ensure-state-soon
+      sleep 1
+    done
+    if [ "$LAST_CHANGE_ID" -eq "$CHANGE_ID" ]; then
+      echo "Expected a new auto-refresh change with id greater than $LAST_CHANGE_ID, but it didn't happen"
+      exit 1
+    fi
+    echo "$CHANGE_ID"
+  }
+
+  force_channel_change() {
+    local SNAP="$1"
+    local CHANNEL="$2"
+    echo "Modify snap $SNAP to track the $CHANNEL channel"
+    jq ".data.snaps[\"$SNAP\"].channel = \"$CHANNEL\"" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
+  }
+
+  LAST_REFRESH_CHANGE_ID=1
+
+  echo "Install test snaps"
+  snap install "$SNAP_NAME"
+  snap install "$CONTENT_SNAP_NAME"
+
+  echo "Connecting the two test snaps with content interface"
+  snap connect "$SNAP_NAME:content" "$CONTENT_SNAP_NAME:content"
+
+  # sanity check
+  snap list | MATCH "$SNAP_NAME +1\.0\.0"
+  snap list | MATCH "$CONTENT_SNAP_NAME +1\.0\.0"
+
+  echo "Check that the --pending information is not available yet"
+  "$SNAP_NAME".pending > pending.log
+  MATCH "pending: none" < pending.log
+  NOMATCH "version:" < pending.log
+
+  snap set core refresh.schedule="0:00-23:59"
+
+  systemctl stop snapd.{service,socket}
+  force_channel_change "$SNAP_NAME" beta
+  force_channel_change "$CONTENT_SNAP_NAME" beta
+
+  # Request the snap to hold the refresh (itself and its content provider).
+  # Writing into this file affects the command performed by the gate-auto-refresh hook
+  # in tests/lib/snaps/store/test-snapd-refresh-control.v*/meta/hooks/gate-auto-refresh.
+  echo "--hold" > "$CONTROL_FILE"
+
+  echo "Trigger auto-refresh of test-snapd-refresh-control-provider but hold it via test-snapd-refresh-control's hook"
+  force_autorefresh
+  systemctl start snapd.{service,socket}
+  
+  LAST_REFRESH_CHANGE_ID=$(wait_for_autorefresh "$LAST_REFRESH_CHANGE_ID")
+
+  echo "Check that the --pending information is available from the snap"
+  "$SNAP_NAME".pending > pending.log
+  MATCH "restart: +true" < pending.log
+  MATCH "base: +false" < pending.log
+  MATCH "channel: beta" < pending.log
+  MATCH "pending: ready" < pending.log
+  MATCH "version: 2\.0\.0" < pending.log
+
+  echo "Ensure our snaps were not updated"
+  snap list | MATCH "$CONTENT_SNAP_NAME +1\.0\.0"
+  # sanity check for the gating snap.
+  snap list | MATCH "$SNAP_NAME +1\.0\.0"
+
+  echo "Request to proceed from the snap (but hold it by the hook)"
+  echo "--hold" > "$CONTROL_FILE"
+  "$SNAP_NAME".proceed
+
+  LAST_REFRESH_CHANGE_ID=$(wait_for_autorefresh "$LAST_REFRESH_CHANGE_ID")
+
+  echo "Ensure our snaps were not updated"
+  snap list | MATCH "$CONTENT_SNAP_NAME +1\.0\.0"
+  snap list | MATCH "$SNAP_NAME +1\.0\.0"
+
+  echo "Request to proceed from the snap and stop holding the refresh from the hook"
+  rm -f "$CONTROL_FILE"
+  "$SNAP_NAME".proceed
+
+  LAST_REFRESH_CHANGE_ID=$(wait_for_autorefresh "$LAST_REFRESH_CHANGE_ID")
+
+  echo "Ensure our snaps were updated"
+  snap list | MATCH "$CONTENT_SNAP_NAME +2\.0\.0"
+  snap list | MATCH "$SNAP_NAME +2\.0\.0"

--- a/tests/main/auto-refresh-gating-from-snap/task.yaml
+++ b/tests/main/auto-refresh-gating-from-snap/task.yaml
@@ -2,7 +2,11 @@ summary: Check that snapctl refresh --pending/--proceed can be used outside of
   hooks.
 
 details: |
-  XXX
+  Test auto-refresh with gate-auto-refresh hook support enabled
+  (experimental.gate-auto-refresh-hook feature) and verify the snaps can
+  use snapctl refresh --pending/--proceed commands outside of hooks.
+  The test uses two test snaps, there are a few versions of these
+  snaps in the store (in stable/beta/edge channels) for this test.
 
 environment:
   SNAP_NAME: test-snapd-refresh-control


### PR DESCRIPTION
Spread test for snapctl refresh --pending and --proceed from the snap

Based on #10528 and #10626.
