### PR TITLE
o/ifacestate: do not create stray task in batchConnectTasks if there are no connections

### DIFF
--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -469,11 +469,14 @@ func (s *interfaceManagerSuite) TestBatchConnectTasks(c *C) {
 	conns := make(map[string]*interfaces.ConnRef)
 	connOpts := make(map[string]*ifacestate.ConnectOpts)
 
-	// no connections
+	// no connections and tasks created (also, no stray tasks in the state)
 	ts, hasInterfaceHooks, err := ifacestate.BatchConnectTasks(s.state, snapsup, conns, connOpts)
 	c.Assert(err, IsNil)
-	c.Check(ts.Tasks(), HasLen, 0)
+	c.Check(ts, IsNil)
 	c.Check(hasInterfaceHooks, Equals, false)
+	// state.TaskCount() is the only way of checking for stray tasks without a
+	// change (state.Tasks() filters those out).
+	c.Assert(s.state.TaskCount(), Equals, 0)
 
 	// two connections
 	cref1 := interfaces.ConnRef{PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"}, SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}}

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -76,6 +76,23 @@ func (ss *stateSuite) TestGetAndSet(c *C) {
 	c.Check(&mSt2B, DeepEquals, mSt2)
 }
 
+func (ss *stateSuite) TestStrayTaskWithNoChange(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("change", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+	_ = st.NewTask("bar", "...")
+
+	// only the task with associate change is returned
+	c.Assert(st.Tasks(), HasLen, 1)
+	c.Assert(st.Tasks()[0].ID(), Equals, t1.ID())
+	// but count includes all tasks
+	c.Assert(st.TaskCount(), Equals, 2)
+}
+
 func (ss *stateSuite) TestSetPanic(c *C) {
 	st := state.New(nil)
 	st.Lock()


### PR DESCRIPTION
Do not create stray "Setup snap ... security profiles for auto-connection" task in the state (with no associated change) in batchConnectTasks if there are no connections, just return early. Not sure it's really a bug, maybe a "mild bug" since I think we do have cases where we create tasks in state and error out elsewhere in processing, and never add them to changes which is fine, but it's best to avoid leaving garbage in happy cases where there are no connections to handle.

The task wouldn't be executed and has no impact on snapd ops AFAICT, but is useless/confusing when found in the state (this was noticed while investigating https://bugs.launchpad.net/snapd/+bug/1943686, but not a fix for that bug).

Also added a simple test for state for the behavior of .Tasks() and .TaskCount(), since the test for batchConnect relies on the latter and if we ever changed TaskCount() to filter stray tasks out, the batchConnect test would still happily pass.