### PR TITLE
overlord: extend kernel/base success and failover with bootenv checks

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1953,7 +1953,7 @@ type: os
 	st.Lock()
 	c.Assert(err, IsNil)
 
-	// final steps will are post poned until we are in the restarted snapd
+	// final steps will are postponed until we are in the restarted snapd
 	ok, rst := restart.Pending(st)
 	c.Assert(ok, Equals, true)
 	c.Assert(rst, Equals, restart.RestartSystem)
@@ -1970,10 +1970,9 @@ type: os
 		"snap_mode":       boot.TryStatus,
 	})
 
-	// simulate successful restart happened
-	restart.MockPending(st, restart.RestartUnset)
-	bloader.BootVars["snap_mode"] = boot.DefaultStatus
-	bloader.SetBootBase("core_x1.snap")
+	// simulate successful restart happened, technically "core" is of type
+	// "os", but for the purpose of the mock it is handled like a base
+	s.mockSuccessfulReboot(c, bloader, []snap.Type{snap.TypeBase})
 
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -1981,6 +1980,99 @@ type: os
 	c.Assert(err, IsNil)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
+
+	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
+		"snap_core":       "core_x1.snap",
+		"snap_try_core":   "",
+		"snap_try_kernel": "",
+		"snap_mode":       "",
+	})
+}
+
+func (s *mgrsSuite) TestInstallCoreSnapUpdatesBootloaderEnvAndFailWithRollback(c *C) {
+	bloader := boottest.MockUC16Bootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+	bloader.SetBootBase("core_99.snap")
+
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	model := s.brands.Model("my-brand", "my-model", modelDefaults)
+
+	const packageOS = `
+name: core
+version: 16.04-1
+type: os
+`
+	snapPath := makeTestSnap(c, packageOS)
+
+	st := s.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	// setup model assertion
+	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+	devicestatetest.SetDevice(st, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+	err := assertstate.Add(st, model)
+	c.Assert(err, IsNil)
+
+	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "core"}, snapPath, "", "", snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg := st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	// final steps will are postponed until we are in the restarted snapd
+	ok, rst := restart.Pending(st)
+	c.Assert(ok, Equals, true)
+	c.Assert(rst, Equals, restart.RestartSystem)
+
+	t := findKind(chg, "auto-connect")
+	c.Assert(t, NotNil)
+	c.Assert(t.Status(), Equals, state.DoingStatus, Commentf("install-snap change failed with: %v", chg.Err()))
+
+	// this is already set
+	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
+		"snap_core":       "core_99.snap",
+		"snap_try_core":   "core_x1.snap",
+		"snap_try_kernel": "",
+		"snap_mode":       boot.TryStatus,
+	})
+
+	// simulate a reboot in which bootloader updates the env
+	s.mockRollbackAcrossReboot(c, bloader, []snap.Type{snap.TypeBase})
+
+	s.o.DeviceManager().ResetToPostBootState()
+	st.Unlock()
+	err = s.o.DeviceManager().Ensure()
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(chg.Status(), Equals, state.ErrorStatus, Commentf("install-snap change did not fail"))
+	tLink := findKind(chg, "link-snap")
+	c.Assert(tLink, NotNil)
+	c.Assert(tLink.Status(), Equals, state.UndoneStatus)
+
+	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
+		"snap_core":       "core_99.snap",
+		"snap_try_core":   "",
+		"snap_try_kernel": "",
+		"snap_mode":       "",
+	})
 }
 
 type rebootEnv interface {
@@ -2110,6 +2202,14 @@ type: kernel`
 	c.Assert(err, IsNil)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
+
+	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
+		"snap_core":       "core18_2.snap",
+		"snap_try_core":   "",
+		"snap_kernel":     "pc-kernel_x1.snap",
+		"snap_try_kernel": "",
+		"snap_mode":       "",
+	})
 }
 
 func (s *mgrsSuite) TestInstallKernelSnapUndoUpdatesBootloaderEnv(c *C) {
@@ -2219,6 +2319,23 @@ type: kernel`
 	})
 	restarting, _ = restart.Pending(st)
 	c.Check(restarting, Equals, true)
+
+	// pretend we restarted back to the old kernel
+	s.mockSuccessfulReboot(c, bloader, []snap.Type{snap.TypeKernel})
+
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	// and we undo the bootvars and trigger a reboot
+	c.Check(bloader.BootVars, DeepEquals, map[string]string{
+		"snap_core":       "core18_2.snap",
+		"snap_try_core":   "",
+		"snap_try_kernel": "",
+		"snap_kernel":     "pc-kernel_123.snap",
+		"snap_mode":       "",
+	})
 }
 
 func (s *mgrsSuite) TestInstallKernelSnap20UpdatesBootloaderEnv(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -2031,7 +2031,7 @@ type: os
 	st.Lock()
 	c.Assert(err, IsNil)
 
-	// final steps will are postponed until we are in the restarted snapd
+	// final steps will be postponed until we are in the restarted snapd
 	ok, rst := restart.Pending(st)
 	c.Assert(ok, Equals, true)
 	c.Assert(rst, Equals, restart.RestartSystem)


### PR DESCRIPTION
Verify the post-change bootloader environment state in kernel and base states
for both happy and failover scenarios.

Related to: https://bugs.launchpad.net/snappy/+bug/1931873