### PR TITLE
tests: disable flacky test snapd-failover

### DIFF
--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -1,5 +1,8 @@
 summary: Check that snapd failure handling works
 
+# TODO: reenable execution on UC16 once the flakiness is fixed
+systems: [-ubuntu-core-16-*]
+
 prepare: |
     # on UC16, we should transition to using the snapd snap before running the 
     # test because it by default uses the core snap


### PR DESCRIPTION
Temporarily disable the test until the reason for the flackiness is
found and resolved.

Link to a failed build:
https://github.com/snapcore/snapd/runs/4289056946?check_suite_focus=true