### PR TITLE
o/snapstate: prevent install hang if prereq install fails

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -317,7 +317,12 @@ func (m *SnapManager) installOneBaseOrRequired(t *state.Task, snapName string, c
 	// something might have triggered an explicit install while
 	// the state was unlocked -> deal with that here by simply
 	// retrying the operation.
-	if _, ok := err.(*ChangeConflictError); ok {
+	if conflErr, ok := err.(*ChangeConflictError); ok {
+		// conflicted with an install in the same change, just skip
+		if conflErr.ChangeID == t.Change().ID() {
+			return nil, nil
+		}
+
 		return nil, &state.Retry{After: prerequisitesRetryTimeout}
 	}
 	return ts, err

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4097,3 +4097,40 @@ func (s *snapmgrTestSuite) TestHasAllContentAttributes(c *C) {
 	_, err = snapstate.HasAllContentAttrs(s.state, "some-snap", []string{"some"})
 	c.Assert(err.Error(), Equals, `expected 'content' attribute of slot 'bad-content-slot' (snap: 'some-snap') to be string but was int`)
 }
+
+func (s *snapmgrTestSuite) TestInstallPrereqIgnoreConflictInSameChange(c *C) {
+	s.state.Lock()
+	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
+
+	repo := interfaces.NewRepository()
+	ifacerepo.Replace(s.state, repo)
+
+	prodInfo := &snap.SideInfo{
+		RealName: "snap-content-slot",
+		SnapID:   "snap-content-slot-id",
+		Revision: snap.R(1),
+	}
+
+	chg := s.state.NewChange("install", "")
+
+	// To make the test deterministic, we inject a conflicting task to simulate
+	// an InstallMany({snap-content-plug, snap-content-slot}) with a failing snap-content-slot
+	conflTask := s.state.NewTask("conflicting-task", "test: conflicting task")
+	conflTask.Set("snap-setup", &snapstate.SnapSetup{SideInfo: prodInfo})
+	chg.AddTask(conflTask)
+
+	installTasks, err := snapstate.Install(context.Background(), s.state, "snap-content-plug", nil, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Check(installTasks.Tasks(), Not(HasLen), 0)
+	chg.AddAll(installTasks)
+
+	s.state.Unlock()
+	s.settle(c)
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// check that the prereq task wasn't retried
+	prereqTask := findStrictlyOnePrereqTask(c, chg)
+	c.Check(prereqTask.Status(), Equals, state.DoneStatus)
+	c.Assert(prereqTask.AtTime().IsZero(), Equals, true)
+}


### PR DESCRIPTION
This PR prevents an install from hanging when its prerequisite has a duplicate install in the same change that fails. The following situation would trigger the bug: 
* `snap install A B` (where A depends on B)
* B's independent (i.e., not as a prerequisite) install fails
* A's installation starts and installs B as a prerequisite
* B's install checks for conflicts and fails, because the conflict checking code looks for a task affecting B that belongs to a change with tasks to be done (the previous install of B meets the criteria)
* The conflict error causes the prerequisite task to be retried after a timeout which causes the install be stuck in this loop, since the conflict is never "fixed"

One caveat: the check just skips without returning an error so A's install will proceed even though the other installed also failed (and B isn't installed). However, returning an error didn't seem right because there might be a situation where the install of the prerequisite conflicts with another install which hasn't completed but will succeed. Since the content provider is a soft dependency I thought it was more correct to just skip