### PR TITLE
tests: initialize CHANGE_ID in _wait_autorefresh

### DIFF
--- a/tests/lib/tools/snapd-state
+++ b/tests/lib/tools/snapd-state
@@ -75,6 +75,7 @@ _wait_autorefresh(){
     local RETRIES="$2"
     local CHECK_MESSAGE="$3"
 
+    CHANGE_ID="$LAST_CHANGE_ID"
     for _ in $(seq "$RETRIES"); do
       # get last 2 lines of snap changes (the last one is always empty), match
       # auto-refresh change; only proceed if the change has greater change id


### PR DESCRIPTION
There was a failure in the snapd tests:
```
...
2021-11-02T16:55:11.8447301Z ++ /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/snapd-state wait-for-autorefresh 19
2021-11-02T16:55:11.8449962Z /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/snapd-state: line 92: [: : integer expression expected
...
```
and then a subsequent failure. Looking at snapd-state it seems like
the above failure will happen if _wait_autorefresh() times out. In
this case CHANGE_ID is never set and the line:
```
if [ "$LAST_CHANGE_ID" -eq "$CHANGE_ID" ]; then
```
errors because CHANGE_ID is never initialized and empty.

This commit initializes it which prevents this error.