### PR TITLE
snap-bootstrap: wait in `mountNonDataPartitionMatchingKernelDisk`

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1214,19 +1214,16 @@ func checkDataAndSavePairing(rootdir string) (bool, error) {
 	return subtle.ConstantTimeCompare(marker1, marker2) == 1, nil
 }
 
-// waitPartSrc waits for the given partSrc to appear.
-//
-// No checks beyond file existance are performed. It can be mocked in
-// tests.
-var waitPartSrc = func(partSrc string, wait time.Duration, n int) error {
+// waitFile waits for the given file/device-node/directory to appear.
+var waitFile = func(path string, wait time.Duration, n int) error {
 	for i := 0; i < n; i++ {
-		if osutil.FileExists(partSrc) {
+		if osutil.FileExists(path) {
 			return nil
 		}
 		time.Sleep(wait)
 	}
 
-	return fmt.Errorf("no device %v after waiting for %v", partSrc, time.Duration(n*int(wait)))
+	return fmt.Errorf("no %v after waiting for %v", path, time.Duration(n*int(wait)))
 }
 
 // mountNonDataPartitionMatchingKernelDisk will select the partition to mount at
@@ -1251,7 +1248,7 @@ func mountNonDataPartitionMatchingKernelDisk(dir, fallbacklabel string) error {
 		pollWait := 50 * time.Millisecond
 		pollIterations := 1200
 		logger.Noticef("waiting up to %v for %v to appear", time.Duration(pollIterations*int(pollWait)), partSrc)
-		if err := waitPartSrc(filepath.Join(dirs.GlobalRootDir, partSrc), pollWait, pollIterations); err != nil {
+		if err := waitFile(filepath.Join(dirs.GlobalRootDir, partSrc), pollWait, pollIterations); err != nil {
 			return fmt.Errorf("cannot mount source: %v", err)
 		}
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1223,7 +1223,7 @@ var waitFile = func(path string, wait time.Duration, n int) error {
 		time.Sleep(wait)
 	}
 
-	return fmt.Errorf("no %v after waiting for %v", path, time.Duration(n*int(wait)))
+	return fmt.Errorf("no %v after waiting for %v", path, time.Duration(n)*wait)
 }
 
 // mountNonDataPartitionMatchingKernelDisk will select the partition to mount at
@@ -1247,7 +1247,7 @@ func mountNonDataPartitionMatchingKernelDisk(dir, fallbacklabel string) error {
 	if !osutil.FileExists(filepath.Join(dirs.GlobalRootDir, partSrc)) {
 		pollWait := 50 * time.Millisecond
 		pollIterations := 1200
-		logger.Noticef("waiting up to %v for %v to appear", time.Duration(pollIterations*int(pollWait)), partSrc)
+		logger.Noticef("waiting up to %v for %v to appear", time.Duration(pollIterations)*pollWait, partSrc)
 		if err := waitFile(filepath.Join(dirs.GlobalRootDir, partSrc), pollWait, pollIterations); err != nil {
 			return fmt.Errorf("cannot mount source: %v", err)
 		}

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -163,10 +163,12 @@ func MockTryRecoverySystemHealthCheck(mock func() error) (restore func()) {
 	}
 }
 
-func MockPartSrcPollIterations(n int) (restore func()) {
-	old := partSrcPollIterations
-	partSrcPollIterations = n
+func MockWaitPartSrc(f func(string, time.Duration, int) error) (restore func()) {
+	old := waitPartSrc
+	waitPartSrc = f
 	return func() {
-		partSrcPollIterations = old
+		waitPartSrc = old
 	}
 }
+
+var WaitPartSrc = waitPartSrc

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -163,12 +163,12 @@ func MockTryRecoverySystemHealthCheck(mock func() error) (restore func()) {
 	}
 }
 
-func MockWaitPartSrc(f func(string, time.Duration, int) error) (restore func()) {
-	old := waitPartSrc
-	waitPartSrc = f
+func MockWaitFile(f func(string, time.Duration, int) error) (restore func()) {
+	old := waitFile
+	waitFile = f
 	return func() {
-		waitPartSrc = old
+		waitFile = old
 	}
 }
 
-var WaitPartSrc = waitPartSrc
+var WaitFile = waitFile

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -32,6 +32,8 @@ var (
 	Parser = parser
 
 	DoSystemdMount = doSystemdMountImpl
+
+	MountNonDataPartitionMatchingKernelDisk = mountNonDataPartitionMatchingKernelDisk
 )
 
 type SystemdMountOptions = systemdMountOptions
@@ -158,5 +160,13 @@ func MockTryRecoverySystemHealthCheck(mock func() error) (restore func()) {
 	tryRecoverySystemHealthCheck = mock
 	return func() {
 		tryRecoverySystemHealthCheck = old
+	}
+}
+
+func MockPartSrcPollIterations(n int) (restore func()) {
+	old := partSrcPollIterations
+	partSrcPollIterations = n
+	return func() {
+		partSrcPollIterations = old
 	}
 }


### PR DESCRIPTION
The current snap-bootstrap has a race when mounting the seed
partition in `mountNonDataPartitionMatchingKernelDisk` on EFI
systems.

The code determines the partUUID of the disk that booted the
kernel by reading the EFI LoaderDevicePartUUID variable. However
there is no guarantee that this partition is available when
snap-bootstrap runs, the kernel may still enumerate the HW.
This can be observed on a fast NUC when booting from a USB
stick.

Note that the `the-tool.serice` already has a
"After=systemd-udev-settle.service" set but that is still
racy because any `udev settle` (or `udev trigger --settle`)
is racy, the only option is to poll for the part uuid to
appear.

This is a minimal commit to avoid too much churn in code. Let me
know if it's too hacky to avoid a bigger diff.

Thanks to Sertac for reporting this bug.
