### PR TITLE
tests/nested/manual/core20-remodel: wait for device to have a serial before starting a remodel

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1437,7 +1437,7 @@ nested_fetch_spread() {
         mkdir -p "$NESTED_WORK_DIR"
         curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xz -C "$NESTED_WORK_DIR"
         # make sure spread really exists
-        test -x "$NESTED_WORK_DIR/spread"        
+        test -x "$NESTED_WORK_DIR/spread"
     fi
     echo "$NESTED_WORK_DIR/spread"
 }
@@ -1451,9 +1451,9 @@ nested_build_seed_cdrom() {
 
     local ORIG_DIR=$PWD
 
-    pushd "$SEED_DIR" || return 1 
+    pushd "$SEED_DIR" || return 1
     genisoimage -output "$ORIG_DIR/$SEED_NAME" -volid "$LABEL" -joliet -rock "$@"
-    popd || return 1 
+    popd || return 1
 }
 
 nested_wait_for_device_initialized_change() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1455,3 +1455,17 @@ nested_build_seed_cdrom() {
     genisoimage -output "$ORIG_DIR/$SEED_NAME" -volid "$LABEL" -joliet -rock "$@"
     popd || return 1 
 }
+
+nested_wait_for_device_initialized_change() {
+    local retry=60
+    local wait=1
+
+    while ! nested_exec "snap changes" | MATCH "Done.*Initialize device"; do
+        retry=$(( retry - 1 ))
+        if [ $retry -le 0 ]; then
+            echo "Timed out waiting for device to be fully initialized. Aborting!"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}

--- a/tests/nested/manual/core20-remodel/task.yaml
+++ b/tests/nested/manual/core20-remodel/task.yaml
@@ -23,6 +23,9 @@ execute: |
     # conflict with an existing system label
     label_base=$(tests.nested exec "date '+%Y%m%d'")
 
+    # wait until device is initialized and has a serial
+    nested_wait_for_device_initialized_change
+
     echo "Refresh model assertion to revision 2"
     nested_copy "$TESTSLIB/assertions/valid-for-testing-pc-revno-2-20.model"
     REMOTE_CHG_ID="$(tests.nested exec sudo snap remodel --no-wait valid-for-testing-pc-revno-2-20.model)"


### PR DESCRIPTION
Devices are expected to have serials before remodel can be started. We already have the right checks for tests/core, but not for nested tests.