### PR TITLE
gadget: replace ondisk implementation with disks package, refactor part calcs

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -44,8 +44,6 @@ var (
 
 	Flatten = flatten
 
-	FilesystemInfoForPartition = filesystemInfoForPartition
-
 	NewRawStructureUpdater      = newRawStructureUpdater
 	NewMountedFilesystemUpdater = newMountedFilesystemUpdater
 

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2615,9 +2615,9 @@ var mockDeviceLayout = gadget.OnDiskVolume{
 	Size:       2 * quantity.SizeGiB,
 	SectorSize: 512,
 
-	// ( 2 GB / 512 B sector size ) - 34 typical GPT header backup sectors +
+	// ( 2 GB / 512 B sector size ) - 33 typical GPT header backup sectors +
 	// 1 sector to get the exclusive end
-	UsableSectorsEnd: uint64((2*quantity.SizeGiB/512)-34) + 1,
+	UsableSectorsEnd: uint64((2*quantity.SizeGiB/512)-33) + 1,
 }
 
 const mockSimpleGadgetYaml = `volumes:

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -72,28 +72,3 @@ func MustLayOutSingleVolumeFromGadget(gadgetRoot, kernelRoot string, model gadge
 	// length of 1
 	panic("impossible logic error")
 }
-
-// MockLsblkCommand returns a string suitable for use with MockCommand for lsblk
-// with the expected input/output pairing. The input keys are expected to be a
-// full string of the lsblk arguments and options, while the output values are
-// expected to be a string of the bash quoted JSON to be output for that input.
-func MockLsblkCommand(expIO map[string]string) string {
-	templ := `
-case "$*" in 
-	%s
-	*)
-		echo "unexpected args $*"
-		exit 1
-		;;
-esac`
-
-	insert := ""
-	for inArgs, outJSON := range expIO {
-		insert += fmt.Sprintf(`
-	%q)
-		echo %s
-		;;
-`, inArgs, outJSON)
-	}
-	return fmt.Sprintf(templ, insert)
-}

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -92,7 +92,10 @@ func createMissingPartitions(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) 
 func buildPartitionList(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) (sfdiskInput *bytes.Buffer, toBeCreated []gadget.OnDiskStructure) {
 	sectorSize := uint64(dl.SectorSize)
 
-	// Keep track what partitions we already have on disk
+	// Keep track what partitions we already have on disk - the keys to this map
+	// is the starting sector of the structure we have seen.
+	// TODO: use quantity.SectorOffset or similar when that is available
+
 	seen := map[uint64]bool{}
 	for _, s := range dl.Structure {
 		start := uint64(s.StartOffset) / sectorSize

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -90,12 +90,12 @@ func createMissingPartitions(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) 
 // returns a partitioning description suitable for sfdisk input and a
 // list of the partitions to be created.
 func buildPartitionList(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) (sfdiskInput *bytes.Buffer, toBeCreated []gadget.OnDiskStructure) {
-	sectorSize := dl.SectorSize
+	sectorSize := uint64(dl.SectorSize)
 
 	// Keep track what partitions we already have on disk
-	seen := map[quantity.Offset]bool{}
+	seen := map[uint64]bool{}
 	for _, s := range dl.Structure {
-		start := s.StartOffset / quantity.Offset(sectorSize)
+		start := uint64(s.StartOffset) / sectorSize
 		seen[start] = true
 	}
 
@@ -122,8 +122,8 @@ func buildPartitionList(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) (sfdi
 		s := p.VolumeStructure
 
 		// Skip partitions that are already in the volume
-		start := p.StartOffset / quantity.Offset(sectorSize)
-		if seen[start] {
+		startInSectors := uint64(p.StartOffset) / sectorSize
+		if seen[startInSectors] {
 			continue
 		}
 
@@ -136,9 +136,11 @@ func buildPartitionList(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) (sfdi
 		}
 
 		// Check if the data partition should be expanded
-		size := s.Size
-		if s.Role == gadget.SystemData && canExpandData && quantity.Size(p.StartOffset)+s.Size < dl.Size {
-			size = dl.Size - quantity.Size(p.StartOffset)
+		newSizeInSectors := uint64(s.Size) / sectorSize
+		if s.Role == gadget.SystemData && canExpandData && startInSectors+newSizeInSectors < dl.UsableSectorsEnd {
+			// note that if startInSectors + newSizeInSectors == dl.UsableSectorEnd
+			// then we won't hit this branch, but it would be redundant anyways
+			newSizeInSectors = dl.UsableSectorsEnd - startInSectors
 		}
 
 		// Can we use the index here? Get the largest existing partition number and
@@ -146,12 +148,12 @@ func buildPartitionList(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) (sfdi
 		// (can this actually happen in our images?)
 		node := deviceName(dl.Device, pIndex)
 		fmt.Fprintf(buf, "%s : start=%12d, size=%12d, type=%s, name=%q\n", node,
-			p.StartOffset/quantity.Offset(sectorSize), size/sectorSize, ptype, s.Name)
+			startInSectors, newSizeInSectors, ptype, s.Name)
 
 		toBeCreated = append(toBeCreated, gadget.OnDiskStructure{
 			LaidOutStructure: p,
 			Node:             node,
-			Size:             size,
+			Size:             quantity.Size(newSizeInSectors * sectorSize),
 		})
 	}
 

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -20,7 +20,6 @@
 package install_test
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -34,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -62,10 +62,6 @@ func (s *partitionTestSuite) SetUpTest(c *C) {
 	s.AddCleanup(cmdSfdisk.Restore)
 	cmdLsblk := testutil.MockCommand(c, "lsblk", `echo "lsblk was not mocked"; exit 1`)
 	s.AddCleanup(cmdLsblk.Restore)
-
-	// we test different sector sizes elsewhere, here we always use it to get the sector size
-	cmdBlockdev := testutil.MockCommand(c, "blockdev", blockdevSectorSize512Script)
-	s.AddCleanup(cmdBlockdev.Restore)
 }
 
 const (
@@ -74,138 +70,68 @@ const (
 	scriptPartitionsBiosSeedData
 )
 
-func makeSfdiskScript(num int) string {
-	var b bytes.Buffer
+func makeMockDiskMappingIncludingPartitions(num int) *disks.MockDiskMapping {
+	disk := &disks.MockDiskMapping{
+		DevNum:              "42:0",
+		DiskSizeInBytes:     (8388574 + 34) * 512,
+		DiskUsableSectorEnd: 8388574 + 1,
+		DiskSchema:          "gpt",
+		ID:                  "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+		SectorSizeBytes:     512,
+		Structure:           []disks.Partition{},
+		DevNode:             "/dev/node",
+	}
 
-	b.WriteString(`
->&2 echo "Some warning from sfdisk"
-echo '{
-  "partitiontable": {
-    "label": "gpt",
-    "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
-    "device": "/dev/node",
-    "unit": "sectors",
-    "firstlba": 34,
-    "lastlba": 8388574,
-    "partitions": [`)
-
-	// BIOS boot partition
 	if num >= scriptPartitionsBios {
-		b.WriteString(`
-      {
-        "node": "/dev/node1",
-        "start": 2048,
-        "size": 2048,
-        "type": "21686148-6449-6E6F-744E-656564454649",
-        "uuid": "2E59D969-52AB-430B-88AC-F83873519F6F",
-        "name": "BIOS Boot"
-      }`)
+		disk.Structure = append(disk.Structure, disks.Partition{
+			KernelDeviceNode: "/dev/node1",
+			StartInBytes:     2048 * 512,
+			SizeInBytes:      2048 * 512,
+			PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+			PartitionUUID:    "2E59D969-52AB-430B-88AC-F83873519F6F",
+			PartitionLabel:   "BIOS Boot",
+			Major:            42,
+			Minor:            1,
+			StructureIndex:   1,
+		})
 	}
 
-	// Seed partition
 	if num >= scriptPartitionsBiosSeed {
-		b.WriteString(`,
-      {
-        "node": "/dev/node2",
-        "start": 4096,
-        "size": 2457600,
-        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-        "uuid": "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
-        "name": "Recovery"
-      }`)
+		disk.Structure = append(disk.Structure, disks.Partition{
+			KernelDeviceNode: "/dev/node2",
+			StartInBytes:     4096 * 512,
+			SizeInBytes:      2457600 * 512,
+			PartitionType:    "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+			PartitionUUID:    "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
+			PartitionLabel:   "Recovery",
+			Major:            42,
+			Minor:            2,
+			StructureIndex:   2,
+			FilesystemType:   "vfat",
+			FilesystemUUID:   "A644-B807",
+			FilesystemLabel:  "ubuntu-seed",
+		})
 	}
 
-	// Data partition
 	if num >= scriptPartitionsBiosSeedData {
-		b.WriteString(`,
-      {
-        "node": "/dev/node3",
-        "start": 2461696,
-        "size": 2457600,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "f940029d-bfbb-4887-9d44-321e85c63866",
-        "name": "Writable"
-      }`)
+		disk.Structure = append(disk.Structure, disks.Partition{
+			KernelDeviceNode: "/dev/node3",
+			StartInBytes:     2461696 * 512,
+			SizeInBytes:      2457600 * 512,
+			PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+			PartitionUUID:    "F940029D-BFBB-4887-9D44-321E85C63866",
+			PartitionLabel:   "Writable",
+			Major:            42,
+			Minor:            3,
+			StructureIndex:   3,
+			FilesystemType:   "ext4",
+			FilesystemUUID:   "8781-433a",
+			FilesystemLabel:  "ubuntu-data",
+		})
 	}
 
-	b.WriteString(`
-    ]
-  }
-}'`)
-	return b.String()
+	return disk
 }
