### PR TITLE
interface/builtin/log_observe: allow to access /dev/kmsg

### DIFF
--- a/interfaces/builtin/log_observe.go
+++ b/interfaces/builtin/log_observe.go
@@ -35,6 +35,8 @@ const logObserveConnectedPlugAppArmor = `
 
 /var/log/ r,
 /var/log/** r,
+# for accessing dmesg
+/dev/kmsg r,
 
 # for accessing journald and journalctl
 /run/log/journal/ r,


### PR DESCRIPTION
To access kernel messages from snap, we need log_observe interface to
permit /dev/kmsg as read-only.

Signed-off-by: Hsieh-Tseng Shen <woodrow.shen@canonical.com>
