### PR TITLE
 cmd/snap-confine: lazy set up of device cgroup, only when devices were assigned (2.53)

### DIFF
--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -237,26 +237,26 @@ static void sc_cleanup_udev_enumerate(struct udev_enumerate **enumerate)
  * when the binary itself is build with recent enough toolchain (eg. gcc &
  * binutils on Ubuntu 20.04)
  */
-static int (*__sc_udev_device_has_current_tag)(struct udev_device *udev_device,
-											   const char *tag) = NULL;
+static int (*__sc_udev_device_has_current_tag)(struct udev_device * udev_device,
+					       const char *tag) = NULL;
 static void setup_current_tags_support(void)
 {
-    void *lib = dlopen("libudev.so.1", RTLD_NOW);
-    if (lib == NULL) {
-        debug("cannot load libudev.so.1: %s", dlerror());
-        /* bit unexpected as we use the library from the host and it's stable */
-        return;
-    }
-    /* check whether we have the symbol introduced in systemd v247 to inspect
-     * the CURRENT_TAGS property */
-    void *sym = dlsym(lib, "udev_device_has_current_tag");
-    if (sym == NULL) {
-        debug("cannot find current tags symbol: %s", dlerror());
-        /* symbol is not found in the library version */
-        return;
-    }
-    debug("libudev has current tags support");
-    __sc_udev_device_has_current_tag = sym;
+	void *lib = dlopen("libudev.so.1", RTLD_NOW);
+	if (lib == NULL) {
+		debug("cannot load libudev.so.1: %s", dlerror());
+		/* bit unexpected as we use the library from the host and it's stable */
+		return;
+	}
+	/* check whether we have the symbol introduced in systemd v247 to inspect
+	 * the CURRENT_TAGS property */
+	void *sym = dlsym(lib, "udev_device_has_current_tag");
+	if (sym == NULL) {
+		debug("cannot find current tags symbol: %s", dlerror());
+		/* symbol is not found in the library version */
+		return;
+	}
+	debug("libudev has current tags support");
+	__sc_udev_device_has_current_tag = sym;
 }
 
 void sc_setup_device_cgroup(const char *security_tag)

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -345,8 +345,8 @@ void sc_setup_device_cgroup(const char *security_tag)
 		}
 
 		if (cgroup == NULL) {
-			/* initialize cgroup wrapper only know when we are sure that there
-			 * are devices assigned to this snap */
+			/* initialize cgroup wrapper only when we are sure that there are
+			 * devices assigned to this snap */
 			cgroup = sc_device_cgroup_new(security_tag, 0);
 			/* Setup the device group access control list */
 			sc_udev_setup_acls_common(cgroup);
@@ -360,8 +360,8 @@ void sc_setup_device_cgroup(const char *security_tag)
 		debug
 		    ("associated snap application process %i with device cgroup %s",
 		     getpid(), security_tag);
-		return;
+	} else {
+		debug("no devices tagged with %s, skipping device cgroup setup",
+		      udev_tag);
 	}
-	debug("no devices tagged with %s, skipping device cgroup setup",
-	      udev_tag);
 }

--- a/tests/main/security-dev-input-event-denied/task.yaml
+++ b/tests/main/security-dev-input-event-denied/task.yaml
@@ -76,13 +76,9 @@ execute: |
     echo "Then the snap is not able to access an evdev keyboard"
     retry -n 5 --wait 1 sh -c '! test-snapd-event "-event-kbd" 2> call.error'
 
-    if os.query is-hirsute || os.query is-impish; then
-        # Cgroups is 'Operation not permitted' which is expected with default policy
-        MATCH "Operation not permitted" < call.error
-    else
-        # AppArmor is 'Permission denied' which is expected with default policy
-        MATCH "Permission denied" < call.error
-    fi
+    # AppArmor is 'Permission denied' which is expected with default policy, and
+    # the AppArmor LSM being evaluated first
+    MATCH "Permission denied" < call.error
 
     echo "When the device-buttons plug is connected"
     snap connect test-snapd-event:device-buttons
@@ -95,5 +91,6 @@ execute: |
 
     # device cgroup is 'Operation not permitted' which is expected when the
     # device-buttons interface is connected since a keyboard shouldn't be added
-    # to the device cgroup.
+    # to the device cgroup. Even though AppArmor path-based permissions allow
+    # access to given device, it still gets blocked by device cgroup filtering.
     MATCH "Operation not permitted" < call.error


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/10968 for 2.53 