### PR TITLE
osutil/disks: add Partition struct and Disks.Partitions()

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -62,6 +62,9 @@ type Disk interface {
 	// does not have partitions for example.
 	HasPartitions() bool
 
+	// Partitions returns all partitions found on a physical disk device.
+	Partitions() ([]Partition, error)
+
 	// KernelDeviceNode returns the full device node path in /dev/ for the disk
 	// such as /dev/mmcblk0 or /dev/vda.
 	KernelDeviceNode() string
@@ -69,6 +72,30 @@ type Disk interface {
 	// KernelDevicePath returns the full device path in /sys/devices for the
 	// disk such as /sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda/.
 	KernelDevicePath() string
+}
+
+// Partition represents a partition on a Disk device.
+type Partition struct {
+	// FilesystemLabel is the encoded filesystem label, this should only be
+	// compared with normal Go strings that are encoded with BlkIDEncodeLabel.
+	FilesystemLabel string
+	// FilesystemUUID is the encoded filesystem UUID, this should be compared
+	// with normal Go strings that are encoded with BlkIDEncodeLabel.
+	FilesystemUUID string
+	// PartitionLabel is the encoded partition label, this should only be
+	// compared with normal Go strings that are encoded with BlkIDEncodeLabel.
+	PartitionLabel string
+	// the partition UUID
+	PartitionUUID string
+	// Major is the major number for this partition.
+	Major int
+	// Minor is the minor number for this partition.
+	Minor int
+	// KernelDevicePath is the kernel device path for this device in /sys for
+	// this partition.
+	KernelDevicePath string
+	// KernelDeviceNode is the kernel device node in /dev.
+	KernelDeviceNode string
 }
 
 // PartitionNotFoundError is an error where a partition matching the SearchType

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -188,16 +188,22 @@ var diskFromDeviceName = func(deviceName string) (Disk, error) {
 	return diskFromUdevProps(deviceName, "name", props)
 }
 
+func (d *disk) Partitions() ([]Partition, error) {
+	if !d.hasPartitions {
+		// for i.e. device mapper disks which don't have partitions
+		return nil, nil
+	}
+	if err := d.populatePartitions(); err != nil {
+		return nil, err
+	}
+
+	return d.partitions, nil
+}
+
 // DiskFromMountPoint finds a matching Disk for the specified mount point.
 func DiskFromMountPoint(mountpoint string, opts *Options) (Disk, error) {
 	// call the unexported version that may be mocked by tests
 	return diskFromMountPoint(mountpoint, opts)
-}
-
-type partition struct {
-	fsLabel   string
-	partLabel string
-	partUUID  string
 }
 
 type disk struct {
@@ -214,7 +220,7 @@ type disk struct {
 	// partitions is the set of discovered partitions for the disk, each
 	// partition must have a partition uuid, but may or may not have either a
 	// partition label or a filesystem label
-	partitions []partition
+	partitions []Partition
 
 	// whether the disk device has partitions, and thus is of type "disk", or
 	// whether the disk device is a volume that is not a physical disk
@@ -354,7 +360,7 @@ func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
 	}
 
 	// ID_PART_ENTRY_DISK will give us the major and minor of the disk that this
-	// partition originated from
+	// partition originated from if this mount point is indeed for a partition
 	if majorMinor, ok := props["ID_PART_ENTRY_DISK"]; ok {
 		maj, min, err := parseDeviceMajorMinor(majorMinor)
 		if err != nil {
@@ -408,7 +414,7 @@ func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
 
 func (d *disk) populatePartitions() error {
 	if d.partitions == nil {
-		d.partitions = []partition{}
+		d.partitions = []Partition{}
 
 		// step 1. using the devpath for the disk, glob for matching devices
 		//         using the devname in that sysfs directory
@@ -434,7 +440,7 @@ func (d *disk) populatePartitions() error {
 		sort.Strings(paths)
 
 		for _, path := range paths {
-			part := partition{}
+			part := Partition{}
 
 			// check if this device is a partition - note that the mere
 			// existence of this file is sufficient to indicate that it is a
@@ -455,22 +461,46 @@ func (d *disk) populatePartitions() error {
 				continue
 			}
 
+			// the devpath should always be available
+			devpath, ok := udevProps["DEVPATH"]
+			if !ok {
+				return fmt.Errorf("cannot get udev properties for device %s (a partition of %s), missing required udev property \"DEVPATH\"", partDev, d.Dev())
+			}
+			part.KernelDevicePath = filepath.Join(dirs.SysfsDir, devpath)
+
+			devname, ok := udevProps["DEVNAME"]
+			if !ok {
+				return fmt.Errorf("cannot get udev properties for device %s (a partition of %s), missing required udev property \"DEVNAME\"", partDev, d.Dev())
+			}
+			part.KernelDeviceNode = devname
+
 			// we should always have the partition uuid, and we may not have
 			// either the partition label or the filesystem label, on GPT disks
 			// the partition label is optional, and may or may not have a
 			// filesystem on the partition, on MBR we will never have a
 			// partition label, and we also may or may not have a filesystem on
 			// the partition
-			part.partUUID = udevProps["ID_PART_ENTRY_UUID"]
-			if part.partUUID == "" {
+			part.PartitionUUID = udevProps["ID_PART_ENTRY_UUID"]
+			if part.PartitionUUID == "" {
 				return fmt.Errorf("cannot get udev properties for device %s (a partition of %s), missing udev property \"ID_PART_ENTRY_UUID\"", partDev, d.Dev())
+			}
+
+			// we should also always have the device major/minor for this device
+			part.Major, err = strconv.Atoi(udevProps["MAJOR"])
+			if err != nil {
+				return fmt.Errorf("cannot parse device major number format: %v", err)
+			}
+
+			part.Minor, err = strconv.Atoi(udevProps["MINOR"])
+			if err != nil {
+				return fmt.Errorf("cannot parse device major number format: %v", err)
 			}
 
 			// on MBR disks we may not have a partition label, so this may be
 			// the empty string. Note that this value is encoded similarly to
 			// libblkid and should be compared with normal Go strings that are
 			// encoded using BlkIDEncodeLabel.
-			part.partLabel = udevProps["ID_PART_ENTRY_NAME"]
+			part.PartitionLabel = udevProps["ID_PART_ENTRY_NAME"]
 
 			// a partition doesn't need to have a filesystem, and such may not
 			// have a filesystem label; the bios-boot partition in the amd64 pc
@@ -479,7 +509,10 @@ func (d *disk) populatePartitions() error {
 			// Note that this value is also encoded similarly to
 			// ID_PART_ENTRY_NAME and thus should only be compared with normal
 			// Go strings that are encoded with BlkIDEncodeLabel.
-			part.fsLabel = udevProps["ID_FS_LABEL_ENC"]
+			part.FilesystemLabel = udevProps["ID_FS_LABEL_ENC"]
+
+			// similar to above, this may be empty, but if non-empty is encoded
+			part.FilesystemUUID = udevProps["ID_FS_UUID_ENC"]
 
 			// prepend the partition to the front, this has the effect that if
 			// two partitions have the same label (either filesystem or
@@ -493,7 +526,7 @@ func (d *disk) populatePartitions() error {
 			// non-unique filesystem labels or non-unique partition labels (or
 			// even non-unique partition uuids)? then we would just error if we
 			// encounter a duplicated value for a partition
-			d.partitions = append([]partition{part}, d.partitions...)
+			d.partitions = append([]Partition{part}, d.partitions...)
 		}
 	}
 
@@ -507,44 +540,62 @@ func (d *disk) populatePartitions() error {
 	return nil
 }
 
-func (d *disk) FindMatchingPartitionUUIDWithPartLabel(label string) (string, error) {
+func (d *disk) FindMatchingPartitionWithPartLabel(label string) (Partition, error) {
 	// always encode the label
 	encodedLabel := BlkIDEncodeLabel(label)
 
 	if err := d.populatePartitions(); err != nil {
-		return "", err
+		return Partition{}, err
 	}
 
 	for _, p := range d.partitions {
-		if p.partLabel == encodedLabel {
-			return p.partUUID, nil
+		if p.PartitionLabel == encodedLabel {
+			return p, nil
 		}
 	}
 
-	return "", PartitionNotFoundError{
+	return Partition{}, PartitionNotFoundError{
 		SearchType:  "partition-label",
 		SearchQuery: label,
 	}
 }
 
-func (d *disk) FindMatchingPartitionUUIDWithFsLabel(label string) (string, error) {
+func (d *disk) FindMatchingPartitionWithFsLabel(label string) (Partition, error) {
 	// always encode the label
 	encodedLabel := BlkIDEncodeLabel(label)
 
 	if err := d.populatePartitions(); err != nil {
-		return "", err
+		return Partition{}, err
 	}
 
 	for _, p := range d.partitions {
-		if p.fsLabel == encodedLabel {
-			return p.partUUID, nil
+		if p.FilesystemLabel == encodedLabel {
+			return p, nil
 		}
 	}
 
-	return "", PartitionNotFoundError{
+	return Partition{}, PartitionNotFoundError{
 		SearchType:  "filesystem-label",
 		SearchQuery: label,
 	}
+}
+
+// compatibility methods
+// TODO: eliminate these and use the more generic functions in callers
+func (d *disk) FindMatchingPartitionUUIDWithFsLabel(label string) (string, error) {
+	p, err := d.FindMatchingPartitionWithFsLabel(label)
+	if err != nil {
+		return "", err
+	}
+	return p.PartitionUUID, nil
+}
+
+func (d *disk) FindMatchingPartitionUUIDWithPartLabel(label string) (string, error) {
+	p, err := d.FindMatchingPartitionWithPartLabel(label)
+	if err != nil {
+		return "", err
+	}
+	return p.PartitionUUID, nil
 }
 
 func (d *disk) MountPointIsFromDisk(mountpoint string, opts *Options) (bool, error) {

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -34,6 +34,9 @@ var _ = Disk(&MockDiskMapping{})
 // DevNum must be a unique string per unique mocked disk, if only one disk is
 // being mocked it can be left empty.
 type MockDiskMapping struct {
+	// TODO: eliminate these manual mappings and instead switch all the users
+	// over to providing the full list of Partitions instead, but in the
+	// interest of smaller PR's we are doing that in a separate PR.
 	// FilesystemLabelToPartUUID is a mapping of the udev encoded filesystem
 	// labels to the expected partition uuids.
 	FilesystemLabelToPartUUID map[string]string
@@ -41,6 +44,8 @@ type MockDiskMapping struct {
 	// labels to the expected partition uuids.
 	PartitionLabelToPartUUID map[string]string
 	DiskHasPartitions        bool
+
+	// TODO: add an exported list of Partitions here
 
 	// static variables for the disk
 	DevNum  string
@@ -72,6 +77,42 @@ func (d *MockDiskMapping) FindMatchingPartitionUUIDWithPartLabel(label string) (
 		SearchType:  "partition-label",
 		SearchQuery: label,
 	}
+}
+
+func (d *MockDiskMapping) Partitions() ([]Partition, error) {
+	// TODO: this should just return the static list that was in the mapping
+	// when that is a thing
+
+	// dynamically build up a list of partitions with the mappings we were
+	// provided
+	parts := make([]Partition, 0, len(d.PartitionLabelToPartUUID))
+
+	partUUIDToPart := map[string]Partition{}
+
+	// first populate with all the partition labels
+	for partLabel, partuuid := range d.PartitionLabelToPartUUID {
+		part := Partition{
+			PartitionLabel: partLabel,
+			PartitionUUID:  partuuid,
+		}
+
+		partUUIDToPart[partuuid] = part
+	}
+
+	for fsLabel, partuuid := range d.FilesystemLabelToPartUUID {
+		existingPart, ok := partUUIDToPart[partuuid]
+		if !ok {
+			parts = append(parts, Partition{
+				FilesystemLabel: fsLabel,
+				PartitionUUID:   partuuid,
+			})
+			continue
+		}
+		existingPart.FilesystemLabel = fsLabel
+		parts = append(parts, existingPart)
+	}
+
+	return parts, nil
 }
 
 // HasPartitions returns if the mock disk has partitions or not. Part of the

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -74,12 +74,18 @@ func (s *mockDiskSuite) TestMockDeviceNameDisksToPartitionMapping(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(res.KernelDeviceNode(), Equals, "/dev/vda")
 	c.Assert(res.KernelDevicePath(), Equals, "/sys/devices/foo1")
+	parts, err := res.Partitions()
+	c.Assert(err, IsNil)
+	c.Assert(parts, DeepEquals, []disks.Partition{{FilesystemLabel: "label1", PartitionUUID: "part1"}})
 	c.Assert(res, DeepEquals, d1)
 
 	res2, err := disks.DiskFromDeviceName("devName2")
 	c.Assert(err, IsNil)
 	c.Assert(res2.KernelDeviceNode(), Equals, "/dev/vda")
 	c.Assert(res2.KernelDevicePath(), Equals, "/sys/devices/foo1")
+	parts, err = res.Partitions()
+	c.Assert(err, IsNil)
+	c.Assert(parts, DeepEquals, []disks.Partition{{FilesystemLabel: "label1", PartitionUUID: "part1"}})
 	c.Assert(res2, DeepEquals, d1)
 
 	_, err = disks.DiskFromDeviceName("devName3")
@@ -89,6 +95,9 @@ func (s *mockDiskSuite) TestMockDeviceNameDisksToPartitionMapping(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(res3.KernelDeviceNode(), Equals, "/dev/vdb")
 	c.Assert(res3.KernelDevicePath(), Equals, "/sys/devices/foo2")
+	parts, err = res3.Partitions()
+	c.Assert(err, IsNil)
+	c.Assert(parts, DeepEquals, []disks.Partition{{FilesystemLabel: "label2", PartitionUUID: "part2"}})
 	c.Assert(res3, DeepEquals, d2)
 }
 
@@ -212,6 +221,13 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Equals, "part1")
 
+	// and it has the right set of partitions
+	parts, err := foundDisk.Partitions()
+	c.Assert(err, IsNil)
+	c.Assert(parts, DeepEquals, []disks.Partition{
+		{PartitionLabel: "part-label1", FilesystemLabel: "label1", PartitionUUID: "part1"},
+	})
+
 	// the same mount point is always from the same disk
 	matches, err := foundDisk.MountPointIsFromDisk("mount1", nil)
 	c.Assert(err, IsNil)
@@ -240,6 +256,13 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	uuid, err = foundDisk2.FindMatchingPartitionUUIDWithPartLabel("part-label2")
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Equals, "part2")
+
+	// and it has the right set of partitions
+	parts, err = foundDisk2.Partitions()
+	c.Assert(err, IsNil)
+	c.Assert(parts, DeepEquals, []disks.Partition{
+		{PartitionLabel: "part-label2", FilesystemLabel: "label2", PartitionUUID: "part2"},
+	})
 
 	// we can't find label1 from mount1's or mount2's disk
 	_, err = foundDisk2.FindMatchingPartitionUUIDWithFsLabel("label1")


### PR DESCRIPTION
Based on top of https://github.com/snapcore/snapd/pull/10856.

This was also a long standing TODO to more fully represent a partition on a
disk, so here this is too.

We also refactor the FindMatchingPartitionUUIDWith{Fs,Part}Label methods to use
a more generic searching function which returns the full Partition not just the
PartitionUUID. The more generic methods will be added to the Disk interface
shortly (in a future PR that is).