### PR TITLE
configcore: relax validation rules for hostname

### DIFF
--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -98,7 +98,7 @@ func init() {
 	addFSOnlyHandler(validateTimezoneSettings, handleTimezoneConfiguration, coreOnly)
 
 	// system.hostname - note that the validation is done via hostnamectl
-	// when applying so there is no valiation handler, see LP:1952740
+	// when applying so there is no validation handler, see LP:1952740
 	addFSOnlyHandler(nil, handleHostnameConfiguration, coreOnly)
 
 	sysconfig.ApplyFilesystemOnlyDefaultsImpl = filesystemOnlyApply

--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -98,7 +98,7 @@ func init() {
 	addFSOnlyHandler(validateTimezoneSettings, handleTimezoneConfiguration, coreOnly)
 
 	// system.hostname
-	addFSOnlyHandler(validateHostnameSettings, handleHostnameConfiguration, coreOnly)
+	addFSOnlyHandler(nil, handleHostnameConfiguration, coreOnly)
 
 	sysconfig.ApplyFilesystemOnlyDefaultsImpl = filesystemOnlyApply
 }

--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -97,7 +97,8 @@ func init() {
 	// system.timezone
 	addFSOnlyHandler(validateTimezoneSettings, handleTimezoneConfiguration, coreOnly)
 
-	// system.hostname
+	// system.hostname - note that the validation is done via hostnamectl
+	// when applying so there is no valiation handler, see LP:1952740
 	addFSOnlyHandler(nil, handleHostnameConfiguration, coreOnly)
 
 	sysconfig.ApplyFilesystemOnlyDefaultsImpl = filesystemOnlyApply

--- a/overlord/configstate/configcore/hostname.go
+++ b/overlord/configstate/configcore/hostname.go
@@ -38,23 +38,22 @@ func init() {
 	config.RegisterExternalConfig("core", "system.hostname", getHostnameFromSystemHelper)
 }
 
-// We are conservative here and follow hostname(7). The hostnamectl
-// binary is more liberal but let's err on the side of caution for
-// now.
-var validHostnameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}(\.[a-z0-9-]{1,63})*$`).MatchString
+// The hostname can also be set via hostnamectl so we cannot be more strict
+// than hostnamectl itself.
+// See: systemd/src/basic/hostname-util.c:ostname_is_valid
+var validHostnameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,62}(\.[a-zA-Z0-9-]{1,63})*$`).MatchString
 
-func validateHostnameSettings(tr config.ConfGetter) error {
-	hostname, err := coreCfg(tr, "system.hostname")
-	if err != nil {
-		return err
-	}
-	if hostname == "" {
-		return nil
-	}
+// Note that HOST_NAME_MAX is 64 on Linux, but DNS allows domain names
+// up to 255 characters
+const HOST_NAME_MAX = 64
 
-	validHostname := len(hostname) <= 253 && validHostnameRegexp(hostname)
+func validateHostname(hostname string) error {
+	validHostname := validHostnameRegexp(hostname)
 	if !validHostname {
 		return fmt.Errorf("cannot set hostname %q: name not valid", hostname)
+	}
+	if len(hostname) > HOST_NAME_MAX {
+		return fmt.Errorf("cannot set hostname %q: name too long", hostname)
 	}
 
 	return nil
@@ -83,6 +82,10 @@ func handleHostnameConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts 
 			return fmt.Errorf("cannot set hostname: %v", osutil.OutputErr(output, err))
 		}
 	} else {
+		if err := validateHostname(hostname); err != nil {
+			return err
+		}
+
 		// On the UC16/UC18/UC20 images the file /etc/hostname is a
 		// symlink to /etc/writable/hostname. The /etc/hostname is
 		// not part of the "writable-path" so we must set the file
@@ -105,7 +108,18 @@ func getHostnameFromSystemHelper(key string) (interface{}, error) {
 }
 
 func getHostnameFromSystem() (string, error) {
-	output, err := exec.Command("hostname").CombinedOutput()
+	// try pretty hostname first
+	output, err := exec.Command("hostnamectl", "status", "--pretty").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("cannot get hostname (pretty): %v", osutil.OutputErr(output, err))
+	}
+	prettyHostname := strings.TrimSpace(string(output))
+	if len(prettyHostname) > 0 {
+		return prettyHostname, nil
+	}
+
+	// then static hostname
+	output, err = exec.Command("hostnamectl", "status", "--static").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("cannot get hostname: %v", osutil.OutputErr(output, err))
 	}

--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -18,6 +18,8 @@ prepare: |
         # create a flag to indicate the ryslog service is fake
         touch rsyslog.fake
     fi
+    # hostname is modified during the tests
+    hostnamectl status --static > hostname
 
 restore: |
     if [ -f rsyslog.fake ]; then
@@ -29,6 +31,8 @@ restore: |
         systemctl start rsyslog.service
     fi
     rm -f /etc/systemd/login.conf.d/00-snap-core.conf
+    # restore hostname
+    hostnamectl set-hostname "$(cat hostname)"
 
 execute: |
     echo "Check that service disable works"
@@ -144,3 +148,5 @@ execute: |
     tests.cleanup defer hostnamectl set-hostname "$(hostname)"
     snap set system system.hostname=foo
     hostname | MATCH foo
+    snap set system system.hostname=F00
+    hostnamectl status | MATCH F00

--- a/tests/nested/manual/core-early-config/defaults.yaml
+++ b/tests/nested/manual/core-early-config/defaults.yaml
@@ -7,4 +7,4 @@ defaults:
         disable: true
     system:
       timezone: Europe/Malta
-      hostname: foo
+      hostname: F00

--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -57,4 +57,4 @@ execute: |
     tests.nested exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
 
     # hostname is set
-    tests.nested exec "cat /etc/hostname" | MATCH "foo"
+    tests.nested exec "cat /etc/hostname" | MATCH "F00"


### PR DESCRIPTION
The strict hostname validation rules in combination with the
fact that we now use the external configuration is broken.

If the hostname can be set externally via the hostnamectl
command we cannot have a validaton that is stricter then what
hostnamectl is doing.

This PR changes two things:
1. Only validate the hostname if it's set to in FSOnly apply mode,
   i.e. when no hostnamectl call is issued [1].
2. Directly pass the hostname to hostnamectl and let it handle invalid
   names. It has a concept of "static" and "pretty" hostname and will
   apply even invalid hostnames as "pretty" hostnames. However it will
   simplify/filter the pretty hostname so that it becomes a valid static
   hostname. Because of this our logic to detect if the hostname has
   changed needs to be tweaked to talk to hostnamectl instead of using
   the "hostname" command that only gets the "static" hostname view.

This should fix the issues around hostname setting.

[1] https://github.com/systemd/systemd/blob/main/src/basic/hostname-util.c#L85