### PR TITLE
[RFC] o/configcore: allow hostnames up to 253 characters, with dot-delimited elements

### DIFF
--- a/overlord/configstate/configcore/hostname.go
+++ b/overlord/configstate/configcore/hostname.go
@@ -41,7 +41,7 @@ func init() {
 // We are conservative here and follow hostname(7). The hostnamectl
 // binary is more liberal but let's err on the side of caution for
 // now.
-var validHostname = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,62}$`).MatchString
+var validHostname = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,62}(\.[a-z0-9-]{1,63})*$`).MatchString
 
 func validateHostnameSettings(tr config.ConfGetter) error {
 	hostname, err := coreCfg(tr, "system.hostname")
@@ -51,7 +51,7 @@ func validateHostnameSettings(tr config.ConfGetter) error {
 	if hostname == "" {
 		return nil
 	}
-	if !validHostname(hostname) {
+	if len(hostname) > 253 || !validHostname(hostname) {
 		return fmt.Errorf("cannot set hostname %q: name not valid", hostname)
 	}
 

--- a/overlord/configstate/configcore/hostname_test.go
+++ b/overlord/configstate/configcore/hostname_test.go
@@ -51,10 +51,12 @@ func (s *hostnameSuite) SetUpTest(c *C) {
 }
 
 func (s *hostnameSuite) TestConfigureHostnameInvalid(c *C) {
+	filler := strings.Repeat("x", 60)
 	invalidHostnames := []string{
 		"-no-start-with-dash", "no-upper-A", "no-ä", "no/slash",
 		"ALL-CAPS-IS-NEVER-OKAY", "no-SHOUTING-allowed",
 		strings.Repeat("x", 64),
+		strings.Join([]string{filler, filler, filler, filler, filler}, "."),
 	}
 
 	for _, name := range invalidHostnames {
@@ -77,6 +79,7 @@ func (s *hostnameSuite) TestConfigureHostnameIntegration(c *C) {
 	mockedHostname := testutil.MockCommand(c, "hostname", "echo bar")
 	defer mockedHostname.Restore()
 
+	filler := strings.Repeat("x", 63)
 	validHostnames := []string{
 		"foo",
 		strings.Repeat("x", 63),
@@ -84,7 +87,11 @@ func (s *hostnameSuite) TestConfigureHostnameIntegration(c *C) {
 		"foo-------bar",
 		"foo99",
 		"99foo",
+		"localhost.localdomain",
+		"foo.-bar.com",
 		"can-end-with-a-dash-",
+		// 3*63 + 61 + 3 dots = 253
+		strings.Join([]string{filler, filler, filler, strings.Repeat("x", 61)}, "."),
 	}
 
 	for _, hostname := range validHostnames {


### PR DESCRIPTION
When answering to a forum topic related to our hostname validation and looking at the code, I got a bit confused by what we have, compared to what hostname(7) man page says - in particular this sentence:

_Each element of the hostname must be from 1 to 63 characters long and the entire hostname, including the dots, can be at most 253 characters long._

A present we allow a single element up to 63 characters long, and no dots.