### PR TITLE
o/assertstate,snapstate: refresh validation set assertions with snap declarations

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -143,7 +143,7 @@ var (
 	snapstateRevertToRevision  = snapstate.RevertToRevision
 	snapstateSwitch            = snapstate.Switch
 
-	assertstateRefreshSnapDeclarations = assertstate.RefreshSnapDeclarations
+	assertstateRefreshAssertions = assertstate.RefreshAssertions
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -336,7 +336,7 @@ func snapUpdate(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 	}
 
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can
-	if err = assertstateRefreshSnapDeclarations(st, inst.userID); err != nil {
+	if err = assertstateRefreshAssertions(st, inst.userID); err != nil {
 		return "", nil, err
 	}
 
@@ -584,8 +584,9 @@ func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionRe
 }
 
 func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
-	// we need refreshed snap-declarations to enforce refresh-control as best as we can, this also ensures that snap-declarations and their prerequisite assertions are updated regularly
-	if err := assertstateRefreshSnapDeclarations(st, inst.userID); err != nil {
+	// we need refreshed snap-declarations to enforce refresh-control as best as we can, this also ensures that snap-declarations and their prerequisite assertions are updated regularly,
+	// as well as updates validation sets assertions.
+	if err := assertstateRefreshAssertions(st, inst.userID); err != nil {
 		return nil, err
 	}
 

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -478,7 +478,7 @@ func (s *snapsSuite) TestPostSnapsOpMoreComplexContentType(c *check.C) {
 }
 
 func (s *snapsSuite) testPostSnapsOp(c *check.C, contentType string) {
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(*state.State, int) error { return nil })()
+	defer daemon.MockAssertstateRefreshAssertions(func(*state.State, int) error { return nil })()
 	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
 		c.Check(names, check.HasLen, 0)
 		t := s.NewTask("fake-refresh-all", "Refreshing everything")
@@ -519,7 +519,7 @@ func (s *snapsSuite) TestPostSnapsOpInvalidCharset(c *check.C) {
 
 func (s *snapsSuite) TestRefreshAll(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		refreshSnapDecls = true
 		return assertstate.RefreshSnapDeclarations(s, userID)
 	})()
@@ -555,7 +555,7 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 
 func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		refreshSnapDecls = true
 		return assertstate.RefreshSnapDeclarations(s, userID)
 	})()
@@ -578,7 +578,7 @@ func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 
 func (s *snapsSuite) TestRefreshMany(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		refreshSnapDecls = true
 		return nil
 	})()
@@ -603,7 +603,7 @@ func (s *snapsSuite) TestRefreshMany(c *check.C) {
 
 func (s *snapsSuite) TestRefreshMany1(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		refreshSnapDecls = true
 		return nil
 	})()
@@ -1434,7 +1434,7 @@ func (s *snapsSuite) TestInstallIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-install-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1600,7 +1600,7 @@ func (s *snapsSuite) TestRefresh(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		assertstateCalledUserID = userID
 		return nil
 	})()
