### PR TITLE
[RFC, draft] tests: report stray tasks in spread test restore

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -740,8 +740,9 @@ restore_suite() {
 }
 
 restore_project_each() {
-    $STRAY_TASKS=$(cat /var/lib/snapd/state.json | jq '.tasks[] | select (.change == "") | {"id":.id,"summary":.summary,"kind":.kind}')
-    if [ $(echo "$STRAY_TASKS" | wc -l) -gt 0 ]; then
+    STRAY_TASKS=$(jq '.tasks[] | select (.change == "") | {"id":.id,"summary":.summary,"kind":.kind}' < /var/lib/snapd/state.json)
+    if [ "$(echo "${STRAY_TASKS}" | wc -l)" -gt 0 ]; then
+        echo "There are stray tasks without an associated change leftover in the state.json:"
         echo "$STRAY_TASKS"
         exit 1
     fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -740,6 +740,12 @@ restore_suite() {
 }
 
 restore_project_each() {
+    $STRAY_TASKS=$(cat /var/lib/snapd/state.json | jq '.tasks[] | select (.change == "") | {"id":.id,"summary":.summary,"kind":.kind}')
+    if [ $(echo "$STRAY_TASKS" | wc -l) -gt 0 ]; then
+        echo "$STRAY_TASKS"
+        exit 1
+    fi
+
     "$TESTSTOOLS"/cleanup-state pre-invariant
     # Check for invariants early, in order not to mask bugs in tests.
     tests.invariant check

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -740,11 +740,13 @@ restore_suite() {
 }
 
 restore_project_each() {
-    STRAY_TASKS=$(jq '.tasks[] | select (.change == "") | {"id":.id,"summary":.summary,"kind":.kind}' < /var/lib/snapd/state.json)
-    if [ "$(echo "${STRAY_TASKS}" | wc -l)" -gt 0 ]; then
-        echo "There are stray tasks without an associated change leftover in the state.json:"
-        echo "$STRAY_TASKS"
-        exit 1
+    if os.query is-classic; then
+        STRAY_TASKS=$(jq '.tasks[] | select (.change == "") | {"id":.id,"summary":.summary,"kind":.kind}' < /var/lib/snapd/state.json)
+        if [ "$(echo "${STRAY_TASKS}" | wc -l)" -gt 0 ]; then
+            echo "There are stray tasks without an associated change leftover in the state.json:"
+            echo "$STRAY_TASKS"
+            exit 1
+        fi
     fi
 
     "$TESTSTOOLS"/cleanup-state pre-invariant


### PR DESCRIPTION
Just an experiment - report stray tasks without changes on spread test restore. Generally not an issue, but I wonder how many of those we have and if some can be optimized/cleaned up (similiar to #10782)