### PR TITLE
cmd/snap: improve snap disconnect arg parsing and err msg

### DIFF
--- a/cmd/snap/cmd_disconnect.go
+++ b/cmd/snap/cmd_disconnect.go
@@ -73,17 +73,14 @@ func (x *cmdDisconnect) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	offer := x.Positionals.Offer.SnapAndName
-	use := x.Positionals.Use.SnapAndName
+	offer := x.Positionals.Offer.SnapAndNameStrict
+	use := x.Positionals.Use.SnapAndNameStrict
 
 	// snap disconnect <snap>:<slot>
 	// snap disconnect <snap>
 	if use.Snap == "" && use.Name == "" {
 		// Swap Offer and Use around
 		offer, use = use, offer
-	}
-	if use.Name == "" {
-		return fmt.Errorf("please provide the plug or slot name to disconnect from snap %q", use.Snap)
 	}
 
 	opts := &client.DisconnectOptions{Forget: x.Forget}

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -209,7 +209,7 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSnap(c *C) {
 		c.Fatalf("expected nothing to reach the server")
 	})
 	rest, err := Parser(Client()).ParseArgs([]string{"disconnect", "consumer"})
-	c.Assert(err, ErrorMatches, `please provide the plug or slot name to disconnect from snap "consumer"`)
+	c.Assert(err, ErrorMatches, `invalid value: "consumer" \(want snap:name\)`)
 	c.Assert(rest, DeepEquals, []string{"consumer"})
 	c.Assert(s.Stdout(), Equals, "")
 	c.Assert(s.Stderr(), Equals, "")

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -209,7 +209,7 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSnap(c *C) {
 		c.Fatalf("expected nothing to reach the server")
 	})
 	rest, err := Parser(Client()).ParseArgs([]string{"disconnect", "consumer"})
-	c.Assert(err, ErrorMatches, `invalid value: "consumer" \(want snap:name\)`)
+	c.Assert(err, ErrorMatches, `invalid value: "consumer" \(want snap:name or :name\)`)
 	c.Assert(rest, DeepEquals, []string{"consumer"})
 	c.Assert(s.Stdout(), Equals, "")
 	c.Assert(s.Stderr(), Equals, "")

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -202,7 +202,7 @@ func (s keyName) Complete(match string) []flags.Completion {
 }
 
 type disconnectSlotOrPlugSpec struct {
-	SnapAndName
+	SnapAndNameStrict
 }
 
 func (dps disconnectSlotOrPlugSpec) Complete(match string) []flags.Completion {
@@ -217,7 +217,7 @@ func (dps disconnectSlotOrPlugSpec) Complete(match string) []flags.Completion {
 }
 
 type disconnectSlotSpec struct {
-	SnapAndName
+	SnapAndNameStrict
 }
 
 // TODO: look at what the previous arg is, and filter accordingly

--- a/cmd/snap/interfaces_common.go
+++ b/cmd/snap/interfaces_common.go
@@ -26,7 +26,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 )
 
-// SnapAndName holds a snap name and a plug or slot name.
+// SnapAndName holds a snap name and, optionally, a plug or slot name.
 type SnapAndName struct {
 	Snap string
 	Name string
@@ -51,5 +51,23 @@ func (sn *SnapAndName) UnmarshalFlag(value string) error {
 	if sn.Snap == "" && sn.Name == "" {
 		return fmt.Errorf(i18n.G("invalid value: %q (want snap:name or snap)"), value)
 	}
+	return nil
+}
+
+// SnapAndNameStrict holds a snap name and a plug or slot name (both components
+// must be non-empty).
+type SnapAndNameStrict struct {
+	SnapAndName
+}
+
+func (sn *SnapAndNameStrict) UnmarshalFlag(value string) error {
+	sn.Snap, sn.Name = "", ""
+
+	parts := strings.Split(value, ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf(i18n.G("invalid value: %q (want snap:name)"), value)
+	}
+
+	sn.Snap, sn.Name = parts[0], parts[1]
 	return nil
 }

--- a/cmd/snap/interfaces_common.go
+++ b/cmd/snap/interfaces_common.go
@@ -26,13 +26,18 @@ import (
 	"github.com/snapcore/snapd/i18n"
 )
 
-// SnapAndName holds a snap name and, optionally, a plug or slot name.
+// SnapAndName holds a snap name and a plug or slot name.
 type SnapAndName struct {
 	Snap string
 	Name string
 }
 
-// UnmarshalFlag unmarshals snap and plug or slot name.
+// UnmarshalFlag unmarshals the snap and plug or slot name. The following
+// combinations are allowed:
+// * <snap>:<plug/slot>
+// * <snap>
+// * :<plug/slot>
+// Every other combination results in an error.
 func (sn *SnapAndName) UnmarshalFlag(value string) error {
 	parts := strings.Split(value, ":")
 	sn.Snap = ""
@@ -49,7 +54,7 @@ func (sn *SnapAndName) UnmarshalFlag(value string) error {
 		}
 	}
 	if sn.Snap == "" && sn.Name == "" {
-		return fmt.Errorf(i18n.G("invalid value: %q (want snap:name or snap)"), value)
+		return fmt.Errorf(i18n.G("invalid value: %q (want snap:name, snap or :name)"), value)
 	}
 	return nil
 }
