### PR TITLE
data/env: provide profile setup for fish shell

### DIFF
--- a/data/env/Makefile
+++ b/data/env/Makefile
@@ -15,22 +15,35 @@
 
 SNAP_MOUNT_DIR := /snap
 ENVD := /etc/profile.d
+DATADIR ?= /usr/share
 
 %.sh: %.sh.in
 	sed   < $< > $@ \
 		s:@SNAP_MOUNT_DIR@:${SNAP_MOUNT_DIR}:g
 
-GENERATED = snapd.sh
+%.fish: %.fish.in
+	sed   < $< > $@ \
+		s:@SNAP_MOUNT_DIR@:${SNAP_MOUNT_DIR}:g
 
+GENERATED_SH = snapd.sh
+GENERATED_FISH = snapd.fish
+GENERATED = ${GENERATED_SH} ${GENERATED_FISH}
 
 all: ${GENERATED}
 .PHONY: all
 
-install: ${GENERATED}
+install-sh: ${GENERATED_SH}
 	# NOTE: old (e.g. 14.04) GNU coreutils doesn't -D with -t
 	install -d -m 0755 ${DESTDIR}/${ENVD}
 	install -m 0644 -t ${DESTDIR}/${ENVD} $^
-.PHONY: install
+
+# fish uses a separate directory to store vendor configuration files
+install-fish: ${GENERATED_FISH}
+	install -d -m 0755 ${DESTDIR}/${DATADIR}/fish/vendor_conf.d
+	install -m 0644 -t ${DESTDIR}/${DATADIR}/fish/vendor_conf.d $^
+
+install: install-sh install-fish
+.PHONY: install install-sh install-fish
 
 clean:
 	$(RM) ${GENERATED}

--- a/data/env/snapd.fish.in
+++ b/data/env/snapd.fish.in
@@ -1,0 +1,13 @@
+# Expand $PATH to include the directory where snappy applications go.
+set -u snap_bin_path "@SNAP_MOUNT_DIR@/bin"
+if ! contains $snap_bin_path $PATH
+    set PATH $PATH $snap_bin_path
+end
+
+# Desktop files (used by desktop environments within both X11 and Wayland) are
+# looked for in XDG_DATA_DIRS; make sure it includes the relevant directory for
+# snappy applications' desktop files.
+set -u snap_xdg_path /var/lib/snapd/desktop
+if ! contains $snap_xdg_path $XDG_DATA_DIRS
+    set XDG_DATA_DIRS $XDG_DATA_DIRS $snap_xdg_path
+end

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -604,7 +604,7 @@ popd
 
 # Build systemd units, dbus services, and env files
 pushd ./data
-make BINDIR="%{_bindir}" LIBEXECDIR="%{_libexecdir}" \
+make BINDIR="%{_bindir}" LIBEXECDIR="%{_libexecdir}" DATADIR="%{_datadir}" \
      SYSTEMDSYSTEMUNITDIR="%{_unitdir}" \
      SNAP_MOUNT_DIR="%{_sharedstatedir}/snapd/snap" \
      SNAPD_ENVIRONMENT_FILE="%{_sysconfdir}/sysconfig/snapd"
@@ -689,7 +689,7 @@ popd
 
 # Install all systemd and dbus units, and env files
 pushd ./data
-%make_install BINDIR="%{_bindir}" LIBEXECDIR="%{_libexecdir}" \
+%make_install BINDIR="%{_bindir}" LIBEXECDIR="%{_libexecdir}" DATADIR="%{_datadir}" \
               SYSTEMDSYSTEMUNITDIR="%{_unitdir}" SYSTEMDUSERUNITDIR="%{_userunitdir}" \
               SNAP_MOUNT_DIR="%{_sharedstatedir}/snapd/snap" \
               SNAPD_ENVIRONMENT_FILE="%{_sysconfdir}/sysconfig/snapd"
@@ -831,6 +831,7 @@ popd
 %{_datadir}/dbus-1/system.d/snapd.system-services.conf
 %{_datadir}/polkit-1/actions/io.snapcraft.snapd.policy
 %{_datadir}/applications/io.snapcraft.SessionAgent.desktop
+%{_datadir}/fish/vendor_conf.d/snapd.fish
 %{_sysconfdir}/xdg/autostart/snap-userd-autostart.desktop
 %config(noreplace) %{_sysconfdir}/sysconfig/snapd
 %dir %{_sharedstatedir}/snapd
@@ -865,6 +866,8 @@ popd
 # this is typically owned by zsh, but we do not want to explicitly require zsh
 %dir %{_datadir}/zsh
 %dir %{_datadir}/zsh/site-functions
+# similar case for fish
+%dir %{_datadir}/fish/vendor_conf.d
 
 %files -n snap-confine
 %doc cmd/snap-confine/PORTING

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -272,6 +272,7 @@ done
 %make_install -C %{indigo_srcdir}/data \
 		BINDIR=%{_bindir} \
 		LIBEXECDIR=%{_libexecdir} \
+		DATADIR=%{_datadir} \
 		SYSTEMDSYSTEMUNITDIR=%{_unitdir} \
 		SNAP_MOUNT_DIR=%{snap_mount_dir}
 # Install all the C executables.
@@ -401,6 +402,8 @@ fi
 # this is typically owned by zsh, but we do not want to explicitly require zsh
 %dir %{_datadir}/zsh
 %dir %{_datadir}/zsh/site-functions
+# similar case for fish
+%dir %{_datadir}/fish/vendor_conf.d
 
 # Ghost entries for things created at runtime
 %ghost %dir %{_localstatedir}/snap
@@ -424,6 +427,7 @@ fi
 %{_datadir}/dbus-1/session.d/snapd.session-services.conf
 %{_datadir}/dbus-1/system.d/snapd.system-services.conf
 %{_datadir}/polkit-1/actions/io.snapcraft.snapd.policy
+%{_datadir}/fish/vendor_conf.d/snapd.fish
 %{_environmentdir}/990-snapd.conf
 %{_libexecdir}/snapd/complete.sh
 %{_libexecdir}/snapd/etelpmoc.sh


### PR DESCRIPTION
Profile profile setup for fish shell, which does not load /etc/profile.d.

Fixes: https://bugs.launchpad.net/snapd/+bug/1951145
