### PR TITLE
tests/lib/pkgdb: install dbus-user-session during prepare, drop dbus-x11

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -530,7 +530,7 @@ pkg_dependencies_ubuntu_classic(){
     echo "
         avahi-daemon
         cups
-        dbus-x11
+        dbus-user-session
         fontconfig
         gnome-keyring
         jq
@@ -553,7 +553,6 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-16.04-64)
             echo "
-                dbus-user-session
                 evolution-data-server
                 fwupd
                 gccgo-6

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -81,7 +81,7 @@ check_stray_dbus_daemon() {
 	(
 		skipped_system=0
 		skipped_root_session=0
-		for pid in $(pgrep dbus-daemon); do
+		for pid in $(pgrep -x dbus-daemon); do
 			cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline")"
 			# Ignore one dbus-daemon responsible for the system bus.
 			if echo "$cmdline" | grep -q 'dbus-daemon --system' && [ "$skipped_system" -eq 0 ]; then


### PR DESCRIPTION
Use dbus-user-session to provide the session but, and drop dbus-x11 which
requires $DISPLAY and actual X to be running.


