### PR TITLE
tests/main/mount-ns: make the test run early

### DIFF
--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -56,6 +56,18 @@ systems: [ubuntu-18.04-64]
 # side-effects now. The test should be _eventually_ enabled on
 # ubuntu-core-16-64 and ubuntu-core-18-64.
 
+# We have seen this test to fail when executed after another test that uses LXD
+# (eg. tests/main/snap-snap). It is also documented in
+# https://bugs.launchpad.net/snapd/+bug/1949710 that LXD modifies the mounts in
+# the host system thus making the state of the system different from what is
+# expected and checked for in this test. Since we cannot really skip the test,
+# cannot set a constraint that the test should not run on the same node as some
+# other test, and we cannot fix LXD test to reboot in restore due to
+# https://github.com/snapcore/spread/pull/85, we employ a workaround which is to
+# bump the priority of this test such that is runs before any other tests that
+# may use LXD.
+priority: 1001
+
 environment:
     MACHINE_STATE/inherit: inherit
     MACHINE_STATE/reboot: reboot


### PR DESCRIPTION
Before LXD alters the mounts on the host, thus breaking the expected system
state.

See: https://bugs.launchpad.net/snapd/+bug/1949710

