### PR TITLE
o/ifacestate: don't lose connections if snaps are broken

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -594,9 +594,9 @@ func (s *daemonSuite) TestStartStop(c *check.C) {
 	st.Lock()
 	si := &snap.SideInfo{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"}
 	snapstate.Set(st, "core", &snapstate.SnapState{
-		Active: true,
+		Active:   true,
 		Sequence: []*snap.SideInfo{si},
-		Current: snap.R(1),
+		Current:  snap.R(1),
 	})
 	st.Unlock()
 	snaptest.MockSnap(c, `name: core
@@ -729,9 +729,9 @@ func (s *daemonSuite) TestGracefulStop(c *check.C) {
 	st.Lock()
 	si := &snap.SideInfo{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"}
 	snapstate.Set(st, "core", &snapstate.SnapState{
-		Active: true,
+		Active:   true,
 		Sequence: []*snap.SideInfo{si},
-		Current: snap.R(1),
+		Current:  snap.R(1),
 	})
 	st.Unlock()
 	snaptest.MockSnap(c, `name: core

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/snapcore/snapd/overlord/standby"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
@@ -591,14 +592,15 @@ func (s *daemonSuite) TestStartStop(c *check.C) {
 	// and pretend we have snaps
 	st := d.overlord.State()
 	st.Lock()
+	si := &snap.SideInfo{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"}
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
-			{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"},
-		},
+		Sequence: []*snap.SideInfo{si},
 		Current: snap.R(1),
 	})
 	st.Unlock()
+	snaptest.MockSnap(c, `name: core
+version: 1`, si)
 	// 1 snap => extended timeout 30s + 5s
 	const extendedTimeoutUSec = "EXTEND_TIMEOUT_USEC=35000000"
 
@@ -725,14 +727,15 @@ func (s *daemonSuite) TestGracefulStop(c *check.C) {
 	// and pretend we have snaps
 	st := d.overlord.State()
 	st.Lock()
+	si := &snap.SideInfo{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"}
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
-			{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"},
-		},
+		Sequence: []*snap.SideInfo{si},
 		Current: snap.R(1),
 	})
 	st.Unlock()
+	snaptest.MockSnap(c, `name: core
+version: 1`, si)
 
 	snapdL, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, check.IsNil)

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -241,6 +241,9 @@ var removeStaleConnections = func(st *state.State) error {
 func isBroken(st *state.State, snapName string) (bool, error) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(st, snapName, &snapst)
+	if err == state.ErrNoState {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}
@@ -298,7 +301,7 @@ ConnsLoop:
 				// leave the connection untouched.
 				for _, snapName := range []string{connRef.PlugRef.Snap, connRef.SlotRef.Snap} {
 					broken, err := isBroken(m.state, snapName)
-					if err != nil && err != state.ErrNoState {
+					if err != nil {
 						return nil, err
 					}
 					if broken {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -238,6 +238,19 @@ var removeStaleConnections = func(st *state.State) error {
 	return nil
 }
 
+func isBroken(st *state.State, snapName string) (bool, error) {
+	var snapst snapstate.SnapState
+	err := snapstate.Get(st, snapName, &snapst)
+	if err != nil {
+		return false, err
+	}
+	snapInfo, _ := snapst.CurrentInfo()
+	if snapInfo != nil && snapInfo.Broken != "" {
+		return true, nil
+	}
+	return false, nil
+}
+
 // reloadConnections reloads connections stored in the state in the repository.
 // Using non-empty snapName the operation can be scoped to connections
 // affecting a given snap.
@@ -251,6 +264,7 @@ func (m *InterfaceManager) reloadConnections(snapName string) ([]string, error) 
 
 	connStateChanged := false
 	affected := make(map[string]bool)
+ConnsLoop:
 	for connId, connState := range conns {
 		// Skip entries that just mark a connection as undesired. Those don't
 		// carry attributes that can go stale. In the same spirit, skip
@@ -280,6 +294,18 @@ func (m *InterfaceManager) reloadConnections(snapName string) ([]string, error) 
 			// as long as it wasn't disconnected manually; note that undesired flag is taken care of at
 			// the beginning of the loop.
 			if connState.Auto && !connState.ByGadget && connState.Interface != "core-support" {
+				// only do anything about this connection if snap isn't in a broken state, otherwise
+				// leave the connection untouched.
+				for _, snapName := range []string{connRef.PlugRef.Snap, connRef.SlotRef.Snap} {
+					broken, err := isBroken(m.state, snapName)
+					if err != nil && err != state.ErrNoState {
+						return nil, err
+					}
+					if broken {
+						logger.Noticef("Snap %q is broken, ignored by reloadConnections", snapName)
+						continue ConnsLoop
+					}
+				}
 				delete(conns, connId)
 				connStateChanged = true
 			}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -88,12 +88,24 @@ func (m *InterfaceManager) addBackends(extra []interfaces.SecurityBackend) error
 }
 
 func (m *InterfaceManager) addSnaps(snaps []*snap.Info) error {
+	var repoSnaps int
 	for _, snapInfo := range snaps {
 		if err := addImplicitSlots(m.state, snapInfo); err != nil {
 			return err
 		}
 		if err := m.repo.AddSnap(snapInfo); err != nil {
 			logger.Noticef("cannot add snap %q to interface repository: %s", snapInfo.InstanceName(), err)
+		} else {
+			repoSnaps++
+		}
+	}
+	if repoSnaps == 0 {
+		expectedNumOfSnaps, err := snapstate.NumSnaps(m.state)
+		if err != nil {
+			return err
+		}
+		if expectedNumOfSnaps > 0 {
+			return fmt.Errorf("expected %d snaps in the system, but no snaps are mounted", expectedNumOfSnaps)
 		}
 	}
 	return nil

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -88,24 +88,12 @@ func (m *InterfaceManager) addBackends(extra []interfaces.SecurityBackend) error
 }
 
 func (m *InterfaceManager) addSnaps(snaps []*snap.Info) error {
-	var repoSnaps int
 	for _, snapInfo := range snaps {
 		if err := addImplicitSlots(m.state, snapInfo); err != nil {
 			return err
 		}
 		if err := m.repo.AddSnap(snapInfo); err != nil {
 			logger.Noticef("cannot add snap %q to interface repository: %s", snapInfo.InstanceName(), err)
-		} else {
-			repoSnaps++
-		}
-	}
-	if repoSnaps == 0 {
-		expectedNumOfSnaps, err := snapstate.NumSnaps(m.state)
-		if err != nil {
-			return err
-		}
-		if expectedNumOfSnaps > 0 {
-			return fmt.Errorf("expected %d snaps in the system, but no snaps are mounted", expectedNumOfSnaps)
 		}
 	}
 	return nil

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1867,6 +1867,69 @@ func (s *interfaceManagerSuite) TestStaleConnectionsIgnoredInReloadConnections(c
 	c.Assert(logLines[1], Equals, "")
 }
 
+func (s *interfaceManagerSuite) testStaleAutoConnectionsNotRemovedIfSnapBroken(c *C, brokenSnapName string) {
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restore := ifacestate.MockRemoveStaleConnections(func(s *state.State) error { return nil })
+	defer restore()
+
+	s.state.Set("conns", map[string]interface{}{
+		"consumer:plug producer:slot":             map[string]interface{}{"interface": "test", "auto": true},
+		"other-consumer:plug other-producer:slot": map[string]interface{}{"interface": "test", "auto": true},
+	})
+	sideInfo := &snap.SideInfo{
+		RealName: brokenSnapName,
+		Revision: snap.R(1),
+	}
+
+	// have one of them in state, and broken due to missing snap.yaml
+	snapstate.Set(s.state, brokenSnapName, &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{sideInfo},
+		Current:  sideInfo.Revision,
+		SnapType: "app",
+	})
+
+	// sanity check - snap is broken
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, brokenSnapName, &snapst), IsNil)
+	curInfo, err := snapst.CurrentInfo()
+	c.Assert(err, IsNil)
+	c.Check(curInfo.Broken, Matches, fmt.Sprintf(`cannot find installed snap "%s" at revision 1: missing file .*/1/meta/snap.yaml`, brokenSnapName))
+
+	s.state.Unlock()
+	defer s.state.Lock()
+	mgr := s.manager(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Ensure that nothing is connected
+	repo := mgr.Repository()
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, HasLen, 0)
+
+	// but the consumer:plug producer:slot connection is kept in the state and only the other one
+	// got dropped.
+	var conns map[string]interface{}
+	c.Assert(s.state.Get("conns", &conns), IsNil)
+	c.Check(conns, DeepEquals, map[string]interface{}{
+		"consumer:plug producer:slot": map[string]interface{}{"interface": "test", "auto": true},
+	})
+
+	c.Check(s.log.String(), testutil.Contains, fmt.Sprintf("Snap %q is broken, ignored by reloadConnections", brokenSnapName))
+}
+
+func (s *interfaceManagerSuite) TestStaleAutoConnectionsNotRemovedIfPlugSnapBroken(c *C) {
+	s.testStaleAutoConnectionsNotRemovedIfSnapBroken(c, "consumer")
+}
+
+func (s *interfaceManagerSuite) TestStaleAutoConnectionsNotRemovedIfSlotSnapBroken(c *C) {
+	s.testStaleAutoConnectionsNotRemovedIfSnapBroken(c, "producer")
+}
+
 func (s *interfaceManagerSuite) TestStaleConnectionsRemoved(c *C) {
 	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -6459,6 +6459,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInit(c *C) {
 		SnapType: "os",
 	})
 	st.Unlock()
+	s.mockSnap(c, coreSnapYaml)
 
 	restoreTimeout := ifacestate.MockUDevInitRetryTimeout(0 * time.Second)
 	defer restoreTimeout()
@@ -6499,6 +6500,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitErrors(c *C) {
 		SnapType: "os",
 	})
 	st.Unlock()
+	s.mockSnap(c, coreSnapYaml)
 
 	restoreTimeout := ifacestate.MockUDevInitRetryTimeout(0 * time.Second)
 	defer restoreTimeout()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2910,7 +2910,6 @@ func ActiveInfos(st *state.State) ([]*snap.Info, error) {
 	if err := st.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {
 		return nil, err
 	}
-	var active, broken int
 	for instanceName, snapst := range stateMap {
 		if !snapst.Active {
 			continue
@@ -2918,13 +2917,9 @@ func ActiveInfos(st *state.State) ([]*snap.Info, error) {
 		snapInfo, err := snapst.CurrentInfo()
 		if err != nil {
 			logger.Noticef("cannot retrieve info for snap %q: %s", instanceName, err)
-			broken++
 			continue
 		}
 		infos = append(infos, snapInfo)
-	}
-	if active > 0 && active == broken {
-		return nil, fmt.Errorf("expected %d snaps in the system, but all appear broken (likely not mounted)", active)
 	}
 	return infos, nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2910,6 +2910,7 @@ func ActiveInfos(st *state.State) ([]*snap.Info, error) {
 	if err := st.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {
 		return nil, err
 	}
+	var active, broken int
 	for instanceName, snapst := range stateMap {
 		if !snapst.Active {
 			continue
@@ -2917,9 +2918,13 @@ func ActiveInfos(st *state.State) ([]*snap.Info, error) {
 		snapInfo, err := snapst.CurrentInfo()
 		if err != nil {
 			logger.Noticef("cannot retrieve info for snap %q: %s", instanceName, err)
+			broken++
 			continue
 		}
 		infos = append(infos, snapInfo)
+	}
+	if active > 0 && active == broken {
+		return nil, fmt.Errorf("expected %d snaps in the system, but all appear broken (likely not mounted)", active)
 	}
 	return infos, nil
 }

--- a/tests/regression/lp-1943853/task.yaml
+++ b/tests/regression/lp-1943853/task.yaml
@@ -1,0 +1,35 @@
+summary: Regression test for LP:#1943853
+
+details: |
+  Test that snapd doesn't drop connected interfaces when snaps are not mounted.
+
+prepare: |
+  "$TESTSTOOLS"/snaps-state install-local home-consumer
+
+execute: |
+  echo "Connect home interface in case it's not connected (i.e. core)"
+  snap connect home-consumer:home
+  snap connections home-consumer | MATCH "^home +home-consumer:home +:home .+-"
+
+  REV=$(snap list home-consumer|tail -1|awk '{print $3}')
+
+  echo "Manually stop the mount unit of home-consumer snap"
+  systemctl stop snap-home\\x2dconsumer-"$REV".mount
+  systemctl stop snapd.{socket,service}
+  systemctl start snapd.{socket,service}
+
+  echo "And the snap now appears broken"
+  snap list home-consumer | MATCH "broken"
+
+  "$TESTSTOOLS"/journal-state get-log | MATCH "Snap \"home-consumer\" is broken, ignored by reloadConnections"
+
+  echo "Start the mount unit of home-consumer snap"
+  systemctl start snap-home\\x2dconsumer-"$REV".mount
+
+  echo "And the snap is not broken anymore"
+  systemctl stop snapd.{socket,service}
+  systemctl start snapd.{socket,service}
+  snap list home-consumer | NOMATCH "broken"
+
+  echo "And its connections were kept"
+  snap connections home-consumer | MATCH "^home +home-consumer:home +:home .+-"

--- a/tests/regression/lp-1943853/task.yaml
+++ b/tests/regression/lp-1943853/task.yaml
@@ -15,7 +15,7 @@ execute: |
 
   REV=$(snap list home-consumer|tail -1|awk '{print $3}')
   SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-  MOUNT_UNIT="$(systemd-escape -p "${SNAP_MOUNT_DIR}")-home\\x2dconsumer-"$REV".mount"
+  MOUNT_UNIT="$(systemd-escape -p "${SNAP_MOUNT_DIR}")-home\\x2dconsumer-$REV.mount"
 
   echo "Manually stop the mount unit of home-consumer snap"
   systemctl stop "$MOUNT_UNIT"

--- a/tests/regression/lp-1943853/task.yaml
+++ b/tests/regression/lp-1943853/task.yaml
@@ -1,20 +1,24 @@
 summary: Regression test for LP:#1943853
 
 details: |
-  Test that snapd doesn't drop connected interfaces when snaps are not mounted.
+  Test that snapd doesn't drop auto-connected interfaces when snaps are not mounted.
+
+# the test makes sense only for auto-connected interfaces and uses home interface,
+# therefore disable it on core.
+systems: [-ubuntu-core-*]
 
 prepare: |
   "$TESTSTOOLS"/snaps-state install-local home-consumer
 
 execute: |
-  echo "Connect home interface in case it's not connected (i.e. core)"
-  snap connect home-consumer:home
   snap connections home-consumer | MATCH "^home +home-consumer:home +:home .+-"
 
   REV=$(snap list home-consumer|tail -1|awk '{print $3}')
+  SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+  MOUNT_UNIT="$(systemd-escape -p "${SNAP_MOUNT_DIR}")-home\\x2dconsumer-"$REV".mount"
 
   echo "Manually stop the mount unit of home-consumer snap"
-  systemctl stop snap-home\\x2dconsumer-"$REV".mount
+  systemctl stop "$MOUNT_UNIT"
   systemctl stop snapd.{socket,service}
   systemctl start snapd.{socket,service}
 
@@ -24,7 +28,7 @@ execute: |
   "$TESTSTOOLS"/journal-state get-log | MATCH "Snap \"home-consumer\" is broken, ignored by reloadConnections"
 
   echo "Start the mount unit of home-consumer snap"
-  systemctl start snap-home\\x2dconsumer-"$REV".mount
+  systemctl start "$MOUNT_UNIT"
 
   echo "And the snap is not broken anymore"
   systemctl stop snapd.{socket,service}


### PR DESCRIPTION
Fix for https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1943853

Conns that refer to an unknown plug/slot (unknown = not in the repo = newer version of the snap doesn't have it OR we failed to load its info entirely) will not get pruned from the state if either plug or slot snap is in "broken" state.
