### PR TITLE
interfaces/apparmor/template.go: allow udevadm from merged usr systems

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -405,7 +405,7 @@ var templateCommon = `
   signal (receive) peer=unconfined,
 
   # for 'udevadm trigger --verbose --dry-run --tag-match=snappy-assign'
-  /{,s}bin/udevadm ixr,
+  /{,usr/}{,s}bin/udevadm ixr,
   /etc/udev/udev.conf r,
   /{,var/}run/udev/tags/snappy-assign/ r,
   @{PROC}/cmdline r,


### PR DESCRIPTION
Such as the core20 and newer base snaps for example.

Thanks to @xnox for finding this issue.

Not really sure if this needs security review, on the off chance it does though I added the tag hopefully it is quick enough to review :-)