### PR TITLE
cmd/snap-seccomp/syscalls: update syscalls to match libseccomp abad8a8f4

### DIFF
--- a/cmd/snap-seccomp/syscalls/syscalls.go
+++ b/cmd/snap-seccomp/syscalls/syscalls.go
@@ -292,6 +292,7 @@ var SeccompSyscalls = []string{
 	"preadv2",
 	"prlimit64",
 	"process_madvise",
+	"process_mrelease",
 	"process_vm_readv",
 	"process_vm_writev",
 	"prof",

--- a/tests/main/snap-seccomp-syscalls/task.yaml
+++ b/tests/main/snap-seccomp-syscalls/task.yaml
@@ -17,6 +17,8 @@ execute: |
     echo "Build a list of syscalls known to libseccomp by using the internal test tool arch-syscall-dump"
     git clone https://github.com/seccomp/libseccomp
     pushd libseccomp
+    # so that we know what is the latest revision tried in the test
+    git log -1
     ./autogen.sh
     ./configure
     pushd src && make arch-syscall-dump


### PR DESCRIPTION
Update the list of syscalls, to match the latest libseccomp commit:
seccomp/libseccomp@abad8a8