### PR TITLE
tests: using test-snapd-curl snap instead of http snap

### DIFF
--- a/tests/core/snapd-refresh-vs-services-reboots/task.yaml
+++ b/tests/core/snapd-refresh-vs-services-reboots/task.yaml
@@ -12,7 +12,7 @@ environment:
   SNAPD_2_49_2_ARMHF: https://storage.googleapis.com/snapd-spread-tests/snaps/snapd_2.49.2_11586.snap
 
 prepare: |
-  snap install http --devmode # devmode so it can save to any dir
+  snap install test-snapd-curl --edge --devmode # devmode so it can save to any dir
 
   # save the version of snapd from the PR to refresh to later
   INITIAL_REV=$(snap list snapd | tail -n +2 | awk '{print $3}')
@@ -20,11 +20,11 @@ prepare: |
 
   # download and install snapd 2.49.2
   if os.query is-pc-amd64; then
-    http --quiet --download --output snapd_2.49.2.snap GET "$SNAPD_2_49_2_X86"
+    test-snapd-curl.curl -s -o snapd_2.49.2.snap "$SNAPD_2_49_2_X86"
   elif os.query is-arm64; then
-    http --quiet --download --output snapd_2.49.2.snap GET "$SNAPD_2_49_2_ARM64"
+    test-snapd-curl.curl -s -o snapd_2.49.2.snap "$SNAPD_2_49_2_ARM64"
   elif os.query is-armhf; then
-    http --quiet --download --output snapd_2.49.2.snap GET "$SNAPD_2_49_2_ARMHF"
+    test-snapd-curl.curl -s -o snapd_2.49.2.snap "$SNAPD_2_49_2_ARMHF"
   else
     echo "architecture not supported for this variant"
     exit 0

--- a/tests/core/snapd-refresh-vs-services/task.yaml
+++ b/tests/core/snapd-refresh-vs-services/task.yaml
@@ -23,7 +23,7 @@ prepare: |
   # install http snap to download files, jq + remarshal to simplify the check if
   # stable == 2.49.2 so we can skip that case automatically until a new version
   # is released to stable
-  snap install http --devmode # devmode so it can save to any dir
+  snap install test-snapd-curl --edge --devmode # devmode so it can save to any dir
   snap install jq remarshal
   # save the current version of snapd for later
   INITIAL_REV=$(snap list snapd | tail -n +2 | awk '{print $3}')
@@ -62,11 +62,11 @@ execute: |
   # introduced so we can install a snap service that will not have Requires= in
   # it
   if os.query is-pc-amd64; then
-    http --quiet --download --output snapd_2.49.1.snap GET "$SNAPD_2_49_1_X86"
+    test-snapd-curl.curl -s -o snapd_2.49.1.snap "$SNAPD_2_49_1_X86"
   elif os.query is-arm64; then
-    http --quiet --download --output snapd_2.49.1.snap GET "$SNAPD_2_49_1_ARM64"
+    test-snapd-curl.curl -s -o snapd_2.49.1.snap "$SNAPD_2_49_1_ARM64"
   elif os.query is-armhf; then
-    http --quiet --download --output snapd_2.49.1.snap GET "$SNAPD_2_49_1_ARMHF"
+    test-snapd-curl.curl -s -o snapd_2.49.1.snap "$SNAPD_2_49_1_ARMHF"
   fi
 
   snap install --dangerous snapd_2.49.1.snap
@@ -93,11 +93,11 @@ execute: |
   elif [ "${SNAPD_VERSION_UNDER_TEST}" = "2.49.2" ]; then
     # download and install snapd 2.49.2
     if os.query is-pc-amd64; then
-      http --quiet --download --output snapd_2.49.2.snap GET "$SNAPD_2_49_2_X86"
+      test-snapd-curl.curl -s -o snapd_2.49.2.snap "$SNAPD_2_49_2_X86"
     elif os.query is-arm64; then
