### PR TITLE
.github/workflows/test.yaml: fail all spread runs, show spread's exit status

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -301,6 +301,7 @@ jobs:
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |
+          set -o pipefail    
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"
           spread -abend google:${{ matrix.system }}:tests/... | tee spread.log
@@ -364,6 +365,7 @@ jobs:
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |
+          set -o pipefail
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"
           export NESTED_BUILD_SNAPD_FROM_CURRENT=true


### PR DESCRIPTION
This is to debug what is going on with erroneously passing checks which should
have failed as per the spread log, but are marked passing in GitHub Actions UI.