### PR TITLE
osutil/mkfs: Use host environment for fakeroot command

### DIFF
--- a/osutil/mkfs/mkfs.go
+++ b/osutil/mkfs/mkfs.go
@@ -111,6 +111,7 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantit
 		// no need to fake it if we're already root
 		cmd = exec.Command(mkfsArgs[0], mkfsArgs[1:]...)
 	}
+	cmd.Env = os.Environ()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return osutil.OutputErr(out, err)


### PR DESCRIPTION
The ubuntu-image snap stages fakeroot, but currently the ubuntu-image snap will use the fakeroot from the host system rather than the one staged in the snap. This one-line change uses the snap's environment variables which leads to the loading of the correct fakeroot.