### PR TITLE
overlord: extended ssl support, synthetic update-ca-certification functionality

### DIFF
--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
 // +build !nomanagers
 
 /*
@@ -31,6 +32,221 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 )
+
+type certificate struct {
+	Name     string
+	Path     string
+	RealPath string
+}
+
+// This function validates the name of the certificate. We only allow certificates
+// with the correct suffix ".crt" except for the ca-certificates.crt,
+// or if the name is in the blockedCerts lists.
+func isBlocked(cert certificate, blockedCerts []string) bool {
+	// Special case for ca-certificates.crt
+	if cert.Name == "ca-certificates.crt" {
+		return true
+	}
+
+	// Check that the real underlying filepath to the certificate ends with .crt
+	if !strings.HasSuffix(cert.RealPath, ".crt") {
+		return true
+	}
+
+	// See if the name appears in the blockedCerts list
+	for _, blockedCert := range blockedCerts {
+		if cert.Name == blockedCert {
+			return true
+		}
+	}
+	return false
+}
+
+// TODO Should we support recursive directories inside the certs dir?
+func getCertObjects(basePath string) ([]certificate, error) {
+	certFiles, err := ioutil.ReadDir(basePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read base certs: %v", err)
+	}
+
+	certsObjects := []certificate{}
+	for _, cert := range certFiles {
+		if cert.IsDir() {
+			continue
+		}
+
+		// So what are we trying to achieve here? When provided with certificate directories
+		// they may or may not be symbolic links to the actual certificate file. To handle this
+		// correctly we evaluate the symbolic links and get the real path of the certificate, because
+		// we are not going to 'copy' or link to the symbolic link, instead we will recreate the symbolic
+		// link to the real path of the certificate.
+		certRealPath := filepath.Join(basePath, cert.Name())
+		if cert.Mode()&os.ModeSymlink != 0 {
+			resolvedPath, err := filepath.EvalSymlinks(certRealPath)
+			if err == nil {
+				certRealPath = resolvedPath
+			}
+		}
+
+		// If the file is not a symbolic link then Path and RealPath will be identical.
+		certObject := certificate{
+			Name:     cert.Name(),
+			Path:     filepath.Join(basePath, cert.Name()),
+			RealPath: certRealPath,
+		}
+		certsObjects = append(certsObjects, certObject)
+	}
+	return certsObjects, nil
+}
+
+// Filters out the certificates that are not allowed to be merged.
+func filterCerts(certs []certificate, blockedCerts []string) ([]certificate, error) {
+	filteredCerts := []certificate{}
+	for _, cert := range certs {
+		if isBlocked(cert, blockedCerts) {
+			continue
+		}
+		filteredCerts = append(filteredCerts, cert)
+	}
+	return filteredCerts, nil
+}
+
+func filterCertsInDirectory(dirPath string, blockedCerts []string) error {
+	existingCerts, err := getCertObjects(dirPath)
+	if err != nil {
+		return err
+	}
+
+	// Remove the certs that are marked blocked.
+	for _, cert := range existingCerts {
+		if isBlocked(cert, blockedCerts) {
+			err := os.Remove(cert.Path)
+			if err != nil {
+				return fmt.Errorf("cannot remove blocked certificate: %v", err)
+			}
+		}
+	}
+	return nil
+}
+
+// Populates symbolic links in the output directory, to each certificate
+// provided.
+func installCerts(outputPath string, certs []certificate) error {
+	for _, cert := range certs {
+		// When updating existing certifications we want to make sure we don't
+		// overwrite the certification with itself.
+		certDestinationPath := filepath.Join(outputPath, cert.Name)
+		if certDestinationPath == cert.RealPath {
+			continue
+		}
+
+		// If the path exists, then remove it first to update the certificate
+		if _, err := os.Lstat(certDestinationPath); err == nil {
+			err := os.Remove(certDestinationPath)
+			if err != nil {
+				return fmt.Errorf("cannot remove existing certificate: %v", err)
+			}
+		}
+
+		// Create a link to the real path of the cert in the output path
+		err := os.Symlink(cert.RealPath, certDestinationPath)
+		if err != nil {
+			return fmt.Errorf("cannot copy store certificate: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Generate the ca-certificates.crt to the output path
+// The ca-certificates.crt is a concatenation of all the certs in the
+// output path.
+func generateCACertificate(outputPath string) error {
+	certificates, err := getCertObjects(outputPath)
+	if err != nil {
+		return err
+	}
+
+	certsPath := filepath.Join(outputPath, "ca-certificates.crt")
+	certsFile, err := os.Create(certsPath)
+	if err != nil {
+		return fmt.Errorf("cannot create ca-certificates.crt: %v", err)
+	}
+
+	for _, cert := range certificates {
+		certBytes, err := ioutil.ReadFile(cert.RealPath)
+		if err != nil {
+			return fmt.Errorf("cannot read certificate %q: %v", cert.Name, err)
+		}
+
+		_, err = certsFile.Write(certBytes)
+		if err != nil {
+			return fmt.Errorf("cannot write certificate %q: %v", cert.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func getCertObjectsFromPaths(outputPath string, inputPaths []string) ([]certificate, error) {
+	certObjects := []certificate{}
+	for _, certDirectoryPath := range inputPaths {
+		// If the input directory equals output, then ignore it
+		certFullPath, err := filepath.Abs(certDirectoryPath)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get absolute path for path: %v", certDirectoryPath)
+		}
+		if certFullPath == outputPath {
+			continue
+		}
+
+		certs, err := getCertObjects(certDirectoryPath)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read certs: %v", err)
+		}
+		certObjects = append(certObjects, certs...)
+	}
+	return certObjects, nil
+}
+
+// Allows the caller to combine multiple certification directories into one single directory.
+// The code takes care of creating new symlinks in the output directory, following symlinks from
+// the source directories, and generates the ca-certificates.crt file in the output folder.
+func CombineCertConfigurations(outputPath string, certDirectoryPaths []string, blockedCerts []string) error {
+	outputFullPath, err := filepath.Abs(outputPath)
+	if err != nil {
+		return fmt.Errorf("cannot get absolute path for output path: %v", outputPath)
+	}
+
+	certObjects, err := getCertObjectsFromPaths(outputFullPath, certDirectoryPaths)
+	if err != nil {
+		return err
+	}
+
+	filteredCerts, err := filterCerts(certObjects, blockedCerts)
+	if err != nil {
+		return fmt.Errorf("cannot filter certs: %v", err)
+	}
+
+	if err := os.MkdirAll(outputPath, 0755); err != nil {
+		return fmt.Errorf("cannot create store ssl certs dir: %v", err)
+	}
+
+	// Filter out the certs that are not allowed to be merged, in the output
+	// directory, as we may or may not have certs already in destination path.
+	if err := filterCertsInDirectory(outputPath, blockedCerts); err != nil {
+		return fmt.Errorf("cannot filter output directory: %v", err)
+	}
+
+	if err := installCerts(outputPath, filteredCerts); err != nil {
+		return fmt.Errorf("failed to copy base certs: %v", err)
+	}
+
+	if err := generateCACertificate(outputPath); err != nil {
+		return fmt.Errorf("failed to generate ca-certificates.crt: %v", err)
+	}
+	return nil
+}
 
 func handleCertConfiguration(tr config.Conf, opts *fsOnlyContext) error {
 	// This handles the "snap revert core" case:

--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -234,7 +234,7 @@ func CombineCertConfigurations(outputPath string, certDirectoryPaths []string, b
 	}
 
 	if err := os.MkdirAll(outputPath, 0755); err != nil {
-		return fmt.Errorf("cannot create store ssl certs dir: %v", err)
+		return fmt.Errorf("cannot create output ssl certs dir: %v", err)
 	}
 
 	// Filter out the certs that are not allowed to be merged, in the output

--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -175,14 +175,19 @@ func generateCACertificates(outputPath string) error {
 	}
 
 	for _, cert := range certificates {
-		certBytes, err := ioutil.ReadFile(cert.RealPath)
-		if err != nil {
-			return fmt.Errorf("cannot read certificate %q: %v", cert.Name, err)
+		copyOne := func(from string) error {
+			inf, err := os.Open(from)
+			if err := nil {
+				return err
+			}
+			defer inf.Close()
+			if _, err := io.Copy(certsFile, inf); err != nil {
+				return err
+			}
+			return nil
 		}
-
-		_, err = certsFile.Write(certBytes)
-		if err != nil {
-			return fmt.Errorf("cannot write certificate %q: %v", cert.Name, err)
+		if err := copyOne(cert.RealPath); err != nil {
+			return fmt.Errorf("cannot copy certificate %q: %v", cert.Name, err)
 		}
 	}
 

--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -119,8 +119,7 @@ func filterCertsInDirectory(dirPath string, blockedCerts []string) error {
 	// Remove the certs that are marked blocked.
 	for _, cert := range existingCerts {
 		if isBlocked(cert, blockedCerts) {
-			err := os.Remove(cert.Path)
-			if err != nil {
+			if err := os.Remove(cert.Path); err != nil {
 				return fmt.Errorf("cannot remove blocked certificate: %v", err)
 			}
 		}

--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -154,10 +154,10 @@ func installCerts(outputPath string, certs []certificate) error {
 	return nil
 }
 
-// generateCACertificate Generate the ca-certificates.crt to the output path
+// generateCACertificates Generate the ca-certificates.crt to the output path
 // The ca-certificates.crt is a concatenation of all the certs in the
 // output path.
-func generateCACertificate(outputPath string) error {
+func generateCACertificates(outputPath string) error {
 	certificates, err := getCertObjects(outputPath)
 	if err != nil {
 		return err
@@ -238,7 +238,7 @@ func CombineCertConfigurations(outputPath string, certDirectoryPaths []string, b
 		return fmt.Errorf("failed to copy base certs: %v", err)
 	}
 
-	if err := generateCACertificate(outputPath); err != nil {
+	if err := generateCACertificates(outputPath); err != nil {
 		return fmt.Errorf("failed to generate ca-certificates.crt: %v", err)
 	}
 	return nil
@@ -252,6 +252,7 @@ func handleCertConfiguration(tr config.Conf, opts *fsOnlyContext) error {
 	// XXX: remove this code once we have a general way to handle
 	//      "snap revert" and config updates
 	//
+
 	// TODO: add ways to detect cleanly if tr is a patch, skip the sync code if it is
 	storeCerts, err := filepath.Glob(filepath.Join(dirs.SnapdStoreSSLCertsDir, "*.pem"))
 	if err != nil {

--- a/overlord/configstate/configcore/certs_test.go
+++ b/overlord/configstate/configcore/certs_test.go
@@ -42,6 +42,19 @@ type certsSuite struct {
 
 var _ = Suite(&certsSuite{})
 
+func (s *certsSuite) SetUpTest(c *C) {
+	// Create the folder structure that we need
+	s.certsBasePath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "base")
+	s.certsAddedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "added")
+	s.certsMergedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "merged")
+	s.certsBlockedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "blocked")
+
+	c.Assert(os.MkdirAll(s.certsBasePath, 0755), IsNil)
+	c.Assert(os.MkdirAll(s.certsAddedPath, 0755), IsNil)
+	c.Assert(os.MkdirAll(s.certsMergedPath, 0755), IsNil)
+	c.Assert(os.MkdirAll(s.certsBlockedPath, 0755), IsNil)
+}
+
 func (s *certsSuite) TestConfigureCertsUnhappyName(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
@@ -151,19 +164,6 @@ func (s *certsSuite) TestConfigureCertsUnhappyContent(c *C) {
 		},
 	})
 	c.Assert(err, ErrorMatches, `cannot decode pem certificate "cert-bad"`)
-}
-
-func (s *certsSuite) setupCertificatesTest(c *C) {
-	// Create the folder structure that we need
-	s.certsBasePath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "base")
-	s.certsAddedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "added")
-	s.certsMergedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "merged")
-	s.certsBlockedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "blocked")
-
-	c.Assert(os.MkdirAll(s.certsBasePath, 0755), IsNil)
-	c.Assert(os.MkdirAll(s.certsAddedPath, 0755), IsNil)
-	c.Assert(os.MkdirAll(s.certsMergedPath, 0755), IsNil)
-	c.Assert(os.MkdirAll(s.certsBlockedPath, 0755), IsNil)
 }
 
 func (s *certsSuite) writeMockCertificates(c *C, outputPath string, names []string) {

--- a/overlord/configstate/configcore/certs_test.go
+++ b/overlord/configstate/configcore/certs_test.go
@@ -42,19 +42,6 @@ type certsSuite struct {
 
 var _ = Suite(&certsSuite{})
 
-func (s *certsSuite) SetUpTest(c *C) {
-	// Create the folder structure that we need
-	s.certsBasePath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "base")
-	s.certsAddedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "added")
-	s.certsMergedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "merged")
-	s.certsBlockedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "blocked")
-
-	c.Assert(os.MkdirAll(s.certsBasePath, 0755), IsNil)
-	c.Assert(os.MkdirAll(s.certsAddedPath, 0755), IsNil)
-	c.Assert(os.MkdirAll(s.certsMergedPath, 0755), IsNil)
-	c.Assert(os.MkdirAll(s.certsBlockedPath, 0755), IsNil)
-}
-
 func (s *certsSuite) TestConfigureCertsUnhappyName(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
@@ -164,6 +151,19 @@ func (s *certsSuite) TestConfigureCertsUnhappyContent(c *C) {
 		},
 	})
 	c.Assert(err, ErrorMatches, `cannot decode pem certificate "cert-bad"`)
+}
+
+func (s *certsSuite) setupCertificatesTest(c *C) {
+	// Create the folder structure that we need
+	s.certsBasePath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "base")
+	s.certsAddedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "added")
+	s.certsMergedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "merged")
+	s.certsBlockedPath = filepath.Join(dirs.SnapdStoreSSLCertsDir, "blocked")
+
+	c.Assert(os.MkdirAll(s.certsBasePath, 0755), IsNil)
+	c.Assert(os.MkdirAll(s.certsAddedPath, 0755), IsNil)
+	c.Assert(os.MkdirAll(s.certsMergedPath, 0755), IsNil)
+	c.Assert(os.MkdirAll(s.certsBlockedPath, 0755), IsNil)
 }
 
 func (s *certsSuite) writeMockCertificates(c *C, outputPath string, names []string) {

--- a/overlord/configstate/configcore/certs_test.go
+++ b/overlord/configstate/configcore/certs_test.go
@@ -196,14 +196,15 @@ func (s *certsSuite) TestCombineAndInstallCerts(c *C) {
 	}
 
 	// Perform the actual combine of the certifiation configurations
-	configcore.CombineCertConfigurations(s.certsMergedPath, []string{s.certsBasePath, s.certsAddedPath}, blockedCerts)
+	err := configcore.CombineCertConfigurations(s.certsMergedPath, []string{s.certsBasePath, s.certsAddedPath}, blockedCerts)
+	c.Assert(err, IsNil)
 
 	// Verify output in folder
 	c.Assert(filepath.Join(s.certsMergedPath, "cert0.crt"), testutil.FileEquals, mockCert)
 	c.Assert(filepath.Join(s.certsMergedPath, "cert1.crt"), testutil.FileAbsent)
 	c.Assert(filepath.Join(s.certsMergedPath, "cert2.crt"), testutil.FileEquals, mockCert)
 	c.Assert(filepath.Join(s.certsMergedPath, "cert3.crt"), testutil.FileEquals, mockCert)
-	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, expectedCACdata)
+	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, string(expectedCACdata))
 }
 
 func (s *certsSuite) TestVerifyExclusionOfExtensions(c *C) {
@@ -227,7 +228,7 @@ func (s *certsSuite) TestVerifyExclusionOfExtensions(c *C) {
 	c.Assert(filepath.Join(s.certsMergedPath, "cert1.crt"), testutil.FileEquals, mockCert)
 	c.Assert(filepath.Join(s.certsMergedPath, "cert2"), testutil.FileAbsent)
 	c.Assert(filepath.Join(s.certsMergedPath, "cert3.lasd"), testutil.FileAbsent)
-	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, expectedCACdata)
+	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, string(expectedCACdata))
 }
 
 func (s *certsSuite) TestEmptyDirsNoErrors(c *C) {
@@ -244,7 +245,7 @@ func (s *certsSuite) TestEmptyDirsNoErrors(c *C) {
 	configcore.CombineCertConfigurations(s.certsMergedPath, []string{s.certsBasePath, s.certsAddedPath}, []string{})
 
 	// Verify output in folder
-	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, expectedCACdata)
+	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, string(expectedCACdata))
 }
 
 func (s *certsSuite) TestUpdateCertificates(c *C) {
@@ -273,7 +274,7 @@ func (s *certsSuite) TestUpdateCertificates(c *C) {
 	c.Assert(filepath.Join(s.certsMergedPath, "cert1.crt"), testutil.FileEquals, mockCert)
 	c.Assert(filepath.Join(s.certsMergedPath, "cert1.crt"), testutil.SymlinkTargetEquals, filepath.Join(s.certsAddedPath, "cert1.crt"))
 	c.Assert(filepath.Join(s.certsMergedPath, "cert2.crt"), testutil.FileEquals, mockCert)
-	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, expectedCACdata)
+	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, string(expectedCACdata))
 }
 
 func (s *certsSuite) TestUpdateCertificatesWithOutputInInput(c *C) {
@@ -302,5 +303,5 @@ func (s *certsSuite) TestUpdateCertificatesWithOutputInInput(c *C) {
 	c.Assert(filepath.Join(s.certsMergedPath, "cert1.crt"), testutil.FileEquals, mockCert)
 	c.Assert(filepath.Join(s.certsMergedPath, "cert1.crt"), testutil.SymlinkTargetEquals, filepath.Join(s.certsAddedPath, "cert1.crt"))
 	c.Assert(filepath.Join(s.certsMergedPath, "cert2.crt"), testutil.FileEquals, mockCert)
-	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, expectedCACdata)
+	c.Assert(filepath.Join(s.certsMergedPath, "ca-certificates.crt"), testutil.FileEquals, string(expectedCACdata))
 }


### PR DESCRIPTION
This is preliminary support for synthesizing the functionality update-ca-certificates provides. Since the etc/ssl/certs is mounted as read-only in ubuntu core, we cannot use the update-ca-certificates functionality. 

The story for this PR is to add support for building a new /etc/ssl/certs somewhere that is writable, and then bind mount that directory to /etc/ssl/certs instead. This PR currently only covers the backend functionality of this, and nothing else. Thus this is just a draft PR to start a discussion and get some reviews/comments. This is not ready to be merged as there is still missing the configuration part of how it will work from a frontend perspective.

The goal of this was to have a tool that can take a list of input directories with added certificates, a list of blocked certificates that the user does not want, and then update/fill a target directory with the final combination of SSL certificates, including the generation of the ca-certificates.crt file. 


Oh and I have no idea if this is the right place to put the code, would love to get some feedback on where to put it!