### PR TITLE
tests: be more robust against a new day stepping in

### DIFF
--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -14,9 +14,19 @@ execute: |
     "$TESTSTOOLS"/snapd-state --foo 2>&1 | MATCH "snapd-state: no such command: --foo"
     "$TESTSTOOLS"/snapd-state foo 2>&1 | MATCH "snapd-state: no such command: foo"
 
+    function check_date() {
+        local TEST_DATE="$1"
+        local TOLERANCE_SECONDS="1800" # 30 minutes
+
+        CURRENT_DATE="$(date +'%F')"
+        TIMESTAMP_MINUS_TOLERANCE=$(($(date +%s) - TOLERANCE_SECONDS))
+        DATE_MINUS_TOLERANCE="$(date +'%F' --date="@${TIMESTAMP_MINUS_TOLERANCE}")"
+        echo "$TEST_DATE" | MATCH "^(${CURRENT_DATE}|${DATE_MINUS_TOLERANCE})"
+    }
+
     # Check print state command
     current_date="$("$TESTSTOOLS"/snapd-state print-state '.data["last-refresh"]')"
-    echo "$current_date" | MATCH "^$(date +'%F')"
+    check_date "$current_date"
 
     # Check check state command
     "$TESTSTOOLS"/snapd-state check-state '.data["last-refresh"]' = "$current_date"
@@ -42,7 +52,7 @@ execute: |
     # check prevent autorefresh command
     "$TESTSTOOLS"/snapd-state prevent-autorefresh
     new_refresh_date="$("$TESTSTOOLS"/snapd-state print-state '.data["last-refresh"]')"
-    echo "$new_refresh_date" | MATCH "^$(date +'%F')"
+    check_date "$new_refresh_date"
 
     # check wait-for-snap-autorefresh command
     systemctl stop snapd.{service,socket}

--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -16,7 +16,8 @@ execute: |
 
     function check_date() {
         local TEST_DATE="$1"
-        local TOLERANCE_SECONDS=1800 # 30 minutes
+        local TOLERANCE_SECONDS=1800 # 30 minutes; in practice, the timestamp
+                                     # difference should be about 10 minutes
         local TEST_TIMESTAMP CURRENT_TIMESTAMP
 
         TEST_TIMESTAMP=$(date +'%s' --date="${TEST_DATE}")

--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -17,9 +17,10 @@ execute: |
     function check_date() {
         local TEST_DATE="$1"
         local TOLERANCE_SECONDS=1800 # 30 minutes
+        local TEST_TIMESTAMP CURRENT_TIMESTAMP
 
-        local TEST_TIMESTAMP=$(date +'%s' --date="${TEST_DATE}")
-        local CURRENT_TIMESTAMP="$(date +'%s')"
+        TEST_TIMESTAMP=$(date +'%s' --date="${TEST_DATE}")
+        CURRENT_TIMESTAMP="$(date +'%s')"
         if ((TEST_TIMESTAMP < CURRENT_TIMESTAMP - TOLERANCE_SECONDS || TEST_TIMESTAMP > CURRENT_TIMESTAMP)); then
             echo "Time $TEST_DATE too far from current time ($(date --iso-8601=seconds))"
             exit 1

--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -16,12 +16,14 @@ execute: |
 
     function check_date() {
         local TEST_DATE="$1"
-        local TOLERANCE_SECONDS="1800" # 30 minutes
+        local TOLERANCE_SECONDS=1800 # 30 minutes
 
-        CURRENT_DATE="$(date +'%F')"
-        TIMESTAMP_MINUS_TOLERANCE=$(($(date +%s) - TOLERANCE_SECONDS))
-        DATE_MINUS_TOLERANCE="$(date +'%F' --date="@${TIMESTAMP_MINUS_TOLERANCE}")"
-        echo "$TEST_DATE" | MATCH "^(${CURRENT_DATE}|${DATE_MINUS_TOLERANCE})"
+        local TEST_TIMESTAMP=$(date +'%s' --date="${TEST_DATE}")
+        local CURRENT_TIMESTAMP="$(date +'%s')"
+        if ((TEST_TIMESTAMP < CURRENT_TIMESTAMP - TOLERANCE_SECONDS || TEST_TIMESTAMP > CURRENT_TIMESTAMP)); then
+            echo "Time $TEST_DATE too far from current time ($(date --iso-8601=seconds))"
+            exit 1
+        fi
     }
 
     # Check print state command


### PR DESCRIPTION
Weird things can happen at midnight:

  https://pastebin.ubuntu.com/p/mmQskRXvhM/

The test could fail because it attempts to match the times by their date
component, without taking into account that if the two measurements
happen with the midnight in between, the date component will be
different.

Here we attempt to be a bit more robust, by comparing the given date not
only against the current date, but also against the date we had a few
minutes ago.
