### PR TITLE
tests: fix regex of TestSnapActionTimeout test

### DIFF
--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -3222,5 +3222,5 @@ func (s *storeActionSuite) TestSnapActionTimeout(c *C) {
 		},
 	}, nil, nil, nil)
 	close(quit)
-	c.Assert(err, ErrorMatches, `Post http://127.0.0.1:.*/v2/snaps/refresh: net/http: request canceled \(Client.Timeout exceeded while awaiting headers\)`)
+	c.Assert(err, ErrorMatches, `.*/v2/snaps/refresh"?: net/http: request canceled \(Client.Timeout exceeded while awaiting headers\).*`)
 }


### PR DESCRIPTION
PR #10785 was merged prematurely, there was a real unit test failure caused by small change in error message between the go version I've locally and the one we use, causing:

FAIL: store_action_test.go:3191: storeActionSuite.TestSnapActionTimeout

store_action_test.go:3225:
    c.Assert(err, ErrorMatches, `Post http://127.0.0.1:.*/v2/snaps/refresh: net/http: request canceled \(Client.Timeout exceeded while awaiting headers\)`)
... error string = "Post \"http://127.0.0.1:38331/v2/snaps/refresh\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)"
... regex string = "Post http://127.0.0.1:.*/v2/snaps/refresh: net/http: request canceled \\(Client.Timeout exceeded while awaiting headers\\)"

This PR fixes that