### PR TITLE
gadget/gadget.go: add AllDiskVolumeDeviceTraits

### DIFF
--- a/cmd/snap/cmd_debug_gadget_disk_mapping.go
+++ b/cmd/snap/cmd_debug_gadget_disk_mapping.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/gadget"
+)
+
+type cmdGadgetDiskMapping struct {
+	clientMixin
+}
+
+func init() {
+	cmd := addDebugCommand("gadget-disk-mapping",
+		"(internal) obtain the gadget disk mapping",
+		"(internal) obtain the gadget disk mapping",
+		func() flags.Commander {
+			return &cmdGadgetDiskMapping{}
+		}, nil, nil)
+	cmd.hidden = true
+}
+
+func (x *cmdGadgetDiskMapping) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	resp := map[string]gadget.DiskVolumeDeviceTraits{}
+	if err := x.client.DebugGet("gadget-disk-mapping", &resp, nil); err != nil {
+		return err
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(Stdout, "%s\n", string(b))
+	return nil
+}

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -269,6 +269,37 @@ func getChangeTimings(st *state.State, changeID, ensureTag, startupTag string, a
 	return SyncResponse(responseData)
 }
 
+func getGadgetDiskMapping(st *state.State) Response {
+	deviceCtx, err := devicestate.DeviceCtx(st, nil, nil)
+	if err != nil {
+		return InternalError("cannot get device context: %v", err)
+	}
+	gadgetInfo, err := snapstate.GadgetInfo(st, deviceCtx)
+	if err != nil {
+		return InternalError("cannot get gadget info: %v", err)
+	}
+	gadgetDir := gadgetInfo.MountDir()
+
+	kernelInfo, err := snapstate.KernelInfo(st, deviceCtx)
+	if err != nil {
+		return InternalError("cannot get kernel info: %v", err)
+	}
+	kernelDir := kernelInfo.MountDir()
+
+	_, allLaidOutVols, err := gadget.LaidOutVolumesFromGadget(gadgetDir, kernelDir, deviceCtx.Model())
+	if err != nil {
+		return InternalError("cannot get all disk volume device traits: cannot layout volumes: %v", err)
+	}
+
+	// TODO: allow passing options in here
+	res, err := gadget.AllDiskVolumeDeviceTraits(allLaidOutVols, nil)
+	if err != nil {
+		return InternalError("cannot get all disk volume device traits: %v", err)
+	}
+
+	return SyncResponse(res)
+}
+
 func getDisks(st *state.State) Response {
 
 	disks, err := disks.AllPhysicalDisks()
@@ -327,6 +358,8 @@ func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		return getChangeTimings(st, chgID, ensureTag, startupTag, all == "true")
 	case "seeding":
 		return getSeedingInfo(st)
+	case "gadget-disk-mapping":
+		return getGadgetDiskMapping(st)
 	case "disks":
 		return getDisks(st)
 	default:

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snapfile"
@@ -324,6 +325,77 @@ func LoadDiskVolumesDeviceTraits(dir string) (map[string]DiskVolumeDeviceTraits,
 	}
 
 	return mapping, nil
+}
+
+// AllDiskVolumeDeviceTraits takes a mapping of volume name to LaidOutVolume and
+// produces a map of volume name to DiskVolumeDeviceTraits. Since doing so uses
+// DiskVolumeDeviceTraitsForDevice, it will also validate that disk devices
+// identified for the laid out volume are compatible and matching before
+// returning.
+func AllDiskVolumeDeviceTraits(allLaidOutVols map[string]*LaidOutVolume, optsPerVolume map[string]*DiskVolumeValidationOptions) (map[string]DiskVolumeDeviceTraits, error) {
+	// build up the mapping of volumes to disk device traits
+
+	allVols := map[string]DiskVolumeDeviceTraits{}
+
+	// find all devices which map to volumes to save the current state of the
+	// system
+	for name, vol := range allLaidOutVols {
+		// try to find a device for a structure inside the volume, we have a
+		// loop to attempt to use all structures in the volume in case there are
+		// partitions we can't map to a device directly at first using the
+		// device symlinks that FindDeviceForStructure uses
+		dev := ""
+		for _, vs := range vol.LaidOutStructure {
+			// TODO: This code works for volumes that have at least one
+			// partition (i.e. not type: bare structure), but does not work for
+			// volumes which contain only type: bare structures with no other
+			// structures on them. It is entirely unclear how to identify such
+			// a volume, since there is no information on the disk about where
+			// such raw structures begin and end and thus no way to validate
+			// that a given disk "has" such raw structures at particular
+			// locations, aside from potentially reading and comparing the bytes
+			// at the expected locations, but that is probably fragile and very
+			// non-performant.
+
+			if !vs.IsPartition() {
+				// skip trying to find non-partitions on disk, it won't work
+				continue
+			}
+
+			structureDevice, err := FindDeviceForStructure(&vs)
+			if err != nil && err != ErrDeviceNotFound {
+				return nil, err
+			}
+			if structureDevice != "" {
+				// we found a device for this structure, get the parent disk
+				// and save that as the device for this volume
+				disk, err := disks.DiskFromPartitionDeviceNode(structureDevice)
+				if err != nil {
+					return nil, err
+				}
+
+				dev = disk.KernelDeviceNode()
+				break
+			}
+		}
+
+		if dev == "" {
+			return nil, fmt.Errorf("cannot find disk for volume %s from gadget", name)
+		}
+
+		// now that we have a candidate device for this disk, build up the
+		// traits for it, this will also validate concretely that the
+		// device we picked and the volume are compatible
+		opts := optsPerVolume[name]
+		traits, err := DiskTraitsFromDeviceAndValidate(vol, dev, opts)
+		if err != nil {
+			return nil, fmt.Errorf("cannot gather disk traits for device %s to use with volume %s: %v", dev, name, err)
+		}
+
+		allVols[name] = traits
+	}
+
+	return allVols, nil
 }
 
 // GadgetConnect describes an interface connection requested by the gadget

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -3260,6 +3260,18 @@ func (s *gadgetYamlTestSuite) TestOnDiskStructureIsLikelyImplicitSystemDataRoleU
 	}
 }
 
