### PR TITLE
o/assertstate, api: move enforcing/monitoring from api to assertstate, save history

### DIFF
--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -262,8 +262,8 @@ func applyValidationSet(c *Command, r *http.Request, user *auth.UserState) Respo
 	}
 }
 
-var validationSetAssertionForMonitor = assertstate.ValidationSetAssertionForMonitor
-var validationSetAssertionForEnforce = assertstate.ValidationSetAssertionForEnforce
+var assertstateMonitorValidationSet = assertstate.MonitorValidationSet
+var assertstateEnforceValidationSet = assertstate.EnforceValidationSet
 
 // updateValidationSet handles snap validate --monitor and --enforce accountId/name[=sequence].
 func updateValidationSet(st *state.State, accountID, name string, reqMode string, sequence int, user *auth.UserState) Response {
@@ -286,24 +286,10 @@ func updateValidationSet(st *state.State, accountID, name string, reqMode string
 		return enforceValidationSet(st, accountID, name, sequence, userID)
 	}
 
-	tr := assertstate.ValidationSetTracking{
-		AccountID: accountID,
-		Name:      name,
-		Mode:      mode,
-		// note, Sequence may be 0, meaning not pinned.
-		PinnedAt: sequence,
-	}
-
-	pinned := sequence > 0
-	opts := assertstate.ResolveOptions{AllowLocalFallback: true}
-	as, local, err := validationSetAssertionForMonitor(st, accountID, name, sequence, pinned, userID, &opts)
+	err := assertstateMonitorValidationSet(st, accountID, name, sequence, userID)
 	if err != nil {
 		return BadRequest("cannot get validation set assertion for %v: %v", assertstate.ValidationSetKey(accountID, name), err)
 	}
-	tr.Current = as.Sequence()
-	tr.LocalOnly = local
-
-	assertstate.UpdateValidationSet(st, &tr)
 	return SyncResponse(nil)
 }
 
@@ -319,7 +305,9 @@ func forgetValidationSet(st *state.State, accountID, name string, sequence int) 
 	if err != nil {
 		return InternalError("accessing validation sets failed: %v", err)
 	}
-	assertstate.DeleteValidationSet(st, accountID, name)
+	if err := assertstate.ForgetValidationSet(st, accountID, name); err != nil {
+		return BadRequest("cannot forget validation set for %v: %v", assertstate.ValidationSetKey(accountID, name), err)
+	}
 	return SyncResponse(nil)
 }
 
@@ -410,21 +398,11 @@ func enforceValidationSet(st *state.State, accountID, name string, sequence, use
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	vs, err := validationSetAssertionForEnforce(st, accountID, name, sequence, userID, snaps, ignoreValidation)
-	if err != nil {
+	if err := assertstateEnforceValidationSet(st, accountID, name, sequence, userID, snaps, ignoreValidation); err != nil {
 		// XXX: provide more specific error kinds? This would probably require
 		// assertstate.ValidationSetAssertionForEnforce tuning too.
 		return BadRequest("cannot enforce validation set: %v", err)
 	}
 
-	tr := assertstate.ValidationSetTracking{
-		AccountID: accountID,
-		Name:      name,
-		Mode:      assertstate.Enforce,
-		// note, sequence may be 0, meaning not pinned.
-		PinnedAt: sequence,
-		Current:  vs.Sequence(),
-	}
-	assertstate.UpdateValidationSet(st, &tr)
 	return SyncResponse(nil)
 }

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/testutil"
@@ -600,31 +599,15 @@ func (s *apiValidationSetsSuite) TestGetValidationSetPinnedNotFound(c *check.C) 
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedLocalOnly(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error) {
+	var called int
+	restore := daemon.MockAssertstateMonitorValidationSet(func(st *state.State, accountID, name string, sequence, userID int) error {
 		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 99)
-		c.Assert(pinned, check.Equals, true)
-		c.Assert(opts, check.NotNil)
-		c.Check(opts.AllowLocalFallback, check.Equals, true)
-
-		db := assertstate.DB(st)
-		headers, err := asserts.HeadersFromPrimaryKey(asserts.ValidationSetType, []string{release.Series, accountID, name, fmt.Sprintf("%d", sequence)})
-		c.Assert(err, check.IsNil)
-		// validation set assertion available locally
-		vs, err := db.Find(asserts.ValidationSetType, headers)
-		c.Assert(err, check.IsNil)
-		return vs.(*asserts.ValidationSet), true, nil
+		called++
+		return nil
 	})
 	defer restore()
-
-	st := s.d.Overlord().State()
-
-	st.Lock()
-	vs := s.mockAssert(c, "bar", "99")
-	// add validation set assertion to the local db
-	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key, vs)
-	st.Unlock()
 
 	body := `{"action":"apply","mode":"monitor", "sequence":99}`
 	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
