### PR TITLE
tests: force 16.04 packaging when doing test snapd-snap build

### DIFF
--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -144,6 +144,8 @@ execute: |
     # shellcheck disable=SC2164
     pushd "$PROJECT_PATH"
     echo "Build the snap"
+    # Force use 16.04 packaging to build the snap
+    ln -sf packaging/ubuntu-16.04 debian
     snap run snapcraft snap --output=snapd_spread-test.snap
     popd
 


### PR DESCRIPTION
Prepare steps of the spread harness can change debian packaging from
current ubuntu-16.04 to some other release. However, snapd-snap is
currently build on xenial using ubuntu-16.04 packaging only. Before
performing snapd-snap test, ensure that 16.04 packaging is used to
build the snap.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
