### PR TITLE
tests: use the latest cpu family for nested tests execution

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -168,6 +168,7 @@ backends:
         location: snapd-spread/us-east1-b
         plan: n2-standard-2
         halt-timeout: 2h
+        cpu-family: 'Intel Cascade Lake'
         systems:
             - ubuntu-16.04-64:
                   image: ubuntu-1604-64-virt-enabled


### PR DESCRIPTION
This is possible due to the new change merged in spread to select the cpu to execute the tests.

Available options are:

Intel Xeon E5 (Sandy Bridge): "Intel Sandy Bridge" -> 2011
Intel Xeon E5 v2 (Ivy Bridge): "Intel Ivy Bridge" -> 2012
Intel Xeon E5 v3 (Haswell): "Intel Haswell" -> 2013
Intel Xeon E5 v4 (Broadwell): "Intel Broadwell" -> 2014
Intel Xeon (Skylake): "Intel Skylake" -> 2015
Intel Xeon (Cascade Lake): "Intel Cascade Lake" -> 2019