### PR TITLE
data/selinux: update the policy to allow s-c to manipulate BPF map and programs

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -577,6 +577,15 @@ allow snappy_confine_t snappy_snap_t:process transition;
 
 allow snappy_confine_t self:process { setexec };
 allow snappy_confine_t self:capability { setgid setuid sys_admin sys_chroot dac_read_search dac_override };
+# when managing cgroup v2 snap-confines creates BPF map and attaches a BPF
+# device cgroup program, however those bits can only be built on a sufficiently
+# recent system
+ifndef(`no_bpf',`
+  allow snappy_confine_t self:bpf { map_create map_read map_write prog_load prog_run };
+  # snap-confine creates /sys/fs/bpf/snap directory and pings BPF maps inside
+  fs_manage_bpf_dirs(snappy_confine_t)
+  fs_manage_bpf_files(snappy_confine_t)
+')
 
 init_read_state(snappy_confine_t)
 
@@ -589,6 +598,8 @@ kernel_read_system_state(snappy_confine_t)
 fs_getattr_all_fs(snappy_confine_t)
 dev_getattr_fs(snappy_confine_t)
 dev_getattr_sysfs_fs(snappy_confine_t)
+dev_list_sysfs(snappy_confine_t)
+dev_read_sysfs(snappy_confine_t)
 fs_getattr_cgroup(snappy_confine_t)
 fs_getattr_hugetlbfs(snappy_confine_t)
 fs_getattr_tmpfs(snappy_confine_t)

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -577,7 +577,7 @@ allow snappy_confine_t snappy_snap_t:process transition;
 
 allow snappy_confine_t self:process { setexec };
 allow snappy_confine_t self:capability { setgid setuid sys_admin sys_chroot dac_read_search dac_override };
-# when managing cgroup v2 snap-confines creates BPF map and attaches a BPF
+# when managing cgroup v2 snap-confine creates a BPF map and attaches a BPF
 # device cgroup program, however those bits can only be built on a sufficiently
 # recent system
 ifndef(`no_bpf',`

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -573,6 +573,10 @@ sed -e "s/-Bstatic -lseccomp/-Bstatic/g" -i cmd/snap-seccomp/*.go
 %if 0%{?rhel} == 7
     M4PARAM='-D distro_rhel7'
 %endif
+%if 0%{?rhel} == 7 || 0%{?rhel} == 8
+    # RHEL7 and RHEL8 are missing the BPF interfaces from their reference policy
+    M4PARAM="$M4PARAM -D no_bpf"
+%endif
     # Build SELinux module
     cd ./data/selinux
     # pass M4PARAM in env instead of as an override, so that make can still


### PR DESCRIPTION
Update the SELinux policy. The bpffs is mounted at /sys/fs/bpf, so we need permissions to list/read /sys. On top of this, there's separate permissions to manipulate files in bpffs, and bpf related capabilities.
