### PR TITLE
tests: give interfaces-udisks2 more time for the loop device to appear

### DIFF
--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -46,7 +46,7 @@ execute: |
 
     # We retry because there is a race with the device becoming
     # registered by udisks2. The issue can be easily reproduced on ubuntu-20.04
-    retry -n 3 --wait 1 sh -c "test-snapd-udisks2.udisksctl mount -b \"$device\" -t ext4 | MATCH 'Mounted /dev/'"
+    retry -n 15 --wait 1 sh -c "test-snapd-udisks2.udisksctl mount -b \"$device\" -t ext4 | MATCH 'Mounted /dev/'"
     test-snapd-udisks2.udisksctl unmount -b "$device" | MATCH "Unmounted /dev/"
 
     if [ "$(snap debug confinement)" = partial ] ; then


### PR DESCRIPTION
The test fails regularly with:
```
2021-11-02T20:35:10.3649857Z ++ losetup -j /home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-udisks2/dev0-fake0
2021-11-02T20:35:10.3652953Z + device=/dev/loop200
2021-11-02T20:35:10.3656188Z + retry -n 3 --wait 1 sh -c 'test-snapd-udisks2.udisksctl mount -b "/dev/loop200" -t ext4 | MATCH '\''Mounted /dev/'\'''
2021-11-02T20:35:10.3658850Z Error looking up object for device /dev/loop200
2021-11-02T20:35:10.3660405Z grep error: pattern not found, got:
2021-11-02T20:35:10.3661382Z
2021-11-02T20:35:10.3662638Z Error looking up object for device /dev/loop200
2021-11-02T20:35:10.3664163Z grep error: pattern not found, got:
2021-11-02T20:35:10.3665133Z
2021-11-02T20:35:10.3666746Z Error looking up object for device /dev/loop200
2021-11-02T20:35:10.3668381Z grep error: pattern not found, got:
2021-11-02T20:35:10.3669363Z
...
```
so give it more time to see if that helps.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
