### PR TITLE
many: replace state.State restart support with overlord/restart

### DIFF
--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1150,8 +1150,7 @@ func (s *snapsSuite) TestPostSnapWithChannel(c *check.C) {
 }
 
 func (s *snapsSuite) TestPostSnapSystemRestartImmediate(c *check.C) {
-	checkOpts := func(opts *snapstate.RevisionOptions) {}
-	_, systemRestartImmediate := s.testPostSnap(c, `"system-restart-immediate": true`, checkOpts)
+	_, systemRestartImmediate := s.testPostSnap(c, `"system-restart-immediate": true`, nil)
 	c.Check(systemRestartImmediate, check.Equals, true)
 }
 
@@ -1168,7 +1167,9 @@ func (s *snapsSuite) testPostSnap(c *check.C, extraJSON string, checkOpts func(o
 
 	checked := false
 	defer daemon.MockSnapstateInstall(func(ctx context.Context, s *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
-		checkOpts(opts)
+		if checkOpts != nil {
+			checkOpts(opts)
+		}
 		checked = true
 		t := s.NewTask("fake-install-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
-	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
@@ -439,8 +439,8 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		d := s.daemon(c)
 		st := d.Overlord().State()
 		st.Lock()
-		// devicemgr needs boot id to request a reboot
-		st.VerifyReboot("boot-id-0")
+		// make things look like a reboot
+		restart.ReplaceBootID(st, "boot-id-1")
 		// device model
 		assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
 		assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
@@ -505,7 +505,7 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 				// daemon is not started, only check whether reboot was scheduled as expected
 
 				// reboot flag
-				c.Check(d.RequestedRestart(), check.Equals, state.RestartSystemNow, check.Commentf(tc.comment))
+				c.Check(d.RequestedRestart(), check.Equals, restart.RestartSystemNow, check.Commentf(tc.comment))
 				// slow reboot schedule
 				c.Check(cmd.Calls(), check.DeepEquals, [][]string{
 					{"shutdown", "-r", "+10", "reboot scheduled to update the system"},

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -60,7 +61,7 @@ func (d *Daemon) Overlord() *overlord.Overlord {
 	return d.overlord
 }
 
-func (d *Daemon) RequestedRestart() state.RestartType {
+func (d *Daemon) RequestedRestart() restart.RestartType {
 	return d.requestedRestart
 }
 

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -88,42 +89,42 @@ func (r *respJSON) JSON() *respJSON {
 	return r
 }
 
-func maintenanceForRestartType(rst state.RestartType) *errorResult {
+func maintenanceForRestartType(rst restart.RestartType) *errorResult {
 	e := &errorResult{}
 	switch rst {
-	case state.RestartSystem, state.RestartSystemNow:
+	case restart.RestartSystem, restart.RestartSystemNow:
 		e.Kind = client.ErrorKindSystemRestart
 		e.Message = systemRestartMsg
 		e.Value = map[string]interface{}{
 			"op": "reboot",
 		}
-	case state.RestartSystemHaltNow:
+	case restart.RestartSystemHaltNow:
 		e.Kind = client.ErrorKindSystemRestart
 		e.Message = systemHaltMsg
 		e.Value = map[string]interface{}{
 			"op": "halt",
 		}
-	case state.RestartSystemPoweroffNow:
+	case restart.RestartSystemPoweroffNow:
 		e.Kind = client.ErrorKindSystemRestart
 		e.Message = systemPoweroffMsg
 		e.Value = map[string]interface{}{
 			"op": "poweroff",
 		}
-	case state.RestartDaemon:
+	case restart.RestartDaemon:
 		e.Kind = client.ErrorKindDaemonRestart
 		e.Message = daemonRestartMsg
-	case state.RestartSocket:
+	case restart.RestartSocket:
 		e.Kind = client.ErrorKindDaemonRestart
 		e.Message = socketRestartMsg
-	case state.RestartUnset:
+	case restart.RestartUnset:
 		// shouldn't happen, maintenance for unset type should just be nil
 		panic("internal error: cannot marshal maintenance for RestartUnset")
 	}
 	return e
 }
 
-func (r *respJSON) addMaintenanceFromRestartType(rst state.RestartType) {
-	if rst == state.RestartUnset {
+func (r *respJSON) addMaintenanceFromRestartType(rst restart.RestartType) {
+	if rst == restart.RestartUnset {
 		// nothing to do
 		return
 	}

--- a/overlord/backend.go
+++ b/overlord/backend.go
@@ -23,13 +23,11 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/overlord/state"
 )
 
 type overlordStateBackend struct {
-	path           string
-	ensureBefore   func(d time.Duration)
-	requestRestart func(t state.RestartType)
+	path         string
+	ensureBefore func(d time.Duration)
 }
 
 func (osb *overlordStateBackend) Checkpoint(data []byte) error {
@@ -38,8 +36,4 @@ func (osb *overlordStateBackend) Checkpoint(data []byte) error {
 
 func (osb *overlordStateBackend) EnsureBefore(d time.Duration) {
 	osb.ensureBefore(d)
-}
-
-func (osb *overlordStateBackend) RequestRestart(t state.RestartType) {
-	osb.requestRestart(t)
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -44,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate/internal"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
@@ -1506,7 +1507,7 @@ var ErrUnsupportedAction = errors.New("unsupported action")
 func (m *DeviceManager) Reboot(systemLabel, mode string) error {
 	rebootCurrent := func() {
 		logger.Noticef("rebooting system")
-		m.state.RequestRestart(state.RestartSystemNow)
+		restart.Request(m.state, restart.RestartSystemNow)
 	}
 
 	// most simple case: just reboot
@@ -1530,7 +1531,7 @@ func (m *DeviceManager) Reboot(systemLabel, mode string) error {
 
 	switched := func(systemLabel string, sysAction *SystemAction) {
 		logger.Noticef("rebooting into system %q in %q mode", systemLabel, sysAction.Mode)
-		m.state.RequestRestart(state.RestartSystemNow)
+		restart.Request(m.state, restart.RestartSystemNow)
 	}
 	// even if we are already in the right mode we restart here by
 	// passing rebootCurrent as this is what the user requested
@@ -1549,7 +1550,7 @@ func (m *DeviceManager) RequestSystemAction(systemLabel string, action SystemAct
 	nop := func() {}
 	switched := func(systemLabel string, sysAction *SystemAction) {
 		logger.Noticef("restarting into system %q for action %q", systemLabel, sysAction.Title)
-		m.state.RequestRestart(state.RestartSystemNow)
+		restart.Request(m.state, restart.RestartSystemNow)
 	}
 	// we do nothing (nop) if the mode and system are the same
 	return m.switchToSystemAndMode(systemLabel, action.Mode, nop, switched)

--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -128,7 +129,7 @@ func (s *deviceMgrBootconfigSuite) testBootConfigUpdateRun(c *C, updateAttempted
 			c.Assert(log, HasLen, 1)
 			c.Check(log[0], Matches, ".* updated boot config assets")
 			// update was applied, thus a restart was requested
-			c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystem})
+			c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystem})
 		} else {
 			// update was not applied or failed
 			c.Check(s.restartRequests, HasLen, 0)

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -361,7 +362,7 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetOnCoreSimple(c *C, grade string, 
 	c.Check(rollbackDir, Equals, passedRollbackDir)
 	// should have been removed right after update
 	c.Check(osutil.IsDirectory(rollbackDir), Equals, false)
-	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystem})
+	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystem})
 }
 
 func (s *deviceMgrGadgetSuite) TestUpdateGadgetOnCoreSimple(c *C) {
@@ -1140,7 +1141,7 @@ func (s *deviceMgrGadgetSuite) testGadgetCommandlineUpdateRun(c *C, fromFiles, t
 		}
 		if updated {
 			// update was applied, thus a restart was requested
-			c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystem})
+			c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystem})
 		} else {
 			// update was not applied or failed
 			c.Check(s.restartRequests, HasLen, 0)
@@ -1471,7 +1472,7 @@ func (s *deviceMgrGadgetSuite) TestGadgetCommandlineUpdateUndo(c *C) {
 	c.Check(log[0], Matches, ".* Updated kernel command line")
 	c.Check(log[1], Matches, ".* Reverted kernel command line change")
 	// update was applied and then undone
-	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystem, state.RestartSystem})
+	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystem, restart.RestartSystem})
 	c.Check(restartCount, Equals, 2)
 	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args")
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -343,7 +344,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 
 	c.Assert(installRunCalled, Equals, 1)
 	c.Assert(bootMakeBootableCalled, Equals, 1)
-	c.Assert(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
+	c.Assert(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 
 	return nil
 }
@@ -421,7 +422,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallExpTasks(c *C) {
 	c.Assert(waitTasks[0].ID(), Equals, setupRunSystemTask.ID())
 
 	// we did request a restart through restartSystemToRunModeTask
-	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
+	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallWithInstallDeviceHookExpTasks(c *C) {
@@ -490,13 +491,13 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithInstallDeviceHookExpTasks(c *
 	c.Assert(waitTasks[0].ID(), Equals, installDevice.ID())
 
 	// we did request a restart through restartSystemToRunModeTask
-	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
+	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 
 	c.Assert(hooksCalled, HasLen, 1)
 	c.Assert(hooksCalled[0].HookName(), Equals, "install-device")
 }
 
-func (s *deviceMgrInstallModeSuite) testInstallWithInstallDeviceHookSnapctlReboot(c *C, arg string, rst state.RestartType) {
+func (s *deviceMgrInstallModeSuite) testInstallWithInstallDeviceHookSnapctlReboot(c *C, arg string, rst restart.RestartType) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
@@ -532,15 +533,15 @@ func (s *deviceMgrInstallModeSuite) testInstallWithInstallDeviceHookSnapctlReboo
 	c.Check(installSystem.Err(), IsNil)
 
 	// we did end up requesting the right shutdown
-	c.Check(s.restartRequests, DeepEquals, []state.RestartType{rst})
+	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{rst})
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallWithInstallDeviceHookSnapctlRebootHalt(c *C) {
-	s.testInstallWithInstallDeviceHookSnapctlReboot(c, "--halt", state.RestartSystemHaltNow)
+	s.testInstallWithInstallDeviceHookSnapctlReboot(c, "--halt", restart.RestartSystemHaltNow)
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallWithInstallDeviceHookSnapctlRebootPoweroff(c *C) {
-	s.testInstallWithInstallDeviceHookSnapctlReboot(c, "--poweroff", state.RestartSystemPoweroffNow)
+	s.testInstallWithInstallDeviceHookSnapctlReboot(c, "--poweroff", restart.RestartSystemPoweroffNow)
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallWithBrokenInstallDeviceHookUnhappy(c *C) {

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -1515,7 +1516,7 @@ volumes:
 	c.Check(chg.IsReady(), Equals, true)
 	c.Check(chg.Err(), IsNil)
 	c.Check(gadgetUpdateCalled, Equals, true)
-	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystem})
+	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystem})
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelGadgetAssetsParanoidCheck(c *C) {
@@ -2419,7 +2420,7 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 			defer st.Unlock()
 			// not strictly needed, but underlines there's a reboot
 			// happening
-			st.RequestRestart(state.RestartSystemNow)
+			restart.Request(st, restart.RestartSystemNow)
 		}
 		if fakeRebootCallsReady {
 			return nil
@@ -2454,7 +2455,7 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 	c.Check(chg.IsReady(), Equals, false)
 	c.Check(chg.Err(), IsNil)
 	// injected by fake restart
-	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystemNow})
+	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 	// 3 calls: promote tried system, old & new model, just the new model
 	c.Check(resealKeyCalls, Equals, 3)
 	// even if errors occur during reseal, set-model is done

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -89,7 +90,7 @@ type deviceMgrBaseSuite struct {
 
 	ancillary []asserts.Assertion
 
-	restartRequests []state.RestartType
+	restartRequests []restart.RestartType
 	restartObserve  func()
 
 	newFakeStore func(storecontext.DeviceBackend) snapstate.StoreService
@@ -157,15 +158,15 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 
 	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
 	s.restartObserve = nil
-	s.o = overlord.MockWithStateAndRestartHandler(nil, func(req state.RestartType) {
+	s.o = overlord.Mock()
+	s.state = s.o.State()
+	s.state.Lock()
+	restart.Init(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(req restart.RestartType) {
 		s.restartRequests = append(s.restartRequests, req)
 		if s.restartObserve != nil {
 			s.restartObserve()
 		}
-	})
-	s.state = s.o.State()
-	s.state.Lock()
-	s.state.VerifyReboot("boot-id-0")
+	}))
 	s.state.Unlock()
 	s.se = s.o.StateEngine()
 

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -309,7 +310,7 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv
 	// at this point the system is "restarting", pretend the restart has
 	// happened
 	c.Assert(chg.Status(), Equals, state.DoingStatus)
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2019 Canonical Ltd
+ * Copyright (C) 2015-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -1415,7 +1416,7 @@ snaps:
 	// at this point the system is "restarting", pretend the restart has
 	// happened
 	c.Assert(chg.Status(), Equals, state.DoingStatus)
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
@@ -1758,7 +1759,7 @@ snaps:
 	// at this point the system is "restarting", pretend the restart has
 	// happened
 	c.Assert(chg.Status(), Equals, state.DoingStatus)
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
@@ -1897,7 +1898,7 @@ snaps:
 	// at this point the system is "restarting", pretend the restart has
 	// happened
 	c.Assert(chg.Status(), Equals, state.DoingStatus)
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -78,7 +79,7 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 
 			// do not mark this task done as this makes it racy against taskrunner tear down (the next task
 			// could start). Let this task finish after snapd restart when preseed mode is off.
-			st.RequestRestart(state.StopDaemon)
+			restart.Request(st, restart.StopDaemon)
 		}
 
 		return &state.Retry{Reason: "mark-preseeded will be marked done when snapd is executed in normal mode"}

--- a/overlord/devicestate/handlers_bootconfig.go
+++ b/overlord/devicestate/handlers_bootconfig.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 )
@@ -81,7 +82,7 @@ func (m *DeviceManager) doUpdateManagedBootConfig(t *state.Task, _ *tomb.Tomb) e
 		// boot assets were updated, request a restart now so that the
 		// situation does not end up more complicated if more updates of
 		// boot assets were to be applied
-		st.RequestRestart(state.RestartSystem)
+		restart.Request(st, restart.RestartSystem)
 	}
 
 	// minimize wasteful redos

--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -209,7 +210,7 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 
 	// TODO: consider having the option to do this early via recovery in
 	// core20, have fallback code as well there
-	st.RequestRestart(state.RestartSystem)
+	restart.Request(st, restart.RestartSystem)
 
 	return nil
 }
@@ -284,7 +285,7 @@ func (m *DeviceManager) doUpdateGadgetCommandLine(t *state.Task, _ *tomb.Tomb) e
 	// kernel command line
 
 	// kernel command line was updated, request a reboot to make it effective
-	st.RequestRestart(state.RestartSystem)
+	restart.Request(st, restart.RestartSystem)
 	return nil
 }
 
@@ -321,6 +322,6 @@ func (m *DeviceManager) undoUpdateGadgetCommandLine(t *state.Task, _ *tomb.Tomb)
 	t.SetStatus(state.UndoneStatus)
 
 	// kernel command line was updated, request a reboot to make it effective
-	st.RequestRestart(state.RestartSystem)
+	restart.Request(st, restart.RestartSystem)
 	return nil
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/randutil"
@@ -570,18 +571,18 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 	// request by default a restart as the last action after a
 	// successful install or what install-device requested via
 	// snapctl reboot
-	rst := state.RestartSystemNow
+	rst := restart.RestartSystemNow
 	what := "restart"
 	switch rebootOpts.Op {
 	case RebootHaltOp:
 		what = "halt"
-		rst = state.RestartSystemHaltNow
+		rst = restart.RestartSystemHaltNow
 	case RebootPoweroffOp:
 		what = "poweroff"
-		rst = state.RestartSystemPoweroffNow
+		rst = restart.RestartSystemPoweroffNow
 	}
 	logger.Noticef("request immediate system %s", what)
-	st.RequestRestart(rst)
+	restart.Request(st, rst)
 
 	return nil
 }

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -272,7 +273,7 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 	t.SetStatus(state.DoneStatus)
 
 	logger.Noticef("restarting into candidate system %q", label)
