### PR TITLE
osutil/strace: try to enable strace on more arches

### DIFF
--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/strace"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/progress/progresstest"
 	"github.com/snapcore/snapd/sandbox/cgroup"
@@ -993,7 +994,7 @@ echo "stdout output 2"
 			filepath.Join(straceCmd.BinDir(), "strace"),
 			"-u", user.Username,
 			"-f",
-			"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid,gettimeofday,nanosleep",
+			"-e", strace.ExcludedSyscalls,
 			filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 			"snap.snapname.app",
 			filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
@@ -1016,7 +1017,7 @@ echo "stdout output 2"
 			filepath.Join(straceCmd.BinDir(), "strace"),
 			"-u", user.Username,
 			"-f",
-			"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid,gettimeofday,nanosleep",
+			"-e", strace.ExcludedSyscalls,
 			filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 			"snap.snapname.app",
 			filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
@@ -1063,7 +1064,7 @@ func (s *RunSuite) TestSnapRunAppWithStraceOptions(c *check.C) {
 			filepath.Join(straceCmd.BinDir(), "strace"),
 			"-u", user.Username,
 			"-f",
-			"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid,gettimeofday,nanosleep",
+			"-e", strace.ExcludedSyscalls,
 			"-tt",
 			"-o",
 			"file with spaces",

--- a/osutil/strace/export_test.go
+++ b/osutil/strace/export_test.go
@@ -19,10 +19,6 @@
 
 package strace
 
-var (
-	ExcludedSyscalls = excludedSyscalls
-)
-
 func (stt *ExecveTiming) ExeRuntimes() []ExeRuntime {
 	return stt.exeRuntimes
 }


### PR DESCRIPTION
Some syscalls do not exist on some arches, and for some of these
non-existent syscalls strace doesn't have a mapping either. Meaning
the default syscall filter needs per-arch adjustments. This should
enable strace in snap run on arm and riscv64.