### PR TITLE
many: fix run-checks gofmt check 

### DIFF
--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -136,7 +136,7 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 		options = append(options, "bind")
 	}
 	if len(options) > 0 {
-		args = append(args, "--options=" + strings.Join(options, ","))
+		args = append(args, "--options="+strings.Join(options, ","))
 	}
 
 	// note that we do not currently parse any output from systemd-mount, but if

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -155,7 +155,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			where: "/run/mnt/data",
 			opts: &main.SystemdMountOptions{
 				NoSuid: true,
-				Bind: true,
+				Bind:   true,
 			},
 			timeNowTimes:     []time.Time{testStart, testStart},
 			isMountedReturns: []bool{true},

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -111,7 +111,7 @@ and environment.
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"gdb": i18n.G("Run the command with gdb (deprecated, use --gdbserver instead)"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"gdbserver": i18n.G("Run the command with gdbserver"),
+			"gdbserver":              i18n.G("Run the command with gdbserver"),
 			"experimental-gdbserver": "",
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"timer": i18n.G("Run as a timer service with given schedule"),

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -780,11 +780,11 @@ func (s *RunSuite) TestAntialiasHappy(c *check.C) {
 	app, outArgs = snaprun.Antialias("alias", inArgs)
 	c.Check(app, check.Equals, "an-app")
 	c.Check(outArgs, check.DeepEquals, []string{
-		"99", // COMP_TYPE (no change)
-		"99", // COMP_KEY (no change)
-		"11", // COMP_POINT (+1 because "an-app" is one longer than "alias")
-		"2",  // COMP_CWORD (no change)
-		" ",  // COMP_WORDBREAKS (no change)
+		"99",                    // COMP_TYPE (no change)
+		"99",                    // COMP_KEY (no change)
+		"11",                    // COMP_POINT (+1 because "an-app" is one longer than "alias")
+		"2",                     // COMP_CWORD (no change)
+		" ",                     // COMP_WORDBREAKS (no change)
 		"an-app alias bo-alias", // COMP_LINE (argv[0] changed)
 		"an-app",                // argv (arv[0] changed)
 		"alias",
@@ -805,12 +805,12 @@ func (s *RunSuite) TestAntialiasBailsIfUnhappy(c *check.C) {
 	weird2[5] = "alias "
 
 	for desc, inArgs := range map[string][]string{
-		"nil args":                                               nil,
-		"too-short args":                                         {"alias"},
-		"COMP_POINT not a number":                                mkCompArgs("hello", "alias"),
-		"COMP_POINT is inside argv[0]":                           mkCompArgs("2", "alias", ""),
-		"COMP_POINT is outside argv":                             mkCompArgs("99", "alias", ""),
-		"COMP_WORDS[0] is not argv[0]":                           mkCompArgs("10", "not-alias", ""),
+		"nil args":                     nil,
+		"too-short args":               {"alias"},
+		"COMP_POINT not a number":      mkCompArgs("hello", "alias"),
+		"COMP_POINT is inside argv[0]": mkCompArgs("2", "alias", ""),
+		"COMP_POINT is outside argv":   mkCompArgs("99", "alias", ""),
+		"COMP_WORDS[0] is not argv[0]": mkCompArgs("10", "not-alias", ""),
 		"mismatch between argv[0], COMP_LINE and COMP_WORDS, #1": weird1,
 		"mismatch between argv[0], COMP_LINE and COMP_WORDS, #2": weird2,
 	} {

--- a/run-checks
+++ b/run-checks
@@ -141,10 +141,9 @@ if [ "$STATIC" = 1 ]; then
     if [ -z "${SKIP_GOFMT:-}" ]; then
         echo Checking formatting
         fmt=""
-        for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' | grep -E 'snapd/[A-Za-z0-9_]+$' ); do
+        for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/\(c-\)\?vendor/' ); do
             # skip vendor packages
-            # skip subpackages of packages under snapd, gofmt already inspects them
-            s="$(${GOFMT:-gofmt} -s -l -d "$dir" || true)"
+            s="$(${GOFMT:-gofmt} -s -d "$dir" || true)"
             if [ -n "$s" ]; then
                 fmt="$s\\n$fmt"
             fi

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -446,7 +446,7 @@ func (s *storeTestSuite) TestAssertionsEndpointNotFound(c *C) {
 	var respObj map[string]interface{}
 	err = dec.Decode(&respObj)
 	c.Assert(err, IsNil)
-	c.Check(respObj["error-list"], DeepEquals, []interface{}{map[string]interface{}{"code":"not-found", "message":"not found"}})
+	c.Check(respObj["error-list"], DeepEquals, []interface{}{map[string]interface{}{"code": "not-found", "message": "not found"}})
 }
 
 func (s *storeTestSuite) TestSnapActionEndpoint(c *C) {


### PR DESCRIPTION
gofmt was only running on paths ending with "snapd/[A-Za-z0-9_]+$".
This was done to avoid running gofmt on root dirs and again in their
subdirs (since gofmt already does that) but would also exclude paths
that don't have a package in the dir directly below snapd, like snap/cmd.
snapd/cmd/snap (has a pkg) would be excluded and snapd/cmd isn't listed
by 'go list' (doesn't have a pkg) so it wasn't gofmt'ed.

This fix is simply runs gofmt on all dirs since the performance
impact was negligible (in my local tests).

Edit: oh, I also removed the `-l` when invoking gofmt because, since we already
use `-d`, I didn't see the need for it but please correct me if I'm wrong. 