### PR TITLE
cmd: build gdb shims as static binaries

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -531,6 +531,7 @@ snap_gdb_shim_snap_gdb_shim_SOURCES = \
 	snap-gdb-shim/snap-gdb-shim.c
 
 snap_gdb_shim_snap_gdb_shim_LDADD = libsnap-confine-private.a
+snap_gdb_shim_snap_gdb_shim_LDFLAGS = -static
 
 ##
 ## snap-gdbserver-shim
@@ -542,6 +543,7 @@ snap_gdb_shim_snap_gdbserver_shim_SOURCES = \
 	snap-gdb-shim/snap-gdbserver-shim.c
 
 snap_gdb_shim_snap_gdbserver_shim_LDADD = libsnap-confine-private.a
+snap_gdb_shim_snap_gdbserver_shim_LDFLAGS = -static
 
 ##
 ## snapd-generator


### PR DESCRIPTION
The gdb helper shims execute inside the snap mount namespace, but may come from
the snapd package on the host, or have otherwise been built on the host system.
In order to avoid dependency on a specific version of glibc on the host, build
both binaries statically.