### PR TITLE
gadget/install/partition.go: wait for udev settle when creating partitions too

### DIFF
--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -77,6 +77,13 @@ func createMissingPartitions(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) 
 		return nil, err
 	}
 
+	// run udevadm settle to wait for udev events that may have been triggered
+	// by reloading the partition table to be processed, as we need the udev
+	// database to be freshly updated
+	if out, err := exec.Command("udevadm", "settle", "--timeout=180").CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("cannot wait for udev to settle after reloading partition table: %v", osutil.OutputErr(out, err))
+	}
+
 	// Make sure the devices for the partitions we created are available
 	if err := ensureNodesExist(created, 5*time.Second); err != nil {
 		return nil, fmt.Errorf("partition not available: %v", err)

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -237,6 +237,9 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 	restore := disks.MockDeviceNameToDiskMapping(m)
 	defer restore()
 
+	cmdUdevadm := testutil.MockCommand(c, "udevadm", "")
+	defer cmdUdevadm.Restore()
+
 	calls := 0
 	restore = install.MockEnsureNodesExist(func(ds []gadget.OnDiskStructure, timeout time.Duration) error {
 		calls++
@@ -266,6 +269,10 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 	// Check partition table update
 	c.Assert(s.cmdPartx.Calls(), DeepEquals, [][]string{
 		{"partx", "-u", "/dev/node"},
+	})
+
+	c.Assert(cmdUdevadm.Calls(), DeepEquals, [][]string{
+		{"udevadm", "settle", "--timeout=180"},
 	})
 }
 


### PR DESCRIPTION
We previously added code to wait for udev to settle when removing partitions,
but we need the same thing when creating partitions too, otherwise we may fail
in the ensureNodesExist implementation.

Example failure of the tests/main/uc20-create-partitions-reinstall spread test
that happened once out of ~15 runs for me:

```
+ uc20-create-partitions ./gadget-dir ''
panic: cannot create the partitions: partition not available: Failed to open the device '/dev/loop1p3': No such file or directory

goroutine 1 [running]:
main.main()
        /home/gopath/src/github.com/snapcore/snapd/tests/lib/uc20-create-partitions/main.go:81 +0x665
-----
```

But by the time the debug section runs:

```
+ udevadm info --query property /dev/loop1p3
DEVPATH=/devices/virtual/block/loop1/loop1p3
DEVNAME=/dev/loop1p3
DEVTYPE=partition
PARTN=3
PARTNAME=ubuntu-boot
MAJOR=259
MINOR=2
SUBSYSTEM=block
```

So indeed we just need to wait for udev to finish before doing anything else.

With this patch, I can't reproduce the failure anymore after 20+ runs of the
failing spread test.