-	m.state.RequestRestart(state.RestartSystemNow)
+	restart.Request(m.state, restart.RestartSystemNow)
 	return nil
 }
 
@@ -326,7 +327,7 @@ func (m *DeviceManager) doFinalizeTriedRecoverySystem(t *state.Task, _ *tomb.Tom
 	st.Lock()
 	defer st.Unlock()
 
-	if ok, _ := st.Restarting(); ok {
+	if ok, _ := restart.Pending(st); ok {
 		// don't continue until we are in the restarted snapd
 		t.Logf("Waiting for system reboot...")
 		return &state.Retry{}

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
@@ -544,7 +545,7 @@ func (s *preseedModeSuite) TestDoMarkPreseeded(c *C) {
 	})
 
 	// and snapd stop was requested
-	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.StopDaemon})
+	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.StopDaemon})
 
 	s.cmdUmount.ForgetCalls()
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
@@ -1953,9 +1954,9 @@ type: os
 	c.Assert(err, IsNil)
 
 	// final steps will are post poned until we are in the restarted snapd
-	ok, rst := st.Restarting()
+	ok, rst := restart.Pending(st)
 	c.Assert(ok, Equals, true)
-	c.Assert(rst, Equals, state.RestartSystem)
+	c.Assert(rst, Equals, restart.RestartSystem)
 
 	t := findKind(chg, "auto-connect")
 	c.Assert(t, NotNil)
