### PR TITLE
tests: manually umount devices during reset to prevent invariant error

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -53,7 +53,14 @@ reset_classic() {
         ls -lR "$SNAP_MOUNT_DIR"/ /var/snap/
         exit 1
     fi
+
+    # Make sure no junk in /tmp/snap.rootfs_*
     rm -rf /tmp/snap.*
+    # Umount any device that could be still mounted
+    for rootfsdir in /tmp/snap.rootfs.*; do
+        dev="$(mount | grep "$rootfsdir" | awk '{print $1}')"
+        umount "$dev"
+    done
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*)

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -54,13 +54,13 @@ reset_classic() {
         exit 1
     fi
 
-    # Make sure no junk in /tmp/snap.rootfs_*
-    rm -rf /tmp/snap.*
     # Umount any device that could be still mounted
     for rootfsdir in /tmp/snap.rootfs.*; do
         dev="$(mount | grep "$rootfsdir" | awk '{print $1}')"
         umount "$dev"
     done
+    # Make sure no junk in /tmp/snap.rootfs_*
+    rm -rf /tmp/snap.rootfs.*
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*)

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -60,7 +60,7 @@ reset_classic() {
         umount "$dev"
     done
     # Make sure no junk in /tmp/snap.rootfs_*
-    rm -rf /tmp/snap.rootfs.*
+    rm -rf /tmp/snap.rootfs_*
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*)

--- a/tests/main/upgrade-from-2.15/task.yaml
+++ b/tests/main/upgrade-from-2.15/task.yaml
@@ -20,12 +20,6 @@ restore: |
     "$TESTSTOOLS"/apt-state restore installed.pkgs
     rm -f installed.pkgs
 
-    # snap-confine, in the old version of snapd, leaves behind junk in
-    # /tmp/snap.rootfs_* This is now detected by invariant detector, which uses
-    # it as a sign of possible snap-confine crash. To avoid the false positive,
-    # remove those leftovers.
-    rm -rf /tmp/snap.rootfs_*
-
     # Remove file with wget history
     rm -f /root/.wget-hsts
 


### PR DESCRIPTION
This change is to avoid some tests fail during restore because the
invariant check fails with:

tests.invariant: it seems snap-confine has crashed
/tmp/snap.rootfs_WHbwux

Debugging the error I saw the /tmp/snapd.rootfs_WHbwux directory is
empty before the reset is executed.

To reproduce the issue just run:
google:opensuse-15.2-64:tests/main/postrm-purge

The idea is to manually umount any device which remains mounted during
reset.

