### PR TITLE
tests: cherry-pick shellcheck fix `bd730fd4` from #10443 (2.51)

### DIFF
--- a/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
+++ b/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
@@ -68,7 +68,7 @@ test_get_nested() {
   fi
   expected_output='{\n\t"key1": "a",\n\t"key2": "b"\n}'
   # note: "echo" is a built-in of sh and doesn't support -e flag, use /bin/echo.
-  # shellcheck disable=SC3037
+  # shellcheck disable=SC2039,SC3037
   if [ "$output" != "$(/bin/echo -e "$expected_output")" ]; then
       echo "Expected output to be '$(/bin/echo -e "$expected_output")' but it was '$output'"
       exit 1


### PR DESCRIPTION
The new and the older shellcheck versions disagree about the
nature of the echo -e warning. New shellcheck warns with SC3037
and old with SC2039. The old shellcheck runs when in the
tests/unit/go spread test and the new in GH actions. Given that
this is the only instance where this is a problem this commit just
makes shellcheck ignore both the old and the new code for the issue.

This was merged as part of #10443 [1] but because it got squashed
we need the isolated fix for 2.51.

[1] https://github.com/snapcore/snapd/pull/10443/commits/bd730fd49cbb0309430c5fa3fecc35073d2d343d
