### PR TITLE
o/snapstate: enforce validation sets on snap install

### DIFF
--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -200,6 +201,11 @@ func (s *servicectlSuite) SetUpTest(c *C) {
 	s.st.Set("seeded", true)
 	s.st.Set("refresh-privacy-key", "privacy-key")
 	s.AddCleanup(snapstatetest.UseFallbackDeviceModel())
+
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
+		return nil, nil
+	})
+	s.AddCleanup(restore)
 }
 
 func (s *servicectlSuite) TestStopCommand(c *C) {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -3787,5 +3787,5 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSetAtRevision(
 
 func (s *validationSetsSuite) TestInstallSnapReferencedByValidationSetWrongRevision(c *C) {
 	err := s.installSnapReferencedByValidationSet(c, "required", "3", snap.R(2))
-	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" at requested revision 2, revision 3 required by validation sets: foo/bar`)
+	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" at requested revision 2 without --ignore-validation, revision 3 required by validation sets: foo/bar`)
 }

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -3705,7 +3705,7 @@ func (s *snapmgrTestSuite) TestInstallContentProviderDownloadFailure(c *C) {
 	c.Check(snapSt.Current, Equals, snap.R(42))
 }
 
-func (s *validationSetsSuite) installSnapReferencedByValidationSet(c *C, presence string) error {
+func (s *validationSetsSuite) installSnapReferencedByValidationSet(c *C, presence, requiredRev string, installRev snap.Revision) error {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
 		someSnap := map[string]interface{}{
@@ -3713,45 +3713,8 @@ func (s *validationSetsSuite) installSnapReferencedByValidationSet(c *C, presenc
 			"name":     "some-snap",
 			"presence": presence,
 		}
-		vsa1 := s.mockValidationSetAssert(c, "bar", "1", someSnap)
-		vs.Add(vsa1.(*asserts.ValidationSet))
-		return vs, nil
-	})
-	defer restore()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	tr := assertstate.ValidationSetTracking{
-		AccountID: "foo",
-		Name:      "bar",
-		Mode:      assertstate.Enforce,
-		Current:   1,
-	}
-	assertstate.UpdateValidationSet(s.state, &tr)
-
-	_, err := snapstate.Install(context.Background(), s.state, "some-snap", nil, 0, snapstate.Flags{})
-	return err
-}
-
-func (s *validationSetsSuite) TestInstallSnapInvalidForValidationSetRefused(c *C) {
-	err := s.installSnapReferencedByValidationSet(c, "invalid")
-	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" due to enforcing rules of validation set foo/bar`)
-}
-
-func (s *validationSetsSuite) TestInstallSnapOptionalForValidationSetOK(c *C) {
-	err := s.installSnapReferencedByValidationSet(c, "optional")
-	c.Assert(err, IsNil)
-}
-
-func (s *validationSetsSuite) TestInstallSnapReferencedByValidationSetWrongRevision(c *C) {
-	restore := snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
-		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
-			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
-			"name":     "some-snap",
-			"presence": "required",
-			"revision": "3",
+		if requiredRev != "" {
+			someSnap["revision"] = requiredRev
 		}
 		vsa1 := s.mockValidationSetAssert(c, "bar", "1", someSnap)
 		vs.Add(vsa1.(*asserts.ValidationSet))
@@ -3770,6 +3733,59 @@ func (s *validationSetsSuite) TestInstallSnapReferencedByValidationSetWrongRevis
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 
-	_, err := snapstate.Install(context.Background(), s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(2)}, 0, snapstate.Flags{})
+	var opts *snapstate.RevisionOptions
+	if !installRev.Unset() {
+		opts = &snapstate.RevisionOptions{Revision: installRev}
+	}
+	_, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, 0, snapstate.Flags{})
+	return err
+}
+
+func (s *validationSetsSuite) TestInstallSnapInvalidForValidationSetRefused(c *C) {
+	err := s.installSnapReferencedByValidationSet(c, "invalid", "", snap.R(0))
+	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" due to enforcing rules of validation set foo/bar`)
+}
+
+func (s *validationSetsSuite) TestInstallSnapOptionalForValidationSetOK(c *C) {
+	err := s.installSnapReferencedByValidationSet(c, "optional", "", snap.R(0))
+	c.Assert(err, IsNil)
+}
+
+func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSet(c *C) {
+	err := s.installSnapReferencedByValidationSet(c, "required", "", snap.R(0))
+	c.Assert(err, IsNil)
+	c.Assert(s.fakeBackend.ops, HasLen, 2)
+	expectedOp := fakeOp{
+		op: "storesvc-snap-action:action",
+		action: store.SnapAction{
+			Action:         "install",
+			InstanceName:   "some-snap",
+			Channel:        "stable",
+			ValidationSets: [][]string{{"foo", "bar"}},
+		},
+		revno: snap.R(11),
+	}
+	c.Assert(s.fakeBackend.ops[1], DeepEquals, expectedOp)
+}
+
+func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSetAtRevision(c *C) {
+	err := s.installSnapReferencedByValidationSet(c, "required", "2", snap.R(2))
+	c.Assert(err, IsNil)
+	c.Assert(s.fakeBackend.ops, HasLen, 2)
+	expectedOp := fakeOp{
+		op: "storesvc-snap-action:action",
+		action: store.SnapAction{
+			Action:         "install",
+			Revision:       snap.R(2),
+			InstanceName:   "some-snap",
+			ValidationSets: [][]string{{"foo", "bar"}},
+		},
+		revno: snap.R(2),
+	}
+	c.Assert(s.fakeBackend.ops[1], DeepEquals, expectedOp)
+}
+
+func (s *validationSetsSuite) TestInstallSnapReferencedByValidationSetWrongRevision(c *C) {
+	err := s.installSnapReferencedByValidationSet(c, "required", "3", snap.R(2))
 	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" at requested revision 2, revision 3 required by validation sets: foo/bar`)
 }

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -265,18 +265,18 @@ func installInfo(ctx context.Context, st *state.State, name string, revOpts *Rev
 		}
 	}
 
