### PR TITLE
tests/main/preseed: update for new base snap of the lxd snap

### DIFF
--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -102,7 +102,7 @@ execute: |
   # preseeding artifacts.
   MATCH "Type=squashfs$" < "$IMAGE_MOUNTPOINT"/etc/systemd/system/snap-lxd-*.mount
   MATCH "Type=squashfs$" < "$IMAGE_MOUNTPOINT"/etc/systemd/system/snap-snapd-*.mount
-  MATCH "Type=squashfs$" < "$IMAGE_MOUNTPOINT"/etc/systemd/system/snap-core18-*.mount
+  MATCH "Type=squashfs$" < "$IMAGE_MOUNTPOINT"/etc/systemd/system/snap-core20-*.mount
 
   snap debug state "$IMAGE_MOUNTPOINT"/var/lib/snapd/state.json --change=1 > tasks.log
 
@@ -141,6 +141,6 @@ execute: |
 
   echo "Sanity check that mount overrides were generated inside the container"
   lxc exec my-ubuntu-preseeded -- find /var/run/systemd/generator/ -name container.conf > overrides.log
-  MATCH "/var/run/systemd/generator/snap-core18.*mount.d/container.conf" < overrides.log
+  MATCH "/var/run/systemd/generator/snap-core20.*mount.d/container.conf" < overrides.log
   MATCH "/var/run/systemd/generator/snap-snapd-.*mount.d/container.conf" < overrides.log
   MATCH "/var/run/systemd/generator/snap-lxd-.*mount.d/container.conf" < overrides.log

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -9,6 +9,7 @@ systems: [ubuntu-2*]
 
 environment:
   IMAGE_MOUNTPOINT: /mnt/cloudimg
+  LXD_BASE_SNAP: core20
 
 prepare: |
   # the get_image_url_for_nested_vm is a convenient helper that returns
@@ -36,12 +37,6 @@ restore: |
   umount_ubuntu_image "$IMAGE_MOUNTPOINT" || true
 
 execute: |
-  if os.query is-focal; then
-      core_snap=core18
-  else
-      core_snap=core20
-  fi
-
   echo "Checking missing chroot path arg error"
   /usr/lib/snapd/snap-preseed 2>&1 | MATCH "error: need chroot path as argument"
 
@@ -68,15 +63,15 @@ execute: |
   MATCH "Done .+ set-auto-aliases +Set automatic aliases for snap \"snapd\"" < tasks.log
   MATCH "Done .+ setup-aliases +Setup snap \"snapd\" aliases" < tasks.log
 
-  MATCH "Done .+ prerequisites +Ensure prerequisites for \"$core_snap\" are available" < tasks.log
-  MATCH "Done .+ prepare-snap +Prepare snap \"/var/lib/snapd/seed/snaps/${core_snap}_[0-9]+.snap" < tasks.log
-  MATCH "Done .+ mount-snap +Mount snap \"$core_snap\" \([0-9]+\)" < tasks.log
-  MATCH "Done .+ copy-snap-data +Copy snap \"$core_snap\" data" < tasks.log
-  MATCH "Done .+ setup-profiles +Setup snap \"$core_snap\" \([0-9]+\) security profiles" < tasks.log
-  MATCH "Done .+ link-snap +Make snap \"$core_snap\" \([0-9]+\) available to the system" < tasks.log
-  MATCH "Done .+ auto-connect +Automatically connect eligible plugs and slots of snap \"$core_snap\"" < tasks.log
-  MATCH "Done .+ set-auto-aliases +Set automatic aliases for snap \"$core_snap\"" < tasks.log
-  MATCH "Done .+ setup-aliases +Setup snap \"$core_snap\" aliases" < tasks.log
+  MATCH "Done .+ prerequisites +Ensure prerequisites for \"${LXD_BASE_SNAP}\" are available" < tasks.log
+  MATCH "Done .+ prepare-snap +Prepare snap \"/var/lib/snapd/seed/snaps/${LXD_BASE_SNAP}_[0-9]+.snap" < tasks.log
+  MATCH "Done .+ mount-snap +Mount snap \"${LXD_BASE_SNAP}\" \([0-9]+\)" < tasks.log
+  MATCH "Done .+ copy-snap-data +Copy snap \"${LXD_BASE_SNAP}\" data" < tasks.log
+  MATCH "Done .+ setup-profiles +Setup snap \"${LXD_BASE_SNAP}\" \([0-9]+\) security profiles" < tasks.log
+  MATCH "Done .+ link-snap +Make snap \"${LXD_BASE_SNAP}\" \([0-9]+\) available to the system" < tasks.log
+  MATCH "Done .+ auto-connect +Automatically connect eligible plugs and slots of snap \"${LXD_BASE_SNAP}\"" < tasks.log
+  MATCH "Done .+ set-auto-aliases +Set automatic aliases for snap \"${LXD_BASE_SNAP}\"" < tasks.log
+  MATCH "Done .+ setup-aliases +Setup snap \"${LXD_BASE_SNAP}\" aliases" < tasks.log
 
   MATCH "Done .+ prerequisites +Ensure prerequisites for \"lxd\" are available" < tasks.log
   MATCH "Done .+ prepare-snap +Prepare snap \"/var/lib/snapd/seed/snaps/lxd_[0-9]+.snap\" \([0-9]+\)" < tasks.log
