### PR TITLE
snapstate: fix misleading `assumes` error message

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3302,7 +3302,7 @@ assumes: [something-that-is-not-provided]
 	defer st.Unlock()
 
 	_, err := snapstate.Install(context.TODO(), st, "some-snap", nil, 0, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" assumes unsupported features: something-that-is-not-provided \(try to update snapd and refresh the core snap\)`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" assumes unsupported features: something-that-is-not-provided \(try to refresh snapd\)`)
 }
 
 func (s *mgrsSuite) TestUpdateWithAssumesIsRefusedEarly(c *C) {
@@ -3332,7 +3332,7 @@ assumes: [something-that-is-not-provided]
 	})
 
 	_, err := snapstate.Update(st, "some-snap", nil, 0, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" assumes unsupported features: something-that-is-not-provided \(try to update snapd and refresh the core snap\)`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" assumes unsupported features: something-that-is-not-provided \(try to refresh snapd\)`)
 }
 
 func (s *mgrsSuite) TestUpdateManyWithAssumesIsRefusedEarly(c *C) {

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -63,11 +63,7 @@ func checkAssumes(si *snap.Info) error {
 		}
 	}
 	if len(missing) > 0 {
-		hint := "try to refresh the core or snapd snaps"
-		if release.OnClassic {
-			hint = "try to update snapd and refresh the core snap"
-		}
-		return fmt.Errorf("snap %q assumes unsupported features: %s (%s)", si.InstanceName(), strings.Join(missing, ", "), hint)
+		return fmt.Errorf("snap %q assumes unsupported features: %s (try to refresh snapd)", si.InstanceName(), strings.Join(missing, ", "))
 	}
 	return nil
 }

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -101,11 +101,11 @@ var assumesTests = []struct {
 	assumes: "[common-data-dir]",
 }, {
 	assumes: "[f1, f2]",
-	error:   `snap "foo" assumes unsupported features: f1, f2 \(try to refresh the core or snapd snaps\)`,
+	error:   `snap "foo" assumes unsupported features: f1, f2 \(try to refresh snapd\)`,
 }, {
 	assumes: "[f1, f2]",
 	classic: true,
-	error:   `snap "foo" assumes unsupported features: f1, f2 \(try to update snapd and refresh the core snap\)`,
+	error:   `snap "foo" assumes unsupported features: f1, f2 \(try to refresh snapd\)`,
 }, {
 	assumes: "[snapd2.15]",
 	version: "unknown",


### PR DESCRIPTION
When the `assumes` are not satisfied snapd will return an error
message that suggests to refresh `core` snap to fix the issue.

This is misleading and no longer valid. Hence this part is just
removed in this commit. It also unfies the message between
core and classic. Only on UC16 devices the message about refreshing
the core snap is still valid and those are in ESM mode.
