### PR TITLE
interfaces: Allow access to hunspell dictionaries for spellchecking

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -63,6 +63,10 @@ owner @{HOME}/.local/share/fonts/{,**} r,
 # some applications are known to mmap fonts
 /usr/{,local/}share/fonts/** m,
 
+# Allow access to the host's hunspell dictionaries for spellchecking
+# /usr/share/hunspell plus possible distro specific variants
+/usr/{,local/}share/{hunspell,myspell}/** r,
+
 # subset of gnome abstraction
 /etc/gtk-3.0/settings.ini r,
 owner @{HOME}/.config/gtk-3.0/settings.ini r,


### PR DESCRIPTION
This commit is a step to address this bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=1732755

Users should be able to install spellchecking dictionaries as needed
and share those also with the confined Firefox snap. If combined with
setting the DICPATH environment variable, this rule will prevent a
functional regression for Ubuntu users who switch from Firefox installed
as .deb to the Firefox snap.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
