### PR TITLE
interface/modem-manager: add accept for MBIM/QMI proxy clients

### DIFF
--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -67,7 +67,7 @@ network netlink raw,
 capability sys_admin,
 
 # For {mbim,qmi}-proxy
-unix (bind, listen) type=stream addr="@{mbim,qmi}-proxy",
+unix (bind, listen, accept) type=stream addr="@{mbim,qmi}-proxy",
 /sys/devices/**/usb**/{descriptors,manufacturer,product,bInterfaceClass,bInterfaceSubClass,bInterfaceProtocol,bInterfaceNumber} r,
 # See https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-net-qmi
 /sys/devices/**/net/*/qmi/* rw,


### PR DESCRIPTION
We need accept too for clients to connect.