### PR TITLE
mkversion.sh: do full opts parsing, add --ignore-debian-rules-changes 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,13 +44,17 @@ jobs:
       uses: snapcore/action-build@v1
       with:
         snapcraft-channel: 4.x/candidate
-    - name: Cache built artifact
+    - name: Cache and check built artifact
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")
-        if ls snapd*dirty*.snap > /dev/null 2>&1; then
+        unsquashfs snapd*.snap meta/snap.yaml usr/lib/snapd/info
+        if cat squashfs-root/meta/snap.yaml | grep -q "version:.*dirty.*"; then
           echo "PR produces dirty snapd snap version"
-          unsquashfs snapd*dirty*.snap
           cat squashfs-root/usr/lib/snapd/dirty-git-tree-info.txt
+          exit 1
+        elif cat squashfs-root/usr/lib/snapd/info | grep -q "VERSION=.*dirty.*"; then
+          echo "PR produces dirty internal snapd info version"
+          cat squashfs-root/usr/lib/snapd/info
           exit 1
         fi
         cp -v *.snap "$(dirname $CACHE_RESULT_STAMP)/"

--- a/bootloader/assets/grub_cfg_asset.go
+++ b/bootloader/assets/grub_cfg_asset.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/bootloader/assets/grub_recovery_cfg_asset.go
+++ b/bootloader/assets/grub_recovery_cfg_asset.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -52,7 +52,7 @@ parts:
       # TODO: when something like "craftctl get-version" is ready, then we can
       # use that, but until then, we have to re-run mkversion.sh to check if the
       # version number was set as "dirty" from the override-pull step
-      if sh -x ./mkversion.sh --output-only | grep "dirty"; then
+      if bash -x ./mkversion.sh --output-only | grep "dirty"; then
         mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd
         ( 
           echo "dirty git tree during build detected:"

--- a/mkversion-debian-rules-changes.patch
+++ b/mkversion-debian-rules-changes.patch
@@ -1,0 +1,62 @@
+diff --git a/cmd/snap-seccomp/old_seccomp.go b/cmd/snap-seccomp/old_seccomp.go
+deleted file mode 100644
+index a053dce..0000000
+--- a/cmd/snap-seccomp/old_seccomp.go
++++ /dev/null
+@@ -1,31 +0,0 @@
+-// -*- Mode: Go; indent-tabs-mode: t -*-
+-//go:build oldseccomp
+-// +build oldseccomp
+-
+-/*
+- * Copyright (C) 2021 Canonical Ltd
+- *
+- * This program is free software: you can redistribute it and/or modify
+- * it under the terms of the GNU General Public License version 3 as
+- * published by the Free Software Foundation.
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU General Public License for more details.
+- *
+- * You should have received a copy of the GNU General Public License
+- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+- *
+- */
+-
+-package main
+-
+-// On 14.04 we need to use forked libseccomp-golang, as recent
+-// upstream libseccomp-golang does not support building against
+-// libseecomp 2.1.1. This is patched in via packaging patch. But to
+-// continue vendoring the modules in go.mod any golang file must still
+-// reference the old forked libseccomp-golang. Which is here.  This
+-// file and import can be safely removed, once 14.04 build support of
+-// master is deemed to never be required again.
+-import "github.com/mvo5/libseccomp-golang"
+diff --git a/go.mod b/go.mod
+index 7689d42..2c999b4 100644
+--- a/go.mod
++++ b/go.mod
+@@ -16,7 +16,6 @@ require (
+ 	github.com/kr/pretty v0.2.2-0.20200810074440-814ac30b4b18 // indirect
+ 	github.com/mvo5/goconfigparser v0.0.0-20200803085309-72e476556adb
+ 	// if below two libseccomp-golang lines are updated, one must also update packaging/ubuntu-14.04/rules
+-	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
+ 	github.com/seccomp/libseccomp-golang v0.9.2-0.20210917151616-9da99da69b1b
+ 	github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8
+ 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
+diff --git a/go.sum b/go.sum
+index 11eea37..3a4cdb1 100644
+--- a/go.sum
++++ b/go.sum
+@@ -33,8 +33,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+ github.com/mvo5/goconfigparser v0.0.0-20200803085309-72e476556adb h1:1I/JqsB+FffFssjcOeEP0popLhJ46+OwtXztJ/1DhM0=
+ github.com/mvo5/goconfigparser v0.0.0-20200803085309-72e476556adb/go.mod h1:xmt4k1xLDl8Tdan+0S/jmMK2uSUBSzTc18+5GN5Vea8=
+-github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb h1:+u5VeqU0Lm7ESN1mS0WONqKRScw7WpPYYtr3zmqEFQ0=
+-github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb/go.mod h1:RduRpSkQHOCvZTbGgT/NJUGjFBFkYlVedimxssQ64ag=
+ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+ github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=
+ github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # debugging if anything fails is tricky as dh-golang eats up all output
@@ -26,20 +26,61 @@ if [ "$GOPACKAGE" = "snapdtool" ]; then
     GO_GENERATE_BUILDDIR="$(pwd)/.."
 fi
 
-OUTPUT_ONLY=false
-if [ "$1" = "--output-only" ]; then
-    OUTPUT_ONLY=true
-    shift
-fi
 
-# If the version is passed in as an argument to mkversion.sh, let's use that.
-if [ -n "$1" ]; then
-    version_from_user="$1"
-fi
+show_help() {
+    echo "mkversion.sh [OPTIONS]"
+    echo ""
+    echo "mkversion.sh detects and sets the version of snapd in both the source code and in a static info file included"
+    echo ""
+    echo "-o, --output-only                  Prevents writing or modifying the info file or version.go in the source tree"
+    echo "-i, --ignore-debian-rules-changes  Only treats the git tree as dirty if the changes are not those that debian/rules files perform to support trusty with libseccomp"
+    echo "-s, --set-version <version>        Disables the auto-detection and forces the version to be the specified version"
+    echo ""
+}
+
+# parse options before the positional arguments
+# this is adapted from https://stackoverflow.com/a/14203146/10102404
+POSITIONAL_ARGS=()
+
+OUTPUT_ONLY=false
+IGNORE_DEBIAN_RULES_CHANGES=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        -o|--output-only)
+            OUTPUT_ONLY="true"
+            shift # past argument
+            ;;
+        -i|--ignore-debian-rules-changes)
+            IGNORE_DEBIAN_RULES_CHANGES=true
+            shift # past argument
+            ;;
+        -s|--set-version)
+            version_from_user="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -*)
+            echo "Unknown option $1"
+            show_help
+            exit 1
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1") # save positional arg
+            shift # past argument
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
 DIRTY=false
 
