### PR TITLE
tests: fixed an issue with retrieval of the squashfuse repo

### DIFF
--- a/c-vendor/vendor.sh
+++ b/c-vendor/vendor.sh
@@ -7,9 +7,12 @@ set -e
 if [ ! -d ./squashfuse ]; then
     git clone https://github.com/vasi/squashfuse
 fi
+
 # This is just tip/master as of Aug 30th 2021, there is no other
 # specific reason to use this. It works with both "libfuse-dev" and
 # "libfuse3-dev" which is important as 16.04 only have libfuse-dev
 # and 21.10 only has libfuse3-dev
-(cd squashfuse && git checkout 74f4fe86ebd47a2fb7df5cb60d452354f977c72e)
+if [ -d ./squashfuse/.git ]; then
+    (cd squashfuse && git checkout 74f4fe86ebd47a2fb7df5cb60d452354f977c72e)
+fi
 


### PR DESCRIPTION
During tests local instance of snapd is populated to VM
without `.git` folders. In case squashfuse is already
populated within the local instance, the `vendor.sh` script
fails to checkout a certain commit.
The checkout now checks first that `.git` exists, otherwise
is assumes that populated squashfuse is correct.

Signed-off-by: Arseniy Aharonov <arseniy@aharonov.icu>
