### PR TITLE
.github/workflows/test.yaml: test github.events key

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,11 +3,14 @@ on:
   pull_request:
     branches: [ "master", "release/**" ]
   push:
-    branches: [ "release/**" ]
+    # we trigger runs on master branch, but we do not run spread on master 
+    # branch, the master branch runs are just for unit tests + codecov.io
+    branches: [ "master","release/**" ]
 
 jobs:
   snap-builds:
     runs-on: ubuntu-20.04
+    if: ${{ github.event_name != 'push' && github.ref != 'refs/heads/master' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -227,6 +230,7 @@ jobs:
 
   spread:
     needs: [unit-tests]
+    if: ${{ github.event_name != 'push' && github.ref != 'refs/heads/master' }}
     runs-on: self-hosted
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
@@ -301,6 +305,7 @@ jobs:
 
   spread-nested:
     needs: [unit-tests]
+    if: ${{ github.event_name != 'push' && github.ref != 'refs/heads/master' }}
     runs-on: self-hosted
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.


### PR DESCRIPTION
This should make coverage work for Pull requests, because we need to trigger the unit tests (but probably _just_ the unit tests) to run on pushes to master.

Alternatively, if this is considered too much work / time for running CI, we could switch to a schedule based run where we run the unit-tests job on a schedule like nightly or every 6 hours or something, but this seems deceptively easy.

Also I am deliberately not adding the "skip-spread" label here so we can see that spread jobs do still run for PRs, and then after this is merged we should confirm that the github actions workflow that is triggered _only_ runs the unit-tests job and not the snap-builds, spread or spread-nested jobs