### PR TITLE
tests: add more space on ubuntu xenial

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -83,6 +83,7 @@ backends:
                   workers: 6
             - ubuntu-16.04-64:
                   workers: 8
+                  storage: 12G
             - ubuntu-18.04-32:
                   workers: 6
             - ubuntu-18.04-64:


### PR DESCRIPTION
Sometimes a test fails due to lack of disk space:

2021-09-01T07:22:47.7421902Z Failed to create snap, snap command failed:
2021-09-01T07:22:47.7422575Z stdout:
2021-09-01T07:22:47.7422907Z
2021-09-01T07:22:47.7423352Z stderr:
2021-09-01T07:22:47.7424089Z error: cannot pack "/root/prime":
mksquashfs call failed:
2021-09-01T07:22:47.7425146Z -----
2021-09-01T07:22:47.7426088Z Write failed because No space left on
device
....
2021-09-01T07:22:49.8110021Z 2021-09-01 07:22:49 Debug output for
google:ubuntu-16.04-64:tests/main/snapd-snap:lxd (sep010658-426075) :
