### PR TITLE
o/snapstate: add ChangeID to conflict error

### DIFF
--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -958,7 +958,9 @@ func (s *deviceMgrRemodelSuite) TestRemodelClashInProgress(c *C) {
 
 	_, err := devicestate.Remodel(s.state, new)
 	c.Check(err, DeepEquals, &snapstate.ChangeConflictError{
-		Message: "cannot start remodel, clashing with concurrent one",
+		Message:    "cannot start remodel, clashing with concurrent one",
+		ChangeKind: "remodel",
+		ChangeID:   "1",
 	})
 }
 
@@ -1014,19 +1016,19 @@ func (s *deviceMgrRemodelSuite) TestRemodeling(c *C) {
 	defer s.state.Unlock()
 
 	// no changes
-	c.Check(devicestate.Remodeling(s.state), Equals, false)
+	c.Check(devicestate.RemodelingChange(s.state), IsNil)
 
 	// other change
 	s.state.NewChange("other", "...")
-	c.Check(devicestate.Remodeling(s.state), Equals, false)
+	c.Check(devicestate.RemodelingChange(s.state), IsNil)
 
 	// remodel change
 	chg := s.state.NewChange("remodel", "...")
-	c.Check(devicestate.Remodeling(s.state), Equals, true)
+	c.Check(devicestate.RemodelingChange(s.state), NotNil)
 
 	// done
 	chg.SetStatus(state.DoneStatus)
-	c.Check(devicestate.Remodeling(s.state), Equals, false)
+	c.Check(devicestate.RemodelingChange(s.state), IsNil)
 }
 
 func (s *deviceMgrRemodelSuite) TestDeviceCtxNoTask(c *C) {

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1005,6 +1005,7 @@ func (s *deviceMgrRemodelSuite) TestReregRemodelClashAnyChange(c *C) {
 	c.Assert(err, DeepEquals, &snapstate.ChangeConflictError{
 		ChangeKind: "chg",
 		Message:    `other changes in progress (conflicting change "chg"), change "remodel" not allowed until they are done`,
+		ChangeID:   chg.ID(),
 	})
 }
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -4346,7 +4346,7 @@ func (s *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	chg, err := devicestate.Remodel(st, newModel)
 	c.Assert(err, IsNil)
 
-	c.Check(devicestate.Remodeling(st), Equals, true)
+	c.Check(devicestate.RemodelingChange(st), NotNil)
 
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -4355,7 +4355,7 @@ func (s *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("upgrade-snap change failed with: %v", chg.Err()))
 
-	c.Check(devicestate.Remodeling(st), Equals, false)
+	c.Check(devicestate.RemodelingChange(st), IsNil)
 
 	// the new required-snap "foo" is installed
 	var snapst snapstate.SnapState
@@ -6472,7 +6472,7 @@ func (s *mgrsSuite) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) {
 	chg, err := devicestate.Remodel(st, newModel)
 	c.Assert(err, IsNil)
 
-	c.Check(devicestate.Remodeling(st), Equals, true)
+	c.Check(devicestate.RemodelingChange(st), NotNil)
 
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -6480,7 +6480,7 @@ func (s *mgrsSuite) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) {
 	c.Assert(err, IsNil, Commentf(s.logbuf.String()))
 
 	c.Check(chg.Status(), Equals, state.DoingStatus, Commentf("remodel change failed: %v", chg.Err()))
-	c.Check(devicestate.Remodeling(st), Equals, true)
+	c.Check(devicestate.RemodelingChange(st), NotNil)
 	restarting, kind := st.Restarting()
 	c.Check(restarting, Equals, true)
 	c.Assert(kind, Equals, state.RestartSystemNow)

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -2108,12 +2108,14 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2ConflictOtherSnapOp(c *C) {
 	c.Assert(err, DeepEquals, &snapstate.ChangeConflictError{
 		ChangeKind: "fake-auto-refresh",
 		Snap:       "snap-a",
+		ChangeID:   chg.ID(),
 	})
 
 	_, err = snapstate.Update(s.state, "snap-a", nil, 0, snapstate.Flags{})
 	c.Assert(err, DeepEquals, &snapstate.ChangeConflictError{
 		ChangeKind: "fake-auto-refresh",
 		Snap:       "snap-a",
+		ChangeID:   chg.ID(),
 	})
 
 	// only 2 tasks because we don't run settle() so conditional-auto-refresh

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -37,7 +37,7 @@ type ChangeConflictError struct {
 	ChangeKind string
 	// a Message is optional, otherwise one is composed from the other information
 	Message string
-	// ChangeID is the ID of the change with which the operation conflicts
+	// ChangeID can optionally be set to the ID of the change with which the operation conflicts
 	ChangeID string
 }
 

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -37,6 +37,8 @@ type ChangeConflictError struct {
 	ChangeKind string
 	// a Message is optional, otherwise one is composed from the other information
 	Message string
+	// ChangeID is the ID of the change with which the operation conflicts
+	ChangeID string
 }
 
 func (e *ChangeConflictError) Error() string {
@@ -57,7 +59,7 @@ var (
 	affectedSnapsByKind = make(map[string]AffectedSnapsFunc)
 )
 
-// AddAffectedSnapsByAttrs registers an AffectedSnapsFunc for returning the affected snaps for tasks sporting the given identifying attribute, to use in conflicts detection.
+// AddAffectedSnapsByAttr registers an AffectedSnapsFunc for returning the affected snaps for tasks sporting the given identifying attribute, to use in conflicts detection.
 func AddAffectedSnapsByAttr(attr string, f AffectedSnapsFunc) {
 	affectedSnapsByAttr[attr] = f
 }
@@ -100,11 +102,13 @@ func checkChangeConflictExclusiveKinds(st *state.State, newExclusiveChangeKind, 
 			return &ChangeConflictError{
 				Message:    "ubuntu-core to core transition in progress, no other changes allowed until this is done",
 				ChangeKind: "transition-ubuntu-core",
+				ChangeID:   chg.ID(),
 			}
 		case "transition-to-snapd-snap":
 			return &ChangeConflictError{
 				Message:    "transition to snapd snap in progress, no other changes allowed until this is done",
 				ChangeKind: "transition-to-snapd-snap",
+				ChangeID:   chg.ID(),
 			}
 		case "remodel":
 			if ignoreChangeID != "" && chg.ID() == ignoreChangeID {
@@ -113,6 +117,7 @@ func checkChangeConflictExclusiveKinds(st *state.State, newExclusiveChangeKind, 
 			return &ChangeConflictError{
 				Message:    "remodeling in progress, no other changes allowed until this is done",
 				ChangeKind: "remodel",
+				ChangeID:   chg.ID(),
 			}
 		case "create-recovery-system":
 			if ignoreChangeID != "" && chg.ID() == ignoreChangeID {
@@ -121,6 +126,7 @@ func checkChangeConflictExclusiveKinds(st *state.State, newExclusiveChangeKind, 
 			return &ChangeConflictError{
 				Message:    "creating recovery system in progress, no other changes allowed until this is done",
 				ChangeKind: "create-recovery-system",
+				ChangeID:   chg.ID(),
 			}
 		default:
 			if newExclusiveChangeKind != "" {
@@ -131,6 +137,7 @@ func checkChangeConflictExclusiveKinds(st *state.State, newExclusiveChangeKind, 
 				return &ChangeConflictError{
 					Message:    msg,
 					ChangeKind: chg.Kind(),
+					ChangeID:   chg.ID(),
 				}
 			}
 		}
@@ -185,7 +192,11 @@ func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChan
 
 		for _, snap := range snaps {
 			if snapMap[snap] {
-				return &ChangeConflictError{Snap: snap, ChangeKind: chg.Kind()}
+				return &ChangeConflictError{
+					Snap:       snap,
+					ChangeKind: chg.Kind(),
+					ChangeID:   chg.ID(),
+				}
 			}
 		}
 	}

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -56,7 +56,7 @@ var (
 
 // Hook setup by devicestate to know whether a remodeling is in progress.
 var (
-	Remodeling func(st *state.State) bool
+	RemodelingChange func(st *state.State) *state.Change
 )
 
 // ModelFromTask returns a model assertion through the device context for the task.
@@ -80,7 +80,7 @@ func DevicePastSeeding(st *state.State, providedDeviceCtx DeviceContext) (Device
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
-	if Remodeling(st) {
+	if chg := RemodelingChange(st); chg != nil {
 		// a remodeling is in progress and this is not called
 		// as part of it. The 2nd check should not be needed
 		// in practice.
@@ -89,6 +89,7 @@ func DevicePastSeeding(st *state.State, providedDeviceCtx DeviceContext) (Device
 				Message: "remodeling in progress, no other " +
 					"changes allowed until this is done",
 				ChangeKind: "remodel",
+				ChangeID:   chg.ID(),
 			}
 		}
 	}

--- a/overlord/snapstate/devicectx_test.go
+++ b/overlord/snapstate/devicectx_test.go
@@ -86,9 +86,10 @@ func (s *deviceCtxSuite) TestDevicePastSeedingProvided(c *C) {
 	c.Assert(deviceCtx, Equals, deviceCtx1)
 
 	// remodeling is also ok
+	chg := s.st.NewChange("remodel", "dummy remodeling")
 	deviceCtx2 := &snapstatetest.TrivialDeviceContext{DeviceModel: MakeModel(nil), Remodeling: true}
-	defer snapstatetest.ReplaceRemodelingHook(func(*state.State) bool {
-		return true
+	defer snapstatetest.ReplaceRemodelingHook(func(*state.State) *state.Change {
+		return chg
 	})()
 	deviceCtx, err = snapstate.DevicePastSeeding(s.st, deviceCtx2)
 	c.Assert(err, IsNil)
@@ -98,6 +99,7 @@ func (s *deviceCtxSuite) TestDevicePastSeedingProvided(c *C) {
 		Message: "remodeling in progress, no other " +
 			"changes allowed until this is done",
 		ChangeKind: "remodel",
+		ChangeID:   chg.ID(),
 	}
 
 	// should not happen in practice but correct
@@ -147,14 +149,17 @@ func (s *deviceCtxSuite) TestDevicePastSeedingButRemodeling(c *C) {
 
 	r := snapstatetest.MockDeviceModel(DefaultModel())
 	defer r()
-	defer snapstatetest.ReplaceRemodelingHook(func(*state.State) bool {
-		return true
+
+	chg := s.st.NewChange("remodel", "dummy remodeling")
+	defer snapstatetest.ReplaceRemodelingHook(func(*state.State) *state.Change {
+		return chg
 	})()
 
 	expectedErr := &snapstate.ChangeConflictError{
 		Message: "remodeling in progress, no other " +
 			"changes allowed until this is done",
 		ChangeKind: "remodel",
+		ChangeID:   chg.ID(),
 	}
 
 	_, err := snapstate.DevicePastSeeding(s.st, nil)

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -119,8 +119,12 @@ func MockDeviceContext(deviceCtx snapstate.DeviceContext) (restore func()) {
 	r1 := ReplaceDeviceCtxHook(deviceCtxHook)
 	// for convenience reflect from the context whether there is a
 	// remodeling
-	r2 := ReplaceRemodelingHook(func(*state.State) bool {
-		return deviceCtx != nil && deviceCtx.ForRemodeling()
+	r2 := ReplaceRemodelingHook(func(s *state.State) *state.Change {
+		if deviceCtx != nil && deviceCtx.ForRemodeling() {
+			return s.NewChange("dummy", "dummy remodeling change")
+		}
+
+		return nil
 	})
 	return func() {
 		r1()
@@ -140,10 +144,10 @@ func UseFallbackDeviceModel() (restore func()) {
 	return MockDeviceModel(sysdb.GenericClassicModel())
 }
 
-func ReplaceRemodelingHook(remodelingHook func(st *state.State) bool) (restore func()) {
-	oldHook := snapstate.Remodeling
-	snapstate.Remodeling = remodelingHook
+func ReplaceRemodelingHook(remodelingHook func(st *state.State) *state.Change) (restore func()) {
+	oldHook := snapstate.RemodelingChange
+	snapstate.RemodelingChange = remodelingHook
 	return func() {
-		snapstate.Remodeling = oldHook
+		snapstate.RemodelingChange = oldHook
 	}
 }


### PR DESCRIPTION
This PR adds the change ID to the change conflict error so that an op conflicting with a duplicate op in the same change can just check that the conflict a kind of "self-conflict" and skip.
