### PR TITLE
tests: skip `snap advise-command` test if the store is overloaded

### DIFF
--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -48,6 +48,10 @@ execute: |
             echo "Store is reporting catalog refresh failed: cannot retrieve the sections, skipping the test"
             exit 0
         fi
+        if "$TESTSTOOLS"/journal-state get-log -u snapd | MATCH "cannot decode new commands catalog: got unexpected HTTP status code 403"; then
+            echo "Store is reporting 403: cannot retrieve the sections, skipping the test"
+            exit 0
+        fi
         exit 1
     fi
     echo "Ensure the database is readable by a regular user"


### PR DESCRIPTION
When the store is overloaded it will sent 403 from the
```
https://api.snapcraft.io/api/v1/snaps/names?confinement=strict%2Cclassic
```
endpoint. This causes our `snap-advise-command` test to fail but
we really should handle this gracefully instead.
