### PR TITLE
o/assertstate, api: update validation set assertions only when updating all snaps

### DIFF
--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -478,7 +478,7 @@ func (s *snapsSuite) TestPostSnapsOpMoreComplexContentType(c *check.C) {
 }
 
 func (s *snapsSuite) testPostSnapsOp(c *check.C, contentType string) {
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(*state.State, int) error { return nil })()
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(*state.State, int, *assertstate.RefreshAssertionsOptions) error { return nil })()
 	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
 		c.Check(names, check.HasLen, 0)
 		t := s.NewTask("fake-refresh-all", "Refreshing everything")
@@ -519,9 +519,11 @@ func (s *snapsSuite) TestPostSnapsOpInvalidCharset(c *check.C) {
 
 func (s *snapsSuite) TestRefreshAll(c *check.C) {
 	refreshSnapAssertions := false
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	var refreshAssertionsOpts *assertstate.RefreshAssertionsOptions
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		refreshSnapAssertions = true
-		return assertstate.RefreshSnapAssertions(s, userID)
+		refreshAssertionsOpts = opts
+		return assertstate.RefreshSnapAssertions(s, userID, opts)
 	})()
 
 	d := s.daemon(c)
@@ -535,6 +537,7 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 		{[]string{"fake1", "fake2"}, `Refresh snaps "fake1", "fake2"`},
 	} {
 		refreshSnapAssertions = false
+		refreshAssertionsOpts = nil
 
 		defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
 			c.Check(names, check.HasLen, 0)
@@ -550,14 +553,16 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Check(res.Summary, check.Equals, tst.msg)
 		c.Check(refreshSnapAssertions, check.Equals, true)
+		c.Assert(refreshAssertionsOpts, check.NotNil)
+		c.Check(refreshAssertionsOpts.IsRefreshOfAllSnaps, check.Equals, true)
 	}
 }
 
 func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 	refreshSnapAssertions := false
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		refreshSnapAssertions = true
-		return assertstate.RefreshSnapAssertions(s, userID)
+		return assertstate.RefreshSnapAssertions(s, userID, opts)
 	})()
 
 	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
@@ -578,8 +583,10 @@ func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 
 func (s *snapsSuite) TestRefreshMany(c *check.C) {
 	refreshSnapAssertions := false
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	var refreshAssertionsOpts *assertstate.RefreshAssertionsOptions
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		refreshSnapAssertions = true
+		refreshAssertionsOpts = opts
 		return nil
 	})()
 
@@ -599,11 +606,13 @@ func (s *snapsSuite) TestRefreshMany(c *check.C) {
 	c.Check(res.Summary, check.Equals, `Refresh snaps "foo", "bar"`)
 	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
 	c.Check(refreshSnapAssertions, check.Equals, true)
+	c.Assert(refreshAssertionsOpts, check.NotNil)
+	c.Check(refreshAssertionsOpts.IsRefreshOfAllSnaps, check.Equals, false)
 }
 
 func (s *snapsSuite) TestRefreshMany1(c *check.C) {
 	refreshSnapAssertions := false
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		refreshSnapAssertions = true
 		return nil
 	})()
@@ -1434,7 +1443,7 @@ func (s *snapsSuite) TestInstallIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-install-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1600,7 +1609,7 @@ func (s *snapsSuite) TestRefresh(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		assertstateCalledUserID = userID
 		return nil
 	})()
