### PR TITLE
gadget/install: use disks functions to implement deviceFromRole, also rename

### DIFF
--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	DeviceFromSystemSeedRole = deviceFromSystemSeedRole
-	NewEncryptedDeviceLUKS   = newEncryptedDeviceLUKS
+	DiskWithSystemSeed     = diskWithSystemSeed
+	NewEncryptedDeviceLUKS = newEncryptedDeviceLUKS
 )
 
 func MockSecbootFormatEncryptedDevice(f func(key secboot.EncryptionKey, label, node string) error) (restore func()) {

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	DeviceFromRole         = deviceFromRole
-	NewEncryptedDeviceLUKS = newEncryptedDeviceLUKS
+	DeviceFromSystemSeedRole = deviceFromSystemSeedRole
+	NewEncryptedDeviceLUKS   = newEncryptedDeviceLUKS
 )
 
 func MockSecbootFormatEncryptedDevice(f func(key secboot.EncryptionKey, label, node string) error) (restore func()) {

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -28,9 +28,9 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/install"
+	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
@@ -105,7 +105,7 @@ const mockUC20GadgetYaml = `volumes:
         size: 750M
 `
 
-func (s *installSuite) setupMockSysfs(c *C) {
+func (s *installSuite) setupMockUdevSymlinks(c *C) {
 	err := os.MkdirAll(filepath.Join(s.dir, "/dev/disk/by-partlabel"), 0755)
 	c.Assert(err, IsNil)
 
@@ -113,23 +113,29 @@ func (s *installSuite) setupMockSysfs(c *C) {
 	c.Assert(err, IsNil)
 	err = os.Symlink("../../fakedevice0p1", filepath.Join(s.dir, "/dev/disk/by-partlabel/ubuntu-seed"))
 	c.Assert(err, IsNil)
-
-	// make parent device
-	err = ioutil.WriteFile(filepath.Join(s.dir, "/dev/fakedevice0"), nil, 0644)
-	c.Assert(err, IsNil)
-	// and fake /sys/block structure
-	err = os.MkdirAll(filepath.Join(s.dir, "/sys/block/fakedevice0/fakedevice0p1"), 0755)
-	c.Assert(err, IsNil)
 }
 
 func (s *installSuite) TestDeviceFromRoleHappy(c *C) {
-	s.setupMockSysfs(c)
+
+	s.setupMockUdevSymlinks(c)
+
+	m := map[string]*disks.MockDiskMapping{
+		filepath.Join(s.dir, "/dev/fakedevice0p1"): {
+			DevNum:  "42:0",
+			DevNode: "/dev/fakedevice0",
+			DevPath: "/sys/block/fakedevice0",
+		},
+	}
+
+	restore := disks.MockPartitionDeviceNodeToDiskMapping(m)
+	defer restore()
+
 	lv, err := gadgettest.LayoutFromYaml(c.MkDir(), mockUC20GadgetYaml, uc20Mod)
 	c.Assert(err, IsNil)
 
-	device, err := install.DeviceFromRole(lv, gadget.SystemSeed)
+	device, err := install.DeviceFromSystemSeedRole(lv)
 	c.Assert(err, IsNil)
-	c.Check(device, Matches, ".*/dev/fakedevice0")
+	c.Check(device, Equals, "/dev/fakedevice0")
 }
 
 func (s *installSuite) TestDeviceFromRoleErrorNoMatchingSysfs(c *C) {
@@ -137,15 +143,15 @@ func (s *installSuite) TestDeviceFromRoleErrorNoMatchingSysfs(c *C) {
 	lv, err := gadgettest.LayoutFromYaml(c.MkDir(), mockUC20GadgetYaml, uc20Mod)
 	c.Assert(err, IsNil)
 
-	_, err = install.DeviceFromRole(lv, gadget.SystemSeed)
+	_, err = install.DeviceFromSystemSeedRole(lv)
 	c.Assert(err, ErrorMatches, `cannot find device for role "system-seed": device not found`)
 }
 
 func (s *installSuite) TestDeviceFromRoleErrorNoRole(c *C) {
-	s.setupMockSysfs(c)
+	s.setupMockUdevSymlinks(c)
 	lv, err := gadgettest.LayoutFromYaml(c.MkDir(), mockGadgetYaml, nil)
 	c.Assert(err, IsNil)
 
-	_, err = install.DeviceFromRole(lv, gadget.SystemSeed)
+	_, err = install.DeviceFromSystemSeedRole(lv)
 	c.Assert(err, ErrorMatches, "cannot find role system-seed in gadget")
 }

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -133,7 +133,7 @@ func (s *installSuite) TestDeviceFromRoleHappy(c *C) {
 	lv, err := gadgettest.LayoutFromYaml(c.MkDir(), mockUC20GadgetYaml, uc20Mod)
 	c.Assert(err, IsNil)
 
-	device, err := install.DeviceFromSystemSeedRole(lv)
+	device, err := install.DiskWithSystemSeed(lv)
 	c.Assert(err, IsNil)
 	c.Check(device, Equals, "/dev/fakedevice0")
 }
@@ -143,8 +143,8 @@ func (s *installSuite) TestDeviceFromRoleErrorNoMatchingSysfs(c *C) {
 	lv, err := gadgettest.LayoutFromYaml(c.MkDir(), mockUC20GadgetYaml, uc20Mod)
 	c.Assert(err, IsNil)
 
-	_, err = install.DeviceFromSystemSeedRole(lv)
-	c.Assert(err, ErrorMatches, `cannot find device for role "system-seed": device not found`)
+	_, err = install.DiskWithSystemSeed(lv)
+	c.Assert(err, ErrorMatches, `cannot find device for role system-seed: device not found`)
 }
 
 func (s *installSuite) TestDeviceFromRoleErrorNoRole(c *C) {
@@ -152,6 +152,6 @@ func (s *installSuite) TestDeviceFromRoleErrorNoRole(c *C) {
 	lv, err := gadgettest.LayoutFromYaml(c.MkDir(), mockGadgetYaml, nil)
 	c.Assert(err, IsNil)
 
-	_, err = install.DeviceFromSystemSeedRole(lv)
+	_, err = install.DiskWithSystemSeed(lv)
 	c.Assert(err, ErrorMatches, "cannot find role system-seed in gadget")
 }


### PR DESCRIPTION
This is to better support being able to mock things via the MockDevice... family of functions.

Eventually more of the gadget functions like gadget.ParentDiskFromMountSource can be 
eliminated too, but for now just this little tidbit which should be small and bite sized to review.