### PR TITLE
data/env: improve fish shell env setup

### DIFF
--- a/data/env/snapd.fish.in
+++ b/data/env/snapd.fish.in
@@ -1,8 +1,6 @@
 # Expand $PATH to include the directory where snappy applications go.
 set -u snap_bin_path "@SNAP_MOUNT_DIR@/bin"
-if ! contains $snap_bin_path $PATH
-    set PATH $PATH $snap_bin_path
-end
+fish_add_path -aP $snap_bin_path
 
 # Desktop files (used by desktop environments within both X11 and Wayland) are
 # looked for in XDG_DATA_DIRS; make sure it includes the relevant directory for


### PR DESCRIPTION
Based on comments in https://github.com/snapcore/snapd/pull/11071 the way to add
$SNAP_MOUNT_DIR/bin to fish PATH can be simplified.

Thanks to @Karrq for the suggestion.

