### PR TITLE
tests: ensure systemd-timesyncd is installed on debian

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -631,6 +631,7 @@ pkg_dependencies_ubuntu_classic(){
                 packagekit
                 sbuild
                 schroot
+                systemd-timesyncd
                 "
             ;;
     esac


### PR DESCRIPTION
Required by interfaces-timeserver-control test.
