### PR TITLE
tests: ensure ntp-sync is re-enabled after interfaces-time-control

### DIFF
--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -14,6 +14,13 @@ prepare: |
 
     date +'%m%d%H%M.%y' > now.txt
 
+    # ensure ntp sync is restored if needed
+    case "$(busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP)" in
+        "b true")
+            tests.cleanup defer busctl call org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 SetNTP bb true false
+            ;;
+    esac
+
 restore: |
     # Restore the initial rtc configuration
     if [ -f rtc.txt ]; then


### PR DESCRIPTION
The test `interfaces-time-control` implicitly disables ntp-sync
when calling `data $(cat now.txt)`. Ensure that ntp is sync is
enabled afterwards as needed.

This will fix flaky tests as described in
https://bugs.launchpad.net/snapd/+bug/1949886

Alternative idea to fix https://github.com/snapcore/snapd/pull/11063 
