### PR TITLE
o/servicestate: Update task summary for restart action

### DIFF
--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -29,6 +29,7 @@ var (
 	UpdateSnapstateServices  = updateSnapstateServices
 	CheckSystemdVersion      = checkSystemdVersion
 	QuotaStateAlreadyUpdated = quotaStateAlreadyUpdated
+	ServiceControlTs         = serviceControlTs
 )
 
 type QuotaStateUpdated = quotaStateUpdated

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -127,10 +127,18 @@ func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instructi
 		sort.Strings(explicitSvcs)
 		cmd.ExplicitServices = explicitSvcs
 
+		// When composing the task summary, prefer using the explicit
+		// services, if that's not empty
 		var summary string
-		if inst.Action == "restart" && len(explicitSvcs) == 0 {
+		if len(explicitSvcs) > 0 {
+			svcs = explicitSvcs
+		} else if inst.Action == "restart" {
+			// Use a generic message, since we cannot know the exact list of
+			// services affected
 			summary = fmt.Sprintf("Run service command %q for running services of snap %q", cmd.Action, cmd.SnapName)
-		} else {
+		}
+
+		if summary == "" {
 			summary = fmt.Sprintf("Run service command %q for services %q of snap %q", cmd.Action, svcs, cmd.SnapName)
 		}
 		task := st.NewTask("service-control", summary)

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -127,7 +127,12 @@ func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instructi
 		sort.Strings(explicitSvcs)
 		cmd.ExplicitServices = explicitSvcs
 
-		summary := fmt.Sprintf("Run service command %q for services %q of snap %q", cmd.Action, svcs, cmd.SnapName)
+		var summary string
+		if inst.Action == "restart" && len(explicitSvcs) == 0 {
+			summary = fmt.Sprintf("Run service command %q for running services of snap %q", cmd.Action, cmd.SnapName)
+		} else {
+			summary = fmt.Sprintf("Run service command %q for services %q of snap %q", cmd.Action, svcs, cmd.SnapName)
+		}
 		task := st.NewTask("service-control", summary)
 		task.Set("service-action", cmd)
 		if prev != nil {

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -424,6 +424,14 @@ func (s *snapServiceOptionsSuite) TestServiceControlTaskSummaries(c *C) {
 		},
 		{
 			&servicestate.Instruction{
+				Action:         "restart",
+				RestartOptions: client.RestartOptions{Reload: true},
+				Names:          []string{"foo.svc2", "foo.svc1"},
+			},
+			`Run service command "reload-or-restart" for services ["svc1" "svc2"] of snap "foo"`,
+		},
+		{
+			&servicestate.Instruction{
 				Action: "stop",
 				Names:  []string{"foo.svc1"},
 			},

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
@@ -372,4 +373,68 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 		VitalityRank: 2,
 		QuotaGroup:   grp,
 	})
+}
+
+func (s *snapServiceOptionsSuite) TestServiceControlTaskSummaries(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	si := snap.SideInfo{RealName: "foo", Revision: snap.R(1)}
+	snp := &snap.Info{SideInfo: si}
+	snapstate.Set(st, "foo", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	appInfos := []*snap.AppInfo{
+		{
+			Snap:        snp,
+			Name:        "svc1",
+			Daemon:      "simple",
+			DaemonScope: snap.UserDaemon,
+		},
+		{
+			Snap:        snp,
+			Name:        "svc2",
+			Daemon:      "simple",
+			DaemonScope: snap.UserDaemon,
+		},
+	}
+
+	for _, tc := range []struct {
+		instruction     *servicestate.Instruction
+		expectedSummary string
+	}{
+		{
+			&servicestate.Instruction{Action: "start"},
+			`Run service command "start" for services ["svc1" "svc2"] of snap "foo"`,
+		},
+		{
+			&servicestate.Instruction{Action: "restart"},
+			`Run service command "restart" for running services of snap "foo"`,
+		},
+		{
+			&servicestate.Instruction{
+				Action: "restart",
+				Names:  []string{"foo.svc2"},
+			},
+			`Run service command "restart" for services ["svc2"] of snap "foo"`,
+		},
+		{
+			&servicestate.Instruction{
+				Action: "stop",
+				Names:  []string{"foo.svc1"},
+			},
+			`Run service command "stop" for services ["svc1"] of snap "foo"`,
+		},
+	} {
+		taskSet, err := servicestate.ServiceControlTs(st, appInfos, tc.instruction)
+		c.Check(err, IsNil)
+		tasks := taskSet.Tasks()
+		c.Assert(tasks, HasLen, 1)
+		task := tasks[0]
+		c.Check(task.Summary(), Equals, tc.expectedSummary)
+	}
 }


### PR DESCRIPTION
If no services have been explicitly given, we are unable to tell what
services will be effectively restarted.

See also:
https://bugs.launchpad.net/snapd/+bug/1803212/comments/9
