### PR TITLE
tests/main/security-udev-input-subsystem: drop info from udev

### DIFF
--- a/tests/main/security-udev-input-subsystem/task.yaml
+++ b/tests/main/security-udev-input-subsystem/task.yaml
@@ -14,6 +14,10 @@ prepare: |
     echo "Given the test-snapd-udev-input-subsystem is installed"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-udev-input-subsystem
 
+debug: |
+    # shellcheck disable=SC2046
+    udevadm info $(find /dev/input/ -type c) | grep -e N: -e MAJOR= -e MINOR= -e TAGS= || true
+
 execute: |
     if [ -z "$(find /dev/input/by-path -name '*-event-kbd')" ]; then
         if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ]; then


### PR DESCRIPTION
Drop information from udev database about devices used in the test
