### PR TITLE
cmd/libsnap-confine-private, tests, sandbox: remove warnings about cgroup v2, drop forced devmode

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -80,8 +80,6 @@ static const char *cgroup_dir = "/sys/fs/cgroup";
 // hybrid or legacy) The algorithm is described in
 // https://systemd.io/CGROUP_DELEGATION/
 bool sc_cgroup_is_v2(void) {
-    bool hide_warning = getenv_bool("SNAPD_HIDE_CGROUPV2_WARNING", false);
-    static bool did_warn = false;
     struct statfs buf;
 
     if (statfs(cgroup_dir, &buf) != 0) {
@@ -91,10 +89,6 @@ bool sc_cgroup_is_v2(void) {
         die("cannot statfs %s", cgroup_dir);
     }
     if (buf.f_type == CGROUP2_SUPER_MAGIC) {
-        if (!did_warn && !hide_warning) {
-            fprintf(stderr, "WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement\n");
-            did_warn = true;
-        }
         return true;
     }
     return false;

--- a/sandbox/forcedevmode.go
+++ b/sandbox/forcedevmode.go
@@ -23,7 +23,6 @@ package sandbox
 
 import (
 	"github.com/snapcore/snapd/sandbox/apparmor"
-	"github.com/snapcore/snapd/sandbox/cgroup"
 )
 
 // For testing only
@@ -37,10 +36,7 @@ func ForceDevMode() bool {
 	}
 
 	apparmorFull := apparmor.ProbedLevel() == apparmor.Full
-	// TODO: update once security backends affected by cgroupv2 are fully
-	// supported
-	cgroupv2 := cgroup.IsUnified()
-	return !apparmorFull || cgroupv2
+	return !apparmorFull
 }
 
 // MockForceDevMode fake the system to believe its in a distro

--- a/sandbox/forcedevmode_test.go
+++ b/sandbox/forcedevmode_test.go
@@ -49,13 +49,15 @@ func (s *forceDevModeSuite) TestForceDevMode(c *C) {
 
 	for _, tc := range []struct {
 		apparmorLevel apparmor.LevelType
+		// cgroup v2 used to be a factor when checking for forced dev
+		// mode
 		cgroupVersion int
 		exp           bool
 	}{
 		{apparmor.Full, cgroup.V1, false},
 		{apparmor.Partial, cgroup.V1, true},
 		// unified mode
-		{apparmor.Full, cgroup.V2, true},
+		{apparmor.Full, cgroup.V2, false},
 		{apparmor.Partial, cgroup.V2, true},
 	} {
 		runTest(tc.apparmorLevel, tc.cgroupVersion, tc.exp)

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -44,21 +44,14 @@ execute: |
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 
-    if is_cgroupv2; then
-        check_stderr() {
-            test -n "$1"
-            test "WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement" = "$(cat "$1")"
-        }
-    else
-        check_stderr() {
-            test -n "$1"
-            if [ -s "$1" ]; then
-                echo "stderr contains some messages"
-                cat "$1"
-                exit 1
-            fi
-        }
-    fi
+    check_stderr() {
+        test -n "$1"
+        if [ -s "$1" ]; then
+            echo "stderr contains some messages"
+            cat "$1"
+            exit 1
+        fi
+    }
 
     echo "No output on stderr when running with a session bus, when xdg-document-portal is not present."
     tests.session -u test exec test-snapd-desktop.check-dirs /home/test/snap/test-snapd-desktop/current 2>stderr.log

--- a/tests/main/snapctl-is-connected/task.yaml
+++ b/tests/main/snapctl-is-connected/task.yaml
@@ -10,18 +10,10 @@ restore: |
 execute: |
   check_empty() {
     local OUT="$1"
-    case "$SPREAD_SYSTEM" in
-        # special case systems using unified cgroup v2 hierarchy
-        fedora-33-*|fedora-34-*|debian-sid-*|arch-*|opensuse-tumbleweed-*)
-            echo "$OUT" | MATCH '^WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement$'
-            ;;
-        *)
-            if [ -n "$OUT" ]; then
-                echo "Expected no output, but got: $OUT"
-                exit 1
-            fi
-      ;;
-    esac
+    if [ -n "$OUT" ]; then
+        echo "Expected no output, but got: $OUT"
+        exit 1
+    fi
   }
 
   # network is connected by default

--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -22,29 +22,19 @@ execute: |
     echo "Ensure that the snap can be run as root"
     test-snapd-sh.sh -c 'echo hello' > stdout.log 2> stderr.log
     MATCH "^hello$" < stdout.log
-    if is_cgroupv2; then
-        # snap-confine issues a warning on a cgroupv2 system
-        [ "$(cat stderr.log)" = 'WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement' ]
-    else
-       if [ -s stderr.log ]; then
-           echo "stderr.log must be empty but it is not: (run as root)"
-           cat stderr.log
-           exit 1
-       fi
+    if [ -s stderr.log ]; then
+        echo "stderr.log must be empty but it is not: (run as root)"
+        cat stderr.log
+        exit 1
     fi
 
     echo "Ensure that the snap can be run as the user"
     su -l -c "test-snapd-sh.sh -c 'echo hello' > stdout.log 2> stderr.log" test
     MATCH "^hello$" < stdout.log
-    if is_cgroupv2; then
-        # snap-confine issues a warning on a cgroupv2 system
-        [ "$(cat stderr.log)" = 'WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement' ]
-    else
-       if [ -s stderr.log ]; then
-           echo "stderr.log must be empty but it is not: (run as user)"
-           cat stderr.log
-           exit 1
-       fi
+    if [ -s stderr.log ]; then
+        echo "stderr.log must be empty but it is not: (run as user)"
+        cat stderr.log
+        exit 1
     fi
 
     echo "Ensure the snap is listed"


### PR DESCRIPTION
Now that we have cgroup v2 support in master, we can drop the warnings and forced devmode.