### PR TITLE
tests: use --snap instead of --extra-snaps to create the core image

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -904,7 +904,7 @@ EOF
         cp "$TESTSLIB/assertions/pc-${REMOTE_STORE}.model" "$IMAGE_HOME/pc.model"
 
         # FIXME: how to test store updated of ubuntu-core with sideloaded snap?
-        IMAGE=all-snap-amd64.img
+        IMAGE=pc.img
     fi
 
     EXTRA_FUNDAMENTAL=
@@ -917,7 +917,7 @@ EOF
         # need to download it
         snap download --channel="$KERNEL_CHANNEL" pc-kernel
 
-        EXTRA_FUNDAMENTAL="--extra-snaps $PWD/pc-kernel_*.snap"
+        EXTRA_FUNDAMENTAL="--snap $PWD/pc-kernel_*.snap"
         IMAGE_CHANNEL="$GADGET_CHANNEL"
     fi
 
@@ -927,7 +927,7 @@ EOF
         test -e pc-kernel.snap
         # build the initramfs with our snapd assets into the kernel snap
         uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$IMAGE_HOME"
-        EXTRA_FUNDAMENTAL="--extra-snaps $IMAGE_HOME/pc-kernel_*.snap"
+        EXTRA_FUNDAMENTAL="--snap $IMAGE_HOME/pc-kernel_*.snap"
     fi
 
     # 'snap pack' creates snaps 0644, and ubuntu-image just copies those in
@@ -973,12 +973,13 @@ EOF
         EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $IMAGE_HOME/core20.snap"
     fi
 
+    # shellcheck disable=SC2086
     /snap/bin/ubuntu-image snap \
                            -w "$IMAGE_HOME" "$IMAGE_HOME/pc.model" \
                            --channel "$IMAGE_CHANNEL" \
-                           "$EXTRA_FUNDAMENTAL" \
-                           --extra-snaps "${extra_snap[0]}" \
-                           --output "$IMAGE_HOME/$IMAGE"
+                           $EXTRA_FUNDAMENTAL \
+                           --snap "${extra_snap[0]}" \
+                           --outputdir "$IMAGE_HOME"
     rm -f ./pc-kernel_*.{snap,assert} ./pc-kernel.{snap,assert} ./pc_*.{snap,assert} ./snapd_*.{snap,assert} ./core20.{snap,assert}
 
     if os.query is-core20; then

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -849,6 +849,7 @@ setup_reflash_magic() {
     # needs to be under /home because ubuntu-device-flash
     # uses snap-confine and that will hide parts of the hostfs
     IMAGE_HOME=/home/image
+    IMAGE=pc.img
     mkdir -p "$IMAGE_HOME"
 
     # ensure that ubuntu-image is using our test-build of snapd with the
@@ -862,11 +863,9 @@ setup_reflash_magic() {
         repack_snapd_snap_with_deb_content "$IMAGE_HOME"
         # FIXME: fetch directly once its in the assertion service
         cp "$TESTSLIB/assertions/ubuntu-core-18-amd64.model" "$IMAGE_HOME/pc.model"
-        IMAGE=core18-amd64.img
     elif os.query is-core20; then
         repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
         cp "$TESTSLIB/assertions/ubuntu-core-20-amd64.model" "$IMAGE_HOME/pc.model"
-        IMAGE=core20-amd64.img
     else
         # FIXME: install would be better but we don't have dpkg on
         #        the image
@@ -902,9 +901,6 @@ EOF
 
         # FIXME: fetch directly once its in the assertion service
         cp "$TESTSLIB/assertions/pc-${REMOTE_STORE}.model" "$IMAGE_HOME/pc.model"
-
-        # FIXME: how to test store updated of ubuntu-core with sideloaded snap?
-        IMAGE=pc.img
     fi
 
     EXTRA_FUNDAMENTAL=

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -979,7 +979,7 @@ EOF
                            --channel "$IMAGE_CHANNEL" \
                            $EXTRA_FUNDAMENTAL \
                            --snap "${extra_snap[0]}" \
-                           --outputdir "$IMAGE_HOME"
+                           --output-dir "$IMAGE_HOME"
     rm -f ./pc-kernel_*.{snap,assert} ./pc-kernel.{snap,assert} ./pc_*.{snap,assert} ./snapd_*.{snap,assert} ./core20.{snap,assert}
 
     if os.query is-core20; then


### PR DESCRIPTION
This is to make ubuntu-image happy and be able to create the core images
Also updated the output parameter, now output-dir is used

Next step in a following pr is to fix the nested helper