### PR TITLE
o/snapstate: clean up snaps after hooks

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -4274,13 +4274,13 @@ func validateRefreshTasks(c *C, tasks []*state.Task, name, revno string, flags i
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Start snap "%s" (%s) services`, name, revno))
 	i++
-	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Clean up "%s" (%s) install`, name, revno))
-	i++
 	if flags&noConfigure == 0 {
 		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Run configure hook of "%s" snap if present`, name))
 		i++
 	}
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Run health check of "%s" snap`, name))
+	i++
+	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Clean up "%s" (%s) install`, name, revno))
 	i++
 	return i
 }

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1803,8 +1803,8 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2(c *C) {
 		"setup-aliases",
 		"run-hook [base-snap-b;post-refresh]",
 		"start-snap-services",
-		"cleanup",
 		"run-hook [base-snap-b;check-health]",
+		"cleanup",
 		"prerequisites",
 		"download-snap",
 		"validate-snap",
@@ -1821,9 +1821,9 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2(c *C) {
 		"setup-aliases",
 		"run-hook [snap-a;post-refresh]",
 		"start-snap-services",
-		"cleanup",
 		"run-hook [snap-a;configure]",
 		"run-hook [snap-a;check-health]",
+		"cleanup",
 		"check-rerefresh",
 	}
 
@@ -1882,9 +1882,9 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2Held(c *C) {
 		"setup-aliases",
 		"run-hook [snap-a;post-refresh]",
 		"start-snap-services",
-		"cleanup",
 		"run-hook [snap-a;configure]",
 		"run-hook [snap-a;check-health]",
+		"cleanup",
 		"check-rerefresh",
 	}
 
@@ -1937,9 +1937,9 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2Proceed(c *C) {
 		"setup-aliases",
 		"run-hook [snap-a;post-refresh]",
 		"start-snap-services",
-		"cleanup",
 		"run-hook [snap-a;configure]",
 		"run-hook [snap-a;check-health]",
+		"cleanup",
 		"check-rerefresh",
 	}
 
@@ -2170,8 +2170,8 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2Conflict(c *C) {
 		"setup-aliases",
 		"run-hook [base-snap-b;post-refresh]",
 		"start-snap-services",
-		"cleanup",
 		"run-hook [base-snap-b;check-health]",
+		"cleanup",
 		"check-rerefresh",
 	}
 	verifyPhasedAutorefreshTasks(c, chg.Tasks(), expected)
@@ -2332,8 +2332,8 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2GatedSnaps(c *C) {
 		"setup-aliases",
 		"run-hook [base-snap-b;post-refresh]",
 		"start-snap-services",
-		"cleanup",
 		"run-hook [base-snap-b;check-health]",
+		"cleanup",
 		"check-rerefresh",
 	}
 	tasks := chg.Tasks()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -451,7 +451,9 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 				retain = 3
 			}
 		}
-		retain-- //  we're adding one
+		if snapst.LastIndex(snapsup.Revision()) == -1 {
+			retain-- //  we're adding one
+		}
 
 		seq := snapst.Sequence
 		currentIndex := snapst.LastIndex(snapst.Current)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -21,12 +21,14 @@ package snapstate_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"time"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
@@ -3383,7 +3385,6 @@ func verifyStopReason(c *C, ts *state.TaskSet, reason string) {
 	err := tl[0].Get("stop-reason", &stopReason)
 	c.Assert(err, IsNil)
 	c.Check(stopReason, Equals, reason)
-
 }
 
 func (s *snapmgrTestSuite) TestUndoMountSnapFailsInCopyData(c *C) {
@@ -4313,4 +4314,91 @@ func (s *snapmgrTestSuite) testRetainCorrectNumRevisions(c *C, installFn install
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
 	c.Assert(snapst.Sequence, DeepEquals, seq)
+}
+func (s *snapmgrTestSuite) TestUndoInstallWithSameRev(c *C) {
+	// different paths to install a revision already stored in the state
+	installFuncs := []installFn{
+		func(si *snap.SideInfo) (*state.TaskSet, error) {
+			yaml := "name: some-snap\nversion: 1.0\nepoch: 1*"
+			path := snaptest.MakeTestSnapWithFiles(c, yaml, nil)
+			ts, _, err := snapstate.InstallPath(s.state, si, path, "some-snap", "", snapstate.Flags{})
+			return ts, err
+		}, func(si *snap.SideInfo) (*state.TaskSet, error) {
+			return snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: si.Revision}, s.user.ID, snapstate.Flags{})
+		},
+	}
+
+	for _, fn := range installFuncs {
+		s.testUndoInstallWithSameRev(c, fn)
+	}
+}
+
+func (s *snapmgrTestSuite) testUndoInstallWithSameRev(c *C, installFn installFn) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// mocks a failing last task
+	s.o.TaskRunner().AddHandler("test-fail", func(task *state.Task, tomb *tomb.Tomb) error {
+		return errors.New("expected: test failure")
+	}, nil)
+
+	// add two revisions, mock the snapstate.Configure to fail, check it failed before and works now
+	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
+
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(2),
+	}
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/stable",
+		Sequence: []*snap.SideInfo{
+			{
+				RealName: "some-snap",
+				SnapID:   "some-snap-id",
+				Revision: snap.R(1),
+			},
+			si},
+		Current:  si.Revision,
+		SnapType: "app",
+	})
+
+	ts, err := installFn(si)
+	c.Assert(err, IsNil)
+	c.Assert(ts, NotNil)
+
+	chg := s.state.NewChange("install", "install a snap")
+	chg.AddAll(ts)
+
+	// mock a hook failure at the end of the end install
+	hookTask := findLastTask(chg, "run-hook")
+	c.Assert(hookTask, NotNil)
+	failTask := s.state.NewTask("test-fail", "")
+	failTask.WaitFor(hookTask)
+
+	chg.AddTask(failTask)
+
+	s.state.Unlock()
+	defer s.state.Lock()
+	s.settle(c)
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// ensure all our tasks ran
+	c.Assert(chg.Err(), NotNil)
+	c.Assert(chg.IsReady(), Equals, true)
+}
+
+func findLastTask(chg *state.Change, kind string) *state.Task {
+	ts := chg.Tasks()
+	for i := len(ts) - 1; i >= 0; i-- {
+		t := ts[i]
+		if t.Kind() == kind {
+			return t
+		}
+	}
+
+	return nil
 }

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -21,14 +21,12 @@ package snapstate_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
@@ -4315,91 +4313,4 @@ func (s *snapmgrTestSuite) testRetainCorrectNumRevisions(c *C, installFn install
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
 	c.Assert(snapst.Sequence, DeepEquals, seq)
-}
-func (s *snapmgrTestSuite) TestUndoInstallWithSameRev(c *C) {
-	// different paths to install a revision already stored in the state
-	installFuncs := []installFn{
-		func(si *snap.SideInfo) (*state.TaskSet, error) {
-			yaml := "name: some-snap\nversion: 1.0\nepoch: 1*"
-			path := snaptest.MakeTestSnapWithFiles(c, yaml, nil)
-			ts, _, err := snapstate.InstallPath(s.state, si, path, "some-snap", "", snapstate.Flags{})
-			return ts, err
-		}, func(si *snap.SideInfo) (*state.TaskSet, error) {
-			return snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: si.Revision}, s.user.ID, snapstate.Flags{})
-		},
-	}
-
-	for _, fn := range installFuncs {
-		s.testUndoInstallWithSameRev(c, fn)
-	}
-}
-
-func (s *snapmgrTestSuite) testUndoInstallWithSameRev(c *C, installFn installFn) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	// mocks a failing last task
-	s.o.TaskRunner().AddHandler("test-fail", func(task *state.Task, tomb *tomb.Tomb) error {
-		return errors.New("expected: test failure")
-	}, nil)
-
-	// add two revisions, mock the snapstate.Configure to fail, check it failed before and works now
-	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
-
-	si := &snap.SideInfo{
-		RealName: "some-snap",
-		SnapID:   "some-snap-id",
-		Revision: snap.R(2),
-	}
-
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:          true,
-		TrackingChannel: "latest/stable",
-		Sequence: []*snap.SideInfo{
-			{
-				RealName: "some-snap",
-				SnapID:   "some-snap-id",
-				Revision: snap.R(1),
-			},
-			si},
-		Current:  si.Revision,
-		SnapType: "app",
-	})
-
-	ts, err := installFn(si)
-	c.Assert(err, IsNil)
-	c.Assert(ts, NotNil)
-
-	chg := s.state.NewChange("install", "install a snap")
-	chg.AddAll(ts)
-
-	// mock a hook failure at the end of the end install
-	hookTask := findLastTask(chg, "run-hook")
-	c.Assert(hookTask, NotNil)
-	failTask := s.state.NewTask("test-fail", "")
-	failTask.WaitFor(hookTask)
-
-	chg.AddTask(failTask)
-
-	s.state.Unlock()
-	defer s.state.Lock()
-	s.settle(c)
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	// ensure all our tasks ran
-	c.Assert(chg.Err(), NotNil)
-	c.Assert(chg.IsReady(), Equals, true)
-}
-
-func findLastTask(chg *state.Change, kind string) *state.Task {
-	ts := chg.Tasks()
-	for i := len(ts) - 1; i >= 0; i-- {
-		t := ts[i]
-		if t.Kind() == kind {
-			return t
-		}
-	}
-
-	return nil
 }

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4246,3 +4246,71 @@ func (s *snapmgrTestSuite) TestInstallDeduplicatesSnapNames(c *C) {
 	c.Check(installed, testutil.DeepUnsortedMatches, []string{"some-snap", "some-base"})
 	c.Check(ts, HasLen, 2)
 }
+
+type installFn func(info *snap.SideInfo) (*state.TaskSet, error)
+
+func (s *snapmgrTestSuite) TestCorrectNumRevisionsIfNoneAdded(c *C) {
+	// different paths to install a revision already stored in the state
+	installFuncs := []installFn{
+		func(si *snap.SideInfo) (*state.TaskSet, error) {
+			yaml := "name: some-snap\nversion: 1.0\nepoch: 1*"
+			path := snaptest.MakeTestSnapWithFiles(c, yaml, nil)
+			ts, _, err := snapstate.InstallPath(s.state, si, path, "some-snap", "", snapstate.Flags{})
+			return ts, err
+		}, func(si *snap.SideInfo) (*state.TaskSet, error) {
+			return snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: si.Revision}, s.user.ID, snapstate.Flags{})
+		},
+	}
+
+	for _, fn := range installFuncs {
+		s.testRetainCorrectNumRevisions(c, fn)
+	}
+}
+
+func (s *snapmgrTestSuite) testRetainCorrectNumRevisions(c *C, installFn installFn) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	seq := []*snap.SideInfo{{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(1),
+	}, {
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(2),
+	}}
+	curInfo := seq[len(seq)-1]
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/stable",
+		Sequence:        seq,
+		Current:         curInfo.Revision,
+		SnapType:        "app",
+	})
+
+	// the default is also 2 but this makes the test more robust against changes
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "refresh.retain", 2), IsNil)
+	tr.Commit()
+
+	// install already stored revision
+	ts, err := installFn(curInfo)
+	c.Assert(err, IsNil)
+	c.Assert(ts, NotNil)
+	chg := s.state.NewChange("install", "")
+	chg.AddAll(ts)
+
+	s.state.Unlock()
+	defer s.state.Lock()
+	s.settle(c)
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(chg.Err(), IsNil)
+
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, "some-snap", &snapst)
+	c.Assert(err, IsNil)
+	c.Assert(snapst.Sequence, DeepEquals, seq)
+}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -6155,7 +6155,6 @@ func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnRefresh(c *C) {
 
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh|updatesGadget, 0, ts, s.state)
-
 }
 
 func (s *snapmgrTestSuite) TestForSnapSetupResetsFlags(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -96,6 +96,10 @@ func verifyUpdateTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.St
 		"start-snap-services")
 
 	c.Assert(ts.Tasks()[len(expected)-2].Summary(), Matches, `Run post-refresh hook of .*`)
+	expected = append(expected,
+		"run-hook[configure]",
+		"run-hook[check-health]",
+	)
 	for i := 0; i < discards; i++ {
 		expected = append(expected,
 			"clear-snap",
@@ -107,14 +111,9 @@ func verifyUpdateTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.St
 			"cleanup",
 		)
 	}
-	expected = append(expected,
-		"run-hook[configure]",
-		"run-hook[check-health]",
-	)
 	if opts&doesReRefresh != 0 {
 		expected = append(expected, "check-rerefresh")
 	}
-
 	c.Assert(kinds, DeepEquals, expected)
 }
 
@@ -301,13 +300,13 @@ func (s *snapmgrTestSuite) TestUpdateTasksWithOldCurrent(c *C) {
 	var snapsup snapstate.SnapSetup
 	tasks := ts.Tasks()
 
-	i := len(tasks) - 8
+	i := len(tasks) - 6
 	c.Check(tasks[i].Kind(), Equals, "clear-snap")
 	err = tasks[i].Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Check(snapsup.Revision(), Equals, si3.Revision)
 
-	i = len(tasks) - 6
+	i = len(tasks) - 4
 	c.Check(tasks[i].Kind(), Equals, "clear-snap")
 	err = tasks[i].Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
@@ -5650,8 +5649,9 @@ set-auto-aliases: Hold
 setup-aliases: Hold
 run-hook: Hold
 start-snap-services: Hold
-cleanup: Hold
-run-hook: Hold`)
+run-hook: Hold
+run-hook: Hold
+cleanup: Hold`)
 	c.Check(errSig, Matches, `(?sm)snap-install:
 prerequisites: Undo
  snap-setup: "some-snap"
@@ -5666,8 +5666,9 @@ set-auto-aliases: Hold
 setup-aliases: Hold
 run-hook: Hold
 start-snap-services: Hold
-cleanup: Hold
-run-hook: Hold`)
+run-hook: Hold
+run-hook: Hold
+cleanup: Hold`)
 
 	// run again with empty "ubuntu-core-transition-retry"
 	s.state.Set("ubuntu-core-transition-retry", 0)


### PR DESCRIPTION
Since undoLinkSnap expects Sequence to be the same length, remove revisions as late as possible so that there's less chance of having to undo after Sequence was shortened. 
Maybe there should be an additional check in undoLinkSnap (and anywhere else where there are similar assumptions). Not sure what the special behavior should be though

Blocked by https://github.com/snapcore/snapd/pull/10987