### PR TITLE
osutil/disks, many: switch to defining Partitions directly for MockDiskMapping

### DIFF
--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -123,17 +123,41 @@ func MockLkFiles(c *C, rootdir string, opts *Options) (restore func()) {
 		lkBootDisk := &disks.MockDiskMapping{
 			// mock the partition labels, since these structures won't have
 			// filesystems, but they will have partition labels
-			PartitionLabelToPartUUID: map[string]string{
-				"snapbootsel":        "snapbootsel-partuuid",
-				"snapbootselbak":     "snapbootselbak-partuuid",
-				"snaprecoverysel":    "snaprecoverysel-partuuid",
-				"snaprecoveryselbak": "snaprecoveryselbak-partuuid",
+			Structure: []disks.Partition{
+				{
+					PartitionLabel: "snapbootsel",
+					PartitionUUID:  "snapbootsel-partuuid",
+				},
+				{
+					PartitionLabel: "snapbootselbak",
+					PartitionUUID:  "snapbootselbak-partuuid",
+				},
+				{
+					PartitionLabel: "snaprecoverysel",
+					PartitionUUID:  "snaprecoverysel-partuuid",
+				},
+				{
+					PartitionLabel: "snaprecoveryselbak",
+					PartitionUUID:  "snaprecoveryselbak-partuuid",
+				},
 				// for run mode kernel snaps
-				"boot_a": "boot-a-partuuid",
-				"boot_b": "boot-b-partuuid",
+				{
+					PartitionLabel: "boot_a",
+					PartitionUUID:  "boot-a-partuuid",
+				},
+				{
+					PartitionLabel: "boot_b",
+					PartitionUUID:  "boot-b-partuuid",
+				},
 				// for recovery system kernel snaps
-				"boot_ra": "boot-ra-partuuid",
-				"boot_rb": "boot-rb-partuuid",
+				{
+					PartitionLabel: "boot_ra",
+					PartitionUUID:  "boot-ra-partuuid",
+				},
+				{
+					PartitionLabel: "boot_rb",
+					PartitionUUID:  "boot-rb-partuuid",
+				},
 			},
 			DiskHasPartitions: true,
 			DevNum:            "lk-boot-disk-dev-num",

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -93,34 +93,64 @@ var (
 		NoSuid: true,
 	}
 
+	seedPart = disks.Partition{
+		FilesystemLabel: "ubuntu-seed",
+		PartitionUUID:   "ubuntu-seed-partuuid",
+	}
+
+	bootPart = disks.Partition{
+		FilesystemLabel: "ubuntu-boot",
+		PartitionUUID:   "ubuntu-boot-partuuid",
+	}
+
+	savePart = disks.Partition{
+		FilesystemLabel: "ubuntu-save",
+		PartitionUUID:   "ubuntu-save-partuuid",
+	}
+
+	dataPart = disks.Partition{
+		FilesystemLabel: "ubuntu-data",
+		PartitionUUID:   "ubuntu-data-partuuid",
+	}
+
+	saveEncPart = disks.Partition{
+		FilesystemLabel: "ubuntu-save-enc",
+		PartitionUUID:   "ubuntu-save-enc-partuuid",
+	}
+
+	dataEncPart = disks.Partition{
+		FilesystemLabel: "ubuntu-data-enc",
+		PartitionUUID:   "ubuntu-data-enc-partuuid",
+	}
+
 	// a boot disk without ubuntu-save
 	defaultBootDisk = &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-boot": "ubuntu-boot-partuuid",
-			"ubuntu-seed": "ubuntu-seed-partuuid",
-			"ubuntu-data": "ubuntu-data-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			bootPart,
+			dataPart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "default",
 	}
 
 	defaultBootWithSaveDisk = &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-boot": "ubuntu-boot-partuuid",
-			"ubuntu-seed": "ubuntu-seed-partuuid",
-			"ubuntu-data": "ubuntu-data-partuuid",
-			"ubuntu-save": "ubuntu-save-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			bootPart,
+			dataPart,
+			savePart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "default-with-save",
 	}
 
 	defaultEncBootDisk = &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-boot":     "ubuntu-boot-partuuid",
-			"ubuntu-seed":     "ubuntu-seed-partuuid",
-			"ubuntu-data-enc": "ubuntu-data-enc-partuuid",
-			"ubuntu-save-enc": "ubuntu-save-enc-partuuid",
+		Structure: []disks.Partition{
+			bootPart,
+			seedPart,
+			dataEncPart,
+			saveEncPart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "defaultEncDev",
@@ -2086,10 +2116,10 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyNoS
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	defaultEncNoSaveBootDisk := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-boot":     "ubuntu-boot-partuuid",
-			"ubuntu-seed":     "ubuntu-seed-partuuid",
-			"ubuntu-data-enc": "ubuntu-data-enc-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			bootPart,
+			dataEncPart,
 			// missing ubuntu-save
 		},
 		DiskHasPartitions: true,
@@ -3542,10 +3572,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 	defer bootloader.Force(nil)
 
 	defaultEncDiskNoBoot := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-seed":     "ubuntu-seed-partuuid",
-			"ubuntu-data-enc": "ubuntu-data-enc-partuuid",
-			"ubuntu-save-enc": "ubuntu-save-enc-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			// missing ubuntu-boot
+			dataEncPart,
+			saveEncPart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "defaultEncDevNoBoot",
@@ -3698,10 +3729,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 	defer bootloader.Force(nil)
 
 	defaultEncDiskNoBoot := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-seed":     "ubuntu-seed-partuuid",
-			"ubuntu-data-enc": "ubuntu-data-enc-partuuid",
-			"ubuntu-save-enc": "ubuntu-save-enc-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			// missing ubuntu-boot
+			dataEncPart,
+			saveEncPart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "defaultEncDevNoBoot",
@@ -4059,10 +4091,10 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedAbsentDataU
 
 	// no ubuntu-data on the disk at all
 	mockDiskNoData := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-boot": "ubuntu-boot-partuuid",
-			"ubuntu-seed": "ubuntu-seed-partuuid",
-			"ubuntu-save": "ubuntu-save-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			bootPart,
+			savePart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "noDataUnenc",
@@ -4239,12 +4271,12 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedUnencrypted
 
 	// no ubuntu-data on the disk at all
 	mockDiskDataUnencSaveEnc := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-boot": "ubuntu-boot-partuuid",
-			"ubuntu-seed": "ubuntu-seed-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			bootPart,
 			// ubuntu-data is unencrypted but ubuntu-save is encrypted
-			"ubuntu-data":     "ubuntu-data-partuuid",
-			"ubuntu-save-enc": "ubuntu-save-enc-partuuid",
+			dataPart,
+			saveEncPart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "dataUnencSaveEnc",
@@ -4372,12 +4404,12 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeDegradedEncryptedDa
 	defer bootloader.Force(nil)
 
 	mockDiskDataUnencSaveEnc := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-boot":     "ubuntu-boot-partuuid",
-			"ubuntu-seed":     "ubuntu-seed-partuuid",
-			"ubuntu-data-enc": "ubuntu-data-enc-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			bootPart,
 			// ubuntu-data is encrypted but ubuntu-save is not
-			"ubuntu-save": "ubuntu-save-partuuid",
+			savePart,
+			dataEncPart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "dataUnencSaveEnc",
@@ -4627,12 +4659,12 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
 
-	// no ubuntu-data on the disk at all
 	mockDiskNoData := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-boot":     "ubuntu-boot-partuuid",
-			"ubuntu-seed":     "ubuntu-seed-partuuid",
-			"ubuntu-save-enc": "ubuntu-save-enc-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			bootPart,
+			// no ubuntu-data on the disk at all
+			saveEncPart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "defaultEncDev",
@@ -5193,21 +5225,33 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedAttackerFS
 	defer bootloader.Force(nil)
 
 	mockDisk := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-seed":     "ubuntu-seed-partuuid",
-			"ubuntu-boot":     "ubuntu-boot-partuuid",
-			"ubuntu-data-enc": "ubuntu-data-enc-partuuid",
-			"ubuntu-save-enc": "ubuntu-save-enc-partuuid",
+		Structure: []disks.Partition{
+			seedPart,
+			bootPart,
+			saveEncPart,
+			dataEncPart,
 		},
 		DiskHasPartitions: true,
 		DevNum:            "bootDev",
 	}
 	attackerDisk := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-seed":     "ubuntu-seed-attacker-partuuid",
