### PR TITLE
interfaces/seccomp: add clone3 to default template

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -103,6 +103,7 @@ clock_gettime64
 clock_nanosleep
 clock_nanosleep_time64
 clone
+clone3
 close
 
 # needed by ls -l


### PR DESCRIPTION
Recent combinations of Go 1.17, glibc 2.34 and Linux 5.14 ended up triggering
pthread_create() code paths that try to use clone3() syscall when executing
snap-exec. Since snap-exec runs under the seccomp profile of the application,
make sure that clone3 is allowed in the default template. Also, applications may
trigger this code path themselves anyway.

The strace output when this fails looks like this:
```
mprotect(0x7f4ad3ea2000, 8388608, PROT_READ|PROT_WRITE) = 0
rt_sigprocmask(SIG_BLOCK, ~[], ~[KILL STOP RTMIN RT_1], 8) = 0
syscall_435(0x7ffc466b4c60, 0x58, 0x58b300, 0x8, 0x7f4ad46a1640, 0x7ffc466b4d4f) = -1 (errno 1)
rt_sigprocmask(SIG_SETMASK, ~[KILL STOP RTMIN RT_1], NULL, 8) = 0
rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
write(2, "runtime/cgo: ", 13runtime/cgo: )           = 13
write(2, "pthread_create failed: Operation not permitted", 46pthread_create
failed: Operation not permitted) = 46
```

Where syscall 435 is also known as clone3:

```
$ scmp_sys_resolver 435
clone3
```