### PR TITLE
o/snapstate: refactor disk space checks

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2071,14 +2071,16 @@ func checkDiskSpace(st *state.State, changeKind string, infos []minimalInstallIn
 	case "refresh":
 		featFlag = features.CheckDiskSpaceRefresh
 	default:
-		panic(fmt.Sprintf("unsupported disk space check for change of kind %q", changeKind))
+		return fmt.Errorf("cannot check disk space for invalid change kind %q", changeKind)
 	}
 
 	tr := config.NewTransaction(st)
 	enabled, err := features.Flag(tr, featFlag)
 	if err != nil && !config.IsNoOption(err) {
 		return err
-	} else if !enabled {
+	}
+
+	if !enabled {
 		return nil
 	}
 


### PR DESCRIPTION
The disk space checks were repeated throughout the various install
and refresh functions (and more are being added soon), so this
change refactors them to a single function.
