### PR TITLE
tests: set to 10 minutes the kill timeout for tests failing on slow boards

### DIFF
--- a/tests/main/services-refresh-mode/task.yaml
+++ b/tests/main/services-refresh-mode/task.yaml
@@ -3,7 +3,7 @@ summary: "Check that refresh-modes works"
 # takes >1.5min to run
 backends: [-autopkgtest]
 
-kill-timeout: 12m
+kill-timeout: 10m
 
 debug: |
     grep -n '' ./*.pid || true

--- a/tests/main/services-snapctl/task.yaml
+++ b/tests/main/services-snapctl/task.yaml
@@ -3,7 +3,7 @@ summary: Check that own services can be controlled by snapctl
 # takes >1.5min to run
 backends: [-autopkgtest]
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 environment:
     SERVICEOPTIONFILE: /var/snap/test-snapd-service/current/service-option

--- a/tests/main/services-stop-mode-sigkill/task.yaml
+++ b/tests/main/services-stop-mode-sigkill/task.yaml
@@ -3,7 +3,7 @@ summary: "Check that refresh-modes sigkill works"
 # slow in autopkgtest (>1m)
 backends: [-autopkgtest]
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 restore: |
     # remove to ensure all services are stopped

--- a/tests/main/services-stop-mode/task.yaml
+++ b/tests/main/services-stop-mode/task.yaml
@@ -6,7 +6,7 @@ backends: [-autopkgtest]
 # journald in ubuntu-14.04 not reliable
 systems: [-ubuntu-14.04-*]
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 restore: |
     # remove to ensure all services are stopped

--- a/tests/main/snap-service/task.yaml
+++ b/tests/main/snap-service/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that `snap run --command=reload` works
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 execute: |
     echo "When the service snap is installed"

--- a/tests/main/snap-user-service-restart-on-upgrade/task.yaml
+++ b/tests/main/snap-user-service-restart-on-upgrade/task.yaml
@@ -8,7 +8,7 @@ systems:
     # Centos 7 gives error "Unit user@12345.service not loaded."
     - -centos-7-*
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 prepare: |
     # Ensure that snapd.session-agent.socket is enabled.  This may not

--- a/tests/main/snap-user-service-socket-activation/task.yaml
+++ b/tests/main/snap-user-service-socket-activation/task.yaml
@@ -8,7 +8,7 @@ systems:
     # Centos 7 gives error "Unit user@12345.service not loaded."
     - -centos-7-*
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 prepare: |
     snap set system experimental.user-daemons=true

--- a/tests/main/snap-user-service-start-on-install/task.yaml
+++ b/tests/main/snap-user-service-start-on-install/task.yaml
@@ -8,7 +8,7 @@ systems:
     # Centos 7 gives error "Unit user@12345.service not loaded."
     - -centos-7-*
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 prepare: |
     # Ensure that snapd.session-agent.socket is enabled.  This may not

--- a/tests/main/snap-user-service-upgrade-failure/task.yaml
+++ b/tests/main/snap-user-service-upgrade-failure/task.yaml
@@ -8,7 +8,7 @@ systems:
     # Centos 7 gives error "Unit user@12345.service not loaded."
     - -centos-7-*
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 prepare: |
     # Ensure that snapd.session-agent.socket is enabled.  This may not

--- a/tests/main/snap-user-service/task.yaml
+++ b/tests/main/snap-user-service/task.yaml
@@ -8,7 +8,7 @@ systems:
     # Centos 7 gives error "Unit user@12345.service not loaded."
     - -centos-7-*
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 prepare: |
     snap set system experimental.user-daemons=true

--- a/tests/main/snap-wait/task.yaml
+++ b/tests/main/snap-wait/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that `snap wait` works
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local basic-hooks


### PR DESCRIPTION
Some of these tests are failing on pi2 and pi3 in the lab with kill
timeout.

Some boards are getting slow and the idea is to move from 5m to 10m to
avoid those issues.

The affected tests are the ones that run on ubuntu core.

The test services-refresh-mode initially was in 5 minutes, then moved to 12 but when tested with 10m it works fine. 