### PR TITLE
tests/nested/core/core20-create-recovery: fix passing of data to curl

### DIFF
--- a/tests/nested/core/core20-create-recovery/task.yaml
+++ b/tests/nested/core/core20-create-recovery/task.yaml
@@ -8,7 +8,8 @@ prepare: |
 execute: |
     echo "Create a recovery system with a typical recovery system label"
     boot_id="$( tests.nested boot-id )"
-    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | tests.nested exec sudo test-snapd-curl.curl -X POST --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
+    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | \
+        tests.nested exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     tests.nested wait-for reboot "${boot_id}"
     tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
@@ -23,7 +24,8 @@ execute: |
 
     echo "Create a recovery system with an alternative recovery system label"
     boot_id="$( tests.nested boot-id )"
-    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234-1"}}' | tests.nested exec sudo test-snapd-curl.curl -X POST --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
+    echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234-1"}}' | \
+        tests.nested exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     tests.nested wait-for reboot "${boot_id}"
     tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"


### PR DESCRIPTION
After recent switch to test-snapd-curl, there was no data being passed in the
request.

