### PR TITLE
tests: run snap-disconnect on uc16

### DIFF
--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -1,7 +1,5 @@
 summary: Check that snap disconnect works
 
-systems: [-ubuntu-core-16-64]
-
 environment:
     SNAP_FILE: "home-consumer_1.0_all.snap"
 


### PR DESCRIPTION
The test pass in google backend, it was created 5 years ago and the
system ubuntu-core-16-64 was skipped.
