### PR TITLE
tests: merge coverage results

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
       # to use the go snap automatically. Note that we install go from the
       # snap in a step below. Without this we get the GitHub-controlled latest
       # version of go.
-      PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
+      PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
       GITHUB_PULL_REQUEST: ${{ github.event.number }}
     strategy:
@@ -181,6 +181,10 @@ jobs:
       if: steps.cached-results.outputs.already-ran != 'true'
       run: |
           cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/ && make check
+    - name: Reset code coverage data
+      if: steps.cached-results.outputs.already-ran != 'true'
+      run: |
+          rm -rf ${{ github.workspace }}/.coverage/
     - name: Test Go
       if: steps.cached-results.outputs.already-ran != 'true'
       run: |
@@ -206,17 +210,23 @@ jobs:
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
+    - name: Merge coverage results
+      if: ${{ steps.cached-results.outputs.already-ran != 'true' && matrix.gochannel != 'latest/stable' }}
+      run: |
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
+        go install github.com/makholm/covertool
+        covertool merge -o .coverage/all.cov .coverage/coverage*.cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       # uploading to codecov occasionally fails, so continue running the test
       # workflow regardless of the upload
       continue-on-error: true
-      if: steps.cached-results.outputs.already-ran != 'true'
+      if: ${{ steps.cached-results.outputs.already-ran != 'true' && matrix.gochannel != 'latest/stable' }}
       with:
         fail_ci_if_error: true
         flags: unittests
         name: codecov-umbrella
-        files: .coverage/coverage.out
+        files: .coverage/all.cov
         verbose: true
     - name: Cache successful run
       run: |

--- a/run-checks
+++ b/run-checks
@@ -86,15 +86,6 @@ endmsg() {
 }
 addtrap endmsg
 
-# Append the coverage profile of a package to the project coverage.
-append_coverage() (
-    profile="$1"
-    if [ -f "$profile" ]; then
-        grep -v "^mode:" -- "$profile" >> .coverage/coverage.out || true
-        rm "$profile"
-    fi
-)
-
 missing_interface_spread_test() {
     snap_yaml="tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml"
     core_snap_yaml="tests/lib/snaps/test-snapd-policy-app-provider-core/meta/snap.yaml"
@@ -307,20 +298,8 @@ if [ "$UNIT" = 1 ]; then
             echo "Skipping test coverage"
         fi
 
-        if command -v dpkg >/dev/null && dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
-            # shellcheck disable=SC2046,SC2086
-            GOTRACEBACK=1 $goctest $tags -timeout 5m $coverage $(go list ./... | grep -v '/vendor/' )
-        else
-            for pkg in $(go list ./... | grep -v '/vendor/' ); do
-                # shellcheck disable=SC2086
-                GOTRACEBACK=1 go test $tags -timeout 5m -i "$pkg"
-                if [ -z "${SKIP_COVERAGE-}" ]; then
-                    # shellcheck disable=SC2086
-                    GOTRACEBACK=1 $goctest $tags -timeout 5m $coverage "$pkg"
-                    append_coverage .coverage/profile.out
-                fi
-            done
-        fi
+        # shellcheck disable=SC2046,SC2086
+        GOTRACEBACK=1 $goctest $tags -timeout 5m $coverage $(go list ./... | grep -v '/vendor/' )
     fi
 
     # python unit test for mountinfo.query and version-compare

--- a/run-checks
+++ b/run-checks
@@ -9,6 +9,8 @@ else
     goctest="go test"
 fi
 COVERMODE=${COVERMODE:-atomic}
+COVERAGE_SUFFIX=${GO_BUILD_TAGS:-notags}
+COVERAGE_OUT=${COVERAGE_OUT:-.coverage/coverage-$COVERAGE_SUFFIX.cov}
 
 if [ -z "${GITHUB_WORKFLOW:-}" ]; then
     # when *not* running inside github, ensure we use go-1.13 by default
@@ -289,11 +291,10 @@ if [ "$UNIT" = 1 ]; then
     else
         coverage=""
         if [ -z "${SKIP_COVERAGE-}" ]; then
-            coverage="-coverprofile=.coverage/coverage.out -covermode=$COVERMODE"
+            coverage="-coverprofile=$COVERAGE_OUT -covermode=$COVERMODE"
             # Prepare the coverage output profile.
-            rm -rf .coverage
-            mkdir .coverage
-            echo "mode: $COVERMODE" > .coverage/coverage.out
+            mkdir -p "$(dirname "$COVERAGE_OUT")"
+            echo "mode: $COVERMODE" > "$COVERAGE_OUT"
         else
             echo "Skipping test coverage"
         fi


### PR DESCRIPTION
We are running the unit tests several times under different build flags, but every iteration destroys the data collected during the previous one. This PR wants to test whether combining the coverage results would have any benefit.

Edit: it turns out there's no benefit at all in the overall coverage numbers :-(, but these test runs are effectively covering different parts of the codebase, so I think we should still consider all of them:

|Build tag|# of tested files|Extra files
--- | --- | ---
| - |   900| - |
|faultinject|   900| osutil/faultinject.go |
|nosecboot|   897| cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go, gadget/install/install_dummy.go, secboot/encrypt_dummy.go, secboot/secboot_dummy.go |
|withbootassetstesting|   902|bootloader/assets/assetstesting.go, bootloader/withbootassettesting.go |


