### PR TITLE
sysconfig: set TMPDIR in tests to avoid cluttering the real /tmp

### DIFF
--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -51,6 +51,10 @@ func (s *sysconfigSuite) SetUpTest(c *C) {
 	s.tmpdir = c.MkDir()
 	dirs.SetRootDir(s.tmpdir)
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
+
+	oldTmpdir := os.Getenv("TMPDIR")
+	os.Setenv("TMPDIR", s.tmpdir)
+	s.AddCleanup(func() { os.Unsetenv(oldTmpdir) })
 }
 
 func (s *sysconfigSuite) makeCloudCfgSrcDirFiles(c *C, cfgs ...string) (string, []string) {


### PR DESCRIPTION
The cloud-init filtering writes a bunch of files into /tmp that
are not removed. So avoid cluttering /tmp on the hosts when
unit tests are run this commit sets TMPDIR to the unit test
tmpdir so that it's properly cleaned up.

This brings up a bit of a meta question (which may make the PR obsolete):
Should we write the filtered config into something like `/run/snapd/cloud-init`
to avoid having it in /tmp that may get cleared at random points?
(see `sysconfig/cloudinit.go:filterCloudCfgFile()` and ioutil.TempFile() there).