### PR TITLE
tests/main/security-device-cgroups-helper: collect some debug info when the test fails

### DIFF
--- a/tests/main/security-device-cgroups-helper/task.yaml
+++ b/tests/main/security-device-cgroups-helper/task.yaml
@@ -9,6 +9,11 @@ environment:
     # and /dev/kmsg has 1:11
     DEVICES_PATH_MEM_KMSG: /devices/virtual/mem/kmsg
 
+debug: |
+    udevadm info /dev/full || true
+    udevadm info /dev/kmsg || true
+    tests.device-cgroup test-strict-cgroup-helper.sh dump || true
+
 execute: |
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB/systems.sh"


### PR DESCRIPTION
The test was reported to be flaky in https://bugs.launchpad.net/snapd/+bug/1952813. Try to collect more information on the system state when the test fails.

