### PR TITLE
docs: update HACKING.md instructions for snapd 2.52 and later

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -17,7 +17,7 @@ If you need to build older versions of snapd, please have a look at the file
 ### Setting up your build environment
 
 If your Go environment (e.g. `GOPATH`) is already configured, you should skip
-this step. The go environment setup can be added to your shell login script
+this step. The Go environment setup can be added to your shell login script
 (e.g. ~/.bashrc for bash) for automatic setup (after a terminal restart).
 
 ```
@@ -61,7 +61,7 @@ above).
 
 ### Getting the snapd sources
 
-The easiest way to get the source for `snapd` is to clone the Github repository
+The easiest way to get the source for `snapd` is to clone the GitHub repository
 in a directory where you have read-write permissions, such as your home
 directory.
 
@@ -82,12 +82,12 @@ http://www.ubuntu.com/legal/contributors).
 Complete requirements can be found in CONTRIBUTING.md.
 
 Contributions are submitted through a Pull Request created from a fork of the
-`snapd` repository (under your Github account). 
+`snapd` repository (under your GitHub account). 
 
-Start by creating a fork of the `snapd` repository on Github.
+Start by creating a fork of the `snapd` repository on GitHub.
 
 Add your fork as an additional remote to an already cloned `snapd` main
-repository. Replace `<user>` with your Github account username.
+repository. Replace `<user>` with your GitHub account username.
 
 ```
 cd ~/snapd
@@ -109,9 +109,9 @@ git commit -a -m "commit message"
 git push fork <branchname>
 ```
 
-Create the Pull Request for your branch on Github.
+Create the Pull Request for your branch on GitHub.
 
-This complete process is outlined in the Github documentation [here](
+This complete process is outlined in the GitHub documentation [here](
 https://docs.github.com/en/github/collaborating-with-pull-requests).
 
 We value good tests, so when you fix a bug or add a new feature we highly
@@ -133,7 +133,7 @@ Go module dependencies are automatically resolved at build time.
 
 ### Building (natively)
 
-To build the `snap` commandline client:
+To build the `snap` command line client:
 
 ```
 cd ~/snapd

--- a/HACKING.md
+++ b/HACKING.md
@@ -12,7 +12,7 @@ Go 1.13 or later is required to build `snapd`.
 
 If you need to build older versions of snapd, please have a look at the file
 `debian/control` to find out what dependencies were needed at the time
-(including which version of the go compiler).
+(including which version of the Go compiler).
 
 ### Setting up your build environment
 
@@ -31,7 +31,7 @@ export PATH="$PATH:$GOPATH/bin"
 When working with the source of Go programs, you should define a path within
 your home directory (or other workspace) which will be your `GOPATH`. `GOPATH`
 is similar to Java's `CLASSPATH` or Python's `~/.local`. `GOPATH` is
