### PR TITLE
tests: stop the service when is active in test interfaces-firewall-control test

### DIFF
--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -38,7 +38,10 @@ prepare: |
     EOF
 
 restore: |
-    systemctl stop "$SERVICE_NAME"
+    # In case the service is not active, the restore fails stopping the service
+    if systemctl is-active "$SERVICE_NAME"; then
+        systemctl stop "$SERVICE_NAME"
+    fi
     rm -f "$REQUEST_FILE"
 
 execute: |


### PR DESCRIPTION
In case the service is not active, the restore fails to stop the service and the machine is discarded.

In case the restore fails when using the external backend, the whole run is lost.

