### PR TITLE
mount-control: step 3

### DIFF
--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -377,6 +377,12 @@ func validateMountInfo(mountInfo *MountInfo) error {
 		return fmt.Errorf(`mount-control "what" attribute must be "none" with "tmpfs"; found %q instead`, mountInfo.what)
 	}
 
+	// Until we have a clear picture of how this should work, disallow creating
+	// persistent mounts into $SNAP_DATA
+	if mountInfo.persistent && strings.HasPrefix(mountInfo.where, "$SNAP_DATA") {
+		return errors.New(`mount-control "persistent" attribute cannot be used to mount onto $SNAP_DATA`)
+	}
+
 	return nil
 }
 

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -254,6 +254,10 @@ apps:
 			"mount:\n  - what: /\n    where: /media/*\n    options: [rw]\n    type: [tmpfs]",
 			`mount-control "what" attribute must be "none" with "tmpfs"; found "/" instead`,
 		},
+		{
+			"mount:\n  - what: /\n    where: $SNAP_DATA/foo\n    options: [ro]\n    persistent: true",
+			`mount-control "persistent" attribute cannot be used to mount onto \$SNAP_DATA`,
+		},
 	}
 
 	for _, testData := range data {

--- a/overlord/hookstate/ctlcmd/mount.go
+++ b/overlord/hookstate/ctlcmd/mount.go
@@ -1,0 +1,237 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/utils"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/systemd"
+)
+
+var (
+	shortMountHelp = i18n.G("Create a temporary or permanent mount")
+	longMountHelp  = i18n.G(`
+The mount command mounts the given source onto the given destination path,
+provided that the snap has a plug for the mount-control interface which allows
+this operation.`)
+)
+
+func init() {
+	addCommand("mount", shortMountHelp, longMountHelp, func() command { return &mountCommand{} })
+}
+
+type mountCommand struct {
+	baseCommand
+	Positional struct {
+		What  string `positional-arg-name:"<what>" required:"yes" description:"path to the resource to be mounted"`
+		Where string `positional-arg-name:"<where>" required:"yes" description:"path to the destination mount point"`
+	} `positional-args:"yes" required:"yes"`
+	Persistent  bool   `long:"persistent" description:"make the mount persist across reboots"`
+	Type        string `long:"type" short:"t" description:"filesystem type"`
+	Options     string `long:"options" short:"o" description:"comma-separated list of mount options"`
+	snapInfo    *snap.Info
+	optionsList []string
+}
+
+func matchMountPathAttribute(path string, attribute interface{}, snapInfo *snap.Info) bool {
+	pattern, ok := attribute.(string)
+	if !ok {
+		return false
+	}
+
+	expandedPattern := snapInfo.ExpandSnapVariables(pattern)
+
+	pp, err := utils.NewPathPattern(expandedPattern)
+	return err == nil && pp.Matches(path)
+}
+
+// matchConnection checks whether the given mount connection attributes give
+// the snap permission to execute the mount command
+func (m *mountCommand) matchConnection(attributes map[string]interface{}) bool {
+	if !matchMountPathAttribute(m.Positional.What, attributes["what"], m.snapInfo) {
+		return false
+	}
+
+	if !matchMountPathAttribute(m.Positional.Where, attributes["where"], m.snapInfo) {
+		return false
+	}
+
+	if m.Type != "" {
+		if types, ok := attributes["type"].([]interface{}); ok {
+			found := false
+			for _, iface := range types {
+				if typeString, ok := iface.(string); ok && typeString == m.Type {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		} else {
+			return false
+		}
+	} else {
+		// The filesystem type was not given; we let it through only if the
+		// plug also did not specify a type.
+		if _, typeIsSet := attributes["type"]; typeIsSet {
+			return false
+		}
+	}
+
+	if optionsIfaces, ok := attributes["options"].([]interface{}); ok {
+		var allowedOptions []string
+		for _, iface := range optionsIfaces {
+			if option, ok := iface.(string); ok {
+				allowedOptions = append(allowedOptions, option)
+			}
+		}
+		for _, option := range m.optionsList {
+			if !strutil.ListContains(allowedOptions, option) {
+				return false
+			}
+		}
+	}
+
+	if m.Persistent {
+		if allowedPersistent, ok := attributes["persistent"].(bool); !ok || !allowedPersistent {
+			return false
+		}
+	}
+
+	return true
+}
+
+// checkConnections checks whether the established connections give the snap
+// permission to execute the mount command
+func (m *mountCommand) checkConnections(context *hookstate.Context) error {
+	snapName := context.InstanceName()
+
+	st := context.State()
+	st.Lock()
+	defer st.Unlock()
+
+	conns, err := ifacestate.ConnectionStates(st)
+	if err != nil {
+		return fmt.Errorf("internal error: cannot get connections: %s", err)
+	}
+
+	m.snapInfo, err = snapstate.CurrentInfo(st, snapName)
+	if err != nil {
+		return fmt.Errorf("internal error: cannot get snap info: %s", err)
+	}
+
+	for connId, connState := range conns {
+		if connState.Interface != "mount-control" {
+			continue
+		}
+
+		if connState.Undesired || connState.HotplugGone {
+			continue
+		}
+
+		connRef, err := interfaces.ParseConnRef(connId)
+		if err != nil {
+			return err
+		}
+
+		if connRef.PlugRef.Snap != snapName {
+			continue
+		}
+
+		mounts, ok := connState.StaticPlugAttrs["mount"].([]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, mountAttributes := range mounts {
+			if m.matchConnection(mountAttributes.(map[string]interface{})) {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("no matching mount-control connection found")
+}
+
+func (m *mountCommand) createMountUnit(sysd systemd.Systemd) (string, error) {
+	snapName := m.snapInfo.InstanceName()
+	revision := m.snapInfo.SnapRevision().String()
+	lifetime := systemd.Transient
+	if m.Persistent {
+		lifetime = systemd.Persistent
+	}
+	return sysd.AddMountUnitFileWithOptions(&systemd.MountUnitOptions{
+		Lifetime: lifetime,
+		SnapName: snapName,
+		Revision: revision,
+		What:     m.Positional.What,
+		Where:    m.Positional.Where,
+		Fstype:   m.Type,
+		Options:  m.optionsList,
+		Origin:   "mount-control",
+	})
+}
+
+func (m *mountCommand) Execute([]string) error {
+	context, err := m.ensureContext()
+	if err != nil {
+		return err
+	}
+
+	// Parse the mount options into an array
+	for _, option := range strings.Split(m.Options, ",") {
+		if option != "" {
+			m.optionsList = append(m.optionsList, option)
+		}
+	}
+
+	if err := m.checkConnections(context); err != nil {
+		snapName := context.InstanceName()
+		return fmt.Errorf("snap %q lacks permissions to create the requested mount: %v", snapName, err)
+	}
+
+	sysd := systemd.New(systemd.SystemMode, nil)
+	name, err := m.createMountUnit(sysd)
+	if err != nil {
+		return fmt.Errorf("cannot create mount unit: %v", err)
+	}
+
+	if err := sysd.Start(name); err != nil {
+		// There's no point in keeping the mount unit if it doesn't work. Even
+		// if the problem is transient, the next invocation of "snapctl mount"
+		// will create a new unit anyway.
+		if err := sysd.RemoveMountUnitFile(m.Positional.Where); err != nil {
+			// Not much we can do about it, other than logging.
+			logger.Noticef("cannot remove mount unit on %q which failed to start: %v", m.Positional.Where, err)
+		}
+		return fmt.Errorf("cannot start mount unit: %v", err)
+	}
+	return nil
+}

--- a/overlord/hookstate/ctlcmd/mount_test.go
+++ b/overlord/hookstate/ctlcmd/mount_test.go
@@ -1,0 +1,371 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	"errors"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type ResultForAddMountUnitFileWithOptions struct {
+	path string
+	err  error
+}
+
+type FakeSystemdForMount struct {
+	systemd.Systemd
+
+	StartCalls  [][]string
+	StartResult error
+
+	RemoveMountUnitFileCalls  []string
+	RemoveMountUnitFileResult error
+
+	AddMountUnitFileWithOptionsCalls  []*systemd.MountUnitOptions
+	AddMountUnitFileWithOptionsResult ResultForAddMountUnitFileWithOptions
+}
+
+func (s *FakeSystemdForMount) Start(serviceNames ...string) error {
+	s.StartCalls = append(s.StartCalls, serviceNames)
+	return s.StartResult
+}
+
+func (s *FakeSystemdForMount) RemoveMountUnitFile(baseDir string) error {
+	s.RemoveMountUnitFileCalls = append(s.RemoveMountUnitFileCalls, baseDir)
+	return s.RemoveMountUnitFileResult
+}
+
+func (s *FakeSystemdForMount) AddMountUnitFileWithOptions(options *systemd.MountUnitOptions) (string, error) {
+	s.AddMountUnitFileWithOptionsCalls = append(s.AddMountUnitFileWithOptionsCalls, options)
+	return s.AddMountUnitFileWithOptionsResult.path, s.AddMountUnitFileWithOptionsResult.err
+}
+
+func CopyMap(m map[string]interface{}) map[string]interface{} {
+	cp := make(map[string]interface{})
+	for k, v := range m {
+		switch value := v.(type) {
+		case map[string]interface{}:
+			cp[k] = CopyMap(value)
+		case []interface{}:
+			cp[k] = CopySlice(value)
+		default:
+			cp[k] = v
+		}
+	}
+	return cp
+}
+
+func CopySlice(s []interface{}) []interface{} {
+	cp := make([]interface{}, len(s))
+	for i, v := range s {
+		switch value := v.(type) {
+		case map[string]interface{}:
+			cp[i] = CopyMap(value)
+		case []interface{}:
+			cp[i] = CopySlice(value)
+		default:
+			cp[i] = v
+		}
+	}
+	return cp
+}
+
+type mountSuite struct {
+	testutil.BaseTest
+	state       *state.State
+	mockContext *hookstate.Context
+	mockHandler *hooktest.MockHandler
+	hookTask    *state.Task
+	sysd        *FakeSystemdForMount
+	// A connection state for a snap using the mount interface with the plug
+	// properly configured, which we'll be reusing in different test cases
+	regularConnState map[string]interface{}
+}
+
+var _ = Suite(&mountSuite{})
+
+func (s *mountSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+
+	s.mockHandler = hooktest.NewMockHandler()
+
+	s.state = state.New(nil)
+	s.state.Lock()
+	defer s.state.Unlock()
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(42), Hook: "mount"}
+
+	ctx, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	s.mockContext = ctx
+
+	s.regularConnState = map[string]interface{}{
+		"interface": "mount-control",
+		"plug-static": map[string]interface{}{
+			"mount": []interface{}{
+				map[string]interface{}{
+					"what":       "/src",
+					"where":      "/dest",
+					"type":       []string{"ext4"},
+					"options":    []string{"bind", "rw", "sync"},
+					"persistent": true,
+				},
+				map[string]interface{}{
+					"what":       "/media/me/data",
+					"where":      "$SNAP_DATA/dest",
+					"options":    []string{"bind", "ro"},
+					"persistent": false,
+				},
+			},
+		},
+	}
+	s.hookTask = task
+
+	s.sysd = &FakeSystemdForMount{}
+	s.AddCleanup(systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		return s.sysd
+	}))
+}
+
+func (s *mountSuite) injectSnapWithProperPlug(c *C) {
+	s.state.Lock()
+	mockInstalledSnap(c, s.state, `name: snap1`, "")
+	s.state.Set("conns", map[string]interface{}{
+		"snap1:plug1 snap2:slot2": s.regularConnState,
+	})
+	s.state.Unlock()
+}
+
+func (s *mountSuite) TestMissingContext(c *C) {
+	_, _, err := ctlcmd.Run(nil, []string{"mount", "/src", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `cannot invoke snapctl operation commands \(here "mount"\) from outside of a snap`)
+}
+
+func (s *mountSuite) TestBadConnection(c *C) {
+	setup := &hookstate.HookSetup{}
+
+	// Inject some invalid connection data into the state, so that
+	// ifacestate.ConnectionStates() will return an error.
+	state := state.New(nil)
+	state.Lock()
+	task := state.NewTask("test-task", "my test task")
+	state.Set("conns", "I wish I was JSON")
+	state.Unlock()
+	ctx, err := hookstate.NewContext(task, state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+
+	_, _, err = ctlcmd.Run(ctx, []string{"mount", "/src", "/dest"}, 0)
+	c.Assert(err, ErrorMatches, `.*internal error: cannot get connections: .*`)
+}
+
+func (s *mountSuite) TestBadSnapInfo(c *C) {
+	s.state.Lock()
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(42), Hook: "configure"}
+	s.state.Unlock()
+
+	ctx, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+
+	_, _, err = ctlcmd.Run(ctx, []string{"mount", "/src", "/dest"}, 0)
+	c.Assert(err, ErrorMatches, `.*cannot get snap info: snap \"test-snap\" is not installed`)
+}
+
+func (s *mountSuite) TestMissingProperPlug(c *C) {
+	s.state.Lock()
+	mockInstalledSnap(c, s.state, `name: snap1`, "")
+	// Inject a lot of connections in the state, but all of them defective for
+	// one or another reason
+	connections := make(map[string]interface{})
+	// wrong interface
+	conn := CopyMap(s.regularConnState)
+	conn["interface"] = "unrelated"
+	connections["snap1:plug1 snap2:slot1"] = conn
+	// undesired
+	conn = CopyMap(s.regularConnState)
+	conn["undesired"] = true
+	connections["snap1:plug2 snap2:slot1"] = conn
+	// hotplug gone
+	conn = CopyMap(s.regularConnState)
+	conn["hotplug-gone"] = true
+	connections["snap1:plug3 snap2:slot1"] = conn
+	// different snap
+	conn = CopyMap(s.regularConnState)
+	connections["othersnap:plug1 snap2:slot1"] = conn
+	// missing plug info
+	conn = CopyMap(s.regularConnState)
+	delete(conn, "plug-static")
+	connections["snap1:plug4 snap2:slot1"] = conn
+	// incompatible "what" field
+	conn = CopyMap(s.regularConnState)
+	plugInfo := func(conn map[string]interface{}) map[string]interface{} {
+		return conn["plug-static"].(map[string]interface{})["mount"].([]interface{})[0].(map[string]interface{})
+	}
+	plugInfo(conn)["what"] = "/some/other/path"
+	connections["snap1:plug5 snap2:slot1"] = conn
+	// wrong type for "what" field
+	conn = CopyMap(s.regularConnState)
+	plugInfo(conn)["what"] = []string{}
+	connections["snap1:plug6 snap2:slot1"] = conn
+	// incompatible "where" field
+	conn = CopyMap(s.regularConnState)
+	plugInfo(conn)["where"] = "/some/other/target/path"
+	connections["snap1:plug7 snap2:slot1"] = conn
+	// incompatible "type" field
+	conn = CopyMap(s.regularConnState)
+	plugInfo(conn)["type"] = []string{"vfat"}
+	connections["snap1:plug8 snap2:slot1"] = conn
+	// wrong type for "type" field
+	conn = CopyMap(s.regularConnState)
+	plugInfo(conn)["type"] = "ext4"
+	connections["snap1:plug9 snap2:slot1"] = conn
+	// incompatible "options" field
+	conn = CopyMap(s.regularConnState)
+	plugInfo(conn)["options"] = []string{"rw"}
+	connections["snap1:plug10 snap2:slot1"] = conn
+	// no persistent mounts allowed
+	conn = CopyMap(s.regularConnState)
+	plugInfo(conn)["persistent"] = false
+	connections["snap1:plug11 snap2:slot1"] = conn
+	// like above, just not expliticly
+	conn = CopyMap(s.regularConnState)
+	delete(plugInfo(conn), "persistent")
+	connections["snap1:plug12 snap2:slot1"] = conn
+
+	s.state.Set("conns", connections)
+	s.state.Unlock()
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "--persistent", "-t", "ext4", "-o", "bind,rw", "/src", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `.*no matching mount-control connection found`)
+	c.Check(s.sysd.AddMountUnitFileWithOptionsCalls, HasLen, 0)
+
+	// Try the same without the filesystem type
+	_, _, err = ctlcmd.Run(s.mockContext, []string{"mount", "--persistent", "-o", "bind,rw", "/src", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `.*no matching mount-control connection found`)
+	c.Check(s.sysd.AddMountUnitFileWithOptionsCalls, HasLen, 0)
+}
+
+func (s *mountSuite) TestUnitCreationFailure(c *C) {
+	s.injectSnapWithProperPlug(c)
+
+	s.sysd.AddMountUnitFileWithOptionsResult = ResultForAddMountUnitFileWithOptions{"", errors.New("creation error")}
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "-t", "ext4", "/src", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `cannot create mount unit: creation error`)
+	c.Check(s.sysd.AddMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
+		{
+			Lifetime: systemd.Transient,
+			SnapName: "snap1",
+			Revision: "1",
+			What:     "/src",
+			Where:    "/dest",
+			Fstype:   "ext4",
+			Origin:   "mount-control",
+		},
+	})
+	c.Check(s.sysd.StartCalls, HasLen, 0)
+}
+
+func (s *mountSuite) TestUnitStartFailure(c *C) {
+	s.injectSnapWithProperPlug(c)
+
+	s.sysd.AddMountUnitFileWithOptionsResult = ResultForAddMountUnitFileWithOptions{"/path/unit.mount", nil}
+	s.sysd.StartResult = errors.New("some start error")
+	s.sysd.RemoveMountUnitFileResult = errors.New("some removal error")
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "-t", "ext4", "/src", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `cannot start mount unit: some start error`)
+	c.Check(s.sysd.AddMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
+		{
+			Lifetime: systemd.Transient,
+			SnapName: "snap1",
+			Revision: "1",
+			What:     "/src",
+			Where:    "/dest",
+			Fstype:   "ext4",
+			Origin:   "mount-control",
+		},
+	})
+	c.Check(s.sysd.StartCalls, DeepEquals, [][]string{
+		{"/path/unit.mount"},
+	})
+}
+
+func (s *mountSuite) TestHappy(c *C) {
+	s.injectSnapWithProperPlug(c)
+
+	s.sysd.AddMountUnitFileWithOptionsResult = ResultForAddMountUnitFileWithOptions{"/path/unit.mount", nil}
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "--persistent", "-t", "ext4", "-o", "sync,rw", "/src", "/dest"}, 0)
+	c.Check(err, IsNil)
+	c.Check(s.sysd.AddMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
+		{
+			Lifetime: systemd.Persistent,
+			SnapName: "snap1",
+			Revision: "1",
+			What:     "/src",
+			Where:    "/dest",
+			Fstype:   "ext4",
+			Options:  []string{"sync", "rw"},
+			Origin:   "mount-control",
+		},
+	})
+	c.Check(s.sysd.StartCalls, DeepEquals, [][]string{
+		{"/path/unit.mount"},
+	})
+}
+
+func (s *mountSuite) TestHappyWithVariableExpansion(c *C) {
+	s.injectSnapWithProperPlug(c)
+
+	s.sysd.AddMountUnitFileWithOptionsResult = ResultForAddMountUnitFileWithOptions{"/path/unit.mount", nil}
+
+	// Now try with $SNAP_* variables in the paths
+	snapDataDir := filepath.Join(dirs.SnapDataDir, "snap1", "1")
+	where := filepath.Join(snapDataDir, "/dest")
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "-o", "bind,ro", "/media/me/data", where}, 0)
+	c.Check(err, IsNil)
+	c.Check(s.sysd.AddMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
+		{
+			Lifetime: systemd.Transient,
+			SnapName: "snap1",
+			Revision: "1",
+			What:     "/media/me/data",
+			Where:    where,
+			Options:  []string{"bind", "ro"},
+			Origin:   "mount-control",
+		},
+	})
+	c.Check(s.sysd.StartCalls, DeepEquals, [][]string{
+		{"/path/unit.mount"},
+	})
+}

