### PR TITLE
cmd/snap: don't translate service statuses in 'snap services' output

### DIFF
--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -138,15 +138,15 @@ func (s *svcStatus) Execute(args []string) error {
 	fmt.Fprintln(w, i18n.G("Service\tStartup\tCurrent\tNotes"))
 
 	for _, svc := range services {
-		startup := i18n.G("disabled")
+		startup := "disabled"
 		if svc.Enabled {
-			startup = i18n.G("enabled")
+			startup = "enabled"
 		}
-		current := i18n.G("inactive")
+		current := "inactive"
 		if svc.DaemonScope == snap.UserDaemon {
 			current = "-"
 		} else if svc.Active {
-			current = i18n.G("active")
+			current = "active"
 		}
 		fmt.Fprintf(w, "%s.%s\t%s\t%s\t%s\n", svc.Snap, svc.Name, startup, current, clientutil.ClientAppInfoNotes(svc))
 	}


### PR DESCRIPTION
It was rightfully pointed out in https://bugs.launchpad.net/snappy/+bug/1941926 that translating service statuses makes it hard to handle 'snap services' in scripts, so this PR drops i18n around service status. I think 'snap services' should be usable for scripts just like 'systemctl' is.
