### PR TITLE
github: test for "dirty" in usr/lib/snapd/info

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,6 +53,12 @@ jobs:
           cat squashfs-root/usr/lib/snapd/dirty-git-tree-info.txt
           exit 1
         fi
+        unsquashfs snapd*.snap usr/lib/snapd/info
+        if grep dirty squashfs-root/usr/lib/snapd/info; then
+            echo "PR produced dirty snapd info version"
+            cat squashfs-root/usr/lib/snapd/info
+            exit 1
+        fi
         cp -v *.snap "$(dirname $CACHE_RESULT_STAMP)/"
     - name: Uploading snapd snap artifact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
During the 2.54 cycle we fixed the "dirty" version during the
snapcraft build. Unfortunately the "dirty" tag creeped into
our version information that was generated during the package
build and resulted in a "dirty" version in `usr/lib/snapd/info`
and in the auto-generated `snapdtools/version_generated.go`.

To detect this as well, this commit adds an extra check to the
workflow for this.