-documented [online](http://golang.org/pkg/go/build/) and inside the go tool
+documented [online](http://golang.org/pkg/go/build/) and inside the `go` tool
 itself.
 
     go help gopath
@@ -50,7 +50,7 @@ packages and compiled binaries, respectively.
 Setting `GOPATH` correctly is critical when developing Go programs. Set and
 export it as part of your login script.
 
-Add `$GOPATH/bin` to your `PATH`, so you can run the go programs you install:
+Add `$GOPATH/bin` to your `PATH`, so you can run the Go programs you install:
 
     PATH="$PATH:$GOPATH/bin"
 
@@ -165,7 +165,7 @@ Install a suitable cross-compiler for the target architecture.
 sudo apt-get install gcc-arm-linux-gnueabihf
 ```
 
-Verify the default architecture version of your GCC cross compiler.
+Verify the default architecture version of your GCC cross-compiler.
 
 ```
 arm-linux-gnueabihf-gcc -v
@@ -176,7 +176,7 @@ arm-linux-gnueabihf-gcc -v
 --with-mode=thumb
 ```
 
-Verify the supported Go cross compile ARM targets [here](
+Verify the supported Go cross-compile ARM targets [here](
 https://github.com/golang/go/wiki/GoArm).
 
 `Snapd` depends on libseccomp v2.3 or later. The following instructions can be

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,8 +1,8 @@
 # Hacking on snapd
 
 Hacking on `snapd` is fun and straightforward. The code is extensively unit
-tested and we use the [spread](https://github.com/snapcore/spread) integration test framework for the
-integration/system level tests.
+tested and we use the [spread](https://github.com/snapcore/spread)
+integration test framework for the integration/system level tests.
 
 ## Development
 
@@ -10,13 +10,15 @@ integration/system level tests.
 
 Go 1.13 or later is required to build `snapd`.
 
-If you need to build older versions of snapd, please have a look at the file `debian/control` to find out what dependencies were needed at the time (including which version of the go compiler).
+If you need to build older versions of snapd, please have a look at the file
+`debian/control` to find out what dependencies were needed at the time
+(including which version of the go compiler).
 
 ### Setting up your build environment
 
 If your Go environment (e.g. `GOPATH`) is already configured, you should skip
-this step. The go environment setup can be added to your shell login
-script (e.g. ~/.bashrc for bash) for automatic setup (after a terminal restart).
+this step. The go environment setup can be added to your shell login script
+(e.g. ~/.bashrc for bash) for automatic setup (after a terminal restart).
 
 ```
 export GOPATH=${HOME}/work
@@ -28,21 +30,22 @@ export PATH="$PATH:$GOPATH/bin"
 
 When working with the source of Go programs, you should define a path within
 your home directory (or other workspace) which will be your `GOPATH`. `GOPATH`
-is similar to Java's `CLASSPATH` or Python's `~/.local`. `GOPATH` is documented
-[online](http://golang.org/pkg/go/build/) and inside the go tool itself
+is similar to Java's `CLASSPATH` or Python's `~/.local`. `GOPATH` is
+documented [online](http://golang.org/pkg/go/build/) and inside the go tool
+itself.
 
     go help gopath
 
 Various conventions exist for naming the location of your `GOPATH`, but it
-should exist, and be writable by you. For example
+should exist, and be writable by you. For example:
 
     export GOPATH=${HOME}/work
     mkdir $GOPATH
 
 will define and create `$HOME/work` as your local `GOPATH`. The `go` tool
 itself will create three subdirectories inside your `GOPATH` when required;
-`src`, `pkg` and `bin`, which hold the source of Go programs, compiled packages
-and compiled binaries, respectively.
+`src`, `pkg` and `bin`, which hold the source of Go programs, compiled
+packages and compiled binaries, respectively.
 
 Setting `GOPATH` correctly is critical when developing Go programs. Set and
 export it as part of your login script.
@@ -58,15 +61,16 @@ above).
 
 ### Getting the snapd sources
 
-The easiest way to get the source for `snapd` is to clone the Github repository in
-a directory where you have read-write permissions, such as your home directory.
+The easiest way to get the source for `snapd` is to clone the Github repository
+in a directory where you have read-write permissions, such as your home
+directory.
 
-    cd ~/
+    cd
     git clone https://github.com/snapcore/snapd.git
     cd snapd
 
-This will allow you to build and test `snapd`. If you wish to contribute to the
-`snapd` project, please see the Contributing section.
+This will allow you to build and test `snapd`. If you wish to contribute to
+the `snapd` project, please see the Contributing section.
 
 ### Contributing
 
@@ -77,16 +81,38 @@ http://www.ubuntu.com/legal/contributors).
 
 Complete requirements can be found in CONTRIBUTING.md.
 
-Before you contribute to the`snapd` project, please fork the `snapd` repository
-(under your Github account), and submit patches through a Pull Request.
+Contributions are submitted through a Pull Request created from a fork of the
+`snapd` repository (under your Github account). 
+
+Start by creating a fork of the `snapd` repository on Github.
+
+Add your fork as an additional remote to an already cloned `snapd` main
+repository. Replace `<user>` with your Github account username.
 
 ```
-cd ~/
-git clone https://github.com/<user>/snapd.git
 cd snapd
+git remote add fork git@github.com:<user>/snapd.git
 ```
 
-This process is outlined in the Github documentation [here](https://docs.github.com/en/github/collaborating-with-pull-requests)
+Create a working branch on which to commit your work. Replace
+`<branchname>` with a suitable branch name.
+
+```
+git checkout -b <branchname>
+```
+
+Make changes to the repository and commit the changes to your
+working branch. Push the changes to your forked `snapd` repository.
+
+```
+git commit -a -m "commit message"
+git push fork <branchname>
+```
+
+Create the Pull Request for your branch on Github.
+
+This complete process is outlined in the Github documentation [here](
+https://docs.github.com/en/github/collaborating-with-pull-requests).
 
 We value good tests, so when you fix a bug or add a new feature we highly
 encourage you to add tests.
@@ -112,7 +138,7 @@ To build the `snap` commandline client:
 ```
 cd ~/snapd
 mkdir -p /tmp/build
-go build -o /tmp/build/snapd ./cmd/snapd
+go build -o /tmp/build/snap ./cmd/snap
 ```
 
 To build the `snapd` REST API daemon:
@@ -150,10 +176,11 @@ arm-linux-gnueabihf-gcc -v
 --with-mode=thumb
 ```
 
-Verify the supported Go cross compile ARM targets [here](https://github.com/golang/go/wiki/GoArm).
+Verify the supported Go cross compile ARM targets [here](
+https://github.com/golang/go/wiki/GoArm).
 
-`Snapd` depends on libseccomp v2.3 or later. The following instructions can be used to
-cross-compile the library:
+`Snapd` depends on libseccomp v2.3 or later. The following instructions can be
+used to cross-compile the library:
 
 ```
 cd ~/
@@ -175,9 +202,10 @@ export GOARCH=arm
 export GOARM=7
 ```
 
-The Go environment variables are now explicitly set to target the ARM v7 architecture.
+The Go environment variables are now explicitly set to target the ARM v7
+architecture.
 
-Run the same build commands from the Building (natively) section above. 
+Run the same build commands from the Building (natively) section above.
 
 Verify the target architecture by looking at the application ELF header.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -18,7 +18,7 @@ If you need to build older versions of snapd, please have a look at the file
 
 If your Go environment (e.g. `GOPATH`) is already configured, you should skip
 this step. The Go environment setup can be added to your shell login script
-(e.g. ~/.bashrc for bash) for automatic setup (after a terminal restart).
+(e.g. `~/.bashrc` for bash) for automatic setup (after a terminal restart).
 
 ```
 export GOPATH=${HOME}/work
@@ -72,54 +72,7 @@ directory.
 This will allow you to build and test `snapd`. If you wish to contribute to
 the `snapd` project, please see the Contributing section.
 
-### Contributing
-
-Contributions are always welcome!
-
-Please make sure that you sign the Canonical contributor agreement [here](
-http://www.ubuntu.com/legal/contributors).
-
-Complete requirements can be found in CONTRIBUTING.md.
-
-Contributions are submitted through a Pull Request created from a fork of the
-`snapd` repository (under your GitHub account). 
-
-Start by creating a fork of the `snapd` repository on GitHub.
-
-Add your fork as an additional remote to an already cloned `snapd` main
-repository. Replace `<user>` with your GitHub account username.
-
-```
-cd ~/snapd
-git remote add fork git@github.com:<user>/snapd.git
-```
-
-Create a working branch on which to commit your work. Replace
-`<branchname>` with a suitable branch name.
-
-```
-git checkout -b <branchname>
-```
-
-Make changes to the repository and commit the changes to your
-working branch. Push the changes to your forked `snapd` repository.
-
-```
-git commit -a -m "commit message"
-git push fork <branchname>
-```
-
-Create the Pull Request for your branch on GitHub.
-
-This complete process is outlined in the GitHub documentation [here](
-https://docs.github.com/en/github/collaborating-with-pull-requests).
-
-We value good tests, so when you fix a bug or add a new feature we highly
-encourage you to add tests.
-
-For more information on testing, please see the Testing section.
-
-### Build host dependencies
+### Installing build dependencies
 
 Build dependencies can automatically be resolved using `build-dep`on Ubuntu.
 
@@ -228,6 +181,52 @@ File Attributes
   Tag_CPU_arch: v7
   Tag_FP_arch: VFPv3-D16
 ```
+### Contributing
+
+Contributions are always welcome!
+
+Please make sure that you sign the Canonical contributor agreement [here](
+http://www.ubuntu.com/legal/contributors).
+
+Complete requirements can be found in CONTRIBUTING.md.
+
+Contributions are submitted through a Pull Request created from a fork of the
+`snapd` repository (under your GitHub account). 
+
+Start by creating a fork of the `snapd` repository on GitHub.
+
+Add your fork as an additional remote to an already cloned `snapd` main
+repository. Replace `<user>` with your GitHub account username.
+
+```
+cd ~/snapd
+git remote add fork git@github.com:<user>/snapd.git
+```
+
+Create a working branch on which to commit your work. Replace
+`<branchname>` with a suitable branch name.
+
+```
+git checkout -b <branchname>
+```
+
+Make changes to the repository and commit the changes to your
+working branch. Push the changes to your forked `snapd` repository.
+
+```
+git commit -a -m "commit message"
+git push fork <branchname>
+```
+
+Create the Pull Request for your branch on GitHub.
+
+This complete process is outlined in the GitHub documentation [here](
+https://docs.github.com/en/github/collaborating-with-pull-requests).
+
+We value good tests, so when you fix a bug or add a new feature we highly
+encourage you to add tests.
+
+For more information on testing, please see the Testing section.
 
 ### Testing
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -64,10 +64,32 @@ a directory where you have read-write permissions, such as your home directory.
     cd snapd
 
 This will allow you to build and test `snapd`. If you wish to contribute to the
-`snapd` project, you can fork the `snapd` repository (under your Github account),
-and submit patches through a Pull Request.
+`snapd` project, please see the Contributing section.
+
+### Contributing
+
+Contributions are always welcome!
+
+Please make sure that you sign the Canonical contributor agreement [here](
+http://www.ubuntu.com/legal/contributors).
+
+Complete requirements can be found in CONTRIBUTING.md.
+
+Before you contribute to the`snapd` project, please fork the `snapd` repository
+(under your Github account), and submit patches through a Pull Request.
+
+```
+cd ~/
+git clone https://github.com/<user>/snapd.git
+cd snapd
+```
 
 This process is outlined in the Github documentation [here](https://docs.github.com/en/github/collaborating-with-pull-requests)
+
+We value good tests, so when you fix a bug or add a new feature we highly
+encourage you to add tests.
+
+For more information on testing, please see the Testing section.
 
 ### Build host dependencies
 
@@ -76,10 +98,10 @@ Build dependencies can automatically be resolved using `build-deb`on Ubuntu.
     cd ~/snapd
     sudo apt-get build-dep .
 
-Package build dependancies for other distributions can be found under the
+Package build dependencies for other distributions can be found under the
 `packages\`directory.
 
-Go module dependancies are automatically resolved at build time.
+Go module dependencies are automatically resolved at build time.
 
 ### Building (natively)
 
@@ -99,7 +121,7 @@ mkdir -p /tmp/build
 go build -o /tmp/build/snapd ./cmd/snapd
 ```
 
-To build the all`snapd` components:
+To build the all`snapd` Go components:
 
 ```
 cd ~/snapd
@@ -115,7 +137,7 @@ Install a suitable cross-compiler for the target architecture.
 sudo apt-get install gcc-arm-linux-gnueabihf
 ```
 
-`Snapd` depends on libseccomp. The following instructions can be used to
+`Snapd` depends on libseccomp v2.3 or later. The following instructions can be used to
 cross-compile the library:
 
 ```
@@ -153,28 +175,13 @@ mkdir -p /tmp/build
 go build -o /tmp/build/snapd ./cmd/snapd
 ```
 
-To build all`snapd` components:
+To build all`snapd` Go components:
 
 ```
 cd ~/snapd
 mkdir -p /tmp/build
 go build -o /tmp/build ./...
 ```
-
-### Contributing
-
-Contributions are always welcome! Please make sure that you sign the
-Canonical contributor license agreement at
-http://www.ubuntu.com/legal/contributors
-
-Snapd can be found on GitHub, so in order to fork the source and contribute,
-go to https://github.com/snapcore/snapd. Check out [GitHub's help
-pages](https://help.github.com/) to find out how to set up your local branch,
-commit changes and create pull requests.
-
-We value good tests, so when you fix a bug or add a new feature we highly
-encourage you to create a test in `$source_test.go`. See also the section
-about Testing.
 
 ### Testing
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -65,7 +65,7 @@ The easiest way to get the source for `snapd` is to clone the Github repository
 in a directory where you have read-write permissions, such as your home
 directory.
 
-    cd
+    cd ~/
     git clone https://github.com/snapcore/snapd.git
     cd snapd
 
@@ -90,7 +90,7 @@ Add your fork as an additional remote to an already cloned `snapd` main
 repository. Replace `<user>` with your Github account username.
 
 ```
-cd snapd
+cd ~/snapd
 git remote add fork git@github.com:<user>/snapd.git
 ```
 


### PR DESCRIPTION
HACKING.md: 

Push up the minimum Go version to 1.13 and assume Go
module support. Update the instructions to work on the current version
of snapd and Go. Any person checking out an older version will get the
older version of HACKING.md, which will provide matching instructions.

Add instructions for cross-compiling.

Signed-off-by: Fred Lotter <fred.lotter@canonical.com>