### PR TITLE
tests: tidy up the top-level of ubuntu-seed during tests

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1022,13 +1022,13 @@ EOF
     # mount it so we can use it now
     mount "/dev/mapper/${dev}p${LOOP_PARTITION}" /mnt
 
-    mkdir -p /mnt/user-data/
     # copy over everything from gopath to user-data, exclude:
     # - VCS files
     # - built debs
     # - golang archive files and built packages dir
     # - govendor .cache directory and the binary,
     if os.query is-core16 || os.query is-core18; then
+        mkdir -p /mnt/user-data/
         # we need to include "core" here because -C option says to ignore 
         # files the way CVS(?!) does, so it ignores files named "core" which
         # are core dumps, but we have a test suite named "core", so including 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -586,9 +586,10 @@ uc20_build_initramfs_kernel_snap() {
         # all tests
         mode=$(grep -Eo 'snapd_recovery_mode=([a-z]+)' /proc/cmdline)
         mode=${mode##snapd_recovery_mode=}
-        stat -c '%Y' /usr/lib/clock-epoch >> /run/mnt/ubuntu-seed/${mode}-clock-epoch
-        echo "$beforeDate" > /run/mnt/ubuntu-seed/${mode}-before-snap-bootstrap-date
-        date --utc '+%s' > /run/mnt/ubuntu-seed/${mode}-after-snap-bootstrap-date
+        mkdir -p /run/mnt/ubuntu-seed/test
+        stat -c '%Y' /usr/lib/clock-epoch >> /run/mnt/ubuntu-seed/test/${mode}-clock-epoch
+        echo "$beforeDate" > /run/mnt/ubuntu-seed/test/${mode}-before-snap-bootstrap-date
+        date --utc '+%s' > /run/mnt/ubuntu-seed/test/${mode}-after-snap-bootstrap-date
 EOF
 
         if [ "$injectKernelPanic" = "true" ]; then

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -30,4 +30,4 @@ execute: |
   test "$(tests.nested exec date --utc '+%s')" -ge "$MODEL_ASSERTION_SIGN_TIME"
 
   echo "Verify that the timestamp from after snap-bootstrap ran is greater than the time from the model assertion"
-  test "$(tests.nested exec "cat /run/mnt/ubuntu-seed/install-after-snap-bootstrap-date")" -ge "$MODEL_ASSERTION_SIGN_TIME"
+  test "$(tests.nested exec "cat /run/mnt/ubuntu-seed/test/install-after-snap-bootstrap-date")" -ge "$MODEL_ASSERTION_SIGN_TIME"


### PR DESCRIPTION
have a "test" directory for that

also stop creating an unused user-data directory in ubuntu-seed in UC20

Address https://github.com/snapcore/snapd/pull/10051#discussion_r602103141 as well