### PR TITLE
tests: fix restore in snapfuse spread tests

### DIFF
--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -5,7 +5,7 @@ systems: [ubuntu-18.04-64]
 
 restore: |
     lxc delete --force my-ubuntu
-    snap remove ---purge lxd
+    snap remove --purge lxd
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
     # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -5,7 +5,7 @@ systems: [ubuntu-18.04-64]
 
 restore: |
     lxc delete --force my-ubuntu
-    snap remove ---purge lxd
+    snap remove --purge lxd
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
     # Remove manually the snap.lxd.workaround.service systemd unit. This unit is needed to


### PR DESCRIPTION
Fixes an incorrect `snap remove ---purge lxd` in the restore stage of the snapfuse spread tests. We weren't catching this before because `---purge` was taken as a snap that just wasn't installed. Since https://github.com/snapcore/snapd/pull/10647 was merged this morning, this started failing. 

https://github.com/snapcore/snapd/runs/3420611415?check_suite_focus=true#step:5:1483