### PR TITLE
tests: pre-cache snaps in classic and core systems

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -275,7 +275,10 @@ prepare_classic() {
 
         # Cache snaps
         # shellcheck disable=SC2086
-        cache_snaps core core18 core20 ${PRE_CACHE_SNAPS}
+        cache_snaps core core18 ${PRE_CACHE_SNAPS}
+        if os.query is-pc-amd64; then
+            cache_snaps core20
+        fi
 
         # now use parameterized core channel (defaults to edge) instead
         # of a fixed one and close to stable in order to detect defects

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -275,7 +275,7 @@ prepare_classic() {
 
         # Cache snaps
         # shellcheck disable=SC2086
-        cache_snaps core ${PRE_CACHE_SNAPS}
+        cache_snaps core core18 core20 ${PRE_CACHE_SNAPS}
 
         # now use parameterized core channel (defaults to edge) instead
         # of a fixed one and close to stable in order to detect defects
@@ -1123,6 +1123,9 @@ prepare_ubuntu_core() {
         cache_snaps core
         if os.query is-core18; then
             cache_snaps test-snapd-sh-core18
+        fi
+        if os.query is-core20; then
+            cache_snaps test-snapd-sh-core20
         fi
     fi
 


### PR DESCRIPTION
The idea of this change is to have cached the snaps in the system so
then it is faster to install new snaps which depends on either core18 or
core20
