### PR TITLE
fde: add new device-setup support to fde-setup

### DIFF
--- a/kernel/fde/fde.go
+++ b/kernel/fde/fde.go
@@ -116,3 +116,28 @@ func InitialSetup(runSetupHook RunSetupHookFunc, params *InitialSetupParams) (*I
 	}
 	return res, nil
 }
+
+// CheckFeatures returns the features of fde-setup hook.
+func CheckFeatures(runSetupHook RunSetupHookFunc) ([]string, error) {
+	req := &SetupRequest{
+		Op: "features",
+	}
+	output, err := runSetupHook(req)
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		Features []string `json:"features"`
+		Error    string   `json:"error"`
+	}
+	if err := json.Unmarshal(output, &res); err != nil {
+		return nil, fmt.Errorf("cannot parse hook output %q: %v", output, err)
+	}
+	if res.Features == nil && res.Error == "" {
+		return nil, fmt.Errorf(`cannot use hook: neither "features" nor "error" returned`)
+	}
+	if res.Error != "" {
+		return nil, fmt.Errorf("cannot use hook: it returned error: %v", res.Error)
+	}
+	return res.Features, nil
+}

--- a/kernel/fde/fde_test.go
+++ b/kernel/fde/fde_test.go
@@ -525,3 +525,49 @@ func (s *fdeSuite) TestRevealErr(c *C) {
 	// ensure no tmp files are left behind
 	c.Check(osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "/run/fde-reveal-key")), Equals, false)
 }
+
+func (s *fdeSuite) TestDeviceSetupHappy(c *C) {
+	mockKey := []byte{1, 2, 3, 4}
+	mockDevice := "/dev/sda2"
+
+	runSetupHook := func(req *fde.SetupRequest) ([]byte, error) {
+		c.Check(req, DeepEquals, &fde.SetupRequest{
+			Op:     "device-setup",
+			Key:    mockKey,
+			Device: mockDevice,
+		})
+		// empty reply: no error
+		mockJSON := `{}`
+		return []byte(mockJSON), nil
+	}
+
+	params := &fde.DeviceSetupParams{
+		Key:    mockKey,
+		Device: mockDevice,
+	}
+	err := fde.DeviceSetup(runSetupHook, params)
+	c.Assert(err, IsNil)
+}
+
+func (s *fdeSuite) TestDeviceSetupError(c *C) {
+	mockKey := []byte{1, 2, 3, 4}
+	mockDevice := "/dev/sda2"
+
+	runSetupHook := func(req *fde.SetupRequest) ([]byte, error) {
+		c.Check(req, DeepEquals, &fde.SetupRequest{
+			Op:     "device-setup",
+			Key:    mockKey,
+			Device: mockDevice,
+		})
+		// empty reply: no error
+		mockJSON := `something failed badly`
+		return []byte(mockJSON), fmt.Errorf("exit status 1")
+	}
+
+	params := &fde.DeviceSetupParams{
+		Key:    mockKey,
+		Device: mockDevice,
+	}
+	err := fde.DeviceSetup(runSetupHook, params)
+	c.Check(err, ErrorMatches, "device setup failed with: something failed badly")
+}

--- a/overlord/hookstate/ctlcmd/fde_setup.go
+++ b/overlord/hookstate/ctlcmd/fde_setup.go
@@ -75,9 +75,9 @@ func (c *fdeSetupRequestCommand) Execute(args []string) error {
 	if err := context.Get("fde-setup-request", &fdeSetup); err != nil {
 		return fmt.Errorf("cannot get fde-setup-op from context: %v", err)
 	}
-	// Op is either "initial-setup" or "features"
+	// Op is either "initial-setup", "device-setup" or "features"
 	switch fdeSetup.Op {
-	case "features", "initial-setup":
+	case "features", "initial-setup", "device-setup":
 		// fine
 	default:
 		return fmt.Errorf("unknown fde-setup-request op %q", fdeSetup.Op)

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -166,3 +166,24 @@ func (s *fdeSetupSuite) TestFdeSetupResult(c *C) {
 	s.mockContext.Unlock()
 	c.Check(fdeSetupResult, DeepEquals, mockStdin)
 }
+
+func (s *fdeSetupSuite) TestFdeSetupRequestOpDeviceSetup(c *C) {
+	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
+	fdeSetup := &fde.SetupRequest{
+		Op:     "device-setup",
+		Key:    mockKey[:],
+		Device: "/dev/sda1",
+	}
+	s.mockContext.Lock()
+	s.mockContext.Set("fde-setup-request", fdeSetup)
+	s.mockContext.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fde-setup-request"}, 0)
+	c.Assert(err, IsNil)
+
+	// the encryption key should be base64 encoded
+	encodedBase64Key := base64.StdEncoding.EncodeToString(mockKey[:])
+
+	c.Check(string(stdout), Equals, fmt.Sprintf(`{"op":"device-setup","key":%q,"device":"/dev/sda1"}`+"\n", encodedBase64Key))
+	c.Check(string(stderr), Equals, "")
+}


### PR DESCRIPTION
This PR adds the ability to run the `device-setup` hook in addition to the `InitialSetup`. It also contains a small refactor to move the `CheckFeatures()` into the `kernel/fde` package to make it more symmetric with the other hook usage.
