### PR TITLE
gadget: include size + sector-size in DiskVolumeDeviceTraits

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -238,6 +238,14 @@ type DiskVolumeDeviceTraits struct {
 	// the volume that may be useful in identifying whether a disk matches a
 	// volume or not.
 	Structure []DiskStructureDeviceTraits `json:"structure"`
+
+	// Size is the physical size of the disk, regardless of usable space
+	// considerations.
+	Size quantity.Size `json:"size"`
+
+	// SectorSize is the physical sector size of the disk, typically 512 or
+	// 4096.
+	SectorSize quantity.Size `json:"sector-size"`
 }
 
 // DiskStructureDeviceTraits is a similar to DiskVolumeDeviceTraits, but is a

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2941,6 +2941,8 @@ func (s *gadgetYamlTestSuite) TestSaveLoadDiskVolumeDeviceTraits(c *C) {
 			OriginalDevicePath: "/sys/devices/pci0000:00/0000:00:04.0/virtio2/block/vdb",
 			OriginalKernelPath: "/dev/vdb",
 			DiskID:             "484B4BA1-3EDF-4270-A1A8-378FCBB0E1DE",
+			Size:               10 * quantity.SizeGiB,
+			SectorSize:         quantity.Size(512),
 			Structure: []gadget.DiskStructureDeviceTraits{
 				// first structure is a bare structure with no filesystem
 				{


### PR DESCRIPTION
This will also be helpful in identifying which disk is which when it comes time
to finally do that.

Needs Samuele review just to confirm the field names here.