### PR TITLE
packaging: remove TEST_GITHUB_AUTOPKGTEST support

### DIFF
--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -123,17 +123,6 @@ override_dh_installdeb:
 	dh_installdeb
 
 override_dh_clean:
-ifneq (,$(TEST_GITHUB_AUTOPKGTEST))
-	# this will be set by the GITHUB webhook to trigger a autopkgtest
-	# we only need to run "govendor sync" here and then its ready
-	(export GOPATH="/tmp/go"; \
-	  mkdir -p /tmp/go/src/github.com/snapcore/; \
-          cp -ar . /tmp/go/src/github.com/snapcore/snapd; \
-	  go get -u github.com/kardianos/govendor; \
-	  (cd /tmp/go/src/github.com/snapcore/snapd ; /tmp/go/bin/govendor sync); \
-	  cp -ar /tmp/go/src/github.com/snapcore/snapd/vendor/ .; \
-        )
-endif
 	dh_clean
 	$(MAKE) -C data clean
 	# XXX: hacky

--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -108,17 +108,6 @@ override_dh_installdeb:
 	dh_installdeb
 
 override_dh_clean:
-ifneq (,$(TEST_GITHUB_AUTOPKGTEST))
-	# this will be set by the GITHUB webhook to trigger a autopkgtest
-	# we only need to run "govendor sync" here and then its ready
-	(export GOPATH="/tmp/go"; \
-	  mkdir -p /tmp/go/src/github.com/snapcore/; \
-          cp -ar . /tmp/go/src/github.com/snapcore/snapd; \
-	  go get -u github.com/kardianos/govendor; \
-	  (cd /tmp/go/src/github.com/snapcore/snapd ; /tmp/go/bin/govendor sync); \
-	  cp -ar /tmp/go/src/github.com/snapcore/snapd/vendor/ .; \
-        )
-endif
 	dh_clean
 	$(MAKE) -C data clean
 	# XXX: hacky

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -147,17 +147,6 @@ override_dh_systemd_enable:
 	dh_systemd_enable
 
 override_dh_clean:
-ifneq (,$(TEST_GITHUB_AUTOPKGTEST))
-	# this will be set by the GITHUB webhook to trigger a autopkgtest
-	# we only need to run "govendor sync" here and then its ready
-	(export GOPATH="/tmp/go"; \
-	  mkdir -p /tmp/go/src/github.com/snapcore/; \
-          cp -ar . /tmp/go/src/github.com/snapcore/snapd; \
-	  go get -u github.com/kardianos/govendor; \
-	  (cd /tmp/go/src/github.com/snapcore/snapd ; /tmp/go/bin/govendor sync); \
-	  cp -ar /tmp/go/src/github.com/snapcore/snapd/vendor/ .; \
-        )
-endif
 	dh_clean
 	$(MAKE) -C data clean
 	# XXX: hacky


### PR DESCRIPTION
In the (very) old days before spread we ran our testsuite in the
autopkgtest infrastructure. This had many problems and when spread
came along we used that and never looked back.

The code to run the tests in autopkgtest is still in place [1] and
this commit removes it now as it is unlikely we ever us this
again (and if so we can always revert this commit).

This is broken out from the code that moves to `go modules`.

[1] In debian/rules because autopkgtest really only can deal with
debian packages.
