### PR TITLE
o/hookstate: print cohort with snapctl refresh --pending

### DIFF
--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -64,7 +64,7 @@ func (s *fdeSetupSuite) SetUpTest(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	mockInstalledSnap(c, s.st, mockFdeSetupKernelYaml)
+	mockInstalledSnap(c, s.st, mockFdeSetupKernelYaml, "")
 	s.mockTask = s.st.NewTask("test-task", "my test task")
 	hooksup := &hookstate.HookSetup{
 		Snap:     "pc-kernel",

--- a/overlord/hookstate/ctlcmd/is_connected_test.go
+++ b/overlord/hookstate/ctlcmd/is_connected_test.go
@@ -134,7 +134,7 @@ var isConnectedTests = []struct {
 	exitCode: ctlcmd.ClassicSnapCode,
 }}
 
-func mockInstalledSnap(c *C, st *state.State, snapYaml string) {
+func mockInstalledSnap(c *C, st *state.State, snapYaml, cohortKey string) {
 	info := snaptest.MockSnapCurrent(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
 	snapstate.Set(st, info.InstanceName(), &snapstate.SnapState{
 		Active: true,
@@ -147,6 +147,7 @@ func mockInstalledSnap(c *C, st *state.State, snapYaml string) {
 		},
 		Current:         info.Revision,
 		TrackingChannel: "stable",
+		CohortKey:       cohortKey,
 	})
 }
 
@@ -165,11 +166,11 @@ slots:
   cc:
     interface: cups-control
   audio-record:
-    interface: audio-record`)
+    interface: audio-record`, "")
 	mockInstalledSnap(c, s.st, `name: snap2
 slots:
   slot2:
-    interface: x11`)
+    interface: x11`, "")
 	mockInstalledSnap(c, s.st, `name: snap3
 plugs:
   plug4:
@@ -178,16 +179,16 @@ plugs:
     interface: cups-control
 slots:
   slot3:
-    interface: x11`)
+    interface: x11`, "")
 	mockInstalledSnap(c, s.st, `name: snap4
 slots:
   slot4:
-    interface: x11`)
+    interface: x11`, "")
 	mockInstalledSnap(c, s.st, `name: snap5
 confinement: classic
 plugs:
   cc:
-    interface: cups-control`)
+    interface: cups-control`, "")
 	restore := ctlcmd.MockCgroupSnapNameFromPid(func(pid int) (string, error) {
 		switch {
 		case 1000 < pid && pid < 1100:
@@ -269,7 +270,7 @@ func (s *isConnectedSuite) TestGetRegularUser(c *C) {
 	mockInstalledSnap(c, s.st, `name: snap1
 plugs:
   plug1:
-    interface: x11`)
+    interface: x11`, "")
 
 	s.st.Set("conns", map[string]interface{}{
 		"snap1:plug1 snap2:slot2": map[string]interface{}{},

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -209,11 +209,11 @@ func getUpdateDetails(context *hookstate.Context) (*updateDetails, error) {
 		Pending: pending,
 	}
 
-	allow, err := hasSnapRefreshControlInterface(st, context.InstanceName())
+	hasRefreshControl, err := hasSnapRefreshControlInterface(st, context.InstanceName())
 	if err != nil {
 		return nil, err
 	}
-	if allow {
+	if hasRefreshControl {
 		up.CohortKey = snapst.CohortKey
 	}
 
@@ -297,11 +297,11 @@ func (c *refreshCommand) proceed() error {
 	// running outside of hook
 	if ctx.IsEphemeral() {
 		st := ctx.State()
-		allow, err := hasSnapRefreshControlInterface(st, ctx.InstanceName())
+		hasRefreshControl, err := hasSnapRefreshControlInterface(st, ctx.InstanceName())
 		if err != nil {
 			return err
 		}
-		if !allow {
+		if !hasRefreshControl {
 			return fmt.Errorf("cannot proceed: requires snap-refresh-control interface")
 		}
 		// we need to check if GateAutoRefreshHook feature is enabled when

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -145,7 +145,7 @@ func (c *refreshCommand) Execute(args []string) error {
 type updateDetails struct {
 	Pending   string `yaml:"pending,omitempty"`
 	Channel   string `yaml:"channel,omitempty"`
-	CohortKey string `yaml:"cohort-key,omitempty"`
+	CohortKey string `yaml:"cohort,omitempty"`
 	Version   string `yaml:"version,omitempty"`
 	Revision  int    `yaml:"revision,omitempty"`
 	// TODO: epoch

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -143,10 +143,11 @@ func (c *refreshCommand) Execute(args []string) error {
 }
 
 type updateDetails struct {
-	Pending  string `yaml:"pending,omitempty"`
-	Channel  string `yaml:"channel,omitempty"`
-	Version  string `yaml:"version,omitempty"`
-	Revision int    `yaml:"revision,omitempty"`
+	Pending   string `yaml:"pending,omitempty"`
+	Channel   string `yaml:"channel,omitempty"`
+	CohortKey string `yaml:"cohort-key,omitempty"`
+	Version   string `yaml:"version,omitempty"`
+	Revision  int    `yaml:"revision,omitempty"`
 	// TODO: epoch
 	Base    bool `yaml:"base"`
 	Restart bool `yaml:"restart"`
@@ -206,6 +207,14 @@ func getUpdateDetails(context *hookstate.Context) (*updateDetails, error) {
 		Base:    base,
 		Restart: restart,
 		Pending: pending,
+	}
+
+	allow, err := hasSnapRefreshControlInterface(st, context.InstanceName())
+	if err != nil {
+		return nil, err
+	}
+	if allow {
+		up.CohortKey = snapst.CohortKey
 	}
 
 	// try to find revision/version/channel info from refresh-candidates; it
@@ -288,7 +297,7 @@ func (c *refreshCommand) proceed() error {
 	// running outside of hook
 	if ctx.IsEphemeral() {
 		st := ctx.State()
-		allow, err := allowRefreshProceedOutsideHook(st, ctx.InstanceName())
+		allow, err := hasSnapRefreshControlInterface(st, ctx.InstanceName())
 		if err != nil {
 			return err
 		}
@@ -318,7 +327,7 @@ func (c *refreshCommand) proceed() error {
 	return nil
 }
 
-func allowRefreshProceedOutsideHook(st *state.State, snapName string) (bool, error) {
+func hasSnapRefreshControlInterface(st *state.State, snapName string) (bool, error) {
 	conns, err := ifacestate.ConnectionStates(st)
 	if err != nil {
 		return false, fmt.Errorf("internal error: cannot get connections: %s", err)

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -372,7 +372,7 @@ version: 1
 	stdout, _, err = ctlcmd.Run(mockContext, []string{"refresh", "--pending"}, 0)
 	c.Assert(err, IsNil)
 	// cohort is printed
-	c.Check(string(stdout), Equals, "pending: none\nchannel: stable\ncohort-key: some-cohort-key\nbase: false\nrestart: false\n")
+	c.Check(string(stdout), Equals, "pending: none\nchannel: stable\ncohort: some-cohort-key\nbase: false\nrestart: false\n")
 }
 
 func (s *refreshSuite) TestPendingWithCohort(c *C) {
@@ -398,7 +398,7 @@ version: 1
 	stdout, _, err := ctlcmd.Run(mockContext, []string{"refresh", "--pending"}, 0)
 	c.Assert(err, IsNil)
 	// cohort is printed
-	c.Check(string(stdout), Equals, "pending: none\nchannel: stable\ncohort-key: some-cohort-key\nbase: false\nrestart: false\n")
+	c.Check(string(stdout), Equals, "pending: none\nchannel: stable\ncohort: some-cohort-key\nbase: false\nrestart: false\n")
 }
 
 func (s *refreshSuite) TestRefreshProceedFromSnapError(c *C) {

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -131,15 +131,15 @@ base: snap1-base
 version: 1
 hooks:
  gate-auto-refresh:
-`)
+`, "")
 	mockInstalledSnap(c, s.st, `name: snap1-base
 type: base
 version: 1
-`)
+`, "")
 	mockInstalledSnap(c, s.st, `name: kernel
 type: kernel
 version: 1
-`)
+`, "")
 	s.st.Unlock()
 
 	for _, test := range refreshFromHookTests {
@@ -182,11 +182,11 @@ base: snap1-base
 version: 1
 hooks:
  gate-auto-refresh:
-`)
+`, "")
 	mockInstalledSnap(c, s.st, `name: snap1-base
 type: base
 version: 1
-`)
+`, "")
 
 	candidates := map[string]interface{}{
 		"snap1-base": mockRefreshCandidate("snap1-base", "edge", "v1", snap.Revision{N: 3}),
@@ -220,7 +220,7 @@ func (s *refreshSuite) TestRefreshProceed(c *C) {
 
 	mockInstalledSnap(c, s.st, `name: foo
 version: 1
-`)
+`, "")
 
 	// pretend snap foo is held initially
 	_, err = snapstate.HoldRefresh(s.st, "snap1", 0, "foo")
@@ -301,7 +301,7 @@ func (s *refreshSuite) TestRefreshProceedFromSnap(c *C) {
 	// note: don't mock the plug, it's enough to have it in conns
 	mockInstalledSnap(c, s.st, `name: foo
 version: 1
-`)
+`, "")
 
 	s.st.Set("conns", map[string]interface{}{
 		"foo:plug core:slot": map[string]interface{}{"interface": "snap-refresh-control"},
@@ -330,7 +330,7 @@ func (s *refreshSuite) TestPendingFromSnapNoRefreshCandidates(c *C) {
 
 	mockInstalledSnap(c, s.st, `name: foo
 version: 1
-`)
+`, "")
 
 	setup := &hookstate.HookSetup{Snap: "foo", Revision: snap.R(1)}
 	mockContext, err := hookstate.NewContext(nil, s.st, setup, nil, "")
@@ -341,6 +341,64 @@ version: 1
 	stdout, _, err := ctlcmd.Run(mockContext, []string{"refresh", "--pending"}, 0)
 	c.Assert(err, IsNil)
 	c.Check(string(stdout), Equals, "pending: none\nchannel: stable\nbase: false\nrestart: false\n")
+}
+
+func (s *refreshSuite) TestPendingFromSnapWithCohort(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	mockInstalledSnap(c, s.st, `name: foo
+version: 1
+`, "some-cohort-key")
+
+	setup := &hookstate.HookSetup{Snap: "foo", Revision: snap.R(1)}
+	mockContext, err := hookstate.NewContext(nil, s.st, setup, nil, "")
+	c.Check(err, IsNil)
+
+	s.st.Unlock()
+	defer s.st.Lock()
+
+	stdout, _, err := ctlcmd.Run(mockContext, []string{"refresh", "--pending"}, 0)
+	c.Assert(err, IsNil)
+	// cohort is not printed if snap-refresh-control isn't connected
+	c.Check(string(stdout), Equals, "pending: none\nchannel: stable\nbase: false\nrestart: false\n")
+
+	s.st.Lock()
+	s.st.Set("conns", map[string]interface{}{
+		"foo:plug core:slot": map[string]interface{}{"interface": "snap-refresh-control"},
+	})
+	s.st.Unlock()
+
+	stdout, _, err = ctlcmd.Run(mockContext, []string{"refresh", "--pending"}, 0)
+	c.Assert(err, IsNil)
+	// cohort is printed
+	c.Check(string(stdout), Equals, "pending: none\nchannel: stable\ncohort-key: some-cohort-key\nbase: false\nrestart: false\n")
+}
+
+func (s *refreshSuite) TestPendingWithCohort(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	mockInstalledSnap(c, s.st, `name: foo
+version: 1
+`, "some-cohort-key")
+
+	task := s.st.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "foo", Revision: snap.R(1), Hook: "gate-auto-refresh"}
+	mockContext, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
+	c.Check(err, IsNil)
+
+	s.st.Set("conns", map[string]interface{}{
+		"foo:plug core:slot": map[string]interface{}{"interface": "snap-refresh-control"},
+	})
+
+	s.st.Unlock()
+	defer s.st.Lock()
+
+	stdout, _, err := ctlcmd.Run(mockContext, []string{"refresh", "--pending"}, 0)
+	c.Assert(err, IsNil)
+	// cohort is printed
+	c.Check(string(stdout), Equals, "pending: none\nchannel: stable\ncohort-key: some-cohort-key\nbase: false\nrestart: false\n")
 }
 
 func (s *refreshSuite) TestRefreshProceedFromSnapError(c *C) {
@@ -355,7 +413,7 @@ func (s *refreshSuite) TestRefreshProceedFromSnapError(c *C) {
 	// note: don't mock the plug, it's enough to have it in conns
 	mockInstalledSnap(c, s.st, `name: foo
 version: 1
-`)
+`, "")
 	s.st.Set("conns", map[string]interface{}{
 		"foo:plug core:slot": map[string]interface{}{"interface": "snap-refresh-control"},
 	})
@@ -389,7 +447,7 @@ func (s *refreshSuite) TestRefreshProceedFromSnapErrorNoSnapRefreshControl(c *C)
 	// note: don't mock the plug, it's enough to have it in conns
 	mockInstalledSnap(c, s.st, `name: foo
 version: 1
-`)
+`, "")
 	s.st.Set("conns", map[string]interface{}{
 		"foo:plug core:slot": map[string]interface{}{
 			"interface": "snap-refresh-control",


### PR DESCRIPTION
Print cohort key with `snapctl refresh --pending` as long as snap-refresh-control interface is connected.
