### PR TITLE
tests: fix timing issue on security-dev-input-event-denied test

### DIFF
--- a/tests/main/security-dev-input-event-denied/task.yaml
+++ b/tests/main/security-dev-input-event-denied/task.yaml
@@ -54,16 +54,15 @@ execute: |
 
     echo "When the joystick plug is connected"
     snap connect test-snapd-event:joystick
+    udevadm trigger
     udevadm settle
 
     # Note, '-event-kbd' devices aren't joysticks (those are -event-joystick
     # (evdev event*) and -joystick (js*)) and therefore shouldn't be added to
     # the device cgroup when the joystick interface is plugged.
     echo "Then the snap is still not able to access an evdev keyboard"
-    if test-snapd-event "-event-kbd" 2> call.error; then
-        echo "Expected permission error calling evtest with connected joystick plug"
-        exit 1
-    fi
+    retry -n 3 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
+
     # device cgroup is 'Operation not permitted' which is expected when the
     # joystick interface is connected since a keyboard shouldn't be added to
     # the device cgroup.
@@ -73,15 +72,13 @@ execute: |
     # in device buttons, make sure we start in clean state and disconnect the
     # joystick interface
     snap disconnect test-snapd-event:joystick
+    udevadm trigger
     udevadm settle
 
     # 2. Device Buttons
 
     echo "Then the snap is not able to access an evdev keyboard"
-    if test-snapd-event "-event-kbd" 2> call.error; then
-        echo "Expected permission error calling evtest with disconnected plug"
-        exit 1
-    fi
+    retry -n 3 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
 
     if os.query is-hirsute || os.query is-impish; then
         # Cgroups is 'Operation not permitted' which is expected with default policy
@@ -93,16 +90,15 @@ execute: |
 
     echo "When the device-buttons plug is connected"
     snap connect test-snapd-event:device-buttons
+    udevadm trigger
     udevadm settle
 
     # Note, '-event-kbd' devices aren't device buttons (those are
     # -gpio-keys-event (evdev event*) and therefore shouldn't be added to
     # the device cgroup when the device-buttons interface is plugged.
     echo "Then the snap is still not able to access an evdev keyboard"
-    if test-snapd-event "-event-kbd" 2> call.error; then
-        echo "Expected permission error calling evtest with connected device-buttons plug"
-        exit 1
-    fi
+    retry -n 3 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
+
     # device cgroup is 'Operation not permitted' which is expected when the
     # device-buttons interface is connected since a keyboard shouldn't be added
     # to the device cgroup.

--- a/tests/main/security-dev-input-event-denied/task.yaml
+++ b/tests/main/security-dev-input-event-denied/task.yaml
@@ -54,14 +54,12 @@ execute: |
 
     echo "When the joystick plug is connected"
     snap connect test-snapd-event:joystick
-    udevadm trigger
-    udevadm settle
 
     # Note, '-event-kbd' devices aren't joysticks (those are -event-joystick
     # (evdev event*) and -joystick (js*)) and therefore shouldn't be added to
     # the device cgroup when the joystick interface is plugged.
     echo "Then the snap is still not able to access an evdev keyboard"
-    retry -n 3 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
+    retry -n 5 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
 
     # device cgroup is 'Operation not permitted' which is expected when the
     # joystick interface is connected since a keyboard shouldn't be added to
@@ -72,13 +70,11 @@ execute: |
     # in device buttons, make sure we start in clean state and disconnect the
     # joystick interface
     snap disconnect test-snapd-event:joystick
-    udevadm trigger
-    udevadm settle
 
     # 2. Device Buttons
 
     echo "Then the snap is not able to access an evdev keyboard"
-    retry -n 3 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
+    retry -n 5 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
 
     if os.query is-hirsute || os.query is-impish; then
         # Cgroups is 'Operation not permitted' which is expected with default policy
@@ -90,14 +86,12 @@ execute: |
 
     echo "When the device-buttons plug is connected"
     snap connect test-snapd-event:device-buttons
-    udevadm trigger
-    udevadm settle
 
     # Note, '-event-kbd' devices aren't device buttons (those are
     # -gpio-keys-event (evdev event*) and therefore shouldn't be added to
     # the device cgroup when the device-buttons interface is plugged.
     echo "Then the snap is still not able to access an evdev keyboard"
-    retry -n 3 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
+    retry -n 5 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
 
     # device cgroup is 'Operation not permitted' which is expected when the
     # device-buttons interface is connected since a keyboard shouldn't be added


### PR DESCRIPTION
The test is failing with the following error:

+ udevadm settle
+ echo 'Then the snap is still not able to access an evdev keyboard'
Then the snap is still not able to access an evdev keyboard
+ test-snapd-event -event-kbd
+ echo 'Expected permission error calling evtest with connected joystick
plug'
Expected permission error calling evtest with connected joystick plug
+ exit 1

The idea of the fix is to retry the check because sometimes it takes a
bit of time to start denying access.
