### PR TITLE
tests: fix services-refresh-mode test

### DIFF
--- a/tests/main/services-refresh-mode/task.yaml
+++ b/tests/main/services-refresh-mode/task.yaml
@@ -3,7 +3,7 @@ summary: "Check that refresh-modes works"
 # takes >1.5min to run
 backends: [-autopkgtest]
 
-kill-timeout: 5m
+kill-timeout: 12m
 
 debug: |
     grep -n '' ./*.pid || true
@@ -23,7 +23,7 @@ execute: |
     echo "We can still see it running with the same PID"
     systemctl show -p MainPID snap.test-snapd-service.test-snapd-endure-service > new-main.pid
 
-    test "$(cat new-endure.pid)" = "$(cat old-endure.pid)"
+    test "$(cat new-main.pid)" = "$(cat old-main.pid)"
 
     echo "Once the snap is removed, the service is stopped"
     snap remove --purge test-snapd-service


### PR DESCRIPTION
The change contains 2 fixes:
1. The timeout has been increased due to on some pi3 it is giving kill-timeout. Just the remove takes like 3 minutes.
2. The files checked are wrong, bot cat are giving "No such file or directory"
