### PR TITLE
o/hookstate: require snap-refresh-control interface for snapctl refresh --proceed

### DIFF
--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -256,7 +256,7 @@ func (c *refreshCommand) proceed() error {
 	// running outside of hook
 	if ctx.IsEphemeral() {
 		st := ctx.State()
-		allow, err := allowProceed(st, ctx.InstanceName())
+		allow, err := allowRefreshProceedOutsideHook(st, ctx.InstanceName())
 		if err != nil {
 			return err
 		}
@@ -286,7 +286,7 @@ func (c *refreshCommand) proceed() error {
 	return nil
 }
 
-func allowProceed(st *state.State, snapName string) (bool, error) {
+func allowRefreshProceedOutsideHook(st *state.State, snapName string) (bool, error) {
 	conns, err := ifacestate.ConnectionStates(st)
 	if err != nil {
 		return false, fmt.Errorf("internal error: cannot get connections: %s", err)

--- a/tests/lib/snaps/store/test-snapd-refresh-control.v1/build-aux/snap/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-refresh-control.v1/build-aux/snap/snapcraft.yaml
@@ -28,3 +28,5 @@ plugs:
     interface: content
     content: test-content
     target: $SNAP/content
+  snap-refresh-control:
+    interface: snap-refresh-control

--- a/tests/lib/snaps/store/test-snapd-refresh-control.v2/build-aux/snap/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-refresh-control.v2/build-aux/snap/snapcraft.yaml
@@ -28,3 +28,5 @@ plugs:
     interface: content
     content: test-content
     target: $SNAP/content
+  snap-refresh-control:
+    interface: snap-refresh-control

--- a/tests/main/auto-refresh-gating-from-snap/task.yaml
+++ b/tests/main/auto-refresh-gating-from-snap/task.yaml
@@ -31,6 +31,9 @@ execute: |
   echo "Connecting the two test snaps with content interface"
   snap connect "$SNAP_NAME:content" "$CONTENT_SNAP_NAME:content"
 
+  echo "Connecting snap-refresh-control interface to allow the snap to call snapctl refresh --proceed"
+  snap connect "$SNAP_NAME:snap-refresh-control"
+
   # sanity check
   snap list | MATCH "$SNAP_NAME +1\.0\.0"
   snap list | MATCH "$CONTENT_SNAP_NAME +1\.0\.0"
@@ -89,3 +92,7 @@ execute: |
   echo "Ensure our snaps were updated"
   snap list | MATCH "$CONTENT_SNAP_NAME +2\.0\.0"
   snap list | MATCH "$SNAP_NAME +2\.0\.0"
+
+  echo "Check than --proceed is not allowed without snap-refresh-control interface"
+  snap disconnect "$SNAP_NAME":snap-refresh-control
+  "$SNAP_NAME".proceed 2>&1 | MATCH "cannot proceed: requires snap-refresh-control interface"


### PR DESCRIPTION
Require snap-refresh-control interface for `snapctl refresh --proceed` from snaps. The test snaps in the store have been updated with the new definitions including this interface.