### PR TITLE
tests: do not run k8s smoke test on 32 bit systems

### DIFF
--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -9,7 +9,7 @@ systems:
   - -fedora-35-*      # fails to start service daemon-containerd
   - -debian-10-*      # doesn't have libseccomp >= 2.4
   - -ubuntu-14.04-*   # doesn't have libseccomp >= 2.4
-  - -ubuntu-18.04-32  # no microk8s snap for i386 pc systems
+  - -ubuntu-*-32      # no microk8s snap for 32 bit systems
   - -arch-linux-*     # XXX: no curl to the pod for unknown reasons
 
 environment:


### PR DESCRIPTION
There is no microk8s snap available for 32 bit systems like i386
or armhf. So this test must be skipped.
