### PR TITLE
gadget: add VolumeName to Volume and VolumeStructure

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -112,12 +112,16 @@ type Volume struct {
 	ID string `yaml:"id"`
 	// Structure describes the structures that are part of the volume
 	Structure []VolumeStructure `yaml:"structure"`
+	// VolumeName is the name of the volume from the gadget.yaml
+	VolumeName string
 }
 
 // VolumeStructure describes a single structure inside a volume. A structure can
 // represent a partition, Master Boot Record, or any other contiguous range
 // within the volume.
 type VolumeStructure struct {
+	// VolumeName is the name of the volume that this structure belongs to.
+	VolumeName string
 	// Name, when non empty, provides the name of the structure
 	Name string `yaml:"name"`
 	// Label provides the filesystem label
@@ -339,6 +343,8 @@ func InfoFromGadgetYaml(gadgetYaml []byte, model Model) (*Info, error) {
 	var bootloadersFound int
 	knownFsLabelsPerVolume := make(map[string]map[string]bool, len(gi.Volumes))
 	for name, v := range gi.Volumes {
+		// set the VolumeName for the volume
+		v.VolumeName = name
 		if err := validateVolume(name, v, knownFsLabelsPerVolume); err != nil {
 			return nil, fmt.Errorf("invalid volume %q: %v", name, err)
 		}
@@ -393,6 +399,8 @@ func setImplicitForVolume(vol *Volume, model Model, knownFsLabels map[string]boo
 		vol.Schema = schemaGPT
 	}
 	for i := range vol.Structure {
+		// set the VolumeName for the structure from the volume itself
+		vol.Structure[i].VolumeName = vol.VolumeName
 		if err := setImplicitForVolumeStructure(&vol.Structure[i], rs, knownFsLabels); err != nil {
 			return err
 		}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -671,11 +671,13 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlValid(c *C) {
 		},
 		Volumes: map[string]*gadget.Volume{
 			"volumename": {
+				VolumeName: "volumename",
 				Schema:     "mbr",
 				Bootloader: "u-boot",
 				ID:         "0C",
 				Structure: []gadget.VolumeStructure{
 					{
+						VolumeName:  "volumename",
 						Label:       "system-boot",
 						Role:        "system-boot", // implicit
 						Offset:      asOffsetPtr(12345),
@@ -712,10 +714,12 @@ func (s *gadgetYamlTestSuite) TestReadMultiVolumeGadgetYamlValid(c *C) {
 	c.Assert(ginfo, DeepEquals, &gadget.Info{
 		Volumes: map[string]*gadget.Volume{
 			"frobinator-image": {
+				VolumeName: "frobinator-image",
 				Schema:     "mbr",
 				Bootloader: "u-boot",
 				Structure: []gadget.VolumeStructure{
 					{
+						VolumeName: "frobinator-image",
 						Name:       "system-boot",
 						Role:       "system-boot",
 						Label:      "system-boot",
@@ -730,6 +734,7 @@ func (s *gadgetYamlTestSuite) TestReadMultiVolumeGadgetYamlValid(c *C) {
 						},
 					},
 					{
+						VolumeName: "frobinator-image",
 						Role:       "system-data",
 						Name:       "writable",
 						Label:      "writable",
@@ -740,13 +745,15 @@ func (s *gadgetYamlTestSuite) TestReadMultiVolumeGadgetYamlValid(c *C) {
 				},
 			},
 			"u-boot-frobinator": {
-				Schema: "gpt",
+				VolumeName: "u-boot-frobinator",
+				Schema:     "gpt",
 				Structure: []gadget.VolumeStructure{
 					{
-						Name:   "u-boot",
-						Type:   "bare",
-						Size:   623000,
-						Offset: asOffsetPtr(0),
+						VolumeName: "u-boot-frobinator",
+						Name:       "u-boot",
+						Type:       "bare",
+						Size:       623000,
+						Offset:     asOffsetPtr(0),
 						Content: []gadget.VolumeContent{
 							{
 								Image: "u-boot.imz",
@@ -846,11 +853,13 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlVolumeUpdate(c *C) {
 	c.Assert(ginfo, DeepEquals, &gadget.Info{
 		Volumes: map[string]*gadget.Volume{
 			"bootloader": {
+				VolumeName: "bootloader",
 				Schema:     "mbr",
 				Bootloader: "u-boot",
 				ID:         "0C",
 				Structure: []gadget.VolumeStructure{
 					{
+						VolumeName:  "bootloader",
 						Label:       "system-boot",
 						Role:        "system-boot", // implicit
 						Offset:      asOffsetPtr(12345),
@@ -2169,6 +2178,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlFromSnapFileValid(c *C) {
 	c.Assert(ginfo, DeepEquals, &gadget.Info{
 		Volumes: map[string]*gadget.Volume{
 			"pc": {
+				VolumeName: "pc",
 				Bootloader: "grub",
 				Schema:     "gpt",
 			},

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -180,6 +180,7 @@ var mockOnDiskStructureWritable = gadget.OnDiskStructure{
 	Node: "/dev/node3",
 	LaidOutStructure: gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
+			VolumeName: "pc",
 			Name:       "Writable",
 			Size:       1258291200,
 			Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
@@ -198,6 +199,7 @@ var mockOnDiskStructureSave = gadget.OnDiskStructure{
 	Node: "/dev/node3",
 	LaidOutStructure: gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
+			VolumeName: "pc",
 			Name:       "Save",
 			Size:       128 * quantity.SizeMiB,
 			Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
@@ -215,6 +217,7 @@ var mockOnDiskStructureWritableAfterSave = gadget.OnDiskStructure{
 	Node: "/dev/node4",
 	LaidOutStructure: gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
+			VolumeName: "pc",
 			Name:       "Writable",
 			Size:       1200 * quantity.SizeMiB,
 			Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -791,6 +791,7 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 		Info: &gadget.Info{
 			Volumes: map[string]*gadget.Volume{
 				"pc": {
+					VolumeName: "pc",
 					Bootloader: "grub",
 					Schema:     "gpt",
 				},
@@ -826,6 +827,7 @@ volumes:
 		Info: &gadget.Info{
 			Volumes: map[string]*gadget.Volume{
 				"pc": {
+					VolumeName: "pc",
 					Bootloader: "grub",
 					Schema:     "gpt",
 					ID:         "123",

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1440,9 +1440,11 @@ volumes:
 			Info: &gadget.Info{
 				Volumes: map[string]*gadget.Volume{
 					"pc": {
+						VolumeName: "pc",
 						Bootloader: "grub",
 						Schema:     "gpt",
 						Structure: []gadget.VolumeStructure{{
+							VolumeName: "pc",
 							Name:       "foo",
 							Type:       "00000000-0000-0000-0000-0000deadcafe",
 							Size:       10 * quantity.SizeMiB,
@@ -1451,9 +1453,10 @@ volumes:
 								{UnresolvedSource: "foo-content", Target: "/"},
 							},
 						}, {
-							Name: "bare-one",
-							Type: "bare",
-							Size: quantity.SizeMiB,
+							VolumeName: "pc",
+							Name:       "bare-one",
+							Type:       "bare",
+							Size:       quantity.SizeMiB,
 							Content: []gadget.VolumeContent{
 								{Image: "bare.img"},
 							},
@@ -1467,9 +1470,11 @@ volumes:
 			Info: &gadget.Info{
 				Volumes: map[string]*gadget.Volume{
 					"pc": {
+						VolumeName: "pc",
 						Bootloader: "grub",
 						Schema:     "gpt",
 						Structure: []gadget.VolumeStructure{{
+							VolumeName: "pc",
 							Name:       "foo",
 							Type:       "00000000-0000-0000-0000-0000deadcafe",
 							Size:       10 * quantity.SizeMiB,
@@ -1478,9 +1483,10 @@ volumes:
 								{UnresolvedSource: "new-foo-content", Target: "/"},
 							},
 						}, {
-							Name: "bare-one",
-							Type: "bare",
-							Size: quantity.SizeMiB,
+							VolumeName: "pc",
+							Name:       "bare-one",
+							Type:       "bare",
+							Size:       quantity.SizeMiB,
 							Content: []gadget.VolumeContent{
 								{Image: "new-bare-content.img"},
 							},


### PR DESCRIPTION
This is useful when we have a VolumeStructure or LaidOutStructure or one of the
other derived types and we want a back-reference to know which volume this
structure came from.

Part of the multi-volume gadget asset update work.