### PR TITLE
fde: add HasDeviceUnlock() helper

### DIFF
--- a/kernel/fde/fde.go
+++ b/kernel/fde/fde.go
@@ -43,11 +43,11 @@ func HasRevealKey() bool {
 	return err == nil
 }
 
-// HasDeviceUnlock return true if the current system has a
+// HasDeviceUnlock returns true if the current system has a
 // "fde-device-unlock" binary (usually used in the initrd).
 //
 // This will be used by the initrd to determine if cryptsetup is
-// skipped and a hook need to be used to unlock individual device.
+// skipped and a hook needs to be used to unlock individual device.
 func HasDeviceUnlock() bool {
 	_, err := exec.LookPath("fde-device-unlock")
 	return err == nil

--- a/kernel/fde/fde.go
+++ b/kernel/fde/fde.go
@@ -43,6 +43,16 @@ func HasRevealKey() bool {
 	return err == nil
 }
 
+// HasDeviceUnlock return true if the current system has a
+// "fde-device-unlock" binary (usually used in the initrd).
+//
+// This will be used by the initrd to determine if cryptsetup is
+// skipped and a hook need to be used to unlock individual device.
+func HasDeviceUnlock() bool {
+	_, err := exec.LookPath("fde-device-unlock")
+	return err == nil
+}
+
 func isV1Hook(hookOutput []byte) bool {
 	// This is the prefix of a tpm secboot v1 key as used in the
 	// "denver" project. So if we see this prefix we know it's

--- a/kernel/fde/fde_test.go
+++ b/kernel/fde/fde_test.go
@@ -74,6 +74,8 @@ func (s *fdeSuite) TestHasRevealKey(c *C) {
 	// correct fde-reveal-key, no logging
 	err = os.Chmod(mockBin+"fde-reveal-key", 0755)
 	c.Assert(err, IsNil)
+
+	c.Check(fde.HasRevealKey(), Equals, true)
 }
 
 func (s *fdeSuite) TestInitialSetupV2(c *C) {
@@ -512,4 +514,29 @@ service result: exit-code
 -----`)
 	// ensure no tmp files are left behind
 	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
+}
+
+func (s *fdeSuite) TestHasDeviceUnlock(c *C) {
+	oldPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", oldPath) }()
+
+	mockRoot := c.MkDir()
+	os.Setenv("PATH", mockRoot+"/bin")
+	mockBin := mockRoot + "/bin/"
+	err := os.Mkdir(mockBin, 0755)
+	c.Assert(err, IsNil)
+
+	// no fde-device-unlock binary
+	c.Check(fde.HasDeviceUnlock(), Equals, false)
+
+	// fde-device-unlock without +x
+	err = ioutil.WriteFile(mockBin+"fde-device-unlock", nil, 0644)
+	c.Assert(err, IsNil)
+	c.Check(fde.HasDeviceUnlock(), Equals, false)
+
+	// correct fde-device-unlock, no logging
+	err = os.Chmod(mockBin+"fde-device-unlock", 0755)
+	c.Assert(err, IsNil)
+
+	c.Check(fde.HasDeviceUnlock(), Equals, true)
 }


### PR DESCRIPTION
This method is used to determine if the fde-device-unlock helper is
available.

This is part of the inline-crypt-setup hook support.

 If you feel it's too little to review I can push the (messy) WIP branch that implements this all where this is chopped off from.