### PR TITLE
packaging: Update openSUSE spec file with apparmor-parser and datadir for fish

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -419,6 +419,7 @@ fi
 %dir %{_datadir}/zsh
 %dir %{_datadir}/zsh/site-functions
 # similar case for fish
+%dir %{_datadir}/fish
 %dir %{_datadir}/fish/vendor_conf.d
 
 # Ghost entries for things created at runtime

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -125,6 +125,7 @@ BuildRequires:  ca-certificates-mozilla
 %if %{with apparmor}
 BuildRequires:  libapparmor-devel
 BuildRequires:  apparmor-rpm-macros
+BuildRequires:  apparmor-parser
 %endif
 
 PreReq:         permissions


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
Yes. I have signed it.

I have updated the openSUSE spec file because of failed builds.
s390x requires apparmor-parser as a BuildRequires. Error message:
AppArmor status: apparmor_parser not found

Additionally, there is following message: at the end of the build log (for all) architectures:
[  578s] snapd-2.54.1-5.1.x86_64.rpm: directories not owned by a package:
[  578s]  - /usr/share/fish

That is the reason for adding the datadir for fish the same as it exists for zsh.

