### PR TITLE
desktop: implement gtk notification backend and provide minimal notification api

### DIFF
--- a/desktop/notification/export_test.go
+++ b/desktop/notification/export_test.go
@@ -19,6 +19,32 @@
 
 package notification
 
+import "github.com/godbus/dbus"
+
 var (
-	ProcessSignal = processSignal
+	NewFdoBackend = newFdoBackend
+	NewGtkBackend = newGtkBackend
 )
+
+type FdoBackend = fdoBackend
+type GtkBackend = gtkBackend
+
+func (srv *fdoBackend) ProcessSignal(sig *dbus.Signal, observer Observer) error {
+	return srv.processSignal(sig, observer)
+}
+
+func MockNewFdoBackend(f func(conn *dbus.Conn, desktopID string) NotificationManager) (restore func()) {
+	old := newFdoBackend
+	newFdoBackend = f
+	return func() {
+		newFdoBackend = old
+	}
+}
+
+func MockNewGtkBackend(f func(conn *dbus.Conn, desktopID string) (NotificationManager, error)) (restore func()) {
+	old := newGtkBackend
+	newGtkBackend = f
+	return func() {
+		newGtkBackend = old
+	}
+}

--- a/desktop/notification/fdo.go
+++ b/desktop/notification/fdo.go
@@ -219,6 +219,9 @@ func (srv *fdoBackend) processNotificationClosed(sig *dbus.Signal, observer Obse
 	if !ok {
 		return fmt.Errorf("expected second body element to be uint32, got %T", sig.Body[1])
 	}
+
+	// we may receive signals for notifications we don't know about, silently
+	// ignore them.
 	if localID, ok := srv.serverToLocalID[id]; ok {
 		delete(srv.localToServerID, localID)
 		delete(srv.serverToLocalID, id)

--- a/desktop/notification/fdo.go
+++ b/desktop/notification/fdo.go
@@ -228,14 +228,13 @@ func (srv *fdoBackend) processNotificationClosed(sig *dbus.Signal, observer Obse
 	if !ok {
 		return fmt.Errorf("expected second body element to be uint32, got %T", sig.Body[1])
 	}
-	srv.lastRemove = timeNow()
-	localID, ok := srv.serverToLocalID[id]
-	if !ok {
-		return fmt.Errorf("unknown notification with id %q", id)
+	if localID, ok := srv.serverToLocalID[id]; ok {
+		srv.lastRemove = timeNow()
+		delete(srv.localToServerID, localID)
+		delete(srv.serverToLocalID, id)
+		return observer.NotificationClosed(localID, CloseReason(reason))
 	}
-	delete(srv.localToServerID, localID)
-	delete(srv.serverToLocalID, id)
-	return observer.NotificationClosed(localID, CloseReason(reason))
+	return nil
 }
 
 func (srv *fdoBackend) processActionInvoked(sig *dbus.Signal, observer Observer) error {

--- a/desktop/notification/fdo_test.go
+++ b/desktop/notification/fdo_test.go
@@ -58,7 +58,7 @@ func (s *fdoSuite) TearDownTest(c *C) {
 }
 
 func (s *fdoSuite) TestServerInformationSuccess(c *C) {
-	srv := notification.New(s.SessionBus)
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	name, vendor, version, specVersion, err := srv.ServerInformation()
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "name")
@@ -69,13 +69,13 @@ func (s *fdoSuite) TestServerInformationSuccess(c *C) {
 
 func (s *fdoSuite) TestServerInformationError(c *C) {
 	s.backend.SetError(&dbus.Error{Name: "org.freedesktop.DBus.Error.Failed"})
-	srv := notification.New(s.SessionBus)
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	_, _, _, _, err := srv.ServerInformation()
 	c.Assert(err, ErrorMatches, "org.freedesktop.DBus.Error.Failed")
 }
 
 func (s *fdoSuite) TestServerCapabilitiesSuccess(c *C) {
-	srv := notification.New(s.SessionBus)
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	caps, err := srv.ServerCapabilities()
 	c.Assert(err, IsNil)
 	c.Check(caps, DeepEquals, []notification.ServerCapability{"cap-foo", "cap-bar"})
@@ -83,20 +83,20 @@ func (s *fdoSuite) TestServerCapabilitiesSuccess(c *C) {
 
 func (s *fdoSuite) TestServerCapabilitiesError(c *C) {
 	s.backend.SetError(&dbus.Error{Name: "org.freedesktop.DBus.Error.Failed"})
-	srv := notification.New(s.SessionBus)
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	_, err := srv.ServerCapabilities()
 	c.Assert(err, ErrorMatches, "org.freedesktop.DBus.Error.Failed")
 }
 
 func (s *fdoSuite) TestSendNotificationSuccess(c *C) {
-	srv := notification.New(s.SessionBus)
-	id, err := srv.SendNotification(&notification.Message{
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	err := srv.SendNotification("some-id", &notification.Message{
 		AppName:       "app-name",
 		Icon:          "icon",
-		Summary:       "summary",
+		Title:         "summary",
 		Body:          "body",
+		Priority:      notification.PriorityUrgent,
 		ExpireTimeout: time.Second * 1,
-		ReplacesID:    notification.ID(42),
 		Actions: []notification.Action{
 			{ActionKey: "key-1", LocalizedText: "text-1"},
 			{ActionKey: "key-2", LocalizedText: "text-2"},
@@ -108,63 +108,76 @@ func (s *fdoSuite) TestSendNotificationSuccess(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	c.Check(s.backend.Get(uint32(id)), DeepEquals, &notificationtest.FdoNotification{
-		ID:      uint32(id),
+	c.Check(s.backend.Get(1), DeepEquals, &notificationtest.FdoNotification{
+		ID:      uint32(1),
 		AppName: "app-name",
 		Icon:    "icon",
 		Summary: "summary",
 		Body:    "body",
 		Actions: []string{"key-1", "text-1", "key-2", "text-2"},
 		Hints: map[string]dbus.Variant{
-			"hint-str":  dbus.MakeVariant("str"),
-			"hint-bool": dbus.MakeVariant(true),
+			"hint-str":      dbus.MakeVariant("str"),
+			"hint-bool":     dbus.MakeVariant(true),
+			"urgency":       dbus.MakeVariant(uint8(2)),
+			"desktop-entry": dbus.MakeVariant("desktop-id"),
 		},
 		Expires: 1000,
 	})
 }
 
 func (s *fdoSuite) TestSendNotificationWithServerDecidedExpireTimeout(c *C) {
-	srv := notification.New(s.SessionBus)
-	id, err := srv.SendNotification(&notification.Message{
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	err := srv.SendNotification("some-id", &notification.Message{
 		ExpireTimeout: notification.ServerSelectedExpireTimeout,
 	})
 	c.Assert(err, IsNil)
 
-	c.Check(s.backend.Get(uint32(id)), DeepEquals, &notificationtest.FdoNotification{
-		ID:      uint32(id),
+	c.Check(s.backend.Get(uint32(1)), DeepEquals, &notificationtest.FdoNotification{
+		ID:      uint32(1),
 		Actions: []string{},
-		Hints:   map[string]dbus.Variant{},
+		Hints: map[string]dbus.Variant{
+			"urgency":       dbus.MakeVariant(uint8(1)),
+			"desktop-entry": dbus.MakeVariant("desktop-id"),
+		},
 		Expires: -1,
 	})
 }
 
 func (s *fdoSuite) TestSendNotificationError(c *C) {
 	s.backend.SetError(&dbus.Error{Name: "org.freedesktop.DBus.Error.Failed"})
-	srv := notification.New(s.SessionBus)
-	_, err := srv.SendNotification(&notification.Message{})
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id")
+	err := srv.SendNotification("some-id", &notification.Message{})
 	c.Assert(err, ErrorMatches, "org.freedesktop.DBus.Error.Failed")
 }
 
 func (s *fdoSuite) TestCloseNotificationSuccess(c *C) {
-	srv := notification.New(s.SessionBus)
-	id, err := srv.SendNotification(&notification.Message{})
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	err := srv.SendNotification("some-id", &notification.Message{})
 	c.Assert(err, IsNil)
 
-	err = srv.CloseNotification(id)
+	err = srv.CloseNotification("some-id")
 	c.Assert(err, IsNil)
-	c.Check(s.backend.Get(uint32(id)), IsNil)
+	c.Check(s.backend.GetAll(), HasLen, 0)
 }
 
 func (s *fdoSuite) TestCloseNotificationError(c *C) {
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	err := srv.SendNotification("some-id", &notification.Message{})
+	c.Assert(err, IsNil)
 	s.backend.SetError(&dbus.Error{Name: "org.freedesktop.DBus.Error.Failed"})
-	srv := notification.New(s.SessionBus)
-	err := srv.CloseNotification(notification.ID(42))
+	err = srv.CloseNotification("some-id")
 	c.Assert(err, ErrorMatches, "org.freedesktop.DBus.Error.Failed")
+}
+
+func (s *fdoSuite) TestCloseNotificationUnknownNotification(c *C) {
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id")
+	err := srv.CloseNotification("some-id")
+	c.Assert(err, ErrorMatches, `unknown notification with id "some-id"`)
 }
 
 type testObserver struct {
 	notificationClosed func(notification.ID, notification.CloseReason) error
-	actionInvoked      func(notification.ID, string) error
+	actionInvoked      func(uint32, string) error
 }
 
 func (o *testObserver) NotificationClosed(id notification.ID, reason notification.CloseReason) error {
@@ -174,7 +187,7 @@ func (o *testObserver) NotificationClosed(id notification.ID, reason notificatio
 	return nil
 }
 
-func (o *testObserver) ActionInvoked(id notification.ID, actionKey string) error {
+func (o *testObserver) ActionInvoked(id uint32, actionKey string) error {
 	if o.actionInvoked != nil {
 		return o.actionInvoked(id, actionKey)
 	}
@@ -182,7 +195,7 @@ func (o *testObserver) ActionInvoked(id notification.ID, actionKey string) error
 }
 
 func (s *fdoSuite) TestObserveNotificationsContextAndSignalWatch(c *C) {
-	srv := notification.New(s.SessionBus)
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	signalDelivered := make(chan struct{}, 1)
@@ -191,7 +204,7 @@ func (s *fdoSuite) TestObserveNotificationsContextAndSignalWatch(c *C) {
 	wg.Add(1)
 	go func() {
 		err := srv.ObserveNotifications(ctx, &testObserver{
-			actionInvoked: func(id notification.ID, actionKey string) error {
+			actionInvoked: func(id uint32, actionKey string) error {
 				select {
 				case signalDelivered <- struct{}{}:
 				default:
@@ -218,17 +231,16 @@ func (s *fdoSuite) TestObserveNotificationsContextAndSignalWatch(c *C) {
 }
 
 func (s *fdoSuite) TestObserveNotificationsProcessingError(c *C) {
-	srv := notification.New(s.SessionBus)
-
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	signalDelivered := make(chan struct{}, 1)
 	defer close(signalDelivered)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		err := srv.ObserveNotifications(context.TODO(), &testObserver{
-			actionInvoked: func(id notification.ID, actionKey string) error {
+			actionInvoked: func(id uint32, actionKey string) error {
 				signalDelivered <- struct{}{}
-				c.Check(id, Equals, notification.ID(42))
+				c.Check(id, Equals, uint32(42))
 				c.Check(actionKey, Equals, "action-key")
 				return fmt.Errorf("boom")
 			},
@@ -252,15 +264,16 @@ func (s *fdoSuite) TestObserveNotificationsProcessingError(c *C) {
 }
 
 func (s *fdoSuite) TestProcessActionInvokedSignalSuccess(c *C) {
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	called := false
-	err := notification.ProcessSignal(&dbus.Signal{
+	err := srv.ProcessSignal(&dbus.Signal{
 		// Sender and Path are not used
 		Name: "org.freedesktop.Notifications.ActionInvoked",
 		Body: []interface{}{uint32(42), "action-key"},
 	}, &testObserver{
-		actionInvoked: func(id notification.ID, actionKey string) error {
+		actionInvoked: func(id uint32, actionKey string) error {
 			called = true
-			c.Check(id, Equals, notification.ID(42))
+			c.Check(id, Equals, uint32(42))
 			c.Check(actionKey, Equals, "action-key")
 			return nil
 		},
@@ -270,11 +283,12 @@ func (s *fdoSuite) TestProcessActionInvokedSignalSuccess(c *C) {
 }
 
 func (s *fdoSuite) TestProcessActionInvokedSignalError(c *C) {
-	err := notification.ProcessSignal(&dbus.Signal{
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	err := srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
 		Body: []interface{}{uint32(42), "action-key"},
 	}, &testObserver{
-		actionInvoked: func(id notification.ID, actionKey string) error {
+		actionInvoked: func(id uint32, actionKey string) error {
 			return fmt.Errorf("boom")
 		},
 	})
@@ -282,25 +296,26 @@ func (s *fdoSuite) TestProcessActionInvokedSignalError(c *C) {
 }
 
 func (s *fdoSuite) TestProcessActionInvokedSignalBodyParseErrors(c *C) {
-	err := notification.ProcessSignal(&dbus.Signal{
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	err := srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
 		Body: []interface{}{uint32(42), "action-key", "unexpected"},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process ActionInvoked signal: unexpected number of body elements: 3")
 
-	err = notification.ProcessSignal(&dbus.Signal{
+	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
 		Body: []interface{}{uint32(42)},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process ActionInvoked signal: unexpected number of body elements: 1")
 
-	err = notification.ProcessSignal(&dbus.Signal{
+	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
 		Body: []interface{}{uint32(42), true},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process ActionInvoked signal: expected second body element to be string, got bool")
 
-	err = notification.ProcessSignal(&dbus.Signal{
+	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
 		Body: []interface{}{true, "action-key"},
 	}, &testObserver{})
@@ -308,14 +323,18 @@ func (s *fdoSuite) TestProcessActionInvokedSignalBodyParseErrors(c *C) {
 }
 
 func (s *fdoSuite) TestProcessNotificationClosedSignalSuccess(c *C) {
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	// send a notification first
+	err := srv.SendNotification("some-id", &notification.Message{})
+	c.Assert(err, IsNil)
 	called := false
-	err := notification.ProcessSignal(&dbus.Signal{
+	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
-		Body: []interface{}{uint32(42), uint32(2)},
+		Body: []interface{}{uint32(1), uint32(2)},
 	}, &testObserver{
 		notificationClosed: func(id notification.ID, reason notification.CloseReason) error {
 			called = true
-			c.Check(id, Equals, notification.ID(42))
+			c.Check(id, Equals, notification.ID("some-id"))
 			c.Check(reason, Equals, notification.CloseReason(2))
 			return nil
 		},
@@ -325,9 +344,13 @@ func (s *fdoSuite) TestProcessNotificationClosedSignalSuccess(c *C) {
 }
 
 func (s *fdoSuite) TestProcessNotificationClosedSignalError(c *C) {
-	err := notification.ProcessSignal(&dbus.Signal{
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	// send a notification first
+	err := srv.SendNotification("some-id", &notification.Message{})
+	c.Assert(err, IsNil)
+	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
-		Body: []interface{}{uint32(42), uint32(2)},
+		Body: []interface{}{uint32(1), uint32(2)},
 	}, &testObserver{
 		notificationClosed: func(id notification.ID, reason notification.CloseReason) error {
 			return fmt.Errorf("boom")
@@ -337,25 +360,26 @@ func (s *fdoSuite) TestProcessNotificationClosedSignalError(c *C) {
 }
 
 func (s *fdoSuite) TestProcessNotificationClosedSignalBodyParseErrors(c *C) {
-	err := notification.ProcessSignal(&dbus.Signal{
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	err := srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
 		Body: []interface{}{uint32(42), uint32(2), "unexpected"},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process NotificationClosed signal: unexpected number of body elements: 3")
 
-	err = notification.ProcessSignal(&dbus.Signal{
+	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
 		Body: []interface{}{uint32(42)},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process NotificationClosed signal: unexpected number of body elements: 1")
 
-	err = notification.ProcessSignal(&dbus.Signal{
+	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
 		Body: []interface{}{uint32(42), true},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process NotificationClosed signal: expected second body element to be uint32, got bool")
 
-	err = notification.ProcessSignal(&dbus.Signal{
+	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
 		Body: []interface{}{true, uint32(2)},
 	}, &testObserver{})

--- a/desktop/notification/fdo_test.go
+++ b/desktop/notification/fdo_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/godbus/dbus"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/desktop/notification"

--- a/desktop/notification/fdo_test.go
+++ b/desktop/notification/fdo_test.go
@@ -263,6 +263,22 @@ func (s *fdoSuite) TestObserveNotificationsProcessingError(c *C) {
 	wg.Wait()
 }
 
+func (s *fdoSuite) TestProcessNotificationClosedUnknownNotificationNoError(c *C) {
+	var called bool
+	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
+	err := srv.ProcessSignal(&dbus.Signal{
+		Name: "org.freedesktop.Notifications.NotificationClosed",
+		Body: []interface{}{uint32(1), uint32(2)},
+	}, &testObserver{
+		notificationClosed: func(id notification.ID, reason notification.CloseReason) error {
+			called = true
+			return fmt.Errorf("this shouldn't get called")
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Assert(called, Equals, false)
+}
+
 func (s *fdoSuite) TestProcessActionInvokedSignalSuccess(c *C) {
 	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	called := false

--- a/desktop/notification/gtk.go
+++ b/desktop/notification/gtk.go
@@ -51,6 +51,7 @@ var newGtkBackend = func(conn *dbus.Conn, desktopID string) (NotificationManager
 		conn:      conn,
 		manager:   conn.Object(gtkBusName, gtkObjectPath),
 		desktopID: desktopID,
+		firstUse: timeNow(),
 	}
 	return b, nil
 }
@@ -75,10 +76,6 @@ func (srv *gtkBackend) IdleDuration() time.Duration {
 }
 
 func (srv *gtkBackend) SendNotification(id ID, msg *Message) error {
-	if srv.firstUse.IsZero() {
-		srv.firstUse = timeNow()
-	}
-
 	info := make(map[string]dbus.Variant)
 	if msg.Title != "" {
 		info["title"] = dbus.MakeVariant(msg.Title)

--- a/desktop/notification/gtk.go
+++ b/desktop/notification/gtk.go
@@ -39,6 +39,8 @@ type gtkBackend struct {
 var newGtkBackend = func(conn *dbus.Conn, desktopID string) (NotificationManager, error) {
 	// If the D-Bus service is not already running, assume it is
 	// not available.
+	// Use owner to verify that the return values of the method call have the
+	// types we expect, which is generally a good sanity check.
 	var owner string
 	if err := conn.BusObject().Call("org.freedesktop.DBus.GetNameOwner", 0, gtkBusName).Store(&owner); err != nil {
 		return nil, err

--- a/desktop/notification/gtk.go
+++ b/desktop/notification/gtk.go
@@ -20,8 +20,6 @@
 package notification
 
 import (
-	"time"
-
 	"github.com/godbus/dbus"
 )
 
@@ -35,7 +33,6 @@ type gtkBackend struct {
 	conn      *dbus.Conn
 	manager   dbus.BusObject
 	desktopID string
-	firstUse  time.Time
 }
 
 // TODO: support actions via session agent.
@@ -51,7 +48,6 @@ var newGtkBackend = func(conn *dbus.Conn, desktopID string) (NotificationManager
 		conn:      conn,
 		manager:   conn.Object(gtkBusName, gtkObjectPath),
 		desktopID: desktopID,
-		firstUse:  timeNow(),
 	}
 	return b, nil
 }

--- a/desktop/notification/gtk.go
+++ b/desktop/notification/gtk.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notification
+
+import (
+	"time"
+
+	"github.com/godbus/dbus"
+)
+
+const (
+	gtkBusName    = "org.gtk.Notifications"
+	gtkObjectPath = "/org/gtk/Notifications"
+	gtkInterface  = "org.gtk.Notifications"
+)
+
+type gtkBackend struct {
+	conn      *dbus.Conn
+	manager   dbus.BusObject
+	desktopID string
+	firstUse  time.Time
+}
+
+// TODO: support actions via session agent.
+var newGtkBackend = func(conn *dbus.Conn, desktopID string) (NotificationManager, error) {
+	// If the D-Bus service is not already running, assume it is
+	// not available.
+	var owner string
+	if err := conn.BusObject().Call("org.freedesktop.DBus.GetNameOwner", 0, gtkBusName).Store(&owner); err != nil {
+		return nil, err
+	}
+
+	b := &gtkBackend{
+		conn:      conn,
+		manager:   conn.Object(gtkBusName, gtkObjectPath),
+		desktopID: desktopID,
+	}
+	return b, nil
+}
+
+func gtkPriority(priority Priority) string {
+	switch priority {
+	case PriorityLow:
+		return "low"
+	case PriorityNormal:
+		return "normal"
+	case PriorityHigh:
+		return "high"
+	case PriorityUrgent:
+		return "urgent"
+	default:
+		return "normal" // default to normal
+	}
+}
+
+func (srv *gtkBackend) IdleDuration() time.Duration {
+	return timeNow().Sub(srv.firstUse)
+}
+
+func (srv *gtkBackend) SendNotification(id ID, msg *Message) error {
+	if srv.firstUse.IsZero() {
+		srv.firstUse = timeNow()
+	}
+
+	info := make(map[string]dbus.Variant)
+	if msg.Title != "" {
+		info["title"] = dbus.MakeVariant(msg.Title)
+	}
+	if msg.Body != "" {
+		info["body"] = dbus.MakeVariant(msg.Body)
+	}
+	if msg.Icon != "" {
+		info["icon"] = dbus.MakeVariant(msg.Icon)
+	}
+	info["priority"] = dbus.MakeVariant(gtkPriority(msg.Priority))
+	call := srv.manager.Call(gtkInterface+".AddNotification", 0, srv.desktopID, id, info)
+	return call.Store()
+}
+
+func (srv *gtkBackend) CloseNotification(id ID) error {
+	call := srv.manager.Call(gtkInterface+".RemoveNotification", 0, srv.desktopID, id)
+	return call.Store()
+}

--- a/desktop/notification/gtk.go
+++ b/desktop/notification/gtk.go
@@ -51,7 +51,7 @@ var newGtkBackend = func(conn *dbus.Conn, desktopID string) (NotificationManager
 		conn:      conn,
 		manager:   conn.Object(gtkBusName, gtkObjectPath),
 		desktopID: desktopID,
-		firstUse: timeNow(),
+		firstUse:  timeNow(),
 	}
 	return b, nil
 }
@@ -75,6 +75,11 @@ func (srv *gtkBackend) IdleDuration() time.Duration {
 	return timeNow().Sub(srv.firstUse)
 }
 
+type icon struct {
+	Type  string
+	Value dbus.Variant
+}
+
 func (srv *gtkBackend) SendNotification(id ID, msg *Message) error {
 	info := make(map[string]dbus.Variant)
 	if msg.Title != "" {
@@ -84,7 +89,8 @@ func (srv *gtkBackend) SendNotification(id ID, msg *Message) error {
 		info["body"] = dbus.MakeVariant(msg.Body)
 	}
 	if msg.Icon != "" {
-		info["icon"] = dbus.MakeVariant(msg.Icon)
+		icon := icon{Type: "file", Value: dbus.MakeVariant(msg.Icon)}
+		info["icon"] = dbus.MakeVariant(icon)
 	}
 	info["priority"] = dbus.MakeVariant(gtkPriority(msg.Priority))
 	call := srv.manager.Call(gtkInterface+".AddNotification", 0, srv.desktopID, id, info)

--- a/desktop/notification/gtk.go
+++ b/desktop/notification/gtk.go
@@ -71,10 +71,6 @@ func gtkPriority(priority Priority) string {
 	}
 }
 
-func (srv *gtkBackend) IdleDuration() time.Duration {
-	return timeNow().Sub(srv.firstUse)
-}
-
 type icon struct {
 	Type  string
 	Value dbus.Variant

--- a/desktop/notification/gtk_test.go
+++ b/desktop/notification/gtk_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/godbus/dbus"
+
 	"github.com/snapcore/snapd/desktop/notification"
 	"github.com/snapcore/snapd/desktop/notification/notificationtest"
 	"github.com/snapcore/snapd/testutil"

--- a/desktop/notification/gtk_test.go
+++ b/desktop/notification/gtk_test.go
@@ -1,0 +1,111 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notification_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/godbus/dbus"
+	"github.com/snapcore/snapd/desktop/notification"
+	"github.com/snapcore/snapd/desktop/notification/notificationtest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type gtkSuite struct {
+	testutil.BaseTest
+	testutil.DBusTest
+
+	backend *notificationtest.GtkServer
+}
+
+var _ = Suite(&gtkSuite{})
+
+func (s *gtkSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.DBusTest.SetUpTest(c)
+
+	backend, err := notificationtest.NewGtkServer()
+	c.Assert(err, IsNil)
+	s.AddCleanup(func() { c.Check(backend.Stop(), IsNil) })
+	s.backend = backend
+}
+
+func (s *gtkSuite) TearDownTest(c *C) {
+	s.DBusTest.TearDownTest(c)
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *gtkSuite) TestGtkNotAvailabe(c *C) {
+	s.backend.ReleaseName()
+	_, err := notification.NewGtkBackend(s.SessionBus, "desktop-id")
+	c.Assert(err, ErrorMatches, `Could not get owner of name 'org.gtk.Notifications': no such name`)
+}
+
+func (s *gtkSuite) TestSendNotificationSuccess(c *C) {
+	srv, err := notification.NewGtkBackend(s.SessionBus, "desktop-id")
+	c.Assert(err, IsNil)
+	err = srv.SendNotification("some-id", &notification.Message{
+		Title:    "some title",
+		Body:     "a body",
+		Icon:     "an icon",
+		Priority: notification.PriorityUrgent,
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(s.backend.Get("some-id"), DeepEquals, &notificationtest.GtkNotification{
+		DesktopID: "desktop-id",
+		ID:        "some-id",
+		Info: map[string]dbus.Variant{
+			"title":    dbus.MakeVariant("some title"),
+			"body":     dbus.MakeVariant("a body"),
+			"icon":     dbus.MakeVariant("an icon"),
+			"priority": dbus.MakeVariant("urgent"),
+		},
+	})
+}
+
+func (s *gtkSuite) TestSendNotificationError(c *C) {
+	s.backend.SetError(&dbus.Error{Name: "org.gtk.Notifications.Error.Failed"})
+	srv, err := notification.NewGtkBackend(s.SessionBus, "desktop-id")
+	c.Assert(err, IsNil)
+	err = srv.SendNotification("some-id", &notification.Message{})
+	c.Assert(err, ErrorMatches, "org.gtk.Notifications.Error.Failed")
+}
+
+func (s *gtkSuite) TestCloseNotificationSuccess(c *C) {
+	srv, err := notification.NewGtkBackend(s.SessionBus, "desktop-id")
+	c.Assert(err, IsNil)
+	err = srv.SendNotification("some-id", &notification.Message{})
+	c.Assert(err, IsNil)
+
+	err = srv.CloseNotification("some-id")
+	c.Assert(err, IsNil)
+	c.Check(s.backend.GetAll(), HasLen, 0)
+}
+
+func (s *gtkSuite) TestCloseNotificationError(c *C) {
+	srv, err := notification.NewGtkBackend(s.SessionBus, "desktop-id")
+	c.Assert(err, IsNil)
+	err = srv.SendNotification("some-id", &notification.Message{})
+	c.Assert(err, IsNil)
+	s.backend.SetError(&dbus.Error{Name: "org.gtk.Notifications.Error.Failed"})
+	err = srv.CloseNotification("some-id")
+	c.Assert(err, ErrorMatches, "org.gtk.Notifications.Error.Failed")
+}

--- a/desktop/notification/gtk_test.go
+++ b/desktop/notification/gtk_test.go
@@ -75,7 +75,7 @@ func (s *gtkSuite) TestSendNotificationSuccess(c *C) {
 		Info: map[string]dbus.Variant{
 			"title":    dbus.MakeVariant("some title"),
 			"body":     dbus.MakeVariant("a body"),
-			"icon":     dbus.MakeVariant("an icon"),
+			"icon":     dbus.MakeVariant([]interface{}{"file", dbus.MakeVariant("an icon")}),
 			"priority": dbus.MakeVariant("urgent"),
 		},
 	})

--- a/desktop/notification/manager.go
+++ b/desktop/notification/manager.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notification
+
+import (
+	"time"
+
+	"github.com/godbus/dbus"
+)
+
+type NotificationManager interface {
+	SendNotification(id ID, msg *Message) error
+	CloseNotification(id ID) error
+	IdleDuration() time.Duration
+}
+
+func NewNotificationManager(conn *dbus.Conn, desktopID string) NotificationManager {
+	// first try the GTK backend
+	if manager, err := newGtkBackend(conn, desktopID); err == nil {
+		return manager
+	}
+
+	// fallback to the older FDO API
+	return newFdoBackend(conn, desktopID)
+}

--- a/desktop/notification/manager.go
+++ b/desktop/notification/manager.go
@@ -20,15 +20,12 @@
 package notification
 
 import (
-	"time"
-
 	"github.com/godbus/dbus"
 )
 
 type NotificationManager interface {
 	SendNotification(id ID, msg *Message) error
 	CloseNotification(id ID) error
-	IdleDuration() time.Duration
 }
 
 func NewNotificationManager(conn *dbus.Conn, desktopID string) NotificationManager {

--- a/desktop/notification/manager_test.go
+++ b/desktop/notification/manager_test.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notification_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/godbus/dbus"
+	"github.com/snapcore/snapd/desktop/notification"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type managerSuite struct {
+	testutil.BaseTest
+	testutil.DBusTest
+}
+
+var _ = Suite(&managerSuite{})
+
+func (s *managerSuite) SetUpTest(c *C) {
+}
+
+func (s *managerSuite) TestUseGtkBackendIfAvailable(c *C) {
+	restoreGtk := notification.MockNewGtkBackend(func(conn *dbus.Conn, desktopID string) (notification.NotificationManager, error) {
+		return &notification.GtkBackend{}, nil
+	})
+	defer restoreGtk()
+
+	restoreFdo := notification.MockNewFdoBackend(func(conn *dbus.Conn, desktopID string) notification.NotificationManager {
+		c.Fatalf("fdo backend shouldn't be created")
+		return nil
+	})
+	defer restoreFdo()
+
+	mgr := notification.NewNotificationManager(s.SessionBus, "desktop-id")
+	c.Assert(mgr, NotNil)
+}
+
+func (s *managerSuite) TestFdoFallback(c *C) {
+	restoreGtk := notification.MockNewGtkBackend(func(conn *dbus.Conn, desktopID string) (notification.NotificationManager, error) {
+		c.Check(conn, NotNil)
+		c.Check(desktopID, Equals, "desktop-id")
+		return nil, fmt.Errorf("boom")
+	})
+	defer restoreGtk()
+
+	var fdo bool
+	restoreFdo := notification.MockNewFdoBackend(func(conn *dbus.Conn, desktopID string) notification.NotificationManager {
+		fdo = true
+		c.Check(conn, NotNil)
+		c.Check(desktopID, Equals, "desktop-id")
+		return notification.NewFdoBackend(conn, desktopID)
+	})
+	defer restoreFdo()
+
+	mgr := notification.NewNotificationManager(s.SessionBus, "desktop-id")
+	c.Assert(mgr, NotNil)
+	c.Assert(fdo, Equals, true)
+}

--- a/desktop/notification/notificationtest/gtk.go
+++ b/desktop/notification/notificationtest/gtk.go
@@ -1,0 +1,165 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notificationtest
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/godbus/dbus"
+	"github.com/snapcore/snapd/dbusutil"
+)
+
+const (
+	gtkBusName    = "org.gtk.Notifications"
+	gtkObjectPath = "/org/gtk/Notifications"
+	gtkInterface  = "org.gtk.Notifications"
+)
+
+type GtkNotification struct {
+	DesktopID string
+	ID        string
+	Info      map[string]dbus.Variant
+}
+
+type GtkServer struct {
+	conn *dbus.Conn
+	err  *dbus.Error
+
+	mu            sync.Mutex
+	notifications map[string]*GtkNotification
+}
+
+func NewGtkServer() (*GtkServer, error) {
+	conn, err := dbusutil.SessionBusPrivate()
+	if err != nil {
+		return nil, err
+	}
+
+	server := &GtkServer{
+		conn:          conn,
+		notifications: make(map[string]*GtkNotification),
+	}
+	conn.Export(gtkApi{server}, gtkObjectPath, gtkInterface)
+
+	reply, err := conn.RequestName(gtkBusName, dbus.NameFlagDoNotQueue)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		conn.Close()
+		return nil, fmt.Errorf("cannot obtain bus name %q", gtkBusName)
+	}
+	return server, nil
+}
+
+func (server *GtkServer) Get(id string) *GtkNotification {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	return server.notifications[id]
+}
+
+func (server *GtkServer) GetAll() []*GtkNotification {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	notifications := make([]*GtkNotification, 0, len(server.notifications))
+	for _, n := range server.notifications {
+		notifications = append(notifications, n)
+	}
+	sort.Slice(notifications, func(i, j int) bool {
+		return notifications[i].ID < notifications[j].ID
+	})
+	return notifications
+}
+
+func (server *GtkServer) ReleaseName() error {
+	if _, err := server.conn.ReleaseName(gtkBusName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (server *GtkServer) Stop() error {
+	if _, err := server.conn.ReleaseName(gtkBusName); err != nil {
+		return err
+	}
+	return server.conn.Close()
+}
+
+// SetError sets an error to be returned by the D-Bus interface.
+//
+// If not nil, all the gtkApi methods will return the provided error
+// in place of performing their usual task.
+func (server *GtkServer) SetError(err *dbus.Error) {
+	server.err = err
+}
+
+func (server *GtkServer) Close(id string) error {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	if _, ok := server.notifications[id]; !ok {
+		return fmt.Errorf("no such notification: %s", id)
+	}
+	delete(server.notifications, id)
+
+	// XXX: does real server emit any signal like with fdo?
+	return nil
+}
+
+type gtkApi struct {
+	server *GtkServer
+}
+
+func (a gtkApi) AddNotification(desktopID, id string, info map[string]dbus.Variant) *dbus.Error {
+	if a.server.err != nil {
+		return a.server.err
+	}
+
+	a.server.mu.Lock()
+	defer a.server.mu.Unlock()
+
+	notification := &GtkNotification{
+		ID:        id,
+		DesktopID: desktopID,
+		Info:      info,
+	}
+	a.server.notifications[id] = notification
+	return nil
+}
+
+func (a gtkApi) RemoveNotification(desktopId, id string) *dbus.Error {
+	if a.server.err != nil {
+		return a.server.err
+	}
+
+	if err := a.server.Close(id); err != nil {
+		return &dbus.Error{
+			Name: "org.gtk.Notifications.Failed",
+			Body: []interface{}{err.Error()},
+		}
+	}
+	return nil
+}

--- a/desktop/notification/notificationtest/gtk.go
+++ b/desktop/notification/notificationtest/gtk.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/godbus/dbus"
+
 	"github.com/snapcore/snapd/dbusutil"
 )
 

--- a/desktop/notification/notify.go
+++ b/desktop/notification/notify.go
@@ -28,8 +28,6 @@ import (
 	"time"
 )
 
-var timeNow = time.Now
-
 // Message describes a single notification message.
 //
 // The notification should be related to a specific application, as indicated by

--- a/desktop/notification/notify.go
+++ b/desktop/notification/notify.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2020-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,14 +17,18 @@
  *
  */
 
-// Package notification implements bindings to D-Bus notification
+// Package notification implements bindings to FDO D-Bus notification
 // specification, version 1.2, as documented at https://developer.gnome.org/notification-spec/
+// and GTK notification API. Appropriate notification backend is determined at
+// runtime.
 package notification
 
 import (
 	"fmt"
 	"time"
 )
+
+var timeNow = time.Now
 
 // Message describes a single notification message.
 //
@@ -44,12 +48,6 @@ import (
 // timeout is -1 a message expires after a server-defined duration which may
 // vary for the type of the notification message sent.
 //
-// A notification may replace an existing notification by setting the ReplacesID
-// to a non-zero value. This only works if the notification server was not
-// re-started and should be used for as long as the sender process is alive, as
-// sending the identifier across session startup boundary has no chance of
-// working correctly.
-//
 // A notification may optionally carry a number of hints that further customize it
 // in a specific way. Refer to various hint constructors for details.
 //
@@ -65,13 +63,24 @@ import (
 type Message struct {
 	AppName       string
 	Icon          string
-	Summary       string
+	Title         string
 	Body          string
 	ExpireTimeout time.Duration // Effective resolution in milliseconds with 31-bit range.
-	ReplacesID    ID
+	Priority      Priority
 	Actions       []Action
-	Hints         []Hint
+
+	// XXX: only useful for fdo, should we drop it or rename to FdoHints?
+	Hints []Hint
 }
+
+type Priority uint32
+
+const (
+	PriorityNormal Priority = iota
+	PriorityLow
+	PriorityHigh
+	PriorityUrgent
+)
 
 // ServerSelectedExpireTimeout requests the server to pick an expiration timeout
 // appropriate for the message type.
@@ -82,7 +91,7 @@ const ServerSelectedExpireTimeout = time.Millisecond * -1
 // Notifications with known identifiers can be closed or updated. The identifier
 // is valid within one desktop session and should not be used unless the calling
 // process initially sent the message.
-type ID uint32
+type ID string
 
 // Action describes a single notification action.
 //
@@ -148,5 +157,6 @@ type Observer interface {
 	NotificationClosed(id ID, reason CloseReason) error
 	// ActionInvoked is caliled when one of the notification message actions is
 	// clicked by the user.
-	ActionInvoked(id ID, actionKey string) error
+	// XXX: revisit, should we return id at all? Remap to ID?
+	ActionInvoked(id uint32, actionKey string) error
 }

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -249,9 +249,7 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 		})
 	}
 
-	// TODO: support desktop-specific notification APIs if they provide a better
-	// experience. For example, the GNOME notification API.
-	// XXX: should be instantiated once on startup as for fdoBackend it keeps
+	// TODO: should be instantiated once on startup as for fdoBackend it keeps
 	// notification mappings.
 	notifySrv := notification.NewNotificationManager(c.s.bus, "io.snapcraft.SessionAgent")
 
@@ -300,7 +298,7 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 
 	// TODO: silently ignore error returned when the notification server does not exist.
 	// TODO: track returned notification ID and respond to actions, if supported.
-	if err := notifySrv.SendNotification(notification.ID(refreshInfo.InstanceName), msg); err != nil {
+	if err := notifySrv.SendNotification(notification.ID(fmt.Sprintf("refresh:%s", refreshInfo.InstanceName)), msg); err != nil {
 		return SyncResponse(&resp{
 			Type:   ResponseTypeError,
 			Status: 500,


### PR DESCRIPTION
Implement a simple gtk-based notification api backend and provie simple NotificationManager interface for both the new gtk backend and existing fdo implementation, as outlined by @jhenstridge here: https://forum.snapcraft.io/t/a-desktop-notifications-client-api-for-snapd/25063 ; based on old prototype from James (thank you!). 

A couple of high level remarks:
- one of the main ideas of the new approach is to use snap-name based notification ids that are internally remapped by fdoBackend to and from the IDs used by fdo notifications; gtk notifications are stateless on the client side so this is much simpler. This will let us avoid duplicate notifications about same snap.
- the existing fdo backend implements functions to cover aspects of the fdo that we are not aiming to use atm, so they aren't exposed when using the minimal NotificationManager interface. I've kept them in the code for later.
-  related to the above and to the above design, actions are not supported yet.

TODOs for followup(s):
- instantiate notification manager close to usersession agent startup (to keep it around).
- create go routine to observe "notification close" signal for fdo backend (most likely using already existing ObserveNotifications).
- handle idle timeout for the agent, based on notifications we need to wait for.
