### PR TITLE
tests: fix tests for 21.10

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -654,7 +654,7 @@ pkg_dependencies_ubuntu_core(){
         pkg_linux_image_extra
 }
 
-pkg_dependencies_fedora(){
+pkg_dependencies_fedora_centos_common(){
     echo "
         python3
         clang
@@ -687,6 +687,12 @@ pkg_dependencies_fedora(){
         "
 }
 
+pkg_dependencies_fedora(){
+    echo "
+         libcap-static
+        "
+}
+
 pkg_dependencies_amazon(){
     echo "
         python3
@@ -700,6 +706,7 @@ pkg_dependencies_amazon(){
         grub2-tools
         jq
         iptables-services
+        libcap-static
         man
         nc
         net-tools
@@ -804,7 +811,11 @@ pkg_dependencies(){
         amazon-*|centos-7-*)
             pkg_dependencies_amazon
             ;;
-        fedora-*|centos-*)
+        centos-*)
+            pkg_dependencies_fedora_centos_common
+            ;;
+        fedora-*)
+            pkg_dependencies_fedora_centos_common
             pkg_dependencies_fedora
             ;;
         opensuse-*)

--- a/tests/main/snap-confine-drops-sys-admin/task.yaml
+++ b/tests/main/snap-confine-drops-sys-admin/task.yaml
@@ -17,8 +17,10 @@ prepare: |
 
     echo "Compile and prepare the support program"
     # Because we use the snap data directory we don't need to clean it up
-    # manually as all snaps and their data are reset after each test.
-    gcc -Wall -Wextra -Werror ./has-sys-admin.c -lcap -o "$P/has-sys-admin"
+    # manually as all snaps and their data are reset after each test. Build the
+    # binary statically, such that it can execute regardless of an older glibc
+    # in the base snap.
+    gcc -Wall -Wextra -Werror -static ./has-sys-admin.c -lcap -o "$P/has-sys-admin"
 
 execute: |
     echo "The test executables files have the expected mode and ownership"

--- a/tests/main/snap-confine-drops-sys-admin/task.yaml
+++ b/tests/main/snap-confine-drops-sys-admin/task.yaml
@@ -3,7 +3,8 @@ summary: ensure that snap-confine drops CAP_SYS_ADMIN for non-root
 # This test is not executed on a core system simply because of the hassle of
 # building the support C program. In the future it might be improved with the
 # use of the classic snap where we just use classic to build the helper.
-systems: [-ubuntu-core-*]
+# Arch, CentOS, AMZN2, openSUSE do not have a static version of libcap.
+systems: [-ubuntu-core-*, -arch-linux-*, -centos-*, -amazon-linux-*, -opensuse-* ]
 
 environment:
     # This is used to abbreviate some of the paths below.
@@ -20,7 +21,7 @@ prepare: |
     # manually as all snaps and their data are reset after each test. Build the
     # binary statically, such that it can execute regardless of an older glibc
     # in the base snap.
-    gcc -Wall -Wextra -Werror -static ./has-sys-admin.c -lcap -o "$P/has-sys-admin"
+    gcc -Wall -Wextra -Werror ./has-sys-admin.c -o "$P/has-sys-admin" -lcap -static
 
 execute: |
     echo "The test executables files have the expected mode and ownership"

--- a/tests/main/snap-confine-privs/task.yaml
+++ b/tests/main/snap-confine-privs/task.yaml
@@ -23,7 +23,9 @@ prepare: |
     echo "Compile and prepare the support program"
     # Because we use the snap data directory we don't need to clean it up
     # manually as all snaps and their data are reset after each test.
-    gcc -Wall -Wextra -Werror ./uids-and-gids.c -o "$P/uids-and-gids"
+    # Build the test binary statically, as it will be running inside a base with
+    # potentially older glibc.
+    gcc -Wall -Wextra -Werror ./uids-and-gids.c -o "$P/uids-and-gids" -static
     cp "$P/uids-and-gids" "$P/uids-and-gids-setuid"
     chown root "$P/uids-and-gids-setuid"
     chmod 4755 "$P/uids-and-gids-setuid"

--- a/tests/regression/lp-1812973/Makefile
+++ b/tests/regression/lp-1812973/Makefile
@@ -1,6 +1,9 @@
-name=lp-1812973
+name = lp-1812973
 
-CFLAGS=-Wall -Werror
+CFLAGS = -Wall -Werror
+# build the test binary statically as it will be running inside the snap mount
+# namespace that may use a base with an older version of glibc
+LDFLAGS = -static
 
 .PHONY: all
 all: $(name)


### PR DESCRIPTION
21.10 uses glibc 2.34 while all our base snaps use and older version, thus binaries built on 21.10 host will not work properly in the mount ns of snaps using those bases.