### PR TITLE
osutil/disks: add Disk.FindMatchingPartitionWith{Fs,Part}Label

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -31,18 +31,32 @@ type Options struct {
 
 // Disk is a single physical disk device that contains partitions.
 type Disk interface {
-	// FindMatchingPartitionUUIDWithFsLabel finds the partition uuid for a
-	// partition matching the specified filesystem label on the disk. Note that
-	// for non-ascii labels like "Some label", the label will be encoded using
-	// \x<hex> for potentially non-safe characters like in "Some\x20Label".
-	// If the filesystem label was not found on the disk, and no other errors
-	// were encountered, a PartitionNotFoundError will be returned.
+	// FindMatchingPartitionWithFsLabel finds the partition with a matching
+	// filesystem label on the disk. Note that for non-ascii labels like
+	// "Some label", the label will be encoded using \x<hex> for potentially
+	// non-safe characters like in "Some\x20Label". If the filesystem label was
+	// not found on the disk, and no other errors were encountered, a
+	// PartitionNotFoundError will be returned.
+	FindMatchingPartitionWithFsLabel(string) (Partition, error)
+
+	// FindMatchingPartitionWithPartLabel is like
+	// FindMatchingPartitionWithFsLabel, but searches for a partition that
+	// has a matching partition label instead of the filesystem label. The same
+	// encoding scheme is performed on the label as in that function.
+	FindMatchingPartitionWithPartLabel(string) (Partition, error)
+
+	// FindMatchingPartitionUUIDWithFsLabel is like
+	// FindMatchingPartitionWithFsLabel, but returns specifically the
+	// PartitionUUID. This method will be eliminated soon in favor of all
+	// clients using FindMatchingPartitionWithFsLabel instead as it is more
+	// generically useful.
 	FindMatchingPartitionUUIDWithFsLabel(string) (string, error)
 
 	// FindMatchingPartitionUUIDWithPartLabel is like
-	// FindMatchingPartitionUUIDWithFsLabel, but searches for a partition that
-	// has a matching partition label instead of the filesystem label. The same
-	// encoding scheme is performed on the label as in that function.
+	// FindMatchingPartitionWithPartLabel, but returns specifically the
+	// PartitionUUID. This method will be eliminated soon in favor of all
+	// clients using FindMatchingPartitionWithPartLabel instead as it is more
+	// generically useful.
 	FindMatchingPartitionUUIDWithPartLabel(string) (string, error)
 
 	// MountPointIsFromDisk returns whether the specified mountpoint corresponds

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -685,6 +685,43 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 `)
 	defer restore()
 
+	partsOnDisk := map[string]disks.Partition{
+		"ubuntu-data-enc": {
+			FilesystemLabel:  "ubuntu-data-enc",
+			PartitionUUID:    "ubuntu-data-enc-partuuid",
+			Major:            42,
+			Minor:            4,
+			KernelDevicePath: fmt.Sprintf("%s/devices/ubuntu-data-enc-device", dirs.SysfsDir),
+			KernelDeviceNode: "/dev/vda4",
+		},
+		"ubuntu-boot": {
+			FilesystemLabel:  "ubuntu-boot",
+			PartitionLabel:   "ubuntu-boot",
+			PartitionUUID:    "ubuntu-boot-partuuid",
+			Major:            42,
+			Minor:            3,
+			KernelDevicePath: fmt.Sprintf("%s/devices/ubuntu-boot-device", dirs.SysfsDir),
+			KernelDeviceNode: "/dev/vda3",
+		},
+		"ubuntu-seed": {
+			FilesystemLabel:  "ubuntu-seed",
+			PartitionLabel:   "ubuntu-seed",
+			PartitionUUID:    "ubuntu-seed-partuuid",
+			Major:            42,
+			Minor:            2,
+			KernelDevicePath: fmt.Sprintf("%s/devices/ubuntu-seed-device", dirs.SysfsDir),
+			KernelDeviceNode: "/dev/vda2",
+		},
+		"bios-boot": {
+			PartitionLabel:   "BIOS\\x20Boot",
+			PartitionUUID:    "bios-boot-partuuid",
+			Major:            42,
+			Minor:            1,
+			KernelDevicePath: fmt.Sprintf("%s/devices/bios-boot-device", dirs.SysfsDir),
+			KernelDeviceNode: "/dev/vda1",
+		},
+	}
+
 	ubuntuDataEncUdevPropMap := map[string]string{
 		"ID_FS_LABEL_ENC":    "ubuntu-data-enc",
 		"ID_PART_ENTRY_UUID": "ubuntu-data-enc-partuuid",
@@ -811,40 +848,10 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 	parts, err := ubuntuDataDisk.Partitions()
 	c.Assert(err, IsNil)
 	c.Assert(parts, DeepEquals, []disks.Partition{
-		{
-			FilesystemLabel:  "ubuntu-data-enc",
-			PartitionUUID:    "ubuntu-data-enc-partuuid",
-			Major:            42,
-			Minor:            4,
-			KernelDevicePath: fmt.Sprintf("%s/devices/ubuntu-data-enc-device", dirs.SysfsDir),
-			KernelDeviceNode: "/dev/vda4",
-		},
-		{
-			FilesystemLabel:  "ubuntu-boot",
-			PartitionLabel:   "ubuntu-boot",
-			PartitionUUID:    "ubuntu-boot-partuuid",
-			Major:            42,
-			Minor:            3,
-			KernelDevicePath: fmt.Sprintf("%s/devices/ubuntu-boot-device", dirs.SysfsDir),
-			KernelDeviceNode: "/dev/vda3",
-		},
-		{
-			FilesystemLabel:  "ubuntu-seed",
-			PartitionLabel:   "ubuntu-seed",
-			PartitionUUID:    "ubuntu-seed-partuuid",
-			Major:            42,
-			Minor:            2,
-			KernelDevicePath: fmt.Sprintf("%s/devices/ubuntu-seed-device", dirs.SysfsDir),
-			KernelDeviceNode: "/dev/vda2",
-		},
-		{
-			PartitionLabel:   "BIOS\\x20Boot",
-			PartitionUUID:    "bios-boot-partuuid",
-			Major:            42,
-			Minor:            1,
-			KernelDevicePath: fmt.Sprintf("%s/devices/bios-boot-device", dirs.SysfsDir),
-			KernelDeviceNode: "/dev/vda1",
-		},
+		partsOnDisk["ubuntu-data-enc"],
+		partsOnDisk["ubuntu-boot"],
+		partsOnDisk["ubuntu-seed"],
+		partsOnDisk["bios-boot"],
 	})
 
 	// we have the ubuntu-seed, ubuntu-boot, and ubuntu-data partition labels
@@ -852,6 +859,10 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 		id, err := ubuntuDataDisk.FindMatchingPartitionUUIDWithFsLabel(label)
 		c.Assert(err, IsNil)
 		c.Assert(id, Equals, label+"-partuuid")
+
+		part, err := ubuntuDataDisk.FindMatchingPartitionWithFsLabel(label)
+		c.Assert(err, IsNil)
+		c.Assert(part, DeepEquals, partsOnDisk[label])
 	}
 
 	// and the mountpoint for ubuntu-boot at /run/mnt/ubuntu-boot matches the

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -221,6 +221,22 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Equals, "part1")
 
+	part, err := foundDisk.FindMatchingPartitionWithFsLabel("label1")
+	c.Assert(err, IsNil)
+	c.Assert(part, DeepEquals, disks.Partition{
+		PartitionLabel:  "part-label1",
+		FilesystemLabel: "label1",
+		PartitionUUID:   "part1",
+	})
+
+	part, err = foundDisk.FindMatchingPartitionWithPartLabel("part-label1")
+	c.Assert(err, IsNil)
+	c.Assert(part, DeepEquals, disks.Partition{
+		PartitionLabel:  "part-label1",
+		FilesystemLabel: "label1",
+		PartitionUUID:   "part1",
+	})
+
 	// and it has the right set of partitions
 	parts, err := foundDisk.Partitions()
 	c.Assert(err, IsNil)
@@ -256,6 +272,22 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	uuid, err = foundDisk2.FindMatchingPartitionUUIDWithPartLabel("part-label2")
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Equals, "part2")
+
+	part, err = foundDisk2.FindMatchingPartitionWithFsLabel("label2")
+	c.Assert(err, IsNil)
+	c.Assert(part, DeepEquals, disks.Partition{
+		PartitionLabel:  "part-label2",
+		FilesystemLabel: "label2",
+		PartitionUUID:   "part2",
+	})
+
+	part, err = foundDisk2.FindMatchingPartitionWithPartLabel("part-label2")
+	c.Assert(err, IsNil)
+	c.Assert(part, DeepEquals, disks.Partition{
+		PartitionLabel:  "part-label2",
+		FilesystemLabel: "label2",
+		PartitionUUID:   "part2",
+	})
 
 	// and it has the right set of partitions
 	parts, err = foundDisk2.Partitions()


### PR DESCRIPTION
These methods were already implemented for *disk, so expose them as part of the
interface so they can be directly tested.

Also, temporarily implement these methods for the MockDiskMapping using the
existing mappings that are provided with a TODO to switch over the
implementation to searching the static list when that static list is provided
by the test callers that need to mock this.

Finally notate in the doc-comments of
FindMatchingPartitionUUIDWith{Fs,Part}Label that these methods will be taken
out to pasture soon.