### PR TITLE
tests: disable flaky uc18 tests until systemd is fixed

### DIFF
--- a/tests/core/snapd-refresh-vs-services-reboots/task.yaml
+++ b/tests/core/snapd-refresh-vs-services-reboots/task.yaml
@@ -2,7 +2,8 @@ summary: Check that refreshing snapd in the worst case reboots if things go side
 
 # TODO: move this test to tests/regression/lp-1924805 ?
 
-systems: [ubuntu-core-18-*, ubuntu-core-20-*]
+# temporarily disabled uc18 because of systemd bug LP:1949511
+systems: [ubuntu-core-20-*]
 
 environment:
   # the test needs to start from 2.49.2 to reproduce the bug and demonstrate the

--- a/tests/main/services-disabled-kept-happy/task.yaml
+++ b/tests/main/services-disabled-kept-happy/task.yaml
@@ -2,6 +2,9 @@ summary: Check that disabled snap services stay disabled across happy refreshes,
   reverts, and disable/enable cycles (there is a separate tests for unhappy
   undos, etc.)
 
+# temporarily disabled on uc18 because of systemd bug LP:1949506
+systems: [-ubuntu-core-18-*]
+
 # This test is for the "happy" paths for disabled services, where nothing goes
 # wrong and is undone, but there are still a lot of cases here for that. This
 # test covers the following cases:

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that snap disconnect works
 
-systems: [-ubuntu-core-16-64]
+# temporarily disabled on uc18 because of systemd bug LP:1949514
+systems: [-ubuntu-core-16-64, -ubuntu-core-18-64]
 
 environment:
     SNAP_FILE: "home-consumer_1.0_all.snap"


### PR DESCRIPTION
Because of a bug/regression in systemd (LP:1949089) we see a bunch
of test failures on UC18. While the bug gets fixed we need to
disable the tests to avoid having unmergable PRs for reasons
outside of our control.

Once this is merged I will push a PR that reverts this commit so
that we can track the progress of the systemd fix.
