### PR TITLE
build-aux: ensure that debian packaging matches build-base

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -32,6 +32,10 @@ parts:
     build-snaps: [go/1.13/stable]
     override-pull: |
       snapcraftctl pull
+      # Ensure that ./debian/ packaging which we are about to use
+      # matches the current `build-base` release. I.e. ubuntu-16.04
+      # for build-base:core, etc.
+      ./generate-packaging-dir
       # install build dependencies
       export DEBIAN_FRONTEND=noninteractive
       export DEBCONF_NONINTERACTIVE_SEEN=true


### PR DESCRIPTION
Currently snapd snap can only be built correctly, when the ./debian symlink points to packaging that matches the current build-base (at the moment that is ubuntu-16.04). Thus to allow building classic .deb and snapd snap on any ubuntu release in a row, the snapcraft.yaml must ensure that correct debian packaging is used during part built time.

With this change:

    $ ./generate-packaging-dir
    $ dpkg-buildpackage -b
    $ snapcraft --use-provider lxd

can be performed on any ubuntu release, and result in creating correct .deb for the host release and create a correct universal snap.

CC: @bboozzoo @anonymouse64 @alexmurray 