-# Let's try to derive the version from git..
+# Let's try to derive the version from git.
 if command -v git >/dev/null; then
     # don't include --dirty here as we independently track whether the tree is
     # dirty and append that last, including it here will make dirty trees 
@@ -53,7 +94,38 @@ if command -v git >/dev/null; then
 
     # check if we are using a dirty tree
     if git describe --always --dirty | grep -q dirty; then
-        DIRTY=true
+        # HACK: we call mkversion.sh from debian/rules which will mutate some of
+        # the tree because we cannot build the same code using go modules for
+        # both trusty and non-trusty (this is related to seccomp)
+        # however this mutation should not be treated as a dirty tree, we should
+        # essentially "ignore" those changes, so we need to compare the diff to
+        # see if the diff is just those changes and if so then don't treat the
+        # tree as being dirty
+
+        if [ "$IGNORE_DEBIAN_RULES_CHANGES" = "true" ]; then
+            # to do this, we attempt to apply the inverse patch of the debian 
+            # changes and if after applying that patch we have a clean tree, then
+            # we do not treat the tree as dirty
+            pushd "$PKG_BUILDDIR" > /dev/null
+            if git apply "$PKG_BUILDDIR/undo-mkversion-debian-rules-changes.patch" > /dev/null 2>&1; then
+                git describe --always --dirty
+                # the undoing patch was clean - check if we still have changes
+                if git describe --always --dirty | grep -q dirty; then
+                    # there are more changes, it is still dirty
+                    DIRTY=true
+                fi
+
+                # re-do it to go back to the dirty changes and mark as clean
+                git apply "$PKG_BUILDDIR/mkversion-debian-rules-changes.patch"
+            else
+                # patch failed to apply, just leave as dirty
+                DIRTY=true
+            fi
+            popd > /dev/null
+        else
+            # if not in debian/rules mode then just always treat it as dirty
+            DIRTY=true
+        fi
     fi
 fi
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -65,7 +65,7 @@ build() {
   export CGO_CXXFLAGS="${CXXFLAGS}"
   export CGO_LDFLAGS="${LDFLAGS}"
 
-  ./mkversion.sh $pkgver-$pkgrel
+  ./mkversion.sh --set-version $pkgver-$pkgrel
 
   # because argument expansion with quoting in bash is hard, and -ldflags=-extldflags='-foo'
   # is not exactly the same as -ldflags "-extldflags '-foo'" use the array trick

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -517,7 +517,7 @@ rm -rf vendor/*
 
 %build
 # Generate version files
-./mkversion.sh "%{version}-%{release}"
+./mkversion.sh --set-version "%{version}-%{release}"
 
 # Build snapd
 mkdir -p src/github.com/snapcore

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -205,7 +205,7 @@ __DEFINES__
 
 # Set the version that is compiled into the various executables/
 pushd %{indigo_srcdir}
-./mkversion.sh %{version}-%{release}
+./mkversion.sh --set-version %{version}-%{release}
 popd
 
 # Sanity check, ensure that systemd system generator directory is in agreement between the build system and packaging.

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -170,10 +170,10 @@ override_dh_clean:
 
 override_dh_auto_build:
 	# usually done via `go generate` but that is not supported on powerpc
-	./mkversion.sh
+	./mkversion.sh --ignore-debian-rules-changes
 	# ensure auto-generated version is also in the build-tree
 	# XXX: do we need this?
-	(cd _build/src/$(DH_GOPKG)/ && ../../../../../mkversion.sh)
+	(cd _build/src/$(DH_GOPKG)/ && ../../../../../mkversion.sh --ignore-debian-rules-changes)
 	# Build golang bits
 	mkdir -p _build/src/$(DH_GOPKG)/cmd/snap/test-data
 	cp -a cmd/snap/test-data/*.gpg _build/src/$(DH_GOPKG)/cmd/snap/test-data/

--- a/snapdtool/version.go
+++ b/snapdtool/version.go
@@ -22,7 +22,7 @@
 // tools.
 package snapdtool
 
-//go:generate mkversion.sh
+//go:generate mkversion.sh --ignore-debian-rules-changes
 
 // Version will be overwritten at build-time via mkversion.sh
 var Version = "unknown"

--- a/undo-mkversion-debian-rules-changes.patch
+++ b/undo-mkversion-debian-rules-changes.patch
@@ -1,0 +1,62 @@
+diff --git a/cmd/snap-seccomp/old_seccomp.go b/cmd/snap-seccomp/old_seccomp.go
+new file mode 100644
+index 0000000000..a053dceb82
+--- /dev/null
++++ b/cmd/snap-seccomp/old_seccomp.go
+@@ -0,0 +1,31 @@
++// -*- Mode: Go; indent-tabs-mode: t -*-
++//go:build oldseccomp
++// +build oldseccomp
++
++/*
++ * Copyright (C) 2021 Canonical Ltd
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 3 as
++ * published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ *
++ */
++
++package main
++
++// On 14.04 we need to use forked libseccomp-golang, as recent
++// upstream libseccomp-golang does not support building against
++// libseecomp 2.1.1. This is patched in via packaging patch. But to
++// continue vendoring the modules in go.mod any golang file must still
++// reference the old forked libseccomp-golang. Which is here.  This
++// file and import can be safely removed, once 14.04 build support of
++// master is deemed to never be required again.
++import "github.com/mvo5/libseccomp-golang"
+diff --git a/go.mod b/go.mod
+index 2c999b4f2b..7689d42ba8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -16,6 +16,7 @@ require (
+ 	github.com/kr/pretty v0.2.2-0.20200810074440-814ac30b4b18 // indirect
+ 	github.com/mvo5/goconfigparser v0.0.0-20200803085309-72e476556adb
+ 	// if below two libseccomp-golang lines are updated, one must also update packaging/ubuntu-14.04/rules
++	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
+ 	github.com/seccomp/libseccomp-golang v0.9.2-0.20210917151616-9da99da69b1b
+ 	github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8
+ 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
+diff --git a/go.sum b/go.sum
+index 3a4cdb1d31..11eea376be 100644
+--- a/go.sum
++++ b/go.sum
+@@ -33,6 +33,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+ github.com/mvo5/goconfigparser v0.0.0-20200803085309-72e476556adb h1:1I/JqsB+FffFssjcOeEP0popLhJ46+OwtXztJ/1DhM0=
+ github.com/mvo5/goconfigparser v0.0.0-20200803085309-72e476556adb/go.mod h1:xmt4k1xLDl8Tdan+0S/jmMK2uSUBSzTc18+5GN5Vea8=
++github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb h1:+u5VeqU0Lm7ESN1mS0WONqKRScw7WpPYYtr3zmqEFQ0=
++github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb/go.mod h1:RduRpSkQHOCvZTbGgT/NJUGjFBFkYlVedimxssQ64ag=
+ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+ github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=
+ github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=


### PR DESCRIPTION
Re-implement options parsing using bash case/esac flow with shift, etc. to be
able to support more explicit options and also display a help message with
invalid options or --help option.

Also add a new option behavior with --ignore-debian-rules-changes which
specifically will treat the specific change that is caused by the debian/rules
file when handling libseccomp on non-trusty platforms as not being "dirty". If
there are other changes in addition to those changes, then the tree is treated
as being dirty, otherwise if only those changes are present and the option is
specified we treat it as if the tree was pristine for the purposes of setting
the version number. This is implemented through two patches, one which is the
exact expected change that debian/rules file should be performing, and one
which is the exact revert of those changes. This allows us to detect what
changes are present and undo any changes we do locally.

Finally use the new options as relevant across the packaging scripts.

This removes the "-dirty" prefix from the info/version.go files that are generated
in the snapd snaps.

There are probably better ways to do all of this, open to suggestions, but this does
at least do what is advertised on the box and ignore the changes generate by
the debian/rules file when it is run.