### PR TITLE
asserts: change behavior of alternative attribute matcher

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -150,7 +150,8 @@ func init() {
 	// 2: support for $SLOT()/$PLUG()/$MISSING
 	// 3: support for on-store/on-brand/on-model device scope constraints
 	// 4: support for plug-names/slot-names constraints
-	maxSupportedFormat[SnapDeclarationType.Name] = 4
+	// 5: alt attr matcher usage (was unused before, has new behavior now)
+	maxSupportedFormat[SnapDeclarationType.Name] = 5
 
 	// 1: support to limit to device serials
 	maxSupportedFormat[SystemUserType.Name] = 1

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -197,9 +197,6 @@ func snapDeclarationFormatAnalyze(headers map[string]interface{}, body []byte) (
 		if rule.feature(nameConstraintsFeature) {
 			setFormatNum(4)
 		}
-		if rule.feature(nameConstraintsFeature) {
-			setFormatNum(4)
-		}
 		if rule.feature(altAttrMatcherFeature) {
 			setFormatNum(5)
 		}

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -175,6 +175,9 @@ func snapDeclarationFormatAnalyze(headers map[string]interface{}, body []byte) (
 		if rule.feature(nameConstraintsFeature) {
 			setFormatNum(4)
 		}
+		if rule.feature(altAttrMatcherFeature) {
+			setFormatNum(5)
+		}
 	})
 	if err != nil {
 		return 0, err
@@ -193,6 +196,12 @@ func snapDeclarationFormatAnalyze(headers map[string]interface{}, body []byte) (
 		}
 		if rule.feature(nameConstraintsFeature) {
 			setFormatNum(4)
+		}
+		if rule.feature(nameConstraintsFeature) {
+			setFormatNum(4)
+		}
+		if rule.feature(altAttrMatcherFeature) {
+			setFormatNum(5)
 		}
 	})
 	if err != nil {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -546,6 +546,24 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 			c.Check(fmtnum, Equals, 4)
 		}
 	}
+
+	// alt matcher (so far unused) => format 5
+	for _, sidePrefix := range []string{"plug", "slot"} {
+		headers = map[string]interface{}{
+			sidePrefix + "s": map[string]interface{}{
+				"interface5": map[string]interface{}{
+					"allow-auto-connection": map[string]interface{}{
+						sidePrefix + "-attributes": map[string]interface{}{
+							"x": []interface{}{"alt1", "alt2"}, // alt matcher
+						},
+					},
+				},
+			},
+		}
+		fmtnum, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
+		c.Assert(err, IsNil)
+		c.Check(fmtnum, Equals, 5)
+	}
 }
 
 func prereqDevAccount(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {


### PR DESCRIPTION
change the behavior of an alt attribute matcher when matching against
a list of values to match the alternatives to each element and not
overall

this is the approach used by all other matchers against a list of
values

the old behavior was unused and as the new tests show the new behavior
is quite productive. if really needed expressing for different
variants of a list can still be done by expressing variants for one
full level up

to avoid uses of this confusing old snapd, make sure format: 5 is used
to mark snap-declarations that use alt attribute matchers going
forward