### PR TITLE
packaging: merge 2.51.6 changelog back to 2.52

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.51.5
+pkgver=2.51.6
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,11 @@
+snapd (2.51.6-1) unstable; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - secboot: use half the mem for KDF in AddRecoveryKey
+    - secboot: switch main key KDF memory cost to 32KB
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Thu, 19 Aug 2021 15:49:47 -0500
+
 snapd (2.51.5-1) unstable; urgency=medium
 
   * New upstream release, LP: #1929842

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -97,7 +97,7 @@
 %endif
 
 Name:           snapd
-Version:        2.51.5
+Version:        2.51.6
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -971,6 +971,11 @@ fi
 
 
 %changelog
+* Thu Aug 19 2021 Ian Johnson <ian.johnson@canonical.com>
+- New upstream release 2.51.6
+ - secboot: use half the mem for KDF in AddRecoveryKey
+ - secboot: switch main key KDF memory cost to 32KB
+
 * Mon Aug 16 2021 Ian Johnson <ian.johnson@canonical.com>
 - New upstream release 2.51.5
  - snap/squashfs: handle squashfs-tools 4.5+

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Aug 19 20:49:47 UTC 2021 - ian.johnson@canonical.com
+
+- Update to upstream release 2.51.6
+
+-------------------------------------------------------------------
 Mon Aug 16 20:02:40 UTC 2021 - ian.johnson@canonical.com
 
 - Update to upstream release 2.51.5

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -83,7 +83,7 @@
 
 
 Name:           snapd
-Version:        2.51.5
+Version:        2.51.6
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,11 @@
+snapd (2.51.6~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - secboot: use half the mem for KDF in AddRecoveryKey
+    - secboot: switch main key KDF memory cost to 32KB
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Thu, 19 Aug 2021 15:49:47 -0500
+
 snapd (2.51.5~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #1929842

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,11 @@
+snapd (2.51.6) xenial; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - secboot: use half the mem for KDF in AddRecoveryKey
+    - secboot: switch main key KDF memory cost to 32KB
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Thu, 19 Aug 2021 15:49:47 -0500
+
 snapd (2.51.5) xenial; urgency=medium
 
   * New upstream release, LP: #1929842


### PR DESCRIPTION
Mainly for consistency in the view of the release versions for 2.52 when it comes time to cut this release.