### PR TITLE
desktop, usersession: observe notifications

### DIFF
--- a/desktop/notification/gtk.go
+++ b/desktop/notification/gtk.go
@@ -20,6 +20,9 @@
 package notification
 
 import (
+	"context"
+	"time"
+
 	"github.com/godbus/dbus"
 )
 
@@ -33,6 +36,7 @@ type gtkBackend struct {
 	conn      *dbus.Conn
 	manager   dbus.BusObject
 	desktopID string
+	firstUse  time.Time
 }
 
 // TODO: support actions via session agent.
@@ -50,6 +54,7 @@ var newGtkBackend = func(conn *dbus.Conn, desktopID string) (NotificationManager
 		conn:      conn,
 		manager:   conn.Object(gtkBusName, gtkObjectPath),
 		desktopID: desktopID,
+		firstUse:  time.Now(),
 	}
 	return b, nil
 }
@@ -94,4 +99,13 @@ func (srv *gtkBackend) SendNotification(id ID, msg *Message) error {
 func (srv *gtkBackend) CloseNotification(id ID) error {
 	call := srv.manager.Call(gtkInterface+".RemoveNotification", 0, srv.desktopID, id)
 	return call.Store()
+}
+
+func (srv *gtkBackend) HandleNotifications(context.Context) error {
+	// do nothing
+	return nil
+}
+
+func (srv *gtkBackend) IdleDuration() time.Duration {
+	return time.Since(srv.firstUse)
 }

--- a/desktop/notification/manager.go
+++ b/desktop/notification/manager.go
@@ -20,12 +20,18 @@
 package notification
 
 import (
+	"context"
+	"time"
+
 	"github.com/godbus/dbus"
 )
 
 type NotificationManager interface {
 	SendNotification(id ID, msg *Message) error
 	CloseNotification(id ID) error
+	IdleDuration() time.Duration
+
+	HandleNotifications(ctx context.Context) error
 }
 
 func NewNotificationManager(conn *dbus.Conn, desktopID string) NotificationManager {

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -249,10 +249,6 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 		})
 	}
 
-	// TODO: should be instantiated once on startup as for fdoBackend it keeps
-	// notification mappings.
-	notifySrv := notification.NewNotificationManager(c.s.bus, "io.snapcraft.SessionAgent")
-
 	// TODO: this message needs to be crafted better as it's the only thing guaranteed to be delivered.
 	summary := fmt.Sprintf(i18n.G("Pending update of %q snap"), refreshInfo.InstanceName)
 	var urgencyLevel notification.Urgency
@@ -298,7 +294,7 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 
 	// TODO: silently ignore error returned when the notification server does not exist.
 	// TODO: track returned notification ID and respond to actions, if supported.
-	if err := notifySrv.SendNotification(notification.ID(fmt.Sprintf("refresh:%s", refreshInfo.InstanceName)), msg); err != nil {
+	if err := c.s.notificationMgr.SendNotification(notification.ID(refreshInfo.InstanceName), msg); err != nil {
 		return SyncResponse(&resp{
 			Type:   ResponseTypeError,
 			Status: 500,

--- a/usersession/agent/session_agent.go
+++ b/usersession/agent/session_agent.go
@@ -323,6 +323,12 @@ func (s *SessionAgent) handleNotifications() error {
 // Stop performs a graceful shutdown of the session agent and waits up to 5
 // seconds for it to complete.
 func (s *SessionAgent) Stop() error {
+	if s.bus != nil {
+		_, err := s.bus.ReleaseName(sessionAgentBusName)
+		if err != nil {
+			logger.Noticef("%v", err)
+		}
+	}
 	s.tomb.Kill(nil)
 	return s.tomb.Wait()
 }

--- a/usersession/agent/session_agent.go
+++ b/usersession/agent/session_agent.go
@@ -310,7 +310,7 @@ Loop:
 	return nil
 }
 
-// handleNotifications blocks handling notifications.
+// handleNotifications handles notifications in a blocking manner.
 // This should only be called when notificationMgr is available (i.e. s.bus is set).
 func (s *SessionAgent) handleNotifications() error {
 	err := s.notificationMgr.HandleNotifications(s.tomb.Context(context.Background()))


### PR DESCRIPTION
Observe notifications and handle notification closing and idle duration - usersession agent needs to stay alive till we have any notifications that need to be monitored for close signal. This is only needed for fdo backend which needs to update its internal mappings. The notification manager instance is now created on agent startup and kept around for its lifetime.

Also fixes reading from the channel which would sometimes panic with segmentation violation, depending on the timing (whether ObserveNotifications loop breaks due to ctx.Done() or final channel receive.

This is followup to the recently landed notifications PR and implementation of the plan outlined here: https://forum.snapcraft.io/t/a-desktop-notifications-client-api-for-snapd/25063