### PR TITLE
o/assertstate,daemon: refresh validation sets assertions with snap declarations

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -143,7 +143,7 @@ var (
 	snapstateRevertToRevision  = snapstate.RevertToRevision
 	snapstateSwitch            = snapstate.Switch
 
-	assertstateRefreshSnapDeclarations = assertstate.RefreshSnapDeclarations
+	assertstateRefreshAssertions = assertstate.RefreshAssertions
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -143,7 +143,7 @@ var (
 	snapstateRevertToRevision  = snapstate.RevertToRevision
 	snapstateSwitch            = snapstate.Switch
 
-	assertstateRefreshAssertions = assertstate.RefreshAssertions
+	assertstateRefreshSnapAssertions = assertstate.RefreshSnapAssertions
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -336,7 +336,7 @@ func snapUpdate(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 	}
 
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can
-	if err = assertstateRefreshSnapDeclarations(st, inst.userID, nil); err != nil {
+	if err = assertstateRefreshAssertions(st, inst.userID); err != nil {
 		return "", nil, err
 	}
 
@@ -585,7 +585,7 @@ func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionRe
 
 func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can, this also ensures that snap-declarations and their prerequisite assertions are updated regularly
-	if err := assertstateRefreshSnapDeclarations(st, inst.userID, nil); err != nil {
+	if err := assertstateRefreshAssertions(st, inst.userID); err != nil {
 		return nil, err
 	}
 

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -336,7 +336,7 @@ func snapUpdate(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 	}
 
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can
-	if err = assertstateRefreshAssertions(st, inst.userID); err != nil {
+	if err = assertstateRefreshSnapAssertions(st, inst.userID); err != nil {
 		return "", nil, err
 	}
 
@@ -588,7 +588,7 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionRes
 	// we can, this also ensures that snap-declarations and their prerequisite
 	// assertions are updated regularly, as well as updates validation sets
 	// assertions.
-	if err := assertstateRefreshAssertions(st, inst.userID); err != nil {
+	if err := assertstateRefreshSnapAssertions(st, inst.userID); err != nil {
 		return nil, err
 	}
 

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -584,7 +584,10 @@ func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionRe
 }
 
 func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
-	// we need refreshed snap-declarations to enforce refresh-control as best as we can, this also ensures that snap-declarations and their prerequisite assertions are updated regularly
+	// we need refreshed snap-declarations to enforce refresh-control as best as
+	// we can, this also ensures that snap-declarations and their prerequisite
+	// assertions are updated regularly, as well as updates validation sets
+	// assertions.
 	if err := assertstateRefreshAssertions(st, inst.userID); err != nil {
 		return nil, err
 	}

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -478,7 +478,7 @@ func (s *snapsSuite) TestPostSnapsOpMoreComplexContentType(c *check.C) {
 }
 
 func (s *snapsSuite) testPostSnapsOp(c *check.C, contentType string) {
-	defer daemon.MockAssertstateRefreshAssertions(func(*state.State, int) error { return nil })()
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(*state.State, int) error { return nil })()
 	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
 		c.Check(names, check.HasLen, 0)
 		t := s.NewTask("fake-refresh-all", "Refreshing everything")
@@ -518,10 +518,10 @@ func (s *snapsSuite) TestPostSnapsOpInvalidCharset(c *check.C) {
 }
 
 func (s *snapsSuite) TestRefreshAll(c *check.C) {
-	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
-		refreshSnapDecls = true
-		return assertstate.RefreshSnapDeclarations(s, userID, nil)
+	refreshSnapAssertions := false
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+		refreshSnapAssertions = true
+		return assertstate.RefreshSnapAssertions(s, userID)
 	})()
 
 	d := s.daemon(c)
@@ -534,7 +534,7 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 		{[]string{"fake"}, `Refresh snap "fake"`},
 		{[]string{"fake1", "fake2"}, `Refresh snaps "fake1", "fake2"`},
 	} {
-		refreshSnapDecls = false
+		refreshSnapAssertions = false
 
 		defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
 			c.Check(names, check.HasLen, 0)
@@ -549,15 +549,15 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 		st.Unlock()
 		c.Assert(err, check.IsNil)
 		c.Check(res.Summary, check.Equals, tst.msg)
-		c.Check(refreshSnapDecls, check.Equals, true)
+		c.Check(refreshSnapAssertions, check.Equals, true)
 	}
 }
 
 func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
-	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
-		refreshSnapDecls = true
-		return assertstate.RefreshSnapDeclarations(s, userID, nil)
+	refreshSnapAssertions := false
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+		refreshSnapAssertions = true
+		return assertstate.RefreshSnapAssertions(s, userID)
 	})()
 
 	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
