### PR TITLE
overlord/devicestate: record recovery capable system on a successful remodel

### DIFF
--- a/boot/debug.go
+++ b/boot/debug.go
@@ -71,6 +71,7 @@ func DebugDumpBootVars(w io.Writer, dir string, uc20 bool) error {
 			"kernel_status",
 			"recovery_system_status",
 			"try_recovery_system",
+			"snapd_good_recovery_systems",
 			"snapd_extra_cmdline_args",
 			"snapd_full_cmdline_args",
 		}

--- a/cmd/snap/cmd_debug_bootvars_test.go
+++ b/cmd/snap/cmd_debug_bootvars_test.go
@@ -102,12 +102,13 @@ func (s *SnapSuite) TestDebugGetSetBootvarsWithParams(c *check.C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	err := bloader.SetBootVars(map[string]string{
-		"snapd_recovery_system":  "1234",
-		"snapd_recovery_mode":    "run",
-		"unrelated":              "thing",
-		"snap_kernel":            "pc-kernel_3.snap",
-		"recovery_system_status": "try",
-		"try_recovery_system":    "9999",
+		"snapd_recovery_system":       "1234",
+		"snapd_recovery_mode":         "run",
+		"unrelated":                   "thing",
+		"snap_kernel":                 "pc-kernel_3.snap",
+		"recovery_system_status":      "try",
+		"try_recovery_system":         "9999",
+		"snapd_good_recovery_systems": "0000",
 	})
 	c.Assert(err, check.IsNil)
 
@@ -122,6 +123,7 @@ snap_try_kernel=
 kernel_status=
 recovery_system_status=try
 try_recovery_system=9999
+snapd_good_recovery_systems=0000
 snapd_extra_cmdline_args=
 snapd_full_cmdline_args=
 `)

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -286,6 +286,9 @@ func (rc *baseRemodelContext) updateRunModeSystem() error {
 	}); err != nil {
 		return fmt.Errorf("cannot record a new seeded system: %v", err)
 	}
+	if err := boot.MarkRecoveryCapableSystem(rc.recoverySystemLabel); err != nil {
+		return fmt.Errorf("cannot mark system %q as recovery capable", rc.recoverySystemLabel)
+	}
 	return nil
 }
 

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -1008,6 +1008,11 @@ func (s *uc20RemodelLogicSuite) SetUpTest(c *C) {
 	err = devicestate.RecordSeededSystem(s.mgr, s.state, &sys)
 	c.Assert(err, IsNil)
 	s.oldSeededTs = sys.SeedTime
+
+	err = s.bootloader.SetBootVars(map[string]string{
+		"snapd_good_recovery_systems": "0000",
+	})
+	c.Assert(err, IsNil)
 }
 
 var uc20ModelDefaults = map[string]interface{}{
@@ -1149,6 +1154,11 @@ func (s *uc20RemodelLogicSuite) TestReregRemodelContextUC20(c *C) {
 		"seed-time": "",
 	})
 	c.Assert(newSeedTs.After(s.oldSeededTs), Equals, true)
+	env, err := s.bootloader.GetBootVars("snapd_good_recovery_systems")
+	c.Assert(err, IsNil)
+	c.Assert(env, DeepEquals, map[string]string{
+		"snapd_good_recovery_systems": "0000,1234",
+	})
 }
 
 func (s *uc20RemodelLogicSuite) TestUpdateRemodelContext(c *C) {
@@ -1248,6 +1258,11 @@ func (s *uc20RemodelLogicSuite) TestUpdateRemodelContext(c *C) {
 		"seed-time": "",
 	})
 	c.Assert(newSeedTs.After(s.oldSeededTs), Equals, true)
+	env, err := s.bootloader.GetBootVars("snapd_good_recovery_systems")
+	c.Assert(err, IsNil)
+	c.Assert(env, DeepEquals, map[string]string{
+		"snapd_good_recovery_systems": "0000,1234",
+	})
 }
 
 func (s *uc20RemodelLogicSuite) TestSimpleRemodelErr(c *C) {
@@ -1318,4 +1333,9 @@ func (s *uc20RemodelLogicSuite) TestSimpleRemodelErr(c *C) {
 		"timestamp": s.oldModel.Timestamp().Format(time.RFC3339Nano),
 		"seed-time": s.oldSeededTs.Format(time.RFC3339Nano),
 	}})
+	env, err := s.bootloader.GetBootVars("snapd_good_recovery_systems")
+	c.Assert(err, IsNil)
+	c.Assert(env, DeepEquals, map[string]string{
+		"snapd_good_recovery_systems": "0000",
+	})
 }

--- a/tests/nested/manual/core20-remodel/task.yaml
+++ b/tests/nested/manual/core20-remodel/task.yaml
@@ -47,6 +47,7 @@ execute: |
     tests.nested exec "sudo cat /var/lib/snapd/modeenv" > modeenv
     MATCH "current_recovery_systems=.*,${revno2_label}" < modeenv
     MATCH "good_recovery_systems=.*,${revno2_label}" < modeenv
+    tests.nested exec "sudo snap debug boot-vars --root-dir=/run/mnt/ubuntu-seed" | MATCH "snapd_good_recovery_systems=${label_base},${revno2_label}"
 
     # the revision pulls in test-snapd-tools-core20 snap
     echo "Verify new model revision snaps"
@@ -77,6 +78,7 @@ execute: |
     tests.nested exec "sudo cat /var/lib/snapd/modeenv" > modeenv
     MATCH "current_recovery_systems=.*,${revno3_label}" < modeenv
     MATCH "good_recovery_systems=.*,${revno3_label}" < modeenv
+    tests.nested exec "sudo snap debug boot-vars --root-dir=/run/mnt/ubuntu-seed" | MATCH "snapd_good_recovery_systems=${label_base},${revno2_label},${revno3_label}"
 
     # because the system is considered 'seeded' we are able to switch to the
     # recover mode


### PR DESCRIPTION
When the remodel is successful, update the bootloader environment with a new
recovery capable system.
