### PR TITLE
o/snapstate: improve install/update tests

### DIFF
--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -586,7 +586,6 @@ func (s *snapmgrTestSuite) TestInstallStrictIgnoresClassic(c *C) {
 	defer restore()
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	opts := &snapstate.RevisionOptions{Channel: "channel-for-strict"}
 	ts, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{Classic: true})
@@ -601,6 +600,7 @@ func (s *snapmgrTestSuite) TestInstallStrictIgnoresClassic(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.IsReady(), Equals, true)
@@ -618,7 +618,6 @@ func (s *snapmgrTestSuite) TestInstallSnapWithDefaultTrack(c *C) {
 	defer restore()
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	opts := &snapstate.RevisionOptions{Channel: "candidate"}
 	ts, err := snapstate.Install(context.Background(), s.state, "some-snap-with-default-track", opts, s.user.ID, snapstate.Flags{})
@@ -631,6 +630,7 @@ func (s *snapmgrTestSuite) TestInstallSnapWithDefaultTrack(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.IsReady(), Equals, true)
@@ -647,7 +647,6 @@ func (s *snapmgrTestSuite) TestInstallIgnoreValidation(c *C) {
 	defer restore()
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	ts, err := snapstate.Install(context.Background(), s.state, "some-snap", nil, s.user.ID, snapstate.Flags{IgnoreValidation: true})
 	c.Assert(err, IsNil)
@@ -659,6 +658,7 @@ func (s *snapmgrTestSuite) TestInstallIgnoreValidation(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.IsReady(), Equals, true)
@@ -674,7 +674,6 @@ func (s *snapmgrTestSuite) TestInstallManySnapOneWithDefaultTrack(c *C) {
 	defer restore()
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapNames := []string{"some-snap", "some-snap-with-default-track"}
 	installed, tss, err := snapstate.InstallMany(s.state, snapNames, s.user.ID)
@@ -690,6 +689,7 @@ func (s *snapmgrTestSuite) TestInstallManySnapOneWithDefaultTrack(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.IsReady(), Equals, true)
@@ -798,7 +798,6 @@ func (s *snapmgrTestSuite) TestInstallPathStrictIgnoresClassic(c *C) {
 	defer restore()
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	mockSnap := makeTestSnap(c, `name: some-snap
 version: 1.0
@@ -817,6 +816,7 @@ confinement: strict
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.IsReady(), Equals, true)
@@ -830,7 +830,6 @@ confinement: strict
 
 func (s *snapmgrTestSuite) TestInstallPathAsRefresh(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
@@ -860,6 +859,7 @@ epoch: 1
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.IsReady(), Equals, true)
@@ -917,7 +917,6 @@ func (s *snapmgrTestSuite) TestInstallPathFailsEarlyOnEpochMismatch(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	// we start without the auxiliary store info
 	c.Check(snapstate.AuxStoreInfoFilename("some-snap-id"), testutil.FileAbsent)
@@ -932,6 +931,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -1095,7 +1095,6 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.parallel-instances", true)
@@ -1110,6 +1109,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 	s.state.Unlock()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -1275,7 +1275,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	chg := s.state.NewChange("install", "install a snap")
 	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
@@ -1296,6 +1295,7 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	mountTask := tasks[len(tasks)-11]
 	c.Assert(mountTask.Kind(), Equals, "mount-snap")
@@ -1432,7 +1432,6 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	chg := s.state.NewChange("install", "install a snap")
 	opts := &snapstate.RevisionOptions{Channel: "some-channel", CohortKey: "scurries"}
@@ -1444,6 +1443,7 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -1599,7 +1599,6 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	chg := s.state.NewChange("install", "install a snap")
 	opts := &snapstate.RevisionOptions{Channel: "some-channel", Revision: snap.R(42)}
@@ -1611,6 +1610,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -1760,7 +1760,6 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallStartOrder(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	chg := s.state.NewChange("install", "install a snap")
 	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
@@ -1772,6 +1771,7 @@ func (s *snapmgrTestSuite) TestInstallStartOrder(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -1813,7 +1813,6 @@ func (s *snapmgrTestSuite) TestInstallFirstLocalRunThrough(c *C) {
 	defer restoreInstallSize()
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	mockSnap := makeTestSnap(c, `name: mock
 version: 1.0`)
@@ -1830,6 +1829,7 @@ version: 1.0`)
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	expected := fakeOps{
 		{
@@ -1919,7 +1919,6 @@ func (s *snapmgrTestSuite) TestInstallSubsequentLocalRunThrough(c *C) {
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "mock", &snapstate.SnapState{
 		Active: true,
@@ -1943,6 +1942,7 @@ epoch: 1*
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	expected := fakeOps{
 		{
@@ -2039,7 +2039,6 @@ func (s *snapmgrTestSuite) TestInstallOldSubsequentLocalRunThrough(c *C) {
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "mock", &snapstate.SnapState{
 		Active: true,
@@ -2063,6 +2062,7 @@ epoch: 1*
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	expected := fakeOps{
 		{
@@ -2144,7 +2144,6 @@ func (s *snapmgrTestSuite) TestInstallPathWithMetadataRunThrough(c *C) {
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	someSnap := makeTestSnap(c, `name: orig-name
 version: 1.0`)
@@ -2163,6 +2162,7 @@ version: 1.0`)
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure only local install was run, i.e. first actions are pseudo-action current
 	c.Assert(s.fakeBackend.ops.Ops(), HasLen, 9)
@@ -2235,7 +2235,6 @@ func (s *snapmgrTestSuite) TestInstallPathSkipConfigure(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	// pretend we don't have core
 	snapstate.Set(s.state, "core", nil)
@@ -2250,6 +2249,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -2454,7 +2454,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	restore := snapstate.MockPrerequisitesRetryTimeout(10 * time.Millisecond)
 	defer restore()
@@ -2478,6 +2477,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran and core was only installed once
 	c.Assert(chg1.Err(), IsNil)
@@ -2498,7 +2498,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	// slightly longer retry timeout to avoid deadlock when we
 	// trigger a retry quickly that the link snap for core does
@@ -2574,8 +2573,9 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 			Channel:  "",
 			Revision: snap.R(21),
 		})
-
 	}
+
+	s.state.Unlock()
 }
 
 type behindYourBackStore struct {
@@ -2636,7 +2636,6 @@ func (s behindYourBackStore) SnapAction(ctx context.Context, currentSnaps []*sto
 // this is actually what happens.
 func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	restore := snapstate.MockPrerequisitesRetryTimeout(10 * time.Millisecond)
 	defer restore()
@@ -2683,6 +2682,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 	c.Assert(chg.IsReady(), Equals, true)
 
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -2714,7 +2714,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
 
@@ -2731,6 +2730,7 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -2878,7 +2878,6 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallDefaultProviderCompat(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
 
@@ -2895,6 +2894,7 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderCompat(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -3215,7 +3215,6 @@ func (s *snapmgrTestSuite) TestInstallFailsWhenClassicSnapsAreNotSupported(c *C)
 
 func (s *snapmgrTestSuite) TestInstallUndoRunThroughUndoContextOptional(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	chg := s.state.NewChange("install", "install a snap")
 	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
@@ -3236,6 +3235,7 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughUndoContextOptional(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	mountTask := tasks[len(tasks)-11]
 	c.Assert(mountTask.Kind(), Equals, "mount-snap")
@@ -3245,7 +3245,6 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughUndoContextOptional(c *C) {
 
 func (s *snapmgrTestSuite) TestInstallDefaultProviderCircular(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
 
@@ -3262,6 +3261,7 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderCircular(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
@@ -3387,7 +3387,6 @@ func verifyStopReason(c *C, ts *state.TaskSet, reason string) {
 
 func (s *snapmgrTestSuite) TestUndoMountSnapFailsInCopyData(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	chg := s.state.NewChange("install", "install a snap")
 	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
@@ -3401,6 +3400,7 @@ func (s *snapmgrTestSuite) TestUndoMountSnapFailsInCopyData(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	expected := fakeOps{
 		{
@@ -3475,7 +3475,6 @@ func (s *snapmgrTestSuite) TestUndoMountSnapFailsInCopyData(c *C) {
 
 func (s *snapmgrTestSuite) TestSideInfoPaid(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 	opts := &snapstate.RevisionOptions{Channel: "channel-for-paid"}
 	ts, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
@@ -3487,6 +3486,7 @@ func (s *snapmgrTestSuite) TestSideInfoPaid(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// verify snap has paid sideinfo
 	var snapst snapstate.SnapState
@@ -3498,7 +3498,6 @@ func (s *snapmgrTestSuite) TestSideInfoPaid(c *C) {
 
 func (s *snapmgrTestSuite) TestSideInfoPrivate(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 	opts := &snapstate.RevisionOptions{Channel: "channel-for-private"}
 	ts, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
@@ -3510,6 +3509,7 @@ func (s *snapmgrTestSuite) TestSideInfoPrivate(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// verify snap has private sideinfo
 	var snapst snapstate.SnapState
@@ -3673,7 +3673,6 @@ volumes:
 
 func (s *snapmgrTestSuite) TestInstallContentProviderDownloadFailure(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	// trigger download error on content provider
 	s.fakeStore.downloadError["snap-content-slot"] = fmt.Errorf("boom")
@@ -3693,6 +3692,7 @@ func (s *snapmgrTestSuite) TestInstallContentProviderDownloadFailure(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Err(), ErrorMatches, "cannot perform the following tasks:\n.*Download snap \"snap-content-slot\" \\(11\\) from channel \"stable\" \\(boom\\).*")
 	c.Assert(chg.IsReady(), Equals, true)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -86,7 +86,24 @@ type snapmgrTestSuite struct {
 
 func (s *snapmgrTestSuite) settle(c *C) {
 	err := s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
-	c.Assert(err, IsNil)
+	if err != nil {
+		c.Error(err)
+		s.logTasks(c)
+		c.FailNow()
+	}
+}
+
+func (s *snapmgrTestSuite) logTasks(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	for _, chg := range s.state.Changes() {
+		c.Logf("\nChange %q (%s):", chg.Summary(), chg.Status())
+
+		for _, t := range chg.Tasks() {
+			c.Logf("\t%s - %s", t.Summary(), t.Status())
+		}
+	}
 }
 
 var _ = Suite(&snapmgrTestSuite{})

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -117,7 +117,6 @@ func verifyUpdateTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.St
 
 func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 	restore := release.MockOnClassic(false)
 	defer restore()
 
@@ -142,6 +141,7 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure garbage collection runs as the last tasks
 	expectedTail := fakeOps{
@@ -207,7 +207,6 @@ func (s *snapmgrTestSuite) testUpdateScenario(c *C, desc string, t switchScenari
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Sequence:        []*snap.SideInfo{&si},
@@ -229,6 +228,7 @@ func (s *snapmgrTestSuite) testUpdateScenario(c *C, desc string, t switchScenari
 	s.state.Unlock()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// switch is not really really doing anything backend related
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, []string{
@@ -324,7 +324,6 @@ func (s *snapmgrTestSuite) TestUpdateCanDoBackwards(c *C) {
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
@@ -342,6 +341,7 @@ func (s *snapmgrTestSuite) TestUpdateCanDoBackwards(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 	expected := fakeOps{
 		{
 			op:   "remove-snap-aliases",
@@ -416,7 +416,6 @@ type opSeqOpts struct {
 // check the revision sequence is as in `after`.
 func (s *snapmgrTestSuite) testOpSequence(c *C, opts *opSeqOpts) (*snapstate.SnapState, *state.TaskSet) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	seq := make([]*snap.SideInfo, len(opts.before))
 	for i, n := range opts.before {
@@ -468,6 +467,7 @@ func (s *snapmgrTestSuite) testOpSequence(c *C, opts *opSeqOpts) (*snapstate.Sna
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
@@ -713,7 +713,6 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, &si)
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -732,6 +731,7 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{{
@@ -852,7 +852,6 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	defer restoreTimeNow()
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
 		Active:          true,
@@ -875,6 +874,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	expected := fakeOps{
 		{
@@ -1141,7 +1141,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 	defer r()
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.parallel-instances", true)
@@ -1164,6 +1163,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 	s.state.Unlock()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	expected := fakeOps{
 		{
@@ -1357,7 +1357,6 @@ func (s *snapmgrTestSuite) TestUpdateWithNewBase(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -1376,6 +1375,7 @@ func (s *snapmgrTestSuite) TestUpdateWithNewBase(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
 		{macaroon: s.user.StoreMacaroon, name: "some-base", target: filepath.Join(dirs.SnapBlobDir, "some-base_11.snap")},
@@ -1392,7 +1392,6 @@ func (s *snapmgrTestSuite) TestUpdateWithAlreadyInstalledBase(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -1422,6 +1421,7 @@ func (s *snapmgrTestSuite) TestUpdateWithAlreadyInstalledBase(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
 		{macaroon: s.user.StoreMacaroon, name: "some-snap", target: filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap")},
@@ -1430,7 +1430,6 @@ func (s *snapmgrTestSuite) TestUpdateWithAlreadyInstalledBase(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateWithNewDefaultProvider(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
 	repo := interfaces.NewRepository()
@@ -1459,6 +1458,7 @@ func (s *snapmgrTestSuite) TestUpdateWithNewDefaultProvider(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
 		{macaroon: s.user.StoreMacaroon, name: "snap-content-plug", target: filepath.Join(dirs.SnapBlobDir, "snap-content-plug_11.snap")},
@@ -1468,7 +1468,6 @@ func (s *snapmgrTestSuite) TestUpdateWithNewDefaultProvider(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateWithInstalledDefaultProvider(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
 	repo := interfaces.NewRepository()
@@ -1520,6 +1519,7 @@ func (s *snapmgrTestSuite) TestUpdateWithInstalledDefaultProvider(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
 		{macaroon: s.user.StoreMacaroon, name: "snap-content-plug", target: filepath.Join(dirs.SnapBlobDir, "snap-content-plug_11.snap")},
@@ -1528,7 +1528,6 @@ func (s *snapmgrTestSuite) TestUpdateWithInstalledDefaultProvider(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateRememberedUserRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
@@ -1549,6 +1548,7 @@ func (s *snapmgrTestSuite) TestUpdateRememberedUserRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 	c.Assert(chg.Err(), IsNil)
@@ -1587,7 +1587,6 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 	defer r()
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	r1 := snapstatetest.MockDeviceModel(ModelWithKernelTrack("18"))
 	defer r1()
@@ -1607,6 +1606,7 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 
@@ -1690,7 +1690,6 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
@@ -1732,6 +1731,7 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 	c.Assert(chg.Err(), IsNil)
@@ -1798,7 +1798,6 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
@@ -1840,6 +1839,7 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 	c.Assert(chg.Err(), IsNil)
@@ -1925,7 +1925,6 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserWithNoStoreAuthRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
@@ -1967,6 +1966,7 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserWithNoStoreAuthRunThro
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 	c.Assert(chg.Err(), IsNil)
@@ -2041,7 +2041,6 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
@@ -2061,6 +2060,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	expected := fakeOps{
 		{
@@ -2245,7 +2245,6 @@ func (s *snapmgrTestSuite) TestUpdateUndoRestoresRevisionConfig(c *C) {
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -2278,6 +2277,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRestoresRevisionConfig(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
 	c.Check(errorTaskExecuted, Equals, true)
@@ -2291,7 +2291,6 @@ func (s *snapmgrTestSuite) TestUpdateUndoRestoresRevisionConfig(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateMakesConfigSnapshot(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
@@ -2321,6 +2320,7 @@ func (s *snapmgrTestSuite) TestUpdateMakesConfigSnapshot(c *C) {
 	s.settle(c)
 
 	s.state.Lock()
+	defer s.state.Unlock()
 	cfgs = nil
 	// config copy of rev. 1 has been made
 	c.Assert(s.state.Get("revision-config", &cfgs), IsNil)
@@ -2339,7 +2339,6 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -2369,6 +2368,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	expected := fakeOps{
 		{
@@ -2551,7 +2551,6 @@ func (s *snapmgrTestSuite) TestUpdateSameRevision(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateToRevisionRememberedUserRunThrough(c *C) {
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
@@ -2572,6 +2571,7 @@ func (s *snapmgrTestSuite) TestUpdateToRevisionRememberedUserRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 	c.Assert(chg.Err(), IsNil)
@@ -2713,7 +2713,6 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -2731,6 +2730,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	expected := fakeOps{
 		// we just expect the "storesvc-snap-action" ops, we
@@ -2856,7 +2856,6 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidationRunThroug
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -2875,6 +2874,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidationRunThroug
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// verify snapSetup info
 	var snapsup snapstate.SnapSetup
@@ -2983,7 +2983,6 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
@@ -3145,6 +3144,7 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	snapst = snapstate.SnapState{}
 	err = snapstate.Get(s.state, "some-snap", &snapst)
@@ -3161,7 +3161,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateIgnoreValidationSticky(c *C
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.parallel-instances", true)
@@ -3238,6 +3237,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateIgnoreValidationSticky(c *C
 	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
+	defer s.state.Unlock()
 
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)


### PR DESCRIPTION
I've noticed that it's a bit cumbersome to debug behaviour related to retrying and tasks in the install and update tests. First, most tests lock the state at the beginning and defer an unlock but then unlock again before the call to Settle(). However, if the call to Settle() fails then the test panics because the deferred statement unlocks and already unlocked lock. This hides the true failure and forces us to change the test and re-run it to get the real failure. Second, if the test fails to Settle(), it just logs that the settle failed to converge. There's no information on which tasks were running and their statuses.
This PR changing the occurrences of `defer state.Unlock()` in snapstate_update_test.go and snapstate_install_test.go and also logs tasks and their statuses if the settle() fails.