### PR TITLE
tests: skip the test-snapd-timedate-control-consumer.date to avoid NTP sync error

### DIFF
--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -16,14 +16,12 @@ prepare: |
 
 restore: |
     # Restore the initial rtc configuration
-    snap connect test-snapd-timedate-control-consumer:netlink-audit
-    snap connect test-snapd-timedate-control-consumer:time-control
     if [ -f rtc.txt ]; then
-        test-snapd-timedate-control-consumer.timedatectl-time set-local-rtc "$(cat rtc.txt)"
+        timedatectl set-local-rtc "$(cat rtc.txt)"
     fi
 
     # TODO: re-enable once the ntp issue is fixed
-    #test-snapd-timedate-control-consumer.date "$(cat now.txt)"
+    #date "$(cat now.txt)"
 
 execute: |
     # hwclock with libaudit (ie, core 16) also needs netlink-audit connected.
@@ -56,8 +54,8 @@ execute: |
     [ "$(test-snapd-timedate-control-consumer.timedatectl-time status | grep -oP 'RTC in local TZ: \K(.*)')" = "no" ]
 
     echo "And direct setting via date"
-    # Ntp syncronization is not done after the date is changed using the date command.
-    # The issue happens even when the syncronization is manually forced.
+    # Ntp synchronization is not done after the date is changed using the date command.
+    # The issue happens even when the synchronization is manually forced.
     # The error displayed in the journal is the following:
     # synchronized.go:72: DEBUG: NTPSynchronized state returned by timedate1: false
 

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -16,11 +16,14 @@ prepare: |
 
 restore: |
     # Restore the initial rtc configuration
+    snap connect test-snapd-timedate-control-consumer:netlink-audit
+    snap connect test-snapd-timedate-control-consumer:time-control
     if [ -f rtc.txt ]; then
-        timedatectl set-local-rtc "$(cat rtc.txt)"
+        test-snapd-timedate-control-consumer.timedatectl-time set-local-rtc "$(cat rtc.txt)"
     fi
 
-    date "$(cat now.txt)"
+    # TODO: re-enable once the ntp issue is fixed
+    #test-snapd-timedate-control-consumer.date "$(cat now.txt)"
 
 execute: |
     # hwclock with libaudit (ie, core 16) also needs netlink-audit connected.
@@ -53,8 +56,14 @@ execute: |
     [ "$(test-snapd-timedate-control-consumer.timedatectl-time status | grep -oP 'RTC in local TZ: \K(.*)')" = "no" ]
 
     echo "And direct setting via date"
-    nice_when="$(date -d 'tomorrow' +'%m%d%H%M.%y')"
-    test-snapd-timedate-control-consumer.date "$nice_when"
+    # Ntp syncronization is not done after the date is changed using the date command.
+    # The issue happens even when the syncronization is manually forced.
+    # The error displayed in the journal is the following:
+    # synchronized.go:72: DEBUG: NTPSynchronized state returned by timedate1: false
+
+    # TODO: re-enable once the ntp issue is fixed
+    #nice_when="$(date -d 'tomorrow' +'%m%d%H%M.%y')"
+    #test-snapd-timedate-control-consumer.date "$nice_when"
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0


### PR DESCRIPTION
NTP syncronization is not done after the date is changed using the date
command. The issue happens even when the syncronization is manually forced.
The error displayed in the journal is the following:
synchronized.go:72: DEBUG: NTPSynchronized state returned by timedate1:
false

In order to reproduce the error and check the fix, run:
spread-debug -order -single-worker -debug
google:ubuntu-20.04-64:tests/main/interfaces-time-control
google:ubuntu-20.04-64:tests/main/snapd-stat

