### PR TITLE
client: turn the Client type into an interface

### DIFF
--- a/client/aliases.go
+++ b/client/aliases.go
@@ -34,8 +34,17 @@ type aliasAction struct {
 	Alias  string `json:"alias,omitempty"`
 }
 
+type ClientAliases interface {
+	Alias(snapName, app, alias string) (changeID string, err error)
+	DisableAllAliases(snapName string) (changeID string, err error)
+	RemoveManualAlias(alias string) (changeID string, err error)
+	Unalias(aliasOrSnap string) (changeID string, err error)
+	Prefer(snapName string) (changeID string, err error)
+	Aliases() (allStatuses map[string]map[string]AliasStatus, err error)
+}
+
 // performAliasAction performs a single action on aliases.
-func (client *Client) performAliasAction(sa *aliasAction) (changeID string, err error) {
+func (client *client) performAliasAction(sa *aliasAction) (changeID string, err error) {
 	b, err := json.Marshal(sa)
 	if err != nil {
 		return "", err
@@ -44,7 +53,7 @@ func (client *Client) performAliasAction(sa *aliasAction) (changeID string, err 
 }
 
 // Alias sets up a manual alias from alias to app in snapName.
-func (client *Client) Alias(snapName, app, alias string) (changeID string, err error) {
+func (client *client) Alias(snapName, app, alias string) (changeID string, err error) {
 	return client.performAliasAction(&aliasAction{
 		Action: "alias",
 		Snap:   snapName,
@@ -54,7 +63,7 @@ func (client *Client) Alias(snapName, app, alias string) (changeID string, err e
 }
 
 // // DisableAllAliases disables all aliases of a snap, removing all manual ones.
-func (client *Client) DisableAllAliases(snapName string) (changeID string, err error) {
+func (client *client) DisableAllAliases(snapName string) (changeID string, err error) {
 	return client.performAliasAction(&aliasAction{
 		Action: "unalias",
 		Snap:   snapName,
@@ -62,7 +71,7 @@ func (client *Client) DisableAllAliases(snapName string) (changeID string, err e
 }
 
 // RemoveManualAlias removes a manual alias.
-func (client *Client) RemoveManualAlias(alias string) (changeID string, err error) {
+func (client *client) RemoveManualAlias(alias string) (changeID string, err error) {
 	return client.performAliasAction(&aliasAction{
 		Action: "unalias",
 		Alias:  alias,
@@ -70,7 +79,7 @@ func (client *Client) RemoveManualAlias(alias string) (changeID string, err erro
 }
 
 // Unalias tears down a manual alias or disables all aliases of a snap (removing all manual ones)
-func (client *Client) Unalias(aliasOrSnap string) (changeID string, err error) {
+func (client *client) Unalias(aliasOrSnap string) (changeID string, err error) {
 	return client.performAliasAction(&aliasAction{
 		Action: "unalias",
 		Snap:   aliasOrSnap,
@@ -80,7 +89,7 @@ func (client *Client) Unalias(aliasOrSnap string) (changeID string, err error) {
 
 // Prefer enables all aliases of a snap in preference to conflicting aliases
 // of other snaps whose aliases will be disabled (removed for manual ones).
-func (client *Client) Prefer(snapName string) (changeID string, err error) {
+func (client *client) Prefer(snapName string) (changeID string, err error) {
 	return client.performAliasAction(&aliasAction{
 		Action: "prefer",
 		Snap:   snapName,
@@ -96,7 +105,7 @@ type AliasStatus struct {
 }
 
 // Aliases returns a map snap -> alias -> AliasStatus for all snaps and aliases in the system.
-func (client *Client) Aliases() (allStatuses map[string]map[string]AliasStatus, err error) {
+func (client *client) Aliases() (allStatuses map[string]map[string]AliasStatus, err error) {
 	_, err = client.doSync("GET", "/v2/aliases", nil, nil, nil, &allStatuses)
 	return
 }

--- a/client/apps.go
+++ b/client/apps.go
@@ -57,6 +57,14 @@ type AppInfo struct {
 	Activators  []AppActivator   `json:"activators,omitempty"`
 }
 
+type ClientApps interface {
+	Apps(names []string, opts AppOptions) ([]*AppInfo, error)
+	Logs(names []string, opts LogOptions) (<-chan Log, error)
+	Start(names []string, opts StartOptions) (changeID string, err error)
+	Stop(names []string, opts StopOptions) (changeID string, err error)
+	Restart(names []string, opts RestartOptions) (changeID string, err error)
+}
+
 // IsService returns true if the application is a background daemon.
 func (a *AppInfo) IsService() bool {
 	if a == nil {
@@ -79,7 +87,7 @@ type AppOptions struct {
 // Apps returns information about all matching apps. Each name can be
 // either a snap or a snap.app. If names is empty, list all (that
 // satisfy opts).
-func (client *Client) Apps(names []string, opts AppOptions) ([]*AppInfo, error) {
+func (client *client) Apps(names []string, opts AppOptions) ([]*AppInfo, error) {
 	q := make(url.Values)
 	if len(names) > 0 {
 		q.Add("names", strings.Join(names, ","))
@@ -127,7 +135,7 @@ func (l Log) fmtLog(timezone *time.Location) string {
 }
 
 // Logs asks for the logs of a series of services, by name.
-func (client *Client) Logs(names []string, opts LogOptions) (<-chan Log, error) {
+func (client *client) Logs(names []string, opts LogOptions) (<-chan Log, error) {
 	query := url.Values{}
 	if len(names) > 0 {
 		query.Set("names", strings.Join(names, ","))
@@ -207,7 +215,7 @@ type StartOptions struct {
 // It takes a list of names that can be snaps, of which all their
 // services are started, or snap.service which are individual
 // services to start; it shouldn't be empty.
-func (client *Client) Start(names []string, opts StartOptions) (changeID string, err error) {
+func (client *client) Start(names []string, opts StartOptions) (changeID string, err error) {
 	if len(names) == 0 {
 		return "", ErrNoNames
 	}
@@ -235,7 +243,7 @@ type StopOptions struct {
 // It takes a list of names that can be snaps, of which all their
 // services are stopped, or snap.service which are individual
 // services to stop; it shouldn't be empty.
-func (client *Client) Stop(names []string, opts StopOptions) (changeID string, err error) {
+func (client *client) Stop(names []string, opts StopOptions) (changeID string, err error) {
 	if len(names) == 0 {
 		return "", ErrNoNames
 	}
@@ -264,7 +272,7 @@ type RestartOptions struct {
 // services are restarted, or snap.service which are individual
 // services to restart; it shouldn't be empty. If the service is not
 // running, starts it.
-func (client *Client) Restart(names []string, opts RestartOptions) (changeID string, err error) {
+func (client *client) Restart(names []string, opts RestartOptions) (changeID string, err error) {
 	if len(names) == 0 {
 		return "", ErrNoNames
 	}

--- a/client/asserts.go
+++ b/client/asserts.go
@@ -34,11 +34,18 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+type ClientAsserts interface {
+	Ack(b []byte) error
+	AssertionTypes() ([]string, error)
+	Known(assertTypeName string, headers map[string]string, opts *KnownOptions) ([]asserts.Assertion, error)
+	StoreAccount(accountID string) (*snap.StoreAccount, error)
+}
+
 // Ack tries to add an assertion to the system assertion
 // database. To succeed the assertion must be valid, its signature
 // verified with a known public key and the assertion consistent with
 // and its prerequisite in the database.
-func (client *Client) Ack(b []byte) error {
+func (client *client) Ack(b []byte) error {
 	var rsp interface{}
 	if _, err := client.doSync("POST", "/v2/assertions", nil, nil, bytes.NewReader(b), &rsp); err != nil {
 		return err
@@ -48,7 +55,7 @@ func (client *Client) Ack(b []byte) error {
 }
 
 // AssertionTypes returns a list of assertion type names.
-func (client *Client) AssertionTypes() ([]string, error) {
+func (client *client) AssertionTypes() ([]string, error) {
 	var types struct {
 		Types []string `json:"types"`
 	}
@@ -68,7 +75,7 @@ type KnownOptions struct {
 }
 
 // Known queries assertions with type assertTypeName and matching assertion headers.
-func (client *Client) Known(assertTypeName string, headers map[string]string, opts *KnownOptions) ([]asserts.Assertion, error) {
+func (client *client) Known(assertTypeName string, headers map[string]string, opts *KnownOptions) ([]asserts.Assertion, error) {
 	if opts == nil {
 		opts = &KnownOptions{}
 	}
@@ -125,7 +132,7 @@ func (client *Client) Known(assertTypeName string, headers map[string]string, op
 }
 
 // StoreAccount returns the full store account info for the specified accountID
-func (client *Client) StoreAccount(accountID string) (*snap.StoreAccount, error) {
+func (client *client) StoreAccount(accountID string) (*snap.StoreAccount, error) {
 	assertions, err := client.Known("account", map[string]string{"account-id": accountID}, nil)
 	if err != nil {
 		return nil, err

--- a/client/buy.go
+++ b/client/buy.go
@@ -36,7 +36,12 @@ type BuyResult struct {
 	State string `json:"state,omitempty"`
 }
 
-func (client *Client) Buy(opts *BuyOptions) (*BuyResult, error) {
+type ClientBuy interface {
+	Buy(opts *BuyOptions) (*BuyResult, error)
+	ReadyToBuy() error
+}
+
+func (client *client) Buy(opts *BuyOptions) (*BuyResult, error) {
 	if opts == nil {
 		opts = &BuyOptions{}
 	}
@@ -56,7 +61,7 @@ func (client *Client) Buy(opts *BuyOptions) (*BuyResult, error) {
 	return &result, nil
 }
 
-func (client *Client) ReadyToBuy() error {
+func (client *client) ReadyToBuy() error {
 	var result bool
 	_, err := client.doSync("GET", "/v2/buy/ready", nil, nil, nil, &result)
 	return err

--- a/client/change.go
+++ b/client/change.go
@@ -43,6 +43,12 @@ type Change struct {
 	data map[string]*json.RawMessage
 }
 
+type ClientChange interface {
+	Change(id string) (*Change, error)
+	Abort(id string) (*Change, error)
+	Changes(opts *ChangesOptions) ([]*Change, error)
+}
+
 var ErrNoData = fmt.Errorf("data entry not found")
 
 // Get unmarshals into value the kind-specific data with the provided key.
@@ -79,7 +85,7 @@ type changeAndData struct {
 }
 
 // Change fetches information about a Change given its ID.
-func (client *Client) Change(id string) (*Change, error) {
+func (client *client) Change(id string) (*Change, error) {
 	var chgd changeAndData
 	_, err := client.doSync("GET", "/v2/changes/"+id, nil, nil, nil, &chgd)
 	if err != nil {
@@ -91,7 +97,7 @@ func (client *Client) Change(id string) (*Change, error) {
 }
 
 // Abort attempts to abort a change that is in not yet ready.
-func (client *Client) Abort(id string) (*Change, error) {
+func (client *client) Abort(id string) (*Change, error) {
 	var postData struct {
 		Action string `json:"action"`
 	}
@@ -136,7 +142,7 @@ type ChangesOptions struct {
 	Selector ChangeSelector
 }
 
-func (client *Client) Changes(opts *ChangesOptions) ([]*Change, error) {
+func (client *client) Changes(opts *ChangesOptions) ([]*Change, error) {
 	query := url.Values{}
 	if opts != nil {
 		if opts.Selector != 0 {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -48,7 +48,7 @@ func Test(t *testing.T) { TestingT(t) }
 type clientSuite struct {
 	testutil.BaseTest
 
-	cli           *client.Client
+	cli           *client.ClientImpl
 	req           *http.Request
 	reqs          []*http.Request
 	rsp           string
@@ -68,7 +68,7 @@ func (cs *clientSuite) SetUpTest(c *C) {
 	os.Setenv(client.TestAuthFileEnvKey, filepath.Join(c.MkDir(), "auth.json"))
 	cs.AddCleanup(func() { os.Unsetenv(client.TestAuthFileEnvKey) })
 
-	cs.cli = client.New(nil)
+	cs.cli = client.New(nil).(*client.ClientImpl)
 	cs.cli.SetDoer(cs)
 	cs.err = nil
 	cs.req = nil
@@ -281,7 +281,7 @@ func (cs *clientSuite) TestClientHonorsDisableAuth(c *C) {
 	c.Assert(err, IsNil)
 
 	var v string
-	cli := client.New(&client.Config{DisableAuth: true})
+	cli := client.New(&client.Config{DisableAuth: true}).(*client.ClientImpl)
 	cli.SetDoer(cs)
 	_, _ = cli.Do("GET", "/this", nil, nil, &v, nil)
 	authorization := cs.req.Header.Get("Authorization")
@@ -290,13 +290,13 @@ func (cs *clientSuite) TestClientHonorsDisableAuth(c *C) {
 
 func (cs *clientSuite) TestClientHonorsInteractive(c *C) {
 	var v string
-	cli := client.New(&client.Config{Interactive: false})
+	cli := client.New(&client.Config{Interactive: false}).(*client.ClientImpl)
 	cli.SetDoer(cs)
 	_, _ = cli.Do("GET", "/this", nil, nil, &v, nil)
 	interactive := cs.req.Header.Get(client.AllowInteractionHeader)
 	c.Check(interactive, Equals, "")
 
-	cli = client.New(&client.Config{Interactive: true})
+	cli = client.New(&client.Config{Interactive: true}).(*client.ClientImpl)
 	cli.SetDoer(cs)
 	_, _ = cli.Do("GET", "/this", nil, nil, &v, nil)
 	interactive = cs.req.Header.Get(client.AllowInteractionHeader)
@@ -560,7 +560,7 @@ func (cs *clientSuite) TestIsRetryable(c *C) {
 }
 
 func (cs *clientSuite) TestUserAgent(c *C) {
-	cli := client.New(&client.Config{UserAgent: "some-agent/9.87"})
+	cli := client.New(&client.Config{UserAgent: "some-agent/9.87"}).(*client.ClientImpl)
 	cli.SetDoer(cs)
 
 	var v string
@@ -622,7 +622,7 @@ func (cs *integrationSuite) TestClientTimeoutLP1837804(c *C) {
 	}))
 	defer func() { testServer.Close() }()
 
-	cli := client.New(&client.Config{BaseURL: testServer.URL})
+	cli := client.New(&client.Config{BaseURL: testServer.URL}).(*client.ClientImpl)
 	_, err := cli.Do("GET", "/", nil, nil, nil, nil)
 	c.Assert(err, ErrorMatches, `.* timeout exceeded while waiting for response`)
 

--- a/client/cohort.go
+++ b/client/cohort.go
@@ -32,7 +32,11 @@ type CohortAction struct {
 	Snaps  []string `json:"snaps"`
 }
 
-func (client *Client) CreateCohorts(snaps []string) (map[string]string, error) {
+type ClientCohort interface {
+	CreateCohorts(snaps []string) (map[string]string, error)
+}
+
+func (client *client) CreateCohorts(snaps []string) (map[string]string, error) {
 	data, err := json.Marshal(&CohortAction{Action: "create", Snaps: snaps})
 	if err != nil {
 		return nil, fmt.Errorf("cannot request cohorts: %v", err)

--- a/client/conf.go
+++ b/client/conf.go
@@ -26,8 +26,13 @@ import (
 	"strings"
 )
 
+type ClientConf interface {
+	SetConf(snapName string, patch map[string]interface{}) (changeID string, err error)
+	Conf(snapName string, keys []string) (configuration map[string]interface{}, err error)
+}
+
 // SetConf requests a snap to apply the provided patch to the configuration.
-func (client *Client) SetConf(snapName string, patch map[string]interface{}) (changeID string, err error) {
+func (client *client) SetConf(snapName string, patch map[string]interface{}) (changeID string, err error) {
 	b, err := json.Marshal(patch)
 	if err != nil {
 		return "", err
@@ -38,7 +43,7 @@ func (client *Client) SetConf(snapName string, patch map[string]interface{}) (ch
 // Conf asks for a snap's current configuration.
 //
 // Note that the configuration may include json.Numbers.
-func (client *Client) Conf(snapName string, keys []string) (configuration map[string]interface{}, err error) {
+func (client *client) Conf(snapName string, keys []string) (configuration map[string]interface{}, err error) {
 	// Prepare query
 	query := url.Values{}
 	query.Set("keys", strings.Join(keys, ","))

--- a/client/connections.go
+++ b/client/connections.go
@@ -62,9 +62,13 @@ type ConnectionOptions struct {
 	All bool
 }
 
+type ClientConnections interface {
+	Connections(opts *ConnectionOptions) (Connections, error)
+}
+
 // Connections returns matching plugs, slots and their connections. Unless
 // specified by matching options, returns established connections.
-func (client *Client) Connections(opts *ConnectionOptions) (Connections, error) {
+func (client *client) Connections(opts *ConnectionOptions) (Connections, error) {
 	var conns Connections
 	query := url.Values{}
 	if opts != nil && opts.Snap != "" {

--- a/client/console_conf.go
+++ b/client/console_conf.go
@@ -28,10 +28,14 @@ type InternalConsoleConfStartResponse struct {
 	ActiveAutoRefreshSnaps   []string `json:"active-auto-refresh-snaps,omitempty"`
 }
 
+type ClientConsoleConf interface {
+	InternalConsoleConfStart() ([]string, []string, error)
+}
+
 // InternalConsoleConfStart invokes the dedicated console-conf start support
 // to handle intervening auto-refreshes.
 // Not for general use.
-func (client *Client) InternalConsoleConfStart() ([]string, []string, error) {
+func (client *client) InternalConsoleConfStart() ([]string, []string, error) {
 	resp := &InternalConsoleConfStartResponse{}
 	// do the post with a short timeout so that if snapd is not available due to
 	// maintenance we will return very quickly so the caller can handle that

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -25,15 +25,17 @@ import (
 	"net/url"
 )
 
+type ClientImpl = client
+
 // SetDoer sets the client's doer to the given one
-func (client *Client) SetDoer(d doer) {
+func (client *client) SetDoer(d doer) {
 	client.doer = d
 }
 
 type DoOptions = doOptions
 
 // Do does do.
-func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}, opts *DoOptions) (statusCode int, err error) {
+func (client *client) Do(method, path string, query url.Values, body io.Reader, v interface{}, opts *DoOptions) (statusCode int, err error) {
 	return client.do(method, path, query, nil, body, v, opts)
 }
 

--- a/client/icons.go
+++ b/client/icons.go
@@ -34,10 +34,14 @@ type Icon struct {
 	Content  []byte
 }
 
+type ClientIcons interface {
+	Icon(pkgID string) (*Icon, error)
+}
+
 var contentDispositionMatcher = regexp.MustCompile(`attachment; filename=(.+)`).FindStringSubmatch
 
 // Icon returns the Icon belonging to an installed snap
-func (c *Client) Icon(pkgID string) (*Icon, error) {
+func (c *client) Icon(pkgID string) (*Icon, error) {
 	const errPrefix = "cannot retrieve icon"
 
 	response, cancel, err := c.rawWithTimeout(context.Background(), "GET", fmt.Sprintf("/v2/icons/%s/icon", pkgID), nil, nil, nil, nil)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -91,7 +91,13 @@ type DisconnectOptions struct {
 	Forget bool
 }
 
-func (client *Client) Interfaces(opts *InterfaceOptions) ([]*Interface, error) {
+type ClientInterfaces interface {
+	Interfaces(opts *InterfaceOptions) ([]*Interface, error)
+	Connect(plugSnapName, plugName, slotSnapName, slotName string) (changeID string, err error)
+	Disconnect(plugSnapName, plugName, slotSnapName, slotName string, opts *DisconnectOptions) (changeID string, err error)
+}
+
+func (client *client) Interfaces(opts *InterfaceOptions) ([]*Interface, error) {
 	query := url.Values{}
 	if opts != nil && len(opts.Names) > 0 {
 		query.Set("names", strings.Join(opts.Names, ",")) // Return just those specific interfaces.
@@ -120,7 +126,7 @@ func (client *Client) Interfaces(opts *InterfaceOptions) ([]*Interface, error) {
 }
 
 // performInterfaceAction performs a single action on the interface system.
-func (client *Client) performInterfaceAction(sa *InterfaceAction) (changeID string, err error) {
+func (client *client) performInterfaceAction(sa *InterfaceAction) (changeID string, err error) {
 	b, err := json.Marshal(sa)
 	if err != nil {
 		return "", err
@@ -130,7 +136,7 @@ func (client *Client) performInterfaceAction(sa *InterfaceAction) (changeID stri
 
 // Connect establishes a connection between a plug and a slot.
 // The plug and the slot must have the same interface.
-func (client *Client) Connect(plugSnapName, plugName, slotSnapName, slotName string) (changeID string, err error) {
+func (client *client) Connect(plugSnapName, plugName, slotSnapName, slotName string) (changeID string, err error) {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "connect",
 		Plugs:  []Plug{{Snap: plugSnapName, Name: plugName}},
@@ -139,7 +145,7 @@ func (client *Client) Connect(plugSnapName, plugName, slotSnapName, slotName str
 }
 
 // Disconnect breaks the connection between a plug and a slot.
-func (client *Client) Disconnect(plugSnapName, plugName, slotSnapName, slotName string, opts *DisconnectOptions) (changeID string, err error) {
+func (client *client) Disconnect(plugSnapName, plugName, slotSnapName, slotName string, opts *DisconnectOptions) (changeID string, err error) {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "disconnect",
 		Forget: opts != nil && opts.Forget,

--- a/client/login.go
+++ b/client/login.go
@@ -45,8 +45,14 @@ type loginData struct {
 	Otp      string `json:"otp,omitempty"`
 }
 
+type ClientLogin interface {
+	Login(email, password, otp string) (*User, error)
+	Logout() error
+	LoggedInUser() *User
+}
+
 // Login logs user in.
-func (client *Client) Login(email, password, otp string) (*User, error) {
+func (client *client) Login(email, password, otp string) (*User, error) {
 	postData := loginData{
 		Email:    email,
 		Password: password,
@@ -69,7 +75,7 @@ func (client *Client) Login(email, password, otp string) (*User, error) {
 }
 
 // Logout logs the user out.
-func (client *Client) Logout() error {
+func (client *client) Logout() error {
 	_, err := client.doSync("POST", "/v2/logout", nil, nil, nil, nil)
 	if err != nil {
 		return err
@@ -78,7 +84,7 @@ func (client *Client) Logout() error {
 }
 
 // LoggedInUser returns the logged in User or nil
-func (client *Client) LoggedInUser() *User {
+func (client *client) LoggedInUser() *User {
 	u, err := readAuthData()
 	if err != nil {
 		return nil

--- a/client/model.go
+++ b/client/model.go
@@ -35,8 +35,14 @@ type remodelData struct {
 	NewModel string `json:"new-model"`
 }
 
+type ClientModel interface {
+	Remodel(b []byte) (changeID string, err error)
+	CurrentModelAssertion() (*asserts.Model, error)
+	CurrentSerialAssertion() (*asserts.Serial, error)
+}
+
 // Remodel tries to remodel the system with the given assertion data
-func (client *Client) Remodel(b []byte) (changeID string, err error) {
+func (client *client) Remodel(b []byte) (changeID string, err error) {
 	data, err := json.Marshal(&remodelData{
 		NewModel: string(b),
 	})
@@ -51,7 +57,7 @@ func (client *Client) Remodel(b []byte) (changeID string, err error) {
 }
 
 // CurrentModelAssertion returns the current model assertion
-func (client *Client) CurrentModelAssertion() (*asserts.Model, error) {
+func (client *client) CurrentModelAssertion() (*asserts.Model, error) {
 	assert, err := currentAssertion(client, "/v2/model")
 	if err != nil {
 		return nil, err
@@ -64,7 +70,7 @@ func (client *Client) CurrentModelAssertion() (*asserts.Model, error) {
 }
 
 // CurrentSerialAssertion returns the current serial assertion
-func (client *Client) CurrentSerialAssertion() (*asserts.Serial, error) {
+func (client *client) CurrentSerialAssertion() (*asserts.Serial, error) {
 	assert, err := currentAssertion(client, "/v2/model/serial")
 	if err != nil {
 		return nil, err
@@ -77,7 +83,7 @@ func (client *Client) CurrentSerialAssertion() (*asserts.Serial, error) {
 }
 
 // helper function for getting assertions from the daemon via a REST path
-func currentAssertion(client *Client, path string) (asserts.Assertion, error) {
+func currentAssertion(client *client, path string) (asserts.Assertion, error) {
 	q := url.Values{}
 
 	response, cancel, err := client.rawWithTimeout(context.Background(), "GET", path, q, nil, nil, nil)

--- a/client/packages.go
+++ b/client/packages.go
@@ -90,6 +90,14 @@ type SnapHealth struct {
 	Code      string        `json:"code,omitempty"`
 }
 
+type ClientPackages interface {
+	List(names []string, opts *ListOptions) ([]*Snap, error)
+	Sections() ([]string, error)
+	Find(opts *FindOptions) ([]*Snap, *ResultInfo, error)
+	FindOne(name string) (*Snap, *ResultInfo, error)
+	Snap(name string) (*Snap, *ResultInfo, error)
+}
+
 func (s *Snap) MarshalJSON() ([]byte, error) {
 	type auxSnap Snap // use auxiliary type so that Go does not call Snap.MarshalJSON()
 	// separate type just for marshalling
@@ -153,7 +161,7 @@ type ListOptions struct {
 
 // List returns the list of all snaps installed on the system
 // with names in the given list; if the list is empty, all snaps.
-func (client *Client) List(names []string, opts *ListOptions) ([]*Snap, error) {
+func (client *client) List(names []string, opts *ListOptions) ([]*Snap, error) {
 	if opts == nil {
 		opts = &ListOptions{}
 	}
@@ -179,7 +187,7 @@ func (client *Client) List(names []string, opts *ListOptions) ([]*Snap, error) {
 }
 
 // Sections returns the list of existing snap sections in the store
-func (client *Client) Sections() ([]string, error) {
+func (client *client) Sections() ([]string, error) {
 	var sections []string
 	_, err := client.doSync("GET", "/v2/sections", nil, nil, nil, &sections)
 	if err != nil {
@@ -191,7 +199,7 @@ func (client *Client) Sections() ([]string, error) {
 
 // Find returns a list of snaps available for install from the
 // store for this system and that match the query
-func (client *Client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
+func (client *client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
 	if opts == nil {
 		opts = &FindOptions{}
 	}
@@ -226,7 +234,7 @@ func (client *Client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
 	return client.snapsFromPath("/v2/find", q)
 }
 
-func (client *Client) FindOne(name string) (*Snap, *ResultInfo, error) {
+func (client *client) FindOne(name string) (*Snap, *ResultInfo, error) {
 	q := url.Values{}
 	q.Set("name", name)
 
@@ -243,7 +251,7 @@ func (client *Client) FindOne(name string) (*Snap, *ResultInfo, error) {
 	return snaps[0], ri, nil
 }
 
-func (client *Client) snapsFromPath(path string, query url.Values) ([]*Snap, *ResultInfo, error) {
+func (client *client) snapsFromPath(path string, query url.Values) ([]*Snap, *ResultInfo, error) {
 	var snaps []*Snap
 	ri, err := client.doSync("GET", path, query, nil, nil, &snaps)
 	if e, ok := err.(*Error); ok {
@@ -258,7 +266,7 @@ func (client *Client) snapsFromPath(path string, query url.Values) ([]*Snap, *Re
 
 // Snap returns the most recently published revision of the snap with the
 // provided name.
-func (client *Client) Snap(name string) (*Snap, *ResultInfo, error) {
+func (client *client) Snap(name string) (*Snap, *ResultInfo, error) {
 	var snap *Snap
 	path := fmt.Sprintf("/v2/snaps/%s", name)
 	ri, err := client.doSync("GET", path, nil, nil, nil, &snap)

--- a/client/quota.go
+++ b/client/quota.go
@@ -48,9 +48,16 @@ type QuotaValues struct {
 	Memory quantity.Size `json:"memory,omitempty"`
 }
 
+type ClientQuota interface {
+	EnsureQuota(groupName string, parent string, snaps []string, maxMemory quantity.Size) (changeID string, err error)
+	GetQuotaGroup(groupName string) (*QuotaGroupResult, error)
+	RemoveQuotaGroup(groupName string) (changeID string, err error)
+	Quotas() ([]*QuotaGroupResult, error)
+}
+
 // EnsureQuota creates a quota group or updates an existing group.
 // The list of snaps can be empty.
-func (client *Client) EnsureQuota(groupName string, parent string, snaps []string, maxMemory quantity.Size) (changeID string, err error) {
+func (client *client) EnsureQuota(groupName string, parent string, snaps []string, maxMemory quantity.Size) (changeID string, err error) {
 	if groupName == "" {
 		return "", fmt.Errorf("cannot create or update quota group without a name")
 	}
@@ -78,7 +85,7 @@ func (client *Client) EnsureQuota(groupName string, parent string, snaps []strin
 	return chgID, nil
 }
 
-func (client *Client) GetQuotaGroup(groupName string) (*QuotaGroupResult, error) {
+func (client *client) GetQuotaGroup(groupName string) (*QuotaGroupResult, error) {
 	if groupName == "" {
 		return nil, fmt.Errorf("cannot get quota group without a name")
 	}
@@ -92,7 +99,7 @@ func (client *Client) GetQuotaGroup(groupName string) (*QuotaGroupResult, error)
 	return res, nil
 }
 
-func (client *Client) RemoveQuotaGroup(groupName string) (changeID string, err error) {
+func (client *client) RemoveQuotaGroup(groupName string) (changeID string, err error) {
 	if groupName == "" {
 		return "", fmt.Errorf("cannot remove quota group without a name")
 	}
@@ -113,7 +120,7 @@ func (client *Client) RemoveQuotaGroup(groupName string) (changeID string, err e
 	return chgID, nil
 }
 
-func (client *Client) Quotas() ([]*QuotaGroupResult, error) {
+func (client *client) Quotas() ([]*QuotaGroupResult, error) {
 	var res []*QuotaGroupResult
 	if _, err := client.doSync("GET", "/v2/quotas", nil, nil, nil, &res); err != nil {
 		return nil, err

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -38,25 +38,25 @@ import (
 var chanName = "achan"
 
 var ops = []struct {
-	op     func(*client.Client, string, *client.SnapOptions) (string, error)
+	op     func(client.Client, string, *client.SnapOptions) (string, error)
 	action string
 }{
-	{(*client.Client).Install, "install"},
-	{(*client.Client).Refresh, "refresh"},
-	{(*client.Client).Remove, "remove"},
-	{(*client.Client).Revert, "revert"},
-	{(*client.Client).Enable, "enable"},
-	{(*client.Client).Disable, "disable"},
-	{(*client.Client).Switch, "switch"},
+	{(client.Client).Install, "install"},
+	{(client.Client).Refresh, "refresh"},
+	{(client.Client).Remove, "remove"},
+	{(client.Client).Revert, "revert"},
+	{(client.Client).Enable, "enable"},
+	{(client.Client).Disable, "disable"},
+	{(client.Client).Switch, "switch"},
 }
 
 var multiOps = []struct {
-	op     func(*client.Client, []string, *client.SnapOptions) (string, error)
+	op     func(client.Client, []string, *client.SnapOptions) (string, error)
 	action string
 }{
-	{(*client.Client).RefreshMany, "refresh"},
-	{(*client.Client).InstallMany, "install"},
-	{(*client.Client).RemoveMany, "remove"},
+	{(client.Client).RefreshMany, "refresh"},
+	{(client.Client).InstallMany, "install"},
+	{(client.Client).RemoveMany, "remove"},
 }
 
 func (cs *clientSuite) TestClientOpSnapServerError(c *check.C) {

--- a/client/snapctl.go
+++ b/client/snapctl.go
@@ -27,6 +27,10 @@ import (
 	"io/ioutil"
 )
 
+type ClientSnapctl interface {
+	RunSnapctl(options *SnapCtlOptions, stdin io.Reader) (stdout, stderr []byte, err error)
+}
+
 // InternalSnapctlCmdNeedsStdin returns true if the given snapctl command
 // needs data from stdin
 func InternalSnapctlCmdNeedsStdin(name string) bool {
@@ -66,7 +70,7 @@ type snapctlOutput struct {
 var stdinReadLimit = int64(4 * 1000 * 1000)
 
 // RunSnapctl requests a snapctl run for the given options.
-func (client *Client) RunSnapctl(options *SnapCtlOptions, stdin io.Reader) (stdout, stderr []byte, err error) {
+func (client *client) RunSnapctl(options *SnapCtlOptions, stdin io.Reader) (stdout, stderr []byte, err error) {
 	// TODO: instead of reading all of stdin here we need to forward it to
 	//       the daemon eventually
 	var stdinData []byte

--- a/client/systems.go
+++ b/client/systems.go
@@ -61,8 +61,14 @@ type SystemAction struct {
 	Mode string `json:"mode,omitempty"`
 }
 
+type ClientSystem interface {
+	ListSystems() ([]System, error)
+	DoSystemAction(systemLabel string, action *SystemAction) error
+	RebootToSystem(systemLabel, mode string) error
+}
+
 // ListSystems list all systems available for seeding or recovery.
-func (client *Client) ListSystems() ([]System, error) {
+func (client *client) ListSystems() ([]System, error) {
 	type systemsResponse struct {
 		Systems []System `json:"systems,omitempty"`
 	}
@@ -77,7 +83,7 @@ func (client *Client) ListSystems() ([]System, error) {
 
 // DoSystemAction issues a request to perform an action using the given seed
 // system and its mode.
-func (client *Client) DoSystemAction(systemLabel string, action *SystemAction) error {
+func (client *client) DoSystemAction(systemLabel string, action *SystemAction) error {
 	if systemLabel == "" {
 		return fmt.Errorf("cannot request an action without the system")
 	}
@@ -115,7 +121,7 @@ func (client *Client) DoSystemAction(systemLabel string, action *SystemAction) e
 //
 // Note that "recover" and "run" modes are only available for the
 // current system.
-func (client *Client) RebootToSystem(systemLabel, mode string) error {
+func (client *client) RebootToSystem(systemLabel, mode string) error {
 	// verification is done by the backend
 
 	req := struct {

--- a/client/users.go
+++ b/client/users.go
@@ -61,7 +61,14 @@ type userAction struct {
 	*RemoveUserOptions
 }
 
-func (client *Client) doUserAction(act *userAction, result interface{}) error {
+type ClientUsers interface {
+	CreateUser(options *CreateUserOptions) (*CreateUserResult, error)
+	CreateUsers(options []*CreateUserOptions) ([]*CreateUserResult, error)
+	RemoveUser(options *RemoveUserOptions) (removed []*User, err error)
+	Users() ([]*User, error)
+}
+
+func (client *client) doUserAction(act *userAction, result interface{}) error {
 	data, err := json.Marshal(act)
 	if err != nil {
 		return err
@@ -72,7 +79,7 @@ func (client *Client) doUserAction(act *userAction, result interface{}) error {
 }
 
 // CreateUser creates a local system user. See CreateUserOptions for details.
-func (client *Client) CreateUser(options *CreateUserOptions) (*CreateUserResult, error) {
+func (client *client) CreateUser(options *CreateUserOptions) (*CreateUserResult, error) {
 	if options == nil || options.Email == "" {
 		return nil, fmt.Errorf("cannot create a user without providing an email")
 	}
@@ -88,7 +95,7 @@ func (client *Client) CreateUser(options *CreateUserOptions) (*CreateUserResult,
 // CreateUsers creates multiple local system users. See CreateUserOptions for details.
 //
 // Results may be provided even if there are errors.
-func (client *Client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserResult, error) {
+func (client *client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserResult, error) {
 	for _, opts := range options {
 		if opts == nil || (opts.Email == "" && !(opts.Known || opts.Automatic)) {
 			return nil, fmt.Errorf("cannot create user from store details without an email to query for")
@@ -121,7 +128,7 @@ func (client *Client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserRe
 }
 
 // RemoveUser removes a local system user.
-func (client *Client) RemoveUser(options *RemoveUserOptions) (removed []*User, err error) {
+func (client *client) RemoveUser(options *RemoveUserOptions) (removed []*User, err error) {
 	if options == nil || options.Username == "" {
 		return nil, fmt.Errorf("cannot remove a user without providing a username")
 	}
@@ -135,7 +142,7 @@ func (client *Client) RemoveUser(options *RemoveUserOptions) (removed []*User, e
 }
 
 // Users returns the local users.
-func (client *Client) Users() ([]*User, error) {
+func (client *client) Users() ([]*User, error) {
 	var result []*User
 
 	if _, err := client.doSync("GET", "/v2/users", nil, nil, nil, &result); err != nil {

--- a/client/validate.go
+++ b/client/validate.go
@@ -53,9 +53,16 @@ type postValidationSetData struct {
 	Sequence int    `json:"sequence,omitempty"`
 }
 
+type ClientValidate interface {
+	ForgetValidationSet(accountID, name string, sequence int) error
+	ApplyValidationSet(accountID, name string, opts *ValidateApplyOptions) error
+	ListValidationsSets() ([]*ValidationSetResult, error)
+	ValidationSet(accountID, name string, sequence int) (*ValidationSetResult, error)
+}
+
 // ForgetValidationSet forgets the given validation set identified by account,
 // name and optional sequence (if non-zero).
-func (client *Client) ForgetValidationSet(accountID, name string, sequence int) error {
+func (client *client) ForgetValidationSet(accountID, name string, sequence int) error {
 	if accountID == "" || name == "" {
 		return xerrors.Errorf("cannot forget validation set without account ID and name")
 	}
@@ -78,7 +85,7 @@ func (client *Client) ForgetValidationSet(accountID, name string, sequence int) 
 }
 
 // ApplyValidationSet applies the given validation set identified by account and name.
-func (client *Client) ApplyValidationSet(accountID, name string, opts *ValidateApplyOptions) error {
+func (client *client) ApplyValidationSet(accountID, name string, opts *ValidateApplyOptions) error {
 	if accountID == "" || name == "" {
 		return xerrors.Errorf("cannot apply validation set without account ID and name")
 	}
@@ -102,7 +109,7 @@ func (client *Client) ApplyValidationSet(accountID, name string, opts *ValidateA
 }
 
 // ListValidationsSets queries all validation sets.
-func (client *Client) ListValidationsSets() ([]*ValidationSetResult, error) {
+func (client *client) ListValidationsSets() ([]*ValidationSetResult, error) {
 	var res []*ValidationSetResult
 	if _, err := client.doSync("GET", "/v2/validation-sets", nil, nil, nil, &res); err != nil {
 		fmt := "cannot list validation sets: %w"
@@ -112,7 +119,7 @@ func (client *Client) ListValidationsSets() ([]*ValidationSetResult, error) {
 }
 
 // ValidationSet queries the given validation set identified by account/name.
-func (client *Client) ValidationSet(accountID, name string, sequence int) (*ValidationSetResult, error) {
+func (client *client) ValidationSet(accountID, name string, sequence int) (*ValidationSetResult, error) {
 	if accountID == "" || name == "" {
 		return nil, xerrors.Errorf("cannot query validation set without account ID and name")
 	}

--- a/client/warnings.go
+++ b/client/warnings.go
@@ -52,8 +52,13 @@ type WarningsOptions struct {
 	All bool
 }
 
+type ClientWarnings interface {
+	Warnings(opts WarningsOptions) ([]*Warning, error)
+	Okay(t time.Time) error
+}
+
 // Warnings returns the list of un-okayed warnings.
-func (client *Client) Warnings(opts WarningsOptions) ([]*Warning, error) {
+func (client *client) Warnings(opts WarningsOptions) ([]*Warning, error) {
 	var jws []*jsonWarning
 	q := make(url.Values)
 	if opts.All {
@@ -78,7 +83,7 @@ type warningsAction struct {
 
 // Okay asks snapd to chill about the warnings that would have been returned by
 // Warnings at the given time.
-func (client *Client) Okay(t time.Time) error {
+func (client *client) Okay(t time.Time) error {
 	var body bytes.Buffer
 	var op = warningsAction{Action: "okay", Timestamp: t}
 	if err := json.NewEncoder(&body).Encode(op); err != nil {

--- a/cmd/snap-recovery-chooser/main.go
+++ b/cmd/snap-recovery-chooser/main.go
@@ -134,7 +134,7 @@ func cleanupTriggerMarker() error {
 	return nil
 }
 
-func chooser(cli *client.Client) (reboot bool, err error) {
+func chooser(cli client.Client) (reboot bool, err error) {
 	if _, err := os.Stat(defaultMarkerFile); err != nil {
 		if os.IsNotExist(err) {
 			return false, fmt.Errorf("cannot run chooser without the marker file")

--- a/cmd/snap/cmd_ack.go
+++ b/cmd/snap/cmd_ack.go
@@ -59,7 +59,7 @@ func init() {
 	}})
 }
 
-func ackFile(cli *client.Client, assertFile string) error {
+func ackFile(cli client.Client, assertFile string) error {
 	assertData, err := ioutil.ReadFile(assertFile)
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -151,7 +151,7 @@ func queueFile(src string) error {
 	return osutil.CopyFile(src, dst, osutil.CopyFlagOverwrite)
 }
 
-func autoImportFromSpool(cli *client.Client) (added int, err error) {
+func autoImportFromSpool(cli client.Client) (added int, err error) {
 	files, err := ioutil.ReadDir(dirs.SnapAssertsSpoolDir)
 	if os.IsNotExist(err) {
 		return 0, nil
@@ -178,7 +178,7 @@ func autoImportFromSpool(cli *client.Client) (added int, err error) {
 	return added, nil
 }
 
-func autoImportFromAllMounts(cli *client.Client) (int, error) {
+func autoImportFromAllMounts(cli client.Client) (int, error) {
 	cands, err := autoImportCandidates()
 	if err != nil {
 		return 0, err

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -60,7 +60,7 @@ func (x *cmdBuy) Execute(args []string) error {
 	return buySnap(x.client, string(x.Positional.SnapName))
 }
 
-func buySnap(cli *client.Client, snapName string) error {
+func buySnap(cli client.Client, snapName string) error {
 	user := cli.LoggedInUser()
 	if user == nil {
 		return fmt.Errorf(i18n.G("You need to be logged in to purchase software. Please run 'snap login' and try again."))

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -70,7 +70,7 @@ func (s changesByTime) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 var allDigits = regexp.MustCompile(`^[0-9]+$`).MatchString
 
-func queryChanges(cli *client.Client, opts *client.ChangesOptions) ([]*client.Change, error) {
+func queryChanges(cli client.Client, opts *client.ChangesOptions) ([]*client.Change, error) {
 	chgs, err := cli.Changes(opts)
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func (c *cmdTasks) Execute([]string) error {
 	return c.showChange(chid)
 }
 
-func queryChange(cli *client.Client, chid string) (*client.Change, error) {
+func queryChange(cli client.Client, chid string) (*client.Change, error) {
 	chg, err := cli.Change(chid)
 	if err != nil {
 		return nil, err
@@ -198,7 +198,7 @@ func (c *cmdTasks) showChange(chid string) error {
 
 const line = "......................................................................"
 
-func warnMaintenance(cli *client.Client) error {
+func warnMaintenance(cli client.Client) error {
 	if maintErr := cli.Maintenance(); maintErr != nil {
 		msg, err := errorToCmdMessage("", maintErr, nil)
 		if err != nil {

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -121,7 +121,7 @@ func cachedSections() (sections []string, err error) {
 	return sections, nil
 }
 
-func getSections(cli *client.Client) (sections []string, err error) {
+func getSections(cli client.Client) (sections []string, err error) {
 	// try loading from cached sections file
 	sections, err = cachedSections()
 	if err != nil {
@@ -134,7 +134,7 @@ func getSections(cli *client.Client) (sections []string, err error) {
 	return cli.Sections()
 }
 
-func showSections(cli *client.Client) error {
+func showSections(cli client.Client) error {
 	sections, err := getSections(cli)
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -65,7 +65,7 @@ func init() {
 		}})
 }
 
-func requestLoginWith2faRetry(cli *client.Client, email, password string) error {
+func requestLoginWith2faRetry(cli client.Client, email, password string) error {
 	var otp []byte
 	var err error
 
@@ -94,7 +94,7 @@ func requestLoginWith2faRetry(cli *client.Client, email, password string) error 
 	}
 }
 
-func requestLogin(cli *client.Client, email string) error {
+func requestLogin(cli client.Client, email string) error {
 	fmt.Fprintf(Stdout, i18n.G("Password of %q: "), email)
 	password, err := ReadPassword(0)
 	fmt.Fprint(Stdout, "\n")

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -141,7 +141,7 @@ func isStopping() (bool, error) {
 	return false, err
 }
 
-func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
+func maybeWaitForSecurityProfileRegeneration(cli client.Client) error {
 	// check if the security profiles key has changed, if so, we need
 	// to wait for snapd to re-generate all profiles
 	mismatch, err := interfaces.SystemKeyMismatch()

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -326,7 +326,7 @@ func maybeWithSudoSecurePath() bool {
 }
 
 // show what has been done
-func showDone(cli *client.Client, names []string, op string, opts *client.SnapOptions, esc *escapes) error {
+func showDone(cli client.Client, names []string, op string, opts *client.SnapOptions, esc *escapes) error {
 	snaps, err := cli.List(names, nil)
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -51,7 +51,7 @@ func (cmd cmdVersion) Execute(args []string) error {
 	return printVersions(cmd.client)
 }
 
-func printVersions(cli *client.Client) error {
+func printVersions(cli client.Client) error {
 	sv := serverVersion(cli)
 	w := tabWriter()
 

--- a/cmd/snap/cmd_version_linux.go
+++ b/cmd/snap/cmd_version_linux.go
@@ -29,7 +29,7 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
-func serverVersion(cli *client.Client) *client.ServerVersion {
+func serverVersion(cli client.Client) *client.ServerVersion {
 	if release.OnWSL {
 		return &client.ServerVersion{
 			Version:       i18n.G("unavailable"),

--- a/cmd/snap/cmd_version_other.go
+++ b/cmd/snap/cmd_version_other.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
-func serverVersion(*client.Client) *client.ServerVersion {
+func serverVersion(client.Client) *client.ServerVersion {
 	return &client.ServerVersion{
 		Version:       i18n.G("unavailable"),
 		Series:        release.Series,

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -265,7 +265,7 @@ func MockWaitConfTimeout(d time.Duration) (restore func()) {
 	}
 }
 
-func Wait(cli *client.Client, id string) (*client.Change, error) {
+func Wait(cli client.Client, id string) (*client.Change, error) {
 	wmx := waitMixin{}
 	wmx.client = cli
 	return wmx.wait(id)

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -202,14 +202,14 @@ func fixupArg(optName string) string {
 }
 
 type clientSetter interface {
-	setClient(*client.Client)
+	setClient(client.Client)
 }
 
 type clientMixin struct {
-	client *client.Client
+	client client.Client
 }
 
-func (ch *clientMixin) setClient(cli *client.Client) {
+func (ch *clientMixin) setClient(cli client.Client) {
 	ch.client = cli
 }
 
@@ -250,7 +250,7 @@ func completionHandler(comps []flags.Completion) {
 	}
 }
 
-func registerCommands(cli *client.Client, parser *flags.Parser, baseCmd *flags.Command, commands []*cmdInfo, checkUnique func(*cmdInfo)) {
+func registerCommands(cli client.Client, parser *flags.Parser, baseCmd *flags.Command, commands []*cmdInfo, checkUnique func(*cmdInfo)) {
 	for _, c := range commands {
 		checkUnique(c)
 		markForNoCompletion(c)
@@ -315,7 +315,7 @@ func registerCommands(cli *client.Client, parser *flags.Parser, baseCmd *flags.C
 // Parser creates and populates a fresh parser.
 // Since commands have local state a fresh parser is required to isolate tests
 // from each other.
-func Parser(cli *client.Client) *flags.Parser {
+func Parser(cli client.Client) *flags.Parser {
 	optionsData.Version = func() {
 		printVersions(cli)
 		panic(&exitStatus{0})
@@ -383,7 +383,7 @@ var ClientConfig = client.Config{
 
 // Client returns a new client using ClientConfig as configuration.
 // commands should (in general) not use this, and instead use clientMixin.
-func mkClient() *client.Client {
+func mkClient() client.Client {
 	cfg := &ClientConfig
 	// Set client user-agent when talking to the snapd daemon to the
 	// same value as when talking to the store.


### PR DESCRIPTION
Create an interface for each source file which provides some public
methods on the Client type, which is turned into an interfaces composed
by all these bits.
This sets the ground for the introduction of a mock mechanism, through
which code depending on the Client type can be more easily tested by
mocking the client.
