### PR TITLE
tests: bump the number of retries when waiting for /dev/nbd0p1

### DIFF
--- a/tests/lib/preseed.sh
+++ b/tests/lib/preseed.sh
@@ -17,7 +17,7 @@ mount_ubuntu_image() {
     # stdin/stdout it would otherwise inherit from the spread session.
     systemd-run --system --service-type=forking --unit=qemu-nbd-preseed.service "$(command -v qemu-nbd)" --fork -c /dev/nbd0 "$CLOUD_IMAGE"
     # nbd0p1 may take a short while to become available
-    retry -n 5 --wait 1 test -e /dev/nbd0p1
+    retry -n 15 --wait 1 test -e /dev/nbd0p1
     mount /dev/nbd0p1 "$IMAGE_MOUNTPOINT"
     mount -t proc /proc "$IMAGE_MOUNTPOINT/proc"
     mount -t sysfs sysfs "$IMAGE_MOUNTPOINT/sys"


### PR DESCRIPTION
Bump the number of retries when waiting for /deb/nbd0p1, for some reason it is much slower on 21.10 and preseed/preseed-reset tests tend to fail because of this.