### PR TITLE
tests: update the time tolerance to fix the snapd-state test

### DIFF
--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -16,8 +16,15 @@ execute: |
 
     function check_date() {
         local TEST_DATE="$1"
-        local TOLERANCE_SECONDS=1800 # 30 minutes; in practice, the timestamp
-                                     # difference should be about 10 minutes
+        # The tolerance is the maximun since the snapd state is backed up when the suite
+        # is prepared. In case of external backend that time could be until 12 hours.
+        # In case of the google backend the tolerance time could be until 90 minutes
+        local TOLERANCE_SECONDS
+        if [ "$SPREAD_BACKENDS" = external ]; then
+            TOLERANCE_SECONDS=43200 # 60s*60m*12h=43200
+        else
+            TOLERANCE_SECONDS=5400 # 60s*90m=5400
+        fi
         local TEST_TIMESTAMP CURRENT_TIMESTAMP
 
         TEST_TIMESTAMP=$(date +'%s' --date="${TEST_DATE}")

--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -20,7 +20,7 @@ execute: |
         # is prepared. In case of external backend that time could be until 12 hours.
         # In case of the google backend the tolerance time could be until 90 minutes
         local TOLERANCE_SECONDS
-        if [ "$SPREAD_BACKENDS" = external ]; then
+        if [ "$SPREAD_BACKEND" = "external" ]; then
             TOLERANCE_SECONDS=43200 # 60s*60m*12h=43200
         else
             TOLERANCE_SECONDS=5400 # 60s*90m=5400


### PR DESCRIPTION
Currently the last-refresh time depends on the time when the snapd suite
was prepared, as the state is backed up at that moment and then restored
on each test. So the idea of this change is to increate the time
tolerance to address that.
