### PR TITLE
spread: use `bios: uefi` for uc20

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -226,7 +226,7 @@ backends:
                   image: ubuntu-20.04-64
                   username: ubuntu
                   password: ubuntu
-                  flags: [virtio]
+                  bios: uefi
             - ubuntu-18.04-64:
                   username: ubuntu
                   password: ubuntu


### PR DESCRIPTION
Spread has now "official" support for UEFI boot, see: https://github.com/snapcore/spread/pull/116

This commit updates the UC20 qemu spread system so that this is now used.