### PR TITLE
o/devicestate: during remodel first check pending download tasks for snaps

### DIFF
--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -145,8 +145,44 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 
 	// get all infos
 	infoGetter := func(name string) (info *snap.Info, present bool, err error) {
-		// snap may be present in the system in which case info comes
-		// from snapstate
+		// snaps are either being fetched or present in the system
+
+		if isRemodel {
+			// in a remodel scenario, the snaps may need to be
+			// fetched and thus their content can be different from
+			// what we have in already installed snaps, so we should
+			// first check the download tasks before consulting
+			// snapstate
+			logger.Debugf("requested info for snap %q being installed during remodel", name)
+			for _, tskID := range setup.SnapSetupTasks {
+				taskWithSnapSetup := st.Task(tskID)
+				snapsup, err := snapstate.TaskSnapSetup(taskWithSnapSetup)
+				if err != nil {
+					return nil, false, err
+				}
+				if snapsup.SnapName() != name {
+					continue
+				}
+				// by the time this task runs, the file has already been
+				// downloaded and validated
+				snapFile, err := snapfile.Open(snapsup.MountFile())
+				if err != nil {
+					return nil, false, err
+				}
+				info, err = snap.ReadInfoFromSnapFile(snapFile, snapsup.SideInfo)
+				if err != nil {
+					return nil, false, err
+				}
+
+				return info, true, nil
+			}
+		}
+
+		// either a remodel scenario, in which case the snap is not
+		// among the ones being fetched, or just creating a recovery
+		// system, in which case we use the snaps that are already
+		// installed
+
 		info, err = snapstate.CurrentInfo(st, name)
 		if err == nil {
 			hash, _, err := asserts.SnapFileSHA3_384(info.MountFile())
@@ -158,40 +194,6 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 		}
 		if _, ok := err.(*snap.NotInstalledError); !ok {
 			return nil, false, err
-		}
-		logger.Debugf("requested info for not yet installed snap %q", name)
-
-		if !isRemodel {
-			// when not in remodel, a recovery system can only be
-			// created from snaps that are already installed
-			return nil, false, nil
-		}
-
-		// in a remodel scenario, the snaps may need to be fetched, and
-		// thus we can pull the relevant information from the tasks
-		// carrying snap-setup
-
-		for _, tskID := range setup.SnapSetupTasks {
-			taskWithSnapSetup := st.Task(tskID)
-			snapsup, err := snapstate.TaskSnapSetup(taskWithSnapSetup)
-			if err != nil {
-				return nil, false, err
-			}
-			if snapsup.SnapName() != name {
-				continue
-			}
-			// by the time this task runs, the file has already been
-			// downloaded and validated
-			snapFile, err := snapfile.Open(snapsup.MountFile())
-			if err != nil {
-				return nil, false, err
-			}
-			info, err = snap.ReadInfoFromSnapFile(snapFile, snapsup.SideInfo)
-			if err != nil {
-				return nil, false, err
-			}
-
-			return info, true, nil
 		}
 		return nil, false, nil
 	}


### PR DESCRIPTION
When remodeling, it is possible that the new model will use a snap of the same
name, but from a different track/channel which may in fact carry different
content. Thus when creating a recovery system, make sure to use the 'new' snap
if it is part of the download tasks, rather than first checking the local ones.