### PR TITLE
tests/nested/core/extra-snaps-assertions: fix the match pattern

### DIFF
--- a/tests/nested/core/extra-snaps-assertions/task.yaml
+++ b/tests/nested/core/extra-snaps-assertions/task.yaml
@@ -12,9 +12,9 @@ execute: |
     echo "We have a model assertion"
     tests.nested exec "snap known model" | MATCH "series: 16"
 
-    EXPRESSION="^core .* +latest/$NESTED_CORE_CHANNEL +canonical\\* +core"
+    EXPRESSION="^core18 .* +latest/$NESTED_CORE_CHANNEL +canonical\\* +base"
     if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "true" ]; then
-        EXPRESSION="^core .* +x1 .* core"
+        EXPRESSION="^core18 .* +x1 .* base"
     fi
 
     echo "Make sure core has an actual revision"


### PR DESCRIPTION
Since switching to Bionic in cc6266051b6f98797fdce6ec04fc4b84ec7ee36c the test
was broken as it expected a different pattern.

