### PR TITLE
spread: display information about current device cgroup in debug dump

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -455,6 +455,7 @@ debug-each: |
             # dump any information on device cgroup of current session
             cgroup_dev="$(awk -F: '/:devices:/ { print $3}' < /proc/self/cgroup || true)"
             if [ -n "$cgroup_dev" ]; then
+                echo "# device cgroup $cgroup_dev"
                 cat "/sys/fs/cgroup/devices/$cgroup_dev/devices.list" || true
             fi
         fi

--- a/spread.yaml
+++ b/spread.yaml
@@ -422,6 +422,8 @@ debug-each: |
     if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
         #shellcheck source=tests/lib/state.sh
         . "$TESTSLIB/state.sh"
+        #shellcheck source=tests/lib/systems.sh
+        . "$TESTSLIB/systems.sh"
 
         echo '# System information'
         cat /etc/os-release || true
@@ -448,6 +450,14 @@ debug-each: |
         echo '# user sessions information'
         journalctl --user -u snapd.session-agent.service
         systemctl status --user snapd.session-agent  || true
+
+        if ! is_cgroupv2; then
+            # dump any information on device cgroup of current session
+            cgroup_dev="$(awk -F: '/:devices:/ { print $3}' < /proc/self/cgroup || true)"
+            if [ -n "$cgroup_dev" ]; then
+                cat "/sys/fs/cgroup/devices/$cgroup_dev/devices.list" || true
+            fi
+        fi
 
         case "$SPREAD_SYSTEM" in
             fedora-*|centos-*|amazon-*)


### PR DESCRIPTION
This shoudl be regather impossible, but we see mknod failing with EPERM in
prepare of certain tests. As far as I can tell, the kernel should not be
triggering this with devmtmpfs even if the device the node we are creating for
does not exist. Perhaps there is a device cgroup set up for the current session.
