### PR TITLE
o/snapstate/handlers: propagate read errors on "copy-snap-data"

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1105,7 +1105,7 @@ func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	newInfo, err := readInfo(snapsup.InstanceName(), snapsup.SideInfo, 0)
+	newInfo, err := readInfo(snapsup.InstanceName(), snapsup.SideInfo, errorOnBroken)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers_copy_test.go
+++ b/overlord/snapstate/handlers_copy_test.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type copySnapDataSuite struct {
+	baseHandlerSuite
+}
+
+var _ = Suite(&copySnapDataSuite{})
+
+func (s *copySnapDataSuite) SetUpTest(c *C) {
+	s.baseHandlerSuite.SetUpTest(c)
+}
+
+func (s *copySnapDataSuite) TestDoCopySnapDataFailedRead(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// With a snap "pkg" at revision 42
+	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(42)}
+	snapstate.Set(s.state, "pkg", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		Active:   true,
+	})
+
+	// With an app belonging to the snap that is apparently running.
+	snapstate.MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		return nil, errors.New("some error")
+	})
+
+	// We can unlink the current revision of that snap, by setting IgnoreRunning flag.
+	task := s.state.NewTask("copy-snap-data", "test")
+	task.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "pkg",
+			Revision: snap.R(42),
+		},
+	})
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(task)
+
+	// Run the task we created
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	// And observe the results.
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "pkg", &snapst)
+	c.Assert(err, IsNil)
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches, `(?s).*\(some error\)`)
+}


### PR DESCRIPTION
If the "copy-snap-data" task fails to read the snap data, an error is
logged but is not causing the task to fail. See for example these logs
(from `journald -xe`, occurring on [LP#1949089](https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1949089)):

```
Nov 12 06:08:50 nov120556-302222 systemd[1]: Reloading.
Nov 12 06:08:50 nov120556-302222 systemd[1]: Unmounting Mount unit for disabled-svcs-kept, revision x2...
-- Subject: Unit snap-disabled\x2dsvcs\x2dkept-x2.mount has begun shutting down
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
--
-- Unit snap-disabled\x2dsvcs\x2dkept-x2.mount has begun shutting down.
Nov 12 06:08:50 nov120556-302222 systemd-udevd[663]: Network interface NamePolicy= disabled on kernel command line, ignoring.
Nov 12 06:08:50 nov120556-302222 systemd[1]: Unmounted Mount unit for disabled-svcs-kept, revision x2.
-- Subject: Unit snap-disabled\x2dsvcs\x2dkept-x2.mount has finished shutting down
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
--
-- Unit snap-disabled\x2dsvcs\x2dkept-x2.mount has finished shutting down.
Nov 12 06:08:50 nov120556-302222 snapd[2819]: taskrunner.go:439: DEBUG: Running task 154 on Do: Copy snap "disabled-svcs-kept" data
Nov 12 06:08:50 nov120556-302222 snapd[2819]: snapmgr.go:324: cannot read snap info of snap "disabled-svcs-kept" at revision x2: cannot find installed snap "disabled-svcs-kept" at revision x2: missing file
Nov 12 06:08:51 nov120556-302222 snapd[2819]: taskrunner.go:439: DEBUG: Running task 155 on Do: Setup snap "disabled-svcs-kept" (unset) security profiles
Nov 12 06:08:51 nov120556-302222 snapd[2819]: task.go:337: DEBUG: 2021-11-12T06:08:51Z ERROR cannot find installed snap "disabled-svcs-kept" at revision x2: missing file /snap/disabled-svcs-kept/x2/meta/sna
Nov 12 06:08:51 nov120556-302222 snapd[2819]: taskrunner.go:271: [change 15 "Setup snap \"disabled-svcs-kept\" (unset) security profiles" task] failed: cannot find installed snap "disabled-svcs-kept" at rev
Nov 12 06:08:51 nov120556-302222 snapd[2819]: taskrunner.go:439: DEBUG: Running task 154 on Undo: Copy snap "disabled-svcs-kept" data
Nov 12 06:08:51 nov120556-302222 snapd[2819]: snapmgr.go:324: cannot read snap info of snap "disabled-svcs-kept" at revision x2: cannot find installed snap "disabled-svcs-kept" at revision x2: missing file
Nov 12 06:08:51 nov120556-302222 snapd[2819]: taskrunner.go:439: DEBUG: Running task 153 on Undo: Make current revision for snap "disabled-svcs-kept" unavailable
Nov 12 06:08:51 nov120556-302222 systemd[1]: Reloading.
```

It can be seen that the "copy" task reported an error, but the next task
("setup-profiles") is also executed, and that's when the error is
actually propagated and the revert procedure starts.

While this does not appear to be a problem in practice, it seems more
correct to fail the copy task if the snap info cannot be read.