-
-var biosPartitionLsBlkInOut = map[string]string{
-	// BIOS boot partition
-	"--json /dev/node1": `'{
-		"blockdevices": [
-			{"name":"node1", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-		]
-	}'`,
-	"--fs --json /dev/node1": `'{
-    "blockdevices": [ {"name": "node1", "fstype": null, "label": null, "uuid": null, "mountpoint": null} ]
-}'`,
-}
-
-var biosSeedPartitionLsBlkInOut = map[string]string{
-	// BIOS boot partition
-	"--json /dev/node1": `'{
-		"blockdevices": [
-			{"name":"node1", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-		]
-	}'`,
-	"--fs --json /dev/node1": `'{
-    "blockdevices": [ {"name": "node1", "fstype": null, "label": null, "uuid": null, "mountpoint": null} ]
-}'`,
-	// Seed partition
-	"--json /dev/node2": `'{
-		"blockdevices": [
-			{"name":"node2", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-		]
-	}'`,
-	"--fs --json /dev/node2": `'{
-    "blockdevices": [ {"name": "node2", "fstype": "vfat", "label": "ubuntu-seed", "uuid": "A644-B807", "mountpoint": null} ]
-}'`,
-}
-
-var biosSeedDataPartitionLsBlkInOut = map[string]string{
-	// BIOS boot partition
-	"--json /dev/node1": `'{
-		"blockdevices": [
-			{"name":"node1", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-		]
-	}'`,
-	"--fs --json /dev/node1": `'{
-    "blockdevices": [ {"name": "node1", "fstype": null, "label": null, "uuid": null, "mountpoint": null} ]
-}'`,
-	// Seed partition
-	"--json /dev/node2": `'{
-		"blockdevices": [
-			{"name":"node2", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-		]
-	}'`,
-	"--fs --json /dev/node2": `'{
-    "blockdevices": [ {"name": "node2", "fstype": "vfat", "label": "ubuntu-seed", "uuid": "A644-B807", "mountpoint": null} ]
-}'`,
-	// Data partition
-	"--json /dev/node3": `'{
-		"blockdevices": [
-			{"name":"node3", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-		]
-	}'`,
-	"--fs --json /dev/node3": `'{
-    "blockdevices": [ {"name": "node3", "fstype": "ext4", "label": "ubuntu-data", "uuid": "8781-433a", "mountpoint": null} ]
-}'`,
-}
-
-const blockdevSectorSize512Script = `
-if [ "$1" == "--getss" ]; then
-	echo 512
-	exit 0
-fi
-echo "unexpected cmdline opts $*"
-exit 1
-`
 
 var mockOnDiskStructureWritable = gadget.OnDiskStructure{
 	Node: "/dev/node3",
@@ -271,11 +197,12 @@ func (c uc20Model) Grade() asserts.ModelGrade { return asserts.ModelSigned }
 var uc20Mod = uc20Model{}
 
 func (s *partitionTestSuite) TestBuildPartitionList(c *C) {
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", makeSfdiskScript(scriptPartitionsBiosSeed))
-	defer cmdSfdisk.Restore()
+	m := map[string]*disks.MockDiskMapping{
+		"/dev/node": makeMockDiskMappingIncludingPartitions(scriptPartitionsBiosSeed),
+	}
 
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(biosSeedPartitionLsBlkInOut))
-	defer cmdLsblk.Restore()
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
@@ -297,14 +224,18 @@ func (s *partitionTestSuite) TestBuildPartitionList(c *C) {
 }
 
 func (s *partitionTestSuite) TestCreatePartitions(c *C) {
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", makeSfdiskScript(scriptPartitionsBiosSeed))
+	cmdSfdisk := testutil.MockCommand(c, "sfdisk", "")
 	defer cmdSfdisk.Restore()
 
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(biosSeedPartitionLsBlkInOut))
-	defer cmdLsblk.Restore()
+	m := map[string]*disks.MockDiskMapping{
+		"/dev/node": makeMockDiskMappingIncludingPartitions(scriptPartitionsBiosSeed),
+	}
+
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
 
 	calls := 0
-	restore := install.MockEnsureNodesExist(func(ds []gadget.OnDiskStructure, timeout time.Duration) error {
+	restore = install.MockEnsureNodesExist(func(ds []gadget.OnDiskStructure, timeout time.Duration) error {
 		calls++
 		c.Assert(ds, HasLen, 1)
 		c.Assert(ds[0].Node, Equals, "/dev/node3")
@@ -324,9 +255,8 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 	c.Assert(created, DeepEquals, []gadget.OnDiskStructure{mockOnDiskStructureWritable})
 	c.Assert(calls, Equals, 1)
 
-	// Check partition table read and write
+	// Check partition table write
 	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
 		{"sfdisk", "--append", "--no-reread", "/dev/node"},
 	})
 
@@ -338,11 +268,12 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 
 func (s *partitionTestSuite) TestRemovePartitionsTrivial(c *C) {
 	// no locally created partitions
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", makeSfdiskScript(scriptPartitionsBios))
-	defer cmdSfdisk.Restore()
+	m := map[string]*disks.MockDiskMapping{
+		"/dev/node": makeMockDiskMappingIncludingPartitions(scriptPartitionsBios),
+	}
 
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(biosPartitionLsBlkInOut))
-	defer cmdLsblk.Restore()
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
 
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
@@ -354,63 +285,99 @@ func (s *partitionTestSuite) TestRemovePartitionsTrivial(c *C) {
 
 	err = install.RemoveCreatedPartitions(pv, dl)
 	c.Assert(err, IsNil)
-
-	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-	})
-
-	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node1"},
-		{"lsblk", "--fs", "--json", "/dev/node1"},
-	})
 }
 
 func (s *partitionTestSuite) TestRemovePartitions(c *C) {
-	const mockSfdiskScriptRemovablePartition = `
-if [ -f %[1]s/2 ]; then
-   rm %[1]s/[0-9]
-elif [ -f %[1]s/1 ]; then
-   touch %[1]s/2
-   exit 0
-else
-   PART=',
-   {"node": "/dev/node2", "start": 4096, "size": 2457600, "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4", "uuid": "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F", "name": "Recovery"},
-   {"node": "/dev/node3", "start": 2461696, "size": 2457600, "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4", "uuid": "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F", "name": "Recovery"}
-   '
-   touch %[1]s/1
-fi
-echo '{
-   "partitiontable": {
-      "label": "gpt",
-      "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
-      "device": "/dev/node",
-      "unit": "sectors",
-      "firstlba": 34,
-      "lastlba": 8388574,
-      "partitions": [
-         {"node": "/dev/node1", "start": 2048, "size": 2048, "type": "21686148-6449-6E6F-744E-656564454649", "uuid": "2E59D969-52AB-430B-88AC-F83873519F6F", "name": "BIOS Boot"}
-         '"$PART
-      ]
-   }
-}"`
+	m := map[string]*disks.MockDiskMapping{
+		"/dev/node": {
+			DevNum: "42:0",
+			// this is so that the updated version will be found after we delete
+			// the partitions and reload the partition table
+			// XXX: this is a bit of a hack but is easier than mocking every
+			// individual call to find a disk in order
+			DevNode: "/dev/updated-node",
+			// assume GPT backup header section is 34 sectors long
+			DiskSizeInBytes:     (8388574 + 34) * 512,
+			DiskUsableSectorEnd: 8388574 + 1,
+			DiskSchema:          "gpt",
+			ID:                  "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+			SectorSizeBytes:     512,
+			Structure: []disks.Partition{
+				// all 3 partitions present
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     2048 * 512,
+					SizeInBytes:      2048 * 512,
+					PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+					PartitionUUID:    "2E59D969-52AB-430B-88AC-F83873519F6F",
+					PartitionLabel:   "BIOS Boot",
+					Major:            42,
+					Minor:            1,
+					StructureIndex:   1,
+				},
+				{
+					KernelDeviceNode: "/dev/node2",
+					StartInBytes:     4096 * 512,
+					SizeInBytes:      2457600 * 512,
+					PartitionType:    "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+					PartitionUUID:    "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
+					PartitionLabel:   "Recovery",
+					Major:            42,
+					Minor:            2,
+					StructureIndex:   2,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "A644-B807",
+					FilesystemLabel:  "ubuntu-seed",
+				},
+				{
+					KernelDeviceNode: "/dev/node3",
+					StartInBytes:     2461696 * 512,
+					SizeInBytes:      2457600 * 512,
+					PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+					PartitionUUID:    "F940029D-BFBB-4887-9D44-321E85C63866",
+					PartitionLabel:   "Writable",
+					Major:            42,
+					Minor:            3,
+					StructureIndex:   3,
+					FilesystemType:   "ext4",
+					FilesystemUUID:   "8781-433a",
+					FilesystemLabel:  "ubuntu-data",
+				},
+			},
+		},
+		"/dev/updated-node": {
+			DevNum:              "42:0",
+			DevNode:             "/dev/updated-node",
+			DiskSizeInBytes:     (8388574 + 34) * 512,
+			DiskUsableSectorEnd: 8388574 + 1,
+			DiskSchema:          "gpt",
+			ID:                  "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+			SectorSizeBytes:     512,
+			Structure: []disks.Partition{
+				// only the first partition
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     2048 * 512,
+					SizeInBytes:      2048 * 512,
+					PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+					PartitionUUID:    "2E59D969-52AB-430B-88AC-F83873519F6F",
+					PartitionLabel:   "BIOS Boot",
+					Major:            42,
+					Minor:            1,
+					StructureIndex:   1,
+				},
+			},
+		},
+	}
 
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", fmt.Sprintf(mockSfdiskScriptRemovablePartition, s.dir))
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
+
+	cmdSfdisk := testutil.MockCommand(c, "sfdisk", "")
 	defer cmdSfdisk.Restore()
-
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(biosSeedDataPartitionLsBlkInOut))
-	defer cmdLsblk.Restore()
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
 	c.Assert(err, IsNil)
-
-	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node1"},
-		{"lsblk", "--fs", "--json", "/dev/node1"},
-		{"lsblk", "--json", "/dev/node2"},
-		{"lsblk", "--fs", "--json", "/dev/node2"},
-		{"lsblk", "--json", "/dev/node3"},
-		{"lsblk", "--fs", "--json", "/dev/node3"},
-	})
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
@@ -421,20 +388,72 @@ echo '{
 	c.Assert(err, IsNil)
 
 	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-		{"sfdisk", "--no-reread", "--delete", "/dev/node", "3"},
-		{"sfdisk", "--json", "/dev/node"},
+		{"sfdisk", "--no-reread", "--delete", "/dev/updated-node", "3"},
 	})
 }
 
-func (s *partitionTestSuite) TestRemovePartitionsError(c *C) {
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", makeSfdiskScript(scriptPartitionsBiosSeedData))
+func (s *partitionTestSuite) TestRemovePartitionsDoesNotRemoveError(c *C) {
+	cmdSfdisk := testutil.MockCommand(c, "sfdisk", "")
 	defer cmdSfdisk.Restore()
 
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(biosSeedDataPartitionLsBlkInOut))
-	defer cmdLsblk.Restore()
+	m := map[string]*disks.MockDiskMapping{
+		"/dev/node": {
+			DevNum:              "42:0",
+			DevNode:             "/dev/node",
+			DiskSizeInBytes:     (8388574 + 34) * 512,
+			DiskUsableSectorEnd: 8388574 + 1,
+			DiskSchema:          "gpt",
+			ID:                  "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+			SectorSizeBytes:     512,
+			Structure: []disks.Partition{
+				// all 3 partitions present
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     2048 * 512,
+					SizeInBytes:      2048 * 512,
+					PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+					PartitionUUID:    "2E59D969-52AB-430B-88AC-F83873519F6F",
+					PartitionLabel:   "BIOS Boot",
+					Major:            42,
+					Minor:            1,
+					StructureIndex:   1,
+				},
+				{
+					KernelDeviceNode: "/dev/node2",
+					StartInBytes:     4096 * 512,
+					SizeInBytes:      2457600 * 512,
+					PartitionType:    "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+					PartitionUUID:    "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
+					PartitionLabel:   "Recovery",
+					Major:            42,
+					Minor:            2,
+					StructureIndex:   2,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "A644-B807",
+					FilesystemLabel:  "ubuntu-seed",
+				},
+				{
+					KernelDeviceNode: "/dev/node3",
+					StartInBytes:     2461696 * 512,
+					SizeInBytes:      2457600 * 512,
+					PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+					PartitionUUID:    "F940029D-BFBB-4887-9D44-321E85C63866",
+					PartitionLabel:   "Writable",
+					Major:            42,
+					Minor:            3,
+					StructureIndex:   3,
+					FilesystemType:   "ext4",
+					FilesystemUUID:   "8781-433a",
+					FilesystemLabel:  "ubuntu-data",
+				},
+			},
+		},
+	}
 
