### PR TITLE
snapstate: add debug message where a snap is mounted

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -876,6 +876,7 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	for i := 0; i < 10; i++ {
 		_, readInfoErr = readInfo(snapsup.InstanceName(), snapsup.SideInfo, errorOnBroken)
 		if readInfoErr == nil {
+			logger.Debugf("snap %q (%v) available at %q", snapsup.InstanceName(), snapsup.Revision(), snapsup.placeInfo().MountDir())
 			break
 		}
 		if _, ok := readInfoErr.(*snap.NotFoundError); !ok {


### PR DESCRIPTION
When debugging the test failure in LP:1949506 I ran into the issue
that the test fails with:
```
2021-10-27T14:53:31.6448594Z Oct 27 14:53:29 oct271439-116856 snapd[9755]: snapmgr.go:303: cannot read snap info of snap "disabled-svcs-kept" at revision x4: cannot find installed snap "disabled-svcs-kept" at revision x4: missing file /snap/disabled-svcs-kept/x4/meta/snap.yaml
```
but there is no indication that the mount failed. Yet the mount
for "x4" is not available and the exiting debug message yield not
enough data to see what happend. The mount task was there but it
is unclear if maybe some error handling in there is wrong or if
it was mounted to the wrong place etc. Hence this new debug line.

