### PR TITLE
mount-control: step 1

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -88,12 +88,13 @@ var (
 	SnapCommandsDB      string
 	SnapAuxStoreInfoDir string
 
-	SnapBinariesDir     string
-	SnapServicesDir     string
-	SnapUserServicesDir string
-	SnapSystemdConfDir  string
-	SnapDesktopFilesDir string
-	SnapDesktopIconsDir string
+	SnapBinariesDir        string
+	SnapServicesDir        string
+	SnapRuntimeServicesDir string
+	SnapUserServicesDir    string
+	SnapSystemdConfDir     string
+	SnapDesktopFilesDir    string
+	SnapDesktopIconsDir    string
 
 	SnapDBusSessionPolicyDir   string
 	SnapDBusSystemPolicyDir    string
@@ -376,6 +377,7 @@ func SetRootDir(rootdir string) {
 
 	SnapBinariesDir = filepath.Join(SnapMountDir, "bin")
 	SnapServicesDir = filepath.Join(rootdir, "/etc/systemd/system")
+	SnapRuntimeServicesDir = filepath.Join(rootdir, "/run/systemd/system")
 	SnapUserServicesDir = filepath.Join(rootdir, "/etc/systemd/user")
 	SnapSystemdConfDir = SnapSystemdConfDirUnder(rootdir)
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -198,6 +198,9 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 		if out := systemdtest.HandleMockAllUnitsActiveOutput(cmd, nil); out != nil {
 			return out, nil
 		}
+		if out, ok := systemdtest.HandleMockListMountUnitsOutput(cmd, nil); ok {
+			return out, nil
+		}
 		return []byte("ActiveState=inactive\n"), nil
 	})
 	s.AddCleanup(r)

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -91,6 +91,7 @@ type managerBackend interface {
 	RemoveSnapData(info *snap.Info) error
 	RemoveSnapCommonData(info *snap.Info) error
 	RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool) error
+	RemoveSnapMountUnits(s snap.PlaceInfo, meter progress.Meter) error
 	DiscardSnapNamespace(snapName string) error
 	RemoveSnapInhibitLock(snapName string) error
 

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -44,3 +44,18 @@ func removeMountUnit(mountDir string, meter progress.Meter) error {
 	sysd := systemd.New(systemd.SystemMode, meter)
 	return sysd.RemoveMountUnitFile(mountDir)
 }