@@ -1970,7 +1971,7 @@ type: os
 	})
 
 	// simulate successful restart happened
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	bloader.BootVars["snap_mode"] = boot.DefaultStatus
 	bloader.SetBootBase("core_x1.snap")
 
@@ -1989,10 +1990,10 @@ type rebootEnv interface {
 
 func (s *baseMgrsSuite) mockSuccessfulReboot(c *C, be rebootEnv, which []snap.Type) {
 	st := s.o.State()
-	restarting, restartType := st.Restarting()
+	restarting, restartType := restart.Pending(st)
 	c.Assert(restarting, Equals, true, Commentf("mockSuccessfulReboot called when there was no pending restart"))
-	c.Assert(restartType, Equals, state.RestartSystem, Commentf("mockSuccessfulReboot called but restartType is not SystemRestart but %v", restartType))
-	state.MockRestarting(st, state.RestartUnset)
+	c.Assert(restartType, Equals, restart.RestartSystem, Commentf("mockSuccessfulReboot called but restartType is not SystemRestart but %v", restartType))
+	restart.MockPending(st, restart.RestartUnset)
 	err := be.SetTryingDuringReboot(which)
 	c.Assert(err, IsNil)
 	s.o.DeviceManager().ResetToPostBootState()
@@ -2004,10 +2005,10 @@ func (s *baseMgrsSuite) mockSuccessfulReboot(c *C, be rebootEnv, which []snap.Ty
 
 func (s *baseMgrsSuite) mockRollbackAcrossReboot(c *C, be rebootEnv, which []snap.Type) {
 	st := s.o.State()
-	restarting, restartType := st.Restarting()
+	restarting, restartType := restart.Pending(st)
 	c.Assert(restarting, Equals, true, Commentf("mockRollbackAcrossReboot called when there was no pending restart"))
-	c.Assert(restartType, Equals, state.RestartSystem, Commentf("mockRollbackAcrossReboot called but restartType is not SystemRestart but %v", restartType))
-	state.MockRestarting(st, state.RestartUnset)
+	c.Assert(restartType, Equals, restart.RestartSystem, Commentf("mockRollbackAcrossReboot called but restartType is not SystemRestart but %v", restartType))
+	restart.MockPending(st, restart.RestartUnset)
 	err := be.SetRollbackAcrossReboot(which)
 	c.Assert(err, IsNil)
 	s.o.DeviceManager().ResetToPostBootState()
@@ -2087,7 +2088,7 @@ type: kernel`
 	st.Lock()
 	c.Assert(err, IsNil)
 	// we are in restarting state and the change is not done yet
-	restarting, _ := st.Restarting()
+	restarting, _ := restart.Pending(st)
 	c.Check(restarting, Equals, true)
 	c.Check(chg.Status(), Equals, state.DoingStatus)
 
@@ -2193,7 +2194,7 @@ type: kernel`
 	})
 
 	// we are in restarting state and the change is not done yet
-	restarting, _ := st.Restarting()
+	restarting, _ := restart.Pending(st)
 	c.Check(restarting, Equals, true)
 	c.Check(chg.Status(), Equals, state.DoingStatus)
 	// pretend we restarted
@@ -2214,7 +2215,7 @@ type: kernel`
 		"snap_kernel":     "pc-kernel_x1.snap",
 		"snap_mode":       boot.TryStatus,
 	})
-	restarting, _ = st.Restarting()
+	restarting, _ = restart.Pending(st)
 	c.Check(restarting, Equals, true)
 }
 
@@ -2323,7 +2324,7 @@ type: kernel`
 	})
 
 	// we are in restarting state and the change is not done yet
-	restarting, _ := st.Restarting()
+	restarting, _ := restart.Pending(st)
 	c.Check(restarting, Equals, true)
 	c.Check(chg.Status(), Equals, state.DoingStatus)
 
@@ -2517,7 +2518,7 @@ type: kernel`
 	c.Assert(currentTryKernel.Filename(), Equals, kernelSnapInfo.Filename())
 
 	// we are in restarting state and the change is not done yet
-	restarting, _ := st.Restarting()
+	restarting, _ := restart.Pending(st)
 	c.Check(restarting, Equals, true)
 	c.Check(chg.Status(), Equals, state.DoingStatus)
 	// pretend we restarted
@@ -2531,7 +2532,7 @@ type: kernel`
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 
 	// we should have triggered a reboot to undo the boot changes
-	restarting, _ = st.Restarting()
+	restarting, _ = restart.Pending(st)
 	c.Check(restarting, Equals, true)
 
 	// we need to reboot with a "new" try kernel, so kernel_status was set again
