### PR TITLE
tests: disable flaky "interfaces-udisks2" on ubuntu-18.04-32

### DIFF
--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -6,7 +6,9 @@ details: |
 # Interfaces not defined for ubuntu core systems
 # FIXME: `udisksctl mount -b  "$device"` fails on arch with:
 #   Object /org/freedesktop/UDisks2/block_devices/loop200 is not a mountable filesystem.
-systems: [-ubuntu-core-*, -arch-linux-*]
+# 2021-11-02: disabled ubuntu-18.04-32 because it keeps failing when trying
+#             to create/use /dev/loop200
+systems: [-ubuntu-core-*, -arch-linux-*, -ubuntu-18.04-32]
 
 environment:
     FS_PATH: "$(pwd)/dev0-fake0"


### PR DESCRIPTION
This test keeps failing when it tires to mount /dev/loop200. Maybe
we run out of loop devices?