+func (s *gadgetYamlTestSuite) TestAllDiskVolumeDeviceTraitsUnhappy(c *C) {
+	vol, err := gadgettest.LayoutFromYaml(c.MkDir(), gadgettest.MockExtraVolumeYAML, nil)
+	c.Assert(err, IsNil)
+
+	// don't setup the expected/needed symlinks in /dev
+	m := map[string]*gadget.LaidOutVolume{
+		"foo": vol,
+	}
+	_, err = gadget.AllDiskVolumeDeviceTraits(m, nil)
+	c.Assert(err, ErrorMatches, `cannot find disk for volume foo from gadget`)
+}
+
 func (s *gadgetYamlTestSuite) TestAllDiskVolumeDeviceTraitsHappy(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/dev"), 0755)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This PR is somewhat large mainly just because of the test cases which have a 
lot of large objects included in them for mocking purposes, etc.

This is a more generalized version of DiskTraitsFromDeviceAndValidate which
takes multiple laid out volumes and attempts to do the actual task of locating
what devices volumes may exist on using FindDeviceForStructure.

With this, multiple test cases and example outputs are provided to test the
logic here for different situations in the gadgettest package and some existing
tests are re-written to use these common setups.

Finally, add a multi-volume equivalent of LayoutFromYaml to accommodate these
tests in gadgettest with LayoutMultiVolumeFromYaml.

Also add a debug command to call this function for easy debugging of multi-volume
gadget asset updates on real devices.

PR's split out from this one: 
- [x] https://github.com/snapcore/snapd/pull/11297
- [x] https://github.com/snapcore/snapd/pull/11296