### PR TITLE
o/snapstate: refactor disk space checks (2.53)

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2062,14 +2062,16 @@ func checkDiskSpace(st *state.State, changeKind string, infos []minimalInstallIn
 	case "refresh":
 		featFlag = features.CheckDiskSpaceRefresh
 	default:
-		panic(fmt.Sprintf("unsupported disk space check for change of kind %q", changeKind))
+		return fmt.Errorf("cannot check disk space for invalid change kind %q", changeKind)
 	}
 
 	tr := config.NewTransaction(st)
 	enabled, err := features.Flag(tr, featFlag)
 	if err != nil && !config.IsNoOption(err) {
 		return err
-	} else if !enabled {
+	}
+
+	if !enabled {
 		return nil
 	}
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1005,30 +1005,8 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 		return nil, err
 	}
 
-	tr := config.NewTransaction(st)
-	checkDiskSpaceInstall, err := features.Flag(tr, features.CheckDiskSpaceInstall)
-	if err != nil && !config.IsNoOption(err) {
+	if err := checkDiskSpace(st, "install", []minimalInstallInfo{installSnapInfo{info}}, userID); err != nil {
 		return nil, err
-	}
-	if checkDiskSpaceInstall {
-		// check if there is enough disk space for requested snap and its
-		// prerequisites.
-		totalSize, err := installSize(st, []minimalInstallInfo{installSnapInfo{info}}, userID)
-		if err != nil {
-			return nil, err
-		}
-		requiredSpace := safetyMarginDiskSpace(totalSize)
-		path := dirs.SnapdStateDir(dirs.GlobalRootDir)
-		if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
-			if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
-				return nil, &InsufficientSpaceError{
-					Path:       path,
-					Snaps:      []string{info.InstanceName()},
-					ChangeKind: "install",
-				}
-			}
-			return nil, err
-		}
 	}
 
 	providerContentAttrs := defaultProviderContentAttrs(st, info)
@@ -1095,35 +1073,13 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 		return nil, nil, err
 	}
 
-	tr := config.NewTransaction(st)
-	checkDiskSpaceInstall, err := features.Flag(tr, features.CheckDiskSpaceInstall)
-	if err != nil && !config.IsNoOption(err) {
-		return nil, nil, err
+	snapInfos := make([]minimalInstallInfo, len(installs))
+	for i, sar := range installs {
+		snapInfos[i] = installSnapInfo{sar.Info}
 	}
-	if checkDiskSpaceInstall {
-		// check if there is enough disk space for requested snaps and their
-		// prerequisites.
-		snapInfos := make([]minimalInstallInfo, len(installs))
-		for i, sar := range installs {
-			snapInfos[i] = installSnapInfo{sar.Info}
-		}
-		totalSize, err := installSize(st, snapInfos, userID)
-		if err != nil {
-			return nil, nil, err
-		}
 
-		requiredSpace := safetyMarginDiskSpace(totalSize)
-		path := dirs.SnapdStateDir(dirs.GlobalRootDir)
-		if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
-			if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
-				return nil, nil, &InsufficientSpaceError{
-					Path:       path,
-					Snaps:      toInstall,
-					ChangeKind: "install",
-				}
-			}
-			return nil, nil, err
-		}
+	if err = checkDiskSpace(st, "install", snapInfos, userID); err != nil {
+		return nil, nil, err
 	}
 
 	tasksets := make([]*state.TaskSet, 0, len(installs))
@@ -1252,34 +1208,8 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 		toUpdate[i] = installSnapInfo{up}
 	}
 
-	tr := config.NewTransaction(st)
-	checkDiskSpaceRefresh, err := features.Flag(tr, features.CheckDiskSpaceRefresh)
-	if err != nil && !config.IsNoOption(err) {
+	if err = checkDiskSpace(st, "refresh", toUpdate, userID); err != nil {
 		return nil, nil, err
-	}
-	if checkDiskSpaceRefresh {
-		// check if there is enough disk space for requested snap and its
-		// prerequisites.
-		totalSize, err := installSize(st, toUpdate, userID)
-		if err != nil {
-			return nil, nil, err
-		}
-		requiredSpace := safetyMarginDiskSpace(totalSize)
-		path := dirs.SnapdStateDir(dirs.GlobalRootDir)
-		if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
-			snaps := make([]string, len(updates))
-			for i, up := range updates {
-				snaps[i] = up.InstanceName()
-			}
-			if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
-				return nil, nil, &InsufficientSpaceError{
-					Path:       path,
-					Snaps:      snaps,
-					ChangeKind: "refresh",
-				}
-			}
-			return nil, nil, err
-		}
 	}
 
 	updated, tasksets, err := doUpdate(ctx, st, names, toUpdate, params, userID, flags, deviceCtx, fromChange)
