### PR TITLE
interfaces/network-manager-observe: Update for libnm / dart clients

### DIFF
--- a/interfaces/builtin/network_manager_observe.go
+++ b/interfaces/builtin/network_manager_observe.go
@@ -127,11 +127,17 @@ dbus (send)
     interface="org.freedesktop.NetworkManager.Settings{,.Connection}"
     member="GetSettings"
     peer=(label=###SLOT_SECURITY_TAGS###),
+dbus (send)
+    bus=system
+    path=/org/freedesktop
+    interface=org.freedesktop.DBus.ObjectManager
+    member="GetManagedObjects"
+    peer=(label=###SLOT_SECURITY_TAGS###),
 
 # receive signals for updated settings and properties
 dbus (receive)
     bus=system
-    path="/org/freedesktop/NetworkManager{,/{ActiveConnection,Devices}/*}"
+    path="/org/freedesktop/NetworkManager{,/**}"
     interface=org.freedesktop.DBus.Properties
     member=PropertiesChanged
     peer=(label=###SLOT_SECURITY_TAGS###),
@@ -164,6 +170,12 @@ dbus (receive)
     path="/org/freedesktop/NetworkManager/Settings/*"
     interface="org.freedesktop.NetworkManager.Settings.Connection"
     member=PropertiesChanged
+    peer=(label=###SLOT_SECURITY_TAGS###),
+dbus (receive)
+    bus=system
+    path=/org/freedesktop
+    interface=org.freedesktop.DBus.ObjectManager
+    member="Interfaces{Added,Removed}"
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 


### PR DESCRIPTION
Dart applications use the ObjectManager.GetManagedObjects() DBus interface
method to query properties from NetworkManager so update this interface to
provide access to that, plus ensure they can also receive the
PropertiesChanged signal from NetworkManager objects as well.

https://forum.snapcraft.io/t/request-auto-connect-network-manager-for-cybear-jinni-app-again/26520
