### PR TITLE
data/selinux: allow poking /proc/xen

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -437,6 +437,10 @@ ifndef(`distro_rhel7',`
 allow snappy_t snappy_cli_t:process { getpgid sigkill };
 allow snappy_t unconfined_service_t:process { getpgid sigkill };
 
+# Snapd invokes systemd-detect-virt, which may make poke /proc/xen/, but does
+# not transition to a separate type and has no interface policy
+kernel_read_xen_state(snappy_t)
+
 ########################################
 #
 # snap-update-ns, snap-dicsard-ns local policy


### PR DESCRIPTION
When running in a Xen guest, systemd-detect-virt when invoked by snapd may
trigger the following denial:

```
type=PROCTITLE msg=audit(1640771959.147:236972): proctitle="systemd-detect-virt"
type=AVC msg=audit(1640771959.147:236972): avc:  denied  { search } for pid=21113
         comm="systemd-detect-" name="xen" dev="proc"
         ino=4026532003
         scontext=system_u:system_r:snappy_t:s0
         tcontext=system_u:object_r:proc_xen_t:s0
         tclass=dir permissive=1
```

See https://forum.snapcraft.io/t/snapd-unavailable-red-hat-enterprise-linux/28004/15
for details.