-	dl, err := gadget.OnDiskVolumeFromDevice("node")
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
+
+	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
 	c.Assert(err, IsNil)
 
 	err = makeMockGadget(s.gadgetRoot, gadgetContent)
@@ -530,68 +549,75 @@ const gptGadgetContentWithSave = `volumes:
 `
 
 func (s *partitionTestSuite) TestCreatedDuringInstallGPT(c *C) {
-	gptLsBlkInOut := map[string]string{
-		"--json /dev/node1":      `'{ "blockdevices": [ {"name":"node1", "type":"part"} ] }'`,
-		"--fs --json /dev/node1": `'{ "blockdevices": [ {"fstype":"ext4", "label":null} ] }'`,
-
-		"--json /dev/node2":      `'{ "blockdevices": [ {"name":"node2", "type":"part"} ] }'`,
-		"--fs --json /dev/node2": `'{ "blockdevices": [ {"fstype":"ext4", "label":"ubuntu-seed"} ] }'`,
-
-		"--json /dev/node3":      `'{ "blockdevices": [ {"name":"node3", "type":"part"} ] }'`,
-		"--fs --json /dev/node3": `'{ "blockdevices": [ {"fstype":"ext4", "label":"ubuntu-save"} ] }'`,
-
-		"--json /dev/node4":      `'{ "blockdevices": [ {"name":"node4", "type":"part"} ] }'`,
-		"--fs --json /dev/node4": `'{ "blockdevices": [ {"fstype":"ext4", "label":"ubuntu-data"} ] }'`,
+	m := map[string]*disks.MockDiskMapping{
+		"node": {
+			DevNum:              "42:0",
+			DiskSizeInBytes:     (8388574 + 34) * 512,
+			DiskUsableSectorEnd: 8388574 + 1,
+			DiskSchema:          "gpt",
+			ID:                  "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+			SectorSizeBytes:     512,
+			DevNode:             "/dev/node",
+			Structure: []disks.Partition{
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     2048 * 512,
+					SizeInBytes:      2048 * 512,
+					PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+					PartitionUUID:    "2E59D969-52AB-430B-88AC-F83873519F6F",
+					PartitionLabel:   "BIOS Boot",
+					Major:            42,
+					Minor:            1,
+					StructureIndex:   1,
+				},
+				{
+					KernelDeviceNode: "/dev/node2",
+					StartInBytes:     4096 * 512,
+					SizeInBytes:      2457600 * 512,
+					PartitionType:    "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+					PartitionUUID:    "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
+					PartitionLabel:   "ubuntu-seed",
+					Major:            42,
+					Minor:            2,
+					StructureIndex:   2,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "A644-B807",
+					FilesystemLabel:  "ubuntu-seed",
+				},
+				{
+					KernelDeviceNode: "/dev/node3",
+					StartInBytes:     2461696 * 512,
+					SizeInBytes:      262144 * 512,
+					PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+					PartitionUUID:    "F940029D-BFBB-4887-9D44-321E85C63866",
+					PartitionLabel:   "ubuntu-boot",
+					Major:            42,
+					Minor:            3,
+					StructureIndex:   3,
+					FilesystemType:   "ext4",
+					FilesystemUUID:   "8781-433a",
+					FilesystemLabel:  "ubuntu-boot",
+				},
+				{
+					KernelDeviceNode: "/dev/node4",
+					StartInBytes:     2723840 * 512,
+					SizeInBytes:      2457600 * 512,
+					PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+					PartitionUUID:    "G940029D-BFBB-4887-9D44-321E85C63866",
+					PartitionLabel:   "ubuntu-data",
+					Major:            42,
+					Minor:            4,
+					StructureIndex:   4,
+					FilesystemType:   "ext4",
+					FilesystemUUID:   "8123-433a",
+					FilesystemLabel:  "ubuntu-data",
+				},
+			},
+		},
 	}
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(gptLsBlkInOut))
-	defer cmdLsblk.Restore()
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", `
-echo '{
-  "partitiontable": {
-    "label": "gpt",
-    "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
-    "device": "/dev/node",
-    "unit": "sectors",
-    "firstlba": 34,
-    "lastlba": 8388574,
-    "partitions": [
-     {
-         "node": "/dev/node1",
-         "start": 2048,
-         "size": 2048,
-         "type": "21686148-6449-6E6F-744E-656564454649",
-         "uuid": "30a26851-4b08-4b8d-8aea-f686e723ed8c",
-         "name": "BIOS boot partition"
-     },
-     {
-         "node": "/dev/node2",
-         "start": 4096,
-         "size": 2457600,
-         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-         "uuid": "7ea3a75a-3f6d-4647-8134-89ae61fe88d5",
-         "name": "Linux filesystem"
-     },
-     {
-         "node": "/dev/node3",
-         "start": 2461696,
-         "size": 262144,
-         "type": "0fc63daf-8483-4772-8e79-3d69d8477de4",
-         "uuid": "641764aa-a680-4d36-a7ad-f7bd01fd8d12",
-         "name": "Linux filesystem"
-     },
-     {
-         "node": "/dev/node4",
-         "start": 2723840,
-         "size": 2457600,
-         "type": "0fc63daf-8483-4772-8e79-3d69d8477de4",
-         "uuid": "8ab3e8fd-d53d-4d72-9c5e-56146915fd07",
-         "name": "Another Linux filesystem"
-     }
-     ]
-  }
-}'
-`)
-	defer cmdSfdisk.Restore()
+
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
 
 	err := makeMockGadget(s.gadgetRoot, gptGadgetContentWithSave)
 	c.Assert(err, IsNil)
@@ -641,72 +667,79 @@ const mbrGadgetContentWithSave = `volumes:
 
 func (s *partitionTestSuite) TestCreatedDuringInstallMBR(c *C) {
 
-	mbrLsBlkInOut := map[string]string{
-		"--json /dev/node1":      `'{ "blockdevices": [ {"name":"node1", "type":"part"} ] }'`,
-		"--fs --json /dev/node1": `'{ "blockdevices": [ {"fstype":"ext4", "label":"ubuntu-seed"} ] }'`,
-
-		"--json /dev/node2":      `'{ "blockdevices": [ {"name":"node2", "type":"part"} ] }'`,
-		"--fs --json /dev/node2": `'{ "blockdevices": [ {"fstype":"ext4", "label":"ubuntu-boot"} ] }'`,
-
-		"--json /dev/node3":      `'{ "blockdevices": [ {"name":"node3", "type":"part"} ] }'`,
-		"--fs --json /dev/node3": `'{ "blockdevices": [ {"fstype":"ext4", "label":"ubuntu-save"} ] }'`,
-
-		"--json /dev/node4":      `'{ "blockdevices": [ {"name":"node4", "type":"part"} ] }'`,
-		"--fs --json /dev/node4": `'{ "blockdevices": [ {"fstype":"ext4", "label":"ubuntu-data"} ] }'`,
+	const (
+		twoMeg                   = 2 * 1024 * 1024
+		oneHundredTwentyEightMeg = 128 * 1024 * 1024
+		twelveHundredMeg         = 1200 * 1024 * 1024
+	)
+	m := map[string]*disks.MockDiskMapping{
+		"node": {
+			DevNum:              "42:0",
+			DevNode:             "/dev/node",
+			DiskSizeInBytes:     (8388574 + 34) * 512,
+			DiskUsableSectorEnd: 8388574 + 1,
+			DiskSchema:          "dos",
+			ID:                  "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+			SectorSizeBytes:     512,
+			Structure: []disks.Partition{
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     twoMeg,
+					SizeInBytes:      twelveHundredMeg,
+					PartitionType:    "0a",
+					PartitionLabel:   "Recovery",
+					Major:            42,
+					Minor:            1,
+					StructureIndex:   1,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "A644-B807",
+					FilesystemLabel:  "ubuntu-seed",
+				},
+				{
+					KernelDeviceNode: "/dev/node2",
+					StartInBytes:     twelveHundredMeg + twoMeg,
+					SizeInBytes:      twelveHundredMeg,
+					PartitionType:    "b",
+					PartitionLabel:   "Boot",
+					Major:            42,
+					Minor:            2,
+					StructureIndex:   2,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "A644-B807",
+					FilesystemLabel:  "ubuntu-boot",
+				},
+				{
+					KernelDeviceNode: "/dev/node3",
+					StartInBytes:     twoMeg + twelveHundredMeg + twelveHundredMeg,
+					SizeInBytes:      oneHundredTwentyEightMeg,
+					PartitionType:    "c",
+					PartitionLabel:   "Save",
+					Major:            42,
+					Minor:            3,
+					StructureIndex:   3,
+					FilesystemType:   "ext4",
+					FilesystemUUID:   "8781-433a",
+					FilesystemLabel:  "ubuntu-save",
+				},
+				{
+					KernelDeviceNode: "/dev/node4",
+					StartInBytes:     twoMeg + twelveHundredMeg + twelveHundredMeg + oneHundredTwentyEightMeg,
+					SizeInBytes:      twelveHundredMeg,
+					PartitionType:    "0d",
+					PartitionLabel:   "Data",
+					Major:            42,
+					Minor:            4,
+					StructureIndex:   4,
+					FilesystemType:   "ext4",
+					FilesystemUUID:   "8123-433a",
+					FilesystemLabel:  "ubuntu-data",
+				},
+			},
+		},
 	}
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(mbrLsBlkInOut))
-	defer cmdLsblk.Restore()
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", `
-echo '{
-  "partitiontable": {
-    "label": "dos",
-    "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
-    "device": "/dev/node",
-    "unit": "sectors",
-    "firstlba": 0,
-    "lastlba": 8388574,
-    "partitions": [
-     {
-         "node": "/dev/node1",
-         "start": 0,
-         "size": 2460672,
-         "type": "0a"
-     },
-     {
-         "node": "/dev/node2",
-         "start": 2461696,
-         "size": 2460672,
-         "type": "b"
-     },
-     {
-         "node": "/dev/node3",
-         "start": 4919296,
-         "size": 262144,
-         "type": "c"
-     },
-     {
-         "node": "/dev/node4",
-         "start": 5181440,
-         "size": 2460672,
-         "type": "0d"
-     }
-     ]
-  }
-}'
-`)
-	defer cmdSfdisk.Restore()
-	cmdBlockdev := testutil.MockCommand(c, "blockdev", `
-if [ "$1" == "--getss" ]; then
-	echo 512
-	exit 0
-elif [ "$1" == "--getsz" ]; then
-	echo 1234567
-	exit 0
-fi
-echo "unexpected cmdline opts $*"
-exit 1
-`)
-	defer cmdBlockdev.Restore()
+
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
 
 	dl, err := gadget.OnDiskVolumeFromDevice("node")
 	c.Assert(err, IsNil)

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -73,7 +73,7 @@ type LaidOutStructure struct {
 	// AbsoluteOffsetWrite is the resolved absolute position of offset-write
 	// for this structure element within the enclosing volume
 	AbsoluteOffsetWrite *quantity.Offset
-	// Index of the structure definition in gadget YAML
+	// Index of the structure definition in gadget YAML, note this starts at 0.
 	Index int
 	// LaidOutContent is a list of raw content inside the structure
 	LaidOutContent []LaidOutContent

--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -20,57 +20,11 @@
 package gadget
 
 import (
-	"encoding/json"
 	"fmt"
-	"os/exec"
-	"strconv"
-	"strings"
 
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/disks"
 )
-
-// sfdiskDeviceDump represents the sfdisk --dump JSON output format.
-type sfdiskDeviceDump struct {
-	PartitionTable sfdiskPartitionTable `json:"partitiontable"`
-}
-
-type sfdiskPartitionTable struct {
-	// Label from sfdisk is really the schema for the disk; DOS or GPT.
-	Label string `json:"label"`
-	// ID is the disk's identifier, it is a UUID for GPT disks or an unsigned
-	// integer for DOS disks encoded as a string in hexadecimal as in
-	// "0x1212e868".
-	ID string `json:"id"`
-	// Device is the full device node path in /dev as in /dev/sda.
-	Device     string            `json:"device"`
-	Unit       string            `json:"unit"`
-	FirstLBA   uint64            `json:"firstlba"`
-	LastLBA    uint64            `json:"lastlba"`
-	Partitions []sfdiskPartition `json:"partitions"`
-}
-
-type sfdiskPartition struct {
-	// Node is the full device node path in /dev as in /dev/sda1.
-	Node  string `json:"node"`
-	Start uint64 `json:"start"`
-	Size  uint64 `json:"size"`
-	// List of GPT partition attributes in <attr>[ <attr>] format, numeric attributes
-	// are listed as GUID:<bit>[,<bit>]. Note that the even though the sfdisk(8) manpage
-	// says --part-attrs takes a space or comma separated list, the output from
-	// --json/--dump uses a different format.
-	Attrs string `json:"attrs"`
-	// Type is the structure type, which is the same as VolumeStructure's Type,
-	// see that doc-comment for full details, but note that sfdisk may format
-	// the type differently than would normally be used in gadget.yaml so
-	// conversion should be done before using this Type field directly.
-	Type string `json:"type"`
-	// UUID is the partition UUID for the partition.
-	UUID string `json:"uuid"`
-	// Name is the GPT partition label for GPT disks. It is empty for MBR/DOS
-	// disks.
-	Name string `json:"name"`
-}
 
 // TODO: consider looking into merging LaidOutVolume/Structure OnDiskVolume/Structure
 
@@ -101,6 +55,12 @@ type OnDiskVolume struct {
 	Schema string
 	// size in bytes
 	Size quantity.Size
+	// UsableSectorsEnd is the end (exclusive) of usable sectors on the disk,
+	// this sector specifically is not usable for partitions, though it may be
+	// used for i.e. GPT header backups on some disks. This should be used when
+	// calculating the size of an auto-expanded partition instead of the Size
+	// parameter which does not take this into account.
+	UsableSectorsEnd uint64
 	// sector size in bytes
 	SectorSize quantity.Size
 }
@@ -108,158 +68,90 @@ type OnDiskVolume struct {
 // OnDiskVolumeFromDevice obtains the partitioning and filesystem information from
 // the block device.
 func OnDiskVolumeFromDevice(device string) (*OnDiskVolume, error) {
-	output, err := exec.Command("sfdisk", "--json", device).Output()
-	if err != nil {
-		return nil, osutil.OutputErr(output, err)
-	}
-
-	var dump sfdiskDeviceDump
-	if err := json.Unmarshal(output, &dump); err != nil {
-		return nil, fmt.Errorf("cannot parse sfdisk output: %v", err)
-	}
-
-	dl, err := onDiskVolumeFromPartitionTable(dump.PartitionTable)
-	if err != nil {
-		return nil, err
-	}
-	dl.Device = device
-
-	return dl, nil
-}
-
-func fromSfdiskPartitionType(st string, sfdiskLabel string) (string, error) {
-	switch sfdiskLabel {
-	case "dos":
-		// sometimes sfdisk reports what is "0C" in gadget.yaml as "c",
-		// normalize the values
-		v, err := strconv.ParseUint(st, 16, 8)
-		if err != nil {
-			return "", fmt.Errorf("cannot convert MBR partition type %q", st)
-		}
-		return fmt.Sprintf("%02X", v), nil
-	case "gpt":
-		return st, nil
-	default:
-		return "", fmt.Errorf("unsupported partitioning schema %q", sfdiskLabel)
-	}
-}
-
-func blockdevSizeCmd(cmd, devpath string) (quantity.Size, error) {
-	out, err := exec.Command("blockdev", cmd, devpath).CombinedOutput()
-	if err != nil {
-		return 0, osutil.OutputErr(out, err)
-	}
-	nospace := strings.TrimSpace(string(out))
-	sz, err := strconv.Atoi(nospace)
-	if err != nil {
-		return 0, fmt.Errorf("cannot parse blockdev %s result size %q: %v", cmd, nospace, err)
-	}
-	return quantity.Size(sz), nil
-}
-
-func blockDeviceSizeInSectors(devpath string) (quantity.Size, error) {
-	// the size is always reported in 512-byte sectors, even if the device does
-	// not have a physical sector size of 512
-	// XXX: consider using /sys/block/<dev>/size directly
-	return blockdevSizeCmd("--getsz", devpath)
-}
-
-func blockDeviceSectorSize(devpath string) (quantity.Size, error) {
-	// the size is reported in raw bytes
-	sz, err := blockdevSizeCmd("--getss", devpath)
-	if err != nil {
-		return 0, err
-	}
-
-	// ensure that the sector size is a multiple of 512, since we rely on that
-	// when we calculate the size in sectors, as blockdev --getsz always returns
-	// the size in 512-byte sectors
-	if sz%512 != 0 {
-		return 0, fmt.Errorf("cannot calculate structure size: sector size (%s) is not a multiple of 512", sz.String())
-	}
-	if sz == 0 {
-		// extra paranoia
-		return 0, fmt.Errorf("internal error: sector size returned as 0")
-	}
-	return sz, nil
-}
-
-// onDiskVolumeFromPartitionTable takes an sfdisk dump partition table and returns
-// the partitioning information as an on-disk volume.
-func onDiskVolumeFromPartitionTable(ptable sfdiskPartitionTable) (*OnDiskVolume, error) {
-	if ptable.Unit != "sectors" {
-		return nil, fmt.Errorf("cannot position partitions: unknown unit %q", ptable.Unit)
-	}
-
-	structure := make([]VolumeStructure, len(ptable.Partitions))
-	ds := make([]OnDiskStructure, len(ptable.Partitions))
-
-	sectorSize, err := blockDeviceSectorSize(ptable.Device)
+	disk, err := disks.DiskFromDeviceName(device)
 	if err != nil {
 		return nil, err
 	}
 
-	for i, p := range ptable.Partitions {
-		bd, err := filesystemInfoForPartition(p.Node)
-		if err != nil {
-			return nil, fmt.Errorf("cannot obtain filesystem information: %v", err)
-		}
+	return OnDiskVolumeFromDisk(disk)
+}
 
-		vsType, err := fromSfdiskPartitionType(p.Type, ptable.Label)
+func OnDiskVolumeFromDisk(disk disks.Disk) (*OnDiskVolume, error) {
+	parts, err := disk.Partitions()
+	if err != nil {
+		return nil, err
+	}
+
+	structure := make([]VolumeStructure, len(parts))
+	ds := make([]OnDiskStructure, len(parts))
+
+	for _, p := range parts {
+		// use the index of the structure on the disk rather than the order in
+		// which we iterate over the list of partitions, since the order of the
+		// partitions is returned "last seen first" which matches the behavior
+		// of udev when picking partitions with the same filesystem label and
+		// populating /dev/disk/by-label/ and friends
+		// all that is to say the order that the list of partitions from
+		// Partitions() is in is _not_ the same as the order that the structures
+		// actually appear in on disk, but this is why the StructureIndex
+		// property exists
+		i := p.StructureIndex - 1
+
+		// the PartitionLabel and FilesystemLabel are encoded, so they must be
+		// decoded before they can be used in other gadget functions
+
+		decodedPartLabel, err := disks.BlkIDDecodeLabel(p.PartitionLabel)
 		if err != nil {
-			return nil, fmt.Errorf("cannot convert sfdisk partition type %q: %v", p.Type, err)
+			return nil, fmt.Errorf("cannot decode partition label for partition on disk %s: %v", disk.KernelDeviceNode(), err)
+		}
+		decodedFsLabel, err := disks.BlkIDDecodeLabel(p.FilesystemLabel)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode partition label for partition on disk %s: %v", disk.KernelDeviceNode(), err)
 		}
 
 		structure[i] = VolumeStructure{
-			Name:       p.Name,
-			Size:       quantity.Size(p.Size) * sectorSize,
-			Label:      bd.Label,
-			Type:       vsType,
-			Filesystem: bd.FSType,
-			ID:         strings.ToUpper(p.UUID),
+			Name:       decodedPartLabel,
+			Size:       quantity.Size(p.SizeInBytes),
+			Label:      decodedFsLabel,
+			Type:       p.PartitionType,
+			Filesystem: p.FilesystemType,
+			ID:         p.PartitionUUID,
 		}
 
 		ds[i] = OnDiskStructure{
 			LaidOutStructure: LaidOutStructure{
 				VolumeStructure: &structure[i],
-				StartOffset:     quantity.Offset(p.Start) * quantity.Offset(sectorSize),
-				Index:           i + 1,
+				StartOffset:     quantity.Offset(p.StartInBytes),
+				Index:           int(p.StructureIndex),
 			},
-			Node: p.Node,
+			Size: quantity.Size(p.SizeInBytes),
+			Node: p.KernelDeviceNode,
 		}
 	}
 
-	var numSectors quantity.Size
-	if ptable.LastLBA != 0 {
-		// sfdisk reports the last usable LBA for GPT disks only
-		numSectors = quantity.Size(ptable.LastLBA + 1)
-	} else {
-		// sfdisk does not report any information about the size of a
-		// MBR partitioned disk, find out the size of the device by
-		// other means
-		sz, err := blockDeviceSizeInSectors(ptable.Device)
-		if err != nil {
-			return nil, fmt.Errorf("cannot obtain the size of device %q: %v", ptable.Device, err)
-		}
+	diskSz, err := disk.SizeInBytes()
+	if err != nil {
+		return nil, err
+	}
 
-		// since blockdev always reports the size in 512-byte sectors, if for
-		// some reason we are on a disk that does not 512-byte sectors, we will
-		// get confused, so in this case, multiply the number of 512-byte
-		// sectors by 512, then divide by the actual sector size to get the
-		// number of sectors
+	sectorSz, err := disk.SectorSize()
+	if err != nil {
+		return nil, err
+	}
 
-		// this will never have a divisor, since we verified that sector size is
-		// a multiple of 512 above
-		numSectors = sz * 512 / sectorSize
+	sectorsEnd, err := disk.UsableSectorsEnd()
+	if err != nil {
+		return nil, err
 	}
 
 	dl := &OnDiskVolume{
-		Structure:  ds,
-		ID:         ptable.ID,
-		Device:     ptable.Device,
-		Schema:     ptable.Label,
-		Size:       numSectors * sectorSize,
-		SectorSize: sectorSize,
+		Structure:        ds,
+		ID:               disk.DiskID(),
+		Device:           disk.KernelDeviceNode(),
+		Schema:           disk.Schema(),
+		Size:             quantity.Size(diskSz),
+		UsableSectorsEnd: sectorsEnd,
+		SectorSize:       quantity.Size(sectorSz),
 	}
 
 	return dl, nil
@@ -278,96 +170,4 @@ func UpdatePartitionList(dl *OnDiskVolume) error {
 
 	dl.Structure = layout.Structure
 	return nil
-}
-
-// lsblkInfo represents the lsblk JSON output format.
-type lsblkInfo struct {
-	BlockDevices []lsblkBlockDevice `json:"blockdevices"`
-}
-
-// lsblkBlockDevice represents a block device from the output of lsblk, which
-// could either be a loopback device or a physical disk or a partition, etc.
-// As such, only some fields are set depending on the context that the struct is
-// returned in.
-type lsblkBlockDevice struct {
-	// common shared fields
-
-	// Name is the name of the block device as identified by the node in /dev,
-	// such as mmcblk0p1 or loop319 or vda. This is specifically just the name,
-	// not the full path in /dev/.
-	Name string `json:"name"`
-	// Mountpoint is the mount point of the specific block device if it is
-	// mounted, as determined by lsblk. Note that there could be multiple
-	// mountpoints, it is unclear which specific one lsblk chooses to use as
-	// this setting in this situation. For physical disk devices (not partition
-	// devices), this is null/empty.
-	Mountpoint string `json:"mountpoint"`
-
-	// --fs option specific fields
-
-	// FSType is the type of filesystem on this device, i.e. ext4, squashfs,
-	// vfat, etc.
-	FSType string `json:"fstype"`
-	// Label is the filesystem label for a partition/device.
-	Label string `json:"label"`
-	// UUID is the filesystem UUID for a partition/device.
-	UUID string `json:"uuid"`
-
-	// no --fs option specific fields
-
-	// Type is the type of block device, i.e. loop or disk typically.
-	Type string `json:"type"`
-}
-
-// filesystemInfoForPartition returns information about the filesystem of a
-// single partition, identified by the device node path for this partition such
-// as /dev/mmcblk0p1 or /dev/sda1.
-func filesystemInfoForPartition(node string) (blk lsblkBlockDevice, err error) {
-	// verify that the specified node is indeed a partition by first running
-	// lsblk without the --fs
-	output, err := exec.Command("lsblk", "--json", node).CombinedOutput()
-	if err != nil {
-		return blk, osutil.OutputErr(output, err)
-	}
-
-	var info lsblkInfo
-	if err := json.Unmarshal(output, &info); err != nil {
-		return blk, fmt.Errorf("cannot parse lsblk output: %v", err)
-	}
-
-	if len(info.BlockDevices) != 1 || strings.ToLower(info.BlockDevices[0].Type) != "part" {
-		return blk, fmt.Errorf("device node %s is not a partition", node)
-	}
-
-	// otherwise the device is indeed a partition, get the information for the
-	// filesystem
-
-	// we only expect a single block device
-	output, err = exec.Command("lsblk", "--fs", "--json", node).CombinedOutput()
-	if err != nil {
-		return blk, osutil.OutputErr(output, err)
-	}
-
-	if err := json.Unmarshal(output, &info); err != nil {
-		return blk, fmt.Errorf("cannot parse lsblk output: %v", err)
-	}
-
-	switch len(info.BlockDevices) {
-	case 1:
-		// ok, expected, make the UUID capitalized for consistency
-		toUpperUUID(&info.BlockDevices[0])
-		return info.BlockDevices[0], nil
-	case 0:
-		// very unexpected, there was previously only one block device just
-		// above but now we somehow don't have one
-		return blk, fmt.Errorf("block device for device %s unexpectedly disappeared", node)
-	default:
-		// we now have more block devices for this partition, which is also
-		// unexpected
-		return blk, fmt.Errorf("block device for device %s unexpectedly multiplied", node)
-	}
-}
-
-func toUpperUUID(bd *lsblkBlockDevice) {
-	bd.UUID = strings.ToUpper(bd.UUID)
 }

--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -86,15 +86,16 @@ func OnDiskVolumeFromDisk(disk disks.Disk) (*OnDiskVolume, error) {
 	ds := make([]OnDiskStructure, len(parts))
 
 	for _, p := range parts {
-		// use the index of the structure on the disk rather than the order in
+		// Use the index of the structure on the disk rather than the order in
 		// which we iterate over the list of partitions, since the order of the
 		// partitions is returned "last seen first" which matches the behavior
 		// of udev when picking partitions with the same filesystem label and
-		// populating /dev/disk/by-label/ and friends
-		// all that is to say the order that the list of partitions from
+		// populating /dev/disk/by-label/ and friends.
+		// All that is to say the order that the list of partitions from
 		// Partitions() is in is _not_ the same as the order that the structures
 		// actually appear in on disk, but this is why the StructureIndex
-		// property exists
+		// property exists. Also note that StructureIndex starts at 1, as
+		// opposed to gadget.LaidOutVolume.Structure's Index which starts at 0.
 		i := p.StructureIndex - 1
 
 		// the PartitionLabel and FilesystemLabel are encoded, so they must be

--- a/gadget/ondisk_test.go
+++ b/gadget/ondisk_test.go
@@ -27,8 +27,8 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/gadget"
-	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -50,105 +50,6 @@ func (s *ondiskTestSuite) SetUpTest(c *C) {
 	s.gadgetRoot = c.MkDir()
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
-}
-
-const mockSfdiskScriptBiosSeed = `
->&2 echo "Some warning from sfdisk"
-echo '{
-  "partitiontable": {
-    "label": "gpt",
-    "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
-    "device": "/dev/node",
-    "unit": "sectors",
-    "firstlba": 34,
-    "lastlba": 8388574,
-    "partitions": [
-      {
-        "node": "/dev/node1",
-        "start": 2048,
-        "size": 2048,
-        "type": "21686148-6449-6E6F-744E-656564454649",
-        "uuid": "2E59D969-52AB-430B-88AC-F83873519F6F",
-        "name": "BIOS Boot"
-      },
-      {
-        "node": "/dev/node2",
-        "start": 4096,
-        "size": 2457600,
-        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-        "uuid": "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
-        "name": "Recovery"
-      }
-    ]
-  }
-}'`
-
-var mockLsblkScriptBiosSeedArgs = map[string]string{
-	"--json /dev/node1": `'{
-	"blockdevices": [
-		{"name":"node1", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-	]
-}'`,
-	"--fs --json /dev/node1": `'{
-	"blockdevices": [ {"name": "node1", "fstype": null, "label": null, "uuid": null, "mountpoint": null} ]
-}'`,
-	"--json /dev/node2": `'{
-	"blockdevices": [
-		{"name":"node2", "maj:min":"8:2", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-	]
-}'`,
-	"--fs --json /dev/node2": `'{
-		"blockdevices": [ {"name": "node2", "fstype": "vfat", "label": "ubuntu-seed", "uuid": "A644-B807", "mountpoint": null} ]
-}'`,
-}
-
-var mockLsblkForMBRArgs = map[string]string{
-	"--json /dev/node1": `'{
-"blockdevices": [
-	{"name":"node1", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-]
-}'`,
-	"--fs --json /dev/node1": `'{
-		"blockdevices": [ {"name": "node1", "fstype": "vfat", "label": "ubuntu-seed", "uuid": "A644-B807", "mountpoint": null} ]
-}'`,
-
-	"--json /dev/node2": `'{
-"blockdevices": [
-	{"name":"node2", "maj:min":"8:2", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-]
-}'`,
-	"--fs --json /dev/node2": `'{
-		"blockdevices": [ {"name": "node2", "fstype": "vfat", "label": "ubuntu-boot", "uuid": "A644-B808", "mountpoint": null} ]
-}'`,
-
-	"--json /dev/node3": `'{
-	"blockdevices": [
-		{"name":"node3", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-	]
-}'`,
-	"--fs --json /dev/node3": `'{
-		"blockdevices": [ {"name": "node3", "fstype": "ext4", "label": "ubuntu-save", "mountpoint": null} ]
-}'`,
-
-	"--json /dev/node4": `'{
-	"blockdevices": [
-		{"name":"node4", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-	]
-}'`,
-	"--fs --json /dev/node4": `'{
-		"blockdevices": [ {"name": "node3", "fstype": "ext4", "label": "ubuntu-data", "mountpoint": null} ]
-}'`,
-}
-
-var mockLsblkScriptBiosArgs = map[string]string{
-	"--json /dev/node1": `'{
-	"blockdevices": [
-		{"name":"node1", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-	]
-}'`,
-	"--fs --json /dev/node1": `'{
-	"blockdevices": [ {"name": "node1", "fstype": null, "label": null, "uuid": null, "mountpoint": null} ]
-}'`,
 }
 
 func makeMockGadget(gadgetRoot, gadgetContent string) error {
@@ -209,38 +110,55 @@ const gadgetContent = `volumes:
 `
 
 func (s *ondiskTestSuite) TestDeviceInfoGPT(c *C) {
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", mockSfdiskScriptBiosSeed)
-	defer cmdSfdisk.Restore()
+	m := map[string]*disks.MockDiskMapping{
+		"/dev/node": {
+			DevNum:          "42:0",
+			DevNode:         "/dev/node",
+			DiskSizeInBytes: (8388574 + 1) * 512,
+			DiskSchema:      "gpt",
+			ID:              "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+			SectorSizeBytes: 512,
+			// the actual order of the structure partitions does not matter,
+			// they will be put into the right order in the returned
+			// OnDiskVolume
+			Structure: []disks.Partition{
+				{
+					KernelDeviceNode: "/dev/node2",
+					StartInBytes:     4096 * 512,
+					SizeInBytes:      2457600 * 512,
+					PartitionType:    "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+					PartitionUUID:    "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
+					PartitionLabel:   "Recovery",
+					Major:            42,
+					Minor:            2,
+					StructureIndex:   2,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "A644-B807",
+					// The filesystem label will be properly decoded
+					FilesystemLabel: "ubuntu\x20seed",
+				},
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     2048 * 512,
+					SizeInBytes:      2048 * 512,
+					PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+					PartitionUUID:    "2E59D969-52AB-430B-88AC-F83873519F6F",
+					// the PartitionLabel will be properly decoded
+					PartitionLabel: "BIOS\x20Boot",
+					Major:          42,
+					Minor:          1,
+					StructureIndex: 1,
+				},
+			},
+		},
+	}
 
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(mockLsblkScriptBiosSeedArgs))
-	defer cmdLsblk.Restore()
-
-	cmdBlockdev := testutil.MockCommand(c, "blockdev", `
-if [ "$1" == --getss ]; then
-	# sector size
-	echo 512
-	exit 0
-fi
-echo "unexpected cmdline opts: $*"
-exit 1
-	`)
-	defer cmdBlockdev.Restore()
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
 	c.Assert(err, IsNil)
