### PR TITLE
go: update go.mod dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,6 @@ require (
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	gopkg.in/tylerb/graceful.v1 v1.2.15
 	gopkg.in/yaml.v2 v2.3.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	maze.io/x/crypto v0.0.0-20190131090603-9b94c9afe066 // indirect
 )


### PR DESCRIPTION
Required by github.com/snapcore/snapd/overlord/configstate/configcore; running go test over master updates it every time (was indirect before).
