### PR TITLE
tests: increase timeout/add debug around nbd0 mounting

### DIFF
--- a/tests/lib/preseed.sh
+++ b/tests/lib/preseed.sh
@@ -17,7 +17,11 @@ mount_ubuntu_image() {
     # stdin/stdout it would otherwise inherit from the spread session.
     systemd-run --system --service-type=forking --unit=qemu-nbd-preseed.service "$(command -v qemu-nbd)" --fork -c /dev/nbd0 "$CLOUD_IMAGE"
     # nbd0p1 may take a short while to become available
-    retry -n 15 --wait 1 test -e /dev/nbd0p1
+    if ! retry -n 30 --wait 1 test -e /dev/nbd0p1; then
+        echo "ERROR: /dev/nbd0p1 did not show up"
+        journalctl -u qemu-nbd-preseed.service
+        exit 1
+    fi
     mount /dev/nbd0p1 "$IMAGE_MOUNTPOINT"
     mount -t proc /proc "$IMAGE_MOUNTPOINT/proc"
     mount -t sysfs sysfs "$IMAGE_MOUNTPOINT/sys"

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -25,7 +25,11 @@ prepare: |
   # stdin/stdout it would otherwise inherit from the spread session.
   systemd-run --system --service-type=forking --unit=qemu-nbd-preseed.service "$(command -v qemu-nbd)" --fork -c /dev/nbd0 "$(pwd)/cloudimg.img"
   # nbd0p1 may take a short while to become available
-  retry -n 30 --wait 1 test -e /dev/nbd0p1
+  if ! retry -n 30 --wait 1 test -e /dev/nbd0p1; then
+        echo "ERROR: /dev/nbd0p1 did not show up"
+        journalctl -u qemu-nbd-preseed.service
+        exit 1
+  fi
   mkdir -p "$IMAGE_MOUNTPOINT"
   mount /dev/nbd0p1 "$IMAGE_MOUNTPOINT"
 


### PR DESCRIPTION
The nbd0 mount for the preseed test sometimes does not show
up, see LP:#1949513
```
...
2021-11-01T15:38:19.3281867Z + modprobe nbd
2021-11-01T15:38:19.3282497Z ++ command -v qemu-nbd
2021-11-01T15:38:19.3284212Z + systemd-run --system --service-type=forking --unit=qemu-nbd-preseed.service /usr/bin/qemu-nbd --fork -c /dev/nbd0 /home/gopath/src/github.com/snapcore/snapd/tests/main/preseed-reset/cloudimg.img
2021-11-01T15:38:19.3285956Z Running as unit: qemu-nbd-preseed.service
2021-11-01T15:38:19.3286886Z + retry -n 15 --wait 1 test -e /dev/nbd0p1
2021-11-01T15:38:19.3287721Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3288730Z retry: next attempt in 1.0 second(s) (attempt 1 of 15)
2021-11-01T15:38:19.3289674Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3290350Z retry: next attempt in 1.0 second(s) (attempt 2 of 15)
2021-11-01T15:38:19.3291345Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3291992Z retry: next attempt in 1.0 second(s) (attempt 3 of 15)
2021-11-01T15:38:19.3292977Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3293746Z retry: next attempt in 1.0 second(s) (attempt 4 of 15)
2021-11-01T15:38:19.3294728Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3295450Z retry: next attempt in 1.0 second(s) (attempt 5 of 15)
2021-11-01T15:38:19.3296313Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3296998Z retry: next attempt in 1.0 second(s) (attempt 6 of 15)
2021-11-01T15:38:19.3297861Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3298556Z retry: next attempt in 1.0 second(s) (attempt 7 of 15)
2021-11-01T15:38:19.3299444Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3300122Z retry: next attempt in 1.0 second(s) (attempt 8 of 15)
2021-11-01T15:38:19.3301001Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3301769Z retry: next attempt in 1.0 second(s) (attempt 9 of 15)
2021-11-01T15:38:19.3302619Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3303517Z retry: next attempt in 1.0 second(s) (attempt 10 of 15)
2021-11-01T15:38:19.3304482Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3305173Z retry: next attempt in 1.0 second(s) (attempt 11 of 15)
2021-11-01T15:38:19.3306038Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3306728Z retry: next attempt in 1.0 second(s) (attempt 12 of 15)
2021-11-01T15:38:19.3307600Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3308295Z retry: next attempt in 1.0 second(s) (attempt 13 of 15)
2021-11-01T15:38:19.3309176Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3310232Z retry: next attempt in 1.0 second(s) (attempt 14 of 15)
2021-11-01T15:38:19.3311359Z retry: command test -e /dev/nbd0p1 failed with code 1
2021-11-01T15:38:19.3312340Z retry: command test -e /dev/nbd0p1 keeps failing after 15 attempts
2021-11-01T15:38:19.3313086Z -----
```

This commit increases the timeout to consistent 30s and if it still
fails add code to show the status of the systemd unit that is
responsible for this device to show up.