-	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-	})
-	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node1"},
-		{"lsblk", "--fs", "--json", "/dev/node1"},
-		{"lsblk", "--json", "/dev/node2"},
-		{"lsblk", "--fs", "--json", "/dev/node2"},
-	})
-	c.Assert(cmdBlockdev.Calls(), DeepEquals, [][]string{
-		{"blockdev", "--getss", "/dev/node"},
-	})
-	c.Assert(err, IsNil)
+
 	c.Assert(dl, DeepEquals, &gadget.OnDiskVolume{
 		Device:     "/dev/node",
 		ID:         "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
@@ -261,6 +179,7 @@ exit 1
 					StartOffset: 0x100000,
 					Index:       1,
 				},
+				Size: 0x100000,
 				Node: "/dev/node1",
 			},
 			{
@@ -268,7 +187,7 @@ exit 1
 					VolumeStructure: &gadget.VolumeStructure{
 						Name:       "Recovery",
 						Size:       0x4b000000,
-						Label:      "ubuntu-seed",
+						Label:      "ubuntu seed",
 						Type:       "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
 						ID:         "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
 						Filesystem: "vfat",
@@ -276,6 +195,7 @@ exit 1
 					StartOffset: 0x200000,
 					Index:       2,
 				},
+				Size: 0x4b000000,
 				Node: "/dev/node2",
 			},
 		},
