### PR TITLE
interfaces/builtin/block_devices: allow blkid to print block device attributes

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -99,6 +99,9 @@ capability sys_admin,
 # Allow /sys/block/sdX/device/state to be accessible to accept or reject the request from given the path.
 # To take the path offline will cause any subsequent access to fail immediately, vice versa.
 /sys/devices/**/host*/**/state rw,
+
+# Allow to use blkid to export key=value pairs such as UUID to get block device attributes
+/{,usr/}sbin/blkid ixr,
 `
 
 var blockDevicesConnectedPlugUDev = []string{


### PR DESCRIPTION
To allow blkid to visit block_devices attributes via low level probing, so that
we can get information like partition table type or PART_ENTRY_UUID
which could be useful for script based snap without parsing
/run/udev/data/b{major}:{minor}.

Signed-off-by: Hsieh-Tseng Shen <woodrow.shen@canonical.com>
