### PR TITLE
tests: fix netplan test on i386 architecture

### DIFF
--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -19,13 +19,21 @@ prepare: |
     sed "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml.in" -e "s/base: BASESNAP/base: core18/" > "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml"
     snap pack "$TESTSLIB/snaps/netplan-snap" --filename=netplan-snap-18.snap
 
-    # use base: core20
-    sed "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml.in" -e "s/base: BASESNAP/base: core20/" > "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml"
-    snap pack "$TESTSLIB/snaps/netplan-snap" --filename=netplan-snap-20.snap
+    # Skip i386 because core20 is not available for pc-i386 architecture
+    if not os.query is-pc-i386; then
+        # use base: core20
+        sed "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml.in" -e "s/base: BASESNAP/base: core20/" > "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml"
+        snap pack "$TESTSLIB/snaps/netplan-snap" --filename=netplan-snap-20.snap
+    fi
 
 execute: |
     # test all base versions of netplan on all combos of core releases
-    for rel in 16 18 20; do
+    versions="16 18 20"
+    # Skip i386 because core20 is not available for pc-i386 architecture
+    if os.query is-pc-i386; then
+        versions="16 18"
+    fi
+    for rel in $versions; do
         snap install --dangerous "netplan-snap-$rel.snap"
         echo "The interface is disconnected by default"
         snap connections netplan-snap | MATCH 'network-setup-control +netplan-snap:network-setup-control +- +-'


### PR DESCRIPTION
Skip i386 because core20 is not available for pc-i386 architecture

This is failing on beta validation:

+ snap install --dangerous netplan-snap-20.snap
error: cannot perform the following tasks:
- Ensure prerequisites for "netplan-snap" are available (cannot install
snap base "core20": no snap revision available as specified)