@@ -283,37 +203,48 @@ exit 1
 }
 
 func (s *ondiskTestSuite) TestDeviceInfoGPT4096SectorSize(c *C) {
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", mockSfdiskScriptBiosSeed)
-	defer cmdSfdisk.Restore()
+	m := map[string]*disks.MockDiskMapping{
+		"/dev/node": {
+			DevNum:          "42:0",
+			DevNode:         "/dev/node",
+			DiskSizeInBytes: (8388574 + 1) * 4096,
+			DiskSchema:      "gpt",
+			ID:              "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+			SectorSizeBytes: 4096,
+			Structure: []disks.Partition{
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     2048 * 4096,
+					SizeInBytes:      2048 * 4096,
+					PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+					PartitionUUID:    "2E59D969-52AB-430B-88AC-F83873519F6F",
+					PartitionLabel:   "BIOS Boot",
+					Major:            42,
+					Minor:            1,
+					StructureIndex:   1,
+				},
+				{
+					KernelDeviceNode: "/dev/node2",
+					StartInBytes:     4096 * 4096,
+					SizeInBytes:      2457600 * 4096,
+					PartitionType:    "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+					PartitionUUID:    "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
+					PartitionLabel:   "Recovery",
+					Major:            42,
+					Minor:            2,
+					StructureIndex:   2,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "A644-B807",
+					FilesystemLabel:  "ubuntu-seed",
+				},
+			},
+		},
+	}
 
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(mockLsblkScriptBiosSeedArgs))
-	defer cmdLsblk.Restore()
-
-	cmdBlockdev := testutil.MockCommand(c, "blockdev", `
-if [ "$1" == --getss ]; then
-	# sector size
-	echo 4096
-	exit 0
-fi
-echo "unexpected cmdline opts: $*"
-exit 1
-	`)
-	defer cmdBlockdev.Restore()
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
-	c.Assert(err, IsNil)
-	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-	})
-	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node1"},
-		{"lsblk", "--fs", "--json", "/dev/node1"},
-		{"lsblk", "--json", "/dev/node2"},
-		{"lsblk", "--fs", "--json", "/dev/node2"},
-	})
-	c.Assert(cmdBlockdev.Calls(), DeepEquals, [][]string{
-		{"blockdev", "--getss", "/dev/node"},
-	})
 	c.Assert(err, IsNil)
 	c.Assert(dl, DeepEquals, &gadget.OnDiskVolume{
 		Device:     "/dev/node",
@@ -335,6 +266,7 @@ exit 1
 					StartOffset: 0x800000,
 					Index:       1,
 				},
+				Size: 0x800000,
 				Node: "/dev/node1",
 			},
 			{
@@ -350,6 +282,7 @@ exit 1
 					StartOffset: 0x1000000,
 					Index:       2,
 				},
