### PR TITLE
devicestate,timeutil: improve logging of NTP sync

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1754,7 +1754,12 @@ func (m *DeviceManager) StoreContextBackend() storecontext.Backend {
 var timeutilIsNTPSynchronized = timeutil.IsNTPSynchronized
 
 func (m *DeviceManager) ntpSyncedOrWaitedLongerThan(maxWait time.Duration) bool {
-	if m.ntpSyncedOrTimedOut || time.Now().After(startTime.Add(maxWait)) {
+	if m.ntpSyncedOrTimedOut {
+		return true
+	}
+	if time.Now().After(startTime.Add(maxWait)) {
+		logger.Noticef("no NTP sync after %v, trying auto-refresh anyway", maxWait)
+		m.ntpSyncedOrTimedOut = true
 		return true
 	}
 

--- a/timeutil/synchronized.go
+++ b/timeutil/synchronized.go
@@ -25,7 +25,6 @@ import (
 	"github.com/godbus/dbus"
 
 	"github.com/snapcore/snapd/dbusutil"
-	"github.com/snapcore/snapd/logger"
 )
 
 func isNoServiceOrUnknownPropertyDbusErr(err error) bool {
@@ -69,7 +68,6 @@ func IsNTPSynchronized() (bool, error) {
 	if !ok {
 		return false, fmt.Errorf("timedate1 returned invalid value for NTPSynchronized property: %s", dbusV)
 	}
-	logger.Debugf("NTPSynchronized state returned by timedate1: %s", dbusV)
 
 	return v, nil
 }


### PR DESCRIPTION
The current code in timeutil can produce excessive logging that spams the journal, if no NTP sync is happening each Ensure() call will trigger a log message that no NTP sync happend. The logger also does not belong into something generic like timeutil.

Instead it the devicemgr code will log (once) when it can*t get an NTP sync within the timeout.