### PR TITLE
interfaces/apparmor/template.go: allow inspection of dbus mediation level

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -267,6 +267,8 @@ var templateCommon = `
   @{PROC}/sys/kernel/pid_max r,
   @{PROC}/sys/kernel/yama/ptrace_scope r,
   @{PROC}/sys/kernel/shmmax r,
+  # Allow apps to introspect the level of dbus mediation AppArmor implements.
+  /sys/kernel/security/apparmor/features/dbus/mask r,
   @{PROC}/sys/fs/file-max r,
   @{PROC}/sys/fs/file-nr r,
   @{PROC}/sys/fs/inotify/max_* r,


### PR DESCRIPTION
This does not leak any information since an app could always try to send dbus
messages and see what fails to perform the same inspection, but this helps
eliminate some messages when using i.e. dbus-run-session legitimately for some
applications.

See also the thread on https://forum.snapcraft.io/t/how-to-use-dbus-run-session-on-ubuntu-core/7077/3