### PR TITLE
osutil: ensure parent dir is opened and sync'd

### DIFF
--- a/osutil/io.go
+++ b/osutil/io.go
@@ -255,6 +255,11 @@ func AtomicRename(oldName, newName string) error {
 	// snapdUnsafeIO controls the ability to ignore expensive disk
 	// synchronization. It is only used inside tests.
 	if !snapdUnsafeIO {
+		// if called with a path with trailing '/', filepath.Dir
+		// returns the dir itself instead of the parent
+		oldName = filepath.Clean(oldName)
+		newName = filepath.Clean(newName)
+
 		oldDirPath := filepath.Dir(oldName)
 		newDirPath := filepath.Dir(newName)
 


### PR DESCRIPTION
osutil.AtomicRename won't work if called with a path to a directory with a trailing '/'. The method gets the parent directories of the old and new file, so it can sync them after the rename. However, since filepath.Dir() removes the section up to the last path separator, if called with "/parent/child/" it would return "/parent/child" and we'd open the wrong file.