--- a/overlord/hookstate/ctlcmd/umount.go
+++ b/overlord/hookstate/ctlcmd/umount.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/systemd"
+)
+
+var (
+	shortUmountHelp = i18n.G("Remove a temporary or permanent mount")
+	longUmountHelp  = i18n.G(`
+The umount command unmounts the given mount point, which must have been
+previously created with "snapctl mount".`)
+)
+
+func init() {
+	addCommand("umount", shortUmountHelp, longUmountHelp, func() command { return &umountCommand{} })
+}
+
+type umountCommand struct {
+	baseCommand
+	Positional struct {
+		Where string `positional-arg-name:"<where>" required:"yes" description:"path to the mount point"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+func (m *umountCommand) Execute([]string) error {
+	context, err := m.ensureContext()
+	if err != nil {
+		return err
+	}
+
+	if m.Positional.Where == "" {
+		return fmt.Errorf("mount point cannot be empty")
+	}
+
+	snapName := context.InstanceName()
+
+	// Get the list of all our mount units, to find the matching one
+	sysd := systemd.New(systemd.SystemMode, nil)
+	mountPoints, err := sysd.ListMountUnits(snapName, "mount-control")
+	if err != nil {
+		return fmt.Errorf("cannot retrieve list of mount units: %v", err)
+	}
+
+	found := false
+	for _, where := range mountPoints {
+		if where != m.Positional.Where {
+			continue
+		}
+
+		if err := sysd.RemoveMountUnitFile(where); err != nil {
+			return fmt.Errorf("cannot remove mount unit: %v", err)
+		}
+		found = true
+	}
+
+	if !found {
+		return fmt.Errorf("cannot find the given mount")
+	}
+
+	return nil
+}

--- a/overlord/hookstate/ctlcmd/umount_test.go
+++ b/overlord/hookstate/ctlcmd/umount_test.go
@@ -1,0 +1,164 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type ParamsForListMountUnits struct {
+	snapName string
+	origin   string
+}
+
+type ResultForListMountUnits struct {
+	units []string
+	err   error
+}
+
+type FakeSystemdForUmount struct {
+	systemd.Systemd
+
+	RemoveMountUnitFileCalls       []string
+	RemoveMountUnitFileCallsResult error
+
+	ListMountUnitsCalls       []*ParamsForListMountUnits
+	ListMountUnitsCallsResult ResultForListMountUnits
+}
+
+func (s *FakeSystemdForUmount) RemoveMountUnitFile(mountedDir string) error {
+	s.RemoveMountUnitFileCalls = append(s.RemoveMountUnitFileCalls, mountedDir)
+	return s.RemoveMountUnitFileCallsResult
+}
+
+func (s *FakeSystemdForUmount) ListMountUnits(snapName, origin string) ([]string, error) {
+	s.ListMountUnitsCalls = append(s.ListMountUnitsCalls,
+		&ParamsForListMountUnits{snapName, origin})
+	return s.ListMountUnitsCallsResult.units, s.ListMountUnitsCallsResult.err
+}
+
+type umountSuite struct {
+	testutil.BaseTest
+	state       *state.State
+	mockContext *hookstate.Context
+	mockHandler *hooktest.MockHandler
+	hookTask    *state.Task
+	sysd        *FakeSystemdForUmount
+}
+
+var _ = Suite(&umountSuite{})
+
+func (s *umountSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+
+	s.mockHandler = hooktest.NewMockHandler()
+
+	s.state = state.New(nil)
+	s.state.Lock()
+	defer s.state.Unlock()
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(42), Hook: "umount"}
+
+	ctx, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	s.mockContext = ctx
+
+	s.hookTask = task
+
+	s.sysd = &FakeSystemdForUmount{}
+	s.AddCleanup(systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		return s.sysd
+	}))
+}
+
+func (s *umountSuite) TestMissingContext(c *C) {
+	_, _, err := ctlcmd.Run(nil, []string{"umount", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `cannot invoke snapctl operation commands \(here "umount"\) from outside of a snap`)
+}
+
+func (s *umountSuite) TestMissingParameters(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"umount", ""}, 0)
+	c.Check(err, ErrorMatches, `mount point cannot be empty`)
+}
+
+func (s *umountSuite) TestListUnitFailure(c *C) {
+	s.sysd.ListMountUnitsCallsResult = ResultForListMountUnits{[]string{}, errors.New("list error")}
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `cannot retrieve list of mount units: list error`)
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []*ParamsForListMountUnits{
+		{"snap1", "mount-control"},
+	})
+	c.Check(s.sysd.RemoveMountUnitFileCalls, HasLen, 0)
+}
+
+func (s *umountSuite) TestUnitNotFound(c *C) {
+	s.sysd.ListMountUnitsCallsResult = ResultForListMountUnits{[]string{
+		"/this/is",
+		"/not/our/mount/destination",
+	}, nil}
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `cannot find the given mount`)
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []*ParamsForListMountUnits{
+		{"snap1", "mount-control"},
+	})
+	c.Check(s.sysd.RemoveMountUnitFileCalls, HasLen, 0)
+}
+
+func (s *umountSuite) TestRemovalError(c *C) {
+	s.sysd.ListMountUnitsCallsResult = ResultForListMountUnits{[]string{"/dest"}, nil}
+
+	s.sysd.RemoveMountUnitFileCallsResult = errors.New("remove error")
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `cannot remove mount unit: remove error`)
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []*ParamsForListMountUnits{
+		{"snap1", "mount-control"},
+	})
+	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{
+		"/dest",
+	})
+}
+
+func (s *umountSuite) TestHappy(c *C) {
+	s.sysd.ListMountUnitsCallsResult = ResultForListMountUnits{[]string{"/dest"}, nil}
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0)
+	c.Check(err, IsNil)
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []*ParamsForListMountUnits{
+		{"snap1", "mount-control"},
+	})
+	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{
+		"/dest",
+	})
+}

--- a/tests/lib/snaps/test-snapd-mount-control/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-mount-control/meta/snap.yaml
@@ -13,6 +13,7 @@ plugs:
             - what: /var/tmp/**
               where: $SNAP_COMMON/**
               options: [rw, bind]
+              persistent: true
             - what: /dev/sd*
               where: /media/**
               type: [ext2, ext3, ext4]

--- a/tests/main/interfaces-mount-control/task.yaml
+++ b/tests/main/interfaces-mount-control/task.yaml
@@ -15,83 +15,125 @@ restore: |
     rm -rf "$MOUNT_SRC"
 
 execute: |
-    echo "First verify that a snap with a malicious manifest cannot be connected"
-    "$TESTSTOOLS"/snaps-state install-local test-mount-control-invalid
-    snap connect test-mount-control-invalid:mntctl 2> connect_error.log || true
-    if os.query is-trusty; then
-        echo "On Trusty, we should fail anyway due to systemd being too old"
-        MATCH "systemd version 204 is too old" < connect_error.log
-        exit 0
-    fi
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        # first pass: install the snap and try basic mount operations
+        echo "First verify that a snap with a malicious manifest cannot be connected"
+        "$TESTSTOOLS"/snaps-state install-local test-mount-control-invalid
+        snap connect test-mount-control-invalid:mntctl 2> connect_error.log || true
+        if os.query is-trusty; then
+            echo "On Trusty, we should fail anyway due to systemd being too old"
+            MATCH "systemd version 204 is too old" < connect_error.log
+            exit 0
+        fi
 
-    MATCH 'mount-control "where" pattern is not clean' < connect_error.log
+        MATCH 'mount-control "where" pattern is not clean' < connect_error.log
 
-    echo "Installing the test snap"
+        echo "Installing the test snap"
 
-    "$TESTSTOOLS"/snaps-state install-local "${SNAP_NAME}"
+        "$TESTSTOOLS"/snaps-state install-local "${SNAP_NAME}"
 
-    echo "Connecting the mount-control interface"
-    snap connect "${SNAP_NAME}":mntctl
+        echo "Connecting the mount-control interface"
+        snap connect "${SNAP_NAME}":mntctl
 
-    echo "Verify that the snap can perform a mount"
-    mkdir -p "$MOUNT_DEST"
-    "${SNAP_NAME}".cmd mount -o bind,rw "$MOUNT_SRC" "$MOUNT_DEST"
+        echo "Verify that the snap can perform a mount"
+        mkdir -p "$MOUNT_DEST"
+        "${SNAP_NAME}".cmd mount -o bind,rw "$MOUNT_SRC" "$MOUNT_DEST"
 
-    echo "Verify that the mount has been performed"
-    "${SNAP_NAME}".cmd grep "$MOUNT_DEST" /proc/self/mountinfo
+        echo "Verify that the mount has been performed"
+        "${SNAP_NAME}".cmd grep "$MOUNT_DEST" /proc/self/mountinfo
 
-    echo "and that it's only in the snap's namespace"
-    NOMATCH "$MOUNT_DEST" < /proc/self/mountinfo
+        echo "and that it's only in the snap's namespace"
+        NOMATCH "$MOUNT_DEST" < /proc/self/mountinfo
 
-    echo "Ensure that the mounted files are visible"
-    "${SNAP_NAME}".cmd test -e "$MOUNT_DEST/file1"
+        echo "Ensure that the mounted files are visible"
+        "${SNAP_NAME}".cmd test -e "$MOUNT_DEST/file1"
 
-    echo "Unmount via the system command umount(8)"
-    "${SNAP_NAME}".cmd umount "$MOUNT_DEST"
-    if "${SNAP_NAME}".cmd grep "$MOUNT_DEST" /proc/self/mountinfo; then
-        echo "Unmount failed"
-        exit 1
-    fi
-    "${SNAP_NAME}".cmd test "!" -e "$MOUNT_DEST/file1"
+        echo "Unmount via the system command umount(8)"
+        "${SNAP_NAME}".cmd umount "$MOUNT_DEST"
+        if "${SNAP_NAME}".cmd grep "$MOUNT_DEST" /proc/self/mountinfo; then
+            echo "Unmount failed"
+            exit 1
+        fi
+        "${SNAP_NAME}".cmd test "!" -e "$MOUNT_DEST/file1"
 
-    echo "Verify that a mount with a specific FS type can be created"
-    "${SNAP_NAME}".cmd mount -o rw -t tmpfs none "$MOUNT_DEST"
-    "${SNAP_NAME}".cmd grep "$MOUNT_DEST.*tmpfs" /proc/self/mountinfo
-    "${SNAP_NAME}".cmd umount "$MOUNT_DEST"
+        echo "Verify that a mount with a specific FS type can be created"
+        "${SNAP_NAME}".cmd mount -o rw -t tmpfs none "$MOUNT_DEST"
+        "${SNAP_NAME}".cmd grep "$MOUNT_DEST.*tmpfs" /proc/self/mountinfo
+        "${SNAP_NAME}".cmd umount "$MOUNT_DEST"
 
-    if [ "$(snap debug confinement)" = partial ] ; then
-        echo "Early exit on systems where strict confinement does not work"
-        exit 0
-    fi
+        if [ "$(snap debug confinement)" = partial ] ; then
+            echo "Early exit on systems where strict confinement does not work"
+            exit 0
+        fi
 
-    if os.query is-opensuse && ! os.query is-opensuse-tumbleweed; then
-        echo "Early exit in OpenSUSE as confinement is disabled"
-        exit 0
-    fi
+        if os.query is-opensuse && ! os.query is-opensuse-tumbleweed; then
+            echo "Early exit in OpenSUSE as confinement is disabled"
+            exit 0
+        fi
 
-    echo "Verify that a mount not matching the allowed pattern will fail"
-    if "${SNAP_NAME}".cmd mount -o bind,rw "$MOUNT_SRC" "/tmp/"; then
-        echo "Mount succeeded despite not matching the allowed pattern"
-        exit 1
-    fi
+        echo "Verify that a mount not matching the allowed pattern will fail"
+        if "${SNAP_NAME}".cmd mount -o bind,rw "$MOUNT_SRC" "/tmp/"; then
+            echo "Mount succeeded despite not matching the allowed pattern"
+            exit 1
+        fi
 
-    echo "Verify that a mount not matching the allowed options will fail"
-    if "${SNAP_NAME}".cmd mount -o sync "$MOUNT_SRC" "$MOUNT_DEST"; then
-        echo "Mount succeeded despite not matching the allowed options"
-        exit 1
-    fi
+        echo "Verify that a mount not matching the allowed options will fail"
+        if "${SNAP_NAME}".cmd mount -o sync "$MOUNT_SRC" "$MOUNT_DEST"; then
+            echo "Mount succeeded despite not matching the allowed options"
+            exit 1
+        fi
 
-    echo "Verify that a mount not matching the allowed FS type will fail"
-    mkdir -p /media/somedir
-    if "${SNAP_NAME}".cmd mount -t debugfs "/dev/sda" "/media/somedir"; then
-        echo "Mount succeeded despite not matching the allowed FS type"
-        exit 1
-    fi
-    journalctl -t audit | grep 'fstype="debugfs"' | MATCH 'info="failed type match"'
-    rmdir /media/somedir
+        echo "Verify that a mount not matching the allowed FS type will fail"
+        mkdir -p /media/somedir
+        if "${SNAP_NAME}".cmd mount -t debugfs "/dev/sda" "/media/somedir"; then
+            echo "Mount succeeded despite not matching the allowed FS type"
+            exit 1
+        fi
+        journalctl -t audit | grep 'fstype="debugfs"' | MATCH 'info="failed type match"'
+        rmdir /media/somedir
 
-    echo "Verify that a maliciously crafted path cannot bypass the allowed pattern"
-    if "${SNAP_NAME}".cmd mount -o bind,rw "$MOUNT_SRC" "$SNAP_COMMON/.."; then
-        echo "Malicious pattern was not blocked"
-        exit 1
+        echo "Verify that a maliciously crafted path cannot bypass the allowed pattern"
+        if "${SNAP_NAME}".cmd mount -o bind,rw "$MOUNT_SRC" "$SNAP_COMMON/.."; then
+            echo "Malicious pattern was not blocked"
+            exit 1
+        fi
+
+        echo "Now create the same mount using snapctl"
+        "${SNAP_NAME}".cmd snapctl mount -o bind,rw "$MOUNT_SRC" "$MOUNT_DEST"
+
+        echo "Verify the mount"
+        "${SNAP_NAME}".cmd grep "$MOUNT_DEST" /proc/self/mountinfo
+        "${SNAP_NAME}".cmd test -e "$MOUNT_DEST/file1"
+
+        echo "Unmount via snapctl"
+        "${SNAP_NAME}".cmd snapctl umount "$MOUNT_DEST"
+
+        # Now try to create a persistent mount, but for a target which doesn't
+        # have the `persistent` flag set in the plug rules: it must fail
+        echo "Attempt persistent mount not allowed by plug specification"
+        "${SNAP_NAME}".cmd snapctl mount --persistent -o bind,rw /usr/share "$MOUNT_DEST" 2>&1 \
+            | MATCH 'snap "test-snapd-mount-control" lacks permissions to create the requested mount'
+
+        # Do the same, but for an allowed target: this should work
+        echo "Create a persistent mount"
+        "${SNAP_NAME}".cmd snapctl mount --persistent -o bind,rw "$MOUNT_SRC" "$MOUNT_DEST"
+
+        echo "Verify that the persistent mount is also immediately available"
+        "${SNAP_NAME}".cmd grep "$MOUNT_DEST" /proc/self/mountinfo
+        "${SNAP_NAME}".cmd test -e "$MOUNT_DEST/file1"
+
+        REBOOT
+    else
+        # after reboot
+
+        echo "Verify that the persistent mount is still active"
+        "${SNAP_NAME}".cmd grep "$MOUNT_DEST" /proc/self/mountinfo
+        "${SNAP_NAME}".cmd test -e "$MOUNT_DEST/file1"
+
+        echo "Remove the persistent mount"
+        "${SNAP_NAME}".cmd snapctl umount "$MOUNT_DEST"
+
+        echo "Verify that the mount is gone"
+        "${SNAP_NAME}".cmd grep "$MOUNT_DEST" /proc/self/mountinfo && exit 1
+        "${SNAP_NAME}".cmd test "!" -e "$MOUNT_DEST/file1"
     fi


### PR DESCRIPTION
This adds support for persistent mounts, via a `snapctl` subcommand.