### PR TITLE
HACKING.md: adjust again for building the snapd snap

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -101,9 +101,12 @@ can be built using snapcraft either in a LXD container or a multipass VM (or
 natively with `--destructive-mode` on a Ubuntu 16.04 host).
 
 Note: Currently, snapcraft's default track of 5.x does not support building the 
-snapd snap, since the snapd snap uses `build-base: core`, which uses Ubuntu 
-16.04 as the base for building and Ubuntu 16.04 is in Extended Security 
-Maintenance (ESM), and as such only is buildable using snapcraft's 4.x channel.
+snapd snap, since the snapd snap uses `build-base: core`. Building with a 
+`build-base` of core uses Ubuntu 16.04 as the base operating system (and thus 
+root filesystem) for building and Ubuntu 16.04 is now in Extended Security 
+Maintenance (ESM - see https://ubuntu.com/blog/ubuntu-16-04-lts-transitions-to-extended-security-maintenance-esm), and as such only is buildable using snapcraft's 4.x channel. At some point in the future,
+the snapd snap should be moved to a newer `build-base`, but until then `4.x` 
+needs to be used.
 
 Install snapcraft from the 4.x channel:
 
@@ -129,31 +132,40 @@ can either use `snap revert snapd`, or you can refresh directly with
 `snap refresh snapd --stable --amend`.
 
 Note: It is also sometimes useful to use snapcraft to build the snapd snap for
-other architectures using the remote-build feature, however there is currently a
-bug in snapcraft around using the 4.x channel and using remote-build, where the
-LP job created for the remote-build will attempt to use the 5.x channel instead
-of the 4.x channel. This being tracked at
-https://warthogs.atlassian.net/browse/CRAFT-568. To work-around this until the
-bug is properly fixed, you can hack the snapcraft snap by applying this patch to
-the snapcraft 4.8.3 git tag: https://pastebin.ubuntu.com/p/ZvrzghB32p/ and 
-rebuilding the snapcraft snap using snapcraft itself, then installing the 
-snapcraft snap that was built. This will force all remote-builds to use 4.x, so
-obviously the patch is not suitable for general consumption but is a temporary
-work-around until the bug is fixed properly in snapcraft upstream.
+other architectures using the `remote-build` feature, however there is currently a
+bug in snapcraft around using the `4.x` track and using `remote-build`, where the
+Launchpad job created for the remote-build will attempt to use the `latest` track instead
+of the `4.x` channel. This was recently fixed in snapcraft in https://github.com/snapcore/snapcraft/pull/3600
+which for now requires using the `latest/edge` channel of snapcraft instead of the
+`4.x` track which is needed to build the snap locally. However, this fix does 
+then introduce a different problem due to one of the tests in the snapd git tree
+which currently has circular symlinks in the tree, which due to a regression in
+snapcraft is no longer usable with remote-build. Removing these files in the 
+snapd git tree is tracked at https://bugs.launchpad.net/snapd/+bug/1948838, but
+in the mean time in order to build remotely with snapcraft, do the following:
 
 ```
-git clone -b 4.8.3 --single-branch --depth 1 https://github.com/snapcore/snapcraft.git
-cd snapcraft
-wget --quiet https://gist.githubusercontent.com/anonymouse64/8fc6e81dac06ed033636132b4d9215f9/raw/ea3128904d419de071d035f0c6b15b74ccfac4fa/snapcraft.patch
-git apply --ignore-whitespace snapcraft.patch
-snapcraft
-snap install snapcraft_*.snap
+snap refresh snapcraft --channel=latest/edge
 ```
 
-Now you can use remote-build with snapcraft on the snapd tree:
+And then get rid of the symlinks in question:
 
 ```
-snapcraft remote-build --build-on=armhf
+rm -r tests/main/validate-container-failures/
+```
+
+Now you can use remote-build with snapcraft on the snapd tree for any desired 
+architectures:
+
+```
+snapcraft remote-build --build-on=armhf,s390x,arm64
+```
+
+And to go back to building the snapd snap locally, just revert the channel back
+to 4.x:
+
+```
+snap refresh snapcraft --channel=4.x/stable
 ```
 
 
@@ -166,10 +178,10 @@ complex in that it assumes it is built inside Launchpad with the
 snapd into this by rebuilding the core snap directly, so an easier way is to 
 actually first build the snapd snap and inject the binaries from the snapd snap
 into the core snap. This currently works since both the snapd snap and the core 
-snap have the same build base of Ubuntu 16.04, so at some point in time this 
-trick will stop working when the snapd snap starts using a build base other than
-Ubuntu 16.04, but until then, you can use the following trick to more easily get
-a custom version of snapd inside a core snap.
+snap have the same `build-base` of Ubuntu 16.04. However, at some point in time
+this trick will stop working when the snapd snap starts using a `build-base` other
+than Ubuntu 16.04, but until then, you can use the following trick to more 
+easily get a custom version of snapd inside a core snap.
 
 First follow the steps above to build a full snapd snap. Then, extract the core
 snap you wish to splice the custom snapd snap into:

--- a/HACKING.md
+++ b/HACKING.md
@@ -142,7 +142,7 @@ then introduce a different problem due to one of the tests in the snapd git tree
 which currently has circular symlinks in the tree, which due to a regression in
 snapcraft is no longer usable with remote-build. Removing these files in the 
 snapd git tree is tracked at https://bugs.launchpad.net/snapd/+bug/1948838, but
-in the mean time in order to build remotely with snapcraft, do the following:
+in the meantime in order to build remotely with snapcraft, do the following:
 
 ```
 snap refresh snapcraft --channel=latest/edge


### PR DESCRIPTION
Update the snapcraft remote-build instructions since now snapcraft on the
latest channel supports building remotely properly, but has a different
regression around the symlink farm we have in one of our tests.