### PR TITLE
tests: use host-scaled timeout to avoid riscv64 test failure

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3773,7 +3773,7 @@ version: @VERSION@`
 	tts[2].Tasks()[0].SetStatus(state.HoldStatus)
 
 	st.Unlock()
-	err = s.o.Settle(3 * time.Second)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
Use host-scaled timeout to avoid riscv64 failure (as seen here for 2.51.1 - https://launchpadlibrarian.net/556133108/buildlog_ubuntu-focal-riscv64.snapd_2.51.1+20.04_BUILDING.txt.gz)

We use host-scaled timeout for other settle ops in this test suite and it gives 6 * 45 second timeout on riscv64, so this makes it consistent with the rest.