### PR TITLE
codecov: fix files pathnames

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+    - "src/github.com/snapcore/snapd/::"


### PR DESCRIPTION
Apply a mapping, as documented in [1], to allow codecov to resolve the
filenames into valid paths inside our git repository. This will allow us
to see the coverage data for individual source files.

[1]: https://codecov.freshdesk.com/support/solutions/articles/43000593943-files-not-showing-in-codecov-fixing-paths-
