### PR TITLE
tests: fix lxd-mount-units test which is based on core20 in ubuntu focal system

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -91,6 +91,7 @@ backends:
             - ubuntu-18.04-64:
                   workers: 8
             - ubuntu-20.04-64:
+                  storage: 12G
                   workers: 8
             - ubuntu-core-16-64:
                   image: ubuntu-16.04-64

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -20,11 +20,8 @@ execute: |
     lxd waitready
     lxd init --auto
 
-    if os.query is-focal; then
-        core_snap=core18
-    else
-        core_snap=core20
-    fi
+    # Define the core snap for the current system
+    core_snap=core20
 
     echo "Setting up proxy for lxc"
     if [ -n "${http_proxy:-}" ]; then


### PR DESCRIPTION
Use core20 as base snap for focal system

The test is failing on focal with this error:
+ lxd.lxc exec ubuntu -- find /var/run/systemd/generator/ -name
container.conf
+ MATCH '/var/run/systemd/generator/snap-core18.*mount.d/container.conf'
grep error: pattern not found, got:
/var/run/systemd/generator/snap-snapd-12883.mount.d/container.conf
/var/run/systemd/generator/snap-core20-1081.mount.d/container.conf
/var/run/systemd/generator/snap-lxd-21545.mount.d/container.conf
