### PR TITLE
image/image_linux.go: add newline

### DIFF
--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -334,7 +334,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 	}
 
 	if opts.Customizations.Validation == "" && !opts.Classic {
-		fmt.Fprintf(Stderr, "WARNING: proceeding to download snaps ignoring validations, this default will change in the future. For now use --validation=enforce for validations to be taken into account, pass instead --validation=ignore to preserve current behavior going forward")
+		fmt.Fprintf(Stderr, "WARNING: proceeding to download snaps ignoring validations, this default will change in the future. For now use --validation=enforce for validations to be taken into account, pass instead --validation=ignore to preserve current behavior going forward\n")
 	}
 	if opts.Customizations.Validation == "" {
 		opts.Customizations.Validation = "ignore"

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1671,7 +1671,7 @@ func (s *imageSuite) TestSetupSeedLocalSnapsWithStoreAsserts(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(m["snap_core"], Equals, "core_3.snap")
 
-	c.Check(s.stderr.String(), Equals, `WARNING: proceeding to download snaps ignoring validations, this default will change in the future. For now use --validation=enforce for validations to be taken into account, pass instead --validation=ignore to preserve current behavior going forward`)
+	c.Check(s.stderr.String(), Equals, `WARNING: proceeding to download snaps ignoring validations, this default will change in the future. For now use --validation=enforce for validations to be taken into account, pass instead --validation=ignore to preserve current behavior going forward`+"\n")
 
 	// current snap info sent
 	c.Check(s.curSnaps, HasLen, 1)


### PR DESCRIPTION
This is how it shows up in ubuntu-image today:

WARNING: proceeding to download snaps ignoring validations, this default will change in the future. For now use --validation=enforce for validations to be taken into account, pass instead --validation=ignore to preserve current behavior going forwardWARNING: "pc-kernel", "pc" installed from local snaps disconnected from a store cannot be refreshed subsequently!
Copying "snapd-upstream.snap" (snapd)
Copying "pc-kernel.snap" (pc-kernel)
Copying "core20-upstream.snap" (core20)
Copying "pc-gadget.snap" (pc)

There should be a newline so it appears like

WARNING: proceeding to download snaps ignoring validations, this default will change in the future. For now use --validation=enforce for validations to be taken into account, pass instead --validation=ignore to preserve current behavior going forward
WARNING: "pc-kernel", "pc" installed from local snaps disconnected from a store cannot be refreshed subsequently!
Copying "snapd-upstream.snap" (snapd)
Copying "pc-kernel.snap" (pc-kernel)
Copying "core20-upstream.snap" (core20)
Copying "pc-gadget.snap" (pc)