### PR TITLE
packaging: make postrm script robust against `rm` failures

### DIFF
--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -137,7 +137,7 @@ if [ "$1" = "purge" ]; then
     echo "Final directory cleanup"
     for d in "/snap/bin" "/snap" "/var/snap"; do
         # Force remove due to directories for old revisions could still exist
-        rm -rf "$d"
+        rm -rf "$d" || true
         if [ -d "$d" ]; then
             echo "Cannot remove directory $d"
         fi


### PR DESCRIPTION
We do not want to risk failing the whole script (and therefore leaving
the user's system in a dirty state) if removing the snap directories
fails.
This has happened in real life (see the bug report linked below) and,
although the mechanisms to reproduce the issue are not clear, this fixes
the symptoms.

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1950634
