### PR TITLE
spread, github: drop Fedora 33, add Fedora 35

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -255,8 +255,8 @@ jobs:
         - debian-10-64
         - debian-11-64
         - debian-sid-64
-        - fedora-33-64
         - fedora-34-64
+        - fedora-35-64
         - opensuse-15.2-64
         - opensuse-15.3-64
         - opensuse-tumbleweed-64

--- a/spread.yaml
+++ b/spread.yaml
@@ -126,9 +126,9 @@ backends:
             - debian-sid-64:
                   workers: 6
 
-            - fedora-33-64:
-                  workers: 6
             - fedora-34-64:
+                  workers: 6
+            - fedora-35-64:
                   workers: 6
 
             - arch-linux-64:


### PR DESCRIPTION
Fedora 33 is EOL on 30.11.2021, while Fedora 35 was already released so it's time to add it.