### PR TITLE
snapstate: abort kernel refresh if no gadget update can be found

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -269,6 +269,7 @@ func AddForeignTaskHandlers(runner *state.TaskRunner, tracker ForeignTaskTracker
 	runner.AddHandler("validate-snap", fakeHandler, nil)
 	runner.AddHandler("transition-ubuntu-core", fakeHandler, nil)
 	runner.AddHandler("transition-to-snapd-snap", fakeHandler, nil)
+	runner.AddHandler("update-gadget-assets", fakeHandler, nil)
 
 	// Add handler to test full aborting of changes
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1556,6 +1556,9 @@ func (s *snapmgrTestSuite) TestUpdateRememberedUserRunThrough(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
 	// use services-snap here to make sure services would be stopped/started appropriately
 	si := snap.SideInfo{
 		RealName: "kernel",


### PR DESCRIPTION
This commit detects if a kernel refresh is in progress that does
not contain a "update-gadget-assets" task and aborts this part
of the change if that happens. This works around the issue that
is triggered in https://bugs.launchpad.net/snapd/+bug/1940553

A manager test for this is also added.

Thanks to Ian for suggesting it in #10656 - either way we should
be able to re-use the manager test for this.
