### PR TITLE
o/snapstate, hookstate: print remaining hold time on snapctl --hold

### DIFF
--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -269,7 +269,7 @@ func (c *refreshCommand) hold() error {
 		return err
 	}
 	var details holdDetails
-	details.Hold = fmt.Sprintf("%s", remaining)
+	details.Hold = remaining.String()
 
 	out, err := yaml.Marshal(details)
 	if err != nil {

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -152,6 +152,10 @@ type updateDetails struct {
 	Restart bool `yaml:"restart"`
 }
 
+type holdDetails struct {
+	Hold string `yaml:"hold"`
+}
+
 // refreshCandidate is a subset of refreshCandidate defined by snapstate and
 // stored in "refresh-candidates".
 type refreshCandidate struct {
@@ -259,10 +263,19 @@ func (c *refreshCommand) hold() error {
 
 	// no duration specified, use maximum allowed for this gating snap.
 	var holdDuration time.Duration
-	if err := snapstate.HoldRefresh(st, ctx.InstanceName(), holdDuration, affecting...); err != nil {
+	remaining, err := snapstate.HoldRefresh(st, ctx.InstanceName(), holdDuration, affecting...)
+	if err != nil {
 		// TODO: let a snap hold again once for 1h.
 		return err
 	}
+	var details holdDetails
+	details.Hold = fmt.Sprintf("%s", remaining)
+
+	out, err := yaml.Marshal(details)
+	if err != nil {
+		return err
+	}
+	c.printf("%s", string(out))
 
 	return nil
 }

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -197,7 +197,7 @@ version: 1
 
 	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"refresh", "--hold"}, 0)
 	c.Assert(err, IsNil)
-	c.Check(string(stdout), Equals, "")
+	c.Check(string(stdout), Equals, "hold: 48h0m0s\n")
 	c.Check(string(stderr), Equals, "")
 
 	mockContext.Lock()
@@ -223,7 +223,8 @@ version: 1
 `)
 
 	// pretend snap foo is held initially
-	c.Check(snapstate.HoldRefresh(s.st, "snap1", 0, "foo"), IsNil)
+	_, err = snapstate.HoldRefresh(s.st, "snap1", 0, "foo")
+	c.Check(err, IsNil)
 	s.st.Unlock()
 
 	// sanity check

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -241,7 +241,7 @@ func (h *gateAutoRefreshHookHandler) Error(hookErr error) (ignoreHookErr bool, e
 
 	// no duration specified, use maximum allowed for this gating snap.
 	var holdDuration time.Duration
-	if err := snapstate.HoldRefresh(st, snapName, holdDuration, affecting...); err != nil {
+	if _, err := snapstate.HoldRefresh(st, snapName, holdDuration, affecting...); err != nil {
 		// log the original hook error as we either ignore it or error out from
 		// this handler, in both cases hookErr won't be logged by hook manager.
 		h.context.Errorf("error: %v (while handling previous hook error: %v)", err, hookErr)

--- a/overlord/hookstate/hooks_test.go
+++ b/overlord/hookstate/hooks_test.go
@@ -242,7 +242,8 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshDefaultProceedUnlocksRunin
 	defer st.Unlock()
 
 	// pretend that snap-a is initially held by itself.
-	c.Assert(snapstate.HoldRefresh(st, "snap-a", 0, "snap-a"), IsNil)
+	_, err := snapstate.HoldRefresh(st, "snap-a", 0, "snap-a")
+	c.Assert(err, IsNil)
 	// sanity
 	checkIsHeld(c, st, "snap-a", "snap-a")
 
@@ -292,7 +293,8 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshDefaultProceed(c *C) {
 	defer st.Unlock()
 
 	// pretend that snap-b is initially held by snap-a.
-	c.Assert(snapstate.HoldRefresh(st, "snap-a", 0, "snap-b"), IsNil)
+	_, err := snapstate.HoldRefresh(st, "snap-a", 0, "snap-b")
+	c.Assert(err, IsNil)
 	// sanity
 	checkIsHeld(c, st, "snap-b", "snap-a")
 

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -218,8 +218,8 @@ func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration,
 		}
 		gating[heldSnap][gatingSnap] = hold
 
-		if durationMin == 0 || dur < durationMin {
-			durationMin = dur
+		if durationMin == 0 || left < durationMin {
+			durationMin = left
 		}
 	}
 

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -144,16 +144,20 @@ func holdDurationLeft(now time.Time, lastRefresh, firstHeld time.Time, maxDurati
 
 // HoldRefresh marks affectingSnaps as held for refresh for up to holdTime.
 // HoldTime of zero denotes maximum allowed hold time.
-// Holding may fail for only some snaps in which case HoldError is returned and
-// it contains the details of failed ones.
-func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration, affectingSnaps ...string) error {
+// Holding fails if not all snaps can be held, in that case HoldError is returned
+// and it contains the details of snaps that prevented holding. On success the
+// function returns the remaining hold time.
+func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration, affectingSnaps ...string) (time.Duration, error) {
 	gating, err := refreshGating(st)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	herr := &HoldError{
 		SnapsInError: make(map[string]HoldDurationError),
 	}
+
+	var durationMin time.Duration
+
 	now := timeNow()
 	for _, heldSnap := range affectingSnaps {
 		hold, ok := gating[heldSnap][gatingSnap]
@@ -165,7 +169,7 @@ func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration,
 
 		lastRefreshTime, err := lastRefreshed(st, heldSnap)
 		if err != nil {
-			return err
+			return 0, err
 		}
 
 		mp := maxPostponement - maxPostponementBuffer
@@ -213,6 +217,10 @@ func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration,
 			gating[heldSnap] = make(map[string]*holdState)
 		}
 		gating[heldSnap][gatingSnap] = hold
+
+		if durationMin == 0 || dur < durationMin {
+			durationMin = dur
+		}
 	}
 
 	if len(herr.SnapsInError) > 0 {
@@ -228,9 +236,9 @@ func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration,
 	}
 	st.Set("snaps-hold", gating)
 	if len(herr.SnapsInError) > 0 {
-		return herr
+		return 0, herr
 	}
-	return nil
+	return durationMin, nil
 }
 
 // ProceedWithRefresh unblocks all snaps held by gatingSnap for refresh. This

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -146,7 +146,8 @@ func holdDurationLeft(now time.Time, lastRefresh, firstHeld time.Time, maxDurati
 // HoldTime of zero denotes maximum allowed hold time.
 // Holding fails if not all snaps can be held, in that case HoldError is returned
 // and it contains the details of snaps that prevented holding. On success the
-// function returns the remaining hold time.
+// function returns the remaining hold time. The remaining hold time is the
+// minimum of the remaining hold time for all affecting snaps.
 func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration, affectingSnaps ...string) (time.Duration, error) {
 	gating, err := refreshGating(st)
 	if err != nil {
@@ -218,6 +219,7 @@ func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration,
 		}
 		gating[heldSnap][gatingSnap] = hold
 
+		// note, left is guaranteed to be > 0 at this point
 		if durationMin == 0 || left < durationMin {
 			durationMin = left
 		}

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -1642,8 +1642,10 @@ func (s *snapmgrTestSuite) TestRemovePrunesRefreshGatingDataOnLastRevision(c *C)
 	}
 	st.Set("refresh-candidates", rc)
 
-	c.Assert(snapstate.HoldRefresh(st, "some-snap", 0, "foo-snap"), IsNil)
-	c.Assert(snapstate.HoldRefresh(st, "another-snap", 0, "some-snap"), IsNil)
+	_, err := snapstate.HoldRefresh(st, "some-snap", 0, "foo-snap")
+	c.Assert(err, IsNil)
+	_, err = snapstate.HoldRefresh(st, "another-snap", 0, "some-snap")
+	c.Assert(err, IsNil)
 
 	held, err := snapstate.HeldSnaps(st)
 	c.Assert(err, IsNil)
@@ -1699,7 +1701,8 @@ func (s *snapmgrTestSuite) TestRemoveKeepsGatingDataIfNotLastRevision(c *C) {
 	rc := map[string]*snapstate.RefreshCandidate{"some-snap": {}}
 	st.Set("refresh-candidates", rc)
 
-	c.Assert(snapstate.HoldRefresh(st, "some-snap", 0, "some-snap"), IsNil)
+	_, err := snapstate.HoldRefresh(st, "some-snap", 0, "some-snap")
+	c.Assert(err, IsNil)
 
 	held, err := snapstate.HeldSnaps(st)
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1108,7 +1108,8 @@ func (s *snapmgrTestSuite) TestUpdateResetsHoldState(c *C) {
 	tr.Commit()
 
 	// pretend that the snap was held during last auto-refresh
-	c.Assert(snapstate.HoldRefresh(s.state, "gating-snap", 0, "some-snap", "other-snap"), IsNil)
+	_, err := snapstate.HoldRefresh(s.state, "gating-snap", 0, "some-snap", "other-snap")
+	c.Assert(err, IsNil)
 	// sanity check
 	held, err := snapstate.HeldSnaps(s.state)
 	c.Assert(err, IsNil)

--- a/tests/main/auto-refresh-gating/task.yaml
+++ b/tests/main/auto-refresh-gating/task.yaml
@@ -68,6 +68,11 @@ execute: |
     MATCH "pending: none" < "$DEBUG_LOG_FILE"
     NOMATCH "version:" < "$DEBUG_LOG_FILE"
 
+    echo "Check that --hold output contains remaining hold time"
+    # we cannot match precisely, this might be 48h0m0s if we are lucky, or
+    # a tiny bit less depending on timing.
+    MATCH "hold: 4[78]h.*m.*s" < "$DEBUG_LOG_FILE"
+
     echo "Ensure our content snap was held and is still at version 1"
     snap list | MATCH "$CONTENT_SNAP_NAME +1\.0\.0"
     # sanity check for the gating snap.


### PR DESCRIPTION
Print remaining hold time after `snapctl --hold`; this time is the minimum value of hold times of all snaps held by the gating snap that calls snapctl command. In the future this may get extended to allow snaps to ask for 1 extra hour.

The output is go-formatted duration with the idea of maybe adding a flag (e.g. --print-seconds) to request hold time in seconds.

