### PR TITLE
interfaces/builtin/hardware-observer: add /proc/bus/input/devices too

### DIFF
--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -45,6 +45,9 @@ capability sys_admin,
 /etc/modprobe.d/{,*} r,
 /{,usr/}lib/modprobe.d/{,*} r,
 
+# for reading the available input devices on the system
+/proc/bus/input/devices r,
+
 # files in /sys pertaining to hardware (eg, 'lspci -A linux-sysfs')
 /sys/{block,bus,class,devices,firmware}/{,**} r,
 


### PR DESCRIPTION
This is needed for a customer request, see ticket 00320804 for full details.