### PR TITLE
data/selinux: update the policy to allow snapd to talk to org.freedesktop.timedate1

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -335,6 +335,21 @@ optional_policy(`
 	allow snappy_t journalctl_t:process sigkill;
 ')
 
+# snapd may talk to systemd-timesyncd over dbus
+optional_policy(`
+  gen_require(`
+	  type systemd_timedated_t;
+    class dbus send_msg;
+  ')
+	allow snappy_t systemd_timedated_t:dbus send_msg;
+	allow systemd_timedated_t snappy_t:dbus send_msg;
+')
+# or on some systems same dbus API may be provided by timedatex
+# RHEL7: there is no timedatex.if
+ifndef(`distro_rhel7',`
+  timedatex_dbus_chat(snappy_t)
+')
+
 # only pops up in cloud images where cloud-init.target is incorrectly labeled
 allow snappy_t init_var_run_t:lnk_file read;
 


### PR DESCRIPTION
Snapd needs to poke the org.freedesktop.timedate1 service to find out whether
NTP was synchronized. That DBus API is provide by systemd-timesyncd (most
systems) or timedatex (CentOS mostly). The SELinux policy does not currently
allow talking to either service, so upon startup snapd will enter a deadlock
after getting blocked in the timeutil.IsNTPSynchronized() waiting for dbus
messages, while this is called in a code path that acquired state.Lock(), thus
blocking all Ensure() calls and interaction through the snapd socket.

Extend the SELinux policy to allow dbus communication to either timedate1
provider service.

