### PR TITLE
sandbox/cgroup: freeze and thaw cgroups related to services and scopes only

### DIFF
--- a/sandbox/cgroup/freezer.go
+++ b/sandbox/cgroup/freezer.go
@@ -150,6 +150,11 @@ func applyToSnap(snapName string, action func(groupName string) error, skipError
 		if !strings.HasPrefix(info.Name(), canary) {
 			return nil
 		}
+		// snap applications end up inside a cgroup related to a
+		// service, or when ran standalone, a scope
+		if ext := filepath.Ext(info.Name()); ext != ".scope" && ext != ".service" {
+			return nil
+		}
 		// found a group
 		if err := action(name); err != nil && !skipError(err) {
 			return err


### PR DESCRIPTION
When freezing and thawing cgroups related to a snap, the code would incorrectly
try to operate on cgroups related to mounts, socket, slices if they had the
snap.<name>.<app> prefix.

