### PR TITLE
data/selinux: allow snap-confine to read udev's database

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -591,6 +591,7 @@ init_read_state(snappy_confine_t)
 
 # libudev
 udev_manage_pid_dirs(snappy_confine_t)
+udev_read_db(snappy_confine_t)
 
 # basic access to system info in /proc
 kernel_read_system_state(snappy_confine_t)


### PR DESCRIPTION
These denials occasionally pop up when snap-confine starts inspecting assigned
devices:

```
----
type=AVC msg=audit(10/28/21 06:54:05.000:11501) : avc:  denied  { read } for  pid=56565 comm=snap-confine name=c1:7 dev="tmpfs" ino=17684 scontext=system_u:system_r:snappy_confine_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=1
----
type=AVC msg=audit(10/28/21 06:54:05.000:11502) : avc:  denied  { open } for  pid=56565 comm=snap-confine path=/run/udev/data/c1:7 dev="tmpfs" ino=17684 scontext=system_u:system_r:snappy_confine_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=1
----
type=AVC msg=audit(10/28/21 06:54:05.000:11503) : avc:  denied  { getattr } for  pid=56565 comm=snap-confine path=/run/udev/data/c1:7 dev="tmpfs" ino=17684 scontext=system_u:system_r:snappy_confine_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=1
-----
```

