### PR TITLE
data/env: treat XDG_DATA_DIRS like PATH for fish

### DIFF
--- a/data/env/snapd.fish.in
+++ b/data/env/snapd.fish.in
@@ -6,6 +6,7 @@ fish_add_path -aP $snap_bin_path
 # looked for in XDG_DATA_DIRS; make sure it includes the relevant directory for
 # snappy applications' desktop files.
 set -u snap_xdg_path /var/lib/snapd/desktop
+set --path XDG_DATA_DIRS $XDG_DATA_DIRS
 if ! contains $snap_xdg_path $XDG_DATA_DIRS
     set XDG_DATA_DIRS $XDG_DATA_DIRS $snap_xdg_path
 end


### PR DESCRIPTION
Tell fish to treat XDG_DATA_DIRS as a column separated list and not space separated (default).
Otherwise, get corrupted list with mixed separators:
`XDG_DATA_DIRS=/var/lib/flatpak/exports/share:/usr/local/share/:/usr/share/:/var/lib/snapd/desktop /var/lib/snapd/desktop /var/lib/snapd/desktop`