+
+func (b Backend) RemoveSnapMountUnits(s snap.PlaceInfo, meter progress.Meter) error {
+	sysd := systemd.New(systemd.SystemMode, meter)
+	originFilter := ""
+	mountPoints, err := sysd.ListMountUnits(s.InstanceName(), originFilter)
+	if err != nil {
+		return err
+	}
+	for _, mountPoint := range mountPoints {
+		if err := sysd.RemoveMountUnitFile(mountPoint); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1083,6 +1083,14 @@ func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bo
 	return f.maybeErrForLastOp()
 }
 
+func (f *fakeSnappyBackend) RemoveSnapMountUnits(s snap.PlaceInfo, meter progress.Meter) error {
+	f.ops = append(f.ops, fakeOp{
+		op:   "remove-snap-mount-units",
+		name: s.InstanceName(),
+	})
+	return f.maybeErrForLastOp()
+}
+
 func (f *fakeSnappyBackend) RemoveSnapDir(s snap.PlaceInfo, otherInstances bool) error {
 	f.ops = append(f.ops, fakeOp{
 		op:             "remove-snap-dir",

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2289,6 +2289,10 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		return &state.Retry{After: 3 * time.Minute}
 	}
 	if len(snapst.Sequence) == 0 {
+		if err = m.backend.RemoveSnapMountUnits(snapsup.placeInfo(), nil); err != nil {
+			return err
+		}
+
 		if err := pruneRefreshCandidates(st, snapsup.InstanceName()); err != nil {
 			return err
 		}

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -298,6 +298,10 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 			stype: "app",
 		},
 		{
+			op:   "remove-snap-mount-units",
+			name: "some-snap",
+		},
+		{
 			op:   "discard-namespace",
 			name: "some-snap",
 		},
@@ -439,6 +443,10 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
 			stype: "app",
+		},
+		{
+			op:   "remove-snap-mount-units",
+			name: "some-snap_instance",
 		},
 		{
 			op:   "discard-namespace",
@@ -589,6 +597,10 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 			stype: "app",
 		},
 		{
+			op:   "remove-snap-mount-units",
+			name: "some-snap_instance",
+		},
+		{
 			op:   "discard-namespace",
 			name: "some-snap_instance",
 		},
@@ -711,6 +723,10 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 			stype: "app",
+		},
+		{
+			op:   "remove-snap-mount-units",
+			name: "some-snap",
 		},
 		{
 			op:   "discard-namespace",
@@ -893,7 +909,7 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 	s.settle(c)
 	s.state.Lock()
 
-	c.Check(len(s.fakeBackend.ops), Equals, 8)
+	c.Check(len(s.fakeBackend.ops), Equals, 9)
 	expected := fakeOps{
 		{
 			op:    "auto-disconnect:Doing",
@@ -917,6 +933,10 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "some-snap/2"),
 			stype: "app",
+		},
+		{
+			op:   "remove-snap-mount-units",
+			name: "some-snap",
 		},
 		{
 			op:   "discard-namespace",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4516,6 +4516,10 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 			stype: "os",
 		},
 		{
+			op:   "remove-snap-mount-units",
+			name: "ubuntu-core",
+		},
+		{
 			op:   "discard-namespace",
 			name: "ubuntu-core",
 		},
@@ -4614,6 +4618,10 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "ubuntu-core/1"),
 			stype: "os",
+		},
+		{
+			op:   "remove-snap-mount-units",
+			name: "ubuntu-core",
 		},
 		{
 			op:   "discard-namespace",

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -126,6 +126,7 @@ func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype str
 	// mounted with fuse, but mount unit will use squashfs.
 	mountUnitOptions := append(fsMountOptions(fstype), squashfs.StandardOptions()...)
 	mountUnitName, err := writeMountUnitFile(&MountUnitOptions{
+		Lifetime: Persistent,
 		SnapName: snapName,
 		Revision: revision,
 		What:     what,

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -192,6 +192,10 @@ func (s *emulation) RemoveMountUnitFile(mountedDir string) error {
 	return nil
 }
 
+func (s *emulation) ListMountUnits(snapName, origin string) ([]string, error) {
+	return nil, errNotImplemented
+}
+
 func (s *emulation) Mask(service string) error {
 	_, err := systemctlCmd("--root", s.rootDir, "mask", service)
 	return err

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -125,7 +125,14 @@ func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype str
 	// This means that when preseeding in a lxd container, the snap will be
 	// mounted with fuse, but mount unit will use squashfs.
 	mountUnitOptions := append(fsMountOptions(fstype), squashfs.StandardOptions()...)
-	mountUnitName, err := writeMountUnitFile(snapName, revision, what, where, fstype, mountUnitOptions)
+	mountUnitName, err := writeMountUnitFile(&MountUnitOptions{
+		SnapName: snapName,
+		Revision: revision,
+		What:     what,
+		Where:    where,
+		Fstype:   fstype,
+		Options:  mountUnitOptions,
+	})
 	if err != nil {
 		return "", err
 	}
@@ -148,6 +155,10 @@ func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype str
 		return "", fmt.Errorf("cannot enable mount unit %s: %v", mountUnitName, err)
 	}
 	return mountUnitName, nil
+}
+
+func (s *emulation) AddMountUnitFileWithOptions(unitOptions *MountUnitOptions) (string, error) {
+	return "", errNotImplemented
 }
 
 func (s *emulation) RemoveMountUnitFile(mountedDir string) error {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1156,6 +1156,9 @@ func writeMountUnitFile(u *MountUnitOptions) (mountUnitName string, err error) {
 	if u.Revision != "" {
 		snapDesc += fmt.Sprintf(", revision %s", u.Revision)
 	}
+	if u.Origin != "" {
+		snapDesc += fmt.Sprintf(" via %s", u.Origin)
+	}
 	content := fmt.Sprintf(mountUnitTemplate, snapDesc,
 		u.What, u.Where, u.Fstype, strings.Join(u.Options, ","))
 	if u.Origin != "" {

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -841,7 +841,7 @@ func (s *SystemdTestSuite) TestAddMountUnitTransient(c *C) {
 
 	c.Assert(filepath.Join(dirs.SnapRuntimeServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(`
 [Unit]
-Description=Mount unit for foo
+Description=Mount unit for foo via bar
 Before=snapd.service
 After=zfs-mount.service
 

--- a/systemd/systemdtest/systemdtest.go
+++ b/systemd/systemdtest/systemdtest.go
@@ -59,3 +59,34 @@ Type=simple
 	}
 	return output
 }
+
+type MountUnitInfo struct {
+	Description  string
+	Where        string
+	FragmentPath string
+}
+
+// HandleMockListMountUnitsOutput returns the output for systemctl in the case
+// where units have the state as described by states.
+// If `cmd` is the command issued by systemd.Status(), this function returns
+// the output to be produced by the command so that the queried services will
+// appear having the ActiveState and UnitFileState according to the data
+// passed in the `states` map.
+func HandleMockListMountUnitsOutput(cmd []string, mounts []MountUnitInfo) ([]byte, bool) {
+	osutil.MustBeTestBinary("mocking systemctl output can only be done from tests")
+	if cmd[0] != "show" ||
+		cmd[1] != "--property=Description,Where,FragmentPath" {
+		return nil, false
+	}
+	var output []byte
+	for _, mountInfo := range mounts {
+		if len(output) > 0 {
+			output = append(output, byte('\n'))
+		}
+		output = append(output, []byte(fmt.Sprintf(`Description=%s
+Where=%s
+FragmentPath=%s
+`, mountInfo.Description, mountInfo.Where, mountInfo.FragmentPath))...)
+	}
+	return output, true
+}


### PR DESCRIPTION
This includes the changes in systemd, overlord and wrappers to create, list and remove mount unit files.