### PR TITLE
overlord, o/snapstate, many: backport single reboot (2.53)

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -8555,6 +8555,240 @@ func (s *mgrsSuite) TestGadgetKernelCommandLineTransitionExtraToFull(c *C) {
 	})
 }
 
+func (s *mgrsSuite) testUpdateKernelBaseSingleRebootSetup(c *C) (*boottest.RunBootenv20, *state.Change) {
+	bloader := boottest.MockUC20RunBootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bootloader.Force(bloader)
+	s.AddCleanup(func() { bootloader.Force(nil) })
+
+	// a revision which is assumed to be installed
+	kernel, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
+	c.Assert(err, IsNil)
+	restore := bloader.SetEnabledKernel(kernel)
+	s.AddCleanup(restore)
+
+	restore = release.MockOnClassic(false)
+	s.AddCleanup(restore)
+
+	mockServer := s.mockStore(c)
+	s.AddCleanup(func() { mockServer.Close() })
+
+	st := s.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	model := s.brands.Model("can0nical", "my-model", uc20ModelDefaults)
+	// setup model assertion
+	devicestatetest.SetDevice(st, &auth.DeviceState{
+		Brand:  "can0nical",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+	err = assertstate.Add(st, model)
+	c.Assert(err, IsNil)
+
+	// mock the modeenv file
+	m := &boot.Modeenv{
+		Mode:                   "run",
+		Base:                   "core20_1.snap",
+		CurrentKernels:         []string{"pc-kernel_1.snap"},
+		CurrentRecoverySystems: []string{"1234"},
+		GoodRecoverySystems:    []string{"1234"},
+
+		Model:          model.Model(),
+		BrandID:        model.BrandID(),
+		Grade:          string(model.Grade()),
+		ModelSignKeyID: model.SignKeyID(),
+	}
+	err = m.WriteTo("")
+	c.Assert(err, IsNil)
+	c.Assert(s.o.DeviceManager().ReloadModeenv(), IsNil)
+
+	pcKernelYaml := "name: pc-kernel\nversion: 1.0\ntype: kernel"
+	baseYaml := "name: core20\nversion: 1.0\ntype: base"
+	siKernel := &snap.SideInfo{RealName: "pc-kernel", SnapID: fakeSnapID("pc-kernel"), Revision: snap.R(1)}
+	snaptest.MockSnap(c, pcKernelYaml, siKernel)
+	siBase := &snap.SideInfo{RealName: "core20", SnapID: fakeSnapID("core20"), Revision: snap.R(1)}
+	snaptest.MockSnap(c, baseYaml, siBase)
+
+	// test setup adds core, get rid of it
+	snapstate.Set(st, "core", nil)
+	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{siKernel},
+		Current:  snap.R(1),
+		SnapType: "kernel",
+	})
+	snapstate.Set(st, "core20", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{siBase},
+		Current:  snap.R(1),
+		SnapType: "base",
+	})
+
+	p, _ := s.makeStoreTestSnap(c, pcKernelYaml, "2")
+	s.serveSnap(p, "2")
+	p, _ = s.makeStoreTestSnap(c, baseYaml, "2")
+	s.serveSnap(p, "2")
+
+	affected, tss, err := snapstate.UpdateMany(context.Background(), st, []string{"pc-kernel", "core20"}, 0, nil)
+	c.Assert(err, IsNil)
+	c.Assert(affected, DeepEquals, []string{"core20", "pc-kernel"})
+	chg := st.NewChange("update-many", "...")
+	for _, ts := range tss {
+		// skip the taskset of UpdateMany that does the
+		// check-rerefresh, see tsWithoutReRefresh for details
+		if ts.Tasks()[0].Kind() == "check-rerefresh" {
+			c.Logf("skipping rerefresh")
+			continue
+		}
+		chg.AddAll(ts)
+	}
+	return bloader, chg
+}
+
+func (s *mgrsSuite) TestUpdateKernelBaseSingleRebootHappy(c *C) {
+	bloader, chg := s.testUpdateKernelBaseSingleRebootSetup(c)
+	st := s.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	st.Unlock()
+	err := s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil, Commentf(s.logbuf.String()))
+
+	// final steps will are postponed until we are in the restarted snapd
+	ok, rst := restart.Pending(st)
+	c.Assert(ok, Equals, true)
+	c.Assert(rst, Equals, restart.RestartSystem)
+
+	// auto connects aren't done yet
+	autoConnects := 0
+	for _, tsk := range chg.Tasks() {
+		if tsk.Kind() == "auto-connect" {
+			expectedStatus := state.DoStatus
+			snapsup, err := snapstate.TaskSnapSetup(tsk)
+			c.Assert(err, IsNil)
+			if snapsup.InstanceName() == "core20" {
+				expectedStatus = state.DoingStatus
+			}
+			c.Assert(tsk.Status(), Equals, expectedStatus,
+				Commentf("%q has status other than %s", tsk.Summary(), expectedStatus))
+			autoConnects++
+		}
+	}
+	// one for kernel, one for base
+	c.Check(autoConnects, Equals, 2)
+
+	// try snaps are set
+	currentTryKernel, err := bloader.TryKernel()
+	c.Assert(err, IsNil)
+	c.Assert(currentTryKernel.Filename(), Equals, "pc-kernel_2.snap")
+	m, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Check(m.BaseStatus, Equals, boot.TryStatus)
+	c.Check(m.TryBase, Equals, "core20_2.snap")
+
+	// simulate successful restart happened
+	restart.MockPending(st, restart.RestartUnset)
+	err = bloader.SetTryingDuringReboot([]snap.Type{snap.TypeKernel})
+	c.Assert(err, IsNil)
+	m.BaseStatus = boot.TryingStatus
+	c.Assert(m.Write(), IsNil)
+	s.o.DeviceManager().ResetToPostBootState()
+	st.Unlock()
+	err = s.o.DeviceManager().Ensure()
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	// go on
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("change failed with: %v", chg.Err()))
+}
+
+func (s *mgrsSuite) TestUpdateKernelBaseSingleRebootKernelUndo(c *C) {
+	bloader, chg := s.testUpdateKernelBaseSingleRebootSetup(c)
+	st := s.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	st.Unlock()
+	err := s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil, Commentf(s.logbuf.String()))
+
+	// final steps will are postponed until we are in the restarted snapd
+	ok, rst := restart.Pending(st)
+	c.Assert(ok, Equals, true)
+	c.Assert(rst, Equals, restart.RestartSystem)
+
+	// auto connects aren't done yet
+	autoConnects := 0
+	for _, tsk := range chg.Tasks() {
+		if tsk.Kind() == "auto-connect" {
+			expectedStatus := state.DoStatus
+			snapsup, err := snapstate.TaskSnapSetup(tsk)
+			c.Assert(err, IsNil)
+			if snapsup.InstanceName() == "core20" {
+				expectedStatus = state.DoingStatus
+			}
+			c.Assert(tsk.Status(), Equals, expectedStatus,
+				Commentf("%q has status other than %s", tsk.Summary(), expectedStatus))
+			autoConnects++
+		}
+	}
+	// one for kernel, one for base
+	c.Check(autoConnects, Equals, 2)
+
+	// try snaps are set
+	currentTryKernel, err := bloader.TryKernel()
+	c.Assert(err, IsNil)
+	c.Assert(currentTryKernel.Filename(), Equals, "pc-kernel_2.snap")
+	m, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Check(m.BaseStatus, Equals, boot.TryStatus)
+	c.Check(m.TryBase, Equals, "core20_2.snap")
+
+	// simulate successful restart happened
+	restart.MockPending(st, restart.RestartUnset)
+	// pretend the kernel panics during boot, kernel status gets reset to ""
+	err = bloader.SetRollbackAcrossReboot([]snap.Type{snap.TypeKernel})
+	c.Assert(err, IsNil)
+	s.o.DeviceManager().ResetToPostBootState()
+
+	// go on
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	// devicemgr's ensure boot ok tries to launch a revert
+	c.Check(err, ErrorMatches, `.*snap "pc-kernel" has "update-many" change in progress.*snap "core20" has "update-many" change in progress.*`)
+
+	c.Assert(chg.Status(), Equals, state.ErrorStatus, Commentf("change failed with: %v", chg.Err()))
+	c.Assert(chg.Err(), ErrorMatches, `(?ms).*cannot finish core20 installation, there was a rollback across reboot\)`)
+	// there is no try kernel, bootloader references only the old one
+	_, err = bloader.TryKernel()
+	c.Assert(err, Equals, bootloader.ErrNoTryKernelRef)
+	kpi, err := bloader.Kernel()
+	c.Assert(err, IsNil)
+	c.Assert(kpi.Filename(), Equals, "pc-kernel_1.snap")
+	m, err = boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m.BaseStatus, Equals, "")
+	c.Assert(m.TryBase, Equals, "")
+	c.Assert(m.Base, Equals, "core20_1.snap")
+
+	for _, tsk := range chg.Tasks() {
+		if tsk.Kind() == "link-snap" {
+			c.Assert(tsk.Status(), Equals, state.UndoneStatus,
+				Commentf("%q has status other than undone", tsk.Summary()))
+		}
+	}
+}
+
 type gadgetUpdatesSuite struct {
 	baseMgrsSuite
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -8658,9 +8658,9 @@ func (s *mgrsSuite) TestUpdateKernelBaseSingleRebootHappy(c *C) {
 	c.Assert(err, IsNil, Commentf(s.logbuf.String()))
 
 	// final steps will are postponed until we are in the restarted snapd
-	ok, rst := restart.Pending(st)
+	ok, rst := st.Restarting()
 	c.Assert(ok, Equals, true)
-	c.Assert(rst, Equals, restart.RestartSystem)
+	c.Assert(rst, Equals, state.RestartSystem)
 
 	// auto connects aren't done yet
 	autoConnects := 0
@@ -8690,7 +8690,7 @@ func (s *mgrsSuite) TestUpdateKernelBaseSingleRebootHappy(c *C) {
 	c.Check(m.TryBase, Equals, "core20_2.snap")
 
 	// simulate successful restart happened
-	restart.MockPending(st, restart.RestartUnset)
+	state.MockRestarting(st, state.RestartUnset)
 	err = bloader.SetTryingDuringReboot([]snap.Type{snap.TypeKernel})
 	c.Assert(err, IsNil)
 	m.BaseStatus = boot.TryingStatus
@@ -8722,9 +8722,9 @@ func (s *mgrsSuite) TestUpdateKernelBaseSingleRebootKernelUndo(c *C) {
 	c.Assert(err, IsNil, Commentf(s.logbuf.String()))
 
 	// final steps will are postponed until we are in the restarted snapd
-	ok, rst := restart.Pending(st)
+	ok, rst := st.Restarting()
 	c.Assert(ok, Equals, true)
-	c.Assert(rst, Equals, restart.RestartSystem)
+	c.Assert(rst, Equals, state.RestartSystem)
 
 	// auto connects aren't done yet
 	autoConnects := 0
@@ -8754,7 +8754,7 @@ func (s *mgrsSuite) TestUpdateKernelBaseSingleRebootKernelUndo(c *C) {
 	c.Check(m.TryBase, Equals, "core20_2.snap")
 
 	// simulate successful restart happened
-	restart.MockPending(st, restart.RestartUnset)
+	state.MockRestarting(st, state.RestartUnset)
 	// pretend the kernel panics during boot, kernel status gets reset to ""
 	err = bloader.SetRollbackAcrossReboot([]snap.Type{snap.TypeKernel})
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -375,9 +375,6 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	case "kernel-id":
 		name = "kernel"
 		typ = snap.TypeKernel
-	case "kernel-core18-id":
-		name = "kernel-core18"
-		typ = snap.TypeKernel
 	case "brand-gadget-id":
 		name = "brand-gadget"
 		typ = snap.TypeGadget
@@ -446,8 +443,6 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 				Attrs:     map[string]interface{}{"content": "some-content"},
 			},
 		}
-	} else if name == "kernel-core18" {
-		info.Base = "core18"
 	}
 
 	switch cand.channel {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1169,12 +1169,13 @@ func (f *fakeSnappyBackend) CurrentInfo(curInfo *snap.Info) {
 	})
 }
 
-func (f *fakeSnappyBackend) ForeignTask(kind string, status state.Status, snapsup *snapstate.SnapSetup) {
+func (f *fakeSnappyBackend) ForeignTask(kind string, status state.Status, snapsup *snapstate.SnapSetup) error {
 	f.appendOp(&fakeOp{
 		op:    kind + ":" + status.String(),
 		name:  snapsup.InstanceName(),
 		revno: snapsup.Revision(),
 	})
+	return f.maybeErrForLastOp()
 }
 
 type byAlias []*backend.Alias

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -375,6 +375,9 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	case "kernel-id":
 		name = "kernel"
 		typ = snap.TypeKernel
+	case "kernel-core18-id":
+		name = "kernel-core18"
+		typ = snap.TypeKernel
 	case "brand-gadget-id":
 		name = "brand-gadget"
 		typ = snap.TypeGadget
@@ -443,6 +446,8 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 				Attrs:     map[string]interface{}{"content": "some-content"},
 			},
 		}
