### PR TITLE
store: deal correctly with "assumes" from the store raw yaml

### DIFF
--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -311,6 +311,9 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 			info.Slots[k] = v
 			info.Slots[k].Snap = info
 		}
+		for _, s := range rawYamlInfo.Assumes {
+			info.Assumes = append(info.Assumes, s)
+		}
 	}
 
 	// convert prices

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -120,7 +120,7 @@ const (
   },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
-  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\napps:\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\n",
+  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\n",
   "store-url": "https://snapcraft.io/thingy",
   "summary": "useful thingy",
   "title": "This Is The Most Fantastical Snap of Thingy",
@@ -204,6 +204,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 	info2.Slots = nil
 	c.Check(&info2, DeepEquals, &snap.Info{
 		Architectures: []string{"amd64"},
+		Assumes:       []string{"snapd2.49"},
 		Base:          "base-18",
 		SideInfo: snap.SideInfo{
 			RealName:          "thingy",


### PR DESCRIPTION
Our code did not deal with the `assumes:` field in the raw yaml
that we get from the store. This lead to the really nasty bug
that on a refresh the assumes is not checked correctly, see
https://bugs.launchpad.net/snapd/+bug/1940553

A bigger manager test is included in the followup for this.