### PR TITLE
tests: print extra debug on auto-refresh-gating test failure

### DIFF
--- a/tests/main/auto-refresh-gating/task.yaml
+++ b/tests/main/auto-refresh-gating/task.yaml
@@ -19,8 +19,8 @@ prepare: |
 
 debug: |
   jq -r '.data["snaps-hold"]' < /var/lib/snapd/state.json || true
-  snap changes
-  snap refresh --time
+  snap changes || true
+  snap refresh --time || true
 
 execute: |
   LAST_REFRESH_CHANGE_ID=1

--- a/tests/main/auto-refresh-gating/task.yaml
+++ b/tests/main/auto-refresh-gating/task.yaml
@@ -19,6 +19,8 @@ prepare: |
 
 debug: |
   jq -r '.data["snaps-hold"]' < /var/lib/snapd/state.json || true
+  snap changes
+  snap refresh --time
 
 execute: |
   LAST_REFRESH_CHANGE_ID=1


### PR DESCRIPTION
auto-refresh-gating spread test occasionally fails (https://bugs.launchpad.net/snapd/+bug/1950994); add more debug to help understand why.