### PR TITLE
tests: use "shellcheck" snap in `go` unit test

### DIFF
--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -11,12 +11,15 @@ prepare: |
     if not os.query is-trusty; then
         tests.session -u test prepare
     fi
+    # ensure to use an up-to-date shellcheck
+    snap install shellcheck
 
 restore: |
     if not os.query is-trusty; then
         tests.session -u test restore
     fi
     rm -rf /tmp/static-unit-tests
+    snap remove shellcheck
 
 execute: |
     mkdir -p /tmp/static-unit-tests/src/github.com/snapcore


### PR DESCRIPTION
There is currently an inconsistency between when we run the
`tests/unit/go` shellcheck testing and the github action shellcheck.

The former will use whatever shellcheck is on the system but the
GH action will use the snap. That leads to the following issue:

With the new shellcheck we get an error SC3037 but the old shellcheck
from the distro calls that SC2039 - and we need to disable it.

This commit ensures that the go unit testis also using the snap
shellcheck.

I noticed this while reviewing some of the recent failures in 20.04.