@@ -3781,7 +3782,7 @@ version: @VERSION@`
 	c.Assert(err, IsNil)
 
 	// simulate successful restart happened
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	tts[2].Tasks()[0].SetStatus(state.DefaultStatus)
 	st.Unlock()
 
@@ -4625,7 +4626,7 @@ version: 20.04`
 
 	// simulate successful restart happened and that the bootvars
 	// got updated
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	bloader.SetBootVars(map[string]string{
 		"snap_mode":   boot.DefaultStatus,
 		"snap_core":   "core20_2.snap",
@@ -4784,9 +4785,9 @@ version: 20.04`
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 
 	// and we are in restarting state
-	restarting, restartType := st.Restarting()
+	restarting, restartType := restart.Pending(st)
 	c.Check(restarting, Equals, true)
-	c.Check(restartType, Equals, state.RestartSystem)
+	c.Check(restartType, Equals, restart.RestartSystem)
 
 	// and the undo gave us our old kernel back
 	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
@@ -4921,7 +4922,7 @@ version: 20.04`
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 
 	// and we are *not* in restarting state
-	restarting, _ := st.Restarting()
+	restarting, _ := restart.Pending(st)
 	c.Check(restarting, Equals, false)
 	// bootvars unchanged
 	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
@@ -5420,9 +5421,9 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndo(c *C) {
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 
 	// and we are in restarting state
-	restarting, restartType := st.Restarting()
+	restarting, restartType := restart.Pending(st)
 	c.Check(restarting, Equals, true)
-	c.Check(restartType, Equals, state.RestartSystem)
+	c.Check(restartType, Equals, restart.RestartSystem)
 
 	// and the undo gave us our old kernel back
 	c.Assert(ms.bloader.BootVars, DeepEquals, map[string]string{
@@ -5476,7 +5477,7 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndoOnRollback(c *C) {
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 
 	// and we are *not* in restarting state
-	restarting, _ := st.Restarting()
+	restarting, _ := restart.Pending(st)
 	c.Check(restarting, Equals, false)
 
 	// and the undo gave us our old kernel back
@@ -5794,11 +5795,11 @@ volumes:
 	c.Check(updaterForStructureCalls, Equals, 1)
 
 	// gadget update requests a restart
-	restarting, _ := st.Restarting()
+	restarting, _ := restart.Pending(st)
 	c.Check(restarting, Equals, true)
 
 	// simulate successful restart happened
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -6481,9 +6482,9 @@ func (s *mgrsSuite) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) {
 
 	c.Check(chg.Status(), Equals, state.DoingStatus, Commentf("remodel change failed: %v", chg.Err()))
 	c.Check(devicestate.RemodelingChange(st), NotNil)
-	restarting, kind := st.Restarting()
+	restarting, kind := restart.Pending(st)
 	c.Check(restarting, Equals, true)
-	c.Assert(kind, Equals, state.RestartSystemNow)
+	c.Assert(kind, Equals, restart.RestartSystemNow)
 
 	now := time.Now()
 	expectedLabel := now.Format("20060102")
@@ -6506,7 +6507,7 @@ func (s *mgrsSuite) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) {
 	c.Assert(err, Equals, state.ErrNoState)
 
 	// simulate successful reboot to recovery and back
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	// this would be done by snap-bootstrap in initramfs
 	err = bl.SetBootVars(map[string]string{
 		"try_recovery_system":    expectedLabel,
@@ -6826,7 +6827,7 @@ type: kernel`
 	})
 
 	// we are in restarting state and the change is not done yet
-	restarting, _ := st.Restarting()
+	restarting, _ := restart.Pending(st)
 	c.Check(restarting, Equals, true)
 	c.Check(chg.Status(), Equals, state.DoingStatus)
 	s.mockRollbackAcrossReboot(c, bloader, []snap.Type{snap.TypeKernel})
@@ -7052,16 +7053,16 @@ WantedBy=multi-user.target
 
 	// check the snapd task state
 	c.Check(chg.Status(), Equals, state.DoingStatus)
-	restarting, kind := st.Restarting()
+	restarting, kind := restart.Pending(st)
 	c.Check(restarting, Equals, true)
-	c.Assert(kind, Equals, state.RestartDaemon)
+	c.Assert(kind, Equals, restart.RestartDaemon)
 
 	// now we do want the ensure loop to run though
 	r = servicestate.MockEnsuredSnapServices(s.o.ServiceManager(), false)
 	defer r()
 
 	// mock a restart of snapd to progress with the change
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 
 	// let the change run its course
 	st.Unlock()
@@ -7074,7 +7075,7 @@ WantedBy=multi-user.target
 
 	// we don't restart since the unit file was just rewritten, no services were
 	// killed
-	restarting, _ = st.Restarting()
+	restarting, _ = restart.Pending(st)
 	c.Check(restarting, Equals, false)
 
 	// the unit file was rewritten to use Wants= now
@@ -7291,16 +7292,16 @@ WantedBy=multi-user.target
 
 	// check the snapd task state
 	c.Check(chg.Status(), Equals, state.DoingStatus)
-	restarting, kind := st.Restarting()
+	restarting, kind := restart.Pending(st)
 	c.Check(restarting, Equals, true)
-	c.Assert(kind, Equals, state.RestartDaemon)
+	c.Assert(kind, Equals, restart.RestartDaemon)
 
 	// now we do want the ensure loop to run though
 	r = servicestate.MockEnsuredSnapServices(s.o.ServiceManager(), false)
 	defer r()
 
 	// mock a restart of snapd to progress with the change
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 
 	// let the change try to run its course
 	st.Unlock()
@@ -7313,9 +7314,9 @@ WantedBy=multi-user.target
 
 	// we do end up restarting now, since we tried to restart the service but
 	// failed and so to be safe as possible we reboot the system immediately
-	restarting, kind = st.Restarting()
+	restarting, kind = restart.Pending(st)
 	c.Check(restarting, Equals, true)
-	c.Assert(kind, Equals, state.RestartSystemNow)
+	c.Assert(kind, Equals, restart.RestartSystemNow)
 
 	// the unit file was rewritten to use Wants= now
 	rewrittenUnitFile := fmt.Sprintf(unitTempl,
@@ -7332,7 +7333,7 @@ WantedBy=multi-user.target
 	// of this test it's enough to ensure that 1) a restart is requested and 2)
 	// the manager ensure loop doesn't fail after we restart since the unit
 	// files don't need to be rewritten
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 
 	// we want the service ensure loop to run again to show it doesn't break
 	// anything
@@ -7470,12 +7471,12 @@ volumes:
 		// boot config is updated after link-snap, so first comes the
 		// daemon restart
 		c.Check(chg.Status(), Equals, state.DoingStatus)
-		restarting, kind := st.Restarting()
+		restarting, kind := restart.Pending(st)
 		c.Check(restarting, Equals, true)
-		c.Assert(kind, Equals, state.RestartDaemon)
+		c.Assert(kind, Equals, restart.RestartDaemon)
 
 		// simulate successful daemon restart happened
-		state.MockRestarting(st, state.RestartUnset)
+		restart.MockPending(st, restart.RestartUnset)
 
 		// let the change run its course
 		st.Unlock()
@@ -7484,12 +7485,12 @@ volumes:
 		c.Assert(err, IsNil)
 
 		c.Check(chg.Status(), Equals, state.DoneStatus, Commentf("change failed: %v", chg.Err()))
-		restarting, kind = st.Restarting()
+		restarting, kind = restart.Pending(st)
 		if updated {
 			// boot config updated, thus a system restart was
 			// requested
 			c.Check(restarting, Equals, true)
-			c.Assert(kind, Equals, state.RestartSystem)
+			c.Assert(kind, Equals, restart.RestartSystem)
 		} else {
 			c.Check(restarting, Equals, false)
 		}
@@ -7618,11 +7619,11 @@ func (s *mgrsSuite) testNonUC20RunUpdateManagedBootConfig(c *C, snapPath string,
 	c.Assert(err, IsNil)
 
 	c.Check(chg.Status(), Equals, state.DoingStatus)
-	restarting, _ := st.Restarting()
+	restarting, _ := restart.Pending(st)
 	c.Check(restarting, Equals, true)
 
 	// simulate successful restart happened
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	if si.RealName == "core" {
 		// pretend we switched to a new core
 		bl.SetBootVars(map[string]string{
@@ -7804,12 +7805,12 @@ func (s *mgrsSuite) testGadgetKernelCommandLine(c *C, gadgetPath string, gadgetS
 	if update {
 		// when updated, a system restart will be requested
 		c.Check(chg.Status(), Equals, state.DoingStatus, Commentf("change failed: %v", chg.Err()))
-		restarting, kind := st.Restarting()
+		restarting, kind := restart.Pending(st)
 		c.Check(restarting, Equals, true)
-		c.Assert(kind, Equals, state.RestartSystem)
+		c.Assert(kind, Equals, restart.RestartSystem)
 
 		// simulate successful system restart happened
-		state.MockRestarting(st, state.RestartUnset)
+		restart.MockPending(st, restart.RestartUnset)
 
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -8157,7 +8158,7 @@ volumes:
 	c.Assert(t, NotNil)
 	c.Assert(t.Status(), Equals, state.DoingStatus, Commentf("install-snap change failed with: %v", chg.Err()))
 	// simulate successful restart happened
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 
 	// settle again
 	st.Unlock()
@@ -8343,7 +8344,7 @@ volumes:
 	c.Assert(t, NotNil)
 	c.Assert(t.Status(), Equals, state.DoingStatus, Commentf("install-snap change failed with: %v", chg.Err()))
 	// simulate successful restart happened after gadget update
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 
 	// settle again
 	st.Unlock()

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -642,7 +642,3 @@ func (mb mockBackend) EnsureBefore(d time.Duration) {
 
 	mb.o.ensureBefore(d)
 }
-
-func (mb mockBackend) RequestRestart(t state.RestartType) {
-	panic("SHOULD NOT BE REACHED")
-}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -44,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/patch"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -86,8 +87,6 @@ type Overlord struct {
 
 	startOfOperationTime time.Time
 
-	// restarts
-	restartBehavior RestartBehavior
 	// managers
 	inited     bool
 	startedUp  bool
@@ -104,35 +103,21 @@ type Overlord struct {
 	proxyConf func(req *http.Request) (*url.URL, error)
 }
 
-// RestartBehavior controls how to hanndle and carry forward restart requests
-// via the state.
-type RestartBehavior interface {
-	HandleRestart(t state.RestartType)
-	// RebootAsExpected is called early when either a reboot was
-	// requested by snapd and happened or no reboot was expected at all.
-	RebootAsExpected(st *state.State) error
-	// RebootDidNotHappen is called early instead when a reboot was
-	// requested by snad but did not happen.
-	RebootDidNotHappen(st *state.State) error
-}
-
 var storeNew = store.New
 
 // New creates a new Overlord with all its state managers.
-// It can be provided with an optional RestartBehavior.
-func New(restartBehavior RestartBehavior) (*Overlord, error) {
+// It can be provided with an optional restart.Handler.
+func New(restartHandler restart.Handler) (*Overlord, error) {
 	o := &Overlord{
-		loopTomb:        new(tomb.Tomb),
-		inited:          true,
-		restartBehavior: restartBehavior,
+		loopTomb: new(tomb.Tomb),
+		inited:   true,
 	}
 
 	backend := &overlordStateBackend{
-		path:           dirs.SnapStateFile,
-		ensureBefore:   o.ensureBefore,
-		requestRestart: o.requestRestart,
+		path:         dirs.SnapStateFile,
+		ensureBefore: o.ensureBefore,
 	}
-	s, err := loadState(backend, restartBehavior)
+	s, err := loadState(backend, restartHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +209,7 @@ func (o *Overlord) addManager(mgr StateManager) {
 	o.stateEng.AddManager(mgr)
 }
 
-func loadState(backend state.Backend, restartBehavior RestartBehavior) (*state.State, error) {
+func loadState(backend state.Backend, restartHandler restart.Handler) (*state.State, error) {
 	curBootID, err := osutil.BootID()
 	if err != nil {
 		return nil, fmt.Errorf("fatal: cannot find current boot id: %v", err)
@@ -240,9 +225,7 @@ func loadState(backend state.Backend, restartBehavior RestartBehavior) (*state.S
 			return nil, fmt.Errorf("fatal: directory %q must be present", stateDir)
 		}
 		s := state.New(backend)
-		s.Lock()
-		s.VerifyReboot(curBootID)
-		s.Unlock()
+		initRestart(s, curBootID, restartHandler)
 		patch.Init(s)
 		return s, nil
 	}
@@ -264,7 +247,7 @@ func loadState(backend state.Backend, restartBehavior RestartBehavior) (*state.S
 	perfTimings.Save(s)
 	s.Unlock()
 
-	err = verifyReboot(s, curBootID, restartBehavior)
+	err = initRestart(s, curBootID, restartHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -277,24 +260,10 @@ func loadState(backend state.Backend, restartBehavior RestartBehavior) (*state.S
 	return s, nil
 }
 
-func verifyReboot(s *state.State, curBootID string, restartBehavior RestartBehavior) error {
+func initRestart(s *state.State, curBootID string, restartHandler restart.Handler) error {
 	s.Lock()
 	defer s.Unlock()
-	err := s.VerifyReboot(curBootID)
-	if err != nil && err != state.ErrExpectedReboot {
-		return err
-	}
-	expectedRebootDidNotHappen := err == state.ErrExpectedReboot
-	if restartBehavior != nil {
-		if expectedRebootDidNotHappen {
-			return restartBehavior.RebootDidNotHappen(s)
-		}
-		return restartBehavior.RebootAsExpected(s)
-	}
-	if expectedRebootDidNotHappen {
-		logger.Noticef("expected system restart but it did not happen")
-	}
-	return nil
+	return restart.Init(s, curBootID, restartHandler)
 }
 
 func (o *Overlord) newStoreWithContext(storeCtx store.DeviceAndAuthContext) snapstate.StoreService {
@@ -401,14 +370,6 @@ func (o *Overlord) ensureBefore(d time.Duration) {
 		}
 		o.ensureTimer.Reset(0)
 		o.ensureNext = now
-	}
-}
-
-func (o *Overlord) requestRestart(t state.RestartType) {
-	if o.restartBehavior == nil {
-		logger.Noticef("restart requested but no behavior set")
-	} else {
-		o.restartBehavior.HandleRestart(t)
 	}
 }
 
@@ -634,18 +595,16 @@ func (o *Overlord) SnapshotManager() *snapshotstate.SnapshotManager {
 // Mock creates an Overlord without any managers and with a backend
 // not using disk. Managers can be added with AddManager. For testing.
 func Mock() *Overlord {
-	return MockWithStateAndRestartHandler(nil, nil)
+	return MockWithState(nil)
 }
 
-// MockWithStateAndRestartHandler creates an Overlord with the given state
+// MockWithState creates an Overlord with the given state
 // unless it is nil in which case it uses a state backend not using
-// disk. It will use the given handler on restart requests. Managers
-// can be added with AddManager. For testing.
-func MockWithStateAndRestartHandler(s *state.State, handleRestart func(state.RestartType)) *Overlord {
+// disk. Managers can be added with AddManager. For testing.
+func MockWithState(s *state.State) *Overlord {
 	o := &Overlord{
-		loopTomb:        new(tomb.Tomb),
-		inited:          false,
-		restartBehavior: mockRestartBehavior(handleRestart),
+		loopTomb: new(tomb.Tomb),
+		inited:   false,
 	}
 	if s == nil {
 		s = state.New(mockBackend{o: o})
@@ -663,23 +622,6 @@ func (o *Overlord) AddManager(mgr StateManager) {
 		panic("internal error: cannot add managers to a fully initialized Overlord")
 	}
 	o.addManager(mgr)
-}
-
-type mockRestartBehavior func(state.RestartType)
-
-func (rb mockRestartBehavior) HandleRestart(t state.RestartType) {
-	if rb == nil {
-		return
-	}
-	rb(t)
-}
-
-func (rb mockRestartBehavior) RebootAsExpected(*state.State) error {
-	panic("internal error: overlord.Mock should not invoke RebootAsExpected")
-}
-
-func (rb mockRestartBehavior) RebootDidNotHappen(*state.State) error {
-	panic("internal error: overlord.Mock should not invoke RebootDidNotHappen")
 }
 
 type mockBackend struct {
@@ -702,5 +644,5 @@ func (mb mockBackend) EnsureBefore(d time.Duration) {
 }
 
 func (mb mockBackend) RequestRestart(t state.RestartType) {
-	mb.o.requestRestart(t)
+	panic("SHOULD NOT BE REACHED")
 }

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -1,0 +1,163 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package restart implements requesting restarts from any part of the code that has access to state.
+package restart
+
+import (
+	/*"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"*/
+
+	//"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type RestartType int
+
+const (
+	RestartUnset RestartType = iota
+	RestartDaemon
+	RestartSystem
+	// RestartSystemNow is like RestartSystem but action is immediate
+	RestartSystemNow
+	// RestartSocket will restart the daemon so that it goes into
+	// socket activation mode.
+	RestartSocket
+	// Stop just stops the daemon (used with image pre-seeding)
+	StopDaemon
+	// RestartSystemHaltNow will shutdown --halt the system asap
+	RestartSystemHaltNow
+	// RestartSystemPoweroffNow will shutdown --poweroff the system asap
+	RestartSystemPoweroffNow
+)
+
+// Handler can handle restart requests and whether expected reboots happen.
+type Handler interface {
+	HandleRestart(t RestartType)
+	// RebootAsExpected is called early when either a reboot was
+	// requested by snapd and happened or no reboot was expected at all.
+	RebootAsExpected(st *state.State) error
+	// RebootDidNotHappen is called early instead when a reboot was
+	// requested by snapd but did not happen.
+	RebootDidNotHappen(st *state.State) error
+}
+
+// Init initializes the support for restarts requests.
+// It takes the current boot id to track and verify reboots and a
+// Handler that handles the actual requests and reacts to reboot
+// happening.
+// It must be called with the state lock held.
+func Init(st *state.State, curBootID string, h Handler) error {
+	rs := &restartState{
+		h:      h,
+		bootID: curBootID,
+	}
+	var fromBootID string
+	err := st.Get("system-restart-from-boot-id", &fromBootID)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	st.Cache(restartStateKey{}, rs)
+	if fromBootID == "" {
+		return rs.rebootAsExpected(st)
+	}
+	if fromBootID == curBootID {
+		return rs.rebootDidNotHappen(st)
+	}
+	// we rebooted alright
+	ClearReboot(st)
+	return rs.rebootAsExpected(st)
+}
+
+// ClearReboot clears state information about tracking requested reboots.
+func ClearReboot(st *state.State) {
+	st.Set("system-restart-from-boot-id", nil)
+}
+
+type restartStateKey struct{}
+
+type restartState struct {
+	restarting RestartType
+	h          Handler
+	bootID     string
+}
+
+func (rs *restartState) handleRestart(t RestartType) {
+	if rs.h != nil {
+		rs.h.HandleRestart(t)
+	}
+}
+
+func (rs *restartState) rebootAsExpected(st *state.State) error {
+	if rs.h != nil {
+		return rs.h.RebootAsExpected(st)
+	}
+	return nil
+}
+
+func (rs *restartState) rebootDidNotHappen(st *state.State) error {
+	if rs.h != nil {
+		return rs.h.RebootDidNotHappen(st)
+	}
+	return nil
+}
+
+// Request asks for a restart of the managing process.
+// The state needs to be locked to request a restart.
+func Request(st *state.State, t RestartType) {
+	cached := st.Cached(restartStateKey{})
+	if cached == nil {
+		panic("internal error: cannot request a restart before restart.Init")
+	}
+	rs := cached.(*restartState)
+	switch t {
+	case RestartSystem, RestartSystemNow, RestartSystemHaltNow, RestartSystemPoweroffNow:
+		st.Set("system-restart-from-boot-id", rs.bootID)
+	}
+	rs.restarting = t
+	rs.handleRestart(t)
+}
+
+// Pending returns whether a restart was requested with Request and of which type.
+func Pending(st *state.State) (bool, RestartType) {
+	cached := st.Cached(restartStateKey{})
+	if cached == nil {
+		return false, RestartUnset
+	}
+	rs := cached.(*restartState)
+	return rs.restarting != RestartUnset, rs.restarting
+}
+
+func MockPending(st *state.State, restarting RestartType) RestartType {
+	cached := st.Cached(restartStateKey{})
+	if cached == nil {
+		panic("internal error: cannot mock a restart request before restart.Init")
+	}
+	rs := cached.(*restartState)
+	old := rs.restarting
+	rs.restarting = restarting
+	return old
+}

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -161,3 +161,12 @@ func MockPending(st *state.State, restarting RestartType) RestartType {
 	rs.restarting = restarting
 	return old
 }
+
+func ReplaceBootID(st *state.State, bootID string) {
+	cached := st.Cached(restartStateKey{})
+	if cached == nil {
+		panic("internal error: cannot mock a restart request before restart.Init")
+	}
+	rs := cached.(*restartState)
+	rs.bootID = bootID
+}

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -21,17 +21,6 @@
 package restart
 
 import (
-	/*"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"sort"
-	"strconv"
-	"sync"
-	"sync/atomic"
-	"time"*/
-
-	//"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/state"
 )
 

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -60,7 +60,7 @@ func (s *restartSuite) TestRequestRestartDaemon(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	// unitialized
+	// uninitialized
 	ok, t := restart.Pending(st)
 	c.Check(ok, Equals, false)
 	c.Check(t, Equals, restart.RestartUnset)

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -1,0 +1,143 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package restart_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestRestart(t *testing.T) { TestingT(t) }
+
+type restartSuite struct{}
+
+var _ = Suite(&restartSuite{})
+
+type testHandler struct {
+	restartRequested   bool
+	rebootAsExpected   bool
+	rebootDidNotHappen bool
+}
+
+func (h *testHandler) HandleRestart(t restart.RestartType) {
+	h.restartRequested = true
+}
+
+func (h *testHandler) RebootAsExpected(*state.State) error {
+	h.rebootAsExpected = true
+	return nil
+}
+
+func (h *testHandler) RebootDidNotHappen(*state.State) error {
+	h.rebootDidNotHappen = true
+	return nil
+}
+
+func (s *restartSuite) TestRequestRestartDaemon(c *C) {
+	st := state.New(nil)
+
+	st.Lock()
+	defer st.Unlock()
+
+	// unitialized
+	ok, t := restart.Pending(st)
+	c.Check(ok, Equals, false)
+	c.Check(t, Equals, restart.RestartUnset)
+
+	h := &testHandler{}
+
+	err := restart.Init(st, "boot-id-1", h)
+	c.Assert(err, IsNil)
+	c.Check(h.rebootAsExpected, Equals, true)
+
+	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, false)
+	c.Check(t, Equals, restart.RestartUnset)
+
+	restart.Request(st, restart.RestartDaemon)
+
+	c.Check(h.restartRequested, Equals, true)
+
+	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartDaemon)
+}
+
+func (s *restartSuite) TestRequestRestartDaemonNoHandler(c *C) {
+	st := state.New(nil)
+
+	st.Lock()
+	defer st.Unlock()
+
+	err := restart.Init(st, "boot-id-1", nil)
+	c.Assert(err, IsNil)
+
+	restart.Request(st, restart.RestartDaemon)
+
+	ok, t := restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartDaemon)
+}
+
+func (s *restartSuite) TestRequestRestartSystemAndVerifyReboot(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	h := &testHandler{}
+	err := restart.Init(st, "boot-id-1", h)
+	c.Assert(err, IsNil)
+	c.Check(h.rebootAsExpected, Equals, true)
+
+	ok, t := restart.Pending(st)
+	c.Check(ok, Equals, false)
+	c.Check(t, Equals, restart.RestartUnset)
+
+	restart.Request(st, restart.RestartSystem)
+
+	c.Check(h.restartRequested, Equals, true)
+
+	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartSystem)
+
+	var fromBootID string
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), IsNil)
+	c.Check(fromBootID, Equals, "boot-id-1")
+
+	h1 := &testHandler{}
+	err = restart.Init(st, "boot-id-1", h1)
+	c.Assert(err, IsNil)
+	c.Check(h1.rebootAsExpected, Equals, false)
+	c.Check(h1.rebootDidNotHappen, Equals, true)
+	fromBootID = ""
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), IsNil)
+	c.Check(fromBootID, Equals, "boot-id-1")
+
+	h2 := &testHandler{}
+	err = restart.Init(st, "boot-id-2", h2)
+	c.Assert(err, IsNil)
+	c.Check(h2.rebootAsExpected, Equals, true)
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), Equals, state.ErrNoState)
+}

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
@@ -179,7 +180,7 @@ func (m *ServiceManager) ensureSnapServicesUpdated() (err error) {
 		// we need to immediately reboot in the hopes that this restores
 		// services to a functioning state
 
-		m.state.RequestRestart(state.RestartSystemNow)
+		restart.Request(m.state, restart.RestartSystemNow)
 		return fmt.Errorf("error trying to restart killed services, immediately rebooting: %v", err)
 	}
 

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/settings"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
@@ -1551,7 +1552,7 @@ func (m *SnapManager) maybeRestart(t *state.Task, info *snap.Info, rebootRequire
 
 	if rebootRequired {
 		t.Logf("Requested system restart.")
-		st.RequestRestart(state.RestartSystem)
+		restart.Request(st, restart.RestartSystem)
 		return
 	}
 
@@ -1570,7 +1571,7 @@ func (m *SnapManager) maybeRestart(t *state.Task, info *snap.Info, rebootRequire
 	}
 
 	t.Logf(restartReason)
-	st.RequestRestart(state.RestartDaemon)
+	restart.Request(st, restart.RestartDaemon)
 }
 
 func daemonRestartReason(st *state.State, typ snap.Type) string {
@@ -1856,7 +1857,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	// core snap -> next core snap
 	if release.OnClassic && newInfo.Type() == snap.TypeOS && oldCurrent.Unset() {
 		t.Logf("Requested daemon restart (undo classic initial core install)")
-		st.RequestRestart(state.RestartDaemon)
+		restart.Request(st, restart.RestartDaemon)
 	}
 	return nil
 }

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -38,7 +38,7 @@ type discardSnapSuite struct {
 var _ = Suite(&discardSnapSuite{})
 
 func (s *discardSnapSuite) SetUpTest(c *C) {
-	s.setup(c, nil)
+	s.baseHandlerSuite.SetUpTest(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -43,7 +43,7 @@ type downloadSnapSuite struct {
 var _ = Suite(&downloadSnapSuite{})
 
 func (s *downloadSnapSuite) SetUpTest(c *C) {
-	s.setup(c, nil)
+	s.baseHandlerSuite.SetUpTest(c)
 
 	s.fakeStore = &fakeStore{
 		state:       s.state,

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -49,29 +50,19 @@ import (
 type linkSnapSuite struct {
 	baseHandlerSuite
 
-	stateBackend *witnessRestartReqStateBackend
+	restartRequested []restart.RestartType
 }
 
 var _ = Suite(&linkSnapSuite{})
 
-type witnessRestartReqStateBackend struct {
-	restartRequested []state.RestartType
-}
-
-func (b *witnessRestartReqStateBackend) Checkpoint([]byte) error {
-	return nil
-}
-
-func (b *witnessRestartReqStateBackend) RequestRestart(t state.RestartType) {
-	b.restartRequested = append(b.restartRequested, t)
-}
-
-func (b *witnessRestartReqStateBackend) EnsureBefore(time.Duration) {}
-
 func (s *linkSnapSuite) SetUpTest(c *C) {
-	s.stateBackend = &witnessRestartReqStateBackend{}
+	s.baseHandlerSuite.SetUpTest(c)
 
-	s.setup(c, s.stateBackend)
+	s.state.Lock()
+	restart.Init(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+		s.restartRequested = append(s.restartRequested, t)
+	}))
+	s.state.Unlock()
 
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
 
@@ -79,6 +70,7 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 	snapstate.SnapServiceOptions = servicestate.SnapServiceOptions
 	s.AddCleanup(func() {
 		snapstate.SnapServiceOptions = oldSnapServiceOptions
+		s.restartRequested = nil
 	})
 }
 
@@ -141,7 +133,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccess(c *C) {
 	c.Check(snapst.UserID, Equals, 2)
 	c.Check(snapst.CohortKey, Equals, "")
 	c.Check(t.Status(), Equals, state.DoneStatus)
-	c.Check(s.stateBackend.restartRequested, HasLen, 0)
+	c.Check(s.restartRequested, HasLen, 0)
 
 	// we end with the auxiliary store info
 	c.Check(snapstate.AuxStoreInfoFilename("foo-id"), testutil.FilePresent)
@@ -192,7 +184,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessWithCohort(c *C) {
 	c.Check(snapst.UserID, Equals, 2)
 	c.Check(snapst.CohortKey, Equals, "wobbling")
 	c.Check(t.Status(), Equals, state.DoneStatus)
-	c.Check(s.stateBackend.restartRequested, HasLen, 0)
+	c.Check(s.restartRequested, HasLen, 0)
 
 	// we end with the auxiliary store info
 	c.Check(snapstate.AuxStoreInfoFilename("foo-id"), testutil.FilePresent)
@@ -759,7 +751,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessCoreRestarts(c *C) {
 	c.Check(typ, Equals, snap.TypeOS)
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon})
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon})
 	c.Check(t.Log(), HasLen, 1)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart\.`)
 }
@@ -801,7 +793,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdRestartsOnCoreWithBase(c *C) {
 	c.Check(typ, Equals, snap.TypeSnapd)
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon})
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon})
 	c.Check(t.Log(), HasLen, 1)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
 }
@@ -817,10 +809,6 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForCoreBase(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-
-	// we need to init the boot-id
-	err := s.state.VerifyReboot("some-boot-id")
-	c.Assert(err, IsNil)
 
 	si := &snap.SideInfo{
 		RealName: "core18",
@@ -839,7 +827,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForCoreBase(c *C) {
 	s.state.Lock()
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartSystem})
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartSystem})
 	c.Assert(t.Log(), HasLen, 1)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested system restart.*`)
 }
@@ -878,7 +866,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdRestartsOnClassic(c *C) {
 	c.Check(typ, Equals, snap.TypeSnapd)
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon})
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon})
 	c.Check(t.Log(), HasLen, 1)
 }
 
@@ -925,7 +913,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessCoreAndSnapdNoCoreRestart(c *C) {
 	c.Check(typ, Equals, snap.TypeOS)
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
-	c.Check(s.stateBackend.restartRequested, IsNil)
+	c.Check(s.restartRequested, IsNil)
 	c.Check(t.Log(), HasLen, 0)
 }
 
@@ -1213,7 +1201,7 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCore(c *C) {
 	c.Check(snapst.Current, Equals, snap.R(1))
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon})
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon})
 	c.Check(lp.instanceNames, DeepEquals, []string{"core", "core"})
 }
 
@@ -1228,9 +1216,6 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCoreBase(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	// we need to init the boot-id
-	err := s.state.VerifyReboot("some-boot-id")
-	c.Assert(err, IsNil)
 
 	si1 := &snap.SideInfo{
 		RealName: "core18",
@@ -1265,14 +1250,14 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCoreBase(c *C) {
 	s.state.Lock()
 
 	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "core18", &snapst)
+	err := snapstate.Get(s.state, "core18", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, true)
 	c.Check(snapst.Sequence, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(1))
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartSystem})
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartSystem})
 }
 
 func (s *linkSnapSuite) TestDoUndoLinkSnapCoreClassic(c *C) {
@@ -1313,7 +1298,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapCoreClassic(c *C) {
 	c.Assert(err, Equals, state.ErrNoState)
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon, state.RestartDaemon})
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon, restart.RestartDaemon})
 
 }
 
@@ -1412,7 +1397,7 @@ func (s *linkSnapSuite) TestDoLinkSnapFailureCleansUpAux(c *C) {
 	defer s.state.Unlock()
 
 	c.Check(t.Status(), Equals, state.ErrorStatus)
-	c.Check(s.stateBackend.restartRequested, HasLen, 0)
+	c.Check(s.restartRequested, HasLen, 0)
 
 	// we end without the auxiliary store info
 	c.Check(snapstate.AuxStoreInfoFilename("foo-id"), testutil.FileAbsent)
@@ -1709,7 +1694,7 @@ func (s *linkSnapSuite) TestUndoLinkSnapdFirstInstall(c *C) {
 	c.Check(s.fakeBackend.ops, DeepEquals, expected)
 
 	// 2 restarts, one from link snap, another one from undo
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon, state.RestartDaemon})
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon, restart.RestartDaemon})
 	c.Check(t.Log(), HasLen, 3)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
 	c.Check(t.Log()[2], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
@@ -1782,7 +1767,7 @@ func (s *linkSnapSuite) TestUndoLinkSnapdNthInstall(c *C) {
 
 	// 1 restart from link snap, the other restart happens
 	// in undoUnlinkCurrentSnap (not tested here)
-	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon})
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon})
 	c.Assert(t.Log(), HasLen, 1)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
 }
@@ -1890,7 +1875,7 @@ func (s *linkSnapSuite) TestMaybeUndoRemodelBootChangesUnrelatedAppDoesNothing(c
 
 	err := s.snapmgr.MaybeUndoRemodelBootChanges(t)
 	c.Assert(err, IsNil)
-	c.Check(s.stateBackend.restartRequested, HasLen, 0)
+	c.Check(s.restartRequested, HasLen, 0)
 }
 
 func (s *linkSnapSuite) TestMaybeUndoRemodelBootChangesSameKernel(c *C) {
@@ -1909,7 +1894,7 @@ func (s *linkSnapSuite) TestMaybeUndoRemodelBootChangesSameKernel(c *C) {
 
 	err := s.snapmgr.MaybeUndoRemodelBootChanges(t)
 	c.Assert(err, IsNil)
-	c.Check(s.stateBackend.restartRequested, HasLen, 0)
+	c.Check(s.restartRequested, HasLen, 0)
 }
 
 func (s *linkSnapSuite) TestMaybeUndoRemodelBootChangesNeedsUndo(c *C) {
@@ -1924,10 +1909,6 @@ func (s *linkSnapSuite) TestMaybeUndoRemodelBootChangesNeedsUndo(c *C) {
 	// the (default) mocking of snapReadInfo()
 	restore = snapstate.MockSnapReadInfo(snap.ReadInfo)
 	defer restore()
-
-	// we need to init the boot-id
-	err := s.state.VerifyReboot("some-boot-id")
-	c.Assert(err, IsNil)
 
 	// we pretend we do a remodel from kernel -> new-kernel
 	s.setMockKernelRemodelCtx(c, "kernel", "new-kernel")
@@ -1965,7 +1946,7 @@ func (s *linkSnapSuite) TestMaybeUndoRemodelBootChangesNeedsUndo(c *C) {
 	})
 
 	// now we simulate that the new kernel is getting undone
-	err = s.snapmgr.MaybeUndoRemodelBootChanges(t)
+	err := s.snapmgr.MaybeUndoRemodelBootChanges(t)
 	c.Assert(err, IsNil)
 
 	// that will schedule a boot into the previous kernel
@@ -1974,8 +1955,8 @@ func (s *linkSnapSuite) TestMaybeUndoRemodelBootChangesNeedsUndo(c *C) {
 		"snap_kernel":     "new-kernel_1.snap",
 		"snap_try_kernel": "kernel_1.snap",
 	})
-	c.Check(s.stateBackend.restartRequested, HasLen, 1)
-	c.Check(s.stateBackend.restartRequested[0], Equals, state.RestartSystem)
+	c.Check(s.restartRequested, HasLen, 1)
+	c.Check(s.restartRequested[0], Equals, restart.RestartSystem)
 }
 
 func (s *linkSnapSuite) testDoLinkSnapWithToolingDependency(c *C, classicOrBase string) {

--- a/overlord/snapstate/handlers_mount_test.go
+++ b/overlord/snapstate/handlers_mount_test.go
@@ -40,7 +40,7 @@ type mountSnapSuite struct {
 var _ = Suite(&mountSnapSuite{})
 
 func (s *mountSnapSuite) SetUpTest(c *C) {
-	s.setup(c, nil)
+	s.baseHandlerSuite.SetUpTest(c)
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
 }
 

--- a/overlord/snapstate/handlers_prepare_test.go
+++ b/overlord/snapstate/handlers_prepare_test.go
@@ -44,13 +44,13 @@ type baseHandlerSuite struct {
 	fakeBackend *fakeSnappyBackend
 }
 
-func (s *baseHandlerSuite) setup(c *C, b state.Backend) {
+func (s *baseHandlerSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
 	dirs.SetRootDir(c.MkDir())
 
 	s.fakeBackend = &fakeSnappyBackend{}
-	s.state = state.New(b)
+	s.state = state.New(nil)
 	s.runner = state.NewTaskRunner(s.state)
 
 	var err error
@@ -81,10 +81,6 @@ func (s *baseHandlerSuite) setup(c *C, b state.Backend) {
 		return nil
 	})
 	s.AddCleanup(restoreSecurityProfilesDiscardLate)
-}
-
-func (s *baseHandlerSuite) SetUpTest(c *C) {
-	s.setup(c, nil)
 }
 
 type prepareSnapSuite struct {

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -48,7 +48,7 @@ type prereqSuite struct {
 var _ = Suite(&prereqSuite{})
 
 func (s *prereqSuite) SetUpTest(c *C) {
-	s.setup(c, nil)
+	s.baseHandlerSuite.SetUpTest(c)
 
 	s.fakeStore = &fakeStore{
 		state:       s.state,

--- a/overlord/snapstate/handlers_test.go
+++ b/overlord/snapstate/handlers_test.go
@@ -33,14 +33,12 @@ import (
 
 type handlersSuite struct {
 	baseHandlerSuite
-
-	stateBackend *witnessRestartReqStateBackend
 }
 
 var _ = Suite(&handlersSuite{})
 
 func (s *handlersSuite) SetUpTest(c *C) {
-	s.setup(c, s.stateBackend)
+	s.baseHandlerSuite.SetUpTest(c)
 
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -594,7 +595,7 @@ var generateSnapdWrappers = backend.GenerateSnapdWrappers
 // For snapd snap updates this will also rerun wrappers generation to fully
 // catch up with any change.
 func FinishRestart(task *state.Task, snapsup *SnapSetup) (err error) {
-	if ok, _ := task.State().Restarting(); ok {
+	if ok, _ := restart.Pending(task.State()); ok {
 		// don't continue until we are in the restarted snapd
 		task.Logf("Waiting for automatic snapd restart...")
 		return &state.Retry{}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
@@ -99,6 +100,9 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 
 	s.o = overlord.Mock()
 	s.state = s.o.State()
+	s.state.Lock()
+	restart.Init(s.state, "boot-id-0", nil)
+	s.state.Unlock()
 
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
@@ -3260,7 +3264,7 @@ func (s *snapmgrTestSuite) TestFinishRestartBasics(c *C) {
 	task := st.NewTask("auto-connect", "...")
 
 	// not restarting
-	state.MockRestarting(st, state.RestartUnset)
+	restart.MockPending(st, restart.RestartUnset)
 	si := &snap.SideInfo{RealName: "some-app"}
 	snaptest.MockSnap(c, "name: some-app\nversion: 1", si)
 	snapsup := &snapstate.SnapSetup{SideInfo: si}
@@ -3268,7 +3272,7 @@ func (s *snapmgrTestSuite) TestFinishRestartBasics(c *C) {
 	c.Check(err, IsNil)
 
 	// restarting ... we always wait
-	state.MockRestarting(st, state.RestartDaemon)
+	restart.MockPending(st, restart.RestartDaemon)
 	err = snapstate.FinishRestart(task, snapsup)
 	c.Check(err, FitsTypeOf, &state.Retry{})
 }
@@ -3327,7 +3331,7 @@ type: snapd
 		snapsup := &snapstate.SnapSetup{SideInfo: si, Type: snapInfo.SnapType}
 
 		// restarting
-		state.MockRestarting(st, state.RestartUnset)
+		restart.MockPending(st, restart.RestartUnset)
 		c.Assert(snapstate.FinishRestart(task, snapsup), IsNil)
 		c.Check(generateWrappersCalled, Equals, tc.expectedWrappersCall, Commentf("#%d: %v", i, tc))
 

--- a/overlord/snapstate/snapstatetest/restart.go
+++ b/overlord/snapstate/snapstatetest/restart.go
@@ -1,6 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -16,12 +17,28 @@
  *
  */
 
-package standby
+package snapstatetest
 
 import (
-	"time"
+	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/state"
 )
 
-func (m *StandbyOpinions) SetStartTime(t time.Time) {
-	m.startTime = t
+// MockRestartHandler mocks a restart.Handler based on a function
+// to witness the restart requests.
+type MockRestartHandler func(restart.RestartType)
+
+func (h MockRestartHandler) HandleRestart(t restart.RestartType) {
+	if h == nil {
+		return
+	}
+	h(t)
+}
+
+func (h MockRestartHandler) RebootAsExpected(*state.State) error {
+	return nil
+}
+
+func (h MockRestartHandler) RebootDidNotHappen(*state.State) error {
+	panic("internal error: mocking should not invoke RebootDidNotHappen")
 }

--- a/overlord/standby/standby.go
+++ b/overlord/standby/standby.go
@@ -23,13 +23,12 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
 var standbyWait = 5 * time.Second
 var maxWait = 5 * time.Minute
-
-var stateRequestRestart = (*state.State).RequestRestart
 
 type Opinionator interface {
 	CanStandby() bool
@@ -99,7 +98,9 @@ func (m *StandbyOpinions) Start() {
 		timer := time.NewTimer(wait)
 		for {
 			if m.CanStandby() {
-				stateRequestRestart(m.state, state.RestartSocket)
+				m.state.Lock()
+				restart.Request(m.state, restart.RestartSocket)
+				m.state.Unlock()
 			}
 			select {
 			case <-timer.C:

--- a/overlord/state/copy.go
+++ b/overlord/state/copy.go
@@ -47,10 +47,6 @@ func (b *checkpointOnlyBackend) EnsureBefore(d time.Duration) {
 	panic("cannot use EnsureBefore in checkpointOnlyBackend")
 }
 
-func (b *checkpointOnlyBackend) RequestRestart(t RestartType) {
-	panic("cannot use RequestRestart in checkpointOnlyBackend")
-}
-
 // copyData will copy the given subkeys specifier from srcData to dstData.
 //
 // The subkeys is constructed from a dotted path like "user.auth". This copy

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -185,10 +185,9 @@ func (ss *stateSuite) TestCache(c *C) {
 }
 
 type fakeStateBackend struct {
-	checkpoints      [][]byte
-	error            func() error
-	ensureBefore     time.Duration
-	restartRequested bool
+	checkpoints  [][]byte
+	error        func() error
+	ensureBefore time.Duration
 }
 
 func (b *fakeStateBackend) Checkpoint(data []byte) error {
@@ -201,10 +200,6 @@ func (b *fakeStateBackend) Checkpoint(data []byte) error {
 
 func (b *fakeStateBackend) EnsureBefore(d time.Duration) {
 	b.ensureBefore = d
-}
-
-func (b *fakeStateBackend) RequestRestart(t state.RestartType) {
-	b.restartRequested = true
 }
 
 func (ss *stateSuite) TestImplicitCheckpointAndRead(c *C) {
@@ -978,71 +973,6 @@ func (ss *stateSuite) TestPruneHonorsStartOperationTime(c *C) {
 	st.Prune(opTime, pruneWait, abortWait, 100)
 	c.Assert(st.Changes(), HasLen, 1)
 	c.Check(chg.Status(), Equals, state.HoldStatus)
-}
-
-func (ss *stateSuite) TestRequestRestart(c *C) {
-	b := new(fakeStateBackend)
-	st := state.New(b)
-
-	ok, t := st.Restarting()
-	c.Check(ok, Equals, false)
-	c.Check(t, Equals, state.RestartUnset)
-
-	st.RequestRestart(state.RestartDaemon)
-
-	c.Check(b.restartRequested, Equals, true)
-
-	ok, t = st.Restarting()
-	c.Check(ok, Equals, true)
-	c.Check(t, Equals, state.RestartDaemon)
-}
-
-func (ss *stateSuite) TestRequestRestartSystemAndVerifyReboot(c *C) {
-	b := new(fakeStateBackend)
-	st := state.New(b)
-
-	st.Lock()
-	err := st.VerifyReboot("boot-id-1")
-	st.Unlock()
-	c.Assert(err, IsNil)
-
-	ok, t := st.Restarting()
-	c.Check(ok, Equals, false)
-	c.Check(t, Equals, state.RestartUnset)
-
-	st.Lock()
-	st.RequestRestart(state.RestartSystem)
-	st.Unlock()
-
-	c.Check(b.restartRequested, Equals, true)
-
-	ok, t = st.Restarting()
-	c.Check(ok, Equals, true)
-	c.Check(t, Equals, state.RestartSystem)
-
-	var fromBootID string
-	st.Lock()
-	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), IsNil)
-	st.Unlock()
-	c.Check(fromBootID, Equals, "boot-id-1")
-
-	st.Lock()
-	err = st.VerifyReboot("boot-id-1")
-	st.Unlock()
-	c.Check(err, Equals, state.ErrExpectedReboot)
-	fromBootID = ""
-	st.Lock()
-	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), IsNil)
-	st.Unlock()
-	c.Check(fromBootID, Equals, "boot-id-1")
-
-	st.Lock()
-	err = st.VerifyReboot("boot-id-2")
-	st.Unlock()
-	c.Assert(err, IsNil)
-	st.Lock()
-	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), Equals, state.ErrNoState)
-	st.Unlock()
 }
 
 func (ss *stateSuite) TestReadStateInitsCache(c *C) {

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -1030,6 +1030,11 @@ func (ss *stateSuite) TestRequestRestartSystemAndVerifyReboot(c *C) {
 	err = st.VerifyReboot("boot-id-1")
 	st.Unlock()
 	c.Check(err, Equals, state.ErrExpectedReboot)
+	fromBootID = ""
+	st.Lock()
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), IsNil)
+	st.Unlock()
+	c.Check(fromBootID, Equals, "boot-id-1")
 
 	st.Lock()
 	err = st.VerifyReboot("boot-id-2")

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -58,8 +58,6 @@ func (b *stateBackend) EnsureBefore(d time.Duration) {
 	}
 }
 
-func (b *stateBackend) RequestRestart(t state.RestartType) {}
-
 func ensureChange(c *C, r *state.TaskRunner, sb *stateBackend, chg *state.Change) {
 	for i := 0; i < 20; i++ {
 		sb.ensureBefore = time.Hour


### PR DESCRIPTION
this offers functionality equivalent to state.State.RequestRestart
etc but on top of the state itself instead of tied into it

a small difference is that this required the state lock being held
consistently while some subset of the old functionality didn't need
it
