### PR TITLE
tests/lib/nested.sh: split out additional helper for adding files to VM imgs

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -792,10 +792,9 @@ users:
 EOF
 }
 
-nested_configure_cloud_init_on_core20_vm() {
+nested_add_file_to_vm() {
     local IMAGE=$1
-    nested_create_cloud_init_uc20_config "$NESTED_ASSETS_DIR/data.cfg"
-
+    local FILE=$2
     local devloop dev ubuntuSeedDev tmp
     # mount the image and find the loop device /dev/loop that is created for it
     kpartx -avs "$IMAGE"
@@ -810,10 +809,17 @@ nested_configure_cloud_init_on_core20_vm() {
     tmp=$(mktemp -d)
     mount "$ubuntuSeedDev" "$tmp"
     mkdir -p "$tmp/data/etc/cloud/cloud.cfg.d/"
-    cp -f "$NESTED_ASSETS_DIR/data.cfg" "$tmp/data/etc/cloud/cloud.cfg.d/"
+    cp -f "$FILE" "$tmp/data/etc/cloud/cloud.cfg.d/"
     sync
     umount "$tmp"
     kpartx -d "$IMAGE"
+}
+
+nested_configure_cloud_init_on_core20_vm() {
+    local IMAGE=$1
+    nested_create_cloud_init_uc20_config "$NESTED_ASSETS_DIR/data.cfg"
+
+    nested_add_file_to_vm "$IMAGE" "$NESTED_ASSETS_DIR/data.cfg"
 }
 
 nested_save_serial_log() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1032,8 +1032,10 @@ nested_start_core_vm_unit() {
         nested_exec "sudo snap wait system seed.loaded"
         # Copy tools to be used on tests
         nested_prepare_tools
-        # Wait for cloud init to be done
-        nested_exec "retry --wait 1 -n 5 sh -c 'cloud-init status --wait'"
+        # Wait for cloud init to be done if the system is using cloud-init
+        if [ "$NESTED_USE_CLOUD_INIT" = true ]; then
+            nested_exec "retry --wait 1 -n 5 sh -c 'cloud-init status --wait'"
+        fi
     fi
 }
 


### PR DESCRIPTION
This is needed for testing ubuntu-seed MAAS config on UC20 nested tests, where
we need to add multiple / many files to a UC20 image file before booting it.

Also don't check cloud-init if the VM is not using cloud-init.

Broken out from https://github.com/snapcore/snapd/pull/10573

See the spread test in https://github.com/snapcore/snapd/pull/10573 for an example of how this is used.
