### PR TITLE
tests: disable `SC2039` in `snapctl-hooks` configure hook

### DIFF
--- a/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
+++ b/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
@@ -68,7 +68,7 @@ test_get_nested() {
   fi
   expected_output='{\n\t"key1": "a",\n\t"key2": "b"\n}'
   # note: "echo" is a built-in of sh and doesn't support -e flag, use /bin/echo.
-  # shellcheck disable=SC3037
+  # shellcheck disable=SC3037,SC2039
   if [ "$output" != "$(/bin/echo -e "$expected_output")" ]; then
       echo "Expected output to be '$(/bin/echo -e "$expected_output")' but it was '$output'"
       exit 1


### PR DESCRIPTION
The new and the older shellcheck versions disagree about the
nature of the `echo -e` warning. New shellcheck warns with SC3037
and old with SC2039. The old shellcheck runs when in the
`tests/unit/go` spread test and the new in GH actions. Given that
this is the only instance where this is a problem this commit just
makes shellcheck ignore both the old and the new code for the issue.

Simpler version of #10687 to unblock us.