### PR TITLE
tests: workaround missing bluez snap

### DIFF
--- a/tests/main/interfaces-bluez/task.yaml
+++ b/tests/main/interfaces-bluez/task.yaml
@@ -8,22 +8,8 @@ details: |
     we can connect its slot and plug.
 
 execute: |
-    if ! snap list --unicode=never bluez &> /dev/null ; then
-        echo "Installing bluez snap from the store ..."
-        expected="(?s)bluez .* from Canonical\\* installed\\n"
-        if snap install bluez > output 2> errors; then
-            grep -Pzq "$expected" output
-        else
-            echo "Installation failed:"
-            cat errors
-            if grep -q "not available" errors; then
-                echo "snap is not available in the store, skipping the test"
-                exit 0
-            else
-                exit 1
-            fi
-        fi
-    fi
+    echo "Installing bluez snap from the store ..."
+    snap install --channel=latest/stable bluez
 
     echo "Connecting bluez snap plugs/slots ..."
     snap connect bluez:client bluez:service

--- a/tests/main/interfaces-bluez/task.yaml
+++ b/tests/main/interfaces-bluez/task.yaml
@@ -11,7 +11,18 @@ execute: |
     if ! snap list --unicode=never bluez &> /dev/null ; then
         echo "Installing bluez snap from the store ..."
         expected="(?s)bluez .* from Canonical\\* installed\\n"
-        snap install bluez | grep -Pzq "$expected"
+        if snap install bluez > output 2> errors; then
+            grep -Pzq "$expected" output
+        else
+            echo "Installation failed:"
+            cat errors
+            if grep -q "not available" errors; then
+                echo "snap is not available in the store, skipping the test"
+                exit 0
+            else
+                exit 1
+            fi
+        fi
     fi
 
     echo "Connecting bluez snap plugs/slots ..."


### PR DESCRIPTION
This test is currently failing on 32-bit Ubuntu 18.04:

https://github.com/snapcore/snapd/runs/4759182899?check_suite_focus=true

The error occurs because the bluez snap is currently not available in
the stable channel (this would deserve an investigation of its own), but
we don't want this to cause our tests to fail.

The resulting code is rather verbose. I wonder if we really need to check for the standard output, if `snap install` quits with a 0 exit status?