### PR TITLE
daemon: allow enabling enforce mode

### DIFF
--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -334,27 +334,20 @@ func validationSetForAssert(st *state.State, accountID, name string, sequence in
 	return sets, nil
 }
 
-func validationSetAssertFromDb(st *state.State, accountID, name string, sequence int) (vset *asserts.ValidationSet, err error) {
+func validationSetAssertFromDb(st *state.State, accountID, name string, sequence int) (*asserts.ValidationSet, error) {
 	headers := map[string]string{
 		"series":     release.Series,
 		"account-id": accountID,
 		"name":       name,
+		"sequence":   fmt.Sprintf("%d", sequence),
 	}
 	db := assertstate.DB(st)
-	var as asserts.Assertion
-	if sequence > 0 {
-		headers["sequence"] = fmt.Sprintf("%d", sequence)
-		as, err = db.Find(asserts.ValidationSetType, headers)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		as, err = db.FindSequence(asserts.ValidationSetType, headers, -1, asserts.ValidationSetType.MaxSupportedFormat())
-		if err != nil {
-			return nil, err
-		}
+	as, err := db.Find(asserts.ValidationSetType, headers)
+	if err != nil {
+		return nil, err
 	}
-	vset = as.(*asserts.ValidationSet)
+
+	vset := as.(*asserts.ValidationSet)
 	return vset, nil
 }
 

--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -405,7 +405,7 @@ func getSingleSeqFormingAssertion(st *state.State, accountID, name string, seque
 }
 
 func enforceValidationSet(st *state.State, accountID, name string, sequence, userID int) Response {
-	snaps, err := installedSnaps(st)
+	snaps, err := snapstate.InstalledSnaps(st)
 	if err != nil {
 		return InternalError(err.Error())
 	}

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -887,13 +887,6 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetsErrors(c *check.C) {
 			message:       `invalid mode "bad"`,
 			status:        400,
 		},
-		// XXX: enable when enforcing is implemented.
-		{
-			validationSet: "foo/bar",
-			mode:          "enforce",
-			message:       `invalid mode "enforce"`,
-			status:        400,
-		},
 		{
 			validationSet: "foo/bar",
 			sequence:      "-1",
@@ -925,4 +918,190 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetUnsupportedAction(c *chec
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, check.Equals, 400)
 	c.Check(rspe.Message, check.Matches, `unsupported action "baz"`)
+}
+
+func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceMode(c *check.C) {
+	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap) (*asserts.ValidationSet, error) {
+		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
+		c.Assert(name, check.Equals, "bar")
+		c.Assert(sequence, check.Equals, 0)
+		c.Check(userID, check.Equals, 0)
+		as := s.mockAssert(c, "bar", "3")
+		return as.(*asserts.ValidationSet), nil
+	})
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	snapstate.Set(st, "snap-b", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Current:  snap.R(1),
+	})
+
+	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
+
+	st.Unlock()
+	defer st.Lock()
+	body := `{"action":"apply","mode":"enforce"}`
+	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
+	c.Assert(err, check.IsNil)
+
+	rsp := s.syncReq(c, req, nil)
+	c.Assert(rsp.Status, check.Equals, 200)
+
+	// verify tracking information
+	st.Lock()
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
+		Mode:      assertstate.Enforce,
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Current:   3,
+	})
+}
+
+func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeSpecificSequence(c *check.C) {
+	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap) (*asserts.ValidationSet, error) {
+		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
+		c.Assert(name, check.Equals, "bar")
+		c.Assert(sequence, check.Equals, 5)
+		c.Check(userID, check.Equals, 0)
+		as := s.mockAssert(c, "bar", "5")
+		return as.(*asserts.ValidationSet), nil
+	})
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	snapstate.Set(st, "snap-b", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Current:  snap.R(1),
+	})
+
+	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
+
+	st.Unlock()
+	defer st.Lock()
+	body := `{"action":"apply","mode":"enforce","sequence":5}`
+	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
+	c.Assert(err, check.IsNil)
+
+	rsp := s.syncReq(c, req, nil)
+	c.Assert(rsp.Status, check.Equals, 200)
+
+	// verify tracking information
+	st.Lock()
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
+		Mode:      assertstate.Enforce,
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Current:   5,
+		PinnedAt:  5,
+	})
+}
+
+func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeUpdateFromMonitorMode(c *check.C) {
+	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap) (*asserts.ValidationSet, error) {
+		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
+		c.Assert(name, check.Equals, "bar")
+		c.Assert(sequence, check.Equals, 0)
+		c.Check(userID, check.Equals, 0)
+		as := s.mockAssert(c, "bar", "3")
+		return as.(*asserts.ValidationSet), nil
+	})
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	snapstate.Set(st, "snap-b", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Current:  snap.R(1),
+	})
+
+	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
+
+	// pretend we are tracking it in monitor mode
+	trMonitor := assertstate.ValidationSetTracking{
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(st, &trMonitor)
+
+	st.Unlock()
+	defer st.Lock()
+
+	// request enforce mode
+	body := `{"action":"apply","mode":"enforce"}`
+	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
+	c.Assert(err, check.IsNil)
+
+	rsp := s.syncReq(c, req, nil)
+	c.Assert(rsp.Status, check.Equals, 200)
+
+	// verify tracking information
+	st.Lock()
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
+		Mode:      assertstate.Enforce,
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Current:   3,
+	})
+}
+
+func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeError(c *check.C) {
+	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap) (*asserts.ValidationSet, error) {
+		return nil, fmt.Errorf("boom")
+	})
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	snapstate.Set(st, "snap-b", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Current:  snap.R(1),
+	})
+
+	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
+
+	st.Unlock()
+	defer st.Lock()
+	body := `{"action":"apply","mode":"enforce"}`
+	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
+	c.Assert(err, check.IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Assert(rspe.Status, check.Equals, 400)
+	c.Check(string(rspe.Message), check.Equals, "cannot enforce validation set: boom")
+
+	// tracking information isn't set
+	st.Lock()
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
+	st.Unlock()
+	c.Assert(err, check.Equals, state.ErrNoState)
 }

