### PR TITLE
tests/nested/manual/refresh-revert-fundamentals: fix variable use

### DIFF
--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -91,7 +91,7 @@ execute: |
         pc-kernel|core20)
             #shellcheck disable=SC2098
             #shellcheck disable=SC2097
-            retry --wait 1 -n 10 --env REVERT_ID="$REVERT_ID" sh -c "tests.nested exec snap changes | MATCH \"$REVERT_ID\s+Done\s+.*\""
+            retry --wait 1 -n 10 --env REFRESH_ID="$REFRESH_ID" sh -c "tests.nested exec snap changes | MATCH \"$REFRESH_ID\s+Done\s+.*\""
             ;;
     esac
 

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -119,6 +119,6 @@ execute: |
     echo "Check the change is completed"
     case "$SNAP" in
         pc-kernel|core20)
-            tests.nested exec "retry --wait 1 -n 10 --env REVERT_ID=\"$REVERT_ID\" sh -c \'snap changes | MATCH \"$REVERT_ID\s+Done\s+.*\"\'"
+            tests.nested exec "retry --wait 1 -n 30 --env REVERT_ID=\"$REVERT_ID\" sh -c \'snap changes | MATCH \"$REVERT_ID\s+Done\s+.*\"\'"
             ;;
     esac

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -119,6 +119,6 @@ execute: |
     echo "Check the change is completed"
     case "$SNAP" in
         pc-kernel|core20)
-            tests.nested exec "retry --wait 1 -n 30 --env REVERT_ID=\"$REVERT_ID\" sh -c \'snap changes | MATCH \"$REVERT_ID\s+Done\s+.*\"\'"
+            retry --wait 1 -n 10 --env REVERT_ID="$REVERT_ID" sh -c "tests.nested exec snap changes | MATCH \"$REVERT_ID\s+Done\s+.*\""
             ;;
     esac


### PR DESCRIPTION
Commit a7657b5b10e7bfc38991918d33467d659d05fe4b seems to have broken the test,
which went unnoticed until there happened to be leaking a set -u from one of the
sourced files which triggered this error:

```
+ echo 'Check the new version of the snaps is correct after the system reboot'
Check the new version of the snaps is correct after the system reboot
+ tests.nested exec 'snap list core20'
+ MATCH '^core20.*1113.*latest/edge.*'
Warning: Permanently added '[localhost]:8022' (ECDSA) to the list of known hosts.
+ echo 'Check the change is completed'
Check the change is completed
+ case "$SNAP" in
/bin/bash: line 121: REVERT_ID: unbound variable
-----
```

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
