### PR TITLE
daemon,tests: support forgetting device serial via API

### DIFF
--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2020 Canonical Ltd
+ * Copyright (C) 2019-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -22,6 +22,7 @@ package daemon_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -375,4 +376,64 @@ func (s *modelSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	// created above
 	c.Assert(devKey, check.FitsTypeOf, "")
 	c.Assert(devKey.(string), check.Equals, string(encDevKey))
+}
+
+func (s *userSuite) TestPostSerialBadAction(c *check.C) {
+	buf := bytes.NewBufferString(`{"action":"what"}`)
+	req, err := http.NewRequest("POST", "/v2/model/serial", buf)
+	c.Assert(err, check.IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe, check.DeepEquals, daemon.BadRequest(`unsupported serial action "what"`))
+}
+
+func (s *userSuite) TestPostSerialForget(c *check.C) {
+	unregister := 0
+	defer daemon.MockDevicestateDeviceManagerUnregister(func(mgr *devicestate.DeviceManager, opts *devicestate.UnregisterOptions) error {
+		unregister++
+		c.Check(mgr, check.NotNil)
+		c.Check(opts.NoRegistrationUntilReboot, check.Equals, false)
+		return nil
+	})()
+
+	buf := bytes.NewBufferString(`{"action":"forget"}`)
+	req, err := http.NewRequest("POST", "/v2/model/serial", buf)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.syncReq(c, req, nil)
+	c.Check(rsp.Result, check.IsNil)
+
+	c.Check(unregister, check.Equals, 1)
+}
+
+func (s *userSuite) TestPostSerialForgetNoRegistrationUntilReboot(c *check.C) {
+	unregister := 0
+	defer daemon.MockDevicestateDeviceManagerUnregister(func(mgr *devicestate.DeviceManager, opts *devicestate.UnregisterOptions) error {
+		unregister++
+		c.Check(mgr, check.NotNil)
+		c.Check(opts.NoRegistrationUntilReboot, check.Equals, true)
+		return nil
+	})()
+
+	buf := bytes.NewBufferString(`{"action":"forget", "no-registration-until-reboot": true}`)
+	req, err := http.NewRequest("POST", "/v2/model/serial", buf)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.syncReq(c, req, nil)
+	c.Check(rsp.Result, check.IsNil)
+
+	c.Check(unregister, check.Equals, 1)
+}
+
+func (s *userSuite) TestPostSerialForgetError(c *check.C) {
+	defer daemon.MockDevicestateDeviceManagerUnregister(func(mgr *devicestate.DeviceManager, opts *devicestate.UnregisterOptions) error {
+		return errors.New("boom")
+	})()
+
+	buf := bytes.NewBufferString(`{"action":"forget"}`)
+	req, err := http.NewRequest("POST", "/v2/model/serial", buf)
+	c.Assert(err, check.IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe, check.DeepEquals, daemon.InternalError(`forgetting serial failed: boom`))
 }

--- a/daemon/export_api_model_test.go
+++ b/daemon/export_api_model_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -29,6 +30,14 @@ func MockDevicestateRemodel(mock func(*state.State, *asserts.Model) (*state.Chan
 	devicestateRemodel = mock
 	return func() {
 		devicestateRemodel = oldDevicestateRemodel
+	}
+}
+
+func MockDevicestateDeviceManagerUnregister(mock func(*devicestate.DeviceManager, *devicestate.UnregisterOptions) error) (restore func()) {
+	oldDevicestateDeviceManagerUnregister := devicestateDeviceManagerUnregister
+	devicestateDeviceManagerUnregister = mock
+	return func() {
+		devicestateDeviceManagerUnregister = oldDevicestateDeviceManagerUnregister
 	}
 }
 

--- a/tests/main/generic-unregister/task.yaml
+++ b/tests/main/generic-unregister/task.yaml
@@ -1,0 +1,44 @@
+summary: |
+    Ensure that unregistration API works.
+
+# ubuntu-14.04: curl does not have --unix-socket option
+systems: [-ubuntu-core-*, -ubuntu-14.04-*]
+
+prepare: |
+    systemctl stop snapd.service snapd.socket
+    cp /var/lib/snapd/state.json state.json.bak
+    mkdir key
+    cp /var/lib/snapd/device/private-keys-v1/* key
+    systemctl start snapd.service snapd.socket
+
+restore: |
+    systemctl stop snapd.service snapd.socket
+    cp key/* /var/lib/snapd/device/private-keys-v1/
+    cp state.json.bak /var/lib/snapd/state.json
+    systemctl start snapd.service snapd.socket
+
+execute: |
+    #shellcheck source=tests/lib/core-config.sh
+    . "$TESTSLIB"/core-config.sh
+
+    wait_for_device_initialized_change
+
+    snap model --assertion | MATCH "series: 16"
+
+    if snap model --verbose | NOMATCH "brand-id:\s* generic" ; then
+       echo "Not a generic model. Skipping."
+       exit 0
+    fi
+
+    curl --data '{"action":"forget","no-registration-until-reboot":true}' --unix-socket /run/snapd.socket http://localhost/v2/model/serial
+
+    test -f /run/snapd/noregister
+
+    snap model --serial 2>&1|MATCH "error: device not registered yet"
+
+    systemctl restart snapd.service
+
+    snap model --serial 2>&1|MATCH "error: device not registered yet"
+    snap find pc
+    NOMATCH '"session-macaroon":"[^"]' < /var/lib/snapd/state.json
+

--- a/tests/main/generic-unregister/task.yaml
+++ b/tests/main/generic-unregister/task.yaml
@@ -15,6 +15,7 @@ restore: |
     systemctl stop snapd.service snapd.socket
     cp key/* /var/lib/snapd/device/private-keys-v1/
     cp state.json.bak /var/lib/snapd/state.json
+    rm -f /run/snapd/noregister
     systemctl start snapd.service snapd.socket
 
 execute: |


### PR DESCRIPTION
this is done by posting {"action":"forget"} to /v2/model/serial

a flag no-registration-until-reboot is also supported
