### PR TITLE
tests: give nbd0 more time to show up in preseed-lxd

### DIFF
--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -25,7 +25,7 @@ prepare: |
   # stdin/stdout it would otherwise inherit from the spread session.
   systemd-run --system --service-type=forking --unit=qemu-nbd-preseed.service "$(command -v qemu-nbd)" --fork -c /dev/nbd0 "$(pwd)/cloudimg.img"
   # nbd0p1 may take a short while to become available
-  retry -n 5 --wait 1 test -e /dev/nbd0p1
+  retry -n 30 --wait 1 test -e /dev/nbd0p1
   mkdir -p "$IMAGE_MOUNTPOINT"
   mount /dev/nbd0p1 "$IMAGE_MOUNTPOINT"
 
@@ -58,7 +58,7 @@ restore: |
 
   # qemu-nbd -d may sporadically fail when removing the device,
   # reporting it's still in use.
-  retry -n 5 --wait 1 qemu-nbd -d /dev/nbd0
+  retry -n 30 --wait 1 qemu-nbd -d /dev/nbd0
 
   "$TESTSTOOLS"/lxd-state undo-mount-changes
 


### PR DESCRIPTION
There were some failures in spread because /dev/nbd0p1 does not
appear. To ensure it's not a timing bug incrase the time from 5s
to 30s.
