### PR TITLE
o/hookstate/ctlcmd: Implement snapctl refresh --show-lock command

### DIFF
--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -25,6 +25,8 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/snapcore/snapd/cmd/snaplock"
+	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
@@ -45,6 +47,8 @@ type refreshCommand struct {
 	// these two options are mutually exclusive
 	Proceed bool `long:"proceed" description:"Proceed with potentially disruptive refreshes"`
 	Hold    bool `long:"hold" description:"Do not proceed with potentially disruptive refreshes"`
+
+	PrintInhibitLock bool `long:"show-inhibit-lock" description:"Show inhibit lock value (may be empty)"`
 }
 
 var shortRefreshHelp = i18n.G("The refresh command prints pending refreshes and can hold back disruptive ones.")
@@ -101,8 +105,21 @@ func (c *refreshCommand) Execute(args []string) error {
 		return fmt.Errorf("can only be used from gate-auto-refresh hook")
 	}
 
-	if c.Proceed && c.Hold {
-		return fmt.Errorf("cannot use --proceed and --hold together")
+	var which string
+	for _, opt := range []struct {
+		val  bool
+		name string
+	}{
+		{c.PrintInhibitLock, "--show-inhibit-lock"},
+		{c.Hold, "--hold"},
+		{c.Proceed, "--proceed"},
+	} {
+		if opt.val && which != "" {
+			return fmt.Errorf("cannot use %s and %s together", opt.name, which)
+		}
+		if opt.val {
+			which = opt.name
+		}
 	}
 
 	// --pending --proceed is a verbose way of saying --proceed, so only
@@ -118,6 +135,8 @@ func (c *refreshCommand) Execute(args []string) error {
 		return c.proceed()
 	case c.Hold:
 		return c.hold()
+	case c.PrintInhibitLock:
+		return c.printInhibitLockHint()
 	}
 
 	return nil
@@ -304,4 +323,28 @@ func allowRefreshProceedOutsideHook(st *state.State, snapName string) (bool, err
 		}
 	}
 	return false, nil
+}
+
+func (c *refreshCommand) printInhibitLockHint() error {
+	ctx := c.context()
+	ctx.Lock()
+	snapName := ctx.InstanceName()
+	ctx.Unlock()
+
+	// obtain snap lock before manipulating runinhibit lock.
+	lock, err := snaplock.OpenLock(snapName)
+	if err != nil {
+		return err
+	}
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+	defer lock.Unlock()
+
+	hint, err := runinhibit.IsLocked(snapName)
+	if err != nil {
+		return err
+	}
+	c.printf("%s", hint)
+	return nil
 }

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -48,7 +48,7 @@ type refreshCommand struct {
 	Proceed bool `long:"proceed" description:"Proceed with potentially disruptive refreshes"`
 	Hold    bool `long:"hold" description:"Do not proceed with potentially disruptive refreshes"`
 
-	PrintInhibitLock bool `long:"show-inhibit-lock" description:"Show inhibit lock value (may be empty)"`
+	PrintInhibitLock bool `long:"show-lock" description:"Show the value of the run inhibit lock held during refreshes (empty means not held)"`
 }
 
 var shortRefreshHelp = i18n.G("The refresh command prints pending refreshes and can hold back disruptive ones.")
@@ -110,7 +110,7 @@ func (c *refreshCommand) Execute(args []string) error {
 		val  bool
 		name string
 	}{
-		{c.PrintInhibitLock, "--show-inhibit-lock"},
+		{c.PrintInhibitLock, "--show-lock"},
 		{c.Hold, "--hold"},
 		{c.Proceed, "--proceed"},
 	} {

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -25,6 +25,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/cmd/snaplock"
+	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -82,6 +84,12 @@ var refreshFromHookTests = []struct {
 }{{
 	args: []string{"refresh", "--proceed", "--hold"},
 	err:  "cannot use --proceed and --hold together",
+}, {
+	args: []string{"refresh", "--proceed", "--show-inhibit-lock"},
+	err:  "cannot use --proceed and --show-inhibit-lock together",
+}, {
+	args: []string{"refresh", "--hold", "--show-inhibit-lock"},
+	err:  "cannot use --hold and --show-inhibit-lock together",
 }, {
 	args: []string{"refresh", "--pending"},
 	refreshCandidates: map[string]interface{}{
@@ -428,4 +436,25 @@ func (s *refreshSuite) TestRefreshRegularUserForbidden(c *C) {
 	c.Assert(err, ErrorMatches, `cannot use "refresh" with uid 1000, try with sudo`)
 	forbidden, _ := err.(*ctlcmd.ForbiddenCommandError)
 	c.Assert(forbidden, NotNil)
+}
+
+func (s *refreshSuite) TestRefreshPrintInhibitHint(c *C) {
+	s.st.Lock()
+	task := s.st.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(1), Hook: "gate-auto-refresh"}
+	mockContext, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
+	c.Check(err, IsNil)
+	s.st.Unlock()
+
+	lock, err := snaplock.OpenLock("snap1")
+	c.Assert(err, IsNil)
+	err = lock.Lock()
+	c.Assert(err, IsNil)
+	c.Check(runinhibit.LockWithHint("snap1", runinhibit.HintInhibitedForRefresh), IsNil)
+	lock.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"refresh", "--show-inhibit-lock"}, 0)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, "refresh")
+	c.Check(string(stderr), Equals, "")
 }

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -458,3 +458,17 @@ func (s *refreshSuite) TestRefreshPrintInhibitHint(c *C) {
 	c.Check(string(stdout), Equals, "refresh")
 	c.Check(string(stderr), Equals, "")
 }
+
+func (s *refreshSuite) TestRefreshPrintInhibitHintEmpty(c *C) {
+	s.st.Lock()
+	task := s.st.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "some-snap", Revision: snap.R(1), Hook: "gate-auto-refresh"}
+	mockContext, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
+	c.Check(err, IsNil)
+	s.st.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"refresh", "--show-lock"}, 0)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+}

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -85,11 +85,11 @@ var refreshFromHookTests = []struct {
 	args: []string{"refresh", "--proceed", "--hold"},
 	err:  "cannot use --proceed and --hold together",
 }, {
-	args: []string{"refresh", "--proceed", "--show-inhibit-lock"},
-	err:  "cannot use --proceed and --show-inhibit-lock together",
+	args: []string{"refresh", "--proceed", "--show-lock"},
+	err:  "cannot use --proceed and --show-lock together",
 }, {
-	args: []string{"refresh", "--hold", "--show-inhibit-lock"},
-	err:  "cannot use --hold and --show-inhibit-lock together",
+	args: []string{"refresh", "--hold", "--show-lock"},
+	err:  "cannot use --hold and --show-lock together",
 }, {
 	args: []string{"refresh", "--pending"},
 	refreshCandidates: map[string]interface{}{
@@ -453,7 +453,7 @@ func (s *refreshSuite) TestRefreshPrintInhibitHint(c *C) {
 	c.Check(runinhibit.LockWithHint("snap1", runinhibit.HintInhibitedForRefresh), IsNil)
 	lock.Unlock()
 
-	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"refresh", "--show-inhibit-lock"}, 0)
+	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"refresh", "--show-lock"}, 0)
 	c.Assert(err, IsNil)
 	c.Check(string(stdout), Equals, "refresh")
 	c.Check(string(stderr), Equals, "")


### PR DESCRIPTION
Implement snapctl refresh --show-lock command for showing current value of refresh inhibit lock.
