### PR TITLE
tests: add a local snap variant to testing prepare-image gating support

### DIFF
--- a/tests/main/prepare-image-gating/task.yaml
+++ b/tests/main/prepare-image-gating/task.yaml
@@ -7,20 +7,28 @@ systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*]
 environment:
     ROOT: "$PWD/root"
     SEED: "$PWD/root/system-seed"
+    LOCAL_GATING/local: 1
+    LOCAL_GATING/fetched: 0
 
 debug: |
     find "$SEED" -ls || true
 
 execute: |
     echo Running prepare-image
-    # TODO: variant were we pass in the gating snap via --snap *.snap
     cat >custom.json <<EOF
     {
       "validation": "enforce"
     }
     EOF
 
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --customize custom.json $TESTSLIB/assertions/gating-20-amd64.model $ROOT" test
+    SNAP_ARG=
+    if [ "${LOCAL_GATING}" = "1" ]; then
+       snap download --edge test-snapd-gating
+       chmod +r test-snapd-gating_*.snap
+       SNAP_ARG="--snap test-snapd-gating_*.snap"
+    fi
+
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image ${SNAP_ARG} --customize custom.json $TESTSLIB/assertions/gating-20-amd64.model $ROOT" test
 
     GATED_REV=2
 


### PR DESCRIPTION
this resolves the TODO in the original PR
