### PR TITLE
tests: (partially) revert the memory limits PR#r10241

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -246,7 +246,8 @@ prepare_memory_limit_override() {
         # systemd is backwards compatible so the limit is still set.
         cat <<EOF > /etc/systemd/system/snapd.service.d/memory-max.conf
 [Service]
-MemoryLimit=100M
+# mvo: disabled because of many failures in restore, e.g. in PR#11014
+#MemoryLimit=100M
 EOF
     fi
     # the service setting may have changed in the service so we need


### PR DESCRIPTION
There are a bunch of failures with the memory limits in e.g.
https://github.com/snapcore/snapd/pull/11014

To avoid blocking landings this commit partially reverts
memory limits.
