### PR TITLE
 o/devicestate, o/servicestate: update gadget assets and cmdline when remodeling

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -401,23 +401,34 @@ type modelSnapsForRemodel struct {
 	newModelSnap     *asserts.ModelSnap
 }
 
-func remodelKernelOrBaseTasks(ctx context.Context, st *state.State, ms modelSnapsForRemodel, deviceCtx snapstate.DeviceContext, fromChange string) (*state.TaskSet, error) {
+func (ms *modelSnapsForRemodel) canHaveUC18PinnedTrack() bool {
+	return ms.newModelSnap != nil &&
+		(ms.newModelSnap.SnapType == "kernel" || ms.newModelSnap.SnapType == "gadget")
+}
+
+func remodelEssentialSnapTasks(ctx context.Context, st *state.State, ms modelSnapsForRemodel, deviceCtx snapstate.DeviceContext, fromChange string) (*state.TaskSet, error) {
 	userID := 0
 	newModelSnapChannel, err := modelSnapChannelFromDefaultOrPinnedTrack(ms.new, ms.newModelSnap)
 	if err != nil {
 		return nil, err
 	}
+
+	addExistingSnapTasks := snapstate.LinkNewBaseOrKernel
+	if ms.newModelSnap != nil && ms.newModelSnap.SnapType == "gadget" {
+		addExistingSnapTasks = snapstate.SwitchToNewGadget
+	}
+
 	if ms.currentSnap == ms.newSnap {
+		// new model uses the same base, kernel or gadget snap
 		changed := false
 		if ms.new.Grade() != asserts.ModelGradeUnset {
 			// UC20 models can specify default channel for all snaps
-			// including base and kernel
-			// new model uses the same base or kernel
+			// including base, kernel and gadget
 			changed, err = installedSnapChannelChanged(st, ms.newSnap, newModelSnapChannel)
 			if err != nil {
 				return nil, err
 			}
-		} else if ms.newModelSnap != nil && ms.newModelSnap.SnapType == "kernel" {
+		} else if ms.canHaveUC18PinnedTrack() {
 			// UC18 models could only specify track for the kernel
 			// and gadget snaps
 			changed = ms.currentModelSnap.PinnedTrack != ms.newModelSnap.PinnedTrack
@@ -464,7 +475,7 @@ func remodelKernelOrBaseTasks(ctx context.Context, st *state.State, ms modelSnap
 					// the update is not a simple
 					// switch-snap-channel
 					return ts, nil
-				} else {
+				} else if ms.newModelSnap.SnapType == "kernel" || ms.newModelSnap.SnapType == "base" {
 					// in other cases make sure that the
 					// kernel or base is linked and available
 					return snapstate.AddLinkNewBaseOrKernel(st, ts)
@@ -472,42 +483,7 @@ func remodelKernelOrBaseTasks(ctx context.Context, st *state.State, ms modelSnap
 			}
 		}
 	}
-	return snapstate.LinkNewBaseOrKernel(st, ms.newSnap)
-}
-
-func remodelGadgetTasks(ctx context.Context, st *state.State, ms modelSnapsForRemodel, deviceCtx snapstate.DeviceContext, fromChange string) (*state.TaskSet, error) {
-	userID := 0
-	newGadgetChannel, err := modelSnapChannelFromDefaultOrPinnedTrack(ms.new, ms.newModelSnap)
-	if err != nil {
-		return nil, err
-	}
-	if ms.currentSnap == ms.newSnap {
-		// already installed, but may be using a different channel
-		changed := false
-		if ms.new.Grade() != asserts.ModelGradeUnset {
-			// UC20 models can specify default channel for all snaps
-			// including the gadget
-			changed, err = installedSnapChannelChanged(st, ms.newSnap, newGadgetChannel)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			// pre UC20 models could only specify a track for the
-			// gadget
-			changed = ms.currentModelSnap.PinnedTrack != ms.newModelSnap.PinnedTrack
-		}
-		if changed {
-			return snapstateUpdateWithDeviceContext(st, ms.newSnap,
-				&snapstate.RevisionOptions{Channel: newGadgetChannel},
-				userID, snapstate.Flags{NoReRefresh: true}, deviceCtx, fromChange)
-		}
-		return nil, nil
-	}
-
-	// install the new gadget
-	return snapstateInstallWithDeviceContext(ctx, st, ms.newSnap,
-		&snapstate.RevisionOptions{Channel: newGadgetChannel},
-		userID, snapstate.Flags{}, deviceCtx, fromChange)
+	return addExistingSnapTasks(st, ms.newSnap)
 }
 
 func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Model, deviceCtx snapstate.DeviceContext, fromChange string) ([]*state.TaskSet, error) {
@@ -522,7 +498,7 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 		newSnap:          new.Kernel(),
 		newModelSnap:     new.KernelSnap(),
 	}
-	ts, err := remodelKernelOrBaseTasks(ctx, st, kms, deviceCtx, fromChange)
+	ts, err := remodelEssentialSnapTasks(ctx, st, kms, deviceCtx, fromChange)
 	if err != nil {
 		return nil, err
 	}
@@ -537,7 +513,7 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 		newSnap:          new.Base(),
 		newModelSnap:     new.BaseSnap(),
 	}
-	ts, err = remodelKernelOrBaseTasks(ctx, st, bms, deviceCtx, fromChange)
+	ts, err = remodelEssentialSnapTasks(ctx, st, bms, deviceCtx, fromChange)
 	if err != nil {
 		return nil, err
 	}
@@ -552,7 +528,7 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 		newSnap:          new.Gadget(),
 		newModelSnap:     new.GadgetSnap(),
 	}
-	ts, err = remodelGadgetTasks(ctx, st, gms, deviceCtx, fromChange)
+	ts, err = remodelEssentialSnapTasks(ctx, st, gms, deviceCtx, fromChange)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -2803,6 +2803,9 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseSnapsInstalledSna
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsTrackingDifferentChannelThanDefaultSameAsNew(c *C) {
+	// essential snaps from new model are already installed and track
+	// channels different than declared in the old model, but already the
+	// same as in the new one
 	s.state.Lock()
 	defer s.state.Unlock()
 	s.state.Set("seeded", true)
@@ -2977,6 +2980,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsTrackingDifferentCh
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsAlreadyInstalledAndLocal(c *C) {
+	// remodel when the essential snaps declared in new model are already
+	// installed, but have a local revision
 	s.state.Lock()
 	defer s.state.Unlock()
 	s.state.Set("seeded", true)
@@ -3148,6 +3153,9 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsAlreadyInstalledAnd
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelUC20NoDownloadSimpleChannelSwitch(c *C) {
+	// remodel when a channel declared in new model carries the same
+	// revision as already installed, so there is no full fledged, but a
+	// simple channel switch
 	s.state.Lock()
 	defer s.state.Unlock()
 	s.state.Set("seeded", true)


### PR DESCRIPTION
It is possible that due to prior remodels, the kernel or gadget snaps the new model request are already installed. The gadget may be carrying boot assets or command line elements, in which case we should ensure that both the boot assets and the kernel command line is updated during remodel.