### PR TITLE
github: do not try to upload coverage when working with cached run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -212,6 +212,7 @@ jobs:
         SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
+      if: steps.cached-results.outputs.already-ran != 'true'
       with:
         # token: ${{ secrets.CODECOV_TOKEN }} # needed ?
         fail_ci_if_error: true


### PR DESCRIPTION
When the test run was restored from cache, do not try to upload coverage

