### PR TITLE
tests: add `--debug` to netplan apply

### DIFF
--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -52,8 +52,7 @@ execute: |
         snap connect netplan-snap:network-setup-control
 
         # sometimes the systems becomes unreachable after "netplan apply"
-        # (see LP:1949708), adding this debug line might give us clues why
-        netplan-snap.netplan get --debug
+        # (see LP:1949708), adding --debug might give us clues why
         echo "Running netplan apply now works"
         if ! netplan-snap.netplan --debug apply; then
             echo "Unexpected error running netplan apply"

--- a/tests/core/netplan/task.yaml
+++ b/tests/core/netplan/task.yaml
@@ -51,8 +51,11 @@ execute: |
         echo "When the interface is connected"
         snap connect netplan-snap:network-setup-control
 
+        # sometimes the systems becomes unreachable after "netplan apply"
+        # (see LP:1949708), adding this debug line might give us clues why
+        netplan-snap.netplan get --debug
         echo "Running netplan apply now works"
-        if ! netplan-snap.netplan apply; then
+        if ! netplan-snap.netplan --debug apply; then
             echo "Unexpected error running netplan apply"
             exit 1
         fi


### PR DESCRIPTION
The netplan test is a bit flaky (see LP:1949708 for details). To
get a better understanding what is going this commit adds a
--debug to netplan apply to see what it is about to do and also
a `netplan get` before the apply so that even if netplan apply
cuts the network connections early we still see what is going on.

