### PR TITLE
snap-bootstrap: Mount snaps read only

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -86,6 +86,10 @@ var (
 	secbootLockSealedKeys func() error
 
 	bootFindPartitionUUIDForBootedKernelDisk = boot.FindPartitionUUIDForBootedKernelDisk
+
+	mountReadOnlyOptions = &systemdMountOptions{
+		ReadOnly: true,
+	}
 )
 
 func stampedAction(stamp string, action func() error) error {
@@ -1309,7 +1313,7 @@ func generateMountsCommonInstallRecover(mst *initramfsMountsState) (model *asser
 
 		dir := snapTypeToMountDir[essentialSnap.EssentialType]
 		// TODO:UC20: we need to cross-check the kernel path with snapd_recovery_kernel used by grub
-		if err := doSystemdMount(essentialSnap.Path, filepath.Join(boot.InitramfsRunMntDir, dir), nil); err != nil {
+		if err := doSystemdMount(essentialSnap.Path, filepath.Join(boot.InitramfsRunMntDir, dir), mountReadOnlyOptions); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -1557,7 +1561,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 		if sn, ok := mounts[typ]; ok {
 			dir := snapTypeToMountDir[typ]
 			snapPath := filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), sn.Filename())
-			if err := doSystemdMount(snapPath, filepath.Join(boot.InitramfsRunMntDir, dir), nil); err != nil {
+			if err := doSystemdMount(snapPath, filepath.Join(boot.InitramfsRunMntDir, dir), mountReadOnlyOptions); err != nil {
 				return err
 			}
 		}
@@ -1570,8 +1574,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 		if err != nil {
 			return fmt.Errorf("cannot load metadata and verify snapd snap: %v", err)
 		}
-
-		return doSystemdMount(essSnaps[0].Path, filepath.Join(boot.InitramfsRunMntDir, "snapd"), nil)
+		return doSystemdMount(essSnaps[0].Path, filepath.Join(boot.InitramfsRunMntDir, "snapd"), mountReadOnlyOptions)
 	}
 
 	return nil

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -92,6 +92,9 @@ var (
 	needsNoSuidDiskMountOpts = &main.SystemdMountOptions{
 		NoSuid: true,
 	}
+	snapMountOpts = &main.SystemdMountOptions{
+		ReadOnly: true,
+	}
 
 	seedPart = disks.Partition{
 		FilesystemLabel: "ubuntu-seed",
@@ -501,6 +504,7 @@ func (s *initramfsMountsSuite) makeSeedSnapSystemdMount(typ snap.Type) systemdMo
 	}
 	mnt.what = filepath.Join(s.seedDir, "snaps", name+"_1.snap")
 	mnt.where = filepath.Join(boot.InitramfsRunMntDir, dir)
+	mnt.opts = snapMountOpts
 
 	return mnt
 }
@@ -519,6 +523,7 @@ func (s *initramfsMountsSuite) makeRunSnapSystemdMount(typ snap.Type, sn snap.Pl
 
 	mnt.what = filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), sn.Filename())
 	mnt.where = filepath.Join(boot.InitramfsRunMntDir, dir)
+	mnt.opts = snapMountOpts
 
 	return mnt
 }
@@ -1247,6 +1252,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.kernel.Filename()),
@@ -1254,6 +1260,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.core20.Filename()),
@@ -1261,6 +1268,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			"tmpfs",
@@ -1415,6 +1423,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.kernel.Filename()),
@@ -1422,6 +1431,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.core20.Filename()),
@@ -1429,6 +1439,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			"tmpfs",
@@ -1561,6 +1572,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.kernel.Filename()),
@@ -1568,6 +1580,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.core20.Filename()),
@@ -1575,6 +1588,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			"tmpfs",
@@ -1746,6 +1760,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), s.kernel.Filename()),
@@ -1753,6 +1768,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		},
 	})
 }
@@ -1870,6 +1886,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), s.kernel.Filename()),
@@ -1877,6 +1894,7 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--options=ro",
 		},
 	})
 }

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -72,6 +72,8 @@ type systemdMountOptions struct {
 	NoSuid bool
 	// Bind indicates a bind mount
 	Bind bool
+	// Read-only mount
+	ReadOnly bool
 }
 
 // doSystemdMount will mount "what" at "where" using systemd-mount(1) with
@@ -134,6 +136,9 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 	}
 	if opts.Bind {
 		options = append(options, "bind")
+	}
+	if opts.ReadOnly {
+		options = append(options, "ro")
 	}
 	if len(options) > 0 {
 		args = append(args, "--options="+strings.Join(options, ","))

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -81,3 +81,11 @@ execute: |
 
     # check that we have a boot-flags file
     test -f /run/snapd/boot-flags
+
+    # make sure that loop devices created by snap-bootstrap initramfs-mounts for snaps are readonly
+    for mount in /run/mnt/base /run/mnt/kernel; do
+        mountpoint "${mount}"
+        loop="$(findmnt -o source "${mount}" -n)"
+        echo "${loop}" | MATCH "/dev/loop[0-9]+"
+        losetup -O ro -n --raw "${loop}" | MATCH "1"
+    done


### PR DESCRIPTION
While squashfs is always read-only, when mount creates the required
loop device, it does not know that squashfs is a read-only
filesystem. This causes the loop devices for snaps mounted in the
initramfs to be be writable. Since the snaps are stored on
`/run/mnt/data`, it means the `/run/mnt/data` cannot be remounted
read-only.

There is a mount cycle now in Ubuntu Core where `/run/mnt/data` cannot
be unmounted because it contains the snap for the Core snap which is
mounted as root. After switching to the shutdown ramfs, then systemd
tries again to umount the remaining file systems as well as the root
file system. At this point, it still cannot umount `/run/mnt/data`, so
`systemd-shutdown` tries to remount read-only. But since the loop
device for the Core snap that cannot be unmounted is still writable,
then `/run/mnt/data` cannnot be remounted read-only.

This results in Ubuntu Core not properly unmounting `/run/mnt/data`.
This can be seen in the screen or serial console right before powering
off or rebooting:

```
Failed to remount '/oldroot/run/mnt/data' read-only: Device or resource busy
```

With this fix, this error disappears. While other errors about
unmounting are still here, it is safer because everything is
read-only.