-      http --quiet --download --output snapd_2.49.2.snap GET "$SNAPD_2_49_2_ARM64"
+      test-snapd-curl.curl -s -o snapd_2.49.2.snap "$SNAPD_2_49_2_ARM64"
     elif os.query is-armhf; then
-      http --quiet --download --output snapd_2.49.2.snap GET "$SNAPD_2_49_2_ARMHF"
+      test-snapd-curl.curl -s -o snapd_2.49.2.snap "$SNAPD_2_49_2_ARMHF"
     fi
 
     echo "Refreshing snapd to 2.49.2"

--- a/tests/lib/snaps/store/test-snapd-curl/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-curl/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: test-snapd-curl
+version: '7.58'
+summary: Curl is a command-line tool for transferring data.
+description: |
+  Curl is a command-line tool for transferring data specified with URL syntax.
+grade: stable
+confinement: strict
+base: core18
+
+apps:
+  curl:
+    command: bin/curl
+    plugs:
+      - network
+      - home
+
+parts:
+  copy:
+    plugin: dump
+    stage-packages:
+        - curl
+    source: .

--- a/tests/main/default-tracks/task.yaml
+++ b/tests/main/default-tracks/task.yaml
@@ -5,11 +5,12 @@ environment:
     A_TRACK: default
 
 prepare: |
-    snap install http jq
+    snap install jq
+    snap install test-snapd-curl --edge
 
 execute: |
     # first, sanity check that the snap has a default track
-    snap run http GET "https://api.snapcraft.io/v2/snaps/info/$A_SNAP" Snap-Device-Series:16 > info
+    snap run test-snapd-curl.curl -H "Snap-Device-Series:16" "https://api.snapcraft.io/v2/snaps/info/$A_SNAP" > info
     test "$( snap run  jq -r '."default-track"' < info )" == "$A_TRACK"
 
     # TODO: check the output of 'snap info' for the default-track-having snap
@@ -23,7 +24,7 @@ execute: |
     "$TESTSTOOLS"/snapd-state check-state ".data.snaps.\"$A_SNAP\".channel" = "$A_TRACK/candidate"
 
     snap remove --purge "$A_SNAP"
-    snap remove --purge http
+    snap remove --purge test-snapd-curl
     snap remove --purge jq
 
     # now try a multi-install

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -16,7 +16,8 @@ systems:
   - -ubuntu-core-16-*
 
 prepare: |
-  snap install go-example-webserver jq remarshal http hello-world
+  snap install go-example-webserver jq remarshal hello-world
+  snap install test-snapd-curl --edge
   snap set system experimental.quota-groups=true
   tests.cleanup defer snap unset system experimental.quota-groups
 
@@ -80,7 +81,7 @@ execute: |
       exit 1
   fi
 
-  snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-one | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap run ttest-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-one | jq -r '.result.current.memory')"
   kernelSaysMemUsage="$(cat "$cgroupMemFile")"
 
   pyCmd="import math; print(math.ceil(abs($snapdSaysMemUsage - $kernelSaysMemUsage) / $snapdSaysMemUsage * 100))"
@@ -168,7 +169,7 @@ execute: |
   # in reporting it's memory usage on old systemd versions
   snap set-quota group-five --memory=10MB --parent=group-four hello-world
 
-  snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-five | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-five | jq -r '.result.current.memory')"
   # both 0 and 4096 values are expected here, 0 is for older systemd/kernels 
   # where an empty cgroup has exactly 0, but on newer systems there is some 
   # minimum amount of accounting memory for an empty cgroup, so it shows up as 
@@ -178,7 +179,7 @@ execute: |
     exit 1
   fi
 
-  snapdSaysMemUsage="$(sudo snap run http --body GET snapd:///v2/quotas/group-four | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-four | jq -r '.result.current.memory')"
   if [ "$snapdSaysMemUsage" != null ] && [ "$snapdSaysMemUsage" != 0 ] && [ "$snapdSaysMemUsage" != 4096 ] ; then
     echo "unexpected memory usage for empty quota group group-four, snapd says: $snapdSaysMemUsage"
     exit 1