+	} else if name == "kernel-core18" {
+		info.Base = "core18"
 	}
 
 	switch cand.channel {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -712,6 +712,7 @@ type fakeSnappyBackend struct {
 	linkSnapWaitTrigger string
 	linkSnapFailTrigger string
 	linkSnapMaybeReboot bool
+	linkSnapRebootFor   map[string]bool
 
 	copySnapDataFailTrigger string
 	emptyContainer          snap.Container
@@ -963,7 +964,8 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev boot.Device, linkCtx b
 
 	reboot := false
 	if f.linkSnapMaybeReboot {
-		reboot = info.InstanceName() == dev.Base()
+		reboot = info.InstanceName() == dev.Base() ||
+			(f.linkSnapRebootFor != nil && f.linkSnapRebootFor[info.InstanceName()])
 	}
 
 	return reboot, nil

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -35,7 +35,7 @@ import (
 // fallback logic will revert to "os=v1" but on the filesystem snappy
 // still has the "active" version set to "v2" which is
 // misleading. This code will check what kernel/os booted and set
-// those versions active.To do this it creates a Change and kicks
+// those versions active. To do this it creates a Change and kicks
 // start it directly.
 func UpdateBootRevisions(st *state.State) error {
 	const errorPrefix = "cannot update revisions after boot changes: "

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1550,15 +1550,16 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	// so that we switch executing its snapd.
 	var canReboot bool
 	if reboot {
+		var cannotReboot bool
 		// system reboot is required, but can this task request that?
-		if err := t.Get("can-reboot", &canReboot); err != nil && err != state.ErrNoState {
+		if err := t.Get("cannot-reboot", &cannotReboot); err != nil && err != state.ErrNoState {
 			return err
-		} else if err == state.ErrNoState {
-			// err-no-state, implying the the task was created
-			// before those variables were introduced
-			canReboot = true
 		}
-		if !canReboot {
+		if !cannotReboot {
+			// either the task was created before that variable was
+			// introduced or the task can request a reboot
+			canReboot = true
+		} else {
 			t.Logf("reboot postponed to later tasks")
 		}
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1417,7 +1417,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	if !deviceCtx.Classic() && deviceCtx.Model().Base() != "" {
 		linkCtx.RequireMountedSnapdSnap = true
 	}
-	reboot, err := m.backend.LinkSnap(newInfo, deviceCtx, linkCtx, perfTimings)
+	needsReboot, err := m.backend.LinkSnap(newInfo, deviceCtx, linkCtx, perfTimings)
 	// defer a cleanup helper which will unlink the snap if anything fails after
 	// this point
 	defer func() {
@@ -1549,7 +1549,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	// if we just installed a core snap, request a restart
 	// so that we switch executing its snapd.
 	var canReboot bool
-	if reboot {
+	if needsReboot {
 		var cannotReboot bool
 		// system reboot is required, but can this task request that?
 		if err := t.Get("cannot-reboot", &cannotReboot); err != nil && err != state.ErrNoState {
@@ -1563,8 +1563,8 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 			t.Logf("reboot postponed to later tasks")
 		}
 	}
-	if !reboot || canReboot {
-		m.maybeRestart(t, newInfo, reboot)
+	if !needsReboot || canReboot {
+		m.maybeRestart(t, newInfo, needsReboot)
 	}
 
 	return nil

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -198,7 +198,7 @@ func defaultPrereqSnapsChannel() string {
 	return channel
 }
 
-func findLinkSnapTask(st *state.State, snapName string) (*state.Task, error) {
+func findLinkSnapTaskForSnap(st *state.State, snapName string) (*state.Task, error) {
 	for _, chg := range st.Changes() {
 		if chg.Status().Ready() {
 			continue
@@ -305,7 +305,7 @@ func (m *SnapManager) installOneBaseOrRequired(t *state.Task, snapName string, c
 	}
 
 	// in progress?
-	if linkTask, err := findLinkSnapTask(st, snapName); err != nil {
+	if linkTask, err := findLinkSnapTaskForSnap(st, snapName); err != nil {
 		return nil, err
 	} else if linkTask != nil {
 		return nil, onInFlight
@@ -386,7 +386,7 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 // Checks for conflicting tasks. Returns true if the operation should be skipped. The error
 // can be a state.Retry if the operation should be retried later.
 func shouldSkipToAvoidConflict(task *state.Task, snapName string) (bool, error) {
-	otherTask, err := findLinkSnapTask(task.State(), snapName)
+	otherTask, err := findLinkSnapTaskForSnap(task.State(), snapName)
 	if err != nil {
 		return false, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -69,6 +69,10 @@ const (
 	BeginEdge                 = state.TaskSetEdge("begin")
 	BeforeHooksEdge           = state.TaskSetEdge("before-hooks")
 	HooksEdge                 = state.TaskSetEdge("hooks")
+	BeforeMaybeRebootEdge     = state.TaskSetEdge("before-maybe-reboot")
+	MaybeRebootEdge           = state.TaskSetEdge("maybe-reboot")
+	MaybeRebootWaitEdge       = state.TaskSetEdge("maybe-reboot-wait")
+	AfterMaybeRebootWaitEdge  = state.TaskSetEdge("after-maybe-reboot-wait")
 )
 
 var ErrNothingToDo = errors.New("nothing to do")
@@ -510,6 +514,10 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	installSet.WaitAll(ts)
 	installSet.MarkEdge(prereq, BeginEdge)
 	installSet.MarkEdge(setupAliases, BeforeHooksEdge)
+	installSet.MarkEdge(setupSecurity, BeforeMaybeRebootEdge)
+	installSet.MarkEdge(linkSnap, MaybeRebootEdge)
+	installSet.MarkEdge(autoConnect, MaybeRebootWaitEdge)
+	installSet.MarkEdge(setAutoAliases, AfterMaybeRebootWaitEdge)
 	if installHook != nil {
 		installSet.MarkEdge(installHook, HooksEdge)
 	}
@@ -1150,15 +1158,6 @@ func UpdateMany(ctx context.Context, st *state.State, names []string, userID int
 type updateFilter func(*snap.Info, *SnapState) bool
 
 func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) error {
-	var findTaskOfKind = func(ts *state.TaskSet, kind string) (*state.Task, int) {
-		for idx, tsk := range ts.Tasks() {
-			if tsk.Kind() == kind {
-				return tsk, idx
-			}
-		}
-		return nil, -1
-	}
-
 	haveBase, haveKernel := bootBaseTs != nil, kernelTs != nil
 	if !haveBase && !haveKernel {
 		// neither base nor kernel update
@@ -1182,17 +1181,20 @@ func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) err
 	//
 	// where (r) denotes the task that can effectively request a reboot
 
-	linkSnapKernel, lsKernelIdx := findTaskOfKind(kernelTs, "link-snap")
-	autoConnectKernel, _ := findTaskOfKind(kernelTs, "auto-connect")
-	if linkSnapKernel == nil || autoConnectKernel == nil {
-		return fmt.Errorf("internal error: cannot identify link-snap or auto-connect for the kernel snap")
+	beforeLinkSnapKernel := kernelTs.MaybeEdge(BeforeMaybeRebootEdge)
+	linkSnapKernel := kernelTs.MaybeEdge(MaybeRebootEdge)
+	autoConnectKernel := kernelTs.MaybeEdge(MaybeRebootWaitEdge)
+
+	if linkSnapKernel == nil || autoConnectKernel == nil || beforeLinkSnapKernel == nil {
+		return fmt.Errorf("internal error: cannot identify link-snap or auto-connect or the preceding task for the kernel snap")
 	}
 	kernelLanes := linkSnapKernel.Lanes()
 
-	linkSnapBase, _ := findTaskOfKind(bootBaseTs, "link-snap")
-	autoConnectBase, acBaseIdx := findTaskOfKind(bootBaseTs, "auto-connect")
-	if linkSnapBase == nil || autoConnectBase == nil {
-		return fmt.Errorf("internal error: cannot identify link-snap or auto-connect for the base snap")
+	linkSnapBase := bootBaseTs.MaybeEdge(MaybeRebootEdge)
+	autoConnectBase := bootBaseTs.MaybeEdge(MaybeRebootWaitEdge)
+	afterAutoConnectBase := bootBaseTs.MaybeEdge(AfterMaybeRebootWaitEdge)
+	if linkSnapBase == nil || autoConnectBase == nil || afterAutoConnectBase == nil {
+		return fmt.Errorf("internal error: cannot identify link-snap or auto-connect or the following task for the base snap")
 	}
 	baseLanes := linkSnapBase.Lanes()
 
@@ -1206,7 +1208,7 @@ func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) err
 	}
 	// make link-snap base wait for the last task directly preceding
 	// link-snap of the kernel
-	linkSnapBase.WaitFor(kernelTs.Tasks()[lsKernelIdx-1])
+	linkSnapBase.WaitFor(beforeLinkSnapKernel)
 	// order: link-snap-base -> link-snap-kernel
 	linkSnapKernel.WaitFor(linkSnapBase)
 	// order: link-snap-kernel -> auto-connect-base
@@ -1215,7 +1217,7 @@ func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) err
 	autoConnectKernel.WaitFor(autoConnectBase)
 	// make the first task after auto-connect base wait for auto-connect
 	// kernel, this task already waits for auto-connect of base
-	bootBaseTs.Tasks()[acBaseIdx+1].WaitFor(autoConnectKernel)
+	afterAutoConnectBase.WaitFor(autoConnectKernel)
 
 	// cannot-reboot indicates that a task cannot invoke a reboot
 	linkSnapBase.Set("cannot-reboot", true)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1188,6 +1188,7 @@ func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) err
 		return fmt.Errorf("internal error: cannot identify link-snap or auto-connect for the kernel snap")
 	}
 	kernelLanes := linkSnapKernel.Lanes()
+
 	linkSnapBase, _ := findTaskOfKind(bootBaseTs, "link-snap")
 	autoConnectBase, acBaseIdx := findTaskOfKind(bootBaseTs, "auto-connect")
 	if linkSnapBase == nil || autoConnectBase == nil {
@@ -1203,7 +1204,8 @@ func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) err
 		linkSnapKernel.JoinLane(lane)
 		autoConnectKernel.JoinLane(lane)
 	}
-	// make link-snap base wait for the last pre-link-snap-kernel task
+	// make link-snap base wait for the last task directly preceding
+	// link-snap of the kernel
 	linkSnapBase.WaitFor(kernelTs.Tasks()[lsKernelIdx-1])
 	// order: link-snap-base -> link-snap-kernel
 	linkSnapKernel.WaitFor(linkSnapBase)
@@ -1211,8 +1213,8 @@ func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) err
 	autoConnectBase.WaitFor(linkSnapKernel)
 	// order: auto-connect-base -> auto-connect-kernel
 	autoConnectKernel.WaitFor(autoConnectBase)
-	// make the first post auto-connect base wait for auto-connect kernel,
-	// this task already waits for auto-connect of base
+	// make the first task after auto-connect base wait for auto-connect
+	// kernel, this task already waits for auto-connect of base
 	bootBaseTs.Tasks()[acBaseIdx+1].WaitFor(autoConnectKernel)
 
 	// cannot-reboot indicates that a task cannot invoke a reboot
@@ -1385,9 +1387,19 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 			// prereqs were processed already, wait for
 			// them as necessary for the other kind of
 			// snaps
+
+			// because "core" has type "os" it is ordered before all
+			// other updates, right after snapd, that introduces a
+			// dependency on "core" tasks for all other snaps, and
+			// thus preventing us from reordering them to perform a
+			// single reboot when both kernel and base (core in this
+			// case) are updated
 			waitPrereq(ts, defaultCoreSnapName)
 			waitPrereq(ts, "snapd")
 			if update.SnapBase() != "" {
+				// the kernel snap is ordered before the base,
+				// so its task will not have an implicit
+				// dependency on base update
 				waitPrereq(ts, update.SnapBase())
 			}
 		}
@@ -1422,8 +1434,12 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 		kernelTs.WaitAll(gadgetTs)
 	}
 
-	if err := rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs); err != nil {
-		return nil, nil, err
+	if deviceCtx.Model().Base() != "" {
+		// reordering of kernel and base tasks is supported only on
+		// UC18+ devices
+		if err := rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	if len(newAutoAliases) != 0 {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1339,7 +1339,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 		reportUpdated[snapName] = true
 	}
 
-	// first snapd, core, bases, then rest
+	// first snapd, core, kernel, bases, then rest
 	sort.Stable(byType(updates))
 	prereqs := make(map[string]*state.TaskSet)
 	waitPrereq := func(ts *state.TaskSet, prereqName string) {
@@ -1391,7 +1391,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 				waitPrereq(ts, update.SnapBase())
 			}
 		}
-		// keep track of kernel/gadget updates
+		// keep track of kernel/gadget/base updates
 		switch update.Type() {
 		case snap.TypeKernel:
 			kernelTs = ts

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1149,6 +1149,92 @@ func UpdateMany(ctx context.Context, st *state.State, names []string, userID int
 // consider.
 type updateFilter func(*snap.Info, *SnapState) bool
 
+func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) error {
+	var findTaskOfKind = func(ts *state.TaskSet, kind string) (*state.Task, int) {
+		for idx, tsk := range ts.Tasks() {
+			if tsk.Kind() == kind {
+				return tsk, idx
+			}
+		}
+		return nil, -1
+	}
+
+	haveBase, haveKernel := bootBaseTs != nil, kernelTs != nil
+	if !haveBase && !haveKernel {
+		return nil
+	}
+	if haveBase != haveKernel {
+		// have one but not the other
+		var linkSnap *state.Task
+		if haveKernel {
+			// only kernel in this update
+			linkSnap, _ = findTaskOfKind(kernelTs, "link-snap")
+		} else {
+			// only boot base in this update
+			linkSnap, _ = findTaskOfKind(bootBaseTs, "link-snap")
+		}
+		if linkSnap != nil {
+			// we're only updating the base or the kernel, so the link-snap
+			// task can request a reboot
+			linkSnap.Set("can-reboot", true)
+		}
+		return nil
+	}
+
+	// both kernel and boot base are being updated, reorder link-snap and
+	// auto-connect tasks from both snaps such that we end up with the
+	// following ordering:
+	//
+	// tasks of base and kernel ->
+	//     link-snap(base) ->
+	//        link-snap(kernel)(r) ->
+	//            auto-connect(base) ->
+	//                auto-connect(kernel) ->
+	//                    remaining tasks of base and kernel
+	//
+	// where (r) denotes the task that can effectively request a reboot
+
+	linkSnapKernel, lsKernelIdx := findTaskOfKind(kernelTs, "link-snap")
+	autoConnectKernel, _ := findTaskOfKind(kernelTs, "auto-connect")
+	if linkSnapKernel == nil || autoConnectKernel == nil {
+		return fmt.Errorf("internal error: cannot identify link-snap or auto-connect for the kernel snap")
+	}
+	kernelLanes := linkSnapKernel.Lanes()
+	linkSnapBase, _ := findTaskOfKind(bootBaseTs, "link-snap")
+	autoConnectBase, acBaseIdx := findTaskOfKind(bootBaseTs, "auto-connect")
+	if linkSnapBase == nil || autoConnectBase == nil {
+		return fmt.Errorf("internal error: cannot identify link-snap or auto-connect for the base snap")
+	}
+	baseLanes := linkSnapBase.Lanes()
+
+	for _, lane := range kernelLanes {
+		linkSnapBase.JoinLane(lane)
+		autoConnectBase.JoinLane(lane)
+	}
+	for _, lane := range baseLanes {
+		linkSnapKernel.JoinLane(lane)
+		autoConnectKernel.JoinLane(lane)
+	}
+	// make link-snap base wait for the last pre-link-snap-kernel task
+	linkSnapBase.WaitFor(kernelTs.Tasks()[lsKernelIdx-1])
+	// order: link-snap-base -> link-snap-kernel
+	linkSnapKernel.WaitFor(linkSnapBase)
+	// order: link-snap-kernel -> auto-connect-base
+	autoConnectBase.WaitFor(linkSnapKernel)
+	// order: auto-connect-base -> auto-connect-kernel
+	autoConnectKernel.WaitFor(autoConnectBase)
+	// make the first post auto-connect base wait for auto-connect kernel,
+	// this task already waits for auto-connect of base
+	bootBaseTs.Tasks()[acBaseIdx+1].WaitFor(autoConnectKernel)
+
+	linkSnapBase.Set("can-reboot", false)
+	// kernel link snap can reboot
+	linkSnapKernel.Set("can-reboot", true)
+	// first auto connect will wait for reboot, but the restart pending flag
+	// will be cleared for the second one that runs
+	return nil
+}
+
 func updateManyFiltered(ctx context.Context, st *state.State, names []string, userID int, filter updateFilter, flags *Flags, fromChange string) ([]string, []*state.TaskSet, error) {
 	if flags == nil {
 		flags = &Flags{}
@@ -1274,7 +1360,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 			ts.WaitAll(preTs)
 		}
 	}
-	var kernelTs, gadgetTs *state.TaskSet
+	var kernelTs, gadgetTs, bootBaseTs *state.TaskSet
 
 	// updates is sorted by kind so this will process first core
 	// and bases and then other snaps
@@ -1317,12 +1403,17 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 				waitPrereq(ts, update.SnapBase())
 			}
 		}
-		// keep track of kernel/gadget udpates
+		// keep track of kernel/gadget updates
 		switch update.Type() {
 		case snap.TypeKernel:
 			kernelTs = ts
 		case snap.TypeGadget:
 			gadgetTs = ts
+		case snap.TypeBase, snap.TypeOS:
+			if update.InstanceName() == deviceCtx.Model().Base() {
+				// only the boot base is relevant for reboots
+				bootBaseTs = ts
+			}
 		}
 
 		scheduleUpdate(update.InstanceName(), ts)
@@ -1336,6 +1427,10 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 	// kernel aborts the wait tasks (the gadget) is put on "Hold".
 	if kernelTs != nil && gadgetTs != nil {
 		kernelTs.WaitAll(gadgetTs)
+	}
+
+	if err := rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs); err != nil {
+		return nil, nil, err
 	}
 
 	if len(newAutoAliases) != 0 {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1397,11 +1397,16 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 			kernelTs = ts
 		case snap.TypeGadget:
 			gadgetTs = ts
-		case snap.TypeBase, snap.TypeOS:
+		case snap.TypeBase:
 			if update.InstanceName() == deviceCtx.Model().Base() {
 				// only the boot base is relevant for reboots
 				bootBaseTs = ts
 			}
+		case snap.TypeOS:
+			// nothing to do, we cannot set up a single reboot with
+			// "core" due to all tasks of other snaps impolitely
+			// waiting for all tasks of "core", what makes us end up
+			// with a task wait loop
 		}
 
 		scheduleUpdate(update.InstanceName(), ts)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1161,23 +1161,11 @@ func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) err
 
 	haveBase, haveKernel := bootBaseTs != nil, kernelTs != nil
 	if !haveBase && !haveKernel {
+		// neither base nor kernel update
 		return nil
 	}
 	if haveBase != haveKernel {
 		// have one but not the other
-		var linkSnap *state.Task
-		if haveKernel {
-			// only kernel in this update
-			linkSnap, _ = findTaskOfKind(kernelTs, "link-snap")
-		} else {
-			// only boot base in this update
-			linkSnap, _ = findTaskOfKind(bootBaseTs, "link-snap")
-		}
-		if linkSnap != nil {
-			// we're only updating the base or the kernel, so the link-snap
-			// task can request a reboot
-			linkSnap.Set("can-reboot", true)
-		}
 		return nil
 	}
 
@@ -1227,9 +1215,9 @@ func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) err
 	// this task already waits for auto-connect of base
 	bootBaseTs.Tasks()[acBaseIdx+1].WaitFor(autoConnectKernel)
 
-	linkSnapBase.Set("can-reboot", false)
-	// kernel link snap can reboot
-	linkSnapKernel.Set("can-reboot", true)
+	// cannot-reboot indicates that a task cannot invoke a reboot
+	linkSnapBase.Set("cannot-reboot", true)
+
 	// first auto connect will wait for reboot, but the restart pending flag
 	// will be cleared for the second one that runs
 	return nil

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1390,6 +1390,11 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 			name: "some-snap",
 		},
 		{
+			op:    "auto-connect:Undoing",
+			name:  "some-snap",
+			revno: snap.R(11),
+		},
+		{
 			op:   "discard-namespace",
 			name: "some-snap",
 		},

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2020 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -56,7 +56,7 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-func verifyInstallTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.State) {
+func verifyInstallTasks(c *C, opts, discards int, ts *state.TaskSet) {
 	kinds := taskKinds(ts.Tasks())
 
 	expected := []string{
@@ -177,7 +177,7 @@ func (s *snapmgrTestSuite) TestInstallTasks(c *C) {
 	ts, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	verifyInstallTasks(c, 0, 0, ts, s.state)
+	verifyInstallTasks(c, 0, 0, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
@@ -220,7 +220,7 @@ func (s *snapmgrTestSuite) TestInstallSnapdSnapTypeOnClassic(c *C) {
 	ts, err := snapstate.Install(context.Background(), s.state, "snapd", opts, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	verifyInstallTasks(c, noConfigure, 0, ts, s.state)
+	verifyInstallTasks(c, noConfigure, 0, ts)
 
 	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
 	c.Assert(err, IsNil)
@@ -238,7 +238,7 @@ func (s *snapmgrTestSuite) TestInstallSnapdSnapTypeOnCore(c *C) {
 	ts, err := snapstate.Install(context.Background(), s.state, "snapd", opts, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	verifyInstallTasks(c, noConfigure|updatesBootConfig, 0, ts, s.state)
+	verifyInstallTasks(c, noConfigure|updatesBootConfig, 0, ts)
 
 	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
 	c.Assert(err, IsNil)
@@ -256,7 +256,7 @@ func (s *snapmgrTestSuite) TestInstallCohortTasks(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(snapsup.CohortKey, Equals, "what")
 
-	verifyInstallTasks(c, 0, 0, ts, s.state)
+	verifyInstallTasks(c, 0, 0, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
@@ -273,7 +273,7 @@ func (s *snapmgrTestSuite) TestInstallWithDeviceContext(c *C) {
 	ts, err := snapstate.InstallWithDeviceContext(context.Background(), s.state, "some-snap", opts, 0, snapstate.Flags{}, deviceCtx, "")
 	c.Assert(err, IsNil)
 
-	verifyInstallTasks(c, 0, 0, ts, s.state)
+	verifyInstallTasks(c, 0, 0, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
@@ -3315,7 +3315,7 @@ func (s *snapmgrTestSuite) TestInstallMany(c *C) {
 	c.Check(s.fakeStore.seenPrivacyKeys["privacy-key"], Equals, true)
 
 	for i, ts := range tts {
-		verifyInstallTasks(c, 0, 0, ts, s.state)
+		verifyInstallTasks(c, 0, 0, ts)
 		// check that tasksets are in separate lanes
 		for _, t := range ts.Tasks() {
 			c.Assert(t.Lanes(), DeepEquals, []int{i + 1})

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -249,7 +249,7 @@ func (s *snapmgrTestSuite) TearDownTest(c *C) {
 }
 
 type ForeignTaskTracker interface {
-	ForeignTask(kind string, status state.Status, snapsup *snapstate.SnapSetup)
+	ForeignTask(kind string, status state.Status, snapsup *snapstate.SnapSetup) error
 }
 
 func AddForeignTaskHandlers(runner *state.TaskRunner, tracker ForeignTaskTracker) {
@@ -264,9 +264,7 @@ func AddForeignTaskHandlers(runner *state.TaskRunner, tracker ForeignTaskTracker
 			return err
 		}
 
-		tracker.ForeignTask(kind, status, snapsup)
-
-		return nil
+		return tracker.ForeignTask(kind, status, snapsup)
 	}
 	runner.AddHandler("setup-profiles", fakeHandler, fakeHandler)
 	runner.AddHandler("auto-connect", fakeHandler, nil)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -401,7 +401,6 @@ func (s *snapmgrTestSuite) TestUserFromUserID(c *C) {
 const (
 	unlinkBefore = 1 << iota
 	cleanupAfter
-	maybeCore
 	runCoreConfigure
 	doesReRefresh
 	updatesGadget
@@ -4335,7 +4334,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasks(c *C) {
 
 	c.Assert(tsl, HasLen, 3)
 	// 1. install core
-	verifyInstallTasks(c, runCoreConfigure|maybeCore, 0, tsl[0])
+	verifyInstallTasks(c, snap.TypeOS, runCoreConfigure, 0, tsl[0])
 	// 2 transition-connections
 	verifyTransitionConnectionsTasks(c, tsl[1])
 	// 3 remove-ubuntu-core
@@ -4898,7 +4897,7 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapWithCoreRunthrough(c *C) {
 	c.Assert(chg.IsReady(), Equals, true)
 	c.Check(s.fakeStore.downloads, HasLen, 1)
 	ts := state.NewTaskSet(chg.Tasks()...)
-	verifyInstallTasks(c, noConfigure, 0, ts)
+	verifyInstallTasks(c, snap.TypeSnapd, noConfigure, 0, ts)
 
 	// ensure preferences from the core snap got transferred over
 	var snapst snapstate.SnapState
@@ -6134,7 +6133,7 @@ func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnInstall(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
-	verifyInstallTasks(c, updatesGadget, 0, ts)
+	verifyInstallTasks(c, snap.TypeGadget, 0, 0, ts)
 }
 
 func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnRefresh(c *C) {
@@ -6158,7 +6157,7 @@ func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnRefresh(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh|updatesGadget, 0, ts)
+	verifyUpdateTasks(c, snap.TypeGadget, doesReRefresh, 0, ts)
 
 }
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -404,6 +404,7 @@ const (
 	runCoreConfigure
 	doesReRefresh
 	updatesGadget
+	updatesGadgetAssets
 	updatesBootConfig
 	noConfigure
 )

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -82,6 +82,8 @@ type snapmgrTestSuite struct {
 	user  *auth.UserState
 	user2 *auth.UserState
 	user3 *auth.UserState
+
+	restartRequests []state.RestartType
 }
 
 func (s *snapmgrTestSuite) settle(c *C) {
@@ -97,7 +99,10 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
 
-	s.o = overlord.Mock()
+	s.restartRequests = nil
+	s.o = overlord.MockWithStateAndRestartHandler(nil, func(t state.RestartType) {
+		s.restartRequests = append(s.restartRequests, t)
+	})
 	s.state = s.o.State()
 
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -267,7 +267,7 @@ func AddForeignTaskHandlers(runner *state.TaskRunner, tracker ForeignTaskTracker
 		return tracker.ForeignTask(kind, status, snapsup)
 	}
 	runner.AddHandler("setup-profiles", fakeHandler, fakeHandler)
-	runner.AddHandler("auto-connect", fakeHandler, nil)
+	runner.AddHandler("auto-connect", fakeHandler, fakeHandler)
 	runner.AddHandler("auto-disconnect", fakeHandler, nil)
 	runner.AddHandler("remove-profiles", fakeHandler, fakeHandler)
 	runner.AddHandler("discard-conns", fakeHandler, fakeHandler)
@@ -1922,6 +1922,11 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 		{
 			op:   "remove-snap-aliases",
 			name: "some-snap",
+		},
+		{
+			op:    "auto-connect:Undoing",
+			name:  "some-snap",
+			revno: snap.R(1),
 		},
 		{
 			op:   "unlink-snap",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4335,7 +4335,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasks(c *C) {
 
 	c.Assert(tsl, HasLen, 3)
 	// 1. install core
-	verifyInstallTasks(c, runCoreConfigure|maybeCore, 0, tsl[0], s.state)
+	verifyInstallTasks(c, runCoreConfigure|maybeCore, 0, tsl[0])
 	// 2 transition-connections
 	verifyTransitionConnectionsTasks(c, tsl[1])
 	// 3 remove-ubuntu-core
@@ -4898,7 +4898,7 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapWithCoreRunthrough(c *C) {
 	c.Assert(chg.IsReady(), Equals, true)
 	c.Check(s.fakeStore.downloads, HasLen, 1)
 	ts := state.NewTaskSet(chg.Tasks()...)
-	verifyInstallTasks(c, noConfigure, 0, ts, s.state)
+	verifyInstallTasks(c, noConfigure, 0, ts)
 
 	// ensure preferences from the core snap got transferred over
 	var snapst snapstate.SnapState
@@ -6134,7 +6134,7 @@ func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnInstall(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
-	verifyInstallTasks(c, updatesGadget, 0, ts, s.state)
+	verifyInstallTasks(c, updatesGadget, 0, ts)
 }
 
 func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnRefresh(c *C) {
@@ -6158,7 +6158,7 @@ func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnRefresh(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh|updatesGadget, 0, ts, s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh|updatesGadget, 0, ts)
 
 }
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6911,14 +6911,16 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 		restartRequested = append(restartRequested, t)
 	}))
 
-	restore = snapstatetest.MockDeviceModel(ModelWithBase("core18"))
+	restore = snapstatetest.MockDeviceModel(MakeModel(map[string]interface{}{
+		"kernel": "kernel-core18",
+		"base":   "core18",
+	}))
 	defer restore()
 
-	// use services-snap here to make sure services would be stopped/started appropriately
 	siKernel := snap.SideInfo{
-		RealName: "kernel",
+		RealName: "kernel-core18",
 		Revision: snap.R(7),
-		SnapID:   "kernel-id",
+		SnapID:   "kernel-core18-id",
 	}
 	siBase := snap.SideInfo{
 		RealName: "core18",
@@ -6942,9 +6944,9 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 
 	chg := s.state.NewChange("refresh", "refresh kernel and base")
 	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state,
-		[]string{"kernel", "core18"}, s.user.ID, &snapstate.Flags{})
+		[]string{"kernel-core18", "core18"}, s.user.ID, &snapstate.Flags{})
 	c.Assert(err, IsNil)
-	c.Assert(affected, DeepEquals, []string{"core18", "kernel"})
+	c.Assert(affected, DeepEquals, []string{"core18", "kernel-core18"})
 	snapTasks := make(map[string]*state.Task)
 	for _, ts := range tss {
 		chg.AddAll(ts)
@@ -6956,7 +6958,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 			case "link-snap", "auto-connect", "setup-profiles", "set-auto-aliases":
 				snapsup, err := snapstate.TaskSnapSetup(tsk)
 				c.Assert(err, IsNil)
-				snapTasks[fmt.Sprintf("%s@%s", tsk.Kind(), snapsup.InstanceName())] = tsk
+				snapTasks[fmt.Sprintf("%s@%s", tsk.Kind(), snapsup.Type)] = tsk
 				if tsk.Kind() == "link-snap" {
 					opts := 0
 					if snapsup.Type == snap.TypeBase {
@@ -6971,11 +6973,11 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	c.Assert(snapTasks, HasLen, 8)
 	linkSnapKernel := snapTasks["link-snap@kernel"]
 	autoConnectKernel := snapTasks["auto-connect@kernel"]
-	linkSnapBase := snapTasks["link-snap@core18"]
-	autoConnectBase := snapTasks["auto-connect@core18"]
+	linkSnapBase := snapTasks["link-snap@base"]
+	autoConnectBase := snapTasks["auto-connect@base"]
 
 	c.Assert(linkSnapBase.WaitTasks(), DeepEquals, []*state.Task{
-		snapTasks["setup-profiles@core18"], snapTasks["setup-profiles@kernel"],
+		snapTasks["setup-profiles@base"], snapTasks["setup-profiles@kernel"],
 	})
 	c.Assert(linkSnapKernel.WaitTasks(), DeepEquals, []*state.Task{
 		snapTasks["setup-profiles@kernel"], linkSnapBase,
@@ -6984,19 +6986,27 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 		snapTasks["link-snap@kernel"], autoConnectBase,
 	})
 	c.Assert(autoConnectBase.WaitTasks(), DeepEquals, []*state.Task{
-		snapTasks["link-snap@core18"], snapTasks["link-snap@kernel"],
+		snapTasks["link-snap@base"], snapTasks["link-snap@kernel"],
 	})
 	c.Assert(snapTasks["set-auto-aliases@kernel"].WaitTasks(), DeepEquals, []*state.Task{
 		autoConnectKernel,
 	})
-	c.Assert(snapTasks["set-auto-aliases@core18"].WaitTasks(), DeepEquals, []*state.Task{
+	c.Assert(snapTasks["set-auto-aliases@base"].WaitTasks(), DeepEquals, []*state.Task{
 		autoConnectBase, autoConnectKernel,
 	})
+
+	var cannotReboot bool
+	// link-snap of base cannot issue a reboot
+	c.Assert(linkSnapBase.Get("cannot-reboot", &cannotReboot), IsNil)
+	c.Assert(cannotReboot, Equals, true)
+	// but the link-snap of the kernel can issue a reboot
+	c.Assert(linkSnapKernel.Get("cannot-reboot", &cannotReboot), Equals, state.ErrNoState)
+
 	// have fake backend indicate a need to reboot for both snaps
 	s.fakeBackend.linkSnapMaybeReboot = true
 	s.fakeBackend.linkSnapRebootFor = map[string]bool{
-		"kernel": true,
-		"core18": true,
+		"kernel-core18": true,
+		"core18":        true,
 	}
 
 	defer s.se.Stop()
@@ -7008,8 +7018,8 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 		restart.RestartSystem,
 	})
 
-	for _, name := range []string{"kernel", "core18"} {
-		snapID := "kernel-id"
+	for _, name := range []string{"kernel-core18", "core18"} {
+		snapID := "kernel-core18-id"
 		if name == "core18" {
 			snapID = "core18-snap-id"
 		}
@@ -7049,15 +7059,145 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	}
 	c.Assert(ops, HasLen, 8)
 	c.Assert(ops[0:2], testutil.DeepUnsortedMatches, []string{
-		"setup-profiles:Doing-kernel/11", "setup-profiles:Doing-core18/11",
+		"setup-profiles:Doing-kernel-core18/11", "setup-profiles:Doing-core18/11",
 	})
 	c.Assert(ops[2:6], DeepEquals, []string{
-		"core18/11", "kernel/11",
-		"auto-connect:Doing-core18/11", "auto-connect:Doing-kernel/11",
+		"core18/11", "kernel-core18/11",
+		"auto-connect:Doing-core18/11", "auto-connect:Doing-kernel-core18/11",
 	})
 	c.Assert(ops[6:], testutil.DeepUnsortedMatches, []string{
-		"cleanup-trash-core18", "cleanup-trash-kernel",
+		"cleanup-trash-core18", "cleanup-trash-kernel-core18",
 	})
+}
+
+func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootNotWithCoreHappy(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+	restore = snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var restartRequested []restart.RestartType
+	restart.Init(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+		restartRequested = append(restartRequested, t)
+	}))
+
+	restore = snapstatetest.MockDeviceModel(DefaultModel())
+	defer restore()
+
+	siKernel := snap.SideInfo{
+		RealName: "kernel",
+		Revision: snap.R(7),
+		SnapID:   "kernel-id",
+	}
+	siCore := snap.SideInfo{
+		RealName: "core",
+		Revision: snap.R(7),
+		SnapID:   "core-snap-id",
+	}
+	for _, si := range []*snap.SideInfo{&siKernel, &siCore} {
+		snaptest.MockSnap(c, fmt.Sprintf(`name: %s`, si.RealName), si)
+		typ := "kernel"
+		if si.RealName == "core18" {
+			typ = "base"
+		}
+		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
+			Active:          true,
+			Sequence:        []*snap.SideInfo{si},
+			Current:         si.Revision,
+			TrackingChannel: "latest/stable",
+			SnapType:        typ,
+		})
+	}
+
+	chg := s.state.NewChange("refresh", "refresh kernel and base")
+	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state,
+		[]string{"kernel", "core"}, s.user.ID, &snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Assert(affected, DeepEquals, []string{"core", "kernel"})
+	snapTasks := make(map[string]*state.Task)
+	var coreTs *state.TaskSet
+	for _, ts := range tss {
+		chg.AddAll(ts)
+		for _, tsk := range ts.Tasks() {
+			switch tsk.Kind() {
+			// setup-profiles should appear right before link-snap
+			case "link-snap", "auto-connect", "setup-profiles":
+				snapsup, err := snapstate.TaskSnapSetup(tsk)
+				c.Assert(err, IsNil)
+				snapTasks[fmt.Sprintf("%s@%s", tsk.Kind(), snapsup.Type)] = tsk
+				if tsk.Kind() == "link-snap" {
+					opts := 0
+					if snapsup.Type == snap.TypeBase {
+						opts |= noConfigure
+					}
+					verifyUpdateTasks(c, snapsup.Type, opts, 0, ts)
+					if snapsup.Type == snap.TypeOS {
+						coreTs = ts
+					}
+				}
+			}
+		}
+	}
+
+	c.Assert(snapTasks, HasLen, 6)
+	linkSnapKernel := snapTasks["link-snap@kernel"]
+	autoConnectKernel := snapTasks["auto-connect@kernel"]
+	linkSnapBase := snapTasks["link-snap@os"]
+	autoConnectBase := snapTasks["auto-connect@os"]
+
+	c.Assert(coreTs, NotNil)
+
+	c.Assert(linkSnapBase.WaitTasks(), DeepEquals, []*state.Task{
+		snapTasks["setup-profiles@os"],
+	})
+	c.Assert(autoConnectBase.WaitTasks(), DeepEquals, []*state.Task{
+		snapTasks["link-snap@os"],
+	})
+	// kernel tasks have an implicit dependency on all "core" tasks
+	c.Assert(linkSnapKernel.WaitTasks(), DeepEquals, append([]*state.Task{
+		snapTasks["setup-profiles@kernel"],
+	}, coreTs.Tasks()...))
+	c.Assert(autoConnectKernel.WaitTasks(), DeepEquals, append([]*state.Task{
+		snapTasks["link-snap@kernel"],
+	}, coreTs.Tasks()...))
+	// have fake backend indicate a need to reboot for both snaps
+	s.fakeBackend.linkSnapMaybeReboot = true
+	s.fakeBackend.linkSnapRebootFor = map[string]bool{
+		"kernel": true,
+		"core":   true,
+	}
+
+	defer s.se.Stop()
+	s.settle(c)
+
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	// when updating both kernel that uses core as base, and "core" we have two reboots
+	c.Check(restartRequested, DeepEquals, []restart.RestartType{
+		restart.RestartSystem,
+		restart.RestartSystem,
+	})
+
+	for _, name := range []string{"kernel", "core"} {
+		snapID := "kernel-id"
+		if name == "core" {
+			snapID = "core-snap-id"
+		}
+		var snapst snapstate.SnapState
+		err = snapstate.Get(s.state, name, &snapst)
+		c.Assert(err, IsNil)
+
+		c.Assert(snapst.Active, Equals, true)
+		c.Assert(snapst.Sequence, HasLen, 2)
+		c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+			RealName: name,
+			Channel:  "latest/stable",
+			SnapID:   snapID,
+			Revision: snap.R(11),
+		})
+	}
 }
 
 func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUndone(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -55,7 +55,7 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-func verifyUpdateTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.State) {
+func verifyUpdateTasks(c *C, opts, discards int, ts *state.TaskSet) {
 	kinds := taskKinds(ts.Tasks())
 
 	expected := []string{
@@ -295,7 +295,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksWithOldCurrent(c *C) {
 	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 2, ts, s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 2, ts)
 
 	// and ensure that it will remove the revisions after "current"
 	// (si3, si4)
@@ -697,7 +697,7 @@ func (s *snapmgrTestSuite) TestUpdateTasks(c *C) {
 
 	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts, s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 
 	c.Check(validateCalled, Equals, true)
@@ -3398,7 +3398,7 @@ func (s *snapmgrTestSuite) TestUpdateAmend(c *C) {
 
 	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "channel-for-7"}, s.user.ID, snapstate.Flags{Amend: true})
 	c.Assert(err, IsNil)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts, s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts)
 
 	// ensure we go from local to store revision-7
 	var snapsup snapstate.SnapSetup
@@ -4102,7 +4102,7 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContext(c *C) {
 
 	ts, err := snapstate.UpdateWithDeviceContext(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{}, deviceCtx, "")
 	c.Assert(err, IsNil)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts, s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 
 	c.Check(validateCalled, Equals, true)
@@ -4133,7 +4133,7 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContextToRevision(c *C) {
 	opts := &snapstate.RevisionOptions{Channel: "some-channel", Revision: snap.R(11)}
 	ts, err := snapstate.UpdateWithDeviceContext(s.state, "some-snap", opts, 0, snapstate.Flags{}, deviceCtx, "")
 	c.Assert(err, IsNil)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts, s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
@@ -4425,7 +4425,7 @@ func (s *snapmgrTestSuite) testUpdateCreatesGCTasks(c *C, expectedDiscards int) 
 	c.Assert(te, NotNil)
 	c.Assert(err, IsNil)
 
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, expectedDiscards, ts, s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, expectedDiscards, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
@@ -4448,7 +4448,7 @@ func (s *snapmgrTestSuite) TestUpdateCreatesDiscardAfterCurrentTasks(c *C) {
 	ts, err := snapstate.Update(s.state, "some-snap", nil, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 3, ts, s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 3, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
@@ -4493,7 +4493,7 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 	c.Check(updates, DeepEquals, []string{"some-snap"})
 
 	ts := tts[0]
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 3, ts, s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 3, ts)
 
 	// check that the tasks are in non-default lane
 	for _, t := range ts.Tasks() {
@@ -4920,7 +4920,7 @@ func (s *snapmgrTestSuite) TestUpdateManyValidateRefreshes(c *C) {
 	c.Assert(tts, HasLen, 2)
 	verifyLastTasksetIsReRefresh(c, tts)
 	c.Check(updates, DeepEquals, []string{"some-snap"})
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, tts[0], s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, tts[0])
 
 	c.Check(validateCalled, Equals, true)
 }
@@ -4986,8 +4986,8 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateMany(c *C) {
 	c.Assert(snapsup.InstanceName(), Equals, "some-snap")
 	c.Assert(snapsupInstance.InstanceName(), Equals, "some-snap_instance")
 
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 3, tts[0], s.state)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 1, tts[1], s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 3, tts[0])
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 1, tts[1])
 }
 
 func (s *snapmgrTestSuite) TestParallelInstanceUpdateManyValidateRefreshes(c *C) {
@@ -5044,8 +5044,8 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateManyValidateRefreshes(c *C)
 	verifyLastTasksetIsReRefresh(c, tts)
 	sort.Strings(updates)
 	c.Check(updates, DeepEquals, []string{"some-snap", "some-snap_instance"})
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, tts[0], s.state)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, tts[1], s.state)
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, tts[0])
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, tts[1])
 
 	c.Check(validateCalled, Equals, true)
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6806,7 +6806,11 @@ func (s *snapmgrTestSuite) TestUpdatePrerequisiteBackwardsCompat(c *C) {
 	snapsup.PrereqContentAttrs = nil
 	prereqTask.Set("snap-setup", &snapsup)
 
+	defer s.se.Stop()
+	s.state.Unlock()
+	defer s.se.Stop()
 	s.settle(c)
+	s.state.Lock()
 
 	// the producer wasn't updated since there were no content attributes
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
@@ -6969,7 +6973,10 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	}
 
 	defer s.se.Stop()
+	s.state.Unlock()
+	defer s.se.Stop()
 	s.settle(c)
+	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 	// a single system restart was requested
@@ -7138,7 +7145,10 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 	}
 
 	defer s.se.Stop()
+	s.state.Unlock()
+	defer s.se.Stop()
 	s.settle(c)
+	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 	// when updating both kernel that uses core as base, and "core" we have two reboots
@@ -7254,7 +7264,10 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUndone(c *C) {
 	}
 
 	defer s.se.Stop()
+	s.state.Unlock()
+	defer s.se.Stop()
 	s.settle(c)
+	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
 	c.Check(chg.Err(), ErrorMatches, `(?s).*\(auto-connect-kernel mock error\)`)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2020 Canonical Ltd
+ * Copyright (C) 2016-2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -55,63 +55,10 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-func verifyUpdateTasks(c *C, opts, discards int, ts *state.TaskSet) {
+func verifyUpdateTasks(c *C, typ snap.Type, opts, discards int, ts *state.TaskSet) {
 	kinds := taskKinds(ts.Tasks())
 
-	expected := []string{
-		"prerequisites",
-		"download-snap",
-		"validate-snap",
-		"mount-snap",
-	}
-	expected = append(expected, "run-hook[pre-refresh]")
-	if opts&unlinkBefore != 0 {
-		expected = append(expected,
-			"stop-snap-services",
-		)
-	}
-	if opts&unlinkBefore != 0 {
-		expected = append(expected,
-			"remove-aliases",
-			"unlink-current-snap",
-		)
-	}
-	if opts&updatesGadget != 0 {
-		expected = append(expected,
-			"update-gadget-assets",
-			"update-gadget-cmdline")
-	}
-	expected = append(expected,
-		"copy-snap-data",
-		"setup-profiles",
-		"link-snap",
-	)
-	if opts&maybeCore != 0 {
-		expected = append(expected, "setup-profiles")
-	}
-	expected = append(expected,
-		"auto-connect",
-		"set-auto-aliases",
-		"setup-aliases",
-		"run-hook[post-refresh]",
-		"start-snap-services")
-
-	c.Assert(ts.Tasks()[len(expected)-2].Summary(), Matches, `Run post-refresh hook of .*`)
-	for i := 0; i < discards; i++ {
-		expected = append(expected,
-			"clear-snap",
-			"discard-snap",
-		)
-	}
-	if opts&cleanupAfter != 0 {
-		expected = append(expected,
-			"cleanup",
-		)
-	}
-	expected = append(expected,
-		"run-hook[configure]",
-		"run-hook[check-health]",
-	)
+	expected := expectedDoInstallTasks(typ, unlinkBefore|cleanupAfter|opts, discards)
 	if opts&doesReRefresh != 0 {
 		expected = append(expected, "check-rerefresh")
 	}
@@ -295,7 +242,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksWithOldCurrent(c *C) {
 	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 2, ts)
+	verifyUpdateTasks(c, snap.TypeApp, doesReRefresh, 2, ts)
 
 	// and ensure that it will remove the revisions after "current"
 	// (si3, si4)
@@ -697,7 +644,7 @@ func (s *snapmgrTestSuite) TestUpdateTasks(c *C) {
 
 	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts)
+	verifyUpdateTasks(c, snap.TypeApp, doesReRefresh, 0, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 
 	c.Check(validateCalled, Equals, true)
@@ -3398,7 +3345,7 @@ func (s *snapmgrTestSuite) TestUpdateAmend(c *C) {
 
 	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "channel-for-7"}, s.user.ID, snapstate.Flags{Amend: true})
 	c.Assert(err, IsNil)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts)
+	verifyUpdateTasks(c, snap.TypeApp, doesReRefresh, 0, ts)
 
 	// ensure we go from local to store revision-7
 	var snapsup snapstate.SnapSetup
@@ -4102,7 +4049,7 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContext(c *C) {
 
 	ts, err := snapstate.UpdateWithDeviceContext(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{}, deviceCtx, "")
 	c.Assert(err, IsNil)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts)
+	verifyUpdateTasks(c, snap.TypeApp, doesReRefresh, 0, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 
 	c.Check(validateCalled, Equals, true)
@@ -4133,7 +4080,7 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContextToRevision(c *C) {
 	opts := &snapstate.RevisionOptions{Channel: "some-channel", Revision: snap.R(11)}
 	ts, err := snapstate.UpdateWithDeviceContext(s.state, "some-snap", opts, 0, snapstate.Flags{}, deviceCtx, "")
 	c.Assert(err, IsNil)
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts)
+	verifyUpdateTasks(c, snap.TypeApp, doesReRefresh, 0, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
@@ -4425,7 +4372,7 @@ func (s *snapmgrTestSuite) testUpdateCreatesGCTasks(c *C, expectedDiscards int) 
 	c.Assert(te, NotNil)
 	c.Assert(err, IsNil)
 
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, expectedDiscards, ts)
+	verifyUpdateTasks(c, snap.TypeApp, doesReRefresh, expectedDiscards, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
@@ -4448,7 +4395,7 @@ func (s *snapmgrTestSuite) TestUpdateCreatesDiscardAfterCurrentTasks(c *C) {
 	ts, err := snapstate.Update(s.state, "some-snap", nil, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 3, ts)
+	verifyUpdateTasks(c, snap.TypeApp, doesReRefresh, 3, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
@@ -4493,7 +4440,7 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 	c.Check(updates, DeepEquals, []string{"some-snap"})
 
 	ts := tts[0]
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 3, ts)
+	verifyUpdateTasks(c, snap.TypeApp, 0, 3, ts)
 
 	// check that the tasks are in non-default lane
 	for _, t := range ts.Tasks() {
@@ -4920,7 +4867,7 @@ func (s *snapmgrTestSuite) TestUpdateManyValidateRefreshes(c *C) {
 	c.Assert(tts, HasLen, 2)
 	verifyLastTasksetIsReRefresh(c, tts)
 	c.Check(updates, DeepEquals, []string{"some-snap"})
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, tts[0])
+	verifyUpdateTasks(c, snap.TypeApp, 0, 0, tts[0])
 
 	c.Check(validateCalled, Equals, true)
 }
@@ -4986,8 +4933,8 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateMany(c *C) {
 	c.Assert(snapsup.InstanceName(), Equals, "some-snap")
 	c.Assert(snapsupInstance.InstanceName(), Equals, "some-snap_instance")
 
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 3, tts[0])
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 1, tts[1])
+	verifyUpdateTasks(c, snap.TypeApp, 0, 3, tts[0])
+	verifyUpdateTasks(c, snap.TypeApp, 0, 1, tts[1])
 }
 
 func (s *snapmgrTestSuite) TestParallelInstanceUpdateManyValidateRefreshes(c *C) {
@@ -5044,8 +4991,8 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateManyValidateRefreshes(c *C)
 	verifyLastTasksetIsReRefresh(c, tts)
 	sort.Strings(updates)
 	c.Check(updates, DeepEquals, []string{"some-snap", "some-snap_instance"})
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, tts[0])
-	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, tts[1])
+	verifyUpdateTasks(c, snap.TypeApp, 0, 0, tts[0])
+	verifyUpdateTasks(c, snap.TypeApp, 0, 0, tts[1])
 
 	c.Check(validateCalled, Equals, true)
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6912,15 +6912,15 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	}))
 
 	restore = snapstatetest.MockDeviceModel(MakeModel(map[string]interface{}{
-		"kernel": "kernel-core18",
+		"kernel": "kernel",
 		"base":   "core18",
 	}))
 	defer restore()
 
 	siKernel := snap.SideInfo{
-		RealName: "kernel-core18",
+		RealName: "kernel",
 		Revision: snap.R(7),
-		SnapID:   "kernel-core18-id",
+		SnapID:   "kernel-id",
 	}
 	siBase := snap.SideInfo{
 		RealName: "core18",
@@ -6944,9 +6944,9 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 
 	chg := s.state.NewChange("refresh", "refresh kernel and base")
 	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state,
-		[]string{"kernel-core18", "core18"}, s.user.ID, &snapstate.Flags{})
+		[]string{"kernel", "core18"}, s.user.ID, &snapstate.Flags{})
 	c.Assert(err, IsNil)
-	c.Assert(affected, DeepEquals, []string{"core18", "kernel-core18"})
+	c.Assert(affected, DeepEquals, []string{"core18", "kernel"})
 	snapTasks := make(map[string]*state.Task)
 	var kernelTs, baseTs *state.TaskSet
 	for _, ts := range tss {
@@ -7020,8 +7020,8 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	// have fake backend indicate a need to reboot for both snaps
 	s.fakeBackend.linkSnapMaybeReboot = true
 	s.fakeBackend.linkSnapRebootFor = map[string]bool{
-		"kernel-core18": true,
-		"core18":        true,
+		"kernel": true,
+		"core18": true,
 	}
 
 	defer s.se.Stop()
@@ -7033,8 +7033,8 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 		restart.RestartSystem,
 	})
 
-	for _, name := range []string{"kernel-core18", "core18"} {
-		snapID := "kernel-core18-id"
+	for _, name := range []string{"kernel", "core18"} {
+		snapID := "kernel-id"
 		if name == "core18" {
 			snapID = "core18-snap-id"
 		}
@@ -7074,14 +7074,14 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	}
 	c.Assert(ops, HasLen, 8)
 	c.Assert(ops[0:2], testutil.DeepUnsortedMatches, []string{
-		"setup-profiles:Doing-kernel-core18/11", "setup-profiles:Doing-core18/11",
+		"setup-profiles:Doing-kernel/11", "setup-profiles:Doing-core18/11",
 	})
 	c.Assert(ops[2:6], DeepEquals, []string{
-		"core18/11", "kernel-core18/11",
-		"auto-connect:Doing-core18/11", "auto-connect:Doing-kernel-core18/11",
+		"core18/11", "kernel/11",
+		"auto-connect:Doing-core18/11", "auto-connect:Doing-kernel/11",
 	})
 	c.Assert(ops[6:], testutil.DeepUnsortedMatches, []string{
-		"cleanup-trash-core18", "cleanup-trash-kernel-core18",
+		"cleanup-trash-core18", "cleanup-trash-kernel",
 	})
 }
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -7085,7 +7085,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootNotWithCoreHappy(c *C) {
+func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHappy(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 	restore = snapstate.MockRevisionDate(nil)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -2473,6 +2473,11 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 			name: "some-snap",
 		},
 		{
+			op:    "auto-connect:Undoing",
+			name:  "some-snap",
+			revno: snap.R(11),
+		},
+		{
 			op:   "unlink-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/11"),
 		},

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -44,6 +45,7 @@ import (
 	_ "github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -6816,4 +6818,370 @@ func (s *snapmgrTestSuite) TestUpdatePrerequisiteWithSameDeviceContext(c *C) {
 		{macaroon: s.user.StoreMacaroon, name: "outdated-consumer", target: filepath.Join(dirs.SnapBlobDir, "outdated-consumer_11.snap")},
 		{macaroon: s.user.StoreMacaroon, name: "outdated-producer", target: filepath.Join(dirs.SnapBlobDir, "outdated-producer_11.snap")},
 	})
+}
+
+func (s *snapmgrTestSuite) TestUpdatePrerequisiteBackwardsCompat(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "outdated-producer", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{{
+			RealName: "outdated-producer",
+			SnapID:   "outdated-producer-id",
+			Revision: snap.R(1),
+		}},
+		Current: snap.R(1),
+		Active:  true,
+	})
+	snapstate.Set(s.state, "outdated-consumer", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{{
+			RealName: "outdated-consumer",
+			SnapID:   "outdated-consumer-id",
+			Revision: snap.R(1),
+		}},
+		Current: snap.R(1),
+		Active:  true,
+	})
+
+	tasks, err := snapstate.Update(s.state, "outdated-consumer", nil, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Check(tasks, Not(HasLen), 0)
+	chg := s.state.NewChange("update", "test: update snap")
+	chg.AddAll(tasks)
+
+	prereqTask := findStrictlyOnePrereqTask(c, chg)
+
+	var snapsup snapstate.SnapSetup
+	err = prereqTask.Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+
+	// mimic a task serialized by an "old" snapd without PrereqContentAttrs
+	// The new code shouldn't update the prereq since it doesn't have the content attrs
+	snapsup.PrereqContentAttrs = nil
+	prereqTask.Set("snap-setup", &snapsup)
+
+	s.settle(c)
+
+	// the producer wasn't updated since there were no content attributes
+	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
+		{macaroon: s.user.StoreMacaroon, name: "outdated-consumer", target: filepath.Join(dirs.SnapBlobDir, "outdated-consumer_11.snap")},
+	})
+}
+
+func (s *snapmgrTestSuite) TestUpdateDeduplicatesSnapNames(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{{
+			RealName: "some-snap",
+			SnapID:   "some-snap-id",
+			Revision: snap.R(1),
+		}},
+		Current: snap.R(1),
+		Active:  true,
+	})
+
+	snapstate.Set(s.state, "some-base", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{{
+			RealName: "some-base",
+			SnapID:   "some-base-id",
+			Revision: snap.R(1),
+		}},
+		Current: snap.R(1),
+		Active:  true,
+	})
+
+	updated, _, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap", "some-base", "some-snap", "some-base"}, s.user.ID, nil)
+	c.Assert(err, IsNil)
+	c.Check(updated, testutil.DeepUnsortedMatches, []string{"some-snap", "some-base"})
+}
+
+func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+	restore = snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var restartRequested []restart.RestartType
+	restart.Init(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+		restartRequested = append(restartRequested, t)
+	}))
+
+	restore = snapstatetest.MockDeviceModel(ModelWithBase("core18"))
+	defer restore()
+
+	// use services-snap here to make sure services would be stopped/started appropriately
+	siKernel := snap.SideInfo{
+		RealName: "kernel",
+		Revision: snap.R(7),
+		SnapID:   "kernel-id",
+	}
+	siBase := snap.SideInfo{
+		RealName: "core18",
+		Revision: snap.R(7),
+		SnapID:   "core18-snap-id",
+	}
+	for _, si := range []*snap.SideInfo{&siKernel, &siBase} {
+		snaptest.MockSnap(c, fmt.Sprintf(`name: %s`, si.RealName), si)
+		typ := "kernel"
+		if si.RealName == "core18" {
+			typ = "base"
+		}
+		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
+			Active:          true,
+			Sequence:        []*snap.SideInfo{si},
+			Current:         si.Revision,
+			TrackingChannel: "latest/stable",
+			SnapType:        typ,
+		})
+	}
+
+	chg := s.state.NewChange("refresh", "refresh kernel and base")
+	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state,
+		[]string{"kernel", "core18"}, s.user.ID, &snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Assert(affected, DeepEquals, []string{"core18", "kernel"})
+	snapTasks := make(map[string]*state.Task)
+	for _, ts := range tss {
+		chg.AddAll(ts)
+		for _, tsk := range ts.Tasks() {
+			switch tsk.Kind() {
+			// setup-profiles should appear right before link-snap,
+			// while set-auto-aliase appears right after
+			// auto-connect
+			case "link-snap", "auto-connect", "setup-profiles", "set-auto-aliases":
+				snapsup, err := snapstate.TaskSnapSetup(tsk)
+				c.Assert(err, IsNil)
+				snapTasks[fmt.Sprintf("%s@%s", tsk.Kind(), snapsup.InstanceName())] = tsk
+				if tsk.Kind() == "link-snap" {
+					opts := 0
+					if snapsup.Type == snap.TypeBase {
+						opts |= noConfigure
+					}
+					verifyUpdateTasks(c, snapsup.Type, opts, 0, ts)
+				}
+			}
+		}
+	}
+
+	c.Assert(snapTasks, HasLen, 8)
+	linkSnapKernel := snapTasks["link-snap@kernel"]
+	autoConnectKernel := snapTasks["auto-connect@kernel"]
+	linkSnapBase := snapTasks["link-snap@core18"]
+	autoConnectBase := snapTasks["auto-connect@core18"]
+
+	c.Assert(linkSnapBase.WaitTasks(), DeepEquals, []*state.Task{
+		snapTasks["setup-profiles@core18"], snapTasks["setup-profiles@kernel"],
+	})
+	c.Assert(linkSnapKernel.WaitTasks(), DeepEquals, []*state.Task{
+		snapTasks["setup-profiles@kernel"], linkSnapBase,
+	})
+	c.Assert(autoConnectKernel.WaitTasks(), DeepEquals, []*state.Task{
+		snapTasks["link-snap@kernel"], autoConnectBase,
+	})
+	c.Assert(autoConnectBase.WaitTasks(), DeepEquals, []*state.Task{
+		snapTasks["link-snap@core18"], snapTasks["link-snap@kernel"],
+	})
+	c.Assert(snapTasks["set-auto-aliases@kernel"].WaitTasks(), DeepEquals, []*state.Task{
+		autoConnectKernel,
+	})
+	c.Assert(snapTasks["set-auto-aliases@core18"].WaitTasks(), DeepEquals, []*state.Task{
+		autoConnectBase, autoConnectKernel,
+	})
+	// have fake backend indicate a need to reboot for both snaps
+	s.fakeBackend.linkSnapMaybeReboot = true
+	s.fakeBackend.linkSnapRebootFor = map[string]bool{
+		"kernel": true,
+		"core18": true,
+	}
+
+	defer s.se.Stop()
+	s.settle(c)
+
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	// a single system restart was requested
+	c.Check(restartRequested, DeepEquals, []restart.RestartType{
+		restart.RestartSystem,
+	})
+
+	for _, name := range []string{"kernel", "core18"} {
+		snapID := "kernel-id"
+		if name == "core18" {
+			snapID = "core18-snap-id"
+		}
+		var snapst snapstate.SnapState
+		err = snapstate.Get(s.state, name, &snapst)
+		c.Assert(err, IsNil)
+
+		c.Assert(snapst.Active, Equals, true)
+		c.Assert(snapst.Sequence, HasLen, 2)
+		c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+			RealName: name,
+			SnapID:   snapID,
+			Channel:  "",
+			Revision: snap.R(7),
+		})
+		c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+			RealName: name,
+			Channel:  "latest/stable",
+			SnapID:   snapID,
+			Revision: snap.R(11),
+		})
+	}
+
+	// ops come in semi random order, but we know that link and auto-connect
+	// operations will be done in a specific order,
+	ops := make([]string, 0, 8)
+	for _, op := range s.fakeBackend.ops {
+		if op.op == "link-snap" {
+			split := strings.Split(op.path, "/")
+			c.Assert(len(split) > 2, Equals, true)
+			ops = append(ops, filepath.Join(split[len(split)-2:]...))
+		} else if op.op == "cleanup-trash" {
+			ops = append(ops, fmt.Sprintf("%s-%s", op.op, op.name))
+		} else if strings.HasPrefix(op.op, "auto-connect:") || strings.HasPrefix(op.op, "setup-profiles:") {
+			ops = append(ops, fmt.Sprintf("%s-%s/%s", op.op, op.name, op.revno))
+		}
+	}
+	c.Assert(ops, HasLen, 8)
+	c.Assert(ops[0:2], testutil.DeepUnsortedMatches, []string{
+		"setup-profiles:Doing-kernel/11", "setup-profiles:Doing-core18/11",
+	})
+	c.Assert(ops[2:6], DeepEquals, []string{
+		"core18/11", "kernel/11",
+		"auto-connect:Doing-core18/11", "auto-connect:Doing-kernel/11",
+	})
+	c.Assert(ops[6:], testutil.DeepUnsortedMatches, []string{
+		"cleanup-trash-core18", "cleanup-trash-kernel",
+	})
+}
+
+func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUndone(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+	restore = snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var restartRequested []restart.RestartType
+	restart.Init(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+		restartRequested = append(restartRequested, t)
+	}))
+
+	restore = snapstatetest.MockDeviceModel(ModelWithBase("core18"))
+	defer restore()
+
+	// use services-snap here to make sure services would be stopped/started appropriately
+	siKernel := snap.SideInfo{
+		RealName: "kernel",
+		Revision: snap.R(7),
+		SnapID:   "kernel-id",
+	}
+	siBase := snap.SideInfo{
+		RealName: "core18",
+		Revision: snap.R(7),
+		SnapID:   "core18-snap-id",
+	}
+	for _, si := range []*snap.SideInfo{&siKernel, &siBase} {
+		snaptest.MockSnap(c, fmt.Sprintf(`name: %s`, si.RealName), si)
+		typ := "kernel"
+		if si.RealName == "core18" {
+			typ = "base"
+		}
+		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
+			Active:          true,
+			Sequence:        []*snap.SideInfo{si},
+			Current:         si.Revision,
+			TrackingChannel: "latest/stable",
+			SnapType:        typ,
+		})
+	}
+
+	chg := s.state.NewChange("refresh", "refresh kernel and base")
+	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state,
+		[]string{"kernel", "core18"}, s.user.ID, &snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Assert(affected, DeepEquals, []string{"core18", "kernel"})
+	var autoConnectBase, autoConnectKernel *state.Task
+	for _, ts := range tss {
+		chg.AddAll(ts)
+		for _, tsk := range ts.Tasks() {
+			if tsk.Kind() == "auto-connect" {
+				snapsup, err := snapstate.TaskSnapSetup(tsk)
+				c.Assert(err, IsNil)
+				if snapsup.Type == "kernel" {
+					autoConnectKernel = tsk
+				} else {
+					autoConnectBase = tsk
+				}
+				break
+			}
+		}
+	}
+	// verify auto connect of kernel waits for base
+	waitsForBase := false
+	for _, tsk := range autoConnectKernel.WaitTasks() {
+		if tsk == autoConnectBase {
+			waitsForBase = true
+		}
+	}
+	c.Assert(waitsForBase, Equals, true, Commentf("auto-connect of kernel does not wait for base"))
+
+	// have fake backend indicate a need to reboot for both snaps
+	s.fakeBackend.linkSnapMaybeReboot = true
+	s.fakeBackend.linkSnapRebootFor = map[string]bool{
+		"kernel": true,
+		"core18": true,
+	}
+	errInjected := 0
+	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
+		if op.op == "auto-connect:Doing" && op.name == "kernel" {
+			errInjected++
+			return fmt.Errorf("auto-connect-kernel mock error")
+		}
+		return nil
+	}
+
+	defer s.se.Stop()
+	s.settle(c)
+
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches, `(?s).*\(auto-connect-kernel mock error\)`)
+	c.Check(restartRequested, DeepEquals, []restart.RestartType{
+		// do path
+		restart.RestartSystem,
+		// undo
+		restart.RestartSystem,
+		restart.RestartSystem,
+	})
+	c.Check(errInjected, Equals, 1)
+
+	// ops come in semi random order, but we know that link and auto-connect
+	// operations will be done in a specific order,
+	ops := make([]string, 0, 7)
+	for _, op := range s.fakeBackend.ops {
+		if op.op == "link-snap" {
+			split := strings.Split(op.path, "/")
+			c.Assert(len(split) > 2, Equals, true)
+			ops = append(ops, filepath.Join(split[len(split)-2:]...))
+		} else if strings.HasPrefix(op.op, "auto-connect:") {
+			ops = append(ops, fmt.Sprintf("%s-%s/%s", op.op, op.name, op.revno))
+		}
+	}
+	c.Assert(ops, HasLen, 7)
+	c.Assert(ops[0:5], DeepEquals, []string{
+		// link snaps
+		"core18/11", "kernel/11",
+		"auto-connect:Doing-core18/11",
+		"auto-connect:Doing-kernel/11", // fails
+		"auto-connect:Undoing-core18/11",
+	})
+	// those run unordered
+	c.Assert(ops[5:], testutil.DeepUnsortedMatches, []string{"core18/7", "kernel/7"})
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6948,6 +6948,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"core18", "kernel-core18"})
 	snapTasks := make(map[string]*state.Task)
