### PR TITLE
tests: verify that simultaneous refresh of kernel and base triggers a single reboot only

### DIFF
--- a/tests/core/kernel-and-base-single-reboot/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot/task.yaml
@@ -1,0 +1,131 @@
+summary: Exercises a simultaneous kernel and base refresh with a single reboot
+
+# TODO make the test work with ubuntu-core-20
+systems: [ubuntu-core-18-*]
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+
+    setup_fake_store "$BLOB_DIR"
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    core_snap=core20
+    if os.query is-core18; then
+        core_snap=core18
+    fi
+
+    readlink /snap/pc-kernel/current > pc-kernel.rev
+    readlink "/snap/$core_snap/current" > core.rev
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    teardown_fake_store "$BLOB_DIR"
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+
+    core_snap=core20
+    if os.query is-core18; then
+        core_snap=core18
+    fi
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        init_fake_refreshes "$BLOB_DIR" pc-kernel
+        init_fake_refreshes "$BLOB_DIR" "$core_snap"
+
+        # taken from transition_to_recover_mode()
+        cp /bin/systemctl /tmp/orig-systemctl
+        mount -o bind "$TESTSLIB/mock-shutdown" /bin/systemctl
+        tests.cleanup defer umount /bin/systemctl
+
+        snap refresh --no-wait "$core_snap" pc-kernel > refresh-change-id
+        test -n "$(cat refresh-change-id)"
+        change_id="$(cat refresh-change-id)"
+        # wait until we observe reboots
+        # shellcheck disable=SC2016
+        retry -n 100 --wait 5 sh -c 'test "$(wc -l < /tmp/mock-shutdown.calls)" -gt "1"'
+        # stop snapd now to avoid snapd waiting for too long and deciding to
+        # error out assuming a rollback across reboot
+        systemctl stop snapd.service snapd.socket
+
+        # both link snaps should be done now, we could not use use snap change
+        # as snapd is busy retrying the auto-connect task and does not respond to
+        # API requests, work around that by inspecting the state directly
+        snap debug state --change "$change_id" /var/lib/snapd/state.json > tasks.state
+        # both link snaps are done
+        MATCH ' Done\s+.*Make snap "pc-kernel" .* available' < tasks.state
+        MATCH " Done\s+.*Make snap \"$core_snap\" .* available" < tasks.state
+        # auto-connect of the base is in doing and waiting for reboot
+        MATCH " Doing\s+.*Automatically connect eligible plugs and slots of snap \"$core_snap\"" < tasks.state
+        # auto-connect of the kernel is still queued
+        MATCH ' Do\s+.*Automatically connect eligible plugs and slots of snap "pc-kernel"' < tasks.state
+
+        if os.query is-core18; then
+            snap debug boot-vars > boot-vars.dump
+            MATCH 'snap_mode=try' < boot-vars.dump
+            MATCH 'snap_try_core=core18_.*.snap' < boot-vars.dump
+            MATCH 'snap_try_kernel=pc-kernel_.*.snap' < boot-vars.dump
+        elif os.query is-core20; then
+            stat /boot/grub/kernel.efi | MATCH 'pc_kernel.*.snap/kernel.efi'
+            stat -L /boot/grub/kernel.efi
+            stat /boot/grub/try-kernel.efi | MATCH 'pc_kernel.*.snap/kernel.efi'
+            stat -L /boot/grub/try-kernel.efi
+        else
+            echo "unsupported Ubuntu Core system"
+            exit 1
+        fi
+
+        # restore shutdown so that spread can reboot the host
+        tests.cleanup pop
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 1 ]; then
+        change_id="$(cat refresh-change-id)"
+        # XXX: is this sufficiently robust?
+        snap watch "$change_id" || true
+        snap changes | MATCH "$change_id\s+(Done|Error)"
+        # we expect re-refresh to fail since the tests uses a fake store
+        snap change "$change_id" > tasks.done
+        MATCH '^Error .* Handling re-refresh' < tasks.done
+        # no other errors
+        grep -v 'Handling re-refresh' < tasks.done | NOMATCH '^Error'
+        # nothing was undone
+        grep -v 'Handling re-refresh' < tasks.done | NOMATCH '^Undone'
+        # we did not even try to hijack shutdown (/bin/systemctl) because that
+        # could race with snapd (if that wanted to call it), so just check that
+        # the system is in a stable state once we have already determined that
+        # the change is complete
+        # XXX systemctl exits with non-0 when in degraded state
+        (systemctl is-system-running || true) | MATCH '(running|degraded)'
+
+        # now we need to revert both snaps for restore to behave properly, start
+        # with the kernel
+        snap revert pc-kernel --revision "$(cat pc-kernel.rev)"
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 2 ]; then
+        snap watch --last=revert\?
+        # now the base
+        snap revert "$core_snap" --revision "$(cat core.rev)"
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 3 ]; then
+        snap watch --last=revert\?
+        # we're done
+    fi

