### PR TITLE
tests: remove "features" from fde-setup.go example

### DIFF
--- a/tests/lib/fde-setup-hook/fde-setup.go
+++ b/tests/lib/fde-setup-hook/fde-setup.go
@@ -184,8 +184,6 @@ func runFdeRevealKey() error {
 		// hook, the lock operation must be implemented here
 		// to block decryption operations. This example does
 		// nothing.
-	case "features":
-		fmt.Fprintf(osStdout, `{"features":[]}`)
 	default:
 		return fmt.Errorf(`unsupported operation %q`, js.Op)
 	}


### PR DESCRIPTION
The `fde-setup.go` example hook contains a "features" op in the
`fde-reveal-key` that is not needed or used. Let's remove it to
avoid confusion.
