### PR TITLE
tests: ensure the `libvirt-daemon-system` pacakge is installed

### DIFF
--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -15,8 +15,10 @@ details: |
 systems: [ubuntu-20.04-64]
 
 prepare: |
-    # Given test user is added to the libvirtd group
-    adduser test libvirtd
+    apt install -y libvirt-daemon-system
+
+    # Given test user is added to the libvirt group
+    adduser test libvirt
 
     echo "And libvirt is configured to manage /dev/net/tun"
     systemctl stop libvirtd.service || true
@@ -36,6 +38,8 @@ prepare: |
 
 restore: |
     ip link delete tap100
+
+    apt autoremove --purge -y libvirt-daemon-system
 
     # remove test user from the libvirtd group
     deluser test libvirtd


### PR DESCRIPTION
The test for interfaces-libvirt needs the `libvirt-daemon-system`
that is currently not installed on our images for 20.04. This
broke with https://github.com/snapcore/snapd/pull/10675

The name of the group also changed from `libvirtd` to `libvirt`.

We could also add it to `pkgdb.sh` but given that this is really
only needed in this test it seems to be fine to just install it
here and remove it again.

I noticed this when reviewing the logs for PR #10634 - with
this PR and #10710 master should be green again.
