### PR TITLE
build-aux: stage libgcc1 library into snapd snap

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -90,6 +90,7 @@ parts:
     stage-packages:
       - libc6
       - libc-bin
+      - libgcc1
     stage:
       - lib/*
       - usr/lib/*


### PR DESCRIPTION
Investigating LP: #1943077 revealed that libc has been loading
libgcc_s.so.1 from the host forever, which apparently we have been
getting away with but no longer works on impish.

