### PR TITLE
tests/main/security-device-cgroups-strict-enforced: extend the comments

### DIFF
--- a/tests/main/security-device-cgroups-strict-enforced/task.yaml
+++ b/tests/main/security-device-cgroups-strict-enforced/task.yaml
@@ -61,20 +61,28 @@ execute: |
     rm -f /var/snap/test-strict-cgroup/common/started
     rm -f /var/snap/test-strict-cgroup/common/ready
 
+    # device cgroup settings can be updated by snap-device-helper based on udev
+    # events, in which case only the device identified by the event should be
+    # changed, while no other property of the device cgroup shall be changed
+    # (incl. other already allowed devices)
+
     # trigger a change event for /dev/full so that we observe that the device
     # cgroup settings remain stable and we can still access /dev/zero
     snap run test-strict-cgroup.sh -c 'touch /var/snap/test-strict-cgroup/common/started; until test -e /var/snap/test-strict-cgroup/common/ready; do sleep 1; done; echo ok > /dev/zero' > run.log 2>&1 &
     retry -n 5 test -e /var/snap/test-strict-cgroup/common/started
     # save the dump
     tests.device-cgroup test-strict-cgroup.sh dump | sort > dump-before-change
-    # trigger a change of /dev/full
+    # by now the device cgroup got already set up by snap-confine when the
+    # application was starting, triggering a udev event for /dev/full will not
+    # affect already allowed devices (incl. /dev/zero)
     udevadm trigger --name-match /dev/full
     udevadm settle
     tests.device-cgroup test-strict-cgroup.sh dump | sort > dump-after-change
     # we are ready
     touch /var/snap/test-strict-cgroup/common/ready
     wait || true
-    # nothing was logged
+    # nothing was logged, i.e. /dev/zero access was successful
     MATCH "^$" < run.log
-    # dumps are the same
+    # dumps are the same, because the event action was 'change', so /dev/full
+    # still exists
     diff -up dump-before-change dump-after-change


### PR DESCRIPTION
Extend the comments describing what happens in the test.

