### PR TITLE
spread.yaml: add debian-{10,11}, drop debian-9

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -257,10 +257,10 @@ backends:
             - ubuntu-21.10-64:
                   username: ubuntu
                   password: ubuntu
-            - debian-sid-64:
+            - debian-10-64:
                   username: debian
                   password: debian
-            - debian-9-64:
+            - debian-11-64:
                   username: debian
                   password: debian
             - debian-sid-64:


### PR DESCRIPTION
The qemu systems had a duplicated debian-sid entry and no entries
for debian-10 and debian-11. This commit fixes this.
