### PR TITLE
tests/nested/manual: use loop for checking for initialize-system task done

### DIFF
--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -136,6 +136,9 @@ execute: |
         exit
     fi
 
+    # wait for the initialize device task to be done
+    retry -n 200 --wait 1 sh -c "tests.nested exec snap changes | MATCH 'Done.*Initialize device'"
+
     echo "Check we have the right model from snap model"
     tests.nested exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-secured-core-20-amd64"
     tests.nested exec "sudo snap model --verbose" | MATCH "grade:\s+secured"

--- a/tests/nested/manual/grade-signed-above-testkeys-boot/task.yaml
+++ b/tests/nested/manual/grade-signed-above-testkeys-boot/task.yaml
@@ -120,8 +120,8 @@ execute: |
       exit
   fi
 
-  #shellcheck source=tests/lib/nested.sh
-  . "$TESTSLIB/nested.sh"
+  # wait for the initialize device task to be done
+  retry -n 200 --wait 1 sh -c "tests.nested exec snap changes | MATCH 'Done.*Initialize device'"
 
   echo "Check we have the right model from snap model"
   tests.nested exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-${MODEL_GRADE}-core-20-amd64"

--- a/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
+++ b/tests/nested/manual/grade-signed-cloud-init-testkeys/task.yaml
@@ -123,6 +123,9 @@ execute: |
       exit
   fi
 
+  # wait for the initialize device task to be done
+  retry -n 200 --wait 1 sh -c "tests.nested exec snap changes | MATCH 'Done.*Initialize device'"
+
   echo "The initial cloud-init user was created"
   tests.nested exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
 


### PR DESCRIPTION
There is a race here in waiting for snapd to finish this task, since the
nested tooling will wait for snapd to be seeded, but this task runs immediately
after seeding is done, so we may execute the code before the task is actually
done executing.