### PR TITLE
tests: ensure machine clock is ntp synced during prepare

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -378,6 +378,9 @@ prepare_classic() {
 
     disable_kernel_rate_limiting
 
+    # ensure that the system clock is ntp synced
+    timedatectl set-ntp true
+
     if os.query is-arch-linux; then
         # Arch packages do not ship empty directories by default, hence there is
         # no /etc/dbus-1/system.d what prevents dbus from properly establishing

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -21,6 +21,7 @@ debug: |
     systemctl status systemd-timedated || true
     journalctl -u systemd-timedated || true
     timedatectl || true
+    timedatectl timesync-status || true
 
 execute: |
     echo "Auto refresh information is shown"

--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -10,6 +10,7 @@ debug: |
     systemctl status systemd-timedated || true
     journalctl -u systemd-timedated || true
     timedatectl || true
+    timedatectl timesync-status || true
 
 execute: |
     # Check help


### PR DESCRIPTION
We see failures in some tests now because the auto-refresh
timers wait for ntp to be available. For some reason not
all GCE machines sync their clocks. It looks a bit random
so to workaround this this commit explicitly enables the
ntp sync.

In addition it expands the debug for the two failing tests
so that if this is not enough we get better information what
is going on.