+	var kernelTs, baseTs *state.TaskSet
 	for _, ts := range tss {
 		chg.AddAll(ts)
 		for _, tsk := range ts.Tasks() {
@@ -6963,6 +6964,9 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 					opts := 0
 					if snapsup.Type == snap.TypeBase {
 						opts |= noConfigure
+						baseTs = ts
+					} else if snapsup.Type == snap.TypeKernel {
+						kernelTs = ts
 					}
 					verifyUpdateTasks(c, snapsup.Type, opts, 0, ts)
 				}
@@ -6975,6 +6979,17 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	autoConnectKernel := snapTasks["auto-connect@kernel"]
 	linkSnapBase := snapTasks["link-snap@base"]
 	autoConnectBase := snapTasks["auto-connect@base"]
+	c.Assert(kernelTs, NotNil)
+	c.Assert(baseTs, NotNil)
+	c.Assert(kernelTs.MaybeEdge(snapstate.BeforeMaybeRebootEdge), Equals, snapTasks["setup-profiles@kernel"])
+	c.Assert(kernelTs.MaybeEdge(snapstate.MaybeRebootEdge), Equals, linkSnapKernel)
+	c.Assert(kernelTs.MaybeEdge(snapstate.MaybeRebootWaitEdge), Equals, autoConnectKernel)
+	c.Assert(kernelTs.MaybeEdge(snapstate.AfterMaybeRebootWaitEdge), Equals, snapTasks["set-auto-aliases@kernel"])
+
+	c.Assert(baseTs.MaybeEdge(snapstate.BeforeMaybeRebootEdge), Equals, snapTasks["setup-profiles@base"])
+	c.Assert(baseTs.MaybeEdge(snapstate.MaybeRebootEdge), Equals, linkSnapBase)
+	c.Assert(baseTs.MaybeEdge(snapstate.MaybeRebootWaitEdge), Equals, autoConnectBase)
+	c.Assert(baseTs.MaybeEdge(snapstate.AfterMaybeRebootWaitEdge), Equals, snapTasks["set-auto-aliases@base"])
 
 	c.Assert(linkSnapBase.WaitTasks(), DeepEquals, []*state.Task{
 		snapTasks["setup-profiles@base"], snapTasks["setup-profiles@kernel"],
@@ -7118,35 +7133,45 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootNotWithCoreHappy(c *C
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"core", "kernel"})
 	snapTasks := make(map[string]*state.Task)
-	var coreTs *state.TaskSet
+	var kernelTs, coreTs *state.TaskSet
 	for _, ts := range tss {
 		chg.AddAll(ts)
 		for _, tsk := range ts.Tasks() {
 			switch tsk.Kind() {
 			// setup-profiles should appear right before link-snap
-			case "link-snap", "auto-connect", "setup-profiles":
+			case "link-snap", "auto-connect", "setup-profiles", "set-auto-aliases":
 				snapsup, err := snapstate.TaskSnapSetup(tsk)
 				c.Assert(err, IsNil)
 				snapTasks[fmt.Sprintf("%s@%s", tsk.Kind(), snapsup.Type)] = tsk
 				if tsk.Kind() == "link-snap" {
 					opts := 0
-					if snapsup.Type == snap.TypeBase {
-						opts |= noConfigure
-					}
 					verifyUpdateTasks(c, snapsup.Type, opts, 0, ts)
 					if snapsup.Type == snap.TypeOS {
 						coreTs = ts
+					} else if snapsup.Type == snap.TypeKernel {
+						kernelTs = ts
 					}
 				}
 			}
 		}
 	}
 
-	c.Assert(snapTasks, HasLen, 6)
+	c.Assert(snapTasks, HasLen, 8)
 	linkSnapKernel := snapTasks["link-snap@kernel"]
 	autoConnectKernel := snapTasks["auto-connect@kernel"]
 	linkSnapBase := snapTasks["link-snap@os"]
 	autoConnectBase := snapTasks["auto-connect@os"]
+	c.Assert(kernelTs, NotNil)
+	c.Assert(coreTs, NotNil)
+	c.Assert(kernelTs.MaybeEdge(snapstate.BeforeMaybeRebootEdge), Equals, snapTasks["setup-profiles@kernel"])
+	c.Assert(kernelTs.MaybeEdge(snapstate.MaybeRebootEdge), Equals, linkSnapKernel)
+	c.Assert(kernelTs.MaybeEdge(snapstate.MaybeRebootWaitEdge), Equals, autoConnectKernel)
+	c.Assert(kernelTs.MaybeEdge(snapstate.AfterMaybeRebootWaitEdge), Equals, snapTasks["set-auto-aliases@kernel"])
+
+	c.Assert(coreTs.MaybeEdge(snapstate.BeforeMaybeRebootEdge), Equals, snapTasks["setup-profiles@os"])
+	c.Assert(coreTs.MaybeEdge(snapstate.MaybeRebootEdge), Equals, linkSnapBase)
+	c.Assert(coreTs.MaybeEdge(snapstate.MaybeRebootWaitEdge), Equals, autoConnectBase)
+	c.Assert(coreTs.MaybeEdge(snapstate.AfterMaybeRebootWaitEdge), Equals, snapTasks["set-auto-aliases@os"])
 
 	c.Assert(coreTs, NotNil)
 

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -344,7 +344,7 @@ func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 	}
 }
 
