### PR TITLE
tests: skip lxd test on ubuntu-21.04 due to apparmor issue

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -7,8 +7,9 @@ backends: [-autopkgtest]
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
 # TODO: enable for ubuntu-21.10+ once the lxd image is published
+# TODO: enable for ubuntu-21.04-64 once test is fixed
 # ubuntu-18.04-32: i386 is not supported by lxd
-systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-20*, ubuntu-21.04-*, ubuntu-core-*]
+systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-20*, ubuntu-core-*]
 
 # Start before anything else as it can take a really long time.
 priority: 1000


### PR DESCRIPTION
The test is failing just on 21.04 with several apparmor errors:

snapd.failure.service is a disabled or a static unit, not starting it.
snapd.snap-repair.service is a disabled or a static unit, not starting
it.
Job for snapd.service failed because the control process exited with
error code.
See "systemctl status snapd.service" and "journalctl -xe" for details.
Job for snapd.seeded.service failed because the control process exited
with error code.
See "systemctl status snapd.seeded.service" and "journalctl -xe" for
details.
Processing triggers for dbus (1.12.20-1ubuntu3) ...
Failed to open connection to "system" message bus: Failed to query
AppArmor policy: Permission denied
Processing triggers for man-db (2.9.4-2) ...
Error connecting: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied:
Failed to query AppArmor policy: Permission denied
