### PR TITLE
daemon: use the syscall connection to get the socket credentials

### DIFF
--- a/tests/main/snapd-sigterm/task.yaml
+++ b/tests/main/snapd-sigterm/task.yaml
@@ -1,0 +1,30 @@
+summary: Ensure that snapd quits on SIGTERM
+
+details: |
+    This is a regression test for LP#1946656. We want to check that a pending
+    connection can not prevent snapd from quitting.
+
+restore: |
+    echo "Restarting snapd"
+    # No harm if it was already running
+    systemctl start snapd.service
+
+execute: |
+    echo "Make a request, keep the connection open"
+    nc -U /run/snapd.socket << EOF &
+    GET /v2/apps HTTP/1.1
+    Host: localhost
+
+    EOF
+
+    echo "Stopping snapd, and measuring time"
+    TEST_TIME0="$(date +'%s')"
+    systemctl stop snapd.service
+
+    retry -n 10 sh -c 'systemctl status snapd.service | MATCH "inactive"'
+    TEST_TIME1="$(date +'%s')"
+
+    if ((TEST_TIME1 > TEST_TIME0 + 5)); then
+        echo "Stopping snapd took more than 5 seconds!"
+        exit 1
+    fi


### PR DESCRIPTION
For some reason, the old code was causing snapd to hang when asked to
terminate if there were still some clients connected: the connection
would not move to the "idle" state.

This was found while investigating LP#1946656, and as a matter of facts
it fixes it. While debugging, an inspection of snapd threads while in
hanging state revealed that one thread was stuck in

    daemon.(*ucrednetConn).Read

and it was verified that removing the Accept function completely would
resolve the issue (though also considerably changing snapd behaviour).
This changeset also appears to fix the issue, while not changing snapd
behaviour.

The problem with the old code does not lie in duplicating the file
descriptor (which is done by calling UnixConn.File()), but rather in the
apparently innocuous call to File.Fd(): as it can be seen by looking at
its source code[^note1], this function sets the file descriptor mode to
blocking, and this is what causes our connections to hang.

[^note1]: https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/os/file_unix.go;l=81-88