### PR TITLE
devicestate: use EncryptionType

### DIFF
--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -65,9 +65,7 @@ func roleOrLabelOrName(part gadget.OnDiskStructure) string {
 func Run(model gadget.Model, gadgetRoot, kernelRoot, device string, options Options, observer gadget.ContentObserver, perfTimings timings.Measurer) (*InstalledSystemSideData, error) {
 	logger.Noticef("installing a new system")
 	logger.Noticef("        gadget data from: %v", gadgetRoot)
-	if options.Encrypt {
-		logger.Noticef("        encryption: on")
-	}
+	logger.Noticef("        encryption: %v", options.EncryptionType)
 	if gadgetRoot == "" {
 		return nil, fmt.Errorf("cannot use empty gadget root directory")
 	}
@@ -149,7 +147,8 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, device string, options Opti
 		}
 		logger.Noticef("created new partition %v for structure %v (size %v) %s",
 			part.Node, part, part.Size.IECString(), roleFmt)
-		if options.Encrypt && roleNeedsEncryption(part.Role) {
+		encrypt := (options.EncryptionType != secboot.EncryptionTypeNone)
+		if encrypt && roleNeedsEncryption(part.Role) {
 			var keys *EncryptionKeySet
 			timings.Run(perfTimings, fmt.Sprintf("make-key-set[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Create encryption key set for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
 				keys, err = makeKeySet()

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -26,8 +26,8 @@ import (
 type Options struct {
 	// Also mount the filesystems after creation
 	Mount bool
-	// Encrypt the data partition
-	Encrypt bool
+	// Encrypt the data/save partitions
+	EncryptionType secboot.EncryptionType
 }
 
 // EncryptionKeySet is a set of encryption keys.

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
@@ -1745,7 +1746,7 @@ func (m *DeviceManager) runFDESetupHook(req *fde.SetupRequest) ([]byte, error) {
 	return hookOutput, nil
 }
 
-func (m *DeviceManager) checkFDEFeatures() error {
+func (m *DeviceManager) checkFDEFeatures() (et secboot.EncryptionType, err error) {
 	// TODO: move most of this to kernel/fde.Features
 	// Run fde-setup hook with "op":"features". If the hook
 	// returns any {"features":[...]} reply we consider the
@@ -1756,22 +1757,28 @@ func (m *DeviceManager) checkFDEFeatures() error {
 	}
 	output, err := m.runFDESetupHook(req)
 	if err != nil {
-		return err
+		return et, err
 	}
 	var res struct {
 		Features []string `json:"features"`
 		Error    string   `json:"error"`
 	}
 	if err := json.Unmarshal(output, &res); err != nil {
-		return fmt.Errorf("cannot parse hook output %q: %v", output, err)
+		return et, fmt.Errorf("cannot parse hook output %q: %v", output, err)
 	}
 	if res.Features == nil && res.Error == "" {
-		return fmt.Errorf(`cannot use hook: neither "features" nor "error" returned`)
+		return et, fmt.Errorf(`cannot use hook: neither "features" nor "error" returned`)
 	}
 	if res.Error != "" {
-		return fmt.Errorf("cannot use hook: it returned error: %v", res.Error)
+		return et, fmt.Errorf("cannot use hook: it returned error: %v", res.Error)
 	}
-	return nil
+	if strutil.ListContains(res.Features, "device-setup") {
+		et = secboot.EncryptionTypeDeviceSetupHook
+	} else {
+		et = secboot.EncryptionTypeCryptsetup
+	}
+
+	return et, nil
 }
 
 func hasFDESetupHookInKernel(kernelInfo *snap.Info) bool {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1775,7 +1775,7 @@ func (m *DeviceManager) checkFDEFeatures() (et secboot.EncryptionType, err error
 	if strutil.ListContains(res.Features, "device-setup") {
 		et = secboot.EncryptionTypeDeviceSetupHook
 	} else {
-		et = secboot.EncryptionTypeCryptsetup
+		et = secboot.EncryptionTypeLUKS
 	}
 
 	return et, nil

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -323,7 +323,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	if tc.encrypt {
 		c.Assert(brOpts, DeepEquals, install.Options{
 			Mount:          true,
-			EncryptionType: secboot.EncryptionTypeCryptsetup,
+			EncryptionType: secboot.EncryptionTypeLUKS,
 		})
 	} else {
 		c.Assert(brOpts, DeepEquals, install.Options{
@@ -863,7 +863,7 @@ func (s *deviceMgrInstallModeSuite) testInstallEncryptionSanityChecks(c *C, errM
 
 func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoKeys(c *C) {
 	restore := devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver, _ timings.Measurer) (*install.InstalledSystemSideData, error) {
-		c.Check(options.EncryptionType, Equals, secboot.EncryptionTypeCryptsetup)
+		c.Check(options.EncryptionType, Equals, secboot.EncryptionTypeLUKS)
 		// no keys set
 		return &install.InstalledSystemSideData{}, nil
 	})
@@ -874,7 +874,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoKeys(c *C
 
 func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoSystemDataKey(c *C) {
 	restore := devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver, _ timings.Measurer) (*install.InstalledSystemSideData, error) {
-		c.Check(options.EncryptionType, Equals, secboot.EncryptionTypeCryptsetup)
+		c.Check(options.EncryptionType, Equals, secboot.EncryptionTypeLUKS)
 		// no keys set
 		return &install.InstalledSystemSideData{
 			// empty map
@@ -1234,9 +1234,9 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncrypted(c *C) {
 		// unhappy: no tpm, no hook
 		{false, "[]", false, secboot.EncryptionTypeNone},
 		// happy: either tpm or hook or both
-		{false, "[]", true, secboot.EncryptionTypeCryptsetup},
-		{true, "[]", false, secboot.EncryptionTypeCryptsetup},
-		{true, "[]", true, secboot.EncryptionTypeCryptsetup},
+		{false, "[]", true, secboot.EncryptionTypeLUKS},
+		{true, "[]", false, secboot.EncryptionTypeLUKS},
+		{true, "[]", true, secboot.EncryptionTypeLUKS},
 		// happy but device-setup hook
 		{true, `["device-setup"]`, true, secboot.EncryptionTypeDeviceSetupHook},
 	} {
@@ -1407,9 +1407,9 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedFDEHook(c *C) {
 		{`{"error":"failed"}`, `cannot use hook: it returned error: failed`, secboot.EncryptionTypeNone},
 		{`{}`, `cannot use hook: neither "features" nor "error" returned`, secboot.EncryptionTypeNone},
 		// valid
-		{`{"features":[]}`, "", secboot.EncryptionTypeCryptsetup},
-		{`{"features":["a"]}`, "", secboot.EncryptionTypeCryptsetup},
-		{`{"features":["a","b"]}`, "", secboot.EncryptionTypeCryptsetup},
+		{`{"features":[]}`, "", secboot.EncryptionTypeLUKS},
+		{`{"features":["a"]}`, "", secboot.EncryptionTypeLUKS},
+		{`{"features":["a","b"]}`, "", secboot.EncryptionTypeLUKS},
 		// features must be list of strings
 		{`{"features":[1]}`, `cannot parse hook output ".*": json: cannot unmarshal number into Go struct.*`, secboot.EncryptionTypeNone},
 		{`{"features":1}`, `cannot parse hook output ".*": json: cannot unmarshal number into Go struct.*`, secboot.EncryptionTypeNone},

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/timings"
 )
@@ -332,7 +333,7 @@ func DeviceManagerRunFDESetupHook(mgr *DeviceManager, req *fde.SetupRequest) ([]
 	return mgr.runFDESetupHook(req)
 }
 
-func DeviceManagerCheckEncryption(mgr *DeviceManager, st *state.State, deviceCtx snapstate.DeviceContext) (bool, error) {
+func DeviceManagerCheckEncryption(mgr *DeviceManager, st *state.State, deviceCtx snapstate.DeviceContext) (secboot.EncryptionType, error) {
 	return mgr.checkEncryption(st, deviceCtx)
 }
 

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -337,6 +337,6 @@ func DeviceManagerCheckEncryption(mgr *DeviceManager, st *state.State, deviceCtx
 	return mgr.checkEncryption(st, deviceCtx)
 }
 
-func DeviceManagerCheckFDEFeatures(mgr *DeviceManager, st *state.State) error {
+func DeviceManagerCheckFDEFeatures(mgr *DeviceManager, st *state.State) (secboot.EncryptionType, error) {
 	return mgr.checkFDEFeatures()
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -493,7 +493,7 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 	if !hasFDESetupHook {
 		checkEncryptionErr = secbootCheckTPMKeySealingSupported()
 		if checkEncryptionErr == nil {
-			res = secboot.EncryptionTypeCryptsetup
+			res = secboot.EncryptionTypeLUKS
 		}
 	}
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -485,14 +485,16 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 	)
 	if kernelInfo, err := snapstate.KernelInfo(st, deviceCtx); err == nil {
 		if hasFDESetupHook = hasFDESetupHookInKernel(kernelInfo); hasFDESetupHook {
-			// TODO: support getting EncryptionTypeDeviceSetupHook
-			checkEncryptionErr = m.checkFDEFeatures()
+			res, checkEncryptionErr = m.checkFDEFeatures()
 		}
 	}
 	// Note that having a fde-setup hook will disable the build-in
 	// secboot encryption
 	if !hasFDESetupHook {
 		checkEncryptionErr = secbootCheckTPMKeySealingSupported()
+		if checkEncryptionErr == nil {
+			res = secboot.EncryptionTypeCryptsetup
+		}
 	}
 
 	// check if encryption is required
@@ -514,8 +516,6 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 		return res, nil
 	}
 
-	// encrypt
-	res = secboot.EncryptionTypeCryptsetup
 	return res, nil
 }
 

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -122,6 +122,6 @@ type EncryptionType string
 
 const (
 	EncryptionTypeNone            EncryptionType = ""
-	EncryptionTypeCryptsetup      EncryptionType = "cryptsetup"
+	EncryptionTypeLUKS      EncryptionType = "cryptsetup"
 	EncryptionTypeDeviceSetupHook EncryptionType = "device-setup-hook"
 )

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -116,3 +116,12 @@ func NewAuxKey() (AuxKey, error) {
 	// On return, n == len(b) if and only if err == nil
 	return key, err
 }
+
+// EncryptionType specifies what encryption backend should be used (if any)
+type EncryptionType string
+
+const (
+	EncryptionTypeNone            EncryptionType = ""
+	EncryptionTypeCryptsetup      EncryptionType = "cryptsetup"
+	EncryptionTypeDeviceSetupHook EncryptionType = "device-setup-hook"
+)

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -122,6 +122,6 @@ type EncryptionType string
 
 const (
 	EncryptionTypeNone            EncryptionType = ""
-	EncryptionTypeLUKS      EncryptionType = "cryptsetup"
+	EncryptionTypeLUKS            EncryptionType = "cryptsetup"
 	EncryptionTypeDeviceSetupHook EncryptionType = "device-setup-hook"
 )

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -67,9 +67,14 @@ func main() {
 
 	obs := &simpleObserver{}
 
+	var encryptionType secboot.EncryptionType
+	if args.Encrypt {
+		encryptionType = secboot.EncryptionTypeCryptsetup
+	}
+
 	options := install.Options{
-		Mount:   args.Mount,
-		Encrypt: args.Encrypt,
+		Mount:          args.Mount,
+		EncryptionType: encryptionType,
 	}
 	installSideData, err := installRun(uc20Constraints{}, args.Positional.GadgetRoot, args.Positional.KernelRoot, args.Positional.Device, options, obs, timings.New(nil))
 	if err != nil {

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	var encryptionType secboot.EncryptionType
 	if args.Encrypt {
-		encryptionType = secboot.EncryptionTypeCryptsetup
+		encryptionType = secboot.EncryptionTypeLUKS
 	}
 
 	options := install.Options{


### PR DESCRIPTION
This branch uses a new `EncryptionType` in `DeviceManager.checkEncryption()` and `DeviceManager.checkFDEFeatures()`. 

This prepares for the "device-setup" feature that will not use cryptsetup but instead uses a device specific hook to configure crypto hardware.