### PR TITLE
systemd: add support for .target units

### DIFF
--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -72,12 +72,14 @@ func (s *statusDecoratorSuite) TestDecorateWithStatus(c *C) {
 				activeState = "inactive"
 				unitState = "disabled"
 			}
-			if strings.HasSuffix(unit, ".timer") || strings.HasSuffix(unit, ".socket") {
+			if strings.HasSuffix(unit, ".timer") || strings.HasSuffix(unit, ".socket") || strings.HasSuffix(unit, ".target") {
+				// Units using the baseProperties query
 				return []byte(fmt.Sprintf(`Id=%s
 ActiveState=%s
 UnitFileState=%s
 `, args[2], activeState, unitState)), nil
 			} else {
+				// Units using the extendedProperties query
 				return []byte(fmt.Sprintf(`Id=%s
 Type=simple
 ActiveState=%s

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -576,6 +576,7 @@ var extendedProperties = []string{"Id", "ActiveState", "UnitFileState", "Type"}
 var unitProperties = map[string][]string{
 	".timer":  baseProperties,
 	".socket": baseProperties,
+	".target": baseProperties,
 	// in service units, Type is the daemon type
 	".service": extendedProperties,
 	// in mount units, Type is the fs type
@@ -791,9 +792,13 @@ func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
 	var extendedUnits []string
 
 	for _, name := range unitNames {
-		if strings.HasSuffix(name, ".timer") || strings.HasSuffix(name, ".socket") {
+		// Group units with the same query string together to
+		// optimize the number of 'systemctl' invocations.
+		if strings.HasSuffix(name, ".timer") || strings.HasSuffix(name, ".socket") || strings.HasSuffix(name, ".target") {
+			// Units using the baseProperties query
 			limitedUnits = append(limitedUnits, name)
 		} else {
+			// Units using the extendedProperties query
 			extendedUnits = append(extendedUnits, name)
 		}
 	}


### PR DESCRIPTION
systemd/systemd.go: provides systemctl Status() support for socket,
mount, service and timer units.

Target units in systemd provides a logical grouping of dependencies
associated with a high level capability (such as hibernate, sleep, reboot
and ctrl-alt-del). In order to manage these capabilities on a platform, 
we need the ability to perform unit operations on systemd targets using 
the existing systemctl interface in snapd.

The end goal is to allow snapd to control the platform behaviour by
exposing configuration items for some of these capabilities, such as
allowing ctrl-alt-del behaviour to be changed.

snap set system system.ctrl-alt-del="none"

Most systemctl functionality is generic in snapd and will already work
with systemd target units. The Status() function parsing the systemctl
reply requires minor changes to accommodate specific unit types
because of unit specific queries (different sets of unit parameters are
requested).

- Add systemd.Status() support for .target units.

- Add unit test for .target unit

See: https://bugs.launchpad.net/snapd/+bug/1929539

Signed-off-by: Fred Lotter <fred.lotter@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
