### PR TITLE
spread: run lxd tests with version from latest/edge

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -35,7 +35,7 @@ environment:
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     MANAGED_DEVICE: "false"
     # a global setting for LXD channel to use in the tests
-    LXD_SNAP_CHANNEL: "latest/stable"
+    LXD_SNAP_CHANNEL: "latest/edge"
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'


### PR DESCRIPTION
Upstream LXD is current broken for nested containers [1]. The lxd team
says this is fixed in latest/edge so let's switch to that for now
until the fix is in beta.

[1] https://github.com/lxc/lxd/issues/9410