-func (ts *taskRunnerSuite) TestAbortAcrossLanes(c *C) {
+func (ts *taskRunnerSuite) TestAbortAcrossLanesDescendantTask(c *C) {
 
 	// <task>(<lane>)
 	//  t11(1) -> t12(1)                                                  => t15(1)
@@ -444,6 +444,101 @@ func (ts *taskRunnerSuite) TestAbortAcrossLanes(c *C) {
 		"t24:undo", "t23:undo", "t14:undo", "t13:undo",
 	})
 	c.Assert(sequence[15:19], testutil.DeepUnsortedMatches, []string{
+		"t21:undo", "t22:undo",
+		"t12:undo", "t11:undo",
+	})
+}
+
+func (ts *taskRunnerSuite) TestAbortAcrossLanesStriclyOrderedTasks(c *C) {
+
+	// <task>(<lane>)
+	//  t11(1) -> t12(1)
+	//                   \
+	//                    => t13(1,2) => t14(1,2) => t23(1,2) => t24(1,2)
+	//                   /
+	//  t21(2) -> t22(2)
+	//
+	names := strings.Fields("t11 t12 t13 t14 t21 t22 t23 t24")
+
+	sb := &stateBackend{}
+	st := state.New(sb)
+	r := state.NewTaskRunner(st)
+	defer r.Stop()
+
+	st.Lock()
+	defer st.Unlock()
+
+	c.Assert(len(st.Tasks()), Equals, 0)
+
+	chg := st.NewChange("install", "...")
+	tasks := make(map[string]*state.Task)
+	for _, name := range names {
+		tasks[name] = st.NewTask("do", name)
+		chg.AddTask(tasks[name])
+	}
+	tasks["t12"].WaitFor(tasks["t11"])
+	tasks["t13"].WaitFor(tasks["t12"])
+	tasks["t14"].WaitFor(tasks["t13"])
+	for lane, names := range map[int][]string{
+		1: {"t11", "t12", "t13", "t14", "t23", "t24"},
+		2: {"t21", "t22", "t23", "t24", "t13", "t14"},
+	} {
+		for _, name := range names {
+			tasks[name].JoinLane(lane)
+		}
+	}
+
+	tasks["t22"].WaitFor(tasks["t21"])
+	tasks["t23"].WaitFor(tasks["t22"])
+	tasks["t24"].WaitFor(tasks["t23"])
+
+	tasks["t13"].WaitFor(tasks["t22"])
+	tasks["t23"].WaitFor(tasks["t14"])
+
+	ch := make(chan string, 256)
+	do := func(task *state.Task, tomb *tomb.Tomb) error {
+		c.Logf("do %q", task.Summary())
+		label := task.Summary()
+		if label == "t24" {
+			ch <- fmt.Sprintf("t24:error")
+			return fmt.Errorf("mock error")
+		}
+		ch <- fmt.Sprintf("%s:do", label)
+		return nil
+	}
+	undo := func(task *state.Task, tomb *tomb.Tomb) error {
+		c.Logf("undo %q", task.Summary())
+		label := task.Summary()
+		ch <- fmt.Sprintf("%s:undo", label)
+		return nil
+	}
+	r.AddHandler("do", do, undo)
+
+	c.Logf("-----")
+
+	st.Unlock()
+	ensureChange(c, r, sb, chg)
+	st.Lock()
+	close(ch)
+	var sequence []string
+	for event := range ch {
+		sequence = append(sequence, event)
+	}
+	for _, name := range names {
+		task := tasks[name]
+		c.Logf("%5s %5s lanes: %v status: %v", task.ID(), task.Summary(), task.Lanes(), task.Status())
+	}
+	c.Assert(sequence[:4], testutil.DeepUnsortedMatches, []string{
+		"t11:do", "t12:do",
+		"t21:do", "t22:do",
+	})
+	c.Assert(sequence[4:8], DeepEquals, []string{
+		"t13:do", "t14:do", "t23:do", "t24:error",
+	})
+	c.Assert(sequence[8:11], DeepEquals, []string{
+		"t23:undo", "t14:undo", "t13:undo",
+	})
+	c.Assert(sequence[11:], testutil.DeepUnsortedMatches, []string{
 		"t21:undo", "t22:undo",
 		"t12:undo", "t11:undo",
 	})

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type taskRunnerSuite struct{}
@@ -341,6 +342,111 @@ func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 		comment := Commentf("calls: %s", test.result)
 		c.Assert(strings.Join(gotStatus, " "), Equals, strings.Join(wantStatus, " "), comment)
 	}
