### PR TITLE
snap: add support for `snap watch --last={revert,enable,disable,switch}`

### DIFF
--- a/cmd/snap/last.go
+++ b/cmd/snap/last.go
@@ -72,7 +72,7 @@ func (l *changeIDMixin) GetChangeID() (string, error) {
 		kind = kind[:l]
 	}
 	// our internal change types use "-snap" postfix but let user skip it and use short form.
-	if kind == "refresh" || kind == "install" || kind == "remove" || kind == "connect" || kind == "disconnect" || kind == "configure" || kind == "try" {
+	if kind == "refresh" || kind == "install" || kind == "remove" || kind == "connect" || kind == "disconnect" || kind == "configure" || kind == "try" || kind == "revert" || kind == "enable" || kind == "disable" || kind == "switch" {
 		kind += "-snap"
 	}
 	changes, err := queryChanges(cli, &client.ChangesOptions{Selector: client.ChangesAll})

--- a/cmd/snap/last.go
+++ b/cmd/snap/last.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/strutil"
 )
 
 type changeIDMixin struct {
@@ -72,7 +73,17 @@ func (l *changeIDMixin) GetChangeID() (string, error) {
 		kind = kind[:l]
 	}
 	// our internal change types use "-snap" postfix but let user skip it and use short form.
-	if kind == "refresh" || kind == "install" || kind == "remove" || kind == "connect" || kind == "disconnect" || kind == "configure" || kind == "try" || kind == "revert" || kind == "enable" || kind == "disable" || kind == "switch" {
+	shortForms := []string{
+		// see api_snaps.go:snapInstructionDispTable
+		"install", "refresh", "remove", "revert", "enable", "disable", "switch",
+		// see api_interfaces.go:changeInterfaces
+		"connect", "disconnect",
+		// see api_snap_conf.go:setSnapConf
+		"configure",
+		// see api_sideload_n_try.go:trySnap
+		"try",
+	}
+	if strutil.ListContains(shortForms, kind) {
 		kind += "-snap"
 	}
 	changes, err := queryChanges(cli, &client.ChangesOptions{Selector: client.ChangesAll})


### PR DESCRIPTION
While looking at our code I noticed that we are a bit inconsistent
in our changeIDMixin about where we accept the "short" form for
a change and where we don't. E.g. for the change type `install-snap`
we support the short form `install` but for others like `revert-snap`
we do not.

This commit unifies this some more and fixes a bug in our testsuite
along the way where we use `snap watch --last=revert?` which does
not work today.
