### PR TITLE
o/snapstate: check disk space w/o store if possible

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -269,7 +269,7 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// if a previous version of snapd persisted Prereq only, fill the contentAttrs.
-	// There will be not content attrs, so it will not update an outdated default provider
+	// There will be no content attrs, so it will not update an outdated default provider
 	if len(snapsup.PrereqContentAttrs) == 0 && len(snapsup.Prereq) != 0 {
 		snapsup.PrereqContentAttrs = make(map[string][]string, len(snapsup.Prereq))
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -173,7 +173,7 @@ type pathInfo struct {
 }
 
 func (i pathInfo) DownloadSize() int64 {
-	return i.DownloadInfo.Size
+	return i.Size
 }
 
 // SnapBase returns the base snap of the snap.

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4702,7 +4702,7 @@ version: 1
 	return brokenSnap, si
 }
 
-func (s *snapmgrTestSuite) TestInstallPathManyDiskSpaceCheckIsLocal(c *C) {
+func (s *snapmgrTestSuite) TestInstallPathManyWithLocalPrereqAndBaseNoStore(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -4710,190 +4710,9 @@ func (s *snapmgrTestSuite) TestInstallPathManyDiskSpaceCheckIsLocal(c *C) {
 	c.Assert(tr.Set("core", "experimental.check-disk-space-install", true), IsNil)
 	tr.Commit()
 
+	// use the real disk check since it also includes store checks
 	restore := snapstate.MockInstallSize(snapstate.InstallSize)
 	defer restore()
-
-	var paths []string
-	var sideInfos []*snap.SideInfo
-
-	snapNames := []string{"some-snap", "other-snap", "core"}
-	yamls := []string{
-		`name: some-snap
-version: 1.0
-epoch: 1
-base: core
-plugs:
-  myplug:
-    interface: content
-    content: mycontent
-    default-provider: other-snap`,
-		`name: other-snap
-version: 1.0
-epoch: 1
-base: core
-slots:
-  myslot:
-    interface: content
-    content: mycontent`,
-		`name: core
-version: 1.0
-epoch: 1
-type: base`,
-	}
-
-	for i, name := range snapNames {
-		yaml := yamls[i]
-		paths = append(paths, makeTestSnap(c, yaml))
-
-		si := &snap.SideInfo{
-			RealName: name,
-			Revision: snap.R("1"),
-		}
-		sideInfos = append(sideInfos, si)
-	}
-
-	_, err := snapstate.InstallPathMany(context.Background(), s.state, sideInfos, paths, 0, nil)
-	c.Assert(err, IsNil)
-
-	op := s.fakeBackend.ops.First("storesvc-snap-action")
-	c.Assert(op, IsNil)
-}
-
-func (s *snapmgrTestSuite) TestInstallPathManyDiskSpaceCheckIsLocalWithCoreInstalled(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	snapstate.Set(s.state, "core", &snapstate.SnapState{
-		Active: true,
-		Sequence: []*snap.SideInfo{
-			{RealName: "core", Revision: snap.R(1), SnapID: "core"},
-		},
-		Current:  snap.R(1),
-		SnapType: "os",
-	})
-
-	tr := config.NewTransaction(s.state)
-	c.Assert(tr.Set("core", "experimental.check-disk-space-install", true), IsNil)
-	tr.Commit()
-
-	restore := snapstate.MockInstallSize(snapstate.InstallSize)
-	defer restore()
-
-	var paths []string
-	var sideInfos []*snap.SideInfo
-
-	snapNames := []string{"some-snap", "other-snap"}
-	yamls := []string{
-		`name: some-snap
-version: 1.0
-epoch: 1
-base: core
-plugs:
-  myplug:
-    interface: content
-    content: mycontent
-    default-provider: other-snap`,
-		`name: other-snap
-version: 1.0
-epoch: 1
-base: core
-slots:
-  myslot:
-    interface: content
-    content: mycontent`,
-	}
-
-	for i, name := range snapNames {
-		yaml := yamls[i]
-		paths = append(paths, makeTestSnap(c, yaml))
-
-		si := &snap.SideInfo{
-			RealName: name,
-			Revision: snap.R("1"),
-		}
-		sideInfos = append(sideInfos, si)
-	}
-
-	_, err := snapstate.InstallPathMany(context.Background(), s.state, sideInfos, paths, 0, nil)
-	c.Assert(err, IsNil)
-
-	op := s.fakeBackend.ops.First("storesvc-snap-action")
-	c.Assert(op, IsNil)
-}
-
-func (s *snapmgrTestSuite) TestInstallPathManyLocalDiskSpaceCheckExceeding(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	tr := config.NewTransaction(s.state)
-	c.Assert(tr.Set("core", "experimental.check-disk-space-install", true), IsNil)
-	tr.Commit()
-
-	restore := snapstate.MockInstallSize(snapstate.InstallSize)
-	defer restore()
-
-	var paths []string
-	var sideInfos []*snap.SideInfo
-
-	snapNames := []string{"some-snap", "other-snap", "core"}
-	yamls := []string{
-		`name: some-snap
-version: 1.0
-epoch: 1
-base: core
-plugs:
-  myplug:
-    interface: content
-    content: mycontent
-    default-provider: other-snap`,
-		`name: other-snap
-version: 1.0
-epoch: 1
-base: core
-slots:
-  myslot:
-    interface: content
-    content: mycontent`,
-		`name: core
-version: 1.0
-epoch: 1
-type: base`,
-	}
-
-	var totalSize uint64
-	for i, name := range snapNames {
-		yaml := yamls[i]
-		path := makeTestSnap(c, yaml)
-		paths = append(paths, path)
-
-		si := &snap.SideInfo{
-			RealName: name,
-			Revision: snap.R("1"),
-		}
-		sideInfos = append(sideInfos, si)
-
-		fi, err := os.Stat(path)
-		c.Assert(err, IsNil)
-		totalSize += uint64(fi.Size())
-	}
-
-	restore = snapstate.MockOsutilCheckFreeSpace(func(path string, minSize uint64) error {
-		c.Assert(minSize, Equals, snapstate.SafetyMarginDiskSpace(totalSize))
-		return &osutil.NotEnoughDiskSpaceError{}
-	})
-	defer restore()
-
-	tss, err := snapstate.InstallPathMany(context.Background(), s.state, sideInfos, paths, 0, nil)
-	c.Assert(err, FitsTypeOf, &snapstate.InsufficientSpaceError{})
-	c.Check(tss, HasLen, 0)
-
-	op := s.fakeBackend.ops.First("storesvc-snap-action")
-	c.Assert(op, IsNil)
-}
-
-func (s *snapmgrTestSuite) TestInstallPathManyWithLocalBase(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
 
 	// no core, we'll install it as well
 	snapstate.Set(s.state, "core", nil)
@@ -4901,13 +4720,24 @@ func (s *snapmgrTestSuite) TestInstallPathManyWithLocalBase(c *C) {
 	var paths []string
 	var sideInfos []*snap.SideInfo
 
-	snapNames := []string{"some-snap", "core"}
+	snapNames := []string{"some-snap", "prereq-snap", "core"}
 	yamls := []string{
 		`name: some-snap
 version: 1.0
-type: app
 base: core
+plugs:
+  myplug:
+    interface: content
+    content: mycontent
+    default-provider: prereq-snap
 `,
+		`name: prereq-snap
+version: 1.0
+base: core
+slots:
+  myslot:
+    interface: content
+    content: mycontent`,
 		`name: core
 version: 1.0
 type: base
@@ -4925,60 +4755,7 @@ type: base
 
 	tss, err := snapstate.InstallPathMany(context.Background(), s.state, sideInfos, paths, 0, nil)
 	c.Assert(err, IsNil)
-	c.Assert(tss, HasLen, 2)
-
-	chg := s.state.NewChange("install", "install local snaps")
-	for _, ts := range tss {
-		chg.AddAll(ts)
-	}
-
-	defer s.se.Stop()
-	s.settle(c)
-
-	c.Assert(chg.Err(), IsNil)
-	c.Assert(chg.IsReady(), Equals, true)
-
-	op := s.fakeBackend.ops.First("storesvc-snap-action")
-	c.Assert(op, IsNil)
-}
-
-func (s *snapmgrTestSuite) TestInstallPathManyWithLocalPrerequisite(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	var paths []string
-	var sideInfos []*snap.SideInfo
-
-	snapNames := []string{"some-snap", "prereq-snap"}
-	yamls := []string{
-		`name: some-snap
-version: 1.0
-plugs:
-  myplug:
-    interface: content
-    content: mycontent
-    default-provider: prereq-snap`,
-		`name: prereq-snap
-version: 1.0
-slots:
-  myslot:
-    interface: content
-    content: mycontent
-`,
-	}
-
-	for i, name := range snapNames {
-		paths = append(paths, makeTestSnap(c, yamls[i]))
-		si := &snap.SideInfo{
-			RealName: name,
-			Revision: snap.R("1"),
-		}
-		sideInfos = append(sideInfos, si)
-	}
-
-	tss, err := snapstate.InstallPathMany(context.Background(), s.state, sideInfos, paths, 0, nil)
-	c.Assert(err, IsNil)
-	c.Assert(tss, HasLen, 2)
+	c.Assert(tss, HasLen, 3)
 
 	chg := s.state.NewChange("install", "install local snaps")
 	for _, ts := range tss {

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -113,6 +113,11 @@ var installSize = func(st *state.State, snaps []minimalInstallInfo, userID int) 
 		accountedSnaps[snap.InstanceName] = true
 	}
 
+	// if prerequisites are included in the install, don't download them again
+	for _, snap := range snaps {
+		accountedSnaps[snap.InstanceName()] = true
+	}
+
 	var prereqs []string
 
 	resolveBaseAndContentProviders := func(inst minimalInstallInfo) {

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -113,7 +113,8 @@ var installSize = func(st *state.State, snaps []minimalInstallInfo, userID int) 
 		accountedSnaps[snap.InstanceName] = true
 	}
 
-	// if prerequisites are included in the install, don't download them again
+	// if the prerequisites are included in the install, don't query the store
+	// for info on them
 	for _, snap := range snaps {
 		accountedSnaps[snap.InstanceName()] = true
 	}

--- a/snap/info.go
+++ b/snap/info.go
@@ -303,7 +303,7 @@ type Info struct {
 	Broken string
 
 	// The information in these fields is ephemeral, available only from the
-	// store.
+	// store or when read from a snap file.
 	DownloadInfo
 
 	Prices  map[string]float64


### PR DESCRIPTION
The disk space checks were obtaining the size of the snaps' prerequisites and 
base via a call to the store. However, an InstallPathMany should allow the
user to install without calls to the store, if all requirements are
available locally. This change makes it so that, if the required bases and
prereqs are included in the install, those are used for the disk check instead
of gotten through the store. Note that for Install/UpdateMany with
prerequisites the already downloaded prereqs are also used, instead of
redownloaded.