### PR TITLE
data/selinux: allow snapd to access /etc/modprobe.d

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -350,6 +350,11 @@ ifndef(`distro_rhel7',`
   timedatex_dbus_chat(snappy_t)
 ')
 
+# kernel-module-load interface may inspect or write files under /etc/modprobe.d
+optional_policy(`
+  modutils_manage_module_config(snappy_t)
+')
+
 # only pops up in cloud images where cloud-init.target is incorrectly labeled
 allow snappy_t init_var_run_t:lnk_file read;
 


### PR DESCRIPTION
The kernel-module-load interface may trigger accesses to /etc/modprobe.d as seen
in the following denials:

```
type=AVC msg=audit(120721 16:27:22.859:25079) : avc: denied { getattr } for
pid=97494 comm=snapd path=/etc/modprobe.d dev="sda5" ino=13371
scontext=system_u:system_r:snappy_t:s0
tcontext=system_u:object_r:modules_conf_t:s0 tclass=dir permissive=1

type=AVC msg=audit(120721 16:27:22.859:25080) : avc: denied { read } for
pid=97494 comm=snapd name=modprobe.d dev="sda5" ino=13371
scontext=system_u:system_r:snappy_t:s0
tcontext=system_u:object_r:modules_conf_t:s0 tclass=dir permissive=1

type=AVC msg=audit(120721 16:27:22.859:25081) : avc: denied { open } for
pid=97494 comm=snapd path=/etc/modprobe.d dev="sda5" ino=13371
scontext=system_u:system_r:snappy_t:s0
tcontext=system_u:object_r:modules_conf_t:s0 tclass=dir permissive=1
```

