### PR TITLE
many: shellcheck fixes (2.51)

### DIFF
--- a/get-deps.sh
+++ b/get-deps.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ "$GOPATH" = "" ]; then
     tmpdir=$(mktemp -d)
-    export GOPATH=$tmpdir
+    export GOPATH="$tmpdir"
     # shellcheck disable=SC2064
     trap "rm -rf $tmpdir" EXIT
 

--- a/packaging/ubuntu-14.04/tests/integrationtests
+++ b/packaging/ubuntu-14.04/tests/integrationtests
@@ -36,6 +36,6 @@ fi
 . /etc/os-release
 apt-get install golang-1.6-go
 export GOPATH=/tmp/go
-export PATH=/usr/lib/go-1.6/bin:${PATH}
+export PATH=/usr/lib/go-1.6/bin:"${PATH}"
 go get -u github.com/snapcore/spread/cmd/spread
 /tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)"

--- a/run-checks
+++ b/run-checks
@@ -12,7 +12,7 @@ COVERMODE=${COVERMODE:-atomic}
 
 if [ -z "${GITHUB_WORKFLOW:-}" ]; then
     # when *not* running inside github, ensure we use go-1.10 by default
-    export PATH=/usr/lib/go-1.10/bin:${PATH}
+    export PATH=/usr/lib/go-1.10/bin:"${PATH}"
 fi
 
 # add workaround for https://github.com/golang/go/issues/24449

--- a/tests/lib/snaps/config-versions-v2/meta/hooks/configure
+++ b/tests/lib/snaps/config-versions-v2/meta/hooks/configure
@@ -3,7 +3,7 @@
 snapctl set configure-marker="executed-for-v2"
 
 command=$(snapctl get fail-configure)
-if [ "x$command" = "xyes" ]; then
+if [ "$command" = "yes" ]; then
     echo "failing configure hook as requested"
     exit 1
 fi

--- a/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
+++ b/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
@@ -68,9 +68,9 @@ test_get_nested() {
   fi
   expected_output='{\n\t"key1": "a",\n\t"key2": "b"\n}'
   # note: "echo" is a built-in of sh and doesn't support -e flag, use /bin/echo.
-  # shellcheck disable=SC2039
+  # shellcheck disable=SC3037
   if [ "$output" != "$(/bin/echo -e "$expected_output")" ]; then
-      echo "Expected output to be '$expected_output' but it was '$output'"
+      echo "Expected output to be '$(/bin/echo -e "$expected_output")' but it was '$output'"
       exit 1
   fi
 }

--- a/tests/lib/snaps/store/test-snapd-upower/bin/upowerd.sh
+++ b/tests/lib/snaps/store/test-snapd-upower/bin/upowerd.sh
@@ -32,6 +32,6 @@ if [ ! -e "$SNAP_DATA/UPower.conf" ]; then
 	cp "$SNAP/etc/UPower/UPower.conf" "$SNAP_DATA"
 fi
 
-export UPOWER_CONF_FILE_NAME=$SNAP_DATA/UPower.conf
+export UPOWER_CONF_FILE_NAME="$SNAP_DATA"/UPower.conf
 
 exec "$SNAP/usr/libexec/upowerd" $UPOWER_OPTS


### PR DESCRIPTION
* many: shellcheck fixes

We got a new shellcheck in "edge" and it seems this broke master.
This commit adds the required fixes.

* tests: update `shellcheck disable=SC3037` for echo -e

We want to keep the `echo -e` - using printf is not cleaner and
also results in a shellcheck warning. We already had a shellcheck
disable that seems to have been changed with the new version of
shellcheck. So this commit updates it to the new SC3037 value.