--- a/daemon/export_api_validate_test.go
+++ b/daemon/export_api_validate_test.go
@@ -45,3 +45,11 @@ func MockValidationSetAssertionForMonitor(f func(st *state.State, accountID, nam
 		validationSetAssertionForMonitor = old
 	}
 }
+
+func MockValidationSetAssertionForEnforce(f func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap) (vs *asserts.ValidationSet, err error)) func() {
+	old := validationSetAssertionForEnforce
+	validationSetAssertionForEnforce = f
+	return func() {
+		validationSetAssertionForEnforce = old
+	}
+}

--- a/tests/main/snap-validate-basic/task.yaml
+++ b/tests/main/snap-validate-basic/task.yaml
@@ -38,6 +38,9 @@ execute: |
   snap validate --monitor --enforce foo/bar 2>&1 | MATCH "cannot use --monitor and --enforce together"
   snap validate foo 2>&1 | MATCH "cannot parse validation set \"foo\""
 
+  echo "Checking enforce mode error"
+  snap validate --enforce "$ACCOUNT_ID"/bar=1 2>&1 | MATCH "error: cannot apply validation set: cannot enforce validation set: validation sets assertions are not met:"
+
   echo "Tracking not set up yet, but validation is possible with local assertion"
   snap validate "$ACCOUNT_ID"/bar=1 2>&1 | MATCH "^invalid"
 

--- a/tests/main/snap-validate-basic/task.yaml
+++ b/tests/main/snap-validate-basic/task.yaml
@@ -38,9 +38,6 @@ execute: |
   snap validate --monitor --enforce foo/bar 2>&1 | MATCH "cannot use --monitor and --enforce together"
   snap validate foo 2>&1 | MATCH "cannot parse validation set \"foo\""
 
-  echo "Checking that enforce mode is not supported yet"
-  snap validate --enforce foo/bar=1 2>&1 | MATCH "error: cannot apply validation set: invalid mode \"enforce\""
-
   echo "Tracking not set up yet, but validation is possible with local assertion"
   snap validate "$ACCOUNT_ID"/bar=1 2>&1 | MATCH "^invalid"
 


### PR DESCRIPTION
Allow enabling enforcing mode for a validation set with `snap validate --enforce ...`.

The existing spread test is only updated not to fail. Actual enforcing will be spread-tested separately once all the bits land.