### PR TITLE
packaging/ubuntu, packaging/debian: depend on dbus-session-bus provider

### DIFF
--- a/packaging/debian-sid/control
+++ b/packaging/debian-sid/control
@@ -95,7 +95,8 @@ Depends: adduser,
          systemd,
          udev,
          ${misc:Depends},
-         ${shlibs:Depends}
+         ${shlibs:Depends},
+         default-dbus-session-bus | dbus-session-bus
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
 Recommends: gnupg

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -70,7 +70,8 @@ Depends: adduser,
          systemd,
          udev,
          ${misc:Depends},
-         ${shlibs:Depends}
+         ${shlibs:Depends},
+         default-dbus-session-bus | dbus-session-bus
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
 Recommends: gnupg

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -71,7 +71,7 @@ Depends: adduser,
          udev,
          ${misc:Depends},
          ${shlibs:Depends},
-         default-dbus-session-bus | dbus-session-bus
+         ${dbussession:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
 Recommends: gnupg

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -24,15 +24,25 @@ export GOCACHE:=/tmp/go-build
 
 include /etc/os-release
 
+SUBSTVARS =
 # On 18.04 the released version of apt (1.6.1) has a bug that causes
 # problem on "apt purge snapd". To ensure this won't happen add the
 # right dependency on 18.04.
 ifeq (${VERSION_ID},"18.04")
-	SUBSTVARS = -Vsnapd:Breaks="systemd (<< 237-3ubuntu10.24), apt (<< 1.6.3)"
+	SUBSTVARS += -Vsnapd:Breaks="systemd (<< 237-3ubuntu10.24), apt (<< 1.6.3)"
 endif
 # Same as above for 18.10 just a different version.
 ifeq (${VERSION_ID},"18.10")
-	SUBSTVARS = -Vsnapd:Breaks="apt (<< 1.7.0~alpha2)"
+	SUBSTVARS += -Vsnapd:Breaks="apt (<< 1.7.0~alpha2)"
+endif
+# Since 21.10 is using cgroups v2, having a session bus is a hard requirement,
+# for earlier versions it's nice to have and allows snaps to be tracked
+# correctly. However, the (default-)dbus-session-bus virtual packages were only
+# introduced in 2018, so earlier supported releases (16.04) have to explicitly
+# specify the requirement.
+ifneq (${VERSION_ID},"16.04")
+	# version with appropriate virtual packages
+	SUBSTVARS += -Vdbussession:Depends="default-dbus-session-bus | dbus-session-bus"
 endif
 
 # this is overridden in the ubuntu/14.04 release branch

--- a/spread.yaml
+++ b/spread.yaml
@@ -103,7 +103,7 @@ backends:
                   image: ubuntu-16.04-64
                   workers: 6
             - ubuntu-core-18-64:
-                  image: ubuntu-16.04-64
+                  image: ubuntu-18.04-64
                   workers: 6
             - ubuntu-core-20-64:
                   image: ubuntu-20.04-64
@@ -225,7 +225,7 @@ backends:
                   username: ubuntu
                   password: ubuntu
             - ubuntu-core-18-64:
-                  image: ubuntu-16.04-64
+                  image: ubuntu-18.04-64
                   username: ubuntu
                   password: ubuntu
             - ubuntu-core-20-64:

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -549,7 +549,7 @@ pkg_dependencies_ubuntu_classic(){
 
     case "$SPREAD_SYSTEM" in
         ubuntu-14.04-*)
-                pkg_linux_image_extra
+            pkg_linux_image_extra
             ;;
         ubuntu-16.04-64)
             echo "

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -569,7 +569,6 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-18.04-32)
             echo "
-                dbus-user-session
                 gccgo-6
                 evolution-data-server
                 fwupd
@@ -580,7 +579,6 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-18.04-64)
             echo "
-                dbus-user-session
                 gccgo-8
                 gperf
                 evolution-data-server
@@ -604,7 +602,6 @@ pkg_dependencies_ubuntu_classic(){
         ubuntu-21.04-64|ubuntu-21.10-64*)
             # bpftool is part of linux-tools package
             echo "
-                dbus-user-session
                 fwupd
                 golang
                 linux-tools-$(uname -r)
@@ -620,7 +617,6 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 autopkgtest
                 debootstrap
-                dbus-user-session
                 eatmydata
                 evolution-data-server
                 fwupd

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -40,10 +40,13 @@ execute: |
     if [ -n "${https_proxy:-}" ]; then
         lxd.lxc exec ubuntu -- sh -c "echo https_proxy=$https_proxy >> /etc/environment"
     fi
+    # wait for the container to be fully up
+    retry -n 30 sh -c 'lxd.lxc exec ubuntu -- systemctl is-system-running | MATCH "(running|degraded)"'
 
     lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "ubuntu/root/"
 
     DEB=$(basename "$GOHOME"/snapd_*.deb)
+    lxd.lxc exec ubuntu -- apt update
     lxd.lxc exec ubuntu -- apt install -y /root/"$DEB"
     lxd.lxc restart ubuntu
 

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -42,10 +42,13 @@ execute: |
         snap info lxd
         exit 1
     fi
+    # wait for the container to be fully up
+    retry -n 30 sh -c 'lxd.lxc exec my-ubuntu -- systemctl is-system-running | MATCH "(running|degraded)"'
 
     echo "Install snapd"
     lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"
     lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "my-ubuntu/$GOHOME/"
+    lxd.lxc exec my-ubuntu -- apt update
     lxd.lxc exec my-ubuntu -- apt install -y "$GOHOME"/snapd_*.deb
 
     echo "And validate that we can use snaps"

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -29,7 +29,7 @@ prepare: |
   fi
 
   # wait for the container to be fully up
-  gretry -n 30 sh -c 'lxd.lxc exec ubuntu -- systemctl is-system-running | MATCH "(running|degraded)"'
+  retry -n 30 sh -c 'lxd.lxc exec ubuntu -- systemctl is-system-running | MATCH "(running|degraded)"'
 
   lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "ubuntu/root/"
   DEB=$(basename "$GOHOME"/snapd_*.deb)

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -28,8 +28,12 @@ prepare: |
       lxd.lxc exec ubuntu -- sh -c "echo https_proxy=$https_proxy >> /etc/environment"
   fi
 
+  # wait for the container to be fully up
+  gretry -n 30 sh -c 'lxd.lxc exec ubuntu -- systemctl is-system-running | MATCH "(running|degraded)"'
+
   lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "ubuntu/root/"
   DEB=$(basename "$GOHOME"/snapd_*.deb)
+  lxd.lxc exec ubuntu -- apt update
   lxd.lxc exec ubuntu -- apt install -y /root/"$DEB"
   lxd.lxc file push -r --quiet "$TESTSLIB"/snaps/test-snapd-tools "ubuntu/root/"
 


### PR DESCRIPTION
On a cgroup v2 system, we rely on being able to set up a systemd scope for the
snap applications. This is done by communicating with a proper systemd instance
over a dbus bus, which for user session is the session bus.

This only came up when one of the intermediate dependencies of ubuntu-server,
had their dependencies updated and no longer requires session bus and we
observed that it was impossible to launch snap applications that required device
access on Ubuntu 21.10.

Related to:
- https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1951491
- https://forum.snapcraft.io/t/cannot-launch-snap-applications-with-cgroup-v2/27700

cc @slyon 
