### PR TITLE
tests: support running all spread tests with experimental features

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -59,7 +59,7 @@ environment:
     SKIP_REMOVE_SNAPS: '$(HOST: echo "${SPREAD_SKIP_REMOVE_SNAPS:-}") test-snapd-rsync test-snapd-rsync-core18 test-snapd-rsync-core20'
     # Use the installed snapd and reset the systems without removing snapd
     REUSE_SNAPD: '$(HOST: echo "${SPREAD_REUSE_SNAPD:-0}")'
-    EXPERIMENTAL_FEATURES: '$(HOST: echo "${EXPERIMENTAL_FEATURES:-}")'
+    EXPERIMENTAL_FEATURES: '$(HOST: echo "${SPREAD_EXPERIMENTAL_FEATURES:-}")'
 
     # Directory where the nested images and test assets are stored
     NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/tmp/work-dir}")'

--- a/spread.yaml
+++ b/spread.yaml
@@ -59,6 +59,7 @@ environment:
     SKIP_REMOVE_SNAPS: '$(HOST: echo "${SPREAD_SKIP_REMOVE_SNAPS:-}") test-snapd-rsync test-snapd-rsync-core18 test-snapd-rsync-core20'
     # Use the installed snapd and reset the systems without removing snapd
     REUSE_SNAPD: '$(HOST: echo "${SPREAD_REUSE_SNAPD:-0}")'
+    EXPERIMENTAL_FEATURES: '$(HOST: echo "${EXPERIMENTAL_FEATURES:-}")'
 
     # Directory where the nested images and test assets are stored
     NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/tmp/work-dir}")'

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -96,6 +96,20 @@ EOF
     systemctl start snapd.service
 }
 
+# setup_experimental_features enables experimental snapd features passed
+# via optional EXPERIMENTAL_FEATURES environment variable. The features must be
+# separated by commas and "experimental." prefixes should be omitted.
+setup_experimental_features() {
+    if [ -n "$EXPERIMENTAL_FEATURES" ]; then
+        echo "$EXPERIMENTAL_FEATURES" | while IFS="," read -r FEATURE; do
+            echo "Enabling feature experimental.$FEATURE"
+            snap set system "experimental.$FEATURE"=true
+        done
+    else
+        echo "There are no experimental snapd features to enable"
+    fi
+}
+
 update_core_snap_for_classic_reexec() {
     # it is possible to disable this to test that snapd (the deb) works
     # fine with whatever is in the core snap
@@ -306,6 +320,7 @@ prepare_classic() {
             exit 1
         fi
 
+        setup_experimental_features
         systemctl stop snapd.{service,socket}
         save_snapd_state
         systemctl start snapd.socket
@@ -1162,6 +1177,7 @@ prepare_ubuntu_core() {
 
     # Snapshot the fresh state (including boot/bootenv)
     if ! is_snapd_state_saved; then
+        setup_experimental_features
         systemctl stop snapd.service snapd.socket
         save_snapd_state
         systemctl start snapd.socket


### PR DESCRIPTION
Support setting experimental snapd features via EXPERIMENTAL_FEATURES environment variable, affecting all spread tests.
The idea is to use this with nightly test suite to run it with and without experimental.gate-auto-refresh-hook feature, e.g.

`EXPERIMENTAL_FEATURES=gate-auto-refresh-hook spread -debug google:ubuntu-core-18-64:tests/main/`
