### PR TITLE
osutil/disks: add DiskFromPartitionDeviceNode 

### DIFF
--- a/osutil/disks/disks_darwin.go
+++ b/osutil/disks/disks_darwin.go
@@ -44,3 +44,7 @@ var diskFromMountPoint = func(mountpoint string, opts *Options) (Disk, error) {
 var mountPointsForPartitionRoot = func(p Partition, opts map[string]string) ([]string, error) {
 	return nil, osutil.ErrDarwin
 }
+
+var diskFromPartitionDeviceNode = func(node string) (Disk, error) {
+	return nil, osutil.ErrDarwin
+}

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -122,7 +122,7 @@ type errNonPhysicalDisk struct {
 
 func (e errNonPhysicalDisk) Error() string { return e.err }
 
-func diskFromUdevProps(deviceIdentifier string, deviceIDType string, props map[string]string) (Disk, error) {
+func diskFromUDevProps(deviceIdentifier string, deviceIDType string, props map[string]string) (Disk, error) {
 	// all physical disks must have ID_PART_TABLE_TYPE defined as the schema for
 	// the disk, so check for that first and if it's missing then we return a
 	// specific NotAPhysicalDisk error
@@ -198,7 +198,7 @@ var diskFromDevicePath = func(devicePath string) (Disk, error) {
 		return nil, err
 	}
 
-	return diskFromUdevProps(devicePath, "path", props)
+	return diskFromUDevProps(devicePath, "path", props)
 }
 
 // DiskFromDeviceName finds a matching Disk using the specified name, such as
@@ -216,7 +216,7 @@ var diskFromDeviceName = func(deviceName string) (Disk, error) {
 		return nil, err
 	}
 
-	return diskFromUdevProps(deviceName, "name", props)
+	return diskFromUDevProps(deviceName, "name", props)
 }
 
 func mountPointsForPartitionRoot(part Partition, mountOptsMatching map[string]string) ([]string, error) {
@@ -265,7 +265,7 @@ var diskFromPartitionDeviceNode = func(node string) (Disk, error) {
 		return nil, err
 	}
 
-	disk, err := diskFromPartUdevPropsAndOpts(props, nil)
+	disk, err := diskFromPartUDevProps(props, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find disk from partition device node %s: %v", node, err)
 	}
@@ -400,7 +400,7 @@ func (d *disk) Schema() string {
 	return d.schema
 }
 
-func diskFromPartUdevPropsAndOpts(props map[string]string, opts *Options) (*disk, error) {
+func diskFromPartUDevProps(props map[string]string, opts *Options) (*disk, error) {
 	if opts != nil && opts.IsDecryptedDevice {
 		// verify that the mount point is indeed a mapper device, it should:
 		// 1. have DEVTYPE == disk from udev
@@ -598,7 +598,7 @@ func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
 		return nil, fmt.Errorf("cannot find disk for partition %s: %v", partMountPointSource, err)
 	}
 
-	disk, err := diskFromPartUdevPropsAndOpts(props, opts)
+	disk, err := diskFromPartUDevProps(props, opts)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find disk from mountpoint source %s of %s: %v", partMountPointSource, mountpoint, err)
 	}

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -202,6 +202,50 @@ func (s *diskSuite) TestDiskFromDevicePathHappy(c *C) {
 	c.Assert(d.HasPartitions(), Equals, true)
 }
 
+func (s *diskSuite) TestDiskFromPartitionDeviceNodeHappy(c *C) {
+	restore := disks.MockUdevPropertiesForDevice(func(typeOpt, dev string) (map[string]string, error) {
+		c.Assert(typeOpt, Equals, "--name")
+		switch dev {
+		// first is for the partition itself, only relevant info is the
+		// ID_PART_ENTRY_DISK which is the parent disk
+		case "/dev/sda1":
+			return map[string]string{
+				"ID_PART_ENTRY_DISK": "42:0",
+			}, nil
+		// next up is the disk itself identified by the major/minor
+		case "/dev/block/42:0":
+			return map[string]string{
+				"DEVTYPE":            "disk",
+				"DEVNAME":            "/dev/sda",
+				"DEVPATH":            "/devices/foo/sda",
+				"ID_PART_TABLE_UUID": "foo-id",
+				"ID_PART_TABLE_TYPE": "gpt",
+			}, nil
+		default:
+			c.Errorf("unexpected udev device properties requested: %s", dev)
+			return nil, fmt.Errorf("unexpected udev device: %s", dev)
+		}
+	})
+	defer restore()
+
+	// create the partition device node too
+	createVirtioDevicesInSysfs(c, "/devices/foo/sda", map[string]bool{
+		"sda1": true,
+	})
+
+	d, err := disks.DiskFromPartitionDeviceNode("/dev/sda1")
+	c.Assert(err, IsNil)
+	c.Assert(d.Dev(), Equals, "42:0")
+	c.Assert(d.DiskID(), Equals, "foo-id")
+	c.Assert(d.Schema(), Equals, "gpt")
+	c.Assert(d.KernelDeviceNode(), Equals, "/dev/sda")
+	// note that we don't always prepend exactly /sys, we use dirs.SysfsDir
+	c.Assert(d.KernelDevicePath(), Equals, filepath.Join(dirs.SysfsDir, "/devices/foo/sda"))
+
+	// it doesn't have any partitions since we didn't mock any in sysfs
+	c.Assert(d.HasPartitions(), Equals, true)
+}
+
 func (s *diskSuite) TestDiskFromDeviceNameUnhappyPartition(c *C) {
 	restore := disks.MockUdevPropertiesForDevice(func(typeOpt, dev string) (map[string]string, error) {
 		c.Assert(typeOpt, Equals, "--name")
@@ -279,7 +323,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyMissingUdevProps(c *C) {
 	defer restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "cannot find disk for partition /dev/vda4, incomplete udev output")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point, incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyBadUdevPropsMountpointPartition(c *C) {
@@ -298,7 +342,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyBadUdevPropsMountpointPartition
 	defer restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, `cannot find disk for partition /dev/vda4, bad udev output: invalid device number format: \(expected <int>:<int>\)`)
+	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point, bad udev output: invalid device number format: \(expected <int>:<int>\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(c *C) {
@@ -326,7 +370,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `mountpoint source /dev/vda4 is not a decrypted device: devtype is not disk \(is partition\)`)
+	c.Assert(err, ErrorMatches, `mountpoint source /dev/vda4 of /run/mnt/point is not a decrypted device: devtype is not disk \(is partition\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) {
@@ -340,6 +384,8 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) 
 		case "/dev/mapper/something":
 			return map[string]string{
 				"DEVTYPE": "disk",
+				"MAJOR":   "252",
+				"MINOR":   "0",
 			}, nil
 		default:
 			c.Errorf("unexpected udev device properties requested: %s", dev)
@@ -352,7 +398,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) 
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`mountpoint source /dev/mapper/something is not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`mountpoint source /dev/mapper/something of /run/mnt/point is not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
 }
 
 func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitionsInSysfs(c *C) {
@@ -493,22 +539,17 @@ func (s *diskSuite) TestDiskFromMountPointVolumeUnhappyWithoutPartEntryDisk(c *C
 
 	udevadmCmd := testutil.MockCommand(c, "udevadm", `
 if [ "$*" = "info --query property --name /dev/mapper/something" ]; then
-	# not a partition, so no ID_PART_ENTRY_DISK, but we will have DEVTYPE=disk
+	# no ID_PART_ENTRY_DISK, so not a disk from this mount point
 	echo "DEVTYPE=disk"
 else
 	echo "unexpected arguments $*"
 	exit 1
 fi
 `)
+	defer udevadmCmd.Restore()
 
-	d, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, IsNil)
-	c.Assert(d.Dev(), Equals, "42:1")
-	c.Assert(d.HasPartitions(), Equals, false)
-
-	c.Assert(udevadmCmd.Calls(), DeepEquals, [][]string{
-		{"udevadm", "info", "--query", "property", "--name", "/dev/mapper/something"},
-	})
+	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point, incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
 }
 
 func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
@@ -522,10 +563,12 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
 		case "/dev/mapper/something":
 			return map[string]string{
 				"DEVTYPE": "disk",
+				"MAJOR":   "242",
+				"MINOR":   "1",
 			}, nil
 		case "/dev/disk/by-uuid/5a522809-c87e-4dfa-81a8-8dc5667d1304":
 			return map[string]string{
-				"DEVTYPE":            "disk",
+				// "DEVTYPE":            "disk",
 				"ID_PART_ENTRY_DISK": "42:0",
 			}, nil
 		case "/dev/block/42:0":
@@ -535,6 +578,8 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
 				"DEVPATH":            "/devices/foo",
 				"ID_PART_TABLE_UUID": "foo-uuid",
 				"ID_PART_TABLE_TYPE": "thing",
+				// "DEVTYPE":            "disk",
+				// "ID_PART_ENTRY_DISK": "42:0",
 			}, nil
 		default:
 			c.Errorf("unexpected udev device properties requested: %s", dev)
@@ -570,6 +615,8 @@ func (s *diskSuite) TestDiskFromMountPointNotDiskUnsupported(c *C) {
 
 	udevadmCmd := testutil.MockCommand(c, "udevadm", `
 if [ "$*" = "info --query property --name /dev/not-a-disk" ]; then
+	echo "ID_PART_ENTRY_DISK=43:0"
+elif [ "$*" = "info --query property --name /dev/block/43:0" ]; then
 	echo "DEVTYPE=not-a-disk"
 else
 	echo "unexpected arguments $*"
@@ -578,10 +625,11 @@ fi
 `)
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "unsupported DEVTYPE \"not-a-disk\" for mount point source /dev/not-a-disk")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/not-a-disk of /run/mnt/point, unsupported DEVTYPE \"not-a-disk\"")
 
 	c.Assert(udevadmCmd.Calls(), DeepEquals, [][]string{
 		{"udevadm", "info", "--query", "property", "--name", "/dev/not-a-disk"},
+		{"udevadm", "info", "--query", "property", "--name", "/dev/block/43:0"},
 	})
 }
 
@@ -817,6 +865,8 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 			// the mapper device is a disk/volume
 			return map[string]string{
 				"DEVTYPE": "disk",
+				"MAJOR":   "252",
+				"MINOR":   "0",
 			}, nil
 		case 2:
 			// next we find the physical disk by the dm uuid
@@ -878,6 +928,8 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 			// the mapper device is a disk/volume
 			return map[string]string{
 				"DEVTYPE": "disk",
+				"MAJOR":   "252",
+				"MINOR":   "0",
 			}, nil
 		case 17:
 			// then we find the physical disk by the dm uuid

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -568,7 +568,6 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
 			}, nil
 		case "/dev/disk/by-uuid/5a522809-c87e-4dfa-81a8-8dc5667d1304":
 			return map[string]string{
-				// "DEVTYPE":            "disk",
 				"ID_PART_ENTRY_DISK": "42:0",
 			}, nil
 		case "/dev/block/42:0":
@@ -578,8 +577,6 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
 				"DEVPATH":            "/devices/foo",
 				"ID_PART_TABLE_UUID": "foo-uuid",
 				"ID_PART_TABLE_TYPE": "thing",
-				// "DEVTYPE":            "disk",
-				// "ID_PART_ENTRY_DISK": "42:0",
 			}, nil
 		default:
 			c.Errorf("unexpected udev device properties requested: %s", dev)

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -323,7 +323,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyMissingUdevProps(c *C) {
 	defer restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point, incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point: incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyBadUdevPropsMountpointPartition(c *C) {
@@ -342,7 +342,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyBadUdevPropsMountpointPartition
 	defer restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point, bad udev output: invalid device number format: \(expected <int>:<int>\)`)
+	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point: bad udev output: invalid device number format: \(expected <int>:<int>\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(c *C) {
@@ -370,7 +370,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `mountpoint source /dev/vda4 of /run/mnt/point is not a decrypted device: devtype is not disk \(is partition\)`)
+	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point: not a decrypted device: devtype is not disk \(is partition\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) {
@@ -398,7 +398,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) 
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`mountpoint source /dev/mapper/something of /run/mnt/point is not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point: not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
 }
 
 func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitionsInSysfs(c *C) {
@@ -549,7 +549,7 @@ fi
 	defer udevadmCmd.Restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point, incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point: incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
 }
 
 func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
@@ -625,7 +625,7 @@ fi
 `)
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/not-a-disk of /run/mnt/point, unsupported DEVTYPE \"not-a-disk\"")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/not-a-disk of /run/mnt/point: unsupported DEVTYPE \"not-a-disk\"")
 
 	c.Assert(udevadmCmd.Calls(), DeepEquals, [][]string{
 		{"udevadm", "info", "--query", "property", "--name", "/dev/not-a-disk"},


### PR DESCRIPTION
This will be used when we have /dev/sda1 for example and want to get a Disk of
/dev/sda. Eventually this should be usable too when we need to track back from
a mapper device as well, but for now this is left out to be simpler and quicker
to mock and use in tests.

This also in effect removes the currently entirely unused and unclear use-case
around getting a Disk() for a non-physical mapper volume device node, where the
backing device of the mapper device is not a physical disk. These cases 
probably exist in real life on systems, but we do not need to concern ourselves
with them for now and it is becoming ever more clear that the disks package is
about real physical disks at the end of the day, so supporting these 
non-physical disks is out of scope of these functions.

Originally, based on top of the following PR's, but now is just rebased on master since they all landed:
- [x] #10904 
- [x] #10905
- [x] https://github.com/snapcore/snapd/pull/10917
- [x] https://github.com/snapcore/snapd/pull/10918