### PR TITLE
cmd/snap: improve snap run help message

### DIFF
--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -141,7 +141,7 @@ func (s *SnapSuite) TestSubCommandHelpPrintsHelp(c *check.C) {
 		// regexp matches "Usage: snap <the command>" plus an arbitrary
 		// number of [<something>] plus an arbitrary number of
 		// <<something>> optionally ending in ellipsis
-		c.Check(s.Stdout(), check.Matches, fmt.Sprintf(`(?sm)Usage:\s+snap %s(?: \[[^][]+\])*(?:(?: <[^<>]+>)+(?:\.\.\.)?)?$.*`, cmd), comment)
+		c.Check(s.Stdout(), check.Matches, fmt.Sprintf(`(?sm)Usage:\s+snap %s(?: \[[^][]+\])*(?:(?: <[^<>]+>(?:\.<[^<>]+>)?)+(?:\.\.\.)?)?(?: \[[^][]+\])?$.*`, cmd), comment)
 		c.Check(s.Stderr(), check.Equals, "", comment)
 	}
 }

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -203,6 +203,10 @@ func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
 	return fmt.Errorf("timeout waiting for snap system profiles to get updated")
 }
 
+func (x *cmdRun) Usage() string {
+	return "[run-OPTIONS] <NAME-OF-SNAP>.<NAME-OF-APP> [<SNAP-APP-ARG>...]"
+}
+
 func (x *cmdRun) Execute(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf(i18n.G("need the application to run as argument"))


### PR DESCRIPTION
Snap run help message does not indicate how to run a snap application. Improve
it by adding placeholders for snap.app and its arguments.

Fixes: https://bugs.launchpad.net/snapd/+bug/1944393
