### PR TITLE
.github/workflows/test.yaml: bump action-build to 1.0.9

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
           fi
     - name: Build snapd snap
       if: steps.cached-results.outputs.already-ran != 'true'
-      uses: snapcore/action-build@v1
+      uses: snapcore/action-build@v1.0.9
       with:
         snapcraft-channel: 4.x/candidate
     - name: Cache built artifact


### PR DESCRIPTION
This is necessary to avoid the failure to refresh LXD - the images already have
LXD and so can build the snap, they just can't refresh LXD due to store
outages sometimes, so this new version helps with that when it happens and
keeps out CI moving along to the extent that it can.