### PR TITLE
tests: move interfaces-libvirt test back to 16.04

### DIFF
--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -12,7 +12,7 @@ details: |
     The test uses a snap that carries a unikernel built to be run on top of qemu, boot and
     respond to ping. Once the domain is created, the test checks connectivity to the unikernel.
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-16.04-64]
 
 prepare: |
     # Given test user is added to the libvirtd group


### PR DESCRIPTION
This test was moved to run on `20.04` but there are at least two
problems:
1. The `libvirtd` group got renamed to `libvirt`
2. The <kernel>test_ping_serve.virtio</kernel> errors when it
   comes from a read-only medium like a snap

To unblock us short term this commit just reverts back to 16.04 to
unbreak master and then we can work on a proper fix.
