### PR TITLE
.github/workflows/test.yaml: also check internal snapd version for cleanliness

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,13 +44,17 @@ jobs:
       uses: snapcore/action-build@v1
       with:
         snapcraft-channel: 4.x/candidate
-    - name: Cache built artifact
+    - name: Cache and check built artifact
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")
-        if ls snapd*dirty*.snap > /dev/null 2>&1; then
+        unsquashfs snapd*.snap meta/snap.yaml usr/lib/snapd/info
+        if cat squashfs-root/meta/snap.yaml | grep -q "version:.*dirty.*"; then
           echo "PR produces dirty snapd snap version"
-          unsquashfs snapd*dirty*.snap
           cat squashfs-root/usr/lib/snapd/dirty-git-tree-info.txt
+          exit 1
+        elif cat squashfs-root/usr/lib/snapd/info | grep -q "VERSION=.*dirty.*"; then
+          echo "PR produces dirty internal snapd info version"
+          cat squashfs-root/usr/lib/snapd/info
           exit 1
         fi
         cp -v *.snap "$(dirname $CACHE_RESULT_STAMP)/"


### PR DESCRIPTION
This is to prevent committing code to PR's which result in snapd internal
version being dirty, like we currently have on master.

This is expected to fail the snapd snap build action because we have not yet merged
https://github.com/snapcore/snapd/pull/11206. If this fails as I expect it to, I will close
this and cherry-pick this commit to https://github.com/snapcore/snapd/pull/11206.