### PR TITLE
cmd/snap: only log translation warnings in debug/testing

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -50,11 +50,6 @@ func init() {
 	// set User-Agent for when 'snap' talks to the store directly (snap download etc...)
 	snapdenv.SetUserAgentFromVersion(snapdtool.Version, nil, "snap")
 
-	if osutil.GetenvBool("SNAPD_DEBUG") || snapdenv.Testing() {
-		// in tests or when debugging, enforce the "tidy" lint checks
-		noticef = logger.Panicf
-	}
-
 	// plug/slot sanitization not used by snap commands (except for snap pack
 	// which re-sets it), make it no-op.
 	snap.SanitizePlugsSlots = func(snapInfo *snap.Info) {}
@@ -67,8 +62,6 @@ var (
 	Stderr io.Writer = os.Stderr
 	// overridden for testing
 	ReadPassword = terminal.ReadPassword
-	// set to logger.Panicf in testing
-	noticef = logger.Noticef
 )
 
 type options struct {
@@ -171,7 +164,7 @@ func lintDesc(cmdName, optName, desc, origDesc string) {
 		r, _ := utf8.DecodeRuneInString(desc)
 		// note IsLower != !IsUpper for runes with no upper/lower.
 		if unicode.IsLower(r) && !strings.HasPrefix(desc, "login.ubuntu.com") && !strings.HasPrefix(desc, cmdName) {
-			noticef("description of %s's %q is lowercase in locale %q: %q", cmdName, optName, i18n.CurrentLocale(), desc)
+			panicOnDebug("description of %s's %q is lowercase in locale %q: %q", cmdName, optName, i18n.CurrentLocale(), desc)
 		}
 	}
 }
@@ -185,7 +178,7 @@ func lintArg(cmdName, optName, desc, origDesc string) {
 		// see comment in fixupArg about the >s case
 		return
 	}
-	noticef("argument %q's %q should begin with < and end with >", cmdName, optName)
+	panicOnDebug("argument %q's %q should begin with < and end with >", cmdName, optName)
 }
 
 func fixupArg(optName string) string {
@@ -588,4 +581,10 @@ fixed-width fonts, so it can be hard to tell.
 	maybePresentWarnings(cli.WarningsSummary())
 
 	return nil
+}
+
+func panicOnDebug(msg string, v ...interface{}) {
+	if osutil.GetenvBool("SNAPD_DEBUG") || snapdenv.Testing() {
+		logger.Panicf(msg, v...)
+	}
 }

--- a/tests/main/i18n/task.yaml
+++ b/tests/main/i18n/task.yaml
@@ -3,6 +3,11 @@ summary: Test that i18n works
 # no i18n yet in debian-sid
 systems: [-debian-sid-*]
 
+restore: |
+  if os.query is_ubuntu && ! os.query is_core; then
+    apt remove -y 'language-pack-[a-z]+$'
+  fi
+
 execute: |
     # The snapd deb from the archive does not contain .mo files, those
     # are stripped out by the langpack buildd stuff and put into the
@@ -10,19 +15,25 @@ execute: |
     # Therefore this test only makes sense when we build snapd from
     # the local source. When running against an official snapd deb
     # or against the core we will not see translations
-    if [ ! -f /usr/share/locale/de/LC_MESSAGES/snappy.mo ]; then
-        echo "SKIP: No mo files for snapd available"
-        exit 0
+    if [ -f /usr/share/locale/de/LC_MESSAGES/snappy.mo ]; then
+      echo "Ensure that i18n works"
+      LANG=de snap changes everything | MATCH "Ja, ja, allerdings."
+
+      echo "Basic smoke test to ensure no locale causes crashes nor warnings"
+      for p in /usr/share/locale/*; do
+          b=$( basename "$p" )
+          if ! SNAPPY_TESTING=1 LANG="$b" snap >/dev/null 2>&1; then
+              SNAPPY_TESTING=0 LANG="$b" snap 2>&1 >/dev/null | sed -e "s/[^ ]* [^ ]* /${b^^}: /" >> bad
+          fi
+      done
+      not cat bad
     fi
 
-    echo "Ensure that i18n works"
-    LANG=de snap changes everything | MATCH "Ja, ja, allerdings."
+    echo "Lint translated commands"
+    # Only attempt to install the langpacks in Ubuntu
+    if os.query is_ubuntu && ! os.query is_core; then
+      apt install -y 'language-pack-[a-z]+$'
+    fi
 
-    echo "Basic smoke test to ensure no locale causes crashes nor warnings"
-    for p in /usr/share/locale/*; do
-        b=$( basename "$p" )
-        if ! SNAPPY_TESTING=1 LANG="$b" snap >/dev/null 2>&1; then
-            SNAPPY_TESTING=0 LANG="$b" snap 2>&1 >/dev/null | sed -e "s/[^ ]* [^ ]* /${b^^}: /" >> bad
-        fi
-    done
-    not cat bad
+    # shellcheck disable=SC2002
+    grep -v -E '(pt|ko|nl)_' /usr/share/i18n/SUPPORTED | xargs -d '\n' -Iloc env SNAPD_DEBUG=1 LANG=loc snap changes everything 2>&1 > /dev/null | NOMATCH panic:


### PR DESCRIPTION
There's been a few reports about a log warning breaking autocomplete and confusing users.  It looks something like: `description of <command>'s "<arg name>" is lowercase in locale "<locale>": "<the translation">`. This PR removes logs caused by  "incorrect" translation during normal operation but keeps the panic when testing/debugging. IMO the warning doesn't reach the intended audience, it's not actionable for the user and it reportedly breaks some functionality (autocomplete) so I think it's better to remove it.

https://bugs.launchpad.net/snapd/+bug/1773174
https://bugs.launchpad.net/snapd/+bug/1808213
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1932579
