### PR TITLE
overlord/devicestate: make settle wait longer in remodel tests

### DIFF
--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -2435,7 +2435,7 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 	}
 	s.state.Unlock()
 
-	s.longSettle(c)
+	s.settle(c)
 
 	s.state.Lock()
 	// set model was injected by prepare-remodeling

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -2435,7 +2435,7 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 	}
 	s.state.Unlock()
 
-	s.settle(c)
+	s.longSettle(c)
 
 	s.state.Lock()
 	// set model was injected by prepare-remodeling

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -67,7 +67,7 @@ import (
 )
 
 var (
-	settleTimeout = testutil.HostScaledTimeout(15 * time.Second)
+	settleTimeout = testutil.HostScaledTimeout(30 * time.Second)
 )
 
 func TestDeviceManager(t *testing.T) { TestingT(t) }
@@ -245,11 +245,6 @@ func (s *deviceMgrBaseSuite) newStore(devBE storecontext.DeviceBackend) snapstat
 
 func (s *deviceMgrBaseSuite) settle(c *C) {
 	err := s.o.Settle(settleTimeout)
-	c.Assert(err, IsNil)
-}
-
-func (s *deviceMgrBaseSuite) longSettle(c *C) {
-	err := s.o.Settle(settleTimeout * 2)
 	c.Assert(err, IsNil)
 }
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -248,6 +248,11 @@ func (s *deviceMgrBaseSuite) settle(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *deviceMgrBaseSuite) longSettle(c *C) {
+	err := s.o.Settle(settleTimeout * 2)
+	c.Assert(err, IsNil)
+}
+
 // seeding avoids triggering a real full seeding, it simulates having it in process instead
 func (s *deviceMgrBaseSuite) seeding() {
 	chg := s.state.NewChange("seed", "Seed system")


### PR DESCRIPTION
We occasionally see the TestUC20RemodelSetModelWithReboot fail when running the
test suite runs on Launchpad builder on armhf or s390, but not really on other
architectures. Use a longer timeout as the test seems to be working in general,
but it is suspected that the build host/vm is so slow that settle does not
converge in time.

