### PR TITLE
interfaces/builtin/time-control: allow pps access

### DIFF
--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -129,8 +129,8 @@ socket AF_NETLINK - NETLINK_AUDIT
 `
 
 var timeControlConnectedPlugUDev = []string{
-  `SUBSYSTEM=="rtc"`,
-  `KERNEL=="pps[0-9]*"`,
+	`SUBSYSTEM=="rtc"`,
+	`KERNEL=="pps[0-9]*"`,
 }
 
 func init() {

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -93,6 +93,11 @@ capability sys_time,
 /sys/class/rtc/*/ rw,
 /sys/class/rtc/*/** rw,
 
+# Allow access to pps
+# https://www.kernel.org/doc/html/latest/driver-api/pps.html
+/dev/pps[0-9]* rw,
+/sys/devices/virtual/pps/*/** rw,
+
 # As the core snap ships the hwclock utility we can also allow
 # clients to use it now that they have access to the relevant
 # device nodes. Note: some invocations of hwclock will try to
@@ -123,7 +128,10 @@ bind
 socket AF_NETLINK - NETLINK_AUDIT
 `
 
-var timeControlConnectedPlugUDev = []string{`SUBSYSTEM=="rtc"`}
+var timeControlConnectedPlugUDev = []string{
+  `SUBSYSTEM=="rtc"`,
+  `KERNEL=="pps[0-9]*"`,
+}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -106,9 +106,11 @@ func (s *TimeControlInterfaceSuite) TestSecCompSpec(c *C) {
 func (s *TimeControlInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets(), testutil.Contains, `# time-control
 SUBSYSTEM=="rtc", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# time-control
+KERNEL=="pps[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }
 


### PR DESCRIPTION
Allow `/dev/pps[0-9]*` access for time-control interface

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>