@@ -1800,34 +1730,8 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 		toUpdate[i] = installSnapInfo{up}
 	}
 
-	tr := config.NewTransaction(st)
-	checkDiskSpaceRefresh, err := features.Flag(tr, features.CheckDiskSpaceRefresh)
-	if err != nil && !config.IsNoOption(err) {
+	if err = checkDiskSpace(st, "refresh", toUpdate, userID); err != nil {
 		return nil, err
-	}
-	if checkDiskSpaceRefresh {
-		// check if there is enough disk space for requested snap and its
-		// prerequisites.
-		totalSize, err := installSize(st, toUpdate, userID)
-		if err != nil {
-			return nil, err
-		}
-		requiredSpace := safetyMarginDiskSpace(totalSize)
-		path := dirs.SnapdStateDir(dirs.GlobalRootDir)
-		if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
-			snaps := make([]string, len(updates))
-			for i, up := range updates {
-				snaps[i] = up.InstanceName()
-			}
-			if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
-				return nil, &InsufficientSpaceError{
-					Path:       path,
-					Snaps:      snaps,
-					ChangeKind: "refresh",
-				}
-			}
-			return nil, err
-		}
 	}
 
 	params := func(update *snap.Info) (*RevisionOptions, Flags, *SnapState) {
@@ -2135,34 +2039,8 @@ func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshC
 		toUpdate[i] = up
 	}
 
-	tr := config.NewTransaction(st)
-	checkDiskSpaceRefresh, err := features.Flag(tr, features.CheckDiskSpaceRefresh)
-	if err != nil && !config.IsNoOption(err) {
+	if err := checkDiskSpace(st, "refresh", toUpdate, 0); err != nil {
 		return nil, err
-	}
-	if checkDiskSpaceRefresh {
-		// check if there is enough disk space for requested snaps and their
-		// prerequisites.
-		totalSize, err := installSize(st, toUpdate, 0)
-		if err != nil {
-			return nil, err
-		}
-		requiredSpace := safetyMarginDiskSpace(totalSize)
-		path := dirs.SnapdStateDir(dirs.GlobalRootDir)
-		if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
-			snaps := make([]string, len(updates))
-			for i, up := range updates {
-				snaps[i] = up.InstanceName()
-			}
-			if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
-				return nil, &InsufficientSpaceError{
-					Path:       path,
-					Snaps:      snaps,
-					ChangeKind: "refresh",
-				}
-			}
-			return nil, err
-		}
 	}
 
 	updated, tasksets, err := doUpdate(ctx, st, nil, toUpdate, nil, userID, flags, deviceCtx, fromChange)
@@ -2172,6 +2050,52 @@ func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshC
 
 	tasksets = finalizeUpdate(st, tasksets, len(updates) > 0, updated, userID, flags)
 	return tasksets, nil
+}
+
+// checkDiskSpace checks if there is enough space for the requested snaps and their prerequisites
+func checkDiskSpace(st *state.State, changeKind string, infos []minimalInstallInfo, userID int) error {
+	var featFlag features.SnapdFeature
+
+	switch changeKind {
+	case "install":
+		featFlag = features.CheckDiskSpaceInstall
+	case "refresh":
+		featFlag = features.CheckDiskSpaceRefresh
+	default:
+		panic(fmt.Sprintf("unsupported disk space check for change of kind %q", changeKind))
+	}
+
+	tr := config.NewTransaction(st)
+	enabled, err := features.Flag(tr, featFlag)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	} else if !enabled {
+		return nil
+	}
+
+	totalSize, err := installSize(st, infos, userID)
+	if err != nil {
+		return err
+	}
+
+	requiredSpace := safetyMarginDiskSpace(totalSize)
+	path := dirs.SnapdStateDir(dirs.GlobalRootDir)
+	if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
+		snaps := make([]string, len(infos))
+		for i, up := range infos {
+			snaps[i] = up.InstanceName()
+		}
+		if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
+			return &InsufficientSpaceError{
+				Path:       path,
+				Snaps:      snaps,
+				ChangeKind: changeKind,
+			}
+		}
+		return err
+	}
+
+	return nil
 }
 
 // LinkNewBaseOrKernel will create prepare/link-snap tasks for a remodel


### PR DESCRIPTION
Backport of https://github.com/snapcore/snapd/pull/11103, as a prerequisite to the backport of https://github.com/snapcore/snapd/pull/11109