### PR TITLE
interfaces: timezone-control, add permission for ListTimezones DBus call

### DIFF
--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -59,6 +59,13 @@ dbus (send)
     member="SetTimezone"
     peer=(label=unconfined),
 
+dbus (send)
+    bus=system
+    path=/org/freedesktop/timedate1
+    interface=org.freedesktop.timedate1
+    member="ListTimezones"
+    peer=(label=unconfined),
+
 # Read all properties from timedate1
 # do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)


### PR DESCRIPTION
Using a snap with the timezone-control interface connected does not allow the ListTimezones DBus call, so the app can not determine what time-zones are supported by the host system:
```
$ snap run --shell geoip-lookup.geoip
$ timedatectl list-timezones
Failed to request list of time zones: Access denied
$ dbus-send --system --dest=org.freedesktop.timedate1 --type=method_call --print-reply /org/freedesktop/timedate1 org.freedesktop.timedate1.ListTimezones
Error org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender=":1.46" (uid=1000 pid=11034 comm="dbus-send --system --dest=org.freedesktop.timedate" label="snap.geoip-lookup.geoip (enforce)") interface="org.freedesktop.timedate1" member="ListTimezones" error name="(unset)" requested_reply="0" destination="org.freedesktop.timedate1" (bus)
```
Fails with the following denial:
```
kernel: audit: type=1107 audit(1633950085.076:776): pid=1059 uid=100 auid=4294967295 ses=4294967295 msg='apparmor="DENIED" operation="dbus_method_call"  bus="system" path="/org/freedesktop/timedate1" interface="org.freedesktop.timedate1" member="ListTimezones" mask="send" name="org.freedesktop.timedate1" pid=11020 label="snap.geoip-lookup.geoip" peer_pid=10986 peer_label="unconfined"
```

Allowing this DBus call in the apparmor profile of the app fixes the issue and all time-zones are listed as expected.