### PR TITLE
cmd/snap, daemon: add debug command for getting OnDiskVolume dump

### DIFF
--- a/cmd/snap/cmd_debug_disks.go
+++ b/cmd/snap/cmd_debug_disks.go
@@ -23,9 +23,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/snapcore/snapd/gadget"
-
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/gadget"
 )
 
 type cmdDiskMapping struct {

--- a/cmd/snap/cmd_debug_disks.go
+++ b/cmd/snap/cmd_debug_disks.go
@@ -33,8 +33,8 @@ type cmdDiskMapping struct {
 
 func init() {
 	cmd := addDebugCommand("disks",
-		"(internal) obtain all on disk volumes",
-		"(internal) obtain all on disk volumes",
+		"(internal) obtain all on-disk volumes information as yaml",
+		"(internal) obtain all on-disk volumes information as yaml",
 		func() flags.Commander {
 			return &cmdDiskMapping{}
 		}, nil, nil)

--- a/cmd/snap/cmd_debug_disks.go
+++ b/cmd/snap/cmd_debug_disks.go
@@ -23,8 +23,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/jessevdk/go-flags"
 	"github.com/snapcore/snapd/gadget"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdDiskMapping struct {
@@ -33,8 +34,8 @@ type cmdDiskMapping struct {
 
 func init() {
 	cmd := addDebugCommand("disks",
-		"(internal) obtain all on-disk volumes information as yaml",
-		"(internal) obtain all on-disk volumes information as yaml",
+		"(internal) obtain all on-disk volume information as JSON",
+		"(internal) obtain all on-disk volume information as JSON",
 		func() flags.Commander {
 			return &cmdDiskMapping{}
 		}, nil, nil)

--- a/cmd/snap/cmd_debug_disks.go
+++ b/cmd/snap/cmd_debug_disks.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/snapcore/snapd/gadget"
+)
+
+type cmdDiskMapping struct {
+	clientMixin
+}
+
+func init() {
+	cmd := addDebugCommand("disks",
+		"(internal) obtain all on disk volumes",
+		"(internal) obtain all on disk volumes",
+		func() flags.Commander {
+			return &cmdDiskMapping{}
+		}, nil, nil)
+	cmd.hidden = true
+}
+
+func (x *cmdDiskMapping) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	resp := []gadget.OnDiskVolume{}
+	if err := x.client.DebugGet("disks", &resp, nil); err != nil {
+		return err
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(Stdout, "%s\n", string(b))
+	return nil
+}


### PR DESCRIPTION
Simple utility for getting the OnDiskVolume's for all disks on a device for debugging purposes. It's not super clean and contains lots of `null` since we don't have any json tags defined, but IMHO for a debug thing like this we don't need it.

Example output:

```json
[
    {
        "Structure": [
            {
                "VolumeName": "",
                "Name": "BIOS Boot",
                "Label": "",
                "Offset": null,
                "OffsetWrite": null,
                "Type": "21686148-6449-6E6F-744E-656564454649",
                "Role": "",
                "ID": "b2e891ee-b971-4a2b-b874-694bbf9b821a",
                "Filesystem": "",
                "Content": null,
                "Update": {
                    "Edition": 0,
                    "Preserve": null
                },
                "StartOffset": 1048576,
                "AbsoluteOffsetWrite": null,
                "Index": 1,
                "LaidOutContent": null,
                "ResolvedContent": null,
                "Node": "/dev/sda1",
                "Size": 1048576
            },
            {
                "VolumeName": "",
                "Name": "EFI System",
                "Label": "system-boot",
                "Offset": null,
                "OffsetWrite": null,
                "Type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
                "Role": "",
                "ID": "a87e9dcb-b1e1-4eab-89cf-1c2fc057b038",
                "Filesystem": "vfat",
                "Content": null,
                "Update": {
                    "Edition": 0,
                    "Preserve": null
                },
                "StartOffset": 2097152,
                "AbsoluteOffsetWrite": null,
                "Index": 2,
                "LaidOutContent": null,
                "ResolvedContent": null,
                "Node": "/dev/sda2",
                "Size": 52428800
            },
            {
                "VolumeName": "",
                "Name": "writable",
                "Label": "writable",
                "Offset": null,
                "OffsetWrite": null,
                "Type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                "Role": "",
                "ID": "cba2b8b3-c2e4-4e51-9a57-d35041b7bf9a",
                "Filesystem": "ext4",
                "Content": null,
                "Update": {
                    "Edition": 0,
                    "Preserve": null
                },
                "StartOffset": 54525952,
                "AbsoluteOffsetWrite": null,
                "Index": 3,
                "LaidOutContent": null,
                "ResolvedContent": null,
                "Node": "/dev/sda3",
                "Size": 10682875392
            }
        ],
        "ID": "2a9b0671-4597-433b-b3ad-be99950e8c5e",
        "Device": "/dev/sda",
        "Schema": "gpt",
        "Size": 10737418240,
        "UsableSectorsEnd": 20971487,
        "SectorSize": 512
    }
]
```