### PR TITLE
build-aux: detect/fix dirty git revisions while snapcraft building

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -32,6 +32,15 @@ parts:
     build-snaps: [go/1.13/stable]
     override-pull: |
       snapcraftctl pull
+      # set version, this needs dpkg-parsechangelog (from dpkg-dev) and git
+      sudo -E apt-get install -y dpkg-dev git
+      if sh -x ./mkversion.sh --output-only | grep "dirty"; then
+          echo "dirty git tree during build detected:"
+          git status
+          git diff
+          exit 1
+      fi
+      snapcraftctl set-version "$(./mkversion.sh --output-only)"
       # Ensure that ./debian/ packaging which we are about to use
       # matches the current `build-base` release. I.e. ubuntu-16.04
       # for build-base:core, etc.
@@ -41,14 +50,6 @@ parts:
       export DEBCONF_NONINTERACTIVE_SEEN=true
       sudo -E apt-get build-dep -y ./
       ./get-deps.sh --skip-unused-check
-      # set version after installing dependencies so we have all the tools here
-      if sh -x ./mkversion.sh --output-only | grep "dirty"; then
-          echo "dirty git tree during build detected:"
-          git status
-          git diff
-          exit 1
-      fi
-      snapcraftctl set-version "$(./mkversion.sh --output-only)"
     override-build: |
       # unset the LD_FLAGS and LD_LIBRARY_PATH vars that snapcraft sets for us
       # as those will point to the $SNAPCRAFT_STAGE which on re-builds will 

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -42,6 +42,12 @@ parts:
       sudo -E apt-get build-dep -y ./
       ./get-deps.sh --skip-unused-check
       # set version after installing dependencies so we have all the tools here
+      if sh -x ./mkversion.sh --output-only | grep "dirty"; then
+          echo "dirty git tree during build detected:"
+          git status
+          git diff
+          exit 1
+      fi
       snapcraftctl set-version "$(./mkversion.sh --output-only)"
     override-build: |
       # unset the LD_FLAGS and LD_LIBRARY_PATH vars that snapcraft sets for us

--- a/debian
+++ b/debian
@@ -1,1 +1,1 @@
-packaging/ubuntu-16.04/
+packaging/ubuntu-16.04

--- a/generate-packaging-dir
+++ b/generate-packaging-dir
@@ -13,5 +13,5 @@ set -eu
 
 # update symlink
 rm -f debian
-ln -s "packaging/${ID}-${VERSION_ID}" debian
+ln -s "packaging/${ID}-${VERSION_ID}/" debian
 

--- a/generate-packaging-dir
+++ b/generate-packaging-dir
@@ -13,5 +13,5 @@ set -eu
 
 # update symlink
 rm -f debian
-ln -s "packaging/${ID}-${VERSION_ID}/" debian
+ln -s "packaging/${ID}-${VERSION_ID}" debian
 

--- a/packaging/ubuntu-14.04/source
+++ b/packaging/ubuntu-14.04/source
@@ -1,1 +1,1 @@
-../ubuntu-16.04/source/
+../ubuntu-16.04/source

--- a/tests/lib/snaps/store/test-snapd-daemon-user/src/setregid32.c
+++ b/tests/lib/snaps/store/test-snapd-daemon-user/src/setregid32.c
@@ -1,1 +1,1 @@
-./setregid.c
+setregid.c


### PR DESCRIPTION
When merging https://github.com/snapcore/snapd/pull/10957 we accidentally introduced a change that made the git tree dirty during the build. This lead to version numbers like "2.54-dirty" instead of the expected 2.54. Unfortunately this means we need a 2.54.1 with this fix to ensure we have a sane version number.

This PR adds two commits, one that detects and errors for dirty git trees and one that fixes the issue introduced in #10957.