### PR TITLE
overlord/ifacestate: fix arguments in unit tests

### DIFF
--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -8839,7 +8839,7 @@ func (s *interfaceManagerSuite) TestResolveDisconnectMatrixTypical(c *C) {
 
 func (s *interfaceManagerSuite) TestConnectSetsUpSecurityFails(c *C) {
 	s.MockModel(c, nil)
-	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)


### PR DESCRIPTION
The #10728 PR landed after we merged unused arguments cleanups and caused some
conflicts with current master.

Fixes:
```
Running vet
# github.com/snapcore/snapd/overlord/ifacestate_test
vet: overlord/ifacestate/ifacestate_test.go:8842:15: cannot use c (variable of type *check.C) as interfaces.Interface value in argument to s.mockIfaces: missing method AutoConnect
```
