### PR TITLE
cmd/snap: print a placeholder for version of broken snaps

### DIFF
--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -84,6 +84,14 @@ func fmtChannel(ch string) string {
 	return ch[:idx+1] + "…"
 }
 
+func fmtVersion(v string) string {
+	if v == "" {
+		// most likely a broken snap, leave a placeholder
+		return "-"
+	}
+	return v
+}
+
 func (x *cmdList) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
@@ -116,7 +124,7 @@ func (x *cmdList) Execute(args []string) error {
 		// doing it this way because otherwise it's a sea of %s\t%s\t%s
 		line := []string{
 			snap.Name,
-			snap.Version,
+			fmtVersion(snap.Version),
 			snap.Revision.String(),
 			fmtChannel(snap.TrackingChannel),
 			shortPublisher(esc, snap.Publisher),

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -202,6 +202,8 @@ func (s *SnapSuite) TestListWithNotes(c *check.C) {
 ,{"name": "dm1", "status": "active", "version": "5", "revision":1, "devmode": true, "confinement": "devmode"}
 ,{"name": "dm2", "status": "active", "version": "5", "revision":1, "devmode": true, "confinement": "strict"}
 ,{"name": "cf1", "status": "active", "version": "6", "revision":2, "confinement": "devmode", "jailmode": true}
+,{"name": "br1", "status": "active", "version": "", "revision":2, "publisher": {"id": "bar-id", "username": "bar", "display-name": "Bar", "validation": "unproven"}, "confinement": "strict", "broken": "snap is broken"}
+,{"name": "dbr1", "status": "", "version": "", "revision":2, "publisher": {"id": "bar-id", "username": "bar", "display-name": "Bar", "validation": "unproven"}, "confinement": "strict", "broken": "snap is broken"}
 ]}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
@@ -217,6 +219,8 @@ func (s *SnapSuite) TestListWithNotes(c *check.C) {
 	c.Check(s.Stdout(), check.Matches, `(?ms).*^dm1 +.* +devmode$`)
 	c.Check(s.Stdout(), check.Matches, `(?ms).*^dm2 +.* +devmode$`)
 	c.Check(s.Stdout(), check.Matches, `(?ms).*^cf1 +.* +jailmode$`)
+	c.Check(s.Stdout(), check.Matches, `(?ms).*^br1 +- +2 +- +bar +broken$`)
+	c.Check(s.Stdout(), check.Matches, `(?ms).*^dbr1 +- +2 +- +bar +disabled,broken$`)
 	c.Check(s.Stderr(), check.Equals, "")
 }
 

--- a/cmd/snap/cmd_warnings_test.go
+++ b/cmd/snap/cmd_warnings_test.go
@@ -222,7 +222,7 @@ func (s *warningSuite) TestListWithWarnings(c *check.C) {
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
 Name  Version  Rev    Tracking  Publisher  Notes
-               unset  -         -          disabled
+      -        unset  -         -          disabled
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "WARNING: There are 2 new warnings. See 'snap warnings'.\n")
 


### PR DESCRIPTION
When producing the output of `snap list`, snaps that are broken (i.e. not
mounted) are printed without their version. This can be confusing when the
output is further processes by shell tools such as sed/awk/cut. Tweak the code
to always include a placeholder, even if the version is empty.