@@ -97,7 +92,7 @@ execute: |
   [ "$(grep -c ' Done ' tasks.log)" = "32" ]
 
   # everything below is pending execution on first boot
-  MATCH "Do .+ run-hook +Run install hook of \"$core_snap\" snap if present" < tasks.log
+  MATCH "Do .+ run-hook +Run install hook of \"${LXD_BASE_SNAP}\" snap if present" < tasks.log
   MATCH "Do .+ start-snap-services +Start snap \"lxd\" \([0-9]+\) services" < tasks.log
   MATCH "Do .+ run-hook +Run configure hook of \"lxd\" snap if present" < tasks.log
   MATCH "Do .+ run-hook +Run health check of \"lxd\" snap" < tasks.log
@@ -105,8 +100,8 @@ execute: |
   MATCH "Do .+ run-hook +Run install hook of \"snapd\" snap if present" < tasks.log
   MATCH "Do .+ start-snap-services +Start snap \"snapd\" \(unset\) services" < tasks.log
   MATCH "Do .+ run-hook +Run configure hook of \"core\" snap if present" < tasks.log
-  MATCH "Do .+ start-snap-services  +Start snap \"$core_snap\" \([0-9]+\) services" < tasks.log
-  MATCH "Do .+ run-hook +Run health check of \"$core_snap\" snap" < tasks.log
+  MATCH "Do .+ start-snap-services  +Start snap \"${LXD_BASE_SNAP}\" \([0-9]+\) services" < tasks.log
+  MATCH "Do .+ run-hook +Run health check of \"${LXD_BASE_SNAP}\" snap" < tasks.log
   MATCH "Do .+ run-hook +Run install hook of \"lxd\" snap if present" < tasks.log
 
   echo "Checking that apparmor and seccomp profiles have been created on the target image"
@@ -127,8 +122,8 @@ execute: |
   test -f "$SYSTEMD_UNITS"/system/snap-lxd-*.mount
   test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-lxd-*.mount
   test -f "$SYSTEMD_UNITS"/system/snap-snapd-*.mount
-  test -f "$SYSTEMD_UNITS"/system/snap-"$core_snap"-*.mount
-  test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-"$core_snap"-*.mount
+  test -f "$SYSTEMD_UNITS"/system/snap-"${LXD_BASE_SNAP}"-*.mount
+  test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-"${LXD_BASE_SNAP}"-*.mount
   test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-snapd-*.mount
 
   for unit in snap.lxd.daemon.service snap.lxd.daemon.unix.socket snap.lxd.activate.service; do


### PR DESCRIPTION
The lxd snap now uses the core20 base snap, so we need to check for that
everywhere.

See the following output from a failing task:

```
Check that the tasks of preseeded snapd have expected statuses
+ MATCH 'Doing .+ mark-preseeded +Mark system pre-seeded'
+ MATCH 'Done .+ prerequisites +Ensure prerequisites for "snapd" are available'
+ MATCH 'Done .+ prepare-snap +Prepare snap "/var/lib/snapd/seed/snaps/snapd.snap'
+ MATCH 'Done .+ mount-snap +Mount snap "snapd" \(unset\)'
+ MATCH 'Done .+ copy-snap-data +Copy snap "snapd" data'
+ MATCH 'Done .+ setup-profiles +Setup snap "snapd" \(unset\) security profiles'
+ MATCH 'Done .+ link-snap +Make snap "snapd" \(unset\) available to the system'
+ MATCH 'Done .+ auto-connect +Automatically connect eligible plugs and slots of snap "snapd"'
+ MATCH 'Done .+ set-auto-aliases +Set automatic aliases for snap "snapd"'
+ MATCH 'Done .+ setup-aliases +Setup snap "snapd" aliases'
+ MATCH 'Done .+ prerequisites +Ensure prerequisites for "core18" are available'
grep error: pattern not found, got:
Lanes  ID   Status  Spawn               Ready               Kind                 Summary
0      3    Done    today at 16:53 UTC  today at 16:53 UTC  prerequisites        Ensure prerequisites for "snapd" are available
0      4    Done    today at 16:53 UTC  today at 16:53 UTC  prepare-snap         Prepare snap "/var/lib/snapd/seed/snaps/snapd.snap" (unset)
0      5    Done    today at 16:53 UTC  today at 16:53 UTC  mount-snap           Mount snap "snapd" (unset)
0      6    Done    today at 16:53 UTC  today at 16:53 UTC  copy-snap-data       Copy snap "snapd" data
0      7    Done    today at 16:53 UTC  today at 16:53 UTC  setup-profiles       Setup snap "snapd" (unset) security profiles
0      8    Done    today at 16:53 UTC  today at 16:53 UTC  link-snap            Make snap "snapd" (unset) available to the system
0      9    Done    today at 16:53 UTC  today at 16:53 UTC  auto-connect         Automatically connect eligible plugs and slots of snap "snapd"
0      10   Done    today at 16:53 UTC  today at 16:53 UTC  set-auto-aliases     Set automatic aliases for snap "snapd"
0      11   Done    today at 16:53 UTC  today at 16:53 UTC  setup-aliases        Setup snap "snapd" aliases
0      14   Done    today at 16:53 UTC  today at 16:53 UTC  prerequisites        Ensure prerequisites for "core20" are available
```