--- a/tests/core/kernel-and-base-single-reboot/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot/task.yaml
@@ -66,9 +66,10 @@ execute: |
         # error out assuming a rollback across reboot
         systemctl stop snapd.service snapd.socket
 
-        # both link snaps should be done now, we could not use use snap change
-        # as snapd is busy retrying the auto-connect task and does not respond to
-        # API requests, work around that by inspecting the state directly
+        # both link snaps should be done now, snapd was stopped, so we cannot
+        # use 'snap change' and we need to inspect the state directly (even if
+        # snapd was up, it would not respond to API requests as it would be busy
+        # retrying auto-connect)
         snap debug state --change "$change_id" /var/lib/snapd/state.json > tasks.state
         # both link snaps are done
         MATCH ' Done\s+.*Make snap "pc-kernel" .* available' < tasks.state

--- a/tests/core/kernel-and-base-single-reboot/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot/task.yaml
@@ -17,18 +17,18 @@ prepare: |
 
     setup_fake_store "$BLOB_DIR"
 
+    core_snap=core20
+    if os.query is-core18; then
+        core_snap=core18
+    fi
+    readlink /snap/pc-kernel/current > pc-kernel.rev
+    readlink "/snap/$core_snap/current" > core.rev
+
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
     fi
-    core_snap=core20
-    if os.query is-core18; then
-        core_snap=core18
-    fi
-
-    readlink /snap/pc-kernel/current > pc-kernel.rev
-    readlink "/snap/$core_snap/current" > core.rev
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh
     teardown_fake_store "$BLOB_DIR"

--- a/tests/core/kernel-and-base-single-reboot/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot/task.yaml
@@ -117,6 +117,14 @@ execute: |
         # XXX systemctl exits with non-0 when in degraded state
         (systemctl is-system-running || true) | MATCH '(running|degraded)'
 
+        # fake refreshes generate revision numbers that are n+1
+        expecting_kernel="$(($(cat pc-kernel.rev) + 1))"
+        expecting_core="$(($(cat core.rev) + 1))"
+
+        # verify that current points to new revisions
+        test "$(readlink /snap/pc-kernel/current)" = "$expecting_kernel"
+        test "$(readlink /snap/$core_snap/current)" = "$expecting_core"
+
         # now we need to revert both snaps for restore to behave properly, start
         # with the kernel
         snap revert pc-kernel --revision "$(cat pc-kernel.rev)"
@@ -128,5 +136,10 @@ execute: |
         REBOOT
     elif [ "$SPREAD_REBOOT" = 3 ]; then
         snap watch --last=revert\?
-        # we're done
+        # we're done, verify current symlinks to the right revisions
+        test "$(readlink /snap/pc-kernel/current)" = "$(cat pc-kernel.rev)"
+        test "$(readlink /snap/$core_snap/current)" = "$(cat core.rev)"
+    else
+        echo "unexpected reboot"
+        exit 1
     fi

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -146,7 +146,7 @@ func makeFakeRefreshForSnap(snap, targetDir string, db *asserts.Database, f asse
 		// needing quoting, eg. version: '2021112', but since we're
 		// adding +fake1 suffix, the resulting value will clearly be a
 		// string, so have the regex strip quoting too
-		`s/version:[ ]\+['"]\?\([a-zA-Z0-9-]\+\)['"]\?/version: \1+fake1/`,
+		`s/version:[ ]\+['"]\?\([-.a-zA-Z0-9]\+\)['"]\?/version: \1+fake1/`,
 		filepath.Join(fakeUpdateDir, "meta/snap.yaml")).Run()
 	if err != nil {
 		return fmt.Errorf("changing fake snap version: %v", err)

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -141,7 +141,13 @@ func makeFakeRefreshForSnap(snap, targetDir string, db *asserts.Database, f asse
 	}
 
 	// fake new version
-	err = exec.Command("sudo", "sed", "-i", `s/version:\(.*\)/version:\1+fake1/`, filepath.Join(fakeUpdateDir, "meta/snap.yaml")).Run()
+	err = exec.Command("sudo", "sed", "-i",
+		// version can be all numbers thus making it ambiguous and
+		// needing quoting, eg. version: '2021112', but since we're
+		// adding +fake1 suffix, the resulting value will clearly be a
+		// string, so have the regex strip quoting too
+		`s/version:[ ]\+['"]\?\([a-zA-Z0-9-]\+\)['"]\?/version: \1+fake1/`,
+		filepath.Join(fakeUpdateDir, "meta/snap.yaml")).Run()
 	if err != nil {
 		return fmt.Errorf("changing fake snap version: %v", err)
 	}


### PR DESCRIPTION
Verify the single reboot feature. Sadly I was not able to make the test work correctly for core20 as the pc-kernel snap is repacked when preparing the UC20 system. Nonetheless, I'll keep on trying to have it work on uc20 too.
