### PR TITLE
o/assertstate: check installed snaps when refreshing validation set assertions

### DIFF
--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -104,7 +104,7 @@ func listValidationSets(c *Command, r *http.Request, _ *auth.UserState) Response
 	}
 	sort.Strings(names)
 
-	snaps, err := installedSnaps(st)
+	snaps, err := assertstate.InstalledSnaps(st)
 	if err != nil {
 		return InternalError(err.Error())
 	}
@@ -140,25 +140,6 @@ func listValidationSets(c *Command, r *http.Request, _ *auth.UserState) Response
 
 var checkInstalledSnaps = func(vsets *snapasserts.ValidationSets, snaps []*snapasserts.InstalledSnap) error {
 	return vsets.CheckInstalledSnaps(snaps)
-}
-
-func installedSnaps(st *state.State) ([]*snapasserts.InstalledSnap, error) {
-	var snaps []*snapasserts.InstalledSnap
-	all, err := snapstate.All(st)
-	if err != nil {
-		return nil, err
-	}
-	for _, snapState := range all {
-		cur, err := snapState.CurrentInfo()
-		if err != nil {
-			return nil, err
-		}
-		snaps = append(snaps,
-			snapasserts.NewInstalledSnap(snapState.InstanceName(),
-				snapState.CurrentSideInfo().SnapID,
-				cur.Revision))
-	}
-	return snaps, nil
 }
 
 func getValidationSet(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -219,7 +200,7 @@ func getValidationSet(c *Command, r *http.Request, user *auth.UserState) Respons
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	snaps, err := installedSnaps(st)
+	snaps, err := assertstate.InstalledSnaps(st)
 	if err != nil {
 		return InternalError(err.Error())
 	}
@@ -380,7 +361,7 @@ func validateAgainstStore(st *state.State, accountID, name string, sequence int,
 	if err := sets.Add(vset); err != nil {
 		return InternalError(err.Error())
 	}
-	snaps, err := installedSnaps(st)
+	snaps, err := assertstate.InstalledSnaps(st)
 	if err != nil {
 		return InternalError(err.Error())
 	}

--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -104,7 +104,7 @@ func listValidationSets(c *Command, r *http.Request, _ *auth.UserState) Response
 	}
 	sort.Strings(names)
 
-	snaps, err := assertstate.InstalledSnaps(st)
+	snaps, err := snapstate.InstalledSnaps(st)
 	if err != nil {
 		return InternalError(err.Error())
 	}
@@ -200,7 +200,7 @@ func getValidationSet(c *Command, r *http.Request, user *auth.UserState) Respons
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	snaps, err := assertstate.InstalledSnaps(st)
+	snaps, err := snapstate.InstalledSnaps(st)
 	if err != nil {
 		return InternalError(err.Error())
 	}
@@ -361,7 +361,7 @@ func validateAgainstStore(st *state.State, accountID, name string, sequence int,
 	if err := sets.Add(vset); err != nil {
 		return InternalError(err.Error())
 	}
-	snaps, err := assertstate.InstalledSnaps(st)
+	snaps, err := snapstate.InstalledSnaps(st)
 	if err != nil {
 		return InternalError(err.Error())
 	}

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -453,7 +453,7 @@ func RefreshValidationSetAssertions(s *state.State, userID int, opts *RefreshAss
 			return err
 		}
 
-		snaps, err := InstalledSnaps(s)
+		snaps, err := snapstate.InstalledSnaps(s)
 		if err != nil {
 			return err
 		}

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -420,7 +420,7 @@ func RefreshValidationSetAssertions(s *state.State, userID int, opts *RefreshAss
 		return err
 	}
 
-	checkForConflicts := func(db *asserts.Database, bs asserts.Backstore) error {
+	checkConflictsAndPresence := func(db *asserts.Database, bs asserts.Backstore) error {
 		vsets := snapasserts.NewValidationSets()
 		tmpDb := db.WithStackedBackstore(bs)
 		for _, vs := range enforceModeSets {
@@ -449,12 +449,24 @@ func RefreshValidationSetAssertions(s *state.State, userID int, opts *RefreshAss
 				return fmt.Errorf("internal error: cannot check validation sets conflicts: %v", err)
 			}
 		}
-		return vsets.Conflict()
+		if err := vsets.Conflict(); err != nil {
+			return err
+		}
+
+		snaps, err := InstalledSnaps(s)
+		if err != nil {
+			return err
+		}
+		return vsets.CheckInstalledSnaps(snaps)
 	}
 
-	if err := bulkRefreshValidationSetAsserts(s, enforceModeSets, checkForConflicts, userID, deviceCtx, opts); err != nil {
+	if err := bulkRefreshValidationSetAsserts(s, enforceModeSets, checkConflictsAndPresence, userID, deviceCtx, opts); err != nil {
 		if _, ok := err.(*snapasserts.ValidationSetsConflictError); ok {
 			logger.Noticef("cannot refresh to conflicting validation set assertions: %v", err)
+			return nil
+		}
+		if _, ok := err.(*snapasserts.ValidationSetsValidationError); ok {
+			logger.Noticef("cannot refresh to validation set assertions that do not satisfy installed snaps: %v", err)
 			return nil
 		}
 		return err

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -457,7 +457,15 @@ func RefreshValidationSetAssertions(s *state.State, userID int, opts *RefreshAss
 		if err != nil {
 			return err
 		}
-		return vsets.CheckInstalledSnaps(snaps)
+		err = vsets.CheckInstalledSnaps(snaps)
+		if verr, ok := err.(*snapasserts.ValidationSetsValidationError); ok {
+			if len(verr.InvalidSnaps) > 0 || len(verr.MissingSnaps) > 0 {
+				return verr
+			}
+			// ignore wrong revisions
+			return nil
+		}
+		return err
 	}
 
 	if err := bulkRefreshValidationSetAsserts(s, enforceModeSets, checkConflictsAndPresence, userID, deviceCtx, opts); err != nil {

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -884,14 +884,14 @@ func (s *assertMgrSuite) TestValidateSnapCrossCheckFail(c *C) {
 	c.Assert(chg.Err(), ErrorMatches, `(?s).*cannot install "f", snap "f" is undergoing a rename to "foo".*`)
 }
 
-func (s *assertMgrSuite) validationSetAssert(c *C, name, sequence, revision string, snapPresence string) *asserts.ValidationSet {
+func (s *assertMgrSuite) validationSetAssert(c *C, name, sequence, revision string, snapPresence, requiredRevision string) *asserts.ValidationSet {
 	snaps := []interface{}{map[string]interface{}{
 		"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 		"name":     "foo",
 		"presence": snapPresence,
 	}}
-	if snapPresence != "invalid" {
-		snaps[0].(map[string]interface{})["revision"] = "1"
+	if requiredRevision != "" {
+		snaps[0].(map[string]interface{})["revision"] = requiredRevision
 	}
 	headers := map[string]interface{}{
 		"series":       "16",
@@ -963,7 +963,7 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 	c.Assert(assertstate.Add(s.state, snapDeclFoo), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 	tr := assertstate.ValidationSetTracking{
 		AccountID: s.dev1Acct.AccountID(),
@@ -988,7 +988,7 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 	c.Assert(err, IsNil)
 
 	// changed validation set assertion
-	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	err = assertstate.RefreshSnapAssertions(s.state, 0)
@@ -2238,10 +2238,10 @@ func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefresh(c *C) {
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
-	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	tr := assertstate.ValidationSetTracking{
@@ -2296,7 +2296,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsStoreError(c *C) {
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
 	tr := assertstate.ValidationSetTracking{
@@ -2325,10 +2325,10 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
-	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required", "1")
 	err = s.storeSigning.Add(vsetAs2)
 	c.Assert(err, IsNil)
 
@@ -2359,7 +2359,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, true)
 
 	// sequence changed in the store to 4
-	vsetAs3 := s.validationSetAssert(c, "bar", "4", "3", "required")
+	vsetAs3 := s.validationSetAssert(c, "bar", "4", "3", "required", "1")
 	err = s.storeSigning.Add(vsetAs3)
 	c.Assert(err, IsNil)
 
@@ -2411,10 +2411,10 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsPinned(c *C) {
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "2", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "2", "1", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
-	vsetAs2 := s.validationSetAssert(c, "bar", "2", "5", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "5", "required", "1")
 	err = s.storeSigning.Add(vsetAs2)
 	c.Assert(err, IsNil)
 
@@ -2446,7 +2446,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsPinned(c *C) {
 	})
 
 	// sequence changed in the store to 7
-	vsetAs3 := s.validationSetAssert(c, "bar", "7", "8", "required")
+	vsetAs3 := s.validationSetAssert(c, "bar", "7", "8", "required", "1")
 	err = s.storeSigning.Add(vsetAs3)
 	c.Assert(err, IsNil)
 
@@ -2488,13 +2488,13 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsLocalOnlyFailed(c *C)
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
-	vsetAs2 := s.validationSetAssert(c, "baz", "3", "1", "required")
+	vsetAs2 := s.validationSetAssert(c, "baz", "3", "1", "required", "1")
 	c.Assert(assertstate.Add(st, vsetAs2), IsNil)
 
 	// vset2 present and updated in the store
-	vsetAs2_2 := s.validationSetAssert(c, "baz", "3", "2", "required")
+	vsetAs2_2 := s.validationSetAssert(c, "baz", "3", "2", "required", "1")
 	err = s.storeSigning.Add(vsetAs2_2)
 	c.Assert(err, IsNil)
 
@@ -2569,17 +2569,17 @@ version: 1`), &snap.SideInfo{
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "foo", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "foo", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
-	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs2), IsNil)
 
 	// in the store
-	vsetAs3 := s.validationSetAssert(c, "foo", "1", "2", "required")
+	vsetAs3 := s.validationSetAssert(c, "foo", "1", "2", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs3), IsNil)
 
-	vsetAs4 := s.validationSetAssert(c, "bar", "2", "3", "required")
+	vsetAs4 := s.validationSetAssert(c, "bar", "2", "3", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs4), IsNil)
 
 	tr := assertstate.ValidationSetTracking{
@@ -2652,13 +2652,13 @@ version: 1`), &snap.SideInfo{Revision: snap.R("1")})
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "2", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "2", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
 	// in the store
 	c.Assert(s.storeSigning.Add(vsetAs1), IsNil)
 
-	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	tr := assertstate.ValidationSetTracking{
@@ -2709,14 +2709,14 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeConflict
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "foo", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "foo", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
-	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs2), IsNil)
 
 	// in the store
-	vsetAs3 := s.validationSetAssert(c, "foo", "2", "2", "invalid")
+	vsetAs3 := s.validationSetAssert(c, "foo", "2", "2", "invalid", "")
 	c.Assert(s.storeSigning.Add(vsetAs3), IsNil)
 
 	tr := assertstate.ValidationSetTracking{
@@ -2782,11 +2782,12 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeMissingS
 	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
 	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
 
-	vsetAs1 := s.validationSetAssert(c, "foo", "1", "1", "optional")
+	// currently tracked, but snap is not installed (it's optional)
+	vsetAs1 := s.validationSetAssert(c, "foo", "1", "1", "optional", "1")
 	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
 
-	// in the store
-	vsetAs3 := s.validationSetAssert(c, "foo", "2", "2", "required")
+	// in the store, snap is now required
+	vsetAs3 := s.validationSetAssert(c, "foo", "2", "2", "required", "")
 	c.Assert(s.storeSigning.Add(vsetAs3), IsNil)
 
 	tr := assertstate.ValidationSetTracking{
@@ -2828,6 +2829,64 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeMissingS
 	c.Check(tr.Current, Equals, 1)
 }
 
+func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeWrongSnapRevisionOK(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err := s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	// store key already present
+	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+
+	snapstate.Set(s.state, "foo", &snapstate.SnapState{
+		Active: false,
+		Sequence: []*snap.SideInfo{
+			{RealName: "foo", Revision: snap.R(1)},
+		},
+		Current: snap.R(1),
+	})
+
+	// snap revision 1 is installed
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
+	c.Assert(assertstate.Add(s.state, vsetAs1), IsNil)
+
+	// in the store, revision 2 required
+	vsetAs3 := s.validationSetAssert(c, "bar", "2", "2", "required", "2")
+	c.Assert(s.storeSigning.Add(vsetAs3), IsNil)
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	c.Assert(assertstate.RefreshValidationSetAssertions(s.state, 0, nil), IsNil)
+
+	// new assertion has been committed to the database.
+	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "2",
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
+		{"account", "account-key", "validation-set"},
+	})
+
+	// tracking current has been updated
+	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
+	c.Check(tr.Current, Equals, 2)
+}
+
 func (s *assertMgrSuite) TestValidationSetAssertionForMonitorLocalFallbackForPinned(c *C) {
 	st := s.state
 
@@ -2842,7 +2901,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorLocalFallbackForPin
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
-	vsetAs := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(st, vsetAs), IsNil)
 
 	opts := assertstate.ResolveOptions{AllowLocalFallback: true}
@@ -2866,11 +2925,11 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorPinnedRefreshedFrom
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
 
 	// newer revision available in the store
-	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "1", "2", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 1, true, 0, nil)
@@ -2894,11 +2953,11 @@ func (s *assertMgrSuite) TestValidationSetAssertionForMonitorUnpinnedRefreshedFr
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add to local database
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
 
 	// newer assertion available in the store
-	vsetAs2 := s.validationSetAssert(c, "bar", "3", "1", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "3", "1", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	vs, local, err := assertstate.ValidationSetAssertionForMonitor(st, s.dev1Acct.AccountID(), "bar", 0, false, 0, nil)
@@ -2938,7 +2997,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedHappy(c *C
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add sequence to the store
-	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required")
+	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
@@ -2976,7 +3035,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforcePinnedHappy(c *C) {
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add sequence to the store
-	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required")
+	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
@@ -3014,7 +3073,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyMis
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add sequence to the store
-	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required")
+	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{}
@@ -3051,7 +3110,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyCon
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add an assertion to local database
-	vsetAs := s.validationSetAssert(c, "boo", "4", "4", "invalid")
+	vsetAs := s.validationSetAssert(c, "boo", "4", "4", "invalid", "")
 	c.Assert(assertstate.Add(st, vsetAs), IsNil)
 	// and to the store (for refresh to be happy)
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
@@ -3066,7 +3125,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyCon
 	assertstate.UpdateValidationSet(st, &tr)
 
 	// add sequence to the store, it conflicts with boo
-	vsetAs2 := s.validationSetAssert(c, "bar", "2", "2", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "2", "2", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{}
@@ -3099,11 +3158,11 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedAfterForge
 
 	// add an old assertion to local database; it's not tracked which is the
 	// case after 'snap validate --forget' (we don't prune assertions from db).
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
 
 	// newer sequence available in the store
-	vsetAs2 := s.validationSetAssert(c, "bar", "3", "5", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "3", "5", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
@@ -3141,7 +3200,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedAfterMonit
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// add and old assertion to local database
-	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required")
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
 	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
 
 	// and pretend it was tracked already in monitor mode
@@ -3154,7 +3213,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedAfterMonit
 	assertstate.UpdateValidationSet(st, &tr)
 
 	// newer sequence available in the store
-	vsetAs2 := s.validationSetAssert(c, "bar", "3", "5", "required")
+	vsetAs2 := s.validationSetAssert(c, "bar", "3", "5", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -3255,28 +3255,3 @@ func (s *assertMgrSuite) TestTemporaryDB(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(fromDB.(*asserts.Model), DeepEquals, model)
 }
-
-func (s *assertMgrSuite) TestInstalledSnaps(c *C) {
-	st := s.state
-	st.Lock()
-	defer st.Unlock()
-
-	snaps, err := assertstate.InstalledSnaps(st)
-	c.Assert(err, IsNil)
-	c.Check(snaps, HasLen, 0)
-
-	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "foo", Revision: snap.R(23), SnapID: "foo-id"}},
-		Current:  snap.R(23),
-	})
-	snaptest.MockSnap(c, string(`name: foo
-version: 1`), &snap.SideInfo{Revision: snap.R("13")})
-
-	snaps, err = assertstate.InstalledSnaps(st)
-	c.Assert(err, IsNil)
-	c.Check(snaps, HasLen, 1)
-	c.Check(snaps[0].SnapName(), Equals, "foo")
-	c.Check(snaps[0].ID(), Equals, "foo-id")
-	c.Check(snaps[0].Revision, Equals, snap.R("23"))
-}

--- a/overlord/assertstate/bulk.go
+++ b/overlord/assertstate/bulk.go
@@ -183,6 +183,9 @@ func bulkRefreshValidationSetAsserts(s *state.State, vsets map[string]*Validatio
 	if _, ok := err.(*snapasserts.ValidationSetsConflictError); ok {
 		return err
 	}
+	if _, ok := err.(*snapasserts.ValidationSetsValidationError); ok {
+		return err
+	}
 
 	if rerr, ok := err.(*resolvePoolError); ok {
 		// ignore resolving errors for validation sets that are local only (no

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -21,6 +21,7 @@ package assertstate
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -79,4 +80,25 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 	// (but try to save as much possible still),
 	// or err is a check error
 	return b.CommitTo(db, nil)
+}
+
+// InstalledSnaps returns the list of all installed snaps suitable for
+// ValidationSets checks.
+func InstalledSnaps(st *state.State) ([]*snapasserts.InstalledSnap, error) {
+	var snaps []*snapasserts.InstalledSnap
+	all, err := snapstate.All(st)
+	if err != nil {
+		return nil, err
+	}
+	for _, snapState := range all {
+		cur, err := snapState.CurrentInfo()
+		if err != nil {
+			return nil, err
+		}
+		snaps = append(snaps,
+			snapasserts.NewInstalledSnap(snapState.InstanceName(),
+				snapState.CurrentSideInfo().SnapID,
+				cur.Revision))
+	}
+	return snaps, nil
 }

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -21,7 +21,6 @@ package assertstate
 
 import (
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -80,25 +79,4 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 	// (but try to save as much possible still),
 	// or err is a check error
 	return b.CommitTo(db, nil)
-}
-
-// InstalledSnaps returns the list of all installed snaps suitable for
-// ValidationSets checks.
-func InstalledSnaps(st *state.State) ([]*snapasserts.InstalledSnap, error) {
-	var snaps []*snapasserts.InstalledSnap
-	all, err := snapstate.All(st)
-	if err != nil {
-		return nil, err
-	}
-	for _, snapState := range all {
-		cur, err := snapState.CurrentInfo()
-		if err != nil {
-			return nil, err
-		}
-		snaps = append(snaps,
-			snapasserts.NewInstalledSnap(snapState.InstanceName(),
-				snapState.CurrentSideInfo().SnapID,
-				cur.Revision))
-	}
-	return snaps, nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2869,6 +2869,27 @@ func All(st *state.State) (map[string]*SnapState, error) {
 	return curStates, nil
 }
 
+// InstalledSnaps returns the list of all installed snaps suitable for
+// ValidationSets checks.
+func InstalledSnaps(st *state.State) ([]*snapasserts.InstalledSnap, error) {
+	var snaps []*snapasserts.InstalledSnap
+	all, err := All(st)
+	if err != nil {
+		return nil, err
+	}
+	for _, snapState := range all {
+		cur, err := snapState.CurrentInfo()
+		if err != nil {
+			return nil, err
+		}
+		snaps = append(snaps,
+			snapasserts.NewInstalledSnap(snapState.InstanceName(),
+				snapState.CurrentSideInfo().SnapID,
+				cur.Revision))
+	}
+	return snaps, nil
+}
+
 // NumSnaps returns the number of installed snaps.
 func NumSnaps(st *state.State) (int, error) {
 	var snaps map[string]*json.RawMessage


### PR DESCRIPTION
Check installed snaps when refreshing validation set assertions (not just if the assertions conflict), otherwise we may end up in a situation where installed snaps do not meet the requirements of updated assertions.

This also moves InstalledSnaps helper to snapstate.