### PR TITLE
tests/lib/pkgdb: install strace on Debian 11 and Sid

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -638,6 +638,7 @@ pkg_dependencies_ubuntu_classic(){
         debian-11-*|debian-sid-*)
             echo "
                  bpftool
+                 strace
                  "
             ;;
     esac


### PR DESCRIPTION
Strace provided by strace-static is too old and segfaults on Sid.