### PR TITLE
secboot: remove duplicate import

### DIFF
--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -28,7 +28,6 @@ import (
 	"os"
 
 	"github.com/canonical/go-tpm2"
-	"github.com/snapcore/secboot"
 	sb "github.com/snapcore/secboot"
 	"golang.org/x/xerrors"
 
@@ -64,7 +63,7 @@ var (
 	provisionTPM = provisionTPMImpl
 
 	// dummy to check whether the interfaces match
-	_ (secboot.SnapModel) = ModelForSealing(nil)
+	_ (sb.SnapModel) = ModelForSealing(nil)
 )
 
 func isTPMEnabledImpl(tpm *sb.TPMConnection) bool {


### PR DESCRIPTION
Remove duplicate import, and use existing/long-standing snapcore
secboot import called sb.

Fixes: 37fc0edcdc866f05b5cd458c6dd056ec4e3ae57c