### PR TITLE
.github/workflows/test.yaml: revert #10809

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
           fi
     - name: Build snapd snap
       if: steps.cached-results.outputs.already-ran != 'true'
-      uses: snapcore/action-build@v1.0.9
+      uses: snapcore/action-build@v1
       with:
         snapcraft-channel: 4.x/candidate
     - name: Cache built artifact


### PR DESCRIPTION
This reverts commit 5296059c305482ca19d7a26dfeca5d06c8bc7eef.

Now that the v1 tag has been updated to point to 1.0.9, we can go back to 
tracking v1 instead of tracking specifically v1.0.9, which will prevent us from
getting updates in the future if there is i.e. a 1.0.10 or something.

See also: https://github.com/snapcore/action-build/issues/25#issuecomment-922830224