### PR TITLE
tests/nested/manual/core20-to-core22: wait for device to be initialized before starting a remodel

### DIFF
--- a/tests/nested/manual/core20-to-core22/task.yaml
+++ b/tests/nested/manual/core20-to-core22/task.yaml
@@ -33,6 +33,9 @@ execute: |
     label_base=$(tests.nested exec "date '+%Y%m%d'")
     label="${label_base}-1"
 
+    # wait until device is initialized and has a serial
+    nested_wait_for_device_initialized_change
+
     echo "Remodel to UC22"
     nested_copy "$TESTSLIB/assertions/valid-for-testing-pc-22-from-20.model"
     REMOTE_CHG_ID="$(tests.nested exec sudo snap remodel --no-wait valid-for-testing-pc-22-from-20.model)"


### PR DESCRIPTION
Wait for device to obtain a serial number before the test executes a remodel.

Fixes: https://bugs.launchpad.net/snapd/+bug/1956361
