### PR TITLE
tests: skip interfaces-timeserver-control on debian-sid

### DIFF
--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -4,6 +4,9 @@ details: |
     This test makes sure that a snap using the timeserver-control interface
     can access timeserver information and update it.
 
+# TODO: Research error on debian-sid that cannot use ntp
+systems: [-debian-sid-*]
+
 prepare: |
     # This test requires busctl but on 14.04 we don't have one.
     # Let's pick the one from the core snap in such case.


### PR DESCRIPTION
Added a TODO to research why it is failing with the following error:

Error: 2021-10-19 10:11:07 Error executing
google:debian-sid-64:tests/main/interfaces-timeserver-control
(oct190937-914203) :

++ busctl get-property org.freedesktop.timedate1
/org/freedesktop/timedate1 org.freedesktop.timedate1 CanNTP
+ '[' 'b false' '!=' 'b true' ']'
+ echo 'This system cannot use NTP, test precondition failed'
This system cannot use NTP, test precondition failed
+ exit 1