@@ -1639,7 +1648,7 @@ func (s *snapsSuite) TestRefreshDevMode(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1673,7 +1682,7 @@ func (s *snapsSuite) TestRefreshClassic(c *check.C) {
 		calledFlags = flags
 		return nil, nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1707,7 +1716,7 @@ func (s *snapsSuite) TestRefreshIgnoreValidation(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1746,7 +1755,7 @@ func (s *snapsSuite) TestRefreshIgnoreRunning(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1781,7 +1790,7 @@ func (s *snapsSuite) TestRefreshCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 
@@ -1811,7 +1820,7 @@ func (s *snapsSuite) TestRefreshLeaveCohort(c *check.C) {
 		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
-	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int) error {
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		return nil
 	})()
 

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -105,7 +106,7 @@ func MockUnsafeReadSnapInfo(mock func(string) (*snap.Info, error)) (restore func
 	}
 }
 
-func MockAssertstateRefreshSnapAssertions(mock func(*state.State, int) error) (restore func()) {
+func MockAssertstateRefreshSnapAssertions(mock func(*state.State, int, *assertstate.RefreshAssertionsOptions) error) (restore func()) {
 	oldAssertstateRefreshSnapAssertions := assertstateRefreshSnapAssertions
 	assertstateRefreshSnapAssertions = mock
 	return func() {

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -57,6 +57,10 @@ func findError(format string, ref *asserts.Ref, err error) error {
 
 type RefreshAssertionsOptions struct {
 	IsAutoRefresh bool
+	// IsRefreshOfAllSnaps indicates if assertions are refreshed together with
+	// all installed snaps, which means validation set assertions can be refreshed
+	// as well. It is implied if IsAutoRefresh is true.
+	IsRefreshOfAllSnaps bool
 }
 
 // RefreshSnapDeclarations refetches all the current snap declarations and their prerequisites.
@@ -352,10 +356,16 @@ func AutoRefreshAssertions(s *state.State, userID int) error {
 }
 
 // RefreshSnapAssertions tries to refresh all snap-centered assertions
-func RefreshSnapAssertions(s *state.State, userID int) error {
-	opts := &RefreshAssertionsOptions{IsAutoRefresh: false}
+func RefreshSnapAssertions(s *state.State, userID int, opts *RefreshAssertionsOptions) error {
+	if opts == nil {
+		opts = &RefreshAssertionsOptions{}
+	}
+	opts.IsAutoRefresh = false
 	if err := RefreshSnapDeclarations(s, userID, opts); err != nil {
 		return err
+	}
+	if !opts.IsRefreshOfAllSnaps {
+		return nil
 	}
 	return RefreshValidationSetAssertions(s, userID, opts)
 }

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -1014,7 +1014,7 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
 
 	// changed validation set assertion again
-	vsetAs3 := s.validationSetAssert(c, "bar", "4", "5", "required")
+	vsetAs3 := s.validationSetAssert(c, "bar", "4", "5", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs3), IsNil)
 
 	// but pretend it's not a refresh of all snaps

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -991,7 +991,7 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 	vsetAs2 := s.validationSetAssert(c, "bar", "2", "3", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
-	err = assertstate.RefreshSnapAssertions(s.state, 0)
+	err = assertstate.RefreshSnapAssertions(s.state, 0, &assertstate.RefreshAssertionsOptions{IsRefreshOfAllSnaps: true})
 	c.Assert(err, IsNil)
 
 	a, err := assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
@@ -1012,6 +1012,23 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 
 	c.Assert(err, IsNil)
 	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+
+	// changed validation set assertion again
+	vsetAs3 := s.validationSetAssert(c, "bar", "4", "5", "required")
+	c.Assert(s.storeSigning.Add(vsetAs3), IsNil)
+
+	// but pretend it's not a refresh of all snaps
+	err = assertstate.RefreshSnapAssertions(s.state, 0, &assertstate.RefreshAssertionsOptions{IsRefreshOfAllSnaps: false})
+	c.Assert(err, IsNil)
+
+	// so the assertion is not updated
+	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "4",
+	})
+	c.Check(asserts.IsNotFound(err), Equals, true)
 }
 
 func (s *assertMgrSuite) TestRefreshSnapDeclarationsTooEarly(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1907,6 +1907,8 @@ func AutoRefresh(ctx context.Context, st *state.State) ([]string, []*state.TaskS
 	userID := 0
 
 	if AutoRefreshAssertions != nil {
+		// TODO: do something else if features.GateAutoRefreshHook is active
+		// since some snaps may be held and not refreshed.
 		if err := AutoRefreshAssertions(st, userID); err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Update validation set assertions only when updating all snaps (i.e. snap names are not specified with `snap refresh` command). This is needed because if only specific snaps are requested, then refreshing all validation set assertions could result in a "broken" state where newer assertions required newer revisions of some snaps (but they were excluded from refresh).