### PR TITLE
tests/main/snapd-reexec-snapd-snap: improve debugging

### DIFF
--- a/tests/main/snapd-reexec-snapd-snap/task.yaml
+++ b/tests/main/snapd-reexec-snapd-snap/task.yaml
@@ -8,13 +8,13 @@ restore: |
 
 debug: |
     echo 'experimental "snapd-snap" feature is enabled:'
-    snap get core experimental.snapd-snap
+    snap get core experimental.snapd-snap || true
 
     echo "snap changes"
-    snap changes
+    snap changes || true
 
     echo "list of installed snaps"
-    snap list
+    snap list || true
 
 execute: |
     if [ "${SNAP_REEXEC:-}" = "0" ]; then

--- a/tests/main/snapd-reexec-snapd-snap/task.yaml
+++ b/tests/main/snapd-reexec-snapd-snap/task.yaml
@@ -6,11 +6,24 @@ systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
 restore: |
     umount /snap/snapd/current/usr/lib/snapd/info || true
 
+debug: |
+    echo 'experimental "snapd-snap" feature is enabled:'
+    snap get core experimental.snapd-snap
+
+    echo "snap changes"
+    snap changes
+
+    echo "list of installed snaps"
+    snap list
+
 execute: |
     if [ "${SNAP_REEXEC:-}" = "0" ]; then
         echo "skipping test when SNAP_REEXEC is disabled"
         exit 0
     fi
+
+    # Make sure that the snapd snap is not installed
+    snap info snapd | NOMATCH "^installed:"
 
     echo "Enable installing the snapd snap, this happens automatically"
     snap set core experimental.snapd-snap=true


### PR DESCRIPTION
The test has had a recent failure
(https://github.com/snapcore/snapd/runs/4287754619), which does not seem
easy to reproduce. Add a few debugging info, in case it happens again.

Please let me know if you have ideas of more debugging info to print.