### PR TITLE
tests: fix error trying to create the extra-snaps dir which already exists

### DIFF
--- a/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/task.yaml
+++ b/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/task.yaml
@@ -63,6 +63,8 @@ prepare: |
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
   SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
 
+  # modify and repack gadget snap to add a defaults section and use our own
+  # prepare-device hook to use the fakedevicesvc
   snap download --basename=pc --channel="20/edge" pc
   unsquashfs -d pc-gadget pc.snap
 

--- a/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/task.yaml
+++ b/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/task.yaml
@@ -58,10 +58,6 @@ prepare: |
   cp "$TESTSLIB"/assertions/developer1.account "$NESTED_FAKESTORE_BLOB_DIR/asserts"
   cp "$TESTSLIB"/assertions/developer1.account-key "$NESTED_FAKESTORE_BLOB_DIR/asserts"
 
-  # modify and repack gadget snap to add a defaults section and use our own
-  # prepare-device hook to use the fakedevicesvc
-  mkdir "$(nested_get_extra_snaps_path)"
-
   # Get the snakeoil key and cert for signing gadget assets (shim)
   KEY_NAME=$(nested_get_snakeoil_key)
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"


### PR DESCRIPTION
The test tests/nested/manual/core20-cloud-init-maas-signed-seed-data is
failing trying to create the extra-snaps directory which is being
created while the test is prepared.

+ mkdir
/home/gopath/src/github.com/snapcore/snapd/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/extra-snaps
mkdir: cannot create directory
‘/home/gopath/src/github.com/snapcore/snapd/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/extra-snaps’:
File exists
