### PR TITLE
interfaces/builtin: do not probe parser features when apparmor isn't available

### DIFF
--- a/interfaces/builtin/netlink_audit.go
+++ b/interfaces/builtin/netlink_audit.go
@@ -64,6 +64,10 @@ type netlinkAuditInterface struct {
 }
 
 func (iface *netlinkAuditInterface) BeforeConnectPlug(plug *interfaces.ConnectedPlug) error {
+	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.Unsupported {
+		// no apparmor means we don't have to deal with parser features
+		return nil
+	}
 	features, err := apparmor_sandbox.ParserFeatures()
 	if err != nil {
 		return err

--- a/interfaces/builtin/netlink_audit_test.go
+++ b/interfaces/builtin/netlink_audit_test.go
@@ -77,10 +77,19 @@ func (s *NetlinkAuditInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *NetlinkAuditInterfaceSuite) TestSanitizePlugConnectionMissingAppArmorSandboxFeatures(c *C) {
-	r := apparmor_sandbox.MockFeatures(nil, nil, nil, nil)
+	r := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
+	defer r()
+	r = apparmor_sandbox.MockFeatures(nil, nil, nil, nil)
 	defer r()
 	err := interfaces.BeforeConnectPlug(s.iface, s.plug)
 	c.Assert(err, ErrorMatches, "cannot connect plug on system without audit_read support")
+}
+
+func (s *NetlinkAuditInterfaceSuite) TestSanitizePlugConnectionMissingNoAppArmor(c *C) {
+	r := apparmor_sandbox.MockLevel(apparmor_sandbox.Unsupported)
+	defer r()
+	err := interfaces.BeforeConnectPlug(s.iface, s.plug)
+	c.Assert(err, IsNil)
 }
 
 func (s *NetlinkAuditInterfaceSuite) TestAppArmorSpec(c *C) {

--- a/interfaces/builtin/qualcomm_ipc_router.go
+++ b/interfaces/builtin/qualcomm_ipc_router.go
@@ -66,6 +66,10 @@ type qualcomIPCRouterInterface struct {
 }
 
 func (iface *qualcomIPCRouterInterface) BeforeConnectPlug(plug *interfaces.ConnectedPlug) error {
+	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.Unsupported {
+		// no apparmor means we don't have to deal with parser features
+		return nil
+	}
 	features, err := apparmor_sandbox.ParserFeatures()
 	if err != nil {
 		return err

--- a/interfaces/builtin/qualcomm_ipc_router_test.go
+++ b/interfaces/builtin/qualcomm_ipc_router_test.go
@@ -81,10 +81,19 @@ func (s *QrtrInterfaceSuite) TestSanitizePlugConnectionFullAppArmorSandboxFeatur
 }
 
 func (s *QrtrInterfaceSuite) TestSanitizePlugConnectionMissingAppArmorSandboxFeatures(c *C) {
-	r := apparmor_sandbox.MockFeatures(nil, nil, nil, nil)
+	r := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
+	defer r()
+	r = apparmor_sandbox.MockFeatures(nil, nil, nil, nil)
 	defer r()
 	err := interfaces.BeforeConnectPlug(s.iface, s.plug)
 	c.Assert(err, ErrorMatches, "cannot connect plug on system without qipcrtr socket support")
+}
+
+func (s *QrtrInterfaceSuite) TestSanitizePlugConnectionMissingNoAppArmor(c *C) {
+	r := apparmor_sandbox.MockLevel(apparmor_sandbox.Unsupported)
+	defer r()
+	err := interfaces.BeforeConnectPlug(s.iface, s.plug)
+	c.Assert(err, IsNil)
 }
 
 func (s *QrtrInterfaceSuite) TestAppArmorSpec(c *C) {


### PR DESCRIPTION
On systems where AppArmor isn't available, connecting netlink-audit or
qualcomm-ipc-router fails trying to assess the apparmor_parser feature support.
This is not very useful when there is no AppArmor support at all.
