### PR TITLE
github: enable pipefail when running spread

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -301,6 +301,7 @@ jobs:
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |
+          set -o pipefail
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"
           spread -abend google:${{ matrix.system }}:tests/... | tee spread.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -301,10 +301,9 @@ jobs:
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |
-          set -o pipefail
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"
-          spread -abend google:${{ matrix.system }}:tests/... | tee spread.log
+          (set -o pipefail; spread -abend google:${{ matrix.system }}:tests/... | tee spread.log)
     - name: Cache successful run
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")


### PR DESCRIPTION
It seems that some recent github runs did not fail although no tests were run.
The only reasonable explanation being either broken action, or missing pipefail
that hid spread's non-0 exit status.

