### PR TITLE
Show new logs even when in Done state

### DIFF
--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -116,16 +116,16 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 		}
 
 		for _, t := range chg.Tasks {
+			nowLog := lastLogStr(t.Log)
+			if lastLog[t.ID] != nowLog {
+				pb.Notify(nowLog)
+				lastLog[t.ID] = nowLog
+			}
 			switch {
 			case t.Status != "Doing":
 				continue
 			case t.Progress.Total == 1:
 				pb.Spin(t.Summary)
-				nowLog := lastLogStr(t.Log)
-				if lastLog[t.ID] != nowLog {
-					pb.Notify(nowLog)
-					lastLog[t.ID] = nowLog
-				}
 			case t.ID == lastID:
 				pb.Set(float64(t.Progress.Done))
 			default:


### PR DESCRIPTION
Based on discussion with @mvo5, this is probably not the right fix, but per Michael's email to me, I'm posting here as a PR for further discussion with the folks who are closest to the code. My original email is below for context:

-----

I'm working on Pebble, which inherits a bunch of snapd code, and have run across what I think is an issue in the waitMixin helper type for the CLI -- specifically, it sometimes misses displaying task logs. We're using basically the same version of waitMixin as snapd, so I'll link to the snapd code here.

In [cmd/snap/wait.go:124](https://github.com/snapcore/snapd/blob/515f093694b7777a0297dba57e76989ad6e1979f/cmd/snap/wait.go#L124-L128), the wait() method loops through the tasks in the change it's just received, and prints out the task logs to the user. (This code was originally added [here](https://github.com/snapcore/snapd/commit/a88e1001c54a7aced4ab741f2d2bdfa0f1606d3f) and tweaked [here](https://github.com/snapcore/snapd/commit/866e2e36229ac368b23b525c7f60ea79e4e8c641).)

The issue I'm seeing is that if the change happens quickly enough so it's Status==Done on the first call to Change(), no logs get printed. If the change takes longer than one call to Change(), the first Status will be Doing and so the log will get printed. This behavior seems buggy.

For example, here are two runs of "pebble start test" to start a service that's already started, which is obviously quite quick. I've added the "change ..." line to debug what's happening:

```
$ pebble start test
change 121 task 121 (state "Doing", 1 logs):
2021-11-18T14:47:27+13:00 INFO Service "test" already started.
change 121 task 121 (state "Done", 1 logs):

$ pebble start test
change 122 task 122 (state "Done", 1 logs):
```

A couple of things:

1) Unless I'm missing something, shouldn't it try to print out any new logs even in Done state? If fixed this here in Pebble but we want to make sure I've understood things correctly and it's the right fix ... and fix in snapd as it also has the same issue.

2) Why does the code only print out the last log from each task? Should we be printing out all task logs (from after the last log we've printed)?

3) Similar to the above: why are the logs only printed when Progress.Total==1? Wouldn't you want to see the logs as they came through?

Please let me know if I'm misunderstanding the intent of this code or if there's a better fix for the inconsistent behavior I'm seeing.