### PR TITLE
interfaces/dsp: add a usb rule to the ambarella flavor

### DIFF
--- a/interfaces/builtin/dsp.go
+++ b/interfaces/builtin/dsp.go
@@ -62,6 +62,9 @@ const ambarellaDspConnectedPlugApparmor = `
 
 # also needed for interfacing with the DSP
 /proc/ambarella/vin0_idsp rw,
+
+# needed to control the usb device attached to the DSP
+/proc/ambarella/usbphy0 rw,
 `
 
 var ambarellaDspConnectedPlugUDev = []string{


### PR DESCRIPTION
This is needed as per a recent customer ticket, see SF ticket #00319598 for
more details.