### PR TITLE
many: fix formatting w/ latest go version

### DIFF
--- a/asserts/sysdb/staging.go
+++ b/asserts/sysdb/staging.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build withtestkeys || withstagingkeys
 // +build withtestkeys withstagingkeys
 
 /*

--- a/asserts/sysdb/testkeys.go
+++ b/asserts/sysdb/testkeys.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build withtestkeys
 // +build withtestkeys
 
 /*

--- a/bootloader/assets/assetstesting.go
+++ b/bootloader/assets/assetstesting.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build withbootassetstesting
 // +build withbootassetstesting
 
 /*

--- a/bootloader/withbootassettesting.go
+++ b/bootloader/withbootassettesting.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build withbootassetstesting
 // +build withbootassetstesting
 
 /*

--- a/bootloader/withbootassettesting_test.go
+++ b/bootloader/withbootassettesting_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build withbootassetstesting
 // +build withbootassetstesting
 
 /*

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build nosecboot
 // +build nosecboot
 
 /*

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_secboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_secboot.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/cmd/snap-preseed/preseed_other.go
+++ b/cmd/snap-preseed/preseed_other.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !linux
 // +build !linux
 
 /*

--- a/cmd/snap-repair/staging.go
+++ b/cmd/snap-repair/staging.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build withtestkeys || withstagingkeys
 // +build withtestkeys withstagingkeys
 
 /*

--- a/cmd/snap-repair/testkeys.go
+++ b/cmd/snap-repair/testkeys.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build withtestkeys
 // +build withtestkeys
 
 /*

--- a/cmd/snap-seccomp/main_nonriscv64.go
+++ b/cmd/snap-seccomp/main_nonriscv64.go
@@ -1,5 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
+//go:build !riscv64
 // +build !riscv64
 
 /*

--- a/cmd/snap-seccomp/main_ppc64le.go
+++ b/cmd/snap-seccomp/main_ppc64le.go
@@ -1,5 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
+//go:build ppc64le && go1.7 && !go1.8
 // +build ppc64le,go1.7,!go1.8
 
 /*

--- a/cmd/snap-seccomp/main_riscv64.go
+++ b/cmd/snap-seccomp/main_riscv64.go
@@ -1,5 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
+//go:build riscv64
 // +build riscv64
 
 /*

--- a/cmd/snap-seccomp/old_seccomp.go
+++ b/cmd/snap-seccomp/old_seccomp.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build oldseccomp
 // +build oldseccomp
 
 /*

--- a/cmd/snap-update-ns/bootstrap_ppc64le.go
+++ b/cmd/snap-update-ns/bootstrap_ppc64le.go
@@ -1,5 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
+//go:build ppc64le && go1.7 && !go1.8
 // +build ppc64le,go1.7,!go1.8
 
 /*

--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !darwin
 // +build !darwin
 
 /*

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !darwin
 // +build !darwin
 
 /*

--- a/cmd/snap/cmd_version_other.go
+++ b/cmd/snap/cmd_version_other.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !linux
 // +build !linux
 
 /*

--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/gadget/install/install_dummy.go
+++ b/gadget/install/install_dummy.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build nosecboot
 // +build nosecboot
 
 /*

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/gadget/install/mount_other.go
+++ b/gadget/install/mount_other.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !linux
 // +build !linux
 
 /*

--- a/osutil/chattr_32.go
+++ b/osutil/chattr_32.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build arm || 386 || ppc
 // +build arm 386 ppc
 
 /*

--- a/osutil/chattr_64.go
+++ b/osutil/chattr_64.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build amd64 || arm64 || ppc64le || riscv64 || s390x
 // +build amd64 arm64 ppc64le riscv64 s390x
 
 /*

--- a/osutil/cp_other.go
+++ b/osutil/cp_other.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !linux
 // +build !linux
 
 /*

--- a/osutil/export_fault_test.go
+++ b/osutil/export_fault_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build faultinject
 // +build faultinject
 
 /*

--- a/osutil/faultinject.go
+++ b/osutil/faultinject.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build faultinject
 // +build faultinject
 
 /*

--- a/osutil/faultinject_dummy.go
+++ b/osutil/faultinject_dummy.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !faultinject
 // +build !faultinject
 
 /*

--- a/osutil/faultinject_dummy_test.go
+++ b/osutil/faultinject_dummy_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !faultinject
 // +build !faultinject
 
 /*

--- a/osutil/faultinject_test.go
+++ b/osutil/faultinject_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build faultinject
 // +build faultinject
 
 /*

--- a/osutil/group_cgo.go
+++ b/osutil/group_cgo.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build cgo
 // +build cgo
 
 /*

--- a/osutil/group_no_cgo.go
+++ b/osutil/group_no_cgo.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !cgo
 // +build !cgo
 
 package osutil

--- a/osutil/settime_32bit.go
+++ b/osutil/settime_32bit.go
@@ -1,5 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
+//go:build (386 || arm) && linux
 // +build 386 arm
 // +build linux
 

--- a/osutil/settime_64bit.go
+++ b/osutil/settime_64bit.go
@@ -1,8 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
-// +build !386
-// +build !arm
-// +build linux
+//go:build !386 && !arm && linux
+// +build !386,!arm,linux
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/osutil/sys/sysnum_16_linux.go
+++ b/osutil/sys/sysnum_16_linux.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build arm || 386
 // +build arm 386
 
 /*

--- a/osutil/sys/sysnum_32_linux.go
+++ b/osutil/sys/sysnum_32_linux.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build amd64 || arm64 || ppc || ppc64le || riscv64 || s390x
 // +build amd64 arm64 ppc ppc64le riscv64 s390x
 
 /*

--- a/osutil/udev/netlink/rawsockstop_other.go
+++ b/osutil/udev/netlink/rawsockstop_other.go
@@ -1,4 +1,6 @@
+//go:build !arm64
 // +build !arm64
+
 // don't remove the newline between the above statement and the package statement
 // or else the build constraint will be ignored and assumed to be part of the package comment!
 

--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
 // +build !nomanagers
 
 /*

--- a/overlord/configstate/configcore/cloud.go
+++ b/overlord/configstate/configcore/cloud.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
 // +build !nomanagers
 
 /*

--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
 // +build !nomanagers
 
 /*

--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
 // +build !nomanagers
 
 /*

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
 // +build !nomanagers
 
 /*

--- a/overlord/configstate/configcore/snapshots.go
+++ b/overlord/configstate/configcore/snapshots.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
 // +build !nomanagers
 
 /*

--- a/overlord/configstate/configcore/vitality.go
+++ b/overlord/configstate/configcore/vitality.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
 // +build !nomanagers
 
 /*

--- a/polkit/pid_start_time.go
+++ b/polkit/pid_start_time.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build linux
 // +build linux
 
 /*

--- a/polkit/pid_start_time_test.go
+++ b/polkit/pid_start_time_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build linux
 // +build linux
 
 /*

--- a/secboot/encrypt_dummy.go
+++ b/secboot/encrypt_dummy.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build nosecboot
 // +build nosecboot
 
 /*

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build nosecboot
 // +build nosecboot
 
 /*

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 // +build !nosecboot
 
 /*

--- a/snapdenv/withtestkeys.go
+++ b/snapdenv/withtestkeys.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build withtestkeys
 // +build withtestkeys
 
 /*

--- a/snapdtool/tool_other.go
+++ b/snapdtool/tool_other.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !linux
 // +build !linux
 
 /*

--- a/strutil/ctrl16.go
+++ b/strutil/ctrl16.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package strutil

--- a/strutil/ctrl17.go
+++ b/strutil/ctrl17.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package strutil


### PR DESCRIPTION
Fix formatting when running the latest version (1.17) of gofmt. The relevant part of the go release's changelog is [here](https://go.dev/doc/go1.17#gofmt) 
