### PR TITLE
daemon: write formdata file parts to snaps dir

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -163,11 +163,11 @@ func newChange(st *state.State, kind, summary string, tsets []*state.TaskSet, sn
 }
 
 func isTrue(form *Form, key string) bool {
-	value := form.Value[key]
-	if len(value) == 0 {
+	values := form.Values[key]
+	if len(values) == 0 {
 		return false
 	}
-	b, err := strconv.ParseBool(value[0])
+	b, err := strconv.ParseBool(values[0])
 	if err != nil {
 		return false
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -21,7 +21,6 @@ package daemon
 
 import (
 	"fmt"
-	"mime/multipart"
 	"net/http"
 	"strconv"
 	"strings"
@@ -163,7 +162,7 @@ func newChange(st *state.State, kind, summary string, tsets []*state.TaskSet, sn
 	return chg
 }
 
-func isTrue(form *multipart.Form, key string) bool {
+func isTrue(form *Form, key string) bool {
 	value := form.Value[key]
 	if len(value) == 0 {
 		return false

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -625,7 +625,7 @@ func (s *apiBaseSuite) syncReq(c *check.C, req *http.Request, u *auth.UserState)
 
 func (s *apiBaseSuite) asyncReq(c *check.C, req *http.Request, u *auth.UserState) *daemon.RespJSON {
 	rsp := s.jsonReq(c, req, u)
-	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeAsync, check.Commentf("expected async resp: %#v", rsp))
+	c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeAsync, check.Commentf("expected async resp: %#v, result %v", rsp, rsp.Result))
 	return rsp
 }
 

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -285,8 +285,8 @@ func readForm(reader *multipart.Reader) (_ *Form, apiErr *apiError) {
 			return nil, InternalError("cannot open parent dir of temp files: %v", err)
 		}
 		defer func() {
-			if cerr := dir.Close(); err == nil && cerr != nil {
-				err = InternalError("cannot close parent dir of temp files: %v", cerr)
+			if cerr := dir.Close(); apiErr == nil && cerr != nil {
+				apiErr = InternalError("cannot close parent dir of temp files: %v", cerr)
 			}
 		}()
 

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -43,7 +43,7 @@ import (
 	"github.com/snapcore/snapd/snap/snapfile"
 )
 
-// Form is a multipart form that hold file and non-file parts
+// Form is a multipart form that holds file and non-file parts
 type Form struct {
 	// Values holds non-file parts keyed by their "name" parameter (from the
 	// part's Content-Disposition header).
@@ -51,7 +51,7 @@ type Form struct {
 
 	// FileRefs holds file parts keyed by their "name" parameter (from the
 	// part's Content-Disposition header). Each reference contains a filename
-	// (the "filename" parameter) and the path to a file with the parts contents.
+	// (the "filename" parameter) and the path to a file with the part's contents.
 	FileRefs map[string][]*FileReference
 }
 

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -254,7 +254,7 @@ func readForm(reader *multipart.Reader) (_ *Form, apiErr *apiError) {
 
 			// copy one byte more than the max so we know if it exceeds the limit
 			n, err := io.CopyN(buf, part, availMemory+1)
-			if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			if err != nil && !errors.Is(err, io.EOF) {
 				return nil, BadRequest("cannot read form data: %v", err)
 			}
 

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -36,7 +36,6 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
-	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -61,7 +60,7 @@ func (f *Form) RemoveAll() {
 	}
 }
 
-func sideloadOrTrySnap(c *Command, body io.ReadCloser, boundary string, user *auth.UserState) Response {
+func sideloadOrTrySnap(c *Command, body io.ReadCloser, boundary string) Response {
 	route := c.d.router.Get(stateChangeCmd.Path)
 	if route == nil {
 		return InternalError("cannot find route for change")

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -613,7 +613,7 @@ func (s *sideloadSuite) TestCleanUpTempFilesIfRequestFailed(c *check.C) {
 
 	apiErr := s.errorReq(c, req, nil)
 	c.Check(apiErr, check.NotNil)
-	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, dirs.LocalInstallBlobTempPrefix+"*"))
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
 	c.Assert(err, check.IsNil)
 	c.Check(matches, check.HasLen, 0)
 }
@@ -641,7 +641,7 @@ func (s *sideloadSuite) TestCleanUpUnusedTempSnapFiles(c *check.C) {
 
 	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, dirs.LocalInstallBlobTempPrefix+"*"))
 	c.Assert(err, check.IsNil)
-	// only the file passed into the change remains
+	// only the file passed into the change (the request's first file) remains
 	c.Check(matches, check.HasLen, 1)
 }
 

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -487,7 +487,7 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("unknown content type: %s", contentType)
 	}
 
-	return sideloadOrTrySnap(c, r.Body, params["boundary"], user)
+	return sideloadOrTrySnap(c, r.Body, params["boundary"])
 }
 
 func snapOpMany(c *Command, r *http.Request, user *auth.UserState) Response {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -117,11 +117,11 @@ func (s *apiSuite) TestIsTrue(c *check.C) {
 	form := &daemon.Form{}
 	c.Check(daemon.IsTrue(form, "foo"), check.Equals, false)
 	for _, f := range []string{"", "false", "0", "False", "f", "try"} {
-		form.Value = map[string][]string{"foo": {f}}
+		form.Values = map[string][]string{"foo": {f}}
 		c.Check(daemon.IsTrue(form, "foo"), check.Equals, false, check.Commentf("expected %q to be false", f))
 	}
 	for _, t := range []string{"true", "1", "True", "t"} {
-		form.Value = map[string][]string{"foo": {t}}
+		form.Values = map[string][]string{"foo": {t}}
 		c.Check(daemon.IsTrue(form, "foo"), check.Equals, true, check.Commentf("expected %q to be true", t))
 	}
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -21,7 +21,6 @@ package daemon_test
 
 import (
 	"fmt"
-	"mime/multipart"
 	"net/http"
 
 	"gopkg.in/check.v1"
@@ -115,7 +114,7 @@ func (s *apiSuite) TestUserFromRequestHeaderValidUser(c *check.C) {
 }
 
 func (s *apiSuite) TestIsTrue(c *check.C) {
-	form := &multipart.Form{}
+	form := &daemon.Form{}
 	c.Check(daemon.IsTrue(form, "foo"), check.Equals, false)
 	for _, f := range []string{"", "false", "0", "False", "f", "try"} {
 		form.Value = map[string][]string{"foo": {f}}

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -229,4 +229,6 @@ var (
 
 	MakeErrorResponder = makeErrorResponder
 	ErrToResponse      = errToResponse
+
+	MaxReadBuflen = maxReadBuflen
 )


### PR DESCRIPTION
The multipart stdlib writes formdata file parts (above a limit) to
/tmp and that could exceed the available space on devices using tmpfs.
The files would then be copied from /tmp to /var/lib/snapd/snaps.
This change adds a custom form reader that reads non-file parts into
memory and writes file parts directly to /var/lib/snapd/snaps.

Note: This also effectively reduces the memory limit because the library added
10MB to user passed limit. Since this change doesn't try to keep the file parts
in memory, I think the 1MB limit for non-file parts is more than enough. 

https://bugs.launchpad.net/snapd/+bug/1950190