+}
+
+func (ts *taskRunnerSuite) TestAbortAcrossLanes(c *C) {
+
+	// <task>(<lane>)
+	//  t11(1) -> t12(1)                                                  => t15(1)
+	//                   \                                               /
+	//                    => t13(1,2) => t14(1,2) => t23(1,2) => t24(1,2)
+	//                   /                                               \
+	//  t21(2) -> t22(2)                                                  => t25(2)
+	//
+	names := strings.Fields("t11 t12 t13 t14 t15 t21 t22 t23 t24 t25")
+
+	sb := &stateBackend{}
+	st := state.New(sb)
+	r := state.NewTaskRunner(st)
+	defer r.Stop()
+
+	st.Lock()
+	defer st.Unlock()
+
+	c.Assert(len(st.Tasks()), Equals, 0)
+
+	chg := st.NewChange("install", "...")
+	tasks := make(map[string]*state.Task)
+	for _, name := range names {
+		tasks[name] = st.NewTask("do", name)
+		chg.AddTask(tasks[name])
+	}
+	tasks["t12"].WaitFor(tasks["t11"])
+	tasks["t13"].WaitFor(tasks["t12"])
+	tasks["t14"].WaitFor(tasks["t13"])
+	tasks["t15"].WaitFor(tasks["t14"])
+	for lane, names := range map[int][]string{
+		1: {"t11", "t12", "t13", "t14", "t15", "t23", "t24"},
+		2: {"t21", "t22", "t23", "t24", "t25", "t13", "t14"},
+	} {
+		for _, name := range names {
+			tasks[name].JoinLane(lane)
+		}
+	}
+
+	tasks["t22"].WaitFor(tasks["t21"])
+	tasks["t23"].WaitFor(tasks["t22"])
+	tasks["t24"].WaitFor(tasks["t23"])
+	tasks["t25"].WaitFor(tasks["t24"])
+
+	tasks["t13"].WaitFor(tasks["t22"])
+	tasks["t15"].WaitFor(tasks["t24"])
+	tasks["t23"].WaitFor(tasks["t14"])
+
+	ch := make(chan string, 256)
+	do := func(task *state.Task, tomb *tomb.Tomb) error {
+		c.Logf("do %q", task.Summary())
+		label := task.Summary()
+		if label == "t15" {
+			ch <- fmt.Sprintf("t15:error")
+			return fmt.Errorf("mock error")
+		}
+		ch <- fmt.Sprintf("%s:do", label)
+		return nil
+	}
+	undo := func(task *state.Task, tomb *tomb.Tomb) error {
+		c.Logf("undo %q", task.Summary())
+		label := task.Summary()
+		ch <- fmt.Sprintf("%s:undo", label)
+		return nil
+	}
+	r.AddHandler("do", do, undo)
+
+	c.Logf("-----")
+
+	st.Unlock()
+	ensureChange(c, r, sb, chg)
+	st.Lock()
+	close(ch)
+	var sequence []string
+	for event := range ch {
+		sequence = append(sequence, event)
+	}
+	for _, name := range names {
+		task := tasks[name]
+		c.Logf("%5s %5s lanes: %v status: %v", task.ID(), task.Summary(), task.Lanes(), task.Status())
+	}
+	c.Assert(sequence[:4], testutil.DeepUnsortedMatches, []string{
+		"t11:do", "t12:do",
+		"t21:do", "t22:do",
+	})
+	c.Assert(sequence[4:8], DeepEquals, []string{
+		"t13:do", "t14:do", "t23:do", "t24:do",
+	})
+	c.Assert(sequence[8:10], testutil.DeepUnsortedMatches, []string{
+		"t25:do",
+		"t15:error",
+	})
+	c.Assert(sequence[10:11], testutil.DeepUnsortedMatches, []string{
+		"t25:undo",
+	})
+	c.Assert(sequence[11:15], DeepEquals, []string{
+		"t24:undo", "t23:undo", "t14:undo", "t13:undo",
+	})
+	c.Assert(sequence[15:19], testutil.DeepUnsortedMatches, []string{
+		"t21:undo", "t22:undo",
+		"t12:undo", "t11:undo",
+	})
 }
 
 func (ts *taskRunnerSuite) TestExternalAbort(c *C) {

--- a/tests/core/kernel-and-base-single-reboot-failover/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot-failover/task.yaml
@@ -1,0 +1,117 @@
+summary: Exercises a simultaneous kernel and base refresh with a single reboot
+
+# TODO make the test work with ubuntu-core-20
+systems: [ubuntu-core-18-*]
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+
+    setup_fake_store "$BLOB_DIR"
+
+    readlink /snap/pc-kernel/current > pc-kernel.rev
+    readlink "/snap/core18/current" > core.rev
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    teardown_fake_store "$BLOB_DIR"
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        # break the pc-kernel snap
+        unsquashfs -d pc-kernel-snap /var/lib/snapd/snaps/pc-kernel_*.snap
+        truncate -s 0 pc-kernel-snap/initrd.img
+
+        init_fake_refreshes "$BLOB_DIR" pc-kernel --snap-blob "$PWD/pc-kernel-snap"
+        init_fake_refreshes "$BLOB_DIR" core18
+
+        # taken from transition_to_recover_mode()
+        cp /bin/systemctl /tmp/orig-systemctl
+        mount -o bind "$TESTSLIB/mock-shutdown" /bin/systemctl
+        tests.cleanup defer umount /bin/systemctl
+
+        snap refresh --no-wait core18 pc-kernel > refresh-change-id
+        test -n "$(cat refresh-change-id)"
+        change_id="$(cat refresh-change-id)"
+        # wait until we observe reboots
+        # shellcheck disable=SC2016
+        retry -n 100 --wait 5 sh -c 'test "$(wc -l < /tmp/mock-shutdown.calls)" -gt "1"'
+        # stop snapd now to avoid snapd waiting for too long and deciding to
+        # error out assuming a rollback across reboot
+        systemctl stop snapd.service snapd.socket
+
+        # both link snaps should be done now, snapd was stopped, so we cannot
+        # use 'snap change' and we need to inspect the state directly (even if
+        # snapd was up, it would not respond to API requests as it would be busy
+        # retrying auto-connect)
+        snap debug state --change "$change_id" /var/lib/snapd/state.json > tasks.state
+        # both link snaps are done
+        MATCH ' Done\s+.*Make snap "pc-kernel" .* available' < tasks.state
+        MATCH ' Done\s+.*Make snap "core18" .* available' < tasks.state
+        # auto-connect of the base is in doing and waiting for reboot
+        MATCH ' Doing\s+.*Automatically connect eligible plugs and slots of snap "core18"' < tasks.state
+        # auto-connect of the kernel is still queued
+        MATCH ' Do\s+.*Automatically connect eligible plugs and slots of snap "pc-kernel"' < tasks.state
+
+        snap debug boot-vars > boot-vars.dump
+        MATCH 'snap_mode=try' < boot-vars.dump
+        MATCH 'snap_try_core=core18_.*.snap' < boot-vars.dump
+        MATCH 'snap_try_kernel=pc-kernel_.*.snap' < boot-vars.dump
+
+        # restore shutdown so that spread can reboot the host
+        tests.cleanup pop
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 1 ]; then
+        change_id="$(cat refresh-change-id)"
+        # we expect the change to have failed due to the kernel not booting
+        # properly
+        snap watch "$change_id" || true
+        snap changes | MATCH "$change_id\s+Error"
+        snap change "$change_id" > tasks.done
+        # both link snaps were undone
+        MATCH 'Undone\s+.*Make snap "pc-kernel" .* available' < tasks.done
+        MATCH 'Undone\s+.*Make snap "core18" .* available' < tasks.done
+
+        # boot variables should have been cleared
+        snap debug boot-vars > boot-vars.dump
+        MATCH 'snap_mode=$' < boot-vars.dump
+        MATCH 'snap_try_core=$' < boot-vars.dump
+        MATCH 'snap_try_kernel=$' < boot-vars.dump
+
+        # make sure the system is in stable state, no pending reboots
+        # XXX systemctl exits with non-0 when in degraded state
+        (systemctl is-system-running || true) | MATCH '(running|degraded)'
+
+        # we're expecting the old revisions to be back
+        expecting_kernel="$(cat pc-kernel.rev)"
+        expecting_core="$(cat core.rev)"
+
+        # verify that current points to old revisions
+        test "$(readlink /snap/pc-kernel/current)" = "$expecting_kernel"
+        test "$(readlink /snap/core18/current)" = "$expecting_core"
+    else
+        echo "unexpected reboot"
+        exit 1
+    fi

