### PR TITLE
overlord: fix generated snap-revision assertions in remodel unit tests

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -844,7 +844,7 @@ func (s *baseMgrsSuite) makeStoreSnapRevision(c *C, name, revno, digest string, 
 	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
 	err = s.storeSigning.Add(snapRev)
-	c.Assert(err, IsNil)
+	c.Assert(err, IsNil, Commentf("cannot add snap revision %v", headers))
 	return snapRev
 }
 
@@ -6222,8 +6222,21 @@ var (
 		"baz":       "version: 1.0\nname: baz\nbase: core20",
 	}
 	snapFilesForRemodel = map[string][][]string{
-		"pc":        pcGadgetFiles,
+		"pc": pcGadgetFiles,
+		// use a different fileset, such that the pc snap with this
+		// content will have a different digest than the regular pc snap
+		"pc-rev-33": append(pcGadgetFiles, []string{
+			"this-is-new", "",
+		}),
 		"pc-kernel": pcKernelFiles,
+		// similar reasoning as for the pc snap
+		"pc-kernel-rev-33": append(pcKernelFiles, []string{
+			"this-is-new", "",
+		}),
+		// and again
+		"core20-rev-33": {
+			{"this-is-new", ""},
+		},
 	}
 
 	// headers of a regular UC20 model assertion
@@ -6829,10 +6842,8 @@ func (s *mgrsSuite) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C) {
 
 func (s *mgrsSuite) TestRemodelUC20DifferentKernelChannel(c *C) {
 	s.testRemodelUC20WithRecoverySystemSimpleSetUp(c)
-	// add sleep such that the assertion timestamp will be different and
-	// won't conflict with already existing one
-	time.Sleep(time.Second)
-	snapPath, _ := s.makeStoreTestSnapWithFiles(c, snapYamlsForRemodel["pc-kernel"], "33", snapFilesForRemodel["pc-kernel"])
+	// use a different set of files, such that the snap digest must also be different
+	snapPath, _ := s.makeStoreTestSnapWithFiles(c, snapYamlsForRemodel["pc-kernel"], "33", snapFilesForRemodel["pc-kernel-rev-33"])
 	s.serveSnap(snapPath, "33")
 	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
 		"snaps": []interface{}{
@@ -6960,10 +6971,8 @@ func (s *mgrsSuite) TestRemodelUC20DifferentKernelChannel(c *C) {
 
 func (s *mgrsSuite) TestRemodelUC20DifferentGadgetChannel(c *C) {
 	s.testRemodelUC20WithRecoverySystemSimpleSetUp(c)
-	// add sleep such that the assertion timestamp will be different and
-	// won't conflict with already existing one
-	time.Sleep(time.Second)
-	snapPath, _ := s.makeStoreTestSnapWithFiles(c, snapYamlsForRemodel["pc"], "33", snapFilesForRemodel["pc"])
+	// use a different set of files, such that the snap digest must also be different
+	snapPath, _ := s.makeStoreTestSnapWithFiles(c, snapYamlsForRemodel["pc"], "33", snapFilesForRemodel["pc-rev-33"])
 	s.serveSnap(snapPath, "33")
 	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
 		"snaps": []interface{}{
@@ -7067,10 +7076,8 @@ func (s *mgrsSuite) TestRemodelUC20DifferentGadgetChannel(c *C) {
 
 func (s *mgrsSuite) TestRemodelUC20DifferentBaseChannel(c *C) {
 	s.testRemodelUC20WithRecoverySystemSimpleSetUp(c)
-	// add sleep such that the assertion timestamp will be different and
-	// won't conflict with already existing one
-	time.Sleep(time.Second)
-	snapPath, _ := s.makeStoreTestSnapWithFiles(c, snapYamlsForRemodel["core20"], "33", snapFilesForRemodel["core20"])
+	// use a different set of files, such that the snap digest must also be different
+	snapPath, _ := s.makeStoreTestSnapWithFiles(c, snapYamlsForRemodel["core20"], "33", snapFilesForRemodel["core20-rev-33"])
 	s.serveSnap(snapPath, "33")
 	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
 		"snaps": []interface{}{


### PR DESCRIPTION
When building on LP, the mock snap files generated with mksquashfs end up having
the same sha3-348 digest, despite forcing a 1s delay between consecutive snap
builds, what should have affected the internal file timestamps. As a workaround,
use a different content of mock files, such that the files must yield a
different digest.
