### PR TITLE
tests: fix fakedevicesvc service already exists

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -896,6 +896,7 @@ suites:
             tests.nested remove-vm
             tests.nested restore
             tests.backup restore
+            tests.cleanup restore
         restore: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
@@ -932,6 +933,7 @@ suites:
         restore-each: |
             tests.nested remove-vm
             tests.backup restore
+            tests.cleanup restore
         restore: |
             tests.nested restore
 
@@ -970,6 +972,7 @@ suites:
         restore-each: |
             tests.nested remove-vm
             tests.backup restore
+            tests.cleanup restore
         restore: |
             tests.nested restore
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -895,8 +895,8 @@ suites:
         restore-each: |
             tests.nested remove-vm
             tests.nested restore
-            tests.backup restore
             tests.cleanup restore
+            tests.backup restore
         restore: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
@@ -932,8 +932,8 @@ suites:
             tests.nested create-vm classic
         restore-each: |
             tests.nested remove-vm
-            tests.backup restore
             tests.cleanup restore
+            tests.backup restore
         restore: |
             tests.nested restore
 
@@ -971,8 +971,8 @@ suites:
             tests.nested create-vm core
         restore-each: |
             tests.nested remove-vm
-            tests.backup restore
             tests.cleanup restore
+            tests.backup restore
         restore: |
             tests.nested restore
 

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -103,6 +103,8 @@ prepare: |
 
     # start fake device svc
     systemd-run --collect --unit fakedevicesvc fakedevicesvc localhost:11029
+    # stop fake device svc
+    tests.cleanup defer systemctl stop fakedevicesvc
 
     # include the extra snap declaration bits we need to auto-connect the 
     # system-files plugs for the install-device hook
@@ -123,9 +125,6 @@ restore: |
         echo "This test needs test keys to be trusted"
         exit
     fi
-
-    # stop fake device svc
-    systemctl stop fakedevicesvc
 
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -103,7 +103,6 @@ prepare: |
 
     # start fake device svc
     systemd-run --collect --unit fakedevicesvc fakedevicesvc localhost:11029
-    tests.cleanup defer systemctl stop fakedevicesvc
 
     # include the extra snap declaration bits we need to auto-connect the 
     # system-files plugs for the install-device hook
@@ -124,6 +123,9 @@ restore: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+
+    # stop fake device svc
+    systemctl stop fakedevicesvc
 
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh


### PR DESCRIPTION
This is to avoid the error

systemd-run --collect --unit fakedevicesvc fakedevicesvc localhost:11029
Failed to start transient service unit: Unit fakedevicesvc.service
already exists.

The the following tests were executed in order:

google-nested:ubuntu-20.04-64:tests/nested/manual/core20-install-device-file-install-via-hook-hack
google-nested:ubuntu-20.04-64:tests/nested/manual/grade-signed-above-testkeys-boot:secured
