### PR TITLE
o/snapstate, assertsate: validation sets/undo on partial failure

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -142,7 +142,7 @@ var (
 	snapstateRevertToRevision  = snapstate.RevertToRevision
 	snapstateSwitch            = snapstate.Switch
 
-	assertstateRefreshSnapAssertions = assertstate.RefreshSnapAssertions
+	assertstateRefreshSnapAssertions         = assertstate.RefreshSnapAssertions
 	assertstateRestoreValidationSetsTracking = assertstate.RestoreValidationSetsTracking
 )
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -143,6 +143,7 @@ var (
 	snapstateSwitch            = snapstate.Switch
 
 	assertstateRefreshSnapAssertions = assertstate.RefreshSnapAssertions
+	assertstateRestoreValidationSetsTracking = assertstate.RestoreValidationSetsTracking
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -607,6 +607,7 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionRes
 	// TODO: use a per-request context
 	updated, tasksets, err := snapstateUpdateMany(context.TODO(), st, inst.Snaps, inst.userID, nil)
 	if err != nil {
+		// XXX: restore validation-sets from history?
 		return nil, err
 	}
 

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -608,8 +608,8 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionRes
 	updated, tasksets, err := snapstateUpdateMany(context.TODO(), st, inst.Snaps, inst.userID, nil)
 	if err != nil {
 		if opts.IsRefreshOfAllSnaps {
-			if restoreErr := assertstateRestoreValidationSetsTracking(st); restoreErr != nil && restoreErr != state.ErrNoState {
-				return nil, restoreErr
+			if err := assertstateRestoreValidationSetsTracking(st); err != nil && !errors.Is(err, state.ErrNoState) {
+				return nil, err
 			}
 		}
 		return nil, err

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -607,7 +607,11 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionRes
 	// TODO: use a per-request context
 	updated, tasksets, err := snapstateUpdateMany(context.TODO(), st, inst.Snaps, inst.userID, nil)
 	if err != nil {
-		// XXX: restore validation-sets from history?
+		if opts.IsRefreshOfAllSnaps {
+			if restoreErr := assertstateRestoreValidationSetsTracking(st); restoreErr != nil && restoreErr != state.ErrNoState {
+				return nil, restoreErr
+			}
+		}
 		return nil, err
 	}
 

--- a/daemon/export_api_snaps_test.go
+++ b/daemon/export_api_snaps_test.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -31,3 +32,11 @@ func MakeAboutSnap(info *snap.Info, snapst *snapstate.SnapState) aboutSnap {
 var (
 	MapLocal = mapLocal
 )
+
+func MockAssertstateRestoreValidationSetsTracking(f func(*state.State) error) (restore func()) {
+	old := assertstateRestoreValidationSetsTracking
+	assertstateRestoreValidationSetsTracking = f
+	return func() {
+		assertstateRestoreValidationSetsTracking = old
+	}
+}

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -344,6 +344,10 @@ func delayedCrossMgrInit() {
 	snapstate.AutoAliases = AutoAliases
 	// hook the helper for getting enforced validation sets
 	snapstate.EnforcedValidationSets = EnforcedValidationSets
+	// hook the helper for saving current validation sets to the stack
+	snapstate.AddCurrentTrackingToValidationSetsStack = addCurrentTrackingToValidationSetsHistory
+	// hook the helper for restoring validation sets tracking from the stack
+	snapstate.RestoreValidationSetsTracking = RestoreValidationSetsTracking
 }
 
 // AutoRefreshAssertions tries to refresh all assertions

--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -272,7 +272,7 @@ func RestoreValidationSetsTracking(st *state.State) error {
 	}
 	if len(trackingState) == 0 {
 		// we should never be called when there is nothing in the stack
-		return fmt.Errorf("no validation sets state to restore")
+		return state.ErrNoState
 	}
 	st.Set("validation-sets", trackingState)
 	return nil

--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -261,3 +261,19 @@ func ValidationSetsHistory(st *state.State) ([]map[string]*ValidationSetTracking
 	}
 	return vshist, nil
 }
+
+// RestoreValidationSets restores validation-sets state to the last state
+// stored in the validation-sets-stack. It should only be called when the stack
+// is not empty, otherwise an error is returned.
+func RestoreValidationSetsTracking(st *state.State) error {
+	trackingState, err := validationSetsHistoryTop(st)
+	if err != nil {
+		return err
+	}
+	if len(trackingState) == 0 {
+		// we should never be called when there is nothing in the stack
+		return fmt.Errorf("no validation sets state to restore")
+	}
+	st.Set("validation-sets", trackingState)
+	return nil
+}

--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -262,7 +262,7 @@ func ValidationSetsHistory(st *state.State) ([]map[string]*ValidationSetTracking
 	return vshist, nil
 }
 
-// RestoreValidationSets restores validation-sets state to the last state
+// RestoreValidationSetsTracking restores validation-sets state to the last state
 // stored in the validation-sets-stack. It should only be called when the stack
 // is not empty, otherwise an error is returned.
 func RestoreValidationSetsTracking(st *state.State) error {

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -436,31 +436,20 @@ func (s *validationSetTrackingSuite) TestRestoreValidationSetsTracking(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(all, HasLen, 1)
 
-	tr3 := assertstate.ValidationSetTracking{
+	tr2 := assertstate.ValidationSetTracking{
 		AccountID: "foo",
 		Name:      "baz",
 		Mode:      assertstate.Enforce,
 		Current:   5,
 	}
-	assertstate.UpdateValidationSet(s.st, &tr3)
+	assertstate.UpdateValidationSet(s.st, &tr2)
 
 	all, err = assertstate.ValidationSets(s.st)
 	c.Assert(err, IsNil)
 	// two validation sets are now tracked
 	c.Check(all, DeepEquals, map[string]*assertstate.ValidationSetTracking{
-		"foo/bar": {
-			AccountID: "foo",
-			Name:      "bar",
-			Mode:      assertstate.Enforce,
-			PinnedAt:  1,
-			Current:   2,
-		},
-		"foo/baz": {
-			AccountID: "foo",
-			Name:      "baz",
-			Mode:      assertstate.Enforce,
-			Current:   5,
-		},
+		"foo/bar": &tr1,
+		"foo/baz": &tr2,
 	})
 
 	// restore
@@ -470,12 +459,6 @@ func (s *validationSetTrackingSuite) TestRestoreValidationSetsTracking(c *C) {
 	all, err = assertstate.ValidationSets(s.st)
 	c.Assert(err, IsNil)
 	c.Check(all, DeepEquals, map[string]*assertstate.ValidationSetTracking{
-		"foo/bar": {
-			AccountID: "foo",
-			Name:      "bar",
-			Mode:      assertstate.Enforce,
-			PinnedAt:  1,
-			Current:   2,
-		},
+		"foo/bar": &tr1,
 	})
 }

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -414,7 +414,7 @@ func (s *validationSetTrackingSuite) TestRestoreValidationSetsTrackingNoHistory(
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	c.Assert(assertstate.RestoreValidationSetsTracking(s.st), ErrorMatches, `no validation sets state to restore`)
+	c.Assert(assertstate.RestoreValidationSetsTracking(s.st), Equals, state.ErrNoState)
 }
 
 func (s *validationSetTrackingSuite) TestRestoreValidationSetsTracking(c *C) {

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -384,3 +384,11 @@ func MockRestoreValidationSetsTracking(f func(*state.State) error) (restore func
 		RestoreValidationSetsTracking = old
 	}
 }
+
+func MockMaybeRestoreValidationSetsAndRevertSnaps(f func(st *state.State, refreshedSnaps []string) ([]*state.TaskSet, error)) (restore func()) {
+	old := maybeRestoreValidationSetsAndRevertSnaps
+	maybeRestoreValidationSetsAndRevertSnaps = f
+	return func() {
+		maybeRestoreValidationSetsAndRevertSnaps = old
+	}
+}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -212,6 +212,8 @@ func MockAsyncPendingRefreshNotification(fn func(context.Context, *userclient.Cl
 var (
 	RefreshedSnaps  = refreshedSnaps
 	ReRefreshFilter = reRefreshFilter
+
+	MaybeRestoreValidationSetsAndRevertSnaps = maybeRestoreValidationSetsAndRevertSnaps
 )
 
 type UpdateFilter = updateFilter
@@ -364,5 +366,21 @@ func MockSnapsToRefresh(f func(gatingTask *state.Task) ([]*refreshCandidate, err
 	snapsToRefresh = f
 	return func() {
 		snapsToRefresh = old
+	}
+}
+
+func MockAddCurrentTrackingToValidationSetsStack(f func(st *state.State) error) (restore func()) {
+	old := AddCurrentTrackingToValidationSetsStack
+	AddCurrentTrackingToValidationSetsStack = f
+	return func() {
+		AddCurrentTrackingToValidationSetsStack = old
+	}
+}
+
+func MockRestoreValidationSetsTracking(f func(*state.State) error) (restore func()) {
+	old := RestoreValidationSetsTracking
+	RestoreValidationSetsTracking = f
+	return func() {
+		RestoreValidationSetsTracking = old
 	}
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3352,7 +3352,7 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 // validation sets and - if necessary - creates tasksets to revert some or all
 // of the refreshed snaps to their previous revisions to satisfy the restored
 // validation sets tracking.
-func maybeRestoreValidationSetsAndRevertSnaps(st *state.State, refreshedSnaps []string) ([]*state.TaskSet, error) {
+var maybeRestoreValidationSetsAndRevertSnaps = func(st *state.State, refreshedSnaps []string) ([]*state.TaskSet, error) {
 	enforcedSets, err := EnforcedValidationSets(st)
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3395,7 +3395,10 @@ var maybeRestoreValidationSetsAndRevertSnaps = func(st *state.State, refreshedSn
 	}
 	err = enforcedSets.CheckInstalledSnaps(installedSnaps, ignoreValidation)
 	if err == nil {
-		// XXX: can this really happen?
+		// all fine after restoring validation sets: this can happen if previous
+		// validation sets only required a snap (regardless of its revision), then
+		// after update they require a specific snap revision, so after restoring
+		// we are back with the good state.
 		return nil, nil
 	}
 	verr, ok := err.(*snapasserts.ValidationSetsValidationError)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3150,7 +3150,8 @@ func changeReadyUpToTask(task *state.Task) bool {
 }
 
 // refreshedSnaps returns the instance names of the snaps successfully refreshed
-// in the last batch of refreshes before the given (re-refresh) task.
+// in the last batch of refreshes before the given (re-refresh) task; failed is
+// true if any of the snaps failed to refresh.
 //
 // It does this by advancing through the given task's change's tasks, keeping
 // track of the instance names from the first SnapSetup in every lane, stopping
@@ -3251,7 +3252,7 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		}
 	}
 
-	// if some (or all) snaps failed to refresh, reconsider validation set tracking
+	// if any snap failed to refresh, reconsider validation set tracking
 	if failed {
 		tasksets, err := maybeRestoreValidationSetsAndRevertSnaps(st, snaps)
 		if err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3274,7 +3274,15 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		return nil
 	}
 
-	// update validation sets stack
+	// update validation sets stack: there are two possibilities
+	// - if maybeRestoreValidationSetsAndRevertSnaps restored previous tracking
+	// or refresh succeeded and it hasn't changed then this is a noop
+	// (AddCurrentTrackingToValidationSetsStack ignores tracking if identical
+	// to the topmost stack entry);
+	// - if maybeRestoreValidationSetsAndRevertSnaps kept new tracking
+	// because its constraints were met even after partial failure or
+	// refresh succeeded and tracking got updated, then
+	// this creates a new copy of validation-sets tracking data.
 	if AddCurrentTrackingToValidationSetsStack != nil {
 		if err := AddCurrentTrackingToValidationSetsStack(st); err != nil {
 			return err

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -34,6 +34,7 @@ import (
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
@@ -3155,7 +3156,7 @@ func changeReadyUpToTask(task *state.Task) bool {
 // track of the instance names from the first SnapSetup in every lane, stopping
 // when finding the given task, and resetting things when finding a different
 // re-refresh task (that indicates the end of a batch that isn't the given one).
-func refreshedSnaps(reTask *state.Task) []string {
+func refreshedSnaps(reTask *state.Task) (snapNames []string, failed bool) {
 	// NOTE nothing requires reTask to be a check-rerefresh task, nor even to be in
 	// a refresh-ish change, but it doesn't make much sense to call this otherwise.
 	tid := reTask.ID()
@@ -3197,15 +3198,16 @@ func refreshedSnaps(reTask *state.Task) []string {
 		laneSnaps[lane] = snapsup.InstanceName()
 	}
 
-	snapNames := make([]string, 0, len(laneSnaps))
+	snapNames = make([]string, 0, len(laneSnaps))
 	for _, name := range laneSnaps {
 		if name == "" {
 			// the lane was unsuccessful
+			failed = true
 			continue
 		}
 		snapNames = append(snapNames, name)
 	}
-	return snapNames
+	return snapNames, failed
 }
 
 // reRefreshSetup holds the necessary details to re-refresh snaps that need it
@@ -3241,14 +3243,42 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 	if !changeReadyUpToTask(t) {
 		return &state.Retry{After: reRefreshRetryTimeout, Reason: "pending refreshes"}
 	}
-	snaps := refreshedSnaps(t)
+
+	snaps, failed := refreshedSnaps(t)
+	if len(snaps) > 0 {
+		if err := pruneRefreshCandidates(st, snaps...); err != nil {
+			return err
+		}
+	}
+
+	// if some (or all) snaps failed to refresh, reconsider validation set tracking
+	if failed {
+		tasksets, err := maybeRestoreValidationSetsAndRevertSnaps(st, snaps)
+		if err != nil {
+			return err
+		}
+		if len(tasksets) > 0 {
+			chg := t.Change()
+			for _, taskset := range tasksets {
+				chg.AddAll(taskset)
+			}
+			st.EnsureBefore(0)
+			t.SetStatus(state.DoneStatus)
+			return nil
+		}
+		// else - validation sets tracking got restored or wasn't affected, carry on
+	}
+
 	if len(snaps) == 0 {
 		// nothing to do (maybe everything failed)
 		return nil
 	}
 
-	if err := pruneRefreshCandidates(st, snaps...); err != nil {
-		return err
+	// update validation sets stack
+	if AddCurrentTrackingToValidationSetsStack != nil {
+		if err := AddCurrentTrackingToValidationSetsStack(st); err != nil {
+			return err
+		}
 	}
 
 	var re reRefreshSetup
@@ -3315,6 +3345,83 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 
 	st.EnsureBefore(0)
 	return nil
+}
+
+// maybeRestoreValidationSetsAndRevertSnaps restores validation-sets to their
+// previous state using validation sets stack if there are any enforced
+// validation sets and - if necessary - creates tasksets to revert some or all
+// of the refreshed snaps to their previous revisions to satisfy the restored
+// validation sets tracking.
+func maybeRestoreValidationSetsAndRevertSnaps(st *state.State, refreshedSnaps []string) ([]*state.TaskSet, error) {
+	enforcedSets, err := EnforcedValidationSets(st)
+	if err != nil {
+		return nil, err
+	}
+	if enforcedSets == nil {
+		// no enforced validation sets, nothing to do
+		return nil, nil
+	}
+
+	installedSnaps, ignoreValidation, err := InstalledSnaps(st)
+	if err != nil {
+		return nil, err
+	}
+	if err := enforcedSets.CheckInstalledSnaps(installedSnaps, ignoreValidation); err == nil {
+		// validation sets are still correct, nothing to do
+		return nil, nil
+	}
+
+	// restore previous validation sets tracking state
+	if err := RestoreValidationSetsTracking(st); err != nil {
+		return nil, fmt.Errorf("cannot restore validation sets: %v", err)
+	}
+
+	// no snaps were refreshed, after restoring validation sets tracking
+	// there is nothing else to do
+	if len(refreshedSnaps) == 0 {
+		return nil, nil
+	}
+
+	// check installed snaps again against restored validation-sets.
+	// this may fail which is fine, but it tells us which snaps are
+	// at invalid revisions and need reverting.
+	// note: we need to fetch enforced sets again because of RestoreValidationSetsTracking.
+	enforcedSets, err = EnforcedValidationSets(st)
+	if err != nil {
+		return nil, err
+	}
+	if enforcedSets == nil {
+		return nil, fmt.Errorf("internal error: no enforced validation sets after restoring from the stack")
+	}
+	err = enforcedSets.CheckInstalledSnaps(installedSnaps, ignoreValidation)
+	if err == nil {
+		// XXX: can this really happen?
+		return nil, nil
+	}
+	verr, ok := err.(*snapasserts.ValidationSetsValidationError)
+	if !ok {
+		return nil, err
+	}
+	if len(verr.WrongRevisionSnaps) == 0 {
+		// if we hit ValidationSetsValidationError but it's not about wrong revisions,
+		// then something is really broken (we shouldn't have invalid or missing required
+		// snaps at this point).
+		return nil, fmt.Errorf("internal error: unexpected validation error of installed snaps after unsuccesfull refresh: %v", verr)
+	}
+	// revert some or all snaps
+	var tss []*state.TaskSet
+	for _, snapName := range refreshedSnaps {
+		if verr.WrongRevisionSnaps[snapName] != nil {
+			// XXX: should we be extra paranoid and use RevertToRevision with
+			// the specific revision from verr.WrongRevisionSnaps?
+			ts, err := Revert(st, snapName, Flags{RevertStatus: NotBlocked})
+			if err != nil {
+				return nil, err
+			}
+			tss = append(tss, ts)
+		}
+	}
+	return tss, nil
 }
 
 // InjectTasks makes all the halt tasks of the mainTask wait for extraTasks;

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -28,9 +28,12 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	. "github.com/snapcore/snapd/testutil"
 )
 
@@ -204,7 +207,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshAddsNewTasks(c *C) {
 
 // wrapper around snapstate.RefreshedSnaps for easier testing
 func refreshedSnaps(task *state.Task) string {
-	snaps := snapstate.RefreshedSnaps(task)
+	snaps, _ := snapstate.RefreshedSnaps(task)
 	sort.Strings(snaps)
 	return strings.Join(snaps, ",")
 }
@@ -368,4 +371,229 @@ func (s *reRefreshSuite) TestFilterReturnsFalseIfEpochEqualZero(c *C) {
 	}
 	c.Check(snapstate.ReRefreshFilter(&snap.Info{Epoch: snap.E("0")}, snapst), Equals, false)
 	c.Check(snapstate.ReRefreshFilter(&snap.Info{Epoch: snap.Epoch{}}, snapst), Equals, false)
+}
+
+func (s *refreshSuite) TestMaybeRestoreValidationSetsAndRevertSnaps(c *C) {
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
+		return nil, nil
+	})
+	defer restore()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	refreshedSnaps := []string{"foo", "bar"}
+	// nothing to do with no enforced validation sets
+	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps)
+	c.Assert(err, IsNil)
+	c.Check(ts, IsNil)
+}
+
+func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRevert(c *C) {
+	var enforcedValidationSetsCalled int
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
+		enforcedValidationSetsCalled++
+
+		vs := snapasserts.NewValidationSets()
+		var snap1, snap2, snap3 map[string]interface{}
+		snap3 = map[string]interface{}{
+			"id":       "abcKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "some-snap3",
+			"presence": "required",
+		}
+
+		switch enforcedValidationSetsCalled {
+		case 1:
+			// refreshed validation sets
+			snap1 = map[string]interface{}{
+				"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
+				"name":     "some-snap1",
+				"presence": "required",
+				"revision": "3",
+			}
+			// require snap2 at revision 5 (if snap refresh succeeded, but it didn't, so
+			// current revision of the snap is wrong)
+			snap2 = map[string]interface{}{
+				"id":       "bgtKhntON3vR7kwEbVPsILm7bUViPDzx",
+				"name":     "some-snap2",
+				"presence": "required",
+				"revision": "5",
+			}
+		case 2:
+			// validation sets restored from history
+			snap1 = map[string]interface{}{
+				"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
+				"name":     "some-snap1",
+				"presence": "required",
+				"revision": "1",
+			}
+			snap2 = map[string]interface{}{
+				"id":       "bgtKhntON3vR7kwEbVPsILm7bUViPDzx",
+				"name":     "some-snap2",
+				"presence": "required",
+				"revision": "2",
+			}
+		default:
+			c.Fatalf("unexpected call to EnforcedValidatioSets")
+		}
+		vsa1 := s.mockValidationSetAssert(c, "bar", "2", snap1, snap2, snap3)
+		vs.Add(vsa1.(*asserts.ValidationSet))
+		return vs, nil
+	})
+	defer restore()
+
+	var restoreValidationSetsTrackingCalled int
+	restoreRestoreValidationSetsTracking := snapstate.MockRestoreValidationSetsTracking(func(*state.State) error {
+		restoreValidationSetsTrackingCalled++
+		return nil
+	})
+	defer restoreRestoreValidationSetsTracking()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// snaps installed after partial refresh
+	si1 := &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(3)}
+	si11 := &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
+	snapstate.Set(s.state, "some-snap1", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si11, si1},
+		Current:  snap.R(3),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap1`, si1)
+
+	// some-snap2 failed to refresh and remains at revision 2
+	si2 := &snap.SideInfo{RealName: "some-snap2", SnapID: "bgtKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(2)}
+	snapstate.Set(s.state, "some-snap2", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si2},
+		Current:  snap.R(2),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap2`, si2)
+
+	si3 := &snap.SideInfo{RealName: "some-snap3", SnapID: "abcKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(3)}
+	snapstate.Set(s.state, "some-snap3", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si3},
+		Current:  snap.R(3),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap3`, si3)
+
+	// some-snap2 failed to refresh
+	refreshedSnaps := []string{"some-snap1", "some-snap3"}
+	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps)
+	c.Assert(err, IsNil)
+
+	// we expect revert of snap1
+	c.Assert(ts, HasLen, 1)
+	revertTasks := ts[0].Tasks()
+	c.Assert(taskKinds(revertTasks), DeepEquals, []string{
+		"prerequisites",
+		"prepare-snap",
+		"stop-snap-services",
+		"remove-aliases",
+		"unlink-current-snap",
+		"setup-profiles",
+		"link-snap",
+		"auto-connect",
+		"set-auto-aliases",
+		"setup-aliases",
+		"start-snap-services",
+		"run-hook[configure]",
+		"run-hook[check-health]",
+	})
+
+	snapsup, err := snapstate.TaskSnapSetup(revertTasks[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Flags, Equals, snapstate.Flags{Revert: true, RevertStatus: snapstate.NotBlocked})
+	c.Check(snapsup.InstanceName(), Equals, "some-snap1")
+	c.Check(snapsup.Revision(), Equals, snap.R(1))
+
+	c.Check(restoreValidationSetsTrackingCalled, Equals, 1)
+	c.Check(enforcedValidationSetsCalled, Equals, 2)
+}
+
+func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertJustValidationSetsRestore(c *C) {
+	var enforcedValidationSetsCalled int
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
+		enforcedValidationSetsCalled++
+
+		vs := snapasserts.NewValidationSets()
+		var snap1, snap2 map[string]interface{}
+		snap2 = map[string]interface{}{
+			"id":       "abcKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "some-snap2",
+			"presence": "required",
+		}
+
+		switch enforcedValidationSetsCalled {
+		case 1:
+			// refreshed validation sets
+			// snap1 revision 3 is now required (but snap wasn't refreshed)
+			snap1 = map[string]interface{}{
+				"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
+				"name":     "some-snap1",
+				"presence": "required",
+				"revision": "3",
+			}
+		case 2:
+			// validation sets restored from history
+			snap1 = map[string]interface{}{
+				"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
+				"name":     "some-snap1",
+				"presence": "required",
+				"revision": "1",
+			}
+		default:
+			c.Fatalf("unexpected call to EnforcedValidatioSets")
+		}
+		vsa1 := s.mockValidationSetAssert(c, "bar", "2", snap1, snap2)
+		vs.Add(vsa1.(*asserts.ValidationSet))
+		return vs, nil
+	})
+	defer restore()
+
+	var restoreValidationSetsTrackingCalled int
+	restoreRestoreValidationSetsTracking := snapstate.MockRestoreValidationSetsTracking(func(*state.State) error {
+		restoreValidationSetsTrackingCalled++
+		return nil
+	})
+	defer restoreRestoreValidationSetsTracking()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// snaps in the system after partial refresh
+	si1 := &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
+	snapstate.Set(s.state, "some-snap1", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si1},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap1`, si1)
+
+	si3 := &snap.SideInfo{RealName: "some-snap2", SnapID: "abcKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(3)}
+	snapstate.Set(s.state, "some-snap2", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si3},
+		Current:  snap.R(3),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap2`, si3)
+
+	refreshedSnaps := []string{"some-snap2"}
+	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps)
+	c.Assert(err, IsNil)
+
+	// we expect no snap reverts
+	c.Assert(ts, HasLen, 0)
+	c.Check(restoreValidationSetsTrackingCalled, Equals, 1)
+	c.Check(enforcedValidationSetsCalled, Equals, 2)
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2069,6 +2069,10 @@ func infoForUpdate(st *state.State, snapst *SnapState, name string, opts *Revisi
 // into the Autorefresh function.
 var AutoRefreshAssertions func(st *state.State, userID int) error
 
+var AddCurrentTrackingToValidationSetsStack func(st *state.State) error
+
+var RestoreValidationSetsTracking func(st *state.State) error
+
 // AutoRefresh is the wrapper that will do a refresh of all the installed
 // snaps on the system. In addition to that it will also refresh important
 // assertions.

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6934,7 +6934,9 @@ func (s *validationSetsSuite) TestUpdateManyValidationSetsPartialFailureNothingT
 	// mockMaybeRestoreValidationSetsAndRevertSnaps was called.
 	c.Check(refreshed, DeepEquals, []string{"some-snap"})
 
-	// validation sets history has been updated
+	// validation sets history update was attempted (could be a no-op if
+	// maybeRestoreValidationSetsAndRevertSnaps restored last tracking
+	// data).
 	c.Check(addCurrentTrackingToValidationSetsStackCalled, Equals, 1)
 }
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6844,6 +6844,104 @@ func (s *snapmgrTestSuite) TestUpdatePrerequisiteWithSameDeviceContext(c *C) {
 	})
 }
 
+/*
+func (s *validationSetsSuite) TestUpdateManyValidationSetsPartialFailure(c *C) {
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State) (*snapasserts.ValidationSets, error) {
+		vs := snapasserts.NewValidationSets()
+		snap1 := map[string]interface{}{
+			"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "some-snap1",
+			"presence": "required",
+			"revision": "1",
+		}
+		snap2 := map[string]interface{}{
+			"id":       "bgtKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "some-snap2",
+			"presence": "required",
+			"revision": "2",
+		}
+		snap3 := map[string]interface{}{
+			"id":       "abcKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "some-snap3",
+			"presence": "required",
+		}
+		vsa1 := s.mockValidationSetAssert(c, "bar", "2", snap1, snap2, snap3)
+		vs.Add(vsa1.(*asserts.ValidationSet))
+		return vs, nil
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: "foo",
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		Current:   2,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	si1 := &snap.SideInfo{RealName: "some-snap1", SnapID: "some-snap-id1", Revision: snap.R(1)}
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si1},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap1`, si1)
+
+	si2 := &snap.SideInfo{RealName: "some-snap2", SnapID: "some-snap-id2", Revision: snap.R(2)}
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si2},
+		Current:  snap.R(2),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap2`, si2)
+
+	si3 := &snap.SideInfo{RealName: "some-snap3", SnapID: "some-snap-id3", Revision: snap.R(3)}
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si3},
+		Current:  snap.R(3),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap3`, si3)
+
+	s.fakeBackend.ops = nil
+	s.fakeStore.refreshRevnos = map[string]snap.Revision{
+		"some-snap-id1": snap.R(12),
+	}
+
+	refreshedDate := fakeRevDateEpoch.AddDate(0, 0, 1)
+	names, _, err := snapstate.UpdateMany(context.Background(), s.state, nil, 0, &snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Check(names, DeepEquals, []string{"some-snap"})
+
+	c.Assert(s.fakeBackend.ops, HasLen, 2)
+	expectedOps := fakeOps{{
+		op: "storesvc-snap-action",
+		curSnaps: []store.CurrentSnap{{
+			InstanceName:     "some-snap",
+			SnapID:           "some-snap-id",
+			Revision:         snap.R(1),
+			Epoch:            snap.E("1*"),
+			RefreshedDate:    refreshedDate,
+			IgnoreValidation: true,
+		}},
+	}, {
+		op: "storesvc-snap-action:action",
+		action: store.SnapAction{
+			Action:       "refresh",
+			InstanceName: "some-snap",
+			SnapID:       "some-snap-id",
+		},
+		revno: snap.R(11),
+	}}
+	c.Assert(s.fakeBackend.ops, DeepEquals, expectedOps)
+}*/
+
 func (s *snapmgrTestSuite) TestUpdatePrerequisiteBackwardsCompat(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
When refresh/auto-refresh fails for some snaps, reconsider validation sets and restore them to the previous tracking state as well as revert some or all of the affected snaps to bring the system back to the state where validation-sets enforcing is satisfied. The critical logic is in maybeRestoreValidationSetsAndRevertSnaps function.

The following is considered:
- if after refresh failure validation sets as happy, then obviously there is nothing to do (this means that snaps that succeeded to refresh didn't affect the validation sets, e.g. revisions didn't matter or they are not required at all).
- otherwise validation sets tracking is restored using the topmost v-s history entry and:
- snaps that are at wrong revisions per the restored validation sets get reverted to the previous revisions. The revert uses NotBlocked flag so it's not blocked for future refreshes.
- other refreshed snaps are left intact (as not affecting enforced validation sets)

