### PR TITLE
gadget/gadget.go: include disk schema in the disk device volume traits too

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -246,6 +246,9 @@ type DiskVolumeDeviceTraits struct {
 	// SectorSize is the physical sector size of the disk, typically 512 or
 	// 4096.
 	SectorSize quantity.Size `json:"sector-size"`
+
+	// Schema is the disk schema, either dos or gpt in lowercase.
+	Schema string `json:"schema"`
 }
 
 // DiskStructureDeviceTraits is a similar to DiskVolumeDeviceTraits, but is a

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2943,6 +2943,7 @@ func (s *gadgetYamlTestSuite) TestSaveLoadDiskVolumeDeviceTraits(c *C) {
 			DiskID:             "484B4BA1-3EDF-4270-A1A8-378FCBB0E1DE",
 			Size:               10 * quantity.SizeGiB,
 			SectorSize:         quantity.Size(512),
+			Schema:             "gpt",
 			Structure: []gadget.DiskStructureDeviceTraits{
 				// first structure is a bare structure with no filesystem
 				{
@@ -2974,6 +2975,7 @@ func (s *gadgetYamlTestSuite) TestSaveLoadDiskVolumeDeviceTraits(c *C) {
 			OriginalDevicePath: "/sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda",
 			OriginalKernelPath: "/dev/vda",
 			DiskID:             "46E2573B-7891-4316-B83C-DE0817A7CFB5",
+			Schema:             "gpt",
 			Structure: []gadget.DiskStructureDeviceTraits{
 				{
 					OriginalDevicePath: "/dev/vda1",


### PR DESCRIPTION
This should also be there to verify that disks are the same.