### PR TITLE
secboot: switch main key KDF memory cost to 32KB

### DIFF
--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -46,7 +46,7 @@ func FormatEncryptedDevice(key EncryptionKey, label, node string) error {
 		// benchmark. This is okay because we have a high
 		// entropy key and the KDF does not gain us much.
 		KDFOptions: &sb.KDFOptions{
-			MemoryKiB:       32 * 1024,
+			MemoryKiB:       32,
 			ForceIterations: 4,
 		},
 	}

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -54,8 +54,8 @@ func (s *encryptSuite) TestFormatEncryptedDevice(c *C) {
 				MetadataKiBSize:     2048,
 				KeyslotsAreaKiBSize: 2560,
 				KDFOptions: &sb.KDFOptions{
-					MemoryKiB: 32768, TargetDuration: 0,
-					ForceIterations: 4, Parallel: 0,
+					MemoryKiB:       32,
+					ForceIterations: 4,
 				},
 			})
 			return tc.initErr


### PR DESCRIPTION
The main encryption key is high entropy 256bit already so there is
no need to use a strong KDF on top of this. There was a PR already
that switched this to 32MB but it turns out that 32KB is enough.

