### PR TITLE
tests: re-enable kernel-module-load tests on arm

### DIFF
--- a/tests/main/interfaces-kernel-module-load/task.yaml
+++ b/tests/main/interfaces-kernel-module-load/task.yaml
@@ -4,9 +4,6 @@ details: |
     The kernel-module-load interface allows to statically control kernel module
     loading in a way that can be constrained via snap-declaration.
 
-systems:
-    - ubuntu-core-*-arm-* # XXX: fails with a kill-timeout
-
 environment:
     SNAP_NAME: test-snapd-kernel-module-load
 
@@ -25,14 +22,14 @@ execute: |
     MODPROBE_CONF="/etc/modprobe.d/snap.$SNAP_NAME.conf"
     MATCH "blacklist mymodule" < "$MODPROBE_CONF"
     MATCH "blacklist other_module" < "$MODPROBE_CONF"
-    MATCH "options parport_pc io=0x3bc,0x278 irq=none" < "$MODPROBE_CONF"
-    NOMATCH "blacklist parport_pc" < "$MODPROBE_CONF"
+    MATCH "options bfq slice_idle_us=20 strict_guarantees=1" < "$MODPROBE_CONF"
+    NOMATCH "blacklist bfq" < "$MODPROBE_CONF"
     NOMATCH "pcspkr" < "$MODPROBE_CONF"
 
     echo "And modules are configured to be auto-loaded"
     MODULES_LOAD_CONF="/etc/modules-load.d/snap.$SNAP_NAME.conf"
-    MATCH "parport_pc" < "$MODULES_LOAD_CONF"
-    MATCH "pcspkr" < "$MODULES_LOAD_CONF"
+    MATCH "bfq" < "$MODULES_LOAD_CONF"
+    MATCH "arc4" < "$MODULES_LOAD_CONF"
     NOMATCH "mymodule" < "$MODULES_LOAD_CONF"
 
     echo "Disconnect the interface"

--- a/tests/main/interfaces-kernel-module-load/test-snapd-kernel-module-load/meta/snap.yaml
+++ b/tests/main/interfaces-kernel-module-load/test-snapd-kernel-module-load/meta/snap.yaml
@@ -8,10 +8,10 @@ plugs:
         modules:
             - name: mymodule
               load: denied
-            - name: parport_pc
+            - name: bfq
               load: on-boot
-              options: io=0x3bc,0x278 irq=none
+              options: slice_idle_us=20 strict_guarantees=1
             - name: other_module
               load: denied
-            - name: pcspkr
+            - name: arc4
               load: on-boot


### PR DESCRIPTION
Find another pair of modules which we can use on all tested devices.

The problem with the previous modules was that on the PI the pcspkr module was missing, and the parport_pc was causing a (recoverable) kernel crash.
