### PR TITLE
o/snapstate: only conflict with runnable and relevant tasks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,6 @@ require (
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	gopkg.in/tylerb/graceful.v1 v1.2.15
 	gopkg.in/yaml.v2 v2.3.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	maze.io/x/crypto v0.0.0-20190131090603-9b94c9afe066 // indirect
 )

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -166,6 +166,7 @@ func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChan
 		if chg == nil || chg.Status().Ready() {
 			continue
 		}
+
 		if ignoreChangeID != "" && chg.ID() == ignoreChangeID {
 			continue
 		}
@@ -181,6 +182,13 @@ func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChan
 		snaps, err := affectedSnaps(task)
 		if err != nil {
 			return err
+		}
+
+		// ignore, if this task can't run. Otherwise, we will signal a
+		// conflict if other tasks in this change can still run, even if
+		// they don't affect the snap we care about
+		if task.Status().Ready() {
+			continue
 		}
 
 		for _, snap := range snaps {

--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -65,7 +65,7 @@ const (
 	// ErrorStatus means the change or task has errored out while running or being undone.
 	ErrorStatus Status = 9
 
-	nStatuses = iota
+	NStatuses = iota
 )
 
 // Ready returns whether a task or change with this status needs further
@@ -264,7 +264,7 @@ var statusOrder = []Status{
 }
 
 func init() {
-	if len(statusOrder) != nStatuses-1 {
+	if len(statusOrder) != NStatuses-1 {
 		panic("statusOrder has wrong number of elements")
 	}
 }
@@ -284,7 +284,7 @@ func (c *Change) Status() Status {
 		if len(c.taskIDs) == 0 {
 			return HoldStatus
 		}
-		statusStats := make([]int, nStatuses)
+		statusStats := make([]int, NStatuses)
 		for _, tid := range c.taskIDs {
 			statusStats[c.state.tasks[tid].Status()]++
 		}


### PR DESCRIPTION
We were signalling conflicts on tasks that affected the relevant snap but couldn't run (e.g., failed), because we only checked if the Change had tasks that could run. As a result, if two tasks sets in the same Change affected the same snap and the first one failed, the second would always conflict because it would find a relevant task that couldn't run but was in a change with tasks that could.

Blocking #10630


