### PR TITLE
tests/main/services-install-hook-can-run-svcs: shellcheck issue fix

### DIFF
--- a/tests/main/services-install-hook-can-run-svcs/task.yaml
+++ b/tests/main/services-install-hook-can-run-svcs/task.yaml
@@ -6,7 +6,7 @@ environment:
 
 execute: |
   # setup the install hook with the right flags
-  sed ./test-snapd-install-hook-runs-svc/meta/hooks/install.in -e s/%%FLAGS%%/$FLAGS/ > ./test-snapd-install-hook-runs-svc/meta/hooks/install
+  sed ./test-snapd-install-hook-runs-svc/meta/hooks/install.in -e "s/%%FLAGS%%/$FLAGS/" > ./test-snapd-install-hook-runs-svc/meta/hooks/install
 
   chmod +x ./test-snapd-install-hook-runs-svc/meta/hooks/install
 


### PR DESCRIPTION
Shellcheck complains:

```
ERROR:root:tests/main/services-install-hook-can-run-svcs/task.yaml: section 'execute':

In - line 5:
sed ./test-snapd-install-hook-runs-svc/meta/hooks/install.in -e s/%%FLAGS%%/$FLAGS/ > ./test-snapd-install-hook-runs-svc/meta/hooks/install
                                                                            ^----^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
sed ./test-snapd-install-hook-runs-svc/meta/hooks/install.in -e s/%%FLAGS%%/"$FLAGS"/ > ./test-snapd-install-hook-runs-svc/meta/hooks/install

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

ERROR:root:validation failed for the following files:
 - tests/main/services-install-hook-can-run-svcs/task.yaml
```