+				Size: 0x258000000,
 				Node: "/dev/node2",
 			},
 		},
@@ -357,73 +290,89 @@ exit 1
 }
 
 func (s *ondiskTestSuite) TestDeviceInfoMBR(c *C) {
-	const mockSfdiskWithMBR = `
->&2 echo "Some warning from sfdisk"
-echo '{
-   "partitiontable": {
-      "label": "dos",
-      "device": "/dev/node",
-      "unit": "sectors",
-      "partitions": [
-         {"node": "/dev/node1", "start": 4096, "size": 2457600, "type": "c"},
-         {"node": "/dev/node2", "start": 2461696, "size": 1048576, "type": "d"},
-         {"node": "/dev/node3", "start": 3510272, "size": 1048576, "type": "d"},
-         {"node": "/dev/node4", "start": 4558848, "size": 1048576, "type": "d"}
-      ]
-   }
-}'`
 
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", mockSfdiskWithMBR)
-	defer cmdSfdisk.Restore()
+	m := map[string]*disks.MockDiskMapping{
+		"/dev/node": {
+			DevNum:          "42:0",
+			DevNode:         "/dev/node",
+			DiskSizeInBytes: 12345670 * 512,
+			DiskSchema:      "dos",
+			ID:              "0x1234567",
+			SectorSizeBytes: 512,
+			Structure: []disks.Partition{
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     4096 * 512,
+					SizeInBytes:      2457600 * 512,
+					PartitionType:    "0C",
+					PartitionLabel:   "ubuntu-seed",
+					Major:            42,
+					Minor:            1,
+					StructureIndex:   1,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "FF44-B807",
+					FilesystemLabel:  "ubuntu-seed",
+				},
+				{
+					KernelDeviceNode: "/dev/node2",
+					StartInBytes:     (4096 + 2457600) * 512,
+					SizeInBytes:      1048576 * 512,
+					PartitionType:    "0D",
+					PartitionLabel:   "ubuntu-boot",
+					Major:            42,
+					Minor:            2,
+					StructureIndex:   2,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "A644-B807",
+					FilesystemLabel:  "ubuntu-boot",
+				},
+				{
+					KernelDeviceNode: "/dev/node3",
+					StartInBytes:     (4096 + 2457600 + 1048576) * 512,
+					SizeInBytes:      1048576 * 512,
+					PartitionType:    "0D",
+					PartitionLabel:   "ubuntu-save",
+					Major:            42,
+					Minor:            3,
+					StructureIndex:   3,
+					FilesystemType:   "ext4",
+					FilesystemUUID:   "8781-433a",
+					FilesystemLabel:  "ubuntu-save",
+				},
+				{
+					KernelDeviceNode: "/dev/node4",
+					StartInBytes:     (4096 + 2457600 + 1048576 + 1048576) * 512,
+					SizeInBytes:      1048576 * 512,
+					PartitionType:    "0D",
+					PartitionLabel:   "ubuntu-data",
+					Major:            42,
+					Minor:            4,
+					StructureIndex:   4,
+					FilesystemType:   "ext4",
+					FilesystemUUID:   "8123-433a",
+					FilesystemLabel:  "ubuntu-data",
+				},
+			},
+		},
+	}
 
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(mockLsblkForMBRArgs))
-	defer cmdLsblk.Restore()
-
-	cmdBlockdev := testutil.MockCommand(c, "blockdev", `
-if [ "$1" == --getss ]; then
-	# sector size
-	echo 512
-	exit 0
-elif [ "$1" == --getsz ]; then
-# disk size in 512-byte sectors
-	echo 12345670
-	exit 0
-fi
-echo "unexpected cmdline opts: $*"
-exit 1
-	`)
-	defer cmdBlockdev.Restore()
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
-	c.Assert(err, IsNil)
-	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-	})
-	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node1"},
-		{"lsblk", "--fs", "--json", "/dev/node1"},
-		{"lsblk", "--json", "/dev/node2"},
-		{"lsblk", "--fs", "--json", "/dev/node2"},
-		{"lsblk", "--json", "/dev/node3"},
-		{"lsblk", "--fs", "--json", "/dev/node3"},
-		{"lsblk", "--json", "/dev/node4"},
-		{"lsblk", "--fs", "--json", "/dev/node4"},
-	})
-	c.Assert(cmdBlockdev.Calls(), DeepEquals, [][]string{
-		{"blockdev", "--getss", "/dev/node"},
-		{"blockdev", "--getsz", "/dev/node"},
-	})
 	c.Assert(err, IsNil)
 
 	c.Assert(dl, DeepEquals, &gadget.OnDiskVolume{
 		Device:     "/dev/node",
 		Schema:     "dos",
+		ID:         "0x1234567",
 		SectorSize: quantity.Size(512),
 		Size:       quantity.Size(12345670 * 512),
 		Structure: []gadget.OnDiskStructure{
 			{
 				LaidOutStructure: gadget.LaidOutStructure{
 					VolumeStructure: &gadget.VolumeStructure{
+						Name:       "ubuntu-seed",
 						Size:       2457600 * 512,
 						Label:      "ubuntu-seed",
 						Type:       "0C",
@@ -432,11 +381,13 @@ exit 1
 					StartOffset: 4096 * 512,
 					Index:       1,
 				},
+				Size: 2457600 * 512,
 				Node: "/dev/node1",
 			},
 			{
 				LaidOutStructure: gadget.LaidOutStructure{
 					VolumeStructure: &gadget.VolumeStructure{
+						Name:       "ubuntu-boot",
 						Size:       1048576 * 512,
 						Label:      "ubuntu-boot",
 						Type:       "0D",
@@ -445,11 +396,13 @@ exit 1
 					StartOffset: (4096 + 2457600) * 512,
 					Index:       2,
 				},
+				Size: 1048576 * 512,
 				Node: "/dev/node2",
 			},
 			{
 				LaidOutStructure: gadget.LaidOutStructure{
 					VolumeStructure: &gadget.VolumeStructure{
+						Name:       "ubuntu-save",
 						Size:       1048576 * 512,
 						Label:      "ubuntu-save",
 						Type:       "0D",
@@ -458,11 +411,13 @@ exit 1
 					StartOffset: (4096 + 2457600 + 1048576) * 512,
 					Index:       3,
 				},
+				Size: 1048576 * 512,
 				Node: "/dev/node3",
 			},
 			{
 				LaidOutStructure: gadget.LaidOutStructure{
 					VolumeStructure: &gadget.VolumeStructure{
+						Name:       "ubuntu-data",
 						Size:       1048576 * 512,
 						Label:      "ubuntu-data",
 						Type:       "0D",
@@ -471,400 +426,96 @@ exit 1
 					StartOffset: (4096 + 2457600 + 1048576 + 1048576) * 512,
 					Index:       4,
 				},
+				Size: 1048576 * 512,
 				Node: "/dev/node4",
 			},
 		},
 	})
-}
-
-func (s *ondiskTestSuite) TestDeviceInfoMBR4096SectorSize(c *C) {
-	const mockSfdiskWithMBR = `
->&2 echo "Some warning from sfdisk"
-echo '{
-   "partitiontable": {
-      "label": "dos",
-      "device": "/dev/node",
-      "unit": "sectors",
-      "partitions": [
-		{"node": "/dev/node1", "start":256, "size":2560, "type": "c"},
-		{"node": "/dev/node2", "start":2816, "size":2560, "type": "d"},
-		{"node": "/dev/node3", "start":5376, "size":128000, "type": "d"},
-		{"node": "/dev/node4", "start":133376, "size":6202079, "type": "d"}
-	 ]
-   }
-}'`
-
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", mockSfdiskWithMBR)
-	defer cmdSfdisk.Restore()
-
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(mockLsblkForMBRArgs))
-	defer cmdLsblk.Restore()
-
-	cmdBlockdev := testutil.MockCommand(c, "blockdev", `
-if [ "$1" == --getss ]; then
-	# sector size
-	echo 4096
-	exit 0
-elif [ "$1" == --getsz ]; then
-	# disk size in 512-byte sectors
-	echo 50683904
-	exit 0
-fi
-echo "unexpected cmdline opts: $*"
-exit 1
-	`)
-	defer cmdBlockdev.Restore()
-
-	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
-	c.Assert(err, IsNil)
-	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-	})
-	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node1"},
-		{"lsblk", "--fs", "--json", "/dev/node1"},
-		{"lsblk", "--json", "/dev/node2"},
-		{"lsblk", "--fs", "--json", "/dev/node2"},
-		{"lsblk", "--json", "/dev/node3"},
-		{"lsblk", "--fs", "--json", "/dev/node3"},
-		{"lsblk", "--json", "/dev/node4"},
-		{"lsblk", "--fs", "--json", "/dev/node4"},
-	})
-	c.Assert(cmdBlockdev.Calls(), DeepEquals, [][]string{
-		{"blockdev", "--getss", "/dev/node"},
-		{"blockdev", "--getsz", "/dev/node"},
-	})
-	c.Assert(err, IsNil)
-
-	c.Assert(dl, DeepEquals, &gadget.OnDiskVolume{
-		Device:     "/dev/node",
-		Schema:     "dos",
-		SectorSize: quantity.Size(4096),
-		Size:       quantity.Size(6335488 * 4096),
-		Structure: []gadget.OnDiskStructure{
-			{
-				LaidOutStructure: gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						Size:       2560 * 4096,
-						Label:      "ubuntu-seed",
-						Type:       "0C",
-						Filesystem: "vfat",
-					},
-					StartOffset: 256 * 4096,
-					Index:       1,
-				},
-				Node: "/dev/node1",
-			},
-			{
-				LaidOutStructure: gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						Size:       2560 * 4096,
-						Label:      "ubuntu-boot",
-						Type:       "0D",
-						Filesystem: "vfat",
-					},
-					StartOffset: (256 + 2560) * 4096,
-					Index:       2,
-				},
-				Node: "/dev/node2",
-			},
-			{
-				LaidOutStructure: gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						Size:       128000 * 4096,
-						Label:      "ubuntu-save",
-						Type:       "0D",
-						Filesystem: "ext4",
-					},
-					StartOffset: (256 + 2560 + 2560) * 4096,
-					Index:       3,
-				},
-				Node: "/dev/node3",
-			},
-			{
-				LaidOutStructure: gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						Size:       6202079 * 4096,
-						Label:      "ubuntu-data",
-						Type:       "0D",
-						Filesystem: "ext4",
-					},
-					StartOffset: (256 + 2560 + 2560 + 128000) * 4096,
-					Index:       4,
-				},
-				Node: "/dev/node4",
-			},
-		},
-	})
-}
-
-func (s *ondiskTestSuite) TestDeviceInfoNotSectors(c *C) {
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", `echo '{
-   "partitiontable": {
-      "label": "gpt",
-      "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
-      "device": "/dev/node",
-      "unit": "not_sectors",
-      "firstlba": 34,
-      "lastlba": 8388574,
-      "partitions": [
-         {"node": "/dev/node1", "start": 2048, "size": 2048, "type": "21686148-6449-6E6F-744E-656564454649", "uuid": "2E59D969-52AB-430B-88AC-F83873519F6F", "name": "BIOS Boot"}
-      ]
-   }
-}'`)
-	defer cmdSfdisk.Restore()
-
-	_, err := gadget.OnDiskVolumeFromDevice("/dev/node")
-	c.Assert(err, ErrorMatches, "cannot position partitions: unknown unit .*")
-}
-
-func (s *ondiskTestSuite) TestDeviceInfoSectorSizeNotMultiple512Unhappy(c *C) {
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", `echo '{
-   "partitiontable": {
-      "label": "gpt",
-      "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
-      "device": "/dev/node",
-      "unit": "sectors",
-      "firstlba": 34,
-      "lastlba": 8388574,
-      "partitions": [
-         {"node": "/dev/node1", "start": 2048, "size": 2048, "type": "21686148-6449-6E6F-744E-656564454649", "uuid": "2E59D969-52AB-430B-88AC-F83873519F6F", "name": "BIOS Boot"}
-      ]
-   }
-}'`)
-	defer cmdSfdisk.Restore()
-
-	cmdBlockdev := testutil.MockCommand(c, "blockdev", `
-if [ "$1" == --getss ]; then
-   # sector size
-   echo 513
-   exit 0
-fi
-echo "unexpected cmdline opts: $*"
-exit 1
-`)
-	defer cmdBlockdev.Restore()
-
-	_, err := gadget.OnDiskVolumeFromDevice("/dev/node")
-	c.Assert(err, ErrorMatches, `cannot calculate structure size: sector size \(513\) is not a multiple of 512`)
-
-	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-	})
-
-	c.Assert(cmdBlockdev.Calls(), DeepEquals, [][]string{
-		{"blockdev", "--getss", "/dev/node"},
-	})
-
-}
-
-func (s *ondiskTestSuite) TestDeviceInfoFilesystemInfoError(c *C) {
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", `echo '{
-   "partitiontable": {
-      "label": "gpt",
-      "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
-      "device": "/dev/node",
-      "unit": "sectors",
-      "firstlba": 34,
-      "lastlba": 8388574,
-      "partitions": [
-         {"node": "/dev/node1", "start": 2048, "size": 2048, "type": "21686148-6449-6E6F-744E-656564454649", "uuid": "2E59D969-52AB-430B-88AC-F83873519F6F", "name": "BIOS Boot"}
-      ]
-   }
-}'`)
-	defer cmdSfdisk.Restore()
-
-	cmdBlockdev := testutil.MockCommand(c, "blockdev", `
-if [ "$1" == --getss ]; then
-   # sector size
-   echo 512
-   exit 0
-fi
-echo "unexpected cmdline opts: $*"
-exit 1
-`)
-	defer cmdBlockdev.Restore()
-
-	cmdLsblk := testutil.MockCommand(c, "lsblk", "echo lsblk error; exit 1")
-	defer cmdLsblk.Restore()
-
-	_, err := gadget.OnDiskVolumeFromDevice("/dev/node")
-	c.Assert(err, ErrorMatches, "cannot obtain filesystem information: lsblk error")
-
-	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-	})
-
-	c.Assert(cmdBlockdev.Calls(), DeepEquals, [][]string{
-		{"blockdev", "--getss", "/dev/node"},
-	})
-
-	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node1"},
-	})
-}
-
-func (s *ondiskTestSuite) TestDeviceInfoJsonError(c *C) {
-	cmd := testutil.MockCommand(c, "sfdisk", `echo 'This is not a json'`)
-	defer cmd.Restore()
-
-	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
-	c.Assert(err, ErrorMatches, "cannot parse sfdisk output: invalid .*")
-	c.Assert(dl, IsNil)
-}
-
-func (s *ondiskTestSuite) TestDeviceInfoError(c *C) {
-	cmd := testutil.MockCommand(c, "sfdisk", "echo 'sfdisk: not found'; exit 127")
-	defer cmd.Restore()
-
-	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
-	c.Assert(err, ErrorMatches, "sfdisk: not found")
-	c.Assert(dl, IsNil)
 }
 
 func (s *ondiskTestSuite) TestUpdatePartitionList(c *C) {
-	const mockSfdiskScriptBios = `
->&2 echo "Some warning from sfdisk"
-echo '{
-  "partitiontable": {
-    "label": "gpt",
-    "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
-    "device": "/dev/node",
-    "unit": "sectors",
-    "firstlba": 34,
-    "lastlba": 8388574,
-    "partitions": [
-      {
-        "node": "/dev/node1",
-        "start": 2048,
-        "size": 2048,
-        "type": "21686148-6449-6E6F-744E-656564454649",
-        "uuid": "2E59D969-52AB-430B-88AC-F83873519F6F",
-        "name": "BIOS Boot"
-      }
-    ]
-  }
-}'`
-
-	// sector size is same for all calls
-	cmdBlockdev := testutil.MockCommand(c, "blockdev", `
-if [ "$1" == --getss ]; then
-   # sector size
-   echo 512
-   exit 0
-fi
-echo "unexpected cmdline opts: $*"
-exit 1
-`)
-	defer cmdBlockdev.Restore()
-
 	// start with a single partition
-	cmdSfdisk := testutil.MockCommand(c, "sfdisk", mockSfdiskScriptBios)
-	defer cmdSfdisk.Restore()
+	m := map[string]*disks.MockDiskMapping{
+		"/dev/node": {
+			DevNum:          "42:0",
+			DevNode:         "/dev/node",
+			DiskSizeInBytes: (8388574 + 1) * 512,
+			DiskSchema:      "gpt",
+			ID:              "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+			SectorSizeBytes: 512,
+			Structure: []disks.Partition{
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     2048 * 512,
+					SizeInBytes:      2048 * 512,
+					PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+					PartitionUUID:    "2E59D969-52AB-430B-88AC-F83873519F6F",
+					PartitionLabel:   "BIOS Boot",
+					Major:            42,
+					Minor:            1,
+					StructureIndex:   1,
+				},
+			},
+		},
+	}
 