@@ -1639,7 +1639,7 @@ func (s *snapsSuite) TestRefreshDevMode(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1673,7 +1673,7 @@ func (s *snapsSuite) TestRefreshClassic(c *check.C) {
 		calledFlags = flags
 		return nil, nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1707,7 +1707,7 @@ func (s *snapsSuite) TestRefreshIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1746,7 +1746,7 @@ func (s *snapsSuite) TestRefreshIgnoreRunning(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1781,7 +1781,7 @@ func (s *snapsSuite) TestRefreshCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1811,7 +1811,7 @@ func (s *snapsSuite) TestRefreshLeaveCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -105,11 +105,11 @@ func MockUnsafeReadSnapInfo(mock func(string) (*snap.Info, error)) (restore func
 	}
 }
 
-func MockAssertstateRefreshSnapDeclarations(mock func(*state.State, int) error) (restore func()) {
-	oldAssertstateRefreshSnapDeclarations := assertstateRefreshSnapDeclarations
-	assertstateRefreshSnapDeclarations = mock
+func MockAssertstateRefreshAssertions(mock func(*state.State, int) error) (restore func()) {
+	oldAssertstateRefreshAssertions := assertstateRefreshAssertions
+	assertstateRefreshAssertions = mock
 	return func() {
-		assertstateRefreshSnapDeclarations = oldAssertstateRefreshSnapDeclarations
+		assertstateRefreshAssertions = oldAssertstateRefreshAssertions
 	}
 }
 

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -327,15 +327,15 @@ func delayedCrossMgrInit() {
 	// hook validation of refreshes into snapstate logic
 	snapstate.ValidateRefreshes = ValidateRefreshes
 	// hook auto refresh of assertions (snap declarations) into snapstate
-	snapstate.AutoRefreshAssertions = AutoRefreshAssertions
+	snapstate.RefreshAssertions = RefreshAssertions
 	// hook retrieving auto-aliases into snapstate logic
 	snapstate.AutoAliases = AutoAliases
 	// hook the helper for getting enforced validation sets
 	snapstate.EnforcedValidationSets = EnforcedValidationSets
 }
 
-// AutoRefreshAssertions tries to refresh all assertions
-func AutoRefreshAssertions(s *state.State, userID int) error {
+// RefreshAssertions tries to refresh all assertions
+func RefreshAssertions(s *state.State, userID int) error {
 	if err := RefreshSnapDeclarations(s, userID); err != nil {
 		return err
 	}

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -955,7 +955,7 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 	c.Assert(s.storeSigning.Add(storeAs), IsNil)
 
 	// previous state
-	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")) , IsNil)
+	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, snapDeclFoo), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -2218,7 +2218,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsNop(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefresh(c *C) {
+func (s *assertMgrSuite) TestValidationSetAssertionsRefresh(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2257,7 +2257,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefresh(c *C) {
 	c.Check(a.Revision(), Equals, 3)
 }
 
-func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefreshError(c *C) {
+func (s *assertMgrSuite) TestValidationSetAssertionsRefreshError(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -2181,7 +2181,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefresh(c *C) {
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 
-	c.Assert(assertstate.AutoRefreshAssertions(s.state, 0), IsNil)
+	c.Assert(assertstate.RefreshAssertions(s.state, 0), IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
@@ -2208,7 +2208,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefreshError(c *C) {
 		Current:   1,
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
-	err := assertstate.AutoRefreshAssertions(s.state, 0)
+	err := assertstate.RefreshAssertions(s.state, 0)
 	c.Assert(asserts.IsNotFound(err), Equals, true)
 }
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1890,9 +1890,9 @@ func infoForUpdate(st *state.State, snapst *SnapState, name string, opts *Revisi
 	return readInfo(name, sideInfo, errorOnBroken)
 }
 
-// AutoRefreshAssertions allows to hook fetching of important assertions
+// RefreshAssertions allows to hook fetching of important assertions
 // into the Autorefresh function.
-var AutoRefreshAssertions func(st *state.State, userID int) error
+var RefreshAssertions func(st *state.State, userID int) error
 
 // AutoRefresh is the wrapper that will do a refresh of all the installed
 // snaps on the system. In addition to that it will also refresh important
@@ -1900,8 +1900,8 @@ var AutoRefreshAssertions func(st *state.State, userID int) error
 func AutoRefresh(ctx context.Context, st *state.State) ([]string, []*state.TaskSet, error) {
 	userID := 0
 
-	if AutoRefreshAssertions != nil {
-		if err := AutoRefreshAssertions(st, userID); err != nil {
+	if RefreshAssertions != nil {
+		if err := RefreshAssertions(st, userID); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -3116,11 +3116,11 @@ func (s *snapmgrTestSuite) TestEnsureRefreshesInFlight(c *C) {
 	c.Check(s.state.Changes(), HasLen, 1)
 }
 
-func mockAutoRefreshAssertions(f func(st *state.State, userID int) error) func() {
-	origAutoRefreshAssertions := snapstate.AutoRefreshAssertions
-	snapstate.AutoRefreshAssertions = f
+func mockRefreshAssertions(f func(st *state.State, userID int) error) func() {
+	origRefreshAssertions := snapstate.RefreshAssertions
+	snapstate.RefreshAssertions = f
 	return func() {
-		snapstate.AutoRefreshAssertions = origAutoRefreshAssertions
+		snapstate.RefreshAssertions = origRefreshAssertions
 	}
 }
 
@@ -3132,7 +3132,7 @@ func (s *snapmgrTestSuite) TestEnsureRefreshesWithUpdateStoreError(c *C) {
 	// avoid special at seed policy
 	s.state.Set("last-refresh", time.Time{})
 	autoRefreshAssertionsCalled := 0
-	restore := mockAutoRefreshAssertions(func(st *state.State, userID int) error {
+	restore := mockRefreshAssertions(func(st *state.State, userID int) error {
 		// simulate failure in snapstate.AutoRefresh()
 		autoRefreshAssertionsCalled++
 		return fmt.Errorf("simulate store error")
@@ -3175,7 +3175,7 @@ func (s *snapmgrTestSuite) testEnsureRefreshesDisabledViaSnapdControl(c *C, conf
 
 	// snapstate.AutoRefresh is called from AutoRefresh()
 	autoRefreshAssertionsCalled := 0
-	restore := mockAutoRefreshAssertions(func(st *state.State, userID int) error {
+	restore := mockRefreshAssertions(func(st *state.State, userID int) error {
 		autoRefreshAssertionsCalled++
 		return nil
 	})


### PR DESCRIPTION
Refresh validation set assertions together with snap declarations (on snap update atm, will be expanded to install and remove in another PR). This means that we need to do the same thing that AutoRefreshAssertions does, so this PR renamed AutoRefreshAssertions to RefreshAssertions and removes calls assertstate.RefreshSnapDeclarations, replacing them with asserstate. RefreshAssertions.