### PR TITLE
tests: enable lxd tests on 21.10 too

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -6,9 +6,8 @@ backends: [-autopkgtest]
 
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
-# TODO: enable for ubuntu-21.10+ once the lxd image is published
 # ubuntu-18.04-32: i386 is not supported by lxd
-systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-20*, ubuntu-21.04-*, ubuntu-core-*]
+systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*]
 
 # Start before anything else as it can take a really long time.
 priority: 1000


### PR DESCRIPTION
We did not run lxd 21.10 tests, time to do this :)
