### PR TITLE
tests: fix testing in trusty qemu

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -539,7 +539,6 @@ pkg_dependencies_ubuntu_classic(){
     echo "
         avahi-daemon
         cups
-        dbus-user-session
         fontconfig
         gnome-keyring
         jq
@@ -562,6 +561,7 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-16.04-64)
             echo "
+                dbus-user-session
                 evolution-data-server
                 fwupd
                 gccgo-6
@@ -577,6 +577,7 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-18.04-32)
             echo "
+                dbus-user-session
                 gccgo-6
                 evolution-data-server
                 fwupd
@@ -587,6 +588,7 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-18.04-64)
             echo "
+                dbus-user-session
                 gccgo-8
                 gperf
                 evolution-data-server
@@ -597,6 +599,7 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-20.04-64)
             echo "
+                dbus-user-session
                 evolution-data-server
                 fwupd
                 gccgo-9
@@ -610,6 +613,7 @@ pkg_dependencies_ubuntu_classic(){
         ubuntu-21.04-64|ubuntu-21.10-64*)
             # bpftool is part of linux-tools package
             echo "
+                dbus-user-session
                 fwupd
                 golang
                 linux-tools-$(uname -r)

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -199,14 +199,17 @@ distro_install_package() {
         ubuntu-*|debian-*)
             # shellcheck disable=SC2086
             quiet eatmydata apt-get install $APT_FLAGS -y "${pkg_names[@]}"
+            retval=$?
             ;;
         amazon-*|centos-7-*)
             # shellcheck disable=SC2086
             quiet yum -y install $YUM_FLAGS "${pkg_names[@]}"
+            retval=$?
             ;;
         fedora-*|centos-*)
             # shellcheck disable=SC2086
             quiet dnf -y --refresh install $DNF_FLAGS "${pkg_names[@]}"
+            retval=$?
             ;;
         opensuse-*)
             # packages may be downgraded in the repositories, which would be
@@ -219,10 +222,12 @@ distro_install_package() {
 
             # shellcheck disable=SC2086
             quiet zypper install -y --allow-downgrade --force-resolution $ZYPPER_FLAGS "${pkg_names[@]}"
+            retval=$?
             ;;
         arch-*)
             # shellcheck disable=SC2086
             pacman -Suq --needed --noconfirm "${pkg_names[@]}"
+            retval=$?
             ;;
         *)
             echo "ERROR: Unsupported distribution $SPREAD_SYSTEM"
@@ -230,6 +235,10 @@ distro_install_package() {
             ;;
     esac
     test "$orig_xtrace" = on && set -x
+    # pass any errors up
+    if [ "$retval" != "0" ]; then
+        return $retval
+    fi
 }
 
 distro_purge_package() {

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -639,7 +639,6 @@ pkg_dependencies_ubuntu_classic(){
                 packagekit
                 sbuild
                 schroot
-                systemd-timesyncd
                 "
             ;;
     esac

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -424,7 +424,7 @@ prepare_project() {
 
     restart_logind=
     restart_networkd=
-    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -lt 246 ]; then
+    if not os.query is-trusty && [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -lt 246 ]; then
         restart_logind=maybe
         restart_networkd=maybe
     fi
@@ -440,8 +440,8 @@ prepare_project() {
         if [ "$restart_networkd" = maybe ]; then
             systemctl reset-failed systemd-networkd.service
             systemctl try-restart systemd-networkd.service
-            install_pkg_dependencies
         fi
+        install_pkg_dependencies
     fi
 
     if [ "$restart_logind" = maybe ]; then

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -423,26 +423,11 @@ prepare_project() {
     esac
 
     restart_logind=
-    restart_networkd=
-    if not os.query is-trusty && [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -lt 246 ]; then
+    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -lt 246 ]; then
         restart_logind=maybe
-        restart_networkd=maybe
     fi
 
-
-    # Try installing package dependencies. Because we pull in some systemd
-    # development packages we can easily pull in a whole systemd upgrade. Most
-    # of the time that's okay but, well, not always.
-    if ! install_pkg_dependencies; then
-        # If this failed, maybe systemd-networkd got busted during the 245-246
-        # upgrade? If so we can just restart it and try again.
-        # This is related to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966612
-        if [ "$restart_networkd" = maybe ]; then
-            systemctl reset-failed systemd-networkd.service
-            systemctl try-restart systemd-networkd.service
-        fi
-        install_pkg_dependencies
-    fi
+    install_pkg_dependencies
 
     if [ "$restart_logind" = maybe ]; then
         if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 246 ]; then


### PR DESCRIPTION
This PR fixes some issues that I ran into when testing inside my own 14.04 qemu:
* distro_install_package will silently ignore errors when used in an `if` context
* the `dbus-user-session` package is not available on 14.04
* networkd cannot be restarted on 14.04
* the whole logic around trying to restart systemd-networkd is only for a very specific version upgrade during the 20.10 development cycle and is no longer needed.