### PR TITLE
interfaces/udev: append --quiet to udevadm trigger calls with newer systemd (>=248)

### DIFF
--- a/interfaces/udev/export_test.go
+++ b/interfaces/udev/export_test.go
@@ -19,6 +19,11 @@
 
 package udev
 
+var (
+	GetSystemdVersion = getSystemdVersion
+	MaybeTriggerQuiet = maybeTriggerQuiet
+)
+
 func (b *Backend) ReloadRules(subsystemTriggers []string) error {
 	return b.reloadRules(subsystemTriggers)
 }

--- a/interfaces/udev/udev.go
+++ b/interfaces/udev/udev.go
@@ -44,7 +44,7 @@ func init() {
 func maybeTriggerQuiet(args ...string) []string {
 	args = append([]string{"trigger"}, args...)
 	if systemdVersion >= 248 {
-		// append --quiet flag with new systemd to accomodate to change in error
+		// append --quiet flag with new systemd to accommodate to change in error
 		// reporting introduced with ubuntu 21.10; see https://github.com/lxc/lxd/issues/9526
 		args = append(args, "--quiet")
 	}


### PR DESCRIPTION
Related to https://github.com/snapcore/snapd/pull/11050 and an issue reported against lxd https://github.com/lxc/lxd/issues/9526 : pass --quiet flag to `udevadm trigger ...` if systemd is >=248 (i.e. ubuntu 21.10) to ignore errors.
