### PR TITLE
asserts, snapstate: return full validation set keys from CheckPresenceRequired and CheckPresenceInvalid

### DIFF
--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -495,7 +495,11 @@ func (v *ValidationSets) CheckPresenceRequired(snapRef naming.SnapRef) ([]string
 	var keys []string
 	for rev, revCstr := range cstrs.revisions {
 		for _, rc := range revCstr {
-			keys = append(keys, rc.validationSetKey)
+			vs := v.sets[rc.validationSetKey]
+			if vs == nil {
+				return nil, unspecifiedRevision, fmt.Errorf("internal error: no validation set for %q", rc.validationSetKey)
+			}
+			keys = append(keys, strings.Join(vs.At().PrimaryKey, "/"))
 			// there may be constraints without revision; only set snapRev if
 			// it wasn't already determined. Note that if revisions are set,
 			// then they are the same, otherwise validation sets would be in
@@ -527,7 +531,11 @@ func (v *ValidationSets) CheckPresenceInvalid(snapRef naming.SnapRef) ([]string,
 	for _, revCstr := range cstrs.revisions {
 		for _, rc := range revCstr {
 			if rc.Presence == asserts.PresenceInvalid {
-				keys = append(keys, rc.validationSetKey)
+				vs := v.sets[rc.validationSetKey]
+				if vs == nil {
+					return nil, fmt.Errorf("internal error: no validation set for %q", rc.validationSetKey)
+				}
+				keys = append(keys, strings.Join(vs.At().PrimaryKey, "/"))
 			}
 		}
 	}

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -499,7 +499,7 @@ func (v *ValidationSets) CheckPresenceRequired(snapRef naming.SnapRef) ([]string
 			if vs == nil {
 				return nil, unspecifiedRevision, fmt.Errorf("internal error: no validation set for %q", rc.validationSetKey)
 			}
-			keys = append(keys, strings.Join(vs.At().PrimaryKey, "/"))
+			keys = append(keys, strings.Join(vs.Ref().PrimaryKey, "/"))
 			// there may be constraints without revision; only set snapRev if
 			// it wasn't already determined. Note that if revisions are set,
 			// then they are the same, otherwise validation sets would be in
@@ -535,7 +535,7 @@ func (v *ValidationSets) CheckPresenceInvalid(snapRef naming.SnapRef) ([]string,
 				if vs == nil {
 					return nil, fmt.Errorf("internal error: no validation set for %q", rc.validationSetKey)
 				}
-				keys = append(keys, strings.Join(vs.At().PrimaryKey, "/"))
+				keys = append(keys, strings.Join(vs.Ref().PrimaryKey, "/"))
 			}
 		}
 	}

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -733,12 +733,12 @@ func (s *validationSetsSuite) TestCheckPresenceRequired(c *C) {
 	vsKeys, rev, err := valsets.CheckPresenceRequired(naming.Snap("my-snap"))
 	c.Assert(err, IsNil)
 	c.Check(rev, DeepEquals, snap.Revision{N: 7})
-	c.Check(vsKeys, DeepEquals, []string{"account-id/my-snap-ctl", "account-id/my-snap-ctl2", "account-id/my-snap-ctl3"})
+	c.Check(vsKeys, DeepEquals, []string{"16/account-id/my-snap-ctl/1", "16/account-id/my-snap-ctl2/2", "16/account-id/my-snap-ctl3/1"})
 
 	vsKeys, rev, err = valsets.CheckPresenceRequired(naming.NewSnapRef("my-snap", "mysnapididididididididididididid"))
 	c.Assert(err, IsNil)
 	c.Check(rev, DeepEquals, snap.Revision{N: 7})
-	c.Check(vsKeys, DeepEquals, []string{"account-id/my-snap-ctl", "account-id/my-snap-ctl2", "account-id/my-snap-ctl3"})
+	c.Check(vsKeys, DeepEquals, []string{"16/account-id/my-snap-ctl/1", "16/account-id/my-snap-ctl2/2", "16/account-id/my-snap-ctl3/1"})
 
 	// other-snap is not required
 	vsKeys, rev, err = valsets.CheckPresenceRequired(naming.Snap("other-snap"))
@@ -762,7 +762,7 @@ func (s *validationSetsSuite) TestCheckPresenceRequired(c *C) {
 	vsKeys, rev, err = valsets.CheckPresenceRequired(naming.Snap("my-snap"))
 	c.Assert(err, IsNil)
 	c.Check(rev, DeepEquals, snap.Revision{N: 0})
-	c.Check(vsKeys, DeepEquals, []string{"account-id/my-snap-ctl3"})
+	c.Check(vsKeys, DeepEquals, []string{"16/account-id/my-snap-ctl3/1"})
 }
 
 func (s *validationSetsSuite) TestIsPresenceInvalid(c *C) {
@@ -819,11 +819,11 @@ func (s *validationSetsSuite) TestIsPresenceInvalid(c *C) {
 	// invalid in two sets
 	vsKeys, err = valsets.CheckPresenceInvalid(naming.Snap("my-snap"))
 	c.Assert(err, IsNil)
-	c.Check(vsKeys, DeepEquals, []string{"account-id/my-snap-ctl", "account-id/my-snap-ctl2"})
+	c.Check(vsKeys, DeepEquals, []string{"16/account-id/my-snap-ctl/1", "16/account-id/my-snap-ctl2/2"})
 
 	vsKeys, err = valsets.CheckPresenceInvalid(naming.NewSnapRef("my-snap", "mysnapididididididididididididid"))
 	c.Assert(err, IsNil)
-	c.Check(vsKeys, DeepEquals, []string{"account-id/my-snap-ctl", "account-id/my-snap-ctl2"})
+	c.Check(vsKeys, DeepEquals, []string{"16/account-id/my-snap-ctl/1", "16/account-id/my-snap-ctl2/2"})
 
 	// other-snap isn't invalid
 	vsKeys, err = valsets.CheckPresenceInvalid(naming.Snap("other-snap"))

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -3746,7 +3746,7 @@ func (s *validationSetsSuite) installSnapReferencedByValidationSet(c *C, presenc
 
 func (s *validationSetsSuite) TestInstallSnapInvalidForValidationSetRefused(c *C) {
 	err := s.installSnapReferencedByValidationSet(c, "invalid", "", snap.R(0), "")
-	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" due to enforcing rules of validation set foo/bar`)
+	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" due to enforcing rules of validation set 16/foo/bar/1`)
 }
 
 func (s *validationSetsSuite) TestInstallSnapOptionalForValidationSetOK(c *C) {
@@ -3764,7 +3764,7 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSet(c *C) {
 			Action:         "install",
 			InstanceName:   "some-snap",
 			Channel:        "stable",
-			ValidationSets: [][]string{{"foo", "bar"}},
+			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
 		},
 		revno: snap.R(11),
 	}
@@ -3781,7 +3781,7 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSetAtRevision(
 			Action:         "install",
 			Revision:       snap.R(2),
 			InstanceName:   "some-snap",
-			ValidationSets: [][]string{{"foo", "bar"}},
+			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
 		},
 		revno: snap.R(2),
 	}
@@ -3798,7 +3798,7 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSetCohortIgnor
 			Action:         "install",
 			Revision:       snap.R(2),
 			InstanceName:   "some-snap",
-			ValidationSets: [][]string{{"foo", "bar"}},
+			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
 		},
 		revno: snap.R(2),
 	}
@@ -3807,5 +3807,5 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSetCohortIgnor
 
 func (s *validationSetsSuite) TestInstallSnapReferencedByValidationSetWrongRevision(c *C) {
 	err := s.installSnapReferencedByValidationSet(c, "required", "3", snap.R(2), "")
-	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" at requested revision 2 without --ignore-validation, revision 3 required by validation sets: foo/bar`)
+	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" at requested revision 2 without --ignore-validation, revision 3 required by validation sets: 16/foo/bar/1`)
 }

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -1843,7 +1843,7 @@ func (s *validationSetsSuite) removeSnapReferencedByValidationSet(c *C, presence
 
 func (s *validationSetsSuite) TestRemoveSnapRequiredByValidationSetRefused(c *C) {
 	err := s.removeSnapReferencedByValidationSet(c, "required")
-	c.Check(err, ErrorMatches, `snap "some-snap" is not removable: snap "some-snap" is required by validation sets: foo/bar`)
+	c.Check(err, ErrorMatches, `snap "some-snap" is not removable: snap "some-snap" is required by validation sets: 16/foo/bar/1`)
 }
 
 func (s *validationSetsSuite) TestRemoveOptionalSnapOK(c *C) {
@@ -1904,7 +1904,7 @@ func (s *validationSetsSuite) TestRemoveSnapRequiredByValidationSetAtSpecificRev
 	assertstate.UpdateValidationSet(s.state, &tr)
 
 	_, err := snapstate.Remove(s.state, "some-snap", snap.R(0), nil)
-	c.Assert(err, ErrorMatches, `snap "some-snap" is not removable: snap "some-snap" at revision 2 is required by validation sets: foo/bar`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" is not removable: snap "some-snap" at revision 2 is required by validation sets: 16/foo/bar/1`)
 
 	// it's ok to remove an unused revision
 	_, err = snapstate.Remove(s.state, "some-snap", snap.R(3), nil)
@@ -1957,7 +1957,7 @@ func (s *validationSetsSuite) TestRemoveSnapRequiredByValidationSetAtSpecificRev
 	// remove inactive revision 2 fails as it is required
 	// XXX: is this a viable scenario? the required revision isn't the active one?
 	_, err := snapstate.Remove(s.state, "some-snap", snap.R(2), nil)
-	c.Assert(err, ErrorMatches, `snap "some-snap" is not removable: snap "some-snap" at revision 2 is required by validation sets: foo/bar`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" is not removable: snap "some-snap" at revision 2 is required by validation sets: 16/foo/bar/1`)
 }
 
 func (s *snapmgrTestSuite) TestRemoveFailsWithInvalidSnapName(c *C) {


### PR DESCRIPTION
Return full validation set keys from CheckPresenceRequired and CheckPresenceInvalid. Full keys including series and sequence are expected by store api.
