### PR TITLE
o/snapstate: optimize conflicts around snaps stored on conditional-auto-refresh task

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3061,6 +3061,15 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 		return err
 	}
 
+	// update the map of refreshed snaps on the task, this affects
+	// conflict checks (we don't want to conflict on snaps that were held and
+	// won't be refreshed) -  see conditionalAutoRefreshAffectedSnaps().
+	newToUpdate := make(map[string]*refreshCandidate, len(snaps))
+	for _, candidate := range snaps {
+		newToUpdate[candidate.InstanceName()] = candidate
+	}
+	t.Set("snaps", newToUpdate)
+
 	// update original auto-refresh change
 	chg := t.Change()
 	for _, ts := range tss {


### PR DESCRIPTION
Update the list of snaps stored on conditional-auto-refresh task when we know what snaps are going to be refreshed. This avoids unnecessary conflicts on snaps that are held and won't get refreshed (for more context see the end of autoRefreshPhase1() function where "snaps" map is originally stored on the task, and conditionalAutoRefreshAffectedSnaps() helper that affects conflict check based on "snaps").
