### PR TITLE
cmd/snap-confine: update s-c apparmor profile to allow versioned ld.so

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -14,7 +14,11 @@
     # any abstractions
     /etc/ld.so.cache r,
     /etc/ld.so.preload r,
-    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld-*.so mrix,
+
+    # Do not assume that the interpreter is always named like
+    # ld-linux-x86_64.so, as on some architectures there can be a version after
+    # the .so suffix, eg. ld-linux-aarch64.so.1
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld-*.so* mrix,
     # libc, you are funny
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,
@@ -459,7 +463,7 @@
         # We run privileged, so be fanatical about what we include and don't use
         # any abstractions
         /etc/ld.so.cache r,
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld-*.so mrix,
+        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld-*.so* mrix,
         # libc, you are funny
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,


### PR DESCRIPTION
On some architectures, such as aarch64, we've seen the ld.so interpreter to be
named like lib-linux-aarch64.so.1. However, snap-confine's AppArmor profile
prevents that path from being loaded, thus breaking execution of snaps. The
following denial was observed on affected systems:

audit: type=1400 audit(1632477434.031:8902): apparmor="DENIED" operation="file_mmap"
    namespace="root//lxd-happy-impish_<var-snap-lxd-common-lxd>"
    profile="/snap/snapd/12886/usr/lib/snapd/snap-confine"
    name="/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
    pid=1101743 comm="snap-confine" requested_mask="m" denied_mask="m"
    fsuid=1000000 ouid=1000000

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1944004

