### PR TITLE
.github/workflows/test.yaml: fix logic

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -231,6 +231,8 @@ jobs:
 
   spread:
     needs: [unit-tests]
+    # have spread jobs run on master on PRs only, but on both PRs and pushes to
+    # release branches
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
     runs-on: self-hosted
     strategy:
@@ -306,6 +308,8 @@ jobs:
 
   spread-nested:
     needs: [unit-tests]
+    # have spread jobs run on master on PRs only, but on both PRs and pushes to
+    # release branches
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
     runs-on: self-hosted
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,9 @@ on:
 jobs:
   snap-builds:
     runs-on: ubuntu-20.04
-    if: ${{ github.event_name != 'push' && github.ref != 'refs/heads/master' }}
+    # only build the snap for pull requests, it's not needed on release branches
+    # or on master since we have launchpad build recipes which do this already
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -230,7 +232,7 @@ jobs:
 
   spread:
     needs: [unit-tests]
-    if: ${{ github.event_name != 'push' && github.ref != 'refs/heads/master' }}
+    if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
     runs-on: self-hosted
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
@@ -305,7 +307,7 @@ jobs:
 
   spread-nested:
     needs: [unit-tests]
-    if: ${{ github.event_name != 'push' && github.ref != 'refs/heads/master' }}
+    if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
     runs-on: self-hosted
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -219,7 +219,6 @@ jobs:
       uses: codecov/codecov-action@v2
       if: steps.cached-results.outputs.already-ran != 'true'
       with:
-        # token: ${{ secrets.CODECOV_TOKEN }} # needed ?
         fail_ci_if_error: true
         flags: unittests
         name: codecov-umbrella


### PR DESCRIPTION
We want the spread tests to also run on pushes to release/** branches, so the
operator here should just be || otherwise these jobs will not run on pushes.
Thanks to Alberto for pointing this out to me.

Furthermore, we don't want to run the snap-builds job on anything other than
pull requests, since we already have Launchpad snap build recipes setup for the
release and master branches and this would just be duplicating that effort and
use up artifact storage space.

Also cleanup an unused setting that I had commented out as I wasn't sure if it 
would be necessary or not, but I can see now that it's not necessary.

Again, I'm deliberately not adding the skip spread label so we can see the actions 
run here just in case I have mucked things up again.