### PR TITLE
packaging/opensuse: sync with openSUSE packaging, enable AppArmor on 15.3+

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -20,10 +20,8 @@
 # Test keys: used for internal testing in snapd.
 %bcond_with testkeys
 
-# Enable AppArmor on openSUSE Tumbleweed (post 15.0) or higher
-# N.B.: Prior to openSUSE Tumbleweed in May 2018, the AppArmor userspace in SUSE
-# did not support what we needed to be able to turn on basic integration.
-%if 0%{?suse_version} >= 1550
+# Enable apparmor on Tumbleweed and Leap 15.3+
+%if 0%{?suse_version} >= 1550 || 0%{?sle_version} >= 150300
 %bcond_without apparmor
 %else
 %bcond_with apparmor
@@ -91,14 +89,11 @@ Group:          System/Packages
 Url:            https://%{import_path}
 Source0:        https://github.com/snapcore/snapd/releases/download/%{version}/%{name}_%{version}.vendor.tar.xz
 Source1:        snapd-rpmlintrc
-%if (0%{?sle_version} >= 120200 || 0%{?suse_version} >= 1500) && 0%{?is_opensuse}
-BuildRequires:  ShellCheck
-%endif
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  glib2-devel
 BuildRequires:  glibc-devel-static
-BuildRequires:  go >= 1.9
+BuildRequires:  go >= 1.13
 BuildRequires:  gpg2
 BuildRequires:  indent
 BuildRequires:  libcap-devel
@@ -147,7 +142,7 @@ Requires:       system-user-daemon
 # Old versions of xdg-document-portal can expose data belonging to
 # other confied apps.  Older OpenSUSE releases are unlikely to change,
 # so for now limit this to Tumbleweed.
-%if 0%{?suse_version} >= 1550
+%if 0%{?suse_version} >= 1550 || 0%{?sle_version} >= 150300
 Conflicts:      xdg-desktop-portal < 0.11
 %endif
 
@@ -180,6 +175,7 @@ tar -axf %{_sourcedir}/%{name}_%{version}.vendor.tar.xz --strip-components=1 -C 
 # Patch the source in the place it got extracted to.
 pushd %{indigo_srcdir}
 # Add patch0 -p1 ... as appropriate here.
+%autopatch -p1
 popd
 
 # Generate snapd.defines.mk, this file is included by snapd.mk. It contains a


### PR DESCRIPTION
Sync with openSUSE packaging. Enable AppArmor during build on Leap 15.3+.

