### PR TITLE
o/devicestate: copy timesyncd clock timestamp during install

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -1572,7 +1572,6 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeWritesTimesyncdClockHappy(c *
 	// a month old timestamp file
 	c.Assert(os.Chtimes(clockTsInSrc, now.AddDate(0, -1, 0), now.AddDate(0, -1, 0)), IsNil)
 
-	// pretend we have a cloud-init config on the seed partition
 	s.mockInstallModeChange(c, "dangerous", "")
 
 	s.state.Lock()
@@ -1581,7 +1580,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeWritesTimesyncdClockHappy(c *
 	installSystem := s.findInstallSystem()
 	c.Assert(installSystem, NotNil)
 
-	// and was run successfully
+	// installation was successful
 	c.Check(installSystem.Err(), IsNil)
 	c.Check(installSystem.Status(), Equals, state.DoneStatus)
 
@@ -1610,7 +1609,6 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeWritesTimesyncdClockErr(c *C)
 	c.Assert(os.Chmod(timesyncDirInDst, 0000), IsNil)
 	defer os.Chmod(timesyncDirInDst, 0755)
 
-	// pretend we have a cloud-init config on the seed partition
 	s.mockInstallModeChange(c, "dangerous", "")
 
 	s.state.Lock()
@@ -1619,7 +1617,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeWritesTimesyncdClockErr(c *C)
 	installSystem := s.findInstallSystem()
 	c.Assert(installSystem, NotNil)
 
-	// and was run successfully
+	// install failed copying the timestamp
 	c.Check(installSystem.Err(), ErrorMatches, `(?s).*\(cannot seed timesyncd clock: cannot copy clock:.*Permission denied.*`)
 	c.Check(installSystem.Status(), Equals, state.ErrorStatus)
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -344,7 +344,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("cannot store the model: %v", err)
 	}
 
-	// preserve systemd-timesync clock timestamp, so that RTC-less devices
+	// preserve systemd-timesyncd clock timestamp, so that RTC-less devices
 	// can start with a more recent time on the next boot
 	if err := writeTimesyncdClock(dirs.GlobalRootDir, boot.InstallHostWritableDir); err != nil {
 		return fmt.Errorf("cannot seed timesyncd clock: %v", err)


### PR DESCRIPTION
When in install mode, populate the timesyncd clock timestamp from the host, such
that a system without RTC has something reasonable to start with on the next
boot.

