### PR TITLE
tests: retry umounting /var/lib/snapd/seed on uc20 on fsck-on-boot test

### DIFF
--- a/tests/core/fsck-on-boot/task.yaml
+++ b/tests/core/fsck-on-boot/task.yaml
@@ -44,7 +44,7 @@ execute: |
       if mountpoint /run/mnt/snapd >/dev/null; then
         umount /run/mnt/snapd
       fi
-      umount /var/lib/snapd/seed
+      retry -n 20 --wait 2 sh -c 'umount /var/lib/snapd/seed'
       umount /run/mnt/ubuntu-seed
 
       # Refer to the core 20 gadgets for details:


### PR DESCRIPTION
This is to avoid the issue "target is busy umount" trying to umount
/var/lib/snapd/seed on uc20

This error is just reproduced on beta validation.

2021-12-06 17:16:12 Error executing
external:ubuntu-core-20-64:tests/core/fsck-on-boot
(external:ubuntu-core-20-64) :

+ os.query is-core16
+ os.query is-core18
+ os.query is-core20
+ LABEL=ubuntu-seed
+ case "$SPREAD_REBOOT" in
+ echo 'We can corrupt the boot partition'
We can corrupt the boot partition
+ unmount_vfat
+ os.query is-core16
+ os.query is-core18
+ os.query is-core20
+ mountpoint /run/mnt/snapd
+ umount /run/mnt/snapd
+ umount /var/lib/snapd/seed
umount: /var/lib/snapd/seed: target is busy.
