### PR TITLE
gadget: do not crash if gadget.yaml has an empty Volumes section

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -462,7 +462,14 @@ func InfoFromGadgetYaml(gadgetYaml []byte, model Model) (*Info, error) {
 	// basic validation
 	var bootloadersFound int
 	knownFsLabelsPerVolume := make(map[string]map[string]bool, len(gi.Volumes))
-	for name, v := range gi.Volumes {
+	for name := range gi.Volumes {
+		v := gi.Volumes[name]
+		if v == nil {
+			// XXX: we could also error here, it seems strange
+			// (probably a user error) if a volume is entirely
+			// empty
+			v = &Volume{}
+		}
 		// set the VolumeName for the volume
 		v.Name = name
 		if err := validateVolume(v, knownFsLabelsPerVolume); err != nil {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -465,10 +465,7 @@ func InfoFromGadgetYaml(gadgetYaml []byte, model Model) (*Info, error) {
 	for name := range gi.Volumes {
 		v := gi.Volumes[name]
 		if v == nil {
-			// XXX: we could also error here, it seems strange
-			// (probably a user error) if a volume is entirely
-			// empty
-			v = &Volume{}
+			return nil, fmt.Errorf("cannot use empty volume %q", name)
 		}
 		// set the VolumeName for the volume
 		v.Name = name

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -465,7 +465,7 @@ func InfoFromGadgetYaml(gadgetYaml []byte, model Model) (*Info, error) {
 	for name := range gi.Volumes {
 		v := gi.Volumes[name]
 		if v == nil {
-			return nil, fmt.Errorf("cannot use empty volume %q", name)
+			return nil, fmt.Errorf("volume %q stanza is empty", name)
 		}
 		// set the VolumeName for the volume
 		v.Name = name

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -621,6 +621,19 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 	})
 }
 
+var mockGadgetWithEmptyVolumes = `device-tree-origin: kernel
+volumes:
+  lun-0:
+`
+
+func (s *gadgetYamlTestSuite) TestRegressionGadgetWithEmptyVolume(c *C) {
+	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(mockGadgetWithEmptyVolumes), 0644)
+	c.Assert(err, IsNil)
+
+	_, err = gadget.ReadInfo(s.dir, nil)
+	c.Assert(err, ErrorMatches, "bootloader not declared in any volume")
+}
+
 func (s *gadgetYamlTestSuite) TestReadGadgetDefaultsMultiline(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, mockClassicGadgetMultilineDefaultsYaml, 0644)
 	c.Assert(err, IsNil)

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -631,7 +631,7 @@ func (s *gadgetYamlTestSuite) TestRegressionGadgetWithEmptyVolume(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
-	c.Assert(err, ErrorMatches, "bootloader not declared in any volume")
+	c.Assert(err, ErrorMatches, `cannot use empty volume "lun-0"`)
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetDefaultsMultiline(c *C) {

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -631,7 +631,7 @@ func (s *gadgetYamlTestSuite) TestRegressionGadgetWithEmptyVolume(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
-	c.Assert(err, ErrorMatches, `cannot use empty volume "lun-0"`)
+	c.Assert(err, ErrorMatches, `volume "lun-0" stanza is empty`)
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetDefaultsMultiline(c *C) {


### PR DESCRIPTION
The current code did not check if a gadget.yaml contains empty
volume sections. This leads to crashes for gadget.yaml like:
```
volumes:
  lun-0:
```

This commits ensures that empty sections do not crash the code.

