### PR TITLE
tests: ensure that test-snapd-kernel-module-load is removed

### DIFF
--- a/tests/main/interfaces-kernel-module-load/task.yaml
+++ b/tests/main/interfaces-kernel-module-load/task.yaml
@@ -10,6 +10,10 @@ environment:
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local $SNAP_NAME
 
+restore: |
+    echo "Ensure snap is removed even if something goes wrong"
+    snap remove "$SNAP_NAME"
+
 execute: |
     echo "When the interface is connected"
     snap connect "$SNAP_NAME:kernel-module-load"


### PR DESCRIPTION
The `interfaces-kernel-module-load` test currently has no restore
section which means that if the test fails for some reason the
subsequent cleanup on core systems will fail because:
```
2021-12-24T11:45:04.0436279Z + snap remove --purge core
2021-12-24T11:45:04.0437140Z error: cannot remove "core": snap "core" is not removable: snap is being used
2021-12-24T11:45:04.0438421Z        by snap test-snapd-kernel-module-load.
```

This commit adds the missing restore.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
