### PR TITLE
systemd: add fake type for easier mocking of systemd functions

### DIFF
--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -21,6 +21,8 @@ package backend
 
 import (
 	"os/exec"
+
+	"github.com/snapcore/snapd/systemd"
 )
 
 var (
@@ -41,5 +43,13 @@ func MockCommandFromSystemSnap(f func(string, ...string) (*exec.Cmd, error)) (re
 	commandFromSystemSnap = f
 	return func() {
 		commandFromSystemSnap = old
+	}
+}
+
+func MockSystemdNew(f func(systemd.InstanceMode, systemd.Reporter) systemd.Systemd) (restore func()) {
+	old := systemdNew
+	systemdNew = f
+	return func() {
+		systemdNew = old
 	}
 }

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -26,6 +26,10 @@ import (
 	"github.com/snapcore/snapd/systemd"
 )
 
+var (
+	systemdNew = systemd.New
+)
+
 func addMountUnit(s *snap.Info, preseed bool, meter progress.Meter) error {
 	squashfsPath := dirs.StripRootDir(s.MountFile())
 	whereDir := dirs.StripRootDir(s.MountDir())
@@ -41,6 +45,6 @@ func addMountUnit(s *snap.Info, preseed bool, meter progress.Meter) error {
 }
 
 func removeMountUnit(mountDir string, meter progress.Meter) error {
-	sysd := systemd.New(systemd.SystemMode, meter)
+	sysd := systemdNew(systemd.SystemMode, meter)
 	return sysd.RemoveMountUnitFile(mountDir)
 }

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -38,7 +38,7 @@ func addMountUnit(s *snap.Info, preseed bool, meter progress.Meter) error {
 	if preseed {
 		sysd = systemd.NewEmulationMode(dirs.GlobalRootDir)
 	} else {
-		sysd = systemd.New(systemd.SystemMode, meter)
+		sysd = systemdNew(systemd.SystemMode, meter)
 	}
 	_, err := sysd.AddMountUnitFile(s.InstanceName(), s.Revision.String(), squashfsPath, whereDir, "squashfs")
 	return err

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -306,18 +306,18 @@ const (
 	UserServicesTarget = "default.target"
 )
 
-type reporter interface {
+type Reporter interface {
 	Notify(string)
 }
 
 // New returns a Systemd that uses the default root directory and omits
 // --root argument when executing systemctl.
-func New(mode InstanceMode, rep reporter) Systemd {
+func New(mode InstanceMode, rep Reporter) Systemd {
 	return &systemd{mode: mode, reporter: rep}
 }
 
 // NewUnderRoot returns a Systemd that operates on the given rootdir.
-func NewUnderRoot(rootDir string, mode InstanceMode, rep reporter) Systemd {
+func NewUnderRoot(rootDir string, mode InstanceMode, rep Reporter) Systemd {
 	return &systemd{rootDir: rootDir, mode: mode, reporter: rep}
 }
 
@@ -353,7 +353,7 @@ const (
 
 type systemd struct {
 	rootDir  string
-	reporter reporter
+	reporter Reporter
 	mode     InstanceMode
 }
 

--- a/systemd/systemdtest/systemdtest.go
+++ b/systemd/systemdtest/systemdtest.go
@@ -21,8 +21,12 @@ package systemdtest
 
 import (
 	"fmt"
+	"io"
+	"time"
 
+	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/systemd"
 )
 
 type ServiceState struct {
@@ -59,3 +63,52 @@ Type=simple
 	}
 	return output
 }
+
+type FakeSystemd struct {
+	Mode     systemd.InstanceMode
+	Reporter systemd.Reporter
+
+	/* The user of this fake object can replace the implementation of the
+	* various methods */
+	MockedRemoveMountUnitFile func(baseDir string) error
+}
+
+/* For each of these methods, I'll create a "Mocked<MethodName>" field in the
+ * FakeSystemd struct, to allow the caller to override it. See the
+ * RemoveMountUnitFile() method below.
+ */
+func (s *FakeSystemd) DaemonReload() error                                   { return nil }
+func (s *FakeSystemd) DaemonReexec() error                                   { return nil }
+func (s *FakeSystemd) Enable(service string) error                           { return nil }
+func (s *FakeSystemd) Disable(service string) error                          { return nil }
+func (s *FakeSystemd) Start(service ...string) error                         { return nil }
+func (s *FakeSystemd) StartNoBlock(service ...string) error                  { return nil }
+func (s *FakeSystemd) Stop(service string, timeout time.Duration) error      { return nil }
+func (s *FakeSystemd) Kill(service, signal, who string) error                { return nil }
+func (s *FakeSystemd) Restart(service string, timeout time.Duration) error   { return nil }
+func (s *FakeSystemd) ReloadOrRestart(service string) error                  { return nil }
+func (s *FakeSystemd) RestartAll(service string) error                       { return nil }
+func (s *FakeSystemd) Status(units ...string) ([]*systemd.UnitStatus, error) { return nil, nil }
+func (s *FakeSystemd) InactiveEnterTimestamp(unit string) (time.Time, error) { return time.Time{}, nil }
+func (s *FakeSystemd) IsEnabled(service string) (bool, error)                { return false, nil }
+func (s *FakeSystemd) IsActive(service string) (bool, error)                 { return false, nil }
+func (s *FakeSystemd) LogReader(services []string, n int, follow bool) (io.ReadCloser, error) {
+	return nil, nil
+}
+func (s *FakeSystemd) AddMountUnitFile(name, revision, what, where, fstype string) (string, error) {
+	return "", nil
+}
+
+func (s *FakeSystemd) RemoveMountUnitFile(baseDir string) error {
+	if s.MockedRemoveMountUnitFile != nil {
+		return s.MockedRemoveMountUnitFile(baseDir)
+	}
+	return nil
+}
+
+func (s *FakeSystemd) Mask(service string) error                             { return nil }
+func (s *FakeSystemd) Unmask(service string) error                           { return nil }
+func (s *FakeSystemd) Mount(what, where string, options ...string) error     { return nil }
+func (s *FakeSystemd) Umount(whatOrWhere string) error                       { return nil }
+func (s *FakeSystemd) CurrentMemoryUsage(unit string) (quantity.Size, error) { return 0, nil }
+func (s *FakeSystemd) CurrentTasksCount(unit string) (uint64, error)         { return 0, nil }

--- a/systemd/systemdtest/systemdtest.go
+++ b/systemd/systemdtest/systemdtest.go
@@ -71,6 +71,7 @@ type FakeSystemd struct {
 	/* The user of this fake object can replace the implementation of the
 	* various methods */
 	MockedRemoveMountUnitFile func(baseDir string) error
+	MockedAddMountUnitFile func(name, revision, what, where, fstype string) (string, error)
 }
 
 /* For each of these methods, I'll create a "Mocked<MethodName>" field in the
@@ -95,7 +96,11 @@ func (s *FakeSystemd) IsActive(service string) (bool, error)                 { r
 func (s *FakeSystemd) LogReader(services []string, n int, follow bool) (io.ReadCloser, error) {
 	return nil, nil
 }
+
 func (s *FakeSystemd) AddMountUnitFile(name, revision, what, where, fstype string) (string, error) {
+	if s.MockedAddMountUnitFile != nil {
+		return s.MockedAddMountUnitFile(name, revision, what, where, fstype)
+	}
 	return "", nil
 }
 


### PR DESCRIPTION
This is still a draft.

The idea is to create a fake type which implements the `systemd.Systemd` interface and which can be easily programmed in unit tests. Beside a fake default implementation, which just return empty values, all methods (at the moment only `RemoveMountUnitFile()` and `ListMountUnits()`, but I'll add all the others if I receive positive feedback) will have a corresponding `Mocked<method name>` field in the `FakeSystemd` type, which allows the test code to inject its desired implementation.

The benefit is that we'll have fewer dependencies in the tests, and fewer things to adapt when we change the implementation of the systemd methods (systemctl calls in particular).