### PR TITLE
o/hookstate/ctlcmd: correct err message if missing root

### DIFF
--- a/overlord/hookstate/ctlcmd/ctlcmd_test.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd_test.go
@@ -145,3 +145,11 @@ func (s *ctlcmdSuite) TestRunHelpAtAnyPosition(c *C) {
 	c.Check(err, NotNil)
 	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
 }
+
+func (s *ctlcmdSuite) TestRunNonRootAllowedCommandWithAllowedCmdAsArg(c *C) {
+	// this test protects us against a future refactor introducing a bug that allows
+	// a root-only command to run without root if an arg is in the nonRootAllowed list
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"set", "get", "a"}, 1000)
+	c.Check(err, FitsTypeOf, &ctlcmd.ForbiddenCommandError{})
+	c.Check(err.Error(), Equals, `cannot use "set" with uid 1000, try with sudo`)
+}

--- a/overlord/hookstate/ctlcmd/ctlcmd_test.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd_test.go
@@ -21,6 +21,7 @@ package ctlcmd_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/jessevdk/go-flags"
@@ -123,4 +124,24 @@ func (s *ctlcmdSuite) TestRootRequiredCommandFailure(c *C) {
 func (s *ctlcmdSuite) TestRunNoArgsFailure(c *C) {
 	_, _, err := ctlcmd.Run(s.mockContext, []string{}, 0)
 	c.Check(err, NotNil)
+}
+
+func (s *ctlcmdSuite) TestRunOnlyHelp(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"-h"}, 1000)
+	c.Check(err, NotNil)
+	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
+
+	_, _, err = ctlcmd.Run(s.mockContext, []string{"--help"}, 1000)
+	c.Check(err, NotNil)
+	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
+}
+
+func (s *ctlcmdSuite) TestRunHelpAtAnyPosition(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"start", "a", "-h"}, 1000)
+	c.Check(err, NotNil)
+	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
+
+	_, _, err = ctlcmd.Run(s.mockContext, []string{"start", "a", "b", "--help"}, 1000)
+	c.Check(err, NotNil)
+	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
 }

--- a/overlord/hookstate/ctlcmd/ctlcmd_test.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd_test.go
@@ -112,3 +112,15 @@ func (s *ctlcmdSuite) TestHiddenCommand(c *C) {
 	// mock-hidden is not in the help message
 	c.Check(err.Error(), Not(testutil.Contains), "  mock-hidden\n")
 }
+
+func (s *ctlcmdSuite) TestRootRequiredCommandFailure(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"start"}, 1000)
+
+	c.Check(err, FitsTypeOf, &ctlcmd.ForbiddenCommandError{})
+	c.Check(err.Error(), Equals, `cannot use "start" with uid 1000, try with sudo`)
+}
+
+func (s *ctlcmdSuite) TestRunNoArgsFailure(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{}, 0)
+	c.Check(err, NotNil)
+}

--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -37,6 +37,9 @@ execute: |
     echo "Verify that snapctl set is forbidden for regular user"
     su -c "snapctl set snapctl-hooks foo=bar" test 2>&1 | MATCH "cannot use \"set\" with uid .*, try with sudo"
 
+    echo "Verify that snapctl fails with correct error message using flag if regular user"
+    su -c "snapctl start --enable" test 2>&1 | MATCH "cannot use \"start\" with uid [0-9]+, try with sudo"
+ 
     echo "Verify that the snapd API is only available via the snapd socket"
     if ! printf 'GET /v2/snaps HTTP/1.0\r\n\r\n' | nc -U -w 1 /run/snapd.socket | grep '200 OK'; then
         echo "Expected snapd API to be available on the snapd socket"


### PR DESCRIPTION
Fixes the error message returned by snapctl when running a command that requires root without root and with a flag (like `--disable`). When a command should be blocked from running due to not running as root, we were adding a ForbiddenCommand to the parser which would then just return an error when running. However, if called with a flag, the parser would fail because the ForbiddenCommand didn't have any flag fields. The fix changes this so that no command is added, instead we fail immediately  and deal with the "-h", "--help" case manually. 

https://bugs.launchpad.net/snapd/+bug/1893970