-	cmdLsblk := testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(mockLsblkScriptBiosArgs))
-	defer cmdLsblk.Restore()
+	restore := disks.MockDeviceNameToDiskMapping(m)
+	defer restore()
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
 	c.Assert(err, IsNil)
-
-	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-	})
-
-	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node1"},
-		{"lsblk", "--fs", "--json", "/dev/node1"},
-	})
 
 	c.Assert(len(dl.Structure), Equals, 1)
 	c.Assert(dl.Structure[0].Node, Equals, "/dev/node1")
 
 	// add a partition
-	cmdSfdisk = testutil.MockCommand(c, "sfdisk", mockSfdiskScriptBiosSeed)
-	defer cmdSfdisk.Restore()
+	m2 := map[string]*disks.MockDiskMapping{
+		"/dev/node": {
+			DevNum:          "42:0",
+			DevNode:         "/dev/node",
+			DiskSizeInBytes: (8388574 + 1) * 512,
+			DiskSchema:      "gpt",
+			ID:              "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",
+			SectorSizeBytes: 512,
+			Structure: []disks.Partition{
+				{
+					KernelDeviceNode: "/dev/node1",
+					StartInBytes:     2048 * 512,
+					SizeInBytes:      2048 * 512,
+					PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+					PartitionUUID:    "2E59D969-52AB-430B-88AC-F83873519F6F",
+					PartitionLabel:   "BIOS Boot",
+					Major:            42,
+					Minor:            1,
+					StructureIndex:   1,
+				},
+				{
+					KernelDeviceNode: "/dev/node2",
+					StartInBytes:     4096 * 512,
+					SizeInBytes:      2457600 * 512,
+					PartitionType:    "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+					PartitionUUID:    "44C3D5C3-CAE1-4306-83E8-DF437ACDB32F",
+					PartitionLabel:   "ubuntu-seed",
+					Major:            42,
+					Minor:            2,
+					StructureIndex:   2,
+					FilesystemType:   "vfat",
+					FilesystemUUID:   "A644-B807",
+					FilesystemLabel:  "ubuntu-seed",
+				},
+			},
+		},
+	}
 
