### PR TITLE
osutil/disks: support device-unlock encrypted device mapper nodes in disks pkg [easy]

### DIFF
--- a/kernel/fde/fde.go
+++ b/kernel/fde/fde.go
@@ -29,6 +29,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/snapcore/snapd/osutil"
 )
@@ -185,4 +186,12 @@ func DeviceSetup(runSetupHook RunSetupHookFunc, params *DeviceSetupParams) error
 	}
 
 	return nil
+}
+
+// IsEncryptedDevice returns true when the provided device mapper name indicates
+// that it is encrypted using FDE hooks.
+func IsEncryptedDeviceMapperName(dmName string) bool {
+	// TODO: is there anything more we can use to limit the prefix of the
+	// dmName?
+	return dmName != "-device-locked" && strings.HasSuffix(dmName, "-device-locked")
 }

--- a/kernel/fde/fde_test.go
+++ b/kernel/fde/fde_test.go
@@ -598,3 +598,27 @@ func (s *fdeSuite) TestHasDeviceUnlock(c *C) {
 
 	c.Check(fde.HasDeviceUnlock(), Equals, true)
 }
+
+func (s *fdeSuite) TestIsEncryptedDeviceMapperName(c *C) {
+	// matches
+	for _, t := range []string{
+		"something-device-locked",
+		"foo23-device-locked",
+		"device-device-locked",
+		"WE-DON'T-CARE-WHAT-THE-PREFIX-IS-AND-YOU-CAN'T-MAKE-US-device-locked",
+	} {
+		c.Assert(fde.IsEncryptedDeviceMapperName(t), Equals, true)
+	}
+
+	// doesn't match
+	for _, t := range []string{
+		"",
+		"-device-locked",
+		"device-locked",
+		"-device-locked-foo",
+		"some-device",
+		"CRYPT-LUKS2-5a522809c87e4dfa81a88dc5667d1304-ubuntu-data-3776bab4-8bcc-46b7-9da2-6a84ce7f93b4",
+	} {
+		c.Assert(fde.IsEncryptedDeviceMapperName(t), Equals, false)
+	}
+}

--- a/osutil/disks/disks_darwin.go
+++ b/osutil/disks/disks_darwin.go
@@ -44,3 +44,7 @@ var diskFromMountPoint = func(mountpoint string, opts *Options) (Disk, error) {
 var mountPointsForPartitionRoot = func(p Partition, opts map[string]string) ([]string, error) {
 	return nil, osutil.ErrDarwin
 }
+
+var diskFromPartitionDeviceNode = func(node string) (Disk, error) {
+	return nil, osutil.ErrDarwin
+}

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/osutil"
 )
 
