### PR TITLE
systemd: add mock systemd helper

### DIFF
--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -111,8 +111,9 @@ func (s *mountunitSuite) TestAddMountUnit(c *C) {
 		where:    fmt.Sprintf("%s/foo/13", dirs.StripRootDir(dirs.SnapMountDir)),
 		fstype:   "squashfs",
 	}
-	c.Check(sysd.AddMountUnitFileCalls, HasLen, 1)
-	c.Check(sysd.AddMountUnitFileCalls[0], DeepEquals, expectedParameters)
+	c.Check(sysd.AddMountUnitFileCalls, DeepEquals, []ParamsForAddMountUnitFile{
+		expectedParameters,
+	})
 }
 
 func (s *mountunitSuite) TestRemoveMountUnit(c *C) {

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -20,15 +20,12 @@
 package backend_test
 
 import (
+	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/osutil/squashfs"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
@@ -36,11 +33,41 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
+type ParamsForAddMountUnitFile struct {
+	name, revision, what, where, fstype string
+}
+
+type ResultForAddMountUnitFile struct {
+	path string
+	err  error
+}
+
+type FakeSystemd struct {
+	systemd.Systemd
+
+	Kind  systemd.Kind
+	Mode  systemd.InstanceMode
+	Meter systemd.Reporter
+
+	AddMountUnitFileCalls  []ParamsForAddMountUnitFile
+	AddMountUnitFileResult ResultForAddMountUnitFile
+
+	RemoveMountUnitFileCalls  []string
+	RemoveMountUnitFileResult error
+}
+
+func (s *FakeSystemd) AddMountUnitFile(name, revision, what, where, fstype string) (string, error) {
+	s.AddMountUnitFileCalls = append(s.AddMountUnitFileCalls,
+		ParamsForAddMountUnitFile{name, revision, what, where, fstype})
+	return s.AddMountUnitFileResult.path, s.AddMountUnitFileResult.err
+}
+
+func (s *FakeSystemd) RemoveMountUnitFile(mountDir string) error {
+	s.RemoveMountUnitFileCalls = append(s.RemoveMountUnitFileCalls, mountDir)
+	return s.RemoveMountUnitFileResult
+}
+
 type mountunitSuite struct {
-	umount *testutil.MockCmd
-
-	systemctlRestorer func()
-
 	testutil.BaseTest
 }
 
@@ -48,27 +75,21 @@ var _ = Suite(&mountunitSuite{})
 
 func (s *mountunitSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
-
-	// needed for system key generation
-	s.AddCleanup(osutil.MockMountInfo(""))
-
-	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc", "systemd", "system", "multi-user.target.wants"), 0755)
-	c.Assert(err, IsNil)
-
-	s.systemctlRestorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
-		return []byte("ActiveState=inactive\n"), nil
-	})
-	s.umount = testutil.MockCommand(c, "umount", "")
 }
 
 func (s *mountunitSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-	s.umount.Restore()
-	s.systemctlRestorer()
 }
 
 func (s *mountunitSuite) TestAddMountUnit(c *C) {
-	restore := squashfs.MockNeedsFuse(false)
+	expectedErr := errors.New("creation error")
+
+	var sysd *FakeSystemd
+	restore := systemd.MockNewSystemd(func(kind systemd.Kind, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		sysd = &FakeSystemd{Kind: kind, Mode: mode, Meter: meter}
+		sysd.AddMountUnitFileResult = ResultForAddMountUnitFile{"", expectedErr}
+		return sysd
+	})
 	defer restore()
 
 	info := &snap.Info{
@@ -80,49 +101,33 @@ func (s *mountunitSuite) TestAddMountUnit(c *C) {
 		Architectures: []string{"all"},
 	}
 	err := backend.AddMountUnit(info, false, progress.Null)
-	c.Assert(err, IsNil)
+	c.Check(err, Equals, expectedErr)
 
-	// ensure correct mount unit
-	un := fmt.Sprintf("%s.mount", systemd.EscapeUnitNamePath(filepath.Join(dirs.StripRootDir(dirs.SnapMountDir), "foo", "13")))
-	c.Assert(filepath.Join(dirs.SnapServicesDir, un), testutil.FileEquals, fmt.Sprintf(`
-[Unit]
-Description=Mount unit for foo, revision 13
-Before=snapd.service
-After=zfs-mount.service
-
-[Mount]
-What=/var/lib/snapd/snaps/foo_13.snap
-Where=%s/foo/13
-Type=squashfs
-Options=nodev,ro,x-gdu.hide,x-gvfs-hide
-LazyUnmount=yes
-
-[Install]
-WantedBy=multi-user.target
-`[1:], dirs.StripRootDir(dirs.SnapMountDir)))
+	// ensure correct parameters
+	expectedParameters := ParamsForAddMountUnitFile{
+		name:     "foo",
+		revision: "13",
+		what:     "/var/lib/snapd/snaps/foo_13.snap",
+		where:    fmt.Sprintf("%s/foo/13", dirs.StripRootDir(dirs.SnapMountDir)),
+		fstype:   "squashfs",
+	}
+	c.Check(sysd.AddMountUnitFileCalls, HasLen, 1)
+	c.Check(sysd.AddMountUnitFileCalls[0], DeepEquals, expectedParameters)
 }
 
 func (s *mountunitSuite) TestRemoveMountUnit(c *C) {
-	info := &snap.Info{
-		SideInfo: snap.SideInfo{
-			RealName: "foo",
-			Revision: snap.R(13),
-		},
-		Version:       "1.1",
-		Architectures: []string{"all"},
-	}
+	expectedErr := errors.New("removal error")
 
-	err := backend.AddMountUnit(info, false, progress.Null)
-	c.Assert(err, IsNil)
+	var sysd *FakeSystemd
+	restore := systemd.MockNewSystemd(func(kind systemd.Kind, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		sysd = &FakeSystemd{Kind: kind, Mode: mode, Meter: meter}
+		sysd.RemoveMountUnitFileResult = expectedErr
+		return sysd
+	})
+	defer restore()
 
-	// ensure we have the files
-	un := fmt.Sprintf("%s.mount", systemd.EscapeUnitNamePath(filepath.Join(dirs.StripRootDir(dirs.SnapMountDir), "foo", "13")))
-	p := filepath.Join(dirs.SnapServicesDir, un)
-	c.Assert(osutil.FileExists(p), Equals, true)
-
-	// now call remove and ensure they are gone
-	err = backend.RemoveMountUnit(info.MountDir(), progress.Null)
-	c.Assert(err, IsNil)
-	p = filepath.Join(dirs.SnapServicesDir, un)
-	c.Assert(osutil.FileExists(p), Equals, false)
+	err := backend.RemoveMountUnit("/some/where", progress.Null)
+	c.Check(err, Equals, expectedErr)
+	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 1)
+	c.Check(sysd.RemoveMountUnitFileCalls[0], Equals, "/some/where")
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -337,7 +337,7 @@ func newSystemdReal(kind Kind, rootDir string, mode InstanceMode, rep Reporter) 
 // New returns a Systemd that uses the default root directory and omits
 // --root argument when executing systemctl.
 func New(mode InstanceMode, rep Reporter) Systemd {
-	return newSystemd(FullImplementation, dirs.GlobalRootDir, mode, rep)
+	return newSystemd(FullImplementation, "", mode, rep)
 }
 
 // NewUnderRoot returns a Systemd that operates on the given rootdir.

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -306,22 +306,22 @@ const (
 	UserServicesTarget = "default.target"
 )
 
-type reporter interface {
+type Reporter interface {
 	Notify(string)
 }
 
-func newSystemd(kind Kind, rootDir string, mode InstanceMode, rep reporter) Systemd {
+func newSystemdReal(kind Kind, rootDir string, mode InstanceMode, rep Reporter) Systemd {
 	return &systemd{rootDir: rootDir, mode: mode, reporter: rep}
 }
 
 // New returns a Systemd that uses the default root directory and omits
 // --root argument when executing systemctl.
-func New(mode InstanceMode, rep reporter) Systemd {
+func New(mode InstanceMode, rep Reporter) Systemd {
 	return newSystemd(FullImplementation, dirs.GlobalRootDir, mode, rep)
 }
 
 // NewUnderRoot returns a Systemd that operates on the given rootdir.
-func NewUnderRoot(rootDir string, mode InstanceMode, rep reporter) Systemd {
+func NewUnderRoot(rootDir string, mode InstanceMode, rep Reporter) Systemd {
 	return newSystemd(FullImplementation, rootDir, mode, rep)
 }
 
@@ -362,7 +362,7 @@ const (
 
 type systemd struct {
 	rootDir  string
-	reporter reporter
+	reporter Reporter
 	mode     InstanceMode
 }
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -310,15 +310,19 @@ type reporter interface {
 	Notify(string)
 }
 
+func newSystemd(kind Kind, rootDir string, mode InstanceMode, rep reporter) Systemd {
+	return &systemd{rootDir: rootDir, mode: mode, reporter: rep}
+}
+
 // New returns a Systemd that uses the default root directory and omits
 // --root argument when executing systemctl.
 func New(mode InstanceMode, rep reporter) Systemd {
-	return &systemd{mode: mode, reporter: rep}
+	return newSystemd(FullImplementation, dirs.GlobalRootDir, mode, rep)
 }
 
 // NewUnderRoot returns a Systemd that operates on the given rootdir.
 func NewUnderRoot(rootDir string, mode InstanceMode, rep reporter) Systemd {
-	return &systemd{rootDir: rootDir, mode: mode, reporter: rep}
+	return newSystemd(FullImplementation, rootDir, mode, rep)
 }
 
 // NewEmulationMode returns a Systemd that runs in emulation mode where
@@ -328,9 +332,7 @@ func NewEmulationMode(rootDir string) Systemd {
 	if rootDir == "" {
 		rootDir = dirs.GlobalRootDir
 	}
-	return &emulation{
-		rootDir: rootDir,
-	}
+	return newSystemd(EmulationMode, rootDir, SystemMode, nil)
 }
 
 // InstanceMode determines which instance of systemd to control.
@@ -349,6 +351,13 @@ const (
 	SystemMode InstanceMode = iota
 	UserMode
 	GlobalUserMode
+)
+
+type Kind int
+
+const (
+	FullImplementation Kind = iota
+	EmulationMode
 )
 
 type systemd struct {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -63,6 +63,9 @@ var (
 	daemonReloadLock extMutex
 
 	osutilIsMounted = osutil.IsMounted
+
+	// allow replacing the systemd implementation with a mock one
+	newSystemd = newSystemdReal
 )
 
 // mu is a sync.Mutex that also supports to check if the lock is taken
@@ -89,6 +92,16 @@ func (m *extMutex) Unlock() {
 func (m *extMutex) Taken(errMsg string) {
 	if atomic.LoadInt32(&m.muC) != 1 {
 		panic("internal error: " + errMsg)
+	}
+}
+
+// MockNewSystemd can be used to replace the constructor of the
+// Systemd types with a function that returns a mock object.
+func MockNewSystemd(f func(kind Kind, rootDir string, mode InstanceMode, rep Reporter) Systemd) func() {
+	oldNewSystemd := newSystemd
+	newSystemd = f
+	return func() {
+		newSystemd = oldNewSystemd
 	}
 }
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -324,7 +324,14 @@ type Reporter interface {
 }
 
 func newSystemdReal(kind Kind, rootDir string, mode InstanceMode, rep Reporter) Systemd {
-	return &systemd{rootDir: rootDir, mode: mode, reporter: rep}
+	switch kind {
+	case FullImplementation:
+		return &systemd{rootDir: rootDir, mode: mode, reporter: rep}
+	case EmulationMode:
+		return &emulation{rootDir: rootDir}
+	default:
+		panic(fmt.Sprintf("unsupported systemd kind %v", kind))
+	}
 }
 
 // New returns a Systemd that uses the default root directory and omits


### PR DESCRIPTION
Add a helper to allow injecting a mock Systemd implementation.

The mount backend tests are rewritten to use this new feature, as an example.

The benefit is that we'll have fewer dependencies in the tests, and fewer things to adapt when we change the implementation of the systemd methods (systemctl calls in particular).

The previous attempt at something similar was in https://github.com/snapcore/snapd/pull/10704