@@ -632,164 +615,12 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedLocalOnl
 
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
-
-	var tr assertstate.ValidationSetTracking
-
-	// verify tracking information
-	st.Lock()
-	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
-		Mode:      assertstate.Monitor,
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		PinnedAt:  99,
-		Current:   99,
-		LocalOnly: true,
-	})
-}
-
-func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedUnresolved(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error) {
-		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
-		c.Assert(name, check.Equals, "bar")
-		c.Assert(sequence, check.Equals, 99)
-		c.Assert(pinned, check.Equals, true)
-
-		snaps := []interface{}{map[string]interface{}{
-			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzz",
-			"name":     "snap-b",
-			"presence": "required",
-			"revision": "1",
-		}}
-		headers := map[string]interface{}{
-			"authority-id": s.dev1acct.AccountID(),
-			"account-id":   s.dev1acct.AccountID(),
-			"name":         "bar",
-			"series":       "16",
-			"sequence":     "99",
-			"revision":     "5",
-			"timestamp":    "2030-11-06T09:16:26Z",
-			"snaps":        snaps,
-		}
-		// validation set assertion coming from the store
-		vs, err := s.dev1Signing.Sign(asserts.ValidationSetType, headers, nil, "")
-		c.Assert(err, check.IsNil)
-		return vs.(*asserts.ValidationSet), false, nil
-	})
-	defer restore()
-
-	st := s.d.Overlord().State()
-
-	st.Lock()
-	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
-	st.Unlock()
-
-	body := `{"action":"apply","mode":"monitor", "sequence":99}`
-	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
-	c.Assert(err, check.IsNil)
-
-	rsp := s.syncReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 200)
-
-	var tr assertstate.ValidationSetTracking
-
-	// verify tracking information
-	st.Lock()
-	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
-		Mode:      assertstate.Monitor,
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		PinnedAt:  99,
-		Current:   99,
-	})
-}
-
-func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeUnpinnedRefreshed(c *check.C) {
-	snaps := []interface{}{map[string]interface{}{
-		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzz",
-		"name":     "snap-b",
-		"presence": "required",
-		"revision": "1",
-	}}
-
-	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error) {
-		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
-		c.Assert(name, check.Equals, "bar")
-		c.Assert(sequence, check.Equals, 0)
-		c.Assert(pinned, check.Equals, false)
-
-		// new sequence
-		headers := map[string]interface{}{
-			"authority-id": s.dev1acct.AccountID(),
-			"account-id":   s.dev1acct.AccountID(),
-			"name":         "bar",
-			"series":       "16",
-			"sequence":     "2",
-			"revision":     "1",
-			"timestamp":    "2030-11-06T09:16:26Z",
-			"snaps":        snaps,
-		}
-		// updated validation set assertion coming from the store
-		vs, err := s.dev1Signing.Sign(asserts.ValidationSetType, headers, nil, "")
-		c.Assert(err, check.IsNil)
-		return vs.(*asserts.ValidationSet), false, nil
-	})
-	defer restore()
-
-	st := s.d.Overlord().State()
-
-	st.Lock()
-	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
-	st.Unlock()
-
-	headers := map[string]interface{}{
-		"authority-id": s.dev1acct.AccountID(),
-		"account-id":   s.dev1acct.AccountID(),
-		"name":         "bar",
-		"series":       "16",
-		"sequence":     "1",
-		"revision":     "1",
-		"timestamp":    "2030-11-06T09:16:26Z",
-		"snaps":        snaps,
-	}
-	vs, err := s.dev1Signing.Sign(asserts.ValidationSetType, headers, nil, "")
-	c.Assert(err, check.IsNil)
-
-	st.Lock()
-	// add validation set assertion to the local db
-	c.Assert(assertstate.Add(st, vs), check.IsNil)
-	st.Unlock()
-
-	body := `{"action":"apply","mode":"monitor"}`
-	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
-	c.Assert(err, check.IsNil)
-
-	rsp := s.syncReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 200)
-
-	var tr assertstate.ValidationSetTracking
-
-	// verify tracking information
-	st.Lock()
-	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
-		Mode:      assertstate.Monitor,
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		Current:   2,
-	})
+	c.Check(called, check.Equals, 1)
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeError(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForMonitor(func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error) {
-		return nil, false, fmt.Errorf("boom")
+	restore := daemon.MockAssertstateMonitorValidationSet(func(st *state.State, accountID, name string, sequence, userID int) error {
+		return fmt.Errorf("boom")
 	})
 	defer restore()
 
@@ -924,14 +755,15 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetUnsupportedAction(c *chec
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceMode(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*asserts.ValidationSet, error) {
+	var called int
+	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
 		c.Check(ignoreValidation, check.HasLen, 0)
 		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 0)
 		c.Check(userID, check.Equals, 0)
-		as := s.mockAssert(c, "bar", "3")
-		return as.(*asserts.ValidationSet), nil
+		called++
+		return nil
 	})
 	defer restore()
 
@@ -955,23 +787,12 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceMode(c *check.C) {
 
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
-
-	// verify tracking information
-	st.Lock()
-	var tr assertstate.ValidationSetTracking
-	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
-		Mode:      assertstate.Enforce,
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		Current:   3,
-	})
+	c.Check(called, check.Equals, 1)
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeIgnoreValidationOK(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*asserts.ValidationSet, error) {
+	var called int
+	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
 		c.Check(ignoreValidation, check.DeepEquals, map[string]bool{"snap-b": true})
 		c.Check(snaps, testutil.DeepUnsortedMatches, []*snapasserts.InstalledSnap{
 			snapasserts.NewInstalledSnap("snap-b", "yOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.R("1"))})
@@ -979,8 +800,8 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeIgnoreValidati
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 0)
 		c.Check(userID, check.Equals, 0)
-		as := s.mockAssert(c, "bar", "3")
-		return as.(*asserts.ValidationSet), nil
+		called++
+		return nil
 	})
 	defer restore()
 
@@ -1005,29 +826,18 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeIgnoreValidati
 
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
-
-	// verify tracking information
-	st.Lock()
-	var tr assertstate.ValidationSetTracking
-	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
-		Mode:      assertstate.Enforce,
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		Current:   3,
-	})
+	c.Check(called, check.Equals, 1)
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeSpecificSequence(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*asserts.ValidationSet, error) {
+	var called int
+	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
 		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 5)
 		c.Check(userID, check.Equals, 0)
