### PR TITLE
daemon: make daemon shutdown timeout shorter

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -280,7 +280,7 @@ func (d *Daemon) addRoutes() {
 }
 
 var (
-	shutdownTimeout = 25 * time.Second
+	shutdownTimeout = 10 * time.Second
 )
 
 type connTracker struct {


### PR DESCRIPTION
When snapd is requested to stop, the daemon would wait 25s for late clients.
Because of the waits along the stop path, it may so happen that snapd goes over
the default stop timeout for the snapd service. Since we don't want snapd to
wait too long for the clients, make the shutdown timeout shorter and thus be
more aggressive when performing a graceful shutdown.

