### PR TITLE
timeutil,deviceutil: fix unit tests on systems without dbus or without ntp-sync

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -239,6 +239,10 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 
 	s.AddCleanup(func() { s.ancillary = nil })
 	s.AddCleanup(func() { s.newFakeStore = nil })
+
+	s.AddCleanup(devicestate.MockTimeutilIsNTPSynchronized(func() (bool, error) {
+		return true, nil
+	}))
 }
 
 func (s *deviceMgrBaseSuite) newStore(devBE storecontext.DeviceBackend) snapstate.StoreService {

--- a/timeutil/synchronized.go
+++ b/timeutil/synchronized.go
@@ -54,7 +54,7 @@ func IsNTPSynchronized() (bool, error) {
 	// shared connection, no need to close
 	conn, err := dbusutil.SystemBus()
 	if err != nil {
-		return false, fmt.Errorf("cannot connect to system bus: %v", err)
+		return false, NoTimedate1Error{err}
 	}
 
 	tdObj := conn.Object("org.freedesktop.timedate1", "/org/freedesktop/timedate1")


### PR DESCRIPTION
The new timeutilIs.NTPSynchronized is not correctly dealing with systems without dbus (like the sbuild environment). So two fixes here to make it more robust.