### PR TITLE
tests: use our own image for ubuntu impish

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -256,7 +256,6 @@ jobs:
         - ubuntu-20.04-64
         - ubuntu-21.04-64
         - ubuntu-21.10-64
-        - ubuntu-21.10-64-cgroupv2
         - ubuntu-core-16-64
         - ubuntu-core-18-64
         - ubuntu-core-20-64

--- a/spread.yaml
+++ b/spread.yaml
@@ -109,13 +109,6 @@ backends:
             - ubuntu-21.04-64:
                   workers: 8
             - ubuntu-21.10-64:
-                  image: ubuntu-os-cloud-devel/ubuntu-2110
-                  storage: 12G
-                  workers: 8
-            # TODO: drop once the 21.10 cloud images have switched to cgroup v2
-            # by default
-            - ubuntu-21.10-64-cgroupv2:
-                  image: ubuntu-2110-64
                   storage: 12G
                   workers: 8
 


### PR DESCRIPTION
As there are many images in ubuntu-os-cloud-devel project we need to
update the image to avoid pagination issue of spread

This change will fix issue trying to allocate image:
2021-09-22 19:58:26 Cannot allocate google:ubuntu-21.10-64: cannot find
any Google image matching "ubuntu-os-cloud-devel/ubuntu-2110" on project
"ubuntu-os-cloud-devel"

As the new impish image includes by default cgroups v2, I am removing the old image with groups v2 added manually. 

The image will be updated daily