@@ -447,52 +448,70 @@ func diskFromPartUdevPropsAndOpts(props map[string]string, opts *Options) (*disk
 		if err != nil {
 			return nil, fmt.Errorf(errFmt, err)
 		}
+		dmUUID = bytes.TrimSpace(dmUUID)
 
 		dmName, err := ioutil.ReadFile(filepath.Join(dmDir, "name"))
 		if err != nil {
 			return nil, fmt.Errorf(errFmt, err)
 		}
+		dmName = bytes.TrimSpace(dmName)
 
-		// trim the suffix of the dm name from the dm uuid to safely match the
-		// regex - the dm uuid contains the dm name, and the dm name is user
-		// controlled, so we want to remove that and just use the luks pattern
-		// to match the device uuid
-		// we are extra safe here since the dm name could be hypothetically user
-		// controlled via an external USB disk with LVM partition names, etc.
-		dmUUIDSafe := bytes.TrimSuffix(
-			bytes.TrimSpace(dmUUID),
-			append([]byte("-"), bytes.TrimSpace(dmName)...),
-		)
-		matches := luksUUIDPatternRe.FindSubmatch(dmUUIDSafe)
-		if len(matches) != 2 {
-			// the format of the uuid is different - different luks version
-			// maybe?
-			return nil, fmt.Errorf("cannot verify disk: partition %s does not have a valid luks uuid format: %s", majmin, dmUUIDSafe)
-		}
+		if strings.HasPrefix(string(dmUUID), "CRYPT-LUKS") {
+			// this is a LUKS encrypted device
 
-		// the uuid is the first and only submatch, but it is not in the same
-		// format exactly as we want to use, namely it is missing all of the "-"
-		// characters in a typical uuid, i.e. it is of the form:
-		// ae6e79de00a9406f80ee64ba7c1966bb but we want it to be like:
-		// ae6e79de-00a9-406f-80ee-64ba7c1966bb so we need to add in 4 "-"
-		// characters
-		compactUUID := string(matches[1])
-		canonicalUUID := fmt.Sprintf(
-			"%s-%s-%s-%s-%s",
-			compactUUID[0:8],
-			compactUUID[8:12],
-			compactUUID[12:16],
-			compactUUID[16:20],
-			compactUUID[20:],
-		)
+			// trim the suffix of the dm name from the dm uuid to safely match the
+			// regex - the dm uuid contains the dm name, and the dm name is user
+			// controlled, so we want to remove that and just use the luks pattern
+			// to match the device uuid
+			// we are extra safe here since the dm name could be hypothetically user
+			// controlled via an external USB disk with LVM partition names, etc.
+			dmUUIDSafe := bytes.TrimSuffix(
+				bytes.TrimSpace(dmUUID),
+				append([]byte("-"), bytes.TrimSpace(dmName)...),
+			)
+			matches := luksUUIDPatternRe.FindSubmatch(dmUUIDSafe)
+			if len(matches) != 2 {
+				// the format of the uuid is different - different luks version
+				// maybe?
+				return nil, fmt.Errorf("cannot verify disk: partition %s does not have a valid luks uuid format: %s", majmin, dmUUIDSafe)
+			}
 
-		// now finally, we need to use this uuid, which is the device uuid of
-		// the actual physical encrypted partition to get the path, which will
-		// be something like /dev/vda4, etc.
-		byUUIDPath := filepath.Join("/dev/disk/by-uuid", canonicalUUID)
-		props, err = udevPropertiesForName(byUUIDPath)
-		if err != nil {
-			return nil, fmt.Errorf("cannot get udev properties for encrypted partition %s: %v", byUUIDPath, err)
+			// the uuid is the first and only submatch, but it is not in the same
+			// format exactly as we want to use, namely it is missing all of the "-"
+			// characters in a typical uuid, i.e. it is of the form:
+			// ae6e79de00a9406f80ee64ba7c1966bb but we want it to be like:
+			// ae6e79de-00a9-406f-80ee-64ba7c1966bb so we need to add in 4 "-"
+			// characters
+			compactUUID := string(matches[1])
+			canonicalUUID := fmt.Sprintf(
+				"%s-%s-%s-%s-%s",
+				compactUUID[0:8],
+				compactUUID[8:12],
+				compactUUID[12:16],
+				compactUUID[16:20],
+				compactUUID[20:],
+			)
+
+			// now finally, we need to use this uuid, which is the device uuid of
+			// the actual physical encrypted partition to get the path, which will
+			// be something like /dev/vda4, etc.
+			byUUIDPath := filepath.Join("/dev/disk/by-uuid", canonicalUUID)
+			props, err = udevPropertiesForName(byUUIDPath)
+			if err != nil {
+				return nil, fmt.Errorf("cannot get udev properties for encrypted partition %s: %v", byUUIDPath, err)
+			}
+		} else if fde.IsEncryptedDeviceMapperName(string(dmName)) {
+			// this is a device encrypted using FDE hooks
+
+			// the uuid of the mapper device is the same
+			// as the partlabel
+			byUUIDPath := filepath.Join("/dev/disk/by-partuuid", string(dmUUID))
+			props, err = udevPropertiesForName(byUUIDPath)
+			if err != nil {
+				return nil, fmt.Errorf("cannot get udev properties for encrypted partition %s: %v", byUUIDPath, err)
+			}
+		} else {
+			return nil, fmt.Errorf("expected encrypted device, but got unencrypted one")
 		}
 	}
 

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -202,6 +202,50 @@ func (s *diskSuite) TestDiskFromDevicePathHappy(c *C) {
 	c.Assert(d.HasPartitions(), Equals, true)
 }
 
+func (s *diskSuite) TestDiskFromPartitionDeviceNodeHappy(c *C) {
+	restore := disks.MockUdevPropertiesForDevice(func(typeOpt, dev string) (map[string]string, error) {
+		c.Assert(typeOpt, Equals, "--name")
+		switch dev {
+		// first is for the partition itself, only relevant info is the
+		// ID_PART_ENTRY_DISK which is the parent disk
+		case "/dev/sda1":
+			return map[string]string{
+				"ID_PART_ENTRY_DISK": "42:0",
+			}, nil
+		// next up is the disk itself identified by the major/minor
+		case "/dev/block/42:0":
+			return map[string]string{
+				"DEVTYPE":            "disk",
+				"DEVNAME":            "/dev/sda",
+				"DEVPATH":            "/devices/foo/sda",
+				"ID_PART_TABLE_UUID": "foo-id",
+				"ID_PART_TABLE_TYPE": "gpt",
+			}, nil
+		default:
+			c.Errorf("unexpected udev device properties requested: %s", dev)
+			return nil, fmt.Errorf("unexpected udev device: %s", dev)
+		}
+	})
+	defer restore()
+
+	// create the partition device node too
+	createVirtioDevicesInSysfs(c, "/devices/foo/sda", map[string]bool{
+		"sda1": true,
+	})
+
+	d, err := disks.DiskFromPartitionDeviceNode("/dev/sda1")
+	c.Assert(err, IsNil)
+	c.Assert(d.Dev(), Equals, "42:0")
+	c.Assert(d.DiskID(), Equals, "foo-id")
+	c.Assert(d.Schema(), Equals, "gpt")
+	c.Assert(d.KernelDeviceNode(), Equals, "/dev/sda")
+	// note that we don't always prepend exactly /sys, we use dirs.SysfsDir
+	c.Assert(d.KernelDevicePath(), Equals, filepath.Join(dirs.SysfsDir, "/devices/foo/sda"))
+
+	// it doesn't have any partitions since we didn't mock any in sysfs
+	c.Assert(d.HasPartitions(), Equals, true)
+}
+
 func (s *diskSuite) TestDiskFromDeviceNameUnhappyPartition(c *C) {
 	restore := disks.MockUdevPropertiesForDevice(func(typeOpt, dev string) (map[string]string, error) {
 		c.Assert(typeOpt, Equals, "--name")
@@ -279,7 +323,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyMissingUdevProps(c *C) {
 	defer restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "cannot find disk for partition /dev/vda4, incomplete udev output")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point, incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyBadUdevPropsMountpointPartition(c *C) {
@@ -298,7 +342,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyBadUdevPropsMountpointPartition
 	defer restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, `cannot find disk for partition /dev/vda4, bad udev output: invalid device number format: \(expected <int>:<int>\)`)
+	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point, bad udev output: invalid device number format: \(expected <int>:<int>\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(c *C) {
@@ -326,7 +370,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `mountpoint source /dev/vda4 is not a decrypted device: devtype is not disk \(is partition\)`)
+	c.Assert(err, ErrorMatches, `mountpoint source /dev/vda4 of /run/mnt/point is not a decrypted device: devtype is not disk \(is partition\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) {
@@ -340,6 +384,8 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) 
 		case "/dev/mapper/something":
 			return map[string]string{
 				"DEVTYPE": "disk",
+				"MAJOR":   "252",
+				"MINOR":   "0",
 			}, nil
 		default:
 			c.Errorf("unexpected udev device properties requested: %s", dev)
@@ -352,7 +398,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) 
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`mountpoint source /dev/mapper/something is not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`mountpoint source /dev/mapper/something of /run/mnt/point is not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
 }
 
 func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitionsInSysfs(c *C) {
@@ -493,22 +539,17 @@ func (s *diskSuite) TestDiskFromMountPointVolumeUnhappyWithoutPartEntryDisk(c *C
 
 	udevadmCmd := testutil.MockCommand(c, "udevadm", `
 if [ "$*" = "info --query property --name /dev/mapper/something" ]; then
-	# not a partition, so no ID_PART_ENTRY_DISK, but we will have DEVTYPE=disk
+	# no ID_PART_ENTRY_DISK, so not a disk from this mount point
 	echo "DEVTYPE=disk"
 else
 	echo "unexpected arguments $*"
 	exit 1
 fi
 `)
+	defer udevadmCmd.Restore()
 
-	d, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, IsNil)
-	c.Assert(d.Dev(), Equals, "42:1")
-	c.Assert(d.HasPartitions(), Equals, false)
-
-	c.Assert(udevadmCmd.Calls(), DeepEquals, [][]string{
-		{"udevadm", "info", "--query", "property", "--name", "/dev/mapper/something"},
-	})
+	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point, incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
 }
 
 func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
@@ -522,10 +563,12 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
 		case "/dev/mapper/something":
 			return map[string]string{
 				"DEVTYPE": "disk",
+				"MAJOR":   "242",
+				"MINOR":   "1",
 			}, nil
 		case "/dev/disk/by-uuid/5a522809-c87e-4dfa-81a8-8dc5667d1304":
 			return map[string]string{
-				"DEVTYPE":            "disk",
+				// "DEVTYPE":            "disk",
 				"ID_PART_ENTRY_DISK": "42:0",
 			}, nil
 		case "/dev/block/42:0":
@@ -535,6 +578,8 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
 				"DEVPATH":            "/devices/foo",
 				"ID_PART_TABLE_UUID": "foo-uuid",
 				"ID_PART_TABLE_TYPE": "thing",
+				// "DEVTYPE":            "disk",
+				// "ID_PART_ENTRY_DISK": "42:0",
 			}, nil
 		default:
 			c.Errorf("unexpected udev device properties requested: %s", dev)
@@ -570,6 +615,8 @@ func (s *diskSuite) TestDiskFromMountPointNotDiskUnsupported(c *C) {
 
 	udevadmCmd := testutil.MockCommand(c, "udevadm", `
 if [ "$*" = "info --query property --name /dev/not-a-disk" ]; then
+	echo "ID_PART_ENTRY_DISK=43:0"
+elif [ "$*" = "info --query property --name /dev/block/43:0" ]; then
 	echo "DEVTYPE=not-a-disk"
 else
 	echo "unexpected arguments $*"
@@ -578,10 +625,11 @@ fi
 `)
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "unsupported DEVTYPE \"not-a-disk\" for mount point source /dev/not-a-disk")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/not-a-disk of /run/mnt/point, unsupported DEVTYPE \"not-a-disk\"")
 
 	c.Assert(udevadmCmd.Calls(), DeepEquals, [][]string{
 		{"udevadm", "info", "--query", "property", "--name", "/dev/not-a-disk"},
+		{"udevadm", "info", "--query", "property", "--name", "/dev/block/43:0"},
 	})
 }
 
@@ -817,6 +865,8 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 			// the mapper device is a disk/volume
 			return map[string]string{
 				"DEVTYPE": "disk",
+				"MAJOR":   "252",
+				"MINOR":   "0",
 			}, nil
 		case 2:
 			// next we find the physical disk by the dm uuid
@@ -878,6 +928,8 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 			// the mapper device is a disk/volume
 			return map[string]string{
 				"DEVTYPE": "disk",
+				"MAJOR":   "252",
+				"MINOR":   "0",
 			}, nil
 		case 17:
 			// then we find the physical disk by the dm uuid

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -323,7 +323,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyMissingUdevProps(c *C) {
 	defer restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point, incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point: incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyBadUdevPropsMountpointPartition(c *C) {
@@ -342,7 +342,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyBadUdevPropsMountpointPartition
 	defer restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point, bad udev output: invalid device number format: \(expected <int>:<int>\)`)
+	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point: bad udev output: invalid device number format: \(expected <int>:<int>\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(c *C) {
@@ -370,7 +370,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `mountpoint source /dev/vda4 of /run/mnt/point is not a decrypted device: devtype is not disk \(is partition\)`)
+	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point: not a decrypted device: devtype is not disk \(is partition\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) {
@@ -398,7 +398,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) 
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`mountpoint source /dev/mapper/something of /run/mnt/point is not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point: not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
 }
 
 func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitionsInSysfs(c *C) {
@@ -549,7 +549,7 @@ fi
 	defer udevadmCmd.Restore()
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point, incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point: incomplete udev output missing required property \"ID_PART_ENTRY_DISK\"")
 }
 
 func (s *diskSuite) TestDiskFromMountPointIsDecryptedDeviceVolumeHappy(c *C) {
@@ -625,7 +625,7 @@ fi
 `)
 
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", nil)
-	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/not-a-disk of /run/mnt/point, unsupported DEVTYPE \"not-a-disk\"")
+	c.Assert(err, ErrorMatches, "cannot find disk from mountpoint source /dev/not-a-disk of /run/mnt/point: unsupported DEVTYPE \"not-a-disk\"")
 
 	c.Assert(udevadmCmd.Calls(), DeepEquals, [][]string{
 		{"udevadm", "info", "--query", "property", "--name", "/dev/not-a-disk"},


### PR DESCRIPTION
Based on top of https://github.com/snapcore/snapd/pull/10919, since these changes conflict with that PR, so it's easier to base these changes on top of that PR.

This is broken out from https://github.com/snapcore/snapd/pull/10851.

This is the "easy" short-term solution which doesn't resolve the importing of the fde package at all and merely kicks the can down the road, but could at least be merged with minimal reviews I think. I will open a separate PR with the "harder" solution which will require more reviews and more code, but resolves the issue with importing the fde package.

The main commits to review are https://github.com/snapcore/snapd/pull/11027/commits/4ff0475fbc4aa4cc96155ee54f7f797066d491b9 and https://github.com/snapcore/snapd/pull/11027/commits/c1a89453c28fb7b0971788c6f15ffa7e46bc506a