### PR TITLE
o/snapstate: fail remove with invalid snap names

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2525,6 +2525,10 @@ func removeInactiveRevision(st *state.State, name, snapID string, revision snap.
 // RemoveMany removes everything from the given list of names.
 // Note that the state must be locked by the caller.
 func RemoveMany(st *state.State, names []string) ([]string, []*state.TaskSet, error) {
+	if err := validateSnapNames(names); err != nil {
+		return nil, nil, err
+	}
+
 	removed := make([]string, 0, len(names))
 	tasksets := make([]*state.TaskSet, 0, len(names))
 
@@ -2563,6 +2567,22 @@ func RemoveMany(st *state.State, names []string) ([]string, []*state.TaskSet, er
 	}
 
 	return removed, tasksets, nil
+}
+
+func validateSnapNames(names []string) error {
+	var invalidNames []string
+
+	for _, name := range names {
+		if err := snap.ValidateInstanceName(name); err != nil {
+			invalidNames = append(invalidNames, name)
+		}
+	}
+
+	if len(invalidNames) > 0 {
+		return fmt.Errorf("cannot remove invalid snap names: %v", strings.Join(invalidNames, ", "))
+	}
+
+	return nil
 }
 
 // Revert returns a set of tasks for reverting to the previous version of the snap.

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -1707,3 +1707,23 @@ func (s *snapmgrTestSuite) TestRemoveKeepsGatingDataIfNotLastRevision(c *C) {
 	c.Assert(candidates, HasLen, 1)
 	c.Check(candidates["some-snap"], NotNil)
 }
+
+func (s *snapmgrTestSuite) TestRemoveFailsWithInvalidSnapName(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	removed, ts, err := snapstate.RemoveMany(s.state, []string{"some-snap", "rev=", "123"})
+	c.Check(removed, HasLen, 0)
+	c.Check(ts, HasLen, 0)
+	c.Check(err.Error(), Equals, "cannot remove invalid snap names: rev=, 123")
+}
+
+func (s *snapmgrTestSuite) TestRemoveSucceedsWithInstanceName(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	removed, ts, err := snapstate.RemoveMany(s.state, []string{"some-snap", "ab_c"})
+	c.Check(removed, NotNil)
+	c.Check(ts, NotNil)
+	c.Check(err, IsNil)
+}


### PR DESCRIPTION
Fails `snap remove` without removing any snap, if any of the specified snaps does not exist.

https://bugs.launchpad.net/snapd/+bug/1842203