### PR TITLE
[RFC] o/snapstate: maintain a stack of enforced validation sets per snap revision

### DIFF
--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/restart"
@@ -192,6 +193,14 @@ func MockSnapstateRemoveMany(mock func(*state.State, []string) ([]string, []*sta
 	snapstateRemoveMany = mock
 	return func() {
 		snapstateRemoveMany = oldSnapstateRemoveMany
+	}
+}
+
+func MockEnforcedValidationSets(f func(st *state.State) (*snapasserts.ValidationSets, error)) func() {
+	old := enforcedValidationSets
+	enforcedValidationSets = f
+	return func() {
+		enforcedValidationSets = old
 	}
 }
 

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
@@ -111,6 +112,10 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	bs.AddCleanup(func() {
 		snapstate.SnapServiceOptions = oldSnapServiceOptions
 	})
+
+	bs.AddCleanup(snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
+		return nil, nil
+	}))
 }
 
 func (bs *bootedSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1331,6 +1331,16 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	cand := snapsup.SideInfo
 	m.backend.Candidate(cand)
 
+	// update the stack of validation sets requiring this revision (this updates
+	// cand SideInfo).
+	vsets, err := EnforcedValidationSets(st)
+	if err != nil {
+		return err
+	}
+	if err := UpdateValidationSetsStack(st, vsets, snapst, cand); err != nil {
+		return err
+	}
+
 	oldCandidateIndex := snapst.LastIndex(cand.Revision)
 
 	if oldCandidateIndex < 0 {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -29,6 +29,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
@@ -72,6 +73,10 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 		snapstate.SnapServiceOptions = oldSnapServiceOptions
 		s.restartRequested = nil
 	})
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
+		return nil, nil
+	})
+	s.AddCleanup(restore)
 }
 
 func checkHasCookieForSnap(c *C, st *state.State, instanceName string) {

--- a/overlord/snapstate/handlers_test.go
+++ b/overlord/snapstate/handlers_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -40,6 +41,10 @@ var _ = Suite(&handlersSuite{})
 func (s *handlersSuite) SetUpTest(c *C) {
 	s.baseHandlerSuite.SetUpTest(c)
 
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
+		return nil, nil
+	})
+	s.AddCleanup(restore)
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
 }
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -246,6 +246,11 @@ type SideInfo struct {
 	EditedDescription string              `yaml:"description,omitempty" json:"description,omitempty"`
 	Private           bool                `yaml:"private,omitempty" json:"private,omitempty"`
 	Paid              bool                `yaml:"paid,omitempty" json:"paid,omitempty"`
+
+	// all enforced validation sets that require this revision at a given time; this is a stack,
+	// validation set keys get added to it on 'snap validate --enforce ...' or
+	// when updated.
+	ValidationSets    [][]string          `yaml:"validation-sets,omitempty" json:"validation-sets,omitempty"`
 }
 
 // Info provides information about snaps.

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -305,7 +305,8 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		"Tracks",   // handled at a different level (see TestInfo)
 		"Layout",
 		"SideInfo.Channel",
-		"SideInfo.EditedLinks",         // TODO: take this value from the store
+		"SideInfo.EditedLinks", // TODO: take this value from the store
+		"SideInfo.ValidationSets",
 		"DownloadInfo.AnonDownloadURL", // TODO: going away at some point
 		"SystemUsernames",
 	}


### PR DESCRIPTION
Maintain a stack of enforced validation sets per snap-revision for snaps that are required for the given sets. This will later be surfaced to the user via new cli, but the main point is to handle partial failures when refreshing snaps to decide what revisions to go back to (or what validation set sequence to get back to).

TODO:

- unit test for link-snap change (I need one of my existing PRs to land to utilize its changes to test suite)
- maybe do something on ` snap validate --forget` but I'm not sure yet about that.
