### PR TITLE
cmd: Fixup .clangd to use correct syntax

### DIFF
--- a/cmd/.clangd
+++ b/cmd/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-  Add: -I/usr/include/glib-2.0 -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wno-missing-field-initializers -Wno-unused-parameter
+  Add: [-I/usr/include/glib-2.0, -Wall, -Wextra, -Wmissing-prototypes, -Wstrict-prototypes, -Wno-missing-field-initializers, -Wno-unused-parameter]


### PR DESCRIPTION
Add is expected to be a list of options not a single element as per the
example in https://clangd.llvm.org/config.html#add

Signed-off-by: Alex Murray <alex.murray@canonical.com>
