### PR TITLE
tests: fix fwupd interface test in debian sid

### DIFF
--- a/tests/main/interfaces-fwupd-classic/task.yaml
+++ b/tests/main/interfaces-fwupd-classic/task.yaml
@@ -28,4 +28,9 @@ execute: |
     fi
 
     echo "With the plug connected, we can talk to fwupd"
-    test-snapd-fwupd.get-version | MATCH 'variant +string "[0-9.]+(-[0-9a-g-]+)?"'
+    VERSION_PREFIX=""
+    if os.query is-debian; then
+        # In Debian we might see "debian/" prepended to the version
+        VERSION_PREFIX="(debian/)?"
+    fi
+    test-snapd-fwupd.get-version | MATCH "variant +string \"${VERSION_PREFIX}[0-9.]+(-[0-9a-g-]+)?\""


### PR DESCRIPTION
The test has been seen failing here:
https://github.com/snapcore/snapd/runs/4759182513?check_suite_focus=true

Relevant log lines:

    + MATCH 'variant +string "[0-9.]+(-[0-9a-g-]+)?"'
    + test-snapd-fwupd.get-version
    grep error: pattern not found, got:
    method return time=1641807098.785012 sender=:1.137 -> destination=:1.136 serial=311 reply_serial=2
       variant       string "debian/1.7.1-1-2-geeedfc7c"

Since not all versions of debian are affected by this, and that there's
the possibility that the version prefix might appear and disappear
according to the versioning policy followed by the Debian fwupd
maintainer, let's accept a `debian/` prefix but do not require it.
