### PR TITLE
cmd: support installing multiple local snaps

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -216,7 +216,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 func (client *Client) InstallPath(path, name string, options *SnapOptions) (changeID string, err error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", fmt.Errorf("cannot open: %q", path)
+		return "", fmt.Errorf("cannot open %q: %w", path, err)
 	}
 
 	action := actionData{
@@ -244,7 +244,7 @@ func (client *Client) InstallPathMany(paths []string, options *SnapOptions) (cha
 			for _, openFile := range files {
 				openFile.Close()
 			}
-			return "", fmt.Errorf("cannot open: %q", path)
+			return "", fmt.Errorf("cannot open %q: %w", path, err)
 		}
 
 		files = append(files, f)

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -302,6 +302,74 @@ func (cs *clientSuite) TestClientOpInstallPathInstance(c *check.C) {
 	c.Check(id, check.Equals, "66b3")
 }
 
+func (cs *clientSuite) TestClientOpInstallPathMany(c *check.C) {
+	cs.status = 202
+	cs.rsp = `{
+		"change": "66b3",
+		"status-code": 202,
+		"type": "async"
+	}`
+
+	var paths []string
+	names := []string{"foo.snap", "bar.snap"}
+	for _, name := range names {
+		path := filepath.Join(c.MkDir(), name)
+		paths = append(paths, path)
+		c.Assert(ioutil.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
+	}
+
+	id, err := cs.cli.InstallPathMany(paths, nil)
+	c.Assert(err, check.IsNil)
+
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+
+	for _, name := range names {
+		c.Assert(string(body), check.Matches, fmt.Sprintf(`(?s).*Content-Disposition: form-data; name="snap"; filename="%s"\r\nContent-Type: application/octet-stream\r\n\r\nsnap-data\r\n.*`, name))
+
+	}
+	c.Assert(string(body), check.Matches, `(?s).*Content-Disposition: form-data; name="action"\r\n\r\ninstall\r\n.*`)
+
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/snaps")
+	c.Assert(cs.req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
+
+	_, ok := cs.req.Context().Deadline()
+	c.Assert(ok, check.Equals, false)
+	c.Check(id, check.Equals, "66b3")
+}
+
+func (cs *clientSuite) TestClientOpInstallPathManyWithOptions(c *check.C) {
+	cs.status = 202
+	cs.rsp = `{
+		"change": "66b3",
+		"status-code": 202,
+		"type": "async"
+	}`
+
+	var paths []string
+	for _, name := range []string{"foo.snap", "bar.snap"} {
+		path := filepath.Join(c.MkDir(), name)
+		paths = append(paths, path)
+		c.Assert(ioutil.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
+	}
+
+	// InstallPathMany supports opts
+	_, err := cs.cli.InstallPathMany(paths, &client.SnapOptions{
+		Dangerous: true,
+		DevMode:   true,
+		Classic:   true,
+	})
+
+	c.Assert(err, check.IsNil)
+
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+
+	c.Check(string(body), check.Matches, `(?s).*Content-Disposition: form-data; name="dangerous"\r\n\r\ntrue\r\n.*`)
+	c.Check(string(body), check.Matches, `(?s).*Content-Disposition: form-data; name="devmode"\r\n\r\ntrue\r\n.*`)
+	c.Check(string(body), check.Matches, `(?s).*Content-Disposition: form-data; name="classic"\r\n\r\ntrue\r\n.*`)
+}
 func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
 	cs.status = 202
 	cs.rsp = `{

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -955,6 +955,99 @@ func (s *SnapOpSuite) TestInstallPathInstance(c *check.C) {
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
 
+func (s *SnapOpSuite) TestInstallPathMany(c *check.C) {
+	snaps := []string{"foo.snap", "bar.snap"}
+	total := 4
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			c.Check(r.Method, check.Equals, "POST")
+
+			form := testForm(r, c)
+			defer form.RemoveAll()
+			c.Check(form.Value["action"], check.DeepEquals, []string{"install"})
+			c.Check(form.Value, check.HasLen, 1)
+			names, filenames, bodies := formFiles(form, c)
+			for i, name := range names {
+				c.Check(name, check.Equals, "snap")
+				c.Check(filenames[i], check.Equals, snaps[i])
+				c.Assert(string(bodies[i]), check.Equals, "snap-data")
+			}
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"snap-names": ["one","two"]}}}`)
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			fmt.Fprintf(w, `{"type": "sync", "result": [{"name": "one", "version": "1.0", "developer": "bar", "publisher": {"id": "bar-id", "username": "bar", "display-name": "Bar"}},{"name": "two", "version": "2.0", "developer": "baz", "publisher": {"id": "baz-id", "username": "baz", "display-name": "Baz"}}]}\n`)
+
+		default:
+			c.Fatalf("expected to get %d requests, now on %d", total, n+1)
+		}
+
+		n++
+	})
+
+	args := []string{"install"}
+	for _, snap := range snaps {
+		path := filepath.Join(c.MkDir(), snap)
+		args = append(args, path)
+		err := ioutil.WriteFile(path, []byte("snap-data"), 0644)
+		c.Assert(err, check.IsNil)
+	}
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs(args)
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+
+	c.Check(s.Stdout(), check.Matches, `(?sm).*one 1.0 from Bar installed`)
+	c.Check(s.Stdout(), check.Matches, `(?sm).*two 2.0 from Baz installed`)
+	c.Check(s.Stderr(), check.Equals, "")
+
+	c.Check(n, check.Equals, total)
+}
+
+func formFiles(form *multipart.Form, c *check.C) (names, filenames []string, contents [][]byte) {
+	for name, fheaders := range form.File {
+		for _, h := range fheaders {
+			body, err := h.Open()
+			c.Assert(err, check.IsNil)
+			defer body.Close()
+
+			content, err := ioutil.ReadAll(body)
+			c.Assert(err, check.IsNil)
+			contents = append(contents, content)
+			filenames = append(filenames, h.Filename)
+		}
+
+		names = append(names, name)
+	}
+
+	return names, filenames, contents
+}
+
+func (s *SnapOpSuite) TestInstallPathManyChannel(c *check.C) {
+	s.RedirectClientToTestServer(nil)
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--beta", "one.snap", "two.snap"})
+	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify channel flags`)
+}
+
+func (s *SnapOpSuite) TestInstallPathManyMode(c *check.C) {
+	s.RedirectClientToTestServer(nil)
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--classic", "foo.snap", "bar.snap"})
+	// allows mode with many local snaps (err is unrelated)
+	c.Assert(err.Error(), check.Equals, `cannot open: "foo.snap"`)
+}
+
 func (s *SnapSuite) TestInstallWithInstanceNoPath(c *check.C) {
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--name", "foo_bar", "some-snap"})
 	c.Assert(err, check.ErrorMatches, "cannot use explicit name when installing from store")
@@ -1858,13 +1951,19 @@ func (s *SnapOpSuite) TestRemoveMany(c *check.C) {
 func (s *SnapOpSuite) TestInstallManyChannel(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--beta", "one", "two"})
-	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
+	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify channel flags`)
+}
+
+func (s *SnapOpSuite) TestInstallManyMode(c *check.C) {
+	s.RedirectClientToTestServer(nil)
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--classic", "one", "two"})
+	c.Assert(err.Error(), check.Equals, `cannot specify mode for multiple store snaps (only for one store snap or several local ones)`)
 }
 
 func (s *SnapOpSuite) TestInstallManyMixFileAndStore(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "store-snap", "./local.snap"})
