### PR TITLE
tests: add test for store.SnapAction() request timeout

### DIFF
--- a/store/export_test.go
+++ b/store/export_test.go
@@ -237,6 +237,14 @@ func MockRatelimitReader(f func(r io.Reader, bucket *ratelimit.Bucket) io.Reader
 	}
 }
 
+func MockRequestTimeout(d time.Duration) (restore func()) {
+	old := requestTimeout
+	requestTimeout = d
+	return func() {
+		requestTimeout = old
+	}
+}
+
 type (
 	ErrorListEntryJSON   = errorListEntry
 	SnapActionResultJSON = snapActionResult

--- a/store/store.go
+++ b/store/store.go
@@ -68,6 +68,8 @@ const (
 	UbuntuCoreWireProtocol = "1"
 )
 
+var requestTimeout = 10 * time.Second
+
 // the LimitTime should be slightly more than 3 times of our http.Client
 // Timeout value
 var defaultRetryStrategy = retry.LimitCount(6, retry.LimitTime(38*time.Second,
@@ -394,7 +396,7 @@ func New(cfg *Config, dauthCtx DeviceAndAuthContext) *Store {
 		userAgent:          userAgent,
 	}
 	store.client = store.newHTTPClient(&httputil.ClientOptions{
-		Timeout:    10 * time.Second,
+		Timeout:    requestTimeout,
 		MayLogBody: true,
 	})
 	store.SetCacheDownloads(cfg.CacheDownloads)

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -3187,3 +3187,40 @@ func (s *storeActionSuite) TestSnapAction400(c *C) {
 	c.Check(err, FitsTypeOf, &store.UnexpectedHTTPStatusError{})
 	c.Check(results, HasLen, 0)
 }
+
+func (s *storeActionSuite) TestSnapActionTimeout(c *C) {
+	restore := store.MockRequestTimeout(250 * time.Millisecond)
+	defer restore()
+
+	quit := make(chan bool)
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// block the handler, do not send response headers.
+		select {
+		case <-quit:
+		case <-time.After(30 * time.Second):
+			// we expect to hit RequestTimeout first
+			c.Fatalf("unexpected")
+		}
+		mockServer.CloseClientConnections()
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+	}
+	dauthCtx := &testDauthContext{c: c, device: s.device}
+	sto := store.New(&cfg, dauthCtx)
+
+	_, _, err := sto.SnapAction(s.ctx, nil, []*store.SnapAction{
+		{
+			Action:       "install",
+			InstanceName: "foo",
+		},
+	}, nil, nil, nil)
+	close(quit)
+	c.Assert(err, ErrorMatches, `Post http://127.0.0.1:.*/v2/snaps/refresh: net/http: request canceled \(Client.Timeout exceeded while awaiting headers\)`)
+}


### PR DESCRIPTION
Following previous revelation from #10518 I wanted to double-check that the Timeout we set in store's http client works, so added a test similar to that from #10518 (and yes it works 😅 )