-		as := s.mockAssert(c, "bar", "5")
-		return as.(*asserts.ValidationSet), nil
+		called++
+		return nil
 	})
 	defer restore()
 
@@ -1051,82 +861,12 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeSpecificSequen
 
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
-
-	// verify tracking information
-	st.Lock()
-	var tr assertstate.ValidationSetTracking
-	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
-		Mode:      assertstate.Enforce,
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		Current:   5,
-		PinnedAt:  5,
-	})
-}
-
-func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeUpdateFromMonitorMode(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*asserts.ValidationSet, error) {
-		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
-		c.Assert(name, check.Equals, "bar")
-		c.Assert(sequence, check.Equals, 0)
-		c.Check(userID, check.Equals, 0)
-		as := s.mockAssert(c, "bar", "3")
-		return as.(*asserts.ValidationSet), nil
-	})
-	defer restore()
-
-	st := s.d.Overlord().State()
-	st.Lock()
-	defer st.Unlock()
-
-	snapstate.Set(st, "snap-b", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
-		Current:  snap.R(1),
-	})
-
-	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
-
-	// pretend we are tracking it in monitor mode
-	trMonitor := assertstate.ValidationSetTracking{
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		Mode:      assertstate.Monitor,
-		Current:   1,
-	}
-	assertstate.UpdateValidationSet(st, &trMonitor)
-
-	st.Unlock()
-	defer st.Lock()
-
-	// request enforce mode
-	body := `{"action":"apply","mode":"enforce"}`
-	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
-	c.Assert(err, check.IsNil)
-
-	rsp := s.syncReq(c, req, nil)
-	c.Assert(rsp.Status, check.Equals, 200)
-
-	// verify tracking information
-	st.Lock()
-	var tr assertstate.ValidationSetTracking
-	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
-		Mode:      assertstate.Enforce,
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		Current:   3,
-	})
+	c.Check(called, check.Equals, 1)
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeError(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*asserts.ValidationSet, error) {
-		return nil, fmt.Errorf("boom")
+	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
+		return fmt.Errorf("boom")
 	})
 	defer restore()
 
