### PR TITLE
tests/main/security-device-cgroups: fix when both variants run on the same host

### DIFF
--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -76,6 +76,13 @@ execute: |
         exit 0
     fi
 
+    tags_are_sticky=0
+    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+        # with systemd versions 247+, the TAGS are sticky, but CURRENT_TAGS is
+        # updated to reflect the latest state of DB
+        tags_are_sticky=1
+    fi
+
     echo "Given snap is installed"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
@@ -97,13 +104,18 @@ execute: |
     echo "Then the device is shown as assigned to the snap"
     udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
     # CURRENT_TAGS just available on systemd 247+
-    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+    if [ "$tags_are_sticky" = "1" ]; then
         udevadm info "$UDEVADM_PATH" | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
     fi
 
     echo "And other devices are not shown as assigned to the snap"
-    udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
-    udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+    if [ "$tags_are_sticky" = "1" ]; then
+        # no point in checking TAGS are other variant of the test could have
+        # executed on the same host and thus TAGS will be tainted
+        udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
+    else
+        udevadm info "$OTHER_UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"
+    fi
 
     echo "When a snap command is called"
     test-snapd-sh.sh -c 'true'
@@ -133,9 +145,7 @@ execute: |
     udevadm info "$UDEVADM_PATH" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
     test ! -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
 
-    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
-        # with systemd versions 247+, the TAGS are sticky, but CURRENT_TAGS has
-        # been updated updated and checked
+    if [ "$tags_are_sticky" = "1" ]; then
         udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
     else
         udevadm info "$UDEVADM_PATH" | NOMATCH "E: TAGS=.*snap_test-snapd-sh_sh"


### PR DESCRIPTION
When both variants of the test run on the same host where the TAGS are sticky
due to systemd 247+, then any TAGS added due to the first variant will break the
assumptions of the second variant. Make sure that we check proper
TAGS/CURRENT_TAGS when verifying assumptions.
