### PR TITLE
interfaces: allow access to new at-spi socket location in desktop-legacy

### DIFF
--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -54,6 +54,10 @@ dbus (send)
 
 #include <abstractions/dbus-accessibility-strict>
 
+# Allow access to the non-abstract D-Bus socket used by at-spi > 2.42.0
+#   https://gitlab.gnome.org/GNOME/at-spi2-core/-/issues/43
+owner @{run}/user/[0-9]*/at-spi/bus* rw,
+
 # Allow the accessibility services in the user session to send us any events
 dbus (receive)
     bus=accessibility

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -56,7 +56,7 @@ dbus (send)
 
 # Allow access to the non-abstract D-Bus socket used by at-spi > 2.42.0
 #   https://gitlab.gnome.org/GNOME/at-spi2-core/-/issues/43
-owner @{run}/user/[0-9]*/at-spi/bus* rw,
+owner /{,var/}run/user/[0-9]*/at-spi/bus* rw,
 
 # Allow the accessibility services in the user session to send us any events
 dbus (receive)


### PR DESCRIPTION
In at-spi 2.40, the socket location for the accessibility bus was changed from an abstract namespace socket to a regular unix socket, with the aim of making it easier to sandbox: without the help of a kernel MAC system like AppArmor, you've really only got a choice between allowing access to all abstract sockets or denying access to all sockets. In contrast, access to regular unix sockets can be controlled via mount namespace manipulation or file permissions.

Unfortunately that release changed to using a randomised socket name under `/tmp`, which could not reasonably be supported with snapd's private /tmp. That issue has been fixed upstream in at-spi, presumably to be included in 2.44:

https://gitlab.gnome.org/GNOME/at-spi2-core/-/issues/43

Now the socket will be named something matching `$XDG_RUNTIME_DIR/at-spi/bus*` (where the exact name will depend on the value of `$DISPLAY`). This PR updates the desktop-legacy AppArmor rules to allow access to this socket.