@@ -1151,62 +891,4 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeError(c *check
 	rspe := s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 400)
 	c.Check(string(rspe.Message), check.Equals, "cannot enforce validation set: boom")
-
-	// tracking information isn't set
-	st.Lock()
-	var tr assertstate.ValidationSetTracking
-	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
-	st.Unlock()
-	c.Assert(err, check.Equals, state.ErrNoState)
-}
-
-func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeErrorStaysInMonitor(c *check.C) {
-	restore := daemon.MockValidationSetAssertionForEnforce(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*asserts.ValidationSet, error) {
-		return nil, fmt.Errorf("boom")
-	})
-	defer restore()
-
-	st := s.d.Overlord().State()
-	st.Lock()
-	defer st.Unlock()
-
-	snapstate.Set(st, "snap-b", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
-		Current:  snap.R(1),
-	})
-
-	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
-
-	// pretend we are tracking it in monitor mode
-	trMonitor := assertstate.ValidationSetTracking{
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		Mode:      assertstate.Monitor,
-		Current:   1,
-	}
-	assertstate.UpdateValidationSet(st, &trMonitor)
-
-	st.Unlock()
-	defer st.Lock()
-	body := `{"action":"apply","mode":"enforce"}`
-	req, err := http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/bar", s.dev1acct.AccountID()), strings.NewReader(body))
-	c.Assert(err, check.IsNil)
-
-	rspe := s.errorReq(c, req, nil)
-	c.Assert(rspe.Status, check.Equals, 400)
-	c.Check(string(rspe.Message), check.Equals, "cannot enforce validation set: boom")
-
-	// and tracking remains in monitor mode
-	st.Lock()
-	var tr assertstate.ValidationSetTracking
-	err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "bar", &tr)
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-	c.Check(tr, check.DeepEquals, assertstate.ValidationSetTracking{
-		Mode:      assertstate.Monitor,
-		AccountID: s.dev1acct.AccountID(),
-		Name:      "bar",
-		Current:   1,
-	})
 }