--- a/tests/nested/core/core20-create-recovery/task.yaml
+++ b/tests/nested/core/core20-create-recovery/task.yaml
@@ -3,12 +3,12 @@ summary: verify creating recovery system on UC20
 systems: [ubuntu-20.04-64]
 
 prepare: |
-    tests.nested exec sudo snap install http
+    tests.nested exec sudo snap install test-snapd-curl --edge
 
 execute: |
     echo "Create a recovery system with a typical recovery system label"
     boot_id="$( tests.nested boot-id )"
-    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | tests.nested exec sudo http POST snapd:///v2/debug > change.out
+    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | tests.nested exec sudo test-snapd-curl.curl -X POST --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     tests.nested wait-for reboot "${boot_id}"
     tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
@@ -23,7 +23,7 @@ execute: |
 
     echo "Create a recovery system with an alternative recovery system label"
     boot_id="$( tests.nested boot-id )"
-    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234-1"}}' | tests.nested exec sudo http POST snapd:///v2/debug > change.out
+    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234-1"}}' | tests.nested exec sudo test-snapd-curl.curl -X POST --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     tests.nested wait-for reboot "${boot_id}"
     tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -30,18 +30,18 @@ prepare: |
     # thus this test would no longer be testing that old vulnerable devices 
     # become safe after refreshing to the fix
     if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "false" ]; then
-        snap install http --devmode # devmode so it can save to any dir
+        snap install test-snapd-curl --edge --devmode # devmode so it can save to any dir
 
         if os.query is-xenial; then
             # uc16 uses core snap
-            http --quiet --download --output core_2.45.snap GET "$SNAPD_2_45_CORE_SNAP"
+            test-snapd-curl.curl -s -o core_2.45.snap "$SNAPD_2_45_CORE_SNAP"
             # The core snap is unpacked and repacked to prevent it is auto-refreshed when
             # it is installed with --dangerous as it has a different hash
             unsquashfs -d core-snap core_2.45.snap
             snap pack core-snap/ "$(tests.nested get extra-snaps-path)"
         else 
             # uc18 uses snapd snap
-            http --quiet --download --output snapd_2.45.snap GET "$SNAPD_2_45_SNAPD_SNAP"
+            test-snapd-curl.curl -s -o snapd_2.45.snap "$SNAPD_2_45_SNAPD_SNAP"
             cp snapd_2.45.snap "$(tests.nested get extra-snaps-path)"
         fi
     fi

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -36,18 +36,18 @@ prepare: |
     # thus this test would no longer be testing that old vulnerable devices 
     # become safe after refreshing to the fix
     if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "false" ]; then
-        snap install http --devmode # devmode so it can save to any dir
+        snap install test-snapd-curl --edge --devmode # devmode so it can save to any dir
 
         if os.query is-xenial; then
             # uc16 uses core snap
-            http --quiet --download --output core_2.45.snap GET "$SNAPD_2_45_CORE_SNAP"
+            test-snapd-curl.curl -s -o core_2.45.snap "$SNAPD_2_45_CORE_SNAP"
             # The core snap is unpacked and repacked to prevent it is auto-refreshed when
             # it is installed with --dangerous as it has a different hash
             unsquashfs -d core-snap core_2.45.snap
             snap pack core-snap/ "$(tests.nested get extra-snaps-path)"
         else 
             # uc18 uses snapd snap
-            http --quiet --download --output snapd_2.45.snap GET "$SNAPD_2_45_SNAPD_SNAP"
+            test-snapd-curl.curl -s -o snapd_2.45.snap "$SNAPD_2_45_SNAPD_SNAP"
             cp snapd_2.45.snap "$(tests.nested get extra-snaps-path)"
         fi
     fi


### PR DESCRIPTION
The tests have been updated to use test-snapd-curl snap instead of HTTP snap

Also, the code of the test-snapd-curl snap is included in the snapd repo,
which now is built based on the curl package in ubuntu

