### PR TITLE
o/snapstate: do not prune refresh-candidates if gate-auto-refresh-hook feature is not enabled

### DIFF
--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1704,6 +1704,11 @@ func (s *snapmgrTestSuite) testAutoRefreshPhase2(c *C, beforePhase1 func(), gate
 	st.Lock()
 	defer st.Unlock()
 
+	// enable gate-auto-refresh-hook feature
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
+	tr.Commit()
+
 	s.o.TaskRunner().AddHandler("run-hook", func(t *state.Task, tomb *tomb.Tomb) error {
 		var hsup hookstate.HookSetup
 		t.State().Lock()
@@ -2237,6 +2242,11 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2GatedSnaps(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
+
+	// enable gate-auto-refresh-hook feature
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
+	tr.Commit()
 
 	restore := snapstate.MockSnapsToRefresh(func(gatingTask *state.Task) ([]*snapstate.RefreshCandidate, error) {
 		c.Assert(gatingTask.Kind(), Equals, "conditional-auto-refresh")

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -202,15 +202,16 @@ func pruneRefreshCandidates(st *state.State, snaps ...string) error {
 	if err != nil && !config.IsNoOption(err) {
 		return err
 	}
-	// do nothing if gate-auto-refresh-hook feature is not enabled.
-	// this acts as a workaround for the case where a snapd from edge was
-	// used and created refresh-candidates in the old format (an array) with the
-	// feature enabled, but the feature was then disabled so the new map format
-	// will never make it into the state. When the feature is enabled then
-	// auto-refresh code will re-initialize refresh-candidates in the correct format
-	// expected here.
+	// Remove refresh-candidates from state if gate-auto-refresh-hook feature is
+	// not enabled. This acts as a workaround for the case where a snapd from
+	// edge was used and created refresh-candidates in the old format (an array)
+	// with the feature enabled, but the feature was then disabled so the new
+	// map format will never make it into the state.
+	// When the feature is enabled then auto-refresh code will re-initialize
+	// refresh-candidates in the correct format expected here.
 	// See https://forum.snapcraft.io/t/cannot-r-emove-snap-json-cannot-unmarshal-array-into-go-value-of-type-map-string-snapstate-refreshcandidate/27276
 	if !gateAutoRefreshHook {
+		st.Set("refresh-candidates", nil)
 		return nil
 	}
 

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -23,8 +23,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -195,9 +197,26 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 // pruneRefreshCandidates removes the given snaps from refresh-candidates map
 // in the state.
 func pruneRefreshCandidates(st *state.State, snaps ...string) error {
+	tr := config.NewTransaction(st)
+	gateAutoRefreshHook, err := features.Flag(tr, features.GateAutoRefreshHook)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	// do nothing if gate-auto-refresh-hook feature is not enabled.
+	// this acts as a workaround for the case where a snapd from edge was
+	// used and created refresh-candidates in the old format (an array) with the
+	// feature enabled, but the feature was then disabled so the new map format
+	// will never make it into the state. When the feature is enabled then
+	// auto-refresh code will re-initialize refresh-candidates in the correct format
+	// expected here.
+	// See https://forum.snapcraft.io/t/cannot-r-emove-snap-json-cannot-unmarshal-array-into-go-value-of-type-map-string-snapstate-refreshcandidate/27276
+	if !gateAutoRefreshHook {
+		return nil
+	}
+
 	var candidates map[string]*refreshCandidate
 
-	err := st.Get("refresh-candidates", &candidates)
+	err = st.Get("refresh-candidates", &candidates)
 	if err != nil {
 		if err == state.ErrNoState {
 			return nil

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -409,14 +409,9 @@ func (s *refreshHintsTestSuite) TestPruneRefreshCandidatesIncorrectFormat(c *C) 
 
 	// it doesn't fail as long as experimental.gate-auto-refresh-hook is not enabled
 	c.Assert(snapstate.PruneRefreshCandidates(st, "snap-a"), IsNil)
-
-	// enable gate-auto-refresh-hook feature
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
-	tr.Commit()
-
-	// and fails when experimental.gate-auto-refresh-hook is enabled
-	c.Assert(snapstate.PruneRefreshCandidates(st, "snap-a"), ErrorMatches, `internal error: could not unmarshal state entry "refresh-candidates".*`)
+	var data interface{}
+	// and refresh-candidates has been removed from the state
+	c.Check(st.Get("refresh-candidates", data), Equals, state.ErrNoState)
 }
 
 func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongArch(c *C) {

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -334,6 +335,11 @@ func (s *refreshHintsTestSuite) TestPruneRefreshCandidates(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
+	// enable gate-auto-refresh-hook feature
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
+	tr.Commit()
+
 	// check that calling PruneRefreshCandidates when there is nothing to do is fine.
 	c.Assert(snapstate.PruneRefreshCandidates(st, "some-snap"), IsNil)
 
@@ -388,6 +394,29 @@ func (s *refreshHintsTestSuite) TestPruneRefreshCandidates(c *C) {
 	c.Check(ok, Equals, false)
 	_, ok = candidates3["snap-c"]
 	c.Check(ok, Equals, true)
+}
+
+func (s *refreshHintsTestSuite) TestPruneRefreshCandidatesIncorrectFormat(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// bad format - an array
+	candidates := []*snapstate.RefreshCandidate{{
+		SnapSetup: snapstate.SnapSetup{Type: "app", SideInfo: &snap.SideInfo{RealName: "snap-a", Revision: snap.R(1)}},
+	}}
+	st.Set("refresh-candidates", candidates)
+
+	// it doesn't fail as long as experimental.gate-auto-refresh-hook is not enabled
+	c.Assert(snapstate.PruneRefreshCandidates(st, "snap-a"), IsNil)
+
+	// enable gate-auto-refresh-hook feature
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
+	tr.Commit()
+
+	// and fails when experimental.gate-auto-refresh-hook is enabled
+	c.Assert(snapstate.PruneRefreshCandidates(st, "snap-a"), ErrorMatches, `internal error: could not unmarshal state entry "refresh-candidates".*`)
 }
 
 func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongArch(c *C) {

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -1600,6 +1600,11 @@ func (s *snapmgrTestSuite) TestRemovePrunesRefreshGatingDataOnLastRevision(c *C)
 	st.Lock()
 	defer st.Unlock()
 
+	// enable gate-auto-refresh-hook feature
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
+	tr.Commit()
+
 	for _, sn := range []string{"some-snap", "another-snap", "foo-snap"} {
 		si := snap.SideInfo{
 			RealName: sn,


### PR DESCRIPTION
Do not prune refresh-candidates if gate-auto-refresh-hook feature is not enabled. This makes it symmetrical with auto-refresh logic which only overwrites refresh-candidates state entry if that feature is enabled.  This is a workaround for a case where snapd from edge was used and  created the entry using "old" array format; the format was later 
changed to a  map, but if in the meantime the feature got disabled, the new format  would never be written to the state by auto-refresh, so pruning code  would always fail trying to unmarshal refresh-candidates in the old format.

Related: https://forum.snapcraft.io/t/cannot-r-emove-snap-json-cannot-unmarshal-array-into-go-value-of-type-map-string-snapstate-refreshcandidate/27276