### PR TITLE
interfaces/builtin/network-control: also allow for mstp and bchat devices too

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -204,8 +204,8 @@ capability setuid,
 # are virtual and don't show up in /dev
 /dev/net/tun rw,
 
-# Access to sysfs interfaces for tun/tap device settings.
-/sys/devices/virtual/net/tap*/** rw,
+# Access to sysfs interfaces for tun/tap/mstp/bchat device settings.
+/sys/devices/virtual/net/{tap*,mstp*,bchat*}/** rw,
 
 # access to bridge sysfs interfaces for bridge settings
 /sys/devices/virtual/net/*/bridge/* rw,


### PR DESCRIPTION
This is needed for a customer device, see ticket #00318125.

Please hold off on merging until we can get confirmation that this works and is 
sufficient for the customer (hence the blocked label)

But reviews are welcome here.