### PR TITLE
many: install bash completion files in writable directory

### DIFF
--- a/data/completion/bash/complete.sh
+++ b/data/completion/bash/complete.sh
@@ -102,10 +102,10 @@ _complete_from_snap() {
 }
 
 # this file can be sourced directly as e.g. /usr/lib/snapd/complete.sh, or via
-# a symlink from /usr/share/bash-completion/completions/. In the first case we
+# a symlink from /var/lib/snapd/desktop/bash-completion/completions/. In the first case we
 # want to load the default loader; in the second, the specific one.
 #
-if [[ "${BASH_SOURCE[0]}" =~ ^/usr/share/bash-completion/completions/ ]]; then
+if [[ "${BASH_SOURCE[0]}" =~ ^(/var/lib/snapd/desktop|/usr/share)/bash-completion/completions/ ]]; then
     complete -F _complete_from_snap "$1"
 else
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -123,6 +123,8 @@ var (
 	XdgRuntimeDirGlob string
 
 	CompletionHelperInCore string
+	BashCompletionScript   string
+	LegacyCompletersDir    string
 	CompletersDir          string
 
 	SystemFontsDir            string
@@ -471,7 +473,9 @@ func SetRootDir(rootdir string) {
 	XdgRuntimeDirGlob = filepath.Join(XdgRuntimeDirBase, "*/")
 
 	CompletionHelperInCore = filepath.Join(CoreLibExecDir, "etelpmoc.sh")
-	CompletersDir = filepath.Join(rootdir, "/usr/share/bash-completion/completions/")
+	BashCompletionScript = filepath.Join(rootdir, "/usr/share/bash-completion/bash_completion")
+	LegacyCompletersDir = filepath.Join(rootdir, "/usr/share/bash-completion/completions/")
+	CompletersDir = filepath.Join(rootdir, snappyDir, "desktop/bash-completion/completions/")
 
 	// These paths agree across all supported distros
 	SystemFontsDir = filepath.Join(rootdir, "/usr/share/fonts")

--- a/image/preseed/preseed_classic_test.go
+++ b/image/preseed/preseed_classic_test.go
@@ -301,6 +301,8 @@ func (s *preseedSuite) TestReset(c *C) {
 			// bash-completion symlinks
 			{filepath.Join(dirs.CompletersDir, "foo.bar"), "/a/snapd/complete.sh"},
 			{filepath.Join(dirs.CompletersDir, "foo"), "foo.bar"},
+			{filepath.Join(dirs.LegacyCompletersDir, "foo.bar"), "/a/snapd/complete.sh"},
+			{filepath.Join(dirs.LegacyCompletersDir, "foo"), "foo.bar"},
 		}
 
 		for _, art := range artifacts {

--- a/image/preseed/reset.go
+++ b/image/preseed/reset.go
@@ -36,10 +36,10 @@ import (
 // e.g.
 // lxd.lxc -> /snap/core/current/usr/lib/snapd/complete.sh
 // lxc -> lxd.lxc
-func resetCompletionSymlinks(preseedChroot string) error {
-	files, err := ioutil.ReadDir(filepath.Join(preseedChroot, dirs.CompletersDir))
+func resetCompletionSymlinks(completersPath string) error {
+	files, err := ioutil.ReadDir(completersPath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("error reading %s: %v", dirs.CompletersDir, err)
+		return fmt.Errorf("error reading %s: %v", completersPath, err)
 	}
 	completeShSymlinks := make(map[string]string)
 	var otherSymlinks []string
@@ -49,7 +49,7 @@ func resetCompletionSymlinks(preseedChroot string) error {
 		if fileInfo.Mode()&os.ModeSymlink == 0 {
 			continue
 		}
-		fullPath := filepath.Join(preseedChroot, dirs.CompletersDir, fileInfo.Name())
+		fullPath := filepath.Join(completersPath, fileInfo.Name())
 		if dirs.IsCompleteShSymlink(fullPath) {
 			if err := os.Remove(fullPath); err != nil {
 				return fmt.Errorf("error removing symlink %s: %v", fullPath, err)
@@ -174,8 +174,10 @@ func ResetPreseededChroot(preseedChroot string) error {
 		}
 	}
 
-	if err := resetCompletionSymlinks(preseedChroot); err != nil {
-		return err
+	for _, completersPath := range []string{dirs.CompletersDir, dirs.LegacyCompletersDir} {
+		if err := resetCompletionSymlinks(filepath.Join(preseedChroot, completersPath)); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/snap/info.go
+++ b/snap/info.go
@@ -1061,6 +1061,11 @@ func (app *AppInfo) CompleterPath() string {
 	return filepath.Join(dirs.CompletersDir, JoinSnapApp(app.Snap.InstanceName(), app.Name))
 }
 
+// CompleterPath returns the legacy path to the completer snippet for the app binary.
+func (app *AppInfo) LegacyCompleterPath() string {
+	return filepath.Join(dirs.LegacyCompletersDir, JoinSnapApp(app.Snap.InstanceName(), app.Name))
+}
+
 func (app *AppInfo) launcherCommand(command string) string {
 	if command != "" {
 		command = " " + command

--- a/tests/completion/indirect/task.exp
+++ b/tests/completion/indirect/task.exp
@@ -5,7 +5,7 @@ send "source /usr/share/bash-completion/bash_completion\n"
 next
 if {$::env(_COMPLETE_SH)} {
     # because this sources complete.sh, it won't be using the snippets
-    send "source $::env(SPREAD_PATH)/data/completion/complete.sh\n"
+    send "source $::env(SPREAD_PATH)/data/completion/bash/complete.sh\n"
     next
 }
 chat "$::env(CMD) \t\t" $::env(_OUT0)

--- a/tests/completion/indirect/task.yaml
+++ b/tests/completion/indirect/task.yaml
@@ -22,6 +22,7 @@ execute: |
   #shellcheck disable=SC1090
   source "${SPREAD_PATH}/${SPREAD_SUITE}/${SPREAD_VARIANT}.vars"
   export _OUT0 _OUT1 _OUT2 _KEY1 _KEY2 _COMP
+  export XDG_DATA_DIRS="${XDG_DATA_DIRS:-}${XDG_DATA_DIRS:+:}/var/lib/snapd/desktop"
   for c in test-snapd-complexion test-snapd-complexion.two cplx cplx2; do
     sudo CMD=$c "PATH=$PATH" _COMPLETE_SH=true -E -u test expect -d -f "$d"/task.exp
     sudo CMD=$c "PATH=$PATH" _COMPLETE_SH=false -E -u test expect -d -f "$d"/task.exp

--- a/tests/completion/lib.exp0
+++ b/tests/completion/lib.exp0
@@ -66,5 +66,5 @@ proc brexit {} {
 # tests to fail.
 spawn env -u PS1 bash --norc -i
 next
-send ". /usr/share/bash-completion/bash_completion; . ../../../data/completion/snap\n"
+send ". /usr/share/bash-completion/bash_completion; . ../../../data/completion/bash/snap\n"
 next

--- a/tests/completion/snippets/task.yaml
+++ b/tests/completion/snippets/task.yaml
@@ -20,4 +20,5 @@ execute: |
   #shellcheck disable=SC1090
   source "${SPREAD_PATH}/${SPREAD_SUITE}/${SPREAD_VARIANT}.vars"
   export _OUT0 _OUT1 _OUT2 _KEY1 _KEY2 _COMP
+  export XDG_DATA_DIRS="${XDG_DATA_DIRS:-}${XDG_DATA_DIRS:+:}/var/lib/snapd/desktop"
   sudo PATH="$PATH" -E -u test expect -d -f "$d"/task.exp

--- a/tests/core/bash-completion/task.yaml
+++ b/tests/core/bash-completion/task.yaml
@@ -1,0 +1,24 @@
+summary: bash completion
+
+systems:
+  - ubuntu-core-22-*
+
+prepare: |
+  snap install strace-static --edge
+  cp ../../lib/snaps/test-snapd-complexion/meta/snap.yaml snap.yaml.bak
+  cat <<EOF >>../../lib/snaps/test-snapd-complexion/meta/snap.yaml
+  base: core22
+  EOF
+  cd ../../lib/snaps/test-snapd-complexion || exit 1
+  snap try --devmode
+  snap alias test-snapd-complexion cplx
+  snap alias test-snapd-complexion.two cplx2
+
+restore: |
+  snap remove --purge test-snapd-complexion
+  mv snap.yaml.bak ../../lib/snaps/test-snapd-complexion/meta/snap.yaml
+
+execute: |
+  for c in test-snapd-complexion test-snapd-complexion.two cplx cplx2; do
+      python3 test-completion.py "${PWD}/test-rc" "${c}"
+  done

--- a/tests/core/bash-completion/test-completion.py
+++ b/tests/core/bash-completion/test-completion.py
@@ -1,0 +1,123 @@
+import os
+import asyncio
+import contextlib
+import re
+import sys
+
+
+class Pty:
+    def __init__(self):
+        self._loop = asyncio.get_running_loop()
+        self._parent, self.child = os.openpty()
+
+    def close(self):
+        self.close_parent()
+        self.close_child()
+
+    def close_parent(self):
+        if self._parent is not None:
+            os.close(self._parent)
+            self._parent = None
+
+    def close_child(self):
+        if self.child is not None:
+            os.close(self.child)
+            self.child = None
+
+    async def read(self, size):
+        fut = self._loop.create_future()
+        def reader():
+            try:
+                data = os.read(self._parent, size)
+            except Exception as e:
+                fut.set_exception(e)
+            else:
+                fut.set_result(data)
+            finally:
+                self._loop.remove_reader(self._parent)
+        self._loop.add_reader(self._parent, reader)
+        return await fut
+
+    async def write(self, data):
+        fut = self._loop.create_future()
+        def writer():
+            try:
+                written = os.write(self._parent, data)
+            except Exception as e:
+                fut.set_exception(e)
+            else:
+                fut.set_result(written)
+            finally:
+                self._loop.remove_writer(self._parent)
+
+        self._loop.add_writer(self._parent, writer)
+        return await fut
+
+
+class TermReader:
+    def __init__(self, pty):
+        self._pty = pty
+        self._buf = bytearray()
+
+    async def expect(self, search):
+        while True:
+            m = re.search(search, self._buf)
+            if m:
+                print("Found {}. Eaten: {}".format(search, self._buf[0:m.endpos]))
+                del self._buf[0:m.endpos]
+                return True
+            try:
+                self._buf.extend(await asyncio.wait_for(self._pty.read(4096), timeout=2))
+            except asyncio.TimeoutError:
+                print("Did not find {}. Available: {}".format(search, self._buf))
+                return False
+
+
+class Shell:
+    @staticmethod
+    def prepare_tty():
+        os.setsid()
+        # Force being controlled by terminal
+        tmp_fd = os.open(os.ttyname(0), os.O_RDWR)
+        os.close(tmp_fd)
+
+    @staticmethod
+    async def create(pty, init):
+        environ = os.environ.copy()
+        p = await asyncio.create_subprocess_exec(
+            '/bin/bash', '--init-file', init, '-i',
+            stdout=pty.child, stdin=pty.child, stderr=pty.child,
+            close_fds=True,
+            preexec_fn=Shell.prepare_tty,
+            env=environ)
+        pty.close_child()
+        return Shell(p)
+
+    def __init__(self, process):
+        self._process = process
+
+    async def kill(self):
+        self._process.terminate()
+        await asyncio.sleep(1)
+        self._process.kill()
+
+    async def aclose(self):
+        killer = asyncio.create_task(self.kill())
+        try:
+            await asyncio.wait_for(self._process.wait(), timeout=1.5)
+        except asyncio.TimeoutError:
+            pass
+        killer.cancel()
+
+
+async def run(init, executable):
+    with contextlib.closing(Pty()) as pty:
+        async with contextlib.aclosing(await Shell.create(pty, init)):
+            reader = TermReader(pty)
+            assert await reader.expect(rb'prompt[$] ')
+            print(await pty.write('{} -b \t\t'.format(executable).encode('ascii')))
+            assert await reader.expect(b'\a') # Bell
+            assert await reader.expect(rb'counterrevolutionary  *electroencephalogram  *uncharacteristically')
+
+
+asyncio.run(run(sys.argv[1], sys.argv[2]))

--- a/tests/core/bash-completion/test-rc
+++ b/tests/core/bash-completion/test-rc
@@ -1,0 +1,8 @@
+export TERM=ansi
+export PS1='prompt$ '
+export XDG_DATA_DIRS="${XDG_DATA_DIRS:-}${XDG_DATA_DIRS:+:}/var/lib/snapd/desktop"
+
+# This removes escape bracket characters that clutter outputs
+bind 'set enable-bracketed-paste off'
+
+. /usr/share/bash-completion/bash_completion

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -432,6 +432,8 @@ StandardOutput=journal+console
 StandardError=journal+console
 EOF
 
+    cp "${SPREAD_PATH}"/data/completion/bash/complete.sh "${UNPACK_DIR}"/usr/lib/snapd/complete.sh
+
     snap pack --filename="$TARGET" "$UNPACK_DIR"
 
     rm -rf "$UNPACK_DIR"
@@ -519,6 +521,8 @@ systemctl reload ssh
 touch /root/spread-setup-done
 EOF
     chmod 0755 "$UNPACK_DIR"/usr/lib/snapd/snapd.spread-tests-run-mode-tweaks.sh
+
+    cp "${SPREAD_PATH}"/data/completion/bash/complete.sh "${UNPACK_DIR}"/usr/lib/snapd/complete.sh
 
     snap pack "$UNPACK_DIR" "$TARGET"
     rm -rf "$UNPACK_DIR"

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -21,12 +21,87 @@
 package wrappers
 
 import (
+	"bufio"
 	"os"
+	"regexp"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 )
+
+type completionMode int
+
+const (
+	noCompletion completionMode = iota
+	legacyCompletion
+	normalCompletion
+)
+
+// detectCompletion verifies if and how completion should be installed.
+// If `complete.sh` is not available then completion is disabled.
+// If bash-completion less than 2.2, bash-completion does not support
+// XDG_DATA_DIRS. So we select legacy path installation.
+// If it fails to detect the version of bash-completion, it disables
+// completion.
+func detectCompletion(base string) (string, completionMode) {
+	completeSh := dirs.CompleteShPath(base)
+
+	if !osutil.FileExists(completeSh) {
+		return "", noCompletion
+	}
+
+	fd, err := os.Open(dirs.BashCompletionScript)
+	if err != nil {
+		// Cannot read file, disable completion
+		return "", noCompletion
+	}
+	defer fd.Close()
+
+	// Up to 2.5
+	releaseOld := regexp.MustCompile(`^# *RELEASE: ([0-9.]+)$`)
+	// 2.6 and later
+	releaseNew := regexp.MustCompile(`^BASH_COMPLETION_VERSINFO=`)
+	s := bufio.NewScanner(fd)
+	var matched []string
+	for s.Scan() {
+		line := s.Text()
+		matched = releaseOld.FindStringSubmatch(line)
+		if matched == nil {
+			if releaseNew.MatchString(line) {
+				// It must be 2.6 or later
+				return completeSh, normalCompletion
+			}
+		} else {
+			break
+		}
+	}
+	if err := s.Err(); err != nil {
+		// Cannot read file, disable completion
+		return "", noCompletion
+	}
+	if matched == nil {
+		// Unknown version: disable completion
+		return "", noCompletion
+	}
+
+	versionComp, err := strutil.VersionCompare(matched[1], "2.2")
+	if err != nil {
+		// Cannot parse version, disable completion
+		return "", noCompletion
+	}
+
+	if versionComp < 0 {
+		if !osutil.IsWritable(dirs.LegacyCompletersDir) {
+			return "", noCompletion
+		} else {
+			return completeSh, legacyCompletion
+		}
+	} else {
+		return completeSh, normalCompletion
+	}
+}
 
 // AddSnapBinaries writes the wrapper binaries for the applications from the snap which aren't services.
 func AddSnapBinaries(s *snap.Info) (err error) {
@@ -44,8 +119,8 @@ func AddSnapBinaries(s *snap.Info) (err error) {
 		return err
 	}
 
-	completeSh := dirs.CompleteShPath(s.Base)
-	noCompletion := !osutil.IsWritable(dirs.CompletersDir) || !osutil.FileExists(completeSh)
+	completeSh, completion := detectCompletion(s.Base)
+
 	for _, app := range s.Apps {
 		if app.IsService() {
 			continue
@@ -60,11 +135,28 @@ func AddSnapBinaries(s *snap.Info) (err error) {
 		}
 		created = append(created, wrapperPath)
 
-		if noCompletion || app.Completer == "" {
+		if completion == normalCompletion {
+			legacyCompPath := app.LegacyCompleterPath()
+			if dirs.IsCompleteShSymlink(legacyCompPath) {
+				os.Remove(legacyCompPath)
+			}
+		}
+
+		if completion == noCompletion || app.Completer == "" {
 			continue
 		}
 		// symlink the completion snippet
+		compDir := dirs.CompletersDir
+		if completion == legacyCompletion {
+			compDir = dirs.LegacyCompletersDir
+		}
+		if err := os.MkdirAll(compDir, 0755); err != nil {
+			return err
+		}
 		compPath := app.CompleterPath()
+		if completion == legacyCompletion {
+			compPath = app.LegacyCompleterPath()
+		}
 		if err := os.Symlink(completeSh, compPath); err == nil {
 			created = append(created, compPath)
 		} else if !os.IsExist(err) {
@@ -85,6 +177,10 @@ func RemoveSnapBinaries(s *snap.Info) error {
 		compPath := app.CompleterPath()
 		if dirs.IsCompleteShSymlink(compPath) {
 			os.Remove(compPath)
+		}
+		legacyCompPath := app.LegacyCompleterPath()
+		if dirs.IsCompleteShSymlink(legacyCompPath) {
+			os.Remove(legacyCompPath)
 		}
 	}
 


### PR DESCRIPTION
Snapd installs bash completion files from snaps in
`/usr/share/bash-completion/completions` which in some distributions
is a read-only filesystem.

Instead of installing them in `/usr` we can install them within
`/var/lib/snapd` which should always be writable.

To enable that path in bash completions we only need to add the path
to `XDG_DATA_DIRS`.

An alternative could be to install the file in
`/etc/bash_completion.d`.

~~DRAFT: This is incomplete as we need to migrate symlinks in
`/usr/share/bash-completion/completions` to `/var/lib/snapd`~~
Migration of the path was added.
