### PR TITLE
o/snapstate: add hide/expose snap data to backend

### DIFF
--- a/overlord/snapshotstate/backend/export_test.go
+++ b/overlord/snapshotstate/backend/export_test.go
@@ -48,14 +48,6 @@ func MockIsTesting(newIsTesting bool) func() {
 	}
 }
 
-func MockUserLookupId(newLookupId func(string) (*user.User, error)) func() {
-	oldLookupId := userLookupId
-	userLookupId = newLookupId
-	return func() {
-		userLookupId = oldLookupId
-	}
-}
-
 func MockOsOpen(newOsOpen func(string) (*os.File, error)) func() {
 	oldOsOpen := osOpen
 	osOpen = newOsOpen

--- a/overlord/snapshotstate/backend/helpers.go
+++ b/overlord/snapshotstate/backend/helpers.go
@@ -97,7 +97,7 @@ var (
 
 func usersForUsernamesImpl(usernames []string, opts *dirs.SnapDirOptions) ([]*user.User, error) {
 	if len(usernames) == 0 {
-		return allUsers(opts)
+		return AllUsers(opts)
 	}
 	users := make([]*user.User, 0, len(usernames))
 	for _, username := range usernames {
@@ -133,7 +133,7 @@ func usersForUsernamesImpl(usernames []string, opts *dirs.SnapDirOptions) ([]*us
 	return users, nil
 }
 
-func allUsers(opts *dirs.SnapDirOptions) ([]*user.User, error) {
+func AllUsers(opts *dirs.SnapDirOptions) ([]*user.User, error) {
 	ds, err := filepath.Glob(snap.DataHomeGlob(opts))
 	if err != nil {
 		// can't happen?

--- a/overlord/snapshotstate/backend/helpers.go
+++ b/overlord/snapshotstate/backend/helpers.go
@@ -27,9 +27,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
@@ -97,7 +95,7 @@ var (
 
 func usersForUsernamesImpl(usernames []string, opts *dirs.SnapDirOptions) ([]*user.User, error) {
 	if len(usernames) == 0 {
-		return AllUsers(opts)
+		return snap.AllUsers(opts)
 	}
 	users := make([]*user.User, 0, len(usernames))
 	for _, username := range usernames {
@@ -130,59 +128,6 @@ func usersForUsernamesImpl(usernames []string, opts *dirs.SnapDirOptions) ([]*us
 		users = append(users, usr)
 
 	}
-	return users, nil
-}
-
-func AllUsers(opts *dirs.SnapDirOptions) ([]*user.User, error) {
-	ds, err := filepath.Glob(snap.DataHomeGlob(opts))
-	if err != nil {
-		// can't happen?
-		return nil, err
-	}
-
-	users := make([]*user.User, 1, len(ds)+1)
-	root, err := user.LookupId("0")
-	if err != nil {
-		return nil, err
-	}
-	users[0] = root
-	seen := make(map[uint32]bool, len(ds)+1)
-	seen[0] = true
-	var st syscall.Stat_t
-	for _, d := range ds {
-		err := syscall.Stat(d, &st)
-		if err != nil {
-			continue
-		}
-		if seen[st.Uid] {
-			continue
-		}
-		seen[st.Uid] = true
-		usr, err := userLookupId(strconv.FormatUint(uint64(st.Uid), 10))
-		if err != nil {
-			// Treat all non-nil errors as user.Unknown{User,Group}Error's, as
-			// currently Go's handling of returned errno from get{pw,gr}nam_r
-			// in the cgo implementation of user.Lookup is lacking, and thus
-			// user.Unknown{User,Group}Error is returned only when errno is 0
-			// and the list of users/groups is empty, but as per the man page
-			// for get{pw,gr}nam_r, there are many other errno's that typical
-			// systems could return to indicate that the user/group wasn't
-			// found, however unfortunately the POSIX standard does not actually
-			// dictate what errno should be used to indicate "user/group not
-			// found", and so even if Go is more robust, it may not ever be
-			// fully robust. See from the man page:
-			//
-			// > It [POSIX.1-2001] does not call "not found" an error, hence
-			// > does not specify what value errno might have in this situation.
-			// > But that makes it impossible to recognize errors.
-			//
-			// See upstream Go issue: https://github.com/golang/go/issues/40334
-			continue
-		} else {
-			users = append(users, usr)
-		}
-	}
-
 	return users, nil
 }
 

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -83,7 +83,7 @@ type managerBackend interface {
 	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, meter progress.Meter) error
 	UndoCopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter, opts *dirs.SnapDirOptions) error
 	// cleanup
-	ClearTrashedData(oldSnap *snap.Info, opts *dirs.SnapDirOptions)
+	ClearTrashedData(oldSnap *snap.Info)
 
 	// remove related
 	UnlinkSnap(info *snap.Info, linkCtx backend.LinkContext, meter progress.Meter) error
@@ -108,4 +108,8 @@ type managerBackend interface {
 	RunInhibitSnapForUnlink(info *snap.Info, hint runinhibit.Hint, decision func() error) (*osutil.FileLock, error)
 	// (not a backend method because doInstall cannot access the backend)
 	// WithSnapLock(info *snap.Info, action func() error) error
+
+	// ~/.snap/data migration related
+	HideSnapData(snapName string) error
+	UndoHideSnapData(snapName string) error
 }

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -28,12 +28,11 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	snapshotbackend "github.com/snapcore/snapd/overlord/snapshotstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 )
 
-var allUsers = snapshotbackend.AllUsers
+var allUsers = snap.AllUsers
 
 // CopySnapData makes a copy of oldSnap data for newSnap in its data directories.
 func (b Backend) CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter, opts *dirs.SnapDirOptions) error {

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -20,18 +20,25 @@
 package backend
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	snapshotbackend "github.com/snapcore/snapd/overlord/snapshotstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 )
 
+var allUsers = snapshotbackend.AllUsers
+
 // CopySnapData makes a copy of oldSnap data for newSnap in its data directories.
 func (b Backend) CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter, opts *dirs.SnapDirOptions) error {
 	// deal with the old data or
-	// otherwise just create a empty data dir
+	// otherwise just create an empty data dir
 
 	// Make sure the base data directory exists for instance snaps
 	if newSnap.InstanceKey != "" {
@@ -86,16 +93,137 @@ func (b Backend) UndoCopySnapData(newInfo, oldInfo *snap.Info, _ progress.Meter,
 }
 
 // ClearTrashedData removes the trash. It returns no errors on the assumption that it is called very late in the game.
-func (b Backend) ClearTrashedData(oldSnap *snap.Info, opts *dirs.SnapDirOptions) {
-	dirs, err := snapDataDirs(oldSnap, opts)
+func (b Backend) ClearTrashedData(oldSnap *snap.Info) {
+	dataDirs, err := snapDataDirs(oldSnap, nil)
 	if err != nil {
 		logger.Noticef("Cannot remove previous data for %q: %v", oldSnap.InstanceName(), err)
 		return
 	}
 
-	for _, d := range dirs {
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+	hiddenDirs, err := snapDataDirs(oldSnap, opts)
+	if err != nil {
+		logger.Noticef("Cannot remove previous data for %q: %v", oldSnap.InstanceName(), err)
+		return
+	}
+
+	// this will have duplicates but the second remove will just be ignored
+	dataDirs = append(dataDirs, hiddenDirs...)
+	for _, d := range dataDirs {
 		if err := clearTrash(d); err != nil {
 			logger.Noticef("Cannot remove %s: %v", d, err)
 		}
 	}
+}
+
+func (b Backend) HideSnapData(snapName string) error {
+	postMigrationOpts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+
+	users, err := allUsers(nil)
+	if err != nil {
+		return err
+	}
+
+	for _, usr := range users {
+		uid, gid, err := osutil.UidGid(usr)
+		if err != nil {
+			return err
+		}
+
+		// nothing to migrate
+		oldSnapDir := snap.UserSnapDir(usr.HomeDir, snapName, nil)
+		if _, err := os.Stat(oldSnapDir); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("cannot stat snap dir %q: %w", oldSnapDir, err)
+		}
+
+		// create the new hidden snap dir
+		hiddenSnapDir := snap.SnapDir(usr.HomeDir, postMigrationOpts)
+		if err := osutil.MkdirAllChown(hiddenSnapDir, 0700, uid, gid); err != nil {
+			return fmt.Errorf("cannot create snap dir %q: %w", hiddenSnapDir, err)
+		}
+
+		// move the snap's dir
+		newSnapDir := snap.UserSnapDir(usr.HomeDir, snapName, postMigrationOpts)
+		if err := osutil.AtomicRename(oldSnapDir, newSnapDir); err != nil {
+			return fmt.Errorf("cannot move %q to %q: %w", oldSnapDir, newSnapDir, err)
+		}
+
+		// remove ~/snap if it's empty
+		if err := removeIfEmpty(snap.SnapDir(usr.HomeDir, nil)); err != nil {
+			return fmt.Errorf("failed to remove old snap dir: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (b Backend) UndoHideSnapData(snapName string) error {
+	postMigrationOpts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+
+	users, err := allUsers(postMigrationOpts)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+	handle := func(err error) {
+		// keep going, restore previous state as much as possible
+		if firstErr == nil {
+			firstErr = err
+		} else {
+			logger.Noticef(err.Error())
+		}
+	}
+
+	for _, usr := range users {
+		uid, gid, err := osutil.UidGid(usr)
+		if err != nil {
+			handle(err)
+			continue
+		}
+
+		// skip it if wasn't migrated
+		hiddenSnapDir := snap.UserSnapDir(usr.HomeDir, snapName, postMigrationOpts)
+		if _, err := os.Stat(hiddenSnapDir); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				handle(fmt.Errorf("cannot read files in %q: %w", hiddenSnapDir, err))
+			}
+			continue
+		}
+
+		// ensure parent dirs exist
+		exposedDir := snap.SnapDir(usr.HomeDir, nil)
+		if err := osutil.MkdirAllChown(exposedDir, 0700, uid, gid); err != nil {
+			handle(fmt.Errorf("cannot create snap dir %q: %w", exposedDir, err))
+			continue
+		}
+
+		exposedSnapDir := snap.UserSnapDir(usr.HomeDir, snapName, nil)
+		if err := osutil.AtomicRename(hiddenSnapDir, exposedSnapDir); err != nil {
+			handle(fmt.Errorf("cannot move %q to %q: %w", hiddenSnapDir, exposedSnapDir, err))
+		}
+
+		// remove ~/.snap/data dir if empty
+		hiddenDir := snap.SnapDir(usr.HomeDir, postMigrationOpts)
+		if err := removeIfEmpty(hiddenDir); err != nil {
+			handle(fmt.Errorf("cannot remove dir %q: %w", hiddenDir, err))
+		}
+	}
+
+	return firstErr
+}
+
+var removeIfEmpty = func(dir string) error {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	if len(files) > 0 {
+		return nil
+	}
+
+	return os.Remove(dir)
 }

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -21,11 +21,15 @@ package backend
 
 import (
 	"os/exec"
+	"os/user"
+
+	"github.com/snapcore/snapd/dirs"
 )
 
 var (
 	AddMountUnit    = addMountUnit
 	RemoveMountUnit = removeMountUnit
+	RemoveIfEmpty   = removeIfEmpty
 )
 
 func MockUpdateFontconfigCaches(f func() error) (restore func()) {
@@ -41,5 +45,22 @@ func MockCommandFromSystemSnap(f func(string, ...string) (*exec.Cmd, error)) (re
 	commandFromSystemSnap = f
 	return func() {
 		commandFromSystemSnap = old
+	}
+}
+
+func MockAllUsers(f func(options *dirs.SnapDirOptions) ([]*user.User, error)) func() {
+	old := allUsers
+	allUsers = f
+	return func() {
+		allUsers = old
+	}
+
+}
+
+func MockRemoveIfEmpty(f func(dir string) error) func() {
+	old := removeIfEmpty
+	removeIfEmpty = f
+	return func() {
+		removeIfEmpty = old
 	}
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -905,7 +905,7 @@ apps:
 	return info, nil
 }
 
-func (f *fakeSnappyBackend) ClearTrashedData(si *snap.Info, opts *dirs.SnapDirOptions) {
+func (f *fakeSnappyBackend) ClearTrashedData(si *snap.Info) {
 	f.appendOp(&fakeOp{
 		op:    "cleanup-trash",
 		name:  si.InstanceName(),
@@ -1237,6 +1237,16 @@ func (f *fakeSnappyBackend) RunInhibitSnapForUnlink(info *snap.Info, hint runinh
 	}
 	// XXX: returning a real lock is somewhat annoying
 	return osutil.NewFileLock(filepath.Join(f.lockDir, info.InstanceName()+".lock"))
+}
+
+func (f *fakeSnappyBackend) HideSnapData(snapName string) error {
+	f.appendOp(&fakeOp{op: "hide-snap-data", name: snapName})
+	return f.maybeErrForLastOp()
+}
+
+func (f *fakeSnappyBackend) UndoHideSnapData(snapName string) error {
+	f.appendOp(&fakeOp{op: "undo-hide-snap-data", name: snapName})
+	return f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) appendOp(op *fakeOp) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1221,12 +1221,7 @@ func (m *SnapManager) cleanupCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	opts, err := GetSnapDirOptions(st)
-	if err != nil {
-		return err
-	}
-
-	m.backend.ClearTrashedData(info, opts)
+	m.backend.ClearTrashedData(info)
 
 	return nil
 }

--- a/snap/helpers.go
+++ b/snap/helpers.go
@@ -20,9 +20,74 @@
 package snap
 
 import (
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap/naming"
+)
+
+var (
+	userLookupId = user.LookupId
 )
 
 func IsSnapd(snapID string) bool {
 	return snapID == naming.WellKnownSnapID("snapd")
+}
+
+// AllUsers returns a list of users, including the root user and all users that
+// can be found under /home with a snap directory.
+func AllUsers(opts *dirs.SnapDirOptions) ([]*user.User, error) {
+	ds, err := filepath.Glob(DataHomeGlob(opts))
+	if err != nil {
+		// can't happen?
+		return nil, err
+	}
+
+	users := make([]*user.User, 1, len(ds)+1)
+	root, err := user.LookupId("0")
+	if err != nil {
+		return nil, err
+	}
+	users[0] = root
+	seen := make(map[uint32]bool, len(ds)+1)
+	seen[0] = true
+	var st syscall.Stat_t
+	for _, d := range ds {
+		err := syscall.Stat(d, &st)
+		if err != nil {
+			continue
+		}
+		if seen[st.Uid] {
+			continue
+		}
+		seen[st.Uid] = true
+		usr, err := userLookupId(strconv.FormatUint(uint64(st.Uid), 10))
+		if err != nil {
+			// Treat all non-nil errors as user.Unknown{User,Group}Error's, as
+			// currently Go's handling of returned errno from get{pw,gr}nam_r
+			// in the cgo implementation of user.Lookup is lacking, and thus
+			// user.Unknown{User,Group}Error is returned only when errno is 0
+			// and the list of users/groups is empty, but as per the man page
+			// for get{pw,gr}nam_r, there are many other errno's that typical
+			// systems could return to indicate that the user/group wasn't
+			// found, however unfortunately the POSIX standard does not actually
+			// dictate what errno should be used to indicate "user/group not
+			// found", and so even if Go is more robust, it may not ever be
+			// fully robust. See from the man page:
+			//
+			// > It [POSIX.1-2001] does not call "not found" an error, hence
+			// > does not specify what value errno might have in this situation.
+			// > But that makes it impossible to recognize errors.
+			//
+			// See upstream Go issue: https://github.com/golang/go/issues/40334
+			continue
+		} else {
+			users = append(users, usr)
+		}
+	}
+
+	return users, nil
 }


### PR DESCRIPTION
This is the first PR of a series that will implement the hidden snap folder migration (the draft PR with all of migration code is https://github.com/snapcore/snapd/pull/10956). This PR adds functions to the backend to hide and undo the hiding of snap data. It also changes ClearTrashedData to look for data to clear in both hidden and exposed dirs. The final version of these functions will be slightly different because SnapDirOptions will have to have two flags, one to signal intent to migrate and another to signal that is has happened. When reviewing UndoHideSnapData bear in mind that it'll be used not only when disabling the feature but also as part of the error recovery behavior [when undoing](https://github.com/MiguelPires/snapd/blob/5dd673998556cc791bea4930679ada7f9f5e51f2/overlord/snapstate/handlers.go#L1205).