### PR TITLE
tests: moving to manual opensuse 15.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -257,7 +257,6 @@ jobs:
         - debian-sid-64
         - fedora-34-64
         - fedora-35-64
-        - opensuse-15.2-64
         - opensuse-15.3-64
         - opensuse-tumbleweed-64
         - ubuntu-14.04-64

--- a/spread.yaml
+++ b/spread.yaml
@@ -147,6 +147,7 @@ backends:
             # unstable systems below
             - opensuse-15.2-64:
                   workers: 6
+                  manual: true
             - opensuse-15.3-64:
                   workers: 6
             - opensuse-tumbleweed-64:


### PR DESCRIPTION
As openSUSE Leap 15.2 reach its end of life on Dec. 31, 2021
