### PR TITLE
tests: add more debug around qemu-nbd

### DIFF
--- a/tests/lib/preseed.sh
+++ b/tests/lib/preseed.sh
@@ -15,11 +15,12 @@ mount_ubuntu_image() {
 
     # Run qemu-nbd as a service, so that it does not interact with ssh
     # stdin/stdout it would otherwise inherit from the spread session.
-    systemd-run --system --service-type=forking --unit=qemu-nbd-preseed.service "$(command -v qemu-nbd)" --fork -c /dev/nbd0 "$CLOUD_IMAGE"
+    systemd-run --system --service-type=forking --unit=qemu-nbd-preseed.service "$(command -v qemu-nbd)" -v --fork -c /dev/nbd0 "$CLOUD_IMAGE"
     # nbd0p1 may take a short while to become available
     if ! retry -n 30 --wait 1 test -e /dev/nbd0p1; then
         echo "ERROR: /dev/nbd0p1 did not show up"
         journalctl -u qemu-nbd-preseed.service
+        find /dev/ -name "nbd0*" -ls        
         exit 1
     fi
     mount /dev/nbd0p1 "$IMAGE_MOUNTPOINT"

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -23,11 +23,13 @@ prepare: |
 
   # Run qemu-nbd as a service, so that it does not interact with ssh
   # stdin/stdout it would otherwise inherit from the spread session.
-  systemd-run --system --service-type=forking --unit=qemu-nbd-preseed.service "$(command -v qemu-nbd)" --fork -c /dev/nbd0 "$(pwd)/cloudimg.img"
+  # TODO: re-use tests/lib/preseed.sh:mount_ubuntu_image() here
+  systemd-run --system --service-type=forking --unit=qemu-nbd-preseed.service "$(command -v qemu-nbd)" -v --fork -c /dev/nbd0 "$(pwd)/cloudimg.img"
   # nbd0p1 may take a short while to become available
   if ! retry -n 30 --wait 1 test -e /dev/nbd0p1; then
         echo "ERROR: /dev/nbd0p1 did not show up"
         journalctl -u qemu-nbd-preseed.service
+        find /dev/ -name "nbd0*" -ls
         exit 1
   fi
   mkdir -p "$IMAGE_MOUNTPOINT"


### PR DESCRIPTION
The pressed-* tests are flaky (see LP: 1949513). To get more
insights, add more debug to see why the device does not show up.
