### PR TITLE
o/snapstate: account for deleted revs when undoing install

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1334,9 +1334,14 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 
 	oldCandidateIndex := snapst.LastIndex(cand.Revision)
 
+	var oldRevsBeforeCand []snap.Revision
 	if oldCandidateIndex < 0 {
 		snapst.Sequence = append(snapst.Sequence, cand)
 	} else if !snapsup.Revert {
+		// save the revs before the candidate, so undoLink can account for discarded revs when putting it back
+		for _, si := range snapst.Sequence[:oldCandidateIndex] {
+			oldRevsBeforeCand = append(oldRevsBeforeCand, si.Revision)
+		}
 		// remove the old candidate from the sequence, add it at the end
 		copy(snapst.Sequence[oldCandidateIndex:len(snapst.Sequence)-1], snapst.Sequence[oldCandidateIndex+1:])
 		snapst.Sequence[len(snapst.Sequence)-1] = cand
@@ -1481,6 +1486,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	t.Set("old-refresh-inhibited-time", oldRefreshInhibitedTime)
 	t.Set("old-cohort-key", oldCohortKey)
 	t.Set("old-last-refresh-time", oldLastRefreshTime)
+	t.Set("old-revs-before-cand", oldRevsBeforeCand)
 	if snapsup.Revert {
 		t.Set("old-revert-status", snapst.RevertStatus)
 		switch snapsup.RevertStatus {
@@ -1760,6 +1766,10 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err := t.Get("old-cohort-key", &oldCohortKey); err != nil && err != state.ErrNoState {
 		return err
 	}
+	var oldRevsBeforeCand []snap.Revision
+	if err := t.Get("old-revs-before-cand", &oldRevsBeforeCand); err != nil && err != state.ErrNoState {
+		return err
+	}
 
 	if len(snapst.Sequence) == 1 {
 		// XXX: shouldn't these two just log and carry on? this is an undo handler...
@@ -1790,6 +1800,10 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if oldCandidateIndex < 0 {
 		snapst.Sequence = append(snapst.Sequence[:currentIndex], snapst.Sequence[currentIndex+1:]...)
 	} else if !isRevert {
+		// account for revisions discarded before the install failed
+		discarded := countExcludedRevs(oldRevsBeforeCand, snapst.Sequence)
+		oldCandidateIndex -= discarded
+
 		oldCand := snapst.Sequence[currentIndex]
 		copy(snapst.Sequence[oldCandidateIndex+1:], snapst.Sequence[oldCandidateIndex:])
 		snapst.Sequence[oldCandidateIndex] = oldCand
@@ -1900,6 +1914,19 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		restart.Request(st, restart.RestartDaemon)
 	}
 	return nil
+}
+
+func countExcludedRevs(items []snap.Revision, seq []*snap.SideInfo) int {
+	var found int
+	for _, rev := range items {
+		for _, si := range seq {
+			if si.Revision == rev {
+				found++
+			}
+		}
+	}
+
+	return len(items) - found
 }
 
 type doSwitchFlags struct {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1916,17 +1916,18 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func countExcludedRevs(items []snap.Revision, seq []*snap.SideInfo) int {
+// countExcludedRevs counts how many of the revisions aren't present in the sequence of sideInfos
+func countExcludedRevs(revisions []snap.Revision, sideInfos []*snap.SideInfo) int {
 	var found int
-	for _, rev := range items {
-		for _, si := range seq {
+	for _, rev := range revisions {
+		for _, si := range sideInfos {
 			if si.Revision == rev {
 				found++
 			}
 		}
 	}
 
-	return len(items) - found
+	return len(revisions) - found
 }
 
 type doSwitchFlags struct {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1801,7 +1801,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		snapst.Sequence = append(snapst.Sequence[:currentIndex], snapst.Sequence[currentIndex+1:]...)
 	} else if !isRevert {
 		// account for revisions discarded before the install failed
-		discarded := countExcludedRevs(oldRevsBeforeCand, snapst.Sequence)
+		discarded := countMissingRevs(oldRevsBeforeCand, snapst.Sequence)
 		oldCandidateIndex -= discarded
 
 		oldCand := snapst.Sequence[currentIndex]
@@ -1916,8 +1916,8 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-// countExcludedRevs counts how many of the revisions aren't present in the sequence of sideInfos
-func countExcludedRevs(revisions []snap.Revision, sideInfos []*snap.SideInfo) int {
+// countMissingRevs counts how many of the revisions aren't present in the sequence of sideInfos
+func countMissingRevs(revisions []snap.Revision, sideInfos []*snap.SideInfo) int {
 	var found int
 	for _, rev := range revisions {
 		for _, si := range sideInfos {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4264,7 +4264,6 @@ func (s *snapmgrTestSuite) testRetainCorrectNumRevisions(c *C, installFn install
 		SnapType:        "app",
 	})
 
-	// the default is also 2 but this makes the test more robust against changes
 	tr := config.NewTransaction(s.state)
 	c.Assert(tr.Set("core", "refresh.retain", 1), IsNil)
 	tr.Commit()

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6913,3 +6913,89 @@ func (s *snapmgrTestSuite) TestUpdateDeduplicatesSnapNames(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(updated, testutil.DeepUnsortedMatches, []string{"some-snap", "some-base"})
 }
+
+func (s *snapmgrTestSuite) TestUndoInstallAfterDeletingRevisions(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// 1 and 2 should be deleted, 3 is target revision and 4 is current
+	seq := []*snap.SideInfo{
+		{
+			RealName: "some-snap",
+			SnapID:   "some-snap-id",
+			Revision: snap.R(1),
+		},
+		{
+			RealName: "some-snap",
+			SnapID:   "some-snap-id",
+			Revision: snap.R(2),
+		},
+		{
+			RealName: "some-snap",
+			SnapID:   "some-snap-id",
+			Revision: snap.R(3),
+		},
+		{
+			RealName: "some-snap",
+			SnapID:   "some-snap-id",
+			Revision: snap.R(4),
+		},
+	}
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: seq,
+		Current:  seq[len(seq)-1].Revision,
+	})
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "refresh.retain", 1), IsNil)
+	tr.Commit()
+
+	s.o.TaskRunner().AddHandler("fail", func(*state.Task, *tomb.Tomb) error {
+		return errors.New("expected")
+	}, nil)
+
+	// install already stored revision
+	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: seq[len(seq)-2].Revision}, s.user.ID, snapstate.Flags{NoReRefresh: true})
+	c.Assert(err, IsNil)
+	c.Assert(ts, NotNil)
+	chg := s.state.NewChange("refresh", "")
+	chg.AddAll(ts)
+
+	// make update fail after removing old snaps
+	failTask := s.state.NewTask("fail", "expected")
+	disc := findLastTask(chg, "discard-snap")
+	for _, lane := range disc.Lanes() {
+		failTask.JoinLane(lane)
+	}
+	failTask.WaitFor(disc)
+	chg.AddTask(failTask)
+
+	s.settle(c)
+
+	c.Assert(chg.Status(), Equals, state.ErrorStatus)
+
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, "some-snap", &snapst)
+	c.Assert(err, IsNil)
+	c.Assert(snapst.Sequence, DeepEquals, seq[2:])
+
+	linkTask := findLastTask(chg, "link-snap")
+	c.Check(linkTask.Status(), Equals, state.UndoneStatus)
+
+	var oldRevsBeforeCand []snap.Revision
+	c.Assert(linkTask.Get("old-revs-before-cand", &oldRevsBeforeCand), IsNil)
+	c.Assert(oldRevsBeforeCand, DeepEquals, []snap.Revision{seq[0].Revision, seq[1].Revision})
+}
+
+func findLastTask(chg *state.Change, kind string) *state.Task {
+	var last *state.Task
+
+	for _, task := range chg.Tasks() {
+		if task.Kind() == kind {
+			last = task
+		}
+	}
+
+	return last
+}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6948,6 +6948,8 @@ func (s *snapmgrTestSuite) TestUndoInstallAfterDeletingRevisions(c *C) {
 	})
 
 	tr := config.NewTransaction(s.state)
+	// remove the first two revisions so the old-candidate-index+1 (in undoLinkSnap) would be out of bounds if we didn't
+	// account for discarded revisions
 	c.Assert(tr.Set("core", "refresh.retain", 1), IsNil)
 	tr.Commit()
 


### PR DESCRIPTION
The undoLinkSnap handlers puts the candidate revision back in its
previous position, if the install fails. However, the install may
fail after the discard-snap tasks run which means that the old
candidate index may be outdated which could result in the wrong
Sequence being remade or even a panic. This change accounts for the
number of discarded revisions when undoing the install.