@@ -573,13 +573,13 @@ func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Refresh all snaps: no updates`)
-	c.Check(refreshSnapDecls, check.Equals, true)
+	c.Check(refreshSnapAssertions, check.Equals, true)
 }
 
 func (s *snapsSuite) TestRefreshMany(c *check.C) {
-	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
-		refreshSnapDecls = true
+	refreshSnapAssertions := false
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+		refreshSnapAssertions = true
 		return nil
 	})()
 
@@ -598,13 +598,13 @@ func (s *snapsSuite) TestRefreshMany(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Refresh snaps "foo", "bar"`)
 	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
-	c.Check(refreshSnapDecls, check.Equals, true)
+	c.Check(refreshSnapAssertions, check.Equals, true)
 }
 
 func (s *snapsSuite) TestRefreshMany1(c *check.C) {
-	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
-		refreshSnapDecls = true
+	refreshSnapAssertions := false
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+		refreshSnapAssertions = true
 		return nil
 	})()
 
@@ -623,7 +623,7 @@ func (s *snapsSuite) TestRefreshMany1(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Refresh snap "foo"`)
 	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
-	c.Check(refreshSnapDecls, check.Equals, true)
+	c.Check(refreshSnapAssertions, check.Equals, true)
 }
 
 func (s *snapsSuite) TestInstallMany(c *check.C) {
@@ -1434,7 +1434,7 @@ func (s *snapsSuite) TestInstallIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-install-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1600,7 +1600,7 @@ func (s *snapsSuite) TestRefresh(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
 		assertstateCalledUserID = userID
 		return nil
 	})()
@@ -1639,7 +1639,7 @@ func (s *snapsSuite) TestRefreshDevMode(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1673,7 +1673,7 @@ func (s *snapsSuite) TestRefreshClassic(c *check.C) {
 		calledFlags = flags
 		return nil, nil
 	})()
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1707,7 +1707,7 @@ func (s *snapsSuite) TestRefreshIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1746,7 +1746,7 @@ func (s *snapsSuite) TestRefreshIgnoreRunning(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1781,7 +1781,7 @@ func (s *snapsSuite) TestRefreshCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1811,7 +1811,7 @@ func (s *snapsSuite) TestRefreshLeaveCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -478,7 +478,7 @@ func (s *snapsSuite) TestPostSnapsOpMoreComplexContentType(c *check.C) {
 }
 
 func (s *snapsSuite) testPostSnapsOp(c *check.C, contentType string) {
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(*state.State, int, *assertstate.RefreshAssertionsOptions) error { return nil })()
+	defer daemon.MockAssertstateRefreshAssertions(func(*state.State, int) error { return nil })()
 	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
 		c.Check(names, check.HasLen, 0)
 		t := s.NewTask("fake-refresh-all", "Refreshing everything")
@@ -519,9 +519,9 @@ func (s *snapsSuite) TestPostSnapsOpInvalidCharset(c *check.C) {
 
 func (s *snapsSuite) TestRefreshAll(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		refreshSnapDecls = true
-		return assertstate.RefreshSnapDeclarations(s, userID, opts)
+		return assertstate.RefreshSnapDeclarations(s, userID, nil)
 	})()
 
 	d := s.daemon(c)
@@ -555,9 +555,9 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 
 func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		refreshSnapDecls = true
-		return assertstate.RefreshSnapDeclarations(s, userID, opts)
+		return assertstate.RefreshSnapDeclarations(s, userID, nil)
 	})()
 
 	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
@@ -578,7 +578,7 @@ func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 
 func (s *snapsSuite) TestRefreshMany(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		refreshSnapDecls = true
 		return nil
 	})()
@@ -603,7 +603,7 @@ func (s *snapsSuite) TestRefreshMany(c *check.C) {
 
 func (s *snapsSuite) TestRefreshMany1(c *check.C) {
 	refreshSnapDecls := false
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		refreshSnapDecls = true
 		return nil
 	})()
@@ -1434,7 +1434,7 @@ func (s *snapsSuite) TestInstallIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-install-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1600,7 +1600,7 @@ func (s *snapsSuite) TestRefresh(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		assertstateCalledUserID = userID
 		return nil
 	})()
@@ -1639,7 +1639,7 @@ func (s *snapsSuite) TestRefreshDevMode(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1673,7 +1673,7 @@ func (s *snapsSuite) TestRefreshClassic(c *check.C) {
 		calledFlags = flags
 		return nil, nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1707,7 +1707,7 @@ func (s *snapsSuite) TestRefreshIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1746,7 +1746,7 @@ func (s *snapsSuite) TestRefreshIgnoreRunning(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1781,7 +1781,7 @@ func (s *snapsSuite) TestRefreshCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 
@@ -1811,7 +1811,7 @@ func (s *snapsSuite) TestRefreshLeaveCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapDeclarations(func(s *state.State, userID int, _ *assertstate.RefreshAssertionsOptions) error {
+	defer daemon.MockAssertstateRefreshAssertions(func(s *state.State, userID int) error {
 		return nil
 	})()
 

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/snapcore/snapd/overlord"
-	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -106,11 +105,11 @@ func MockUnsafeReadSnapInfo(mock func(string) (*snap.Info, error)) (restore func
 	}
 }
 
-func MockAssertstateRefreshSnapDeclarations(mock func(*state.State, int, *assertstate.RefreshAssertionsOptions) error) (restore func()) {
-	oldAssertstateRefreshSnapDeclarations := assertstateRefreshSnapDeclarations
-	assertstateRefreshSnapDeclarations = mock
+func MockAssertstateRefreshAssertions(mock func(*state.State, int) error) (restore func()) {
+	oldAssertstateRefreshAssertions := assertstateRefreshAssertions
+	assertstateRefreshAssertions = mock
 	return func() {
-		assertstateRefreshSnapDeclarations = oldAssertstateRefreshSnapDeclarations
+		assertstateRefreshAssertions = oldAssertstateRefreshAssertions
 	}
 }
 

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -105,11 +105,11 @@ func MockUnsafeReadSnapInfo(mock func(string) (*snap.Info, error)) (restore func
 	}
 }
 
-func MockAssertstateRefreshAssertions(mock func(*state.State, int) error) (restore func()) {
-	oldAssertstateRefreshAssertions := assertstateRefreshAssertions
-	assertstateRefreshAssertions = mock
+func MockAssertstateRefreshSnapAssertions(mock func(*state.State, int) error) (restore func()) {
+	oldAssertstateRefreshSnapAssertions := assertstateRefreshSnapAssertions
+	assertstateRefreshSnapAssertions = mock
 	return func() {
-		assertstateRefreshAssertions = oldAssertstateRefreshAssertions
+		assertstateRefreshSnapAssertions = oldAssertstateRefreshSnapAssertions
 	}
 }
 

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -351,6 +351,15 @@ func AutoRefreshAssertions(s *state.State, userID int) error {
 	return RefreshValidationSetAssertions(s, userID, opts)
 }
 
+// RefreshAssertions tries to refresh all assertions
+func RefreshAssertions(s *state.State, userID int) error {
+	opts := &RefreshAssertionsOptions{IsAutoRefresh: false}
+	if err := RefreshSnapDeclarations(s, userID, opts); err != nil {
+		return err
+	}
+	return RefreshValidationSetAssertions(s, userID, opts)
+}
+
 // RefreshValidationSetAssertions tries to refresh all validation set
 // assertions.
 func RefreshValidationSetAssertions(s *state.State, userID int, opts *RefreshAssertionsOptions) error {

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -351,8 +351,8 @@ func AutoRefreshAssertions(s *state.State, userID int) error {
 	return RefreshValidationSetAssertions(s, userID, opts)
 }
 
-// RefreshAssertions tries to refresh all assertions
-func RefreshAssertions(s *state.State, userID int) error {
+// RefreshSnapAssertions tries to refresh all snap-centered assertions
+func RefreshSnapAssertions(s *state.State, userID int) error {
 	opts := &RefreshAssertionsOptions{IsAutoRefresh: false}
 	if err := RefreshSnapDeclarations(s, userID, opts); err != nil {
 		return err

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -991,7 +991,7 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
-	err = assertstate.RefreshAssertions(s.state, 0)
+	err = assertstate.RefreshSnapAssertions(s.state, 0)
 	c.Assert(err, IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -1009,6 +1009,9 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 	})
 	c.Assert(err, IsNil)
 	c.Check(a.Revision(), Equals, 3)
+
+	c.Assert(err, IsNil)
+	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
 }
 
 func (s *assertMgrSuite) TestRefreshSnapDeclarationsTooEarly(c *C) {

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -947,6 +947,70 @@ func (s *assertMgrSuite) stateFromDecl(c *C, decl *asserts.SnapDeclaration, inst
 	})
 }
 
+func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidationSets(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	storeAs := s.setupModelAndStore(c)
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+
+	s.stateFromDecl(c, snapDeclFoo, "", snap.R(7))
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
+
+	// previous state
+	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(s.state, snapDeclFoo), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
+	tr := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	// changed snap decl assertion
+	headers := map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "foo-id",
+		"snap-name":    "fo-o",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+		"revision":     "1",
+	}
+	snapDeclFoo1, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(snapDeclFoo1)
+	c.Assert(err, IsNil)
+
+	// changed validation set assertion
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required")
+	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
+
+	err = assertstate.RefreshAssertions(s.state, 0)
+	c.Assert(err, IsNil)
+
+	a, err := assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  "16",
+		"snap-id": "foo-id",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.SnapDeclaration).SnapName(), Equals, "fo-o")
+
+	a, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "2",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.Revision(), Equals, 3)
+}
+
 func (s *assertMgrSuite) TestRefreshSnapDeclarationsTooEarly(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
Refresh validation set assertions together with snap declarations (on snap update atm, will be expanded to install and remove in another PR) with new asserstate.RefreshAssertions helper.