### PR TITLE
cmd/snap-confine/snap-confine.apparmor.in: update ld rule for s390x impish

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -18,7 +18,7 @@
     # Do not assume that the interpreter is always named like
     # ld-linux-x86_64.so, as on some architectures there can be a version after
     # the .so suffix, eg. ld-linux-aarch64.so.1
-    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld-*.so* mrix,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so* mrix,
     # libc, you are funny
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,
@@ -465,7 +465,7 @@
         # We run privileged, so be fanatical about what we include and don't use
         # any abstractions
         /etc/ld.so.cache r,
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld-*.so* mrix,
+        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so* mrix,
         # libc, you are funny
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,


### PR DESCRIPTION
Observed on an Impish s390x machine:

root@test-i:~# ls -lah /usr/lib/ld64.so.1
lrwxrwxrwx 1 root root 25 Sep  2 21:26 /usr/lib/ld64.so.1 -> s390x-linux-gnu/ld64.so.1

Which comes from the new libc6, and is different from what we expected on
previous releases, see for example Hirsute:

root@testing-h:~# ls -lah /usr/lib/ld64.so.1
lrwxrwxrwx 1 root root 26 Mar 31  2021 /usr/lib/ld64.so.1 -> s390x-linux-gnu/ld-2.33.so

The latter matched the existing rule, while the former does not. The new rule
allows both.

Also note that ppc64le had the same transition with the same filepaths, so this PR
will unbreak impish on that platform as well as s390x.