### PR TITLE
cmd/libsnap-confine-private: fix set but unused variable in the unit tests

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support-test.c
+++ b/cmd/libsnap-confine-private/cgroup-support-test.c
@@ -279,9 +279,10 @@ static void test_sc_cgroupv2_own_group_path_empty(cgroupv2_own_group_fixture *fi
 
 static void _test_sc_cgroupv2_own_group_path_die_with_message(const char *msg) {
     if (g_test_subprocess()) {
-        char *p SC_CLEANUP(sc_cleanup_string) = NULL;
-        // keep this separate so that p isn't unused
+        char *p = NULL;
         p = sc_cgroup_v2_own_path_full();
+        /* not reached */
+        sc_cleanup_string(&p);
     }
     g_test_trap_subprocess(NULL, 0, 0);
     g_test_trap_assert_failed();


### PR DESCRIPTION
Clang 13.0 generates this warning:

```
libsnap-confine-private/cgroup-support-test.c:282:15: error: variable 'p' set but not used [-Werror,-Wunused-but-set-variable]
        char *p SC_CLEANUP(sc_cleanup_string) = NULL;
              ^
1 error generated.
```