@@ -60,12 +65,17 @@ type SnapAndNameStrict struct {
 	SnapAndName
 }
 
+// UnmarshalFlag unmarshals the snap and plug or slot name. The following
+// combinations are allowed:
+// * <snap>:<plug/slot>
+// * :<plug/slot>
+// Every other combination results in an error.
 func (sn *SnapAndNameStrict) UnmarshalFlag(value string) error {
 	sn.Snap, sn.Name = "", ""
 
 	parts := strings.Split(value, ":")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return fmt.Errorf(i18n.G("invalid value: %q (want snap:name)"), value)
+	if len(parts) != 2 || parts[1] == "" {
+		return fmt.Errorf(i18n.G("invalid value: %q (want snap:name or :name)"), value)
 	}
 
 	sn.Snap, sn.Name = parts[0], parts[1]

--- a/cmd/snap/interfaces_common.go
+++ b/cmd/snap/interfaces_common.go
@@ -54,7 +54,7 @@ func (sn *SnapAndName) UnmarshalFlag(value string) error {
 		}
 	}
 	if sn.Snap == "" && sn.Name == "" {
-		return fmt.Errorf(i18n.G("invalid value: %q (want snap:name, snap or :name)"), value)
+		return fmt.Errorf(i18n.G("invalid value: %q (want snap:name or snap)"), value)
 	}
 	return nil
 }

--- a/cmd/snap/interfaces_common.go
+++ b/cmd/snap/interfaces_common.go
@@ -59,8 +59,11 @@ func (sn *SnapAndName) UnmarshalFlag(value string) error {
 	return nil
 }
 
-// SnapAndNameStrict holds a snap name and a plug or slot name (both components
-// must be non-empty).
+// SnapAndNameStrict holds a plug or slot name and, optionally, a snap name.
+// The following combinations are allowed:
+// * <snap>:<plug/slot>
+// * :<plug/slot>
+// Every other combination results in an error.
 type SnapAndNameStrict struct {
 	SnapAndName
 }

