### PR TITLE
i/builtin/xilinx-dma: add interface for Xilinx DMA driver

### DIFF
--- a/interfaces/builtin/xilinx_dma.go
+++ b/interfaces/builtin/xilinx_dma.go
@@ -1,0 +1,70 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+// https://www.xilinx.com/support/documentation/ip_documentation/xdma/v4_1/pg195-pcie-dma.pdf
+// https://github.com/Xilinx/dma_ip_drivers/
+const xilinxDmaSummary = `allows access to Xilinx DMA IP on a connected PCIe card`
+
+const xilinxDmaBaseDeclarationPlugs = `
+  xilinx-dma:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const xilinxDmaBaseDeclarationSlots = `
+  xilinx-dma:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+// For the most part, applications just need access to the device nodes. However, there
+// are some important parameters exposed at /sys/modules/xdma/*
+const xilinxDmaConnectedPlugAppArmor = `
+# Access to the main device nodes created by the Xilinx XDMA driver
+/dev/xdma[0-9]*_{c2h,h2c,events}_[0-9]* rw,
+/dev/xdma[0-9]*_{control,user,xvc} rw,
+
+# If multiple cards are detected, nodes are created under
+/dev/xdma/card[0-9]*/** rw,
+
+# View XDMA driver module parameters
+/sys/module/xdma/parameters/* r,
+`
+
+// The xdma subsystem alone should serve as a unique identifier for all relevant devices
+var xilinxDmaConnectedPlugUDev = []string{
+	`SUBSYSTEM=="xdma"`,
+}
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "xilinx-dma",
+		summary:               xilinxDmaSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationPlugs:  xilinxDmaBaseDeclarationPlugs,
+		baseDeclarationSlots:  xilinxDmaBaseDeclarationSlots,
+		connectedPlugAppArmor: xilinxDmaConnectedPlugAppArmor,
+		connectedPlugUDev:     xilinxDmaConnectedPlugUDev,
+	})
+}

--- a/interfaces/builtin/xilinx_dma_test.go
+++ b/interfaces/builtin/xilinx_dma_test.go
@@ -1,0 +1,110 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type XilinxDmaInterfaceSuite struct {
+	iface        interfaces.Interface
+	coreSlotInfo *snap.SlotInfo
+	coreSlot     *interfaces.ConnectedSlot
+	plugInfo     *snap.PlugInfo
+	plug         *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&XilinxDmaInterfaceSuite{
+	iface: builtin.MustInterface("xilinx-dma"),
+})
+
+const xilinxDmaConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [xilinx-dma]
+`
+
+const xilinxDmaCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  xilinx-dma:
+`
+
+func (s *XilinxDmaInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, xilinxDmaConsumerYaml, nil, "xilinx-dma")
+	s.coreSlot, s.coreSlotInfo = MockConnectedSlot(c, xilinxDmaCoreYaml, nil, "xilinx-dma")
+}
+
+func (s *XilinxDmaInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "xilinx-dma")
+}
+
+func (s *XilinxDmaInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.coreSlotInfo), IsNil)
+}
+
+func (s *XilinxDmaInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *XilinxDmaInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/xdma[0-9]*_{c2h,h2c,events}_[0-9]* rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/xdma/card[0-9]*/** rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/xdma[0-9]*_{control,user,xvc} rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/module/xdma/parameters/* r,`)
+}
+
+func (s *XilinxDmaInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `# xilinx-dma
+SUBSYSTEM=="xdma", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(
+		`TAG=="snap_consumer_app", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *XilinxDmaInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to Xilinx DMA IP on a connected PCIe card`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+	c.Assert(si.BaseDeclarationPlugs, testutil.Contains, "allow-installation: false")
+}
+
+func (s *XilinxDmaInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -755,6 +755,7 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 		"tee":                   true,
 		"uinput":                true,
 		"unity8":                true,
+		"xilinx-dma":            true,
 	}
 
 	for _, iface := range all {
@@ -1002,6 +1003,7 @@ func (s *baseDeclSuite) TestSanity(c *C) {
 		"uinput":                true,
 		"unity8":                true,
 		"wayland":               true,
+		"xilinx-dma":            true,
 	}
 
 	for _, iface := range all {

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -491,6 +491,9 @@ apps:
   x11:
     command: bin/run
     plugs: [ x11 ]
+  xilinx-dma:
+    command: bin/run
+    plugs: [ xilinx-dma ]
 
 plugs:
   browser-sandbox:


### PR DESCRIPTION
Needed for a customer enablement project.

Should be a fairly self-explanatory hardware access interface. The hardware in question is a Xilinx FPGA PCIe card. This interface is for use on the device that is hosting the PCIe card, and allows it access to the character device streams provided by the driver (from https://github.com/Xilinx/dma_ip_drivers)
