### PR TITLE
interfaces: allow receiving PropertiesChanged on the mpris plug

### DIFF
--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -158,6 +158,14 @@ dbus (send)
     bus=session
     path=/org/mpris/MediaPlayer2
     peer=(label=###SLOT_SECURITY_TAGS###),
+
+# receive signals for updated properties
+dbus (receive)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/mpris/MediaPlayer2
+    member=PropertiesChanged
+    peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
 type mprisInterface struct{}


### PR DESCRIPTION
Allow apps connected to mpris slot (e.g. of spotify snap) to monitor PropertiesChanged signal of /org/mpris/MediaPlayer2.

This should address the request from the forum: https://forum.snapcraft.io/t/mpris-interface-snap-unable-to-receive-propertieschanged-events/26869

I've verified this signal with a custom-built snap that includes dbus-monitor & spotify snap.