### PR TITLE
spread.yaml: show `journalctl -e` for all suites on debug

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -505,6 +505,8 @@ debug-each: |
         ps axl
         echo "# /var/lib/snapd"
         find /var/lib/snapd/ -not -path '/var/lib/snapd/snap/*' -ls || true
+        echo '# system journal messages'
+        journalctl -e
     fi
 
 rename:
@@ -729,7 +731,6 @@ suites:
         debug: |
             if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
                 systemctl status snapd.socket || true
-                journalctl -e
             fi
     tests/core/:
         summary: Subset of Ubuntu Core specific tests


### PR DESCRIPTION
Rigt now we only show `journalctl -e` in the main spread suite.
However during debugging of LP:#1949511 it turned out that this
is not ideal because there was a failure like:
```
2021-11-02T10:53:19.0115499Z ##[error]2021-11-02 10:53:19 Error executing google:ubuntu-core-18-64:tests/core/snapd-refresh-vs-services-reboots (nov021031-469292) :
2021-11-02T10:53:19.0144305Z -----
2021-11-02T10:53:19.0145250Z + os.query is-pc-amd64
2021-11-02T10:53:19.0146770Z + '[' 0 = 0 ']'
2021-11-02T10:53:19.0148966Z + snap pack test-snapd-svc-flip-flop --filename=app.snap
2021-11-02T10:53:19.0150087Z built: app.snap
2021-11-02T10:53:19.0151186Z + snap install --dangerous app.snap
2021-11-02T10:53:19.0152138Z error: cannot perform the following tasks:
2021-11-02T10:53:19.0160635Z - Start snap "test-snapd-svc-flip-flop" (unset) services ([start snap.test-snapd-svc-flip-flop.svc1.service] failed with exit status 1: A dependency job for snap.test-snapd-svc-flip-flop.svc1.service failed. See 'journalctl -xe' for details.
2021-11-02T10:53:19.0163484Z )
```
But without the `journalctl -e` output it's unclear what exactly
happend and because this failed on core this is missing.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
