### PR TITLE
interfaces/builtin/opengl.go: add boot_vga sys/devices file

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -127,6 +127,7 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 # /sys/devices
 /sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/config r,
 /sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/revision r,
+/sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/boot_vga r,
 /sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/{,subsystem_}class r,
 /sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/{,subsystem_}device r,
 /sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/{,subsystem_}vendor r,


### PR DESCRIPTION
Allow reading boot_vga attribute
(e.g. /sys/devices/pci0000:00/0000:00:01.0/boot_vga ) of the graphics
cards in /sys/devices, as is done by libpciaccess library by default.
