### PR TITLE
tests/main: disable cgroup-devices-v1 and freezer tests on 21.10

### DIFF
--- a/tests/main/cgroup-devices-v1/task.yaml
+++ b/tests/main/cgroup-devices-v1/task.yaml
@@ -1,8 +1,6 @@
 summary: measuring basic properties of device cgroup
 
-# fedora-33, fedora-34, debian-sid, arch, opensuse TW use cgroupv2, which we
-# don't support
-# also disable special images that are configured to use cgroup v2
-systems: [ -fedora-33-*, -fedora-34-*, -debian-sid-*, -arch-*, -opensuse-tumbleweed-*, -*-cgroupv2]
+# Disable the test on all systems that boot with cgroup v2
+systems: [ -fedora-33-*, -fedora-34-*, -debian-sid-*, -arch-*, -opensuse-tumbleweed-*, -ubuntu-21.10-*]
 
 execute: ./task.sh

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -4,9 +4,8 @@ details: |
     This test creates a snap process that suspends itself and ensures that it
     placed into the appropriate hierarchy under the freezer cgroup.
 
-# fedora-33, fedora-34, debian-sid, arch, opensuse TW use cgroupv2, which does
-# not support a separate freezer controller
-systems: [ -fedora-33-*, -fedora-34-*, -debian-sid-*, -arch-*, -opensuse-tumbleweed-*, -ubuntu-21.10-*-cgroupv2]
+# Disable the test on all systems that boot with cgroup v2
+systems: [ -fedora-33-*, -fedora-34-*, -debian-sid-*, -arch-*, -opensuse-tumbleweed-*, -ubuntu-21.10-*]
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh


### PR DESCRIPTION
Ubuntu 21.10 boots with unified hierarchy by default. Those tests cannot be
successfully executed on such systems.