+	// check if desired revision matches the revision required by validation sets
+	if !requiredRevision.Unset() && !revOpts.Revision.Unset() && revOpts.Revision.N != requiredRevision.N {
+		return store.SnapActionResult{}, fmt.Errorf("cannot install snap %q at requested revision %s, revision %s required by validation sets: %s", name, revOpts.Revision, requiredRevision, strings.Join(requiredValsets, ","))
+	}
+
 	// cannot specify both with the API
 	if revOpts.Revision.Unset() {
 		// the desired channel
 		action.Channel = revOpts.Channel
 		// the desired cohort key
-		// XXX: should we disallow cohort key if validation sets require this snap?
 		action.CohortKey = revOpts.CohortKey
 	} else {
-		// the desired revision; check if it matches the revision required by validation sets
-		if !requiredRevision.Unset() && revOpts.Revision.N != requiredRevision.N {
-			return store.SnapActionResult{}, fmt.Errorf("cannot install snap %q at requested revision %s, revision %s required by validation sets: %s", name, revOpts.Revision, requiredRevision, strings.Join(requiredValsets, ","))
-		}
 		action.Revision = revOpts.Revision
 	}
 

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -205,8 +205,8 @@ var installSize = func(st *state.State, snaps []minimalInstallInfo, userID int) 
 
 func setActionValidationSets(action *store.SnapAction, valsets []string) {
 	for _, vs := range valsets {
-		vskey := strings.Split(vs, "/")
-		action.ValidationSets = append(action.ValidationSets, vskey)
+		keyParts := strings.Split(vs, "/")
+		action.ValidationSets = append(action.ValidationSets, keyParts)
 	}
 }
 
@@ -240,7 +240,7 @@ func installInfo(ctx context.Context, st *state.State, name string, revOpts *Rev
 	}
 
 	var requiredRevision snap.Revision
-	var requiredValsets []string
+	var requiredValSets []string
 	if enforcedSets != nil {
 		// check for invalid presence first to have a list of sets where it's invalid
 		invalidForValSets, err := enforcedSets.CheckPresenceInvalid(naming.Snap(name))
@@ -252,14 +252,14 @@ func installInfo(ctx context.Context, st *state.State, name string, revOpts *Rev
 		if len(invalidForValSets) > 0 {
 			return store.SnapActionResult{}, fmt.Errorf("cannot install snap %q due to enforcing rules of validation set %s", name, strings.Join(invalidForValSets, ","))
 		}
-		requiredValsets, requiredRevision, err = enforcedSets.CheckPresenceRequired(naming.Snap(name))
+		requiredValSets, requiredRevision, err = enforcedSets.CheckPresenceRequired(naming.Snap(name))
 		if err != nil {
 			return store.SnapActionResult{}, err
 		}
 	}
 
-	if len(requiredValsets) > 0 {
-		setActionValidationSets(action, requiredValsets)
+	if len(requiredValSets) > 0 {
+		setActionValidationSets(action, requiredValSets)
 		if !requiredRevision.Unset() {
 			action.Revision = requiredRevision
 		}
@@ -267,7 +267,7 @@ func installInfo(ctx context.Context, st *state.State, name string, revOpts *Rev
 
 	// check if desired revision matches the revision required by validation sets
 	if !requiredRevision.Unset() && !revOpts.Revision.Unset() && revOpts.Revision.N != requiredRevision.N {
-		return store.SnapActionResult{}, fmt.Errorf("cannot install snap %q at requested revision %s, revision %s required by validation sets: %s", name, revOpts.Revision, requiredRevision, strings.Join(requiredValsets, ","))
+		return store.SnapActionResult{}, fmt.Errorf("cannot install snap %q at requested revision %s, revision %s required by validation sets: %s", name, revOpts.Revision, requiredRevision, strings.Join(requiredValSets, ","))
 	}
 
 	// cannot specify both with the API


### PR DESCRIPTION
Enforce validation sets on snap install (single snap). This mostly means:
- checking that the requested snap doesn't have presence:invalid in any validation set
- requesting specific snap revision if the snap is required at the specific revision (open question: this may not be a viable real use case since it won't be possible to enable the validation set without having snap already installed?)
- passing respective validation set keys to store action.

Based on #10678 
