### PR TITLE
tests: exclude interfaces-kernel-module load on arm

### DIFF
--- a/tests/main/interfaces-kernel-module-load/task.yaml
+++ b/tests/main/interfaces-kernel-module-load/task.yaml
@@ -4,6 +4,9 @@ details: |
     The kernel-module-load interface allows to statically control kernel module
     loading in a way that can be constrained via snap-declaration.
 
+systems:
+    - ubuntu-core-*-arm-* # XXX: fails with a kill-timeout
+
 environment:
     SNAP_NAME: test-snapd-kernel-module-load
 


### PR DESCRIPTION
The tests on the pi fail with `<kill-timeout reached>`. The
deeper reason needs investigation but right now it breaks the
testing because this also fails in restore with stops the full
test run.
