### PR TITLE
tests/main/apparmor-batch-reload: fix fake apparmor_parser to handle --preprocess

### DIFF
--- a/tests/main/apparmor-batch-reload/bin/apparmor_parser.fake
+++ b/tests/main/apparmor-batch-reload/bin/apparmor_parser.fake
@@ -8,7 +8,7 @@ while [ -n "$1" ]; do
     case "$1" in
         --preprocess)
             # preprocess is used by snapd to verify apparmor features
-            exit 0
+            break
             ;;
         --cache-loc=*)
             ;;


### PR DESCRIPTION
Fix the mock apparmor_parser such that the parser feature detection still works
correctly. A followup to #10951

