### PR TITLE
tests: Revert "tests: disable flaky uc18 tests until systemd is fixed"

### DIFF
--- a/tests/core/snapd-refresh-vs-services-reboots/task.yaml
+++ b/tests/core/snapd-refresh-vs-services-reboots/task.yaml
@@ -2,8 +2,7 @@ summary: Check that refreshing snapd in the worst case reboots if things go side
 
 # TODO: move this test to tests/regression/lp-1924805 ?
 
-# temporarily disabled uc18 because of systemd bug LP:1949511
-systems: [ubuntu-core-20-*]
+systems: [ubuntu-core-18-*, ubuntu-core-20-*]
 
 environment:
   # the test needs to start from 2.49.2 to reproduce the bug and demonstrate the

--- a/tests/main/services-disabled-kept-happy/task.yaml
+++ b/tests/main/services-disabled-kept-happy/task.yaml
@@ -2,9 +2,6 @@ summary: Check that disabled snap services stay disabled across happy refreshes,
   reverts, and disable/enable cycles (there is a separate tests for unhappy
   undos, etc.)
 
-# temporarily disabled on uc18 because of systemd bug LP:1949506
-systems: [-ubuntu-core-18-*]
-
 # This test is for the "happy" paths for disabled services, where nothing goes
 # wrong and is undone, but there are still a lot of cases here for that. This
 # test covers the following cases:

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -1,7 +1,6 @@
 summary: Check that snap disconnect works
 
-# temporarily disabled on uc18 because of systemd bug LP:1949514
-systems: [-ubuntu-core-16-64, -ubuntu-core-18-64]
+systems: [-ubuntu-core-16-64]
 
 environment:
     SNAP_FILE: "home-consumer_1.0_all.snap"


### PR DESCRIPTION
This reverts commit 4aa662960544c1a5ddd33ab05ba4a087919c6a38.

Once https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1949089 is fixed we can re-enable this.