### PR TITLE
tests/main/snapd-sigterm: fix race conditions

### DIFF
--- a/tests/main/snapd-sigterm/task.yaml
+++ b/tests/main/snapd-sigterm/task.yaml
@@ -17,17 +17,14 @@ execute: |
     s.connect('/run/snapd.socket')
     s.send(b'GET /v2/apps HTTP/1.1\r\nHost: localhost\r\n\r\n')
     s.recv(10000)
-    print('DONE')
+    print('DONE', flush=True)
     time.sleep(60)
     EOF
 
     tests.cleanup defer rm -f stamp
 
-    while ! grep DONE stamp
-    do
-        echo "Waiting for snapd reply..."
-        sleep 0.1
-    done
+    echo "Waiting for snapd reply..."
+    retry -n 200 --wait 0.1 grep DONE stamp  # 20 seconds
 
     echo "Stopping snapd, and measuring time"
     TEST_TIME0="$(date +'%s')"


### PR DESCRIPTION
There are a few issues with the current test:

- the previous attempt to fix the failures (adding the `-q` option to
  nc) did not help, because the `-q` option only adds a wait before
  exiting the program, and does not delay the closing of the socket.

- the reason why the snapd service was being restarted is that spawning
  the client in the background (`&`) does not guarantee that the client
  has completed (or even initiated) its request to snapd before we stop
  the service.

Here we fix both issues by:

1. Replace nc with a python script that does perform a sleep() *before*
   closing the socket.
2. Use a sentinel file to understand when the client request to snapd
   has completed and the socket is idle.
