### PR TITLE
interfaces/apparmor: allow read access to random files for haveged

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -276,6 +276,8 @@ var templateCommon = `
   @{PROC}/sys/kernel/random/boot_id r,
   @{PROC}/sys/kernel/random/entropy_avail r,
   @{PROC}/sys/kernel/random/uuid r,
+  @{PROC}/sys/kernel/random/poolsize r,
+  @{PROC}/sys/kernel/random/write_wakeup_threshold r,
   @{PROC}/sys/kernel/cap_last_cap r,
   # Allow access to the uuidd daemon (this daemon is a thin wrapper around
   # time and getrandom()/{,u}random and, when available, runs under an


### PR DESCRIPTION
Similar to the PR, https://github.com/snapcore/snapd/pull/10036.

The functionality of the project haveged is implemented in the newer kernel version but not for the one of uc20. We'd like to include haveged in our images. In its manual, https://github.com/jirka-h/haveged/blob/e675ae0cb08225af181a5997d127aeb448899c47/man/haveged.8, it says the haveged service will read the below files:
- /dev/random
- /proc/sys/kernel/osrelease
- /proc/sys/kernel/random/poolsize
- /proc/sys/kernel/random/write_wakeup_threshold

The first 2 files are readable already by snapd. This PR is to add the latter 2 files. :)