### PR TITLE
tests: use host-scaled settle timeout for hookstate tests

### DIFF
--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -60,6 +60,10 @@ type baseHookManagerSuite struct {
 	command     *testutil.MockCmd
 }
 
+var (
+	settleTimeout = testutil.HostScaledTimeout(15 * time.Second)
+)
+
 func (s *baseHookManagerSuite) commonSetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
@@ -174,7 +178,7 @@ func (s *hookManagerSuite) TearDownTest(c *C) {
 }
 
 func (s *hookManagerSuite) settle(c *C) {
-	err := s.o.Settle(5 * time.Second)
+	err := s.o.Settle(settleTimeout)
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
This should help avoid another riscv64 build failure. I'm setting it to 15s (which is multiplied by 6 on riscv) instead of 45 as was in managers test, hopefully this will be enough.
