### PR TITLE
tests: fix remodel-kernel test when running on external devices

### DIFF
--- a/tests/core/remodel-kernel/task.yaml
+++ b/tests/core/remodel-kernel/task.yaml
@@ -16,7 +16,9 @@ prepare: |
     . "$TESTSLIB"/systemd.sh
 
     # Save the revision of the pc-kernel snap.
-    readlink /snap/pc-kernel/current > original-revision.txt
+    readlink /snap/"$OLD_KERNEL"/current > original-revision.txt
+    # Save the original tracking channel
+    snap list "$OLD_KERNEL" | grep -v ^Name | tr -s ' ' | cut -f4 -d' ' > original-channel.txt
 
     systemctl stop snapd.service snapd.socket
 
@@ -39,16 +41,16 @@ restore: |
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
 
-    # Wait for the final refresh to complete.
-    snap watch --last=refresh
+    # Wait for the final refresh to complete (if needed).
+    snap watch --last=refresh?
 
     # Remove all the revisions of pc-kernel that should not be there.
-    for revno_path in /snap/pc-kernel/*; do
+    for revno_path in /snap/"$OLD_KERNEL"/*; do
         revno="$(basename "$revno_path")"
         if [ "$revno" == current ] || [ "$revno" == "$(cat original-revision.txt)" ]; then
             continue;
         fi
-        snap remove pc-kernel --revision="$revno"
+        snap remove "$OLD_KERNEL" --revision="$revno"
     done
 
     systemctl stop snapd.service snapd.socket
@@ -149,6 +151,6 @@ execute: |
         snap remove --purge "$NEW_KERNEL"
 
         echo "Ensure we are back to the original kernel channel and kernel"
-        snap refresh --channel="$KERNEL_CHANNEL" "$OLD_KERNEL"
+        snap refresh --channel="$(cat original-channel.txt)" "$OLD_KERNEL"
         REBOOT
     fi

--- a/tests/core/remodel-kernel/task.yaml
+++ b/tests/core/remodel-kernel/task.yaml
@@ -18,7 +18,7 @@ prepare: |
     # Save the revision of the pc-kernel snap.
     readlink /snap/"$OLD_KERNEL"/current > original-revision.txt
     # Save the original tracking channel
-    snap list "$OLD_KERNEL" | grep -v ^Name | tr -s ' ' | cut -f4 -d' ' > original-channel.txt
+    snap info "$OLD_KERNEL" | awk '/^tracking:/ {print $2}' > original-channel.txt
 
     systemctl stop snapd.service snapd.socket
 


### PR DESCRIPTION
Save/restore the tracking channel of the kernel in the test to
fix a failure when this test runs on e.g. external devices that
have models where the tracking channel of the kernel does not
match the "$KERNEL_CHANNEL" we use when we build the images on
our own.
