### PR TITLE
interfaces/u2f-devices: add Nitrokey FIDO2

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -103,6 +103,11 @@ var u2fDevices = []u2fDevice{
 		ProductIDPattern: "4287",
 	},
 	{
+		Name:             "Nitrokey FIDO2",
+		VendorIDPattern:  "20a0",
+		ProductIDPattern: "42b1",
+	},
+	{
 		Name:             "Google Titan U2F",
 		VendorIDPattern:  "18d1",
 		ProductIDPattern: "5026",

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -89,7 +89,7 @@ func (s *u2fDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 19)
+	c.Assert(spec.Snippets(), HasLen, 20)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
This adds the Nitrokey FIDO2 to the list of supported U2F devices.

See also this Launchpad bug: https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/1940467
And this thread on the Snapcraft forum: https://forum.snapcraft.io/t/nitrokey-fido2-does-not-work-with-chromium-snap/26098

I am, however, not sure how to add the line `TAG=="snap_chromium_chromium", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_chromium_chromium $devpath $major:$minor"`, which is also required to make this key actually work.