### PR TITLE
spread: add 21.10 to qemu, remove 20.10 (EOL)

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -236,10 +236,10 @@ backends:
             - ubuntu-20.04-32:
                   username: ubuntu
                   password: ubuntu
-            - ubuntu-20.10-64:
+            - ubuntu-21.04-64:
                   username: ubuntu
                   password: ubuntu
-            - ubuntu-21.04-64:
+            - ubuntu-21.10-64:
                   username: ubuntu
                   password: ubuntu
             - debian-sid-64:


### PR DESCRIPTION
Update qemu spread machines to have 21.10 and remove no longer
needed 20.10.
