### PR TITLE
interfaces/network-control: additional ethernet rule

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -142,6 +142,9 @@ network sna,
 /sys/devices/{pci[0-9a-f]*,platform,virtual}/**/rfkill[0-9]*/{,**} r,
 /sys/devices/{pci[0-9a-f]*,platform,virtual}/**/rfkill[0-9]*/state w,
 
+# For reading the address of a particular ethernet interface
+/sys/devices/{pci[0-9a-f]*,platform,virtual}/**/net/*/address r,
+
 # arp
 network netlink dgram,
 


### PR DESCRIPTION
This should allow an access of the form:

AVC apparmor="DENIED" operation="open" profile="snap.name.app" name=/sys/devices/platform/soc@0/30800000.bus/30be0000.ethernet/net/eth0/address pid=18219 comm="vgc-bc" requested_mask="r" denied_mask="r" fsuid=0 ouid=0