### PR TITLE
packaging: ship the `snapd.apparmor.service` unit in debian

### DIFF
--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -253,10 +253,6 @@ override_dh_install-arch:
 	# Rename the apparmor profile, see dh_apparmor call above for an explanation.
 	mv $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine.real
 
-	# On Ubuntu and Debian we don't need to install the apparmor helper service.
-	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.apparmor.service
-	rm $(CURDIR)/debian/tmp/usr/lib/snapd/snapd-apparmor
-
 	# Ouside of core we don't need to install the following files:
 	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.autoimport.service
 	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.core-fixup.service

--- a/packaging/debian-sid/snapd.install
+++ b/packaging/debian-sid/snapd.install
@@ -38,3 +38,6 @@ usr/lib/snapd/snap-gdbserver-shim
 usr/lib/systemd/system-environment-generators
 # but system generators end up in lib
 lib/systemd/system-generators
+
+# service for loading apparmor profiles for snap applications
+usr/lib/snapd/snapd-apparmor


### PR DESCRIPTION
The `snapd.apparmor.service` was not needed in debian because
it used a version of apparmor that would do the snapd apparmor
profile loading for us. However this support was dropped with
apparmor 3 and when it entered unstable this broke snapd.

This commit ensures it is shipped on debian too.
