### PR TITLE
disks: add `Size()` to disks interface

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -62,6 +62,10 @@ type Disk interface {
 	// does not have partitions for example.
 	HasPartitions() bool
 
+	// Size returns the size of the disk in bytes (as reported by
+	// BLKGETSIZE)
+	Size() (uint64, error)
+
 	// TODO: add function to get some properties like an associated /dev node
 	//       for a disk for better user error reporting, i.e. /dev/vda3 is much
 	//       more helpful than 252:3

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -506,3 +506,18 @@ func (d *disk) HasPartitions() bool {
 	//       d.partitions is empty or not
 	return d.hasPartitions
 }
+
+func (d *disk) Size() (uint64, error) {
+	path := fmt.Sprintf("/sys/dev/block/%v:%v/size", d.major, d.minor)
+	raw, err := ioutil.ReadFile(filepath.Join(dirs.GlobalRootDir, path))
+	if err != nil {
+		return 0, fmt.Errorf("cannot open disk to get size: %v", err)
+	}
+	sizeb := bytes.TrimSpace(raw)
+
+	size, err := strconv.ParseUint(string(sizeb), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cannot get size for device %v:%v: %v", d.major, d.minor, err)
+	}
+	return size, nil
+}

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -40,6 +40,8 @@ type MockDiskMapping struct {
 	PartitionLabelToPartUUID map[string]string
 	DiskHasPartitions        bool
 	DevNum                   string
+	DiskSize                 uint64
+	DiskSizeError            error
 }
 
 // FindMatchingPartitionUUIDWithFsLabel returns a matching PartitionUUID
@@ -98,6 +100,11 @@ func (d *MockDiskMapping) MountPointIsFromDisk(mountpoint string, opts *Options)
 // interface.
 func (d *MockDiskMapping) Dev() string {
 	return d.DevNum
+}
+
+// Size returns the size of the disk in bytes.
+func (d *MockDiskMapping) Size() (uint64, error) {
+	return d.DiskSize, d.DiskSizeError
 }
 
 // Mountpoint is a combination of a mountpoint location and whether that


### PR DESCRIPTION
The `Size()` function will be used in the fde device-setup helpers
to create the right mapping devices for systems that use e.g.
inline encryption engines.