--- a/daemon/export_api_validate_test.go
+++ b/daemon/export_api_validate_test.go
@@ -20,9 +20,7 @@
 package daemon
 
 import (
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
-	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -38,18 +36,18 @@ func MockCheckInstalledSnaps(f func(vsets *snapasserts.ValidationSets, snaps []*
 	}
 }
 
-func MockValidationSetAssertionForMonitor(f func(st *state.State, accountID, name string, sequence int, pinned bool, userID int, opts *assertstate.ResolveOptions) (*asserts.ValidationSet, bool, error)) func() {
-	old := validationSetAssertionForMonitor
-	validationSetAssertionForMonitor = f
+func MockAssertstateMonitorValidationSet(f func(st *state.State, accountID, name string, sequence int, userID int) error) func() {
+	old := assertstateMonitorValidationSet
+	assertstateMonitorValidationSet = f
 	return func() {
-		validationSetAssertionForMonitor = old
+		assertstateMonitorValidationSet = old
 	}
 }
 
-func MockValidationSetAssertionForEnforce(f func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (vs *asserts.ValidationSet, err error)) func() {
-	old := validationSetAssertionForEnforce
-	validationSetAssertionForEnforce = f
+func MockAssertstateEnforceValidationSet(f func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error) func() {
+	old := assertstateEnforceValidationSet
+	assertstateEnforceValidationSet = f
 	return func() {
-		validationSetAssertionForEnforce = old
+		assertstateEnforceValidationSet = old
 	}
 }

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -726,6 +726,9 @@ func validationSetAssertionForEnforce(st *state.State, accountID, name string, s
 	return vs, err
 }
 
+// EnforceValidationSet tries to fetch the given validation set and enforce it.
+// If all validation sets constrains are satisfied, the current validation sets
+// tracking state is saved in validation sets history.
 func EnforceValidationSet(st *state.State, accountID, name string, sequence, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
 	vs, err := validationSetAssertionForEnforce(st, accountID, name, sequence, userID, snaps, ignoreValidation)
 	if err != nil {
@@ -745,6 +748,8 @@ func EnforceValidationSet(st *state.State, accountID, name string, sequence, use
 	return addCurrentTrackingToValidationSetsHistory(st)
 }
 
+// MonitorValidationSet tries to fetch the given validation set and monitor it.
+// The current validation sets tracking state is saved in validation sets history.
 func MonitorValidationSet(st *state.State, accountID, name string, sequence int, userID int) error {
 	pinned := sequence > 0
 	opts := ResolveOptions{AllowLocalFallback: true}

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -3331,3 +3331,294 @@ func (s *assertMgrSuite) TestTemporaryDB(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(fromDB.(*asserts.Model), DeepEquals, model)
 }
+
+func (s *assertMgrSuite) TestEnforceValidationSetAssertion(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
+
+	// add sequence to the store
+	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required", "1")
+	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
+
+	snaps := []*snapasserts.InstalledSnap{
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+	}
+
+	sequence := 2
+	err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	c.Assert(err, IsNil)
+
+	// and it has been committed
+	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "2",
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+
+	var tr assertstate.ValidationSetTracking
+	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
+
+	c.Check(tr, DeepEquals, assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  2,
+		Current:   2,
+	})
+
+	// and it was added to the history
+	vshist, err := assertstate.ValidationSetsHistory(st)
+	c.Assert(err, IsNil)
+	c.Check(vshist, DeepEquals, []map[string]*assertstate.ValidationSetTracking{{
+		fmt.Sprintf("%s/bar", s.dev1Acct.AccountID()): {
+			AccountID: s.dev1Acct.AccountID(),
+			Name:      "bar",
+			Mode:      assertstate.Enforce,
+			PinnedAt:  2,
+			Current:   2,
+		},
+	}})
+}
+
+func (s *assertMgrSuite) TestEnforceValidationSetAssertionAfterMonitor(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
+
+	// add and old assertion to local database
+	vsetAs1 := s.validationSetAssert(c, "bar", "1", "1", "required", "1")
+	c.Assert(assertstate.Add(st, vsetAs1), IsNil)
+
+	monitor := assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(st, &monitor)
+
+	snaps := []*snapasserts.InstalledSnap{
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+	}
+
+	// add a newer sequence to the store
+	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required", "1")
+	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
+
+	sequence := 2
+	err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	c.Assert(err, IsNil)
+
+	// and it has been committed
+	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "2",
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+
+	var tr assertstate.ValidationSetTracking
+	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
+
+	c.Check(tr, DeepEquals, assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  2,
+		Current:   2,
+	})
+}
+
+func (s *assertMgrSuite) TestEnforceValidationSetAssertionIgnoreValidation(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
+
+	// add sequence to the store
+	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required", "1")
+	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
+
+	snaps := []*snapasserts.InstalledSnap{
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 3}),
+	}
+
+	sequence := 2
+	ignoreValidation := map[string]bool{}
+	err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, ignoreValidation)
+	wrongRevErr, ok := err.(*snapasserts.ValidationSetsValidationError)
+	c.Assert(ok, Equals, true)
+	c.Check(wrongRevErr.WrongRevisionSnaps["foo"], NotNil)
+
+	ignoreValidation["foo"] = true
+	err = assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, ignoreValidation)
+	c.Assert(err, IsNil)
+
+	// and it has been committed
+	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "2",
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+
+	var tr assertstate.ValidationSetTracking
+	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
+
+	c.Check(tr, DeepEquals, assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  2,
+		Current:   2,
+	})
+}
+
+func (s *assertMgrSuite) TestMonitorValidationSet(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
+
+	// add to the store
+	vsetAs := s.validationSetAssert(c, "bar", "2", "2", "required", "1")
+	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
+
+	sequence := 2
+	err := assertstate.MonitorValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0)
+	c.Assert(err, IsNil)
+
+	// and it has been committed
+	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
+		"series":     "16",
+		"account-id": s.dev1Acct.AccountID(),
+		"name":       "bar",
+		"sequence":   "2",
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+
+	var tr assertstate.ValidationSetTracking
+	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
+
+	c.Check(tr, DeepEquals, assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		PinnedAt:  2,
+		Current:   2,
+	})
+
+	// and it was added to the history
+	vshist, err := assertstate.ValidationSetsHistory(st)
+	c.Assert(err, IsNil)
+	c.Check(vshist, DeepEquals, []map[string]*assertstate.ValidationSetTracking{{
+		fmt.Sprintf("%s/bar", s.dev1Acct.AccountID()): {
+			AccountID: s.dev1Acct.AccountID(),
+			Name:      "bar",
+			Mode:      assertstate.Monitor,
+			PinnedAt:  2,
+			Current:   2,
+		},
+	}})
+}
+
+func (s *assertMgrSuite) TestForgetValidationSet(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	c.Assert(s.storeSigning.Add(storeAs), IsNil)
+	c.Assert(assertstate.Add(st, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
+
+	// add to the store
+	vsetAs1 := s.validationSetAssert(c, "bar", "2", "2", "required", "1")
+	c.Assert(s.storeSigning.Add(vsetAs1), IsNil)
+
+	vsetAs2 := s.validationSetAssert(c, "baz", "2", "2", "required", "1")
+	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
+
+	c.Assert(assertstate.MonitorValidationSet(st, s.dev1Acct.AccountID(), "bar", 2, 0), IsNil)
+	c.Assert(assertstate.MonitorValidationSet(st, s.dev1Acct.AccountID(), "baz", 2, 0), IsNil)
+
+	c.Assert(assertstate.ForgetValidationSet(st, s.dev1Acct.AccountID(), "bar"), IsNil)
+
+	// and it was added to the history
+	vshist, err := assertstate.ValidationSetsHistory(st)
+	c.Assert(err, IsNil)
+	c.Check(vshist, DeepEquals, []map[string]*assertstate.ValidationSetTracking{{
+		fmt.Sprintf("%s/bar", s.dev1Acct.AccountID()): {
+			AccountID: s.dev1Acct.AccountID(),
+			Name:      "bar",
+			Mode:      assertstate.Monitor,
+			PinnedAt:  2,
+			Current:   2,
+		},
+	}, {
+		fmt.Sprintf("%s/bar", s.dev1Acct.AccountID()): {
+			AccountID: s.dev1Acct.AccountID(),
+			Name:      "bar",
+			Mode:      assertstate.Monitor,
+			PinnedAt:  2,
+			Current:   2,
+		},
+		fmt.Sprintf("%s/baz", s.dev1Acct.AccountID()): {
+			AccountID: s.dev1Acct.AccountID(),
+			Name:      "baz",
+			Mode:      assertstate.Monitor,
+			PinnedAt:  2,
+			Current:   2,
+		},
+	}, {
+		fmt.Sprintf("%s/baz", s.dev1Acct.AccountID()): {
+			AccountID: s.dev1Acct.AccountID(),
+			Name:      "baz",
+			Mode:      assertstate.Monitor,
+			PinnedAt:  2,
+			Current:   2,
+		},
+	}})
+}

--- a/overlord/assertstate/export_test.go
+++ b/overlord/assertstate/export_test.go
@@ -22,6 +22,8 @@ package assertstate
 // expose for testing
 var (
 	DoFetch                                   = doFetch
+	ValidationSetAssertionForEnforce          = validationSetAssertionForEnforce
+	ValidationSetAssertionForMonitor          = validationSetAssertionForMonitor
 	AddCurrentTrackingToValidationSetsHistory = addCurrentTrackingToValidationSetsHistory
 	ValidationSetsHistoryTop                  = validationSetsHistoryTop
 )

--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -92,19 +92,21 @@ func UpdateValidationSet(st *state.State, tr *ValidationSetTracking) {
 	st.Set("validation-sets", vsmap)
 }
 
-// DeleteValidationSet deletes a validation set for the given accountID and name.
+// ForgetValidationSet deletes a validation set for the given accountID and name.
 // It is not an error to delete a non-existing one.
-func DeleteValidationSet(st *state.State, accountID, name string) {
+func ForgetValidationSet(st *state.State, accountID, name string) error {
 	var vsmap map[string]*json.RawMessage
 	err := st.Get("validation-sets", &vsmap)
 	if err != nil && err != state.ErrNoState {
 		panic("internal error: cannot unmarshal validation set tracking state: " + err.Error())
 	}
 	if len(vsmap) == 0 {
-		return
+		return nil
 	}
 	delete(vsmap, ValidationSetKey(accountID, name))
 	st.Set("validation-sets", vsmap)
+
+	return addCurrentTrackingToValidationSetsHistory(st)
 }
 
 // GetValidationSet retrieves the ValidationSetTracking for the given account and name.

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -133,12 +133,12 @@ func (s *validationSetTrackingSuite) TestUpdate(c *C) {
 	c.Check(gotSecond, Equals, true)
 }
 
-func (s *validationSetTrackingSuite) TestDelete(c *C) {
+func (s *validationSetTrackingSuite) TestForget(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
 	// delete non-existing one is fine
-	assertstate.DeleteValidationSet(s.st, "foo", "bar")
+	assertstate.ForgetValidationSet(s.st, "foo", "bar")
 	all, err := assertstate.ValidationSets(s.st)
 	c.Assert(err, IsNil)
 	c.Assert(all, HasLen, 0)
@@ -154,8 +154,8 @@ func (s *validationSetTrackingSuite) TestDelete(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(all, HasLen, 1)
 
-	// deletes existing one
-	assertstate.DeleteValidationSet(s.st, "foo", "bar")
+	// forget existing one
+	assertstate.ForgetValidationSet(s.st, "foo", "bar")
 	all, err = assertstate.ValidationSets(s.st)
 	c.Assert(err, IsNil)
 	c.Assert(all, HasLen, 0)

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -133,6 +133,7 @@ func (s *validationSetTrackingSuite) TestUpdate(c *C) {
 	c.Check(gotSecond, Equals, true)
 }
 
+// there is a more extensive test for forget in assertstate_test.go.
 func (s *validationSetTrackingSuite) TestForget(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()


### PR DESCRIPTION
Move functions that set enforcing/monitoring from api to assertstate. Save current validation sets to the history on enforce/monitor/forget.

The affected api tests became more lightweight since most of the logic was already tested by assertstate tests.