### PR TITLE
tests/main/interfaces-many: run both variants on all possible Ubuntu systems

### DIFF
--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -11,24 +11,13 @@ backends: [-autopkgtest]
 
 # Ideally we would run this everywhere, but on systems with full security
 # support, it takes a while, which leads to travis timeouts. Limit to:
-# - Ubuntu Core 16 amd64
-# - Ubuntu classic 14.04 i386 VM
-# - Ubuntu classic 16.04 amd64 VM
-# - Ubuntu classic 18.04 amd64 VM
+# - Ubuntu Core
+# - Ubuntu classic
 # - All Ubuntu autopkgtests
 # - Debian sid amd64 VM
 # - TODO: All Fedora systems (for classic-only; unrelated error elsewhere)
 systems:
-    - ubuntu-core-1*-64
-    - ubuntu-14.04-32
-    - ubuntu-16.04-64
-    - ubuntu-18.04-64
-    - ubuntu-18.04-32
-    - ubuntu-*-amd64
-    - ubuntu-*-armhf
-    - ubuntu-*-arm64
-    - ubuntu-*-i386
-    - ubuntu-*-ppc64el
+    - ubuntu-*
     - debian-*
 
 # Start early as it takes a long time.

--- a/tests/main/interfaces-many-snap-provided/task.yaml
+++ b/tests/main/interfaces-many-snap-provided/task.yaml
@@ -11,14 +11,14 @@ backends: [-autopkgtest]
 
 # Ideally we would run this everywhere, but on systems with full security
 # support, it takes a while, which leads to travis timeouts. Limit to:
-# - Ubuntu Core 16 amd64
-# - Ubuntu classic 14.04 i386 VM
-# - Ubuntu classic 16.04 amd64 VM
-# - Ubuntu classic 18.04 amd64 VM
+# - Ubuntu Core
+# - Ubuntu classic
 # - All Ubuntu autopkgtests
 # - Debian sid amd64 VM
 # - TODO: All Fedora systems (for classic-only; unrelated error elsewhere)
-systems: [ubuntu-core-1*-64, ubuntu-14.04-32, ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-18.04-32, ubuntu-*-amd64, ubuntu-*-armhf, ubuntu-*-arm64, ubuntu-*-i386, ubuntu-*-ppc64el, debian-*]
+systems:
+  - ubuntu-*
+  - debian-*
 
 # Start early as it takes a long time.
 priority: 100


### PR DESCRIPTION
The test was only limited to a list of specific Ubuntu version. The list was
never updated since 20.04 release, which proves that listing specific is not
very useful.


