### PR TITLE
o/snapstate: migrate to hidden dir on refresh

### DIFF
--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -24,17 +24,22 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/usersession/agent"
 	"github.com/snapcore/snapd/usersession/autostart"
 	"github.com/snapcore/snapd/usersession/userd"
 )
+
+var autostartSessionApps = autostart.AutostartSessionApps
 
 type cmdUserd struct {
 	Autostart bool `long:"autostart"`
@@ -87,19 +92,21 @@ func (x *cmdUserd) Execute(args []string) error {
 	}
 
 	if x.Autostart {
-		// get the user's snap dir ($HOME/snap or $HOME/.snap/data)
-		usrSnapDir, err := getUserSnapDir()
+		// there may be two snap dirs (~/snap and ~/.snap/data)
+		usrSnapDirs, err := getUserSnapDirs()
 		if err != nil {
 			return err
 		}
 
-		// autostart is called when starting the graphical session, use that as
-		// an opportunity to fix ~/snap permission bits
-		if err := maybeFixupUsrSnapPermissions(usrSnapDir); err != nil {
-			fmt.Fprintf(Stderr, "failure fixing ~/snap permissions: %v\n", err)
+		for _, usrSnapDir := range usrSnapDirs {
+			// autostart is called when starting the graphical session, use that as
+			// an opportunity to fix snap dir permission bits
+			if err := maybeFixupUsrSnapPermissions(usrSnapDir); err != nil {
+				fmt.Fprintf(Stderr, "failure fixing %s permissions: %v\n", usrSnapDir, err)
+			}
 		}
 
-		return x.runAutostart(usrSnapDir)
+		return x.runAutostart(usrSnapDirs)
 	}
 
 	if x.Agent {
@@ -152,10 +159,20 @@ func (x *cmdUserd) runAgent() error {
 	return agent.Stop()
 }
 
-func (x *cmdUserd) runAutostart(usrSnapDir string) error {
-	if err := autostart.AutostartSessionApps(usrSnapDir); err != nil {
-		return fmt.Errorf("autostart failed for the following apps:\n%v", err)
+func (x *cmdUserd) runAutostart(usrSnapDirs []string) error {
+	var sb strings.Builder
+	for _, usrSnapDir := range usrSnapDirs {
+		if err := autostartSessionApps(usrSnapDir); err != nil {
+			// try to run autostart for others
+			sb.WriteString(err.Error())
+			sb.WriteRune('\n')
+		}
 	}
+
+	if sb.Len() > 0 {
+		return fmt.Errorf("autostart failed for the following apps:\n%s", sb.String())
+	}
+
 	return nil
 }
 
@@ -166,12 +183,23 @@ func signalNotifyImpl(sig ...os.Signal) (ch chan os.Signal, stop func()) {
 	return ch, stop
 }
 
-func getUserSnapDir() (string, error) {
+func getUserSnapDirs() ([]string, error) {
 	usr, err := userCurrent()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	opts := getSnapDirOptions()
-	return snap.SnapDir(usr.HomeDir, opts), nil
+	var snapDirsInUse []string
+	exposedSnapDir := snap.SnapDir(usr.HomeDir, nil)
+	hiddenSnapDir := snap.SnapDir(usr.HomeDir, &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true})
+
+	for _, dir := range []string{exposedSnapDir, hiddenSnapDir} {
+		if exists, _, err := osutil.DirExists(dir); err != nil {
+			return nil, err
+		} else if exists {
+			snapDirsInUse = append(snapDirsInUse, dir)
+		}
+	}
+
+	return snapDirsInUse, nil
 }

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -21,6 +21,7 @@
 package main_test
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -231,6 +232,8 @@ func (s *userdSuite) TestAutostartSessionAppsRestrictsPermissions(c *C) {
 
 func (s *userdSuite) TestAutostartSessionAppsLogsWhenItCannotRestrictPermissions(c *C) {
 	userDir := path.Join(c.MkDir(), "home")
+	c.Assert(os.MkdirAll(filepath.Join(userDir, "snap"), 0770), IsNil)
+
 	mockUserCurrent := func() (*user.User, error) {
 		return &user.User{HomeDir: userDir}, nil
 	}
@@ -277,4 +280,55 @@ func (s *userdSuite) TestAutostartSessionAppsRestrictsPermissionsNoCreateSnapDir
 
 	// make sure that the directory was not created
 	c.Assert(filepath.Join(userDir, "snap"), testutil.FileAbsent)
+}
+
+func (s *userdSuite) TestAutostartWithBothSnapDirs(c *C) {
+	userDir := path.Join(c.MkDir(), "home")
+	mockUserCurrent := func() (*user.User, error) {
+		return &user.User{HomeDir: userDir}, nil
+	}
+	r := snap.MockUserCurrent(mockUserCurrent)
+	defer r()
+
+	var autostartArgs []string
+	mockAutostart := func(arg string) error {
+		autostartArgs = append(autostartArgs, arg)
+		return nil
+	}
+	autostartRestore := snap.MockAutostartSessionApps(mockAutostart)
+	defer autostartRestore()
+
+	exposedDir := filepath.Join(userDir, "snap")
+	c.Assert(os.MkdirAll(exposedDir, 0770), IsNil)
+	hiddenDir := filepath.Join(userDir, ".snap", "data")
+	c.Assert(os.MkdirAll(hiddenDir, 0770), IsNil)
+
+	args, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd", "--autostart"})
+	c.Assert(err, IsNil)
+	c.Assert(args, DeepEquals, []string{})
+
+	c.Assert(autostartArgs, testutil.DeepUnsortedMatches, []string{hiddenDir, exposedDir})
+}
+
+func (s *userdSuite) TestAutostartErrorsInBoth(c *C) {
+	userDir := path.Join(c.MkDir(), "home")
+	mockUserCurrent := func() (*user.User, error) {
+		return &user.User{HomeDir: userDir}, nil
+	}
+	r := snap.MockUserCurrent(mockUserCurrent)
+	defer r()
+
+	mockAutostart := func(arg string) error {
+		return errors.New("test")
+	}
+	autostartRestore := snap.MockAutostartSessionApps(mockAutostart)
+	defer autostartRestore()
+
+	exposedDir := filepath.Join(userDir, "snap")
+	c.Assert(os.MkdirAll(exposedDir, 0770), IsNil)
+	hiddenDir := filepath.Join(userDir, ".snap", "data")
+	c.Assert(os.MkdirAll(hiddenDir, 0770), IsNil)
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd", "--autostart"})
+	c.Assert(err, ErrorMatches, "autostart failed for the following apps:\ntest\ntest\n")
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -95,6 +95,8 @@ var (
 
 	GetKeypairManager = getKeypairManager
 	GenerateKey       = generateKey
+
+	GetSnapDirOptions = getSnapDirOptions
 )
 
 func HiddenCmd(descr string, completeHidden bool) *cmdInfo {
@@ -439,5 +441,13 @@ func MockIsGraphicalSession(graphical bool) (restore func()) {
 	}
 	return func() {
 		isGraphicalSession = old
+	}
+}
+
+func MockAutostartSessionApps(f func(string) error) func() {
+	old := autostartSessionApps
+	autostartSessionApps = f
+	return func() {
+		autostartSessionApps = old
 	}
 }

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -162,8 +162,11 @@ var (
 )
 
 type SnapDirOptions struct {
-	// HiddenSnapDataDir determines if the snaps' data is in ~/.snap/data instead of ~/snap
-	HiddenSnapDataDir bool
+	// UseHiddenSnapDataDir determines if we should use ~/.snap/data as the snap data dir instead of ~/snap. Can be true
+	// while ActiveSnapDataDir still holds ~/snap, in which case the migration is yet to be performed
+	UseHiddenSnapDataDir bool
+	// MigratedToHiddenDir states if data has been migrated from ~/snap to ~/.snap/data
+	MigratedToHiddenDir bool
 }
 
 func init() {

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -1073,8 +1073,8 @@ func (s *snapshotSuite) TestEstimateSnapshotSize(c *check.C) {
 		opts    *dirs.SnapDirOptions
 	}{
 		{dirs.UserHomeSnapDir, nil},
-		{dirs.UserHomeSnapDir, &dirs.SnapDirOptions{HiddenSnapDataDir: false}},
-		{dirs.HiddenSnapDataHomeDir, &dirs.SnapDirOptions{HiddenSnapDataDir: true}}} {
+		{dirs.UserHomeSnapDir, &dirs.SnapDirOptions{UseHiddenSnapDataDir: false}},
+		{dirs.HiddenSnapDataHomeDir, &dirs.SnapDirOptions{UseHiddenSnapDataDir: true}}} {
 		s.testEstimateSnapshotSize(c, t.snapDir, t.opts)
 	}
 }

--- a/overlord/snapshotstate/backend/helpers.go
+++ b/overlord/snapshotstate/backend/helpers.go
@@ -97,7 +97,7 @@ var (
 
 func usersForUsernamesImpl(usernames []string, opts *dirs.SnapDirOptions) ([]*user.User, error) {
 	if len(usernames) == 0 {
-		return allUsers(opts)
+		return AllUsers(opts)
 	}
 	users := make([]*user.User, 0, len(usernames))
 	for _, username := range usernames {
@@ -133,7 +133,7 @@ func usersForUsernamesImpl(usernames []string, opts *dirs.SnapDirOptions) ([]*us
 	return users, nil
 }
 
-func allUsers(opts *dirs.SnapDirOptions) ([]*user.User, error) {
+func AllUsers(opts *dirs.SnapDirOptions) ([]*user.User, error) {
 	ds, err := filepath.Glob(snap.DataHomeGlob(opts))
 	if err != nil {
 		// can't happen?

--- a/overlord/snapshotstate/snapshotmgr.go
+++ b/overlord/snapshotstate/snapshotmgr.go
@@ -224,7 +224,7 @@ func doSave(task *state.Task, tomb *tomb.Tomb) error {
 	st := task.State()
 
 	st.Lock()
-	opts, err := snapstate.GetSnapDirOptions(st)
+	opts, err := snapstate.GetSnapDirOptions(st, nil, snapshot.Snap)
 	st.Unlock()
 	if err != nil {
 		return err
@@ -309,7 +309,7 @@ func doRestore(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	st.Lock()
-	opts, err := snapstate.GetSnapDirOptions(st)
+	opts, err := snapstate.GetSnapDirOptions(st, nil, snapshot.Snap)
 	st.Unlock()
 	if err != nil {
 		return err

--- a/overlord/snapshotstate/snapshotmgr_test.go
+++ b/overlord/snapshotstate/snapshotmgr_test.go
@@ -301,8 +301,8 @@ func (snapshotSuite) TestDoSave(c *check.C) {
 }
 
 func (snapshotSuite) TestDoSaveGetsSnapDirOpts(c *check.C) {
-	restore := snapstate.MockGetSnapDirOptions(func(*state.State) (*dirs.SnapDirOptions, error) {
-		return &dirs.SnapDirOptions{HiddenSnapDataDir: true}, nil
+	restore := snapstate.MockGetSnapDirOptions(func(*state.State, *snapstate.SnapSetup, string) (*dirs.SnapDirOptions, error) {
+		return &dirs.SnapDirOptions{UseHiddenSnapDataDir: true}, nil
 	})
 	defer restore()
 
@@ -320,7 +320,7 @@ func (snapshotSuite) TestDoSaveGetsSnapDirOpts(c *check.C) {
 
 	var checkOpts bool
 	defer snapshotstate.MockBackendSave(func(_ context.Context, id uint64, si *snap.Info, cfg map[string]interface{}, usernames []string, opts *dirs.SnapDirOptions) (*client.Snapshot, error) {
-		c.Check(opts.HiddenSnapDataDir, check.Equals, true)
+		c.Check(opts.UseHiddenSnapDataDir, check.Equals, true)
 		checkOpts = true
 		return nil, nil
 	})()

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -110,7 +110,7 @@ func EstimateSnapshotSize(st *state.State, instanceName string, users []string) 
 		return 0, err
 	}
 
-	opts, err := snapstate.GetSnapDirOptions(st)
+	opts, err := snapstate.GetSnapDirOptions(st, nil, cur.InstanceName())
 	if err != nil {
 		return 0, err
 	}

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -1154,9 +1154,8 @@ func (snapshotSuite) TestRestoreIntegration(c *check.C) {
 }
 
 func (snapshotSuite) TestRestoreIntegrationHiddenSnapDir(c *check.C) {
-	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
-
-	restore := snapstate.MockGetSnapDirOptions(func(*state.State) (*dirs.SnapDirOptions, error) {
+	opts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}
+	restore := snapstate.MockGetSnapDirOptions(func(*state.State, *snapstate.SnapSetup, string) (*dirs.SnapDirOptions, error) {
 		return opts, nil
 	})
 	defer restore()

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -83,7 +83,7 @@ type managerBackend interface {
 	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, meter progress.Meter) error
 	UndoCopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter, opts *dirs.SnapDirOptions) error
 	// cleanup
-	ClearTrashedData(oldSnap *snap.Info, opts *dirs.SnapDirOptions)
+	ClearTrashedData(oldSnap *snap.Info)
 
 	// remove related
 	UnlinkSnap(info *snap.Info, linkCtx backend.LinkContext, meter progress.Meter) error
@@ -108,4 +108,8 @@ type managerBackend interface {
 	RunInhibitSnapForUnlink(info *snap.Info, hint runinhibit.Hint, decision func() error) (*osutil.FileLock, error)
 	// (not a backend method because doInstall cannot access the backend)
 	// WithSnapLock(info *snap.Info, action func() error) error
+
+	// ~/.snap/data migration related
+	HideSnapData(snapName string) error
+	UndoHideSnapData(snapName string) error
 }

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -20,18 +20,25 @@
 package backend
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	snapshot_backend "github.com/snapcore/snapd/overlord/snapshotstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 )
 
+var allUsers = snapshot_backend.AllUsers
+
 // CopySnapData makes a copy of oldSnap data for newSnap in its data directories.
 func (b Backend) CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter, opts *dirs.SnapDirOptions) error {
 	// deal with the old data or
-	// otherwise just create a empty data dir
+	// otherwise just create an empty data dir
 
 	// Make sure the base data directory exists for instance snaps
 	if newSnap.InstanceKey != "" {
@@ -86,16 +93,139 @@ func (b Backend) UndoCopySnapData(newInfo, oldInfo *snap.Info, _ progress.Meter,
 }
 
 // ClearTrashedData removes the trash. It returns no errors on the assumption that it is called very late in the game.
-func (b Backend) ClearTrashedData(oldSnap *snap.Info, opts *dirs.SnapDirOptions) {
-	dirs, err := snapDataDirs(oldSnap, opts)
+func (b Backend) ClearTrashedData(oldSnap *snap.Info) {
+	dataDirs, err := snapDataDirs(oldSnap, nil)
 	if err != nil {
 		logger.Noticef("Cannot remove previous data for %q: %v", oldSnap.InstanceName(), err)
 		return
 	}
 
-	for _, d := range dirs {
+	opts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}
+	hiddenDirs, err := snapDataDirs(oldSnap, opts)
+	if err != nil {
+		logger.Noticef("Cannot remove previous data for %q: %v", oldSnap.InstanceName(), err)
+		return
+	}
+
+	// this will have duplicates but the second remove will just be ignored
+	dataDirs = append(dataDirs, hiddenDirs...)
+	for _, d := range dataDirs {
 		if err := clearTrash(d); err != nil {
 			logger.Noticef("Cannot remove %s: %v", d, err)
 		}
 	}
+}
+
+func (b Backend) HideSnapData(snapName string) error {
+	preMigrationOpts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true}
+	postMigrationOpts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}
+
+	users, err := allUsers(preMigrationOpts)
+	if err != nil {
+		return err
+	}
+
+	for _, usr := range users {
+		uid, gid, err := osutil.UidGid(usr)
+		if err != nil {
+			return err
+		}
+
+		// nothing to migrate
+		oldSnapDir := snap.UserSnapDir(usr.HomeDir, snapName, preMigrationOpts)
+		if _, err := os.Stat(oldSnapDir); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("cannot stat snap dir %q: %w", oldSnapDir, err)
+		}
+
+		// create the new hidden snap dir
+		hiddenSnapDir := snap.SnapDir(usr.HomeDir, postMigrationOpts)
+		if err := osutil.MkdirAllChown(hiddenSnapDir, 0700, uid, gid); err != nil {
+			return fmt.Errorf("cannot create snap dir %q: %w", hiddenSnapDir, err)
+		}
+
+		// move the snap's dir
+		newSnapDir := snap.UserSnapDir(usr.HomeDir, snapName, postMigrationOpts)
+		if err := osutil.AtomicRename(oldSnapDir, newSnapDir); err != nil {
+			return fmt.Errorf("cannot move %q to %q: %w", oldSnapDir, newSnapDir, err)
+		}
+
+		// remove ~/snap if it's empty
+		if err := removeIfEmpty(snap.SnapDir(usr.HomeDir, preMigrationOpts)); err != nil {
+			return fmt.Errorf("failed to remove old snap dir: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (b Backend) UndoHideSnapData(snapName string) error {
+	preMigrationOpts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true}
+	postMigrationOpts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}
+
+	users, err := allUsers(postMigrationOpts)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+	handle := func(err error) {
+		// keep going, restore previous state as much as possible
+		if firstErr == nil {
+			firstErr = err
+		} else {
+			logger.Noticef(err.Error())
+		}
+	}
+
+	for _, usr := range users {
+		uid, gid, err := osutil.UidGid(usr)
+		if err != nil {
+			handle(err)
+			continue
+		}
+
+		// skip it if wasn't migrated
+		hiddenSnapDir := snap.UserSnapDir(usr.HomeDir, snapName, postMigrationOpts)
+		if _, err := os.Stat(hiddenSnapDir); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				handle(fmt.Errorf("cannot read files in %q: %w", hiddenSnapDir, err))
+			}
+			continue
+		}
+
+		// ensure parent dirs exist
+		exposedDir := snap.SnapDir(usr.HomeDir, preMigrationOpts)
+		if err := osutil.MkdirAllChown(exposedDir, 0700, uid, gid); err != nil {
+			handle(fmt.Errorf("cannot create snap dir %q: %w", exposedDir, err))
+			continue
+		}
+
+		exposedSnapDir := snap.UserSnapDir(usr.HomeDir, snapName, preMigrationOpts)
+		if err := osutil.AtomicRename(hiddenSnapDir, exposedSnapDir); err != nil {
+			handle(fmt.Errorf("cannot move %q to %q: %w", hiddenSnapDir, exposedSnapDir, err))
+		}
+
+		// remove ~/.snap/data dir if empty
+		hiddenDir := snap.SnapDir(usr.HomeDir, postMigrationOpts)
+		if err := removeIfEmpty(hiddenDir); err != nil {
+			handle(fmt.Errorf("cannot remove dir %q: %w", hiddenDir, err))
+		}
+	}
+
+	return firstErr
+}
+
+var removeIfEmpty = func(dir string) error {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	if len(files) > 0 {
+		return nil
+	}
+
+	return os.Remove(dir)
 }

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -20,9 +20,11 @@
 package backend_test
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -30,6 +32,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
@@ -70,7 +73,8 @@ func (s *copydataSuite) TestCopyData(c *C) {
 	}{
 		{snapDir: dirs.UserHomeSnapDir, opts: nil},
 		{snapDir: dirs.UserHomeSnapDir, opts: &dirs.SnapDirOptions{}},
-		{snapDir: dirs.HiddenSnapDataHomeDir, opts: &dirs.SnapDirOptions{HiddenSnapDataDir: true}}} {
+		{snapDir: dirs.UserHomeSnapDir, opts: &dirs.SnapDirOptions{UseHiddenSnapDataDir: true}},
+		{snapDir: dirs.HiddenSnapDataHomeDir, opts: &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}}} {
 		s.testCopyData(c, t.snapDir, t.opts)
 		c.Assert(os.RemoveAll(s.tempdir), IsNil)
 		s.tempdir = c.MkDir()
@@ -212,7 +216,7 @@ func (s *copydataSuite) TestCopyDataDoUndo(c *C) {
 	}{
 		{snapDir: dirs.UserHomeSnapDir},
 		{snapDir: dirs.UserHomeSnapDir, opts: &dirs.SnapDirOptions{}},
-		{snapDir: dirs.HiddenSnapDataHomeDir, opts: &dirs.SnapDirOptions{HiddenSnapDataDir: true}},
+		{snapDir: dirs.HiddenSnapDataHomeDir, opts: &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}},
 	} {
 		s.testCopyDataUndo(c, t.snapDir, t.opts)
 		c.Assert(os.RemoveAll(s.tempdir), IsNil)
@@ -299,7 +303,7 @@ func (s *copydataSuite) TestCopyDataDoUndoFirstInstall(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataDoABA(c *C) {
-	for _, opts := range []*dirs.SnapDirOptions{nil, {}, {HiddenSnapDataDir: true}} {
+	for _, opts := range []*dirs.SnapDirOptions{nil, {}, {UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}} {
 		s.testCopyDataDoABA(c, opts)
 	}
 }
@@ -325,7 +329,7 @@ func (s *copydataSuite) testCopyDataDoABA(c *C, opts *dirs.SnapDirOptions) {
 	c.Check(s.populatedData("10.old"), Equals, "10\n")
 
 	// but cleanup cleans it up, huzzah
-	s.be.ClearTrashedData(v1, opts)
+	s.be.ClearTrashedData(v1)
 	c.Check(s.populatedData("10.old"), Equals, "")
 }
 
@@ -576,5 +580,270 @@ func (s *copydataSuite) TestUndoCopyDataSameRevision(c *C) {
 	} {
 		c.Check(osutil.FileExists(fn), Equals, true, Commentf(fn))
 	}
+}
 
+func (s *copydataSuite) TestHideSnapData(c *C) {
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+
+	// mock user home
+	homedir := filepath.Join(s.tempdir, "home", "user")
+	usr, err := user.Current()
+	c.Assert(err, IsNil)
+	usr.HomeDir = homedir
+
+	restore := backend.MockAllUsers(func(*dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	// writes a file canary.home file to the rev dir of the "hello" snap
+	s.populateHomeData(c, "user", snap.R(10))
+
+	// write file in common
+	err = os.MkdirAll(info.UserCommonDataDir(homedir, nil), 0770)
+	c.Assert(err, IsNil)
+
+	commonFilePath := filepath.Join(info.UserCommonDataDir(homedir, nil), "file.txt")
+	err = ioutil.WriteFile(commonFilePath, []byte("some content"), 0640)
+	c.Assert(err, IsNil)
+
+	// make 'current' symlink
+	revDir := snap.UserDataDir(homedir, "hello", snap.R(10), nil)
+	// path must be relative, otherwise move would make it dangling
+	err = os.Symlink(filepath.Base(revDir), filepath.Join(revDir, "..", "current"))
+	c.Assert(err, IsNil)
+
+	err = s.be.HideSnapData("hello")
+	c.Assert(err, IsNil)
+
+	// check versioned file was moved
+	opts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}
+	revFile := filepath.Join(info.UserDataDir(homedir, opts), "canary.home")
+	data, err := ioutil.ReadFile(revFile)
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, []byte("10\n"))
+
+	// check common file was moved
+	commonFile := filepath.Join(info.UserCommonDataDir(homedir, opts), "file.txt")
+	data, err = ioutil.ReadFile(commonFile)
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, []byte("some content"))
+
+	// check 'current' symlink has correct attributes and target
+	link := filepath.Join(homedir, dirs.HiddenSnapDataHomeDir, "hello", "current")
+	linkInfo, err := os.Lstat(link)
+	c.Assert(err, IsNil)
+	c.Assert(linkInfo.Mode()&os.ModeSymlink, Equals, os.ModeSymlink)
+
+	target, err := os.Readlink(link)
+	c.Assert(err, IsNil)
+	c.Assert(target, Equals, "10")
+
+	// check old '~/snap' folder was removed
+	_, err = os.Stat(snap.SnapDir(homedir, nil))
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
+}
+
+func (s *copydataSuite) TestHideSnapDataSkipNoData(c *C) {
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+
+	// mock user home
+	homedir := filepath.Join(s.tempdir, "home", "user")
+	usr, err := user.Current()
+	c.Assert(err, IsNil)
+	usr.HomeDir = homedir
+
+	// create user without snap dir (to be skipped)
+	usrNoSnapDir := &user.User{
+		HomeDir: filepath.Join(s.tempdir, "home", "other-user"),
+		Name:    "other-user",
+		Uid:     "1001",
+		Gid:     "1001",
+	}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr, usrNoSnapDir}, nil
+	})
+	defer restore()
+
+	s.populateHomeData(c, "user", snap.R(10))
+
+	// make 'current' symlink
+	revDir := info.UserDataDir(homedir, nil)
+	linkPath := filepath.Join(revDir, "..", "current")
+	err = os.Symlink(revDir, linkPath)
+	c.Assert(err, IsNil)
+
+	// empty user dir is skipped
+	err = s.be.HideSnapData("hello")
+	c.Assert(err, IsNil)
+
+	// only the user with snap data was migrated
+	newSnapDir := filepath.Join(homedir, dirs.HiddenSnapDataHomeDir)
+	matches, err := filepath.Glob(dirs.HiddenSnapDataHomeGlob)
+	c.Assert(err, IsNil)
+	c.Assert(matches, HasLen, 1)
+	c.Assert(matches[0], Equals, newSnapDir)
+}
+
+func (s *copydataSuite) TestUndoHideSnapData(c *C) {
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+
+	// mock user home dir
+	homedir := filepath.Join(s.tempdir, "home", "user")
+	usr, err := user.Current()
+	c.Assert(err, IsNil)
+	usr.HomeDir = homedir
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	// write file in revisioned dir
+	opts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}
+	err = os.MkdirAll(info.UserDataDir(homedir, opts), 0770)
+	c.Assert(err, IsNil)
+
+	hiddenRevFile := filepath.Join(info.UserDataDir(homedir, opts), "file.txt")
+	err = ioutil.WriteFile(hiddenRevFile, []byte("some content"), 0640)
+	c.Assert(err, IsNil)
+
+	// write file in common
+	err = os.MkdirAll(info.UserCommonDataDir(homedir, opts), 0770)
+	c.Assert(err, IsNil)
+
+	hiddenCommonFile := filepath.Join(info.UserCommonDataDir(homedir, opts), "file.txt")
+	err = ioutil.WriteFile(hiddenCommonFile, []byte("other content"), 0640)
+	c.Assert(err, IsNil)
+
+	// make 'current' symlink
+	revDir := info.UserDataDir(homedir, opts)
+	// path must be relative otherwise the move would make it dangling
+	err = os.Symlink(filepath.Base(revDir), filepath.Join(revDir, "..", "current"))
+	c.Assert(err, IsNil)
+
+	// undo migration
+	err = s.be.UndoHideSnapData("hello")
+	c.Assert(err, IsNil)
+
+	// check versioned file was restored
+	revFile := filepath.Join(info.UserDataDir(homedir, nil), "file.txt")
+	data, err := ioutil.ReadFile(revFile)
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, []byte("some content"))
+
+	// check common file was restored
+	commonFile := filepath.Join(info.UserCommonDataDir(homedir, nil), "file.txt")
+	data, err = ioutil.ReadFile(commonFile)
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, []byte("other content"))
+
+	// check symlink points to revisioned dir
+	exposedDir := filepath.Join(homedir, dirs.UserHomeSnapDir)
+	target, err := os.Readlink(filepath.Join(exposedDir, "hello", "current"))
+	c.Assert(err, IsNil)
+	c.Assert(target, Equals, "10")
+
+	// ~/.snap/data was removed
+	_, err = os.Stat(snap.SnapDir(homedir, opts))
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
+}
+
+func (s *copydataSuite) TestCleanupAfterCopyAndMigration(c *C) {
+	homedir := filepath.Join(s.tempdir, "home", "user")
+	usr, err := user.Current()
+	c.Assert(err, IsNil)
+	usr.HomeDir = homedir
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	// add trashed data in exposed dir
+	s.populateHomeData(c, "user", snap.R(10))
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	exposedTrash := filepath.Join(homedir, "snap", "hello", "10.old")
+	c.Assert(os.MkdirAll(exposedTrash, 0770), IsNil)
+
+	// add trashed data in hidden dir
+	s.populateHomeDataWithSnapDir(c, "user", dirs.HiddenSnapDataHomeDir, snap.R(10))
+	hiddenTrash := filepath.Join(homedir, ".snap", "data", "hello", "10.old")
+	c.Assert(os.MkdirAll(exposedTrash, 0770), IsNil)
+
+	s.be.ClearTrashedData(v1)
+
+	// clear should remove both
+	exists, _, err := osutil.DirExists(exposedTrash)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
+
+	exists, _, err = osutil.DirExists(hiddenTrash)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
+}
+
+func (s *copydataSuite) TestRemoveIfEmpty(c *C) {
+	file := filepath.Join(s.tempdir, "random")
+	c.Assert(ioutil.WriteFile(file, []byte("stuff"), 0664), IsNil)
+
+	// dir contains a file, shouldn't do anything
+	c.Assert(backend.RemoveIfEmpty(s.tempdir), IsNil)
+	files, err := ioutil.ReadDir(s.tempdir)
+	c.Assert(err, IsNil)
+	c.Check(files, HasLen, 1)
+	c.Check(filepath.Join(s.tempdir, files[0].Name()), testutil.FileEquals, "stuff")
+
+	c.Assert(os.Remove(file), IsNil)
+
+	// dir is empty, should be removed
+	c.Assert(backend.RemoveIfEmpty(s.tempdir), IsNil)
+	c.Assert(osutil.FileExists(file), Equals, false)
+}
+
+func (s *copydataSuite) TestUndoHideKeepGoingPreserveFirstErr(c *C) {
+	firstTime := true
+	restore := backend.MockRemoveIfEmpty(func(dir string) error {
+		var err error
+		if firstTime {
+			err = errors.New("first error")
+			firstTime = false
+		} else {
+			err = errors.New("other error")
+		}
+
+		return err
+	})
+	defer restore()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+
+	// mock two users so that the undo is done twice
+	var usrs []*user.User
+	for _, usrName := range []string{"usr1", "usr2"} {
+		homedir := filepath.Join(s.tempdir, "home", usrName)
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = homedir
+
+		opts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}
+		err = os.MkdirAll(info.UserDataDir(homedir, opts), 0770)
+		c.Assert(err, IsNil)
+
+		usrs = append(usrs, usr)
+	}
+
+	restUsers := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return usrs, nil
+	})
+	defer restUsers()
+
+	buf, restLogger := logger.MockLogger()
+	defer restLogger()
+
+	err := s.be.UndoHideSnapData("hello")
+	// the first error is returned
+	c.Assert(err, ErrorMatches, `cannot remove dir ".*": first error`)
+	// the undo keeps going and logs the next error
+	c.Assert(buf, Matches, `.*cannot remove dir ".*": other error\n`)
 }

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -21,11 +21,15 @@ package backend
 
 import (
 	"os/exec"
+	"os/user"
+
+	"github.com/snapcore/snapd/dirs"
 )
 
 var (
 	AddMountUnit    = addMountUnit
 	RemoveMountUnit = removeMountUnit
+	RemoveIfEmpty   = removeIfEmpty
 )
 
 func MockUpdateFontconfigCaches(f func() error) (restore func()) {
@@ -41,5 +45,22 @@ func MockCommandFromSystemSnap(f func(string, ...string) (*exec.Cmd, error)) (re
 	commandFromSystemSnap = f
 	return func() {
 		commandFromSystemSnap = old
+	}
+}
+
+func MockAllUsers(f func(options *dirs.SnapDirOptions) ([]*user.User, error)) func() {
+	old := allUsers
+	allUsers = f
+	return func() {
+		allUsers = old
+	}
+
+}
+
+func MockRemoveIfEmpty(f func(dir string) error) func() {
+	old := removeIfEmpty
+	removeIfEmpty = f
+	return func() {
+		removeIfEmpty = old
 	}
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -905,7 +905,7 @@ apps:
 	return info, nil
 }
 
-func (f *fakeSnappyBackend) ClearTrashedData(si *snap.Info, opts *dirs.SnapDirOptions) {
+func (f *fakeSnappyBackend) ClearTrashedData(si *snap.Info) {
 	f.appendOp(&fakeOp{
 		op:    "cleanup-trash",
 		name:  si.InstanceName(),
@@ -931,7 +931,7 @@ func (f *fakeSnappyBackend) CopySnapData(newInfo, oldInfo *snap.Info, p progress
 		op.old = oldInfo.MountDir()
 	}
 
-	if opts != nil && opts.HiddenSnapDataDir {
+	if opts != nil && opts.UseHiddenSnapDataDir {
 		op.dirOpts = opts
 	}
 
@@ -1237,6 +1237,16 @@ func (f *fakeSnappyBackend) RunInhibitSnapForUnlink(info *snap.Info, hint runinh
 	}
 	// XXX: returning a real lock is somewhat annoying
 	return osutil.NewFileLock(filepath.Join(f.lockDir, info.InstanceName()+".lock"))
+}
+
+func (f *fakeSnappyBackend) HideSnapData(snapName string) error {
+	f.appendOp(&fakeOp{op: "hide-snap-data", name: snapName})
+	return f.maybeErrForLastOp()
+}
+
+func (f *fakeSnappyBackend) UndoHideSnapData(snapName string) error {
+	f.appendOp(&fakeOp{op: "undo-hide-snap-data", name: snapName})
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) appendOp(op *fakeOp) {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -329,7 +329,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSeqFile(c *C) {
 	// and check that the sequence file got updated
 	seqContent, err := ioutil.ReadFile(filepath.Join(dirs.SnapSeqDir, "foo.json"))
 	c.Assert(err, IsNil)
-	c.Check(string(seqContent), Equals, `{"sequence":[{"name":"foo","snap-id":"","revision":"11"},{"name":"foo","snap-id":"","revision":"33"}],"current":"33"}`)
+	c.Check(string(seqContent), Equals, `{"sequence":[{"name":"foo","snap-id":"","revision":"11"},{"name":"foo","snap-id":"","revision":"33"}],"current":"33","migrated-hidden-dir":false}`)
 }
 
 func (s *linkSnapSuite) TestDoUndoLinkSnap(c *C) {
@@ -394,7 +394,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnap(c *C) {
 	// and check that the sequence file got updated
 	seqContent, err := ioutil.ReadFile(filepath.Join(dirs.SnapSeqDir, "foo.json"))
 	c.Assert(err, IsNil)
-	c.Check(string(seqContent), Equals, `{"sequence":[],"current":"unset"}`)
+	c.Check(string(seqContent), Equals, `{"sequence":[],"current":"unset","migrated-hidden-dir":false}`)
 
 	// nothing in config
 	var config map[string]*json.RawMessage

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -102,6 +102,10 @@ type SnapSetup struct {
 	// InstanceKey is set by the user during installation and differs for
 	// each instance of given snap
 	InstanceKey string `json:"instance-key,omitempty"`
+
+	// MigratedToHiddenDir is set if the user's snap dir has been migrated
+	// to ~/.snap/data.
+	MigratedToHiddenDir bool `json:"migrated-hidden-dir,omitempty"`
 }
 
 func (snapsup *SnapSetup) InstanceName() string {
@@ -193,6 +197,10 @@ type SnapState struct {
 
 	// LastRefreshTime records the time when the snap was last refreshed.
 	LastRefreshTime *time.Time `json:"last-refresh-time,omitempty"`
+
+	// MigratedToHiddenDir is set if the user's snap dir has been migrated
+	// to ~/.snap/data.
+	MigratedToHiddenDir bool `json:"migrated-hidden-dir,omitempty"`
 }
 
 func (snapst *SnapState) SetTrackingChannel(s string) error {

--- a/snap/info.go
+++ b/snap/info.go
@@ -203,7 +203,7 @@ func snapDataDir(opts *dirs.SnapDirOptions) string {
 		opts = &dirs.SnapDirOptions{}
 	}
 
-	if opts.HiddenSnapDataDir {
+	if opts.UseHiddenSnapDataDir && opts.MigratedToHiddenDir {
 		return dirs.HiddenSnapDataHomeDir
 	}
 
@@ -536,7 +536,7 @@ func DataHomeGlob(opts *dirs.SnapDirOptions) string {
 		opts = &dirs.SnapDirOptions{}
 	}
 
-	if opts.HiddenSnapDataDir {
+	if opts.UseHiddenSnapDataDir && opts.MigratedToHiddenDir {
 		return dirs.HiddenSnapDataHomeGlob
 	}
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1852,7 +1852,7 @@ func (s *infoSuite) TestSortAppInfoBySnapApp(c *C) {
 
 func (s *infoSuite) TestHelpersWithHiddenSnapFolder(c *C) {
 	dirs.SetRootDir("")
-	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+	opts := &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}
 
 	c.Check(snap.UserDataDir("/home/bob", "name", snap.R(1), opts), Equals, "/home/bob/.snap/data/name/1")
 	c.Check(snap.UserCommonDataDir("/home/bob", "name", opts), Equals, "/home/bob/.snap/data/name/common")

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -300,12 +300,21 @@ func (s *HTestSuite) TestHiddenDirEnv(c *C) {
 	})
 	defer restore()
 
-	env := osutil.Environment{}
-	ExtendEnvForRun(env, mockSnapInfo, &dirs.SnapDirOptions{HiddenSnapDataDir: true})
+	for _, t := range []struct {
+		dir  string
+		opts *dirs.SnapDirOptions
+	}{
+		{dir: dirs.UserHomeSnapDir, opts: nil},
+		{dir: dirs.UserHomeSnapDir, opts: &dirs.SnapDirOptions{UseHiddenSnapDataDir: true}},
+		{dir: dirs.HiddenSnapDataHomeDir, opts: &dirs.SnapDirOptions{UseHiddenSnapDataDir: true, MigratedToHiddenDir: true}},
+	} {
+		env := osutil.Environment{}
+		ExtendEnvForRun(env, mockSnapInfo, t.opts)
 
-	c.Check(env["SNAP_USER_COMMON"], Equals, filepath.Join(testDir, dirs.HiddenSnapDataHomeDir, mockSnapInfo.SuggestedName, "common"))
-	c.Check(env["SNAP_USER_DATA"], DeepEquals, filepath.Join(testDir, dirs.HiddenSnapDataHomeDir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String()))
-	c.Check(env["HOME"], DeepEquals, filepath.Join(testDir, dirs.HiddenSnapDataHomeDir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String()))
+		c.Check(env["SNAP_USER_COMMON"], Equals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, "common"))
+		c.Check(env["SNAP_USER_DATA"], DeepEquals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String()))
+		c.Check(env["HOME"], DeepEquals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String()))
+	}
 }
 
 func MockUserCurrent(f func() (*user.User, error)) func() {

--- a/tests/main/migrate-hidden-dir/task.yaml
+++ b/tests/main/migrate-hidden-dir/task.yaml
@@ -1,0 +1,67 @@
+summary: Ensure snap data is migrated on refresh
+
+# 14.04 doesn't support systemd-run
+systems: [-ubuntu-14.04-*]
+
+environment:
+  BLOB_DIR: $(pwd)/fake-store-blobdir
+
+prepare: |
+  snap install test-snapd-sh
+
+  #shellcheck source=tests/lib/store.sh
+  . "$TESTSLIB"/store.sh
+  setup_fake_store "$BLOB_DIR"
+
+  init_fake_refreshes "$BLOB_DIR" test-snapd-sh
+  retry -n 5 test -e "$BLOB_DIR"/test-snapd-sh*fake1*.snap
+
+restore: |
+  snap remove test-snapd-sh
+  snap set system experimental.hidden-snap-folder!
+
+  #shellcheck source=tests/lib/store.sh
+  . "$TESTSLIB"/store.sh
+  teardown_fake_store "$BLOB_DIR"
+  rm -rf "$BLOB_DIR" "$HOME"/snap/test-snapd-sh "$HOME"/.snap/data/test-snapd-sh
+
+execute: |
+  echo "Create snap user dirs"
+  test-snapd-sh.sh -c 'true'
+
+  echo "Set hidden snap folder feature flag"
+  snap set system experimental.hidden-snap-folder=true
+
+  echo "Check user dirs weren't migrated"
+  test -d "$HOME"/snap/test-snapd-sh
+  test ! -d "$HOME"/.snap/data/test-sh
+
+  echo "Check env vars are still the same"
+  test-snapd-sh.sh -c "touch \$SNAP_USER_DATA/rev.txt"
+  test-snapd-sh.sh -c "touch \$SNAP_USER_COMMON/common.txt"
+
+  test -f "$HOME"/snap/test-snapd-sh/current/rev.txt
+  test -f "$HOME"/snap/test-snapd-sh/common/common.txt
+
+  echo "Refresh snap"
+  snap refresh test-snapd-sh | MATCH ".* refreshed"
+
+  echo "Check that snap data was migrated"
+  test ! -d "$HOME"/snap/test-snapd-sh
+  test -d "$HOME"/.snap/data/test-snapd-sh
+  test -f "$HOME"/.snap/data/test-snapd-sh/current/rev.txt
+  test -f "$HOME"/.snap/data/test-snapd-sh/common/common.txt
+
+  echo "Delete snap and its data"
+  snap remove --purge test-snapd-sh
+  rm -rf "$HOME"/.snap/data/test-snapd-sh
+  rm -rf "$HOME"/snap/test-snapd-sh
+
+  echo "Install snap with flag already set"
+  snap install test-snapd-sh
+
+  echo "Check data is migrated"
+  test-snapd-sh.sh -c "touch \$SNAP_USER_DATA/rev.txt"
+  test-snapd-sh.sh -c "touch \$SNAP_USER_COMMON/common.txt"
+  test -f "$HOME"/.snap/data/test-snapd-sh/current/rev.txt
+  test -f "$HOME"/.snap/data/test-snapd-sh/common/common.txt


### PR DESCRIPTION
This is currently blocked by https://github.com/snapcore/snapd/pull/10836. The only commit relevant to this branch is the last one. The commit adds a flag to distinguish whether the migration has been done or not. The migration code is split between the backend and the install handlers. There are also some changes to cmd_run.go because to create the correct SnapDirOptions we now need to read the sequence file to know if the snap was migrated. Other than that, just unit tests and a spread test.
