### PR TITLE
tests: skip the interfaces-openvswitch on fedora 33

### DIFF
--- a/tests/nightly/interfaces-openvswitch/task.yaml
+++ b/tests/nightly/interfaces-openvswitch/task.yaml
@@ -14,7 +14,7 @@ details: |
 # Openvswitch getting stuck during installation sporadically on ubuntu-14.04-64
 # Openvswitch service fails to start on debian-sid
 # Openvswitch service not available on the following systems
-systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -arch-linux-*, -centos-*, -debian-sid-*, -ubuntu-14.04-64]
+systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -arch-linux-*, -centos-*, -debian-sid-*, -ubuntu-14.04-64, -fedora-33-*]
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh


### PR DESCRIPTION
This is needed because there are some dependency issues that make the
test fail in this system.

This test is executed on nightly suite, this is the error:
https://github.com/snapcore/spread-cron/runs/3971118177?check_suite_focus=true#step:3:7065

+ tests.pkgs remove openssl-libs-1.1.1l-2.fc33.x86_64
++ command -v dnf
+ '[' /usr/bin/dnf '!=' '' ']'
+ dnf remove -y openssl-libs-1.1.1l-2.fc33.x86_64
Error: 
 Problem: The operation would result in removing the following protected packages: sudo
(try to add '--skip-broken' to skip uninstallable packages)

