### PR TITLE
interfaces/block-devices: support to access the state of block devices

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -95,6 +95,10 @@ capability sys_admin,
 # Devices for various controllers used with ioctl()
 /dev/mpt2ctl{,_wd} rw,
 /dev/megaraid_sas_ioctl_node rw,
+
+# Allow /sys/block/sdX/device/state to be accessible to accept or reject the request from given the path.
+# To take the path offline will cause any subsequent access to fail immediately, vice versa.
+/sys/devices/**/host*/**/state rw,
 `
 
 var blockDevicesConnectedPlugUDev = []string{


### PR DESCRIPTION
This enables the control for the path of block devices that can be removed or
recovered after setting the state of running, so it would be safer to
take block devices to be offline state instead of unplugging the
physical devices.

Signed-off-by: Hsieh-Tseng Shen <woodrow.shen@canonical.com>

