### PR TITLE
osutil/disks: add RootMountPointsForPartition

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -112,6 +112,13 @@ type Partition struct {
 	KernelDeviceNode string
 }
 
+// RootMountPointsForPartition returns all mounts from the mount table which are
+// for the root directory of the specified partition. The order in which they
+// are returned is the exact order that they appear in the mount table.
+func RootMountPointsForPartition(p Partition) ([]string, error) {
+	return rootMountPointsForPartition(p)
+}
+
 // PartitionNotFoundError is an error where a partition matching the SearchType
 // was not found. SearchType can be either "partition-label" or
 // "filesystem-label" to indicate searching by the partition label or the

--- a/osutil/disks/disks_darwin.go
+++ b/osutil/disks/disks_darwin.go
@@ -40,3 +40,7 @@ func DiskFromMountPoint(mountpoint string, opts *Options) (Disk, error) {
 var diskFromMountPoint = func(mountpoint string, opts *Options) (Disk, error) {
 	return nil, osutil.ErrDarwin
 }
+
+var rootMountPointsForPartition = func(p Partition) ([]string, error) {
+	return nil, osutil.ErrDarwin
+}

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -188,6 +188,24 @@ var diskFromDeviceName = func(deviceName string) (Disk, error) {
 	return diskFromUdevProps(deviceName, "name", props)
 }
 
+func rootMountPointsForPartition(part Partition) ([]string, error) {
+	mounts, err := osutil.LoadMountInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	mountpoints := []string{}
+	for _, mnt := range mounts {
+		if mnt.DevMajor == part.Major && mnt.DevMinor == part.Minor {
+			if mnt.Root == "/" {
+				mountpoints = append(mountpoints, mnt.MountDir)
+			}
+		}
+	}
+
+	return mountpoints, nil
+}
+
 func (d *disk) Partitions() ([]Partition, error) {
 	if !d.hasPartitions {
 		// for i.e. device mapper disks which don't have partitions


### PR DESCRIPTION
RootMountPointsForPartition will be used from multi-volume gadget asset updates
where we need to identify the mount point for an arbitrary partition returned
by Disk.Partitions().


Based on top of https://github.com/snapcore/snapd/pull/10857, main commit to review is 5ccb29f6e9369cfaaab6cd1365e583cf56e838f4