### PR TITLE
tests/main/snapd-snap: restore debian symlink

### DIFF
--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -128,6 +128,13 @@ prepare: |
         tests.cleanup defer umount "$CORE_SNAP"
     fi
 
+restore: |
+    if os.query is-trusty; then
+        # when building on 14.04, debian becomes symlinked to packaging/14.04,
+        # make sure to restore the symlink
+        (cd "$PROJECT_PATH"; ln -sf packaging/ubuntu-16.04 debian)
+    fi
+
 execute: |
     # shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB/systems.sh"


### PR DESCRIPTION
When building on 14.04, debian is symlinked to packaging/14.04, while it's
pointing to packaging/16.04 by default. Restore the symlink after the test.

Related to #10940
