### PR TITLE
tests: reset some mount units failing on ubuntu impish

### DIFF
--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -30,8 +30,7 @@ execute: |
             ;;
         ubuntu-21.10-64)
             # Some mount units failing which are installed in the prebuilt image 
-            systemctl reset-failed snap-google-cloud-sdk-*.mount
-            systemctl reset-failed snap-lxd-*.mount
+            systemctl reset-failed --type mount
             ;;
     esac
 


### PR DESCRIPTION
Some mount units failing which are installed in the prebuilt image