-	c.Assert(err, check.ErrorMatches, `only one snap file can be installed at a time`)
+	c.Assert(err, check.ErrorMatches, `cannot install local and store snaps at the same time`)
 }
 
 func (s *SnapOpSuite) TestInstallMany(c *check.C) {

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1045,7 +1045,7 @@ func (s *SnapOpSuite) TestInstallPathManyMode(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--classic", "foo.snap", "bar.snap"})
 	// allows mode with many local snaps (err is unrelated)
-	c.Assert(err.Error(), check.Equals, `cannot open: "foo.snap"`)
+	c.Assert(err, check.ErrorMatches, `cannot open "foo.snap":.*`)
 }
 
 func (s *SnapSuite) TestInstallWithInstanceNoPath(c *check.C) {

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -79,3 +79,8 @@ execute: |
     snap remove --revision x1 test-snapd-tools
     test-snapd-tools.success
     test ! -d "$SNAP_MOUNT_DIR/test-snapd-tools/x1"
+
+    echo "Install multiple local snaps"
+    expected="(basic 1.0 installed\stest-snapd-tools 1.0 installed)|(test-snapd-tools 1.0 installed\sbasic 1.0 installed)"
+    snap install --dangerous test-snapd-tools_1.0_all.snap basic_1.0_all.snap | MATCH -z "$expected"
+    snap install --devmode test-snapd-tools_1.0_all.snap basic_1.0_all.snap | MATCH -z "$expected"


### PR DESCRIPTION
Adds `cmd` support for installing multiple local snaps. 