--- a/cmd/snap/interfaces_common_test.go
+++ b/cmd/snap/interfaces_common_test.go
@@ -31,16 +31,25 @@ var _ = Suite(&SnapAndNameSuite{})
 
 func (s *SnapAndNameSuite) TestUnmarshalFlag(c *C) {
 	var sn SnapAndName
+
 	// Typical
 	err := sn.UnmarshalFlag("snap:name")
 	c.Assert(err, IsNil)
 	c.Check(sn.Snap, Equals, "snap")
 	c.Check(sn.Name, Equals, "name")
+
 	// Abbreviated
 	err = sn.UnmarshalFlag("snap")
 	c.Assert(err, IsNil)
 	c.Check(sn.Snap, Equals, "snap")
 	c.Check(sn.Name, Equals, "")
+
+	// Core snap
+	err = sn.UnmarshalFlag(":name")
+	c.Assert(err, IsNil)
+	c.Check(sn.Snap, Equals, "")
+	c.Check(sn.Name, Equals, "name")
+
 	// Invalid
 	for _, input := range []string{
 		"snap:",          // Empty name, should be spelled as "snap"
@@ -49,7 +58,7 @@ func (s *SnapAndNameSuite) TestUnmarshalFlag(c *C) {
 		"",               // Empty input
 	} {
 		err = sn.UnmarshalFlag(input)
-		c.Assert(err, ErrorMatches, `invalid value: ".*" \(want snap:name or snap\)`)
+		c.Assert(err, ErrorMatches, `invalid value: ".*" \(want snap:name, snap or :name\)`)
 		c.Check(sn.Snap, Equals, "")
 		c.Check(sn.Name, Equals, "")
 	}
@@ -57,10 +66,17 @@ func (s *SnapAndNameSuite) TestUnmarshalFlag(c *C) {
 
 func (s *SnapAndNameSuite) TestUnmarshalFlagStrict(c *C) {
 	var sn SnapAndNameStrict
+
 	// Typical
 	err := sn.UnmarshalFlag("snap:name")
 	c.Assert(err, IsNil)
 	c.Check(sn.Snap, Equals, "snap")
+	c.Check(sn.Name, Equals, "name")
+
+	// Core snap
+	err = sn.UnmarshalFlag(":name")
+	c.Assert(err, IsNil)
+	c.Check(sn.Snap, Equals, "")
 	c.Check(sn.Name, Equals, "name")
 
 	// Invalid
@@ -70,10 +86,9 @@ func (s *SnapAndNameSuite) TestUnmarshalFlagStrict(c *C) {
 		"snap:name:more", // Name containing :, probably a typo
 		"",               // Empty input
 		"snap",           // Name empty unsupported for strict
-		":name",          // Snap empty
 	} {
 		err = sn.UnmarshalFlag(input)
-		c.Assert(err, ErrorMatches, `invalid value: ".*" \(want snap:name\)`)
+		c.Assert(err, ErrorMatches, `invalid value: ".*" \(want snap:name or :name\)`)
 		c.Check(sn.Snap, Equals, "")
 		c.Check(sn.Name, Equals, "")
 	}

--- a/cmd/snap/interfaces_common_test.go
+++ b/cmd/snap/interfaces_common_test.go
@@ -54,3 +54,27 @@ func (s *SnapAndNameSuite) TestUnmarshalFlag(c *C) {
 		c.Check(sn.Name, Equals, "")
 	}
 }
+
+func (s *SnapAndNameSuite) TestUnmarshalFlagStrict(c *C) {
+	var sn SnapAndNameStrict
+	// Typical
+	err := sn.UnmarshalFlag("snap:name")
+	c.Assert(err, IsNil)
+	c.Check(sn.Snap, Equals, "snap")
+	c.Check(sn.Name, Equals, "name")
+
+	// Invalid
+	for _, input := range []string{
+		"snap:",          // Empty name, should be spelled as "snap"
+		":",              // Both snap and name empty, makes no sense
+		"snap:name:more", // Name containing :, probably a typo
+		"",               // Empty input
+		"snap",           // Name empty unsupported for strict
+		":name",          // Snap empty
+	} {
+		err = sn.UnmarshalFlag(input)
+		c.Assert(err, ErrorMatches, `invalid value: ".*" \(want snap:name\)`)
+		c.Check(sn.Snap, Equals, "")
+		c.Check(sn.Name, Equals, "")
+	}
+}

--- a/cmd/snap/interfaces_common_test.go
+++ b/cmd/snap/interfaces_common_test.go
@@ -31,25 +31,16 @@ var _ = Suite(&SnapAndNameSuite{})
 
 func (s *SnapAndNameSuite) TestUnmarshalFlag(c *C) {
 	var sn SnapAndName
-
 	// Typical
 	err := sn.UnmarshalFlag("snap:name")
 	c.Assert(err, IsNil)
 	c.Check(sn.Snap, Equals, "snap")
 	c.Check(sn.Name, Equals, "name")
-
 	// Abbreviated
 	err = sn.UnmarshalFlag("snap")
 	c.Assert(err, IsNil)
 	c.Check(sn.Snap, Equals, "snap")
 	c.Check(sn.Name, Equals, "")
-
-	// Core snap
-	err = sn.UnmarshalFlag(":name")
-	c.Assert(err, IsNil)
-	c.Check(sn.Snap, Equals, "")
-	c.Check(sn.Name, Equals, "name")
-
 	// Invalid
 	for _, input := range []string{
 		"snap:",          // Empty name, should be spelled as "snap"

--- a/cmd/snap/interfaces_common_test.go
+++ b/cmd/snap/interfaces_common_test.go
@@ -58,7 +58,7 @@ func (s *SnapAndNameSuite) TestUnmarshalFlag(c *C) {
 		"",               // Empty input
 	} {
 		err = sn.UnmarshalFlag(input)
-		c.Assert(err, ErrorMatches, `invalid value: ".*" \(want snap:name, snap or :name\)`)
+		c.Assert(err, ErrorMatches, `invalid value: ".*" \(want snap:name or snap\)`)
 		c.Check(sn.Snap, Equals, "")
 		c.Check(sn.Name, Equals, "")
 	}

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -54,6 +54,10 @@ execute: |
     echo "Disconnecting again using abbreviated form is handled"
     snap disconnect home-consumer:home | MATCH "No connections to disconnect"
 
+    echo "Disconnecting without specifying the slot/plug fails"
+    snap disconnect home-consumer: 2>&1 | MATCH '.*invalid value: "home-consumer:" \(want snap:name or :name\)'
+    snap disconnect home-consumer 2>&1 | MATCH '.*invalid value: "home-consumer" \(want snap:name or :name\)'
+    snap disconnect home-consumer:home core 2>&1 | MATCH '.*invalid value: "core" \(want snap:name or :name\)'
 
     # these checks rely on automatic connection of home on non-core systems
     if ! os.query is-core; then


### PR DESCRIPTION
snap disconnect's parsing would output an error message "invalid
value: (want snap:name or snap)" even though invoking it with just
the snap resulted in an error with a conflicting message.
This commit fixes the parsing for snap disconnect so it's done in a
single place and returns a single error message.

https://bugs.launchpad.net/snapd/+bug/1943987