### PR TITLE
many: remove unused parameters

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -518,16 +518,16 @@ func (o *TrustedAssetsUpdateObserver) Observe(op gadget.ContentOperation, affect
 	}
 	switch op {
 	case gadget.ContentUpdate:
-		return o.observeUpdate(whichBootloader, isRecovery, root, relativeTarget, data)
+		return o.observeUpdate(whichBootloader, isRecovery, relativeTarget, data)
 	case gadget.ContentRollback:
-		return o.observeRollback(whichBootloader, isRecovery, root, relativeTarget, data)
+		return o.observeRollback(whichBootloader, isRecovery, root, relativeTarget)
 	default:
 		// we only care about update and rollback actions
 		return gadget.ChangeApply, nil
 	}
 }
 
-func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, recovery bool, root, relativeTarget string, change *gadget.ContentChange) (gadget.ContentChangeAction, error) {
+func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, recovery bool, relativeTarget string, change *gadget.ContentChange) (gadget.ContentChangeAction, error) {
 	modeenvBefore, err := o.modeenv.Copy()
 	if err != nil {
 		return gadget.ChangeAbort, fmt.Errorf("cannot copy modeenv: %v", err)
@@ -594,7 +594,7 @@ func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, re
 	return gadget.ChangeApply, nil
 }
 
-func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, recovery bool, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error) {
+func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, recovery bool, root, relativeTarget string) (gadget.ContentChangeAction, error) {
 	trustedAssets := &o.modeenv.CurrentTrustedBootAssets
 	otherTrustedAssets := o.modeenv.CurrentTrustedRecoveryBootAssets
 	if recovery {

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -79,7 +79,7 @@ func (s *assetsSuite) uc20UpdateObserver(c *C, gadgetDir string) (*boot.TrustedA
 	return obs, uc20Model
 }
 
-func (s *assetsSuite) bootloaderWithTrustedAssets(c *C, trustedAssets []string) *bootloadertest.MockTrustedAssetsBootloader {
+func (s *assetsSuite) bootloaderWithTrustedAssets(trustedAssets []string) *bootloadertest.MockTrustedAssetsBootloader {
 	tab := bootloadertest.Mock("trusted", "").WithTrustedAssets()
 	bootloader.Force(tab)
 	tab.TrustedAssetsList = trustedAssets
@@ -253,7 +253,7 @@ func (s *assetsSuite) TestInstallObserverNew(c *C) {
 	c.Assert(nonUC20obs, IsNil)
 
 	// listing trusted assets fails
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 	})
 	tab.TrustedAssetsErr = fmt.Errorf("fail")
@@ -369,7 +369,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootRealGrub(c *C) {
 func (s *assetsSuite) TestInstallObserverObserveSystemBootMocked(c *C) {
 	d := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 		"nested/other-asset",
 	})
@@ -429,7 +429,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootMocked(c *C) {
 
 func (s *assetsSuite) TestInstallObserverObserveSystemBootMockedNoEncryption(c *C) {
 	d := c.MkDir()
-	s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	s.bootloaderWithTrustedAssets([]string{"asset"})
 	uc20Model := boottest.MakeMockUC20Model()
 	useEncryption := false
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d, useEncryption)
@@ -439,7 +439,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootMockedNoEncryption(c *
 
 func (s *assetsSuite) TestInstallObserverObserveSystemBootMockedUnencryptedWithManaged(c *C) {
 	d := c.MkDir()
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets([]string{"asset"})
 	tab.ManagedAssetsList = []string{"managed"}
 	uc20Model := boottest.MakeMockUC20Model()
 	useEncryption := false
@@ -505,7 +505,7 @@ func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
 func (s *assetsSuite) TestInstallObserverTrustedReuseNameErr(c *C) {
 	d := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 		"nested/asset",
 	})
@@ -537,7 +537,7 @@ func (s *assetsSuite) TestInstallObserverTrustedReuseNameErr(c *C) {
 func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryMocked(c *C) {
 	d := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 		"nested/other-asset",
 		"shim",
@@ -587,7 +587,7 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryMocked(c *C) {
 func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryReuseNameErr(c *C) {
 	d := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 		"nested/asset",
 	})
@@ -617,7 +617,7 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryReuseNameErr(c *
 func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryButMissingErr(c *C) {
 	d := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 	})
 
@@ -634,7 +634,7 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryButMissingErr(c 
 }
 
 func (s *assetsSuite) TestUpdateObserverNew(c *C) {
-	tab := s.bootloaderWithTrustedAssets(c, nil)
+	tab := s.bootloaderWithTrustedAssets(nil)
 
 	uc20Model := boottest.MakeMockUC20Model()
 
@@ -710,7 +710,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedWithReseal(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 		"nested/other-asset",
 		"shim",
@@ -796,7 +796,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 		"shim",
 	})
@@ -902,7 +902,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateNothingTrackedMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 	})
 
@@ -958,7 +958,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateOtherRoleStructMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 	})
 
@@ -1135,7 +1135,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateAfterSuccessfulBootMocked(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	s.bootloaderWithTrustedAssets(c, []string{
+	s.bootloaderWithTrustedAssets([]string{
 		"asset",
 	})
 
@@ -1183,7 +1183,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 	d := c.MkDir()
 	backups := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 		"nested/other-asset",
 		"shim",
@@ -1300,7 +1300,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 func (s *assetsSuite) TestUpdateObserverRollbackFileSanity(c *C) {
 	root := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets([]string{"asset"})
 
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
@@ -1590,7 +1590,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
@@ -1672,7 +1672,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -1791,7 +1791,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
@@ -1850,7 +1850,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledEmptyModeenvAssets(c *C) {
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
@@ -1904,7 +1904,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledAfterRollback(c *C) {
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
@@ -1974,7 +1974,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 		c.Assert(err, IsNil)
 	}
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
@@ -2043,7 +2043,7 @@ func (s *assetsSuite) TestObserveSuccessfulBootNoTrusted(c *C) {
 func (s *assetsSuite) TestObserveSuccessfulBootNoAssetsOnDisk(c *C) {
 	// call to observe successful boot, but assets do not exist on disk
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	s.bootloaderWithTrustedAssets([]string{"asset"})
 
 	m := &boot.Modeenv{
 		Mode: "run",
@@ -2066,7 +2066,7 @@ func (s *assetsSuite) TestObserveSuccessfulBootNoAssetsOnDisk(c *C) {
 func (s *assetsSuite) TestObserveSuccessfulBootAfterUpdate(c *C) {
 	// call to observe successful boot
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2116,7 +2116,7 @@ func (s *assetsSuite) TestObserveSuccessfulBootAfterUpdate(c *C) {
 func (s *assetsSuite) TestObserveSuccessfulBootWithUnexpected(c *C) {
 	// call to observe successful boot, but the asset we booted with is unexpected
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	s.bootloaderWithTrustedAssets([]string{"asset"})
 
 	data := []byte("foobar")
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
@@ -2156,7 +2156,7 @@ func (s *assetsSuite) TestObserveSuccessfulBootWithUnexpected(c *C) {
 func (s *assetsSuite) TestObserveSuccessfulBootSingleEntries(c *C) {
 	// call to observe successful boot
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2194,7 +2194,7 @@ func (s *assetsSuite) TestObserveSuccessfulBootDropCandidateUsedByOtherBootloade
 	// bootloader is used by the ubuntu-boot bootloader, so it cannot be
 	// dropped from cache
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	s.bootloaderWithTrustedAssets([]string{"asset"})
 
 	maybeDrop := []byte("maybe-drop")
 	maybeDropHash := "08a99ce3af529ebbfb9a82df690007ac650635b165c3d1b416d471907fa3843270dce9cc001ea26f4afb4e0c5af05209"
@@ -2234,7 +2234,7 @@ func (s *assetsSuite) TestObserveSuccessfulBootDropCandidateUsedByOtherBootloade
 func (s *assetsSuite) TestObserveSuccessfulBootParallelUpdate(c *C) {
 	// call to observe successful boot
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2282,7 +2282,7 @@ func (s *assetsSuite) TestObserveSuccessfulBootHashErr(c *C) {
 		c.Skip("the test cannot be executed by the root user")
 	}
 
-	s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	s.bootloaderWithTrustedAssets([]string{"asset"})
 
 	data := []byte("foobar")
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
@@ -2306,7 +2306,7 @@ func (s *assetsSuite) TestObserveSuccessfulBootHashErr(c *C) {
 }
 
 func (s *assetsSuite) TestObserveSuccessfulBootDifferentMode(c *C) {
-	s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	s.bootloaderWithTrustedAssets([]string{"asset"})
 
 	m := &boot.Modeenv{
 		Mode: "recover",
@@ -2439,7 +2439,7 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 		"shim",
 	})
@@ -2498,7 +2498,7 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	})
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		return uc20model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
+		return uc20model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -2582,7 +2582,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	tab := s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
 
 	// we get an observer for UC20
 	obs, uc20model := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
@@ -2636,7 +2636,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 	c.Check(res, Equals, gadget.ChangeApply)
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		return uc20model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
+		return uc20model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -2723,7 +2723,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedNonEncryption(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{
+	tab := s.bootloaderWithTrustedAssets([]string{
 		"asset",
 	})
 	tab.ManagedAssetsList = []string{

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -2178,7 +2178,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	uc20Model := boottest.MakeMockUC20Model()
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		return uc20Model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
+		return uc20Model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -2314,7 +2314,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	uc20Model := boottest.MakeMockUC20Model()
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		return uc20Model, []*seed.Snap{mockNamedKernelSeedSnap(c, snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
+		return uc20Model, []*seed.Snap{mockNamedKernelSeedSnap(snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -2472,7 +2472,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	uc20Model := boottest.MakeMockUC20Model()
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		return uc20Model, []*seed.Snap{mockNamedKernelSeedSnap(c, snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
+		return uc20Model, []*seed.Snap{mockNamedKernelSeedSnap(snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -741,7 +741,7 @@ func (brs20 *bootState20RecoverySystem) markSuccessful(update bootStateUpdate) (
 		return nil, err
 	}
 
-	newM, err := observeSuccessfulSystems(brs20.dev.Model(), u20.writeModeenv)
+	newM, err := observeSuccessfulSystems(u20.writeModeenv)
 	if err != nil {
 		return nil, fmt.Errorf("cannot mark successful recovery system: %v", err)
 	}

--- a/boot/boottest/bootenv.go
+++ b/boot/boottest/bootenv.go
@@ -75,7 +75,7 @@ func includesType(which []snap.Type, t snap.Type) bool {
 			return true
 		}
 	}
-	return true
+	return false
 }
 
 func exactlyType(which []snap.Type, t snap.Type) bool {

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -73,7 +73,7 @@ func MakeBootableImage(model *asserts.Model, rootdir string, bootWith *BootableS
 	if !bootWith.Recovery {
 		return fmt.Errorf("internal error: MakeBootableImage called at runtime, use MakeRunnableSystem instead")
 	}
-	return makeBootable20(model, rootdir, bootWith, bootFlags)
+	return makeBootable20(rootdir, bootWith, bootFlags)
 }
 
 // makeBootable16 setups the image filesystem for boot with UC16
@@ -153,7 +153,7 @@ func makeBootable16(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	return nil
 }
 
-func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet, bootFlags []string) error {
+func makeBootable20(rootdir string, bootWith *BootableSet, bootFlags []string) error {
 	// we can only make a single recovery system bootable right now
 	recoverySystems, err := filepath.Glob(filepath.Join(rootdir, "systems/*"))
 	if err != nil {

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -559,7 +559,7 @@ version: 5.0
 	readSystemEssentialCalls := 0
 	restore = boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		readSystemEssentialCalls++
-		return model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
+		return model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -899,7 +899,7 @@ version: 5.0
 	readSystemEssentialCalls := 0
 	restore = boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		readSystemEssentialCalls++
-		return model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
+		return model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -1060,7 +1060,7 @@ version: 5.0
 	readSystemEssentialCalls := 0
 	restore = boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		readSystemEssentialCalls++
-		return model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, gadgetFiles)}, nil
+		return model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, gadgetFiles)}, nil
 	})
 	defer restore()
 

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -165,7 +165,7 @@ func (s *modelSuite) SetUpTest(c *C) {
 			kernelRev = 999
 			systemModel = s.newUc20dev.Model()
 		}
-		return systemModel, []*seed.Snap{mockKernelSeedSnap(c, snap.R(kernelRev)), mockGadgetSeedSnap(c, nil)}, nil
+		return systemModel, []*seed.Snap{mockKernelSeedSnap(snap.R(kernelRev)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	s.AddCleanup(restore)
 }

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -59,11 +59,11 @@ func (s *sealSuite) SetUpTest(c *C) {
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
 }
 
-func mockKernelSeedSnap(c *C, rev snap.Revision) *seed.Snap {
-	return mockNamedKernelSeedSnap(c, rev, "pc-kernel")
+func mockKernelSeedSnap(rev snap.Revision) *seed.Snap {
+	return mockNamedKernelSeedSnap(rev, "pc-kernel")
 }
 
-func mockNamedKernelSeedSnap(c *C, rev snap.Revision, name string) *seed.Snap {
+func mockNamedKernelSeedSnap(rev snap.Revision, name string) *seed.Snap {
 	revAsString := rev.String()
 	if rev.Unset() {
 		revAsString = "unset"
@@ -151,7 +151,7 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		readSystemEssentialCalls := 0
 		restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 			readSystemEssentialCalls++
-			return model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
+			return model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 		})
 		defer restore()
 
@@ -415,7 +415,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 		readSystemEssentialCalls := 0
 		restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 			readSystemEssentialCalls++
-			return model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
+			return model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 		})
 		defer restore()
 
@@ -730,7 +730,7 @@ func (s *sealSuite) TestResealKeyToModeenvRecoveryKeysForGoodSystemsOnly(c *C) {
 		if label == "1234" {
 			kernelRev = 999
 		}
-		return model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(kernelRev)), mockGadgetSeedSnap(c, nil)}, nil
+		return model, []*seed.Snap{mockKernelSeedSnap(snap.R(kernelRev)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -999,7 +999,7 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 	readSystemEssentialCalls := 0
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
 		readSystemEssentialCalls++
-		return model, []*seed.Snap{mockKernelSeedSnap(c, snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
+		return model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -1211,7 +1211,7 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 			default:
 				return nil, nil, fmt.Errorf("invalid system seed")
 			}
-			return systemModel, []*seed.Snap{mockKernelSeedSnap(c, snap.R(kernelRev)), mockGadgetSeedSnap(c, tc.gadgetFilesForSystem[label])}, nil
+			return systemModel, []*seed.Snap{mockKernelSeedSnap(snap.R(kernelRev)), mockGadgetSeedSnap(c, tc.gadgetFilesForSystem[label])}, nil
 		})
 		defer restore()
 
@@ -1714,7 +1714,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithTryModel(c *C) {
 				"grade": "secured",
 			})
 		}
-		return systemModel, []*seed.Snap{mockKernelSeedSnap(c, snap.R(kernelRev)), mockGadgetSeedSnap(c, nil)}, nil
+		return systemModel, []*seed.Snap{mockKernelSeedSnap(snap.R(kernelRev)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -22,7 +22,6 @@ package boot
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/strutil"
@@ -289,7 +288,7 @@ func EnsureNextBootToRunModeWithTryRecoverySystemOutcome(outcome TryRecoverySyst
 	return bl.SetBootVars(vars)
 }
 
-func observeSuccessfulSystems(model *asserts.Model, m *Modeenv) (*Modeenv, error) {
+func observeSuccessfulSystems(m *Modeenv) (*Modeenv, error) {
 	// updates happen in run mode only
 	if m.Mode != "run" {
 		return m, nil

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -96,7 +96,7 @@ func (s *systemsSuite) SetUpTest(c *C) {
 	s.recoveryKernelBf = bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap",
 		"kernel.efi", bootloader.RoleRecovery)
 
-	s.seedKernelSnap = mockKernelSeedSnap(c, snap.R(1))
+	s.seedKernelSnap = mockKernelSeedSnap(snap.R(1))
 	s.seedGadgetSnap = mockGadgetSeedSnap(c, nil)
 }
 

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -81,13 +81,13 @@ func (g *grub) dir() string {
 	return filepath.Join(g.rootdir, g.basedir)
 }
 
-func (g *grub) installManagedRecoveryBootConfig(gadgetDir string) error {
+func (g *grub) installManagedRecoveryBootConfig() error {
 	assetName := g.Name() + "-recovery.cfg"
 	systemFile := filepath.Join(g.rootdir, "/EFI/ubuntu/grub.cfg")
 	return genericSetBootConfigFromAsset(systemFile, assetName)
 }
 
-func (g *grub) installManagedBootConfig(gadgetDir string) error {
+func (g *grub) installManagedBootConfig() error {
 	assetName := g.Name() + ".cfg"
 	systemFile := filepath.Join(g.rootdir, "/EFI/ubuntu/grub.cfg")
 	return genericSetBootConfigFromAsset(systemFile, assetName)
@@ -96,11 +96,11 @@ func (g *grub) installManagedBootConfig(gadgetDir string) error {
 func (g *grub) InstallBootConfig(gadgetDir string, opts *Options) error {
 	if opts != nil && opts.Role == RoleRecovery {
 		// install managed config for the recovery partition
-		return g.installManagedRecoveryBootConfig(gadgetDir)
+		return g.installManagedRecoveryBootConfig()
 	}
 	if opts != nil && opts.Role == RoleRunMode {
 		// install managed boot config that can handle kernel.efi
-		return g.installManagedBootConfig(gadgetDir)
+		return g.installManagedBootConfig()
 	}
 
 	gadgetFile := filepath.Join(gadgetDir, g.Name()+".conf")

--- a/client/interfaces_test.go
+++ b/client/interfaces_test.go
@@ -70,7 +70,7 @@ func (cs *clientSuite) TestClientInterfacesAll(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientInterfacesConnected(c *check.C) {
-	// Ask for for a summary of connected interfaces.
+	// Ask for a summary of connected interfaces.
 	cs.rsp = `{
 		"type": "sync",
 		"result": [

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -64,7 +64,7 @@ func init() {
 
 type cmdInitramfsMounts struct{}
 
-func (c *cmdInitramfsMounts) Execute(args []string) error {
+func (c *cmdInitramfsMounts) Execute([]string) error {
 	return generateInitramfsMounts()
 }
 

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -243,7 +243,7 @@ func (s *apiBaseSuite) TearDownTest(c *check.C) {
 	s.BaseTest.TearDownTest(c)
 }
 
-func (s *apiBaseSuite) mockModel(c *check.C, st *state.State, model *asserts.Model) {
+func (s *apiBaseSuite) mockModel(st *state.State, model *asserts.Model) {
 	// realistic model setup
 	if model == nil {
 		model = s.Brands.Model("can0nical", "pc", map[string]interface{}{
@@ -282,7 +282,7 @@ func (s *apiBaseSuite) daemonWithStore(c *check.C, sto snapstate.StoreService) *
 	defer st.Unlock()
 	snapstate.ReplaceStore(st, sto)
 	// registered
-	s.mockModel(c, st, nil)
+	s.mockModel(st, nil)
 
 	// don't actually try to talk to the store on snapstate.Ensure
 	// needs doing after the call to devicestate.Manager (which
@@ -301,7 +301,7 @@ func (s *apiBaseSuite) daemon(c *check.C) *daemon.Daemon {
 	return s.daemonWithStore(c, s)
 }
 
-func (s *apiBaseSuite) daemonWithOverlordMock(c *check.C) *daemon.Daemon {
+func (s *apiBaseSuite) daemonWithOverlordMock() *daemon.Daemon {
 	if s.d != nil {
 		panic("called daemon*() twice")
 	}
@@ -311,7 +311,7 @@ func (s *apiBaseSuite) daemonWithOverlordMock(c *check.C) *daemon.Daemon {
 	return s.d
 }
 
-func (s *apiBaseSuite) daemonWithOverlordMockAndStore(c *check.C) *daemon.Daemon {
+func (s *apiBaseSuite) daemonWithOverlordMockAndStore() *daemon.Daemon {
 	if s.d != nil {
 		panic("called daemon*() twice")
 	}
@@ -373,7 +373,7 @@ func (m *fakeSnapManager) Ensure() error {
 var _ overlord.StateManager = (*fakeSnapManager)(nil)
 
 func (s *apiBaseSuite) daemonWithFakeSnapManager(c *check.C) *daemon.Daemon {
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	st := d.Overlord().State()
 	runner := d.Overlord().TaskRunner()
 	d.Overlord().AddManager(newFakeSnapManager(st, runner))

--- a/daemon/api_console_conf_test.go
+++ b/daemon/api_console_conf_test.go
@@ -41,7 +41,7 @@ type consoleConfSuite struct {
 
 func (s *consoleConfSuite) TestPostConsoleConfStartRoutine(c *C) {
 	t0 := time.Now()
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock()
 	snapMgr, err := snapstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, IsNil)
 	d.Overlord().AddManager(snapMgr)

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -37,7 +37,7 @@ type seedingDebugSuite struct {
 
 func (s *seedingDebugSuite) SetUpTest(c *C) {
 	s.apiBaseSuite.SetUpTest(c)
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMock()
 }
 
 func (s *seedingDebugSuite) getSeedingDebug(c *C) interface{} {

--- a/daemon/api_debug_test.go
+++ b/daemon/api_debug_test.go
@@ -39,7 +39,7 @@ type postDebugSuite struct {
 }
 
 func (s *postDebugSuite) TestPostDebugEnsureStateSoon(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMock()
 	s.expectRootAccess()
 
 	soon := 0
@@ -119,7 +119,7 @@ func mockDurationThreshold() func() {
 func (s *postDebugSuite) getDebugTimings(c *check.C, request string) []interface{} {
 	defer mockDurationThreshold()()
 
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMock()
 
 	req, err := http.NewRequest("GET", request, nil)
 	c.Assert(err, check.IsNil)
@@ -206,7 +206,7 @@ func (s *postDebugSuite) TestGetDebugTimingsEnsureAll(c *check.C) {
 }
 
 func (s *postDebugSuite) TestGetDebugTimingsError(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMock()
 
 	req, err := http.NewRequest("GET", "/v2/debug?aspect=change-timings&ensure=unknown", nil)
 	c.Assert(err, check.IsNil)

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -76,7 +76,7 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 		"revision": "2",
 	})
 
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -86,7 +86,7 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 	st.Lock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.mockModel(c, st, oldModel)
+	s.mockModel(st, oldModel)
 	st.Unlock()
 
 	soon := 0
@@ -134,7 +134,7 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 
 func (s *modelSuite) TestGetModelNoModelAssertion(c *check.C) {
 
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -155,7 +155,7 @@ func (s *modelSuite) TestGetModelHasModelAssertion(c *check.C) {
 	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -165,7 +165,7 @@ func (s *modelSuite) TestGetModelHasModelAssertion(c *check.C) {
 	st.Lock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.mockModel(c, st, theModel)
+	s.mockModel(st, theModel)
 	st.Unlock()
 
 	// make a new get request to the model endpoint
@@ -198,7 +198,7 @@ func (s *modelSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 	theModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -208,7 +208,7 @@ func (s *modelSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 	st.Lock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.mockModel(c, st, theModel)
+	s.mockModel(st, theModel)
 	st.Unlock()
 
 	// make a new get request to the model endpoint with json as true
@@ -231,7 +231,7 @@ func (s *modelSuite) TestGetModelJSONHasModelAssertion(c *check.C) {
 
 func (s *modelSuite) TestGetModelNoSerialAssertion(c *check.C) {
 
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -257,7 +257,7 @@ func (s *modelSuite) TestGetModelHasSerialAssertion(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -268,7 +268,7 @@ func (s *modelSuite) TestGetModelHasSerialAssertion(c *check.C) {
 	defer st.Unlock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.mockModel(c, st, theModel)
+	s.mockModel(st, theModel)
 
 	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
 		"authority-id":        "my-brand",
@@ -325,7 +325,7 @@ func (s *modelSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -336,7 +336,7 @@ func (s *modelSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	defer st.Unlock()
 	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-	s.mockModel(c, st, theModel)
+	s.mockModel(st, theModel)
 
 	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
 		"authority-id":        "my-brand",

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -232,7 +232,7 @@ func (s *sideloadSuite) TestSideloadSnapJailModeAndDevmode(c *check.C) {
 		"\r\n" +
 		"true\r\n" +
 		"----hello--\r\n"
-	s.daemonWithOverlordMockAndStore(c)
+	s.daemonWithOverlordMockAndStore()
 
 	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
 	c.Assert(err, check.IsNil)
@@ -253,7 +253,7 @@ func (s *sideloadSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
 		"\r\n" +
 		"true\r\n" +
 		"----hello--\r\n"
-	s.daemonWithOverlordMockAndStore(c)
+	s.daemonWithOverlordMockAndStore()
 
 	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
 	c.Assert(err, check.IsNil)
@@ -267,7 +267,7 @@ func (s *sideloadSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
 }
 
 func (s *sideloadSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	// add the assertions first
 	st := d.Overlord().State()
 
@@ -345,7 +345,7 @@ func (s *sideloadSuite) TestSideloadSnapNoSignaturesDangerOff(c *check.C) {
 		"\r\n" +
 		"xyzzy\r\n" +
 		"----hello--\r\n"
-	s.daemonWithOverlordMockAndStore(c)
+	s.daemonWithOverlordMockAndStore()
 
 	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
 	c.Assert(err, check.IsNil)
@@ -394,7 +394,7 @@ func (s *sideloadSuite) TestSideloadSnapChangeConflict(c *check.C) {
 		"\r\n" +
 		"true\r\n" +
 		"----hello--\r\n"
-	s.daemonWithOverlordMockAndStore(c)
+	s.daemonWithOverlordMockAndStore()
 
 	defer daemon.MockUnsafeReadSnapInfo(func(path string) (*snap.Info, error) {
 		return &snap.Info{SuggestedName: "foo"}, nil
@@ -626,7 +626,7 @@ func (s *trySuite) TestTrySnapNotDir(c *check.C) {
 }
 
 func (s *trySuite) TestTryChangeConflict(c *check.C) {
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	st := d.Overlord().State()
 
 	// mock a try dir

--- a/daemon/api_snap_conf_test.go
+++ b/daemon/api_snap_conf_test.go
@@ -276,7 +276,7 @@ func (s *snapConfSuite) TestSetConfNumber(c *check.C) {
 }
 
 func (s *snapConfSuite) TestSetConfBadSnap(c *check.C) {
-	s.daemonWithOverlordMockAndStore(c)
+	s.daemonWithOverlordMockAndStore()
 
 	text, err := json.Marshal(map[string]interface{}{"key": "value"})
 	c.Assert(err, check.IsNil)

--- a/daemon/api_snap_file_test.go
+++ b/daemon/api_snap_file_test.go
@@ -38,7 +38,7 @@ type snapFileSuite struct {
 }
 
 func (s *snapFileSuite) TestGetFile(c *check.C) {
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock()
 	st := d.Overlord().State()
 
 	type scenario struct {

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -418,7 +418,7 @@ func (s *snapsSuite) TestSnapsInfoFilterRemote(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapsVerifyMultiSnapInstruction(c *check.C) {
-	s.daemonWithOverlordMockAndStore(c)
+	s.daemonWithOverlordMockAndStore()
 
 	buf := strings.NewReader(`{"action": "install","snaps":["ubuntu-core"]}`)
 	req, err := http.NewRequest("POST", "/v2/snaps", buf)
@@ -431,7 +431,7 @@ func (s *snapsSuite) TestPostSnapsVerifyMultiSnapInstruction(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapsUnsupportedMultiOp(c *check.C) {
-	s.daemonWithOverlordMockAndStore(c)
+	s.daemonWithOverlordMockAndStore()
 
 	buf := strings.NewReader(`{"action": "switch","snaps":["foo"]}`)
 	req, err := http.NewRequest("POST", "/v2/snaps", buf)
@@ -444,7 +444,7 @@ func (s *snapsSuite) TestPostSnapsUnsupportedMultiOp(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapsNoWeirdses(c *check.C) {
-	s.daemonWithOverlordMockAndStore(c)
+	s.daemonWithOverlordMockAndStore()
 
 	// one could add more actions here ... 🤷
 	for _, action := range []string{"install", "refresh", "remove"} {
@@ -485,7 +485,7 @@ func (s *snapsSuite) testPostSnapsOp(c *check.C, contentType string) {
 		return []string{"fake1", "fake2"}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 
 	buf := bytes.NewBufferString(`{"action": "refresh"}`)
 	req, err := http.NewRequest("POST", "/v2/snaps", buf)
@@ -1114,7 +1114,7 @@ func (s *snapsSuite) TestPostSnapWithChannel(c *check.C) {
 }
 
 func (s *snapsSuite) testPostSnap(c *check.C, withChannel bool) {
-	d := s.daemonWithOverlordMock(c)
+	d := s.daemonWithOverlordMock()
 
 	soon := 0
 	var origEnsureStateSoon func(*state.State)
@@ -1171,7 +1171,7 @@ func (s *snapsSuite) testPostSnap(c *check.C, withChannel bool) {
 }
 
 func (s *snapsSuite) TestPostSnapVerifySnapInstruction(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMock()
 
 	buf := bytes.NewBufferString(`{"action": "install"}`)
 	req, err := http.NewRequest("POST", "/v2/snaps/ubuntu-core", buf)
@@ -1183,7 +1183,7 @@ func (s *snapsSuite) TestPostSnapVerifySnapInstruction(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapCohortUnsupportedAction(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMock()
 	const expectedErr = "cohort-key can only be specified for install, refresh, or switch"
 
 	for _, action := range []string{"remove", "revert", "enable", "disable", "xyzzy"} {
@@ -1198,7 +1198,7 @@ func (s *snapsSuite) TestPostSnapCohortUnsupportedAction(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapLeaveCohortUnsupportedAction(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMock()
 	const expectedErr = "leave-cohort can only be specified for refresh or switch"
 
 	for _, action := range []string{"install", "remove", "revert", "enable", "disable", "xyzzy"} {
@@ -1213,7 +1213,7 @@ func (s *snapsSuite) TestPostSnapLeaveCohortUnsupportedAction(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapCohortIncompat(c *check.C) {
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMock()
 	type T struct {
 		opts   string
 		errmsg string

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -46,7 +46,7 @@ type snapshotSuite struct {
 
 func (s *snapshotSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
-	s.daemonWithOverlordMock(c)
+	s.daemonWithOverlordMock()
 	s.expectAuthenticatedAccess()
 	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage"})
 }

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -127,7 +127,7 @@ func (s *systemsSuite) TestSystemsGetSome(c *check.C) {
 	err := m.WriteTo("")
 	c.Assert(err, check.IsNil)
 
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -205,7 +205,7 @@ func (s *systemsSuite) TestSystemsGetNone(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// model assertion setup
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -233,7 +233,7 @@ func (s *systemsSuite) TestSystemActionRequestErrors(c *check.C) {
 	err := m.WriteTo("")
 	c.Assert(err, check.IsNil)
 
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
@@ -444,7 +444,7 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		// device model
 		assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 		assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
-		s.mockModel(c, st, model)
+		s.mockModel(st, model)
 		if tc.currentMode == "run" {
 			// only set in run mode
 			st.Set("seeded-systems", currentSystem)
@@ -530,7 +530,7 @@ func (s *systemsSuite) TestSystemActionBrokenSeed(c *check.C) {
 	err := m.WriteTo("")
 	c.Assert(err, check.IsNil)
 
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
@@ -558,7 +558,7 @@ func (s *systemsSuite) TestSystemActionBrokenSeed(c *check.C) {
 }
 
 func (s *systemsSuite) TestSystemActionNonRoot(c *check.C) {
-	d := s.daemonWithOverlordMockAndStore(c)
+	d := s.daemonWithOverlordMockAndStore()
 	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
 	c.Assert(err, check.IsNil)
 	mgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -366,7 +366,7 @@ func (s *themesSuite) TestThemesCmdGet(c *C) {
 }
 
 func (s *themesSuite) daemonWithIfaceMgr(c *C) *daemon.Daemon {
-	d := s.apiBaseSuite.daemonWithOverlordMock(c)
+	d := s.apiBaseSuite.daemonWithOverlordMock()
 
 	overlord := d.Overlord()
 	st := overlord.State()

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1205,7 +1205,7 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeSchema(c *C) {
 	} {
 		c.Logf("tc: %v %+v", i, tc.s)
 
-		err := gadget.ValidateVolume("name", &gadget.Volume{Schema: tc.s}, nil, nil)
+		err := gadget.ValidateVolume("name", &gadget.Volume{Schema: tc.s}, nil)
 		if tc.err != "" {
 			c.Check(err, ErrorMatches, tc.err)
 		} else {
@@ -1235,7 +1235,7 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeName(c *C) {
 	} {
 		c.Logf("tc: %v %+v", i, tc.s)
 
-		err := gadget.ValidateVolume(tc.s, &gadget.Volume{}, nil, nil)
+		err := gadget.ValidateVolume(tc.s, &gadget.Volume{}, nil)
 		if tc.err != "" {
 			c.Check(err, ErrorMatches, tc.err)
 		} else {
@@ -1250,7 +1250,7 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeDuplicateStructures(c *C) {
 			{Name: "duplicate", Type: "bare", Size: 1024},
 			{Name: "duplicate", Type: "21686148-6449-6E6F-744E-656564454649", Size: 2048},
 		},
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, ErrorMatches, `structure name "duplicate" is not unique`)
 }
 
@@ -1260,7 +1260,7 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeDuplicateFsLabel(c *C) {
 			{Label: "foo", Type: "21686148-6449-6E6F-744E-656564454123", Size: quantity.SizeMiB},
 			{Label: "foo", Type: "21686148-6449-6E6F-744E-656564454649", Size: quantity.SizeMiB},
 		},
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, ErrorMatches, `filesystem label "foo" is not unique`)
 
 	// writable isn't special
@@ -1274,27 +1274,23 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeDuplicateFsLabel(c *C) {
 		{true, "writable", `filesystem label "writable" is not unique`},
 		{true, "ubuntu-data", `filesystem label "ubuntu-data" is not unique`},
 	} {
-		for _, mod := range []*modelCharateristics{
-			{classic: false, systemSeed: x.systemSeed},
-			{classic: true, systemSeed: x.systemSeed},
-		} {
-			err = gadget.ValidateVolume("name", &gadget.Volume{
-				Structure: []gadget.VolumeStructure{{
-					Name:  "data1",
-					Role:  gadget.SystemData,
-					Label: x.label,
-					Type:  "21686148-6449-6E6F-744E-656564454123",
-					Size:  quantity.SizeMiB,
-				}, {
-					Name:  "data2",
-					Role:  gadget.SystemData,
-					Label: x.label,
-					Type:  "21686148-6449-6E6F-744E-656564454649",
-					Size:  quantity.SizeMiB,
-				}},
-			}, mod, nil)
-			c.Assert(err, ErrorMatches, x.errMsg)
-		}
+
+		err = gadget.ValidateVolume("name", &gadget.Volume{
+			Structure: []gadget.VolumeStructure{{
+				Name:  "data1",
+				Role:  gadget.SystemData,
+				Label: x.label,
+				Type:  "21686148-6449-6E6F-744E-656564454123",
+				Size:  quantity.SizeMiB,
+			}, {
+				Name:  "data2",
+				Role:  gadget.SystemData,
+				Label: x.label,
+				Type:  "21686148-6449-6E6F-744E-656564454649",
+				Size:  quantity.SizeMiB,
+			}},
+		}, nil)
+		c.Assert(err, ErrorMatches, x.errMsg)
 	}
 
 	// nor is system-boot
@@ -1310,7 +1306,7 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeDuplicateFsLabel(c *C) {
 			Type:  "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
 			Size:  quantity.SizeMiB,
 		}},
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, ErrorMatches, `filesystem label "system-boot" is not unique`)
 }
 
@@ -1320,7 +1316,7 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeErrorsWrapped(c *C) {
 			{Type: "bare", Size: 1024},
 			{Type: "bogus", Size: 1024},
 		},
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, ErrorMatches, `invalid structure #1: invalid type "bogus": invalid format`)
 
 	err = gadget.ValidateVolume("name", &gadget.Volume{
@@ -1328,14 +1324,14 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeErrorsWrapped(c *C) {
 			{Type: "bare", Size: 1024},
 			{Type: "bogus", Size: 1024, Name: "foo"},
 		},
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, ErrorMatches, `invalid structure #1 \("foo"\): invalid type "bogus": invalid format`)
 
 	err = gadget.ValidateVolume("name", &gadget.Volume{
 		Structure: []gadget.VolumeStructure{
 			{Type: "bare", Name: "foo", Size: 1024, Content: []gadget.VolumeContent{{UnresolvedSource: "foo"}}},
 		},
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, ErrorMatches, `invalid structure #0 \("foo"\): invalid content #0: cannot use non-image content for bare file system`)
 }
 

--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -66,7 +66,7 @@ func writeContent(ds *gadget.OnDiskStructure, gadgetRoot string, observer gadget
 			return err
 		}
 	case ds.HasFilesystem():
-		if err := writeFilesystemContent(ds, gadgetRoot, observer); err != nil {
+		if err := writeFilesystemContent(ds, observer); err != nil {
 			return err
 		}
 	}
@@ -95,7 +95,7 @@ func mountFilesystem(ds *gadget.OnDiskStructure, baseMntPoint string) error {
 	return nil
 }
 
-func writeFilesystemContent(ds *gadget.OnDiskStructure, gadgetRoot string, observer gadget.ContentObserver) (err error) {
+func writeFilesystemContent(ds *gadget.OnDiskStructure, observer gadget.ContentObserver) (err error) {
 	mountpoint := filepath.Join(contentMountpoint, strconv.Itoa(ds.Index))
 	if err := os.MkdirAll(mountpoint, 0755); err != nil {
 		return err

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -611,7 +611,7 @@ func (f *mountedFilesystemUpdater) checkpointPrefix(dstRoot, target string, back
 	return nil
 }
 
-func (f *mountedFilesystemUpdater) ignoreChange(change *ContentChange, backupPath string) error {
+func (f *mountedFilesystemUpdater) ignoreChange(backupPath string) error {
 	preserveStamp := backupPath + ".preserve"
 	backupName := backupPath + ".backup"
 	sameStamp := backupPath + ".same"
@@ -640,7 +640,7 @@ func (f *mountedFilesystemUpdater) observedBackupOrCheckpointFile(dstRoot, sourc
 		}
 		if act == ChangeIgnore {
 			// observer asked for the change to be ignored
-			if err := f.ignoreChange(change, backupPath); err != nil {
+			if err := f.ignoreChange(backupPath); err != nil {
 				return fmt.Errorf("cannot ignore content change: %v", err)
 			}
 		}

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -93,7 +93,7 @@ func ruleValidateVolumes(vols map[string]*Volume, model Model, extra *Validation
 	}
 
 	for name, v := range vols {
-		if err := ruleValidateVolume(name, v, expectedSeed); err != nil {
+		if err := ruleValidateVolume(v, expectedSeed); err != nil {
 			return fmt.Errorf("invalid volume %q: %v", name, err)
 		}
 	}
@@ -117,7 +117,7 @@ func ruleValidateVolumes(vols map[string]*Volume, model Model, extra *Validation
 	return nil
 }
 
-func ruleValidateVolume(name string, vol *Volume, expectedSeed bool) error {
+func ruleValidateVolume(vol *Volume, expectedSeed bool) error {
 	for idx, s := range vol.Structure {
 		if err := ruleValidateVolumeStructure(&s, expectedSeed); err != nil {
 			return fmt.Errorf("invalid structure %v: %v", fmtIndexAndName(idx, s.Name), err)

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -158,10 +158,8 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	}
 
 	// Get the files that this snap should have
-	content, err := b.deriveContent(spec.(*Specification), snapInfo)
-	if err != nil {
-		return fmt.Errorf("cannot obtain expected DBus configuration files for snap %q: %s", snapName, err)
-	}
+	content := b.deriveContent(spec.(*Specification), snapInfo)
+
 	glob := fmt.Sprintf("%s.conf", interfaces.SecurityTagGlob(snapName))
 	dir := dirs.SnapDBusSystemPolicyDir
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -188,7 +186,7 @@ func (b *Backend) Remove(snapName string) error {
 
 // deriveContent combines security snippets collected from all the interfaces
 // affecting a given snap into a content map applicable to EnsureDirState.
-func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (content map[string]osutil.FileState, err error) {
+func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (content map[string]osutil.FileState) {
 	for _, appInfo := range snapInfo.Apps {
 		securityTag := appInfo.SecurityTag()
 		appSnippets := spec.SnippetForTag(securityTag)
@@ -215,7 +213,7 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (conte
 		addContent(securityTag, hookSnippets, content)
 	}
 
-	return content, nil
+	return content
 }
 
 func addContent(securityTag string, snippet string, content map[string]osutil.FileState) {

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -234,7 +234,7 @@ func checkSlotConnectionAltConstraints(connc *ConnectCandidate, altConstraints [
 	return nil, firstErr
 }
 
-func checkSnapTypeSlotInstallationConstraints1(ic *InstallCandidateMinimalCheck, slot *snap.SlotInfo, constraints *asserts.SlotInstallationConstraints) error {
+func checkSnapTypeSlotInstallationConstraints1(slot *snap.SlotInfo, constraints *asserts.SlotInstallationConstraints) error {
 	if err := checkSnapType(slot.Snap, constraints.SlotSnapTypes); err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func checkSnapTypeSlotInstallationConstraints1(ic *InstallCandidateMinimalCheck,
 	return nil
 }
 
-func checkMinimalSlotInstallationAltConstraints(ic *InstallCandidateMinimalCheck, slot *snap.SlotInfo, altConstraints []*asserts.SlotInstallationConstraints) (bool, error) {
+func checkMinimalSlotInstallationAltConstraints(slot *snap.SlotInfo, altConstraints []*asserts.SlotInstallationConstraints) (bool, error) {
 	var firstErr error
 	var hasSnapTypeConstraints bool
 	// OR of constraints
@@ -253,7 +253,7 @@ func checkMinimalSlotInstallationAltConstraints(ic *InstallCandidateMinimalCheck
 			continue
 		}
 		hasSnapTypeConstraints = true
-		err := checkSnapTypeSlotInstallationConstraints1(ic, slot, constraints)
+		err := checkSnapTypeSlotInstallationConstraints1(slot, constraints)
 		if err == nil {
 			return true, nil
 		}

--- a/interfaces/policy/policy.go
+++ b/interfaces/policy/policy.go
@@ -281,12 +281,12 @@ type InstallCandidateMinimalCheck struct {
 }
 
 func (ic *InstallCandidateMinimalCheck) checkSlotRule(slot *snap.SlotInfo, rule *asserts.SlotRule) error {
-	if hasConstraints, err := checkMinimalSlotInstallationAltConstraints(ic, slot, rule.DenyInstallation); hasConstraints && err == nil {
+	if hasConstraints, err := checkMinimalSlotInstallationAltConstraints(slot, rule.DenyInstallation); hasConstraints && err == nil {
 		return fmt.Errorf("installation denied by %q slot rule of interface %q", slot.Name, slot.Interface)
 	}
 
 	// TODO check that the snap is an app or gadget if allow-installation had no slot-snap-type constraints
-	if _, err := checkMinimalSlotInstallationAltConstraints(ic, slot, rule.AllowInstallation); err != nil {
+	if _, err := checkMinimalSlotInstallationAltConstraints(slot, rule.AllowInstallation); err != nil {
 		return fmt.Errorf("installation not allowed by %q slot rule of interface %q", slot.Name, slot.Interface)
 	}
 	return nil

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1745,7 +1745,7 @@ func (m *DeviceManager) runFDESetupHook(req *fde.SetupRequest) ([]byte, error) {
 	return hookOutput, nil
 }
 
-func (m *DeviceManager) checkFDEFeatures(st *state.State) error {
+func (m *DeviceManager) checkFDEFeatures() error {
 	// TODO: move most of this to kernel/fde.Features
 	// Run fde-setup hook with "op":"features". If the hook
 	// returns any {"features":[...]} reply we consider the

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1136,7 +1136,7 @@ volumes:
 	snapf, err := snapfile.Open(info.MountDir())
 	c.Assert(err, IsNil)
 
-	s.setupBrands(c)
+	s.setupBrands()
 
 	oldModel := fakeMyModel(map[string]interface{}{
 		"architecture": "amd64",
@@ -1267,7 +1267,7 @@ version: 123
 	snapf, err := snapfile.Open(info.MountDir())
 	c.Assert(err, IsNil)
 
-	s.setupBrands(c)
+	s.setupBrands()
 	// model assertion in device context
 	oldModel := fakeMyModel(map[string]interface{}{
 		"architecture": "amd64",

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -257,7 +257,7 @@ func (s *deviceMgrBaseSuite) seeding() {
 func (s *deviceMgrBaseSuite) makeModelAssertionInState(c *C, brandID, model string, extras map[string]interface{}) *asserts.Model {
 	modelAs := s.brands.Model(brandID, model, extras)
 
-	s.setupBrands(c)
+	s.setupBrands()
 	assertstatetest.AddMany(s.state, modelAs)
 	return modelAs
 }
@@ -278,7 +278,7 @@ func (s *deviceMgrBaseSuite) setPCModelInState(c *C) {
 	})
 }
 
-func (s *deviceMgrBaseSuite) setupBrands(c *C) {
+func (s *deviceMgrBaseSuite) setupBrands() {
 	assertstatetest.AddMany(s.state, s.brands.AccountsAndKeys("my-brand")...)
 	otherAcct := assertstest.NewAccount(s.storeSigning, "other-brand", map[string]interface{}{
 		"account-id": "other-brand",
@@ -610,7 +610,7 @@ func (s *deviceMgrSuite) TestCheckGadget(c *C) {
 
 	gadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: other-gadget, version: 0}", nil)
 
-	s.setupBrands(c)
+	s.setupBrands()
 	// model assertion in device context
 	model := fakeMyModel(map[string]interface{}{
 		"architecture": "amd64",
@@ -668,7 +668,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassic(c *C) {
 
 	gadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: other-gadget, version: 0}", nil)
 
-	s.setupBrands(c)
+	s.setupBrands()
 	// model assertion in device context
 	model := fakeMyModel(map[string]interface{}{
 		"classic": "true",
@@ -720,7 +720,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassicGadgetNotSpecified(c *C) {
 
 	gadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: gadget, version: 0}", nil)
 
-	s.setupBrands(c)
+	s.setupBrands()
 	// model assertion in device context
 	model := fakeMyModel(map[string]interface{}{
 		"classic": "true",
@@ -772,7 +772,7 @@ func (s *deviceMgrSuite) TestCheckKernel(c *C) {
 	c.Check(err, ErrorMatches, `cannot install a kernel snap on classic`)
 	release.OnClassic = false
 
-	s.setupBrands(c)
+	s.setupBrands()
 	// model assertion in device context
 	model := fakeMyModel(map[string]interface{}{
 		"architecture": "amd64",

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -337,5 +337,5 @@ func DeviceManagerCheckEncryption(mgr *DeviceManager, st *state.State, deviceCtx
 }
 
 func DeviceManagerCheckFDEFeatures(mgr *DeviceManager, st *state.State) error {
-	return mgr.checkFDEFeatures(st)
+	return mgr.checkFDEFeatures()
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -484,7 +484,7 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 	)
 	if kernelInfo, err := snapstate.KernelInfo(st, deviceCtx); err == nil {
 		if hasFDESetupHook = hasFDESetupHookInKernel(kernelInfo); hasFDESetupHook {
-			checkEncryptionErr = m.checkFDEFeatures(st)
+			checkEncryptionErr = m.checkFDEFeatures()
 		}
 	}
 	// Note that having a fde-setup hook will disable the build-in

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -149,7 +149,7 @@ func (s *createSystemSuite) TestCreateSystemFromAssertedSnaps(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.setupBrands(c)
+	s.setupBrands()
 	infos := s.makeEssentialSnapInfos(c)
 	infos["other-present"] = s.makeSnap(c, "other-present", snap.R(5))
 	infos["other-required"] = s.makeSnap(c, "other-required", snap.R(6))
@@ -265,7 +265,7 @@ func (s *createSystemSuite) TestCreateSystemFromUnassertedSnaps(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.setupBrands(c)
+	s.setupBrands()
 	infos := s.makeEssentialSnapInfos(c)
 	// unasserted with local revision
 	infos["other-unasserted"] = s.makeSnap(c, "other-unasserted", snap.R(-1))
@@ -350,7 +350,7 @@ func (s *createSystemSuite) TestCreateSystemWithSomeSnapsAlreadyExisting(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.setupBrands(c)
+	s.setupBrands()
 	infos := s.makeEssentialSnapInfos(c)
 	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
 		"architecture": "amd64",
@@ -482,7 +482,7 @@ func (s *createSystemSuite) TestCreateSystemInfoAndAssertsChecks(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.setupBrands(c)
+	s.setupBrands()
 	// missing info for the pc snap
 	infos["pc-kernel"] = s.makeSnap(c, "pc-kernel", snap.R(1))
 	infos["core20"] = s.makeSnap(c, "core20", snap.R(3))
@@ -575,7 +575,7 @@ func (s *createSystemSuite) TestCreateSystemGetInfoErr(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.setupBrands(c)
+	s.setupBrands()
 	// missing info for the pc snap
 	infos := s.makeEssentialSnapInfos(c)
 	infos["other-required"] = s.makeSnap(c, "other-required", snap.R(5))
@@ -655,7 +655,7 @@ func (s *createSystemSuite) TestCreateSystemNonUC20(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.setupBrands(c)
+	s.setupBrands()
 	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		"base":         "core18",
@@ -683,7 +683,7 @@ func (s *createSystemSuite) TestCreateSystemImplicitSnaps(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.setupBrands(c)
+	s.setupBrands()
 	infos := s.makeEssentialSnapInfos(c)
 
 	// snapd snap is implicitly required
@@ -741,7 +741,7 @@ func (s *createSystemSuite) TestCreateSystemObserverErr(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.setupBrands(c)
+	s.setupBrands()
 	infos := s.makeEssentialSnapInfos(c)
 
 	// snapd snap is implicitly required

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -46,10 +46,9 @@ type refreshSuite struct {
 
 var _ = Suite(&refreshSuite{})
 
-func mockRefreshCandidate(snapName, instanceKey, channel, version string, revision snap.Revision) interface{} {
+func mockRefreshCandidate(snapName, channel, version string, revision snap.Revision) interface{} {
 	sup := &snapstate.SnapSetup{
-		Channel:     channel,
-		InstanceKey: instanceKey,
+		Channel: channel,
 		SideInfo: &snap.SideInfo{
 			Revision: revision,
 			RealName: snapName,
@@ -86,7 +85,7 @@ var refreshFromHookTests = []struct {
 }, {
 	args: []string{"refresh", "--pending"},
 	refreshCandidates: map[string]interface{}{
-		"snap1": mockRefreshCandidate("snap1", "", "edge", "v1", snap.Revision{N: 3}),
+		"snap1": mockRefreshCandidate("snap1", "edge", "v1", snap.Revision{N: 3}),
 	},
 	stdout: "pending: ready\nchannel: edge\nversion: v1\nrevision: 3\nbase: false\nrestart: false\n",
 }, {
@@ -95,13 +94,13 @@ var refreshFromHookTests = []struct {
 }, {
 	args: []string{"refresh", "--pending"},
 	refreshCandidates: map[string]interface{}{
-		"snap1-base": mockRefreshCandidate("snap1-base", "", "edge", "v1", snap.Revision{N: 3}),
+		"snap1-base": mockRefreshCandidate("snap1-base", "edge", "v1", snap.Revision{N: 3}),
 	},
 	stdout: "pending: none\nchannel: stable\nbase: true\nrestart: false\n",
 }, {
 	args: []string{"refresh", "--pending"},
 	refreshCandidates: map[string]interface{}{
-		"kernel": mockRefreshCandidate("kernel", "", "edge", "v1", snap.Revision{N: 3}),
+		"kernel": mockRefreshCandidate("kernel", "edge", "v1", snap.Revision{N: 3}),
 	},
 	stdout: "pending: none\nchannel: stable\nbase: false\nrestart: true\n",
 }, {
@@ -182,7 +181,7 @@ version: 1
 `)
 
 	candidates := map[string]interface{}{
-		"snap1-base": mockRefreshCandidate("snap1-base", "", "edge", "v1", snap.Revision{N: 3}),
+		"snap1-base": mockRefreshCandidate("snap1-base", "edge", "v1", snap.Revision{N: 3}),
 	}
 	s.st.Set("refresh-candidates", candidates)
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -92,7 +92,7 @@ func (am *AssertsMock) SetupAsserts(c *C, st *state.State, cleaner cleaner) {
 	st.Unlock()
 }
 
-func (am *AssertsMock) mockModel(c *C, extraHeaders map[string]interface{}) *asserts.Model {
+func (am *AssertsMock) mockModel(extraHeaders map[string]interface{}) *asserts.Model {
 	model := map[string]interface{}{
 		"type":         "model",
 		"authority-id": "my-brand",
@@ -108,12 +108,12 @@ func (am *AssertsMock) mockModel(c *C, extraHeaders map[string]interface{}) *ass
 }
 
 func (am *AssertsMock) MockModel(c *C, extraHeaders map[string]interface{}) {
-	model := am.mockModel(c, extraHeaders)
+	model := am.mockModel(extraHeaders)
 	am.cleaner.AddCleanup(snapstatetest.MockDeviceModel(model))
 }
 
 func (am *AssertsMock) TrivialDeviceContext(c *C, extraHeaders map[string]interface{}) *snapstatetest.TrivialDeviceContext {
-	model := am.mockModel(c, extraHeaders)
+	model := am.mockModel(extraHeaders)
 	return &snapstatetest.TrivialDeviceContext{DeviceModel: model}
 }
 
@@ -351,7 +351,7 @@ func (s *interfaceManagerSuite) TestRepoAvailable(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectTask(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	_ = s.manager(c)
@@ -456,7 +456,7 @@ func (s *interfaceManagerSuite) TestConnectTasksDelayProfilesFlag(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestBatchConnectTasks(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, consumer2Yaml)
 	s.mockSnap(c, producerYaml)
@@ -525,7 +525,7 @@ func (s *interfaceManagerSuite) TestBatchConnectTasks(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestBatchConnectTasksNoHooks(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumer2Yaml)
 	s.mockSnap(c, producer2Yaml)
 	_ = s.manager(c)
@@ -620,7 +620,7 @@ var connectHooksTests = []interfaceHooksTestData{{
 }}
 
 func (s *interfaceManagerSuite) TestConnectTaskHookdEdges(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	_ = s.manager(c)
 	for _, hooks := range connectHooksTests {
@@ -677,7 +677,7 @@ func (s *interfaceManagerSuite) TestConnectTaskHookdEdges(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectTaskHooksConditionals(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	_ = s.manager(c)
 	for _, hooks := range connectHooksTests {
@@ -716,7 +716,7 @@ func (s *interfaceManagerSuite) TestConnectTaskHooksConditionals(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestDisconnectTaskHooksConditionals(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	hooksTests := []interfaceHooksTestData{{
 		consumer:  []string{"disconnect-plug-plug"},
@@ -772,7 +772,7 @@ func (s *interfaceManagerSuite) TestDisconnectTaskHooksConditionals(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestParallelInstallConnectTask(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnapInstance(c, "consumer_foo", consumerYaml)
 	s.mockSnapInstance(c, "producer", producerYaml)
 	_ = s.manager(c)
@@ -850,7 +850,7 @@ func (s *interfaceManagerSuite) TestParallelInstallConnectTask(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectAlreadyConnected(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	_ = s.manager(c)
@@ -957,7 +957,7 @@ func (s *interfaceManagerSuite) TestDisconnectConflictsSlotSnapOnLink(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectDoesConflict(c *C) {
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -982,7 +982,7 @@ func (s *interfaceManagerSuite) TestConnectDoesConflict(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectBecomeOperationalNoConflict(c *C) {
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -1174,7 +1174,7 @@ func (s *interfaceManagerSuite) TestAutoconnectRetryOnConnect(c *C) {
 func (s *interfaceManagerSuite) TestAutoconnectIgnoresSetupProfilesPhase2(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -1216,7 +1216,7 @@ func (s *interfaceManagerSuite) TestAutoconnectIgnoresSetupProfilesPhase2(c *C) 
 func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	_ = s.manager(c)
@@ -1267,7 +1267,7 @@ func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {
 func (s *interfaceManagerSuite) TestConnectTaskCheckInterfaceMismatch(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	_ = s.manager(c)
@@ -1301,7 +1301,7 @@ func (s *interfaceManagerSuite) TestConnectTaskCheckInterfaceMismatch(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectTaskNoSuchSlot(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	_ = s.manager(c)
@@ -1313,7 +1313,7 @@ func (s *interfaceManagerSuite) TestConnectTaskNoSuchSlot(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectTaskNoSuchPlug(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	_ = s.manager(c)
@@ -1394,7 +1394,7 @@ slots:
         - $SLOT_PUBLISHER_ID
 `))
 	defer restore()
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 
 	setup()
 	_ = s.manager(c)
@@ -1518,7 +1518,7 @@ slots:
     allow-connection: false
 `))
 	defer restore()
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.MockSnapDecl(c, "producer", "one-publisher", nil)
 	s.mockSnap(c, producerYaml)
@@ -1554,7 +1554,7 @@ slots:
 }
 
 func (s *interfaceManagerSuite) TestDisconnectTask(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	plugSnap := s.mockSnap(c, consumerYaml)
 	slotSnap := s.mockSnap(c, producerYaml)
 
@@ -1635,7 +1635,7 @@ func (s *interfaceManagerSuite) getConnection(c *C, plugSnap, plugName, slotSnap
 func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSnap, slotName string) {
 	// Put two snaps in place They consumer has an plug that can be connected
 	// to slot on the producer.
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -1702,7 +1702,7 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 }
 
 func (s *interfaceManagerSuite) TestDisconnectUndo(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	var consumerYaml = `
 name: consumer
 version: 1
@@ -1772,7 +1772,7 @@ slots:
 }
 
 func (s *interfaceManagerSuite) TestForgetUndo(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
@@ -1829,7 +1829,7 @@ func (s *interfaceManagerSuite) TestForgetUndo(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestStaleConnectionsIgnoredInReloadConnections(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	// Put a stray connection in the state so that it automatically gets set up
 	// when we create the manager.
@@ -1865,7 +1865,7 @@ func (s *interfaceManagerSuite) TestStaleConnectionsIgnoredInReloadConnections(c
 }
 
 func (s *interfaceManagerSuite) TestStaleConnectionsRemoved(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.state.Lock()
 	// Add stale connection to the state
@@ -1892,7 +1892,7 @@ func (s *interfaceManagerSuite) TestStaleConnectionsRemoved(c *C) {
 }
 
 func (s *interfaceManagerSuite) testForget(c *C, plugSnap, plugName, slotSnap, slotName string) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -2003,15 +2003,15 @@ func (s *interfaceManagerSuite) TestForgetActiveConnection(c *C) {
 	})
 }
 
-func (s *interfaceManagerSuite) mockSecBackend(c *C, backend interfaces.SecurityBackend) {
+func (s *interfaceManagerSuite) mockSecBackend(backend interfaces.SecurityBackend) {
 	s.extraBackends = append(s.extraBackends, backend)
 }
 
-func (s *interfaceManagerSuite) mockIface(c *C, iface interfaces.Interface) {
+func (s *interfaceManagerSuite) mockIface(iface interfaces.Interface) {
 	s.extraIfaces = append(s.extraIfaces, iface)
 }
 
-func (s *interfaceManagerSuite) mockIfaces(c *C, ifaces ...interfaces.Interface) {
+func (s *interfaceManagerSuite) mockIfaces(ifaces ...interfaces.Interface) {
 	s.extraIfaces = append(s.extraIfaces, ifaces...)
 }
 
@@ -2070,7 +2070,7 @@ func (s *interfaceManagerSuite) mockUpdatedSnap(c *C, yamlText string, revision 
 	return snapInfo
 }
 
-func (s *interfaceManagerSuite) addSetupSnapSecurityChange(c *C, snapsup *snapstate.SnapSetup) *state.Change {
+func (s *interfaceManagerSuite) addSetupSnapSecurityChange(snapsup *snapstate.SnapSetup) *state.Change {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2088,7 +2088,7 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChange(c *C, snapsup *snapst
 	return change
 }
 
-func (s *interfaceManagerSuite) addRemoveSnapSecurityChange(c *C, snapName string) *state.Change {
+func (s *interfaceManagerSuite) addRemoveSnapSecurityChange(snapName string) *state.Change {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2105,7 +2105,7 @@ func (s *interfaceManagerSuite) addRemoveSnapSecurityChange(c *C, snapName strin
 	return change
 }
 
-func (s *interfaceManagerSuite) addDiscardConnsChange(c *C, snapName string) (*state.Change, *state.Task) {
+func (s *interfaceManagerSuite) addDiscardConnsChange(snapName string) (*state.Change, *state.Task) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2335,7 +2335,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsUndesiredFlag(c *C)
 	mgr := s.manager(c)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2382,7 +2382,7 @@ func (s *interfaceManagerSuite) TestBadInterfacesWarning(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2419,7 +2419,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsPlugs(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2456,7 +2456,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlots(c *C) {
 	s.MockModel(c, nil)
 
 	// Mock the interface that will be used by the test
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	// Add an OS snap.
 	s.mockSnap(c, ubuntuCoreSnapYaml)
 	// Add a consumer snap with unconnect plug (interface "test")
@@ -2469,7 +2469,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlots(c *C) {
 	snapInfo := s.mockSnap(c, producerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2511,7 +2511,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlotsMultiple
 	s.MockModel(c, nil)
 
 	// Mock the interface that will be used by the test
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	// Add an OS snap.
 	s.mockSnap(c, ubuntuCoreSnapYaml)
 	// Add a consumer snap with unconnect plug (interface "test")
@@ -2526,7 +2526,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlotsMultiple
 	snapInfo := s.mockSnap(c, producerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2575,7 +2575,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectSlotsIfAlter
 	s.MockModel(c, nil)
 
 	// Mock the interface that will be used by the test
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 	// Add an OS snap.
 	s.mockSnap(c, ubuntuCoreSnapYaml)
 	// Add a consumer snap with unconnect plug (interface "test")
@@ -2591,7 +2591,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectSlotsIfAlter
 	snapInfo := s.mockSnap(c, producerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2650,7 +2650,7 @@ slots:
 `))
 	defer restore()
 	// Add the producer snap
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.MockSnapDecl(c, "producer", "one-publisher", nil)
 	s.mockSnap(c, producerYaml)
 
@@ -2664,7 +2664,7 @@ slots:
 	snapInfo := s.mockSnap(c, consumerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			SnapID:   snapInfo.SnapID,
@@ -2798,7 +2798,7 @@ slots:
 `))
 	defer restore()
 	// Add the producer snap
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.MockSnapDecl(c, "producer", "one-publisher", nil)
 	s.mockSnap(c, producerYaml)
 
@@ -2818,7 +2818,7 @@ slots:
 	snapInfo := s.mockSnap(c, consumerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			SnapID:   snapInfo.SnapID,
@@ -2867,7 +2867,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityKeepsExistingConnectionSt
 	s.state.Unlock()
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2959,7 +2959,7 @@ slots:
 			return nil
 		},
 	}
-	s.mockSecBackend(c, secBackend)
+	s.mockSecBackend(secBackend)
 	//s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "content"})
 
 	// Create the interface manager. This indirectly adds the snaps to the
@@ -3110,8 +3110,8 @@ slots:
 			return nil
 		},
 	}
-	s.mockSecBackend(c, secBackend)
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "unrelated"})
+	s.mockSecBackend(secBackend)
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "unrelated"})
 
 	// Create the interface manager. This indirectly adds the snaps to the
 	// repository and reloads the connection.
@@ -3220,7 +3220,7 @@ slots:
 	snaptest.MockSnapInstance(c, "", producerV2Yaml, &snap.SideInfo{Revision: snap.R(2)})
 
 	secBackend := &ifacetest.TestSecurityBackend{BackendName: "test"}
-	s.mockSecBackend(c, secBackend)
+	s.mockSecBackend(secBackend)
 
 	// Create the interface manager. This indirectly adds the snaps to the
 	// repository and reloads the connection.
@@ -3280,7 +3280,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityIgnoresStrayConnection(c 
 	s.state.Unlock()
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3311,7 +3311,7 @@ func (s *interfaceManagerSuite) TestDoSetupProfilesAddsImplicitSlots(c *C) {
 	snapInfo := s.mockSnap(c, ubuntuCoreSnapYaml)
 
 	// Run the setup-profiles task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3337,7 +3337,7 @@ func (s *interfaceManagerSuite) TestDoSetupProfilesAddsImplicitSlots(c *C) {
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInvokedOnPlugSide(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	snapInfo := s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	s.testDoSetupSnapSecurityReloadsConnectionsWhenInvokedOn(c, snapInfo.InstanceName(), snapInfo.Revision)
@@ -3355,7 +3355,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInv
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInvokedOnSlotSide(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	snapInfo := s.mockSnap(c, producerYaml)
 	s.testDoSetupSnapSecurityReloadsConnectionsWhenInvokedOn(c, snapInfo.InstanceName(), snapInfo.Revision)
@@ -3380,7 +3380,7 @@ func (s *interfaceManagerSuite) testDoSetupSnapSecurityReloadsConnectionsWhenInv
 	mgr := s.manager(c)
 
 	// Run the setup-profiles task
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapName,
 			Revision: revision,
@@ -3418,7 +3418,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 
 	// Run the setup-profiles task and let it finish.
 	// Note that the task will see SnapSetup.Flags equal to DeveloperMode.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3453,7 +3453,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesSetupManyError(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-profiles task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3513,7 +3513,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesUsesFreshSnapInfo(c *C) {
 	c.Assert(newSnapInfo.Revision, Equals, snap.R(42))
 
 	// Run the setup-profiles task for the new revision and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: newSnapInfo.SnapName(),
 			Revision: newSnapInfo.Revision,
@@ -3567,7 +3567,7 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingPlugs(c *C, 
 	s.MockModel(c, nil)
 
 	// Mock the interface that will be used by the test
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test1"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test1"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 
 	// Put the OS and the sample snap in place.
 	_ = s.mockSnap(c, ubuntuCoreSnapYaml2)
@@ -3582,7 +3582,7 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingPlugs(c *C, 
 	_ = s.manager(c)
 
 	// Run the setup-profiles task for the new revision and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: newSnapInfo.SnapName(),
 			Revision: newSnapInfo.Revision,
@@ -3613,7 +3613,7 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingSlots(c *C, 
 	s.MockModel(c, nil)
 
 	// Mock the interface that will be used by the test
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test1"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test1"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 
 	// Put sample snaps in place.
 	newSnapInfo1 := s.mockSnap(c, refreshedSnapYaml2)
@@ -3628,7 +3628,7 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingSlots(c *C, 
 	_ = s.manager(c)
 
 	// Run the setup-profiles task for the new revision and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: newSnapInfo1.SnapName(),
 			Revision: newSnapInfo1.Revision,
@@ -3663,7 +3663,7 @@ func (s *interfaceManagerSuite) TestAutoConnectSetupSecurityForConnectedSlots(c 
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3708,7 +3708,7 @@ func (s *interfaceManagerSuite) TestAutoConnectSetupSecurityOnceWithMultiplePlug
 	snapInfo := s.mockSnap(c, sampleSnapYamlManyPlugs)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3783,7 +3783,7 @@ func (s *interfaceManagerSuite) testDoDiscardConns(c *C, snapName string) {
 	s.state.Unlock()
 
 	// Run the discard-conns task and let it finish
-	change, _ := s.addDiscardConnsChange(c, snapName)
+	change, _ := s.addDiscardConnsChange(snapName)
 
 	s.settle(c)
 
@@ -3821,7 +3821,7 @@ func (s *interfaceManagerSuite) testUndoDiscardConns(c *C, snapName string) {
 	s.state.Unlock()
 
 	// Run the discard-conns task and let it finish
-	change, t := s.addDiscardConnsChange(c, snapName)
+	change, t := s.addDiscardConnsChange(snapName)
 	s.state.Lock()
 	terr := s.state.NewTask("error-trigger", "provoking undo")
 	terr.WaitFor(t)
@@ -3849,7 +3849,7 @@ func (s *interfaceManagerSuite) testUndoDiscardConns(c *C, snapName string) {
 }
 
 func (s *interfaceManagerSuite) TestDoRemove(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	var consumerYaml = `
 name: consumer
 version: 1
@@ -3876,7 +3876,7 @@ slots:
 	mgr := s.manager(c)
 
 	// Run the remove-security task
-	change := s.addRemoveSnapSecurityChange(c, "consumer")
+	change := s.addRemoveSnapSecurityChange("consumer")
 	s.se.Ensure()
 	s.se.Wait()
 	s.se.Stop()
@@ -3910,7 +3910,7 @@ slots:
 func (s *interfaceManagerSuite) TestConnectTracksConnectionsInState(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -3954,7 +3954,7 @@ func (s *interfaceManagerSuite) TestConnectTracksConnectionsInState(c *C) {
 func (s *interfaceManagerSuite) TestConnectSetsUpSecurity(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
@@ -3993,7 +3993,7 @@ func (s *interfaceManagerSuite) TestConnectSetsUpSecurity(c *C) {
 func (s *interfaceManagerSuite) TestConnectSetsHotplugKeyFromTheSlot(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumer2Yaml)
 	s.mockSnap(c, coreSnapYaml)
 
@@ -4037,7 +4037,7 @@ func (s *interfaceManagerSuite) TestConnectSetsHotplugKeyFromTheSlot(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestDisconnectSetsUpSecurity(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -4081,7 +4081,7 @@ func (s *interfaceManagerSuite) TestDisconnectSetsUpSecurity(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestDisconnectTracksConnectionsInState(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	s.state.Lock()
@@ -4120,7 +4120,7 @@ func (s *interfaceManagerSuite) TestDisconnectTracksConnectionsInState(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestDisconnectDisablesAutoConnect(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	s.state.Lock()
@@ -4165,7 +4165,7 @@ func (s *interfaceManagerSuite) TestDisconnectDisablesAutoConnect(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestDisconnectByHotplug(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	var consumerYaml = `
 name: consumer
 version: 1
@@ -4228,7 +4228,7 @@ plugs:
 }
 
 func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	var consumerYaml = `
 name: consumer
 version: 1
@@ -4292,7 +4292,7 @@ slots:
 }
 
 func (s *interfaceManagerSuite) TestManagerDoesntReloadUndesiredAutoconnections(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -4311,7 +4311,7 @@ func (s *interfaceManagerSuite) TestManagerDoesntReloadUndesiredAutoconnections(
 }
 
 func (s *interfaceManagerSuite) setupHotplugSlot(c *C) {
-	s.mockIfaces(c, &ifacetest.TestHotplugInterface{TestInterface: ifacetest.TestInterface{InterfaceName: "test"}})
+	s.mockIfaces(&ifacetest.TestHotplugInterface{TestInterface: ifacetest.TestInterface{InterfaceName: "test"}})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, coreSnapYaml)
 
@@ -4398,7 +4398,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesDevModeMultiple(c *C) {
 	_, err = repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: siC.SnapName(),
 			Revision: siC.Revision,
@@ -4435,7 +4435,7 @@ slots:
     deny-installation: true
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.MockSnapDecl(c, "producer", "producer-publisher", nil)
 	snapInfo := s.mockSnap(c, producerYaml)
@@ -4456,7 +4456,7 @@ slots:
     deny-installation: true
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	// crucially, this test is missing this: s.mockSnapDecl(c, "producer", "producer-publisher", nil)
 	snapInfo := s.mockSnap(c, producerYaml)
@@ -4480,7 +4480,7 @@ slots:
         - core
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	// no snap decl
 	snapInfo := s.mockSnap(c, producerYaml)
@@ -4504,7 +4504,7 @@ slots:
         - app
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	// no snap decl
 	snapInfo := s.mockSnap(c, producerYaml)
@@ -4526,7 +4526,7 @@ slots:
     deny-installation: true
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
 		"format": "1",
@@ -4555,7 +4555,7 @@ slots:
     deny-installation: true
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
 		"format": "3",
@@ -4586,7 +4586,7 @@ slots:
     deny-installation: true
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
 		"format": "3",
@@ -4619,7 +4619,7 @@ slots:
     deny-installation: true
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
 		"format": "3",
@@ -4656,7 +4656,7 @@ slots:
     deny-installation: true
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
 		"format": "3",
@@ -4693,7 +4693,7 @@ slots:
     deny-installation: true
 `))
 	defer restore()
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
 		"format": "3",
@@ -4737,7 +4737,7 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnInstall(c *C) {
 	s.state.Unlock()
 
 	// Add a change that undoes "setup-snap-security"
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -4777,7 +4777,7 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Add a change that undoes "setup-snap-security"
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -4895,7 +4895,7 @@ func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCoreUndo(c *C) {
 // Test "core-support" connections that loop back to core is
 // renamed to match the rename of the plug.
 func (s *interfaceManagerSuite) TestCoreConnectionsRenamed(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "unrelated"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "unrelated"})
 
 	// Put state with old connection data.
 	s.state.Lock()
@@ -4971,7 +4971,7 @@ func (s *interfaceManagerSuite) TestAutoConnectDuringCoreTransition(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -5047,7 +5047,7 @@ func makeAutoConnectChange(st *state.State, plugSnap, plug, slotSnap, slot strin
 func (s *interfaceManagerSuite) mockConnectForUndo(c *C, conns map[string]interface{}, delayedSetupProfiles bool) *state.Change {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.manager(c)
 	producer := s.mockSnap(c, producerYaml)
 	consumer := s.mockSnap(c, consumerYaml)
@@ -5261,7 +5261,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingPlugSnapOnAutoConnect(c *
 func (s *interfaceManagerSuite) TestConnectErrorMissingPlugOnAutoConnect(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	_ = s.manager(c)
 	producer := s.mockSnap(c, producerYaml)
 	// consumer snap has no plug, doConnect should complain
@@ -5296,7 +5296,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingPlugOnAutoConnect(c *C) {
 func (s *interfaceManagerSuite) TestConnectErrorMissingSlotOnAutoConnect(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	_ = s.manager(c)
 	// producer snap has no slot, doConnect should complain
 	s.mockSnap(c, producerYaml)
@@ -5331,7 +5331,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingSlotOnAutoConnect(c *C) {
 func (s *interfaceManagerSuite) TestConnectHandlesAutoconnect(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	_ = s.manager(c)
 	producer := s.mockSnap(c, producerYaml)
 	consumer := s.mockSnap(c, consumerYaml)
@@ -5378,7 +5378,7 @@ func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKey
 	restore := interfaces.MockSystemKey(`{"core": "123"}`)
 	defer restore()
 
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	c.Assert(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)
 
@@ -5403,7 +5403,7 @@ func (s *interfaceManagerSuite) TestStartupTimings(c *C) {
 	defer restore()
 
 	s.extraBackends = []interfaces.SecurityBackend{&ifacetest.TestSecurityBackend{BackendName: "fake"}}
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 
 	oldDurationThreshold := timings.DurationThreshold
@@ -5440,7 +5440,7 @@ func (s *interfaceManagerSuite) TestStartupTimings(c *C) {
 func (s *interfaceManagerSuite) TestAutoconnectSelf(c *C) {
 	s.MockModel(c, nil)
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, selfconnectSnapYaml)
 	repo := s.manager(c).Repository()
 	c.Assert(repo.Slots("producerconsumer"), HasLen, 1)
@@ -5801,7 +5801,7 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfilesMiddleOfFirstBoot(c
 }
 
 func (s *interfaceManagerSuite) TestDisconnectInterfaces(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	_ = s.manager(c)
 
 	consumerInfo := s.mockSnap(c, consumerYaml)
@@ -5876,7 +5876,7 @@ func (s *interfaceManagerSuite) TestDisconnectInterfaces(c *C) {
 }
 
 func (s *interfaceManagerSuite) testDisconnectInterfacesRetry(c *C, conflictingKind string) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	_ = s.manager(c)
 
 	consumerInfo := s.mockSnap(c, consumerYaml)
@@ -5938,7 +5938,7 @@ func (s *interfaceManagerSuite) TestDisconnectInterfacesRetrySetupProfiles(c *C)
 }
 
 func (s *interfaceManagerSuite) setupAutoConnectGadget(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	r := assertstest.MockBuiltinBaseDeclaration([]byte(`
 type: base-declaration
@@ -6229,7 +6229,7 @@ slots:
 	r1 := release.MockOnClassic(false)
 	defer r1()
 
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.MockSnapDecl(c, "consumer", "publisher1", nil)
 	s.mockSnap(c, consumerYaml)
 	s.MockSnapDecl(c, "producer", "publisher2", nil)
@@ -7823,7 +7823,7 @@ func (s *interfaceManagerSuite) TestResolveDisconnectFromConns(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestResolveDisconnectWithRepository(c *C) {
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	mgr := s.manager(c)
 
 	consumerInfo := s.mockSnap(c, consumerYaml)
@@ -8021,7 +8021,7 @@ plugs:
 	snapInfo := s.mockSnap(c, themeConsumerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			SnapID:   snapInfo.SnapID,
@@ -8149,7 +8149,7 @@ plugs:
     allow-auto-connection: false
 `))
 	defer restore()
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.MockSnapDecl(c, "gadget", "one-publisher", nil)
 
@@ -8188,7 +8188,7 @@ plugs:
 	snapInfo := s.mockSnap(c, consumerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			SnapID:   snapInfo.SnapID,
@@ -8218,7 +8218,7 @@ plugs:
 
 func (s *interfaceManagerSuite) autoconnectChangeForPreseeding(c *C, skipMarkPreseeded bool) (autoconnectTask, markPreseededTask *state.Task) {
 	s.MockModel(c, nil)
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
 
 	snapInfo := s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
@@ -8405,7 +8405,7 @@ func (s *interfaceManagerSuite) TestFirstTaskAfterBootWhenPreseeding(c *C) {
 // The actual snaps are not installed though.
 func (s *interfaceManagerSuite) TestResolveDisconnectMatrixNoSnaps(c *C) {
 	// Mock the interface that will be used by the test
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "interface"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "interface"})
 	mgr := s.manager(c)
 	scenarios := []struct {
 		plugSnapName, plugName, slotSnapName, slotName string
@@ -8482,7 +8482,7 @@ func (s *interfaceManagerSuite) TestResolveDisconnectMatrixJustSnapdSnap(c *C) {
 	defer restore()
 
 	// Mock the interface that will be used by the test
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "interface"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "interface"})
 	mgr := s.manager(c)
 	repo := mgr.Repository()
 	// Rename the "slot" from the snapd snap so that it is not picked up below.
@@ -8562,7 +8562,7 @@ func (s *interfaceManagerSuite) TestResolveDisconnectMatrixJustCoreSnap(c *C) {
 	defer restore()
 
 	// Mock the interface that will be used by the test
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "interface"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "interface"})
 	mgr := s.manager(c)
 	repo := mgr.Repository()
 	// Rename the "slot" from the core snap so that it is not picked up below.
@@ -8643,7 +8643,7 @@ func (s *interfaceManagerSuite) TestResolveDisconnectMatrixDisconnectedSnaps(c *
 	defer restore()
 
 	// Mock the interface that will be used by the test
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "interface"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "interface"})
 	mgr := s.manager(c)
 	repo := mgr.Repository()
 	// Rename the "slot" from the core snap so that it is not picked up below.
@@ -8731,7 +8731,7 @@ func (s *interfaceManagerSuite) TestResolveDisconnectMatrixTypical(c *C) {
 	defer restore()
 
 	// Mock the interface that will be used by the test
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "interface"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "interface"})
 	mgr := s.manager(c)
 	repo := mgr.Repository()
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -478,7 +478,7 @@ func (ms *baseMgrsSuite) mockInstalledSnapWithFiles(c *C, snapYaml string, files
 func (ms *baseMgrsSuite) mockInstalledSnapWithRevAndFiles(c *C, snapYaml string, rev snap.Revision, files [][]string) *snap.Info {
 	st := ms.o.State()
 
-	info := snaptest.MockSnapWithFiles(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)}, files)
+	info := snaptest.MockSnapWithFiles(c, snapYaml, &snap.SideInfo{Revision: rev}, files)
 	si := &snap.SideInfo{
 		RealName: info.SnapName(),
 		SnapID:   fakeSnapID(info.SnapName()),

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -860,7 +860,7 @@ type sampleManager struct {
 	ensureCallback func()
 }
 
-func newSampleManager(s *state.State, runner *state.TaskRunner) *sampleManager {
+func newSampleManager(runner *state.TaskRunner) *sampleManager {
 	sm := &sampleManager{}
 
 	runner.AddHandler("runMgr1", func(t *state.Task, _ *tomb.Tomb) error {
@@ -922,7 +922,7 @@ func (ovs *overlordSuite) TestTrivialSettle(c *C) {
 	o := overlord.Mock()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
@@ -951,7 +951,7 @@ func (ovs *overlordSuite) TestSettleNotConverging(c *C) {
 	o := overlord.Mock()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
@@ -978,7 +978,7 @@ func (ovs *overlordSuite) TestSettleChain(c *C) {
 	o := overlord.Mock()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
@@ -1012,7 +1012,7 @@ func (ovs *overlordSuite) TestSettleChainWCleanup(c *C) {
 	o := overlord.Mock()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
@@ -1049,7 +1049,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 	o := overlord.Mock()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	sm1.ensureCallback = func() {
 		s.Lock()
 		defer s.Unlock()

--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -193,7 +193,7 @@ type unitOptions struct {
 	oomScore             string
 }
 
-func mkUnitFile(c *C, opts *unitOptions) string {
+func mkUnitFile(opts *unitOptions) string {
 	if opts == nil {
 		opts = &unitOptions{}
 	}
@@ -309,7 +309,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleWritesServicesFiles
 	c.Assert(err, IsNil)
 
 	// we wrote a service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		snapName: "test-snap",
 		snapRev:  "42",
 	})
@@ -381,7 +381,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesUC18(c
 	c.Assert(err, IsNil)
 
 	// we wrote the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -424,7 +424,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesVitali
 	c.Assert(err, IsNil)
 
 	// we wrote the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -487,7 +487,7 @@ echo %[1]q
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -506,7 +506,7 @@ echo %[1]q
 	c.Assert(err, IsNil)
 
 	// we wrote the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -558,7 +558,7 @@ exit 1
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -583,7 +583,7 @@ exit 1
 	c.Assert(err, IsNil)
 
 	// we wrote the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -622,7 +622,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRes
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -663,7 +663,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRes
 	c.Assert(err, IsNil)
 
 	// we wrote the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -702,7 +702,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesButDoe
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -743,7 +743,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesButDoe
 	c.Assert(err, IsNil)
 
 	// we wrote the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -776,7 +776,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKil
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -809,7 +809,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKil
 	c.Assert(err, IsNil)
 
 	// we wrote the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -842,7 +842,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKil
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -875,7 +875,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKil
 	c.Assert(err, IsNil)
 
 	// we wrote the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -925,7 +925,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -962,7 +962,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 	c.Assert(err, IsNil)
 
 	// the file was rewritten to use Wants instead now
-	wantsContent := mkUnitFile(c, &unitOptions{
+	wantsContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1012,7 +1012,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1049,7 +1049,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 	c.Assert(err, IsNil)
 
 	// the file was rewritten to use Wants instead now
-	wantsContent := mkUnitFile(c, &unitOptions{
+	wantsContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1085,7 +1085,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1122,7 +1122,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 	c.Assert(err, IsNil)
 
 	// the file was rewritten to use Wants instead now
-	wantsContent := mkUnitFile(c, &unitOptions{
+	wantsContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1155,7 +1155,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesNoChangeServiceFileDoesNo
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Wants
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1198,7 +1198,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesWhe
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1222,7 +1222,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesWhe
 	err = s.mgr.Ensure()
 	c.Assert(err, IsNil)
 
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1255,7 +1255,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRes
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1301,7 +1301,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRes
 	c.Assert(err, ErrorMatches, "error trying to restart killed services, immediately rebooting: this service is having a bad day")
 
 	// we did write the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1334,7 +1334,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndTri
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.test-snap.svc1.service")
 
 	// add the initial state of the service file using Requires
-	requiresContent := mkUnitFile(c, &unitOptions{
+	requiresContent := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Requires",
 		snapName:             "test-snap",
 		snapRev:              "42",
@@ -1372,7 +1372,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndTri
 	c.Assert(err, ErrorMatches, "error trying to restart killed services, immediately rebooting: systemd is having a bad day")
 
 	// we did write the service unit file
-	content := mkUnitFile(c, &unitOptions{
+	content := mkUnitFile(&unitOptions{
 		usrLibSnapdOrderVerb: "Wants",
 		snapName:             "test-snap",
 		snapRev:              "42",

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -364,7 +364,7 @@ func (m *autoRefresh) Ensure() error {
 				return nil
 			}
 
-			err = m.launchAutoRefresh(refreshSchedule)
+			err = m.launchAutoRefresh()
 			if _, ok := err.(*httputil.PersistentNetworkError); !ok {
 				m.nextRefresh = time.Time{}
 			} // else - refresh will be retried after refreshRetryDelay
@@ -489,7 +489,7 @@ func autoRefreshSummary(updated []string) string {
 }
 
 // launchAutoRefresh creates the auto-refresh taskset and a change for it.
-func (m *autoRefresh) launchAutoRefresh(refreshSchedule []*timeutil.Schedule) error {
+func (m *autoRefresh) launchAutoRefresh() error {
 	perfTimings := timings.New(map[string]string{"ensure": "auto-refresh"})
 	tm := perfTimings.StartSpan("auto-refresh", "query store and setup auto-refresh change")
 	defer func() {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -182,7 +182,7 @@ func (f *fakeStore) SnapInfo(ctx context.Context, spec store.SnapSpec, user *aut
 	sspec := snapSpec{
 		Name: spec.Name,
 	}
-	info, err := f.snap(sspec, user)
+	info, err := f.snap(sspec)
 
 	userID := 0
 	if user != nil {
@@ -200,7 +200,7 @@ type snapSpec struct {
 	Cohort   string
 }
 
-func (f *fakeStore) snap(spec snapSpec, user *auth.UserState) (*snap.Info, error) {
+func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 	if spec.Revision.Unset() {
 		switch {
 		case spec.Cohort != "":
@@ -517,7 +517,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 				Revision: a.Revision,
 				Cohort:   a.CohortKey,
 			}
-			info, err := f.snap(spec, user)
+			info, err := f.snap(spec)
 			if err != nil {
 				installErrors[a.InstanceName] = err
 				continue

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -365,7 +365,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, snapf sn
 		return nil
 	}
 
-	currentSnap, err := infoForDeviceSnap(st, deviceCtx, kind, whichName)
+	currentSnap, err := infoForDeviceSnap(st, deviceCtx, whichName)
 	if err == state.ErrNoState {
 		// check if we are in the remodel case
 		if deviceCtx != nil && deviceCtx.ForRemodeling() {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -960,7 +960,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	// if we just put back a previous a core snap, request a restart
 	// so that we switch executing its snapd
-	m.maybeRestart(t, oldInfo, reboot, deviceCtx)
+	m.maybeRestart(t, oldInfo, reboot)
 	return nil
 }
 
@@ -1418,14 +1418,14 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 
 	// if we just installed a core snap, request a restart
 	// so that we switch executing its snapd.
-	m.maybeRestart(t, newInfo, reboot, deviceCtx)
+	m.maybeRestart(t, newInfo, reboot)
 
 	return nil
 }
 
 // maybeRestart will schedule a reboot or restart as needed for the
 // just linked snap with info if it's a core or snapd or kernel snap.
-func (m *SnapManager) maybeRestart(t *state.Task, info *snap.Info, rebootRequired bool, deviceCtx DeviceContext) {
+func (m *SnapManager) maybeRestart(t *state.Task, info *snap.Info, rebootRequired bool) {
 	// Don't restart when preseeding - we will switch to new snapd on
 	// first boot.
 	if m.preseed {
@@ -1540,7 +1540,7 @@ func (m *SnapManager) maybeUndoRemodelBootChanges(t *state.Task) error {
 
 	// we may just have switch back to the old kernel/base/core so
 	// we may need to restart
-	m.maybeRestart(t, info, reboot, groundDeviceCtx)
+	m.maybeRestart(t, info, reboot)
 
 	return nil
 }
@@ -1718,7 +1718,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	// undoLinkCurrentSnap() instead
 	if firstInstall && newInfo.Type() == snap.TypeSnapd {
 		const rebootRequired = false
-		m.maybeRestart(t, newInfo, rebootRequired, deviceCtx)
+		m.maybeRestart(t, newInfo, rebootRequired)
 	}
 
 	// write sequence file for failover helpers
@@ -2194,7 +2194,7 @@ func (m *SnapManager) undoUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	// if we just linked back a core snap, request a restart
 	// so that we switch executing its snapd.
-	m.maybeRestart(t, info, reboot, deviceCtx)
+	m.maybeRestart(t, info, reboot)
 
 	return nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2937,7 +2937,7 @@ func infosForType(st *state.State, snapType snap.Type) ([]*snap.Info, error) {
 	return res, nil
 }
 
-func infoForDeviceSnap(st *state.State, deviceCtx DeviceContext, which string, whichName func(*asserts.Model) string) (*snap.Info, error) {
+func infoForDeviceSnap(st *state.State, deviceCtx DeviceContext, whichName func(*asserts.Model) string) (*snap.Info, error) {
 	if deviceCtx == nil {
 		return nil, fmt.Errorf("internal error: unset deviceCtx")
 	}
@@ -2956,12 +2956,12 @@ func infoForDeviceSnap(st *state.State, deviceCtx DeviceContext, which string, w
 
 // GadgetInfo finds the gadget snap's info for the given device context.
 func GadgetInfo(st *state.State, deviceCtx DeviceContext) (*snap.Info, error) {
-	return infoForDeviceSnap(st, deviceCtx, "gadget", (*asserts.Model).Gadget)
+	return infoForDeviceSnap(st, deviceCtx, (*asserts.Model).Gadget)
 }
 
 // KernelInfo finds the kernel snap's info for the given device context.
 func KernelInfo(st *state.State, deviceCtx DeviceContext) (*snap.Info, error) {
-	return infoForDeviceSnap(st, deviceCtx, "kernel", (*asserts.Model).Kernel)
+	return infoForDeviceSnap(st, deviceCtx, (*asserts.Model).Kernel)
 }
 
 // BootBaseInfo finds the boot base snap's info for the given device context.
@@ -2973,7 +2973,7 @@ func BootBaseInfo(st *state.State, deviceCtx DeviceContext) (*snap.Info, error) 
 		}
 		return base
 	}
-	return infoForDeviceSnap(st, deviceCtx, "boot base", baseName)
+	return infoForDeviceSnap(st, deviceCtx, baseName)
 }
 
 // TODO: reintroduce a KernelInfo(state.State, DeviceContext) if needed

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -126,15 +126,15 @@ func isV1EncryptedKeyFile(p string) bool {
 // 2. Key created with v2 data-format on disk (json), v1 hook created the data (no handle) and reads the data (hook output not json but raw binary data)
 // 3. Key created with v1 data-format on disk (raw), v2 hook
 // 4. Key created with v2 data-format on disk (json), v2 hook [easy]
-func unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName string, opts *UnlockVolumeUsingSealedKeyOptions) (UnlockResult, error) {
+func unlockVolumeUsingSealedKeyFDERevealKey(sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName string, opts *UnlockVolumeUsingSealedKeyOptions) (UnlockResult, error) {
 	// deal with v1 keys
 	if isV1EncryptedKeyFile(sealedEncryptionKeyFile) {
-		return unlockVolumeUsingSealedKeyFDERevealKeyV1(name, sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName, opts)
+		return unlockVolumeUsingSealedKeyFDERevealKeyV1(sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName)
 	}
-	return unlockVolumeUsingSealedKeyFDERevealKeyV2(name, sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName, opts)
+	return unlockVolumeUsingSealedKeyFDERevealKeyV2(sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName, opts)
 }
 
-func unlockVolumeUsingSealedKeyFDERevealKeyV1(name, sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName string, opts *UnlockVolumeUsingSealedKeyOptions) (UnlockResult, error) {
+func unlockVolumeUsingSealedKeyFDERevealKeyV1(sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName string) (UnlockResult, error) {
 	res := UnlockResult{IsEncrypted: true, PartDevice: sourceDevice}
 
 	sealedKey, err := ioutil.ReadFile(sealedEncryptionKeyFile)
@@ -160,7 +160,7 @@ func unlockVolumeUsingSealedKeyFDERevealKeyV1(name, sealedEncryptionKeyFile, sou
 	return res, nil
 }
 
-func unlockVolumeUsingSealedKeyFDERevealKeyV2(name, sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName string, opts *UnlockVolumeUsingSealedKeyOptions) (res UnlockResult, err error) {
+func unlockVolumeUsingSealedKeyFDERevealKeyV2(sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName string, opts *UnlockVolumeUsingSealedKeyOptions) (res UnlockResult, err error) {
 	res = UnlockResult{IsEncrypted: true, PartDevice: sourceDevice}
 
 	f, err := sb.NewFileKeyDataReader(sealedEncryptionKeyFile)

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -106,7 +106,7 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, sealedE
 	targetDevice := filepath.Join("/dev/mapper", mapperName)
 
 	if fdeHasRevealKey() {
-		return unlockVolumeUsingSealedKeyFDERevealKey(name, sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName, opts)
+		return unlockVolumeUsingSealedKeyFDERevealKey(sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName, opts)
 	} else {
 		return unlockVolumeUsingSealedKeyTPM(name, sealedEncryptionKeyFile, sourceDevice, targetDevice, mapperName, opts)
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -233,7 +233,7 @@ func unlockVolumeUsingSealedKeyTPM(name, sealedEncryptionKeyFile, sourceDevice, 
 
 	// otherwise we have a tpm and we should use the sealed key first, but
 	// this method will fallback to using the recovery key if enabled
-	method, err := unlockEncryptedPartitionWithSealedKey(tpm, mapperName, sourceDevice, sealedEncryptionKeyFile, "", opts.AllowRecoveryKey)
+	method, err := unlockEncryptedPartitionWithSealedKey(tpm, mapperName, sourceDevice, sealedEncryptionKeyFile, opts.AllowRecoveryKey)
 	res.UnlockMethod = method
 	if err == nil {
 		res.FsDevice = targetDevice
@@ -272,7 +272,7 @@ func activateVolOpts(allowRecoveryKey bool) *sb.ActivateVolumeOptions {
 // unlockEncryptedPartitionWithSealedKey unseals the keyfile and opens an encrypted
 // device. If activation with the sealed key fails, this function will attempt to
 // activate it with the fallback recovery key instead.
-func unlockEncryptedPartitionWithSealedKey(tpm *sb.TPMConnection, name, device, keyfile, pinfile string, allowRecovery bool) (UnlockMethod, error) {
+func unlockEncryptedPartitionWithSealedKey(tpm *sb.TPMConnection, name, device, keyfile string, allowRecovery bool) (UnlockMethod, error) {
 	options := activateVolOpts(allowRecovery)
 	// XXX: pinfile is currently not used
 	activated, err := sbActivateVolumeWithTPMSealedKey(tpm, name, device, keyfile, nil, options)

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -54,20 +54,18 @@ func addImplicitHooks(snapInfo *Info) error {
 //
 // Existing hooks (i.e. ones defined in the YAML) are not changed; only missing
 // hooks are added.
-func addImplicitHooksFromContainer(snapInfo *Info, snapf Container) error {
+func addImplicitHooksFromContainer(snapInfo *Info, snapf Container) {
 	// Read the hooks directory. If this fails we assume the hooks directory
 	// doesn't exist, which means there are no implicit hooks to load (not an
 	// error).
 	fileNames, err := snapf.ListDir("meta/hooks")
 	if err != nil {
-		return nil
+		return
 	}
 
 	for _, fileName := range fileNames {
 		addHookIfValid(snapInfo, fileName)
 	}
-
-	return nil
 }
 
 func addHookIfValid(snapInfo *Info, hookName string) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -1256,10 +1256,7 @@ func ReadInfoFromSnapFile(snapf Container, si *SideInfo) (*Info, error) {
 		return nil, err
 	}
 
-	err = addImplicitHooksFromContainer(info, snapf)
-	if err != nil {
-		return nil, err
-	}
+	addImplicitHooksFromContainer(info, snapf)
 
 	bindImplicitHooks(info, strk)
 

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -249,17 +249,17 @@ func validateSocketAddrAbstract(socket *SocketInfo, fieldName string, path strin
 func validateSocketAddrNet(socket *SocketInfo, fieldName string, address string) error {
 	lastIndex := strings.LastIndex(address, ":")
 	if lastIndex >= 0 {
-		if err := validateSocketAddrNetHost(socket, fieldName, address[:lastIndex]); err != nil {
+		if err := validateSocketAddrNetHost(fieldName, address[:lastIndex]); err != nil {
 			return err
 		}
-		return validateSocketAddrNetPort(socket, fieldName, address[lastIndex+1:])
+		return validateSocketAddrNetPort(fieldName, address[lastIndex+1:])
 	}
 
 	// Address only contains a port
-	return validateSocketAddrNetPort(socket, fieldName, address)
+	return validateSocketAddrNetPort(fieldName, address)
 }
 
-func validateSocketAddrNetHost(socket *SocketInfo, fieldName string, address string) error {
+func validateSocketAddrNetHost(fieldName string, address string) error {
 	validAddresses := []string{"127.0.0.1", "[::1]", "[::]"}
 	for _, valid := range validAddresses {
 		if address == valid {
@@ -270,7 +270,7 @@ func validateSocketAddrNetHost(socket *SocketInfo, fieldName string, address str
 	return fmt.Errorf("invalid %q address %q, must be one of: %s", fieldName, address, strings.Join(validAddresses, ", "))
 }
 
-func validateSocketAddrNetPort(socket *SocketInfo, fieldName string, port string) error {
+func validateSocketAddrNetPort(fieldName string, port string) error {
 	var val uint64
 	var err error
 	retErr := fmt.Errorf("invalid %q port number %q", fieldName, port)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -723,11 +723,11 @@ func (s *storeTestSuite) TestEnsureDeviceSessionSerialisation(c *C) {
 	for i := 0; i < 10; i++ {
 		wgGetDevice.Add(1)
 		wg.Add(1)
-		go func(n int) {
+		go func() {
 			_, err := sto.EnsureDeviceSession()
 			c.Assert(err, IsNil)
 			wg.Done()
-		}(i)
+		}()
 	}
 
 	wgGetDevice.Wait()

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -40,7 +40,7 @@ func testInfo(c *check.C, checker check.Checker, name string, paramNames []strin
 	}
 }
 
-func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...interface{}) ([]interface{}, []string) {
+func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...interface{}) {
 	info := checker.Info()
 	if len(params) != len(info.Params) {
 		c.Fatalf("unexpected param count in test; expected %d got %d", len(info.Params), len(params))
@@ -51,5 +51,4 @@ func testCheck(c *check.C, checker check.Checker, result bool, error string, par
 		c.Fatalf("%s.Check(%#v) returned (%#v, %#v) rather than (%#v, %#v)",
 			info.Name, params, resultActual, errorActual, result, error)
 	}
-	return params, names
 }

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -574,7 +574,7 @@ func writeSnapdDbusConfigOnCore(s *snap.Info) error {
 	return nil
 }
 
-func undoSnapdDbusConfigOnCore(s *snap.Info) error {
+func undoSnapdDbusConfigOnCore() error {
 	_, _, err := osutil.EnsureDirState(dirs.SnapDBusSystemPolicyDir, "snapd.*.conf", nil)
 	if err != nil {
 		return err
@@ -605,7 +605,7 @@ func writeSnapdDbusActivationOnCore(s *snap.Info) error {
 	return err
 }
 
-func undoSnapdDbusActivationOnCore(s *snap.Info) error {
+func undoSnapdDbusActivationOnCore() error {
 	_, _, err := osutil.EnsureDirStateGlobs(dirs.SnapDBusSessionServicesDir, dbusSessionServices, nil)
 	return err
 }
@@ -626,10 +626,10 @@ func RemoveSnapdSnapServicesOnCore(s *snap.Info, inter interacter) error {
 
 	sysd := systemd.NewUnderRoot(dirs.GlobalRootDir, systemd.SystemMode, inter)
 
-	if err := undoSnapdDbusActivationOnCore(s); err != nil {
+	if err := undoSnapdDbusActivationOnCore(); err != nil {
 		return err
 	}
-	if err := undoSnapdDbusConfigOnCore(s); err != nil {
+	if err := undoSnapdDbusConfigOnCore(); err != nil {
 		return err
 	}
 	if err := undoSnapdServicesOnCore(s, sysd); err != nil {

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -77,7 +77,7 @@ func generateSnapServiceFile(app *snap.AppInfo, opts *AddSnapServicesOptions) ([
 
 // generateGroupSliceFile generates a systemd slice unit definition for the
 // specified quota group.
-func generateGroupSliceFile(grp *quota.Group) ([]byte, error) {
+func generateGroupSliceFile(grp *quota.Group) []byte {
 	buf := bytes.Buffer{}
 
 	template := `[Unit]
@@ -99,7 +99,7 @@ TasksAccounting=true
 
 	fmt.Fprintf(&buf, template, grp.Name, grp.MemoryLimit)
 
-	return buf.Bytes(), nil
+	return buf.Bytes()
 }
 
 func stopUserServices(cli *client.Client, inter interacter, services ...string) error {
@@ -682,10 +682,7 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 
 	// now make sure that all of the slice units exist
 	for _, grp := range neededQuotaGrps.AllQuotaGroups() {
-		content, err := generateGroupSliceFile(grp)
-		if err != nil {
-			return err
-		}
+		content := generateGroupSliceFile(grp)
 
 		sliceFileName := grp.SliceFileName()
 		path := filepath.Join(dirs.SnapServicesDir, sliceFileName)


### PR DESCRIPTION
I noticed we had a few unused parameters in the code which are sometimes misleading so  I ran the unparam linter which flagged a lot of them. I didn't fix all of its warnings since some seemed like either false positives or just things we'd rather keep (e.g., unused args in exported methods even though the `check-exported` setting was set to false, test methods that always received same input but were more readable, etc). That is also why I didn't enable the linter in the end. Most of the removed occurrences  were just cruft but some were actually bugs. Since the PR touches a lot of files with menial changes, I'll point out the more serious changes in subsequent comments to make reviewing them easier. 
