### PR TITLE
packaging: merge 2.53.4 (and also 2.53.3) changelogs back to master

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.53.2
+pkgver=2.53.4
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,38 @@
+snapd (2.53.4-1) unstable; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - devicestate: mock devicestate.MockTimeutilIsNTPSynchronized to
+      avoid host env leaking into tests
+    - timeutil: return NoTimedate1Error if it can't connect to the
+      system bus
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Thu, 02 Dec 2021 17:16:48 -0600
+
+snapd (2.53.3-1) unstable; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - devicestate: Unregister deletes the device key pair as well
+    - daemon,tests: support forgetting device serial via API
+    - configcore: relax validation rules for hostname
+    - o/devicestate: introduce DeviceManager.Unregister
+    - packaging/ubuntu, packaging/debian: depend on dbus-session-bus
+      provider
+    - many: wait for up to 10min for NTP synchronization before
+      autorefresh
+    - interfaces/interfaces/scsi_generic: add interface for scsi generic
+      devices
+    - interfaces/microstack-support: set controlsDeviceCgroup to true
+    - interface/builtin/log_observe: allow to access /dev/kmsg
+    - daemon: write formdata file parts to snaps dir
+    - spread: run lxd tests with version from latest/edge
+    - cmd/libsnap-confine-private: fix snap-device-helper device allow
+      list modification on cgroup v2
+    - interfaces/builtin/dsp: add proc files for monitoring Ambarella
+      DSP firmware
+    - interfaces/builtin/dsp: update proc file accordingly
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Thu, 02 Dec 2021 11:42:15 -0600
+
 snapd (2.53.2-1) unstable; urgency=medium
 
   * New upstream release, LP: #1946127

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -102,7 +102,7 @@
 %endif
 
 Name:           snapd
-Version:        2.53.2
+Version:        2.53.4
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -989,6 +989,35 @@ fi
 
 
 %changelog
+* Thu Dec 02 2021 Ian Johnson <ian.johnson@canonical.com>
+- New upstream release 2.53.4
+ - devicestate: mock devicestate.MockTimeutilIsNTPSynchronized to
+   avoid host env leaking into tests
+ - timeutil: return NoTimedate1Error if it can't connect to the
+   system bus
+
+* Thu Dec 02 2021 Ian Johnson <ian.johnson@canonical.com>
+- New upstream release 2.53.3
+ - devicestate: Unregister deletes the device key pair as well
+ - daemon,tests: support forgetting device serial via API
+ - configcore: relax validation rules for hostname
+ - o/devicestate: introduce DeviceManager.Unregister
+ - packaging/ubuntu, packaging/debian: depend on dbus-session-bus
+   provider
+ - many: wait for up to 10min for NTP synchronization before
+   autorefresh
+ - interfaces/interfaces/scsi_generic: add interface for scsi generic
+   devices
+ - interfaces/microstack-support: set controlsDeviceCgroup to true
+ - interface/builtin/log_observe: allow to access /dev/kmsg
+ - daemon: write formdata file parts to snaps dir
+ - spread: run lxd tests with version from latest/edge
+ - cmd/libsnap-confine-private: fix snap-device-helper device allow
+   list modification on cgroup v2
+ - interfaces/builtin/dsp: add proc files for monitoring Ambarella
+   DSP firmware
+ - interfaces/builtin/dsp: update proc file accordingly
+
 * Mon Nov 15 2021 Ian Johnson <ian.johnson@canonical.com>
 - New upstream release 2.53.2
  - interfaces/builtin/block_devices: allow blkid to print block

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Dec 02 23:16:48 UTC 2021 - ian.johnson@canonical.com
+
+- Update to upstream release 2.53.4
+
+-------------------------------------------------------------------
+Thu Dec 02 17:42:15 UTC 2021 - ian.johnson@canonical.com
+
+- Update to upstream release 2.53.3
+
+-------------------------------------------------------------------
 Mon Nov 15 22:09:09 UTC 2021 - ian.johnson@canonical.com
 
 - Update to upstream release 2.53.2

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -81,7 +81,7 @@
 
 
 Name:           snapd
-Version:        2.53.2
+Version:        2.53.4
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,38 @@
+snapd (2.53.4~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - devicestate: mock devicestate.MockTimeutilIsNTPSynchronized to
+      avoid host env leaking into tests
+    - timeutil: return NoTimedate1Error if it can't connect to the
+      system bus
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Thu, 02 Dec 2021 17:16:48 -0600
+
+snapd (2.53.3~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - devicestate: Unregister deletes the device key pair as well
+    - daemon,tests: support forgetting device serial via API
+    - configcore: relax validation rules for hostname
+    - o/devicestate: introduce DeviceManager.Unregister
+    - packaging/ubuntu, packaging/debian: depend on dbus-session-bus
+      provider
+    - many: wait for up to 10min for NTP synchronization before
+      autorefresh
+    - interfaces/interfaces/scsi_generic: add interface for scsi generic
+      devices
+    - interfaces/microstack-support: set controlsDeviceCgroup to true
+    - interface/builtin/log_observe: allow to access /dev/kmsg
+    - daemon: write formdata file parts to snaps dir
+    - spread: run lxd tests with version from latest/edge
+    - cmd/libsnap-confine-private: fix snap-device-helper device allow
+      list modification on cgroup v2
+    - interfaces/builtin/dsp: add proc files for monitoring Ambarella
+      DSP firmware
+    - interfaces/builtin/dsp: update proc file accordingly
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Thu, 02 Dec 2021 11:42:15 -0600
+
 snapd (2.53.2~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #1946127

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,38 @@
+snapd (2.53.4) xenial; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - devicestate: mock devicestate.MockTimeutilIsNTPSynchronized to
+      avoid host env leaking into tests
+    - timeutil: return NoTimedate1Error if it can't connect to the
+      system bus
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Thu, 02 Dec 2021 17:16:48 -0600
+
+snapd (2.53.3) xenial; urgency=medium
+
+  * New upstream release, LP: #1929842
+    - devicestate: Unregister deletes the device key pair as well
+    - daemon,tests: support forgetting device serial via API
+    - configcore: relax validation rules for hostname
+    - o/devicestate: introduce DeviceManager.Unregister
+    - packaging/ubuntu, packaging/debian: depend on dbus-session-bus
+      provider
+    - many: wait for up to 10min for NTP synchronization before
+      autorefresh
+    - interfaces/interfaces/scsi_generic: add interface for scsi generic
+      devices
+    - interfaces/microstack-support: set controlsDeviceCgroup to true
+    - interface/builtin/log_observe: allow to access /dev/kmsg
+    - daemon: write formdata file parts to snaps dir
+    - spread: run lxd tests with version from latest/edge
+    - cmd/libsnap-confine-private: fix snap-device-helper device allow
+      list modification on cgroup v2
+    - interfaces/builtin/dsp: add proc files for monitoring Ambarella
+      DSP firmware
+    - interfaces/builtin/dsp: update proc file accordingly
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Thu, 02 Dec 2021 11:42:15 -0600
+
 snapd (2.53.2) xenial; urgency=medium
 
   * New upstream release, LP: #1946127


### PR DESCRIPTION
2.53.3 will go down in history as the short lived but nonetheless 4th straight "failed" snapd release, so here's hoping 2.53.4 is the one :crossed_fingers: 