### PR TITLE
client: fail fast on non-retryable errors

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -175,10 +176,15 @@ func (e RequestError) Error() string {
 	return fmt.Sprintf("cannot build request: %v", e.error)
 }
 
-type AuthorizationError struct{ error }
+type AuthorizationError struct{ Err error }
 
 func (e AuthorizationError) Error() string {
-	return fmt.Sprintf("cannot add authorization: %v", e.error)
+	return fmt.Sprintf("cannot add authorization: %v", e.Err)
+}
+
+func (e AuthorizationError) Is(target error) bool {
+	_, ok := target.(AuthorizationError)
+	return ok
 }
 
 type ConnectionError struct{ Err error }
@@ -198,6 +204,17 @@ func (e ConnectionError) Error() string {
 
 func (e ConnectionError) Unwrap() error {
 	return e.Err
+}
+
+type InternalError struct{ Err error }
+
+func (e InternalError) Error() string {
+	return fmt.Sprintf("internal error: %s", e.Err.Error())
+}
+
+func (e InternalError) Is(target error) bool {
+	_, ok := target.(InternalError)
+	return ok
 }
 
 // AllowInteractionHeader is the HTTP request header used to indicate
@@ -267,7 +284,7 @@ func (client *Client) raw(ctx context.Context, method, urlpath string, query url
 func (client *Client) rawWithTimeout(ctx context.Context, method, urlpath string, query url.Values, headers map[string]string, body io.Reader, opts *doOptions) (*http.Response, context.CancelFunc, error) {
 	opts = ensureDoOpts(opts)
 	if opts.Timeout <= 0 {
-		return nil, nil, fmt.Errorf("internal error: timeout not set in options for rawWithTimeout")
+		return nil, nil, InternalError{fmt.Errorf("timeout not set in options for rawWithTimeout")}
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
@@ -349,13 +366,13 @@ func (client *Client) do(method, path string, query url.Values, headers map[stri
 	client.checkMaintenanceJSON()
 
 	var rsp *http.Response
-	var ctx context.Context = context.Background()
+	ctx := context.Background()
 	if opts.Timeout <= 0 {
 		// no timeout and retries
 		rsp, err = client.raw(ctx, method, path, query, headers, body)
 	} else {
 		if opts.Retry <= 0 {
-			return 0, fmt.Errorf("internal error: retry setting %s invalid", opts.Retry)
+			return 0, InternalError{fmt.Errorf("retry setting %s invalid", opts.Retry)}
 		}
 		retry := time.NewTicker(opts.Retry)
 		defer retry.Stop()
@@ -371,7 +388,7 @@ func (client *Client) do(method, path string, query url.Values, headers map[stri
 			if err == nil {
 				defer cancel()
 			}
-			if err == nil || method != "GET" {
+			if err == nil || notRetryable(err) || method != "GET" {
 				break
 			}
 			select {
@@ -394,6 +411,11 @@ func (client *Client) do(method, path string, query url.Values, headers map[stri
 	}
 
 	return rsp.StatusCode, nil
+}
+
+func notRetryable(err error) bool {
+	return errors.Is(err, AuthorizationError{}) ||
+		errors.Is(err, InternalError{})
 }
 
 func decodeInto(reader io.Reader, v interface{}) error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -225,6 +225,26 @@ func (cs *clientSuite) TestClientDoRetryWorks(c *C) {
 	c.Assert(cs.doCalls < 1100, Equals, true, Commentf("got %v calls", cs.doCalls))
 }
 
+func (cs *clientSuite) TestClientOnlyRetryAppropriateErrors(c *C) {
+	reqBody := ioutil.NopCloser(strings.NewReader(""))
+	doOpts := &client.DoOptions{
+		Retry:   time.Millisecond,
+		Timeout: 1 * time.Minute,
+	}
+
+	for _, t := range []struct{ error }{
+		{client.InternalError{Err: fmt.Errorf("boom")}},
+		{client.AuthorizationError{Err: fmt.Errorf("boom")}},
+	} {
+		cs.doCalls = 0
+		cs.err = t.error
+
+		_, err := cs.cli.Do("GET", "/this", nil, reqBody, nil, doOpts)
+		c.Check(err, ErrorMatches, fmt.Sprintf(".*%s", t.error.Error()))
+		c.Assert(cs.doCalls, Equals, 1)
+	}
+}
+
 func (cs *clientSuite) TestClientUnderstandsStatusCode(c *C) {
 	var v []int
 	cs.status = 202


### PR DESCRIPTION
The snap client retries all requests for a long time, regardless of the kind of error (e.g., snap list retries for 2min, if it fails to read auth.json). This is unnecessary and a bit unexpected since not all errors are transient so it obfuscates the error a bit. This commit prevents internal and auth errors from retrying since they're probably not transient.
You can test this by running snap list or version with an incorrect auth.json file, like: `touch ~/.snap/auth.json; snap list` (assuming you don't already have one).