### PR TITLE
gadget: misc helper fixes for implicit system-data role handling

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -57,6 +57,8 @@ var (
 	ResolveVolumeContent = resolveVolumeContent
 
 	GadgetVolumeConsumesOneKernelUpdateAsset = gadgetVolumeConsumesOneKernelUpdateAsset
+
+	OnDiskStructureIsLikelyImplicitSystemDataRole = onDiskStructureIsLikelyImplicitSystemDataRole
 )
 
 func MockEvalSymlinks(mock func(path string) (string, error)) (restore func()) {

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -3036,6 +3036,23 @@ func (s *gadgetYamlTestSuite) TestLayoutCompatibilityWithUnspecifiedGadgetFilesy
 	c.Assert(err, IsNil)
 }
 
+func (s *gadgetYamlTestSuite) TestLayoutCompatibilityWithImplicitSystemData(c *C) {
+	gadgetLayout, err := gadgettest.LayoutFromYaml(c.MkDir(), mockUC16YAMLImplicitSystemData, nil)
+	c.Assert(err, IsNil)
+	deviceLayout := uc16DeviceLayout
+
+	// with no/default opts, then they are not compatible
+	err = gadget.EnsureLayoutCompatibility(gadgetLayout, &deviceLayout, nil)
+	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/sda3 \(starting at 54525952\) in gadget`)
+
+	// compatible with AllowImplicitSystemData however
+	opts := &gadget.EnsureLayoutCompatibilityOptions{
+		AllowImplicitSystemData: true,
+	}
+	err = gadget.EnsureLayoutCompatibility(gadgetLayout, &deviceLayout, opts)
+	c.Assert(err, IsNil)
+}
+
 func (s *gadgetYamlTestSuite) TestSchemaCompatibility(c *C) {
 	gadgetLayout, err := gadgettest.LayoutFromYaml(c.MkDir(), mockSimpleGadgetYaml, nil)
 	c.Assert(err, IsNil)

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -198,7 +198,6 @@ func onDiskStructureIsLikelyImplicitSystemDataRole(gadgetLayout *LaidOutVolume, 
 		numPartsInGadget+1 == numPartsOnDisk
 }
 
-
 // EnsureLayoutCompatibilityOptions is a set of options for determining how
 // strict to be when evaluating whether an on-disk structure matches a laid out
 // structure.


### PR DESCRIPTION
I recently realized that there was another corner case to handle here, where ubuntu-image would create a system-data role partition on the disk at image build time when it was not specified in the gadet.yaml. This needs to be taken care of before we can merge https://github.com/snapcore/snapd/pull/11084 for consistency's sake, so I have prepared some fixes here which are based on top of this PR:

- [x] https://github.com/snapcore/snapd/pull/11207 

Additionally, as requested I broke out one particular change to a separate PR here:

- [x] https://github.com/snapcore/snapd/pull/11234

You can also see how the helpers are used in https://github.com/snapcore/snapd/pull/11084, which now depends on this specific PR.

The main summary of changes:
- introduce OnDiskStructure.DiskIndex + LaidOutStructure.YamlIndex to fix ambiguity, issue with OnDiskStructure.Index vs LaidOutStructure.Index (as they mean different things and come from different data sources)
- add onDiskStructureIsLikelyImplicitSystemDataRole helper to identify the implicit system-data role where it may appear
- add AllowImplicitSystemData to EnsureLayoutCompatibleOptions to allow gadget.yaml's without system-data on UC16/UC18 to match with OnDiskVolume's that have a physical system-data partition

The alternative to this is to instead make a hard u-turn from the direction I have been trying to go with this code and instead be very permissive with whatever is on the disk on UC16/UC18 gadgets, in which case we would probably just skip the final check in EnsureLayoutCompatibility entirely and instead with an option ignore all extra stuff on disk that isn't mentioned in the gadget.yaml, but this is a departure from what we are doing on UC20 where we are more strict. 

I have a reasonable expectation that this is the last case where I find a corner case in what we need to allow UC16/UC18 gadgets to do things that UC20 doesn't, because I don't expect there to be any devices out there that in addition to not having system-data declared in their gadget.yaml also happen to have other random partitions on the disk because that really goes against the whole point of the gadget.yaml's volumes key to declare the partition layout for an Ubuntu Core device.