### PR TITLE
o/snapstate: support ignore-validation flag when updating to a specific snap revision

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1931,7 +1931,7 @@ func infoForUpdate(st *state.State, snapst *SnapState, name string, opts *Revisi
 	}
 	if sideInfo == nil {
 		// refresh from given revision from store
-		return updateToRevisionInfo(st, snapst, opts.Revision, userID, deviceCtx)
+		return updateToRevisionInfo(st, snapst, opts.Revision, userID, flags, deviceCtx)
 	}
 
 	// refresh-to-local, this assumes the snap revision is mounted


### PR DESCRIPTION
Support --ignore-validation flag when requesting refresh to a specific revision and it doesn't match the revision required by validation set.

Followup to #10760 