--- a/tests/core/kernel-and-base-single-reboot/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot/task.yaml
@@ -1,0 +1,145 @@
+summary: Exercises a simultaneous kernel and base refresh with a single reboot
+
+# TODO make the test work with ubuntu-core-20
+systems: [ubuntu-core-18-*]
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+
+    setup_fake_store "$BLOB_DIR"
+
+    core_snap=core20
+    if os.query is-core18; then
+        core_snap=core18
+    fi
+    readlink /snap/pc-kernel/current > pc-kernel.rev
+    readlink "/snap/$core_snap/current" > core.rev
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    teardown_fake_store "$BLOB_DIR"
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+
+    core_snap=core20
+    if os.query is-core18; then
+        core_snap=core18
+    fi
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        init_fake_refreshes "$BLOB_DIR" pc-kernel
+        init_fake_refreshes "$BLOB_DIR" "$core_snap"
+
+        # taken from transition_to_recover_mode()
+        cp /bin/systemctl /tmp/orig-systemctl
+        mount -o bind "$TESTSLIB/mock-shutdown" /bin/systemctl
+        tests.cleanup defer umount /bin/systemctl
+
+        snap refresh --no-wait "$core_snap" pc-kernel > refresh-change-id
+        test -n "$(cat refresh-change-id)"
+        change_id="$(cat refresh-change-id)"
+        # wait until we observe reboots
+        # shellcheck disable=SC2016
+        retry -n 100 --wait 5 sh -c 'test "$(wc -l < /tmp/mock-shutdown.calls)" -gt "1"'
+        # stop snapd now to avoid snapd waiting for too long and deciding to
+        # error out assuming a rollback across reboot
+        systemctl stop snapd.service snapd.socket
+
+        # both link snaps should be done now, snapd was stopped, so we cannot
+        # use 'snap change' and we need to inspect the state directly (even if
+        # snapd was up, it would not respond to API requests as it would be busy
+        # retrying auto-connect)
+        snap debug state --change "$change_id" /var/lib/snapd/state.json > tasks.state
+        # both link snaps are done
+        MATCH ' Done\s+.*Make snap "pc-kernel" .* available' < tasks.state
+        MATCH " Done\s+.*Make snap \"$core_snap\" .* available" < tasks.state
+        # auto-connect of the base is in doing and waiting for reboot
+        MATCH " Doing\s+.*Automatically connect eligible plugs and slots of snap \"$core_snap\"" < tasks.state
+        # auto-connect of the kernel is still queued
+        MATCH ' Do\s+.*Automatically connect eligible plugs and slots of snap "pc-kernel"' < tasks.state
+
+        if os.query is-core18; then
+            snap debug boot-vars > boot-vars.dump
+            MATCH 'snap_mode=try' < boot-vars.dump
+            MATCH 'snap_try_core=core18_.*.snap' < boot-vars.dump
+            MATCH 'snap_try_kernel=pc-kernel_.*.snap' < boot-vars.dump
+        elif os.query is-core20; then
+            stat /boot/grub/kernel.efi | MATCH 'pc_kernel.*.snap/kernel.efi'
+            stat -L /boot/grub/kernel.efi
+            stat /boot/grub/try-kernel.efi | MATCH 'pc_kernel.*.snap/kernel.efi'
+            stat -L /boot/grub/try-kernel.efi
+        else
+            echo "unsupported Ubuntu Core system"
+            exit 1
+        fi
+
+        # restore shutdown so that spread can reboot the host
+        tests.cleanup pop
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 1 ]; then
+        change_id="$(cat refresh-change-id)"
+        # XXX: is this sufficiently robust?
+        snap watch "$change_id" || true
+        snap changes | MATCH "$change_id\s+(Done|Error)"
+        # we expect re-refresh to fail since the tests uses a fake store
+        snap change "$change_id" > tasks.done
+        MATCH '^Error .* Handling re-refresh' < tasks.done
+        # no other errors
+        grep -v 'Handling re-refresh' < tasks.done | NOMATCH '^Error'
+        # nothing was undone
+        grep -v 'Handling re-refresh' < tasks.done | NOMATCH '^Undone'
+        # we did not even try to hijack shutdown (/bin/systemctl) because that
+        # could race with snapd (if that wanted to call it), so just check that
+        # the system is in a stable state once we have already determined that
+        # the change is complete
+        # XXX systemctl exits with non-0 when in degraded state
+        (systemctl is-system-running || true) | MATCH '(running|degraded)'
+
+        # fake refreshes generate revision numbers that are n+1
+        expecting_kernel="$(($(cat pc-kernel.rev) + 1))"
+        expecting_core="$(($(cat core.rev) + 1))"
+
+        # verify that current points to new revisions
+        test "$(readlink /snap/pc-kernel/current)" = "$expecting_kernel"
+        test "$(readlink /snap/$core_snap/current)" = "$expecting_core"
+
+        # now we need to revert both snaps for restore to behave properly, start
+        # with the kernel
+        snap revert pc-kernel --revision "$(cat pc-kernel.rev)"
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 2 ]; then
+        snap watch --last=revert\?
+        # now the base
+        snap revert "$core_snap" --revision "$(cat core.rev)"
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 3 ]; then
+        snap watch --last=revert\?
+        # we're done, verify current symlinks to the right revisions
+        test "$(readlink /snap/pc-kernel/current)" = "$(cat pc-kernel.rev)"
+        test "$(readlink /snap/$core_snap/current)" = "$(cat core.rev)"
+    else
+        echo "unexpected reboot"
+        exit 1
+    fi

