### PR TITLE
overlord: fix issue with concurrent execution of two snapd processes

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -294,6 +294,9 @@ func (s *apiBaseSuite) daemonWithStore(c *check.C, sto snapstate.StoreService) *
 }
 
 func (s *apiBaseSuite) resetDaemon() {
+	if s.d != nil {
+		s.d.Overlord().Stop()
+	}
 	s.d = nil
 }
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -75,6 +75,7 @@ var (
 	SnapSeqDir            string
 
 	SnapStateFile     string
+	SnapStateLockFile string
 	SnapSystemKeyFile string
 
 	SnapRepairDir        string
@@ -251,6 +252,11 @@ func SnapStateFileUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "state.json")
 }
 
+// SnapStateLockFileUnder returns the path to snapd state lock file under rootdir.
+func SnapStateLockFileUnder(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir, "state.lock")
+}
+
 // SnapModeenvFileUnder returns the path to the modeenv file under rootdir.
 func SnapModeenvFileUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "modeenv")
@@ -363,6 +369,7 @@ func SetRootDir(rootdir string) {
 	SnapSeqDir = filepath.Join(rootdir, snappyDir, "sequence")
 
 	SnapStateFile = SnapStateFileUnder(rootdir)
+	SnapStateLockFile = SnapStateLockFileUnder(rootdir)
 	SnapSystemKeyFile = filepath.Join(rootdir, snappyDir, "system-key")
 
 	SnapCacheDir = filepath.Join(rootdir, "/var/cache/snapd")

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -132,8 +132,12 @@ func (t *firstBootBaseTest) startOverlord(c *C) {
 	devicestate.EarlyConfig = func(st *state.State, preloadGadget func() (sysconfig.Device, *gadget.Info, error)) error {
 		return nil
 	}
-	t.AddCleanup(func() { devicestate.EarlyConfig = nil })
 	t.overlord = ovld
+	t.AddCleanup(func() {
+		devicestate.EarlyConfig = nil
+		t.overlord.Stop()
+		t.overlord = nil
+	})
 	c.Assert(ovld.StartUp(), IsNil)
 
 	// don't actually try to talk to the store on snapstate.Ensure
@@ -164,8 +168,6 @@ var _ = Suite(&firstBoot16Suite{})
 func (s *firstBoot16Suite) SetUpTest(c *C) {
 	s.TestingSeed16 = &seedtest.TestingSeed16{}
 	s.setup16BaseTest(c, &s.firstBootBaseTest)
-
-	s.startOverlord(c)
 
 	s.SeedDir = dirs.SnapSeedDir
 
@@ -222,6 +224,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoop(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -260,6 +263,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {
 	defer restore()
 
 	ovld, err := overlord.New(nil)
+	defer ovld.Stop()
 	c.Assert(err, IsNil)
 	st := ovld.State()
 
@@ -288,6 +292,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicEmptySeedYaml(c *C) {
 	defer restore()
 
 	ovld, err := overlord.New(nil)
+	defer ovld.Stop()
 	c.Assert(err, IsNil)
 	st := ovld.State()
 
@@ -314,6 +319,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoSeedYamlWithCloudInsta
 	restore := release.MockOnClassic(true)
 	defer restore()
 
+	s.startOverlord(c)
 	st := s.overlord.State()
 
 	// add the model assertion and its chain
@@ -382,6 +388,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoSeedYamlWithCloudInsta
 }
 
 func (s *firstBoot16Suite) TestPopulateFromSeedErrorsOnState(c *C) {
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -552,6 +559,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedHappy(c *C) {
 	bloader.SetBootKernel("pc-kernel_1.snap")
 	bloader.SetBootBase("core_1.snap")
 
+	s.startOverlord(c)
 	st := s.overlord.State()
 	chg, model := s.makeSeedChange(c, st, nil, checkSeedTasks, checkOrder)
 	err := s.overlord.Settle(settleTimeout)
@@ -643,6 +651,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedHappy(c *C) {
 }
 
 func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
+	s.startOverlord(c)
 	st0 := s.overlord.State()
 	st0.Lock()
 	db := assertstate.DB(st0)
@@ -730,6 +739,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -835,6 +845,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -991,6 +1002,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1061,6 +1073,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedClassicModelMismatch(c *C
 	defer restore()
 
 	ovld, err := overlord.New(nil)
+	defer ovld.Stop()
 	c.Assert(err, IsNil)
 	st := ovld.State()
 
@@ -1078,6 +1091,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedClassicModelMismatch(c *C
 
 func (s *firstBoot16Suite) TestImportAssertionsFromSeedAllSnapsModelMismatch(c *C) {
 	ovld, err := overlord.New(nil)
+	defer ovld.Stop()
 	c.Assert(err, IsNil)
 	st := ovld.State()
 
@@ -1095,6 +1109,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedAllSnapsModelMismatch(c *
 
 func (s *firstBoot16Suite) TestLoadDeviceSeed(c *C) {
 	ovld, err := overlord.New(nil)
+	defer ovld.Stop()
 	c.Assert(err, IsNil)
 	st := ovld.State()
 
@@ -1131,6 +1146,7 @@ func (s *firstBoot16Suite) TestLoadDeviceSeed(c *C) {
 
 func (s *firstBoot16Suite) TestLoadDeviceSeedCaching(c *C) {
 	ovld, err := overlord.New(nil)
+	defer ovld.Stop()
 	c.Assert(err, IsNil)
 	st := ovld.State()
 
@@ -1190,6 +1206,7 @@ func (s *firstBoot16Suite) TestLoadDeviceSeedCaching(c *C) {
 
 func (s *firstBoot16Suite) TestImportAssertionsFromSeedHappy(c *C) {
 	ovld, err := overlord.New(nil)
+	defer ovld.Stop()
 	c.Assert(err, IsNil)
 	st := ovld.State()
 
@@ -1234,6 +1251,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedHappy(c *C) {
 }
 
 func (s *firstBoot16Suite) TestImportAssertionsFromSeedMissingSig(c *C) {
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1254,6 +1272,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedMissingSig(c *C) {
 }
 
 func (s *firstBoot16Suite) TestImportAssertionsFromSeedTwoModelAsserts(c *C) {
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1272,6 +1291,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedTwoModelAsserts(c *C) {
 }
 
 func (s *firstBoot16Suite) TestImportAssertionsFromSeedNoModelAsserts(c *C) {
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1385,6 +1405,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1507,6 +1528,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1543,6 +1565,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1609,6 +1632,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1680,6 +1704,7 @@ snaps:
 	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644), IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1728,6 +1753,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1813,6 +1839,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1867,6 +1894,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1937,6 +1965,7 @@ snaps:
 }
 
 func (s *firstBoot16Suite) TestCriticalTaskEdgesForPreseed(c *C) {
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1962,6 +1991,7 @@ func (s *firstBoot16Suite) TestCriticalTaskEdgesForPreseed(c *C) {
 }
 
 func (s *firstBoot16Suite) TestCriticalTaskEdgesForPreseedMissing(c *C) {
+	s.startOverlord(c)
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()

--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/snapcore/snapd/store"
 )
 
+var (
+	LockWithTimeout = lockWithTimeout
+)
+
 // MockEnsureInterval sets the overlord ensure interval for tests.
 func MockEnsureInterval(d time.Duration) (restore func()) {
 	old := ensureInterval
@@ -49,6 +53,18 @@ func MockPruneInterval(prunei, prunew, abortw time.Duration) (restore func()) {
 		pruneInterval = oldPruneInterval
 		pruneWait = oldPruneWait
 		abortWait = oldAbortWait
+	}
+}
+
+// MockStateLockTimeout sets the overlord state lock timeout for the tests.
+func MockStateLockTimeout(timeout, retryInterval time.Duration) (restore func()) {
+	oldTimeout := stateLockTimeout
+	oldRetryInterval := stateLockRetryInterval
+	stateLockTimeout = timeout
+	stateLockRetryInterval = retryInterval
+	return func() {
+		stateLockTimeout = oldTimeout
+		stateLockRetryInterval = oldRetryInterval
 	}
 }
 
@@ -95,5 +111,13 @@ func MockPreseedExitWithError(f func(err error)) (restore func()) {
 	preseedExitWithError = f
 	return func() {
 		preseedExitWithError = old
+	}
+}
+
+func MockSystemdSdNotify(f func(notifyState string) error) (restore func()) {
+	old := systemdSdNotify
+	systemdSdNotify = f
+	return func() {
+		systemdSdNotify = old
 	}
 }

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -231,6 +231,9 @@ func lockWithTimeout(l *osutil.FileLock, timeout time.Duration) error {
 	for {
 		err := l.TryLock()
 		if err != osutil.ErrAlreadyLocked {
+			// We return nil if err is nil (that is, if we got the lock); we
+			// also return for any error except for ErrAlreadyLocked, because
+			// in that case we want to continue trying.
 			return err
 		}
 

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -21,6 +21,7 @@
 package overlord
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -53,6 +54,7 @@ import (
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -62,11 +64,15 @@ var (
 	pruneWait      = 24 * time.Hour * 1
 	abortWait      = 24 * time.Hour * 7
 
+	stateLockTimeout       = 1 * time.Minute
+	stateLockRetryInterval = 1 * time.Second
+
 	pruneMaxChanges = 500
 
 	defaultCachedDownloads = 5
 
 	configstateInit = configstate.Init
+	systemdSdNotify = systemd.SdNotify
 )
 
 var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
@@ -76,6 +82,8 @@ var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
 // Overlord is the central manager of a snappy system, keeping
 // track of all available state managers and related helpers.
 type Overlord struct {
+	stateFLock *osutil.FileLock
+
 	stateEng *StateEngine
 	// ensure loop
 	loopTomb    *tomb.Tomb
@@ -116,7 +124,7 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 		path:         dirs.SnapStateFile,
 		ensureBefore: o.ensureBefore,
 	}
-	s, err := loadState(backend, restartHandler)
+	s, err := o.loadState(backend, restartHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +216,54 @@ func (o *Overlord) addManager(mgr StateManager) {
 	o.stateEng.AddManager(mgr)
 }
 
-func loadState(backend state.Backend, restartHandler restart.Handler) (*state.State, error) {
+func initStateFileLock() (*osutil.FileLock, error) {
+	lockFilePath := dirs.SnapStateLockFile
+	if err := os.MkdirAll(filepath.Dir(lockFilePath), 0755); err != nil {
+		return nil, err
+	}
+
+	return osutil.NewFileLockWithMode(lockFilePath, 0644)
+}
+
+func lockWithTimeout(l *osutil.FileLock, timeout time.Duration) error {
+	startTime := time.Now()
+	systemdWasNotified := false
+	for {
+		err := l.TryLock()
+		if err != osutil.ErrAlreadyLocked {
+			return err
+		}
+
+		// The state is locked. Let's notify systemd that our startup might be
+		// longer than usual, or we risk getting killed if we overstep the
+		// systemd timeout.
+		if !systemdWasNotified {
+			logger.Noticef("Adjusting startup timeout by %v", timeout)
+			systemdSdNotify(fmt.Sprintf("EXTEND_TIMEOUT_USEC=%d", timeout.Microseconds()))
+			systemdWasNotified = true
+		}
+
+		if time.Since(startTime) >= timeout {
+			return errors.New("timeout for state lock file expired")
+		}
+		time.Sleep(stateLockRetryInterval)
+	}
+}
+
+func (o *Overlord) loadState(backend state.Backend, restartHandler restart.Handler) (*state.State, error) {
+	flock, err := initStateFileLock()
+	if err != nil {
+		return nil, fmt.Errorf("fatal: error opening lock file: %v", err)
+	}
+	o.stateFLock = flock
+
+	logger.Noticef("Acquiring state lock file")
+	if err := lockWithTimeout(o.stateFLock, stateLockTimeout); err != nil {
+		logger.Noticef("Failed to lock state file")
+		return nil, fmt.Errorf("fatal: could not lock state file: %v", err)
+	}
+	logger.Noticef("Acquired state lock file")
+
 	curBootID, err := osutil.BootID()
 	if err != nil {
 		return nil, fmt.Errorf("fatal: cannot find current boot id: %v", err)
@@ -440,6 +495,11 @@ func (o *Overlord) Stop() error {
 		err = o.loopTomb.Wait()
 	}
 	o.stateEng.Stop()
+	if o.stateFLock != nil {
+		// This will also unlock the file
+		o.stateFLock.Close()
+		logger.Noticef("Released state lock file")
+	}
 	return err
 }
 

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -23,8 +23,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"syscall"
@@ -1314,4 +1316,66 @@ func (ovs *overlordSuite) TestStartupTimeout(c *C) {
 
 	c.Check(to, Equals, (30+5+5)*time.Second)
 	c.Check(reasoning, Equals, "pessimistic estimate of 30s plus 5s per snap")
+}
+
+func (ovs *overlordSuite) TestLockWithTimeoutHappy(c *C) {
+	f, err := ioutil.TempFile("", "testlock-*")
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	c.Assert(err, IsNil)
+	flock, err := osutil.NewFileLock(f.Name())
+	c.Assert(err, IsNil)
+
+	err = overlord.LockWithTimeout(flock, time.Second)
+	c.Check(err, IsNil)
+}
+
+func (ovs *overlordSuite) TestLockWithTimeoutFailed(c *C) {
+	// Set the state lock retry interval to 0.1 ms; the timeout is not used in
+	// this test (we specify the timeout when calling the lockWithTimeout()
+	// function below); we set it to a big value in order to trigger a test
+	// failure in case the logic gets modified and it suddenly becomes
+	// relevant.
+	restoreTimeout := overlord.MockStateLockTimeout(time.Hour, 100*time.Microsecond)
+	defer restoreTimeout()
+
+	var notifyCalls []string
+	restoreNotify := overlord.MockSystemdSdNotify(func(notifyState string) error {
+		notifyCalls = append(notifyCalls, notifyState)
+		return nil
+	})
+	defer restoreNotify()
+
+	f, err := ioutil.TempFile("", "testlock-*")
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	c.Assert(err, IsNil)
+	flock, err := osutil.NewFileLock(f.Name())
+	c.Assert(err, IsNil)
+
+	cmd := exec.Command("flock", "-w", "2", f.Name(), "-c", "echo acquired && sleep 5")
+	stdout, err := cmd.StdoutPipe()
+	c.Assert(err, IsNil)
+	err = cmd.Start()
+	c.Assert(err, IsNil)
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}()
+
+	// Wait until the shell command prints "acquired"
+	buf := make([]byte, 8)
+	bytesRead, err := io.ReadAtLeast(stdout, buf, len(buf))
+	c.Assert(err, IsNil)
+	c.Assert(bytesRead, Equals, len(buf))
+
+	err = overlord.LockWithTimeout(flock, 5*time.Millisecond)
+	c.Check(err, ErrorMatches, "timeout for state lock file expired")
+	c.Check(notifyCalls, DeepEquals, []string{
+		"EXTEND_TIMEOUT_USEC=5000",
+	})
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1626,11 +1626,14 @@ func (m *SnapManager) maybeRestart(t *state.Task, info *snap.Info, rebootRequire
 
 	typ := info.Type()
 
-	// if bp is non-trivial then either we're not on classic, or the snap is
-	// snapd. So daemonRestartReason will always return "" which is what we
-	// want. If that combination stops being true and there's a situation
-	// where a non-trivial bp could return a non-empty reason, use IsTrivial
-	// to check and bail before reaching this far.
+	// If the type of the snap requesting this start is non-trivial that either
+	// means we are on Ubuntu Core and the type is a base/kernel/gadget which
+	// requires a reboot of the system, or that the type is snapd in which case
+	// we just do a restart of snapd itself. In these cases restartReason will
+	// be non-empty and thus we will perform a restart.
+	// If restartReason is empty, then the snap requesting the restart was not
+	// a boot participant and thus we don't need to do any sort of restarts as
+	// a result of updating this snap.
 
 	restartReason := daemonRestartReason(st, typ)
 	if restartReason == "" {

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -273,9 +273,15 @@ func AddSnapdSnapServices(s *snap.Info, inter interacter) error {
 			}
 		}
 	}
+
 	// and finally start snapd.service (it will stop by itself and gets
 	// started by systemd then)
-	if err := sysd.Start("snapd.service"); err != nil {
+	// Because of the file lock held on the snapstate by the Overlord, the new
+	// snapd will block there until we release it. For this reason, we cannot
+	// start the unit in blocking mode.
+	// TODO: move/share this responsibility with daemon so that we can make the
+	// start blocking again
+	if err := sysd.StartNoBlock("snapd.service"); err != nil {
 		return err
 	}
 	if err := sysd.StartNoBlock("snapd.seeded.service"); err != nil {

--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -209,7 +209,7 @@ WantedBy=snapd.service
 		{"show", "--property=ActiveState", "snapd.snap-repair.timer"},
 		{"start", "snapd.snap-repair.timer"},
 		{"is-active", "snapd.socket"},
-		{"start", "snapd.service"},
+		{"start", "--no-block", "snapd.service"},
 		{"start", "--no-block", "snapd.seeded.service"},
 		{"start", "--no-block", "snapd.autoimport.service"},
 		{"--user", "--global", "disable", "snapd.session-agent.service"},


### PR DESCRIPTION
There can be situations where there exist two snapd processes in the
system: that's the case when one of them is invoked as a subprocess by
the snap-failure systemd unit (which runs cmd/snap-failure/cmd_snap.go),
which we refer to as the "ephimeral snapd", and the other one is the
new, repaired snapd which is started by the ephimeral one. When this
happens, we do not want both of these processes to operate on the
snapstate at the same time; therefore, create a file-based lock to make
the accesses mutually exclusive.

A file-based lock will cause the second process to block and wait until
the lock is released (which can happen either as a result of an explicit
release operation, or at the termination of the process holding it). The
process starting snapd therefore needs to invoke the "systemctl start
snapd.service" command in non-blocking mode, or it would get itself
blocked, too.

Fixes: https://bugs.launchpad.net/snapd/+bug/1952404

(I first went for an alternative solution involving deferring the snapd start, but I couldn't really follow the code flow. Along the way, I noticed a comment which turned out more confusing than clarifying, so I'm adding a TODO on making it better. But if you already have a suggestion on how to rephrase it, please let me know and I'll update it on the spot)