### PR TITLE
release-tools/repack-debian-tarball.sh: fix c-vendor dir

### DIFF
--- a/release-tools/repack-debian-tarball.sh
+++ b/release-tools/repack-debian-tarball.sh
@@ -90,4 +90,4 @@ fakeroot tar \
 	--transform="s/$top_dir/snapd-$upstream_version/" \
 	--file=snapd_"$upstream_version".only-vendor.tar.xz \
 	--auto-compress \
-	--directory="$scratch_dir/" "$top_dir"/vendor/ /c-vendor/
+	--directory="$scratch_dir/" "$top_dir"/vendor/ "$top_dir"/c-vendor/


### PR DESCRIPTION
This needs to be absolute to the extracted dir.

I'm milestoning this for 2.53 because a wise old wizard told me we are likely to have more 2.53.X releases in our future so we should cherry-pick this to the release branch too.