### PR TITLE
tests/lib/tools/tests.invariant: add invariant for detecting broken snaps

### DIFF
--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -126,10 +126,12 @@ check_leftover_defer_sh() {
 check_broken_snaps() {
 	n="$1" # invariant name
 	(
-		# awk is hard - this just gives us the names of snaps that are broken
-		for broke_snap in $(snap list --all | tail -n +2 | awk '{print $(NF) " " $1}' | grep 'broken ' | awk '{print $(NF)}' | sort | uniq); do
-			# could be multiple broken revisions
-			echo "snap ${broke_snap} is broken"
+		# fist column is the snap name, revision is 3rd from the end, we cannot use $3 as
+		# broken snaps have empty version column
+		# TODO: when https://github.com/snapcore/snapd/pull/11166 is landed, 
+		# this can be simplified
+		snap list --all | awk '/,?broken,?/ { print $1, $(NF-3) }' | while read -r name rev; do 
+			echo "snap $name ($rev) is broken"
 		done
 	) > "$TESTSTMP/tests.invariant.$n"
 	if [ -s "$TESTSTMP/tests.invariant.$n" ]; then

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -127,9 +127,9 @@ check_broken_snaps() {
 	n="$1" # invariant name
 	(
 		# awk is hard - this just gives us the names of snaps that are broken
-		for brokesn in $(snap list --all | tail -n +2 | awk '{print $(NF) " " $1}' | grep 'broken ' | awk '{print $(NF)}' | sort | uniq); do
+		for broke_snap in $(snap list --all | tail -n +2 | awk '{print $(NF) " " $1}' | grep 'broken ' | awk '{print $(NF)}' | sort | uniq); do
 			# could be multiple broken revisions
-			echo "snap $brokesn is broken"
+			echo "snap ${broke_snap} is broken"
 		done
 	) > "$TESTSTMP/tests.invariant.$n"
 	if [ -s "$TESTSTMP/tests.invariant.$n" ]; then

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -9,6 +9,7 @@ show_help() {
 	echo "    lxcfs-mounted: /var/lib/lxcfs is a mount point"
 	echo "    stray-dbus-daemon: at most one dbus-daemon is running"
 	echo "    leftover-defer-sh: defer.sh must not be left over by tests"
+	echo "    broken-snaps: snaps must not be left around that are in a broken state"
 }
 
 if [ $# -eq 0 ]; then
@@ -122,6 +123,22 @@ check_leftover_defer_sh() {
 	fi
 }
 
+check_broken_snaps() {
+	n="$1" # invariant name
+	(
+		# awk is hard - this just gives us the names of snaps that are broken
+		for brokesn in $(snap list --all | tail -n +2 | awk '{print $(NF) " " $1}' | grep 'broken ' | awk '{print $(NF)}' | sort | uniq); do
+			# could be multiple broken revisions
+			echo "snap $brokesn is broken"
+		done
+	) > "$TESTSTMP/tests.invariant.$n"
+	if [ -s "$TESTSTMP/tests.invariant.$n" ]; then
+		echo "tests.invariant: broken snaps" >&2
+		cat "$TESTSTMP/tests.invariant.$n" >&2
+		return 1
+	fi
+}
+
 check_invariant() {
 	case "$1" in
 		root-files-in-home)
@@ -139,6 +156,9 @@ check_invariant() {
 		leftover-defer-sh)
 			check_leftover_defer_sh "$1"
 			;;
+		broken-snaps)
+			check_broken_snaps "$1"
+			;;
 		*)
 			echo "tests.invariant: unknown invariant $1" >&2
 			exit 1
@@ -147,7 +167,7 @@ check_invariant() {
 }
 
 main() {
-	ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted stray-dbus-daemon leftover-defer-sh"
+	ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted stray-dbus-daemon leftover-defer-sh broken-snaps"
 
 	case "$action" in
 		check)

--- a/tests/main/try/task.yaml
+++ b/tests/main/try/task.yaml
@@ -21,8 +21,7 @@ restore: |
 execute: |
     echo "Given a buildable snap in a known directory"
     echo "When try is executed on that directory"
-    cp -r "$TESTSLIB"/snaps/test-snapd-tools test-snapd-tools
-    snap try test-snapd-tools
+    snap try "$TESTSLIB"/snaps/test-snapd-tools
 
     echo "Then the snap is listed as installed with try in the notes"
     snap list | MATCH '^test-snapd-tools .* try'
@@ -33,16 +32,6 @@ execute: |
     echo "And commands from the snap-try binary can read in a readable dir"
     echo -n "Hello World" > "$READABLE_FILE"
     test-snapd-tools.cat "$READABLE_FILE" | MATCH "Hello World"
-
-    # intentionally break the try snap by removing the meta directory so that
-    # snapd cannot read the snap.yaml
-    rm -r test-snapd-tools
-
-    systemctl restart snapd
-
-    # exit early so that the tests.invariant catches out purposefully broken 
-    # snap (hopefully...)
-    exit 0
 
     echo "Given a buildable snap which access confinement-protected resources in a known directory"
     echo "When try is executed on that directory"

--- a/tests/main/try/task.yaml
+++ b/tests/main/try/task.yaml
@@ -21,7 +21,8 @@ restore: |
 execute: |
     echo "Given a buildable snap in a known directory"
     echo "When try is executed on that directory"
-    snap try "$TESTSLIB"/snaps/test-snapd-tools
+    cp -r "$TESTSLIB"/snaps/test-snapd-tools test-snapd-tools
+    snap try test-snapd-tools
 
     echo "Then the snap is listed as installed with try in the notes"
     snap list | MATCH '^test-snapd-tools .* try'
@@ -32,6 +33,16 @@ execute: |
     echo "And commands from the snap-try binary can read in a readable dir"
     echo -n "Hello World" > "$READABLE_FILE"
     test-snapd-tools.cat "$READABLE_FILE" | MATCH "Hello World"
+
+    # intentionally break the try snap by removing the meta directory so that
+    # snapd cannot read the snap.yaml
+    rm -r test-snapd-tools
+
+    systemctl restart snapd
+
+    # exit early so that the tests.invariant catches out purposefully broken 
+    # snap (hopefully...)
+    exit 0
 
     echo "Given a buildable snap which access confinement-protected resources in a known directory"
     echo "When try is executed on that directory"


### PR DESCRIPTION
Tests should generally not leave broken snaps lying around, if there are broken
snaps left, then they should be cleaned up by the test itself to avoid failing
this invariant.

I expect the initial opening of this to reveal some lurking dragons so opening as
a draft to see what happens and what tests need to be cleaned up.