### PR TITLE
wrappers: fix a bunch of duplicated service definitions in tests

### DIFF
--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -59,7 +59,7 @@ func (s *binariesTestSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 }
 
-const packageHello = `name: hello-snap
+const packageHelloNoSrv = `name: hello-snap
 version: 1.10
 summary: hello
 description: Hello...
@@ -69,6 +69,9 @@ apps:
  world:
    command: bin/world
    completer: world-completer.sh
+`
+
+const packageHello = packageHelloNoSrv + `
  svc1:
   command: bin/hello
   stop-command: bin/goodbye

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -1675,7 +1675,7 @@ plugs:
 
 	for _, t := range tt {
 		comment := Commentf(t.comment)
-		info := snaptest.MockSnap(c, packageHello+`
+		info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   daemon: simple
 `+t.plugSnippet,
@@ -1738,7 +1738,7 @@ WantedBy=multi-user.target
 }
 
 func (s *servicesTestSuite) TestAddSnapServicesAndRemoveUserDaemons(c *C) {
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   daemon: simple
   daemon-scope: user
@@ -1780,7 +1780,7 @@ type: snapd
 `
 
 func (s *servicesTestSuite) TestRemoveSnapWithSocketsRemovesSocketsService(c *C) {
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   daemon: simple
   plugs: [network-bind]
@@ -2104,7 +2104,7 @@ func (s *servicesTestSuite) TestStopServicesWithSockets(c *C) {
 	})
 	defer r()
 
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   daemon: simple
   plugs: [network-bind]
@@ -2158,7 +2158,7 @@ func (s *servicesTestSuite) TestStartServices(c *C) {
 }
 
 func (s *servicesTestSuite) TestStartServicesUserDaemons(c *C) {
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   daemon: simple
   daemon-scope: user
@@ -2389,7 +2389,7 @@ func (s *servicesTestSuite) TestAddSnapMultiUserServicesFailEnableCleanup(c *C) 
 	})
 	defer r()
 
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   command: bin/hello
   daemon: simple
@@ -2440,7 +2440,7 @@ func (s *servicesTestSuite) TestAddSnapMultiUserServicesStartFailOnSystemdReload
 	})
 	defer r()
 
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   command: bin/hello
   daemon: simple
@@ -2464,7 +2464,7 @@ func (s *servicesTestSuite) TestAddSnapMultiUserServicesStartFailOnSystemdReload
 }
 
 func (s *servicesTestSuite) TestAddSnapSocketFiles(c *C) {
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   daemon: simple
   plugs: [network-bind]
@@ -2516,7 +2516,7 @@ ListenStream=%s
 }
 
 func (s *servicesTestSuite) TestAddSnapUserSocketFiles(c *C) {
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   daemon: simple
   daemon-scope: user
@@ -2694,7 +2694,7 @@ func (s *servicesTestSuite) TestStartSnapMultiUserServicesFailStartCleanup(c *C)
 	})
 	defer r()
 
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   command: bin/hello
   daemon: simple
@@ -3454,7 +3454,7 @@ apps:
 }
 
 func (s *servicesTestSuite) TestStopAndDisableServices(c *C) {
-	info := snaptest.MockSnap(c, packageHello+`
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
  svc1:
   daemon: simple
 `, &snap.SideInfo{Revision: snap.R(12)})


### PR DESCRIPTION
We have a bunch of duplicated key in our snap.yaml that we use in
tests. This is not allowed with the yaml spec but `yaml.v2` is
leaniant about it. It becomes a problem with `yaml.v3` because
that errors for duplicated keys. Hence this first commit to fix some
obvious duplication. There will be more :)
