### PR TITLE
github: do not fail when codecov upload fails

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -203,6 +203,9 @@ jobs:
         SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
+      # uploading to codecov occasionally fails, so continue running the test
+      # workflow regardless of the upload
+      continue-on-error: true
       if: steps.cached-results.outputs.already-ran != 'true'
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
Uploading coverage to codecov fails on occasion. It is not really useful to
block the whole test run because of this.
