### PR TITLE
run-checks: remove --spread from help message

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -50,7 +50,7 @@ case "${1:-all}" in
         short=1
         ;;
     *)
-        echo "Wrong flag ${1}. To run a single suite use --static, --unit, --spread."
+        echo "Wrong flag ${1}. To run a single suite use --static, --unit."
         exit 1
 esac
 


### PR DESCRIPTION
This removes "--spread" from the run-checks help message since it's no longer supported.