--- a/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
@@ -20,16 +20,25 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/tests/lib/fakestore/refresh"
 )
 
 type cmdMakeRefreshable struct {
-	TopDir string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
+	TopDir     string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
+	SnapBlob   string `long:"snap-blob" description:"File or directory with new snap revision contents"`
+	Positional struct {
+		SnapName string `description:"snap name" positional-arg-name:"snap-name"`
+	} `positional-args:"yes" required:"1"`
 }
 
 func (x *cmdMakeRefreshable) Execute(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unexpected additional arguments %v", args)
+	}
 	// setup fake new revisions of snaps for refresh
-	return refresh.MakeFakeRefreshForSnaps(args, x.TopDir)
+	return refresh.MakeFakeRefreshForSnaps(x.Positional.SnapName, x.TopDir, x.SnapBlob)
 }
 
 var shortMakeRefreshableHelp = "Makes new versions of the given snaps"

--- a/tests/lib/fakestore/cmd/fakestore/main.go
+++ b/tests/lib/fakestore/cmd/fakestore/main.go
@@ -30,7 +30,7 @@ import (
 
 type Options struct{}
 
-var parser = flags.NewParser(&Options{}, flags.Default)
+var parser = flags.NewParser(&Options{}, flags.HelpFlag|flags.PassDoubleDash)
 
 func main() {
 	if err := logger.SimpleSetup(); err != nil {

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -54,7 +54,7 @@ func newAssertsDB(signingPrivKey string) (*asserts.Database, error) {
 	return db, nil
 }
 
-func MakeFakeRefreshForSnaps(snaps []string, blobDir string) error {
+func MakeFakeRefreshForSnaps(snap string, blobDir string, snapBlob string) error {
 	db, err := newAssertsDB(systestkeys.TestStorePrivKey)
 	if err != nil {
 		return err
@@ -94,10 +94,8 @@ func MakeFakeRefreshForSnaps(snaps []string, blobDir string) error {
 
 	f := asserts.NewFetcher(db, retrieve, save)
 
-	for _, snap := range snaps {
-		if err := makeFakeRefreshForSnap(snap, blobDir, db, f); err != nil {
-			return err
-		}
+	if err := makeFakeRefreshForSnap(snap, blobDir, snapBlob, db, f); err != nil {
+		return err
 	}
 	return nil
 }
@@ -113,7 +111,7 @@ func writeAssert(a asserts.Assertion, targetDir string) (string, error) {
 	return p, err
 }
 
-func makeFakeRefreshForSnap(snap, targetDir string, db *asserts.Database, f asserts.Fetcher) error {
+func makeFakeRefreshForSnap(snap, targetDir, snapBlob string, db *asserts.Database, f asserts.Fetcher) error {
 	// make a fake update snap in /var/tmp (which is not a tempfs)
 	fakeUpdateDir, err := ioutil.TempDir("/var/tmp", "snap-build-")
 	if err != nil {
@@ -130,9 +128,28 @@ func makeFakeRefreshForSnap(snap, targetDir string, db *asserts.Database, f asse
 	}
 	defer exec.Command("sudo", "rm", "-rf", fakeUpdateDir)
 
-	origInfo, err := copySnap(snap, fakeUpdateDir)
+	origInfo, err := getOrigInfo(snap)
 	if err != nil {
-		return fmt.Errorf("copying snap: %v", err)
+		return err
+	}
+	if snapBlob != "" {
+		fi, err := os.Stat(snapBlob)
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			if err := copyDir(snapBlob, fakeUpdateDir); err != nil {
+				return fmt.Errorf("copying snap blob dir: %v", err)
+			}
+		} else {
+			if err := unpackSnap(snapBlob, fakeUpdateDir); err != nil {
+				return fmt.Errorf("unpacking snap blob: %v", err)
+			}
+		}
+	} else {
+		if err := copySnap(snap, fakeUpdateDir); err != nil {
+			return fmt.Errorf("copying snap: %v", err)
+		}
 	}
 
 	err = copySnapAsserts(origInfo, f)
@@ -172,30 +189,11 @@ type info struct {
 	size     uint64
 }
 
-func copySnap(snapName, targetDir string) (*info, error) {
-	baseDir := filepath.Join(dirs.SnapMountDir, snapName)
-	if _, err := os.Stat(baseDir); err != nil {
-		return nil, err
-	}
-	sourceDir := filepath.Join(baseDir, "current")
-	files, err := filepath.Glob(filepath.Join(sourceDir, "*"))
+func getOrigInfo(snapName string) (*info, error) {
+	origRevision, err := currentRevision(snapName)
 	if err != nil {
 		return nil, err
 	}
-
-	revnoDir, err := filepath.EvalSymlinks(sourceDir)
-	if err != nil {
-		return nil, err
-	}
-	origRevision := filepath.Base(revnoDir)
-
-	for _, m := range files {
-		if err = exec.Command("sudo", "cp", "-a", m, targetDir).Run(); err != nil {
-			return nil, err
-
-		}
-	}
-
 	rev, err := snap.ParseRevision(origRevision)
 	if err != nil {
 		return nil, err
@@ -208,6 +206,48 @@ func copySnap(snapName, targetDir string) (*info, error) {
 	}
 
 	return &info{revision: origRevision, size: origSize, digest: origDigest}, nil
+}
+
+func currentRevision(snapName string) (string, error) {
+	baseDir := filepath.Join(dirs.SnapMountDir, snapName)
+	if _, err := os.Stat(baseDir); err != nil {
+		return "", err
+	}
+	sourceDir := filepath.Join(baseDir, "current")
+	revnoDir, err := filepath.EvalSymlinks(sourceDir)
+	if err != nil {
+		return "", err
+	}
+	origRevision := filepath.Base(revnoDir)
+	return origRevision, nil
+}
+
+func copyDir(sourceDir, targetDir string) error {
+	files, err := filepath.Glob(filepath.Join(sourceDir, "*"))
+	if err != nil {
+		return err
+	}
+
+	for _, m := range files {
+		if err = exec.Command("sudo", "cp", "-a", m, targetDir).Run(); err != nil {
+			return err
+
+		}
+	}
+	return nil
+}
+
+func copySnap(snapName, targetDir string) error {
+	baseDir := filepath.Join(dirs.SnapMountDir, snapName)
+	if _, err := os.Stat(baseDir); err != nil {
+		return err
+	}
+	sourceDir := filepath.Join(baseDir, "current")
+	return copyDir(sourceDir, targetDir)
+}
+
+func unpackSnap(snapBlob, targetDir string) error {
+	return exec.Command("sudo", "unsquashfs", "-d", targetDir, "-f", snapBlob).Run()
 }
 
 func buildSnap(snapDir, targetDir string) (*info, error) {

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -141,7 +141,13 @@ func makeFakeRefreshForSnap(snap, targetDir string, db *asserts.Database, f asse
 	}
 
 	// fake new version
-	err = exec.Command("sudo", "sed", "-i", `s/version:\(.*\)/version:\1+fake1/`, filepath.Join(fakeUpdateDir, "meta/snap.yaml")).Run()
+	err = exec.Command("sudo", "sed", "-i",
+		// version can be all numbers thus making it ambiguous and
+		// needing quoting, eg. version: '2021112', but since we're
+		// adding +fake1 suffix, the resulting value will clearly be a
+		// string, so have the regex strip quoting too
+		`s/version:[ ]\+['"]\?\([-.a-zA-Z0-9]\+\)['"]\?/version: \1+fake1/`,
+		filepath.Join(fakeUpdateDir, "meta/snap.yaml")).Run()
 	if err != nil {
 		return fmt.Errorf("changing fake snap version: %v", err)
 	}


### PR DESCRIPTION
Backport of #11030 and dependencies #11019, #11007, bits from #10943

Marked as blocked as I need the spread tests from ~~#11126~~ and the failover one from #11138