### PR TITLE
cmd/snap, cmd/snap-confine: extend manpage, update links

### DIFF
--- a/cmd/snap-confine/snap-confine.rst
+++ b/cmd/snap-confine/snap-confine.rst
@@ -182,4 +182,4 @@ directly into the kernel. The actual apparmor profile is managed by `snapd`.
 BUGS
 ====
 
-Please report all bugs with https://bugs.launchpad.net/snap-confine/+filebug
+Please report all bugs with https://bugs.launchpad.net/snapd/+filebug

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -129,6 +129,20 @@ func (w *manfixer) flush() {
 	io.Copy(Stdout, strings.NewReader(str))
 }
 
+func manExtend(out io.Writer) {
+	out.Write([]byte(`
+.SH NOTES
+.IP " 1. " 4
+Online documentation
+.RS 4
+\%https://docs.snapcraft.io
+.RE
+.SH BUGS
+.sp
+Please report all bugs with \fI\%https://bugs.launchpad.net/snapd/+filebug\fP
+`))
+}
+
 func (cmd cmdHelp) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
@@ -138,6 +152,7 @@ func (cmd cmdHelp) Execute(args []string) error {
 		// subcommand, but --man is hidden so no real need to check.
 		out := &manfixer{}
 		cmd.parser.WriteManPage(out)
+		manExtend(out)
 		out.flush()
 		return nil
 	}

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -56,7 +56,8 @@ To install multiple instances of the same snap, append an underscore and a
 unique identifier (for each instance) to a snap's name.
 
 With no further options, the snaps are installed tracking the stable channel,
-with strict security confinement.
+with strict security confinement. All available channels of a snap are listed in
+its 'snap info' output.
 
 Revision choice via the --revision override requires the user to
 have developer access to the snap, either directly or through the
@@ -85,7 +86,8 @@ The refresh command updates the specified snaps, or all snaps in the system if
 none are specified.
 
 With no further options, the snaps are refreshed to the current revision of the
-channel they're tracking, preserving their confinement options.
+channel they're tracking, preserving their confinement options. All available
+channels of a snap are listed in its 'snap info' output.
 
 Revision choice via the --revision override requires the user to
 have developer access to the snap, either directly or through the
@@ -1032,7 +1034,8 @@ func (x *cmdRevert) Execute(args []string) error {
 var shortSwitchHelp = i18n.G("Switches snap to a different channel")
 var longSwitchHelp = i18n.G(`
 The switch command switches the given snap to a different channel without
-doing a refresh.
+doing a refresh. All available channels of a snap are listed in
+its 'snap info' output.
 `)
 
 type cmdSwitch struct {


### PR DESCRIPTION
Add mention of how to find channels in `snap {install|refresh|switch} --help` output. Update snap manpage to include links to online docs. While at it, update the link for filing bugs in s-c manpage.

Related to https://bugs.launchpad.net/snapd/+bug/1956832

