### PR TITLE
tests: the `lxd` test is failing right now on 21.10

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -7,7 +7,9 @@ backends: [-autopkgtest]
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
 # ubuntu-18.04-32: i386 is not supported by lxd
-systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-20*, ubuntu-21.04-*, ubuntu-21.10-*, ubuntu-core-*]
+# ubuntu-21.10-*: failing currently with
+# "Setup snap "core" (11993) security profiles (cannot run udev triggers: exit status 1"
+systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-20*, ubuntu-21.04-*, ubuntu-core-*]
 
 # Start before anything else as it can take a really long time.
 priority: 1000


### PR DESCRIPTION
The `lxd` test is currently failing in 21.10 with:
```
...
2021-11-11T07:41:21.3458885Z + lxd.lxc exec my-nesting-ubuntu -- snap set system experimental.refresh-app-awareness=false
2021-11-11T07:41:21.3460916Z + echo 'Ensure we can use snapd inside lxd'
2021-11-11T07:41:21.3461565Z Ensure we can use snapd inside lxd
2021-11-11T07:41:21.3488625Z + lxd.lxc exec my-ubuntu snap install test-snapd-sh
2021-11-11T07:41:21.3489599Z error: cannot perform the following tasks:
2021-11-11T07:41:21.3491133Z - Setup snap "core" (11993) security profiles (cannot run udev triggers: exit status 1
2021-11-11T07:41:21.3491824Z udev output:
2021-11-11T07:41:21.3492889Z LNXSYSTM:00: Failed to write 'change' to '/sys/devices/LNXSYSTM:00/uevent': Permission denied
...
```
until this is fixed we need to disable this test and in parallel find a fix/talk to the LXD folks.


I reported https://github.com/lxc/lxd/issues/9526 - I suspect this could be either cgroup v2 or https://github.com/snapcore/snapd/pull/11039 related but the 11039 fix also fails in the tests so maybe it's not that.