### PR TITLE
o/c/c/hostname: be more robust against future code changes

### DIFF
--- a/overlord/configstate/configcore/hostname.go
+++ b/overlord/configstate/configcore/hostname.go
@@ -61,6 +61,10 @@ func validateHostnameSettings(tr config.ConfGetter) error {
 }
 
 func handleHostnameConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
+	if opts == nil {
+		opts = &fsOnlyContext{}
+	}
+
 	hostname, err := coreCfg(tr, "system.hostname")
 	if err != nil {
 		return nil
@@ -70,7 +74,7 @@ func handleHostnameConfiguration(_ sysconfig.Device, tr config.ConfGetter, opts 
 		return nil
 	}
 	// runtime system
-	if opts == nil {
+	if opts.RootDir == "" {
 		currentHostname, err := getHostnameFromSystem()
 		if err != nil {
 			return err


### PR DESCRIPTION
If more fields are added to the `fsOnlyContext` structure, or if it will
be initialized with an empty `rootDir` field, the code would take the
`else` path and directly write the hostname file, even though the path
using `hostnamectl` would work (and is arguably preferable).

At the moment it seems that the code in
overlord/configstate/configcore/handlers.go is always initializing a
`fsOnlyContext` structure with a non-empty `rootDir`, so this really
does not matter much for the time being.
