### PR TITLE
snapstate: add compat code that injects missing asset update tasks

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -50,6 +50,9 @@ var featureSet = map[string]bool{
 	// Support for "kernel-assets" in gadget.yaml. I.e. having volume
 	// content of the style $kernel:ref`
 	"kernel-assets": true,
+
+	// XXX: find a good name here
+	"kernel-assets-for-real": true,
 }
 
 func checkAssumes(si *snap.Info) error {


### PR DESCRIPTION
In https://bugs.launchpad.net/snapd/+bug/1940553 it was reported
that snapd does not update the DTBs when there is a refresh of
snap/pi/pi-kernel. After a bit of debugging it turns out the following
is happening:

1. Old snapd (2.45.3.1) creates the refresh tasks for the snapd/pi/pi-kernel
update. Here no kernel related asset-update task is generated because the
old snapd does not know about this yet
2. The refresh happens and the first thing that gets restarted is snapd, now
we have a snapd running that knows about "asset-updates"
3. Then the pi-kernel with the "assumes: [kernel-assets]" is mounted and
checked. And at this point the the snapd support kernel-assets so snapd does
not hold this refresh back. But that is wrong because the "gadget-update"
task for the kernel is still missing.

So the bug is that the "assumes" is not checked early enough. Unfortunately
we can't fix the past so the only way forward I can see is that we need to
have code in snapd that ensures that on a snapd refresh all changes that
contain a kernel refresh are checked and "asset-update" tasks are injected.

Draft of my thinking for the fix. Needs fleshing out of course with proper tests
(manager_test ?).