### PR TITLE
osutil/disks: support filtering by mount opts in MountPointsForPartitionRoot

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -118,10 +118,13 @@ type Partition struct {
 }
 
 // MountPointsForPartitionRoot returns all mounts from the mount table which are
-// for the root directory of the specified partition. The order in which they
-// are returned is the exact order that they appear in the mount table.
-func MountPointsForPartitionRoot(p Partition) ([]string, error) {
-	return mountPointsForPartitionRoot(p)
+// for the root directory of the specified partition and have matching mount
+// options as specified. Options not specified in the map argument can have any
+// value or be set or unset, but any option set in the map must match exactly.
+// The order in which they are returned is the same order that they appear in
+// the mount table.
+func MountPointsForPartitionRoot(p Partition, matchingMountOptions map[string]string) ([]string, error) {
+	return mountPointsForPartitionRoot(p, matchingMountOptions)
 }
 
 // PartitionNotFoundError is an error where a partition matching the SearchType

--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -76,7 +76,10 @@ type Disk interface {
 	// does not have partitions for example.
 	HasPartitions() bool
 
-	// Partitions returns all partitions found on a physical disk device.
+	// Partitions returns all partitions found on a physical disk device. Note
+	// that this method, and all others that require discovering partitions on
+	// the disk, caches the partitions once first found and does not re-discover
+	// partitions again later on if the disk is re-partitioned.
 	Partitions() ([]Partition, error)
 
 	// KernelDeviceNode returns the full device node path in /dev/ for the disk
@@ -110,6 +113,8 @@ type Partition struct {
 	KernelDevicePath string
 	// KernelDeviceNode is the kernel device node in /dev.
 	KernelDeviceNode string
+	// TODO: also include a Disk field for finding what Disk this partition came
+	// from?
 }
 
 // RootMountPointsForPartition returns all mounts from the mount table which are

--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -117,11 +117,11 @@ type Partition struct {
 	// from?
 }
 
-// RootMountPointsForPartition returns all mounts from the mount table which are
+// MountPointsForPartitionRoot returns all mounts from the mount table which are
 // for the root directory of the specified partition. The order in which they
 // are returned is the exact order that they appear in the mount table.
-func RootMountPointsForPartition(p Partition) ([]string, error) {
-	return rootMountPointsForPartition(p)
+func MountPointsForPartitionRoot(p Partition) ([]string, error) {
+	return mountPointsForPartitionRoot(p)
 }
 
 // PartitionNotFoundError is an error where a partition matching the SearchType

--- a/osutil/disks/disks_darwin.go
+++ b/osutil/disks/disks_darwin.go
@@ -41,6 +41,6 @@ var diskFromMountPoint = func(mountpoint string, opts *Options) (Disk, error) {
 	return nil, osutil.ErrDarwin
 }
 
-var mountPointsForPartitionRoot = func(p Partition) ([]string, error) {
+var mountPointsForPartitionRoot = func(p Partition, opts map[string]string) ([]string, error) {
 	return nil, osutil.ErrDarwin
 }

--- a/osutil/disks/disks_darwin.go
+++ b/osutil/disks/disks_darwin.go
@@ -41,6 +41,6 @@ var diskFromMountPoint = func(mountpoint string, opts *Options) (Disk, error) {
 	return nil, osutil.ErrDarwin
 }
 
-var rootMountPointsForPartition = func(p Partition) ([]string, error) {
+var mountPointsForPartitionRoot = func(p Partition) ([]string, error) {
 	return nil, osutil.ErrDarwin
 }

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -188,7 +188,7 @@ var diskFromDeviceName = func(deviceName string) (Disk, error) {
 	return diskFromUdevProps(deviceName, "name", props)
 }
 
-func rootMountPointsForPartition(part Partition) ([]string, error) {
+func mountPointsForPartitionRoot(part Partition) ([]string, error) {
 	mounts, err := osutil.LoadMountInfo()
 	if err != nil {
 		return nil, err
@@ -196,10 +196,8 @@ func rootMountPointsForPartition(part Partition) ([]string, error) {
 
 	mountpoints := []string{}
 	for _, mnt := range mounts {
-		if mnt.DevMajor == part.Major && mnt.DevMinor == part.Minor {
-			if mnt.Root == "/" {
-				mountpoints = append(mountpoints, mnt.MountDir)
-			}
+		if mnt.DevMajor == part.Major && mnt.DevMinor == part.Minor && mnt.Root == "/" {
+			mountpoints = append(mountpoints, mnt.MountDir)
 		}
 	}
 

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -892,7 +892,7 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 	c.Assert(matches, Equals, true)
 }
 
-func (s *diskSuite) TestRootMountPointsForPartition(c *C) {
+func (s *diskSuite) TestMountPointsForPartitionRoot(c *C) {
 	const (
 		validRootMnt1    = "130 30 42:1 / /run/mnt/ubuntu-data rw,relatime shared:54 - ext4 /dev/vda3 rw\n"
 		validRootMnt2    = "130 30 42:1 / /run/mnt/foo-other-place rw,relatime shared:54 - ext4 /dev/vda3 rw\n"
@@ -950,7 +950,7 @@ func (s *diskSuite) TestRootMountPointsForPartition(c *C) {
 			part.Minor = 1
 		}
 
-		res, err := disks.RootMountPointsForPartition(part)
+		res, err := disks.MountPointsForPartitionRoot(part)
 		c.Check(err, IsNil, cmt)
 
 		if len(t.exp) == 0 {

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -894,44 +894,86 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 
 func (s *diskSuite) TestMountPointsForPartitionRoot(c *C) {
 	const (
-		validRootMnt1    = "130 30 42:1 / /run/mnt/ubuntu-data rw,relatime shared:54 - ext4 /dev/vda3 rw\n"
-		validRootMnt2    = "130 30 42:1 / /run/mnt/foo-other-place rw,relatime shared:54 - ext4 /dev/vda3 rw\n"
-		validNonRootMnt1 = "130 30 42:1 /subdir /run/mnt/other-ubuntu-data rw,relatime shared:54 - ext4 /dev/vda3 rw\n"
-		validNonRootMnt2 = "130 30 42:1 /subdir2 /run/mnt/other-ubuntu-data-other-other rw,relatime shared:54 - ext4 /dev/vda3 rw\n"
+		validRootMnt1         = "130 30 42:1 / /run/mnt/ubuntu-seed rw,relatime,key=val shared:54 - ext4 /dev/vda3 rw\n"
+		validRootMnt2         = "130 30 42:1 / /run/mnt/foo-other-place rw,relatime,key=val shared:54 - ext4 /dev/vda3 rw\n"
+		validRootMnt3ReadOnly = "130 30 42:1 / /var/lib/snapd/seed ro,relatime,key=val shared:54 - ext4 /dev/vda3 rw\n"
+		validNonRootMnt1      = "130 30 42:1 /subdir /run/mnt/other-ubuntu-seed rw,relatime,key=val shared:54 - ext4 /dev/vda3 rw\n"
+		validNonRootMnt2      = "130 30 42:1 /subdir2 /run/mnt/other-ubuntu-seed-other-other rw,relatime,key=val shared:54 - ext4 /dev/vda3 rw\n"
 	)
 
 	tt := []struct {
 		maj, min  int
 		mountinfo string
+		mountOpts map[string]string
 		exp       []string
 		comment   string
 	}{
 		{
-			comment:   "single valid root mountpoint",
+			comment:   "single valid root mountpoint, no opt filter",
 			mountinfo: validRootMnt1,
-			exp:       []string{"/run/mnt/ubuntu-data"},
+			exp:       []string{"/run/mnt/ubuntu-seed"},
 		},
 		{
-			comment:   "multiple valid root mountpoints",
-			mountinfo: validRootMnt1 + validRootMnt2,
-			exp:       []string{"/run/mnt/ubuntu-data", "/run/mnt/foo-other-place"},
+			comment:   "single valid root mountpoint, single opt valueless filter",
+			mountinfo: validRootMnt1,
+			// the rw option has no value
+			mountOpts: map[string]string{"rw": ""},
+			exp:       []string{"/run/mnt/ubuntu-seed"},
 		},
 		{
-			comment:   "multiple non-root mountpoints, no root mountpoint",
+			comment:   "single valid root mountpoint, multiple opts filter",
+			mountinfo: validRootMnt1,
+			// the rw and relatime options have no value
+			mountOpts: map[string]string{
+				"rw":       "",
+				"relatime": "",
+				"key":      "val",
+			},
+			exp: []string{"/run/mnt/ubuntu-seed"},
+		},
+		{
+			comment:   "multiple valid root mountpoints, no opt filter",
+			mountinfo: validRootMnt1 + validRootMnt2 + validRootMnt3ReadOnly,
+			exp:       []string{"/run/mnt/ubuntu-seed", "/run/mnt/foo-other-place", "/var/lib/snapd/seed"},
+		},
+		{
+			comment:   "multiple non-root mountpoints, no root mountpoint, no opt filter",
 			mountinfo: validNonRootMnt1 + validNonRootMnt1,
 		},
 		{
-			comment:   "multiple non-root mountpoints, one root mountpoint",
+			comment:   "multiple non-root mountpoints, one root mountpoint, no opt filter",
 			mountinfo: validRootMnt1 + validNonRootMnt1 + validNonRootMnt1,
-			exp:       []string{"/run/mnt/ubuntu-data"},
+			exp:       []string{"/run/mnt/ubuntu-seed"},
 		},
 		{
-			comment:   "multiple non-root mountpoints, multiple root mountpoint",
-			mountinfo: validRootMnt1 + validRootMnt2 + validNonRootMnt1 + validNonRootMnt1,
-			exp:       []string{"/run/mnt/ubuntu-data", "/run/mnt/foo-other-place"},
+			comment:   "multiple non-root mountpoints, multiple root mountpoint, no opt filter",
+			mountinfo: validRootMnt1 + validRootMnt2 + validRootMnt3ReadOnly + validNonRootMnt1 + validNonRootMnt1,
+			exp:       []string{"/run/mnt/ubuntu-seed", "/run/mnt/foo-other-place", "/var/lib/snapd/seed"},
 		},
 		{
-			comment: "no matching mounts",
+			comment:   "single valid root mountpoint, removed via opt filter",
+			mountinfo: validRootMnt1,
+			mountOpts: map[string]string{
+				"relatime": "",    // does match
+				"key":      "val", // does match
+				"ro":       "",    // doesn't match
+			},
+		},
+		{
+			comment:   "single valid root mountpoint, removed via key-value opt filter",
+			mountinfo: validRootMnt1,
+			mountOpts: map[string]string{
+				"key": "foo", // doesn't match
+			},
+		},
+		{
+			comment:   "multiple valid root mountpoints, only single one filtered via opts",
+			mountinfo: validRootMnt1 + validRootMnt3ReadOnly,
+			mountOpts: map[string]string{"rw": ""},
+			exp:       []string{"/run/mnt/ubuntu-seed"},
+		},
+		{
+			comment: "no matching mounts, no opt filter",
 			maj:     4000, min: 8000,
 			mountinfo: validRootMnt1,
 		},
@@ -950,7 +992,7 @@ func (s *diskSuite) TestMountPointsForPartitionRoot(c *C) {
 			part.Minor = 1
 		}
 
-		res, err := disks.MountPointsForPartitionRoot(part)
+		res, err := disks.MountPointsForPartitionRoot(part, t.mountOpts)
 		c.Check(err, IsNil, cmt)
 
 		if len(t.exp) == 0 {


### PR DESCRIPTION
Rename `RootMountPointsForPartition` -> `MountPointsForPartitionRoot` as suggested by @mardy, and expand it to support filtering by mount options since we will need to ensure we are only using rw mounts when actually performing gadget asset updates.

Also address some comments in https://github.com/snapcore/snapd/pull/10862 and https://github.com/snapcore/snapd/pull/10857.

Adding skip spread since nothing is using MountPointsForPartitionRoot right now so there is little regression risk here.