### PR TITLE
i/b/mount-control: support creating tmpfs mounts

### DIFF
--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -174,7 +174,7 @@ type mountControlInterface struct {
 // is expected that sensible values of what are enforced by the store manual
 // review queue and security teams.
 var (
-	whatRegexp  = regexp.MustCompile(`^/[^"@]*$`)
+	whatRegexp  = regexp.MustCompile(`^(none|/[^"@]*)$`)
 	whereRegexp = regexp.MustCompile(`^(\$SNAP_COMMON|\$SNAP_DATA)?/[^\$"@]+$`)
 )
 
@@ -303,6 +303,7 @@ func validateWhereAttr(where string) error {
 }
 
 func validateMountTypes(types []string) error {
+	includesTmpfs := false
 	for _, t := range types {
 		if !typeRegexp.MatchString(t) {
 			return fmt.Errorf(`mount-control filesystem type invalid: %q`, t)
@@ -310,6 +311,13 @@ func validateMountTypes(types []string) error {
 		if !strutil.ListContains(allowedFSTypes, t) {
 			return fmt.Errorf(`mount-control forbidden filesystem type: %q`, t)
 		}
+		if t == "tmpfs" {
+			includesTmpfs = true
+		}
+	}
+
+	if includesTmpfs && len(types) > 1 {
+		return errors.New(`mount-control filesystem type "tmpfs" cannot be listed with other types`)
 	}
 	return nil
 }
@@ -357,6 +365,16 @@ func validateMountInfo(mountInfo *MountInfo) error {
 	fsExclusiveOption := optionIncompatibleWithFsType(mountInfo.options)
 	if fsExclusiveOption != "" && len(mountInfo.types) > 0 {
 		return fmt.Errorf(`mount-control option %q is incompatible with specifying filesystem type`, fsExclusiveOption)
+	}
+
+	// "what" must be set to "none" iff the type is "tmpfs"
+	isTmpfs := len(mountInfo.types) == 1 && mountInfo.types[0] == "tmpfs"
+	if mountInfo.what == "none" {
+		if !isTmpfs {
+			return errors.New(`mount-control "what" attribute can be "none" only with "tmpfs"`)
+		}
+	} else if isTmpfs {
+		return fmt.Errorf(`mount-control "what" attribute must be "none" with "tmpfs"; found %q instead`, mountInfo.what)
 	}
 
 	return nil

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -238,6 +238,22 @@ apps:
 			"mount:\n  - what: /\n    where: /media/../etc",
 			`mount-control "where" pattern is not clean:.*`,
 		},
+		{
+			"mount:\n  - what: none\n    where: /media/*\n    options: [rw]",
+			`mount-control "what" attribute can be "none" only with "tmpfs"`,
+		},
+		{
+			"mount:\n  - what: none\n    where: /media/*\n    options: [rw]\n    type: [ext4,ntfs]",
+			`mount-control "what" attribute can be "none" only with "tmpfs"`,
+		},
+		{
+			"mount:\n  - what: none\n    where: /media/*\n    options: [rw]\n    type: [tmpfs,ext4]",
+			`mount-control filesystem type "tmpfs" cannot be listed with other types`,
+		},
+		{
+			"mount:\n  - what: /\n    where: /media/*\n    options: [rw]\n    type: [tmpfs]",
+			`mount-control "what" attribute must be "none" with "tmpfs"; found "/" instead`,
+		},
 	}
 
 	for _, testData := range data {

--- a/tests/lib/snaps/test-snapd-mount-control/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-mount-control/meta/snap.yaml
@@ -17,4 +17,7 @@ plugs:
               where: /media/**
               type: [ext2, ext3, ext4]
               options: [rw, sync]
-
+            - what: none
+              where: $SNAP_COMMON/**
+              type: [tmpfs]
+              options: [rw]

--- a/tests/main/interfaces-mount-control/task.yaml
+++ b/tests/main/interfaces-mount-control/task.yaml
@@ -54,6 +54,11 @@ execute: |
     fi
     "${SNAP_NAME}".cmd test "!" -e "$MOUNT_DEST/file1"
 
+    echo "Verify that a mount with a specific FS type can be created"
+    "${SNAP_NAME}".cmd mount -o rw -t tmpfs none "$MOUNT_DEST"
+    "${SNAP_NAME}".cmd grep "$MOUNT_DEST.*tmpfs" /proc/self/mountinfo
+    "${SNAP_NAME}".cmd umount "$MOUNT_DEST"
+
     if [ "$(snap debug confinement)" = partial ] ; then
         echo "Early exit on systems where strict confinement does not work"
         exit 0


### PR DESCRIPTION
The source device for "tmpfs" must be "none": update the code to allow
the "what" attribute to be set to this value, and add a few checks to
ensure that the same value cannot be used with other filesystem types.
