### PR TITLE
interfaces/builtin/dsp: update proc files for ambarella flavor

### DIFF
--- a/interfaces/builtin/dsp.go
+++ b/interfaces/builtin/dsp.go
@@ -70,6 +70,8 @@ const ambarellaDspConnectedPlugApparmor = `
 /proc/ambarella/cma r,
 /proc/ambarella/ambarella_hwtimer rw,
 /proc/ambarella/ambarella_hwtimer_outfreq rw,
+/proc/ambarella/vapi_sync r,
+/proc/ambarella/dsp_state r,
 
 # to match vin0_idsp, vin1_idsp, vin2_idsp, etc.
 /proc/ambarella/vin[0-9]_idsp r,

--- a/interfaces/builtin/dsp.go
+++ b/interfaces/builtin/dsp.go
@@ -61,18 +61,18 @@ const ambarellaDspConnectedPlugApparmor = `
 /dev/lens rw,
 
 # various ambarella specific DSP control parameters
-/proc/ambarella/iav rw,
-/proc/ambarella/ambnl rw,
-/proc/ambarella/udc rw,
-/proc/ambarella/clock rw,
+/proc/ambarella/iav r,
+/proc/ambarella/ambnl/** rw,
+/proc/ambarella/udc r,
+/proc/ambarella/clock r,
 /proc/ambarella/dsp_print rw,
-/proc/ambarella/hdmi_edid rw,
-/proc/ambarella/cma rw,
+/proc/ambarella/hdmi_edid r,
+/proc/ambarella/cma r,
 /proc/ambarella/ambarella_hwtimer rw,
 /proc/ambarella/ambarella_hwtimer_outfreq rw,
 
 # to match vin0_idsp, vin1_idsp, vin2_idsp, etc.
-/proc/ambarella/vin[0-9]_idsp rw,
+/proc/ambarella/vin[0-9]_idsp r,
 
 # to match e0021000.dma and e0020000.dma
 /proc/ambarella/[0-9a-e][0-9a-e][0-9a-e][0-9a-e][0-9a-e][0-9a-e][0-9a-e][0-9a-e].dma rw,

--- a/interfaces/builtin/dsp_test.go
+++ b/interfaces/builtin/dsp_test.go
@@ -98,7 +98,7 @@ func (s *dspSuite) TestApparmorConnectedPlugAmbarella(c *C) {
 	spec := &apparmor.Specification{}
 	err := spec.AddConnectedPlug(s.iface, s.plug, s.ambarellaSlot)
 	c.Assert(err, IsNil)
-	c.Assert(spec.SnippetForTag("snap.my-device.svc"), testutil.Contains, "/proc/ambarella/vin[0-9]_idsp rw,\n")
+	c.Assert(spec.SnippetForTag("snap.my-device.svc"), testutil.Contains, "/proc/ambarella/vin[0-9]_idsp r,\n")
 }
 
 func (s *dspSuite) TestUDevConnectedPlugAmbarella(c *C) {


### PR DESCRIPTION
There are two commits that just update ambarella flavor to add proc files to support their new features, and meanwhile rectify some permissions of proc files.