### PR TITLE
tests: remove the test user just when it was installed on create-user-2 test

### DIFF
--- a/tests/core/create-user-2/task.yaml
+++ b/tests/core/create-user-2/task.yaml
@@ -8,7 +8,10 @@ restore: |
     if [ -e managed.device ]; then
         exit 0
     fi
-    snap remove-user "$USER_NAME"
+    # Check if the user exists before remove it
+    if id "$USER_NAME" >/dev/null 2>&1; then
+        snap remove-user "$USER_NAME"
+    fi
 
 debug: |
     if [ -e managed.device ]; then

--- a/tests/core/create-user/task.yaml
+++ b/tests/core/create-user/task.yaml
@@ -9,7 +9,10 @@ restore: |
     if [ -e managed.device ]; then
         exit 0
     fi
-    snap remove-user "$USER_NAME"
+    # Check if the user exists before remove it
+    if id "$USER_NAME" >/dev/null 2>&1; then
+        snap remove-user "$USER_NAME"
+    fi
 
 debug: |
     if [ -e managed.device ]; then


### PR DESCRIPTION
In case the create-user-2 test fails and the user was not installed, then we need to
check the user was created before removing it, otherwise the restore phase fails and the machine is discarded. 

When this happens with external backend the whole execution is lost because of that error.