-	cmdLsblk = testutil.MockCommand(c, "lsblk", gadgettest.MockLsblkCommand(mockLsblkScriptBiosSeedArgs))
-	defer cmdLsblk.Restore()
+	restore = disks.MockDeviceNameToDiskMapping(m2)
+	defer restore()
 
 	// update the partition list
 	err = gadget.UpdatePartitionList(dl)
 	c.Assert(err, IsNil)
 
-	c.Assert(cmdBlockdev.Calls(), DeepEquals, [][]string{
-		{"blockdev", "--getss", "/dev/node"},
-		{"blockdev", "--getss", "/dev/node"},
-	})
-
-	c.Assert(cmdSfdisk.Calls(), DeepEquals, [][]string{
-		{"sfdisk", "--json", "/dev/node"},
-	})
-
-	c.Assert(cmdLsblk.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node1"},
-		{"lsblk", "--fs", "--json", "/dev/node1"},
-		{"lsblk", "--json", "/dev/node2"},
-		{"lsblk", "--fs", "--json", "/dev/node2"},
-	})
-
 	// check if the partition list was updated
 	c.Assert(len(dl.Structure), Equals, 2)
 	c.Assert(dl.Structure[0].Node, Equals, "/dev/node1")
 	c.Assert(dl.Structure[1].Node, Equals, "/dev/node2")
-}
-
-func (s *ondiskTestSuite) TestFilesystemInfo(c *C) {
-	// we call lsblk twice, first time to verify that the block device specified
-	// is a partition and then to actually get the filesystem info
-	cmd := testutil.MockCommand(c, "lsblk", `
-case "$*" in 
-	"--json /dev/node")
-		# the partition check call
-		echo '{
-			"blockdevices": [
-			{"name":"node", "maj:min":"8:1", "rm":false, "size":"931.5G", "ro":false, "type":"part", "mountpoint":null}
-			]
-		}'
-		;;
-	 "--fs --json /dev/node")
-		# the filesystem call
-		echo '{
-			"blockdevices": [
-			{"name": "loop8p2", "fstype": "vfat", "label": "ubuntu-seed", "uuid": "C1F4-CE43", "mountpoint": null}
-			]
-		}'
-		;;
-	*)
-		echo "unexpected args $*"
-		exit 1
-		;;
-esac`)
-	defer cmd.Restore()
-
-	bd, err := gadget.FilesystemInfoForPartition("/dev/node")
-	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"lsblk", "--json", "/dev/node"},
-		{"lsblk", "--fs", "--json", "/dev/node"},
-	})
-	c.Assert(err, IsNil)
-	c.Assert(bd.Name, Equals, "loop8p2")
-	c.Assert(bd.FSType, Equals, "vfat")
-	c.Assert(bd.Label, Equals, "ubuntu-seed")
-	c.Assert(bd.UUID, Equals, "C1F4-CE43")
-}
-
-func (s *ondiskTestSuite) TestFilesystemInfoJsonError(c *C) {
-	cmd := testutil.MockCommand(c, "lsblk", `echo 'This is not a json'`)
-	defer cmd.Restore()
-
-	_, err := gadget.FilesystemInfoForPartition("/dev/node")
-	c.Assert(err, ErrorMatches, "cannot parse lsblk output: invalid .*")
-}
-
-func (s *ondiskTestSuite) TestFilesystemInfoError(c *C) {
-	cmd := testutil.MockCommand(c, "lsblk", "echo 'lsblk: not found'; exit 127")
-	defer cmd.Restore()
-
-	_, err := gadget.FilesystemInfoForPartition("/dev/node")
-	c.Assert(err, ErrorMatches, "lsblk: not found")
 }

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -177,13 +177,16 @@ func EnsureLayoutCompatibility(gadgetLayout *LaidOutVolume, diskLayout *OnDiskVo
 			// don't return a reason if the names don't match
 			return false, ""
 		case ds.StartOffset != gs.StartOffset:
-			return false, fmt.Sprintf("start offsets do not match (disk: %d (%s) and gadget: %d (%s))", ds.StartOffset, ds.StartOffset.IECString(), gs.StartOffset, gs.StartOffset.IECString())
+			return false, fmt.Sprintf("start offsets do not match (disk: %d (%s) and gadget: %d (%s))",
+				ds.StartOffset, ds.StartOffset.IECString(), gs.StartOffset, gs.StartOffset.IECString())
 		case !isCreatableAtInstall(gv) && dv.Filesystem != gv.Filesystem:
 			return false, "filesystems do not match and the partition is not creatable at install"
 		case dv.Size < gv.Size:
-			return false, "on disk size is smaller than gadget size"
+			return false, fmt.Sprintf("on disk size %d (%s) is smaller than gadget size %d (%s)",
+				dv.Size, dv.Size.IECString(), gv.Size, gv.Size.IECString())
 		case gv.Role != SystemData && dv.Size > gv.Size:
-			return false, "on disk size is larger than gadget size (and the role should not be expanded)"
+			return false, fmt.Sprintf("on disk size %d (%s) is larger than gadget size %d (%s) (and the role should not be expanded)",
+				dv.Size, dv.Size.IECString(), gv.Size, gv.Size.IECString())
 		default:
 			return false, "some other logic condition (should be impossible?)"
 		}
@@ -206,9 +209,10 @@ func EnsureLayoutCompatibility(gadgetLayout *LaidOutVolume, diskLayout *OnDiskVo
 	}
 
 	// check size of volumes
-	if gadgetLayout.Size > diskLayout.Size {
-		return fmt.Errorf("device %v (%s) is too small to fit the requested layout (%s)", diskLayout.Device,
-			diskLayout.Size.IECString(), gadgetLayout.Size.IECString())
+	lastUsableByte := quantity.Size(diskLayout.UsableSectorsEnd) * diskLayout.SectorSize
+	if gadgetLayout.Size > lastUsableByte {
+		return fmt.Errorf("device %v (last usable byte at %s) is too small to fit the requested layout (%s)", diskLayout.Device,
+			lastUsableByte.IECString(), gadgetLayout.Size.IECString())
 	}
 
 	// check that the sizes of all structures in the gadget are multiples of

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -49,6 +49,13 @@ restore: |
 
 debug: |
     cat /proc/partitions
+    LOOP="$(cat loop.txt)"
+    udevadm info --query property "${LOOP}" || true
+    udevadm info --query property "${LOOP}p1" || true
+    udevadm info --query property "${LOOP}p2" || true
+    udevadm info --query property "${LOOP}p3" || true
+    udevadm info --query property "${LOOP}p4" || true
+    udevadm info --query property "${LOOP}p5" || true
 
 execute: |
     LOOP="$(cat loop.txt)"

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -3,6 +3,9 @@ summary: Integration tests for the bootstrap.Run
 # use the same system and tooling as uc20
 systems: [ubuntu-20.04-64]
 
+environment:
+    SNAPD_DEBUG: "1"
+
 prepare: |
     echo "Create a fake block device image that looks like an image from u-i"
     truncate --size=20GB fake.img
@@ -54,6 +57,13 @@ restore: |
 
 debug: |
     cat /proc/partitions
+    LOOP="$(cat loop.txt)"
+    udevadm info --query property "${LOOP}" || true
+    udevadm info --query property "${LOOP}p1" || true
+    udevadm info --query property "${LOOP}p2" || true
+    udevadm info --query property "${LOOP}p3" || true
+    udevadm info --query property "${LOOP}p4" || true
+    udevadm info --query property "${LOOP}p5" || true
 
 execute: |
     LOOP="$(cat loop.txt)"
@@ -80,11 +90,13 @@ execute: |
 
     # we used "lsblk --fs" here but it was unreliable
     mkdir -p ./mnt
+
+    echo "Mount ubuntu-seed and check it is vfat"
     mount "${LOOP}p2" ./mnt
     df -T "${LOOP}p2" | MATCH vfat
     umount ./mnt
 
-    mkdir -p ./mnt
+    echo "Mount ubuntu-boot and check it is ext4 with metadata_csum"
     mount "${LOOP}p3" ./mnt
     df -T "${LOOP}p3" | MATCH ext4
     umount ./mnt
@@ -92,7 +104,7 @@ execute: |
     # check metadata_csum
     tune2fs -l "${LOOP}p3" | MATCH '^Filesystem features:.*metadata_csum'
 
-    mkdir -p ./mnt
+    echo "Mount ubuntu-save and check it is ext4 with metadata_csum"
     mount "${LOOP}p4" ./mnt
     df -T "${LOOP}p4" | MATCH ext4
     umount ./mnt
@@ -100,14 +112,16 @@ execute: |
     # check metadata_csum
     tune2fs -l "${LOOP}p4" | MATCH '^Filesystem features:.*metadata_csum'
 
-    mkdir -p ./mnt
+    echo "Mount ubuntu-data and check it is ext4 with metadata_csum"
     mount "${LOOP}p5" ./mnt
     df -T "${LOOP}p5" | MATCH ext4
     umount ./mnt
     file -s "${LOOP}p5" | MATCH 'ext4 filesystem data,.* volume name "ubuntu-data"'
     # check metadata_csum
     tune2fs -l "${LOOP}p5" | MATCH '^Filesystem features:.*metadata_csum'
+
     # size is reported in 512 blocks
+    echo "Check ubuntu-data size is expanded"
     sz="$(udevadm info -q property "${LOOP}p5" |grep "^ID_PART_ENTRY_SIZE=" | cut -f2 -d=)"
     # the disk size is 20GB, 1GB in 512 blocks is 2097152, with auto grow, the
     # partition can be safely assumed to be > 10GB
@@ -117,7 +131,6 @@ execute: |
     fi
 
     echo "Check that the filesystem content was deployed"
-    mkdir -p ./mnt
     mount "${LOOP}p3" ./mnt
     ls ./mnt/EFI/boot/grubx64.efi
     ls ./mnt/EFI/boot/bootx64.efi
@@ -142,8 +155,6 @@ execute: |
     sfdisk -l "$LOOP" | MATCH "${LOOP}p6 .* 110M\s* Linux filesystem"
 
     echo "check that the filesystems are created and mounted"
-    mount
-
     mount | MATCH /run/mnt/ubuntu-boot
     mount | MATCH /run/mnt/ubuntu-save
     mount | MATCH /run/mnt/ubuntu-data


### PR DESCRIPTION
This enables us to write much simpler tests for complicated disk setups, which
will be critical for supporting multiple volume update situations, as otherwise
we would be left writing extremely complicated sfdisk and lsblk mock commands
which is no fun.

This also refactors the calculation of the size of partitions to use the more
natural and specific field "UsableSectorsEnd" which makes the code more 
readable and clear about what is going on without using the Size field, which
isn't quite what we want for the partition size calculation of expanded 
partitions.

Also delete the short-lived MockLsblkCommand in the gadgettest package, its
utility is no more.

Based on top of:
- [x] https://github.com/snapcore/snapd/pull/10919
- [x] https://github.com/snapcore/snapd/pull/10920
- [x] https://github.com/snapcore/snapd/pull/10921