### PR TITLE
osutil/disks: re-org methods for end of usable region, size information

### DIFF
--- a/osutil/disks/blockdev.go
+++ b/osutil/disks/blockdev.go
@@ -62,7 +62,9 @@ func blockDeviceSectorSize(devpath string) (uint64, error) {
 		return 0, fmt.Errorf("sector size (%d) is not a multiple of 512", sz)
 	}
 	if sz == 0 {
-		// extra paranoia
+		// in some other places we are using the sector size as a divisor (to
+		// convert from bytes to sectors), so it's essential that 0 is treated
+		// as an error
 		return 0, fmt.Errorf("internal error: sector size returned as 0")
 	}
 	return sz, nil

--- a/osutil/disks/blockdev.go
+++ b/osutil/disks/blockdev.go
@@ -59,7 +59,7 @@ func blockDeviceSectorSize(devpath string) (uint64, error) {
 	// when we calculate the size in sectors, as blockdev --getsz always returns
 	// the size in 512-byte sectors
 	if sz%512 != 0 {
-		return 0, fmt.Errorf("cannot calculate structure size: sector size (%d) is not a multiple of 512", sz)
+		return 0, fmt.Errorf("sector size (%d) is not a multiple of 512", sz)
 	}
 	if sz == 0 {
 		// extra paranoia

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -51,10 +51,11 @@ type MockDiskMapping struct {
 	DevNode string
 	DevPath string
 
-	ID              string
-	DiskSchema      string
-	SectorSizeBytes uint64
-	SizeBytes       uint64
+	ID                  string
+	DiskSchema          string
+	SectorSizeBytes     uint64
+	DiskUsableSectorEnd uint64
+	DiskSizeInBytes     uint64
 }
 
 // FindMatchingPartitionUUIDWithFsLabel returns a matching PartitionUUID
@@ -164,8 +165,12 @@ func (d *MockDiskMapping) SectorSize() (uint64, error) {
 	return d.SectorSizeBytes, nil
 }
 
-func (d *MockDiskMapping) LastUsableByte() (uint64, error) {
-	return d.SizeBytes, nil
+func (d *MockDiskMapping) UsableSectorsEnd() (uint64, error) {
+	return d.DiskUsableSectorEnd, nil
+}
+
+func (d *MockDiskMapping) SizeInBytes() (uint64, error) {
+	return d.DiskSizeInBytes, nil
 }
 
 // Mountpoint is a combination of a mountpoint location and whether that


### PR DESCRIPTION
Split off the LastUsableByte function into two methods, SizeInBytes and 
UsableSectorsEnd. The SizeInBytes function returns the most basic, commonly
understood size of a disk, including all regions, even those that are not 
usable by user partitions, etc.

The UsableSectorsEnd method however now essentially returns the last sector of
the disk that cannot be used, such that a partition which is specified as 
occupying [start, end) at the end of the disk can be calculated easily with
this method. 

This also refactors some of the tests to be more clear what they are testing
and test related methods in the same test.