### PR TITLE
packaging, bloader, github: restore cleanliness of snapd info file; check in GA workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,13 +44,17 @@ jobs:
       uses: snapcore/action-build@v1
       with:
         snapcraft-channel: 4.x/candidate
-    - name: Cache built artifact
+    - name: Cache and check built artifact
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")
-        if ls snapd*dirty*.snap > /dev/null 2>&1; then
+        unsquashfs snapd*.snap meta/snap.yaml usr/lib/snapd/info
+        if cat squashfs-root/meta/snap.yaml | grep -q "version:.*dirty.*"; then
           echo "PR produces dirty snapd snap version"
-          unsquashfs snapd*dirty*.snap
           cat squashfs-root/usr/lib/snapd/dirty-git-tree-info.txt
+          exit 1
+        elif cat squashfs-root/usr/lib/snapd/info | grep -q "VERSION=.*dirty.*"; then
+          echo "PR produces dirty internal snapd info version"
+          cat squashfs-root/usr/lib/snapd/info
           exit 1
         fi
         cp -v *.snap "$(dirname $CACHE_RESULT_STAMP)/"

--- a/bootloader/assets/grub_cfg_asset.go
+++ b/bootloader/assets/grub_cfg_asset.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/bootloader/assets/grub_recovery_cfg_asset.go
+++ b/bootloader/assets/grub_recovery_cfg_asset.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -164,9 +164,6 @@ override_dh_clean:
 	$(MAKE) -C cmd distclean || true
 	# XXX: hacky^2
 	(cd c-vendor/squashfuse && rm -f snapfuse && make distclean || true )
-	# XXX: drop old mvo5/libseccomp
-	rm -f ./cmd/snap-seccomp/old_seccomp.go
-	sed '/mvo5\/libseccomp-golang/d' -i go.mod go.sum vendor/modules.txt || true
 
 override_dh_auto_build:
 	# usually done via `go generate` but that is not supported on powerpc


### PR DESCRIPTION
The Copyright year for the generated bootloader asset files was out of date since the
year is now 2022, so building the snapd deb/snap resulted in this being changed.

The old_seccomp.go file is only needed for trusty, build tags already exclude this file 
from being built, so it's unnecessary to do this for xenial et al.

This should produce clean snapd versions again in the info/version.go files.

Also add to the GitHub Actions snap build a check that the info file has a clean version.