### PR TITLE
tests: add ntp related debug around "auto-refresh" test

### DIFF
--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -15,6 +15,13 @@ restore: |
         snap set system experimental.parallel-instances=null
     fi
 
+debug: |
+    # GCE does not always NTP sync, try to figure out why here
+    # (LP: 1949886)
+    systemctl status systemd-timedated || true
+    journalctl -u systemd-timedated || true
+    timedatectl || true
+
 execute: |
     echo "Auto refresh information is shown"
     output=$(snap refresh --time)

--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -4,6 +4,13 @@ prepare: |
     snap install test-snapd-tools
     snap install --devmode jq
 
+debug: |
+    # GCE does not always NTP sync, try to figure out why here
+    # (LP: 1949886)
+    systemctl status systemd-timedated || true
+    journalctl -u systemd-timedated || true
+    timedatectl || true
+
 execute: |
     # Check help
     "$TESTSTOOLS"/snapd-state | MATCH "usage: check-state <jq-filter>"


### PR DESCRIPTION
The auto-refresh test is now flaky because not all images are
ntp synced in GCE. See https://bugs.launchpad.net/snapd/+bug/1949886

This commit adds some debug for this.

