### PR TITLE
spread: fix lxd channel for pc-i386

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -35,7 +35,7 @@ environment:
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     MANAGED_DEVICE: "false"
     # a global setting for LXD channel to use in the tests
-    LXD_SNAP_CHANNEL: "latest/candidate"
+    LXD_SNAP_CHANNEL: '$(if os.query is-pc-i386; then echo 3.0/stable; else echo latest/candidate; fi)'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'


### PR DESCRIPTION
LP: #1946962

https://bugs.launchpad.net/snapd/+bug/1946962

lxd latest/candidate is no longer available on i386.
