### PR TITLE
cmd/snap-device-helper: bring back the device type identification behavior, but for remove action fallback only

### DIFF
--- a/cmd/snap-device-helper/snap-device-helper-test.c
+++ b/cmd/snap-device-helper/snap-device-helper-test.c
@@ -282,6 +282,94 @@ static void test_sdh_action_nvme(sdh_test_fixture *fixture, gconstpointer test_d
     }
 }
 
+static void test_sdh_action_remove_fallback_devtype(sdh_test_fixture *fixture, gconstpointer test_data) {
+    /* check that fallback guessing of device type if applied during remove action */
+    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1");
+    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1p1");
+    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/ng0n1");
+    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/hwmon0");
+    mkdir_in_sysroot(fixture, "/sys/devices/foo/block/sda/sda4");
+    mkdir_in_sysroot(fixture, "/sys//devices/pnp0/00:04/tty/ttyS0");
+
+    struct {
+        const char *dev;
+        const char *majmin;
+        int expected_maj;
+        int expected_min;
+        int expected_type;
+    } tcs[] = {
+        /* these device paths match the fallback pattern of block devices */
+        {
+            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1",
+            .majmin = "259:0",
+            .expected_maj = 259,
+            .expected_min = 0,
+            .expected_type = S_IFBLK,
+        },
+        {
+            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1p1",
+            .majmin = "259:1",
+            .expected_maj = 259,
+            .expected_min = 1,
+            .expected_type = S_IFBLK,
+        },
+        {
+            .dev = "/devices/foo/block/sda/sda4",
+            .majmin = "8:0",
+            .expected_maj = 8,
+            .expected_min = 0,
+            .expected_type = S_IFBLK,
+        },
+        /* these are treated as char devices */
+        {
+            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0",
+            .majmin = "242:0",
+            .expected_maj = 242,
+            .expected_min = 0,
+            .expected_type = S_IFCHR,
+        },
+        {
+            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/hwmon0",
+            .majmin = "241:0",
+            .expected_maj = 241,
+            .expected_min = 0,
+            .expected_type = S_IFCHR,
+        },
+        {
+            .dev = "/devices/pnp0/00:04/tty/ttyS0",
+            .majmin = "4:64",
+            .expected_maj = 4,
+            .expected_min = 64,
+            .expected_type = S_IFCHR,
+        },
+    };
+
+    int bogus = 0;
+
+    for (size_t i = 0; i < sizeof(tcs) / sizeof(tcs[0]); i++) {
+        mocks_reset();
+        /* make cgroup_device_new return a non-NULL */
+        mocks.new_ret = &bogus;
+
+        struct sdh_invocation inv_block = {
+            .action = "remove",
+            .tagname = "snap_foo_bar",
+            .devpath = tcs[i].dev,
+            .majmin = tcs[i].majmin,
+        };
+        int ret = snap_device_helper_run(&inv_block);
+        g_assert_cmpint(ret, ==, 0);
+        g_assert_cmpint(mocks.cgorup_new_calls, ==, 1);
+        g_assert_cmpint(mocks.cgroup_allow_calls, ==, 0);
+        g_assert_cmpint(mocks.cgroup_deny_calls, ==, 1);
+        g_assert_cmpint(mocks.device_major, ==, tcs[i].expected_maj);
+        g_assert_cmpint(mocks.device_minor, ==, tcs[i].expected_min);
+        g_assert_cmpint(mocks.device_type, ==, tcs[i].expected_type);
+        g_assert_cmpint(mocks.new_flags, !=, 0);
+        g_assert_cmpint(mocks.new_flags, ==, SC_DEVICE_CGROUP_FROM_EXISTING);
+    }
+}
+
 static void run_sdh_die(const char *action, const char *tagname, const char *devpath, const char *majmin,
                         const char *msg) {
     struct sdh_invocation inv = {
@@ -355,10 +443,16 @@ static void test_sdh_err_badaction(sdh_test_fixture *fixture, gconstpointer test
                 "ERROR: unknown action \"badaction\"\n");
 }
 
-static void test_sdh_err_nosymlink(sdh_test_fixture *fixture, gconstpointer test_data) {
+static void test_sdh_err_nosymlink_block(sdh_test_fixture *fixture, gconstpointer test_data) {
     // missing symlink
     run_sdh_die("add", "snap_foo_bar", "/devices/foo/block/sda/sda4", "8:4",
                 "cannot read symlink */sys//devices/foo/block/sda/sda4/subsystem*\n");
+}
+
+static void test_sdh_err_nosymlink_char(sdh_test_fixture *fixture, gconstpointer test_data) {
+    // missing symlink
+    run_sdh_die("add", "snap_foo_bar", "/devices/pnp0/00:04/tty/ttyS0", "4:64",
+                "cannot read symlink */sys//devices/pnp0/00:04/tty/ttyS0/subsystem*\n");
 }
 
 static void test_sdh_err_funtag1(sdh_test_fixture *fixture, gconstpointer test_data) {
@@ -427,6 +521,7 @@ static void __attribute__((constructor)) init(void) {
     _test_add("/snap-device-helper/add", &add_data, test_sdh_action);
     _test_add("/snap-device-helper/change", &change_data, test_sdh_action);
     _test_add("/snap-device-helper/remove", &remove_data, test_sdh_action);
+    _test_add("/snap-device-helper/remove_fallback", NULL, test_sdh_action_remove_fallback_devtype);
 
     _test_add("/snap-device-helper/err/no-appname", NULL, test_sdh_err_noappname);
     _test_add("/snap-device-helper/err/bad-appname", NULL, test_sdh_err_badappname);
@@ -436,7 +531,8 @@ static void __attribute__((constructor)) init(void) {
     _test_add("/snap-device-helper/err/wrong-devmajorminor_late1", NULL, test_sdh_err_wrongdevmajorminor_late1);
     _test_add("/snap-device-helper/err/wrong-devmajorminor_late2", NULL, test_sdh_err_wrongdevmajorminor_late2);
     _test_add("/snap-device-helper/err/bad-action", NULL, test_sdh_err_badaction);
-    _test_add("/snap-device-helper/err/no-symlink", NULL, test_sdh_err_nosymlink);
+    _test_add("/snap-device-helper/err/no-symlink-block", NULL, test_sdh_err_nosymlink_block);
+    _test_add("/snap-device-helper/err/no-symlink-char", NULL, test_sdh_err_nosymlink_char);
     _test_add("/snap-device-helper/err/funtag1", NULL, test_sdh_err_funtag1);
     _test_add("/snap-device-helper/err/funtag2", NULL, test_sdh_err_funtag2);
     _test_add("/snap-device-helper/err/funtag3", NULL, test_sdh_err_funtag3);

--- a/cmd/snap-device-helper/snap-device-helper.c
+++ b/cmd/snap-device-helper/snap-device-helper.c
@@ -15,6 +15,7 @@
  *
  */
 #include <errno.h>
+#include <fnmatch.h>
 #include <libgen.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -175,11 +176,26 @@ int snap_device_helper_run(const struct sdh_invocation *inv) {
     char fullsubsystem[PATH_MAX] = {0};
     sc_must_snprintf(sysdevsubsystem, sizeof(sysdevsubsystem), "%s/sys/%s/subsystem", sysroot, devpath);
     if (readlink(sysdevsubsystem, fullsubsystem, sizeof(fullsubsystem)) < 0) {
-        die("cannot read symlink %s", sysdevsubsystem);
-    }
-    char *subsystem = basename(fullsubsystem);
-    if (sc_streq(subsystem, "block")) {
-        devtype = S_IFBLK;
+        if (errno == ENOENT && sc_streq(action, "remove")) {
+            // on removal the devices are going away, so it is possible that the
+            // symlink is already gone, in which case try guessing the type like
+            // the old shell-based snap-device-helper did:
+            //
+            // > char devices are .../nvme/nvme* but block devices are
+            // > .../nvme/nvme*/nvme*n* and .../nvme/nvme*/nvme*n*p* so if have a
+            // > device that has nvme/nvme*/nvme*n* in it, treat it as a block
+            // > device
+            if ((fnmatch("*/block/*", devpath, 0) == 0) || (fnmatch("*/nvme/nvme*/nvme*n*", devpath, 0) == 0)) {
+                devtype = S_IFBLK;
+            }
+        } else {
+            die("cannot read symlink %s", sysdevsubsystem);
+        }
+    } else {
+        char *subsystem = basename(fullsubsystem);
+        if (sc_streq(subsystem, "block")) {
+            devtype = S_IFBLK;
+        }
     }
     sc_device_cgroup *cgroup = sc_device_cgroup_new(security_tag, SC_DEVICE_CGROUP_FROM_EXISTING);
     if (!cgroup) {

--- a/tests/main/security-device-cgroups-helper/task.yaml
+++ b/tests/main/security-device-cgroups-helper/task.yaml
@@ -95,6 +95,13 @@ execute: |
     NOMATCH 'Operation not permitted' < run.log
     test -n "$(cat run.log)"
 
+    # remove action removes the device from the cgroup
+    "$libexecdir"/snapd/snap-device-helper remove snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
+    # /dev/kmsg is not present anymore
+    tests.device-cgroup test-strict-cgroup-helper.sh dump | NOMATCH 'c 1:11 rwm'
+    # and it's not possible to read /dev/kmsg again
+    snap run test-strict-cgroup-helper.sh -c 'head -1 /dev/kmsg' 2>&1 | MATCH "Operation not permitted"
+
     # now remove the cgroup
     if is_cgroupv2; then
         rm /sys/fs/bpf/snap/snap_test-strict-cgroup-helper_sh


### PR DESCRIPTION
The old shell-based snap-device-helper would identify the devices based on
pattern matching the device path. Specifically any device matching */block/*
or */nvme/nvme*/nvme*n* patterns was considered a block device, while all other
devices were consider to be char devices.

Bring back the old behavior, but only in a fallback path of the remove action.
Since when devices are removed, it is possible that the symlinks are already
gone by the time we inspect entries in /sys/devices/. However, we would still
like to remove the device from the cgroup.


