### PR TITLE
tests: use ubuntu-image 1.11 from stable channel 

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -37,7 +37,7 @@ environment:
     MANAGED_DEVICE: "false"
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/edge"
-    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
+    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/stable"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'

--- a/spread.yaml
+++ b/spread.yaml
@@ -37,6 +37,9 @@ environment:
     MANAGED_DEVICE: "false"
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/edge"
+    # TODO: as of 2021-11-18 ubuntu-image in candidate and up has a bug which is
+    # fixed in https://github.com/canonical/ubuntu-image/pull/26, revert to
+    # latest/candidate when the fix lands in master and the snap is released
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/stable"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'


### PR DESCRIPTION
This is because images create with ubuntu-image 2.0 are displaying "No
space left on device" error
