### PR TITLE
usersession/userd: support Cloudflare WARP URL scheme

### DIFF
--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -80,10 +80,6 @@ var (
 		//   - scheme: apt:<name of package>
 		//   - https://github.com/snapcore/snapd/pull/7731
 		"apt",
-		// com.cloudflare.warp: the scheme allows for specifying a package for
-		//   xdg-open to pass to the Cloudflare Teams client so that users can
-		//   sign into their team
-		"com.cloudflare.warp",
 		// help: the scheme allows for specifying a help URL. This code ensures that
 		//   the url is parseable
 		//   - scheme: help://topic
@@ -119,6 +115,10 @@ var (
 		// zoomus: alternative name for zoommtg
 		//   - https://github.com/snapcore/snapd/pull/8910
 		"zoomus",
+		// com.cloudflare.warp: the scheme allows for specifying a package for
+		//   xdg-open to pass to the Cloudflare Teams client so that users can
+		//   sign into their team
+		"com.cloudflare.warp",
 	}
 )
 

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -80,7 +80,7 @@ var (
 		//   - scheme: apt:<name of package>
 		//   - https://github.com/snapcore/snapd/pull/7731
 		"apt",
-		// com.cloudflare.warp: the scheme allows for specifiying a package for
+		// com.cloudflare.warp: the scheme allows for specifying a package for
 		//   xdg-open to pass to the Cloudflare Teams client so that users can
 		//   sign into their team
 		"com.cloudflare.warp",

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -80,6 +80,10 @@ var (
 		//   - scheme: apt:<name of package>
 		//   - https://github.com/snapcore/snapd/pull/7731
 		"apt",
+		// com.cloudflare.warp: the scheme allows for specifiying a package for
+		//   xdg-open to pass to the Cloudflare Teams client so that users can
+		//   sign into their team
+		"com.cloudflare.warp",
 		// help: the scheme allows for specifying a help URL. This code ensures that
 		//   the url is parseable
 		//   - scheme: help://topic

--- a/usersession/userd/launcher_test.go
+++ b/usersession/userd/launcher_test.go
@@ -74,7 +74,7 @@ func (s *launcherSuite) TestOpenURLWithNotAllowedScheme(c *C) {
 }
 
 func (s *launcherSuite) TestOpenURLWithAllowedSchemeHappy(c *C) {
-	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams"} {
+	for _, schema := range []string{"com.cloudflare.warp", "http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams"} {
 		err := s.launcher.OpenURL(schema+"://snapcraft.io", ":some-dbus-sender")
 		c.Assert(err, IsNil)
 		c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{

--- a/usersession/userd/launcher_test.go
+++ b/usersession/userd/launcher_test.go
@@ -74,7 +74,7 @@ func (s *launcherSuite) TestOpenURLWithNotAllowedScheme(c *C) {
 }
 
 func (s *launcherSuite) TestOpenURLWithAllowedSchemeHappy(c *C) {
-	for _, schema := range []string{"com.cloudflare.warp", "http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams"} {
+	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams", "com.cloudflare.warp"} {
 		err := s.launcher.OpenURL(schema+"://snapcraft.io", ":some-dbus-sender")
 		c.Assert(err, IsNil)
 		c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{


### PR DESCRIPTION
Allow Cloudflare WARP URL scheme to be opened by xdg-open with in snap
to support WARP's user authorization work flow.
