### PR TITLE
tests: skip installing systemd-timesyncd in debian 10

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -627,7 +627,6 @@ pkg_dependencies_ubuntu_classic(){
                 packagekit
                 sbuild
                 schroot
-                systemd-timesyncd
                 "
             ;;
     esac
@@ -636,6 +635,7 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                  bpftool
                  strace
+                 systemd-timesyncd
                  "
             ;;
     esac


### PR DESCRIPTION
This packages is having dependency issues to be installed in debian 10,
so images cannot be updated correctly on spread-images project.

The error is:

The following packages have unmet dependencies:
systemd-timesyncd : Depends: systemd (= 247.3-6~bpo10+1) but
241-7~deb10u8 is to be installed
Breaks: systemd (< 245.4-2~) but 241-7~deb10u8 is
to be installed
E: Unable to correct problems, you have held broken packages.
quiet: end of output.