-			"ubuntu-boot":     "ubuntu-boot-attacker-partuuid",
-			"ubuntu-data-enc": "ubuntu-data-enc-attacker-partuuid",
-			"ubuntu-save-enc": "ubuntu-save-enc-attacker-partuuid",
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "ubuntu-seed",
+				PartitionUUID:   "ubuntu-seed-attacker-partuuid",
+			},
+			{
+				FilesystemLabel: "ubuntu-boot",
+				PartitionUUID:   "ubuntu-boot-attacker-partuuid",
+			},
+			{
+				FilesystemLabel: "ubuntu-save-enc",
+				PartitionUUID:   "ubuntu-save-enc-attacker-partuuid",
+			},
+			{
+				FilesystemLabel: "ubuntu-data-enc",
+				PartitionUUID:   "ubuntu-data-enc-attacker-partuuid",
+			},
 		},
 		DiskHasPartitions: true,
 		DevNum:            "attackerDev",
@@ -5332,8 +5376,8 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallRecoverModeMeasure(c *C
 
 	mockDiskMapping := map[disks.Mountpoint]*disks.MockDiskMapping{
 		{Mountpoint: boot.InitramfsUbuntuSeedDir}: {
-			FilesystemLabelToPartUUID: map[string]string{
-				"ubuntu-seed": "ubuntu-seed-partuuid",
+			Structure: []disks.Partition{
+				seedPart,
 			},
 			DiskHasPartitions: true,
 		},
@@ -5366,9 +5410,7 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallRecoverModeMeasure(c *C
 		// also add the ubuntu-data and ubuntu-save fs labels to the
 		// disk referenced by the ubuntu-seed partition
 		disk := mockDiskMapping[disks.Mountpoint{Mountpoint: boot.InitramfsUbuntuSeedDir}]
-		disk.FilesystemLabelToPartUUID["ubuntu-boot"] = "ubuntu-boot-partuuid"
-		disk.FilesystemLabelToPartUUID["ubuntu-data"] = "ubuntu-data-partuuid"
-		disk.FilesystemLabelToPartUUID["ubuntu-save"] = "ubuntu-save-partuuid"
+		disk.Structure = append(disk.Structure, bootPart, savePart, dataPart)
 
 		// and also add the /run/mnt/host/ubuntu-{boot,data,save} mountpoints
 		// for cross-checking after mounting

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -34,20 +34,19 @@ var _ = Disk(&MockDiskMapping{})
 // DevNum must be a unique string per unique mocked disk, if only one disk is
 // being mocked it can be left empty.
 type MockDiskMapping struct {
-	// TODO: eliminate these manual mappings and instead switch all the users
-	// over to providing the full list of Partitions instead, but in the
-	// interest of smaller PR's we are doing that in a separate PR.
-	// FilesystemLabelToPartUUID is a mapping of the udev encoded filesystem
-	// labels to the expected partition uuids.
-	FilesystemLabelToPartUUID map[string]string
-	// PartitionLabelToPartUUID is a mapping of the udev encoded partition
-	// labels to the expected partition uuids.
-	PartitionLabelToPartUUID map[string]string
-	DiskHasPartitions        bool
+	// TODO: should this be automatically determined if Structure has non-zero
+	// len instead?
+	DiskHasPartitions bool
 
-	// TODO: add an exported list of Partitions here
+	// Structure is the set of partitions or structures on the disk. These
+	// partitions are used with Partitions() as well as
+	// FindMatchingPartitionWith{Fs,Part}Label
+	Structure []Partition
 
-	// static variables for the disk
+	// static variables for the disk that must be unique for different disks,
+	// but note that there are potentially multiple DevNode values that could
+	// map to a single disk, but it's not worth encoding that complexity here
+	// by making DevNodes a list
 	DevNum  string
 	DevNode string
 	DevPath string
@@ -58,19 +57,13 @@ type MockDiskMapping struct {
 func (d *MockDiskMapping) FindMatchingPartitionWithFsLabel(label string) (Partition, error) {
 	// TODO: this should just iterate over the static list when that is a thing
 	osutil.MustBeTestBinary("mock disks only to be used in tests")
-	if partuuid, ok := d.FilesystemLabelToPartUUID[label]; ok {
-		part := Partition{
-			PartitionUUID:   partuuid,
-			FilesystemLabel: label,
+
+	for _, p := range d.Structure {
+		if p.FilesystemLabel == label {
+			return p, nil
 		}
-		// add the partition label too if we have one for this partition uuid
-		for partlabel, partuuid2 := range d.PartitionLabelToPartUUID {
-			if partuuid2 == partuuid {
-				part.PartitionLabel = partlabel
-			}
-		}
-		return part, nil
 	}
+
 	return Partition{}, PartitionNotFoundError{
 		SearchType:  "filesystem-label",
 		SearchQuery: label,
@@ -80,21 +73,14 @@ func (d *MockDiskMapping) FindMatchingPartitionWithFsLabel(label string) (Partit
 // FindMatchingPartitionUUIDWithPartLabel returns a matching PartitionUUID
 // for the specified filesystem label if it exists. Part of the Disk interface.
 func (d *MockDiskMapping) FindMatchingPartitionWithPartLabel(label string) (Partition, error) {
-	// TODO: this should just iterate over the static list when that is a thing
 	osutil.MustBeTestBinary("mock disks only to be used in tests")
-	if partuuid, ok := d.PartitionLabelToPartUUID[label]; ok {
-		part := Partition{
-			PartitionUUID:  partuuid,
-			PartitionLabel: label,
+
+	for _, p := range d.Structure {
+		if p.PartitionLabel == label {
+			return p, nil
 		}
-		// add the filesystem label too if we have one for this partition uuid
-		for fsLabel, partuuid2 := range d.FilesystemLabelToPartUUID {
-			if partuuid2 == partuuid {
-				part.FilesystemLabel = fsLabel
-			}
-		}
-		return part, nil
 	}
+
 	return Partition{}, PartitionNotFoundError{
 		SearchType:  "partition-label",
 		SearchQuery: label,
@@ -118,39 +104,7 @@ func (d *MockDiskMapping) FindMatchingPartitionUUIDWithPartLabel(label string) (
 }
 
 func (d *MockDiskMapping) Partitions() ([]Partition, error) {
-	// TODO: this should just return the static list that was in the mapping
-	// when that is a thing
-
-	// dynamically build up a list of partitions with the mappings we were
-	// provided
-	parts := make([]Partition, 0, len(d.PartitionLabelToPartUUID))
-
-	partUUIDToPart := map[string]Partition{}
-
-	// first populate with all the partition labels
-	for partLabel, partuuid := range d.PartitionLabelToPartUUID {
-		part := Partition{
-			PartitionLabel: partLabel,
-			PartitionUUID:  partuuid,
-		}
-
-		partUUIDToPart[partuuid] = part
-	}
-
-	for fsLabel, partuuid := range d.FilesystemLabelToPartUUID {
-		existingPart, ok := partUUIDToPart[partuuid]
-		if !ok {
-			parts = append(parts, Partition{
-				FilesystemLabel: fsLabel,
-				PartitionUUID:   partuuid,
-			})
-			continue
-		}
-		existingPart.FilesystemLabel = fsLabel
-		parts = append(parts, existingPart)
-	}
-
-	return parts, nil
+	return d.Structure, nil
 }
 
 // HasPartitions returns if the mock disk has partitions or not. Part of the
@@ -202,19 +156,100 @@ type Mountpoint struct {
 	IsDecryptedDevice bool
 }
 
+func checkMockDiskMappingsForDuplicates(mockedDisks map[string]*MockDiskMapping) {
+	// we do the minimal amount of validation here, where if things are
+	// specified as non-zero value we check that they make sense, but we don't
+	// require that every field is set for every partition since many tests
+	// don't care about every field
+
+	// check partition uuid's and partition labels for duplication inter-disk
+	// we could have valid cloned disks where the same partition uuid/label
+	// appears on two disks, but never on the same disk
+	for _, disk := range mockedDisks {
+		seenPartUUID := make(map[string]bool, len(disk.Structure))
+		seenPartLabel := make(map[string]bool, len(disk.Structure))
+		for _, p := range disk.Structure {
+			if p.PartitionUUID != "" {
+				if seenPartUUID[p.PartitionUUID] {
+					panic("mock error: disk has duplicated partition uuids in its structure")
+				}
+				seenPartUUID[p.PartitionUUID] = true
+			}
+
+			if p.PartitionLabel != "" {
+				if seenPartLabel[p.PartitionLabel] {
+					panic("mock error: disk has duplicated partition labels in its structure")
+				}
+				seenPartLabel[p.PartitionLabel] = true
+			}
+		}
+	}
+
+	// check major/minors across all structures
+	type majmin struct{ maj, min int }
+	seenMajorMinors := map[majmin]bool{}
+	for _, disk := range mockedDisks {
+		for _, p := range disk.Structure {
+			if p.Major == 0 && p.Minor == 0 {
+				continue
+			}
+
+			m := majmin{maj: p.Major, min: p.Minor}
+			if seenMajorMinors[m] {
+				panic("mock error: duplicated major minor numbers for partitions in disk mapping")
+			}
+			seenMajorMinors[m] = true
+		}
+	}
+
+	// check device paths across all structures
+	seenDevPaths := map[string]bool{}
+	for _, disk := range mockedDisks {
+		for _, p := range disk.Structure {
+			if p.KernelDevicePath == "" {
+				continue
+			}
+			if seenDevPaths[p.KernelDevicePath] {
+				panic("mock error: duplicated kernel device paths for partitions in disk mapping")
+			}
+			seenDevPaths[p.KernelDevicePath] = true
+		}
+	}
+
+	// check device nodes across all structures
+	seendDevNodes := map[string]bool{}
+	for _, disk := range mockedDisks {
+		for _, p := range disk.Structure {
+			if p.KernelDevicePath == "" {
+				continue
+			}
+
+			if seendDevNodes[p.KernelDeviceNode] {
+				panic("mock error: duplicated kernel device nodes for partitions in disk mapping")
+			}
+			seendDevNodes[p.KernelDeviceNode] = true
+		}
+	}
+
+	// no checking of filesystem label/uuid since those could be duplicated as
+	// they exist independent of any other structure
+}
+
 // MockDeviceNameDisksToPartitionMapping will mock DiskFromDeviceName such that
 // the provided map of device names to mock disks is used instead of the actual
 // implementation using udev.
-func MockDeviceNameDisksToPartitionMapping(mockedMountPoints map[string]*MockDiskMapping) (restore func()) {
+func MockDeviceNameDisksToPartitionMapping(mockedDisks map[string]*MockDiskMapping) (restore func()) {
 	osutil.MustBeTestBinary("mock disks only to be used in tests")
 
-	// note that devices can have many names that are recognized by
+	checkMockDiskMappingsForDuplicates(mockedDisks)
+
+	// note that devices can have multiple "names" that are recognized by
 	// udev/kernel, so we don't do any validation of the mapping here like we do
-	// for MockMountPointDisksToPartitionMapping
+	// for MockMountPointDisksToPartitionMapping and MockDevicePathDisksToPartitionMapping
 
 	old := diskFromDeviceName
 	diskFromDeviceName = func(deviceName string) (Disk, error) {
-		disk, ok := mockedMountPoints[deviceName]
+		disk, ok := mockedDisks[deviceName]
 		if !ok {
 			return nil, fmt.Errorf("device name %q not mocked", deviceName)
 		}

--- a/osutil/disks/mockdisk_test.go
+++ b/osutil/disks/mockdisk_test.go
@@ -42,8 +42,11 @@ func (s *mockDiskSuite) SetUpTest(c *C) {
 func (s *mockDiskSuite) TestMockDeviceNameDisksToPartitionMapping(c *C) {
 	// one disk with different device names
 	d1 := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"label1": "part1",
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "label1",
+				PartitionUUID:   "part1",
+			},
 		},
 		DiskHasPartitions: true,
 		DevNum:            "d1",
@@ -52,8 +55,11 @@ func (s *mockDiskSuite) TestMockDeviceNameDisksToPartitionMapping(c *C) {
 	}
 
 	d2 := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"label2": "part2",
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "label2",
+				PartitionUUID:   "part2",
+			},
 		},
 		DiskHasPartitions: true,
 		DevNum:            "d2",
@@ -104,16 +110,22 @@ func (s *mockDiskSuite) TestMockDeviceNameDisksToPartitionMapping(c *C) {
 func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMappingVerifiesUniqueness(c *C) {
 	// two different disks with different DevNum's
 	d1 := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"label1": "part1",
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "label1",
+				PartitionUUID:   "part1",
+			},
 		},
 		DiskHasPartitions: true,
 		DevNum:            "d1",
 	}
 
 	d2 := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"label1": "part1",
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "label1",
+				PartitionUUID:   "part1",
+			},
 		},
 		DiskHasPartitions: false,
 		DevNum:            "d2",
@@ -152,8 +164,11 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMappingVerifiesUniquen
 
 func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMappingVerifiesConsistency(c *C) {
 	d1 := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"label1": "part1",
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "label1",
+				PartitionUUID:   "part1",
+			},
 		},
 		DiskHasPartitions: true,
 		DevNum:            "d1",
@@ -177,22 +192,24 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMappingVerifiesConsist
 
 func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 	d1 := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"label1": "part1",
-		},
-		PartitionLabelToPartUUID: map[string]string{
-			"part-label1": "part1",
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "label1",
+				PartitionUUID:   "part1",
+				PartitionLabel:  "part-label1",
+			},
 		},
 		DiskHasPartitions: true,
 		DevNum:            "d1",
 	}
 
 	d2 := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"label2": "part2",
-		},
-		PartitionLabelToPartUUID: map[string]string{
-			"part-label2": "part2",
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "label2",
+				PartitionUUID:   "part2",
+				PartitionLabel:  "part-label2",
+			},
 		},
 		DiskHasPartitions: true,
 		DevNum:            "d2",
@@ -322,10 +339,19 @@ func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMapping(c *C) {
 
 func (s *mockDiskSuite) TestMockMountPointDisksToPartitionMappingDecryptedDevices(c *C) {
 	d1 := &disks.MockDiskMapping{
-		FilesystemLabelToPartUUID: map[string]string{
-			"ubuntu-seed":     "ubuntu-seed-part",
-			"ubuntu-boot":     "ubuntu-boot-part",
-			"ubuntu-data-enc": "ubuntu-data-enc-part",
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "ubuntu-seed",
+				PartitionUUID:   "ubuntu-seed-part",
+			},
+			{
+				FilesystemLabel: "ubuntu-boot",
+				PartitionUUID:   "ubuntu-boot-part",
+			},
+			{
+				FilesystemLabel: "ubuntu-data-enc",
+				PartitionUUID:   "ubuntu-data-enc-part",
+			},
 		},
 		DiskHasPartitions: true,
 		DevNum:            "d1",


### PR DESCRIPTION
This will be necessary for more complicated test cases in the gadget package,
so time to rip this band-aid and get rid of the old methods.

I did consider having the new member "Structure" exist alongside the existing map
fields, but it made the implementation clunky and difficult to read, so I opted instead
to just rip the band-aid off and totally remove these methods instead.
