### PR TITLE
tests: increase memory quota in quota-groups-systemd-accounting

### DIFF
--- a/tests/main/quota-groups-systemd-accounting/task.yaml
+++ b/tests/main/quota-groups-systemd-accounting/task.yaml
@@ -36,12 +36,12 @@ execute: |
 
   # create another sub-group which will serve as the poisoned branch on buggy
   # systems
-  snap set-quota --memory=5000B --parent=top sub2
+  snap set-quota --memory=50MB --parent=top sub2
 
   # now create a quota group under sub2 with no services in it, but still has a
   # snap in it so that the systemd slice underlying the quota group is generated
   # and exists
-  snap set-quota --memory=4900B --parent=sub2 sub21 hello-world
+  snap set-quota --memory=49MB --parent=sub2 sub21 hello-world
 
   # check that usage is still sensible for the groups that have real usage - 
   # here 18.4EB is how we format the maximum size of a 64-bit unsigned integer


### PR DESCRIPTION
The quota-groups-systemd-accounting test has been seen failing on Arch
with these logs:

  https://paste.ubuntu.com/p/YB5xpM5FYR/

While it's not totally clear why the OOM was triggered (there don't
appear to be any processes inside the control group), the test does
indeed create a couple of control groups with a ridiculously low amount
of memory, and one theory about this failure is that the systemd process
itself got momentarily assigned to the group.

In any case, the test is not interested in checking whether an OOM
occurred or not, so we do not want to trigger a failure if it happened.
