### PR TITLE
i18n/xgettext-go: preserve already escaped quotes

### DIFF
--- a/i18n/xgettext-go/main.go
+++ b/i18n/xgettext-go/main.go
@@ -123,10 +123,9 @@ func inspectNodeForTranslations(fset *token.FileSet, f *ast.File, n ast.Node) bo
 				}
 				// the "`" is special
 				if s[0] == '`' {
-					// replace inner " with \"
-					s = strings.Replace(s, "\"", "\\\"", -1)
-					// replace \n with \\n
-					s = strings.Replace(s, "\n", "\\n", -1)
+					// keep escaped ", replace inner " with \", replace \n with \\n
+					rep := strings.NewReplacer(`\"`, `\"`, `"`, `\"`, "\n", "\\n")
+					s = rep.Replace(s)
 				}
 				// strip leading and trailing " (or `)
 				s = s[1 : len(s)-1]

--- a/i18n/xgettext-go/main_test.go
+++ b/i18n/xgettext-go/main_test.go
@@ -513,3 +513,26 @@ msgstr  ""
 	c.Check(out.String(), Equals, expected)
 
 }
+
+func (s *xgettextTestSuite) TestDontEscapeAlreadyEscapedQuoteInBacktick(c *C) {
+	fname := makeGoSourceFile(c, []byte(`package main
+
+func main() {
+    i18n.G(`+"`"+`Some text: "{\"key\":\"value\"}"`+"`"+`)
+}
+`))
+
+	err := processFiles([]string{fname})
+	c.Assert(err, IsNil)
+
+	out := bytes.NewBuffer([]byte(""))
+	writePotFile(out)
+
+	expected := fmt.Sprintf(`%s
+#: %[2]s:4
+msgid   "Some text: \"{\"key\":\"value\"}\""
+msgstr  ""
+
+`, header, fname)
+	c.Check(out.String(), Equals, expected)
+}


### PR DESCRIPTION
The update-pot script was failing because escaped double quotes in raw strings were being escaped again resulting in \\" which would escape the slash and not the quote breaking the output. This changes the processing to keep escaped double quotes as they are and only escape standalone quotes.